### PR TITLE
tcl pkg: deprivileged sandbox, operator hooks, and locked-down policy

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,6 +2738,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_spanned"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6662b5879511e06e8999a8a235d848113e942c9124f211511b16466ee2995f26"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3031,6 +3040,7 @@ dependencies = [
  "tcl-lsp-core",
  "tcl-pkg",
  "tcl-registry",
+ "tcl-sandbox",
 ]
 
 [[package]]
@@ -3225,7 +3235,9 @@ dependencies = [
  "serde_json",
  "sha2",
  "tar",
+ "tcl-sandbox",
  "tcl-syntax",
+ "toml",
  "ureq",
  "zip",
 ]
@@ -3255,6 +3267,14 @@ name = "tcl-runtime-api"
 version = "0.1.0"
 dependencies = [
  "tcl-core-types",
+]
+
+[[package]]
+name = "tcl-sandbox"
+version = "0.1.0"
+dependencies = [
+ "serde",
+ "wait-timeout",
 ]
 
 [[package]]
@@ -3528,6 +3548,45 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81f3d15e84cbcd896376e6730314d59fb5a87f31e4b038454184435cd57defee"
+dependencies = [
+ "indexmap",
+ "serde_core",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_parser",
+ "toml_writer",
+ "winnow",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow",
+]
+
+[[package]]
+name = "toml_writer"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "756daf9b1013ebe47a8776667b466417e2d4c5679d441c26230efd9ef78692db"
+
+[[package]]
 name = "tower"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3768,6 +3827,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d9b2acfb050df409c972a37d3b8e08cdea3bddb0c09db9d53137e504cfabed0"
 dependencies = [
  "utf8parse",
+]
+
+[[package]]
+name = "wait-timeout"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09ac3b126d3914f9849036f826e054cbabdc8519970b8998ddaf3b5bd3c65f11"
+dependencies = [
+ "libc",
 ]
 
 [[package]]
@@ -4373,6 +4441,12 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
 
 [[package]]
 name = "wit-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,6 +67,7 @@ members = [
     "rust/tcl-cli-support",
     "rust/tcl-cli",
     "rust/tcl-pkg",
+    "rust/tcl-sandbox",
     "rust/f5-cli",
     "rust/f5-xc",
     "rust/tcl-fuzz",

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -71,6 +71,9 @@ rules for the KCS/documentation split live in
 
 - [tclpkg-architecture.md](tclpkg-architecture.md) — architecture overview,
   contracts, file-path anchors, test anchors.
+- [tclpkg-security.md](tclpkg-security.md) — sandboxing (the `tcl-sandbox`
+  crate), operator hooks, and the layered, admin-lockable policy for the Rust
+  package manager, with the supply-chain threat model that drives it.
 - [contracts/tclpkg-manifest.md](contracts/tclpkg-manifest.md) — manifest
   directives, safe-mode whitelist, validation rules.
 - [contracts/tclpkg-lockfile.md](contracts/tclpkg-lockfile.md) — canonical

--- a/docs/design/tclpkg-security.md
+++ b/docs/design/tclpkg-security.md
@@ -1,0 +1,240 @@
+# `tcl pkg` security architecture: sandboxing, operator hooks, locked-down policy
+
+Companion to [`tclpkg-architecture.md`](tclpkg-architecture.md). This document
+describes the security model added to the **Rust** package manager
+(`rust/tcl-pkg`, `rust/tcl-cli`, `rust/tcl-sandbox`). The Python implementation
+(`tooling/tclpkg/`) is out of scope.
+
+## Goals
+
+1. **Everything `tcl pkg` runs is deprivileged.** `git`, `tclsh`, operator
+   hooks and — above all — package-provided build scripts run through one
+   sandbox that strips ambient authority (credentials in the environment, the
+   user's home directory, unrestricted network) instead of inheriting it.
+2. **Operators, not developers, set security policy** — in a file developers
+   cannot edit, with the ability to **lock** individual settings so lower
+   configuration layers cannot loosen them.
+3. **Packages are data by default.** No package-provided code ever runs as a
+   side effect of resolving or installing. A build phase exists only as an
+   explicit, operator-gated, sandboxed opt-in.
+
+## Threat model
+
+The design is grounded in real supply-chain attacks. The dominant vector across
+every ecosystem is **arbitrary code execution at build/install time** with full
+user privilege and ambient secrets/network:
+
+| Ecosystem | Representative incidents | Execution vector |
+|---|---|---|
+| npm | event-stream (2018), ua-parser-js (2021), coa/rc (2021), node-ipc (2022), chalk/debug (Sept 2025), Shai-Hulud worm (2025) | `preinstall`/`postinstall` lifecycle scripts run with full user privilege during `npm install` |
+| PyPI | `colourama`/`jeIlyfish` typosquats, W4SP stealer, `ultralytics` CI cache poisoning (2024) | `setup.py` executes arbitrary code when installing an sdist |
+| **cargo** | `rustdecimal` (2022), `faster_log`/`chrono_anchor` (2025-26) | **`build.rs` and proc-macros run arbitrary code at build time** — the closest precedent for us |
+| AUR | Atomic Arch (2026) | `PKGBUILD` `.install` scripts run as root |
+| xz-utils | CVE-2024-3094 (2024) | multi-year maintainer social engineering; payload hidden in a release tarball and injected by an `m4` macro **at build time**, bypassing source review |
+
+Secondary vectors: resolve-time (dependency confusion, typosquatting),
+fetch-time (cache poisoning), and publish/maintainer-account compromise. The
+TanStack compromise (2026) shipped malware with **valid SLSA provenance** —
+proof that provenance attests *who built it*, not *that it is safe*.
+
+### Defence mapping
+
+No single control suffices; the design layers them. Each row is a control and
+where it lives in the implementation.
+
+| Control | Mitigates | Where |
+|---|---|---|
+| Packages are pure data; manifest is parse-only | install/postinstall RCE | `manifest.rs` (whitelisted directives, no interpreter) |
+| Deprivileged build sandbox (no secrets, no net, confined FS) | `build.rs`/`setup.py`-style build RCE, xz-style build injection | `tcl-sandbox`, `tcl pkg build` |
+| Environment scrubbing | credential theft from env (event-stream, Shai-Hulud) | `tcl-sandbox` baseline |
+| Operator hooks (scan/deny at lifecycle stages) | malware detection, org policy, cooldown, provenance | `hooks.rs` |
+| Admin-locked policy (registry allow/deny, require-https, required signature) | dependency confusion, untrusted registries | `policy.rs` |
+| Integrity hashes + lockfile pinning | tarball swap, cache poisoning | `cas.rs`, `lockfile.rs`, `verification.require-integrity` |
+| Cooldown / min-release-age | worm replication window, fresh typosquats | `cooldown` policy (surfaced to hooks) |
+| Network egress denial during build | build-time exfiltration | sandbox `deny-network` / per-profile network grant |
+
+Provenance/signature verification is supported only as an optional hook, never
+as the sole gate, because of the TanStack lesson. A Go-style transparency log is
+registry-side infrastructure and out of scope for the client.
+
+## Architecture
+
+```
+                       ┌──────────────────────────────┐
+   tclpkg.tcl  ──────► │ manifest.rs (parse-only,      │
+   (pure data)         │ whitelisted directives)       │
+                       └──────────────────────────────┘
+   /etc/…/pkg-policy.toml ┐
+   ~/.config/…/pkg.toml   ├─► policy.rs ─► PolicyConfig ─┐
+   ./tclpkg.toml          ┘   (layered + locked)         │
+                                                         ▼
+   git / tclsh / hooks / build script ──► exec.rs ──► tcl-sandbox::run
+                                          (chokepoint    (capability ∩ policy,
+                                           + audit log)   baseline + OS tier)
+```
+
+### The sandbox crate (`rust/tcl-sandbox`)
+
+A standalone, `unsafe`-free crate. A [`Profile`] describes what a command
+*requests* (program, args, cwd, env passthrough, network, fs read/write,
+timeout); a [`SandboxPolicy`] is the operator floor. `run()` computes the
+effective grant (`requested`, clamped and widened by the floor) and executes the
+child under the strongest available **confinement tier**:
+
+- **Baseline (every platform, always applied):** `env_clear()` + an explicit
+  allow-list with a sensitive-name denylist (`*_TOKEN`, `AWS_*`, `SSH_*`,
+  `GITHUB_*`, `NETRC`, …), working-directory pinning, output capture, and a
+  wall-clock timeout that kills runaways.
+- **OS-native (per platform, layered via the [`Confinement`] trait):** Landlock
+  + seccomp on Linux, Seatbelt on macOS, `pledge`/`unveil` on OpenBSD, Capsicum
+  on FreeBSD, restricted tokens + Job Objects on Windows. `detect_confinement()`
+  returns the strongest tier the host can provide; the achieved
+  [`IsolationLevel`] is recorded and reported.
+
+If a policy marks a floor mandatory (e.g. `require-network-deny`) and the host
+cannot enforce it, `run()` **fails closed** rather than running weaker than
+promised. The crate writes no `unsafe`: OS tiers are driven through wrapper
+crates (`landlock`, `seccompiler`, `rlimit`, `win32job`, …) so the workspace
+`unsafe_code = "forbid"` lint holds.
+
+> Implementation status: the baseline tier and the capability/policy-floor model
+> are implemented. The OS-native tiers are defined behind the `Confinement`
+> trait and are the next increment; until a host provides one, execution runs at
+> `baseline` isolation and says so (e.g. `tcl pkg build` prints a warning, and
+> `fail-closed` policies refuse rather than under-confine).
+
+### Layered, lockable policy (`rust/tcl-pkg/src/policy.rs`)
+
+TOML, merged lowest-precedence first:
+
+1. **System** — `/etc/tcl-lsp/pkg-policy.toml` (POSIX) /
+   `%PROGRAMDATA%\tcl-lsp\pkg-policy.toml` (Windows). Honoured only when the
+   file is owned by root/Administrators and not world-writable, so a developer
+   cannot weaken it by editing a file they own.
+2. **User** — `~/.config/tcl-lsp/pkg.toml`.
+3. **Project** — `tclpkg.toml` beside the manifest.
+
+The system layer can **lock** keys:
+
+- `lock = ["sandbox.deny-network", "registry"]` — a dotted leaf is frozen at its
+  system value; a whole section name freezes the entire subtree (no sibling
+  additions).
+- `lock-all = true` — every leaf the system layer sets is frozen, while still
+  letting lower layers add keys the system did not set.
+
+Override attempts against a locked key are ignored and surfaced as warnings
+(`tcl pkg policy show` / `verify`).
+
+#### Schema
+
+```toml
+[sandbox]
+fail-closed = false            # abort when a mandatory floor can't be met
+require-network-deny = false   # network denial must be enforceable
+deny-network = false           # force network off for everything
+max-timeout-secs = 300         # clamp every command's timeout
+env-allow = ["PATH"]           # extra passthrough names
+env-deny  = []                 # names never passed through
+
+[registry]
+allow = ["https://reg.corp/"]  # if non-empty, only these source prefixes
+deny  = []
+require-https = true           # reject http:// sources
+
+[cooldown]
+min-release-age-days = 7       # surfaced to hooks for enforcement
+
+[verification]
+require-integrity = true       # install fails if any package lacks a hash
+require-provenance = false     # delegated to a verification hook
+
+[build]
+allow-build-scripts = false    # packages are data unless an operator opts in
+trusted = []                   # packages whose build script may run
+
+[[hooks]]
+name = "scan-fetched"
+stage = "post-fetch"
+command = ["/opt/secscan/tcl-scan", "${TCLPKG_PKG_DIR}"]
+network = false
+timeout-secs = 30
+
+lock = ["sandbox", "registry", "verification", "build", "hooks"]
+```
+
+### The execution chokepoint (`exec.rs`)
+
+Nothing in `tcl-pkg` spawns a process directly. `exec::execute()` builds the
+profile, applies the sandbox policy and appends a JSON audit record (label,
+program, requested/enforced network, achieved isolation, exit code, timeout) to
+`$XDG_STATE_HOME/tcl-lsp/pkg-audit.log` (`tcl pkg audit`). The wired call sites:
+
+- `fetchers::fetch_git` — git clone/rev-parse; the one trusted tool granted the
+  network, still with credentials scrubbed (only PATH/HOME/proxy/TLS pass).
+- `venv::tclsh_version_string` — the tclsh version probe (script on stdin).
+- `tcl pkg run` — the project's own entry point (full env, network allowed, but
+  audited, policy-clamped and wrapped in pre/post-run hooks).
+- `tcl pkg build` — the deprivileged build script (see below).
+
+### Operator hooks (`hooks.rs`)
+
+Hooks are defined **in policy** (so they live in the locked-down system layer)
+and fire at lifecycle stages: `pre/post-resolve`, `pre/post-fetch`,
+`pre/post-build`, `pre/post-install`, `pre/post-run`. Each hook runs through the
+sandbox with its declared, policy-clamped capabilities. Context (package name,
+version, source URL, integrity, on-disk path) is passed as scrubbed `TCLPKG_*`
+environment variables, with `${VAR}` expansion in the command and path entries.
+**A non-zero exit aborts the operation** — this is how an operator's scanner,
+denylist, cooldown check or provenance verifier blocks a package.
+
+### Build phase (`build` directive + `tcl pkg build`)
+
+The manifest gains a data-only `build` directive:
+
+```tcl
+build  build.tcl           ;# script path, relative to the manifest
+build  build.tcl -network  ;# optionally declares it needs the network
+```
+
+Declaring it never causes execution. `tcl pkg build` runs the script **only**
+when policy both enables build scripts (`[build] allow-build-scripts = true`) and
+trusts the package (`[build] trusted` / `tcl pkg trust <name>`) — mirroring npm
+v12 / pnpm / Bun / Deno's "scripts off by default". When it does run, it is the
+most confined profile: environment scrubbed of secrets, `HOME` pointed at a
+throwaway directory, network denied unless the manifest declared it (and policy
+allows it), confined to the project tree, with the achieved isolation level
+reported.
+
+## CLI surface
+
+| Command | Purpose |
+|---|---|
+| `tcl pkg policy show [--json]` | Print the merged policy, its layers, and which keys are admin-locked |
+| `tcl pkg policy verify [--json]` | Validate the policy files; non-zero on warnings (untrusted system file, schema errors, ignored overrides) |
+| `tcl pkg hooks [--json]` | List the operator hooks bound to each stage |
+| `tcl pkg audit [--lines N] [--json]` | Show recent sandboxed-execution audit records |
+| `tcl pkg trust <pkg> [--remove]` | Add/remove a package from the per-user build-trust list |
+| `tcl pkg build` | Run the manifest's declared build script, deprivileged |
+
+## Testing
+
+- `tcl-sandbox` unit tests cover env scrubbing (including the sensitive-name
+  denylist), the fail-closed path, the timeout kill, and capability merging,
+  without mutating the process environment (an injectable env lookup keeps the
+  crate `unsafe`-free under edition 2024).
+- `tcl-pkg` unit tests cover layered policy merging and all three lock modes
+  (locked leaf, locked section, `lock-all`), the registry allow/deny gate, and
+  hook stage parsing / `${VAR}` expansion.
+- End-to-end: an operator hook that exits non-zero aborts `tcl pkg install`; a
+  `build` script cannot see a `GITHUB_TOKEN` planted in the parent environment
+  and runs against a throwaway `HOME`.
+
+## Non-goals / future work
+
+- OS-native confinement tiers (Landlock/seccomp, Seatbelt, pledge/unveil,
+  Capsicum, Job Objects) — designed-for behind `Confinement`, not yet wired.
+- Per-dependency build scripts (this increment runs only the *project's* build
+  script; the resolver does not yet parse each dependency's manifest for a
+  declared build phase).
+- Child resource limits (memory/CPU rlimits) via a re-exec helper.
+- Registry-side transparency log (Go sumdb-style).

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -78,6 +78,10 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 
 ## How-Tos
 
