### PR TITLE
Fix spurious arity error on try handler `-` fallthrough bodies (#703)

### DIFF
--- a/docs/design/compiler/control-flow-patterns.md
+++ b/docs/design/compiler/control-flow-patterns.md
@@ -93,10 +93,19 @@ local variables.  LVT-indexed access is faster than name-based `loadStk`.
 **IR**: `IRSwitch` with `IRSwitchArm` patterns.
 **CFG**: Cascade of `CFGBranch` blocks, one per arm, merging at `switch_end`.
 
+A pattern body of `-` is a fallthrough: the arm shares the next non-`-` arm's
+body. The lowerer marks it `SwitchArm.fallthrough = true` with a `None` body.
+
 ### `catch` / `try`
 
 **IR**: `IRCatch` / `IRTry` with `IRTryHandler`.
 **CFG**: Body block + handler blocks, merging after.
+
+An `on`/`trap` handler body of `-` is a fallthrough — the same mechanism
+`switch` uses — sharing the next non-`-` handler's body. The lowerer marks it
+`TryHandler.fallthrough = true` with an empty body, so the `-` is not mistaken
+for a zero-argument command call (issue #703). `switch` and `try` are the only
+two Tcl commands with this `-` fallthrough form.
 
 ### Key bytecode conventions matching tclsh
 

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -57,6 +57,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-issue-counter-numtests-array-init.md](kcs-issue-counter-numtests-array-init.md)
   — tcltest's `numTests(Failed)` reads as an empty string in the
   compiled counter-bundle run.
+- [kcs-issue-try-dash-handler-body-false-error.md](kcs-issue-try-dash-handler-body-false-error.md)
+  — a `try` handler with a `-` fallthrough body is wrongly flagged
+  "too few arguments for '-'" (issue #703).
 - [kcs-issue-vm-set-test-codegen.md](kcs-issue-vm-set-test-codegen.md)
   — VM `set.test` core slice: nested array-set, brace-suppressed array
   keys, array reads in word templates, and `while executing` errorInfo

--- a/docs/kcs/kcs-issue-try-dash-handler-body-false-error.md
+++ b/docs/kcs/kcs-issue-try-dash-handler-body-false-error.md
@@ -60,9 +60,14 @@ analyser already handled `switch` correctly — `try` was the gap.
 
 ## Decision rules / contracts
 
-1. A `try` handler body that is the literal `-` (single-token word, including
-   the braced `{-}` / quoted `"-"` forms, which evaluate to the same string) is
-   a **fallthrough**, not a script. The lowerer sets
+1. A `try` handler body whose **string value** is `-` (a single-token word) is
+   a **fallthrough**, not a script. Tcl recognises the marker by value, so the
+   bare `-`, braced `{-}`, quoted `"-"`, and backslash-escaped (`\-`, `\x2d`, …)
+   forms all qualify. Braces suppress backslash substitution, so a *braced*
+   word's value is its raw content (`{\-}` is the literal two-char string `\-`,
+   **not** a fallthrough); bare and quoted words are backslash-substituted
+   first. A braced single-token word's representative token is a `Str` (the
+   `{`-stripping wrapper kind); bare / quoted words are `Esc`. The lowerer sets
    [`TryHandler.fallthrough`](../../rust/tcl-compiler/src/ir.rs) to `true` and
    gives the handler an empty `Script` body, so no command — and therefore no
    arity check — is synthesised for it.

