### PR TITLE
Amortize iRule-test stub sourcing: ~1500 procs → one data table (20.6s → 2.7s)

### DIFF
--- a/rust/tcl-irule-test/src/live.rs
+++ b/rust/tcl-irule-test/src/live.rs
@@ -308,9 +308,10 @@ mod tests {
         // (category, action) — the data table replaced ~1500 per-command stub
         // procs, so guard that the decision log is unchanged for a stub-only
         // command (`ACCESS::session` -> {access session}).
+        let decisions = s.decisions().unwrap();
         assert!(
-            s.decisions().unwrap().contains("access session"),
-            "stub dispatch must record the decision under its real category/action"
+            decisions.contains("access session"),
+            "stub dispatch must record the decision under its real category/action; got: {decisions}"
         );
     }
 

--- a/rust/tcl-irule-test/src/live.rs
+++ b/rust/tcl-irule-test/src/live.rs
@@ -304,6 +304,14 @@ mod tests {
             "web",
             "stub-only ACCESS::session must dispatch, not abort the handler"
         );
+        // The generic stub must log the call under the command's real
+        // (category, action) — the data table replaced ~1500 per-command stub
+        // procs, so guard that the decision log is unchanged for a stub-only
+        // command (`ACCESS::session` -> {access session}).
+        assert!(
+            s.decisions().unwrap().contains("access session"),
+            "stub dispatch must record the decision under its real category/action"
+        );
     }
 
     #[test]

--- a/rust/tcl-irule-test/tcl/_mock_stubs.tcl
+++ b/rust/tcl-irule-test/tcl/_mock_stubs.tcl
@@ -1,7812 +1,1512 @@
-# _mock_stubs.tcl -- AUTO-GENERATED stub mocks for iRule commands
+# _mock_stubs.tcl -- AUTO-GENERATED stub action table for iRule commands
 #
-# DO NOT EDIT.  Regenerate with:
-#   python -m tooling.irule_test.codegen_mock_stubs
+# DO NOT EDIT.  Regenerate from compiler/registry via xtask (the former
+# `python -m tooling.irule_test.codegen_mock_stubs` generator was retired with
+# the Python tree; see docs history).
 #
-# These stubs provide minimal mock implementations for iRule commands
-# that do not have hand-written mocks in command_mocks.tcl.  Each stub
-# logs the call to the decision log and returns an empty string.
+# These entries provide minimal mock behaviour for iRule commands that do not
+# have hand-written mocks in command_mocks.tcl.  Formerly each command had its
+# own generated stub proc (`proc <name> {args} { log_decision <cat> <act> ...
+# }`); defining ~1500 such procs cost ~9.7 s of VM proc-body compilation on
+# every fresh session.  They are now a single data table consumed by the one
+# generic `::itest::cmd::_stub` proc below and wired up on demand by
+# `::itest::cmd::register_all`, which is behaviourally identical (same decision
+# log) but parses as one list literal instead of ~1500 proc bodies.
 #
 # Source: compiler/registry/
 #
 # Copyright (c) 2024 tcl-lsp contributors.  MIT licence.
 
