### PR TITLE
fix(explorer-wasm): publish=false (unbreak explorer-gui-cdn wasm build)

### DIFF
--- a/rust/tcl-explorer-wasm/Cargo.toml
+++ b/rust/tcl-explorer-wasm/Cargo.toml
@@ -6,7 +6,13 @@
 # Built via `make explorer-wasm` (wasm-pack + wasm-opt); see the Makefile.
 [package]
 name = "tcl-explorer-wasm"
-publish.workspace = true
+# This crate is `exclude`d from the root workspace (see the comment above and
+# the workspace `exclude` list), so it cannot inherit `publish` from
+# `[workspace.package]` — `publish.workspace = true` makes `cargo metadata`
+# (and therefore wasm-pack) fail with "failed to find a workspace root".  It is
+# a browser wasm facade that is never published to crates.io, so set it
+# explicitly.
+publish = false
 description = "Rust → WASM compile() facade for the Tcl compiler-explorer GUI"
 version = "0.1.0"
 edition = "2024"


### PR DESCRIPTION
Final blocker for the v2.1.0 alpha. With the native server + vsix now building, the only failing release job is `build-zipapp (explorer-gui-cdn)`, which fails the `build-zipapp` matrix and thus skips `publish-checksums` → `publish-vsix-marketplace`.

`rust/tcl-explorer-wasm` is `exclude`d from the root workspace (wasm32 cdylib needing `unsafe`, banned by the workspace `unsafe_code = forbid`), yet declared `publish.workspace = true`. Inheriting from a workspace it isn't part of makes `cargo metadata` (hence wasm-pack) fail: *failed to find a workspace root*. It's a browser facade never published to crates.io → set `publish = false`.

Only touches an excluded crate's manifest, so the workspace gate (`rust-tests`/`lsp-e2e`/`cargo-deny`) doesn't cover it; validated by re-cutting `v2.1.0`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)