### PR TITLE
Order BIG-IP profiles by traffic order and iRule events by firing order

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4025,6 +4025,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tcl-bigip",
+ "tcl-registry",
  "temp-env",
  "ureq",
  "x509-parser",

--- a/rust/bigip-query-py/Cargo.lock
+++ b/rust/bigip-query-py/Cargo.lock
@@ -1110,6 +1110,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tcl-bigip",
+ "tcl-registry",
  "ureq",
  "x509-parser",
 ]
@@ -1119,6 +1120,15 @@ name = "tcl-bytecode"
 version = "0.1.0"
 dependencies = [
  "tcl-lexer",
+ "tcl-syntax",
+]
+
+[[package]]
+name = "tcl-cmd-core"
+version = "0.1.0"
+dependencies = [
+ "tcl-platform",
+ "tcl-runtime-api",
  "tcl-syntax",
 ]
 
@@ -1180,15 +1190,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcl-platform"
+version = "0.1.0"
+
+[[package]]
 name = "tcl-registry"
 version = "0.1.0"
 dependencies = [
  "bitflags",
  "rustc-hash",
  "sha2",
+ "tcl-cmd-core",
  "tcl-core-types",
  "tcl-lexer",
  "tcl-syntax",
+]
+
+[[package]]
+name = "tcl-runtime-api"
+version = "0.1.0"
+dependencies = [
+ "tcl-core-types",
 ]
 
 [[package]]

--- a/rust/bigip-query-py/python/f5report/report.py
+++ b/rust/bigip-query-py/python/f5report/report.py
@@ -228,7 +228,9 @@ def _shape_monitor(f: dict[str, Any], used_by: dict[str, list[str]]) -> dict[str
 
 def _shape_rule(f: dict[str, Any], used_by: dict[str, list[str]]) -> dict[str, Any]:
     body = f.get("body", "") or ""
-    events = sorted(set(re.findall(r"\bwhen\s+([A-Z][A-Z0-9_]+)", body)))
+    # Canonical firing order (via the shared registry), not alphabetical — so
+    # CLIENT_ACCEPTED precedes CLIENTSSL_HANDSHAKE, etc. Matches the Rust report.
+    events = _engine.order_events(list(set(re.findall(r"\bwhen\s+([A-Z][A-Z0-9_]+)", body))))
     fp = f.get("full-path", "")
     # `.refs` is the engine's synthesised iRule reference sub-object: pools /
     # persistences / data-groups the rule body actually uses.
@@ -424,6 +426,20 @@ def _collect_device(uri: str, source: str) -> dict[str, Any]:
                 }
                 for f in rows
             ]
+
+    # Order each virtual's attached profiles into traffic (protocol-stack)
+    # order via the shared engine — transport → TLS → application — so a
+    # listener reads TCP → … → HTTP, not the raw config order. The config's
+    # typed profile inventory is authoritative; the engine falls back to
+    # well-known default-profile names for base profiles it doesn't define.
+    type_of = {
+        p["fullPath"]: p.get("type", "")
+        for p in device.get("profiles", [])
+        if isinstance(p, dict) and p.get("fullPath")
+    }
+    for v in device.get("virtuals", []):
+        if isinstance(v, dict) and isinstance(v.get("profiles"), list):
+            v["profiles"] = _engine.order_profiles(v["profiles"], type_of)
 
     # Tag built-in / system objects (default profiles, monitors, `_sys_*` iRules
     # from profile_base.conf / low_profile_base.conf) so they can be hidden by

--- a/rust/bigip-query-py/src/lib.rs
+++ b/rust/bigip-query-py/src/lib.rs
@@ -481,6 +481,35 @@ fn highlight_tcl(body: &str) -> String {
     tcl_lexer::highlight_tcl(body)
 }
 
+/// Sort iRule `when` event names into canonical firing order.
+///
+/// Wraps the shared [`tcl_registry`] event registry — the same firing-order
+/// table the Rust report and LSP use — so the Python and Rust report models
+/// list a rule's events identically (not alphabetically). Events absent from
+/// the master order are appended in sorted order, so none are dropped.
+#[pyfunction]
+fn order_events(events: Vec<String>) -> Vec<String> {
+    tcl_registry::events::EventRegistry::build().order_events(&events)
+}
+
+/// Sort a virtual server's attached profiles into traffic (protocol-stack)
+/// order — transport → TLS → application → … — the order the device processes
+/// them, not the arbitrary config order.
+///
+/// Wraps the shared [`tcl_bigip_query`] traffic-order core so the Python and
+/// Rust report models order profiles identically. `types` optionally maps a
+/// profile full-path to its authoritative profile type (e.g. from the report's
+/// typed profile inventory); profiles it doesn't cover fall back to well-known
+/// default-profile-name inference. Layering always comes from the registry.
+#[pyfunction]
+#[pyo3(signature = (profiles, types=None))]
+fn order_profiles(profiles: Vec<String>, types: Option<HashMap<String, String>>) -> Vec<String> {
+    let types = types.unwrap_or_default();
+    tcl_bigip_query::builtins::f5profile::order_profiles_by_traffic(&profiles, |n| {
+        types.get(n).cloned()
+    })
+}
+
 /// Build a Mermaid control-flow flowchart for an iRule.
 ///
 /// Uses the IR-based [`tcl_diagram`] (the same control-flow extraction the CLI
