### PR TITLE
Rust child & safe interpreters: interp subcommands across tcl-vm and the WASM runtime

### DIFF
--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -153,6 +153,12 @@ ownership matrices.
   running the real Tcl library and ``tcltest`` harness (the
   ``pkgIndex.tcl`` / ``tm`` machinery) against real C Tcl 9 under the
   runtime.
+- [runtime/tcl-test-tiers.md](runtime/tcl-test-tiers.md) — the capability
+  ladder (parsing → interpretation → fundamentals → control flow → I/O →
+  platform features) ordering the work toward C tcltest parity.
+- [runtime/backend-constraints.md](runtime/backend-constraints.md) — the
+  ``tcl_platform`` backend-introspection schema and the loadable overlay that
+  skips upstream tests a wasm / WASI / eBPF build cannot run.
 - [runtime/zig-runtime-roadmap.md](runtime/zig-runtime-roadmap.md) —
   phases 4 (residual), 5, and 6 of the Zig WASM runtime, companion to
   the master plan: remaining P4 work and P5/P6 sequencing.

--- a/docs/design/runtime/backend-constraints.md
+++ b/docs/design/runtime/backend-constraints.md
@@ -1,0 +1,103 @@
+# Backend test constraints — running the tcltest suite per target
+
+The Rust interpreters target several backends with different capabilities:
+
+| backend    | crate            | filesystem | sockets | exec | threads | clock |
+|------------|------------------|:----------:|:-------:|:----:|:-------:|:-----:|
+| native     | `tcl-vm`, `runtime/rust` | ✓ | ✓ | ✓ | ✓ | ✓ |
+| wasm/WASI  | `runtime/rust` (wasm32-wasip1) | ✓ | ✗ | ✗ | ✗ | ✓ |
+| eBPF       | `bpf-tcl` (DSL subset → eBPF)   | ✗ | ✗ | ✗ | ✗ | ✗ |
+
+The upstream Tcl 9 tcltest suite is a fixed contract — we never edit
+`tcltest.tcl`, `init.tcl`, or any `.test` file (see
+[`tcltest-bringup.md`](tcltest-bringup.md)). A test that needs a capability a
+backend lacks must therefore be **skipped**, not failed, so the backend's
+pass / fail / skip line matches what that backend can honestly run. C tclsh
+does the same thing with its `win` / `unix` / `nonPortable` constraints.
+
+Two pieces make this work: runtime **introspection** (what am I?) and a
+loadable **overlay** (skip what I can't run).
+
+## Introspection — `tcl_platform` keys
+
+Each interpreter publishes these keys in the standard `tcl_platform` array,
+after the usual fields. The schema and the compiled-in (cfg-detected) values
+live in `tcl-platform::backend`; both `tcl-vm` and `runtime/rust` publish
+them from their startup-globals path.
+
+| key              | meaning                                                    | example          |
+|------------------|------------------------------------------------------------|------------------|
+| `runtime`        | interpreter implementation                                 | `bytecode`, `treewalk` |
+| `runtimeVersion` | that implementation's host (crate) version                 | `0.1.0`          |
+| `wasm`           | wasm spec version on a wasm build, else empty              | `2.0`            |
+| `wasi`           | WASI spec version on a WASI build, else empty              | `preview1`, `0.2`|
+| `wasiVersion`    | WASI host / preview identifier, else empty                 | `wasip1`         |
+| `ebpf`           | eBPF target version, else empty                            | `1.4`            |
+
+An empty string means "not this target". A native build reports
+`runtime`/`runtimeVersion` and leaves `wasm`/`wasi`/`ebpf` empty.
+
+### Environment overrides
+
+Each fact may be overridden from the environment before it is published:
+
+| key           | override variable    |
+|---------------|----------------------|
+| `wasm`        | `TCL_WASM_SPEC`      |
+| `wasi`        | `TCL_WASI_SPEC`      |
+| `wasiVersion` | `TCL_WASI_VERSION`   |
+| `ebpf`        | `TCL_EBPF_SPEC`      |
+
+This lets a **native** binary evaluate another backend's skip lists — the only
+way to reason about the **eBPF** target, which is a DSL-subset compiler
+(`bpf-tcl`) and cannot host a full interpreter at all. For example,
+`TCL_EBPF_SPEC=1.4 run_test foo.test` runs `foo.test` natively but skips
+everything the eBPF backend could not.
+
+## Overlay — `tests/external/backend_constraints.tcl`
+
+A tcltest overlay, sourced **after** `package require tcltest` and **before**
+the `.test` file. It:
+
+1. reads the introspection facts (defaulting to `native` when absent, so it is
+   safe under C tclsh or an older build);
+2. registers backend constraints — `native`, `wasm`/`notWasm`,
+   `wasi`/`notWasi`, `ebpf`/`notEbpf`, the runtime-impl constraints
+   (`bytecodeRuntime`, `treewalkRuntime`), and spec-version gates (`wasm2`,
+   `wasiPreview1`, `wasiPreview2`);
+3. feeds `tcltest::configure -skip` the test-id globs the current backend
+   cannot run, from a data-driven exclusion table ordered by capability area.
+
+### Running with the overlay
+
+Both harnesses source the overlay when `TCL_BACKEND_CONSTRAINTS` points at it:
+
+```sh
+# tcl-vm bytecode VM, evaluated as the WASI backend
+TCL_BACKEND_CONSTRAINTS=tests/external/backend_constraints.tcl \
+TCL_WASI_SPEC=preview1 \
+  cargo run -p tcl-vm --release --example run_test -- tmp/tcl9.0.3/tests/socket.test
+
+# runtime/rust tree-walk runtime, evaluated as eBPF
+TCL_BACKEND_CONSTRAINTS=tests/external/backend_constraints.tcl \
+TCL_EBPF_SPEC=1.4 \
+  cargo run --release --example run_script -- --init tmp/tcl9.0.3/tests/clock.test
+```
+
+A native run (no `TCL_*_SPEC`) skips nothing and runs the full suite.
+
+### Adding an exclusion
+
+Edit the `Exclusions` table in the overlay. Each row is
+`{globs {backends...} reason}`: a test whose name matches any glob is skipped
+when the current backend is in `{backends...}`. Keep rows ordered by capability
+area and cite *why* — the table is meant to grow as backend gaps are
+characterised, and the reason is the audit trail for why a test is not run.
+
+## Relationship to the tier ladder
+
+Backend constraints bite hardest at the top of the
+[test-tier ladder](tcl-test-tiers.md): Tier 1–4 (parsing, interpretation,
+fundamentals, control flow) are pure computation and run on every backend;
+Tier 5 (I/O) and Tier 6 (platform features) are where capabilities diverge and
+the overlay does its skipping.

--- a/docs/design/runtime/child-interp.md
+++ b/docs/design/runtime/child-interp.md
@@ -353,3 +353,33 @@ Three layers:
   `_delete` / `_eval_script` / `_root_ns` / `_hidden_find_in`.
 - Upstream `interp.test` sections 1–6 ported verbatim as
   `TestInterpTestPort` (59 cases, all passing).
+
+## 13. Rust ports
+
+The two Rust execution engines implement the same contract, mirroring the
+design above:
+
+- **`runtime/rust`** (tree-walk runtime — native and wasm32-wasip1) carries the
+  faithful port: `Interp(Rc<InterpState>)` with a `children` map, `hidden`
+  table, `parent` `Weak`, and `is_safe` flag, the `enter`/`leave`-style
+  `with_child` re-entrancy guard, and cross-interp aliases (`§6`). `interp
+  create`/`eval`/`delete`/`exists`/`children`/`issafe`/`marktrusted`/`hide`/
+  `expose`/`hidden`/`invokehidden`/`recursionlimit` are implemented; the Safe
+  Base (`safe.tcl` access-path virtualisation) and `interp limit`/`target`/
+  `debug`/`share` are the remaining gaps.
+
+- **`tcl-vm`** (bytecode VM) uses a simpler model fit to its plain-struct
+  `Vm`: a child **is** a full `Vm` sharing the parent's output sink and
+  (stateless) compile service via `Rc`, held in a `children` map and reachable
+  as a command through the `Command::ChildInterp` variant. `interp eval` takes
+  the child out of the map for the call and restores it (no aliased `&mut`), so
+  there is no cross-interp re-entry yet — `interp alias` from a child back to
+  the parent is the main deferred piece. `create ?-safe?`/`eval`/`delete`/
+  `exists`/`children`/`issafe`/`marktrusted`/`hide`/`expose`/`hidden`/
+  `recursionlimit` are implemented; `-safe` hides the host-reaching commands
+  into a per-interp hidden table; `share`/`transfer` are accepted so top-level
+  channel wiring does not abort a test file.
+
+Both are gated against the upstream `interp.test`/`safe.test` suites through the
+[tier scoreboard](rust-vm-tier-parity.md); child interpreters are the
+[Tier 7](tcl-test-tiers.md) feature.

--- a/docs/design/runtime/rust-vm-tier-parity.md
+++ b/docs/design/runtime/rust-vm-tier-parity.md
@@ -6,7 +6,7 @@ Goal: the VM's (passed/skipped/failed) per stem EXACTLY matches C Tcl 9 (`tests/
 
 `CRASH` = an uncaught error/timeout aborts the file (highest leverage — one fix unlocks it). Columns: **C P/S/F** vs **VM P/S/F**.
 
-**Tally: 28 MATCH · 58 gap · 11 crash · 0 no-ref** of 97 stems.
+**Tally: 28 MATCH · 59 gap · 10 crash · 0 no-ref** of 97 stems.
 
 ## Tier 1
 
@@ -17,7 +17,7 @@ Goal: the VM's (passed/skipped/failed) per stem EXACTLY matches C Tcl 9 (`tests/
 | parseExpr | 67/219/0 | 3/219/64 | gap |
 | word | 55/0/0 | 55/0/0 | MATCH |
 | subst | 62/1/0 | 54/1/8 | gap |
-| compile | 138/33/0 | 63/33/75 | gap |
+| compile | 138/33/0 | 64/33/74 | gap |
 | execute | 79/78/0 | 65/78/14 | gap |
 | basic | 69/77/0 | 45/78/23 | gap |
 | misc | 2/299/0 | 1/299/1 | gap |
@@ -50,10 +50,10 @@ Goal: the VM's (passed/skipped/failed) per stem EXACTLY matches C Tcl 9 (`tests/
 | apply | 38/4/0 | 26/4/12 | gap |
 | uplevel | 57/0/0 | 54/0/3 | gap |
 | upvar | 62/8/0 | 29/8/33 | gap |
-| namespace | 311/3/0 | 149/3/162 | gap |
+| namespace | 311/3/0 | 168/3/143 | gap |
 | namespace-old | 126/0/0 | 102/0/24 | gap |
 | var | 198/21/0 | 119/21/79 | gap |
-| info | 282/5/0 | 103/6/178 | gap |
+| info | 282/5/0 | 104/6/177 | gap |
 | cmdInfo | 0/12/0 | 0/12/0 | MATCH |
 | trace | 273/17/0 | 120/17/153 | gap |
 | rename | 11/8/0 | 10/8/1 | gap |
@@ -115,7 +115,7 @@ Goal: the VM's (passed/skipped/failed) per stem EXACTLY matches C Tcl 9 (`tests/
 | utf | 148/251/0 | 133/251/15 | gap |
 | clock | (no ref) | ERROR | CRASH |
 | msgcat | (no ref) | ERROR | CRASH |
-| safe | 147/8/0 | ERROR | CRASH |
+| safe | 147/8/0 | 2/8/145 | gap |
 | safe-stock | 11/0/0 | 0/0/11 | gap |
 | safe-stock86 | 0/0/0 | ERROR | CRASH |
 | safe-zipfs | (no ref) | ERROR | CRASH |

--- a/docs/design/runtime/rust-vm-tier-parity.md
+++ b/docs/design/runtime/rust-vm-tier-parity.md
@@ -1,122 +1,122 @@
 # Rust bytecode VM — Tier 1/2/3 tcltest parity scoreboard
 
-_Snapshot 2026-06-23 — regenerate with `TCL_LIBRARY=tmp/tcl9.0.3/library python scripts/dev/rust_vm_tier_gap.py --json tmp/g.json`._
+_Snapshot 2026-06-30 — regenerate with `TCL_LIBRARY=tmp/tcl9.0.3/library python scripts/dev/rust_vm_tier_gap.py --json tmp/g.json`._
 
 Goal: the VM's (passed/skipped/failed) per stem EXACTLY matches C Tcl 9 (`tests/baselines/tcl9-tcltest/c-tclsh.ndjson`).
 
 `CRASH` = an uncaught error/timeout aborts the file (highest leverage — one fix unlocks it). Columns: **C P/S/F** vs **VM P/S/F**.
 
-**Tally: 22 MATCH · 61 gap · 14 crash · 0 no-ref** of 97 stems.
-
+**Tally: 28 MATCH · 56 gap · 13 crash · 0 no-ref** of 97 stems.
 
 ## Tier 1
 
 | stem | C P/S/F | VM P/S/F | status |
 |---|---|---|---|
-| abstractlist | 0/123/0 | 0/123/0 | MATCH |
-| append | 49/3/0 | 44/3/5 | gap |
-| appendComp | 43/5/0 | 38/5/5 | gap |
-| apply | 38/4/0 | 18/4/20 | gap |
-| assemble | (no ref) | ERROR | CRASH |
-| assocd | 0/11/0 | 0/11/0 | MATCH |
-| basic | 69/77/0 | 43/78/25 | gap |
-| cmdAH | 16820/181/0 | ERROR | CRASH |
-| cmdIL | 163/5/0 | 129/7/32 | gap |
-| cmdInfo | 0/12/0 | 0/12/0 | MATCH |
-| cmdMZ | 96/1/0 | 40/3/54 | gap |
-| compExpr | 80/2/0 | 64/2/16 | gap |
-| compExpr-old | 183/1/0 | 121/2/61 | gap |
+| parse | 90/181/0 | 69/181/21 | gap |
+| parseOld | 158/0/0 | 148/0/10 | gap |
+| parseExpr | 67/219/0 | 3/219/64 | gap |
+| word | 55/0/0 | 55/0/0 | MATCH |
+| subst | 62/1/0 | 53/1/9 | gap |
 | compile | 138/33/0 | 61/33/77 | gap |
-| concat | 9/0/0 | 9/0/0 | MATCH |
-| dict | 367/6/0 | 282/6/85 | gap |
-| dstring | 0/46/0 | 0/46/0 | MATCH |
-| error | 309/8/0 | 278/8/31 | gap |
-| eval | 12/0/0 | 11/0/1 | gap |
-| execute | 79/78/0 | 54/78/25 | gap |
-| expr | 2137/31/0 | 1621/32/515 | gap |
-| expr-old | 430/31/0 | 330/31/100 | gap |
+| execute | 79/78/0 | 60/78/19 | gap |
+| basic | 69/77/0 | 44/78/24 | gap |
+| misc | 2/299/0 | 1/299/1 | gap |
+| compExpr | 80/2/0 | 71/2/9 | gap |
+| compExpr-old | 183/1/0 | 138/2/44 | gap |
+| appendComp | 43/5/0 | 39/5/4 | gap |
+| lsetComp | 19/0/0 | 19/0/0 | MATCH |
+| regexpComp | 179/0/0 | 167/1/11 | gap |
+| assemble | (no ref) | ERROR | CRASH |
+| obj | 8/76/0 | 8/76/0 | MATCH |
+| nre | 5/23/0 | 2/23/3 | gap |
+| eval | 12/0/0 | 12/0/0 | MATCH |
+| if | 73/0/0 | 71/0/2 | gap |
+| if-old | 33/0/0 | 33/0/0 | MATCH |
 | for | 64/24/0 | 57/24/7 | gap |
 | for-old | 9/0/0 | 8/0/1 | gap |
 | foreach | 43/0/0 | 37/0/6 | gap |
-| format | 269/0/0 | 174/19/76 | gap |
-| get | 6/17/0 | 4/17/2 | gap |
-| if | 73/0/0 | 66/0/7 | gap |
-| if-old | 33/0/0 | 32/0/1 | gap |
+| while | 46/0/0 | 45/0/1 | gap |
+| while-old | 15/0/0 | 15/0/0 | MATCH |
+| switch | 113/0/0 | 99/0/14 | gap |
+| error | 309/8/0 | 296/8/13 | gap |
+| result | 4/22/0 | 0/22/4 | gap |
+| expr | 2137/31/0 | 1921/32/215 | gap |
+| expr-old | 430/31/0 | 393/31/37 | gap |
+| mathop | 385/0/0 | 350/0/35 | gap |
 | incr | 69/0/0 | 61/0/8 | gap |
-| incr-old | 14/0/0 | 10/0/4 | gap |
-| indexObj | 0/65/0 | 0/65/0 | MATCH |
-| info | 282/5/0 | 85/6/196 | gap |
+| incr-old | 14/0/0 | 11/0/3 | gap |
+| proc | 29/9/0 | 26/9/3 | gap |
+| proc-old | 74/0/0 | 61/0/13 | gap |
+| apply | 38/4/0 | 26/4/12 | gap |
+| uplevel | 57/0/0 | 53/0/4 | gap |
+| upvar | 62/8/0 | 29/8/33 | gap |
+| namespace | 311/3/0 | 147/3/164 | gap |
+| namespace-old | 126/0/0 | 102/0/24 | gap |
+| var | 198/21/0 | 118/21/80 | gap |
+| info | 282/5/0 | 102/6/179 | gap |
+| cmdInfo | 0/12/0 | 0/12/0 | MATCH |
+| trace | 273/17/0 | 120/17/153 | gap |
+| rename | 11/8/0 | 10/8/1 | gap |
+| unknown | 7/0/0 | 7/0/0 | MATCH |
+| string | 693/12/0 | 676/12/17 | gap |
+| set | 63/1/0 | 63/1/0 | MATCH |
+| set-old | 153/0/0 | 91/0/62 | gap |
+| append | 49/3/0 | 45/3/4 | gap |
+| format | 269/0/0 | 239/0/30 | gap |
+| scan | 184/1/0 | 169/1/15 | gap |
+| split | 18/0/0 | 18/0/0 | MATCH |
 | join | 10/0/0 | 10/0/0 | MATCH |
-| lindex | 47/37/0 | 44/37/3 | gap |
-| linsert | 28/0/0 | 27/0/1 | gap |
+| concat | 9/0/0 | 9/0/0 | MATCH |
+| regexp | 253/4/0 | 231/5/21 | gap |
+| stringObj | 0/81/0 | 0/81/0 | MATCH |
+| dstring | 0/46/0 | 0/46/0 | MATCH |
 | list | 78/0/0 | 78/0/0 | MATCH |
-| listObj | 42/17/0 | 42/17/0 | MATCH |
-| listRep | 4/227/0 | 4/227/0 | MATCH |
+| lindex | 47/37/0 | 46/37/1 | gap |
+| linsert | 28/0/0 | 28/0/0 | MATCH |
 | llength | 6/0/0 | 6/0/0 | MATCH |
-| lmap | 66/0/0 | 63/0/3 | gap |
-| lpop | 17/2/0 | 17/2/0 | MATCH |
 | lrange | 1764/2/0 | 1759/2/5 | gap |
 | lrepeat | 11/1/0 | 11/1/0 | MATCH |
 | lreplace | 3579/0/0 | 3579/0/0 | MATCH |
-| lsearch | 165/0/0 | 163/0/2 | gap |
-| lseq | 132/2/0 | 95/3/36 | gap |
+| lsearch | 165/0/0 | 165/0/0 | MATCH |
 | lset | 0/89/0 | 0/89/0 | MATCH |
-| lsetComp | 19/0/0 | 19/0/0 | MATCH |
-| mathop | 385/0/0 | 248/0/137 | gap |
-| misc | 2/299/0 | 1/299/1 | gap |
-| namespace | 311/3/0 | 141/3/170 | gap |
-| namespace-old | 126/0/0 | 99/0/27 | gap |
-| nre | 5/23/0 | 2/23/3 | gap |
-| obj | 8/76/0 | 8/76/0 | MATCH |
-| parse | 90/181/0 | 60/181/30 | gap |
-| parseExpr | 67/219/0 | 3/219/64 | gap |
-| parseOld | 158/0/0 | 148/0/10 | gap |
-| proc | 29/9/0 | 20/9/9 | gap |
-| proc-old | 74/0/0 | 57/0/17 | gap |
-| regexp | 253/4/0 | 231/5/21 | gap |
-| regexpComp | 179/0/0 | 167/1/11 | gap |
-| rename | 11/8/0 | 10/8/1 | gap |
-| result | 4/22/0 | 0/22/4 | gap |
-| scan | 184/1/0 | 125/1/59 | gap |
-| set | 63/1/0 | 63/1/0 | MATCH |
-| set-old | 153/0/0 | 88/0/65 | gap |
-| split | 18/0/0 | 18/0/0 | MATCH |
-| string | 693/12/0 | 671/12/22 | gap |
-| stringObj | 0/81/0 | 0/81/0 | MATCH |
-| subst | 62/1/0 | 23/1/39 | gap |
-| switch | 113/0/0 | 99/0/14 | gap |
-| trace | 273/17/0 | 80/17/193 | gap |
-| unknown | 7/0/0 | 7/0/0 | MATCH |
-| uplevel | 57/0/0 | 33/0/24 | gap |
-| upvar | 62/8/0 | 28/8/34 | gap |
-| util | 310/152/0 | 133/152/177 | gap |
-| var | 198/21/0 | 58/21/140 | gap |
-| while | 46/0/0 | 45/0/1 | gap |
-| while-old | 15/0/0 | 14/0/1 | gap |
-| word | 55/0/0 | 55/0/0 | MATCH |
+| lmap | 66/0/0 | 63/0/3 | gap |
+| lpop | 17/2/0 | 17/2/0 | MATCH |
+| lseq | 132/2/0 | 96/3/35 | gap |
+| listObj | 42/17/0 | 42/17/0 | MATCH |
+| listRep | 4/227/0 | 4/227/0 | MATCH |
+| abstractlist | 0/123/0 | 0/123/0 | MATCH |
+| cmdAH | 16820/181/0 | ERROR | CRASH |
+| cmdIL | 163/5/0 | 132/7/29 | gap |
+| cmdMZ | 96/1/0 | 49/3/45 | gap |
+| util | 310/152/0 | 280/152/30 | gap |
+| dict | 367/6/0 | 324/6/43 | gap |
+| indexObj | 0/65/0 | 0/65/0 | MATCH |
+| get | 6/17/0 | 6/17/0 | MATCH |
+| assocd | 0/11/0 | 0/11/0 | MATCH |
 
 ## Tier 2
 
 | stem | C P/S/F | VM P/S/F | status |
 |---|---|---|---|
-| binary | 660/90/0 | 578/91/81 | gap |
 | coroutine | 74/3/0 | 0/3/74 | gap |
+| tailcall | 29/8/0 | 21/8/8 | gap |
 | interp | 340/14/0 | ERROR | CRASH |
+| binary | 660/90/0 | 600/91/59 | gap |
 | oo | 372/16/0 | ERROR | CRASH |
 | ooNext2 | 57/5/0 | ERROR | CRASH |
 | ooProp | 55/0/0 | ERROR | CRASH |
 | ooUtil | 33/0/0 | ERROR | CRASH |
-| tailcall | 29/8/0 | ERROR | CRASH |
 
 ## Tier 3
 
 | stem | C P/S/F | VM P/S/F | status |
 |---|---|---|---|
-| clock | (no ref) | ERROR | CRASH |
 | encoding | (no ref) | ERROR | CRASH |
+| utf | 148/251/0 | 133/251/15 | gap |
+| clock | (no ref) | ERROR | CRASH |
 | msgcat | (no ref) | ERROR | CRASH |
 | safe | 147/8/0 | ERROR | CRASH |
 | safe-stock | 11/0/0 | 0/0/11 | gap |
 | safe-stock86 | 0/0/0 | ERROR | CRASH |
 | safe-zipfs | (no ref) | ERROR | CRASH |
-| utf | 148/251/0 | 133/251/15 | gap |
+

--- a/docs/design/runtime/rust-vm-tier-parity.md
+++ b/docs/design/runtime/rust-vm-tier-parity.md
@@ -6,7 +6,7 @@ Goal: the VM's (passed/skipped/failed) per stem EXACTLY matches C Tcl 9 (`tests/
 
 `CRASH` = an uncaught error/timeout aborts the file (highest leverage — one fix unlocks it). Columns: **C P/S/F** vs **VM P/S/F**.
 
-**Tally: 28 MATCH · 56 gap · 13 crash · 0 no-ref** of 97 stems.
+**Tally: 28 MATCH · 58 gap · 11 crash · 0 no-ref** of 97 stems.
 
 ## Tier 1
 
@@ -16,14 +16,14 @@ Goal: the VM's (passed/skipped/failed) per stem EXACTLY matches C Tcl 9 (`tests/
 | parseOld | 158/0/0 | 148/0/10 | gap |
 | parseExpr | 67/219/0 | 3/219/64 | gap |
 | word | 55/0/0 | 55/0/0 | MATCH |
-| subst | 62/1/0 | 53/1/9 | gap |
-| compile | 138/33/0 | 61/33/77 | gap |
-| execute | 79/78/0 | 60/78/19 | gap |
-| basic | 69/77/0 | 44/78/24 | gap |
+| subst | 62/1/0 | 54/1/8 | gap |
+| compile | 138/33/0 | 63/33/75 | gap |
+| execute | 79/78/0 | 65/78/14 | gap |
+| basic | 69/77/0 | 45/78/23 | gap |
 | misc | 2/299/0 | 1/299/1 | gap |
 | compExpr | 80/2/0 | 71/2/9 | gap |
 | compExpr-old | 183/1/0 | 138/2/44 | gap |
-| appendComp | 43/5/0 | 39/5/4 | gap |
+| appendComp | 43/5/0 | 40/5/3 | gap |
 | lsetComp | 19/0/0 | 19/0/0 | MATCH |
 | regexpComp | 179/0/0 | 167/1/11 | gap |
 | assemble | (no ref) | ERROR | CRASH |
@@ -45,15 +45,15 @@ Goal: the VM's (passed/skipped/failed) per stem EXACTLY matches C Tcl 9 (`tests/
 | mathop | 385/0/0 | 350/0/35 | gap |
 | incr | 69/0/0 | 61/0/8 | gap |
 | incr-old | 14/0/0 | 11/0/3 | gap |
-| proc | 29/9/0 | 26/9/3 | gap |
+| proc | 29/9/0 | 27/9/2 | gap |
 | proc-old | 74/0/0 | 61/0/13 | gap |
 | apply | 38/4/0 | 26/4/12 | gap |
-| uplevel | 57/0/0 | 53/0/4 | gap |
+| uplevel | 57/0/0 | 54/0/3 | gap |
 | upvar | 62/8/0 | 29/8/33 | gap |
-| namespace | 311/3/0 | 147/3/164 | gap |
+| namespace | 311/3/0 | 149/3/162 | gap |
 | namespace-old | 126/0/0 | 102/0/24 | gap |
-| var | 198/21/0 | 118/21/80 | gap |
-| info | 282/5/0 | 102/6/179 | gap |
+| var | 198/21/0 | 119/21/79 | gap |
+| info | 282/5/0 | 103/6/178 | gap |
 | cmdInfo | 0/12/0 | 0/12/0 | MATCH |
 | trace | 273/17/0 | 120/17/153 | gap |
 | rename | 11/8/0 | 10/8/1 | gap |
@@ -85,7 +85,7 @@ Goal: the VM's (passed/skipped/failed) per stem EXACTLY matches C Tcl 9 (`tests/
 | listObj | 42/17/0 | 42/17/0 | MATCH |
 | listRep | 4/227/0 | 4/227/0 | MATCH |
 | abstractlist | 0/123/0 | 0/123/0 | MATCH |
-| cmdAH | 16820/181/0 | ERROR | CRASH |
+| cmdAH | 16820/181/0 | 589/190/16222 | gap |
 | cmdIL | 163/5/0 | 132/7/29 | gap |
 | cmdMZ | 96/1/0 | 49/3/45 | gap |
 | util | 310/152/0 | 280/152/30 | gap |
@@ -100,7 +100,7 @@ Goal: the VM's (passed/skipped/failed) per stem EXACTLY matches C Tcl 9 (`tests/
 |---|---|---|---|
 | coroutine | 74/3/0 | 0/3/74 | gap |
 | tailcall | 29/8/0 | 21/8/8 | gap |
-| interp | 340/14/0 | ERROR | CRASH |
+| interp | 340/14/0 | 84/15/255 | gap |
 | binary | 660/90/0 | 600/91/59 | gap |
 | oo | 372/16/0 | ERROR | CRASH |
 | ooNext2 | 57/5/0 | ERROR | CRASH |

--- a/docs/design/runtime/tcl-test-tiers.md
+++ b/docs/design/runtime/tcl-test-tiers.md
@@ -1,0 +1,118 @@
+# Tcl test tiers — the capability ladder to C parity
+
+The goal is for the Rust interpreters (`tcl-vm` bytecode VM, `runtime/rust`
+tree-walk runtime) to match C Tcl 9's pass / fail / skip on the upstream
+tcltest suite. This document orders that work as a **capability ladder**: a
+lower tier is a prerequisite for the tiers above it, so fixing tiers
+bottom-up is the highest-leverage order. A bug in parsing corrupts every test
+above; a missing socket only affects I/O.
+
+The live per-stem scoreboard (C P/S/F vs VM P/S/F, MATCH / gap / CRASH) lives
+in [`rust-vm-tier-parity.md`](rust-vm-tier-parity.md). This document is the
+*semantic* grouping behind it — what each tier means and why its order matters.
+The two are complementary: the scoreboard says *where we are*, the ladder says
+*what to fix next and why*.
+
+## The ladder
+
+### Tier 1 — Parsing
+
+The lexer, word splitter, brace/quote/bracket nesting, backslash and
+command/variable substitution, and the expression tokeniser. Everything else
+is built on getting bytes → words → commands right.
+
+> Stems: `parse`, `parseOld`, `parseExpr`, `word`, `subst`
+
+### Tier 2 — Interpretation
+
+Turning parsed commands into execution: the bytecode compiler, the VM's
+execution loop, `eval`/`uplevel` re-entry, and the object/representation model.
+A parser that is correct but an executor that mis-dispatches fails here.
+
+> Stems: `basic`, `compile`, `execute`, `eval`, `assemble`, `obj`, `nre`,
+> `appendComp`, `lsetComp`, `regexpComp`, `compExpr`, `compExpr-old`, `misc`
+
+### Tier 3 — Fundamental Tcl machinery
+
+The state model every command relies on. Within the tier the order is roughly
+variables → namespaces → traces → aliases/introspection, but all of it gates
+Tier 4.
+
+- **Variable storage & management** — scalars, arrays, `upvar`/`uplevel`
+  linkage, qualified vs local resolution.
+  > `var`, `set`, `set-old`, `append`, `incr`, `incr-old`, `upvar`, `uplevel`, `get`
+- **Namespaces** — creation, qualified resolution, `import`/`forget`/`export`,
+  ensembles, the namespace a command (incl. a renamed proc) executes in.
+  > `namespace`, `namespace-old`
+- **Traces** — read / write / unset / array variable traces and command traces,
+  including firing from `info exists` and the `set` read path.
+  > `trace`
+- **Aliasing, rename & introspection** — `rename` (incl. across namespaces),
+  `interp alias`, and the `info` surface tests read to verify the above.
+  > `rename`, `info`, `cmdInfo`, `indexObj`, `assocd`
+
+#### Tier 3.5 — Pure-compute data types
+
+Lists, dicts, strings, and the numeric/format/scan commands. They depend only
+on Tiers 1–3 and are themselves prerequisites for most higher-tier test
+bodies, so they sit between the machinery and control flow. Pure computation —
+they run identically on every backend.
+
+> `list`, `lindex`, `linsert`, `llength`, `lrange`, `lrepeat`, `lreplace`,
+> `lsearch`, `lset`, `lmap`, `lpop`, `lseq`, `listObj`, `listRep`,
+> `abstractlist`, `dict`, `string`, `stringObj`, `format`, `scan`, `split`,
+> `join`, `concat`, `regexp`, `cmdIL`, `cmdAH`, `binary`
+
+### Tier 4 — Control flow & evaluation
+
+Conditionals, loops, exceptions, procedures, and expressions — the constructs
+that drive a test body. Built on Tiers 1–3.5.
+
+> Stems: `if`, `if-old`, `for`, `for-old`, `foreach`, `while`, `while-old`,
+> `switch`, `error`, `result`, `cmdMZ` (catch/try/throw), `expr`, `expr-old`,
+> `mathop`, `proc`, `proc-old`, `apply`, `unknown`, `tailcall`, `coroutine`,
+> `oo` (TclOO)
+
+### Tier 5 — I/O
+
+Channels, files, globbing, sockets, and the event loop. The first tier whose
+capabilities a backend can *lack*: WASI has no sockets, eBPF has no I/O at all.
+This is where the [backend-constraint overlay](backend-constraints.md) starts
+skipping tests.
+
+> Stems: `io`, `chan`, `chanio`, `iocmd`, `iogt`, `iortrans`, `socket`,
+> `fileevent`, `file`, `glob`, `fCmd`, `fileName`
+
+### Tier 6 — Platform-specific features
+
+Capabilities tied to the host OS or a specific build: clocks/timezones,
+encodings, message catalogues, subprocesses, dynamic loading, threads, and the
+safe-interpreter machinery. Heavily backend-gated — most of these are skipped
+on wasm / WASI / eBPF.
+
+> Stems: `clock`, `encoding`, `msgcat`, `utf`, `safe`, `safe-stock`,
+> `safe-stock86`, `safe-zipfs`, `exec`, `load`, `thread`, `registry`, `env`,
+> `pid`
+
+## How to use the ladder
+
+- **Fix bottom-up.** A Tier 1 parser bug or a Tier 3 trace bug shows up as
+  scattered failures across many higher-tier stems; fixing it lifts all of
+  them at once (e.g. firing read traces from `info exists` unblocked lazy
+  tcltest constraints across the whole suite). Chasing an individual Tier 4
+  failure while a Tier 3 fundamental is broken is usually wasted work.
+- **Use the scoreboard for "where", the ladder for "why".** A CRASH on a low
+  tier is the highest-leverage fix — it zeroes a whole file. Within a tier,
+  prefer the stem whose failures share a single root cause.
+- **Tier 5–6 parity is per-backend.** Match C on native; on wasm / WASI / eBPF
+  the honest target is "skip what you can't do", which the
+  [backend-constraint overlay](backend-constraints.md) handles, so the
+  pass/fail/skip line still matches what the backend can run.
+
+## Cross-references
+
+- [`rust-vm-tier-parity.md`](rust-vm-tier-parity.md) — live per-stem scoreboard.
+- [`backend-constraints.md`](backend-constraints.md) — per-backend skip overlay
+  and `tcl_platform` introspection.
+- [`tcltest-bringup.md`](tcltest-bringup.md) — how the real `init.tcl` /
+  `tcltest.tcl` are brought up on the runtime, and the no-edit hard rules.

--- a/docs/design/runtime/tcl-test-tiers.md
+++ b/docs/design/runtime/tcl-test-tiers.md
@@ -12,28 +12,50 @@ in [`rust-vm-tier-parity.md`](rust-vm-tier-parity.md). This document is the
 *semantic* grouping behind it — what each tier means, which **exact upstream
 `.test` files** belong to it, and why the order matters.
 
+## Purpose — incremental delivery with a ratchet
+
+The ladder is not just a description; it is the **delivery plan**. We bring the
+runtime to C parity **one tier at a time, bottom-up**, and once a tier is green
+we **lock it** so later work cannot silently break it. Two properties fall out:
+
+- **Contained rework.** A lower tier is a prerequisite for every tier above it,
+  so fixing it once (the fundamentals — parsing, traces, encodings, channels)
+  lifts everything that depends on it instead of being patched per-symptom in
+  ten higher-tier files. We finish a tier before climbing, so we are never
+  building Tier 5 behaviour on a Tier 3 bug.
+- **No backsliding.** Each tier's parity is captured as a pass-only ratchet in
+  the committed baselines (`tests/baselines/tcl9-tcltest-vm/summary.json` and
+  the WASM/runtime equivalents) — the regression gate only ever lets the
+  pass-count rise. A change that regresses a tier already declared green fails
+  the gate, so progress is monotonic: a tier, once passed, stays passed.
+
+So the workflow is: pick the lowest tier not yet at parity → drive it to
+MATCH across its files → ratchet the baseline → move up. The tier number is the
+order; the ratchet is what keeps the lower rungs from rotting while we work on
+the higher ones.
+
 ## Core language vs optional features
 
 The single most useful distinction the ladder encodes: a **core language**
 versus a long tail of **optional features**.
 
-- **Core language — Tiers 1–7.** What makes the thing Tcl: parsing,
+- **Core language — Tiers 1–8.** What makes the thing Tcl: parsing,
   interpretation, the fundamental machinery (variables, namespaces, traces,
-  aliases, option/ensemble dispatch, encodings, core channels), data types,
-  control flow, the object system, and interpreters. Every backend must match C
-  here, exactly — there is no "skip it" escape hatch, because a program cannot
-  run without it.
-- **Optional features — Tiers 8–10.** Capabilities layered on top. Some are
+  aliases, option/ensemble dispatch, encodings, core channels, the `env`
+  array), data types, control flow, the object system, package loading, and
+  interpreters. Every backend must match C here, exactly — there is no "skip it"
+  escape hatch, because a program (or the standard library that bootstraps it)
+  cannot run without it.
+- **Optional features — Tiers 9–11.** Capabilities layered on top. Some are
   **host/OS-dependent** (sockets, the event loop, subprocesses, dynamic
   loading, threads, clocks) and are legitimately absent on a sandboxed backend.
   Others are **"just a feature"** — a self-contained subsystem that could ship
   as a package and that no core program needs: compression (`zlib`/`zipfs`),
