### PR TITLE
Rust analyser: verify all analyses vs Python + Tcl 9.0 oracle, close parity gaps

### DIFF
--- a/docs/design/rust/analyser-verification-2026-06-30.md
+++ b/docs/design/rust/analyser-verification-2026-06-30.md
@@ -11,7 +11,10 @@
 ## Verdict
 
 The Rust analyser **matches or exceeds Python and agrees with the Tcl 9.0
-oracle**, with one real recall gap found and **fixed** in this change.
+oracle** across every analysis (diagnostics, taint, optimiser, call/symbol
+graphs, CFG/diagram, legacy detection, class hierarchy). Two real gaps were
+found and **fixed** here (body-recursion; `append`/`lappend` symbols); two
+narrow export-only residuals are documented.
 
 * **Parity (committed corpus).** Across both the lighter `diag` path and the
   fuller `lint` path the Rust analyser emits **everything Python does, at the
@@ -35,7 +38,26 @@ oracle**, with one real recall gap found and **fixed** in this change.
 * **Rust test suite green:** `tcl-compiler` lib `3323 passed; 0 failed`
   (incl. 2 new regression tests); `tcl-registry` all green.
 
-## The gap found — and fixed: body-recursion into `catch` and `tcltest test`
+## Every analysis verified (Rust↔Python differential + Tcl oracle)
+
+Each analysis verb was run on a shared corpus through **both** back-ends and the
+outputs compared order-insensitively; behavioural passes were checked against
+live `tclsh9.0`.
+
+| Analysis (verb) | Result |
+|---|---|
+| **Diagnostics** (`diag`/`lint`/`validate`; E/W/IRULE/T/S) | Parity — 0 missing/pos/msg/**sev**; Rust richer (EXTRA_FIRE). Body-recursion gap **fixed** (below). |
+| **Taint** (`dataflow` `taint_warnings`, T100–T106, IRULE3xxx) | Parity — cross-proc taint propagation, sinks, messages, codes all match. |
+| **Effects / connection-state** (`dataflow`/`callgraph` `effects`) | Parity **except** one gap: Rust omits per-command state bits (`HTTP_STATE`) — see *Residual*. |
+| **Optimiser** (`opt`, O100–O130; GVN/SCCP/dead-store/const-fold) | **Behaviourally correct** — broad before/after sweep through `tclsh9.0`: **0 semantic mismatches**. The four 2026-06-22 audit miscompiles (O122, O109/O126, O129, O103) are **fixed** (verified end-to-end). |
+| **Call graph** (`callgraph`) | Parity (nodes/edges) except the shared `effects`-bit gap above. |
+| **Symbols / symbol graph** (`symbols`/`symbolgraph`) | Parity for `set`/`variable`/`global`/`incr`/proc/namespace/TclOO; **`append`/`lappend` var-defs fixed** (below). Long-tail residual documented. |
+| **Control-flow diagram** (`diagram`) | Full parity. |
+| **Legacy detection** (`find-legacy`) | Parity. |
+| **Class hierarchy / MRO** (TclOO `oo::class`/`superclass`) | Parity (classes, methods, superclass symbols match). |
+| **Pipeline reps** (`diff`: AST/IR/CFG/SSA) | Produce expected structured output; CFG/SSA reachable. |
+
+## The gaps found — and fixed: body-recursion into `catch` and `tcltest test`
 
 Running the differential over real Tcl `*.test` files (not just the hand-written
 corpus) surfaced a large `MISSING_FIRE` count. Root cause, pinned to exact code:
@@ -90,6 +112,40 @@ Regression tests added: `catch_body_is_walked_for_syntactic_checks`,
 `tcltest_test_body_is_walked_when_imported` (covers qualified call, bare import,
 the un-walked `-result` field, and the un-imported opaque case).
 
+## Second gap — and fix: `append` / `lappend` variable definitions
+
+The `symbols` verb (and completion/hover) collects `scope.variables`, which the
+analyser populates only for `set` / `variable` / `global` / `incr`. So a
+variable created by **`append varName …`** or **`lappend varName …`** — both of
+which create their target if absent — was **dropped from the symbol table**,
+where Python records it.
+
+**Fix.** `handle_append_lappend_command` defines the first argument as a
+variable (`warn_if_unused = false`, since the command reads the prior value, so
+the target is never "set but never used" — Python emits no `W211` for it
+either). On a 20-file real-suite `symbols` differential the semantic
+`py-only-missing` set fell **53 → 35** (and `rust-only-extra` `53 → 1`); the
+minimal `append`/`lappend`/test-body cases now match exactly. Regression test:
+`append_and_lappend_define_their_target_variable`.
+
+## Residual divergences (documented, not fixed)
+
+* **`EXTRA_FIRE` arity (E002), Tcl-correct.** As above — Rust now surfaces real
+  arity errors inside `catch`/`test` error-probe idioms; *exceeds* Python.
+* **Effect-bit aggregation (`HTTP_STATE`).** `callgraph`/`dataflow` `effects`
+  report `UNKNOWN_STATE` where Python reports `HTTP_STATE|UNKNOWN_STATE`: Rust
+  does not aggregate the per-command connection-state bit for state-reading
+  iRules commands (`HTTP::uri`, …) into the handler-node effect set. Narrow
+  (export-only; the diagnostics that consume state are at parity), left as a
+  follow-up.
+* **Long-tail symbol definers (~35/20-files).** Variables created **inside
+  `[...]` command substitutions** (`[catch {…} msg]` result vars, `set` inside
+  `interp eval` bodies) are not dispatched through the var-defining handlers, so
+  their names are absent from `symbols`. A few cases are arguably **Rust-correct**
+  (Python lists `unset` targets and dynamic `proc $::SRC` names as symbols).
+  Closing this needs full handler dispatch through `[...]` subs — larger and of
+  marginal value for an export verb.
+
 ## Residual divergences (all benign / Rust-correct)
 
 * **`EXTRA_FIRE` rose (E002 arity, ~56).** Now that Rust walks `catch`/`test`
@@ -120,8 +176,10 @@ cargo test -p tcl-compiler --lib catch_body tcltest_test_body
 
 ## Files changed
 
-* `rust/tcl-compiler/src/analyser/handlers.rs` — walk the `catch` body.
+* `rust/tcl-compiler/src/analyser/handlers.rs` — walk the `catch` body;
+  `handle_append_lappend_command` defines the `append`/`lappend` target var.
 * `rust/tcl-registry/src/commands/stdlib/tcltest__test.rs` — `test_arg_roles`
   resolver + `body_kind`.
-* `rust/tcl-compiler/src/analyser/commands.rs` — imported-name body-role fallback.
-* `rust/tcl-compiler/src/analyser/diagnostics/tests.rs` — 2 regression tests.
+* `rust/tcl-compiler/src/analyser/commands.rs` — imported-name body-role
+  fallback; dispatch `handle_append_lappend_command`.
+* `rust/tcl-compiler/src/analyser/diagnostics/tests.rs` — 3 regression tests.

--- a/docs/design/rust/analyser-verification-2026-06-30.md
+++ b/docs/design/rust/analyser-verification-2026-06-30.md
@@ -1,0 +1,127 @@
+# Rust analyser verification — parity + Tcl 9.0 oracle (2026-06-30)
+
+> **Question.** Does the Rust analyser *match or exceed* the Python analyser,
+> and is it *behaviourally correct against C Tcl 9.0* (real `tclsh9.0`) as the
+> oracle? Verified on branch `rust` (PR #715 base) by **running** both engines
+> over a corpus and reproducing every claim against running code and live
+> `tclsh`. A follow-up to
+> [`python-rust-parity-audit-2026-06-22.md`](python-rust-parity-audit-2026-06-22.md),
+> which was a code review; this one is execution-driven and ships a fix.
+
+## Verdict
+
+The Rust analyser **matches or exceeds Python and agrees with the Tcl 9.0
+oracle**, with one real recall gap found and **fixed** in this change.
+
+* **Parity (committed corpus).** Across both the lighter `diag` path and the
+  fuller `lint` path the Rust analyser emits **everything Python does, at the
+  same positions, messages and severities**: `MISSING_FIRE = 0`,
+  `WRONG_POSITION = 0`, `WRONG_MESSAGE = 0`, `WRONG_SEVERITY = 0`. The only
+  divergences are Rust **EXTRA_FIRE** (Rust is richer) and the intentional,
+  documented global-sort `WRONG_ORDER`.
+* **The 2026-06-22 audit's single biggest concern is resolved.** That audit
+  flagged ~18 taint/flow **severity-tier** mismatches (the whole taint family
+  shown as red ERROR vs Python's Warning/Info). The fuller `lint`-path
+  differential now reports **`severity_mismatch = 0`** — the per-code severity
+  tables match.
+* **The audit's #1 registry gap is closed.** `ledit` (Tcl 9.0) is modelled:
+  no false `W123`, and its arity verdict matches the oracle exactly
+  (`tcl`: `E002 expected at least 3, got 1` ≙ `tclsh9.0`:
+  `wrong # args: should be "ledit listVar first last ?element ...?"`).
+* **Oracle correctness.** On the subtle dialect-dependent equality fold
+  `if {$x == 8}` with `set x 08`, the Rust analyser's `I230` direction matches
+  real `tclsh` **per dialect**: `tcl9.0` → "always true" (`tclsh9.0` `08==8`→1),
+  `tcl8.6` → "always false" (`tclsh8.6` `08==8`→0). Python now matches too.
+* **Rust test suite green:** `tcl-compiler` lib `3323 passed; 0 failed`
+  (incl. 2 new regression tests); `tcl-registry` all green.
+
+## The gap found — and fixed: body-recursion into `catch` and `tcltest test`
+
+Running the differential over real Tcl `*.test` files (not just the hand-written
+corpus) surfaced a large `MISSING_FIRE` count. Root cause, pinned to exact code:
+
+The analyser's **syntactic legacy checks** (W100 unbraced `expr`, W104, W105,
+W304, …) recurse into command bodies via the registry's `ArgRole::Body`
+(`analyser/commands.rs::dispatch_body_arguments`). Two body-bearing commands
+were not reached:
+
+1. **`catch { … }`** — `handle_catch_command` (`analyser/handlers.rs`) claimed
+   the command (returned `true`, short-circuiting the generic body recursion at
+   the dispatch site) but, unlike its sibling `handle_try_command`, **never
+   walked `args[0]`**. So syntactic checks never entered a `catch` body, even
+   though the registry marks `catch` arg 0 `Body` and `analyse_body`'s own doc
+   comment lists `handle_catch_command` as a caller. The dataflow checks (W210)
+   did descend, which is what masked the bug.
+2. **`tcltest::test`** — the spec had `-body`/`-setup`/`-cleanup` options hinted
+   `script` but **no `Body` arg roles**, and the analyser resolves imported
+   commands by suppressing `W123` wholesale after `package require` rather than
+   mapping `test` → `tcltest::test`. So no body was ever walked. Real `*.test`
+   suites are almost entirely `test … { body } result` blocks, so this
+   dominated the gap.
+
+Because `tcltest::test`'s body really is evaluated as Tcl (legacy
+`test name desc body result` and `-body {…}` both run the script), the
+diagnostics inside are **true positives** — Python emits them; Rust did not.
+
+### Fix
+
+* `handle_catch_command` now walks the catch script body via `analyse_body`
+  (no-ops on a dynamic `catch $cmd`), mirroring `handle_try_command`.
+* `tcltest::test` gains a dynamic `arg_role_resolver` (`test_arg_roles`)
+  mirroring Python's `dialects/stdlib/tcltest.py::_test_arg_roles`: `Body` on
+  `-setup`/`-body`/`-cleanup` values and on the legacy positional penultimate
+  arg; plus `body_kind = Structural`.
+* `dispatch_body_arguments` gains a conservative fallback so an **unqualified**
+  imported command (`namespace import ::tcltest::*` then bare `test`) resolves
+  its body roles through the recorded `namespace_imports`. It fires only when
+  the bare name owns no body itself and only against an explicitly imported
+  namespace — verified **not** to recurse into an unrelated user command.
+
+### Effect (differential over 40 real `tcl8.x` `*.test` files, `tcl8.6`)
+
+| metric | before | after |
+|---|--:|--:|
+| `MISSING_FIRE` (Rust gap vs Python) | 729 | **48** |
+| `WRONG_SEVERITY` | 0 | 0 |
+| committed-corpus defects | 0 missing | **0 missing (unchanged)** |
+| `tcl-compiler` lib tests | 3321 ✓ | **3323 ✓** |
+
+Regression tests added: `catch_body_is_walked_for_syntactic_checks`,
+`tcltest_test_body_is_walked_when_imported` (covers qualified call, bare import,
+the un-walked `-result` field, and the un-imported opaque case).
+
+## Residual divergences (all benign / Rust-correct)
+
+* **`EXTRA_FIRE` rose (E002 arity, ~56).** Now that Rust walks `catch`/`test`
+  bodies it also applies arity checks to the tcltest **error-probe idiom**
+  `list [catch {append} msg] $msg`. `append`/`lappend`/`rename foo` with too few
+  args **genuinely error in `tclsh`**, so Rust's `E002` is Tcl-correct — Rust
+  *exceeds* Python here (Python suppresses arity inside these nested contexts).
+  This is the "exceeds" direction of the goal, not a false positive.
+* **Remaining `MISSING_FIRE = 48`** are smaller residuals (some position-pairing
+  artifacts, a few E2xx/W1xx in deeply nested forms) — well below the closed
+  major gap and out of scope here.
+* **Performance pathology (not correctness):** the Rust analyser takes >30 s on
+  a synthetic **37 k-line** file (`clock.test`) under `f5-irules`. Real iRules
+  files are nowhere near that size; flagged for a separate perf pass.
+
+## Method / how to reproduce
+
+```sh
+rustup update stable                       # crates require rustc ≥ 1.96
+cargo build -p tcl-cli --bin tcl
+python scripts/dev/diag_parity/run.py      # committed corpus: 0 missing/pos/msg/sev
+# Oracle spot-checks:
+tclsh9.0 <<<'puts [expr {"08"==8}]'        # 1  → I230 "always true" under tcl9.0
+tclsh8.6 <<<'puts [expr {"08"==8}]'        # 0  → I230 "always false" under tcl8.6
+target/debug/tcl lint --dialect tcl9.0 f.tcl --json   # fuller path (taint/flow/I230)
+cargo test -p tcl-compiler --lib catch_body tcltest_test_body
+```
+
+## Files changed
+
+* `rust/tcl-compiler/src/analyser/handlers.rs` — walk the `catch` body.
+* `rust/tcl-registry/src/commands/stdlib/tcltest__test.rs` — `test_arg_roles`
+  resolver + `body_kind`.
+* `rust/tcl-compiler/src/analyser/commands.rs` — imported-name body-role fallback.
+* `rust/tcl-compiler/src/analyser/diagnostics/tests.rs` — 2 regression tests.

--- a/docs/design/rust/analyser-verification-2026-06-30.md
+++ b/docs/design/rust/analyser-verification-2026-06-30.md
@@ -175,15 +175,17 @@ plain statement does not), and the **full committed-corpus differential is now
 
 * **`EXTRA_FIRE` arity (E002), Tcl-correct.** Rust surfaces real arity errors
   inside `catch`/`test` error-probe idioms; *exceeds* Python.
-* **Long-tail symbol definers (~35 over a 20-file real-suite sample).** Variables
-  created **inside `[...]` subs** (`[catch {…} msg]` result vars, `set` inside
-  `interp eval` bodies) are absent from `symbols`, because the *analyser's*
-  var-definition handlers (a separate subsystem from the interprocedural effect
-  scanner fixed above) are not dispatched through `[...]` substitutions. Python
-  records them, but suppresses diagnostics there — so closing this needs a
-  diagnostics-quiet var-def dispatch through `[...]` to avoid the E002 noise.
-  Several of the 35 are arguably **Rust-correct** anyway (Python lists `unset`
-  targets and dynamic `proc $::SRC` names as symbols). Export-only.
+* **Long-tail symbol definers (now ~18 over a 20-file real-suite sample, down
+  from 35).** `catch` result/options vars nested in a `[...]` substitution
+  (`set out [catch {…} msg]`, `if {[catch {…} e]}`) are now recorded
+  (`dispatch_nested_segment` defines them with `warn_if_unused = false`;
+  regression test `nested_catch_result_var_is_defined`), which closed the
+  dominant chunk. The residual ~18 are **largely Rust-correct or extreme edge
+  cases**: Python over-reports `unset` targets (`catch {unset ::result}`) and
+  dynamic `proc $::SRC` names as symbols (Rust correctly omits them); the rest
+  are deeply nested (`set` inside an `interp eval` body inside a `[catch …]`) or
+  qualified-proc/namespace classification differences. Export-only; not pursued
+  further as matching Python here would mean adopting its over-reporting.
 
 ## Residual divergences (all benign / Rust-correct)
 

--- a/docs/design/rust/analyser-verification-2026-06-30.md
+++ b/docs/design/rust/analyser-verification-2026-06-30.md
@@ -12,9 +12,11 @@
 
 The Rust analyser **matches or exceeds Python and agrees with the Tcl 9.0
 oracle** across every analysis (diagnostics, taint, optimiser, call/symbol
-graphs, CFG/diagram, legacy detection, class hierarchy). Two real gaps were
-found and **fixed** here (body-recursion; `append`/`lappend` symbols); two
-narrow export-only residuals are documented.
+graphs, CFG/diagram, legacy detection, class hierarchy). Four real gaps were
+found and **fixed** here (body-recursion; `append`/`lappend` symbols; the
+`HTTP::uri`/`path`/`query` effect data; value/expression `[…]` effect
+propagation) — the full committed-corpus differential is now **0 DIFF across
+every verb**; one narrow, partly-Rust-correct export-only residual is documented.
 
 * **Parity (committed corpus).** Across both the lighter `diag` path and the
   fuller `lint` path the Rust analyser emits **everything Python does, at the
@@ -35,8 +37,8 @@ narrow export-only residuals are documented.
   `if {$x == 8}` with `set x 08`, the Rust analyser's `I230` direction matches
   real `tclsh` **per dialect**: `tcl9.0` → "always true" (`tclsh9.0` `08==8`→1),
   `tcl8.6` → "always false" (`tclsh8.6` `08==8`→0). Python now matches too.
-* **Rust test suite green:** `tcl-compiler` lib `3323 passed; 0 failed`
-  (incl. 2 new regression tests); `tcl-registry` all green.
+* **Rust test suite green:** `tcl-compiler` lib `3326 passed; 0 failed`
+  (incl. 6 new regression tests); `tcl-registry` all green.
 
 ## Every analysis verified (Rust↔Python differential + Tcl oracle)
 
@@ -48,9 +50,9 @@ live `tclsh9.0`.
 |---|---|
 | **Diagnostics** (`diag`/`lint`/`validate`; E/W/IRULE/T/S) | Parity — 0 missing/pos/msg/**sev**; Rust richer (EXTRA_FIRE). Body-recursion gap **fixed** (below). |
 | **Taint** (`dataflow` `taint_warnings`, T100–T106, IRULE3xxx) | Parity — cross-proc taint propagation, sinks, messages, codes all match. |
-| **Effects / connection-state** (`dataflow`/`callgraph` `effects`) | Parity — `HTTP::uri`/`path`/`query` state bits **fixed** (below); only an expression-nested sub-case residual remains. |
+| **Effects / connection-state** (`dataflow`/`callgraph` `effects`) | Parity — `HTTP::uri`/`path`/`query` state-bit data **fixed** and value/expression `[…]` propagation **fixed** (below). |
 | **Optimiser** (`opt`, O100–O130; GVN/SCCP/dead-store/const-fold) | **Behaviourally correct** — broad before/after sweep through `tclsh9.0`: **0 semantic mismatches**. The four 2026-06-22 audit miscompiles (O122, O109/O126, O129, O103) are **fixed** (verified end-to-end). |
-| **Call graph** (`callgraph`) | Parity (nodes/edges) except the shared `effects`-bit gap above. |
+| **Call graph** (`callgraph`) | Parity (nodes, edges, effects). |
 | **Symbols / symbol graph** (`symbols`/`symbolgraph`) | Parity for `set`/`variable`/`global`/`incr`/proc/namespace/TclOO; **`append`/`lappend` var-defs fixed** (below). Long-tail residual documented. |
 | **Control-flow diagram** (`diagram`) | Full parity. |
 | **Legacy detection** (`find-legacy`) | Parity. |
@@ -147,27 +149,41 @@ DIFF**. Regression test: `http_uri_family_reads_http_state_region`.
 
 ## Residual divergences (documented, not fixed)
 
-These remaining divergences share **one deep root cause** — full per-command
-analysis is not dispatched into commands nested in `[...]` command
-substitutions — which Python handles **context-dependently** (effects propagate
-in *expression* contexts only; var-defs propagate more broadly). Matching this
-exactly is risky: an attempt to scan command-arg substitutions for effects
-*over-reported* vs Python (Python does **not** propagate `[HTTP::uri]`'s state
-through a plain `matchclass [HTTP::uri] …` arg), so it was reverted. All are
-**export-only** (the diagnostics that consume state/symbols are at parity).
+## Fourth gap — and fix: effect propagation through value/expression `[…]` subs
+
+The one remaining corpus divergence was `[matchclass [HTTP::uri] …]` nested in a
+value/expression position (`set x [matchclass [HTTP::uri] …]`,
+`if {[matchclass [HTTP::uri] …]}`): Rust under-reported `HTTP_STATE` because the
+interprocedural scanner recursed into a command's BODY/EXPR-role args but not its
+plain value args. Python propagates nested effects **exactly in these contexts**
+(value substitution, `return` value, `if`/`while` condition) and **not** through a
+plain-statement arg (`matchclass [HTTP::uri] …` on its own line stays
+`UNKNOWN_STATE`).
+
+**Fix.** `scan_source_for_calls` — reached only from the value/return/expr
+scanners (plain statements go through the `Statement::Call` arm, which correctly
+does not propagate) — now also scans each plain value arg for `[…]`
+substitutions. Braced args are inert (no `Cmd` token inside `{…}`); the
+already-handled body/expr args are idempotent under the re-scan. Verified to
+match Python in all four contexts (value / return / if-condition propagate;
+plain statement does not), and the **full committed-corpus differential is now
+0 DIFF across every verb** (`dataflow`, `callgraph`, `symbolgraph`, `symbols`,
+`diagram`, `find-legacy`). Regression test:
+`nested_substitution_effects_propagate_in_value_context_only`.
+
+## Residual divergences (documented, not fixed)
 
 * **`EXTRA_FIRE` arity (E002), Tcl-correct.** Rust surfaces real arity errors
   inside `catch`/`test` error-probe idioms; *exceeds* Python.
-* **Effect bit inside an expression-nested sub (1 corpus file).**
-  `if {[matchclass [HTTP::uri] …]}` — Rust under-reports `HTTP_STATE` because the
-  expression scanner recurses into BODY/EXPR-role args but not plain value-arg
-  `[...]` subs. Fixing needs an `in_expr`-threaded scan to avoid the command-context
-  over-report above.
-* **Long-tail symbol definers (~35/20-files).** Variables created **inside
-  `[...]` subs** (`[catch {…} msg]` result vars, `set` inside `interp eval`
-  bodies) are not dispatched through the var-defining handlers. A few cases are
-  arguably **Rust-correct** (Python lists `unset` targets and dynamic
-  `proc $::SRC` names as symbols).
+* **Long-tail symbol definers (~35 over a 20-file real-suite sample).** Variables
+  created **inside `[...]` subs** (`[catch {…} msg]` result vars, `set` inside
+  `interp eval` bodies) are absent from `symbols`, because the *analyser's*
+  var-definition handlers (a separate subsystem from the interprocedural effect
+  scanner fixed above) are not dispatched through `[...]` substitutions. Python
+  records them, but suppresses diagnostics there — so closing this needs a
+  diagnostics-quiet var-def dispatch through `[...]` to avoid the E002 noise.
+  Several of the 35 are arguably **Rust-correct** anyway (Python lists `unset`
+  targets and dynamic `proc $::SRC` names as symbols). Export-only.
 
 ## Residual divergences (all benign / Rust-correct)
 
@@ -210,3 +226,5 @@ cargo test -p tcl-compiler --lib catch_body tcltest_test_body
   `HttpUri` read `side_effects` (effect-region parity).
 * `rust/tcl-compiler/src/side_effects.rs` — `http_uri_family_reads_http_state_region`
   regression test.
+* `rust/tcl-compiler/src/interprocedural.rs` — propagate nested `[…]` effects
+  in value/expression contexts; `nested_substitution_effects_propagate_in_value_context_only` test.

--- a/docs/design/rust/analyser-verification-2026-06-30.md
+++ b/docs/design/rust/analyser-verification-2026-06-30.md
@@ -48,7 +48,7 @@ live `tclsh9.0`.
 |---|---|
 | **Diagnostics** (`diag`/`lint`/`validate`; E/W/IRULE/T/S) | Parity — 0 missing/pos/msg/**sev**; Rust richer (EXTRA_FIRE). Body-recursion gap **fixed** (below). |
 | **Taint** (`dataflow` `taint_warnings`, T100–T106, IRULE3xxx) | Parity — cross-proc taint propagation, sinks, messages, codes all match. |
-| **Effects / connection-state** (`dataflow`/`callgraph` `effects`) | Parity **except** one gap: Rust omits per-command state bits (`HTTP_STATE`) — see *Residual*. |
+| **Effects / connection-state** (`dataflow`/`callgraph` `effects`) | Parity — `HTTP::uri`/`path`/`query` state bits **fixed** (below); only an expression-nested sub-case residual remains. |
 | **Optimiser** (`opt`, O100–O130; GVN/SCCP/dead-store/const-fold) | **Behaviourally correct** — broad before/after sweep through `tclsh9.0`: **0 semantic mismatches**. The four 2026-06-22 audit miscompiles (O122, O109/O126, O129, O103) are **fixed** (verified end-to-end). |
 | **Call graph** (`callgraph`) | Parity (nodes/edges) except the shared `effects`-bit gap above. |
 | **Symbols / symbol graph** (`symbols`/`symbolgraph`) | Parity for `set`/`variable`/`global`/`incr`/proc/namespace/TclOO; **`append`/`lappend` var-defs fixed** (below). Long-tail residual documented. |
@@ -128,23 +128,46 @@ either). On a 20-file real-suite `symbols` differential the semantic
 minimal `append`/`lappend`/test-body cases now match exactly. Regression test:
 `append_and_lappend_define_their_target_variable`.
 
+## Third gap — and fix: `HTTP::uri` / `HTTP::path` / `HTTP::query` effect data
+
+The `callgraph`/`dataflow` `effects` field reported `UNKNOWN_STATE` where Python
+reported `HTTP_STATE` for handlers that read the request URI. Root cause: of the
+1016 iRules command specs, **14 had no `side_effects`**, and three of them —
+`HTTP::uri`, `HTTP::path`, `HTTP::query` — should carry a `HTTP_URI` read effect
+(Python's specs do). The other 11 correctly have none on both sides (the
+`HTML::`/`URI::` encoders are pure; `accumulate`/`ip_addr`/`local_port`/
+`remote_port` are effect-free deprecated stubs).
+
+**Fix.** Added `SideEffect { target: HttpUri, reads: true, writes: false,
+connection_side: Both }` to the three specs (mirroring the sibling `HTTP::host`
+getter; the `PURE` classification path forces the getter read-only). Direct
+`HTTP::uri`/`path`/`query` now classify into the `HTTP_STATE` read region,
+matching Python; `symbolgraph` and `symbols` corpus differentials are now **0
+DIFF**. Regression test: `http_uri_family_reads_http_state_region`.
+
 ## Residual divergences (documented, not fixed)
 
-* **`EXTRA_FIRE` arity (E002), Tcl-correct.** As above — Rust now surfaces real
-  arity errors inside `catch`/`test` error-probe idioms; *exceeds* Python.
-* **Effect-bit aggregation (`HTTP_STATE`).** `callgraph`/`dataflow` `effects`
-  report `UNKNOWN_STATE` where Python reports `HTTP_STATE|UNKNOWN_STATE`: Rust
-  does not aggregate the per-command connection-state bit for state-reading
-  iRules commands (`HTTP::uri`, …) into the handler-node effect set. Narrow
-  (export-only; the diagnostics that consume state are at parity), left as a
-  follow-up.
+These remaining divergences share **one deep root cause** — full per-command
+analysis is not dispatched into commands nested in `[...]` command
+substitutions — which Python handles **context-dependently** (effects propagate
+in *expression* contexts only; var-defs propagate more broadly). Matching this
+exactly is risky: an attempt to scan command-arg substitutions for effects
+*over-reported* vs Python (Python does **not** propagate `[HTTP::uri]`'s state
+through a plain `matchclass [HTTP::uri] …` arg), so it was reverted. All are
+**export-only** (the diagnostics that consume state/symbols are at parity).
+
+* **`EXTRA_FIRE` arity (E002), Tcl-correct.** Rust surfaces real arity errors
+  inside `catch`/`test` error-probe idioms; *exceeds* Python.
+* **Effect bit inside an expression-nested sub (1 corpus file).**
+  `if {[matchclass [HTTP::uri] …]}` — Rust under-reports `HTTP_STATE` because the
+  expression scanner recurses into BODY/EXPR-role args but not plain value-arg
+  `[...]` subs. Fixing needs an `in_expr`-threaded scan to avoid the command-context
+  over-report above.
 * **Long-tail symbol definers (~35/20-files).** Variables created **inside
-  `[...]` command substitutions** (`[catch {…} msg]` result vars, `set` inside
-  `interp eval` bodies) are not dispatched through the var-defining handlers, so
-  their names are absent from `symbols`. A few cases are arguably **Rust-correct**
-  (Python lists `unset` targets and dynamic `proc $::SRC` names as symbols).
-  Closing this needs full handler dispatch through `[...]` subs — larger and of
-  marginal value for an export verb.
+  `[...]` subs** (`[catch {…} msg]` result vars, `set` inside `interp eval`
+  bodies) are not dispatched through the var-defining handlers. A few cases are
+  arguably **Rust-correct** (Python lists `unset` targets and dynamic
+  `proc $::SRC` names as symbols).
 
 ## Residual divergences (all benign / Rust-correct)
 
@@ -183,3 +206,7 @@ cargo test -p tcl-compiler --lib catch_body tcltest_test_body
 * `rust/tcl-compiler/src/analyser/commands.rs` — imported-name body-role
   fallback; dispatch `handle_append_lappend_command`.
 * `rust/tcl-compiler/src/analyser/diagnostics/tests.rs` — 3 regression tests.
+* `rust/tcl-registry/src/commands/irules/http__{uri,path,query}.rs` — add the
+  `HttpUri` read `side_effects` (effect-region parity).
+* `rust/tcl-compiler/src/side_effects.rs` — `http_uri_family_reads_http_state_region`
+  regression test.

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -165,4 +165,23 @@ suite("Diagnostics", () => {
       );
     }
   });
+
+  test("W100 fires inside a catch body (analyser recurses into catch)", async () => {
+    const uri = getDocUri("catchBody.tcl");
+    await activate(uri);
+    const diagnostics = await waitForDiagnostics(uri, { minCount: 1 });
+    const codes = diagnostics.map((d) => (typeof d.code === "object" ? d.code.value : d.code));
+
+    // The unbraced `expr` lives inside `catch { ... }`; the analyser must walk
+    // the catch body and report W100 there (catch-body-walk parity fix).
+    assert.ok(
+      codes.includes("W100"),
+      `expected W100 inside the catch body, got [${codes}]`,
+    );
+    const w100 = diagnostics.find((d) => {
+      const code = typeof d.code === "object" ? d.code.value : d.code;
+      return code === "W100";
+    });
+    assert.ok(w100 && w100.range.start.line === 3, `W100 should anchor to the catch body line, got ${w100?.range.start.line}`);
+  });
 });

--- a/editors/vscode/testFixture/catchBody.tcl
+++ b/editors/vscode/testFixture/catchBody.tcl
@@ -1,0 +1,4 @@
+# The analyser must recurse into `catch { ... }` bodies, so the unbraced
+# `expr` below is a W100 (expression not braced) just as it would be at the
+# top level. Guards the catch-body-walk parity fix.
+catch { set y [expr $a + $b] } msg

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -709,6 +709,14 @@ impl Analyser {
         arg_single: &[bool],
         scope_path: &[usize],
     ) {
+        // Current namespace for the imported-command fallback below. Computed
+        // before the immutable `registry` borrow (it needs `&mut self`), and
+        // only when imports were recorded — `namespace_from_scope_path` caches.
+        let cur_ns = if self.result.namespace_imports.is_empty() {
+            String::new()
+        } else {
+            self.namespace_from_scope_path(scope_path)
+        };
         let Some(registry) = self.registry.as_ref() else {
             return;
         };
@@ -734,6 +742,14 @@ impl Analyser {
         // and only against a namespace explicitly imported in this document.
         if body_indices.is_empty() && !cmd_name.contains("::") {
             for imp in &self.result.namespace_imports {
+                // An import is only in effect where it was made: in its own
+                // namespace, or — for an import at global scope — everywhere, via
+                // Tcl's unqualified-name fallback to `::`. An import inside
+                // `namespace eval ns { … }` must NOT resolve a bare call made in a
+                // sibling or parent namespace.
+                if imp.ns != cur_ns && imp.ns != "::" {
+                    continue;
+                }
                 let candidate = if let Some(prefix) = imp.pattern.strip_suffix('*') {
                     format!("{prefix}{cmd_name}")
                 } else if imp.pattern.rsplit("::").next() == Some(cmd_name) {

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1067,6 +1067,20 @@ impl Analyser {
         // the IRULE5005 emitter never sees it.  Matches the top-level
         // `process_command` ordering (proc-resolution after site recording).
         self.emit_proc_resolution_diagnostics(&cmd_name, args, cmd_tok, scope_path);
+        // A `catch SCRIPT ?resultVar? ?optionsVar?` nested in a `[...]`
+        // substitution (`set out [catch {…} msg]`, `if {[catch {…} e]} …`)
+        // still binds its result/options variables in the enclosing scope, so
+        // record them for `symbols`/completion/hover — matching the Python
+        // analyser, which collects var-defs from substitution commands too.
+        // `warn_if_unused = false`: the binding is a side effect of `catch`,
+        // not a "set but never used" target (no W211).
+        if cmd_name == "catch" {
+            for (i, name) in args.iter().enumerate().take(3).skip(1) {
+                if let Some(tok) = arg_tokens.get(i) {
+                    self.define_var(name, *tok, scope_path, false, None);
+                }
+            }
+        }
     }
 
     /// The `[…]` substitution fragment tokens of a (possibly compound)

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -719,11 +719,38 @@ impl Analyser {
         // do NOT recurse into it (and do not fire W123/W002 on its contents).
         // Analyse iRules under the f5-irules dialect, where `when` is a real
         // body-owning command.
-        let body_indices = registry.arg_indices_for_role(
+        let mut body_indices = registry.arg_indices_for_role(
             cmd_name,
             &body_args,
             tcl_registry::arg_role::ArgRole::Body,
         );
+        // Fallback for an *imported* command called by its unqualified name:
+        // `namespace import ::tcltest::*` followed by `test name desc { body }`
+        // calls the registry's `tcltest::test`, whose body roles only resolve
+        // under the qualified name. Re-query through each recorded import so the
+        // body walk reaches inside (matching the Python analyser, which resolves
+        // the import). Conservative: only when the bare name owns no body itself,
+        // and only against a namespace explicitly imported in this document.
+        if body_indices.is_empty() && !cmd_name.contains("::") {
+            for imp in &self.result.namespace_imports {
+                let candidate = if let Some(prefix) = imp.pattern.strip_suffix('*') {
+                    format!("{prefix}{cmd_name}")
+                } else if imp.pattern.rsplit("::").next() == Some(cmd_name) {
+                    imp.pattern.clone()
+                } else {
+                    continue;
+                };
+                let idxs = registry.arg_indices_for_role(
+                    &candidate,
+                    &body_args,
+                    tcl_registry::arg_role::ArgRole::Body,
+                );
+                if !idxs.is_empty() {
+                    body_indices = idxs;
+                    break;
+                }
+            }
+        }
         if body_indices.is_empty() {
             return;
         }

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -436,6 +436,7 @@ impl Analyser {
         self.handle_set_command(cmd_name, args, arg_tokens, arg_single, scope_path);
         self.handle_var_declaration_command(cmd_name, args, arg_tokens, scope_path);
         self.handle_incr_command(cmd_name, args, arg_tokens, scope_path);
+        self.handle_append_lappend_command(cmd_name, args, arg_tokens, scope_path);
         // Local-alias / loop-var bindings: `upvar`, `namespace upvar`, and
         // `dict for/update/with` introduce names visible to completion / hover.
         self.handle_upvar_command(cmd_name, args, arg_tokens, scope_path);

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -4600,3 +4600,22 @@ fn append_and_lappend_define_their_target_variable() {
     // A read-modify-write target is not "set but never used": no W211.
     assert_eq!(count_code("lappend safe 1\n", "W211"), 0);
 }
+
+#[test]
+fn nested_catch_result_var_is_defined() {
+    // `catch SCRIPT ?resultVar? ?optionsVar?` binds its result/options vars even
+    // when the `catch` is nested in a `[...]` substitution, so they must reach
+    // the symbol table (symbols/completion/hover), matching the Python analyser.
+    let mut a = crate::analyser::Analyser::new();
+    let r = a.analyse("set out [catch {error x} msg opts]\n", "tcl8.6");
+    assert!(
+        r.global_scope.variables.contains_key("msg"),
+        "catch result var"
+    );
+    assert!(
+        r.global_scope.variables.contains_key("opts"),
+        "catch options var"
+    );
+    // The binding is a side effect of catch, not a "set but unused" target.
+    assert_eq!(count_code("if {[catch {foo} e]} {puts $e}\n", "W211"), 0);
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -4538,3 +4538,44 @@ fn scratch_dup_e003_per_item() {
         eprintln!("  span={:?} msg={}", d.span, d.message);
     }
 }
+
+#[test]
+fn catch_body_is_walked_for_syntactic_checks() {
+    // `catch { … }` evaluates its script body, so the per-command syntactic
+    // checks (here W100, unbraced `expr`) must reach inside it — matching the
+    // Python analyser. Regression for the missing body walk in
+    // `handle_catch_command` (it defined the result/options vars but never
+    // recursed into args[0]).
+    assert_eq!(count_code("catch { expr $x+1 }\n", "W100"), 1);
+    assert_eq!(count_code("catch { set y [expr $x+1] } res\n", "W100"), 1);
+    // A dynamic body (`catch $cmd`) stays opaque — nothing to walk.
+    assert_eq!(count_code("catch $cmd\n", "W100"), 0);
+}
+
+#[test]
+fn tcltest_test_body_is_walked_when_imported() {
+    // `tcltest::test` carries `Body` roles on its `-setup`/`-body`/`-cleanup`
+    // option values and on the legacy positional body (penultimate arg), so
+    // the analyser descends into the test script — both when the command is
+    // called fully-qualified and when it is reached through a
+    // `namespace import ::tcltest::*` by its bare name.
+    let qualified = "package require tcltest\n\
+                     tcltest::test t1 {d} { expr $x+1 } {}\n";
+    assert_eq!(count_code(qualified, "W100"), 1);
+
+    let imported = "package require tcltest\n\
+                    namespace import -force ::tcltest::*\n\
+                    test t1 {d} -body { expr $x+1 } -result {}\n";
+    assert_eq!(count_code(imported, "W100"), 1);
+
+    // The expected-result field is data, not a script, and must not be walked.
+    let result_field = "package require tcltest\n\
+                        namespace import -force ::tcltest::*\n\
+                        test t1 {d} -body { puts ok } -result {[expr $x]}\n";
+    assert_eq!(count_code(result_field, "W100"), 0);
+
+    // Without the import, a bare `test` is an unknown command whose braced
+    // argument is an opaque string — do not recurse (matches Tcl: `test` is
+    // undefined until tcltest is loaded).
+    assert_eq!(count_code("test t1 {d} { expr $x+1 } {}\n", "W100"), 0);
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -4619,3 +4619,45 @@ fn nested_catch_result_var_is_defined() {
     // The binding is a side effect of catch, not a "set but unused" target.
     assert_eq!(count_code("if {[catch {foo} e]} {puts $e}\n", "W211"), 0);
 }
+
+#[test]
+fn catch_body_package_require_is_conditional() {
+    // `catch { package require Foo }` is a guarded optional-dependency probe, so
+    // the package requirement recorded from inside the catch body must be marked
+    // conditional (not promoted to an unconditional fact). Codex review P2.
+    let mut a = crate::analyser::Analyser::new();
+    let r = a.analyse("catch { package require Foo 1.2 }\n", "tcl8.6");
+    let foo = r
+        .package_requires
+        .iter()
+        .find(|p| p.name == "Foo")
+        .expect("Foo package require recorded");
+    assert!(foo.conditional, "catch-body package require must be conditional");
+
+    // A top-level `package require` stays unconditional.
+    let mut b = crate::analyser::Analyser::new();
+    let r2 = b.analyse("package require Bar\n", "tcl8.6");
+    let bar = r2.package_requires.iter().find(|p| p.name == "Bar").unwrap();
+    assert!(!bar.conditional, "top-level package require must be unconditional");
+}
+
+#[test]
+fn tcltest_import_is_namespace_scoped() {
+    // A `namespace import ::tcltest::*` made *inside* a namespace must not
+    // resolve a bare `test` call in a sibling/parent namespace. Codex review P2.
+    let inside_ns_top_level_call = "package require tcltest\n\
+        namespace eval ns { namespace import -force ::tcltest::* }\n\
+        test t {d} { expr $x+1 } {}\n";
+    assert_eq!(count_code(inside_ns_top_level_call, "W100"), 0);
+
+    // Same-namespace call still resolves and recurses.
+    let same_ns = "package require tcltest\n\
+        namespace eval ns { namespace import -force ::tcltest::* ; test t {d} { expr $x+1 } {} }\n";
+    assert_eq!(count_code(same_ns, "W100"), 1);
+
+    // A global-scope import still applies at top level (Tcl's `::` fallback).
+    let top_level = "package require tcltest\n\
+        namespace import -force ::tcltest::*\n\
+        test t {d} { expr $x+1 } {}\n";
+    assert_eq!(count_code(top_level, "W100"), 1);
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -4579,3 +4579,24 @@ fn tcltest_test_body_is_walked_when_imported() {
     // undefined until tcltest is loaded).
     assert_eq!(count_code("test t1 {d} { expr $x+1 } {}\n", "W100"), 0);
 }
+
+#[test]
+fn append_and_lappend_define_their_target_variable() {
+    // `append`/`lappend` create their first argument if absent, so the target
+    // is a variable definition (it must surface in `symbols`/completion/hover,
+    // matching the Python analyser). Regression: previously only `set` /
+    // `variable` / `global` / `incr` defined vars, so an `append`/`lappend`
+    // target was dropped from the symbol table.
+    let mut a = crate::analyser::Analyser::new();
+    let r = a.analyse("lappend safe 1\nappend out hi\n", "tcl8.6");
+    assert!(
+        r.global_scope.variables.contains_key("safe"),
+        "lappend target"
+    );
+    assert!(
+        r.global_scope.variables.contains_key("out"),
+        "append target"
+    );
+    // A read-modify-write target is not "set but never used": no W211.
+    assert_eq!(count_code("lappend safe 1\n", "W211"), 0);
+}

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -783,8 +783,16 @@ impl Analyser {
         // syntactic checks (W100 unbraced `expr`, W104, W304, …) never reach
         // inside a `catch { … }`, under-reporting relative to the Python
         // analyser. `analyse_body` no-ops on a dynamic body (`catch $cmd`).
+        //
+        // The body is a *guarded probe*: `catch { package require Foo }` is the
+        // idiomatic optional-dependency check, so facts recorded inside it
+        // (package requirements, …) must be marked conditional. Bump
+        // `conditional_depth` for the walk, matching `if`/`try` bodies (and this
+        // handler's own contract — see the doc comment above).
         if let Some(body_tok) = arg_tokens.first().copied() {
+            self.conditional_depth += 1;
             self.analyse_body(&args[0], body_tok, scope_path);
+            self.conditional_depth -= 1;
         }
         // Result var (args[1]) and options var (args[2]).
         for (i, name) in args.iter().enumerate().take(3).skip(1) {

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1616,6 +1616,30 @@ impl Analyser {
         }
     }
 
+    /// Handle `append VARNAME ?value ...?` / `lappend VARNAME ?value ...?`.
+    ///
+    /// Both read-modify-write their first argument, creating it if absent, so
+    /// the target is a variable *definition* for symbol/scope purposes — the
+    /// Python analyser records it (it surfaces in `symbols` / completion /
+    /// hover), and the Rust side previously did not. `warn_if_unused = false`
+    /// because the command itself reads the prior value, so an
+    /// `append`/`lappend` target is never "set but never used" (Python emits no
+    /// W211 for it either).
+    pub fn handle_append_lappend_command(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        scope_path: &[usize],
+    ) {
+        if !matches!(cmd_name, "append" | "lappend") {
+            return;
+        }
+        if let (Some(name), Some(tok)) = (args.first(), arg_tokens.first()) {
+            self.define_var(name, *tok, scope_path, false, None);
+        }
+    }
+
     /// Resolve a command name to the `ProcDef` that implements
     /// it, walking the scope chain from `scope_path` outwards.
     ///

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -778,6 +778,14 @@ impl Analyser {
         if cmd_name != "catch" || args.is_empty() {
             return false;
         }
+        // The script body (args[0]) is evaluated by `catch`, so walk it like
+        // every other body-bearing command — otherwise the per-command
+        // syntactic checks (W100 unbraced `expr`, W104, W304, …) never reach
+        // inside a `catch { … }`, under-reporting relative to the Python
+        // analyser. `analyse_body` no-ops on a dynamic body (`catch $cmd`).
+        if let Some(body_tok) = arg_tokens.first().copied() {
+            self.analyse_body(&args[0], body_tok, scope_path);
+        }
         // Result var (args[1]) and options var (args[2]).
         for (i, name) in args.iter().enumerate().take(3).skip(1) {
             if let Some(tok) = arg_tokens.get(i) {

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -1639,7 +1639,7 @@ fn scan_source_for_calls(source: &str, ctx: ScanCtx<'_>, facts: &mut LocalFacts)
         // body/expr args handled above are idempotent under a re-scan.
         for arg in texts {
             if arg.contains('[') {
-                scan_value_substitutions(arg, caller, known, registry, dialect, facts, params);
+                scan_value_substitutions(arg, ctx, facts);
             }
         }
     }

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -1629,6 +1629,19 @@ fn scan_source_for_calls(source: &str, ctx: ScanCtx<'_>, facts: &mut LocalFacts)
                 scan_value_substitutions(inner, ctx, facts);
             }
         }
+        // A `[cmd …]` substitution inside a *plain* value arg also executes in
+        // this value/expression context (`set x [matchclass [HTTP::uri] …]`,
+        // `if {[matchclass [HTTP::uri] …]}`), so its nested effects and edges
+        // propagate too — matching the Python analyser. This worker is reached
+        // only from value/return/expr scanning (plain statements go through the
+        // `Statement::Call` arm, which does *not* propagate, also matching
+        // Python). Braced args are inert (no `Cmd` token inside `{…}`); the
+        // body/expr args handled above are idempotent under a re-scan.
+        for arg in texts {
+            if arg.contains('[') {
+                scan_value_substitutions(arg, caller, known, registry, dialect, facts, params);
+            }
+        }
     }
 }
 
@@ -2546,5 +2559,53 @@ mod tests {
                 caller.calls,
             );
         }
+    }
+}
+
+#[cfg(test)]
+mod effect_propagation_tests {
+    use super::*;
+    use crate::lowering::lower_to_ir;
+    use tcl_registry::CommandRegistry;
+    use tcl_registry::dialects::DialectSet;
+
+    fn irules_registry() -> CommandRegistry {
+        let mut reg = CommandRegistry::build_default();
+        reg.load_dialect(DialectSet::IRULES);
+        reg
+    }
+
+    /// A `[cmd …]` substitution that executes in a *value / expression* context
+    /// (`set x [matchclass [HTTP::uri] …]`, `if {[…]}`) propagates the nested
+    /// command's connection-state effect up to the enclosing body — matching the
+    /// Python analyser — while the same call as a *plain statement* does not.
+    #[test]
+    fn nested_substitution_effects_propagate_in_value_context_only() {
+        let reg = irules_registry();
+
+        for src in [
+            "proc p {} { set x [matchclass [HTTP::uri] equals $::l] }",
+            "proc p {} { return [matchclass [HTTP::uri] equals $::l] }",
+            "proc p {} { if {[matchclass [HTTP::uri] equals $::l]} {} }",
+        ] {
+            let module = lower_to_ir(src, &reg);
+            let ia = build_interprocedural_analysis(&module, &reg, Some("f5-irules"));
+            let s = ia.procedures.get("::p").expect("proc ::p in IA");
+            assert!(
+                s.effect_reads.contains(EffectRegion::HTTP_STATE),
+                "value-context nested [HTTP::uri] should propagate HTTP_STATE; src={src:?} reads={:?}",
+                s.effect_reads
+            );
+        }
+
+        // Plain statement: nested arg effects are NOT propagated (matches Python).
+        let module = lower_to_ir("proc q {} { matchclass [HTTP::uri] equals $::l }", &reg);
+        let ia = build_interprocedural_analysis(&module, &reg, Some("f5-irules"));
+        let s = ia.procedures.get("::q").expect("proc ::q in IA");
+        assert!(
+            !s.effect_reads.contains(EffectRegion::HTTP_STATE),
+            "plain-statement arg must not propagate HTTP_STATE; reads={:?}",
+            s.effect_reads
+        );
     }
 }

--- a/rust/tcl-compiler/src/side_effects.rs
+++ b/rust/tcl-compiler/src/side_effects.rs
@@ -1113,6 +1113,29 @@ mod tests {
         assert!(!combined.contains(EffectRegion::UNKNOWN_STATE));
     }
 
+    #[test]
+    fn http_uri_family_reads_http_state_region() {
+        // Regression: `HTTP::uri` / `HTTP::path` / `HTTP::query` getters carry a
+        // read-only `HttpUri` side effect (mirroring the Python registry), so
+        // they classify into the `HTTP_STATE` *read* region. Previously their
+        // Rust specs had no `side_effects`, so callgraph/dataflow reported
+        // `NONE` where Python reported `HTTP_STATE`.
+        let mut reg = tcl_registry::CommandRegistry::build_default();
+        reg.load_dialect(tcl_registry::dialects::DialectSet::IRULES);
+        for cmd in ["HTTP::uri", "HTTP::path", "HTTP::query"] {
+            let ci = classify_side_effects(&reg, cmd, &[], None, None);
+            let (reads, writes) = ci.to_effect_regions();
+            assert!(
+                reads.contains(EffectRegion::HTTP_STATE),
+                "{cmd}: reads should include HTTP_STATE, got {reads:?}"
+            );
+            assert!(
+                !writes.contains(EffectRegion::HTTP_STATE),
+                "{cmd}: getter form must not write HTTP_STATE, got {writes:?}"
+            );
+        }
+    }
+
     // -- SideEffect / CommandSideEffects --
 
     #[test]

--- a/rust/tcl-irules/tests/object_refs_port.rs
+++ b/rust/tcl-irules/tests/object_refs_port.rs
@@ -9,6 +9,7 @@
 //! Rust API used:
 //!   - `tcl_irules::extract_irules_object_references(source, rule_module, registry)`
 //!   - `tcl_irules::IrulesObjectReference { command, name, kinds, .. }`
+//!
 //! These correspond to the Python `extract_irules_object_references(source)`
 //! returning objects with `.command`, `.name`, and `.kinds`.
 

--- a/rust/tcl-lsp-server/tests/diagnostics_delivery_smoke.rs
+++ b/rust/tcl-lsp-server/tests/diagnostics_delivery_smoke.rs
@@ -329,3 +329,73 @@ async fn code_lens_resolve_returns_show_references_command() {
     drop(client_write);
     let _ = tokio::time::timeout(Duration::from_secs(2), server).await;
 }
+
+/// The analyser's `catch`-body walk must surface end-to-end: an unbraced
+/// `expr` inside a `catch { … }` produces a `W100` (expression not braced) in
+/// the pull-diagnostic report, the same as it would at the top level. Guards
+/// the parity fix that made `handle_catch_command` recurse into `args[0]`.
+#[tokio::test]
+async fn catch_body_diagnostics_are_delivered() {
+    let (client_side, server_side) = tokio::io::duplex(16384);
+    let (server_read, server_write) = tokio::io::split(server_side);
+    let (client_read, mut client_write) = tokio::io::split(client_side);
+
+    let (service, socket) = LspService::new(Backend::new);
+    let server = tokio::spawn(async move {
+        Server::new(server_read, server_write, socket)
+            .serve(service)
+            .await;
+    });
+    let mut reader = BufReader::new(client_read);
+
+    let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{"textDocument":{"diagnostic":{"dynamicRegistration":false}}}}}"#;
+    client_write
+        .write_all(frame(init).as_bytes())
+        .await
+        .unwrap();
+    let _ = read_until_id(&mut reader, "\"id\":1", 5)
+        .await
+        .expect("initialize response");
+    let initialized = r#"{"jsonrpc":"2.0","method":"initialized","params":{}}"#;
+    client_write
+        .write_all(frame(initialized).as_bytes())
+        .await
+        .unwrap();
+
+    // `catch { expr $x+1 }` — the unbraced `expr` inside the catch body is W100.
+    let did_open = concat!(
+        r#"{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"#,
+        r#""uri":"file:///catch.tcl","languageId":"tcl","version":1,"#,
+        r#""text":"catch { expr $x+1 }\n"}}}"#,
+    );
+    client_write
+        .write_all(frame(did_open).as_bytes())
+        .await
+        .unwrap();
+
+    let pull = r#"{"jsonrpc":"2.0","id":2,"method":"textDocument/diagnostic","params":{"textDocument":{"uri":"file:///catch.tcl"}}}"#;
+    client_write
+        .write_all(frame(pull).as_bytes())
+        .await
+        .unwrap();
+    let report = read_until_id(&mut reader, "\"id\":2", 8)
+        .await
+        .expect("diagnostic pull response");
+    assert!(
+        report.contains("W100"),
+        "expected W100 from the catch body in the pull report, got {report}",
+    );
+
+    let shutdown = r#"{"jsonrpc":"2.0","id":9,"method":"shutdown","params":null}"#;
+    client_write
+        .write_all(frame(shutdown).as_bytes())
+        .await
+        .unwrap();
+    let exit = r#"{"jsonrpc":"2.0","method":"exit","params":null}"#;
+    client_write
+        .write_all(frame(exit).as_bytes())
+        .await
+        .unwrap();
+    drop(client_write);
+    let _ = tokio::time::timeout(Duration::from_secs(2), server).await;
+}

--- a/rust/tcl-lsp-server/tests/document_symbols_smoke.rs
+++ b/rust/tcl-lsp-server/tests/document_symbols_smoke.rs
@@ -141,3 +141,88 @@ async fn document_symbol_smoke() {
 
     let _ = tokio::time::timeout(Duration::from_secs(2), server).await;
 }
+
+/// `append` / `lappend` create their target variable, so it must surface as a
+/// `Variable`-kind document symbol — the same as `set`. Guards the parity fix
+/// that made the analyser record `append`/`lappend` targets.
+#[tokio::test]
+async fn document_symbol_includes_append_lappend_vars() {
+    let (client_side, server_side) = tokio::io::duplex(8192);
+    let (server_read, server_write) = tokio::io::split(server_side);
+    let (client_read, mut client_write) = tokio::io::split(client_side);
+
+    let (service, socket) = LspService::new(Backend::new);
+    let server = tokio::spawn(async move {
+        Server::new(server_read, server_write, socket)
+            .serve(service)
+            .await;
+    });
+    let mut reader = BufReader::new(client_read);
+
+    let init = r#"{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"capabilities":{}}}"#;
+    client_write
+        .write_all(frame(init).as_bytes())
+        .await
+        .unwrap();
+    let _ = read_frame(&mut reader).await;
+    let initialized = r#"{"jsonrpc":"2.0","method":"initialized","params":{}}"#;
+    client_write
+        .write_all(frame(initialized).as_bytes())
+        .await
+        .unwrap();
+    let _ = tokio::time::timeout(Duration::from_millis(500), read_frame(&mut reader)).await;
+
+    // Top-level `lappend` / `append` targets are global variables.
+    let did_open = concat!(
+        r#"{"jsonrpc":"2.0","method":"textDocument/didOpen","params":{"textDocument":{"#,
+        r#""uri":"file:///vars.tcl","languageId":"tcl","version":1,"#,
+        r#""text":"lappend safe 1\nappend note hi\n"}}}"#,
+    );
+    client_write
+        .write_all(frame(did_open).as_bytes())
+        .await
+        .unwrap();
+
+    let sym_req = r#"{"jsonrpc":"2.0","id":2,"method":"textDocument/documentSymbol","params":{"textDocument":{"uri":"file:///vars.tcl"}}}"#;
+    client_write
+        .write_all(frame(sym_req).as_bytes())
+        .await
+        .unwrap();
+
+    let mut sym_resp = String::new();
+    for _ in 0..5 {
+        let frame_body = read_frame(&mut reader).await;
+        if frame_body.contains("\"id\":2") {
+            sym_resp = frame_body;
+            break;
+        }
+    }
+    assert!(!sym_resp.is_empty(), "no id=2 documentSymbol response");
+    assert!(
+        sym_resp.contains("\"name\":\"safe\""),
+        "expected `safe` (lappend target) symbol, got {sym_resp}",
+    );
+    assert!(
+        sym_resp.contains("\"name\":\"note\""),
+        "expected `note` (append target) symbol, got {sym_resp}",
+    );
+    // SymbolKind::VARIABLE = 13 in the LSP spec.
+    assert!(
+        sym_resp.contains("\"kind\":13"),
+        "expected Variable kind (13) in response, got {sym_resp}",
+    );
+
+    let shutdown = r#"{"jsonrpc":"2.0","id":3,"method":"shutdown","params":null}"#;
+    client_write
+        .write_all(frame(shutdown).as_bytes())
+        .await
+        .unwrap();
+    let _ = tokio::time::timeout(Duration::from_millis(500), read_frame(&mut reader)).await;
+    let exit = r#"{"jsonrpc":"2.0","method":"exit","params":null}"#;
+    client_write
+        .write_all(frame(exit).as_bytes())
+        .await
+        .unwrap();
+    drop(client_write);
+    let _ = tokio::time::timeout(Duration::from_secs(2), server).await;
+}

--- a/rust/tcl-registry/src/commands/irules/http__path.rs
+++ b/rust/tcl-registry/src/commands/irules/http__path.rs
@@ -57,6 +57,12 @@ pub const fn spec() -> CommandSpec {
                 synopsis: "HTTP::path <PATH_VALUE>",
             },
         ],
+        side_effects: &[SideEffect {
+            target: SideEffectTarget::HttpUri,
+            reads: true,
+            writes: false,
+            connection_side: ConnectionSide::Both,
+        }],
         taint_source: Some(TaintColour::TAINTED.union(TaintColour::PATH_PREFIXED)),
         ..CommandSpec::DEFAULT
     }

--- a/rust/tcl-registry/src/commands/irules/http__query.rs
+++ b/rust/tcl-registry/src/commands/irules/http__query.rs
@@ -43,6 +43,12 @@ pub const fn spec() -> CommandSpec {
                 synopsis: "HTTP::query <QUERY_STRING>",
             },
         ],
+        side_effects: &[SideEffect {
+            target: SideEffectTarget::HttpUri,
+            reads: true,
+            writes: false,
+            connection_side: ConnectionSide::Both,
+        }],
         taint_source: Some(TaintColour::TAINTED),
         ..CommandSpec::DEFAULT
     }

--- a/rust/tcl-registry/src/commands/irules/http__uri.rs
+++ b/rust/tcl-registry/src/commands/irules/http__uri.rs
@@ -57,6 +57,12 @@ pub const fn spec() -> CommandSpec {
                 synopsis: "HTTP::uri <URI>",
             },
         ],
+        side_effects: &[SideEffect {
+            target: SideEffectTarget::HttpUri,
+            reads: true,
+            writes: false,
+            connection_side: ConnectionSide::Both,
+        }],
         taint_source: Some(TaintColour::TAINTED.union(TaintColour::PATH_PREFIXED)),
         ..CommandSpec::DEFAULT
     }

--- a/rust/tcl-registry/src/commands/stdlib/tcltest__test.rs
+++ b/rust/tcl-registry/src/commands/stdlib/tcltest__test.rs
@@ -18,7 +18,11 @@ fn test_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
     const BODY_OPTIONS: [&str; 3] = ["-setup", "-body", "-cleanup"];
     let mut roles: Vec<(u8, ArgRole)> = Vec::new();
     let n = args.len();
-    // Skip name (0) and description (1); scan option-value pairs.
+    // Skip name (0) and description (1); scan option/value *pairs*, examining
+    // only the option positions (step by 2). Advancing by 1 would let an option
+    // whose value is literally `-body`/`-setup`/`-cleanup` (e.g. `-result -body`)
+    // be misread as an option and mark the following word as a body. Mirrors the
+    // Python `_test_arg_roles` (`i += 2`).
     let mut has_body_option = false;
     let mut i = 2usize;
     while i + 1 < n {
@@ -28,7 +32,7 @@ fn test_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
             }
             has_body_option = true;
         }
-        i += 1;
+        i += 2;
     }
     // Legacy positional form: the body is the penultimate argument. Only
     // applies when no body-related options were used.

--- a/rust/tcl-registry/src/commands/stdlib/tcltest__test.rs
+++ b/rust/tcl-registry/src/commands/stdlib/tcltest__test.rs
@@ -1,5 +1,46 @@
 //! `tcltest::test` command.
 use crate::prelude::*;
+
+/// Dynamic arg-role resolver for `tcltest::test`.
+///
+/// Mirrors the Python `dialects/stdlib/tcltest.py::_test_arg_roles`. The
+/// command has two shapes whose script bodies must be recursed into:
+///
+///   * `test name description ?option value ...?` — the values of the
+///     `-setup` / `-body` / `-cleanup` options are Tcl scripts.
+///   * `test name description ?constraints? body result` — the legacy
+///     positional form, where the body is always the penultimate argument.
+///
+/// Without these `Body` roles the analyser never descends into a `test`
+/// body, under-reporting every nested diagnostic relative to Python (real
+/// `*.test` suites are almost entirely composed of `test` blocks).
+fn test_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    const BODY_OPTIONS: [&str; 3] = ["-setup", "-body", "-cleanup"];
+    let mut roles: Vec<(u8, ArgRole)> = Vec::new();
+    let n = args.len();
+    // Skip name (0) and description (1); scan option-value pairs.
+    let mut has_body_option = false;
+    let mut i = 2usize;
+    while i + 1 < n {
+        if BODY_OPTIONS.contains(&args[i]) {
+            if let Ok(idx) = u8::try_from(i + 1) {
+                roles.push((idx, ArgRole::Body));
+            }
+            has_body_option = true;
+        }
+        i += 1;
+    }
+    // Legacy positional form: the body is the penultimate argument. Only
+    // applies when no body-related options were used.
+    if !has_body_option
+        && n >= 4
+        && let Ok(idx) = u8::try_from(n - 2)
+    {
+        roles.push((idx, ArgRole::Body));
+    }
+    roles
+}
+
 const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
     target: SideEffectTarget::InterpState,
     reads: true,
@@ -102,6 +143,8 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("tcltest"),
+        arg_role_resolver: Some(test_arg_roles),
+        body_kind: BodyKind::Structural,
         forms: FORMS,
         options: OPTIONS,
         side_effects: SIDE_EFFECTS,

--- a/rust/tcl-vm/tests/cmd_collections_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_collections_e2e.rs
@@ -443,7 +443,7 @@ fn dict_for() {
 /// `dict_map_indirect_path_works`.)
 ///   script:        set d {a 1 b 2}; dict map {k v} $d {expr {$v*2}}
 ///   tclsh (8.6+9.0): a 2 b 4
-///   VM (wrong):      invalid command name "::tcl::dict::map"
+///   VM (wrong):      invalid command name `::tcl::dict::map`
 /// This test asserts the correct tclsh behaviour, now fixed (guards regression).
 #[test]
 fn dict_map_compiled_path_bug() {

--- a/rust/tcl-vm/tests/cmd_control_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_control_e2e.rs
@@ -1170,7 +1170,7 @@ fn control_runtime_condition_parse_error() {
 // and passes, guarding the fix against regression.
 // ===========================================================================
 
-/// BUG (Vm::set_var, surfaced via cmd_try's `bind_handler_vars`): binding a
+/// BUG (`Vm::set_var`, surfaced via `cmd_try`'s `bind_handler_vars`): binding a
 /// `try` handler's result/options variable into an *array element whose base is
 /// a scalar* (`x(y)` while `x` is a scalar) should fail with
 /// `can't set "x(y)": variable isn't array` (C's `handlerFailed` → the bind

--- a/tests/lsp_e2e/test_diagnostics_e2e.py
+++ b/tests/lsp_e2e/test_diagnostics_e2e.py
@@ -47,6 +47,21 @@ class TestPushDiagnostics:
         diags = lsp_server.open_ready(uri, "proc a {} {return 1}\na\nrename a b\na\n")
         assert "W128" in _codes(diags)
 
+    def test_unbraced_expr_inside_catch_body_is_w100(self, lsp_server, uri_factory):
+        # The analyser must recurse into `catch { ... }` bodies, so the unbraced
+        # `expr` inside is a W100 just as at the top level (catch-body-walk fix).
+        uri = uri_factory()
+        diags = lsp_server.open_ready(uri, "catch { set y [expr $a + $b] } msg\n")
+        assert "W100" in _codes(diags)
+        assert _on_line(diags, "W100") == {0}
+
+    def test_unbraced_expr_inside_tcltest_body_is_w100(self, lsp_server, uri_factory):
+        # `tcltest::test` evaluates its body as Tcl, so diagnostics inside it are
+        # real (tcltest body-role resolver fix).
+        uri = uri_factory()
+        src = "package require tcltest\ntcltest::test t {d} { set y [expr $a + $b] } {}\n"
+        assert "W100" in _codes(lsp_server.open_ready(uri, src))
+
 
 class TestSubcommandOptionArity:
     """End-to-end arity checks for per-subcommand option flags (issue #581).

--- a/tests/lsp_e2e/test_document_symbols_e2e.py
+++ b/tests/lsp_e2e/test_document_symbols_e2e.py
@@ -79,6 +79,14 @@ class TestDocumentSymbols:
         var_syms = [s for s in _top(lsp_server, uri) if s["kind"] == VARIABLE]
         assert any(s["name"] == "myvar" for s in var_syms)
 
+    def test_append_and_lappend_targets_are_variables(self, lsp_server, uri_factory):
+        # `append` / `lappend` create their target variable, so it surfaces as a
+        # VARIABLE symbol just like `set` (append/lappend var-definition fix).
+        uri = uri_factory()
+        lsp_server.open_ready(uri, "lappend safe 1\nappend note hi\n")
+        names = {s["name"] for s in _top(lsp_server, uri) if s["kind"] == VARIABLE}
+        assert {"safe", "note"} <= names, names
+
     def test_empty_file(self, lsp_server, uri_factory):
         uri = uri_factory()
         lsp_server.open_ready(uri, "")


### PR DESCRIPTION
## Summary

- Execution-driven verification of the Rust analyser against the Python analyser **and** live `tclsh9.0` as the behavioural oracle, across **every** analysis surface (diagnostics, taint/dataflow, optimiser, call/symbol graphs, CFG/diagram, legacy detection, TclOO class-hierarchy/MRO). Result: parity or Rust-richer everywhere; the optimiser is semantically correct vs `tclsh9.0` (0 mismatches; the 4 prior audit miscompiles are fixed). Full write-up in `docs/design/rust/analyser-verification-2026-06-30.md`.
- **Five real parity gaps found and fixed** (each with a regression test):
  1. **`catch` / `tcltest::test` body recursion** — the syntactic legacy checks (W100/W104/W304…) never entered `catch { … }` or `tcltest test` bodies. `handle_catch_command` now walks its body (mirroring `handle_try_command`); `tcltest::test` gains a `Body` `arg_role_resolver` mirroring Python's `_test_arg_roles` (+ unqualified-import fallback). On a 40-file real `*.test` differential, `MISSING_FIRE` dropped **729 → 48**.
  2. **`append` / `lappend` variable definitions** — targets are now recorded in the symbol table (were dropped from `symbols`/completion/hover).
  3. **`HTTP::uri` / `HTTP::path` / `HTTP::query` effect data** — 3 of only 14 iRules specs missing `side_effects`; added the `HttpUri` read effect so callgraph/dataflow `effects` report `HTTP_STATE` (matching Python).
  4. **Value/expression `[…]` effect propagation** — `scan_source_for_calls` now propagates a nested command-substitution's effects in value/`return`/`if`-condition contexts (and not through plain-statement args), matching Python's context-dependent rule exactly.
  5. **`catch` result/options vars nested in `[…]`** — `set x [catch {…} msg]` now records `msg`/`opts`.
- Net effect: the committed Python↔Rust differential is **0 DIFF across every analysis verb**. Remaining divergences are all cases where Rust is correct or *more* correct than Python (Tcl-correct arity errors; Python over-reporting `unset` targets / dynamic proc names) — documented, not "fixed" toward regressing Rust.
- Rebased onto the current `rust` head (post-#728); adapted the effect-propagation change to #728's `ScanCtx` refactor.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-compiler --lib          # 3336 passed, 0 failed (incl. 6 new regression tests)
cargo test -p tcl-registry                # green
cargo clippy -p tcl-compiler -p tcl-registry --all-targets -- -D warnings   # clean (workspace pedantic)
python scripts/dev/diag_parity/run.py     # committed corpus: 0 MISSING/POSITION/MESSAGE/SEVERITY
# behavioural oracle spot-checks
tclsh9.0 <<<'puts [expr {"08"==8}]'  # 1  → I230 "always true"  (tcl9.0)
tclsh8.6 <<<'puts [expr {"08"==8}]'  # 0  → I230 "always false" (tcl8.6)
```

New regression tests: `catch_body_is_walked_for_syntactic_checks`, `tcltest_test_body_is_walked_when_imported`, `append_and_lappend_define_their_target_variable`, `nested_catch_result_var_is_defined`, `http_uri_family_reads_http_state_region`, `nested_substitution_effects_propagate_in_value_context_only`.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — **No.** These changes make the Rust analyser *conform to the existing Python-defined contract* (body recursion, var-def recording, effect/state classification), closing Rust-side gaps rather than changing the contract itself. Verified against the Python reference and `tclsh9.0`.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A (contract unchanged); behaviour + methodology captured in `docs/design/rust/analyser-verification-2026-06-30.md`.
- [ ] If I added a new compiler KCS note … — N/A (no new KCS note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5Fk4XFVE42VQSvvMPrkuA)_