@@ -528,6 +557,8 @@ fn _engine(m: &Bound<'_, PyModule>) -> PyResult<()> {
     m.add_function(wrap_pyfunction!(decrypt_secrets, m)?)?;
     m.add_function(wrap_pyfunction!(list_secrets, m)?)?;
     m.add_function(wrap_pyfunction!(highlight_tcl, m)?)?;
+    m.add_function(wrap_pyfunction!(order_events, m)?)?;
+    m.add_function(wrap_pyfunction!(order_profiles, m)?)?;
     m.add_function(wrap_pyfunction!(irule_flowchart, m)?)?;
     m.add_function(wrap_pyfunction!(irule_attach_patterns, m)?)?;
     m.add_function(wrap_pyfunction!(irule_proc_call_refs, m)?)?;

--- a/rust/bigip-query-py/src/lib.rs
+++ b/rust/bigip-query-py/src/lib.rs
@@ -505,9 +505,7 @@ fn order_events(events: Vec<String>) -> Vec<String> {
 #[pyo3(signature = (profiles, types=None))]
 fn order_profiles(profiles: Vec<String>, types: Option<HashMap<String, String>>) -> Vec<String> {
     let types = types.unwrap_or_default();
-    tcl_bigip_query::builtins::f5profile::order_profiles_by_traffic(&profiles, |n| {
-        types.get(n).cloned()
-    })
+    tcl_bigip_query::builtins::f5profile::order_profiles_with_types(&profiles, &types)
 }
 
 /// Build a Mermaid control-flow flowchart for an iRule.

--- a/rust/bigip-query-py/tests/test_report.py
+++ b/rust/bigip-query-py/tests/test_report.py
@@ -74,6 +74,21 @@ def test_rule_events_in_firing_order():
                 assert evs.index("CLIENT_ACCEPTED") < evs.index("CLIENTSSL_HANDSHAKE"), evs
 
 
+def test_relative_custom_profile_names_ordered_by_traffic():
+    # Partition-relative custom profile names still resolve (by leaf) against
+    # the full-path profile inventory, so transport leads application.
+    scf = (
+        "ltm virtual /Common/relvs {\n"
+        "    destination /Common/1.2.3.4:80\n"
+        "    profiles {\n        my_http { }\n        my_tcp { }\n    }\n}\n"
+        "ltm profile http /Common/my_http { }\n"
+        "ltm profile tcp /Common/my_tcp { }\n"
+    )
+    m = collect_model([("mem://x", scf)], title="T")
+    vs = next(v for d in m["devices"] for v in d["virtuals"] if v["name"] == "relvs")
+    assert vs["profiles"] == ["my_tcp", "my_http"], vs["profiles"]
+
+
 def test_totals_sum_devices():
     m = _model()
     assert m["totals"]["virtuals"] == sum(dv["counts"]["virtuals"] for dv in m["devices"])

--- a/rust/bigip-query-py/tests/test_report.py
+++ b/rust/bigip-query-py/tests/test_report.py
@@ -51,6 +51,29 @@ def test_irule_events_extracted():
     assert any(r["events"] for r in d["rules"])
 
 
+def test_virtual_profiles_in_traffic_order():
+    # app1_t80_vs lists `http` then `tcp` in the config; a BIG-IP processes the
+    # stack transport-first, so the report must show TCP ahead of HTTP.
+    m = _model()
+    vs = next(
+        v for d in m["devices"] for v in d["virtuals"] if v["name"] == "app1_t80_vs"
+    )
+    profs = vs["profiles"]
+    tcp = next(i for i, p in enumerate(profs) if p.endswith("/tcp"))
+    http = next(i for i, p in enumerate(profs) if p.endswith("/http"))
+    assert tcp < http, profs
+
+
+def test_rule_events_in_firing_order():
+    # Events are ordered by canonical firing order, not alphabetically:
+    # CLIENT_ACCEPTED precedes CLIENTSSL_HANDSHAKE wherever both appear.
+    for d in _model()["devices"]:
+        for r in d["rules"]:
+            evs = r["events"]
+            if "CLIENT_ACCEPTED" in evs and "CLIENTSSL_HANDSHAKE" in evs:
+                assert evs.index("CLIENT_ACCEPTED") < evs.index("CLIENTSSL_HANDSHAKE"), evs
+
+
 def test_totals_sum_devices():
     m = _model()
     assert m["totals"]["virtuals"] == sum(dv["counts"]["virtuals"] for dv in m["devices"])

--- a/rust/tcl-bigip-query/Cargo.toml
+++ b/rust/tcl-bigip-query/Cargo.toml
@@ -11,6 +11,10 @@ authors.workspace = true
 
 [dependencies]
 tcl-bigip = { path = "../tcl-bigip" }
+# Profile / event registry — the source of truth for a profile's protocol
+# stack `layer`, used to sort profiles into traffic order. Pure data + logic,
+# so it stays wasm-safe for the report/console build.
+tcl-registry = { path = "../tcl-registry" }
 base64 = "0.22"
 chrono = { version = "0.4", default-features = false, features = ["clock", "std"] }
 indexmap = "2"

--- a/rust/tcl-bigip-query/src/builtins/f5profile.rs
+++ b/rust/tcl-bigip-query/src/builtins/f5profile.rs
@@ -1,0 +1,163 @@
+//! Profile traffic-order builtin.
+//!
+//! A BIG-IP virtual server processes its attached profiles bottom-up — the
+//! transport profile (TCP/UDP/FASTL4) nearest the wire, then TLS, then the
+//! application profile (HTTP/DNS/…), with the security / acceleration facets on
+//! top. A config lists profiles in an arbitrary order (often alphabetical, so
+//! `http` precedes `tcp`); the `profile_order` builtin re-orders them into that
+//! processing ("traffic") order so a listener reads TCP → … → HTTP.
+//!
+//! Each profile's `layer` comes from the shared profile registry
+//! ([`tcl_registry::profiles`]), so this is the single source of truth for
+//! profile ordering across `f5 query`, the BIG-IP report and the LSP.
+
+use std::sync::OnceLock;
+
+use tcl_registry::profiles::ProfileRegistry;
+
+use crate::builtins::{BuiltinSpec, as_str, plain};
+use crate::errors::QueryError;
+use crate::value::Value;
+
+fn registry() -> &'static ProfileRegistry {
+    static R: OnceLock<ProfileRegistry> = OnceLock::new();
+    R.get_or_init(ProfileRegistry::build)
+}
+
+/// Canonical traffic-order rank of a profile *type* — lowest is nearest the
+/// wire. Accepts the type spellings the query engine and model use
+/// (`"HTTP"`, `"CLIENT_SSL"`, `"ProfileType.CLIENT_SSL"`); the engine keys some
+/// multi-word types with underscores where the registry keys them without
+/// (`CLIENT_SSL` vs `CLIENTSSL`), so it retries the underscore-stripped form.
+/// The layer itself always comes from [`ProfileRegistry`].
+#[must_use]
+pub fn profile_traffic_rank(profile_type: &str) -> u8 {
+    let t = profile_type.rsplit('.').next().unwrap_or(profile_type);
+    let reg = registry();
+    if reg.get_profile(t).is_some() {
+        reg.layer_rank(t)
+    } else {
+        reg.layer_rank(&t.replace('_', ""))
+    }
+}
+
+/// The registry profile *type* of a TMOS built-in default profile, inferred
+/// from its well-known name (`/Common/tcp` → `"TCP"`). Used only as a fallback
+/// for base profiles a config never re-declares (so they are absent from the
+/// `.ltm.profile` inventory and have no authoritative type). The resulting
+/// type is still ranked by the registry `layer`.
+#[must_use]
+pub fn default_profile_type(profile_ref: &str) -> Option<&'static str> {
+    let name = profile_ref
+        .rsplit('/')
+        .next()
+        .unwrap_or(profile_ref)
+        .to_ascii_lowercase();
+    if name.contains("clientssl") || name.contains("client-ssl") {
+        Some("CLIENTSSL")
+    } else if name.contains("serverssl") || name.contains("server-ssl") {
+        Some("SERVERSSL")
+    } else if name == "http" || name == "http2" {
+        Some("HTTP")
+    } else if name == "tcp" {
+        Some("TCP")
+    } else if name == "udp" {
+        Some("UDP")
+    } else if name == "fastl4" {
+        Some("FASTL4")
+    } else if name == "sctp" {
+        Some("SCTP")
+    } else if name == "oneconnect" {
+        Some("ONECONNECT")
+    } else if name.contains("fasthttp") {
+        Some("FASTHTTP")
+    } else if name.contains("dns") {
+        Some("DNS")
+    } else {
+        None
+    }
+}
+
+/// Order profile references into traffic order. `resolve_type` maps a reference
+/// to its authoritative profile-type name (e.g. from a config's profile
+/// inventory); references it can't type fall back to well-known
+/// default-profile-name inference ([`default_profile_type`]), then rank last —
+/// keeping their original relative order (the sort is stable on input index).
+pub fn order_profiles_by_traffic<F>(refs: &[String], resolve_type: F) -> Vec<String>
+where
+    F: Fn(&str) -> Option<String>,
+{
+    let mut items: Vec<(usize, u8, String)> = refs
+        .iter()
+        .enumerate()
+        .map(|(i, r)| {
+            let rank = resolve_type(r)
+                .or_else(|| default_profile_type(r).map(str::to_owned))
+                .map_or(u8::MAX, |t| profile_traffic_rank(&t));
+            (i, rank, r.clone())
+        })
+        .collect();
+    items.sort_by(|a, b| a.1.cmp(&b.1).then_with(|| a.0.cmp(&b.0)));
+    items.into_iter().map(|(_, _, r)| r).collect()
+}
+
+pub(super) fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
+    vec![plain(
+        "profile_order",
+        "value",
+        1,
+        Some(1),
+        true,
+        bi_profile_order,
+    )]
+}
+
+/// `profile_order` — sort a list of profile references into traffic order.
+///
+/// Operates on a stream of profile names/paths (e.g. a virtual's `.profiles`).
+/// Types are inferred from well-known profile names; callers that already know
+/// each profile's type (like the report, which has the typed profile
+/// inventory) use [`order_profiles_by_traffic`] directly for exact ordering.
+fn bi_profile_order(args: &[Value]) -> Result<Value, QueryError> {
+    let items = crate::builtins::as_sequence(&args[0], "profile_order", 1)?;
+    let refs: Vec<String> = items
+        .iter()
+        .map(|v| as_str(v, "profile_order", 1).unwrap_or_default())
+        .collect();
+    let ordered = order_profiles_by_traffic(&refs, |_| None);
+    Ok(Value::List(ordered.into_iter().map(Value::Str).collect()))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn ranks_transport_before_application() {
+        assert!(profile_traffic_rank("TCP") < profile_traffic_rank("HTTP"));
+        // Engine underscore spelling still resolves through the registry.
+        assert!(profile_traffic_rank("CLIENT_SSL") < profile_traffic_rank("HTTP"));
+        assert!(profile_traffic_rank("TCP") < profile_traffic_rank("CLIENT_SSL"));
+        assert!(profile_traffic_rank("ProfileType.SERVER_SSL") < profile_traffic_rank("HTTP"));
+    }
+
+    #[test]
+    fn orders_default_profiles_by_name() {
+        let refs = vec!["/Common/http".to_owned(), "/Common/tcp".to_owned()];
+        let out = order_profiles_by_traffic(&refs, |_| None);
+        assert_eq!(out, vec!["/Common/tcp".to_owned(), "/Common/http".to_owned()]);
+    }
+
+    #[test]
+    fn resolver_types_win_over_name_inference() {
+        // A custom-named HTTP profile is ordered after TCP via the resolver.
+        let refs = vec!["/Common/weird_name".to_owned(), "/Common/tcp".to_owned()];
+        let out = order_profiles_by_traffic(&refs, |r| {
+            (r == "/Common/weird_name").then(|| "HTTP".to_owned())
+        });
+        assert_eq!(
+            out,
+            vec!["/Common/tcp".to_owned(), "/Common/weird_name".to_owned()]
+        );
+    }
+}

