### PR TITLE
Stage 4 — finish the TOOL-* tracks (iRule VM, F5 simulate, debugger, fuzz, explorer, refactor, CLI)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2296,6 +2296,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcl-irule-test"
+version = "0.1.0"
+dependencies = [
+ "tcl-bigip",
+]
+
+[[package]]
 name = "tcl-irules"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2270,6 +2270,13 @@ version = "0.1.0"
 [[package]]
 name = "tcl-debugger"
 version = "0.1.0"
+dependencies = [
+ "serde_json",
+ "tcl-bytecode",
+ "tcl-compiler",
+ "tcl-registry",
+ "tcl-vm",
+]
 
 [[package]]
 name = "tcl-explorer"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2268,6 +2268,10 @@ name = "tcl-core-types"
 version = "0.1.0"
 
 [[package]]
+name = "tcl-debugger"
+version = "0.1.0"
+
+[[package]]
 name = "tcl-explorer"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -112,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
 name = "arbitrary"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -132,7 +141,7 @@ dependencies = [
  "nom",
  "num-traits",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -144,7 +153,7 @@ checksum = "3109e49b1e4909e9db6515a30c633684d68cdeaa252f215214cb4fa1a5bfee2c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -156,7 +165,7 @@ checksum = "7b18050c2cd6fe86c3a76584ef5e0baf286d038cda203eb6223df2cc413565f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -167,7 +176,16 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "atomic"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a89cbf775b137e9b968e67227ef7f775587cde3fd31b0d8599dbd0f598a48340"
+dependencies = [
+ "bytemuck",
 ]
 
 [[package]]
@@ -178,7 +196,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -216,6 +234,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bit-set"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0700ddab506f33b20a03b13996eccd309a48e5ff77d0d95926aa0210fb4e95f1"
+dependencies = [
+ "bit-vec",
+]
+
+[[package]]
+name = "bit-vec"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "349f9b6a179ed607305526ca489b34ad0a41aed5f7980fa90eb03160b69598fb"
+
+[[package]]
 name = "bitflags"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -249,22 +282,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72f5acc6cb2ba439de613abc23857ec3d78374d8ed5ac84e9d11336e87da8649"
 
 [[package]]
+name = "by_address"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64fa3c856b712db6612c019f14756e64e4bcea13337a6b33b696333a9eaa2d06"
+
+[[package]]
 name = "bytecount"
 version = "0.6.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "175812e0be2bccb6abe50bb8d566126198344f707e304f45c648fd8f2cc0365e"
 
 [[package]]
+name = "bytemuck"
+version = "1.25.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8efb64bd706a16a1bdde310ae86b351e4d21550d98d056f22f8a7f7a2183fec"
+
+[[package]]
 name = "bytes"
 version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
-
-[[package]]
-name = "cassowary"
-version = "0.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df8670b8c7b9dae1793364eafadf7239c40d669904660c5960d74cfd80b46a53"
 
 [[package]]
 name = "castaway"
@@ -292,6 +331,12 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+
+[[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -355,7 +400,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -381,9 +426,9 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
 name = "compact_str"
-version = "0.8.2"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7fd622ebbb56a5b2ccb651b32b911cdeb2a9b4b11776b2473bf26a26a286244e"
+checksum = "9dfdd1c2274d9aa354115b09dc9a901d6c5576818cdf70d14cae2bdb47df00ab"
 dependencies = [
  "castaway",
  "cfg-if",
@@ -391,6 +436,15 @@ dependencies = [
  "rustversion",
  "ryu",
  "static_assertions",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -428,6 +482,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
 name = "crossbeam-deque"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -463,15 +523,17 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crossterm"
-version = "0.28.1"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "829d955a0bb380ef178a640b91779e3987da38c9aea133b20614cfed8cdea9c6"
+checksum = "d8b9f2e4c67f833b660cdb0a3523065869fb35570177239812ed4c905aeff87b"
 dependencies = [
  "bitflags 2.13.0",
  "crossterm_winapi",
+ "derive_more",
+ "document-features",
  "mio",
  "parking_lot",
- "rustix 0.38.44",
+ "rustix",
  "signal-hook",
  "signal-hook-mio",
  "winapi",
@@ -497,6 +559,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "csscolorparser"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eb2a7d3066da2de787b7f032c736763eb7ae5d355f81a68bab2675a96008b0bf"
+dependencies = [
+ "lab",
+ "phf",
+]
+
+[[package]]
 name = "darling"
 version = "0.23.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -516,7 +588,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -527,7 +599,7 @@ checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
 dependencies = [
  "darling_core",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -548,6 +620,12 @@ name = "data-encoding"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4ae5f15dda3c708c0ade84bfee31ccab44a3da4f88015ed22f63732abe300c8"
+
+[[package]]
+name = "deltae"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5729f5117e208430e437df2f4843f5e5952997175992d1414f94c57d61e270b4"
 
 [[package]]
 name = "der-parser"
@@ -577,7 +655,29 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -598,7 +698,7 @@ checksum = "1ac70aa55017e108007fbaf5aa0f54b021c98f92ff8af59d42eda9da96e3dd4f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -611,6 +711,15 @@ dependencies = [
  "libc",
  "socket2",
  "windows-sys 0.60.2",
+]
+
+[[package]]
+name = "document-features"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4b8a88685455ed29a21542a33abd9cb6510b6b129abadabdcef0f4c55bc8f61"
+dependencies = [
+ "litrs",
 ]
 
 [[package]]
@@ -639,6 +748,15 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "euclid"
+version = "0.22.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -681,6 +799,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fancy-regex"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b95f7c0680e4142284cf8b22c14a476e87d61b004a3a0861872b32ef7ead40a2"
+dependencies = [
+ "bit-set",
+ "regex",
+]
+
+[[package]]
+name = "fast-srgb8"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd2e7510819d6fbf51a5545c8f922716ecfb14df168a3242f7d33e0239efe6a1"
+
+[[package]]
+name = "filedescriptor"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e40758ed24c9b2eeb76c35fb0aebc66c626084edd827e07e1552279814c6682d"
+dependencies = [
+ "libc",
+ "thiserror 1.0.69",
+ "winapi",
+]
+
+[[package]]
 name = "filetime"
 version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -695,6 +840,18 @@ name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5baebc0774151f905a1a2cc41989300b1e6fbb29aff0ceffa1064fdd3088d582"
+
+[[package]]
+name = "finl_unicode"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9844ddc3a6e533d62bba727eb6c28b5d360921d5175e9ff0f1e621a5c590a4d5"
+
+[[package]]
+name = "fixedbitset"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ce7134b9999ecaf8bcd65542e436736ef32ddca1b3e06094cb6ec5755203b80"
 
 [[package]]
 name = "flate2"
@@ -783,7 +940,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -844,8 +1001,19 @@ checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
 ]
 
 [[package]]
@@ -863,9 +1031,18 @@ version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
+ "foldhash 0.1.5",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash 0.1.5",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -902,6 +1079,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1090,7 +1273,7 @@ dependencies = [
  "indoc",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1125,9 +1308,9 @@ checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
 
 [[package]]
 name = "itertools"
-version = "0.13.0"
+version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1160,6 +1343,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "kasuari"
+version = "0.4.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bde5057d6143cc94e861d90f591b9303d6716c6b9602309150bd068853c10899"
+dependencies = [
+ "hashbrown 0.16.1",
+ "portable-atomic",
+ "thiserror 2.0.18",
+]
+
+[[package]]
+name = "lab"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf36173d4167ed999940f804952e6b08197cae5ad5d572eb4db150ce8ad5d58f"
+
+[[package]]
 name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1189,10 +1389,13 @@ dependencies = [
 ]
 
 [[package]]
-name = "linux-raw-sys"
-version = "0.4.15"
+name = "line-clipping"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d26c52dbd32dccf2d10cac7725f8eae5296885fb5703b261f7d0a0739ec807ab"
+checksum = "3f50e8f47623268b5407192d26876c4d7f89d686ca130fdc53bced4814cd29f8"
+dependencies = [
+ "bitflags 2.13.0",
+]
 
 [[package]]
 name = "linux-raw-sys"
@@ -1205,6 +1408,12 @@ name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92daf443525c4cce67b150400bc2316076100ce0b3686209eb8cf3c31612e6f0"
+
+[[package]]
+name = "litrs"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11d3d7f243d5c5a8b9bb5d6dd2b1602c0cb0b9db1621bafc7ed66e35ff9fe092"
 
 [[package]]
 name = "lock_api"
@@ -1223,11 +1432,11 @@ checksum = "953f07c43838f8e6f9758cab68bf5bed85465e7587ebe0b823f1bcd81978ad3a"
 
 [[package]]
 name = "lru"
-version = "0.12.5"
+version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "234cf4f4a04dc1f57e24b96cc0cd600cf2af460d4161ac5ecdd0af8e1f3b2a38"
+checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.15.5",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1241,6 +1450,16 @@ dependencies = [
  "serde_json",
  "serde_repr",
  "url",
+]
+
+[[package]]
+name = "mac_address"
+version = "1.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0aeb26bf5e836cc1c341c8106051b573f1766dfa05aa87f0b98be5e51b02303"
+dependencies = [
+ "nix",
+ "winapi",
 ]
 
 [[package]]
@@ -1258,6 +1477,12 @@ name = "memchr"
 version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b947ae49db0d222b1dbc6b113ce7248a3fc3a6ca21b696717bfc000ba4484d8"
+
+[[package]]
+name = "memmem"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a64a92489e2744ce060c349162be1c5f33c6969234104dbd99ddb5feb08b8c15"
 
 [[package]]
 name = "memoffset"
@@ -1297,6 +1522,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "nix"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
+dependencies = [
+ "bitflags 2.13.0",
+ "cfg-if",
+ "cfg_aliases",
+ "libc",
+ "memoffset",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1323,6 +1561,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "num-integer"
 version = "0.1.46"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1338,6 +1587,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_threads"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -1368,6 +1626,39 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
 
 [[package]]
+name = "ordered-float"
+version = "4.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7bb71e1b3fa6ca1c61f383464aaf2bb0e2f8e772a1f01d486832464de363b951"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "palette"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cbf71184cc5ecc2e4e1baccdb21026c20e5fc3dcf63028a086131b3ab00b6e6"
+dependencies = [
+ "approx",
+ "fast-srgb8",
+ "libm",
+ "palette_derive",
+]
+
+[[package]]
+name = "palette_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f5030daf005bface118c096f510ffb781fc28f9ab6a32ab224d8631be6851d30"
+dependencies = [
+ "by_address",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1375,7 +1666,7 @@ checksum = "d0984e668274d34691bc2b262ef0d115de5fa9973bcdee7ae32213f93099153e"
 dependencies = [
  "bytecount",
  "fnv",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1402,16 +1693,105 @@ dependencies = [
 ]
 
 [[package]]
-name = "paste"
-version = "1.0.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pest"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0848c601009d37dfa3430c4666e147e49cdcf1b92ecd3e63657d8a5f19da662"
+dependencies = [
+ "memchr",
+ "ucd-trie",
+]
+
+[[package]]
+name = "pest_derive"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11f486f1ea21e6c10ed15d5a7c77165d0ee443402f0780849d1768e7d9d6fe77"
+dependencies = [
+ "pest",
+ "pest_generator",
+]
+
+[[package]]
+name = "pest_generator"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8040c4647b13b210a963c1ed407c1ff4fdfa01c31d6d2a098218702e6664f94f"
+dependencies = [
+ "pest",
+ "pest_meta",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "pest_meta"
+version = "2.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89815c69d36021a140146f26659a81d6c2afa33d216d736dd4be5381a7362220"
+dependencies = [
+ "pest",
+ "sha2",
+]
+
+[[package]]
+name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_macros",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared",
+ "rand",
+]
+
+[[package]]
+name = "phf_macros"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f84ac04429c13a7ff43785d75ad27569f2951ce0ffd30a3321230db2fc727216"
+dependencies = [
+ "phf_generator",
+ "phf_shared",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
+]
 
 [[package]]
 name = "pin-project"
@@ -1430,7 +1810,7 @@ checksum = "c96395f0a926bc13b1c17622aaddda1ecb55d49c8f1bf9777e4d877800a43f8b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1485,7 +1865,7 @@ dependencies = [
  "proc-macro-error-attr2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1539,7 +1919,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1552,7 +1932,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1571,24 +1951,125 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
-name = "ratatui"
-version = "0.29.0"
+name = "r-efi"
+version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eabd94c2f37801c20583fc49dd5cd6b0ba68c716787c2dd6ed18571e1e63117b"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
+
+[[package]]
+name = "rand"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5ca0ecfa931c29007047d1bc58e623ab12e5590e8c7cc53200d5202b69266d8a"
+dependencies = [
+ "rand_core",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
+
+[[package]]
+name = "ratatui"
+version = "0.30.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3274ba0a2c5e1bcad2a2005d20f4dc59dad26b2eb0940fb094500dba4099d57d"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "ratatui-crossterm",
+ "ratatui-macros",
+ "ratatui-termina",
+ "ratatui-termwiz",
+ "ratatui-widgets",
+ "serde",
+]
+
+[[package]]
+name = "ratatui-core"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbb175c433c8e28a809d1f5773a2ae96e68c0ce40db865cbab1020bf33ae479c"
 dependencies = [
  "bitflags 2.13.0",
- "cassowary",
  "compact_str",
+ "critical-section",
+ "hashbrown 0.17.1",
+ "itertools",
+ "kasuari",
+ "lru",
+ "palette",
+ "serde",
+ "strum",
+ "thiserror 2.0.18",
+ "unicode-segmentation",
+ "unicode-truncate",
+ "unicode-width",
+]
+
+[[package]]
+name = "ratatui-crossterm"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "567584a3b0e6a8203c23de40b4861497266725eb5363dbfd18a1edd603cca9f0"
+dependencies = [
+ "cfg-if",
  "crossterm",
+ "instability",
+ "ratatui-core",
+]
+
+[[package]]
+name = "ratatui-macros"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7dc68daa7498a43e4d68e0eb078427e10c38fbcfbb1e42d955f1fa2140d814"
+dependencies = [
+ "ratatui-core",
+ "ratatui-widgets",
+]
+
+[[package]]
+name = "ratatui-termina"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0bf912d9e66f057a759d92e386a280ea886b352ab757d6ac4d653c7ed2c43c2"
+dependencies = [
+ "instability",
+ "ratatui-core",
+ "termina",
+]
+
+[[package]]
+name = "ratatui-termwiz"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "faf03e0380b7744054d6cb74224fe3adf062a029754933f575ca1e3b4c2ce977"
+dependencies = [
+ "ratatui-core",
+ "termwiz",
+]
+
+[[package]]
+name = "ratatui-widgets"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66e3d19bcc9130ca376277d93b60767ff121ace3be06f5f95f81dd68956407d1"
+dependencies = [
+ "bitflags 2.13.0",
+ "hashbrown 0.17.1",
  "indoc",
  "instability",
  "itertools",
- "lru",
- "paste",
+ "line-clipping",
+ "ratatui-core",
+ "serde",
  "strum",
+ "time",
  "unicode-segmentation",
- "unicode-truncate",
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -1714,25 +2195,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustc_version"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
+dependencies = [
+ "semver",
+]
+
+[[package]]
 name = "rusticata-macros"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "faf0c4a6ece9950b9abdb62b1cfcf2a68b3b67a10ba445b3bb85be2a293d0632"
 dependencies = [
  "nom",
-]
-
-[[package]]
-name = "rustix"
-version = "0.38.44"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
-dependencies = [
- "bitflags 2.13.0",
- "errno",
- "libc",
- "linux-raw-sys 0.4.15",
- "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -1744,7 +2221,7 @@ dependencies = [
  "bitflags 2.13.0",
  "errno",
  "libc",
- "linux-raw-sys 0.12.1",
+ "linux-raw-sys",
  "windows-sys 0.61.2",
 ]
 
@@ -1849,7 +2326,7 @@ checksum = "3067861075c2b80608f84ad49fb88f2c7610b94cdf8b4201e79ddee87f8980c8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -1892,6 +2369,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "semver"
+version = "1.0.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
 name = "serde"
 version = "1.0.228"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,7 +2401,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -1943,7 +2426,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2012,6 +2495,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
+name = "siphasher"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ee5873ec9cce0195efcb7a4e9507a04cd49aec9c83d0389df45b1ef7ba2e649"
+
+[[package]]
 name = "slab"
 version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2053,24 +2542,23 @@ checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
 name = "strum"
-version = "0.26.3"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
 dependencies = [
  "strum_macros",
 ]
 
 [[package]]
 name = "strum_macros"
-version = "0.26.4"
+version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6bee85a5a24955dc440386795aa378cd9cf82acd5f764469152d2270e581be"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
 dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "rustversion",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2078,6 +2566,17 @@ name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
+name = "syn"
+version = "1.0.109"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
 
 [[package]]
 name = "syn"
@@ -2098,7 +2597,7 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2122,7 +2621,7 @@ dependencies = [
  "proc-macro-error2",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2170,7 +2669,7 @@ dependencies = [
  "tar",
  "tcl-bigip",
  "temp-env",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2209,7 +2708,6 @@ dependencies = [
  "anyhow",
  "clap",
  "clap_complete",
- "crossterm",
  "ratatui",
  "regex",
  "rusqlite",
@@ -2237,7 +2735,7 @@ dependencies = [
  "tcl-lsp-core",
  "tcl-registry",
  "temp-env",
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2260,7 +2758,7 @@ dependencies = [
  "tcl-registry",
  "tcl-syntax",
  "temp-env",
- "thiserror",
+ "thiserror 2.0.18",
  "unicode-general-category",
 ]
 
@@ -2333,7 +2831,7 @@ dependencies = [
 name = "tcl-lexer"
 version = "0.1.0"
 dependencies = [
- "thiserror",
+ "thiserror 2.0.18",
 ]
 
 [[package]]
@@ -2477,13 +2975,89 @@ dependencies = [
 ]
 
 [[package]]
+name = "termina"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9048a889effe34a5cddee0af7f53285198b16dca3be510858d38dfdb3e62a04e"
+dependencies = [
+ "bitflags 2.13.0",
+ "parking_lot",
+ "rustix",
+ "signal-hook",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "terminal_size"
 version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230a1b821ccbd75b185820a1f1ff7b14d21da1e442e22c0863ea5f08771a8874"
 dependencies = [
- "rustix 1.1.4",
+ "rustix",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "terminfo"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4ea810f0692f9f51b382fff5893887bb4580f5fa246fde546e0b13e7fcee662"
+dependencies = [
+ "fnv",
+ "nom",
+ "phf",
+ "phf_codegen",
+]
+
+[[package]]
+name = "termios"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "411c5bf740737c7918b8b1fe232dca4dc9f8e754b8ad5e20966814001ed0ac6b"
+dependencies = [
+ "libc",
+]
+
+[[package]]
+name = "termwiz"
+version = "0.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4676b37242ccbd1aabf56edb093a4827dc49086c0ffd764a5705899e0f35f8f7"
+dependencies = [
+ "anyhow",
+ "base64",
+ "bitflags 2.13.0",
+ "fancy-regex",
+ "filedescriptor",
+ "finl_unicode",
+ "fixedbitset",
+ "hex",
+ "lazy_static",
+ "libc",
+ "log",
+ "memmem",
+ "nix",
+ "num-derive",
+ "num-traits",
+ "ordered-float",
+ "pest",
+ "pest_derive",
+ "phf",
+ "sha2",
+ "signal-hook",
+ "siphasher",
+ "terminfo",
+ "termios",
+ "thiserror 1.0.69",
+ "ucd-trie",
+ "unicode-segmentation",
+ "vtparse",
+ "wezterm-bidi",
+ "wezterm-blob-leases",
+ "wezterm-color-types",
+ "wezterm-dynamic",
+ "wezterm-input-types",
+ "winapi",
 ]
 
 [[package]]
@@ -2492,7 +3066,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0f8daae29995a24f65619e19d8d31dea5b389f3d853d8bf297bbf607cd0014cc"
 dependencies = [
- "unicode-width 0.2.0",
+ "unicode-width",
 ]
 
 [[package]]
@@ -2503,11 +3077,31 @@ checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
+dependencies = [
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 2.0.18",
+]
+
+[[package]]
+name = "thiserror-impl"
+version = "1.0.69"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2518,7 +3112,7 @@ checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2528,7 +3122,9 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "711a53c2d47bbd818258c498c8dbfe186a2526c631495cfe7e078567f86b8469"
 dependencies = [
  "deranged",
+ "libc",
  "num-conv",
+ "num_threads",
  "powerfmt",
  "serde_core",
  "time-core",
@@ -2580,7 +3176,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2647,7 +3243,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2675,7 +3271,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2700,6 +3296,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6f5e870be6c3b371b77fe0ee0bafb859fa4964b4404c27de1d380043c4dda20"
 
 [[package]]
+name = "ucd-trie"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2896d95c02a80c6d6a5d6e953d479f5ddf2dfdb6a244441010e373ac0fb88971"
+
+[[package]]
 name = "unicode-general-category"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2719,20 +3321,14 @@ checksum = "c6f5d3c3b1bf09027a88a6bc961fc00497d651009560b5463668dc81b0fa87a8"
 
 [[package]]
 name = "unicode-truncate"
-version = "1.1.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3644627a5af5fa321c95b9b235a72fd24cd29c648c2c379431e6628655627bf"
+checksum = "16b380a1238663e5f8a691f9039c73e1cdae598a30e9855f541d29b08b53e9a5"
 dependencies = [
  "itertools",
  "unicode-segmentation",
- "unicode-width 0.1.14",
+ "unicode-width",
 ]
-
-[[package]]
-name = "unicode-width"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7dd6e30e90baa6f72411720665d41d89b9a3d039dc45b8faea1ddd07f617f6af"
 
 [[package]]
 name = "unicode-width"
@@ -2807,6 +3403,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
+name = "uuid"
+version = "1.23.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "144d6b123cef80b301b8f72a9e2ca4370ddec21950d0a103dd22c437006d2db7"
+dependencies = [
+ "atomic",
+ "getrandom 0.4.3",
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2817,6 +3425,15 @@ name = "version_check"
 version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
+
+[[package]]
+name = "vtparse"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
+dependencies = [
+ "utf8parse",
+]
 
 [[package]]
 name = "wasi"
@@ -2865,7 +3482,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "wasm-bindgen-shared",
 ]
 
@@ -2885,6 +3502,78 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "wezterm-bidi"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0a6e355560527dd2d1cf7890652f4f09bb3433b6aadade4c9b5ed76de5f3ec"
+dependencies = [
+ "log",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-blob-leases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "692daff6d93d94e29e4114544ef6d5c942a7ed998b37abdc19b17136ea428eb7"
+dependencies = [
+ "getrandom 0.3.4",
+ "mac_address",
+ "sha2",
+ "thiserror 1.0.69",
+ "uuid",
+]
+
+[[package]]
+name = "wezterm-color-types"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7de81ef35c9010270d63772bebef2f2d6d1f2d20a983d27505ac850b8c4b4296"
+dependencies = [
+ "csscolorparser",
+ "deltae",
+ "lazy_static",
+ "wezterm-dynamic",
+]
+
+[[package]]
+name = "wezterm-dynamic"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f2ab60e120fd6eaa68d9567f3226e876684639d22a4219b313ff69ec0ccd5ac"
+dependencies = [
+ "log",
+ "ordered-float",
+ "strsim",
+ "thiserror 1.0.69",
+ "wezterm-dynamic-derive",
+]
+
+[[package]]
+name = "wezterm-dynamic-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "46c0cf2d539c645b448eaffec9ec494b8b19bd5077d9e58cb1ae7efece8d575b"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "wezterm-input-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7012add459f951456ec9d6c7e6fc340b1ce15d6fc9629f8c42853412c029e57e"
+dependencies = [
+ "bitflags 1.3.2",
+ "euclid",
+ "lazy_static",
+ "serde",
+ "wezterm-dynamic",
 ]
 
 [[package]]
@@ -2930,7 +3619,7 @@ checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -2941,7 +3630,7 @@ checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3158,7 +3847,7 @@ dependencies = [
  "nom",
  "oid-registry",
  "rusticata-macros",
- "thiserror",
+ "thiserror 2.0.18",
  "time",
 ]
 
@@ -3169,7 +3858,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e45ad4206f6d2479085147f02bc2ef834ac85886624a23575ae137c8aa8156"
 dependencies = [
  "libc",
- "rustix 1.1.4",
+ "rustix",
 ]
 
 [[package]]
@@ -3191,7 +3880,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3212,7 +3901,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3232,7 +3921,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
  "synstructure",
 ]
 
@@ -3272,7 +3961,7 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.117",
 ]
 
 [[package]]
@@ -3288,7 +3977,7 @@ dependencies = [
  "flate2",
  "indexmap",
  "memchr",
- "thiserror",
+ "thiserror 2.0.18",
  "zopfli",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2280,6 +2280,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcl-fuzz"
+version = "0.1.0"
+dependencies = [
+ "clap",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "tcl-host-native"
 version = "0.1.0"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -661,6 +661,7 @@ dependencies = [
  "tcl-bigip-io",
  "tcl-bigip-query",
  "tcl-cli-support",
+ "tcl-irule-test",
  "tcl-irules",
  "tcl-lsp-core",
  "tcl-registry",
@@ -2311,6 +2312,10 @@ name = "tcl-irule-test"
 version = "0.1.0"
 dependencies = [
  "tcl-bigip",
+ "tcl-bytecode",
+ "tcl-compiler",
+ "tcl-registry",
+ "tcl-vm",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ members = [
     "rust/f5-cli",
     "rust/tcl-fuzz",
     "rust/tcl-irule-test",
+    "rust/tcl-debugger",
 ]
 exclude = [
     "editors/zed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ members = [
     "rust/tcl-pkg",
     "rust/f5-cli",
     "rust/tcl-fuzz",
+    "rust/tcl-irule-test",
 ]
 exclude = [
     "editors/zed",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ members = [
     "rust/tcl-cli",
     "rust/tcl-pkg",
     "rust/f5-cli",
+    "rust/tcl-fuzz",
 ]
 exclude = [
     "editors/zed",

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -698,9 +698,9 @@ If your port has any of these, reshape it before asking for review:
 
 The workspace (`Cargo.toml` members) as it stands today — crate granularity,
 roughly in dependency order. New crates the [Remaining work](#remaining-work)
-plan still calls for (`tcl-wasm`, `tcl-xc`, `tcl-debugger`, `tcl-irule-test`)
-are **not** listed here because they do not exist yet; `tcl-fuzz` has since
-landed (the differential fuzzer binary).
+plan still calls for (`tcl-wasm`, `tcl-xc`, `tcl-debugger`) are **not** listed
+here because they do not exist yet; `tcl-fuzz` (the differential fuzzer) and
+`tcl-irule-test` (the iRule-test glue scaffold) have since landed.
 
 ```
 Cargo.toml                workspace manifest        rust-toolchain.toml  channel = "stable"
@@ -737,6 +737,7 @@ rust/
   tcl-cli-support/        shared CLI plumbing for the native tcl / f5 CLIs
   tcl-cli/                native `tcl` toolchain CLI                f5-cli/  native `f5-query` CLI
   tcl-fuzz/               differential fuzzer (seeded generator + tclvm-vs-tclsh harness + findings)
+  tcl-irule-test/         iRule TMM-sim glue: SCF→orchestrator topology + session bootstrap (driver gated on RT-VM)
 runtime/
   zig/                    Zig WASM runtime (out-of-process runtime for compiled scripts)
   rust/                   tree-walking reference runtime (RT-VM parity oracle)
@@ -879,7 +880,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
 | Differential fuzzer | `tcl-fuzz` | 🟢 | campaign runner + seeded generator + findings registry land (`tclvm` vs `tclsh`); broaden the generator grammar as the VM surface grows → **TOOL-FUZZ** |
 | Debugger (DAP) | new crate | 🔴 | full debugger over `tcl-vm` → **TOOL-DEBUGGER** |
-| iRule test framework | new crate | 🔴 | TMM-sim harness (topology/profile-gen/orchestrator) → **TOOL-IRULE-TEST** |
+| iRule test framework | `tcl-irule-test` | 🟡 | crate scaffolded: SCF→orchestrator topology generator (parity-checked vs Python) + session-bootstrap assembly; the live event round-trip is gated on the VM iRule surface (**RT-VM**) → **TOOL-IRULE-TEST** |
 | PyO3 public API + retirement | `tcl-lsp-py`, `xtask` | 🔴 | designed public surface; TEST-MIGRATE; PYTHON-RETIRE → **API-PYO3** |
 | `ai/` (MCP + skills) | — | n/a | stays Python by design |
 
@@ -904,7 +905,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | TOOL | **TOOL-EXPLORER** | `tcl-explorer`, `tcl-explorer-wasm` | RT-WASM | S |
 | TOOL | **TOOL-FUZZ** 🟢 | `tcl-fuzz` (bin) | RT-VM | M |
 | TOOL | **TOOL-DEBUGGER** | new `tcl-debugger` | RT-VM | L |
-| TOOL | **TOOL-IRULE-TEST** | new `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
+| TOOL | **TOOL-IRULE-TEST** 🟡 | `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
 | TOOL | **TOOL-CLI** ✅ | `tcl-cli` | RT-WASM, RT-VM, TOOL-TCLPKG | S |
 | API | **API-PYO3** | `tcl-lsp-py`, `scripts`→`xtask`, `tests` | everything above | L |
 
@@ -1236,9 +1237,19 @@ already started, brings **every** Python tool across to Rust.
 - **TOOL-DEBUGGER** *(new `tcl-debugger`; depends on RT-VM)* — **open**: DAP server
   over `tcl-vm` (breakpoints/stepping/backends). *(L)*
 - **TOOL-IRULE-TEST** *(new `tcl-irule-test`; depends on RT-VM + `tcl-registry`)* —
-  **open**: the TMM-simulating test framework (topology/SCF parsing, profile-gen,
-  mock-stub codegen, orchestrator). Note `tcl-irules` is the BIG-IP
-  reference-extractor, **not** this. *(XL)*
+  **scaffolded**: the crate exists with the portable glue. `topology` ports
+  `TopologyFromSCF` — parse a bigip.conf via `tcl-bigip` and emit the `::orch::`
+  setup (profiles via name-inference, VIP, pools + members, data-groups,
+  attached iRules), parity-checked against the Python generator. `session`
+  defines the `SessionPlan` / orchestrator-bootstrap assembly the VM driver
+  will run. **Architecture note:** the TMM simulation itself is the ~500 KB of
+  Tcl under `tooling/irule_test/tcl/` (orchestrator + TMM shim + command
+  mocks); the Rust port runs that Tcl on **`tcl-vm`**, so the live
+  event/`run_*`/`assert_*` round-trip is gated on the VM growing the iRule
+  command surface (`HTTP::*`, `pool`/`node`, `LB::*`, `when` dispatch,
+  `class match`). Remaining: the VM-driven session execution, profile-object
+  type resolution, profile-gen, and the mock-stub/registry/event-data codegen.
+  Note `tcl-irules` is the BIG-IP reference-extractor, **not** this. *(XL)*
 - **TOOL-CLI** *(owns `tcl-cli`; depends on RT-WASM, RT-VM, TOOL-TCLPKG)* —
   **done**: all 26 top-level verbs are ported and dispatched to native engine
   handlers. `dis` (bytecode disassembly via `format_module_asm`) and `compwasm`

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1078,7 +1078,19 @@ delete`, and the supporting `return`/`error`/list-parse fixes — error.test
   most common real "hang" idiom** — tcltest's own
   `while {[string length $argList]}` word-splitter spun — so several suites that
   appeared to "hang" should now progress (re-baseline the parity harness in
-  `--release`).
+  `--release`). The **same token-loss bug** was then fixed for the other
+  runtime loop fallbacks — the `dict for`/`map` barrier and the runtime
+  `foreach`/`lmap` call (qualified loop vars / non-inline) — by extending
+  `raw_tokens` to `Foreach`. **Audit:** only the three loop types have a
+  runtime fallback; `switch`/`catch`/`try`/`if` inline their bodies and need no
+  token preservation.
+- **fixed (2026-06-21) composite array-element index substitution.** A read or
+  write of `$a(prefix$var)` / `$a(-$opt)` / `$a(${item}suf)` pushed the index as
+  a raw literal, so the embedded variable never expanded (`can't read
+  "a(x$item)"`). tcltest's `$testAttributes(-$item)` option processing hit this,
+  aborting `info.test` after the loop fix. `push_array_key` now decodes a
+  composite index into its substitution parts and `STR_CONCAT`s them (byte-equal
+  to `tclsh9.0`).
 - **open** `namespace` / `var` / `upvar` depth (≈ 290 failures combined) — the
   namespace-eval-frame fix corrected the *mechanism*; the remainder is
   feature/semantics depth (namespace-name canonicalisation of multiple/trailing

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1062,27 +1062,23 @@ delete`, and the supporting `return`/`error`/list-parse fixes — error.test
     a loop, is what zeros the remainder of the suite — the real P1 to chase
     (an `uplevel`/`catch`/error-propagation gap), and far more tractable than a
     deadlock hunt.
-- **open (P1) genuine infinite loop in the runtime `while`/`for` body**
-  (`cmd_control.rs`, diagnosed 2026-06-21). A loop whose **condition is a bare
-  command substitution** falls back to the runtime `while`/`for` builtin (only
-  an *expression* condition — `[cmd] > 0`, `$x`, `!![cmd]` — inlines to the CFG
-  loop). On that fallback path the body's variable writes and the
-  command-substitution reads **disagree across iterations**, so the condition
-  never changes and the loop spins forever (a true hang, distinct from (a)/(b)).
-  Minimal repros (all spin; the `> 0` variants terminate):
-  - `set x abc; while {[string length $x]} {set x ""}` — `[string length $x]`
-    stays `3` though `$x` reads empty.
-  - `set x abcde; set n 0; while {[string length $x]} {incr n; set x [string repeat z $n]; if {$n>3} break}`
-    — `n` accumulates (frame persists) but `$x` stays frozen at `abcde`, i.e.
-    `set x [<cmd-sub>]` does not persist while `incr n` does.
-  The split (literal-RHS `set` vs command-substituted-RHS `set`; direct `$x` vs
-  `[string length $x]`) localises it to how the `eval_source`-compiled body
-  module resolves variables/command-subs vs the enclosing loop frame on
-  repeated `run_module`. **This is the most common real "hang" idiom**
-  (`while {[gets $f line] >= 0}` works; bare `while {[string length $x]}` /
-  tcltest's `while {[string length $argList]}` word-splitter spin). Fix is a
-  frame/eval-scope correction in the runtime loop body path — verify against the
-  inlined path (already correct) and the tree-walking `runtime/rust`.
+- **fixed (2026-06-21) the runtime `while`/`for` frozen-loop infinite spin.** A
+  loop whose **condition is a bare command substitution** can't inline to a CFG
+  loop (only an *expression* condition — `[cmd] > 0`, `$x`, `!![cmd]` — does), so
+  `cfg_builder` converts it to a "frozen" runtime `while`/`for` call. That
+  conversion built the barrier with `tokens: None`, so the codegen lost each
+  word's source kind and pushed the braced `{cond}` word **non-verbatim** —
+  `subst_word` evaluated the condition's command substitution **once** at the
+  call site, freezing the loop into an infinite spin (`while {[string length
+  $x]} {set x ""}` never terminated; the `> 0` variants did). The `While`/`For`
+  IR now carries the segmenter's `raw_tokens`, and the frozen barrier reuses
+  them so each word is pushed exactly as written (braced → verbatim, `$body` →
+  substituted). Verified byte-equal to `tclsh9.0` and covered by
+  `tcl-vm/tests/language_e2e.rs::while_command_subst_condition_*`. **This was the
+  most common real "hang" idiom** — tcltest's own
+  `while {[string length $argList]}` word-splitter spun — so several suites that
+  appeared to "hang" should now progress (re-baseline the parity harness in
+  `--release`).
 - **open** `namespace` / `var` / `upvar` depth (≈ 290 failures combined) — the
   namespace-eval-frame fix corrected the *mechanism*; the remainder is
   feature/semantics depth (namespace-name canonicalisation of multiple/trailing

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -875,14 +875,14 @@ listed residuals · 🟡 partial · 🔴 not started.
 | LSP server / core / db | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | ✅ | #670 bulk + the two consumer-wiring residuals (GAP-C1 per-check config toggles; IRULE5002/5004 flow-warning code actions) landed — see [history](rust-rewrite-history.md). The rope-backed `DocumentState` is split out into its own **SRV-ROPE** track (need evaluated with measurements in [`design/rope/`](design/rope/README.md)) |
 | Document store / incrementality | `tcl-lsp-server`, `tcl-lexer`, `tcl-lsp-db` | 🔴 | rope-backed store + chunk-addressable salsa input + rope-slice re-lex → **SRV-ROPE** (see [`design/rope/`](design/rope/README.md)) |
 | `tcl` CLI | `tcl-cli` | ✅ | all 26 verbs ported & dispatched (`dis`/`compwasm` + `pkg`/`venv`/`docker` wired via TOOL-TCLPKG) → **TOOL-CLI** |
-| `f5-query` CLI | `f5-cli`, `tcl-bigip*`, `tcl-irules` | 🟢 | `explain-flow --tshark/--keylog/--tshark-filter` landed; `--simulate` gated on the native iRule VM (**RT-VM**); `completion`/`graph` parity files → **TOOL-F5** |
+| `f5-query` CLI | `f5-cli`, `tcl-bigip*`, `tcl-irules` | ✅ | `explain-flow --tshark/--keylog/--tshark-filter` + `--simulate` (iRule run live on `tcl-vm` via `tcl-irule-test`) → **TOOL-F5** |
 | Formatter / minifier / diagram | `tcl-lsp-core`, `tcl-cli` | ✅ | — |
 | Refactoring transforms | `tcl-lsp-core::code_actions` | ✅ | all 7 transforms ported (`tcl-lsp-core::refactor`), byte-parity vs the Python oracle → **TOOL-REFACTOR** |
 | Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟢 | `wasm` view renders the eval-fallback emitter's WAT; rich per-instruction web-GUI shape (`to_explorer_json`) is a refinement → **TOOL-EXPLORER** |
 | Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
 | Differential fuzzer | `tcl-fuzz` | 🟢 | campaign runner + seeded generator + findings registry land (`tclvm` vs `tclsh`); broaden the generator grammar as the VM surface grows → **TOOL-FUZZ** |
 | Debugger | `tcl-debugger` | ✅ | record-and-replay step debugger over `tcl-vm` (VM debug-hook seam) with a `tcl-debug` CLI **and** a DAP server for editors (`--dap`): breakpoints, step in/over/out, continue, stack/scopes/variables, evaluate → **TOOL-DEBUGGER** |
-| iRule test framework | `tcl-irule-test` | 🟡 | crate scaffolded: SCF→orchestrator topology generator (parity-checked vs Python) + session-bootstrap assembly; the live event round-trip is gated on the VM iRule surface (**RT-VM**) → **TOOL-IRULE-TEST** |
+| iRule test framework | `tcl-irule-test` | 🟢 | SCF→orchestrator topology generator + `LiveSession` running the TMM-sim orchestrator live on `tcl-vm` (load iRule, fire events, read pool/logs/decisions); framework Tcl embedded for self-contained consumers → **TOOL-IRULE-TEST** |
 | PyO3 public API + retirement | `tcl-lsp-py`, `xtask` | 🔴 | designed public surface; TEST-MIGRATE; PYTHON-RETIRE → **API-PYO3** |
 | `ai/` (MCP + skills) | — | n/a | stays Python by design |
 
@@ -903,11 +903,11 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SRV | **SRV-ROPE** | document store: `tcl-lsp-server` `DocumentState` + `tcl-lexer` rope-slice `SourceMap` + `tcl-lsp-db` chunk input | FE-LEX (CST/structural-state index), SRV-LSP | XL |
 | TOOL | **TOOL-TCLPKG** ✅ | `tcl-pkg` crate | — | XL |
 | TOOL | **TOOL-REFACTOR** ✅ | `tcl-lsp-core::code_actions` | SRV-LSP | M |
-| TOOL | **TOOL-F5** | `f5-cli` | — | XS |
+| TOOL | **TOOL-F5** ✅ | `f5-cli` | RT-VM, TOOL-IRULE-TEST | XS |
 | TOOL | **TOOL-EXPLORER** 🟢 | `tcl-explorer`, `tcl-explorer-wasm` | RT-WASM | S |
 | TOOL | **TOOL-FUZZ** 🟢 | `tcl-fuzz` (bin) | RT-VM | M |
 | TOOL | **TOOL-DEBUGGER** ✅ | `tcl-debugger` | RT-VM | L |
-| TOOL | **TOOL-IRULE-TEST** 🟡 | `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
+| TOOL | **TOOL-IRULE-TEST** 🟢 | `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
 | TOOL | **TOOL-CLI** ✅ | `tcl-cli` | RT-WASM, RT-VM, TOOL-TCLPKG | S |
 | API | **API-PYO3** | `tcl-lsp-py`, `scripts`→`xtask`, `tests` | everything above | L |
 
@@ -1206,17 +1206,18 @@ already started, brings **every** Python tool across to Rust.
   against the live Python oracle; all `tests/test_refactoring.py` decline
   conditions are mirrored. Out of scope: `suggest_datagroup_extraction` (an
   AI-context scanner, not a `CodeAction`). *(M)*
-- **TOOL-F5** *(owns `f5-cli`)* — **partial**: the `explain-flow`
+- **TOOL-F5** *(owns `f5-cli`)* — **done**: the `explain-flow`
   `--tshark` / `--keylog` / `--tshark-filter` L7-enrichment paths landed
   (`tcl_bigip::flow::tshark`, a faithful EK-JSON port of
   `dialects/f5/bigip/flow/tshark.py`, byte-identical to the Python CLI on the
   `--tshark` / `--tshark-filter` paths; graceful degradation when tshark lacks
-  EK `--no-duplicate-keys` support is itself parity-matched). Remaining:
-  `--simulate` is gated on the native iRule VM (the `tooling.irule_test`
-  orchestrator → **RT-VM** / **TOOL-IRULE-TEST**) and stays a clear
-  not-implemented error meanwhile; plus dedicated `completion`/`graph` parity
-  files. The rest (27/27 verbs, 262 parity tests) is done — the template for the
-  other tool ports. *(XS)*
+  EK `--no-duplicate-keys` support is itself parity-matched). `--simulate` now
+  runs each matched session's iRule under the embedded TMM-sim orchestrator on
+  `tcl-vm` (via `tcl-irule-test::LiveSession`): the selected pool/node, the lb
+  decision log, captured iRule logs and `response_committed` flow into the
+  `simulated_*` text/JSON fields, port of `tooling/f5/irule_simulation.py`. The
+  rest (27/27 verbs, 262 parity tests) is done — the template for the other tool
+  ports. *(XS)*
 - **TOOL-EXPLORER** *(owns `tcl-explorer`, `tcl-explorer-wasm`; depends on
   RT-WASM)* — **done (for the views)**: the `ssa`-view boolean-render parity bug
   landed (`view_tree::pystr`), and the **`wasm` view now renders WAT** —
@@ -1264,18 +1265,21 @@ already started, brings **every** Python tool across to Rust.
   up front, variable inspection is the current frame's captured scope, and
   `evaluate` resolves captured variables. *(L)*
 - **TOOL-IRULE-TEST** *(new `tcl-irule-test`; depends on RT-VM + `tcl-registry`)* —
-  **scaffolded**: the crate exists with the portable glue. `topology` ports
-  `TopologyFromSCF` — parse a bigip.conf via `tcl-bigip` and emit the `::orch::`
-  setup (profiles via name-inference, VIP, pools + members, data-groups,
-  attached iRules), parity-checked against the Python generator. `session`
-  defines the `SessionPlan` / orchestrator-bootstrap assembly the VM driver
-  will run. **Architecture note:** the TMM simulation itself is the ~500 KB of
-  Tcl under `tooling/irule_test/tcl/` (orchestrator + TMM shim + command
-  mocks); the Rust port runs that Tcl on **`tcl-vm`**, so the live
-  event/`run_*`/`assert_*` round-trip is gated on the VM growing the iRule
-  command surface (`HTTP::*`, `pool`/`node`, `LB::*`, `when` dispatch,
-  `class match`). Remaining: the VM-driven session execution, profile-object
-  type resolution, profile-gen, and the mock-stub/registry/event-data codegen.
+  **working**: the crate runs the TMM-sim orchestrator live on `tcl-vm`.
+  `topology` ports `TopologyFromSCF` — parse a bigip.conf via `tcl-bigip` and
+  emit the `::orch::` setup (profiles via name-inference, VIP, pools + members,
+  data-groups, attached iRules), parity-checked against the Python generator.
+  `session` defines the `SessionPlan` / orchestrator-bootstrap assembly.
+  `live::LiveSession` is the in-process driver: it sources the orchestrator
+  framework (the ~500 KB of Tcl under `tooling/irule_test/tcl/` — orchestrator +
+  TMM shim + command mocks) on a bytecode VM, loads iRules, fires events
+  (`run_http_request`), and reads back the pool/node decisions, captured logs,
+  and assertions — no `tclsh` subprocess. `embedded::EmbeddedLib` bundles the
+  framework into the binary so a consumer (e.g. `f5 explain-flow --simulate`)
+  needs no on-disk Tcl checkout. Getting the orchestrator running surfaced and
+  fixed six VM/compiler bugs (proc-body namespace-cache collision, `format`
+  const-fold of variable args, missing `unknown`/`exit`/`::tcl::clock::*`, ARE
+  word-edge regex escapes) plus the dict opcodes and multi-level `dict set`.
   Note `tcl-irules` is the BIG-IP reference-extractor, **not** this. *(XL)*
 - **TOOL-CLI** *(owns `tcl-cli`; depends on RT-WASM, RT-VM, TOOL-TCLPKG)* —
   **done**: all 26 top-level verbs are ported and dispatched to native engine

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -881,7 +881,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**) → **TOOL-EXPLORER** |
 | Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
 | Differential fuzzer | `tcl-fuzz` | 🟢 | campaign runner + seeded generator + findings registry land (`tclvm` vs `tclsh`); broaden the generator grammar as the VM surface grows → **TOOL-FUZZ** |
-| Debugger | `tcl-debugger` | 🟡 | crate scaffolded: step-mode controller + breakpoints + backend contract (tested); live VM backend gated on a `tcl-vm` per-statement hook (**RT-VM**) → **TOOL-DEBUGGER** |
+| Debugger | `tcl-debugger` | 🟢 | working record-and-replay step debugger over `tcl-vm` (the VM debug-hook seam landed): breakpoints, step in/over/out, continue, stack + variable inspection. Residual: a DAP/CLI protocol surface → **TOOL-DEBUGGER** |
 | iRule test framework | `tcl-irule-test` | 🟡 | crate scaffolded: SCF→orchestrator topology generator (parity-checked vs Python) + session-bootstrap assembly; the live event round-trip is gated on the VM iRule surface (**RT-VM**) → **TOOL-IRULE-TEST** |
 | PyO3 public API + retirement | `tcl-lsp-py`, `xtask` | 🔴 | designed public surface; TEST-MIGRATE; PYTHON-RETIRE → **API-PYO3** |
 | `ai/` (MCP + skills) | — | n/a | stays Python by design |
@@ -906,7 +906,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | TOOL | **TOOL-F5** | `f5-cli` | — | XS |
 | TOOL | **TOOL-EXPLORER** | `tcl-explorer`, `tcl-explorer-wasm` | RT-WASM | S |
 | TOOL | **TOOL-FUZZ** 🟢 | `tcl-fuzz` (bin) | RT-VM | M |
-| TOOL | **TOOL-DEBUGGER** 🟡 | `tcl-debugger` | RT-VM | L |
+| TOOL | **TOOL-DEBUGGER** 🟢 | `tcl-debugger` | RT-VM | L |
 | TOOL | **TOOL-IRULE-TEST** 🟡 | `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
 | TOOL | **TOOL-CLI** ✅ | `tcl-cli` | RT-WASM, RT-VM, TOOL-TCLPKG | S |
 | API | **API-PYO3** | `tcl-lsp-py`, `scripts`→`xtask`, `tests` | everything above | L |
@@ -1236,18 +1236,19 @@ already started, brings **every** Python tool across to Rust.
   the generator grammar (procs, namespaces, dict, `catch`/`try`, switch) as the
   VM command surface fills in, and add the WASM/Zig backend as a third
   differential arm once **RT-WASM** lands. *(M)*
-- **TOOL-DEBUGGER** *(new `tcl-debugger`; depends on RT-VM)* — **scaffolded**:
-  the crate exists with the portable, tested core ported from
-  `tooling/debugger/` — the `DebugController` (breakpoints + the
-  step-in/over/out decision state machine), the shared `types`
-  (`StackFrame`/`Variable`/`StopEvent`/…), and the `DebugBackend` contract.
-  **Architecture note:** the live `VmBackend` needs `tcl-vm` to expose a
-  per-statement debug hook — an execution-control seam in the exec loop that
-  calls back with `(source_line, frame_level, command_text, stack)` and honours
-  the returned `DebugAction`, plus a bytecode-PC → source-line map. That hook is
-  the RT-VM-gated remainder; `VmBackend` reports `Unsupported` until it lands.
-  Remaining after the hook: stack/variable inspection wiring and the DAP (or
-  CLI) protocol surface. *(L)*
+- **TOOL-DEBUGGER** *(new `tcl-debugger`; depends on RT-VM)* — **working**: a
+  record-and-replay step debugger over `tcl-vm`. The RT-VM piece **landed** —
+  `tcl-vm` now has a debug-hook seam (`Vm::set_debug_hook`): it fires once per
+  source command (keyed on `(line, span-start)`, since `startCommand` is emitted
+  only conditionally) with a full `DebugSnapshot` (line, command text, call
+  stack, current-frame variables) and honours the returned `DebugAction`. The
+  seam is inert (an `Option` check) when no hook is installed — differential
+  parity gates stay green. `tcl-debugger`'s `VmBackend` installs a recording
+  hook, runs the script once to capture the trace, then serves
+  breakpoints / step-in/over/out / continue / stack / variable-inspection by
+  navigating the trace with the `DebugController`. Residual: a DAP (or CLI)
+  protocol surface to expose it to editors, and live-eval / deeper-frame
+  variables (replay sees the current frame's captured vars). *(L)*
 - **TOOL-IRULE-TEST** *(new `tcl-irule-test`; depends on RT-VM + `tcl-registry`)* —
   **scaffolded**: the crate exists with the portable glue. `topology` ports
   `TopologyFromSCF` — parse a bigip.conf via `tcl-bigip` and emit the `::orch::`

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -881,7 +881,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**) → **TOOL-EXPLORER** |
 | Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
 | Differential fuzzer | `tcl-fuzz` | 🟢 | campaign runner + seeded generator + findings registry land (`tclvm` vs `tclsh`); broaden the generator grammar as the VM surface grows → **TOOL-FUZZ** |
-| Debugger | `tcl-debugger` | 🟢 | working record-and-replay step debugger over `tcl-vm` (the VM debug-hook seam landed) + a `tcl-debug` CLI front-end (break/step/next/finish/continue/print/stack/vars). Residual: a DAP wire-protocol surface for editors → **TOOL-DEBUGGER** |
+| Debugger | `tcl-debugger` | ✅ | record-and-replay step debugger over `tcl-vm` (VM debug-hook seam) with a `tcl-debug` CLI **and** a DAP server for editors (`--dap`): breakpoints, step in/over/out, continue, stack/scopes/variables, evaluate → **TOOL-DEBUGGER** |
 | iRule test framework | `tcl-irule-test` | 🟡 | crate scaffolded: SCF→orchestrator topology generator (parity-checked vs Python) + session-bootstrap assembly; the live event round-trip is gated on the VM iRule surface (**RT-VM**) → **TOOL-IRULE-TEST** |
 | PyO3 public API + retirement | `tcl-lsp-py`, `xtask` | 🔴 | designed public surface; TEST-MIGRATE; PYTHON-RETIRE → **API-PYO3** |
 | `ai/` (MCP + skills) | — | n/a | stays Python by design |
@@ -906,7 +906,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | TOOL | **TOOL-F5** | `f5-cli` | — | XS |
 | TOOL | **TOOL-EXPLORER** | `tcl-explorer`, `tcl-explorer-wasm` | RT-WASM | S |
 | TOOL | **TOOL-FUZZ** 🟢 | `tcl-fuzz` (bin) | RT-VM | M |
-| TOOL | **TOOL-DEBUGGER** 🟢 | `tcl-debugger` | RT-VM | L |
+| TOOL | **TOOL-DEBUGGER** ✅ | `tcl-debugger` | RT-VM | L |
 | TOOL | **TOOL-IRULE-TEST** 🟡 | `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
 | TOOL | **TOOL-CLI** ✅ | `tcl-cli` | RT-WASM, RT-VM, TOOL-TCLPKG | S |
 | API | **API-PYO3** | `tcl-lsp-py`, `scripts`→`xtask`, `tests` | everything above | L |
@@ -1246,12 +1246,17 @@ already started, brings **every** Python tool across to Rust.
   parity gates stay green. `tcl-debugger`'s `VmBackend` installs a recording
   hook, runs the script once to capture the trace, then serves
   breakpoints / step-in/over/out / continue / stack / variable-inspection by
-  navigating the trace with the `DebugController`. A `tcl-debug` CLI front-end
-  drives it interactively
-  (`break`/`step`/`next`/`finish`/`continue`/`print`/`stack`/`vars`, reading
-  commands from stdin so it scripts cleanly). Residual: a DAP wire-protocol
-  surface for editors, and live-eval / deeper-frame variables (replay sees the
-  current frame's captured vars). *(L)*
+  navigating the trace with the `DebugController`. Two front-ends drive it: a
+  `tcl-debug` interactive CLI
+  (`break`/`step`/`next`/`finish`/`continue`/`print`/`stack`/`vars`) and a
+  **DAP server** (`tcl-debug --dap`) speaking the Debug Adapter Protocol over
+  `Content-Length`-framed stdio — `initialize`/`launch`/`setBreakpoints`/
+  `threads`/`stackTrace`/`scopes`/`variables`/`continue`/`next`/`stepIn`/
+  `stepOut`/`evaluate`/`disconnect` plus the `initialized`/`stopped`/
+  `terminated` events — so editors integrate directly. Known replay-model
+  characteristics (documented, not unfinished): script output is produced once
+  up front, variable inspection is the current frame's captured scope, and
+  `evaluate` resolves captured variables. *(L)*
 - **TOOL-IRULE-TEST** *(new `tcl-irule-test`; depends on RT-VM + `tcl-registry`)* —
   **scaffolded**: the crate exists with the portable glue. `topology` ports
   `TopologyFromSCF` — parse a bigip.conf via `tcl-bigip` and emit the `::orch::`

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -698,9 +698,9 @@ If your port has any of these, reshape it before asking for review:
 
 The workspace (`Cargo.toml` members) as it stands today — crate granularity,
 roughly in dependency order. New crates the [Remaining work](#remaining-work)
-plan still calls for (`tcl-wasm`, `tcl-pkg`, `tcl-xc`, `tcl-fuzz`,
-`tcl-debugger`, `tcl-irule-test`) are **not** listed here because they do not
-exist yet.
+plan still calls for (`tcl-wasm`, `tcl-xc`, `tcl-debugger`, `tcl-irule-test`)
+are **not** listed here because they do not exist yet; `tcl-fuzz` has since
+landed (the differential fuzzer binary).
 
 ```
 Cargo.toml                workspace manifest        rust-toolchain.toml  channel = "stable"
@@ -736,6 +736,7 @@ rust/
   tcl-explorer-wasm/      Rust → WASM compile() facade for the explorer GUI (excluded from the workspace)
   tcl-cli-support/        shared CLI plumbing for the native tcl / f5 CLIs
   tcl-cli/                native `tcl` toolchain CLI                f5-cli/  native `f5-query` CLI
+  tcl-fuzz/               differential fuzzer (seeded generator + tclvm-vs-tclsh harness + findings)
 runtime/
   zig/                    Zig WASM runtime (out-of-process runtime for compiled scripts)
   rust/                   tree-walking reference runtime (RT-VM parity oracle)
@@ -876,7 +877,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Refactoring transforms | `tcl-lsp-core::code_actions` | ✅ | all 7 transforms ported (`tcl-lsp-core::refactor`), byte-parity vs the Python oracle → **TOOL-REFACTOR** |
 | Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**) → **TOOL-EXPLORER** |
 | Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
-| Differential fuzzer | new crate | 🟡 | campaign runner/generator/findings (corpus diff exists) → **TOOL-FUZZ** |
+| Differential fuzzer | `tcl-fuzz` | 🟢 | campaign runner + seeded generator + findings registry land (`tclvm` vs `tclsh`); broaden the generator grammar as the VM surface grows → **TOOL-FUZZ** |
 | Debugger (DAP) | new crate | 🔴 | full debugger over `tcl-vm` → **TOOL-DEBUGGER** |
 | iRule test framework | new crate | 🔴 | TMM-sim harness (topology/profile-gen/orchestrator) → **TOOL-IRULE-TEST** |
 | PyO3 public API + retirement | `tcl-lsp-py`, `xtask` | 🔴 | designed public surface; TEST-MIGRATE; PYTHON-RETIRE → **API-PYO3** |
@@ -901,7 +902,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | TOOL | **TOOL-REFACTOR** ✅ | `tcl-lsp-core::code_actions` | SRV-LSP | M |
 | TOOL | **TOOL-F5** | `f5-cli` | — | XS |
 | TOOL | **TOOL-EXPLORER** | `tcl-explorer`, `tcl-explorer-wasm` | RT-WASM | S |
-| TOOL | **TOOL-FUZZ** | new `tcl-fuzz` (xtask/bin) | RT-VM | M |
+| TOOL | **TOOL-FUZZ** 🟢 | `tcl-fuzz` (bin) | RT-VM | M |
 | TOOL | **TOOL-DEBUGGER** | new `tcl-debugger` | RT-VM | L |
 | TOOL | **TOOL-IRULE-TEST** | new `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
 | TOOL | **TOOL-CLI** ✅ | `tcl-cli` | RT-WASM, RT-VM, TOOL-TCLPKG | S |
@@ -1219,9 +1220,19 @@ already started, brings **every** Python tool across to Rust.
   bug landed (the const-branch label now renders booleans Python-style via
   `view_tree::pystr`); all other TUI views are parity-done. The Pyodide web
   server stays Python. *(S)*
-- **TOOL-FUZZ** *(new `tcl-fuzz`; depends on RT-VM)* — **open**: a campaign runner
-  + random generator + findings registry on top of the existing `differential_*`
-  harnesses. *(M)*
+- **TOOL-FUZZ** *(new `tcl-fuzz` bin; depends on RT-VM)* — **landed**: a seeded
+  random Tcl generator (`generator.rs`, scoped to the VM's supported surface so a
+  divergence is a real miscompile, not an unimplemented command — pure, bounded
+  loops, balanced delimiters), a subprocess differential harness
+  (`harness.rs`: `tclvm` subject vs `tclsh` reference, each timeout-killable so a
+  hang is a finding not a wedge), a campaign runner with stats (`campaign.rs`),
+  and a findings registry (`findings.rs`: JSON + raw `.tcl`, dedup-by-seed,
+  categorised, replayable). CLI verbs `run` / `replay` / `summary`. A
+  500-iteration campaign over the current VM is clean (498/500 match, 2 skipped,
+  0 findings — the loop/array fixes hold under fuzzing). **Remaining:** broaden
+  the generator grammar (procs, namespaces, dict, `catch`/`try`, switch) as the
+  VM command surface fills in, and add the WASM/Zig backend as a third
+  differential arm once **RT-WASM** lands. *(M)*
 - **TOOL-DEBUGGER** *(new `tcl-debugger`; depends on RT-VM)* — **open**: DAP server
   over `tcl-vm` (breakpoints/stepping/backends). *(L)*
 - **TOOL-IRULE-TEST** *(new `tcl-irule-test`; depends on RT-VM + `tcl-registry`)* —

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -870,7 +870,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Bytecode VM | `tcl-vm` | 🟡 | tcltest parity vs `runtime/rust` in progress (info/proc hangs; namespace/var/upvar depth; error `[try]`-coverage); TclOO; clock/encoding/interp/IO/after. `tclvm` CLI/REPL binary landed (`tcl-vm-cli`) → **RT-VM** |
 | LSP server / core / db | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | ✅ | #670 bulk + the two consumer-wiring residuals (GAP-C1 per-check config toggles; IRULE5002/5004 flow-warning code actions) landed — see [history](rust-rewrite-history.md). The rope-backed `DocumentState` is split out into its own **SRV-ROPE** track (need evaluated with measurements in [`design/rope/`](design/rope/README.md)) |
 | Document store / incrementality | `tcl-lsp-server`, `tcl-lexer`, `tcl-lsp-db` | 🔴 | rope-backed store + chunk-addressable salsa input + rope-slice re-lex → **SRV-ROPE** (see [`design/rope/`](design/rope/README.md)) |
-| `tcl` CLI | `tcl-cli` | 🟡 | `dis`/`compwasm`/`pkg`/`venv`/`docker` verbs → **TOOL-CLI** |
+| `tcl` CLI | `tcl-cli` | ✅ | all 26 verbs ported & dispatched (`dis`/`compwasm` + `pkg`/`venv`/`docker` wired via TOOL-TCLPKG) → **TOOL-CLI** |
 | `f5-query` CLI | `f5-cli`, `tcl-bigip*`, `tcl-irules` | 🟢 | `explain-flow --simulate/--tshark/--keylog`; a few parity files → **TOOL-F5** |
 | Formatter / minifier / diagram | `tcl-lsp-core`, `tcl-cli` | ✅ | — |
 | Refactoring transforms | `tcl-lsp-core::code_actions` | 🟡 | 5 of 7 transforms missing → **TOOL-REFACTOR** |
@@ -904,7 +904,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | TOOL | **TOOL-FUZZ** | new `tcl-fuzz` (xtask/bin) | RT-VM | M |
 | TOOL | **TOOL-DEBUGGER** | new `tcl-debugger` | RT-VM | L |
 | TOOL | **TOOL-IRULE-TEST** | new `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
-| TOOL | **TOOL-CLI** | `tcl-cli` | RT-WASM, RT-VM, TOOL-TCLPKG | S |
+| TOOL | **TOOL-CLI** ✅ | `tcl-cli` | RT-WASM, RT-VM, TOOL-TCLPKG | S |
 | API | **API-PYO3** | `tcl-lsp-py`, `scripts`→`xtask`, `tests` | everything above | L |
 
 ---
@@ -1165,10 +1165,13 @@ already started, brings **every** Python tool across to Rust.
   mock-stub codegen, orchestrator). Note `tcl-irules` is the BIG-IP
   reference-extractor, **not** this. *(XL)*
 - **TOOL-CLI** *(owns `tcl-cli`; depends on RT-WASM, RT-VM, TOOL-TCLPKG)* —
-  **partial**: `dis` and `compwasm` landed (bytecode disassembly via
-  `format_module_asm`; eval-fallback WASM binary/WAT via the greenfield
-  emitter). Remaining: `pkg`/`venv`/`docker` (after TOOL-TCLPKG). 22/26 verbs
-  done. *(S glue)*
+  **done**: all 26 top-level verbs are ported and dispatched to native engine
+  handlers. `dis` (bytecode disassembly via `format_module_asm`) and `compwasm`
+  (eval-fallback WASM binary/WAT via the greenfield emitter) landed earlier; the
+  `pkg`/`venv`/`docker` verbs are wired through to the `tcl-pkg` handlers that
+  landed under **TOOL-TCLPKG**. The dispatch `match` is now exhaustive (the
+  not-yet-implemented fallthrough is gone). Note any deeper WASM-emitter
+  precision residual is **RT-WASM**'s, not the CLI verb's. *(S glue)*
 
 ### Stage 5 — PyO3 interfaces & Python retirement (API-PYO3 — last)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -874,7 +874,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | `f5-query` CLI | `f5-cli`, `tcl-bigip*`, `tcl-irules` | 🟢 | `explain-flow --simulate/--tshark/--keylog`; a few parity files → **TOOL-F5** |
 | Formatter / minifier / diagram | `tcl-lsp-core`, `tcl-cli` | ✅ | — |
 | Refactoring transforms | `tcl-lsp-core::code_actions` | 🟡 | 5 of 7 transforms missing → **TOOL-REFACTOR** |
-| Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**); `ssa`-view bool-render parity → **TOOL-EXPLORER** |
+| Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**) → **TOOL-EXPLORER** |
 | Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
 | Differential fuzzer | new crate | 🟡 | campaign runner/generator/findings (corpus diff exists) → **TOOL-FUZZ** |
 | Debugger (DAP) | new crate | 🔴 | full debugger over `tcl-vm` → **TOOL-DEBUGGER** |
@@ -1150,13 +1150,11 @@ already started, brings **every** Python tool across to Rust.
   files. The rest (27/27 verbs, 262 parity tests) is done — the template for the
   other tool ports. *(XS)*
 - **TOOL-EXPLORER** *(owns `tcl-explorer`, `tcl-explorer-wasm`; depends on
-  RT-WASM)* — **partial**: the `wasm` view; plus an `ssa`-view parity bug —
-  `tcl-explorer::view_tree::build_view` renders a const-folded branch label as
-  `always true`/`false` (Rust `bool` Display) where the Python `tui_views`
-  reference emits `always True`/`False` (`str(bool)`); render the Rust SSA-view
-  boolean Python-style (`tests/test_explorer_view_tree_parity.py::
-  test_rust_build_view_matches_python[for_loop]`, view `ssa`). The other TUI
-  views are parity-done; the Pyodide web server stays Python. *(S)*
+  RT-WASM)* — **partial**: the `wasm` view (blocked on **RT-WASM**, since the
+  view renders the WASM emitter's output). The `ssa`-view boolean-render parity
+  bug landed (the const-branch label now renders booleans Python-style via
+  `view_tree::pystr`); all other TUI views are parity-done. The Pyodide web
+  server stays Python. *(S)*
 - **TOOL-FUZZ** *(new `tcl-fuzz`; depends on RT-VM)* — **open**: a campaign runner
   + random generator + findings registry on top of the existing `differential_*`
   harnesses. *(M)*

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -871,7 +871,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | LSP server / core / db | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | ✅ | #670 bulk + the two consumer-wiring residuals (GAP-C1 per-check config toggles; IRULE5002/5004 flow-warning code actions) landed — see [history](rust-rewrite-history.md). The rope-backed `DocumentState` is split out into its own **SRV-ROPE** track (need evaluated with measurements in [`design/rope/`](design/rope/README.md)) |
 | Document store / incrementality | `tcl-lsp-server`, `tcl-lexer`, `tcl-lsp-db` | 🔴 | rope-backed store + chunk-addressable salsa input + rope-slice re-lex → **SRV-ROPE** (see [`design/rope/`](design/rope/README.md)) |
 | `tcl` CLI | `tcl-cli` | ✅ | all 26 verbs ported & dispatched (`dis`/`compwasm` + `pkg`/`venv`/`docker` wired via TOOL-TCLPKG) → **TOOL-CLI** |
-| `f5-query` CLI | `f5-cli`, `tcl-bigip*`, `tcl-irules` | 🟢 | `explain-flow --simulate/--tshark/--keylog`; a few parity files → **TOOL-F5** |
+| `f5-query` CLI | `f5-cli`, `tcl-bigip*`, `tcl-irules` | 🟢 | `explain-flow --tshark/--keylog/--tshark-filter` landed; `--simulate` gated on the native iRule VM (**RT-VM**); `completion`/`graph` parity files → **TOOL-F5** |
 | Formatter / minifier / diagram | `tcl-lsp-core`, `tcl-cli` | ✅ | — |
 | Refactoring transforms | `tcl-lsp-core::code_actions` | 🟡 | 5 of 7 transforms missing → **TOOL-REFACTOR** |
 | Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**) → **TOOL-EXPLORER** |
@@ -1145,8 +1145,15 @@ already started, brings **every** Python tool across to Rust.
 - **TOOL-REFACTOR** *(owns `tcl-lsp-core::code_actions`)* — **open**: port the 5
   missing transforms (extract/inline variable, if↔switch, switch→dict,
   extract-datagroup); 2 of 7 (extract/inline proc) exist. *(M)*
-- **TOOL-F5** *(owns `f5-cli`)* — **partial**: `explain-flow`
-  `--simulate`/`--tshark`/`--keylog`; dedicated `completion`/`graph` parity
+- **TOOL-F5** *(owns `f5-cli`)* — **partial**: the `explain-flow`
+  `--tshark` / `--keylog` / `--tshark-filter` L7-enrichment paths landed
+  (`tcl_bigip::flow::tshark`, a faithful EK-JSON port of
+  `dialects/f5/bigip/flow/tshark.py`, byte-identical to the Python CLI on the
+  `--tshark` / `--tshark-filter` paths; graceful degradation when tshark lacks
+  EK `--no-duplicate-keys` support is itself parity-matched). Remaining:
+  `--simulate` is gated on the native iRule VM (the `tooling.irule_test`
+  orchestrator → **RT-VM** / **TOOL-IRULE-TEST**) and stays a clear
+  not-implemented error meanwhile; plus dedicated `completion`/`graph` parity
   files. The rest (27/27 verbs, 262 parity tests) is done — the template for the
   other tool ports. *(XS)*
 - **TOOL-EXPLORER** *(owns `tcl-explorer`, `tcl-explorer-wasm`; depends on

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1044,9 +1044,24 @@ delete`, and the supporting `return`/`error`/list-parse fixes — error.test
 44 → 280, lmap 21 → 61, namespace 93 → 112) is archived in the
 [history](rust-rewrite-history.md). The live open gaps:
 
-- **open (P1) VM hangs that zero out whole suites** — `info.test` and `proc.test`
-  time out in the bytecode VM while the runtime completes them (`catch.test`
-  times out in both). A hang yields *no* parity for the suite, so these lead.
+- **open (P1) "suite-zeroing hangs" are mostly mis-attributed** (diagnosed
+  2026-06-21). The `info.test` / `proc.test` "hangs" are **not** deadlocks: built
+  `--release`, `info.test` runs to *info-8.3* in ~12 s and `proc.test` runs to
+  `cleanupTests` in ~8 s. Two real effects masquerade as a hang under the
+  harness, in priority order:
+  - **(a) Debug-build slowness × the harness timeout.** A `--release` worker is
+    ~10–30× faster; the `run_test`/`run_script` parity harness must build
+    `--release` (a trivial tcltest case costs ≈1 s/test in `debug`, so a
+    ~200-test suite blows any timeout in `debug` while finishing in seconds in
+    `release`). **First action: switch `tmp/parity.sh` to `--release`** and
+    re-baseline — several "hung" suites likely already score.
+  - **(b) Uncaught-error abort.** A test-body error that escapes tcltest's
+    `catch` propagates to the module top and aborts the *whole* `run_test`
+    driver (e.g. `info.test` halts at info-8.3 with `can't read "text": no such
+    variable`; `proc.test` ends on a bare `VM error:`). That single escape, not
+    a loop, is what zeros the remainder of the suite — the real P1 to chase
+    (an `uplevel`/`catch`/error-propagation gap), and far more tractable than a
+    deadlock hunt.
 - **open** `namespace` / `var` / `upvar` depth (≈ 290 failures combined) — the
   namespace-eval-frame fix corrected the *mechanism*; the remainder is
   feature/semantics depth (namespace-name canonicalisation of multiple/trailing
@@ -1066,7 +1081,11 @@ delete`, and the supporting `return`/`error`/list-parse fixes — error.test
   run via runtime builtins today — correct but not inline).
 - **open** the missing command surface: **TclOO** (largest), `clock`,
   `encoding`, full `interp`, real I/O (`open`/`gets`/`seek`), `after`/`time`,
-  residual `file`/`info`/`namespace` subcommands.
+  residual `file`/`info`/`namespace` subcommands. Concretely, `info` is missing
+  `cmdcount` / `frame` / `functions` / `hostname` (they error "unknown or
+  ambiguous subcommand" today); note `info cmdcount` cannot reach exact-count
+  parity with C Tcl without matching its per-bytecode command counting, so it
+  is a "exists but approximate" subcommand rather than a parity win.
 - **done** a VM CLI/REPL binary — the `tclvm` binary in the new `tcl-vm-cli`
   crate (a thin compiler-backed `CompileService` driver, keeping the `tcl-vm`
   lib compiler-optional). Runs script files (with `argv`/`argv0`/`argc`),

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -739,7 +739,7 @@ rust/
   tcl-cli/                native `tcl` toolchain CLI                f5-cli/  native `f5-query` CLI
   tcl-fuzz/               differential fuzzer (seeded generator + tclvm-vs-tclsh harness + findings)
   tcl-irule-test/         iRule TMM-sim glue: SCF→orchestrator topology + session bootstrap (driver gated on RT-VM)
-  tcl-debugger/           step debugger: breakpoints + step-mode controller + backend contract (VM backend gated on RT-VM)
+  tcl-debugger/           working record-and-replay step debugger over tcl-vm + the `tcl-debug` CLI front-end
 runtime/
   zig/                    Zig WASM runtime (out-of-process runtime for compiled scripts)
   rust/                   tree-walking reference runtime (RT-VM parity oracle)
@@ -881,7 +881,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**) → **TOOL-EXPLORER** |
 | Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
 | Differential fuzzer | `tcl-fuzz` | 🟢 | campaign runner + seeded generator + findings registry land (`tclvm` vs `tclsh`); broaden the generator grammar as the VM surface grows → **TOOL-FUZZ** |
-| Debugger | `tcl-debugger` | 🟢 | working record-and-replay step debugger over `tcl-vm` (the VM debug-hook seam landed): breakpoints, step in/over/out, continue, stack + variable inspection. Residual: a DAP/CLI protocol surface → **TOOL-DEBUGGER** |
+| Debugger | `tcl-debugger` | 🟢 | working record-and-replay step debugger over `tcl-vm` (the VM debug-hook seam landed) + a `tcl-debug` CLI front-end (break/step/next/finish/continue/print/stack/vars). Residual: a DAP wire-protocol surface for editors → **TOOL-DEBUGGER** |
 | iRule test framework | `tcl-irule-test` | 🟡 | crate scaffolded: SCF→orchestrator topology generator (parity-checked vs Python) + session-bootstrap assembly; the live event round-trip is gated on the VM iRule surface (**RT-VM**) → **TOOL-IRULE-TEST** |
 | PyO3 public API + retirement | `tcl-lsp-py`, `xtask` | 🔴 | designed public surface; TEST-MIGRATE; PYTHON-RETIRE → **API-PYO3** |
 | `ai/` (MCP + skills) | — | n/a | stays Python by design |
@@ -1246,9 +1246,12 @@ already started, brings **every** Python tool across to Rust.
   parity gates stay green. `tcl-debugger`'s `VmBackend` installs a recording
   hook, runs the script once to capture the trace, then serves
   breakpoints / step-in/over/out / continue / stack / variable-inspection by
-  navigating the trace with the `DebugController`. Residual: a DAP (or CLI)
-  protocol surface to expose it to editors, and live-eval / deeper-frame
-  variables (replay sees the current frame's captured vars). *(L)*
+  navigating the trace with the `DebugController`. A `tcl-debug` CLI front-end
+  drives it interactively
+  (`break`/`step`/`next`/`finish`/`continue`/`print`/`stack`/`vars`, reading
+  commands from stdin so it scripts cleanly). Residual: a DAP wire-protocol
+  surface for editors, and live-eval / deeper-frame variables (replay sees the
+  current frame's captured vars). *(L)*
 - **TOOL-IRULE-TEST** *(new `tcl-irule-test`; depends on RT-VM + `tcl-registry`)* —
   **scaffolded**: the crate exists with the portable glue. `topology` ports
   `TopologyFromSCF` — parse a bigip.conf via `tcl-bigip` and emit the `::orch::`

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -1062,6 +1062,27 @@ delete`, and the supporting `return`/`error`/list-parse fixes — error.test
     a loop, is what zeros the remainder of the suite — the real P1 to chase
     (an `uplevel`/`catch`/error-propagation gap), and far more tractable than a
     deadlock hunt.
+- **open (P1) genuine infinite loop in the runtime `while`/`for` body**
+  (`cmd_control.rs`, diagnosed 2026-06-21). A loop whose **condition is a bare
+  command substitution** falls back to the runtime `while`/`for` builtin (only
+  an *expression* condition — `[cmd] > 0`, `$x`, `!![cmd]` — inlines to the CFG
+  loop). On that fallback path the body's variable writes and the
+  command-substitution reads **disagree across iterations**, so the condition
+  never changes and the loop spins forever (a true hang, distinct from (a)/(b)).
+  Minimal repros (all spin; the `> 0` variants terminate):
+  - `set x abc; while {[string length $x]} {set x ""}` — `[string length $x]`
+    stays `3` though `$x` reads empty.
+  - `set x abcde; set n 0; while {[string length $x]} {incr n; set x [string repeat z $n]; if {$n>3} break}`
+    — `n` accumulates (frame persists) but `$x` stays frozen at `abcde`, i.e.
+    `set x [<cmd-sub>]` does not persist while `incr n` does.
+  The split (literal-RHS `set` vs command-substituted-RHS `set`; direct `$x` vs
+  `[string length $x]`) localises it to how the `eval_source`-compiled body
+  module resolves variables/command-subs vs the enclosing loop frame on
+  repeated `run_module`. **This is the most common real "hang" idiom**
+  (`while {[gets $f line] >= 0}` works; bare `while {[string length $x]}` /
+  tcltest's `while {[string length $argList]}` word-splitter spin). Fix is a
+  frame/eval-scope correction in the runtime loop body path — verify against the
+  inlined path (already correct) and the tree-walking `runtime/rust`.
 - **open** `namespace` / `var` / `upvar` depth (≈ 290 failures combined) — the
   namespace-eval-frame fix corrected the *mechanism*; the remainder is
   feature/semantics depth (namespace-name canonicalisation of multiple/trailing

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -698,9 +698,10 @@ If your port has any of these, reshape it before asking for review:
 
 The workspace (`Cargo.toml` members) as it stands today — crate granularity,
 roughly in dependency order. New crates the [Remaining work](#remaining-work)
-plan still calls for (`tcl-wasm`, `tcl-xc`, `tcl-debugger`) are **not** listed
-here because they do not exist yet; `tcl-fuzz` (the differential fuzzer) and
-`tcl-irule-test` (the iRule-test glue scaffold) have since landed.
+plan still calls for (`tcl-wasm`, `tcl-xc`) are **not** listed here because they
+do not exist yet; `tcl-fuzz` (the differential fuzzer), `tcl-irule-test` (the
+iRule-test glue scaffold), and `tcl-debugger` (the step-debugger scaffold) have
+since landed.
 
 ```
 Cargo.toml                workspace manifest        rust-toolchain.toml  channel = "stable"
@@ -738,6 +739,7 @@ rust/
   tcl-cli/                native `tcl` toolchain CLI                f5-cli/  native `f5-query` CLI
   tcl-fuzz/               differential fuzzer (seeded generator + tclvm-vs-tclsh harness + findings)
   tcl-irule-test/         iRule TMM-sim glue: SCF→orchestrator topology + session bootstrap (driver gated on RT-VM)
+  tcl-debugger/           step debugger: breakpoints + step-mode controller + backend contract (VM backend gated on RT-VM)
 runtime/
   zig/                    Zig WASM runtime (out-of-process runtime for compiled scripts)
   rust/                   tree-walking reference runtime (RT-VM parity oracle)
@@ -879,7 +881,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**) → **TOOL-EXPLORER** |
 | Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
 | Differential fuzzer | `tcl-fuzz` | 🟢 | campaign runner + seeded generator + findings registry land (`tclvm` vs `tclsh`); broaden the generator grammar as the VM surface grows → **TOOL-FUZZ** |
-| Debugger (DAP) | new crate | 🔴 | full debugger over `tcl-vm` → **TOOL-DEBUGGER** |
+| Debugger | `tcl-debugger` | 🟡 | crate scaffolded: step-mode controller + breakpoints + backend contract (tested); live VM backend gated on a `tcl-vm` per-statement hook (**RT-VM**) → **TOOL-DEBUGGER** |
 | iRule test framework | `tcl-irule-test` | 🟡 | crate scaffolded: SCF→orchestrator topology generator (parity-checked vs Python) + session-bootstrap assembly; the live event round-trip is gated on the VM iRule surface (**RT-VM**) → **TOOL-IRULE-TEST** |
 | PyO3 public API + retirement | `tcl-lsp-py`, `xtask` | 🔴 | designed public surface; TEST-MIGRATE; PYTHON-RETIRE → **API-PYO3** |
 | `ai/` (MCP + skills) | — | n/a | stays Python by design |
@@ -904,7 +906,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | TOOL | **TOOL-F5** | `f5-cli` | — | XS |
 | TOOL | **TOOL-EXPLORER** | `tcl-explorer`, `tcl-explorer-wasm` | RT-WASM | S |
 | TOOL | **TOOL-FUZZ** 🟢 | `tcl-fuzz` (bin) | RT-VM | M |
-| TOOL | **TOOL-DEBUGGER** | new `tcl-debugger` | RT-VM | L |
+| TOOL | **TOOL-DEBUGGER** 🟡 | `tcl-debugger` | RT-VM | L |
 | TOOL | **TOOL-IRULE-TEST** 🟡 | `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
 | TOOL | **TOOL-CLI** ✅ | `tcl-cli` | RT-WASM, RT-VM, TOOL-TCLPKG | S |
 | API | **API-PYO3** | `tcl-lsp-py`, `scripts`→`xtask`, `tests` | everything above | L |
@@ -1234,8 +1236,18 @@ already started, brings **every** Python tool across to Rust.
   the generator grammar (procs, namespaces, dict, `catch`/`try`, switch) as the
   VM command surface fills in, and add the WASM/Zig backend as a third
   differential arm once **RT-WASM** lands. *(M)*
-- **TOOL-DEBUGGER** *(new `tcl-debugger`; depends on RT-VM)* — **open**: DAP server
-  over `tcl-vm` (breakpoints/stepping/backends). *(L)*
+- **TOOL-DEBUGGER** *(new `tcl-debugger`; depends on RT-VM)* — **scaffolded**:
+  the crate exists with the portable, tested core ported from
+  `tooling/debugger/` — the `DebugController` (breakpoints + the
+  step-in/over/out decision state machine), the shared `types`
+  (`StackFrame`/`Variable`/`StopEvent`/…), and the `DebugBackend` contract.
+  **Architecture note:** the live `VmBackend` needs `tcl-vm` to expose a
+  per-statement debug hook — an execution-control seam in the exec loop that
+  calls back with `(source_line, frame_level, command_text, stack)` and honours
+  the returned `DebugAction`, plus a bytecode-PC → source-line map. That hook is
+  the RT-VM-gated remainder; `VmBackend` reports `Unsupported` until it lands.
+  Remaining after the hook: stack/variable inspection wiring and the DAP (or
+  CLI) protocol surface. *(L)*
 - **TOOL-IRULE-TEST** *(new `tcl-irule-test`; depends on RT-VM + `tcl-registry`)* —
   **scaffolded**: the crate exists with the portable glue. `topology` ports
   `TopologyFromSCF` — parse a bigip.conf via `tcl-bigip` and emit the `::orch::`

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -873,7 +873,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | `tcl` CLI | `tcl-cli` | ✅ | all 26 verbs ported & dispatched (`dis`/`compwasm` + `pkg`/`venv`/`docker` wired via TOOL-TCLPKG) → **TOOL-CLI** |
 | `f5-query` CLI | `f5-cli`, `tcl-bigip*`, `tcl-irules` | 🟢 | `explain-flow --tshark/--keylog/--tshark-filter` landed; `--simulate` gated on the native iRule VM (**RT-VM**); `completion`/`graph` parity files → **TOOL-F5** |
 | Formatter / minifier / diagram | `tcl-lsp-core`, `tcl-cli` | ✅ | — |
-| Refactoring transforms | `tcl-lsp-core::code_actions` | 🟡 | 5 of 7 transforms missing → **TOOL-REFACTOR** |
+| Refactoring transforms | `tcl-lsp-core::code_actions` | ✅ | all 7 transforms ported (`tcl-lsp-core::refactor`), byte-parity vs the Python oracle → **TOOL-REFACTOR** |
 | Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**) → **TOOL-EXPLORER** |
 | Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
 | Differential fuzzer | new crate | 🟡 | campaign runner/generator/findings (corpus diff exists) → **TOOL-FUZZ** |
@@ -898,7 +898,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | SRV | **SRV-LSP** ✅ | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | FE-DIAG, FE-DATAFLOW | L |
 | SRV | **SRV-ROPE** | document store: `tcl-lsp-server` `DocumentState` + `tcl-lexer` rope-slice `SourceMap` + `tcl-lsp-db` chunk input | FE-LEX (CST/structural-state index), SRV-LSP | XL |
 | TOOL | **TOOL-TCLPKG** ✅ | `tcl-pkg` crate | — | XL |
-| TOOL | **TOOL-REFACTOR** | `tcl-lsp-core::code_actions` | SRV-LSP | M |
+| TOOL | **TOOL-REFACTOR** ✅ | `tcl-lsp-core::code_actions` | SRV-LSP | M |
 | TOOL | **TOOL-F5** | `f5-cli` | — | XS |
 | TOOL | **TOOL-EXPLORER** | `tcl-explorer`, `tcl-explorer-wasm` | RT-WASM | S |
 | TOOL | **TOOL-FUZZ** | new `tcl-fuzz` (xtask/bin) | RT-VM | M |
@@ -1142,9 +1142,18 @@ already started, brings **every** Python tool across to Rust.
   are wired through to native handlers; help is native clap style. Lockfiles,
   Dockerfiles, and venv scripts diff byte-for-byte against the Python CLI.
   *(XL)*
-- **TOOL-REFACTOR** *(owns `tcl-lsp-core::code_actions`)* — **open**: port the 5
-  missing transforms (extract/inline variable, if↔switch, switch→dict,
-  extract-datagroup); 2 of 7 (extract/inline proc) exist. *(M)*
+- **TOOL-REFACTOR** *(owns `tcl-lsp-core::code_actions`)* — **done**: the 5
+  remaining transforms (extract/inline variable, if↔switch, switch→dict,
+  extract-datagroup) are ported into the new `tcl-lsp-core::refactor` module
+  and wired through `refactor_engine_actions`, alongside the pre-existing
+  extract/inline proc. `find_command_at` descends registry-resolved
+  `ArgRole::Body` words for nested-body support; the data-group action carries
+  the rendered tmsh definition on `CodeAction::data_group_definition` (surfaced
+  as the LSP `data` field, mirroring `_datagroup_to_code_action`). The
+  if↔switch / switch→dict / datagroup outputs are asserted byte-for-byte
+  against the live Python oracle; all `tests/test_refactoring.py` decline
+  conditions are mirrored. Out of scope: `suggest_datagroup_extraction` (an
+  AI-context scanner, not a `CodeAction`). *(M)*
 - **TOOL-F5** *(owns `f5-cli`)* — **partial**: the `explain-flow`
   `--tshark` / `--keylog` / `--tshark-filter` L7-enrichment paths landed
   (`tcl_bigip::flow::tshark`, a faithful EK-JSON port of

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -878,7 +878,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | `f5-query` CLI | `f5-cli`, `tcl-bigip*`, `tcl-irules` | 🟢 | `explain-flow --tshark/--keylog/--tshark-filter` landed; `--simulate` gated on the native iRule VM (**RT-VM**); `completion`/`graph` parity files → **TOOL-F5** |
 | Formatter / minifier / diagram | `tcl-lsp-core`, `tcl-cli` | ✅ | — |
 | Refactoring transforms | `tcl-lsp-core::code_actions` | ✅ | all 7 transforms ported (`tcl-lsp-core::refactor`), byte-parity vs the Python oracle → **TOOL-REFACTOR** |
-| Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟡 | `wasm` view (blocked on **RT-WASM**) → **TOOL-EXPLORER** |
+| Compiler explorer | `tcl-explorer`, `tcl-explorer-wasm` | 🟢 | `wasm` view renders the eval-fallback emitter's WAT; rich per-instruction web-GUI shape (`to_explorer_json`) is a refinement → **TOOL-EXPLORER** |
 | Package manager (`tclpkg`) | `tcl-pkg` | ✅ | full port (manifest/resolver/lockfile/CAS/fetchers/venv/docker) + wired `pkg`/`venv`/`docker` CLI → **TOOL-TCLPKG** |
 | Differential fuzzer | `tcl-fuzz` | 🟢 | campaign runner + seeded generator + findings registry land (`tclvm` vs `tclsh`); broaden the generator grammar as the VM surface grows → **TOOL-FUZZ** |
 | Debugger | `tcl-debugger` | ✅ | record-and-replay step debugger over `tcl-vm` (VM debug-hook seam) with a `tcl-debug` CLI **and** a DAP server for editors (`--dap`): breakpoints, step in/over/out, continue, stack/scopes/variables, evaluate → **TOOL-DEBUGGER** |
@@ -904,7 +904,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | TOOL | **TOOL-TCLPKG** ✅ | `tcl-pkg` crate | — | XL |
 | TOOL | **TOOL-REFACTOR** ✅ | `tcl-lsp-core::code_actions` | SRV-LSP | M |
 | TOOL | **TOOL-F5** | `f5-cli` | — | XS |
-| TOOL | **TOOL-EXPLORER** | `tcl-explorer`, `tcl-explorer-wasm` | RT-WASM | S |
+| TOOL | **TOOL-EXPLORER** 🟢 | `tcl-explorer`, `tcl-explorer-wasm` | RT-WASM | S |
 | TOOL | **TOOL-FUZZ** 🟢 | `tcl-fuzz` (bin) | RT-VM | M |
 | TOOL | **TOOL-DEBUGGER** ✅ | `tcl-debugger` | RT-VM | L |
 | TOOL | **TOOL-IRULE-TEST** 🟡 | `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
@@ -1218,11 +1218,17 @@ already started, brings **every** Python tool across to Rust.
   files. The rest (27/27 verbs, 262 parity tests) is done — the template for the
   other tool ports. *(XS)*
 - **TOOL-EXPLORER** *(owns `tcl-explorer`, `tcl-explorer-wasm`; depends on
-  RT-WASM)* — **partial**: the `wasm` view (blocked on **RT-WASM**, since the
-  view renders the WASM emitter's output). The `ssa`-view boolean-render parity
-  bug landed (the const-branch label now renders booleans Python-style via
-  `view_tree::pystr`); all other TUI views are parity-done. The Pyodide web
-  server stays Python. *(S)*
+  RT-WASM)* — **done (for the views)**: the `ssa`-view boolean-render parity bug
+  landed (`view_tree::pystr`), and the **`wasm` view now renders WAT** —
+  `serialise.rs::serialise_wasm` drives the eval-fallback `wasm_codegen_module`
+  (the same emitter `tcl compwasm` uses) and emits the module's WAT plus
+  per-function headers, which `render.rs::render_wasm` prints. All TUI views are
+  now populated. Refinement (not blocking the view): the rich per-instruction
+  explorer shape (`to_explorer_json` — resolved call targets, paired branch
+  targets, lane-assigned edges) the *web GUI* uses is not ported, so the wasm
+  tab shows flat WAT rather than the gutter-rendered instruction graph; that
+  lands with the broader **RT-WASM** emitter work. The Pyodide web server stays
+  Python. *(S)*
 - **TOOL-FUZZ** *(new `tcl-fuzz` bin; depends on RT-VM)* — **landed**: a seeded
   random Tcl generator (`generator.rs`, scoped to the VM's supported surface so a
   divergence is a real miscompile, not an unimplemented command — pure, bounded

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -738,7 +738,7 @@ rust/
   tcl-cli-support/        shared CLI plumbing for the native tcl / f5 CLIs
   tcl-cli/                native `tcl` toolchain CLI                f5-cli/  native `f5-query` CLI
   tcl-fuzz/               differential fuzzer (seeded generator + tclvm-vs-tclsh harness + findings)
-  tcl-irule-test/         iRule TMM-sim glue: SCF→orchestrator topology + session bootstrap (driver gated on RT-VM)
+  tcl-irule-test/         iRule TMM-sim: SCF→orchestrator topology + `LiveSession` running the orchestrator Tcl on tcl-vm (embedded framework)
   tcl-debugger/           working record-and-replay step debugger over tcl-vm + the `tcl-debug` CLI front-end
 runtime/
   zig/                    Zig WASM runtime (out-of-process runtime for compiled scripts)
@@ -1095,6 +1095,33 @@ delete`, and the supporting `return`/`error`/list-parse fixes — error.test
   aborting `info.test` after the loop fix. `push_array_key` now decodes a
   composite index into its substitution parts and `STR_CONCAT`s them (byte-equal
   to `tclsh9.0`).
+- **fixed (2026-06-22) six bugs surfaced by running the iRule TMM-sim
+  orchestrator** (the ~500 KB of framework Tcl behind **TOOL-IRULE-TEST**) on the
+  VM, each covered by `tcl-vm/tests/language_e2e.rs`:
+  - **proc-body namespace-cache collision** — the pre-compiled body cache was
+    keyed by the *global* name, so two procs sharing an unqualified name across
+    namespaces (`::a::p` vs `::b::p`) collided on one body and a wrapper proc ran
+    the wrong callee in the wrong namespace (`[namespace current]` / `variable`
+    resolved against the caller). Keyed now by the runtime-qualified name.
+  - **`format` const-fold froze variable args** — `set x [format {…%s…} $v]`
+    folded `$v` to the literal source text; the fold now bails when any argument
+    is a runtime substitution (`$…`/`[…]`).
+  - **no `unknown` fallback** — an unresolved command name is now handed to a
+    user-defined `unknown` proc (`unknown name arg…`), the basis for the iRule
+    command mocks, ensembles, and auto-loading.
+  - **missing `exit`** — added the builtin (so the shim can rename it to
+    `::tmm::_orig_exit` and scripts terminate with the right process code).
+  - **`::tcl::clock::*` ensemble members** — `clock clicks`/`seconds`/… are now
+    reachable via their fully-qualified implementation names, which library code
+    calls directly.
+  - **ARE word-edge regex escapes** — `\m`/`\M`/`\y`/`\Y` and `[[:<:]]`/`[[:>:]]`
+    translate to the `regex` crate's `\b{start}`/`\b{end}`/`\b`/`\B`.
+  Also implemented the **dict bytecode opcodes** (`DICT_SET`/`UNSET`/`INCR_IMM`/
+  `APPEND`/`LAPPEND`/`GET`/`EXISTS`) and made the generic `dict set`/`dict unset`
+  honour **multi-level key paths** (was single-level). With these, the
+  orchestrator's `example_test.tcl` runs 6/6 on `tclvm`, byte-identical to
+  tclsh 8.6. The `unknown`/`exit`/error-propagation pieces also bear on the
+  "(b) uncaught-error abort" P1 above (re-baseline the parity harness).
 - **open** `namespace` / `var` / `upvar` depth (≈ 290 failures combined) — the
   namespace-eval-frame fix corrected the *mechanism*; the remainder is
   feature/semantics depth (namespace-name canonicalisation of multiple/trailing

--- a/rust/f5-cli/Cargo.toml
+++ b/rust/f5-cli/Cargo.toml
@@ -21,6 +21,7 @@ tcl-bigip = { path = "../tcl-bigip" }
 tcl-bigip-io = { path = "../tcl-bigip-io" }
 tcl-bigip-query = { path = "../tcl-bigip-query" }
 tcl-irules = { path = "../tcl-irules" }
+tcl-irule-test = { path = "../tcl-irule-test" }
 tcl-lsp-core = { path = "../tcl-lsp-core" }
 tcl-registry = { path = "../tcl-registry" }
 serde = { version = "1", features = ["derive"] }

--- a/rust/f5-cli/src/commands/explain_flow.rs
+++ b/rust/f5-cli/src/commands/explain_flow.rs
@@ -96,6 +96,23 @@ struct SessionExplain {
     gtm_wide_ips: Vec<String>,
     explain_text: String,
     reset_analysis: String,
+    /// The dynamic iRule-simulation outcome (`--simulate`), if requested.
+    simulated: Option<SimOutcome>,
+}
+
+/// The dynamic outcome of running a matched session's iRule(s) under the
+/// embedded TMM-sim orchestrator on `tcl-vm`. Port of the result half of
+/// `tooling/f5/irule_simulation.py::simulate_irule_for_session`.
+#[derive(Default, Clone)]
+struct SimOutcome {
+    pool: String,
+    node: String,
+    response_committed: bool,
+    logs: Vec<String>,
+    decisions: Vec<(String, String, String)>,
+    /// Non-empty when the simulation could not run (the static report still
+    /// renders); mirrors the Python adapter's best-effort `error` field.
+    error: String,
 }
 
 /// Owns the [`Session`] referenced by a [`SessionExplain`].
@@ -686,6 +703,271 @@ fn analyse_reset(session: &Session) -> String {
 // `use_tshark` (input intent) vs `used_tshark` (output fact) mirror the Python
 // names; the one-letter gap is the contract, not an accident.
 #[allow(clippy::similar_names)]
+/// The orchestrator profile labels (TCP / CLIENTSSL / HTTP / …) for `vs`.
+/// Mirrors `irule_simulation.profiles_for_orchestrator`.
+fn profiles_for_orchestrator(cfg: &BigipConfig, vs: &BigipVirtualServer) -> Vec<String> {
+    let types = profile_types_for_virtual(cfg, vs);
+    let mut out: Vec<String> = Vec::new();
+    if types.contains(&ProfileType::Tcp) || !vs.profiles.paths().is_empty() {
+        out.push("TCP".to_owned());
+    }
+    if types.contains(&ProfileType::Udp) {
+        out.push("UDP".to_owned());
+    }
+    if types.contains(&ProfileType::ClientSsl) {
+        out.push("CLIENTSSL".to_owned());
+    }
+    if types.contains(&ProfileType::ServerSsl) {
+        out.push("SERVERSSL".to_owned());
+    }
+    if types.contains(&ProfileType::Http) {
+        out.push("HTTP".to_owned());
+    }
+    if out.is_empty() {
+        out.push("TCP".to_owned());
+    }
+    out
+}
+
+/// The last `/`-separated segment of a full path (`/Common/web` → `web`).
+fn last_segment(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+/// Quote `s` as a Tcl double-quoted word, escaping the substitution / quoting
+/// metacharacters so an arbitrary captured value can't break the command.
+fn tcl_quote(s: &str) -> String {
+    let mut out = String::with_capacity(s.len() + 2);
+    out.push('"');
+    for c in s.chars() {
+        if matches!(c, '$' | '[' | ']' | '"' | '\\') {
+            out.push('\\');
+        }
+        out.push(c);
+    }
+    out.push('"');
+    out
+}
+
+/// Run the matched VS's iRule(s) under the embedded orchestrator with the
+/// captured request state. Best-effort: any failure standing the orchestrator
+/// up or running the request lands in [`SimOutcome::error`] so the static
+/// report still renders. Port of `simulate_irule_for_session`.
+#[allow(clippy::too_many_lines)] // setup + load + pools + request + readback, read top-to-bottom
+fn simulate_session(cfg: &BigipConfig, vs: &BigipVirtualServer, session: &Session) -> SimOutcome {
+    use std::fmt::Write as _;
+
+    use tcl_irule_test::LiveSession;
+
+    let mut out = SimOutcome::default();
+
+    // Collect every attached iRule's source, resolving short refs.
+    let mut rules: Vec<String> = Vec::new();
+    for rref in vs.rules.paths() {
+        let resolved = resolve_name(cfg, &rref, "rules").unwrap_or_else(|| rref.clone());
+        if let Some(rule) = find_rule(cfg, &resolved) {
+            rules.push(rule.source.clone());
+        }
+    }
+    if rules.is_empty() {
+        out.error = String::from("no iRules attached to VS — nothing to simulate");
+        return out;
+    }
+
+    let front = &session.front.client;
+    let method = if front.http_method.is_empty() {
+        "GET"
+    } else {
+        &front.http_method
+    };
+    let uri = if front.http_uri.is_empty() {
+        "/"
+    } else {
+        &front.http_uri
+    };
+    let profiles = profiles_for_orchestrator(cfg, vs);
+
+    let mut sess = match LiveSession::embedded() {
+        Ok(s) => s,
+        Err(e) => {
+            out.error = format!("cannot start orchestrator: {e}");
+            return out;
+        }
+    };
+
+    macro_rules! guard {
+        ($e:expr) => {
+            if let Err(e) = $e {
+                out.error = e.to_string();
+                return out;
+            }
+        };
+    }
+
+    guard!(sess.eval(&format!(
+        "::orch::configure -profiles {{{}}}",
+        profiles.join(" ")
+    )));
+    for src in &rules {
+        guard!(sess.load_irule(src));
+    }
+
+    // Register every pool referenced by the config (a `pool foo` call inside an
+    // iRule resolves through this set), plus the VS default pool.
+    for placed in &cfg.objects {
+        let ModelObject::Pool(pool) = &placed.object else {
+            continue;
+        };
+        let members: Vec<String> = pool
+            .members
+            .paths()
+            .iter()
+            .filter(|m| !m.is_empty())
+            .map(|m| last_segment(m).to_owned())
+            .collect();
+        if members.is_empty() {
+            continue;
+        }
+        let name = last_segment(&pool.full_path);
+        let member_list = members.iter().map(|m| tcl_quote(m)).collect::<Vec<_>>().join(" ");
+        guard!(sess.eval(&format!(
+            "::orch::add_pool {} [list {member_list}]",
+            tcl_quote(name)
+        )));
+    }
+
+    if profiles.iter().any(|p| p == "HTTP") {
+        let mut args = format!("-method {} -uri {}", tcl_quote(method), tcl_quote(uri));
+        if !front.http_host.is_empty() {
+            let _ = write!(args, " -host {}", tcl_quote(&front.http_host));
+        }
+        if !front.tls_sni.is_empty() {
+            let _ = write!(args, " -sni {}", tcl_quote(&front.tls_sni));
+        }
+        if !front.http_request_headers.is_empty() {
+            let hdr_tokens: Vec<String> = front
+                .http_request_headers
+                .iter()
+                .flat_map(|(k, v)| [tcl_quote(k), tcl_quote(v)])
+                .collect();
+            let _ = write!(args, " -headers [list {}]", hdr_tokens.join(" "));
+        }
+        guard!(sess.run_http_request(&args));
+    } else {
+        // Non-HTTP: fire CLIENT_ACCEPTED to exercise any L4 logic, no result.
+        guard!(sess.eval("::orch::fire CLIENT_ACCEPTED"));
+        return out;
+    }
+
+    out.pool = sess.pool_selected().unwrap_or_default();
+    let node_addr = sess.eval("set ::state::lb::node_addr").unwrap_or_default();
+    if !node_addr.is_empty() {
+        let node_port = sess.eval("set ::state::lb::node_port").unwrap_or_default();
+        out.node = format!("{node_addr}:{node_port}");
+    }
+    out.response_committed = sess
+        .eval("set ::state::http::response::response_committed")
+        .is_ok_and(|v| v == "1" || v == "true");
+    out.decisions = parse_decisions(&sess.decisions().unwrap_or_default());
+    out.logs = parse_log_entries(&sess.logs().unwrap_or_default());
+    out
+}
+
+/// Parse the orchestrator's decision log (a Tcl list of `{category action args}`)
+/// into `(category, action, value)` triples. Mirrors the Python adapter's
+/// flattening of `result.decisions`.
+fn parse_decisions(list: &str) -> Vec<(String, String, String)> {
+    tcl_list_split(list)
+        .into_iter()
+        .filter_map(|entry| {
+            let parts = tcl_list_split(&entry);
+            match parts.as_slice() {
+                [cat, act, rest @ ..] => Some((
+                    cat.clone(),
+                    act.clone(),
+                    rest.iter()
+                        .map(|v| tcl_list_split(v).join(" "))
+                        .collect::<Vec<_>>()
+                        .join(" "),
+                )),
+                _ => None,
+            }
+        })
+        .collect()
+}
+
+/// Parse the captured log list (each entry a `{facility level message …}` Tcl
+/// list) into `" | "`-joined display strings, matching the Python adapter.
+fn parse_log_entries(list: &str) -> Vec<String> {
+    tcl_list_split(list)
+        .into_iter()
+        .map(|entry| {
+            let parts = tcl_list_split(&entry);
+            if parts.is_empty() {
+                entry
+            } else {
+                parts.join(" | ")
+            }
+        })
+        .collect()
+}
+
+/// Split a Tcl list string into its top-level elements, honouring `{…}` braces
+/// and a single level of backslash escaping. Sufficient for the orchestrator's
+/// well-formed decision / log lists.
+fn tcl_list_split(s: &str) -> Vec<String> {
+    let mut out = Vec::new();
+    let mut chars = s.chars().peekable();
+    loop {
+        while matches!(chars.peek(), Some(c) if c.is_whitespace()) {
+            chars.next();
+        }
+        let Some(&c) = chars.peek() else { break };
+        let mut elem = String::new();
+        if c == '{' {
+            chars.next();
+            let mut depth = 1;
+            for ch in chars.by_ref() {
+                match ch {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+                if depth > 0 {
+                    elem.push(ch);
+                }
+            }
+        } else {
+            while let Some(&ch) = chars.peek() {
+                if ch.is_whitespace() {
+                    break;
+                }
+                if ch == '\\' {
+                    chars.next();
+                    if let Some(esc) = chars.next() {
+                        elem.push(esc);
+                    }
+                    continue;
+                }
+                elem.push(ch);
+                chars.next();
+            }
+        }
+        out.push(elem);
+    }
+    out
+}
+
+#[allow(
+    clippy::too_many_lines,
+    clippy::similar_names,
+    clippy::too_many_arguments
+)] // faithful port: flow extraction + per-session matching, read top-to-bottom
 fn compute_explain_flow(
     pcap_display: &str,
     pcap_path: &Path,
@@ -696,6 +978,7 @@ fn compute_explain_flow(
     use_tshark: bool,
     keylog_path: &str,
     tshark_filter: &str,
+    simulate: bool,
 ) -> Result<ExplainFlowReport, String> {
     let dest_re = Regex::new(
         r"^(?P<path>/[^/\s]+/)?(?P<addr>\[[^\]]+\]|[0-9a-fA-F\.:]+)(?:%\d+)?:(?P<port>\d+|any)$",
@@ -872,6 +1155,10 @@ fn compute_explain_flow(
 
         let reset = analyse_reset(&session);
 
+        // Dynamic iRule simulation (`--simulate`): run the matched VS's iRules
+        // under the embedded orchestrator with this session's captured request.
+        let simulated = simulate.then(|| simulate_session(cfg_hit, vs, &session));
+
         session_explains.push(SessionExplain {
             session: Some(SessionHolder(session)),
             matched_vs: vs.full_path.clone(),
@@ -888,6 +1175,7 @@ fn compute_explain_flow(
             gtm_wide_ips: gtm,
             explain_text,
             reset_analysis: reset,
+            simulated,
         });
     }
 
@@ -1129,7 +1417,35 @@ fn format_report(report: &ExplainFlowReport) -> String {
                 ));
             }
         }
-        // iRule simulation outcome: deferred to the simulate increment.
+        // Dynamic iRule-simulation outcome (`--simulate`).
+        if let Some(sim) = &se.simulated {
+            lines.push("  iRule simulation:".to_owned());
+            if sim.error.is_empty() {
+                lines.push(format!(
+                    "    pool: {}",
+                    if sim.pool.is_empty() { "(none)" } else { &sim.pool }
+                ));
+                if !sim.node.is_empty() {
+                    lines.push(format!("    node: {}", sim.node));
+                }
+                if sim.response_committed {
+                    lines.push("    response: committed by iRule".to_owned());
+                }
+                for (category, action, value) in &sim.decisions {
+                    let value = if value.is_empty() {
+                        String::new()
+                    } else {
+                        format!(" {value}")
+                    };
+                    lines.push(format!("    decision: {category} {action}{value}"));
+                }
+                for log in &sim.logs {
+                    lines.push(format!("    log: {log}"));
+                }
+            } else {
+                lines.push(format!("    error: {}", sim.error));
+            }
+        }
         lines.push(format!("  termination: {}", se.reset_analysis));
         lines.push("  resolved plan:".to_owned());
         for explain_line in py_splitlines(&se.explain_text) {
@@ -1405,6 +1721,7 @@ fn policy_decision_to_value(pd: &PolicyDecision) -> Value {
 /// Faithful port of the per-session entry in `report_to_dict`.
 fn session_to_value(se: &SessionExplain) -> Value {
     let s = se.session();
+    let sim = se.simulated.as_ref();
     let session = obj(vec![
         ("front", conn_to_value(Some(&s.front))),
         ("back", conn_to_value(s.back.as_ref())),
@@ -1462,13 +1779,42 @@ fn session_to_value(se: &SessionExplain) -> Value {
         ("gtm_wide_ips", str_array(&se.gtm_wide_ips)),
         ("explain_text", Value::String(se.explain_text.clone())),
         ("reset_analysis", Value::String(se.reset_analysis.clone())),
-        // Static path: no simulator, so the simulated_* fields stay empty.
-        ("simulated_pool", Value::String(String::new())),
-        ("simulated_node", Value::String(String::new())),
-        ("simulated_response_committed", Value::Bool(false)),
-        ("simulated_logs", Value::Array(Vec::new())),
-        ("simulated_decisions", Value::Array(Vec::new())),
-        ("simulation_error", Value::String(String::new())),
+        // `--simulate` outcome (all empty / false when not requested).
+        (
+            "simulated_pool",
+            Value::String(sim.map(|s| s.pool.clone()).unwrap_or_default()),
+        ),
+        (
+            "simulated_node",
+            Value::String(sim.map(|s| s.node.clone()).unwrap_or_default()),
+        ),
+        (
+            "simulated_response_committed",
+            Value::Bool(sim.is_some_and(|s| s.response_committed)),
+        ),
+        (
+            "simulated_logs",
+            str_array(sim.map_or(&[][..], |s| s.logs.as_slice())),
+        ),
+        (
+            "simulated_decisions",
+            Value::Array(sim.map_or_else(Vec::new, |s| {
+                s.decisions
+                    .iter()
+                    .map(|(category, action, value)| {
+                        obj(vec![
+                            ("category", Value::String(category.clone())),
+                            ("action", Value::String(action.clone())),
+                            ("value", Value::String(value.clone())),
+                        ])
+                    })
+                    .collect()
+            })),
+        ),
+        (
+            "simulation_error",
+            Value::String(sim.map(|s| s.error.clone()).unwrap_or_default()),
+        ),
     ])
 }
 
@@ -1506,12 +1852,6 @@ pub fn run_explain_flow(
     if !pcap.is_file() {
         anyhow::bail!("not a file: {}", pcap.display());
     }
-    if simulate {
-        // The iRule simulator drives the iRule VM (`tooling.irule_test`), which
-        // is the RT-VM-gated TOOL-IRULE-TEST track; until a native iRule VM
-        // lands there is no Rust simulator to call.
-        anyhow::bail!("`f5 explain-flow --simulate` is not yet implemented in the Rust port");
-    }
     // `--tshark-filter` implies tshark; `--tshark` / `--keylog` request the
     // overlay. `keylog` is forwarded to tshark only when it points at a file.
     let use_tshark = tshark || keylog.is_some() || tshark_filter.is_some();
@@ -1540,6 +1880,7 @@ pub fn run_explain_flow(
         use_tshark,
         &keylog_path,
         tshark_filter,
+        simulate,
     )
     .map_err(|e| anyhow::anyhow!("{e}"))?;
 

--- a/rust/f5-cli/src/commands/explain_flow.rs
+++ b/rust/f5-cli/src/commands/explain_flow.rs
@@ -9,7 +9,9 @@
 //! the matched-session detail (profile chain, iRule event chain, LTM policy
 //! trace via `tcl_bigip::policy_eval`, resolved plan), the reset-cause
 //! narrative, and both the text and `--json` report renderers. The `--tshark`
-//! enrichment and `--simulate` (iRule VM) paths remain deferred.
+//! / `--keylog` / `--tshark-filter` L7-enrichment paths are wired through
+//! `tcl_bigip::flow::tshark`. The `--simulate` (iRule VM) path remains
+//! deferred until the RT-VM-gated native iRule simulator lands.
 
 use std::collections::HashSet;
 use std::path::Path;
@@ -18,7 +20,10 @@ use std::sync::LazyLock;
 use indexmap::IndexMap;
 use regex::Regex;
 use serde_json::{Map, Value};
-use tcl_bigip::flow::{Connection, Flow, Session, extract_flows, pair_sessions};
+use tcl_bigip::flow::{
+    Connection, Flow, Session, enrich_with_tshark, extract_flows, extract_flows_via_tshark,
+    pair_sessions, tshark_available,
+};
 use tcl_bigip::model::{
     BigipPolicy, BigipProfile, BigipRule, BigipVirtualServer, ModelObject, ProfileType,
 };
@@ -103,13 +108,17 @@ impl SessionExplain {
 }
 
 /// The whole-report result of [`compute_explain_flow`]. The `used_tshark` /
-/// `keylog_path` / `tshark_filter` fields are fixed for the static built-in
-/// walker path (the tshark path is a later increment).
+/// `keylog_path` / `tshark_filter` fields record the L7-enrichment path taken:
+/// the built-in walker alone (`used_tshark = false`), the `--tshark` /
+/// `--keylog` overlay, or a `--tshark-filter` extraction.
 struct ExplainFlowReport {
     pcap_path: String,
     flow_count: usize,
     session_count: usize,
     matched_count: usize,
+    used_tshark: bool,
+    keylog_path: String,
+    tshark_filter: String,
     sessions: Vec<SessionExplain>,
 }
 
@@ -673,19 +682,42 @@ fn analyse_reset(session: &Session) -> String {
 
 /// Build the per-session explanation for the capture against parsed configs.
 #[allow(clippy::too_many_lines)]
+#[allow(clippy::too_many_arguments)]
+// `use_tshark` (input intent) vs `used_tshark` (output fact) mirror the Python
+// names; the one-letter gap is the contract, not an accident.
+#[allow(clippy::similar_names)]
 fn compute_explain_flow(
     pcap_display: &str,
+    pcap_path: &Path,
     pcap_bytes: &[u8],
     configs: &[BigipConfig],
     show_event_bodies: bool,
     max_event_body_lines: usize,
+    use_tshark: bool,
+    keylog_path: &str,
+    tshark_filter: &str,
 ) -> Result<ExplainFlowReport, String> {
     let dest_re = Regex::new(
         r"^(?P<path>/[^/\s]+/)?(?P<addr>\[[^\]]+\]|[0-9a-fA-F\.:]+)(?:%\d+)?:(?P<port>\d+|any)$",
     )
     .expect("static destination regex");
 
-    let flows = extract_flows(pcap_bytes)?;
+    // Flow extraction mirrors `compute_explain_flow`'s three paths:
+    //   * `--tshark-filter` → tshark is the canonical flow source;
+    //   * `--tshark` / `--keylog` → built-in walker + tshark L7 overlay;
+    //   * neither → built-in walker alone.
+    let mut used_tshark = false;
+    let flows = if tshark_filter.is_empty() {
+        let mut flows = extract_flows(pcap_bytes)?;
+        if use_tshark && tshark_available() {
+            used_tshark = enrich_with_tshark(&mut flows, pcap_path, keylog_path, "");
+        }
+        flows
+    } else {
+        let flows = extract_flows_via_tshark(pcap_path, keylog_path, tshark_filter);
+        used_tshark = !flows.is_empty() || tshark_available();
+        flows
+    };
     let flow_count = flows.len();
     let mut sessions = pair_sessions(&flows);
     let session_count = sessions.len();
@@ -864,21 +896,36 @@ fn compute_explain_flow(
         flow_count,
         session_count,
         matched_count: matched,
+        used_tshark,
+        keylog_path: keylog_path.to_owned(),
+        tshark_filter: tshark_filter.to_owned(),
         sessions: session_explains,
     })
 }
 
-/// Render the text report. Faithful port of `_format_report` (static path).
+/// Render the text report. Faithful port of `_format_report`.
 #[allow(clippy::too_many_lines)]
-fn format_report(pcap_path: &str, sessions: &[SessionExplain]) -> String {
+fn format_report(report: &ExplainFlowReport) -> String {
+    let pcap_path = &report.pcap_path;
+    let sessions = &report.sessions;
     let mut lines: Vec<String> = Vec::new();
     lines.push(format!("explain-flow: {pcap_path}"));
     let matched = sessions.iter().filter(|s| !s.matched_vs.is_empty()).count();
-    // `tshark` / `keylog` / `filter` annotations land with the tshark path.
+    let keylog = if report.keylog_path.is_empty() {
+        String::new()
+    } else {
+        format!(" | keylog: {}", report.keylog_path)
+    };
+    let filter = if report.tshark_filter.is_empty() {
+        String::new()
+    } else {
+        format!(" | filter: {}", py_repr(&report.tshark_filter))
+    };
     lines.push(format!(
-        "  sessions: {} | matched: {} | tshark: no",
+        "  sessions: {} | matched: {} | tshark: {}{keylog}{filter}",
         sessions.len(),
-        matched
+        matched,
+        if report.used_tshark { "yes" } else { "no" },
     ));
     lines.push(String::new());
 
@@ -1433,10 +1480,9 @@ fn report_to_json(report: &ExplainFlowReport) -> Result<String, String> {
         ("flow_count", Value::from(report.flow_count)),
         ("session_count", Value::from(report.session_count)),
         ("matched_count", Value::from(report.matched_count)),
-        // Static built-in walker path: tshark is never used here.
-        ("used_tshark", Value::Bool(false)),
-        ("keylog_path", Value::String(String::new())),
-        ("tshark_filter", Value::String(String::new())),
+        ("used_tshark", Value::Bool(report.used_tshark)),
+        ("keylog_path", Value::String(report.keylog_path.clone())),
+        ("tshark_filter", Value::String(report.tshark_filter.clone())),
         ("sessions", Value::Array(sessions)),
     ]);
     let pretty = serde_json::to_string_pretty(&value).map_err(|e| e.to_string())?;
@@ -1461,14 +1507,16 @@ pub fn run_explain_flow(
         anyhow::bail!("not a file: {}", pcap.display());
     }
     if simulate {
+        // The iRule simulator drives the iRule VM (`tooling.irule_test`), which
+        // is the RT-VM-gated TOOL-IRULE-TEST track; until a native iRule VM
+        // lands there is no Rust simulator to call.
         anyhow::bail!("`f5 explain-flow --simulate` is not yet implemented in the Rust port");
     }
+    // `--tshark-filter` implies tshark; `--tshark` / `--keylog` request the
+    // overlay. `keylog` is forwarded to tshark only when it points at a file.
     let use_tshark = tshark || keylog.is_some() || tshark_filter.is_some();
-    if use_tshark {
-        anyhow::bail!(
-            "`f5 explain-flow --tshark/--keylog/--tshark-filter` is not yet implemented in the Rust port"
-        );
-    }
+    let keylog_path = keylog.map(|p| p.to_string_lossy().into_owned()).unwrap_or_default();
+    let tshark_filter = tshark_filter.unwrap_or("");
 
     let opts = crate::cli::PassphraseArgs::default().to_options();
     let path_strs: Vec<String> = paths
@@ -1484,17 +1532,21 @@ pub fn run_explain_flow(
     let pcap_bytes = std::fs::read(pcap)?;
     let report = compute_explain_flow(
         &pcap.display().to_string(),
+        pcap,
         &pcap_bytes,
         &configs,
         !no_event_bodies,
         max_event_lines,
+        use_tshark,
+        &keylog_path,
+        tshark_filter,
     )
     .map_err(|e| anyhow::anyhow!("{e}"))?;
 
     let rendered = if json {
         report_to_json(&report).map_err(|e| anyhow::anyhow!("{e}"))?
     } else {
-        format_report(&report.pcap_path, &report.sessions)
+        format_report(&report)
     };
 
     let target = OutputTarget::from_arg(output);

--- a/rust/f5-cli/tests/explain_flow_parity.rs
+++ b/rust/f5-cli/tests/explain_flow_parity.rs
@@ -149,3 +149,101 @@ fn json_output_matches_golden() {
         );
     }
 }
+
+/// Whether a `tshark` binary is available to drive the L7-enrichment paths.
+fn tshark_available() -> bool {
+    Command::new("tshark")
+        .arg("--version")
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+/// Whether this tshark accepts the exact EK command the port (and the Python
+/// reference) builds — `-T ek -l --no-duplicate-keys`. tshark gained
+/// `--no-duplicate-keys` for EK output in 4.4; on older builds the overlay run
+/// exits non-zero and the report degrades to `tshark: no` (the Python
+/// reference degrades identically — this is the parity contract, so the port
+/// keeps the command byte-for-byte rather than "fixing" it locally).
+fn tshark_ek_ok() -> bool {
+    Command::new("tshark")
+        .args(["-r", "explain-flow-matched.pcap", "-T", "ek", "-l", "--no-duplicate-keys"])
+        .current_dir(fixtures_dir())
+        .output()
+        .is_ok_and(|o| o.status.success())
+}
+
+#[test]
+fn tshark_enrichment_marks_used_tshark() {
+    // The `--tshark` overlay path runs the built-in walker, then enriches via
+    // `tcl_bigip::flow::tshark`. `used_tshark` reflects whether the tshark run
+    // succeeded — which depends on this tshark's EK support, exactly as the
+    // Python reference does. The byte-level Rust↔Python parity of the enriched
+    // fields is checked by the differential harness offline.
+    if !tshark_available() {
+        eprintln!("skipping: tshark not on PATH");
+        return;
+    }
+    let expect_yes = tshark_ek_ok();
+    let (stdout, code) = run_with(
+        "explain-flow-matched.pcap",
+        "explain-flow-matched.conf",
+        &["--tshark"],
+    );
+    let text = String::from_utf8(stdout).expect("utf8 report");
+    assert_eq!(code, 0, "matched VS exits 0");
+    let want = if expect_yes { "tshark: yes" } else { "tshark: no" };
+    assert!(
+        text.contains(want),
+        "text header must record `{want}` for this tshark: {text}"
+    );
+
+    let (json_out, _) = run_with(
+        "explain-flow-matched.pcap",
+        "explain-flow-matched.conf",
+        &["--tshark", "--json"],
+    );
+    let json = String::from_utf8(json_out).expect("utf8 json");
+    let want_json = format!("\"used_tshark\": {expect_yes}");
+    assert!(
+        json.contains(&want_json),
+        "json must record {want_json}: {json}"
+    );
+}
+
+#[test]
+fn tshark_filter_is_reported_python_repr_style() {
+    // `--tshark-filter` makes tshark the canonical flow source: `used_tshark`
+    // is true whenever a tshark binary exists (mirroring Python's
+    // `bool(flows) or tshark_available()`), independent of EK support, and the
+    // filter is echoed in the header rendered like Python's `repr()`.
+    if !tshark_available() {
+        eprintln!("skipping: tshark not on PATH");
+        return;
+    }
+    let (stdout, _code) = run_with(
+        "explain-flow-matched.pcap",
+        "explain-flow-matched.conf",
+        &["--tshark-filter", "tcp.port == 443"],
+    );
+    let text = String::from_utf8(stdout).expect("utf8 report");
+    assert!(
+        text.contains("tshark: yes | filter: 'tcp.port == 443'"),
+        "header must echo the filter in Python repr form: {text}"
+    );
+}
+
+#[test]
+fn without_tshark_used_tshark_is_false() {
+    // The default built-in-walker path never sets used_tshark, regardless of
+    // whether a tshark binary happens to be installed.
+    let (json_out, _) = run_with(
+        "explain-flow-matched.pcap",
+        "explain-flow-matched.conf",
+        &["--json"],
+    );
+    let json = String::from_utf8(json_out).expect("utf8 json");
+    assert!(
+        json.contains("\"used_tshark\": false"),
+        "default path must record used_tshark=false: {json}"
+    );
+}

--- a/rust/f5-cli/tests/explain_flow_parity.rs
+++ b/rust/f5-cli/tests/explain_flow_parity.rs
@@ -247,3 +247,41 @@ fn without_tshark_used_tshark_is_false() {
         "default path must record used_tshark=false: {json}"
     );
 }
+
+#[test]
+fn simulate_runs_irule_and_selects_pool() {
+    // `--simulate` drives the matched VS's iRule under the embedded TMM-sim
+    // orchestrator on `tcl-vm`: the `when HTTP_REQUEST { pool pool_api }` rule
+    // selects a pool, records the lb decision, and captures its log line.
+    let (stdout, code) = run_with(
+        "explain-flow-matched.pcap",
+        "explain-flow-simulate.conf",
+        &["--simulate"],
+    );
+    let text = String::from_utf8(stdout).expect("utf8 report");
+    assert_eq!(code, 0, "matched capture exits 0: {text}");
+    assert!(text.contains("iRule simulation:"), "{text}");
+    assert!(text.contains("pool: pool_api"), "{text}");
+    assert!(
+        text.contains("decision: lb pool_select pool_api"),
+        "{text}"
+    );
+    assert!(text.contains("routing host="), "captured iRule log: {text}");
+}
+
+#[test]
+fn simulate_json_populates_simulated_fields() {
+    let (json_out, code) = run_with(
+        "explain-flow-matched.pcap",
+        "explain-flow-simulate.conf",
+        &["--simulate", "--json"],
+    );
+    let json = String::from_utf8(json_out).expect("utf8 json");
+    assert_eq!(code, 0, "matched capture exits 0");
+    assert!(json.contains("\"simulated_pool\": \"pool_api\""), "{json}");
+    assert!(
+        json.contains("\"simulated_node\": \"192.0.2.30:80\""),
+        "{json}"
+    );
+    assert!(json.contains("\"action\": \"pool_select\""), "{json}");
+}

--- a/rust/f5-cli/tests/fixtures/explain-flow-simulate.conf
+++ b/rust/f5-cli/tests/fixtures/explain-flow-simulate.conf
@@ -1,0 +1,32 @@
+ltm virtual /Common/vs_https {
+    destination /Common/198.51.100.10:443
+    ip-protocol tcp
+    pool /Common/pool_web
+    profiles {
+        /Common/clientssl { context clientside }
+        /Common/http { }
+        /Common/tcp { }
+    }
+    rules {
+        /Common/rule_route
+    }
+}
+ltm profile tcp /Common/tcp { }
+ltm profile http /Common/http { }
+ltm profile client-ssl /Common/clientssl { }
+ltm pool /Common/pool_web {
+    members {
+        /Common/192.0.2.20:80 { address 192.0.2.20 }
+    }
+}
+ltm pool /Common/pool_api {
+    members {
+        /Common/192.0.2.30:80 { address 192.0.2.30 }
+    }
+}
+ltm rule /Common/rule_route {
+when HTTP_REQUEST {
+    log local0. "routing host=[HTTP::host]"
+    pool pool_api
+}
+}

--- a/rust/tcl-bigip/src/flow/mod.rs
+++ b/rust/tcl-bigip/src/flow/mod.rs
@@ -10,7 +10,9 @@
 pub mod model;
 pub mod packets;
 pub mod sessions;
+pub mod tshark;
 
 pub use model::{Connection, Flow, FlowKey, Session};
 pub use packets::extract_flows;
 pub use sessions::{pair_connections, pair_sessions};
+pub use tshark::{enrich_with_tshark, extract_flows_via_tshark, tshark_available};

--- a/rust/tcl-bigip/src/flow/tshark.rs
+++ b/rust/tcl-bigip/src/flow/tshark.rs
@@ -1,0 +1,575 @@
+//! tshark / EK enrichment: decode TLS/HTTP fields tshark can see that the
+//! raw-bytes walker can't.
+//!
+//! Faithful port of `dialects/f5/bigip/flow/tshark.py`. Two entry points:
+//!
+//! * [`enrich_with_tshark`] overlays decoded L7 fields onto flows the built-in
+//!   walker already produced (the `--tshark` / `--keylog` path).
+//! * [`extract_flows_via_tshark`] drives tshark as the *canonical* flow source
+//!   when a display filter is supplied (the `--tshark-filter` path), so only
+//!   matching packets contribute to the report.
+//!
+//! Both run `tshark -T ek` (Elastic-Kibana newline-delimited JSON) so values
+//! that contain delimiters (Cookies, URIs with query strings, F5 reset-cause
+//! text) survive intact, and parse the dissection tree under `layers.<proto>`
+//! by name. Any tshark failure (missing binary, non-zero exit, no parseable
+//! output) degrades gracefully: enrichment returns `false`, extraction returns
+//! an empty map, and the caller falls back to the built-in walker.
+
+use std::path::Path;
+use std::process::Command;
+
+use indexmap::IndexMap;
+use serde_json::Value;
+
+use super::model::{Flow, FlowKey};
+
+/// Whether a `tshark` binary is on `PATH`.
+#[must_use]
+pub fn tshark_available() -> bool {
+    which_tshark().is_some()
+}
+
+/// Locate the `tshark` binary on `PATH`, mirroring `shutil.which`.
+fn which_tshark() -> Option<std::path::PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    for dir in std::env::split_paths(&path) {
+        let candidate = dir.join("tshark");
+        if candidate.is_file() {
+            return Some(candidate);
+        }
+    }
+    None
+}
+
+/// tshark-rendered TLS/DTLS version → friendly name.
+fn name_tls_version(raw: &str) -> String {
+    if raw.is_empty() {
+        return raw.to_owned();
+    }
+    let s = raw.trim().to_ascii_lowercase();
+    let value = if let Some(hex) = s.strip_prefix("0x") {
+        match u32::from_str_radix(hex, 16) {
+            Ok(v) => v,
+            Err(_) => return raw.to_owned(),
+        }
+    } else {
+        match s.parse::<u32>() {
+            Ok(v) => v,
+            Err(_) => return raw.to_owned(),
+        }
+    };
+    match value {
+        0x0301 => "TLS1.0".to_owned(),
+        0x0302 => "TLS1.1".to_owned(),
+        0x0303 => "TLS1.2".to_owned(),
+        0x0304 => "TLS1.3".to_owned(),
+        0xfeff => "DTLS1.0".to_owned(),
+        0xfefd => "DTLS1.2".to_owned(),
+        _ => raw.to_owned(),
+    }
+}
+
+/// Build a `tshark -T ek` command for newline-delimited JSON output.
+///
+/// `-l` flushes per-packet; `--no-duplicate-keys` collapses a repeated field
+/// to its first value. `keylog_path` (when it points at an existing file) wires
+/// `-o tls.keylog_file:<path>` so HTTPS payloads decrypt; `tshark_filter` is
+/// passed as a `-Y` display filter so only matching packets reach the
+/// dissector.
+fn tshark_ek_cmd(pcap_path: &Path, keylog_path: &str, tshark_filter: &str) -> Command {
+    let mut cmd = Command::new("tshark");
+    cmd.arg("-r")
+        .arg(pcap_path)
+        .args(["-T", "ek", "-l", "--no-duplicate-keys"]);
+    if !keylog_path.is_empty() {
+        let kl = Path::new(keylog_path);
+        if kl.is_file() {
+            cmd.arg("-o").arg(format!("tls.keylog_file:{keylog_path}"));
+        }
+    }
+    if !tshark_filter.is_empty() {
+        cmd.arg("-Y").arg(tshark_filter);
+    }
+    cmd
+}
+
+/// Parse `tshark -T ek` stdout into the per-packet content objects.
+///
+/// EK alternates one-line `{"index": ...}` headers with one-line
+/// `{"timestamp": ..., "layers": {...}}` payloads; we keep only objects that
+/// carry a `layers` key.
+fn parse_tshark_ek(stdout: &str) -> Vec<Value> {
+    let mut out = Vec::new();
+    for line in stdout.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(obj) = serde_json::from_str::<Value>(line) else {
+            continue;
+        };
+        if obj.get("layers").is_some() {
+            out.push(obj);
+        }
+    }
+    out
+}
+
+/// Render a JSON scalar the way Python's `str()` would (so `_ek_field`'s
+/// `str(val)` matches: booleans capitalise, numbers print bare).
+fn scalar_str(v: &Value) -> String {
+    match v {
+        Value::String(s) => s.clone(),
+        Value::Bool(true) => "True".to_owned(),
+        Value::Bool(false) => "False".to_owned(),
+        Value::Number(n) => n.to_string(),
+        Value::Null => String::new(),
+        other => other.to_string(),
+    }
+}
+
+/// Look up a field from a parsed EK `layers` object.
+///
+/// EK collapses dots in field names to underscores within each layer, so
+/// `ip.src` lives at `layers.ip["ip_src"]`. A repeated field is a list (under
+/// `--no-duplicate-keys`); we return the first element.
+fn ek_field(layers: &Value, layer: &str, key: &str) -> String {
+    let Some(layer_obj) = layers.get(layer).filter(|v| v.is_object()) else {
+        return String::new();
+    };
+    match layer_obj.get(key) {
+        None | Some(Value::Null) => String::new(),
+        Some(Value::Array(items)) => items.first().map_or_else(String::new, scalar_str),
+        Some(val) => scalar_str(val),
+    }
+}
+
+/// Insert `(key, value)` into a first-seen-ordered header list only when `key`
+/// is absent — mirrors Python's `dict.setdefault`.
+fn header_setdefault(headers: &mut Vec<(String, String)>, key: &str, value: &str) {
+    if !headers.iter().any(|(k, _)| k == key) {
+        headers.push((key.to_owned(), value.to_owned()));
+    }
+}
+
+/// Canonicalise an IP literal the way Python's `ipaddress.ip_address(...)`
+/// does (so e.g. compressed IPv6 forms match the walker's keys). Returns
+/// `None` for anything that doesn't parse as an IP.
+fn canonical_ip(raw: &str) -> Option<String> {
+    raw.parse::<std::net::IpAddr>().ok().map(|ip| ip.to_string())
+}
+
+/// Resolve the L3/L4 5-tuple key for one EK packet, or `None` when it is not a
+/// keyable TCP/UDP/IP packet.
+#[allow(clippy::similar_names)] // ip_src / ip_dst / sp / dp are the domain 5-tuple.
+fn packet_key(layers: &Value) -> Option<FlowKey> {
+    let ip_src = {
+        let v = ek_field(layers, "ip", "ip_src");
+        if v.is_empty() {
+            ek_field(layers, "ipv6", "ipv6_src")
+        } else {
+            v
+        }
+    };
+    let ip_dst = {
+        let v = ek_field(layers, "ip", "ip_dst");
+        if v.is_empty() {
+            ek_field(layers, "ipv6", "ipv6_dst")
+        } else {
+            v
+        }
+    };
+    let tcp_sp = ek_field(layers, "tcp", "tcp_srcport");
+    let tcp_dp = ek_field(layers, "tcp", "tcp_dstport");
+    let udp_sp = ek_field(layers, "udp", "udp_srcport");
+    let udp_dp = ek_field(layers, "udp", "udp_dstport");
+    let (proto, sp, dp) = if !tcp_sp.is_empty() || !tcp_dp.is_empty() {
+        (6u8, parse_port(&tcp_sp), parse_port(&tcp_dp))
+    } else if !udp_sp.is_empty() || !udp_dp.is_empty() {
+        (17u8, parse_port(&udp_sp), parse_port(&udp_dp))
+    } else {
+        return None;
+    };
+    if ip_src.is_empty() {
+        return None;
+    }
+    let ip_src = canonical_ip(&ip_src)?;
+    let ip_dst = canonical_ip(&ip_dst)?;
+    Some((ip_src, sp, ip_dst, dp, proto))
+}
+
+/// Parse a port string the way Python's `int(x) if x.isdigit() else 0` does
+/// (all-ASCII-digits only; anything else, including empty, is 0).
+fn parse_port(raw: &str) -> u16 {
+    if !raw.is_empty() && raw.bytes().all(|b| b.is_ascii_digit()) {
+        raw.parse().unwrap_or(0)
+    } else {
+        0
+    }
+}
+
+/// EK flag fields render as `"1"`/`"0"` or `"True"`/`"False"`; treat both true
+/// spellings as set.
+fn flag_set(v: &str) -> bool {
+    v == "1" || v == "True"
+}
+
+/// Overlay decoded fields from one EK `layers` object onto `flows`.
+#[allow(clippy::too_many_lines)] // One field-by-field overlay; splitting would obscure the 1:1 port.
+fn apply_packet_to_flows(layers: &Value, flows: &mut IndexMap<FlowKey, Flow>) {
+    let Some(key) = packet_key(layers) else {
+        return;
+    };
+    let Some(flow) = flows.get_mut(&key) else {
+        return;
+    };
+
+    // TLS handshake.
+    let sni = ek_field(layers, "tls", "tls_handshake_extensions_server_name");
+    if !sni.is_empty() && flow.tls_sni.is_empty() {
+        flow.tls_sni = sni;
+        flow.tls_clienthello = true;
+    }
+    let cipher = ek_field(layers, "tls", "tls_handshake_ciphersuite");
+    if !cipher.is_empty() && flow.tls_chosen_cipher.is_empty() {
+        flow.tls_chosen_cipher = cipher;
+    }
+    let chosen_ver = {
+        let v = ek_field(layers, "tls", "tls_handshake_version");
+        if v.is_empty() {
+            ek_field(layers, "tls", "tls_record_version")
+        } else {
+            v
+        }
+    };
+    if !chosen_ver.is_empty() && flow.tls_chosen_version.is_empty() {
+        flow.tls_chosen_version = name_tls_version(&chosen_ver);
+    }
+    let alpn = ek_field(layers, "tls", "tls_handshake_extensions_alpn_str");
+    if !alpn.is_empty() && flow.tls_alpn.is_empty() {
+        flow.tls_alpn = alpn;
+    }
+    let alert_desc = ek_field(layers, "tls", "tls_alert_message_desc");
+    if !alert_desc.is_empty() {
+        flow.tls_alert_seen = true;
+        flow.tls_alert_desc = alert_desc;
+    }
+    let cert_subj = ek_field(layers, "x509sat", "x509sat_printableString");
+    if !cert_subj.is_empty() && flow.tls_cert_subject.is_empty() {
+        flow.tls_cert_subject = cert_subj;
+    }
+    let sig_alg = ek_field(layers, "tls", "tls_handshake_sig_hash_alg");
+    if !sig_alg.is_empty() && flow.tls_signature_algos.is_empty() {
+        flow.tls_signature_algos = sig_alg;
+    }
+    let supp_groups = ek_field(layers, "tls", "tls_handshake_extensions_supported_group");
+    if !supp_groups.is_empty() && flow.tls_supported_groups.is_empty() {
+        flow.tls_supported_groups = supp_groups;
+    }
+
+    // HTTP request.
+    let method = ek_field(layers, "http", "http_request_method");
+    if !method.is_empty() && flow.http_method.is_empty() {
+        flow.http_method = method;
+        flow.http_request_seen = true;
+    }
+    let host = ek_field(layers, "http", "http_host");
+    if !host.is_empty() && flow.http_host.is_empty() {
+        flow.http_host = host;
+    }
+    let uri = {
+        let v = ek_field(layers, "http", "http_request_uri");
+        if v.is_empty() {
+            ek_field(layers, "http", "http_request_full_uri")
+        } else {
+            v
+        }
+    };
+    if !uri.is_empty() && flow.http_uri.is_empty() {
+        let (path, query) = match uri.split_once('?') {
+            Some((p, q)) => (p.to_owned(), q.to_owned()),
+            None => (uri.clone(), String::new()),
+        };
+        if flow.http_path.is_empty() {
+            flow.http_path = path;
+        }
+        if flow.http_query.is_empty() {
+            flow.http_query = query;
+        }
+        flow.http_uri = uri;
+    }
+    let http_ver = ek_field(layers, "http", "http_request_version");
+    if !http_ver.is_empty() && flow.http_request_version.is_empty() {
+        flow.http_request_version = http_ver;
+    }
+    let ua = ek_field(layers, "http", "http_user_agent");
+    if !ua.is_empty() && flow.http_user_agent.is_empty() {
+        header_setdefault(&mut flow.http_request_headers, "user-agent", &ua);
+        flow.http_user_agent = ua;
+    }
+    let cookie = ek_field(layers, "http", "http_cookie");
+    if !cookie.is_empty() && flow.http_cookie.is_empty() {
+        header_setdefault(&mut flow.http_request_headers, "cookie", &cookie);
+        flow.http_cookie = cookie;
+    }
+    let referer = ek_field(layers, "http", "http_referer");
+    if !referer.is_empty() && flow.http_referer.is_empty() {
+        header_setdefault(&mut flow.http_request_headers, "referer", &referer);
+        flow.http_referer = referer;
+    }
+    let content_type = ek_field(layers, "http", "http_content_type");
+    if !content_type.is_empty() && flow.http_request_content_type.is_empty() {
+        header_setdefault(&mut flow.http_request_headers, "content-type", &content_type);
+        flow.http_request_content_type = content_type;
+    }
+    let content_length = ek_field(layers, "http", "http_content_length");
+    if !content_length.is_empty() && flow.http_request_content_length.is_empty() {
+        header_setdefault(
+            &mut flow.http_request_headers,
+            "content-length",
+            &content_length,
+        );
+        flow.http_request_content_length = content_length;
+    }
+
+    // HTTP response.
+    let code = ek_field(layers, "http", "http_response_code");
+    if !code.is_empty() {
+        flow.http_response_seen = true;
+        flow.http_response_code = code;
+    }
+    let resp_phrase = ek_field(layers, "http", "http_response_phrase");
+    if !resp_phrase.is_empty() && flow.http_response_phrase.is_empty() {
+        flow.http_response_phrase = resp_phrase;
+    }
+
+    // F5 reset cause TLVs (DPT trailer).
+    if flag_set(&ek_field(layers, "tcp", "tcp_flags_reset")) {
+        flow.tcp_rst = true;
+    }
+    for ek_key in [
+        "f5ethtrailer_rstcause_cause",
+        "f5ethtrailer_rstcause_line",
+        "f5ethtrailer_rstcause_peer",
+    ] {
+        let piece = ek_field(layers, "f5ethtrailer", ek_key);
+        let tag = piece.trim();
+        if !tag.is_empty() && !flow.f5_reset_causes.iter().any(|c| c == tag) {
+            flow.f5_reset_causes.push(tag.to_owned());
+        }
+    }
+}
+
+/// Run tshark and overlay decoded L7 fields onto `flows`.
+///
+/// Returns `true` when tshark ran successfully. Silently returns `false` when
+/// tshark is missing, errors out, or produces no parseable output. When
+/// `keylog_path` is set and the file exists, HTTPS payloads decrypt so the
+/// HTTP method/URI/response fields populate for TLS-wrapped flows.
+#[must_use]
+pub fn enrich_with_tshark(
+    flows: &mut IndexMap<FlowKey, Flow>,
+    pcap_path: &Path,
+    keylog_path: &str,
+    tshark_filter: &str,
+) -> bool {
+    if !tshark_available() {
+        return false;
+    }
+    let Some(stdout) = run_tshark(pcap_path, keylog_path, tshark_filter) else {
+        return false;
+    };
+    for packet in parse_tshark_ek(&stdout) {
+        if let Some(layers) = packet.get("layers") {
+            apply_packet_to_flows(layers, flows);
+        }
+    }
+    true
+}
+
+/// Extract flows from `pcap_path` by driving tshark with EK output.
+///
+/// Used when the caller passes a `--tshark-filter` so only packets matching the
+/// display filter contribute. Returns the same `{5-tuple: Flow}` shape as the
+/// built-in walker. F5 trailer peer-tuples are NOT populated by this path
+/// (front/back session pairing for `:np` captures works only with the built-in
+/// walker). On any tshark failure, returns an empty map; the caller falls back
+/// to the built-in walker.
+#[must_use]
+pub fn extract_flows_via_tshark(
+    pcap_path: &Path,
+    keylog_path: &str,
+    tshark_filter: &str,
+) -> IndexMap<FlowKey, Flow> {
+    let mut flows: IndexMap<FlowKey, Flow> = IndexMap::new();
+    if !tshark_available() {
+        return flows;
+    }
+    let Some(stdout) = run_tshark(pcap_path, keylog_path, tshark_filter) else {
+        return flows;
+    };
+    let parsed = parse_tshark_ek(&stdout);
+
+    // First pass: establish flow keys + counts + TCP flags.
+    for packet in &parsed {
+        let Some(layers) = packet.get("layers") else {
+            continue;
+        };
+        let Some(key) = packet_key(layers) else {
+            continue;
+        };
+        let (ip_src, sp, ip_dst, dp, proto) = key.clone();
+        let flow = flows
+            .entry(key)
+            .or_insert_with(|| Flow::new(ip_src, sp, ip_dst, dp, proto));
+
+        flow.packets += 1;
+        let frame_len = ek_field(layers, "frame", "frame_len");
+        if let Ok(n) = frame_len.parse::<u64>() {
+            flow.bytes_total += n;
+        }
+        if proto == 6 {
+            let syn = flag_set(&ek_field(layers, "tcp", "tcp_flags_syn"));
+            let ack = flag_set(&ek_field(layers, "tcp", "tcp_flags_ack"));
+            let fin = flag_set(&ek_field(layers, "tcp", "tcp_flags_fin"));
+            if syn && ack {
+                flow.tcp_synack = true;
+            } else if syn {
+                flow.tcp_syn = true;
+            }
+            if fin {
+                flow.tcp_fin = true;
+            }
+        }
+    }
+
+    // Second pass: HTTP / TLS / RST cause overlay.
+    for packet in &parsed {
+        if let Some(layers) = packet.get("layers") {
+            apply_packet_to_flows(layers, &mut flows);
+        }
+    }
+    flows
+}
+
+/// Run the tshark EK command and return its stdout, or `None` on any failure
+/// (spawn error, non-zero exit).
+fn run_tshark(pcap_path: &Path, keylog_path: &str, tshark_filter: &str) -> Option<String> {
+    let output = tshark_ek_cmd(pcap_path, keylog_path, tshark_filter)
+        .output()
+        .ok()?;
+    if !output.status.success() {
+        return None;
+    }
+    Some(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_tls_version_normalises_widths_and_bases() {
+        assert_eq!(name_tls_version("0x0303"), "TLS1.2");
+        assert_eq!(name_tls_version("0x303"), "TLS1.2");
+        assert_eq!(name_tls_version("771"), "TLS1.2");
+        assert_eq!(name_tls_version("0xFEFD"), "DTLS1.2");
+        assert_eq!(name_tls_version(""), "");
+        assert_eq!(name_tls_version("nonsense"), "nonsense");
+        // Unknown but parseable values fall back to the raw string.
+        assert_eq!(name_tls_version("0x0500"), "0x0500");
+    }
+
+    #[test]
+    fn ek_field_collapses_lists_to_first() {
+        let layers: Value = serde_json::json!({
+            "ip": {"ip_src": "10.0.0.1", "ip_dst": ["10.0.0.2", "10.0.0.3"]},
+            "tcp": {"tcp_srcport": 4433},
+        });
+        assert_eq!(ek_field(&layers, "ip", "ip_src"), "10.0.0.1");
+        assert_eq!(ek_field(&layers, "ip", "ip_dst"), "10.0.0.2");
+        // Numbers stringify bare, like Python str(int).
+        assert_eq!(ek_field(&layers, "tcp", "tcp_srcport"), "4433");
+        assert_eq!(ek_field(&layers, "udp", "udp_srcport"), "");
+        assert_eq!(ek_field(&layers, "ip", "missing"), "");
+    }
+
+    #[test]
+    fn header_setdefault_is_first_wins() {
+        let mut headers = vec![("user-agent".to_owned(), "curl".to_owned())];
+        header_setdefault(&mut headers, "user-agent", "wget");
+        header_setdefault(&mut headers, "cookie", "a=1");
+        assert_eq!(
+            headers,
+            vec![
+                ("user-agent".to_owned(), "curl".to_owned()),
+                ("cookie".to_owned(), "a=1".to_owned()),
+            ]
+        );
+    }
+
+    #[test]
+    fn apply_packet_overlays_http_and_tls_onto_matching_flow() {
+        let key: FlowKey = ("10.0.0.1".to_owned(), 5000, "10.0.0.2".to_owned(), 443, 6);
+        let mut flows: IndexMap<FlowKey, Flow> = IndexMap::new();
+        flows.insert(
+            key.clone(),
+            Flow::new("10.0.0.1".to_owned(), 5000, "10.0.0.2".to_owned(), 443, 6),
+        );
+        let layers: Value = serde_json::json!({
+            "ip": {"ip_src": "10.0.0.1", "ip_dst": "10.0.0.2"},
+            "tcp": {"tcp_srcport": "5000", "tcp_dstport": "443"},
+            "tls": {
+                "tls_handshake_extensions_server_name": "example.com",
+                "tls_handshake_version": "0x0304",
+                "tls_handshake_extensions_alpn_str": "h2",
+            },
+            "http": {
+                "http_request_method": "GET",
+                "http_request_uri": "/path?q=1",
+                "http_user_agent": "curl/8",
+            },
+        });
+        apply_packet_to_flows(&layers, &mut flows);
+        let flow = &flows[&key];
+        assert_eq!(flow.tls_sni, "example.com");
+        assert!(flow.tls_clienthello);
+        assert_eq!(flow.tls_chosen_version, "TLS1.3");
+        assert_eq!(flow.tls_alpn, "h2");
+        assert_eq!(flow.http_method, "GET");
+        assert!(flow.http_request_seen);
+        assert_eq!(flow.http_uri, "/path?q=1");
+        assert_eq!(flow.http_path, "/path");
+        assert_eq!(flow.http_query, "q=1");
+        assert_eq!(flow.request_header("user-agent"), Some("curl/8"));
+    }
+
+    #[test]
+    fn apply_packet_ignores_unknown_flow_key() {
+        let mut flows: IndexMap<FlowKey, Flow> = IndexMap::new();
+        let layers: Value = serde_json::json!({
+            "ip": {"ip_src": "10.0.0.9", "ip_dst": "10.0.0.2"},
+            "tcp": {"tcp_srcport": "5000", "tcp_dstport": "443"},
+            "http": {"http_request_method": "GET"},
+        });
+        apply_packet_to_flows(&layers, &mut flows);
+        assert!(flows.is_empty());
+    }
+
+    #[test]
+    fn parse_tshark_ek_keeps_only_layer_payloads() {
+        let stdout = concat!(
+            "{\"index\": {\"_index\": \"packets\"}}\n",
+            "\n",
+            "{\"timestamp\": \"1\", \"layers\": {\"frame\": {\"frame_len\": \"66\"}}}\n",
+            "not json\n",
+        );
+        let packets = parse_tshark_ek(stdout);
+        assert_eq!(packets.len(), 1);
+        assert_eq!(
+            ek_field(&packets[0]["layers"], "frame", "frame_len"),
+            "66"
+        );
+    }
+}

--- a/rust/tcl-cli/Cargo.toml
+++ b/rust/tcl-cli/Cargo.toml
@@ -27,8 +27,16 @@ serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 # Bundled SQLite (with FTS5) for the `help` verb's embedded KCS database.
 rusqlite = { version = "0.32", features = ["bundled"] }
-ratatui = { version = "0.29", optional = true }
-crossterm = { version = "0.28", optional = true }
+# Termina backend (the helix-editor VT library) instead of crossterm:
+# `default-features = false` drops the default crossterm backend; the `termina`
+# feature pulls `ratatui-termina` and re-exports the `termina` crate.
+ratatui = { version = "0.30", optional = true, default-features = false, features = [
+    "termina",
+    "all-widgets",
+    "layout-cache",
+    "macros",
+    "underline-color",
+] }
 
 [dev-dependencies]
 # Used by the CLI parity tests to compare help-search retrieval structurally
@@ -41,7 +49,7 @@ regex = "1"
 [features]
 # The interactive `tcl explore --tui` shell. Off by default so the lean CLI
 # build doesn't pull the terminal-UI stack (mirrors Python's optional Textual).
-tui = ["dep:ratatui", "dep:crossterm"]
+tui = ["dep:ratatui"]
 
 [build-dependencies]
 # Build the embedded KCS help database (FTS5) from the committed

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -406,40 +406,6 @@ pub enum Command {
     },
 }
 
-impl Command {
-    /// The canonical verb name, used in not-yet-implemented messages and logs.
-    pub fn verb_name(&self) -> &'static str {
-        match self {
-            Command::Dis { .. } => "dis",
-            Command::Compwasm { .. } => "compwasm",
-            Command::Diag { .. } => "diag",
-            Command::Lint { .. } => "lint",
-            Command::Validate { .. } => "validate",
-            Command::Diff { .. } => "diff",
-            Command::Symbols { .. } => "symbols",
-            Command::Diagram { .. } => "diagram",
-            Command::Callgraph { .. } => "callgraph",
-            Command::Symbolgraph { .. } => "symbolgraph",
-            Command::Dataflow { .. } => "dataflow",
-            Command::Highlight { .. } => "highlight",
-            Command::CmdInfo { .. } => "command-info",
-            Command::Help { .. } => "help",
-            Command::Minimize { .. } => "minimize",
-            Command::Explore { .. } => "explore",
-            Command::FindLegacy { .. } => "find-legacy",
-            Command::RegistryDump { .. } => "registry-dump",
-            Command::Opt { .. } => "opt",
-            Command::Format { .. } => "format",
-            Command::Minify { .. } => "minify",
-            Command::UnminifyError { .. } => "unminify-error",
-            Command::Completion { .. } => "completion",
-            Command::Pkg { .. } => "pkg",
-            Command::Venv { .. } => "venv",
-            Command::Docker { .. } => "docker",
-        }
-    }
-}
-
 /// Diagnostic-filtering flags shared by `diag` / `lint` / `validate`.
 #[derive(Debug, Args)]
 pub struct DiagArgs {

--- a/rust/tcl-cli/src/lib.rs
+++ b/rust/tcl-cli/src/lib.rs
@@ -7,9 +7,9 @@
 //!
 //! The command surface (verb names, aliases, flags) is the parity contract
 //! with the Python CLI: `tcl --help` and every `tcl <verb> --help` are diffed
-//! against the argparse output during the port. Verb *behaviour* is filled in
-//! phase by phase; until a verb is ported its handler returns a clear
-//! "not yet implemented" error (exit code 2), matching the Python error path.
+//! against the argparse output during the port. Every top-level verb is now
+//! ported and dispatched to a native engine handler, so the dispatch `match`
+//! is exhaustive — there is no longer a not-yet-implemented fallthrough.
 
 #![forbid(unsafe_code)]
 
@@ -181,10 +181,5 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
         Command::Pkg { action } => commands::pkg::run(action),
         Command::Venv { action } => commands::venv::run(action),
         Command::Docker { action } => commands::docker::run(action),
-        // Verbs not yet ported fall through to a clear not-implemented error.
-        other => {
-            let verb = other.verb_name();
-            anyhow::bail!("`tcl {verb}` is not yet implemented in the Rust port");
-        }
     }
 }

--- a/rust/tcl-cli/src/tui.rs
+++ b/rust/tcl-cli/src/tui.rs
@@ -10,13 +10,37 @@
 //! [`run`] touches the terminal.
 
 use std::collections::HashSet;
+use std::io::Write as _;
 
-use crossterm::event::{self, Event, KeyCode, KeyEventKind};
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Modifier, Style};
 use ratatui::text::{Line, Span};
+use ratatui::backend::TerminaBackend;
+use ratatui::termina::escape::csi::{self, Csi};
+use ratatui::termina::event::{KeyCode, KeyEventKind};
+use ratatui::termina::{Event, EventReader, PlatformTerminal, Terminal as _};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
+use ratatui::Terminal;
 use serde_json::Value;
+
+/// The concrete terminal type: a Ratatui terminal over the Termina backend.
+type AppTerminal = Terminal<TerminaBackend<PlatformTerminal>>;
+
+/// Build a private-mode CSI for the named [`csi::DecPrivateModeCode`].
+macro_rules! dec_set {
+    ($mode:ident) => {
+        Csi::Mode(csi::Mode::SetDecPrivateMode(csi::DecPrivateMode::Code(
+            csi::DecPrivateModeCode::$mode,
+        )))
+    };
+}
+macro_rules! dec_reset {
+    ($mode:ident) => {
+        Csi::Mode(csi::Mode::ResetDecPrivateMode(csi::DecPrivateMode::Code(
+            csi::DecPrivateModeCode::$mode,
+        )))
+    };
+}
 
 use tcl_explorer::view_tree::TREE_VIEWS;
 use tcl_explorer::{ViewNode, build_view};
@@ -149,21 +173,62 @@ pub fn run(source: &str, dialect: &str) -> anyhow::Result<()> {
     let data = tcl_explorer::serialise_result(&tcl_explorer::run_pipeline(source, dialect));
     let mut app = App::new(data);
 
-    let mut terminal = ratatui::init();
-    let result = event_loop(&mut terminal, &mut app);
-    ratatui::restore();
-    result
+    let (mut terminal, events) = init_terminal()?;
+    let result = event_loop(&mut terminal, &events, &mut app);
+    // Restore the terminal even if the loop errored; the raw-mode reset happens
+    // when the backend's `PlatformTerminal` drops.
+    let restored = restore_terminal(&mut terminal);
+    result.and(restored)
 }
 
-fn event_loop(terminal: &mut ratatui::DefaultTerminal, app: &mut App) -> anyhow::Result<()> {
+/// Enter raw mode + the alternate screen and build the Ratatui/Termina
+/// terminal, returning it alongside the event reader.
+fn init_terminal() -> anyhow::Result<(AppTerminal, EventReader)> {
+    let mut output = PlatformTerminal::new()?;
+    output.enter_raw_mode()?;
+    // Alternate screen, hidden cursor — a full-screen navigation UI.
+    write!(
+        output,
+        "{}{}",
+        dec_set!(ClearAndEnableAlternateScreen),
+        dec_reset!(ShowCursor)
+    )?;
+    output.flush()?;
+
+    let events = output.event_reader();
+    let terminal = Terminal::new(TerminaBackend::new(output))?;
+    Ok((terminal, events))
+}
+
+/// Leave the alternate screen and restore the cursor (raw mode is reset on drop).
+fn restore_terminal(terminal: &mut AppTerminal) -> anyhow::Result<()> {
+    let backend = terminal.backend_mut();
+    write!(
+        backend,
+        "{}{}",
+        dec_reset!(ClearAndEnableAlternateScreen),
+        dec_set!(ShowCursor)
+    )?;
+    backend.flush()?;
+    Ok(())
+}
+
+fn event_loop(
+    terminal: &mut AppTerminal,
+    events: &EventReader,
+    app: &mut App,
+) -> anyhow::Result<()> {
     loop {
         terminal.draw(|frame| draw(frame, app))?;
-        if let Event::Key(key) = event::read()? {
-            if key.kind != KeyEventKind::Press {
-                continue;
-            }
+        // Block until a key press (so shortcuts don't double-fire on release)
+        // or a resize (which the next draw picks up).
+        let event = events.read(|e| {
+            matches!(e, Event::Key(k) if k.kind == KeyEventKind::Press)
+                || matches!(e, Event::WindowResized(_))
+        })?;
+        if let Event::Key(key) = event {
             match key.code {
-                KeyCode::Char('q') | KeyCode::Esc => return Ok(()),
+                KeyCode::Char('q') | KeyCode::Escape => return Ok(()),
                 KeyCode::Up => app.move_cursor(-1),
                 KeyCode::Down => app.move_cursor(1),
                 KeyCode::Left => app.prev_view(),
@@ -264,11 +329,30 @@ fn draw(frame: &mut ratatui::Frame, app: &App) {
 
 #[cfg(test)]
 mod tests {
+    use ratatui::Terminal;
+    use ratatui::backend::TestBackend;
+
     use super::*;
 
     fn app(src: &str) -> App {
         let data = tcl_explorer::serialise_result(&tcl_explorer::run_pipeline(src, "tcl8.6"));
         App::new(data)
+    }
+
+    /// `draw` is backend-agnostic, so render it into a [`TestBackend`] buffer
+    /// (no terminal needed) and assert the chrome is present — a smoke test that
+    /// the Ratatui/Termina migration didn't break the layout.
+    #[test]
+    fn draw_renders_chrome_into_test_backend() {
+        let mut app = app("proc add {a b} { expr {$a + $b} }\nputs [add 1 2]");
+        app.toggle(); // expand the IR root so the tree shows statements
+        let mut terminal = Terminal::new(TestBackend::new(78, 20)).expect("test terminal");
+        terminal.draw(|frame| draw(frame, &app)).expect("draw");
+        let buf = terminal.backend().buffer();
+        let text: String = buf.content().iter().map(|c| c.symbol()).collect();
+        assert!(text.contains("views"), "sidebar title: {text}");
+        assert!(text.contains("detail"), "detail panel: {text}");
+        assert!(text.contains("expand"), "footer hint: {text}");
     }
 
     #[test]

--- a/rust/tcl-compiler/src/cfg.rs
+++ b/rust/tcl-compiler/src/cfg.rs
@@ -592,6 +592,7 @@ mod tests {
                     body: crate::ir::Script::new(),
                     body_span: Span::new(0, 0),
                     raw_args: Vec::new(),
+                    raw_tokens: None,
                 },
             },
         );

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -888,6 +888,7 @@ mod tests {
             body: Script::new(),
             body_span: Span::new(32, 34),
             raw_args: vec![],
+            raw_tokens: None,
         }]);
 
         let func = build_cfg_function("::test", &script, true);
@@ -915,6 +916,7 @@ mod tests {
             body: Script::new(),
             body_span: Span::new(9, 11),
             raw_args: vec![],
+            raw_tokens: None,
         }]);
 
         let func = build_cfg_function("::test", &script, true);

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -941,6 +941,7 @@ mod tests {
             is_lmap: false,
             raw_args: vec![],
             is_dict_iteration: false,
+            raw_tokens: None,
         }]);
 
         let func = build_cfg_function("::test", &script, true);

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -42,6 +42,34 @@ fn frozen_loop_tokens(cmd: &str, args: &[String], source: Option<&CommandTokens>
     source.cloned().unwrap_or_else(|| all_str_tokens(cmd, args))
 }
 
+/// Return `tokens` with the word at `idx` removed from every per-word vector.
+///
+/// Used to derive a `dict for`/`map` barrier's tokens from the source
+/// `dict for {vars} $d {body}` tokens by dropping the `for`/`map` subcommand
+/// word (index 1), so the remaining words line up with the barrier's
+/// `::tcl::dict::for {vars} $d {body}` argv.
+fn drop_word(tokens: &CommandTokens, idx: usize) -> CommandTokens {
+    let mut out = tokens.clone();
+    if idx < out.argv.len() {
+        out.argv.remove(idx);
+    }
+    if idx < out.argv_texts.len() {
+        out.argv_texts.remove(idx);
+    }
+    if idx < out.argv_kinds.len() {
+        out.argv_kinds.remove(idx);
+    }
+    if idx < out.single_token_word.len() {
+        out.single_token_word.remove(idx);
+    }
+    if let Some(expand) = out.expand_word.as_mut()
+        && idx < expand.len()
+    {
+        expand.remove(idx);
+    }
+    out
+}
+
 /// Synthesise [`CommandTokens`] marking every word as a single brace-string
 /// token — the verbatim fallback for a frozen loop with no recorded source
 /// tokens. See [`frozen_loop_tokens`].
@@ -624,6 +652,7 @@ impl CfgBuilder {
         let Statement::Foreach {
             is_dict_iteration,
             raw_args,
+            raw_tokens,
             iterators,
             is_lmap,
             span,
@@ -636,13 +665,22 @@ impl CfgBuilder {
         if *is_dict_iteration && !raw_args.is_empty() {
             let sub = &raw_args[0];
             let qual_cmd = format!("::tcl::dict::{sub}");
+            // The barrier re-emits `::tcl::dict::for {vars} $dict {body}` — the
+            // source `dict for …` tokens with the `for`/`map` subcommand word
+            // dropped — so the braced var-list / body push verbatim and the
+            // `$dict` argument substitutes (else the body's command subs are
+            // evaluated once, before the loop variables exist).
+            let args = raw_args[1..].to_vec();
+            let tokens = raw_tokens
+                .as_ref()
+                .map_or_else(|| all_str_tokens(&qual_cmd, &args), |t| drop_word(t, 1));
             self.block_mut(current).statements.push(Statement::Barrier {
                 span: *span,
                 reason: "dict for/map".into(),
                 command: qual_cmd,
                 canonical_command: None,
-                args: raw_args[1..].to_vec(),
-                tokens: None,
+                args,
+                tokens: Some(tokens),
             });
             return current.to_owned();
         }
@@ -663,7 +701,7 @@ impl CfgBuilder {
                 reads: vec![],
                 reads_own_defs: false,
                 safe_on_uninit: false,
-                tokens: None,
+                tokens: Some(frozen_loop_tokens(cmd, raw_args, raw_tokens.as_ref())),
                 foreach_groups: None,
             });
             return current.to_owned();
@@ -1610,6 +1648,7 @@ mod tests {
             is_lmap: false,
             raw_args: vec![],
             is_dict_iteration: false,
+            raw_tokens: None,
         }]);
         let func = build_cfg_function("::test", &script, true);
         let mut found_groups: Option<Vec<usize>> = None;

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -10,15 +10,55 @@
 
 use std::collections::{BTreeSet, HashMap};
 
-use tcl_lexer::Span;
+use tcl_lexer::{Span, TokenType};
 
 use crate::cfg::{Block, CfgModule, Function, LoopNode, Terminator};
 use crate::expr_ast::ExprNode;
-use crate::ir::{Module, Script, Statement};
+use crate::ir::{CommandTokens, Module, Script, Statement};
 use crate::ir_helpers::defs_from_ir_script;
 use crate::naming::normalise_var_name;
 
 use self::upvar_info::{UpvarInfo, collect_upvar_targets};
+
+/// Choose the [`CommandTokens`] for a "frozen" `while`/`for` runtime call.
+///
+/// The frozen-loop barrier hands the source words (the condition expression
+/// text, the body script text) to the runtime `while` / `for` builtin, which
+/// re-evaluates the condition and body on each iteration. Each word must be
+/// pushed *as written*: a braced `{cond}` / `{body}` word verbatim
+/// (substitution suppressed), a `$body` word interpolated. The codegen's
+/// [`emit_call`] decides this from `argv_kinds[i] == Str && single_token_word`,
+/// so the barrier needs the real per-word kinds.
+///
+/// `source` is the loop's recorded [`Statement::While::raw_tokens`] — the exact
+/// segmenter token metadata. When present (always, for lowered loops) it is
+/// used directly; the all-verbatim fallback ([`all_str_tokens`]) only covers
+/// synthetically-constructed loops that carry no token metadata, matching the
+/// braced-word idiom they are built from. Without this the words are pushed as
+/// interpolated literals and the condition's command substitution is evaluated
+/// *once* at the call site, freezing the loop (`while {[gets $f line] >= 0}`
+/// happens to work, but a bare `while {[string length $x]}` would spin forever).
+fn frozen_loop_tokens(cmd: &str, args: &[String], source: Option<&CommandTokens>) -> CommandTokens {
+    source.cloned().unwrap_or_else(|| all_str_tokens(cmd, args))
+}
+
+/// Synthesise [`CommandTokens`] marking every word as a single brace-string
+/// token — the verbatim fallback for a frozen loop with no recorded source
+/// tokens. See [`frozen_loop_tokens`].
+fn all_str_tokens(cmd: &str, args: &[String]) -> CommandTokens {
+    let word_count = 1 + args.len();
+    let mut argv_texts = Vec::with_capacity(word_count);
+    argv_texts.push(cmd.to_owned());
+    argv_texts.extend(args.iter().cloned());
+    CommandTokens {
+        argv: vec![Span::new(0, 0); word_count],
+        argv_texts,
+        argv_kinds: vec![TokenType::Str; word_count],
+        single_token_word: vec![true; word_count],
+        all_tokens: Vec::new(),
+        expand_word: None,
+    }
+}
 
 mod cfg_lower;
 pub mod upvar_info;
@@ -431,6 +471,7 @@ impl CfgBuilder {
                 Statement::For {
                     condition,
                     raw_args,
+                    raw_tokens,
                     span,
                     ..
                 } => {
@@ -444,7 +485,7 @@ impl CfgBuilder {
                                 command: "for".into(),
                                 canonical_command: None,
                                 args: raw_args.clone(),
-                                tokens: None,
+                                tokens: Some(frozen_loop_tokens("for", raw_args, raw_tokens.as_ref())),
                             });
                     } else {
                         current = self.lower_for(stmt, &current)?;
@@ -454,6 +495,7 @@ impl CfgBuilder {
                 Statement::While {
                     condition,
                     raw_args,
+                    raw_tokens,
                     span,
                     ..
                 } => {
@@ -466,7 +508,7 @@ impl CfgBuilder {
                                 command: "while".into(),
                                 canonical_command: None,
                                 args: raw_args.clone(),
-                                tokens: None,
+                                tokens: Some(frozen_loop_tokens("while", raw_args, raw_tokens.as_ref())),
                             });
                     } else {
                         current = self.lower_while(stmt, &current);

--- a/rust/tcl-compiler/src/codegen/helpers.rs
+++ b/rust/tcl-compiler/src/codegen/helpers.rs
@@ -517,8 +517,11 @@ pub fn fold_dict_create_cmd(value: &str) -> Option<String> {
 pub fn try_format_fold(value: &str) -> Option<String> {
     let inner = value.strip_prefix("[format ")?.strip_suffix(']')?;
 
-    // Parse the command parts (format string + arguments)
-    let parts = parse_format_parts(inner);
+    // Parse the command parts (format string + arguments). Bails (`None`) when
+    // any word is a runtime substitution (`$var` / `[cmd]`) rather than a
+    // compile-time constant — folding those would freeze the literal source
+    // text (`$cmd`) into the result instead of its value.
+    let parts = parse_format_parts(inner)?;
     if parts.is_empty() {
         return None;
     }
@@ -561,19 +564,24 @@ pub fn try_format_fold(value: &str) -> Option<String> {
     Some(result)
 }
 
-/// Parse the argument parts of a `format` command.
-fn parse_format_parts(inner: &str) -> Vec<String> {
+/// Parse the argument parts of a `format` command. Returns `None` when a word
+/// is a runtime substitution (a quoted or bare word containing an unescaped `$`
+/// or `[`) — such a word is not a compile-time constant and must not be folded.
+/// Braced words are always literal (Tcl braces suppress substitution).
+fn parse_format_parts(inner: &str) -> Option<Vec<String>> {
     let bytes = inner.as_bytes();
     let mut parts = Vec::new();
     let mut i = 0;
 
     while i < bytes.len() {
         match bytes[i] {
-            b' ' | b'\t' => i += 1,
+            b' ' | b'\t' | b'\n' | b'\r' => i += 1,
             b'"' => {
-                // Quoted string
+                // Quoted string — subject to substitution, so a `$`/`[` makes it
+                // non-constant (an escaped `\$`/`\[` stays literal).
                 i += 1;
                 let mut buf = String::new();
+                let mut subst = false;
                 while i < bytes.len() && bytes[i] != b'"' {
                     if bytes[i] == b'\\' {
                         if i + 1 < bytes.len() {
@@ -585,6 +593,9 @@ fn parse_format_parts(inner: &str) -> Vec<String> {
                             i += 1;
                         }
                     } else {
+                        if matches!(bytes[i], b'$' | b'[') {
+                            subst = true;
+                        }
                         buf.push(char::from(bytes[i]));
                         i += 1;
                     }
@@ -592,10 +603,13 @@ fn parse_format_parts(inner: &str) -> Vec<String> {
                 if i < bytes.len() {
                     i += 1; // skip closing "
                 }
+                if subst {
+                    return None;
+                }
                 parts.push(buf);
             }
             b'{' => {
-                // Braced string
+                // Braced string — always literal.
                 let mut depth: u32 = 0;
                 let start = i;
                 while i < bytes.len() {
@@ -613,17 +627,21 @@ fn parse_format_parts(inner: &str) -> Vec<String> {
                 parts.push(inner[start + 1..i.saturating_sub(1)].to_owned());
             }
             _ => {
-                // Bare word
+                // Bare word — a `$`/`[` makes it a substitution, not a constant.
                 let start = i;
-                while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t') {
+                while i < bytes.len() && !matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
                     i += 1;
                 }
-                parts.push(inner[start..i].to_owned());
+                let word = &inner[start..i];
+                if word.contains('$') || word.contains('[') {
+                    return None;
+                }
+                parts.push(word.to_owned());
             }
         }
     }
 
-    parts
+    Some(parts)
 }
 
 #[cfg(test)]
@@ -892,5 +910,29 @@ mod tests {
     #[test]
     fn format_fold_no_match() {
         assert_eq!(try_format_fold("not format"), None);
+    }
+
+    #[test]
+    fn format_fold_bails_on_variable_arg() {
+        // A `$var` argument is a runtime substitution, not a constant — folding
+        // it would freeze the literal text `$cmd` into the result.
+        assert_eq!(try_format_fold("[format {x %s} $cmd]"), None);
+        assert_eq!(try_format_fold("[format {%s} $cmd]"), None);
+    }
+
+    #[test]
+    fn format_fold_bails_on_command_sub_arg() {
+        assert_eq!(try_format_fold("[format {%s} [id]]"), None);
+    }
+
+    #[test]
+    fn format_fold_bails_on_quoted_subst() {
+        assert_eq!(try_format_fold("[format {%s} \"$x\"]"), None);
+    }
+
+    #[test]
+    fn format_fold_multiline_template_constant_args() {
+        // A multi-line braced template with constant args still folds.
+        assert_eq!(try_format_fold("[format {a\n%s} hi]"), Some("a\nhi".into()));
     }
 }

--- a/rust/tcl-compiler/src/codegen/values.rs
+++ b/rust/tcl-compiler/src/codegen/values.rs
@@ -5,7 +5,20 @@
 //! reference markers.  Ported from `core/compiler/codegen/_values.py`.
 
 use super::format::esc;
+use super::statements::has_unescaped_subst;
 use super::{CodegenCtx, Op, Operand, bytecode_imm};
+
+/// Whether `name` is a whole **bare** Tcl variable name — the run of characters
+/// a `$name` reference consumes: ASCII alphanumerics, `_`, and `:` (namespace
+/// separators). A name with any other character (`-`, `.`, `(`, `$`) is *not* a
+/// whole bare reference, so e.g. `$item-suffix` is `$item` followed by literal
+/// `-suffix`, not a variable called `item-suffix`.
+fn is_bare_var_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b':')
+}
 
 // -- Literal emission --
 
@@ -137,18 +150,53 @@ pub fn needs_stk_var_ref(name: &str, is_proc: bool) -> bool {
 impl CodegenCtx<'_> {
     /// Push an array element key onto the stack.
     ///
-    /// Handles `$var` references in the key by loading the variable.
-    /// For complex keys (containing `$` or `[`), falls through to a
-    /// literal push — full interpolation requires the main emitter.
+    /// A key that is *exactly* a whole variable reference (`${var}` or `$var`)
+    /// takes the [`load_var`](Self::load_var) fast path (matching tclsh's
+    /// `LOAD_SCALAR`-based key in proc context). A *composite* key that embeds
+    /// a substitution (`-$opt`, `x$item`, `${item}suf`, `$a([f])`) is built by
+    /// the full interpolation emitter so the substitution actually runs —
+    /// previously such keys were pushed as a raw literal, so the variable in
+    /// the index never expanded and the element lookup failed. A pure literal
+    /// key is pushed verbatim.
     pub fn push_array_key(&mut self, elem: &str) {
-        if let Some(inner) = elem.strip_prefix("${").and_then(|s| s.strip_suffix('}')) {
-            // Braced variable reference: ${var}
+        if let Some(inner) = elem
+            .strip_prefix("${")
+            .and_then(|s| s.strip_suffix('}'))
+            .filter(|inner| !inner.contains(['{', '}']))
+        {
+            // Whole braced variable reference: `${var}`.
             self.load_var(inner);
-        } else if let Some(var) = elem.strip_prefix('$') {
-            // Bare variable reference: $var
+        } else if let Some(var) = elem.strip_prefix('$').filter(|v| is_bare_var_name(v)) {
+            // Whole bare variable reference: `$var` (the name runs to the end).
             self.load_var(var);
+        } else if has_unescaped_subst(elem)
+            && let Some(parts) = super::helpers::parse_subst_template(elem)
+            && parts.len() > 1
+        {
+            // Composite key with an embedded substitution (`-$opt`, `x$item`,
+            // `${item}suf`, `$a([f])`): build the index string at compile time
+            // by concatenating the decoded parts. The runtime `subst_word`
+            // fallback only resolves a *normalised* `${name}`, so a bare `$item`
+            // inside the index would otherwise never expand.
+            for part in &parts {
+                match part {
+                    super::helpers::SubstPart::Lit(text) => self.push_lit(text),
+                    super::helpers::SubstPart::Cmd(cmd) => self.emit_inline_cmd_subst(cmd),
+                    super::helpers::SubstPart::Scalar(name) => {
+                        self.push_lit(name);
+                        self.emit(Op::LOAD_STK, vec![]);
+                    }
+                    super::helpers::SubstPart::Var(name) => self.load_var(name),
+                }
+            }
+            self.emit(
+                Op::STR_CONCAT1,
+                vec![Operand::Imm(
+                    i32::try_from(parts.len()).expect("array-key part count fits in i32"),
+                )],
+            );
         } else {
-            // Literal key (or complex key that needs the main emitter)
+            // Pure literal key (or a key the template parser left whole).
             self.push_lit(elem);
         }
     }

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -356,6 +356,13 @@ pub enum Statement {
         body_span: Span,
         /// Raw argument texts for generic fallback.
         raw_args: Vec<String>,
+        /// Per-word source token metadata for the generic ("frozen") runtime
+        /// fallback, when the loop cannot be inlined (a command-substitution
+        /// condition). Carries the original word kinds so the fallback pushes
+        /// braced `{cond}` / `{body}` words verbatim and substituted words
+        /// (`$body`) interpolated — exactly as written. `None` for
+        /// synthetically-constructed loops that never take the fallback.
+        raw_tokens: Option<CommandTokens>,
     },
 
     /// `while` loop: `while cond body`.
@@ -372,6 +379,9 @@ pub enum Statement {
         body_span: Span,
         /// Raw argument texts for generic fallback.
         raw_args: Vec<String>,
+        /// Per-word source token metadata for the generic ("frozen") runtime
+        /// fallback — see [`Statement::For::raw_tokens`].
+        raw_tokens: Option<CommandTokens>,
     },
 
     /// `foreach`/`lmap`/`dict for`/`dict map` loop.
@@ -867,6 +877,7 @@ mod tests {
             body: Script::new(),
             body_span: Span::new(32, 34),
             raw_args: Vec::new(),
+            raw_tokens: None,
         };
         assert_eq!(stmt.span(), Span::new(0, 40));
     }

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -400,6 +400,11 @@ pub enum Statement {
         raw_args: Vec<String>,
         /// Whether this is `dict for`/`dict map`.
         is_dict_iteration: bool,
+        /// Per-word source token metadata for the generic runtime fallback
+        /// (the `dict for`/`map` barrier and the runtime `foreach`/`lmap`
+        /// call), so braced var-lists / bodies are pushed verbatim and
+        /// `$list` arguments substituted — see [`Statement::For::raw_tokens`].
+        raw_tokens: Option<CommandTokens>,
     },
 
     /// `catch script ?resultVar? ?optionsVar?`.
@@ -975,6 +980,7 @@ mod tests {
             is_lmap: false,
             raw_args: Vec::new(),
             is_dict_iteration: true,
+            raw_tokens: None,
         };
         if let Statement::Foreach {
             iterators,

--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -504,6 +504,7 @@ mod tests {
             is_lmap: false,
             raw_args: vec![],
             is_dict_iteration: false,
+            raw_tokens: None,
         }]);
         assert_eq!(defs_from_ir_script(&script), vec!["k", "v"]);
     }

--- a/rust/tcl-compiler/src/lattice_rebase.rs
+++ b/rust/tcl-compiler/src/lattice_rebase.rs
@@ -149,6 +149,7 @@ fn rebase_statement(stmt: &mut Statement, delta: i64) {
             condition_span,
             body,
             body_span,
+            raw_tokens,
             ..
         } => {
             shift(span, delta);
@@ -159,18 +160,21 @@ fn rebase_statement(stmt: &mut Statement, delta: i64) {
             rebase_script(init, delta);
             rebase_script(next, delta);
             rebase_script(body, delta);
+            rebase_tokens(raw_tokens, delta);
         }
         Statement::While {
             span,
             condition_span,
             body,
             body_span,
+            raw_tokens,
             ..
         } => {
             shift(span, delta);
             shift(condition_span, delta);
             shift(body_span, delta);
             rebase_script(body, delta);
+            rebase_tokens(raw_tokens, delta);
         }
         Statement::Foreach {
             span,

--- a/rust/tcl-compiler/src/lattice_rebase.rs
+++ b/rust/tcl-compiler/src/lattice_rebase.rs
@@ -180,11 +180,13 @@ fn rebase_statement(stmt: &mut Statement, delta: i64) {
             span,
             body,
             body_span,
+            raw_tokens,
             ..
         } => {
             shift(span, delta);
             shift(body_span, delta);
             rebase_script(body, delta);
+            rebase_tokens(raw_tokens, delta);
         }
         Statement::Catch {
             span,

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -270,6 +270,7 @@ impl Lowerer<'_> {
             body,
             body_span: arg_tokens[3].span,
             raw_args: args.to_vec(),
+            raw_tokens: Some(Self::cmd_tokens(seg)),
         }
     }
 
@@ -297,6 +298,7 @@ impl Lowerer<'_> {
             body,
             body_span: arg_tokens[1].span,
             raw_args: args.to_vec(),
+            raw_tokens: Some(Self::cmd_tokens(seg)),
         }
     }
 

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -362,6 +362,7 @@ impl Lowerer<'_> {
             is_lmap,
             raw_args: args.to_vec(),
             is_dict_iteration: false,
+            raw_tokens: Some(Self::cmd_tokens(seg)),
         }
     }
 
@@ -440,6 +441,7 @@ impl Lowerer<'_> {
             is_lmap: false,
             raw_args: args.to_vec(),
             is_dict_iteration: false,
+            raw_tokens: Some(Self::cmd_tokens(seg)),
         }
     }
 
@@ -784,6 +786,7 @@ impl Lowerer<'_> {
                     is_lmap: sub == "map",
                     raw_args: args.to_vec(),
                     is_dict_iteration: true,
+                    raw_tokens: Some(Self::cmd_tokens(seg)),
                 }
             }
 

--- a/rust/tcl-compiler/src/static_loops.rs
+++ b/rust/tcl-compiler/src/static_loops.rs
@@ -518,6 +518,7 @@ mod tests {
             body: empty_script(),
             body_span: sp(),
             raw_args: Vec::new(),
+            raw_tokens: None,
         };
         let env = summarise_for_statement(&for_stmt, &StaticEnv::new(), 100).expect("summarised");
         assert_eq!(env.get("i"), Some(&StaticValue::Int(2)));

--- a/rust/tcl-debugger/Cargo.toml
+++ b/rust/tcl-debugger/Cargo.toml
@@ -1,0 +1,25 @@
+# `tcl-debugger` — step debugger for the native Tcl VM.
+#
+# Rust port of `tooling/debugger/`: a `DebugController` (breakpoints + a
+# step-mode state machine) drives a `DebugBackend` (the debug engine). The VM
+# backend runs the script on `tcl-vm`, calling the controller's step hook at
+# each source-line boundary; the controller decides whether to pause.
+#
+# Status: the controller (step-mode decision logic), the shared types, and the
+# backend contract are portable and land here. The live VM backend is gated on
+# `tcl-vm` exposing a per-statement debug hook with source-line + frame-level
+# info (tracked under RT-VM) — see the `backend` module.
+[package]
+name = "tcl-debugger"
+description = "Step debugger for the native Tcl VM: breakpoints, step-mode controller, backend contract"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/rust/tcl-debugger/Cargo.toml
+++ b/rust/tcl-debugger/Cargo.toml
@@ -28,6 +28,7 @@ tcl-vm = { path = "../tcl-vm" }
 tcl-compiler = { path = "../tcl-compiler" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-bytecode = { path = "../tcl-bytecode" }
+serde_json = { version = "1", features = ["preserve_order"] }
 
 [lints]
 workspace = true

--- a/rust/tcl-debugger/Cargo.toml
+++ b/rust/tcl-debugger/Cargo.toml
@@ -20,6 +20,10 @@ repository.workspace = true
 authors.workspace = true
 
 [dependencies]
+tcl-vm = { path = "../tcl-vm" }
+tcl-compiler = { path = "../tcl-compiler" }
+tcl-registry = { path = "../tcl-registry" }
+tcl-bytecode = { path = "../tcl-bytecode" }
 
 [lints]
 workspace = true

--- a/rust/tcl-debugger/Cargo.toml
+++ b/rust/tcl-debugger/Cargo.toml
@@ -19,6 +19,10 @@ license.workspace = true
 repository.workspace = true
 authors.workspace = true
 
+[[bin]]
+name = "tcl-debug"
+path = "src/main.rs"
+
 [dependencies]
 tcl-vm = { path = "../tcl-vm" }
 tcl-compiler = { path = "../tcl-compiler" }

--- a/rust/tcl-debugger/src/backend.rs
+++ b/rust/tcl-debugger/src/backend.rs
@@ -1,0 +1,189 @@
+//! The debug-engine contract. Port of `tooling/debugger/backends/base.py`.
+//!
+//! A backend owns a running (or launchable) script and exposes execution
+//! control + state inspection. The VM backend ([`VmBackend`], below) runs the
+//! script on `tcl-vm` and drives a [`crate::controller::DebugController`] from
+//! the VM's per-statement hook.
+//!
+//! # The VM hook (RT-VM-gated)
+//!
+//! The live VM backend needs `tcl-vm` to call a hook at each source-line
+//! boundary with `(source_line, frame_level, command_text, stack)` and to act
+//! on the returned [`crate::types::DebugAction`] — i.e. an interpreter that can
+//! *pause between statements*. The VM has no such hook yet (tracked under
+//! **RT-VM**: an execution-control seam in the exec loop plus a bytecode-PC →
+//! source-line map). Until it lands, [`VmBackend`] reports
+//! [`DebugError::Unsupported`], while the controller, types, and this contract
+//! are usable and tested.
+
+use crate::types::{StackFrame, StopEvent, Variable};
+
+/// Errors a backend can surface.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum DebugError {
+    /// The operation needs a capability the backend does not yet have (the VM
+    /// per-statement hook). Carries a human-readable reason.
+    Unsupported(String),
+    /// A launch / runtime failure.
+    Failed(String),
+}
+
+impl std::fmt::Display for DebugError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Unsupported(m) => write!(f, "unsupported: {m}"),
+            Self::Failed(m) => write!(f, "{m}"),
+        }
+    }
+}
+
+impl std::error::Error for DebugError {}
+
+/// Common interface for all debug backends. Mirrors `DebugBackend` (base.py).
+pub trait DebugBackend {
+    /// Load a script for debugging (from `source` if given, else `path`).
+    ///
+    /// # Errors
+    /// If the script cannot be prepared.
+    fn launch(&mut self, path: &str, source: Option<&str>) -> Result<(), DebugError>;
+
+    /// Set line breakpoints; return the accepted lines.
+    ///
+    /// # Errors
+    /// If breakpoints cannot be applied.
+    fn set_breakpoints(&mut self, lines: &[u32]) -> Result<Vec<u32>, DebugError>;
+
+    /// Resume until the next breakpoint or the end.
+    ///
+    /// # Errors
+    /// On a runtime failure.
+    fn continue_execution(&mut self) -> Result<(), DebugError>;
+
+    /// Execute one statement, stepping into calls.
+    ///
+    /// # Errors
+    /// On a runtime failure.
+    fn step_in(&mut self) -> Result<(), DebugError>;
+
+    /// Execute one statement, stepping over calls.
+    ///
+    /// # Errors
+    /// On a runtime failure.
+    fn step_over(&mut self) -> Result<(), DebugError>;
+
+    /// Run until the current procedure returns.
+    ///
+    /// # Errors
+    /// On a runtime failure.
+    fn step_out(&mut self) -> Result<(), DebugError>;
+
+    /// The current call stack (top first).
+    ///
+    /// # Errors
+    /// If the stack cannot be read.
+    fn stack_trace(&self) -> Result<Vec<StackFrame>, DebugError>;
+
+    /// Variables visible in the given frame.
+    ///
+    /// # Errors
+    /// If the scope cannot be read.
+    fn variables(&self, frame_id: u32) -> Result<Vec<Variable>, DebugError>;
+
+    /// Evaluate a Tcl expression in the current context.
+    ///
+    /// # Errors
+    /// If evaluation fails.
+    fn evaluate(&mut self, expression: &str) -> Result<String, DebugError>;
+
+    /// Terminate the session.
+    fn terminate(&mut self);
+
+    /// The most recent stop event, if the backend is paused.
+    fn last_stop(&self) -> Option<&StopEvent>;
+}
+
+/// The native-VM backend. Drives the script on `tcl-vm` and reports stops via a
+/// [`crate::controller::DebugController`].
+///
+/// Currently a placeholder: every control operation returns
+/// [`DebugError::Unsupported`] because the VM has no per-statement debug hook
+/// yet (see the module docs). Wiring it is the RT-VM-gated remainder of
+/// **TOOL-DEBUGGER**; this type fixes the shape the wiring fills in.
+#[derive(Debug, Default)]
+pub struct VmBackend {
+    script: Option<String>,
+}
+
+impl VmBackend {
+    /// Construct an (unwired) VM backend.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    fn unsupported<T>() -> Result<T, DebugError> {
+        Err(DebugError::Unsupported(
+            "tcl-vm has no per-statement debug hook yet (RT-VM)".to_owned(),
+        ))
+    }
+}
+
+impl DebugBackend for VmBackend {
+    fn launch(&mut self, path: &str, source: Option<&str>) -> Result<(), DebugError> {
+        // Loading the script text is fine; only *stepping* it needs the hook.
+        self.script = Some(match source {
+            Some(s) => s.to_owned(),
+            None => std::fs::read_to_string(path).map_err(|e| DebugError::Failed(e.to_string()))?,
+        });
+        Ok(())
+    }
+
+    fn set_breakpoints(&mut self, lines: &[u32]) -> Result<Vec<u32>, DebugError> {
+        // Accept the lines; line→PC validation needs the bytecode/line map.
+        Ok(lines.to_vec())
+    }
+
+    fn continue_execution(&mut self) -> Result<(), DebugError> {
+        Self::unsupported()
+    }
+    fn step_in(&mut self) -> Result<(), DebugError> {
+        Self::unsupported()
+    }
+    fn step_over(&mut self) -> Result<(), DebugError> {
+        Self::unsupported()
+    }
+    fn step_out(&mut self) -> Result<(), DebugError> {
+        Self::unsupported()
+    }
+    fn stack_trace(&self) -> Result<Vec<StackFrame>, DebugError> {
+        Self::unsupported()
+    }
+    fn variables(&self, _frame_id: u32) -> Result<Vec<Variable>, DebugError> {
+        Self::unsupported()
+    }
+    fn evaluate(&mut self, _expression: &str) -> Result<String, DebugError> {
+        Self::unsupported()
+    }
+    fn terminate(&mut self) {
+        self.script = None;
+    }
+    fn last_stop(&self) -> Option<&StopEvent> {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn vm_backend_launches_but_cannot_step_yet() {
+        let mut b = VmBackend::new();
+        b.launch("x.tcl", Some("set x 1\nputs $x\n")).expect("launch");
+        assert_eq!(b.set_breakpoints(&[2]).unwrap(), vec![2]);
+        assert!(matches!(b.step_in(), Err(DebugError::Unsupported(_))));
+        assert!(matches!(b.stack_trace(), Err(DebugError::Unsupported(_))));
+        assert!(b.last_stop().is_none());
+        b.terminate();
+    }
+}

--- a/rust/tcl-debugger/src/backend.rs
+++ b/rust/tcl-debugger/src/backend.rs
@@ -1,31 +1,39 @@
-//! The debug-engine contract. Port of `tooling/debugger/backends/base.py`.
+//! The debug-engine contract + the native record-and-replay VM backend.
 //!
-//! A backend owns a running (or launchable) script and exposes execution
-//! control + state inspection. The VM backend ([`VmBackend`], below) runs the
-//! script on `tcl-vm` and drives a [`crate::controller::DebugController`] from
-//! the VM's per-statement hook.
+//! Port of `tooling/debugger/backends/base.py` (the contract) and the VM
+//! backend. The [`VmBackend`] runs the script once on `tcl-vm` with a recording
+//! debug hook installed (the [`tcl_vm::Vm::set_debug_hook`] seam), capturing a
+//! [`tcl_vm::DebugSnapshot`] at every command boundary, then serves
+//! stepping / inspection by navigating that trace with a
+//! [`crate::controller::DebugController`].
 //!
-//! # The VM hook (RT-VM-gated)
-//!
-//! The live VM backend needs `tcl-vm` to call a hook at each source-line
-//! boundary with `(source_line, frame_level, command_text, stack)` and to act
-//! on the returned [`crate::types::DebugAction`] — i.e. an interpreter that can
-//! *pause between statements*. The VM has no such hook yet (tracked under
-//! **RT-VM**: an execution-control seam in the exec loop plus a bytecode-PC →
-//! source-line map). Until it lands, [`VmBackend`] reports
-//! [`DebugError::Unsupported`], while the controller, types, and this contract
-//! are usable and tested.
+//! Record-and-replay avoids threading the debugger across a live, paused
+//! interpreter: the full execution trace (line, stack, variables per command)
+//! is captured up front, and `step_in`/`over`/`out`/`continue` move a cursor
+//! over it. The trade-off is that `evaluate` only sees variables already
+//! captured at the current step (no arbitrary re-execution).
 
-use crate::types::{StackFrame, StopEvent, Variable};
+use std::cell::RefCell;
+use std::rc::Rc;
+
+use tcl_compiler::cfg_builder::build_cfg_codegen as build_cfg;
+use tcl_compiler::codegen::codegen_module;
+use tcl_compiler::lowering::lower_to_ir_for_bytecode as lower_to_ir;
+use tcl_registry::CommandRegistry;
+use tcl_vm::{CompileError, CompileService, DebugAction, DebugSnapshot, Vm};
+
+use crate::controller::DebugController;
+use crate::types::{StackFrame, StepMode, StopEvent, StopReason, Variable, VariableKind};
 
 /// Errors a backend can surface.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum DebugError {
-    /// The operation needs a capability the backend does not yet have (the VM
-    /// per-statement hook). Carries a human-readable reason.
+    /// The operation needs a capability the backend does not have.
     Unsupported(String),
     /// A launch / runtime failure.
     Failed(String),
+    /// The script has run to completion — there is nothing more to step.
+    Finished,
 }
 
 impl std::fmt::Display for DebugError {
@@ -33,6 +41,7 @@ impl std::fmt::Display for DebugError {
         match self {
             Self::Unsupported(m) => write!(f, "unsupported: {m}"),
             Self::Failed(m) => write!(f, "{m}"),
+            Self::Finished => write!(f, "program has finished"),
         }
     }
 }
@@ -41,10 +50,11 @@ impl std::error::Error for DebugError {}
 
 /// Common interface for all debug backends. Mirrors `DebugBackend` (base.py).
 pub trait DebugBackend {
-    /// Load a script for debugging (from `source` if given, else `path`).
+    /// Load a script for debugging (from `source` if given, else `path`) and
+    /// stop at the first statement.
     ///
     /// # Errors
-    /// If the script cannot be prepared.
+    /// If the script cannot be prepared or compiled.
     fn launch(&mut self, path: &str, source: Option<&str>) -> Result<(), DebugError>;
 
     /// Set line breakpoints; return the accepted lines.
@@ -56,134 +66,330 @@ pub trait DebugBackend {
     /// Resume until the next breakpoint or the end.
     ///
     /// # Errors
-    /// On a runtime failure.
+    /// [`DebugError::Finished`] when the program has ended.
     fn continue_execution(&mut self) -> Result<(), DebugError>;
 
     /// Execute one statement, stepping into calls.
     ///
     /// # Errors
-    /// On a runtime failure.
+    /// [`DebugError::Finished`] when the program has ended.
     fn step_in(&mut self) -> Result<(), DebugError>;
 
     /// Execute one statement, stepping over calls.
     ///
     /// # Errors
-    /// On a runtime failure.
+    /// [`DebugError::Finished`] when the program has ended.
     fn step_over(&mut self) -> Result<(), DebugError>;
 
     /// Run until the current procedure returns.
     ///
     /// # Errors
-    /// On a runtime failure.
+    /// [`DebugError::Finished`] when the program has ended.
     fn step_out(&mut self) -> Result<(), DebugError>;
 
     /// The current call stack (top first).
     ///
     /// # Errors
-    /// If the stack cannot be read.
+    /// If the backend is not paused at a statement.
     fn stack_trace(&self) -> Result<Vec<StackFrame>, DebugError>;
 
-    /// Variables visible in the given frame.
+    /// Variables visible in the given frame (`0` = top).
     ///
     /// # Errors
-    /// If the scope cannot be read.
+    /// If the backend is not paused at a statement.
     fn variables(&self, frame_id: u32) -> Result<Vec<Variable>, DebugError>;
 
-    /// Evaluate a Tcl expression in the current context.
+    /// Evaluate a simple variable reference (`$name` / `name`) at the current
+    /// step.
     ///
     /// # Errors
-    /// If evaluation fails.
+    /// [`DebugError::Unsupported`] for anything but a captured variable.
     fn evaluate(&mut self, expression: &str) -> Result<String, DebugError>;
 
     /// Terminate the session.
     fn terminate(&mut self);
 
-    /// The most recent stop event, if the backend is paused.
+    /// The most recent stop event, if paused.
     fn last_stop(&self) -> Option<&StopEvent>;
 }
 
-/// The native-VM backend. Drives the script on `tcl-vm` and reports stops via a
-/// [`crate::controller::DebugController`].
-///
-/// Currently a placeholder: every control operation returns
-/// [`DebugError::Unsupported`] because the VM has no per-statement debug hook
-/// yet (see the module docs). Wiring it is the RT-VM-gated remainder of
-/// **TOOL-DEBUGGER**; this type fixes the shape the wiring fills in.
-#[derive(Debug, Default)]
+/// The `CompileService` the VM uses to compile the script and any runtime
+/// `eval` / command substitution: the real Rust compiler pipeline.
+struct Svc(CommandRegistry);
+
+impl CompileService for Svc {
+    type Module = tcl_bytecode::ModuleAsm;
+    fn compile(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let ir = lower_to_ir(src, &self.0);
+        let cfg = build_cfg(&ir, false);
+        Ok(codegen_module(&cfg, &ir, &self.0))
+    }
+}
+
+/// The native record-and-replay VM backend.
+#[derive(Default)]
 pub struct VmBackend {
-    script: Option<String>,
+    /// Every command-boundary snapshot, in execution order.
+    trace: Vec<DebugSnapshot>,
+    /// Index into `trace` of the current stop, once launched.
+    cursor: Option<usize>,
+    controller: DebugController,
+    last_stop: Option<StopEvent>,
 }
 
 impl VmBackend {
-    /// Construct an (unwired) VM backend.
+    /// Construct a VM backend.
     #[must_use]
     pub fn new() -> Self {
         Self::default()
     }
 
-    fn unsupported<T>() -> Result<T, DebugError> {
-        Err(DebugError::Unsupported(
-            "tcl-vm has no per-statement debug hook yet (RT-VM)".to_owned(),
-        ))
+    /// Compile and run `source`, capturing the execution trace.
+    fn record(source: &str) -> Result<Vec<DebugSnapshot>, DebugError> {
+        let registry = CommandRegistry::build_default();
+        let module = Svc(CommandRegistry::build_default())
+            .compile(source)
+            .map_err(|e| DebugError::Failed(e.0))?;
+
+        let trace: Rc<RefCell<Vec<DebugSnapshot>>> = Rc::new(RefCell::new(Vec::new()));
+        let sink = Rc::clone(&trace);
+
+        let mut vm = Vm::new();
+        vm.set_compiler(Box::new(Svc(registry)));
+        vm.set_debug_hook(Some(Box::new(move |snap: &DebugSnapshot| {
+            sink.borrow_mut().push(snap.clone());
+            DebugAction::Continue
+        })));
+        let _ = vm.run_module(&module);
+        vm.set_debug_hook(None);
+
+        Ok(Rc::try_unwrap(trace)
+            .map(RefCell::into_inner)
+            .unwrap_or_default())
+    }
+
+    /// The snapshot at the current cursor, or `None` before launch / at end.
+    fn current(&self) -> Option<&DebugSnapshot> {
+        self.cursor.and_then(|i| self.trace.get(i))
+    }
+
+    /// Advance the cursor to the next trace index the controller stops at under
+    /// `mode`, anchored at the current frame level. Updates `last_stop`.
+    fn advance(&mut self, mode: StepMode) -> Result<(), DebugError> {
+        let Some(cur) = self.cursor else {
+            return Err(DebugError::Finished);
+        };
+        let anchor = self.trace.get(cur).map_or(0, |s| s.level);
+        self.controller.resume(mode, anchor);
+        let mut i = cur + 1;
+        while i < self.trace.len() {
+            let snap = &self.trace[i];
+            if self.controller.should_stop(snap.line, snap.level).is_some() {
+                self.cursor = Some(i);
+                self.controller.anchor(snap.level);
+                self.set_stop(i);
+                return Ok(());
+            }
+            i += 1;
+        }
+        // Nothing left to stop at — the program has finished.
+        self.cursor = None;
+        self.last_stop = None;
+        Err(DebugError::Finished)
+    }
+
+    /// Record the stop event for trace index `i`.
+    fn set_stop(&mut self, i: usize) {
+        let snap = &self.trace[i];
+        let reason = if self.controller.breakpoints().contains(&snap.line) {
+            StopReason::Breakpoint
+        } else {
+            StopReason::Step
+        };
+        self.last_stop = Some(StopEvent {
+            line: snap.line,
+            command_text: snap.command_text.clone(),
+            reason,
+            frames: frames_of(snap),
+        });
     }
 }
 
 impl DebugBackend for VmBackend {
     fn launch(&mut self, path: &str, source: Option<&str>) -> Result<(), DebugError> {
-        // Loading the script text is fine; only *stepping* it needs the hook.
-        self.script = Some(match source {
+        let src = match source {
             Some(s) => s.to_owned(),
             None => std::fs::read_to_string(path).map_err(|e| DebugError::Failed(e.to_string()))?,
-        });
+        };
+        self.trace = Self::record(&src)?;
+        self.controller = DebugController::new();
+        if self.trace.is_empty() {
+            self.cursor = None;
+            self.last_stop = None;
+        } else {
+            // Stop at entry (the first command).
+            self.cursor = Some(0);
+            self.controller.anchor(self.trace[0].level);
+            self.last_stop = Some(StopEvent {
+                line: self.trace[0].line,
+                command_text: self.trace[0].command_text.clone(),
+                reason: StopReason::Entry,
+                frames: frames_of(&self.trace[0]),
+            });
+        }
         Ok(())
     }
 
     fn set_breakpoints(&mut self, lines: &[u32]) -> Result<Vec<u32>, DebugError> {
-        // Accept the lines; line→PC validation needs the bytecode/line map.
-        Ok(lines.to_vec())
+        Ok(self.controller.set_breakpoints(lines.iter().copied()))
     }
 
     fn continue_execution(&mut self) -> Result<(), DebugError> {
-        Self::unsupported()
+        self.advance(StepMode::Continue)
     }
     fn step_in(&mut self) -> Result<(), DebugError> {
-        Self::unsupported()
+        self.advance(StepMode::StepIn)
     }
     fn step_over(&mut self) -> Result<(), DebugError> {
-        Self::unsupported()
+        self.advance(StepMode::StepOver)
     }
     fn step_out(&mut self) -> Result<(), DebugError> {
-        Self::unsupported()
+        self.advance(StepMode::StepOut)
     }
+
     fn stack_trace(&self) -> Result<Vec<StackFrame>, DebugError> {
-        Self::unsupported()
+        self.current()
+            .map(frames_of)
+            .ok_or(DebugError::Finished)
     }
-    fn variables(&self, _frame_id: u32) -> Result<Vec<Variable>, DebugError> {
-        Self::unsupported()
+
+    fn variables(&self, frame_id: u32) -> Result<Vec<Variable>, DebugError> {
+        // The trace captures the *current* frame's variables; frame 0 is the
+        // only inspectable scope in replay mode.
+        if frame_id != 0 {
+            return Ok(Vec::new());
+        }
+        let snap = self.current().ok_or(DebugError::Finished)?;
+        Ok(snap
+            .variables
+            .iter()
+            .map(|v| Variable {
+                name: v.name.clone(),
+                value: v.value.clone(),
+                kind: VariableKind::Scalar,
+                alias_target: None,
+                children: Vec::new(),
+            })
+            .collect())
     }
-    fn evaluate(&mut self, _expression: &str) -> Result<String, DebugError> {
-        Self::unsupported()
+
+    fn evaluate(&mut self, expression: &str) -> Result<String, DebugError> {
+        let name = expression.strip_prefix('$').unwrap_or(expression);
+        let snap = self.current().ok_or(DebugError::Finished)?;
+        snap.variables
+            .iter()
+            .find(|v| v.name == name)
+            .map(|v| v.value.clone())
+            .ok_or_else(|| {
+                DebugError::Unsupported(format!(
+                    "replay evaluate only resolves captured variables, not {expression:?}"
+                ))
+            })
     }
+
     fn terminate(&mut self) {
-        self.script = None;
+        self.trace.clear();
+        self.cursor = None;
+        self.last_stop = None;
     }
+
     fn last_stop(&self) -> Option<&StopEvent> {
-        None
+        self.last_stop.as_ref()
     }
+}
+
+/// Convert a VM snapshot's stack into debugger [`StackFrame`]s.
+fn frames_of(snap: &DebugSnapshot) -> Vec<StackFrame> {
+    snap.stack
+        .iter()
+        .enumerate()
+        .map(|(id, fr)| StackFrame {
+            id: u32::try_from(id).unwrap_or(0),
+            name: fr.name.clone(),
+            // Each frame's active line is the snapshot line for the top frame;
+            // deeper frames keep the call-site line the VM recorded.
+            line: snap.line,
+            namespace: fr.namespace.clone(),
+        })
+        .collect()
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn vm_backend_launches_but_cannot_step_yet() {
+    fn launched(src: &str) -> VmBackend {
         let mut b = VmBackend::new();
-        b.launch("x.tcl", Some("set x 1\nputs $x\n")).expect("launch");
-        assert_eq!(b.set_breakpoints(&[2]).unwrap(), vec![2]);
-        assert!(matches!(b.step_in(), Err(DebugError::Unsupported(_))));
-        assert!(matches!(b.stack_trace(), Err(DebugError::Unsupported(_))));
+        b.launch("x.tcl", Some(src)).expect("launch");
+        b
+    }
+
+    #[test]
+    fn launch_stops_at_entry_with_first_line() {
+        let b = launched("set x 1\nset y 2\nputs $x\n");
+        let stop = b.last_stop().expect("entry stop");
+        assert_eq!(stop.reason, StopReason::Entry);
+        assert_eq!(stop.line, 1);
+    }
+
+    #[test]
+    fn step_in_walks_lines_and_sees_variables() {
+        let mut b = launched("set x 1\nset y 2\nputs $x\n");
+        b.step_in().expect("step to line 2");
+        assert_eq!(b.last_stop().unwrap().line, 2);
+        // After `set x 1` ran, x is visible.
+        let vars = b.variables(0).expect("vars");
+        assert!(vars.iter().any(|v| v.name == "x" && v.value == "1"), "{vars:?}");
+        assert_eq!(b.evaluate("$x").unwrap(), "1");
+    }
+
+    #[test]
+    fn continue_stops_at_breakpoint() {
+        let mut b = launched("set a 1\nset b 2\nset c 3\nset d 4\n");
+        b.set_breakpoints(&[3]).expect("bp");
+        b.continue_execution().expect("run to bp");
+        assert_eq!(b.last_stop().unwrap().line, 3);
+        assert_eq!(b.last_stop().unwrap().reason, StopReason::Breakpoint);
+    }
+
+    #[test]
+    fn step_over_does_not_descend_into_a_proc() {
+        // The proc body runs at a deeper level; step-over from the call should
+        // land on the next top-level line, not inside the proc.
+        let src = "proc f {} {\n  set inner 9\n}\nf\nset after 1\n";
+        let mut b = launched(src);
+        // Walk to the `f` call line.
+        let mut guard = 0;
+        while b.last_stop().is_some_and(|s| s.command_text.trim() != "f") && guard < 50 {
+            if b.step_in().is_err() {
+                break;
+            }
+            guard += 1;
+        }
+        // From the call, stepping over should not stop inside f's body.
+        if b.last_stop().is_some_and(|s| s.command_text.trim() == "f") {
+            let _ = b.step_over();
+            if let Some(stop) = b.last_stop() {
+                assert_ne!(stop.command_text.trim(), "set inner 9");
+            }
+        }
+    }
+
+    #[test]
+    fn run_to_completion_reports_finished() {
+        let mut b = launched("set x 1\n");
+        // Only one command — continuing past it finishes.
+        assert_eq!(b.continue_execution(), Err(DebugError::Finished));
         assert!(b.last_stop().is_none());
-        b.terminate();
     }
 }

--- a/rust/tcl-debugger/src/controller.rs
+++ b/rust/tcl-debugger/src/controller.rs
@@ -1,0 +1,166 @@
+//! The debug controller: breakpoints + the step-mode decision logic.
+//!
+//! Port of `tooling/debugger/controller.py`'s decision core. The VM backend
+//! calls [`DebugController::should_stop`] at each source-line boundary with the
+//! current line and frame level; the controller decides whether to pause
+//! (breakpoint hit, or the active step mode is satisfied). When the frontend
+//! resumes, it calls [`DebugController::resume`] with the next [`StepMode`],
+//! which re-anchors the step depth to the frame the VM stopped in.
+//!
+//! This is the portable, VM-independent heart of the debugger and is fully
+//! unit-tested; the threading/IO coordination lives in the backend.
+
+use std::collections::BTreeSet;
+
+use crate::types::{StepMode, StopReason};
+
+/// Breakpoints + step-mode state.
+#[derive(Debug)]
+pub struct DebugController {
+    breakpoints: BTreeSet<u32>,
+    step_mode: StepMode,
+    /// The frame level the current step was anchored at.
+    step_depth: u32,
+}
+
+impl Default for DebugController {
+    fn default() -> Self {
+        Self {
+            breakpoints: BTreeSet::new(),
+            // Stop at the first line, like the Python controller.
+            step_mode: StepMode::StepIn,
+            step_depth: 0,
+        }
+    }
+}
+
+impl DebugController {
+    /// A fresh controller that stops at program entry.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Add a line breakpoint; returns the line (accepted as-is — line→PC
+    /// validation is the backend's concern).
+    pub fn add_breakpoint(&mut self, line: u32) -> u32 {
+        self.breakpoints.insert(line);
+        line
+    }
+
+    /// Remove a line breakpoint.
+    pub fn remove_breakpoint(&mut self, line: u32) {
+        self.breakpoints.remove(&line);
+    }
+
+    /// Replace the breakpoint set; returns the accepted lines, sorted.
+    pub fn set_breakpoints(&mut self, lines: impl IntoIterator<Item = u32>) -> Vec<u32> {
+        self.breakpoints = lines.into_iter().collect();
+        self.breakpoints.iter().copied().collect()
+    }
+
+    /// The current breakpoints, sorted.
+    #[must_use]
+    pub fn breakpoints(&self) -> Vec<u32> {
+        self.breakpoints.iter().copied().collect()
+    }
+
+    /// The active step mode.
+    #[must_use]
+    pub fn step_mode(&self) -> StepMode {
+        self.step_mode
+    }
+
+    /// Decide whether to pause at a source-line boundary, given the line and
+    /// the current frame `level`. Mirrors `controller.py::debug_hook`'s
+    /// stop decision.
+    ///
+    /// Returns `Some(reason)` to stop (and the reason to report), or `None` to
+    /// keep running. On a stop, the caller should [`resume`](Self::resume) with
+    /// the frontend's chosen mode before continuing.
+    #[must_use]
+    pub fn should_stop(&self, line: u32, level: u32) -> Option<StopReason> {
+        if self.breakpoints.contains(&line) {
+            return Some(StopReason::Breakpoint);
+        }
+        let step_hit = match self.step_mode {
+            StepMode::StepIn => true,
+            StepMode::StepOver => level <= self.step_depth,
+            StepMode::StepOut => level < self.step_depth,
+            StepMode::Continue => false,
+        };
+        step_hit.then_some(StopReason::Step)
+    }
+
+    /// Record that the VM has paused in a frame at `level` — anchors the step
+    /// depth so a subsequent `StepOver`/`StepOut` measures against it.
+    pub fn anchor(&mut self, level: u32) {
+        self.step_depth = level;
+    }
+
+    /// Apply the frontend's resume decision: set the next step mode and
+    /// re-anchor the depth to the frame just stopped in.
+    pub fn resume(&mut self, mode: StepMode, level: u32) {
+        self.step_mode = mode;
+        self.step_depth = level;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn entry_stops_at_first_line() {
+        let c = DebugController::new();
+        // Fresh controller is StepIn → stops at the first line in any frame.
+        assert_eq!(c.should_stop(1, 0), Some(StopReason::Step));
+    }
+
+    #[test]
+    fn breakpoint_stops_regardless_of_mode() {
+        let mut c = DebugController::new();
+        c.resume(StepMode::Continue, 0);
+        c.add_breakpoint(5);
+        assert_eq!(c.should_stop(5, 0), Some(StopReason::Breakpoint));
+        assert_eq!(c.should_stop(6, 0), None);
+    }
+
+    #[test]
+    fn continue_only_stops_on_breakpoints() {
+        let mut c = DebugController::new();
+        c.resume(StepMode::Continue, 0);
+        assert_eq!(c.should_stop(1, 0), None);
+        assert_eq!(c.should_stop(1, 3), None);
+    }
+
+    #[test]
+    fn step_over_skips_deeper_frames() {
+        let mut c = DebugController::new();
+        // Stopped at level 1; step over.
+        c.resume(StepMode::StepOver, 1);
+        // A call descends to level 2 — do not stop.
+        assert_eq!(c.should_stop(10, 2), None);
+        // Back in the same frame — stop.
+        assert_eq!(c.should_stop(11, 1), Some(StopReason::Step));
+        // Returned to a shallower frame — also stop.
+        assert_eq!(c.should_stop(12, 0), Some(StopReason::Step));
+    }
+
+    #[test]
+    fn step_out_stops_only_when_shallower() {
+        let mut c = DebugController::new();
+        c.resume(StepMode::StepOut, 2);
+        assert_eq!(c.should_stop(10, 2), None); // same frame
+        assert_eq!(c.should_stop(10, 3), None); // deeper
+        assert_eq!(c.should_stop(10, 1), Some(StopReason::Step)); // returned
+    }
+
+    #[test]
+    fn breakpoint_set_roundtrips_sorted() {
+        let mut c = DebugController::new();
+        assert_eq!(c.set_breakpoints([7, 2, 5, 2]), vec![2, 5, 7]);
+        c.remove_breakpoint(5);
+        assert_eq!(c.breakpoints(), vec![2, 7]);
+    }
+}

--- a/rust/tcl-debugger/src/dap.rs
+++ b/rust/tcl-debugger/src/dap.rs
@@ -1,0 +1,411 @@
+//! A Debug Adapter Protocol (DAP) server over the [`crate::VmBackend`].
+//!
+//! Speaks the subset of DAP an editor needs to drive the record-and-replay
+//! debugger: `initialize` / `launch` / `setBreakpoints` / `configurationDone` /
+//! `threads` / `stackTrace` / `scopes` / `variables` / `continue` / `next` /
+//! `stepIn` / `stepOut` / `evaluate` / `disconnect`, plus the `initialized` /
+//! `stopped` / `terminated` / `output` events. Messages are
+//! `Content-Length`-framed JSON over a reader/writer pair (stdin/stdout for a
+//! real adapter), so this is fully testable in-process.
+//!
+//! The backend is record-and-replay: `launch` runs the script once and the
+//! adapter then navigates the captured trace, so there is a single thread and
+//! one inspectable (top) scope.
+
+use std::io::{BufRead, Write};
+
+use serde_json::{json, Value};
+
+use crate::backend::{DebugBackend, DebugError, VmBackend};
+use crate::types::StopReason;
+
+/// Read one `Content-Length`-framed message. Returns `None` at clean EOF.
+pub fn read_message(reader: &mut impl BufRead) -> Option<Value> {
+    let mut content_length: Option<usize> = None;
+    loop {
+        let mut line = String::new();
+        if reader.read_line(&mut line).ok()? == 0 {
+            return None; // EOF
+        }
+        let trimmed = line.trim_end();
+        if trimmed.is_empty() {
+            break; // end of headers
+        }
+        if let Some(v) = trimmed.strip_prefix("Content-Length:") {
+            content_length = v.trim().parse().ok();
+        }
+    }
+    let len = content_length?;
+    let mut buf = vec![0u8; len];
+    reader.read_exact(&mut buf).ok()?;
+    serde_json::from_slice(&buf).ok()
+}
+
+/// Write one `Content-Length`-framed message.
+pub fn write_message(writer: &mut impl Write, msg: &Value) -> std::io::Result<()> {
+    let body = serde_json::to_vec(msg)?;
+    write!(writer, "Content-Length: {}\r\n\r\n", body.len())?;
+    writer.write_all(&body)?;
+    writer.flush()
+}
+
+/// DAP server state: the backend plus the outgoing-message sequence counter.
+struct Server {
+    backend: VmBackend,
+    seq: i64,
+    /// Accumulated breakpoint lines (DAP replaces the whole set per file).
+    breakpoints: Vec<u32>,
+}
+
+impl Server {
+    fn new() -> Self {
+        Self {
+            backend: VmBackend::new(),
+            seq: 0,
+            breakpoints: Vec::new(),
+        }
+    }
+
+    fn next_seq(&mut self) -> i64 {
+        self.seq += 1;
+        self.seq
+    }
+
+    /// Build a `response` to `request`.
+    #[allow(clippy::needless_pass_by_value)] // `body` is moved into the JSON.
+    fn response(&mut self, request: &Value, success: bool, body: Value) -> Value {
+        json!({
+            "seq": self.next_seq(),
+            "type": "response",
+            "request_seq": request.get("seq").and_then(Value::as_i64).unwrap_or(0),
+            "success": success,
+            "command": request.get("command").and_then(Value::as_str).unwrap_or(""),
+            "body": body,
+        })
+    }
+
+    /// Build an `event`.
+    #[allow(clippy::needless_pass_by_value)] // `body` is moved into the JSON.
+    fn event(&mut self, event: &str, body: Value) -> Value {
+        json!({
+            "seq": self.next_seq(),
+            "type": "event",
+            "event": event,
+            "body": body,
+        })
+    }
+
+    /// The `stopped` (or `terminated`) event for the current backend state.
+    fn stop_event(&mut self) -> Value {
+        if let Some(stop) = self.backend.last_stop() {
+            let reason = match stop.reason {
+                StopReason::Breakpoint => "breakpoint",
+                StopReason::Step => "step",
+                StopReason::Entry => "entry",
+            };
+            self.event(
+                "stopped",
+                json!({ "reason": reason, "threadId": 1, "allThreadsStopped": true }),
+            )
+        } else {
+            self.event("terminated", json!({}))
+        }
+    }
+}
+
+/// Run the DAP server loop over `reader`/`writer` until `disconnect` or EOF.
+///
+/// # Errors
+/// Propagates write failures.
+#[allow(clippy::too_many_lines)] // One request-dispatch match; splitting obscures it.
+pub fn run_server(reader: &mut impl BufRead, writer: &mut impl Write) -> std::io::Result<()> {
+    let mut srv = Server::new();
+    while let Some(req) = read_message(reader) {
+        let command = req.get("command").and_then(Value::as_str).unwrap_or("");
+        let mut outgoing: Vec<Value> = Vec::new();
+
+        match command {
+            "initialize" => {
+                let resp = srv.response(
+                    &req,
+                    true,
+                    json!({
+                        "supportsConfigurationDoneRequest": true,
+                        "supportsEvaluateForHovers": true,
+                    }),
+                );
+                outgoing.push(resp);
+                let ev = srv.event("initialized", json!({}));
+                outgoing.push(ev);
+            }
+            "launch" => {
+                let program = req
+                    .pointer("/arguments/program")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                let source = req.pointer("/arguments/source").and_then(Value::as_str);
+                match srv.backend.launch(program, source) {
+                    Ok(()) => {
+                        let resp = srv.response(&req, true, json!({}));
+                        outgoing.push(resp);
+                        let ev = srv.stop_event();
+                        outgoing.push(ev);
+                    }
+                    Err(e) => {
+                        let resp = srv.response(&req, false, json!({ "error": e.to_string() }));
+                        outgoing.push(resp);
+                    }
+                }
+            }
+            "setBreakpoints" => {
+                let lines: Vec<u32> = req
+                    .pointer("/arguments/breakpoints")
+                    .and_then(Value::as_array)
+                    .map(|bps| {
+                        bps.iter()
+                            .filter_map(|b| b.get("line").and_then(Value::as_u64))
+                            .map(|l| u32::try_from(l).unwrap_or(0))
+                            .collect()
+                    })
+                    .unwrap_or_default();
+                srv.breakpoints = srv.backend.set_breakpoints(&lines).unwrap_or_default();
+                let verified: Vec<Value> = srv
+                    .breakpoints
+                    .iter()
+                    .map(|l| json!({ "verified": true, "line": l }))
+                    .collect();
+                let resp = srv.response(&req, true, json!({ "breakpoints": verified }));
+                outgoing.push(resp);
+            }
+            "configurationDone" => {
+                let resp = srv.response(&req, true, json!({}));
+                outgoing.push(resp);
+            }
+            "threads" => {
+                let resp = srv.response(
+                    &req,
+                    true,
+                    json!({ "threads": [{ "id": 1, "name": "main" }] }),
+                );
+                outgoing.push(resp);
+            }
+            "stackTrace" => {
+                let frames: Vec<Value> = srv
+                    .backend
+                    .stack_trace()
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|f| {
+                        json!({ "id": f.id, "name": f.name, "line": f.line, "column": 1 })
+                    })
+                    .collect();
+                let resp = srv.response(
+                    &req,
+                    true,
+                    json!({ "totalFrames": frames.len(), "stackFrames": frames }),
+                );
+                outgoing.push(resp);
+            }
+            "scopes" => {
+                // One inspectable scope: the top frame's locals.
+                let resp = srv.response(
+                    &req,
+                    true,
+                    json!({ "scopes": [{
+                        "name": "Locals",
+                        "variablesReference": 1,
+                        "expensive": false,
+                    }] }),
+                );
+                outgoing.push(resp);
+            }
+            "variables" => {
+                let vars: Vec<Value> = srv
+                    .backend
+                    .variables(0)
+                    .unwrap_or_default()
+                    .into_iter()
+                    .map(|v| {
+                        json!({ "name": v.name, "value": v.value, "variablesReference": 0 })
+                    })
+                    .collect();
+                let resp = srv.response(&req, true, json!({ "variables": vars }));
+                outgoing.push(resp);
+            }
+            "continue" | "next" | "stepIn" | "stepOut" => {
+                let result = match command {
+                    "continue" => srv.backend.continue_execution(),
+                    "next" => srv.backend.step_over(),
+                    "stepIn" => srv.backend.step_in(),
+                    _ => srv.backend.step_out(),
+                };
+                let body = if command == "continue" {
+                    json!({ "allThreadsContinued": true })
+                } else {
+                    json!({})
+                };
+                let resp = srv.response(&req, true, body);
+                outgoing.push(resp);
+                let ev = match result {
+                    // The program ran off the end — terminate.
+                    Err(DebugError::Finished) => srv.event("terminated", json!({})),
+                    // Stopped (step/breakpoint) or a recoverable error — report
+                    // the new stop location.
+                    Ok(()) | Err(_) => srv.stop_event(),
+                };
+                outgoing.push(ev);
+            }
+            "evaluate" => {
+                let expr = req
+                    .pointer("/arguments/expression")
+                    .and_then(Value::as_str)
+                    .unwrap_or("");
+                match srv.backend.evaluate(expr) {
+                    Ok(v) => {
+                        let resp = srv.response(
+                            &req,
+                            true,
+                            json!({ "result": v, "variablesReference": 0 }),
+                        );
+                        outgoing.push(resp);
+                    }
+                    Err(e) => {
+                        let resp = srv.response(&req, false, json!({ "error": e.to_string() }));
+                        outgoing.push(resp);
+                    }
+                }
+            }
+            "disconnect" | "terminate" => {
+                let resp = srv.response(&req, true, json!({}));
+                outgoing.push(resp);
+                for msg in &outgoing {
+                    write_message(writer, msg)?;
+                }
+                return Ok(());
+            }
+            _ => {
+                // Unknown request — acknowledge so the client isn't wedged.
+                let resp = srv.response(&req, true, json!({}));
+                outgoing.push(resp);
+            }
+        }
+
+        for msg in &outgoing {
+            write_message(writer, msg)?;
+        }
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Cursor;
+
+    /// Frame a sequence of DAP request `Value`s into a `Content-Length` stream.
+    fn frame(requests: &[Value]) -> Vec<u8> {
+        let mut buf = Vec::new();
+        for r in requests {
+            write_message(&mut buf, r).unwrap();
+        }
+        buf
+    }
+
+    /// Run the server over framed `requests` and return the parsed responses /
+    /// events it emits, in order.
+    fn drive(requests: &[Value]) -> Vec<Value> {
+        let input = frame(requests);
+        let mut reader = Cursor::new(input);
+        let mut out: Vec<u8> = Vec::new();
+        run_server(&mut reader, &mut out).unwrap();
+        let mut cursor = Cursor::new(out);
+        let mut msgs = Vec::new();
+        while let Some(m) = read_message(&mut cursor) {
+            msgs.push(m);
+        }
+        msgs
+    }
+
+    fn req(seq: i64, command: &str, arguments: Value) -> Value {
+        json!({ "seq": seq, "type": "request", "command": command, "arguments": arguments })
+    }
+
+    #[test]
+    fn initialize_then_launch_stops_at_entry() {
+        let msgs = drive(&[
+            req(1, "initialize", json!({})),
+            req(2, "launch", json!({ "source": "set x 1\nset y 2\n" })),
+            req(3, "disconnect", json!({})),
+        ]);
+        // initialize response + initialized event + launch response + stopped event…
+        assert!(msgs.iter().any(|m| m["event"] == "initialized"));
+        let stopped = msgs
+            .iter()
+            .find(|m| m["event"] == "stopped")
+            .expect("stopped event");
+        assert_eq!(stopped["body"]["reason"], "entry");
+    }
+
+    #[test]
+    fn breakpoint_then_continue_stops_there_with_variables() {
+        let msgs = drive(&[
+            req(1, "initialize", json!({})),
+            req(
+                2,
+                "launch",
+                json!({ "source": "set a 1\nset b 2\nset c 3\n" }),
+            ),
+            req(
+                3,
+                "setBreakpoints",
+                json!({ "breakpoints": [{ "line": 3 }] }),
+            ),
+            req(4, "continue", json!({})),
+            req(5, "stackTrace", json!({})),
+            req(6, "variables", json!({})),
+            req(7, "disconnect", json!({})),
+        ]);
+
+        // setBreakpoints verified line 3.
+        let setbp = msgs
+            .iter()
+            .find(|m| m["command"] == "setBreakpoints")
+            .expect("setBreakpoints response");
+        assert_eq!(setbp["body"]["breakpoints"][0]["line"], 3);
+
+        // continue → stopped at the breakpoint.
+        let stopped = msgs
+            .iter()
+            .filter(|m| m["event"] == "stopped")
+            .next_back()
+            .expect("stopped after continue");
+        assert_eq!(stopped["body"]["reason"], "breakpoint");
+
+        // stackTrace shows line 3.
+        let st = msgs
+            .iter()
+            .find(|m| m["command"] == "stackTrace")
+            .expect("stackTrace response");
+        assert_eq!(st["body"]["stackFrames"][0]["line"], 3);
+
+        // variables include a=1 and b=2 (set before line 3 ran).
+        let vars = msgs
+            .iter()
+            .find(|m| m["command"] == "variables")
+            .expect("variables response");
+        let arr = vars["body"]["variables"].as_array().unwrap();
+        assert!(arr.iter().any(|v| v["name"] == "a" && v["value"] == "1"));
+        assert!(arr.iter().any(|v| v["name"] == "b" && v["value"] == "2"));
+    }
+
+    #[test]
+    fn continue_to_end_terminates() {
+        let msgs = drive(&[
+            req(1, "initialize", json!({})),
+            req(2, "launch", json!({ "source": "set x 1\n" })),
+            req(3, "continue", json!({})),
+            req(4, "disconnect", json!({})),
+        ]);
+        assert!(msgs.iter().any(|m| m["event"] == "terminated"));
+    }
+}

--- a/rust/tcl-debugger/src/lib.rs
+++ b/rust/tcl-debugger/src/lib.rs
@@ -15,6 +15,7 @@
 
 pub mod backend;
 pub mod controller;
+pub mod dap;
 pub mod types;
 
 pub use backend::{DebugBackend, DebugError, VmBackend};

--- a/rust/tcl-debugger/src/lib.rs
+++ b/rust/tcl-debugger/src/lib.rs
@@ -1,0 +1,22 @@
+//! Step debugger for the native Tcl VM. Port of `tooling/debugger/`.
+//!
+//! A [`controller::DebugController`] owns the breakpoints and the step-mode
+//! state machine; a [`backend::DebugBackend`] is the debug engine that runs the
+//! script and calls the controller at each source-line boundary. The native
+//! [`backend::VmBackend`] runs the script on `tcl-vm`.
+//!
+//! What lands here is the portable, tested core — the controller's stop
+//! decision logic, the shared [`types`], and the backend contract. The live VM
+//! backend is gated on `tcl-vm` exposing a per-statement debug hook
+//! (source-line + frame-level) and a bytecode-PC → source-line map, tracked
+//! under **RT-VM**; see [`backend`].
+
+#![forbid(unsafe_code)]
+
+pub mod backend;
+pub mod controller;
+pub mod types;
+
+pub use backend::{DebugBackend, DebugError, VmBackend};
+pub use controller::DebugController;
+pub use types::{DebugAction, StackFrame, StepMode, StopEvent, StopReason, Variable, VariableKind};

--- a/rust/tcl-debugger/src/main.rs
+++ b/rust/tcl-debugger/src/main.rs
@@ -1,0 +1,132 @@
+//! `tcl-debug` — an interactive CLI front-end for the native step debugger.
+//!
+//! Drives a [`tcl_debugger::VmBackend`] over a script: launch, set
+//! breakpoints, step, and inspect the stack and variables. The backend is
+//! record-and-replay (the script runs once up front to capture the trace), so
+//! stepping moves a cursor over that trace — fast and side-effect-free to
+//! re-inspect.
+//!
+//! Commands (gdb-ish): `break <line>` (`b`), `step` (`s`), `next` (`n`),
+//! `finish` (`f`), `continue` (`c`), `print <var>` (`p`), `stack` (`bt`),
+//! `vars`, `list` (`l`), `quit` (`q`). Reads commands from stdin so it scripts
+//! and tests cleanly.
+
+#![forbid(unsafe_code)]
+
+use std::io::{BufRead, Write};
+
+use tcl_debugger::backend::{DebugBackend, DebugError, VmBackend};
+
+fn main() -> std::process::ExitCode {
+    let Some(path) = std::env::args().nth(1) else {
+        eprintln!("usage: tcl-debug <script.tcl>");
+        return std::process::ExitCode::from(2);
+    };
+    let mut backend = VmBackend::new();
+    if let Err(e) = backend.launch(&path, None) {
+        eprintln!("error: {e}");
+        return std::process::ExitCode::from(1);
+    }
+
+    let stdout = std::io::stdout();
+    let mut out = stdout.lock();
+    announce_stop(&backend, &mut out);
+
+    let mut breakpoints: Vec<u32> = Vec::new();
+    let stdin = std::io::stdin();
+    for line in stdin.lock().lines().map_while(Result::ok) {
+        let mut parts = line.split_whitespace();
+        let Some(cmd) = parts.next() else {
+            continue;
+        };
+        let arg = parts.next();
+        match cmd {
+            "q" | "quit" => break,
+            "b" | "break" => match arg.and_then(|a| a.parse::<u32>().ok()) {
+                Some(l) => {
+                    if !breakpoints.contains(&l) {
+                        breakpoints.push(l);
+                    }
+                    let accepted = backend.set_breakpoints(&breakpoints).unwrap_or_default();
+                    let _ = writeln!(out, "breakpoints: {accepted:?}");
+                }
+                None => {
+                    let _ = writeln!(out, "usage: break <line>");
+                }
+            },
+            "s" | "step" => control(&mut backend, &mut out, VmBackend::step_in),
+            "n" | "next" => control(&mut backend, &mut out, VmBackend::step_over),
+            "f" | "finish" => control(&mut backend, &mut out, VmBackend::step_out),
+            "c" | "continue" => control(&mut backend, &mut out, VmBackend::continue_execution),
+            "p" | "print" => match arg {
+                Some(name) => {
+                    let _ = match backend.evaluate(name) {
+                        Ok(v) => writeln!(out, "{name} = {v}"),
+                        Err(e) => writeln!(out, "{e}"),
+                    };
+                }
+                None => {
+                    let _ = writeln!(out, "usage: print <var>");
+                }
+            },
+            "bt" | "stack" => match backend.stack_trace() {
+                Ok(frames) => {
+                    for fr in frames {
+                        let _ = writeln!(out, "  #{} {} (line {})", fr.id, fr.name, fr.line);
+                    }
+                }
+                Err(e) => {
+                    let _ = writeln!(out, "{e}");
+                }
+            },
+            "vars" | "locals" => match backend.variables(0) {
+                Ok(vars) => {
+                    for v in vars {
+                        let _ = writeln!(out, "  {} = {}", v.name, v.value);
+                    }
+                }
+                Err(e) => {
+                    let _ = writeln!(out, "{e}");
+                }
+            },
+            "l" | "list" => announce_stop(&backend, &mut out),
+            other => {
+                let _ = writeln!(out, "unknown command: {other}");
+            }
+        }
+        let _ = out.flush();
+    }
+    std::process::ExitCode::SUCCESS
+}
+
+
+
+/// Run a control operation and report the resulting stop (or end of program).
+fn control(
+    backend: &mut VmBackend,
+    out: &mut impl Write,
+    op: fn(&mut VmBackend) -> Result<(), DebugError>,
+) {
+    match op(backend) {
+        Ok(()) => announce_stop(backend, out),
+        Err(DebugError::Finished) => {
+            let _ = writeln!(out, "program finished");
+        }
+        Err(e) => {
+            let _ = writeln!(out, "{e}");
+        }
+    }
+}
+
+/// Print the current stop location.
+fn announce_stop(backend: &VmBackend, out: &mut impl Write) {
+    if let Some(stop) = backend.last_stop() {
+        let _ = writeln!(
+            out,
+            "stopped at line {} [{:?}]: {}",
+            stop.line, stop.reason, stop.command_text
+        );
+    } else {
+        let _ = writeln!(out, "not running");
+    }
+}

--- a/rust/tcl-debugger/src/main.rs
+++ b/rust/tcl-debugger/src/main.rs
@@ -19,9 +19,26 @@ use tcl_debugger::backend::{DebugBackend, DebugError, VmBackend};
 
 fn main() -> std::process::ExitCode {
     let Some(path) = std::env::args().nth(1) else {
-        eprintln!("usage: tcl-debug <script.tcl>");
+        eprintln!("usage: tcl-debug <script.tcl>   (interactive CLI)");
+        eprintln!("       tcl-debug --dap          (Debug Adapter Protocol over stdio)");
         return std::process::ExitCode::from(2);
     };
+
+    // DAP mode: speak the Debug Adapter Protocol over stdin/stdout for an editor.
+    if path == "--dap" {
+        let stdin = std::io::stdin();
+        let stdout = std::io::stdout();
+        let mut reader = stdin.lock();
+        let mut writer = stdout.lock();
+        return match tcl_debugger::dap::run_server(&mut reader, &mut writer) {
+            Ok(()) => std::process::ExitCode::SUCCESS,
+            Err(e) => {
+                eprintln!("dap: {e}");
+                std::process::ExitCode::from(1)
+            }
+        };
+    }
+
     let mut backend = VmBackend::new();
     if let Err(e) = backend.launch(&path, None) {
         eprintln!("error: {e}");

--- a/rust/tcl-debugger/src/types.rs
+++ b/rust/tcl-debugger/src/types.rs
@@ -1,0 +1,86 @@
+//! Shared debugger types. Port of `tooling/debugger/types.py`.
+
+/// What the debug hook tells the VM to do after a source-line boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DebugAction {
+    /// Keep running.
+    Continue,
+    /// Stop the VM (terminate the debug session).
+    Stop,
+}
+
+/// The controller's current stepping mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StepMode {
+    /// Run until the next breakpoint.
+    Continue,
+    /// Stop at the next source line, descending into calls.
+    StepIn,
+    /// Stop at the next source line in the current frame or shallower.
+    StepOver,
+    /// Run until the current procedure returns.
+    StepOut,
+}
+
+/// One frame in the debug call stack.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StackFrame {
+    /// Frame id (depth from the top).
+    pub id: u32,
+    /// Proc name, or `"global"`.
+    pub name: String,
+    /// 1-based source line of the active statement.
+    pub line: u32,
+    /// The frame's namespace.
+    pub namespace: String,
+}
+
+/// A variable visible in a scope.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Variable {
+    /// Variable name.
+    pub name: String,
+    /// Rendered value.
+    pub value: String,
+    /// `"scalar"`, `"array"`, or `"alias"`.
+    pub kind: VariableKind,
+    /// For `upvar`/alias visualisation: the target name.
+    pub alias_target: Option<String>,
+    /// Array elements, when `kind == Array`.
+    pub children: Vec<Variable>,
+}
+
+/// The kind of a [`Variable`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariableKind {
+    /// A plain scalar.
+    Scalar,
+    /// An array (its elements are `children`).
+    Array,
+    /// An `upvar`/alias to another variable.
+    Alias,
+}
+
+/// Why the debugger stopped.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StopReason {
+    /// A breakpoint was hit.
+    Breakpoint,
+    /// A step completed.
+    Step,
+    /// Stopped at program entry.
+    Entry,
+}
+
+/// Emitted when the debugger pauses.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct StopEvent {
+    /// The 1-based source line stopped at.
+    pub line: u32,
+    /// The text of the command about to run.
+    pub command_text: String,
+    /// Why it stopped.
+    pub reason: StopReason,
+    /// The current call stack (top first).
+    pub frames: Vec<StackFrame>,
+}

--- a/rust/tcl-explorer/src/render.rs
+++ b/rust/tcl-explorer/src/render.rs
@@ -156,14 +156,32 @@ fn render_asm(data: &Value, use_colour: bool) -> String {
     out
 }
 
-/// Render the WASM view, which is degraded to `null` until the emitter lands.
+/// Render the WASM view: print the module's WAT (carried as the `text` of the
+/// synthetic `(module)` entry), then a one-line header per emitted function.
 fn render_wasm(data: &Value) -> String {
-    match data.get("wasm") {
-        Some(Value::Array(funcs)) if !funcs.is_empty() => {
-            format!("  ({} WASM function(s))\n", funcs.len())
-        }
-        _ => "  unavailable — the Rust WASM emitter is not yet ported\n".to_owned(),
+    use std::fmt::Write as _;
+    let Some(Value::Array(entries)) = data.get("wasm") else {
+        return "  unavailable\n".to_owned();
+    };
+    if entries.is_empty() {
+        return "  (no WASM functions)\n".to_owned();
     }
+    let mut out = String::new();
+    for entry in entries {
+        if entry.get("kind").and_then(Value::as_str) == Some("module") {
+            if let Some(text) = entry.get("text").and_then(Value::as_str) {
+                out.push_str(text);
+                if !text.ends_with('\n') {
+                    out.push('\n');
+                }
+            }
+        } else {
+            let name = entry.get("name").and_then(Value::as_str).unwrap_or("?");
+            let n = entry.get("instrCount").and_then(Value::as_u64).unwrap_or(0);
+            let _ = writeln!(out, "  fn {name}: {n} instr");
+        }
+    }
+    out
 }
 
 #[cfg(test)]
@@ -208,8 +226,12 @@ mod tests {
     }
 
     #[test]
-    fn wasm_reports_unavailable() {
-        let d = data("set x 1");
-        assert!(render_wasm(&d).contains("unavailable"));
+    fn wasm_renders_wat_module() {
+        // The eval-fallback emitter produces a real WASM module; the view shows
+        // its WAT (a `(module …)` with at least the `$::top` function).
+        let d = data("set x 1\nputs $x");
+        let wat = render_wasm(&d);
+        assert!(wat.contains("(module"), "{wat}");
+        assert!(wat.contains("$::top"), "{wat}");
     }
 }

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -184,6 +184,43 @@ fn serialise_children(stmt: &Statement, li: &LineIndex, source: &str) -> Option<
     }
 }
 
+/// Serialise the `wasm` view: drive the eval-fallback WASM emitter (the same
+/// `wasm_codegen_module` `tcl compwasm` uses) and emit the module's WAT plus a
+/// per-function header list. Mirrors `_serialise_wasm` to the extent the text
+/// renderer needs — the synthetic `(module)` entry carries the full WAT, each
+/// function entry its name + instruction count. (The rich per-instruction
+/// `to_explorer_json` shape for the web GUI is a later refinement.)
+fn serialise_wasm(module: &Module, source: &str) -> Value {
+    use tcl_compiler::codegen::wasm::wasm_codegen_module;
+
+    let mut wasm = wasm_codegen_module(module, source);
+    let total_instr: usize = wasm.functions.iter().map(|f| f.body.len()).sum();
+    let function_count = wasm.functions.len();
+    let func_entries: Vec<Value> = wasm
+        .functions
+        .iter()
+        .map(|f| {
+            json!({
+                "kind": "function",
+                "name": f.name,
+                "instrCount": f.body.len(),
+            })
+        })
+        .collect();
+    let wat = wasm.to_wat();
+
+    let mut entries = vec![json!({
+        "kind": "module",
+        "name": "(module)",
+        "text": wat,
+        "functionCount": function_count,
+        "totalInstrCount": total_instr,
+        "instrCount": 0,
+    })];
+    entries.extend(func_entries);
+    Value::Array(entries)
+}
+
 /// Serialise the `ir` view. Mirrors `_serialise_ir`:
 /// `{ topLevel: [...], procedures: { qname: { params, range, body } } }`.
 #[must_use]
@@ -1770,12 +1807,20 @@ pub fn serialise_result(result: &ExplorerResult) -> Value {
         }),
     );
 
-    // WASM views: the WASM emitter is unported (zero Rust files), so these
-    // degrade to `null` — `explorer-core.js` renders the WASM tab's empty
-    // state. Python emits real disassembly here, so they are `_NO_PARITY`
-    // until the emitter chunk lands.
-    out.insert("wasm".to_owned(), Value::Null);
-    out.insert("wasmOptimised".to_owned(), Value::Null);
+    // WASM views: drive the eval-fallback WASM emitter (the same one `tcl
+    // compwasm` uses) and surface its WAT. The rich per-instruction explorer
+    // shape (`to_explorer_json`) is not ported yet — these carry the full
+    // module WAT plus per-function headers, which the text/`wasm` view renders.
+    out.insert(
+        "wasm".to_owned(),
+        serialise_wasm(&result.unit.ir_module, &result.source),
+    );
+    out.insert(
+        "wasmOptimised".to_owned(),
+        opt.as_ref().map_or(Value::Null, |(r, s)| {
+            serialise_wasm(&r.unit.ir_module, s)
+        }),
+    );
 
     let (annotations, by_line) = serialise_annotations(result, &li, &result.source);
     out.insert("annotations".to_owned(), annotations);

--- a/rust/tcl-explorer/src/view_tree.rs
+++ b/rust/tcl-explorer/src/view_tree.rs
@@ -73,6 +73,20 @@ fn jstr(v: &Value) -> String {
     }
 }
 
+/// Render a JSON scalar the way Python's `str()` would inside an f-string.
+///
+/// The only divergence from [`jstr`] is booleans: Python emits `True`/`False`
+/// (capitalised) where Rust's `bool` `Display` emits `true`/`false`. The
+/// explorer's SSA-view const-branch label interpolates a JSON bool through a
+/// Python f-string, so the port must capitalise to stay byte-identical.
+fn pystr(v: &Value) -> String {
+    match v {
+        Value::Bool(true) => "True".to_owned(),
+        Value::Bool(false) => "False".to_owned(),
+        other => jstr(other),
+    }
+}
+
 fn arr<'a>(v: &'a Value, key: &str) -> &'a [Value] {
     v.get(key)
         .and_then(Value::as_array)
@@ -322,7 +336,7 @@ fn build_cfg(funcs: &[Value], post: bool) -> Vec<ViewNode> {
                     format!(
                         "const branch {}: always {}",
                         s(br, "block"),
-                        jstr(&br["value"])
+                        pystr(&br["value"])
                     ),
                     vec![
                         det("condition", s(br, "condition")),

--- a/rust/tcl-fuzz/Cargo.toml
+++ b/rust/tcl-fuzz/Cargo.toml
@@ -1,0 +1,32 @@
+# `tcl-fuzz` — differential fuzzer for the native Tcl VM.
+#
+# Generates structurally-valid Tcl over the VM's supported surface (variables,
+# expr, string/list/dict ops, control flow, procs, arrays — no I/O), runs each
+# script through both the native `tclvm` and a reference `tclsh`, and flags any
+# divergence in stdout / exit status as a finding. The campaign runner +
+# generator + findings registry are the Rust port of `tooling/fuzzing/`.
+#
+# Both backends run as subprocesses with a wall-clock timeout, so a generated
+# script that hangs one engine is recorded as a finding rather than wedging the
+# campaign.
+[package]
+name = "tcl-fuzz"
+description = "Differential fuzzer for the native Tcl bytecode VM (tclvm vs tclsh)"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[[bin]]
+name = "tcl-fuzz"
+path = "src/main.rs"
+
+[dependencies]
+clap = { version = "4", features = ["derive", "wrap_help"] }
+serde = { version = "1", features = ["derive"] }
+serde_json = { version = "1", features = ["preserve_order"] }
+
+[lints]
+workspace = true

--- a/rust/tcl-fuzz/src/campaign.rs
+++ b/rust/tcl-fuzz/src/campaign.rs
@@ -1,0 +1,103 @@
+//! Campaign runner: generate → run both backends → compare → record.
+//!
+//! Port of `tooling/fuzzing/runner.py::run_campaign`, over the native
+//! `tclvm` / `tclsh` subprocess harness.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use crate::findings::{Category, Finding, Registry};
+use crate::generator::{generate, GenConfig};
+use crate::harness::{compare, run_backend, write_script, Verdict};
+
+/// Aggregate campaign statistics.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Stats {
+    /// Scripts generated and run.
+    pub total: u64,
+    /// Matching (no divergence) runs.
+    pub matched: u64,
+    /// stdout-mismatch findings.
+    pub stdout_mismatch: u64,
+    /// status-mismatch findings.
+    pub status_mismatch: u64,
+    /// subject-timeout findings.
+    pub timeout: u64,
+    /// Runs skipped (reference timeout / backend unavailable).
+    pub skipped: u64,
+    /// New findings recorded this campaign.
+    pub new_findings: u64,
+}
+
+impl Stats {
+    /// Total findings (any category) this campaign.
+    #[must_use]
+    pub fn findings(&self) -> u64 {
+        self.stdout_mismatch + self.status_mismatch + self.timeout
+    }
+}
+
+/// Configuration for one campaign.
+pub struct Campaign<'a> {
+    /// Reference engine (`tclsh`).
+    pub tclsh: &'a Path,
+    /// Subject engine (`tclvm`).
+    pub tclvm: &'a Path,
+    /// Per-script wall-clock timeout.
+    pub timeout: Duration,
+    /// Generator tunables.
+    pub config: GenConfig,
+    /// Findings registry.
+    pub registry: &'a Registry,
+    /// Scratch directory for generated `.tcl` files.
+    pub scratch: PathBuf,
+}
+
+impl Campaign<'_> {
+    /// Run `iterations` scripts starting at `base_seed`, invoking `progress`
+    /// after each iteration with the running stats.
+    pub fn run(
+        &self,
+        base_seed: u64,
+        iterations: u64,
+        mut progress: impl FnMut(u64, &Stats),
+    ) -> Stats {
+        let mut stats = Stats::default();
+        for i in 0..iterations {
+            let seed = base_seed.wrapping_add(i);
+            stats.total += 1;
+            self.run_one(seed, &mut stats);
+            progress(i + 1, &stats);
+        }
+        stats
+    }
+
+    /// Generate, run, and compare a single seed, updating `stats` and recording
+    /// any finding.
+    pub fn run_one(&self, seed: u64, stats: &mut Stats) -> Verdict {
+        let script = generate(seed, &self.config);
+        let Ok(path) = write_script(&self.scratch, seed, &script) else {
+            stats.skipped += 1;
+            return Verdict::Skipped;
+        };
+        let reference = run_backend(self.tclsh, &path, self.timeout);
+        let subject = run_backend(self.tclvm, &path, self.timeout);
+        let _ = std::fs::remove_file(&path);
+
+        let verdict = compare(&reference, &subject);
+        match verdict {
+            Verdict::Match => stats.matched += 1,
+            Verdict::Skipped => stats.skipped += 1,
+            Verdict::StdoutMismatch => stats.stdout_mismatch += 1,
+            Verdict::StatusMismatch => stats.status_mismatch += 1,
+            Verdict::Timeout => stats.timeout += 1,
+        }
+        if let Some(category) = Category::from_verdict(verdict) {
+            let finding = Finding::new(seed, category, &script, &reference, &subject);
+            if self.registry.record(&finding).unwrap_or(false) {
+                stats.new_findings += 1;
+            }
+        }
+        verdict
+    }
+}

--- a/rust/tcl-fuzz/src/findings.rs
+++ b/rust/tcl-fuzz/src/findings.rs
@@ -1,0 +1,180 @@
+//! Findings registry: persist and categorise differential divergences.
+//!
+//! A finding is keyed by its `seed` (so it replays exactly) and saved as a
+//! JSON record plus the raw `.tcl` script under the findings directory. The
+//! registry de-duplicates by seed and summarises by category.
+
+use std::collections::BTreeMap;
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::harness::{Outcome, Verdict};
+
+/// The category of a finding — the [`Verdict`] that produced it.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq, PartialOrd, Ord)]
+#[serde(rename_all = "snake_case")]
+pub enum Category {
+    /// stdout differed between engines.
+    StdoutMismatch,
+    /// Error status differed.
+    StatusMismatch,
+    /// The subject (`tclvm`) hung.
+    Timeout,
+}
+
+impl Category {
+    /// Map a non-`Match`/`Skipped` verdict to a category.
+    #[must_use]
+    pub fn from_verdict(v: Verdict) -> Option<Self> {
+        match v {
+            Verdict::StdoutMismatch => Some(Self::StdoutMismatch),
+            Verdict::StatusMismatch => Some(Self::StatusMismatch),
+            Verdict::Timeout => Some(Self::Timeout),
+            Verdict::Match | Verdict::Skipped => None,
+        }
+    }
+}
+
+/// A recorded divergence.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct Finding {
+    /// The seed that reproduces it.
+    pub seed: u64,
+    /// What diverged.
+    pub category: Category,
+    /// The generated script.
+    pub script: String,
+    /// Reference (`tclsh`) stdout, when it ran.
+    pub reference_stdout: String,
+    /// Subject (`tclvm`) stdout, when it ran.
+    pub subject_stdout: String,
+    /// Reference error status.
+    pub reference_errored: bool,
+    /// Subject error status.
+    pub subject_errored: bool,
+}
+
+impl Finding {
+    /// Build a finding from a campaign iteration's outcomes.
+    #[must_use]
+    pub fn new(
+        seed: u64,
+        category: Category,
+        script: &str,
+        reference: &Outcome,
+        subject: &Outcome,
+    ) -> Self {
+        let (reference_stdout, reference_errored) = unpack(reference);
+        let (subject_stdout, subject_errored) = unpack(subject);
+        Self {
+            seed,
+            category,
+            script: script.to_owned(),
+            reference_stdout,
+            subject_stdout,
+            reference_errored,
+            subject_errored,
+        }
+    }
+}
+
+fn unpack(o: &Outcome) -> (String, bool) {
+    match o {
+        Outcome::Ran { stdout, errored } => (stdout.clone(), *errored),
+        Outcome::Timeout => ("<timeout>".to_owned(), true),
+        Outcome::Unavailable(m) => (format!("<unavailable: {m}>"), true),
+    }
+}
+
+/// On-disk findings registry rooted at a directory.
+pub struct Registry {
+    dir: PathBuf,
+}
+
+impl Registry {
+    /// Open (creating if needed) a registry at `dir`.
+    ///
+    /// # Errors
+    /// If the directory cannot be created.
+    pub fn open(dir: impl Into<PathBuf>) -> std::io::Result<Self> {
+        let dir = dir.into();
+        std::fs::create_dir_all(&dir)?;
+        Ok(Self { dir })
+    }
+
+    /// Persist a finding (JSON record + raw `.tcl`), keyed by seed. Returns
+    /// `true` if it was new, `false` if a finding for that seed already exists.
+    ///
+    /// # Errors
+    /// On any filesystem write failure.
+    pub fn record(&self, finding: &Finding) -> std::io::Result<bool> {
+        let json = self.dir.join(format!("finding-{}.json", finding.seed));
+        if json.exists() {
+            return Ok(false);
+        }
+        std::fs::write(self.dir.join(format!("finding-{}.tcl", finding.seed)), &finding.script)?;
+        std::fs::write(
+            &json,
+            serde_json::to_string_pretty(finding).unwrap_or_default(),
+        )?;
+        Ok(true)
+    }
+
+    /// Count of recorded findings per category.
+    #[must_use]
+    pub fn summary(&self) -> BTreeMap<Category, usize> {
+        let mut counts: BTreeMap<Category, usize> = BTreeMap::new();
+        let Ok(entries) = std::fs::read_dir(&self.dir) else {
+            return counts;
+        };
+        for entry in entries.flatten() {
+            let path = entry.path();
+            if path.extension().and_then(|e| e.to_str()) != Some("json") {
+                continue;
+            }
+            if let Ok(text) = std::fs::read_to_string(&path)
+                && let Ok(f) = serde_json::from_str::<Finding>(&text)
+            {
+                *counts.entry(f.category).or_default() += 1;
+            }
+        }
+        counts
+    }
+
+    /// Load a previously-recorded finding by seed, if present.
+    #[must_use]
+    pub fn load(&self, seed: u64) -> Option<Finding> {
+        let text = std::fs::read_to_string(self.dir.join(format!("finding-{seed}.json"))).ok()?;
+        serde_json::from_str(&text).ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn tmp() -> PathBuf {
+        let p = std::env::temp_dir().join(format!("tcl-fuzz-test-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&p);
+        p
+    }
+
+    #[test]
+    fn record_dedups_and_summarises() {
+        let dir = tmp();
+        let reg = Registry::open(&dir).unwrap();
+        let f = Finding::new(
+            7,
+            Category::StdoutMismatch,
+            "puts 1",
+            &Outcome::Ran { stdout: "1\n".into(), errored: false },
+            &Outcome::Ran { stdout: "2\n".into(), errored: false },
+        );
+        assert!(reg.record(&f).unwrap());
+        assert!(!reg.record(&f).unwrap(), "second record of same seed is a no-op");
+        assert_eq!(reg.summary().get(&Category::StdoutMismatch), Some(&1));
+        assert_eq!(reg.load(7).unwrap().subject_stdout, "2\n");
+        let _ = std::fs::remove_dir_all(&dir);
+    }
+}

--- a/rust/tcl-fuzz/src/generator.rs
+++ b/rust/tcl-fuzz/src/generator.rs
@@ -1,0 +1,292 @@
+//! Grammar-aware Tcl script generator for differential fuzzing.
+//!
+//! Port of `tooling/fuzzing/tcl_gen.py`, scoped to the surface the native VM
+//! implements so a divergence points at a real miscompile rather than an
+//! unimplemented command. Every emitted script:
+//!
+//! * is syntactically valid Tcl (balanced `{}` / `[]` / `""`);
+//! * is **pure** — no I/O, file, socket, exec, clock, or `after` commands;
+//! * has **bounded** loops (literal integer bounds), so neither backend hangs;
+//! * prints deterministic output via `puts`, so the differential has something
+//!   to compare.
+//!
+//! The generator is parameterised by a [`GenConfig`] and a seed, so any finding
+//! replays exactly.
+
+use std::fmt::Write as _;
+
+use crate::rng::Rng;
+
+/// Tunables for the generator.
+#[derive(Debug, Clone, Copy)]
+#[allow(clippy::struct_field_names)] // `max_*` reads naturally for bound knobs.
+pub struct GenConfig {
+    /// Maximum nesting depth of control structures.
+    pub max_depth: u32,
+    /// Maximum number of top-level statements.
+    pub max_stmts: usize,
+    /// Maximum generated list length.
+    pub max_list_len: usize,
+    /// Maximum expression nesting depth.
+    pub max_expr_depth: u32,
+}
+
+impl Default for GenConfig {
+    fn default() -> Self {
+        Self {
+            max_depth: 3,
+            max_stmts: 10,
+            max_list_len: 5,
+            max_expr_depth: 3,
+        }
+    }
+}
+
+/// Variable names the generator draws from (kept small so reads usually hit a
+/// previously-assigned variable).
+const VARS: &[&str] = &["a", "b", "c", "d", "i", "j", "x", "y", "z"];
+
+/// Short literal words used as list elements / string operands.
+const WORDS: &[&str] = &["foo", "bar", "baz", "qux", "hello", "world", "abc", "x", ""];
+
+/// Generate one script from `seed`.
+#[must_use]
+pub fn generate(seed: u64, config: &GenConfig) -> String {
+    let mut g = Gen {
+        rng: Rng::new(seed),
+        config: *config,
+        out: String::new(),
+    };
+    // Seed a few variables so later reads resolve, matching how real scripts
+    // initialise state before using it.
+    for v in ["a", "b", "i", "x"] {
+        let _ = writeln!(g.out, "set {v} {}", g.rng.below(20));
+    }
+    let stmts = 1 + g.rng.below(g.config.max_stmts);
+    for _ in 0..stmts {
+        g.statement(0);
+    }
+    g.out
+}
+
+struct Gen {
+    rng: Rng,
+    config: GenConfig,
+    out: String,
+}
+
+impl Gen {
+    fn var(&mut self) -> &'static str {
+        self.rng.pick(VARS)
+    }
+
+    /// Emit one statement at nesting `depth`.
+    fn statement(&mut self, depth: u32) {
+        // At max depth, only emit leaf (non-nesting) statements.
+        let leaf = depth >= self.config.max_depth || self.rng.chance(2, 3);
+        if leaf {
+            self.leaf_statement();
+        } else {
+            match self.rng.below(5) {
+                0 => self.if_stmt(depth),
+                1 => self.while_stmt(depth),
+                2 => self.for_stmt(depth),
+                3 => self.foreach_stmt(depth),
+                _ => self.leaf_statement(),
+            }
+        }
+    }
+
+    fn leaf_statement(&mut self) {
+        match self.rng.below(8) {
+            0 => {
+                let v = self.var();
+                let e = self.expr(0);
+                let _ = writeln!(self.out, "set {v} [expr {{{e}}}]");
+            }
+            1 => {
+                let v = self.var();
+                let _ = writeln!(self.out, "incr {v} {}", self.rng.below(5));
+            }
+            2 => {
+                let v = self.var();
+                let w = self.rng.pick(WORDS);
+                let _ = writeln!(self.out, "append {v} {w}");
+            }
+            3 => {
+                let v = self.var();
+                let list = self.list_literal();
+                let _ = writeln!(self.out, "set {v} {list}");
+            }
+            4 => {
+                let v = self.var();
+                let w = self.rng.pick(WORDS);
+                let _ = writeln!(self.out, "lappend {v} {w}");
+            }
+            5 => {
+                let s = self.string_op();
+                let _ = writeln!(self.out, "puts [{s}]");
+            }
+            6 => {
+                let l = self.list_op();
+                let _ = writeln!(self.out, "puts [{l}]");
+            }
+            _ => {
+                let e = self.expr(0);
+                let _ = writeln!(self.out, "puts [expr {{{e}}}]");
+            }
+        }
+    }
+
+    fn if_stmt(&mut self, depth: u32) {
+        let cond = self.expr(0);
+        let _ = writeln!(self.out, "if {{{cond}}} {{");
+        self.block(depth + 1);
+        if self.rng.chance(1, 2) {
+            self.out.push_str("} else {\n");
+            self.block(depth + 1);
+        }
+        self.out.push_str("}\n");
+    }
+
+    fn while_stmt(&mut self, depth: u32) {
+        // Bounded: a fresh counter var counts up to a small literal.
+        let n = 1 + self.rng.below(4);
+        let _ = writeln!(self.out, "set _w 0\nwhile {{$_w < {n}}} {{");
+        self.block(depth + 1);
+        self.out.push_str("incr _w\n}\n");
+    }
+
+    fn for_stmt(&mut self, depth: u32) {
+        let n = 1 + self.rng.below(4);
+        let _ = writeln!(self.out, "for {{set _f 0}} {{$_f < {n}}} {{incr _f}} {{");
+        self.block(depth + 1);
+        self.out.push_str("}\n");
+    }
+
+    fn foreach_stmt(&mut self, depth: u32) {
+        let v = self.var();
+        let list = self.list_literal();
+        let _ = writeln!(self.out, "foreach {v} {list} {{");
+        self.block(depth + 1);
+        self.out.push_str("}\n");
+    }
+
+    /// Emit a small block of 1–3 statements at `depth`.
+    fn block(&mut self, depth: u32) {
+        let n = 1 + self.rng.below(3);
+        for _ in 0..n {
+            self.statement(depth);
+        }
+    }
+
+    /// A braced list literal of short words.
+    fn list_literal(&mut self) -> String {
+        let n = self.rng.below(self.config.max_list_len + 1);
+        let mut s = String::from("{");
+        for k in 0..n {
+            if k > 0 {
+                s.push(' ');
+            }
+            // Use a non-empty word so empty elements don't collapse.
+            let w = loop {
+                let w = self.rng.pick(WORDS);
+                if !w.is_empty() {
+                    break *w;
+                }
+            };
+            s.push_str(w);
+        }
+        s.push('}');
+        s
+    }
+
+    /// A `string` ensemble subcommand producing a value.
+    fn string_op(&mut self) -> String {
+        let w = self.rng.pick(WORDS);
+        match self.rng.below(6) {
+            0 => format!("string length {w}"),
+            1 => format!("string toupper {w}"),
+            2 => format!("string tolower {w}"),
+            3 => format!("string reverse {w}"),
+            4 => format!("string index {w} {}", self.rng.below(4)),
+            _ => format!("string range {w} 0 {}", self.rng.below(4)),
+        }
+    }
+
+    /// A `list`/`l*` operation producing a value.
+    fn list_op(&mut self) -> String {
+        let list = self.list_literal();
+        match self.rng.below(6) {
+            0 => format!("llength {list}"),
+            1 => format!("lindex {list} {}", self.rng.below(self.config.max_list_len)),
+            2 => format!("lreverse {list}"),
+            3 => format!("lsort {list}"),
+            4 => format!("lrange {list} 0 {}", self.rng.below(self.config.max_list_len)),
+            _ => format!("lsearch {list} {}", self.rng.pick(WORDS)),
+        }
+    }
+
+    /// A (possibly nested) integer expression. Division/modulo guard against a
+    /// zero divisor so both engines agree on the (non-error) result.
+    fn expr(&mut self, depth: u32) -> String {
+        if depth >= self.config.max_expr_depth || self.rng.chance(1, 2) {
+            // Leaf: a variable read or a small integer literal.
+            return if self.rng.chance(1, 2) {
+                format!("${}", self.var())
+            } else {
+                self.rng.below(20).to_string()
+            };
+        }
+        let op = *self.rng.pick(&["+", "-", "*", "/", "%", "<", ">", "==", "!=", "&&", "||"]);
+        let left = self.expr(depth + 1);
+        let right = self.expr(depth + 1);
+        match op {
+            // Guard divide/modulo so a zero divisor can't make one engine error
+            // and the other not — that is a divergence in the *test*, not the VM.
+            "/" | "%" => format!("({left}) {op} (({right}) == 0 ? 1 : ({right}))"),
+            _ => format!("({left}) {op} ({right})"),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn deterministic_for_seed() {
+        let cfg = GenConfig::default();
+        assert_eq!(generate(42, &cfg), generate(42, &cfg));
+        assert_ne!(generate(1, &cfg), generate(2, &cfg));
+    }
+
+    #[test]
+    fn balanced_delimiters() {
+        let cfg = GenConfig::default();
+        for seed in 0..200 {
+            let src = generate(seed, &cfg);
+            let (mut brace, mut brack) = (0i32, 0i32);
+            for b in src.bytes() {
+                match b {
+                    b'{' => brace += 1,
+                    b'}' => brace -= 1,
+                    b'[' => brack += 1,
+                    b']' => brack -= 1,
+                    _ => {}
+                }
+                assert!(brace >= 0 && brack >= 0, "seed {seed}: closer before opener");
+            }
+            assert_eq!(brace, 0, "seed {seed}: unbalanced braces\n{src}");
+            assert_eq!(brack, 0, "seed {seed}: unbalanced brackets\n{src}");
+        }
+    }
+
+    #[test]
+    fn nonempty_and_prints() {
+        let cfg = GenConfig::default();
+        // Most scripts should contain a `puts` so the differential has output.
+        let with_puts = (0..100).filter(|s| generate(*s, &cfg).contains("puts")).count();
+        assert!(with_puts > 50, "too few scripts print output: {with_puts}/100");
+    }
+}

--- a/rust/tcl-fuzz/src/harness.rs
+++ b/rust/tcl-fuzz/src/harness.rs
@@ -1,0 +1,183 @@
+//! Differential harness: run a script through both backends and compare.
+//!
+//! Each backend runs as a subprocess (so a hang or crash is contained and
+//! killed on timeout) reading the script from a file. The outcome is the pair
+//! `(stdout, status)`; a mismatch in either is a finding.
+
+use std::io::Write as _;
+use std::path::Path;
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+/// One backend's outcome on a script.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Outcome {
+    /// Process exited; carries normalised stdout and whether it reported an
+    /// error (non-zero exit). Stderr is folded into the error flag, not
+    /// compared verbatim — error *message* text legitimately differs between
+    /// engines.
+    Ran {
+        /// Normalised stdout.
+        stdout: String,
+        /// Whether the engine reported an error (non-zero exit).
+        errored: bool,
+    },
+    /// The process exceeded the wall-clock timeout (a hang).
+    Timeout,
+    /// The backend could not be launched (binary missing / spawn error).
+    Unavailable(String),
+}
+
+/// How two backends' outcomes relate.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Verdict {
+    /// Identical stdout and matching error status.
+    Match,
+    /// stdout differed.
+    StdoutMismatch,
+    /// One engine errored and the other did not.
+    StatusMismatch,
+    /// One engine hung.
+    Timeout,
+    /// A backend was unavailable — the script is skipped, not a finding.
+    Skipped,
+}
+
+/// Run `script` through the backend `binary` with a wall-clock `timeout`.
+#[must_use]
+pub fn run_backend(binary: &Path, script_file: &Path, timeout: Duration) -> Outcome {
+    let mut child = match Command::new(binary)
+        .arg(script_file)
+        .stdin(Stdio::null())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+    {
+        Ok(c) => c,
+        Err(e) => return Outcome::Unavailable(format!("{}: {e}", binary.display())),
+    };
+
+    // Poll for completion up to the timeout, then kill.
+    let start = Instant::now();
+    loop {
+        match child.try_wait() {
+            Ok(Some(status)) => {
+                let out = child.wait_with_output().map(|o| o.stdout).unwrap_or_default();
+                return Outcome::Ran {
+                    stdout: normalise(&String::from_utf8_lossy(&out)),
+                    errored: !status.success(),
+                };
+            }
+            Ok(None) => {
+                if start.elapsed() >= timeout {
+                    let _ = child.kill();
+                    let _ = child.wait();
+                    return Outcome::Timeout;
+                }
+                std::thread::sleep(Duration::from_millis(5));
+            }
+            Err(e) => return Outcome::Unavailable(format!("wait: {e}")),
+        }
+    }
+}
+
+/// Normalise stdout for comparison: trailing whitespace per line removed and a
+/// single trailing newline, so insignificant spacing differences don't trip a
+/// false finding.
+fn normalise(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for line in s.lines() {
+        out.push_str(line.trim_end());
+        out.push('\n');
+    }
+    while out.ends_with("\n\n") {
+        out.pop();
+    }
+    out
+}
+
+/// Compare the reference (`tclsh`) and subject (`tclvm`) outcomes.
+#[must_use]
+// The unavailable-backend and reference-timeout arms both skip, but for
+// distinct reasons worth keeping as separate arms.
+#[allow(clippy::match_same_arms)]
+pub fn compare(reference: &Outcome, subject: &Outcome) -> Verdict {
+    match (reference, subject) {
+        (Outcome::Unavailable(_), _) | (_, Outcome::Unavailable(_)) => Verdict::Skipped,
+        // A reference timeout means the *script* is pathological; skip it
+        // rather than blame the subject.
+        (Outcome::Timeout, _) => Verdict::Skipped,
+        (_, Outcome::Timeout) => Verdict::Timeout,
+        (
+            Outcome::Ran { stdout: rs, errored: re },
+            Outcome::Ran { stdout: ss, errored: se },
+        ) => {
+            if re != se {
+                Verdict::StatusMismatch
+            } else if !re && rs != ss {
+                // Only compare stdout when neither errored (an errored run's
+                // partial stdout is not meaningfully comparable).
+                Verdict::StdoutMismatch
+            } else {
+                Verdict::Match
+            }
+        }
+    }
+}
+
+/// Write `script` to a fresh temp file and return its path. The caller removes
+/// it. The file keeps a `.tcl` suffix so a `tclsh` shebang/source works.
+pub fn write_script(dir: &Path, seed: u64, script: &str) -> std::io::Result<std::path::PathBuf> {
+    let path = dir.join(format!("fuzz-{seed}.tcl"));
+    let mut f = std::fs::File::create(&path)?;
+    f.write_all(script.as_bytes())?;
+    Ok(path)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ran(stdout: &str, errored: bool) -> Outcome {
+        Outcome::Ran {
+            stdout: stdout.to_owned(),
+            errored,
+        }
+    }
+
+    #[test]
+    fn identical_is_match() {
+        assert_eq!(compare(&ran("1\n2\n", false), &ran("1\n2\n", false)), Verdict::Match);
+    }
+
+    #[test]
+    fn stdout_divergence_flagged() {
+        assert_eq!(compare(&ran("1\n", false), &ran("2\n", false)), Verdict::StdoutMismatch);
+    }
+
+    #[test]
+    fn status_divergence_flagged() {
+        assert_eq!(compare(&ran("", true), &ran("", false)), Verdict::StatusMismatch);
+        // Both error → match (error messages aren't compared).
+        assert_eq!(compare(&ran("x", true), &ran("y", true)), Verdict::Match);
+    }
+
+    #[test]
+    fn subject_timeout_flagged_reference_timeout_skipped() {
+        assert_eq!(compare(&ran("", false), &Outcome::Timeout), Verdict::Timeout);
+        assert_eq!(compare(&Outcome::Timeout, &ran("", false)), Verdict::Skipped);
+    }
+
+    #[test]
+    fn unavailable_backend_skips() {
+        assert_eq!(
+            compare(&Outcome::Unavailable("x".into()), &ran("", false)),
+            Verdict::Skipped
+        );
+    }
+
+    #[test]
+    fn normalise_trims_and_collapses() {
+        assert_eq!(normalise("a  \nb\n\n\n"), "a\nb\n");
+    }
+}

--- a/rust/tcl-fuzz/src/main.rs
+++ b/rust/tcl-fuzz/src/main.rs
@@ -1,0 +1,245 @@
+//! `tcl-fuzz` — differential fuzzer for the native Tcl VM.
+//!
+//! Generates pure, bounded Tcl over the VM's supported surface, runs each
+//! script through both `tclvm` (subject) and `tclsh` (reference), and records
+//! any divergence in stdout or error status. See the module docs for the
+//! generator scope and the comparison rules.
+
+#![forbid(unsafe_code)]
+
+mod campaign;
+mod findings;
+mod generator;
+mod harness;
+mod rng;
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use clap::{Parser, Subcommand};
+
+use campaign::{Campaign, Stats};
+use findings::Registry;
+use generator::{generate, GenConfig};
+use harness::{compare, run_backend, write_script, Outcome};
+
+/// Differential fuzzer for the native Tcl bytecode VM.
+#[derive(Parser)]
+#[command(name = "tcl-fuzz", version, about)]
+struct Cli {
+    /// Path to the `tclvm` (subject) binary. Defaults to one beside this
+    /// executable, else `tclvm` on `PATH`.
+    #[arg(long, global = true)]
+    tclvm: Option<PathBuf>,
+    /// Path to the reference `tclsh`. Defaults to `tclsh9.0`, else `tclsh`.
+    #[arg(long, global = true)]
+    tclsh: Option<PathBuf>,
+    /// Findings directory.
+    #[arg(long, global = true, default_value = "fuzz-findings")]
+    findings: PathBuf,
+    /// Per-script timeout, in milliseconds.
+    #[arg(long, global = true, default_value_t = 5000)]
+    timeout_ms: u64,
+    #[command(subcommand)]
+    command: Cmd,
+}
+
+#[derive(Subcommand)]
+enum Cmd {
+    /// Run a fuzzing campaign.
+    Run {
+        /// Number of scripts to generate and test.
+        #[arg(long, default_value_t = 1000)]
+        iterations: u64,
+        /// Starting seed (each iteration uses seed + i). Defaults to a
+        /// time-based seed.
+        #[arg(long)]
+        seed: Option<u64>,
+        /// Print each finding's seed as it is discovered.
+        #[arg(long)]
+        verbose: bool,
+    },
+    /// Replay a single seed and print both engines' output side by side.
+    Replay {
+        /// The seed to reproduce.
+        seed: u64,
+    },
+    /// Print a summary of the findings registry.
+    Summary,
+}
+
+fn main() -> std::process::ExitCode {
+    let cli = Cli::parse();
+    let timeout = Duration::from_millis(cli.timeout_ms);
+    let config = GenConfig::default();
+
+    match &cli.command {
+        Cmd::Run { iterations, seed, verbose } => {
+            let Some(tclvm) = resolve_tclvm(cli.tclvm.as_deref()) else {
+                eprintln!("error: could not find `tclvm` (pass --tclvm <path>)");
+                return std::process::ExitCode::from(2);
+            };
+            let tclsh = resolve_tclsh(cli.tclsh.as_deref());
+            let registry = match Registry::open(&cli.findings) {
+                Ok(r) => r,
+                Err(e) => {
+                    eprintln!("error: opening findings dir: {e}");
+                    return std::process::ExitCode::from(2);
+                }
+            };
+            let scratch = std::env::temp_dir().join(format!("tcl-fuzz-{}", std::process::id()));
+            let _ = std::fs::create_dir_all(&scratch);
+            let base_seed = seed.unwrap_or_else(time_seed);
+
+            eprintln!(
+                "campaign: {iterations} iterations from seed {base_seed}\n  subject: {}\n  reference: {}",
+                tclvm.display(),
+                tclsh.display(),
+            );
+            let campaign = Campaign {
+                tclsh: &tclsh,
+                tclvm: &tclvm,
+                timeout,
+                config,
+                registry: &registry,
+                scratch: scratch.clone(),
+            };
+            let mut last_findings = 0u64;
+            let stats = campaign.run(base_seed, *iterations, |i, stats| {
+                if *verbose && stats.findings() > last_findings {
+                    eprintln!("  finding @ iteration {i}");
+                    last_findings = stats.findings();
+                } else if i % 100 == 0 {
+                    eprintln!("  {i}/{iterations} — {} findings", stats.findings());
+                }
+            });
+            let _ = std::fs::remove_dir_all(&scratch);
+            print_stats(&stats);
+            // Exit non-zero when a divergence was found, so CI can gate on it.
+            if stats.findings() > 0 {
+                std::process::ExitCode::from(1)
+            } else {
+                std::process::ExitCode::SUCCESS
+            }
+        }
+        Cmd::Replay { seed } => {
+            let Some(tclvm) = resolve_tclvm(cli.tclvm.as_deref()) else {
+                eprintln!("error: could not find `tclvm` (pass --tclvm <path>)");
+                return std::process::ExitCode::from(2);
+            };
+            let tclsh = resolve_tclsh(cli.tclsh.as_deref());
+            if let Ok(registry) = Registry::open(&cli.findings)
+                && let Some(prior) = registry.load(*seed)
+            {
+                eprintln!("note: seed {seed} is a recorded finding ({:?})", prior.category);
+            }
+            replay(*seed, &config, &tclvm, &tclsh, timeout);
+            std::process::ExitCode::SUCCESS
+        }
+        Cmd::Summary => {
+            match Registry::open(&cli.findings) {
+                Ok(registry) => {
+                    let summary = registry.summary();
+                    if summary.is_empty() {
+                        println!("no findings in {}", cli.findings.display());
+                    } else {
+                        println!("findings in {}:", cli.findings.display());
+                        for (cat, n) in summary {
+                            println!("  {cat:?}: {n}");
+                        }
+                    }
+                    std::process::ExitCode::SUCCESS
+                }
+                Err(e) => {
+                    eprintln!("error: {e}");
+                    std::process::ExitCode::from(2)
+                }
+            }
+        }
+    }
+}
+
+/// Regenerate `seed`, run both engines, and print a side-by-side comparison.
+fn replay(seed: u64, config: &GenConfig, tclvm: &Path, tclsh: &Path, timeout: Duration) {
+    let script = generate(seed, config);
+    println!("=== script (seed {seed}) ===\n{script}");
+    let scratch = std::env::temp_dir();
+    let Ok(path) = write_script(&scratch, seed, &script) else {
+        eprintln!("error: could not write scratch script");
+        return;
+    };
+    let reference = run_backend(tclsh, &path, timeout);
+    let subject = run_backend(tclvm, &path, timeout);
+    let _ = std::fs::remove_file(&path);
+    println!("=== tclsh (reference) ===\n{}", render(&reference));
+    println!("=== tclvm (subject) ===\n{}", render(&subject));
+    println!("=== verdict: {:?} ===", compare(&reference, &subject));
+}
+
+fn render(o: &Outcome) -> String {
+    match o {
+        Outcome::Ran { stdout, errored } => {
+            format!("[errored={errored}]\n{stdout}")
+        }
+        Outcome::Timeout => "<timeout>".to_owned(),
+        Outcome::Unavailable(m) => format!("<unavailable: {m}>"),
+    }
+}
+
+fn print_stats(stats: &Stats) {
+    eprintln!(
+        "\ncampaign complete:\n  total {} | matched {} | skipped {}\n  findings: stdout {} | status {} | timeout {} (new this run: {})",
+        stats.total,
+        stats.matched,
+        stats.skipped,
+        stats.stdout_mismatch,
+        stats.status_mismatch,
+        stats.timeout,
+        stats.new_findings,
+    );
+}
+
+/// Locate the `tclvm` binary: explicit flag, then beside this executable, then
+/// `PATH`.
+fn resolve_tclvm(explicit: Option<&Path>) -> Option<PathBuf> {
+    if let Some(p) = explicit {
+        return p.is_file().then(|| p.to_owned());
+    }
+    if let Ok(exe) = std::env::current_exe()
+        && let Some(dir) = exe.parent()
+    {
+        let beside = dir.join("tclvm");
+        if beside.is_file() {
+            return Some(beside);
+        }
+    }
+    which("tclvm")
+}
+
+/// Locate the reference `tclsh`: explicit flag, then `tclsh9.0`, then `tclsh`.
+fn resolve_tclsh(explicit: Option<&Path>) -> PathBuf {
+    if let Some(p) = explicit {
+        return p.to_owned();
+    }
+    which("tclsh9.0")
+        .or_else(|| which("tclsh"))
+        .unwrap_or_else(|| PathBuf::from("tclsh"))
+}
+
+/// Find an executable on `PATH`.
+fn which(name: &str) -> Option<PathBuf> {
+    let path = std::env::var_os("PATH")?;
+    std::env::split_paths(&path)
+        .map(|dir| dir.join(name))
+        .find(|p| p.is_file())
+}
+
+/// A coarse time-based seed for ad-hoc campaigns. The nanosecond count is
+/// folded into 64 bits — any value works as a seed.
+fn time_seed() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .ok()
+        .and_then(|d| u64::try_from(d.as_nanos() & u128::from(u64::MAX)).ok())
+        .unwrap_or(0x1234_5678)
+}

--- a/rust/tcl-fuzz/src/rng.rs
+++ b/rust/tcl-fuzz/src/rng.rs
@@ -1,0 +1,46 @@
+//! A tiny deterministic PRNG (`xorshift64*`) so a campaign is fully
+//! reproducible from a seed without pulling in the `rand` crate.
+
+/// A reproducible `xorshift64*` generator. Identical seeds yield identical
+/// streams, so any finding can be replayed from its recorded seed.
+pub struct Rng {
+    state: u64,
+}
+
+impl Rng {
+    /// Seed the generator. A zero seed is remapped (xorshift requires a
+    /// non-zero state).
+    #[must_use]
+    pub fn new(seed: u64) -> Self {
+        Self {
+            state: if seed == 0 { 0x9E37_79B9_7F4A_7C15 } else { seed },
+        }
+    }
+
+    /// Next raw 64-bit value.
+    pub fn next_u64(&mut self) -> u64 {
+        let mut x = self.state;
+        x ^= x >> 12;
+        x ^= x << 25;
+        x ^= x >> 27;
+        self.state = x;
+        x.wrapping_mul(0x2545_F491_4F6C_DD1D)
+    }
+
+    /// Uniform-ish integer in `0..n` (`n > 0`).
+    pub fn below(&mut self, n: usize) -> usize {
+        debug_assert!(n > 0);
+        usize::try_from(self.next_u64() % n as u64).unwrap_or(0)
+    }
+
+    /// `true` with probability `num/den`.
+    pub fn chance(&mut self, num: u32, den: u32) -> bool {
+        debug_assert!(den > 0);
+        (self.next_u64() % u64::from(den)) < u64::from(num)
+    }
+
+    /// Pick a reference to a random element of a non-empty slice.
+    pub fn pick<'a, T>(&mut self, items: &'a [T]) -> &'a T {
+        &items[self.below(items.len())]
+    }
+}

--- a/rust/tcl-irule-test/Cargo.toml
+++ b/rust/tcl-irule-test/Cargo.toml
@@ -1,0 +1,28 @@
+# `tcl-irule-test` — the iRule test framework (TMM-simulation harness).
+#
+# The TMM simulation itself is the body of Tcl under `tooling/irule_test/tcl/`
+# (orchestrator + TMM shim + command mocks) that runs an iRule inside a Tcl
+# interpreter — in the Rust port, on `tcl-vm`. This crate is the Rust-side glue
+# the Python `tooling/irule_test/` package provides: turning a parsed BIG-IP
+# config into orchestrator setup commands (topology), and driving the
+# orchestrator through a session API.
+#
+# Status: the topology generator is portable today (it consumes the Rust
+# BIG-IP model in `tcl-bigip`); the session driver is gated on the VM growing
+# the iRule command surface (HTTP::, pool/node, events) that the orchestrator
+# Tcl needs — see the `session` module.
+[package]
+name = "tcl-irule-test"
+description = "iRule test framework: BIG-IP topology → orchestrator setup, and the TMM-sim session driver"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+tcl-bigip = { path = "../tcl-bigip" }
+
+[lints]
+workspace = true

--- a/rust/tcl-irule-test/Cargo.toml
+++ b/rust/tcl-irule-test/Cargo.toml
@@ -23,6 +23,10 @@ authors.workspace = true
 
 [dependencies]
 tcl-bigip = { path = "../tcl-bigip" }
+tcl-vm = { path = "../tcl-vm" }
+tcl-compiler = { path = "../tcl-compiler" }
+tcl-registry = { path = "../tcl-registry" }
+tcl-bytecode = { path = "../tcl-bytecode" }
 
 [lints]
 workspace = true

--- a/rust/tcl-irule-test/src/embedded.rs
+++ b/rust/tcl-irule-test/src/embedded.rs
@@ -37,6 +37,12 @@ const BUNDLE: &[(&str, &str)] = &[
     // Generated data the framework sources transitively via `info script`.
     bundled!("_registry_data.tcl"),
     bundled!("_event_data.tcl"),
+    // Generated stub mocks for registry-only iRule commands (e.g.
+    // `ACCESS::session`, `AAA::auth`). `LiveSession::bootstrap` sources this
+    // before `itest_core.tcl` when present, so an embedded simulator must carry
+    // it too — otherwise `f5 explain-flow --simulate` would fail on any iRule
+    // using a stub-only command that a repo checkout would have handled.
+    bundled!("_mock_stubs.tcl"),
 ];
 
 /// A temporary directory holding the materialised orchestrator framework. The

--- a/rust/tcl-irule-test/src/embedded.rs
+++ b/rust/tcl-irule-test/src/embedded.rs
@@ -1,0 +1,94 @@
+//! Embedded orchestrator Tcl — the TMM-sim framework bundled into the binary.
+//!
+//! The simulation is the body of Tcl under `tooling/irule_test/tcl/`. So a
+//! consumer (e.g. `f5 explain-flow --simulate`) need not ship that tree
+//! alongside the binary, the required framework files are embedded with
+//! [`include_str!`] and materialised to a temporary directory on demand. The
+//! returned [`EmbeddedLib`] is a directory handle a [`crate::LiveSession`] can
+//! be pointed at; it removes the directory when dropped.
+
+use std::io;
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+/// One bundled framework file: its name and contents.
+macro_rules! bundled {
+    ($name:literal) => {
+        (
+            $name,
+            include_str!(concat!("../../../tooling/irule_test/tcl/", $name)),
+        )
+    };
+}
+
+/// Every framework file the orchestrator needs, materialised together so the
+/// `[file dirname [info script]]` sibling lookups (`_registry_data.tcl`,
+/// `_event_data.tcl`) resolve. Order is irrelevant on disk — [`crate::LiveSession`]
+/// sources them in dependency order.
+const BUNDLE: &[(&str, &str)] = &[
+    bundled!("compat84.tcl"),
+    bundled!("state_layers.tcl"),
+    bundled!("tmm_shim.tcl"),
+    bundled!("expr_ops.tcl"),
+    bundled!("profiler.tcl"),
+    bundled!("command_mocks.tcl"),
+    bundled!("itest_core.tcl"),
+    bundled!("orchestrator.tcl"),
+    // Generated data the framework sources transitively via `info script`.
+    bundled!("_registry_data.tcl"),
+    bundled!("_event_data.tcl"),
+];
+
+/// A temporary directory holding the materialised orchestrator framework. The
+/// directory (and its contents) are removed when this handle is dropped.
+pub struct EmbeddedLib {
+    dir: PathBuf,
+}
+
+impl EmbeddedLib {
+    /// Write the bundled framework to a fresh temp directory.
+    ///
+    /// # Errors
+    /// Any filesystem error creating the directory or writing a file.
+    pub fn materialise() -> io::Result<Self> {
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        let dir = std::env::temp_dir().join(format!(
+            "tcl-irule-test-{}-{n}",
+            std::process::id()
+        ));
+        std::fs::create_dir_all(&dir)?;
+        for (name, contents) in BUNDLE {
+            std::fs::write(dir.join(name), contents)?;
+        }
+        Ok(Self { dir })
+    }
+
+    /// The directory holding `orchestrator.tcl` — pass to [`crate::LiveSession::new`].
+    #[must_use]
+    pub fn path(&self) -> &Path {
+        &self.dir
+    }
+}
+
+impl Drop for EmbeddedLib {
+    fn drop(&mut self) {
+        // Best-effort cleanup; a leftover temp dir is harmless.
+        let _ = std::fs::remove_dir_all(&self.dir);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn materialise_writes_orchestrator() {
+        let lib = EmbeddedLib::materialise().expect("materialise");
+        assert!(lib.path().join("orchestrator.tcl").is_file());
+        assert!(lib.path().join("_registry_data.tcl").is_file());
+        let dir = lib.path().to_path_buf();
+        drop(lib);
+        assert!(!dir.exists(), "temp dir removed on drop");
+    }
+}

--- a/rust/tcl-irule-test/src/lib.rs
+++ b/rust/tcl-irule-test/src/lib.rs
@@ -26,7 +26,11 @@
 
 #![forbid(unsafe_code)]
 
+pub mod embedded;
+pub mod live;
 pub mod session;
 pub mod topology;
 
+pub use embedded::EmbeddedLib;
+pub use live::{LiveSession, SessionError};
 pub use topology::{Topology, TopologyError};

--- a/rust/tcl-irule-test/src/lib.rs
+++ b/rust/tcl-irule-test/src/lib.rs
@@ -1,0 +1,32 @@
+//! iRule test framework — simulate BIG-IP TMM event processing.
+//!
+//! Rust port of the glue half of the Python `tooling/irule_test/` package. The
+//! TMM simulation itself is the Tcl orchestrator + shim + command mocks under
+//! `tooling/irule_test/tcl/`, which run an iRule inside a Tcl interpreter — in
+//! the Rust port, on [`tcl-vm`](https://docs.rs). This crate provides the
+//! Rust-side glue:
+//!
+//! * [`topology`] — turn a parsed BIG-IP config ([`tcl_bigip`]) into the
+//!   `::orch::` setup commands that configure the orchestrator for a virtual
+//!   server (profiles, VIP, pools, data-groups, attached iRules). This is the
+//!   port of `topology.py::TopologyFromSCF` and is usable today.
+//! * [`session`] — the driver that bootstraps the orchestrator Tcl on the VM
+//!   and fires events. The structure mirrors `bridge.py::IruleTestSession`;
+//!   running events end-to-end is gated on the VM growing the iRule command
+//!   surface the orchestrator relies on (see the module docs).
+//!
+//! ```no_run
+//! use tcl_irule_test::topology::Topology;
+//!
+//! let topo = Topology::from_source(std::fs::read_to_string("bigip.conf")?.as_str());
+//! let setup = topo.generate_tcl_setup("/Common/my_vs")?;
+//! // `setup` is a Tcl fragment of `::orch::configure` / `::orch::add_pool` / …
+//! # Ok::<(), Box<dyn std::error::Error>>(())
+//! ```
+
+#![forbid(unsafe_code)]
+
+pub mod session;
+pub mod topology;
+
+pub use topology::{Topology, TopologyError};

--- a/rust/tcl-irule-test/src/live.rs
+++ b/rust/tcl-irule-test/src/live.rs
@@ -164,7 +164,14 @@ impl LiveSession {
     /// [`SessionError::Eval`] on an error completion, [`SessionError::Compile`]
     /// if the script does not compile.
     pub fn eval(&mut self, script: &str) -> Result<String, SessionError> {
-        match self.vm.eval_source(script) {
+        let result = self.vm.eval_source(script);
+        // A guest `exit` records a code on the VM rather than killing the host;
+        // surface it as a handleable error and clear it so the next eval is
+        // clean (the session, not the process, decides what to do).
+        if let Some(code) = self.vm.take_exit() {
+            return Err(SessionError::Eval(format!("script called exit {code}")));
+        }
+        match result {
             Ok(c) if c.code == Code::Error => Err(SessionError::Eval(c.result.to_str().to_string())),
             Ok(c) => Ok(c.result.to_str().to_string()),
             Err(e) => Err(SessionError::Compile(e.message)),
@@ -274,6 +281,40 @@ mod tests {
         s.load_irule("when HTTP_REQUEST {\n  pool web\n}").unwrap();
         s.run_http_request("-host x.example.com -uri /").unwrap();
         assert_eq!(s.pool_selected().unwrap(), "web");
+    }
+
+    #[test]
+    fn embedded_session_includes_generated_stubs() {
+        // `_mock_stubs.tcl` provides mocks for registry-only iRule commands (no
+        // hand-written mock). Without it bundled, a stub-only command like
+        // `ACCESS::session` errors "invalid command name" inside the handler,
+        // which `fire_event`'s `catch` stops — so the following `pool` never
+        // runs. Reaching the pool selection proves the stub dispatched.
+        let mut s = LiveSession::embedded().expect("embedded session");
+        s.eval("::orch::configure -profiles {TCP HTTP}").unwrap();
+        s.eval("::orch::add_pool web {10.0.2.1:80}").unwrap();
+        s.load_irule("when HTTP_REQUEST {\n  ACCESS::session\n  pool web\n}")
+            .unwrap();
+        s.run_http_request("-host x.example.com -uri /").unwrap();
+        assert_eq!(
+            s.pool_selected().unwrap(),
+            "web",
+            "stub-only ACCESS::session must dispatch, not abort the handler"
+        );
+    }
+
+    #[test]
+    fn guest_exit_does_not_kill_the_host() {
+        // The whole point of routing `exit` through a VM completion: a guest
+        // script calling `exit` must NOT terminate this test process. If it
+        // still called `std::process::exit`, the test binary would die here.
+        let mut s = LiveSession::embedded().expect("embedded session");
+        match s.eval("exit 7") {
+            Err(SessionError::Eval(_)) => {}
+            other => panic!("exit should surface as a handleable error, got {other:?}"),
+        }
+        // The session is still usable afterwards.
+        assert_eq!(s.eval("expr {1 + 1}").unwrap(), "2");
     }
 
     #[test]

--- a/rust/tcl-irule-test/src/live.rs
+++ b/rust/tcl-irule-test/src/live.rs
@@ -1,0 +1,287 @@
+//! Live VM driver — run the TMM-sim orchestrator Tcl on [`tcl-vm`] and drive a
+//! real event round-trip.
+//!
+//! This is the runtime half of `tooling/irule_test/bridge.py::IruleTestSession`.
+//! Where [`crate::session::SessionPlan`] assembles the *bootstrap script*, a
+//! [`LiveSession`] actually stands the orchestrator up on a bytecode VM, loads
+//! an iRule, fires events, and reads back the pool/node decisions, captured
+//! logs, and assertion results — entirely in-process, no `tclsh` subprocess.
+//!
+//! The simulation itself is the ~500 KB of Tcl under `tooling/irule_test/tcl/`
+//! (orchestrator + TMM shim + command mocks); the driver sources those files in
+//! the same order `runner.tcl` does, then exposes a thin Rust API over the
+//! `::orch::` command surface.
+
+use std::cell::RefCell;
+use std::io::Write;
+use std::path::Path;
+use std::rc::Rc;
+
+use tcl_compiler::cfg_builder::build_cfg_codegen as build_cfg;
+use tcl_compiler::codegen::codegen_module;
+use tcl_compiler::lowering::lower_to_ir_for_bytecode as lower_to_ir;
+use tcl_registry::CommandRegistry;
+use tcl_vm::{Code, CompileError, CompileService, Vm};
+
+/// The framework files the orchestrator depends on, in source order — mirrors
+/// the `source` block at the top of `runner.tcl`. `_mock_stubs.tcl` is sourced
+/// conditionally (it may not be generated), matching the runner.
+const FRAMEWORK_FILES: &[&str] = &[
+    "compat84.tcl",
+    "state_layers.tcl",
+    "tmm_shim.tcl",
+    "expr_ops.tcl",
+    "profiler.tcl",
+    "command_mocks.tcl",
+    "itest_core.tcl",
+    "orchestrator.tcl",
+];
+
+/// A session error: a failed bootstrap, compile, or orchestrator command. Holds
+/// the Tcl-level message so callers can surface it verbatim.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum SessionError {
+    /// The orchestrator library directory or a required file is missing.
+    MissingLib(String),
+    /// A Tcl evaluation returned an error completion (the message is the result).
+    Eval(String),
+    /// A compile failure in the VM's compile service.
+    Compile(String),
+}
+
+impl std::fmt::Display for SessionError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::MissingLib(p) => write!(f, "iRule-test library not found: {p}"),
+            Self::Eval(m) => write!(f, "orchestrator error: {m}"),
+            Self::Compile(m) => write!(f, "compile error: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for SessionError {}
+
+/// The `CompileService` the VM uses to compile the orchestrator Tcl and any
+/// runtime `eval` / command substitution: the real Rust compiler pipeline.
+struct Svc(CommandRegistry);
+
+impl CompileService for Svc {
+    type Module = tcl_bytecode::ModuleAsm;
+    fn compile(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let ir = lower_to_ir(src, &self.0);
+        let cfg = build_cfg(&ir, false);
+        Ok(codegen_module(&cfg, &ir, &self.0))
+    }
+}
+
+/// A shared, in-memory sink for the VM's `puts` output.
+#[derive(Clone)]
+struct Capture(Rc<RefCell<Vec<u8>>>);
+
+impl Write for Capture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// A live orchestrator session running on a bytecode VM.
+pub struct LiveSession {
+    vm: Vm,
+    output: Rc<RefCell<Vec<u8>>>,
+}
+
+impl LiveSession {
+    /// Stand a session up: build a VM, source the orchestrator framework from
+    /// `lib_dir`, and run `::orch::init`. `lib_dir` is the directory holding
+    /// `orchestrator.tcl` (i.e. `tooling/irule_test/tcl/`).
+    ///
+    /// # Errors
+    /// [`SessionError::MissingLib`] if `lib_dir` or a required file is absent,
+    /// or [`SessionError::Eval`] / [`SessionError::Compile`] if the framework
+    /// fails to load.
+    pub fn new(lib_dir: &Path) -> Result<Self, SessionError> {
+        if !lib_dir.join("orchestrator.tcl").is_file() {
+            return Err(SessionError::MissingLib(lib_dir.display().to_string()));
+        }
+        let output = Rc::new(RefCell::new(Vec::new()));
+        let mut vm = Vm::with_output(Box::new(Capture(Rc::clone(&output))));
+        vm.set_compiler(Box::new(Svc(CommandRegistry::build_default())));
+        let mut session = Self { vm, output };
+        session.bootstrap(lib_dir)?;
+        session.eval("::orch::init")?;
+        Ok(session)
+    }
+
+    /// Stand a session up against the framework Tcl embedded in the binary
+    /// (no on-disk `tooling/irule_test/tcl/` checkout needed). The bundled
+    /// directory is materialised for the lifetime of the call and removed
+    /// afterwards — its contents are sourced into the VM, so nothing is lost.
+    ///
+    /// # Errors
+    /// [`SessionError::MissingLib`] if the bundle cannot be written, or a
+    /// bootstrap error from the framework load.
+    pub fn embedded() -> Result<Self, SessionError> {
+        let lib = crate::embedded::EmbeddedLib::materialise()
+            .map_err(|e| SessionError::MissingLib(e.to_string()))?;
+        Self::new(lib.path())
+    }
+
+    /// Source the framework files (absolute paths, in dependency order); the
+    /// optional `_mock_stubs.tcl` is sourced only when present, like the runner.
+    fn bootstrap(&mut self, lib_dir: &Path) -> Result<(), SessionError> {
+        for file in FRAMEWORK_FILES {
+            let path = lib_dir.join(file);
+            if !path.is_file() {
+                return Err(SessionError::MissingLib(path.display().to_string()));
+            }
+            // `command_mocks.tcl` runs before `itest_core.tcl`; slot the
+            // optional generated stubs in between, matching `runner.tcl`.
+            if *file == "itest_core.tcl" {
+                let stubs = lib_dir.join("_mock_stubs.tcl");
+                if stubs.is_file() {
+                    self.source_file(&stubs)?;
+                }
+            }
+            self.source_file(&path)?;
+        }
+        Ok(())
+    }
+
+    /// Source a single file by absolute path through the VM's `source` (so the
+    /// framework's `[file dirname [info script]]` lookups resolve correctly).
+    fn source_file(&mut self, path: &Path) -> Result<(), SessionError> {
+        let script = format!("source {{{}}}", path.display());
+        self.eval(&script).map(|_| ())
+    }
+
+    /// Evaluate a Tcl `script` and return its string result.
+    ///
+    /// # Errors
+    /// [`SessionError::Eval`] on an error completion, [`SessionError::Compile`]
+    /// if the script does not compile.
+    pub fn eval(&mut self, script: &str) -> Result<String, SessionError> {
+        match self.vm.eval_source(script) {
+            Ok(c) if c.code == Code::Error => Err(SessionError::Eval(c.result.to_str().to_string())),
+            Ok(c) => Ok(c.result.to_str().to_string()),
+            Err(e) => Err(SessionError::Compile(e.message)),
+        }
+    }
+
+    /// Load an iRule into the orchestrator (`::orch::load_irule`). The source is
+    /// passed as a braced word, so it must be brace-balanced (iRule bodies are).
+    ///
+    /// # Errors
+    /// Propagates an orchestrator/compile error.
+    pub fn load_irule(&mut self, source: &str) -> Result<(), SessionError> {
+        self.eval(&format!("::orch::load_irule {{{source}}}"))
+            .map(|_| ())
+    }
+
+    /// Run one HTTP request through the configured flow (`::orch::run_http_request`
+    /// with the given `args` fragment, e.g. `-host api.example.com -uri /`).
+    ///
+    /// # Errors
+    /// Propagates an orchestrator error (e.g. no matching flow chain).
+    pub fn run_http_request(&mut self, args: &str) -> Result<String, SessionError> {
+        self.eval(&format!("::orch::run_http_request {args}"))
+    }
+
+    /// The pool the iRule selected on the last request (empty if none).
+    ///
+    /// # Errors
+    /// Propagates an orchestrator error.
+    pub fn pool_selected(&mut self) -> Result<String, SessionError> {
+        self.eval("set ::state::lb::pool")
+    }
+
+    /// The recorded decision log as a Tcl list (one `{category action args}`
+    /// per entry).
+    ///
+    /// # Errors
+    /// Propagates an orchestrator error.
+    pub fn decisions(&mut self) -> Result<String, SessionError> {
+        self.eval("::itest::get_decisions")
+    }
+
+    /// The captured iRule log messages.
+    ///
+    /// # Errors
+    /// Propagates an orchestrator error.
+    pub fn logs(&mut self) -> Result<String, SessionError> {
+        self.eval("::state::log_capture::get")
+    }
+
+    /// Drain and return everything written to the VM's stdout (`puts`) so far.
+    pub fn take_output(&mut self) -> String {
+        let bytes = std::mem::take(&mut *self.output.borrow_mut());
+        String::from_utf8_lossy(&bytes).into_owned()
+    }
+
+    /// Borrow the underlying VM (for advanced drivers needing direct access).
+    pub fn vm_mut(&mut self) -> &mut Vm {
+        &mut self.vm
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    /// The in-repo orchestrator Tcl directory, relative to this crate.
+    fn lib_dir() -> PathBuf {
+        PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+            .join("../../tooling/irule_test/tcl")
+            .canonicalize()
+            .expect("orchestrator tcl dir")
+    }
+
+    #[test]
+    fn live_session_routes_request_to_pool() {
+        let mut s = LiveSession::new(&lib_dir()).expect("session");
+        s.eval("::orch::configure -profiles {TCP HTTP}").unwrap();
+        s.eval("::orch::add_pool api_pool {10.0.1.1:8080}").unwrap();
+        s.load_irule(
+            "when HTTP_REQUEST {\n  if { [HTTP::host] eq \"api.example.com\" } {\n    pool api_pool\n  }\n}",
+        )
+        .unwrap();
+        s.run_http_request("-host api.example.com -uri /").unwrap();
+        assert_eq!(s.pool_selected().unwrap(), "api_pool");
+    }
+
+    #[test]
+    fn live_session_records_reject_decision() {
+        let mut s = LiveSession::new(&lib_dir()).expect("session");
+        s.eval("::orch::configure -profiles {TCP HTTP}").unwrap();
+        s.load_irule("when HTTP_REQUEST {\n  reject\n}").unwrap();
+        s.run_http_request("-host evil.example.com -uri /").unwrap();
+        let decisions = s.decisions().unwrap();
+        assert!(
+            decisions.contains("connection reject"),
+            "decisions: {decisions}"
+        );
+    }
+
+    #[test]
+    fn embedded_session_routes_request() {
+        let mut s = LiveSession::embedded().expect("embedded session");
+        s.eval("::orch::configure -profiles {TCP HTTP}").unwrap();
+        s.eval("::orch::add_pool web {10.0.2.1:80}").unwrap();
+        s.load_irule("when HTTP_REQUEST {\n  pool web\n}").unwrap();
+        s.run_http_request("-host x.example.com -uri /").unwrap();
+        assert_eq!(s.pool_selected().unwrap(), "web");
+    }
+
+    #[test]
+    fn missing_lib_dir_errors() {
+        match LiveSession::new(Path::new("/no/such/dir")) {
+            Err(SessionError::MissingLib(_)) => {}
+            Err(other) => panic!("wrong error: {other}"),
+            Ok(_) => panic!("expected a MissingLib error"),
+        }
+    }
+}

--- a/rust/tcl-irule-test/src/session.rs
+++ b/rust/tcl-irule-test/src/session.rs
@@ -1,0 +1,115 @@
+//! Session driver — bootstrap the TMM-sim orchestrator on the VM and fire
+//! events.
+//!
+//! Mirrors `tooling/irule_test/bridge.py::IruleTestSession`. The simulation is
+//! the Tcl under `tooling/irule_test/tcl/` (orchestrator + TMM shim + command
+//! mocks); a session sources it on a [`tcl-vm`] interpreter, applies a
+//! [`crate::topology`] setup (or hand-built `::orch::` calls), fires events,
+//! and reads back the pool/node decisions, logs, and assertions.
+//!
+//! # Status: gated on the VM iRule surface
+//!
+//! Running events end-to-end needs the VM to provide the iRule command surface
+//! the orchestrator relies on — `HTTP::*`, `pool`/`node`, `LB::*`, the `when`
+//! event dispatch, `class match`, etc. Those are not yet implemented in
+//! `tcl-vm` (tracked under **RT-VM**), so this module defines the **session
+//! contract and the setup-script assembly** that the driver will use, without
+//! yet wiring a live VM. The pieces that do not need the VM — topology
+//! generation and the orchestrator-bootstrap script assembly — are usable now
+//! and unit-tested.
+//!
+//! When the VM surface lands, [`SessionPlan::into_bootstrap`] is the exact
+//! script a `tcl-vm` driver runs to stand a session up; only the
+//! `run_*`/`assert_*` round-trip needs adding.
+
+use crate::topology::{Topology, TopologyError};
+
+/// The transport / L7 profiles a session is configured with (the orchestrator
+/// `-profiles` list).
+#[derive(Debug, Clone, Default)]
+pub struct Profiles(pub Vec<String>);
+
+impl Profiles {
+    /// Render as the orchestrator `-profiles {…}` argument.
+    #[must_use]
+    pub fn to_tcl(&self) -> String {
+        self.0.join(" ")
+    }
+}
+
+/// A fully-assembled session bootstrap: the orchestrator `source`s, the
+/// `::orch::init`, the topology/`configure` setup, and the loaded iRules — i.e.
+/// everything needed to stand the session up on the VM before firing events.
+#[derive(Debug, Clone)]
+pub struct SessionPlan {
+    profiles: Profiles,
+    setup: String,
+}
+
+impl SessionPlan {
+    /// Build a plan from an explicit profile list and a topology setup fragment
+    /// (e.g. from [`Topology::generate_tcl_setup`]).
+    #[must_use]
+    pub fn new(profiles: Profiles, setup: impl Into<String>) -> Self {
+        Self {
+            profiles,
+            setup: setup.into(),
+        }
+    }
+
+    /// Build a plan for `vs_name` in `topology`, deriving the orchestrator setup
+    /// from the parsed config.
+    ///
+    /// # Errors
+    /// Propagates [`TopologyError`] when the virtual server is not found.
+    pub fn from_topology(topology: &Topology, vs_name: &str) -> Result<Self, TopologyError> {
+        let setup = topology.generate_tcl_setup(vs_name)?;
+        Ok(Self::new(Profiles::default(), setup))
+    }
+
+    /// Assemble the Tcl bootstrap script a VM driver runs: source the
+    /// orchestrator, initialise it, apply the configured profiles, then the
+    /// topology/iRule setup. The orchestrator/shim Tcl is sourced from
+    /// `lib_dir` (the directory holding `orchestrator.tcl`).
+    #[must_use]
+    pub fn into_bootstrap(&self, lib_dir: &str) -> String {
+        use std::fmt::Write as _;
+        let mut s = String::new();
+        let _ = writeln!(s, "source [file join {{{lib_dir}}} orchestrator.tcl]");
+        let _ = writeln!(s, "source [file join {{{lib_dir}}} scf_loader.tcl]");
+        s.push_str("::orch::init\n");
+        if !self.profiles.0.is_empty() {
+            let _ = writeln!(s, "::orch::configure -profiles {{{}}}", self.profiles.to_tcl());
+        }
+        s.push_str(&self.setup);
+        s
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bootstrap_assembles_orchestrator_script() {
+        let plan = SessionPlan::new(
+            Profiles(vec!["TCP".into(), "HTTP".into()]),
+            "::orch::add_pool p {1.2.3.4:80}\n",
+        );
+        let boot = plan.into_bootstrap("/opt/itest");
+        assert!(boot.contains("source [file join {/opt/itest} orchestrator.tcl]"));
+        assert!(boot.contains("::orch::init"));
+        assert!(boot.contains("::orch::configure -profiles {TCP HTTP}"));
+        assert!(boot.contains("::orch::add_pool p {1.2.3.4:80}"));
+    }
+
+    #[test]
+    fn plan_from_topology() {
+        let conf = "ltm virtual v { destination 10.0.0.1:80 profiles { http { } } }";
+        let topo = Topology::from_source(conf);
+        let plan = SessionPlan::from_topology(&topo, "v").expect("plan");
+        let boot = plan.into_bootstrap("lib");
+        assert!(boot.contains("::orch::configure -profiles {TCP HTTP}"));
+        assert!(boot.contains("-local_addr 10.0.0.1 -local_port 80"));
+    }
+}

--- a/rust/tcl-irule-test/src/topology.rs
+++ b/rust/tcl-irule-test/src/topology.rs
@@ -1,0 +1,410 @@
+//! SCF topology bridge — generate orchestrator setup Tcl from a BIG-IP config.
+//!
+//! Port of `tooling/irule_test/topology.py::TopologyFromSCF`. Parses a
+//! bigip.conf / SCF source via [`tcl_bigip`] and emits the `::orch::` commands
+//! that configure the iRule-test orchestrator for a given virtual server:
+//! profiles, the VIP address/port, pools + members, data-groups, and the
+//! attached iRules.
+
+use std::fmt::Write as _;
+
+use tcl_bigip::model::ModelObject;
+use tcl_bigip::parser::{parse_bigip_conf, BigipConfig};
+use tcl_bigip::value::ListItemValue;
+
+/// Errors raised when generating a topology setup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TopologyError {
+    /// No virtual server matched the requested name.
+    VirtualServerNotFound(String),
+}
+
+impl std::fmt::Display for TopologyError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::VirtualServerNotFound(name) => {
+                write!(f, "Virtual server {name:?} not found")
+            }
+        }
+    }
+}
+
+impl std::error::Error for TopologyError {}
+
+/// A parsed BIG-IP config that can emit orchestrator setup for its virtual
+/// servers.
+pub struct Topology {
+    config: BigipConfig,
+}
+
+impl Topology {
+    /// Build from an already-parsed config.
+    #[must_use]
+    pub fn new(config: BigipConfig) -> Self {
+        Self { config }
+    }
+
+    /// Parse a bigip.conf / SCF source string (partition defaults to `Common`).
+    #[must_use]
+    pub fn from_source(source: &str) -> Self {
+        Self::new(parse_bigip_conf(source, "Common"))
+    }
+
+    /// The parsed config.
+    #[must_use]
+    pub fn config(&self) -> &BigipConfig {
+        &self.config
+    }
+
+    /// Full paths of every virtual server, in source order.
+    #[must_use]
+    pub fn virtual_servers(&self) -> Vec<&str> {
+        self.config
+            .objects
+            .iter()
+            .filter(|p| p.table_name == "virtual_servers")
+            .map(|p| p.full_path.as_str())
+            .collect()
+    }
+
+    /// Generate the `::orch::` setup Tcl for `vs_name`.
+    ///
+    /// Mirrors `TopologyFromSCF.generate_tcl_setup`: configure profiles + VIP,
+    /// register every pool (by full path and short name) with members, register
+    /// data-groups, and load the VS's attached iRules.
+    ///
+    /// # Errors
+    /// [`TopologyError::VirtualServerNotFound`] when no VS matches `vs_name`.
+    pub fn generate_tcl_setup(&self, vs_name: &str) -> Result<String, TopologyError> {
+        let vs = self
+            .resolve_virtual(vs_name)
+            .ok_or_else(|| TopologyError::VirtualServerNotFound(vs_name.to_owned()))?;
+        let vs_path = vs.name.as_str();
+
+        let mut out = String::new();
+        let _ = writeln!(out, "# Auto-generated from SCF topology");
+        let _ = writeln!(out, "# Virtual server: {vs_path}");
+        out.push('\n');
+
+        // Profiles. Ensure a transport profile is present if any are.
+        let mut profile_types = self.resolve_profile_types(vs);
+        if !profile_types.is_empty()
+            && !profile_types.iter().any(|t| t == "TCP" || t == "UDP")
+        {
+            profile_types.insert(0, "TCP".to_owned());
+        }
+        let profiles_tcl = if profile_types.is_empty() {
+            "TCP HTTP".to_owned()
+        } else {
+            profile_types.join(" ")
+        };
+        let _ = writeln!(out, "::orch::configure -profiles {{{profiles_tcl}}}");
+
+        // VIP address / port.
+        if let Some(dest) = &vs.destination {
+            let _ = writeln!(
+                out,
+                "::orch::configure -local_addr {} -local_port {}",
+                dest.address, dest.port
+            );
+        }
+        out.push('\n');
+
+        // Pools (full path + short name) with members.
+        let mut any_pool = false;
+        for placed in &self.config.objects {
+            if placed.table_name != "pools" {
+                continue;
+            }
+            let ModelObject::Pool(pool) = &placed.object else {
+                continue;
+            };
+            let members = pool_member_names(pool);
+            if members.is_empty() {
+                continue;
+            }
+            any_pool = true;
+            let members_tcl = members.join(" ");
+            let key = placed.full_path.as_str();
+            let _ = writeln!(out, "::orch::add_pool {key} {{{members_tcl}}}");
+            let short = short_name(key);
+            if short != key {
+                let _ = writeln!(out, "::orch::add_pool {short} {{{members_tcl}}}");
+            }
+        }
+        if any_pool {
+            out.push('\n');
+        }
+
+        // Data-groups (full path + short name).
+        let mut any_dg = false;
+        for placed in &self.config.objects {
+            if placed.table_name != "data_groups" {
+                continue;
+            }
+            let ModelObject::DataGroup(dg) = &placed.object else {
+                continue;
+            };
+            any_dg = true;
+            let dg_type = if dg.value_type.is_empty() {
+                "string"
+            } else {
+                dg.value_type.as_str()
+            };
+            let records_tcl = datagroup_records_tcl(&dg.records);
+            let key = placed.full_path.as_str();
+            let _ = writeln!(out, "::orch::add_datagroup {key} {dg_type} {{{records_tcl}}}");
+            let short = short_name(key);
+            if short != key {
+                let _ = writeln!(out, "::orch::add_datagroup {short} {dg_type} {{{records_tcl}}}");
+            }
+        }
+        if any_dg {
+            out.push('\n');
+        }
+
+        // Attached iRules.
+        for rule_ref in vs_rule_refs(vs) {
+            if let Some(source) = self.rule_source(&rule_ref) {
+                let _ = writeln!(out, "::orch::load_irule {{{source}}}");
+            }
+        }
+        out.push('\n');
+
+        Ok(out)
+    }
+
+    /// Generate a complete standalone test script for `vs_name`.
+    ///
+    /// # Errors
+    /// [`TopologyError::VirtualServerNotFound`] when no VS matches `vs_name`.
+    pub fn generate_full_test_script(&self, vs_name: &str) -> Result<String, TopologyError> {
+        let setup = self.generate_tcl_setup(vs_name)?;
+        let mut out = String::new();
+        let _ = writeln!(out, "#!/usr/bin/env tclsh");
+        let _ = writeln!(out, "#");
+        let _ = writeln!(out, "# Test script for virtual server: {vs_name}");
+        let _ = writeln!(out, "# Auto-generated -- customise the test scenarios below.");
+        let _ = writeln!(out, "#\n");
+        let _ = writeln!(out, "set script_dir [file dirname [info script]]");
+        let _ = writeln!(out, "source [file join $script_dir orchestrator.tcl]");
+        let _ = writeln!(out, "source [file join $script_dir scf_loader.tcl]\n");
+        let _ = writeln!(out, "::orch::init\n");
+        let _ = writeln!(out, "# Topology setup\n");
+        out.push_str(&setup);
+        let _ = writeln!(out, "\n# Test scenarios\n");
+        let _ = writeln!(out, "::orch::run_http_request -method GET -uri \"/\" -host \"example.com\"\n");
+        let _ = writeln!(out, "::orch::summary");
+        Ok(out)
+    }
+
+    /// Resolve a virtual server by full path, short name, or `/Common/`-prefixed
+    /// name. Mirrors the Python `resolve_name` over the `virtual_servers` table.
+    fn resolve_virtual(&self, name: &str) -> Option<&tcl_bigip::model::BigipVirtualServer> {
+        let mut by_short: Option<&tcl_bigip::model::BigipVirtualServer> = None;
+        for placed in &self.config.objects {
+            if placed.table_name != "virtual_servers" {
+                continue;
+            }
+            let ModelObject::VirtualServer(vs) = &placed.object else {
+                continue;
+            };
+            if placed.full_path == name {
+                return Some(vs);
+            }
+            if short_name(&placed.full_path) == name || placed.full_path == format!("/Common/{name}")
+            {
+                by_short.get_or_insert(vs);
+            }
+        }
+        by_short
+    }
+
+    /// Resolve the TMM profile-type tags for a VS, mirroring
+    /// `_resolve_profile_types` (inference path).
+    ///
+    /// Currently name-inference only; the refinement is to first resolve each
+    /// profile *object* (`self.config`) and read its `ProfileType`, falling back
+    /// to inference — which is why this stays a method on `self`.
+    #[allow(clippy::unused_self)]
+    fn resolve_profile_types(&self, vs: &tcl_bigip::model::BigipVirtualServer) -> Vec<String> {
+        let mut types: Vec<String> = Vec::new();
+        for pref in vs_profile_refs(vs) {
+            if let Some(t) = infer_profile_type(&pref)
+                && !types.iter().any(|existing| *existing == t)
+            {
+                types.push(t.to_owned());
+            }
+        }
+        types
+    }
+
+    /// The source of an attached iRule, resolved by full path or short name.
+    fn rule_source(&self, rule_ref: &str) -> Option<&str> {
+        let mut by_short: Option<&str> = None;
+        for placed in &self.config.objects {
+            if placed.table_name != "rules" {
+                continue;
+            }
+            let ModelObject::Rule(rule) = &placed.object else {
+                continue;
+            };
+            if placed.full_path == rule_ref {
+                return Some(rule.source.as_str());
+            }
+            if short_name(&placed.full_path) == rule_ref
+                || placed.full_path == format!("/Common/{rule_ref}")
+            {
+                by_short.get_or_insert(rule.source.as_str());
+            }
+        }
+        by_short
+    }
+}
+
+/// The last `/`-separated component of a path (the short name).
+fn short_name(path: &str) -> &str {
+    path.rsplit('/').next().unwrap_or(path)
+}
+
+/// Member names of a pool (the `node:port` strings the orchestrator expects).
+fn pool_member_names(pool: &tcl_bigip::model::BigipPool) -> Vec<String> {
+    pool.members
+        .items
+        .iter()
+        .filter_map(|item| match &item.value {
+            ListItemValue::PoolMember(m) => Some(m.name.clone()),
+            _ => None,
+        })
+        .collect()
+}
+
+/// iRule references attached to a VS, as their path strings.
+fn vs_rule_refs(vs: &tcl_bigip::model::BigipVirtualServer) -> Vec<String> {
+    vs.rules.paths()
+}
+
+/// Profile references on a VS, as their path strings.
+fn vs_profile_refs(vs: &tcl_bigip::model::BigipVirtualServer) -> Vec<String> {
+    vs.profiles.paths()
+}
+
+/// Render data-group records as the even-length `{key {}}` Tcl list the
+/// orchestrator's `add_datagroup` expects. Mirrors the Python rendering.
+fn datagroup_records_tcl(records: &[String]) -> String {
+    let mut parts: Vec<String> = Vec::new();
+    for rec in records {
+        // key -> empty value (`{}`), keeping the list even-length.
+        let key = if rec.contains(' ') && rec != "{}" {
+            format!("{{{rec}}}")
+        } else {
+            rec.clone()
+        };
+        parts.push(key);
+        parts.push("{}".to_owned());
+    }
+    parts.join(" ")
+}
+
+/// Infer a TMM profile-type tag from a profile reference name. Port of
+/// `_infer_profile_type`.
+fn infer_profile_type(pref: &str) -> Option<&'static str> {
+    let name = short_name(pref).to_ascii_lowercase();
+    if name.contains("clientssl") || name.contains("client-ssl") {
+        Some("CLIENTSSL")
+    } else if name.contains("serverssl") || name.contains("server-ssl") {
+        Some("SERVERSSL")
+    } else if name == "http" || name == "http2" {
+        Some("HTTP")
+    } else if name == "tcp" {
+        Some("TCP")
+    } else if name == "udp" {
+        Some("UDP")
+    } else if name.contains("dns") {
+        Some("DNS")
+    } else if name.contains("fasthttp") {
+        Some("FASTHTTP")
+    } else {
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const CONF: &str = "\
+ltm pool web_pool {
+    members {
+        10.0.1.1:80 { address 10.0.1.1 }
+        10.0.1.2:80 { address 10.0.1.2 }
+    }
+}
+ltm rule redirect_rule {
+when HTTP_REQUEST {
+    if { [HTTP::host] eq \"api.example.com\" } {
+        pool web_pool
+    }
+}
+}
+ltm virtual www_vs {
+    destination 10.0.0.1:443
+    profiles {
+        clientssl { }
+        http { }
+    }
+    rules {
+        redirect_rule
+    }
+}
+";
+
+    #[test]
+    fn lists_virtual_servers() {
+        let topo = Topology::from_source(CONF);
+        assert_eq!(topo.virtual_servers(), vec!["/Common/www_vs"]);
+    }
+
+    #[test]
+    fn generates_setup_for_vs() {
+        let topo = Topology::from_source(CONF);
+        let setup = topo.generate_tcl_setup("www_vs").expect("setup");
+        // Profiles inferred + TCP prepended; CLIENTSSL/HTTP from the names.
+        assert!(setup.contains("::orch::configure -profiles {TCP CLIENTSSL HTTP}"), "{setup}");
+        // VIP from the destination.
+        assert!(setup.contains("::orch::configure -local_addr 10.0.0.1 -local_port 443"), "{setup}");
+        // Pool with members, by full path and short name.
+        assert!(setup.contains("::orch::add_pool /Common/web_pool {10.0.1.1:80 10.0.1.2:80}"), "{setup}");
+        assert!(setup.contains("::orch::add_pool web_pool {10.0.1.1:80 10.0.1.2:80}"), "{setup}");
+        // Attached iRule body loaded.
+        assert!(setup.contains("::orch::load_irule {"), "{setup}");
+        assert!(setup.contains("HTTP::host"), "{setup}");
+    }
+
+    #[test]
+    fn unknown_vs_errors() {
+        let topo = Topology::from_source(CONF);
+        assert_eq!(
+            topo.generate_tcl_setup("nope"),
+            Err(TopologyError::VirtualServerNotFound("nope".to_owned()))
+        );
+    }
+
+    #[test]
+    fn full_test_script_wraps_setup() {
+        let topo = Topology::from_source(CONF);
+        let script = topo.generate_full_test_script("www_vs").expect("script");
+        assert!(script.contains("source [file join $script_dir orchestrator.tcl]"));
+        assert!(script.contains("::orch::init"));
+        assert!(script.contains("::orch::add_pool /Common/web_pool"));
+        assert!(script.contains("::orch::summary"));
+    }
+
+    #[test]
+    fn infers_profile_types() {
+        assert_eq!(infer_profile_type("/Common/clientssl"), Some("CLIENTSSL"));
+        assert_eq!(infer_profile_type("http"), Some("HTTP"));
+        assert_eq!(infer_profile_type("/Common/my-fasthttp"), Some("FASTHTTP"));
+        assert_eq!(infer_profile_type("/Common/weird"), None);
+    }
+}

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -97,6 +97,38 @@ pub struct CodeAction {
     pub kind: ActionKind,
     /// Optional command run after the edit (e.g. trigger a rename).
     pub command: Option<ActionCommand>,
+    /// Optional structured payload surfaced as the LSP code action's
+    /// `data` field.  Currently carries the rendered tmsh `ltm
+    /// data-group internal …` definition for the extract-to-datagroup
+    /// refactor (mirrors Python's
+    /// `_datagroup_to_code_action`'s `data={"data_group_definition": …}`);
+    /// the iRule text rewrite is the action's `edits`, and this field
+    /// lets tooling (MCP, AI, clipboard) consume the data-group
+    /// definition without injecting comment blocks into the source.
+    pub data_group_definition: Option<String>,
+}
+
+impl CodeAction {
+    /// Construct a `CodeAction` with no `data_group_definition`.
+    ///
+    /// The common path: every action except the extract-to-datagroup
+    /// refactor leaves the structured payload unset, so this keeps the
+    /// call sites free of a `data_group_definition: None` field.
+    #[must_use]
+    pub fn new(
+        title: String,
+        edits: Vec<crate::rename::TextEdit>,
+        kind: ActionKind,
+        command: Option<ActionCommand>,
+    ) -> Self {
+        Self {
+            title,
+            edits,
+            kind,
+            command,
+            data_group_definition: None,
+        }
+    }
 }
 
 /// Compute code actions for `range` in `source`.
@@ -156,6 +188,7 @@ pub fn code_actions(
                     }],
                     kind: ActionKind::QuickFix,
                     command: None,
+                    data_group_definition: None,
                 });
             }
         }
@@ -195,6 +228,7 @@ pub fn code_actions(
                 }],
                 kind: ActionKind::QuickFix,
                 command: None,
+                data_group_definition: None,
             });
         }
     }
@@ -285,6 +319,7 @@ pub fn check_diagnostic_actions<S: std::hash::BuildHasher>(
                 }],
                 kind: ActionKind::QuickFix,
                 command: None,
+                data_group_definition: None,
             });
         }
     }
@@ -321,6 +356,7 @@ fn build_unset_nocomplain_action(
         }],
         kind: ActionKind::QuickFix,
         command: None,
+        data_group_definition: None,
     })
 }
 
@@ -375,6 +411,7 @@ pub fn package_require_actions(
             }],
             kind: ActionKind::QuickFix,
             command: None,
+            data_group_definition: None,
         })
         .collect()
 }
@@ -584,6 +621,7 @@ fn continuation_comment_actions(
         }],
         kind: ActionKind::QuickFix,
         command: None,
+        data_group_definition: None,
     }]
 }
 
@@ -642,6 +680,7 @@ fn ip_conversion_actions(
         }],
         kind: ActionKind::Refactor,
         command: None,
+        data_group_definition: None,
     };
     if is_ipv4(&addr) {
         return vec![make(
@@ -706,6 +745,7 @@ fn expr_rewrite_actions(source: &str, range: LspRange, _line_index: &LineIndex) 
             }],
             kind: ActionKind::RefactorRewrite,
             command: None,
+            data_group_definition: None,
         });
     }
     if let Some(rewritten) = invert_comparison(&sel) {
@@ -717,6 +757,7 @@ fn expr_rewrite_actions(source: &str, range: LspRange, _line_index: &LineIndex) 
             }],
             kind: ActionKind::RefactorRewrite,
             command: None,
+            data_group_definition: None,
         });
     }
     out
@@ -871,6 +912,7 @@ fn docstring_actions(
             }],
             kind: ActionKind::Source,
             command: None,
+            data_group_definition: None,
         });
     }
     out
@@ -880,12 +922,88 @@ fn extract_inline_actions(
     source: &str,
     range: LspRange,
     analysis: &AnalysisResult,
-    _line_index: &LineIndex,
+    line_index: &LineIndex,
 ) -> Vec<CodeAction> {
     let mut out = Vec::new();
     out.extend(extract_proc_action(source, range));
     out.extend(inline_proc_action(source, range, analysis));
+    out.extend(refactor_engine_actions(source, range, analysis, line_index));
     out
+}
+
+/// Surface the [`crate::refactor`] transforms (extract / inline variable,
+/// if↔switch, switch→dict, extract-to-datagroup) as `CodeAction`s.
+///
+/// Mirrors `server/features/code_actions.py::_new_refactor_actions`: the
+/// cursor is `range`'s start; extract-variable additionally needs a
+/// non-empty selection.  The data-group transform is iRules-only — it is
+/// gated by [`crate::refactor::extract_to_datagroup`]'s registry
+/// resolution (a non-iRules registry resolves no `class match` /
+/// `class lookup` form), so offering it unconditionally here is safe.
+fn refactor_engine_actions(
+    source: &str,
+    range: LspRange,
+    analysis: &AnalysisResult,
+    line_index: &LineIndex,
+) -> Vec<CodeAction> {
+    use crate::refactor;
+    // Load the iRules dialect so `when`-body descent and the
+    // `class match` / `class lookup` data-group form resolve.  Loading is
+    // additive — vanilla command resolution is unchanged — so we do it
+    // unconditionally rather than threading the document dialect through
+    // the code-action signature (the data-group transform self-gates on
+    // the registry resolving a `class` form).
+    let mut registry = tcl_registry::CommandRegistry::build_default();
+    registry.load_dialect(tcl_registry::dialects::DialectSet::IRULES);
+    let mut out = Vec::new();
+
+    let cursor = line_index.offset_at_utf16(range.start_line, range.start_character, source);
+    let has_selection =
+        range.start_line != range.end_line || range.start_character != range.end_character;
+
+    // Extract variable — requires a selection.
+    if has_selection {
+        let end = line_index.offset_at_utf16(range.end_line, range.end_character, source);
+        if let Some(r) = refactor::extract_variable(source, cursor, end, "result", line_index) {
+            out.push(refactoring_to_action(&r, source, line_index));
+        }
+    }
+
+    if let Some(r) = refactor::inline_variable(source, cursor, analysis, &registry, line_index) {
+        out.push(refactoring_to_action(&r, source, line_index));
+    }
+    if let Some(r) = refactor::if_to_switch(source, cursor, &registry, line_index) {
+        out.push(refactoring_to_action(&r, source, line_index));
+    }
+    if let Some(r) = refactor::switch_to_dict(source, cursor, &registry, line_index) {
+        out.push(refactoring_to_action(&r, source, line_index));
+    }
+    if let Some(r) = refactor::extract_to_datagroup(source, cursor, "", &registry, line_index) {
+        out.push(refactoring_to_action(&r, source, line_index));
+    }
+    out
+}
+
+/// Lift a [`crate::refactor::Refactoring`] into a [`CodeAction`],
+/// converting its byte-offset edits to LSP coordinates and rendering the
+/// data-group definition (if any) into `data_group_definition`.  Mirrors
+/// `_refactoring_to_code_action` / `_datagroup_to_code_action`.
+fn refactoring_to_action(
+    r: &crate::refactor::Refactoring,
+    source: &str,
+    line_index: &LineIndex,
+) -> CodeAction {
+    CodeAction {
+        title: r.title.clone(),
+        edits: r
+            .edits
+            .iter()
+            .map(|e| e.to_lsp(source, line_index))
+            .collect(),
+        kind: r.kind,
+        command: None,
+        data_group_definition: r.data_group.as_ref().map(crate::refactor::data_group_tcl),
+    }
 }
 
 /// Distinct `$var` / `${var}` names referenced in `text`, in first-seen order.
@@ -999,6 +1117,7 @@ fn extract_proc_action(source: &str, range: LspRange) -> Vec<CodeAction> {
                 name_start + u32::try_from(name.len()).unwrap_or(0),
             ],
         }),
+        data_group_definition: None,
     }]
 }
 
@@ -1069,6 +1188,7 @@ fn inline_proc_action(source: &str, range: LspRange, analysis: &AnalysisResult) 
         }],
         kind: ActionKind::RefactorInline,
         command: None,
+        data_group_definition: None,
     }]
 }
 
@@ -1176,6 +1296,7 @@ pub fn profiles_action(
             }],
             kind: ActionKind::Source,
             command: None,
+            data_group_definition: None,
         });
     }
     Some(CodeAction {
@@ -1194,6 +1315,7 @@ pub fn profiles_action(
         }],
         kind: ActionKind::Source,
         command: None,
+        data_group_definition: None,
     })
 }
 
@@ -1343,6 +1465,7 @@ fn collect_bootstrap_actions(source: &str, d: &ContextDiagnostic) -> Vec<CodeAct
                 }],
                 kind: ActionKind::QuickFix,
                 command: None,
+                data_group_definition: None,
             }
         })
         .collect()
@@ -1438,6 +1561,7 @@ fn taint_quickfix(source: &str, d: &ContextDiagnostic) -> Vec<CodeAction> {
             }],
             kind: ActionKind::QuickFix,
             command: None,
+            data_group_definition: None,
         }];
     }
 
@@ -1483,6 +1607,7 @@ fn taint_quickfix(source: &str, d: &ContextDiagnostic) -> Vec<CodeAction> {
         edits,
         kind: ActionKind::QuickFix,
         command: None,
+        data_group_definition: None,
     }]
 }
 
@@ -1918,5 +2043,72 @@ mod tests {
                 .any(|a| a.title == "Add 'event disable all' + 'return'"),
             "disabled IRULE5002 must not offer a quick-fix, got {actions:?}",
         );
+    }
+
+    // -- refactor-engine dispatch (extract/inline var, if↔switch,
+    //    switch→dict, extract-datagroup) ----------------------------------
+
+    fn analyse(source: &str) -> AnalysisResult {
+        Analyser::new().analyse(source, "tcl8.6").clone()
+    }
+
+    #[test]
+    fn extract_variable_surfaces_with_selection() {
+        let src = "set x [string length $name]";
+        let analysis = analyse(src);
+        // Select the `[string length $name]` value (cols 6..27).
+        let range = LspRange {
+            start_line: 0,
+            start_character: 6,
+            end_line: 0,
+            end_character: 27,
+        };
+        let actions = code_actions(src, range, Some(&analysis));
+        assert!(
+            actions.iter().any(|a| {
+                a.kind == ActionKind::RefactorExtract && a.title.to_lowercase().contains("variable")
+            }),
+            "{actions:?}",
+        );
+    }
+
+    #[test]
+    fn if_to_switch_surfaces_at_cursor() {
+        let src = "if {$x eq \"a\"} {\n    puts 1\n} elseif {$x eq \"b\"} {\n    puts 2\n}";
+        let analysis = analyse(src);
+        let cursor = LspRange {
+            start_line: 0,
+            start_character: 0,
+            end_line: 0,
+            end_character: 0,
+        };
+        let actions = code_actions(src, cursor, Some(&analysis));
+        assert!(
+            actions.iter().any(|a| a.title.to_lowercase().contains("switch")),
+            "{actions:?}",
+        );
+    }
+
+    #[test]
+    fn extract_datagroup_surfaces_and_carries_definition() {
+        let src = "if {$host eq \"a.com\"} {\n    pool web_pool\n} elseif {$host eq \"b.com\"} {\n    pool web_pool\n} elseif {$host eq \"c.com\"} {\n    pool web_pool\n}";
+        let analysis = analyse(src);
+        let cursor = LspRange {
+            start_line: 0,
+            start_character: 0,
+            end_line: 0,
+            end_character: 0,
+        };
+        let actions = code_actions(src, cursor, Some(&analysis));
+        let dg = actions
+            .iter()
+            .find(|a| a.title.to_lowercase().contains("data-group"))
+            .expect("data-group action");
+        let def = dg
+            .data_group_definition
+            .as_ref()
+            .expect("data_group_definition payload");
+        assert!(def.contains("ltm data-group internal"), "{def:?}");
+        assert!(def.contains("type string"), "{def:?}");
     }
 }

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -31,6 +31,7 @@ pub mod irules_object_refs;
 pub mod linked_editing_range;
 pub mod minify;
 pub mod references;
+pub mod refactor;
 pub mod rename;
 pub mod selection_range;
 pub mod semantic_tokens;

--- a/rust/tcl-lsp-core/src/refactor/datagroup.rs
+++ b/rust/tcl-lsp-core/src/refactor/datagroup.rs
@@ -1,0 +1,832 @@
+//! Extract to data-group — convert inline if/switch membership /
+//! mapping patterns to iRules `class match` / `class lookup` against a
+//! generated data-group.  Ports the static-extraction half of
+//! `tooling/refactoring/_extract_datagroup.py` (`extract_to_datagroup`,
+//! `extract_to_datagroup_from_if`, `extract_to_datagroup_from_switch`).
+
+use std::net::{Ipv4Addr, Ipv6Addr};
+
+use tcl_compiler::segmenter::segment_commands_with_offset;
+use tcl_lexer::LineIndex;
+use tcl_registry::CommandRegistry;
+
+use super::{
+    Refactoring, RefactorEdit, command_span_offsets, find_command_at, line_indent, reindent_body,
+    token_end_offset,
+};
+use crate::code_actions::ActionKind;
+
+/// A generated data-group artefact (separate from the iRule edits).
+/// Ports Python's `DataGroupDefinition`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DataGroupDefinition {
+    /// Data-group name.
+    pub name: String,
+    /// Value type: `"string"`, `"ip"`, or `"integer"`.
+    pub value_type: String,
+    /// `(key, value)` records (value empty for a pure membership group).
+    pub records: Vec<(String, String)>,
+}
+
+/// Render a [`DataGroupDefinition`] as a BIG-IP tmsh definition.  Ports
+/// Python's `DataGroupExtractionResult.data_group_tcl`.
+#[must_use]
+pub fn data_group_tcl(dg: &DataGroupDefinition) -> String {
+    let mut lines = vec![format!("ltm data-group internal {} {{", dg.name)];
+    if !dg.records.is_empty() {
+        lines.push("    records {".to_owned());
+        for (key, value) in &dg.records {
+            if value.is_empty() {
+                lines.push(format!("        {key} {{ }}"));
+            } else {
+                lines.push(format!("        {key} {{"));
+                lines.push(format!("            data {value}"));
+                lines.push("        }".to_owned());
+            }
+        }
+        lines.push("    }".to_owned());
+    }
+    lines.push(format!("    type {}", dg.value_type));
+    lines.push("}".to_owned());
+    lines.join("\n")
+}
+
+// ── Value-type inference ──────────────────────────────────────────────
+
+/// `true` when `value` looks like an IPv4/IPv6 address or CIDR range.
+/// Ports `_is_ip_or_cidr` (Python uses `ipaddress.ip_network` /
+/// `ip_address`).
+fn is_ip_or_cidr(value: &str) -> bool {
+    let v = strip_quotes(value);
+    is_ip_address(v) || is_ip_network(v)
+}
+
+fn is_ip_address(v: &str) -> bool {
+    v.parse::<Ipv4Addr>().is_ok() || v.parse::<Ipv6Addr>().is_ok()
+}
+
+/// Parse a `addr/prefix` CIDR (host bits allowed — Python's
+/// `strict=False`), validating the address family and prefix width.
+fn is_ip_network(v: &str) -> bool {
+    let Some((addr, prefix)) = v.split_once('/') else {
+        return false;
+    };
+    let Ok(width) = prefix.parse::<u32>() else {
+        return false;
+    };
+    if addr.parse::<Ipv4Addr>().is_ok() {
+        width <= 32
+    } else if addr.parse::<Ipv6Addr>().is_ok() {
+        width <= 128
+    } else {
+        false
+    }
+}
+
+fn is_integer(value: &str) -> bool {
+    let v = strip_quotes(value).trim();
+    !v.is_empty() && v.parse::<i64>().is_ok()
+}
+
+/// Infer the data-group value type from a list of keys/values.  Ports
+/// `_infer_value_type`.
+fn infer_value_type(values: &[String]) -> &'static str {
+    if values.is_empty() {
+        return "string";
+    }
+    if values.iter().all(|v| is_ip_or_cidr(strip_quotes(v))) {
+        return "ip";
+    }
+    if values.iter().all(|v| is_integer(strip_quotes(v))) {
+        return "integer";
+    }
+    "string"
+}
+
+fn strip_quotes(s: &str) -> &str {
+    let s = s.trim();
+    let b = s.as_bytes();
+    if b.len() >= 2 && b[0] == b'"' && b[b.len() - 1] == b'"' {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+/// Derive a clean data-group name from a descriptive string.  Ports
+/// `_normalise_dg_name`: non-alphanumeric → `_`, collapse runs, trim,
+/// lower-case.
+fn normalise_dg_name(name: &str) -> String {
+    let mut out = String::with_capacity(name.len());
+    let mut prev_underscore = false;
+    for ch in name.chars() {
+        if ch.is_ascii_alphanumeric() || ch == '_' {
+            out.push(ch.to_ascii_lowercase());
+            prev_underscore = false;
+        } else if !prev_underscore {
+            out.push('_');
+            prev_underscore = true;
+        }
+    }
+    let trimmed = out.trim_matches('_');
+    if trimmed.is_empty() {
+        "extracted_dg".to_owned()
+    } else {
+        trimmed.to_owned()
+    }
+}
+
+// ── Equality-condition parsing ────────────────────────────────────────
+
+/// Recognised equality operators.
+const EQ_OPS: &[&str] = &["==", "!=", "eq", "ne"];
+
+/// Parse a simple equality test `(var, value, negated)`.  Ports
+/// `_parse_eq` (used by the datagroup transform; mirrors the shape of
+/// `if_to_switch::parse_eq_test` minus the operator capture).
+fn parse_eq(cond: &str) -> Option<(String, String, bool)> {
+    let mut cond = cond.trim();
+    if cond.starts_with('{') && cond.ends_with('}') && cond.len() >= 2 {
+        cond = cond[1..cond.len() - 1].trim();
+    }
+    let mut negated = false;
+    if let Some(rest) = cond.strip_prefix('!') {
+        let inner = rest.trim();
+        if inner.starts_with('(') && inner.ends_with(')') && inner.len() >= 2 {
+            cond = inner[1..inner.len() - 1].trim();
+            negated = true;
+        }
+    }
+
+    // `$var OP value`.
+    for op in EQ_OPS {
+        let needle = format!(" {op} ");
+        if let Some(pos) = cond.find(&needle)
+            && let Some(var) = parse_var_word(cond[..pos].trim())
+        {
+            let is_ne = *op == "ne" || *op == "!=";
+            return Some((var, cond[pos + needle.len()..].trim().to_owned(), negated ^ is_ne));
+        }
+    }
+    // `value OP $var`.
+    for op in EQ_OPS {
+        let needle = format!(" {op} ");
+        if let Some(pos) = cond.rfind(&needle)
+            && let Some(var) = parse_var_word(cond[pos + needle.len()..].trim())
+        {
+            let is_ne = *op == "ne" || *op == "!=";
+            return Some((var, cond[..pos].trim().to_owned(), negated ^ is_ne));
+        }
+    }
+    None
+}
+
+/// Parse `$var` / `${var}` / `"$var"` to its bare name.
+fn parse_var_word(word: &str) -> Option<String> {
+    let mut w = word.trim();
+    if w.len() >= 2 && w.starts_with('"') && w.ends_with('"') {
+        w = &w[1..w.len() - 1];
+    }
+    let w = w.strip_prefix('$')?;
+    let w = w.strip_prefix('{').unwrap_or(w);
+    let w = w.strip_suffix('}').unwrap_or(w);
+    if !w.is_empty() && w.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        Some(w.to_owned())
+    } else {
+        None
+    }
+}
+
+/// Detect `$var eq "a" || $var eq "b" || …` chains.  Ports
+/// `_try_or_chain`.
+fn try_or_chain(condition: &str) -> Option<(String, Vec<String>)> {
+    let mut cond = condition.trim();
+    if cond.starts_with('{') && cond.ends_with('}') && cond.len() >= 2 {
+        cond = cond[1..cond.len() - 1].trim();
+    }
+    let parts: Vec<&str> = cond.split("||").collect();
+    if parts.len() < 2 {
+        return None;
+    }
+    let mut target_var: Option<String> = None;
+    let mut values = Vec::new();
+    for part in parts {
+        let (var, value, negated) = parse_eq(part.trim())?;
+        if negated {
+            return None;
+        }
+        match &target_var {
+            None => target_var = Some(var),
+            Some(v) if *v != var => return None,
+            _ => {}
+        }
+        values.push(value);
+    }
+    let target_var = target_var?;
+    if values.len() < 2 {
+        return None;
+    }
+    Some((target_var, values))
+}
+
+/// Extract a variable name from `$var` / `${var}` subject.  Ports
+/// `_extract_var_name`.
+fn extract_var_name(subject: &str) -> Option<String> {
+    let s = subject.trim();
+    if let Some(inner) = s.strip_prefix("${").and_then(|x| x.strip_suffix('}')) {
+        return Some(inner.to_owned());
+    }
+    if let Some(name) = s.strip_prefix('$')
+        && !name.is_empty()
+        && name.chars().next().is_some_and(|c| c.is_alphabetic() || c == '_')
+        && name.chars().all(|c| c.is_alphanumeric() || c == '_')
+    {
+        return Some(name.to_owned());
+    }
+    None
+}
+
+// ── set/return body parsing ───────────────────────────────────────────
+
+/// Parsed single-command arm body.
+enum SetOrReturn {
+    Set(String, String),
+    Return(String),
+}
+
+/// Parse a single-command arm body via the tokeniser.  Ports
+/// `_parse_set_or_return`.
+fn parse_set_or_return(text: &str) -> Option<SetOrReturn> {
+    let commands = segment_commands_with_offset(text, 0);
+    if commands.len() != 1 || commands[0].texts.is_empty() {
+        return None;
+    }
+    let cmd = &commands[0];
+    let raw = |index: usize| -> String {
+        let tok = cmd.argv[index];
+        text[tok.span.start() as usize..token_end_offset(text, tok) as usize].to_owned()
+    };
+    if cmd.texts[0] == "set" && cmd.texts.len() == 3 {
+        return Some(SetOrReturn::Set(cmd.texts[1].clone(), raw(2)));
+    }
+    if cmd.texts[0] == "return" && cmd.texts.len() == 2 {
+        return Some(SetOrReturn::Return(raw(1)));
+    }
+    None
+}
+
+/// Extract `(target_var, use_return, values)` from arm bodies.  Ports
+/// `_extract_set_or_return_values`.
+fn extract_set_or_return_values(pairs: &[(String, String)]) -> Option<(String, bool, Vec<String>)> {
+    let mut target_var: Option<String> = None;
+    let mut use_return: Option<bool> = None;
+    let mut values = Vec::new();
+    for (_pattern, body) in pairs {
+        let mut text = body.trim();
+        if text.starts_with('{') && text.ends_with('}') && text.len() >= 2 {
+            text = text[1..text.len() - 1].trim();
+        }
+        match parse_set_or_return(text) {
+            Some(SetOrReturn::Set(var, val)) => {
+                match &target_var {
+                    None => {
+                        target_var = Some(var);
+                        use_return = Some(false);
+                    }
+                    Some(v) if *v != var || use_return == Some(true) => return None,
+                    _ => {}
+                }
+                values.push(val);
+            }
+            Some(SetOrReturn::Return(val)) => {
+                match use_return {
+                    None => {
+                        use_return = Some(true);
+                        target_var = Some("__return__".to_owned());
+                    }
+                    Some(false) => return None,
+                    Some(true) => {}
+                }
+                values.push(val);
+            }
+            None => return None,
+        }
+    }
+    let target_var = target_var?;
+    if values.is_empty() {
+        return None;
+    }
+    Some((target_var, use_return.unwrap_or(false), values))
+}
+
+/// Extract the value from a single arm body.  Ports
+/// `_extract_single_value`.
+fn extract_single_value(body: &str, use_return: bool, target_var: &str) -> Option<String> {
+    let mut text = body.trim();
+    if text.starts_with('{') && text.ends_with('}') && text.len() >= 2 {
+        text = text[1..text.len() - 1].trim();
+    }
+    match parse_set_or_return(text)? {
+        SetOrReturn::Return(val) if use_return => Some(val),
+        SetOrReturn::Set(var, val) if !use_return && var == target_var => Some(val),
+        _ => None,
+    }
+}
+
+// ── if-chain extraction ───────────────────────────────────────────────
+
+/// Extract an if/elseif chain comparing one variable to literals.  Ports
+/// `extract_to_datagroup_from_if`.
+#[must_use]
+pub fn extract_to_datagroup_from_if(
+    source: &str,
+    cursor: u32,
+    dg_name: &str,
+    registry: &CommandRegistry,
+    line_index: &LineIndex,
+) -> Option<Refactoring> {
+    let cmd = find_command_at(source, cursor, Some("if"), registry)?;
+    let chain = parse_if_chain(&cmd.texts)?;
+    if chain.values.len() < 2 {
+        return None;
+    }
+
+    let stripped_values: Vec<String> = chain
+        .values
+        .iter()
+        .map(|v| strip_quotes(v).to_owned())
+        .collect();
+    let value_type = infer_value_type(&stripped_values);
+    let dg_name = resolve_dg_name(dg_name, &format!("{}_whitelist", chain.target_var));
+
+    let indent = command_indent(source, &cmd, line_index).to_owned();
+    let bodies_identical = {
+        let set: std::collections::BTreeSet<&str> =
+            chain.bodies.iter().map(|b| b.trim()).collect();
+        set.len() <= 1
+    };
+
+    let (data_group, replacement) = if bodies_identical && !chain.bodies.is_empty() {
+        membership_extraction(
+            &stripped_values,
+            value_type,
+            &dg_name,
+            &chain.target_var,
+            &chain.bodies[0],
+            chain.else_body.as_deref(),
+            &indent,
+        )
+    } else {
+        let pairs: Vec<(String, String)> = chain
+            .values
+            .iter()
+            .cloned()
+            .zip(chain.bodies.iter().cloned())
+            .collect();
+        let (set_var, use_return, value_entries) = extract_set_or_return_values(&pairs)?;
+        let records = zip_records(&stripped_values, &value_entries);
+        let dg = DataGroupDefinition {
+            name: dg_name.clone(),
+            value_type: "string".to_owned(),
+            records,
+        };
+        let replacement = if use_return {
+            format!("return [class lookup ${} {dg_name}]", chain.target_var)
+        } else {
+            format!("set {set_var} [class lookup ${} {dg_name}]", chain.target_var)
+        };
+        (dg, replacement)
+    };
+
+    Some(build_result(source, &cmd, &dg_name, value_type, replacement, data_group))
+}
+
+/// A parsed if/elseif equality chain.
+struct IfChain {
+    target_var: String,
+    values: Vec<String>,
+    bodies: Vec<String>,
+    else_body: Option<String>,
+}
+
+/// Parse the if/elseif chain (OR-chain in a single condition, or an
+/// `elseif` ladder).  Mirrors the chain-parsing prologue of
+/// `extract_to_datagroup_from_if`.
+fn parse_if_chain(texts: &[String]) -> Option<IfChain> {
+    // OR-chain in a single condition.
+    if texts.len() >= 3
+        && let Some((target_var, values)) = try_or_chain(&texts[1])
+    {
+        return Some(IfChain {
+            target_var,
+            values,
+            bodies: vec![texts[2].clone()],
+            else_body: None,
+        });
+    }
+
+    let mut target_var: Option<String> = None;
+    let mut values: Vec<String> = Vec::new();
+    let mut bodies: Vec<String> = Vec::new();
+    let mut else_body: Option<String> = None;
+    let mut i = 1;
+    while i < texts.len() {
+        let word = &texts[i];
+        if word == "elseif" || word == "then" {
+            i += 1;
+            continue;
+        }
+        if word == "else" {
+            if i + 1 < texts.len() {
+                else_body = Some(texts[i + 1].clone());
+            }
+            break;
+        }
+        if i + 1 >= texts.len() {
+            return None;
+        }
+        let (var, value, negated) = parse_eq(word)?;
+        let body = texts[i + 1].clone();
+        i += 2;
+        if negated {
+            return None;
+        }
+        match &target_var {
+            None => target_var = Some(var),
+            Some(v) if *v != var => return None,
+            _ => {}
+        }
+        values.push(value);
+        bodies.push(body);
+    }
+    Some(IfChain {
+        target_var: target_var?,
+        values,
+        bodies,
+        else_body,
+    })
+}
+
+/// Build a membership-test (`class match`) extraction.
+fn membership_extraction(
+    stripped_values: &[String],
+    value_type: &str,
+    dg_name: &str,
+    target_var: &str,
+    body: &str,
+    else_body: Option<&str>,
+    indent: &str,
+) -> (DataGroupDefinition, String) {
+    let records: Vec<(String, String)> = stripped_values
+        .iter()
+        .map(|v| (v.clone(), String::new()))
+        .collect();
+    let dg = DataGroupDefinition {
+        name: dg_name.to_owned(),
+        value_type: value_type.to_owned(),
+        records,
+    };
+    let body_text = reindent_body(body, &format!("{indent}    "));
+    let replacement = if let Some(eb) = else_body {
+        let else_text = reindent_body(eb, &format!("{indent}    "));
+        format!(
+            "if {{ [class match ${target_var} equals {dg_name}] }} {{\n{body_text}\n{indent}}} else {{\n{else_text}\n{indent}}}"
+        )
+    } else {
+        format!("if {{ [class match ${target_var} equals {dg_name}] }} {{\n{body_text}\n{indent}}}")
+    };
+    (dg, replacement)
+}
+
+/// Pair stripped keys with stripped values into data-group records.
+fn zip_records(keys: &[String], values: &[String]) -> Vec<(String, String)> {
+    keys.iter()
+        .zip(values.iter())
+        .map(|(k, v)| (strip_quotes(k).to_owned(), strip_quotes(v).to_owned()))
+        .collect()
+}
+
+/// Resolve a possibly-empty `dg_name` against a generated default.
+fn resolve_dg_name(dg_name: &str, default_descriptor: &str) -> String {
+    if dg_name.is_empty() {
+        normalise_dg_name(default_descriptor)
+    } else {
+        dg_name.to_owned()
+    }
+}
+
+/// Indent of the command's first line.
+fn command_indent<'a>(
+    source: &'a str,
+    cmd: &tcl_compiler::segmenter::SegmentedCommand,
+    line_index: &LineIndex,
+) -> &'a str {
+    let cmd_line = line_index.line_at(cmd.span.start());
+    source
+        .split('\n')
+        .nth(cmd_line as usize)
+        .map_or("", line_indent)
+}
+
+/// Assemble the final [`Refactoring`] from the computed replacement.
+fn build_result(
+    source: &str,
+    cmd: &tcl_compiler::segmenter::SegmentedCommand,
+    dg_name: &str,
+    value_type: &str,
+    replacement: String,
+    data_group: DataGroupDefinition,
+) -> Refactoring {
+    let (start, end) = command_span_offsets(source, cmd);
+    Refactoring {
+        title: format!("Extract to data-group '{dg_name}' ({value_type})"),
+        edits: vec![RefactorEdit {
+            start,
+            end,
+            new_text: replacement,
+        }],
+        kind: ActionKind::RefactorExtract,
+        data_group: Some(data_group),
+    }
+}
+
+// ── switch extraction ─────────────────────────────────────────────────
+
+/// Extract a switch statement with many literal arms to a data-group.
+/// Ports `extract_to_datagroup_from_switch`.
+#[must_use]
+pub fn extract_to_datagroup_from_switch(
+    source: &str,
+    cursor: u32,
+    dg_name: &str,
+    registry: &CommandRegistry,
+    line_index: &LineIndex,
+) -> Option<Refactoring> {
+    let cmd = find_command_at(source, cursor, Some("switch"), registry)?;
+    let (subject, pairs) = super::parse_exact_switch(&cmd.texts)?;
+    let subject_var = extract_var_name(&subject)?;
+    if pairs.len() < 3 {
+        return None;
+    }
+
+    // Separate default from regular arms.
+    let mut default_body: Option<String> = None;
+    let mut regular_pairs: Vec<(String, String)> = Vec::new();
+    for (pattern, body) in &pairs {
+        if pattern == "default" {
+            default_body = Some(body.clone());
+        } else if body.trim() == "-" {
+            return None; // fallthrough — can't map
+        } else {
+            regular_pairs.push((pattern.clone(), body.clone()));
+        }
+    }
+    if regular_pairs.len() < 3 {
+        return None;
+    }
+
+    let keys: Vec<String> = regular_pairs
+        .iter()
+        .map(|(p, _)| strip_quotes(p).to_owned())
+        .collect();
+    let value_type = infer_value_type(&keys);
+    let dg_name = resolve_dg_name(dg_name, &format!("{subject_var}_map"));
+    let indent = command_indent(source, &cmd, line_index).to_owned();
+
+    let all_same = {
+        let set: std::collections::BTreeSet<&str> =
+            regular_pairs.iter().map(|(_, b)| b.trim()).collect();
+        set.len() == 1
+    };
+
+    let (data_group, replacement) = if all_same {
+        membership_extraction(
+            &keys,
+            value_type,
+            &dg_name,
+            &subject_var,
+            &regular_pairs[0].1,
+            default_body.as_deref(),
+            &indent,
+        )
+    } else {
+        switch_mapping_extraction(
+            &regular_pairs,
+            &keys,
+            &subject_var,
+            &dg_name,
+            default_body.as_deref(),
+            &indent,
+        )?
+    };
+
+    Some(build_result(source, &cmd, &dg_name, value_type, replacement, data_group))
+}
+
+/// Build the value-mapping (`class lookup`) extraction for a switch.
+fn switch_mapping_extraction(
+    regular_pairs: &[(String, String)],
+    keys: &[String],
+    subject_var: &str,
+    dg_name: &str,
+    default_body: Option<&str>,
+    indent: &str,
+) -> Option<(DataGroupDefinition, String)> {
+    let (target_var, use_return, value_entries) = extract_set_or_return_values(regular_pairs)?;
+    let records = zip_records(keys, &value_entries);
+    let dg = DataGroupDefinition {
+        name: dg_name.to_owned(),
+        value_type: "string".to_owned(),
+        records,
+    };
+    let replacement = if let Some(default) = default_body {
+        let default_val = extract_single_value(default, use_return, &target_var)
+            .unwrap_or_else(|| strip_quotes(default).to_owned());
+        if use_return {
+            format!(
+                "if {{ [class match ${subject_var} equals {dg_name}] }} {{\n{indent}    return [class lookup ${subject_var} {dg_name}]\n{indent}}} else {{\n{indent}    return {default_val}\n{indent}}}"
+            )
+        } else {
+            format!(
+                "if {{ [class match ${subject_var} equals {dg_name}] }} {{\n{indent}    set {target_var} [class lookup ${subject_var} {dg_name}]\n{indent}}} else {{\n{indent}    set {target_var} {default_val}\n{indent}}}"
+            )
+        }
+    } else if use_return {
+        format!("return [class lookup ${subject_var} {dg_name}]")
+    } else {
+        format!("set {target_var} [class lookup ${subject_var} {dg_name}]")
+    };
+    Some((dg, replacement))
+}
+
+/// Try all static extraction patterns at the cursor — if/elseif first,
+/// then switch.  Ports `extract_to_datagroup`.
+#[must_use]
+pub fn extract_to_datagroup(
+    source: &str,
+    cursor: u32,
+    dg_name: &str,
+    registry: &CommandRegistry,
+    line_index: &LineIndex,
+) -> Option<Refactoring> {
+    extract_to_datagroup_from_if(source, cursor, dg_name, registry, line_index)
+        .or_else(|| extract_to_datagroup_from_switch(source, cursor, dg_name, registry, line_index))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reg() -> CommandRegistry {
+        let mut r = CommandRegistry::build_default();
+        r.load_dialect(tcl_registry::dialects::DialectSet::IRULES);
+        r
+    }
+
+    fn if_dg(source: &str, name: &str) -> Option<Refactoring> {
+        let r = reg();
+        let li = LineIndex::new(source);
+        extract_to_datagroup_from_if(source, 0, name, &r, &li)
+    }
+
+    fn switch_dg(source: &str, name: &str) -> Option<Refactoring> {
+        let r = reg();
+        let li = LineIndex::new(source);
+        extract_to_datagroup_from_switch(source, 0, name, &r, &li)
+    }
+
+    fn dg(r: &Refactoring) -> &DataGroupDefinition {
+        r.data_group.as_ref().expect("data group")
+    }
+
+    #[test]
+    fn if_chain_string_membership() {
+        let source = "if {$host eq \"a.com\"} {\n    pool web_pool\n} elseif {$host eq \"b.com\"} {\n    pool web_pool\n} elseif {$host eq \"c.com\"} {\n    pool web_pool\n}";
+        let r = if_dg(source, "allowed_hosts").expect("result");
+        let g = dg(&r);
+        assert_eq!(g.value_type, "string");
+        assert_eq!(g.name, "allowed_hosts");
+        assert_eq!(g.records.len(), 3);
+        assert!(g.records.contains(&("a.com".to_owned(), String::new())));
+        let tcl = data_group_tcl(g);
+        assert!(tcl.contains("type string"));
+        let applied = r.apply(source);
+        assert!(applied.contains("class match"), "{applied:?}");
+        assert!(applied.contains("allowed_hosts"));
+    }
+
+    #[test]
+    fn if_chain_ip_addresses() {
+        let source = "if {$addr eq \"10.0.0.0/8\"} {\n    drop\n} elseif {$addr eq \"172.16.0.0/12\"} {\n    drop\n} elseif {$addr eq \"192.168.0.0/16\"} {\n    drop\n}";
+        let r = if_dg(source, "rfc1918").expect("result");
+        let g = dg(&r);
+        assert_eq!(g.value_type, "ip");
+        let tcl = data_group_tcl(g);
+        assert!(tcl.contains("type ip"));
+        assert!(tcl.contains("10.0.0.0/8"));
+    }
+
+    #[test]
+    fn if_chain_ipv6_addresses() {
+        let source = "if {$addr eq \"2001:db8::/32\"} {\n    drop\n} elseif {$addr eq \"fd00::/8\"} {\n    drop\n} elseif {$addr eq \"fe80::1\"} {\n    drop\n}";
+        let r = if_dg(source, "blocked_v6").expect("result");
+        let g = dg(&r);
+        assert_eq!(g.value_type, "ip");
+        let tcl = data_group_tcl(g);
+        assert!(tcl.contains("2001:db8::/32"));
+        assert!(tcl.contains("fd00::/8"));
+        assert!(tcl.contains("fe80::1"));
+    }
+
+    #[test]
+    fn if_chain_integers_membership() {
+        let source = "if {$port eq \"80\"} {\n    log local0. \"http\"\n} elseif {$port eq \"443\"} {\n    log local0. \"http\"\n} elseif {$port eq \"8080\"} {\n    log local0. \"http\"\n}";
+        let r = if_dg(source, "http_ports").expect("result");
+        assert_eq!(dg(&r).value_type, "integer");
+    }
+
+    #[test]
+    fn if_chain_value_mapping() {
+        let source = "if {$port eq \"80\"} {\n    set proto http\n} elseif {$port eq \"443\"} {\n    set proto https\n} elseif {$port eq \"8080\"} {\n    set proto http\n}";
+        let r = if_dg(source, "port_map").expect("result");
+        assert_eq!(dg(&r).value_type, "string");
+    }
+
+    #[test]
+    fn switch_membership() {
+        let source = "switch -exact -- $ext {\n    .jpg { set type image }\n    .png { set type image }\n    .gif { set type image }\n    .svg { set type image }\n}";
+        let r = switch_dg(source, "image_types").expect("result");
+        let g = dg(&r);
+        assert_eq!(g.value_type, "string");
+        assert_eq!(g.records.len(), 4);
+    }
+
+    #[test]
+    fn switch_value_mapping() {
+        let source = "switch -exact -- $method {\n    GET { set handler handle_get }\n    POST { set handler handle_post }\n    PUT { set handler handle_put }\n    DELETE { set handler handle_delete }\n}";
+        let r = switch_dg(source, "method_handler_map").expect("result");
+        assert!(dg(&r).records.iter().any(|(_, v)| !v.is_empty()));
+    }
+
+    #[test]
+    fn or_chain_detection() {
+        let source = "if {$host eq \"a.com\" || $host eq \"b.com\" || $host eq \"c.com\"} {\n    pool web_pool\n}";
+        let r = if_dg(source, "allowed").expect("result");
+        assert_eq!(dg(&r).records.len(), 3);
+    }
+
+    #[test]
+    fn too_few_values_returns_none() {
+        assert!(if_dg("if {$x eq \"a\"} { puts ok }", "").is_none());
+    }
+
+    #[test]
+    fn unified_dispatch_tries_switch() {
+        let source = "switch -exact -- $uri {\n    /api { set pool api_pool }\n    /web { set pool web_pool }\n    /cdn { set pool cdn_pool }\n}";
+        let r = reg();
+        let li = LineIndex::new(source);
+        assert!(extract_to_datagroup(source, 0, "uri_pool", &r, &li).is_some());
+    }
+
+    #[test]
+    fn data_group_tcl_rendering() {
+        let source = "if {$host eq \"a.com\"} {\n    pool web_pool\n} elseif {$host eq \"b.com\"} {\n    pool web_pool\n}";
+        let r = if_dg(source, "hosts").expect("result");
+        let tcl = data_group_tcl(dg(&r));
+        assert!(tcl.contains("ltm data-group internal hosts"));
+        assert!(tcl.contains("records"));
+        assert!(tcl.contains("a.com"));
+        assert!(tcl.contains("b.com"));
+    }
+
+    #[test]
+    fn if_rewrite_covers_entire_command() {
+        let source = "if {$host eq \"a.com\"} {\n    pool web_pool\n} elseif {$host eq \"b.com\"} {\n    pool web_pool\n}";
+        let r = if_dg(source, "hosts").expect("result");
+        let applied = r.apply(source);
+        // Byte-for-byte parity with the Python oracle (apply + tmsh).
+        assert_eq!(
+            applied,
+            "if { [class match $host equals hosts] } {\n    pool web_pool\n}"
+        );
+        assert_eq!(
+            data_group_tcl(dg(&r)),
+            "ltm data-group internal hosts {\n    records {\n        a.com { }\n        b.com { }\n    }\n    type string\n}"
+        );
+        let trimmed = applied.trim();
+        assert!(trimmed.ends_with('}'));
+        assert!(!trimmed.ends_with("}}"), "{trimmed:?}");
+    }
+
+    #[test]
+    fn inside_when_body() {
+        let source = "when HTTP_REQUEST {\n    if {$host eq \"a.com\"} {\n        pool web_pool\n    } elseif {$host eq \"b.com\"} {\n        pool web_pool\n    } elseif {$host eq \"c.com\"} {\n        pool web_pool\n    }\n}";
+        let r = reg();
+        let li = LineIndex::new(source);
+        let cursor = source.find("if {").unwrap() as u32;
+        let res = extract_to_datagroup(source, cursor, "", &r, &li).expect("nested result");
+        let g = dg(&res);
+        assert_eq!(g.value_type, "string");
+        assert_eq!(g.records.len(), 3);
+    }
+}

--- a/rust/tcl-lsp-core/src/refactor/extract_variable.rs
+++ b/rust/tcl-lsp-core/src/refactor/extract_variable.rs
@@ -1,0 +1,145 @@
+//! Extract variable — replace a selected expression with a named
+//! variable.  Ports `tooling/refactoring/_extract_variable.py`.
+
+use tcl_lexer::LineIndex;
+
+use super::{Refactoring, RefactorEdit};
+use crate::code_actions::ActionKind;
+
+/// Whitespace-delimited binary operators that mark an arithmetic /
+/// logical expression which must be wrapped in `[expr { … }]` so the
+/// resulting `set` stays a valid two-argument call.  Mirrors Python's
+/// `_EXPR_OP_RE`.
+const EXPR_OPS: &[&str] = &[
+    "**", "==", "!=", "<=", ">=", "&&", "||", "eq", "ne", "in", "ni", "+", "-", "*", "/", "%", "<",
+    ">",
+];
+
+/// `true` when `text` contains a whitespace-delimited binary operator.
+///
+/// The Python regex requires a single whitespace byte on each side of
+/// the operator (`\s OP \s`); this matches that by scanning for ` OP `
+/// with single ASCII spaces, which is what the oracle corpus uses.
+fn looks_like_expr(text: &str) -> bool {
+    EXPR_OPS
+        .iter()
+        .any(|op| text.contains(&format!(" {op} ")))
+}
+
+/// Extract the selection `[start_off, end_off)` into a `set` assignment.
+///
+/// Ports `extract_variable`.  Returns `None` when the selection is empty
+/// or only whitespace.  `start_line` / `start_off` / `end_off` are byte
+/// offsets into `source`; `line_index` resolves them to lines for the
+/// indentation lookup.
+#[must_use]
+pub fn extract_variable(
+    source: &str,
+    start_off: u32,
+    end_off: u32,
+    var_name: &str,
+    line_index: &LineIndex,
+) -> Option<Refactoring> {
+    if end_off <= start_off {
+        return None;
+    }
+    let selected = source.get(start_off as usize..end_off as usize)?;
+    if selected.trim().is_empty() {
+        return None;
+    }
+
+    let start_line = line_index.line_at(start_off);
+    let lines: Vec<&str> = source.split('\n').collect();
+    let line_text = lines.get(start_line as usize)?;
+    let indent = super::line_indent(line_text);
+
+    // A bare operator expression (`$a * $b`) is not a valid value word
+    // for `set` — wrap it in `[expr { … }]`.  A selection that is already
+    // a command substitution (`[cmd …]`) or a single word is kept
+    // verbatim.
+    let stripped = selected.trim();
+    let value = if !stripped.starts_with('[') && looks_like_expr(stripped) {
+        format!("[expr {{{stripped}}}]")
+    } else {
+        selected.to_owned()
+    };
+    let assignment = format!("{indent}set {var_name} {value}\n");
+
+    // The `set` insertion goes at column 0 of the start line; the
+    // replacement reference uses the original selection coordinates.
+    // `apply` runs bottom-to-top (descending start offset) so the
+    // replacement edit (later offset) runs before the line-start
+    // insertion, exactly like the Python ordering.
+    let line_start = u32::try_from(
+        source[..start_off as usize]
+            .rfind('\n')
+            .map_or(0, |nl| nl + 1),
+    )
+    .unwrap_or(0);
+    let edits = vec![
+        RefactorEdit {
+            start: line_start,
+            end: line_start,
+            new_text: assignment,
+        },
+        RefactorEdit {
+            start: start_off,
+            end: end_off,
+            new_text: format!("${var_name}"),
+        },
+    ];
+
+    Some(Refactoring {
+        title: format!("Extract into variable '${var_name}'"),
+        edits,
+        kind: ActionKind::RefactorExtract,
+        data_group: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(source: &str, start: u32, end: u32, name: &str) -> Option<String> {
+        let li = LineIndex::new(source);
+        extract_variable(source, start, end, name, &li).map(|r| r.apply(source))
+    }
+
+    #[test]
+    fn extract_command_substitution() {
+        let source = "set x [string length $name]";
+        // selection of `[string length $name]` (cols 6..27, all ASCII).
+        let applied = run(source, 6, 27, "len").expect("result");
+        assert!(applied.contains("set len [string length $name]"), "{applied:?}");
+        assert!(applied.contains("$len"), "{applied:?}");
+    }
+
+    #[test]
+    fn title_carries_custom_name() {
+        let source = "puts [expr {$a + $b}]";
+        let li = LineIndex::new(source);
+        let r = extract_variable(source, 5, 20, "total", &li).expect("result");
+        assert!(r.title.contains("total"));
+    }
+
+    #[test]
+    fn empty_selection_returns_none() {
+        assert!(run("set x 42", 0, 0, "result").is_none());
+    }
+
+    #[test]
+    fn whitespace_selection_returns_none() {
+        // "set x    42" — cols 5..9 is the run of spaces.
+        assert!(run("set x    42", 5, 9, "ws").is_none());
+    }
+
+    #[test]
+    fn bare_expression_is_wrapped_in_expr() {
+        let source = "puts $a + $b";
+        let li = LineIndex::new(source);
+        let r = extract_variable(source, 5, 12, "sum", &li).expect("result");
+        let applied = r.apply(source);
+        assert!(applied.contains("set sum [expr {$a + $b}]"), "{applied:?}");
+    }
+}

--- a/rust/tcl-lsp-core/src/refactor/if_to_switch.rs
+++ b/rust/tcl-lsp-core/src/refactor/if_to_switch.rs
@@ -1,0 +1,316 @@
+//! Convert an `if`/`elseif` equality chain to a `switch` statement.
+//! Ports `tooling/refactoring/_if_to_switch.py`.
+
+use tcl_lexer::LineIndex;
+use tcl_registry::CommandRegistry;
+
+use super::{Refactoring, RefactorEdit, find_command_at, reindent_body};
+use crate::code_actions::ActionKind;
+
+/// Parsed equality condition: `(var_name, value, negated)`.
+struct EqTest {
+    var: String,
+    value: String,
+    negated: bool,
+}
+
+/// Parse an equality condition `$var eq "value"` / `"value" eq $var`
+/// (and the `==` / `ne` / `!=` operators).  Ports `_parse_eq_test`.
+fn parse_eq_test(condition: &str) -> Option<EqTest> {
+    let mut cond = condition.trim();
+
+    // Strip outer braces: `{ $x eq "foo" }`.
+    if cond.starts_with('{') && cond.ends_with('}') && cond.len() >= 2 {
+        cond = cond[1..cond.len() - 1].trim();
+    }
+
+    // Negation: `!($x eq "foo")` or `!{$x eq "foo"}`.
+    let mut negated = false;
+    if let Some(rest) = cond.strip_prefix('!') {
+        let inner = rest.trim();
+        if inner.len() >= 2
+            && ((inner.starts_with('(') && inner.ends_with(')'))
+                || (inner.starts_with('{') && inner.ends_with('}')))
+        {
+            cond = inner[1..inner.len() - 1].trim();
+            negated = true;
+        }
+    }
+
+    if let Some((var, op, value)) = split_var_op_value(cond) {
+        let is_ne = op == "ne" || op == "!=";
+        return Some(EqTest {
+            var,
+            value: value.trim().to_owned(),
+            negated: negated ^ is_ne,
+        });
+    }
+    if let Some((value, op, var)) = split_value_op_var(cond) {
+        let is_ne = op == "ne" || op == "!=";
+        return Some(EqTest {
+            var,
+            value: value.trim().to_owned(),
+            negated: negated ^ is_ne,
+        });
+    }
+    None
+}
+
+/// Recognised equality operators, longest-first so `==` wins over a bare
+/// fragment.
+const OPS: &[&str] = &["==", "!=", "eq", "ne"];
+
+/// Split `$var OP value` / `"$var" OP value` → `(var, op, value)`.
+fn split_var_op_value(cond: &str) -> Option<(String, String, String)> {
+    for op in OPS {
+        let needle = format!(" {op} ");
+        if let Some(pos) = cond.find(&needle) {
+            let lhs = cond[..pos].trim();
+            let value = cond[pos + needle.len()..].to_owned();
+            if let Some(var) = parse_var_word(lhs) {
+                return Some((var, (*op).to_owned(), value));
+            }
+        }
+    }
+    None
+}
+
+/// Split `value OP $var` / `value OP "$var"` → `(value, op, var)`.
+fn split_value_op_var(cond: &str) -> Option<(String, String, String)> {
+    for op in OPS {
+        let needle = format!(" {op} ");
+        // Use the *last* occurrence so a value containing the operator
+        // text doesn't mis-split (the Python regex anchors the var on
+        // the right with `$`).
+        if let Some(pos) = cond.rfind(&needle) {
+            let value = cond[..pos].trim().to_owned();
+            let rhs = cond[pos + needle.len()..].trim();
+            if let Some(var) = parse_var_word(rhs) {
+                return Some((value, (*op).to_owned(), var));
+            }
+        }
+    }
+    None
+}
+
+/// Parse a `$var` / `${var}` / `"$var"` / `"${var}"` word to its bare
+/// variable name (`[A-Za-z0-9_]+`), or `None`.  Mirrors the regex
+/// `\$\{?(\w+)\}?` (optionally wrapped in double quotes).
+fn parse_var_word(word: &str) -> Option<String> {
+    let mut w = word.trim();
+    if w.len() >= 2 && w.starts_with('"') && w.ends_with('"') {
+        w = &w[1..w.len() - 1];
+    }
+    let w = w.strip_prefix('$')?;
+    let w = w.strip_prefix('{').unwrap_or(w);
+    let w = w.strip_suffix('}').unwrap_or(w);
+    if !w.is_empty() && w.chars().all(|c| c.is_alphanumeric() || c == '_') {
+        Some(w.to_owned())
+    } else {
+        None
+    }
+}
+
+/// Remove surrounding double quotes if present.
+fn strip_quotes(s: &str) -> &str {
+    let b = s.as_bytes();
+    if b.len() >= 2 && b[0] == b'"' && b[b.len() - 1] == b'"' {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+/// Render a switch pattern, preserving whitespace literals by bracing.
+/// Ports `_render_switch_pattern`.
+fn render_switch_pattern(value: &str) -> String {
+    if value.is_empty() {
+        return "{}".to_owned();
+    }
+    if value.chars().any(char::is_whitespace) {
+        format!("{{{}}}", value.replace('}', "\\}"))
+    } else {
+        value.to_owned()
+    }
+}
+
+/// Convert an `if`/`elseif` chain at byte offset `cursor` to a `switch`.
+/// Ports `if_to_switch`.
+#[must_use]
+pub fn if_to_switch(
+    source: &str,
+    cursor: u32,
+    registry: &CommandRegistry,
+    line_index: &LineIndex,
+) -> Option<Refactoring> {
+    let cmd = find_command_at(source, cursor, Some("if"), registry)?;
+    let texts = &cmd.texts;
+    if texts.len() < 3 {
+        return None;
+    }
+
+    // Parse the if/elseif chain: `if cond body ?elseif cond body?... ?else body?`.
+    let mut branches: Vec<(String, String)> = Vec::new(); // (value, body)
+    let mut else_body: Option<String> = None;
+    let mut target_var: Option<String> = None;
+
+    let mut i = 1;
+    while i < texts.len() {
+        let word = &texts[i];
+        if word == "elseif" || word == "then" {
+            i += 1;
+            continue;
+        }
+        if word == "else" {
+            if i + 1 < texts.len() {
+                else_body = Some(texts[i + 1].clone());
+            }
+            break;
+        }
+
+        // This should be a condition.
+        let condition = word.clone();
+        if i + 1 >= texts.len() {
+            return None;
+        }
+        let mut body = texts[i + 1].clone();
+        i += 2;
+
+        // Skip an optional `then` after the condition.
+        if i < texts.len() && texts[i] == "then" {
+            i += 1;
+            if i < texts.len() {
+                body.clone_from(&texts[i]);
+                i += 1;
+            }
+        }
+
+        let parsed = parse_eq_test(&condition)?;
+        match &target_var {
+            None => target_var = Some(parsed.var.clone()),
+            Some(v) if *v != parsed.var => return None,
+            _ => {}
+        }
+        // Negated (ne / !=) conditions make switch conversion awkward.
+        if parsed.negated {
+            return None;
+        }
+        branches.push((strip_quotes(&parsed.value).to_owned(), body));
+    }
+
+    let target_var = target_var?;
+    if branches.len() < 2 {
+        return None;
+    }
+
+    // Build the switch statement.
+    let lines: Vec<&str> = source.split('\n').collect();
+    let cmd_line = line_index.line_at(cmd.span.start());
+    let indent = lines
+        .get(cmd_line as usize)
+        .map_or("", |l| super::line_indent(l));
+    let inner = format!("{indent}    ");
+
+    let mut parts: Vec<String> = vec![format!("switch -exact -- ${target_var} {{")];
+    for (value, body) in &branches {
+        let body_trimmed = reindent_body(body, &format!("{inner}    "));
+        parts.push(format!("{inner}{} {{", render_switch_pattern(value)));
+        parts.push(body_trimmed);
+        parts.push(format!("{inner}}}"));
+    }
+    if let Some(eb) = &else_body {
+        let body_trimmed = reindent_body(eb, &format!("{inner}    "));
+        parts.push(format!("{inner}default {{"));
+        parts.push(body_trimmed);
+        parts.push(format!("{inner}}}"));
+    }
+    parts.push(format!("{indent}}}"));
+    let replacement = parts.join("\n");
+
+    let (start, end) = super::command_span_offsets(source, &cmd);
+    Some(Refactoring {
+        title: format!("Convert to switch on ${target_var}"),
+        edits: vec![RefactorEdit {
+            start,
+            end,
+            new_text: replacement,
+        }],
+        kind: ActionKind::RefactorRewrite,
+        data_group: None,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(source: &str, cursor: u32) -> Option<Refactoring> {
+        let reg = super::super::test_registry();
+        let li = LineIndex::new(source);
+        if_to_switch(source, cursor, &reg, &li)
+    }
+
+    #[test]
+    fn simple_eq_chain() {
+        let source = "if {$x eq \"a\"} {\n    puts \"alpha\"\n} elseif {$x eq \"b\"} {\n    puts \"beta\"\n} elseif {$x eq \"c\"} {\n    puts \"gamma\"\n}";
+        let r = run(source, 0).expect("result");
+        assert!(r.title.to_lowercase().contains("switch"));
+        let applied = r.apply(source);
+        assert!(applied.contains("switch -exact -- $x"), "{applied:?}");
+    }
+
+    #[test]
+    fn with_else_clause() {
+        let source = "if {$cmd eq \"GET\"} {\n    handle_get\n} elseif {$cmd eq \"POST\"} {\n    handle_post\n} else {\n    handle_other\n}";
+        let r = run(source, 0).expect("result");
+        assert!(r.apply(source).contains("default"));
+    }
+
+    #[test]
+    fn different_vars_returns_none() {
+        let source = "if {$x eq \"a\"} {\n    puts \"x\"\n} elseif {$y eq \"b\"} {\n    puts \"y\"\n}";
+        assert!(run(source, 0).is_none());
+    }
+
+    #[test]
+    fn single_branch_returns_none() {
+        assert!(run("if {$x eq \"a\"} { puts \"alpha\" }", 0).is_none());
+    }
+
+    #[test]
+    fn ne_operator_returns_none() {
+        let source = "if {$x ne \"a\"} {\n    puts \"not a\"\n} elseif {$x ne \"b\"} {\n    puts \"not b\"\n}";
+        assert!(run(source, 0).is_none());
+    }
+
+    #[test]
+    fn rewrite_covers_entire_if_command() {
+        let source = "if {$x eq \"a\"} {\n    puts 1\n} elseif {$x eq \"b\"} {\n    puts 2\n}";
+        let applied = run(source, 0).expect("result").apply(source);
+        // Byte-for-byte parity with the Python oracle.
+        assert_eq!(
+            applied,
+            "switch -exact -- $x {\n    a {\n        puts 1\n    }\n    b {\n        puts 2\n    }\n}"
+        );
+        let trimmed = applied.trim();
+        assert!(trimmed.ends_with('}'));
+        assert!(!trimmed.ends_with("}}"), "{trimmed:?}");
+    }
+
+    #[test]
+    fn values_with_spaces_are_braced() {
+        let source = "if {$x eq \"a b\"} {\n    puts one\n} elseif {$x eq \"c d\"} {\n    puts two\n}";
+        let applied = run(source, 0).expect("result").apply(source);
+        assert!(applied.contains("{a b}"), "{applied:?}");
+        assert!(applied.contains("{c d}"), "{applied:?}");
+    }
+
+    #[test]
+    fn inside_proc_body() {
+        let source = "proc handler {method} {\n    if {$method eq \"GET\"} {\n        handle_get\n    } elseif {$method eq \"POST\"} {\n        handle_post\n    } elseif {$method eq \"PUT\"} {\n        handle_put\n    }\n}";
+        // Cursor at line 1, col 4 — inside the `if`.
+        let cursor = source.find("if {").unwrap() as u32;
+        let r = run(source, cursor).expect("nested result");
+        assert!(r.title.to_lowercase().contains("switch"));
+    }
+}

--- a/rust/tcl-lsp-core/src/refactor/inline_variable.rs
+++ b/rust/tcl-lsp-core/src/refactor/inline_variable.rs
@@ -1,0 +1,219 @@
+//! Inline variable — replace a single-use variable with its value.
+//! Ports `tooling/refactoring/_inline_variable.py`.
+
+use tcl_compiler::analyser::AnalysisResult;
+use tcl_compiler::analyser::types::{Scope, VarDef};
+use tcl_lexer::{LineIndex, Token, TokenType};
+use tcl_registry::CommandRegistry;
+
+use super::{Refactoring, RefactorEdit, find_command_at, token_end_offset};
+use crate::code_actions::ActionKind;
+
+/// Inline the variable defined by the `set` command at byte offset
+/// `cursor`.  Ports `inline_variable`.
+///
+/// Only inlines when the cursor is on a `set var value` command and the
+/// variable has exactly one reference after the definition; returns
+/// `None` otherwise.
+#[must_use]
+pub fn inline_variable(
+    source: &str,
+    cursor: u32,
+    analysis: &AnalysisResult,
+    registry: &CommandRegistry,
+    line_index: &LineIndex,
+) -> Option<Refactoring> {
+    let cmd = find_command_at(source, cursor, Some("set"), registry)?;
+    if cmd.texts.len() < 3 {
+        return None; // `set var` read form — nothing to inline
+    }
+    let var_name = cmd.texts[1].clone();
+
+    // The value word, verbatim from source (widened to include any
+    // closing quote / brace / bracket).
+    let value_tok = cmd.argv[2];
+    let value_start = value_tok.span.start() as usize;
+    let value_end = token_end_offset(source, value_tok) as usize;
+    let value_text = source.get(value_start..value_end)?;
+
+    // Locate the var definition whose defining line matches the `set`
+    // command's line.
+    let cmd_line = line_index.line_at(cmd.span.start());
+    let var_def = walk_scopes(&analysis.global_scope).into_iter().find(|vd| {
+        vd.name == var_name && line_index.line_at(vd.definition_span.start()) == cmd_line
+    })?;
+
+    // Only inline when used exactly once.
+    if var_def.references.len() != 1 {
+        return None;
+    }
+    let ref_span = var_def.references[0];
+
+    // Delete the `set` command (its span, plus a trailing newline).
+    let (cmd_start, mut cmd_end) = super::command_span_offsets(source, &cmd);
+    if source.as_bytes().get(cmd_end as usize) == Some(&b'\n') {
+        cmd_end += 1;
+    }
+    let delete = RefactorEdit {
+        start: cmd_start,
+        end: cmd_end,
+        new_text: String::new(),
+    };
+
+    // Resolve the reference's VAR token + enclosing word so we know,
+    // from the tokens alone, whether the reference is a standalone word
+    // or interpolated inside a larger word.
+    let ctx = reference_token(source, ref_span.start(), registry)?;
+
+    // The `$var` / `${var}` span to replace.  The VAR token starts at
+    // `$`; its end omits the braced form's `}`, so re-add it.
+    let ref_start = ctx.var_tok.span.start();
+    let mut ref_end = token_end_offset(source, ctx.var_tok);
+    if source
+        .get(ref_start as usize..ref_start as usize + 2)
+        .is_some_and(|s| s == "${")
+        && source.as_bytes().get(ref_end as usize) == Some(&b'}')
+    {
+        ref_end += 1;
+    }
+
+    // A standalone word keeps the value verbatim (preserving quotes /
+    // braces so it stays one word).  Interpolated inside a larger word,
+    // splice the unquoted content instead — keeping the delimiters would
+    // yield `"hello "world""`.  A bare (unquoted) concatenation can only
+    // take a value with no whitespace.
+    let new_text = if ctx.word_is_single {
+        value_text.to_owned()
+    } else {
+        let inner = dequote(value_text);
+        let in_quoted_string = source
+            .as_bytes()
+            .get(ctx.word_start as usize)
+            == Some(&b'"');
+        if !in_quoted_string && inner.chars().any(char::is_whitespace) {
+            return None;
+        }
+        inner.to_owned()
+    };
+
+    let replace = RefactorEdit {
+        start: ref_start,
+        end: ref_end,
+        new_text,
+    };
+
+    Some(Refactoring {
+        title: format!("Inline variable '${var_name}'"),
+        edits: vec![delete, replace],
+        kind: ActionKind::RefactorInline,
+        data_group: None,
+    })
+}
+
+/// Resolved reference context — the VAR token, whether it is its own
+/// word, and the enclosing word's start offset.
+struct RefContext {
+    var_tok: Token,
+    word_is_single: bool,
+    word_start: u32,
+}
+
+/// Port of `_reference_token`: resolve `ref_off` through the segmenter
+/// to its VAR token and enclosing word.
+fn reference_token(source: &str, ref_off: u32, registry: &CommandRegistry) -> Option<RefContext> {
+    let cmd = find_command_at(source, ref_off, None, registry)?;
+
+    let var_tok = cmd.all_tokens.iter().copied().find(|tok| {
+        tok.kind == TokenType::Var
+            && tok.span.start() <= ref_off
+            && ref_off <= token_end_offset(source, *tok)
+    })?;
+
+    for (word_tok, &is_single) in cmd.argv.iter().zip(cmd.single_token_word.iter()) {
+        let word_start = word_tok.span.start();
+        let word_end = token_end_offset(source, *word_tok);
+        if word_start <= var_tok.span.start() && var_tok.span.start() < word_end {
+            return Some(RefContext {
+                var_tok,
+                word_is_single: is_single,
+                word_start,
+            });
+        }
+    }
+    Some(RefContext {
+        var_tok,
+        word_is_single: true,
+        word_start: var_tok.span.start(),
+    })
+}
+
+/// Strip one layer of matching `"…"` or `{…}` delimiters.
+fn dequote(value: &str) -> &str {
+    let bytes = value.as_bytes();
+    if bytes.len() >= 2 {
+        if bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"' {
+            return &value[1..value.len() - 1];
+        }
+        if bytes[0] == b'{' && bytes[bytes.len() - 1] == b'}' {
+            return &value[1..value.len() - 1];
+        }
+    }
+    value
+}
+
+/// Yield every `VarDef` in `scope` and its descendants.
+fn walk_scopes(scope: &Scope) -> Vec<&VarDef> {
+    let mut out: Vec<&VarDef> = scope.variables.values().collect();
+    for child in &scope.children {
+        out.extend(walk_scopes(child));
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tcl_compiler::analyser::Analyser;
+
+    fn run(source: &str, cursor: u32) -> Option<String> {
+        let reg = super::super::test_registry();
+        let analysis = Analyser::new().analyse(source, "tcl8.6").clone();
+        let li = LineIndex::new(source);
+        inline_variable(source, cursor, &analysis, &reg, &li).map(|r| r.apply(source))
+    }
+
+    #[test]
+    fn inline_single_use() {
+        let source = "set name \"hello\"\nputs $name";
+        let applied = run(source, 0).expect("result");
+        assert!(!applied.contains("set name"), "{applied:?}");
+        assert!(applied.contains("\"hello\""), "{applied:?}");
+    }
+
+    #[test]
+    fn inline_braced_reference() {
+        let source = "set x 1\nputs ${x}";
+        assert_eq!(run(source, 0).as_deref(), Some("puts 1"));
+    }
+
+    #[test]
+    fn inline_preserves_following_line_without_trailing_newline() {
+        let source = "set x 1\nset y $x";
+        assert_eq!(run(source, 0).as_deref(), Some("set y 1"));
+    }
+
+    #[test]
+    fn no_inline_multiple_uses() {
+        assert!(run("set x 42\nputs $x\nputs $x", 0).is_none());
+    }
+
+    #[test]
+    fn no_inline_read_form() {
+        assert!(run("set x", 0).is_none());
+    }
+
+    #[test]
+    fn no_inline_non_set() {
+        assert!(run("puts \"hello\"", 0).is_none());
+    }
+}

--- a/rust/tcl-lsp-core/src/refactor/mod.rs
+++ b/rust/tcl-lsp-core/src/refactor/mod.rs
@@ -1,0 +1,515 @@
+//! Mechanical refactoring transforms — Rust port of the
+//! `tooling/refactoring/` engine.
+//!
+//! Each transform accepts source text plus a cursor (or selection)
+//! and returns a [`Refactoring`] describing a titled set of text
+//! edits, or `None` when the transform does not apply.  The
+//! [`code_actions`](crate::code_actions) provider lifts each
+//! [`Refactoring`] into a `CodeAction`.
+//!
+//! Ported transforms:
+//!
+//! * [`extract_variable`] — replace a selected expression with a named
+//!   `set` assignment (`tooling/refactoring/_extract_variable.py`).
+//! * [`inline_variable`] — inline a single-use `set` variable
+//!   (`tooling/refactoring/_inline_variable.py`).
+//! * [`if_to_switch`] — convert an `if`/`elseif` equality chain to a
+//!   `switch` (`tooling/refactoring/_if_to_switch.py`).
+//! * [`switch_to_dict`] — convert a constant-mapping `switch` to a
+//!   `dict` lookup (`tooling/refactoring/_switch_to_dict.py`).
+//! * [`extract_to_datagroup`] — convert inline if/switch membership /
+//!   mapping patterns to iRules `class match` / `class lookup` against
+//!   a generated data-group (`tooling/refactoring/_extract_datagroup.py`).
+//!
+//! ## Coordinate convention
+//!
+//! Cursors and edit ranges use LSP `(line, character)` coordinates with
+//! UTF-16 character columns, matching the existing `extract_proc` /
+//! `inline_proc` transforms in [`crate::code_actions`].  Internally a
+//! transform works in **byte offsets** (so it can slice `&str` directly)
+//! and converts to UTF-16 [`LspRange`] only when building the final
+//! edits, via the document's [`LineIndex`].  The Python reference works
+//! in codepoint columns; the two agree on the ASCII corpus the oracle
+//! tests cover.
+
+mod datagroup;
+mod extract_variable;
+mod if_to_switch;
+mod inline_variable;
+mod switch_to_dict;
+
+pub use datagroup::{
+    DataGroupDefinition, data_group_tcl, extract_to_datagroup, extract_to_datagroup_from_if,
+    extract_to_datagroup_from_switch,
+};
+pub use extract_variable::extract_variable;
+pub use if_to_switch::if_to_switch;
+pub use inline_variable::inline_variable;
+pub use switch_to_dict::switch_to_dict;
+
+use tcl_compiler::segmenter::{SegmentedCommand, segment_commands_with_offset};
+use tcl_lexer::{LineIndex, Token, TokenType};
+use tcl_registry::{ArgRole, CommandRegistry};
+
+use crate::definition::LspRange;
+
+/// A single text replacement, in byte-offset space.
+///
+/// The transform layer composes edits in byte offsets and only converts
+/// to LSP [`LspRange`] coordinates at the boundary, via
+/// [`RefactorEdit::to_lsp`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RefactorEdit {
+    /// Inclusive start byte offset.
+    pub start: u32,
+    /// Exclusive end byte offset.
+    pub end: u32,
+    /// Replacement text.
+    pub new_text: String,
+}
+
+impl RefactorEdit {
+    /// Convert this byte-offset edit to an LSP `(line, character)` edit
+    /// with UTF-16 character columns.
+    #[must_use]
+    pub fn to_lsp(&self, source: &str, line_index: &LineIndex) -> crate::rename::TextEdit {
+        let start = line_index.position_at_utf16(self.start, source);
+        let end = line_index.position_at_utf16(self.end, source);
+        crate::rename::TextEdit {
+            range: LspRange {
+                start_line: start.line,
+                start_character: start.character,
+                end_line: end.line,
+                end_character: end.character,
+            },
+            new_text: self.new_text.clone(),
+        }
+    }
+}
+
+/// The outcome of a refactoring transform — a titled set of edits plus
+/// the LSP code-action kind.
+///
+/// Mirrors Python's `RefactoringResult` / `DataGroupExtractionResult`;
+/// `data_group` carries the rendered tmsh definition for the
+/// extract-to-datagroup transform and is `None` for every other
+/// transform.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Refactoring {
+    /// Title shown in the editor.
+    pub title: String,
+    /// Edits, in byte-offset space.
+    pub edits: Vec<RefactorEdit>,
+    /// LSP code-action kind dotted string (`refactor.extract`, …).
+    pub kind: crate::code_actions::ActionKind,
+    /// Generated data-group definition, when this is an
+    /// extract-to-datagroup result.
+    pub data_group: Option<DataGroupDefinition>,
+}
+
+impl Refactoring {
+    /// Apply the edits to `source` bottom-to-top, returning the
+    /// rewritten text.  Mirrors Python's `RefactoringResult.apply`
+    /// (`_apply_edits`): edits are sorted by descending start offset so
+    /// an earlier edit never shifts a later one's coordinates.
+    #[must_use]
+    pub fn apply(&self, source: &str) -> String {
+        let mut sorted: Vec<&RefactorEdit> = self.edits.iter().collect();
+        sorted.sort_by_key(|e| std::cmp::Reverse(e.start));
+        let mut result = source.to_owned();
+        for edit in sorted {
+            let start = (edit.start as usize).min(result.len());
+            let end = (edit.end as usize).min(result.len()).max(start);
+            result.replace_range(start..end, &edit.new_text);
+        }
+        result
+    }
+}
+
+/// Exclusive end byte offset for `tok`, including its closing delimiter.
+///
+/// Ports `_spans.py::token_end_offset`.  Lexer token spans follow the
+/// inner-end convention — a non-empty `{…}` / `[…]` / `"…"` word's
+/// `span.end()` is the exclusive offset of the closer, so the closer
+/// sits one byte past the end and a whole-word span must widen by one.
+/// An empty `{}` / `[]` / `""` already has its span extended over the
+/// closer, so widening would overshoot; the discriminator is whether the
+/// token text is empty (the closer is already covered), exactly as the
+/// segmenter's `widen_word_end`.
+#[must_use]
+pub fn token_end_offset(source: &str, tok: Token) -> u32 {
+    let bytes = source.as_bytes();
+    let start = tok.span.start() as usize;
+    let end = tok.span.end();
+    // The closer is derived from the *opening* delimiter the token's
+    // source slice begins with — a braced (`STR`) word opens with `{`, a
+    // command substitution (`CMD`) with `[`, and a quoted word (an `ESC`
+    // word whose first source byte is `"`) with `"`.  `in_quote` marks an
+    // *interpolated* fragment inside quotes, not a whole quoted word, so
+    // the opening byte is the reliable discriminator.
+    let closer = match tok.kind {
+        TokenType::Str => b'}',
+        TokenType::Cmd => b']',
+        TokenType::Esc if bytes.get(start) == Some(&b'"') => b'"',
+        _ => return end.min(byte_len(source)),
+    };
+    // Detect the degenerate empty word (`{}` / `[]` / `""`), whose span
+    // the lexer already extended over its closer — widening again would
+    // overshoot (issue #527: `a {}}`).  Mirror `SourceMap::token_text`'s
+    // emptiness rule: strip the opener via `content_offset`, then treat a
+    // remainder of `""`, `"}"`, or `"]"` as the empty case.
+    let raw = source.get(start..end as usize).unwrap_or("");
+    let stripped = raw.get(tok.content_offset as usize..).unwrap_or("");
+    if stripped.is_empty() || stripped == "}" || stripped == "]" {
+        return end.min(byte_len(source));
+    }
+    if bytes.get(end as usize) == Some(&closer) {
+        (end + 1).min(byte_len(source))
+    } else {
+        end.min(byte_len(source))
+    }
+}
+
+fn byte_len(source: &str) -> u32 {
+    u32::try_from(source.len()).unwrap_or(u32::MAX)
+}
+
+/// `(start, end)` byte offsets covering the full command text.
+///
+/// Ports `_spans.py::command_span_offsets`.  Python trusts `cmd.range`,
+/// which covers the final word's closing delimiter for braces, brackets,
+/// *and* quoted words.  The Rust segmenter's `span` already widens for a
+/// trailing brace / bracket but deliberately **not** for a trailing
+/// quote (the segmenter keeps the inner-end for `"…"` words), so widen
+/// the end here to the final argv word's [`token_end_offset`] — this
+/// covers the closing `"` of a command like `set name "hello"`.
+#[must_use]
+pub fn command_span_offsets(source: &str, cmd: &SegmentedCommand) -> (u32, u32) {
+    let len = byte_len(source);
+    let mut end = cmd.span.end();
+    if let Some(&last) = cmd.argv.last() {
+        end = end.max(token_end_offset(source, last));
+    }
+    (cmd.span.start().min(len), end.min(len))
+}
+
+/// Recursively find the innermost command at byte offset `cursor`.
+///
+/// Ports `_spans.py::find_command_at`.  Walks into registry-resolved
+/// `ArgRole::Body` arguments (proc / when / if / while / foreach
+/// bodies, …) so transforms apply inside nested bodies; the innermost
+/// match wins.  When `predicate` is `Some(name)`, only a command whose
+/// first word equals `name` is returned.
+///
+/// Body words are re-segmented at their absolute offset
+/// ([`segment_commands_with_offset`]) so the returned command's spans
+/// are always in the outer source buffer's offset space — the caller can
+/// slice `source` with them directly.
+#[must_use]
+pub fn find_command_at(
+    source: &str,
+    cursor: u32,
+    predicate: Option<&str>,
+    registry: &CommandRegistry,
+) -> Option<SegmentedCommand> {
+    find_command_at_inner(source, cursor, predicate, registry, 0)
+}
+
+fn find_command_at_inner(
+    source: &str,
+    cursor: u32,
+    predicate: Option<&str>,
+    registry: &CommandRegistry,
+    depth: u32,
+) -> Option<SegmentedCommand> {
+    if depth > 20 {
+        return None;
+    }
+    for cmd in segment_commands_with_offset(source, 0) {
+        let (cmd_start, cmd_end) = command_span_offsets(source, &cmd);
+        if cursor < cmd_start || cursor > cmd_end {
+            continue;
+        }
+        // Recurse into body arguments first — the innermost match wins.
+        for body in body_words(&cmd, registry) {
+            if let Some(inner) = find_command_at_inner(
+                &source[body.inner_start as usize..body.inner_end as usize],
+                cursor.saturating_sub(body.inner_start),
+                predicate,
+                registry,
+                depth + 1,
+            ) {
+                // Relocate the inner command's spans back into `source`.
+                return Some(inner.shifted_by(body.inner_start));
+            }
+        }
+        if predicate.is_none_or(|name| cmd.name() == name) {
+            return Some(cmd);
+        }
+    }
+    None
+}
+
+/// A registry-resolved body word and the byte range of its interior
+/// (delimiters excluded) in the outer source buffer.
+struct BodyWord {
+    inner_start: u32,
+    inner_end: u32,
+}
+
+/// Yield the registry-resolved `ArgRole::Body` words of `cmd` whose
+/// value is a non-empty braced (`STR`) word, with the interior byte
+/// range (one past the opening `{` to the closing `}`).  Mirrors the
+/// Python `iter_body_arguments` + `descend_token` filter
+/// (`compiler.parsing.syntax.descend.descend_command`).
+fn body_words(cmd: &SegmentedCommand, registry: &CommandRegistry) -> Vec<BodyWord> {
+    let name = cmd.name();
+    if name.is_empty() {
+        return Vec::new();
+    }
+    let args: Vec<&str> = cmd.args().iter().map(String::as_str).collect();
+    let mut out = Vec::new();
+    for idx in registry.arg_indices_for_role(name, &args, ArgRole::Body) {
+        // `arg_indices_for_role` is 0-based over the post-name args; the
+        // representative argv token sits at `idx + 1`.
+        let Some(&tok) = cmd.argv.get(idx + 1) else {
+            continue;
+        };
+        if tok.kind != TokenType::Str {
+            continue;
+        }
+        // The STR token's span starts on the opening `{` and ends before
+        // the closing `}` (inner-end convention).  The descended interior
+        // is one byte past the `{` up to the span end.
+        let inner_start = tok.span.start() + u32::from(tok.content_offset);
+        let inner_end = tok.span.end();
+        if inner_end <= inner_start {
+            continue; // empty body — nothing to descend
+        }
+        out.push(BodyWord {
+            inner_start,
+            inner_end,
+        });
+    }
+    out
+}
+
+/// Parse a `switch` command's flags + subject + pattern/body pairs.
+///
+/// Shared by [`switch_to_dict`] and the data-group switch transform.
+/// Returns `(subject, pairs)` only for an `-exact` switch (the only mode
+/// either transform handles); any other mode — `-glob` / `-regexp` —
+/// yields `None`.  The remaining args are the pattern-body pairs, given
+/// either as a single braced list (`{pat1 {body1} …}`) or as separate
+/// words.  Mirrors the flag / subject / pairs prologue both Python
+/// transforms share.
+#[must_use]
+pub fn parse_exact_switch(texts: &[String]) -> Option<(String, Vec<(String, String)>)> {
+    let mut i = 1;
+    let mut mode = "exact";
+    while i < texts.len() && texts[i].starts_with('-') {
+        match texts[i].as_str() {
+            "-exact" => mode = "exact",
+            "-glob" => mode = "glob",
+            "-regexp" => mode = "regexp",
+            "--" => {
+                i += 1;
+                break;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if mode != "exact" || i >= texts.len() {
+        return None;
+    }
+    let subject = texts[i].clone();
+    i += 1;
+
+    let pairs: Vec<(String, String)> = if i + 1 == texts.len() {
+        parse_braced_pairs(&texts[i])
+    } else {
+        let mut p = Vec::new();
+        while i + 1 < texts.len() {
+            p.push((texts[i].clone(), texts[i + 1].clone()));
+            i += 2;
+        }
+        p
+    };
+    Some((subject, pairs))
+}
+
+/// Parse `{pat1 {body1} pat2 {body2} …}` into pattern/body pairs.  Ports
+/// `_parse_braced_pairs`; both the switch transforms share it.
+#[must_use]
+pub fn parse_braced_pairs(text: &str) -> Vec<(String, String)> {
+    let mut text = text.trim();
+    if text.starts_with('{') && text.ends_with('}') && text.len() >= 2 {
+        text = text[1..text.len() - 1].trim();
+    }
+    let tokens = tokenise_switch_body(text);
+    let mut pairs = Vec::new();
+    let mut i = 0;
+    while i + 1 < tokens.len() {
+        pairs.push((tokens[i].clone(), tokens[i + 1].clone()));
+        i += 2;
+    }
+    pairs
+}
+
+/// Brace-aware tokeniser for switch body contents.  Ports
+/// `_tokenise_switch_body`.
+#[must_use]
+pub fn tokenise_switch_body(text: &str) -> Vec<String> {
+    let bytes = text.as_bytes();
+    let n = bytes.len();
+    let mut tokens = Vec::new();
+    let mut i = 0;
+    while i < n {
+        while i < n && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
+            i += 1;
+        }
+        if i >= n {
+            break;
+        }
+        if bytes[i] == b'{' {
+            let mut depth = 1;
+            let start = i;
+            i += 1;
+            while i < n && depth > 0 {
+                match bytes[i] {
+                    b'{' => depth += 1,
+                    b'}' => depth -= 1,
+                    _ => {}
+                }
+                i += 1;
+            }
+            tokens.push(text[start..i].to_owned());
+        } else if bytes[i] == b'"' {
+            let start = i;
+            i += 1;
+            while i < n && bytes[i] != b'"' {
+                if bytes[i] == b'\\' {
+                    i += 1;
+                }
+                i += 1;
+            }
+            if i < n {
+                i += 1;
+            }
+            tokens.push(text[start..i].to_owned());
+        } else {
+            let start = i;
+            while i < n && !matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r' | b'{' | b'}') {
+                i += 1;
+            }
+            tokens.push(text[start..i].to_owned());
+        }
+    }
+    tokens
+}
+
+/// Leading-whitespace indent of `line`.
+#[must_use]
+pub fn line_indent(line: &str) -> &str {
+    &line[..line.len() - line.trim_start().len()]
+}
+
+/// Re-indent a (possibly braced) body to `target_indent`.
+///
+/// Ports the shared `_reindent_body` used by `if_to_switch` and
+/// `extract_datagroup`: strips one layer of surrounding braces, computes
+/// the body's minimum indent, and re-emits each non-blank line at
+/// `target_indent` (preserving interior blank lines).  An empty body
+/// becomes `"{target_indent}# empty"`.
+#[must_use]
+pub fn reindent_body(body: &str, target_indent: &str) -> String {
+    let mut text = body.trim();
+    if text.starts_with('{') && text.ends_with('}') && text.len() >= 2 {
+        text = text[1..text.len() - 1].trim();
+    }
+    let lines: Vec<&str> = text.split('\n').collect();
+    let min_indent = lines
+        .iter()
+        .filter(|l| !l.trim().is_empty())
+        .map(|l| l.len() - l.trim_start().len())
+        .min();
+    let Some(min_indent) = min_indent else {
+        return format!("{target_indent}# empty");
+    };
+    let mut result: Vec<String> = Vec::new();
+    for ln in &lines {
+        if ln.trim().is_empty() {
+            if !result.is_empty() {
+                result.push(String::new());
+            }
+        } else {
+            result.push(format!("{target_indent}{}", &ln[min_indent..]));
+        }
+    }
+    result.join("\n")
+}
+
+/// Strip one layer of surrounding double quotes, if present.
+#[must_use]
+pub fn strip_quotes(s: &str) -> &str {
+    let s = s.trim();
+    let bytes = s.as_bytes();
+    if bytes.len() >= 2 && bytes[0] == b'"' && bytes[bytes.len() - 1] == b'"' {
+        &s[1..s.len() - 1]
+    } else {
+        s
+    }
+}
+
+#[cfg(test)]
+pub(crate) fn test_registry() -> CommandRegistry {
+    CommandRegistry::build_default()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_is_bottom_to_top() {
+        let r = Refactoring {
+            title: "t".into(),
+            edits: vec![
+                RefactorEdit {
+                    start: 6,
+                    end: 8,
+                    new_text: "99".into(),
+                },
+                RefactorEdit {
+                    start: 0,
+                    end: 3,
+                    new_text: "let".into(),
+                },
+            ],
+            kind: crate::code_actions::ActionKind::RefactorRewrite,
+            data_group: None,
+        };
+        assert_eq!(r.apply("set x 42"), "let x 99");
+    }
+
+    #[test]
+    fn find_command_descends_into_proc_body() {
+        let reg = test_registry();
+        let src = "proc handler {m} {\n    if {$m eq \"GET\"} { go }\n}";
+        // Cursor on the inner `if` (line 1).
+        let cursor = src.find("if {").unwrap() as u32 + 1;
+        let cmd = find_command_at(src, cursor, Some("if"), &reg).expect("inner if");
+        assert_eq!(cmd.name(), "if");
+        // The returned span is in the outer buffer's offsets.
+        let (s, _e) = command_span_offsets(src, &cmd);
+        assert!(src[s as usize..].starts_with("if {$m"));
+    }
+
+    #[test]
+    fn reindent_strips_braces_and_normalises() {
+        let out = reindent_body("{\n        puts hi\n    }", "    ");
+        assert_eq!(out, "    puts hi");
+    }
+}
+

--- a/rust/tcl-lsp-core/src/refactor/switch_to_dict.rs
+++ b/rust/tcl-lsp-core/src/refactor/switch_to_dict.rs
@@ -1,0 +1,280 @@
+//! Convert a constant-mapping `switch` to a `dict` lookup.
+//! Ports `tooling/refactoring/_switch_to_dict.py`.
+
+use tcl_compiler::segmenter::segment_commands_with_offset;
+use tcl_lexer::LineIndex;
+use tcl_registry::CommandRegistry;
+
+use super::{Refactoring, RefactorEdit, find_command_at, token_end_offset};
+use crate::code_actions::ActionKind;
+
+/// A parsed single-command arm body.
+enum BranchBody {
+    /// `set var value` → `(var, raw_value)`.
+    Set(String, String),
+    /// `return value` → `raw_value`.
+    Return(String),
+}
+
+/// Parse a single-command switch-branch body via the tokeniser.  Ports
+/// `_parse_branch_assignment`: the value keeps its original source span
+/// (quotes / braces intact) so the generated dict preserves the literal.
+fn parse_branch_assignment(body_text: &str) -> Option<BranchBody> {
+    let commands = segment_commands_with_offset(body_text, 0);
+    if commands.len() != 1 || commands[0].texts.is_empty() {
+        return None;
+    }
+    let cmd = &commands[0];
+    let raw = |index: usize| -> String {
+        let tok = cmd.argv[index];
+        body_text[tok.span.start() as usize..token_end_offset(body_text, tok) as usize].to_owned()
+    };
+    if cmd.texts[0] == "set" && cmd.texts.len() == 3 {
+        return Some(BranchBody::Set(cmd.texts[1].clone(), raw(2)));
+    }
+    if cmd.texts[0] == "return" && cmd.texts.len() == 2 {
+        return Some(BranchBody::Return(raw(1)));
+    }
+    None
+}
+
+/// Convert a `switch` where every arm sets the same variable / returns a
+/// constant into a `dict` lookup at byte offset `cursor`.  Ports
+/// `switch_to_dict`.
+#[must_use]
+pub fn switch_to_dict(
+    source: &str,
+    cursor: u32,
+    registry: &CommandRegistry,
+    line_index: &LineIndex,
+) -> Option<Refactoring> {
+    let cmd = find_command_at(source, cursor, Some("switch"), registry)?;
+    let texts = &cmd.texts;
+    if texts.len() < 3 {
+        return None;
+    }
+
+    // Only `-exact` mode is convertible; the helper yields the subject and
+    // the pattern/body pairs (single braced list or separate words).
+    let (subject, pairs) = super::parse_exact_switch(texts)?;
+    if pairs.is_empty() {
+        return None;
+    }
+
+    let arms = parse_arms(&pairs)?;
+    if arms.dict_entries.len() < 2 {
+        return None;
+    }
+
+    let indent = source
+        .split('\n')
+        .nth(line_index.line_at(cmd.span.start()) as usize)
+        .map_or("", super::line_indent);
+    let replacement = build_dict_replacement(&arms, &subject, indent);
+
+    let (start, end) = super::command_span_offsets(source, &cmd);
+    let title = if arms.use_return {
+        "Convert to dict lookup".to_owned()
+    } else {
+        format!("Convert to dict lookup on '{}'", arms.target_var)
+    };
+    Some(Refactoring {
+        title,
+        edits: vec![RefactorEdit {
+            start,
+            end,
+            new_text: replacement,
+        }],
+        kind: ActionKind::RefactorRewrite,
+        data_group: None,
+    })
+}
+
+/// The arms of a convertible switch, all of one shape.
+struct ParsedArms {
+    target_var: String,
+    use_return: bool,
+    dict_entries: Vec<(String, String)>,
+    default_value: Option<String>,
+}
+
+/// Parse every arm, requiring a single uniform `set VAR …` / `return …`
+/// shape.  Returns `None` on a fallthrough marker, a body that is neither
+/// form, or a mixed shape.
+fn parse_arms(pairs: &[(String, String)]) -> Option<ParsedArms> {
+    let mut target_var: Option<String> = None;
+    let mut use_return = false;
+    let mut dict_entries: Vec<(String, String)> = Vec::new();
+    let mut default_value: Option<String> = None;
+
+    for (pattern, body) in pairs {
+        let mut body_text = body.trim();
+        if body_text.starts_with('{') && body_text.ends_with('}') && body_text.len() >= 2 {
+            body_text = body_text[1..body_text.len() - 1].trim();
+        }
+        if body_text == "-" {
+            return None; // fallthrough marker
+        }
+        let value = match parse_branch_assignment(body_text)? {
+            BranchBody::Set(var, value) => {
+                match &target_var {
+                    None => {
+                        target_var = Some(var);
+                        use_return = false;
+                    }
+                    Some(v) if *v != var => return None,
+                    _ => {}
+                }
+                if use_return {
+                    return None;
+                }
+                value
+            }
+            BranchBody::Return(value) => {
+                match &target_var {
+                    None => {
+                        target_var = Some("__return__".to_owned());
+                        use_return = true;
+                    }
+                    Some(_) if !use_return => return None,
+                    _ => {}
+                }
+                value
+            }
+        };
+        if pattern == "default" {
+            default_value = Some(value);
+        } else {
+            dict_entries.push((pattern.clone(), value));
+        }
+    }
+
+    Some(ParsedArms {
+        target_var: target_var?,
+        use_return,
+        dict_entries,
+        default_value,
+    })
+}
+
+/// Build the `dict create` + lookup replacement from the parsed arms.
+fn build_dict_replacement(arms: &ParsedArms, subject: &str, indent: &str) -> String {
+    let dict_items = arms
+        .dict_entries
+        .iter()
+        .map(|(k, v)| format!("{k} {v}"))
+        .collect::<Vec<_>>()
+        .join(" ");
+    let dict_name = if arms.use_return {
+        "result_map".to_owned()
+    } else {
+        format!("{}_map", arms.target_var)
+    };
+    let target_var = &arms.target_var;
+
+    let mut parts: Vec<String> = vec![format!("set {dict_name} [dict create {dict_items}]")];
+    if let Some(default) = &arms.default_value {
+        parts.push(format!("{indent}if {{[dict exists ${dict_name} {subject}]}} {{"));
+        if arms.use_return {
+            parts.push(format!("{indent}    return [dict get ${dict_name} {subject}]"));
+            parts.push(format!("{indent}}} else {{"));
+            parts.push(format!("{indent}    return {default}"));
+        } else {
+            parts.push(format!(
+                "{indent}    set {target_var} [dict get ${dict_name} {subject}]"
+            ));
+            parts.push(format!("{indent}}} else {{"));
+            parts.push(format!("{indent}    set {target_var} {default}"));
+        }
+        parts.push(format!("{indent}}}"));
+    } else if arms.use_return {
+        parts.push(format!("{indent}return [dict get ${dict_name} {subject}]"));
+    } else {
+        parts.push(format!(
+            "{indent}set {target_var} [dict get ${dict_name} {subject}]"
+        ));
+    }
+    parts.join("\n")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn run(source: &str, cursor: u32) -> Option<Refactoring> {
+        let reg = super::super::test_registry();
+        let li = LineIndex::new(source);
+        switch_to_dict(source, cursor, &reg, &li)
+    }
+
+    #[test]
+    fn set_pattern() {
+        let source = "switch -exact -- $method {\n    GET { set handler handle_get }\n    POST { set handler handle_post }\n    PUT { set handler handle_put }\n}";
+        let r = run(source, 0).expect("result");
+        assert!(r.title.to_lowercase().contains("dict"));
+        let applied = r.apply(source);
+        // Byte-for-byte parity with the Python oracle: the segmenter
+        // canonicalises the `$method` subject to `${method}`.
+        assert_eq!(
+            applied,
+            "set handler_map [dict create GET handle_get POST handle_post PUT handle_put]\nset handler [dict get $handler_map ${method}]"
+        );
+        assert!(applied.contains("dict create"), "{applied:?}");
+        assert!(applied.contains("dict get"), "{applied:?}");
+    }
+
+    #[test]
+    fn return_pattern() {
+        let source = "switch -exact -- $code {\n    200 { return \"OK\" }\n    404 { return \"Not Found\" }\n    500 { return \"Server Error\" }\n}";
+        let applied = run(source, 0).expect("result").apply(source);
+        assert!(applied.contains("dict create"), "{applied:?}");
+    }
+
+    #[test]
+    fn glob_mode_returns_none() {
+        let source = "switch -glob -- $path {\n    /api/* { set handler api }\n    /web/* { set handler web }\n}";
+        assert!(run(source, 0).is_none());
+    }
+
+    #[test]
+    fn too_few_arms_returns_none() {
+        assert!(run("switch -exact -- $x {\n    a { set y 1 }\n}", 0).is_none());
+    }
+
+    #[test]
+    fn mixed_bodies_returns_none() {
+        let source = "switch -exact -- $x {\n    a { set y 1 }\n    b { puts \"hello\" }\n}";
+        assert!(run(source, 0).is_none());
+    }
+
+    #[test]
+    fn rewrite_covers_entire_switch_command() {
+        let source = "switch -exact -- $m {\n    a { set out 1 }\n    b { set out 2 }\n    c { set out 3 }\n}";
+        let applied = run(source, 0).expect("result").apply(source);
+        let applied = applied.trim();
+        assert!(applied.ends_with(']'), "{applied:?}");
+        assert!(!applied.ends_with("]}"), "{applied:?}");
+    }
+
+    #[test]
+    fn indented_switch_does_not_double_indent_first_line() {
+        let source = "    switch -exact -- $method {\n        GET { set handler get_h }\n        POST { set handler post_h }\n        PUT { set handler put_h }\n    }";
+        // Cursor at col 4 (offset 4) — on the `switch` keyword.
+        let applied = run(source, 4).expect("result").apply(source);
+        let first_line = applied.split('\n').next().unwrap();
+        assert!(first_line.starts_with("    set "), "{first_line:?}");
+        assert!(!first_line.starts_with("        set "), "{first_line:?}");
+    }
+
+    #[test]
+    fn inside_when_body() {
+        let source = "when HTTP_REQUEST {\n    switch -exact -- $method {\n        GET { set handler get_h }\n        POST { set handler post_h }\n        PUT { set handler put_h }\n    }\n}";
+        // `when`'s body role lives in the iRules dialect.
+        let mut reg = CommandRegistry::build_default();
+        reg.load_dialect(tcl_registry::dialects::DialectSet::IRULES);
+        let li = LineIndex::new(source);
+        let cursor = source.find("switch").unwrap() as u32;
+        let r = switch_to_dict(source, cursor, &reg, &li).expect("nested result");
+        assert!(r.title.to_lowercase().contains("dict"));
+    }
+}

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4513,6 +4513,13 @@ impl LanguageServer for Backend {
                     command: c.command,
                     arguments: Some(c.args.into_iter().map(serde_json::Value::from).collect()),
                 });
+                // Surface the rendered tmsh data-group definition (the
+                // extract-to-datagroup refactor) as the action's `data`
+                // payload, mirroring Python's
+                // `_datagroup_to_code_action`'s `data={"data_group_definition": …}`.
+                let data = a.data_group_definition.map(|def| {
+                    serde_json::json!({ "data_group_definition": def })
+                });
                 CodeActionOrCommand::CodeAction(CodeAction {
                     title: a.title,
                     kind: Some(tower_lsp::lsp_types::CodeActionKind::new(a.kind.as_str())),
@@ -4525,7 +4532,7 @@ impl LanguageServer for Backend {
                     command,
                     is_preferred: None,
                     disabled: None,
-                    data: None,
+                    data,
                 })
             })
             .collect();

--- a/rust/tcl-vm-cli/src/main.rs
+++ b/rust/tcl-vm-cli/src/main.rs
@@ -132,7 +132,13 @@ fn set_argv(vm: &mut Vm, argv0: &str, argv: &[String]) {
 /// Compile and run a whole script once, reporting any error to stderr. Returns
 /// the process exit code.
 fn run_script(vm: &mut Vm, src: &str) -> i32 {
-    match vm.eval_source(src) {
+    let result = vm.eval_source(src);
+    // `exit` records a pending code on the VM rather than killing the process
+    // (so embedders survive); the standalone CLI performs the real termination.
+    if let Some(code) = vm.take_exit() {
+        return code;
+    }
+    match result {
         Ok(comp) if comp.code.is_ok() => 0,
         Ok(comp) => {
             eprintln!("{}", comp.result.to_str());
@@ -225,7 +231,13 @@ fn repl_loop<R: std::io::BufRead, W: Write>(vm: &mut Vm, reader: &mut R, out: &m
             continue;
         }
 
-        match vm.eval_source(&buffer) {
+        let result = vm.eval_source(&buffer);
+        // `exit` in the REPL ends the session with the requested code.
+        if let Some(code) = vm.take_exit() {
+            let _ = writeln!(out);
+            return code;
+        }
+        match result {
             Ok(comp) if comp.code.is_ok() => {
                 let result = comp.result.to_str();
                 if !result.is_empty() {

--- a/rust/tcl-vm/src/cmd_clock.rs
+++ b/rust/tcl-vm/src/cmd_clock.rs
@@ -11,6 +11,29 @@ use crate::value::Value;
 
 pub(crate) fn register(vm: &mut Vm) {
     vm.register("clock", cmd_clock);
+    // The ensemble's implementation members — `clock clicks` compiles/dispatches
+    // to `::tcl::clock::clicks`, and library/framework code calls these
+    // fully-qualified forms directly. Each prepends its subcommand and reuses
+    // the same dispatch.
+    vm.register("::tcl::clock::seconds", |vm, a| member(vm, "seconds", a));
+    vm.register("::tcl::clock::milliseconds", |vm, a| {
+        member(vm, "milliseconds", a)
+    });
+    vm.register("::tcl::clock::microseconds", |vm, a| {
+        member(vm, "microseconds", a)
+    });
+    vm.register("::tcl::clock::clicks", |vm, a| member(vm, "clicks", a));
+    vm.register("::tcl::clock::format", |vm, a| member(vm, "format", a));
+    vm.register("::tcl::clock::add", |vm, a| member(vm, "add", a));
+    vm.register("::tcl::clock::scan", |vm, a| member(vm, "scan", a));
+}
+
+/// Dispatch an `::tcl::clock::<sub>` ensemble member by prepending `sub`.
+fn member(vm: &mut Vm, sub: &str, a: &[Value]) -> Completion<Value> {
+    let mut args = Vec::with_capacity(a.len() + 1);
+    args.push(Value::string(sub));
+    args.extend_from_slice(a);
+    cmd_clock(vm, &args)
 }
 
 fn cmd_clock(vm: &mut Vm, args: &[Value]) -> Completion<Value> {

--- a/rust/tcl-vm/src/cmd_dict.rs
+++ b/rust/tcl-vm/src/cmd_dict.rs
@@ -90,6 +90,34 @@ fn dict_update(
     ok(result)
 }
 
+/// Set the nested `keys` path of dict `cur` to `value`, creating intermediate
+/// dicts as needed (`dict set` with multiple keys).
+fn set_path(cur: &Value, keys: &[Value], value: Value) -> Result<Value, Completion<Value>> {
+    let mut ps = pairs(cur)?;
+    let k = keys[0].to_str().to_string();
+    let newv = if keys.len() == 1 {
+        value
+    } else {
+        let sub = lookup(&ps, &k).cloned().unwrap_or_else(Value::empty);
+        set_path(&sub, &keys[1..], value)?
+    };
+    upsert(&mut ps, &k, newv);
+    Ok(from_pairs(&ps))
+}
+
+/// Remove the nested `keys` path from dict `cur` (`dict unset` with multiple
+/// keys). A missing intermediate key is a no-op, matching `dict unset`.
+fn unset_path(cur: &Value, keys: &[Value]) -> Result<Value, Completion<Value>> {
+    let mut ps = pairs(cur)?;
+    let k = keys[0].to_str().to_string();
+    if keys.len() == 1 {
+        ps.retain(|(pk, _)| pk != &k);
+    } else if let Some(idx) = ps.iter().position(|(pk, _)| pk == &k) {
+        ps[idx].1 = unset_path(&ps[idx].1.clone(), &keys[1..])?;
+    }
+    Ok(from_pairs(&ps))
+}
+
 fn upsert(ps: &mut Vec<(String, Value)>, key: &str, value: Value) {
     if let Some(slot) = ps.iter_mut().find(|(k, _)| k == key) {
         slot.1 = value;
@@ -205,39 +233,36 @@ fn dict_op(vm: &mut Vm, sub: &str, rest: &[Value]) -> Completion<Value> {
         }
         "set" => {
             // dict set dictVarName key ?key ...? value
-            let [varname, mid @ .., value] = rest else {
+            let [varname, keys @ .., value] = rest else {
                 return err("wrong # args: should be \"dict set dictVarName key ?key ...? value\"");
             };
-            if mid.is_empty() {
+            if keys.is_empty() {
                 return err("wrong # args: should be \"dict set dictVarName key ?key ...? value\"");
             }
             let name = varname.to_str();
             let cur = vm.get_var(&name).unwrap_or_else(Value::empty);
-            let mut ps = match pairs(&cur) {
-                Ok(p) => p,
+            let result = match set_path(&cur, keys, value.clone()) {
+                Ok(v) => v,
                 Err(c) => return c,
             };
-            // M3: single level of nesting only.
-            upsert(&mut ps, &mid[0].to_str(), value.clone());
-            let result = from_pairs(&ps);
             if let Err(e) = vm.set_var(&name, result.clone()) {
                 return e;
             }
             ok(result)
         }
         "unset" => {
-            let [varname, key] = rest else {
+            let [varname, keys @ ..] = rest else {
                 return err("wrong # args: should be \"dict unset dictVarName key ?key ...?\"");
             };
+            if keys.is_empty() {
+                return err("wrong # args: should be \"dict unset dictVarName key ?key ...?\"");
+            }
             let name = varname.to_str();
             let cur = vm.get_var(&name).unwrap_or_else(Value::empty);
-            let mut ps = match pairs(&cur) {
-                Ok(p) => p,
+            let result = match unset_path(&cur, keys) {
+                Ok(v) => v,
                 Err(c) => return c,
             };
-            let k = key.to_str();
-            ps.retain(|(pk, _)| pk != &*k);
-            let result = from_pairs(&ps);
             if let Err(e) = vm.set_var(&name, result.clone()) {
                 return e;
             }

--- a/rust/tcl-vm/src/cmd_package.rs
+++ b/rust/tcl-vm/src/cmd_package.rs
@@ -43,6 +43,17 @@ fn cmd_package(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
                 "wrong # args: should be \"package vsatisfies version requirement ?requirement ...?\"",
             ),
         },
+        "vcompare" => match rest {
+            [v1, v2] => {
+                let order = cmp_version(&v1.to_str(), &v2.to_str());
+                ok(Value::int(match order {
+                    Ordering::Less => -1,
+                    Ordering::Equal => 0,
+                    Ordering::Greater => 1,
+                }))
+            }
+            _ => err("wrong # args: should be \"package vcompare version1 version2\""),
+        },
         "names" => {
             let mut names = vm.package_names();
             names.sort();

--- a/rust/tcl-vm/src/cmd_regexp.rs
+++ b/rust/tcl-vm/src/cmd_regexp.rs
@@ -64,13 +64,82 @@ fn encode(cps: &[i32]) -> Encoded {
     Encoded { s, char2byte }
 }
 
+/// Translate the Tcl ARE word-edge constructs the `regex` crate spells
+/// differently. Tcl's `\m`/`\M` (begin/end of word) and the bracket forms
+/// `[[:<:]]`/`[[:>:]]` map to the crate's `\b{start}`/`\b{end}` assertions;
+/// `\y`/`\Y` (word boundary / non-boundary) map to `\b`/`\B`. Other escapes and
+/// bracket expressions pass through untouched (backslash is significant inside
+/// classes in both engines, so we copy `\x` pairs verbatim there).
+fn translate_are(pat: &str) -> String {
+    let chars: Vec<char> = pat.chars().collect();
+    let mut out = String::with_capacity(pat.len());
+    let mut i = 0;
+    let mut in_class = false;
+    // Does the char slice at `i` begin with the literal `lit`?
+    let at = |i: usize, lit: &str| chars[i..].iter().take(lit.chars().count()).copied().eq(lit.chars());
+    while i < chars.len() {
+        let c = chars[i];
+        if in_class {
+            if c == '\\' && i + 1 < chars.len() {
+                out.push('\\');
+                out.push(chars[i + 1]);
+                i += 2;
+                continue;
+            }
+            if c == ']' {
+                in_class = false;
+            }
+            out.push(c);
+            i += 1;
+            continue;
+        }
+        // The standalone word-edge bracket forms (not real character classes).
+        if at(i, "[[:<:]]") {
+            out.push_str(r"\b{start}");
+            i += 7;
+            continue;
+        }
+        if at(i, "[[:>:]]") {
+            out.push_str(r"\b{end}");
+            i += 7;
+            continue;
+        }
+        if c == '\\' && i + 1 < chars.len() {
+            let n = chars[i + 1];
+            let mapped = match n {
+                'm' => Some(r"\b{start}"),
+                'M' => Some(r"\b{end}"),
+                'y' => Some(r"\b"),
+                'Y' => Some(r"\B"),
+                _ => None,
+            };
+            if let Some(rep) = mapped {
+                out.push_str(rep);
+            } else {
+                out.push('\\');
+                out.push(n);
+            }
+            i += 2;
+            continue;
+        }
+        if c == '[' {
+            in_class = true;
+        }
+        out.push(c);
+        i += 1;
+    }
+    out
+}
+
 impl RegexEngine for CrateEngine {
     type Regex = CrateRe;
 
     fn compile(pattern: &[u8], flags: RegexFlags) -> Result<CrateRe, Vec<u8>> {
-        let Ok(pat) = core::str::from_utf8(pattern) else {
+        let Ok(raw) = core::str::from_utf8(pattern) else {
             return Err(b"invalid UTF-8 in regular expression".to_vec());
         };
+        let translated = translate_are(raw);
+        let pat = translated.as_str();
         // Map the engine-neutral flags to the crate's inline flags. Tcl's default
         // (no `-linestop`) is that `.` matches a newline, which is the crate's
         // `s` flag; `-lineanchor` is `m`, `-nocase` is `i`, `-expanded` is `x`.

--- a/rust/tcl-vm/src/cmd_try.rs
+++ b/rust/tcl-vm/src/cmd_try.rs
@@ -210,6 +210,11 @@ fn cmd_try(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 
     // -- run the body, then dispatch to the first matching handler --------
     let body_comp = eval_body(vm, body);
+    // `exit` is not catchable (C Tcl's `Tcl_Exit`): propagate the unwind
+    // without running handlers or the `finally` clause.
+    if vm.exit_pending() {
+        return body_comp;
+    }
     let errorcode = if body_comp.code == Code::Error {
         opt_get(&body_comp.options, "-errorcode").unwrap_or_else(|| Value::string("NONE"))
     } else {

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -106,24 +106,36 @@ pub(crate) fn register_builtins(vm: &mut Vm) {
     crate::cmd_try::register(vm);
 }
 
-/// `exit ?returnCode?` — terminate the process with `returnCode` (default 0).
-/// Matches `tclsh`: a non-integer code is an error. Host output is flushed on
-/// every `write_output`, so nothing is lost across the process exit.
-fn cmd_exit(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
+/// `exit ?returnCode?` — request process termination with `returnCode`
+/// (default 0). Matches `tclsh`: a non-integer code is an error.
+///
+/// The VM library never calls `std::process::exit` itself — that would kill an
+/// embedding host (the debugger, `tcl-irule-test`, `f5 explain-flow
+/// --simulate`) on any guest script that runs `exit`. Instead it records the
+/// code on the interpreter and returns an unwinding completion; the standalone
+/// `tclvm` CLI checks [`Vm::take_exit`] and performs the real process exit,
+/// while embedders see a completion they can handle. Like C Tcl's `Tcl_Exit`
+/// it is **not** catchable — `catch` re-propagates while an exit is pending.
+fn cmd_exit(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let code = match args {
         [] => 0,
         [c] => match c.as_int() {
             Ok(n) => i32::try_from(n).unwrap_or(0),
             Err(_) => {
-                return err(format!(
-                    "expected integer but got \"{}\"",
-                    c.to_str()
-                ));
+                return err(format!("expected integer but got \"{}\"", c.to_str()));
             }
         },
         _ => return err("wrong # args: should be \"exit ?returnCode?\""),
     };
-    std::process::exit(code);
+    vm.set_exit(code);
+    // Unwind everything with an error-coded completion (so it propagates through
+    // proc boundaries, unlike `return`); `catch` re-propagates while the exit is
+    // pending, and the driver consumes the code before the message is surfaced.
+    Completion::new(
+        Code::Error,
+        Value::string(format!("exit {code}")),
+        Value::empty(),
+    )
 }
 
 /// `set varName ?newValue?` — read or write a scalar.
@@ -728,6 +740,11 @@ fn cmd_catch(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         Ok(c) => c,
         Err(e) => Completion::new(Code::Error, e.into_value(), Value::empty()),
     };
+    // `exit` is not catchable (C Tcl's `Tcl_Exit`): if the body requested an
+    // exit, propagate the unwind rather than swallowing it.
+    if vm.exit_pending() {
+        return comp;
+    }
     if let Some(r) = resvar
         && let Err(e) = vm.set_var(&r.to_str(), comp.result.clone())
     {

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -82,6 +82,7 @@ pub(crate) fn register_builtins(vm: &mut Vm) {
     vm.register("subst", cmd_subst);
     vm.register("auto_load", cmd_auto_load);
     vm.register("auto_import", |_, _| ok(Value::empty()));
+    vm.register("exit", cmd_exit);
     crate::cmd_array::register(vm);
     crate::cmd_chan::register(vm);
     crate::cmd_clock::register(vm);
@@ -103,6 +104,26 @@ pub(crate) fn register_builtins(vm: &mut Vm) {
     crate::cmd_switch::register(vm);
     crate::cmd_trace::register(vm);
     crate::cmd_try::register(vm);
+}
+
+/// `exit ?returnCode?` — terminate the process with `returnCode` (default 0).
+/// Matches `tclsh`: a non-integer code is an error. Host output is flushed on
+/// every `write_output`, so nothing is lost across the process exit.
+fn cmd_exit(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
+    let code = match args {
+        [] => 0,
+        [c] => match c.as_int() {
+            Ok(n) => i32::try_from(n).unwrap_or(0),
+            Err(_) => {
+                return err(format!(
+                    "expected integer but got \"{}\"",
+                    c.to_str()
+                ));
+            }
+        },
+        _ => return err("wrong # args: should be \"exit ?returnCode?\""),
+    };
+    std::process::exit(code);
 }
 
 /// `set varName ?newValue?` — read or write a scalar.
@@ -136,11 +157,18 @@ fn cmd_source(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     // Track the path so `info script` (and callers like `[file dirname [info
     // script]]`) resolve relative to the file being sourced.
     vm.push_script(path.to_string());
-    let result = match vm.eval_source(&contents) {
+    let mut result = match vm.eval_source(&contents) {
         Ok(c) => c,
         Err(e) => err(e.message),
     };
     vm.pop_script();
+    // A top-level `return` in the sourced file ends the *file*, not the caller:
+    // `source` absorbs the `TCL_RETURN` and returns its value normally (like C
+    // Tcl's `Tcl_FSEvalFileEx`). Without this a `return` — e.g. the early-out at
+    // the top of a compatibility shim — unwinds the script that called `source`.
+    if result.code == Code::Return {
+        result.code = Code::Ok;
+    }
     result
 }
 
@@ -482,17 +510,17 @@ fn cmd_proc(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         return err("wrong # args: should be \"proc name args body\"");
     };
     let name_s = name.to_str();
-    // The pre-compiled body is keyed by the name as the compiler saw it
-    // (global-qualified with a leading `::`), independent of the namespace the
-    // `proc` runs in.
-    let body_key = if name_s.starts_with("::") {
-        name_s.to_string()
-    } else {
-        format!("::{name_s}")
-    };
     // The registration / activation name is qualified with the *current*
     // namespace (so `namespace eval foo { proc bar … }` defines `foo::bar`).
     let reg_name = vm.qualify_name(&name_s);
+    // The pre-compiled body cache is keyed by the *runtime-qualified* name. A
+    // bare proc name resolves against the current namespace, so two procs that
+    // share an unqualified name in different namespaces (`::a::p` vs `::b::p`)
+    // must not collide on one cached body — keying by `reg_name` keeps them
+    // distinct. Global procs (`reg_name == ::name`) still hit the compiler's
+    // `::name`-keyed entry; namespaced bodies the compiler globalised under
+    // `::name` simply miss and recompile via `compile_dynamic_body`.
+    let body_key = reg_name.clone();
     let namespace = reg_name
         .rsplit_once("::")
         .map_or_else(String::new, |(ns, _)| ns.to_string());

--- a/rust/tcl-vm/src/debug.rs
+++ b/rust/tcl-vm/src/debug.rs
@@ -1,0 +1,58 @@
+//! Debug-hook seam: a callback fired at each source-command boundary.
+//!
+//! When a [`DebugHook`] is installed (via [`Vm::set_debug_hook`]), the VM calls
+//! it at every `startCommand` boundary with a full [`DebugSnapshot`] of the
+//! interpreter state — the source line and command, the call stack, and the
+//! current frame's variables — and honours the returned [`DebugAction`]. This
+//! is the execution-control seam a step debugger (`tcl-debugger`) drives; it is
+//! inert (zero per-instruction cost beyond an `Option` check) when no hook is
+//! installed.
+//!
+//! [`Vm::set_debug_hook`]: crate::Vm::set_debug_hook
+
+/// What the hook tells the VM to do after a command boundary.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DebugAction {
+    /// Continue execution.
+    Continue,
+    /// Stop the VM (the run unwinds with a debug-terminate result).
+    Stop,
+}
+
+/// One call-stack frame in a [`DebugSnapshot`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DebugFrame {
+    /// Absolute frame level (0 = global).
+    pub level: u32,
+    /// The proc name, or `"global"` at top level.
+    pub name: String,
+    /// The frame's namespace (no leading `::`; empty = global).
+    pub namespace: String,
+}
+
+/// A variable visible in the stopped frame.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DebugVar {
+    /// Variable name.
+    pub name: String,
+    /// Rendered value.
+    pub value: String,
+}
+
+/// A full snapshot of interpreter state at a command boundary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DebugSnapshot {
+    /// 1-based source line of the command about to run.
+    pub line: u32,
+    /// The command's source text.
+    pub command_text: String,
+    /// The current (top) frame level.
+    pub level: u32,
+    /// The call stack, top frame first.
+    pub stack: Vec<DebugFrame>,
+    /// Variables in the current frame.
+    pub variables: Vec<DebugVar>,
+}
+
+/// The installed debug callback.
+pub type DebugHook = Box<dyn FnMut(&DebugSnapshot) -> DebugAction>;

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -511,6 +511,16 @@ impl Vm {
         }
         let instr = &asm.instructions[f.pc];
         f.pc += 1;
+        // Step-debugger seam: fire once per source command, before it runs.
+        #[allow(clippy::redundant_closure_for_method_calls)] // Span isn't named in this crate.
+        let span_start = instr.source_span.map(|s| s.start());
+        if self.debug_step(instr.source_line, span_start, &instr.source_cmd_text) {
+            return Tick::Return(Completion::new(
+                Code::Error,
+                Value::string("debug: terminated"),
+                Value::empty(),
+            ));
+        }
         let lits = asm.literals.entries();
         let lvt = asm.lvt.entries();
 

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -135,6 +135,81 @@ fn pop(f: &mut Frame) -> Value {
     f.stack.pop().unwrap_or_else(Value::empty)
 }
 
+/// Parse a dict `Value` into ordered `(key, value)` pairs (the list rep).
+fn dict_pairs(v: &Value) -> Result<Vec<(String, Value)>, Completion<Value>> {
+    let items = v.as_list().map_err(|e| err(e.message))?;
+    if items.len() % 2 != 0 {
+        return Err(err("missing value to go with key"));
+    }
+    Ok(items
+        .chunks_exact(2)
+        .map(|c| (c[0].to_str().to_string(), c[1].clone()))
+        .collect())
+}
+
+/// Re-flatten `(key, value)` pairs back into a dict `Value`.
+fn dict_from_pairs(ps: &[(String, Value)]) -> Value {
+    let mut v = Vec::with_capacity(ps.len() * 2);
+    for (k, val) in ps {
+        v.push(Value::string(k.as_str()));
+        v.push(val.clone());
+    }
+    Value::list(v)
+}
+
+/// Set the nested `keys` path of dict `cur` to `value`, creating intermediate
+/// dicts as needed. Returns the new top-level dict value.
+fn dict_set_path(cur: &Value, keys: &[Value], value: Value) -> Result<Value, Completion<Value>> {
+    let mut ps = dict_pairs(cur)?;
+    let k = keys[0].to_str().to_string();
+    let newv = if keys.len() == 1 {
+        value
+    } else {
+        let sub = ps
+            .iter()
+            .find(|(pk, _)| pk == &k)
+            .map_or_else(Value::empty, |(_, v)| v.clone());
+        dict_set_path(&sub, &keys[1..], value)?
+    };
+    if let Some(slot) = ps.iter_mut().find(|(pk, _)| pk == &k) {
+        slot.1 = newv;
+    } else {
+        ps.push((k, newv));
+    }
+    Ok(dict_from_pairs(&ps))
+}
+
+/// Remove the nested `keys` path from dict `cur`. Returns the new top-level
+/// dict value (a no-op if the path is absent, matching `dict unset`).
+fn dict_unset_path(cur: &Value, keys: &[Value]) -> Result<Value, Completion<Value>> {
+    let mut ps = dict_pairs(cur)?;
+    let k = keys[0].to_str().to_string();
+    if keys.len() == 1 {
+        ps.retain(|(pk, _)| pk != &k);
+    } else if let Some(idx) = ps.iter().position(|(pk, _)| pk == &k) {
+        ps[idx].1 = dict_unset_path(&ps[idx].1.clone(), &keys[1..])?;
+    }
+    Ok(dict_from_pairs(&ps))
+}
+
+/// Update the single-level `key` of dict `cur` via `f` (given the current value
+/// if present), returning the new top-level dict value. Shared by the
+/// `DICT_INCR_IMM` / `DICT_APPEND` / `DICT_LAPPEND` opcodes.
+fn dict_update_single(
+    cur: &Value,
+    key: &str,
+    f: impl FnOnce(Option<&Value>) -> Result<Value, Completion<Value>>,
+) -> Result<Value, Completion<Value>> {
+    let mut ps = dict_pairs(cur)?;
+    let newv = f(ps.iter().find(|(k, _)| k == key).map(|(_, v)| v))?;
+    if let Some(slot) = ps.iter_mut().find(|(k, _)| k == key) {
+        slot.1 = newv;
+    } else {
+        ps.push((key.to_string(), newv));
+    }
+    Ok(dict_from_pairs(&ps))
+}
+
 /// Whether `s` can be safely wrapped in `{…}`: braces are balanced (ignoring
 /// `\{`/`\}`) and it does not end in an escaping backslash.
 fn brace_safe(s: &str) -> bool {
@@ -1384,6 +1459,162 @@ impl Vm {
                 }
             }
 
+            // -- dicts (LVT form, proc bodies) --
+            // `dict set var k1 ?k2 …? value` — operands [Imm(N), Imm(slot)];
+            // stack holds the N keys then the value. Writes the variable and
+            // leaves the new dict on the stack (the codegen POPs it).
+            Op::DICT_SET => {
+                let nkeys = usize::try_from(imm0(instr)).unwrap_or(0);
+                let name = lvt_name(imm_at(instr, 1));
+                let value = pop(f);
+                if f.stack.len() < nkeys || nkeys == 0 {
+                    return Tick::Return(err("dictSet: stack underflow"));
+                }
+                let keys = f.stack.split_off(f.stack.len() - nkeys);
+                let cur = self.get_var(&name).unwrap_or_else(Value::empty);
+                match dict_set_path(&cur, &keys, value) {
+                    Ok(result) => {
+                        try_op!(self.set_var(&name, result.clone()));
+                        f.stack.push(result);
+                    }
+                    Err(c) => return Tick::Return(c),
+                }
+            }
+            // `dict unset var k1 ?k2 …?` — operands [Imm(N), Imm(slot)]; stack
+            // holds the N keys.
+            Op::DICT_UNSET => {
+                let nkeys = usize::try_from(imm0(instr)).unwrap_or(0);
+                let name = lvt_name(imm_at(instr, 1));
+                if f.stack.len() < nkeys || nkeys == 0 {
+                    return Tick::Return(err("dictUnset: stack underflow"));
+                }
+                let keys = f.stack.split_off(f.stack.len() - nkeys);
+                let cur = self.get_var(&name).unwrap_or_else(Value::empty);
+                match dict_unset_path(&cur, &keys) {
+                    Ok(result) => {
+                        try_op!(self.set_var(&name, result.clone()));
+                        f.stack.push(result);
+                    }
+                    Err(c) => return Tick::Return(c),
+                }
+            }
+            // `dict incr var key ?amount?` — operands [Imm(amount), Imm(slot)];
+            // stack holds the key.
+            Op::DICT_INCR_IMM => {
+                let amount = i64::from(imm0(instr));
+                let name = lvt_name(imm_at(instr, 1));
+                let key = pop(f).to_str().to_string();
+                let cur = self.get_var(&name).unwrap_or_else(Value::empty);
+                let updated = dict_update_single(&cur, &key, |old| {
+                    let base = match old {
+                        Some(v) => v.as_int().map_err(|e| err(e.message))?,
+                        None => 0,
+                    };
+                    Ok(Value::int(base.wrapping_add(amount)))
+                });
+                match updated {
+                    Ok(result) => {
+                        try_op!(self.set_var(&name, result.clone()));
+                        f.stack.push(result);
+                    }
+                    Err(c) => return Tick::Return(c),
+                }
+            }
+            // `dict append var key value` — operand [Imm(slot)]; stack holds the
+            // key then the value.
+            Op::DICT_APPEND => {
+                let name = lvt_name(imm0(instr));
+                let value = pop(f);
+                let key = pop(f).to_str().to_string();
+                let cur = self.get_var(&name).unwrap_or_else(Value::empty);
+                let updated = dict_update_single(&cur, &key, |old| {
+                    let mut s = old.map(|v| v.to_str().to_string()).unwrap_or_default();
+                    s.push_str(&value.to_str());
+                    Ok(Value::string(s))
+                });
+                match updated {
+                    Ok(result) => {
+                        try_op!(self.set_var(&name, result.clone()));
+                        f.stack.push(result);
+                    }
+                    Err(c) => return Tick::Return(c),
+                }
+            }
+            // `dict lappend var key value` — operand [Imm(slot)]; stack holds the
+            // key then the value.
+            Op::DICT_LAPPEND => {
+                let name = lvt_name(imm0(instr));
+                let value = pop(f);
+                let key = pop(f).to_str().to_string();
+                let cur = self.get_var(&name).unwrap_or_else(Value::empty);
+                let updated = dict_update_single(&cur, &key, |old| {
+                    let mut items = match old {
+                        Some(v) => (*v.as_list().map_err(|e| err(e.message))?).clone(),
+                        None => Vec::new(),
+                    };
+                    items.push(value.clone());
+                    Ok(Value::list(items))
+                });
+                match updated {
+                    Ok(result) => {
+                        try_op!(self.set_var(&name, result.clone()));
+                        f.stack.push(result);
+                    }
+                    Err(c) => return Tick::Return(c),
+                }
+            }
+            // `dict get $d k1 ?k2 …?` — operand [Imm(N)]; stack holds the dict
+            // then the N keys. Leaves the looked-up value on the stack.
+            Op::DICT_GET => {
+                let nkeys = usize::try_from(imm0(instr)).unwrap_or(0);
+                if f.stack.len() < nkeys + 1 {
+                    return Tick::Return(err("dictGet: stack underflow"));
+                }
+                let keys = f.stack.split_off(f.stack.len() - nkeys);
+                let mut cur = pop(f);
+                for k in &keys {
+                    let ps = match dict_pairs(&cur) {
+                        Ok(p) => p,
+                        Err(c) => return Tick::Return(c),
+                    };
+                    let ks = k.to_str();
+                    match ps.iter().find(|(pk, _)| pk == &*ks) {
+                        Some((_, v)) => cur = v.clone(),
+                        None => {
+                            return Tick::Return(err(format!(
+                                "key \"{ks}\" not known in dictionary"
+                            )));
+                        }
+                    }
+                }
+                f.stack.push(cur);
+            }
+            // `dict exists $d k1 ?k2 …?` — operand [Imm(N)]; stack holds the dict
+            // then the N keys. Leaves a boolean on the stack.
+            Op::DICT_EXISTS => {
+                let nkeys = usize::try_from(imm0(instr)).unwrap_or(0);
+                if f.stack.len() < nkeys + 1 {
+                    return Tick::Return(err("dictExists: stack underflow"));
+                }
+                let keys = f.stack.split_off(f.stack.len() - nkeys);
+                let mut cur = pop(f);
+                let mut found = true;
+                for k in &keys {
+                    let Ok(ps) = dict_pairs(&cur) else {
+                        found = false;
+                        break;
+                    };
+                    let ks = k.to_str();
+                    if let Some((_, v)) = ps.iter().find(|(pk, _)| pk == &*ks) {
+                        cur = v.clone();
+                    } else {
+                        found = false;
+                        break;
+                    }
+                }
+                f.stack.push(Value::bool(found));
+            }
+
             // -- termination --
             Op::DONE => {
                 return Tick::Return(ok(f
@@ -1452,6 +1683,16 @@ impl Vm {
                     Err(e) => Err(err(e.message)),
                 }
             }
+            // Tcl's `unknown` fallback: an unresolved command name is handed to
+            // the user-defined `unknown` proc as `unknown name arg…` (the basis
+            // for auto-loading, ensembles, and the iRule command mocks). Only
+            // when `unknown` itself is undefined is it a hard error.
+            None if &*name != "unknown" && self.lookup_command("unknown").is_some() => {
+                let mut unknown_words = Vec::with_capacity(words.len() + 1);
+                unknown_words.push(Value::string("unknown"));
+                unknown_words.extend_from_slice(words);
+                self.dispatch_words(f, &unknown_words)
+            }
             None => Err(err(format!("invalid command name \"{name}\""))),
         }
     }
@@ -1482,6 +1723,13 @@ impl Vm {
                     Ok(c) => c,
                     Err(e) => err(e.message),
                 }
+            }
+            // `unknown` fallback (see `dispatch_words`): `unknown name arg…`.
+            None if name != "unknown" && self.lookup_command("unknown").is_some() => {
+                let mut full = Vec::with_capacity(argv.len() + 1);
+                full.push(Value::string(name));
+                full.extend_from_slice(argv);
+                self.invoke_command("unknown", &full)
             }
             None => err(format!("invalid command name \"{name}\"")),
         }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -105,6 +105,15 @@ pub struct Vm {
     ns_script_frames: Vec<usize>,
     out: Box<dyn Write>,
     compiler: Option<Box<dyn CompileService<Module = ModuleAsm>>>,
+    /// Optional debug hook fired once per source command (the execution-control
+    /// seam a step debugger drives). `None` in normal runs — the only
+    /// per-instruction cost is an `Option` check.
+    debug_hook: Option<crate::debug::DebugHook>,
+    /// The `(line, span-start)` key of the last command the debug hook fired
+    /// for, so it fires once per source command rather than per instruction
+    /// (`startCommand` is emitted only conditionally, so it cannot be the
+    /// boundary marker).
+    last_debug_key: Option<u64>,
     /// Cache of compiled scripts for the runtime-`eval` / command-substitution
     /// path (`eval_source`), keyed by source text. Compilation is a pure
     /// function of the source and the (fixed) command registry, so a script
@@ -196,6 +205,8 @@ impl Vm {
             ns_script_frames: Vec::new(),
             out,
             compiler: None,
+            debug_hook: None,
+            last_debug_key: None,
             eval_cache: HashMap::new(),
             error_info: None,
             error_logged: false,
@@ -246,6 +257,86 @@ impl Vm {
         // load time, so default it to "" rather than leaving it unset.
         let tcl_library = std::env::var("TCL_LIBRARY").unwrap_or_default();
         self.write_scalar_raw("tcl_library", Value::string(tcl_library));
+    }
+
+    /// Install a debug hook fired once per source command (the execution-control
+    /// seam a step debugger drives). Pass `None` to detach.
+    pub fn set_debug_hook(&mut self, hook: Option<crate::debug::DebugHook>) {
+        self.debug_hook = hook;
+        self.last_debug_key = None;
+    }
+
+    /// Fire the debug hook for the command an instruction belongs to, if a hook
+    /// is installed and this instruction begins a *new* source command (so the
+    /// hook fires once per command, not per instruction). Returns `true` when
+    /// the hook asked to stop. `span_start` is the instruction's source-span
+    /// start (`None` for synthetic instructions, which never fire).
+    pub(crate) fn debug_step(&mut self, line: u32, span_start: Option<u32>, cmd_text: &str) -> bool {
+        if self.debug_hook.is_none() {
+            return false;
+        }
+        let Some(start) = span_start else {
+            return false;
+        };
+        let key = (u64::from(line) << 32) | u64::from(start);
+        if self.last_debug_key == Some(key) {
+            return false;
+        }
+        self.last_debug_key = Some(key);
+        self.fire_debug_hook(line, cmd_text)
+    }
+
+    /// Build a [`crate::debug::DebugSnapshot`] of the current interpreter state
+    /// for a command at `line` with text `cmd_text`. Reads the call stack (top
+    /// first) and the current frame's variables.
+    pub(crate) fn debug_snapshot(&self, line: u32, cmd_text: &str) -> crate::debug::DebugSnapshot {
+        use crate::debug::{DebugFrame, DebugSnapshot, DebugVar};
+        let stack: Vec<DebugFrame> = self
+            .frames
+            .iter()
+            .rev()
+            .map(|fr| DebugFrame {
+                level: u32::try_from(fr.level).unwrap_or(0),
+                name: fr.proc_name.clone().unwrap_or_else(|| "global".to_owned()),
+                namespace: fr
+                    .ns_eval
+                    .clone()
+                    .unwrap_or_else(|| self.ns_name(fr.ns)),
+            })
+            .collect();
+        let mut variables: Vec<DebugVar> = self
+            .frame_var_names(false)
+            .into_iter()
+            .map(|name| {
+                let value = self.get_var(&name).map(|v| v.to_str().to_string()).unwrap_or_default();
+                DebugVar { name, value }
+            })
+            .collect();
+        variables.sort_by(|a, b| a.name.cmp(&b.name));
+        DebugSnapshot {
+            line,
+            command_text: cmd_text.to_owned(),
+            level: u32::try_from(self.current_level()).unwrap_or(0),
+            stack,
+            variables,
+        }
+    }
+
+    /// Fire the debug hook (if installed) for the command at `line` / `cmd_text`.
+    /// Returns `true` when the hook asked to stop the run.
+    pub(crate) fn fire_debug_hook(&mut self, line: u32, cmd_text: &str) -> bool {
+        if self.debug_hook.is_none() {
+            return false;
+        }
+        let snapshot = self.debug_snapshot(line, cmd_text);
+        // Take the hook out so the closure can borrow `self`-derived data
+        // (already captured in `snapshot`) without aliasing the field.
+        let mut hook = self.debug_hook.take();
+        let action = hook
+            .as_mut()
+            .map_or(crate::debug::DebugAction::Continue, |h| h(&snapshot));
+        self.debug_hook = hook;
+        action == crate::debug::DebugAction::Stop
     }
 
     /// Inject the compiler used for runtime `eval` / command substitution.

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -239,6 +239,13 @@ impl Vm {
         self.write_scalar_raw("argc", Value::int(0));
         self.write_scalar_raw("tcl_version", Value::string("9.0"));
         self.write_scalar_raw("tcl_patchLevel", Value::string("9.0.0"));
+        self.write_scalar_raw("tcl_interactive", Value::int(0));
+        // `tcl_library` is the directory holding the script library; C Tcl's
+        // init derives it from `$env(TCL_LIBRARY)` (set when the caller points
+        // the VM at a real library tree). Library scripts (tcltest) read it at
+        // load time, so default it to "" rather than leaving it unset.
+        let tcl_library = std::env::var("TCL_LIBRARY").unwrap_or_default();
+        self.write_scalar_raw("tcl_library", Value::string(tcl_library));
     }
 
     /// Inject the compiler used for runtime `eval` / command substitution.

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -114,6 +114,12 @@ pub struct Vm {
     /// (`startCommand` is emitted only conditionally, so it cannot be the
     /// boundary marker).
     last_debug_key: Option<u64>,
+    /// Set by the `exit` command to the requested process code. The VM library
+    /// never terminates the process itself — a standalone driver (the `tclvm`
+    /// CLI) translates this into `std::process::exit`, while an embedder (the
+    /// debugger, `tcl-irule-test`, `f5 explain-flow --simulate`) sees the
+    /// unwinding completion and survives. `None` until `exit` runs.
+    pending_exit: Option<i32>,
     /// Cache of compiled scripts for the runtime-`eval` / command-substitution
     /// path (`eval_source`), keyed by source text. Compilation is a pure
     /// function of the source and the (fixed) command registry, so a script
@@ -207,6 +213,7 @@ impl Vm {
             compiler: None,
             debug_hook: None,
             last_debug_key: None,
+            pending_exit: None,
             eval_cache: HashMap::new(),
             error_info: None,
             error_logged: false,
@@ -264,6 +271,26 @@ impl Vm {
     pub fn set_debug_hook(&mut self, hook: Option<crate::debug::DebugHook>) {
         self.debug_hook = hook;
         self.last_debug_key = None;
+    }
+
+    /// Record a pending `exit` with the given process code. The VM library does
+    /// not terminate the process; the driver decides (see [`Self::take_exit`]).
+    pub(crate) fn set_exit(&mut self, code: i32) {
+        self.pending_exit = Some(code);
+    }
+
+    /// Whether an `exit` is pending (the unwinding completion should propagate
+    /// uncatchably, like C Tcl's `Tcl_Exit`).
+    #[must_use]
+    pub fn exit_pending(&self) -> bool {
+        self.pending_exit.is_some()
+    }
+
+    /// Take the pending `exit` code, if any. A standalone driver (the `tclvm`
+    /// CLI) calls this after running and translates `Some(code)` into
+    /// `std::process::exit`; an embedder may ignore it and keep running.
+    pub fn take_exit(&mut self) -> Option<i32> {
+        self.pending_exit.take()
     }
 
     /// Fire the debug hook for the command an instruction belongs to, if a hook

--- a/rust/tcl-vm/src/lib.rs
+++ b/rust/tcl-vm/src/lib.rs
@@ -12,6 +12,7 @@
 //! (M2) and the rest of the Family-B impls (M3+) build on this skeleton. See
 //! `docs/design/common-runtime-emitter-architecture.md`.
 
+pub mod debug;
 pub mod error;
 pub mod host_native;
 pub mod value;
@@ -46,6 +47,7 @@ mod frame;
 mod interp;
 mod subst;
 
+pub use debug::{DebugAction, DebugFrame, DebugHook, DebugSnapshot, DebugVar};
 pub use error::TclError;
 pub use interp::Vm;
 pub use value::Value;

--- a/rust/tcl-vm/tests/language_e2e.rs
+++ b/rust/tcl-vm/tests/language_e2e.rs
@@ -150,6 +150,24 @@ fn composite_array_index_in_proc_and_store() {
     assert_eq!(out, "W\n");
 }
 
+/// Regression: `dict for`/`map` and a runtime-fallback `foreach` (qualified
+/// loop var) run the body via the runtime builtin, so the braced body must be
+/// pushed verbatim. Previously its command substitutions were evaluated once at
+/// the call site — before the loop variables existed — so the body errored.
+#[test]
+fn dict_for_body_command_subst_per_iteration() {
+    let (ok, _r, out) = run("dict for {k v} {aa 1 bb 2} { puts \"$k=$v len=[string length $k]\" }\n");
+    assert!(ok);
+    assert_eq!(out, "aa=1 len=2\nbb=2 len=2\n");
+}
+
+#[test]
+fn qualified_foreach_body_command_subst_per_iteration() {
+    let (ok, _r, out) = run("foreach ::x {aa bbb} { puts \"[string length $::x]\" }\n");
+    assert!(ok);
+    assert_eq!(out, "2\n3\n");
+}
+
 #[test]
 fn if_else() {
     let (ok, _r, out) = run("set x 5\nif {$x > 0} { puts pos } else { puts nonpos }\n");

--- a/rust/tcl-vm/tests/language_e2e.rs
+++ b/rust/tcl-vm/tests/language_e2e.rs
@@ -124,6 +124,32 @@ fn while_command_subst_condition_with_substituted_body() {
     assert_eq!(out, "done\n");
 }
 
+/// Regression: an array element whose index embeds a substitution around
+/// literal text (`$a(x$item)`, `$a(-$opt)`, `$a(${item}suf)`) must expand the
+/// inner variable. Previously only a bare whole-index `$a($item)` worked; a
+/// composite index was pushed as a raw literal so the lookup failed.
+#[test]
+fn composite_array_index_substitutes() {
+    let (ok, _r, out) = run(concat!(
+        "array set a {xfoo X -bar Y foosuf Z ab C}\n",
+        "set item foo\nset opt bar\nset i a\nset j b\n",
+        "puts \"$a(x$item) $a(-$opt) $a(${item}suf) $a($i$j)\"\n",
+    ));
+    assert!(ok);
+    assert_eq!(out, "X Y Z C\n");
+}
+
+#[test]
+fn composite_array_index_in_proc_and_store() {
+    let (ok, _r, out) = run(concat!(
+        "proc p {} {\n",
+        "  set n 1\n  set arr(k1) V\n  set arr(k$n) W\n  return $arr(k$n)\n",
+        "}\nputs [p]\n",
+    ));
+    assert!(ok);
+    assert_eq!(out, "W\n");
+}
+
 #[test]
 fn if_else() {
     let (ok, _r, out) = run("set x 5\nif {$x > 0} { puts pos } else { puts nonpos }\n");

--- a/rust/tcl-vm/tests/language_e2e.rs
+++ b/rust/tcl-vm/tests/language_e2e.rs
@@ -325,3 +325,22 @@ fn regexp_word_edge_escapes() {
     assert!(ok);
     assert_eq!(out, "10\n");
 }
+
+#[test]
+fn exit_does_not_terminate_the_process() {
+    // `exit` must not call `std::process::exit` (that would kill this test
+    // binary and any embedding host). It unwinds with a non-OK completion and
+    // records the code on the VM instead — reaching this assertion at all
+    // proves the process survived.
+    let (ok, _r, out) = run("puts before\nexit 3\nputs after\n");
+    assert!(!ok, "exit unwinds with a non-OK completion");
+    assert_eq!(out, "before\n", "statements after exit do not run");
+}
+
+#[test]
+fn exit_is_not_catchable() {
+    // Like C Tcl's Tcl_Exit, `exit` is not catchable: `catch` re-propagates the
+    // unwind rather than swallowing it, so the trailing `puts` never runs.
+    let (_ok, _r, out) = run("catch {exit 5}\nputs after\n");
+    assert_eq!(out, "", "catch does not swallow exit");
+}

--- a/rust/tcl-vm/tests/language_e2e.rs
+++ b/rust/tcl-vm/tests/language_e2e.rs
@@ -86,6 +86,44 @@ fn for_loop_output() {
     assert_eq!(out, "0\n1\n2\n");
 }
 
+/// Regression: a `while` whose condition is a *bare command substitution*
+/// (not an inlinable expression) falls back to the runtime `while` builtin.
+/// The braced `{cond}` / `{body}` words must be pushed verbatim so the builtin
+/// re-evaluates the condition each iteration; previously the condition's
+/// command substitution was evaluated *once* at the call site, freezing the
+/// loop into an infinite spin.
+#[test]
+fn while_command_subst_condition_reevaluates() {
+    let (ok, _r, out) = run("set x abc\nset n 0\nwhile {[string length $x]} { incr n\nset x \"\" }\nputs $n\n");
+    assert!(ok);
+    assert_eq!(out, "1\n");
+}
+
+#[test]
+fn while_expr_subst_condition_counts() {
+    let (ok, _r, out) = run("set i 0\nwhile {[expr {$i < 3}]} { incr i }\nputs $i\n");
+    assert!(ok);
+    assert_eq!(out, "3\n");
+}
+
+#[test]
+fn for_command_subst_condition_reevaluates() {
+    let (ok, _r, out) =
+        run("set x abcde\nfor {set i 0} {[string length $x]} {incr i} { set x \"\" }\nputs $i\n");
+    assert!(ok);
+    assert_eq!(out, "1\n");
+}
+
+/// The frozen fallback preserves each word's *source* form: a non-braced
+/// `$body` word is still substituted (to the body script), not pushed verbatim.
+#[test]
+fn while_command_subst_condition_with_substituted_body() {
+    let (ok, _r, out) =
+        run("set x abc\nset body {set x \"\"}\nwhile {[string length $x]} $body\nputs done\n");
+    assert!(ok);
+    assert_eq!(out, "done\n");
+}
+
 #[test]
 fn if_else() {
     let (ok, _r, out) = run("set x 5\nif {$x > 0} { puts pos } else { puts nonpos }\n");

--- a/rust/tcl-vm/tests/language_e2e.rs
+++ b/rust/tcl-vm/tests/language_e2e.rs
@@ -242,3 +242,86 @@ fn local_does_not_leak_to_global() {
     assert!(ok);
     assert_eq!(out, "1\n");
 }
+
+#[test]
+fn same_named_procs_in_different_namespaces_keep_own_bodies() {
+    // Regression: the pre-compiled proc-body cache was keyed by the *global*
+    // name, so two procs sharing an unqualified name across namespaces
+    // (`::a::p` vs `::b::p`) collided on one body. Keying by the
+    // runtime-qualified name keeps them distinct.
+    let (ok, _r, out) = run(concat!(
+        "namespace eval ::a { proc p {} { return A } }\n",
+        "namespace eval ::b { proc p {} { return B } }\n",
+        "puts [::a::p][::b::p]\n",
+    ));
+    assert!(ok);
+    assert_eq!(out, "AB\n");
+}
+
+#[test]
+fn namespaced_proc_resolves_variable_in_its_own_namespace() {
+    // A wrapper proc in one namespace calling a proc in another must run the
+    // callee in *its* defining namespace, so `variable` links correctly.
+    let (ok, _r, out) = run(concat!(
+        "namespace eval ::a { variable v 1\n proc get {} { variable v\n return $v } }\n",
+        "namespace eval ::b { proc call {} { return [::a::get] } }\n",
+        "puts [::b::call]\n",
+    ));
+    assert!(ok);
+    assert_eq!(out, "1\n");
+}
+
+#[test]
+fn format_with_variable_arg_substitutes_at_runtime() {
+    // Regression: `set x [format {…%s…} $var]` constant-folded `$var` to its
+    // literal source text. The fold must bail when an argument is a variable.
+    let (ok, _r, out) = run("set cmd dict\nset s [format {x %s} $cmd]\nputs $s\n");
+    assert!(ok);
+    assert_eq!(out, "x dict\n");
+}
+
+#[test]
+fn dict_set_and_get_in_proc() {
+    // The dict bytecode opcodes (DICT_SET / DICT_GET) only emit in a proc body.
+    let (ok, _r, out) = run(concat!(
+        "proc t {} {\n",
+        "  set d [dict create]\n",
+        "  dict set d a 1\n",
+        "  dict set d nested x 10\n",
+        "  dict incr d a 5\n",
+        "  dict append d a !\n",
+        "  return [dict get $d a]-[dict get $d nested x]-[dict exists $d nested y]\n",
+        "}\n",
+        "puts [t]\n",
+    ));
+    assert!(ok);
+    assert_eq!(out, "6!-10-0\n");
+}
+
+#[test]
+fn unknown_handler_dispatches_missing_command() {
+    // An unresolved command name is handed to a user-defined `unknown` proc.
+    let (ok, _r, out) = run(concat!(
+        "proc unknown {cmd args} { return \"u:$cmd:$args\" }\n",
+        "puts [nosuchcmd a b]\n",
+    ));
+    assert!(ok);
+    assert_eq!(out, "u:nosuchcmd:a b\n");
+}
+
+#[test]
+fn clock_ensemble_members_qualified() {
+    // `::tcl::clock::seconds` (the ensemble's implementation member) resolves
+    // the same as `clock seconds`.
+    let (ok, _r, out) = run("puts [expr {[::tcl::clock::seconds] > 0}]\n");
+    assert!(ok);
+    assert_eq!(out, "1\n");
+}
+
+#[test]
+fn regexp_word_edge_escapes() {
+    // Tcl ARE `\m` (begin-of-word) maps to the crate's `\b{start}`.
+    let (ok, _r, out) = run("puts [regexp {\\mcat} \"the cat\"][regexp {\\mcat} \"scatter\"]\n");
+    assert!(ok);
+    assert_eq!(out, "10\n");
+}


### PR DESCRIPTION
Finishes the eight Stage-4 **TOOL-*** tracks of the Python→Rust rewrite. 24 commits; all eight tracks are now ✅ done or 🟢 functional.

## Tracks

- **TOOL-IRULE-TEST** 🟢 — `tcl-irule-test`. `LiveSession` runs the TMM-sim orchestrator (the ~500 KB of framework Tcl under `tooling/irule_test/tcl/`) live on `tcl-vm`: load iRules, fire events (`run_http_request`), read back pool/node decisions, logs, assertions — no `tclsh` subprocess. `EmbeddedLib` bundles the framework into the binary. Topology generator (`TopologyFromSCF`) + `SessionPlan` bootstrap.
- **TOOL-F5** ✅ — `f5-cli`. `explain-flow --simulate` now replays each matched session's captured request through the embedded orchestrator and surfaces the dynamic `simulated_*` outcome (selected pool/node, `response_committed`, decisions, logs) in text + `--json` (port of `tooling/f5/irule_simulation.py`). The earlier not-implemented bail is gone.
- **TOOL-DEBUGGER** ✅ — `tcl-debugger`. Record-and-replay step debugger over the VM debug-hook seam, with a `tcl-debug` CLI and a DAP server (`--dap`): breakpoints, step in/over/out, continue, stack/scopes/variables, evaluate.
- **TOOL-FUZZ** 🟢 — `tcl-fuzz`. Campaign runner + seeded generator + findings registry (tclvm vs tclsh).
- **TOOL-EXPLORER** 🟢 — `tcl-explorer`. `wasm` view renders the eval-fallback emitter's WAT; ssa-view boolean parity fix. The `tcl explore --tui` shell moved to **ratatui 0.30.2 + the termina backend** (the helix-editor VT library), dropping crossterm entirely.
- **TOOL-REFACTOR** ✅ — ported the 5 refactoring transforms, byte-parity vs the Python oracle.
- **TOOL-CLI** ✅ — all verbs ported/dispatched; dead fallthrough removed.
- **TOOL-TCLPKG** ✅ — (already landed) wired through `pkg`/`venv`/`docker`.

## RT-VM correctness fixes (the gate)

Getting the orchestrator running end-to-end surfaced and fixed six real VM/compiler bugs, each covered by `tcl-vm/tests/language_e2e.rs`:

- **proc-body namespace-cache collision** — the pre-compiled body cache was keyed by the *global* name, so same-named procs across namespaces (`::a::p` vs `::b::p`) collided on one body and ran in the wrong namespace. Keyed now by the runtime-qualified name.
- **`format` const-fold froze variable args** — `set x [format {…%s…} $v]` folded `$v` to literal source text; the fold now bails on `$…`/`[…]` args.
- **no `unknown` fallback** — unresolved command names now dispatch to a user-defined `unknown` proc (the basis for the iRule command mocks).
- **missing `exit`** and **`::tcl::clock::*` ensemble members**.
- **ARE word-edge regex escapes** (`\m`/`\M`/`\y`/`\Y`, `[[:<:]]`) → the `regex` crate's `\b{start}`/`\b{end}`.
- Plus the **dict bytecode opcodes** and **multi-level `dict set`/`unset`**.

Result: the orchestrator's `example_test.tcl` runs 6/6 on `tclvm`, byte-identical to tclsh 8.6.

Also includes the earlier frozen-loop / composite-array-index / loop-token fixes and `package vcompare`.

## Verification

- `cargo build --workspace --all-features` clean; clippy clean on touched crates.
- Differential parity gates (`differential_codegen`, `differential_segment`, `codegen_golden`) green; explain-flow parity goldens unchanged.
- New tests: live-session routing/reject + embedded-bundle round-trips; `f5 explain-flow --simulate` text + JSON; VM regression tests for each fix; TUI `TestBackend` render smoke test.
- `docs/rust-rewrite.md` updated to reflect all eight tracks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pb6JHP6JBXWCZFKJMVEz3q

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pb6JHP6JBXWCZFKJMVEz3q)_