+- [kcs-howto-lock-down-tcl-pkg.md](kcs-howto-lock-down-tcl-pkg.md) — deploy a
+  locked-down `tcl pkg` policy for an organisation: a sandbox floor developers
+  cannot loosen, registry allow-lists, operator scanning hooks, and gating
+  package build scripts.
 - [kcs-howto-build-multiplatform-vsix.md](kcs-howto-build-multiplatform-vsix.md)
   — build the universal VS Code `.vsix` that bundles a native server per
   platform, and add a new platform.

--- a/docs/kcs/kcs-howto-lock-down-tcl-pkg.md
+++ b/docs/kcs/kcs-howto-lock-down-tcl-pkg.md
@@ -1,0 +1,130 @@
+# KCS: How do I lock down `tcl pkg` for my organisation?
+
+> **Audience:** User
+> **Type:** How-To
+
+## Applies to
+
+tcl-lsp CLI (`tcl pkg`), the Rust package manager.
+
+## Question
+
+I administer developer machines and want `tcl pkg` to enforce a security floor
+that developers cannot weaken: confine anything it runs, restrict where packages
+come from, scan packages as they are fetched, and keep package build scripts from
+running unless I approve them. How do I deploy that?
+
+## Before you start
+
+- Administrative (root / Administrator) access to the machines you manage.
+- The package manager already separates *what runs* from *who allows it*: every
+  external command runs in a sandbox, and policy is merged from three layers —
+  **system** (operator), **user**, then **project**. Only the system layer can
+  *lock* settings. See [`tclpkg-security.md`](../design/tclpkg-security.md) for
+  the full design.
+
+## Answer
+
+### 1. Write the system policy
+
+Create the operator policy file. It must be owned by root/Administrators and not
+world-writable, or it is ignored (so a developer cannot replace it with their
+own).
+
+- POSIX: `/etc/tcl-lsp/pkg-policy.toml`
+- Windows: `%PROGRAMDATA%\tcl-lsp\pkg-policy.toml`
+
+```toml
+# Sandbox floor applied to everything tcl pkg runs.
+[sandbox]
+fail-closed = true            # refuse to run if the floor can't be enforced
+require-network-deny = true   # default-deny executions must really have no network
+max-timeout-secs = 300
+env-deny = ["GITHUB_TOKEN", "NPM_TOKEN"]   # belt-and-braces; secrets are stripped anyway
+
+# Only fetch packages from the corporate mirror, over TLS.
+[registry]
+require-https = true
+allow = ["https://packages.corp.example/"]
+
+# Don't use a version until it has been public for a week (catches worm
+# replication waves and fresh typosquats); surfaced to your cooldown hook.
+[cooldown]
+min-release-age-days = 7
+
+# Refuse to lock a package that has no integrity hash.
+[verification]
+require-integrity = true
+
+# Packages are data: build scripts stay off until you both flip this and
+# trust the specific package.
+[build]
+allow-build-scripts = false
+
+# Run a scanner over every fetched package; a non-zero exit aborts the install.
+[[hooks]]
+name = "scan-fetched"
+stage = "post-fetch"
+command = ["/opt/secscan/tcl-scan", "${TCLPKG_PKG_DIR}"]
+network = false
+timeout-secs = 60
+
+# Freeze all of the above so user/project config can't loosen it.
+lock = ["sandbox", "registry", "cooldown", "verification", "build", "hooks"]
+```
+
+### 2. Verify it is being honoured
+
+```console
+$ tcl pkg policy show
+Policy layers (low → high precedence):
+  system   /etc/tcl-lsp/pkg-policy.toml [loaded]
+  user     ~/.config/tcl-lsp/pkg.toml  [loaded]
+...
+Admin-locked keys:
+  build (section)
+  registry (section)
+  sandbox (section)
+  ...
+```
+
+If the system file shows `[—] (ignored: …)` it is not root-owned or is
+world-writable — fix the ownership/permissions. Use `tcl pkg policy verify` in
+your fleet tooling; it exits non-zero when anything is wrong (untrusted system
+file, schema error, or a lower layer trying to override a locked key).
+
+### 3. What developers now experience
+
+- Installs from anywhere other than the corporate mirror are rejected.
+- Every fetched package is scanned; a finding aborts the install.
+- A package that ships a build script does nothing on install. If a developer
+  needs it, *you* enable it: set `allow-build-scripts = true` and add the
+  package to `[build] trusted` (or have the developer run `tcl pkg trust <pkg>`
+  if you did not lock the `build` section). It then runs deprivileged — no
+  ambient secrets, a throwaway `HOME`, and no network unless the manifest
+  declared it and policy allows it.
+- A user `~/.config/tcl-lsp/pkg.toml` or project `tclpkg.toml` may still set
+  *unlocked* keys, but any attempt to override a locked one is ignored and
+  reported.
+
+### 4. Audit what ran
+
+Every sandboxed execution is logged:
+
+```console
+$ tcl pkg audit --lines 20
+{"ts":"…","label":"hook:post-fetch:scan-fetched","isolation":"baseline","success":true,…}
+{"ts":"…","label":"git-clone","network_enforced":true,"success":true,…}
+```
+
+## Notes
+
+- The sandbox always applies a portable baseline (environment scrubbed of
+  credentials, working-directory confinement, timeouts). Stronger OS-native
+  confinement (Landlock/seccomp, Seatbelt, `pledge`/`unveil`, Capsicum, Job
+  Objects) is layered on where available; where it is not, `fail-closed`
+  policies refuse rather than run under-confined, and commands report the
+  isolation level they achieved.
+- Hooks receive context as `TCLPKG_*` environment variables
+  (`TCLPKG_NAME`, `TCLPKG_VERSION`, `TCLPKG_SOURCE_URL`, `TCLPKG_INTEGRITY`,
+  `TCLPKG_PKG_DIR`); reference them in a hook `command` with `${TCLPKG_…}`.

--- a/rust/tcl-cli/Cargo.toml
+++ b/rust/tcl-cli/Cargo.toml
@@ -23,6 +23,7 @@ tcl-explorer = { path = "../tcl-explorer" }
 tcl-lexer = { path = "../tcl-lexer" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-pkg = { path = "../tcl-pkg" }
+tcl-sandbox = { path = "../tcl-sandbox" }
 serde = { version = "1", features = ["derive"] }
 serde_json = { version = "1", features = ["preserve_order"] }
 # Bundled SQLite (with FTS5) for the `help` verb's embedded KCS database.

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -570,6 +570,58 @@ pub enum PkgCommand {
         #[arg(long)]
         offline: bool,
     },
+    /// Inspect the effective sandbox / hooks / registry policy.
+    Policy {
+        #[command(subcommand)]
+        action: PolicyAction,
+    },
+    /// List the operator hooks bound to lifecycle stages.
+    Hooks {
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Show recent sandboxed-execution audit records.
+    Audit {
+        /// Number of trailing records to show.
+        #[arg(long, default_value_t = 20)]
+        lines: usize,
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Trust a package's build script so it may run (when build scripts are
+    /// enabled by policy). Writes to the per-user policy layer.
+    Trust {
+        /// Package name.
+        package: String,
+        /// Remove the package from the trusted list instead.
+        #[arg(long)]
+        remove: bool,
+    },
+    /// Run the manifest's declared build script in a deprivileged sandbox.
+    /// Requires `[build] allow-build-scripts` and the package to be trusted.
+    Build {
+        #[command(flatten)]
+        common: PkgCommon,
+    },
+}
+
+/// Sub-actions for `tcl pkg policy`.
+#[derive(Debug, Subcommand)]
+pub enum PolicyAction {
+    /// Print the merged, effective policy and which keys are admin-locked.
+    Show {
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
+    /// Validate policy files and report any problems (non-zero on warnings).
+    Verify {
+        /// Emit JSON output.
+        #[arg(long)]
+        json: bool,
+    },
 }
 
 #[derive(Debug, Subcommand)]

--- a/rust/tcl-cli/src/commands/pkg.rs
+++ b/rust/tcl-cli/src/commands/pkg.rs
@@ -11,7 +11,6 @@
 
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};
-use std::process::Command;
 
 use serde_json::{Map, Value, json};
 use tcl_pkg::cas::ContentAddressableStore;
@@ -22,7 +21,7 @@ use tcl_pkg::registry::RegistryClient;
 use tcl_pkg::resolver::{ExcludeSpec, PackageRef, ReplaceSpec, ResolveInput, resolve};
 use tcl_pkg::ui;
 
-use crate::cli::{PkgCommand, PkgCommon};
+use crate::cli::{PkgCommand, PkgCommon, PolicyAction};
 
 /// Dispatch a `tcl pkg` sub-action.
 pub fn run(action: &PkgCommand) -> anyhow::Result<u8> {
@@ -77,6 +76,11 @@ pub fn run(action: &PkgCommand) -> anyhow::Result<u8> {
             json,
             offline,
         } => run_search(query, *json, *offline),
+        PkgCommand::Policy { action } => run_policy(action),
+        PkgCommand::Hooks { json } => run_hooks(*json),
+        PkgCommand::Audit { lines, json } => run_audit(*lines, *json),
+        PkgCommand::Trust { package, remove } => run_trust(package, *remove),
+        PkgCommand::Build { common } => run_build(common),
     }
 }
 
@@ -186,6 +190,25 @@ fn run_install(common: &PkgCommon, no_dev: bool, frozen: bool) -> anyhow::Result
         }
     };
 