--- a/rust/tcl-bigip-query/src/builtins/f5profile.rs
+++ b/rust/tcl-bigip-query/src/builtins/f5profile.rs
@@ -11,6 +11,7 @@
 //! ([`tcl_registry::profiles`]), so this is the single source of truth for
 //! profile ordering across `f5 query`, the BIG-IP report and the LSP.
 
+use std::collections::HashMap;
 use std::sync::OnceLock;
 
 use tcl_registry::profiles::ProfileRegistry;
@@ -101,6 +102,32 @@ where
     items.into_iter().map(|(_, _, r)| r).collect()
 }
 
+/// Order profile references into traffic order given a `full_path → type` map
+/// (e.g. a config's typed profile inventory).
+///
+/// Each reference is matched against `types` by exact key first, then by leaf
+/// name (last `/`-separated segment) — so a virtual's partition-relative
+/// reference like `my_http` resolves against the inventory key
+/// `/Common/my_http`. References that resolve to neither fall back to
+/// well-known default-profile-name inference inside
+/// [`order_profiles_by_traffic`]. Leaf collisions across partitions keep the
+/// first-seen type (same-partition attachment is the norm).
+#[must_use]
+pub fn order_profiles_with_types(refs: &[String], types: &HashMap<String, String>) -> Vec<String> {
+    let mut by_leaf: HashMap<&str, &str> = HashMap::new();
+    for (path, ty) in types {
+        let leaf = path.rsplit('/').next().unwrap_or(path);
+        by_leaf.entry(leaf).or_insert(ty.as_str());
+    }
+    order_profiles_by_traffic(refs, |r| {
+        types.get(r).cloned().or_else(|| {
+            by_leaf
+                .get(r.rsplit('/').next().unwrap_or(r))
+                .map(|t| (*t).to_owned())
+        })
+    })
+}
+
 pub(super) fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
     vec![plain(
         "profile_order",
@@ -146,6 +173,19 @@ mod tests {
         let refs = vec!["/Common/http".to_owned(), "/Common/tcp".to_owned()];
         let out = order_profiles_by_traffic(&refs, |_| None);
         assert_eq!(out, vec!["/Common/tcp".to_owned(), "/Common/http".to_owned()]);
+    }
+
+    #[test]
+    fn relative_refs_resolve_by_leaf_against_full_path_inventory() {
+        // Virtual attaches partition-relative names; inventory is full-path
+        // keyed. Leaf matching still types them, so a custom HTTP profile is
+        // ordered after the transport profile.
+        let mut types = HashMap::new();
+        types.insert("/Common/my_http".to_owned(), "HTTP".to_owned());
+        types.insert("/Common/my_tcp".to_owned(), "TCP".to_owned());
+        let refs = vec!["my_http".to_owned(), "my_tcp".to_owned()];
+        let out = order_profiles_with_types(&refs, &types);
+        assert_eq!(out, vec!["my_tcp".to_owned(), "my_http".to_owned()]);
     }
 
     #[test]

--- a/rust/tcl-bigip-query/src/builtins/mod.rs
+++ b/rust/tcl-bigip-query/src/builtins/mod.rs
@@ -35,6 +35,7 @@ use crate::value::{self, Value};
 mod encoding;
 pub(crate) use encoding::json_to_value;
 mod extras;
+pub mod f5profile;
 mod graph;
 mod math;
 mod net;
@@ -322,6 +323,7 @@ fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
     r.extend(graph::registrations());
     r.extend(rename::registrations());
     r.extend(extras::registrations());
+    r.extend(f5profile::registrations());
     #[cfg(feature = "probes")]
     r.extend(crate::probes::registrations());
     r.extend(crate::special::registrations());

--- a/rust/tcl-bigip-report/src/model.rs
+++ b/rust/tcl-bigip-report/src/model.rs
@@ -8,15 +8,26 @@
 //! report for the client-side topology / listener / console views).
 
 use std::collections::{BTreeSet, HashMap};
+use std::sync::OnceLock;
 
 use regex::Regex;
 use serde_json::{Map, Value as J};
+use tcl_registry::events::EventRegistry;
 
 use crate::jutil::{barr, bbool, bstr, sarr, truthy};
 use crate::query::{Source, query};
 
 /// The engine version string embedded in the report header.
 pub const ENGINE_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// The iRule event registry — the source of truth for canonical event firing
+/// order. Built once (the data is compiled into the binary) and reused across
+/// every shaped rule. (Profile *traffic* order lives in the shared
+/// `tcl_bigip_query::builtins::f5profile` engine core.)
+fn event_registry() -> &'static EventRegistry {
+    static R: OnceLock<EventRegistry> = OnceLock::new();
+    R.get_or_init(EventRegistry::build)
+}
 
 // Object containers the report walks, in display order. Each is an `f5-query`
 // container path under a config root.
@@ -324,7 +335,12 @@ fn shape_monitor(f: &Map<String, J>, used: &HashMap<String, Vec<J>>) -> J {
 fn shape_rule(f: &Map<String, J>, used: &HashMap<String, Vec<J>>) -> J {
     let body = bstr(f, "body").to_string();
     let re = Regex::new(r"\bwhen\s+([A-Z][A-Z0-9_]+)").expect("valid when regex");
-    let events: BTreeSet<String> = re.captures_iter(&body).map(|c| c[1].to_string()).collect();
+    // De-dup the `when` events (BTreeSet), then order them into canonical
+    // firing order via the registry — NOT the set's alphabetical order,
+    // which scrambles the lifecycle (e.g. CLIENTSSL_HANDSHAKE ahead of
+    // CLIENT_ACCEPTED). This array renders verbatim in the report.
+    let uniq: BTreeSet<String> = re.captures_iter(&body).map(|c| c[1].to_string()).collect();
+    let events: Vec<String> = event_registry().order_events(&uniq.into_iter().collect::<Vec<_>>());
     let fp = bstr(f, "full-path");
     // `.refs` is the engine's synthesised iRule reference sub-object.
     let refs: Map<String, J> = match f.get("refs") {
@@ -929,6 +945,49 @@ fn annotate_rule_reachability(device: &mut Map<String, J>, rule_vs: &RuleVirtual
     }
 }
 
+/// Order every virtual server's attached-profile list into BIG-IP protocol
+/// stack order (transport → TLS → application → …), resolved from the profile
+/// registry's `layer` metadata. A config lists profiles in an arbitrary order
+/// (often alphabetical, so `/Common/http` precedes `/Common/tcp`), but the
+/// device processes them by layer — the report should show that order, so a
+/// listener reads TCP → … → HTTP, not HTTP → TCP.
+fn order_virtual_profiles(device: &mut Map<String, J>) {
+    // Full path → projected profile type (e.g. "/Common/http" → "HTTP").
+    let mut type_of: HashMap<String, String> = HashMap::new();
+    if let Some(J::Array(profiles)) = device.get("profiles") {
+        for p in profiles {
+            if let Some(pm) = p.as_object() {
+                let fp = bstr(pm, "fullPath").to_string();
+                if !fp.is_empty() {
+                    type_of.insert(fp, bstr(pm, "type").to_string());
+                }
+            }
+        }
+    }
+    if let Some(J::Array(virtuals)) = device.get_mut("virtuals") {
+        for v in virtuals.iter_mut() {
+            let Some(vm) = v.as_object_mut() else { continue };
+            let Some(J::Array(profs)) = vm.get_mut("profiles") else {
+                continue;
+            };
+            let names: Vec<String> =
+                profs.iter().filter_map(|p| p.as_str().map(str::to_owned)).collect();
+            if names.len() != profs.len() {
+                continue; // non-string entries: leave the list untouched
+            }
+            // Delegate to the shared f5-query traffic-order core: the config's
+            // typed profile inventory is authoritative, and the core falls back
+            // to well-known default-profile names (e.g. `/Common/tcp`) that a
+            // config never re-declares.
+            let ordered = tcl_bigip_query::builtins::f5profile::order_profiles_by_traffic(
+                &names,
+                |n| type_of.get(n).cloned(),
+            );
+            *profs = ordered.into_iter().map(J::String).collect();
+        }
+    }
+}
+
 fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>) -> J {
     let sources: Vec<Source> = vec![(uri.to_string(), source.to_string())];
 
@@ -980,6 +1039,10 @@ fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>) 
         };
         device.insert((*key).into(), J::Array(shaped));
     }
