### PR TITLE
fix(analyser): don't flag a loop-body-defined var read after the loop (W210, #756)

### DIFF
--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -2779,7 +2779,87 @@ optimiser's IR-level static-`for` summary is unaffected; codegen
 
 - `analyser::diagnostics::tests::fp_rbs_18_guaranteed_for_defines_body_vars`
   (FP: statically-true entry condition; TP controls: false entry condition,
-  stale-constant `set i $n` init, `incr` in init).
+  provably-empty `incr` init; may-run stale-constant `set i $n` init and
+  upvar-writing init are now silent — see FP-RBS-19).
+
+---
+
+### FP-RBS-19 — a may-run loop whose body defines a variable is assumed to run (#756)
+
+- **Verdict:** FALSE POSITIVE (W210) — a variable assigned inside a loop body
+  and read *after* the loop was flagged read-before-set because the loop
+  *might* iterate zero times. tclsh only errors when the iterator list /
+  condition is actually empty at runtime; on real (non-empty) data the body
+  runs and the variable is defined, so the after-loop read is safe.
+- **Status:** FIXED. Reported by a user (issue #756) hitting the
+  `foreach … { lappend acc … }` accumulator idiom on real code
+  (SpiceGenTcl / ngspice). Supersedes the earlier decision (FP-RBS-16/17/18 TP
+  controls) that a may-run loop *must* fire; only a **provably** zero-iteration
+  loop, or a body that leaves the variable unset on some run, still fires.
+- **Codes:** W210
+- **Corpus:** `SpiceGenTcl` `foreach time [dict get $data time] … { lappend
+  timeVout … }` and the accumulate-in-loop idiom throughout.
+
+#### Reproducer
+
+```tcl
+set data [getDataDict]
+foreach time [dict get $data time] vout [dict get $data osc_out] {
+    lappend timeVout [list $time $vout]
+}
+puts $timeVout   ;# defined whenever the loop ran — not read-before-set
+```
+
+#### Per-line reasoning
+
+1. `foreach time [dict get $data time] …` — a *dynamic* iterator list. The
+   analyser cannot prove it non-empty, so it models the loop as possibly zero
+   iterations (the header's zero-trip exit edge stays executable).
+2. `lappend timeVout …` — the body **unconditionally** assigns `timeVout` on
+   every iteration; the loop-header phi that reaches the after-loop read is
+   undef **only** via the zero-trip entry edge.
+3. `puts $timeVout` — reached only *after* the loop. Matching C Tcl (which
+   errors only when `[dict get $data time]` is actually empty at runtime, not
+   merely when it could be), we assume a may-run loop runs, so `timeVout` is
+   defined. No W210.
+
+#### tclsh ground truth (8.6 / 9.0)
+
+`set l {1 2 3}; foreach x $l { set y $x }; puts $y` → `3` (no error). Only an
+actually-empty list errors: `set l {}; foreach x $l { set y $x }; puts $y` →
+`can't read "y"`. A *provably* empty literal (`foreach x {} …`) or a
+`while 0` / false-on-entry `for` is statically empty and still fires.
+
+#### Why the analyser reaches that verdict
+
+`build_loop_entry_only_undef` (in `analyser/diagnostics/helpers.rs`) walks the
+natural-loop forest (built over the SCCP-executable subgraph, so a provably
+dead body forms no loop). For each loop-header phi in `can_undef` whose every
+*back-edge* operand is itself defined — the body assigns the variable on every
+iteration — it records the phi as loop-entry-only-undef together with the
+loop's body-block set. A provably-empty `foreach` (all iterator lists split to
+zero elements) is excluded, so it keeps firing. The read-before-set emitters
+(`record_chain_w210_uses` and `return_read_fires_w210`) then suppress a read of
+such a version when its block is **outside** the loop body — a read *inside*
+the body (a first-iteration use before the set) still fires. `while`/`for`
+loops with a constant-false condition are already pruned by SCCP, so only the
+opaque-`foreach`-empty-literal case needs the explicit provably-empty guard.
+
+#### Tests
+
+- `analyser::diagnostics::fp::rbs::fp_rbs_19_*` (FP: the reporter's
+  dynamic-foreach `lappend` accumulator; may-run `while`/`for`; TP controls:
+  provably-empty literal, conditional-def-in-body, first-iteration in-body
+  read).
+- Flipped TP controls now asserting silence: `fp_rbs_16_normal_while_*`,
+  `fp_rbs_17_dynamic_list_*`, `fp_rbs_18_unknown_bound_*`,
+  `fp_rbs_18_stale_const_init_*`, and `tests::w210_loop_body_accumulator_*`.
+- Rotation-classification coverage that the flipped W210 proxies used to
+  provide moved to `cfg::for_rotation_requires_a_non_stale_constant_init`.
+- LSP e2e: `tests::e2e::diagnostics::{foreach_accumulator_after_loop_silent,
+  foreach_empty_literal_after_loop_still_fires, normal_while_body_defined_silent}`.
+- VS Code: `precisionFalsePositives.test.ts` "dynamic-loop after-loop reads
+  stay silent (#756)" over `controlFlowRbs.tcl`.
 
 ---
 

--- a/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
+++ b/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
@@ -60,6 +60,32 @@ idioms for a single exact name: `[info vars X] ne ""`,
 (`info globals` is not used — it proves the *global* exists, not the bare-`$X`
 local — and glob patterns are not statically decidable.)
 
+## Variables set inside a loop
+
+A variable assigned inside a loop body and read *after* the loop is **not**
+flagged, as long as the body sets it on every iteration:
+
+```tcl
+foreach item $items {
+    lappend result $item
+}
+puts $result        ;# not flagged — assumed the loop ran at least once
+```
+
+The analyser assumes a loop that *might* run does run, matching how the code
+behaves on real (non-empty) data. Two cases still fire, because they are
+genuine errors:
+
+- A **provably empty** loop never runs its body, so the variable is definitely
+  unset: `foreach x {} { set y $x }; puts $y`, or a `while 0` / a `for` whose
+  condition is false on entry.
+- A read **inside** the loop body, *before* the body's own assignment, is a
+  first-iteration read-before-set: `foreach x $items { puts $y; set y $x }`.
+
+A body that assigns the variable only under an inner condition
+(`foreach x $items { if {$x} { set y 1 } }; puts $y`) is also still flagged —
+the variable can be unset even when the loop runs.
+
 ## How to suppress
 
 Add `# noqa: W210` at the end of the offending line.

--- a/editors/vscode/src/test/precisionFalsePositives.test.ts
+++ b/editors/vscode/src/test/precisionFalsePositives.test.ts
@@ -155,6 +155,23 @@ suite("Control-flow read-before-set (PR #634)", () => {
       );
     }
   });