+    let project_dir = mpath
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    let loaded = tcl_pkg::policy::load(Some(&project_dir));
+    for w in &loaded.warnings {
+        eprintln!("{}", ui::warn(w, colour));
+    }
+    let install_ctx = tcl_pkg::hooks::HookContext::new(&project_dir)
+        .var("MANIFEST", mpath.to_string_lossy())
+        .var("PROJECT", project_dir.to_string_lossy());
+    if let Err(e) = tcl_pkg::hooks::run_stage(
+        tcl_pkg::hooks::Stage::PreInstall,
+        &loaded.config,
+        &install_ctx,
+    ) {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+
     let direct: Vec<PackageRef> = manifest
         .requires
         .iter()
@@ -272,6 +295,15 @@ fn run_install(common: &PkgCommon, no_dev: bool, frozen: bool) -> anyhow::Result
                 Some(&mut registry),
             );
             if let Some(source) = source {
+                // Registry allow/deny + require-https policy gate the source
+                // before any fetch happens.
+                if !source.url.is_empty() && !loaded.config.source_allowed(&source.url) {
+                    eprintln!(
+                        "error: {name} {version}: source '{}' rejected by registry policy",
+                        source.url
+                    );
+                    return Ok(1);
+                }
                 match installer::fetch_and_store(&source, &name, &version, &cas, 60) {
                     Ok(result) => {
                         if let Err(e) = installer::materialise(
@@ -289,6 +321,23 @@ fn run_install(common: &PkgCommon, no_dev: bool, frozen: bool) -> anyhow::Result
                         entry.size = result.size;
                         entry.provides = result.provides;
                         entry.license = result.license;
+
+                        // Operator post-fetch hook (scanner / provenance / deny):
+                        // a non-zero exit aborts the install.
+                        let fetch_ctx = tcl_pkg::hooks::HookContext::new(&project_dir)
+                            .var("NAME", name.clone())
+                            .var("VERSION", version.clone())
+                            .var("SOURCE_URL", entry.source.url.clone())
+                            .var("INTEGRITY", entry.integrity.clone())
+                            .var("PKG_DIR", lib_dir.join(&name).to_string_lossy());
+                        if let Err(e) = tcl_pkg::hooks::run_stage(
+                            tcl_pkg::hooks::Stage::PostFetch,
+                            &loaded.config,
+                            &fetch_ctx,
+                        ) {
+                            eprintln!("error: {e}");
+                            return Ok(1);
+                        }
                     }
                     Err(e) => {
                         entry.source = source;
@@ -298,6 +347,31 @@ fn run_install(common: &PkgCommon, no_dev: bool, frozen: bool) -> anyhow::Result
             }
         }
         lf.packages.push(entry);
+    }
+
+    // Enforce integrity / post-install policy before the lockfile is written.
+    if loaded.config.verification.require_integrity && !offline {
+        let missing: Vec<&str> = lf
+            .packages
+            .iter()
+            .filter(|p| p.integrity.is_empty())
+            .map(|p| p.name.as_str())
+            .collect();
+        if !missing.is_empty() {
+            eprintln!(
+                "error: policy requires integrity hashes but these have none: {}",
+                missing.join(", ")
+            );
+            return Ok(1);
+        }
+    }
+    if let Err(e) = tcl_pkg::hooks::run_stage(
+        tcl_pkg::hooks::Stage::PostInstall,
+        &loaded.config,
+        &install_ctx,
+    ) {
+        eprintln!("error: {e}");
+        return Ok(1);
     }
 
     let lockpath = mpath
@@ -900,8 +974,21 @@ fn run_run(extra: &[String], common: &PkgCommon) -> anyhow::Result<u8> {
         return Ok(1);
     };
 
-    let mut cmd = Command::new(&tclsh);
-    cmd.arg(&entry_path).args(extra);
+    // Operator hooks + audit + policy floor apply even to running the project's
+    // own entry point ("anything tcl pkg runs is sandboxed").
+    let loaded = tcl_pkg::policy::load(Some(parent));
+    let ctx = tcl_pkg::hooks::HookContext::new(parent)
+        .var("ENTRY", entry_path.to_string_lossy())
+        .var("MANIFEST", mpath.to_string_lossy());
+    if let Err(e) = tcl_pkg::hooks::run_stage(tcl_pkg::hooks::Stage::PreRun, &loaded.config, &ctx) {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+
+    let mut profile = tcl_sandbox::Profile::new("pkg-run", &tclsh, parent)
+        .user_code()
+        .arg(entry_path.to_string_lossy())
+        .args(extra.iter().cloned());
     let lib_dir = parent.join("lib");
     if lib_dir.is_dir() {
         let existing = std::env::var("TCLLIBPATH").unwrap_or_default();
@@ -910,15 +997,23 @@ fn run_run(extra: &[String], common: &PkgCommon) -> anyhow::Result<u8> {
         } else {
             format!("{} {existing}", lib_dir.display())
         };
-        cmd.env("TCLLIBPATH", value);
+        profile = profile.set_env("TCLLIBPATH", value);
     }
-    match cmd.status() {
-        Ok(s) => Ok(u8::try_from(s.code().unwrap_or(1)).unwrap_or(1)),
+
+    let code = match tcl_pkg::exec::execute(&profile, &loaded.config.sandbox_policy()) {
+        Ok(out) => u8::try_from(out.code.unwrap_or(1)).unwrap_or(1),
         Err(e) => {
             eprintln!("error: {e}");
-            Ok(1)
+            return Ok(1);
         }
+    };
+
+    if let Err(e) = tcl_pkg::hooks::run_stage(tcl_pkg::hooks::Stage::PostRun, &loaded.config, &ctx)
+    {
+        eprintln!("error: {e}");
+        return Ok(1);
     }
+    Ok(code)
 }
 
 fn run_freeze(common: &PkgCommon) -> anyhow::Result<u8> {
@@ -971,6 +1066,292 @@ fn run_search(query: &str, json: bool, offline: bool) -> anyhow::Result<u8> {
         }
     }
     Ok(0)
+}
+
+fn run_build(common: &PkgCommon) -> anyhow::Result<u8> {
+    let mpath = manifest_path(common);
+    let colour = ui::use_colour(Some(!common.json));
+    let manifest = match load_manifest(&mpath) {
+        Ok(m) => m,
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+    if manifest.build.script.is_empty() {
+        eprintln!("error: no 'build' directive in manifest");
+        return Ok(1);
+    }
+    let project_dir = mpath
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    let loaded = tcl_pkg::policy::load(Some(&project_dir));
+
+    // Packages are data by default: a build script runs only when the operator
+    // both enables build scripts and trusts this package.
+    if !loaded.config.build_script_allowed(&manifest.name) {
+        eprintln!(
+            "error: build script for '{}' is not permitted by policy",
+            manifest.name
+        );
+        eprintln!(
+            "  hint: set [build] allow-build-scripts = true and run 'tcl pkg trust {}'",
+            manifest.name
+        );
+        return Ok(1);
+    }
+
+    let script = project_dir.join(&manifest.build.script);
+    if !script.is_file() {
+        eprintln!("error: build script not found: {}", script.display());
+        return Ok(1);
+    }
+    let tclsh = if let Some(venv) = std::env::var_os("TCL_VENV") {
+        PathBuf::from(venv).join("bin").join("tclsh")
+    } else if let Some(p) = tcl_pkg::venv::find_tclsh() {
+        p
+    } else {
+        eprintln!("error: tclsh not found on PATH");
+        return Ok(1);
+    };
+
+    let ctx = tcl_pkg::hooks::HookContext::new(&project_dir)
+        .var("NAME", manifest.name.clone())
+        .var("BUILD_SCRIPT", script.to_string_lossy());
+    if let Err(e) = tcl_pkg::hooks::run_stage(tcl_pkg::hooks::Stage::PreBuild, &loaded.config, &ctx)
+    {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+
+    // Deprivileged: network denied unless declared (and still policy-clamped),
+    // environment scrubbed of secrets, confined to the project directory, output
+    // streamed. A throwaway HOME keeps the script away from the user's dotfiles.
+    let build_home = project_dir.join(".tclpkg-build-home");
+    let _ = std::fs::create_dir_all(&build_home);
+    let mut profile = tcl_sandbox::Profile::new("pkg-build", &tclsh, &project_dir)
+        .arg(script.to_string_lossy())
+        .network(manifest.build.network)
+        .capture(false)
+        .set_env("HOME", build_home.to_string_lossy())
+        .set_env("TCLPKG_BUILD", "1");
+    for name in ["PATH", "TCL_LIBRARY", "TCLLIBPATH", "TMPDIR"] {
+        profile = profile.pass_env(name);
+    }
+    profile.fs_write = vec![project_dir.clone()];
+    profile.fs_read = vec![project_dir.clone()];
+
+    println!(
+        "{}",
+        ui::dim(
+            &format!(
+                "running build script {} (deprivileged)",
+                manifest.build.script
+            ),
+            colour
+        )
+    );
+    let code = match tcl_pkg::exec::execute(&profile, &loaded.config.sandbox_policy()) {
+        Ok(out) => {
+            if out.isolation == tcl_sandbox::IsolationLevel::Baseline {
+                eprintln!(
+                    "{}",
+                    ui::warn(
+                        "build ran with baseline isolation only (no OS-native filesystem/network confinement on this host)",
+                        colour
+                    )
+                );
+            }
+            u8::try_from(out.code.unwrap_or(1)).unwrap_or(1)
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            return Ok(1);
+        }
+    };
+
+    if let Err(e) =
+        tcl_pkg::hooks::run_stage(tcl_pkg::hooks::Stage::PostBuild, &loaded.config, &ctx)
+    {
+        eprintln!("error: {e}");
+        return Ok(1);
+    }
+    if code == 0 {
+        println!("{}", ui::ok("build complete", colour));
+    }
+    Ok(code)
+}
+
+fn run_policy(action: &PolicyAction) -> anyhow::Result<u8> {
+    let project = find_project_root();
+    let loaded = tcl_pkg::policy::load(project.as_deref());
+    match action {
+        PolicyAction::Show { json } => policy_show(&loaded, *json),
+        PolicyAction::Verify { json } => policy_verify(&loaded, *json),
+    }
+}
+
+fn policy_show(loaded: &tcl_pkg::policy::LoadedPolicy, json: bool) -> anyhow::Result<u8> {
+    let cfg = &loaded.config;
+    if json {
+        let sources: Vec<Value> = loaded
+            .sources
+            .iter()
+            .map(|s| {
+                json!({
+                    "layer": s.layer,
+                    "path": s.path.to_string_lossy(),
+                    "loaded": s.loaded,
+                    "note": s.note,
+                })
+            })
+            .collect();
+        let config = serde_json::to_value(cfg).unwrap_or(Value::Null);
+        println!(
+            "{}",
+            ui::json_output(&json!({
+                "sources": sources,
+                "locked": loaded.locked,
+                "warnings": loaded.warnings,
+                "config": config,
+            }))
+        );
+        return Ok(0);
+    }
+    let colour = ui::use_colour(None);
+    println!("Policy layers (low → high precedence):");
+    for s in &loaded.sources {
+        let status = if s.loaded { "loaded" } else { "—" };
+        let note = s
+            .note
+            .as_deref()
+            .map_or(String::new(), |n| format!("  ({n})"));
+        println!("  {:<8} {} [{status}]{note}", s.layer, s.path.display());
+    }
+    println!("\nSandbox floor:");
+    println!("  fail-closed         {}", cfg.sandbox.fail_closed);
+    println!("  deny-network        {}", cfg.sandbox.deny_network);
+    println!(
+        "  require-network-deny {}",
+        cfg.sandbox.require_network_deny
+    );
+    if let Some(t) = cfg.sandbox.max_timeout_secs {
+        println!("  max-timeout-secs    {t}");
+    }
+    println!("\nRegistry:");
+    println!("  require-https {}", cfg.registry.require_https);
+    println!("  allow         {:?}", cfg.registry.allow);
+    println!("  deny          {:?}", cfg.registry.deny);
+    println!("\nVerification:");
+    println!(
+        "  require-integrity  {}",
+        cfg.verification.require_integrity
+    );
+    println!(
+        "  require-provenance {}",
+        cfg.verification.require_provenance
+    );
+    println!("  cooldown-days      {}", cfg.cooldown.min_release_age_days);
+    println!("\nBuild scripts:");
+    println!("  allow-build-scripts {}", cfg.build.allow_build_scripts);
+    println!("  trusted             {:?}", cfg.build.trusted);
+    println!("\nHooks: {} configured", cfg.hooks.len());
+    if loaded.locked.is_empty() {
+        println!("\nAdmin-locked keys: none");
+    } else {
+        println!("\nAdmin-locked keys:");
+        for k in &loaded.locked {
+            println!("  {k}");
+        }
+    }
+    if !loaded.warnings.is_empty() {
+        println!();
+        for w in &loaded.warnings {
+            println!("{}", ui::warn(w, colour));
+        }
+    }
+    Ok(0)
+}
+
+fn policy_verify(loaded: &tcl_pkg::policy::LoadedPolicy, json: bool) -> anyhow::Result<u8> {
+    let ok = loaded.warnings.is_empty();
+    if json {
+        println!(
+            "{}",
+            ui::json_output(&json!({"ok": ok, "warnings": loaded.warnings}))
+        );
+    } else {
+        let colour = ui::use_colour(None);
+        if ok {
+            println!("{}", ui::ok("policy OK", colour));
+        } else {
+            for w in &loaded.warnings {
+                println!("{}", ui::warn(w, colour));
+            }
+        }
+    }
+    Ok(u8::from(!ok))
+}
+
+fn run_hooks(json: bool) -> anyhow::Result<u8> {
+    let project = find_project_root();
+    let loaded = tcl_pkg::policy::load(project.as_deref());
+    let rows = tcl_pkg::hooks::describe(&loaded.config);
+    if json {
+        let arr: Vec<Value> = rows
+            .iter()
+            .map(|(stage, name, cmd)| json!({"stage": stage, "name": name, "command": cmd}))
+            .collect();
+        println!("{}", ui::json_output(&json!({"hooks": arr})));
+    } else if rows.is_empty() {
+        println!("No operator hooks configured.");
+    } else {
+        println!("{:<14} {:<16} COMMAND", "STAGE", "NAME");
+        for (stage, name, cmd) in &rows {
+            println!("{stage:<14} {name:<16} {cmd}");
+        }
+    }
+    Ok(0)
+}
+
+fn run_audit(lines: usize, json: bool) -> anyhow::Result<u8> {
+    let path = tcl_pkg::exec::audit_log_path();
+    let text = std::fs::read_to_string(&path).unwrap_or_default();
+    let all: Vec<&str> = text.lines().filter(|l| !l.trim().is_empty()).collect();
+    let start = all.len().saturating_sub(lines);
+    let tail = &all[start..];
+    if json {
+        let arr: Vec<Value> = tail
+            .iter()
+            .filter_map(|l| serde_json::from_str::<Value>(l).ok())
+            .collect();
+        println!("{}", ui::json_output(&Value::Array(arr)));
+    } else if tail.is_empty() {
+        println!("No audit records ({}).", path.display());
+    } else {
+        for l in tail {
+            println!("{l}");
+        }
+    }
+    Ok(0)
+}
+
+fn run_trust(package: &str, remove: bool) -> anyhow::Result<u8> {
+    let colour = ui::use_colour(None);
+    match tcl_pkg::policy::set_trusted(package, !remove) {
+        Ok(path) => {
+            let verb = if remove { "untrusted" } else { "trusted" };
+            println!(
+                "{}",
+                ui::ok(&format!("{verb} {package} (in {})", path.display()), colour)
+            );
+            Ok(0)
+        }
+        Err(e) => {
+            eprintln!("error: {e}");
+            Ok(1)
+        }
+    }
 }
 
 /// Build the canonical JSON object for a locked package (`LockedPackage.to_dict`

--- a/rust/tcl-cli/src/tui.rs
+++ b/rust/tcl-cli/src/tui.rs
@@ -12,15 +12,15 @@
 use std::collections::HashSet;
 use std::io::Write as _;
 
+use ratatui::Terminal;
+use ratatui::backend::TerminaBackend;
 use ratatui::layout::{Constraint, Direction, Layout};
 use ratatui::style::{Modifier, Style};
-use ratatui::text::{Line, Span};
-use ratatui::backend::TerminaBackend;
 use ratatui::termina::escape::csi::{self, Csi};
 use ratatui::termina::event::{KeyCode, KeyEventKind};
 use ratatui::termina::{Event, EventReader, PlatformTerminal, Terminal as _};
+use ratatui::text::{Line, Span};
 use ratatui::widgets::{Block, Borders, List, ListItem, ListState, Paragraph};
-use ratatui::Terminal;
 use serde_json::Value;
 
 /// The concrete terminal type: a Ratatui terminal over the Termina backend.

--- a/rust/tcl-pkg/Cargo.toml
+++ b/rust/tcl-pkg/Cargo.toml
@@ -10,9 +10,11 @@ authors.workspace = true
 
 [dependencies]
 tcl-syntax = { path = "../tcl-syntax" }
+tcl-sandbox = { path = "../tcl-sandbox" }
 regex = "1"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+toml = "1"
 sha2 = "0.10"
 base64 = "0.22"
 flate2 = "1"

--- a/rust/tcl-pkg/src/errors.rs
+++ b/rust/tcl-pkg/src/errors.rs
@@ -17,6 +17,9 @@ pub enum Category {
     Registry,
     Fetch,
     Venv,
+    Policy,
+    Sandbox,
+    Hook,
 }
 
 impl Category {
@@ -30,6 +33,9 @@ impl Category {
             Category::Registry => "registry",
             Category::Fetch => "fetch",
             Category::Venv => "venv",
+            Category::Policy => "policy",
+            Category::Sandbox => "sandbox",
+            Category::Hook => "hook",
         }
     }
 }

--- a/rust/tcl-pkg/src/exec.rs
+++ b/rust/tcl-pkg/src/exec.rs
@@ -1,0 +1,82 @@
+//! The single chokepoint every external execution flows through.
+//!
+//! Nothing in `tcl-pkg` spawns a process directly: `git`, `tclsh`, operator
+//! hooks and package build scripts all go through [`execute`], which applies the
+//! sandbox policy and appends an audit record. Routing every exec through one
+//! place is what makes "everything the package manager runs is sandboxed" a
+//! property we can actually uphold and review.
+
+use std::io::Write;
+
+use tcl_sandbox::{Outcome, Profile, SandboxPolicy};
+
+use crate::errors::{Category, TclPkgError};
+
+/// Run `profile` under `policy`, recording the result to the audit log.
+///
+/// # Errors
+///
+/// Returns a [`TclPkgError`] (category [`Category::Sandbox`]) when the sandbox
+/// refuses to run the command (fail-closed) or the child cannot be spawned.
+pub fn execute(profile: &Profile, policy: &SandboxPolicy) -> Result<Outcome, TclPkgError> {
+    let result = tcl_sandbox::run(profile, policy);
+    match &result {
+        Ok(outcome) => audit(profile, Some(outcome), None),
+        Err(e) => audit(profile, None, Some(&e.to_string())),
+    }
+    result.map_err(|e| {
+        TclPkgError::new(e.to_string())
+            .with_category(Category::Sandbox)
+            .with_hint("adjust the sandbox policy or grant the required capability")
+    })
+}
+
+/// Append a one-line JSON audit record. Best-effort: failures to write the log
+/// never block package operations.
+fn audit(profile: &Profile, outcome: Option<&Outcome>, error: Option<&str>) {
+    let mut obj = serde_json::Map::new();
+    obj.insert("ts".into(), chrono::Utc::now().to_rfc3339().into());
+    obj.insert("label".into(), profile.label.clone().into());
+    obj.insert(
+        "program".into(),
+        profile.program.to_string_lossy().into_owned().into(),
+    );
+    obj.insert(
+        "network_requested".into(),
+        serde_json::Value::Bool(profile.allow_network),
+    );
+    if let Some(o) = outcome {
+        obj.insert("isolation".into(), o.isolation.as_str().into());
+        obj.insert(
+            "network_enforced".into(),
+            serde_json::Value::Bool(o.network_enforced),
+        );
+        obj.insert("success".into(), serde_json::Value::Bool(o.success));
+        obj.insert("timed_out".into(), serde_json::Value::Bool(o.timed_out));
+        if let Some(code) = o.code {
+            obj.insert("code".into(), code.into());
+        }
+    }
+    if let Some(e) = error {
+        obj.insert("error".into(), e.into());
+    }
+    let line = serde_json::Value::Object(obj).to_string();
+
+    let dir = crate::state_dir();
+    if std::fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    if let Ok(mut f) = std::fs::OpenOptions::new()
+        .create(true)
+        .append(true)
+        .open(dir.join("pkg-audit.log"))
+    {
+        let _ = writeln!(f, "{line}");
+    }
+}
+
+/// Path to the audit log (may not exist yet).
+#[must_use]
+pub fn audit_log_path() -> std::path::PathBuf {
+    crate::state_dir().join("pkg-audit.log")
+}

--- a/rust/tcl-pkg/src/fetchers.rs
+++ b/rust/tcl-pkg/src/fetchers.rs
@@ -15,8 +15,36 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 
 use flate2::read::GzDecoder;
+use tcl_sandbox::{Profile, SandboxPolicy};
 
 use crate::errors::TclPkgError;
+
+/// Build a sandbox profile for the `git` tool: confined to `cwd`, output
+/// captured, with only the environment git legitimately needs (PATH, HOME, and
+/// proxy/TLS settings). Credentials in the environment (SSH agents, tokens) are
+/// stripped by the sandbox's sensitive-name denylist.
+fn git_profile(label: &str, git: &Path, cwd: &Path) -> Profile {
+    let mut p = Profile::new(label, git, cwd);
+    for name in [
+        "PATH",
+        "HOME",
+        "TMPDIR",
+        "http_proxy",
+        "https_proxy",
+        "no_proxy",
+        "HTTP_PROXY",
+        "HTTPS_PROXY",
+        "NO_PROXY",
+        "ALL_PROXY",
+        "GIT_SSL_CAINFO",
+        "SSL_CERT_FILE",
+        "SSL_CERT_DIR",
+        "CURL_CA_BUNDLE",
+    ] {
+        p = p.pass_env(name);
+    }
+    p
+}
 
 /// Maximum total uncompressed size from a single archive (256 MiB). Protects
 /// against decompression bombs.
@@ -272,26 +300,36 @@ pub fn fetch_git(url: &str, dest: &Path, rev: Option<&str>) -> Result<String, Tc
         }
     }
 