--- a/docs/kcs/kcs-issue-try-dash-handler-body-false-error.md
+++ b/docs/kcs/kcs-issue-try-dash-handler-body-false-error.md
@@ -1,0 +1,129 @@
+# KCS: `try` handler with a `-` body reports a spurious "too few arguments" error
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+all-editors, tcl-lsp-cli, lowering
+
+## Symptom
+
+Reported in issue #703. A `try` command whose `on`/`trap` handler body is a
+bare `-` (a fallthrough marker that shares the *next* handler's body, exactly
+as `switch` shares pattern bodies) was flagged with a false-positive error:
+
+```
+E002  Too few arguments for '-': expected at least 1, got 0
+```
+
+The error landed on the solo `-`, for example the `-` in
+`on ok result - trap NONE result { … }`. The reported position was correct;
+the diagnostic was not. This is valid, working Tcl — it appears in Tcl's own
+`tools/findBadExternals.tcl`:
+
+```tcl
+try {
+    switch $::tcl_platform(platform) {
+        unix - macosx { exec nm --extern-only --defined-only $libtcl }
+        windows       { exec dumpbin /exports $libtcl }
+    }
+} on ok result - trap NONE result {
+    ...
+    return 0
+} on error msg {
+    ...
+    return 1
+}
+```
+
+## Operational context
+
+Two independent paths each treated a `try` handler body as a script:
+
+1. The IR lowerer (`lower_try`) turned every handler body into a nested
+   `Script`. A body of `-` was therefore lowered as a script containing the
+   single command `-`, which the registry knows as the arithmetic-minus
+   operator. With no operands, the generic arity check (E002) fired.
+2. The analyser's `try` walk (`handle_try_command`) re-lexed each braced
+   handler body as a script for variable / diagnostic analysis. A braced
+   `{-}` body re-lexed to a `-` command and tripped the same E002 — even
+   after the lowerer was fixed.
+
+Tcl's `TclNRTryObjCmd` (in `tclCmdMZ.c`) recognises a handler body of `-` by
+its string value and treats the clause as a fallthrough: when the clause
+matches, the runtime scans forward to the next handler whose body is not `-`
+and runs that body with that handler's variable bindings. The last
+non-`finally` clause must not be `-` (there is nothing to fall through to). The
+`switch` command uses the same mechanism for pattern bodies, and the lowerer /
+analyser already handled `switch` correctly — `try` was the gap.
+
+## Decision rules / contracts
+
+1. A `try` handler body that is the literal `-` (single-token word, including
+   the braced `{-}` / quoted `"-"` forms, which evaluate to the same string) is
+   a **fallthrough**, not a script. The lowerer sets
+   [`TryHandler.fallthrough`](../../rust/tcl-compiler/src/ir.rs) to `true` and
+   gives the handler an empty `Script` body, so no command — and therefore no
+   arity check — is synthesised for it.
+2. The analyser's `handle_try_command` skips `analyse_body` for a `-` handler
+   body, mirroring `handle_switch_command`'s arm handling. A `-` body is never
+   re-lexed as a nested script.
+3. `try`'s `arg_role_resolver` gives a `-` handler body no `ArgRole::Body`,
+   mirroring `switch`. A `-` body is never a nested script for semantic tokens
+   or any other role consumer.
+4. A genuine zero-argument `-` *command* in a real body (a true mistake) is
+   still flagged E002. The suppression is scoped to the handler-body slot, not
+   to the `-` command everywhere.
+5. The set of commands with `-` fallthrough is exactly `{switch, try}` —
+   confirmed against the Tcl 8.4–9.0 C sources. No other Tcl or Tk command
+   uses it.
+6. Like `switch`, the LSP does not flag the invalid "last non-`finally` clause
+   is `-`" case; that rare runtime error is accepted silently rather than
+   mis-reported.
+7. A `-` handler may bind a result/options var whose name differs from the
+   target handler's. Real Tcl is itself inconsistent here — a byte-compiled
+   (proc) `try` binds the *matching* handler's var while the interpreted form
+   binds the *target*'s — so the shared body is analysed with the whole
+   group's vars treated as defined: the precise over-approximation that avoids
+   a read-before-set (W210) false positive under either binding rule.
+
+## File-path anchors
+
+- `rust/tcl-compiler/src/lowering/structured.rs` — `lower_try`
+  (fallthrough detection)
+- `rust/tcl-compiler/src/ir.rs` — `TryHandler.fallthrough`
+- `rust/tcl-compiler/src/cfg_builder/cfg_lower.rs` — `lower_try`
+  (shared-body var defs)
+- `rust/tcl-compiler/src/analyser/handlers.rs` — `handle_try_command`
+  (no body re-lex for `-`)
+- `rust/tcl-registry/src/commands/tcl/try_.rs` — `try_arg_roles`
+  (no Body role for `-`)
+- `rust/tcl-registry/src/commands/tcl/switch_.rs` — `switch_arg_roles`
+  (the mirrored precedent)
+
+## Failure modes
+
+- A future refactor lowers the handler body before checking for `-`, so the
+  arity error returns.
+- `handle_try_command` is changed to re-lex the `-` body again, re-tripping
+  E002 on the braced form.
+- The `arg_role_resolver` is changed to mark the `-` body as `Body` again,
+  re-tagging it as an embedded script for semantic tokens.
+- A new fallthrough-style command is added without the same handling (the
+  investigation found none today, but a future Tcl version could add one).
+
+## Test anchors
+
+- `rust/tcl-compiler/src/lowering/structured.rs` — `try_dash_handler_body_is_fallthrough`
+  and siblings (lowering marks the fallthrough flag + empty body).
+- `rust/tcl-compiler/src/analyser/diagnostics/tests.rs` — `issue_703_*`
+  (no E002 on `-`/`{-}`; genuine zero-arg `-` still flagged; no false W210 on
+  the shared body; genuine read-before-set still fires).
+- `rust/tcl-registry/src/commands/tcl/try_.rs` — `dash_handler_body_gets_no_body_role`
+  and siblings (role resolver withholds `Body` from `-`).
+
+## Related
+
+- [KCS index](README.md)
+- [control-flow patterns](../design/compiler/control-flow-patterns.md)

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -4325,3 +4325,97 @@ fn w304_does_not_cross_proc_param_shadow() {
         r2.diagnostics
     );
 }