-
 namespace eval ::itest::cmd {
 
-    # AAA:: stubs (4 commands)
-
-    proc aaa_acct_result {args} {
-        ::itest::log_decision aaa acct_result $args
-        return ""
-    }
-
-    proc aaa_acct_send {args} {
-        ::itest::log_decision aaa acct_send $args
-        return ""
-    }
-
-    proc aaa_auth_result {args} {
-        ::itest::log_decision aaa auth_result $args
-        return ""
-    }
-
-    proc aaa_auth_send {args} {
-        ::itest::log_decision aaa auth_send $args
-        return ""
-    }
-
-
-    # ACCESS:: stubs (15 commands)
-
-    proc access_acl {args} {
-        ::itest::log_decision access acl $args
-        return ""
-    }
-
-    proc access_disable {args} {
-        ::itest::log_decision access disable $args
-        return ""
-    }
-
-    proc access_enable {args} {
-        ::itest::log_decision access enable $args
-        return ""
-    }
-
-    proc access_ephemeral_auth {args} {
-        ::itest::log_decision access ephemeral-auth $args
-        return ""
-    }
-
-    proc access_flowid {args} {
-        ::itest::log_decision access flowid $args
-        return ""
-    }
-
-    proc access_log {args} {
-        ::itest::log_decision access log $args
-        return ""
-    }
-
-    proc access_oauth {args} {
-        ::itest::log_decision access oauth $args
-        return ""
-    }
-
-    proc access_perflow {args} {
-        ::itest::log_decision access perflow $args
-        return ""
-    }
-
-    proc access_policy {args} {
-        ::itest::log_decision access policy $args
-        return ""
-    }
-
-    proc access_respond {args} {
-        ::itest::log_decision access respond $args
-        return ""
-    }
-
-    proc access_restrict_irule_events {args} {
-        ::itest::log_decision access restrict_irule_events $args
-        return ""
-    }
-
-    proc access_saml {args} {
-        ::itest::log_decision access saml $args
-        return ""
-    }
-
-    proc access_session {args} {
-        ::itest::log_decision access session $args
-        return ""
-    }
-
-    proc access_user {args} {
-        ::itest::log_decision access user $args
-        return ""
-    }
-
-    proc access_uuid {args} {
-        ::itest::log_decision access uuid $args
-        return ""
-    }
-
-
-    # ACCESS2:: stubs (1 commands)
-
-    proc access2_access2_proc {args} {
-        ::itest::log_decision access2 access2_proc $args
-        return ""
-    }
-
-
-    # ACL:: stubs (2 commands)
-
-    proc acl_action {args} {
-        ::itest::log_decision acl action $args
-        return ""
-    }
-
-    proc acl_eval {args} {
-        ::itest::log_decision acl eval $args
-        return ""
-    }
-
-
-    # ADAPT:: stubs (12 commands)
-
-    proc adapt_allow {args} {
-        ::itest::log_decision adapt allow $args
-        return ""
-    }
-
-    proc adapt_context_create {args} {
-        ::itest::log_decision adapt context_create $args
-        return ""
-    }
-
-    proc adapt_context_current {args} {
-        ::itest::log_decision adapt context_current $args
-        return ""
-    }
-
-    proc adapt_context_delete_all {args} {
-        ::itest::log_decision adapt context_delete_all $args
-        return ""
-    }
-
-    proc adapt_context_name {args} {
-        ::itest::log_decision adapt context_name $args
-        return ""
-    }
-
-    proc adapt_context_static {args} {
-        ::itest::log_decision adapt context_static $args
-        return ""
-    }
-
-    proc adapt_enable {args} {
-        ::itest::log_decision adapt enable $args
-        return ""
-    }
-
-    proc adapt_preview_size {args} {
-        ::itest::log_decision adapt preview_size $args
-        return ""
-    }
-
-    proc adapt_result {args} {
-        ::itest::log_decision adapt result $args
-        return ""
-    }
-
-    proc adapt_select {args} {
-        ::itest::log_decision adapt select $args
-        return ""
-    }
-
-    proc adapt_service_down_action {args} {
-        ::itest::log_decision adapt service_down_action $args
-        return ""
-    }
-
-    proc adapt_timeout {args} {
-        ::itest::log_decision adapt timeout $args
-        return ""
-    }
-
-
-    # AES:: stubs (3 commands)
-
-    proc aes_decrypt {args} {
-        ::itest::log_decision aes decrypt $args
-        return ""
-    }
-
-    proc aes_encrypt {args} {
-        ::itest::log_decision aes encrypt $args
-        return ""
-    }
-
-    proc aes_key {args} {
-        ::itest::log_decision aes key $args
-        return ""
-    }
-
-
-    # AM:: stubs (7 commands)
-
-    proc am_age {args} {
-        ::itest::log_decision am age $args
-        return ""
-    }
-
-    proc am_application {args} {
-        ::itest::log_decision am application $args
-        return ""
-    }
-
-    proc am_cache {args} {
-        ::itest::log_decision am cache $args
-        return ""
-    }
-
-    proc am_disable {args} {
-        ::itest::log_decision am disable $args
-        return ""
-    }
-
-    proc am_expires {args} {
-        ::itest::log_decision am expires $args
-        return ""
-    }
-
-    proc am_media_playlist {args} {
-        ::itest::log_decision am media_playlist $args
-        return ""
-    }
-
-    proc am_policy_node {args} {
-        ::itest::log_decision am policy_node $args
-        return ""
-    }
-
-
-    # ANTIFRAUD:: stubs (39 commands)
-
-    proc antifraud_alert_additional_info {args} {
-        ::itest::log_decision antifraud alert_additional_info $args
-        return ""
-    }
-
-    proc antifraud_alert_bait_signatures {args} {
-        ::itest::log_decision antifraud alert_bait_signatures $args
-        return ""
-    }
-
-    proc antifraud_alert_component {args} {
-        ::itest::log_decision antifraud alert_component $args
-        return ""
-    }
-
-    proc antifraud_alert_defined_value {args} {
-        ::itest::log_decision antifraud alert_defined_value $args
-        return ""
-    }
-
-    proc antifraud_alert_details {args} {
-        ::itest::log_decision antifraud alert_details $args
-        return ""
-    }
-
-    proc antifraud_alert_device_id {args} {
-        ::itest::log_decision antifraud alert_device_id $args
-        return ""
-    }
-
-    proc antifraud_alert_expected_value {args} {
-        ::itest::log_decision antifraud alert_expected_value $args
-        return ""
-    }
-
-    proc antifraud_alert_fingerprint {args} {
-        ::itest::log_decision antifraud alert_fingerprint $args
-        return ""
-    }
-
-    proc antifraud_alert_forbidden_added_element {args} {
-        ::itest::log_decision antifraud alert_forbidden_added_element $args
-        return ""
-    }
-
-    proc antifraud_alert_guid {args} {
-        ::itest::log_decision antifraud alert_guid $args
-        return ""
-    }
-
-    proc antifraud_alert_html {args} {
-        ::itest::log_decision antifraud alert_html $args
-        return ""
-    }
-
-    proc antifraud_alert_http_referrer {args} {
-        ::itest::log_decision antifraud alert_http_referrer $args
-        return ""
-    }
-
-    proc antifraud_alert_id {args} {
-        ::itest::log_decision antifraud alert_id $args
-        return ""
-    }
-
-    proc antifraud_alert_license_id {args} {
-        ::itest::log_decision antifraud alert_license_id $args
-        return ""
-    }
-
-    proc antifraud_alert_min {args} {
-        ::itest::log_decision antifraud alert_min $args
-        return ""
-    }
-
-    proc antifraud_alert_origin {args} {
-        ::itest::log_decision antifraud alert_origin $args
-        return ""
-    }
-
-    proc antifraud_alert_resolved_value {args} {
-        ::itest::log_decision antifraud alert_resolved_value $args
-        return ""
-    }
-
-    proc antifraud_alert_score {args} {
-        ::itest::log_decision antifraud alert_score $args
-        return ""
-    }
-
-    proc antifraud_alert_transaction_data {args} {
-        ::itest::log_decision antifraud alert_transaction_data $args
-        return ""
-    }
-
-    proc antifraud_alert_transaction_id {args} {
-        ::itest::log_decision antifraud alert_transaction_id $args
-        return ""
-    }
-
-    proc antifraud_alert_type {args} {
-        ::itest::log_decision antifraud alert_type $args
-        return ""
-    }
-
-    proc antifraud_alert_username {args} {
-        ::itest::log_decision antifraud alert_username $args
-        return ""
-    }
-
-    proc antifraud_alert_view_id {args} {
-        ::itest::log_decision antifraud alert_view_id $args
-        return ""
-    }
-
-    proc antifraud_client_id {args} {
-        ::itest::log_decision antifraud client_id $args
-        return ""
-    }
-
-    proc antifraud_device_id {args} {
-        ::itest::log_decision antifraud device_id $args
-        return ""
-    }
-
-    proc antifraud_disable {args} {
-        ::itest::log_decision antifraud disable $args
-        return ""
-    }
-
-    proc antifraud_disable_alert {args} {
-        ::itest::log_decision antifraud disable_alert $args
-        return ""
-    }
-
-    proc antifraud_disable_app_layer_encryption {args} {
-        ::itest::log_decision antifraud disable_app_layer_encryption $args
-        return ""
-    }
-
-    proc antifraud_disable_auto_transactions {args} {
-        ::itest::log_decision antifraud disable_auto_transactions $args
-        return ""
-    }
-
-    proc antifraud_disable_injection {args} {
-        ::itest::log_decision antifraud disable_injection $args
-        return ""
-    }
-
-    proc antifraud_disable_malware {args} {
-        ::itest::log_decision antifraud disable_malware $args
-        return ""
-    }
-
-    proc antifraud_disable_phishing {args} {
-        ::itest::log_decision antifraud disable_phishing $args
-        return ""
-    }
-
-    proc antifraud_enable {args} {
-        ::itest::log_decision antifraud enable $args
-        return ""
-    }
-
-    proc antifraud_enable_log {args} {
-        ::itest::log_decision antifraud enable_log $args
-        return ""
-    }
-
-    proc antifraud_fingerprint {args} {
-        ::itest::log_decision antifraud fingerprint $args
-        return ""
-    }
-
-    proc antifraud_geo {args} {
-        ::itest::log_decision antifraud geo $args
-        return ""
-    }
-
-    proc antifraud_guid {args} {
-        ::itest::log_decision antifraud guid $args
-        return ""
-    }
-
-    proc antifraud_result {args} {
-        ::itest::log_decision antifraud result $args
-        return ""
-    }
-
-    proc antifraud_username {args} {
-        ::itest::log_decision antifraud username $args
-        return ""
-    }
-
-
-    # ASM:: stubs (25 commands)
-
-    proc asm_captcha {args} {
-        ::itest::log_decision asm captcha $args
-        return ""
-    }
-
-    proc asm_captcha_age {args} {
-        ::itest::log_decision asm captcha_age $args
-        return ""
-    }
-
-    proc asm_captcha_status {args} {
-        ::itest::log_decision asm captcha_status $args
-        return ""
-    }
-
-    proc asm_client_ip {args} {
-        ::itest::log_decision asm client_ip $args
-        return ""
-    }
-
-    proc asm_conviction {args} {
-        ::itest::log_decision asm conviction $args
-        return ""
-    }
-
-    proc asm_deception {args} {
-        ::itest::log_decision asm deception $args
-        return ""
-    }
-
-    proc asm_disable {args} {
-        ::itest::log_decision asm disable $args
-        return ""
-    }
-
-    proc asm_enable {args} {
-        ::itest::log_decision asm enable $args
-        return ""
-    }
-
-    proc asm_fingerprint {args} {
-        ::itest::log_decision asm fingerprint $args
-        return ""
-    }
-
-    proc asm_is_authenticated {args} {
-        ::itest::log_decision asm is_authenticated $args
-        return ""
-    }
-
-    proc asm_login_status {args} {
-        ::itest::log_decision asm login_status $args
-        return ""
-    }
-
-    proc asm_microservice {args} {
-        ::itest::log_decision asm microservice $args
-        return ""
-    }
-
-    proc asm_payload {args} {
-        ::itest::log_decision asm payload $args
-        return ""
-    }
-
-    proc asm_policy {args} {
-        ::itest::log_decision asm policy $args
-        return ""
-    }
-
-    proc asm_raise {args} {
-        ::itest::log_decision asm raise $args
-        return ""
-    }
-
-    proc asm_severity {args} {
-        ::itest::log_decision asm severity $args
-        return ""
-    }
-
-    proc asm_signature {args} {
-        ::itest::log_decision asm signature $args
-        return ""
-    }
-
-    proc asm_status {args} {
-        ::itest::log_decision asm status $args
-        return ""
-    }
-
-    proc asm_support_id {args} {
-        ::itest::log_decision asm support_id $args
-        return ""
-    }
-
-    proc asm_threat_campaign {args} {
-        ::itest::log_decision asm threat_campaign $args
-        return ""
-    }
-
-    proc asm_unblock {args} {
-        ::itest::log_decision asm unblock $args
-        return ""
-    }
-
-    proc asm_uncaptcha {args} {
-        ::itest::log_decision asm uncaptcha $args
-        return ""
-    }
-
-    proc asm_username {args} {
-        ::itest::log_decision asm username $args
-        return ""
-    }
-
-    proc asm_violation {args} {
-        ::itest::log_decision asm violation $args
-        return ""
-    }
-
-    proc asm_violation_data {args} {
-        ::itest::log_decision asm violation_data $args
-        return ""
-    }
-
-
-    # ASN1:: stubs (3 commands)
-
-    proc asn1_decode {args} {
-        ::itest::log_decision asn1 decode $args
-        return ""
-    }
-
-    proc asn1_element {args} {
-        ::itest::log_decision asn1 element $args
-        return ""
-    }
-
-    proc asn1_encode {args} {
-        ::itest::log_decision asn1 encode $args
-        return ""
-    }
-
-
-    # AUTH:: stubs (18 commands)
-
-    proc auth_abort {args} {
-        ::itest::log_decision auth abort $args
-        return ""
-    }
-
-    proc auth_authenticate {args} {
-        ::itest::log_decision auth authenticate $args
-        return ""
-    }
-
-    proc auth_authenticate_continue {args} {
-        ::itest::log_decision auth authenticate_continue $args
-        return ""
-    }
-
-    proc auth_cert_credential {args} {
-        ::itest::log_decision auth cert_credential $args
-        return ""
-    }
-
-    proc auth_cert_issuer_credential {args} {
-        ::itest::log_decision auth cert_issuer_credential $args
-        return ""
-    }
-
-    proc auth_last_event_session_id {args} {
-        ::itest::log_decision auth last_event_session_id $args
-        return ""
-    }
-
-    proc auth_password_credential {args} {
-        ::itest::log_decision auth password_credential $args
-        return ""
-    }
-
-    proc auth_response_data {args} {
-        ::itest::log_decision auth response_data $args
-        return ""
-    }
-
-    proc auth_ssl_cc_ldap_status {args} {
-        ::itest::log_decision auth ssl_cc_ldap_status $args
-        return ""
-    }
-
-    proc auth_ssl_cc_ldap_username {args} {
-        ::itest::log_decision auth ssl_cc_ldap_username $args
-        return ""
-    }
-
-    proc auth_start {args} {
-        ::itest::log_decision auth start $args
-        return ""
-    }
-
-    proc auth_status {args} {
-        ::itest::log_decision auth status $args
-        return ""
-    }
-
-    proc auth_subscribe {args} {
-        ::itest::log_decision auth subscribe $args
-        return ""
-    }
-
-    proc auth_unsubscribe {args} {
-        ::itest::log_decision auth unsubscribe $args
-        return ""
-    }
-
-    proc auth_username_credential {args} {
-        ::itest::log_decision auth username_credential $args
-        return ""
-    }
-
-    proc auth_wantcredential_prompt {args} {
-        ::itest::log_decision auth wantcredential_prompt $args
-        return ""
-    }
-
-    proc auth_wantcredential_prompt_style {args} {
-        ::itest::log_decision auth wantcredential_prompt_style $args
-        return ""
-    }
-
-    proc auth_wantcredential_type {args} {
-        ::itest::log_decision auth wantcredential_type $args
-        return ""
-    }
-
-
-    # AVR:: stubs (4 commands)
-
-    proc avr_disable {args} {
-        ::itest::log_decision avr disable $args
-        return ""
-    }
-
-    proc avr_disable_cspm_injection {args} {
-        ::itest::log_decision avr disable_cspm_injection $args
-        return ""
-    }
-
-    proc avr_enable {args} {
-        ::itest::log_decision avr enable $args
-        return ""
-    }
-
-    proc avr_log {args} {
-        ::itest::log_decision avr log $args
-        return ""
-    }
-
-
-    # BIGPROTO:: stubs (1 commands)
-
-    proc bigproto_enable_fix_reset {args} {
-        ::itest::log_decision bigproto enable_fix_reset $args
-        return ""
-    }
-
-
-    # BIGTCP:: stubs (1 commands)
-
-    proc bigtcp_release_flow {args} {
-        ::itest::log_decision bigtcp release_flow $args
-        return ""
-    }
-
-
-    # BOTDEFENSE:: stubs (25 commands)
-
-    proc botdefense_action {args} {
-        ::itest::log_decision botdefense action $args
-        return ""
-    }
-
-    proc botdefense_bot_anomalies {args} {
-        ::itest::log_decision botdefense bot_anomalies $args
-        return ""
-    }
-
-    proc botdefense_bot_categories {args} {
-        ::itest::log_decision botdefense bot_categories $args
-        return ""
-    }
-
-    proc botdefense_bot_name {args} {
-        ::itest::log_decision botdefense bot_name $args
-        return ""
-    }
-
-    proc botdefense_bot_signature {args} {
-        ::itest::log_decision botdefense bot_signature $args
-        return ""
-    }
-
-    proc botdefense_bot_signature_category {args} {
-        ::itest::log_decision botdefense bot_signature_category $args
-        return ""
-    }
-
-    proc botdefense_captcha_age {args} {
-        ::itest::log_decision botdefense captcha_age $args
-        return ""
-    }
-
-    proc botdefense_captcha_status {args} {
-        ::itest::log_decision botdefense captcha_status $args
-        return ""
-    }
-
-    proc botdefense_client_class {args} {
-        ::itest::log_decision botdefense client_class $args
-        return ""
-    }
-
-    proc botdefense_client_type {args} {
-        ::itest::log_decision botdefense client_type $args
-        return ""
-    }
-
-    proc botdefense_cookie_age {args} {
-        ::itest::log_decision botdefense cookie_age $args
-        return ""
-    }
-
-    proc botdefense_cookie_status {args} {
-        ::itest::log_decision botdefense cookie_status $args
-        return ""
-    }
-
-    proc botdefense_cs_allowed {args} {
-        ::itest::log_decision botdefense cs_allowed $args
-        return ""
-    }
-
-    proc botdefense_cs_attribute {args} {
-        ::itest::log_decision botdefense cs_attribute $args
-        return ""
-    }
-
-    proc botdefense_cs_possible {args} {
-        ::itest::log_decision botdefense cs_possible $args
-        return ""
-    }
-
-    proc botdefense_device_id {args} {
-        ::itest::log_decision botdefense device_id $args
-        return ""
-    }
-
-    proc botdefense_disable {args} {
-        ::itest::log_decision botdefense disable $args
-        return ""
-    }
-
-    proc botdefense_enable {args} {
-        ::itest::log_decision botdefense enable $args
-        return ""
-    }
-
-    proc botdefense_intent {args} {
-        ::itest::log_decision botdefense intent $args
-        return ""
-    }
-
-    proc botdefense_micro_service {args} {
-        ::itest::log_decision botdefense micro_service $args
-        return ""
-    }
-
-    proc botdefense_previous_action {args} {
-        ::itest::log_decision botdefense previous_action $args
-        return ""
-    }
-
-    proc botdefense_previous_request_age {args} {
-        ::itest::log_decision botdefense previous_request_age $args
-        return ""
-    }
-
-    proc botdefense_previous_support_id {args} {
-        ::itest::log_decision botdefense previous_support_id $args
-        return ""
-    }
-
-    proc botdefense_reason {args} {
-        ::itest::log_decision botdefense reason $args
-        return ""
-    }
-
-    proc botdefense_support_id {args} {
-        ::itest::log_decision botdefense support_id $args
-        return ""
-    }
-
-
-    # BWC:: stubs (8 commands)
-
-    proc bwc_color {args} {
-        ::itest::log_decision bwc color $args
-        return ""
-    }
-
-    proc bwc_debug {args} {
-        ::itest::log_decision bwc debug $args
-        return ""
-    }
-
-    proc bwc_mark {args} {
-        ::itest::log_decision bwc mark $args
-        return ""
-    }
-
-    proc bwc_measure {args} {
-        ::itest::log_decision bwc measure $args
-        return ""
-    }
-
-    proc bwc_policy {args} {
-        ::itest::log_decision bwc policy $args
-        return ""
-    }
-
-    proc bwc_pps {args} {
-        ::itest::log_decision bwc pps $args
-        return ""
-    }
-
-    proc bwc_priority {args} {
-        ::itest::log_decision bwc priority $args
-        return ""
-    }
-
-    proc bwc_rate {args} {
-        ::itest::log_decision bwc rate $args
-        return ""
-    }
-
-
-    # CACHE:: stubs (17 commands)
-
-    proc cache_accept_encoding {args} {
-        ::itest::log_decision cache accept_encoding $args
-        return ""
-    }
-
-    proc cache_age {args} {
-        ::itest::log_decision cache age $args
-        return ""
-    }
-
-    proc cache_disable {args} {
-        ::itest::log_decision cache disable $args
-        return ""
-    }
-
-    proc cache_disabled {args} {
-        ::itest::log_decision cache disabled $args
-        return ""
-    }
-
-    proc cache_enable {args} {
-        ::itest::log_decision cache enable $args
-        return ""
-    }
-
-    proc cache_expire {args} {
-        ::itest::log_decision cache expire $args
-        return ""
-    }
-
-    proc cache_fresh {args} {
-        ::itest::log_decision cache fresh $args
-        return ""
-    }
-
-    proc cache_header {args} {
-        ::itest::log_decision cache header $args
-        return ""
-    }
-
-    proc cache_headers {args} {
-        ::itest::log_decision cache headers $args
-        return ""
-    }
-
-    proc cache_hits {args} {
-        ::itest::log_decision cache hits $args
-        return ""
-    }
-
-    proc cache_payload {args} {
-        ::itest::log_decision cache payload $args
-        return ""
-    }
-
-    proc cache_priority {args} {
-        ::itest::log_decision cache priority $args
-        return ""
-    }
-
-    proc cache_statskey {args} {
-        ::itest::log_decision cache statskey $args
-        return ""
-    }
-
-    proc cache_trace {args} {
-        ::itest::log_decision cache trace $args
-        return ""
-    }
-
-    proc cache_uri {args} {
-        ::itest::log_decision cache uri $args
-        return ""
-    }
-
-    proc cache_useragent {args} {
-        ::itest::log_decision cache useragent $args
-        return ""
-    }
-
-    proc cache_userkey {args} {
-        ::itest::log_decision cache userkey $args
-        return ""
-    }
-
-
-    # CATEGORY:: stubs (6 commands)
-
-    proc category_analytics {args} {
-        ::itest::log_decision category analytics $args
-        return ""
-    }
-
-    proc category_filetype {args} {
-        ::itest::log_decision category filetype $args
-        return ""
-    }
-
-    proc category_lookup {args} {
-        ::itest::log_decision category lookup $args
-        return ""
-    }
-
-    proc category_matchtype {args} {
-        ::itest::log_decision category matchtype $args
-        return ""
-    }
-
-    proc category_result {args} {
-        ::itest::log_decision category result $args
-        return ""
-    }
-
-    proc category_safesearch {args} {
-        ::itest::log_decision category safesearch $args
-        return ""
-    }
-
-
-    # CLASSIFICATION:: stubs (8 commands)
-
-    proc classification_app {args} {
-        ::itest::log_decision classification app $args
-        return ""
-    }
-
-    proc classification_category {args} {
-        ::itest::log_decision classification category $args
-        return ""
-    }
-
-    proc classification_disable {args} {
-        ::itest::log_decision classification disable $args
-        return ""
-    }
-
-    proc classification_enable {args} {
-        ::itest::log_decision classification enable $args
-        return ""
-    }
-
-    proc classification_protocol {args} {
-        ::itest::log_decision classification protocol $args
-        return ""
-    }
-
-    proc classification_result {args} {
-        ::itest::log_decision classification result $args
-        return ""
-    }
-
-    proc classification_urlcat {args} {
-        ::itest::log_decision classification urlcat $args
-        return ""
-    }
-
-    proc classification_username {args} {
-        ::itest::log_decision classification username $args
-        return ""
-    }
-
-
-    # CLASSIFY:: stubs (6 commands)
-
-    proc classify_application {args} {
-        ::itest::log_decision classify application $args
-        return ""
-    }
-
-    proc classify_category {args} {
-        ::itest::log_decision classify category $args
-        return ""
-    }
-
-    proc classify_defer {args} {
-        ::itest::log_decision classify defer $args
-        return ""
-    }
-
-    proc classify_disable {args} {
-        ::itest::log_decision classify disable $args
-        return ""
-    }
-
-    proc classify_urlcat {args} {
-        ::itest::log_decision classify urlcat $args
-        return ""
-    }
-
-    proc classify_username {args} {
-        ::itest::log_decision classify username $args
-        return ""
-    }
-
-
-    # COMPRESS:: stubs (6 commands)
-
-    proc compress_buffer_size {args} {
-        ::itest::log_decision compress buffer_size $args
-        return ""
-    }
-
-    proc compress_disable {args} {
-        ::itest::log_decision compress disable $args
-        return ""
-    }
-
-    proc compress_enable {args} {
-        ::itest::log_decision compress enable $args
-        return ""
-    }
-
-    proc compress_gzip {args} {
-        ::itest::log_decision compress gzip $args
-        return ""
-    }
-
-    proc compress_method {args} {
-        ::itest::log_decision compress method $args
-        return ""
-    }
-
-    proc compress_nodelay {args} {
-        ::itest::log_decision compress nodelay $args
-        return ""
-    }
-
-
-    # CONNECTOR:: stubs (4 commands)
-
-    proc connector_disable {args} {
-        ::itest::log_decision connector disable $args
-        return ""
-    }
-
-    proc connector_enable {args} {
-        ::itest::log_decision connector enable $args
-        return ""
-    }
-
-    proc connector_profile {args} {
-        ::itest::log_decision connector profile $args
-        return ""
-    }
-
-    proc connector_remap {args} {
-        ::itest::log_decision connector remap $args
-        return ""
-    }
-
-
-    # CRYPTO:: stubs (6 commands)
-
-    proc crypto_decrypt {args} {
-        ::itest::log_decision crypto decrypt $args
-        return ""
-    }
-
-    proc crypto_encrypt {args} {
-        ::itest::log_decision crypto encrypt $args
-        return ""
-    }
-
-    proc crypto_hash {args} {
-        ::itest::log_decision crypto hash $args
-        return ""
-    }
-
-    proc crypto_keygen {args} {
-        ::itest::log_decision crypto keygen $args
-        return ""
-    }
-
-    proc crypto_sign {args} {
-        ::itest::log_decision crypto sign $args
-        return ""
-    }
-
-    proc crypto_verify {args} {
-        ::itest::log_decision crypto verify $args
-        return ""
-    }
-
-
-    # DATAGRAM:: stubs (6 commands)
-
-    proc datagram_dns {args} {
-        ::itest::log_decision datagram dns $args
-        return ""
-    }
-
-    proc datagram_ip {args} {
-        ::itest::log_decision datagram ip $args
-        return ""
-    }
-
-    proc datagram_ip6 {args} {
-        ::itest::log_decision datagram ip6 $args
-        return ""
-    }
-
-    proc datagram_l2 {args} {
-        ::itest::log_decision datagram l2 $args
-        return ""
-    }
-
-    proc datagram_tcp {args} {
-        ::itest::log_decision datagram tcp $args
-        return ""
-    }
-
-    proc datagram_udp {args} {
-        ::itest::log_decision datagram udp $args
-        return ""
-    }
-
-
-    # DECOMPRESS:: stubs (2 commands)
-
-    proc decompress_disable {args} {
-        ::itest::log_decision decompress disable $args
-        return ""
-    }
-
-    proc decompress_enable {args} {
-        ::itest::log_decision decompress enable $args
-        return ""
-    }
-
-
-    # DEMANGLE:: stubs (2 commands)
-
-    proc demangle_disable {args} {
-        ::itest::log_decision demangle disable $args
-        return ""
-    }
-
-    proc demangle_enable {args} {
-        ::itest::log_decision demangle enable $args
-        return ""
-    }
-
-
-    # DHCP:: stubs (1 commands)
-
-    proc dhcp_version {args} {
-        ::itest::log_decision dhcp version $args
-        return ""
-    }
-
-
-    # DHCPv4:: stubs (16 commands)
-
-    proc dhcpv4_chaddr {args} {
-        ::itest::log_decision dhcpv4 chaddr $args
-        return ""
-    }
-
-    proc dhcpv4_ciaddr {args} {
-        ::itest::log_decision dhcpv4 ciaddr $args
-        return ""
-    }
-
-    proc dhcpv4_drop {args} {
-        ::itest::log_decision dhcpv4 drop $args
-        return ""
-    }
-
-    proc dhcpv4_giaddr {args} {
-        ::itest::log_decision dhcpv4 giaddr $args
-        return ""
-    }
-
-    proc dhcpv4_hlen {args} {
-        ::itest::log_decision dhcpv4 hlen $args
-        return ""
-    }
-
-    proc dhcpv4_hops {args} {
-        ::itest::log_decision dhcpv4 hops $args
-        return ""
-    }
-
-    proc dhcpv4_htype {args} {
-        ::itest::log_decision dhcpv4 htype $args
-        return ""
-    }
-
-    proc dhcpv4_len {args} {
-        ::itest::log_decision dhcpv4 len $args
-        return ""
-    }
-
-    proc dhcpv4_opcode {args} {
-        ::itest::log_decision dhcpv4 opcode $args
-        return ""
-    }
-
-    proc dhcpv4_option {args} {
-        ::itest::log_decision dhcpv4 option $args
-        return ""
-    }
-
-    proc dhcpv4_reject {args} {
-        ::itest::log_decision dhcpv4 reject $args
-        return ""
-    }
-
-    proc dhcpv4_secs {args} {
-        ::itest::log_decision dhcpv4 secs $args
-        return ""
-    }
-
-    proc dhcpv4_siaddr {args} {
-        ::itest::log_decision dhcpv4 siaddr $args
-        return ""
-    }
-
-    proc dhcpv4_type {args} {
-        ::itest::log_decision dhcpv4 type $args
-        return ""
-    }
-
-    proc dhcpv4_xid {args} {
-        ::itest::log_decision dhcpv4 xid $args
-        return ""
-    }
-
-    proc dhcpv4_yiaddr {args} {
-        ::itest::log_decision dhcpv4 yiaddr $args
-        return ""
-    }
-
-
-    # DHCPv6:: stubs (9 commands)
-
-    proc dhcpv6_drop {args} {
-        ::itest::log_decision dhcpv6 drop $args
-        return ""
-    }
-
-    proc dhcpv6_hop_count {args} {
-        ::itest::log_decision dhcpv6 hop_count $args
-        return ""
-    }
-
-    proc dhcpv6_len {args} {
-        ::itest::log_decision dhcpv6 len $args
-        return ""
-    }
-
-    proc dhcpv6_link_address {args} {
-        ::itest::log_decision dhcpv6 link_address $args
-        return ""
-    }
-
-    proc dhcpv6_msg_type {args} {
-        ::itest::log_decision dhcpv6 msg_type $args
-        return ""
-    }
-
-    proc dhcpv6_option {args} {
-        ::itest::log_decision dhcpv6 option $args
-        return ""
-    }
-
-    proc dhcpv6_peer_address {args} {
-        ::itest::log_decision dhcpv6 peer_address $args
-        return ""
-    }
-
-    proc dhcpv6_reject {args} {
-        ::itest::log_decision dhcpv6 reject $args
-        return ""
-    }
-
-    proc dhcpv6_transaction_id {args} {
-        ::itest::log_decision dhcpv6 transaction_id $args
-        return ""
-    }
-
-
-    # DIAG:: stubs (1 commands)
-
-    proc diag_test {args} {
-        ::itest::log_decision diag test $args
-        return ""
-    }
-
-
-    # DIAMETER:: stubs (27 commands)
-
-    proc diameter_avp {args} {
-        ::itest::log_decision diameter avp $args
-        return ""
-    }
-
-    proc diameter_command {args} {
-        ::itest::log_decision diameter command $args
-        return ""
-    }
-
-    proc diameter_disconnect {args} {
-        ::itest::log_decision diameter disconnect $args
-        return ""
-    }
-
-    proc diameter_drop {args} {
-        ::itest::log_decision diameter drop $args
-        return ""
-    }
-
-    proc diameter_dynamic_route_insertion {args} {
-        ::itest::log_decision diameter dynamic_route_insertion $args
-        return ""
-    }
-
-    proc diameter_dynamic_route_lookup {args} {
-        ::itest::log_decision diameter dynamic_route_lookup $args
-        return ""
-    }
-
-    proc diameter_header {args} {
-        ::itest::log_decision diameter header $args
-        return ""
-    }
-
-    proc diameter_host {args} {
-        ::itest::log_decision diameter host $args
-        return ""
-    }
-
-    proc diameter_is_request {args} {
-        ::itest::log_decision diameter is_request $args
-        return ""
-    }
-
-    proc diameter_is_response {args} {
-        ::itest::log_decision diameter is_response $args
-        return ""
-    }
-
-    proc diameter_is_retransmission {args} {
-        ::itest::log_decision diameter is_retransmission $args
-        return ""
-    }
-
-    proc diameter_length {args} {
-        ::itest::log_decision diameter length $args
-        return ""
-    }
-
-    proc diameter_message {args} {
-        ::itest::log_decision diameter message $args
-        return ""
-    }
-
-    proc diameter_payload {args} {
-        ::itest::log_decision diameter payload $args
-        return ""
-    }
-
-    proc diameter_persist {args} {
-        ::itest::log_decision diameter persist $args
-        return ""
-    }
-
-    proc diameter_realm {args} {
-        ::itest::log_decision diameter realm $args
-        return ""
-    }
-
-    proc diameter_respond {args} {
-        ::itest::log_decision diameter respond $args
-        return ""
-    }
-
-    proc diameter_result {args} {
-        ::itest::log_decision diameter result $args
-        return ""
-    }
-
-    proc diameter_retransmission {args} {
-        ::itest::log_decision diameter retransmission $args
-        return ""
-    }
-
-    proc diameter_retransmission_default {args} {
-        ::itest::log_decision diameter retransmission_default $args
-        return ""
-    }
-
-    proc diameter_retransmission_reason {args} {
-        ::itest::log_decision diameter retransmission_reason $args
-        return ""
-    }
-
-    proc diameter_retransmit {args} {
-        ::itest::log_decision diameter retransmit $args
-        return ""
-    }
-
-    proc diameter_retry {args} {
-        ::itest::log_decision diameter retry $args
-        return ""
-    }
-
-    proc diameter_route_status {args} {
-        ::itest::log_decision diameter route_status $args
-        return ""
-    }
-
-    proc diameter_session {args} {
-        ::itest::log_decision diameter session $args
-        return ""
-    }
-
-    proc diameter_skip_capabilities_exchange {args} {
-        ::itest::log_decision diameter skip_capabilities_exchange $args
-        return ""
-    }
-
-    proc diameter_state {args} {
-        ::itest::log_decision diameter state $args
-        return ""
-    }
-
-
-    # DNS:: stubs (23 commands)
-
-    proc dns_additional {args} {
-        ::itest::log_decision dns additional $args
-        return ""
-    }
-
-    proc dns_authority {args} {
-        ::itest::log_decision dns authority $args
-        return ""
-    }
-
-    proc dns_class {args} {
-        ::itest::log_decision dns class $args
-        return ""
-    }
-
-    proc dns_disable {args} {
-        ::itest::log_decision dns disable $args
-        return ""
-    }
-
-    proc dns_drop {args} {
-        ::itest::log_decision dns drop $args
-        return ""
-    }
-
-    proc dns_edns0 {args} {
-        ::itest::log_decision dns edns0 $args
-        return ""
-    }
-
-    proc dns_enable {args} {
-        ::itest::log_decision dns enable $args
-        return ""
-    }
-
-    proc dns_is_wideip {args} {
-        ::itest::log_decision dns is_wideip $args
-        return ""
-    }
-
-    proc dns_last_act {args} {
-        ::itest::log_decision dns last_act $args
-        return ""
-    }
-
-    proc dns_len {args} {
-        ::itest::log_decision dns len $args
-        return ""
-    }
-
-    proc dns_log {args} {
-        ::itest::log_decision dns log $args
-        return ""
-    }
-
-    proc dns_name {args} {
-        ::itest::log_decision dns name $args
-        return ""
-    }
-
-    proc dns_origin {args} {
-        ::itest::log_decision dns origin $args
-        return ""
-    }
-
-    proc dns_ptype {args} {
-        ::itest::log_decision dns ptype $args
-        return ""
-    }
-
-    proc dns_query {args} {
-        ::itest::log_decision dns query $args
-        return ""
-    }
-
-    proc dns_question {args} {
-        ::itest::log_decision dns question $args
-        return ""
-    }
-
-    proc dns_rdata {args} {
-        ::itest::log_decision dns rdata $args
-        return ""
-    }
-
-    proc dns_rpz_policy {args} {
-        ::itest::log_decision dns rpz_policy $args
-        return ""
-    }
-
-    proc dns_rr {args} {
-        ::itest::log_decision dns rr $args
-        return ""
-    }
-
-    proc dns_scrape {args} {
-        ::itest::log_decision dns scrape $args
-        return ""
-    }
-
-    proc dns_tsig {args} {
-        ::itest::log_decision dns tsig $args
-        return ""
-    }
-
-    proc dns_ttl {args} {
-        ::itest::log_decision dns ttl $args
-        return ""
-    }
-
-    proc dns_type {args} {
-        ::itest::log_decision dns type $args
-        return ""
-    }
-
-
-    # DNSMSG:: stubs (3 commands)
-
-    proc dnsmsg_header {args} {
-        ::itest::log_decision dnsmsg header $args
-        return ""
-    }
-
-    proc dnsmsg_record {args} {
-        ::itest::log_decision dnsmsg record $args
-        return ""
-    }
-
-    proc dnsmsg_section {args} {
-        ::itest::log_decision dnsmsg section $args
-        return ""
-    }
-
-
-    # DOSL7:: stubs (7 commands)
-
-    proc dosl7_disable {args} {
-        ::itest::log_decision dosl7 disable $args
-        return ""
-    }
-
-    proc dosl7_enable {args} {
-        ::itest::log_decision dosl7 enable $args
-        return ""
-    }
-
-    proc dosl7_health {args} {
-        ::itest::log_decision dosl7 health $args
-        return ""
-    }
-
-    proc dosl7_is_ip_slowdown {args} {
-        ::itest::log_decision dosl7 is_ip_slowdown $args
-        return ""
-    }
-
-    proc dosl7_is_mitigated {args} {
-        ::itest::log_decision dosl7 is_mitigated $args
-        return ""
-    }
-
-    proc dosl7_profile {args} {
-        ::itest::log_decision dosl7 profile $args
-        return ""
-    }
-
-    proc dosl7_slowdown {args} {
-        ::itest::log_decision dosl7 slowdown $args
-        return ""
-    }
-
-
-    # DSLITE:: stubs (1 commands)
-
-    proc dslite_remote_addr {args} {
-        ::itest::log_decision dslite remote_addr $args
-        return ""
-    }
-
-
-    # ECA:: stubs (7 commands)
-
-    proc eca_client_machine_name {args} {
-        ::itest::log_decision eca client_machine_name $args
-        return ""
-    }
-
-    proc eca_disable {args} {
-        ::itest::log_decision eca disable $args
-        return ""
-    }
-
-    proc eca_domainname {args} {
-        ::itest::log_decision eca domainname $args
-        return ""
-    }
-
-    proc eca_enable {args} {
-        ::itest::log_decision eca enable $args
-        return ""
-    }
-
-    proc eca_select {args} {
-        ::itest::log_decision eca select $args
-        return ""
-    }
-
-    proc eca_status {args} {
-        ::itest::log_decision eca status $args
-        return ""
-    }
-
-    proc eca_username {args} {
-        ::itest::log_decision eca username $args
-        return ""
-    }
-
-
-    # FIX:: stubs (1 commands)
-
-    proc fix_tag {args} {
-        ::itest::log_decision fix tag $args
-        return ""
-    }
-
-
-    # FLOW:: stubs (7 commands)
-
-    proc flow_create_related {args} {
-        ::itest::log_decision flow create_related $args
-        return ""
-    }
-
-    proc flow_idle_duration {args} {
-        ::itest::log_decision flow idle_duration $args
-        return ""
-    }
-
-    proc flow_idle_timeout {args} {
-        ::itest::log_decision flow idle_timeout $args
-        return ""
-    }
-
-    proc flow_peer {args} {
-        ::itest::log_decision flow peer $args
-        return ""
-    }
-
-    proc flow_priority {args} {
-        ::itest::log_decision flow priority $args
-        return ""
-    }
-
-    proc flow_refresh {args} {
-        ::itest::log_decision flow refresh $args
-        return ""
-    }
-
-    proc flow_this {args} {
-        ::itest::log_decision flow this $args
-        return ""
-    }
-
-
-    # FLOWTABLE:: stubs (2 commands)
-
-    proc flowtable_count {args} {
-        ::itest::log_decision flowtable count $args
-        return ""
-    }
-
-    proc flowtable_limit {args} {
-        ::itest::log_decision flowtable limit $args
-        return ""
-    }
-
-
-    # FTP:: stubs (6 commands)
-
-    proc ftp_allow_active_mode {args} {
-        ::itest::log_decision ftp allow_active_mode $args
-        return ""
-    }
-
-    proc ftp_disable {args} {
-        ::itest::log_decision ftp disable $args
-        return ""
-    }
-
-    proc ftp_enable {args} {
-        ::itest::log_decision ftp enable $args
-        return ""
-    }
-
-    proc ftp_enforce_tls_session_reuse {args} {
-        ::itest::log_decision ftp enforce_tls_session_reuse $args
-        return ""
-    }
-
-    proc ftp_ftps_mode {args} {
-        ::itest::log_decision ftp ftps_mode $args
-        return ""
-    }
-
-    proc ftp_port {args} {
-        ::itest::log_decision ftp port $args
-        return ""
-    }
-
-
-    # GENERICMESSAGE:: stubs (3 commands)
-
-    proc genericmessage_message {args} {
-        ::itest::log_decision genericmessage message $args
-        return ""
-    }
-
-    proc genericmessage_peer {args} {
-        ::itest::log_decision genericmessage peer $args
-        return ""
-    }
-
-    proc genericmessage_route {args} {
-        ::itest::log_decision genericmessage route $args
-        return ""
-    }
-
-
-    # GTP:: stubs (12 commands)
-
-    proc gtp_clone {args} {
-        ::itest::log_decision gtp clone $args
-        return ""
-    }
-
-    proc gtp_discard {args} {
-        ::itest::log_decision gtp discard $args
-        return ""
-    }
-
-    proc gtp_forward {args} {
-        ::itest::log_decision gtp forward $args
-        return ""
-    }
-
-    proc gtp_header {args} {
-        ::itest::log_decision gtp header $args
-        return ""
-    }
-
-    proc gtp_ie {args} {
-        ::itest::log_decision gtp ie $args
-        return ""
-    }
-
-    proc gtp_length {args} {
-        ::itest::log_decision gtp length $args
-        return ""
-    }
-
-    proc gtp_message {args} {
-        ::itest::log_decision gtp message $args
-        return ""
-    }
-
-    proc gtp_new {args} {
-        ::itest::log_decision gtp new $args
-        return ""
-    }
-
-    proc gtp_parse {args} {
-        ::itest::log_decision gtp parse $args
-        return ""
-    }
-
-    proc gtp_payload {args} {
-        ::itest::log_decision gtp payload $args
-        return ""
-    }
-
-    proc gtp_respond {args} {
-        ::itest::log_decision gtp respond $args
-        return ""
-    }
-
-    proc gtp_tunnel {args} {
-        ::itest::log_decision gtp tunnel $args
-        return ""
-    }
-
-
-    # HA:: stubs (1 commands)
-
-    proc ha_status {args} {
-        ::itest::log_decision ha status $args
-        return ""
-    }
-
-
-    # HSL:: stubs (2 commands)
-
-    proc hsl_open {args} {
-        ::itest::log_decision hsl open $args
-        return ""
-    }
-
-    proc hsl_send {args} {
-        ::itest::log_decision hsl send $args
-        return ""
-    }
-
-
-    # HTML:: stubs (5 commands)
-
-    proc html_comment {args} {
-        ::itest::log_decision html comment $args
-        return ""
-    }
-
-    proc html_disable {args} {
-        ::itest::log_decision html disable $args
-        return ""
-    }
-
-    proc html_enable {args} {
-        ::itest::log_decision html enable $args
-        return ""
-    }
-
-    proc html_encode {args} {
-        ::itest::log_decision html encode $args
-        return ""
-    }
-
-    proc html_tag {args} {
-        ::itest::log_decision html tag $args
-        return ""
-    }
-
-
-    # HTTP:: stubs (6 commands)
-
-    proc http_passthrough_reason {args} {
-        ::itest::log_decision http passthrough_reason $args
-        return ""
-    }
-
-    proc http_password {args} {
-        ::itest::log_decision http password $args
-        return ""
-    }
-
-    proc http_proxy {args} {
-        ::itest::log_decision http proxy $args
-        return ""
-    }
-
-    proc http_reject_reason {args} {
-        ::itest::log_decision http reject_reason $args
-        return ""
-    }
-
-    proc http_response {args} {
-        ::itest::log_decision http response $args
-        return ""
-    }
-
-    proc http_username {args} {
-        ::itest::log_decision http username $args
-        return ""
-    }
-
-
-    # HTTP2:: stubs (8 commands)
-
-    proc http2_active {args} {
-        ::itest::log_decision http2 active $args
-        return ""
-    }
-
-    proc http2_concurrency {args} {
-        ::itest::log_decision http2 concurrency $args
-        return ""
-    }
-
-    proc http2_disable {args} {
-        ::itest::log_decision http2 disable $args
-        return ""
-    }
-
-    proc http2_disconnect {args} {
-        ::itest::log_decision http2 disconnect $args
-        return ""
-    }
-
-    proc http2_enable {args} {
-        ::itest::log_decision http2 enable $args
-        return ""
-    }
-
-    proc http2_push {args} {
-        ::itest::log_decision http2 push $args
-        return ""
-    }
-
-    proc http2_requests {args} {
-        ::itest::log_decision http2 requests $args
-        return ""
-    }
-
-    proc http2_version {args} {
-        ::itest::log_decision http2 version $args
-        return ""
-    }
-
-
-    # HTTPLOG:: stubs (2 commands)
-
-    proc httplog_disable {args} {
-        ::itest::log_decision httplog disable $args
-        return ""
-    }
-
-    proc httplog_enable {args} {
-        ::itest::log_decision httplog enable $args
-        return ""
-    }
-
-
-    # ICAP:: stubs (4 commands)
-
-    proc icap_header {args} {
-        ::itest::log_decision icap header $args
-        return ""
-    }
-
-    proc icap_method {args} {
-        ::itest::log_decision icap method $args
-        return ""
-    }
-
-    proc icap_status {args} {
-        ::itest::log_decision icap status $args
-        return ""
-    }
-
-    proc icap_uri {args} {
-        ::itest::log_decision icap uri $args
-        return ""
-    }
-
-
-    # IKE:: stubs (12 commands)
-
-    proc ike_auth_success {args} {
-        ::itest::log_decision ike auth_success $args
-        return ""
-    }
-
-    proc ike_cert {args} {
-        ::itest::log_decision ike cert $args
-        return ""
-    }
-
-    proc ike_san_dirname {args} {
-        ::itest::log_decision ike san_dirname $args
-        return ""
-    }
-
-    proc ike_san_dns {args} {
-        ::itest::log_decision ike san_dns $args
-        return ""
-    }
-
-    proc ike_san_ediparty {args} {
-        ::itest::log_decision ike san_ediparty $args
-        return ""
-    }
-
-    proc ike_san_email {args} {
-        ::itest::log_decision ike san_email $args
-        return ""
-    }
-
-    proc ike_san_ipadd {args} {
-        ::itest::log_decision ike san_ipadd $args
-        return ""
-    }
-
-    proc ike_san_othername {args} {
-        ::itest::log_decision ike san_othername $args
-        return ""
-    }
-
-    proc ike_san_rid {args} {
-        ::itest::log_decision ike san_rid $args
-        return ""
-    }
-
-    proc ike_san_uri {args} {
-        ::itest::log_decision ike san_uri $args
-        return ""
-    }
-
-    proc ike_san_x400 {args} {
-        ::itest::log_decision ike san_x400 $args
-        return ""
-    }
-
-    proc ike_subjectAltName {args} {
-        ::itest::log_decision ike subjectAltName $args
-        return ""
-    }
-
-
-    # ILX:: stubs (3 commands)
-
-    proc ilx_call {args} {
-        ::itest::log_decision ilx call $args
-        return ""
-    }
-
-    proc ilx_init {args} {
-        ::itest::log_decision ilx init $args
-        return ""
-    }
-
-    proc ilx_notify {args} {
-        ::itest::log_decision ilx notify $args
-        return ""
-    }
-
-
-    # IMAP:: stubs (3 commands)
-
-    proc imap_activation_mode {args} {
-        ::itest::log_decision imap activation_mode $args
-        return ""
-    }
-
-    proc imap_disable {args} {
-        ::itest::log_decision imap disable $args
-        return ""
-    }
-
-    proc imap_enable {args} {
-        ::itest::log_decision imap enable $args
-        return ""
-    }
-
-
-    # IP:: stubs (9 commands)
-
-    proc ip_addr {args} {
-        ::itest::log_decision ip addr $args
-        return ""
-    }
-
-    proc ip_hops {args} {
-        ::itest::log_decision ip hops $args
-        return ""
-    }
-
-    proc ip_idle_timeout {args} {
-        ::itest::log_decision ip idle_timeout $args
-        return ""
-    }
-
-    proc ip_ingress_drop_rate {args} {
-        ::itest::log_decision ip ingress_drop_rate $args
-        return ""
-    }
-
-    proc ip_ingress_rate_limit {args} {
-        ::itest::log_decision ip ingress_rate_limit $args
-        return ""
-    }
-
-    proc ip_intelligence {args} {
-        ::itest::log_decision ip intelligence $args
-        return ""
-    }
-
-    proc ip_reputation {args} {
-        ::itest::log_decision ip reputation $args
-        return ""
-    }
-
-    proc ip_stats {args} {
-        ::itest::log_decision ip stats $args
-        return ""
-    }
-
-    proc ip_version {args} {
-        ::itest::log_decision ip version $args
-        return ""
-    }
-
-
-    # IPFIX:: stubs (3 commands)
-
-    proc ipfix_destination {args} {
-        ::itest::log_decision ipfix destination $args
-        return ""
-    }
-
-    proc ipfix_msg {args} {
-        ::itest::log_decision ipfix msg $args
-        return ""
-    }
-
-    proc ipfix_template {args} {
-        ::itest::log_decision ipfix template $args
-        return ""
-    }
-
-
-    # ISESSION:: stubs (1 commands)
-
-    proc isession_deduplication {args} {
-        ::itest::log_decision isession deduplication $args
-        return ""
-    }
-
-
-    # ISTATS:: stubs (4 commands)
-
-    proc istats_get {args} {
-        ::itest::log_decision istats get $args
-        return ""
-    }
-
-    proc istats_incr {args} {
-        ::itest::log_decision istats incr $args
-        return ""
-    }
-
-    proc istats_remove {args} {
-        ::itest::log_decision istats remove $args
-        return ""
-    }
-
-    proc istats_set {args} {
-        ::itest::log_decision istats set $args
-        return ""
-    }
-
-
-    # IVS_ENTRY:: stubs (1 commands)
-
-    proc ivs_entry_result {args} {
-        ::itest::log_decision ivs_entry result $args
-        return ""
-    }
-
-
-    # JSON:: stubs (9 commands)
-
-    proc json_array {args} {
-        ::itest::log_decision json array $args
-        return ""
-    }
-
-    proc json_create {args} {
-        ::itest::log_decision json create $args
-        return ""
-    }
-
-    proc json_get {args} {
-        ::itest::log_decision json get $args
-        return ""
-    }
-
-    proc json_object {args} {
-        ::itest::log_decision json object $args
-        return ""
-    }
-
-    proc json_parse {args} {
-        ::itest::log_decision json parse $args
-        return ""
-    }
-
-    proc json_render {args} {
-        ::itest::log_decision json render $args
-        return ""
-    }
-
-    proc json_root {args} {
-        ::itest::log_decision json root $args
-        return ""
-    }
-
-    proc json_set {args} {
-        ::itest::log_decision json set $args
-        return ""
-    }
-
-    proc json_type {args} {
-        ::itest::log_decision json type $args
-        return ""
-    }
-
-
-    # L7CHECK:: stubs (1 commands)
-
-    proc l7check_protocol {args} {
-        ::itest::log_decision l7check protocol $args
-        return ""
-    }
-
-
-    # LB:: stubs (16 commands)
-
-    proc lb_bias {args} {
-        ::itest::log_decision lb bias $args
-        return ""
-    }
-
-    proc lb_class {args} {
-        ::itest::log_decision lb class $args
-        return ""
-    }
-
-    proc lb_command {args} {
-        ::itest::log_decision lb command $args
-        return ""
-    }
-
-    proc lb_connect {args} {
-        ::itest::log_decision lb connect $args
-        return ""
-    }
-
-    proc lb_connlimit {args} {
-        ::itest::log_decision lb connlimit $args
-        return ""
-    }
-
-    proc lb_context_id {args} {
-        ::itest::log_decision lb context_id $args
-        return ""
-    }
-
-    proc lb_down {args} {
-        ::itest::log_decision lb down $args
-        return ""
-    }
-
-    proc lb_dst_tag {args} {
-        ::itest::log_decision lb dst_tag $args
-        return ""
-    }
-
-    proc lb_enable_decisionlog {args} {
-        ::itest::log_decision lb enable_decisionlog $args
-        return ""
-    }
-
-    proc lb_mode {args} {
-        ::itest::log_decision lb mode $args
-        return ""
-    }
-
-    proc lb_persist {args} {
-        ::itest::log_decision lb persist $args
-        return ""
-    }
-
-    proc lb_prime {args} {
-        ::itest::log_decision lb prime $args
-        return ""
-    }
-
-    proc lb_queue {args} {
-        ::itest::log_decision lb queue $args
-        return ""
-    }
-
-    proc lb_snat {args} {
-        ::itest::log_decision lb snat $args
-        return ""
-    }
-
-    proc lb_src_tag {args} {
-        ::itest::log_decision lb src_tag $args
-        return ""
-    }
-
-    proc lb_up {args} {
-        ::itest::log_decision lb up $args
-        return ""
-    }
-
-
-    # LDAP:: stubs (3 commands)
-
-    proc ldap_activation_mode {args} {
-        ::itest::log_decision ldap activation_mode $args
-        return ""
-    }
-
-    proc ldap_disable {args} {
-        ::itest::log_decision ldap disable $args
-        return ""
-    }
-
-    proc ldap_enable {args} {
-        ::itest::log_decision ldap enable $args
-        return ""
-    }
-
-
-    # LINE:: stubs (2 commands)
-
-    proc line_get {args} {
-        ::itest::log_decision line get $args
-        return ""
-    }
-
-    proc line_set {args} {
-        ::itest::log_decision line set $args
-        return ""
-    }
-
-
-    # LINK:: stubs (4 commands)
-
-    proc link_lasthop {args} {
-        ::itest::log_decision link lasthop $args
-        return ""
-    }
-
-    proc link_nexthop {args} {
-        ::itest::log_decision link nexthop $args
-        return ""
-    }
-
-    proc link_qos {args} {
-        ::itest::log_decision link qos $args
-        return ""
-    }
-
-    proc link_vlan_id {args} {
-        ::itest::log_decision link vlan_id $args
-        return ""
-    }
-
-
-    # LSN:: stubs (8 commands)
-
-    proc lsn_address {args} {
-        ::itest::log_decision lsn address $args
-        return ""
-    }
-
-    proc lsn_disable {args} {
-        ::itest::log_decision lsn disable $args
-        return ""
-    }
-
-    proc lsn_inbound {args} {
-        ::itest::log_decision lsn inbound $args
-        return ""
-    }
-
-    proc lsn_inbound_entry {args} {
-        ::itest::log_decision lsn inbound-entry $args
-        return ""
-    }
-
-    proc lsn_persistence {args} {
-        ::itest::log_decision lsn persistence $args
-        return ""
-    }
-
-    proc lsn_persistence_entry {args} {
-        ::itest::log_decision lsn persistence-entry $args
-        return ""
-    }
-
-    proc lsn_pool {args} {
-        ::itest::log_decision lsn pool $args
-        return ""
-    }
-
-    proc lsn_port {args} {
-        ::itest::log_decision lsn port $args
-        return ""
-    }
-
-
-    # MESSAGE:: stubs (3 commands)
-
-    proc message_field {args} {
-        ::itest::log_decision message field $args
-        return ""
-    }
-
-    proc message_proto {args} {
-        ::itest::log_decision message proto $args
-        return ""
-    }
-
-    proc message_type {args} {
-        ::itest::log_decision message type $args
-        return ""
-    }
-
-
-    # MQTT:: stubs (29 commands)
-
-    proc mqtt_clean_session {args} {
-        ::itest::log_decision mqtt clean_session $args
-        return ""
-    }
-
-    proc mqtt_client_id {args} {
-        ::itest::log_decision mqtt client_id $args
-        return ""
-    }
-
-    proc mqtt_collect {args} {
-        ::itest::log_decision mqtt collect $args
-        return ""
-    }
-
-    proc mqtt_disable {args} {
-        ::itest::log_decision mqtt disable $args
-        return ""
-    }
-
-    proc mqtt_disconnect {args} {
-        ::itest::log_decision mqtt disconnect $args
-        return ""
-    }
-
-    proc mqtt_drop {args} {
-        ::itest::log_decision mqtt drop $args
-        return ""
-    }
-
-    proc mqtt_dup {args} {
-        ::itest::log_decision mqtt dup $args
-        return ""
-    }
-
-    proc mqtt_enable {args} {
-        ::itest::log_decision mqtt enable $args
-        return ""
-    }
-
-    proc mqtt_insert {args} {
-        ::itest::log_decision mqtt insert $args
-        return ""
-    }
-
-    proc mqtt_keep_alive {args} {
-        ::itest::log_decision mqtt keep_alive $args
-        return ""
-    }
-
-    proc mqtt_length {args} {
-        ::itest::log_decision mqtt length $args
-        return ""
-    }
-
-    proc mqtt_message {args} {
-        ::itest::log_decision mqtt message $args
-        return ""
-    }
-
-    proc mqtt_packet_id {args} {
-        ::itest::log_decision mqtt packet_id $args
-        return ""
-    }
-
-    proc mqtt_password {args} {
-        ::itest::log_decision mqtt password $args
-        return ""
-    }
-
-    proc mqtt_payload {args} {
-        ::itest::log_decision mqtt payload $args
-        return ""
-    }
-
-    proc mqtt_protocol_name {args} {
-        ::itest::log_decision mqtt protocol_name $args
-        return ""
-    }
-
-    proc mqtt_protocol_version {args} {
-        ::itest::log_decision mqtt protocol_version $args
-        return ""
-    }
-
-    proc mqtt_qos {args} {
-        ::itest::log_decision mqtt qos $args
-        return ""
-    }
-
-    proc mqtt_release {args} {
-        ::itest::log_decision mqtt release $args
-        return ""
-    }
-
-    proc mqtt_replace {args} {
-        ::itest::log_decision mqtt replace $args
-        return ""
-    }
-
-    proc mqtt_respond {args} {
-        ::itest::log_decision mqtt respond $args
-        return ""
-    }
-
-    proc mqtt_retain {args} {
-        ::itest::log_decision mqtt retain $args
-        return ""
-    }
-
-    proc mqtt_return_code {args} {
-        ::itest::log_decision mqtt return_code $args
-        return ""
-    }
-
-    proc mqtt_return_code_list {args} {
-        ::itest::log_decision mqtt return_code_list $args
-        return ""
-    }
-
-    proc mqtt_session_present {args} {
-        ::itest::log_decision mqtt session_present $args
-        return ""
-    }
-
-    proc mqtt_topic {args} {
-        ::itest::log_decision mqtt topic $args
-        return ""
-    }
-
-    proc mqtt_type {args} {
-        ::itest::log_decision mqtt type $args
-        return ""
-    }
-
-    proc mqtt_username {args} {
-        ::itest::log_decision mqtt username $args
-        return ""
-    }
-
-    proc mqtt_will {args} {
-        ::itest::log_decision mqtt will $args
-        return ""
-    }
-
-
-    # MR:: stubs (23 commands)
-
-    proc mr_always_match_port {args} {
-        ::itest::log_decision mr always_match_port $args
-        return ""
-    }
-
-    proc mr_available_for_routing {args} {
-        ::itest::log_decision mr available_for_routing $args
-        return ""
-    }
-
-    proc mr_collect {args} {
-        ::itest::log_decision mr collect $args
-        return ""
-    }
-
-    proc mr_connect_back_port {args} {
-        ::itest::log_decision mr connect_back_port $args
-        return ""
-    }
-
-    proc mr_connection_instance {args} {
-        ::itest::log_decision mr connection_instance $args
-        return ""
-    }
-
-    proc mr_connection_mode {args} {
-        ::itest::log_decision mr connection_mode $args
-        return ""
-    }
-
-    proc mr_equivalent_transport {args} {
-        ::itest::log_decision mr equivalent_transport $args
-        return ""
-    }
-
-    proc mr_flow_id {args} {
-        ::itest::log_decision mr flow_id $args
-        return ""
-    }
-
-    proc mr_ignore_peer_port {args} {
-        ::itest::log_decision mr ignore_peer_port $args
-        return ""
-    }
-
-    proc mr_instance {args} {
-        ::itest::log_decision mr instance $args
-        return ""
-    }
-
-    proc mr_max_retries {args} {
-        ::itest::log_decision mr max_retries $args
-        return ""
-    }
-
-    proc mr_message {args} {
-        ::itest::log_decision mr message $args
-        return ""
-    }
-
-    proc mr_payload {args} {
-        ::itest::log_decision mr payload $args
-        return ""
-    }
-
-    proc mr_peer {args} {
-        ::itest::log_decision mr peer $args
-        return ""
-    }
-
-    proc mr_prime {args} {
-        ::itest::log_decision mr prime $args
-        return ""
-    }
-
-    proc mr_protocol {args} {
-        ::itest::log_decision mr protocol $args
-        return ""
-    }
-
-    proc mr_release {args} {
-        ::itest::log_decision mr release $args
-        return ""
-    }
-
-    proc mr_restore {args} {
-        ::itest::log_decision mr restore $args
-        return ""
-    }
-
-    proc mr_retry {args} {
-        ::itest::log_decision mr retry $args
-        return ""
-    }
-
-    proc mr_return {args} {
-        ::itest::log_decision mr return $args
-        return ""
-    }
-
-    proc mr_store {args} {
-        ::itest::log_decision mr store $args
-        return ""
-    }
-
-    proc mr_stream {args} {
-        ::itest::log_decision mr stream $args
-        return ""
-    }
-
-    proc mr_transport {args} {
-        ::itest::log_decision mr transport $args
-        return ""
-    }
-
-
-    # NAME:: stubs (2 commands)
-
-    proc name_lookup {args} {
-        ::itest::log_decision name lookup $args
-        return ""
-    }
-
-    proc name_response {args} {
-        ::itest::log_decision name response $args
-        return ""
-    }
-
-
-    # NSH:: stubs (6 commands)
-
-    proc nsh_chain {args} {
-        ::itest::log_decision nsh chain $args
-        return ""
-    }
-
-    proc nsh_context {args} {
-        ::itest::log_decision nsh context $args
-        return ""
-    }
-
-    proc nsh_md1 {args} {
-        ::itest::log_decision nsh md1 $args
-        return ""
-    }
-
-    proc nsh_mocksf {args} {
-        ::itest::log_decision nsh mocksf $args
-        return ""
-    }
-
-    proc nsh_path_id {args} {
-        ::itest::log_decision nsh path_id $args
-        return ""
-    }
-
-    proc nsh_service_index {args} {
-        ::itest::log_decision nsh service_index $args
-        return ""
-    }
-
-
-    # NTLM:: stubs (2 commands)
-
-    proc ntlm_disable {args} {
-        ::itest::log_decision ntlm disable $args
-        return ""
-    }
-
-    proc ntlm_enable {args} {
-        ::itest::log_decision ntlm enable $args
-        return ""
-    }
-
-
-    # OFFBOX:: stubs (1 commands)
-
-    proc offbox_request {args} {
-        ::itest::log_decision offbox request $args
-        return ""
-    }
-
-
-    # ONECONNECT:: stubs (4 commands)
-
-    proc oneconnect_detach {args} {
-        ::itest::log_decision oneconnect detach $args
-        return ""
-    }
-
-    proc oneconnect_label {args} {
-        ::itest::log_decision oneconnect label $args
-        return ""
-    }
-
-    proc oneconnect_reuse {args} {
-        ::itest::log_decision oneconnect reuse $args
-        return ""
-    }
-
-    proc oneconnect_select {args} {
-        ::itest::log_decision oneconnect select $args
-        return ""
-    }
-
-
-    # PCP:: stubs (3 commands)
-
-    proc pcp_reject {args} {
-        ::itest::log_decision pcp reject $args
-        return ""
-    }
-
-    proc pcp_request {args} {
-        ::itest::log_decision pcp request $args
-        return ""
-    }
-
-    proc pcp_response {args} {
-        ::itest::log_decision pcp response $args
-        return ""
-    }
-
-
-    # PEM:: stubs (5 commands)
-
-    proc pem_disable {args} {
-        ::itest::log_decision pem disable $args
-        return ""
-    }
-
-    proc pem_enable {args} {
-        ::itest::log_decision pem enable $args
-        return ""
-    }
-
-    proc pem_flow {args} {
-        ::itest::log_decision pem flow $args
-        return ""
-    }
-
-    proc pem_session {args} {
-        ::itest::log_decision pem session $args
-        return ""
-    }
-
-    proc pem_subscriber {args} {
-        ::itest::log_decision pem subscriber $args
-        return ""
-    }
-
-
-    # PLUGIN:: stubs (2 commands)
-
-    proc plugin_disable {args} {
-        ::itest::log_decision plugin disable $args
-        return ""
-    }
-
-    proc plugin_enable {args} {
-        ::itest::log_decision plugin enable $args
-        return ""
-    }
-
-
-    # POLICY:: stubs (4 commands)
-
-    proc policy_controls {args} {
-        ::itest::log_decision policy controls $args
-        return ""
-    }
-
-    proc policy_names {args} {
-        ::itest::log_decision policy names $args
-        return ""
-    }
-
-    proc policy_rules {args} {
-        ::itest::log_decision policy rules $args
-        return ""
-    }
-
-    proc policy_targets {args} {
-        ::itest::log_decision policy targets $args
-        return ""
-    }
-
-
-    # POP3:: stubs (3 commands)
-
-    proc pop3_activation_mode {args} {
-        ::itest::log_decision pop3 activation_mode $args
-        return ""
-    }
-
-    proc pop3_disable {args} {
-        ::itest::log_decision pop3 disable $args
-        return ""
-    }
-
-    proc pop3_enable {args} {
-        ::itest::log_decision pop3 enable $args
-        return ""
-    }
-
-
-    # PROFILE:: stubs (25 commands)
-
-    proc profile_access {args} {
-        ::itest::log_decision profile access $args
-        return ""
-    }
-
-    proc profile_antifraud {args} {
-        ::itest::log_decision profile antifraud $args
-        return ""
-    }
-
-    proc profile_auth {args} {
-        ::itest::log_decision profile auth $args
-        return ""
-    }
-
-    proc profile_avr {args} {
-        ::itest::log_decision profile avr $args
-        return ""
-    }
-
-    proc profile_clientssl {args} {
-        ::itest::log_decision profile clientssl $args
-        return ""
-    }
-
-    proc profile_diameter {args} {
-        ::itest::log_decision profile diameter $args
-        return ""
-    }
-
-    proc profile_exchange {args} {
-        ::itest::log_decision profile exchange $args
-        return ""
-    }
-
-    proc profile_exists {args} {
-        ::itest::log_decision profile exists $args
-        return ""
-    }
-
-    proc profile_fastL4 {args} {
-        ::itest::log_decision profile fastL4 $args
-        return ""
-    }
-
-    proc profile_fasthttp {args} {
-        ::itest::log_decision profile fasthttp $args
-        return ""
-    }
-
-    proc profile_ftp {args} {
-        ::itest::log_decision profile ftp $args
-        return ""
-    }
-
-    proc profile_http {args} {
-        ::itest::log_decision profile http $args
-        return ""
-    }
-
-    proc profile_httpclass {args} {
-        ::itest::log_decision profile httpclass $args
-        return ""
-    }
-
-    proc profile_httpcompression {args} {
-        ::itest::log_decision profile httpcompression $args
-        return ""
-    }
-
-    proc profile_list {args} {
-        ::itest::log_decision profile list $args
-        return ""
-    }
-
-    proc profile_oneconnect {args} {
-        ::itest::log_decision profile oneconnect $args
-        return ""
-    }
-
-    proc profile_persist {args} {
-        ::itest::log_decision profile persist $args
-        return ""
-    }
-
-    proc profile_serverssl {args} {
-        ::itest::log_decision profile serverssl $args
-        return ""
-    }
-
-    proc profile_stream {args} {
-        ::itest::log_decision profile stream $args
-        return ""
-    }
-
-    proc profile_tcp {args} {
-        ::itest::log_decision profile tcp $args
-        return ""
-    }
-
-    proc profile_tftp {args} {
-        ::itest::log_decision profile tftp $args
-        return ""
-    }
-
-    proc profile_udp {args} {
-        ::itest::log_decision profile udp $args
-        return ""
-    }
-
-    proc profile_vdi {args} {
-        ::itest::log_decision profile vdi $args
-        return ""
-    }
-
-    proc profile_webacceleration {args} {
-        ::itest::log_decision profile webacceleration $args
-        return ""
-    }
-
-    proc profile_xml {args} {
-        ::itest::log_decision profile xml $args
-        return ""
-    }
-
-
-    # PROTOCOL_INSPECTION:: stubs (2 commands)
-
-    proc protocol_inspection_disable {args} {
-        ::itest::log_decision protocol_inspection disable $args
-        return ""
-    }
-
-    proc protocol_inspection_id {args} {
-        ::itest::log_decision protocol_inspection id $args
-        return ""
-    }
-
-
-    # PSC:: stubs (11 commands)
-
-    proc psc_aaa_reporting_interval {args} {
-        ::itest::log_decision psc aaa_reporting_interval $args
-        return ""
-    }
-
-    proc psc_attr {args} {
-        ::itest::log_decision psc attr $args
-        return ""
-    }
-
-    proc psc_calling_id {args} {
-        ::itest::log_decision psc calling_id $args
-        return ""
-    }
-
-    proc psc_imeisv {args} {
-        ::itest::log_decision psc imeisv $args
-        return ""
-    }
-
-    proc psc_imsi {args} {
-        ::itest::log_decision psc imsi $args
-        return ""
-    }
-
-    proc psc_ip_address {args} {
-        ::itest::log_decision psc ip_address $args
-        return ""
-    }
-
-    proc psc_lease_time {args} {
-        ::itest::log_decision psc lease_time $args
-        return ""
-    }
-
-    proc psc_policy {args} {
-        ::itest::log_decision psc policy $args
-        return ""
-    }
-
-    proc psc_subscriber_id {args} {
-        ::itest::log_decision psc subscriber_id $args
-        return ""
-    }
-
-    proc psc_tower_id {args} {
-        ::itest::log_decision psc tower_id $args
-        return ""
-    }
-
-    proc psc_user_name {args} {
-        ::itest::log_decision psc user_name $args
-        return ""
-    }
-
-
-    # PSM:: stubs (6 commands)
-
-    proc psm_disable {args} {
-        ::itest::log_decision psm disable $args
-        return ""
-    }
-
-    proc psm_enable {args} {
-        ::itest::log_decision psm enable $args
-        return ""
-    }
-
-    proc psm_disable {args} {
-        ::itest::log_decision psm disable $args
-        return ""
-    }
-
-    proc psm_enable {args} {
-        ::itest::log_decision psm enable $args
-        return ""
-    }
-
-    proc psm_disable {args} {
-        ::itest::log_decision psm disable $args
-        return ""
-    }
-
-    proc psm_enable {args} {
-        ::itest::log_decision psm enable $args
-        return ""
-    }
-
-
-    # QOE:: stubs (3 commands)
-
-    proc qoe_disable {args} {
-        ::itest::log_decision qoe disable $args
-        return ""
-    }
-
-    proc qoe_enable {args} {
-        ::itest::log_decision qoe enable $args
-        return ""
-    }
-
-    proc qoe_video {args} {
-        ::itest::log_decision qoe video $args
-        return ""
-    }
-
-
-    # RADIUS:: stubs (5 commands)
-
-    proc radius_avp {args} {
-        ::itest::log_decision radius avp $args
-        return ""
-    }
-
-    proc radius_code {args} {
-        ::itest::log_decision radius code $args
-        return ""
-    }
-
-    proc radius_id {args} {
-        ::itest::log_decision radius id $args
-        return ""
-    }
-
-    proc radius_rtdom {args} {
-        ::itest::log_decision radius rtdom $args
-        return ""
-    }
-
-    proc radius_subscriber {args} {
-        ::itest::log_decision radius subscriber $args
-        return ""
-    }
-
-
-    # RESOLV:: stubs (1 commands)
-
-    proc resolv_lookup {args} {
-        ::itest::log_decision resolv lookup $args
-        return ""
-    }
-
-
-    # RESOLVER:: stubs (2 commands)
-
-    proc resolver_name_lookup {args} {
-        ::itest::log_decision resolver name_lookup $args
-        return ""
-    }
-
-    proc resolver_summarize {args} {
-        ::itest::log_decision resolver summarize $args
-        return ""
-    }
-
-
-    # REST:: stubs (1 commands)
-
-    proc rest_send {args} {
-        ::itest::log_decision rest send $args
-        return ""
-    }
-
-
-    # REWRITE:: stubs (4 commands)
-
-    proc rewrite_disable {args} {
-        ::itest::log_decision rewrite disable $args
-        return ""
-    }
-
-    proc rewrite_enable {args} {
-        ::itest::log_decision rewrite enable $args
-        return ""
-    }
-
-    proc rewrite_payload {args} {
-        ::itest::log_decision rewrite payload $args
-        return ""
-    }
-
-    proc rewrite_post_process {args} {
-        ::itest::log_decision rewrite post_process $args
-        return ""
-    }
-
-
-    # ROUTE:: stubs (9 commands)
-
-    proc route_age {args} {
-        ::itest::log_decision route age $args
-        return ""
-    }
-
-    proc route_bandwidth {args} {
-        ::itest::log_decision route bandwidth $args
-        return ""
-    }
-
-    proc route_clear {args} {
-        ::itest::log_decision route clear $args
-        return ""
-    }
-
-    proc route_cwnd {args} {
-        ::itest::log_decision route cwnd $args
-        return ""
-    }
-
-    proc route_domain {args} {
-        ::itest::log_decision route domain $args
-        return ""
-    }
-
-    proc route_expiration {args} {
-        ::itest::log_decision route expiration $args
-        return ""
-    }
-
-    proc route_mtu {args} {
-        ::itest::log_decision route mtu $args
-        return ""
-    }
-
-    proc route_rtt {args} {
-        ::itest::log_decision route rtt $args
-        return ""
-    }
-
-    proc route_rttvar {args} {
-        ::itest::log_decision route rttvar $args
-        return ""
-    }
-
-
-    # RTSP:: stubs (10 commands)
-
-    proc rtsp_collect {args} {
-        ::itest::log_decision rtsp collect $args
-        return ""
-    }
-
-    proc rtsp_header {args} {
-        ::itest::log_decision rtsp header $args
-        return ""
-    }
-
-    proc rtsp_method {args} {
-        ::itest::log_decision rtsp method $args
-        return ""
-    }
-
-    proc rtsp_msg_source {args} {
-        ::itest::log_decision rtsp msg_source $args
-        return ""
-    }
-
-    proc rtsp_payload {args} {
-        ::itest::log_decision rtsp payload $args
-        return ""
-    }
-
-    proc rtsp_release {args} {
-        ::itest::log_decision rtsp release $args
-        return ""
-    }
-
-    proc rtsp_respond {args} {
-        ::itest::log_decision rtsp respond $args
-        return ""
-    }
-
-    proc rtsp_status {args} {
-        ::itest::log_decision rtsp status $args
-        return ""
-    }
-
-    proc rtsp_uri {args} {
-        ::itest::log_decision rtsp uri $args
-        return ""
-    }
-
-    proc rtsp_version {args} {
-        ::itest::log_decision rtsp version $args
-        return ""
-    }
-
-
-    # SCTP:: stubs (14 commands)
-
-    proc sctp_client_port {args} {
-        ::itest::log_decision sctp client_port $args
-        return ""
-    }
-
-    proc sctp_collect {args} {
-        ::itest::log_decision sctp collect $args
-        return ""
-    }
-
-    proc sctp_local_port {args} {
-        ::itest::log_decision sctp local_port $args
-        return ""
-    }
-
-    proc sctp_mss {args} {
-        ::itest::log_decision sctp mss $args
-        return ""
-    }
-
-    proc sctp_payload {args} {
-        ::itest::log_decision sctp payload $args
-        return ""
-    }
-
-    proc sctp_ppi {args} {
-        ::itest::log_decision sctp ppi $args
-        return ""
-    }
-
-    proc sctp_release {args} {
-        ::itest::log_decision sctp release $args
-        return ""
-    }
-
-    proc sctp_remote_port {args} {
-        ::itest::log_decision sctp remote_port $args
-        return ""
-    }
-
-    proc sctp_respond {args} {
-        ::itest::log_decision sctp respond $args
-        return ""
-    }
-
-    proc sctp_rto_initial {args} {
-        ::itest::log_decision sctp rto_initial $args
-        return ""
-    }
-
-    proc sctp_rto_max {args} {
-        ::itest::log_decision sctp rto_max $args
-        return ""
-    }
-
-    proc sctp_rto_min {args} {
-        ::itest::log_decision sctp rto_min $args
-        return ""
-    }
-
-    proc sctp_sack_timeout {args} {
-        ::itest::log_decision sctp sack_timeout $args
-        return ""
-    }
-
-    proc sctp_server_port {args} {
-        ::itest::log_decision sctp server_port $args
-        return ""
-    }
-
-
-    # SDP:: stubs (3 commands)
-
-    proc sdp_field {args} {
-        ::itest::log_decision sdp field $args
-        return ""
-    }
-
-    proc sdp_media {args} {
-        ::itest::log_decision sdp media $args
-        return ""
-    }
-
-    proc sdp_session_id {args} {
-        ::itest::log_decision sdp session_id $args
-        return ""
-    }
-
-
-    # SIP:: stubs (16 commands)
-
-    proc sip_call_id {args} {
-        ::itest::log_decision sip call_id $args
-        return ""
-    }
-
-    proc sip_discard {args} {
-        ::itest::log_decision sip discard $args
-        return ""
-    }
-
-    proc sip_from {args} {
-        ::itest::log_decision sip from $args
-        return ""
-    }
-
-    proc sip_header {args} {
-        ::itest::log_decision sip header $args
-        return ""
-    }
-
-    proc sip_message {args} {
-        ::itest::log_decision sip message $args
-        return ""
-    }
-
-    proc sip_method {args} {
-        ::itest::log_decision sip method $args
-        return ""
-    }
-
-    proc sip_payload {args} {
-        ::itest::log_decision sip payload $args
-        return ""
-    }
-
-    proc sip_persist {args} {
-        ::itest::log_decision sip persist $args
-        return ""
-    }
-
-    proc sip_record_route {args} {
-        ::itest::log_decision sip record-route $args
-        return ""
-    }
-
-    proc sip_respond {args} {
-        ::itest::log_decision sip respond $args
-        return ""
-    }
-
-    proc sip_response {args} {
-        ::itest::log_decision sip response $args
-        return ""
-    }
-
-    proc sip_route {args} {
-        ::itest::log_decision sip route $args
-        return ""
-    }
-
-    proc sip_route_status {args} {
-        ::itest::log_decision sip route_status $args
-        return ""
-    }
-
-    proc sip_to {args} {
-        ::itest::log_decision sip to $args
-        return ""
-    }
-
-    proc sip_uri {args} {
-        ::itest::log_decision sip uri $args
-        return ""
-    }
-
-    proc sip_via {args} {
-        ::itest::log_decision sip via $args
-        return ""
-    }
-
-
-    # SIPALG:: stubs (3 commands)
-
-    proc sipalg_hairpin {args} {
-        ::itest::log_decision sipalg hairpin $args
-        return ""
-    }
-
-    proc sipalg_hairpin_default {args} {
-        ::itest::log_decision sipalg hairpin_default $args
-        return ""
-    }
-
-    proc sipalg_nonregister_subscriber_listener {args} {
-        ::itest::log_decision sipalg nonregister_subscriber_listener $args
-        return ""
-    }
-
-
-    # SMTPS:: stubs (3 commands)
-
-    proc smtps_activation_mode {args} {
-        ::itest::log_decision smtps activation_mode $args
-        return ""
-    }
-
-    proc smtps_disable {args} {
-        ::itest::log_decision smtps disable $args
-        return ""
-    }
-
-    proc smtps_enable {args} {
-        ::itest::log_decision smtps enable $args
-        return ""
-    }
-
-
-    # SOCKS:: stubs (3 commands)
-
-    proc socks_allowed {args} {
-        ::itest::log_decision socks allowed $args
-        return ""
-    }
-
-    proc socks_destination {args} {
-        ::itest::log_decision socks destination $args
-        return ""
-    }
-
-    proc socks_version {args} {
-        ::itest::log_decision socks version $args
-        return ""
-    }
-
-
-    # SSE:: stubs (1 commands)
-
-    proc sse_field {args} {
-        ::itest::log_decision sse field $args
-        return ""
-    }
-
-
-    # SSL:: stubs (26 commands)
-
-    proc ssl_allow_dynamic_record_sizing {args} {
-        ::itest::log_decision ssl allow_dynamic_record_sizing $args
-        return ""
-    }
-
-    proc ssl_allow_nonssl {args} {
-        ::itest::log_decision ssl allow_nonssl $args
-        return ""
-    }
-
-    proc ssl_alpn {args} {
-        ::itest::log_decision ssl alpn $args
-        return ""
-    }
-
-    proc ssl_authenticate {args} {
-        ::itest::log_decision ssl authenticate $args
-        return ""
-    }
-
-    proc ssl_c3d {args} {
-        ::itest::log_decision ssl c3d $args
-        return ""
-    }
-
-    proc ssl_cert_constraint {args} {
-        ::itest::log_decision ssl cert_constraint $args
-        return ""
-    }
-
-    proc ssl_clientrandom {args} {
-        ::itest::log_decision ssl clientrandom $args
-        return ""
-    }
-
-    proc ssl_collect {args} {
-        ::itest::log_decision ssl collect $args
-        return ""
-    }
-
-    proc ssl_forward_proxy {args} {
-        ::itest::log_decision ssl forward_proxy $args
-        return ""
-    }
-
-    proc ssl_handshake {args} {
-        ::itest::log_decision ssl handshake $args
-        return ""
-    }
-
-    proc ssl_is_renegotiation_secure {args} {
-        ::itest::log_decision ssl is_renegotiation_secure $args
-        return ""
-    }
-
-    proc ssl_maximum_record_size {args} {
-        ::itest::log_decision ssl maximum_record_size $args
-        return ""
-    }
-
-    proc ssl_mode {args} {
-        ::itest::log_decision ssl mode $args
-        return ""
-    }
-
-    proc ssl_modssl_sessionid_headers {args} {
-        ::itest::log_decision ssl modssl_sessionid_headers $args
-        return ""
-    }
-
-    proc ssl_nextproto {args} {
-        ::itest::log_decision ssl nextproto $args
-        return ""
-    }
-
-    proc ssl_payload {args} {
-        ::itest::log_decision ssl payload $args
-        return ""
-    }
-
-    proc ssl_profile {args} {
-        ::itest::log_decision ssl profile $args
-        return ""
-    }
-
-    proc ssl_release {args} {
-        ::itest::log_decision ssl release $args
-        return ""
-    }
-
-    proc ssl_renegotiate {args} {
-        ::itest::log_decision ssl renegotiate $args
-        return ""
-    }
-
-    proc ssl_secure_renegotiation {args} {
-        ::itest::log_decision ssl secure_renegotiation $args
-        return ""
-    }
-
-    proc ssl_session {args} {
-        ::itest::log_decision ssl session $args
-        return ""
-    }
-
-    proc ssl_sessionsecret {args} {
-        ::itest::log_decision ssl sessionsecret $args
-        return ""
-    }
-
-    proc ssl_sessionticket {args} {
-        ::itest::log_decision ssl sessionticket $args
-        return ""
-    }
-
-    proc ssl_tls13_secret {args} {
-        ::itest::log_decision ssl tls13_secret $args
-        return ""
-    }
-
-    proc ssl_unclean_shutdown {args} {
-        ::itest::log_decision ssl unclean_shutdown $args
-        return ""
-    }
-
-    proc ssl_verify_result {args} {
-        ::itest::log_decision ssl verify_result $args
-        return ""
-    }
-
-
-    # STATS:: stubs (5 commands)
-
-    proc stats_get {args} {
-        ::itest::log_decision stats get $args
-        return ""
-    }
-
-    proc stats_incr {args} {
-        ::itest::log_decision stats incr $args
-        return ""
-    }
-
-    proc stats_set {args} {
-        ::itest::log_decision stats set $args
-        return ""
-    }
-
-    proc stats_setmax {args} {
-        ::itest::log_decision stats setmax $args
-        return ""
-    }
-
-    proc stats_setmin {args} {
-        ::itest::log_decision stats setmin $args
-        return ""
-    }
-
-
-    # STREAM:: stubs (7 commands)
-
-    proc stream_disable {args} {
-        ::itest::log_decision stream disable $args
-        return ""
-    }
-
-    proc stream_enable {args} {
-        ::itest::log_decision stream enable $args
-        return ""
-    }
-
-    proc stream_encoding {args} {
-        ::itest::log_decision stream encoding $args
-        return ""
-    }
-
-    proc stream_expression {args} {
-        ::itest::log_decision stream expression $args
-        return ""
-    }
-
-    proc stream_match {args} {
-        ::itest::log_decision stream match $args
-        return ""
-    }
-
-    proc stream_max_matchsize {args} {
-        ::itest::log_decision stream max_matchsize $args
-        return ""
-    }
-
-    proc stream_replace {args} {
-        ::itest::log_decision stream replace $args
-        return ""
-    }
-
-
-    # TAP:: stubs (5 commands)
-
-    proc tap_action {args} {
-        ::itest::log_decision tap action $args
-        return ""
-    }
-
-    proc tap_config {args} {
-        ::itest::log_decision tap config $args
-        return ""
-    }
-
-    proc tap_insight {args} {
-        ::itest::log_decision tap insight $args
-        return ""
-    }
-
-    proc tap_insight_requested {args} {
-        ::itest::log_decision tap insight_requested $args
-        return ""
-    }
-
-    proc tap_score {args} {
-        ::itest::log_decision tap score $args
-        return ""
-    }
-
-
-    # TCP:: stubs (38 commands)
-
-    proc tcp_abc {args} {
-        ::itest::log_decision tcp abc $args
-        return ""
-    }
-
-    proc tcp_analytics {args} {
-        ::itest::log_decision tcp analytics $args
-        return ""
-    }
-
-    proc tcp_autowin {args} {
-        ::itest::log_decision tcp autowin $args
-        return ""
-    }
-
-    proc tcp_congestion {args} {
-        ::itest::log_decision tcp congestion $args
-        return ""
-    }
-
-    proc tcp_delayed_ack {args} {
-        ::itest::log_decision tcp delayed_ack $args
-        return ""
-    }
-
-    proc tcp_dsack {args} {
-        ::itest::log_decision tcp dsack $args
-        return ""
-    }
-
-    proc tcp_earlyrxmit {args} {
-        ::itest::log_decision tcp earlyrxmit $args
-        return ""
-    }
-
-    proc tcp_ecn {args} {
-        ::itest::log_decision tcp ecn $args
-        return ""
-    }
-
-    proc tcp_enhanced_loss_recovery {args} {
-        ::itest::log_decision tcp enhanced_loss_recovery $args
-        return ""
-    }
-
-    proc tcp_idletime {args} {
-        ::itest::log_decision tcp idletime $args
-        return ""
-    }
-
-    proc tcp_keepalive {args} {
-        ::itest::log_decision tcp keepalive $args
-        return ""
-    }
-
-    proc tcp_limxmit {args} {
-        ::itest::log_decision tcp limxmit $args
-        return ""
-    }
-
-    proc tcp_lossfilter {args} {
-        ::itest::log_decision tcp lossfilter $args
-        return ""
-    }
-
-    proc tcp_lossfilterburst {args} {
-        ::itest::log_decision tcp lossfilterburst $args
-        return ""
-    }
-
-    proc tcp_lossfilterrate {args} {
-        ::itest::log_decision tcp lossfilterrate $args
-        return ""
-    }
-
-    proc tcp_nagle {args} {
-        ::itest::log_decision tcp nagle $args
-        return ""
-    }
-
-    proc tcp_naglemode {args} {
-        ::itest::log_decision tcp naglemode $args
-        return ""
-    }
-
-    proc tcp_naglestate {args} {
-        ::itest::log_decision tcp naglestate $args
-        return ""
-    }
-
-    proc tcp_offset {args} {
-        ::itest::log_decision tcp offset $args
-        return ""
-    }
-
-    proc tcp_pacing {args} {
-        ::itest::log_decision tcp pacing $args
-        return ""
-    }
-
-    proc tcp_proxybuffer {args} {
-        ::itest::log_decision tcp proxybuffer $args
-        return ""
-    }
-
-    proc tcp_proxybufferhigh {args} {
-        ::itest::log_decision tcp proxybufferhigh $args
-        return ""
-    }
-
-    proc tcp_proxybufferlow {args} {
-        ::itest::log_decision tcp proxybufferlow $args
-        return ""
-    }
-
-    proc tcp_push_flag {args} {
-        ::itest::log_decision tcp push_flag $args
-        return ""
-    }
-
-    proc tcp_rcv_scale {args} {
-        ::itest::log_decision tcp rcv_scale $args
-        return ""
-    }
-
-    proc tcp_rcv_size {args} {
-        ::itest::log_decision tcp rcv_size $args
-        return ""
-    }
-
-    proc tcp_recvwnd {args} {
-        ::itest::log_decision tcp recvwnd $args
-        return ""
-    }
-
-    proc tcp_rexmt_thresh {args} {
-        ::itest::log_decision tcp rexmt_thresh $args
-        return ""
-    }
-
-    proc tcp_rt_metrics_timeout {args} {
-        ::itest::log_decision tcp rt_metrics_timeout $args
-        return ""
-    }
-
-    proc tcp_rto {args} {
-        ::itest::log_decision tcp rto $args
-        return ""
-    }
-
-    proc tcp_rttvar {args} {
-        ::itest::log_decision tcp rttvar $args
-        return ""
-    }
-
-    proc tcp_sendbuf {args} {
-        ::itest::log_decision tcp sendbuf $args
-        return ""
-    }
-
-    proc tcp_setmss {args} {
-        ::itest::log_decision tcp setmss $args
-        return ""
-    }
-
-    proc tcp_snd_cwnd {args} {
-        ::itest::log_decision tcp snd_cwnd $args
-        return ""
-    }
-
-    proc tcp_snd_scale {args} {
-        ::itest::log_decision tcp snd_scale $args
-        return ""
-    }
-
-    proc tcp_snd_ssthresh {args} {
-        ::itest::log_decision tcp snd_ssthresh $args
-        return ""
-    }
-
-    proc tcp_snd_wnd {args} {
-        ::itest::log_decision tcp snd_wnd $args
-        return ""
-    }
-
-    proc tcp_unused_port {args} {
-        ::itest::log_decision tcp unused_port $args
-        return ""
-    }
-
-
-    # TDS:: stubs (2 commands)
-
-    proc tds_msg {args} {
-        ::itest::log_decision tds msg $args
-        return ""
-    }
-
-    proc tds_session {args} {
-        ::itest::log_decision tds session $args
-        return ""
-    }
-
-
-    # TMM:: stubs (5 commands)
-
-    proc tmm_cmp_count {args} {
-        ::itest::log_decision tmm cmp_count $args
-        return ""
-    }
-
-    proc tmm_cmp_group {args} {
-        ::itest::log_decision tmm cmp_group $args
-        return ""
-    }
-
-    proc tmm_cmp_groups {args} {
-        ::itest::log_decision tmm cmp_groups $args
-        return ""
-    }
-
-    proc tmm_cmp_primary_group {args} {
-        ::itest::log_decision tmm cmp_primary_group $args
-        return ""
-    }
-
-    proc tmm_cmp_unit {args} {
-        ::itest::log_decision tmm cmp_unit $args
-        return ""
-    }
-
-
-    # UDP:: stubs (15 commands)
-
-    proc udp_client_port {args} {
-        ::itest::log_decision udp client_port $args
-        return ""
-    }
-
-    proc udp_debug_queue {args} {
-        ::itest::log_decision udp debug_queue $args
-        return ""
-    }
-
-    proc udp_drop {args} {
-        ::itest::log_decision udp drop $args
-        return ""
-    }
-
-    proc udp_hold {args} {
-        ::itest::log_decision udp hold $args
-        return ""
-    }
-
-    proc udp_local_port {args} {
-        ::itest::log_decision udp local_port $args
-        return ""
-    }
-
-    proc udp_max_buf_pkts {args} {
-        ::itest::log_decision udp max_buf_pkts $args
-        return ""
-    }
-
-    proc udp_max_rate {args} {
-        ::itest::log_decision udp max_rate $args
-        return ""
-    }
-
-    proc udp_mss {args} {
-        ::itest::log_decision udp mss $args
-        return ""
-    }
-
-    proc udp_payload {args} {
-        ::itest::log_decision udp payload $args
-        return ""
-    }
-
-    proc udp_release {args} {
-        ::itest::log_decision udp release $args
-        return ""
-    }
-
-    proc udp_remote_port {args} {
-        ::itest::log_decision udp remote_port $args
-        return ""
-    }
-
-    proc udp_respond {args} {
-        ::itest::log_decision udp respond $args
-        return ""
-    }
-
-    proc udp_sendbuffer {args} {
-        ::itest::log_decision udp sendbuffer $args
-        return ""
-    }
-
-    proc udp_server_port {args} {
-        ::itest::log_decision udp server_port $args
-        return ""
-    }
-
-    proc udp_unused_port {args} {
-        ::itest::log_decision udp unused_port $args
-        return ""
-    }
-
-
-    # URI:: stubs (11 commands)
-
-    proc uri_basename {args} {
-        ::itest::log_decision uri basename $args
-        return ""
-    }
-
-    proc uri_compare {args} {
-        ::itest::log_decision uri compare $args
-        return ""
-    }
-
-    proc uri_decode {args} {
-        ::itest::log_decision uri decode $args
-        return ""
-    }
-
-    proc uri_encode {args} {
-        ::itest::log_decision uri encode $args
-        return ""
-    }
-
-    proc uri_encode_component {args} {
-        ::itest::log_decision uri encode_component $args
-        return ""
-    }
-
-    proc uri_escape {args} {
-        ::itest::log_decision uri escape $args
-        return ""
-    }
-
-    proc uri_host {args} {
-        ::itest::log_decision uri host $args
-        return ""
-    }
-
-    proc uri_path {args} {
-        ::itest::log_decision uri path $args
-        return ""
-    }
-
-    proc uri_port {args} {
-        ::itest::log_decision uri port $args
-        return ""
-    }
-
-    proc uri_protocol {args} {
-        ::itest::log_decision uri protocol $args
-        return ""
-    }
-
-    proc uri_query {args} {
-        ::itest::log_decision uri query $args
-        return ""
-    }
-
-
-    # VALIDATE:: stubs (1 commands)
-
-    proc validate_protocol {args} {
-        ::itest::log_decision validate protocol $args
-        return ""
-    }
-
-
-    # VDI:: stubs (2 commands)
-
-    proc vdi_disable {args} {
-        ::itest::log_decision vdi disable $args
-        return ""
-    }
-
-    proc vdi_enable {args} {
-        ::itest::log_decision vdi enable $args
-        return ""
-    }
-
-
-    # WAM:: stubs (2 commands)
-
-    proc wam_disable {args} {
-        ::itest::log_decision wam disable $args
-        return ""
-    }
-
-    proc wam_enable {args} {
-        ::itest::log_decision wam enable $args
-        return ""
-    }
-
-
-    # WEBSSO:: stubs (3 commands)
-
-    proc websso_disable {args} {
-        ::itest::log_decision websso disable $args
-        return ""
-    }
-
-    proc websso_enable {args} {
-        ::itest::log_decision websso enable $args
-        return ""
-    }
-
-    proc websso_select {args} {
-        ::itest::log_decision websso select $args
-        return ""
-    }
-
-
-    # WS:: stubs (12 commands)
-
-    proc ws_collect {args} {
-        ::itest::log_decision ws collect $args
-        return ""
-    }
-
-    proc ws_disconnect {args} {
-        ::itest::log_decision ws disconnect $args
-        return ""
-    }
-
-    proc ws_enabled {args} {
-        ::itest::log_decision ws enabled $args
-        return ""
-    }
-
-    proc ws_frame {args} {
-        ::itest::log_decision ws frame $args
-        return ""
-    }
-
-    proc ws_masking {args} {
-        ::itest::log_decision ws masking $args
-        return ""
-    }
-
-    proc ws_message {args} {
-        ::itest::log_decision ws message $args
-        return ""
-    }
-
-    proc ws_payload {args} {
-        ::itest::log_decision ws payload $args
-        return ""
-    }
-
-    proc ws_payload_ivs {args} {
-        ::itest::log_decision ws payload_ivs $args
-        return ""
-    }
-
-    proc ws_payload_processing {args} {
-        ::itest::log_decision ws payload_processing $args
-        return ""
-    }
-
-    proc ws_release {args} {
-        ::itest::log_decision ws release $args
-        return ""
-    }
-
-    proc ws_request {args} {
-        ::itest::log_decision ws request $args
-        return ""
-    }
-
-    proc ws_response {args} {
-        ::itest::log_decision ws response $args
-        return ""
-    }
-
-
-    # X509:: stubs (16 commands)
-
-    proc x509_cert_fields {args} {
-        ::itest::log_decision x509 cert_fields $args
-        return ""
-    }
-
-    proc x509_extensions {args} {
-        ::itest::log_decision x509 extensions $args
-        return ""
-    }
-
-    proc x509_hash {args} {
-        ::itest::log_decision x509 hash $args
-        return ""
-    }
-
-    proc x509_issuer {args} {
-        ::itest::log_decision x509 issuer $args
-        return ""
-    }
-
-    proc x509_not_valid_after {args} {
-        ::itest::log_decision x509 not_valid_after $args
-        return ""
-    }
-
-    proc x509_not_valid_before {args} {
-        ::itest::log_decision x509 not_valid_before $args
-        return ""
-    }
-
-    proc x509_pem2der {args} {
-        ::itest::log_decision x509 pem2der $args
-        return ""
-    }
-
-    proc x509_serial_number {args} {
-        ::itest::log_decision x509 serial_number $args
-        return ""
-    }
-
-    proc x509_signature_algorithm {args} {
-        ::itest::log_decision x509 signature_algorithm $args
-        return ""
-    }
-
-    proc x509_subject {args} {
-        ::itest::log_decision x509 subject $args
-        return ""
-    }
-
-    proc x509_subject_public_key {args} {
-        ::itest::log_decision x509 subject_public_key $args
-        return ""
-    }
-
-    proc x509_subject_public_key_RSA_bits {args} {
-        ::itest::log_decision x509 subject_public_key_RSA_bits $args
-        return ""
-    }
-
-    proc x509_subject_public_key_type {args} {
-        ::itest::log_decision x509 subject_public_key_type $args
-        return ""
-    }
-
-    proc x509_verify_cert_error_string {args} {
-        ::itest::log_decision x509 verify_cert_error_string $args
-        return ""
-    }
-
-    proc x509_version {args} {
-        ::itest::log_decision x509 version $args
-        return ""
-    }
-
-    proc x509_whole {args} {
-        ::itest::log_decision x509 whole $args
-        return ""
-    }
-
-
-    # XLAT:: stubs (7 commands)
-
-    proc xlat_listen {args} {
-        ::itest::log_decision xlat listen $args
-        return ""
-    }
-
-    proc xlat_listen_lifetime {args} {
-        ::itest::log_decision xlat listen_lifetime $args
-        return ""
-    }
-
-    proc xlat_src_addr {args} {
-        ::itest::log_decision xlat src_addr $args
-        return ""
-    }
-
-    proc xlat_src_config {args} {
-        ::itest::log_decision xlat src_config $args
-        return ""
-    }
-
-    proc xlat_src_endpoint_reservation {args} {
-        ::itest::log_decision xlat src_endpoint_reservation $args
-        return ""
-    }
-
-    proc xlat_src_nat_valid_range {args} {
-        ::itest::log_decision xlat src_nat_valid_range $args
-        return ""
-    }
-
-    proc xlat_src_port {args} {
-        ::itest::log_decision xlat src_port $args
-        return ""
-    }
-
-
-    # XML:: stubs (12 commands)
-
-    proc xml_address {args} {
-        ::itest::log_decision xml address $args
-        return ""
-    }
-
-    proc xml_collect {args} {
-        ::itest::log_decision xml collect $args
-        return ""
-    }
-
-    proc xml_disable {args} {
-        ::itest::log_decision xml disable $args
-        return ""
-    }
-
-    proc xml_element {args} {
-        ::itest::log_decision xml element $args
-        return ""
-    }
-
-    proc xml_enable {args} {
-        ::itest::log_decision xml enable $args
-        return ""
-    }
-
-    proc xml_event {args} {
-        ::itest::log_decision xml event $args
-        return ""
-    }
-
-    proc xml_eventid {args} {
-        ::itest::log_decision xml eventid $args
-        return ""
-    }
-
-    proc xml_parse {args} {
-        ::itest::log_decision xml parse $args
-        return ""
-    }
-
-    proc xml_payload {args} {
-        ::itest::log_decision xml payload $args
-        return ""
-    }
-
-    proc xml_release {args} {
-        ::itest::log_decision xml release $args
-        return ""
-    }
-
-    proc xml_soap {args} {
-        ::itest::log_decision xml soap $args
-        return ""
-    }
-
-    proc xml_subscribe {args} {
-        ::itest::log_decision xml subscribe $args
-        return ""
-    }
-
-
-    # base64:: stubs (2 commands)
-
-    proc base64_decode {args} {
-        ::itest::log_decision base64 decode $args
-        return ""
-    }
-
-    proc base64_encode {args} {
-        ::itest::log_decision base64 encode $args
-        return ""
-    }
-
-
-    # cmdline:: stubs (10 commands)
-
-    proc cmdline_getArgv0 {args} {
-        ::itest::log_decision cmdline getArgv0 $args
-        return ""
-    }
-
-    proc cmdline_getKnownOpt {args} {
-        ::itest::log_decision cmdline getKnownOpt $args
-        return ""
-    }
-
-    proc cmdline_getKnownOptions {args} {
-        ::itest::log_decision cmdline getKnownOptions $args
-        return ""
-    }
-
-    proc cmdline_getfiles {args} {
-        ::itest::log_decision cmdline getfiles $args
-        return ""
-    }
-
-    proc cmdline_getopt {args} {
-        ::itest::log_decision cmdline getopt $args
-        return ""
-    }
-
-    proc cmdline_getoptions {args} {
-        ::itest::log_decision cmdline getoptions $args
-        return ""
-    }
-
-    proc cmdline_typedGetopt {args} {
-        ::itest::log_decision cmdline typedGetopt $args
-        return ""
-    }
-
-    proc cmdline_typedGetoptions {args} {
-        ::itest::log_decision cmdline typedGetoptions $args
-        return ""
-    }
-
-    proc cmdline_typedUsage {args} {
-        ::itest::log_decision cmdline typedUsage $args
-        return ""
-    }
-
-    proc cmdline_usage {args} {
-        ::itest::log_decision cmdline usage $args
-        return ""
-    }
-
-
-    # csv:: stubs (12 commands)
-
-    proc csv_iscomplete {args} {
-        ::itest::log_decision csv iscomplete $args
-        return ""
-    }
-
-    proc csv_join {args} {
-        ::itest::log_decision csv join $args
-        return ""
-    }
-
-    proc csv_joinlist {args} {
-        ::itest::log_decision csv joinlist $args
-        return ""
-    }
-
-    proc csv_joinmatrix {args} {
-        ::itest::log_decision csv joinmatrix $args
-        return ""
-    }
-
-    proc csv_read2matrix {args} {
-        ::itest::log_decision csv read2matrix $args
-        return ""
-    }
-
-    proc csv_read2queue {args} {
-        ::itest::log_decision csv read2queue $args
-        return ""
-    }
-
-    proc csv_report {args} {
-        ::itest::log_decision csv report $args
-        return ""
-    }
-
-    proc csv_split {args} {
-        ::itest::log_decision csv split $args
-        return ""
-    }
-
-    proc csv_split2matrix {args} {
-        ::itest::log_decision csv split2matrix $args
-        return ""
-    }
-
-    proc csv_split2queue {args} {
-        ::itest::log_decision csv split2queue $args
-        return ""
-    }
-
-    proc csv_writematrix {args} {
-        ::itest::log_decision csv writematrix $args
-        return ""
-    }
-
-    proc csv_writequeue {args} {
-        ::itest::log_decision csv writequeue $args
-        return ""
-    }
-
-
-    # dns:: stubs (13 commands)
-
-    proc dns_address {args} {
-        ::itest::log_decision dns address $args
-        return ""
-    }
-
-    proc dns_cleanup {args} {
-        ::itest::log_decision dns cleanup $args
-        return ""
-    }
-
-    proc dns_cname {args} {
-        ::itest::log_decision dns cname $args
-        return ""
-    }
-
-    proc dns_configure {args} {
-        ::itest::log_decision dns configure $args
-        return ""
-    }
-
-    proc dns_dump {args} {
-        ::itest::log_decision dns dump $args
-        return ""
-    }
-
-    proc dns_error {args} {
-        ::itest::log_decision dns error $args
-        return ""
-    }
-
-    proc dns_errorcode {args} {
-        ::itest::log_decision dns errorcode $args
-        return ""
-    }
-
-    proc dns_name {args} {
-        ::itest::log_decision dns name $args
-        return ""
-    }
-
-    proc dns_reset {args} {
-        ::itest::log_decision dns reset $args
-        return ""
-    }
-
-    proc dns_resolve {args} {
-        ::itest::log_decision dns resolve $args
-        return ""
-    }
-
-    proc dns_result {args} {
-        ::itest::log_decision dns result $args
-        return ""
-    }
-
-    proc dns_status {args} {
-        ::itest::log_decision dns status $args
-        return ""
-    }
-
-    proc dns_wait {args} {
-        ::itest::log_decision dns wait $args
-        return ""
-    }
-
-
-    # fileutil:: stubs (26 commands)
-
-    proc fileutil_appendToFile {args} {
-        ::itest::log_decision fileutil appendToFile $args
-        return ""
-    }
-
-    proc fileutil_cat {args} {
-        ::itest::log_decision fileutil cat $args
-        return ""
-    }
-
-    proc fileutil_fileType {args} {
-        ::itest::log_decision fileutil fileType $args
-        return ""
-    }
-
-    proc fileutil_find {args} {
-        ::itest::log_decision fileutil find $args
-        return ""
-    }
-
-    proc fileutil_findByPattern {args} {
-        ::itest::log_decision fileutil findByPattern $args
-        return ""
-    }
-
-    proc fileutil_foreachLine {args} {
-        ::itest::log_decision fileutil foreachLine $args
-        return ""
-    }
-
-    proc fileutil_fullnormalize {args} {
-        ::itest::log_decision fileutil fullnormalize $args
-        return ""
-    }
-
-    proc fileutil_grep {args} {
-        ::itest::log_decision fileutil grep $args
-        return ""
-    }
-
-    proc fileutil_insertIntoFile {args} {
-        ::itest::log_decision fileutil insertIntoFile $args
-        return ""
-    }
-
-    proc fileutil_install {args} {
-        ::itest::log_decision fileutil install $args
-        return ""
-    }
-
-    proc fileutil_jail {args} {
-        ::itest::log_decision fileutil jail $args
-        return ""
-    }
-
-    proc fileutil_lexnormalize {args} {
-        ::itest::log_decision fileutil lexnormalize $args
-        return ""
-    }
-
-    proc fileutil_maketempdir {args} {
-        ::itest::log_decision fileutil maketempdir $args
-        return ""
-    }
-
-    proc fileutil_relative {args} {
-        ::itest::log_decision fileutil relative $args
-        return ""
-    }
-
-    proc fileutil_relativeUrl {args} {
-        ::itest::log_decision fileutil relativeUrl $args
-        return ""
-    }
-
-    proc fileutil_removeFromFile {args} {
-        ::itest::log_decision fileutil removeFromFile $args
-        return ""
-    }
-
-    proc fileutil_replaceInFile {args} {
-        ::itest::log_decision fileutil replaceInFile $args
-        return ""
-    }
-
-    proc fileutil_stripN {args} {
-        ::itest::log_decision fileutil stripN $args
-        return ""
-    }
-
-    proc fileutil_stripPwd {args} {
-        ::itest::log_decision fileutil stripPwd $args
-        return ""
-    }
-
-    proc fileutil_tempdir {args} {
-        ::itest::log_decision fileutil tempdir $args
-        return ""
-    }
-
-    proc fileutil_tempdirReset {args} {
-        ::itest::log_decision fileutil tempdirReset $args
-        return ""
-    }
-
-    proc fileutil_tempfile {args} {
-        ::itest::log_decision fileutil tempfile $args
-        return ""
-    }
-
-    proc fileutil_test {args} {
-        ::itest::log_decision fileutil test $args
-        return ""
-    }
-
-    proc fileutil_touch {args} {
-        ::itest::log_decision fileutil touch $args
-        return ""
-    }
-
-    proc fileutil_updateInPlace {args} {
-        ::itest::log_decision fileutil updateInPlace $args
-        return ""
-    }
-
-    proc fileutil_writeFile {args} {
-        ::itest::log_decision fileutil writeFile $args
-        return ""
-    }
-
-
-    # html:: stubs (2 commands)
-
-    proc html_html_entities {args} {
-        ::itest::log_decision html html_entities $args
-        return ""
-    }
-
-    proc html_tagstrip {args} {
-        ::itest::log_decision html tagstrip $args
-        return ""
-    }
-
-
-    # http:: stubs (28 commands)
-
-    proc http_cleanup {args} {
-        ::itest::log_decision http cleanup $args
-        return ""
-    }
-
-    proc http_code {args} {
-        ::itest::log_decision http code $args
-        return ""
-    }
-
-    proc http_config {args} {
-        ::itest::log_decision http config $args
-        return ""
-    }
-
-    proc http_cookiejar {args} {
-        ::itest::log_decision http cookiejar $args
-        return ""
-    }
-
-    proc http_data {args} {
-        ::itest::log_decision http data $args
-        return ""
-    }
-
-    proc http_error {args} {
-        ::itest::log_decision http error $args
-        return ""
-    }
-
-    proc http_formatQuery {args} {
-        ::itest::log_decision http formatQuery $args
-        return ""
-    }
-
-    proc http_geturl {args} {
-        ::itest::log_decision http geturl $args
-        return ""
-    }
-
-    proc http_meta {args} {
-        ::itest::log_decision http meta $args
-        return ""
-    }
-
-    proc http_ncode {args} {
-        ::itest::log_decision http ncode $args
-        return ""
-    }
-
-    proc http_postError {args} {
-        ::itest::log_decision http postError $args
-        return ""
-    }
-
-    proc http_quoteString {args} {
-        ::itest::log_decision http quoteString $args
-        return ""
-    }
-
-    proc http_reasonPhrase {args} {
-        ::itest::log_decision http reasonPhrase $args
-        return ""
-    }
-
-    proc http_register {args} {
-        ::itest::log_decision http register $args
-        return ""
-    }
-
-    proc http_registerError {args} {
-        ::itest::log_decision http registerError $args
-        return ""
-    }
-
-    proc http_requestHeaderValue {args} {
-        ::itest::log_decision http requestHeaderValue $args
-        return ""
-    }
-
-    proc http_requestHeaders {args} {
-        ::itest::log_decision http requestHeaders $args
-        return ""
-    }
-
-    proc http_requestLine {args} {
-        ::itest::log_decision http requestLine $args
-        return ""
-    }
-
-    proc http_reset {args} {
-        ::itest::log_decision http reset $args
-        return ""
-    }
-
-    proc http_responseBody {args} {
-        ::itest::log_decision http responseBody $args
-        return ""
-    }
-
-    proc http_responseCode {args} {
-        ::itest::log_decision http responseCode $args
-        return ""
-    }
-
-    proc http_responseHeaderValue {args} {
-        ::itest::log_decision http responseHeaderValue $args
-        return ""
-    }
-
-    proc http_responseHeaders {args} {
-        ::itest::log_decision http responseHeaders $args
-        return ""
-    }
-
-    proc http_responseInfo {args} {
-        ::itest::log_decision http responseInfo $args
-        return ""
-    }
-
-    proc http_responseLine {args} {
-        ::itest::log_decision http responseLine $args
-        return ""
-    }
-
-    proc http_size {args} {
-        ::itest::log_decision http size $args
-        return ""
-    }
-
-    proc http_unregister {args} {
-        ::itest::log_decision http unregister $args
-        return ""
-    }
-
-    proc http_wait {args} {
-        ::itest::log_decision http wait $args
-        return ""
-    }
-
-
-    # ip:: stubs (10 commands)
-
-    proc ip_collapse {args} {
-        ::itest::log_decision ip collapse $args
-        return ""
-    }
-
-    proc ip_contract {args} {
-        ::itest::log_decision ip contract $args
-        return ""
-    }
-
-    proc ip_equal {args} {
-        ::itest::log_decision ip equal $args
-        return ""
-    }
-
-    proc ip_is {args} {
-        ::itest::log_decision ip is $args
-        return ""
-    }
-
-    proc ip_mask {args} {
-        ::itest::log_decision ip mask $args
-        return ""
-    }
-
-    proc ip_normalize {args} {
-        ::itest::log_decision ip normalize $args
-        return ""
-    }
-
-    proc ip_prefix {args} {
-        ::itest::log_decision ip prefix $args
-        return ""
-    }
-
-    proc ip_subtract {args} {
-        ::itest::log_decision ip subtract $args
-        return ""
-    }
-
-    proc ip_type {args} {
-        ::itest::log_decision ip type $args
-        return ""
-    }
-
-    proc ip_version {args} {
-        ::itest::log_decision ip version $args
-        return ""
-    }
-
-
-    # json:: stubs (6 commands)
-
-    proc json_dict2json {args} {
-        ::itest::log_decision json dict2json $args
-        return ""
-    }
-
-    proc json_json2dict {args} {
-        ::itest::log_decision json json2dict $args
-        return ""
-    }
-
-    proc json_list2json {args} {
-        ::itest::log_decision json list2json $args
-        return ""
-    }
-
-    proc json_many_json2dict {args} {
-        ::itest::log_decision json many-json2dict $args
-        return ""
-    }
-
-    proc json_string2json {args} {
-        ::itest::log_decision json string2json $args
-        return ""
-    }
-
-    proc json_validate {args} {
-        ::itest::log_decision json validate $args
-        return ""
-    }
-
-
-    # logger:: stubs (10 commands)
-
-    proc logger_disable {args} {
-        ::itest::log_decision logger disable $args
-        return ""
-    }
-
-    proc logger_enable {args} {
-        ::itest::log_decision logger enable $args
-        return ""
-    }
-
-    proc logger_import {args} {
-        ::itest::log_decision logger import $args
-        return ""
-    }
-
-    proc logger_init {args} {
-        ::itest::log_decision logger init $args
-        return ""
-    }
-
-    proc logger_initNamespace {args} {
-        ::itest::log_decision logger initNamespace $args
-        return ""
-    }
-
-    proc logger_levels {args} {
-        ::itest::log_decision logger levels $args
-        return ""
-    }
-
-    proc logger_servicecmd {args} {
-        ::itest::log_decision logger servicecmd $args
-        return ""
-    }
-
-    proc logger_services {args} {
-        ::itest::log_decision logger services $args
-        return ""
-    }
-
-    proc logger_setlevel {args} {
-        ::itest::log_decision logger setlevel $args
-        return ""
-    }
-
-    proc logger_walk {args} {
-        ::itest::log_decision logger walk $args
-        return ""
-    }
-
-
-    # math:: stubs (43 commands)
-
-    proc math_analyse_Kruskal_Wallis {args} {
-        ::itest::log_decision math analyse-Kruskal-Wallis $args
-        return ""
-    }
-
-    proc math_autocorr {args} {
-        ::itest::log_decision math autocorr $args
-        return ""
-    }
-
-    proc math_basic_stats {args} {
-        ::itest::log_decision math basic-stats $args
-        return ""
-    }
-
-    proc math_control_Rchart {args} {
-        ::itest::log_decision math control-Rchart $args
-        return ""
-    }
-
-    proc math_control_xbar {args} {
-        ::itest::log_decision math control-xbar $args
-        return ""
-    }
-
-    proc math_corr {args} {
-        ::itest::log_decision math corr $args
-        return ""
-    }
-
-    proc math_crosscorr {args} {
-        ::itest::log_decision math crosscorr $args
-        return ""
-    }
-
-    proc math_filter {args} {
-        ::itest::log_decision math filter $args
-        return ""
-    }
-
-    proc math_group_rank {args} {
-        ::itest::log_decision math group-rank $args
-        return ""
-    }
-
-    proc math_histogram {args} {
-        ::itest::log_decision math histogram $args
-        return ""
-    }
-
-    proc math_histogram_alt {args} {
-        ::itest::log_decision math histogram-alt $args
-        return ""
-    }
-
-    proc math_interval_mean_stdev {args} {
-        ::itest::log_decision math interval-mean-stdev $args
-        return ""
-    }
-
-    proc math_lillieforsFit {args} {
-        ::itest::log_decision math lillieforsFit $args
-        return ""
-    }
-
-    proc math_linear_model {args} {
-        ::itest::log_decision math linear-model $args
-        return ""
-    }
-
-    proc math_linear_residuals {args} {
-        ::itest::log_decision math linear-residuals $args
-        return ""
-    }
-
-    proc math_map {args} {
-        ::itest::log_decision math map $args
-        return ""
-    }
-
-    proc math_max {args} {
-        ::itest::log_decision math max $args
-        return ""
-    }
-
-    proc math_mean {args} {
-        ::itest::log_decision math mean $args
-        return ""
-    }
-
-    proc math_mean_histogram_limits {args} {
-        ::itest::log_decision math mean-histogram-limits $args
-        return ""
-    }
-
-    proc math_median {args} {
-        ::itest::log_decision math median $args
-        return ""
-    }
-
-    proc math_min {args} {
-        ::itest::log_decision math min $args
-        return ""
-    }
-
-    proc math_minmax_histogram_limits {args} {
-        ::itest::log_decision math minmax-histogram-limits $args
-        return ""
-    }
-
-    proc math_number {args} {
-        ::itest::log_decision math number $args
-        return ""
-    }
-
-    proc math_print_2x2 {args} {
-        ::itest::log_decision math print-2x2 $args
-        return ""
-    }
-
-    proc math_pstdev {args} {
-        ::itest::log_decision math pstdev $args
-        return ""
-    }
-
-    proc math_pvar {args} {
-        ::itest::log_decision math pvar $args
-        return ""
-    }
-
-    proc math_quantiles {args} {
-        ::itest::log_decision math quantiles $args
-        return ""
-    }
-
-    proc math_samplescount {args} {
-        ::itest::log_decision math samplescount $args
-        return ""
-    }
-
-    proc math_spearman_rank {args} {
-        ::itest::log_decision math spearman-rank $args
-        return ""
-    }
-
-    proc math_spearman_rank_extended {args} {
-        ::itest::log_decision math spearman-rank-extended $args
-        return ""
-    }
-
-    proc math_stdev {args} {
-        ::itest::log_decision math stdev $args
-        return ""
-    }
-
-    proc math_t_test_mean {args} {
-        ::itest::log_decision math t-test-mean $args
-        return ""
-    }
-
-    proc math_test_2x2 {args} {
-        ::itest::log_decision math test-2x2 $args
-        return ""
-    }
-
-    proc math_test_Duckworth {args} {
-        ::itest::log_decision math test-Duckworth $args
-        return ""
-    }
-
-    proc math_test_Dunnett {args} {
-        ::itest::log_decision math test-Dunnett $args
-        return ""
-    }
-
-    proc math_test_Kruskal_Wallis {args} {
-        ::itest::log_decision math test-Kruskal-Wallis $args
-        return ""
-    }
-
-    proc math_test_Rchart {args} {
-        ::itest::log_decision math test-Rchart $args
-        return ""
-    }
-
-    proc math_test_Tukey_range {args} {
-        ::itest::log_decision math test-Tukey-range $args
-        return ""
-    }
-
-    proc math_test_Wilcoxon {args} {
-        ::itest::log_decision math test-Wilcoxon $args
-        return ""
-    }
-
-    proc math_test_anova_F {args} {
-        ::itest::log_decision math test-anova-F $args
-        return ""
-    }
-
-    proc math_test_normal {args} {
-        ::itest::log_decision math test-normal $args
-        return ""
-    }
-
-    proc math_test_xbar {args} {
-        ::itest::log_decision math test-xbar $args
-        return ""
-    }
-
-    proc math_var {args} {
-        ::itest::log_decision math var $args
-        return ""
-    }
-
-
-    # md5:: stubs (1 commands)
-
-    proc md5_md5 {args} {
-        ::itest::log_decision md5 md5 $args
-        return ""
-    }
-
-
-    # mime:: stubs (19 commands)
-
-    proc mime_buildmessage {args} {
-        ::itest::log_decision mime buildmessage $args
-        return ""
-    }
-
-    proc mime_copymessage {args} {
-        ::itest::log_decision mime copymessage $args
-        return ""
-    }
-
-    proc mime_field_decode {args} {
-        ::itest::log_decision mime field_decode $args
-        return ""
-    }
-
-    proc mime_finalize {args} {
-        ::itest::log_decision mime finalize $args
-        return ""
-    }
-
-    proc mime_getContentType {args} {
-        ::itest::log_decision mime getContentType $args
-        return ""
-    }
-
-    proc mime_getTransferEncoding {args} {
-        ::itest::log_decision mime getTransferEncoding $args
-        return ""
-    }
-
-    proc mime_getbody {args} {
-        ::itest::log_decision mime getbody $args
-        return ""
-    }
-
-    proc mime_getheader {args} {
-        ::itest::log_decision mime getheader $args
-        return ""
-    }
-
-    proc mime_getproperty {args} {
-        ::itest::log_decision mime getproperty $args
-        return ""
-    }
-
-    proc mime_getsize {args} {
-        ::itest::log_decision mime getsize $args
-        return ""
-    }
-
-    proc mime_initialize {args} {
-        ::itest::log_decision mime initialize $args
-        return ""
-    }
-
-    proc mime_mapencoding {args} {
-        ::itest::log_decision mime mapencoding $args
-        return ""
-    }
-
-    proc mime_parseaddress {args} {
-        ::itest::log_decision mime parseaddress $args
-        return ""
-    }
-
-    proc mime_parsedatetime {args} {
-        ::itest::log_decision mime parsedatetime $args
-        return ""
-    }
-
-    proc mime_reversemapencoding {args} {
-        ::itest::log_decision mime reversemapencoding $args
-        return ""
-    }
-
-    proc mime_setheader {args} {
-        ::itest::log_decision mime setheader $args
-        return ""
-    }
-
-    proc mime_uniqueID {args} {
-        ::itest::log_decision mime uniqueID $args
-        return ""
-    }
-
-    proc mime_word_decode {args} {
-        ::itest::log_decision mime word_decode $args
-        return ""
-    }
-
-    proc mime_word_encode {args} {
-        ::itest::log_decision mime word_encode $args
-        return ""
-    }
-
-
-    # msgcat:: stubs (18 commands)
-
-    proc msgcat_mc {args} {
-        ::itest::log_decision msgcat mc $args
-        return ""
-    }
-
-    proc msgcat_mcexists {args} {
-        ::itest::log_decision msgcat mcexists $args
-        return ""
-    }
-
-    proc msgcat_mcflmset {args} {
-        ::itest::log_decision msgcat mcflmset $args
-        return ""
-    }
-
-    proc msgcat_mcflset {args} {
-        ::itest::log_decision msgcat mcflset $args
-        return ""
-    }
-
-    proc msgcat_mcforgetpackage {args} {
-        ::itest::log_decision msgcat mcforgetpackage $args
-        return ""
-    }
-
-    proc msgcat_mcload {args} {
-        ::itest::log_decision msgcat mcload $args
-        return ""
-    }
-
-    proc msgcat_mcloadedlocales {args} {
-        ::itest::log_decision msgcat mcloadedlocales $args
-        return ""
-    }
-
-    proc msgcat_mclocale {args} {
-        ::itest::log_decision msgcat mclocale $args
-        return ""
-    }
-
-    proc msgcat_mcmax {args} {
-        ::itest::log_decision msgcat mcmax $args
-        return ""
-    }
-
-    proc msgcat_mcmset {args} {
-        ::itest::log_decision msgcat mcmset $args
-        return ""
-    }
-
-    proc msgcat_mcn {args} {
-        ::itest::log_decision msgcat mcn $args
-        return ""
-    }
-
-    proc msgcat_mcpackageconfig {args} {
-        ::itest::log_decision msgcat mcpackageconfig $args
-        return ""
-    }
-
-    proc msgcat_mcpackagelocale {args} {
-        ::itest::log_decision msgcat mcpackagelocale $args
-        return ""
-    }
-
-    proc msgcat_mcpackagenamespaceget {args} {
-        ::itest::log_decision msgcat mcpackagenamespaceget $args
-        return ""
-    }
-
-    proc msgcat_mcpreferences {args} {
-        ::itest::log_decision msgcat mcpreferences $args
-        return ""
-    }
-
-    proc msgcat_mcset {args} {
-        ::itest::log_decision msgcat mcset $args
-        return ""
-    }
-
-    proc msgcat_mcunknown {args} {
-        ::itest::log_decision msgcat mcunknown $args
-        return ""
-    }
-
-    proc msgcat_mcutil {args} {
-        ::itest::log_decision msgcat mcutil $args
-        return ""
-    }
-
-
-    # pkg:: stubs (1 commands)
-
-    proc pkg_create {args} {
-        ::itest::log_decision pkg create $args
-        return ""
-    }
-
-
-    # platform:: stubs (5 commands)
-
-    proc platform_generic {args} {
-        ::itest::log_decision platform generic $args
-        return ""
-    }
-
-    proc platform_identify {args} {
-        ::itest::log_decision platform identify $args
-        return ""
-    }
-
-    proc platform_patterns {args} {
-        ::itest::log_decision platform patterns $args
-        return ""
-    }
-
-    proc platform_generic {args} {
-        ::itest::log_decision platform generic $args
-        return ""
-    }
-
-    proc platform_identify {args} {
-        ::itest::log_decision platform identify $args
-        return ""
-    }
-
-
-    # safe:: stubs (8 commands)
-
-    proc safe_interpAddToAccessPath {args} {
-        ::itest::log_decision safe interpAddToAccessPath $args
-        return ""
-    }
-
-    proc safe_interpConfigure {args} {
-        ::itest::log_decision safe interpConfigure $args
-        return ""
-    }
-
-    proc safe_interpCreate {args} {
-        ::itest::log_decision safe interpCreate $args
-        return ""
-    }
-
-    proc safe_interpDelete {args} {
-        ::itest::log_decision safe interpDelete $args
-        return ""
-    }
-
-    proc safe_interpFindInAccessPath {args} {
-        ::itest::log_decision safe interpFindInAccessPath $args
-        return ""
-    }
-
-    proc safe_interpInit {args} {
-        ::itest::log_decision safe interpInit $args
-        return ""
-    }
-
-    proc safe_setLogCmd {args} {
-        ::itest::log_decision safe setLogCmd $args
-        return ""
-    }
-
-    proc safe_setSyncMode {args} {
-        ::itest::log_decision safe setSyncMode $args
-        return ""
-    }
-
-
-    # sha1:: stubs (1 commands)
-
-    proc sha1_sha1 {args} {
-        ::itest::log_decision sha1 sha1 $args
-        return ""
-    }
-
-
-    # sha2:: stubs (1 commands)
-
-    proc sha2_sha256 {args} {
-        ::itest::log_decision sha2 sha256 $args
-        return ""
-    }
-
-
-    # smtp:: stubs (1 commands)
-
-    proc smtp_sendmessage {args} {
-        ::itest::log_decision smtp sendmessage $args
-        return ""
-    }
-
-
-    # snit:: stubs (7 commands)
-
-    proc snit_compile {args} {
-        ::itest::log_decision snit compile $args
-        return ""
-    }
-
-    proc snit_macro {args} {
-        ::itest::log_decision snit macro $args
-        return ""
-    }
-
-    proc snit_method {args} {
-        ::itest::log_decision snit method $args
-        return ""
-    }
-
-    proc snit_type {args} {
-        ::itest::log_decision snit type $args
-        return ""
-    }
-
-    proc snit_typemethod {args} {
-        ::itest::log_decision snit typemethod $args
-        return ""
-    }
-
-    proc snit_widget {args} {
-        ::itest::log_decision snit widget $args
-        return ""
-    }
-
-    proc snit_widgetadaptor {args} {
-        ::itest::log_decision snit widgetadaptor $args
-        return ""
-    }
-
-
-    # struct:: stubs (4 commands)
-
-    proc struct_list {args} {
-        ::itest::log_decision struct list $args
-        return ""
-    }
-
-    proc struct_queue {args} {
-        ::itest::log_decision struct queue $args
-        return ""
-    }
-
-    proc struct_set {args} {
-        ::itest::log_decision struct set $args
-        return ""
-    }
-
-    proc struct_stack {args} {
-        ::itest::log_decision struct stack $args
-        return ""
-    }
-
-
-    # tcl:: stubs (11 commands)
-
-    proc tcl_OptKeyDelete {args} {
-        ::itest::log_decision tcl OptKeyDelete $args
-        return ""
-    }
-
-    proc tcl_OptKeyError {args} {
-        ::itest::log_decision tcl OptKeyError $args
-        return ""
-    }
-
-    proc tcl_OptKeyParse {args} {
-        ::itest::log_decision tcl OptKeyParse $args
-        return ""
-    }
-
-    proc tcl_OptKeyRegister {args} {
-        ::itest::log_decision tcl OptKeyRegister $args
-        return ""
-    }
-
-    proc tcl_OptParse {args} {
-        ::itest::log_decision tcl OptParse $args
-        return ""
-    }
-
-    proc tcl_OptProc {args} {
-        ::itest::log_decision tcl OptProc $args
-        return ""
-    }
-
-    proc tcl_OptProcArgGiven {args} {
-        ::itest::log_decision tcl OptProcArgGiven $args
-        return ""
-    }
-
-    proc tcl_decode {args} {
-        ::itest::log_decision tcl decode $args
-        return ""
-    }
-
-    proc tcl_encode {args} {
-        ::itest::log_decision tcl encode $args
-        return ""
-    }
-
-    proc tcl_path {args} {
-        ::itest::log_decision tcl path $args
-        return ""
-    }
-
-    proc tcl_roots {args} {
-        ::itest::log_decision tcl roots $args
-        return ""
-    }
-
-
-    # tcltest:: stubs (41 commands)
-
-    proc tcltest_bytestring {args} {
-        ::itest::log_decision tcltest bytestring $args
-        return ""
-    }
-
-    proc tcltest_cleanupTests {args} {
-        ::itest::log_decision tcltest cleanupTests $args
-        return ""
-    }
-
-    proc tcltest_configure {args} {
-        ::itest::log_decision tcltest configure $args
-        return ""
-    }
-
-    proc tcltest_customMatch {args} {
-        ::itest::log_decision tcltest customMatch $args
-        return ""
-    }
-
-    proc tcltest_debug {args} {
-        ::itest::log_decision tcltest debug $args
-        return ""
-    }
-
-    proc tcltest_errorChannel {args} {
-        ::itest::log_decision tcltest errorChannel $args
-        return ""
-    }
-
-    proc tcltest_errorFile {args} {
-        ::itest::log_decision tcltest errorFile $args
-        return ""
-    }
-
-    proc tcltest_getMatchingFiles {args} {
-        ::itest::log_decision tcltest getMatchingFiles $args
-        return ""
-    }
-
-    proc tcltest_interpreter {args} {
-        ::itest::log_decision tcltest interpreter $args
-        return ""
-    }
-
-    proc tcltest_limitConstraints {args} {
-        ::itest::log_decision tcltest limitConstraints $args
-        return ""
-    }
-
-    proc tcltest_loadFile {args} {
-        ::itest::log_decision tcltest loadFile $args
-        return ""
-    }
-
-    proc tcltest_loadScript {args} {
-        ::itest::log_decision tcltest loadScript $args
-        return ""
-    }
-
-    proc tcltest_loadTestedCommands {args} {
-        ::itest::log_decision tcltest loadTestedCommands $args
-        return ""
-    }
-
-    proc tcltest_mainThread {args} {
-        ::itest::log_decision tcltest mainThread $args
-        return ""
-    }
-
-    proc tcltest_makeDirectory {args} {
-        ::itest::log_decision tcltest makeDirectory $args
-        return ""
-    }
-
-    proc tcltest_makeFile {args} {
-        ::itest::log_decision tcltest makeFile $args
-        return ""
-    }
-
-    proc tcltest_match {args} {
-        ::itest::log_decision tcltest match $args
-        return ""
-    }
-
-    proc tcltest_matchDirectories {args} {
-        ::itest::log_decision tcltest matchDirectories $args
-        return ""
-    }
-
-    proc tcltest_matchFiles {args} {
-        ::itest::log_decision tcltest matchFiles $args
-        return ""
-    }
-
-    proc tcltest_normalizeMsg {args} {
-        ::itest::log_decision tcltest normalizeMsg $args
-        return ""
-    }
-
-    proc tcltest_normalizePath {args} {
-        ::itest::log_decision tcltest normalizePath $args
-        return ""
-    }
-
-    proc tcltest_outputChannel {args} {
-        ::itest::log_decision tcltest outputChannel $args
-        return ""
-    }
-
-    proc tcltest_outputFile {args} {
-        ::itest::log_decision tcltest outputFile $args
-        return ""
-    }
-
-    proc tcltest_preserveCore {args} {
-        ::itest::log_decision tcltest preserveCore $args
-        return ""
-    }
-
-    proc tcltest_removeDirectory {args} {
-        ::itest::log_decision tcltest removeDirectory $args
-        return ""
-    }
-
-    proc tcltest_removeFile {args} {
-        ::itest::log_decision tcltest removeFile $args
-        return ""
-    }
-
-    proc tcltest_restoreState {args} {
-        ::itest::log_decision tcltest restoreState $args
-        return ""
-    }
-
-    proc tcltest_runAllTests {args} {
-        ::itest::log_decision tcltest runAllTests $args
-        return ""
-    }
-
-    proc tcltest_saveState {args} {
-        ::itest::log_decision tcltest saveState $args
-        return ""
-    }
-
-    proc tcltest_singleProcess {args} {
-        ::itest::log_decision tcltest singleProcess $args
-        return ""
-    }
-
-    proc tcltest_skip {args} {
-        ::itest::log_decision tcltest skip $args
-        return ""
-    }
-
-    proc tcltest_skipDirectories {args} {
-        ::itest::log_decision tcltest skipDirectories $args
-        return ""
-    }
-
-    proc tcltest_skipFiles {args} {
-        ::itest::log_decision tcltest skipFiles $args
-        return ""
-    }
-
-    proc tcltest_temporaryDirectory {args} {
-        ::itest::log_decision tcltest temporaryDirectory $args
-        return ""
-    }
-
-    proc tcltest_test {args} {
-        ::itest::log_decision tcltest test $args
-        return ""
-    }
-
-    proc tcltest_testConstraint {args} {
-        ::itest::log_decision tcltest testConstraint $args
-        return ""
-    }
-
-    proc tcltest_testsDirectory {args} {
-        ::itest::log_decision tcltest testsDirectory $args
-        return ""
-    }
-
-    proc tcltest_threadReap {args} {
-        ::itest::log_decision tcltest threadReap $args
-        return ""
-    }
-
-    proc tcltest_verbose {args} {
-        ::itest::log_decision tcltest verbose $args
-        return ""
-    }
-
-    proc tcltest_viewFile {args} {
-        ::itest::log_decision tcltest viewFile $args
-        return ""
-    }
-
-    proc tcltest_workingDirectory {args} {
-        ::itest::log_decision tcltest workingDirectory $args
-        return ""
-    }
-
-
-    # textutil:: stubs (23 commands)
-
-    proc textutil_adjust {args} {
-        ::itest::log_decision textutil adjust $args
-        return ""
-    }
-
-    proc textutil_blank {args} {
-        ::itest::log_decision textutil blank $args
-        return ""
-    }
-
-    proc textutil_cap {args} {
-        ::itest::log_decision textutil cap $args
-        return ""
-    }
-
-    proc textutil_capEachWord {args} {
-        ::itest::log_decision textutil capEachWord $args
-        return ""
-    }
-
-    proc textutil_chop {args} {
-        ::itest::log_decision textutil chop $args
-        return ""
-    }
-
-    proc textutil_indent {args} {
-        ::itest::log_decision textutil indent $args
-        return ""
-    }
-
-    proc textutil_longestCommonPrefix {args} {
-        ::itest::log_decision textutil longestCommonPrefix $args
-        return ""
-    }
-
-    proc textutil_longestCommonPrefixList {args} {
-        ::itest::log_decision textutil longestCommonPrefixList $args
-        return ""
-    }
-
-    proc textutil_splitn {args} {
-        ::itest::log_decision textutil splitn $args
-        return ""
-    }
-
-    proc textutil_splitx {args} {
-        ::itest::log_decision textutil splitx $args
-        return ""
-    }
-
-    proc textutil_strRepeat {args} {
-        ::itest::log_decision textutil strRepeat $args
-        return ""
-    }
-
-    proc textutil_tabify {args} {
-        ::itest::log_decision textutil tabify $args
-        return ""
-    }
-
-    proc textutil_tabify2 {args} {
-        ::itest::log_decision textutil tabify2 $args
-        return ""
-    }
-
-    proc textutil_tail {args} {
-        ::itest::log_decision textutil tail $args
-        return ""
-    }
-
-    proc textutil_trim {args} {
-        ::itest::log_decision textutil trim $args
-        return ""
-    }
-
-    proc textutil_trimEmptyHeading {args} {
-        ::itest::log_decision textutil trimEmptyHeading $args
-        return ""
-    }
-
-    proc textutil_trimPrefix {args} {
-        ::itest::log_decision textutil trimPrefix $args
-        return ""
-    }
-
-    proc textutil_trimleft {args} {
-        ::itest::log_decision textutil trimleft $args
-        return ""
-    }
-
-    proc textutil_trimright {args} {
-        ::itest::log_decision textutil trimright $args
-        return ""
-    }
-
-    proc textutil_uncap {args} {
-        ::itest::log_decision textutil uncap $args
-        return ""
-    }
-
-    proc textutil_undent {args} {
-        ::itest::log_decision textutil undent $args
-        return ""
-    }
-
-    proc textutil_untabify {args} {
-        ::itest::log_decision textutil untabify $args
-        return ""
-    }
-
-    proc textutil_untabify2 {args} {
-        ::itest::log_decision textutil untabify2 $args
-        return ""
-    }
-
-
-    # ttk:: stubs (12 commands)
-
-    proc ttk_button {args} {
-        ::itest::log_decision ttk button $args
-        return ""
-    }
-
-    proc ttk_combobox {args} {
-        ::itest::log_decision ttk combobox $args
-        return ""
-    }
-
-    proc ttk_entry {args} {
-        ::itest::log_decision ttk entry $args
-        return ""
-    }
-
-    proc ttk_frame {args} {
-        ::itest::log_decision ttk frame $args
-        return ""
-    }
-
-    proc ttk_label {args} {
-        ::itest::log_decision ttk label $args
-        return ""
-    }
-
-    proc ttk_notebook {args} {
-        ::itest::log_decision ttk notebook $args
-        return ""
-    }
-
-    proc ttk_progressbar {args} {
-        ::itest::log_decision ttk progressbar $args
-        return ""
-    }
-
-    proc ttk_scale {args} {
-        ::itest::log_decision ttk scale $args
-        return ""
-    }
-
-    proc ttk_separator {args} {
-        ::itest::log_decision ttk separator $args
-        return ""
-    }
-
-    proc ttk_sizegrip {args} {
-        ::itest::log_decision ttk sizegrip $args
-        return ""
-    }
-
-    proc ttk_style {args} {
-        ::itest::log_decision ttk style $args
-        return ""
-    }
-
-    proc ttk_treeview {args} {
-        ::itest::log_decision ttk treeview $args
-        return ""
-    }
-
-
-    # uri:: stubs (8 commands)
-
-    proc uri_canonicalize {args} {
-        ::itest::log_decision uri canonicalize $args
-        return ""
-    }
-
-    proc uri_geturl {args} {
-        ::itest::log_decision uri geturl $args
-        return ""
-    }
-
-    proc uri_isrelative {args} {
-        ::itest::log_decision uri isrelative $args
-        return ""
-    }
-
-    proc uri_join {args} {
-        ::itest::log_decision uri join $args
-        return ""
-    }
-
-    proc uri_register {args} {
-        ::itest::log_decision uri register $args
-        return ""
-    }
-
-    proc uri_resolve {args} {
-        ::itest::log_decision uri resolve $args
-        return ""
-    }
-
-    proc uri_setQuirkOption {args} {
-        ::itest::log_decision uri setQuirkOption $args
-        return ""
-    }
-
-    proc uri_split {args} {
-        ::itest::log_decision uri split $args
-        return ""
-    }
-
-
-    # uuid:: stubs (1 commands)
-
-    proc uuid_uuid {args} {
-        ::itest::log_decision uuid uuid $args
-        return ""
-    }
-
-
-    # yaml:: stubs (6 commands)
-
-    proc yaml_dict2yaml {args} {
-        ::itest::log_decision yaml dict2yaml $args
-        return ""
-    }
-
-    proc yaml_huddle2yaml {args} {
-        ::itest::log_decision yaml huddle2yaml $args
-        return ""
-    }
-
-    proc yaml_list2yaml {args} {
-        ::itest::log_decision yaml list2yaml $args
-        return ""
-    }
-
-    proc yaml_setOptions {args} {
-        ::itest::log_decision yaml setOptions $args
-        return ""
-    }
-
-    proc yaml_yaml2dict {args} {
-        ::itest::log_decision yaml yaml2dict $args
-        return ""
-    }
-
-    proc yaml_yaml2huddle {args} {
-        ::itest::log_decision yaml yaml2huddle $args
-        return ""
-    }
-
-
-    # Top-level stubs (301 commands)
-
-    proc cmd_accumulate {args} {
-        ::itest::log_decision toplevel accumulate $args
-        return ""
-    }
-
-    proc cmd_active_members {args} {
-        ::itest::log_decision toplevel active_members $args
-        return ""
-    }
-
-    proc cmd_active_nodes {args} {
-        ::itest::log_decision toplevel active_nodes $args
-        return ""
-    }
-
-    proc cmd_append {args} {
-        ::itest::log_decision toplevel append $args
-        return ""
-    }
-
-    proc cmd_apply {args} {
-        ::itest::log_decision toplevel apply $args
-        return ""
-    }
-
-    proc cmd_array {args} {
-        ::itest::log_decision toplevel array $args
-        return ""
-    }
-
-    proc cmd_b64decode {args} {
-        ::itest::log_decision toplevel b64decode $args
-        return ""
-    }
-
-    proc cmd_b64encode {args} {
-        ::itest::log_decision toplevel b64encode $args
-        return ""
-    }
-
-    proc cmd_bell {args} {
-        ::itest::log_decision toplevel bell $args
-        return ""
-    }
-
-    proc cmd_binary {args} {
-        ::itest::log_decision toplevel binary $args
-        return ""
-    }
-
-    proc cmd_bind {args} {
-        ::itest::log_decision toplevel bind $args
-        return ""
-    }
-
-    proc cmd_break {args} {
-        ::itest::log_decision toplevel break $args
-        return ""
-    }
-
-    proc cmd_button {args} {
-        ::itest::log_decision toplevel button $args
-        return ""
-    }
-
-    proc cmd_call {args} {
-        ::itest::log_decision toplevel call $args
-        return ""
-    }
-
-    proc cmd_canvas {args} {
-        ::itest::log_decision toplevel canvas $args
-        return ""
-    }
-
-    proc cmd_catch {args} {
-        ::itest::log_decision toplevel catch $args
-        return ""
-    }
-
-    proc cmd_chan {args} {
-        ::itest::log_decision toplevel chan $args
-        return ""
-    }
-
-    proc cmd_check {args} {
-        ::itest::log_decision toplevel check $args
-        return ""
-    }
-
-    proc cmd_checkbutton {args} {
-        ::itest::log_decision toplevel checkbutton $args
-        return ""
-    }
-
-    proc cmd_client_addr {args} {
-        ::itest::log_decision toplevel client_addr $args
-        return ""
-    }
-
-    proc cmd_client_port {args} {
-        ::itest::log_decision toplevel client_port $args
-        return ""
-    }
-
-    proc cmd_clientside {args} {
-        ::itest::log_decision toplevel clientside $args
-        return ""
-    }
-
-    proc cmd_clipboard {args} {
-        ::itest::log_decision toplevel clipboard $args
-        return ""
-    }
-
-    proc cmd_clock {args} {
-        ::itest::log_decision toplevel clock $args
-        return ""
-    }
-
-    proc cmd_clone {args} {
-        ::itest::log_decision toplevel clone $args
-        return ""
-    }
-
-    proc cmd_close {args} {
-        ::itest::log_decision toplevel close $args
-        return ""
-    }
-
-    proc cmd_concat {args} {
-        ::itest::log_decision toplevel concat $args
-        return ""
-    }
-
-    proc cmd_connect {args} {
-        ::itest::log_decision toplevel connect $args
-        return ""
-    }
-
-    proc cmd_const {args} {
-        ::itest::log_decision toplevel const $args
-        return ""
-    }
-
-    proc cmd_continue {args} {
-        ::itest::log_decision toplevel continue $args
-        return ""
-    }
-
-    proc cmd_cpu {args} {
-        ::itest::log_decision toplevel cpu $args
-        return ""
-    }
-
-    proc cmd_crc32 {args} {
-        ::itest::log_decision toplevel crc32 $args
-        return ""
-    }
-
-    proc cmd_decode_uri {args} {
-        ::itest::log_decision toplevel decode_uri $args
-        return ""
-    }
-
-    proc cmd_destroy {args} {
-        ::itest::log_decision toplevel destroy $args
-        return ""
-    }
-
-    proc cmd_domain {args} {
-        ::itest::log_decision toplevel domain $args
-        return ""
-    }
-
-    proc cmd_encoding {args} {
-        ::itest::log_decision toplevel encoding $args
-        return ""
-    }
-
-    proc cmd_entry {args} {
-        ::itest::log_decision toplevel entry $args
-        return ""
-    }
-
-    proc cmd_error {args} {
-        ::itest::log_decision toplevel error $args
-        return ""
-    }
-
-    proc cmd_eval {args} {
-        ::itest::log_decision toplevel eval $args
-        return ""
-    }
-
-    proc cmd_expr {args} {
-        ::itest::log_decision toplevel expr $args
-        return ""
-    }
-
-    proc cmd_fasthash {args} {
-        ::itest::log_decision toplevel fasthash $args
-        return ""
-    }
-
-    proc cmd_findclass {args} {
-        ::itest::log_decision toplevel findclass $args
-        return ""
-    }
-
-    proc cmd_findstr {args} {
-        ::itest::log_decision toplevel findstr $args
-        return ""
-    }
-
-    proc cmd_focus {args} {
-        ::itest::log_decision toplevel focus $args
-        return ""
-    }
-
-    proc cmd_font {args} {
-        ::itest::log_decision toplevel font $args
-        return ""
-    }
-
-    proc cmd_for {args} {
-        ::itest::log_decision toplevel for $args
-        return ""
-    }
-
-    proc cmd_foreach {args} {
-        ::itest::log_decision toplevel foreach $args
-        return ""
-    }
-
-    proc cmd_format {args} {
-        ::itest::log_decision toplevel format $args
-        return ""
-    }
-
-    proc cmd_forward {args} {
-        ::itest::log_decision toplevel forward $args
-        return ""
-    }
-
-    proc cmd_frame {args} {
-        ::itest::log_decision toplevel frame $args
-        return ""
-    }
-
-    proc cmd_getfield {args} {
-        ::itest::log_decision toplevel getfield $args
-        return ""
-    }
-
-    proc cmd_gettimes {args} {
-        ::itest::log_decision toplevel gettimes $args
-        return ""
-    }
-
-    proc cmd_global {args} {
-        ::itest::log_decision toplevel global $args
-        return ""
-    }
-
-    proc cmd_grab {args} {
-        ::itest::log_decision toplevel grab $args
-        return ""
-    }
-
-    proc cmd_grid {args} {
-        ::itest::log_decision toplevel grid $args
-        return ""
-    }
-
-    proc cmd_history {args} {
-        ::itest::log_decision toplevel history $args
-        return ""
-    }
-
-    proc cmd_html_encode {args} {
-        ::itest::log_decision toplevel html_encode $args
-        return ""
-    }
-
-    proc cmd_html_escape {args} {
-        ::itest::log_decision toplevel html_escape $args
-        return ""
-    }
-
-    proc cmd_htmlencode {args} {
-        ::itest::log_decision toplevel htmlencode $args
-        return ""
-    }
-
-    proc cmd_htonl {args} {
-        ::itest::log_decision toplevel htonl $args
-        return ""
-    }
-
-    proc cmd_htons {args} {
-        ::itest::log_decision toplevel htons $args
-        return ""
-    }
-
-    proc cmd_http_client_ip {args} {
-        ::itest::log_decision toplevel http_client_ip $args
-        return ""
-    }
-
-    proc cmd_http_content_len_max {args} {
-        ::itest::log_decision toplevel http_content_len_max $args
-        return ""
-    }
-
-    proc cmd_http_cookie {args} {
-        ::itest::log_decision toplevel http_cookie $args
-        return ""
-    }
-
-    proc cmd_http_header {args} {
-        ::itest::log_decision toplevel http_header $args
-        return ""
-    }
-
-    proc cmd_http_host {args} {
-        ::itest::log_decision toplevel http_host $args
-        return ""
-    }
-
-    proc cmd_http_method {args} {
-        ::itest::log_decision toplevel http_method $args
-        return ""
-    }
-
-    proc cmd_http_uri {args} {
-        ::itest::log_decision toplevel http_uri $args
-        return ""
-    }
-
-    proc cmd_http_version {args} {
-        ::itest::log_decision toplevel http_version $args
-        return ""
-    }
-
-    proc cmd_if {args} {
-        ::itest::log_decision toplevel if $args
-        return ""
-    }
-
-    proc cmd_ifile {args} {
-        ::itest::log_decision toplevel ifile $args
-        return ""
-    }
-
-    proc cmd_image {args} {
-        ::itest::log_decision toplevel image $args
-        return ""
-    }
-
-    proc cmd_imid {args} {
-        ::itest::log_decision toplevel imid $args
-        return ""
-    }
-
-    proc cmd_incr {args} {
-        ::itest::log_decision toplevel incr $args
-        return ""
-    }
-
-    proc cmd_info {args} {
-        ::itest::log_decision toplevel info $args
-        return ""
-    }
-
-    proc cmd_ip_addr {args} {
-        ::itest::log_decision toplevel ip_addr $args
-        return ""
-    }
-
-    proc cmd_ip_protocol {args} {
-        ::itest::log_decision toplevel ip_protocol $args
-        return ""
-    }
-
-    proc cmd_ip_tos {args} {
-        ::itest::log_decision toplevel ip_tos $args
-        return ""
-    }
-
-    proc cmd_ip_ttl {args} {
-        ::itest::log_decision toplevel ip_ttl $args
-        return ""
-    }
-
-    proc cmd_join {args} {
-        ::itest::log_decision toplevel join $args
-        return ""
-    }
-
-    proc cmd_label {args} {
-        ::itest::log_decision toplevel label $args
-        return ""
-    }
-
-    proc cmd_labelframe {args} {
-        ::itest::log_decision toplevel labelframe $args
-        return ""
-    }
-
-    proc cmd_lappend {args} {
-        ::itest::log_decision toplevel lappend $args
-        return ""
-    }
-
-    proc cmd_lasthop {args} {
-        ::itest::log_decision toplevel lasthop $args
-        return ""
-    }
-
-    proc cmd_lgen {args} {
-        ::itest::log_decision toplevel lgen $args
-        return ""
-    }
-
-    proc cmd_lindex {args} {
-        ::itest::log_decision toplevel lindex $args
-        return ""
-    }
-
-    proc cmd_link_qos {args} {
-        ::itest::log_decision toplevel link_qos $args
-        return ""
-    }
-
-    proc cmd_linsert {args} {
-        ::itest::log_decision toplevel linsert $args
-        return ""
-    }
-
-    proc cmd_list {args} {
-        ::itest::log_decision toplevel list $args
-        return ""
-    }
-
-    proc cmd_listbox {args} {
-        ::itest::log_decision toplevel listbox $args
-        return ""
-    }
-
-    proc cmd_listen {args} {
-        ::itest::log_decision toplevel listen $args
-        return ""
-    }
-
-    proc cmd_llength {args} {
-        ::itest::log_decision toplevel llength $args
-        return ""
-    }
-
-    proc cmd_llookup {args} {
-        ::itest::log_decision toplevel llookup $args
-        return ""
-    }
-
-    proc cmd_local_addr {args} {
-        ::itest::log_decision toplevel local_addr $args
-        return ""
-    }
-
-    proc cmd_local_port {args} {
-        ::itest::log_decision toplevel local_port $args
-        return ""
-    }
-
-    proc cmd_lower {args} {
-        ::itest::log_decision toplevel lower $args
-        return ""
-    }
-
-    proc cmd_lrange {args} {
-        ::itest::log_decision toplevel lrange $args
-        return ""
-    }
-
-    proc cmd_lrepeat {args} {
-        ::itest::log_decision toplevel lrepeat $args
-        return ""
-    }
-
-    proc cmd_lreplace {args} {
-        ::itest::log_decision toplevel lreplace $args
-        return ""
-    }
-
-    proc cmd_lreverse {args} {
-        ::itest::log_decision toplevel lreverse $args
-        return ""
-    }
-
-    proc cmd_lsearch {args} {
-        ::itest::log_decision toplevel lsearch $args
-        return ""
-    }
-
-    proc cmd_lset {args} {
-        ::itest::log_decision toplevel lset $args
-        return ""
-    }
-
-    proc cmd_lsort {args} {
-        ::itest::log_decision toplevel lsort $args
-        return ""
-    }
-
-    proc cmd_lstring {args} {
-        ::itest::log_decision toplevel lstring $args
-        return ""
-    }
-
-    proc cmd_matchclass {args} {
-        ::itest::log_decision toplevel matchclass $args
-        return ""
-    }
-
-    proc cmd_md4 {args} {
-        ::itest::log_decision toplevel md4 $args
-        return ""
-    }
-
-    proc cmd_md5 {args} {
-        ::itest::log_decision toplevel md5 $args
-        return ""
-    }
-
-    proc cmd_members {args} {
-        ::itest::log_decision toplevel members $args
-        return ""
-    }
-
-    proc cmd_menu {args} {
-        ::itest::log_decision toplevel menu $args
-        return ""
-    }
-
-    proc cmd_menubutton {args} {
-        ::itest::log_decision toplevel menubutton $args
-        return ""
-    }
-
-    proc cmd_message {args} {
-        ::itest::log_decision toplevel message $args
-        return ""
-    }
-
-    proc cmd_nexthop {args} {
-        ::itest::log_decision toplevel nexthop $args
-        return ""
-    }
-
-    proc cmd_nodes {args} {
-        ::itest::log_decision toplevel nodes $args
-        return ""
-    }
-
-    proc cmd_noop {args} {
-        ::itest::log_decision toplevel noop $args
-        return ""
-    }
-
-    proc cmd_ntohl {args} {
-        ::itest::log_decision toplevel ntohl $args
-        return ""
-    }
-
-    proc cmd_ntohs {args} {
-        ::itest::log_decision toplevel ntohs $args
-        return ""
-    }
-
-    proc cmd_option {args} {
-        ::itest::log_decision toplevel option $args
-        return ""
-    }
-
-    proc cmd_pack {args} {
-        ::itest::log_decision toplevel pack $args
-        return ""
-    }
-
-    proc cmd_panedwindow {args} {
-        ::itest::log_decision toplevel panedwindow $args
-        return ""
-    }
-
-    proc cmd_parray {args} {
-        ::itest::log_decision toplevel parray $args
-        return ""
-    }
-
-    proc cmd_peer {args} {
-        ::itest::log_decision toplevel peer $args
-        return ""
-    }
-
-    proc cmd_pem_dtos {args} {
-        ::itest::log_decision toplevel pem_dtos $args
-        return ""
-    }
-
-    proc cmd_pkg_mkIndex {args} {
-        ::itest::log_decision toplevel pkg_mkIndex $args
-        return ""
-    }
-
-    proc cmd_place {args} {
-        ::itest::log_decision toplevel place $args
-        return ""
-    }
-
-    proc cmd_priority {args} {
-        ::itest::log_decision toplevel priority $args
-        return ""
-    }
-
-    proc cmd_proc {args} {
-        ::itest::log_decision toplevel proc $args
-        return ""
-    }
-
-    proc cmd_puts {args} {
-        ::itest::log_decision toplevel puts $args
-        return ""
-    }
-
-    proc cmd_radiobutton {args} {
-        ::itest::log_decision toplevel radiobutton $args
-        return ""
-    }
-
-    proc cmd_radius_authenticate {args} {
-        ::itest::log_decision toplevel radius_authenticate $args
-        return ""
-    }
-
-    proc cmd_raise {args} {
-        ::itest::log_decision toplevel raise $args
-        return ""
-    }
-
-    proc cmd_rateclass {args} {
-        ::itest::log_decision toplevel rateclass $args
-        return ""
-    }
-
-    proc cmd_read {args} {
-        ::itest::log_decision toplevel read $args
-        return ""
-    }
-
-    proc cmd_recv {args} {
-        ::itest::log_decision toplevel recv $args
-        return ""
-    }
-
-    proc cmd_redirect {args} {
-        ::itest::log_decision toplevel redirect $args
-        return ""
-    }
-
-    proc cmd_regexp {args} {
-        ::itest::log_decision toplevel regexp $args
-        return ""
-    }
-
-    proc cmd_regsub {args} {
-        ::itest::log_decision toplevel regsub $args
-        return ""
-    }
-
-    proc cmd_relate_client {args} {
-        ::itest::log_decision toplevel relate_client $args
-        return ""
-    }
-
-    proc cmd_relate_server {args} {
-        ::itest::log_decision toplevel relate_server $args
-        return ""
-    }
-
-    proc cmd_remote_addr {args} {
-        ::itest::log_decision toplevel remote_addr $args
-        return ""
-    }
-
-    proc cmd_remote_port {args} {
-        ::itest::log_decision toplevel remote_port $args
-        return ""
-    }
-
-    proc cmd_return {args} {
-        ::itest::log_decision toplevel return $args
-        return ""
-    }
-
-    proc cmd_rmd160 {args} {
-        ::itest::log_decision toplevel rmd160 $args
-        return ""
-    }
-
-    proc cmd_scale {args} {
-        ::itest::log_decision toplevel scale $args
-        return ""
-    }
-
-    proc cmd_scan {args} {
-        ::itest::log_decision toplevel scan $args
-        return ""
-    }
-
-    proc cmd_scrollbar {args} {
-        ::itest::log_decision toplevel scrollbar $args
-        return ""
-    }
-
-    proc cmd_selection {args} {
-        ::itest::log_decision toplevel selection $args
-        return ""
-    }
-
-    proc cmd_send {args} {
-        ::itest::log_decision toplevel send $args
-        return ""
-    }
-
-    proc cmd_server_addr {args} {
-        ::itest::log_decision toplevel server_addr $args
-        return ""
-    }
-
-    proc cmd_server_port {args} {
-        ::itest::log_decision toplevel server_port $args
-        return ""
-    }
-
-    proc cmd_serverside {args} {
-        ::itest::log_decision toplevel serverside $args
-        return ""
-    }
-
-    proc cmd_session {args} {
-        ::itest::log_decision toplevel session $args
-        return ""
-    }
-
-    proc cmd_set {args} {
-        ::itest::log_decision toplevel set $args
-        return ""
-    }
-
-    proc cmd_sha1 {args} {
-        ::itest::log_decision toplevel sha1 $args
-        return ""
-    }
-
-    proc cmd_sha256 {args} {
-        ::itest::log_decision toplevel sha256 $args
-        return ""
-    }
-
-    proc cmd_sha384 {args} {
-        ::itest::log_decision toplevel sha384 $args
-        return ""
-    }
-
-    proc cmd_sha512 {args} {
-        ::itest::log_decision toplevel sha512 $args
-        return ""
-    }
-
-    proc cmd_sharedvar {args} {
-        ::itest::log_decision toplevel sharedvar $args
-        return ""
-    }
-
-    proc cmd_spinbox {args} {
-        ::itest::log_decision toplevel spinbox $args
-        return ""
-    }
-
-    proc cmd_split {args} {
-        ::itest::log_decision toplevel split $args
-        return ""
-    }
-
-    proc cmd_string {args} {
-        ::itest::log_decision toplevel string $args
-        return ""
-    }
-
-    proc cmd_subst {args} {
-        ::itest::log_decision toplevel subst $args
-        return ""
-    }
-
-    proc cmd_substr {args} {
-        ::itest::log_decision toplevel substr $args
-        return ""
-    }
-
-    proc cmd_switch {args} {
-        ::itest::log_decision toplevel switch $args
-        return ""
-    }
-
-    proc cmd_tcl_endOfWord {args} {
-        ::itest::log_decision toplevel tcl_endOfWord $args
-        return ""
-    }
-
-    proc cmd_tcl_startOfNextWord {args} {
-        ::itest::log_decision toplevel tcl_startOfNextWord $args
-        return ""
-    }
-
-    proc cmd_tcl_startOfPreviousWord {args} {
-        ::itest::log_decision toplevel tcl_startOfPreviousWord $args
-        return ""
-    }
-
-    proc cmd_tcl_wordBreakAfter {args} {
-        ::itest::log_decision toplevel tcl_wordBreakAfter $args
-        return ""
-    }
-
-    proc cmd_tcl_wordBreakBefore {args} {
-        ::itest::log_decision toplevel tcl_wordBreakBefore $args
-        return ""
-    }
-
-    proc cmd_tcpdump {args} {
-        ::itest::log_decision toplevel tcpdump $args
-        return ""
-    }
-
-    proc cmd_testapplylambda {args} {
-        ::itest::log_decision toplevel testapplylambda $args
-        return ""
-    }
-
-    proc cmd_testappverifierpresent {args} {
-        ::itest::log_decision toplevel testappverifierpresent $args
-        return ""
-    }
-
-    proc cmd_testasync {args} {
-        ::itest::log_decision toplevel testasync $args
-        return ""
-    }
-
-    proc cmd_testbigdata {args} {
-        ::itest::log_decision toplevel testbigdata $args
-        return ""
-    }
-
-    proc cmd_testbignumobj {args} {
-        ::itest::log_decision toplevel testbignumobj $args
-        return ""
-    }
-
-    proc cmd_testbooleanobj {args} {
-        ::itest::log_decision toplevel testbooleanobj $args
-        return ""
-    }
-
-    proc cmd_testbumpinterpepoch {args} {
-        ::itest::log_decision toplevel testbumpinterpepoch $args
-        return ""
-    }
-
-    proc cmd_testbytestring {args} {
-        ::itest::log_decision toplevel testbytestring $args
-        return ""
-    }
-
-    proc cmd_testchannel {args} {
-        ::itest::log_decision toplevel testchannel $args
-        return ""
-    }
-
-    proc cmd_testchannelevent {args} {
-        ::itest::log_decision toplevel testchannelevent $args
-        return ""
-    }
-
-    proc cmd_testcmdinfo {args} {
-        ::itest::log_decision toplevel testcmdinfo $args
-        return ""
-    }
-
-    proc cmd_testcmdtoken {args} {
-        ::itest::log_decision toplevel testcmdtoken $args
-        return ""
-    }
-
-    proc cmd_testcmdtrace {args} {
-        ::itest::log_decision toplevel testcmdtrace $args
-        return ""
-    }
-
-    proc cmd_testconcatobj {args} {
-        ::itest::log_decision toplevel testconcatobj $args
-        return ""
-    }
-
-    proc cmd_testcpuid {args} {
-        ::itest::log_decision toplevel testcpuid $args
-        return ""
-    }
-
-    proc cmd_testcreatecommand {args} {
-        ::itest::log_decision toplevel testcreatecommand $args
-        return ""
-    }
-
-    proc cmd_testdcall {args} {
-        ::itest::log_decision toplevel testdcall $args
-        return ""
-    }
-
-    proc cmd_testdel {args} {
-        ::itest::log_decision toplevel testdel $args
-        return ""
-    }
-
-    proc cmd_testdelassocdata {args} {
-        ::itest::log_decision toplevel testdelassocdata $args
-        return ""
-    }
-
-    proc cmd_testdoubledigits {args} {
-        ::itest::log_decision toplevel testdoubledigits $args
-        return ""
-    }
-
-    proc cmd_testdoubleobj {args} {
-        ::itest::log_decision toplevel testdoubleobj $args
-        return ""
-    }
-
-    proc cmd_testdstring {args} {
-        ::itest::log_decision toplevel testdstring $args
-        return ""
-    }
-
-    proc cmd_testencoding {args} {
-        ::itest::log_decision toplevel testencoding $args
-        return ""
-    }
-
-    proc cmd_testevalex {args} {
-        ::itest::log_decision toplevel testevalex $args
-        return ""
-    }
-
-    proc cmd_testevalobjv {args} {
-        ::itest::log_decision toplevel testevalobjv $args
-        return ""
-    }
-
-    proc cmd_testevent {args} {
-        ::itest::log_decision toplevel testevent $args
-        return ""
-    }
-
-    proc cmd_testexithandler {args} {
-        ::itest::log_decision toplevel testexithandler $args
-        return ""
-    }
-
-    proc cmd_testexitmainloop {args} {
-        ::itest::log_decision toplevel testexitmainloop $args
-        return ""
-    }
-
-    proc cmd_testexprdouble {args} {
-        ::itest::log_decision toplevel testexprdouble $args
-        return ""
-    }
-
-    proc cmd_testexprdoubleobj {args} {
-        ::itest::log_decision toplevel testexprdoubleobj $args
-        return ""
-    }
-
-    proc cmd_testexprlong {args} {
-        ::itest::log_decision toplevel testexprlong $args
-        return ""
-    }
-
-    proc cmd_testexprlongobj {args} {
-        ::itest::log_decision toplevel testexprlongobj $args
-        return ""
-    }
-
-    proc cmd_testexprparser {args} {
-        ::itest::log_decision toplevel testexprparser $args
-        return ""
-    }
-
-    proc cmd_testexprstring {args} {
-        ::itest::log_decision toplevel testexprstring $args
-        return ""
-    }
-
-    proc cmd_testfevent {args} {
-        ::itest::log_decision toplevel testfevent $args
-        return ""
-    }
-
-    proc cmd_testfile {args} {
-        ::itest::log_decision toplevel testfile $args
-        return ""
-    }
-
-    proc cmd_testfilelink {args} {
-        ::itest::log_decision toplevel testfilelink $args
-        return ""
-    }
-
-    proc cmd_testfilesystem {args} {
-        ::itest::log_decision toplevel testfilesystem $args
-        return ""
-    }
-
-    proc cmd_testfindfirst {args} {
-        ::itest::log_decision toplevel testfindfirst $args
-        return ""
-    }
-
-    proc cmd_testfindlast {args} {
-        ::itest::log_decision toplevel testfindlast $args
-        return ""
-    }
-
-    proc cmd_testfstildeexpand {args} {
-        ::itest::log_decision toplevel testfstildeexpand $args
-        return ""
-    }
-
-    proc cmd_testgetassocdata {args} {
-        ::itest::log_decision toplevel testgetassocdata $args
-        return ""
-    }
-
-    proc cmd_testgetindexfromobjstruct {args} {
-        ::itest::log_decision toplevel testgetindexfromobjstruct $args
-        return ""
-    }
-
-    proc cmd_testgetint {args} {
-        ::itest::log_decision toplevel testgetint $args
-        return ""
-    }
-
-    proc cmd_testgetintforindex {args} {
-        ::itest::log_decision toplevel testgetintforindex $args
-        return ""
-    }
-
-    proc cmd_testgetplatform {args} {
-        ::itest::log_decision toplevel testgetplatform $args
-        return ""
-    }
-
-    proc cmd_testgetunichar {args} {
-        ::itest::log_decision toplevel testgetunichar $args
-        return ""
-    }
-
-    proc cmd_testgetvarfullname {args} {
-        ::itest::log_decision toplevel testgetvarfullname $args
-        return ""
-    }
-
-    proc cmd_testhandlecount {args} {
-        ::itest::log_decision toplevel testhandlecount $args
-        return ""
-    }
-
-    proc cmd_testhashsystemhash {args} {
-        ::itest::log_decision toplevel testhashsystemhash $args
-        return ""
-    }
-
-    proc cmd_testindexobj {args} {
-        ::itest::log_decision toplevel testindexobj $args
-        return ""
-    }
-
-    proc cmd_testinterpdelete {args} {
-        ::itest::log_decision toplevel testinterpdelete $args
-        return ""
-    }
-
-    proc cmd_testinterpresolver {args} {
-        ::itest::log_decision toplevel testinterpresolver $args
-        return ""
-    }
-
-    proc cmd_testintobj {args} {
-        ::itest::log_decision toplevel testintobj $args
-        return ""
-    }
-
-    proc cmd_testlink {args} {
-        ::itest::log_decision toplevel testlink $args
-        return ""
-    }
-
-    proc cmd_testlinkarray {args} {
-        ::itest::log_decision toplevel testlinkarray $args
-        return ""
-    }
-
-    proc cmd_testlistobj {args} {
-        ::itest::log_decision toplevel testlistobj $args
-        return ""
-    }
-
-    proc cmd_testlistrep {args} {
-        ::itest::log_decision toplevel testlistrep $args
-        return ""
-    }
-
-    proc cmd_testlocale {args} {
-        ::itest::log_decision toplevel testlocale $args
-        return ""
-    }
-
-    proc cmd_testlongsize {args} {
-        ::itest::log_decision toplevel testlongsize $args
-        return ""
-    }
-
-    proc cmd_testlutil {args} {
-        ::itest::log_decision toplevel testlutil $args
-        return ""
-    }
-
-    proc cmd_testmainthread {args} {
-        ::itest::log_decision toplevel testmainthread $args
-        return ""
-    }
-
-    proc cmd_testmsb {args} {
-        ::itest::log_decision toplevel testmsb $args
-        return ""
-    }
-
-    proc cmd_testnrelevels {args} {
-        ::itest::log_decision toplevel testnrelevels $args
-        return ""
-    }
-
-    proc cmd_testnreunwind {args} {
-        ::itest::log_decision toplevel testnreunwind $args
-        return ""
-    }
-
-    proc cmd_testnumutfchars {args} {
-        ::itest::log_decision toplevel testnumutfchars $args
-        return ""
-    }
-
-    proc cmd_testobj {args} {
-        ::itest::log_decision toplevel testobj $args
-        return ""
-    }
-
-    proc cmd_testpanic {args} {
-        ::itest::log_decision toplevel testpanic $args
-        return ""
-    }
-
-    proc cmd_testparseargs {args} {
-        ::itest::log_decision toplevel testparseargs $args
-        return ""
-    }
-
-    proc cmd_testparser {args} {
-        ::itest::log_decision toplevel testparser $args
-        return ""
-    }
-
-    proc cmd_testparsevar {args} {
-        ::itest::log_decision toplevel testparsevar $args
-        return ""
-    }
-
-    proc cmd_testparsevarname {args} {
-        ::itest::log_decision toplevel testparsevarname $args
-        return ""
-    }
-
-    proc cmd_testpreferstable {args} {
-        ::itest::log_decision toplevel testpreferstable $args
-        return ""
-    }
-
-    proc cmd_testprint {args} {
-        ::itest::log_decision toplevel testprint $args
-        return ""
-    }
-
-    proc cmd_testpurebytesobj {args} {
-        ::itest::log_decision toplevel testpurebytesobj $args
-        return ""
-    }
-
-    proc cmd_testregexp {args} {
-        ::itest::log_decision toplevel testregexp $args
-        return ""
-    }
-
-    proc cmd_testreturn {args} {
-        ::itest::log_decision toplevel testreturn $args
-        return ""
-    }
-
-    proc cmd_testsaveresult {args} {
-        ::itest::log_decision toplevel testsaveresult $args
-        return ""
-    }
-
-    proc cmd_testservicemode {args} {
-        ::itest::log_decision toplevel testservicemode $args
-        return ""
-    }
-
-    proc cmd_testset2 {args} {
-        ::itest::log_decision toplevel testset2 $args
-        return ""
-    }
-
-    proc cmd_testsetassocdata {args} {
-        ::itest::log_decision toplevel testsetassocdata $args
-        return ""
-    }
-
-    proc cmd_testsetbytearraylength {args} {
-        ::itest::log_decision toplevel testsetbytearraylength $args
-        return ""
-    }
-
-    proc cmd_testseterr {args} {
-        ::itest::log_decision toplevel testseterr $args
-        return ""
-    }
-
-    proc cmd_testseterrorcode {args} {
-        ::itest::log_decision toplevel testseterrorcode $args
-        return ""
-    }
-
-    proc cmd_testsetmainloop {args} {
-        ::itest::log_decision toplevel testsetmainloop $args
-        return ""
-    }
-
-    proc cmd_testsetnoerr {args} {
-        ::itest::log_decision toplevel testsetnoerr $args
-        return ""
-    }
-
-    proc cmd_testsetobjerrorcode {args} {
-        ::itest::log_decision toplevel testsetobjerrorcode $args
-        return ""
-    }
-
-    proc cmd_testsetplatform {args} {
-        ::itest::log_decision toplevel testsetplatform $args
-        return ""
-    }
-
-    proc cmd_testsimplefilesystem {args} {
-        ::itest::log_decision toplevel testsimplefilesystem $args
-        return ""
-    }
-
-    proc cmd_testsize {args} {
-        ::itest::log_decision toplevel testsize $args
-        return ""
-    }
-
-    proc cmd_testsocket {args} {
-        ::itest::log_decision toplevel testsocket $args
-        return ""
-    }
-
-    proc cmd_teststaticlibrary {args} {
-        ::itest::log_decision toplevel teststaticlibrary $args
-        return ""
-    }
-
-    proc cmd_teststaticpkg {args} {
-        ::itest::log_decision toplevel teststaticpkg $args
-        return ""
-    }
-
-    proc cmd_teststringbytes {args} {
-        ::itest::log_decision toplevel teststringbytes $args
-        return ""
-    }
-
-    proc cmd_teststringobj {args} {
-        ::itest::log_decision toplevel teststringobj $args
-        return ""
-    }
-
-    proc cmd_testtranslatefilename {args} {
-        ::itest::log_decision toplevel testtranslatefilename $args
-        return ""
-    }
-
-    proc cmd_testuniclass {args} {
-        ::itest::log_decision toplevel testuniclass $args
-        return ""
-    }
-
-    proc cmd_testupvar {args} {
-        ::itest::log_decision toplevel testupvar $args
-        return ""
-    }
-
-    proc cmd_testutfnext {args} {
-        ::itest::log_decision toplevel testutfnext $args
-        return ""
-    }
-
-    proc cmd_testutfprev {args} {
-        ::itest::log_decision toplevel testutfprev $args
-        return ""
-    }
-
-    proc cmd_testwrongnumargs {args} {
-        ::itest::log_decision toplevel testwrongnumargs $args
-        return ""
-    }
-
-    proc cmd_text {args} {
-        ::itest::log_decision toplevel text $args
-        return ""
-    }
-
-    proc cmd_timing {args} {
-        ::itest::log_decision toplevel timing $args
-        return ""
-    }
-
-    proc cmd_tk {args} {
-        ::itest::log_decision toplevel tk $args
-        return ""
-    }
-
-    proc cmd_tk_chooseColor {args} {
-        ::itest::log_decision toplevel tk_chooseColor $args
-        return ""
-    }
-
-    proc cmd_tk_chooseDirectory {args} {
-        ::itest::log_decision toplevel tk_chooseDirectory $args
-        return ""
-    }
-
-    proc cmd_tk_getOpenFile {args} {
-        ::itest::log_decision toplevel tk_getOpenFile $args
-        return ""
-    }
-
-    proc cmd_tk_getSaveFile {args} {
-        ::itest::log_decision toplevel tk_getSaveFile $args
-        return ""
-    }
-
-    proc cmd_tk_messageBox {args} {
-        ::itest::log_decision toplevel tk_messageBox $args
-        return ""
-    }
-
-    proc cmd_tk_popup {args} {
-        ::itest::log_decision toplevel tk_popup $args
-        return ""
-    }
-
-    proc cmd_toplevel {args} {
-        ::itest::log_decision toplevel toplevel $args
-        return ""
-    }
-
-    proc cmd_trace {args} {
-        ::itest::log_decision toplevel trace $args
-        return ""
-    }
-
-    proc cmd_traffic_group {args} {
-        ::itest::log_decision toplevel traffic_group $args
-        return ""
-    }
-
-    proc cmd_translate {args} {
-        ::itest::log_decision toplevel translate $args
-        return ""
-    }
-
-    proc cmd_uniq_ordered_ip_list {args} {
-        ::itest::log_decision toplevel uniq_ordered_ip_list $args
-        return ""
-    }
-
-    proc cmd_uniq_sorted_ip_list {args} {
-        ::itest::log_decision toplevel uniq_sorted_ip_list $args
-        return ""
-    }
-
-    proc cmd_unset {args} {
-        ::itest::log_decision toplevel unset $args
-        return ""
-    }
-
-    proc cmd_uplevel {args} {
-        ::itest::log_decision toplevel uplevel $args
-        return ""
-    }
-
-    proc cmd_upvar {args} {
-        ::itest::log_decision toplevel upvar $args
-        return ""
-    }
-
-    proc cmd_urlcatblindquery {args} {
-        ::itest::log_decision toplevel urlcatblindquery $args
-        return ""
-    }
-
-    proc cmd_urlcatquery {args} {
-        ::itest::log_decision toplevel urlcatquery $args
-        return ""
-    }
-
-    proc cmd_use {args} {
-        ::itest::log_decision toplevel use $args
-        return ""
-    }
-
-    proc cmd_variable {args} {
-        ::itest::log_decision toplevel variable $args
-        return ""
-    }
-
-    proc cmd_vlan_id {args} {
-        ::itest::log_decision toplevel vlan_id $args
-        return ""
-    }
-
-    proc cmd_when {args} {
-        ::itest::log_decision toplevel when $args
-        return ""
-    }
-
-    proc cmd_whereis {args} {
-        ::itest::log_decision toplevel whereis $args
-        return ""
-    }
-
-    proc cmd_while {args} {
-        ::itest::log_decision toplevel while $args
-        return ""
-    }
-
-    proc cmd_winfo {args} {
-        ::itest::log_decision toplevel winfo $args
-        return ""
-    }
-
-    proc cmd_wm {args} {
-        ::itest::log_decision toplevel wm $args
-        return ""
-    }
-
-    proc cmd_xff_list {args} {
-        ::itest::log_decision toplevel xff_list $args
-        return ""
-    }
-
-    proc cmd_xff_uniq_ordered_ip_list {args} {
-        ::itest::log_decision toplevel xff_uniq_ordered_ip_list $args
-        return ""
-    }
-
-    proc cmd_xff_uniq_sorted_ip_list {args} {
-        ::itest::log_decision toplevel xff_uniq_sorted_ip_list $args
-        return ""
+    # Generic stub used for every registry command lacking a hand-written mock.
+    # Logs the call under its (category, action) exactly as the former per-
+    # command stub procs did, then returns the empty string.
+    proc _stub {cat action args} {
+        ::itest::log_decision $cat $action $args
+        return ""
+    }
+
+    # Map: mock-proc-name (the `_mock_proc_name` spelling) -> {category action}
+    # for every registry command without a hand-written mock.  register_all
+    # probes this table with the same name it uses to probe for hand-written
+    # mock procs, so hand-written mocks continue to take precedence.
+    variable _stub_actions
+    array set _stub_actions {
+    aaa_acct_result {aaa acct_result}
+    aaa_acct_send {aaa acct_send}
+    aaa_auth_result {aaa auth_result}
+    aaa_auth_send {aaa auth_send}
+    access_acl {access acl}
+    access_disable {access disable}
+    access_enable {access enable}
+    access_ephemeral_auth {access ephemeral-auth}
+    access_flowid {access flowid}
+    access_log {access log}
+    access_oauth {access oauth}
+    access_perflow {access perflow}
+    access_policy {access policy}
+    access_respond {access respond}
+    access_restrict_irule_events {access restrict_irule_events}
+    access_saml {access saml}
+    access_session {access session}
+    access_user {access user}
+    access_uuid {access uuid}
+    access2_access2_proc {access2 access2_proc}
+    acl_action {acl action}
+    acl_eval {acl eval}
+    adapt_allow {adapt allow}
+    adapt_context_create {adapt context_create}
+    adapt_context_current {adapt context_current}
+    adapt_context_delete_all {adapt context_delete_all}
+    adapt_context_name {adapt context_name}
+    adapt_context_static {adapt context_static}
+    adapt_enable {adapt enable}
+    adapt_preview_size {adapt preview_size}
+    adapt_result {adapt result}
+    adapt_select {adapt select}
+    adapt_service_down_action {adapt service_down_action}
+    adapt_timeout {adapt timeout}
+    aes_decrypt {aes decrypt}
+    aes_encrypt {aes encrypt}
+    aes_key {aes key}
+    am_age {am age}
+    am_application {am application}
+    am_cache {am cache}
+    am_disable {am disable}
+    am_expires {am expires}
+    am_media_playlist {am media_playlist}
+    am_policy_node {am policy_node}
+    antifraud_alert_additional_info {antifraud alert_additional_info}
+    antifraud_alert_bait_signatures {antifraud alert_bait_signatures}
+    antifraud_alert_component {antifraud alert_component}
+    antifraud_alert_defined_value {antifraud alert_defined_value}
+    antifraud_alert_details {antifraud alert_details}
+    antifraud_alert_device_id {antifraud alert_device_id}
+    antifraud_alert_expected_value {antifraud alert_expected_value}
+    antifraud_alert_fingerprint {antifraud alert_fingerprint}
+    antifraud_alert_forbidden_added_element {antifraud alert_forbidden_added_element}
+    antifraud_alert_guid {antifraud alert_guid}
+    antifraud_alert_html {antifraud alert_html}
+    antifraud_alert_http_referrer {antifraud alert_http_referrer}
+    antifraud_alert_id {antifraud alert_id}
+    antifraud_alert_license_id {antifraud alert_license_id}
+    antifraud_alert_min {antifraud alert_min}
+    antifraud_alert_origin {antifraud alert_origin}
+    antifraud_alert_resolved_value {antifraud alert_resolved_value}
+    antifraud_alert_score {antifraud alert_score}
+    antifraud_alert_transaction_data {antifraud alert_transaction_data}
+    antifraud_alert_transaction_id {antifraud alert_transaction_id}
+    antifraud_alert_type {antifraud alert_type}
+    antifraud_alert_username {antifraud alert_username}
+    antifraud_alert_view_id {antifraud alert_view_id}
+    antifraud_client_id {antifraud client_id}
+    antifraud_device_id {antifraud device_id}
+    antifraud_disable {antifraud disable}
+    antifraud_disable_alert {antifraud disable_alert}
+    antifraud_disable_app_layer_encryption {antifraud disable_app_layer_encryption}
+    antifraud_disable_auto_transactions {antifraud disable_auto_transactions}
+    antifraud_disable_injection {antifraud disable_injection}
+    antifraud_disable_malware {antifraud disable_malware}
+    antifraud_disable_phishing {antifraud disable_phishing}
+    antifraud_enable {antifraud enable}
+    antifraud_enable_log {antifraud enable_log}
+    antifraud_fingerprint {antifraud fingerprint}
+    antifraud_geo {antifraud geo}
+    antifraud_guid {antifraud guid}
+    antifraud_result {antifraud result}
+    antifraud_username {antifraud username}
+    asm_captcha {asm captcha}
+    asm_captcha_age {asm captcha_age}
+    asm_captcha_status {asm captcha_status}
+    asm_client_ip {asm client_ip}
+    asm_conviction {asm conviction}
+    asm_deception {asm deception}
+    asm_disable {asm disable}
+    asm_enable {asm enable}
+    asm_fingerprint {asm fingerprint}
+    asm_is_authenticated {asm is_authenticated}
+    asm_login_status {asm login_status}
+    asm_microservice {asm microservice}
+    asm_payload {asm payload}
+    asm_policy {asm policy}
+    asm_raise {asm raise}
+    asm_severity {asm severity}
+    asm_signature {asm signature}
+    asm_status {asm status}
+    asm_support_id {asm support_id}
+    asm_threat_campaign {asm threat_campaign}
+    asm_unblock {asm unblock}
+    asm_uncaptcha {asm uncaptcha}
+    asm_username {asm username}
+    asm_violation {asm violation}
+    asm_violation_data {asm violation_data}
+    asn1_decode {asn1 decode}
+    asn1_element {asn1 element}
+    asn1_encode {asn1 encode}
+    auth_abort {auth abort}
+    auth_authenticate {auth authenticate}
+    auth_authenticate_continue {auth authenticate_continue}
+    auth_cert_credential {auth cert_credential}
+    auth_cert_issuer_credential {auth cert_issuer_credential}
+    auth_last_event_session_id {auth last_event_session_id}
+    auth_password_credential {auth password_credential}
+    auth_response_data {auth response_data}
+    auth_ssl_cc_ldap_status {auth ssl_cc_ldap_status}
+    auth_ssl_cc_ldap_username {auth ssl_cc_ldap_username}
+    auth_start {auth start}
+    auth_status {auth status}
+    auth_subscribe {auth subscribe}
+    auth_unsubscribe {auth unsubscribe}
+    auth_username_credential {auth username_credential}
+    auth_wantcredential_prompt {auth wantcredential_prompt}
+    auth_wantcredential_prompt_style {auth wantcredential_prompt_style}
+    auth_wantcredential_type {auth wantcredential_type}
+    avr_disable {avr disable}
+    avr_disable_cspm_injection {avr disable_cspm_injection}
+    avr_enable {avr enable}
+    avr_log {avr log}
+    bigproto_enable_fix_reset {bigproto enable_fix_reset}
+    bigtcp_release_flow {bigtcp release_flow}
+    botdefense_action {botdefense action}
+    botdefense_bot_anomalies {botdefense bot_anomalies}
+    botdefense_bot_categories {botdefense bot_categories}
+    botdefense_bot_name {botdefense bot_name}
+    botdefense_bot_signature {botdefense bot_signature}
+    botdefense_bot_signature_category {botdefense bot_signature_category}
+    botdefense_captcha_age {botdefense captcha_age}
+    botdefense_captcha_status {botdefense captcha_status}
+    botdefense_client_class {botdefense client_class}
+    botdefense_client_type {botdefense client_type}
+    botdefense_cookie_age {botdefense cookie_age}
+    botdefense_cookie_status {botdefense cookie_status}
+    botdefense_cs_allowed {botdefense cs_allowed}
+    botdefense_cs_attribute {botdefense cs_attribute}
+    botdefense_cs_possible {botdefense cs_possible}
+    botdefense_device_id {botdefense device_id}
+    botdefense_disable {botdefense disable}
+    botdefense_enable {botdefense enable}
+    botdefense_intent {botdefense intent}
+    botdefense_micro_service {botdefense micro_service}
+    botdefense_previous_action {botdefense previous_action}
+    botdefense_previous_request_age {botdefense previous_request_age}
+    botdefense_previous_support_id {botdefense previous_support_id}
+    botdefense_reason {botdefense reason}
+    botdefense_support_id {botdefense support_id}
+    bwc_color {bwc color}
+    bwc_debug {bwc debug}
+    bwc_mark {bwc mark}
+    bwc_measure {bwc measure}
+    bwc_policy {bwc policy}
+    bwc_pps {bwc pps}
+    bwc_priority {bwc priority}
+    bwc_rate {bwc rate}
+    cache_accept_encoding {cache accept_encoding}
+    cache_age {cache age}
+    cache_disable {cache disable}
+    cache_disabled {cache disabled}
+    cache_enable {cache enable}
+    cache_expire {cache expire}
+    cache_fresh {cache fresh}
+    cache_header {cache header}
+    cache_headers {cache headers}
+    cache_hits {cache hits}
+    cache_payload {cache payload}
+    cache_priority {cache priority}
+    cache_statskey {cache statskey}
+    cache_trace {cache trace}
+    cache_uri {cache uri}
+    cache_useragent {cache useragent}
+    cache_userkey {cache userkey}
+    category_analytics {category analytics}
+    category_filetype {category filetype}
+    category_lookup {category lookup}
+    category_matchtype {category matchtype}
+    category_result {category result}
+    category_safesearch {category safesearch}
+    classification_app {classification app}
+    classification_category {classification category}
+    classification_disable {classification disable}
+    classification_enable {classification enable}
+    classification_protocol {classification protocol}
+    classification_result {classification result}
+    classification_urlcat {classification urlcat}
+    classification_username {classification username}
+    classify_application {classify application}
+    classify_category {classify category}
+    classify_defer {classify defer}
+    classify_disable {classify disable}
+    classify_urlcat {classify urlcat}
+    classify_username {classify username}
+    compress_buffer_size {compress buffer_size}
+    compress_disable {compress disable}
+    compress_enable {compress enable}
+    compress_gzip {compress gzip}
+    compress_method {compress method}
+    compress_nodelay {compress nodelay}
+    connector_disable {connector disable}
+    connector_enable {connector enable}
+    connector_profile {connector profile}
+    connector_remap {connector remap}
+    crypto_decrypt {crypto decrypt}
+    crypto_encrypt {crypto encrypt}
+    crypto_hash {crypto hash}
+    crypto_keygen {crypto keygen}
+    crypto_sign {crypto sign}
+    crypto_verify {crypto verify}
+    datagram_dns {datagram dns}
+    datagram_ip {datagram ip}
+    datagram_ip6 {datagram ip6}
+    datagram_l2 {datagram l2}
+    datagram_tcp {datagram tcp}
+    datagram_udp {datagram udp}
+    decompress_disable {decompress disable}
+    decompress_enable {decompress enable}
+    demangle_disable {demangle disable}
+    demangle_enable {demangle enable}
+    dhcp_version {dhcp version}
+    dhcpv4_chaddr {dhcpv4 chaddr}
+    dhcpv4_ciaddr {dhcpv4 ciaddr}
+    dhcpv4_drop {dhcpv4 drop}
+    dhcpv4_giaddr {dhcpv4 giaddr}
+    dhcpv4_hlen {dhcpv4 hlen}
+    dhcpv4_hops {dhcpv4 hops}
+    dhcpv4_htype {dhcpv4 htype}
+    dhcpv4_len {dhcpv4 len}
+    dhcpv4_opcode {dhcpv4 opcode}
+    dhcpv4_option {dhcpv4 option}
+    dhcpv4_reject {dhcpv4 reject}
+    dhcpv4_secs {dhcpv4 secs}
+    dhcpv4_siaddr {dhcpv4 siaddr}
+    dhcpv4_type {dhcpv4 type}
+    dhcpv4_xid {dhcpv4 xid}
+    dhcpv4_yiaddr {dhcpv4 yiaddr}
+    dhcpv6_drop {dhcpv6 drop}
+    dhcpv6_hop_count {dhcpv6 hop_count}
+    dhcpv6_len {dhcpv6 len}
+    dhcpv6_link_address {dhcpv6 link_address}
+    dhcpv6_msg_type {dhcpv6 msg_type}
+    dhcpv6_option {dhcpv6 option}
+    dhcpv6_peer_address {dhcpv6 peer_address}
+    dhcpv6_reject {dhcpv6 reject}
+    dhcpv6_transaction_id {dhcpv6 transaction_id}
+    diag_test {diag test}
+    diameter_avp {diameter avp}
+    diameter_command {diameter command}
+    diameter_disconnect {diameter disconnect}
+    diameter_drop {diameter drop}
+    diameter_dynamic_route_insertion {diameter dynamic_route_insertion}
+    diameter_dynamic_route_lookup {diameter dynamic_route_lookup}
+    diameter_header {diameter header}
+    diameter_host {diameter host}
+    diameter_is_request {diameter is_request}
+    diameter_is_response {diameter is_response}
+    diameter_is_retransmission {diameter is_retransmission}
+    diameter_length {diameter length}
+    diameter_message {diameter message}
+    diameter_payload {diameter payload}
+    diameter_persist {diameter persist}
+    diameter_realm {diameter realm}
+    diameter_respond {diameter respond}
+    diameter_result {diameter result}
+    diameter_retransmission {diameter retransmission}
+    diameter_retransmission_default {diameter retransmission_default}
+    diameter_retransmission_reason {diameter retransmission_reason}
+    diameter_retransmit {diameter retransmit}
+    diameter_retry {diameter retry}
+    diameter_route_status {diameter route_status}
+    diameter_session {diameter session}
+    diameter_skip_capabilities_exchange {diameter skip_capabilities_exchange}
+    diameter_state {diameter state}
+    dns_additional {dns additional}
+    dns_authority {dns authority}
+    dns_class {dns class}
+    dns_disable {dns disable}
+    dns_drop {dns drop}
+    dns_edns0 {dns edns0}
+    dns_enable {dns enable}
+    dns_is_wideip {dns is_wideip}
+    dns_last_act {dns last_act}
+    dns_len {dns len}
+    dns_log {dns log}
+    dns_name {dns name}
+    dns_origin {dns origin}
+    dns_ptype {dns ptype}
+    dns_query {dns query}
+    dns_question {dns question}
+    dns_rdata {dns rdata}
+    dns_rpz_policy {dns rpz_policy}
+    dns_rr {dns rr}
+    dns_scrape {dns scrape}
+    dns_tsig {dns tsig}
+    dns_ttl {dns ttl}
+    dns_type {dns type}
+    dnsmsg_header {dnsmsg header}
+    dnsmsg_record {dnsmsg record}
+    dnsmsg_section {dnsmsg section}
+    dosl7_disable {dosl7 disable}
+    dosl7_enable {dosl7 enable}
+    dosl7_health {dosl7 health}
+    dosl7_is_ip_slowdown {dosl7 is_ip_slowdown}
+    dosl7_is_mitigated {dosl7 is_mitigated}
+    dosl7_profile {dosl7 profile}
+    dosl7_slowdown {dosl7 slowdown}
+    dslite_remote_addr {dslite remote_addr}
+    eca_client_machine_name {eca client_machine_name}
+    eca_disable {eca disable}
+    eca_domainname {eca domainname}
+    eca_enable {eca enable}
+    eca_select {eca select}
+    eca_status {eca status}
+    eca_username {eca username}
+    fix_tag {fix tag}
+    flow_create_related {flow create_related}
+    flow_idle_duration {flow idle_duration}
+    flow_idle_timeout {flow idle_timeout}
+    flow_peer {flow peer}
+    flow_priority {flow priority}
+    flow_refresh {flow refresh}
+    flow_this {flow this}
+    flowtable_count {flowtable count}
+    flowtable_limit {flowtable limit}
+    ftp_allow_active_mode {ftp allow_active_mode}
+    ftp_disable {ftp disable}
+    ftp_enable {ftp enable}
+    ftp_enforce_tls_session_reuse {ftp enforce_tls_session_reuse}
+    ftp_ftps_mode {ftp ftps_mode}
+    ftp_port {ftp port}
+    genericmessage_message {genericmessage message}
+    genericmessage_peer {genericmessage peer}
+    genericmessage_route {genericmessage route}
+    gtp_clone {gtp clone}
+    gtp_discard {gtp discard}
+    gtp_forward {gtp forward}
+    gtp_header {gtp header}
+    gtp_ie {gtp ie}
+    gtp_length {gtp length}
+    gtp_message {gtp message}
+    gtp_new {gtp new}
+    gtp_parse {gtp parse}
+    gtp_payload {gtp payload}
+    gtp_respond {gtp respond}
+    gtp_tunnel {gtp tunnel}
+    ha_status {ha status}
+    hsl_open {hsl open}
+    hsl_send {hsl send}
+    html_comment {html comment}
+    html_disable {html disable}
+    html_enable {html enable}
+    html_encode {html encode}
+    html_tag {html tag}
+    http_passthrough_reason {http passthrough_reason}
+    http_password {http password}
+    http_proxy {http proxy}
+    http_reject_reason {http reject_reason}
+    http_response {http response}
+    http_username {http username}
+    http2_active {http2 active}
+    http2_concurrency {http2 concurrency}
+    http2_disable {http2 disable}
+    http2_disconnect {http2 disconnect}
+    http2_enable {http2 enable}
+    http2_push {http2 push}
+    http2_requests {http2 requests}
+    http2_version {http2 version}
+    httplog_disable {httplog disable}
+    httplog_enable {httplog enable}
+    icap_header {icap header}
+    icap_method {icap method}
+    icap_status {icap status}
+    icap_uri {icap uri}
+    ike_auth_success {ike auth_success}
+    ike_cert {ike cert}
+    ike_san_dirname {ike san_dirname}
+    ike_san_dns {ike san_dns}
+    ike_san_ediparty {ike san_ediparty}
+    ike_san_email {ike san_email}
+    ike_san_ipadd {ike san_ipadd}
+    ike_san_othername {ike san_othername}
+    ike_san_rid {ike san_rid}
+    ike_san_uri {ike san_uri}
+    ike_san_x400 {ike san_x400}
+    ike_subjectAltName {ike subjectAltName}
+    ilx_call {ilx call}
+    ilx_init {ilx init}
+    ilx_notify {ilx notify}
+    imap_activation_mode {imap activation_mode}
+    imap_disable {imap disable}
+    imap_enable {imap enable}
+    ip_addr {ip addr}
+    ip_hops {ip hops}
+    ip_idle_timeout {ip idle_timeout}
+    ip_ingress_drop_rate {ip ingress_drop_rate}
+    ip_ingress_rate_limit {ip ingress_rate_limit}
+    ip_intelligence {ip intelligence}
+    ip_reputation {ip reputation}
+    ip_stats {ip stats}
+    ip_version {ip version}
+    ipfix_destination {ipfix destination}
+    ipfix_msg {ipfix msg}
+    ipfix_template {ipfix template}
+    isession_deduplication {isession deduplication}
+    istats_get {istats get}
+    istats_incr {istats incr}
+    istats_remove {istats remove}
+    istats_set {istats set}
+    ivs_entry_result {ivs_entry result}
+    json_array {json array}
+    json_create {json create}
+    json_get {json get}
+    json_object {json object}
+    json_parse {json parse}
+    json_render {json render}
+    json_root {json root}
+    json_set {json set}
+    json_type {json type}
+    l7check_protocol {l7check protocol}
+    lb_bias {lb bias}
+    lb_class {lb class}
+    lb_command {lb command}
+    lb_connect {lb connect}
+    lb_connlimit {lb connlimit}
+    lb_context_id {lb context_id}
+    lb_down {lb down}
+    lb_dst_tag {lb dst_tag}
+    lb_enable_decisionlog {lb enable_decisionlog}
+    lb_mode {lb mode}
+    lb_persist {lb persist}
+    lb_prime {lb prime}
+    lb_queue {lb queue}
+    lb_snat {lb snat}
+    lb_src_tag {lb src_tag}
+    lb_up {lb up}
+    ldap_activation_mode {ldap activation_mode}
+    ldap_disable {ldap disable}
+    ldap_enable {ldap enable}
+    line_get {line get}
+    line_set {line set}
+    link_lasthop {link lasthop}
+    link_nexthop {link nexthop}
+    link_qos {link qos}
+    link_vlan_id {link vlan_id}
+    lsn_address {lsn address}
+    lsn_disable {lsn disable}
+    lsn_inbound {lsn inbound}
+    lsn_inbound_entry {lsn inbound-entry}
+    lsn_persistence {lsn persistence}
+    lsn_persistence_entry {lsn persistence-entry}
+    lsn_pool {lsn pool}
+    lsn_port {lsn port}
+    message_field {message field}
+    message_proto {message proto}
+    message_type {message type}
+    mqtt_clean_session {mqtt clean_session}
+    mqtt_client_id {mqtt client_id}
+    mqtt_collect {mqtt collect}
+    mqtt_disable {mqtt disable}
+    mqtt_disconnect {mqtt disconnect}
+    mqtt_drop {mqtt drop}
+    mqtt_dup {mqtt dup}
+    mqtt_enable {mqtt enable}
+    mqtt_insert {mqtt insert}
+    mqtt_keep_alive {mqtt keep_alive}
+    mqtt_length {mqtt length}
+    mqtt_message {mqtt message}
+    mqtt_packet_id {mqtt packet_id}
+    mqtt_password {mqtt password}
+    mqtt_payload {mqtt payload}
+    mqtt_protocol_name {mqtt protocol_name}
+    mqtt_protocol_version {mqtt protocol_version}
+    mqtt_qos {mqtt qos}
+    mqtt_release {mqtt release}
+    mqtt_replace {mqtt replace}
+    mqtt_respond {mqtt respond}
+    mqtt_retain {mqtt retain}
+    mqtt_return_code {mqtt return_code}
+    mqtt_return_code_list {mqtt return_code_list}
+    mqtt_session_present {mqtt session_present}
+    mqtt_topic {mqtt topic}
+    mqtt_type {mqtt type}
+    mqtt_username {mqtt username}
+    mqtt_will {mqtt will}
+    mr_always_match_port {mr always_match_port}
+    mr_available_for_routing {mr available_for_routing}
+    mr_collect {mr collect}
+    mr_connect_back_port {mr connect_back_port}
+    mr_connection_instance {mr connection_instance}
+    mr_connection_mode {mr connection_mode}
+    mr_equivalent_transport {mr equivalent_transport}
+    mr_flow_id {mr flow_id}
+    mr_ignore_peer_port {mr ignore_peer_port}
+    mr_instance {mr instance}
+    mr_max_retries {mr max_retries}
+    mr_message {mr message}
+    mr_payload {mr payload}
+    mr_peer {mr peer}
+    mr_prime {mr prime}
+    mr_protocol {mr protocol}
+    mr_release {mr release}
+    mr_restore {mr restore}
+    mr_retry {mr retry}
+    mr_return {mr return}
+    mr_store {mr store}
+    mr_stream {mr stream}
+    mr_transport {mr transport}
+    name_lookup {name lookup}
+    name_response {name response}
+    nsh_chain {nsh chain}
+    nsh_context {nsh context}
+    nsh_md1 {nsh md1}
+    nsh_mocksf {nsh mocksf}
+    nsh_path_id {nsh path_id}
+    nsh_service_index {nsh service_index}
+    ntlm_disable {ntlm disable}
+    ntlm_enable {ntlm enable}
+    offbox_request {offbox request}
+    oneconnect_detach {oneconnect detach}
+    oneconnect_label {oneconnect label}
+    oneconnect_reuse {oneconnect reuse}
+    oneconnect_select {oneconnect select}
+    pcp_reject {pcp reject}
+    pcp_request {pcp request}
+    pcp_response {pcp response}
+    pem_disable {pem disable}
+    pem_enable {pem enable}
+    pem_flow {pem flow}
+    pem_session {pem session}
+    pem_subscriber {pem subscriber}
+    plugin_disable {plugin disable}
+    plugin_enable {plugin enable}
+    policy_controls {policy controls}
+    policy_names {policy names}
+    policy_rules {policy rules}
+    policy_targets {policy targets}
+    pop3_activation_mode {pop3 activation_mode}
+    pop3_disable {pop3 disable}
+    pop3_enable {pop3 enable}
+    profile_access {profile access}
+    profile_antifraud {profile antifraud}
+    profile_auth {profile auth}
+    profile_avr {profile avr}
+    profile_clientssl {profile clientssl}
+    profile_diameter {profile diameter}
+    profile_exchange {profile exchange}
+    profile_exists {profile exists}
+    profile_fastL4 {profile fastL4}
+    profile_fasthttp {profile fasthttp}
+    profile_ftp {profile ftp}
+    profile_http {profile http}
+    profile_httpclass {profile httpclass}
+    profile_httpcompression {profile httpcompression}
+    profile_list {profile list}
+    profile_oneconnect {profile oneconnect}
+    profile_persist {profile persist}
+    profile_serverssl {profile serverssl}
+    profile_stream {profile stream}
+    profile_tcp {profile tcp}
+    profile_tftp {profile tftp}
+    profile_udp {profile udp}
+    profile_vdi {profile vdi}
+    profile_webacceleration {profile webacceleration}
+    profile_xml {profile xml}
+    protocol_inspection_disable {protocol_inspection disable}
+    protocol_inspection_id {protocol_inspection id}
+    psc_aaa_reporting_interval {psc aaa_reporting_interval}
+    psc_attr {psc attr}
+    psc_calling_id {psc calling_id}
+    psc_imeisv {psc imeisv}
+    psc_imsi {psc imsi}
+    psc_ip_address {psc ip_address}
+    psc_lease_time {psc lease_time}
+    psc_policy {psc policy}
+    psc_subscriber_id {psc subscriber_id}
+    psc_tower_id {psc tower_id}
+    psc_user_name {psc user_name}
+    psm_disable {psm disable}
+    psm_enable {psm enable}
+    psm_disable {psm disable}
+    psm_enable {psm enable}
+    psm_disable {psm disable}
+    psm_enable {psm enable}
+    qoe_disable {qoe disable}
+    qoe_enable {qoe enable}
+    qoe_video {qoe video}
+    radius_avp {radius avp}
+    radius_code {radius code}
+    radius_id {radius id}
+    radius_rtdom {radius rtdom}
+    radius_subscriber {radius subscriber}
+    resolv_lookup {resolv lookup}
+    resolver_name_lookup {resolver name_lookup}
+    resolver_summarize {resolver summarize}
+    rest_send {rest send}
+    rewrite_disable {rewrite disable}
+    rewrite_enable {rewrite enable}
+    rewrite_payload {rewrite payload}
+    rewrite_post_process {rewrite post_process}
+    route_age {route age}
+    route_bandwidth {route bandwidth}
+    route_clear {route clear}
+    route_cwnd {route cwnd}
+    route_domain {route domain}
+    route_expiration {route expiration}
+    route_mtu {route mtu}
+    route_rtt {route rtt}
+    route_rttvar {route rttvar}
+    rtsp_collect {rtsp collect}
+    rtsp_header {rtsp header}
+    rtsp_method {rtsp method}
+    rtsp_msg_source {rtsp msg_source}
+    rtsp_payload {rtsp payload}
+    rtsp_release {rtsp release}
+    rtsp_respond {rtsp respond}
+    rtsp_status {rtsp status}
+    rtsp_uri {rtsp uri}
+    rtsp_version {rtsp version}
+    sctp_client_port {sctp client_port}
+    sctp_collect {sctp collect}
+    sctp_local_port {sctp local_port}
+    sctp_mss {sctp mss}
+    sctp_payload {sctp payload}
+    sctp_ppi {sctp ppi}
+    sctp_release {sctp release}
+    sctp_remote_port {sctp remote_port}
+    sctp_respond {sctp respond}
+    sctp_rto_initial {sctp rto_initial}
+    sctp_rto_max {sctp rto_max}
+    sctp_rto_min {sctp rto_min}
+    sctp_sack_timeout {sctp sack_timeout}
+    sctp_server_port {sctp server_port}
+    sdp_field {sdp field}
+    sdp_media {sdp media}
+    sdp_session_id {sdp session_id}
+    sip_call_id {sip call_id}
+    sip_discard {sip discard}
+    sip_from {sip from}
+    sip_header {sip header}
+    sip_message {sip message}
+    sip_method {sip method}
+    sip_payload {sip payload}
+    sip_persist {sip persist}
+    sip_record_route {sip record-route}
+    sip_respond {sip respond}
+    sip_response {sip response}
+    sip_route {sip route}
+    sip_route_status {sip route_status}
+    sip_to {sip to}
+    sip_uri {sip uri}
+    sip_via {sip via}
+    sipalg_hairpin {sipalg hairpin}
+    sipalg_hairpin_default {sipalg hairpin_default}
+    sipalg_nonregister_subscriber_listener {sipalg nonregister_subscriber_listener}
+    smtps_activation_mode {smtps activation_mode}
+    smtps_disable {smtps disable}
+    smtps_enable {smtps enable}
+    socks_allowed {socks allowed}
+    socks_destination {socks destination}
+    socks_version {socks version}
+    sse_field {sse field}
+    ssl_allow_dynamic_record_sizing {ssl allow_dynamic_record_sizing}
+    ssl_allow_nonssl {ssl allow_nonssl}
+    ssl_alpn {ssl alpn}
+    ssl_authenticate {ssl authenticate}
+    ssl_c3d {ssl c3d}
+    ssl_cert_constraint {ssl cert_constraint}
+    ssl_clientrandom {ssl clientrandom}
+    ssl_collect {ssl collect}
+    ssl_forward_proxy {ssl forward_proxy}
+    ssl_handshake {ssl handshake}
+    ssl_is_renegotiation_secure {ssl is_renegotiation_secure}
+    ssl_maximum_record_size {ssl maximum_record_size}
+    ssl_mode {ssl mode}
+    ssl_modssl_sessionid_headers {ssl modssl_sessionid_headers}
+    ssl_nextproto {ssl nextproto}
+    ssl_payload {ssl payload}
+    ssl_profile {ssl profile}
+    ssl_release {ssl release}
+    ssl_renegotiate {ssl renegotiate}
+    ssl_secure_renegotiation {ssl secure_renegotiation}
+    ssl_session {ssl session}
+    ssl_sessionsecret {ssl sessionsecret}
+    ssl_sessionticket {ssl sessionticket}
+    ssl_tls13_secret {ssl tls13_secret}
+    ssl_unclean_shutdown {ssl unclean_shutdown}
+    ssl_verify_result {ssl verify_result}
+    stats_get {stats get}
+    stats_incr {stats incr}
+    stats_set {stats set}
+    stats_setmax {stats setmax}
+    stats_setmin {stats setmin}
+    stream_disable {stream disable}
+    stream_enable {stream enable}
+    stream_encoding {stream encoding}
+    stream_expression {stream expression}
+    stream_match {stream match}
+    stream_max_matchsize {stream max_matchsize}
+    stream_replace {stream replace}
+    tap_action {tap action}
+    tap_config {tap config}
+    tap_insight {tap insight}
+    tap_insight_requested {tap insight_requested}
+    tap_score {tap score}
+    tcp_abc {tcp abc}
+    tcp_analytics {tcp analytics}
+    tcp_autowin {tcp autowin}
+    tcp_congestion {tcp congestion}
+    tcp_delayed_ack {tcp delayed_ack}
+    tcp_dsack {tcp dsack}
+    tcp_earlyrxmit {tcp earlyrxmit}
+    tcp_ecn {tcp ecn}
+    tcp_enhanced_loss_recovery {tcp enhanced_loss_recovery}
+    tcp_idletime {tcp idletime}
+    tcp_keepalive {tcp keepalive}
+    tcp_limxmit {tcp limxmit}
+    tcp_lossfilter {tcp lossfilter}
+    tcp_lossfilterburst {tcp lossfilterburst}
+    tcp_lossfilterrate {tcp lossfilterrate}
+    tcp_nagle {tcp nagle}
+    tcp_naglemode {tcp naglemode}
+    tcp_naglestate {tcp naglestate}
+    tcp_offset {tcp offset}
+    tcp_pacing {tcp pacing}
+    tcp_proxybuffer {tcp proxybuffer}
+    tcp_proxybufferhigh {tcp proxybufferhigh}
+    tcp_proxybufferlow {tcp proxybufferlow}
+    tcp_push_flag {tcp push_flag}
+    tcp_rcv_scale {tcp rcv_scale}
+    tcp_rcv_size {tcp rcv_size}
+    tcp_recvwnd {tcp recvwnd}
+    tcp_rexmt_thresh {tcp rexmt_thresh}
+    tcp_rt_metrics_timeout {tcp rt_metrics_timeout}
+    tcp_rto {tcp rto}
+    tcp_rttvar {tcp rttvar}
+    tcp_sendbuf {tcp sendbuf}
+    tcp_setmss {tcp setmss}
+    tcp_snd_cwnd {tcp snd_cwnd}
+    tcp_snd_scale {tcp snd_scale}
+    tcp_snd_ssthresh {tcp snd_ssthresh}
+    tcp_snd_wnd {tcp snd_wnd}
+    tcp_unused_port {tcp unused_port}
+    tds_msg {tds msg}
+    tds_session {tds session}
+    tmm_cmp_count {tmm cmp_count}
+    tmm_cmp_group {tmm cmp_group}
+    tmm_cmp_groups {tmm cmp_groups}
+    tmm_cmp_primary_group {tmm cmp_primary_group}
+    tmm_cmp_unit {tmm cmp_unit}
+    udp_client_port {udp client_port}
+    udp_debug_queue {udp debug_queue}
+    udp_drop {udp drop}
+    udp_hold {udp hold}
+    udp_local_port {udp local_port}
+    udp_max_buf_pkts {udp max_buf_pkts}
+    udp_max_rate {udp max_rate}
+    udp_mss {udp mss}
+    udp_payload {udp payload}
+    udp_release {udp release}
+    udp_remote_port {udp remote_port}
+    udp_respond {udp respond}
+    udp_sendbuffer {udp sendbuffer}
+    udp_server_port {udp server_port}
+    udp_unused_port {udp unused_port}
+    uri_basename {uri basename}
+    uri_compare {uri compare}
+    uri_decode {uri decode}
+    uri_encode {uri encode}
+    uri_encode_component {uri encode_component}
+    uri_escape {uri escape}
+    uri_host {uri host}
+    uri_path {uri path}
+    uri_port {uri port}
+    uri_protocol {uri protocol}
+    uri_query {uri query}
+    validate_protocol {validate protocol}
+    vdi_disable {vdi disable}
+    vdi_enable {vdi enable}
+    wam_disable {wam disable}
+    wam_enable {wam enable}
+    websso_disable {websso disable}
+    websso_enable {websso enable}
+    websso_select {websso select}
+    ws_collect {ws collect}
+    ws_disconnect {ws disconnect}
+    ws_enabled {ws enabled}
+    ws_frame {ws frame}
+    ws_masking {ws masking}
+    ws_message {ws message}
+    ws_payload {ws payload}
+    ws_payload_ivs {ws payload_ivs}
+    ws_payload_processing {ws payload_processing}
+    ws_release {ws release}
+    ws_request {ws request}
+    ws_response {ws response}
+    x509_cert_fields {x509 cert_fields}
+    x509_extensions {x509 extensions}
+    x509_hash {x509 hash}
+    x509_issuer {x509 issuer}
+    x509_not_valid_after {x509 not_valid_after}
+    x509_not_valid_before {x509 not_valid_before}
+    x509_pem2der {x509 pem2der}
+    x509_serial_number {x509 serial_number}
+    x509_signature_algorithm {x509 signature_algorithm}
+    x509_subject {x509 subject}
+    x509_subject_public_key {x509 subject_public_key}
+    x509_subject_public_key_RSA_bits {x509 subject_public_key_RSA_bits}
+    x509_subject_public_key_type {x509 subject_public_key_type}
+    x509_verify_cert_error_string {x509 verify_cert_error_string}
+    x509_version {x509 version}
+    x509_whole {x509 whole}
+    xlat_listen {xlat listen}
+    xlat_listen_lifetime {xlat listen_lifetime}
+    xlat_src_addr {xlat src_addr}
+    xlat_src_config {xlat src_config}
+    xlat_src_endpoint_reservation {xlat src_endpoint_reservation}
+    xlat_src_nat_valid_range {xlat src_nat_valid_range}
+    xlat_src_port {xlat src_port}
+    xml_address {xml address}
+    xml_collect {xml collect}
+    xml_disable {xml disable}
+    xml_element {xml element}
+    xml_enable {xml enable}
+    xml_event {xml event}
+    xml_eventid {xml eventid}
+    xml_parse {xml parse}
+    xml_payload {xml payload}
+    xml_release {xml release}
+    xml_soap {xml soap}
+    xml_subscribe {xml subscribe}
+    base64_decode {base64 decode}
+    base64_encode {base64 encode}
+    cmdline_getArgv0 {cmdline getArgv0}
+    cmdline_getKnownOpt {cmdline getKnownOpt}
+    cmdline_getKnownOptions {cmdline getKnownOptions}
+    cmdline_getfiles {cmdline getfiles}
+    cmdline_getopt {cmdline getopt}
+    cmdline_getoptions {cmdline getoptions}
+    cmdline_typedGetopt {cmdline typedGetopt}
+    cmdline_typedGetoptions {cmdline typedGetoptions}
+    cmdline_typedUsage {cmdline typedUsage}
+    cmdline_usage {cmdline usage}
+    csv_iscomplete {csv iscomplete}
+    csv_join {csv join}
+    csv_joinlist {csv joinlist}
+    csv_joinmatrix {csv joinmatrix}
+    csv_read2matrix {csv read2matrix}
+    csv_read2queue {csv read2queue}
+    csv_report {csv report}
+    csv_split {csv split}
+    csv_split2matrix {csv split2matrix}
+    csv_split2queue {csv split2queue}
+    csv_writematrix {csv writematrix}
+    csv_writequeue {csv writequeue}
+    dns_address {dns address}
+    dns_cleanup {dns cleanup}
+    dns_cname {dns cname}
+    dns_configure {dns configure}
+    dns_dump {dns dump}
+    dns_error {dns error}
+    dns_errorcode {dns errorcode}
+    dns_name {dns name}
+    dns_reset {dns reset}
+    dns_resolve {dns resolve}
+    dns_result {dns result}
+    dns_status {dns status}
+    dns_wait {dns wait}
+    fileutil_appendToFile {fileutil appendToFile}
+    fileutil_cat {fileutil cat}
+    fileutil_fileType {fileutil fileType}
+    fileutil_find {fileutil find}
+    fileutil_findByPattern {fileutil findByPattern}
+    fileutil_foreachLine {fileutil foreachLine}
+    fileutil_fullnormalize {fileutil fullnormalize}
+    fileutil_grep {fileutil grep}
+    fileutil_insertIntoFile {fileutil insertIntoFile}
+    fileutil_install {fileutil install}
+    fileutil_jail {fileutil jail}
+    fileutil_lexnormalize {fileutil lexnormalize}
+    fileutil_maketempdir {fileutil maketempdir}
+    fileutil_relative {fileutil relative}
+    fileutil_relativeUrl {fileutil relativeUrl}
+    fileutil_removeFromFile {fileutil removeFromFile}
+    fileutil_replaceInFile {fileutil replaceInFile}
+    fileutil_stripN {fileutil stripN}
+    fileutil_stripPwd {fileutil stripPwd}
+    fileutil_tempdir {fileutil tempdir}
+    fileutil_tempdirReset {fileutil tempdirReset}
+    fileutil_tempfile {fileutil tempfile}
+    fileutil_test {fileutil test}
+    fileutil_touch {fileutil touch}
+    fileutil_updateInPlace {fileutil updateInPlace}
+    fileutil_writeFile {fileutil writeFile}
+    html_html_entities {html html_entities}
+    html_tagstrip {html tagstrip}
+    http_cleanup {http cleanup}
+    http_code {http code}
+    http_config {http config}
+    http_cookiejar {http cookiejar}
+    http_data {http data}
+    http_error {http error}
+    http_formatQuery {http formatQuery}
+    http_geturl {http geturl}
+    http_meta {http meta}
+    http_ncode {http ncode}
+    http_postError {http postError}
+    http_quoteString {http quoteString}
+    http_reasonPhrase {http reasonPhrase}
+    http_register {http register}
+    http_registerError {http registerError}
+    http_requestHeaderValue {http requestHeaderValue}
+    http_requestHeaders {http requestHeaders}
+    http_requestLine {http requestLine}
+    http_reset {http reset}
+    http_responseBody {http responseBody}
+    http_responseCode {http responseCode}
+    http_responseHeaderValue {http responseHeaderValue}
+    http_responseHeaders {http responseHeaders}
+    http_responseInfo {http responseInfo}
+    http_responseLine {http responseLine}
+    http_size {http size}
+    http_unregister {http unregister}
+    http_wait {http wait}
+    ip_collapse {ip collapse}
+    ip_contract {ip contract}
+    ip_equal {ip equal}
+    ip_is {ip is}
+    ip_mask {ip mask}
+    ip_normalize {ip normalize}
+    ip_prefix {ip prefix}
+    ip_subtract {ip subtract}
+    ip_type {ip type}
+    ip_version {ip version}
+    json_dict2json {json dict2json}
+    json_json2dict {json json2dict}
+    json_list2json {json list2json}
+    json_many_json2dict {json many-json2dict}
+    json_string2json {json string2json}
+    json_validate {json validate}
+    logger_disable {logger disable}
+    logger_enable {logger enable}
+    logger_import {logger import}
+    logger_init {logger init}
+    logger_initNamespace {logger initNamespace}
+    logger_levels {logger levels}
+    logger_servicecmd {logger servicecmd}
+    logger_services {logger services}
+    logger_setlevel {logger setlevel}
+    logger_walk {logger walk}
+    math_analyse_Kruskal_Wallis {math analyse-Kruskal-Wallis}
+    math_autocorr {math autocorr}
+    math_basic_stats {math basic-stats}
+    math_control_Rchart {math control-Rchart}
+    math_control_xbar {math control-xbar}
+    math_corr {math corr}
+    math_crosscorr {math crosscorr}
+    math_filter {math filter}
+    math_group_rank {math group-rank}
+    math_histogram {math histogram}
+    math_histogram_alt {math histogram-alt}
+    math_interval_mean_stdev {math interval-mean-stdev}
+    math_lillieforsFit {math lillieforsFit}
+    math_linear_model {math linear-model}
+    math_linear_residuals {math linear-residuals}
+    math_map {math map}
+    math_max {math max}
+    math_mean {math mean}
+    math_mean_histogram_limits {math mean-histogram-limits}
+    math_median {math median}
+    math_min {math min}
+    math_minmax_histogram_limits {math minmax-histogram-limits}
+    math_number {math number}
+    math_print_2x2 {math print-2x2}
+    math_pstdev {math pstdev}
+    math_pvar {math pvar}
+    math_quantiles {math quantiles}
+    math_samplescount {math samplescount}
+    math_spearman_rank {math spearman-rank}
+    math_spearman_rank_extended {math spearman-rank-extended}
+    math_stdev {math stdev}
+    math_t_test_mean {math t-test-mean}
+    math_test_2x2 {math test-2x2}
+    math_test_Duckworth {math test-Duckworth}
+    math_test_Dunnett {math test-Dunnett}
+    math_test_Kruskal_Wallis {math test-Kruskal-Wallis}
+    math_test_Rchart {math test-Rchart}
+    math_test_Tukey_range {math test-Tukey-range}
+    math_test_Wilcoxon {math test-Wilcoxon}
+    math_test_anova_F {math test-anova-F}
+    math_test_normal {math test-normal}
+    math_test_xbar {math test-xbar}
+    math_var {math var}
+    md5_md5 {md5 md5}
+    mime_buildmessage {mime buildmessage}
+    mime_copymessage {mime copymessage}
+    mime_field_decode {mime field_decode}
+    mime_finalize {mime finalize}
+    mime_getContentType {mime getContentType}
+    mime_getTransferEncoding {mime getTransferEncoding}
+    mime_getbody {mime getbody}
+    mime_getheader {mime getheader}
+    mime_getproperty {mime getproperty}
+    mime_getsize {mime getsize}
+    mime_initialize {mime initialize}
+    mime_mapencoding {mime mapencoding}
+    mime_parseaddress {mime parseaddress}
+    mime_parsedatetime {mime parsedatetime}
+    mime_reversemapencoding {mime reversemapencoding}
+    mime_setheader {mime setheader}
+    mime_uniqueID {mime uniqueID}
+    mime_word_decode {mime word_decode}
+    mime_word_encode {mime word_encode}
+    msgcat_mc {msgcat mc}
+    msgcat_mcexists {msgcat mcexists}
+    msgcat_mcflmset {msgcat mcflmset}
+    msgcat_mcflset {msgcat mcflset}
+    msgcat_mcforgetpackage {msgcat mcforgetpackage}
+    msgcat_mcload {msgcat mcload}
+    msgcat_mcloadedlocales {msgcat mcloadedlocales}
+    msgcat_mclocale {msgcat mclocale}
+    msgcat_mcmax {msgcat mcmax}
+    msgcat_mcmset {msgcat mcmset}
+    msgcat_mcn {msgcat mcn}
+    msgcat_mcpackageconfig {msgcat mcpackageconfig}
+    msgcat_mcpackagelocale {msgcat mcpackagelocale}
+    msgcat_mcpackagenamespaceget {msgcat mcpackagenamespaceget}
+    msgcat_mcpreferences {msgcat mcpreferences}
+    msgcat_mcset {msgcat mcset}
+    msgcat_mcunknown {msgcat mcunknown}
+    msgcat_mcutil {msgcat mcutil}
+    pkg_create {pkg create}
+    platform_generic {platform generic}
+    platform_identify {platform identify}
+    platform_patterns {platform patterns}
+    platform_generic {platform generic}
+    platform_identify {platform identify}
+    safe_interpAddToAccessPath {safe interpAddToAccessPath}
+    safe_interpConfigure {safe interpConfigure}
+    safe_interpCreate {safe interpCreate}
+    safe_interpDelete {safe interpDelete}
+    safe_interpFindInAccessPath {safe interpFindInAccessPath}
+    safe_interpInit {safe interpInit}
+    safe_setLogCmd {safe setLogCmd}
+    safe_setSyncMode {safe setSyncMode}
+    sha1_sha1 {sha1 sha1}
+    sha2_sha256 {sha2 sha256}
+    smtp_sendmessage {smtp sendmessage}
+    snit_compile {snit compile}
+    snit_macro {snit macro}
+    snit_method {snit method}
+    snit_type {snit type}
+    snit_typemethod {snit typemethod}
+    snit_widget {snit widget}
+    snit_widgetadaptor {snit widgetadaptor}
+    struct_list {struct list}
+    struct_queue {struct queue}
+    struct_set {struct set}
+    struct_stack {struct stack}
+    tcl_OptKeyDelete {tcl OptKeyDelete}
+    tcl_OptKeyError {tcl OptKeyError}
+    tcl_OptKeyParse {tcl OptKeyParse}
+    tcl_OptKeyRegister {tcl OptKeyRegister}
+    tcl_OptParse {tcl OptParse}
+    tcl_OptProc {tcl OptProc}
+    tcl_OptProcArgGiven {tcl OptProcArgGiven}
+    tcl_decode {tcl decode}
+    tcl_encode {tcl encode}
+    tcl_path {tcl path}
+    tcl_roots {tcl roots}
+    tcltest_bytestring {tcltest bytestring}
+    tcltest_cleanupTests {tcltest cleanupTests}
+    tcltest_configure {tcltest configure}
+    tcltest_customMatch {tcltest customMatch}
+    tcltest_debug {tcltest debug}
+    tcltest_errorChannel {tcltest errorChannel}
+    tcltest_errorFile {tcltest errorFile}
+    tcltest_getMatchingFiles {tcltest getMatchingFiles}
+    tcltest_interpreter {tcltest interpreter}
+    tcltest_limitConstraints {tcltest limitConstraints}
+    tcltest_loadFile {tcltest loadFile}
+    tcltest_loadScript {tcltest loadScript}
+    tcltest_loadTestedCommands {tcltest loadTestedCommands}
+    tcltest_mainThread {tcltest mainThread}
+    tcltest_makeDirectory {tcltest makeDirectory}
+    tcltest_makeFile {tcltest makeFile}
+    tcltest_match {tcltest match}
+    tcltest_matchDirectories {tcltest matchDirectories}
+    tcltest_matchFiles {tcltest matchFiles}
+    tcltest_normalizeMsg {tcltest normalizeMsg}
+    tcltest_normalizePath {tcltest normalizePath}
+    tcltest_outputChannel {tcltest outputChannel}
+    tcltest_outputFile {tcltest outputFile}
+    tcltest_preserveCore {tcltest preserveCore}
+    tcltest_removeDirectory {tcltest removeDirectory}
+    tcltest_removeFile {tcltest removeFile}
+    tcltest_restoreState {tcltest restoreState}
+    tcltest_runAllTests {tcltest runAllTests}
+    tcltest_saveState {tcltest saveState}
+    tcltest_singleProcess {tcltest singleProcess}
+    tcltest_skip {tcltest skip}
+    tcltest_skipDirectories {tcltest skipDirectories}
+    tcltest_skipFiles {tcltest skipFiles}
+    tcltest_temporaryDirectory {tcltest temporaryDirectory}
+    tcltest_test {tcltest test}
+    tcltest_testConstraint {tcltest testConstraint}
+    tcltest_testsDirectory {tcltest testsDirectory}
+    tcltest_threadReap {tcltest threadReap}
+    tcltest_verbose {tcltest verbose}
+    tcltest_viewFile {tcltest viewFile}
+    tcltest_workingDirectory {tcltest workingDirectory}
+    textutil_adjust {textutil adjust}
+    textutil_blank {textutil blank}
+    textutil_cap {textutil cap}
+    textutil_capEachWord {textutil capEachWord}
+    textutil_chop {textutil chop}
+    textutil_indent {textutil indent}
+    textutil_longestCommonPrefix {textutil longestCommonPrefix}
+    textutil_longestCommonPrefixList {textutil longestCommonPrefixList}
+    textutil_splitn {textutil splitn}
+    textutil_splitx {textutil splitx}
+    textutil_strRepeat {textutil strRepeat}
+    textutil_tabify {textutil tabify}
+    textutil_tabify2 {textutil tabify2}
+    textutil_tail {textutil tail}
+    textutil_trim {textutil trim}
+    textutil_trimEmptyHeading {textutil trimEmptyHeading}
+    textutil_trimPrefix {textutil trimPrefix}
+    textutil_trimleft {textutil trimleft}
+    textutil_trimright {textutil trimright}
+    textutil_uncap {textutil uncap}
+    textutil_undent {textutil undent}
+    textutil_untabify {textutil untabify}
+    textutil_untabify2 {textutil untabify2}
+    ttk_button {ttk button}
+    ttk_combobox {ttk combobox}
+    ttk_entry {ttk entry}
+    ttk_frame {ttk frame}
+    ttk_label {ttk label}
+    ttk_notebook {ttk notebook}
+    ttk_progressbar {ttk progressbar}
+    ttk_scale {ttk scale}
+    ttk_separator {ttk separator}
+    ttk_sizegrip {ttk sizegrip}
+    ttk_style {ttk style}
+    ttk_treeview {ttk treeview}
+    uri_canonicalize {uri canonicalize}
+    uri_geturl {uri geturl}
+    uri_isrelative {uri isrelative}
+    uri_join {uri join}
+    uri_register {uri register}
+    uri_resolve {uri resolve}
+    uri_setQuirkOption {uri setQuirkOption}
+    uri_split {uri split}
+    uuid_uuid {uuid uuid}
+    yaml_dict2yaml {yaml dict2yaml}
+    yaml_huddle2yaml {yaml huddle2yaml}
+    yaml_list2yaml {yaml list2yaml}
+    yaml_setOptions {yaml setOptions}
+    yaml_yaml2dict {yaml yaml2dict}
+    yaml_yaml2huddle {yaml yaml2huddle}
+    cmd_accumulate {toplevel accumulate}
+    cmd_active_members {toplevel active_members}
+    cmd_active_nodes {toplevel active_nodes}
+    cmd_append {toplevel append}
+    cmd_apply {toplevel apply}
+    cmd_array {toplevel array}
+    cmd_b64decode {toplevel b64decode}
+    cmd_b64encode {toplevel b64encode}
+    cmd_bell {toplevel bell}
+    cmd_binary {toplevel binary}
+    cmd_bind {toplevel bind}
+    cmd_break {toplevel break}
+    cmd_button {toplevel button}
+    cmd_call {toplevel call}
+    cmd_canvas {toplevel canvas}
+    cmd_catch {toplevel catch}
+    cmd_chan {toplevel chan}
+    cmd_check {toplevel check}
+    cmd_checkbutton {toplevel checkbutton}
+    cmd_client_addr {toplevel client_addr}
+    cmd_client_port {toplevel client_port}
+    cmd_clientside {toplevel clientside}
+    cmd_clipboard {toplevel clipboard}
+    cmd_clock {toplevel clock}
+    cmd_clone {toplevel clone}
+    cmd_close {toplevel close}
+    cmd_concat {toplevel concat}
+    cmd_connect {toplevel connect}
+    cmd_const {toplevel const}
+    cmd_continue {toplevel continue}
+    cmd_cpu {toplevel cpu}
+    cmd_crc32 {toplevel crc32}
+    cmd_decode_uri {toplevel decode_uri}
+    cmd_destroy {toplevel destroy}
+    cmd_domain {toplevel domain}
+    cmd_encoding {toplevel encoding}
+    cmd_entry {toplevel entry}
+    cmd_error {toplevel error}
+    cmd_eval {toplevel eval}
+    cmd_expr {toplevel expr}
+    cmd_fasthash {toplevel fasthash}
+    cmd_findclass {toplevel findclass}
+    cmd_findstr {toplevel findstr}
+    cmd_focus {toplevel focus}
+    cmd_font {toplevel font}
+    cmd_for {toplevel for}
+    cmd_foreach {toplevel foreach}
+    cmd_format {toplevel format}
+    cmd_forward {toplevel forward}
+    cmd_frame {toplevel frame}
+    cmd_getfield {toplevel getfield}
+    cmd_gettimes {toplevel gettimes}
+    cmd_global {toplevel global}
+    cmd_grab {toplevel grab}
+    cmd_grid {toplevel grid}
+    cmd_history {toplevel history}
+    cmd_html_encode {toplevel html_encode}
+    cmd_html_escape {toplevel html_escape}
+    cmd_htmlencode {toplevel htmlencode}
+    cmd_htonl {toplevel htonl}
+    cmd_htons {toplevel htons}
+    cmd_http_client_ip {toplevel http_client_ip}
+    cmd_http_content_len_max {toplevel http_content_len_max}
+    cmd_http_cookie {toplevel http_cookie}
+    cmd_http_header {toplevel http_header}
+    cmd_http_host {toplevel http_host}
+    cmd_http_method {toplevel http_method}
+    cmd_http_uri {toplevel http_uri}
+    cmd_http_version {toplevel http_version}
+    cmd_if {toplevel if}
+    cmd_ifile {toplevel ifile}
+    cmd_image {toplevel image}
+    cmd_imid {toplevel imid}
+    cmd_incr {toplevel incr}
+    cmd_info {toplevel info}
+    cmd_ip_addr {toplevel ip_addr}
+    cmd_ip_protocol {toplevel ip_protocol}
+    cmd_ip_tos {toplevel ip_tos}
+    cmd_ip_ttl {toplevel ip_ttl}
+    cmd_join {toplevel join}
+    cmd_label {toplevel label}
+    cmd_labelframe {toplevel labelframe}
+    cmd_lappend {toplevel lappend}
+    cmd_lasthop {toplevel lasthop}
+    cmd_lgen {toplevel lgen}
+    cmd_lindex {toplevel lindex}
+    cmd_link_qos {toplevel link_qos}
+    cmd_linsert {toplevel linsert}
+    cmd_list {toplevel list}
+    cmd_listbox {toplevel listbox}
+    cmd_listen {toplevel listen}
+    cmd_llength {toplevel llength}
+    cmd_llookup {toplevel llookup}
+    cmd_local_addr {toplevel local_addr}
+    cmd_local_port {toplevel local_port}
+    cmd_lower {toplevel lower}
+    cmd_lrange {toplevel lrange}
+    cmd_lrepeat {toplevel lrepeat}
+    cmd_lreplace {toplevel lreplace}
+    cmd_lreverse {toplevel lreverse}
+    cmd_lsearch {toplevel lsearch}
+    cmd_lset {toplevel lset}
+    cmd_lsort {toplevel lsort}
+    cmd_lstring {toplevel lstring}
+    cmd_matchclass {toplevel matchclass}
+    cmd_md4 {toplevel md4}
+    cmd_md5 {toplevel md5}
+    cmd_members {toplevel members}
+    cmd_menu {toplevel menu}
+    cmd_menubutton {toplevel menubutton}
+    cmd_message {toplevel message}
+    cmd_nexthop {toplevel nexthop}
+    cmd_nodes {toplevel nodes}
+    cmd_noop {toplevel noop}
+    cmd_ntohl {toplevel ntohl}
+    cmd_ntohs {toplevel ntohs}
+    cmd_option {toplevel option}
+    cmd_pack {toplevel pack}
+    cmd_panedwindow {toplevel panedwindow}
+    cmd_parray {toplevel parray}
+    cmd_peer {toplevel peer}
+    cmd_pem_dtos {toplevel pem_dtos}
+    cmd_pkg_mkIndex {toplevel pkg_mkIndex}
+    cmd_place {toplevel place}
+    cmd_priority {toplevel priority}
+    cmd_proc {toplevel proc}
+    cmd_puts {toplevel puts}
+    cmd_radiobutton {toplevel radiobutton}
+    cmd_radius_authenticate {toplevel radius_authenticate}
+    cmd_raise {toplevel raise}
+    cmd_rateclass {toplevel rateclass}
+    cmd_read {toplevel read}
+    cmd_recv {toplevel recv}
+    cmd_redirect {toplevel redirect}
+    cmd_regexp {toplevel regexp}
+    cmd_regsub {toplevel regsub}
+    cmd_relate_client {toplevel relate_client}
+    cmd_relate_server {toplevel relate_server}
+    cmd_remote_addr {toplevel remote_addr}
+    cmd_remote_port {toplevel remote_port}
+    cmd_return {toplevel return}
+    cmd_rmd160 {toplevel rmd160}
+    cmd_scale {toplevel scale}
+    cmd_scan {toplevel scan}
+    cmd_scrollbar {toplevel scrollbar}
+    cmd_selection {toplevel selection}
+    cmd_send {toplevel send}
+    cmd_server_addr {toplevel server_addr}
+    cmd_server_port {toplevel server_port}
+    cmd_serverside {toplevel serverside}
+    cmd_session {toplevel session}
+    cmd_set {toplevel set}
+    cmd_sha1 {toplevel sha1}
+    cmd_sha256 {toplevel sha256}
+    cmd_sha384 {toplevel sha384}
+    cmd_sha512 {toplevel sha512}
+    cmd_sharedvar {toplevel sharedvar}
+    cmd_spinbox {toplevel spinbox}
+    cmd_split {toplevel split}
+    cmd_string {toplevel string}
+    cmd_subst {toplevel subst}
+    cmd_substr {toplevel substr}
+    cmd_switch {toplevel switch}
+    cmd_tcl_endOfWord {toplevel tcl_endOfWord}
+    cmd_tcl_startOfNextWord {toplevel tcl_startOfNextWord}
+    cmd_tcl_startOfPreviousWord {toplevel tcl_startOfPreviousWord}
+    cmd_tcl_wordBreakAfter {toplevel tcl_wordBreakAfter}
+    cmd_tcl_wordBreakBefore {toplevel tcl_wordBreakBefore}
+    cmd_tcpdump {toplevel tcpdump}
+    cmd_testapplylambda {toplevel testapplylambda}
+    cmd_testappverifierpresent {toplevel testappverifierpresent}
+    cmd_testasync {toplevel testasync}
+    cmd_testbigdata {toplevel testbigdata}
+    cmd_testbignumobj {toplevel testbignumobj}
+    cmd_testbooleanobj {toplevel testbooleanobj}
+    cmd_testbumpinterpepoch {toplevel testbumpinterpepoch}
+    cmd_testbytestring {toplevel testbytestring}
+    cmd_testchannel {toplevel testchannel}
+    cmd_testchannelevent {toplevel testchannelevent}
+    cmd_testcmdinfo {toplevel testcmdinfo}
+    cmd_testcmdtoken {toplevel testcmdtoken}
+    cmd_testcmdtrace {toplevel testcmdtrace}
+    cmd_testconcatobj {toplevel testconcatobj}
+    cmd_testcpuid {toplevel testcpuid}
+    cmd_testcreatecommand {toplevel testcreatecommand}
+    cmd_testdcall {toplevel testdcall}
+    cmd_testdel {toplevel testdel}
+    cmd_testdelassocdata {toplevel testdelassocdata}
+    cmd_testdoubledigits {toplevel testdoubledigits}
+    cmd_testdoubleobj {toplevel testdoubleobj}
+    cmd_testdstring {toplevel testdstring}
+    cmd_testencoding {toplevel testencoding}
+    cmd_testevalex {toplevel testevalex}
+    cmd_testevalobjv {toplevel testevalobjv}
+    cmd_testevent {toplevel testevent}
+    cmd_testexithandler {toplevel testexithandler}
+    cmd_testexitmainloop {toplevel testexitmainloop}
+    cmd_testexprdouble {toplevel testexprdouble}
+    cmd_testexprdoubleobj {toplevel testexprdoubleobj}
+    cmd_testexprlong {toplevel testexprlong}
+    cmd_testexprlongobj {toplevel testexprlongobj}
+    cmd_testexprparser {toplevel testexprparser}
+    cmd_testexprstring {toplevel testexprstring}
+    cmd_testfevent {toplevel testfevent}
+    cmd_testfile {toplevel testfile}
+    cmd_testfilelink {toplevel testfilelink}
+    cmd_testfilesystem {toplevel testfilesystem}
+    cmd_testfindfirst {toplevel testfindfirst}
+    cmd_testfindlast {toplevel testfindlast}
+    cmd_testfstildeexpand {toplevel testfstildeexpand}
+    cmd_testgetassocdata {toplevel testgetassocdata}
+    cmd_testgetindexfromobjstruct {toplevel testgetindexfromobjstruct}
+    cmd_testgetint {toplevel testgetint}
+    cmd_testgetintforindex {toplevel testgetintforindex}
+    cmd_testgetplatform {toplevel testgetplatform}
+    cmd_testgetunichar {toplevel testgetunichar}
+    cmd_testgetvarfullname {toplevel testgetvarfullname}
+    cmd_testhandlecount {toplevel testhandlecount}
+    cmd_testhashsystemhash {toplevel testhashsystemhash}
+    cmd_testindexobj {toplevel testindexobj}
+    cmd_testinterpdelete {toplevel testinterpdelete}
+    cmd_testinterpresolver {toplevel testinterpresolver}
+    cmd_testintobj {toplevel testintobj}
+    cmd_testlink {toplevel testlink}
+    cmd_testlinkarray {toplevel testlinkarray}
+    cmd_testlistobj {toplevel testlistobj}
+    cmd_testlistrep {toplevel testlistrep}
+    cmd_testlocale {toplevel testlocale}
+    cmd_testlongsize {toplevel testlongsize}
+    cmd_testlutil {toplevel testlutil}
+    cmd_testmainthread {toplevel testmainthread}
+    cmd_testmsb {toplevel testmsb}
+    cmd_testnrelevels {toplevel testnrelevels}
+    cmd_testnreunwind {toplevel testnreunwind}
+    cmd_testnumutfchars {toplevel testnumutfchars}
+    cmd_testobj {toplevel testobj}
+    cmd_testpanic {toplevel testpanic}
+    cmd_testparseargs {toplevel testparseargs}
+    cmd_testparser {toplevel testparser}
+    cmd_testparsevar {toplevel testparsevar}
+    cmd_testparsevarname {toplevel testparsevarname}
+    cmd_testpreferstable {toplevel testpreferstable}
+    cmd_testprint {toplevel testprint}
+    cmd_testpurebytesobj {toplevel testpurebytesobj}
+    cmd_testregexp {toplevel testregexp}
+    cmd_testreturn {toplevel testreturn}
+    cmd_testsaveresult {toplevel testsaveresult}
+    cmd_testservicemode {toplevel testservicemode}
+    cmd_testset2 {toplevel testset2}
+    cmd_testsetassocdata {toplevel testsetassocdata}
+    cmd_testsetbytearraylength {toplevel testsetbytearraylength}
+    cmd_testseterr {toplevel testseterr}
+    cmd_testseterrorcode {toplevel testseterrorcode}
+    cmd_testsetmainloop {toplevel testsetmainloop}
+    cmd_testsetnoerr {toplevel testsetnoerr}
+    cmd_testsetobjerrorcode {toplevel testsetobjerrorcode}
+    cmd_testsetplatform {toplevel testsetplatform}
+    cmd_testsimplefilesystem {toplevel testsimplefilesystem}
+    cmd_testsize {toplevel testsize}
+    cmd_testsocket {toplevel testsocket}
+    cmd_teststaticlibrary {toplevel teststaticlibrary}
+    cmd_teststaticpkg {toplevel teststaticpkg}
+    cmd_teststringbytes {toplevel teststringbytes}
+    cmd_teststringobj {toplevel teststringobj}
+    cmd_testtranslatefilename {toplevel testtranslatefilename}
+    cmd_testuniclass {toplevel testuniclass}
+    cmd_testupvar {toplevel testupvar}
+    cmd_testutfnext {toplevel testutfnext}
+    cmd_testutfprev {toplevel testutfprev}
+    cmd_testwrongnumargs {toplevel testwrongnumargs}
+    cmd_text {toplevel text}
+    cmd_timing {toplevel timing}
+    cmd_tk {toplevel tk}
+    cmd_tk_chooseColor {toplevel tk_chooseColor}
+    cmd_tk_chooseDirectory {toplevel tk_chooseDirectory}
+    cmd_tk_getOpenFile {toplevel tk_getOpenFile}
+    cmd_tk_getSaveFile {toplevel tk_getSaveFile}
+    cmd_tk_messageBox {toplevel tk_messageBox}
+    cmd_tk_popup {toplevel tk_popup}
+    cmd_toplevel {toplevel toplevel}
+    cmd_trace {toplevel trace}
+    cmd_traffic_group {toplevel traffic_group}
+    cmd_translate {toplevel translate}
+    cmd_uniq_ordered_ip_list {toplevel uniq_ordered_ip_list}
+    cmd_uniq_sorted_ip_list {toplevel uniq_sorted_ip_list}
+    cmd_unset {toplevel unset}
+    cmd_uplevel {toplevel uplevel}
+    cmd_upvar {toplevel upvar}
+    cmd_urlcatblindquery {toplevel urlcatblindquery}
+    cmd_urlcatquery {toplevel urlcatquery}
+    cmd_use {toplevel use}
+    cmd_variable {toplevel variable}
+    cmd_vlan_id {toplevel vlan_id}
+    cmd_when {toplevel when}
+    cmd_whereis {toplevel whereis}
+    cmd_while {toplevel while}
+    cmd_winfo {toplevel winfo}
+    cmd_wm {toplevel wm}
+    cmd_xff_list {toplevel xff_list}
+    cmd_xff_uniq_ordered_ip_list {toplevel xff_uniq_ordered_ip_list}
+    cmd_xff_uniq_sorted_ip_list {toplevel xff_uniq_sorted_ip_list}
     }
-
 }
 
-# Total stub mocks generated: 1473
+# Total stub actions generated: 1473

--- a/rust/tcl-irule-test/tcl/command_mocks.tcl
+++ b/rust/tcl-irule-test/tcl/command_mocks.tcl
@@ -1652,7 +1652,6 @@ namespace eval ::itest::cmd {
     proc register_all {} {
         variable _gen_namespaced_commands
         variable _gen_toplevel_commands
-        variable _stub_actions
 
         # Auto-register all iRule commands for which a mock exists.
         # Command list comes from generated registry data (_registry_data.tcl).
@@ -1660,6 +1659,12 @@ namespace eval ::itest::cmd {
         # commands without one fall back to the generic `_stub` driven by the
         # generated `_stub_actions` table (_mock_stubs.tcl, sourced during
         # framework load) — formerly ~1500 individual generated stub procs.
+        #
+        # The table is probed by its fully-qualified name rather than via a
+        # `variable` link: `info exists ::itest::cmd::_stub_actions(...)`
+        # safely returns 0 if `_mock_stubs.tcl` was never sourced (the runner
+        # and example scripts guard it with `[file exists]`), degrading to the
+        # pre-table behaviour of simply leaving stub-only commands unregistered.
         foreach irule_cmd [concat $_gen_namespaced_commands $_gen_toplevel_commands] {
             set mock [_mock_proc_name $irule_cmd]
             # Use _orig_info to bypass the TMM shim's info filter
@@ -1668,9 +1673,9 @@ namespace eval ::itest::cmd {
                 ::itest::register_command $irule_cmd $mock
             } else {
                 set tail [namespace tail $mock]
-                if {[info exists _stub_actions($tail)]} {
+                if {[info exists ::itest::cmd::_stub_actions($tail)]} {
                     ::itest::register_command $irule_cmd \
-                        [list ::itest::cmd::_stub {*}$_stub_actions($tail)]
+                        [list ::itest::cmd::_stub {*}$::itest::cmd::_stub_actions($tail)]
                 }
             }
         }

--- a/rust/tcl-irule-test/tcl/command_mocks.tcl
+++ b/rust/tcl-irule-test/tcl/command_mocks.tcl
@@ -1652,17 +1652,26 @@ namespace eval ::itest::cmd {
     proc register_all {} {
         variable _gen_namespaced_commands
         variable _gen_toplevel_commands
+        variable _stub_actions
 
-        # Auto-register all iRule commands for which a mock proc exists.
+        # Auto-register all iRule commands for which a mock exists.
         # Command list comes from generated registry data (_registry_data.tcl).
-        # Hand-written mocks and generated stubs (from _mock_stubs.tcl,
-        # sourced during framework load) are both discovered here.
+        # Hand-written mocks (procs in this file) take precedence; registry
+        # commands without one fall back to the generic `_stub` driven by the
+        # generated `_stub_actions` table (_mock_stubs.tcl, sourced during
+        # framework load) — formerly ~1500 individual generated stub procs.
         foreach irule_cmd [concat $_gen_namespaced_commands $_gen_toplevel_commands] {
             set mock [_mock_proc_name $irule_cmd]
             # Use _orig_info to bypass the TMM shim's info filter
             # (which hides ::itest::* from info commands).
             if {[llength [::tmm::_orig_info commands $mock]]} {
                 ::itest::register_command $irule_cmd $mock
+            } else {
+                set tail [namespace tail $mock]
+                if {[info exists _stub_actions($tail)]} {
+                    ::itest::register_command $irule_cmd \
+                        [list ::itest::cmd::_stub {*}$_stub_actions($tail)]
+                }
             }
         }
     }


### PR DESCRIPTION
## What

Task #2 of the `rust`-branch test-speed series: **reduce the VM CPU work in `tcl-irule-test`** by amortizing `_mock_stubs.tcl`'s per-session cost.

Every fresh `LiveSession` (and the on-disk `runner.tcl`) sourced `_mock_stubs.tcl`, which defined **~1500 individual stub procs** — one per registry iRule command lacking a hand-written mock, each a trivial:

```tcl
proc <name> {args} { ::itest::log_decision <cat> <action> $args; return "" }
```

Profiling the bootstrap showed compiling those ~1500 proc bodies cost **9.7 s of the ~13 s** it took to bootstrap a session — the single dominant cost in the heaviest crate of the `rust-tests-heavy` gate.

## How

Replace the ~1500 generated procs with:

- **one generic** `::itest::cmd::_stub {cat action args}` (logs + returns `""`, exactly as before), and
- a generated `_stub_actions` **data table** (`mock-proc-name → {category action}`).

`register_all` now falls back to `[list ::itest::cmd::_stub {*}$_stub_actions($tail)]` for any registry command without a hand-written mock (hand-written mocks still take precedence). The table is a single list literal — **parsed, not compiled** — so it loads effectively for free.

## Behaviour is unchanged

- The table is a mechanical extraction of the former file (each proc → its exact `log_decision` args); the 6 duplicate keys all carried identical values.
- The decision log for every stub command is byte-identical.
- `embedded_session_includes_generated_stubs` is strengthened to assert the stub decision log (`ACCESS::session` → `access session`), guarding the data-table path against regression.
- `_mock_stubs.tcl`: ~168 KB / 7810 lines → ~60 KB / 1512 lines.

## Measured (local, warm build)

| | before | after |
|---|---|---|
| single `LiveSession` bootstrap | ~13 s | **2.15 s** |
| full `tcl-irule-test` suite | ~20.6 s | **2.67 s** |

All 17 `tcl-irule-test` tests pass; `cargo clippy` clean (no `#[allow]`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)