### PR TITLE
fix(vscode): unblock test-ext — prettier-format sources, exclude generated

### DIFF
--- a/editors/vscode/.prettierignore
+++ b/editors/vscode/.prettierignore
@@ -1,2 +1,3 @@
 out
 node_modules
+src/generated

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -353,9 +353,7 @@ export async function activate(context: ExtensionContext) {
     synchronize: {
       configurationSection: "tclLsp",
       fileEvents: [
-        workspace.createFileSystemWatcher(
-          "**/*.{tcl,tk,itcl,tm,irul,irule,iapp,iappimpl,impl}",
-        ),
+        workspace.createFileSystemWatcher("**/*.{tcl,tk,itcl,tm,irul,irule,iapp,iappimpl,impl}"),
         // Project config — the server live-reloads its layered settings when
         // a workspace `.tcl-lsp.ini` changes.
         workspace.createFileSystemWatcher("**/.tcl-lsp.ini"),
@@ -834,9 +832,7 @@ async function selectTclInstallation(): Promise<void> {
     paths = picked.paths ?? [];
   }
 
-  const target = workspace.workspaceFolders?.length
-    ? undefined
-    : vscode.ConfigurationTarget.Global;
+  const target = workspace.workspaceFolders?.length ? undefined : vscode.ConfigurationTarget.Global;
   await workspace.getConfiguration("tclLsp").update("libraryPaths", paths, target);
   window.showInformationMessage(
     paths.length > 0

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -174,15 +174,15 @@ suite("Diagnostics", () => {
 
     // The unbraced `expr` lives inside `catch { ... }`; the analyser must walk
     // the catch body and report W100 there (catch-body-walk parity fix).
-    assert.ok(
-      codes.includes("W100"),
-      `expected W100 inside the catch body, got [${codes}]`,
-    );
+    assert.ok(codes.includes("W100"), `expected W100 inside the catch body, got [${codes}]`);
     const w100 = diagnostics.find((d) => {
       const code = typeof d.code === "object" ? d.code.value : d.code;
       return code === "W100";
     });
-    assert.ok(w100 && w100.range.start.line === 3, `W100 should anchor to the catch body line, got ${w100?.range.start.line}`);
+    assert.ok(
+      w100 && w100.range.start.line === 3,
+      `W100 should anchor to the catch body line, got ${w100?.range.start.line}`,
+    );
   });
 
   test("S110 fires for byte-array corruption (string op on a byte array)", async () => {


### PR DESCRIPTION
The v2.1.1 tag build's `test-ext` failed at prettier `format:check` on 3 files (latent on `rust`; only tag/main CI runs test-ext).

- `extension.ts`, `test/diagnostics.test.ts`: hand-written, prettier-dirty → reformatted (pinned prettier 3.6.2).
- `generated/diagnosticCatalog.ts`: generated — the xtask generator emits double-quoted literals while prettier prefers single quotes; that file is governed by the `gen-editor-settings --check` drift gate, so excluded `src/generated` from prettier instead of fighting the generator.

format:check + eslint pass; drift gate stays green. Unblocks the v2.1.1 pre-release re-tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)