### PR TITLE
docs: sync rust-rewrite status as of 2026-06-22

### DIFF
--- a/docs/rust-rewrite-history.md
+++ b/docs/rust-rewrite-history.md
@@ -11216,3 +11216,199 @@ The track closed in `rust-rewrite.md` (now a ✅ row). What landed:
 - **Tests** — 61 `tcl-pkg` unit tests (mirroring the Python `tests/tclpkg/`
   cases) + 5 `tcl-cli` integration tests over the built binary. `cargo clippy
   -p tcl-pkg -p tcl-cli --all-targets` is warning-clean.
+
+## RT-VM — post-parity-push fixes (2026-06-21/22)
+
+Follow-on fixes after the 2026-06-19 parity push (above). Each is covered by
+`tcl-vm/tests/language_e2e.rs` and pinned byte-equal to tclsh; the live open
+gaps stay in [`rust-rewrite.md`](rust-rewrite.md) → **RT-VM**.
+
+- **(2026-06-21) the runtime `while`/`for` frozen-loop infinite spin.** A loop
+  whose **condition is a bare command substitution** can't inline to a CFG loop
+  (only an *expression* condition — `[cmd] > 0`, `$x`, `!![cmd]` — does), so
+  `cfg_builder` converts it to a "frozen" runtime `while`/`for` call. That
+  conversion built the barrier with `tokens: None`, so the codegen lost each
+  word's source kind and pushed the braced `{cond}` word **non-verbatim** —
+  `subst_word` evaluated the condition's command substitution **once** at the
+  call site, freezing the loop into an infinite spin (`while {[string length
+  $x]} {set x ""}` never terminated; the `> 0` variants did). The `While`/`For`
+  IR now carries the segmenter's `raw_tokens`, and the frozen barrier reuses them
+  so each word is pushed exactly as written (braced → verbatim, `$body` →
+  substituted). Covered by
+  `tcl-vm/tests/language_e2e.rs::while_command_subst_condition_*`. **This was the
+  most common real "hang" idiom** — tcltest's own `while {[string length
+  $argList]}` word-splitter spun. The **same token-loss bug** was then fixed for
+  the other runtime loop fallbacks — the `dict for`/`map` barrier and the runtime
+  `foreach`/`lmap` call (qualified loop vars / non-inline) — by extending
+  `raw_tokens` to `Foreach`. Audit: only the three loop types have a runtime
+  fallback; `switch`/`catch`/`try`/`if` inline their bodies and need no token
+  preservation.
+- **(2026-06-21) composite array-element index substitution.** A read or write
+  of `$a(prefix$var)` / `$a(-$opt)` / `$a(${item}suf)` pushed the index as a raw
+  literal, so the embedded variable never expanded (`can't read "a(x$item)"`).
+  tcltest's `$testAttributes(-$item)` option processing hit this, aborting
+  `info.test` after the loop fix. `push_array_key` now decodes a composite index
+  into its substitution parts and `STR_CONCAT`s them (byte-equal to `tclsh9.0`).
+- **(2026-06-22) six bugs surfaced by running the iRule TMM-sim orchestrator**
+  (the ~500 KB of framework Tcl behind **TOOL-IRULE-TEST**) on the VM:
+  - **proc-body namespace-cache collision** — the pre-compiled body cache was
+    keyed by the *global* name, so two procs sharing an unqualified name across
+    namespaces (`::a::p` vs `::b::p`) collided on one body and a wrapper proc ran
+    the wrong callee in the wrong namespace (`[namespace current]` / `variable`
+    resolved against the caller). Keyed now by the runtime-qualified name.
+  - **`format` const-fold froze variable args** — `set x [format {…%s…} $v]`
+    folded `$v` to the literal source text; the fold now bails when any argument
+    is a runtime substitution (`$…`/`[…]`).
+  - **no `unknown` fallback** — an unresolved command name is now handed to a
+    user-defined `unknown` proc (`unknown name arg…`), the basis for the iRule
+    command mocks, ensembles, and auto-loading.
+  - **missing `exit`** — added the builtin (so the shim can rename it to
+    `::tmm::_orig_exit` and scripts terminate with the right process code).
+  - **`::tcl::clock::*` ensemble members** — `clock clicks`/`seconds`/… are now
+    reachable via their fully-qualified implementation names, which library code
+    calls directly.
+  - **ARE word-edge regex escapes** — `\m`/`\M`/`\y`/`\Y` and `[[:<:]]`/`[[:>:]]`
+    translate to the `regex` crate's `\b{start}`/`\b{end}`/`\b`/`\B`.
+
+  Also implemented the **dict bytecode opcodes** (`DICT_SET`/`UNSET`/`INCR_IMM`/
+  `APPEND`/`LAPPEND`/`GET`/`EXISTS`) and made the generic `dict set`/`dict unset`
+  honour **multi-level key paths** (was single-level). With these, the
+  orchestrator's `example_test.tcl` runs 6/6 on `tclvm`, byte-identical to tclsh
+  8.6.
+- **VM CLI/REPL binary (`tclvm`, `tcl-vm-cli`).** A thin compiler-backed
+  `CompileService` driver, keeping the `tcl-vm` lib compiler-optional. Runs
+  script files (with `argv`/`argv0`/`argc`), evaluates inline scripts (`-c`),
+  pipes stdin, and offers an `info complete`-aware REPL (`-i` forces it without a
+  TTY). The `tcl dis` verb it was paired with is wired in `tcl-cli` (bytecode
+  disassembly via `format_module_asm`, with `--optimise`).
+
+## FE-DIAG-F5 — TK / BIG-IP / iApp diagnostics ported (landed 2026-06)
+
+Three of the four F5 dialect diagnostic families ported; the XC-translator family
+stays Python-only (open residual in [`rust-rewrite.md`](rust-rewrite.md) →
+**FE-DIAG-F5**). What landed:
+
+- **TK1001-1003** (geometry/widget/option) — ported to
+  `tcl-compiler::analyser::tk_checks`, gated on the `tk` dialect: TK1002
+  non-existent-parent + TK1003 unknown-option run per command, TK1001 pack/grid
+  conflict is decided post-walk from accumulated per-parent geometry usage
+  (flushed from `run_diagnostic_emitters`).
+- **BIGIP6001-6011** (config validator) — ported to `tcl-bigip::validator`
+  (`validate_bigip_config` / `validate_bigip_source`) producing ranged
+  `ConfigDiagnostic`s over a parsed `BigipConfig`, reusing the lint engine's
+  `ModelView` / `KindMap` / `resolve_name` (now `pub(crate)`). The `regex` crate
+  has no look-around, so the two Python negative look-aheads (`pool !member`,
+  `persist !none`) are filtered in code.
+- **IAPP7001-7003** (iApp template) — ported to
+  `tcl-bigip::apl::{iapp_vars,iapp_diagnostics}`: `extract_iapp_var_refs` pulls
+  `$::section__field` implementation references (ReDoS-safe regex), and
+  `validate_iapp_presentation` / `validate_iapp_implementation` emit
+  IAPP7001/7002/7003 over the existing `AplModel`, gated on the `f5-iapps` /
+  `f5-tmsh` / `f5-bigip` dialects.
+
+## TOOL-REFACTOR — refactoring transforms (landed 2026-06)
+
+The 5 remaining transforms (extract/inline variable, if↔switch, switch→dict,
+extract-datagroup) ported into the new `tcl-lsp-core::refactor` module and wired
+through `refactor_engine_actions`, alongside the pre-existing extract/inline proc
+— 7 transforms total. `find_command_at` descends registry-resolved
+`ArgRole::Body` words for nested-body support; the data-group action carries the
+rendered tmsh definition on `CodeAction::data_group_definition` (surfaced as the
+LSP `data` field, mirroring `_datagroup_to_code_action`). The if↔switch /
+switch→dict / datagroup outputs are asserted byte-for-byte against the live
+Python oracle; all `tests/test_refactoring.py` decline conditions are mirrored.
+Out of scope: `suggest_datagroup_extraction` (an AI-context scanner, not a
+`CodeAction`).
+
+## TOOL-F5 — `f5-cli` (landed 2026-06)
+
+The `explain-flow` `--tshark` / `--keylog` / `--tshark-filter` L7-enrichment
+paths landed (`tcl_bigip::flow::tshark`, a faithful EK-JSON port of
+`dialects/f5/bigip/flow/tshark.py`, byte-identical to the Python CLI on the
+`--tshark` / `--tshark-filter` paths; graceful degradation when tshark lacks EK
+`--no-duplicate-keys` support is itself parity-matched). `--simulate` runs each
+matched session's iRule under the embedded TMM-sim orchestrator on `tcl-vm` (via
+`tcl-irule-test::LiveSession`): the selected pool/node, the lb decision log,
+captured iRule logs and `response_committed` flow into the `simulated_*`
+text/JSON fields, a port of `tooling/f5/irule_simulation.py`. 28 dispatched verbs
+(27 shipped + the temporary rust-branch-only `registry-dump`, demoted from the
+shipped set on `main` by `#664`) and 262 parity tests — the template for the
+other tool ports.
+
+## TOOL-EXPLORER — compiler explorer (landed 2026-06, views)
+
+The `ssa`-view boolean-render parity bug landed (`view_tree::pystr`), and the
+**`wasm` view now renders WAT** — `serialise.rs::serialise_wasm` drives the
+eval-fallback `wasm_codegen_module` (the same emitter `tcl compwasm` uses) and
+emits the module's WAT plus per-function headers, which `render.rs::render_wasm`
+prints. All TUI views are now populated. Refinement (not blocking the view, open
+in [`rust-rewrite.md`](rust-rewrite.md) → **TOOL-EXPLORER**): the rich
+per-instruction explorer shape (`to_explorer_json`) the *web GUI* uses is not
+ported, so the wasm tab shows flat WAT rather than the gutter-rendered
+instruction graph; that lands with the broader **RT-WASM** emitter work. The
+Pyodide web server stays Python.
+
+## TOOL-FUZZ — differential fuzzer (`tcl-fuzz`) (landed 2026-06)
+
+A seeded random Tcl generator (`generator.rs`, scoped to the VM's supported
+surface so a divergence is a real miscompile, not an unimplemented command —
+pure, bounded loops, balanced delimiters), a subprocess differential harness
+(`harness.rs`: `tclvm` subject vs `tclsh` reference, each timeout-killable so a
+hang is a finding not a wedge), a campaign runner with stats (`campaign.rs`), and
+a findings registry (`findings.rs`: JSON + raw `.tcl`, dedup-by-seed,
+categorised, replayable). CLI verbs `run` / `replay` / `summary`. A 500-iteration
+campaign over the current VM is clean (498/500 match, 2 skipped, 0 findings — the
+loop/array fixes hold under fuzzing). Open residual in
+[`rust-rewrite.md`](rust-rewrite.md) → **TOOL-FUZZ**: broaden the generator
+grammar as the VM surface grows + add the WASM/Zig differential arm once
+**RT-WASM** lands.
+
+## TOOL-DEBUGGER — record-and-replay step debugger (`tcl-debugger`) (landed 2026-06)
+
+A record-and-replay step debugger over `tcl-vm`. The RT-VM piece landed —
+`tcl-vm` has a debug-hook seam (`Vm::set_debug_hook`): it fires once per source
+command (keyed on `(line, span-start)`, since `startCommand` is emitted only
+conditionally) with a full `DebugSnapshot` (line, command text, call stack,
+current-frame variables) and honours the returned `DebugAction`. The seam is
+inert (an `Option` check) when no hook is installed — differential parity gates
+stay green. `tcl-debugger`'s `VmBackend` installs a recording hook, runs the
+script once to capture the trace, then serves breakpoints / step-in/over/out /
+continue / stack / variable-inspection by navigating the trace with the
+`DebugController`. Two front-ends drive it: a `tcl-debug` interactive CLI
+(`break`/`step`/`next`/`finish`/`continue`/`print`/`stack`/`vars`) and a **DAP
+server** (`tcl-debug --dap`) speaking the Debug Adapter Protocol over
+`Content-Length`-framed stdio —
+`initialize`/`launch`/`setBreakpoints`/`threads`/`stackTrace`/`scopes`/`variables`/`continue`/`next`/`stepIn`/`stepOut`/`evaluate`/`disconnect`
+plus the `initialized`/`stopped`/`terminated` events — so editors integrate
+directly. Known replay-model characteristics (documented, not unfinished): script
+output is produced once up front, variable inspection is the current frame's
+captured scope, and `evaluate` resolves captured variables.
+
+## TOOL-IRULE-TEST — iRule TMM-sim framework (`tcl-irule-test`) (landed 2026-06)
+
+The crate runs the TMM-sim orchestrator live on `tcl-vm`. `topology` ports
+`TopologyFromSCF` — parse a bigip.conf via `tcl-bigip` and emit the `::orch::`
+setup (profiles via name-inference, VIP, pools + members, data-groups, attached
+iRules), parity-checked against the Python generator. `session` defines the
+`SessionPlan` / orchestrator-bootstrap assembly. `live::LiveSession` is the
+in-process driver: it sources the orchestrator framework (the ~500 KB of Tcl
+under `tooling/irule_test/tcl/` — orchestrator + TMM shim + command mocks) on a
+bytecode VM, loads iRules, fires events (`run_http_request`), and reads back the
+pool/node decisions, captured logs, and assertions — no `tclsh` subprocess.
+`embedded::EmbeddedLib` bundles the framework into the binary so a consumer (e.g.
+`f5 explain-flow --simulate`) needs no on-disk Tcl checkout. Getting the
+orchestrator running surfaced and fixed six VM/compiler bugs (see RT-VM
+post-parity-push fixes above) plus the dict opcodes and multi-level `dict set`.
+Note `tcl-irules` is the BIG-IP reference-extractor, **not** this. Open residual
+in [`rust-rewrite.md`](rust-rewrite.md) → **TOOL-IRULE-TEST**: broaden the
+generator grammar as the VM surface grows.
+
+## TOOL-CLI — native `tcl` CLI (`tcl-cli`) (landed 2026-06)
+
+All 26 top-level verbs ported and dispatched to native engine handlers. `dis`
+(bytecode disassembly via `format_module_asm`) and `compwasm` (eval-fallback WASM
+binary/WAT via the greenfield emitter) landed earlier; the `pkg`/`venv`/`docker`
+verbs are wired through to the `tcl-pkg` handlers that landed under
+**TOOL-TCLPKG**. The dispatch `match` is exhaustive (the not-yet-implemented
+fallthrough is gone). Any deeper WASM-emitter precision residual is **RT-WASM**'s,
+not the CLI verb's.

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -895,7 +895,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | Bytecode codegen | `tcl-compiler::codegen` | 🟢 | state-mutating statement-position specialisations + `expr` const-fold + byte-wise `esc` landed (byte-true vs tclsh9.0; VM opcodes implemented to match); residual: `set x [cmd]` (reverted — needs VM value opcodes), bare-statement `string`/`regexp`/`lindex`/`lreplace`, non-proc `dict` (ensemble `invokeReplace`), `{*}` cmd-subst expansion → **FE-CODEGEN** |
 | Analyser diagnostics | `tcl-compiler::analyser` | ✅ | every family ported + verified (E001/W125/IRULE5005, snit, OO body-walks, W307/W308, C44 path-sensitivity + IRULE5002/5004/2001 quick-fixes, `when`-body gating, source-style/W108, #662 lockstep fixes) — see [history](rust-rewrite-history.md). The two consumer-wiring residuals (per-check config toggles, flow-warning code actions) landed under **SRV-LSP** |
 | F5 dialect diagnostics | `tcl-compiler::analyser::tk_checks`, `tcl-bigip::{validator,apl}`, new `tcl-xc` | 🟢 | TK1001-3 + BIGIP6001-11 + IAPP7001-3 ported (TK live in the analyser); residuals: XC100-301 (gated on a `tcl-xc` translator port of `lower_to_ir`-walking `translator.py`, Python-only meanwhile) + BIG-IP/iApp native-server consumer-wiring (SRV-LSP-style) → **FE-DIAG-F5** |
-| WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🔴 | eval-fallback emitter + `tcl compwasm` wiring landed (binary/WAT, `wasmtime`-validated); residual: `IRInterpBoundary`; codegen DCE/GVN; `--link` (Binaryen) bundling → **RT-WASM** |
+| WASM codegen + runtime | `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` | 🟡 | eval-fallback emitter + `tcl compwasm` wiring landed (binary/WAT, `wasmtime`-validated); residual: `IRInterpBoundary`; codegen DCE/GVN; `--link` (Binaryen) bundling → **RT-WASM** |
 | Bytecode VM | `tcl-vm` | 🟡 | tcltest parity vs `runtime/rust` in progress (info/proc hangs; namespace/var/upvar depth; error `[try]`-coverage); TclOO; clock/encoding/interp/IO/after. `tclvm` CLI/REPL binary landed (`tcl-vm-cli`) → **RT-VM** |
 | LSP server / core / db | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | ✅ | #670 bulk + the two consumer-wiring residuals (GAP-C1 per-check config toggles; IRULE5002/5004 flow-warning code actions) landed — see [history](rust-rewrite-history.md). The rope-backed `DocumentState` is split out into its own **SRV-ROPE** track (need evaluated with measurements in [`design/rope/`](design/rope/README.md)) |
 | Document store / incrementality | `tcl-lsp-server`, `tcl-lexer`, `tcl-lsp-db` | 🔴 | rope-backed store + chunk-addressable salsa input + rope-slice re-lex → **SRV-ROPE** (see [`design/rope/`](design/rope/README.md)) |
@@ -918,14 +918,14 @@ listed residuals · 🟡 partial · 🔴 not started.
 | FE | **FE-DATAFLOW** ✅ | `tcl-compiler::{sccp,intervals,interval_bounds,memory_ssa,ssa}` | — | M |
 | FE | **FE-TYPESHIM** ✅ | `tcl-compiler::{type_infer,value_shapes,rendered_properties,shimmer}` | — | M |
 | FE | **FE-VARESCAPE** ✅ | `tcl-compiler::var_escape` | — | M |
-| FE | **FE-OPT** | `tcl-compiler::optimiser`, `inlining` | — | L |
-| FE | **FE-CODEGEN** | `tcl-compiler::codegen` (non-wasm) | — | M |
+| FE | **FE-OPT** 🟢 | `tcl-compiler::optimiser`, `inlining` | — | L |
+| FE | **FE-CODEGEN** 🟢 | `tcl-compiler::codegen` (non-wasm) | — | M |
 | FE | **FE-DIAG** ✅ | `tcl-compiler::analyser`, `irules_checks` | — | M |
 | FE | **FE-DIAG-F5** 🟢 | `tcl-compiler::analyser::tk_checks`, `tcl-bigip::{validator,apl}` slices, tk; XC residual → `tcl-xc` | `tcl-bigip` | L |
-| RT | **RT-WASM** | `tcl-compiler::codegen::wasm`, `runtime/zig`, `tcl-wasm` bin | FE-CODEGEN | L |
-| RT | **RT-VM** | `tcl-vm`, `tcl-vm-cli` (`tclvm` bin) | `tcl-bytecode` | L |
+| RT | **RT-WASM** 🟡 | `tcl-compiler::codegen::wasm`, `runtime/zig`, `tcl-wasm` bin | FE-CODEGEN | L |
+| RT | **RT-VM** 🟡 | `tcl-vm`, `tcl-vm-cli` (`tclvm` bin) | `tcl-bytecode` | L |
 | SRV | **SRV-LSP** ✅ | `tcl-lsp-server`, `tcl-lsp-core`, `tcl-lsp-db` | FE-DIAG, FE-DATAFLOW | L |
-| SRV | **SRV-ROPE** | document store: `tcl-lsp-server` `DocumentState` + `tcl-lexer` rope-slice `SourceMap` + `tcl-lsp-db` chunk input | FE-LEX (CST/structural-state index), SRV-LSP | XL |
+| SRV | **SRV-ROPE** 🔴 | document store: `tcl-lsp-server` `DocumentState` + `tcl-lexer` rope-slice `SourceMap` + `tcl-lsp-db` chunk input | FE-LEX (CST/structural-state index), SRV-LSP | XL |
 | TOOL | **TOOL-TCLPKG** ✅ | `tcl-pkg` crate | — | XL |
 | TOOL | **TOOL-REFACTOR** ✅ | `tcl-lsp-core::code_actions` | SRV-LSP | M |
 | TOOL | **TOOL-F5** ✅ | `f5-cli` | RT-VM, TOOL-IRULE-TEST | XS |
@@ -934,7 +934,7 @@ listed residuals · 🟡 partial · 🔴 not started.
 | TOOL | **TOOL-DEBUGGER** ✅ | `tcl-debugger` | RT-VM | L |
 | TOOL | **TOOL-IRULE-TEST** 🟢 | `tcl-irule-test` | RT-VM, `tcl-registry` | XL |
 | TOOL | **TOOL-CLI** ✅ | `tcl-cli` | RT-WASM, RT-VM, TOOL-TCLPKG | S |
-| API | **API-PYO3** | `tcl-lsp-py`, `scripts`→`xtask`, `tests` | everything above | L |
+| API | **API-PYO3** 🔴 | `tcl-lsp-py`, `scripts`→`xtask`, `tests` | everything above | L |
 
 ---
 
@@ -998,27 +998,10 @@ were implemented in `tcl-vm` so the codegen runs end-to-end. Remaining:
 #### FE-DIAG-F5 — F5 dialect diagnostics
 Owns new analyser slices on `tcl-bigip` / `tcl-xc` and the tk dialect. The
 per-family port decision (the track's explicit "decide Python-only vs Rust
-port per family") is made and three of the four families are landed; the
-fourth is gated on a separate subsystem port and stays Python-only until it
-lands.
-- **landed** **TK1001-1003** (geometry/widget/option) — ported to
-  `tcl-compiler::analyser::tk_checks`, gated on the `tk` dialect: TK1002
-  non-existent-parent + TK1003 unknown-option run per command, TK1001
-  pack/grid conflict is decided post-walk from accumulated per-parent
-  geometry usage (flushed from `run_diagnostic_emitters`).
-- **landed** **BIGIP6001-6011** (config validator) — ported to
-  `tcl-bigip::validator` (`validate_bigip_config` / `validate_bigip_source`)
-  producing ranged `ConfigDiagnostic`s over a parsed `BigipConfig`, reusing
-  the lint engine's `ModelView` / `KindMap` / `resolve_name` (now
-  `pub(crate)`). The `regex` crate has no look-around, so the two Python
-  negative look-aheads (`pool !member`, `persist !none`) are filtered in
-  code.
-- **landed** **IAPP7001-7003** (iApp template) — ported to
-  `tcl-bigip::apl::{iapp_vars,iapp_diagnostics}`:
-  `extract_iapp_var_refs` pulls `$::section__field` implementation
-  references (ReDoS-safe regex), and `validate_iapp_presentation` /
-  `validate_iapp_implementation` emit IAPP7001/7002/7003 over the existing
-  `AplModel`, gated on the `f5-iapps` / `f5-tmsh` / `f5-bigip` dialects.
+port per family") is made: **TK1001-1003**, **BIGIP6001-6011**, and
+**IAPP7001-7003** are landed (detail in the
+[history archive](rust-rewrite-history.md) → *FE-DIAG-F5*); the fourth family is
+gated on a separate subsystem port and stays Python-only until it lands.
 - **open (deferred, Python-only)** **XC100-301** (BIG-IP→F5-XC translator)
   — the XC-series diagnostics are a thin wrapper over `translate_irule`
   (`dialects/f5/xc/diagnostics.py`), but that translator (`translator.py`
@@ -1042,16 +1025,15 @@ flow-warning code-action residuals **FE-DIAG** handed to **SRV-LSP**.
 ### Stage 2 — Runtime & execution (RT-*)
 
 #### RT-WASM — WASM codegen + runtime
-Owns `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` bin.
+Owns `tcl-compiler::codegen::wasm`, `runtime/zig`, new `tcl-wasm` bin. The
+eval-fallback emitter + `tcl compwasm` wiring have landed (binary/WAT output,
+`wasmtime`-validated; the `_write_binary_output` analogue is
+`tcl_cli_support::write_binary_output`); what remains:
 - **open** finish the WASM emitter (`wasm_codegen_module`) — only the Phase-1 IR
   + encoding (~1 K LOC) is ported vs the ~13-module Python package. *(large)*
 - **open** `IRInterpBoundary` IR node + insert pass; the IR-rewriting
   `passes/dce.py` / `passes/gvn.py`; `source_inliner` / `stdlib_prelude`
   (WASM-bundle self-containment).
-- **done** wire `tcl compwasm` (`tcl-cli`): drives the eval-fallback emitter,
-  writes the binary module (`--output`) and optional WAT (`--wat-output`); the
-  emitted bytes pass `wasmtime compile`. The `_write_binary_output` analogue
-  landed as `tcl_cli_support::write_binary_output`.
 - **open** `tcl-wasm` CLI + `--link` (Binaryen) bundling (standalone
   self-contained module via `source_inliner` / `stdlib_prelude`).
 
@@ -1067,11 +1049,10 @@ suite is at parity when the two columns match. The landing log is in the
 [history](rust-rewrite-history.md) (2026-06-19); the per-suite snapshot + gaps
 below are the live state.
 
-The 2026-06-19 parity push (`namespace eval`/`inscope` real call frames,
-`try`/`throw` as VM builtins, nested-`foreach`/`lmap` runtime routing, `namespace
-delete`, and the supporting `return`/`error`/list-parse fixes — error.test
-44 → 280, lmap 21 → 61, namespace 93 → 112) is archived in the
-[history](rust-rewrite-history.md). The live open gaps:
+The 2026-06-19 parity push and the 2026-06-21/22 follow-on fixes (the runtime
+`while`/`for` frozen-loop spin, composite array-index substitution, the six
+orchestrator bugs, the dict opcodes, and the `tclvm` CLI/REPL binary) are
+archived in the [history](rust-rewrite-history.md). The live open gaps:
 
 - **open (P1) "suite-zeroing hangs" are mostly mis-attributed** (diagnosed
   2026-06-21). The `info.test` / `proc.test` "hangs" are **not** deadlocks: built
@@ -1090,63 +1071,8 @@ delete`, and the supporting `return`/`error`/list-parse fixes — error.test
     variable`; `proc.test` ends on a bare `VM error:`). That single escape, not
     a loop, is what zeros the remainder of the suite — the real P1 to chase
     (an `uplevel`/`catch`/error-propagation gap), and far more tractable than a
-    deadlock hunt.
-- **fixed (2026-06-21) the runtime `while`/`for` frozen-loop infinite spin.** A
-  loop whose **condition is a bare command substitution** can't inline to a CFG
-  loop (only an *expression* condition — `[cmd] > 0`, `$x`, `!![cmd]` — does), so
-  `cfg_builder` converts it to a "frozen" runtime `while`/`for` call. That
-  conversion built the barrier with `tokens: None`, so the codegen lost each
-  word's source kind and pushed the braced `{cond}` word **non-verbatim** —
-  `subst_word` evaluated the condition's command substitution **once** at the
-  call site, freezing the loop into an infinite spin (`while {[string length
-  $x]} {set x ""}` never terminated; the `> 0` variants did). The `While`/`For`
-  IR now carries the segmenter's `raw_tokens`, and the frozen barrier reuses
-  them so each word is pushed exactly as written (braced → verbatim, `$body` →
-  substituted). Verified byte-equal to `tclsh9.0` and covered by
-  `tcl-vm/tests/language_e2e.rs::while_command_subst_condition_*`. **This was the
-  most common real "hang" idiom** — tcltest's own
-  `while {[string length $argList]}` word-splitter spun — so several suites that
-  appeared to "hang" should now progress (re-baseline the parity harness in
-  `--release`). The **same token-loss bug** was then fixed for the other
-  runtime loop fallbacks — the `dict for`/`map` barrier and the runtime
-  `foreach`/`lmap` call (qualified loop vars / non-inline) — by extending
-  `raw_tokens` to `Foreach`. **Audit:** only the three loop types have a
-  runtime fallback; `switch`/`catch`/`try`/`if` inline their bodies and need no
-  token preservation.
-- **fixed (2026-06-21) composite array-element index substitution.** A read or
-  write of `$a(prefix$var)` / `$a(-$opt)` / `$a(${item}suf)` pushed the index as
-  a raw literal, so the embedded variable never expanded (`can't read
-  "a(x$item)"`). tcltest's `$testAttributes(-$item)` option processing hit this,
-  aborting `info.test` after the loop fix. `push_array_key` now decodes a
-  composite index into its substitution parts and `STR_CONCAT`s them (byte-equal
-  to `tclsh9.0`).
-- **fixed (2026-06-22) six bugs surfaced by running the iRule TMM-sim
-  orchestrator** (the ~500 KB of framework Tcl behind **TOOL-IRULE-TEST**) on the
-  VM, each covered by `tcl-vm/tests/language_e2e.rs`:
-  - **proc-body namespace-cache collision** — the pre-compiled body cache was
-    keyed by the *global* name, so two procs sharing an unqualified name across
-    namespaces (`::a::p` vs `::b::p`) collided on one body and a wrapper proc ran
-    the wrong callee in the wrong namespace (`[namespace current]` / `variable`
-    resolved against the caller). Keyed now by the runtime-qualified name.
-  - **`format` const-fold froze variable args** — `set x [format {…%s…} $v]`
-    folded `$v` to the literal source text; the fold now bails when any argument
-    is a runtime substitution (`$…`/`[…]`).
-  - **no `unknown` fallback** — an unresolved command name is now handed to a
-    user-defined `unknown` proc (`unknown name arg…`), the basis for the iRule
-    command mocks, ensembles, and auto-loading.
-  - **missing `exit`** — added the builtin (so the shim can rename it to
-    `::tmm::_orig_exit` and scripts terminate with the right process code).
-  - **`::tcl::clock::*` ensemble members** — `clock clicks`/`seconds`/… are now
-    reachable via their fully-qualified implementation names, which library code
-    calls directly.
-  - **ARE word-edge regex escapes** — `\m`/`\M`/`\y`/`\Y` and `[[:<:]]`/`[[:>:]]`
-    translate to the `regex` crate's `\b{start}`/`\b{end}`/`\b`/`\B`.
-  Also implemented the **dict bytecode opcodes** (`DICT_SET`/`UNSET`/`INCR_IMM`/
-  `APPEND`/`LAPPEND`/`GET`/`EXISTS`) and made the generic `dict set`/`dict unset`
-  honour **multi-level key paths** (was single-level). With these, the
-  orchestrator's `example_test.tcl` runs 6/6 on `tclvm`, byte-identical to
-  tclsh 8.6. The `unknown`/`exit`/error-propagation pieces also bear on the
-  "(b) uncaught-error abort" P1 above (re-baseline the parity harness).
+    deadlock hunt. (The 2026-06-22 `unknown`/`exit`/error-propagation work bears
+    on this — re-baseline the parity harness in `--release`.)
 - **open** `namespace` / `var` / `upvar` depth (≈ 290 failures combined) — the
   namespace-eval-frame fix corrected the *mechanism*; the remainder is
   feature/semantics depth (namespace-name canonicalisation of multiple/trailing
@@ -1171,13 +1097,6 @@ delete`, and the supporting `return`/`error`/list-parse fixes — error.test
   ambiguous subcommand" today); note `info cmdcount` cannot reach exact-count
   parity with C Tcl without matching its per-bytecode command counting, so it
   is a "exists but approximate" subcommand rather than a parity win.
-- **done** a VM CLI/REPL binary — the `tclvm` binary in the new `tcl-vm-cli`
-  crate (a thin compiler-backed `CompileService` driver, keeping the `tcl-vm`
-  lib compiler-optional). Runs script files (with `argv`/`argv0`/`argc`),
-  evaluates inline scripts (`-c`), pipes stdin, and offers an `info
-  complete`-aware REPL (`-i` forces it without a TTY). The `tcl dis` verb it
-  was paired with is wired in `tcl-cli` (bytecode disassembly via
-  `format_module_asm`, with `--optimise`).
 
 ### Stage 3 — LSP server (SRV-LSP) — complete
 
@@ -1234,115 +1153,27 @@ reproducible experiment, and task breakdown live in
 
 These own distinct crates and parallelise; the ones marked *depends* are gated
 on a library track above. This is the layer that, per the `tcl`/`f5` pattern
-already started, brings **every** Python tool across to Rust.
+already started, brings **every** Python tool across to Rust. **Most of the
+stage has landed** — the landing logs are in the
+[history archive](rust-rewrite-history.md) and the tracks survive in the
+subsystem-status / track-map tables above. Only the 🟢 tracks carry residuals:
 
-- **TOOL-TCLPKG** *(new `tcl-pkg` crate; independent)* — **done**: full
-  package-manager port — `version` (semver + Tcl-friendly ordering), `manifest`
-  (whitelisted-directive parser with safe-mode refusal, no VM), `lockfile`
-  (canonical JSON, byte-identical with Python), MVS `resolver`, `cas`
-  (worktree-canonical SHA-256 + store/materialise), `fetchers` (gzip-tarball /
-  zip / git / path over `ureq`), `registry` (TTL cache + conditional GET),
-  `venv`, `docker`, plus `ui`. The `pkg`/`venv`/`docker` CLI stubs in `tcl-cli`
-  are wired through to native handlers; help is native clap style. Lockfiles,
-  Dockerfiles, and venv scripts diff byte-for-byte against the Python CLI.
-  *(XL)*
-- **TOOL-REFACTOR** *(owns `tcl-lsp-core::code_actions`)* — **done**: the 5
-  remaining transforms (extract/inline variable, if↔switch, switch→dict,
-  extract-datagroup) are ported into the new `tcl-lsp-core::refactor` module
-  and wired through `refactor_engine_actions`, alongside the pre-existing
-  extract/inline proc. `find_command_at` descends registry-resolved
-  `ArgRole::Body` words for nested-body support; the data-group action carries
-  the rendered tmsh definition on `CodeAction::data_group_definition` (surfaced
-  as the LSP `data` field, mirroring `_datagroup_to_code_action`). The
-  if↔switch / switch→dict / datagroup outputs are asserted byte-for-byte
-  against the live Python oracle; all `tests/test_refactoring.py` decline
-  conditions are mirrored. Out of scope: `suggest_datagroup_extraction` (an
-  AI-context scanner, not a `CodeAction`). *(M)*
-- **TOOL-F5** *(owns `f5-cli`)* — **done**: the `explain-flow`
-  `--tshark` / `--keylog` / `--tshark-filter` L7-enrichment paths landed
-  (`tcl_bigip::flow::tshark`, a faithful EK-JSON port of
-  `dialects/f5/bigip/flow/tshark.py`, byte-identical to the Python CLI on the
-  `--tshark` / `--tshark-filter` paths; graceful degradation when tshark lacks
-  EK `--no-duplicate-keys` support is itself parity-matched). `--simulate` now
-  runs each matched session's iRule under the embedded TMM-sim orchestrator on
-  `tcl-vm` (via `tcl-irule-test::LiveSession`): the selected pool/node, the lb
-  decision log, captured iRule logs and `response_committed` flow into the
-  `simulated_*` text/JSON fields, port of `tooling/f5/irule_simulation.py`. The
-  rest (28 dispatched verbs — the 27 shipped verbs plus the temporary
-  rust-branch-only `registry-dump`, demoted from the shipped set on `main` by
-  `#664` — and 262 parity tests) is done — the template for the other tool
-  ports. *(XS)*
-- **TOOL-EXPLORER** *(owns `tcl-explorer`, `tcl-explorer-wasm`; depends on
-  RT-WASM)* — **done (for the views)**: the `ssa`-view boolean-render parity bug
-  landed (`view_tree::pystr`), and the **`wasm` view now renders WAT** —
-  `serialise.rs::serialise_wasm` drives the eval-fallback `wasm_codegen_module`
-  (the same emitter `tcl compwasm` uses) and emits the module's WAT plus
-  per-function headers, which `render.rs::render_wasm` prints. All TUI views are
-  now populated. Refinement (not blocking the view): the rich per-instruction
-  explorer shape (`to_explorer_json` — resolved call targets, paired branch
-  targets, lane-assigned edges) the *web GUI* uses is not ported, so the wasm
-  tab shows flat WAT rather than the gutter-rendered instruction graph; that
+- **TOOL-EXPLORER** 🟢 *(depends on RT-WASM)* — the TUI `wasm` view renders flat
+  WAT; the rich per-instruction web-GUI shape (`to_explorer_json` — resolved
+  call targets, paired branch targets, lane-assigned edges) is not ported and
   lands with the broader **RT-WASM** emitter work. The Pyodide web server stays
   Python. *(S)*
-- **TOOL-FUZZ** *(new `tcl-fuzz` bin; depends on RT-VM)* — **landed**: a seeded
-  random Tcl generator (`generator.rs`, scoped to the VM's supported surface so a
-  divergence is a real miscompile, not an unimplemented command — pure, bounded
-  loops, balanced delimiters), a subprocess differential harness
-  (`harness.rs`: `tclvm` subject vs `tclsh` reference, each timeout-killable so a
-  hang is a finding not a wedge), a campaign runner with stats (`campaign.rs`),
-  and a findings registry (`findings.rs`: JSON + raw `.tcl`, dedup-by-seed,
-  categorised, replayable). CLI verbs `run` / `replay` / `summary`. A
-  500-iteration campaign over the current VM is clean (498/500 match, 2 skipped,
-  0 findings — the loop/array fixes hold under fuzzing). **Remaining:** broaden
-  the generator grammar (procs, namespaces, dict, `catch`/`try`, switch) as the
-  VM command surface fills in, and add the WASM/Zig backend as a third
-  differential arm once **RT-WASM** lands. *(M)*
-- **TOOL-DEBUGGER** *(new `tcl-debugger`; depends on RT-VM)* — **working**: a
-  record-and-replay step debugger over `tcl-vm`. The RT-VM piece **landed** —
-  `tcl-vm` now has a debug-hook seam (`Vm::set_debug_hook`): it fires once per
-  source command (keyed on `(line, span-start)`, since `startCommand` is emitted
-  only conditionally) with a full `DebugSnapshot` (line, command text, call
-  stack, current-frame variables) and honours the returned `DebugAction`. The
-  seam is inert (an `Option` check) when no hook is installed — differential
-  parity gates stay green. `tcl-debugger`'s `VmBackend` installs a recording
-  hook, runs the script once to capture the trace, then serves
-  breakpoints / step-in/over/out / continue / stack / variable-inspection by
-  navigating the trace with the `DebugController`. Two front-ends drive it: a
-  `tcl-debug` interactive CLI
-  (`break`/`step`/`next`/`finish`/`continue`/`print`/`stack`/`vars`) and a
-  **DAP server** (`tcl-debug --dap`) speaking the Debug Adapter Protocol over
-  `Content-Length`-framed stdio — `initialize`/`launch`/`setBreakpoints`/
-  `threads`/`stackTrace`/`scopes`/`variables`/`continue`/`next`/`stepIn`/
-  `stepOut`/`evaluate`/`disconnect` plus the `initialized`/`stopped`/
-  `terminated` events — so editors integrate directly. Known replay-model
-  characteristics (documented, not unfinished): script output is produced once
-  up front, variable inspection is the current frame's captured scope, and
-  `evaluate` resolves captured variables. *(L)*
-- **TOOL-IRULE-TEST** *(new `tcl-irule-test`; depends on RT-VM + `tcl-registry`)* —
-  **working**: the crate runs the TMM-sim orchestrator live on `tcl-vm`.
-  `topology` ports `TopologyFromSCF` — parse a bigip.conf via `tcl-bigip` and
-  emit the `::orch::` setup (profiles via name-inference, VIP, pools + members,
-  data-groups, attached iRules), parity-checked against the Python generator.
-  `session` defines the `SessionPlan` / orchestrator-bootstrap assembly.
-  `live::LiveSession` is the in-process driver: it sources the orchestrator
-  framework (the ~500 KB of Tcl under `tooling/irule_test/tcl/` — orchestrator +
-  TMM shim + command mocks) on a bytecode VM, loads iRules, fires events
-  (`run_http_request`), and reads back the pool/node decisions, captured logs,
-  and assertions — no `tclsh` subprocess. `embedded::EmbeddedLib` bundles the
-  framework into the binary so a consumer (e.g. `f5 explain-flow --simulate`)
-  needs no on-disk Tcl checkout. Getting the orchestrator running surfaced and
-  fixed six VM/compiler bugs (proc-body namespace-cache collision, `format`
-  const-fold of variable args, missing `unknown`/`exit`/`::tcl::clock::*`, ARE
-  word-edge regex escapes) plus the dict opcodes and multi-level `dict set`.
-  Note `tcl-irules` is the BIG-IP reference-extractor, **not** this. *(XL)*
-- **TOOL-CLI** *(owns `tcl-cli`; depends on RT-WASM, RT-VM, TOOL-TCLPKG)* —
-  **done**: all 26 top-level verbs are ported and dispatched to native engine
-  handlers. `dis` (bytecode disassembly via `format_module_asm`) and `compwasm`
-  (eval-fallback WASM binary/WAT via the greenfield emitter) landed earlier; the
-  `pkg`/`venv`/`docker` verbs are wired through to the `tcl-pkg` handlers that
-  landed under **TOOL-TCLPKG**. The dispatch `match` is now exhaustive (the
-  not-yet-implemented fallthrough is gone). Note any deeper WASM-emitter
-  precision residual is **RT-WASM**'s, not the CLI verb's. *(S glue)*
+- **TOOL-FUZZ** 🟢 *(depends on RT-VM)* — broaden the seeded generator grammar
+  (procs, namespaces, dict, `catch`/`try`, switch) as the VM command surface
+  fills in, and add the WASM/Zig backend as a third differential arm once
+  **RT-WASM** lands. *(M)*
+- **TOOL-IRULE-TEST** 🟢 *(depends on RT-VM + `tcl-registry`)* — the orchestrator
+  runs live on `tcl-vm`; broaden coverage as the VM surface grows. Note
+  `tcl-irules` is the BIG-IP reference-extractor, **not** this. *(XL)*
+
+**TOOL-TCLPKG**, **TOOL-REFACTOR**, **TOOL-F5**, **TOOL-DEBUGGER**, and
+**TOOL-CLI** are ✅ complete (their landing logs are in the
+[history archive](rust-rewrite-history.md)).
 
 ### Stage 5 — PyO3 interfaces & Python retirement (API-PYO3 — last)
 

--- a/docs/rust-rewrite.md
+++ b/docs/rust-rewrite.md
@@ -762,6 +762,29 @@ Python behaviour it mirrors. Per-task workflow: rebase the touched files off
 plus the `test_fp_*` ground-truth battery), and keep `make prep-pr` green. The
 full historical drift log is in the [history archive](rust-rewrite-history.md).
 
+**Outstanding `main` deltas not yet synced (as of 2026-06-22).** The `rust`
+branch is 10 commits behind `main`. Most are already delta-ported in place (the
+`#662` catch/return flow fix is in **FE-DIAG**; `#656`/`#661` S110 byte-array
+corruption is in **FE-TYPESHIM**), or are rust-branch-irrelevant (release notes,
+CI/security, the `#664` registry-dump demotion). One is a **real, unported
+language-surface delta the whole stack must absorb**:
+
+- **Tcl 9.1 dialect (`#673`, `main` commit `5d2ae37a`).** `main` added a
+  `tcl9.1` entry to `KNOWN_DIALECTS` (`compiler/registry/dialects.py`) plus three
+  new 9.1-only command specs — `timer` (`compiler/.../timer.py`), `unicode`
+  (`unicode_.py`), and the `subst -backslashes/-commands/-variables` options
+  (`subst_.py`), all gated on the `tcl9.1` dialect. **None of this exists on the
+  `rust` branch yet** — neither the Python tree (no `timer.py`/`unicode_.py`, no
+  `tcl9.1` in `dialects.py`) nor any Rust crate. This is a cross-cutting sync:
+  the registry needs the new dialect flag + command specs, `LexerConfig`/dialect
+  gating must learn `tcl9.1`, and the analyser/codegen must treat the new
+  commands and `subst` options as dialect-gated. Until it lands, the rewrite
+  silently lags `main`'s dialect surface. Note this also bears on principle §0
+  ("C Tcl 9.0.3 is the reference standard"): 9.0.3 stays the pinned reference (no
+  9.1 source tree is fetched under `tmp/`), so 9.1 support is a *dialect-flag*
+  addition, not a reference-standard bump — but a future task may need to decide
+  whether to advance the differential oracle once a 9.1 `tclsh` is available.
+
 ## Testing strategy
 
 The 448 pytest files / ~14 K test functions sort into four buckets; port each
@@ -789,11 +812,13 @@ This is the live plan. Everything below is **not yet done**; landed work lives
 in the [history archive](rust-rewrite-history.md), and the deep per-item
 evidence behind each front-end gap is in
 [`design/rust/compiler-pipeline-parity.md`](design/rust/compiler-pipeline-parity.md).
-The plan reflects current source as of 2026-06-20 (`rust` branch). The
-**FE-DATAFLOW**, **FE-TYPESHIM**, **FE-VARESCAPE**, **FE-DIAG** front-end tracks
-and **SRV-LSP** have landed since the last audit; their detail moved
-to the [history archive](rust-rewrite-history.md) and they survive here only as
-table rows (✅ / 🟢).
+The plan reflects current source as of 2026-06-22 (`rust` branch, HEAD
+`8d887c2f`), re-verified that day against the crate source and cross-checked
+against the Python oracle on `main`. The **FE-DATAFLOW**, **FE-TYPESHIM**,
+**FE-VARESCAPE**, **FE-DIAG** front-end tracks and **SRV-LSP** have landed since
+the last audit; their detail moved to the
+[history archive](rust-rewrite-history.md) and they survive here only as table
+rows (✅ / 🟢).
 
 ### Vocabulary
 
@@ -1243,7 +1268,9 @@ already started, brings **every** Python tool across to Rust.
   `tcl-vm` (via `tcl-irule-test::LiveSession`): the selected pool/node, the lb
   decision log, captured iRule logs and `response_committed` flow into the
   `simulated_*` text/JSON fields, port of `tooling/f5/irule_simulation.py`. The
-  rest (27/27 verbs, 262 parity tests) is done — the template for the other tool
+  rest (28 dispatched verbs — the 27 shipped verbs plus the temporary
+  rust-branch-only `registry-dump`, demoted from the shipped set on `main` by
+  `#664` — and 262 parity tests) is done — the template for the other tool
   ports. *(XS)*
 - **TOOL-EXPLORER** *(owns `tcl-explorer`, `tcl-explorer-wasm`; depends on
   RT-WASM)* — **done (for the views)**: the `ssa`-view boolean-render parity bug
@@ -1323,9 +1350,16 @@ already started, brings **every** Python tool across to Rust.
 Owns `tcl-lsp-py`, the `scripts`→`xtask` migration, and `tests`. **This is the
 final track** — every consumer above must port first.
 - **open** the designed public PyO3 surface — re-derive it as a semver-stable
-  API for downstream embedders, not a transcription of in-tree calls; the
-  bindings today expose only folding / document symbols while the native server
-  has ~43 providers.
+  API for downstream embedders, not a transcription of in-tree calls. What
+  `tcl-lsp-py` exports **today** is the legacy soft-dependency shim set the
+  in-tree Python still imports (~39 `#[pyfunction]`s across `tokens` /
+  `expr_lexer` / `compiler_checks` / `interprocedural` / `gvn` /
+  `compilation_unit` / `signature_scan` / `optimiser` / `analyser` / `registry`
+  / `bigip`), plus exactly **two** LSP *feature* bindings — folding and document
+  symbols — against the native server's ~43 feature providers. Per the boundary
+  rule those shims are porting TODOs to retire, not the public API; the designed
+  surface (the `parse_tcl` / `compile_tcl` / `analyse_tcl` / … facades + typed
+  error hierarchy above) is still unbuilt.
 - **open** TEST-MIGRATE — port each remaining pytest file to per-crate Rust
   tests (delete the `test_*.py` in the same change); the `test_fp_*` battery is
   the analyser acceptance gate.


### PR DESCRIPTION
## Summary

Update `rust-rewrite.md` and `rust-rewrite-history.md` to reflect the current state of the Rust rewrite as of 2026-06-22, including:

- **Outstanding `main` deltas**: Document the Tcl 9.1 dialect support (`#673`) that exists on `main` but not yet on the `rust` branch — a cross-cutting sync affecting the registry, `LexerConfig`, analyser, and codegen.
- **Status updates**: Bump several tracks from 🔴/🟡 to 🟢 or ✅:
  - **FE-OPT** and **FE-CODEGEN**: now 🟢 (partial)
  - **RT-WASM**: now 🟡 (partial, eval-fallback emitter landed)
  - **RT-VM**: now 🟡 (partial, parity push + follow-on fixes landed)
  - **API-PYO3**: now 🔴 (clarified scope)
  - **SRV-ROPE**: now 🔴 (clarified scope)
- **Consolidate landed work**: Move detailed landing logs for **FE-DIAG-F5**, **TOOL-REFACTOR**, **TOOL-F5**, **TOOL-EXPLORER**, **TOOL-FUZZ**, **TOOL-DEBUGGER**, **TOOL-IRULE-TEST**, and **TOOL-CLI** to the history archive, keeping only summary rows in the main plan.
- **RT-VM follow-on fixes**: Document the 2026-06-21/22 fixes (frozen-loop token loss, composite array-index substitution, six orchestrator bugs, dict opcodes, `tclvm` CLI/REPL binary) in the history archive.
- **Clarify PyO3 scope**: Distinguish between the legacy soft-dependency shim set (~39 functions) and the designed public API surface (still unbuilt).

The changes reflect verification against the crate source and cross-checks against the Python oracle on `main`.

## Validation

- No code changes; documentation-only update to reflect current project status.
- Verified against `rust` branch HEAD `8d887c2f` and `main` source.

https://claude.ai/code/session_019q8eUZqFubdRy1GvqfPLEd