### PR TITLE
fix(semantic_tokens): highlight multi-line string literals per line (#757)

### DIFF
--- a/editors/vscode/src/test/semanticTokens.test.ts
+++ b/editors/vscode/src/test/semanticTokens.test.ts
@@ -99,4 +99,44 @@ suite("Semantic Tokens", () => {
       `bareword 'proc' argument must stay a string, got '${procTok.type}'`,
     );
   });
+
+  // Issue #757: a braced string literal spanning multiple lines lost its
+  // highlighting (the enclosing multi-line `string` token was dropped).  It
+  // must now carry a `string` token on every covered line, just like the
+  // quoted form.
+  test("multi-line braced string literal is highlighted on every line", async () => {
+    const uri = getDocUri("multilineString.tcl");
+    await activate(uri);
+
+    const tokens = (await vscode.commands.executeCommand(
+      "vscode.provideDocumentSemanticTokens",
+      uri,
+    )) as vscode.SemanticTokens;
+    const legend = (await vscode.commands.executeCommand(
+      "vscode.provideDocumentSemanticTokensLegend",
+      uri,
+    )) as vscode.SemanticTokensLegend;
+    assert.ok(tokens && legend, "expected semantic tokens and a legend");
+
+    const decoded = decodeTokens(tokens, legend);
+    const stringLines = new Set(decoded.filter((t) => t.type === "string").map((t) => t.line));
+    // The braced literal spans lines 0..2; each must carry a string token.
+    for (const line of [0, 1, 2]) {
+      assert.ok(
+        stringLines.has(line),
+        `braced literal line ${line} must carry a string token, got string lines ${JSON.stringify([
+          ...stringLines,
+        ])}`,
+      );
+    }
+    // The quoted literal spans lines 3..5 — highlighted the same way.
+    for (const line of [3, 4, 5]) {
+      assert.ok(
+        stringLines.has(line),
+        `quoted literal line ${line} must carry a string token, got string lines ${JSON.stringify([
+          ...stringLines,
+        ])}`,
+      );
+    }
+  });
 });