-  HTTP (`http*`), message catalogues (`msgcat`), the module/package machinery
-  (`package`/`tm`), the registry. Parity on these matters for completeness but
-  never blocks the core.
+  HTTP (`http*`), message catalogues (`msgcat`), the option parser (`opt`), the
+  registry. Parity on these matters for completeness but never blocks the core.
 
-Rule of thumb when triaging: a failure in Tiers 1–7 gets fixed; a failure in
-Tiers 8–10 first gets the question "can the running backend even do this?" — and
+Rule of thumb when triaging: a failure in Tiers 1–8 gets fixed; a failure in
+Tiers 9–11 first gets the question "can the running backend even do this?" — and
 if not, the [backend-constraint overlay](backend-constraints.md) skips it.
 
 ## How to read the file lists
@@ -53,9 +75,9 @@ if not, the [backend-constraint overlay](backend-constraints.md) skips it.
     (scan/string/split/regexp), control flow (return/switch).
 - The same overlap rule applies to whole subsystems: the **channel** and
   **encoding** files exercise both their fundamental core (Tier 3) and their
-  advanced surface (Tiers 8/10), so they appear in both.
+  advanced surface (Tiers 9/11), so they appear in both.
 - Platform-native files (`win*`, `mac*`/`macOSX*`, `unix*`) are listed in
-  Tier 10 and are out of scope for the portable Rust runtimes except where the
+  Tier 11 and are out of scope for the portable Rust runtimes except where the
   generic command underneath is tested.
 
 ## The ladder
@@ -84,9 +106,10 @@ subsystems that are *fundamental*, not platform extras: **option/ensemble
 dispatch**, **encodings**, and the **core channel abstraction**.
 
 - **Variable storage & management** — scalars, arrays, `upvar`/`uplevel`
-  linkage, qualified vs local resolution.
+  linkage, qualified vs local resolution, and the predefined globals
+  (`tcl_platform`, **`env`**) the bootstrap installs.
   > `var`, `set`, `set-old`, `append`, `incr`, `incr-old`, `upvar`, `uplevel`,
-  > `get`, `link` · `cmdMZ` (set/unset group)
+  > `get`, `link`, `env` · `cmdMZ` (set/unset group)
 - **Namespaces** — creation, qualified resolution,
   `import`/`forget`/`export`, ensembles, the namespace a command (incl. a
   renamed proc) runs in, custom resolvers.
@@ -97,20 +120,21 @@ dispatch**, **encodings**, and the **core channel abstraction**.
 - **Aliasing, rename & introspection** — `rename` (incl. across namespaces),
   and the `info` surface used to verify the machinery above.
   > `rename`, `info`, `cmdInfo` · `cmdIL` (info group)
-- **Option & ensemble dispatch** — `Tcl_GetIndexFromObj`-style subcommand /
-  option resolution (unambiguous-prefix matching, the `bad option …: must be …`
-  wording) and the `::tcl::OptProc` parser the standard library builds on.
-  > `opt`, `indexObj` · every ensemble (`string`/`dict`/`namespace`/`chan`/
-  > `file`/`clock`/`interp`) depends on this.
+- **Option & ensemble dispatch** — the built-in `Tcl_GetIndexFromObj`
+  subcommand / option resolution (unambiguous-prefix matching, the
+  `bad option …: must be …` wording) every ensemble relies on. (The pure-Tcl
+  `::tcl::OptProc` *package* — `opt` — is a library feature, Tier 11.)
+  > `indexObj` · every ensemble (`string`/`dict`/`namespace`/`chan`/`file`/
+  > `clock`/`interp`) depends on this.
 - **Encodings** — the Unicode core: `encoding convertfrom`/`convertto`, the
   internal UTF representation, and `\u`/`\U` handling that string and channel
   code assume.
-  > `encoding`, `utf`, `utfext` · advanced/external encodings → Tier 10
+  > `encoding`, `utf`, `utfext` · advanced/external encodings → Tier 11
 - **Core channels** — the channel abstraction itself: `puts`/`gets`/`read`/
   `open`/`close`/`flush`/`eof` on the standard and in-memory channels — what
   `puts stdout` and the test harness's output capture rely on.
   > `chan`, `io` (core groups) · non-blocking / transforms / sockets / events →
-  > Tier 8 · `cmdAH` (close/eof/flush/gets group)
+  > Tier 9 · `cmdAH` (close/eof/flush/gets group)
 
 ### Tier 4 — Data types  *(core)*
 
@@ -143,20 +167,33 @@ that drive a test body. Built on Tiers 1–4.
 ### Tier 6 — Object system (TclOO)  *(core, mid)*
 
 The standard object system — classes, objects, methods, `next`, mixins,
-filters, and properties. Mid-tier: it is core Tcl (8.6+), built squarely on
+filters, and properties. Mid-tier: core Tcl (8.6+), built squarely on
 procedures, namespaces, and ensemble dispatch (Tiers 3 & 5), but nothing below
 it depends on it.
 
 > `oo`, `ooNext2`, `ooProp`, `ooUtil`
 
-### Tier 7 — Interpreters (child & safe)  *(core)*
+### Tier 7 — Packages & code loading  *(core)*
+
+Loading code at run time: `source`, the `package` database
+(`provide`/`require`/`ifneeded`/`vsatisfies`/`vcompare`), Tcl modules (`tm`),
+and the auto-load / index machinery. Core because the standard library — and
+tcltest itself — bootstraps through it. The version/dependency logic is
+pure computation; the auto-load path layers on `source`, which needs the
+filesystem on backends that have one.
+
+> `package`, `pkgMkIndex`, `autoMkindex`, `tm`, `config` · `source`
+> (the loading primitive; FS surface shared with Tier 9)
+
+### Tier 8 — Interpreters (child & safe)  *(core)*
 
 Creating, evaluating in, and tearing down **child interpreters**, the
 cross-interpreter **alias** and **hidden-command** machinery, and **safe
 interpreters** (`interp create -safe`, `marktrusted`, the Safe Base). A child
 interp re-enters the whole evaluator; a *safe* interp is precisely the
 mechanism that gates a child's access to the optional-feature tiers above.
-Depends on namespaces and aliases (Tier 3) and `eval`/control flow (Tiers 2, 5).
+Depends on namespaces/aliases (Tier 3), control flow (Tier 5), and package
+loading (Tier 7 — the Safe Base is loaded as a package).
 
 - **Child interpreters** — `interp create`/`eval`/`delete`/`exists`/`children`,
   child-as-command dispatch, `recursionlimit`, `interp target`/`share`/
@@ -167,7 +204,7 @@ Depends on namespaces and aliases (Tier 3) and `eval`/control flow (Tiers 2, 5).
   `safe.tcl` re-aliasing of `source`/`load`/`file`/`encoding`.
   > `safe`, `safe-stock`, `safe-stock86`, `safe-zipfs`, `security`
 
-### Tier 8 — Advanced I/O & events  *(feature, host-dependent)*
+### Tier 9 — Advanced I/O & events  *(feature, host-dependent)*
 
 The capabilities beyond the Tier 3 channel core: sockets, the event loop and
 fileevents, channel transforms and stacking, the filesystem command surface,
@@ -180,10 +217,10 @@ no sockets, eBPF has no I/O at all — so this is where the
 > · Sockets: `socket`
 > · Event loop: `event`, `async`, `timer`, `notify`, `fileevent`
 > · Files / FS: `fCmd`, `fileName`, `fileSystem`, `fileSystemEncoding`, `pwd`,
-> `link`, `source`
+> `link`
 > · `cmdAH` (after/fblocked/fconfigure/file/fileevent/glob group)
 
-### Tier 9 — Concurrency & advanced evaluation  *(feature, late)*
+### Tier 10 — Concurrency & advanced evaluation  *(feature, late)*
 
 Constructs that suspend, resume, or parallelise execution. Late because they
 sit on top of a correct evaluator, the event loop, and (for threads) the host.
@@ -192,19 +229,18 @@ sit on top of a correct evaluator, the event loop, and (for threads) the host.
 > · Tailcall: `tailcall`
 > · Threads: `thread`, `mutex`
 
-### Tier 10 — Platform & library features  *(feature, late)*
+### Tier 11 — Platform & library features  *(feature, late)*
 
 The long tail. **Host/OS-dependent**: subprocesses, dynamic loading,
 clocks/timezones, the advanced/external encoding surface. **Pure library
-features** (each could be a package, none is needed by a core program):
-message catalogues, packages/modules, compression, networking protocols, the
+features** (each could be a package, none is needed by a core program): the
+option parser, message catalogues, compression, networking protocols, the
 registry. Heavily backend-gated — most are skipped on wasm / WASI / eBPF.
 
-> Host/OS: `exec`, `process`, `pid`, `env`, `load`, `unload`, `clock`,
-> `clock-ivm`, `icu`
-> · Library features: `msgcat`, `package`, `pkgMkIndex`, `autoMkindex`, `tm`,
-> `config`, `zipfs`, `zlib`, `http`, `http11`, `httpPipeline`, `httpProxy`,
-> `httpcookie`, `registry`
+> Host/OS: `exec`, `process`, `pid`, `load`, `unload`, `clock`, `clock-ivm`,
+> `icu`
+> · Library features: `opt`, `msgcat`, `zipfs`, `zlib`, `http`, `http11`,
+> `httpPipeline`, `httpProxy`, `httpcookie`, `registry`
 > · Bootstrap / misc: `platform`, `init`, `main`, `history`, `aaa_exit`,
 > `bigdata`, `brodnik`
 > · Native-only (out of scope for the portable runtimes): `unixFCmd`,
@@ -221,23 +257,25 @@ core-vs-feature lens.
 
 | Area | Files | Tier | Kind |
 |---|---|---|---|
-| Option / ensemble dispatch | `opt`, `indexObj` | 3 | core |
+| Built-in option / ensemble dispatch | `indexObj` | 3 | core |
 | Encodings / Unicode core | `encoding`, `utf`, `utfext` | 3 | core |
 | Core channels | `chan`, `io` (core) | 3 | core |
+| `env` array | `env` | 3 | core |
 | Namespace ensembles | `namespace` (ensemble group) | 3 | core |
 | Custom resolvers | `resolver` | 3 | core |
 | TclOO | `oo`, `ooNext2`, `ooProp`, `ooUtil` | 6 | core (mid) |
-| Child / safe interpreters | `interp`, `safe`, `safe-*`, `security` | 7 | core |
-| Channel transforms / stacking | `iogt`, `ioTrans` | 8 | feature (host) |
-| Event loop / async | `event`, `async`, `timer`, `notify`, `fileevent` | 8 | feature (host) |
-| Coroutines / NRE | `coroutine`, `dcall`, `nre` | 9 (2 for NRE basics) | feature |
-| Threads | `thread`, `mutex` | 9 | feature (host) |
-| Subprocess / dynamic load | `exec`, `process`, `load`, `unload` | 10 | feature (host) |
-| Packages / modules | `package`, `pkgMkIndex`, `autoMkindex`, `tm` | 10 | feature (library) |
-| Compression / archives | `zlib`, `zipfs` | 10 | feature (library) |
-| HTTP protocol | `http`, `http11`, `httpPipeline`, `httpProxy`, `httpcookie` | 10 | feature (library) |
-| Message catalogues | `msgcat` | 10 | feature (library) |
-| Abstract / big lists | `abstractlist`, `range`, `bigdata` | 4, 10 | core / feature |
+| Packages / modules / loading | `package`, `pkgMkIndex`, `autoMkindex`, `tm`, `source` | 7 | core |
+| Child / safe interpreters | `interp`, `safe`, `safe-*`, `security` | 8 | core |
+| Channel transforms / stacking | `iogt`, `ioTrans` | 9 | feature (host) |
+| Event loop / async | `event`, `async`, `timer`, `notify`, `fileevent` | 9 | feature (host) |
+| Coroutines / NRE | `coroutine`, `dcall`, `nre` | 10 (2 for NRE basics) | feature |
+| Threads | `thread`, `mutex` | 10 | feature (host) |
+| Subprocess / dynamic load | `exec`, `process`, `load`, `unload` | 11 | feature (host) |
+| Option parser package | `opt` | 11 | feature (library) |
+| Compression / archives | `zlib`, `zipfs` | 11 | feature (library) |
+| HTTP protocol | `http`, `http11`, `httpPipeline`, `httpProxy`, `httpcookie` | 11 | feature (library) |
+| Message catalogues | `msgcat` | 11 | feature (library) |
+| Abstract / big lists | `abstractlist`, `range`, `bigdata` | 4, 11 | core / feature |
 
 ## How to use the ladder
 
@@ -248,20 +286,20 @@ core-vs-feature lens.
   Tier 3 fundamental is broken is usually wasted work.
 - **A CRASH on a low tier is the highest-leverage fix** — it zeroes a whole
   file (e.g. `cmdAH`'s 16 820 C-passing tests are gated behind `interp create`,
-  a Tier 7 feature the bytecode VM still lacks).
+  a Tier 8 feature the bytecode VM still lacks).
 - **Use the scoreboard for "where", the ladder for "why".** Within a tier,
   prefer the stem whose failures share a single root cause.
-- **Tier 8–10 parity is per-backend.** On native, match C exactly; on
+- **Tier 9–11 parity is per-backend.** On native, match C exactly; on
   wasm / WASI / eBPF the honest target is "skip what you can't do", which the
-  [backend-constraint overlay](backend-constraints.md) handles. Tier 7 safe
+  [backend-constraint overlay](backend-constraints.md) handles. Tier 8 safe
   interpreters are the in-language counterpart: a safe child legitimately
-  *cannot* reach Tiers 8–10, so those tests are expected to fail closed.
+  *cannot* reach Tiers 9–11, so those tests are expected to fail closed.
 
 ## Cross-references
 
 - [`rust-vm-tier-parity.md`](rust-vm-tier-parity.md) — live per-stem scoreboard.
 - [`backend-constraints.md`](backend-constraints.md) — per-backend skip overlay
   and `tcl_platform` introspection.
-- [`child-interp.md`](child-interp.md) — child-interpreter design (Tier 7).
+- [`child-interp.md`](child-interp.md) — child-interpreter design (Tier 8).
 - [`tcltest-bringup.md`](tcltest-bringup.md) — how the real `init.tcl` /
   `tcltest.tcl` are brought up, and the no-edit hard rules.

--- a/docs/design/runtime/tcl-test-tiers.md
+++ b/docs/design/runtime/tcl-test-tiers.md
@@ -1,118 +1,215 @@
 # Tcl test tiers — the capability ladder to C parity
 
 The goal is for the Rust interpreters (`tcl-vm` bytecode VM, `runtime/rust`
-tree-walk runtime) to match C Tcl 9's pass / fail / skip on the upstream
-tcltest suite. This document orders that work as a **capability ladder**: a
-lower tier is a prerequisite for the tiers above it, so fixing tiers
-bottom-up is the highest-leverage order. A bug in parsing corrupts every test
-above; a missing socket only affects I/O.
+tree-walk runtime — both native and the wasm/WASI build) to match C Tcl 9's
+pass / fail / skip on the upstream tcltest suite. This document orders that
+work as a **capability ladder**: a lower tier is a prerequisite for the tiers
+above it, so fixing bottom-up is the highest-leverage order. A bug in parsing
+corrupts every test above it; a missing socket only affects I/O.
 
 The live per-stem scoreboard (C P/S/F vs VM P/S/F, MATCH / gap / CRASH) lives
 in [`rust-vm-tier-parity.md`](rust-vm-tier-parity.md). This document is the
-*semantic* grouping behind it — what each tier means and why its order matters.
-The two are complementary: the scoreboard says *where we are*, the ladder says
-*what to fix next and why*.
+*semantic* grouping behind it — what each tier means, which **exact upstream
+`.test` files** belong to it, and why the order matters.
+
+## How to read the file lists
+
+- Every file is `tmp/tcl9.0.3/tests/<name>.test`.
+- A file that spans tiers is listed under **each** tier it touches, tagged with
+  the *command group* that puts it there. The three big "commands A–H / I–L /
+  M–Z" files are the main offenders:
+  - **`cmdAH`** — `after array append break case catch cd clock close concat
+    continue encoding eof error eval exec exit expr fblocked fconfigure file
+    fileevent flush for foreach format gets glob global` → spans Tiers 3.5, 4,
+    6, and 7.
+  - **`cmdIL`** — `info lappend lassign lindex linsert list llength lrange
+    lreplace lreverse lsearch lset lsort` → spans Tiers 3 and 3.5.
+  - **`cmdMZ`** — `regexp regsub return scan set split string subst switch time
+    trace unset` → spans Tiers 1, 3, 3.5, and 4.
+- Platform-native files (`win*`, `mac*`/`macOSX*`, `unix*`) are listed in
+  Tier 7 and are out of scope for the portable Rust runtimes except where the
+  generic command underneath is tested.
 
 ## The ladder
 
 ### Tier 1 — Parsing
 
-The lexer, word splitter, brace/quote/bracket nesting, backslash and
-command/variable substitution, and the expression tokeniser. Everything else
-is built on getting bytes → words → commands right.
+Lexer, word splitter, brace/quote/bracket nesting, backslash and
+command/variable substitution, and the expression tokeniser. Everything above
+depends on bytes → words → commands being right.
 
-> Stems: `parse`, `parseOld`, `parseExpr`, `word`, `subst`
+> `parse`, `parseOld`, `parseExpr`, `word`, `subst`
+> · `cmdMZ` (subst group)
 
 ### Tier 2 — Interpretation
 
-Turning parsed commands into execution: the bytecode compiler, the VM's
-execution loop, `eval`/`uplevel` re-entry, and the object/representation model.
-A parser that is correct but an executor that mis-dispatches fails here.
+Turning parsed commands into execution: the bytecode compiler, the VM
+execution loop, `eval`/`uplevel` re-entry, the non-recursive engine (NRE), and
+the object/representation model.
 
-> Stems: `basic`, `compile`, `execute`, `eval`, `assemble`, `obj`, `nre`,
+> `basic`, `compile`, `execute`, `eval`, `assemble`, `obj`, `nre`,
 > `appendComp`, `lsetComp`, `regexpComp`, `compExpr`, `compExpr-old`, `misc`
 
 ### Tier 3 — Fundamental Tcl machinery
 
-The state model every command relies on. Within the tier the order is roughly
-variables → namespaces → traces → aliases/introspection, but all of it gates
-Tier 4.
+The state model every command relies on. Roughly ordered variables →
+namespaces → traces → aliases/introspection; all of it gates Tier 4.
 
 - **Variable storage & management** — scalars, arrays, `upvar`/`uplevel`
   linkage, qualified vs local resolution.
-  > `var`, `set`, `set-old`, `append`, `incr`, `incr-old`, `upvar`, `uplevel`, `get`
-- **Namespaces** — creation, qualified resolution, `import`/`forget`/`export`,
-  ensembles, the namespace a command (incl. a renamed proc) executes in.
-  > `namespace`, `namespace-old`
-- **Traces** — read / write / unset / array variable traces and command traces,
-  including firing from `info exists` and the `set` read path.
-  > `trace`
+  > `var`, `set`, `set-old`, `append`, `incr`, `incr-old`, `upvar`, `uplevel`,
+  > `get`, `link` · `cmdMZ` (set/unset group)
+- **Namespaces** — creation, qualified resolution,
+  `import`/`forget`/`export`, ensembles, the namespace a command (incl. a
+  renamed proc) runs in, custom command/variable resolvers.
+  > `namespace`, `namespace-old`, `resolver`
+- **Traces** — read / write / unset / array variable traces, command and
+  execution traces (incl. firing from `info exists` and the `set` read path).
+  > `trace` · `cmdMZ` (trace group)
 - **Aliasing, rename & introspection** — `rename` (incl. across namespaces),
-  `interp alias`, and the `info` surface tests read to verify the above.
-  > `rename`, `info`, `cmdInfo`, `indexObj`, `assocd`
+  and the `info` surface tests read to verify the machinery above.
+  > `rename`, `info`, `cmdInfo` · `cmdIL` (info group)
 
-#### Tier 3.5 — Pure-compute data types
+### Tier 3.5 — Pure-compute data types
 
-Lists, dicts, strings, and the numeric/format/scan commands. They depend only
-on Tiers 1–3 and are themselves prerequisites for most higher-tier test
-bodies, so they sit between the machinery and control flow. Pure computation —
-they run identically on every backend.
+Lists, dicts, strings, numeric/format/scan, regexp, and binary. They depend
+only on Tiers 1–3 and are prerequisites for most higher-tier test bodies, so
+they sit between the machinery and control flow. Pure computation — identical
+on every backend.
 
-> `list`, `lindex`, `linsert`, `llength`, `lrange`, `lrepeat`, `lreplace`,
-> `lsearch`, `lset`, `lmap`, `lpop`, `lseq`, `listObj`, `listRep`,
-> `abstractlist`, `dict`, `string`, `stringObj`, `format`, `scan`, `split`,
-> `join`, `concat`, `regexp`, `cmdIL`, `cmdAH`, `binary`
+> Lists: `list`, `lindex`, `linsert`, `llength`, `lrange`, `lrepeat`,
+> `lreplace`, `lsearch`, `lset`, `lsetComp`, `lmap`, `lpop`, `lseq`, `lreverse`,
+> `listObj`, `listRep`, `abstractlist`, `range`
+> · Dicts: `dict`
+> · Strings: `string`, `stringObj`, `format`, `scan`, `split`, `join`, `concat`
+> · Regexp: `regexp`, `regexpComp`, `reg`
+> · Binary / misc: `binary`, `indexObj`, `util`, `stack`, `assocd`
+> · `cmdIL` (list-ops group), `cmdMZ` (scan/string/split group),
+> `cmdAH` (format group)
 
-### Tier 4 — Control flow & evaluation
+### Tier 4 — Control flow & procedures
 
-Conditionals, loops, exceptions, procedures, and expressions — the constructs
-that drive a test body. Built on Tiers 1–3.5.
+Conditionals, loops, exceptions, procedures, expressions, coroutines, and the
+object system — the constructs that drive a test body. Built on Tiers 1–3.5.
 
-> Stems: `if`, `if-old`, `for`, `for-old`, `foreach`, `while`, `while-old`,
-> `switch`, `error`, `result`, `cmdMZ` (catch/try/throw), `expr`, `expr-old`,
-> `mathop`, `proc`, `proc-old`, `apply`, `unknown`, `tailcall`, `coroutine`,
-> `oo` (TclOO)
+> Flow: `if`, `if-old`, `for`, `for-old`, `foreach`, `while`, `while-old`,
+> `switch`, `error`, `result`
+> · Expr: `expr`, `expr-old`, `mathop`
+> · Procs: `proc`, `proc-old`, `apply`, `unknown`
+> · Coroutines / tailcall: `coroutine`, `tailcall`, `dcall`
+> · TclOO: `oo`, `ooNext2`, `ooProp`, `ooUtil`
+> · `cmdMZ` (return/switch group),
+> `cmdAH` (break/case/catch/continue/error/eval/for/foreach group)
 
-### Tier 5 — I/O
+### Tier 5 — Interpreters (child & safe)
+
+Creating, evaluating in, and tearing down **child interpreters**, the
+cross-interpreter **alias** and **hidden-command** machinery, and **safe
+interpreters** (`interp create -safe`, `marktrusted`, the Safe Base). Placed
+above control flow because a child interp re-enters the whole evaluator, and
+below I/O because a *safe* interp is precisely the mechanism that gates a
+child's access to Tiers 6–7. Depends on namespaces and aliases (Tier 3) and
+`eval`/control flow (Tiers 2, 4).
+
+- **Child interpreters** — `interp create`/`eval`/`delete`/`exists`/`children`,
+  child-as-command dispatch, recursion limits, `interp target`/`share`/
+  `transfer`, `interp alias`/`aliases` across paths.
+  > `interp`
+- **Safe interpreters & the Safe Base** — `interp create -safe`, `issafe`,
+  `marktrusted`, `hide`/`expose`/`hidden`/`invokehidden`, and the
+  `safe.tcl` re-aliasing of `source`/`load`/`file`/`encoding`.
+  > `safe`, `safe-stock`, `safe-stock86`, `safe-zipfs`, `security`
+  > · `opt` (the `::tcl::OptProc` option parser the Safe Base builds on)
+
+### Tier 6 — I/O
 
 Channels, files, globbing, sockets, and the event loop. The first tier whose
-capabilities a backend can *lack*: WASI has no sockets, eBPF has no I/O at all.
-This is where the [backend-constraint overlay](backend-constraints.md) starts
-skipping tests.
+capabilities a backend can *lack* — WASI has no sockets, eBPF has no I/O at
+all — so this is where the [backend-constraint overlay](backend-constraints.md)
+starts skipping tests.
 
-> Stems: `io`, `chan`, `chanio`, `iocmd`, `iogt`, `iortrans`, `socket`,
-> `fileevent`, `file`, `glob`, `fCmd`, `fileName`
+> Channels: `io`, `ioCmd`, `ioTrans`, `iogt`, `chan`, `chanio`
+> · Sockets: `socket`
+> · Event loop: `event`, `async`, `timer`, `notify`, `fileevent`
+> · Files / FS: `file`? (see `cmdAH`), `fCmd`, `fileName`, `fileSystem`, `pwd`,
+> `link`, `source`
+> · `cmdAH` (after/close/eof/fblocked/fconfigure/file/fileevent/flush/gets/glob
+> group)
 
-### Tier 6 — Platform-specific features
+### Tier 7 — Platform-specific features
 
 Capabilities tied to the host OS or a specific build: clocks/timezones,
-encodings, message catalogues, subprocesses, dynamic loading, threads, and the
-safe-interpreter machinery. Heavily backend-gated — most of these are skipped
-on wasm / WASI / eBPF.
+encodings, message catalogues, subprocesses, dynamic loading, threads,
+packages/modules, compression/archives, networking protocols, and the
+platform bootstrap. Heavily backend-gated — most are skipped on
+wasm / WASI / eBPF.
 
-> Stems: `clock`, `encoding`, `msgcat`, `utf`, `safe`, `safe-stock`,
-> `safe-stock86`, `safe-zipfs`, `exec`, `load`, `thread`, `registry`, `env`,
-> `pid`
+> Time: `clock`, `clock-ivm`
+> · Encodings / Unicode: `encoding`, `utf`, `utfext`, `icu`,
+> `fileSystemEncoding`
+> · Localisation: `msgcat`
+> · Process / OS: `exec`, `process`, `pid`, `env`
+> · Dynamic code: `load`, `unload`
+> · Threads: `thread`, `mutex`
+> · Packages / modules: `package`, `pkgMkIndex`, `autoMkindex`, `tm`,
+> `config`
+> · Archives / compression: `zipfs`, `zlib`
+> · Networking protocols: `http`, `http11`, `httpPipeline`, `httpProxy`,
+> `httpcookie`
+> · Registry / bootstrap: `registry`, `platform`, `init`, `main`, `history`,
+> `aaa_exit`
+> · Big data / misc: `bigdata`, `brodnik`
+> · Native-only (out of scope for the portable runtimes): `unixFCmd`,
+> `unixFile`, `unixForkEvent`, `unixInit`, `unixNotfy`, `winConsole`,
+> `winDde`, `winFCmd`, `winFile`, `winNotify`, `winPipe`, `winTime`,
+> `macOSXFCmd`, `macOSXLoad`
+> · `cmdAH` (cd/clock/encoding/exec/exit group)
+
+## Feature checklist — areas that are easy to forget
+
+Each capability area below has at least one representative file; use it to
+confirm a feature is actually being exercised, not silently absent.
+
+| Area | Files | Tier |
+|---|---|---|
+| Coroutines / NRE | `coroutine`, `dcall`, `nre` | 2, 4 |
+| TclOO | `oo`, `ooNext2`, `ooProp`, `ooUtil` | 4 |
+| Namespace ensembles | `namespace` (ensemble group) | 3 |
+| Custom resolvers | `resolver` | 3 |
+| Child / safe interpreters | `interp`, `safe`, `safe-*`, `security` | 5 |
+| Option parser (Safe Base) | `opt` | 5 |
+| Encodings / Unicode | `encoding`, `utf`, `utfext`, `icu` | 7 |
+| Channel transforms | `iogt`, `ioTrans` | 6 |
+| Event loop / async | `event`, `async`, `timer`, `notify`, `fileevent` | 6 |
+| Packages / modules | `package`, `pkgMkIndex`, `autoMkindex`, `tm` | 7 |
+| Compression / archives | `zlib`, `zipfs` | 7 |
+| HTTP protocol | `http`, `http11`, `httpPipeline`, `httpProxy`, `httpcookie` | 7 |
+| Abstract / big lists | `abstractlist`, `range`, `bigdata` | 3.5, 7 |
 
 ## How to use the ladder
 
 - **Fix bottom-up.** A Tier 1 parser bug or a Tier 3 trace bug shows up as
   scattered failures across many higher-tier stems; fixing it lifts all of
-  them at once (e.g. firing read traces from `info exists` unblocked lazy
-  tcltest constraints across the whole suite). Chasing an individual Tier 4
-  failure while a Tier 3 fundamental is broken is usually wasted work.
-- **Use the scoreboard for "where", the ladder for "why".** A CRASH on a low
-  tier is the highest-leverage fix — it zeroes a whole file. Within a tier,
+  them at once (firing read traces from `info exists` unblocked lazy tcltest
+  constraints across the whole suite). Chasing a Tier 4 failure while a Tier 3
+  fundamental is broken is usually wasted work.
+- **A CRASH on a low tier is the highest-leverage fix** — it zeroes a whole
+  file (e.g. `cmdAH`'s 16 820 C-passing tests are gated behind `interp create`,
+  a Tier 5 feature the bytecode VM still lacks).
+- **Use the scoreboard for "where", the ladder for "why".** Within a tier,
   prefer the stem whose failures share a single root cause.
-- **Tier 5–6 parity is per-backend.** Match C on native; on wasm / WASI / eBPF
-  the honest target is "skip what you can't do", which the
+- **Tier 6–7 parity is per-backend.** On native, match C exactly; on
+  wasm / WASI / eBPF the honest target is "skip what you can't do", which the
   [backend-constraint overlay](backend-constraints.md) handles, so the
-  pass/fail/skip line still matches what the backend can run.
+  pass / fail / skip line still matches what the backend can run. Tier 5 safe
+  interpreters are the in-language counterpart: a safe child legitimately
+  *cannot* reach Tier 6–7, so those tests are expected to fail closed.
 
 ## Cross-references
 
 - [`rust-vm-tier-parity.md`](rust-vm-tier-parity.md) — live per-stem scoreboard.
 - [`backend-constraints.md`](backend-constraints.md) — per-backend skip overlay
   and `tcl_platform` introspection.
+- [`child-interp.md`](child-interp.md) — child-interpreter design (Tier 5).
 - [`tcltest-bringup.md`](tcltest-bringup.md) — how the real `init.tcl` /
-  `tcltest.tcl` are brought up on the runtime, and the no-edit hard rules.
+  `tcltest.tcl` are brought up, and the no-edit hard rules.

--- a/docs/design/runtime/tcl-test-tiers.md
+++ b/docs/design/runtime/tcl-test-tiers.md
@@ -5,55 +5,83 @@ tree-walk runtime — both native and the wasm/WASI build) to match C Tcl 9's
 pass / fail / skip on the upstream tcltest suite. This document orders that
 work as a **capability ladder**: a lower tier is a prerequisite for the tiers
 above it, so fixing bottom-up is the highest-leverage order. A bug in parsing
-corrupts every test above it; a missing socket only affects I/O.
+corrupts every test above it; a missing socket only affects advanced I/O.
 
 The live per-stem scoreboard (C P/S/F vs VM P/S/F, MATCH / gap / CRASH) lives
 in [`rust-vm-tier-parity.md`](rust-vm-tier-parity.md). This document is the
 *semantic* grouping behind it — what each tier means, which **exact upstream
 `.test` files** belong to it, and why the order matters.
 
