### PR TITLE
fix(lsp): highlight TclOO definition bodies for all metaclasses (#747)

### DIFF
--- a/rust/tcl-lsp-core/src/folding.rs
+++ b/rust/tcl-lsp-core/src/folding.rs
@@ -25,6 +25,8 @@ use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
 use tcl_lexer::{Lexer, LineIndex, TokenType};
 use tcl_registry::{ArgRole, CommandRegistry};
 
+use crate::oo_body::{inner_oo_body_indices, is_inner_oo_definition_command, next_inside_oo_body};
+
 /// LSP folding-range kind.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum FoldKind {
@@ -153,81 +155,6 @@ fn push_unique(
             end_line,
             kind,
         });
-    }
-}
-
-/// Collect BODY indices for the inner `property` form's
-/// `-set BODY` / `-get BODY` flag pairs. Always called with
-/// `args` from an inner `property NAME ?-set BODY? ?-get BODY?`
-/// invocation.
-fn collect_property_body_indices(args: &[&str]) -> Vec<usize> {
-    let n = args.len();
-    if n == 0 {
-        return Vec::new();
-    }
-    args.iter()
-        .enumerate()
-        .take(n.saturating_sub(1))
-        .filter_map(|(i, &a)| ((a == "-set" || a == "-get") && i + 1 < n).then_some(i + 1))
-        .collect()
-}
-
-/// Outer (context-free) OO definition commands — `oo::class` /
-/// `oo::define` / `oo::objdefine`. The bodies of these commands
-/// are OO definition bodies; recursing into one switches the
-/// walker into "inside OO body" mode where the inner-OO commands
-/// (`method`, `constructor`, …) become body-bearing.
-fn is_outer_oo_definition_command(name: &str) -> bool {
-    matches!(name, "oo::class" | "oo::define" | "oo::objdefine")
-}
-
-/// Inner OO definition-script commands. These are
-/// context-sensitive: a top-level user proc named `method`
-/// outside an OO block must not be folded as if it were an OO
-/// `method` definition. The walker only consults
-/// [`inner_oo_body_indices`] when `inside_oo_body == true`.
-///
-/// Recursing into one of these inner bodies takes us out of OO
-/// definition context — methods / constructors / destructors hold
-/// regular Tcl code, so the next recursion runs with
-/// `inside_oo_body = false`.
-fn is_inner_oo_definition_command(name: &str) -> bool {
-    matches!(
-        name,
-        "method"
-            | "classmethod"
-            | "constructor"
-            | "destructor"
-            | "initialise"
-            | "initialize"
-            | "private"
-            | "self"
-            | "property"
-    )
-}
-
-/// Return BODY argument indices for inner OO definition-script
-/// commands. Only consulted by the walker when
-/// `inside_oo_body == true` — i.e. we are recursing through the
-/// body of an `oo::class create … { … }` / `oo::define … { … }`
-/// block. Outside that context these commands are treated as
-/// regular calls (a user proc named `method` shadows nothing).
-fn inner_oo_body_indices(command: &str, args: &[&str]) -> Vec<usize> {
-    let n = args.len();
-    match command {
-        "constructor" if n >= 2 => vec![1],
-        // `destructor`/`initialise`/`initialize`/`private` all take a
-        // single body argument at index 0.
-        "destructor" | "initialise" | "initialize" | "private" if n >= 1 => vec![0],
-        "method" | "classmethod" if n >= 3 => vec![n - 1],
-        "self" if n >= 1 => match args[0] {
-            "constructor" if n >= 3 => vec![2],
-            "destructor" if n >= 2 => vec![1],
-            "method" | "classmethod" if n >= 4 => vec![n - 1],
-            _ => Vec::new(),
-        },
-        "property" => collect_property_body_indices(args),
-        _ => Vec::new(),
     }
 }
 
@@ -437,23 +364,10 @@ fn collect_body_folds(
             };
 
         // What "inside_oo_body" should the recursion into THIS
-        // command's bodies see?
-        //
-        //  - Outer OO commands (`oo::class create Foo {...}`):
-        //    the body IS the OO definition body → set true.
-        //  - Inner OO commands inside an OO body
-        //    (`method foo {} {...}`): the body is plain Tcl code
-        //    → set false.
-        //  - Anything else (`if`, `while`, `for`, …): inherit the
-        //    current flag — control-flow nesting inside an OO
-        //    body keeps us in OO context.
-        let next_inside_oo_body = if is_outer_oo_definition_command(cmd.name()) {
-            true
-        } else if inside_oo_body && is_inner_oo_definition_command(cmd.name()) {
-            false
-        } else {
-            inside_oo_body
-        };
+        // command's bodies see?  [`next_inside_oo_body`] encodes the
+        // rule: outer OO commands switch on, inner OO commands switch
+        // off, everything else inherits.
+        let next_inside_oo_body = next_inside_oo_body(cmd.name(), inside_oo_body, ctx.registry);
 
         for idx in body_indices {
             let arg_tokens = cmd.arg_tokens();
@@ -945,57 +859,32 @@ mod tests {
         );
     }
 
+    // The inner-OO body-index table itself is unit-tested in
+    // [`crate::oo_body`]; here we cover the folding-level behaviour it
+    // drives.
+
     #[test]