+
+  // FP-RBS-19 (#756): a may-run loop whose body defines the variable is assumed
+  // to run, so the after-loop reads (`return $acc` on line 21, `puts $y` on
+  // line 25) must stay silent — while the provably-empty foreach read (line 15)
+  // still fires.
+  test("dynamic-loop after-loop reads stay silent (false case, #756)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W210"),
+    });
+    for (const ln of linesWithCode(diags, "W210")) {
+      assert.ok(
+        ![21, 25].includes(ln),
+        `unexpected W210 on a may-run-loop after-loop read (line ${ln})`,
+      );
+    }
+  });
 });
 
 // FP-STY-15 — `$` before a closing `"` is a literal regex end-anchor.

--- a/editors/vscode/testFixture/controlFlowRbs.tcl
+++ b/editors/vscode/testFixture/controlFlowRbs.tcl
@@ -15,3 +15,13 @@ proc fires_empty_foreach {} {
     foreach x {} { set y $x }
     puts $y
 }
+# FP-RBS-19 (#756) — a may-run loop whose body defines the variable is assumed
+# to run, so an after-loop read is silent (matches C Tcl).
+proc silent_dynamic_foreach_accumulator {items} {
+    foreach v $items { lappend acc $v }
+    return $acc
+}
+proc silent_dynamic_while {n} {
+    while {$n > 0} { set y 1; incr n -1 }
+    puts $y
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -881,7 +881,7 @@ file; this call falls through to the 'unknown' handler."
             if supp.suppresses(var) {
                 continue;
             }
-            self.record_chain_w210_uses(fu, chain, &exists_guards, &mut w210_min);
+            self.record_chain_w210_uses(fu, chain, &exists_guards, supp, &mut w210_min);
         }
 
         let mut entries: Vec<(String, tcl_lexer::Span)> = w210_min.into_iter().collect();
@@ -911,6 +911,7 @@ file; this call falls through to the 'unknown' handler."
         fu: &crate::compilation_unit::FunctionUnit,
         chain: &crate::def_use::DefUseChain,
         exists_guards: &[(String, crate::cfg::BlockId)],