-    let mut cmd = std::process::Command::new("git");
-    cmd.args(["clone", "--depth", "1"]);
+    // Resolve git's absolute path: the sandbox clears the environment, so a bare
+    // `git` would not be found via PATH lookup at spawn time.
+    let git = crate::venv::which("git").unwrap_or_else(|| std::path::PathBuf::from("git"));
+    let parent = dest.parent().unwrap_or_else(|| Path::new("."));
+
+    let mut clone_args: Vec<String> = vec!["clone".into(), "--depth".into(), "1".into()];
     if let Some(r) = &rev {
-        cmd.args(["--branch", r]);
+        clone_args.push("--branch".into());
+        clone_args.push(r.clone());
     }
-    cmd.arg(&url).arg(dest);
-    let output = cmd
-        .output()
-        .map_err(|e| fetch_error(format!("git not found: {e}")))?;
-    if !output.status.success() {
-        let stderr = String::from_utf8_lossy(&output.stderr).trim().to_string();
+    clone_args.push(url.clone());
+    clone_args.push(dest.to_string_lossy().into_owned());
+
+    // git fetches over the network, so this is the one trusted tool that runs
+    // with network granted. The environment is still scrubbed of credentials
+    // (SSH_*, *_TOKEN, …); only PATH, HOME and proxy/TLS settings pass through.
+    let profile = git_profile("git-clone", &git, parent)
+        .args(clone_args)
+        .network(true);
+    let outcome = crate::exec::execute(&profile, &SandboxPolicy::default())?;
+    if !outcome.success {
+        let stderr = String::from_utf8_lossy(&outcome.stderr).trim().to_string();
         return Err(fetch_error(format!("git clone failed: {stderr}")));
     }
 
-    let sha = std::process::Command::new("git")
-        .args(["rev-parse", "HEAD"])
-        .current_dir(dest)
-        .output()
+    let rev_profile = git_profile("git-rev-parse", &git, dest)
+        .args(["rev-parse".to_string(), "HEAD".to_string()]);
+    let sha = crate::exec::execute(&rev_profile, &SandboxPolicy::default())
         .ok()
-        .filter(|o| o.status.success())
+        .filter(|o| o.success)
         .map(|o| String::from_utf8_lossy(&o.stdout).trim().to_string())
         .unwrap_or_default();
 

--- a/rust/tcl-pkg/src/hooks.rs
+++ b/rust/tcl-pkg/src/hooks.rs
@@ -1,0 +1,269 @@
+//! Operator lifecycle hooks.
+//!
+//! Hooks are defined in policy (so they live in the locked-down system layer and
+//! a developer cannot remove them) and fire at well-defined points in a package
+//! operation. A hook is an external command run through the [`crate::exec`]
+//! sandbox with the capabilities it declares, clamped by the sandbox policy
+//! floor. **A non-zero exit aborts the operation** — this is how an operator's
+//! scanner, denylist, cooldown check or provenance verifier blocks a package.
+//!
+//! Context (package name, version, source URL, on-disk path, …) is passed to the
+//! hook as scrubbed `TCLPKG_*` environment variables, and `${VAR}` references in
+//! a hook's `command`/`fs-read`/`fs-write` entries are expanded from it.
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use tcl_sandbox::Profile;
+
+use crate::errors::{Category, TclPkgError};
+use crate::policy::{HookDef, PolicyConfig};
+
+/// A lifecycle stage at which hooks may run.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Stage {
+    PreResolve,
+    PostResolve,
+    PreFetch,
+    PostFetch,
+    PreBuild,
+    PostBuild,
+    PreInstall,
+    PostInstall,
+    PreRun,
+    PostRun,
+}
+
+impl Stage {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Stage::PreResolve => "pre-resolve",
+            Stage::PostResolve => "post-resolve",
+            Stage::PreFetch => "pre-fetch",
+            Stage::PostFetch => "post-fetch",
+            Stage::PreBuild => "pre-build",
+            Stage::PostBuild => "post-build",
+            Stage::PreInstall => "pre-install",
+            Stage::PostInstall => "post-install",
+            Stage::PreRun => "pre-run",
+            Stage::PostRun => "post-run",
+        }
+    }
+
+    /// Parse a stage name as written in policy TOML.
+    #[must_use]
+    pub fn parse(s: &str) -> Option<Stage> {
+        Some(match s {
+            "pre-resolve" => Stage::PreResolve,
+            "post-resolve" => Stage::PostResolve,
+            "pre-fetch" => Stage::PreFetch,
+            "post-fetch" => Stage::PostFetch,
+            "pre-build" => Stage::PreBuild,
+            "post-build" => Stage::PostBuild,
+            "pre-install" => Stage::PreInstall,
+            "post-install" => Stage::PostInstall,
+            "pre-run" => Stage::PreRun,
+            "post-run" => Stage::PostRun,
+            _ => return None,
+        })
+    }
+}
+
+/// The per-invocation context handed to hooks.
+#[derive(Debug, Clone, Default)]
+pub struct HookContext {
+    /// The directory the hook runs in (and is confined to).
+    pub cwd: PathBuf,
+    /// `TCLPKG_*` variables exported to the hook and used for `${VAR}` expansion.
+    pub vars: HashMap<String, String>,
+}
+
+impl HookContext {
+    #[must_use]
+    pub fn new(cwd: impl Into<PathBuf>) -> Self {
+        Self {
+            cwd: cwd.into(),
+            vars: HashMap::new(),
+        }
+    }
+
+    #[must_use]
+    pub fn var(mut self, key: &str, value: impl Into<String>) -> Self {
+        self.vars.insert(format!("TCLPKG_{key}"), value.into());
+        self
+    }
+}
+
+/// Run every hook bound to `stage`, in declaration order. Aborts on the first
+/// hook that fails.
+///
+/// # Errors
+///
+/// Returns a [`TclPkgError`] (category [`Category::Hook`]) when a hook is
+/// misconfigured, the sandbox refuses to run it, or the hook exits non-zero.
+pub fn run_stage(stage: Stage, cfg: &PolicyConfig, ctx: &HookContext) -> Result<(), TclPkgError> {
+    let policy = cfg.sandbox_policy();
+    for hook in &cfg.hooks {
+        if Stage::parse(&hook.stage) != Some(stage) {
+            continue;
+        }
+        run_one(hook, stage, &policy, ctx)?;
+    }
+    Ok(())
+}
+
+fn run_one(
+    hook: &HookDef,
+    stage: Stage,
+    policy: &tcl_sandbox::SandboxPolicy,
+    ctx: &HookContext,
+) -> Result<(), TclPkgError> {
+    let Some((program, args)) = hook.command.split_first() else {
+        return Err(
+            TclPkgError::new(format!("hook '{}' has an empty command", hook.name))
+                .with_category(Category::Hook),
+        );
+    };
+    let program = expand(program, &ctx.vars);
+
+    let mut profile = Profile::new(
+        format!("hook:{}:{}", stage.as_str(), hook.name),
+        PathBuf::from(&program),
+        &ctx.cwd,
+    )
+    .args(args.iter().map(|a| expand(a, &ctx.vars)))
+    .network(hook.network)
+    .timeout(hook.timeout_secs.map(Duration::from_secs));
+
+    for (k, v) in &ctx.vars {
+        profile = profile.set_env(k, v);
+    }
+    for name in &hook.env {
+        profile = profile.pass_env(name);
+    }
+    profile.fs_read = hook
+        .fs_read
+        .iter()
+        .map(|p| PathBuf::from(expand(p, &ctx.vars)))
+        .collect();
+    profile.fs_write = hook
+        .fs_write
+        .iter()
+        .map(|p| PathBuf::from(expand(p, &ctx.vars)))
+        .collect();
+
+    let outcome = crate::exec::execute(&profile, policy)?;
+    if outcome.success {
+        return Ok(());
+    }
+
+    let detail = first_nonempty_line(&outcome.stderr)
+        .or_else(|| first_nonempty_line(&outcome.stdout))
+        .unwrap_or_default();
+    let reason = if outcome.timed_out {
+        "timed out".to_string()
+    } else {
+        match outcome.code {
+            Some(c) => format!("exited with code {c}"),
+            None => "killed".to_string(),
+        }
+    };
+    let mut msg = format!("hook '{}' ({}) {reason}", hook.name, stage.as_str());
+    if !detail.is_empty() {
+        msg.push_str(": ");
+        msg.push_str(&detail);
+    }
+    Err(TclPkgError::new(msg)
+        .with_category(Category::Hook)
+        .with_hint("the operator hook rejected this operation"))
+}
+
+/// Expand `${NAME}` references from `vars`; unknown names expand to empty.
+fn expand(input: &str, vars: &HashMap<String, String>) -> String {
+    let mut out = String::with_capacity(input.len());
+    let bytes = input.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] == b'$'
+            && i + 1 < bytes.len()
+            && bytes[i + 1] == b'{'
+            && let Some(end) = input[i + 2..].find('}')
+        {
+            let name = &input[i + 2..i + 2 + end];
+            if let Some(v) = vars.get(name) {
+                out.push_str(v);
+            }
+            i = i + 2 + end + 1;
+            continue;
+        }
+        out.push(bytes[i] as char);
+        i += 1;
+    }
+    out
+}
+
+fn first_nonempty_line(bytes: &[u8]) -> Option<String> {
+    String::from_utf8_lossy(bytes)
+        .lines()
+        .map(str::trim)
+        .find(|l| !l.is_empty())
+        .map(ToString::to_string)
+}
+
+/// List the configured hooks grouped for display, in stage order.
+#[must_use]
+pub fn describe(cfg: &PolicyConfig) -> Vec<(String, String, String)> {
+    let mut rows = Vec::new();
+    for hook in &cfg.hooks {
+        let cmd = hook.command.join(" ");
+        rows.push((hook.stage.clone(), hook.name.clone(), cmd));
+    }
+    rows
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn stage_round_trips() {
+        for s in [
+            Stage::PreFetch,
+            Stage::PostFetch,
+            Stage::PreInstall,
+            Stage::PostRun,
+        ] {
+            assert_eq!(Stage::parse(s.as_str()), Some(s));
+        }
+        assert_eq!(Stage::parse("nope"), None);
+    }
+
+    #[test]
+    fn expand_substitutes_known_vars() {
+        let mut vars = HashMap::new();
+        vars.insert("TCLPKG_PKG_DIR".to_string(), "/cache/foo".to_string());
+        assert_eq!(expand("${TCLPKG_PKG_DIR}/x", &vars), "/cache/foo/x");
+        assert_eq!(expand("${MISSING}/y", &vars), "/y");
+        assert_eq!(expand("no-vars", &vars), "no-vars");
+    }
+
+    #[test]
+    fn empty_command_is_rejected() {
+        let hook = HookDef {
+            name: "bad".into(),
+            stage: "post-fetch".into(),
+            command: vec![],
+            ..HookDef::default()
+        };
+        let err = run_one(
+            &hook,
+            Stage::PostFetch,
+            &tcl_sandbox::SandboxPolicy::default(),
+            &HookContext::new("."),
+        )
+        .unwrap_err();
+        assert_eq!(err.category, Category::Hook);
+    }
+}

--- a/rust/tcl-pkg/src/lib.rs
+++ b/rust/tcl-pkg/src/lib.rs
@@ -9,11 +9,14 @@
 pub mod cas;
 pub mod docker;
 pub mod errors;
+pub mod exec;
 pub mod fetchers;
+pub mod hooks;
 pub mod installer;
 pub mod json;
 pub mod lockfile;
 pub mod manifest;
+pub mod policy;
 pub mod registry;
 pub mod resolver;
 pub mod ui;
@@ -58,6 +61,69 @@ pub fn cache_dir() -> PathBuf {
 #[must_use]
 pub fn venv_pool_dir() -> PathBuf {
     home_dir().join(".tcl-venvs")
+}
+
+/// The per-user configuration directory. `$XDG_CONFIG_HOME` wins, otherwise
+/// `%APPDATA%/tcl-lsp` (Windows), `~/Library/Application Support/tcl-lsp`
+/// (macOS), or `~/.config/tcl-lsp` (Linux/BSD). This is where the per-user
+/// `pkg.toml` policy layer lives.
+#[must_use]
+pub fn config_dir() -> PathBuf {
+    if let Some(xdg) = std::env::var_os("XDG_CONFIG_HOME")
+        && !xdg.is_empty()
+    {
+        return PathBuf::from(xdg).join("tcl-lsp");
+    }
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(appdata) = std::env::var_os("APPDATA") {
+            return PathBuf::from(appdata).join("tcl-lsp");
+        }
+    }
+    let home = home_dir();
+    #[cfg(target_os = "macos")]
+    {
+        return home
+            .join("Library")
+            .join("Application Support")
+            .join("tcl-lsp");
+    }
+    #[cfg(not(target_os = "macos"))]
+    {
+        home.join(".config").join("tcl-lsp")
+    }
+}
+
+/// The system-wide (operator) configuration directory. `/etc/tcl-lsp` on
+/// POSIX (including macOS, deliberately, so corporate provisioning lands in one
+/// well-known root-owned place) and `%PROGRAMDATA%/tcl-lsp` on Windows. The
+/// locked-down policy layer lives here; it is honoured only when the file is
+/// owned by a privileged account and not world-writable.
+#[must_use]
+pub fn system_config_dir() -> PathBuf {
+    #[cfg(target_os = "windows")]
+    {
+        if let Some(pd) = std::env::var_os("PROGRAMDATA") {
+            return PathBuf::from(pd).join("tcl-lsp");
+        }
+        return PathBuf::from(r"C:\ProgramData\tcl-lsp");
+    }
+    #[cfg(not(target_os = "windows"))]
+    {
+        PathBuf::from("/etc/tcl-lsp")
+    }
+}
+
+/// The directory for mutable runtime state (the sandbox audit log, etc.):
+/// `$XDG_STATE_HOME/tcl-lsp` when set, otherwise alongside the cache.
+#[must_use]
+pub fn state_dir() -> PathBuf {
+    if let Some(xdg) = std::env::var_os("XDG_STATE_HOME")
+        && !xdg.is_empty()
+    {
+        return PathBuf::from(xdg).join("tcl-lsp");
+    }
+    cache_dir().join("state")
 }
 
 fn home_dir() -> PathBuf {

--- a/rust/tcl-pkg/src/manifest.rs
+++ b/rust/tcl-pkg/src/manifest.rs
@@ -41,6 +41,7 @@ const DIRECTIVES: &[&str] = &[
     "exclude",
     "provides",
     "entry",
+    "build",
 ];
 
 /// A single `require` / `dev-require` entry.
@@ -83,7 +84,22 @@ pub struct ManifestAst {
     pub excludes: Vec<Exclusion>,
     pub provides: Vec<String>,
     pub entry: String,
+    /// Optional build script (a Tcl file run, deprivileged, by `tcl pkg build`).
+    /// Data only: declaring it never causes execution. It runs solely when an
+    /// operator both enables build scripts and trusts the package.
+    pub build: BuildDecl,
     pub path: String,
+}
+
+/// A declarative build-script declaration. The script path plus the (minimal)
+/// capabilities it asks for; the sandbox grants only the intersection with
+/// policy.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct BuildDecl {
+    /// Path to the build script, relative to the manifest. Empty when absent.
+    pub script: String,
+    /// Whether the build script requests network access.
+    pub network: bool,
 }
 
 impl Default for ManifestAst {
@@ -102,6 +118,7 @@ impl Default for ManifestAst {
             excludes: Vec::new(),
             provides: Vec::new(),
             entry: String::new(),
+            build: BuildDecl::default(),
             path: String::new(),
         }
     }