+
+    // Order each virtual's attached-profile list into protocol-stack order
+    // now that both the virtuals and the typed profile inventory exist.
+    order_virtual_profiles(&mut device);
 
     // Tag built-in / system objects (the default profiles, monitors and
     // `_sys_*` iRules that ship with TMOS — from `profile_base.conf` /

--- a/rust/tcl-bigip-report/src/model.rs
+++ b/rust/tcl-bigip-report/src/model.rs
@@ -975,13 +975,13 @@ fn order_virtual_profiles(device: &mut Map<String, J>) {
             if names.len() != profs.len() {
                 continue; // non-string entries: leave the list untouched
             }
-            // Delegate to the shared f5-query traffic-order core: the config's
-            // typed profile inventory is authoritative, and the core falls back
-            // to well-known default-profile names (e.g. `/Common/tcp`) that a
-            // config never re-declares.
-            let ordered = tcl_bigip_query::builtins::f5profile::order_profiles_by_traffic(
-                &names,
-                |n| type_of.get(n).cloned(),
+            // Delegate to the shared f5-query traffic-order core. The config's
+            // typed profile inventory is authoritative (matched by full path or
+            // by leaf, so partition-relative refs like `my_http` still resolve),
+            // and the core falls back to well-known default-profile names (e.g.
+            // `/Common/tcp`) that a config never re-declares.
+            let ordered = tcl_bigip_query::builtins::f5profile::order_profiles_with_types(
+                &names, &type_of,
             );
             *profs = ordered.into_iter().map(J::String).collect();
         }

--- a/rust/tcl-bigip-report/tests/report.rs
+++ b/rust/tcl-bigip-report/tests/report.rs
@@ -120,6 +120,53 @@ fn irule_events_extracted() {
 }
 
 #[test]
+fn virtual_profiles_in_protocol_stack_order() {
+    // `app1_t80_vs` lists its profiles `http` then `tcp` in the config, but a
+    // BIG-IP processes the stack transport-first — the report must show TCP
+    // ahead of HTTP, not the raw config (alphabetical) order.
+    let m = model();
+    let vs = arr(&m, "devices")
+        .iter()
+        .flat_map(|d| arr(d, "virtuals"))
+        .find(|v| v["name"] == "app1_t80_vs")
+        .expect("app1_t80_vs present");
+    let profiles: Vec<&str> = vs["profiles"]
+        .as_array()
+        .expect("profiles array")
+        .iter()
+        .map(|p| p.as_str().unwrap())
+        .collect();
+    let tcp = profiles.iter().position(|p| p.ends_with("/tcp"));
+    let http = profiles.iter().position(|p| p.ends_with("/http"));
+    assert!(
+        tcp < http,
+        "expected tcp before http, got {profiles:?}"
+    );
+}
+
+#[test]
+fn rule_events_in_firing_order() {
+    // Events are emitted in canonical firing order, not alphabetically. For
+    // every rule that has both, CLIENT_ACCEPTED must precede
+    // CLIENTSSL_HANDSHAKE (which sorts the other way alphabetically).
+    let m = model();
+    for r in arr(&m, "devices").iter().flat_map(|d| arr(d, "rules")) {
+        let evs: Vec<&str> = r["events"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .map(|e| e.as_str().unwrap())
+            .collect();
+        if let (Some(a), Some(b)) = (
+            evs.iter().position(|e| *e == "CLIENT_ACCEPTED"),
+            evs.iter().position(|e| *e == "CLIENTSSL_HANDSHAKE"),
+        ) {
+            assert!(a < b, "firing order wrong in {evs:?}");
+        }
+    }
+}
+
+#[test]
 fn totals_sum_devices() {
     let m = model();
     let per_device: u64 = arr(&m, "devices")
@@ -194,3 +241,4 @@ fn model_json_serialisable() {
     let m = collect_model(&sources, "F5 BIG-IP Configuration Report");
     serde_json::to_string(&m).expect("model serialises");
 }
+

--- a/rust/tcl-bigip-report/tests/report.rs
+++ b/rust/tcl-bigip-report/tests/report.rs
@@ -242,3 +242,26 @@ fn model_json_serialisable() {
     serde_json::to_string(&m).expect("model serialises");
 }
 
+
+#[test]
+fn relative_custom_profile_names_ordered_by_traffic() {
+    // A virtual attaches custom profiles by partition-relative name; the
+    // profile inventory is keyed by full path. Traffic ordering must still
+    // resolve them (by leaf) so the transport profile leads the application
+    // one, not the raw config order.
+    let scf = "ltm virtual /Common/relvs {\n    destination /Common/1.2.3.4:80\n    profiles {\n        my_http { }\n        my_tcp { }\n    }\n}\nltm profile http /Common/my_http { }\nltm profile tcp /Common/my_tcp { }\n";
+    let sources = vec![("mem://x".to_string(), scf.to_string())];
+    let m = collect_model(&sources, "T");
+    let vs = arr(&m, "devices")
+        .iter()
+        .flat_map(|d| arr(d, "virtuals"))
+        .find(|v| v["name"] == "relvs")
+        .expect("relvs present");
+    let profs: Vec<&str> = vs["profiles"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|p| p.as_str().unwrap())
+        .collect();
+    assert_eq!(profs, vec!["my_tcp", "my_http"], "got {profs:?}");
+}

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -1366,7 +1366,13 @@ fn compute_required_profiles(
     // from each profile's `layer` in the registry, not a hardcoded list.
     let profile_registry = tcl_registry::profiles::ProfileRegistry::build();
     profiles.retain(|p| !profile_registry.is_infrastructure_profile(p));
-    profiles.into_iter().collect()
+    // Emit in protocol-stack order (transport → TLS → application → …) using
+    // the registry's `layer` metadata, not the `BTreeSet`'s alphabetical
+    // order — alphabetical would list e.g. `HTTP` before `SERVERSSL` (an
+    // application profile ahead of its TLS layer), or `ASM` before `HTTP`.
+    let mut ordered: Vec<String> = profiles.into_iter().collect();
+    ordered.sort_by_key(|p| (profile_registry.layer_rank(p), p.clone()));
+    ordered
 }
 
 /// Scan leading comment lines for a `# Profiles: HTTP, CLIENTSSL` directive,

--- a/rust/tcl-registry/src/profiles.rs
+++ b/rust/tcl-registry/src/profiles.rs
@@ -163,6 +163,38 @@ impl ProfileRegistry {
                 .is_subset(&active_expanded)
         })
     }
+
+    /// Canonical protocol-stack rank for a profile *type* (e.g. `"HTTP"`),
+    /// lowest = closest to the wire.  Looks the type up in the registry and
+    /// ranks it by its [`ProfileSpec::layer`] via [`layer_rank`].  Unknown
+    /// types rank last so nothing is dropped when ordering.
+    ///
+    /// Use this to order a virtual server's profile stack (transport → TLS →
+    /// application → …) instead of alphabetically, which would list `HTTP`
+    /// ahead of `TCP` and invert the real processing order.
+    #[must_use]
+    pub fn layer_rank(&self, profile_type: &str) -> u8 {
+        layer_rank(self.get_profile(profile_type).map_or("", |p| p.layer))
+    }
+}
+
+/// Rank of a protocol-stack [`ProfileSpec::layer`] name — lowest is nearest
+/// the wire.  A BIG-IP virtual processes its profile stack bottom-up:
+/// transport → TLS → application, with the security / acceleration / utility
+/// facets layered on top.  Unknown layers rank last so no profile is dropped.
+#[must_use]
+pub fn layer_rank(layer: &str) -> u8 {
+    match layer {
+        "transport" => 0,
+        "tls_shared" => 1,
+        "tls" => 2,
+        "application" => 3,
+        "load_balance" => 4,
+        "security" => 5,
+        "acceleration" => 6,
+        "utility" => 7,
+        _ => 8,
+    }
 }
 
 /// Profiles attached to a file.


