### PR TITLE
Drop tabled's derive feature to remove proc-macro-error2 (RUSTSEC-2026-0173)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1995,28 +1995,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
-name = "proc-macro-error-attr2"
-version = "2.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96de42df36bb9bba5542fe9f1a054b8cc87e172759a1868aa05c1f3acc89dfc5"
-dependencies = [
- "proc-macro2",
- "quote",
-]
-
-[[package]]
-name = "proc-macro-error2"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "11ec05c52be0a07b08061f7dd003e7d7092e0472bc731b4af7bb1ef876109802"
-dependencies = [
- "proc-macro-error-attr2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2842,21 +2820,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5dc662e6da844ad6e428ad16b57967c9d33c82e16bb1c258326c0c078605dff"
 dependencies = [
  "papergrid",
- "tabled_derive",
  "testing_table",
-]
-
-[[package]]
-name = "tabled_derive"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ea5d1b13ca6cff1f9231ffd62f15eefd72543dab5e468735f1a456728a02846"
-dependencies = [
- "heck",
- "proc-macro-error2",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]

--- a/deny.toml
+++ b/deny.toml
@@ -23,12 +23,7 @@ version = 2
 db-path = "~/.cargo/advisory-db"
 db-urls = ["https://github.com/rustsec/advisory-db"]
 yanked = "deny"
-ignore = [
-    # `proc-macro-error2` (build-time only, via `tabled` -> `tcl-cli-support`) is
-    # flagged unmaintained with no safe upgrade available; the `tabled` derive is
-    # the only consumer and runs at compile time, so the runtime risk is nil.
-    "RUSTSEC-2026-0173",
-]
+ignore = []
 
 # --------------------------------------------------------------------
 # 2. License policy.  The workspace itself is AGPL-3.0-or-later, so

--- a/rust/tcl-cli-support/Cargo.toml
+++ b/rust/tcl-cli-support/Cargo.toml
@@ -17,7 +17,10 @@ tcl-lsp-core = { path = "../tcl-lsp-core" }
 thiserror = "2"
 anstream = "1"
 anstyle = "1"
-tabled = "0.21"
+# `default-features = false` drops the `derive` feature (and its `tabled_derive`
+# proc-macro, the sole pull of the unmaintained `proc-macro-error2`); the Builder
+# API in `render_table` needs only `std`.
+tabled = { version = "0.21", default-features = false, features = ["std"] }
 rpassword = "7"
 
 [dev-dependencies]

--- a/rust/tcl-cli-support/src/chrome.rs
+++ b/rust/tcl-cli-support/src/chrome.rs
@@ -15,8 +15,6 @@ use std::io::Write;
 
 use anstyle::{AnsiColor, Style};
 
-pub use tabled::Tabled;
-
 /// Style for error prefixes (red, bold).
 #[must_use]
 pub fn error_style() -> Style {
@@ -63,44 +61,35 @@ pub fn eprint_status(style: Style, msg: impl Display) {
     let _ = writeln!(err, "{}{msg}{}", style.render(), style.render_reset());
 }
 
-/// Render `rows` as a table with the project's house style (rounded borders).
+/// Render a table with the project's house style (rounded borders) from a
+/// header row and body rows.
 ///
 /// The single entry point for tabular verbs (`stats`, `registry`, `pkg list`,
-/// …) so every table looks the same. Derive [`Tabled`] on the row type.
+/// …) so every table looks the same. Pass the column headers and one iterator
+/// of cells per row; each cell only needs to be `Into<String>`.
 #[must_use]
-pub fn render_table<T, I>(rows: I) -> String
-where
-    T: Tabled,
-    I: IntoIterator<Item = T>,
-{
+pub fn render_table(
+    headers: impl IntoIterator<Item = impl Into<String>>,
+    rows: impl IntoIterator<Item = impl IntoIterator<Item = impl Into<String>>>,
+) -> String {
+    use tabled::builder::Builder;
     use tabled::settings::Style as TableStyle;
-    tabled::Table::new(rows)
-        .with(TableStyle::rounded())
-        .to_string()
+
+    let mut builder = Builder::new();
+    builder.push_record(headers);
+    for row in rows {
+        builder.push_record(row);
+    }
+    builder.build().with(TableStyle::rounded()).to_string()
 }
 
 #[cfg(test)]
 mod tests {
     use super::{dim_style, error_style, heading_style, render_table, success_style, warn_style};
 
-    #[derive(tabled::Tabled)]
-    struct Row {
-        name: &'static str,
-        count: usize,
-    }
-
     #[test]
     fn render_table_emits_header_rows_and_border() {
-        let table = render_table([
-            Row {
-                name: "pool",
-                count: 3,
-            },
-            Row {
-                name: "node",
-                count: 5,
-            },
-        ]);
+        let table = render_table(["name", "count"], [["pool", "3"], ["node", "5"]]);
         assert!(table.contains("name"), "header present: {table}");
         assert!(
             table.contains("pool") && table.contains('5'),


### PR DESCRIPTION
Turns the `RUSTSEC-2026-0173` ignore that #700 added into a real fix.

The advisory (`proc-macro-error2`, unmaintained) was pulled **only** by `tabled`'s optional `derive` feature → `tabled_derive`. The runtime `tabled` (`papergrid`) is unaffected. The sole use of the derive was one `render_table` helper in `tcl-cli-support`'s chrome module, with no production callers yet — so dropping the derive is contained.

- **`render_table` → Builder API.** Takes column headers + body rows (each cell `Into<String>`) and builds via `tabled::builder::Builder` instead of `#[derive(Tabled)]` + `Table::new`. Same rounded house style; the smoke test is updated to the new signature.
- **`tabled = { default-features = false, features = ["std"] }`** — drops `tabled_derive` (and `proc-macro-error2`) from the dependency tree entirely.
- **Removed the `RUSTSEC-2026-0173` ignore** from `deny.toml`.

### Verification

`cargo tree -i proc-macro-error2` and `cargo tree -i tabled_derive` are both now empty. Green locally: `tcl-cli-support` build + tests, `clippy -D warnings`, `fmt`, both CLI consumers (`tcl-cli`, `f5-cli`) build, and `cargo deny check bans licenses sources` is ok (advisories verify on CI, but the flagged crate is gone so no ignore is needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qcKVFT92bDPhpNogmFmv5

---
_Generated by [Claude Code](https://claude.ai/code/session_014qcKVFT92bDPhpNogmFmv5)_