### PR TITLE
Fix spurious arity error on try handler `-` fallthrough bodies (#703)

### DIFF
--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=5592922-dirty
-head=55929223a79f063f52a5194cebfdc0c6d69e28a4
-date=2026-06-25T10:52:48Z
-fingerprint=0bb58caaf11c087761d140cb7b1673b5850a9d92ac1a2739b7ceb894875cf426
+describe=5a37a70-dirty
+head=5a37a7032a4fdd057aacdbf652f1c591b3b90e07
+date=2026-06-25T11:30:12Z
+fingerprint=f7bb971a7ce42d511a5ee9de66266183469796d61b4438822596549c1fd49afc

--- a/.test-slow.stamp
+++ b/.test-slow.stamp
@@ -3,7 +3,7 @@
 # 'scripts/test-slow-stamp.sh check'.  Only 'fingerprint' is gated on;
 # describe/head/date are informational (they change when this stamp is
 # committed, so they cannot be compared).
-describe=5d2ae37-dirty
-head=5d2ae37a234520e3e0edbbf0f83ffa224fcee07d
-date=2026-06-21T19:41:28Z
-fingerprint=e51d6a7c9b623471070f9ecbb8aa5d71de14e0741b948f04d1d7f35d6144dd21
+describe=5592922-dirty
+head=55929223a79f063f52a5194cebfdc0c6d69e28a4
+date=2026-06-25T10:52:48Z
+fingerprint=0bb58caaf11c087761d140cb7b1673b5850a9d92ac1a2739b7ceb894875cf426

--- a/compiler/cfg.py
+++ b/compiler/cfg.py
@@ -1913,6 +1913,16 @@ class _CFGBuilder:
 
         # Each handler is reachable from body failure (modelled as a
         # non-deterministic branch from the body entry block).
+        #
+        # A ``-`` (fallthrough) handler shares the next non-``-`` handler's
+        # body.  Tcl binds the *matching* handler's variables when running
+        # that shared body in the byte-compiled form, but the *target*
+        # handler's variables in the interpreted form (the two diverge — see
+        # issue #703).  Statically we can't know which handler matched, so the
+        # shared body is analysed with the whole group's variables treated as
+        # defined: the precise over-approximation that avoids a read-before-set
+        # false positive under either binding rule.
+        pending_fallthrough_defs: list[str] = []
         for handler in stmt.handlers:
             handler_block = self._new_block("try_handler")
             # ``block_name`` already gotos ``try_body`` (single successor), so a
@@ -1961,11 +1971,20 @@ class _CFGBuilder:
                         self._exception_edges.append((body_tail, handler_block))
 
             # Emit synthetic defs for handler-bound variables.
-            var_defs: list[str] = []
+            own_defs: list[str] = []
             if handler.var_name:
-                var_defs.append(handler.var_name)
+                own_defs.append(handler.var_name)
             if handler.options_var:
-                var_defs.append(handler.options_var)
+                own_defs.append(handler.options_var)
+            if handler.fallthrough:
+                # Empty body of its own; carry its vars to the shared body.
+                pending_fallthrough_defs.extend(own_defs)
+                var_defs = own_defs
+            else:
+                # Target of any preceding ``-`` chain: its shared body may run
+                # with any group member's vars bound, so define them all here.
+                var_defs = list(dict.fromkeys(pending_fallthrough_defs + own_defs))
+                pending_fallthrough_defs = []
             if var_defs:
                 self._block(handler_block).statements.append(
                     IRCall(range=stmt.range, command="try", defs=tuple(var_defs))

--- a/compiler/inline_uplevel.py
+++ b/compiler/inline_uplevel.py
@@ -545,6 +545,7 @@ def _rewrite_stmt(
                         options_var=handler.options_var,
                         body=h_body,
                         body_range=handler.body_range,
+                        fallthrough=handler.fallthrough,
                     )
                 )
             else:

--- a/compiler/ir.py
+++ b/compiler/ir.py
@@ -379,6 +379,11 @@ class IRTryHandler:
     options_var: str | None  # variable bound to options dict
     body: IRScript
     body_range: Range
+    # ``True`` when the handler body is the literal ``-`` fallthrough
+    # marker: the handler shares the next non-fallthrough handler's
+    # body (Tcl ``try`` semantics, mirroring ``switch``).  ``body`` is
+    # an empty script in that case — the ``-`` is *not* a command call.
+    fallthrough: bool = False
 
 
 @dataclass(frozen=True, slots=True)

--- a/compiler/lowering.py
+++ b/compiler/lowering.py
@@ -1405,17 +1405,28 @@ class _Lowerer:
                 var_list = args[i + 2]
                 handler_body_text = args[i + 3]
                 handler_tok = arg_tokens[i + 3] if i + 3 < len(arg_tokens) else None
+                handler_single = i + 3 < len(arg_single) and arg_single[i + 3]
 
                 # Parse varList to extract result var and options var.
                 var_names = _parse_param_names(var_list)
                 result_var = _normalise_var_name(var_names[0]) if var_names else None
                 options_var = _normalise_var_name(var_names[1]) if len(var_names) > 1 else None
 
-                handler_body = self._lower_body_arg(
-                    handler_body_text,
-                    handler_tok,
-                    namespace=namespace,
-                )
+                # A handler body of literal ``-`` is a fallthrough marker:
+                # the clause shares the next non-``-`` handler's body
+                # (like ``switch``).  Treat it as an empty body rather than
+                # lowering ``-`` as a script — otherwise it compiles to a
+                # zero-arg call of the ``-`` command and trips a spurious
+                # arity error (issue #703).
+                is_fallthrough = handler_single and handler_body_text == "-"
+                if is_fallthrough:
+                    handler_body: IRScript = IRScript()
+                else:
+                    handler_body = self._lower_body_arg(
+                        handler_body_text,
+                        handler_tok,
+                        namespace=namespace,
+                    )
                 handler_range = (
                     range_from_token(handler_tok) if handler_tok is not None else cmd.range
                 )
@@ -1428,6 +1439,7 @@ class _Lowerer:
                         options_var=options_var,
                         body=handler_body,
                         body_range=handler_range,
+                        fallthrough=is_fallthrough,
                     )
                 )
                 i += 4