### PR DESCRIPTION
## Summary

- **Fix the `app1_t80_vs` listener ordering:** the report rendered a virtual's profiles in raw config order (`http` before `tcp`), but a BIG-IP processes the stack transport-first. Profiles are now ordered by **traffic order** (transport → TLS → application → …) so a listener reads TCP → … → HTTP.
- **New `f5-query` builtin `profile_order`** (+ shared `order_profiles_by_traffic` core in `tcl-bigip-query`) is the single source of truth for profile traffic order. Layering comes from the profile registry's `layer` metadata — new `ProfileRegistry::layer_rank` / `layer_rank` in `tcl-registry` — not name-guessing. A profile's type is taken from the config's typed inventory, falling back to well-known default-profile names for base profiles a config never re-declares (e.g. `/Common/tcp`).
- **iRule events now emit in canonical firing order, not alphabetically** (a second naive-sort bug found in an audit): the report collected events into a `BTreeSet` and rendered them verbatim, so `CLIENTSSL_HANDSHAKE` printed ahead of `CLIENT_ACCEPTED`. Now routed through `EventRegistry::order_events`.
- **`# Profiles:` code action** lists required profiles in protocol-stack order instead of alphabetical.
- **Rust ↔ Python parity:** exposed `order_events` / `order_profiles` from the `_engine` pyo3 module wrapping the same core, and wired the Python `f5report` generator to them, so both report generators produce identical output.

