### PR TITLE
fix(rust-release): clear unused_mut + provision wasm-pack for explorer-gui-cdn

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -646,6 +646,21 @@ jobs:
 
       - uses: ./.github/actions/setup-build
 
+      # The explorer-gui-cdn profile is the only one that compiles Rust → WASM
+      # (`make zipapp-explorer-gui-cdn` → `make explorer-wasm` → wasm-pack).
+      # setup-build provides only Python/uv, so this profile additionally needs
+      # a Rust toolchain with the wasm32 target and the wasm-pack binary.  Gated
+      # to the profile so the other (pure-Python) zipapps don't pay for it.
+      - name: Set up Rust toolchain (explorer-gui-cdn builds Rust → WASM)
+        if: matrix.profile == 'explorer-gui-cdn'
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+      - name: Install wasm-pack (explorer-gui-cdn)
+        if: matrix.profile == 'explorer-gui-cdn'
+        run: cargo install wasm-pack --locked
+
       - name: Build ${{ matrix.profile }} zipapp
         run: make zipapp-${{ matrix.profile }}
 

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -365,7 +365,7 @@ impl CfgBuilder {
         };
 
         let mut defs: Vec<String> = Vec::new();
-        let mut record = |name: Option<&String>, defs: &mut Vec<String>| {
+        let record = |name: Option<&String>, defs: &mut Vec<String>| {
             if let Some(n) = name
                 && !n.is_empty()
                 && !n.contains('$')


### PR DESCRIPTION
The pre-release pipeline (#709–#711) now runs end-to-end through `create-release` and most builds. Cutting `v2.1.0` surfaced two genuine rust-line release blockers — the full `ci.yml` only runs on `main`/tags, so these were never exercised by rust's dev CI:

1. **`build-server-matrix` (native server cross-compile, all 3 OS)** — `error: variable does not need to be mutable` at `rust/tcl-compiler/src/cfg_builder/mod.rs:368`. `actions-rust-lang/setup-rust-toolchain` sets `RUSTFLAGS=-D warnings` by default, so the lint is fatal; `rust-tests`' plain `cargo test` doesn't, so it passed there. The `record` closure isn't mutated → drop `mut`. (`rust-tests` on this PR compile-checks the fix.)

2. **`build-zipapp (explorer-gui-cdn)`** — `wasm-pack not found`. That profile is the only zipapp that compiles Rust → WASM (`make explorer-wasm` → `wasm-pack build`), but `build-zipapp` only has Python/uv via `setup-build`. Add a Rust toolchain (`stable` + `wasm32-unknown-unknown`) and `wasm-pack`, gated to the profile so the pure-Python zipapps don't pay for it.

## Notes
- These only manifest on a tag, so they can't be fully validated by this PR's checks — verified by re-cutting `v2.1.0` after merge.
- YAML valid (20 jobs); no `secrets.*`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)