### PR TITLE
Restore cargo-deny to green: pyo3 0.29, license allows, wildcard-path bans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2050,9 +2050,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+checksum = "cd274650b21d4bfc26a0a47587962c1edb425f69287324355cd040c3ea66071c"
 dependencies = [
  "libc",
  "once_cell",
@@ -2064,18 +2064,18 @@ dependencies = [
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+checksum = "c5e2a7d2f0d013342f295c048ad19237add5154a55b1c5a254c0ec93d4109078"
 dependencies = [
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+checksum = "ca85c467da1bbc8d866eea5deff9cf29ea5f7785054a17da36e65bda9c05845b"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -2083,9 +2083,9 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+checksum = "9ac53762fd065daa3194dd09337a38bd793a188100fd1a9304c4ab312d901771"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
@@ -2095,13 +2095,12 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.28.3"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+checksum = "4ca3a1557399783172dc5bf39cfca835157732532cba56b71d2292161e53b362"
 dependencies = [
  "heck",
  "proc-macro2",
- "pyo3-build-config",
  "quote",
  "syn 2.0.117",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -95,6 +95,7 @@ exclude = [
 ]
 
 [workspace.package]
+publish = false
 version = "0.1.0"
 edition = "2024"
 # 2024 is the current Rust edition (editions ship ~every 3 years: 2015 / 2018 /

--- a/deny.toml
+++ b/deny.toml
@@ -23,7 +23,12 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-ignore = []
+ignore = [
+    # `proc-macro-error2` (build-time only, via `tabled` -> `tcl-cli-support`) is
+    # flagged unmaintained with no safe upgrade available; the `tabled` derive is
+    # the only consumer and runs at compile time, so the runtime risk is nil.
+    "RUSTSEC-2026-0173",
+]
 
 # --------------------------------------------------------------------
 # 2. License policy.  The workspace itself is AGPL-3.0-or-later, so
@@ -49,6 +54,12 @@ allow = [
     "AGPL-3.0-or-later",
     # OpenSSL is sometimes pulled in transitively (LibreSSL flavour ok).
     "OpenSSL",
+    # `tower-lsp-server`'s `ls-types` pulls `borrow-or-share` under MIT-0
+    # (MIT No Attribution) — a strictly more permissive MIT.
+    "MIT-0",
+    # `ureq`'s `webpki-roots` ships the Mozilla CA set under the permissive
+    # Community Data License Agreement (data, not code).
+    "CDLA-Permissive-2.0",
 ]
 confidence-threshold = 0.93
 exceptions = []
@@ -69,6 +80,10 @@ license-files = [
 [bans]
 multiple-versions = "warn"
 wildcards = "deny"
+# Internal workspace crates are referenced by `path` with no version, which
+# `wildcards = "deny"` would otherwise reject — only published wildcard versions
+# are a real hazard.
+allow-wildcard-paths = true
 highlight = "all"
 workspace-default-features = "allow"
 external-default-features = "allow"

--- a/rust/bpf-tcl-codegen/Cargo.toml
+++ b/rust/bpf-tcl-codegen/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "bpf-tcl-codegen"
+publish.workspace = true
 description = "eBPF (and later WASM) code generation for the BPF-Tcl DSL"
 version.workspace = true
 edition.workspace = true

--- a/rust/bpf-tcl-ir/Cargo.toml
+++ b/rust/bpf-tcl-ir/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "bpf-tcl-ir"
+publish.workspace = true
 description = "Typed, backend-agnostic mid-IR and framework front-end for the BPF-Tcl DSL"
 version.workspace = true
 edition.workspace = true

--- a/rust/bpf-tcl/Cargo.toml
+++ b/rust/bpf-tcl/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "bpf-tcl"
+publish.workspace = true
 description = "BPF-Tcl compiler CLI and userspace eBPF run harness"
 version.workspace = true
 edition.workspace = true

--- a/rust/f5-cli/Cargo.toml
+++ b/rust/f5-cli/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "f5-cli"
+publish.workspace = true
 description = "The `f5-query` BIG-IP / iRules CLI"
 version.workspace = true
 edition.workspace = true

--- a/rust/f5-xc/Cargo.toml
+++ b/rust/f5-xc/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "f5-xc"
+publish.workspace = true
 description = "iRule → F5 Distributed Cloud (XC) static translator and XC-translatability diagnostics"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-bigip-io/Cargo.toml
+++ b/rust/tcl-bigip-io/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-bigip-io"
+publish.workspace = true
 description = "Pure-Rust f5 input layer: UCS (gzip-tar + OpenPGP-symmetric) archives and the read_path/load_paths resolver"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-bigip-query/Cargo.toml
+++ b/rust/tcl-bigip-query/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-bigip-query"
+publish.workspace = true
 description = "The F5 BIG-IP query DSL: the jq-flavoured language powering `f5 query` (lexer, parser, evaluator, projection, builtins)."
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-bigip/Cargo.toml
+++ b/rust/tcl-bigip/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-bigip"
+publish.workspace = true
 description = "The F5 BIG-IP object model and config parser"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-bytecode/Cargo.toml
+++ b/rust/tcl-bytecode/Cargo.toml
@@ -16,6 +16,7 @@
 # wasm32-clean leaf.
 [package]
 name = "tcl-bytecode"
+publish.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/tcl-cli-support/Cargo.toml
+++ b/rust/tcl-cli-support/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-cli-support"
+publish.workspace = true
 description = "Shared CLI plumbing for the native tcl / f5 CLIs (input/output, dialect registries)"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-cli/Cargo.toml
+++ b/rust/tcl-cli/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-cli"
+publish.workspace = true
 description = "The unified `tcl` toolchain CLI"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-cmd-core/Cargo.toml
+++ b/rust/tcl-cmd-core/Cargo.toml
@@ -17,6 +17,7 @@
 # `tcl-bytecode` or a concrete runtime.
 [package]
 name = "tcl-cmd-core"
+publish.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/tcl-compiler/Cargo.toml
+++ b/rust/tcl-compiler/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-compiler"
+publish.workspace = true
 description = "IR, CFG, SSA, and codegen for the Tcl compiler pipeline"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-core-types/Cargo.toml
+++ b/rust/tcl-core-types/Cargo.toml
@@ -12,6 +12,7 @@
 # diamond).
 [package]
 name = "tcl-core-types"
+publish.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/tcl-debugger/Cargo.toml
+++ b/rust/tcl-debugger/Cargo.toml
@@ -11,6 +11,7 @@
 # info (tracked under RT-VM) — see the `backend` module.
 [package]
 name = "tcl-debugger"
+publish.workspace = true
 description = "Step debugger for the native Tcl VM: breakpoints, step-mode controller, backend contract"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-explorer-wasm/Cargo.toml
+++ b/rust/tcl-explorer-wasm/Cargo.toml
@@ -6,6 +6,7 @@
 # Built via `make explorer-wasm` (wasm-pack + wasm-opt); see the Makefile.
 [package]
 name = "tcl-explorer-wasm"
+publish.workspace = true
 description = "Rust → WASM compile() facade for the Tcl compiler-explorer GUI"
 version = "0.1.0"
 edition = "2024"

--- a/rust/tcl-explorer/Cargo.toml
+++ b/rust/tcl-explorer/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-explorer"
+publish.workspace = true
 description = "Compiler-explorer pipeline + serialiser over the Tcl compiler crates (CLI / TUI / WASM front-ends consume this)"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-fuzz/Cargo.toml
+++ b/rust/tcl-fuzz/Cargo.toml
@@ -11,6 +11,7 @@
 # campaign.
 [package]
 name = "tcl-fuzz"
+publish.workspace = true
 description = "Differential fuzzer for the native Tcl bytecode VM (tclvm vs tclsh)"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-host-native/Cargo.toml
+++ b/rust/tcl-host-native/Cargo.toml
@@ -9,6 +9,7 @@
 # `std::process`/`std::time`).
 [package]
 name = "tcl-host-native"
+publish.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/tcl-irule-test/Cargo.toml
+++ b/rust/tcl-irule-test/Cargo.toml
@@ -12,6 +12,7 @@
 # Tcl needs — see the `session` module.
 [package]
 name = "tcl-irule-test"
+publish.workspace = true
 description = "iRule test framework: BIG-IP topology → orchestrator setup, and the TMM-sim session driver"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-irules/Cargo.toml
+++ b/rust/tcl-irules/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-irules"
+publish.workspace = true
 description = "The F5 iRules BIG-IP object-reference extractor"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-lexer/Cargo.toml
+++ b/rust/tcl-lexer/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-lexer"
+publish.workspace = true
 description = "Position-aware lexer for Tcl, iRules, and related dialects"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-lsp-core/Cargo.toml
+++ b/rust/tcl-lsp-core/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-lsp-core"
+publish.workspace = true
 description = "Pure Rust LSP feature providers for tcl-lsp (folding, symbols, diagnostics projection)"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-lsp-db/Cargo.toml
+++ b/rust/tcl-lsp-db/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-lsp-db"
+publish.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/tcl-lsp-py/Cargo.toml
+++ b/rust/tcl-lsp-py/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-lsp-py"
+publish.workspace = true
 description = "Public PyO3 bindings exposing the tcl-lsp Rust crates to Python"
 version.workspace = true
 edition.workspace = true
@@ -21,7 +22,7 @@ tcl-compiler = { path = "../tcl-compiler" }
 tcl-lsp-core = { path = "../tcl-lsp-core" }
 tcl-bigip = { path = "../tcl-bigip" }
 tcl-bigip-query = { path = "../tcl-bigip-query" }
-pyo3 = { version = "0.28", features = ["extension-module", "abi3-py310"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py310"] }
 serde_json = "1"
 
 [lints]

--- a/rust/tcl-lsp-rust/Cargo.toml
+++ b/rust/tcl-lsp-rust/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-lsp-rust"
+publish.workspace = true
 description = "Alias for tcl-lsp-py — re-exports the public PyO3 surface under the `tcl_lsp_rust` module name."
 version.workspace = true
 edition.workspace = true
@@ -15,7 +16,7 @@ crate-type = ["cdylib", "rlib"]
 
 [dependencies]
 tcl-lsp-py = { path = "../tcl-lsp-py" }
-pyo3 = { version = "0.28", features = ["extension-module", "abi3-py310"] }
+pyo3 = { version = "0.29", features = ["extension-module", "abi3-py310"] }
 
 [lints]
 workspace = true

--- a/rust/tcl-lsp-server/Cargo.toml
+++ b/rust/tcl-lsp-server/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-lsp-server"
+publish.workspace = true
 description = "Native LSP server for Tcl, built on tower-lsp-server + tcl-lsp-core"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-pkg/Cargo.toml
+++ b/rust/tcl-pkg/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-pkg"
+publish.workspace = true
 description = "The tclpkg package manager: manifest, MVS resolver, lockfile, CAS, fetchers, venv, docker"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-platform/Cargo.toml
+++ b/rust/tcl-platform/Cargo.toml
@@ -15,6 +15,7 @@
 # See `docs/design/common-runtime-emitter-architecture.md` (§ capability model).
 [package]
 name = "tcl-platform"
+publish.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/tcl-regex/Cargo.toml
+++ b/rust/tcl-regex/Cargo.toml
@@ -16,6 +16,7 @@
 # the approximate `regex`-crate path (the bytecode VM).
 [package]
 name = "tcl-regex"
+publish.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/tcl-registry/Cargo.toml
+++ b/rust/tcl-registry/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-registry"
+publish.workspace = true
 description = "Command registry — single source of truth for Tcl command metadata"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-runtime-api/Cargo.toml
+++ b/rust/tcl-runtime-api/Cargo.toml
@@ -7,6 +7,7 @@
 # `docs/design/common-runtime-emitter-architecture.md` (§4f/§4g, Family B).
 [package]
 name = "tcl-runtime-api"
+publish.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/tcl-sandbox/Cargo.toml
+++ b/rust/tcl-sandbox/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "tcl-sandbox"
+publish.workspace = true
 description = "Portable, deprivileged execution sandbox for the tcl package manager: a capability/policy-floor model over a portable baseline (environment scrubbing, working-directory confinement, wall-clock timeouts) with OS-native confinement layered on per platform."
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-syntax/Cargo.toml
+++ b/rust/tcl-syntax/Cargo.toml
@@ -16,6 +16,7 @@
 # convert at the call on the UTF-8-internal-rep invariant.
 [package]
 name = "tcl-syntax"
+publish.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/tcl-vm-cli/Cargo.toml
+++ b/rust/tcl-vm-cli/Cargo.toml
@@ -8,6 +8,7 @@
 # evaluates inline scripts, pipes stdin, and offers an interactive REPL.
 [package]
 name = "tcl-vm-cli"
+publish.workspace = true
 description = "The `tclvm` binary: a CLI/REPL driver for the native Tcl bytecode VM"
 version.workspace = true
 edition.workspace = true

--- a/rust/tcl-vm/Cargo.toml
+++ b/rust/tcl-vm/Cargo.toml
@@ -10,6 +10,7 @@
 # See `docs/design/common-runtime-emitter-architecture.md`.
 [package]
 name = "tcl-vm"
+publish.workspace = true
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true

--- a/rust/xtask/Cargo.toml
+++ b/rust/xtask/Cargo.toml
@@ -1,5 +1,6 @@
 [package]
 name = "xtask"
+publish.workspace = true
 description = "Build/check task runner for the workspace"
 version.workspace = true
 edition.workspace = true


### PR DESCRIPTION
The `cargo-deny` gate on `rust` was red across advisories, licenses, and bans — pre-existing/time-based dependency hygiene, not from any one feature. This restores it.

- **advisories** — bump `pyo3` 0.28 → 0.29, closing RUSTSEC-2026-0176 (OOB read in `PyList`/`PyTuple` `nth`/`nth_back`) and RUSTSEC-2026-0177 (missing `Sync` bound on `PyCFunction::new_closure`); the bindings compile and clippy-clean unchanged against 0.29. Ignore RUSTSEC-2026-0173 (`proc-macro-error2` unmaintained) — a build-time-only transitive dep of `tabled` with no safe upgrade.
- **licenses** — allow `MIT-0` (`tower-lsp-server`'s `ls-types` → `borrow-or-share`) and `CDLA-Permissive-2.0` (the Mozilla CA set in `ureq`'s `webpki-roots`); both strictly permissive.
- **bans (wildcards)** — internal workspace crates reference each other by `path` with no version, which `wildcards = "deny"` rejected. Mark every member crate `publish = false` (never published to crates.io) and set `allow-wildcard-paths = true`, so path wildcards pass while a real published `*` dep still fails.

`cargo deny check bans licenses sources` is verified `ok` locally; the advisories DB isn't fetchable in the sandbox, but all three reported advisories are addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014qcKVFT92bDPhpNogmFmv5)_