--- a/editors/vscode/testFixture/multilineString.tcl
+++ b/editors/vscode/testFixture/multilineString.tcl
@@ -1,0 +1,6 @@
+set braced {some long
+string that spans
+multiple lines}
+set quoted "some long
+string that spans
+multiple lines"

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -2213,13 +2213,24 @@ fn push_comment_tokens(source: &str, line_index: &LineIndex, entries: &mut Vec<E
             let comment_start = u32::try_from(idx).unwrap_or(0);
             let pos = line_index.position_at_utf16(comment_start, source);
             let len_utf16 = utf16_len(&source[idx..p]);
-            entries.push((
-                pos.line,
-                pos.character.get(),
-                len_utf16,
-                TokenKind::Comment,
-                0,
-            ));
+            // A `#` is only a Tcl comment in command position.  This naive scan
+            // can't see command position, but a physical line already covered by
+            // an emitted token is inside a multi-line string / braced literal
+            // (whose per-line entries are pushed before this scan), so the `#`
+            // there is literal text, not a comment.  Suppress the comment to
+            // avoid an overlapping token the LSP client would reject (#757).
+            let already_covered = entries.iter().any(|(l, c, ln, _, _)| {
+                *l == pos.line && *c <= pos.character.get() && pos.character.get() < *c + *ln
+            });
+            if !already_covered {
+                entries.push((
+                    pos.line,
+                    pos.character.get(),
+                    len_utf16,
+                    TokenKind::Comment,
+                    0,
+                ));
+            }
             // Skip the remainder of the comment line; the terminating `\n`
             // (at `p`) is processed normally and resets `line_start`.
             skip_until = p;

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1406,7 +1406,8 @@ fn classify_regex_component(matched: &str) -> TokenKind {
 }
 
 /// Push one regex sub-token at absolute byte offset `abs_off` covering
-/// `text`.  Skips empty / multi-line runs.
+/// `text`.  Skips empty runs; a multi-line run is split into one entry per
+/// covered line (see [`push_span_entries`]).
 fn push_subtoken(
     source: &str,
     line_index: &LineIndex,
@@ -1415,12 +1416,59 @@ fn push_subtoken(
     kind: TokenKind,
     entries: &mut Vec<Entry>,
 ) {
-    if text.is_empty() || text.contains('\n') {
+    push_span_entries(source, line_index, abs_off, text, kind, 0, entries);
+}
+
+/// Emit token [`Entry`] values for `text` at absolute byte offset `abs_off`.
+///
+/// The LSP semantic-tokens encoding cannot represent a single token spanning
+/// a newline (each token carries only a length, not an end position), so a
+/// multi-line token is split into one entry per covered line, each covering
+/// that line's slice of the token.  This keeps multi-line literals — braced
+/// (`{…}`) or quoted (`"…"`) strings that span lines (issue #757) — highlighted
+/// rather than dropped.  Empty per-line slices (blank lines, the trailing
+/// slice after a final newline) are skipped, and the newline / `\r` bytes
+/// themselves are never covered.
+fn push_span_entries(
+    source: &str,
+    line_index: &LineIndex,
+    abs_off: usize,
+    text: &str,
+    kind: TokenKind,
+    modifiers: u32,
+    entries: &mut Vec<Entry>,
+) {
+    if text.is_empty() {
         return;
     }
-    let pos = line_index.position_at_utf16(u32::try_from(abs_off).unwrap_or(0), source);
-    let len_utf16 = utf16_len(text);
-    entries.push((pos.line, pos.character.get(), len_utf16, kind, 0));
+    if !text.contains('\n') {
+        let pos = line_index.position_at_utf16(u32::try_from(abs_off).unwrap_or(0), source);
+        entries.push((
+            pos.line,
+            pos.character.get(),
+            utf16_len(text),
+            kind,
+            modifiers,
+        ));
+        return;
+    }
+    let mut off = 0usize;
+    for line in text.split_inclusive('\n') {
+        let seg = line.strip_suffix('\n').unwrap_or(line);
+        let seg = seg.strip_suffix('\r').unwrap_or(seg);
+        if !seg.is_empty() {
+            let pos =
+                line_index.position_at_utf16(u32::try_from(abs_off + off).unwrap_or(0), source);
+            entries.push((
+                pos.line,
+                pos.character.get(),
+                utf16_len(seg),
+                kind,
+                modifiers,
+            ));
+        }
+        off += line.len();
+    }
 }
 
 /// Maximum body / expr / command-substitution recursion depth — guards
@@ -2215,16 +2263,19 @@ fn push_token(
     if end <= start {
         return;
     }
-    let pos = line_index.position_at_utf16(start, source);
     let text = source.get(start as usize..end as usize).unwrap_or("");
-    // Skip multi-line tokens — LSP encoding wants per-line
-    // entries; multi-line tokens would need splitting.
-    // Drop them.
-    if text.contains('\n') {
-        return;
-    }
-    let len_utf16 = utf16_len(text);
-    entries.push((pos.line, pos.character.get(), len_utf16, kind, modifiers));
+    // The LSP encoding wants per-line entries, so a multi-line token (a braced
+    // or quoted string literal spanning lines) is split into one entry per
+    // line rather than dropped — see [`push_span_entries`] and issue #757.
+    push_span_entries(
+        source,
+        line_index,
+        start as usize,
+        text,
+        kind,
+        modifiers,
+        entries,
+    );
 }
 
 /// Emit a structural keyword word (`if`'s then/elseif/else, `try`'s

--- a/rust/tcl-lsp-core/tests/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens.rs
@@ -399,3 +399,57 @@ fn multiline_literal_tokens_never_span_a_newline() {
         );
     }
 }
+
+#[test]
+fn hash_inside_multiline_literal_is_string_not_overlapping_comment() {
+    // Issue #757 review (Codex P1): a physical line inside a multi-line literal
+    // whose first non-whitespace char is `#` is literal text, not a comment.
+    // The per-line string entry must be the only token on that line — the
+    // comment scanner must not also emit an overlapping `comment` token (which
+    // an LSP client would reject).
+    for src in [
+        "set x {a\n# not a comment\nb}\n",
+        "set x \"a\n# not a comment\nb\"\n",
+        "set x {a\n   # indented\nb}\n",
+    ] {
+        let toks = decode(src, "tcl9.0");
+        // The `#` line (line 1) is a string, never a comment.
+        let line1: Vec<&Tok> = toks.iter().filter(|t| t.line == 1).collect();
+        assert!(
+            line1.iter().any(|t| t.ttype == "string"),
+            "line 1 must carry a string token for {src:?}: {toks:?}",
+        );
+        assert!(
+            !line1.iter().any(|t| t.ttype == "comment"),
+            "the `#` inside the literal must not become a comment for {src:?}: {toks:?}",
+        );
+        // No two tokens overlap anywhere in the stream.
+        for (i, a) in toks.iter().enumerate() {
+            for b in &toks[i + 1..] {
+                if a.line == b.line {
+                    let (lo, hi) = if a.character <= b.character {
+                        (a, b)
+                    } else {
+                        (b, a)
+                    };
+                    assert!(
+                        lo.character + lo.length <= hi.character,
+                        "overlapping tokens {a:?} and {b:?} for {src:?}",
+                    );
+                }
+            }
+        }
+    }
+    // A genuine full-line comment is still emitted (not covered by any literal).
+    let real = decode("# a real comment\nset x 1\n", "tcl9.0");
+    assert!(
+        real.iter().any(|t| t.line == 0 && t.ttype == "comment"),
+        "a real top-level comment must still be a comment token: {real:?}",
+    );
+    // A comment inside a recursed proc body is still a comment.
+    let body = decode("proc f {} {\n# real comment\nset x 1\n}\n", "tcl9.0");
+    assert!(
+        body.iter().any(|t| t.line == 1 && t.ttype == "comment"),
+        "a real comment inside a body must still be a comment token: {body:?}",
+    );
+}

--- a/rust/tcl-lsp-core/tests/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens.rs
@@ -346,3 +346,56 @@ fn oo_define_member_form_body_is_not_oo_context() {
         "member-form method body should still tokenise its own code: {toks2:?}",
     );
 }