@@ -267,6 +284,20 @@ fn dispatch(ast: &mut ManifestAst, name: &str, args: &[String]) -> Result<(), St
         "entry" => {
             require_arity("entry", args, 1, 1)?;
             ast.entry.clone_from(&args[0]);
+        }
+        "build" => {
+            // `build <script> ?-network?` — declaration only; never executed here.
+            require_arity("build", args, 1, 2)?;
+            if !ast.build.script.is_empty() {
+                return Err("build directive already set".to_string());
+            }
+            ast.build.script.clone_from(&args[0]);
+            for opt in &args[1..] {
+                match opt.as_str() {
+                    "-network" => ast.build.network = true,
+                    other => return Err(format!("build: unknown option '{other}'")),
+                }
+            }
         }
         _ => unreachable!("dispatch only called for whitelisted directives"),
     }

--- a/rust/tcl-pkg/src/policy.rs
+++ b/rust/tcl-pkg/src/policy.rs
@@ -1,0 +1,573 @@
+//! Layered, operator-lockable package-manager policy.
+//!
+//! Policy is merged from three TOML layers, lowest precedence first:
+//!
+//! 1. **System** (`/etc/tcl-lsp/pkg-policy.toml`, `%PROGRAMDATA%\tcl-lsp\…` on
+//!    Windows) — the operator/corporate layer. Honoured only when the file is
+//!    owned by root/Administrators and not world-writable, so a developer cannot
+//!    weaken it by editing a file they own.
+//! 2. **User** (`~/.config/tcl-lsp/pkg.toml`).
+//! 3. **Project** (`tclpkg.toml` next to the manifest).
+//!
+//! The system layer may **lock** keys so the user and project layers cannot
+//! override them — the primitive that lets corporate IT deploy a floor
+//! developers cannot loosen:
+//!
+//! * `lock = ["sandbox.fail-closed", "registry"]` — a dotted leaf is frozen at
+//!   its system value; a whole section name freezes the entire subtree (no
+//!   sibling additions either).
+//! * `lock-all = true` — every *leaf* the system layer sets is frozen, while
+//!   still allowing lower layers to add keys the system did not set.
+//!
+//! Attempts to override a locked key are ignored and surfaced as warnings (see
+//! [`LoadedPolicy::warnings`]).
+//!
+//! The manifest (`tclpkg.tcl`) stays pure data; nothing here executes code. The
+//! policy only *describes* what may run and how confined it must be — the
+//! [`crate::exec`] chokepoint and [`crate::hooks`] dispatcher enforce it.
+
+use std::path::{Path, PathBuf};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+use tcl_sandbox::SandboxPolicy;
+use toml::{Table, Value};
+
+/// The fully-merged, typed policy.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct PolicyConfig {
+    pub sandbox: SandboxSection,
+    pub registry: RegistrySection,
+    pub cooldown: CooldownSection,
+    pub verification: VerificationSection,
+    pub build: BuildSection,
+    #[serde(default)]
+    pub hooks: Vec<HookDef>,
+    /// Dotted keys / section names the system layer froze.
+    #[serde(default)]
+    pub lock: Vec<String>,
+    /// Freeze every leaf the system layer set.
+    #[serde(default)]
+    pub lock_all: bool,
+}
+
+/// Sandbox floor applied to every sandboxed execution.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct SandboxSection {
+    /// Abort when a mandatory floor cannot be met on this host.
+    pub fail_closed: bool,
+    /// Network denial must be enforced for default-deny executions.
+    pub require_network_deny: bool,
+    /// Force the network off for everything, even callers that request it.
+    pub deny_network: bool,
+    /// Clamp every command's timeout to at most this many seconds.
+    pub max_timeout_secs: Option<u64>,
+    /// Extra environment names every sandboxed child may pass through.
+    pub env_allow: Vec<String>,
+    /// Environment names that must never be passed through.
+    pub env_deny: Vec<String>,
+}
+
+/// Registry source controls.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct RegistrySection {
+    /// If non-empty, only source URLs with one of these prefixes are allowed.
+    pub allow: Vec<String>,
+    /// Source URLs with any of these prefixes are rejected.
+    pub deny: Vec<String>,
+    /// Reject non-`https://` source URLs.
+    pub require_https: bool,
+}
+
+/// Minimum-release-age ("cooldown") control — defends against the replication
+/// window of worms like Shai-Hulud and freshly-published typosquats.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct CooldownSection {
+    pub min_release_age_days: u64,
+}
+
+/// Integrity / provenance requirements.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct VerificationSection {
+    /// Require every locked package to carry an integrity hash and verify it.
+    pub require_integrity: bool,
+    /// Require provenance/attestation verification (delegated to a hook).
+    pub require_provenance: bool,
+}
+
+/// Build-phase script controls. Off by default — packages are data unless an
+/// operator opts in, mirroring npm v12 / pnpm / Bun / Deno.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct BuildSection {
+    /// Allow declared build scripts to run at all.
+    pub allow_build_scripts: bool,
+    /// Packages whose build script is trusted to run (when allowed).
+    pub trusted: Vec<String>,
+}
+
+/// An operator hook bound to a lifecycle stage.
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
+#[serde(default, rename_all = "kebab-case")]
+pub struct HookDef {
+    pub name: String,
+    /// Lifecycle stage, e.g. `post-fetch` (see [`crate::hooks::Stage`]).
+    pub stage: String,
+    /// Argument vector; the first element is the program (run without a shell).
+    pub command: Vec<String>,
+    /// Whether the hook may use the network (default deny).
+    pub network: bool,
+    /// Per-hook timeout in seconds.
+    pub timeout_secs: Option<u64>,
+    /// Filesystem read grants (for the OS-native confinement tier).
+    pub fs_read: Vec<String>,
+    /// Filesystem write grants.
+    pub fs_write: Vec<String>,
+    /// Environment names the hook may pass through.
+    pub env: Vec<String>,
+}
+
+impl PolicyConfig {
+    /// Derive the sandbox floor from the policy.
+    #[must_use]
+    pub fn sandbox_policy(&self) -> SandboxPolicy {
+        let mut base = SandboxPolicy {
+            deny_network: self.sandbox.deny_network,
+            require_network_deny: self.sandbox.require_network_deny,
+            fail_closed: self.sandbox.fail_closed,
+            deny_env: self.sandbox.env_deny.clone(),
+            max_timeout: self.sandbox.max_timeout_secs.map(Duration::from_secs),
+            ..SandboxPolicy::default()
+        };
+        base.base_env_passthrough
+            .extend(self.sandbox.env_allow.iter().cloned());
+        base
+    }
+
+    /// Whether a source URL is permitted by the registry allow/deny policy.
+    #[must_use]
+    pub fn source_allowed(&self, url: &str) -> bool {
+        // Local path / git sources are not URLs; only gate plain-http ones.
+        if self.registry.require_https && url.starts_with("http://") {
+            return false;
+        }
+        if self.registry.deny.iter().any(|p| url.starts_with(p)) {
+            return false;
+        }
+        if !self.registry.allow.is_empty() {
+            return self.registry.allow.iter().any(|p| url.starts_with(p));
+        }
+        true
+    }
+}
+
+/// Which file a policy layer was loaded from, and whether it was honoured.
+#[derive(Debug, Clone)]
+pub struct PolicySource {
+    pub layer: &'static str,
+    pub path: PathBuf,
+    pub loaded: bool,
+    pub note: Option<String>,
+}
+
+/// The result of loading and merging policy.
+#[derive(Debug, Clone)]
+pub struct LoadedPolicy {
+    pub config: PolicyConfig,
+    pub sources: Vec<PolicySource>,
+    pub locked: Vec<String>,
+    pub warnings: Vec<String>,
+}
+
+/// Load and merge the system, user and project policy layers.
+///
+/// `project_dir`, when given, is the directory containing the manifest; its
+/// `tclpkg.toml` is the project layer. Missing files are skipped; malformed
+/// files are skipped with a warning rather than aborting (a broken user file
+/// must never break a locked-down system floor).
+#[must_use]
+pub fn load(project_dir: Option<&Path>) -> LoadedPolicy {
+    let system_path = crate::system_config_dir().join("pkg-policy.toml");
+    let user_path = crate::config_dir().join("pkg.toml");
+    let project_path = project_dir.map(|d| d.join("tclpkg.toml"));
+
+    let mut sources = Vec::new();
+    let mut warnings = Vec::new();
+
+    let system = load_system_layer(&system_path, &mut sources, &mut warnings);
+    let explicit_locks = string_array(&system, "lock");
+    let lock_all = system
+        .get("lock-all")
+        .and_then(Value::as_bool)
+        .unwrap_or(false);
+
+    let mut merged = system.clone();
+    for (layer, path) in [("user", Some(user_path)), ("project", project_path)] {
+        let Some(path) = path else { continue };
+        merge_lower_layer(
+            layer,
+            &path,
+            &system,
+            &explicit_locks,
+            lock_all,
+            &mut merged,
+            &mut sources,
+            &mut warnings,
+        );
+    }
+
+    let locked = collect_locked_leaves(&system, "", &explicit_locks, lock_all);
+    let config = merged.try_into::<PolicyConfig>().unwrap_or_else(|e| {
+        warnings.push(format!("policy schema error: {e}"));
+        PolicyConfig::default()
+    });
+
+    LoadedPolicy {
+        config,
+        sources,
+        locked,
+        warnings,
+    }
+}
+
+/// Read and trust-check the system layer, recording its [`PolicySource`].
+fn load_system_layer(
+    path: &Path,
+    sources: &mut Vec<PolicySource>,
+    warnings: &mut Vec<String>,
+) -> Table {
+    let mut record = |loaded: bool, note: Option<String>| {
+        sources.push(PolicySource {
+            layer: "system",
+            path: path.to_path_buf(),
+            loaded,
+            note,
+        });
+    };
+    match read_layer(path) {
+        LayerRead::Missing => {
+            record(false, None);
+            Table::new()
+        }
+        LayerRead::Invalid(e) => {
+            warnings.push(format!("{}: {e}", path.display()));
+            record(false, Some(e));
+            Table::new()
+        }
+        LayerRead::Parsed(t) if system_file_trusted(path) => {
+            record(true, None);
+            t
+        }
+        LayerRead::Parsed(_) => {
+            let note = "ignored: system policy must be owned by root and not world-writable";
+            warnings.push(format!("{}: {note}", path.display()));
+            record(false, Some(note.to_string()));
+            Table::new()
+        }
+    }
+}
+
+/// Read a user/project layer and merge it into `merged`, honouring locks.
+#[allow(clippy::too_many_arguments)]
+fn merge_lower_layer(
+    layer: &'static str,
+    path: &Path,
+    system: &Table,
+    explicit_locks: &[String],
+    lock_all: bool,
+    merged: &mut Table,
+    sources: &mut Vec<PolicySource>,
+    warnings: &mut Vec<String>,
+) {
+    match read_layer(path) {
+        LayerRead::Missing => sources.push(PolicySource {
+            layer,
+            path: path.to_path_buf(),
+            loaded: false,
+            note: None,
+        }),
+        LayerRead::Invalid(e) => {
+            warnings.push(format!("{}: {e}", path.display()));
+            sources.push(PolicySource {
+                layer,
+                path: path.to_path_buf(),
+                loaded: false,
+                note: Some(e),
+            });
+        }
+        LayerRead::Parsed(t) => {
+            merge_locked(
+                merged,
+                &t,
+                system,
+                "",
+                explicit_locks,
+                lock_all,
+                layer,
+                warnings,
+            );
+            sources.push(PolicySource {
+                layer,
+                path: path.to_path_buf(),
+                loaded: true,
+                note: None,
+            });
+        }
+    }
+}
+
+/// Extract a TOML array of strings at `key`.
+fn string_array(table: &Table, key: &str) -> Vec<String> {
+    table
+        .get(key)
+        .and_then(Value::as_array)
+        .map(|a| {
+            a.iter()
+                .filter_map(|v| v.as_str().map(ToString::to_string))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+enum LayerRead {
+    Missing,
+    Parsed(Table),
+    Invalid(String),
+}
+
+fn read_layer(path: &Path) -> LayerRead {
+    if !path.is_file() {
+        return LayerRead::Missing;
+    }
+    match std::fs::read_to_string(path) {
+        Ok(text) => match text.parse::<Table>() {
+            Ok(t) => LayerRead::Parsed(t),
+            Err(e) => LayerRead::Invalid(e.to_string()),
+        },
+        Err(e) => LayerRead::Invalid(e.to_string()),
+    }
+}
+
+/// On Unix, the system policy must be owned by uid 0 and not group/world
+/// writable. On Windows we trust `%PROGRAMDATA%` ACLs and accept the file.
+#[cfg(unix)]
+fn system_file_trusted(path: &Path) -> bool {
+    use std::os::unix::fs::MetadataExt;
+    let Ok(meta) = std::fs::metadata(path) else {
+        return false;
+    };
+    let mode = meta.mode();
+    let world_or_group_writable = mode & 0o022 != 0;
+    meta.uid() == 0 && !world_or_group_writable
+}
+
+#[cfg(not(unix))]
+fn system_file_trusted(_path: &Path) -> bool {
+    true
+}
+
+/// Look up a dotted path in a table.
+fn table_get<'a>(table: &'a Table, path: &str) -> Option<&'a Value> {
+    let mut current: Option<&Value> = None;
+    for (i, part) in path.split('.').enumerate() {
+        let next = if i == 0 {
+            table.get(part)
+        } else {
+            current.and_then(Value::as_table).and_then(|t| t.get(part))
+        };
+        current = next;
+        current?;
+    }
+    current
+}
+
+/// Whether `path` is frozen by the system layer.
+fn is_locked(path: &str, system: &Table, explicit: &[String], lock_all: bool) -> bool {
+    // An explicit lock entry matches the path itself or any ancestor.
+    for entry in explicit {
+        if entry == path || path.starts_with(&format!("{entry}.")) {
+            return true;
+        }
+    }
+    if lock_all {
+        // Under lock-all only leaves the system actually set are frozen; tables
+        // stay open so lower layers may add sibling keys.
+        return matches!(table_get(system, path), Some(v) if !v.is_table());
+    }
+    false
+}
+
+/// Deep-merge `incoming` into `acc`, refusing to override paths locked by the
+/// system layer and recording each refusal as a warning.
+#[allow(clippy::too_many_arguments)]
+fn merge_locked(
+    acc: &mut Table,
+    incoming: &Table,
+    system: &Table,
+    prefix: &str,
+    explicit: &[String],
+    lock_all: bool,
+    layer: &str,
+    warnings: &mut Vec<String>,
+) {
+    for (k, v) in incoming {
+        let path = if prefix.is_empty() {
+            k.clone()
+        } else {
+            format!("{prefix}.{k}")
+        };
+        if is_locked(&path, system, explicit, lock_all) {
+            warnings.push(format!("{layer}: ignored override of locked key '{path}'"));
+            continue;
+        }
+        match (acc.get_mut(k), v) {
+            (Some(Value::Table(at)), Value::Table(it)) => {
+                merge_locked(at, it, system, &path, explicit, lock_all, layer, warnings);
+            }
+            _ => {
+                acc.insert(k.clone(), v.clone());
+            }
+        }
+    }
+}
+
+/// Enumerate the concrete locked leaf paths, for display by `tcl pkg policy`.
+fn collect_locked_leaves(
+    system: &Table,
+    prefix: &str,
+    explicit: &[String],
+    lock_all: bool,
+) -> Vec<String> {
+    let mut out = Vec::new();
+    for (k, v) in system {
+        if k == "lock" || k == "lock-all" {
+            continue;
+        }
+        let path = if prefix.is_empty() {
+            k.clone()
+        } else {
+            format!("{prefix}.{k}")
+        };
+        if let Value::Table(t) = v {
+            // An explicitly locked section freezes the whole subtree.
+            if explicit.iter().any(|e| e == &path) {
+                out.push(format!("{path} (section)"));
+            } else {
+                out.extend(collect_locked_leaves(t, &path, explicit, lock_all));
+            }
+        } else if is_locked(&path, system, explicit, lock_all) {
+            out.push(path);
+        }
+    }
+    out.sort();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn merge(system: &str, user: &str) -> (PolicyConfig, Vec<String>) {
+        let system: Table = system.parse().unwrap();
+        let user: Table = user.parse().unwrap();
+        let explicit: Vec<String> = system
+            .get("lock")
+            .and_then(Value::as_array)
+            .map(|a| {
+                a.iter()
+                    .filter_map(|v| v.as_str().map(String::from))
+                    .collect()
+            })
+            .unwrap_or_default();
+        let lock_all = system
+            .get("lock-all")
+            .and_then(Value::as_bool)
+            .unwrap_or(false);
+        let mut merged = system.clone();
+        let mut warnings = Vec::new();
+        merge_locked(
+            &mut merged,
+            &user,
+            &system,
+            "",
+            &explicit,
+            lock_all,
+            "user",
+            &mut warnings,
+        );
+        (merged.try_into().unwrap(), warnings)
+    }
+
+    #[test]
+    fn unlocked_user_overrides_system() {
+        let (cfg, warns) = merge(
+            "[sandbox]\nfail-closed = false\n",
+            "[sandbox]\nfail-closed = true\n",
+        );
+        assert!(cfg.sandbox.fail_closed);
+        assert!(warns.is_empty());
+    }
+
+    #[test]
+    fn locked_leaf_cannot_be_overridden() {
+        let (cfg, warns) = merge(
+            "lock = [\"sandbox.fail-closed\"]\n[sandbox]\nfail-closed = true\n",
+            "[sandbox]\nfail-closed = false\n",
+        );
+        assert!(cfg.sandbox.fail_closed, "locked system value must win");
+        assert!(warns.iter().any(|w| w.contains("sandbox.fail-closed")));
+    }
+
+    #[test]
+    fn locked_section_freezes_subtree() {
+        let (cfg, warns) = merge(
+            "lock = [\"registry\"]\n[registry]\nrequire-https = true\nallow = [\"https://a\"]\n",
+            "[registry]\nrequire-https = false\ndeny = [\"https://b\"]\n",
+        );
+        assert!(cfg.registry.require_https);
+        assert!(
+            cfg.registry.deny.is_empty(),
+            "no sibling additions into a locked section"
+        );
+        assert!(warns.iter().any(|w| w.contains("registry")));
+    }
+
+    #[test]
+    fn lock_all_freezes_set_leaves_but_allows_new_keys() {
+        let (cfg, _warns) = merge(
+            "lock-all = true\n[sandbox]\ndeny-network = true\n",
+            "[sandbox]\ndeny-network = false\nfail-closed = true\n",
+        );
+        // The system-set leaf is frozen ...
+        assert!(cfg.sandbox.deny_network);
+        // ... but a key the system never set may still be added by the user.
+        assert!(cfg.sandbox.fail_closed);
+    }
+
+    #[test]
+    fn source_allowed_respects_https_and_lists() {
+        let cfg = PolicyConfig {
+            registry: RegistrySection {
+                require_https: true,
+                allow: vec!["https://good/".into()],
+                deny: vec!["https://good/evil".into()],
+            },
+            ..PolicyConfig::default()
+        };
+        assert!(cfg.source_allowed("https://good/pkg"));
+        assert!(
+            !cfg.source_allowed("http://good/pkg"),
+            "http rejected under require-https"
+        );
+        assert!(!cfg.source_allowed("https://good/evil"), "deny prefix wins");
+        assert!(
+            !cfg.source_allowed("https://other/pkg"),
+            "not in allow list"
+        );
+    }
+}

--- a/rust/tcl-pkg/src/policy.rs
+++ b/rust/tcl-pkg/src/policy.rs
@@ -33,6 +33,8 @@ use serde::{Deserialize, Serialize};
 use tcl_sandbox::SandboxPolicy;
 use toml::{Table, Value};
 
+use crate::errors::TclPkgError;
+
 /// The fully-merged, typed policy.
 #[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(default, rename_all = "kebab-case")]
@@ -164,6 +166,68 @@ impl PolicyConfig {
         }
         true
     }
