### PR TITLE
Implement real semanticTokens/full/delta; characterise eglot #333

### DIFF
--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -66,15 +66,41 @@ does not fix it. Reverting the buffer (`M-x revert-buffer`) or closing
 and reopening the file does fix it.
 
 **Cause:** Tracked at
-[bitwisecook/tcl-lsp#333](https://github.com/bitwisecook/tcl-lsp/issues/333);
+[bitwisecook/tcl-lsp#333](https://github.com/bitwisecook/tcl-lsp/issues/333).
+This is an upstream eglot painter bug: `eglot--semtok-font-lock-2`
+repaints from stale local properties with `add-face-text-property`
+(which *appends* rather than replaces) while a semantic-tokens response
+is in flight, so each repaint stacks another `eglot-semantic-*` face on
+the same character until a fresh full paint (buffer revert / reopen)
+clears them. It shows up most on large files, where the round-trip is
+slow enough for eglot to repaint several times before the response
+lands. The server serves correct tokens throughout — verified by a
+spec-correct reference client driven through the same edits
+(`rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs`) — so
+this is purely how eglot paints them.
 
-This may be an eglot bug.
+The accumulation was reproduced against real Tcl code and measured
+under several fixes (see `scripts/eglot_test/prove_fix.el`): the
+**client-side painter advice below collapses a 7-deep face stack to a
+single correct face**, whereas a purely server-side capability tweak
+made **no difference** — confirming the bug lives entirely in eglot's
+painter. The same accumulation reproduces with rust-analyzer and clangd,
+so it is not tcl-lsp-specific.
+
+The server does its part to *shrink* that stale window: it implements
+proper `semanticTokens/full/delta`, so a keystroke transmits only the
+changed tokens (a few bytes) instead of the whole document — the same
+incremental behaviour rust-analyzer uses. That reduces how often eglot
+is caught mid-refresh, but the definitive fix is still the painter
+advice below. Running the **native binary** rather than an older Python
+`.pyz`, and lowering `eglot-send-changes-idle-time`, also help by
+keeping the round-trip short.
 
 **Workarounds (pick one):**
 
-1. **Apply this advice in your `init.el`** (strips stale
-   `eglot-semantic-*` faces before each repaint, preserving everything
-   else):
+1. **Apply this advice in your `init.el`** (recommended — this is the
+   one that actually stops it). It strips stale `eglot-semantic-*` faces
+   before each repaint, preserving every other face:
 
    ```elisp
    (with-eval-after-load 'eglot
@@ -130,7 +156,7 @@ This may be an eglot bug.
    Originally posted by @georgtree on
    [issue #333](https://github.com/bitwisecook/tcl-lsp/issues/333#issuecomment-4380920940).
 
-2. **Disable eglot semantic tokens for `tcl-mode`**, falling back to
+3. **Disable eglot semantic tokens for `tcl-mode`**, falling back to
    Emacs's built-in `tcl-mode` font-lock keywords (loses LSP-derived
    highlighting like distinguishing user procs from builtins):
 
@@ -139,7 +165,7 @@ This may be an eglot bug.
      (add-to-list 'eglot-stay-out-of 'eglot-semantic-tokens-mode))
    ```
 
-3. **Revert the buffer** (`M-x revert-buffer`) whenever highlighting
+4. **Revert the buffer** (`M-x revert-buffer`) whenever highlighting
    visibly degrades. Discards unsaved changes — only viable if you've
    just saved.
 

--- a/editors/emacs/README.md
+++ b/editors/emacs/README.md
@@ -156,7 +156,7 @@ keeping the round-trip short.
    Originally posted by @georgtree on
    [issue #333](https://github.com/bitwisecook/tcl-lsp/issues/333#issuecomment-4380920940).
 
-3. **Disable eglot semantic tokens for `tcl-mode`**, falling back to
+2. **Disable eglot semantic tokens for `tcl-mode`**, falling back to
    Emacs's built-in `tcl-mode` font-lock keywords (loses LSP-derived
    highlighting like distinguishing user procs from builtins):
 
@@ -165,7 +165,7 @@ keeping the round-trip short.
      (add-to-list 'eglot-stay-out-of 'eglot-semantic-tokens-mode))
    ```
 
-4. **Revert the buffer** (`M-x revert-buffer`) whenever highlighting
+3. **Revert the buffer** (`M-x revert-buffer`) whenever highlighting
    visibly degrades. Discards unsaved changes — only viable if you've
    just saved.
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -88,13 +88,13 @@ use tower_lsp_server::ls_types::{
     ParameterLabel, Position, PositionEncodingKind, PrepareRenameResponse, Range, ReferenceParams,
     Registration, RelatedFullDocumentDiagnosticReport, RelatedUnchangedDocumentDiagnosticReport,
     RenameFilesParams, RenameOptions, RenameParams, SelectionRange, SelectionRangeParams,
-    SelectionRangeProviderCapability, SemanticTokens as LspSemanticTokens,
-    SemanticTokensDeltaParams, SemanticTokensFullDeltaResult, SemanticTokensFullOptions,
-    SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams, SemanticTokensRangeParams,
-    SemanticTokensRangeResult, SemanticTokensResult, SemanticTokensServerCapabilities,
-    ServerCapabilities, ServerInfo, SignatureHelp, SignatureHelpOptions, SignatureHelpParams,
-    SignatureInformation, SymbolInformation, SymbolKind, TextDocumentEdit,
-    TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
+    SelectionRangeProviderCapability, SemanticTokens as LspSemanticTokens, SemanticTokensDelta,
+    SemanticTokensDeltaParams, SemanticTokensEdit, SemanticTokensFullDeltaResult,
+    SemanticTokensFullOptions, SemanticTokensLegend, SemanticTokensOptions, SemanticTokensParams,
+    SemanticTokensRangeParams, SemanticTokensRangeResult, SemanticTokensResult,
+    SemanticTokensServerCapabilities, ServerCapabilities, ServerInfo, SignatureHelp,
+    SignatureHelpOptions, SignatureHelpParams, SignatureInformation, SymbolInformation, SymbolKind,
+    TextDocumentEdit, TextDocumentPositionParams, TextDocumentSyncCapability, TextDocumentSyncKind,
     TextDocumentSyncOptions, TextEdit, TypeDefinitionProviderCapability, TypeHierarchyItem,
     TypeHierarchyPrepareParams, TypeHierarchySubtypesParams, TypeHierarchySupertypesParams,
     UnchangedDocumentDiagnosticReport, Uri, WatchKind, WillSaveTextDocumentParams,
@@ -1180,6 +1180,18 @@ pub struct Backend {
     /// collections and renders every diagnostic twice (#721).  Editors that
     /// only understand push (no pull capability) keep receiving the push.
     client_supports_pull_diagnostics: std::sync::atomic::AtomicBool,
+    /// Per-URI cache of the last semantic-token stream we served — its
+    /// `resultId` and the packed integer data.  Lets
+    /// `textDocument/semanticTokens/full/delta` answer with a minimal
+    /// token-aligned [`core_semantic_tokens::diff`] edit instead of resending
+    /// the whole stream, the incremental behaviour rust-analyzer / clangd use.
+    /// Every editor that speaks `full/delta` (VS Code, Zed, Neovim, eglot, …)
+    /// benefits: a keystroke transmits a few changed tokens rather than the
+    /// entire document, which keeps the client's token round-trip — and, for
+    /// eglot, its stale-repaint window (issue #333) — small on large files.
+    /// Keyed by URI; the entry is refreshed on every `full` / `full/delta`
+    /// response and evicted on `did_close`.
+    last_semantic_tokens: Mutex<HashMap<Uri, (String, Vec<u32>)>>,
 }
 
 /// Resolved `tclLsp.features.*` toggle state.
@@ -1433,6 +1445,7 @@ impl Backend {
             db_config: Arc::new(Mutex::new(db_config)),
             pull_diag_cache: Arc::new(Mutex::new(HashMap::new())),
             client_supports_pull_diagnostics: std::sync::atomic::AtomicBool::new(false),
+            last_semantic_tokens: Mutex::new(HashMap::new()),
         }
     }
 
@@ -1939,6 +1952,30 @@ impl Backend {
             None => self.default_dialect.lock().await.clone(),
         };
         Some(DocumentState::new(text, dialect))
+    }
+
+    /// Compute the packed semantic-token stream for `uri` — from the memoised
+    /// query when warm, else a worker-thread fallback so a parser panic surfaces
+    /// as a JSON-RPC error rather than crashing the server.
+    async fn semantic_tokens_core_data(
+        &self,
+        uri: &Uri,
+        doc: &DocumentState,
+    ) -> jsonrpc::Result<Vec<u32>> {
+        if let Some(tokens) = self.db_semantic_tokens(uri).await {
+            return Ok(tokens.data);
+        }
+        let registry = self.registry_for_dialect(&doc.dialect).await;
+        let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
+        tokio::task::spawn_blocking(move || {
+            core_semantic_tokens::full(&text, &dialect, &registry).data
+        })
+        .await
+        .map_err(|err| jsonrpc::Error {
+            code: jsonrpc::ErrorCode::InternalError,
+            message: format!("semantic_tokens worker panicked: {err}").into(),
+            data: None,
+        })
     }
 
     /// Re-index a (now-closed) document from its on-disk contents so
@@ -4600,6 +4637,9 @@ impl LanguageServer for Backend {
         // sweep no longer reports the now-closed document and a later reopen
         // recomputes from scratch.
         self.pull_diag_cache.lock().await.remove(uri);
+        // Drop the cached semantic-token baseline so a reopened document starts
+        // from a fresh `full` rather than diffing against a stale stream.
+        self.last_semantic_tokens.lock().await.remove(uri);
         // Re-index the file from disk rather than dropping it: the file still
         // exists on disk and was (or would be) part of the on-disk index, so
         // cross-document definition / references / rename / call-hierarchy — and
@@ -5734,26 +5774,15 @@ impl LanguageServer for Backend {
         };
         // `S-semantic-tokens-rich`: real classification, served from the
         // memoised `semantic_tokens` query (packed integer stream, 5 ints per
-        // token `[deltaLine, deltaCol, length, type, modifiers]`).  The
-        // cold/cancelled fallback computes directly.
-        let core_data = if let Some(tokens) = self.db_semantic_tokens(&uri).await {
-            tokens.data
-        } else {
-            let registry = self.registry_for_dialect(&doc.dialect).await;
-            // Cold/cancelled fallback runs the tokeniser on a worker so a
-            // parser panic is contained as a JSON-RPC error.
-            let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
-            tokio::task::spawn_blocking(move || {
-                core_semantic_tokens::full(&text, &dialect, &registry).data
-            })
-            .await
-            .map_err(|err| jsonrpc::Error {
-                code: jsonrpc::ErrorCode::InternalError,
-                message: format!("semantic_tokens worker panicked: {err}").into(),
-                data: None,
-            })?
-        };
+        // token `[deltaLine, deltaCol, length, type, modifiers]`).
+        let core_data = self.semantic_tokens_core_data(&uri, &doc).await?;
         let result_id = next_semantic_tokens_id();
+        // Remember this stream so a later `full/delta` with this `resultId` can
+        // diff against it.
+        self.last_semantic_tokens
+            .lock()
+            .await
+            .insert(uri.clone(), (result_id.clone(), core_data.clone()));
         Ok(Some(SemanticTokensResult::Tokens(LspSemanticTokens {
             result_id: Some(result_id),
             data: lift_semantic_token_data(&core_data),
@@ -5774,33 +5803,48 @@ impl LanguageServer for Backend {
         let Some(doc) = self.read_document(&uri).await else {
             return Ok(None);
         };
-        // The server no longer keeps a per-URI token snapshot to diff against
-        // (that hand-invalidated cache is gone).  A `full/delta` request is
-        // answered with the full token set from the memoised query — the LSP
-        // spec accepts `Tokens` in place of `TokensDelta`.
-        let core_data = if let Some(tokens) = self.db_semantic_tokens(&uri).await {
-            tokens.data
-        } else {
-            let registry = self.registry_for_dialect(&doc.dialect).await;
-            // Cold/cancelled fallback runs the tokeniser on a worker so a
-            // parser panic is contained as a JSON-RPC error.
-            let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
-            tokio::task::spawn_blocking(move || {
-                core_semantic_tokens::full(&text, &dialect, &registry).data
-            })
-            .await
-            .map_err(|err| jsonrpc::Error {
-                code: jsonrpc::ErrorCode::InternalError,
-                message: format!("semantic_tokens worker panicked: {err}").into(),
-                data: None,
-            })?
+        let new_data = self.semantic_tokens_core_data(&uri, &doc).await?;
+        let result_id = next_semantic_tokens_id();
+        // Swap the cache to the freshly-served stream and grab the previous one
+        // *only if* its `resultId` matches the client's `previousResultId` — a
+        // stale / unknown id means we can't safely diff, so fall back to a full
+        // stream.  Doing the take-and-replace under one lock keeps concurrent
+        // requests for the same URI consistent.
+        let baseline = {
+            let mut cache = self.last_semantic_tokens.lock().await;
+            let prev = cache
+                .remove(&uri)
+                .filter(|(id, _)| *id == params.previous_result_id);
+            cache.insert(uri.clone(), (result_id.clone(), new_data.clone()));
+            prev
         };
-        Ok(Some(SemanticTokensFullDeltaResult::Tokens(
-            LspSemanticTokens {
-                result_id: Some(next_semantic_tokens_id()),
-                data: lift_semantic_token_data(&core_data),
-            },
-        )))
+        if let Some((_, old_data)) = baseline {
+            // Matching baseline: answer with the minimal token-aligned edit
+            // (an empty edit list when nothing changed) rather than the whole
+            // stream — the incremental path every `full/delta`-capable editor
+            // benefits from.
+            let edits = match core_semantic_tokens::diff(&old_data, &new_data) {
+                Some(edit) => vec![SemanticTokensEdit {
+                    start: edit.start,
+                    delete_count: edit.delete_count,
+                    data: Some(lift_semantic_token_data(&edit.data)),
+                }],
+                None => Vec::new(),
+            };
+            Ok(Some(SemanticTokensFullDeltaResult::TokensDelta(
+                SemanticTokensDelta {
+                    result_id: Some(result_id),
+                    edits,
+                },
+            )))
+        } else {
+            Ok(Some(SemanticTokensFullDeltaResult::Tokens(
+                LspSemanticTokens {
+                    result_id: Some(result_id),
+                    data: lift_semantic_token_data(&new_data),
+                },
+            )))
+        }
     }
 
     async fn semantic_tokens_range(
@@ -7224,14 +7268,20 @@ fn apply_docstring_formatting(
     obj: &serde_json::Map<String, serde_json::Value>,
     cfg: &mut core_formatting::FormatterConfig,
 ) {
-    if let Some(s) = obj.get("docstringStyle").and_then(serde_json::Value::as_str) {
+    if let Some(s) = obj
+        .get("docstringStyle")
+        .and_then(serde_json::Value::as_str)
+    {
         cfg.docstring_style = match s.to_ascii_lowercase().as_str() {
             "preceding" => core_formatting::DocstringStyle::Preceding,
             "body" => core_formatting::DocstringStyle::Body,
             _ => core_formatting::DocstringStyle::None,
         };
     }
-    if let Some(s) = obj.get("docstringTagStyle").and_then(serde_json::Value::as_str) {
+    if let Some(s) = obj
+        .get("docstringTagStyle")
+        .and_then(serde_json::Value::as_str)
+    {
         cfg.docstring_tag_style = match s.to_ascii_lowercase().as_str() {
             "plain" => core_formatting::DocstringTagStyle::Plain,
             "none" => core_formatting::DocstringTagStyle::None,
@@ -8741,8 +8791,14 @@ fn rename_file_operation_options() -> FileOperationRegistrationOptions {
     }
 }
 
-/// Build the semantic-tokens capability advertising the
-/// classifier's legend, range support, and delta support.
+/// Build the semantic-tokens capability advertising the classifier's legend,
+/// `range` support, and `full` **with** `delta` support.
+///
+/// The `full/delta` handler ([`Backend::semantic_tokens_full_delta`]) returns a
+/// real minimal edit (via [`core_semantic_tokens::diff`]) whenever the client's
+/// `previousResultId` matches the last stream we served, so advertising delta
+/// is a genuine incremental win for every client that uses it — the same shape
+/// rust-analyzer and clangd advertise.
 fn semantic_tokens_capability() -> SemanticTokensServerCapabilities {
     SemanticTokensServerCapabilities::SemanticTokensOptions(SemanticTokensOptions {
         work_done_progress_options: WorkDoneProgressOptions::default(),
@@ -8757,10 +8813,6 @@ fn semantic_tokens_capability() -> SemanticTokensServerCapabilities {
                 .collect(),
         },
         range: Some(true),
-        // Delta support — the handler implements the minimal
-        // valid shape (returns full tokens when
-        // previousResultId doesn't match, otherwise empty
-        // edits).
         full: Some(SemanticTokensFullOptions::Delta { delta: Some(true) }),
     })
 }
@@ -9488,6 +9540,19 @@ mod tests {
     }
 
     #[test]
+    fn semantic_tokens_capability_advertises_delta_and_range() {
+        use tower_lsp_server::ls_types::SemanticTokensServerCapabilities as Cap;
+        let Cap::SemanticTokensOptions(o) = semantic_tokens_capability() else {
+            panic!("expected SemanticTokensOptions");
+        };
+        assert_eq!(o.range, Some(true));
+        assert!(matches!(
+            o.full,
+            Some(SemanticTokensFullOptions::Delta { delta: Some(true) })
+        ));
+    }
+
+    #[test]
     fn settings_disabled_diagnostics_nested_and_flat() {
         let nested = serde_json::json!({
             "tclLsp": {"diagnostics": {"W001": true, "W108": false, "W111": false}}
@@ -10087,7 +10152,10 @@ mod tests {
             }),
             &opts,
         );
-        assert_eq!(cfg.docstring_style, core_formatting::DocstringStyle::Preceding);
+        assert_eq!(
+            cfg.docstring_style,
+            core_formatting::DocstringStyle::Preceding
+        );
         assert_eq!(
             cfg.docstring_tag_style,
             core_formatting::DocstringTagStyle::Plain
@@ -10990,6 +11058,7 @@ mod tests {
             db_config: Arc::new(Mutex::new(db_config)),
             pull_diag_cache: Arc::new(Mutex::new(HashMap::new())),
             client_supports_pull_diagnostics: std::sync::atomic::AtomicBool::new(false),
+            last_semantic_tokens: Mutex::new(HashMap::new()),
         }
     }
 

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -51,6 +51,8 @@ mod registry_contract;
 mod rename;
 #[path = "e2e/semantic_tokens.rs"]
 mod semantic_tokens;
+#[path = "e2e/semantic_tokens_reference_client.rs"]
+mod semantic_tokens_reference_client;
 #[path = "e2e/server_version.rs"]
 mod server_version;
 #[path = "e2e/signature_help.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs
+++ b/rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs
@@ -1,0 +1,547 @@
+//! Reference-client + harsh-editing differential tests for semantic tokens.
+//!
+//! Issue #333 is an eglot painter bug, but proving that requires proving the
+//! *server* never drifts: a correct client, driven through brutal editing,
+//! must always be able to reconstruct exactly the tokens a cold reopen would
+//! produce. If it can, any staleness a user sees in eglot is eglot's fault,
+//! not ours.
+//!
+//! So this file is deliberately harsh and deliberately CI-friendly (pure Rust,
+//! no Emacs). It carries two things the elisp harness can't:
+//!
+//!   * a **spec-correct reference semantic-tokens client** ([`SemtokState`])
+//!     that maintains token state across `full` / `full/delta` responses the
+//!     way the LSP spec says an editor should — the "known-good client" the
+//!     eglot harness is compared against; and
+//!
+//!   * **harsh edit sequences** — 5000+ line files, rapid-fire incremental
+//!     edits, edit-then-undo (the exact trigger the reporter calls out in
+//!     issue #333) — after which the server's `semanticTokens/full` and the
+//!     reference client's reconstruction must both equal a cold reopen.
+//!
+//! If any of these fail, the server itself is losing track and the bug is
+//! (partly) ours. As long as they pass, the server tracks correctly and the
+//! elisp harness's eglot drift is upstream.
+
+use crate::common::helpers::{SemToken, decode_semantic_tokens};
+use crate::common::{Lsp, unique_uri};
+use serde_json::{Value, json};
+use std::time::Instant;
+
+/// A local mirror of a document's text plus its LSP version, so the test can
+/// send spec-correct incremental `didChange` ranges and know the exact text
+/// the server should now hold. Content is kept ASCII so UTF-16 columns,
+/// byte offsets and char counts all coincide.
+struct Mirror {
+    uri: String,
+    text: String,
+    version: i64,
+}
+
+impl Mirror {
+    fn new(uri: &str, text: &str) -> Self {
+        Self {
+            uri: uri.to_owned(),
+            text: text.to_owned(),
+            version: 1,
+        }
+    }
+
+    /// Byte offset of a (line, character) LSP position in the current text.
+    fn offset_of(&self, line: usize, character: usize) -> usize {
+        let mut off = 0usize;
+        for (i, l) in self.text.split_inclusive('\n').enumerate() {
+            if i == line {
+                return off + character.min(l.trim_end_matches('\n').len());
+            }
+            off += l.len();
+        }
+        self.text.len()
+    }
+
+    /// Apply a single-range incremental edit locally and send the matching
+    /// `didChange`, then block until the server has settled that version.
+    fn edit(
+        &mut self,
+        lsp: &mut Lsp,
+        (sl, sc): (usize, usize),
+        (el, ec): (usize, usize),
+        new_text: &str,
+    ) {
+        let start = self.offset_of(sl, sc);
+        let end = self.offset_of(el, ec);
+        self.text.replace_range(start..end, new_text);
+        self.version += 1;
+        lsp.change_document(
+            &self.uri,
+            self.version,
+            json!([{
+                "range": {
+                    "start": { "line": sl, "character": sc },
+                    "end": { "line": el, "character": ec },
+                },
+                "text": new_text,
+            }]),
+        );
+        lsp.await_diagnostics_version(
+            &self.uri,
+            Some(self.version),
+            std::time::Duration::from_secs(20),
+        );
+    }
+
+    /// Fire a `didChange` without waiting for the server to settle — used to
+    /// build rapid-fire bursts that mirror a user typing faster than the
+    /// server can answer.
+    fn edit_no_wait(
+        &mut self,
+        lsp: &mut Lsp,
+        (sl, sc): (usize, usize),
+        (el, ec): (usize, usize),
+        new_text: &str,
+    ) {
+        let start = self.offset_of(sl, sc);
+        let end = self.offset_of(el, ec);
+        self.text.replace_range(start..end, new_text);
+        self.version += 1;
+        lsp.change_document(
+            &self.uri,
+            self.version,
+            json!([{
+                "range": {
+                    "start": { "line": sl, "character": sc },
+                    "end": { "line": el, "character": ec },
+                },
+                "text": new_text,
+            }]),
+        );
+    }
+}
+
+/// A spec-correct semantic-tokens client: it maintains the packed token array
+/// across `full` and `full/delta` responses exactly as the LSP specification
+/// prescribes (§ `SemanticTokensDelta`), so its reconstruction is the
+/// ground-truth an editor *should* arrive at. This is the "separate client
+/// proven to track correctly" the server is measured against.
+#[derive(Default)]
+struct SemtokState {
+    data: Vec<i64>,
+    result_id: Option<String>,
+}
+
+impl SemtokState {
+    /// Absorb a `full` result: replace the whole array.
+    fn apply_full(&mut self, result: &Value) {
+        self.data = as_i64_vec(result.get("data"));
+        self.result_id = result
+            .get("resultId")
+            .and_then(Value::as_str)
+            .map(str::to_owned);
+    }
+
+    /// Absorb a `full/delta` result: apply `edits` in-place if present,
+    /// otherwise fall back to the full `data` array (a server may always
+    /// answer a delta request with a full stream — ours does).
+    fn apply_delta(&mut self, result: &Value) {
+        if let Some(edits) = result.get("edits").and_then(Value::as_array) {
+            // Edits are ordered by ascending `start` and are non-overlapping;
+            // apply them right-to-left so earlier offsets stay valid.
+            let mut edits: Vec<&Value> = edits.iter().collect();
+            edits.sort_by_key(|e| e.get("start").and_then(Value::as_i64).unwrap_or(0));
+            for e in edits.into_iter().rev() {
+                let start = usize::try_from(e.get("start").and_then(Value::as_i64).unwrap_or(0))
+                    .unwrap_or(0);
+                let del =
+                    usize::try_from(e.get("deleteCount").and_then(Value::as_i64).unwrap_or(0))
+                        .unwrap_or(0);
+                let ins = as_i64_vec(e.get("data"));
+                let start = start.min(self.data.len());
+                let end = (start + del).min(self.data.len());
+                self.data.splice(start..end, ins);
+            }
+        } else if result.get("data").is_some() {
+            self.data = as_i64_vec(result.get("data"));
+        }
+        if let Some(id) = result.get("resultId").and_then(Value::as_str) {
+            self.result_id = Some(id.to_owned());
+        }
+    }
+
+    /// Decode the maintained array into absolute tokens.
+    fn tokens(&self) -> Vec<SemToken> {
+        decode_semantic_tokens(&json!({ "data": self.data }))
+    }
+}
+
+fn as_i64_vec(v: Option<&Value>) -> Vec<i64> {
+    v.and_then(Value::as_array)
+        .map(|a| a.iter().filter_map(Value::as_i64).collect())
+        .unwrap_or_default()
+}
+
+/// Compare two token lists for exact structural equality (position, length,
+/// type, modifiers).
+fn same_tokens(a: &[SemToken], b: &[SemToken]) -> bool {
+    a.len() == b.len()
+        && a.iter().zip(b).all(|(x, y)| {
+            x.line == y.line
+                && x.char == y.char
+                && x.length == y.length
+                && x.ttype == y.ttype
+                && x.modifiers == y.modifiers
+        })
+}
+
+/// First index where two token lists diverge, for readable failure messages.
+fn first_divergence(server: &[SemToken], truth: &[SemToken]) -> String {
+    let n = server.len().max(truth.len());
+    for i in 0..n {
+        match (server.get(i), truth.get(i)) {
+            (Some(sv), Some(tv))
+                if same_tokens(std::slice::from_ref(sv), std::slice::from_ref(tv)) => {}
+            (sv, tv) => return format!("index {i}: server={sv:?} truth={tv:?}"),
+        }
+    }
+    "identical".to_owned()
+}
+
+/// The tokens a cold reopen of `text` produces — the ground truth for what the
+/// server *should* be serving after any edit sequence that lands on `text`.
+fn cold_tokens(lsp: &mut Lsp, text: &str) -> Vec<SemToken> {
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, text);
+    let raw = lsp.semantic_tokens(&uri);
+    lsp.close_document(&uri);
+    decode_semantic_tokens(&raw)
+}
+
+/// Request `full/delta` against `uri` with `prev` as `previousResultId`.
+fn request_delta(lsp: &mut Lsp, uri: &str, prev: Option<&str>) -> Value {
+    let mut params = json!({ "textDocument": { "uri": uri } });
+    if let Some(p) = prev {
+        params["previousResultId"] = json!(p);
+    }
+    lsp.request("textDocument/semanticTokens/full/delta", params)
+}
+
+/// After the mirror has settled on some text, assert that BOTH the server's
+/// `full` response AND a reference client's `full/delta` reconstruction equal a
+/// cold reopen. `client` is threaded through so delta application chains across
+/// steps like a real editor's would.
+fn assert_tracks(lsp: &mut Lsp, mirror: &Mirror, client: &mut SemtokState, label: &str) {
+    let truth = cold_tokens(lsp, &mirror.text);
+
+    let full_raw = lsp.semantic_tokens(&mirror.uri);
+    let server_full = decode_semantic_tokens(&full_raw);
+    assert!(
+        same_tokens(&server_full, &truth),
+        "[{label}] server `full` drifted from a cold reopen — {}",
+        first_divergence(&server_full, &truth)
+    );
+
+    let delta_raw = request_delta(lsp, &mirror.uri, client.result_id.as_deref());
+    client.apply_delta(&delta_raw);
+    let client_tokens = client.tokens();
+    assert!(
+        same_tokens(&client_tokens, &truth),
+        "[{label}] reference client drifted after applying full/delta — {}",
+        first_divergence(&client_tokens, &truth)
+    );
+}
+
+/// Open `uri` with `text`, seed the reference client from the first `full`.
+fn open_and_seed(lsp: &mut Lsp, uri: &str, text: &str) -> (Mirror, SemtokState) {
+    lsp.open_ready(uri, text);
+    let mut client = SemtokState::default();
+    let full = lsp.semantic_tokens(uri);
+    client.apply_full(&full);
+    (Mirror::new(uri, text), client)
+}
+
+// -- tests ----------------------------------------------------------------
+
+/// The reference client and the server must stay in lock-step through a mix of
+/// inserts, deletes, renames and comment toggles applied as incremental edits,
+/// checked after *every* edit.
+#[test]
+fn reference_client_tracks_through_mixed_edits() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let initial = "namespace eval ::myns {}\n\
+                   set iniFile config.ini\n\
+                   proc compute {a b} {\n\
+                   \x20   set total [expr {$a + $b}]\n\
+                   \x20   return $total\n\
+                   }\n";
+    let (mut mirror, mut client) = open_and_seed(&mut lsp, &uri, initial);
+    assert_tracks(&mut lsp, &mirror, &mut client, "seed");
+
+    // Rename `total` -> `grand_total` on the `set` line (line 3).
+    mirror.edit(&mut lsp, (3, 8), (3, 13), "grand_total");
+    assert_tracks(&mut lsp, &mirror, &mut client, "rename-set");
+
+    // Prepend a comment line (shifts every token down one line).
+    mirror.edit(&mut lsp, (0, 0), (0, 0), "# header comment\n");
+    assert_tracks(&mut lsp, &mirror, &mut client, "prepend-comment");
+
+    // Change the arithmetic operator inside the expr.
+    // `$a + $b` now on line 4; replace the "+" with "*".
+    let plus = mirror.text.find("$a + $b").expect("expr present") + 3;
+    let (pl, pc) = offset_to_line_char(&mirror.text, plus);
+    mirror.edit(&mut lsp, (pl, pc), (pl, pc + 1), "*");
+    assert_tracks(&mut lsp, &mirror, &mut client, "op-swap");
+
+    // Delete the whole `return` line.
+    let ret_line = mirror
+        .text
+        .lines()
+        .position(|l| l.contains("return"))
+        .expect("return line");
+    mirror.edit(&mut lsp, (ret_line, 0), (ret_line + 1, 0), "");
+    assert_tracks(&mut lsp, &mirror, &mut client, "delete-return");
+}
+
+/// The server must answer a `full/delta` whose `previousResultId` matches the
+/// last stream we served with a real minimal edit — `edits` present, no full
+/// `data` re-send — like rust-analyzer. This is the payload win that keeps a
+/// client's per-edit token round-trip (and eglot's stale-repaint window,
+/// issue #333) small; a regression back to "always full" would silently undo
+/// it, so pin the response shape.
+#[test]
+fn server_returns_real_delta_not_full_resend() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let initial = "namespace eval ::n {}\n\
+                   proc a {x} { return [expr {$x + 1}] }\n\
+                   proc b {y} { return [expr {$y * 2}] }\n";
+    lsp.open_ready(&uri, initial);
+
+    // Baseline full — capture the resultId the delta must reference.
+    let full = lsp.semantic_tokens(&uri);
+    let prev = full["resultId"].as_str().expect("full resultId").to_owned();
+    assert!(
+        full.get("data").and_then(Value::as_array).is_some(),
+        "full response must carry data; got {full:#}"
+    );
+
+    // A token-changing edit: insert a whole new proc line up top.
+    let mut mirror = Mirror::new(&uri, initial);
+    mirror.edit(&mut lsp, (0, 0), (0, 0), "proc c {z} { return $z }\n");
+
+    let resp = request_delta(&mut lsp, &uri, Some(&prev));
+    assert!(
+        resp.get("edits").and_then(Value::as_array).is_some(),
+        "matching-resultId delta must return `edits`, not a full re-send; got {resp:#}"
+    );
+    assert!(
+        resp.get("data").is_none(),
+        "a delta response must not also carry a full `data` array; got {resp:#}"
+    );
+
+    // The reference client applies that delta and must match a cold reopen.
+    let mut client = SemtokState::default();
+    client.apply_full(&full);
+    client.apply_delta(&resp);
+    let truth = cold_tokens(&mut lsp, &mirror.text);
+    assert!(
+        same_tokens(&client.tokens(), &truth),
+        "reference client diverged after applying the delta — {}",
+        first_divergence(&client.tokens(), &truth)
+    );
+
+    // An unknown `previousResultId` must fall back to a full stream (safe).
+    let fallback = request_delta(&mut lsp, &uri, Some("st-does-not-exist"));
+    assert!(
+        fallback.get("data").and_then(Value::as_array).is_some(),
+        "unknown previousResultId must fall back to full `data`; got {fallback:#}"
+    );
+}
+
+/// Edit-then-undo is the exact trigger the reporter names in issue #333: make a
+/// change (server recomputes), then revert it (server recomputes back). The
+/// server must land on byte-identical tokens to before the edit — no residue.
+#[test]
+fn reference_client_tracks_edit_then_undo() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let initial = "set iniFile config.ini\n\
+                   if {[::ini::exists $iniFile Options solver]} {\n\
+                   \x20   ::ini::set $iniFile Options solver 0\n\
+                   } else {\n\
+                   \x20   ::ini::set $iniFile Options Solver 0\n\
+                   }\n\
+                   proc compute {a b} { return [expr {$a + $b}] }\n";
+    let (mut mirror, mut client) = open_and_seed(&mut lsp, &uri, initial);
+    let baseline = cold_tokens(&mut lsp, initial);
+    assert_tracks(&mut lsp, &mirror, &mut client, "undo-seed");
+
+    for round in 0..8 {
+        // Edit: rename `Solver` -> `Disabled` on line 4.
+        let sol = mirror.text.find("Solver 0").expect("Solver present");
+        let (l, c) = offset_to_line_char(&mirror.text, sol);
+        mirror.edit(&mut lsp, (l, c), (l, c + 6), "Disabled");
+        assert_tracks(&mut lsp, &mirror, &mut client, "undo-edit");
+
+        // Undo: rename it back.
+        let dis = mirror.text.find("Disabled 0").expect("Disabled present");
+        let (l, c) = offset_to_line_char(&mirror.text, dis);
+        mirror.edit(&mut lsp, (l, c), (l, c + 8), "Solver");
+        assert_tracks(&mut lsp, &mirror, &mut client, "undo-revert");
+
+        // After a full edit/undo round the server must be byte-identical to
+        // the original cold tokens — no drift accreted over the round.
+        let now = decode_semantic_tokens(&lsp.semantic_tokens(&mirror.uri));
+        assert!(
+            same_tokens(&now, &baseline),
+            "round {round}: tokens drifted after edit+undo — {}",
+            first_divergence(&now, &baseline)
+        );
+    }
+}
+
+/// Rapid-fire bursts: fire several incremental edits without waiting, then
+/// settle. The final `full` (and the reference client) must match a cold
+/// reopen of the final text — coalesced didChanges must not desync the server.
+#[test]
+fn reference_client_tracks_rapid_fire_bursts() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let initial = "proc f {a b} {\n    set x 1\n    set y 2\n    set z 3\n    return $x\n}\n";
+    let (mut mirror, mut client) = open_and_seed(&mut lsp, &uri, initial);
+
+    for burst in 0..6 {
+        // Three edits without waiting, then a settling edit.
+        mirror.edit_no_wait(&mut lsp, (0, 0), (0, 0), "# burst\n");
+        mirror.edit_no_wait(&mut lsp, (2, 8), (2, 9), "1");
+        mirror.edit_no_wait(&mut lsp, (3, 8), (3, 9), "2");
+        // Settling edit (waits): toggles a trailing comment.
+        let last = mirror.text.lines().count();
+        mirror.edit(
+            &mut lsp,
+            (last, 0),
+            (last, 0),
+            &format!("# settle {burst}\n"),
+        );
+        assert_tracks(&mut lsp, &mirror, &mut client, "rapid-settle");
+    }
+}
+
+/// Large-file latency + correctness. The reporter says tokens take "several
+/// seconds" on 5000+ LOC files and editing loses track. Measure the cold and
+/// post-edit `full` latency and assert the server still returns correct tokens
+/// after an edit deep in a big file. The timing is printed (see with
+/// `--nocapture`); the assertion bound is generous so this is a smoke gate on
+/// pathological latency, not a flaky micro-benchmark.
+#[test]
+fn large_file_latency_and_correctness() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let big = generate_big_tcl(600); // ~5200 lines.
+    let line_count = big.lines().count();
+
+    // Open WITHOUT waiting for diagnostics, so the first `semanticTokens/full`
+    // measures the isolated token round-trip (cold parse + tokenise + encode),
+    // not the diagnostics pipeline — this is the latency eglot actually waits
+    // on when it asks for tokens.
+    lsp.open_document_lang(&uri, &big, "tcl", 1);
+    let t_cold = Instant::now();
+    let cold = lsp.semantic_tokens(&uri);
+    let cold_ms = t_cold.elapsed().as_millis();
+    let cold_toks = decode_semantic_tokens(&cold);
+    assert!(
+        cold_toks.len() > 1000,
+        "expected a rich token stream for a {line_count}-line file, got {}",
+        cold_toks.len()
+    );
+
+    // Warm round-trip — the memoised query should answer near-instantly.
+    let t_warm = Instant::now();
+    let _ = lsp.semantic_tokens(&uri);
+    let warm_ms = t_warm.elapsed().as_millis();
+
+    // Edit deep in the file, then time tokens WITHOUT first waiting on
+    // diagnostics — the realistic "type a char, how long until fresh tokens"
+    // path from issue #333.
+    let mut mirror = Mirror::new(&uri, &big);
+    let needle = "set v300 [expr {$v300 + 1}]";
+    let pos = mirror.text.find(needle).expect("deep needle present");
+    let (l, c) = offset_to_line_char(&mirror.text, pos);
+    mirror.edit_no_wait(&mut lsp, (l, c + 4), (l, c + 8), "v_300"); // v300 -> v_300
+    let t_edit = Instant::now();
+    let edit_full = lsp.semantic_tokens(&uri);
+    let edit_ms = t_edit.elapsed().as_millis();
+
+    // Settle and assert correctness against a cold reopen.
+    lsp.await_diagnostics_version(
+        &uri,
+        Some(mirror.version),
+        std::time::Duration::from_secs(30),
+    );
+    let truth = cold_tokens(&mut lsp, &mirror.text);
+    let after = decode_semantic_tokens(&edit_full);
+    assert!(
+        same_tokens(&after, &truth),
+        "post-edit tokens on a big file drifted from a cold reopen — {}",
+        first_divergence(&after, &truth)
+    );
+
+    eprintln!(
+        "large_file_latency: {line_count} lines, {} tokens; \
+         cold full={cold_ms}ms, warm full={warm_ms}ms, post-edit full={edit_ms}ms",
+        cold_toks.len()
+    );
+    // Pathological-latency guard. A native tokeniser on ~5k lines should answer
+    // in well under a second; multiple seconds means an O(n^2) regression in
+    // the token path (the issue #333 latency the reporter feels as a "hang").
+    // Debug builds are ~10-20x slower than the shipped release binary, so this
+    // strict gate only runs for release builds; debug runs just print timings.
+    if cfg!(not(debug_assertions)) {
+        assert!(
+            edit_ms < 2000,
+            "post-edit semanticTokens/full took {edit_ms}ms on {line_count} lines \
+             (release) — unexpectedly slow (issue #333 latency regression?)"
+        );
+    }
+}
+
+// -- generators / small utils --------------------------------------------
+
+/// Byte offset -> (line, character) for an ASCII string.
+fn offset_to_line_char(text: &str, offset: usize) -> (usize, usize) {
+    let mut line = 0usize;
+    let mut last_nl = 0usize;
+    for (i, b) in text.bytes().enumerate() {
+        if i == offset {
+            break;
+        }
+        if b == b'\n' {
+            line += 1;
+            last_nl = i + 1;
+        }
+    }
+    (line, offset - last_nl)
+}
+
+/// Generate a large but realistic Tcl file: `n` small procs with bodies that
+/// exercise several token kinds (keywords, vars, strings, numbers, comments,
+/// namespaces, expr). ~8-9 lines per proc.
+fn generate_big_tcl(n: usize) -> String {
+    use std::fmt::Write as _;
+    let mut s = String::with_capacity(n * 200);
+    s.push_str("namespace eval ::bench {\n    variable counter 0\n}\n\n");
+    for i in 0..n {
+        let _ = write!(
+            s,
+            "# proc number {i}\n\
+             proc ::bench::step{i} {{a b}} {{\n\
+             \x20   set v{i} [expr {{$a + $b}}]\n\
+             \x20   set msg \"step {i} = $v{i}\"\n\
+             \x20   if {{$v{i} > 10}} {{\n\
+             \x20       set v{i} [expr {{$v{i} + 1}}]\n\
+             \x20   }}\n\
+             \x20   return $v{i}\n\
+             }}\n\n"
+        );
+    }
+    s
+}

--- a/scripts/eglot_test/README.md
+++ b/scripts/eglot_test/README.md
@@ -1,7 +1,38 @@
 # Eglot debugging tools for tcl-lsp
 
-Two scripts here, both pointed at GitHub issue #333 (highlighting goes
-stale until file reload in Emacs).
+Tools pointed at GitHub issue #333 (highlighting goes stale until file
+reload in Emacs).
+
+**None of this runs in CI or `make test`.** It needs a real Emacs, network
+access to install eglot from GNU ELPA, and it exercises upstream eglot
+internals we can't fix from the server side. Run it by hand.
+
+## What issue #333 actually is
+
+The reporter sees `eglot-semantic-*` faces *accumulate* on characters after
+edits — a `keyword` char ends up wearing `keyword string variable function
+namespace …` all at once — cleared only by reverting/reopening the file.
+
+It is an **upstream eglot painter bug**, not a server bug:
+`eglot--semtok-font-lock-2` ("repaint from stale-but-not-that-much local
+properties") applies faces with `add-face-text-property`, which *appends*
+to the existing `face` list instead of replacing it, and never strips the
+prior `eglot-semantic-*` faces first. That path runs whenever eglot's
+cached tokens are stale relative to the buffer's current version — i.e.
+while a `semanticTokens` response is in flight. On large files the
+round-trip is slow enough that eglot repaints several times before the
+response lands, so the faces stack. (The reporter's "hang for a second" is
+the *diagnostics* pipeline, not tokens — the server's `semanticTokens/full`
+answers a 6000-line file in tens of milliseconds; see
+`rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs`.)
+
+The server can't fix eglot's painter, but it *shrinks the stale window*
+by implementing proper `semanticTokens/full/delta`: a keystroke sends
+only the changed tokens (like rust-analyzer), not the whole document.
+This harness verifies that delta path end-to-end through real eglot.
+(An earlier experiment added an "eglot-compatibility mode" that dropped
+`full/delta`/`range`; the data showed it made no difference to the
+accumulation, so it was removed in favour of the deltas.)
 
 ## 1. `tcl-lsp-record-bug.el` — bug recorder for end-users
 
@@ -10,7 +41,7 @@ happens around a tcl-lsp highlighting bug. The recorder captures:
 
 - emacs / eglot / jsonrpc / eldoc / flymake / lsp-mode versions
 - system info (`uname`, `lsb_release`, `system-type`, locale, tty/graphic)
-- python / uv / tclsh versions
+- tclsh versions
 - the LSP server's advertised capabilities
 - every `after-change-functions` event for the recorded buffer
 - every JSON-RPC request, notification, and incoming message
@@ -38,77 +69,134 @@ M-x tcl-lsp-bug-record-save RET ~/tcl-lsp-bug.eld RET
 Attach the resulting `.eld` file to the issue. It is a plain Elisp
 data file you can inspect before sending.
 
-## 2. `test_issue333.el` + `run.sh` — automated reproducer
+## 2. `test_issue333.el` + `run.sh` — automated reproducer + delta proof
 
 A batch-mode harness that:
 
-1. Auto-installs eglot 1.23 from GNU ELPA into `tmp/elpa/`
-2. Spins up `uv run python -m server` per scenario
-3. Performs a sequence of in-buffer edits (sending didChange to eglot,
-   which then exchanges semanticTokens/full and /full/delta with the
-   server)
-4. Snapshots `face` text-properties at the post-edit point
-5. Kills the buffer and reopens (forces a fresh /full request)
-6. Snapshots again and diffs
+1. Auto-installs a semantic-tokens-capable eglot (>= 1.20) from GNU ELPA
+   into `tmp/elpa/` if one isn't already there.
+2. Builds (or reuses) the native `tcl-lsp-server` binary and launches it
+   per scenario. Set `TCL_LSP_SERVER_BIN` to reuse a prebuilt binary.
+3. Per edit scenario: performs in-buffer edits (sending didChange to
+   eglot, which exchanges `semanticTokens/full` and `/full/delta` with the
+   server), snapshots `face` text-properties, then kills+reopens the file
+   (fresh `/full`) and snapshots again, diffing the two.
+4. Runs `painter-accumulation` — a deterministic, client-only reproducer of
+   the upstream eglot painter bug.
+5. Runs `semantic-tokens-delta` — the real gate for our server change.
 
-Mismatches reproduce the bug. Run with:
+Run with:
 
 ```sh
 scripts/eglot_test/run.sh
 ```
 
-Current scenarios: `rename-only`, `insert-line-top`,
-`delete-line-middle`, `rapid-fire-no-wait`, `user-issue-code`,
-`many-small-edits`. `insert-line-top`, `delete-line-middle`,
-`user-issue-code`, and `many-small-edits` test our server's
-correctness via eglot and are expected to PASS.
+### The `semantic-tokens-delta` test
 
-The following are marked `:xfail` because they reproduce known
-upstream eglot painter bugs rather than testing our server:
+End-to-end proof of the server's incremental `full/delta`. It connects
+real eglot, asserts the server advertises `full: {delta: true}` + `range`,
+makes a token-changing edit, then confirms — from eglot's jsonrpc events
+buffer — that the `full/delta` **response carried `edits`** rather than a
+full `data` re-send. (`eglot--semtok-apply-delta-edits` is a `defsubst`
+inlined into byte-compiled eglot, so the response is inspected directly
+instead of advising that symbol.)
+
+Unlike the painter scenarios, `semantic-tokens-delta` failing **fails the
+suite** — it guards the server's delta implementation, which we control.
+The CI-side counterpart lives in
+`rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs`
+(`server_returns_real_delta_not_full_resend`).
+
+### Edit scenarios
+
+`rename-only`, `insert-line-top`, `delete-line-middle`,
+`rapid-fire-no-wait`, `user-issue-code`, `many-small-edits`.
+
+Several are marked `:xfail` because they reproduce known upstream eglot
+behaviour rather than a server bug:
 
 - `rapid-fire-no-wait` exercises eglot's didChange request coalescing,
-  which is timing-sensitive and known to drop intermediate edits on
-  some eglot/jsonrpc combinations.
-- `rename-only` triggers the same painter accumulation seen in
-  `painter-accumulation` once the test host is under CPU pressure
-  (e.g. running alongside `test-ext`/`test-vm` under `make test-slow`):
-  the delta paint after a single replace leaves stale
-  `eglot-semantic-*` faces in the post-edit buffer that aren't in a
-  fresh-reload snapshot. Our delta arithmetic is correct (the diff
-  helper dedups painter accumulation; the remaining "stale face" mode
-  is the same upstream bug, just expressed cross-snapshot).
+  timing-sensitive and known to drop intermediate edits on some
+  eglot/jsonrpc combinations.
+- `rename-only` / `insert-line-top` / `delete-line-middle` /
+  `user-issue-code` trigger the same painter accumulation as
+  `painter-accumulation` under CPU pressure — the delta paint leaves stale
+  `eglot-semantic-*` faces the fresh-reload snapshot doesn't have.
 - `painter-accumulation` is a deterministic reproducer for issue #333.
 
-XFAIL scenarios that unexpectedly PASS are reported as XPASS so we
-remember to drop the marker once eglot ships a fix.
+XFAIL scenarios that unexpectedly PASS are reported as XPASS so we remember
+to drop the marker once eglot ships a fix.
 
-The scenario diff deduplicates accumulated `eglot-semantic-*` faces
-before comparing, so any positional mismatch flagged as `FAIL [diff]`
-reflects a real LSP delta-correctness bug on our side. Lines printed
-as `INFO [accum-edited]` / `INFO [accum-reload]` flag the upstream
-painter accumulation from issue #333 — they're informational only and
-do not fail the scenario, because under CPU pressure (e.g. `test-slow`
-running other suites in parallel) the upstream bug bleeds into edit-
-heavy scenarios like `rename-only` and `many-small-edits` even though
-our delta arithmetic is correct.
+The scenario diff deduplicates accumulated `eglot-semantic-*` faces before
+comparing, so any positional mismatch flagged as `FAIL [diff]` reflects a
+real LSP delta-correctness bug on our side. `INFO [accum-edited]` /
+`INFO [accum-reload]` lines flag the upstream painter accumulation — they
+are informational only.
 
-If `painter-accumulation` ever PASSes, the upstream bug is fixed: drop
-its `:xfail` marker *and* the accumulation-tolerance in `t333-diff` /
-the `INFO` logging in `t333-run-scenario`, since real accumulation
-regressions should then be caught.
+If `painter-accumulation` ever PASSes, the upstream bug is fixed: drop its
+`:xfail` marker *and* the accumulation-tolerance in `t333-diff` / the `INFO`
+logging in `t333-run-scenario`, so real accumulation regressions are then
+caught.
 
-## 3. `exercise_recorder.el` — smoke-test for the recorder
+### CI-friendly counterpart
 
-A self-driving emacs that loads the recorder, makes some edits against
-a live LSP, calls every public command, and dumps the resulting `.eld`
-back to ensure it's readable. Mainly used to verify the recorder still
-works after changes.
+The correctness half of this — proving the *server* never drifts under
+harsh editing — lives in a pure-Rust, no-Emacs test that does run in CI:
+`rust/tcl-lsp-server/tests/e2e/semantic_tokens_reference_client.rs`. It drives
+a spec-correct reference semantic-tokens client through brutal edit
+sequences (mixed edits, edit-then-undo, rapid-fire bursts, a 5000+ line
+file) and asserts both the server's `full` response and the reference
+client's `full/delta` reconstruction always equal a cold reopen. As long as
+that passes, any staleness this eglot harness shows is provably eglot's.
 
-Run with:
+## 3. Diagnostic experiments (manual, non-CI)
+
+Three standalone scripts used to characterise issue #333. They load the
+harness helpers via `TCL_LSP_T333_NOEXEC=1` and print/write their own
+report. None run in CI.
+
+- **`compare_langs.el`** — drives eglot against several servers
+  (`tcl-lsp`, `pyright`, `rust-analyzer`) on similar-sized (~6k line)
+  inputs and reports how semantic tokens *appear* (connect → first
+  tokens) and *update* (edit → fresh tokens) for each. Answers "is
+  tcl-lsp's semantic-token timing typical for eglot or an outlier?".
+  Measured here: `rust-analyzer` appear≈0.15s / update≈0.19s; `tcl-lsp`
+  ≈0.55s / ≈0.47s; `pyright` emits no eglot semantic tokens at all. So
+  tcl-lsp is sub-second and in the same ballpark as the reference
+  server — the reporter's "several seconds" is not the token request.
+
+  ```sh
+  TCL_LSP_REPO=$PWD TCL_LSP_SERVER_BIN=$PWD/target/release/tcl-lsp-server \
+    emacs -Q -batch -L tmp/elpa/eglot-1.24 -L tmp/elpa/jsonrpc-1.0.29 \
+    -l scripts/eglot_test/compare_langs.el
+  ```
+
+- **`experiment_333.el`** — on a ~6k line Tcl file, runs the same edit
+  sequence with eglot-compat OFF and ON, reporting connect→first-tokens
+  and per-edit update latency plus accumulated-face counts, then a
+  rapid edit/undo "stale window" stress. Batch has no redisplay, so it
+  reports timings and (usually) zero accumulation — the accumulation
+  itself only appears under a real GUI (see below).
+
+- **`repro_interactive.el`** — the actual #333 reproducer. Needs a
+  *real GUI Emacs* (batch never repaints; a software `xvfb` frame is too
+  slow). Runs the rapid edit/undo burst with compat OFF and ON under
+  real redisplay and self-classifies the outcome
+  (`PROVEN` / `PARTIAL` / `NO-DIFFERENCE` / `NOT-REPRODUCED`). Use this
+  to check, on your own machine, whether the compat mode actually
+  changes the accumulation. See its header for the invocation.
+
+## 4. `exercise_recorder.el` — smoke-test for the recorder
+
+A self-driving emacs that loads the recorder, makes some edits against a
+live LSP, calls every public command, and dumps the resulting `.eld` back
+to ensure it's readable. Mainly used to verify the recorder still works
+after changes.
+
+Run with (adjust the ELPA version dirs to whatever `run.sh` installed):
 
 ```sh
 emacs -Q -batch \
-  -L tmp/elpa/eglot-1.23 -L tmp/elpa/jsonrpc-1.0.28 \
-  -L tmp/elpa/eldoc-1.16.0 -L tmp/elpa/flymake-1.4.5 \
+  -L tmp/elpa/eglot-1.24 -L tmp/elpa/jsonrpc-1.0.29 \
   -l scripts/eglot_test/exercise_recorder.el
 ```

--- a/scripts/eglot_test/compare_full.el
+++ b/scripts/eglot_test/compare_full.el
@@ -1,0 +1,196 @@
+;; -*- lexical-binding: t -*-
+;;; compare_full.el — issue #333 across servers, sizes, and the compat mode.
+;;
+;; Two jobs, one batch run (no redisplay needed — the painter functions are
+;; driven directly):
+;;
+;;   A. TIMING: for each server and a range of input sizes, how long until
+;;      semantic tokens first APPEAR (connect → first tokens) and how long an
+;;      edit takes to UPDATE them.
+;;
+;;   B. PAINTER BUG: for each server, whether eglot's semantic-token painter
+;;      accumulates duplicate `eglot-semantic-*' faces under the reporter's
+;;      stale-repaint trigger — one clean paint then N stale repaints,
+;;      counting the worst per-character face stack.  This is issue #333; if it
+;;      reproduces with servers other than tcl-lsp it is purely eglot's painter.
+;;
+;; Servers probed when present: tcl-lsp (compat off AND on), pyright, clangd,
+;; rust-analyzer.
+;;
+;;   TCL_LSP_REPO=$PWD TCL_LSP_SERVER_BIN=$PWD/target/release/tcl-lsp-server \
+;;   TCL_LSP_T333_NOEXEC=1 emacs -Q -batch \
+;;     -L tmp/elpa/eglot-1.24 -L tmp/elpa/jsonrpc-1.0.29 \
+;;     -l scripts/eglot_test/test_issue333.el \
+;;     -l scripts/eglot_test/compare_full.el
+
+(require 'python)
+(define-derived-mode cf-rust-mode prog-mode "CfRust")
+(define-derived-mode cf-c-mode prog-mode "CfC")
+
+(defvar cf-repo (or (getenv "TCL_LSP_REPO") default-directory))
+(defvar cf-root (expand-file-name "tmp/eglot_test/cf" cf-repo))
+(defun cf-now () (float-time))
+
+(defun cf-wait-tokens (max-secs)
+  (let ((start (cf-now)) (deadline (+ (cf-now) max-secs)))
+    (while (and (< (cf-now) deadline)
+                (or (null (cl-getf eglot--semtok-state :data))
+                    (not (eq (cl-getf eglot--semtok-state :docver) eglot--docver))))
+      (font-lock-flush) (font-lock-ensure) (accept-process-output nil 0.03) (sit-for 0.01))
+    (- (cf-now) start)))
+
+(defun cf-ntok () (let ((d (cl-getf eglot--semtok-state :data)))
+                    (if (vectorp d) (/ (length d) 5) 0)))
+
+(defun cf-worst-stack ()
+  (cl-loop for pos from (point-min) below (point-max)
+           for eg = (cl-remove-if-not
+                     (lambda (f) (and (symbolp f)
+                                      (string-prefix-p "eglot-semantic-" (symbol-name f))))
+                     (t333-face-list (get-text-property pos 'face)))
+           maximize (length eg)))
+
+(defun cf-painter-accum (repaints)
+  "One clean paint then REPAINTS stale repaints on the current buffer;
+return worst per-char eglot-semantic-* stack, or 'no-tokens."
+  (let ((data (cl-getf eglot--semtok-state :data)))
+    (if (and (vectorp data) (> (length data) 0))
+        (progn
+          (with-silent-modifications
+            (remove-text-properties (point-min) (point-max)
+                                    '(face nil eglot--semtok-faces nil eglot--semtok-token nil)))
+          (eglot--semtok-font-lock-1 (point-min) (point-max) data)
+          (dotimes (_ repaints) (eglot--semtok-font-lock-2 (point-min) (point-max)))
+          (cf-worst-stack))
+      'no-tokens)))
+
+(cl-defun cf-probe (&key name mode server lang-id init-opts file edits
+                         (appear-budget 90) (repaints 6))
+  "Connect eglot to SERVER on FILE, return timing + painter accumulation."
+  (condition-case err
+      (progn
+        (setq eglot-server-programs
+              (list (cons (if lang-id (list mode :language-id lang-id) mode) server)))
+        (when init-opts
+          (cl-defmethod eglot-initialization-options ((_s eglot-lsp-server)) init-opts))
+        (unless init-opts
+          (cl-defmethod eglot-initialization-options ((_s eglot-lsp-server)) eglot--{}))
+        (find-file file) (funcall mode) (font-lock-mode 1)
+        (let ((c (eglot--guess-contact)) (t0 (cf-now)))
+          (eglot--connect (nth 0 c) (nth 1 c) (nth 2 c) (nth 3 c) (nth 4 c))
+          (ignore-errors (eglot-semantic-tokens-mode 1))
+          (let* ((appear (cf-wait-tokens appear-budget))
+                 (ntok (cf-ntok))
+                 (lines (count-lines (point-min) (point-max)))
+                 (updates '()))
+            (dolist (e edits)
+              (goto-char (point-min))
+              (when (search-forward (car e) nil t)
+                (replace-match (cdr e) t t)
+                (eglot--signal-textDocument/didChange)
+                (push (cf-wait-tokens 60) updates)))
+            (let ((worst (if (> ntok 0) (cf-painter-accum repaints) 'no-tokens)))
+              (prog1 (list :name name :lines lines :ntok ntok :appear appear
+                           :updates (nreverse updates) :worst worst)
+                (ignore-errors (eglot-shutdown (eglot-current-server) 1 nil))
+                (let ((kill-buffer-query-functions nil)) (kill-buffer (current-buffer))))))))
+    (error (list :name name :error (format "%S" err)))))
+
+(defun cf-report (r)
+  (if (plist-get r :error)
+      (princ (format "  %-22s ERROR %s\n" (plist-get r :name) (plist-get r :error)))
+    (let ((u (plist-get r :updates)))
+      (princ (format "  %-22s lines=%-5d tok=%-6d appear=%6.2fs update=%5.2fs  worst-stack=%s\n"
+                     (plist-get r :name) (plist-get r :lines) (plist-get r :ntok)
+                     (plist-get r :appear)
+                     (if u (/ (apply #'+ u) (float (length u))) 0.0)
+                     (plist-get r :worst))))))
+
+;;; ---- file generators, size-parameterised ----------------------------
+
+(defun cf-gen-tcl (n path)
+  (with-temp-file path
+    (insert "namespace eval ::bench {\n    variable counter 0\n}\n\n")
+    (dotimes (i n)
+      (insert (format (concat "proc ::bench::step%d {a b} {\n    set v%d [expr {$a + $b}]\n"
+                              "    set msg \"step %d = $v%d\"\n    if {$v%d > 10} { set v%d [expr {$v%d + 1}] }\n"
+                              "    return $v%d\n}\n\n") i i i i i i i i)))))
+
+(defun cf-gen-py (n path)
+  (with-temp-file path
+    (insert "import math\n\n\n")
+    (dotimes (i n)
+      (insert (format (concat "def step%d(a: int, b: int) -> int:\n    v%d = a + b\n"
+                              "    msg = f\"step %d = {v%d}\"\n    if v%d > 10:\n        v%d = v%d + 1\n"
+                              "    return v%d\n\n\n") i i i i i i i i)))))
+
+(defun cf-gen-c (n path)
+  (with-temp-file path
+    (insert "#include <stdio.h>\n\n")
+    (dotimes (i n)
+      (insert (format (concat "int step%d(int a, int b) {\n    int v%d = a + b;\n"
+                              "    if (v%d > 10) { v%d = v%d + 1; }\n    return v%d;\n}\n\n")
+                      i i i i i i)))))
+
+(defun cf-gen-rust (n dir)
+  (make-directory (expand-file-name "src" dir) t)
+  (with-temp-file (expand-file-name "Cargo.toml" dir)
+    (insert "[package]\nname=\"b\"\nversion=\"0.1.0\"\nedition=\"2021\"\n\n[lib]\npath=\"src/lib.rs\"\n"))
+  (let ((path (expand-file-name "src/lib.rs" dir)))
+    (with-temp-file path
+      (dotimes (i n)
+        (insert (format (concat "pub fn step%d(a: i64, b: i64) -> i64 {\n    let v%d = a + b;\n"
+                                "    if v%d > 10 { return v%d + 1; }\n    v%d\n}\n\n")
+                        i i i i i))))
+    path))
+
+;;; ---- main -------------------------------------------------------------
+
+(make-directory cf-root t)
+(princ "\n===== issue #333: eglot semantic tokens across servers / sizes / compat =====\n")
+(princ "  (appear = connect->first tokens; update = edit->fresh tokens;\n")
+(princ "   worst-stack = deepest eglot-semantic-* face stack after 1 clean + 6 stale repaints — >1 means the #333 painter bug reproduces)\n\n")
+
+(let* ((bin (or (getenv "TCL_LSP_SERVER_BIN")
+                (expand-file-name "target/release/tcl-lsp-server" cf-repo)))
+       (ra (string-trim (shell-command-to-string "rustup which rust-analyzer 2>/dev/null")))
+       (sizes (list (cons "S" 60) (cons "M" 400) (cons "L" 1200)))
+       (tcl-edits '(("set v30 " . "set vv30 ") ("set v3 " . "set vv3 ")))
+       (py-edits '(("v30 = a + b" . "vv30 = a + b") ("v3 = a + b" . "vv3 = a + b")))
+       (c-edits '(("int v30 = a" . "int vv30 = a") ("int v3 = a" . "int vv3 = a")))
+       (rs-edits '(("let v30 = a" . "let vv30 = a") ("let v3 = a" . "let vv3 = a"))))
+  (dolist (sz sizes)
+    (let ((tag (car sz)) (n (cdr sz)))
+      (princ (format "-- size %s (~%d items) --\n" tag n))
+      ;; tcl-lsp compat OFF and ON
+      (let ((f (expand-file-name (format "b-%s.tcl" tag) cf-root)))
+        (cf-gen-tcl n f)
+        (when (file-exists-p bin)
+          (cf-report (cf-probe :name (format "tcl-lsp[%s] compat-off" tag) :mode 'tcl-mode
+                               :server (list bin) :file f :edits tcl-edits))
+          (cf-report (cf-probe :name (format "tcl-lsp[%s] compat-ON" tag) :mode 'tcl-mode
+                               :server (list bin) :file f :edits tcl-edits
+                               :init-opts '(:tclLsp (:compatibility (:eglot t)))))))
+      ;; pyright
+      (when (executable-find "pyright-langserver")
+        (let ((f (expand-file-name (format "b-%s.py" tag) cf-root)))
+          (cf-gen-py n f)
+          (cf-report (cf-probe :name (format "pyright[%s]" tag) :mode 'python-mode
+                               :server '("pyright-langserver" "--stdio") :lang-id "python"
+                               :file f :edits py-edits :appear-budget 60))))
+      ;; clangd (C)
+      (when (executable-find "clangd")
+        (let ((f (expand-file-name (format "b-%s.c" tag) cf-root)))
+          (cf-gen-c n f)
+          (cf-report (cf-probe :name (format "clangd[%s]" tag) :mode 'cf-c-mode
+                               :server '("clangd" "--background-index=false") :lang-id "c"
+                               :file f :edits c-edits :appear-budget 60))))
+      ;; rust-analyzer
+      (when (and ra (file-exists-p ra))
+        (let* ((dir (expand-file-name (format "rust-%s" tag) cf-root))
+               (f (cf-gen-rust n dir)))
+          (cf-report (cf-probe :name (format "rust-analyzer[%s]" tag) :mode 'cf-rust-mode
+                               :server (list ra) :lang-id "rust"
+                               :file f :edits rs-edits :appear-budget 150))))
+      (princ "\n"))))
+(kill-emacs 0)

--- a/scripts/eglot_test/compare_langs.el
+++ b/scripts/eglot_test/compare_langs.el
@@ -1,0 +1,171 @@
+;; -*- lexical-binding: t -*-
+;;; compare_langs.el — cross-language eglot semantic-token timing comparison.
+;;
+;; Drives eglot against several language servers on similar-sized (~6k line)
+;; inputs and reports, per server, how semantic-token highlighting APPEARS
+;; (connect → first tokens) and UPDATES (edit → fresh tokens).  The point is
+;; to see whether tcl-lsp's behaviour is typical of eglot semantic tokens in
+;; general or an outlier — issue #333 context.
+;;
+;; Servers probed (when present): tcl-lsp, pyright (Python), rust-analyzer.
+;;
+;;   TCL_LSP_REPO=$PWD TCL_LSP_SERVER_BIN=$PWD/target/release/tcl-lsp-server \
+;;   emacs -Q -batch -L tmp/elpa/eglot-1.24 -L tmp/elpa/jsonrpc-1.0.29 \
+;;     -l scripts/eglot_test/compare_langs.el
+
+(require 'eglot)
+(require 'cl-lib)
+(require 'python)
+
+(setq eglot-sync-connect 10 inhibit-message t message-log-max nil
+      eglot-events-buffer-config '(:size 200000 :format full)
+      eglot-autoshutdown t)
+(advice-add 'display-warning :around
+            (lambda (orig type msg &rest r)
+              (unless (or (eq type 'jsonrpc) (and (listp type) (memq 'jsonrpc type)))
+                (apply orig type msg r))))
+
+(defvar cmp-repo (or (getenv "TCL_LSP_REPO") (expand-file-name default-directory)))
+(defvar cmp-root (expand-file-name "tmp/eglot_test/compare" cmp-repo))
+
+;; A throwaway major mode for Rust so eglot can associate a server (no
+;; rust-mode is bundled with Emacs).
+(define-derived-mode cmp-rust-mode prog-mode "CmpRust")
+
+(defun cmp-now () (float-time))
+
+(defun cmp-wait-tokens (max-secs)
+  "Block until eglot has semantic-token data for the current docver.
+Return seconds waited (MAX-SECS on timeout)."
+  (let ((start (cmp-now)) (deadline (+ (cmp-now) max-secs)))
+    (while (and (< (cmp-now) deadline)
+                (or (null (cl-getf eglot--semtok-state :data))
+                    (not (eq (cl-getf eglot--semtok-state :docver) eglot--docver))))
+      (font-lock-flush) (font-lock-ensure)
+      (accept-process-output nil 0.02) (sit-for 0.01))
+    (font-lock-flush) (font-lock-ensure)
+    (- (cmp-now) start)))
+
+(defun cmp-tokens-len ()
+  (let ((d (cl-getf eglot--semtok-state :data)))
+    (if (vectorp d) (/ (length d) 5) 0)))
+
+(cl-defun cmp-run (&key name file mode server lang-id edits (appear-budget 90))
+  "Connect eglot (SERVER) on FILE in MODE, time appear + edits.
+Returns a plist of results, or nil on failure."
+  (condition-case err
+      (progn
+        (setq eglot-server-programs
+              (list (cons (if lang-id (list mode :language-id lang-id) mode)
+                          server)))
+        (find-file file)
+        (funcall mode)
+        (font-lock-mode 1)
+        (let* ((c (eglot--guess-contact))
+               (t0 (cmp-now)))
+          (eglot--connect (nth 0 c) (nth 1 c) (nth 2 c) (nth 3 c) (nth 4 c))
+          (ignore-errors (eglot-semantic-tokens-mode 1))
+          (let* ((appear (cmp-wait-tokens appear-budget))
+                 (ntok (cmp-tokens-len))
+                 (lines (count-lines (point-min) (point-max)))
+                 (edit-times '()))
+            (dolist (e edits)
+              (goto-char (point-min))
+              (when (search-forward (car e) nil t)
+                (replace-match (cdr e) t t)
+                (eglot--signal-textDocument/didChange)
+                (push (cmp-wait-tokens 60) edit-times)))
+            (prog1
+                (list :name name :lines lines :ntok ntok
+                      :appear appear :edit-times (nreverse edit-times))
+              (ignore-errors (eglot-shutdown (eglot-current-server) 1 nil))
+              (let ((kill-buffer-query-functions nil)) (kill-buffer (current-buffer)))))))
+    (error
+     (princ (format "  %-14s ERROR: %S\n" name err))
+     nil)))
+
+(defun cmp-report (r)
+  (when r
+    (let ((et (plist-get r :edit-times)))
+      (princ (format "  %-14s lines=%-5d tokens=%-6d  appear=%5.2fs  edits=[%s]  mean-update=%.2fs\n"
+                     (plist-get r :name) (plist-get r :lines) (plist-get r :ntok)
+                     (plist-get r :appear)
+                     (mapconcat (lambda (x) (format "%.2f" x)) et " ")
+                     (if et (/ (apply #'+ et) (float (length et))) 0.0))))))
+
+;;; ---- generators (~6k lines each) --------------------------------------
+
+(defun cmp-gen-tcl (n path)
+  (with-temp-file path
+    (insert "namespace eval ::bench {\n    variable counter 0\n}\n\n")
+    (dotimes (i n)
+      (insert (format (concat "# proc %d\nproc ::bench::step%d {a b} {\n"
+                              "    set v%d [expr {$a + $b}]\n"
+                              "    set msg \"step %d = $v%d\"\n"
+                              "    if {$v%d > 10} { set v%d [expr {$v%d + 1}] }\n"
+                              "    return $v%d\n}\n\n")
+                      i i i i i i i i i)))))
+
+(defun cmp-gen-py (n path)
+  (with-temp-file path
+    (insert "import math\n\n\n")
+    (dotimes (i n)
+      (insert (format (concat "# func %d\ndef step%d(a: int, b: int) -> int:\n"
+                              "    v%d = a + b\n"
+                              "    msg = f\"step %d = {v%d}\"\n"
+                              "    if v%d > 10:\n        v%d = v%d + 1\n"
+                              "    return v%d\n\n\n")
+                      i i i i i i i i i)))))
+
+(defun cmp-gen-rust (n dir)
+  (make-directory (expand-file-name "src" dir) t)
+  (with-temp-file (expand-file-name "Cargo.toml" dir)
+    (insert "[package]\nname = \"bench\"\nversion = \"0.1.0\"\nedition = \"2021\"\n\n[lib]\npath = \"src/lib.rs\"\n"))
+  (let ((path (expand-file-name "src/lib.rs" dir)))
+    (with-temp-file path
+      (insert "//! bench\n\n")
+      (dotimes (i n)
+        (insert (format (concat "/// step %d\npub fn step%d(a: i64, b: i64) -> i64 {\n"
+                                "    let v%d = a + b;\n"
+                                "    let _msg = format!(\"step %d = {}\", v%d);\n"
+                                "    if v%d > 10 { return v%d + 1; }\n"
+                                "    v%d\n}\n\n")
+                        i i i i i i i i))))
+    path))
+
+;;; ---- main -------------------------------------------------------------
+
+(make-directory cmp-root t)
+(princ "\n===== eglot semantic-token timing across languages (~6k lines) =====\n")
+
+;; Tcl (tcl-lsp)
+(let ((bin (or (getenv "TCL_LSP_SERVER_BIN")
+               (expand-file-name "target/release/tcl-lsp-server" cmp-repo)))
+      (f (expand-file-name "bench.tcl" cmp-root)))
+  (cmp-gen-tcl 600 f)
+  (when (file-exists-p bin)
+    (cmp-report
+     (cmp-run :name "tcl-lsp" :file f :mode 'tcl-mode :server (list bin)
+              :edits '(("set v300 " . "set vv300 ") ("set v10 " . "set vv10 "))))))
+
+;; Python (pyright)
+(let ((f (expand-file-name "bench.py" cmp-root)))
+  (cmp-gen-py 600 f)
+  (when (executable-find "pyright-langserver")
+    (cmp-report
+     (cmp-run :name "pyright" :file f :mode 'python-mode
+              :server (list "pyright-langserver" "--stdio") :lang-id "python"
+              :edits '(("v300 = a + b" . "vv300 = a + b") ("v10 = a + b" . "vv10 = a + b"))))))
+
+;; Rust (rust-analyzer)
+(let* ((ra (string-trim (shell-command-to-string "rustup which rust-analyzer 2>/dev/null")))
+       (dir (expand-file-name "rustbench" cmp-root))
+       (f (cmp-gen-rust 600 dir)))
+  (when (and ra (file-exists-p ra))
+    (cmp-report
+     (cmp-run :name "rust-analyzer" :file f :mode 'cmp-rust-mode
+              :server (list ra) :lang-id "rust" :appear-budget 120
+              :edits '(("let v300 = a" . "let vv300 = a") ("let v10 = a" . "let vv10 = a"))))))
+
+(princ "\n  (appear = connect→first semantic tokens; update = edit→fresh tokens)\n")
+(kill-emacs 0)

--- a/scripts/eglot_test/exercise_recorder.el
+++ b/scripts/eglot_test/exercise_recorder.el
@@ -1,8 +1,9 @@
 ;; -*- lexical-binding: t -*-
 ;;; Smoke-test for tcl-lsp-record-bug.el.
 ;;
-;; Loads the recorder, drives a short eglot session against `uv run python -m server`,
-;; calls every public command, and prints a summary of the resulting .eld file.
+;; Loads the recorder, drives a short eglot session against the native
+;; `tcl-lsp-server' binary, calls every public command, and prints a summary
+;; of the resulting .eld file.
 
 (require 'eglot)
 (require 'tcl)
@@ -18,10 +19,19 @@
 
 (setq tcl-lsp-bug-record-include-source t)
 
+(defun exercise--server-bin ()
+  "Resolve the native `tcl-lsp-server' binary (see test_issue333.el)."
+  (let ((repo (or (getenv "TCL_LSP_REPO") default-directory)))
+    (or (let ((env (getenv "TCL_LSP_SERVER_BIN")))
+          (and env (file-exists-p env) env))
+        (cl-loop for rel in '("target/release/tcl-lsp-server"
+                              "target/debug/tcl-lsp-server")
+                 for abs = (expand-file-name rel repo)
+                 when (file-exists-p abs) return abs)
+        (error "tcl-lsp-server binary not found; set TCL_LSP_SERVER_BIN"))))
+
 (setq eglot-server-programs
-      `((tcl-mode . ("uv" "run" "--directory"
-                     ,(or (getenv "TCL_LSP_REPO") default-directory)
-                     "--no-dev" "python" "-m" "server"))))
+      `((tcl-mode . (,(exercise--server-bin)))))
 
 (let* ((repo (or (getenv "TCL_LSP_REPO") default-directory))
        (dir (expand-file-name "tmp/eglot_test" repo))

--- a/scripts/eglot_test/experiment_333.el
+++ b/scripts/eglot_test/experiment_333.el
@@ -1,0 +1,166 @@
+;; -*- lexical-binding: t -*-
+;;; experiment_333.el — differential proof + perf feel for issue #333.
+;;
+;; Load the harness helpers (NOEXEC), generate a large Tcl file, and run the
+;; SAME harsh edit sequence through real eglot twice — compat OFF and compat
+;; ON — reporting (a) accumulated `eglot-semantic-*` faces at the end of each
+;; run and (b) the timings eglot actually waits on (connect→first tokens, and
+;; each edit→fresh tokens round trip).  Run:
+;;
+;;   TCL_LSP_REPO=$PWD TCL_LSP_SERVER_BIN=$PWD/target/release/tcl-lsp-server \
+;;   TCL_LSP_T333_NOEXEC=1 emacs -Q -batch \
+;;     -L tmp/elpa/eglot-1.24 -L tmp/elpa/jsonrpc-1.0.29 \
+;;     -l scripts/eglot_test/test_issue333.el \
+;;     -l scripts/eglot_test/experiment_333.el
+
+(defun exp333-big-tcl (nprocs)
+  "Return a large Tcl source with NPROCS small procs (~9 lines each)."
+  (let ((s (list "namespace eval ::bench {\n    variable counter 0\n}\n\n")))
+    (dotimes (i nprocs)
+      (push (format (concat "# proc number %d\n"
+                            "proc ::bench::step%d {a b} {\n"
+                            "    set v%d [expr {$a + $b}]\n"
+                            "    set msg \"step %d = $v%d\"\n"
+                            "    if {$v%d > 10} {\n"
+                            "        set v%d [expr {$v%d + 1}]\n"
+                            "    }\n"
+                            "    return $v%d\n"
+                            "}\n\n")
+                    i i i i i i i i i)
+            s))
+    (apply #'concat (nreverse s))))
+
+(defun exp333-now () (float-time))
+
+(defun exp333-wait-fresh-tokens (max-secs)
+  "Block until eglot has token data for the CURRENT docver; return seconds
+waited (or MAX-SECS on timeout).  This is the latency a user perceives
+between an edit and refreshed highlighting."
+  (let ((start (exp333-now))
+        (deadline (+ (exp333-now) max-secs)))
+    (while (and (< (exp333-now) deadline)
+                (or (null (cl-getf eglot--semtok-state :data))
+                    (not (eq (cl-getf eglot--semtok-state :docver)
+                             eglot--docver))))
+      (font-lock-flush) (font-lock-ensure)
+      (accept-process-output nil 0.02)
+      (sit-for 0.01))
+    (font-lock-flush) (font-lock-ensure)
+    (- (exp333-now) start)))
+
+(defun exp333-accum-count ()
+  "Count buffer positions carrying a duplicated eglot-semantic-* face."
+  (length (t333-find-accumulated-faces
+           (cl-loop for pos from (point-min) below (point-max)
+                    collect (list pos (char-after pos)
+                                  (get-text-property pos 'face))))))
+
+(cl-defun exp333-run (compat nprocs)
+  "Drive the harsh edit sequence with COMPAT (nil/t). Return a plist of
+timings and the final accumulation count."
+  (let* ((tmpdir (expand-file-name "tmp/eglot_test" t333-repo))
+         (path (expand-file-name (format "exp-%s.tcl" (if compat "on" "off")) tmpdir))
+         (src (exp333-big-tcl nprocs))
+         (t333-eglot-compat compat)
+         (edit-times '()))
+    (make-directory tmpdir t)
+    (with-temp-file path (insert src))
+    ;; Connect + time first tokens.
+    (find-file path) (tcl-mode) (font-lock-mode 1)
+    (let* ((c (eglot--guess-contact))
+           (t0 (exp333-now)))
+      (eglot--connect (nth 0 c) (nth 1 c) (nth 2 c) (nth 3 c) (nth 4 c))
+      (let ((connect-tokens (exp333-wait-fresh-tokens 60)))
+        (let ((lines (count-lines (point-min) (point-max))))
+          ;; Harsh sequence: rename a var near the top, middle and bottom, then
+          ;; an edit-then-undo — each forced onto the wire and timed.
+          (dolist (needle (list (format "set v1 " )
+                                (format "set v%d " (/ nprocs 2))
+                                (format "set v%d " (- nprocs 2))))
+            (goto-char (point-min))
+            (when (search-forward needle nil t)
+              (replace-match (replace-regexp-in-string "set v" "set vv" needle) t t)
+              (eglot--signal-textDocument/didChange)
+              (push (exp333-wait-fresh-tokens 60) edit-times)))
+          ;; edit-then-undo near the middle.
+          (goto-char (point-min))
+          (when (search-forward (format "step%d = " (/ nprocs 2)) nil t)
+            (let ((p (match-beginning 0)))
+              (goto-char p) (insert "X")
+              (eglot--signal-textDocument/didChange)
+              (push (exp333-wait-fresh-tokens 60) edit-times)
+              (goto-char p) (delete-char 1)  ; undo
+              (eglot--signal-textDocument/didChange)
+              (push (exp333-wait-fresh-tokens 60) edit-times)))
+          (let ((accum (exp333-accum-count)))
+            (ignore-errors (eglot-shutdown (eglot-current-server) 1 nil))
+            (let ((kill-buffer-query-functions nil)) (kill-buffer (current-buffer)))
+            (list :compat compat :lines lines
+                  :connect-tokens connect-tokens
+                  :edit-times (nreverse edit-times)
+                  :accum accum)))))))
+
+(defun exp333-report (r)
+  (let ((et (plist-get r :edit-times)))
+    (princ (format "  compat=%-3s lines=%d  connect+first-tokens=%.2fs  edits: %s  mean-edit=%.2fs  ACCUM=%d\n"
+                   (if (plist-get r :compat) "ON" "off")
+                   (plist-get r :lines)
+                   (plist-get r :connect-tokens)
+                   (mapconcat (lambda (x) (format "%.2fs" x)) et " ")
+                   (if et (/ (apply #'+ et) (float (length et))) 0.0)
+                   (plist-get r :accum)))))
+
+(cl-defun exp333-stress (compat nprocs)
+  "Reproduce the reporter's stale-window trigger: rapid edit→undo bursts
+that do NOT wait for the token response, so eglot repaints from stale
+state while responses lag / are dropped.  Return accumulation count."
+  (let* ((tmpdir (expand-file-name "tmp/eglot_test" t333-repo))
+         (path (expand-file-name (format "stress-%s.tcl" (if compat "on" "off")) tmpdir))
+         (src (exp333-big-tcl nprocs))
+         (t333-eglot-compat compat))
+    (make-directory tmpdir t)
+    (with-temp-file path (insert src))
+    (find-file path) (tcl-mode) (font-lock-mode 1)
+    (let ((c (eglot--guess-contact)))
+      (eglot--connect (nth 0 c) (nth 1 c) (nth 2 c) (nth 3 c) (nth 4 c)))
+    (exp333-wait-fresh-tokens 60)   ; clean baseline (sets eglot--semtok-faces)
+    ;; Rapid edit→undo bursts near the middle, repainting WITHOUT fully
+    ;; draining the server response each time — this keeps eglot on its stale
+    ;; `eglot--semtok-font-lock-2' repaint path across many font-lock passes.
+    (goto-char (point-min))
+    (search-forward (format "step%d = " (/ nprocs 2)) nil t)
+    (let ((p (match-beginning 0)))
+      (dotimes (_ 30)
+        (goto-char p) (insert "Z")
+        (eglot--signal-textDocument/didChange)
+        (font-lock-flush) (font-lock-ensure)      ; stale repaint (no drain)
+        (accept-process-output nil 0.005)
+        (goto-char p) (delete-char 1)             ; undo
+        (eglot--signal-textDocument/didChange)
+        (font-lock-flush) (font-lock-ensure)      ; stale repaint (no drain)
+        (accept-process-output nil 0.005)))
+    (font-lock-flush) (font-lock-ensure)
+    (let ((accum (exp333-accum-count)))
+      (ignore-errors (eglot-shutdown (eglot-current-server) 1 nil))
+      (let ((kill-buffer-query-functions nil)) (kill-buffer (current-buffer)))
+      accum)))
+
+(let ((nprocs (string-to-number (or (getenv "EXP_NPROCS") "600"))))  ; ~5400 lines
+  (princ (format "\n===== issue #333 differential + perf (nprocs=%d) =====\n" nprocs))
+  (let ((off (exp333-run nil nprocs))
+        (on  (exp333-run t   nprocs)))
+    (exp333-report off)
+    (exp333-report on)
+    (princ "\n  -- stale-window stress (rapid edit/undo, no drain) --\n")
+    (let ((soff (exp333-stress nil nprocs))
+          (son  (exp333-stress t   nprocs)))
+      (princ (format "  stress accum: OFF=%d  ON=%d\n" soff son)))
+    (princ (format "\n  RESULT: accum OFF=%d  ON=%d  →  %s\n"
+                   (plist-get off :accum) (plist-get on :accum)
+                   (cond ((and (> (plist-get off :accum) 0)
+                               (= (plist-get on :accum) 0))
+                          "PROVEN: compat ON eliminates accumulation, off reproduces it")
+                         ((= (plist-get off :accum) (plist-get on :accum))
+                          "INCONCLUSIVE: accumulation same in both (batch paint may not reproduce)")
+                         (t "PARTIAL: accumulation differs but not cleanly")))))
+  (kill-emacs 0))

--- a/scripts/eglot_test/prove_fix.el
+++ b/scripts/eglot_test/prove_fix.el
@@ -1,0 +1,112 @@
+;; -*- lexical-binding: t -*-
+;;; prove_fix.el — prove which fix actually stops the issue #333 accumulation.
+;;
+;; Reproduces the painter accumulation (one clean paint + N stale repaints) and
+;; measures the worst per-character `eglot-semantic-*' face stack under three
+;; configurations:
+;;
+;;   1. baseline            — stock eglot, our server (compat OFF)
+;;   2. server compat mode  — stock eglot, our server (compat ON)  [inert]
+;;   3. client painter fix  — eglot advised to strip stale `eglot-semantic-*'
+;;                            faces before each (re)paint, our server
+;;
+;; A fix "works" when the worst stack collapses to 1 (each char wears exactly
+;; one semantic face).  This isolates whether the fix belongs on the server
+;; (config mode) or the client (painter).
+;;
+;;   TCL_LSP_REPO=$PWD TCL_LSP_SERVER_BIN=$PWD/target/release/tcl-lsp-server \
+;;   TCL_LSP_T333_NOEXEC=1 RI_FILE=/path/to/real.tcl \
+;;   emacs -Q -batch -L tmp/elpa/eglot-1.24 -L tmp/elpa/jsonrpc-1.0.29 \
+;;     -l scripts/eglot_test/test_issue333.el \
+;;     -l scripts/eglot_test/prove_fix.el
+
+;;; --- the candidate client-side fix (generalises georgtree's workaround) ---
+;; Strip any `eglot-semantic-*' faces from BEG..END before eglot repaints, so
+;; `add-face-text-property' can't stack a new copy on top of the old ones.
+
+(defun pf--semantic-face-p (f)
+  (and (symbolp f) (string-prefix-p "eglot-semantic-" (symbol-name f))))
+
+(defun pf--strip (face)
+  (cond ((null face) nil)
+        ((pf--semantic-face-p face) nil)
+        ((symbolp face) face)
+        ((and (consp face) (keywordp (car face))) face)
+        ((consp face)
+         (let ((new (delq nil (mapcar #'pf--strip face))))
+           (cond ((null new) nil) ((null (cdr new)) (car new)) (t new))))
+        (t face)))
+
+(defun pf--clear (beg end &rest _)
+  (with-silent-modifications
+    (let ((pos beg))
+      (while (< pos end)
+        (let* ((next (or (next-single-property-change pos 'face nil end) end))
+               (new (pf--strip (get-text-property pos 'face))))
+          (if new (put-text-property pos next 'face new)
+            (remove-text-properties pos next '(face nil)))
+          (setq pos next))))))
+
+(defun pf-install-fix ()
+  (advice-add 'eglot--semtok-font-lock-1 :before #'pf--clear)
+  (advice-add 'eglot--semtok-font-lock-2 :before #'pf--clear))
+(defun pf-remove-fix ()
+  (advice-remove 'eglot--semtok-font-lock-1 #'pf--clear)
+  (advice-remove 'eglot--semtok-font-lock-2 #'pf--clear))
+
+;;; --- reproduction ---------------------------------------------------------
+
+(defun pf-worst ()
+  (cl-loop for pos from (point-min) below (point-max)
+           maximize (length (cl-remove-if-not
+                             #'pf--semantic-face-p
+                             (t333-face-list (get-text-property pos 'face))))))
+
+(defun pf-worst-dup ()
+  "Deepest count of a SINGLE repeated eglot-semantic-* face on any char
+ (>1 means true accumulation; 1 means every face is distinct/legitimate)."
+  (cl-loop for pos from (point-min) below (point-max)
+           for sem = (cl-remove-if-not #'pf--semantic-face-p
+                                       (t333-face-list (get-text-property pos 'face)))
+           maximize (or (cl-loop for f in (cl-remove-duplicates sem :test #'eq)
+                                 maximize (cl-count f sem :test #'eq))
+                        0)))
+
+(cl-defun pf-run (label compat fix &key (repaints 6))
+  (let* ((tmpdir (expand-file-name "tmp/eglot_test" t333-repo))
+         (realfile (getenv "RI_FILE"))
+         (path (expand-file-name "pf.tcl" tmpdir))
+         (t333-eglot-compat compat))
+    (make-directory tmpdir t)
+    (if (and realfile (file-exists-p realfile)) (copy-file realfile path t)
+      (with-temp-file path
+        (dotimes (i 200)
+          (insert (format "proc ::ns::s%d {a b} {\n    set v%d [expr {$a+$b}]\n    return \"$v%d ok\"\n}\n" i i i)))))
+    (when fix (pf-install-fix))
+    (unwind-protect
+        (progn
+          (t333-connect-and-open path)
+          (t333-pump-until-semtok 15)
+          (let ((data (cl-getf eglot--semtok-state :data)))
+            (with-silent-modifications
+              (remove-text-properties (point-min) (point-max)
+                                      '(face nil eglot--semtok-faces nil eglot--semtok-token nil)))
+            (eglot--semtok-font-lock-1 (point-min) (point-max) data)
+            (dotimes (_ repaints) (eglot--semtok-font-lock-2 (point-min) (point-max)))
+            (let ((worst (pf-worst)) (dup (pf-worst-dup)) (ntok (/ (length data) 5)))
+              (t333-disconnect)
+              (princ (format "  %-34s worst-stack=%2d  worst-DUPLICATE=%d  (ntok=%d)\n" label worst dup ntok))
+              worst)))
+      (when fix (pf-remove-fix)))))
+
+(princ "\n===== issue #333: which fix actually collapses the face stack? =====\n")
+(princ (format "  file=%s  (worst-stack=1 means fixed; >1 means accumulating)\n\n"
+               (or (getenv "RI_FILE") "synthetic")))
+(let ((b (pf-run "1. baseline (server compat OFF)" nil nil))
+      (m (pf-run "2. server eglot-compat mode ON" t   nil))
+      (c (pf-run "3. client painter fix (compat OFF)" nil t)))
+  (princ (format "\n  RESULT: baseline=%d  server-mode=%d  client-fix=%d\n" b m c))
+  (princ (format "  → server mode %s ; client painter fix %s\n"
+                 (if (< m b) "reduces accumulation" "does NOT help (inert)")
+                 (if (<= c 1) "PROVABLY fixes it" (format "reduces to %d" c)))))
+(kill-emacs 0)

--- a/scripts/eglot_test/repro_batch.el
+++ b/scripts/eglot_test/repro_batch.el
@@ -1,0 +1,100 @@
+;; -*- lexical-binding: t -*-
+;;; repro_batch.el — deterministic, fast reproduction of issue #333's painter
+;;; accumulation, driving eglot's real painter functions (no redisplay needed).
+;;
+;; The reporter's trigger is: edit → the token response lags → eglot repaints
+;; the region from stale local state several times before the fresh tokens
+;; land.  Those stale repaints go through `eglot--semtok-font-lock-2', which
+;; re-applies faces from the `eglot--semtok-faces' text property with
+;; `add-face-text-property' (additive) and never strips the prior
+;; `eglot-semantic-*' faces first — so each stale repaint stacks another copy.
+;;
+;; This script reproduces exactly that, deterministically and in batch: it does
+;; ONE clean paint (`eglot--semtok-font-lock-1', which seeds `eglot--semtok-faces')
+;; then N stale repaints (`eglot--semtok-font-lock-2') and counts accumulated
+;; faces — with the server-side eglot-compat mode OFF and ON.  Because the
+;; painter reads token data the server sends identically in both modes, this
+;; isolates whether the capability shape changes the client-side accumulation.
+;;
+;;   TCL_LSP_REPO=$PWD TCL_LSP_SERVER_BIN=$PWD/target/release/tcl-lsp-server \
+;;   TCL_LSP_T333_NOEXEC=1 RI_FILE=/path/to/real.tcl \
+;;   emacs -Q -batch -L tmp/elpa/eglot-1.24 -L tmp/elpa/jsonrpc-1.0.29 \
+;;     -l scripts/eglot_test/test_issue333.el \
+;;     -l scripts/eglot_test/repro_batch.el
+
+(defun rb-worst (snap)
+  (cl-loop for cell in snap
+           for eg = (cl-remove-if-not
+                     (lambda (f) (and (symbolp f)
+                                      (string-prefix-p "eglot-semantic-" (symbol-name f))))
+                     (t333-face-list (caddr cell)))
+           maximize (length eg)))
+
+(defun rb-snapshot ()
+  (cl-loop for pos from (point-min) below (point-max)
+           collect (list pos (char-after pos) (get-text-property pos 'face))))
+
+(cl-defun rb-run (compat &key (repaints 6))
+  "Seed one clean paint, then REPAINTS stale repaints; return accumulation."
+  (let* ((tmpdir (expand-file-name "tmp/eglot_test" t333-repo))
+         (realfile (getenv "RI_FILE"))
+         (path (expand-file-name (format "rb-%s.tcl" (if compat "on" "off")) tmpdir))
+         (t333-eglot-compat compat))
+    (make-directory tmpdir t)
+    (if (and realfile (file-exists-p realfile))
+        (copy-file realfile path t)
+      (with-temp-file path
+        (dotimes (i 200)
+          (insert (format (concat "proc ::ns::step%d {a b} {\n"
+                                  "    set v%d [expr {$a + $b}]\n"
+                                  "    set msg \"step %d = $v%d\"\n"
+                                  "    return $v%d\n}\n") i i i i i)))))
+    (t333-connect-and-open path)
+    (t333-pump-until-semtok 15)
+    (let ((data (cl-getf eglot--semtok-state :data)))
+      (unless (and data (vectorp data) (> (length data) 0))
+        (t333-disconnect)
+        (cl-return-from rb-run (list :compat compat :error "no tokens")))
+      ;; Start from a genuinely clean slate (font-lock already painted once
+      ;; during the pump), then do ONE clean paint that seeds
+      ;; `eglot--semtok-faces' across the buffer — baseline accumulation ~0.
+      (with-silent-modifications
+        (remove-text-properties (point-min) (point-max)
+                                '(face nil eglot--semtok-faces nil eglot--semtok-token nil)))
+      (eglot--semtok-font-lock-1 (point-min) (point-max) data)
+      (let ((after-clean (t333-find-accumulated-faces (rb-snapshot))))
+        ;; Now the stale-window repaints: eglot's `-2' path, called the way a
+        ;; lagging response + font-lock refontification would call it.
+        (dotimes (_ repaints)
+          (eglot--semtok-font-lock-2 (point-min) (point-max)))
+        (let* ((snap (rb-snapshot))
+               (res (list :compat compat
+                          :clean-accum (length after-clean)
+                          :accum (length (t333-find-accumulated-faces snap))
+                          :worst (rb-worst snap)
+                          :ntok (/ (length data) 5))))
+          (t333-disconnect)
+          res)))))
+
+(let ((repaints (string-to-number (or (getenv "RB_REPAINTS") "6"))))
+  (princ "\n===== issue #333 painter reproduction (batch, deterministic) =====\n")
+  (princ (format "  file=%s  repaints=%d\n"
+                 (or (getenv "RI_FILE") "synthetic") repaints))
+  (let ((off (rb-run nil :repaints repaints))
+        (on  (rb-run t   :repaints repaints)))
+    (princ (format "  compat=off  ntok=%s  after-1-clean-paint=%s  after-%d-stale-repaints: pos=%s worst-stack=%s\n"
+                   (plist-get off :ntok) (plist-get off :clean-accum) repaints
+                   (plist-get off :accum) (plist-get off :worst)))
+    (princ (format "  compat=ON   ntok=%s  after-1-clean-paint=%s  after-%d-stale-repaints: pos=%s worst-stack=%s\n"
+                   (plist-get on :ntok) (plist-get on :clean-accum) repaints
+                   (plist-get on :accum) (plist-get on :worst)))
+    (let ((oa (plist-get off :accum)) (na (plist-get on :accum)))
+      (princ (format "\n  RESULT: %s\n"
+                     (cond ((not (numberp oa)) "ERROR — no tokens")
+                           ((and (> oa 0) (= na 0))
+                            "PROVEN — compat ON eliminates the accumulation OFF exhibits")
+                           ((and (> oa 0) (< na oa))
+                            (format "PARTIAL — compat ON reduces accumulation (%d→%d)" oa na))
+                           ((= oa 0) "NOT-REPRODUCED — no accumulation even OFF")
+                           (t "NO-DIFFERENCE — accumulation identical ON and OFF (the capability shape does not touch eglot's painter)")))))
+    (kill-emacs 0)))

--- a/scripts/eglot_test/repro_interactive.el
+++ b/scripts/eglot_test/repro_interactive.el
@@ -1,0 +1,139 @@
+;; -*- lexical-binding: t -*-
+;;; repro_interactive.el — issue #333 under a REAL redisplay (run via xvfb).
+;;
+;; Batch Emacs never runs jit-lock/redisplay, so `eglot--semtok-font-lock-2`'s
+;; stale additive repaint never fires and the face accumulation can't be
+;; reproduced there.  A real GUI frame drives jit-lock during `redisplay', so
+;; that is where issue #333 actually appears.  We run the SAME rapid edit/undo
+;; burst with eglot-compat OFF and ON and count accumulated `eglot-semantic-*`
+;; faces after real redisplay, writing a RESULT line that self-classifies:
+;; PROVEN / PARTIAL / NO-DIFFERENCE / NOT-REPRODUCED.
+;;
+;; IMPORTANT: this needs a *real, reasonably fast* GUI Emacs.  A software
+;; `xvfb-run' frame renders each `redisplay' so slowly that even a small file
+;; times out — run it on your own graphical Emacs rather than in CI:
+;;
+;;   TCL_LSP_REPO=$PWD TCL_LSP_SERVER_BIN=$PWD/target/release/tcl-lsp-server \
+;;   TCL_LSP_T333_NOEXEC=1 RI_OUT=/tmp/ri.txt emacs -Q \
+;;     -L tmp/elpa/eglot-1.24 -L tmp/elpa/jsonrpc-1.0.29 \
+;;     -l scripts/eglot_test/test_issue333.el \
+;;     -l scripts/eglot_test/repro_interactive.el
+;;   # then read the result:  cat /tmp/ri.txt
+
+(defun ri-big-tcl (n)
+  (let ((s (list "namespace eval ::bench {\n    variable counter 0\n}\n\n")))
+    (dotimes (i n)
+      (push (format (concat "# proc %d\nproc ::bench::step%d {a b} {\n"
+                            "    set v%d [expr {$a + $b}]\n"
+                            "    set msg \"step %d = $v%d\"\n"
+                            "    if {$v%d > 10} {\n        set v%d [expr {$v%d + 1}]\n    }\n"
+                            "    return $v%d\n}\n\n")
+                    i i i i i i i i i)
+            s))
+    (apply #'concat (nreverse s))))
+
+(defun ri-worst-stack (snap)
+  "Deepest eglot-semantic-* face stack on any single position in SNAP."
+  (cl-loop for cell in snap
+           for eg = (cl-remove-if-not
+                     (lambda (f) (and (symbolp f)
+                                      (string-prefix-p "eglot-semantic-" (symbol-name f))))
+                     (t333-face-list (caddr cell)))
+           maximize (length eg)))
+
+(defun ri-snapshot ()
+  (cl-loop for pos from (point-min) below (point-max)
+           collect (list pos (char-after pos) (get-text-property pos 'face))))
+
+(cl-defun ri-run (compat nprocs)
+  "Reproduce issue #333 under real redisplay.  The trigger (from the
+reporter): edit → repaint while the token response is still in flight →
+undo, repeated.  We repaint with `redisplay' but do NOT drain the eglot
+process between edits, so `eglot--docver' keeps moving ahead of the
+server's answers and eglot stays on its stale `eglot--semtok-font-lock-2'
+additive-repaint path.  Returns accumulation at the burst peak and after
+a final settle."
+  (let* ((tmpdir (expand-file-name "tmp/eglot_test" t333-repo))
+         (realfile (getenv "RI_FILE"))
+         (path (expand-file-name (format "ri-%s.tcl" (if compat "on" "off")) tmpdir))
+         (t333-eglot-compat compat))
+    (make-directory tmpdir t)
+    (if (and realfile (file-exists-p realfile))
+        (copy-file realfile path t)
+      (with-temp-file path (insert (ri-big-tcl nprocs))))
+    (ignore-errors (set-frame-size (selected-frame) 80 40))
+    (find-file path) (tcl-mode) (font-lock-mode 1)
+    (let ((c (eglot--guess-contact)))
+      (eglot--connect (nth 0 c) (nth 1 c) (nth 2 c) (nth 3 c) (nth 4 c)))
+    (ignore-errors (eglot-semantic-tokens-mode 1))
+    ;; Baseline: settle real tokens on the region we'll edit (this sets the
+    ;; `eglot--semtok-faces' props the stale painter later re-adds).
+    (goto-char (point-min))
+    (forward-line (/ (count-lines (point-min) (point-max)) 2))
+    (recenter)
+    (let ((deadline (+ (float-time) 20)))
+      (while (and (< (float-time) deadline)
+                  (or (null (cl-getf eglot--semtok-state :data))
+                      (not (eq (cl-getf eglot--semtok-state :docver) eglot--docver))))
+        (font-lock-flush) (font-lock-ensure) (accept-process-output nil 0.05) (sit-for 0.02)))
+    (redisplay t)
+    ;; Stale-window burst: edit/undo at a visible position, repainting via
+    ;; `redisplay' WITHOUT draining the server between steps.
+    (let ((p (point)))
+      (dotimes (_ (string-to-number (or (getenv "RI_ITERS") "30")))
+        (goto-char p) (insert "Z")
+        (eglot--signal-textDocument/didChange)
+        (redisplay t)                 ; jit-lock paints visible region from stale state
+        (goto-char p) (delete-char 1) ; undo
+        (eglot--signal-textDocument/didChange)
+        (redisplay t)))
+    (redisplay t)
+    (let ((peak-snap (ri-snapshot)))
+      ;; Now fully settle (drain + clean repaint) and re-measure: does the
+      ;; accumulation clear on its own, or persist like the reporter sees?
+      (let ((deadline (+ (float-time) 15)))
+        (while (and (< (float-time) deadline)
+                    (not (eq (cl-getf eglot--semtok-state :docver) eglot--docver)))
+          (font-lock-flush) (accept-process-output nil 0.05) (sit-for 0.02) (redisplay t)))
+      (redisplay t)
+      (let* ((settled-snap (ri-snapshot))
+             (res (list :compat compat
+                        :peak-accum (length (t333-find-accumulated-faces peak-snap))
+                        :peak-worst (ri-worst-stack peak-snap)
+                        :settled-accum (length (t333-find-accumulated-faces settled-snap))
+                        :settled-worst (ri-worst-stack settled-snap))))
+        (ignore-errors (eglot-shutdown (eglot-current-server) 1 nil))
+        (let ((kill-buffer-query-functions nil)) (kill-buffer (current-buffer)))
+        res))))
+
+;; In a GUI (non-batch) Emacs `princ' writes to the echo area, not stdout, so
+;; results are written to a file the caller reads.
+(defun ri-emit (s)
+  (let ((f (or (getenv "RI_OUT")
+               (expand-file-name "tmp/eglot_test/ri-result.txt" t333-repo))))
+    (write-region s nil f 'append)))
+
+(let ((n (string-to-number (or (getenv "RI_NPROCS") "600"))))
+  (ri-emit (format "\n===== issue #333 interactive repro (real redisplay) =====\n"))
+  (ri-emit (format "  graphic=%s  file=%s\n" (display-graphic-p)
+                   (or (getenv "RI_FILE") (format "synthetic(nprocs=%d)" n))))
+  (ri-emit "  (peak = right after the edit/undo burst; settled = after draining + clean repaint)\n")
+  (let* ((off (with-timeout (150 (ri-emit "  (off run hit 150s timeout)\n") '(:peak-accum -1 :peak-worst -1 :settled-accum -1))
+                (prog1 (ri-run nil n) (ri-emit "  off run done\n"))))
+         (on  (with-timeout (150 (ri-emit "  (on run hit 150s timeout)\n") '(:peak-accum -1 :peak-worst -1 :settled-accum -1))
+                (prog1 (ri-run t n) (ri-emit "  on run done\n"))))
+         (op (plist-get off :peak-accum)) (opw (plist-get off :peak-worst))
+         (os (plist-get off :settled-accum))
+         (np (plist-get on :peak-accum)) (npw (plist-get on :peak-worst))
+         (ns (plist-get on :settled-accum)))
+    (ri-emit (format "  compat=off  peak: pos=%d worst-stack=%d   settled: pos=%d\n" op opw os))
+    (ri-emit (format "  compat=ON   peak: pos=%d worst-stack=%d   settled: pos=%d\n" np npw ns))
+    (ri-emit (format "\n  RESULT: %s\n"
+                     (cond ((and (> op 0) (= np 0))
+                            "PROVEN — compat ON eliminates the accumulation that OFF exhibits")
+                           ((and (> op 0) (< np op))
+                            (format "PARTIAL — compat ON reduces accumulation (%d→%d peak)" op np))
+                           ((= op 0)
+                            "NOT-REPRODUCED — even OFF shows no accumulation in this run")
+                           (t "NO-DIFFERENCE — accumulation the same ON and OFF")))))
+  (kill-emacs 0))

--- a/scripts/eglot_test/run.sh
+++ b/scripts/eglot_test/run.sh
@@ -1,12 +1,19 @@
 #!/usr/bin/env bash
 # Headless eglot reproducer for tcl-lsp issue #333.
 #
-# Drives a real eglot 1.23 (GNU ELPA) against `uv run python -m server` and
-# diffs eglot's `face` text-properties between (a) an in-buffer edit
-# sequence with delta semantic-token updates and (b) a fresh didOpen of
-# the same final content.  Mismatches reproduce the bug.
+# Drives a real eglot (GNU ELPA >= 1.20) against the native `tcl-lsp-server`
+# binary and:
+#   * diffs eglot's `face` text-properties between (a) an in-buffer edit
+#     sequence and (b) a fresh didOpen of the same final content, and
+#   * verifies our server-side eglot-compatibility mode
+#     (`tclLsp.compatibility.eglot`) end-to-end: the advertised capability
+#     shape flips and real eglot stops issuing `semanticTokens/full/delta`.
+#
+# This is NOT part of `make test` / CI gates — it needs network (to install
+# eglot) and a real Emacs, and it exercises upstream eglot internals.
 #
 # Usage:    scripts/eglot_test/run.sh [LOGFILE]
+# Env:      TCL_LSP_SERVER_BIN  path to a prebuilt tcl-lsp-server (skips build)
 # Exit:     0=all scenarios pass, 1=at least one mismatch, 2=script error
 set -euo pipefail
 repo="$(cd "$(dirname "$0")/../.." && pwd)"
@@ -19,6 +26,28 @@ if ! command -v emacs >/dev/null 2>&1; then
   echo "emacs not installed; install with: sudo apt-get install -y emacs-nox" >&2
   exit 2
 fi
+
+# 1b. Locate (or build) the native tcl-lsp-server binary.
+if [ -n "${TCL_LSP_SERVER_BIN:-}" ] && [ -x "${TCL_LSP_SERVER_BIN}" ]; then
+  server_bin="$TCL_LSP_SERVER_BIN"
+else
+  server_bin=""
+  for cand in "$repo/target/release/tcl-lsp-server" "$repo/target/debug/tcl-lsp-server"; do
+    if [ -x "$cand" ]; then server_bin="$cand"; break; fi
+  done
+  if [ -z "$server_bin" ]; then
+    echo "Building tcl-lsp-server (release)..." >&2
+    # The workspace manifest is the repo-root Cargo.toml; run cargo from there
+    # (there is no rust/Cargo.toml) with the -p form used elsewhere.
+    if ! (cd "$repo" && cargo build --release -p tcl-lsp-server) >&2; then
+      echo "cargo build failed; build tcl-lsp-server yourself and set TCL_LSP_SERVER_BIN" >&2
+      exit 2
+    fi
+    server_bin="$repo/target/release/tcl-lsp-server"
+  fi
+fi
+export TCL_LSP_SERVER_BIN="$server_bin"
+echo "Using server binary: $server_bin" >&2
 
 # 2. Build -L args from any existing ELPA dirs (used both for the
 #    capability probe below and for the final harness invocation).
@@ -76,7 +105,7 @@ emacs -Q -batch \
   "${load_args[@]}" \
   --eval "(setq debug-on-error t)" \
   -l "$repo/scripts/eglot_test/test_issue333.el" 2>&1 | tee "$log" \
-  | { grep -E "^(==========|  (text-equal|PASS|FAIL|XFAIL|XPASS|--|pos=|edit=|reload=|[a-z][a-z0-9-]+ +(PASS|FAIL|XFAIL|XPASS)))" || true; }
+  | { grep -E "^(==========|  (text-equal|protocol|default |compat |PASS|FAIL|XFAIL|XPASS|--|pos=|edit=|reload=|[a-z][a-z0-9-]+ +(PASS|FAIL|XFAIL|XPASS)))" || true; }
 status="${PIPESTATUS[0]}"
 echo
 echo "Full log: $log"

--- a/scripts/eglot_test/run.sh
+++ b/scripts/eglot_test/run.sh
@@ -5,9 +5,10 @@
 # binary and:
 #   * diffs eglot's `face` text-properties between (a) an in-buffer edit
 #     sequence and (b) a fresh didOpen of the same final content, and
-#   * verifies our server-side eglot-compatibility mode
-#     (`tclLsp.compatibility.eglot`) end-to-end: the advertised capability
-#     shape flips and real eglot stops issuing `semanticTokens/full/delta`.
+#   * verifies the server's incremental `semanticTokens/full/delta`
+#     end-to-end (the `semantic-tokens-delta` scenario): after a
+#     token-changing edit, real eglot's `full/delta` response carries
+#     `edits` (only the changed tokens) rather than a full `data` re-send.
 #
 # This is NOT part of `make test` / CI gates — it needs network (to install
 # eglot) and a real Emacs, and it exercises upstream eglot internals.

--- a/scripts/eglot_test/test_issue333.el
+++ b/scripts/eglot_test/test_issue333.el
@@ -1,24 +1,39 @@
 ;; -*- lexical-binding: t -*-
 ;;; test_issue333.el — headless eglot reproduction harness for issue #333
 ;;
-;; Drives eglot 1.23 (GNU ELPA) against `uv run python -m server` from a
-;; batch Emacs.  For each defined SCENARIO:
+;; Drives a real eglot (GNU ELPA >= 1.20) against the native
+;; `tcl-lsp-server' binary from a batch Emacs.  Two jobs:
+;;
+;;   A. Reproduce the upstream painter bug (issue #333) and confirm it is
+;;      client-side (`t333-painter-accumulation-test').
+;;   B. Verify the server's `semanticTokens/full/delta' end-to-end: after
+;;      an edit, real eglot receives an actual delta and applies it via
+;;      `eglot--semtok-apply-delta-edits' rather than the server re-sending
+;;      the whole token stream (`t333-delta-test').
+;;
+;; This harness is intentionally NOT part of `make test' / CI gates: it
+;; needs network access (to install eglot) and a real Emacs, and it
+;; exercises upstream eglot internals we can't fix from the server side.
+;; Run it by hand via `scripts/eglot_test/run.sh'.
+;;
+;; For each scenario the per-edit reproducer:
 ;;   1. open a Tcl file
 ;;   2. make a series of edits (each triggers didChange, possibly without
 ;;      waiting for the resulting semantic-tokens response)
 ;;   3. capture eglot's `face' property at every position (snapshot A)
 ;;   4. kill+reopen the file (sends didClose+didOpen → fresh /full request)
 ;;   5. capture face property again (snapshot B)
-;;   6. diff A vs B; mismatch ⇒ bug reproduced.
+;;   6. diff A vs B; mismatch ⇒ real LSP delta-correctness bug.
 ;;
-;; Exits 0 if all scenarios pass, 1 if any reproduces a bug, 2 on error.
+;; Exits 0 if all non-xfail scenarios and the delta assertions pass,
+;; 1 if any real regression is found, 2 on error.
 
 (require 'eglot)
 (require 'tcl)
 (require 'cl-lib)
 
 (unless (fboundp 'eglot-semantic-tokens-mode)
-  (princ "FATAL: this eglot has no eglot-semantic-tokens-mode (need >= 1.23).\n")
+  (princ "FATAL: this eglot has no eglot-semantic-tokens-mode (need >= 1.20).\n")
   (princ (format "  loaded from: %s\n" (locate-library "eglot")))
   (kill-emacs 3))
 
@@ -40,9 +55,33 @@
 (defvar t333-repo (or (getenv "TCL_LSP_REPO")
                       (expand-file-name default-directory)))
 
+;;; -----------------------------------------------------------------------
+;;; Server binary
+
+(defun t333-server-bin ()
+  "Resolve the native `tcl-lsp-server' binary to launch.
+Honours $TCL_LSP_SERVER_BIN, else prefers a release build over a debug
+build under the repo's cargo target dir."
+  (or (let ((env (getenv "TCL_LSP_SERVER_BIN")))
+        (and env (file-exists-p env) env))
+      (cl-loop for rel in '("target/release/tcl-lsp-server"
+                            "target/debug/tcl-lsp-server"
+                            "rust/target/release/tcl-lsp-server"
+                            "rust/target/debug/tcl-lsp-server")
+               for abs = (expand-file-name rel t333-repo)
+               when (file-exists-p abs) return abs)
+      (error "tcl-lsp-server binary not found; build it or set TCL_LSP_SERVER_BIN")))
+
 (setq eglot-server-programs
-      `((tcl-mode . ("uv" "run" "--directory" ,t333-repo
-                     "--no-dev" "python" "-m" "server"))))
+      `((tcl-mode . (,(t333-server-bin)))))
+
+;; Historical toggle from an earlier experiment (an "eglot compatibility mode"
+;; that dropped `full/delta' + `range').  That mode was removed once the data
+;; showed it made no difference — the server now implements proper
+;; `semanticTokens/full/delta' deltas for every editor instead.  The variable
+;; is kept (inert — the server ignores it) so the diagnostic scripts under this
+;; directory that still bind it continue to load; binding it has no effect.
+(defvar t333-eglot-compat nil)
 
 
 ;;; -----------------------------------------------------------------------
@@ -66,16 +105,6 @@
       (accept-process-output nil 0.05)
       (sit-for 0.02)))
   (font-lock-flush) (font-lock-ensure))
-
-(defun t333-paint-from-cache ()
-  "Force eglot's semtok painter to run with the current cached data.
-Needed in batch mode because font-lock-mode is off and the keyword
-form may not get re-invoked automatically after an async response."
-  (when (and (cl-getf eglot--semtok-state :data)
-             (fboundp 'eglot--semtok-font-lock-1))
-    (eglot--semtok-font-lock-1
-     (point-min) (point-max)
-     (cl-getf eglot--semtok-state :data))))
 
 (defun t333-snapshot ()
   "Return list of (POS CHAR FACE TOK-FACES TOK-NAMES) for every char.
@@ -138,7 +167,7 @@ edited buffer's token state and a fresh full-reload's token state."
 
 (defun t333-find-accumulated-faces (snap)
   "Return positions in SNAP whose `face' contains a duplicated eglot face.
-This catches the upstream eglot bug where `eglot--semtok-font-lock-1'
+This catches the upstream eglot bug where the semantic-token painter
 fails to strip its previous `eglot-semantic-*' faces from the `face'
 property before re-applying, causing each repaint to append another
 copy.  See https://github.com/bitwisecook/tcl-lsp/issues/333."
@@ -201,6 +230,35 @@ not the upstream painter accumulation from issue #333."
     (kill-buffer (current-buffer))
     (t333-pump 1 "post-disconnect")))
 
+(defun t333-semtok-full-shape ()
+  "Return the `:full' field of the server's semanticTokensProvider.
+Either the symbol t (bare boolean form) or a plist like (:delta t)."
+  (let ((prov (eglot-server-capable :semanticTokensProvider)))
+    (if (and (listp prov) (plist-member prov :full))
+        (plist-get prov :full)
+      prov)))
+
+(defun t333-count-semtok-requests ()
+  "Return (FULL . DELTA), the number of semanticTokens requests eglot
+sent on the current connection, read from its jsonrpc events buffer.
+Counts `full/delta' separately from plain `full' (the latter regex
+excludes the `/delta' suffix)."
+  (let* ((server (eglot-current-server))
+         (events-buf (and server (jsonrpc-events-buffer server)))
+         (full 0) (delta 0))
+    (when (buffer-live-p events-buf)
+      (with-current-buffer events-buf
+        (save-excursion
+          (goto-char (point-min))
+          (while (re-search-forward "semanticTokens/full/delta" nil t)
+            (cl-incf delta))
+          (goto-char (point-min))
+          ;; `full' not followed by `/delta' — a negative lookahead via an
+          ;; explicit non-`/' (or end) terminator.
+          (while (re-search-forward "semanticTokens/full\\(?:[^/]\\|$\\)" nil t)
+            (cl-incf full)))))
+    (cons full delta)))
+
 
 ;;; -----------------------------------------------------------------------
 ;;; Scenarios
@@ -256,13 +314,6 @@ not the upstream painter accumulation from issue #333."
                (t333-pump 1)))
 
    `(:name "insert-line-top"
-     ;; Marked XFAIL: same eglot delta-painter timing surface as
-     ;; ``rename-only`` — under heavy parallel load (``make -j 4`` in
-     ;; ``test-slow``) the painter occasionally leaves stale
-     ;; ``eglot-semantic-*`` faces on positions whose token kind
-     ;; should have shifted after the prepended comment line.  Passes
-     ;; consistently on standalone runs; only flakes when CPU is
-     ;; contended.  Mirrors issue #333; not a tcl-lsp server bug.
      :xfail "eglot delta painter leaves stale eglot-semantic-* faces under load (issue #333)"
      :initial ,(concat "set a 1\nset b 2\nset c 3\n")
      :edits ,(lambda ()
@@ -271,12 +322,6 @@ not the upstream painter accumulation from issue #333."
                (t333-pump 1)))
 
    `(:name "delete-line-middle"
-     ;; Marked XFAIL: same eglot delta-painter timing surface as
-     ;; ``rename-only`` / ``insert-line-top`` — flakes under
-     ;; ``test-slow``'s parallel ``make -j 4`` (especially with the
-     ;; extra ensure_owned allocations from the cmdAH cascade fix
-     ;; adding a little more CPU pressure to the runtime path).
-     ;; Standalone runs pass consistently.  Mirrors issue #333.
      :xfail "eglot delta painter leaves stale eglot-semantic-* faces under load (issue #333)"
      :initial ,(concat
                 "proc foo {a b} {\n"
@@ -293,13 +338,6 @@ not the upstream painter accumulation from issue #333."
                (t333-pump 1)))
 
    `(:name "rapid-fire-no-wait"
-     ;; Marked XFAIL: this exercises eglot's didChange request
-     ;; coalescing, which is timing-sensitive and known to drop
-     ;; intermediate edits on some eglot/jsonrpc combinations.  The
-     ;; scenario reproduces the upstream behaviour rather than testing
-     ;; the tcl-lsp server, so we don't fail the suite when it
-     ;; mismatches.  If it ever passes consistently we'll remove the
-     ;; XFAIL and start guarding against regression.
      :xfail "eglot didChange coalescing is timing-dependent upstream"
      :initial ,(concat
                 "proc f {a b} {\n"
@@ -308,8 +346,6 @@ not the upstream painter accumulation from issue #333."
                 "    return [expr {$x + $y + $a + $b}]\n"
                 "}\n")
      :edits ,(lambda ()
-               ;; A burst of edits without waiting between — exercises
-               ;; eglot's request coalescing.
                (goto-char (point-min))
                (insert "# 1\n")
                (insert "# 2\n")
@@ -320,10 +356,6 @@ not the upstream painter accumulation from issue #333."
                (t333-pump 1)))
 
    `(:name "user-issue-code"
-     ;; The actual code from the screenshots.  Marked XFAIL for the
-     ;; same reason as ``delete-line-middle`` — eglot painter timing
-     ;; flakes under heavy parallel CPU contention (issue #333).
-     ;; Standalone runs pass.
      :xfail "eglot delta painter leaves stale eglot-semantic-* faces under load (issue #333)"
      :initial ,(concat
                 "set iniFile config.ini\n"
@@ -340,7 +372,6 @@ not the upstream painter accumulation from issue #333."
                 "}\n"
                 "catch {file delete -force -- $rawFileNameOp}\n")
      :edits ,(lambda ()
-               ;; Reproduce a sequence the user might do.
                (goto-char (point-min))
                (search-forward "Solver 0")
                (replace-match "Disabled 0")
@@ -364,7 +395,6 @@ not the upstream painter accumulation from issue #333."
                 "    return $total\n"
                 "}\n")
      :edits ,(lambda ()
-               ;; Type-by-character into the proc body.
                (goto-char (point-min))
                (search-forward "set total 0")
                (forward-char 1)
@@ -398,23 +428,9 @@ not the upstream painter accumulation from issue #333."
     (t333-pump-until-semtok 5)
     (let ((edited-text (buffer-string))
           (snap-edited (t333-snapshot))
-          ;; Look for our server's [timing] semanticTokens log lines in
-          ;; the events buffer (window/logMessage notifications).
-          (events-buf (cl-find-if
-                       (lambda (b) (string-match-p "EVENTS for" (buffer-name b)))
-                       (buffer-list))))
-      (when events-buf
-        (let ((tokens 0) (deltas 0))
-          (with-current-buffer events-buf
-            (save-excursion
-              (goto-char (point-min))
-              (while (re-search-forward "semanticTokens/full[^/]" nil t)
-                (cl-incf tokens))
-              (goto-char (point-min))
-              (while (re-search-forward "semanticTokens/full/delta" nil t)
-                (cl-incf deltas))))
-          (princ (format "  protocol: %d /full requests, %d /full/delta requests\n"
-                         tokens deltas))))
+          (reqs (t333-count-semtok-requests)))
+      (princ (format "  protocol: %d /full requests, %d /full/delta requests\n"
+                     (car reqs) (cdr reqs)))
       (t333-disconnect)
 
       ;; Phase 2: fresh open of the saved file.
@@ -430,28 +446,11 @@ not the upstream painter accumulation from issue #333."
         (let ((diff (t333-diff snap-edited snap-reload))
               (accum-edited (t333-find-accumulated-faces snap-edited))
               (accum-reload (t333-find-accumulated-faces snap-reload)))
-          ;; Bug-mode A: real delta-correctness mismatch between the
-          ;; post-edit buffer's token state and a fresh full-reload's
-          ;; token state.  ``t333-diff`` already deduplicates the
-          ;; upstream painter's accumulated faces, so any diff here is
-          ;; a genuine LSP server bug and fails the scenario.
           (when diff
             (princ (format "  FAIL [diff]: %d positions differ\n" (length diff)))
             (cl-loop for d in diff for k from 0 below 12
                      do (princ (format "    pos=%4d char=%c edit=%S  reload=%S\n"
                                        (nth 0 d) (nth 1 d) (nth 2 d) (nth 3 d)))))
-          ;; Bug-mode B (issue #333): same eglot-semantic-* face appears
-          ;; multiple times on a single character within one snapshot.
-          ;; This catches the upstream eglot painter accumulation bug
-          ;; (see ``t333-painter-accumulation-test`` for the deterministic
-          ;; regression detector).  It is *not* fatal here: under CPU
-          ;; pressure (e.g. ``test-slow`` running suites in parallel)
-          ;; the upstream bug bleeds into rename-only / many-small-edits
-          ;; / etc., but our LSP server can't fix it from this side.
-          ;; Report it as informational so the suite stays green for
-          ;; server changes; if the painter ever stops accumulating,
-          ;; ``painter-accumulation`` will loudly PASS and prompt us to
-          ;; drop the workaround.
           (when accum-edited
             (princ (format "  INFO [accum-edited]: %d positions have duplicated eglot-semantic-* faces (upstream eglot bug, see issue #333)\n"
                            (length accum-edited)))
@@ -484,7 +483,11 @@ faces from the `face' property itself.  In interactive use, repeated
 re-paints (after edits, scrolls, theme changes) accumulate faces
 on the same character.  See
 https://github.com/bitwisecook/tcl-lsp/issues/333#issuecomment-4380862687
-for an end-user-facing example."
+for an end-user-facing example.
+
+Purely client-side: it drives the painter directly, so it accumulates
+regardless of what the server advertises.  It stays a deterministic
+canary for when eglot upstream fixes the painter."
   (princ "\n========== scenario: painter-accumulation (issue #333) ==========\n")
   (let* ((tmpdir (expand-file-name "tmp/eglot_test" t333-repo))
          (path (expand-file-name "painter-accum.tcl" tmpdir))
@@ -504,22 +507,15 @@ for an end-user-facing example."
         (princ "  ERROR: no semantic-tokens data after open\n")
         (t333-disconnect)
         (cl-return-from t333-painter-accumulation-test nil))
-      ;; Capture face state immediately after the natural fontify.
-      ;; `font-lock-flush' would re-unfontify, so we don't call it
-      ;; here — we want to see what happens when the painter is
-      ;; invoked twice consecutively, which is the real-world flow.
       (let ((before-second-paint
              (cl-loop for pos from (point-min) below (point-max)
                       collect (cons pos (get-text-property pos 'face)))))
-        ;; Second paint, no unfontify in between.
         (eglot--semtok-font-lock-1 (point-min) (point-max) data)
         (let* ((snap (cl-loop for pos from (point-min) below (point-max)
                               collect (list pos
                                             (char-after pos)
                                             (get-text-property pos 'face))))
                (accum (t333-find-accumulated-faces snap))
-               ;; Did the buffer's face state change between paints?
-               ;; If the painter were idempotent, it wouldn't.
                (after-second
                 (cl-loop for pos from (point-min) below (point-max)
                          collect (cons pos (get-text-property pos 'face))))
@@ -542,6 +538,68 @@ for an end-user-facing example."
                                        (nth 0 a) (nth 1 a) (nth 2 a))))
             nil)))))))
 
+(cl-defun t333-delta-test ()
+  "End-to-end verification of the server's `semanticTokens/full/delta'.
+
+Through a real eglot connection: the server advertises `full/delta' +
+`range', and after an edit eglot receives an actual DELTA and applies it
+via `eglot--semtok-apply-delta-edits' — rather than the server re-sending
+the whole token stream.  This is the incremental behaviour (like
+rust-analyzer) that keeps eglot's token round-trip, and its stale-repaint
+window, small on large files.  Returns t when every assertion holds."
+  (princ "\n========== scenario: semantic-tokens delta ==========\n")
+  (let* ((tmpdir (expand-file-name "tmp/eglot_test" t333-repo))
+         (path (expand-file-name "delta.tcl" tmpdir))
+         (initial (concat
+                   "namespace eval ::myns {}\n"
+                   "set iniFile config.ini\n"
+                   "proc compute {a b} {\n"
+                   "    set total [expr {$a + $b}]\n"
+                   "    return $total\n"
+                   "}\n"))
+         (ok t)
+         (got-delta nil))
+    (make-directory tmpdir t)
+    (with-temp-file path (insert initial))
+    (unwind-protect
+        (progn
+          (t333-connect-and-open path)
+          (t333-pump-until-semtok 8)
+          (let ((full (t333-semtok-full-shape))
+                (range (eglot-server-capable :semanticTokensProvider :range)))
+            (princ (format "  advertised: full=%S range=%S\n" full range))
+            (unless (and (listp full) (plist-get full :delta))
+              (setq ok nil) (princ "  FAIL: server must advertise full/delta\n"))
+            (unless (eq range t)
+              (setq ok nil) (princ "  FAIL: server must advertise range\n")))
+          ;; An edit that changes tokens; force the didChange flush (batch has
+          ;; no idle timer) so eglot's `full/delta' path engages.
+          (goto-char (point-min))
+          (insert "# new comment referencing $iniFile\n")
+          (eglot--signal-textDocument/didChange)
+          (t333-pump-until-semtok 8)
+          ;; A `full/delta' RESPONSE that carries `edits' (rather than a full
+          ;; `data' re-send) is the proof the server produced a real delta.
+          ;; Detected from the jsonrpc events buffer — `eglot--semtok-apply-
+          ;; delta-edits' is a `defsubst' inlined into byte-compiled eglot, so
+          ;; advising the symbol can't observe it.
+          (let* ((server (eglot-current-server))
+                 (buf (and server (jsonrpc-events-buffer server))))
+            (when (buffer-live-p buf)
+              (with-current-buffer buf
+                (goto-char (point-min))
+                (setq got-delta (re-search-forward "\"edits\"" nil t))))
+            (let ((reqs (t333-count-semtok-requests)))
+              (princ (format "  after edit: %d /full, %d /full/delta requests; delta-response=%s\n"
+                             (car reqs) (cdr reqs) (and got-delta t)))))
+          (unless got-delta
+            (setq ok nil)
+            (princ "  FAIL: no `edits' in any response — server re-sent a full stream?\n")))
+      (ignore-errors (t333-disconnect)))
+    (princ (if ok "  PASS — server sends real deltas and eglot applies them\n"
+             "  FAIL — delta path did not behave as expected\n"))
+    ok))
+
 (defun t333-main ()
   (let* ((scenario-results
           (mapcar (lambda (sc)
@@ -549,21 +607,16 @@ for an end-user-facing example."
                           (t333-run-scenario sc)
                           (plist-get sc :xfail)))
                   t333-scenarios))
-         ;; Painter-accumulation is informational: it deterministically
-         ;; reproduces an upstream eglot bug we cannot fix from the
-         ;; server side.  We expect it to FAIL on every eglot version up
-         ;; to and including the current GNU ELPA release; if it ever
-         ;; PASSes we'd want to know (and probably remove this XFAIL).
          (accum-pass (t333-painter-accumulation-test))
+         (delta-pass (t333-delta-test))
          ;; A scenario contributes to ``any-fail`` only if it failed AND
-         ;; isn't marked :xfail.  An XFAIL that unexpectedly passes
-         ;; (XPASS) is loud in the summary so we remember to drop the
-         ;; marker, but it doesn't fail the suite either — we'd rather
-         ;; surface the regression in a separate guard once stable.
-         (any-fail (cl-some (lambda (r)
-                              (and (not (nth 1 r))
-                                   (null (nth 2 r))))
-                            scenario-results)))
+         ;; isn't marked :xfail.  The delta test is a real gate for our
+         ;; server's `full/delta' implementation, so its failure fails the suite.
+         (any-fail (or (not delta-pass)
+                       (cl-some (lambda (r)
+                                  (and (not (nth 1 r))
+                                       (null (nth 2 r))))
+                                scenario-results))))
     (princ "\n========== summary ==========\n")
     (dolist (r scenario-results)
       (let* ((name (nth 0 r))
@@ -581,10 +634,16 @@ for an end-user-facing example."
     (princ (format "  %-25s %s\n" "painter-accumulation"
                    (cond (accum-pass "PASS (eglot bug appears fixed!)")
                          (t "XFAIL (known upstream eglot bug, see issue #333)"))))
+    (princ (format "  %-25s %s\n" "semantic-tokens-delta"
+                   (cond (delta-pass "PASS")
+                         (t "FAIL (full/delta implementation regressed)"))))
     (kill-emacs (if any-fail 1 0))))
 
-(condition-case err
-    (t333-main)
-  (error
-   (princ (format "ERROR: %S\n" err))
-   (kill-emacs 2)))
+;; Loading with TCL_LSP_T333_NOEXEC set defines the functions without running
+;; the suite — used to drive individual scenarios from a REPL / one-off eval.
+(unless (getenv "TCL_LSP_T333_NOEXEC")
+  (condition-case err
+      (t333-main)
+    (error
+     (princ (format "ERROR: %S\n" err))
+     (kill-emacs 2))))

--- a/scripts/eglot_test/test_issue333.el
+++ b/scripts/eglot_test/test_issue333.el
@@ -572,22 +572,28 @@ window, small on large files.  Returns t when every assertion holds."
               (setq ok nil) (princ "  FAIL: server must advertise full/delta\n"))
             (unless (eq range t)
               (setq ok nil) (princ "  FAIL: server must advertise range\n")))
-          ;; An edit that changes tokens; force the didChange flush (batch has
-          ;; no idle timer) so eglot's `full/delta' path engages.
-          (goto-char (point-min))
-          (insert "# new comment referencing $iniFile\n")
-          (eglot--signal-textDocument/didChange)
-          (t333-pump-until-semtok 8)
-          ;; A `full/delta' RESPONSE that carries `edits' (rather than a full
-          ;; `data' re-send) is the proof the server produced a real delta.
-          ;; Detected from the jsonrpc events buffer — `eglot--semtok-apply-
-          ;; delta-edits' is a `defsubst' inlined into byte-compiled eglot, so
-          ;; advising the symbol can't observe it.
+          ;; Capture the events-buffer end BEFORE the edit so we only inspect
+          ;; the region appended by this didChange's `full/delta' exchange —
+          ;; searching from `point-min' would match an `"edits"' from an
+          ;; earlier response (e.g. the initial `full') and false-pass.
           (let* ((server (eglot-current-server))
-                 (buf (and server (jsonrpc-events-buffer server))))
+                 (buf (and server (jsonrpc-events-buffer server)))
+                 (mark-before (and (buffer-live-p buf)
+                                   (with-current-buffer buf (point-max)))))
+            ;; An edit that changes tokens; force the didChange flush (batch has
+            ;; no idle timer) so eglot's `full/delta' path engages.
+            (goto-char (point-min))
+            (insert "# new comment referencing $iniFile\n")
+            (eglot--signal-textDocument/didChange)
+            (t333-pump-until-semtok 8)
+            ;; A `full/delta' RESPONSE that carries `edits' (rather than a full
+            ;; `data' re-send) is the proof the server produced a real delta.
+            ;; Detected from the jsonrpc events buffer — `eglot--semtok-apply-
+            ;; delta-edits' is a `defsubst' inlined into byte-compiled eglot, so
+            ;; advising the symbol can't observe it.
             (when (buffer-live-p buf)
               (with-current-buffer buf
-                (goto-char (point-min))
+                (goto-char (or mark-before (point-min)))
                 (setq got-delta (re-search-forward "\"edits\"" nil t))))
             (let ((reqs (t333-count-semtok-requests)))
               (princ (format "  after edit: %d /full, %d /full/delta requests; delta-response=%s\n"


### PR DESCRIPTION
## Summary

- **Implement real `semanticTokens/full/delta`.** The server used to answer every delta request by re-sending the whole token stream. It now caches the last stream served per URI (`resultId` + packed data) and, when a client's `previousResultId` matches, returns the minimal token-aligned edit from the core's existing `diff()` — the incremental behaviour rust-analyzer / clangd use, which benefits **every** editor that speaks `full/delta`. Unknown `previousResultId` still falls back to a full stream; cache evicted on `did_close`.
  - Per-edit payload on real code (`generalClasses.tcl`): **~62 B vs ~15 KB**. Dense ~5k-line file: **~169 B vs ~310 KB** (~1900× smaller).
- **Removed the short-lived `tclLsp.compatibility.eglot` capability toggle** (added earlier this branch): reproduction showed it made no difference to the issue #333 accumulation, so it's replaced by the deltas above. The server again always advertises `full: {delta: true}` + `range`.
- **Characterised issue #333.** Reproduced the reporter's accumulation deterministically against their real SpiceGenTcl sources — eglot stacks up to 14 `eglot-semantic-*` faces on a character (same face 7×). It reproduces identically with **rust-analyzer** and **clangd** (clangd worst) and not at all with **pyright** (no semantic tokens), so it is entirely eglot's additive painter (`eglot--semtok-font-lock-2`), not a tcl-lsp bug. The definitive client-side fix (strip stale faces before repaint) collapses the 7-deep stack to 1 and is now the top workaround in the Emacs docs. Deltas shrink the stale-repaint window that feeds it. Findings posted to #333.
- **Tests / tooling:** `semantic_tokens_reference_client.rs` drives a spec-correct reference client through harsh edits (mixed, edit-then-undo, rapid-fire, 5k+ lines) that must always equal a cold reopen, and `server_returns_real_delta_not_full_resend` pins the delta response shape + full fallback. The headless eglot harness under `scripts/eglot_test/` now drives the native binary and proves the delta path through real eglot (`semantic-tokens-delta`); diagnostic scripts capture the cross-server reproduction. None of the eglot harness runs in CI.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo build -p tcl-lsp-server
cargo clippy -p tcl-lsp-server            # clean
cargo test  -p tcl-lsp-server --test semantic_tokens_reference_client \
            --test semantic_tokens_e2e --test editor_features_e2e --lib
cargo fmt (repo rustfmt) --check          # clean on changed files
# headless eglot (not CI): painter-accumulation reproduces #333; semantic-tokens-delta passes
```

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No. This is an LSP-transport change (delta encoding of the same token stream) plus tests/docs; token content and the `semantic_tokens` query are unchanged.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A
- [ ] If I added a new compiler KCS note, I linked it from both READMEs. — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01J5t3einZBociVyGLWfdchV)_