+
+#[test]
+fn multiline_braced_string_literal_is_highlighted_per_line() {
+    // Issue #757: a braced string literal spanning multiple lines lost its
+    // highlighting entirely (the enclosing `string` token was dropped because
+    // it crossed a newline).  It must now emit one `string` token per covered
+    // line, matching the quoted-string case.
+    let src = "set x {some long\nstring that spans\nmultiple lines}\n";
+    let toks = decode(src, "tcl9.0");
+    for line in 0..=2 {
+        assert!(
+            toks.iter().any(|t| t.line == line && t.ttype == "string"),
+            "line {line} of the braced literal must carry a string token: {toks:?}",
+        );
+    }
+    // A quoted literal spanning the same lines highlights identically — the
+    // two forms now behave the same (the crux of the report).
+    let quoted = "set x \"some long\nstring that spans\nmultiple lines\"\n";
+    let qtoks = decode(quoted, "tcl9.0");
+    let strings_on = |toks: &[Tok]| -> Vec<(u32, u32, u32)> {
+        toks.iter()
+            .filter(|t| t.ttype == "string")
+            .map(|t| (t.line, t.character, t.length))
+            .collect()
+    };
+    assert_eq!(
+        strings_on(&toks),
+        strings_on(&qtoks),
+        "braced and quoted multi-line string literals must highlight identically",
+    );
+}
+
+#[test]
+fn multiline_literal_tokens_never_span_a_newline() {
+    // The per-line split keeps the LSP invariant that no single emitted token
+    // crosses a line boundary — every string entry stays within one line's
+    // bounds (character + length must not exceed that line's length).
+    let src = "set x {alpha\nbeta gamma\ndelta}\n";
+    let toks = decode(src, "tcl9.0");
+    for t in &toks {
+        let line_chars = src
+            .split('\n')
+            .nth(t.line as usize)
+            .unwrap_or("")
+            .chars()
+            .count();
+        assert!(
+            (t.character + t.length) as usize <= line_chars,
+            "token {t:?} overruns line {} (len {line_chars})",
+            t.line,
+        );
+    }
+}

--- a/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
+++ b/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
@@ -119,6 +119,13 @@ fn invariant_corpus() -> Vec<(&'static str, &'static str)> {
             "switch_braced",
             "switch $x {\n  {a b} { puts one }\n  default { puts def }\n}\n",
         ),
+        // Issue #757 review (Codex P1): a `#`-leading physical line inside a
+        // multi-line literal must not produce a `comment` token overlapping the
+        // per-line `string` token.  Exercises the non-overlap invariant.
+        (
+            "hash_in_multiline_literal",
+            "set x {a\n# not a comment\nb}\nset y \"a\n  # also literal\nb\"\n",
+        ),
     ];
     v.sort_by(|a, b| a.0.cmp(b.0));
     v

--- a/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
+++ b/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
@@ -280,6 +280,49 @@ fn test_braced_string() {
 }
 
 #[test]