-    fn inner_oo_body_indices_table() {
-        // Inner OO definition-script commands (only consulted when
-        // `inside_oo_body == true`).
-        assert_eq!(
-            inner_oo_body_indices("constructor", &["{}", "body"]),
-            vec![1]
+    fn tcloo_method_body_inside_configurable_emits_a_fold() {
+        // Regression for #747: `oo::configurable` is a metaclass like
+        // `oo::class`, so a method body inside its definition block must
+        // fold — the registry-driven outer-command detection now covers it.
+        let source = concat!(
+            "oo::configurable create Widget {\n",
+            "    property color\n",
+            "    method paint {} {\n",
+            "        set x 1\n",
+            "        set y 2\n",
+            "    }\n",
+            "}\n",
         );
-        assert_eq!(inner_oo_body_indices("destructor", &["body"]), vec![0]);
-        // The `destructor | initialise | initialize | private` arm shares a
-        // single body argument at index 0 — pin every member so the merged
-        // match arm keeps mapping each one (positive cases).
-        assert_eq!(inner_oo_body_indices("initialise", &["body"]), vec![0]);
-        assert_eq!(inner_oo_body_indices("initialize", &["body"]), vec![0]);
-        assert_eq!(inner_oo_body_indices("private", &["body"]), vec![0]);
-        // Negative: the `n >= 1` guard fails with no args, so the merged
-        // arm yields no body indices (falls through to the catch-all).
-        assert!(inner_oo_body_indices("initialise", &[]).is_empty());
-        assert!(inner_oo_body_indices("initialize", &[]).is_empty());
-        assert!(inner_oo_body_indices("private", &[]).is_empty());
-        assert!(inner_oo_body_indices("destructor", &[]).is_empty());
-        assert_eq!(
-            inner_oo_body_indices("method", &["name", "{}", "body"]),
-            vec![2],
+        let ranges = folding_ranges_default(source, "tcl9.0");
+        let regions = fold_lines(&ranges, FoldKind::Region);
+        // Method body (`method paint {} { … }`): starts on line 2, spans
+        // through line 4 (the closing `}` sits on line 5).
+        assert!(
+            regions.iter().any(|&(s, e)| s == 2 && e >= 4),
+            "expected method-body fold starting at line 2, got {regions:?}",
         );
-        assert_eq!(
-            inner_oo_body_indices("classmethod", &["name", "{args}", "body"]),
-            vec![2],
-        );
-        assert_eq!(
-            inner_oo_body_indices("self", &["constructor", "{}", "body"]),
-            vec![2],
-        );
-        assert_eq!(
-            inner_oo_body_indices("self", &["destructor", "body"]),
-            vec![1],
-        );
-        assert_eq!(
-            inner_oo_body_indices("self", &["method", "name", "{}", "body"]),
-            vec![3],
-        );
-        assert_eq!(
-            inner_oo_body_indices("property", &["name", "-set", "setter", "-get", "getter"]),
-            vec![2, 4],
-        );
-        // Non-OO command: empty (the walker never even consults this
-        // function for non-inner-OO commands, but the helper itself
-        // is still defensive).
-        assert!(inner_oo_body_indices("set", &["x", "1"]).is_empty());
-        // Too few args: empty.
-        assert!(inner_oo_body_indices("method", &["name"]).is_empty());
     }
 
     /// Top-level OO body shapes are now driven by registry

--- a/rust/tcl-lsp-core/src/folding.rs
+++ b/rust/tcl-lsp-core/src/folding.rs
@@ -367,7 +367,8 @@ fn collect_body_folds(
         // command's bodies see?  [`next_inside_oo_body`] encodes the
         // rule: outer OO commands switch on, inner OO commands switch
         // off, everything else inherits.
-        let next_inside_oo_body = next_inside_oo_body(cmd.name(), inside_oo_body, ctx.registry);
+        let next_inside_oo_body =
+            next_inside_oo_body(cmd.name(), &args_borrow, inside_oo_body, ctx.registry);
 
         for idx in body_indices {
             let arg_tokens = cmd.arg_tokens();

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -32,6 +32,7 @@ pub mod irules_context;
 pub mod irules_object_refs;
 pub mod linked_editing_range;
 pub mod minify;
+pub mod oo_body;
 pub mod package_resolver;
 pub mod refactor;
 pub mod references;

--- a/rust/tcl-lsp-core/src/oo_body.rs
+++ b/rust/tcl-lsp-core/src/oo_body.rs
@@ -1,0 +1,261 @@
+//! Context-sensitive `TclOO` definition-body helpers, shared by the
+//! recursive script walkers ([`crate::folding`] and
+//! [`crate::semantic_tokens`]).
+//!
+//! ## The problem
+//!
+//! A `TclOO` class body —
+//!
+//! ```tcl
+//! oo::class create Point {
+//!     superclass Shape
+//!     variable x y
+//!     constructor {ax ay} { set x $ax; set y $ay }
+//!     method move {dx dy} { incr x $dx; incr y $dy }
+//! }
+//! ```
+//!
+//! — is a *definition script*: its top-level words (`superclass`,
+//! `constructor`, `method`, `property`, `self`, …) are **not** ordinary
+//! commands.  They have no [`tcl_registry::CommandSpec`], so a registry
+//! lookup can't tell a walker that `method move {dx dy} { … }`'s final
+//! word is a script body to recurse into.  Without that, folding stops at
+//! the method keyword and semantic highlighting renders the whole method
+//! body as one opaque string.
+//!
+//! Worse, the sub-keywords are context-sensitive: a top-level user proc
+//! named `method` outside any class body must **not** be treated as an OO
+//! method definition.
+//!
+//! ## The model
+//!
+//! A recursive walker threads an `inside_oo_body` flag:
+//!
+//! * Recursing into the body of an *outer* OO definition command
+//!   ([`is_outer_oo_definition_command`] — the metaclasses' `create` /
+//!   `new` forms plus `oo::define` / `oo::objdefine`) enters OO-body
+//!   context (`inside_oo_body = true`).
+//! * While in that context, an *inner* OO definition command
+//!   ([`is_inner_oo_definition_command`]) contributes body arguments via
+//!   [`inner_oo_body_indices`]; recursing into one of those bodies leaves
+//!   OO-body context (a method body holds ordinary Tcl code).
+//! * Every other command inherits the current flag, so control-flow
+//!   nesting (`if` / `foreach` / …) around a `method` keeps the class
+//!   body's context.
+//!
+//! Outside `inside_oo_body`, none of the inner helpers fire, so a
+//! same-named user proc is never misclassified.
+
+use tcl_registry::CommandRegistry;
+use tcl_registry::prelude::Traits;
+
+/// Outer (context-establishing) OO definition commands: any registry
+/// command carrying the `IS_OO_METACLASS` trait (`oo::class`,
+/// `oo::configurable`, `oo::abstract`, `oo::singleton`, plus any
+/// dialect-registered metaclass) and the two definition commands
+/// `oo::define` / `oo::objdefine`.
+///
+/// The body of one of these runs as a `TclOO` definition script; recursing
+/// into it switches the walker into "inside OO body" mode where the
+/// inner-OO commands (`method`, `constructor`, …) become body-bearing.
+///
+/// Driven by the registry trait rather than a hardcoded name list so a
+/// newly registered metaclass is covered automatically.
+#[must_use]
+pub fn is_outer_oo_definition_command(name: &str, registry: &CommandRegistry) -> bool {
+    if matches!(name, "oo::define" | "oo::objdefine") {
+        return true;
+    }
+    registry
+        .get(name)
+        .is_some_and(|spec| spec.traits.contains(Traits::IS_OO_METACLASS))
+}
+
+/// Inner OO definition-script commands.  These are context-sensitive: a
+/// top-level user proc named `method` outside an OO block must not be
+/// treated as an OO `method` definition.  A walker only consults
+/// [`inner_oo_body_indices`] when it is inside an outer OO body.
+///
+/// Recursing into one of these inner bodies leaves OO definition context —
+/// methods / constructors / destructors hold regular Tcl code.
+#[must_use]
+pub fn is_inner_oo_definition_command(name: &str) -> bool {
+    matches!(
+        name,
+        "method"
+            | "classmethod"
+            | "constructor"
+            | "destructor"
+            | "initialise"
+            | "initialize"
+            | "private"
+            | "self"
+            | "property"
+    )
+}
+
+/// Collect the `-set BODY` / `-get BODY` flag-value indices of an inner
+/// `property NAME ?-set BODY? ?-get BODY?` invocation.  Always called with
+/// `args` from the inner (unprefixed) form, so option scanning starts at
+/// index 0.
+fn collect_property_body_indices(args: &[&str]) -> Vec<usize> {
+    let n = args.len();
+    if n == 0 {
+        return Vec::new();
+    }
+    args.iter()
+        .enumerate()
+        .take(n.saturating_sub(1))
+        .filter_map(|(i, &a)| ((a == "-set" || a == "-get") && i + 1 < n).then_some(i + 1))
+        .collect()
+}
+
+/// Return BODY argument indices (into `args`, i.e. excluding the
+/// command-head word) for an inner OO definition-script command.  Only
+/// meaningful when the caller is inside an outer OO body — outside that
+/// context these words are ordinary calls and this must not be consulted.
+///
+/// Shapes (mirroring [`tcl_registry`]'s `oo_define_arg_roles`, minus the
+/// leading target word that the `oo::define Target …` form carries):
+///
+/// * `constructor ARGS BODY` → body at index 1.
+/// * `destructor BODY` / `initialise BODY` / `initialize BODY` /
+///   `private BODY` → body at index 0.
+/// * `method NAME ARGS BODY` / `classmethod NAME ARGS BODY` → body at the
+///   last index.
+/// * `self constructor ARGS BODY` → index 2; `self destructor BODY` →
+///   index 1; `self method NAME ARGS BODY` → last index.
+/// * `property NAME ?-set BODY? ?-get BODY?` → each flag value.
+#[must_use]
+pub fn inner_oo_body_indices(command: &str, args: &[&str]) -> Vec<usize> {
+    let n = args.len();
+    match command {
+        "constructor" if n >= 2 => vec![1],
+        "destructor" | "initialise" | "initialize" | "private" if n >= 1 => vec![0],
+        "method" | "classmethod" if n >= 3 => vec![n - 1],
+        "self" if n >= 1 => match args[0] {
+            "constructor" if n >= 3 => vec![2],
+            "destructor" if n >= 2 => vec![1],
+            "method" | "classmethod" if n >= 4 => vec![n - 1],
+            _ => Vec::new(),
+        },
+        "property" => collect_property_body_indices(args),
+        _ => Vec::new(),
+    }
+}
+
+/// The `inside_oo_body` flag the recursion into `command`'s body arguments
+/// should carry, given the current flag `cur`:
+///
+/// * An outer OO definition command's body *is* the OO definition script →
+///   `true`.
+/// * An inner OO definition command's body (while already inside an OO
+///   body) is plain Tcl code → `false`.
+/// * Everything else inherits `cur` — control-flow nesting inside a class
+///   body stays in OO context.
+#[must_use]
+pub fn next_inside_oo_body(command: &str, cur: bool, registry: &CommandRegistry) -> bool {
+    if is_outer_oo_definition_command(command, registry) {
+        true
+    } else if cur && is_inner_oo_definition_command(command) {
+        false
+    } else {
+        cur
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry() -> CommandRegistry {
+        CommandRegistry::build_default()
+    }
+
+    #[test]
+    fn metaclasses_are_outer_commands() {
+        let reg = registry();
+        for name in [
+            "oo::class",
+            "oo::configurable",
+            "oo::abstract",
+            "oo::singleton",
+            "oo::define",
+            "oo::objdefine",
+        ] {
+            assert!(
+                is_outer_oo_definition_command(name, &reg),
+                "{name} must be an outer OO definition command"
+            );
+        }
+    }
+
+    #[test]
+    fn ordinary_commands_are_not_outer() {
+        let reg = registry();
+        for name in ["proc", "set", "if", "namespace", "method"] {
+            assert!(
+                !is_outer_oo_definition_command(name, &reg),
+                "{name} must not be an outer OO definition command"
+            );
+        }
+    }
+
+    #[test]
+    fn inner_body_indices_cover_every_shape() {
+        assert_eq!(
+            inner_oo_body_indices("constructor", &["{}", "body"]),
+            vec![1]
+        );
+        assert_eq!(inner_oo_body_indices("destructor", &["body"]), vec![0]);
+        assert_eq!(inner_oo_body_indices("initialise", &["body"]), vec![0]);
+        assert_eq!(inner_oo_body_indices("initialize", &["body"]), vec![0]);
+        assert_eq!(inner_oo_body_indices("private", &["body"]), vec![0]);
+        assert_eq!(
+            inner_oo_body_indices("method", &["name", "{}", "body"]),
+            vec![2]
+        );
+        assert_eq!(
+            inner_oo_body_indices("classmethod", &["name", "{a}", "body"]),
+            vec![2]
+        );
+        assert_eq!(
+            inner_oo_body_indices("self", &["constructor", "{}", "body"]),
+            vec![2]
+        );
+        assert_eq!(
+            inner_oo_body_indices("self", &["destructor", "body"]),
+            vec![1]
+        );
+        assert_eq!(
+            inner_oo_body_indices("self", &["method", "name", "{}", "body"]),
+            vec![3]
+        );
+        assert_eq!(
+            inner_oo_body_indices("property", &["name", "-set", "s", "-get", "g"]),
+            vec![2, 4]
+        );
+    }
+
+    #[test]
+    fn inner_body_indices_reject_short_forms() {
+        assert!(inner_oo_body_indices("method", &["name"]).is_empty());
+        assert!(inner_oo_body_indices("destructor", &[]).is_empty());
+        assert!(inner_oo_body_indices("set", &["x", "1"]).is_empty());
+    }
+
+    #[test]
+    fn context_transitions() {
+        let reg = registry();
+        // Entering an outer body switches on.
+        assert!(next_inside_oo_body("oo::class", false, &reg));
+        assert!(next_inside_oo_body("oo::configurable", false, &reg));
+        // A method body inside a class body switches off.
+        assert!(!next_inside_oo_body("method", true, &reg));
+        // Control flow inherits.
+        assert!(next_inside_oo_body("if", true, &reg));
+        assert!(!next_inside_oo_body("if", false, &reg));
+        // Inner commands at top level (not inside an OO body) don't fire.
+        assert!(!next_inside_oo_body("method", false, &reg));
+    }
+}

--- a/rust/tcl-lsp-core/src/oo_body.rs
+++ b/rust/tcl-lsp-core/src/oo_body.rs
@@ -31,10 +31,12 @@
 //!
 //! A recursive walker threads an `inside_oo_body` flag:
 //!
-//! * Recursing into the body of an *outer* OO definition command
-//!   ([`is_outer_oo_definition_command`] — the metaclasses' `create` /
-//!   `new` forms plus `oo::define` / `oo::objdefine`) enters OO-body
-//!   context (`inside_oo_body = true`).
+//! * Recursing into the body of an *outer* OO definition body
+//!   ([`is_outer_oo_definition_command`] — a metaclass `create` / `new`
+//!   body, or the bare `oo::define` / `oo::objdefine` *script* form) enters
+//!   OO-body context (`inside_oo_body = true`).  The *member* forms of
+//!   `oo::define` / `oo::objdefine` (`… method m {} { body }`, …) do not:
+//!   their body is ordinary method code, not a definition script.
 //! * While in that context, an *inner* OO definition command
 //!   ([`is_inner_oo_definition_command`]) contributes body arguments via
 //!   [`inner_oo_body_indices`]; recursing into one of those bodies leaves
@@ -46,29 +48,67 @@
 //! Outside `inside_oo_body`, none of the inner helpers fire, so a
 //! same-named user proc is never misclassified.
 
-use tcl_registry::CommandRegistry;
 use tcl_registry::prelude::Traits;
+use tcl_registry::{ArgRole, CommandRegistry};
 
-/// Outer (context-establishing) OO definition commands: any registry
-/// command carrying the `IS_OO_METACLASS` trait (`oo::class`,
+/// Whether `command` carries the `IS_OO_METACLASS` trait (`oo::class`,
 /// `oo::configurable`, `oo::abstract`, `oo::singleton`, plus any
-/// dialect-registered metaclass) and the two definition commands
-/// `oo::define` / `oo::objdefine`.
-///
-/// The body of one of these runs as a `TclOO` definition script; recursing
-/// into it switches the walker into "inside OO body" mode where the
-/// inner-OO commands (`method`, `constructor`, …) become body-bearing.
+/// dialect-registered metaclass).  Every body a metaclass takes is the
+/// definition script of a `create` / `new` / `createWithNamespace` form, so
+/// recursing into it always enters OO-body context.
 ///
 /// Driven by the registry trait rather than a hardcoded name list so a
 /// newly registered metaclass is covered automatically.
 #[must_use]
-pub fn is_outer_oo_definition_command(name: &str, registry: &CommandRegistry) -> bool {
-    if matches!(name, "oo::define" | "oo::objdefine") {
+pub fn is_oo_metaclass(command: &str, registry: &CommandRegistry) -> bool {
+    registry
+        .get(command)
+        .is_some_and(|spec| spec.traits.contains(Traits::IS_OO_METACLASS))
+}
+
+/// Whether an `oo::define` / `oo::objdefine` call is the *bare script form*
+/// (`oo::define Target { script }`) rather than a member/subcommand form
+/// (`oo::define Target method m {} { body }`, `constructor …`, `self …`,
+/// `property …`, …).
+///
+/// Only the script form's body is an OO definition script; the member forms
+/// carry ordinary method bodies that must **not** switch the walker into OO
+/// context (issue #747 review — a nested `method a b { … }` inside a real
+/// method body would otherwise be mis-highlighted / mis-folded as an OO
+/// member definition).
+///
+/// Detected via the registry's authoritative body-role resolver: the script
+/// form resolves its definition body at argument index 1, while every member
+/// form resolves a (method) body at index ≥ 2.  `args` excludes the command
+/// head (`["Target", …]`), matching the resolver's calling convention.
+#[must_use]
+fn is_oo_define_script_form(command: &str, args: &[&str], registry: &CommandRegistry) -> bool {
+    registry
+        .arg_indices_for_role(command, args, ArgRole::Body)
+        .contains(&1)
+}
+
+/// Whether recursing into `command`'s body/bodies enters OO-body context —
+/// i.e. the body is a `TclOO` definition script whose top-level words are
+/// the definition sub-keywords (`method`, `superclass`, `self …`, …).
+///
+/// True for metaclass `create` / `new` bodies and for the bare
+/// `oo::define` / `oo::objdefine` script form; false for the member forms
+/// of `oo::define` / `oo::objdefine` (their bodies are ordinary method
+/// code).  `args` excludes the command head.
+#[must_use]
+pub fn is_outer_oo_definition_command(
+    command: &str,
+    args: &[&str],
+    registry: &CommandRegistry,
+) -> bool {
+    if is_oo_metaclass(command, registry) {
         return true;
     }
-    registry
-        .get(name)
-        .is_some_and(|spec| spec.traits.contains(Traits::IS_OO_METACLASS))
+    if matches!(command, "oo::define" | "oo::objdefine") {
+        return is_oo_define_script_form(command, args, registry);
+    }
+    false
 }
 
 /// Inner OO definition-script commands.  These are context-sensitive: a
@@ -145,17 +185,26 @@ pub fn inner_oo_body_indices(command: &str, args: &[&str]) -> Vec<usize> {
 }
 
 /// The `inside_oo_body` flag the recursion into `command`'s body arguments
-/// should carry, given the current flag `cur`:
+/// should carry, given the current flag `cur`.  `args` excludes the command
+/// head.
 ///
-/// * An outer OO definition command's body *is* the OO definition script →
-///   `true`.
+/// * An outer OO definition body (metaclass `create`/`new`, or the bare
+///   `oo::define`/`oo::objdefine` script form) *is* the OO definition
+///   script → `true`.
 /// * An inner OO definition command's body (while already inside an OO
 ///   body) is plain Tcl code → `false`.
-/// * Everything else inherits `cur` — control-flow nesting inside a class
-///   body stays in OO context.
+/// * Everything else — including the *member* forms of `oo::define` /
+///   `oo::objdefine`, whose bodies are ordinary method code — inherits
+///   `cur`, so control-flow nesting inside a class body stays in OO
+///   context while a method body drops out of it.
 #[must_use]
-pub fn next_inside_oo_body(command: &str, cur: bool, registry: &CommandRegistry) -> bool {
-    if is_outer_oo_definition_command(command, registry) {
+pub fn next_inside_oo_body(
+    command: &str,
+    args: &[&str],
+    cur: bool,
+    registry: &CommandRegistry,
+) -> bool {
+    if is_outer_oo_definition_command(command, args, registry) {
         true
     } else if cur && is_inner_oo_definition_command(command) {
         false
@@ -173,19 +222,57 @@ mod tests {
     }
 
     #[test]
-    fn metaclasses_are_outer_commands() {
+    fn metaclass_create_bodies_are_outer() {
         let reg = registry();
+        // Every metaclass `create`/`new` body is a definition script.
         for name in [
             "oo::class",
             "oo::configurable",
             "oo::abstract",
             "oo::singleton",
-            "oo::define",
-            "oo::objdefine",
         ] {
             assert!(
-                is_outer_oo_definition_command(name, &reg),
-                "{name} must be an outer OO definition command"
+                is_outer_oo_definition_command(name, &["create", "C", "{body}"], &reg),
+                "{name} create body must be an outer OO definition body"
+            );
+        }
+    }
+
+    #[test]
+    fn oo_define_script_form_is_outer_but_member_form_is_not() {
+        let reg = registry();
+        // Bare script form: `oo::define Target { script }` → outer body.
+        for cmd in ["oo::define", "oo::objdefine"] {
+            assert!(
+                is_outer_oo_definition_command(cmd, &["Target", "{script}"], &reg),
+                "{cmd} script form must be an outer OO definition body"
+            );
+            // Member forms carry ordinary method bodies → NOT outer (issue
+            // #747 review): a nested `method a b { … }` inside them must not
+            // be treated as an OO member definition.
+            assert!(
+                !is_outer_oo_definition_command(
+                    cmd,
+                    &["Target", "method", "m", "{}", "{body}"],
+                    &reg
+                ),
+                "{cmd} member (method) form must not be an outer OO body"
+            );
+            assert!(
+                !is_outer_oo_definition_command(
+                    cmd,
+                    &["Target", "constructor", "{}", "{body}"],
+                    &reg
+                ),
+                "{cmd} constructor form must not be an outer OO body"
+            );
+            assert!(
+                !is_outer_oo_definition_command(
+                    cmd,
+                    &["Target", "self", "method", "m", "{}", "{body}"],
+                    &reg
+                ),
+                "{cmd} self-method form must not be an outer OO body"
             );
         }
     }
@@ -195,7 +282,7 @@ mod tests {
         let reg = registry();
         for name in ["proc", "set", "if", "namespace", "method"] {
             assert!(
-                !is_outer_oo_definition_command(name, &reg),
+                !is_outer_oo_definition_command(name, &["a", "b"], &reg),
                 "{name} must not be an outer OO definition command"
             );
         }
@@ -247,15 +334,48 @@ mod tests {
     #[test]
     fn context_transitions() {
         let reg = registry();
-        // Entering an outer body switches on.
-        assert!(next_inside_oo_body("oo::class", false, &reg));
-        assert!(next_inside_oo_body("oo::configurable", false, &reg));
+        // Entering an outer (metaclass create) body switches on.
+        assert!(next_inside_oo_body(
+            "oo::class",
+            &["create", "C", "{b}"],
+            false,
+            &reg
+        ));
+        assert!(next_inside_oo_body(
+            "oo::configurable",
+            &["create", "C", "{b}"],
+            false,
+            &reg
+        ));
+        // `oo::define` script form switches on; member form does not.
+        assert!(next_inside_oo_body(
+            "oo::define",
+            &["C", "{script}"],
+            false,
+            &reg
+        ));
+        assert!(!next_inside_oo_body(
+            "oo::define",
+            &["C", "method", "m", "{}", "{body}"],
+            false,
+            &reg
+        ));
         // A method body inside a class body switches off.
-        assert!(!next_inside_oo_body("method", true, &reg));
+        assert!(!next_inside_oo_body(
+            "method",
+            &["m", "{}", "{b}"],
+            true,
+            &reg
+        ));
         // Control flow inherits.
-        assert!(next_inside_oo_body("if", true, &reg));
-        assert!(!next_inside_oo_body("if", false, &reg));
+        assert!(next_inside_oo_body("if", &["{c}", "{b}"], true, &reg));
+        assert!(!next_inside_oo_body("if", &["{c}", "{b}"], false, &reg));
         // Inner commands at top level (not inside an OO body) don't fire.
-        assert!(!next_inside_oo_body("method", false, &reg));
+        assert!(!next_inside_oo_body(
+            "method",
+            &["m", "{}", "{b}"],
+            false,
+            &reg
+        ));
     }
 }

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1622,11 +1622,19 @@ fn collect_script(
         let overrides = special_arg_kinds(&seg, registry, ctx.inside_oo_body);
 
         // The `inside_oo_body` context the recursion into THIS command's
-        // body arguments should carry: outer OO commands switch it on, inner
-        // OO commands (inside an OO body) switch it off, everything else
-        // inherits.  Command substitutions and expressions always run in
-        // ordinary (non-definition) context.
-        let next_oo = crate::oo_body::next_inside_oo_body(head_text, ctx.inside_oo_body, registry);
+        // body arguments should carry: an outer OO definition body switches
+        // it on, an inner OO command (inside an OO body) switches it off,
+        // everything else inherits.  `oo::define`/`oo::objdefine` only switch
+        // it on for their bare script form, not their member (`method …`)
+        // forms — hence the args are consulted.  Command substitutions and
+        // expressions always run in ordinary (non-definition) context.
+        let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
+        let next_oo = crate::oo_body::next_inside_oo_body(
+            head_text,
+            &arg_texts,
+            ctx.inside_oo_body,
+            registry,
+        );
         let body_ctx = ScriptCtx {
             inside_oo_body: next_oo,
             ..ctx

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -471,10 +471,16 @@ fn push_regsub_subtokens(
 ///   `pattern_type == Regex`, option-skipped first positional) →
 ///   [`ArgOverride::RegexPattern`] (sub-tokenised into ARE components);
 /// * a `when EVENT` event-name argument → [`TokenKind::Event`].
+///
+/// `arg_texts` holds the command's argument words (`seg.texts[1..]`, head
+/// excluded) borrowed as `&[&str]`.  The caller builds it once and shares it
+/// with the registry-role and OO-body override passes, so the hot path makes
+/// only a single bridging allocation per command.
 fn special_arg_kinds(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
     inside_oo_body: bool,
+    arg_texts: &[&str],
 ) -> FxHashMap<u32, ArgOverride> {
     let mut overrides = FxHashMap::default();
     let head = &seg.texts[0];
@@ -502,8 +508,8 @@ fn special_arg_kinds(
 
     insert_option_and_subcommand_overrides(seg, registry, &mut overrides);
     insert_switch_regexp_override(seg, &mut overrides);
-    insert_role_overrides(seg, registry, &mut overrides);
-    insert_oo_body_overrides(seg, inside_oo_body, &mut overrides);
+    insert_role_overrides(seg, registry, arg_texts, &mut overrides);
+    insert_oo_body_overrides(seg, inside_oo_body, arg_texts, &mut overrides);
 
     overrides
 }
@@ -522,6 +528,7 @@ fn special_arg_kinds(
 fn insert_oo_body_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     inside_oo_body: bool,
+    arg_texts: &[&str],
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
     let head = &seg.texts[0];
@@ -531,8 +538,7 @@ fn insert_oo_body_overrides(
     // `inner_oo_body_indices` indexes the argument words (excluding the
     // head); `seg.argv[idx + 1]` is the representative token (argv[0] is the
     // head).  Only braced (`Str`) bodies recurse.
-    let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
-    for idx in crate::oo_body::inner_oo_body_indices(head, &arg_texts) {
+    for idx in crate::oo_body::inner_oo_body_indices(head, arg_texts) {
         if let Some(tok) = seg.argv.get(idx + 1)
             && matches!(tok.kind, TokenType::Str)
         {
@@ -710,6 +716,7 @@ fn insert_switch_regexp_override(
 fn insert_role_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
+    arg_texts: &[&str],
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
     let head = &seg.texts[0];
@@ -717,12 +724,11 @@ fn insert_role_overrides(
     // `expr {expr}`, … — keyed on each word's representative token
     // (`argv[i + 1]`; `argv[0]` is the head).  Only braced (`Str`) words
     // recurse; non-literal words fall through.
-    let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
     for (role, ov) in [
         (tcl_registry::ArgRole::Body, ArgOverride::BodyScript),
         (tcl_registry::ArgRole::Expr, ArgOverride::ExprScript),
     ] {
-        for i in registry.arg_indices_for_role(head, &arg_texts, role) {
+        for i in registry.arg_indices_for_role(head, arg_texts, role) {
             if let Some(tok) = seg.argv.get(i + 1)
                 && matches!(tok.kind, TokenType::Str)
             {
@@ -737,7 +743,7 @@ fn insert_role_overrides(
     // registry's `Keyword` role marks them; highlight as keywords.  Unlike
     // body/expr these are bare (`Esc`) or quoted (`Str`) literal words, so
     // no `Str`-only guard.
-    for i in registry.arg_indices_for_role(head, &arg_texts, tcl_registry::ArgRole::Keyword) {
+    for i in registry.arg_indices_for_role(head, arg_texts, tcl_registry::ArgRole::Keyword) {
         if let Some(tok) = seg.argv.get(i + 1)
             && matches!(tok.kind, TokenType::Esc | TokenType::Str)
         {
@@ -1619,7 +1625,14 @@ fn collect_script(
             entries,
         );
 
-        let overrides = special_arg_kinds(&seg, registry, ctx.inside_oo_body);
+        // The command's argument words (head excluded), borrowed once as
+        // `&[&str]` and shared by every registry-driven pass below — the
+        // override builder and the OO-body context check both need it, and
+        // the registry API takes `&[&str]`, so building it here keeps the
+        // hot path to a single bridging allocation per command.
+        let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
+
+        let overrides = special_arg_kinds(&seg, registry, ctx.inside_oo_body, &arg_texts);
 
         // The `inside_oo_body` context the recursion into THIS command's
         // body arguments should carry: an outer OO definition body switches
@@ -1628,7 +1641,6 @@ fn collect_script(
         // it on for their bare script form, not their member (`method …`)
         // forms — hence the args are consulted.  Command substitutions and
         // expressions always run in ordinary (non-definition) context.
-        let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
         let next_oo = crate::oo_body::next_inside_oo_body(
             head_text,
             &arg_texts,

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -474,6 +474,7 @@ fn push_regsub_subtokens(
 fn special_arg_kinds(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
+    inside_oo_body: bool,
 ) -> FxHashMap<u32, ArgOverride> {
     let mut overrides = FxHashMap::default();
     let head = &seg.texts[0];
@@ -502,8 +503,44 @@ fn special_arg_kinds(
     insert_option_and_subcommand_overrides(seg, registry, &mut overrides);
     insert_switch_regexp_override(seg, &mut overrides);
     insert_role_overrides(seg, registry, &mut overrides);
+    insert_oo_body_overrides(seg, inside_oo_body, &mut overrides);
 
     overrides
+}
+
+/// Mark the script-body arguments of a context-sensitive `TclOO` inner
+/// definition command (`method` / `constructor` / `destructor` / `self …`
+/// / `property -get/-set` / …) as [`ArgOverride::BodyScript`] so they are
+/// recursed into rather than emitted as one opaque `string`.
+///
+/// Only consulted when `inside_oo_body` — i.e. this segment is a top-level
+/// word of an `oo::class create … { … }` / `oo::define … { … }` block —
+/// so a same-named user proc at top level is never misclassified.  The
+/// outer OO commands themselves carry their body roles in the registry
+/// (`arg_indices_for_role`, applied by [`insert_role_overrides`]); this
+/// covers only the bare inner sub-keywords, which have no `CommandSpec`.
+fn insert_oo_body_overrides(
+    seg: &tcl_compiler::segmenter::SegmentedCommand,
+    inside_oo_body: bool,
+    overrides: &mut FxHashMap<u32, ArgOverride>,
+) {
+    let head = &seg.texts[0];
+    if !inside_oo_body || !crate::oo_body::is_inner_oo_definition_command(head) {
+        return;
+    }
+    // `inner_oo_body_indices` indexes the argument words (excluding the
+    // head); `seg.argv[idx + 1]` is the representative token (argv[0] is the
+    // head).  Only braced (`Str`) bodies recurse.
+    let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
+    for idx in crate::oo_body::inner_oo_body_indices(head, &arg_texts) {
+        if let Some(tok) = seg.argv.get(idx + 1)
+            && matches!(tok.kind, TokenType::Str)
+        {
+            overrides
+                .entry(tok.span.start())
+                .or_insert(ArgOverride::BodyScript);
+        }
+    }
 }
 
 /// Regex pattern / regsub-replacement overrides for a `pattern_type ==
@@ -1407,6 +1444,13 @@ struct ScriptCtx<'a> {
     dialect: &'a str,
     registry: &'a CommandRegistry,
     line_index: &'a LineIndex,
+    /// Whether this script is a `TclOO` definition body (an
+    /// `oo::class create … { … }` / `oo::define … { … }` block).  Inside
+    /// one, the context-sensitive OO sub-keywords (`method`, `constructor`,
+    /// `property`, `self …`, …) carry script bodies that must be recursed
+    /// into — see [`crate::oo_body`].  Outside one, a same-named user proc
+    /// must not be treated as an OO definition.
+    inside_oo_body: bool,
 }
 
 fn collect_switch_regexp_case_list(
@@ -1575,13 +1619,31 @@ fn collect_script(
             entries,
         );
 
-        let overrides = special_arg_kinds(&seg, registry);
+        let overrides = special_arg_kinds(&seg, registry, ctx.inside_oo_body);
+
+        // The `inside_oo_body` context the recursion into THIS command's
+        // body arguments should carry: outer OO commands switch it on, inner
+        // OO commands (inside an OO body) switch it off, everything else
+        // inherits.  Command substitutions and expressions always run in
+        // ordinary (non-definition) context.
+        let next_oo = crate::oo_body::next_inside_oo_body(head_text, ctx.inside_oo_body, registry);
+        let body_ctx = ScriptCtx {
+            inside_oo_body: next_oo,
+            ..ctx
+        };
 
         for tok in &seg.all_tokens {
             if tok.span == head_tok.span {
                 continue;
             }
-            emit_arg_token(ctx, *tok, overrides.get(&tok.span.start()), entries, depth);
+            emit_arg_token(
+                ctx,
+                body_ctx,
+                *tok,
+                overrides.get(&tok.span.start()),
+                entries,
+                depth,
+            );
         }
     }
 }
@@ -1603,6 +1665,7 @@ fn classify_and_push_if(cond: bool, ctx: ScriptCtx<'_>, tok: Token, entries: &mu
 
 fn emit_arg_token(
     ctx: ScriptCtx<'_>,
+    body_ctx: ScriptCtx<'_>,
     tok: Token,
     override_kind: Option<&ArgOverride>,
     entries: &mut Vec<Entry>,
@@ -1611,6 +1674,12 @@ fn emit_arg_token(
     let full_source = ctx.full_source;
     let line_index = ctx.line_index;
     let tok = &tok;
+    // Command substitutions / expressions never run in OO definition
+    // context, whatever the enclosing command is.
+    let plain_ctx = ScriptCtx {
+        inside_oo_body: false,
+        ..ctx
+    };
     match override_kind {
         Some(ArgOverride::RegexPattern) => {
             if !push_regex_subtokens(line_index, full_source, *tok, entries) {
@@ -1669,8 +1738,13 @@ fn emit_arg_token(
         }
         Some(ArgOverride::BodyScript) => {
             if let Some((cstart, inner)) = subspec_content(full_source, *tok) {
+                // Recurse with the OO-body context computed for this
+                // command's bodies (`body_ctx`) so a method / constructor /
+                // property-accessor body inside a class definition is walked
+                // as ordinary code, while the class body itself stays in OO
+                // context.
                 collect_script(
-                    ctx,
+                    body_ctx,
                     inner,
                     u32::try_from(cstart).unwrap_or(0),
                     entries,
@@ -1681,15 +1755,15 @@ fn emit_arg_token(
             }
         }
         Some(ArgOverride::ExprScript) => {
-            collect_expr(ctx, *tok, entries, depth + 1);
+            collect_expr(plain_ctx, *tok, entries, depth + 1);
         }
         Some(ArgOverride::SwitchRegexpCaseList) => {
-            collect_switch_regexp_case_list(ctx, *tok, entries, depth + 1);
+            collect_switch_regexp_case_list(body_ctx, *tok, entries, depth + 1);
         }
         Some(ArgOverride::KeywordArg) => {
             push_keyword_arg(line_index, full_source, *tok, entries);
         }
-        None => emit_default_arg_token(ctx, *tok, entries, depth),
+        None => emit_default_arg_token(plain_ctx, *tok, entries, depth),
     }
 }
 
@@ -1842,6 +1916,7 @@ fn collect_entries(source: &str, dialect: &str, registry: &CommandRegistry) -> V
         dialect,
         registry,
         line_index: &line_index,
+        inside_oo_body: false,
     };
     collect_script(ctx, source, 0, &mut entries, 0);
 

--- a/rust/tcl-lsp-core/tests/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens.rs
@@ -159,7 +159,7 @@ fn if_elseif_else_are_keywords() {
     }
 }
 
-// -- TclOO definition-body highlighting (issue #747) -----------------------
+// TclOO definition-body highlighting (issue #747).
 //
 // C-Tcl proof: `oo::configurable`, `oo::abstract`, and `oo::singleton` are
 // real Tcl 9.0 metaclasses (`info commands oo::*`) that manufacture classes

--- a/rust/tcl-lsp-core/tests/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens.rs
@@ -50,6 +50,36 @@ fn types(source: &str, dialect: &str) -> Vec<String> {
         .collect()
 }
 
+/// The source substring covered by a decoded token, resolved by
+/// (line, character, length).  Used to assert *which* word carries a kind.
+fn tok_text(source: &str, t: &Tok) -> String {
+    let line = source.split('\n').nth(t.line as usize).unwrap_or("");
+    line.chars()
+        .skip(t.character as usize)
+        .take(t.length as usize)
+        .collect()
+}
+
+/// The token kind covering the first occurrence of `word` in `source`
+/// (matched by column), or `None` if no token starts there.
+fn kind_of_word(source: &str, dialect: &str, word: &str) -> Option<String> {
+    let (needle_line, needle_col) = {
+        let mut found = None;
+        for (li, line) in source.split('\n').enumerate() {
+            if let Some(byte_col) = line.find(word) {
+                let char_col = line[..byte_col].chars().count();
+                found = Some((u32::try_from(li).unwrap(), u32::try_from(char_col).unwrap()));
+                break;
+            }
+        }
+        found?
+    };
+    decode(source, dialect)
+        .into_iter()
+        .find(|t| t.line == needle_line && t.character == needle_col)
+        .map(|t| t.ttype)
+}
+
 #[test]
 fn simple_command_and_word() {
     let t = decode("puts hello", "tcl8.6");
@@ -127,4 +157,166 @@ fn if_elseif_else_are_keywords() {
     for w in ["if", "elseif", "else"] {
         assert!(kw.contains(w), "{w} must be a keyword; got {kw:?}");
     }
+}
+
+// -- TclOO definition-body highlighting (issue #747) -----------------------
+//
+// C-Tcl proof: `oo::configurable`, `oo::abstract`, and `oo::singleton` are
+// real Tcl 9.0 metaclasses (`info commands oo::*`) that manufacture classes
+// with the same `create name ?body?` shape as `oo::class`.  Inside such a
+// definition body the words `superclass` / `self` / `property` / `method`
+// are TclOO definition sub-keywords, and a `method`/`constructor` body holds
+// ordinary Tcl code — so `set x 1` inside it is a real command call.
+
+#[test]
+fn oo_configurable_body_keywords_are_highlighted() {
+    // Regression for #747: `superclass` / `self` / `property` / `method`
+    // inside an `oo::configurable` body must highlight as keywords, exactly
+    // as they already do inside `oo::class`.
+    let src = concat!(
+        "oo::configurable create Widget {\n",
+        "    superclass Base\n",
+        "    self mixin M\n",
+        "    property color\n",
+        "    method paint {} { set x 1 }\n",
+        "}\n",
+    );
+    for kw in ["superclass", "self", "property", "method"] {
+        assert_eq!(
+            kind_of_word(src, "tcl9.0", kw).as_deref(),
+            Some("keyword"),
+            "`{kw}` inside oo::configurable body must be a keyword",
+        );
+    }
+}
+
+#[test]
+fn oo_configurable_method_body_is_recursed() {
+    // The method body `{ set x 1 }` must be tokenised (not emitted as one
+    // opaque string): `set` → function, `1` → number.
+    let src = concat!(
+        "oo::configurable create Widget {\n",
+        "    method paint {} { set x 1 }\n",
+        "}\n",
+    );
+    let toks = decode(src, "tcl9.0");
+    assert!(
+        toks.iter()
+            .any(|t| t.ttype == "function" && tok_text(src, t) == "set"),
+        "method body should tokenise `set` as a function: {toks:?}",
+    );
+    assert!(
+        toks.iter().any(|t| t.ttype == "number"),
+        "method body should tokenise the `1` literal as a number: {toks:?}",
+    );
+}
+
+#[test]
+fn oo_class_method_body_is_recursed() {
+    // Regression for #747 (comment: "even with oo::class it stops at the
+    // method body"): the `method`/`constructor` body inside an oo::class
+    // block must be recursed, not left as one opaque string.
+    let src = concat!(
+        "oo::class create C {\n",
+        "    constructor {} { set y 2 }\n",
+        "    method m {} { puts hello }\n",
+        "}\n",
+    );
+    let toks = decode(src, "tcl9.0");
+    // `puts` (a builtin) inside the method body → function.
+    assert!(
+        toks.iter()
+            .any(|t| t.ttype == "function" && tok_text(src, t) == "puts"),
+        "method body should tokenise `puts`: {toks:?}",
+    );
+    // `set` inside the constructor body → function; `2` → number.
+    assert!(
+        toks.iter()
+            .any(|t| t.ttype == "function" && tok_text(src, t) == "set"),
+        "constructor body should tokenise `set`: {toks:?}",
+    );
+    assert!(
+        toks.iter().any(|t| t.ttype == "number"),
+        "constructor body should tokenise the `2` literal: {toks:?}",
+    );
+}
+
+#[test]
+fn oo_abstract_and_singleton_bodies_are_recursed() {
+    for metaclass in ["oo::abstract", "oo::singleton"] {
+        let src = format!("{metaclass} create C {{\n    method m {{}} {{ set z 3 }}\n}}\n");
+        assert_eq!(
+            kind_of_word(&src, "tcl9.0", "method").as_deref(),
+            Some("keyword"),
+            "`method` inside {metaclass} body must be a keyword",
+        );
+        let toks = decode(&src, "tcl9.0");
+        assert!(
+            toks.iter()
+                .any(|t| t.ttype == "function" && tok_text(&src, t) == "set"),
+            "{metaclass}: method body should tokenise `set`: {toks:?}",
+        );
+    }
+}
+
+#[test]
+fn oo_property_accessor_bodies_are_recursed() {
+    // `property NAME -get { BODY } -set { BODY }` accessor bodies inside a
+    // configurable class must be recursed too.
+    let src = concat!(
+        "oo::configurable create Widget {\n",
+        "    property color -get { return red } -set { set color $value }\n",
+        "}\n",
+    );
+    let toks = decode(src, "tcl9.0");
+    // `return` is itself a language keyword; its presence inside the `-get`
+    // body proves the accessor body was recursed.
+    assert!(
+        toks.iter()
+            .any(|t| t.ttype == "keyword" && tok_text(src, t) == "return"),
+        "`-get` accessor body should tokenise `return`: {toks:?}",
+    );
+    assert!(
+        toks.iter()
+            .any(|t| t.ttype == "function" && tok_text(src, t) == "set"),
+        "`-set` accessor body should tokenise `set`: {toks:?}",
+    );
+    // The `$value` variable substitution inside the `-set` body is recursed.
+    assert!(
+        toks.iter().any(|t| t.ttype == "variable"),
+        "`-set` accessor body should tokenise `$value`: {toks:?}",
+    );
+}
+
+#[test]
+fn top_level_method_is_not_an_oo_body() {
+    // Context guard: a top-level user proc named `method` (outside any OO
+    // definition body) must NOT be treated as an OO method definition.  A
+    // bare `method a b {c}` call at top level is a plain command — its last
+    // braced word must stay an opaque string, not be recursed as a body.
+    let src = "method a b { this is not code }\n";
+    let toks = decode(src, "tcl8.6");
+    // No command inside the braced word should be tokenised as a function;
+    // `this`/`is`/`not`/`code` must never surface as separate command heads.
+    assert!(
+        !toks.iter().any(|t| t.ttype == "function"),
+        "top-level `method` braced arg must not be recursed as a body: {toks:?}",
+    );
+}
+
+#[test]
+fn oo_define_body_form_recurses_method_bodies() {
+    // The `oo::define Cls { … }` script form is an outer OO definition body
+    // too — method bodies inside it must recurse.
+    let src = concat!("oo::define Cls {\n", "    method m {} { puts hi }\n", "}\n",);
+    assert_eq!(
+        kind_of_word(src, "tcl9.0", "method").as_deref(),
+        Some("keyword"),
+    );
+    let toks = decode(src, "tcl9.0");
+    assert!(
+        toks.iter()
+            .any(|t| t.ttype == "function" && tok_text(src, t) == "puts"),
+        "oo::define body method should recurse: {toks:?}",
+    );
 }

--- a/rust/tcl-lsp-core/tests/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens.rs
@@ -320,3 +320,29 @@ fn oo_define_body_form_recurses_method_bodies() {
         "oo::define body method should recurse: {toks:?}",
     );
 }
+
+#[test]
+fn oo_define_member_form_body_is_not_oo_context() {
+    // Issue #747 review (Codex P2): the member form
+    // `oo::define C method m {} { … }` carries an ordinary method body, not
+    // a definition script.  A nested `method a b {not code}` inside it must
+    // NOT be treated as an OO member definition — its `{not code}` stays an
+    // opaque string (no command inside is tokenised as a function).
+    let src = "oo::define C method m {} { method a b {not code} }\n";
+    let toks = decode(src, "tcl9.0");
+    assert!(
+        !toks.iter().any(|t| t.ttype == "function"),
+        "nested `method a b {{not code}}` inside a member-form method body \
+         must not be recursed as an OO body: {toks:?}",
+    );
+    // The real method body itself is still recursed (its own commands are
+    // walked as ordinary code) — a `set` there would tokenise.
+    let src2 = "oo::define C method m {} { set x 1 }\n";
+    let toks2 = decode(src2, "tcl9.0");
+    assert!(
+        toks2
+            .iter()
+            .any(|t| t.ttype == "function" && tok_text(src2, t) == "set"),
+        "member-form method body should still tokenise its own code: {toks2:?}",
+    );
+}

--- a/rust/tcl-registry/src/commands/tcl/oo_abstract.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_abstract.rs
@@ -1,4 +1,5 @@
 //! `TclOO` class.
+use super::oo_class::oo_class_arg_roles;
 use crate::prelude::*;
 const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
     target: SideEffectTarget::InterpState,
@@ -18,7 +19,11 @@ pub fn spec() -> CommandSpec {
         traits: Traits::IS_OO_METACLASS | Traits::LANGUAGE_KEYWORD | Traits::DEFINES_PROCEDURE,
         dialects: Some(DialectSet::TCL90_PLUS),
         arity: Arity::at_least(1),
+        arg_role_resolver: Some(oo_class_arg_roles),
         return_type: Some(TclType::String),
+        // Bodies of `oo::abstract create / new / createWithNamespace`
+        // run in a TclOO definition context, exactly like `oo::class`.
+        body_kind: BodyKind::Structural,
         hover: Some(HoverSnippet {
             summary: "metaclass for abstract classes",
             synopsis: &[

--- a/rust/tcl-registry/src/commands/tcl/oo_class.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_class.rs
@@ -18,7 +18,13 @@ const FORMS: &[FormSpec] = &[FormSpec {
 /// * `oo::class create Name body` → body at index 2.
 /// * `oo::class new body` → body at index 1.
 /// * `oo::class createWithNamespace Name ::ns body` → body at index 3.
-fn oo_class_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+///
+/// Shared by every `IS_OO_METACLASS` command (`oo::class`,
+/// `oo::configurable`, `oo::abstract`, `oo::singleton`) — they all
+/// manufacture classes with the same `create` / `new` /
+/// `createWithNamespace` shapes, so their definition-body argument
+/// lives at the same index.
+pub(crate) fn oo_class_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
     let n = args.len();
     if n < 2 {
         return Vec::new();

--- a/rust/tcl-registry/src/commands/tcl/oo_configurable.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_configurable.rs
@@ -1,4 +1,5 @@
 //! `TclOO` class.
+use super::oo_class::oo_class_arg_roles;
 use crate::prelude::*;
 const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
     target: SideEffectTarget::InterpState,
@@ -18,7 +19,12 @@ pub fn spec() -> CommandSpec {
         traits: Traits::IS_OO_METACLASS | Traits::LANGUAGE_KEYWORD | Traits::DEFINES_PROCEDURE,
         dialects: Some(DialectSet::TCL90_PLUS),
         arity: Arity::at_least(1),
+        arg_role_resolver: Some(oo_class_arg_roles),
         return_type: Some(TclType::String),
+        // Bodies of `oo::configurable create / new / createWithNamespace`
+        // run in a TclOO definition context (not the caller's frame),
+        // exactly like `oo::class`.
+        body_kind: BodyKind::Structural,
         hover: Some(HoverSnippet {
             summary: "class that supports configurable properties",
             synopsis: &[

--- a/rust/tcl-registry/src/commands/tcl/oo_singleton.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_singleton.rs
@@ -1,4 +1,5 @@
 //! `TclOO` class.
+use super::oo_class::oo_class_arg_roles;
 use crate::prelude::*;
 const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
     target: SideEffectTarget::InterpState,
@@ -18,7 +19,11 @@ pub fn spec() -> CommandSpec {
         traits: Traits::IS_OO_METACLASS | Traits::LANGUAGE_KEYWORD | Traits::DEFINES_PROCEDURE,
         dialects: Some(DialectSet::TCL90_PLUS),
         arity: Arity::at_least(1),
+        arg_role_resolver: Some(oo_class_arg_roles),
         return_type: Some(TclType::String),
+        // Bodies of `oo::singleton create / new / createWithNamespace`
+        // run in a TclOO definition context, exactly like `oo::class`.
+        body_kind: BodyKind::Structural,
         hover: Some(HoverSnippet {
             summary: "metaclass for singleton classes",
             synopsis: &[


### PR DESCRIPTION
## Summary

Fixes #747. Semantic highlighting stopped inside `oo::configurable` definition bodies and at every `method` / `constructor` body (even in `oo::class`). Two root causes:

1. **Missing metaclass metadata.** `oo::configurable`, `oo::abstract`, and `oo::singleton` are all `IS_OO_METACLASS` commands that manufacture classes with the same `create name ?body?` shape as `oo::class`, but they lacked an `arg_role_resolver` and `body_kind`. Their definition body was therefore never recognised as an OO body, so `superclass` / `self mixin` / `property` / `method` inside it were rendered as one opaque string.
2. **Inner sub-keywords have no `CommandSpec`.** Inside any OO definition body the words `method` / `constructor` / `destructor` / `self …` / `property -get/-set` are not registry commands, so the recursive walkers couldn't tell that their final braced word is a script body — every method/constructor body was emitted as one opaque string.

Changes:

- **Registry**: give `oo::configurable` / `oo::abstract` / `oo::singleton` the shared `oo_class_arg_roles` resolver and `body_kind: Structural`, matching `oo::class` (`oo_class_arg_roles` promoted to `pub(crate)`).
- **New `tcl-lsp-core::oo_body` module**: centralises the context-sensitive OO-definition-body model — outer vs inner definition commands, inner body-arg indices, and the `inside_oo_body` transition. The outer-command check is registry-trait-driven (`IS_OO_METACLASS`), so any metaclass is covered automatically.
- **`folding`**: refactored to reuse the shared module (its old hardcoded outer-command list omitted `oo::configurable`), so method bodies now fold in every metaclass.
- **`semantic_tokens`**: threads the same `inside_oo_body` context through the recursion and recurses inner OO sub-keyword bodies.

Result: highlighting inside `oo::configurable` reaches parity with `oo::class`, and method / constructor / property-accessor bodies are tokenised in every metaclass and in the `oo::define` / `oo::objdefine` body forms.

## Validation

Ran on the workspace's target toolchain (Rust 1.96.1):

- `cargo test -p tcl-lsp-core` — lib (707) incl. new `oo_body` + folding tests, plus `--test semantic_tokens` (15 new/updated).
- `cargo test -p tcl-registry --lib` (184) and the registry sweep/commands suites.
- `cargo test -p tcl-compiler` and the `tcl-lsp-server` `e2e` suite (562) — no regressions from the `body_kind: Structural` change.
- `cargo xtask {gen-editor-catalogs,gen-editor-settings,gen-vscode-package,gen-jetbrains-catalog,gen-ai-diagnostics,diag-tables} --check` — no generated-file drift.
- `rustfmt --check` and `cargo clippy --all-targets` (pedantic) on the changed crates — the new/changed code is clean.

- [x] I ran relevant tests/checks locally and listed the exact commands.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — No new contract. It extends the existing `oo::class` metaclass contract (definition bodies are `Structural` OO bodies; `create`/`new`/`createWithNamespace` carry the body arg) to the sibling metaclasses `oo::configurable` / `oo::abstract` / `oo::singleton`, bringing them to parity.
- [x] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A (parity fix, no contract change).
- [x] If I added a new compiler KCS note, I linked it from both READMEs. — N/A (no new note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TUacMvjd2PJaqy2iHPuLUZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TUacMvjd2PJaqy2iHPuLUZ)_