+
+// --- Issue #703: `try` handler `-` fallthrough body ---------------------
+//
+// A `try` `on`/`trap` handler body may be a bare `-` to share the *next*
+// handler's body (the same fallthrough mechanism `switch` uses for pattern
+// bodies). The lowerer used to treat every handler body as a script, so the
+// solo `-` compiled to a zero-argument call of the `-` command and tripped a
+// spurious E002 ("Too few arguments for '-'"). These tests assert both sides:
+// the fallthrough `-` raises no E002, and a genuine zero-arg `-` command is
+// still flagged.
+
+fn count_code(src: &str, code: &str) -> usize {
+    let mut a = crate::analyser::Analyser::new();
+    a.analyse(src, "tcl8.6")
+        .diagnostics
+        .iter()
+        .filter(|d| d.code.as_str() == code)
+        .count()
+}
+
+// The reporter's snippet (from Tcl's own `tools/findBadExternals.tcl`).
+const ISSUE_703_SOURCE: &str = "\
+proc main {argc argv} {
+    lassign $argv libtcl
+    try {
+        switch $::tcl_platform(platform) {
+            unix - macosx {
+                exec nm --extern-only --defined-only $libtcl
+            }
+            windows {
+                exec dumpbin /exports $libtcl
+            }
+        }
+    } on ok result - trap NONE result {
+        foreach line [split $result \\n] {
+            puts $line
+        }
+        return 0
+    } on error msg {
+        puts stderr $msg
+        return 1
+    }
+}
+";
+
+#[test]
+fn issue_703_fallthrough_dash_has_no_e002() {
+    // The solo `-` on the `on ok result - trap NONE result` line must not be
+    // flagged as a zero-arg `-` command.
+    assert_eq!(count_code(ISSUE_703_SOURCE, "E002"), 0);
+}
+
+#[test]
+fn issue_703_braced_dash_has_no_e002() {
+    let src =
+        "proc p {} {\n    try {set x 1} on ok a {-} trap NONE b {\n        return $b\n    }\n}\n";
+    assert_eq!(count_code(src, "E002"), 0);
+}
+
+#[test]
+fn issue_703_genuine_dash_command_in_handler_still_flagged() {
+    // A real zero-arg `-` *command* inside a handler body is still a genuine
+    // arity error — the fix must not blunt E002 here.
+    let src = "proc p {} {\n    try {set x 1} on error msg {\n        -\n    }\n}\n";
+    assert_eq!(count_code(src, "E002"), 1);
+}
+
+#[test]
+fn issue_703_genuine_dash_command_outside_try_still_flagged() {
+    assert_eq!(count_code("proc f {} {\n    -\n}\n", "E002"), 1);
+}
+
+#[test]
+fn issue_703_no_false_w210_on_fallthrough_group_var() {
+    // When a fallthrough handler's var differs from the target's, the shared
+    // body must not be flagged W210 for reading either var. Real Tcl is itself
+    // inconsistent here — a byte-compiled `try` binds the *matching* handler's
+    // var, the interpreted form the *target*'s — so the shared body is analysed
+    // with the whole group's vars treated as defined.
+    let reads_fallthrough_var =
+        "proc p {} {\n    try {set v ok} on ok x - on error y {\n        return $x\n    }\n}\n";
+    let reads_target_var =
+        "proc p {} {\n    try {set v ok} on ok x - on error y {\n        return $y\n    }\n}\n";
+    assert_eq!(count_code(reads_fallthrough_var, "W210"), 0);
+    assert_eq!(count_code(reads_target_var, "W210"), 0);
+}
+
+#[test]
+fn issue_703_genuine_read_before_set_still_fires_in_shared_body() {
+    // A read of a variable bound by no handler in the group is still a genuine
+    // read-before-set.
+    let src = "proc p {} {\n    try {set v 1} on ok x - on error y {\n        return $undefinedvar\n    }\n}\n";
+    assert_eq!(count_code(src, "W210"), 1);
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -4419,3 +4419,13 @@ fn issue_703_genuine_read_before_set_still_fires_in_shared_body() {
     let src = "proc p {} {\n    try {set v 1} on ok x - on error y {\n        return $undefinedvar\n    }\n}\n";
     assert_eq!(count_code(src, "W210"), 1);
 }
+
+#[test]
+fn issue_703_backslash_escaped_dash_no_false_w210() {
+    // Codex review on #706: a backslash-escaped `\-` handler body evaluates to
+    // `-` and is a fallthrough, so the shared target body must not be flagged
+    // W210 for reading the fallthrough handler's var (same as the bare `-`).
+    let src =
+        "proc p {} {\n    try {set v ok} on ok x \\- on error y {\n        return $x\n    }\n}\n";
+    assert_eq!(count_code(src, "W210"), 0);
+}

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -812,7 +812,14 @@ impl Analyser {
                 if let Some(vl_tok) = arg_tokens.get(i + 2).copied() {
                     self.define_vars_from_list(&args[i + 2], vl_tok, scope_path);
                 }
-                if let Some(body_tok) = arg_tokens.get(i + 3).copied() {
+                // A handler body of literal `-` is a fallthrough marker (shares
+                // the next handler's body, like `switch`); it is not a script,
+                // so it must not be re-lexed as one — otherwise the solo `-`
+                // reads as a zero-arg `-` command and trips a spurious arity
+                // error (issue #703). Mirrors the `switch` arm handling above.
+                if let Some(body_tok) = arg_tokens.get(i + 3).copied()
+                    && args[i + 3] != "-"
+                {
                     self.analyse_body(&args[i + 3], body_tok, scope_path);
                 }
                 i += 4;

--- a/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
+++ b/rust/tcl-compiler/src/cfg_builder/cfg_lower.rs
@@ -783,6 +783,16 @@ impl CfgBuilder {
             self.ensure_goto(tail, &post_body, Some(*body_span));
         }
 
+        // A `-` (fallthrough) handler shares the next non-`-` handler's body.
+        // Tcl binds the *matching* handler's variables when running that shared
+        // body in the byte-compiled form, but the *target* handler's variables
+        // in the interpreted form (the two diverge — see issue #703).
+        // Statically we can't know which handler matched, so the shared body is
+        // analysed with the whole group's variables treated as defined: the
+        // precise over-approximation that avoids a read-before-set false
+        // positive under either binding rule.
+        let mut pending_fallthrough_defs: Vec<String> = Vec::new();
+
         // Each handler reachable from body failure.
         for handler in handlers {
             let handler_block = self.new_block("try_handler");
@@ -801,13 +811,28 @@ impl CfgBuilder {
                 body_terminal.as_deref(),
             );
 
-            let mut var_defs = Vec::new();
+            let mut own_defs = Vec::new();
             if let Some(vn) = &handler.var_name {
-                var_defs.push(vn.clone());
+                own_defs.push(vn.clone());
             }
             if let Some(ov) = &handler.options_var {
-                var_defs.push(ov.clone());
+                own_defs.push(ov.clone());
             }
+            let var_defs = if handler.fallthrough {
+                // Empty body of its own; carry its vars to the shared body.
+                pending_fallthrough_defs.extend(own_defs.iter().cloned());
+                own_defs
+            } else {
+                // Target of any preceding `-` chain: its shared body may run
+                // with any group member's vars bound, so define them all here.
+                let mut defs = std::mem::take(&mut pending_fallthrough_defs);
+                for d in own_defs {
+                    if !defs.contains(&d) {
+                        defs.push(d);
+                    }
+                }
+                defs
+            };
             if !var_defs.is_empty() {
                 self.block_mut(&handler_block)
                     .statements
@@ -1120,6 +1145,7 @@ mod tests {
                 options_var: None,
                 body: Script::new(),
                 body_span: Span::new(30, 35),
+                fallthrough: false,
             }],
             finally_body: None,
             finally_span: None,

--- a/rust/tcl-compiler/src/inlining/mod.rs
+++ b/rust/tcl-compiler/src/inlining/mod.rs
@@ -963,6 +963,7 @@ fn rewrite_stmt(
                         options_var: h.options_var.clone(),
                         body: hbody,
                         body_span: h.body_span,
+                        fallthrough: h.fallthrough,
                     });
                 } else {
                     new_handlers.push(h.clone());

--- a/rust/tcl-compiler/src/inlining/rename.rs
+++ b/rust/tcl-compiler/src/inlining/rename.rs
@@ -315,6 +315,7 @@ fn rewrite_stmt(stmt: &Statement, rename: &HashMap<String, String>) -> Statement
                         .map(|v| rename.get(v).cloned().unwrap_or_else(|| v.clone())),
                     body: rewrite_script(&h.body, rename),
                     body_span: h.body_span,
+                    fallthrough: h.fallthrough,
                 })
                 .collect(),
             finally_body: finally_body.as_ref().map(|b| rewrite_script(b, rename)),

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -104,6 +104,11 @@ pub struct TryHandler {
     pub body: Script,
     /// Source span of the handler body.
     pub body_span: Span,
+    /// `true` when the handler body is the literal `-` fallthrough
+    /// marker: the handler shares the next non-fallthrough handler's
+    /// body (Tcl `try` semantics, mirroring `switch`). `body` is an
+    /// empty script in that case — the `-` is *not* a command call.
+    pub fallthrough: bool,
 }
 
 /// A `switch` arm: pattern + body.
@@ -1032,6 +1037,7 @@ mod tests {
                 options_var: None,
                 body: Script::new(),
                 body_span: Span::new(30, 40),
+                fallthrough: false,
             }],
             finally_body: Some(Script::new()),
             finally_span: Some(Span::new(50, 58)),

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -576,10 +576,24 @@ impl Lowerer<'_> {
                 // clause shares the next non-`-` handler's body (like `switch`).
                 // Treat it as an empty body rather than lowering `-` as a script
                 // — otherwise it compiles to a zero-arg call of the `-` command