--- a/dialects/tcl/try_.py
+++ b/dialects/tcl/try_.py
@@ -32,7 +32,11 @@ def _try_arg_roles(args: list[str]) -> dict[int, frozenset[ArgRole]]:
             i += 2
         elif kw in ("on", "trap") and i + 3 < len(args):
             roles[i] = _KEYWORD
-            roles[i + 3] = _BODY
+            # A handler body of literal ``-`` is a fallthrough marker
+            # (shares the next handler's body, like ``switch``); it is
+            # not a script, so it gets no BODY role.
+            if args[i + 3] != "-":
+                roles[i + 3] = _BODY
             i += 4
         else:
             i += 1

--- a/docs/design/compiler/control-flow-patterns.md
+++ b/docs/design/compiler/control-flow-patterns.md
@@ -93,10 +93,19 @@ local variables.  LVT-indexed access is faster than name-based `loadStk`.
 **IR**: `IRSwitch` with `IRSwitchArm` patterns.
 **CFG**: Cascade of `CFGBranch` blocks, one per arm, merging at `switch_end`.
 
+A pattern body of `-` is a fallthrough: the arm shares the next non-`-` arm's
+body. The lowerer marks it `IRSwitchArm.fallthrough=True` with a `None` body.
+
 ### `catch` / `try`
 
 **IR**: `IRCatch` / `IRTry` with `IRTryHandler`.
 **CFG**: Body block + handler blocks, merging after.
+
+An `on`/`trap` handler body of `-` is a fallthrough — the same mechanism
+`switch` uses — sharing the next non-`-` handler's body. The lowerer marks it
+`IRTryHandler.fallthrough=True` with an empty `IRScript` body, so the `-` is
+not mistaken for a zero-argument command call (issue #703). `switch` and `try`
+are the only two Tcl commands with this `-` fallthrough form.
 
 ### Key bytecode conventions matching tclsh
 

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -57,6 +57,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-issue-counter-numtests-array-init.md](kcs-issue-counter-numtests-array-init.md)
   — tcltest's `numTests(Failed)` reads as an empty string in the
   compiled counter-bundle run.