+
+    /// Whether `package`'s declared build script may execute: build scripts must
+    /// be enabled by policy *and* the package explicitly trusted.
+    #[must_use]
+    pub fn build_script_allowed(&self, package: &str) -> bool {
+        self.build.allow_build_scripts && self.build.trusted.iter().any(|p| p == package)
+    }
+}
+
+/// Add or remove a package from the per-user `[build] trusted` list, creating
+/// `~/.config/tcl-lsp/pkg.toml` if needed. Returns the file path.
+///
+/// # Errors
+///
+/// Returns a [`TclPkgError`] (category [`Category::Policy`]) when the file
+/// cannot be read, parsed, or written.
+pub fn set_trusted(package: &str, trusted: bool) -> Result<PathBuf, TclPkgError> {
+    let path = crate::config_dir().join("pkg.toml");
+    let mut table: Table = if path.is_file() {
+        std::fs::read_to_string(&path)
+            .map_err(|e| policy_err(e.to_string()))?
+            .parse()
+            .map_err(|e: toml::de::Error| policy_err(e.to_string()))?
+    } else {
+        Table::new()
+    };
+
+    let build = table
+        .entry("build".to_string())
+        .or_insert_with(|| Value::Table(Table::new()));
+    let Value::Table(build) = build else {
+        return Err(policy_err("[build] in pkg.toml is not a table"));
+    };
+    let list = build
+        .entry("trusted".to_string())
+        .or_insert_with(|| Value::Array(Vec::new()));
+    let Value::Array(list) = list else {
+        return Err(policy_err("[build].trusted in pkg.toml is not an array"));
+    };
+
+    let mut names: Vec<String> = list
+        .iter()
+        .filter_map(|v| v.as_str().map(ToString::to_string))
+        .collect();
+    names.retain(|n| n != package);
+    if trusted {
+        names.push(package.to_string());
+    }
+    names.sort();
+    names.dedup();
+    *list = names.into_iter().map(Value::String).collect();
+
+    if let Some(parent) = path.parent() {
+        std::fs::create_dir_all(parent).map_err(|e| policy_err(e.to_string()))?;
+    }
+    let text = toml::to_string_pretty(&table).map_err(|e| policy_err(e.to_string()))?;
+    std::fs::write(&path, text).map_err(|e| policy_err(e.to_string()))?;
+    Ok(path)
+}
+
+fn policy_err(message: impl Into<String>) -> TclPkgError {
+    TclPkgError::new(message).with_category(crate::errors::Category::Policy)
 }
 
 /// Which file a policy layer was loaded from, and whether it was honoured.