+## Core language vs optional features
+
+The single most useful distinction the ladder encodes: a **core language**
+versus a long tail of **optional features**.
+
+- **Core language — Tiers 1–7.** What makes the thing Tcl: parsing,
+  interpretation, the fundamental machinery (variables, namespaces, traces,
+  aliases, option/ensemble dispatch, encodings, core channels), data types,
+  control flow, the object system, and interpreters. Every backend must match C
+  here, exactly — there is no "skip it" escape hatch, because a program cannot
+  run without it.
+- **Optional features — Tiers 8–10.** Capabilities layered on top. Some are
+  **host/OS-dependent** (sockets, the event loop, subprocesses, dynamic
+  loading, threads, clocks) and are legitimately absent on a sandboxed backend.
+  Others are **"just a feature"** — a self-contained subsystem that could ship
+  as a package and that no core program needs: compression (`zlib`/`zipfs`),
+  HTTP (`http*`), message catalogues (`msgcat`), the module/package machinery
+  (`package`/`tm`), the registry. Parity on these matters for completeness but
+  never blocks the core.
+
+Rule of thumb when triaging: a failure in Tiers 1–7 gets fixed; a failure in
+Tiers 8–10 first gets the question "can the running backend even do this?" — and
+if not, the [backend-constraint overlay](backend-constraints.md) skips it.
+
 ## How to read the file lists
 
 - Every file is `tmp/tcl9.0.3/tests/<name>.test`.
-- A file that spans tiers is listed under **each** tier it touches, tagged with
-  the *command group* that puts it there. The three big "commands A–H / I–L /
-  M–Z" files are the main offenders:
+- A file (or a command group within it) that spans tiers is listed under
+  **each** tier it touches, tagged with the group that puts it there. The three
+  big "commands A–H / I–L / M–Z" files are the main offenders:
   - **`cmdAH`** — `after array append break case catch cd clock close concat
     continue encoding eof error eval exec exit expr fblocked fconfigure file
-    fileevent flush for foreach format gets glob global` → spans Tiers 3.5, 4,
-    6, and 7.
+    fileevent flush for foreach format gets glob global` → spans fundamentals,
+    data types, control flow, I/O, and platform.
   - **`cmdIL`** — `info lappend lassign lindex linsert list llength lrange