+fn test_multiline_braced_string_highlighted_per_line() {
+    // Issue #757: a braced string literal spanning multiple lines used to lose
+    // its highlighting (the enclosing multi-line `string` token was dropped).
+    // End-to-end it must now carry a `string` token on every covered line,
+    // exactly like the quoted form.
+    let mut lsp = Lsp::tcl();
+    let lg = legend(&lsp);
+    let braced = open_doc(&mut lsp, "set x {some long\nstring that spans\nmultiple lines}\n");
+    let btoks = typed(&mut lsp, &lg, &braced);
+    for line in 0..=2 {
+        assert!(
+            btoks.iter().any(|t| t.line == line && t.ttype == "string"),
+            "braced literal line {line} must carry a string token: {btoks:?}",
+        );
+    }
+    // The quoted counterpart highlights the same span the same way.
+    let quoted = open_doc(&mut lsp, "set x \"some long\nstring that spans\nmultiple lines\"\n");
+    let qtoks = typed(&mut lsp, &lg, &quoted);
+    let strings = |toks: &[TypedToken]| -> Vec<(i64, i64, i64)> {
+        toks.iter()
+            .filter(|t| t.ttype == "string")
+            .map(|t| (t.line, t.char, t.length))
+            .collect()
+    };
+    assert_eq!(
+        strings(&btoks),
+        strings(&qtoks),
+        "braced and quoted multi-line string literals must highlight identically",
+    );
+    // No emitted token may span a newline (LSP encoding invariant).
+    for t in &btoks {
+        let line = "set x {some long\nstring that spans\nmultiple lines}\n"
+            .split('\n')
+            .nth(t.line as usize)
+            .unwrap_or("");
+        assert!(
+            (t.char + t.length) as usize <= line.chars().count(),
+            "token {t:?} overruns its line",
+        );
+    }
+}
+
+#[test]
 fn test_if_elseif_else_body_recursion() {
     let mut lsp = Lsp::tcl();
     let lg = legend(&lsp);


### PR DESCRIPTION
## Summary

- Fixes #757: a braced string literal spanning multiple lines lost its semantic highlighting entirely.
- **Root cause:** in the semantic-tokens provider (`rust/tcl-lsp-core/src/semantic_tokens.rs`), `push_token` (and `push_subtoken`) *dropped* any token whose text crossed a newline — the LSP encoding can't represent a token spanning a newline, and the old code discarded it rather than splitting it. Quoted multi-line strings only *appeared* fine because the editor's TextMate grammar covers `"..."` across lines while `{...}` relies solely on semantic tokens.
- **Fix:** added a shared `push_span_entries` helper that splits a multi-line token into **one entry per covered line** (each covering that line's slice, never the `\n`/`\r` bytes) instead of dropping it. Both `push_token` and `push_subtoken` route through it, so braced and quoted multi-line literals now highlight identically, while preserving the LSP invariant that no single token spans a newline.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Run from `rust/` (this environment ships Rust 1.95 vs the workspace MSRV 1.96, hence `--ignore-rust-version`; it compiles cleanly):

- `cargo test --ignore-rust-version -p tcl-lsp-core` — 708 lib + all integration tests pass (incl. 2 new: per-line highlighting + the no-token-spans-a-newline invariant).
- `cargo test --ignore-rust-version -p tcl-lsp-server --test e2e` — **563 pass** (was 562; +1 new e2e test against the packaged server over JSON-RPC).
- `cargo clippy --ignore-rust-version -p tcl-lsp-core` — clean on the changed file.
- `rustfmt --check` — clean on the changed files.

Editor coverage: added a VS Code integration test (`editors/vscode/src/test/semanticTokens.test.ts`) plus a `multilineString.tcl` fixture — type-checked, Prettier-formatted, ESLint-clean. (The full VS Code integration *harness* can't bootstrap in this container — it needs a generated `tk_system.md` canonical asset not produced here plus a VS Code download — so the test was validated statically against the existing `structuralKeywords` test pattern.)

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — **No.** This is a presentation-layer fix in the LSP semantic-tokens encoder; it changes how already-parsed tokens are emitted (per-line split vs dropped), not any compiler/analysis contract.
- [ ] N/A — no KCS note needed.
- [ ] N/A — no new KCS note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UPMxNW8q6yv7Jdvw85huyz

---
_Generated by [Claude Code](https://claude.ai/code/session_01UPMxNW8q6yv7Jdvw85huyz)_