+        supp: &UndefSuppression,
         w210_min: &mut std::collections::HashMap<String, tcl_lexer::Span>,
     ) {
         use crate::def_use::UseKind;
@@ -919,6 +920,14 @@ file; this call falls through to the 'unknown' handler."
         let (var, _version) = &chain.key;
         for use_site in &chain.uses {
             if matches!(use_site.kind, UseKind::PhiIncoming) {
+                continue;
+            }
+            // An after-loop read of a variable the loop body defines on every
+            // iteration is not read-before-set (see
+            // `UndefSuppression::loop_entry_only_undef`): we assume a may-run
+            // loop runs, matching C Tcl. A read *inside* the loop body still
+            // fires.
+            if supp.after_loop_defined(&chain.key, &use_site.block) {
                 continue;
             }
             let Some(block) = fu.cfg.block_by_name(&use_site.block) else {
@@ -1151,6 +1160,15 @@ file; this call falls through to the 'unknown' handler."
             || is_implicit_var(name)
             || name.contains("::")
             || ctx.supp.suppresses(name)
+        {
+            return false;
+        }
+        // An after-loop `return` of a variable the loop body defines on every
+        // iteration is not read-before-set (we assume a may-run loop runs,
+        // matching C Tcl); the return block sits outside the loop body.
+        if ctx
+            .supp
+            .after_loop_defined(&(name.to_string(), ver), fu.cfg.block_name(bn))
         {
             return false;
         }

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
@@ -1102,12 +1102,16 @@ fn fp_rbs_16_while1_conditional_break_silent() {
 }
 
 #[test]
-fn fp_rbs_16_normal_while_still_fires() {
-    // TP control: non-constant condition may run zero times; y is maybe-unset.
+fn fp_rbs_16_normal_while_body_defined_silent() {
+    // FP-RBS-19 (#756): a non-constant `while` may run zero times, but its body
+    // unconditionally sets `y`, so a read after the loop is defined whenever the
+    // loop ran. Matching C Tcl (which errors only when the condition is false on
+    // entry at runtime, not merely when it could be), we assume a may-run loop
+    // runs — the after-loop read is not read-before-set.
     let src = "proc f {n} {\n    while {$n > 0} { set y 1; incr n -1 }\n    puts $y\n}\n";
     assert!(
-        fires(src, D, "W210"),
-        "FP-RBS-16 TP: zero-iteration-possible while leaves 'y' maybe-unset; W210 must fire; emitted: {:?}",
+        !fires(src, D, "W210"),
+        "FP-RBS-19: may-run while whose body defines 'y' must NOT fire W210 after the loop; emitted: {:?}",
         codes(src, D)
     );
 }
@@ -1169,12 +1173,16 @@ fn fp_rbs_17_empty_literal_still_fires() {
 }
 
 #[test]
-fn fp_rbs_17_dynamic_list_still_fires() {
-    // TP control: foreach over $var list may be empty; read after is maybe-unset.
+fn fp_rbs_17_dynamic_list_body_defined_silent() {
+    // FP-RBS-19 (#756): a foreach over a *dynamic* list may be empty, but its
+    // body unconditionally sets `y`, so a read after the loop is defined
+    // whenever the loop ran. Matching C Tcl (which errors only when the list is
+    // actually empty at runtime), we assume a may-run loop runs — this is the
+    // exact accumulator idiom the reporter hit (`foreach … { lappend acc … }`).
     let src = "proc f {items} { foreach x $items { set y $x } ; puts $y }\n";
     assert!(
-        fires(src, D, "W210"),
-        "FP-RBS-17 TP: dynamic-list foreach may be empty; W210 must fire; emitted: {:?}",
+        !fires(src, D, "W210"),
+        "FP-RBS-19: dynamic-list foreach whose body defines 'y' must NOT fire W210 after the loop; emitted: {:?}",
         codes(src, D)
     );
 }
@@ -1224,12 +1232,14 @@ fn fp_rbs_18_false_on_entry_still_fires() {
 }
 
 #[test]
-fn fp_rbs_18_unknown_bound_still_fires() {
-    // TP control: for with unknown parameter bound may run zero times.
+fn fp_rbs_18_unknown_bound_body_defined_silent() {
+    // FP-RBS-19 (#756): a `for` with an unknown bound may run zero times, but
+    // its body unconditionally sets `y`, so a read after the loop is defined
+    // whenever the loop ran. Matching C Tcl, we assume a may-run loop runs.
     let src = "proc f {n} { for {set i 0} {$i < $n} {incr i} { set y $i } ; puts $y }\n";
     assert!(
-        fires(src, D, "W210"),
-        "FP-RBS-18 TP: unknown-bound for may run zero times; W210 must fire; emitted: {:?}",
+        !fires(src, D, "W210"),
+        "FP-RBS-19: unknown-bound for whose body defines 'y' must NOT fire W210 after the loop; emitted: {:?}",
         codes(src, D)
     );
 }
@@ -1247,25 +1257,138 @@ fn fp_rbs_18_break_before_set_still_fires() {
 }
 
 #[test]
-fn fp_rbs_18_stale_const_init_still_fires() {
-    // TP (Codex P1): stale const from for-init must be invalidated when overwritten.
+fn fp_rbs_18_stale_const_init_body_defined_silent() {
+    // A stale const from the for-init (`set i $n` overwrites `set i 0`) leaves
+    // the loop may-run (not guaranteed-nonempty; the rotation-soundness of that
+    // classification is covered by the CFG-builder tests). Under FP-RBS-19
+    // (#756) the after-loop read is still silent: the body unconditionally sets
+    // `y`, so a may-run loop is assumed to run, matching C Tcl.
     let src = "proc f {n} { for {set i 0; set i $n} {$i < 3} {incr i} { set y $i }; puts $y }\n";
     assert!(
-        fires(src, D, "W210"),
-        "FP-RBS-18 TP: stale-const for-init must not be treated as guaranteed; W210 must fire; emitted: {:?}",
+        !fires(src, D, "W210"),
+        "FP-RBS-19: may-run for whose body defines 'y' must NOT fire W210 after the loop; emitted: {:?}",
         codes(src, D)
     );
 }
 
 #[test]
-fn fp_rbs_18_incr_in_init_invalidates_const() {
-    // TP (Codex P1, variant): `for {set i 0; incr i 5} {$i < 3} ...` may run zero times.
+fn fp_rbs_18_incr_in_init_provably_empty_fires() {
+    // TP: `for {set i 0; incr i 5} {$i < 3} …` resolves the loop var to `i = 5`,
+    // so `5 < 3` is false — SCCP proves the body dead (a *provably* zero-trip
+    // loop that always errors in tclsh), and W210 still fires. The incr also
+    // invalidates the rotation constant (see the CFG-shape test
+    // `cfg::for_rotation_requires_a_non_stale_constant_init`); unlike a dynamic
+    // may-run bound (FP-RBS-19), this one is statically empty, not merely maybe.
     let src = "proc f {} { for {set i 0; incr i 5} {$i < 3} {incr i} { set y $i }; puts $y }\n";
     assert!(
         fires(src, D, "W210"),
-        "FP-RBS-18 TP: incr-in-init must invalidate the const; W210 must fire; emitted: {:?}",
+        "provably-empty incr-in-init for leaves y unset; W210 must fire; emitted: {:?}",
         codes(src, D)
     );
+}
+
+// ---------------------------------------------------------------------------
+// FP-RBS-19 (#756) — a may-run loop whose body defines a variable is assumed
+// to run: an after-loop read is not read-before-set
+// ---------------------------------------------------------------------------
+
+// The reporter's exact pattern (issue #756): a multi-group `foreach` over
+// dynamic (`dict get`) lists building `lappend` accumulators, read after the
+// loop. tclsh errors only when the iterator lists are actually empty at
+// runtime; on real data the accumulators are defined, so the after-loop reads
+// are not read-before-set.
+const FP_RBS_19_REPRO: &str = "\
+set data [getDataDict]
+foreach time [dict get $data time] vout [dict get $data osc_out] {
+    lappend timeVout [list $time $vout]
+    lappend timeImeas [list $time]
+}
+puts $timeVout
+puts $timeImeas
+";
+
+#[test]
+fn fp_rbs_19_reporter_foreach_accumulator_silent() {
+    assert!(
+        !fires(FP_RBS_19_REPRO, D, "W210"),
+        "FP-RBS-19: dynamic-foreach `lappend` accumulator read after the loop must NOT fire W210; emitted: {:?}",
+        codes(FP_RBS_19_REPRO, D)
+    );
+}
+
+#[test]
+fn fp_rbs_19_provably_empty_literal_still_fires() {
+    // TP control: a *provably* empty literal list runs zero times, so tclsh
+    // always errors — the after-loop read must keep firing.
+    let src = "foreach x {} { lappend acc $x }\nputs $acc\n";
+    assert!(
+        fires(src, D, "W210"),
+        "FP-RBS-19 TP: provably-empty foreach leaves 'acc' unset; W210 must fire; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rbs_19_conditional_def_in_body_still_fires() {
+    // TP control: the body defines `y` only under an inner `if`, so even when
+    // the loop runs `y` may be unset — a genuine read-before-set that fires.
+    let src = "proc f {items} { foreach x $items { if {$x > 0} { set y $x } }\n puts $y }\n";
+    assert!(
+        fires(src, D, "W210"),
+        "FP-RBS-19 TP: conditionally-defined body var may be unset after the loop; W210 must fire; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rbs_19_first_iteration_in_body_read_still_fires() {
+    // TP control: a read *inside* the loop body before the body's own set is a
+    // genuine first-iteration read-before-set — the suppression is confined to
+    // reads reached after the loop.
+    let src = "proc f {items} { foreach x $items { puts $y; set y $x } }\n";
+    assert!(
+        fires(src, D, "W210"),
+        "FP-RBS-19 TP: in-body read before the set must still fire; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rbs_19_nested_loop_accumulator_silent() {
+    // Nested accumulator (`foreach r $rows { foreach c $cols { lappend cells … } }`):
+    // the loop-entry-only-undef analysis converges over nesting, so the inner
+    // loop's defined-on-exit result makes the outer loop entry-only too — the
+    // after-loop read is silent.
+    let src = "proc f {rows cols} { foreach r $rows { foreach c $cols { lappend cells [list $r $c] } }\n return $cells }\n";
+    assert!(
+        !fires(src, D, "W210"),
+        "FP-RBS-19: nested-loop accumulator read after the loops must NOT fire W210; emitted: {:?}",
+        codes(src, D)
+    );
+    // TP control: the inner body defines `y` only conditionally, so even when
+    // both loops run `y` may be unset after them — still fires.
+    let tp = "proc f {rows cols} { foreach r $rows { foreach c $cols { if {$c} { set y 1 } } }\n puts $y }\n";
+    assert!(
+        fires(tp, D, "W210"),
+        "FP-RBS-19 TP: conditionally-defined var in a nested loop may be unset; W210 must fire; emitted: {:?}",
+        codes(tp, D)
+    );
+}
+
+#[test]
+fn fp_rbs_19_while_and_for_may_run_silent() {
+    // A dynamic `while` and an unknown-bound `for` are both may-run loops whose
+    // bodies define the variable — silent after the loop, like the foreach case.
+    for src in [
+        "proc f {n} { while {$n > 0} { set y $n; incr n -1 }\n puts $y }\n",
+        "proc f {n} { for {set i 0} {$i < $n} {incr i} { set y $i }\n puts $y }\n",
+    ] {
+        assert!(
+            !fires(src, D, "W210"),
+            "FP-RBS-19: may-run loop whose body defines 'y' must be silent after the loop; emitted: {:?}",
+            codes(src, D)
+        );
+    }
 }
 
 // ---------------------------------------------------------------------------

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -398,6 +398,20 @@ pub(super) struct UndefSuppression {
     /// read of one is read-before-set; the def-use pass can't express this
     /// because the read targets the *phi* version, not a version-0 origin.
     pub(super) can_undef: FxHashSet<(String, crate::ssa::Version)>,
+    /// Loop-header phi versions whose *only* undef source is the loop's entry
+    /// (zero-trip) edge — the loop body assigns the variable on every back
+    /// edge, so the value is defined whenever the loop ran ≥1 time. Maps each
+    /// such `(name, version)` to the loop's body-block name set.
+    ///
+    /// A read of the version reached *after* the loop (a block outside the
+    /// set) is not read-before-set: matching C Tcl — which errors only when
+    /// the iterator list / condition is actually empty at runtime, not merely
+    /// when it *could* be — we assume a loop that may run does run. A read
+    /// *inside* the loop body (a block in the set) still fires, because a
+    /// first-iteration read before the body's assignment is a genuine error.
+    /// A *provably* empty loop (`foreach x {}`, or a constant-false
+    /// `while`/`for` SCCP already prunes) is excluded, so it keeps firing.
+    pub(super) loop_entry_only_undef: FxHashMap<(String, crate::ssa::Version), FxHashSet<String>>,
 }
 
 impl UndefSuppression {
@@ -411,6 +425,21 @@ impl UndefSuppression {
             || (self.has_dict_with
                 && self.dict_with_any_unknown
                 && !self.explicitly_defined.contains(name))
+    }
+
+    /// True when reading `key` at `block` is a safe *after-loop* read of a
+    /// variable the loop body defines on every iteration (see
+    /// [`Self::loop_entry_only_undef`]): the version is loop-entry-only-undef
+    /// and `block` is outside the loop body. A read inside the loop body still
+    /// fires (first-iteration undef is real).
+    pub(super) fn after_loop_defined(
+        &self,
+        key: &(String, crate::ssa::Version),
+        block: &str,
+    ) -> bool {
+        self.loop_entry_only_undef
+            .get(key)
+            .is_some_and(|body| !body.contains(block))
     }
 
     /// Like [`Self::suppresses`] but **without** the unknown-shape blanket —
@@ -602,11 +631,21 @@ pub(super) fn build_undef_suppression(
             can_undef.insert(key.clone());
         }
     }
+    let loop_entry_only_undef = build_loop_entry_only_undef(
+        fu,
+        considered,
+        &phi_def,
+        &phi_block,
+        &killed,
+        &exists_guards,
+        &can_undef,
+    );
     let mut s = UndefSuppression {
         cmd_sub_writes: collect_expr_cmd_sub_writes(fu, considered),
         dynamic_upvar_locals: crate::optimiser::elimination::scan_dynamic_upvar_locals(&fu.cfg),
         killed,
         can_undef,
+        loop_entry_only_undef,
         ..Default::default()
     };
     harvest_dict_with_suppression(fu, considered, &mut s);
@@ -636,6 +675,128 @@ pub(super) fn build_undef_suppression(
 
     s.alias_tails = collect_qualified_variable_alias_tails(fu, considered);
     s
+}
+
+/// Build the [`UndefSuppression::loop_entry_only_undef`] map: loop-header phi
+/// versions whose sole undef origin is the loop's zero-trip entry edge.
+///
+/// For each natural loop (built over the SCCP-executable subgraph, so a
+/// provably-dead loop body never forms a loop) whose header carries a phi in
+/// `can_undef`, the phi qualifies when *every* back-edge (in-loop
+/// predecessor) operand is itself defined — i.e. the loop body assigns the
+/// variable on each iteration and the only way the phi is undef is by skipping
+/// the loop entirely. A provably-empty `foreach` (all iterator lists are
+/// empty literals) is excluded: its body never runs, so tclsh always errors,
+/// and the read must keep firing.
+fn build_loop_entry_only_undef(
+    fu: &crate::compilation_unit::FunctionUnit,
+    considered: &HashSet<BlockId>,
+    phi_def: &PhiDefMap,
+    phi_block: &PhiBlockMap,
+    killed: &FxHashSet<(String, crate::ssa::Version)>,
+    exists_guards: &[(String, BlockId)],
+    can_undef: &FxHashSet<(String, crate::ssa::Version)>,
+) -> FxHashMap<(String, crate::ssa::Version), FxHashSet<String>> {
+    let mut out: FxHashMap<(String, crate::ssa::Version), FxHashSet<String>> = FxHashMap::default();
+    if can_undef.is_empty() {
+        return out;
+    }
+    let forest = crate::loops::build_loop_forest(&fu.cfg, &fu.ssa, considered);
+    let ctx = PhiUndefCtx {
+        phi_def,
+        phi_block,
+        killed,
+        considered,
+        executable_edges: &fu.sccp.executable_edges,
+        exists_guards,
+        ssa: &fu.ssa,
+    };
+    // Fixpoint over the loop forest so *nested* accumulators converge: an inner
+    // loop whose body defines the variable is itself loop-entry-only-undef, so
+    // for the enclosing loop its exit operand counts as defined (we assume both
+    // loops run). Innermost loops are marked first; a pass that marks nothing
+    // new terminates. Bounded by the forest size (each pass marks ≥1 phi or
+    // stops), so at most `loops.len()` passes.
+    loop {
+        let mut changed = false;
+        for natural in &forest.loops {
+            let Some(header_id) = fu.cfg.block_id(&natural.header) else {
+                continue;
+            };
+            // A provably-empty `foreach` runs zero times: its body-assigned
+            // variables are never set, so tclsh always errors — keep firing.
+            if foreach_header_provably_empty(fu, header_id) {
+                continue;
+            }
+            let body_blocks: FxHashSet<String> = natural.blocks.iter().cloned().collect();
+            let Some(ssa_header) = fu.ssa.blocks.get(&header_id) else {
+                continue;
+            };
+            for phi in &ssa_header.phis {
+                let name = fu.ssa.var_name(phi.name).to_owned();
+                let key = (name.clone(), phi.version);
+                if out.contains_key(&key) || !can_undef.contains(&key) {
+                    continue;
+                }
+                // The phi is "entry-only undef" when no *back-edge* operand can
+                // be undef: a body predecessor that still merges an unset value
+                // is a conditional-def-in-body case (or a break/continue before
+                // the set) that tclsh can still leave unset — those keep firing.
+                // An operand already proven loop-entry-only-undef (a nested
+                // loop's result) counts as defined here.
+                let entry_only = phi.incoming.iter().all(|(&pred, &ver_in)| {
+                    // Only in-loop (back-edge) predecessors gate the verdict;
+                    // the pre-header entry edge carries the zero-trip undef we
+                    // assume away. Non-executable predecessors never read.
+                    if !considered.contains(&pred) {
+                        return true;
+                    }
+                    if !body_blocks.contains(fu.cfg.block_name(pred)) {
+                        return true;
+                    }
+                    if out.contains_key(&(name.clone(), ver_in)) {
+                        return true;
+                    }
+                    let mut seen = FxHashSet::default();
+                    !phi_can_undef(&name, ver_in, &ctx, &mut seen)
+                });
+                if entry_only {
+                    out.insert(key, body_blocks.clone());
+                    changed = true;
+                }
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    out
+}
+
+/// True when `header_id` is the header of a `foreach` / `lmap` / `dict for`
+/// whose iterator lists are *all* statically-empty literals (so the loop body
+/// provably never runs). The synthetic iterator-binding node placed at the
+/// loop header records each iterator list's text in `args`; an argument splits
+/// to zero elements only for an empty literal (a `$`/`[` substitution splits
+/// to a single opaque element, a non-empty literal to ≥1 element).
+fn foreach_header_provably_empty(
+    fu: &crate::compilation_unit::FunctionUnit,
+    header_id: BlockId,
+) -> bool {
+    use crate::ir::Statement;
+    let Some(block) = fu.cfg.blocks.get(&header_id) else {
+        return false;
+    };
+    block.statements.iter().any(|stmt| {
+        matches!(
+            stmt,
+            Statement::Call { foreach_groups: Some(_), args, .. }
+                if !args.is_empty()
+                    && args
+                        .iter()
+                        .all(|a| crate::tcl_expr_eval::split_tcl_list(a).is_empty())
+        )
+    })
 }
 
 /// Local-alias tail names declared by a *qualified* `variable`

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -2100,15 +2100,17 @@ fn fp_rbs_16_dead_loop_exit_phi_operand_not_read_before_set() {
         "while 1 compute/if-break: r set before the only live exit (no W210)",
     );
 
-    // TP control: a non-constant condition may run the body zero times, so
-    // the cond-exit edge IS live and y is genuinely maybe-unset.
+    // FP-RBS-19 (#756): a non-constant condition may run the body zero times,
+    // but the body unconditionally sets y, so a read after the loop is defined
+    // whenever the loop ran. Matching C Tcl, we assume a may-run loop runs.
     assert!(
-        w210_fires_for("proc f {n} { while {$n>0} { set y 1 }\n puts $y }", "y"),
-        "non-constant while condition may run zero times (W210 expected on y)",
+        !w210_fires_for("proc f {n} { while {$n>0} { set y 1 }\n puts $y }", "y"),
+        "may-run while whose body defines y is silent after the loop (no W210)",
     );
 
     // TP control: only one of two break paths sets y, so the exit merges a
-    // genuine unset version on a live edge.
+    // genuine unset version on a live break edge (not the loop-entry edge) —
+    // FP-RBS-19 does not touch this; it still fires.
     assert!(
         w210_fires_for(
             "proc f {c} { while 1 { if {$c} { set y 1; break } else break }\n puts $y }",
@@ -2146,14 +2148,16 @@ fn fp_rbs_17_guaranteed_foreach_defines_body_vars() {
         "empty foreach list runs zero times (W210 expected on y)",
     );
 
-    // TP control: a dynamic (`$i`) list may be empty — not guaranteed.
+    // FP-RBS-19 (#756): a dynamic (`$i`) list may be empty, but the body
+    // unconditionally sets y, so a read after the loop is defined whenever the
+    // loop ran. Matching C Tcl, we assume a may-run loop runs.
     assert!(
-        w210_fires_for("proc f {i} { foreach x $i { set y $x }\n puts $y }", "y"),
-        "dynamic foreach list may be empty (W210 expected on y)",
+        !w210_fires_for("proc f {i} { foreach x $i { set y $x }\n puts $y }", "y"),
+        "may-run dynamic foreach whose body defines y is silent after the loop (no W210)",
     );
 
     // TP control: a first-iteration read-before-set inside the body still
-    // fires — rotation keeps the body's internal order.
+    // fires — the suppression is confined to reads *after* the loop.
     assert!(
         w210_fires_for(
             "proc f {} { foreach x {1 2 3} { puts $acc; set acc $x } }",
@@ -2188,38 +2192,42 @@ fn fp_rbs_18_guaranteed_for_defines_body_vars() {
         "for with false entry condition runs zero times (W210 expected on y)",
     );
 
-    // TP control: a later non-constant write (`set i $n`) in the
-    // init must invalidate the stale `i = 0`, so the condition is unknown.
+    // FP-RBS-19 (#756): a stale-constant init (`set i $n` overwrites `set i 0`)
+    // leaves the loop may-run — but its body unconditionally sets y, so a read
+    // after the loop is silent (we assume a may-run loop runs). The rotation
+    // decision itself (that a stale-const init is NOT claimed guaranteed) is
+    // pinned directly on the CFG shape in
+    // `cfg::for_rotation_requires_a_non_stale_constant_init`.
     assert!(
-        w210_fires_for(
+        !w210_fires_for(
             "proc f {n} { for {set i 0; set i $n} {$i<3} {incr i} { set y $i }\n puts $y }",
             "y",
         ),
-        "stale-constant for-init must not be claimed guaranteed (W210 on y)",
+        "may-run for whose body defines y is silent after the loop (no W210)",
     );
 
-    // TP control: an `incr` in the init likewise invalidates the
-    // constant binding (we don't fold incr in the init env).
+    // TP control: an `incr` in the init resolves the loop var to `i = 5`, so
+    // SCCP folds `5 < 3` to false and the body is provably dead — a genuine
+    // zero-iteration loop that leaves y unset. Still fires.
     assert!(
         w210_fires_for(
             "proc f {} { for {set i 0; incr i 5} {$i<3} {incr i} { set y $i }\n puts $y }",
             "y",
         ),
-        "incr in for-init invalidates the constant binding (W210 on y)",
+        "provably-empty for (incr init makes 5<3 false) leaves y unset (W210 on y)",
     );
 
-    // TP control: an init call to a proc that writes the loop var
-    // through `upvar` must invalidate the stale constant — the upvar pass
-    // adds the caller-side def, so `init_written_names` (via
-    // apply_upvar_invalidation) drops `i` and the loop is not claimed
-    // guaranteed. Here `setter` sets `i = 5`, so `5 < 3` is false → zero
-    // iterations → `y` unset → W210 must fire.
+    // FP-RBS-19 (#756): an init call writing the loop var through `upvar` leaves
+    // the loop may-run (SCCP cannot see through the call), so the after-loop
+    // read of the body-defined y is silent. The invalidation itself (the loop
+    // is NOT claimed guaranteed) is pinned on the CFG shape in
+    // `cfg::for_rotation_requires_a_non_stale_constant_init`.
     assert!(
-        w210_fires_for(
+        !w210_fires_for(
             "proc setter {} { upvar 1 i i; set i 5 }\nproc f {} { for {set i 0; setter} {$i < 3} {incr i} { set y $i }\n puts $y }",
             "y",
         ),
-        "upvar-writing call in for-init invalidates the constant (W210 on y)",
+        "may-run for (upvar-writing init call) whose body defines y is silent after the loop (no W210)",
     );
 
     // FP guard: a *benign* call in the init (one that does not write the
@@ -3349,11 +3357,23 @@ fn w210_phi_undef_use_after_unset_return() {
 }
 
 #[test]
-fn w210_phi_undef_loop_body_only_init_return() {
+fn w210_loop_body_accumulator_read_after_loop_silent() {
+    // FP-RBS-19 (#756): the reporter's exact pattern — a `lappend` accumulator
+    // built inside a dynamic `foreach`, returned after the loop. The body
+    // defines `r` on every iteration, so a read after the loop is defined
+    // whenever the loop ran. Matching C Tcl (which errors only when `$items` is
+    // actually empty at runtime), we assume a may-run loop runs.
     let got = w210_codes("proc f {items} { foreach i $items { lappend r $i }\n return $r }");
     assert!(
-        got.iter().any(|m| m.contains("'r'")),
-        "loop-body-only init + return must fire W210; got {got:?}"
+        got.is_empty(),
+        "after-loop return of a loop-body accumulator must be silent; got {got:?}"
+    );
+    // TP control: a *first-iteration* read of the accumulator, before its set,
+    // is a genuine read-before-set inside the body and still fires.
+    let inbody = w210_codes("proc f {items} { foreach i $items { puts $r; lappend r $i } }");
+    assert!(
+        inbody.iter().any(|m| m.contains("'r'")),
+        "first-iteration in-body read before the set must still fire; got {inbody:?}"
     );
 }
 

--- a/rust/tcl-compiler/tests/cfg.rs
+++ b/rust/tcl-compiler/tests/cfg.rs
@@ -253,6 +253,70 @@ fn for_creates_loop_cfg() {
     );
 }
 
+/// The `render_expr` of a function's first `for_header` Branch condition.
+/// A *rotated* (guaranteed-nonempty) loop carries the synthetic `"1"` guard;
+/// a *may-run* loop keeps its real condition (e.g. `"$i < 3"`).
+fn for_header_condition(func: &Function) -> String {
+    let header = func
+        .blocks
+        .values()
+        .find(|b| b.name.starts_with("for_header"))
+        .expect("a for_header block");
+    match &header.terminator {
+        Some(Terminator::Branch { condition, .. }) => render_expr(condition),
+        other => panic!("for_header must branch, got {other:?}"),
+    }
+}
+
+#[test]
+fn for_rotation_requires_a_non_stale_constant_init() {
+    // Loop rotation (bottom-testing a provably-once loop) is sound only when the
+    // init clause proves the condition true on entry. `for_runs_at_least_once`
+    // processes the init in order, so a later non-constant write, an `incr`, or
+    // an opaque call that could touch the loop var must invalidate the stale
+    // constant — otherwise a possibly-zero-iteration loop would be wrongly
+    // rotated (its optimiser static-for summary and its zero-trip edge would be
+    // unsound). W210 no longer distinguishes these (a may-run loop whose body
+    // defines the var is silent after the loop, matching C Tcl — issue #756), so
+    // this pins the rotation decision directly on the CFG shape.
+
+    // Guaranteed: `0 < 3` is true on entry → rotated (header carries `1`).
+    assert_eq!(
+        for_header_condition(top(&cfg("for {set i 0} {$i < 3} {incr i} {set y $i}"))),
+        "1",
+        "clean constant init must rotate",
+    );
+    // A benign init call that cannot write the loop var keeps it guaranteed.
+    assert_eq!(
+        for_header_condition(top(&cfg("for {set i 0; puts hi} {$i < 3} {incr i} {set y $i}"))),
+        "1",
+        "benign init call must not invalidate the constant",
+    );
+
+    // Stale constant: `set i $n` overwrites `set i 0`, so the condition is
+    // unknown → NOT rotated (the real `$i < 3` stays on the header).
+    assert_eq!(
+        for_header_condition(top(&cfg("for {set i 0; set i $n} {$i < 3} {incr i} {set y $i}"))),
+        "$i < 3",
+        "a non-constant re-write of the loop var must not be claimed guaranteed",
+    );
+    // An `incr` in the init likewise invalidates the constant binding.
+    assert_eq!(
+        for_header_condition(top(&cfg("for {set i 0; incr i 5} {$i < 3} {incr i} {set y $i}"))),
+        "$i < 3",
+        "incr in for-init must not be claimed guaranteed",
+    );
+    // An init call that writes the loop var through `upvar` must invalidate it.
+    let m = cfg(
+        "proc setter {} { upvar 1 i i; set i 5 }\nproc f {} { for {set i 0; setter} {$i < 3} {incr i} { set y $i } }\n",
+    );
+    assert_eq!(
+        for_header_condition(proc(&m, "::f")),
+        "$i < 3",
+        "an upvar-writing init call must not be claimed guaranteed",
+    );
+}
+
 #[test]
 fn return_terminates_block() {
     // In a proc whose body is `set x 1; return $x; set y 2`, some block ends in a

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -520,11 +520,40 @@ fn while1_break_set_silent() {
 }
 
 #[test]
-fn normal_while_still_fires() {
-    // A non-constant condition may run zero times → maybe-unset read.
+fn normal_while_body_defined_silent() {
+    // FP-RBS-19 (#756): a non-constant `while` may run zero times, but its body
+    // unconditionally sets `y`, so a read after the loop is defined whenever the
+    // loop ran. Matching C Tcl (which errors only when the condition is false on
+    // entry at runtime), we assume a may-run loop runs — no W210.
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     let src = "proc f {n} {\n    while {$n > 0} { set y 1; incr n -1 }\n    puts $y\n}\n";
+    assert!(!has_code(&lsp.open_ready(&uri, src), "W210"));
+}
+
+#[test]
+fn foreach_accumulator_after_loop_silent() {
+    // FP-RBS-19 (#756), the reporter's exact pattern: a `lappend` accumulator
+    // built inside a dynamic multi-group `foreach`, read after the loop. The
+    // body defines the accumulators on every iteration, so the after-loop reads
+    // are not read-before-set.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "set data [getDataDict]\n\
+        foreach time [dict get $data time] vout [dict get $data osc_out] {\n\
+        \x20   lappend timeVout [list $time $vout]\n\
+        }\n\
+        puts $timeVout\n";
+    assert!(!has_code(&lsp.open_ready(&uri, src), "W210"));
+}
+
+#[test]
+fn foreach_empty_literal_after_loop_still_fires() {
+    // TP control: a provably-empty literal list runs zero times, so tclsh always
+    // errors — the after-loop read must keep firing.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc f {} {\n    foreach x {} { lappend acc $x }\n    puts $acc\n}\n";
     assert!(has_code(&lsp.open_ready(&uri, src), "W210"));
 }
 


### PR DESCRIPTION
## Summary

- Fixes #756. A variable assigned inside a loop body and read **after** the loop was flagged `W210` (read-before-set) because the loop *might* iterate zero times. But tclsh only errors when the iterator list / condition is actually empty at runtime; on real (non-empty) data the body runs and the variable is defined. This is the common accumulate-in-loop idiom the reporter hit: `foreach time [dict get $data time] … { lappend timeVout … }` then `$timeVout`.
- **Match C Tcl: assume a may-run loop runs.** `W210` now fires only when the loop is *provably* zero-iteration (empty literal `foreach x {}`, `while 0`, false-on-entry `for`) **or** the body leaves the variable unset on some run (conditional def, `break`/`continue` before the set, first-iteration in-body read).
- Implementation: `build_loop_entry_only_undef` (analyser/diagnostics/helpers.rs) walks the natural-loop forest over the SCCP-executable subgraph and records each loop-header phi whose *only* undef source is the loop's zero-trip entry edge — i.e. every back-edge operand is defined. A fixpoint pass makes nested accumulators converge. The read-before-set emitters (`record_chain_w210_uses`, `return_read_fires_w210`) suppress a read of such a version only when its block is **outside** the loop body; a read *inside* the body still fires. Provably-empty `foreach` literals are excluded so they keep firing.
- Supersedes the FP-RBS-16/17/18 TP controls that asserted a may-run loop *must* fire; those flip to assert silence, documented as **FP-RBS-19**. The rotation (guaranteed-nonempty) classification the flipped W210 proxies used to cover moves to a direct CFG-shape test.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-compiler                       # 3356+ tests green
cargo test -p tcl-lsp-server -p tcl-lsp-core     # e2e + unit green
cargo clippy -p tcl-compiler -p tcl-lsp-server   # no new warnings on changed files
```

Ground truth confirmed against `tclsh8.6`: dynamic non-empty `foreach` → no error; actually-empty list → `can't read`.

New/updated tests:
- Compiler: `analyser::diagnostics::fp::rbs::fp_rbs_19_*` (reporter pattern, nested accumulator, may-run `while`/`for`; TP controls: provably-empty literal, conditional-def-in-body, first-iteration in-body read). Flipped `fp_rbs_16_normal_while_*`, `fp_rbs_17_dynamic_list_*`, `fp_rbs_18_unknown_bound_*`/`stale_const_*`, `tests::w210_loop_body_accumulator_*` to assert silence.
- CFG shape: `cfg::for_rotation_requires_a_non_stale_constant_init` (preserves the stale-const / `incr` / upvar rotation-invalidation coverage).
- LSP e2e: `diagnostics::{foreach_accumulator_after_loop_silent, foreach_empty_literal_after_loop_still_fires, normal_while_body_defined_silent}`.
- VS Code: `precisionFalsePositives.test.ts` "dynamic-loop after-loop reads stay silent (#756)" over `controlFlowRbs.tcl`.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Yes: `W210` no longer fires on a may-run loop whose body defines the read variable.
- [x] If yes, I updated at least one relevant KCS note — `docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md` gains a "Variables set inside a loop" section; `docs/design/compiler/FP.md` gains the FP-RBS-19 entry.
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md` — n/a: no new KCS note file was added (existing W210 note extended; the new FP entry lives in `docs/design/compiler/FP.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013GJyv6kicEzNkNBJdxeEPc

---
_Generated by [Claude Code](https://claude.ai/code/session_013GJyv6kicEzNkNBJdxeEPc)_