### PR TITLE
ci: don't auto-skip create-release/build-vsix when Python backstops skip (pre-release fix)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,12 +296,19 @@ jobs:
   # can upload its artifact independently — no single slow or failing
   # build blocks the others.
   create-release:
-    if: startsWith(github.ref, 'refs/tags/v')
     # pr-gate + test-py are the Python (1.x) gate.  For pre-release (odd-minor
-    # 2.x) tags they skip, and a skipped `needs` job is non-blocking, so the
-    # release still proceeds — gated instead on rust-tests, which is added here
-    # so a pre-release is never ungated.  Stable tags run pr-gate + test-py and
-    # require them to pass; a failed need blocks this job as before.
+    # 2.x) tags they SKIP; this release must still run, gated instead on
+    # rust-tests.  A plain `if` without a status-check function would make GitHub
+    # auto-skip this job whenever a `needs` job is skipped — so the `if` uses
+    # `!cancelled()` (a status-check function) plus explicit result guards:
+    # rust-tests must pass, and pr-gate/test-py may be success OR skipped but a
+    # genuine FAILURE (e.g. a stable tag failing the Python suite) still blocks.
+    if: >-
+      !cancelled()
+      && startsWith(github.ref, 'refs/tags/v')
+      && needs.rust-tests.result == 'success'
+      && (needs.pr-gate.result == 'success' || needs.pr-gate.result == 'skipped')
+      && (needs.test-py.result == 'success' || needs.test-py.result == 'skipped')
     needs: [channel, pr-gate, test-py, rust-tests]
     runs-on: ubuntu-24.04
     permissions:
@@ -434,7 +441,16 @@ jobs:
 
   # Build: universal VSIX package (bundles every native server binary)
   build-vsix:
-    if: startsWith(github.ref, 'refs/tags/v')
+    # test-ext (the VS Code extension suite) SKIPS for pre-release tags; like
+    # create-release, this job must still run, so the `if` uses `!cancelled()`
+    # plus result guards.  create-release + build-server-matrix must succeed;
+    # test-ext may be success OR skipped, but a real FAILURE (stable tag) blocks.
+    if: >-
+      !cancelled()
+      && startsWith(github.ref, 'refs/tags/v')
+      && needs.create-release.result == 'success'
+      && needs.build-server-matrix.result == 'success'
+      && (needs.test-ext.result == 'success' || needs.test-ext.result == 'skipped')
     needs: [create-release, test-ext, build-server-matrix]
     runs-on: ubuntu-24.04
     permissions:


### PR DESCRIPTION
Follow-up to #709. That PR correctly skipped `pr-gate`/`test-py`/`test-ext` for pre-release (odd-minor 2.x) tags — but a `v2.1.0` cut then completed with **everything skipped and nothing released**.

## Why

GitHub auto-skips a job whose `if:` has **no status-check function** (`always()`/`!cancelled()`/`success()`/`failure()`) whenever any of its `needs` jobs is **skipped**. So with `pr-gate`/`test-py` skipped, `create-release` (which needs them) was auto-skipped, and so was `build-vsix` (needs the skipped `test-ext`) — cascading to all builds/publish. The run was green (skips aren't failures) but produced **no release object**.

## Fix

Give `create-release` and `build-vsix` an `if:` that **starts with `!cancelled()`** (a status-check function, so GitHub evaluates the condition instead of auto-skipping) plus explicit `result` guards:

- `create-release`: runs a tag when `rust-tests == success` and `pr-gate`/`test-py` are `success` **or** `skipped`. A genuine **failure** (stable tag failing the Python suite) still blocks.
- `build-vsix`: runs when `create-release` + `build-server-matrix` succeed and `test-ext` is `success` **or** `skipped`.

Downstream build/publish jobs need only `create-release` (now a definite `success`), so they run under normal `success()` semantics — no change needed.

## Verification
- `yaml.safe_load(ci.yml)` → valid (20 jobs); folded `if` expressions confirmed single-line
- `! grep -rE 'secrets\.[A-Z_]+' .github/workflows/` → clean
- Validated by re-cutting `v2.1.0` from `rust` after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)