### PR TITLE
fix(analyser): don't emit W215 for backslash-continued proc/method params

### DIFF
--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -63,6 +63,10 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-qa-rust-shim-env-vars.md](kcs-qa-rust-shim-env-vars.md) — what the
   `TCL_LSP_RUST_*` environment variables do and when to set them as the
   Python-to-Rust rewrite lands in chunks.
+- [kcs-qa-how-tcl-parses-lists.md](kcs-qa-how-tcl-parses-lists.md) — how
+  Tcl splits a list (and a `proc` / method parameter list) into elements
+  on whitespace, and how braces, quotes, and a trailing backslash line
+  continuation move those boundaries.
 
 ## How-Tos
 

--- a/docs/kcs/codes/kcs-diagnostic-w215-variable-name-unreachable-via-substitution.md
+++ b/docs/kcs/codes/kcs-diagnostic-w215-variable-name-unreachable-via-substitution.md
@@ -59,5 +59,7 @@ Add `# noqa: W215` at the end of the offending line.
 
 - [KCS codes index](README.md)
 - [Diagnostics feature](../features/kcs-feature-diagnostics.md)
+- [KCS: How does Tcl split a list into elements?](../kcs-qa-how-tcl-parses-lists.md)
+  — why a `\`-wrapped parameter list names the right variables.
 - Tcl(n) man page §"Variable substitution"
 - Related codes: `W212`

--- a/docs/kcs/kcs-qa-how-tcl-parses-lists.md
+++ b/docs/kcs/kcs-qa-how-tcl-parses-lists.md
@@ -1,0 +1,87 @@
+# KCS: How does Tcl split a list into elements?
+
+> **Audience:** User
+> **Type:** Q&A
+
+## Applies to
+
+all-editors
+
+## Question
+
+How does Tcl decide where one list element ends and the next begins, and
+what do braces, quotes, and a trailing backslash do to those boundaries?
+
+## Answer
+
+A Tcl list is a string that Tcl splits into elements on **whitespace**
+(spaces, tabs, and newlines). This is the same rule the interpreter uses
+for a `proc` or method **parameter list**, for the words iterated by
+`foreach`, and everywhere else a value is treated as a list. Braces,
+quotes, and backslashes change where those whitespace boundaries fall.
+
+### Braces group an element verbatim
+
+An element that starts with `{` runs to its matching `}`; braces nest, so
+the inner whitespace does **not** split the element. The bytes between the
+braces are taken literally — the one exception is a **backslash-newline**,
+which Tcl always collapses to a single space even inside braces (so the
+element stays one element, just with a space where the wrapped line was).
+
+```tcl
+llength {a {b c} d}   ;# 3 — {b c} is one element containing a space
+```
+
+### Quotes group with substitution
+
+An element that starts with `"` runs to its matching `"`, and Tcl performs
+backslash and variable substitution on the contents. Like braces, the
+enclosed whitespace does not split the element.
+
+```tcl
+llength {a "b c" d}   ;# 3 — "b c" is one element
+```
+
+### A backslash escapes the next character
+
+Outside braces, a backslash makes the following character part of the
+current element instead of acting on its own. So a backslash before a
+space or tab keeps that whitespace *inside* the element rather than ending
+it:
+
+```tcl
+llength {a\ b c}      ;# 2 — a\ b is one element "a b", then c
+```
+
+### The wrinkle: a trailing backslash before a newline is a *separator*
+
+The one backslash sequence that does **not** stay inside the element is
+**backslash-newline**. A `\` at the end of a line, immediately followed by
+the newline, collapses to a single space — and outside braces that space
+ends the current element and starts the next one. This is what lets a long
+list, such as a parameter list, wrap across several lines:
+
+```tcl
+method Fdjac2 {funct ifree n x fvec ldfjac epsfcn pdata nfev \
+               step dstep dside ddrtol \
+               ddatol} {
+    # ...
+}
+```
+
+Here `ldfjac … pdata nfev` and the wrapped `step …` are all separate
+parameters, and the last name on each wrapped line — `nfev`, `ddrtol` — is
+just that name. The trailing `\` is consumed as part of the line
+continuation, not kept on the name. Windows `\r\n` line endings behave the
+same way.
+
+The practical takeaway: wrap a long list wherever you like with a trailing
+`\`; the element that ends the line is complete, and the next element
+begins on the following line.
+
+## Related
+
+- [KCS index](README.md)
+- [KCS: Why does the analyser warn that a variable name is not reachable via $-substitution? (W215)](codes/kcs-diagnostic-w215-variable-name-unreachable-via-substitution.md)
+- [KCS: Tcl 9.0.3 corner cases for variable handling](kcs-tcl-corner-cases.md)
+- [Glossary](../GLOSSARY.md)

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -988,13 +988,11 @@ mod tests {
 
     #[test]
     fn param_list_with_backslash_continuation_no_spurious_w215() {
-        // A param list split across lines by `\<newline>` (collapsed to a space
-        // even inside braces) leaves the last param on the first line ending in a
-        // raw backslash in `parse_param_list`'s naive scan. The isolated body
-        // re-binds params with a synthetic `Str` token, which would flip W215's
-        // `braced` reachability heuristic and emit a spurious warning the full
-        // `analyse` path never produces. The shell walk already emits W215 for
-        // the declaration, so the isolated rebind must stay diagnostic-free.
+        // A param list split across lines by `\<newline>` list-parses as
+        // separate parameters (`parse_param_list` treats the continuation as an
+        // element separator, issue #743), so no param name ends in a raw
+        // backslash and neither the full `analyse` walk nor the isolated
+        // per-item rebind emits a spurious W215 unreachable-name warning.
         eq("proc foo {a b staticsok\\\n    c d} {\n  set x 1\n}\n");
         // Method form (instance vars + params rebind under the same suppression).
         eq("oo::class create K {\n  method m {a b\\\n    c} { return $a }\n}\n");

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -939,6 +939,20 @@ mod tests {
     }
 
     #[test]
+    fn w215_quiet_for_backslash_continued_param_list() {
+        // Issue #743: a parameter list wrapped across lines with `\`. Tcl
+        // list-parses the braced param list, so `ddrtol\<newline>ddatol` is two
+        // parameters (`ddrtol`, `ddatol`), not a single `ddrtol\` name — no
+        // W215 unreachable-name warning should fire.
+        let src = "proc p {a ddrtol\\\n        ddatol} { list $a $ddrtol $ddatol }";
+        assert!(!diag_codes(src, "tcl").contains(&"W215".to_string()));
+
+        // The reported form: a TclOO `method` with a wrapped parameter list.
+        let method_src = "oo::class create C {\n  method Fdjac2 {funct ifree ddrtol\\\n      ddatol} { list $ddrtol $ddatol }\n}\n";
+        assert!(!diag_codes(method_src, "tcl").contains(&"W215".to_string()));
+    }
+
+    #[test]
     fn w116_fires_for_stub_shadowing_builtin() {
         let src = "# tcl-lsp: stubs-begin\n# tcl-lsp: stub set {a:var b}\n# tcl-lsp: stubs-end\n";
         assert!(diag_codes(src, "tcl").contains(&"W116".to_string()));

--- a/rust/tcl-compiler/src/signature_scan/params.rs
+++ b/rust/tcl-compiler/src/signature_scan/params.rs
@@ -26,8 +26,8 @@ pub fn parse_param_list(param_str: &str) -> Vec<ParamDef> {
     let bytes = text.as_bytes();
     let mut i = 0;
     while i < bytes.len() {
-        while i < bytes.len() && is_whitespace_byte(bytes[i]) {
-            i += 1;
+        while let Some(len) = separator_len(bytes, i) {
+            i += len;
         }
         if i >= bytes.len() {
             break;
@@ -67,9 +67,7 @@ pub fn parse_param_list(param_str: &str) -> Vec<ParamDef> {
             }
         } else {
             let start = i;
-            while i < bytes.len() && !is_whitespace_byte(bytes[i]) {
-                i += 1;
-            }
+            i = scan_bare_word(bytes, i);
             let word = &text[start..i];
             if !word.is_empty() {
                 params.push(ParamDef {
@@ -109,8 +107,8 @@ pub fn param_name_spans(raw: &str, base: u32) -> Vec<tcl_lexer::Span> {
     let mut out = Vec::new();
     let mut i = lo;
     while i < hi {
-        while i < hi && is_whitespace_byte(bytes[i]) {
-            i += 1;
+        while let Some(len) = separator_len(&bytes[..hi], i) {
+            i += len;
         }
         if i >= hi {
             break;
@@ -143,9 +141,7 @@ pub fn param_name_spans(raw: &str, base: u32) -> Vec<tcl_lexer::Span> {
             i = j;
         } else {
             let start = i;
-            while i < hi && !is_whitespace_byte(bytes[i]) {
-                i += 1;
-            }
+            i = scan_bare_word(&bytes[..hi], i);
             if i > start {
                 out.push(tcl_lexer::Span::new(abs(start), abs(i)));
             }
@@ -157,6 +153,51 @@ pub fn param_name_spans(raw: &str, base: u32) -> Vec<tcl_lexer::Span> {
 #[inline]
 fn is_whitespace_byte(b: u8) -> bool {
     matches!(b, b' ' | b'\t' | b'\n' | b'\r')
+}
+
+/// Length of the element separator starting at `bytes[i]`, if any.
+///
+/// A separator is either a single whitespace byte, or a **backslash-newline
+/// line continuation** (`\<LF>`, `\<CR><LF>`, or `\<CR>`).  In Tcl list
+/// parsing — which is how a `proc` / method parameter list is split — a
+/// backslash-newline collapses to element-separating whitespace, so a long
+/// parameter list wrapped across lines with `\` yields distinct parameters
+/// (`{a b\<newline>c}` → `a`, `b`, `c`), not a bogus `b\` name (issue #743).
+/// Every other backslash escape keeps the following byte inside the element
+/// (see [`scan_bare_word`]).
+#[inline]
+fn separator_len(bytes: &[u8], i: usize) -> Option<usize> {
+    let b = *bytes.get(i)?;
+    if is_whitespace_byte(b) {
+        return Some(1);
+    }
+    if b == b'\\' {
+        return match bytes.get(i + 1) {
+            Some(b'\n') => Some(2),
+            Some(b'\r') if bytes.get(i + 2) == Some(&b'\n') => Some(3),
+            Some(b'\r') => Some(2),
+            _ => None,
+        };
+    }
+    None
+}
+
+/// Scan one bare (unbraced) list element starting at `bytes[i]`, returning the
+/// index one past its final byte.  Stops at the next [`separator_len`]
+/// separator; a backslash that escapes any non-newline byte (`a\ b`, `a\tb`)
+/// consumes both bytes so the escaped whitespace stays within the element,
+/// mirroring Tcl's `TclFindElement`.
+#[inline]
+fn scan_bare_word(bytes: &[u8], mut i: usize) -> usize {
+    while i < bytes.len() && separator_len(bytes, i).is_none() {
+        // A backslash before a non-newline byte escapes it into the element.
+        i += if bytes[i] == b'\\' && i + 1 < bytes.len() {
+            2
+        } else {
+            1
+        };
+    }
+    i
 }
 
 /// Split on the first run of whitespace. Returns `None` when the input
@@ -248,6 +289,43 @@ mod tests {
         assert_eq!(params.len(), 2);
         assert_eq!(params[0].name, "a");
         assert_eq!(params[1].name, "b");
+    }
+
+    #[test]
+    fn backslash_newline_continuation_splits_params() {
+        // Issue #743: a long parameter list wrapped with `\` at end-of-line.
+        // Tcl list parsing treats the backslash-newline as element-separating
+        // whitespace, so the last name on the wrapped line is `ddrtol`, not
+        // `ddrtol\`.
+        let params = parse_param_list("a b ddrtol\\\n            ddatol c");
+        let names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["a", "b", "ddrtol", "ddatol", "c"]);
+        assert!(params.iter().all(|p| !p.name.contains('\\')));
+
+        // `\r\n` line endings behave identically.
+        let crlf = parse_param_list("x\\\r\ny");
+        let crlf_names: Vec<&str> = crlf.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(crlf_names, vec!["x", "y"]);
+    }
+
+    #[test]
+    fn backslash_escape_keeps_char_in_element() {
+        // A non-newline backslash escape keeps the following byte in the same
+        // element (matches Tcl `{a\ b}` → single element `a b`).
+        let params = parse_param_list("a\\ b c");
+        let names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
+        assert_eq!(names, vec!["a\\ b", "c"]);
+    }
+
+    #[test]
+    fn param_name_spans_skip_continuation_backslash() {
+        use tcl_lexer::Span;
+        // `{a b\<newline>c}` — the span for `b` must not include the trailing
+        // backslash, and `c` is a separate parameter.
+        let raw = "{a b\\\nc}";
+        let spans = param_name_spans(raw, 0);
+        // a @1..2, b @3..4 (backslash at 4 excluded), c @6..7
+        assert_eq!(spans, vec![Span::new(1, 2), Span::new(3, 4), Span::new(6, 7)]);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- Fixes #743 — a spurious **W215 "variable name unreachable via $-substitution"** warning on a `proc` / TclOO `method` whose parameter list is wrapped across lines with a `\` line-continuation.
- Root cause: `parse_param_list` / `param_name_spans` split the braced parameter list on whitespace bytes only. A list like `{... ddrtol\<newline>ddatol}` kept the trailing backslash on the last name of the wrapped line (`ddrtol\`), and W215 then correctly noted that a name ending in `\` is not `${name}`-substitutable — flagging a parameter that doesn't actually exist.
- Real Tcl list-parses a braced parameter list, where a **backslash-newline collapses to element-separating whitespace**, so `ddrtol\<newline>ddatol` is two parameters (`ddrtol`, `ddatol`). Verified against `tclsh9.0`.
- Fix: both param-list scanners now treat backslash-newline (`\<LF>`, `\<CR><LF>`, `\<CR>`) as an element separator and consume other backslash escapes (`a\ b`, `a\tb`) into the element — mirroring Tcl's `TclFindElement` — via new `separator_len` / `scan_bare_word` helpers in `rust/tcl-compiler/src/signature_scan/params.rs`.
- Docs: added a Q&A KCS note, `docs/kcs/kcs-qa-how-tcl-parses-lists.md`, documenting how Tcl splits a list (and a parameter list) into elements — whitespace separators, brace/quote grouping, backslash escapes, and the trailing backslash-newline line continuation.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Commands (toolchain note: the environment ships stable 1.94.1/1.95.0 while the workspace pins `rust-version = 1.96`, so `--ignore-rust-version` was needed; the code uses nothing newer than the crate already does):

- `rustup run 1.95.0 cargo test -p tcl-compiler --lib --ignore-rust-version` → **3353 passed, 0 failed**
- `rustup run 1.95.0 cargo test -p tcl-compiler --ignore-rust-version --test analyser --test per_item_corpus` → **172 passed**
- `rustup run 1.95.0 cargo clippy -p tcl-compiler --lib --tests --ignore-rust-version` → clean on the changed file (remaining warnings are pre-existing `is_multiple_of` lints in unrelated test files)

New tests added:
- `params::backslash_newline_continuation_splits_params`, `backslash_escape_keeps_char_in_element`, `param_name_spans_skip_continuation_backslash`
- `analyser::scope::w215_quiet_for_backslash_continued_param_list` (covers both the `proc` and the exact TclOO `method` form from the issue)

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — **No.** This is a false-positive fix in parameter-list parsing; the meaning of W215 (which runtime names are unreachable via `$`) is unchanged.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A; no contract change. The existing `docs/kcs/codes/kcs-diagnostic-w215-...md` note remains accurate (and now cross-links the new list-parsing note).
- [x] Documentation added anyway: a new Q&A note (`docs/kcs/kcs-qa-how-tcl-parses-lists.md`) describing Tcl list-element parsing, linked from `docs/kcs/README.md` and reciprocally cross-linked with the W215 code note. It is a Q&A note, not a `docs/kcs/compiler/` pass note, so the compiler-README linking rows above do not apply.

🤖 Generated with [Claude Code](https://claude.com/claude-code)