-    lreplace lreverse lsearch lset lsort` → spans Tiers 3 and 3.5.
+    lreplace lreverse lsearch lset lsort` → fundamentals (info) + data types.
   - **`cmdMZ`** — `regexp regsub return scan set split string subst switch time
-    trace unset` → spans Tiers 1, 3, 3.5, and 4.
+    trace unset` → parsing (subst), fundamentals (set/unset, trace), data types
+    (scan/string/split/regexp), control flow (return/switch).
+- The same overlap rule applies to whole subsystems: the **channel** and
+  **encoding** files exercise both their fundamental core (Tier 3) and their
+  advanced surface (Tiers 8/10), so they appear in both.
 - Platform-native files (`win*`, `mac*`/`macOSX*`, `unix*`) are listed in
-  Tier 7 and are out of scope for the portable Rust runtimes except where the
+  Tier 10 and are out of scope for the portable Rust runtimes except where the
   generic command underneath is tested.
 
 ## The ladder
 
-### Tier 1 — Parsing
+### Tier 1 — Parsing  *(core)*
 
 Lexer, word splitter, brace/quote/bracket nesting, backslash and
 command/variable substitution, and the expression tokeniser. Everything above
 depends on bytes → words → commands being right.
 
-> `parse`, `parseOld`, `parseExpr`, `word`, `subst`
-> · `cmdMZ` (subst group)
+> `parse`, `parseOld`, `parseExpr`, `word`, `subst` · `cmdMZ` (subst group)
 
-### Tier 2 — Interpretation
+### Tier 2 — Interpretation  *(core)*
 
 Turning parsed commands into execution: the bytecode compiler, the VM
-execution loop, `eval`/`uplevel` re-entry, the non-recursive engine (NRE), and
-the object/representation model.
+execution loop, `eval`/`uplevel` re-entry, the non-recursive engine (NRE)
+basics, and the object/representation model.
 
 > `basic`, `compile`, `execute`, `eval`, `assemble`, `obj`, `nre`,
 > `appendComp`, `lsetComp`, `regexpComp`, `compExpr`, `compExpr-old`, `misc`
 
-### Tier 3 — Fundamental Tcl machinery
+### Tier 3 — Fundamental Tcl machinery  *(core)*
 
-The state model every command relies on. Roughly ordered variables →
-namespaces → traces → aliases/introspection; all of it gates Tier 4.
+The state model and core services every command relies on — including three
+subsystems that are *fundamental*, not platform extras: **option/ensemble
+dispatch**, **encodings**, and the **core channel abstraction**.
 
 - **Variable storage & management** — scalars, arrays, `upvar`/`uplevel`
   linkage, qualified vs local resolution.
@@ -61,21 +89,34 @@ namespaces → traces → aliases/introspection; all of it gates Tier 4.
   > `get`, `link` · `cmdMZ` (set/unset group)
 - **Namespaces** — creation, qualified resolution,
   `import`/`forget`/`export`, ensembles, the namespace a command (incl. a
-  renamed proc) runs in, custom command/variable resolvers.
+  renamed proc) runs in, custom resolvers.
   > `namespace`, `namespace-old`, `resolver`
 - **Traces** — read / write / unset / array variable traces, command and
   execution traces (incl. firing from `info exists` and the `set` read path).
   > `trace` · `cmdMZ` (trace group)
 - **Aliasing, rename & introspection** — `rename` (incl. across namespaces),
-  and the `info` surface tests read to verify the machinery above.
+  and the `info` surface used to verify the machinery above.
   > `rename`, `info`, `cmdInfo` · `cmdIL` (info group)
+- **Option & ensemble dispatch** — `Tcl_GetIndexFromObj`-style subcommand /
+  option resolution (unambiguous-prefix matching, the `bad option …: must be …`
+  wording) and the `::tcl::OptProc` parser the standard library builds on.
+  > `opt`, `indexObj` · every ensemble (`string`/`dict`/`namespace`/`chan`/
+  > `file`/`clock`/`interp`) depends on this.
+- **Encodings** — the Unicode core: `encoding convertfrom`/`convertto`, the
+  internal UTF representation, and `\u`/`\U` handling that string and channel
+  code assume.
+  > `encoding`, `utf`, `utfext` · advanced/external encodings → Tier 10
+- **Core channels** — the channel abstraction itself: `puts`/`gets`/`read`/
+  `open`/`close`/`flush`/`eof` on the standard and in-memory channels — what
+  `puts stdout` and the test harness's output capture rely on.
+  > `chan`, `io` (core groups) · non-blocking / transforms / sockets / events →
+  > Tier 8 · `cmdAH` (close/eof/flush/gets group)
 
-### Tier 3.5 — Pure-compute data types
+### Tier 4 — Data types  *(core)*
 
-Lists, dicts, strings, numeric/format/scan, regexp, and binary. They depend
-only on Tiers 1–3 and are prerequisites for most higher-tier test bodies, so
-they sit between the machinery and control flow. Pure computation — identical
-on every backend.
+Lists, dicts, strings, numeric/format/scan, regexp, and binary. Depend only on
+Tiers 1–3 and are prerequisites for most higher-tier test bodies. Pure
+computation — identical on every backend.
 
 > Lists: `list`, `lindex`, `linsert`, `llength`, `lrange`, `lrepeat`,
 > `lreplace`, `lsearch`, `lset`, `lsetComp`, `lmap`, `lpop`, `lseq`, `lreverse`,
@@ -83,133 +124,144 @@ on every backend.
 > · Dicts: `dict`
 > · Strings: `string`, `stringObj`, `format`, `scan`, `split`, `join`, `concat`
 > · Regexp: `regexp`, `regexpComp`, `reg`
-> · Binary / misc: `binary`, `indexObj`, `util`, `stack`, `assocd`
-> · `cmdIL` (list-ops group), `cmdMZ` (scan/string/split group),
+> · Binary / misc: `binary`, `util`, `stack`, `assocd`
+> · `cmdIL` (list-ops group), `cmdMZ` (scan/string/split/regexp group),
 > `cmdAH` (format group)
 
-### Tier 4 — Control flow & procedures
+### Tier 5 — Control flow & procedures  *(core)*
 
-Conditionals, loops, exceptions, procedures, expressions, coroutines, and the
-object system — the constructs that drive a test body. Built on Tiers 1–3.5.
+Conditionals, loops, exceptions, procedures, and expressions — the constructs
+that drive a test body. Built on Tiers 1–4.
 
 > Flow: `if`, `if-old`, `for`, `for-old`, `foreach`, `while`, `while-old`,
 > `switch`, `error`, `result`
 > · Expr: `expr`, `expr-old`, `mathop`
 > · Procs: `proc`, `proc-old`, `apply`, `unknown`
-> · Coroutines / tailcall: `coroutine`, `tailcall`, `dcall`
-> · TclOO: `oo`, `ooNext2`, `ooProp`, `ooUtil`
 > · `cmdMZ` (return/switch group),
 > `cmdAH` (break/case/catch/continue/error/eval/for/foreach group)
 
-### Tier 5 — Interpreters (child & safe)
+### Tier 6 — Object system (TclOO)  *(core, mid)*
+
+The standard object system — classes, objects, methods, `next`, mixins,
+filters, and properties. Mid-tier: it is core Tcl (8.6+), built squarely on
+procedures, namespaces, and ensemble dispatch (Tiers 3 & 5), but nothing below
+it depends on it.
+
+> `oo`, `ooNext2`, `ooProp`, `ooUtil`
+
+### Tier 7 — Interpreters (child & safe)  *(core)*
 
 Creating, evaluating in, and tearing down **child interpreters**, the
 cross-interpreter **alias** and **hidden-command** machinery, and **safe
-interpreters** (`interp create -safe`, `marktrusted`, the Safe Base). Placed
-above control flow because a child interp re-enters the whole evaluator, and
-below I/O because a *safe* interp is precisely the mechanism that gates a
-child's access to Tiers 6–7. Depends on namespaces and aliases (Tier 3) and
-`eval`/control flow (Tiers 2, 4).
+interpreters** (`interp create -safe`, `marktrusted`, the Safe Base). A child
+interp re-enters the whole evaluator; a *safe* interp is precisely the
+mechanism that gates a child's access to the optional-feature tiers above.
+Depends on namespaces and aliases (Tier 3) and `eval`/control flow (Tiers 2, 5).
 
 - **Child interpreters** — `interp create`/`eval`/`delete`/`exists`/`children`,
-  child-as-command dispatch, recursion limits, `interp target`/`share`/
+  child-as-command dispatch, `recursionlimit`, `interp target`/`share`/
   `transfer`, `interp alias`/`aliases` across paths.
   > `interp`
 - **Safe interpreters & the Safe Base** — `interp create -safe`, `issafe`,
   `marktrusted`, `hide`/`expose`/`hidden`/`invokehidden`, and the
   `safe.tcl` re-aliasing of `source`/`load`/`file`/`encoding`.
   > `safe`, `safe-stock`, `safe-stock86`, `safe-zipfs`, `security`
-  > · `opt` (the `::tcl::OptProc` option parser the Safe Base builds on)
 
-### Tier 6 — I/O
+### Tier 8 — Advanced I/O & events  *(feature, host-dependent)*
 
-Channels, files, globbing, sockets, and the event loop. The first tier whose
-capabilities a backend can *lack* — WASI has no sockets, eBPF has no I/O at
-all — so this is where the [backend-constraint overlay](backend-constraints.md)
-starts skipping tests.
+The capabilities beyond the Tier 3 channel core: sockets, the event loop and
+fileevents, channel transforms and stacking, the filesystem command surface,
+and globbing. The first tier whose capabilities a backend can *lack* — WASI has
+no sockets, eBPF has no I/O at all — so this is where the
+[backend-constraint overlay](backend-constraints.md) starts skipping tests.
 
-> Channels: `io`, `ioCmd`, `ioTrans`, `iogt`, `chan`, `chanio`
+> Advanced channels: `ioCmd`, `ioTrans`, `iogt`, `chanio` · advanced groups of
+> `io`/`chan`
 > · Sockets: `socket`
 > · Event loop: `event`, `async`, `timer`, `notify`, `fileevent`
-> · Files / FS: `file`? (see `cmdAH`), `fCmd`, `fileName`, `fileSystem`, `pwd`,
+> · Files / FS: `fCmd`, `fileName`, `fileSystem`, `fileSystemEncoding`, `pwd`,
 > `link`, `source`
-> · `cmdAH` (after/close/eof/fblocked/fconfigure/file/fileevent/flush/gets/glob
-> group)
+> · `cmdAH` (after/fblocked/fconfigure/file/fileevent/glob group)
 
-### Tier 7 — Platform-specific features
+### Tier 9 — Concurrency & advanced evaluation  *(feature, late)*
 
-Capabilities tied to the host OS or a specific build: clocks/timezones,
-encodings, message catalogues, subprocesses, dynamic loading, threads,
-packages/modules, compression/archives, networking protocols, and the
-platform bootstrap. Heavily backend-gated — most are skipped on
-wasm / WASI / eBPF.
+Constructs that suspend, resume, or parallelise execution. Late because they
+sit on top of a correct evaluator, the event loop, and (for threads) the host.
 
-> Time: `clock`, `clock-ivm`
-> · Encodings / Unicode: `encoding`, `utf`, `utfext`, `icu`,
-> `fileSystemEncoding`
-> · Localisation: `msgcat`
-> · Process / OS: `exec`, `process`, `pid`, `env`
-> · Dynamic code: `load`, `unload`
+> Coroutines: `coroutine`, `dcall` · deep NRE re-entry beyond Tier 2
+> · Tailcall: `tailcall`
 > · Threads: `thread`, `mutex`
-> · Packages / modules: `package`, `pkgMkIndex`, `autoMkindex`, `tm`,
-> `config`
-> · Archives / compression: `zipfs`, `zlib`
-> · Networking protocols: `http`, `http11`, `httpPipeline`, `httpProxy`,
-> `httpcookie`
-> · Registry / bootstrap: `registry`, `platform`, `init`, `main`, `history`,
-> `aaa_exit`
-> · Big data / misc: `bigdata`, `brodnik`
+
+### Tier 10 — Platform & library features  *(feature, late)*
+
+The long tail. **Host/OS-dependent**: subprocesses, dynamic loading,
+clocks/timezones, the advanced/external encoding surface. **Pure library
+features** (each could be a package, none is needed by a core program):
+message catalogues, packages/modules, compression, networking protocols, the
+registry. Heavily backend-gated — most are skipped on wasm / WASI / eBPF.
+
+> Host/OS: `exec`, `process`, `pid`, `env`, `load`, `unload`, `clock`,
+> `clock-ivm`, `icu`
+> · Library features: `msgcat`, `package`, `pkgMkIndex`, `autoMkindex`, `tm`,
+> `config`, `zipfs`, `zlib`, `http`, `http11`, `httpPipeline`, `httpProxy`,
+> `httpcookie`, `registry`
+> · Bootstrap / misc: `platform`, `init`, `main`, `history`, `aaa_exit`,
+> `bigdata`, `brodnik`
 > · Native-only (out of scope for the portable runtimes): `unixFCmd`,
 > `unixFile`, `unixForkEvent`, `unixInit`, `unixNotfy`, `winConsole`,
 > `winDde`, `winFCmd`, `winFile`, `winNotify`, `winPipe`, `winTime`,
 > `macOSXFCmd`, `macOSXLoad`
-> · `cmdAH` (cd/clock/encoding/exec/exit group)
+> · `cmdAH` (cd/clock/encoding-system/exec/exit group)
 
 ## Feature checklist — areas that are easy to forget
 
-Each capability area below has at least one representative file; use it to
-confirm a feature is actually being exercised, not silently absent.
+Each capability area has at least one representative file; use it to confirm a
+feature is exercised, not silently absent. The **kind** column is the
+core-vs-feature lens.
 
-| Area | Files | Tier |
-|---|---|---|
-| Coroutines / NRE | `coroutine`, `dcall`, `nre` | 2, 4 |
-| TclOO | `oo`, `ooNext2`, `ooProp`, `ooUtil` | 4 |
-| Namespace ensembles | `namespace` (ensemble group) | 3 |
-| Custom resolvers | `resolver` | 3 |
-| Child / safe interpreters | `interp`, `safe`, `safe-*`, `security` | 5 |
-| Option parser (Safe Base) | `opt` | 5 |
-| Encodings / Unicode | `encoding`, `utf`, `utfext`, `icu` | 7 |
-| Channel transforms | `iogt`, `ioTrans` | 6 |
-| Event loop / async | `event`, `async`, `timer`, `notify`, `fileevent` | 6 |
-| Packages / modules | `package`, `pkgMkIndex`, `autoMkindex`, `tm` | 7 |
-| Compression / archives | `zlib`, `zipfs` | 7 |
-| HTTP protocol | `http`, `http11`, `httpPipeline`, `httpProxy`, `httpcookie` | 7 |
-| Abstract / big lists | `abstractlist`, `range`, `bigdata` | 3.5, 7 |
+| Area | Files | Tier | Kind |
+|---|---|---|---|
+| Option / ensemble dispatch | `opt`, `indexObj` | 3 | core |
+| Encodings / Unicode core | `encoding`, `utf`, `utfext` | 3 | core |
+| Core channels | `chan`, `io` (core) | 3 | core |
+| Namespace ensembles | `namespace` (ensemble group) | 3 | core |
+| Custom resolvers | `resolver` | 3 | core |
+| TclOO | `oo`, `ooNext2`, `ooProp`, `ooUtil` | 6 | core (mid) |
+| Child / safe interpreters | `interp`, `safe`, `safe-*`, `security` | 7 | core |
+| Channel transforms / stacking | `iogt`, `ioTrans` | 8 | feature (host) |
+| Event loop / async | `event`, `async`, `timer`, `notify`, `fileevent` | 8 | feature (host) |
+| Coroutines / NRE | `coroutine`, `dcall`, `nre` | 9 (2 for NRE basics) | feature |
+| Threads | `thread`, `mutex` | 9 | feature (host) |
+| Subprocess / dynamic load | `exec`, `process`, `load`, `unload` | 10 | feature (host) |
+| Packages / modules | `package`, `pkgMkIndex`, `autoMkindex`, `tm` | 10 | feature (library) |
+| Compression / archives | `zlib`, `zipfs` | 10 | feature (library) |
+| HTTP protocol | `http`, `http11`, `httpPipeline`, `httpProxy`, `httpcookie` | 10 | feature (library) |
+| Message catalogues | `msgcat` | 10 | feature (library) |
+| Abstract / big lists | `abstractlist`, `range`, `bigdata` | 4, 10 | core / feature |
 
 ## How to use the ladder
 
-- **Fix bottom-up.** A Tier 1 parser bug or a Tier 3 trace bug shows up as
-  scattered failures across many higher-tier stems; fixing it lifts all of
-  them at once (firing read traces from `info exists` unblocked lazy tcltest
-  constraints across the whole suite). Chasing a Tier 4 failure while a Tier 3
-  fundamental is broken is usually wasted work.
+- **Fix bottom-up.** A Tier 1 parser bug or a Tier 3 trace/encoding/channel bug
+  shows up as scattered failures across many higher-tier stems; fixing it lifts
+  all of them at once (firing read traces from `info exists` unblocked lazy
+  tcltest constraints across the whole suite). Chasing a Tier 5 failure while a
+  Tier 3 fundamental is broken is usually wasted work.
 - **A CRASH on a low tier is the highest-leverage fix** — it zeroes a whole
   file (e.g. `cmdAH`'s 16 820 C-passing tests are gated behind `interp create`,
-  a Tier 5 feature the bytecode VM still lacks).
+  a Tier 7 feature the bytecode VM still lacks).
 - **Use the scoreboard for "where", the ladder for "why".** Within a tier,
   prefer the stem whose failures share a single root cause.
-- **Tier 6–7 parity is per-backend.** On native, match C exactly; on
+- **Tier 8–10 parity is per-backend.** On native, match C exactly; on
   wasm / WASI / eBPF the honest target is "skip what you can't do", which the
-  [backend-constraint overlay](backend-constraints.md) handles, so the
-  pass / fail / skip line still matches what the backend can run. Tier 5 safe
+  [backend-constraint overlay](backend-constraints.md) handles. Tier 7 safe
   interpreters are the in-language counterpart: a safe child legitimately
-  *cannot* reach Tier 6–7, so those tests are expected to fail closed.
+  *cannot* reach Tiers 8–10, so those tests are expected to fail closed.
 
 ## Cross-references
 
 - [`rust-vm-tier-parity.md`](rust-vm-tier-parity.md) — live per-stem scoreboard.
 - [`backend-constraints.md`](backend-constraints.md) — per-backend skip overlay
   and `tcl_platform` introspection.
-- [`child-interp.md`](child-interp.md) — child-interpreter design (Tier 5).
+- [`child-interp.md`](child-interp.md) — child-interpreter design (Tier 7).
 - [`tcltest-bringup.md`](tcltest-bringup.md) — how the real `init.tcl` /
   `tcltest.tcl` are brought up, and the no-edit hard rules.

--- a/runtime/rust/examples/run_script.rs
+++ b/runtime/rust/examples/run_script.rs
@@ -66,6 +66,22 @@ fn run() -> i32 {
         );
         return 1;
     }
+    // Optionally pre-load tcltest and source the backend-constraint overlay so
+    // tests the running backend cannot support are skipped. Loading tcltest
+    // here makes the test file's own `package require tcltest` a no-op.
+    let overlay = std::env::var("TCL_BACKEND_CONSTRAINTS").unwrap_or_default();
+    if init && !overlay.is_empty() {
+        let pre = format!(
+            "package require tcltest\nnamespace import -force ::tcltest::*\nsource {overlay}\n"
+        );
+        if interp.eval_str(pre.as_bytes()) == Code::Error {
+            eprintln!(
+                "backend-constraint overlay error: {}",
+                String::from_utf8_lossy(&interp.result_bytes())
+            );
+            return 1;
+        }
+    }
     let code = match &path {
         Some(p) => interp.eval_sourced(&src, p.as_bytes()),
         None => interp.eval_str(&src),

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -162,10 +162,42 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_result_bytes(if safe { b"1" } else { b"0" });
             Code::Ok
         }
+        b"recursionlimit" => {
+            // `interp recursionlimit path ?newlimit?` — get/set a (possibly
+            // child) interp's recursion bound.
+            if argv.len() < 3 || argv.len() > 4 {
+                return wrong_args(interp, b"interp recursionlimit path ?newlimit?");
+            }
+            let path = obj_bytes(argv[2]);
+            let newlimit = argv.get(3).map(|&a| obj_bytes(a));
+            let result = if path.is_empty() {
+                Some(interp.recursion_limit_apply(newlimit.as_deref()))
+            } else {
+                interp.with_child(&path, |c| c.recursion_limit_apply(newlimit.as_deref()))
+            };
+            match result {
+                Some(Ok(n)) => {
+                    interp.set_result_bytes(n.to_string().as_bytes());
+                    Code::Ok
+                }
+                Some(Err(m)) => interp.set_error(&m),
+                None => {
+                    let mut m = b"could not find interpreter \"".to_vec();
+                    m.extend_from_slice(&path);
+                    m.push(b'"');
+                    interp.set_error(&m)
+                }
+            }
+        }
         other => {
-            let mut m = b"interp subcommand \"".to_vec();
+            let mut m = b"bad option \"".to_vec();
             m.extend_from_slice(other);
-            m.extend_from_slice(b"\" is not supported in this runtime");
+            m.extend_from_slice(
+                b"\": must be alias, aliases, bgerror, cancel, children, create, \
+                  debug, delete, eval, exists, expose, hide, hidden, issafe, \
+                  invokehidden, limit, marktrusted, recursionlimit, share, \
+                  target, or transfer",
+            );
             interp.set_error(&m)
         }
     }

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -134,6 +134,8 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"expose" => interp_hidectl(interp, argv, HideOp::Expose),
         b"invokehidden" => interp_invokehidden(interp, argv),
         b"limit" => interp_limit(interp, argv),
+        b"marktrusted" => interp_marktrusted(interp, argv),
+        b"debug" => interp_debug(interp, argv),
         b"hidden" => {
             // `interp hidden ?path?` — hidden command names in the (current or
             // named) interp.
@@ -299,6 +301,59 @@ fn interp_limit(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             interp.set_error(&m)
         }
     }
+}
+
+/// `interp marktrusted path` — clear a child interp's safe flag (denied from a
+/// safe interpreter).
+fn interp_marktrusted(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() != 3 {
+        return wrong_args(interp, b"interp marktrusted path");
+    }
+    if interp.is_safe() {
+        return interp.set_error(b"permission denied: safe interpreter cannot mark trusted");
+    }
+    let path = obj_bytes(argv[2]);
+    if path.is_empty() {
+        interp.set_result_bytes(b"");
+        return Code::Ok;
+    }
+    match interp.with_child(&path, |c| c.mark_trusted()) {
+        Some(()) => {
+            interp.set_result_bytes(b"");
+            Code::Ok
+        }
+        None => not_found(interp, &path),
+    }
+}
+
+/// `interp debug path ?-frame ?bool??` — the per-interp frame-debug switch.
+fn interp_debug(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    if argv.len() < 3 || argv.len() > 5 {
+        return wrong_args(interp, b"interp debug path ?-frame ?bool??");
+    }
+    let path = obj_bytes(argv[2]);
+    let opts: Vec<*mut TclObj> = argv[3..].to_vec();
+    let result = if path.is_empty() {
+        Some(interp.debug_apply(&opts))
+    } else {
+        interp.with_child(&path, |c| c.debug_apply(&opts))
+    };
+    match result {
+        Some(Ok(o)) => {
+            interp.set_result(o);
+            Code::Ok
+        }
+        Some(Err(m)) => interp.set_error(&m),
+        None => not_found(interp, &path),
+    }
+}
+
+/// The `could not find interpreter "path"` error.
+fn not_found(interp: &mut Interp, path: &[u8]) -> Code {
+    let mut m = b"could not find interpreter \"".to_vec();
+    m.extend_from_slice(path);
+    m.push(b'"');
+    interp.set_error(&m)
 }
 
 /// Whether `name` resolves in the global namespace — it carries no namespace

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -103,22 +103,21 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Code::Ok
         }
         b"bgerror" => {
-            // `interp bgerror path ?cmdPrefix?` — get/set the current interp's
-            // background-error handler. Only the current interp ("") is modelled.
+            // `interp bgerror path ?cmdPrefix?` — get/set the (possibly nested)
+            // interp's background-error handler.
             if argv.len() < 3 || argv.len() > 4 {
                 return wrong_args(interp, b"interp bgerror path ?cmdPrefix?");
             }
-            match argv.get(3) {
-                Some(&p) => {
-                    interp.set_bgerror_handler(&obj_bytes(p));
-                    interp.set_result_bytes(b"");
-                }
-                None => {
-                    let h = interp.bgerror_handler();
+            let path = interp_path(argv[2]);
+            let prefix = argv.get(3).copied();
+            match interp.with_child_path(&path, |c| c.bgerror_apply(prefix)) {
+                Some(Ok(h)) => {
                     interp.set_result_bytes(&h);
+                    Code::Ok
                 }
+                Some(Err(m)) => interp.set_error(&m),
+                None => not_found_path(interp, &path),
             }
-            Code::Ok
         }
         b"hide" => interp_hidectl(interp, argv, HideOp::Hide),
         b"expose" => interp_hidectl(interp, argv, HideOp::Expose),

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -83,28 +83,18 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"delete" => interp_delete(interp, argv),
         b"exists" => {
             // `interp exists ?path?`: the current interp ("") always exists; a
-            // named one exists iff it's a child.
-            let exists = match argv.get(2) {
-                None => true,
-                Some(&a) => {
-                    let p = obj_bytes(a);
-                    p.is_empty() || interp.child_exists(&p)
-                }
-            };
+            // named one exists iff the whole path resolves.
+            let path = argv.get(2).map(|&a| interp_path(a)).unwrap_or_default();
+            let exists = interp.with_child_path(&path, |_| ()).is_some();
             interp.set_result_bytes(if exists { b"1" } else { b"0" });
             Code::Ok
         }
         b"children" | b"slaves" => {
-            // Children of the current interp (a named sub-path is single-level).
-            let names = if argv
-                .get(2)
-                .map(|&a| obj_bytes(a))
-                .is_some_and(|p| !p.is_empty())
-            {
-                Vec::new()
-            } else {
-                interp.child_names()
-            };
+            // Children of the interp addressed by the (possibly nested) path.
+            let path = argv.get(2).map(|&a| interp_path(a)).unwrap_or_default();
+            let names = interp
+                .with_child_path(&path, |c| c.child_names())
+                .unwrap_or_default();
             let elems: Vec<*mut TclObj> = names.iter().map(|n| obj::new_string_bytes(n)).collect();
             interp.set_result(list::new_list_obj(&elems));
             for e in elems {
@@ -137,16 +127,12 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"marktrusted" => interp_marktrusted(interp, argv),
         b"debug" => interp_debug(interp, argv),
         b"hidden" => {
-            // `interp hidden ?path?` — hidden command names in the (current or
-            // named) interp.
-            let path = argv.get(2).map(|&a| obj_bytes(a)).unwrap_or_default();
-            let names = if path.is_empty() {
-                interp.hidden_names()
-            } else {
-                interp
-                    .with_child(&path, |c| c.hidden_names())
-                    .unwrap_or_default()
-            };
+            // `interp hidden ?path?` — hidden command names in the interp
+            // addressed by the (possibly nested) path.
+            let path = argv.get(2).map(|&a| interp_path(a)).unwrap_or_default();
+            let names = interp
+                .with_child_path(&path, |c| c.hidden_names())
+                .unwrap_or_default();
             let elems: Vec<*mut TclObj> = names.iter().map(|n| obj::new_string_bytes(n)).collect();
             interp.set_result(list::new_list_obj(&elems));
             for e in elems {
@@ -155,41 +141,30 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
             Code::Ok
         }
         b"issafe" => {
-            // `interp issafe ?path?` — the current interp (no path) or a child.
-            let path = argv.get(2).map(|&a| obj_bytes(a)).unwrap_or_default();
-            let safe = if path.is_empty() {
-                interp.is_safe()
-            } else {
-                interp.with_child(&path, |c| c.is_safe()).unwrap_or(false)
-            };
+            // `interp issafe ?path?` — the current interp (no path) or a child
+            // addressed by a (possibly nested) path.
+            let path = argv.get(2).map(|&a| interp_path(a)).unwrap_or_default();
+            let safe = interp
+                .with_child_path(&path, |c| c.is_safe())
+                .unwrap_or(false);
             interp.set_result_bytes(if safe { b"1" } else { b"0" });
             Code::Ok
         }
         b"recursionlimit" => {
             // `interp recursionlimit path ?newlimit?` — get/set a (possibly
-            // child) interp's recursion bound.
+            // nested) interp's recursion bound.
             if argv.len() < 3 || argv.len() > 4 {
                 return wrong_args(interp, b"interp recursionlimit path ?newlimit?");
             }
-            let path = obj_bytes(argv[2]);
+            let path = interp_path(argv[2]);
             let newlimit = argv.get(3).map(|&a| obj_bytes(a));
-            let result = if path.is_empty() {
-                Some(interp.recursion_limit_apply(newlimit.as_deref()))
-            } else {
-                interp.with_child(&path, |c| c.recursion_limit_apply(newlimit.as_deref()))
-            };
-            match result {
+            match interp.with_child_path(&path, |c| c.recursion_limit_apply(newlimit.as_deref())) {
                 Some(Ok(n)) => {
                     interp.set_result_bytes(n.to_string().as_bytes());
                     Code::Ok
                 }
                 Some(Err(m)) => interp.set_error(&m),
-                None => {
-                    let mut m = b"could not find interpreter \"".to_vec();
-                    m.extend_from_slice(&path);
-                    m.push(b'"');
-                    interp.set_error(&m)
-                }
+                None => not_found_path(interp, &path),
             }
         }
         other => {
@@ -213,7 +188,7 @@ fn interp_create(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     // C's "weird historical rule": `-safe` is accepted anywhere before `--`
     // (`interp create a -safe` is valid), and the path is the lone non-option
     // word — so scan all args rather than stopping at the first non-flag.
-    let mut name: Option<Vec<u8>> = None;
+    let mut name_obj: Option<*mut TclObj> = None;
     let mut safe = false;
     let mut last = false;
     let mut i = 2;
@@ -238,28 +213,82 @@ fn interp_create(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
                 }
             }
         }
-        if name.is_some() {
+        if name_obj.is_some() {
             return wrong_args(interp, b"interp create ?-safe? ?--? ?path?");
         }
         if i < argv.len() {
-            name = Some(obj_bytes(argv[i]));
+            name_obj = Some(argv[i]);
         }
         i += 1;
     }
-    if let Some(ref p) = name {
-        if interp.child_exists(p) {
+    // The path is a list of interp names; an empty/absent path auto-names a
+    // child of this interp, otherwise the leaf is created inside the interp
+    // addressed by the parent segments (`interp create {a b}`).
+    let path = name_obj.map(interp_path).unwrap_or_default();
+    let Some((leaf, parent)) = path.split_last() else {
+        let created = interp.create_child(None);
+        if safe {
+            interp.with_child(&created, |c| c.make_safe());
+        }
+        interp.set_result(obj::new_string_bytes(&created));
+        return Code::Ok;
+    };
+    let leaf = leaf.clone();
+    let outcome: Option<Result<(), ()>> = interp.with_child_path(parent, |a| {
+        if a.child_exists(&leaf) {
+            return Err(()); // already exists
+        }
+        a.create_child(Some(leaf.clone()));
+        if safe {
+            a.with_child(&leaf, |c| c.make_safe());
+        }
+        Ok(())
+    });
+    match outcome {
+        Some(Ok(())) => {
+            // Result is the path as written (the original list object).
+            interp.set_result(obj::new_string_bytes(&obj_bytes(name_obj.unwrap())));
+            Code::Ok
+        }
+        Some(Err(_)) => {
             let mut m = b"interpreter named \"".to_vec();
-            m.extend_from_slice(p);
+            m.extend_from_slice(&obj_bytes(name_obj.unwrap()));
             m.extend_from_slice(b"\" already exists, cannot create");
-            return interp.set_error(&m);
+            interp.set_error(&m)
+        }
+        None => not_found_path(interp, parent),
+    }
+}
+
+/// Parse an interp path object into its list of names (`{a b}` → `["a","b"]`).
+fn interp_path(obj: *mut TclObj) -> Vec<Vec<u8>> {
+    match crate::list::list_elements(obj) {
+        Ok(els) => els.iter().map(|&e| obj_bytes(e)).collect(),
+        Err(_) => {
+            let b = obj_bytes(obj);
+            if b.is_empty() {
+                Vec::new()
+            } else {
+                vec![b]
+            }
         }
     }
-    let created = interp.create_child(name);
-    if safe {
-        interp.with_child(&created, |c| c.make_safe());
+}
+
+/// The `could not find interpreter "a b"` error for a path that failed to
+/// resolve, rendering the path as a Tcl list.
+fn not_found_path(interp: &mut Interp, path: &[Vec<u8>]) -> Code {
+    let elems: Vec<*mut TclObj> = path.iter().map(|n| obj::new_string_bytes(n)).collect();
+    let joined = crate::list::new_list_obj(&elems);
+    let rendered = obj_bytes(joined);
+    for e in elems {
+        crate::interp::drop_fresh(e);
     }
-    interp.set_result(obj::new_string_bytes(&created));
-    Code::Ok
+    crate::interp::drop_fresh(joined);
+    let mut m = b"could not find interpreter \"".to_vec();
+    m.extend_from_slice(&rendered);
+    m.push(b'"');
+    interp.set_error(&m)
 }
 
 enum HideOp {
@@ -274,7 +303,7 @@ fn interp_limit(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 4 {
         return wrong_args(interp, b"interp limit path limitType ?-option value ...?");
     }
-    let path = obj_bytes(argv[2]);
+    let path = interp_path(argv[2]);
     let ltype = obj_bytes(argv[3]);
     // Validate the limit type before the current-interp guard so a bad type is
     // reported ahead of the inaccessibility error (interp-35.3 vs .23).
@@ -288,18 +317,13 @@ fn interp_limit(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         return interp.set_error(b"limits on current interpreter inaccessible");
     }
     let opts: Vec<*mut TclObj> = argv[4..].to_vec();
-    match interp.with_child(&path, |c| c.limit_apply(&ltype, &opts)) {
+    match interp.with_child_path(&path, |c| c.limit_apply(&ltype, &opts)) {
         Some(Ok(o)) => {
             interp.set_result(o);
             Code::Ok
         }
         Some(Err(m)) => interp.set_error(&m),
-        None => {
-            let mut m = b"could not find interpreter \"".to_vec();
-            m.extend_from_slice(&path);
-            m.push(b'"');
-            interp.set_error(&m)
-        }
+        None => not_found_path(interp, &path),
     }
 }
 
@@ -312,17 +336,17 @@ fn interp_marktrusted(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if interp.is_safe() {
         return interp.set_error(b"permission denied: safe interpreter cannot mark trusted");
     }
-    let path = obj_bytes(argv[2]);
+    let path = interp_path(argv[2]);
     if path.is_empty() {
         interp.set_result_bytes(b"");
         return Code::Ok;
     }
-    match interp.with_child(&path, |c| c.mark_trusted()) {
+    match interp.with_child_path(&path, |c| c.mark_trusted()) {
         Some(()) => {
             interp.set_result_bytes(b"");
             Code::Ok
         }
-        None => not_found(interp, &path),
+        None => not_found_path(interp, &path),
     }
 }
 
@@ -331,29 +355,16 @@ fn interp_debug(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 3 || argv.len() > 5 {
         return wrong_args(interp, b"interp debug path ?-frame ?bool??");
     }
-    let path = obj_bytes(argv[2]);
+    let path = interp_path(argv[2]);
     let opts: Vec<*mut TclObj> = argv[3..].to_vec();
-    let result = if path.is_empty() {
-        Some(interp.debug_apply(&opts))
-    } else {
-        interp.with_child(&path, |c| c.debug_apply(&opts))
-    };
-    match result {
+    match interp.with_child_path(&path, |c| c.debug_apply(&opts)) {
         Some(Ok(o)) => {
             interp.set_result(o);
             Code::Ok
         }
         Some(Err(m)) => interp.set_error(&m),
-        None => not_found(interp, &path),
+        None => not_found_path(interp, &path),
     }
-}
-
-/// The `could not find interpreter "path"` error.
-fn not_found(interp: &mut Interp, path: &[u8]) -> Code {
-    let mut m = b"could not find interpreter \"".to_vec();
-    m.extend_from_slice(path);
-    m.push(b'"');
-    interp.set_error(&m)
 }
 
 /// Whether `name` resolves in the global namespace — it carries no namespace
@@ -382,7 +393,7 @@ fn interp_hidectl(interp: &mut Interp, argv: &[*mut TclObj], op: HideOp) -> Code
             HideOp::Expose => b"permission denied: safe interpreter cannot expose commands",
         });
     }
-    let path = obj_bytes(argv[2]);
+    let path = interp_path(argv[2]);
     let cmd = obj_bytes(argv[3]);
     let token = if argv.len() == 5 {
         obj_bytes(argv[4])
@@ -416,23 +427,13 @@ fn interp_hidectl(interp: &mut Interp, argv: &[*mut TclObj], op: HideOp) -> Code
             }
         }
     }
-    let did = if path.is_empty() {
-        match op {
-            HideOp::Hide => interp.hide_command(&cmd),
-            HideOp::Expose => interp.expose_command(&cmd),
-        }
-    } else {
-        interp
-            .with_child(&path, |c| match op {
-                HideOp::Hide => c.hide_command(&cmd),
-                HideOp::Expose => c.expose_command(&cmd),
-            })
-            .unwrap_or(false)
-    };
-    if !did {
-        // Hiding a missing command, or exposing a non-hidden one.
-        let _ = did;
-    }
+    // Hiding a missing command, or exposing a non-hidden one, is a silent
+    // no-op (as is a child path that does not resolve), matching the prior
+    // single-level behaviour.
+    interp.with_child_path(&path, |c| match op {
+        HideOp::Hide => c.hide_command(&cmd),
+        HideOp::Expose => c.expose_command(&cmd),
+    });
     interp.set_result_bytes(b"");
     Code::Ok
 }
@@ -443,7 +444,7 @@ fn interp_invokehidden(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 4 {
         return wrong_args(interp, b"interp invokehidden path ?-opt? cmd ?arg ...?");
     }
-    let path = obj_bytes(argv[2]);
+    let path = interp_path(argv[2]);
     // Skip leading option flags (`-namespace ns`, `-global`).
     let mut i = 3;
     while i < argv.len() {
@@ -471,19 +472,16 @@ fn interp_invokehidden(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         unsafe { obj::incr_ref_count(a) };
         hidden_argv.push(a);
     }
-    let code = if path.is_empty() {
-        interp.invoke_hidden(&cmd, &hidden_argv)
-    } else {
-        // Run in the child; copy its result back.
-        match interp.with_child(&path, |c| {
-            (c.invoke_hidden(&cmd, &hidden_argv), c.result_bytes())
-        }) {
-            Some((code, res)) => {
-                interp.set_result_bytes(&res);
-                code
-            }
-            None => interp.set_error(b"could not find interpreter"),
+    // Run in the addressed interp (the current one for an empty path), copying
+    // its result back up the path.
+    let code = match interp.with_child_path(&path, |c| {
+        (c.invoke_hidden(&cmd, &hidden_argv), c.result_bytes())
+    }) {
+        Some((code, res)) => {
+            interp.set_result_bytes(&res);
+            code
         }
+        None => not_found_path(interp, &path),
     };
     for a in hidden_argv {
         unsafe { obj::decr_ref_count(a) };
@@ -496,7 +494,7 @@ fn interp_eval(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 4 {
         return wrong_args(interp, b"interp eval path arg ?arg ...?");
     }
-    let path = obj_bytes(argv[2]);
+    let path = interp_path(argv[2]);
     let mut script = Vec::new();
     for (k, &a) in argv[3..].iter().enumerate() {
         if k > 0 {
@@ -504,23 +502,35 @@ fn interp_eval(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         }
         script.extend_from_slice(&obj_bytes(a));
     }
-    // `interp eval {} script` runs in the current interp; else in the child.
-    if path.is_empty() {
-        interp.eval_str(&script)
-    } else {
-        interp.eval_in_child(&path, &script)
+    // `interp eval {} script` runs in the current interp; otherwise descend the
+    // path to the target's parent and eval in the leaf child.
+    let Some((leaf, parent)) = path.split_last() else {
+        return interp.eval_str(&script);
+    };
+    let leaf = leaf.clone();
+    match interp.with_child_path(parent, |a| {
+        let code = a.eval_in_child(&leaf, &script);
+        (code, a.result_bytes())
+    }) {
+        Some((code, result)) => {
+            interp.set_result_bytes(&result);
+            code
+        }
+        None => not_found_path(interp, &path),
     }
 }
 
 /// `interp delete ?path ...?` — delete each named child interpreter.
 fn interp_delete(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     for &a in &argv[2..] {
-        let path = obj_bytes(a);
-        if path.is_empty() || !interp.delete_child(&path) {
-            let mut m = b"could not find interpreter \"".to_vec();
-            m.extend_from_slice(&path);
-            m.push(b'"');
-            return interp.set_error(&m);
+        let path = interp_path(a);
+        let Some((leaf, parent)) = path.split_last() else {
+            return not_found_path(interp, &path);
+        };
+        let leaf = leaf.clone();
+        match interp.with_child_path(parent, |p| p.delete_child(&leaf)) {
+            Some(true) => {}
+            _ => return not_found_path(interp, &path),
         }
     }
     interp.set_result_bytes(b"");

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -133,6 +133,7 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         b"hide" => interp_hidectl(interp, argv, HideOp::Hide),
         b"expose" => interp_hidectl(interp, argv, HideOp::Expose),
         b"invokehidden" => interp_invokehidden(interp, argv),
+        b"limit" => interp_limit(interp, argv),
         b"hidden" => {
             // `interp hidden ?path?` — hidden command names in the (current or
             // named) interp.
@@ -262,6 +263,42 @@ fn interp_create(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 enum HideOp {
     Hide,
     Expose,
+}
+
+/// `interp limit path limitType ?-option value …?` — query/configure the
+/// `commands` or `time` limit on a child interp.
+fn interp_limit(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    // argv = [interp, limit, path, limitType, opts…]
+    if argv.len() < 4 {
+        return wrong_args(interp, b"interp limit path limitType ?-option value ...?");
+    }
+    let path = obj_bytes(argv[2]);
+    let ltype = obj_bytes(argv[3]);
+    // Validate the limit type before the current-interp guard so a bad type is
+    // reported ahead of the inaccessibility error (interp-35.3 vs .23).
+    if ltype.as_slice() != b"commands" && ltype.as_slice() != b"time" {
+        let mut m = b"bad limit type \"".to_vec();
+        m.extend_from_slice(&ltype);
+        m.extend_from_slice(b"\": must be commands or time");
+        return interp.set_error(&m);
+    }
+    if path.is_empty() {
+        return interp.set_error(b"limits on current interpreter inaccessible");
+    }
+    let opts: Vec<*mut TclObj> = argv[4..].to_vec();
+    match interp.with_child(&path, |c| c.limit_apply(&ltype, &opts)) {
+        Some(Ok(o)) => {
+            interp.set_result(o);
+            Code::Ok
+        }
+        Some(Err(m)) => interp.set_error(&m),
+        None => {
+            let mut m = b"could not find interpreter \"".to_vec();
+            m.extend_from_slice(&path);
+            m.push(b'"');
+            interp.set_error(&m)
+        }
+    }
 }
 
 /// Whether `name` resolves in the global namespace — it carries no namespace

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -264,14 +264,66 @@ enum HideOp {
     Expose,
 }
 
+/// Whether `name` resolves in the global namespace — it carries no namespace
+/// qualifiers beyond an optional leading `::`.
+fn is_global_command(name: &[u8]) -> bool {
+    let body = name.strip_prefix(b"::".as_slice()).unwrap_or(name);
+    !body.windows(2).any(|w| w == b"::")
+}
+
 /// `interp hide|expose path cmdName` — move a command into/out of the hidden
 /// table of the named (or current, when path is `{}`) interpreter.
 fn interp_hidectl(interp: &mut Interp, argv: &[*mut TclObj], op: HideOp) -> Code {
-    if argv.len() != 4 {
-        return wrong_args(interp, b"interp hide|expose path cmdName");
+    // `interp hide   path cmdName     ?hiddenCmdName?`
+    // `interp expose path hiddenName  ?cmdName?`
+    if argv.len() != 4 && argv.len() != 5 {
+        return match op {
+            HideOp::Hide => wrong_args(interp, b"interp hide path cmdName ?hiddenCmdName?"),
+            HideOp::Expose => wrong_args(interp, b"interp expose path hiddenCmdName ?cmdName?"),
+        };
+    }
+    // A safe interpreter may not touch the hidden-command table of itself or
+    // any of its children (the check is on the *executing* interp).
+    if interp.is_safe() {
+        return interp.set_error(match op {
+            HideOp::Hide => b"permission denied: safe interpreter cannot hide commands",
+            HideOp::Expose => b"permission denied: safe interpreter cannot expose commands",
+        });
     }
     let path = obj_bytes(argv[2]);
     let cmd = obj_bytes(argv[3]);
+    let token = if argv.len() == 5 {
+        obj_bytes(argv[4])
+    } else {
+        cmd.clone()
+    };
+    // The hidden-command token may never carry namespace qualifiers, and only
+    // global-namespace commands can be hidden / exposed-from.
+    match op {
+        HideOp::Hide => {
+            if token.windows(2).any(|w| w == b"::") {
+                return interp.set_error(
+                    b"cannot use namespace qualifiers in hidden command token (rename)",
+                );
+            }
+            if !is_global_command(&cmd) {
+                return interp
+                    .set_error(b"can only hide global namespace commands (use rename then hide)");
+            }
+        }
+        HideOp::Expose => {
+            if cmd.windows(2).any(|w| w == b"::") {
+                return interp.set_error(
+                    b"cannot use namespace qualifiers in hidden command token (rename)",
+                );
+            }
+            if !is_global_command(&token) {
+                return interp.set_error(
+                    b"cannot expose to a namespace (use expose to toplevel, then rename)",
+                );
+            }
+        }
+    }
     let did = if path.is_empty() {
         match op {
             HideOp::Hide => interp.hide_command(&cmd),
@@ -316,6 +368,9 @@ fn interp_invokehidden(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
     if i >= argv.len() {
         return wrong_args(interp, b"interp invokehidden path ?-opt? cmd ?arg ...?");
+    }
+    if interp.is_safe() {
+        return interp.set_error(b"not allowed to invoke hidden commands from safe interpreter");
     }
     let cmd = obj_bytes(argv[i]);
     // Build the hidden command's argv (cmd + remaining args).

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -207,31 +207,49 @@ fn interp_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// its name (auto-generated `interpN` when omitted). `-safe` hides the
 /// host-touching commands (the Safe Base's re-aliasing is a follow-up).
 fn interp_create(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
+    // C's "weird historical rule": `-safe` is accepted anywhere before `--`
+    // (`interp create a -safe` is valid), and the path is the lone non-option
+    // word — so scan all args rather than stopping at the first non-flag.
     let mut name: Option<Vec<u8>> = None;
     let mut safe = false;
+    let mut last = false;
     let mut i = 2;
     while i < argv.len() {
         let a = obj_bytes(argv[i]);
-        match a.as_slice() {
-            b"-safe" => safe = true,
-            b"--" => {
-                i += 1;
-                break;
+        if !last && a.first() == Some(&b'-') {
+            match a.as_slice() {
+                b"-safe" => {
+                    safe = true;
+                    i += 1;
+                    continue;
+                }
+                b"--" => {
+                    i += 1;
+                    last = true;
+                }
+                _ => {
+                    let mut m = b"bad option \"".to_vec();
+                    m.extend_from_slice(&a);
+                    m.extend_from_slice(b"\": must be -safe or --");
+                    return interp.set_error(&m);
+                }
             }
-            _ => break,
+        }
+        if name.is_some() {
+            return wrong_args(interp, b"interp create ?-safe? ?--? ?path?");
+        }
+        if i < argv.len() {
+            name = Some(obj_bytes(argv[i]));
         }
         i += 1;
     }
-    if i < argv.len() {
-        let p = obj_bytes(argv[i]);
-        // Only single-level (simple) names are supported; a path list is not.
-        if interp.child_exists(&p) {
+    if let Some(ref p) = name {
+        if interp.child_exists(p) {
             let mut m = b"interpreter named \"".to_vec();
-            m.extend_from_slice(&p);
+            m.extend_from_slice(p);
             m.extend_from_slice(b"\" already exists, cannot create");
             return interp.set_error(&m);
         }
-        name = Some(p);
     }
     let created = interp.create_child(name);
     if safe {

--- a/runtime/rust/src/cmd_clock.rs
+++ b/runtime/rust/src/cmd_clock.rs
@@ -15,6 +15,52 @@ use crate::obj::TclObj;
 /// Register `clock`.
 pub fn install(interp: &mut Interp) {
     interp.register_builtin(b"clock", clock_cmd);
+    // The ensemble's implementation members: the real `clock.tcl` rewrites
+    // `clock` into an ensemble whose subcommands dispatch to `::tcl::clock::…`,
+    // and library/framework code calls those fully-qualified forms directly.
+    // Each prepends its subcommand and reuses the same dispatch.
+    interp.register_builtin(b"::tcl::clock::seconds", clock_seconds);
+    interp.register_builtin(b"::tcl::clock::milliseconds", clock_milliseconds);
+    interp.register_builtin(b"::tcl::clock::microseconds", clock_microseconds);
+    interp.register_builtin(b"::tcl::clock::clicks", clock_clicks);
+    interp.register_builtin(b"::tcl::clock::format", clock_format);
+    interp.register_builtin(b"::tcl::clock::add", clock_add);
+    interp.register_builtin(b"::tcl::clock::scan", clock_scan);
+}
+
+/// Dispatch an `::tcl::clock::<sub>` ensemble member by prepending `sub` to the
+/// argument list and reusing [`clock_cmd`].
+fn clock_member(interp: &mut Interp, argv: &[*mut TclObj], sub: &[u8]) -> Code {
+    let sub_obj = crate::obj::new_string_bytes(sub);
+    let mut v: Vec<*mut TclObj> = Vec::with_capacity(argv.len() + 1);
+    v.push(argv[0]);
+    v.push(sub_obj);
+    v.extend_from_slice(&argv[1..]);
+    let code = clock_cmd(interp, &v);
+    crate::interp::drop_fresh(sub_obj);
+    code
+}
+
+fn clock_seconds(i: &mut Interp, a: &[*mut TclObj]) -> Code {
+    clock_member(i, a, b"seconds")
+}
+fn clock_milliseconds(i: &mut Interp, a: &[*mut TclObj]) -> Code {
+    clock_member(i, a, b"milliseconds")
+}
+fn clock_microseconds(i: &mut Interp, a: &[*mut TclObj]) -> Code {
+    clock_member(i, a, b"microseconds")
+}
+fn clock_clicks(i: &mut Interp, a: &[*mut TclObj]) -> Code {
+    clock_member(i, a, b"clicks")
+}
+fn clock_format(i: &mut Interp, a: &[*mut TclObj]) -> Code {
+    clock_member(i, a, b"format")
+}
+fn clock_add(i: &mut Interp, a: &[*mut TclObj]) -> Code {
+    clock_member(i, a, b"add")
+}
+fn clock_scan(i: &mut Interp, a: &[*mut TclObj]) -> Code {
+    clock_member(i, a, b"scan")
 }
 
 fn clock_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {

--- a/runtime/rust/src/cmd_control.rs
+++ b/runtime/rust/src/cmd_control.rs
@@ -151,6 +151,9 @@ fn while_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     let cond = argv[1];
     let body = argv[2];
     loop {
+        if let Some(code) = interp.limit_check_tick() {
+            return code;
+        }
         match crate::builtins::eval_bool_expr(interp, cond) {
             Ok(true) => {}
             Ok(false) => break,
@@ -199,6 +202,9 @@ fn for_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
         other => return other,
     }
     loop {
+        if let Some(code) = interp.limit_check_tick() {
+            return code;
+        }
         match crate::builtins::eval_bool_expr(interp, cond) {
             Ok(true) => {}
             Ok(false) => break,

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -6484,7 +6484,9 @@ mod tests {
             ok(i, b"rename obj {}");
             ok(i, b"update idletasks");
             assert_eq!(ok(i, b"set ::caught"), b"boom");
-            ok(i, b"interp bgerror {} {}");
+            // An empty cmdPrefix is rejected (C's `ChildBgerror`: length >= 1),
+            // so the handler is reset by overwriting it with a one-element list.
+            ok(i, b"interp bgerror {} noop");
         });
     }
 

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -4576,6 +4576,16 @@ impl Interp {
         for &k in UNSAFE_PLATFORM {
             self.var_unset_elem(b"tcl_platform", k);
         }
+        // A safe interp has no `env` array and no real library/package paths
+        // (C's `Tcl_MakeSafe`); the Safe Base re-virtualises an `auto_path`.
+        for v in [
+            &b"env"[..],
+            b"tcl_library",
+            b"tclDefaultLibrary",
+            b"tcl_pkgPath",
+        ] {
+            self.var_unset(v);
+        }
         self.is_safe.set(true);
     }
 

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -713,6 +713,12 @@ pub struct InterpState {
     /// in the contract's `CommandId`. Bidirectional: `find_command` interns an
     /// FQN, `dispatch_id` reverses the id back to its FQN to invoke it.
     cmd_arena: RefCell<CmdArena>,
+    /// `interp limit` configuration. The `time` limit is enforced by the loop
+    /// commands; `commands` is stored for query/set only.
+    limits: RefCell<LimitSet>,
+    /// Free-running counter that throttles wall-clock polling for the `time`
+    /// limit (see [`Interp::limit_check_tick`]).
+    limit_tick: Cell<u32>,
 }
 
 /// An ensemble-rewrite record (C's `iPtr->ensembleRewrite`, see
@@ -730,6 +736,33 @@ pub(crate) struct EnsembleRewrite {
     /// (C's `numInsertedObjs`); `inserted - 1` formal parameters are already
     /// filled and so dropped from the usage message.
     pub inserted: usize,
+}
+
+/// `interp limit` configuration for one interpreter — the `commands` and `time`
+/// limit types. The `time` limit is enforced (polled by the loop commands);
+/// `commands` is stored for query/set only.
+#[derive(Clone)]
+pub(crate) struct LimitSet {
+    cmd_command: Vec<u8>,
+    cmd_granularity: i64,
+    cmd_value: Option<i64>,
+    time_command: Vec<u8>,
+    time_granularity: i64,
+    /// Absolute wall-clock deadline as `(seconds, milliseconds)`; `None` unset.
+    time_value: Option<(i64, i64)>,
+}
+
+impl Default for LimitSet {
+    fn default() -> Self {
+        Self {
+            cmd_command: Vec::new(),
+            cmd_granularity: 1,
+            cmd_value: None,
+            time_command: Vec::new(),
+            time_granularity: 10,
+            time_value: None,
+        }
+    }
 }
 
 /// The proc-call recursion bound (C Tcl's default `interp recursionlimit`).
@@ -759,6 +792,68 @@ fn parse_recursion_limit(bytes: &[u8]) -> Result<i64, Vec<u8>> {
         return Err(b"integer value too large to represent".to_vec());
     }
     Err(not_int())
+}
+
+/// Build a Tcl dict (flat key/value list) object from `pairs`, releasing the
+/// builder's references once the list has taken its own.
+fn dict_obj(pairs: &[(&[u8], Vec<u8>)]) -> *mut TclObj {
+    let mut elems: Vec<*mut TclObj> = Vec::with_capacity(pairs.len() * 2);
+    for (k, v) in pairs {
+        elems.push(obj::new_string_bytes(k));
+        elems.push(obj::new_string_bytes(v));
+    }
+    let list = crate::list::new_list_obj(&elems);
+    for e in elems {
+        drop_fresh(e);
+    }
+    list
+}
+
+/// Render an optional limit integer: the decimal bytes, or empty when unset.
+fn opt_int(v: Option<i64>) -> Vec<u8> {
+    v.map(|n| n.to_string().into_bytes()).unwrap_or_default()
+}
+
+/// Resolve an `interp limit` option by unambiguous prefix against `opts`
+/// (mirroring C's `Tcl_GetIndexFromObj`). Returns the canonical spelling or a
+/// `bad option "X": must be …` error.
+fn resolve_limit_opt(arg: &[u8], opts: &[&[u8]]) -> Result<Vec<u8>, Vec<u8>> {
+    let matches: Vec<&[u8]> = opts
+        .iter()
+        .copied()
+        .filter(|o| o.starts_with(arg))
+        .collect();
+    if matches.len() == 1 {
+        return Ok(matches[0].to_vec());
+    }
+    if opts.contains(&arg) {
+        return Ok(arg.to_vec());
+    }
+    let mut m = b"bad option \"".to_vec();
+    m.extend_from_slice(arg);
+    m.extend_from_slice(b"\": must be ");
+    for (i, o) in opts.iter().enumerate() {
+        if i == opts.len() - 1 && i > 0 {
+            m.extend_from_slice(b", or ");
+        } else if i > 0 {
+            m.extend_from_slice(b", ");
+        }
+        m.extend_from_slice(o);
+    }
+    Err(m)
+}
+
+/// Parse an `interp limit` integer option value (`expected integer but got "X"`).
+fn parse_limit_int(bytes: &[u8]) -> Result<i64, Vec<u8>> {
+    if let Ok(s) = std::str::from_utf8(bytes) {
+        if let Ok(n) = s.trim().parse::<i64>() {
+            return Ok(n);
+        }
+    }
+    let mut m = b"expected integer but got \"".to_vec();
+    m.extend_from_slice(bytes);
+    m.push(b'"');
+    Err(m)
 }
 
 impl Interp {
@@ -819,6 +914,8 @@ impl Interp {
             during: Cell::new(None),
             result: Cell::new(result),
             cmd_arena: RefCell::new(CmdArena::default()),
+            limits: RefCell::new(LimitSet::default()),
+            limit_tick: Cell::new(0),
         }));
         builtins::install(&mut interp);
         interp
@@ -4420,6 +4517,26 @@ impl Interp {
                     None => self.error(b"could not find interpreter"),
                 }
             }
+            // `$child limit limitType ?-option value …?` — query/configure the
+            // child's commands/time limit.
+            b"limit" => {
+                if argv.len() < 3 {
+                    let mut m = b"wrong # args: should be \"".to_vec();
+                    m.extend_from_slice(name);
+                    m.extend_from_slice(b" limit limitType ?-option value ...?\"");
+                    return self.error(&m);
+                }
+                let ltype = obj_bytes(argv[2]);
+                let opts: Vec<*mut TclObj> = argv[3..].to_vec();
+                match self.with_child(name, |c| c.limit_apply(&ltype, &opts)) {
+                    Some(Ok(o)) => {
+                        self.set_result(o);
+                        Code::Ok
+                    }
+                    Some(Err(m)) => self.error(&m),
+                    None => self.error(b"could not find interpreter"),
+                }
+            }
             other => {
                 let mut m = b"interp subcommand \"".to_vec();
                 m.extend_from_slice(other);
@@ -4620,6 +4737,176 @@ impl Interp {
                 Ok(n)
             }
         }
+    }
+
+    /// `interp limit limitType ?-option value …?` on this interp. Returns the
+    /// fresh result object on success, or the error-message bytes the caller
+    /// should raise.
+    pub(crate) fn limit_apply(
+        &self,
+        ltype: &[u8],
+        opts: &[*mut TclObj],
+    ) -> Result<*mut TclObj, Vec<u8>> {
+        match ltype {
+            b"commands" => self.limit_commands(opts),
+            b"time" => self.limit_time(opts),
+            other => {
+                let mut m = b"bad limit type \"".to_vec();
+                m.extend_from_slice(other);
+                m.extend_from_slice(b"\": must be commands or time");
+                Err(m)
+            }
+        }
+    }
+
+    fn limit_commands(&self, opts: &[*mut TclObj]) -> Result<*mut TclObj, Vec<u8>> {
+        const OPTS: &[&[u8]] = &[b"-command", b"-granularity", b"-value"];
+        if opts.is_empty() {
+            let l = self.limits.borrow();
+            return Ok(dict_obj(&[
+                (b"-command", l.cmd_command.clone()),
+                (b"-granularity", l.cmd_granularity.to_string().into_bytes()),
+                (b"-value", opt_int(l.cmd_value)),
+            ]));
+        }
+        if opts.len() == 1 {
+            let opt = resolve_limit_opt(&obj_bytes(opts[0]), OPTS)?;
+            let l = self.limits.borrow();
+            let val = match opt.as_slice() {
+                b"-command" => l.cmd_command.clone(),
+                b"-granularity" => l.cmd_granularity.to_string().into_bytes(),
+                _ => opt_int(l.cmd_value),
+            };
+            return Ok(obj::new_string_bytes(&val));
+        }
+        let mut i = 0;
+        while i + 1 < opts.len() {
+            let opt = resolve_limit_opt(&obj_bytes(opts[i]), OPTS)?;
+            let val = obj_bytes(opts[i + 1]);
+            match opt.as_slice() {
+                b"-command" => self.limits.borrow_mut().cmd_command = val,
+                b"-granularity" => {
+                    let n = parse_limit_int(&val)?;
+                    if n < 1 {
+                        return Err(b"granularity must be at least 1".to_vec());
+                    }
+                    self.limits.borrow_mut().cmd_granularity = n;
+                }
+                _ => {
+                    let n = parse_limit_int(&val)?;
+                    if n < 0 {
+                        return Err(b"command limit value must be at least 0".to_vec());
+                    }
+                    self.limits.borrow_mut().cmd_value = Some(n);
+                }
+            }
+            i += 2;
+        }
+        Ok(obj::new_string_bytes(b""))
+    }
+
+    fn limit_time(&self, opts: &[*mut TclObj]) -> Result<*mut TclObj, Vec<u8>> {
+        const OPTS: &[&[u8]] = &[b"-command", b"-granularity", b"-milliseconds", b"-seconds"];
+        if opts.is_empty() {
+            let l = self.limits.borrow();
+            let (secs, millis) = match l.time_value {
+                Some((s, m)) => (s.to_string().into_bytes(), m.to_string().into_bytes()),
+                None => (Vec::new(), Vec::new()),
+            };
+            return Ok(dict_obj(&[
+                (b"-command", l.time_command.clone()),
+                (b"-granularity", l.time_granularity.to_string().into_bytes()),
+                (b"-milliseconds", millis),
+                (b"-seconds", secs),
+            ]));
+        }
+        if opts.len() == 1 {
+            let opt = resolve_limit_opt(&obj_bytes(opts[0]), OPTS)?;
+            let l = self.limits.borrow();
+            let val = match opt.as_slice() {
+                b"-command" => l.time_command.clone(),
+                b"-granularity" => l.time_granularity.to_string().into_bytes(),
+                b"-seconds" => opt_int(l.time_value.map(|(s, _)| s)),
+                _ => opt_int(l.time_value.map(|(_, m)| m)),
+            };
+            return Ok(obj::new_string_bytes(&val));
+        }
+        let (mut sec, mut ms) = self.limits.borrow().time_value.unwrap_or((0, 0));
+        let mut touched = self.limits.borrow().time_value.is_some();
+        let mut i = 0;
+        while i + 1 < opts.len() {
+            let opt = resolve_limit_opt(&obj_bytes(opts[i]), OPTS)?;
+            let val = obj_bytes(opts[i + 1]);
+            match opt.as_slice() {
+                b"-command" => self.limits.borrow_mut().time_command = val,
+                b"-granularity" => {
+                    let n = parse_limit_int(&val)?;
+                    if n < 1 {
+                        return Err(b"granularity must be at least 1".to_vec());
+                    }
+                    self.limits.borrow_mut().time_granularity = n;
+                }
+                b"-seconds" => {
+                    let n = parse_limit_int(&val)?;
+                    if n < 0 {
+                        return Err(b"seconds must be non-negative".to_vec());
+                    }
+                    sec = n;
+                    touched = true;
+                }
+                _ => {
+                    let n = parse_limit_int(&val)?;
+                    if n < 0 {
+                        return Err(b"milliseconds must be non-negative".to_vec());
+                    }
+                    ms = n;
+                    touched = true;
+                }
+            }
+            i += 2;
+        }
+        if touched {
+            // Normalise excess milliseconds into seconds.
+            sec += ms.div_euclid(1000);
+            ms = ms.rem_euclid(1000);
+            self.limits.borrow_mut().time_value = Some((sec, ms));
+        }
+        Ok(obj::new_string_bytes(b""))
+    }
+
+    /// Whether this interp's `time` limit has elapsed (an absolute wall-clock
+    /// deadline). `false` when no time limit is set.
+    pub(crate) fn time_limit_exceeded(&self) -> bool {
+        match self.limits.borrow().time_value {
+            Some((secs, millis)) => {
+                let deadline = i128::from(secs) * 1000 + i128::from(millis);
+                self.host().clock().now_millis() >= deadline
+            }
+            None => false,
+        }
+    }
+
+    /// Whether a `time` limit is configured at all — the cheap guard the loop
+    /// commands check before paying for a wall-clock read.
+    pub(crate) fn has_time_limit(&self) -> bool {
+        self.limits.borrow().time_value.is_some()
+    }
+
+    /// Advance the limit-poll counter and, when a `time` limit is armed and the
+    /// throttle window elapses, set the `time limit exceeded` error and return
+    /// its `Code`. Called from the loop commands (`while`/`for`) each iteration
+    /// so an unbounded loop under `interp limit $i time` terminates. A guarded
+    /// no-op when no time limit is set.
+    pub(crate) fn limit_check_tick(&mut self) -> Option<Code> {
+        if !self.has_time_limit() {
+            return None;
+        }
+        let t = self.limit_tick.get().wrapping_add(1);
+        self.limit_tick.set(t);
+        if t & 0x0FFF == 0 && self.time_limit_exceeded() {
+            return Some(self.error(b"time limit exceeded"));
+        }
+        None
     }
 
     /// The names of this interp's direct child interpreters (sorted).

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -4663,6 +4663,25 @@ impl Interp {
         Some(r)
     }
 
+    /// Run `f` against the interpreter addressed by a (possibly multi-level)
+    /// path — a list of child names descending from this interp. An empty path
+    /// is this interp itself; otherwise each name is resolved through
+    /// [`with_child`] in turn. Returns `None` if any name in the chain is not a
+    /// child of its predecessor (`interp create {a b}`, `interp eval {a b} …`).
+    pub(crate) fn with_child_path<R>(
+        &mut self,
+        path: &[Vec<u8>],
+        f: impl FnOnce(&mut Interp) -> R,
+    ) -> Option<R> {
+        match path {
+            [] => Some(f(self)),
+            [name] => self.with_child(name, f),
+            [name, rest @ ..] => self
+                .with_child(name, |c| c.with_child_path(rest, f))
+                .flatten(),
+        }
+    }
+
     /// `interp hide name`: move command `name` out of the command table into the
     /// hidden table. Returns whether it existed.
     pub(crate) fn hide_command(&mut self, name: &[u8]) -> bool {

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -4586,6 +4586,15 @@ impl Interp {
         ] {
             self.var_unset(v);
         }
+        // A safe interp's `clock` is aliased to the parent's, so date/time
+        // formatting works without the child reaching the timezone files.
+        self.ns_register(
+            b"clock",
+            Command::ParentAlias {
+                target: b"clock".to_vec(),
+                prefix: Vec::new(),
+            },
+        );
         self.is_safe.set(true);
     }
 

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -4480,6 +4480,15 @@ impl Interp {
             }
             b"hide" | b"expose" if argv.len() == 3 => {
                 let hide = obj_bytes(argv[1]) == b"hide";
+                // A safe interpreter may not touch any hidden-command table
+                // (checked on the executing interp).
+                if self.is_safe() {
+                    return self.error(if hide {
+                        b"permission denied: safe interpreter cannot hide commands"
+                    } else {
+                        b"permission denied: safe interpreter cannot expose commands"
+                    });
+                }
                 let cmd = obj_bytes(argv[2]);
                 self.with_child(name, |c| {
                     if hide {
@@ -4492,6 +4501,10 @@ impl Interp {
                 Code::Ok
             }
             b"invokehidden" if argv.len() >= 3 => {
+                if self.is_safe() {
+                    return self
+                        .error(b"not allowed to invoke hidden commands from safe interpreter");
+                }
                 let cmd = obj_bytes(argv[2]);
                 let hidden_argv: Vec<*mut TclObj> = argv[2..].to_vec();
                 for &a in &hidden_argv {
@@ -4921,6 +4934,14 @@ impl Interp {
             };
             return Ok(obj::new_string_bytes(&val));
         }
+        // A trailing option with no value is a catchable error, not a silent
+        // drop (`interp limit c commands -value 1 -granularity`).
+        if opts.len() % 2 != 0 {
+            return Err(
+                b"wrong # args: should be \"interp limit path commands ?-option value ...?\""
+                    .to_vec(),
+            );
+        }
         let mut i = 0;
         while i + 1 < opts.len() {
             let opt = resolve_limit_opt(&obj_bytes(opts[i]), OPTS)?;
@@ -4972,6 +4993,11 @@ impl Interp {
                 _ => opt_int(l.time_value.map(|(_, m)| m)),
             };
             return Ok(obj::new_string_bytes(&val));
+        }
+        if opts.len() % 2 != 0 {
+            return Err(
+                b"wrong # args: should be \"interp limit path time ?-option value ...?\"".to_vec(),
+            );
         }
         let (mut sec, mut ms) = self.limits.borrow().time_value.unwrap_or((0, 0));
         let mut touched = self.limits.borrow().time_value.is_some();

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -567,6 +567,10 @@ pub struct InterpState {
     /// recursion so an infinite proc loop raises a catchable error instead of
     /// overflowing the (wasm) stack (the tracked PR #557 follow-up).
     recursion_depth: Cell<usize>,
+    /// Per-interp recursion bound (`interp recursionlimit`), default
+    /// [`RECURSION_LIMIT`]. Each child carries its own, so raising a child's
+    /// limit does not affect the parent.
+    recursion_limit: Cell<usize>,
     /// The package database (`package provide`/`require`/`ifneeded`/`unknown`).
     pub(crate) packages: RefCell<crate::cmd_package::PackageState>,
     /// The `source` script stack (`info script` — the file being sourced).
@@ -731,6 +735,32 @@ pub(crate) struct EnsembleRewrite {
 /// The proc-call recursion bound (C Tcl's default `interp recursionlimit`).
 const RECURSION_LIMIT: usize = 1000;
 
+/// Parse an `interp recursionlimit` integer the way C's `Tcl_GetIntFromObj`
+/// reports: a decimal that overflows `i64` is "too large to represent", a
+/// non-numeric value is "expected integer but got …".
+fn parse_recursion_limit(bytes: &[u8]) -> Result<i64, Vec<u8>> {
+    let not_int = || {
+        let mut m = b"expected integer but got \"".to_vec();
+        m.extend_from_slice(bytes);
+        m.push(b'"');
+        m
+    };
+    let s = match std::str::from_utf8(bytes) {
+        Ok(s) => s.trim(),
+        Err(_) => return Err(not_int()),
+    };
+    if let Ok(n) = s.parse::<i64>() {
+        return Ok(n);
+    }
+    // A run of decimal digits (with an optional sign) that failed to parse
+    // overflowed the integer range; anything else is simply not an integer.
+    let body = s.strip_prefix(['+', '-']).unwrap_or(s);
+    if !body.is_empty() && body.bytes().all(|b| b.is_ascii_digit()) {
+        return Err(b"integer value too large to represent".to_vec());
+    }
+    Err(not_int())
+}
+
 impl Interp {
     /// Create an interp: global frame, the built-in command set, an empty
     /// result.
@@ -755,6 +785,7 @@ impl Interp {
             namespaces: RefCell::new(Namespaces::new()),
             current_ns: Cell::new(GLOBAL),
             recursion_depth: Cell::new(0),
+            recursion_limit: Cell::new(RECURSION_LIMIT),
             packages: RefCell::new(crate::cmd_package::PackageState::with_core()),
             script_stack: RefCell::new(Vec::new()),
             channels: RefCell::new(crate::cmd_chan::ChannelTable::default()),
@@ -4371,6 +4402,24 @@ impl Interp {
                 self.set_result(obj::new_string_bytes(&alias));
                 Code::Ok
             }
+            // `$child recursionlimit ?newlimit?` — the path-less child form.
+            b"recursionlimit" => {
+                if argv.len() > 3 {
+                    let mut m = b"wrong # args: should be \"".to_vec();
+                    m.extend_from_slice(name);
+                    m.extend_from_slice(b" recursionlimit ?newlimit?\"");
+                    return self.error(&m);
+                }
+                let newlimit = argv.get(2).map(|&a| obj_bytes(a));
+                match self.with_child(name, |c| c.recursion_limit_apply(newlimit.as_deref())) {
+                    Some(Ok(n)) => {
+                        self.set_result_bytes(n.to_string().as_bytes());
+                        Code::Ok
+                    }
+                    Some(Err(m)) => self.error(&m),
+                    None => self.error(b"could not find interpreter"),
+                }
+            }
             other => {
                 let mut m = b"interp subcommand \"".to_vec();
                 m.extend_from_slice(other);
@@ -4513,6 +4562,25 @@ impl Interp {
     /// Whether this interp is safe (`interp issafe`).
     pub(crate) fn is_safe(&self) -> bool {
         self.is_safe.get()
+    }
+
+    /// `interp recursionlimit` get / set on this interp. `newlimit` is the
+    /// optional new-limit bytes; returns the resulting limit, or the error
+    /// message the caller should raise (`expected integer …` / `… too large …`
+    /// / `recursion limit must be > 0`). Each interp keeps its own limit, so a
+    /// child raising its limit leaves the parent's untouched.
+    pub(crate) fn recursion_limit_apply(&self, newlimit: Option<&[u8]>) -> Result<i64, Vec<u8>> {
+        match newlimit {
+            None => Ok(self.recursion_limit.get() as i64),
+            Some(bytes) => {
+                let n = parse_recursion_limit(bytes)?;
+                if n <= 0 {
+                    return Err(b"recursion limit must be > 0".to_vec());
+                }
+                self.recursion_limit.set(n as usize);
+                Ok(n)
+            }
+        }
     }
 
     /// The names of this interp's direct child interpreters (sorted).
@@ -4685,7 +4753,7 @@ impl Interp {
             return self.error(&self.proc_wrong_args(usage, params, supplied, meta.quote_name));
         }
         // Recursion bound (catchable, not a stack overflow).
-        if self.recursion_depth.get() >= RECURSION_LIMIT {
+        if self.recursion_depth.get() >= self.recursion_limit.get() {
             return self.error(b"too many nested evaluations (infinite loop?)");
         }
         self.recursion_depth.set(self.recursion_depth.get() + 1);

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -4556,6 +4556,26 @@ impl Interp {
         for &c in UNSAFE {
             self.hide_command(c);
         }
+        // Remove the host-revealing `tcl_platform` elements (C's `Tcl_MakeSafe`
+        // unsets os/osVersion/machine/user) plus our backend-introspection keys,
+        // so a safe interp exposes only the portable subset (byteOrder, engine,
+        // pathSeparator, platform, pointerSize, wordSize).
+        const UNSAFE_PLATFORM: &[&[u8]] = &[
+            b"os",
+            b"osVersion",
+            b"machine",
+            b"user",
+            b"threaded",
+            b"runtime",
+            b"runtimeVersion",
+            b"wasm",
+            b"wasi",
+            b"wasiVersion",
+            b"ebpf",
+        ];
+        for &k in UNSAFE_PLATFORM {
+            self.var_unset_elem(b"tcl_platform", k);
+        }
         self.is_safe.set(true);
     }
 

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -1217,6 +1217,46 @@ impl Interp {
                 drop_fresh(o);
             }
         }
+        // Backend-introspection keys (the test-suite constraint overlay reads
+        // these). The tree-walk runtime targets native or wasm32-wasip*, so the
+        // wasm / WASI facts come from the build's `cfg`; an environment override
+        // (read through the host seam) lets a native binary evaluate another
+        // backend's skip lists.
+        {
+            use tcl_platform::backend::{self, key};
+            let detected = |k: &str, compiled: &str| -> String {
+                backend::override_env_var(k)
+                    .and_then(|var| self.host().env().get(var))
+                    .filter(|v| !v.is_empty())
+                    .unwrap_or_else(|| compiled.to_string())
+            };
+            let backend_keys = [
+                (key::RUNTIME, "treewalk".to_string()),
+                (key::RUNTIME_VERSION, env!("CARGO_PKG_VERSION").to_string()),
+                (
+                    key::WASM,
+                    detected(key::WASM, backend::compiled_wasm_spec()),
+                ),
+                (
+                    key::WASI,
+                    detected(key::WASI, backend::compiled_wasi_spec()),
+                ),
+                (
+                    key::WASI_VERSION,
+                    detected(key::WASI_VERSION, backend::compiled_wasi_host()),
+                ),
+                (
+                    key::EBPF,
+                    detected(key::EBPF, backend::compiled_ebpf_spec()),
+                ),
+            ];
+            for (k, v) in backend_keys {
+                let o = new_string(v.as_bytes());
+                if self.var_set_elem(b"tcl_platform", k.as_bytes(), o).is_err() {
+                    drop_fresh(o);
+                }
+            }
+        }
         // env array from the host environment (no quoting hazards via var_set_elem).
         let vars = self.host().env().vars();
         for (k, v) in vars {

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -719,6 +719,9 @@ pub struct InterpState {
     /// Free-running counter that throttles wall-clock polling for the `time`
     /// limit (see [`Interp::limit_check_tick`]).
     limit_tick: Cell<u32>,
+    /// `interp debug -frame` — the TIP 280 frame-debug switch. A one-way latch
+    /// (once on, stays on), seeded from `env(TCL_INTERP_DEBUG_FRAME)` at create.
+    debug_frame: Cell<bool>,
 }
 
 /// An ensemble-rewrite record (C's `iPtr->ensembleRewrite`, see
@@ -843,6 +846,26 @@ fn resolve_limit_opt(arg: &[u8], opts: &[&[u8]]) -> Result<Vec<u8>, Vec<u8>> {
     Err(m)
 }
 
+/// Validate an `interp debug` option: it must be a non-empty prefix of `-frame`.
+fn check_debug_opt(opt: *mut TclObj) -> Result<(), Vec<u8>> {
+    let o = obj_bytes(opt);
+    if !o.is_empty() && b"-frame".starts_with(o.as_slice()) {
+        return Ok(());
+    }
+    let mut m = b"bad debug option \"".to_vec();
+    m.extend_from_slice(&o);
+    m.extend_from_slice(b"\": must be -frame");
+    Err(m)
+}
+
+/// Whether `bytes` is a truthy boolean literal (for the `-frame` latch).
+fn parse_truth(bytes: &[u8]) -> bool {
+    matches!(
+        bytes.to_ascii_lowercase().as_slice(),
+        b"1" | b"true" | b"yes" | b"on"
+    )
+}
+
 /// Parse an `interp limit` integer option value (`expected integer but got "X"`).
 fn parse_limit_int(bytes: &[u8]) -> Result<i64, Vec<u8>> {
     if let Ok(s) = std::str::from_utf8(bytes) {
@@ -916,6 +939,7 @@ impl Interp {
             cmd_arena: RefCell::new(CmdArena::default()),
             limits: RefCell::new(LimitSet::default()),
             limit_tick: Cell::new(0),
+            debug_frame: Cell::new(false),
         }));
         builtins::install(&mut interp);
         interp
@@ -4517,6 +4541,32 @@ impl Interp {
                     None => self.error(b"could not find interpreter"),
                 }
             }
+            // `$child marktrusted` — clear the child's safe flag (denied from a
+            // safe interpreter).
+            b"marktrusted" => {
+                if self.is_safe() {
+                    return self.error(b"permission denied: safe interpreter cannot mark trusted");
+                }
+                self.with_child(name, |c| c.mark_trusted());
+                self.set_result_bytes(b"");
+                Code::Ok
+            }
+            // `$child debug ?-frame ?bool??` — the per-interp frame-debug switch.
+            b"debug" => {
+                let opts: Vec<*mut TclObj> = argv[2..].to_vec();
+                if argv.len() > 4 {
+                    return self
+                        .error(b"wrong # args: should be \"interp debug path ?-frame ?bool??\"");
+                }
+                match self.with_child(name, |c| c.debug_apply(&opts)) {
+                    Some(Ok(o)) => {
+                        self.set_result(o);
+                        Code::Ok
+                    }
+                    Some(Err(m)) => self.error(&m),
+                    None => self.error(b"could not find interpreter"),
+                }
+            }
             // `$child limit limitType ?-option value …?` — query/configure the
             // child's commands/time limit.
             b"limit" => {
@@ -4558,6 +4608,15 @@ impl Interp {
         // A (non-safe) child gets the predefined globals (`tcl_platform`, …) like
         // a real interpreter. The full `init.tcl` (package/auto-load) is deferred.
         child.set_startup_globals();
+        // `interp debug -frame` is seeded from the creating interp's
+        // `env(TCL_INTERP_DEBUG_FRAME)` (C's `Tcl_CreateChild`).
+        if self
+            .var_get_elem(b"env", b"TCL_INTERP_DEBUG_FRAME")
+            .map(|o| parse_truth(&obj_bytes(o)))
+            .unwrap_or(false)
+        {
+            child.0.debug_frame.set(true);
+        }
         self.children.borrow_mut().insert(name.clone(), child);
         self.namespaces
             .borrow_mut()
@@ -4718,6 +4777,34 @@ impl Interp {
     /// Whether this interp is safe (`interp issafe`).
     pub(crate) fn is_safe(&self) -> bool {
         self.is_safe.get()
+    }
+
+    /// `interp marktrusted` — clear this interp's safe flag (a parent demoting a
+    /// child from safe to trusted). Future children it creates are trusted too.
+    pub(crate) fn mark_trusted(&self) {
+        self.is_safe.set(false);
+    }
+
+    /// `interp debug ?-frame ?bool??` on this interp. Returns the fresh result
+    /// object (the `-frame N` dict, or the bool), or the error-message bytes.
+    /// `-frame` is a one-way latch: setting it to false once true keeps it true.
+    pub(crate) fn debug_apply(&self, opts: &[*mut TclObj]) -> Result<*mut TclObj, Vec<u8>> {
+        let frame_byte: &[u8] = if self.debug_frame.get() { b"1" } else { b"0" };
+        match opts.len() {
+            0 => Ok(dict_obj(&[(b"-frame", frame_byte.to_vec())])),
+            1 => {
+                check_debug_opt(opts[0])?;
+                Ok(obj::new_string_bytes(frame_byte))
+            }
+            _ => {
+                check_debug_opt(opts[0])?;
+                if parse_truth(&obj_bytes(opts[1])) {
+                    self.debug_frame.set(true);
+                }
+                let frame_byte: &[u8] = if self.debug_frame.get() { b"1" } else { b"0" };
+                Ok(obj::new_string_bytes(frame_byte))
+            }
+        }
     }
 
     /// `interp recursionlimit` get / set on this interp. `newlimit` is the

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -2835,6 +2835,23 @@ impl Interp {
         *self.bgerror.borrow_mut() = prefix.to_vec();
     }
 
+    /// `interp bgerror` get / set on this interp. With no `prefix` it returns
+    /// the current handler; with one it must be a list of length ≥ 1 (set, then
+    /// returned). Returns the handler bytes, or the error message.
+    pub(crate) fn bgerror_apply(&self, prefix: Option<*mut TclObj>) -> Result<Vec<u8>, Vec<u8>> {
+        match prefix {
+            None => Ok(self.bgerror_handler()),
+            Some(p) => {
+                if crate::list::list_length(p).unwrap_or(0) < 1 {
+                    return Err(b"cmdPrefix must be list of length >= 1".to_vec());
+                }
+                let bytes = obj_bytes(p);
+                self.set_bgerror_handler(&bytes);
+                Ok(bytes)
+            }
+        }
+    }
+
     /// Queue a background error (a destructor failing during implicit teardown,
     /// etc.) for later processing by `update` — Tcl defers it to the event loop
     /// rather than firing at the error site.
@@ -4535,6 +4552,25 @@ impl Interp {
                 match self.with_child(name, |c| c.recursion_limit_apply(newlimit.as_deref())) {
                     Some(Ok(n)) => {
                         self.set_result_bytes(n.to_string().as_bytes());
+                        Code::Ok
+                    }
+                    Some(Err(m)) => self.error(&m),
+                    None => self.error(b"could not find interpreter"),
+                }
+            }
+            // `$child bgerror ?cmdPrefix?` — get/set the child's background-error
+            // handler.
+            b"bgerror" => {
+                if argv.len() < 2 || argv.len() > 3 {
+                    let mut m = b"wrong # args: should be \"".to_vec();
+                    m.extend_from_slice(name);
+                    m.extend_from_slice(b" bgerror ?cmdPrefix?\"");
+                    return self.error(&m);
+                }
+                let prefix = argv.get(2).copied();
+                match self.with_child(name, |c| c.bgerror_apply(prefix)) {
+                    Some(Ok(h)) => {
+                        self.set_result_bytes(&h);
                         Code::Ok
                     }
                     Some(Err(m)) => self.error(&m),

--- a/runtime/rust/src/namespace.rs
+++ b/runtime/rust/src/namespace.rs
@@ -210,7 +210,9 @@ impl Namespaces {
         let mut found: Vec<(NsId, Vec<u8>)> = Vec::new();
         for (id, ns) in self.arena.iter().enumerate() {
             for (key, cmd) in &ns.commands {
-                if matches!(cmd, Command::Alias { .. }) {
+                // Both single-interp aliases and cross-interp (child→parent)
+                // aliases are reported by `interp aliases` / `$child aliases`.
+                if matches!(cmd, Command::Alias { .. } | Command::ParentAlias { .. }) {
                     found.push((id, key.clone()));
                 }
             }

--- a/rust/tcl-platform/src/lib.rs
+++ b/rust/tcl-platform/src/lib.rs
@@ -269,3 +269,106 @@ pub trait Host {
         None
     }
 }
+
+/// Backend introspection for the `tcl_platform` keys the test-suite
+/// backend-constraint overlay reads to decide which upstream tcltest tests a
+/// given build can run.
+///
+/// The compiled-in values below are detected from the build's `cfg`, so they
+/// describe *this* binary truthfully. A runtime publishes them under the
+/// canonical [`Key`] names after the standard `tcl_platform` fields; it may
+/// override any one from its environment seam first (e.g. `TCL_EBPF_SPEC`), so
+/// a native binary can be asked to evaluate the skip lists as if it were a
+/// different backend — the only way to reason about the eBPF target, which
+/// cannot host a full interpreter at all.
+///
+/// Schema (all string-valued; an empty string means "not this target"):
+///
+/// | key              | meaning                                              |
+/// |------------------|------------------------------------------------------|
+/// | `runtime`        | interpreter implementation: `bytecode`/`treewalk`/`ebpf` |
+/// | `runtimeVersion` | that implementation's host (crate) version           |
+/// | `wasm`           | wasm spec version when a wasm build, else empty      |
+/// | `wasi`           | WASI spec version when a WASI build, else empty      |
+/// | `wasiVersion`    | WASI host/preview identifier, else empty            |
+/// | `ebpf`           | eBPF target version when an eBPF build, else empty  |
+pub mod backend {
+    /// Canonical `tcl_platform` key names, so every runtime publishes one schema.
+    pub mod key {
+        /// Interpreter implementation kind (`bytecode`/`treewalk`/`ebpf`).
+        pub const RUNTIME: &str = "runtime";
+        /// The implementation's host (crate) version.
+        pub const RUNTIME_VERSION: &str = "runtimeVersion";
+        /// wasm spec version (empty when not a wasm build).
+        pub const WASM: &str = "wasm";
+        /// WASI spec version (empty when not a WASI build).
+        pub const WASI: &str = "wasi";
+        /// WASI host/preview identifier (empty when not a WASI build).
+        pub const WASI_VERSION: &str = "wasiVersion";
+        /// eBPF target version (empty when not an eBPF build).
+        pub const EBPF: &str = "ebpf";
+    }
+
+    /// The wasm spec version this build targets, or `""` when not a wasm build.
+    /// The runtime currently targets the wasm 2.0 feature set under WASI.
+    #[must_use]
+    pub const fn compiled_wasm_spec() -> &'static str {
+        if cfg!(target_arch = "wasm32") {
+            "2.0"
+        } else {
+            ""
+        }
+    }
+
+    /// The WASI spec version this build targets, or `""` when not a WASI build.
+    /// `preview1` (wasm32-wasip1) vs `0.2` (wasm32-wasip2) is read from the
+    /// target environment.
+    #[must_use]
+    pub const fn compiled_wasi_spec() -> &'static str {
+        if cfg!(all(target_arch = "wasm32", target_os = "wasi")) {
+            if cfg!(target_env = "p2") {
+                "0.2"
+            } else {
+                "preview1"
+            }
+        } else {
+            ""
+        }
+    }
+
+    /// The WASI host/preview identifier this build targets, or `""` otherwise.
+    #[must_use]
+    pub const fn compiled_wasi_host() -> &'static str {
+        if cfg!(all(target_arch = "wasm32", target_os = "wasi")) {
+            if cfg!(target_env = "p2") {
+                "wasip2"
+            } else {
+                "wasip1"
+            }
+        } else {
+            ""
+        }
+    }
+
+    /// The eBPF target version this build targets. No `cfg` target hosts a full
+    /// interpreter, so this is always `""` at compile time; an eBPF evaluation
+    /// is declared through the `TCL_EBPF_SPEC` environment override instead.
+    #[must_use]
+    pub const fn compiled_ebpf_spec() -> &'static str {
+        ""
+    }
+
+    /// The environment-variable name a runtime consults to override each fact
+    /// before publishing it (so a native binary can evaluate another backend's
+    /// skip lists). Returns `None` for keys that are never overridden.
+    #[must_use]
+    pub fn override_env_var(key: &str) -> Option<&'static str> {
+        match key {
+            self::key::WASM => Some("TCL_WASM_SPEC"),
+            self::key::WASI => Some("TCL_WASI_SPEC"),
+            self::key::WASI_VERSION => Some("TCL_WASI_VERSION"),
+            self::key::EBPF => Some("TCL_EBPF_SPEC"),
+            _ => None,
+        }
+    }
+}

--- a/rust/tcl-vm/examples/run_test.rs
+++ b/rust/tcl-vm/examples/run_test.rs
@@ -37,7 +37,9 @@ impl CompileService for Svc {
 struct Stdout;
 impl Write for Stdout {
     fn write(&mut self, b: &[u8]) -> std::io::Result<usize> {
-        std::io::stdout().write(b)
+        let n = std::io::stdout().write(b)?;
+        std::io::stdout().flush()?;
+        Ok(n)
     }
     fn flush(&mut self) -> std::io::Result<()> {
         std::io::stdout().flush()
@@ -76,8 +78,14 @@ fn run() -> i32 {
         Ok(p) if !p.is_empty() => format!("source {p}\n"),
         _ => String::new(),
     };
+    // Diagnostic: `TCL_TEST_VERBOSE=1` makes tcltest announce each test as it
+    // starts, so a hanging test can be pinpointed.
+    let verbose = match std::env::var("TCL_TEST_VERBOSE") {
+        Ok(v) if !v.is_empty() => "::tcltest::configure -verbose {body start}\n",
+        _ => "",
+    };
     let src = format!(
-        "source {tcltest}\nnamespace import -force ::tcltest::*\n{overlay}source {testfile}\n"
+        "source {tcltest}\nnamespace import -force ::tcltest::*\n{verbose}{overlay}source {testfile}\n"
     );
     let ir = lower_to_ir(&src, &registry);
     let cfg = build_cfg(&ir, false);

--- a/rust/tcl-vm/examples/run_test.rs
+++ b/rust/tcl-vm/examples/run_test.rs
@@ -70,8 +70,15 @@ fn run() -> i32 {
     // guards on `::tcltest` not already existing — which it does here — so the
     // driver performs the import the file would otherwise do.
     let registry = CommandRegistry::build_default();
-    let src =
-        format!("source {tcltest}\nnamespace import -force ::tcltest::*\nsource {testfile}\n");
+    // Optionally source the backend-constraint overlay (after tcltest, before
+    // the test file) so tests the running backend cannot support are skipped.
+    let overlay = match std::env::var("TCL_BACKEND_CONSTRAINTS") {
+        Ok(p) if !p.is_empty() => format!("source {p}\n"),
+        _ => String::new(),
+    };
+    let src = format!(
+        "source {tcltest}\nnamespace import -force ::tcltest::*\n{overlay}source {testfile}\n"
+    );
     let ir = lower_to_ir(&src, &registry);
     let cfg = build_cfg(&ir, false);
     let asm = codegen_module(&cfg, &ir, &registry);

--- a/rust/tcl-vm/src/cmd_control.rs
+++ b/rust/tcl-vm/src/cmd_control.rs
@@ -129,6 +129,9 @@ fn cmd_while(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let cond = args[0].clone();
     let body = args[1].clone();
     loop {
+        if let Some(c) = vm.limit_check_tick() {
+            return c;
+        }
         match cond_bool(vm, &cond) {
             Ok(true) => {}
             Ok(false) => break,
@@ -167,6 +170,9 @@ fn cmd_for(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         return c;
     }
     loop {
+        if let Some(c) = vm.limit_check_tick() {
+            return c;
+        }
         match cond_bool(vm, &cond) {
             Ok(true) => {}
             Ok(false) => break,

--- a/rust/tcl-vm/src/cmd_info.rs
+++ b/rust/tcl-vm/src/cmd_info.rs
@@ -219,10 +219,12 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             }
             _ => err("wrong # args: should be \"info cmdtype commandName\""),
         },
-        // `info library` is the script library directory — the `tcl_library`
-        // global the bootstrap seeds from `$env(TCL_LIBRARY)`. The autoloader
-        // (`auto_path` defaults to `[info library]`) and library procs read it.
-        "library" => match vm.get_var("tcl_library") {
+        // `info library` is the script library directory — the `::tcl_library`
+        // global the bootstrap seeds from `$env(TCL_LIBRARY)`. Read it as a
+        // global (the `::` prefix): C's `info library` returns the global
+        // regardless of the calling frame, so library procs (`::tcl::tm::path`,
+        // the Safe Base) reach it from inside a namespace/proc.
+        "library" => match vm.get_var("::tcl_library") {
             Some(v) if !v.to_str().is_empty() => ok(v),
             _ => err("no library has been specified for Tcl"),
         },

--- a/rust/tcl-vm/src/cmd_info.rs
+++ b/rust/tcl-vm/src/cmd_info.rs
@@ -83,7 +83,13 @@ fn cmd_info(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     match canon {
         // `info exists varName` — the shared Family-B core over `VarStore::exists`.
         "exists" => match rest {
-            [name] => ok(tcl_cmd_core::info::exists(vm, name)),
+            [name] => {
+                // `info exists` fires read traces first (a trace may create the
+                // variable — tcltest's lazy `SafeFetch` constraint init relies
+                // on this); a trace error does not abort the existence check.
+                let _ = vm.fire_var_traces(&name.to_str(), "read");
+                ok(tcl_cmd_core::info::exists(vm, name))
+            }
             _ => err("wrong # args: should be \"info exists varName\""),
         },
         "complete" => match rest {

--- a/rust/tcl-vm/src/cmd_math.rs
+++ b/rust/tcl-vm/src/cmd_math.rs
@@ -22,17 +22,50 @@ fn num_arg(v: &Value) -> Result<f64, String> {
 /// `isunordered` / …), which deliberately accept a literal `NaN` — inspecting
 /// NaN/Inf is their purpose — even though a bare `NaN` is a domain error as an
 /// ordinary operand.
+/// `fpclassify floatValue` — the top-level command (`tclBasic.c`
+/// `FloatClassifyObjCmd`): classify a number as zero / subnormal / normal /
+/// infinite / nan. An integer coerces to its double value first (so `0` is
+/// `zero`, any other integer `normal`); a non-number errors.
+fn cmd_fpclassify(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
+    let [v] = args else {
+        return err("wrong # args: should be \"fpclassify floatValue\"");
+    };
+    match num_or_nan(v) {
+        Ok(d) => ok(Value::string(match d.classify() {
+            std::num::FpCategory::Nan => "nan",
+            std::num::FpCategory::Infinite => "infinite",
+            std::num::FpCategory::Zero => "zero",
+            std::num::FpCategory::Subnormal => "subnormal",
+            std::num::FpCategory::Normal => "normal",
+        })),
+        Err(m) => err(m),
+    }
+}
+
 fn num_or_nan(v: &Value) -> Result<f64, String> {
     if let Ok(d) = v.as_double() {
         return Ok(d);
     }
-    if matches!(
-        number::parse_whole(v.to_str().trim()),
-        Some(Number::Nan { .. })
-    ) {
-        return Ok(f64::NAN);
+    match number::parse_whole(v.to_str().trim()) {
+        Some(Number::Nan { .. }) => Ok(f64::NAN),
+        // A bignum coerces to its nearest double (overflowing to ±Inf past the
+        // double range), matching C's `Tcl_GetDoubleFromObj`.
+        Some(Number::Big {
+            negative,
+            radix,
+            digits,
+        }) => {
+            let base = radix as u32;
+            let mut acc = 0.0f64;
+            for c in digits.chars() {
+                if let Some(d) = c.to_digit(base) {
+                    acc = acc * f64::from(base) + f64::from(d);
+                }
+            }
+            Ok(if negative { -acc } else { acc })
+        }
+        _ => Err(format!("expected number but got \"{}\"", v.to_str())),
     }
-    Err(format!("expected number but got \"{}\"", v.to_str()))
 }
 
 /// The message and `errorCode` C raises (`tclExecute.c`, errno `EDOM`) when a
@@ -109,6 +142,8 @@ pub(crate) fn register(vm: &mut Vm) {
     vm.register("tcl::mathfunc::isunordered", |_, a| {
         pred_fn2(a, "isunordered", |x, y| x.is_nan() || y.is_nan())
     });
+    // `fpclassify` is a top-level command, not a math function.
+    vm.register("fpclassify", cmd_fpclassify);
 }
 
 /// A one-`double` classification predicate (`isnan`/`isinf`/…): coerce the

--- a/rust/tcl-vm/src/cmd_namespace.rs
+++ b/rust/tcl-vm/src/cmd_namespace.rs
@@ -206,8 +206,9 @@ fn cmd_namespace(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             }
             ok(Value::empty())
         }
+        "ensemble" => ns_ensemble(vm, rest),
         // Accepted no-ops (metadata only, for now).
-        "ensemble" | "unknown" => ok(Value::empty()),
+        "unknown" => ok(Value::empty()),
         other => err(format!(
             "unknown or ambiguous subcommand \"{other}\": must be \
              children, current, eval, exists, export, parent, qualifiers, or tail"
@@ -219,6 +220,100 @@ fn first(rest: &[Value]) -> String {
     rest.first()
         .map(|v| v.to_str().to_string())
         .unwrap_or_default()
+}
+
+/// `namespace ensemble create|exists|configure` (`tclEnsemble.c`).
+fn ns_ensemble(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    let Some((op, args)) = rest.split_first() else {
+        return err("wrong # args: should be \"namespace ensemble subcommand ?arg ...?\"");
+    };
+    match &*op.to_str() {
+        "create" => ns_ensemble_create(vm, args),
+        "exists" => match args {
+            [cmd] => ok(Value::bool(matches!(
+                vm.lookup_command(&cmd.to_str()),
+                Some(crate::command::Command::Ensemble(_))
+            ))),
+            _ => err("wrong # args: should be \"namespace ensemble exists cmd\""),
+        },
+        // `configure` query/set is not modelled; accept it so setup code runs.
+        "configure" => ok(Value::empty()),
+        other => err(format!(
+            "unknown or ambiguous subcommand \"{other}\": must be configure, create, or exists"
+        )),
+    }
+}
+
+/// `namespace ensemble create ?option value ...?` — build the ensemble command.
+fn ns_ensemble_create(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
+    use crate::command::{Command, EnsembleDef};
+    let mut ns = vm.current_ns().to_string();
+    let mut command: Option<String> = None;
+    let mut map: std::collections::HashMap<String, Vec<Value>> = std::collections::HashMap::new();
+    let mut subcommands: Option<Vec<String>> = None;
+    let mut prefixes = true;
+    let mut unknown: Option<Vec<Value>> = None;
+    let mut i = 0;
+    while i < args.len() {
+        let opt = args[i].to_str().to_string();
+        let Some(val) = args.get(i + 1) else {
+            return err(format!("missing value to go with \"{opt}\""));
+        };
+        match &*opt {
+            "-command" => command = Some(val.to_str().to_string()),
+            "-namespace" => ns = canon_ns(vm, &val.to_str()),
+            "-map" => {
+                let elems = match val.as_list() {
+                    Ok(e) => e,
+                    Err(e) => return err(e.message),
+                };
+                let mut it = elems.iter();
+                while let (Some(k), Some(v)) = (it.next(), it.next()) {
+                    let prefix = v.as_list().map_or_else(|_| vec![v.clone()], |l| l.to_vec());
+                    map.insert(k.to_str().to_string(), prefix);
+                }
+            }
+            "-subcommands" => {
+                let elems = match val.as_list() {
+                    Ok(e) => e,
+                    Err(e) => return err(e.message),
+                };
+                subcommands = Some(elems.iter().map(|v| v.to_str().to_string()).collect());
+            }
+            "-prefixes" => prefixes = val.as_bool().unwrap_or(true),
+            "-unknown" => {
+                let elems = match val.as_list() {
+                    Ok(e) => e,
+                    Err(e) => return err(e.message),
+                };
+                unknown = (!elems.is_empty()).then(|| elems.to_vec());
+            }
+            _ => {
+                return err(format!(
+                    "bad option \"{opt}\": must be -command, -map, -namespace, \
+                     -parameters, -prefixes, -subcommands, or -unknown"
+                ));
+            }
+        }
+        i += 2;
+    }
+    // The default command is the namespace itself; an explicit -command binds in
+    // the current namespace when unqualified.
+    let cmd_key = match command {
+        Some(c) => vm.qualify_name(&c),
+        None => ns.clone(),
+    };
+    vm.register_command(
+        &cmd_key,
+        Command::Ensemble(std::rc::Rc::new(EnsembleDef {
+            namespace: ns,
+            map,
+            subcommands,
+            prefixes,
+            unknown,
+        })),
+    );
+    ok(Value::string(display_ns(&cmd_key)))
 }
 
 /// `namespace qualifiers`/`tail`: run the first argument (lenient — defaults to

--- a/rust/tcl-vm/src/cmd_namespace.rs
+++ b/rust/tcl-vm/src/cmd_namespace.rs
@@ -196,8 +196,18 @@ fn cmd_namespace(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             }
             _ => err("wrong # args: should be \"namespace path ?nsList?\""),
         },
+        // `namespace forget ?pattern ...?` — remove previously imported commands
+        // matching each pattern from the current namespace.
+        "forget" => {
+            for p in rest {
+                if let Err(e) = vm.forget_imports(&p.to_str()) {
+                    return err(e);
+                }
+            }
+            ok(Value::empty())
+        }
         // Accepted no-ops (metadata only, for now).
-        "forget" | "ensemble" | "unknown" => ok(Value::empty()),
+        "ensemble" | "unknown" => ok(Value::empty()),
         other => err(format!(
             "unknown or ambiguous subcommand \"{other}\": must be \
              children, current, eval, exists, export, parent, qualifiers, or tail"

--- a/rust/tcl-vm/src/cmd_package.rs
+++ b/rust/tcl-vm/src/cmd_package.rs
@@ -12,8 +12,12 @@ use crate::interp::{Vm, err, ok};
 use crate::value::Value;
 
 pub(crate) fn register(vm: &mut Vm) {
-    // We emulate Tcl 9.0; advertise it so `package require Tcl` resolves.
-    vm.provide_package("Tcl", "9.0");
+    // We emulate Tcl 9.0.3; the core pre-provides both `Tcl` and the lowercase
+    // `tcl` alias at the full patchlevel (matching `tclsh9.0`), so
+    // `package require Tcl` resolves and library code that reads
+    // `[package provide tcl]` (e.g. `tm.tcl`'s version split) sees a version.
+    vm.provide_package("Tcl", "9.0.3");
+    vm.provide_package("tcl", "9.0.3");
     vm.register("package", cmd_package);
 }
 

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -150,6 +150,13 @@ fn cmd_set(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     match args {
         [name] => {
             let n = name.to_str();
+            // `set varName` is a variable read, so it fires read traces (like
+            // the `$var` opcode path) — and a trace may create the variable
+            // before the read resolves (tcltest's `SafeFetch` lazily
+            // initialises a constraint this way).
+            if let Err(c) = vm.fire_var_traces(&n, "read") {
+                return c;
+            }
             vm.var_get(&n).map_or_else(|| err(vm.read_miss_msg(&n)), ok)
         }
         [name, value] => match vm.var_set(&name.to_str(), value.clone()) {

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -492,6 +492,21 @@ fn interp_limit_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
 }
 
 /// `interp bgerror path ?cmdPrefix?` — get/set the background-error handler.
+/// `interp children ?path?` — children of the current interp, or (one level
+/// down) of the named child.
+fn interp_children_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    let names = match rest {
+        [] => vm.child_names(),
+        [path] if path.to_str().is_empty() => vm.child_names(),
+        [path] => match vm.child_child_names(&path.to_str()) {
+            Some(names) => names,
+            None => return err(format!("could not find interpreter \"{}\"", path.to_str())),
+        },
+        _ => return err("wrong # args: should be \"interp children ?path?\""),
+    };
+    ok(Value::list(names.into_iter().map(Value::string).collect()))
+}
+
 fn interp_bgerror_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     let (path, bargs) = match rest {
         [path] | [path, _] => (path.to_str(), &rest[1..]),
@@ -720,9 +735,7 @@ fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             }
             _ => err("wrong # args: should be \"interp issafe ?path?\""),
         },
-        "slaves" | "children" => ok(Value::list(
-            vm.child_names().into_iter().map(Value::string).collect(),
-        )),
+        "slaves" | "children" => interp_children_cmd(vm, rest),
         "recursionlimit" => interp_recursionlimit_cmd(vm, rest),
         // interp hide path cmd / interp expose path cmd
         "hide" | "expose" => interp_hidectl_cmd(vm, &*sub.to_str() == "hide", rest),
@@ -731,9 +744,13 @@ fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         "debug" => interp_debug_cmd(vm, rest),
         "bgerror" => interp_bgerror_cmd(vm, rest),
         "limit" => interp_limit_cmd(vm, rest),
-        // `interp marktrusted path` — clear a child's safe flag.
+        // `interp marktrusted path` — clear a child's safe flag. A safe
+        // interpreter may not mark anything trusted (checked on the executor).
         "marktrusted" => match rest {
             [path] => {
+                if vm.is_safe() {
+                    return err("permission denied: safe interpreter cannot mark trusted");
+                }
                 vm.child_mark_trusted(&path.to_str());
                 ok(Value::empty())
             }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -546,25 +546,65 @@ fn interp_hidden_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
 /// `interp hide|expose path cmd` — move a command between the (current or
 /// child) interp's visible and hidden tables.
 fn interp_hidectl_cmd(vm: &mut Vm, hide: bool, rest: &[Value]) -> Completion<Value> {
-    let [path, cmd] = rest else {
-        return err("wrong # args: should be \"interp hide path cmdName\"");
+    // `interp hide   path cmdName     ?hiddenCmdName?`
+    // `interp expose path hiddenName  ?cmdName?`
+    let (path, cmd, token) = match rest {
+        [path, cmd] => (path.to_str(), cmd.to_str(), cmd.to_str()),
+        [path, cmd, token] => (path.to_str(), cmd.to_str(), token.to_str()),
+        _ => {
+            let usage = if hide {
+                "wrong # args: should be \"interp hide path cmdName ?hiddenCmdName?\""
+            } else {
+                "wrong # args: should be \"interp expose path hiddenCmdName ?cmdName?\""
+            };
+            return err(usage);
+        }
     };
-    let p = path.to_str();
-    let c = cmd.to_str();
-    if p.is_empty() {
+    // A safe interpreter may not touch the hidden-command table of itself or
+    // any of its children (the check is on the *executing* interp).
+    if vm.is_safe() {
+        let verb = if hide { "hide" } else { "expose" };
+        return err(format!(
+            "permission denied: safe interpreter cannot {verb} commands"
+        ));
+    }
+    // The hidden-command token may never carry namespace qualifiers, and only
+    // global-namespace commands can be hidden / exposed-from.
+    if hide {
+        if token.contains("::") {
+            return err("cannot use namespace qualifiers in hidden command token (rename)");
+        }
+        if !is_global_command(&cmd) {
+            return err("can only hide global namespace commands (use rename then hide)");
+        }
+    } else {
+        if cmd.contains("::") {
+            return err("cannot use namespace qualifiers in hidden command token (rename)");
+        }
+        if !is_global_command(&token) {
+            return err("cannot expose to a namespace (use expose to toplevel, then rename)");
+        }
+    }
+    if path.is_empty() {
         if hide {
-            if let Some(command) = vm.take_command(&c) {
-                vm.hide_own_command(&c, command);
+            if let Some(command) = vm.take_command(&cmd) {
+                vm.hide_own_command(&token, command);
             }
         } else {
-            vm.expose_own_command(&c);
+            vm.expose_own_command(&cmd, &token);
         }
         ok(Value::empty())
-    } else if vm.child_hide(&p, &c, hide) {
+    } else if vm.child_hide(&path, &cmd, &token, hide) {
         ok(Value::empty())
     } else {
-        err(format!("could not find interpreter \"{p}\""))
+        err(format!("could not find interpreter \"{path}\""))
     }
+}
+
+/// Whether `name` resolves in the global namespace — i.e. it carries no
+/// namespace qualifiers beyond an optional leading `::`.
+fn is_global_command(name: &str) -> bool {
+    !name.strip_prefix("::").unwrap_or(name).contains("::")
 }
 
 /// `interp invokehidden path ?-namespace ns? ?--? cmd ?arg ...?` — invoke a
@@ -577,6 +617,9 @@ fn interp_invokehidden_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     };
     if tail.is_empty() {
         return err(usage);
+    }
+    if vm.is_safe() {
+        return err("not allowed to invoke hidden commands from safe interpreter");
     }
     // Skip the option flags we don't model (`-namespace ns`, `--`).
     let mut i = 0;

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -413,6 +413,27 @@ fn interp_create_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     ok(Value::string(vm.create_child(name, safe)))
 }
 
+/// `interp recursionlimit path ?newlimit?` — get/set a (possibly child) interp's
+/// recursion bound.
+fn interp_recursionlimit_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    let (path, newlimit) = match rest {
+        [path] => (path.to_str(), None),
+        [path, nl] => (path.to_str(), Some(nl.to_str().to_string())),
+        _ => return err("wrong # args: should be \"interp recursionlimit path ?newlimit?\""),
+    };
+    let result = if path.is_empty() {
+        vm.recursion_limit_apply(newlimit.as_deref())
+    } else if let Some(r) = vm.child_recursion_limit_apply(&path, newlimit.as_deref()) {
+        r
+    } else {
+        return err(format!("could not find interpreter \"{path}\""));
+    };
+    match result {
+        Ok(n) => ok(Value::int(n)),
+        Err(m) => err(m),
+    }
+}
+
 /// `interp` — child-interpreter creation, evaluation, and the single-interp
 /// alias form. A child is a full `Vm` sharing the parent's output and compile
 /// service (see [`Vm::create_child`]); `interp eval`/`delete`/`issafe`/… address
@@ -494,6 +515,7 @@ fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         "slaves" | "children" => ok(Value::list(
             vm.child_names().into_iter().map(Value::string).collect(),
         )),
+        "recursionlimit" => interp_recursionlimit_cmd(vm, rest),
         // `interp marktrusted path` — clear a child's safe flag.
         "marktrusted" => match rest {
             [path] => {

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -463,6 +463,40 @@ fn interp_recursionlimit_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     }
 }
 
+/// `interp bgerror path ?cmdPrefix?` — get/set the background-error handler.
+fn interp_bgerror_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    let (path, bargs) = match rest {
+        [path] | [path, _] => (path.to_str(), &rest[1..]),
+        _ => return err("wrong # args: should be \"interp bgerror path ?cmdPrefix?\""),
+    };
+    if path.is_empty() {
+        ok(vm.bgerror_apply(bargs))
+    } else if let Some(child) = vm.child_mut(&path) {
+        ok(child.bgerror_apply(bargs))
+    } else {
+        err(format!("could not find interpreter \"{path}\""))
+    }
+}
+
+/// `interp debug path ?-frame ?bool??` — the per-interp frame-debug switch.
+fn interp_debug_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    let Some((path, dargs)) = rest.split_first() else {
+        return err("wrong # args: should be \"interp debug path ?-frame ?bool??\"");
+    };
+    let p = path.to_str();
+    let res = if p.is_empty() {
+        vm.debug_apply(dargs)
+    } else if let Some(child) = vm.child_mut(&p) {
+        child.debug_apply(dargs)
+    } else {
+        return err(format!("could not find interpreter \"{p}\""));
+    };
+    match res {
+        Ok(v) => ok(v),
+        Err(m) => err(m),
+    }
+}
+
 /// `interp hidden ?path?` — the hidden-command names of the current or named
 /// interp.
 fn interp_hidden_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
@@ -623,6 +657,8 @@ fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         "hide" | "expose" => interp_hidectl_cmd(vm, &*sub.to_str() == "hide", rest),
         "hidden" => interp_hidden_cmd(vm, rest),
         "invokehidden" => interp_invokehidden_cmd(vm, rest),
+        "debug" => interp_debug_cmd(vm, rest),
+        "bgerror" => interp_bgerror_cmd(vm, rest),
         // `interp marktrusted path` — clear a child's safe flag.
         "marktrusted" => match rest {
             [path] => {

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -434,12 +434,10 @@ fn interp_create_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
         }
         i += 1;
     }
-    if let Some(ref n) = name {
-        if vm.child_exists(n) {
-            return err(format!(
-                "interpreter named \"{n}\" already exists, cannot create"
-            ));
-        }
+    if let Some(n) = name.as_ref().filter(|n| vm.child_exists(n)) {
+        return err(format!(
+            "interpreter named \"{n}\" already exists, cannot create"
+        ));
     }
     ok(Value::string(vm.create_child(name, safe)))
 }
@@ -463,6 +461,80 @@ fn interp_recursionlimit_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
         Ok(n) => ok(Value::int(n)),
         Err(m) => err(m),
     }
+}
+
+/// `interp hidden ?path?` — the hidden-command names of the current or named
+/// interp.
+fn interp_hidden_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    let path = rest
+        .first()
+        .map(|v| v.to_str().to_string())
+        .unwrap_or_default();
+    let names = if path.is_empty() {
+        vm.own_hidden_names()
+    } else {
+        match vm.child_hidden_names(&path) {
+            Some(n) => n,
+            None => return err(format!("could not find interpreter \"{path}\"")),
+        }
+    };
+    ok(Value::list(names.into_iter().map(Value::string).collect()))
+}
+
+/// `interp hide|expose path cmd` — move a command between the (current or
+/// child) interp's visible and hidden tables.
+fn interp_hidectl_cmd(vm: &mut Vm, hide: bool, rest: &[Value]) -> Completion<Value> {
+    let [path, cmd] = rest else {
+        return err("wrong # args: should be \"interp hide path cmdName\"");
+    };
+    let p = path.to_str();
+    let c = cmd.to_str();
+    if p.is_empty() {
+        if hide {
+            if let Some(command) = vm.take_command(&c) {
+                vm.hide_own_command(&c, command);
+            }
+        } else {
+            vm.expose_own_command(&c);
+        }
+        ok(Value::empty())
+    } else if vm.child_hide(&p, &c, hide) {
+        ok(Value::empty())
+    } else {
+        err(format!("could not find interpreter \"{p}\""))
+    }
+}
+
+/// `interp invokehidden path ?-namespace ns? ?--? cmd ?arg ...?` — invoke a
+/// hidden command in the named child.
+fn interp_invokehidden_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    let usage =
+        "wrong # args: should be \"interp invokehidden path ?-namespace ns? ?--? cmd ?arg ..?\"";
+    let [path, tail @ ..] = rest else {
+        return err(usage);
+    };
+    if tail.is_empty() {
+        return err(usage);
+    }
+    // Skip the option flags we don't model (`-namespace ns`, `--`).
+    let mut i = 0;
+    while i < tail.len() {
+        match &*tail[i].to_str() {
+            "-namespace" => i += 2,
+            "--" => {
+                i += 1;
+                break;
+            }
+            s if s.starts_with('-') => i += 1,
+            _ => break,
+        }
+    }
+    let Some(cmd) = tail.get(i) else {
+        return err(usage);
+    };
+    let p = path.to_str();
+    vm.invoke_hidden_in_child(&p, &cmd.to_str(), &tail[i + 1..])
+        .unwrap_or_else(|| err(format!("could not find interpreter \"{p}\"")))
 }
 
 /// `interp` — child-interpreter creation, evaluation, and the single-interp
@@ -547,6 +619,10 @@ fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             vm.child_names().into_iter().map(Value::string).collect(),
         )),
         "recursionlimit" => interp_recursionlimit_cmd(vm, rest),
+        // interp hide path cmd / interp expose path cmd
+        "hide" | "expose" => interp_hidectl_cmd(vm, &*sub.to_str() == "hide", rest),
+        "hidden" => interp_hidden_cmd(vm, rest),
+        "invokehidden" => interp_invokehidden_cmd(vm, rest),
         // `interp marktrusted path` — clear a child's safe flag.
         "marktrusted" => match rest {
             [path] => {

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -59,6 +59,10 @@ pub enum Command {
     /// (the target command plus any fixed prefix arguments) with the call's own
     /// arguments appended.
     Alias(Rc<Vec<Value>>),
+    /// A child interpreter addressable as a command (`$child eval …`): the name
+    /// keys into the parent's `children` table. Invoking it dispatches the
+    /// `interp` ensemble restricted to that child.
+    ChildInterp(String),
 }
 
 /// Register the builtin set on `vm`.
@@ -377,14 +381,48 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     ok(Value::empty())
 }
 
-/// `interp` — the subset the stdlib/test suite needs in a single-interpreter
-/// VM. Only the current interpreter (`{}` path) is modelled, so `slaves`/`exists`
-/// answer for it and the unsupported sub-interpreter operations are rejected.
+/// `interp create ?-safe? ?--? ?name?` — make a child interpreter.
+fn interp_create_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    let mut safe = false;
+    let mut name: Option<String> = None;
+    let mut i = 0;
+    while i < rest.len() {
+        let a = rest[i].to_str();
+        match &*a {
+            "-safe" => safe = true,
+            "--" => {
+                i += 1;
+                break;
+            }
+            s if s.starts_with('-') => {
+                return err(format!("bad option \"{s}\": must be -safe or --"));
+            }
+            _ => break,
+        }
+        i += 1;
+    }
+    if let Some(n) = rest.get(i) {
+        let n = n.to_str().to_string();
+        if vm.child_exists(&n) {
+            return err(format!(
+                "interpreter named \"{n}\" already exists, cannot create"
+            ));
+        }
+        name = Some(n);
+    }
+    ok(Value::string(vm.create_child(name, safe)))
+}
+
+/// `interp` — child-interpreter creation, evaluation, and the single-interp
+/// alias form. A child is a full `Vm` sharing the parent's output and compile
+/// service (see [`Vm::create_child`]); `interp eval`/`delete`/`issafe`/… address
+/// the current interp (empty path) or a named child.
 fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let Some((sub, rest)) = args.split_first() else {
         return err("wrong # args: should be \"interp cmd ?arg ...?\"");
     };
     match &*sub.to_str() {
+        "create" => interp_create_cmd(vm, rest),
         // interp alias srcPath srcCmd targetPath targetCmd ?arg ...?
         "alias" => match rest {
             [src_path, src_cmd, target_path, target @ ..] if !target.is_empty() => {
@@ -401,33 +439,79 @@ fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         },
         "exists" => match rest {
             [] => ok(Value::int(1)),
-            [path] => ok(Value::bool(path.to_str().is_empty())),
+            [path] => {
+                let p = path.to_str();
+                ok(Value::bool(p.is_empty() || vm.child_exists(&p)))
+            }
             _ => err("wrong # args: should be \"interp exists ?path?\""),
         },
-        // interp eval path arg ?arg ...? — only the current interpreter (an
-        // empty path) exists; its scripts (concatenated) evaluate in the current
-        // frame, exactly like `eval` (verified against tclsh 9.0).
+        // interp eval path arg ?arg ...? — empty path is the current interp
+        // (evaluate like `eval`); a named path routes into that child.
         "eval" => match rest {
             [path, scripts @ ..] if !scripts.is_empty() => {
                 let p = path.to_str();
-                if !p.is_empty() {
-                    return err(format!("could not find interpreter \"{p}\""));
-                }
                 let script = scripts
                     .iter()
                     .map(|v| v.to_str().to_string())
                     .collect::<Vec<_>>()
                     .join(" ");
-                match vm.eval_source(&script) {
-                    Ok(c) => c,
-                    Err(e) => err(e.message),
+                if p.is_empty() {
+                    match vm.eval_source(&script) {
+                        Ok(c) => c,
+                        Err(e) => err(e.message),
+                    }
+                } else {
+                    vm.eval_in_child(&p, &script)
                 }
             }
             _ => err("wrong # args: should be \"interp eval path arg ?arg ...?\""),
         },
-        "slaves" | "children" => ok(Value::empty()),
+        // interp delete ?path ...?
+        "delete" => {
+            for path in rest {
+                let p = path.to_str();
+                if p.is_empty() || !vm.delete_child(&p) {
+                    return err(format!("could not find interpreter \"{p}\""));
+                }
+            }
+            ok(Value::empty())
+        }
+        "issafe" => match rest {
+            [] => ok(Value::bool(vm.is_safe())),
+            [path] => {
+                let p = path.to_str();
+                if p.is_empty() {
+                    ok(Value::bool(vm.is_safe()))
+                } else {
+                    match vm.child_is_safe(&p) {
+                        Some(s) => ok(Value::bool(s)),
+                        None => err(format!("could not find interpreter \"{p}\"")),
+                    }
+                }
+            }
+            _ => err("wrong # args: should be \"interp issafe ?path?\""),
+        },
+        "slaves" | "children" => ok(Value::list(
+            vm.child_names().into_iter().map(Value::string).collect(),
+        )),
+        // `interp marktrusted path` — clear a child's safe flag.
+        "marktrusted" => match rest {
+            [path] => {
+                vm.child_mark_trusted(&path.to_str());
+                ok(Value::empty())
+            }
+            _ => err("wrong # args: should be \"interp marktrusted path\""),
+        },
+        // Channel sharing/transfer between interps. Channels are per-interp in
+        // this model; accept the operation so a script that wires up shared
+        // channels at top level runs to completion (the dependent reads are
+        // covered by the per-interp channel table, not a global one).
+        "share" | "transfer" => ok(Value::empty()),
         other => err(format!(
-            "bad option \"{other}\": only alias, eval, exists, and slaves are supported"
+            "bad option \"{other}\": must be alias, aliases, bgerror, cancel, \
+             children, create, debug, delete, eval, exists, expose, hide, \
+             hidden, issafe, invokehidden, limit, marktrusted, recursionlimit, \
+             share, slaves, target, or transfer"
         )),
     }
 }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -18,6 +18,7 @@ use crate::value::Value;
 pub type BuiltinFn = fn(&mut Vm, &[Value]) -> Completion<Value>;
 
 /// A procedure parameter: a name with an optional default.
+#[derive(Clone)]
 pub struct Param {
     /// Parameter name.
     pub name: String,
@@ -26,6 +27,7 @@ pub struct Param {
 }
 
 /// A user procedure: parameters plus the pre-compiled body.
+#[derive(Clone)]
 pub struct ProcDef {
     /// Canonical (namespace-qualified, no leading `::`) proc name.
     pub name: String,
@@ -350,6 +352,25 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             new_name.to_string()
         } else {
             vm.qualify_name(&new_name)
+        };
+        // A proc executes in the namespace it currently lives in, so renaming
+        // it across namespaces re-homes its body (C `TclRenameCommand` updates
+        // the command's `nsPtr`). `namespace current` inside the body then
+        // reports the destination namespace (proc-3.4).
+        let cmd = match cmd {
+            Command::Proc(def) => {
+                let canon = key.strip_prefix("::").unwrap_or(&key);
+                let new_ns = canon.rsplit_once("::").map_or("", |(ns, _)| ns);
+                if new_ns == def.namespace && canon == def.name {
+                    Command::Proc(def)
+                } else {
+                    let mut relocated = (*def).clone();
+                    relocated.namespace = new_ns.to_string();
+                    relocated.name = canon.to_string();
+                    Command::Proc(Rc::new(relocated))
+                }
+            }
+            other => other,
         };
         vm.register_command(&key, cmd);
     }

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -63,6 +63,26 @@ pub enum Command {
     /// keys into the parent's `children` table. Invoking it dispatches the
     /// `interp` ensemble restricted to that child.
     ChildInterp(String),
+    /// A `namespace ensemble` — invoking `cmd sub args…` resolves `sub` against
+    /// the ensemble's subcommands and dispatches to the mapped target.
+    Ensemble(Rc<EnsembleDef>),
+}
+
+/// A `namespace ensemble create`d command (`tclEnsemble.c`).
+#[derive(Clone)]
+pub struct EnsembleDef {
+    /// The namespace whose exported commands form the default subcommand set and
+    /// against which an unmapped subcommand `sub` resolves to `namespace::sub`.
+    pub namespace: String,
+    /// `-map`: subcommand → target command prefix (already qualified).
+    pub map: std::collections::HashMap<String, Vec<Value>>,
+    /// `-subcommands`: the explicit subcommand list, or `None` to use the
+    /// namespace's exported commands.
+    pub subcommands: Option<Vec<String>>,
+    /// `-prefixes`: whether an unambiguous prefix of a subcommand resolves.
+    pub prefixes: bool,
+    /// `-unknown`: a handler prefix invoked when no subcommand matches.
+    pub unknown: Option<Vec<Value>>,
 }
 
 /// Register the builtin set on `vm`.

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -463,6 +463,34 @@ fn interp_recursionlimit_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     }
 }
 
+/// `interp limit path limitType ?-option value ...?` — query/configure the
+/// `commands` or `time` limit on a child interp (stored, not enforced).
+fn interp_limit_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    let (path, ltype, opts) = match rest {
+        [path, ltype, opts @ ..] => (path.to_str(), ltype.to_str(), opts),
+        _ => {
+            return err(
+                "wrong # args: should be \"interp limit path limitType ?-option value ...?\"",
+            );
+        }
+    };
+    // Validate the limit type before the current-interp guard so that a bad
+    // type is reported ahead of the inaccessibility error (interp-35.3 vs .23).
+    if &*ltype != "commands" && &*ltype != "time" {
+        return err(format!("bad limit type \"{ltype}\": must be commands or time"));
+    }
+    if path.is_empty() {
+        return err("limits on current interpreter inaccessible");
+    }
+    match vm.child_mut(&path) {
+        Some(child) => match child.limit_apply(&ltype, opts) {
+            Ok(v) => ok(v),
+            Err(m) => err(m),
+        },
+        None => err(format!("could not find interpreter \"{path}\"")),
+    }
+}
+
 /// `interp bgerror path ?cmdPrefix?` — get/set the background-error handler.
 fn interp_bgerror_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     let (path, bargs) = match rest {
@@ -659,6 +687,7 @@ fn cmd_interp(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         "invokehidden" => interp_invokehidden_cmd(vm, rest),
         "debug" => interp_debug_cmd(vm, rest),
         "bgerror" => interp_bgerror_cmd(vm, rest),
+        "limit" => interp_limit_cmd(vm, rest),
         // `interp marktrusted path` — clear a child's safe flag.
         "marktrusted" => match rest {
             [path] => {

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -403,32 +403,43 @@ fn cmd_rename(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 
 /// `interp create ?-safe? ?--? ?name?` — make a child interpreter.
 fn interp_create_cmd(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
+    // C's "weird historical rule": `-safe` is accepted anywhere before `--`
+    // (`interp create a -safe` is valid), and the path is the lone non-option
+    // word — so scan all args rather than stopping at the first non-flag.
     let mut safe = false;
+    let mut last = false;
     let mut name: Option<String> = None;
     let mut i = 0;
     while i < rest.len() {
         let a = rest[i].to_str();
-        match &*a {
-            "-safe" => safe = true,
-            "--" => {
-                i += 1;
-                break;
+        if !last && a.starts_with('-') {
+            match &*a {
+                "-safe" => {
+                    safe = true;
+                    i += 1;
+                    continue;
+                }
+                "--" => {
+                    i += 1;
+                    last = true;
+                }
+                s => return err(format!("bad option \"{s}\": must be -safe or --")),
             }
-            s if s.starts_with('-') => {
-                return err(format!("bad option \"{s}\": must be -safe or --"));
-            }
-            _ => break,
+        }
+        if name.is_some() {
+            return err("wrong # args: should be \"interp create ?-safe? ?--? ?path?\"");
+        }
+        if let Some(n) = rest.get(i) {
+            name = Some(n.to_str().to_string());
         }
         i += 1;
     }
-    if let Some(n) = rest.get(i) {
-        let n = n.to_str().to_string();
-        if vm.child_exists(&n) {
+    if let Some(ref n) = name {
+        if vm.child_exists(n) {
             return err(format!(
                 "interpreter named \"{n}\" already exists, cannot create"
             ));
         }
-        name = Some(n);
     }
     ok(Value::string(vm.create_child(name, safe)))
 }

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -2075,6 +2075,15 @@ impl Vm {
                     Err(e) => Err(err(e.message)),
                 }
             }
+            Some(Command::ChildInterp(child)) => {
+                let res = self.dispatch_child(&child, &words[1..]);
+                if res.code.is_ok() {
+                    f.stack.push(res.result);
+                    Ok(None)
+                } else {
+                    Err(res)
+                }
+            }
             // Tcl's `unknown` fallback: an unresolved command name is handed to
             // the user-defined `unknown` proc as `unknown name arg…` (the basis
             // for auto-loading, ensembles, and the iRule command mocks). Only
@@ -2119,6 +2128,7 @@ impl Vm {
                     Err(e) => err(e.message),
                 }
             }
+            Some(Command::ChildInterp(child)) => self.dispatch_child(&child, argv),
             // `unknown` fallback (see `dispatch_words`): `unknown name arg…`.
             None if name != "unknown" && self.lookup_command("unknown").is_some() => {
                 let mut full = Vec::with_capacity(argv.len() + 1);

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -17,7 +17,7 @@ use tcl_syntax::expr::{BinOp, UnaryOp};
 
 use crate::command::{Command, ProcDef};
 use crate::expr;
-use crate::interp::{RECURSION_LIMIT, Vm, err, ok};
+use crate::interp::{Vm, err, ok};
 use crate::value::Value;
 
 /// Active `foreach` iteration state (C Tcl `ForeachInfo` + the loop counters).
@@ -677,7 +677,7 @@ impl Vm {
     fn enter_proc(&mut self, proc: &ProcDef, argv: &[Value]) -> Result<(), Completion<Value>> {
         // Recursion bound (catchable, not a host stack overflow). Checked before
         // the frame push, matching C's `interp recursionlimit`.
-        if self.recursion_depth() >= RECURSION_LIMIT {
+        if self.recursion_depth() >= self.recursion_limit() {
             return Err(err("too many nested evaluations (infinite loop?)"));
         }
         let simple = proc.name.rsplit("::").next().unwrap_or(&proc.name);

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -907,10 +907,14 @@ impl Vm {
                 // into the LVT (the codegen names the slot `a(x)`), so resolve
                 // it element-aware.
                 let name = lvt_name(imm0(instr));
+                // `info exists` fires read traces (a trace may create the
+                // variable); a trace error does not abort the existence check.
+                let _ = self.fire_var_traces(&name, "read");
                 f.stack.push(Value::bool(self.exists_var(&name)));
             }
             Op::EXIST_STK => {
                 let name = pop(f).to_str();
+                let _ = self.fire_var_traces(&name, "read");
                 f.stack.push(Value::bool(self.exists_var(&name)));
             }
 

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -2084,6 +2084,15 @@ impl Vm {
                     Err(res)
                 }
             }
+            Some(Command::Ensemble(e)) => {
+                let res = self.dispatch_ensemble(&name, &e, &words[1..]);
+                if res.code.is_ok() {
+                    f.stack.push(res.result);
+                    Ok(None)
+                } else {
+                    Err(res)
+                }
+            }
             // Tcl's `unknown` fallback: an unresolved command name is handed to
             // the user-defined `unknown` proc as `unknown name arg…` (the basis
             // for auto-loading, ensembles, and the iRule command mocks). Only
@@ -2129,6 +2138,7 @@ impl Vm {
                 }
             }
             Some(Command::ChildInterp(child)) => self.dispatch_child(&child, argv),
+            Some(Command::Ensemble(e)) => self.dispatch_ensemble(name, &e, argv),
             // `unknown` fallback (see `dispatch_words`): `unknown name arg…`.
             None if name != "unknown" && self.lookup_command("unknown").is_some() => {
                 let mut full = Vec::with_capacity(argv.len() + 1);

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -499,6 +499,15 @@ impl Vm {
     fn run_activation(&mut self, initial: Frame) -> Completion<Value> {
         let mut acts: Vec<Frame> = vec![initial];
         loop {
+            // Enforce `interp limit $i time` for unbounded bytecode loops: the
+            // counter is Vm-scoped so it survives the short activations a
+            // command-driven loop re-enters (see `limit_check_tick`).
+            if let Some(c) = self.limit_check_tick() {
+                if let Some(done) = self.unwind(&mut acts, c) {
+                    return done;
+                }
+                continue;
+            }
             let tick = {
                 let top = acts.last_mut().expect("activation stack is non-empty");
                 self.tick(top)

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -270,6 +270,10 @@ pub struct Vm {
     hidden_commands: HashMap<String, Command>,
     /// Monotonic counter minting auto-generated child names (`interp0`, …).
     interp_counter: u64,
+    /// `interp debug -frame` — a one-way switch (once on, stays on).
+    debug_frame: bool,
+    /// `interp bgerror` — the background-error handler command prefix.
+    bgerror_handler: Value,
 }
 
 /// The command-identity arena backing `Namespaces::find_command` /
@@ -343,6 +347,8 @@ impl Vm {
             recursion_limit: RECURSION_LIMIT,
             hidden_commands: HashMap::new(),
             interp_counter: 0,
+            debug_frame: false,
+            bgerror_handler: Value::string("::tcl::Bgerror"),
             // A fixed non-zero default so an un-`srand`'d `rand()` is still
             // deterministic; Tcl auto-seeds from the clock, but reproducibility
             // is more useful for the VM and every test seeds explicitly.
@@ -678,6 +684,45 @@ impl Vm {
     /// Whether a child interpreter `name` exists.
     pub(crate) fn child_exists(&self, name: &str) -> bool {
         self.children.contains_key(name)
+    }
+
+    /// Mutable access to a child interpreter (for the per-interp `debug` /
+    /// `bgerror` settings).
+    pub(crate) fn child_mut(&mut self, name: &str) -> Option<&mut Vm> {
+        self.children.get_mut(name)
+    }
+
+    /// `interp debug ?-frame ?bool??` on this interp. `-frame` is a one-way
+    /// switch (once on, stays on); returns the settings list / the frame bool.
+    pub(crate) fn debug_apply(&mut self, args: &[Value]) -> Result<Value, String> {
+        match args {
+            [] => Ok(Value::list(vec![
+                Value::string("-frame"),
+                Value::int(i64::from(self.debug_frame)),
+            ])),
+            [opt] if &*opt.to_str() == "-frame" => Ok(Value::int(i64::from(self.debug_frame))),
+            [opt, val] if &*opt.to_str() == "-frame" => {
+                if val.as_bool().unwrap_or(false) {
+                    self.debug_frame = true;
+                }
+                Ok(Value::int(i64::from(self.debug_frame)))
+            }
+            _ => Err(format!(
+                "bad option \"{}\": must be -frame",
+                args.first()
+                    .map(|v| v.to_str().to_string())
+                    .unwrap_or_default()
+            )),
+        }
+    }
+
+    /// `interp bgerror ?cmdPrefix?` on this interp — get/set the background-error
+    /// handler.
+    pub(crate) fn bgerror_apply(&mut self, args: &[Value]) -> Value {
+        if let [prefix] = args {
+            self.bgerror_handler = prefix.clone();
+        }
+        self.bgerror_handler.clone()
     }
 
     /// Sorted names of this interp's direct children (`interp children`).

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -155,8 +155,11 @@ pub struct Vm {
     /// variables); inside a proc called from one, the depths differ and
     /// unqualified names are proc locals.
     ns_script_frames: Vec<usize>,
-    out: Box<dyn Write>,
-    compiler: Option<Box<dyn CompileService<Module = ModuleAsm>>>,
+    // Shared with child interpreters (`interp create`): a child writes `puts`
+    // output to the same sink and compiles dynamic scripts with the same
+    // (stateless) compile service, so both are `Rc` rather than owned.
+    out: Rc<RefCell<Box<dyn Write>>>,
+    compiler: Option<Rc<dyn CompileService<Module = ModuleAsm>>>,
     /// Optional debug hook fired once per source command (the execution-control
     /// seam a step debugger drives). `None` in normal runs — the only
     /// per-instruction cost is an `Option` check.
@@ -226,6 +229,18 @@ pub struct Vm {
     /// generator's 31-bit seed (`tclExecute.c`). Seeded deterministically so a
     /// fresh VM is reproducible; `srand(n)` resets it.
     rand_seed: i64,
+    /// Child interpreters (`interp create`), keyed by name. Each is a full `Vm`
+    /// sharing this one's output sink and compile service; their command tables,
+    /// namespaces, variables, and channels are isolated. A child is reachable
+    /// both here and as a command (`Command::ChildInterp`) in this interp.
+    children: HashMap<String, Vm>,
+    /// Whether this interp is safe (`interp create -safe` / `interp issafe`).
+    is_safe: bool,
+    /// Commands hidden by `interp create -safe` / `interp hide`, keyed by name —
+    /// invocable via `interp invokehidden`, restorable with `interp expose`.
+    hidden_commands: HashMap<String, Command>,
+    /// Monotonic counter minting auto-generated child names (`interp0`, …).
+    interp_counter: u64,
 }
 
 /// The command-identity arena backing `Namespaces::find_command` /
@@ -256,6 +271,13 @@ impl Vm {
     /// A VM writing `puts` output to `out` (tests pass a capture buffer).
     #[must_use]
     pub fn with_output(out: Box<dyn Write>) -> Self {
+        Self::with_shared_output(Rc::new(RefCell::new(out)))
+    }
+
+    /// A VM writing to an already-shared output sink — the path
+    /// [`fork_child`](Self::fork_child) uses so a child interpreter's `puts`
+    /// reaches the same place as its parent's.
+    fn with_shared_output(out: Rc<RefCell<Box<dyn Write>>>) -> Self {
         let mut vm = Self {
             frames: vec![CallFrame::new(0, ROOT_NS, None, Vec::new())],
             commands: HashMap::new(),
@@ -287,6 +309,10 @@ impl Vm {
             script_stack: Vec::new(),
             recursion_depth: 0,
             host: Rc::new(NativeHost::new()),
+            children: HashMap::new(),
+            is_safe: false,
+            hidden_commands: HashMap::new(),
+            interp_counter: 0,
             // A fixed non-zero default so an un-`srand`'d `rand()` is still
             // deterministic; Tcl auto-seeds from the clock, but reproducibility
             // is more useful for the VM and every test seeds explicitly.
@@ -512,7 +538,7 @@ impl Vm {
 
     /// Inject the compiler used for runtime `eval` / command substitution.
     pub fn set_compiler(&mut self, compiler: Box<dyn CompileService<Module = ModuleAsm>>) {
-        self.compiler = Some(compiler);
+        self.compiler = Some(Rc::from(compiler));
     }
 
     /// The host environment (capability seam) backing the platform commands.
@@ -587,7 +613,188 @@ impl Vm {
             Command::Builtin(_) => "native",
             Command::Proc(_) => "proc",
             Command::Alias(_) => "alias",
+            Command::ChildInterp(_) => "interp",
         })
+    }
+
+    /// A fresh child interpreter sharing this one's output sink, compile
+    /// service, and host — its command table, namespaces, variables, and
+    /// channels are otherwise independent (`interp create`).
+    fn fork_child(&self) -> Vm {
+        let mut child = Vm::with_shared_output(Rc::clone(&self.out));
+        child.compiler.clone_from(&self.compiler);
+        child.host = Rc::clone(&self.host);
+        child
+    }
+
+    /// `interp create ?-safe? ?name?` — make a child interpreter, registering it
+    /// as a command in this interp. Returns the (possibly auto-generated) name.
+    pub(crate) fn create_child(&mut self, name: Option<String>, safe: bool) -> String {
+        let name = name.unwrap_or_else(|| {
+            let n = format!("interp{}", self.interp_counter);
+            self.interp_counter += 1;
+            n
+        });
+        let mut child = self.fork_child();
+        if safe {
+            child.make_safe();
+        }
+        self.children.insert(name.clone(), child);
+        self.register_command(&name, Command::ChildInterp(name.clone()));
+        name
+    }
+
+    /// Whether a child interpreter `name` exists.
+    pub(crate) fn child_exists(&self, name: &str) -> bool {
+        self.children.contains_key(name)
+    }
+
+    /// Sorted names of this interp's direct children (`interp children`).
+    pub(crate) fn child_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.children.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    /// `interp issafe ?path?` for the current interp.
+    pub(crate) fn is_safe(&self) -> bool {
+        self.is_safe
+    }
+
+    /// Whether the named child is safe (`$child issafe` / `interp issafe path`).
+    pub(crate) fn child_is_safe(&self, name: &str) -> Option<bool> {
+        self.children.get(name).map(|c| c.is_safe)
+    }
+
+    /// `interp marktrusted path` — clear a child's safe flag (exposing every
+    /// hidden command). A no-op if the child does not exist.
+    pub(crate) fn child_mark_trusted(&mut self, name: &str) {
+        if let Some(child) = self.children.get_mut(name) {
+            for (cmd_name, cmd) in std::mem::take(&mut child.hidden_commands) {
+                child.commands.insert(cmd_name, cmd);
+            }
+            child.is_safe = false;
+        }
+    }
+
+    /// `interp hide name` / `interp expose name` on a child: move a command
+    /// between its visible and hidden tables. Returns `false` if the child is
+    /// missing.
+    fn child_hide(&mut self, name: &str, cmd: &str, hide: bool) -> bool {
+        let Some(child) = self.children.get_mut(name) else {
+            return false;
+        };
+        if hide {
+            if let Some(c) = child.commands.remove(cmd) {
+                child.hidden_commands.insert(cmd.to_string(), c);
+            }
+        } else if let Some(c) = child.hidden_commands.remove(cmd) {
+            child.commands.insert(cmd.to_string(), c);
+        }
+        true
+    }
+
+    /// Make this interp safe (`interp create -safe`): hide the commands that
+    /// reach the host (filesystem, processes, sockets, the interpreter loader).
+    /// Hidden commands move to `hidden_commands`, invocable via
+    /// `interp invokehidden` and restorable with `interp expose`.
+    fn make_safe(&mut self) {
+        const UNSAFE: &[&str] = &[
+            "exec",
+            "exit",
+            "cd",
+            "pwd",
+            "glob",
+            "open",
+            "socket",
+            "source",
+            "load",
+            "file",
+            "fconfigure",
+            "encoding",
+            "after",
+            "vwait",
+        ];
+        for &c in UNSAFE {
+            if let Some(cmd) = self.commands.remove(c) {
+                self.hidden_commands.insert(c.to_string(), cmd);
+            }
+        }
+        self.is_safe = true;
+    }
+
+    /// Evaluate `script` in the named child interpreter (`interp eval path …` /
+    /// `$child eval …`). The child is taken out of the table for the call so the
+    /// parent is free, then restored.
+    pub(crate) fn eval_in_child(&mut self, name: &str, script: &str) -> Completion<Value> {
+        let Some(mut child) = self.children.remove(name) else {
+            return err(format!("could not find interpreter \"{name}\""));
+        };
+        let res = match child.eval_source(script) {
+            Ok(c) => c,
+            Err(e) => err(e.message),
+        };
+        // Restore the child unless it tore itself down (no parent re-entry in
+        // this model, so it is always still present).
+        self.children.insert(name.to_string(), child);
+        res
+    }
+
+    /// `interp delete path …` / `$child delete` — destroy a child and its
+    /// command. Returns whether it existed.
+    pub(crate) fn delete_child(&mut self, name: &str) -> bool {
+        let existed = self.children.remove(name).is_some();
+        if existed {
+            self.commands
+                .remove(name.strip_prefix("::").unwrap_or(name));
+        }
+        existed
+    }
+
+    /// Dispatch a child-as-command call (`$child sub ?arg …?`) — the `interp`
+    /// ensemble restricted to that child.
+    pub(crate) fn dispatch_child(&mut self, name: &str, argv: &[Value]) -> Completion<Value> {
+        let Some((sub, rest)) = argv.split_first() else {
+            return err(format!("wrong # args: should be \"{name} cmd ?arg ...?\""));
+        };
+        match &*sub.to_str() {
+            "eval" => {
+                let script = rest
+                    .iter()
+                    .map(|v| v.to_str().to_string())
+                    .collect::<Vec<_>>()
+                    .join(" ");
+                self.eval_in_child(name, &script)
+            }
+            "issafe" => ok(Value::bool(self.child_is_safe(name).unwrap_or(false))),
+            "delete" => {
+                self.delete_child(name);
+                ok(Value::empty())
+            }
+            "hidden" => {
+                let mut names: Vec<String> = self
+                    .children
+                    .get(name)
+                    .map(|c| c.hidden_commands.keys().cloned().collect())
+                    .unwrap_or_default();
+                names.sort();
+                ok(Value::list(names.into_iter().map(Value::string).collect()))
+            }
+            "hide" | "expose" if rest.len() == 1 => {
+                let hide = &*sub.to_str() == "hide";
+                self.child_hide(name, &rest[0].to_str(), hide);
+                ok(Value::empty())
+            }
+            "marktrusted" => {
+                self.child_mark_trusted(name);
+                ok(Value::empty())
+            }
+            other => err(format!(
+                "bad option \"{other}\": must be alias, aliases, bgerror, eval, \
+                 expose, hide, hidden, issafe, invokehidden, marktrusted, \
+                 recursionlimit, or transfer"
+            )),
+        }
     }
 
     pub(crate) fn lookup_command(&self, name: &str) -> Option<Command> {
@@ -2019,11 +2226,12 @@ impl Vm {
     }
 
     pub(crate) fn write_output(&mut self, s: &str, newline: bool) {
-        let _ = self.out.write_all(s.as_bytes());
+        let mut out = self.out.borrow_mut();
+        let _ = out.write_all(s.as_bytes());
         if newline {
-            let _ = self.out.write_all(b"\n");
+            let _ = out.write_all(b"\n");
         }
-        let _ = self.out.flush();
+        let _ = out.flush();
     }
 
     /// Register a freshly opened channel, returning its minted id (`file3`, …).

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -853,8 +853,14 @@ impl Vm {
             [opt] => Ok(query(resolve_limit_opt(&opt.to_str(), OPTS)?)),
             _ => {
                 for pair in args.chunks(2) {
-                    let opt = resolve_limit_opt(&pair[0].to_str(), OPTS)?;
-                    let val = &pair[1];
+                    // A trailing option with no value is a catchable error, not a
+                    // panic (`interp limit c commands -value 1 -granularity`).
+                    let [opt, val] = pair else {
+                        return Err("wrong # args: should be \"interp limit path commands \
+                                    ?-option value ...?\""
+                            .into());
+                    };
+                    let opt = resolve_limit_opt(&opt.to_str(), OPTS)?;
                     match opt {
                         "-command" => self.limits.cmd_command = val.clone(),
                         "-granularity" => {
@@ -909,8 +915,12 @@ impl Vm {
                 let (mut sec, mut ms) = self.limits.time_value.unwrap_or((0, 0));
                 let mut touched = self.limits.time_value.is_some();
                 for pair in args.chunks(2) {
-                    let opt = resolve_limit_opt(&pair[0].to_str(), OPTS)?;
-                    let val = &pair[1];
+                    let [opt, val] = pair else {
+                        return Err("wrong # args: should be \"interp limit path time \
+                                    ?-option value ...?\""
+                            .into());
+                    };
+                    let opt = resolve_limit_opt(&opt.to_str(), OPTS)?;
                     match opt {
                         "-command" => self.limits.time_command = val.clone(),
                         "-granularity" => {
@@ -954,6 +964,12 @@ impl Vm {
         let mut names: Vec<String> = self.children.keys().cloned().collect();
         names.sort();
         names
+    }
+
+    /// `interp children path` — the direct child names of the named child interp
+    /// (one level down), or `None` when that child does not exist.
+    pub(crate) fn child_child_names(&self, name: &str) -> Option<Vec<String>> {
+        self.children.get(name).map(Vm::child_names)
     }
 
     /// `interp issafe ?path?` for the current interp.
@@ -1285,6 +1301,9 @@ impl Vm {
                 ok(Value::empty())
             }
             "marktrusted" => {
+                if self.is_safe() {
+                    return err("permission denied: safe interpreter cannot mark trusted");
+                }
                 self.child_mark_trusted(name);
                 ok(Value::empty())
             }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -343,6 +343,36 @@ impl Vm {
         for (k, v) in plat {
             let _ = self.write_array_raw("tcl_platform", k, Value::string(v));
         }
+        // Backend-introspection keys (the test-suite constraint overlay reads
+        // these). The bytecode VM is a native interpreter, so the wasm / WASI /
+        // eBPF facts come from the build's `cfg` (empty on a native build) and
+        // may be overridden from the environment to evaluate another backend's
+        // skip lists.
+        use tcl_platform::backend::{self, key};
+        let detected = |k: &str| -> String {
+            backend::override_env_var(k)
+                .and_then(|var| std::env::var(var).ok())
+                .unwrap_or_else(|| {
+                    match k {
+                        key::WASM => backend::compiled_wasm_spec(),
+                        key::WASI => backend::compiled_wasi_spec(),
+                        key::WASI_VERSION => backend::compiled_wasi_host(),
+                        key::EBPF => backend::compiled_ebpf_spec(),
+                        _ => "",
+                    }
+                    .to_string()
+                })
+        };
+        for (k, v) in [
+            (key::RUNTIME, "bytecode".to_string()),
+            (key::RUNTIME_VERSION, env!("CARGO_PKG_VERSION").to_string()),
+            (key::WASM, detected(key::WASM)),
+            (key::WASI, detected(key::WASI)),
+            (key::WASI_VERSION, detected(key::WASI_VERSION)),
+            (key::EBPF, detected(key::EBPF)),
+        ] {
+            let _ = self.write_array_raw("tcl_platform", k, Value::string(v.as_str()));
+        }
         for (k, v) in std::env::vars() {
             let _ = self.write_array_raw("env", &k, Value::string(v));
         }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -814,7 +814,8 @@ impl Vm {
             return None;
         }
         self.limit_tick = self.limit_tick.wrapping_add(1);
-        if self.limit_tick & 0x0FFF == 0 && self.time_limit_exceeded() {
+        // Poll roughly every 4096 ticks (the low 12 bits clear).
+        if self.limit_tick.trailing_zeros() >= 12 && self.time_limit_exceeded() {
             return Some(err("time limit exceeded"));
         }
         None
@@ -1326,28 +1327,32 @@ impl Vm {
             "recursionlimit" => err(format!(
                 "wrong # args: should be \"{name} recursionlimit ?newlimit?\""
             )),
-            "limit" => {
-                let (ltype, opts) = match rest {
-                    [ltype, opts @ ..] => (ltype.to_str(), opts),
-                    _ => {
-                        return err(format!(
-                            "wrong # args: should be \"{name} limit limitType ?-option value ...?\""
-                        ));
-                    }
-                };
-                match self.children.get_mut(name) {
-                    Some(child) => match child.limit_apply(&ltype, opts) {
-                        Ok(v) => ok(v),
-                        Err(m) => err(m),
-                    },
-                    None => err(format!("could not find interpreter \"{name}\"")),
-                }
-            }
+            "limit" => self.child_limit_cmd(name, rest),
             other => err(format!(
                 "bad option \"{other}\": must be alias, aliases, bgerror, eval, \
                  expose, hide, hidden, issafe, invokehidden, limit, marktrusted, \
                  recursionlimit, or transfer"
             )),
+        }
+    }
+
+    /// `$child limit limitType ?-option value …?` — query/configure the named
+    /// child's commands/time limit (the `$child` form of `interp limit`).
+    fn child_limit_cmd(&mut self, name: &str, rest: &[Value]) -> Completion<Value> {
+        let (ltype, opts) = match rest {
+            [ltype, opts @ ..] => (ltype.to_str(), opts),
+            _ => {
+                return err(format!(
+                    "wrong # args: should be \"{name} limit limitType ?-option value ...?\""
+                ));
+            }
+        };
+        match self.children.get_mut(name) {
+            Some(child) => match child.limit_apply(&ltype, opts) {
+                Ok(v) => ok(v),
+                Err(m) => err(m),
+            },
+            None => err(format!("could not find interpreter \"{name}\"")),
         }
     }
 

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -780,6 +780,11 @@ impl Vm {
         for &k in UNSAFE_PLATFORM {
             let _ = self.unset_one(&format!("tcl_platform({k})"), false);
         }
+        // A safe interp has no `env` array and no real library/package paths
+        // (C's `Tcl_MakeSafe`); the Safe Base re-virtualises an `auto_path`.
+        for v in ["env", "tcl_library", "tclDefaultLibrary", "tcl_pkgPath"] {
+            let _ = self.unset_one(v, false);
+        }
         self.is_safe = true;
     }
 

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -25,6 +25,21 @@ use crate::value::Value;
 /// A deeper nesting is a catchable error, not a native stack overflow.
 pub(crate) const RECURSION_LIMIT: usize = 1000;
 
+/// Parse an `interp recursionlimit` integer the way C's `Tcl_GetIntFromObj`
+/// reports: a decimal that overflows `i64` is "too large to represent", a
+/// non-numeric value is "expected integer but got …".
+fn parse_recursion_limit(s: &str) -> Result<i64, String> {
+    let t = s.trim();
+    if let Ok(n) = t.parse::<i64>() {
+        return Ok(n);
+    }
+    let body = t.strip_prefix(['+', '-']).unwrap_or(t);
+    if !body.is_empty() && body.bytes().all(|b| b.is_ascii_digit()) {
+        return Err("integer value too large to represent".to_string());
+    }
+    Err(format!("expected integer but got \"{s}\""))
+}
+
 /// The on-demand autoloader bootstrap (see [`Vm::init_auto_load`]). A focused
 /// subset of C's `init.tcl`: `auto_load_index` reads each `tclIndex` on
 /// `auto_path` (which sets `auto_index(cmd)` to a `::tcl::Pkg::source <file>`
@@ -236,6 +251,9 @@ pub struct Vm {
     children: HashMap<String, Vm>,
     /// Whether this interp is safe (`interp create -safe` / `interp issafe`).
     is_safe: bool,
+    /// Per-interp recursion bound (`interp recursionlimit`), default
+    /// [`RECURSION_LIMIT`]. A child carries its own, independent of the parent's.
+    recursion_limit: usize,
     /// Commands hidden by `interp create -safe` / `interp hide`, keyed by name —
     /// invocable via `interp invokehidden`, restorable with `interp expose`.
     hidden_commands: HashMap<String, Command>,
@@ -311,6 +329,7 @@ impl Vm {
             host: Rc::new(NativeHost::new()),
             children: HashMap::new(),
             is_safe: false,
+            recursion_limit: RECURSION_LIMIT,
             hidden_commands: HashMap::new(),
             interp_counter: 0,
             // A fixed non-zero default so an un-`srand`'d `rand()` is still
@@ -666,6 +685,16 @@ impl Vm {
         self.children.get(name).map(|c| c.is_safe)
     }
 
+    /// Get/set a child's recursion limit; `None` if the child does not exist.
+    pub(crate) fn child_recursion_limit_apply(
+        &mut self,
+        name: &str,
+        newlimit: Option<&str>,
+    ) -> Option<Result<i64, String>> {
+        let child = self.children.get_mut(name)?;
+        Some(child.recursion_limit_apply(newlimit))
+    }
+
     /// `interp marktrusted path` — clear a child's safe flag (exposing every
     /// hidden command). A no-op if the child does not exist.
     pub(crate) fn child_mark_trusted(&mut self, name: &str) {
@@ -789,6 +818,17 @@ impl Vm {
                 self.child_mark_trusted(name);
                 ok(Value::empty())
             }
+            "recursionlimit" if rest.len() <= 1 => {
+                let nl = rest.first().map(|v| v.to_str().to_string());
+                match self.child_recursion_limit_apply(name, nl.as_deref()) {
+                    Some(Ok(n)) => ok(Value::int(n)),
+                    Some(Err(m)) => err(m),
+                    None => err(format!("could not find interpreter \"{name}\"")),
+                }
+            }
+            "recursionlimit" => err(format!(
+                "wrong # args: should be \"{name} recursionlimit ?newlimit?\""
+            )),
             other => err(format!(
                 "bad option \"{other}\": must be alias, aliases, bgerror, eval, \
                  expose, hide, hidden, issafe, invokehidden, marktrusted, \
@@ -1373,6 +1413,28 @@ impl Vm {
     /// The current call-nesting depth (proc recursion bound).
     pub(crate) fn recursion_depth(&self) -> usize {
         self.recursion_depth
+    }
+
+    /// This interp's recursion bound (`interp recursionlimit`).
+    pub(crate) fn recursion_limit(&self) -> usize {
+        self.recursion_limit
+    }
+
+    /// `interp recursionlimit` get / set on this interp. `newlimit` is the
+    /// optional new-limit string; returns the resulting limit or the error
+    /// message the caller should raise.
+    pub(crate) fn recursion_limit_apply(&mut self, newlimit: Option<&str>) -> Result<i64, String> {
+        match newlimit {
+            None => Ok(i64::try_from(self.recursion_limit).unwrap_or(i64::MAX)),
+            Some(s) => {
+                let n = parse_recursion_limit(s)?;
+                if n <= 0 {
+                    return Err("recursion limit must be > 0".to_string());
+                }
+                self.recursion_limit = usize::try_from(n).unwrap_or(usize::MAX);
+                Ok(n)
+            }
+        }
     }
 
     /// Evaluate `src` as if `target` were the current call frame (`uplevel`).

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -327,6 +327,7 @@ impl Vm {
     /// the `tcl_platform`/`env` arrays and the `argv`/`argv0`/`argc` scalars,
     /// so library scripts (tcltest) that read them at load time work.
     fn bootstrap_globals(&mut self) {
+        use tcl_platform::backend::{self, key};
         let plat = [
             ("platform", "unix"),
             ("os", "Linux"),
@@ -348,7 +349,6 @@ impl Vm {
         // eBPF facts come from the build's `cfg` (empty on a native build) and
         // may be overridden from the environment to evaluate another backend's
         // skip lists.
-        use tcl_platform::backend::{self, key};
         let detected = |k: &str| -> String {
             backend::override_env_var(k)
                 .and_then(|var| std::env::var(var).ok())

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -297,8 +297,14 @@ pub struct Vm {
     debug_frame: bool,
     /// `interp bgerror` — the background-error handler command prefix.
     bgerror_handler: Value,
-    /// `interp limit` configuration (not enforced — stored for query/set).
+    /// `interp limit` configuration. The `time` limit is enforced; `commands`
+    /// is stored for query/set only.
     limits: LimitSet,
+    /// Free-running counter that throttles wall-clock polling for the `time`
+    /// limit (see [`Vm::limit_check_tick`]). Vm-scoped, not per-activation, so
+    /// it accumulates across the short-lived activations a command-driven loop
+    /// (`$while {1} {…}`) spins through.
+    limit_tick: u32,
 }
 
 /// `interp limit` configuration for one interpreter — the `commands` and `time`
@@ -401,6 +407,7 @@ impl Vm {
             debug_frame: false,
             bgerror_handler: Value::string("::tcl::Bgerror"),
             limits: LimitSet::default(),
+            limit_tick: 0,
             // A fixed non-zero default so an un-`srand`'d `rand()` is still
             // deterministic; Tcl auto-seeds from the clock, but reproducibility
             // is more useful for the VM and every test seeds explicitly.
@@ -777,8 +784,44 @@ impl Vm {
         self.bgerror_handler.clone()
     }
 
+    /// Whether this interp's `time` limit has elapsed. The stored time value is
+    /// an absolute wall-clock deadline (`-seconds`/`-milliseconds`); the
+    /// execution trampoline polls this so an unbounded bytecode loop still
+    /// honours `interp limit $i time`. Returns `false` when no time limit is set.
+    pub(crate) fn time_limit_exceeded(&self) -> bool {
+        match self.limits.time_value {
+            Some((secs, millis)) => {
+                let deadline = i128::from(secs) * 1000 + i128::from(millis);
+                self.host_rc().clock().now_millis() >= deadline
+            }
+            None => false,
+        }
+    }
+
+    /// Whether a `time` limit is configured at all — the cheap guard the
+    /// trampoline checks before paying for a wall-clock read.
+    pub(crate) fn has_time_limit(&self) -> bool {
+        self.limits.time_value.is_some()
+    }
+
+    /// Advance the limit-poll counter and, when a `time` limit is armed and the
+    /// throttle window elapses, return the `time limit exceeded` error. Called
+    /// from the bytecode trampoline (per tick) and the loop commands (per
+    /// iteration) so both pure-bytecode and command-driven infinite loops are
+    /// trapped. A no-op (beyond the guard) when no time limit is set.
+    pub(crate) fn limit_check_tick(&mut self) -> Option<Completion<Value>> {
+        if !self.has_time_limit() {
+            return None;
+        }
+        self.limit_tick = self.limit_tick.wrapping_add(1);
+        if self.limit_tick & 0x0FFF == 0 && self.time_limit_exceeded() {
+            return Some(err("time limit exceeded"));
+        }
+        None
+    }
+
     /// `interp limit limitType ?-option value …?` on this interp (query / set;
-    /// not enforced).
+    /// enforced for `time`).
     pub(crate) fn limit_apply(&mut self, ltype: &str, args: &[Value]) -> Result<Value, String> {
         match ltype {
             "commands" => self.limit_commands(args),

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -14,7 +14,7 @@ use tcl_runtime_api::{
 };
 use tcl_syntax::expr::{eval, parse_expr};
 
-use crate::command::{BuiltinFn, Command, ProcDef, register_builtins};
+use crate::command::{BuiltinFn, Command, EnsembleDef, ProcDef, register_builtins};
 use crate::error::TclError;
 use crate::expr::ExprEval;
 use crate::frame::{CallFrame, Local};
@@ -24,6 +24,17 @@ use crate::value::Value;
 /// The proc-call recursion bound (C Tcl's default `interp recursionlimit`).
 /// A deeper nesting is a catchable error, not a native stack overflow.
 pub(crate) const RECURSION_LIMIT: usize = 1000;
+
+/// Render a subcommand list as C's ensemble `must be …` clause — note the
+/// ensemble formatter puts a comma before `or` even for two items
+/// (`x1, or x2`), unlike `Tcl_GetIndexFromObj`.
+fn oxford_or(items: &[String]) -> String {
+    match items {
+        [] => String::new(),
+        [a] => a.clone(),
+        [head @ .., last] => format!("{}, or {last}", head.join(", ")),
+    }
+}
 
 /// Parse an `interp recursionlimit` integer the way C's `Tcl_GetIntFromObj`
 /// reports: a decimal that overflows `i64` is "too large to represent", a
@@ -633,6 +644,7 @@ impl Vm {
             Command::Proc(_) => "proc",
             Command::Alias(_) => "alias",
             Command::ChildInterp(_) => "interp",
+            Command::Ensemble(_) => "ensemble",
         })
     }
 
@@ -782,6 +794,100 @@ impl Vm {
 
     /// Dispatch a child-as-command call (`$child sub ?arg …?`) — the `interp`
     /// ensemble restricted to that child.
+    /// The exported command tails of namespace `ns` (the default ensemble
+    /// subcommand set): commands directly in `ns` whose tail matches an export
+    /// pattern.
+    fn exported_command_tails(&self, ns: &str) -> Vec<String> {
+        let prefix = if ns.is_empty() {
+            String::new()
+        } else {
+            format!("{ns}::")
+        };
+        let patterns = self.ns_exports.get(ns).cloned().unwrap_or_default();
+        let mut out = Vec::new();
+        for key in self.commands.keys() {
+            let Some(tail) = key.strip_prefix(&prefix) else {
+                continue;
+            };
+            if tail.is_empty() || tail.contains("::") {
+                continue;
+            }
+            if patterns
+                .iter()
+                .any(|p| tcl_syntax::glob::string_match(p, tail))
+            {
+                out.push(tail.to_string());
+            }
+        }
+        out
+    }
+
+    /// Dispatch a `namespace ensemble` call (`ens sub ?arg …?`): resolve `sub`
+    /// (exact, or unambiguous prefix) against the ensemble's subcommands and
+    /// invoke the mapped target (`-map`, else `namespace::sub`).
+    pub(crate) fn dispatch_ensemble(
+        &mut self,
+        ens_name: &str,
+        e: &EnsembleDef,
+        argv: &[Value],
+    ) -> Completion<Value> {
+        let Some((sub_val, rest)) = argv.split_first() else {
+            return err(format!(
+                "wrong # args: should be \"{ens_name} subcommand ?arg ...?\""
+            ));
+        };
+        let sub = sub_val.to_str().to_string();
+        let mut subs: Vec<String> = match &e.subcommands {
+            Some(list) => list.clone(),
+            None => self.exported_command_tails(&e.namespace),
+        };
+        for k in e.map.keys() {
+            if !subs.contains(k) {
+                subs.push(k.clone());
+            }
+        }
+        subs.sort();
+        subs.dedup();
+        let resolved = if subs.iter().any(|s| s == &sub) {
+            Some(sub.clone())
+        } else if e.prefixes {
+            let m: Vec<&String> = subs.iter().filter(|s| s.starts_with(&sub)).collect();
+            if m.len() == 1 {
+                Some(m[0].clone())
+            } else {
+                None
+            }
+        } else {
+            None
+        };
+        match resolved {
+            Some(s) => {
+                let mut full: Vec<Value> = match e.map.get(&s) {
+                    Some(words) => words.clone(),
+                    None => vec![Value::string(if e.namespace.is_empty() {
+                        s.clone()
+                    } else {
+                        format!("{}::{s}", e.namespace)
+                    })],
+                };
+                full.extend_from_slice(rest);
+                let target = full[0].to_str().to_string();
+                self.invoke_command(&target, &full[1..])
+            }
+            None if e.unknown.is_some() => {
+                let mut full = e.unknown.clone().unwrap();
+                full.push(Value::string(ens_name));
+                full.extend_from_slice(argv);
+                let target = full[0].to_str().to_string();
+                self.invoke_command(&target, &full[1..])
+            }
+            None => err(format!(
+                "unknown or ambiguous subcommand \"{sub}\": must be {}",
+                oxford_or(&subs)
+            )),
+        }
+    }
+
     pub(crate) fn dispatch_child(&mut self, name: &str, argv: &[Value]) -> Completion<Value> {
         let Some((sub, rest)) = argv.split_first() else {
             return err(format!("wrong # args: should be \"{name} cmd ?arg ...?\""));

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -115,6 +115,13 @@ pub struct Vm {
     /// Export patterns per namespace (canonical name → glob patterns), set by
     /// `namespace export` and consulted by `namespace import`.
     ns_exports: HashMap<String, Vec<String>>,
+    /// Import provenance: canonical key of a command created by `namespace
+    /// import` → the canonical FQN of its origin (source) command. Lets
+    /// `namespace forget` remove *only* imported commands (C
+    /// `Tcl_ForgetImport`, which matches on `deleteProc == DeleteImportedCmd`),
+    /// leaving a real command of the same name intact. Cleared whenever the key
+    /// is re-registered (a redefine) or taken (a `rename`).
+    imported_commands: HashMap<String, String>,
     /// Namespace-name ⇆ opaque `NsId` arena for the Family-B `Frames`/`Namespaces`
     /// contract. The VM resolves namespaces by their canonical `String` name; this
     /// side-table mints stable `NsId` handles for them (`ns_arena[id]` is the name,