--- a/rust/tcl-pkg/src/venv.rs
+++ b/rust/tcl-pkg/src/venv.rs
@@ -81,25 +81,24 @@ fn resolve_tclsh(requested: Option<&str>) -> Result<PathBuf, TclPkgError> {
 }
 
 fn tclsh_version_string(tclsh: &Path) -> String {
-    use std::io::Write;
-    use std::process::{Command, Stdio};
+    use tcl_sandbox::{Profile, SandboxPolicy};
 
-    let Ok(mut child) = Command::new(tclsh)
+    let cwd = tclsh
+        .parent()
+        .map_or_else(|| PathBuf::from("."), Path::to_path_buf);
+    // Trusted internal probe: no network, but tclsh needs its library to start,
+    // so PATH/HOME and the Tcl library env pass through. The script is fed on
+    // stdin via `tclsh -`.
+    let mut profile = Profile::new("tclsh-probe", tclsh, cwd)
         .arg("-")
-        .stdin(Stdio::piped())
-        .stdout(Stdio::piped())
-        .stderr(Stdio::null())
-        .spawn()
-    else {
-        return String::new();
-    };
-    if let Some(stdin) = child.stdin.take() {
-        let mut stdin = stdin;
-        let _ = stdin.write_all(b"puts [info patchlevel]");
+        .network(false)
+        .stdin_bytes(b"puts [info patchlevel]".to_vec());
+    for name in ["PATH", "HOME", "TCL_LIBRARY", "TCLLIBPATH", "TMPDIR"] {
+        profile = profile.pass_env(name);
     }
-    match child.wait_with_output() {
-        Ok(out) => String::from_utf8_lossy(&out.stdout).trim().to_string(),
-        Err(_) => String::new(),
+    match crate::exec::execute(&profile, &SandboxPolicy::default()) {
+        Ok(out) if out.success => String::from_utf8_lossy(&out.stdout).trim().to_string(),
+        _ => String::new(),
     }
 }
 

--- a/rust/tcl-sandbox/Cargo.toml
+++ b/rust/tcl-sandbox/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "tcl-sandbox"
+description = "Portable, deprivileged execution sandbox for the tcl package manager: a capability/policy-floor model over a portable baseline (environment scrubbing, working-directory confinement, wall-clock timeouts) with OS-native confinement layered on per platform."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+
+[dependencies]
+serde = { version = "1", features = ["derive"] }
+wait-timeout = "0.2"
+
+[lints]
+workspace = true

--- a/rust/tcl-sandbox/src/capability.rs
+++ b/rust/tcl-sandbox/src/capability.rs
@@ -1,0 +1,104 @@
+//! Declarative capabilities — the serde-facing vocabulary a build script or
+//! operator hook uses to request authority, and that an operator policy uses to
+//! grant or deny it.
+//!
+//! A package's build script declares the capabilities it needs; the sandbox
+//! grants the *minimum* of what was requested and what policy allows, never
+//! more. This mirrors the capability-declaration model used by tools such as
+//! Deno and Bun, where code states its needs up front instead of inheriting the
+//! caller's full authority.
+
+use std::path::PathBuf;
+
+use serde::{Deserialize, Serialize};
+
+use crate::Profile;
+
+/// A single declared capability.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum Capability {
+    /// Permission to use the network.
+    Network,
+    /// Permission to read a path subtree.
+    FsRead(PathBuf),
+    /// Permission to write a path subtree.
+    FsWrite(PathBuf),
+    /// Permission to pass a named environment variable through.
+    Env(String),
+}
+
+/// A declared capability set, e.g. parsed from a manifest `build` directive or a
+/// hook definition in policy TOML.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+pub struct CapabilitySet {
+    #[serde(default)]
+    pub network: bool,
+    #[serde(default)]
+    pub fs_read: Vec<PathBuf>,
+    #[serde(default)]
+    pub fs_write: Vec<PathBuf>,
+    #[serde(default)]
+    pub env: Vec<String>,
+}
+
+impl CapabilitySet {
+    /// Fold this declared set into a [`Profile`], widening the profile's
+    /// requested authority. The policy floor is applied later, in
+    /// [`crate::run`].
+    #[must_use]
+    pub fn apply_to(&self, mut profile: Profile) -> Profile {
+        if self.network {
+            profile.allow_network = true;
+        }
+        profile.fs_read.extend(self.fs_read.iter().cloned());
+        profile.fs_write.extend(self.fs_write.iter().cloned());
+        profile.env_passthrough.extend(self.env.iter().cloned());
+        profile
+    }
+
+    /// Enumerate the set as individual [`Capability`] values (for display).
+    #[must_use]
+    pub fn to_capabilities(&self) -> Vec<Capability> {
+        let mut caps = Vec::new();
+        if self.network {
+            caps.push(Capability::Network);
+        }
+        caps.extend(self.fs_read.iter().cloned().map(Capability::FsRead));
+        caps.extend(self.fs_write.iter().cloned().map(Capability::FsWrite));
+        caps.extend(self.env.iter().cloned().map(Capability::Env));
+        caps
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn apply_widens_profile() {
+        let caps = CapabilitySet {
+            network: true,
+            fs_read: vec![PathBuf::from("/pkg")],
+            fs_write: vec![PathBuf::from("/out")],
+            env: vec!["TCLLIBPATH".into()],
+        };
+        let profile = caps.apply_to(Profile::new("build", "/bin/sh", "/pkg"));
+        assert!(profile.allow_network);
+        assert_eq!(profile.fs_read, vec![PathBuf::from("/pkg")]);
+        assert_eq!(profile.fs_write, vec![PathBuf::from("/out")]);
+        assert!(profile.env_passthrough.contains(&"TCLLIBPATH".to_string()));
+    }
+
+    #[test]
+    fn to_capabilities_enumerates() {
+        let caps = CapabilitySet {
+            network: true,
+            fs_read: vec![PathBuf::from("/a")],
+            ..CapabilitySet::default()
+        };
+        let list = caps.to_capabilities();
+        assert!(list.contains(&Capability::Network));
+        assert!(list.contains(&Capability::FsRead(PathBuf::from("/a"))));
+    }
+}

--- a/rust/tcl-sandbox/src/lib.rs
+++ b/rust/tcl-sandbox/src/lib.rs
@@ -1,0 +1,622 @@
+//! `tcl-sandbox` — portable, deprivileged execution for the `tcl pkg` package
+//! manager.
+//!
+//! The package manager runs three classes of external code: its own trusted
+//! tools (`git`, `tclsh`), operator-defined hooks, and — most dangerously —
+//! package-provided build scripts. Every one of them is funnelled through this
+//! crate so that none inherits the caller's ambient authority (credentials in
+//! the environment, the user's home directory, unrestricted network).
+//!
+//! # Design
+//!
+//! Execution is modelled as a [`Profile`] (what a command *requests*) evaluated
+//! against a [`SandboxPolicy`] (the operator's *floor* — the minimum confinement
+//! that must hold, plus hard denials). The effective grant is
+//! `requested ∩ allowed` widened by the policy floor; if the host cannot enforce
+//! a floor the policy marked mandatory, execution **fails closed**.
+//!
+//! Two confinement tiers exist:
+//!
+//! * **Baseline** (every platform, always applied): the environment is cleared
+//!   to an explicit allow-list (so tokens, SSH keys and cloud credentials never
+//!   leak), the working directory is pinned to a caller-supplied root, output is
+//!   captured, and a wall-clock timeout kills runaway children.
+//! * **OS-native** (per platform, layered on top): Landlock + seccomp on Linux,
+//!   Seatbelt on macOS, `pledge`/`unveil` on OpenBSD, Capsicum on FreeBSD, and
+//!   restricted tokens + Job Objects on Windows. These are introduced behind the
+//!   [`Confinement`] trait; [`detect_confinement`] returns the strongest tier the
+//!   running host can provide and execution reports the [`IsolationLevel`]
+//!   actually achieved.
+//!
+//! The crate contains no `unsafe`: OS-native tiers are driven through wrapper
+//! crates that encapsulate the raw syscalls, honouring the workspace
+//! `unsafe_code = "forbid"` lint.
+
+use std::io::Read;
+use std::path::PathBuf;
+use std::process::{Command, Stdio};
+use std::time::Duration;
+
+use serde::{Deserialize, Serialize};
+
+pub mod capability;
+
+pub use capability::Capability;
+
+/// Environment variable name fragments that must never be passed to a sandboxed
+/// child, even if a caller or policy accidentally allow-lists them. Matched
+/// case-insensitively as substrings of the variable name. This is the
+/// defence-in-depth net behind the explicit allow-list; the lessons of
+/// event-stream (AES key read from `npm_package_description`) and the
+/// Shai-Hulud worm (credential theft from the process environment) make a
+/// belt-and-braces denylist worthwhile.
+const SENSITIVE_FRAGMENTS: &[&str] = &[
+    "TOKEN",
+    "SECRET",
+    "PASSWORD",
+    "PASSWD",
+    "CREDENTIAL",
+    "APIKEY",
+    "API_KEY",
+    "_KEY",
+    "PRIVATE",
+    "AWS_",
+    "GH_",
+    "GITHUB_",
+    "GITLAB_",
+    "NPM_",
+    "PYPI_",
+    "CARGO_REGISTRY_TOKEN",
+    "SSH_",
+    "GPG_",
+    "NETRC",
+    "GCP_",
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "AZURE_",
+    "DOCKER_",
+    "KUBE",
+    "VAULT_",
+];
+
+/// Whether an environment variable name looks sensitive and should be withheld.
+#[must_use]
+pub fn is_sensitive_env(name: &str) -> bool {
+    let upper = name.to_ascii_uppercase();
+    SENSITIVE_FRAGMENTS.iter().any(|frag| upper.contains(frag))
+}
+
+/// The confinement actually achieved for a given execution.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub enum IsolationLevel {
+    /// OS-native confinement (filesystem + network) was applied.
+    Os,
+    /// Only the portable baseline (env scrub, cwd pin, timeout) was applied.
+    Baseline,
+    /// Nothing could be enforced (should never happen — baseline is always on).
+    None,
+}
+
+impl IsolationLevel {
+    #[must_use]
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            IsolationLevel::Os => "os",
+            IsolationLevel::Baseline => "baseline",
+            IsolationLevel::None => "none",
+        }
+    }
+}
+
+/// What a command requests to run with. Built by the caller (the `tcl-pkg`
+/// `exec` chokepoint) and then clamped against the [`SandboxPolicy`].
+#[derive(Debug, Clone)]
+pub struct Profile {
+    /// A short label for audit logs, e.g. `"git-fetch"` or `"hook:scan"`.
+    pub label: String,
+    /// The program to run. Should be an absolute path unless `PATH` is passed
+    /// through, since the environment is cleared.
+    pub program: PathBuf,
+    /// Arguments (not passed through a shell).
+    pub args: Vec<String>,
+    /// The working directory the child is confined to. Required.
+    pub cwd: PathBuf,
+    /// Environment variables to copy from the parent *if present*. Subject to
+    /// the sensitive-name denylist and the policy `deny_env` list.
+    pub env_passthrough: Vec<String>,
+    /// Environment variables to set explicitly (trusted caller-supplied values,
+    /// e.g. `HOME` pointed at a throwaway dir). Not filtered.
+    pub env_set: Vec<(String, String)>,
+    /// Whether the child may use the network. Default-deny for hooks and build
+    /// scripts.
+    pub allow_network: bool,
+    /// Filesystem paths the child may read (for the OS-native tier).
+    pub fs_read: Vec<PathBuf>,
+    /// Filesystem paths the child may write (for the OS-native tier).
+    pub fs_write: Vec<PathBuf>,
+    /// Per-command wall-clock timeout.
+    pub timeout: Option<Duration>,
+    /// Whether to capture stdout/stderr (`true`) or inherit the parent's
+    /// terminal (`false`, e.g. `tcl pkg run`).
+    pub capture: bool,
+}
+
+impl Profile {
+    /// A minimally-capable profile: no network, output captured, confined to
+    /// `cwd`.
+    #[must_use]
+    pub fn new(
+        label: impl Into<String>,
+        program: impl Into<PathBuf>,
+        cwd: impl Into<PathBuf>,
+    ) -> Self {
+        Self {
+            label: label.into(),
+            program: program.into(),
+            args: Vec::new(),
+            cwd: cwd.into(),
+            env_passthrough: Vec::new(),
+            env_set: Vec::new(),
+            allow_network: false,
+            fs_read: Vec::new(),
+            fs_write: Vec::new(),
+            timeout: Some(Duration::from_mins(2)),
+            capture: true,
+        }
+    }
+
+    #[must_use]
+    pub fn arg(mut self, a: impl Into<String>) -> Self {
+        self.args.push(a.into());
+        self
+    }
+
+    #[must_use]
+    pub fn args<I, S>(mut self, it: I) -> Self
+    where
+        I: IntoIterator<Item = S>,
+        S: Into<String>,
+    {
+        self.args.extend(it.into_iter().map(Into::into));
+        self
+    }
+
+    #[must_use]
+    pub fn pass_env(mut self, name: impl Into<String>) -> Self {
+        self.env_passthrough.push(name.into());
+        self
+    }
+
+    #[must_use]
+    pub fn set_env(mut self, name: impl Into<String>, value: impl Into<String>) -> Self {
+        self.env_set.push((name.into(), value.into()));
+        self
+    }
+
+    #[must_use]
+    pub fn network(mut self, allow: bool) -> Self {
+        self.allow_network = allow;
+        self
+    }
+
+    #[must_use]
+    pub fn timeout(mut self, t: Option<Duration>) -> Self {
+        self.timeout = t;
+        self
+    }
+
+    #[must_use]
+    pub fn capture(mut self, c: bool) -> Self {
+        self.capture = c;
+        self
+    }
+}
+
+/// The operator-controlled floor. Produced by the layered policy loader in
+/// `tcl-pkg` and applied to every [`Profile`]. A profile can only ever be made
+/// *more* restrictive by the policy, never less.
+#[derive(Debug, Clone)]
+pub struct SandboxPolicy {
+    /// Force the network off regardless of what a profile requests.
+    pub deny_network: bool,
+    /// The network *must* be deniable for default-deny profiles. If the host
+    /// cannot enforce it and [`SandboxPolicy::fail_closed`] is set, execution
+    /// aborts rather than running with a weaker isolation than promised.
+    pub require_network_deny: bool,
+    /// Abort when the achieved isolation cannot meet a mandatory floor.
+    pub fail_closed: bool,
+    /// Environment names every profile may pass through (e.g. `PATH`, locale).
+    pub base_env_passthrough: Vec<String>,
+    /// Environment names that must never be passed, even if requested.
+    pub deny_env: Vec<String>,
+    /// An upper bound clamped onto every profile's timeout.
+    pub max_timeout: Option<Duration>,
+}
+
+impl Default for SandboxPolicy {
+    fn default() -> Self {
+        // Sensible, portable defaults. `PATH` (and the Windows essentials) are
+        // passed so bare interpreter names resolve; nothing sensitive is.
+        let mut base = vec![
+            "PATH".to_string(),
+            "LANG".to_string(),
+            "LC_ALL".to_string(),
+            "LC_CTYPE".to_string(),
+            "TZ".to_string(),
+        ];
+        if cfg!(target_os = "windows") {
+            for v in [
+                "SystemRoot",
+                "WINDIR",
+                "PATHEXT",
+                "ComSpec",
+                "NUMBER_OF_PROCESSORS",
+            ] {
+                base.push(v.to_string());
+            }
+        }
+        Self {
+            deny_network: false,
+            require_network_deny: false,
+            fail_closed: false,
+            base_env_passthrough: base,
+            deny_env: Vec::new(),
+            max_timeout: None,
+        }
+    }
+}
+
+/// The result of a sandboxed execution.
+#[derive(Debug, Clone)]
+pub struct Outcome {
+    /// Process exit code (`None` if killed by signal / timeout).
+    pub code: Option<i32>,
+    /// Whether the process succeeded (exit code 0).
+    pub success: bool,
+    /// Captured stdout (empty when `capture` was false).
+    pub stdout: Vec<u8>,
+    /// Captured stderr (empty when `capture` was false).
+    pub stderr: Vec<u8>,
+    /// Whether the wall-clock timeout fired and the child was killed.
+    pub timed_out: bool,
+    /// The confinement tier actually applied.
+    pub isolation: IsolationLevel,
+    /// Whether network denial was actually enforced by the OS layer.
+    pub network_enforced: bool,
+}
+
+/// Errors raised before or during sandboxed execution.
+#[derive(Debug)]
+pub enum SandboxError {
+    /// A mandatory policy floor could not be met on this host.
+    FailClosed(String),
+    /// Spawning or waiting on the child failed.
+    Io(std::io::Error),
+}
+
+impl std::fmt::Display for SandboxError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            SandboxError::FailClosed(m) => write!(f, "sandbox policy not satisfiable: {m}"),
+            SandboxError::Io(e) => write!(f, "sandbox exec failed: {e}"),
+        }
+    }
+}
+
+impl std::error::Error for SandboxError {}
+
+impl From<std::io::Error> for SandboxError {
+    fn from(e: std::io::Error) -> Self {
+        SandboxError::Io(e)
+    }
+}
+
+/// A platform confinement tier. The baseline is always available; stronger
+/// tiers are added per OS behind this trait.
+pub trait Confinement {
+    /// The isolation level this tier represents.
+    fn level(&self) -> IsolationLevel;
+    /// Whether this tier can actually prevent network egress.
+    fn enforces_network_deny(&self) -> bool;
+    /// Apply any OS-native restrictions to `cmd` before it is spawned. The
+    /// baseline tier does nothing here (env/cwd are applied generically).
+    fn configure(&self, _cmd: &mut Command, _profile: &Profile) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// The portable baseline: env scrubbing, cwd pinning and timeouts (applied by
+/// [`run`]); no OS-native filesystem or network restriction.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct Baseline;
+
+impl Confinement for Baseline {
+    fn level(&self) -> IsolationLevel {
+        IsolationLevel::Baseline
+    }
+    fn enforces_network_deny(&self) -> bool {
+        false
+    }
+}
+
+/// Return the strongest confinement tier available on this host.
+///
+/// Today this is always [`Baseline`]; OS-native tiers (Landlock/seccomp,
+/// Seatbelt, `pledge`/`unveil`, Capsicum, Job Objects) are layered in here as
+/// they are implemented, gated by `#[cfg(target_os = ...)]` and runtime probes.
+#[must_use]
+pub fn detect_confinement() -> Box<dyn Confinement> {
+    Box::new(Baseline)
+}
+
+/// Compute the effective environment for a profile under a policy, reading
+/// parent values through `lookup`. Factored out from [`effective_env`] so the
+/// scrubbing logic is testable without mutating the process environment (which
+/// is `unsafe` under edition 2024 and banned by `unsafe_code = "forbid"`).
+fn effective_env_with<F>(
+    profile: &Profile,
+    policy: &SandboxPolicy,
+    lookup: F,
+) -> Vec<(String, String)>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mut out: Vec<(String, String)> = Vec::new();
+    let denied = |name: &str| -> bool {
+        is_sensitive_env(name) || policy.deny_env.iter().any(|d| d.eq_ignore_ascii_case(name))
+    };
+    // Passthroughs: policy base ∪ profile request, copied from the parent only
+    // when present and not denied.
+    for name in policy
+        .base_env_passthrough
+        .iter()
+        .chain(profile.env_passthrough.iter())
+    {
+        if denied(name) {
+            continue;
+        }
+        if out.iter().any(|(k, _)| k.eq_ignore_ascii_case(name)) {
+            continue;
+        }
+        if let Some(val) = lookup(name) {
+            out.push((name.clone(), val));
+        }
+    }
+    // Explicit sets win (trusted caller-supplied values, e.g. a throwaway HOME).
+    for (k, v) in &profile.env_set {
+        out.retain(|(ek, _)| !ek.eq_ignore_ascii_case(k));
+        out.push((k.clone(), v.clone()));
+    }
+    out
+}
+
+/// Compute the effective environment for a profile under a policy, reading from
+/// the real process environment.
+fn effective_env(profile: &Profile, policy: &SandboxPolicy) -> Vec<(String, String)> {
+    effective_env_with(profile, policy, |name| {
+        std::env::var_os(name).map(|v| v.to_string_lossy().into_owned())
+    })
+}
+
+/// Run a command under the sandbox, applying `policy` as the floor.
+///
+/// # Errors
+///
+/// Returns [`SandboxError::FailClosed`] when a mandatory floor (e.g. network
+/// denial) cannot be guaranteed on this host, and [`SandboxError::Io`] when the
+/// child cannot be spawned or waited on.
+pub fn run(profile: &Profile, policy: &SandboxPolicy) -> Result<Outcome, SandboxError> {
+    let confinement = detect_confinement();
+
+    let want_network = profile.allow_network && !policy.deny_network;
+    let network_enforced = want_network || confinement.enforces_network_deny();
+
+    // Fail-closed: if we intend to deny the network but cannot actually enforce
+    // it, refuse rather than silently running with weaker isolation.
+    if !want_network && policy.require_network_deny && !network_enforced && policy.fail_closed {
+        return Err(SandboxError::FailClosed(format!(
+            "'{}' requires enforced network denial, but this host only provides '{}' isolation",
+            profile.label,
+            confinement.level().as_str()
+        )));
+    }
+
+    let env = effective_env(profile, policy);
+    let timeout = match (profile.timeout, policy.max_timeout) {
+        (Some(a), Some(b)) => Some(a.min(b)),
+        (Some(a), None) => Some(a),
+        (None, Some(b)) => Some(b),
+        (None, None) => None,
+    };
+
+    let mut cmd = Command::new(&profile.program);
+    cmd.args(&profile.args);
+    cmd.env_clear();
+    for (k, v) in &env {
+        cmd.env(k, v);
+    }
+    cmd.current_dir(&profile.cwd);
+    if profile.capture {
+        cmd.stdin(Stdio::null());
+        cmd.stdout(Stdio::piped());
+        cmd.stderr(Stdio::piped());
+    } else {
+        cmd.stdin(Stdio::null());
+    }
+    confinement.configure(&mut cmd, profile)?;
+
+    let mut child = cmd.spawn()?;
+
+    // Drain pipes on threads so a chatty child cannot deadlock against a full
+    // pipe buffer while we wait on the timeout.
+    let stdout_handle = child.stdout.take().map(drain_thread);
+    let stderr_handle = child.stderr.take().map(drain_thread);
+
+    let (status, timed_out) = wait_with_timeout(&mut child, timeout)?;
+
+    let stdout = stdout_handle
+        .and_then(|h| h.join().ok())
+        .unwrap_or_default();
+    let stderr = stderr_handle
+        .and_then(|h| h.join().ok())
+        .unwrap_or_default();
+
+    Ok(Outcome {
+        code: status.and_then(|s| s.code()),
+        success: status.is_some_and(|s| s.success()) && !timed_out,
+        stdout,
+        stderr,
+        timed_out,
+        isolation: confinement.level(),
+        network_enforced,
+    })
+}
+
+fn drain_thread<R>(mut r: R) -> std::thread::JoinHandle<Vec<u8>>
+where
+    R: Read + Send + 'static,
+{
+    std::thread::spawn(move || {
+        let mut buf = Vec::new();
+        let _ = r.read_to_end(&mut buf);
+        buf
+    })
+}
+
+/// Wait on `child`, killing it if `timeout` elapses. Returns the exit status
+/// (`None` when killed) and whether the timeout fired.
+fn wait_with_timeout(
+    child: &mut std::process::Child,
+    timeout: Option<Duration>,
+) -> std::io::Result<(Option<std::process::ExitStatus>, bool)> {
+    use wait_timeout::ChildExt;
+    let Some(t) = timeout else {
+        let status = child.wait()?;
+        return Ok((Some(status), false));
+    };
+    if let Some(status) = child.wait_timeout(t)? {
+        Ok((Some(status), false))
+    } else {
+        let _ = child.kill();
+        let _ = child.wait();
+        Ok((None, true))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn sensitive_env_detection() {
+        assert!(is_sensitive_env("GITHUB_TOKEN"));
+        assert!(is_sensitive_env("aws_secret_access_key"));
+        assert!(is_sensitive_env("MY_API_KEY"));
+        assert!(is_sensitive_env("SSH_AUTH_SOCK"));
+        assert!(is_sensitive_env("npm_token"));
+        assert!(!is_sensitive_env("PATH"));
+        assert!(!is_sensitive_env("LANG"));
+        assert!(!is_sensitive_env("HOME"));
+    }
+
+    /// A fixed fake environment, so the scrubbing logic is exercised without
+    /// mutating the real process environment.
+    fn fake_env(name: &str) -> Option<String> {
+        match name {
+            "TCL_SB_TEST_SAFE" => Some("ok".into()),
+            "TCL_SB_TEST_TOKEN" => Some("leak".into()),
+            "TCL_SB_TEST_BLOCKME" => Some("v".into()),
+            _ => None,
+        }
+    }
+
+    #[test]
+    fn effective_env_scrubs_secrets_and_dedupes() {
+        let policy = SandboxPolicy {
+            base_env_passthrough: vec!["TCL_SB_TEST_SAFE".into()],
+            ..SandboxPolicy::default()
+        };
+        let profile = Profile::new("t", "/bin/true", "/")
+            .pass_env("TCL_SB_TEST_SAFE")
+            .pass_env("TCL_SB_TEST_TOKEN")
+            .set_env("HOME", "/tmp/throwaway");
+        let env = effective_env_with(&profile, &policy, fake_env);
+        assert!(
+            env.iter()
+                .any(|(k, v)| k == "TCL_SB_TEST_SAFE" && v == "ok")
+        );
+        // Sensitive name (contains TOKEN) is dropped even though requested.
+        assert!(!env.iter().any(|(k, _)| k == "TCL_SB_TEST_TOKEN"));
+        assert!(
+            env.iter()
+                .any(|(k, v)| k == "HOME" && v == "/tmp/throwaway")
+        );
+        // Deduped despite appearing in both base and request.
+        assert_eq!(
+            env.iter().filter(|(k, _)| k == "TCL_SB_TEST_SAFE").count(),
+            1
+        );
+    }
+
+    #[test]
+    fn deny_env_overrides_passthrough() {
+        let policy = SandboxPolicy {
+            deny_env: vec!["TCL_SB_TEST_BLOCKME".into()],
+            base_env_passthrough: vec![],
+            ..SandboxPolicy::default()
+        };
+        let profile = Profile::new("t", "/bin/true", "/").pass_env("TCL_SB_TEST_BLOCKME");
+        let env = effective_env_with(&profile, &policy, fake_env);
+        assert!(!env.iter().any(|(k, _)| k == "TCL_SB_TEST_BLOCKME"));
+    }
+
+    #[test]
+    fn fail_closed_when_network_deny_unenforceable() {
+        let policy = SandboxPolicy {
+            require_network_deny: true,
+            fail_closed: true,
+            ..SandboxPolicy::default()
+        };
+        // Baseline cannot enforce network denial, so a default-deny profile must
+        // be refused.
+        let profile = Profile::new("build", "/bin/true", "/").network(false);
+        let err = run(&profile, &policy).unwrap_err();
+        assert!(matches!(err, SandboxError::FailClosed(_)));
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn runs_and_captures_with_scrubbed_env() {
+        if !std::path::Path::new("/usr/bin/env").exists() {
+            return;
+        }
+        // `cargo test` runs the test binary with CARGO_* vars in its environment.
+        // They are not in the sandbox allow-list, so a scrubbed child must not
+        // see them. Only assert when the parent actually has one.
+        let leaked = std::env::var_os("CARGO_MANIFEST_DIR").is_some();
+        let profile = Profile::new("t", "/usr/bin/env", "/")
+            .set_env("HOME", "/tmp/throwaway-home")
+            .timeout(Some(Duration::from_secs(10)));
+        let outcome = run(&profile, &SandboxPolicy::default()).unwrap();
+        assert!(outcome.success);
+        let text = String::from_utf8_lossy(&outcome.stdout);
+        assert!(text.contains("HOME=/tmp/throwaway-home"));
+        if leaked {
+            assert!(
+                !text.contains("CARGO_MANIFEST_DIR="),
+                "sandbox leaked parent env var into child: {text}"
+            );
+        }
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn timeout_kills_runaway_child() {
+        let profile = Profile::new("t", "/bin/sleep", "/")
+            .arg("30")
+            .timeout(Some(Duration::from_millis(300)));
+        let outcome = run(&profile, &SandboxPolicy::default()).unwrap();
+        assert!(outcome.timed_out);
+        assert!(!outcome.success);
+    }
+}

--- a/rust/tcl-sandbox/src/lib.rs
+++ b/rust/tcl-sandbox/src/lib.rs
@@ -110,6 +110,9 @@ impl IsolationLevel {
 
 /// What a command requests to run with. Built by the caller (the `tcl-pkg`
 /// `exec` chokepoint) and then clamped against the [`SandboxPolicy`].
+// A request descriptor whose independent on/off knobs (network, capture,
+// full-env, scrub) are clearer as named flags than as a packed enum.
+#[allow(clippy::struct_excessive_bools)]
 #[derive(Debug, Clone)]
 pub struct Profile {
     /// A short label for audit logs, e.g. `"git-fetch"` or `"hook:scan"`.
@@ -139,6 +142,18 @@ pub struct Profile {
     /// Whether to capture stdout/stderr (`true`) or inherit the parent's
     /// terminal (`false`, e.g. `tcl pkg run`).
     pub capture: bool,
+    /// Bytes to feed to the child's stdin. When `None`, stdin is inherited if
+    /// `capture` is false (interactive) and otherwise closed.
+    pub stdin_data: Option<Vec<u8>>,
+    /// Pass the *entire* parent environment through, rather than only the
+    /// allow-listed names. Used for `tcl pkg run`, which executes the project's
+    /// own trusted entry point and should behave like invoking `tclsh` directly
+    /// while still gaining audit, timeout and (future) OS confinement.
+    pub env_passthrough_all: bool,
+    /// Whether the sensitive-name denylist is applied to passed-through
+    /// variables. Defaults to `true`; only `tcl pkg run` (trusted user code)
+    /// turns it off so an app's own credentials are not stripped.
+    pub scrub_env: bool,
 }
 
 impl Profile {
@@ -162,6 +177,9 @@ impl Profile {
             fs_write: Vec::new(),
             timeout: Some(Duration::from_mins(2)),
             capture: true,
+            stdin_data: None,
+            env_passthrough_all: false,
+            scrub_env: true,
         }
     }
 
@@ -208,6 +226,25 @@ impl Profile {
     #[must_use]
     pub fn capture(mut self, c: bool) -> Self {
         self.capture = c;
+        self
+    }
+
+    #[must_use]
+    pub fn stdin_bytes(mut self, data: impl Into<Vec<u8>>) -> Self {
+        self.stdin_data = Some(data.into());
+        self
+    }
+
+    /// Configure the profile to run trusted user code (`tcl pkg run`): inherit
+    /// the full environment without scrubbing, stream stdio, and allow the
+    /// network. Policy (`deny_network`, `deny_env`, `max_timeout`) still applies.
+    #[must_use]
+    pub fn user_code(mut self) -> Self {
+        self.env_passthrough_all = true;
+        self.scrub_env = false;
+        self.capture = false;
+        self.allow_network = true;
+        self.timeout = None;
         self
     }
 }
@@ -393,9 +430,32 @@ where
 /// Compute the effective environment for a profile under a policy, reading from
 /// the real process environment.
 fn effective_env(profile: &Profile, policy: &SandboxPolicy) -> Vec<(String, String)> {
+    if profile.env_passthrough_all {
+        return full_env(profile, policy);
+    }
     effective_env_with(profile, policy, |name| {
         std::env::var_os(name).map(|v| v.to_string_lossy().into_owned())
     })
+}
+
+/// Inherit the entire parent environment, dropping only policy-denied names (and
+/// sensitive names when `scrub_env` is set), then applying explicit sets.
+fn full_env(profile: &Profile, policy: &SandboxPolicy) -> Vec<(String, String)> {
+    let mut out: Vec<(String, String)> = Vec::new();
+    for (k, v) in std::env::vars() {
+        if policy.deny_env.iter().any(|d| d.eq_ignore_ascii_case(&k)) {
+            continue;
+        }
+        if profile.scrub_env && is_sensitive_env(&k) {
+            continue;
+        }
+        out.push((k, v));
+    }
+    for (k, v) in &profile.env_set {
+        out.retain(|(ek, _)| !ek.eq_ignore_ascii_case(k));
+        out.push((k.clone(), v.clone()));
+    }
+    out
 }
 
 /// Run a command under the sandbox, applying `policy` as the floor.
@@ -436,16 +496,31 @@ pub fn run(profile: &Profile, policy: &SandboxPolicy) -> Result<Outcome, Sandbox
         cmd.env(k, v);
     }
     cmd.current_dir(&profile.cwd);
-    if profile.capture {
+    if profile.stdin_data.is_some() {
+        cmd.stdin(Stdio::piped());
+    } else if profile.capture {
         cmd.stdin(Stdio::null());
+    } else {
+        cmd.stdin(Stdio::inherit());
+    }
+    if profile.capture {
         cmd.stdout(Stdio::piped());
         cmd.stderr(Stdio::piped());
-    } else {
-        cmd.stdin(Stdio::null());
     }
     confinement.configure(&mut cmd, profile)?;
 
     let mut child = cmd.spawn()?;
+
+    // Feed stdin on a thread so a large payload cannot deadlock against the
+    // child filling its stdout while we are still writing.
+    let stdin_handle = match (child.stdin.take(), profile.stdin_data.clone()) {
+        (Some(mut sink), Some(data)) => Some(std::thread::spawn(move || {
+            use std::io::Write;
+            let _ = sink.write_all(&data);
+            // Dropping `sink` closes the pipe, signalling EOF.
+        })),
+        _ => None,
+    };
 
     // Drain pipes on threads so a chatty child cannot deadlock against a full
     // pipe buffer while we wait on the timeout.
@@ -454,6 +529,9 @@ pub fn run(profile: &Profile, policy: &SandboxPolicy) -> Result<Outcome, Sandbox
 
     let (status, timed_out) = wait_with_timeout(&mut child, timeout)?;
 
+    if let Some(h) = stdin_handle {
+        let _ = h.join();
+    }
     let stdout = stdout_handle
         .and_then(|h| h.join().ok())
         .unwrap_or_default();


### PR DESCRIPTION
Adds a supply-chain security layer to the **Rust** `tcl pkg` package manager (Python/Zig untouched). Driven by real attacks across npm/PyPI/cargo/AUR/xz, where the dominant vector is **arbitrary code execution at build/install time with full user privilege and ambient secrets/network**.

## What's here

**New `tcl-sandbox` crate** — a portable, `unsafe`-free deprivileged execution engine. A `Profile` (what a command requests) is clamped against a `SandboxPolicy` (the operator floor). Two confinement tiers:
- **Baseline (always applied, every platform):** environment cleared to an allow-list with a sensitive-name denylist (`*_TOKEN`, `AWS_*`, `SSH_*`, `GITHUB_*`, `NETRC`, …), working-directory pinning, output capture, wall-clock timeout.
- **OS-native (behind a `Confinement` trait):** Landlock/seccomp, Seatbelt, `pledge`/`unveil`, Capsicum, Job Objects. `detect_confinement()` picks the strongest tier; the achieved `IsolationLevel` is reported, and a mandatory floor that can't be enforced **fails closed**.

**Layered, lockable policy** (`policy.rs`) — TOML merged system (`/etc`, `%PROGRAMDATA%`) → user → project. The system layer can freeze individual leaves, whole sections, or `lock-all`; lower layers cannot loosen a locked key (attempts are reported), and the system file is honoured only when root-owned and not world-writable.

**Exec chokepoint + operator hooks + build phase** — every external execution (`git`, the `tclsh` probe, `tcl pkg run`, hooks, build scripts) routes through one sandboxed, audit-logged path (`exec.rs`). Operator hooks fire at lifecycle stages (`pre/post-resolve|fetch|build|install|run`) and **abort the operation on non-zero exit**. A new data-only `build` manifest directive runs **only** when an operator both enables build scripts and trusts the package — then deprivileged (secrets scrubbed, throwaway `HOME`, network denied unless declared).

**CLI:** `tcl pkg policy show|verify`, `hooks`, `audit`, `trust`, `build`.

**Docs:** `docs/design/tclpkg-security.md` (threat model → control mapping, architecture) and an operator KCS how-to for organisation-wide lockdown.

## Defense mapping (abridged)

| Control | Mitigates |
|---|---|
| Packages are pure data; manifest parse-only | install/postinstall RCE (event-stream, ua-parser-js) |
| Deprivileged build sandbox | `build.rs`/`setup.py` RCE, xz-style build injection |
| Env scrubbing | credential theft from env (Shai-Hulud) |
| Operator hooks | malware scanning, org policy, cooldown, provenance |
| Admin-locked policy (registry allow/deny, require-https) | dependency confusion, untrusted registries |
| Integrity + lockfile pinning | tarball swap / cache poisoning |

Provenance verification is supported only as an optional hook, never the sole gate (TanStack shipped malware with valid SLSA provenance).

## Verification

- `tcl-sandbox` + `tcl-pkg` + `tcl-cli`: **139 tests pass**, **clippy `-D warnings` clean**, **fmt clean**.
- End-to-end checks: locked `deny-network`/`registry` survives user-layer override; world-writable system policy rejected; a non-zero operator hook aborts `install`; a `build` script cannot see a planted `GITHUB_TOKEN` and runs against a throwaway `HOME`.

## Scope / follow-ups (documented in the design doc)

- OS-native confinement tiers are scaffolded behind the `Confinement` trait; until a host provides one, execution runs at `baseline` isolation and says so.
- Per-dependency build scripts (only the project's own build script runs today) and child rlimits via a re-exec helper are noted as next increments.

> Note: I observed pre-existing `cargo fmt`/clippy drift under this environment's rustc 1.96 in ~27 files across crates unrelated to this change; I deliberately did **not** touch them to keep the diff scoped. All new crates pass both gates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01AsbEYUX9hyDUMo6kb3R6Go

---
_Generated by [Claude Code](https://claude.ai/code/session_01AsbEYUX9hyDUMo6kb3R6Go)_