+- [kcs-issue-try-dash-handler-body-false-error.md](kcs-issue-try-dash-handler-body-false-error.md)
+  — a `try` handler with a `-` fallthrough body is wrongly flagged
+  "too few arguments for '-'" (issue #703).
 
 ## Q&A
 

--- a/docs/kcs/kcs-issue-try-dash-handler-body-false-error.md
+++ b/docs/kcs/kcs-issue-try-dash-handler-body-false-error.md
@@ -1,0 +1,103 @@
+# KCS: `try` handler with a `-` body reports a spurious "too few arguments" error
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+all-editors, tcl-lsp-cli, lowering
+
+## Symptom
+
+Reported in issue #703. A `try` command whose `on`/`trap` handler body is a
+bare `-` (a fallthrough marker that shares the *next* handler's body, exactly
+as `switch` shares pattern bodies) was flagged with a false-positive error:
+
+```
+E002  Too few arguments for '-': expected at least 1, got 0
+```
+
+The error landed on the solo `-`, for example the `-` in
+`on ok result - trap NONE result { … }`. The reported position was correct;
+the diagnostic was not. This is valid, working Tcl — it appears in Tcl's own
+`tools/findBadExternals.tcl`:
+
+```tcl
+try {
+    switch $::tcl_platform(platform) {
+        unix - macosx { exec nm --extern-only --defined-only $libtcl }
+        windows       { exec dumpbin /exports $libtcl }
+    }
+} on ok result - trap NONE result {
+    ...
+    return 0
+} on error msg {
+    ...
+    return 1
+}
+```
+
+## Operational context
+
+The lowerer turned every `try` handler body into a nested script. A handler
+body of `-` was therefore lowered as a script containing the single command
+`-`, which the registry knows as the arithmetic-minus operator. With no
+operands, the generic arity check (E002) fired.
+
+Tcl's `TclNRTryObjCmd` (in `tclCmdMZ.c`) recognises a handler body of `-` by
+its string value and treats the clause as a fallthrough: when the clause
+matches, the runtime scans forward to the next handler whose body is not `-`
+and runs that body with that handler's variable bindings. The last
+non-`finally` clause must not be `-` (there is nothing to fall through to). The
+`switch` command uses the same mechanism for pattern bodies, and the lowerer
+already handled `switch` correctly — `try` was the gap.
+
+## Decision rules / contracts
+
+1. A `try` handler body that is the literal `-` (single-token word, including
+   the braced `{-}` form, which evaluates to the same string) is a
+   **fallthrough**, not a script. The lowerer sets
+   [`IRTryHandler.fallthrough`](../../compiler/ir.py) to `True` and gives the
+   handler an empty `IRScript` body, so no command — and therefore no arity
+   check — is synthesised for it.
+2. `dialects/tcl/try_.py`'s `arg_role_resolver` gives a `-` handler body no
+   `ArgRole.BODY`, mirroring `dialects/tcl/switch_.py`. A `-` body is never a
+   nested script for semantic tokens or any other role consumer.
+3. A genuine zero-argument `-` *command* in a real body (a true mistake) is
+   still flagged E002. The suppression is scoped to the handler-body slot, not
+   to the `-` command everywhere.
+4. The set of commands with `-` fallthrough is exactly `{switch, try}` —
+   confirmed against the Tcl 8.4–9.0 C sources. No other Tcl or Tk command
+   uses it.
+5. Like `switch`, the LSP does not flag the invalid "last non-`finally` clause
+   is `-`" case; that rare runtime error is accepted silently rather than
+   mis-reported.
+
+## File-path anchors
+
+- `compiler/lowering.py` — `IRLowerer._lower_try` (fallthrough detection)
+- `compiler/ir.py` — `IRTryHandler.fallthrough`
+- `dialects/tcl/try_.py` — `_try_arg_roles` (no BODY role for `-`)
+- `dialects/tcl/switch_.py` — `_switch_arg_roles` (the mirrored precedent)
+
+## Failure modes
+
+- A future refactor lowers the handler body before checking for `-`, so the
+  arity error returns.
+- The `arg_role_resolver` is changed to mark the `-` body as `BODY` again,
+  re-tagging it as an embedded script for semantic tokens.
+- A new fallthrough-style command is added without the same handling (the
+  investigation found none today, but a future Tcl version could add one).
+
+## Test anchors
+
+- `tests/test_issue_703_try_fallthrough.py` — both sides: the fallthrough `-`
+  (and `{-}`) raises no E002 and lowers to a fallthrough handler with an empty
+  body; a genuine zero-arg `-` command is still flagged.
+
+## Related
+
+- [KCS index](README.md)
+- [control-flow patterns](../design/compiler/control-flow-patterns.md)
+- [`else`/`on`/`trap` keyword highlighting (#637)](kcs-issue-shadowed-builtin-breaks-highlighting.md)
+- [command registry](../design/compiler/command-registry.md)

--- a/tests/test_issue_703_try_fallthrough.py
+++ b/tests/test_issue_703_try_fallthrough.py
@@ -50,6 +50,12 @@ from compiler.ir import IRScript, IRTry
 from compiler.lowering import lower_to_ir
 from server.features.diagnostics import get_diagnostics
 
+
+def _codes(source: str, code: str):
+    """Return diagnostics for *source* with the given code."""
+    return [d for d in get_diagnostics(source) if d.code == code]
+
+
 # The reporter's exact snippet (header comments omitted, as in the issue).
 _ISSUE_SOURCE = """\
 proc main {argc argv} {
@@ -181,6 +187,53 @@ proc p {} {
     def test_genuine_dash_command_outside_try_still_flagged(self):
         # Bare ``-`` as a command in a plain proc body stays an arity error.
         assert len(_e002("proc f {} {\n    -\n}\n")) == 1
+
+    def test_no_false_w210_on_fallthrough_group_var(self):
+        # Codex review follow-up: when a fallthrough handler's var name
+        # differs from the target's, the shared body must not be flagged
+        # W210 for reading either var.  Real Tcl is itself inconsistent
+        # here — a byte-compiled (proc) ``try`` binds the *matching*
+        # handler's var, while the interpreted form binds the *target*'s —
+        # so the shared body is analysed with the whole group's vars
+        # treated as defined.
+        reads_fallthrough_var = """\
+proc p {} {
+    try {set v ok} on ok x - on error y {
+        return $x
+    }
+}
+"""
+        reads_target_var = """\
+proc p {} {
+    try {set v ok} on ok x - on error y {
+        return $y
+    }
+}
+"""
+        assert _codes(reads_fallthrough_var, "W210") == []
+        assert _codes(reads_target_var, "W210") == []
+
+    def test_no_false_w210_in_three_handler_group(self):
+        source = """\
+proc p {} {
+    try {error boom} on ok a - on error b - trap NONE c {
+        return $b
+    }
+}
+"""
+        assert _codes(source, "W210") == []
+
+    def test_genuine_read_before_set_still_fires_in_shared_body(self):
+        # A read of a variable that is *not* bound by any handler in the
+        # group is still a genuine read-before-set.
+        source = """\
+proc p {} {
+    try {set v 1} on ok x - on error y {
+        return $undefinedvar
+    }
+}
+"""
+        assert len(_codes(source, "W210")) == 1
 
     def test_empty_handler_body_is_not_fallthrough(self):
         # A genuinely empty ``{}`` body is valid and distinct from ``-``.

--- a/tests/test_issue_703_try_fallthrough.py
+++ b/tests/test_issue_703_try_fallthrough.py
@@ -1,0 +1,200 @@
+"""Regression test for GitHub issue #703 -- ``try`` handler ``-`` fallthrough.
+
+Issue #703 reported a **false positive**: the body of a ``try`` ``on``/``trap``
+handler may be a bare ``-`` to make the clause share the *next* handler's body
+(the same fallthrough mechanism ``switch`` uses for pattern bodies).  The
+extension wrongly treated every handler body as a script, so the solo ``-`` was
+lowered to a zero-argument call of the ``-`` command and flagged E002
+("Too few arguments for '-': expected at least 1, got 0").
+
+The reporter's working example (``tools/findBadExternals.tcl`` on Tcl's ``main``
+branch) is::
+
+    try {
+        switch $::tcl_platform(platform) {
+            unix - macosx { exec nm --extern-only --defined-only $libtcl }
+            windows       { exec dumpbin /exports $libtcl }
+        }
+    } on ok result - trap NONE result {
+        ...
+        return 0
+    } on error msg {
+        ...
+        return 1
+    }
+
+The fix lives in :func:`compiler.lowering.IRLowerer._lower_try` (a ``-`` handler
+body lowers to an empty :class:`~compiler.ir.IRScript` with
+``IRTryHandler.fallthrough=True`` rather than a ``-`` command call) and in
+``dialects/tcl/try_.py`` (the ``-`` body gets no ``ArgRole.BODY``).
+
+Per the Tcl C source (``TclNRTryObjCmd`` in ``tclCmdMZ.c``), a body of ``-``
+is recognised by string value, so the braced ``{-}`` form is *also* a
+fallthrough -- both are asserted here.  This file asserts **both** sides so the
+wiring can't silently regress:
+
+* **fix holds** -- the fallthrough ``-`` (and ``{-}``) handler body raises no
+  E002, and lowers to a fallthrough handler with an empty body; and
+* **true positive still fires** -- a genuine zero-argument ``-`` *command* call
+  inside a real handler/proc body is still flagged E002.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from compiler.ir import IRScript, IRTry
+from compiler.lowering import lower_to_ir
+from server.features.diagnostics import get_diagnostics
+
+# The reporter's exact snippet (header comments omitted, as in the issue).
+_ISSUE_SOURCE = """\
+proc main {argc argv} {
+    if {$argc != 1} {
+        puts stderr "syntax is: [info script] libtcl"
+        return 1
+    }
+    lassign $argv libtcl
+
+    try {
+        switch $::tcl_platform(platform) {
+            unix - macosx {
+                exec nm --extern-only --defined-only $libtcl
+            }
+            windows {
+                exec dumpbin /exports $libtcl
+            }
+        }
+    } on ok result - trap NONE result {
+        foreach line [split $result \\n] {
+            if {! [string match {* [Tt]cl*} $line]} {
+                puts $line
+            }
+        }
+        return 0
+    } on error msg {
+        puts stderr $msg
+        return 1
+    }
+}
+exit [main $::argc $::argv]
+"""
+
+
+def _e002(source: str):
+    """Return all E002 diagnostics for *source*."""
+    return [d for d in get_diagnostics(source) if d.code == "E002"]
+
+
+def _find_try(script: IRScript) -> IRTry | None:
+    """Depth-first search for the first :class:`IRTry` in *script*."""
+    for stmt in script.statements:
+        if isinstance(stmt, IRTry):
+            return stmt
+        for attr in ("body", "then_body", "else_body", "finally_body"):
+            sub = getattr(stmt, attr, None)
+            if isinstance(sub, IRScript):
+                found = _find_try(sub)
+                if found is not None:
+                    return found
+    return None
+
+
+class TestIssue703TryFallthrough:
+    """#703 -- ``try`` handler body of ``-`` is a fallthrough, not a command."""
+
+    def test_fix_holds_reporter_snippet_has_no_e002(self):
+        # The exact reporter snippet: the solo ``-`` on the
+        # ``on ok result - trap NONE result`` line must not be flagged.
+        assert _e002(_ISSUE_SOURCE) == []
+
+    def test_fallthrough_handler_lowers_to_empty_body(self):
+        ir = lower_to_ir(_ISSUE_SOURCE)
+        stmt = _find_try(ir.procedures["::main"].body)
+        assert stmt is not None, "expected an IRTry in proc main"
+        kinds = [(h.kind, h.match_arg, h.fallthrough) for h in stmt.handlers]
+        assert kinds == [
+            ("on", "ok", True),
+            ("trap", "NONE", False),
+            ("on", "error", False),
+        ]
+        # The fallthrough handler carries no statements of its own; the
+        # shared code lives in the following ``trap NONE`` handler.
+        fall, target = stmt.handlers[0], stmt.handlers[1]
+        assert fall.body.statements == ()
+        assert len(target.body.statements) >= 1
+
+    def test_braced_dash_body_is_also_fallthrough(self):
+        # Per Tcl semantics a body of ``{-}`` evaluates to the string
+        # ``-`` and is equally a fallthrough marker.
+        source = """\
+proc p {} {
+    try {
+        set x 1
+    } on ok a {-} trap NONE b {
+        return $b
+    }
+}
+"""
+        assert _e002(source) == []
+        ir = lower_to_ir(source)
+        stmt = _find_try(ir.procedures["::p"].body)
+        assert stmt is not None
+        assert stmt.handlers[0].fallthrough is True
+        assert stmt.handlers[0].body.statements == ()
+
+    def test_consecutive_fallthrough_handlers(self):
+        # Several ``-`` handlers in a row all share the final body.
+        source = """\
+proc p {} {
+    try {
+        set x 1
+    } on ok a - on return b - trap NONE c {
+        return $c
+    }
+}
+"""
+        assert _e002(source) == []
+        ir = lower_to_ir(source)
+        stmt = _find_try(ir.procedures["::p"].body)
+        assert stmt is not None
+        flags = [h.fallthrough for h in stmt.handlers]
+        assert flags == [True, True, False]
+
+    def test_genuine_dash_command_in_handler_body_still_flagged(self):
+        # A real zero-arg ``-`` *command* inside a handler body is still a
+        # genuine arity error -- the fix must not blunt E002 here.
+        source = """\
+proc p {} {
+    try {
+        set x 1
+    } on error msg {
+        -
+    }
+}
+"""
+        assert len(_e002(source)) == 1
+
+    def test_genuine_dash_command_outside_try_still_flagged(self):
+        # Bare ``-`` as a command in a plain proc body stays an arity error.
+        assert len(_e002("proc f {} {\n    -\n}\n")) == 1
+
+    def test_empty_handler_body_is_not_fallthrough(self):
+        # A genuinely empty ``{}`` body is valid and distinct from ``-``.
+        source = """\
+proc p {} {
+    try {
+        set x 1
+    } on ok a {} on error b {
+        return $b
+    }
+}
+"""
+        assert _e002(source) == []
+        ir = lower_to_ir(source)
+        stmt = _find_try(ir.procedures["::p"].body)
+        assert stmt is not None
+        assert stmt.handlers[0].fallthrough is False


### PR DESCRIPTION
## Summary

Fixes #703.

A `try` `on`/`trap` handler body may be a bare `-` to share the **next** handler's body — the same fallthrough mechanism `switch` uses for pattern bodies. The lowerer treated every handler body as a script, so the solo `-` compiled to a zero-argument call of the `-` command and tripped **E002** (`Too few arguments for '-': expected at least 1, got 0`). This is valid, working Tcl — it appears in Tcl's own `tools/findBadExternals.tcl`:

```tcl
try {
    switch $::tcl_platform(platform) {
        unix - macosx { exec nm --extern-only --defined-only $libtcl }
        windows       { exec dumpbin /exports $libtcl }
    }
} on ok result - trap NONE result {
    ...
    return 0
} on error msg {
    ...
    return 1
}
```

## Fix

- **`compiler/ir.py`** — added `IRTryHandler.fallthrough` (mirrors `IRSwitchArm.fallthrough`).
- **`compiler/lowering.py`** — `_lower_try` now recognises a single-token `-` handler body (including the braced `{-}` form, which evaluates to the same string per Tcl's `TclNRTryObjCmd`) as a fallthrough: it lowers to an empty `IRScript` with `fallthrough=True`, so no `-` command — and no arity check — is synthesised.
- **`dialects/tcl/try_.py`** — withholds the `ArgRole.BODY` role from a `-` body, mirroring `dialects/tcl/switch_.py` (affects semantic tokens and other role consumers).
- **`compiler/inline_uplevel.py`** — preserves the new flag when rewriting handlers during inlining.

A genuine zero-argument `-` *command* in a real body is still flagged E002 — the suppression is scoped to the handler-body slot, not to the `-` command everywhere. `switch` and `try` are the **only** two Tcl commands with this `-` fallthrough form (verified against the 8.4–9.0 C sources; no Tk command uses it).

## Tests & docs

- `tests/test_issue_703_try_fallthrough.py` — 7 tests covering both sides: the fallthrough `-` (and `{-}`, and consecutive fallthroughs) raises no E002 and lowers to a fallthrough handler with an empty body; a genuine zero-arg `-` command is still flagged; an empty `{}` body stays distinct from `-`.
- New KCS issue note (`docs/kcs/kcs-issue-try-dash-handler-body-false-error.md`) + index entry; updated `docs/design/compiler/control-flow-patterns.md`.

## Validation

- `make ci-fast` — **PASS** (the PR CI gate).
- `make test-slow` — **PASS** on every phase, with the committed `.test-slow.stamp` matching the tree. One caveat: `test-ext` (the VS Code extension integration tests) was run via the documented `SKIP_TEST_EXT=1` because the VS Code/Electron binary segfaults on launch in this remote sandbox (it segfaults even on `code --version`) — an environment limitation, not a code issue. This change is Python-only and does not touch the extension; the affected LSP behaviour is covered by the in-process server tests and the LSP e2e suite, which all pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PVPCjeS49w5P3bbzx8F7dm

---
_Generated by [Claude Code](https://claude.ai/code/session_01PVPCjeS49w5P3bbzx8F7dm)_