-                // and trips a spurious arity error (issue #703). The braced
-                // `{-}` form evaluates to the same string, so it is also a
-                // fallthrough (braces are stripped in `args`).
-                let is_fallthrough = handler_single && args[i + 3] == "-";
+                // and trips a spurious arity error (issue #703).
+                //
+                // Tcl recognises the marker by the word's *string value*, so the
+                // braced `{-}`, quoted `"-"`, and backslash-escaped (`\-`,
+                // `\x2d`, …) forms — all of which evaluate to `-` — are equally
+                // fallthroughs. Braces suppress backslash substitution, so a
+                // braced word's value is its raw content (`{\-}` is the literal
+                // two-char string `\-`, *not* a fallthrough); bare and quoted
+                // words are backslash-substituted first. A braced single-token
+                // word's representative token is a `Str` (the `{`-stripping
+                // wrapper kind); bare / quoted words are `Esc`.
+                let is_braced = handler_tok.is_some_and(|t| t.kind == TokenType::Str);
+                let body_value = if is_braced {
+                    std::borrow::Cow::Borrowed(args[i + 3].as_str())
+                } else {
+                    tcl_lexer::backslash_subst(&args[i + 3])
+                };
+                let is_fallthrough = handler_single && body_value == "-";
                 let handler_body = if is_fallthrough {
                     crate::ir::Script::new()
                 } else {
@@ -1075,6 +1089,59 @@ mod tests {
             panic!("expected Try");
         };
         assert!(!handlers[0].fallthrough);
+    }
+
+    #[test]
+    fn try_quoted_dash_handler_body_is_fallthrough() {
+        // A quoted `"-"` evaluates to the string `-`, like the bare/braced forms.
+        let m = lower_to_ir(
+            "try {set x 1} on ok a \"-\" trap NONE b {return $b}",
+            &reg(),
+        );
+        let Statement::Try { handlers, .. } = &m.top_level.statements[0] else {
+            panic!("expected Try");
+        };
+        assert!(handlers[0].fallthrough);
+        assert!(handlers[0].body.statements.is_empty());
+    }
+
+    #[test]
+    fn try_backslash_escaped_dash_handler_body_is_fallthrough() {
+        // Tcl applies backslash substitution before `try` sees the word, so a
+        // bare `\-` / `\x2d` body evaluates to `-` and is a fallthrough
+        // (Codex review on #706 / port of #704).
+        for src in [
+            "try {set x 1} on ok a \\- trap NONE b {return $b}",
+            "try {set x 1} on ok a \\x2d trap NONE b {return $b}",
+            "try {set x 1} on ok a \"\\-\" trap NONE b {return $b}",
+        ] {
+            let m = lower_to_ir(src, &reg());
+            let Statement::Try { handlers, .. } = &m.top_level.statements[0] else {
+                panic!("expected Try for {src:?}");
+            };
+            assert!(handlers[0].fallthrough, "expected fallthrough for {src:?}");
+            assert!(
+                handlers[0].body.statements.is_empty(),
+                "expected empty body for {src:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn try_braced_escaped_dash_handler_body_is_not_fallthrough() {
+        // Braces suppress backslash substitution: `{\-}` is the literal
+        // two-char string `\-`, which is *not* the `-` fallthrough marker.
+        let m = lower_to_ir(
+            "try {set x 1} on ok a {\\-} trap NONE b {return $b}",
+            &reg(),
+        );
+        let Statement::Try { handlers, .. } = &m.top_level.statements[0] else {
+            panic!("expected Try");
+        };
+        assert!(
+            !handlers[0].fallthrough,
+            "braced `{{\\-}}` is a literal string, not a fallthrough",
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -566,12 +566,25 @@ impl Lowerer<'_> {
                 let match_arg = args[i + 1].clone();
                 let var_list = &args[i + 2];
                 let handler_tok = arg_tokens.get(i + 3);
+                let handler_single = arg_single.get(i + 3).copied().unwrap_or(false);
 
                 let var_names = parse_param_names(var_list);
                 let result_var = var_names.first().map(|v| normalise_var_name(v).to_owned());
                 let options_var = var_names.get(1).map(|v| normalise_var_name(v).to_owned());
 
-                let handler_body = self.lower_body_from_tok(&args[i + 3], handler_tok, namespace);
+                // A handler body of literal `-` is a fallthrough marker: the
+                // clause shares the next non-`-` handler's body (like `switch`).
+                // Treat it as an empty body rather than lowering `-` as a script
+                // — otherwise it compiles to a zero-arg call of the `-` command
+                // and trips a spurious arity error (issue #703). The braced
+                // `{-}` form evaluates to the same string, so it is also a
+                // fallthrough (braces are stripped in `args`).
+                let is_fallthrough = handler_single && args[i + 3] == "-";
+                let handler_body = if is_fallthrough {
+                    crate::ir::Script::new()
+                } else {
+                    self.lower_body_from_tok(&args[i + 3], handler_tok, namespace)
+                };
 
                 handlers.push(TryHandler {
                     kind: keyword.clone(),
@@ -580,6 +593,7 @@ impl Lowerer<'_> {
                     options_var,
                     body: handler_body,
                     body_span: handler_tok.map_or(seg.span, |t| t.span),
+                    fallthrough: is_fallthrough,
                 });
                 i += 4;
                 continue;
@@ -996,6 +1010,71 @@ mod tests {
         } else {
             panic!("expected Try");
         }
+    }
+
+    #[test]
+    fn try_dash_handler_body_is_fallthrough() {
+        // Issue #703: a `-` handler body is a fallthrough marker (shares the
+        // next non-`-` handler's body, like `switch`), not a zero-arg `-`
+        // command. It must lower to a fallthrough handler with an empty body.
+        let m = lower_to_ir(
+            "try {set x 1} on ok result - trap NONE result {return 0} on error msg {return 1}",
+            &reg(),
+        );
+        let Statement::Try { handlers, .. } = &m.top_level.statements[0] else {
+            panic!("expected Try");
+        };
+        let shape: Vec<(&str, &str, bool)> = handlers
+            .iter()
+            .map(|h| (h.kind.as_str(), h.match_arg.as_str(), h.fallthrough))
+            .collect();
+        assert_eq!(
+            shape,
+            vec![
+                ("on", "ok", true),
+                ("trap", "NONE", false),
+                ("on", "error", false)
+            ],
+        );
+        // The fallthrough handler carries no statements of its own.
+        assert!(handlers[0].body.statements.is_empty());
+        assert!(!handlers[1].body.statements.is_empty());
+    }
+
+    #[test]
+    fn try_braced_dash_handler_body_is_fallthrough() {
+        // Per Tcl's `TclNRTryObjCmd`, a body of `{-}` evaluates to the string
+        // `-` and is equally a fallthrough marker.
+        let m = lower_to_ir("try {set x 1} on ok a {-} trap NONE b {return $b}", &reg());
+        let Statement::Try { handlers, .. } = &m.top_level.statements[0] else {
+            panic!("expected Try");
+        };
+        assert!(handlers[0].fallthrough);
+        assert!(handlers[0].body.statements.is_empty());
+    }
+
+    #[test]
+    fn try_consecutive_dash_handlers_are_fallthrough() {
+        // Several `-` handlers in a row all share the final body.
+        let m = lower_to_ir(
+            "try {set x 1} on ok a - on return b - trap NONE c {return $c}",
+            &reg(),
+        );
+        let Statement::Try { handlers, .. } = &m.top_level.statements[0] else {
+            panic!("expected Try");
+        };
+        let flags: Vec<bool> = handlers.iter().map(|h| h.fallthrough).collect();
+        assert_eq!(flags, vec![true, true, false]);
+    }
+
+    #[test]
+    fn try_empty_brace_handler_body_is_not_fallthrough() {
+        // A genuinely empty `{}` body is valid and distinct from `-`.
+        let m = lower_to_ir("try {set x 1} on ok a {} on error b {return $b}", &reg());
+        let Statement::Try { handlers, .. } = &m.top_level.statements[0] else {
+            panic!("expected Try");
+        };
+        assert!(!handlers[0].fallthrough);
     }
 
     #[test]

--- a/rust/tcl-registry/src/commands/tcl/try_.rs
+++ b/rust/tcl-registry/src/commands/tcl/try_.rs
@@ -14,6 +14,21 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "try body ?handler...? ?finally script?",
 }];
 
+/// Whether a handler-body word is the literal `-` fallthrough marker
+/// (issue #703). Tcl recognises a body of `-` by string value, so the
+/// braced `{-}` and quoted `"-"` forms — which evaluate to the same
+/// string — are equally fallthroughs. Role-resolver callers may pass
+/// the word either stripped (`-`) or brace/quote-inclusive (`{-}`),
+/// so one layer of matched `{}`/`""` is stripped before comparing.
+fn is_dash_fallthrough(arg: &str) -> bool {
+    let stripped = arg
+        .strip_prefix('{')
+        .and_then(|s| s.strip_suffix('}'))
+        .or_else(|| arg.strip_prefix('"').and_then(|s| s.strip_suffix('"')))
+        .unwrap_or(arg);
+    stripped == "-"
+}
+
 /// Dynamic arg role resolver for `try`/`on`/`trap`/`finally`.
 ///
 /// The structural keyword words (`on`/`trap`/`finally`) carry
@@ -40,7 +55,12 @@ fn try_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
             i += 2;
         } else if (kw == "on" || kw == "trap") && i + 3 < args.len() {
             push_keyword(&mut roles, i);
-            if let Ok(idx) = u8::try_from(i + 3) {
+            // A handler body of literal `-` is a fallthrough marker (shares the
+            // next handler's body, like `switch`); it is not a script, so it
+            // gets no BODY role.
+            if !is_dash_fallthrough(args[i + 3])
+                && let Ok(idx) = u8::try_from(i + 3)
+            {
                 roles.push((idx, ArgRole::Body));
             }
             i += 4;
@@ -76,5 +96,54 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         side_effects: SIDE_EFFECTS,
         ..CommandSpec::DEFAULT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn body_indices(args: &[&str]) -> Vec<u8> {
+        let mut idx: Vec<u8> = try_arg_roles(args)
+            .into_iter()
+            .filter(|(_, role)| *role == ArgRole::Body)
+            .map(|(i, _)| i)
+            .collect();
+        idx.sort_unstable();
+        idx
+    }
+
+    #[test]
+    fn dash_handler_body_gets_no_body_role() {
+        // Issue #703: a `-` fallthrough handler body is not a script, so it
+        // must carry no `ArgRole::Body` (mirrors `switch`). Index layout for
+        // `try <body> on ok result - trap NONE result <body>`:
+        //   0 body, 1 on, 2 ok, 3 result, 4 `-`, 5 trap, 6 NONE, 7 result, 8 body
+        let args = [
+            "{...}", "on", "ok", "result", "-", "trap", "NONE", "result", "{...}",
+        ];
+        let indices = body_indices(&args);
+        assert!(!indices.contains(&4), "`-` body must get no Body role");
+        assert!(indices.contains(&0), "try body keeps Body role");
+        assert!(indices.contains(&8), "real handler body keeps Body role");
+    }
+
+    #[test]
+    fn braced_and_quoted_dash_body_get_no_body_role() {
+        // The braced `{-}` / quoted `"-"` forms evaluate to the same string
+        // and are equally fallthroughs.
+        for dash in ["{-}", "\"-\""] {
+            let args = ["{...}", "on", "ok", "a", dash, "trap", "NONE", "b", "{...}"];
+            assert!(
+                !body_indices(&args).contains(&4),
+                "{dash} body must get no Body role",
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_handler_body_keeps_body_role() {
+        let args = ["{...}", "on", "error", "msg", "{puts $msg}"];
+        assert!(body_indices(&args).contains(&4));
     }
 }


### PR DESCRIPTION
## Summary

Port of #704 (the Python fix) to the Rust implementation.

A `try` `on`/`trap` handler body may be a bare `-` to share the **next** handler's body — the same fallthrough mechanism `switch` uses for pattern bodies. In the Rust port, **two** independent paths treated every handler body as a script, so a solo `-` was read as a zero-argument call of the `-` command and tripped **E002** (`Too few arguments for '-': expected at least 1, got 0`). This is valid, working Tcl — it appears in Tcl's own `tools/findBadExternals.tcl`:

```tcl
try {
    switch $::tcl_platform(platform) {
        unix - macosx { exec nm --extern-only --defined-only $libtcl }
        windows       { exec dumpbin /exports $libtcl }
    }
} on ok result - trap NONE result {
    ...
    return 0
} on error msg {
    ...
    return 1
}
```

## Fix

- **`tcl-compiler/src/ir.rs`** — added `TryHandler.fallthrough` (mirrors `SwitchArm.fallthrough`).
- **`tcl-compiler/src/lowering/structured.rs`** — `lower_try` recognises a single-token `-` handler body (including the braced `{-}` and quoted `"-"` forms, which evaluate to the same string) as a fallthrough: it lowers to an empty `Script` with `fallthrough = true`, so no `-` command — and no arity check — is synthesised.
- **`tcl-compiler/src/analyser/handlers.rs`** — `handle_try_command` skips re-lexing a `-` body as a script, mirroring the `switch` arm handling. This is a Rust-specific second path: it tripped the braced `{-}` form even after the lowerer was fixed.
- **`tcl-compiler/src/cfg_builder/cfg_lower.rs`** — `lower_try` carries a fallthrough handler's bound vars onto the shared target body, so the shared body is analysed with the whole group's vars treated as defined (avoids a **W210** read-before-set false positive under either of Tcl's two binding rules — byte-compiled vs interpreted diverge here).
- **`tcl-registry/src/commands/tcl/try_.rs`** — withholds the `ArgRole::Body` role from a `-` body, mirroring `switch_.rs` (affects semantic tokens and other role consumers).
- **`tcl-compiler/src/inlining/{mod,rename}.rs`** — preserve the new flag when rewriting handlers during inlining.

A genuine zero-argument `-` *command* in a real body is still flagged E002 — the suppression is scoped to the handler-body slot, not to the `-` command everywhere. `switch` and `try` are the **only** two Tcl commands with this `-` fallthrough form (verified against the 8.4–9.0 C sources; no Tk command uses it).

## Tests & docs

- **`lowering/structured.rs`** — `try_dash_handler_body_is_fallthrough` and siblings: fallthrough flag + empty body, braced `{-}`, consecutive `-` handlers, and an empty `{}` body staying distinct from `-`.
- **`analyser/diagnostics/tests.rs`** — `issue_703_*`: the reporter snippet (and `{-}`) raises no E002 and a genuine zero-arg `-` command is still flagged; no false W210 on the shared body across var-name mismatches; a genuine read-before-set still fires.
- **`tcl-registry/.../try_.rs`** — `dash_handler_body_gets_no_body_role` and siblings: the role resolver withholds `Body` from `-`/`{-}`/`"-"`.
- New KCS issue note (`docs/kcs/kcs-issue-try-dash-handler-body-false-error.md`) + index entry; updated `docs/design/compiler/control-flow-patterns.md`.

## Validation

- `cargo test -p tcl-compiler -p tcl-registry` — **PASS** (2926 + all integration/unit suites green).
- `cargo fmt` + `cargo clippy` — clean on the touched crates.
- `cargo build --workspace` — **PASS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01YTDSaAWSwLumgWjWPm2Zih)_