### Naive-sort audit
A sweep of `rust/` for sorts that alphabetise domain-ordered data surfaced exactly two real bugs (profiles-by-layer, events-by-firing-order — both fixed here). Everything else checked out: semantic-version `Ord`, numeric-keyed maps, deliberate priority sorts, and generic display sorts where alphabetical is correct.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
# Rust (all green)
cargo test -p tcl-registry -p tcl-bigip-query -p tcl-bigip-report -p tcl-lsp-core
cargo clippy -p tcl-registry -p tcl-bigip-query -p tcl-bigip-report -p tcl-lsp-core
# new tests: tcl-bigip-report virtual_profiles_in_protocol_stack_order,
# rule_events_in_firing_order; tcl-bigip-query builtins::f5profile::tests

# Python f5report (built _engine via maturin, 11 passed)
maturin build -i python && PYTHONPATH=rust/bigip-query-py/python \
  python -m pytest rust/bigip-query-py/tests/test_report.py
# new tests: test_virtual_profiles_in_traffic_order, test_rule_events_in_firing_order
```

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract?
- [x] No — this touches the BIG-IP report/query engine and iRule code-action presentation ordering, not compiler fact contracts, diagnostics, or analysis semantics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QM2PH2yst9582xW76JJdk5

---
_Generated by [Claude Code](https://claude.ai/code/session_01QM2PH2yst9582xW76JJdk5)_