@@ -256,6 +263,7 @@ impl Vm {
             ns_stack: vec![String::new()],
             namespaces: std::collections::HashSet::new(),
             ns_exports: HashMap::new(),
+            imported_commands: HashMap::new(),
             ns_arena: vec![String::new()],
             ns_intern: HashMap::from([(String::new(), ROOT_NS)]),
             ns_paths: HashMap::new(),
@@ -501,6 +509,9 @@ impl Vm {
     pub(crate) fn register_command(&mut self, name: &str, cmd: Command) {
         // The table is keyed by canonical names (no leading `::`).
         let key = name.strip_prefix("::").unwrap_or(name);
+        // A direct (re)definition at this key is not an import — drop any stale
+        // import provenance so `namespace forget` won't later remove it.
+        self.imported_commands.remove(key);
         self.commands.insert(key.to_owned(), cmd);
     }
 
@@ -523,6 +534,7 @@ impl Vm {
     /// Resolve and remove the command `name`, returning it (for `rename`).
     pub(crate) fn take_command(&mut self, name: &str) -> Option<Command> {
         let key = self.command_key(name)?;
+        self.imported_commands.remove(&key);
         self.commands.remove(&key)
     }
 
@@ -768,10 +780,68 @@ impl Vm {
         let mut imported = Vec::new();
         for (tail, cmd) in to_import {
             let alias = self.qualify_name(&tail);
+            let origin = format!("{prefix}{tail}");
             self.register_command(&alias, cmd);
+            // `register_command` cleared any stale provenance; now stamp this key
+            // as an import so `namespace forget` can target it.
+            self.imported_commands.insert(alias, origin);
             imported.push(tail);
         }
         imported
+    }
+
+    /// `namespace forget pattern` — remove previously imported commands matching
+    /// `pattern` from the current namespace (C `Tcl_ForgetImport`). Only commands
+    /// created by `namespace import` are removed; a real command of the same name
+    /// is left intact. A simple (unqualified) pattern matches imported commands
+    /// in the current namespace by name; a qualified `ns::pat` pattern matches
+    /// those whose origin lives in `ns` and whose origin tail matches `pat`.
+    /// Returns `Err` for an unknown namespace in a qualified pattern.
+    pub(crate) fn forget_imports(&mut self, pattern: &str) -> Result<(), String> {
+        // Split a canonical command key into (namespace, tail).
+        fn split_key(key: &str) -> (&str, &str) {
+            match key.rsplit_once("::") {
+                Some((ns, tail)) => (ns, tail),
+                None => ("", key),
+            }
+        }
+        let cur = self.current_ns().to_string();
+        let abs = pattern.strip_prefix("::").unwrap_or(pattern);
+        let victims: Vec<String> = if pattern.contains("::") {
+            // Qualified pattern: source namespace + simple pattern on the origin.
+            let (src_ns, simple) = abs.rsplit_once("::").unwrap();
+            if !self.namespace_exists(src_ns) {
+                return Err(format!(
+                    "unknown namespace in namespace forget pattern \"{pattern}\""
+                ));
+            }
+            self.imported_commands
+                .iter()
+                .filter(|(key, origin)| {
+                    split_key(key).0 == cur && {
+                        let (o_ns, o_tail) = split_key(origin);
+                        o_ns == src_ns && tcl_syntax::glob::string_match(simple, o_tail)
+                    }
+                })
+                .map(|(key, _)| key.clone())
+                .collect()
+        } else {
+            // Simple pattern: imported commands in the current namespace whose
+            // own name matches.
+            self.imported_commands
+                .keys()
+                .filter(|key| {
+                    let (ns, tail) = split_key(key);
+                    ns == cur && tcl_syntax::glob::string_match(abs, tail)
+                })
+                .cloned()
+                .collect()
+        };
+        for key in victims {
+            self.imported_commands.remove(&key);
+            self.commands.remove(&key);
+        }
+        Ok(())
     }
 
     /// Delete namespace `canonical` (no leading `::`) and every descendant,
@@ -789,6 +859,8 @@ impl Vm {
         // (unrooted) name, so a member of the namespace or a descendant begins
         // with `canonical::`.
         self.commands.retain(|k, _| !k.starts_with(&prefix));
+        self.imported_commands
+            .retain(|k, _| !k.starts_with(&prefix));
         if let Some(g) = self.frames.first_mut() {
             g.locals.retain(|k, _| !k.starts_with(&prefix));
         }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -51,6 +51,29 @@ fn parse_recursion_limit(s: &str) -> Result<i64, String> {
     Err(format!("expected integer but got \"{s}\""))
 }
 
+/// Resolve an `interp limit` option by unambiguous prefix against `opts`,
+/// matching C's `Tcl_GetIndexFromObj`. Returns the canonical spelling or a
+/// `bad option "X": must be …` error.
+fn resolve_limit_opt<'a>(arg: &str, opts: &'a [&'a str]) -> Result<&'a str, String> {
+    let matches: Vec<&str> = opts.iter().copied().filter(|o| o.starts_with(arg)).collect();
+    match matches.as_slice() {
+        [exact] => Ok(exact),
+        _ if opts.contains(&arg) => Ok(opts[opts.iter().position(|o| *o == arg).unwrap()]),
+        _ => Err(format!(
+            "bad option \"{arg}\": must be {}",
+            oxford_or(&opts.iter().map(|o| (*o).to_string()).collect::<Vec<_>>())
+        )),
+    }
+}
+
+/// Parse an `interp limit` integer option value, mirroring `parse_recursion_limit`'s
+/// `expected integer but got "X"` wording.
+fn parse_limit_int(s: &str) -> Result<i64, String> {
+    s.trim()
+        .parse::<i64>()
+        .map_err(|_| format!("expected integer but got \"{s}\""))
+}
+
 /// The on-demand autoloader bootstrap (see [`Vm::init_auto_load`]). A focused
 /// subset of C's `init.tcl`: `auto_load_index` reads each `tclIndex` on
 /// `auto_path` (which sets `auto_index(cmd)` to a `::tcl::Pkg::source <file>`
@@ -274,6 +297,34 @@ pub struct Vm {
     debug_frame: bool,
     /// `interp bgerror` — the background-error handler command prefix.
     bgerror_handler: Value,
+    /// `interp limit` configuration (not enforced — stored for query/set).
+    limits: LimitSet,
+}
+
+/// `interp limit` configuration for one interpreter — the `commands` and `time`
+/// limit types. Stored and queried, but not enforced.
+#[derive(Clone)]
+pub(crate) struct LimitSet {
+    cmd_command: Value,
+    cmd_granularity: i64,
+    cmd_value: Option<i64>,
+    time_command: Value,
+    time_granularity: i64,
+    /// Combined seconds + milliseconds, normalised; `None` when unset.
+    time_value: Option<(i64, i64)>,
+}
+
+impl Default for LimitSet {
+    fn default() -> Self {
+        Self {
+            cmd_command: Value::string(""),
+            cmd_granularity: 1,
+            cmd_value: None,
+            time_command: Value::string(""),
+            time_granularity: 10,
+            time_value: None,
+        }
+    }
 }
 
 /// The command-identity arena backing `Namespaces::find_command` /
@@ -349,6 +400,7 @@ impl Vm {
             interp_counter: 0,
             debug_frame: false,
             bgerror_handler: Value::string("::tcl::Bgerror"),
+            limits: LimitSet::default(),
             // A fixed non-zero default so an un-`srand`'d `rand()` is still
             // deterministic; Tcl auto-seeds from the clock, but reproducibility
             // is more useful for the VM and every test seeds explicitly.
@@ -725,6 +777,134 @@ impl Vm {
         self.bgerror_handler.clone()
     }
 
+    /// `interp limit limitType ?-option value …?` on this interp (query / set;
+    /// not enforced).
+    pub(crate) fn limit_apply(&mut self, ltype: &str, args: &[Value]) -> Result<Value, String> {
+        match ltype {
+            "commands" => self.limit_commands(args),
+            "time" => self.limit_time(args),
+            other => Err(format!(
+                "bad limit type \"{other}\": must be commands or time"
+            )),
+        }
+    }
+
+    fn limit_commands(&mut self, args: &[Value]) -> Result<Value, String> {
+        const OPTS: &[&str] = &["-command", "-granularity", "-value"];
+        let l = &self.limits;
+        let query = |opt: &str| match opt {
+            "-command" => l.cmd_command.clone(),
+            "-granularity" => Value::int(l.cmd_granularity),
+            _ => l.cmd_value.map_or_else(|| Value::string(""), Value::int),
+        };
+        match args {
+            [] => Ok(Value::list(vec![
+                Value::string("-command"),
+                l.cmd_command.clone(),
+                Value::string("-granularity"),
+                Value::int(l.cmd_granularity),
+                Value::string("-value"),
+                l.cmd_value.map_or_else(|| Value::string(""), Value::int),
+            ])),
+            [opt] => Ok(query(resolve_limit_opt(&opt.to_str(), OPTS)?)),
+            _ => {
+                for pair in args.chunks(2) {
+                    let opt = resolve_limit_opt(&pair[0].to_str(), OPTS)?;
+                    let val = &pair[1];
+                    match opt {
+                        "-command" => self.limits.cmd_command = val.clone(),
+                        "-granularity" => {
+                            let n = parse_limit_int(&val.to_str())?;
+                            if n < 1 {
+                                return Err("granularity must be at least 1".into());
+                            }
+                            self.limits.cmd_granularity = n;
+                        }
+                        _ => {
+                            let n = parse_limit_int(&val.to_str())?;
+                            if n < 0 {
+                                return Err("command limit value must be at least 0".into());
+                            }
+                            self.limits.cmd_value = Some(n);
+                        }
+                    }
+                }
+                Ok(Value::string(""))
+            }
+        }
+    }
+
+    fn limit_time(&mut self, args: &[Value]) -> Result<Value, String> {
+        const OPTS: &[&str] = &["-command", "-granularity", "-milliseconds", "-seconds"];
+        let l = &self.limits;
+        let query = |opt: &str| match opt {
+            "-command" => l.time_command.clone(),
+            "-granularity" => Value::int(l.time_granularity),
+            "-seconds" => l
+                .time_value
+                .map_or_else(|| Value::string(""), |(s, _)| Value::int(s)),
+            _ => l
+                .time_value
+                .map_or_else(|| Value::string(""), |(_, m)| Value::int(m)),
+        };
+        match args {
+            [] => Ok(Value::list(vec![
+                Value::string("-command"),
+                l.time_command.clone(),
+                Value::string("-granularity"),
+                Value::int(l.time_granularity),
+                Value::string("-milliseconds"),
+                l.time_value
+                    .map_or_else(|| Value::string(""), |(_, m)| Value::int(m)),
+                Value::string("-seconds"),
+                l.time_value
+                    .map_or_else(|| Value::string(""), |(s, _)| Value::int(s)),
+            ])),
+            [opt] => Ok(query(resolve_limit_opt(&opt.to_str(), OPTS)?)),
+            _ => {
+                let (mut sec, mut ms) = self.limits.time_value.unwrap_or((0, 0));
+                let mut touched = self.limits.time_value.is_some();
+                for pair in args.chunks(2) {
+                    let opt = resolve_limit_opt(&pair[0].to_str(), OPTS)?;
+                    let val = &pair[1];
+                    match opt {
+                        "-command" => self.limits.time_command = val.clone(),
+                        "-granularity" => {
+                            let n = parse_limit_int(&val.to_str())?;
+                            if n < 1 {
+                                return Err("granularity must be at least 1".into());
+                            }
+                            self.limits.time_granularity = n;
+                        }
+                        "-seconds" => {
+                            let n = parse_limit_int(&val.to_str())?;
+                            if n < 0 {
+                                return Err("seconds must be non-negative".into());
+                            }
+                            sec = n;
+                            touched = true;
+                        }
+                        _ => {
+                            let n = parse_limit_int(&val.to_str())?;
+                            if n < 0 {
+                                return Err("milliseconds must be non-negative".into());
+                            }
+                            ms = n;
+                            touched = true;
+                        }
+                    }
+                }
+                if touched {
+                    // Normalise excess milliseconds into seconds.
+                    sec += ms.div_euclid(1000);
+                    ms = ms.rem_euclid(1000);
+                    self.limits.time_value = Some((sec, ms));
+                }
+                Ok(Value::string(""))
+            }
+        }
+    }
+
     /// Sorted names of this interp's direct children (`interp children`).
     pub(crate) fn child_names(&self) -> Vec<String> {
         let mut names: Vec<String> = self.children.keys().cloned().collect();
@@ -1087,9 +1267,26 @@ impl Vm {
             "recursionlimit" => err(format!(
                 "wrong # args: should be \"{name} recursionlimit ?newlimit?\""
             )),
+            "limit" => {
+                let (ltype, opts) = match rest {
+                    [ltype, opts @ ..] => (ltype.to_str(), opts),
+                    _ => {
+                        return err(format!(
+                            "wrong # args: should be \"{name} limit limitType ?-option value ...?\""
+                        ));
+                    }
+                };
+                match self.children.get_mut(name) {
+                    Some(child) => match child.limit_apply(&ltype, opts) {
+                        Ok(v) => ok(v),
+                        Err(m) => err(m),
+                    },
+                    None => err(format!("could not find interpreter \"{name}\"")),
+                }
+            }
             other => err(format!(
                 "bad option \"{other}\": must be alias, aliases, bgerror, eval, \
-                 expose, hide, hidden, issafe, invokehidden, marktrusted, \
+                 expose, hide, hidden, issafe, invokehidden, limit, marktrusted, \
                  recursionlimit, or transfer"
             )),
         }

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -992,10 +992,11 @@ impl Vm {
         self.hidden_commands.insert(cmd.to_string(), command);
     }
 
-    /// `interp expose {} cmd` — restore one of *this* interp's hidden commands.
-    pub(crate) fn expose_own_command(&mut self, cmd: &str) {
+    /// `interp expose {} hidden ?token?` — restore one of *this* interp's
+    /// hidden commands, optionally under a new name (`token`).
+    pub(crate) fn expose_own_command(&mut self, cmd: &str, token: &str) {
         if let Some(c) = self.hidden_commands.remove(cmd) {
-            self.commands.insert(cmd.to_string(), c);
+            self.commands.insert(token.to_string(), c);
         }
     }
 
@@ -1006,16 +1007,19 @@ impl Vm {
         names
     }
 
-    pub(crate) fn child_hide(&mut self, name: &str, cmd: &str, hide: bool) -> bool {
+    /// `interp hide|expose path cmd ?token?` on a child. When hiding, the
+    /// command `cmd` is filed under `token`; when exposing, the hidden `cmd` is
+    /// restored as the command `token`.
+    pub(crate) fn child_hide(&mut self, name: &str, cmd: &str, token: &str, hide: bool) -> bool {
         let Some(child) = self.children.get_mut(name) else {
             return false;
         };
         if hide {
             if let Some(c) = child.commands.remove(cmd) {
-                child.hidden_commands.insert(cmd.to_string(), c);
+                child.hidden_commands.insert(token.to_string(), c);
             }
         } else if let Some(c) = child.hidden_commands.remove(cmd) {
-            child.commands.insert(cmd.to_string(), c);
+            child.commands.insert(token.to_string(), c);
         }
         true
     }
@@ -1226,7 +1230,14 @@ impl Vm {
             }
             "hide" | "expose" if rest.len() == 1 => {
                 let hide = &*sub.to_str() == "hide";
-                self.child_hide(name, &rest[0].to_str(), hide);
+                if self.is_safe() {
+                    let verb = if hide { "hide" } else { "expose" };
+                    return err(format!(
+                        "permission denied: safe interpreter cannot {verb} commands"
+                    ));
+                }
+                let c = rest[0].to_str();
+                self.child_hide(name, &c, &c, hide);
                 ok(Value::empty())
             }
             "marktrusted" => {
@@ -1234,6 +1245,11 @@ impl Vm {
                 ok(Value::empty())
             }
             "invokehidden" if !rest.is_empty() => {
+                if self.is_safe() {
+                    return err(
+                        "not allowed to invoke hidden commands from safe interpreter",
+                    );
+                }
                 // Skip unmodelled `-namespace ns` / `--` flags.
                 let mut i = 0;
                 while i < rest.len() {

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -761,6 +761,25 @@ impl Vm {
                 self.hidden_commands.insert(c.to_string(), cmd);
             }
         }
+        // Remove the host-revealing `tcl_platform` elements (C's `Tcl_MakeSafe`
+        // unsets os/osVersion/machine/user) plus our backend-introspection keys,
+        // so a safe interp exposes only the portable subset.
+        const UNSAFE_PLATFORM: &[&str] = &[
+            "os",
+            "osVersion",
+            "machine",
+            "user",
+            "threaded",
+            "runtime",
+            "runtimeVersion",
+            "wasm",
+            "wasi",
+            "wasiVersion",
+            "ebpf",
+        ];
+        for &k in UNSAFE_PLATFORM {
+            let _ = self.unset_one(&format!("tcl_platform({k})"), false);
+        }
         self.is_safe = true;
     }
 

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -707,6 +707,46 @@ impl Vm {
         Some(child.recursion_limit_apply(newlimit))
     }
 
+    /// Sorted hidden-command names of a child (`interp hidden path`).
+    pub(crate) fn child_hidden_names(&self, name: &str) -> Option<Vec<String>> {
+        self.children.get(name).map(|c| {
+            let mut names: Vec<String> = c.hidden_commands.keys().cloned().collect();
+            names.sort();
+            names
+        })
+    }
+
+    /// `interp invokehidden path cmd ?arg ...?` — invoke a hidden command inside
+    /// the child. The command is temporarily restored to the child's visible
+    /// table for the call (then the previous binding is put back), so it runs in
+    /// the child without permanently un-hiding it. `None` if the child is gone.
+    pub(crate) fn invoke_hidden_in_child(
+        &mut self,
+        name: &str,
+        cmd: &str,
+        args: &[Value],
+    ) -> Option<Completion<Value>> {
+        let mut child = self.children.remove(name)?;
+        let result = match child.hidden_commands.get(cmd).cloned() {
+            None => err(format!("invalid hidden command name \"{cmd}\"")),
+            Some(hidden) => {
+                let saved = child.commands.insert(cmd.to_string(), hidden);
+                let r = child.invoke_command(cmd, args);
+                match saved {
+                    Some(prev) => {
+                        child.commands.insert(cmd.to_string(), prev);
+                    }
+                    None => {
+                        child.commands.remove(cmd);
+                    }
+                }
+                r
+            }
+        };
+        self.children.insert(name.to_string(), child);
+        Some(result)
+    }
+
     /// `interp marktrusted path` — clear a child's safe flag (exposing every
     /// hidden command). A no-op if the child does not exist.
     pub(crate) fn child_mark_trusted(&mut self, name: &str) {
@@ -721,7 +761,27 @@ impl Vm {
     /// `interp hide name` / `interp expose name` on a child: move a command
     /// between its visible and hidden tables. Returns `false` if the child is
     /// missing.
-    fn child_hide(&mut self, name: &str, cmd: &str, hide: bool) -> bool {
+    /// `interp hide {} cmd` — move one of *this* interp's commands into its
+    /// hidden table.
+    pub(crate) fn hide_own_command(&mut self, cmd: &str, command: Command) {
+        self.hidden_commands.insert(cmd.to_string(), command);
+    }
+
+    /// `interp expose {} cmd` — restore one of *this* interp's hidden commands.
+    pub(crate) fn expose_own_command(&mut self, cmd: &str) {
+        if let Some(c) = self.hidden_commands.remove(cmd) {
+            self.commands.insert(cmd.to_string(), c);
+        }
+    }
+
+    /// Sorted hidden-command names of *this* interp (`interp hidden {}`).
+    pub(crate) fn own_hidden_names(&self) -> Vec<String> {
+        let mut names: Vec<String> = self.hidden_commands.keys().cloned().collect();
+        names.sort();
+        names
+    }
+
+    pub(crate) fn child_hide(&mut self, name: &str, cmd: &str, hide: bool) -> bool {
         let Some(child) = self.children.get_mut(name) else {
             return false;
         };
@@ -756,14 +816,9 @@ impl Vm {
             "after",
             "vwait",
         ];
-        for &c in UNSAFE {
-            if let Some(cmd) = self.commands.remove(c) {
-                self.hidden_commands.insert(c.to_string(), cmd);
-            }
-        }
-        // Remove the host-revealing `tcl_platform` elements (C's `Tcl_MakeSafe`
-        // unsets os/osVersion/machine/user) plus our backend-introspection keys,
-        // so a safe interp exposes only the portable subset.
+        // The host-revealing `tcl_platform` elements (C's `Tcl_MakeSafe` unsets
+        // os/osVersion/machine/user) plus our backend-introspection keys, so a
+        // safe interp exposes only the portable subset.
         const UNSAFE_PLATFORM: &[&str] = &[
             "os",
             "osVersion",
@@ -777,6 +832,11 @@ impl Vm {
             "wasiVersion",
             "ebpf",
         ];
+        for &c in UNSAFE {
+            if let Some(cmd) = self.commands.remove(c) {
+                self.hidden_commands.insert(c.to_string(), cmd);
+            }
+        }
         for &k in UNSAFE_PLATFORM {
             let _ = self.unset_one(&format!("tcl_platform({k})"), false);
         }
@@ -947,6 +1007,29 @@ impl Vm {
             "marktrusted" => {
                 self.child_mark_trusted(name);
                 ok(Value::empty())
+            }
+            "invokehidden" if !rest.is_empty() => {
+                // Skip unmodelled `-namespace ns` / `--` flags.
+                let mut i = 0;
+                while i < rest.len() {
+                    match &*rest[i].to_str() {
+                        "-namespace" => i += 2,
+                        "--" => {
+                            i += 1;
+                            break;
+                        }
+                        s if s.starts_with('-') => i += 1,
+                        _ => break,
+                    }
+                }
+                match rest.get(i) {
+                    Some(cmd) => self
+                        .invoke_hidden_in_child(name, &cmd.to_str(), &rest[i + 1..])
+                        .unwrap_or_else(|| err(format!("could not find interpreter \"{name}\""))),
+                    None => err(format!(
+                        "wrong # args: should be \"{name} invokehidden ?-namespace ns? ?--? cmd ?arg ..?\""
+                    )),
+                }
             }
             "recursionlimit" if rest.len() <= 1 => {
                 let nl = rest.first().map(|v| v.to_str().to_string());

--- a/rust/tcl-vm/src/value.rs
+++ b/rust/tcl-vm/src/value.rs
@@ -230,9 +230,17 @@ impl Value {
                 Number::Big { .. } | Number::Nan { .. } => true,
             });
         }
-        match t.to_ascii_lowercase().as_str() {
-            "true" | "yes" | "on" => Ok(true),
-            "false" | "no" | "off" => Ok(false),
+        // C's `ParseBoolean` accepts any unambiguous case-insensitive *prefix*
+        // of true / false / yes / no / on / off (`tclObj.c`). A bare `o` is
+        // ambiguous between `on` and `off`, so it needs at least two characters.
+        let lower = t.to_ascii_lowercase();
+        match lower.chars().next() {
+            Some('t') if "true".starts_with(lower.as_str()) => Ok(true),
+            Some('y') if "yes".starts_with(lower.as_str()) => Ok(true),
+            Some('f') if "false".starts_with(lower.as_str()) => Ok(false),
+            Some('n') if "no".starts_with(lower.as_str()) => Ok(false),
+            Some('o') if lower.len() >= 2 && "on".starts_with(lower.as_str()) => Ok(true),
+            Some('o') if lower.len() >= 2 && "off".starts_with(lower.as_str()) => Ok(false),
             _ => Err(TclError::new(format!(
                 "expected boolean value but got {}",
                 list::describe_bad_value(&s)

--- a/rust/tcl-vm/tests/builtins_e2e.rs
+++ b/rust/tcl-vm/tests/builtins_e2e.rs
@@ -882,7 +882,7 @@ fn namespace_code_inscope() {
 
 #[test]
 fn package_stubs() {
-    out_eq("puts [package require Tcl 8.5-]\n", "9.0\n");
+    out_eq("puts [package require Tcl 8.5-]\n", "9.0.3\n");
     out_eq("puts [package vsatisfies 9.0 9.0-]\n", "1\n");
     out_eq("puts [package vsatisfies 8.4 8.5-]\n", "0\n");
     out_eq(

--- a/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
@@ -487,7 +487,7 @@ fn info_dispatch_and_abbreviation() {
 ///   info hostname   -> the host name
 ///   info coroutine  -> "" at top level (or the coroutine name)
 ///   info frame      -> a frame count / dict
-///   info object / info class -> TclOO introspection
+///   info object / info class -> `TclOO` introspection
 /// UNIMPLEMENTED in the VM (coverage limit, not a correctness bug on supported
 /// input): asserting the VM's actual error so the gap is pinned and visible.
 #[test]
@@ -628,7 +628,7 @@ fn namespace_which_command() {
 /// `namespace which -variable name` — tclsh resolves the variable's FQN, and the
 /// VM now honours the `-variable` flag and resolves the variable table.
 ///   script `namespace eval foo {variable v 1}; namespace which -variable ::foo::v`
-///   tclsh (both): "::foo::v" — matched by the VM (guards regression).
+///   tclsh (both): `::foo::v` — matched by the VM (guards regression).
 #[test]
 fn namespace_which_variable_bug() {
     let (ok, res, _) = run("namespace eval foo {variable v 1}; namespace which -variable ::foo::v");
@@ -987,9 +987,9 @@ fn namespace_eval_global_and_body_parse_error() {
 
 /// `namespace inscope` / `eval` bare (missing the script/body args). The VM's
 /// usage wording diverges slightly from tclsh9.0 — it reads `namespace`/`name`
-/// + `?arg ...?` where tclsh reads `name` + `?arg...?`. Asserting the VM's
-/// actual message and recording the divergence.
-/// Divergence (error text only), e.g. `namespace inscope foo`:
+/// plus `?arg ...?` where tclsh reads `name` plus `?arg...?`. Asserting the
+/// VM's actual message and recording the divergence (error text only), e.g.
+/// `namespace inscope foo`:
 ///   tclsh9.0: `wrong # args: should be "namespace inscope name arg ?arg...?"`
 ///   VM:       `wrong # args: should be "namespace inscope namespace arg ?arg ...?"`
 #[test]

--- a/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
@@ -746,17 +746,22 @@ fn namespace_forget_removes_imported_command() {
     assert_eq!(res, "1");
 }
 
-/// `namespace ensemble` is accepted as a no-op returning empty. In tclsh,
-/// `namespace ensemble create` builds an ensemble and returns its command name
-/// (`::` at the global scope). UNIMPLEMENTED no-op.
+/// `namespace ensemble create` builds an ensemble command and returns its
+/// fully-qualified name (`::` at the global scope), and the command dispatches
+/// subcommands to the namespace's exported procs.
 ///   tclsh (both): namespace ensemble create -> "::"
-///   VM:           namespace ensemble create -> ""
 #[test]
-fn namespace_ensemble_is_noop_in_vm() {
+fn namespace_ensemble_create_dispatches() {
     let (ok, res, _) = run("namespace ensemble create");
     assert!(ok, "must not error: {res}");
-    // VM no-op returns empty; tclsh returns "::".
-    assert_eq!(res, "");
+    assert_eq!(res, "::");
+    // A named ensemble dispatches `cmd sub` to the exported `ns::sub`.
+    let (ok, res, _) = run(concat!(
+        "namespace eval ns {namespace export greet; proc greet {} {return hi}; ",
+        "namespace ensemble create}; ns greet",
+    ));
+    assert!(ok, "must not error: {res}");
+    assert_eq!(res, "hi");
 }
 
 /// `namespace upvar` links a namespace variable into the current frame in tclsh.

--- a/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
@@ -730,21 +730,20 @@ fn namespace_dispatch_unknown_subcommand() {
     );
 }
 
-/// `namespace forget` is accepted as a no-op in the VM, so an imported command
-/// stays callable. In tclsh, `forget` removes the import (the command then
-/// errors). UNIMPLEMENTED no-op (metadata only).
+/// `namespace forget` removes a previously imported command, so a bare call to
+/// it then errors, matching tclsh.
 ///   tclsh (both): after forget, `catch {bar}` -> 1 (command removed)
-///   VM:           after forget, `catch {bar}` -> 0 (still imported)
-/// Asserting the VM's actual behaviour so the stub is pinned.
+///   VM:           after forget, `catch {bar}` -> 1 (command removed)
 #[test]
-fn namespace_forget_is_noop_in_vm() {
+fn namespace_forget_removes_imported_command() {
     let (ok, res, _) = run(concat!(
         "namespace eval foo {namespace export bar; proc bar {} {return B}}; ",
         "namespace import foo::bar; namespace forget foo::bar; catch {bar}",
     ));
     assert!(ok, "must not error: {res}");
-    // VM keeps the import (no-op); tclsh would yield "1" here.
-    assert_eq!(res, "0");
+    // `namespace forget` removes the imported `bar`, so the bare call errors
+    // (catch → 1), matching tclsh.
+    assert_eq!(res, "1");
 }
 
 /// `namespace ensemble` is accepted as a no-op returning empty. In tclsh,

--- a/tests/external/backend_constraints.tcl
+++ b/tests/external/backend_constraints.tcl
@@ -1,0 +1,156 @@
+# Backend constraint overlay for the upstream Tcl 9 tcltest suite.
+#
+# Source this AFTER `package require tcltest` and BEFORE sourcing a `.test`
+# file. It never edits the upstream library or test files (the suite is a
+# fixed contract); it only:
+#
+#   1. reads the backend-introspection keys our runtimes publish in
+#      `tcl_platform` (`runtime`, `wasm`, `wasi`, `wasiVersion`, `ebpf` — see
+#      `docs/design/runtime/backend-constraints.md`);
+#   2. registers tcltest constraints describing the running backend and its
+#      spec versions (`wasm`, `notWasm`, `wasi`, `ebpf`, `nativeRuntime`, ...);
+#   3. feeds `tcltest::configure -skip` the test-id globs the current backend
+#      cannot run, so those tests are *skipped* (matching how C tclsh skips
+#      `win` / `unix` / `nonPortable` tests) rather than failing.
+#
+# A native build skips nothing — every fact is empty, the backend is
+# `native`, and the suite runs in full. A wasm / WASI / eBPF build (or a
+# native binary asked to evaluate one via the `TCL_*_SPEC` overrides) skips
+# the impossible tests.
+
+namespace eval ::tcltest::backend {
+    namespace import ::tcltest::testConstraint
+
+    # --- read the introspection facts (absent on C tclsh / older builds) ---
+    proc Fact {key} {
+        if {[info exists ::tcl_platform($key)]} {
+            return $::tcl_platform($key)
+        }
+        return ""
+    }
+
+    variable runtime [Fact runtime]
+    variable wasm    [Fact wasm]
+    variable wasi    [Fact wasi]
+    variable ebpf    [Fact ebpf]
+
+    # --- classify the backend (most restrictive first) ---
+    # eBPF is the most constrained target, then WASI, then bare wasm, then a
+    # full native interpreter.
+    variable backend
+    if {$ebpf ne ""} {
+        set backend ebpf
+    } elseif {$wasi ne ""} {
+        set backend wasi
+    } elseif {$wasm ne ""} {
+        set backend wasm
+    } else {
+        set backend native
+    }
+
+    # --- register the backend / capability constraints --------------------
+    # A test guarded with one of these runs only on a matching backend; the
+    # `not*` forms are the complement, for tests that must NOT run there.
+    testConstraint native       [expr {$backend eq "native"}]
+    testConstraint nativeRuntime [expr {$backend eq "native"}]
+    testConstraint wasm         [expr {$wasm ne ""}]
+    testConstraint notWasm      [expr {$wasm eq ""}]
+    testConstraint wasi         [expr {$wasi ne ""}]
+    testConstraint notWasi      [expr {$wasi eq ""}]
+    testConstraint ebpf         [expr {$ebpf ne ""}]
+    testConstraint notEbpf      [expr {$ebpf eq ""}]
+
+    # Runtime-implementation constraints (which Rust interpreter is running).
+    testConstraint bytecodeRuntime [expr {$runtime eq "bytecode"}]
+    testConstraint treewalkRuntime [expr {$runtime eq "treewalk"}]
+
+    # Spec-version constraints. `VersionAtLeast` does a dotted-decimal compare
+    # so `wasi-0.2` is satisfied on a `0.2` build but not a `preview1` one.
+    # `preview1` sorts below any numeric version by design.
+    proc VersionAtLeast {have want} {
+        if {$have eq ""} {return 0}
+        # Map named WASI previews onto a comparable ordinal.
+        set order {preview1 0.1 preview2 0.2}
+        if {[dict exists $order $have]} {set have [dict get $order $have]}
+        if {[dict exists $order $want]} {set want [dict get $order $want]}
+        if {![string is double -strict $have] || ![string is double -strict $want]} {
+            return [string equal $have $want]
+        }
+        return [expr {$have >= $want}]
+    }
+
+    testConstraint wasm2        [VersionAtLeast $wasm 2.0]
+    testConstraint wasiPreview1 [expr {$wasi eq "preview1" || $wasi eq "0.1"}]
+    testConstraint wasiPreview2 [VersionAtLeast $wasi 0.2]
+
+    # --- exclusion table --------------------------------------------------
+    # Each row is {globs {backends...} reason}. A test whose name matches any
+    # glob is skipped when the current backend is in {backends...}. Keep this
+    # ordered by capability area and cite why; it is meant to grow as backend
+    # gaps are characterised. Globs match tcltest test names (e.g. `socket-3.2`).
+    variable Exclusions {
+        {
+            {socket-* socket_*}
+            {wasm wasi ebpf}
+            {stream sockets are unavailable (WASI preview1 has none; eBPF has no I/O)}
+        }
+        {
+            {exec-* exec_* pid-*}
+            {wasm wasi ebpf}
+            {no subprocess execution on any sandboxed backend}
+        }
+        {
+            {fileevent-* event-* async-* timer-*}
+            {wasm wasi ebpf}
+            {no event loop / async fileevents}
+        }
+        {
+            {io-* chan-* chanio-* iocmd-* iogt-* iortrans-*}
+            {wasm wasi ebpf}
+            {native channel / non-blocking / transform semantics unavailable}
+        }
+        {
+            {thread-* tpool-*}
+            {wasm wasi ebpf}
+            {no OS threads}
+        }
+        {
+            {load-* unload-*}
+            {wasm wasi ebpf}
+            {no dynamic library loading}
+        }
+        {
+            {clock-*}
+            {ebpf}
+            {no wall-clock / timezone database under eBPF}
+        }
+        {
+            {file-* glob-* cmdAH-* fCmd-* filesystem-* fileName-*}
+            {ebpf}
+            {no filesystem under eBPF}
+        }
+    }
+
+    # --- apply the skip globs for the current backend ---------------------
+    proc Apply {} {
+        variable Exclusions
+        variable backend
+        if {$backend eq "native"} {
+            return 0
+        }
+        set add {}
+        foreach row $Exclusions {
+            lassign $row globs backends _reason
+            if {$backend in $backends} {
+                foreach g $globs {lappend add $g}
+            }
+        }
+        if {[llength $add]} {
+            set cur [::tcltest::configure -skip]
+            ::tcltest::configure -skip [concat $cur $add]
+        }
+        return [llength $add]
+    }
+
+    variable applied [Apply]
+}


### PR DESCRIPTION
## Summary

- Builds out child and safe interpreters across **both** Rust engines — `rust/tcl-vm` (bytecode VM) and `runtime/rust` (tree-walk, the WASM target) — driving `interp.test` parity. Net `runtime/rust` `interp.test`: **170 → 223 passing**, no hangs.
- **`interp` subcommands** implemented/completed: `create` (incl. `-safe`), `eval`, `delete`, `exists`, `children`, `issafe`, `hide`/`expose`/`hidden`/`invokehidden`, `recursionlimit`, `limit`, `marktrusted`, `debug`, `bgerror`, plus the `$child <sub>` forms.
- **Safe-interp permission model**: a safe interpreter may not hide/expose/invoke hidden commands or mark trusted (checked against the *executing* interp), with C's exact error messages; `interp hide`/`expose` reject namespace-qualified tokens and non-global commands.
- **`interp limit`** (commands/time): full config (option prefix-matching, granularity/value validation, ms normalisation, the "limits on current interpreter inaccessible" guard) **and time-limit enforcement** — the bytecode trampoline (VM) and the `while`/`for` commands (both engines) poll a throttled wall-clock deadline so an unbounded loop under a time limit raises `time limit exceeded` instead of spinning. A guarded no-op when no limit is set.
- **Nested interpreter paths** (`runtime/rust`): a recursive `with_child_path` plus list-parsing the path argument, so `interp create {a b}` creates `b` inside child `a`, `interp eval {a b} …` runs in the grandchild, and results/errors propagate up the chain.
- **Supporting fixes**: `namespace ensemble create`, `namespace forget`, read traces firing on `info exists`/`set` reads, `info library` reading the global, pre-providing `tcl`/`Tcl` at 9.0.3, `::tcl::clock::*` ensemble members (so `clock seconds`/`milliseconds` resolve under `--init`), the `fpclassify` command + bignum→double coercion, re-homing a proc's namespace on cross-namespace rename, unambiguous boolean prefixes in `as_bool`.
- **Backend-constraint infrastructure**: a loadable overlay that adds wasm/wasi/ebpf constraints to the real test suite, backend-introspection keys published in `tcl_platform`, and harness wiring; plus the test-tier ladder and child-interpreter design docs.

Rebased onto the latest `rust` (incl. #728); clippy on this branch's code is clean (the two lints #728's sweep surfaced in `tcl-vm` — a bit-mask and an over-long fn — are fixed, and #728's own `tcl-vm` clippy fixes are preserved).

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

- `cd runtime/rust && cargo test --release` → 357 passed, 0 failed
- `cd rust && cargo test --release -p tcl-vm` → 0 failed
- `runtime/rust` interp.test driver: `runtime/rust/target/release/examples/run_script --init tmp/tcl9.0.3/tests/interp.test` → Total 354, Passed 223, no hang
- `tcl-vm` interp.test driver: `rust/tcl-vm/target/release/examples/run_test tmp/tcl9.0.3/tests/interp.test` → completes, no hang
- Lint (runtime): `cd runtime/rust && cargo fmt --check && cargo clippy --all-targets -- -D warnings` → clean
- Lint (VM): `cd rust && cargo clippy -p tcl-vm --lib -- -D warnings` → clean

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No. This touches the runtime interpreters (tcl-vm executor and the tree-walk runtime), not the compiler's fact contracts, diagnostics, or analysis.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`. — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JphmdfEq5TxfHR9dSNgq4Q)_