### PR TITLE
Add multi-device architecture, GTM, and AFM firewall/NAT support

### DIFF
--- a/rust/bigip-query-py/python/f5report/templates/report.css
+++ b/rust/bigip-query-py/python/f5report/templates/report.css
@@ -360,3 +360,34 @@ html,body{max-width:100%}
   .chip.chip-link,.dev-tab,.expander,.ref-obj{min-height:32px}
   tr.expandable{cursor:pointer}
 }
+
+/* --- Architecture (multi-device tiers) ------------------------------------ */
+.architecture{background:var(--panel);border:1px solid var(--line);border-radius:12px;
+  padding:16px 18px;margin:0 0 18px}
+.arch-head{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;margin-bottom:12px}
+.arch-head h2{margin:0;font-size:16px}
+.arch-tiers{display:flex;gap:14px;overflow-x:auto;padding-bottom:6px;align-items:stretch}
+.arch-tier{flex:0 0 auto;min-width:150px;border:1px dashed var(--line);border-radius:10px;padding:10px;
+  display:flex;flex-direction:column;gap:8px;background:color-mix(in srgb,var(--bg) 50%,transparent)}
+.arch-tier-lbl{font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);font-weight:600}
+.arch-node{border:1px solid var(--line);border-radius:8px;padding:8px 10px;background:var(--panel);
+  display:flex;flex-direction:column;gap:2px;border-left:3px solid var(--muted)}
+.arch-node-name{font-family:var(--mono);font-size:12px;font-weight:600}
+.arch-node-role{font-size:10px;text-transform:uppercase;letter-spacing:.04em;color:var(--muted)}
+.arch-role-gtm{border-left-color:var(--green)}
+.arch-role-ltm{border-left-color:var(--blue)}
+.arch-role-afm,.arch-role-firewall{border-left-color:var(--amber)}
+.arch-links{margin-top:14px}
+.arch-arrow{text-align:center;color:var(--muted);font-size:15px}
+.arch-mermaid-src{margin-top:12px}
+.arch-mermaid-src summary{cursor:pointer;color:var(--muted);font-size:12px}
+.arch-mermaid-src .mermaid-code{white-space:pre;overflow-x:auto;background:var(--bg);border:1px solid var(--line);
+  border-radius:8px;padding:10px;font-family:var(--mono);font-size:11px;margin:8px 0 0}
+
+/* --- GTM + Firewall panels ------------------------------------------------- */
+.subhead{margin:18px 0 8px;font-size:13px;font-weight:600;display:flex;align-items:center;gap:8px}
+.subhead:first-child{margin-top:4px}
+.subhead .n{background:var(--tag-bg);color:var(--muted);border-radius:10px;padding:0 8px;font-size:11px;font-weight:600}
+.rule-list-block{margin:0 0 14px}
+.rule-list-name{margin:10px 0 6px;font-size:12px}
+.fw-rules td{vertical-align:top}

--- a/rust/bigip-query-py/python/f5report/templates/report.css
+++ b/rust/bigip-query-py/python/f5report/templates/report.css
@@ -366,6 +366,11 @@ html,body{max-width:100%}
   padding:16px 18px;margin:0 0 18px}
 .arch-head{display:flex;align-items:baseline;gap:10px;flex-wrap:wrap;margin-bottom:12px}
 .arch-head h2{margin:0;font-size:16px}
+.arch-diagram{margin:4px 0 14px;overflow-x:auto}
+.arch-diagram:empty{display:none}
+.arch-diagram svg{display:block;margin:0 auto}
+.arch-diagram .mm-node:hover{filter:brightness(1.08)}
+.arch-tiers-lbl{font-size:11px;text-transform:uppercase;letter-spacing:.05em;color:var(--muted);font-weight:600;margin:0 0 6px}
 .arch-tiers{display:flex;gap:14px;overflow-x:auto;padding-bottom:6px;align-items:stretch}
 .arch-tier{flex:0 0 auto;min-width:150px;border:1px dashed var(--line);border-radius:10px;padding:10px;
   display:flex;flex-direction:column;gap:8px;background:color-mix(in srgb,var(--bg) 50%,transparent)}

--- a/rust/bigip-query-py/python/f5report/templates/topology.js
+++ b/rust/bigip-query-py/python/f5report/templates/topology.js
@@ -528,6 +528,47 @@
     host.querySelectorAll(".edgeLabel").forEach(function (el) { /* labels stay */ });
   }
 
+  // ---- Cross-device architecture diagram ---------------------------------
+  // The top-level Architecture section renders the tier graph (one node per
+  // loaded device) interactively: click a device node to jump to its section.
+  function activateDevice(di) {
+    var tab = document.querySelector('.dev-tab[data-dev="' + di + '"]');
+    if (tab) tab.click();
+    var dev = document.querySelector('.device[data-dev="' + di + '"]');
+    if (dev) dev.scrollIntoView({ behavior: "smooth", block: "start" });
+  }
+
+  function initArchitecture() {
+    var arch = MODEL.architecture;
+    if (!arch || !arch.mermaid || (arch.deviceCount || 0) < 2) return;
+    var host = document.getElementById("archDiagram");
+    if (!host) return;
+    if (!window.mermaid) { host.style.display = "none"; return; }
+    var id = "archmmd" + (_rid++);
+    mermaid.render(id, arch.mermaid).then(function (res) {
+      host.innerHTML = res.svg;
+      var svg = host.querySelector("svg");
+      if (svg) { svg.style.maxWidth = "100%"; svg.style.maxHeight = "60vh"; svg.style.height = "auto"; }
+      // Each device node's element id is `flowchart-d<index>-<seq>`.
+      host.querySelectorAll(".node").forEach(function (el) {
+        var m = /flowchart-d(\d+)-/.exec(el.id || "");
+        if (!m) return;
+        var di = parseInt(m[1], 10);
+        el.classList.add("mm-node");
+        el.style.cursor = "pointer";
+        el.setAttribute("title", "Jump to this device");
+        el.addEventListener("click", function (ev) {
+          ev.stopPropagation();
+          activateDevice(di);
+        });
+      });
+    }).catch(function (err) {
+      // Fall back to the static tier columns already in the section.
+      host.style.display = "none";
+      if (window.console) console.warn("architecture diagram error:", err);
+    });
+  }
+
   // ---- Topology tab ------------------------------------------------------
   function initTopology(deviceEl, ix) {
     var panel = deviceEl.querySelector('.panel[data-panel="topology"]');
@@ -1177,6 +1218,9 @@
       });
     });
   });
+
+  // The cross-device architecture diagram (top-level, always visible).
+  initArchitecture();
 
   // drawer close handlers
   var closeBtn = document.querySelector("#objDrawer .drawer-close");

--- a/rust/bigip-report-wasm/Cargo.lock
+++ b/rust/bigip-report-wasm/Cargo.lock
@@ -789,6 +789,7 @@ dependencies = [
  "serde_json",
  "sha2",
  "tcl-bigip",
+ "tcl-registry",
  "x509-parser",
 ]
 
@@ -816,6 +817,15 @@ name = "tcl-bytecode"
 version = "0.1.0"
 dependencies = [
  "tcl-lexer",
+ "tcl-syntax",
+]
+
+[[package]]
+name = "tcl-cmd-core"
+version = "0.1.0"
+dependencies = [
+ "tcl-platform",
+ "tcl-runtime-api",
  "tcl-syntax",
 ]
 
@@ -876,15 +886,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "tcl-platform"
+version = "0.1.0"
+
+[[package]]
 name = "tcl-registry"
 version = "0.1.0"
 dependencies = [
  "bitflags",
  "rustc-hash",
  "sha2",
+ "tcl-cmd-core",
  "tcl-core-types",
  "tcl-lexer",
  "tcl-syntax",
+]
+
+[[package]]
+name = "tcl-runtime-api"
+version = "0.1.0"
+dependencies = [
+ "tcl-core-types",
 ]
 
 [[package]]

--- a/rust/bigip-report-wasm/src/lib.rs
+++ b/rust/bigip-report-wasm/src/lib.rs
@@ -146,6 +146,11 @@ pub fn decrypt_secrets(scf: &str, master_key: &str) -> Result<String, JsError> {
 /// * `generated_at` — a generation timestamp string (the caller stamps it with
 ///   the browser's local clock; the engine itself is time-free).
 /// * `embed_console` — embed the in-browser `f5-query` WASM console.
+/// * `architecture_json` — an optional architecture manifest (JSON declaring
+///   each device's role/tier and explicit inter-device links). Empty means pure
+///   auto-detection (an upstream device's pool member / GTM server address that a
+///   downstream device serves is a tier hop). A malformed manifest is surfaced in
+///   the report's Architecture section, not fatal.
 ///
 /// Returns the full HTML document, or a `JsError` carrying the engine's error.
 #[wasm_bindgen]
@@ -155,6 +160,7 @@ pub fn generate_report(
     title: &str,
     generated_at: &str,
     embed_console: bool,
+    architecture_json: &str,
 ) -> Result<String, JsError> {
     let sources: Vec<Source> = serde_json::from_str(sources_json)
         .map_err(|e| JsError::new(&format!("invalid sources JSON: {e}")))?;
@@ -168,11 +174,17 @@ pub fn generate_report(
             serde_json::from_str(cert_files_json)
                 .map_err(|e| JsError::new(&format!("invalid cert-files JSON: {e}")))?
         };
+    let architecture = if architecture_json.trim().is_empty() {
+        None
+    } else {
+        Some(architecture_json.to_owned())
+    };
     let opts = RenderOptions {
         title: title.to_owned(),
         generated_at: generated_at.to_owned(),
         embed_console,
         cert_pems,
+        architecture,
     };
     build_report(&sources, &opts).map_err(|e| JsError::new(&e.to_string()))
 }

--- a/rust/bigip-report-wasm/src/lib.rs
+++ b/rust/bigip-report-wasm/src/lib.rs
@@ -146,14 +146,13 @@ pub fn decrypt_secrets(scf: &str, master_key: &str) -> Result<String, JsError> {
 /// * `generated_at` — a generation timestamp string (the caller stamps it with
 ///   the browser's local clock; the engine itself is time-free).
 /// * `embed_console` — embed the in-browser `f5-query` WASM console.
-/// * `architecture_json` — an optional architecture manifest declaring each
+/// * `architecture_manifest` — an optional architecture manifest declaring each
 ///   device's role/tier and explicit inter-device links. It is a small **Tcl
 ///   script** (`device <match> -role R -tier N -label L`, `link <from> <to>`),
-///   parsed with the project's Tcl tokeniser; a JSON document (first character
-///   `{`/`[`) is still accepted for compatibility. Empty means pure
-///   auto-detection (an upstream device's pool member / GTM server address that a
-///   downstream device serves is a tier hop). A malformed manifest is surfaced in
-///   the report's Architecture section, not fatal.
+///   parsed with the project's Tcl tokeniser. Empty means pure auto-detection
+///   (an upstream device's pool member / GTM server address that a downstream
+///   device serves is a tier hop). A malformed manifest is surfaced in the
+///   report's Architecture section, not fatal.
 ///
 /// Returns the full HTML document, or a `JsError` carrying the engine's error.
 #[wasm_bindgen]
@@ -163,7 +162,7 @@ pub fn generate_report(
     title: &str,
     generated_at: &str,
     embed_console: bool,
-    architecture_json: &str,
+    architecture_manifest: &str,
 ) -> Result<String, JsError> {
     let sources: Vec<Source> = serde_json::from_str(sources_json)
         .map_err(|e| JsError::new(&format!("invalid sources JSON: {e}")))?;
@@ -177,10 +176,10 @@ pub fn generate_report(
             serde_json::from_str(cert_files_json)
                 .map_err(|e| JsError::new(&format!("invalid cert-files JSON: {e}")))?
         };
-    let architecture = if architecture_json.trim().is_empty() {
+    let architecture = if architecture_manifest.trim().is_empty() {
         None
     } else {
-        Some(architecture_json.to_owned())
+        Some(architecture_manifest.to_owned())
     };
     let opts = RenderOptions {
         title: title.to_owned(),

--- a/rust/bigip-report-wasm/src/lib.rs
+++ b/rust/bigip-report-wasm/src/lib.rs
@@ -146,8 +146,11 @@ pub fn decrypt_secrets(scf: &str, master_key: &str) -> Result<String, JsError> {
 /// * `generated_at` — a generation timestamp string (the caller stamps it with
 ///   the browser's local clock; the engine itself is time-free).
 /// * `embed_console` — embed the in-browser `f5-query` WASM console.
-/// * `architecture_json` — an optional architecture manifest (JSON declaring
-///   each device's role/tier and explicit inter-device links). Empty means pure
+/// * `architecture_json` — an optional architecture manifest declaring each
+///   device's role/tier and explicit inter-device links. It is a small **Tcl
+///   script** (`device <match> -role R -tier N -label L`, `link <from> <to>`),
+///   parsed with the project's Tcl tokeniser; a JSON document (first character
+///   `{`/`[`) is still accepted for compatibility. Empty means pure
 ///   auto-detection (an upstream device's pool member / GTM server address that a
 ///   downstream device serves is a tier hop). A malformed manifest is surfaced in
 ///   the report's Architecture section, not fatal.

--- a/rust/bigip-report-wasm/www/index.html
+++ b/rust/bigip-report-wasm/www/index.html
@@ -74,6 +74,10 @@
   .arch-adv textarea { width: 100%; box-sizing: border-box; margin-top: .5rem; padding: .55rem .65rem;
     border: 1px solid var(--border); border-radius: 8px; background: var(--bg); color: var(--fg);
     font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82rem; resize: vertical; }
+  .arch-adv-actions { display: flex; flex-wrap: wrap; gap: .4rem; margin-top: .5rem; }
+  button.ghost { font: inherit; font-size: .82rem; padding: .3rem .6rem; border: 1px solid var(--border);
+    border-radius: 7px; background: var(--bg); color: var(--fg); cursor: pointer; }
+  button.ghost:hover { border-color: var(--accent); color: var(--accent); }
   .row { display: grid; gap: .9rem; grid-template-columns: 1fr 1fr; margin-top: 1rem; }
   @media (max-width: 34rem) { .row { grid-template-columns: 1fr; } }
   input[type=text], input[type=password] {
@@ -131,17 +135,22 @@
 
     <details class="arch-adv" id="archAdv" style="display:none">
       <summary>Architecture — how these devices relate <span class="hint" style="font-weight:400">(optional)</span></summary>
-      <p class="sub" style="margin:.5rem 0">Give each file a <b>role</b> and <b>tier</b> above to describe the topology — e.g. a GTM at tier 0 in front of an LTM tier 1 in front of an LTM tier 2. Inter-device links are auto-detected from address overlap (a pool member or GTM server address that another device serves), and drawn in the report's Architecture view. To declare links explicitly or override the auto result, paste a manifest below — it wins over the per-file choices.</p>
-      <textarea id="manifest" rows="6" spellcheck="false" placeholder='{
-  "devices": [
-    {"match": "gtm.ucs",   "role": "gtm", "tier": 0, "label": "DNS"},
-    {"match": "edge.ucs",  "role": "ltm", "tier": 1},
-    {"match": "core.ucs",  "role": "ltm", "tier": 2}
-  ],
-  "links": [
-    {"from": "gtm.ucs", "to": "edge.ucs"}
-  ]
-}'></textarea>
+      <p class="sub" style="margin:.5rem 0">Give each file a <b>role</b> and <b>tier</b> above to describe the topology — e.g. a GTM at tier 0 in front of an LTM tier 1 in front of an LTM tier 2. Inter-device links are auto-detected from address overlap (a pool member or GTM server address that another device serves), and drawn in the report's Architecture view. To declare links explicitly or override the auto result, write a small <b>Tcl manifest</b> below — it wins over the per-file choices, and is remembered in this browser.</p>
+      <textarea id="manifest" rows="7" spellcheck="false" placeholder='# a small Tcl script — one command per device / link
+device gtm.ucs  -role gtm -tier 0 -label "DNS Edge"
+device edge.ucs -role ltm -tier 1
+device core.ucs -role ltm -tier 2
+
+# links are auto-detected; declare extras here
+link gtm.ucs  edge.ucs
+link edge.ucs core.ucs -label internal'></textarea>
+      <div class="arch-adv-actions">
+        <button type="button" id="manifestFromFiles" class="ghost">Fill from files above</button>
+        <button type="button" id="manifestSave" class="ghost">Save .tcl ↓</button>
+        <button type="button" id="manifestLoad" class="ghost">Load .tcl ↑</button>
+        <button type="button" id="manifestClear" class="ghost">Clear</button>
+        <input type="file" id="manifestFile" accept=".tcl,.txt,text/plain" hidden>
+      </div>
     </details>
 
     <div class="row">
@@ -226,27 +235,49 @@
   var lastUrl = null;    // object URL of the last generated report
 
   var ROLES = ["auto", "gtm", "ltm", "afm"];
+  var LS_MANIFEST = "f5report-arch-manifest";
+  var LS_META = "f5report-arch-meta";
 
-  // Build the architecture manifest from the per-file role/tier choices (or the
-  // raw manifest textarea, which takes precedence). Returns a JSON string, or ""
-  // for pure auto-detection.
+  // Quote a word for the Tcl manifest: brace it when it carries whitespace or
+  // Tcl-special characters, so a filename with spaces stays one word.
+  function tclWord(s) {
+    return /[\s{}\[\]$";\\]/.test(s) ? "{" + s + "}" : s;
+  }
+
+  // Build the architecture manifest — a small Tcl script — from the per-file
+  // role/tier choices. The raw manifest textarea (if the user typed one) takes
+  // precedence. Returns "" for pure auto-detection.
   function buildManifest() {
     var raw = (document.getElementById("manifest").value || "").trim();
     if (raw) return raw;
-    var devices = [];
+    var lines = [];
     files.forEach(function (f) {
       var m = meta[f.name] || {};
-      var entry = { match: f.name };
-      var any = false;
-      if (m.role && m.role !== "auto") { entry.role = m.role; any = true; }
+      var parts = [];
+      if (m.role && m.role !== "auto") parts.push("-role " + m.role);
       if (m.tier !== undefined && m.tier !== "" && m.tier !== null) {
-        entry.tier = parseInt(m.tier, 10);
-        if (!isNaN(entry.tier)) any = true; else delete entry.tier;
+        var t = parseInt(m.tier, 10);
+        if (!isNaN(t)) parts.push("-tier " + t);
       }
-      if (any) devices.push(entry);
+      if (parts.length) lines.push("device " + tclWord(f.name) + " " + parts.join(" "));
     });
-    if (!devices.length) return "";
-    return JSON.stringify({ devices: devices });
+    return lines.join("\n");
+  }
+
+  // --- persistence: remember the manifest + per-file choices in this browser --
+  function saveManifestState() {
+    try {
+      localStorage.setItem(LS_MANIFEST, document.getElementById("manifest").value || "");
+      localStorage.setItem(LS_META, JSON.stringify(meta));
+    } catch (e) {}
+  }
+  function restoreManifestState() {
+    try {
+      var m = localStorage.getItem(LS_MANIFEST);
+      if (m) document.getElementById("manifest").value = m;
+      var mt = localStorage.getItem(LS_META);
+      if (mt) meta = JSON.parse(mt) || {};
+    } catch (e) {}
   }
 
   function setStatus(msg, cls) {
@@ -305,14 +336,14 @@
           role.appendChild(opt);
         });
         role.addEventListener("click", function (e) { e.stopPropagation(); });
-        role.addEventListener("change", function () { mrec.role = role.value; });
+        role.addEventListener("change", function () { mrec.role = role.value; saveManifestState(); });
 
         var tier = document.createElement("input");
         tier.type = "number"; tier.min = "0"; tier.className = "arch-tier";
         tier.placeholder = "tier"; tier.title = "Tier (0 = front)";
         tier.value = mrec.tier;
         tier.addEventListener("click", function (e) { e.stopPropagation(); });
-        tier.addEventListener("input", function () { mrec.tier = tier.value; });
+        tier.addEventListener("input", function () { mrec.tier = tier.value; saveManifestState(); });
 
         li.appendChild(role);
         li.appendChild(tier);
@@ -349,6 +380,48 @@
     drop.addEventListener(ev, function (e) { e.preventDefault(); drop.classList.remove("drag"); });
   });
   drop.addEventListener("drop", function (e) { if (e.dataTransfer && e.dataTransfer.files) addFiles(e.dataTransfer.files); });
+
+  // --- architecture manifest: persistence + file load/save ------------------
+  (function initManifestControls() {
+    var ta = document.getElementById("manifest");
+    restoreManifestState();
+    ta.addEventListener("input", saveManifestState);
+
+    document.getElementById("manifestFromFiles").addEventListener("click", function () {
+      // Clear the textarea first so buildManifest() derives from the per-file
+      // choices, then drop the generated Tcl in for the user to edit.
+      var keep = ta.value; ta.value = "";
+      var gen = buildManifest();
+      ta.value = gen || keep;
+      saveManifestState();
+    });
+
+    document.getElementById("manifestSave").addEventListener("click", function () {
+      var text = ta.value.trim() || buildManifest();
+      if (!text) { setStatus("nothing to save — set roles/tiers or write a manifest", "err"); return; }
+      var blob = new Blob([text + "\n"], { type: "text/plain" });
+      var url = URL.createObjectURL(blob);
+      var a = document.createElement("a");
+      a.href = url; a.download = "architecture.tcl";
+      document.body.appendChild(a); a.click(); a.remove();
+      setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+    });
+
+    var fileInput = document.getElementById("manifestFile");
+    document.getElementById("manifestLoad").addEventListener("click", function () { fileInput.click(); });
+    fileInput.addEventListener("change", function () {
+      var f = fileInput.files && fileInput.files[0];
+      if (!f) return;
+      var r = new FileReader();
+      r.onload = function () { ta.value = String(r.result || ""); saveManifestState(); };
+      r.readAsText(f);
+      fileInput.value = "";
+    });
+
+    document.getElementById("manifestClear").addEventListener("click", function () {
+      ta.value = ""; saveManifestState();
+    });
+  })();
 
   // --- decode the inlined wasm and initialise ------------------------------
   function b64ToBytes(b64) {

--- a/rust/bigip-report-wasm/www/index.html
+++ b/rust/bigip-report-wasm/www/index.html
@@ -64,6 +64,16 @@
   .files li .sz { color: var(--muted); margin-left: auto; white-space: nowrap; }
   .files li .rm { border: 0; background: transparent; color: var(--muted); cursor: pointer; font-size: 1.1rem; padding: 0 .2rem; }
   .files li .lock { color: var(--warn-fg); }
+  .files li .sz { margin-left: auto; }
+  .files li .arch-role { font: inherit; font-size: .8rem; padding: .2rem .3rem; border: 1px solid var(--border);
+    border-radius: 6px; background: var(--bg); color: var(--fg); }
+  .files li .arch-tier { width: 3.4rem; font: inherit; font-size: .8rem; padding: .2rem .35rem;
+    border: 1px solid var(--border); border-radius: 6px; background: var(--bg); color: var(--fg); }
+  .arch-adv { margin-top: .9rem; border: 1px solid var(--border); border-radius: 8px; padding: .5rem .7rem; }
+  .arch-adv summary { cursor: pointer; font-weight: 600; font-size: .9rem; }
+  .arch-adv textarea { width: 100%; box-sizing: border-box; margin-top: .5rem; padding: .55rem .65rem;
+    border: 1px solid var(--border); border-radius: 8px; background: var(--bg); color: var(--fg);
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .82rem; resize: vertical; }
   .row { display: grid; gap: .9rem; grid-template-columns: 1fr 1fr; margin-top: 1rem; }
   @media (max-width: 34rem) { .row { grid-template-columns: 1fr; } }
   input[type=text], input[type=password] {
@@ -100,7 +110,7 @@
 <body>
 <div class="wrap">
   <h1>F5 BIG-IP Report Generator</h1>
-  <p class="tagline">Turn a <code>.ucs</code> backup or a <code>bigip.conf</code> / SCF into one interactive, self-contained HTML report — virtual servers, pools, iRules, an SSL-certificate expiry inventory, a topology explorer, a listener simulator and a live <code>f5-query</code> console.</p>
+  <p class="tagline">Turn one or more <code>.ucs</code> backups or <code>bigip.conf</code> / SCF files into one interactive, self-contained HTML report — virtual servers, pools, iRules, GTM/DNS, AFM firewall &amp; NAT, an SSL-certificate expiry inventory, a topology explorer, a listener simulator and a live <code>f5-query</code> console. Load several devices to see how they relate as tiers (GTM → LTM tier 1 → LTM tier 2, …).</p>
 
   <div class="privacy">
     <span class="lock" aria-hidden="true">🔒</span>
@@ -118,6 +128,21 @@
     </div>
     <input type="file" id="picker" multiple accept=".ucs,.scf,.conf,.txt,text/plain,application/octet-stream">
     <ul class="files" id="fileList"></ul>
+
+    <details class="arch-adv" id="archAdv" style="display:none">
+      <summary>Architecture — how these devices relate <span class="hint" style="font-weight:400">(optional)</span></summary>
+      <p class="sub" style="margin:.5rem 0">Give each file a <b>role</b> and <b>tier</b> above to describe the topology — e.g. a GTM at tier 0 in front of an LTM tier 1 in front of an LTM tier 2. Inter-device links are auto-detected from address overlap (a pool member or GTM server address that another device serves), and drawn in the report's Architecture view. To declare links explicitly or override the auto result, paste a manifest below — it wins over the per-file choices.</p>
+      <textarea id="manifest" rows="6" spellcheck="false" placeholder='{
+  "devices": [
+    {"match": "gtm.ucs",   "role": "gtm", "tier": 0, "label": "DNS"},
+    {"match": "edge.ucs",  "role": "ltm", "tier": 1},
+    {"match": "core.ucs",  "role": "ltm", "tier": 2}
+  ],
+  "links": [
+    {"from": "gtm.ucs", "to": "edge.ucs"}
+  ]
+}'></textarea>
+    </details>
 
     <div class="row">
       <div>
@@ -197,7 +222,32 @@
   var verEl = document.getElementById("ver");
 
   var files = [];        // selected File objects
+  var meta = {};         // per-file architecture hint, keyed by file name: {role, tier}
   var lastUrl = null;    // object URL of the last generated report
+
+  var ROLES = ["auto", "gtm", "ltm", "afm"];
+
+  // Build the architecture manifest from the per-file role/tier choices (or the
+  // raw manifest textarea, which takes precedence). Returns a JSON string, or ""
+  // for pure auto-detection.
+  function buildManifest() {
+    var raw = (document.getElementById("manifest").value || "").trim();
+    if (raw) return raw;
+    var devices = [];
+    files.forEach(function (f) {
+      var m = meta[f.name] || {};
+      var entry = { match: f.name };
+      var any = false;
+      if (m.role && m.role !== "auto") { entry.role = m.role; any = true; }
+      if (m.tier !== undefined && m.tier !== "" && m.tier !== null) {
+        entry.tier = parseInt(m.tier, 10);
+        if (!isNaN(entry.tier)) any = true; else delete entry.tier;
+      }
+      if (any) devices.push(entry);
+    });
+    if (!devices.length) return "";
+    return JSON.stringify({ devices: devices });
+  }
 
   function setStatus(msg, cls) {
     statusEl.textContent = msg;
@@ -238,9 +288,40 @@
         li.appendChild(lk);
       }
       li.appendChild(sz);
+
+      // Per-file architecture hint: role + tier. Shown once more than one file
+      // is loaded (a single device has no architecture to describe).
+      if (files.length > 1) {
+        if (!meta[f.name]) meta[f.name] = { role: "auto", tier: "" };
+        var mrec = meta[f.name];
+
+        var role = document.createElement("select");
+        role.className = "arch-role";
+        role.title = "Device role";
+        ROLES.forEach(function (r) {
+          var opt = document.createElement("option");
+          opt.value = r; opt.textContent = r;
+          if (r === mrec.role) opt.selected = true;
+          role.appendChild(opt);
+        });
+        role.addEventListener("click", function (e) { e.stopPropagation(); });
+        role.addEventListener("change", function () { mrec.role = role.value; });
+
+        var tier = document.createElement("input");
+        tier.type = "number"; tier.min = "0"; tier.className = "arch-tier";
+        tier.placeholder = "tier"; tier.title = "Tier (0 = front)";
+        tier.value = mrec.tier;
+        tier.addEventListener("click", function (e) { e.stopPropagation(); });
+        tier.addEventListener("input", function () { mrec.tier = tier.value; });
+
+        li.appendChild(role);
+        li.appendChild(tier);
+      }
+
       li.appendChild(rm);
       fileListEl.appendChild(li);
     });
+    document.getElementById("archAdv").style.display = files.length > 1 ? "" : "none";
     updateReady();
   }
 
@@ -407,8 +488,9 @@
         setTimeout(function () { resolve({ sources: sources, certFiles: certFiles, locked: locked }); }, 20);
       });
     }).then(function (st) {
+      var manifest = buildManifest();
       var html = wasm_bindgen.generate_report(
-        JSON.stringify(st.sources), JSON.stringify(st.certFiles), title, utcStamp(), embed);
+        JSON.stringify(st.sources), JSON.stringify(st.certFiles), title, utcStamp(), embed, manifest);
       deliver(html, st.sources.length, st.locked);
     });
   }

--- a/rust/tcl-bigip-query/src/projection.rs
+++ b/rust/tcl-bigip-query/src/projection.rs
@@ -29,9 +29,12 @@ use tcl_bigip::model::{
     BigipGtmDatacenter, BigipGtmListener, BigipGtmPool, BigipGtmPoolMember, BigipGtmServer,
     BigipGtmWideip, BigipMonitor, BigipNode, BigipPersistence, BigipPolicy, BigipPolicyAction,
     BigipPolicyCondition, BigipPolicyRule, BigipPool, BigipPoolMember, BigipProfile, BigipRule,
-    BigipSnatPool, BigipVirtualAddress, BigipVirtualServer, DataGroupType, ModelObject,
-    ProfileType,
+    BigipSecurityFirewallAddressList, BigipSecurityFirewallPolicy, BigipSecurityFirewallPortList,
+    BigipSecurityFirewallRuleList, BigipSecurityNatDestinationTranslation, BigipSecurityNatPolicy,
+    BigipSecurityNatSourceTranslation, BigipSnatPool, BigipVirtualAddress, BigipVirtualServer,
+    DataGroupType, ModelObject, ProfileType,
 };
+use tcl_bigip::value::{FirewallEndpoint, FirewallRule};
 use tcl_bigip::parser::Placed;
 use tcl_bigip::value::{BigipList, ListItemValue, MonitorExpression};
 
@@ -201,12 +204,30 @@ const GTM_KINDS: &[(&str, &str)] = &[
     ("listener", "gtm listener"),
 ];
 
-/// Every `(label, tmsh_kind)` the projection covers, across modules. Iterated by
-/// the per-module entry builder and the kind/label lookups.
+/// `(label, tmsh_kind)` for the AFM `security` kinds the projection covers:
+/// firewall policies / rule-lists and the address-/port-lists they reference,
+/// plus the NAT policies and source/destination translations. These let the
+/// report surface the firewall + NAT posture alongside the LTM/GTM estate.
+const SECURITY_KINDS: &[(&str, &str)] = &[
+    ("firewall-policy", "security firewall policy"),
+    ("firewall-rule-list", "security firewall rule-list"),
+    ("firewall-address-list", "security firewall address-list"),
+    ("firewall-port-list", "security firewall port-list"),
+    ("nat-policy", "security nat policy"),
+    ("nat-source-translation", "security nat source-translation"),
+    ("nat-destination-translation", "security nat destination-translation"),
+];
+
+/// Every covered kind table, in module order. Iterated by the per-module entry
+/// builder and the kind/label lookups.
+const KIND_TABLES: &[&[(&str, &str)]] = &[LTM_KINDS, GTM_KINDS, SECURITY_KINDS];
+
+/// The `(label, tmsh_kind)` table for a module, or empty for an uncovered one.
 fn module_kinds(module: &str) -> &'static [(&'static str, &'static str)] {
     match module {
         "ltm" => LTM_KINDS,
         "gtm" => GTM_KINDS,
+        "security" => SECURITY_KINDS,
         _ => &[],
     }
 }
@@ -214,14 +235,14 @@ fn module_kinds(module: &str) -> &'static [(&'static str, &'static str)] {
 /// The set of leaf object kinds, restricted to the covered subset. Used by
 /// `Container.is_object_kind`.
 fn is_object_kind_alias(kind: &str) -> bool {
-    [LTM_KINDS, GTM_KINDS]
+    KIND_TABLES
         .iter()
         .any(|table| table.iter().any(|(_, k)| *k == kind))
 }
 
 /// Map a kind to its label (for `PathRef` container navigation).
 fn kind_to_label(kind: &str) -> Option<&'static str> {
-    [LTM_KINDS, GTM_KINDS]
+    KIND_TABLES
         .iter()
         .flat_map(|table| table.iter())
         .find(|(_, k)| *k == kind)
@@ -292,6 +313,15 @@ fn placed_kind(placed: &Placed) -> Option<&'static str> {
         ModelObject::GtmPool(_) => Some("gtm pool"),
         ModelObject::GtmWideip(_) => Some("gtm wideip"),
         ModelObject::GtmListener(_) => Some("gtm listener"),
+        ModelObject::SecurityFirewallPolicy(_) => Some("security firewall policy"),
+        ModelObject::SecurityFirewallRuleList(_) => Some("security firewall rule-list"),
+        ModelObject::SecurityFirewallAddressList(_) => Some("security firewall address-list"),
+        ModelObject::SecurityFirewallPortList(_) => Some("security firewall port-list"),
+        ModelObject::SecurityNatPolicy(_) => Some("security nat policy"),
+        ModelObject::SecurityNatSourceTranslation(_) => Some("security nat source-translation"),
+        ModelObject::SecurityNatDestinationTranslation(_) => {
+            Some("security nat destination-translation")
+        }
         _ => None,
     }
 }
@@ -365,6 +395,13 @@ fn model_range(obj: &ModelObject) -> Option<tcl_bigip::range::Range> {
         ModelObject::GtmPool(o) => o.range,
         ModelObject::GtmWideip(o) => o.range,
         ModelObject::GtmListener(o) => o.range,
+        ModelObject::SecurityFirewallPolicy(o) => o.range,
+        ModelObject::SecurityFirewallRuleList(o) => o.range,
+        ModelObject::SecurityFirewallAddressList(o) => o.range,
+        ModelObject::SecurityFirewallPortList(o) => o.range,
+        ModelObject::SecurityNatPolicy(o) => o.range,
+        ModelObject::SecurityNatSourceTranslation(o) => o.range,
+        ModelObject::SecurityNatDestinationTranslation(o) => o.range,
         _ => None,
     }
 }
@@ -533,6 +570,26 @@ fn project_fields(kind: &str, obj: &ModelObject, root: &Rc<Root>) -> IndexMap<St
         ("gtm pool", ModelObject::GtmPool(o)) => project_gtm_pool(o),
         ("gtm wideip", ModelObject::GtmWideip(o)) => project_gtm_wideip(o),
         ("gtm listener", ModelObject::GtmListener(o)) => project_gtm_listener(o),
+        ("security firewall policy", ModelObject::SecurityFirewallPolicy(o)) => {
+            project_fw_policy(o)
+        }
+        ("security firewall rule-list", ModelObject::SecurityFirewallRuleList(o)) => {
+            project_fw_rule_list(o)
+        }
+        ("security firewall address-list", ModelObject::SecurityFirewallAddressList(o)) => {
+            project_fw_address_list(o)
+        }
+        ("security firewall port-list", ModelObject::SecurityFirewallPortList(o)) => {
+            project_fw_port_list(o)
+        }
+        ("security nat policy", ModelObject::SecurityNatPolicy(o)) => project_nat_policy(o),
+        ("security nat source-translation", ModelObject::SecurityNatSourceTranslation(o)) => {
+            project_nat_source_translation(o)
+        }
+        (
+            "security nat destination-translation",
+            ModelObject::SecurityNatDestinationTranslation(o),
+        ) => project_nat_destination_translation(o),
         _ => IndexMap::new(),
     }
 }
@@ -1329,6 +1386,127 @@ fn project_gtm_listener(o: &BigipGtmListener) -> IndexMap<String, Value> {
         .b("vlans-enabled", o.vlans_enabled)
         .s("state", &o.state)
         .s("description", &o.description)
+        .done()
+}
+
+// Security (AFM firewall + NAT) projections
+
+/// Project a firewall endpoint (source / destination 5-tuple side).
+fn fw_endpoint(e: &FirewallEndpoint) -> Value {
+    Value::Object(
+        Fields::new()
+            .v("addresses", str_list(&e.addresses))
+            .v(
+                "address-lists",
+                path_ref_list_strs(&e.address_lists, "security firewall address-list"),
+            )
+            .v("ports", str_list(&e.ports))
+            .v(
+                "port-lists",
+                path_ref_list_strs(&e.port_lists, "security firewall port-list"),
+            )
+            .done(),
+    )
+}
+
+/// Project one firewall / NAT rule to a structured object.
+fn fw_rule(r: &FirewallRule) -> Value {
+    Value::Object(
+        Fields::new()
+            .s("name", &r.name)
+            .s("action", &r.action)
+            .s("ip-protocol", &r.ip_protocol)
+            .b("log", r.log)
+            .v("source", fw_endpoint(&r.source))
+            .v("destination", fw_endpoint(&r.destination))
+            .s("rule-list", &r.rule_list)
+            .done(),
+    )
+}
+
+fn fw_rule_list_value(rules: &[FirewallRule]) -> Value {
+    Value::List(rules.iter().map(fw_rule).collect())
+}
+
+fn project_fw_policy(o: &BigipSecurityFirewallPolicy) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("description", &o.description)
+        .v("rules", str_list(&o.rules))
+        .v(
+            "rule-lists",
+            path_ref_list_strs(&o.rule_lists, "security firewall rule-list"),
+        )
+        .done()
+}
+
+fn project_fw_rule_list(o: &BigipSecurityFirewallRuleList) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("description", &o.description)
+        .v("rules", fw_rule_list_value(&o.rule_objects))
+        .done()
+}
+
+fn project_fw_address_list(o: &BigipSecurityFirewallAddressList) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("description", &o.description)
+        .v("addresses", str_list(&o.addresses))
+        .v(
+            "address-lists",
+            path_ref_list_strs(&o.address_lists, "security firewall address-list"),
+        )
+        .v("fqdns", str_list(&o.fqdns))
+        .done()
+}
+
+fn project_fw_port_list(o: &BigipSecurityFirewallPortList) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("description", &o.description)
+        .v("ports", str_list(&o.ports))
+        .done()
+}
+
+fn project_nat_policy(o: &BigipSecurityNatPolicy) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("description", &o.description)
+        .v("rules", str_list(&o.rules))
+        .v(
+            "rule-lists",
+            path_ref_list_strs(&o.rule_lists, "security nat rule-list"),
+        )
+        .done()
+}
+
+fn project_nat_source_translation(o: &BigipSecurityNatSourceTranslation) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("description", &o.description)
+        .s("type", &o.type_)
+        .v("addresses", str_list(&o.addresses))
+        .v("ports", str_list(&o.ports))
+        .done()
+}
+
+fn project_nat_destination_translation(
+    o: &BigipSecurityNatDestinationTranslation,
+) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("description", &o.description)
+        .s("type", &o.type_)
+        .v("addresses", str_list(&o.addresses))
+        .v("ports", str_list(&o.ports))
         .done()
 }
 

--- a/rust/tcl-bigip-query/src/projection.rs
+++ b/rust/tcl-bigip-query/src/projection.rs
@@ -26,7 +26,8 @@ use std::rc::Rc;
 use indexmap::IndexMap;
 use tcl_bigip::model::BigipDataGroup;
 use tcl_bigip::model::{
-    BigipMonitor, BigipNode, BigipPersistence, BigipPolicy, BigipPolicyAction,
+    BigipGtmDatacenter, BigipGtmListener, BigipGtmPool, BigipGtmPoolMember, BigipGtmServer,
+    BigipGtmWideip, BigipMonitor, BigipNode, BigipPersistence, BigipPolicy, BigipPolicyAction,
     BigipPolicyCondition, BigipPolicyRule, BigipPool, BigipPoolMember, BigipProfile, BigipRule,
     BigipSnatPool, BigipVirtualAddress, BigipVirtualServer, DataGroupType, ModelObject,
     ProfileType,
@@ -188,16 +189,41 @@ const LTM_KINDS: &[(&str, &str)] = &[
     ("data-group", "ltm data-group"),
 ];
 
+/// `(label, tmsh_kind)` for the GTM kinds the projection covers. GTM matters to
+/// the estate report because a GTM (DNS) tier fronts one or more LTM tiers: a
+/// `gtm server`'s `virtual-servers` destinations are the downstream LTM virtual
+/// addresses, which is how the report links a GTM to the LTMs it load-balances.
+const GTM_KINDS: &[(&str, &str)] = &[
+    ("datacenter", "gtm datacenter"),
+    ("server", "gtm server"),
+    ("pool", "gtm pool"),
+    ("wideip", "gtm wideip"),
+    ("listener", "gtm listener"),
+];
+
+/// Every `(label, tmsh_kind)` the projection covers, across modules. Iterated by
+/// the per-module entry builder and the kind/label lookups.
+fn module_kinds(module: &str) -> &'static [(&'static str, &'static str)] {
+    match module {
+        "ltm" => LTM_KINDS,
+        "gtm" => GTM_KINDS,
+        _ => &[],
+    }
+}
+
 /// The set of leaf object kinds, restricted to the covered subset. Used by
 /// `Container.is_object_kind`.
 fn is_object_kind_alias(kind: &str) -> bool {
-    LTM_KINDS.iter().any(|(_, k)| *k == kind)
+    [LTM_KINDS, GTM_KINDS]
+        .iter()
+        .any(|table| table.iter().any(|(_, k)| *k == kind))
 }
 
 /// Map a kind to its label (for `PathRef` container navigation).
 fn kind_to_label(kind: &str) -> Option<&'static str> {
-    LTM_KINDS
+    [LTM_KINDS, GTM_KINDS]
         .iter()
+        .flat_map(|table| table.iter())
         .find(|(_, k)| *k == kind)
         .map(|(label, _)| *label)
 }
@@ -219,16 +245,14 @@ fn build_entries(container: &Container) -> IndexMap<String, Value> {
         return out;
     }
 
-    // Module-level container (`.ltm`): one Container per kind.
+    // Module-level container (`.ltm` / `.gtm`): one Container per covered kind.
     if MODULE_NAMES.contains(&container.kind.as_str()) {
         let mut out = IndexMap::new();
-        if container.kind == "ltm" {
-            for (label, tmsh_kind) in LTM_KINDS {
-                out.insert(
-                    (*label).to_owned(),
-                    Value::Container(Container::new(*tmsh_kind, Rc::clone(root))),
-                );
-            }
+        for (label, tmsh_kind) in module_kinds(&container.kind) {
+            out.insert(
+                (*label).to_owned(),
+                Value::Container(Container::new(*tmsh_kind, Rc::clone(root))),
+            );
         }
         return out;
     }
@@ -263,6 +287,11 @@ fn placed_kind(placed: &Placed) -> Option<&'static str> {
         ModelObject::SnatPool(_) => Some("ltm snatpool"),
         ModelObject::Policy(_) => Some("ltm policy"),
         ModelObject::DataGroup(_) => Some("ltm data-group"),
+        ModelObject::GtmDatacenter(_) => Some("gtm datacenter"),
+        ModelObject::GtmServer(_) => Some("gtm server"),
+        ModelObject::GtmPool(_) => Some("gtm pool"),
+        ModelObject::GtmWideip(_) => Some("gtm wideip"),
+        ModelObject::GtmListener(_) => Some("gtm listener"),
         _ => None,
     }
 }
@@ -331,6 +360,11 @@ fn model_range(obj: &ModelObject) -> Option<tcl_bigip::range::Range> {
         ModelObject::SnatPool(o) => o.range,
         ModelObject::Policy(o) => o.range,
         ModelObject::DataGroup(o) => o.range,
+        ModelObject::GtmDatacenter(o) => o.range,
+        ModelObject::GtmServer(o) => o.range,
+        ModelObject::GtmPool(o) => o.range,
+        ModelObject::GtmWideip(o) => o.range,
+        ModelObject::GtmListener(o) => o.range,
         _ => None,
     }
 }
@@ -494,6 +528,11 @@ fn project_fields(kind: &str, obj: &ModelObject, root: &Rc<Root>) -> IndexMap<St
         ("ltm snatpool", ModelObject::SnatPool(o)) => project_snatpool(o),
         ("ltm policy", ModelObject::Policy(o)) => project_policy(o, root),
         ("ltm data-group", ModelObject::DataGroup(o)) => project_data_group(o),
+        ("gtm datacenter", ModelObject::GtmDatacenter(o)) => project_gtm_datacenter(o),
+        ("gtm server", ModelObject::GtmServer(o)) => project_gtm_server(o),
+        ("gtm pool", ModelObject::GtmPool(o)) => project_gtm_pool(o),
+        ("gtm wideip", ModelObject::GtmWideip(o)) => project_gtm_wideip(o),
+        ("gtm listener", ModelObject::GtmListener(o)) => project_gtm_listener(o),
         _ => IndexMap::new(),
     }
 }
@@ -1178,6 +1217,119 @@ fn project_data_group(o: &BigipDataGroup) -> IndexMap<String, Value> {
 /// A `Vec<String>` projected as a list of strings.
 fn str_list(values: &[String]) -> Value {
     Value::List(values.iter().map(|s| Value::Str(s.clone())).collect())
+}
+
+// GTM projections
+
+fn project_gtm_datacenter(o: &BigipGtmDatacenter) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("contact", &o.contact)
+        .s("location", &o.location)
+        .s("description", &o.description)
+        .v("prober-pool", path_ref(&o.prober_pool, "gtm prober-pool"))
+        .s("prober-preference", &o.prober_preference)
+        .s("prober-fallback", &o.prober_fallback)
+        .s("state", &o.state)
+        .done()
+}
+
+fn project_gtm_server(o: &BigipGtmServer) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .v("datacenter", path_ref(&o.datacenter, "gtm datacenter"))
+        .v("monitor", monitor_value(&o.monitor))
+        .s("product", &o.product)
+        // The device's own (self) IP addresses.
+        .v("addresses", str_list(&o.addresses))
+        // The destinations of the server's virtual-servers — these are the
+        // downstream LTM virtual addresses this GTM balances across, and the
+        // signal the report uses to link a GTM tier to its LTM tiers.
+        .v("virtual-servers", str_list(&o.virtual_servers))
+        .s("description", &o.description)
+        .s("state", &o.state)
+        .v("prober-pool", path_ref(&o.prober_pool, "gtm prober-pool"))
+        .s("virtual-server-discovery", &o.virtual_server_discovery)
+        .done()
+}
+
+fn project_gtm_pool(o: &BigipGtmPool) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("record-type", &o.record_type)
+        .v("monitor", monitor_value(&o.monitor))
+        .s("load-balancing-mode", &o.load_balancing_mode)
+        .s("alternate-mode", &o.alternate_mode)
+        .s("fallback-mode", &o.fallback_mode)
+        .s("fallback-ip", &o.fallback_ip)
+        .s("ttl", &o.ttl)
+        .s("max-answers-returned", &o.max_answers_returned)
+        .s("verify-member-availability", &o.verify_member_availability)
+        .v("members", project_gtm_pool_members(&o.members))
+        .s("description", &o.description)
+        .s("state", &o.state)
+        .done()
+}
+
+fn project_gtm_pool_members(members: &[BigipGtmPoolMember]) -> Value {
+    Value::List(
+        members
+            .iter()
+            .map(|m| {
+                Value::Object(
+                    Fields::new()
+                        .s("name", &m.name)
+                        .s("service-port", &m.service_port)
+                        .s("order", &m.order)
+                        .s("member-order", &m.member_order)
+                        .s("ratio", &m.ratio)
+                        .v("monitor", monitor_value(&m.monitor))
+                        .s("static-target", &m.static_target)
+                        .s("state", &m.state)
+                        .s("description", &m.description)
+                        .done(),
+                )
+            })
+            .collect(),
+    )
+}
+
+fn project_gtm_wideip(o: &BigipGtmWideip) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("record-type", &o.record_type)
+        .v("pools", path_ref_list_strs(&o.pools, "gtm pool"))
+        .v("aliases", str_list(&o.aliases))
+        .s("pool-lb-mode", &o.pool_lb_mode)
+        .v("last-resort-pool", path_ref(&o.last_resort_pool, "gtm pool"))
+        .s("persistence", &o.persistence)
+        .s("description", &o.description)
+        .s("state", &o.state)
+        .done()
+}
+
+fn project_gtm_listener(o: &BigipGtmListener) -> IndexMap<String, Value> {
+    Fields::new()
+        .s("name", &o.name)
+        .s("full-path", &o.full_path)
+        .s("address", &o.address)
+        .s("port", &o.port)
+        .s("ip-protocol", &o.ip_protocol)
+        .s("mask", &o.mask)
+        .v("pool", path_ref(&o.pool, "gtm pool"))
+        .v("profiles", path_ref_list_strs(&o.profiles, "ltm profile"))
+        .v("rules", path_ref_list_strs(&o.rules, "gtm rule"))
+        .s("source-address-translation", &o.source_address_translation)
+        .v("vlans", str_list(&o.vlans))
+        .b("vlans-disabled", o.vlans_disabled)
+        .b("vlans-enabled", o.vlans_enabled)
+        .s("state", &o.state)
+        .s("description", &o.description)
+        .done()
 }
 
 // PathRef resolution

--- a/rust/tcl-bigip-report/src/architecture.rs
+++ b/rust/tcl-bigip-report/src/architecture.rs
@@ -481,9 +481,17 @@ pub(crate) fn build_architecture(devices: &[J], manifest_text: Option<&str>) -> 
                     J::Object(vo)
                 })
                 .collect();
+            let label_of = |i: usize| -> String {
+                dev_json
+                    .get(i)
+                    .and_then(J::as_object)
+                    .map_or(String::new(), |m| bstr(m, "label").to_string())
+            };
             let mut o = Map::new();
             o.insert("from".into(), J::from(l.from));
             o.insert("to".into(), J::from(l.to));
+            o.insert("fromLabel".into(), J::String(label_of(l.from)));
+            o.insert("toLabel".into(), J::String(label_of(l.to)));
             o.insert("source".into(), J::String(l.source.clone()));
             if let Some(lbl) = &l.label {
                 o.insert("label".into(), J::String(lbl.clone()));
@@ -496,10 +504,27 @@ pub(crate) fn build_architecture(devices: &[J], manifest_text: Option<&str>) -> 
 
     let mermaid = build_mermaid(&dev_json, &links, &tiers);
 
+    // Pre-group devices by tier (ascending) so the report can render tier
+    // columns without regrouping in the template.
+    let mut tier_map: BTreeMap<i64, Vec<J>> = BTreeMap::new();
+    for (i, d) in dev_json.iter().enumerate() {
+        tier_map.entry(tiers[i]).or_default().push(d.clone());
+    }
+    let tier_json: Vec<J> = tier_map
+        .into_iter()
+        .map(|(tier, devs)| {
+            let mut o = Map::new();
+            o.insert("tier".into(), J::from(tier));
+            o.insert("devices".into(), J::Array(devs));
+            J::Object(o)
+        })
+        .collect();
+
     let mut arch = Map::new();
     arch.insert("defined".into(), J::Bool(manifest.is_some()));
     arch.insert("deviceCount".into(), J::from(n));
     arch.insert("devices".into(), J::Array(dev_json));
+    arch.insert("tiers".into(), J::Array(tier_json));
     arch.insert("links".into(), J::Array(link_json));
     arch.insert("mermaid".into(), J::String(mermaid));
     if let Some(e) = manifest_error {

--- a/rust/tcl-bigip-report/src/architecture.rs
+++ b/rust/tcl-bigip-report/src/architecture.rs
@@ -239,11 +239,132 @@ fn resolve_device(matcher: &str, devices: &[J]) -> Option<usize> {
     })
 }
 
+/// Parse a manifest, auto-detecting the format. A document whose first
+/// non-space character is `{` or `[` is treated as JSON (kept for
+/// compatibility); anything else is the Tcl manifest DSL — the natural spelling
+/// in this project, parsed with the real Tcl tokeniser:
+///
+/// ```tcl
+/// # one line per device; options are Tcl-style flags
+/// device gtm.ucs  -role gtm -tier 0 -label "DNS Edge"
+/// device edge.ucs -role ltm -tier 1
+/// device core.ucs -role ltm -tier 2
+///
+/// # explicit links (auto-detection still runs and is merged in)
+/// link gtm.ucs  edge.ucs
+/// link edge.ucs core.ucs -label internal
+/// ```
+fn parse_manifest(text: &str) -> Result<Manifest, String> {
+    if matches!(text.trim_start().chars().next(), Some('{' | '[')) {
+        parse_manifest_json(text)
+    } else {
+        Ok(parse_manifest_tcl(text))
+    }
+}
+
+/// Split a Tcl script into commands, each a list of literal words, using the
+/// real Tcl tokeniser (so braces, quotes, comments and `;` separators are
+/// handled exactly as Tcl would). Substitutions (`$var`, `[cmd]`) are taken
+/// literally — the manifest DSL never needs them.
+fn tcl_commands(src: &str) -> Vec<Vec<String>> {
+    use tcl_lexer::{Lexer, SourceMap, TokenType};
+
+    let Ok(tokens) = Lexer::new(src).tokenise_all() else {
+        return Vec::new();
+    };
+    let sm = SourceMap::new(src);
+    let mut commands: Vec<Vec<String>> = Vec::new();
+    let mut cmd: Vec<String> = Vec::new();
+    let mut word = String::new();
+    let mut in_word = false;
+    for tok in tokens {
+        match tok.kind {
+            TokenType::Sep => {
+                if in_word {
+                    cmd.push(std::mem::take(&mut word));
+                    in_word = false;
+                }
+            }
+            TokenType::Eol => {
+                if in_word {
+                    cmd.push(std::mem::take(&mut word));
+                    in_word = false;
+                }
+                if !cmd.is_empty() {
+                    commands.push(std::mem::take(&mut cmd));
+                }
+            }
+            TokenType::Comment | TokenType::Eof | TokenType::Expand => {}
+            // Esc / Str / Cmd / Var — a (fragment of a) word.
+            _ => {
+                word.push_str(sm.token_text(tok));
+                in_word = true;
+            }
+        }
+    }
+    if in_word {
+        cmd.push(word);
+    }
+    if !cmd.is_empty() {
+        commands.push(cmd);
+    }
+    commands
+}
+
+/// Interpret the Tcl manifest DSL. Recognised commands are `device <match>
+/// [-role R] [-tier N] [-label L]` and `link <from> <to> [-label L]`; unknown
+/// commands and unknown flags are skipped leniently.
+fn parse_manifest_tcl(text: &str) -> Manifest {
+    let mut devices = Vec::new();
+    let mut links = Vec::new();
+
+    // Read `-flag value` pairs from a word slice into (role, tier, label).
+    let read_opts = |words: &[String]| -> (Option<String>, Option<i64>, Option<String>) {
+        let (mut role, mut tier, mut label) = (None, None, None);
+        let mut i = 0;
+        while i + 1 < words.len() {
+            let (flag, val) = (words[i].as_str(), words[i + 1].clone());
+            match flag {
+                "-role" => role = Some(val),
+                "-tier" => tier = val.parse::<i64>().ok(),
+                "-label" | "-name" => label = Some(val),
+                _ => {}
+            }
+            i += 2;
+        }
+        (role, tier, label)
+    };
+
+    for cmd in tcl_commands(text) {
+        match cmd.first().map(String::as_str) {
+            Some("device") if cmd.len() >= 2 => {
+                let (role, tier, label) = read_opts(&cmd[2..]);
+                devices.push(DeviceSpec {
+                    matcher: cmd[1].clone(),
+                    role,
+                    tier,
+                    label,
+                });
+            }
+            Some("link") if cmd.len() >= 3 => {
+                let (_r, _t, label) = read_opts(&cmd[3..]);
+                links.push(LinkSpec {
+                    from: cmd[1].clone(),
+                    to: cmd[2].clone(),
+                    label,
+                });
+            }
+            _ => {}
+        }
+    }
+    Manifest { devices, links }
+}
+
 /// Parse the manifest JSON. Accepts a top-level object with `devices` and
 /// `links` arrays. Every field is optional and leniently typed; a malformed
 /// document yields `Err(message)` so the caller can surface it without failing
 /// the whole report.
-fn parse_manifest(text: &str) -> Result<Manifest, String> {
+fn parse_manifest_json(text: &str) -> Result<Manifest, String> {
     let root: J = serde_json::from_str(text).map_err(|e| format!("invalid manifest JSON: {e}"))?;
     let obj = root
         .as_object()

--- a/rust/tcl-bigip-report/src/architecture.rs
+++ b/rust/tcl-bigip-report/src/architecture.rs
@@ -11,10 +11,11 @@
 //!   address) is served by a virtual server (or listener) on the other device.
 //!   That IP overlap is the physical evidence of a tier hop, so it needs no
 //!   configuration to find.
-//! * **a manifest** — an optional user-supplied JSON document that names each
-//!   device's role and tier and can declare links explicitly. It overrides and
-//!   augments auto-detection (a manifest link auto-detection missed is still
-//!   added; a device's manifest tier/role wins over the inferred one).
+//! * **a manifest** — an optional user-supplied *Tcl script* (parsed with the
+//!   project's own Tcl tokeniser) that names each device's role and tier and can
+//!   declare links explicitly. It overrides and augments auto-detection (a
+//!   manifest link auto-detection missed is still added; a device's manifest
+//!   tier/role wins over the inferred one).
 //!
 //! The result is an `architecture` object embedded in the report model: the
 //! ordered devices with their resolved role/tier, the inter-device links with
@@ -239,10 +240,11 @@ fn resolve_device(matcher: &str, devices: &[J]) -> Option<usize> {
     })
 }
 
-/// Parse a manifest, auto-detecting the format. A document whose first
-/// non-space character is `{` or `[` is treated as JSON (kept for
-/// compatibility); anything else is the Tcl manifest DSL — the natural spelling
-/// in this project, parsed with the real Tcl tokeniser:
+/// Parse the architecture manifest — a small Tcl script — with the project's
+/// own Tcl tokeniser. Recognised commands are `device <match> [-role R] [-tier
+/// N] [-label L]` and `link <from> <to> [-label L]`; unknown commands and flags
+/// are skipped leniently. Unbalanced braces / quotes make the tokeniser fail,
+/// surfaced as `Err(message)` so the report can show it without aborting.
 ///
 /// ```tcl
 /// # one line per device; options are Tcl-style flags
@@ -255,23 +257,69 @@ fn resolve_device(matcher: &str, devices: &[J]) -> Option<usize> {
 /// link edge.ucs core.ucs -label internal
 /// ```
 fn parse_manifest(text: &str) -> Result<Manifest, String> {
-    if matches!(text.trim_start().chars().next(), Some('{' | '[')) {
-        parse_manifest_json(text)
-    } else {
-        Ok(parse_manifest_tcl(text))
+    let commands = tcl_commands(text)?;
+    let mut devices = Vec::new();
+    let mut links = Vec::new();
+
+    // Read `-flag value` pairs from a word slice into (role, tier, label).
+    let read_opts = |words: &[String]| -> (Option<String>, Option<i64>, Option<String>) {
+        let (mut role, mut tier, mut label) = (None, None, None);
+        let mut i = 0;
+        while i + 1 < words.len() {
+            let (flag, val) = (words[i].as_str(), words[i + 1].clone());
+            match flag {
+                "-role" => role = Some(val),
+                "-tier" => tier = val.parse::<i64>().ok(),
+                "-label" | "-name" => label = Some(val),
+                _ => {}
+            }
+            i += 2;
+        }
+        (role, tier, label)
+    };
+
+    for cmd in commands {
+        match cmd.first().map(String::as_str) {
+            Some("device") if cmd.len() >= 2 => {
+                let (role, tier, label) = read_opts(&cmd[2..]);
+                devices.push(DeviceSpec {
+                    matcher: cmd[1].clone(),
+                    role,
+                    tier,
+                    label,
+                });
+            }
+            Some("link") if cmd.len() >= 3 => {
+                let (_r, _t, label) = read_opts(&cmd[3..]);
+                links.push(LinkSpec {
+                    from: cmd[1].clone(),
+                    to: cmd[2].clone(),
+                    label,
+                });
+            }
+            _ => {}
+        }
     }
+    Ok(Manifest { devices, links })
 }
 
 /// Split a Tcl script into commands, each a list of literal words, using the
 /// real Tcl tokeniser (so braces, quotes, comments and `;` separators are
 /// handled exactly as Tcl would). Substitutions (`$var`, `[cmd]`) are taken
-/// literally — the manifest DSL never needs them.
-fn tcl_commands(src: &str) -> Vec<Vec<String>> {
-    use tcl_lexer::{Lexer, SourceMap, TokenType};
+/// literally — the manifest DSL never needs them. A tokeniser failure (an
+/// unbalanced brace / quote) is returned as `Err(message)`.
+fn tcl_commands(src: &str) -> Result<Vec<Vec<String>>, String> {
+    use tcl_lexer::{Lexer, LexerConfig, SourceMap, TokenType};
 
-    let Ok(tokens) = Lexer::new(src).tokenise_all() else {
-        return Vec::new();
+    // Strict quoting so an unbalanced brace / quote is a hard error we can
+    // report, rather than a silently truncated word.
+    let config = LexerConfig {
+        strict_quoting: true,
+        ..LexerConfig::default()
     };
+    let tokens = Lexer::with_source_map(SourceMap::new(src), config)
+        .tokenise_all()
+        .map_err(|e| format!("invalid Tcl manifest: {e}"))?;
     let sm = SourceMap::new(src);
     let mut commands: Vec<Vec<String>> = Vec::new();
     let mut cmd: Vec<String> = Vec::new();
@@ -308,109 +356,7 @@ fn tcl_commands(src: &str) -> Vec<Vec<String>> {
     if !cmd.is_empty() {
         commands.push(cmd);
     }
-    commands
-}
-
-/// Interpret the Tcl manifest DSL. Recognised commands are `device <match>
-/// [-role R] [-tier N] [-label L]` and `link <from> <to> [-label L]`; unknown
-/// commands and unknown flags are skipped leniently.
-fn parse_manifest_tcl(text: &str) -> Manifest {
-    let mut devices = Vec::new();
-    let mut links = Vec::new();
-
-    // Read `-flag value` pairs from a word slice into (role, tier, label).
-    let read_opts = |words: &[String]| -> (Option<String>, Option<i64>, Option<String>) {
-        let (mut role, mut tier, mut label) = (None, None, None);
-        let mut i = 0;
-        while i + 1 < words.len() {
-            let (flag, val) = (words[i].as_str(), words[i + 1].clone());
-            match flag {
-                "-role" => role = Some(val),
-                "-tier" => tier = val.parse::<i64>().ok(),
-                "-label" | "-name" => label = Some(val),
-                _ => {}
-            }
-            i += 2;
-        }
-        (role, tier, label)
-    };
-
-    for cmd in tcl_commands(text) {
-        match cmd.first().map(String::as_str) {
-            Some("device") if cmd.len() >= 2 => {
-                let (role, tier, label) = read_opts(&cmd[2..]);
-                devices.push(DeviceSpec {
-                    matcher: cmd[1].clone(),
-                    role,
-                    tier,
-                    label,
-                });
-            }
-            Some("link") if cmd.len() >= 3 => {
-                let (_r, _t, label) = read_opts(&cmd[3..]);
-                links.push(LinkSpec {
-                    from: cmd[1].clone(),
-                    to: cmd[2].clone(),
-                    label,
-                });
-            }
-            _ => {}
-        }
-    }
-    Manifest { devices, links }
-}
-
-/// Parse the manifest JSON. Accepts a top-level object with `devices` and
-/// `links` arrays. Every field is optional and leniently typed; a malformed
-/// document yields `Err(message)` so the caller can surface it without failing
-/// the whole report.
-fn parse_manifest_json(text: &str) -> Result<Manifest, String> {
-    let root: J = serde_json::from_str(text).map_err(|e| format!("invalid manifest JSON: {e}"))?;
-    let obj = root
-        .as_object()
-        .ok_or_else(|| "manifest must be a JSON object".to_string())?;
-
-    let sstr = |m: &Map<String, J>, k: &str| m.get(k).and_then(J::as_str).map(str::to_string);
-
-    let mut devices = Vec::new();
-    if let Some(arr) = obj.get("devices").and_then(J::as_array) {
-        for d in arr {
-            let Some(dm) = d.as_object() else { continue };
-            // Accept `match`, `uri`, or `name` as the matcher key.
-            let matcher = sstr(dm, "match")
-                .or_else(|| sstr(dm, "uri"))
-                .or_else(|| sstr(dm, "name"))
-                .unwrap_or_default();
-            if matcher.is_empty() {
-                continue;
-            }
-            devices.push(DeviceSpec {
-                matcher,
-                role: sstr(dm, "role"),
-                tier: dm.get("tier").and_then(J::as_i64),
-                label: sstr(dm, "label"),
-            });
-        }
-    }
-
-    let mut links = Vec::new();
-    if let Some(arr) = obj.get("links").and_then(J::as_array) {
-        for l in arr {
-            let Some(lm) = l.as_object() else { continue };
-            let from = sstr(lm, "from").unwrap_or_default();
-            let to = sstr(lm, "to").unwrap_or_default();
-            if from.is_empty() || to.is_empty() {
-                continue;
-            }
-            links.push(LinkSpec {
-                from,
-                to,
-                label: sstr(lm, "label"),
-            });
-        }
-    }
-
-    Ok(Manifest { devices, links })
+    Ok(commands)
 }
 
 /// Auto-detect links by IP overlap: an upstream device targets an address that a

--- a/rust/tcl-bigip-report/src/architecture.rs
+++ b/rust/tcl-bigip-report/src/architecture.rs
@@ -103,6 +103,17 @@ fn bare_ip(addr: &str) -> Option<String> {
             return Some(ip.to_string());
         }
     }
+    // BIG-IP spells an IPv6 destination's port with a `.` (the `:` is taken by
+    // the address), e.g. `2001:db8::10.443`. Strip a trailing `.<digits>` from a
+    // colon-bearing address and re-parse the host.
+    if addr.contains(':')
+        && let Some((host, port)) = addr.rsplit_once('.')
+        && !port.is_empty()
+        && port.bytes().all(|b| b.is_ascii_digit())
+        && let Ok(ip) = IpAddr::from_str(host)
+    {
+        return Some(ip.to_string());
+    }
     None
 }
 
@@ -154,7 +165,14 @@ fn outbound_targets(device: &Map<String, J>) -> Vec<Target> {
         let pool_fp = bstr(pm, "fullPath").to_string();
         for m in barr(pm, "members") {
             let Some(mm) = m.as_object() else { continue };
-            if let Some(ip) = bare_ip(bstr(mm, "address")) {
+            // Prefer the explicit `address`; fall back to the member name, which
+            // carries the IP for members declared only by keyed name
+            // (`/Common/10.2.0.20:443 { ... }` with no `address` property).
+            let ip = bare_ip(bstr(mm, "address")).or_else(|| {
+                let name = bstr(mm, "name");
+                bare_ip(name.rsplit('/').next().unwrap_or(name))
+            });
+            if let Some(ip) = ip {
                 out.push(Target {
                     address: ip,
                     from_obj: pool_fp.clone(),
@@ -666,6 +684,9 @@ mod tests {
         assert_eq!(bare_ip("10.0.0.5").as_deref(), Some("10.0.0.5"));
         assert_eq!(bare_ip("[::1]:443").as_deref(), Some("::1"));
         assert_eq!(bare_ip("2001:db8::1%3").as_deref(), Some("2001:db8::1"));
+        // BIG-IP's unbracketed IPv6 destination-port form (`.port`).
+        assert_eq!(bare_ip("2001:db8::10.443").as_deref(), Some("2001:db8::10"));
+        assert_eq!(bare_ip("2001:db8::1").as_deref(), Some("2001:db8::1"));
         assert_eq!(bare_ip("api.example.com"), None);
         assert_eq!(bare_ip("any"), None);
         assert_eq!(bare_ip(""), None);

--- a/rust/tcl-bigip-report/src/architecture.rs
+++ b/rust/tcl-bigip-report/src/architecture.rs
@@ -1,0 +1,580 @@
+//! Multi-device *architecture*: how the loaded configs relate as tiers.
+//!
+//! A report can be built from several configs at once — a GTM in front of a
+//! tier-1 LTM in front of a tier-2 LTM, for example. Individually each config
+//! is just a flat estate; the value of loading them together is knowing **what
+//! points to what**. This module derives that relationship two ways, and merges
+//! them:
+//!
+//! * **auto-detection** — the default. A device *fronts* another when one of its
+//!   outbound targets (an LTM pool member address, or a GTM pool member / server
+//!   address) is served by a virtual server (or listener) on the other device.
+//!   That IP overlap is the physical evidence of a tier hop, so it needs no
+//!   configuration to find.
+//! * **a manifest** — an optional user-supplied JSON document that names each
+//!   device's role and tier and can declare links explicitly. It overrides and
+//!   augments auto-detection (a manifest link auto-detection missed is still
+//!   added; a device's manifest tier/role wins over the inferred one).
+//!
+//! The result is an `architecture` object embedded in the report model: the
+//! ordered devices with their resolved role/tier, the inter-device links with
+//! the object pairs that evidence them, and a ready-to-render Mermaid diagram.
+
+use std::collections::BTreeMap;
+use std::net::IpAddr;
+use std::str::FromStr;
+
+use serde_json::{Map, Value as J};
+
+use crate::jutil::{barr, bstr};
+
+/// One device's declared role/tier/label from a manifest entry.
+struct DeviceSpec {
+    matcher: String,
+    role: Option<String>,
+    tier: Option<i64>,
+    label: Option<String>,
+}
+
+/// An explicit `from -> to` link declared in a manifest.
+struct LinkSpec {
+    from: String,
+    to: String,
+    label: Option<String>,
+}
+
+/// A parsed manifest (roles/tiers + explicit links).
+struct Manifest {
+    devices: Vec<DeviceSpec>,
+    links: Vec<LinkSpec>,
+}
+
+/// An auto-detected or declared link between two device indices.
+struct Link {
+    from: usize,
+    to: usize,
+    /// `"auto"`, `"manifest"`, or `"manifest+auto"` when both agree.
+    source: String,
+    label: Option<String>,
+    /// Object pairs that evidence the hop (empty for a manifest-only link).
+    vias: Vec<Via>,
+}
+
+/// One piece of evidence for a link: an outbound target on the upstream device
+/// that resolves to a served address on the downstream device.
+struct Via {
+    address: String,
+    from_obj: String,
+    to_obj: String,
+    port: String,
+}
+
+/// Normalise an address to a canonical IP string, or `None` when it is not a
+/// concrete IP (a hostname, `any`, a route-domain-only token, empty).
+///
+/// Strips a `%route-domain` suffix and a `/prefix` (or `:port` on IPv4) so a
+/// pool member `10.0.0.5%2:443` and a virtual-address `10.0.0.5` compare equal.
+fn bare_ip(addr: &str) -> Option<String> {
+    let addr = addr.trim();
+    if addr.is_empty() {
+        return None;
+    }
+    // Drop a route-domain qualifier first (`10.0.0.5%2` -> `10.0.0.5`).
+    let addr = addr.split('%').next().unwrap_or(addr);
+    // Drop a CIDR prefix (`10.0.0.0/24` -> `10.0.0.0`).
+    let addr = addr.split('/').next().unwrap_or(addr);
+    // A direct parse handles bare IPv4 and full IPv6.
+    if let Ok(ip) = IpAddr::from_str(addr) {
+        return Some(ip.to_string());
+    }
+    // IPv4 with a trailing `:port` (`10.0.0.5:443`). IPv6 with a port is
+    // bracketed (`[::1]:443`) and is handled below.
+    if let Some((host, _port)) = addr.rsplit_once(':')
+        && !host.contains(':')
+        && let Ok(ip) = IpAddr::from_str(host)
+    {
+        return Some(ip.to_string());
+    }
+    // Bracketed IPv6 literal, optionally with a port.
+    if let Some(rest) = addr.strip_prefix('[') {
+        let host = rest.split(']').next().unwrap_or(rest);
+        if let Ok(ip) = IpAddr::from_str(host) {
+            return Some(ip.to_string());
+        }
+    }
+    None
+}
+
+/// The set of IP addresses a device *serves* — the concrete listener addresses
+/// its virtual servers (and, when present, GTM listeners) answer on. A device
+/// serving one of another device's outbound targets is the downstream tier.
+fn served_addresses(device: &Map<String, J>) -> BTreeMap<String, String> {
+    // address -> the serving object's full path (first wins, for a stable label)
+    let mut out: BTreeMap<String, String> = BTreeMap::new();
+    for v in barr(device, "virtuals") {
+        let Some(vm) = v.as_object() else { continue };
+        if let Some(ip) = bare_ip(bstr(vm, "destAddr")) {
+            out.entry(ip).or_insert_with(|| bstr(vm, "fullPath").to_string());
+        }
+    }
+    // Virtual-address objects carry the raw served IP as their leaf name.
+    for va in barr(device, "virtualAddresses") {
+        let Some(am) = va.as_object() else { continue };
+        let fp = bstr(am, "fullPath");
+        if let Some(ip) = bare_ip(bstr(am, "name")).or_else(|| bare_ip(fp)) {
+            out.entry(ip).or_insert_with(|| fp.to_string());
+        }
+    }
+    // GTM listeners answer DNS on their own address; a GTM fronts by resolving a
+    // name to a downstream address, but its listener address is itself a served
+    // address (an upstream resolver could point at it).
+    for l in barr(device, "gtmListeners") {
+        let Some(lm) = l.as_object() else { continue };
+        if let Some(ip) = bare_ip(bstr(lm, "address")) {
+            out.entry(ip).or_insert_with(|| bstr(lm, "fullPath").to_string());
+        }
+    }
+    out
+}
+
+/// One outbound target a device points at: `(address, from_obj, port)`.
+struct Target {
+    address: String,
+    from_obj: String,
+    port: String,
+}
+
+/// The IP addresses a device *reaches out to* — LTM pool member addresses and
+/// GTM pool member / server addresses. Each downstream match evidences a link.
+fn outbound_targets(device: &Map<String, J>) -> Vec<Target> {
+    let mut out: Vec<Target> = Vec::new();
+    for p in barr(device, "pools") {
+        let Some(pm) = p.as_object() else { continue };
+        let pool_fp = bstr(pm, "fullPath").to_string();
+        for m in barr(pm, "members") {
+            let Some(mm) = m.as_object() else { continue };
+            if let Some(ip) = bare_ip(bstr(mm, "address")) {
+                out.push(Target {
+                    address: ip,
+                    from_obj: pool_fp.clone(),
+                    port: bstr(mm, "port").to_string(),
+                });
+            }
+        }
+    }
+    // GTM pool members reference GTM servers; the shaped GTM pool carries the
+    // resolved member address so a GTM->LTM hop is detected the same way.
+    for p in barr(device, "gtmPools") {
+        let Some(pm) = p.as_object() else { continue };
+        let pool_fp = bstr(pm, "fullPath").to_string();
+        for m in barr(pm, "members") {
+            let Some(mm) = m.as_object() else { continue };
+            if let Some(ip) = bare_ip(bstr(mm, "address")) {
+                out.push(Target {
+                    address: ip,
+                    from_obj: pool_fp.clone(),
+                    port: bstr(mm, "port").to_string(),
+                });
+            }
+        }
+    }
+    // GTM servers list their virtual-server addresses directly.
+    for s in barr(device, "gtmServers") {
+        let Some(sm) = s.as_object() else { continue };
+        let server_fp = bstr(sm, "fullPath").to_string();
+        for a in barr(sm, "addresses") {
+            if let Some(ip) = a.as_str().and_then(bare_ip) {
+                out.push(Target {
+                    address: ip,
+                    from_obj: server_fp.clone(),
+                    port: String::new(),
+                });
+            }
+        }
+    }
+    out
+}
+
+/// Whether a device looks like a GTM/DNS node (has any GTM objects).
+fn looks_like_gtm(device: &Map<String, J>) -> bool {
+    ["gtmWideips", "gtmPools", "gtmServers", "gtmListeners"]
+        .iter()
+        .any(|k| !barr(device, k).is_empty())
+}
+
+/// Resolve a manifest matcher string to a device index.
+///
+/// Tries, in order: exact URI, exact name, URI substring, name substring, and
+/// finally the URI's file-name stem. Returns `None` when nothing matches.
+fn resolve_device(matcher: &str, devices: &[J]) -> Option<usize> {
+    let m = matcher.trim();
+    if m.is_empty() {
+        return None;
+    }
+    let field = |d: &J, k: &str| d.get(k).and_then(J::as_str).unwrap_or("").to_string();
+    // exact uri / name
+    if let Some(i) = devices
+        .iter()
+        .position(|d| field(d, "uri") == m || field(d, "name") == m)
+    {
+        return Some(i);
+    }
+    // substring on uri / name
+    if let Some(i) = devices
+        .iter()
+        .position(|d| field(d, "uri").contains(m) || field(d, "name").contains(m))
+    {
+        return Some(i);
+    }
+    // file-name stem of the uri (`/path/lab-device-01.ucs` -> `lab-device-01`)
+    devices.iter().position(|d| {
+        let uri = field(d, "uri");
+        let stem = uri
+            .rsplit('/')
+            .next()
+            .and_then(|f| f.rsplit_once('.').map_or(Some(f), |(s, _)| Some(s)))
+            .unwrap_or("");
+        !stem.is_empty() && stem == m
+    })
+}
+
+/// Parse the manifest JSON. Accepts a top-level object with `devices` and
+/// `links` arrays. Every field is optional and leniently typed; a malformed
+/// document yields `Err(message)` so the caller can surface it without failing
+/// the whole report.
+fn parse_manifest(text: &str) -> Result<Manifest, String> {
+    let root: J = serde_json::from_str(text).map_err(|e| format!("invalid manifest JSON: {e}"))?;
+    let obj = root
+        .as_object()
+        .ok_or_else(|| "manifest must be a JSON object".to_string())?;
+
+    let sstr = |m: &Map<String, J>, k: &str| m.get(k).and_then(J::as_str).map(str::to_string);
+
+    let mut devices = Vec::new();
+    if let Some(arr) = obj.get("devices").and_then(J::as_array) {
+        for d in arr {
+            let Some(dm) = d.as_object() else { continue };
+            // Accept `match`, `uri`, or `name` as the matcher key.
+            let matcher = sstr(dm, "match")
+                .or_else(|| sstr(dm, "uri"))
+                .or_else(|| sstr(dm, "name"))
+                .unwrap_or_default();
+            if matcher.is_empty() {
+                continue;
+            }
+            devices.push(DeviceSpec {
+                matcher,
+                role: sstr(dm, "role"),
+                tier: dm.get("tier").and_then(J::as_i64),
+                label: sstr(dm, "label"),
+            });
+        }
+    }
+
+    let mut links = Vec::new();
+    if let Some(arr) = obj.get("links").and_then(J::as_array) {
+        for l in arr {
+            let Some(lm) = l.as_object() else { continue };
+            let from = sstr(lm, "from").unwrap_or_default();
+            let to = sstr(lm, "to").unwrap_or_default();
+            if from.is_empty() || to.is_empty() {
+                continue;
+            }
+            links.push(LinkSpec {
+                from,
+                to,
+                label: sstr(lm, "label"),
+            });
+        }
+    }
+
+    Ok(Manifest { devices, links })
+}
+
+/// Auto-detect links by IP overlap: an upstream device targets an address that a
+/// downstream device serves.
+fn detect_links(devices: &[J]) -> Vec<Link> {
+    // Pre-compute each device's served-address index.
+    let served: Vec<BTreeMap<String, String>> = devices
+        .iter()
+        .map(|d| d.as_object().map(served_addresses).unwrap_or_default())
+        .collect();
+
+    let mut links: Vec<Link> = Vec::new();
+    for (i, dev) in devices.iter().enumerate() {
+        let Some(dm) = dev.as_object() else { continue };
+        // Accumulate vias per downstream device before emitting one link each.
+        let mut per_target: BTreeMap<usize, Vec<Via>> = BTreeMap::new();
+        for t in outbound_targets(dm) {
+            for (j, srv) in served.iter().enumerate() {
+                if i == j {
+                    continue; // a device serving its own member is not a tier hop
+                }
+                if let Some(to_obj) = srv.get(&t.address) {
+                    per_target.entry(j).or_default().push(Via {
+                        address: t.address.clone(),
+                        from_obj: t.from_obj.clone(),
+                        to_obj: to_obj.clone(),
+                        port: t.port.clone(),
+                    });
+                }
+            }
+        }
+        for (j, vias) in per_target {
+            links.push(Link {
+                from: i,
+                to: j,
+                source: "auto".to_string(),
+                label: None,
+                vias,
+            });
+        }
+    }
+    links
+}
+
+/// Merge manifest-declared links into the auto-detected set, resolving matchers
+/// to indices. A manifest link that coincides with an auto link promotes its
+/// source to `manifest+auto`; a new one is appended as `manifest`.
+fn merge_manifest_links(auto: &mut Vec<Link>, manifest: &Manifest, devices: &[J]) {
+    for spec in &manifest.links {
+        let (Some(from), Some(to)) = (
+            resolve_device(&spec.from, devices),
+            resolve_device(&spec.to, devices),
+        ) else {
+            continue;
+        };
+        if from == to {
+            continue;
+        }
+        if let Some(existing) = auto.iter_mut().find(|l| l.from == from && l.to == to) {
+            existing.source = "manifest+auto".to_string();
+            if existing.label.is_none() {
+                existing.label.clone_from(&spec.label);
+            }
+        } else {
+            auto.push(Link {
+                from,
+                to,
+                source: "manifest".to_string(),
+                label: spec.label.clone(),
+                vias: Vec::new(),
+            });
+        }
+    }
+}
+
+/// Longest-path tier assignment over the link DAG: a root (no inbound link) is
+/// tier 0, and every node sits one tier below its deepest predecessor. Cycles
+/// are broken by a fixed iteration cap so the pass always terminates.
+fn assign_tiers(n: usize, links: &[Link], overrides: &BTreeMap<usize, i64>) -> Vec<i64> {
+    let mut tier = vec![0i64; n];
+    // Relax edges up to `n` times (Bellman-Ford-style longest path on a DAG;
+    // the cap bounds work even if the manifest introduced a cycle).
+    for _ in 0..n.max(1) {
+        let mut changed = false;
+        for l in links {
+            let cand = tier[l.from] + 1;
+            if cand > tier[l.to] {
+                tier[l.to] = cand;
+                changed = true;
+            }
+        }
+        if !changed {
+            break;
+        }
+    }
+    // Manifest overrides win outright.
+    for (i, t) in overrides {
+        if *i < n {
+            tier[*i] = *t;
+        }
+    }
+    tier
+}
+
+/// Build the `architecture` model object from the shaped device list and an
+/// optional manifest. Auto-detection always runs; the manifest (when present and
+/// well-formed) overrides roles/tiers and augments links.
+pub(crate) fn build_architecture(devices: &[J], manifest_text: Option<&str>) -> J {
+    let n = devices.len();
+
+    // Parse the manifest up front; a parse error is reported but non-fatal.
+    let (manifest, manifest_error) = match manifest_text {
+        Some(t) if !t.trim().is_empty() => match parse_manifest(t) {
+            Ok(m) => (Some(m), None),
+            Err(e) => (None, Some(e)),
+        },
+        _ => (None, None),
+    };
+
+    // Resolve manifest device specs to per-index role/tier/label overrides.
+    let mut role_over: BTreeMap<usize, String> = BTreeMap::new();
+    let mut tier_over: BTreeMap<usize, i64> = BTreeMap::new();
+    let mut label_over: BTreeMap<usize, String> = BTreeMap::new();
+    if let Some(m) = &manifest {
+        for spec in &m.devices {
+            let Some(i) = resolve_device(&spec.matcher, devices) else {
+                continue;
+            };
+            if let Some(r) = &spec.role {
+                role_over.insert(i, r.clone());
+            }
+            if let Some(t) = spec.tier {
+                tier_over.insert(i, t);
+            }
+            if let Some(l) = &spec.label {
+                label_over.insert(i, l.clone());
+            }
+        }
+    }
+
+    // Links: auto-detect, then merge the manifest's declarations.
+    let mut links = detect_links(devices);
+    if let Some(m) = &manifest {
+        merge_manifest_links(&mut links, m, devices);
+    }
+
+    let tiers = assign_tiers(n, &links, &tier_over);
+
+    // Shape the device entries with their resolved role/tier/label.
+    let mut dev_json: Vec<J> = Vec::with_capacity(n);
+    for (i, d) in devices.iter().enumerate() {
+        let dm = d.as_object();
+        let uri = dm.map_or("", |m| bstr(m, "uri")).to_string();
+        let name = dm.map_or("", |m| bstr(m, "name")).to_string();
+        let role = role_over.get(&i).cloned().unwrap_or_else(|| {
+            if dm.is_some_and(looks_like_gtm) {
+                "gtm".to_string()
+            } else {
+                "ltm".to_string()
+            }
+        });
+        let label = label_over.get(&i).cloned().unwrap_or_else(|| name.clone());
+        let mut o = Map::new();
+        o.insert("index".into(), J::from(i));
+        o.insert("uri".into(), J::String(uri));
+        o.insert("name".into(), J::String(name));
+        o.insert("label".into(), J::String(label));
+        o.insert("role".into(), J::String(role));
+        o.insert("tier".into(), J::from(tiers[i]));
+        dev_json.push(J::Object(o));
+    }
+
+    // Shape the links, sorted for a stable, tier-ascending render.
+    links.sort_by(|a, b| {
+        (tiers[a.from], a.from, a.to).cmp(&(tiers[b.from], b.from, b.to))
+    });
+    let link_json: Vec<J> = links
+        .iter()
+        .map(|l| {
+            let vias: Vec<J> = l
+                .vias
+                .iter()
+                .map(|v| {
+                    let mut vo = Map::new();
+                    vo.insert("address".into(), J::String(v.address.clone()));
+                    vo.insert("fromObj".into(), J::String(v.from_obj.clone()));
+                    vo.insert("toObj".into(), J::String(v.to_obj.clone()));
+                    vo.insert("port".into(), J::String(v.port.clone()));
+                    J::Object(vo)
+                })
+                .collect();
+            let mut o = Map::new();
+            o.insert("from".into(), J::from(l.from));
+            o.insert("to".into(), J::from(l.to));
+            o.insert("source".into(), J::String(l.source.clone()));
+            if let Some(lbl) = &l.label {
+                o.insert("label".into(), J::String(lbl.clone()));
+            }
+            o.insert("viaCount".into(), J::from(l.vias.len()));
+            o.insert("vias".into(), J::Array(vias));
+            J::Object(o)
+        })
+        .collect();
+
+    let mermaid = build_mermaid(&dev_json, &links, &tiers);
+
+    let mut arch = Map::new();
+    arch.insert("defined".into(), J::Bool(manifest.is_some()));
+    arch.insert("deviceCount".into(), J::from(n));
+    arch.insert("devices".into(), J::Array(dev_json));
+    arch.insert("links".into(), J::Array(link_json));
+    arch.insert("mermaid".into(), J::String(mermaid));
+    if let Some(e) = manifest_error {
+        arch.insert("manifestError".into(), J::String(e));
+    }
+    J::Object(arch)
+}
+
+/// Render the architecture as a left-to-right Mermaid flowchart, one subgraph
+/// per tier, edges labelled with the number of evidencing flows.
+fn build_mermaid(dev_json: &[J], links: &[Link], tiers: &[i64]) -> String {
+    use std::fmt::Write;
+
+    if dev_json.is_empty() {
+        return String::new();
+    }
+    let mut out = String::from("flowchart LR\n");
+
+    // Group device indices by tier for the subgraphs.
+    let mut by_tier: BTreeMap<i64, Vec<usize>> = BTreeMap::new();
+    for (i, t) in tiers.iter().enumerate() {
+        by_tier.entry(*t).or_default().push(i);
+    }
+    let node_label = |i: usize| -> String {
+        let d = dev_json[i].as_object();
+        let label = d.map_or("", |m| bstr(m, "label"));
+        let role = d.map_or("", |m| bstr(m, "role"));
+        let text = if label.is_empty() {
+            format!("device {i}")
+        } else {
+            label.to_string()
+        };
+        // Mermaid label text: escape quotes, tag the role.
+        let safe = text.replace('"', "'");
+        format!("\"{safe}<br/><small>{role}</small>\"")
+    };
+
+    for (t, members) in &by_tier {
+        let _ = writeln!(out, "  subgraph tier{t}[\"Tier {t}\"]");
+        for i in members {
+            let _ = writeln!(out, "    d{i}[{}]", node_label(*i));
+        }
+        out.push_str("  end\n");
+    }
+
+    for l in links {
+        let lbl = l.label.clone().unwrap_or_else(|| {
+            if l.vias.is_empty() {
+                String::new()
+            } else {
+                format!("{} flow(s)", l.vias.len())
+            }
+        });
+        if lbl.is_empty() {
+            let _ = writeln!(out, "  d{} --> d{}", l.from, l.to);
+        } else {
+            let safe = lbl.replace('"', "'");
+            let _ = writeln!(out, "  d{} -->|\"{safe}\"| d{}", l.from, l.to);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn bare_ip_normalises() {
+        assert_eq!(bare_ip("10.0.0.5%2:443").as_deref(), Some("10.0.0.5"));
+        assert_eq!(bare_ip("10.0.0.0/24").as_deref(), Some("10.0.0.0"));
+        assert_eq!(bare_ip("10.0.0.5").as_deref(), Some("10.0.0.5"));
+        assert_eq!(bare_ip("[::1]:443").as_deref(), Some("::1"));
+        assert_eq!(bare_ip("2001:db8::1%3").as_deref(), Some("2001:db8::1"));
+        assert_eq!(bare_ip("api.example.com"), None);
+        assert_eq!(bare_ip("any"), None);
+        assert_eq!(bare_ip(""), None);
+    }
+}

--- a/rust/tcl-bigip-report/src/architecture.rs
+++ b/rust/tcl-bigip-report/src/architecture.rs
@@ -162,32 +162,33 @@ fn outbound_targets(device: &Map<String, J>) -> Vec<Target> {
             }
         }
     }
-    // GTM pool members reference GTM servers; the shaped GTM pool carries the
-    // resolved member address so a GTM->LTM hop is detected the same way.
-    for p in barr(device, "gtmPools") {
-        let Some(pm) = p.as_object() else { continue };
-        let pool_fp = bstr(pm, "fullPath").to_string();
-        for m in barr(pm, "members") {
-            let Some(mm) = m.as_object() else { continue };
-            if let Some(ip) = bare_ip(bstr(mm, "address")) {
-                out.push(Target {
-                    address: ip,
-                    from_obj: pool_fp.clone(),
-                    port: bstr(mm, "port").to_string(),
-                });
-            }
-        }
-    }
-    // GTM servers list their virtual-server addresses directly.
+    // GTM servers list their virtual-server destinations (e.g. `10.2.0.20:443`)
+    // — the downstream LTM virtual addresses this GTM balances across. That
+    // overlap is the GTM -> LTM tier hop.
     for s in barr(device, "gtmServers") {
         let Some(sm) = s.as_object() else { continue };
         let server_fp = bstr(sm, "fullPath").to_string();
-        for a in barr(sm, "addresses") {
+        for a in barr(sm, "virtualServers") {
             if let Some(ip) = a.as_str().and_then(bare_ip) {
                 out.push(Target {
                     address: ip,
                     from_obj: server_fp.clone(),
                     port: String::new(),
+                });
+            }
+        }
+    }
+    // Static GTM pool members carry an explicit target IP (`static-target`).
+    for p in barr(device, "gtmPools") {
+        let Some(pm) = p.as_object() else { continue };
+        let pool_fp = bstr(pm, "fullPath").to_string();
+        for m in barr(pm, "members") {
+            let Some(mm) = m.as_object() else { continue };
+            if let Some(ip) = bare_ip(bstr(mm, "staticTarget")) {
+                out.push(Target {
+                    address: ip,
+                    from_obj: pool_fp.clone(),
+                    port: bstr(mm, "servicePort").to_string(),
                 });
             }
         }

--- a/rust/tcl-bigip-report/src/lib.rs
+++ b/rust/tcl-bigip-report/src/lib.rs
@@ -22,6 +22,7 @@
     clippy::manual_let_else
 )]
 
+mod architecture;
 mod certs;
 mod graph;
 mod jutil;
@@ -33,7 +34,9 @@ mod services;
 
 pub use tcl_lexer::highlight_tcl;
 
-pub use model::{ENGINE_VERSION, collect_model, collect_model_with_certs};
+pub use model::{
+    ENGINE_VERSION, collect_model, collect_model_with_architecture, collect_model_with_certs,
+};
 pub use query::{ReportError, Source};
 pub use render::{RenderOptions, build_report};
 pub use secrets::{collect_secrets, count_encrypted_secrets, decrypt_secrets};

--- a/rust/tcl-bigip-report/src/model.rs
+++ b/rust/tcl-bigip-report/src/model.rs
@@ -45,6 +45,17 @@ const CONTAINERS: &[(&str, &str)] = &[
     ("virtualAddresses", ".ltm.\"virtual-address\""),
 ];
 
+// GTM object containers the report walks, in display order. A GTM (DNS) tier
+// fronts the LTM tiers; surfacing these lets the report show the wide-IP ->
+// pool -> server chain and link the GTM to the downstream LTM virtuals.
+const GTM_CONTAINERS: &[(&str, &str)] = &[
+    ("gtmWideips", ".gtm.wideip"),
+    ("gtmPools", ".gtm.pool"),
+    ("gtmServers", ".gtm.server"),
+    ("gtmDatacenters", ".gtm.datacenter"),
+    ("gtmListeners", ".gtm.listener"),
+];
+
 // Leaf object types that are *referenced* by something else; an empty referrer
 // set means the object is orphaned. Virtuals / virtual-addresses are entry
 // points, so they are never treated as orphans.
@@ -411,6 +422,107 @@ fn shape_data_group(f: &Map<String, J>, used: &HashMap<String, Vec<J>>) -> J {
     o.insert("recordCount".into(), J::from(record_count));
     o.insert("records".into(), J::Array(shown));
     o.insert("usedBy".into(), J::Array(used_by(used, fp)));
+    J::Object(o)
+}
+
+// --- GTM shaping -------------------------------------------------------------
+
+/// `map[key]` as an array of plain strings (skips non-strings).
+fn str_array(m: &Map<String, J>, key: &str) -> Vec<J> {
+    sarr(m, key).iter().map(|s| J::String((*s).into())).collect()
+}
+
+fn shape_gtm_wideip(f: &Map<String, J>, used: &HashMap<String, Vec<J>>) -> J {
+    let fp = bstr(f, "full-path");
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(fp.into()));
+    o.insert("recordType".into(), J::String(bstr(f, "record-type").into()));
+    o.insert("pools".into(), J::Array(clean_arr(f, "pools")));
+    o.insert("aliases".into(), J::Array(str_array(f, "aliases")));
+    o.insert("poolLbMode".into(), J::String(bstr(f, "pool-lb-mode").into()));
+    o.insert("state".into(), J::String(bstr(f, "state").into()));
+    o.insert(
+        "description".into(),
+        J::String(bstr(f, "description").into()),
+    );
+    o.insert("usedBy".into(), J::Array(used_by(used, fp)));
+    J::Object(o)
+}
+
+fn shape_gtm_pool(f: &Map<String, J>, used: &HashMap<String, Vec<J>>) -> J {
+    let members: Vec<J> = barr(f, "members")
+        .iter()
+        .filter_map(J::as_object)
+        .map(|mm| {
+            let mut mo = Map::new();
+            mo.insert("name".into(), J::String(bstr(mm, "name").into()));
+            mo.insert("servicePort".into(), J::String(bstr(mm, "service-port").into()));
+            mo.insert("ratio".into(), J::String(bstr(mm, "ratio").into()));
+            mo.insert(
+                "staticTarget".into(),
+                J::String(bstr(mm, "static-target").into()),
+            );
+            mo.insert("state".into(), J::String(bstr(mm, "state").into()));
+            J::Object(mo)
+        })
+        .collect();
+    let fp = bstr(f, "full-path");
+    let member_count = members.len();
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(fp.into()));
+    o.insert("recordType".into(), J::String(bstr(f, "record-type").into()));
+    o.insert("lbMode".into(), J::String(bstr(f, "load-balancing-mode").into()));
+    o.insert("monitor".into(), J::String(clean_field(f, "monitor")));
+    o.insert("members".into(), J::Array(members));
+    o.insert("memberCount".into(), J::from(member_count));
+    o.insert("state".into(), J::String(bstr(f, "state").into()));
+    o.insert("usedBy".into(), J::Array(used_by(used, fp)));
+    J::Object(o)
+}
+
+fn shape_gtm_server(f: &Map<String, J>, used: &HashMap<String, Vec<J>>) -> J {
+    let fp = bstr(f, "full-path");
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(fp.into()));
+    o.insert("datacenter".into(), J::String(clean_field(f, "datacenter")));
+    o.insert("product".into(), J::String(bstr(f, "product").into()));
+    o.insert("monitor".into(), J::String(clean_field(f, "monitor")));
+    o.insert("addresses".into(), J::Array(str_array(f, "addresses")));
+    // The raw virtual-server destinations (e.g. `10.2.0.20:443`) — the report's
+    // architecture layer resolves these against downstream devices' served
+    // virtual addresses to link this GTM to the LTM tiers it balances.
+    o.insert(
+        "virtualServers".into(),
+        J::Array(str_array(f, "virtual-servers")),
+    );
+    o.insert("state".into(), J::String(bstr(f, "state").into()));
+    o.insert("usedBy".into(), J::Array(used_by(used, fp)));
+    J::Object(o)
+}
+
+fn shape_gtm_datacenter(f: &Map<String, J>) -> J {
+    let fp = bstr(f, "full-path");
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(fp.into()));
+    o.insert("location".into(), J::String(bstr(f, "location").into()));
+    o.insert("contact".into(), J::String(bstr(f, "contact").into()));
+    o.insert("state".into(), J::String(bstr(f, "state").into()));
+    J::Object(o)
+}
+
+fn shape_gtm_listener(f: &Map<String, J>) -> J {
+    let fp = bstr(f, "full-path");
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(fp.into()));
+    o.insert("address".into(), J::String(bstr(f, "address").into()));
+    o.insert("port".into(), J::String(bstr(f, "port").into()));
+    o.insert("pool".into(), J::String(clean_field(f, "pool")));
+    o.insert("state".into(), J::String(bstr(f, "state").into()));
     J::Object(o)
 }
 
@@ -1036,6 +1148,23 @@ fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>) 
                     J::Object(o)
                 })
                 .collect(),
+        };
+        device.insert((*key).into(), J::Array(shaped));
+    }
+
+    // GTM object inventory (the DNS tier). Shaped separately from the LTM
+    // containers — these feed the GTM section and the cross-device architecture
+    // linker (a GTM server's virtual-server destinations point at LTM virtuals).
+    let gtm_used: HashMap<String, Vec<J>> = HashMap::new();
+    for (key, container) in GTM_CONTAINERS {
+        let rows = fields_of(query(&format!("{container}[]"), &sources).unwrap_or_default());
+        let shaped: Vec<J> = match *key {
+            "gtmWideips" => rows.iter().map(|f| shape_gtm_wideip(f, &gtm_used)).collect(),
+            "gtmPools" => rows.iter().map(|f| shape_gtm_pool(f, &gtm_used)).collect(),
+            "gtmServers" => rows.iter().map(|f| shape_gtm_server(f, &gtm_used)).collect(),
+            "gtmDatacenters" => rows.iter().map(shape_gtm_datacenter).collect(),
+            "gtmListeners" => rows.iter().map(shape_gtm_listener).collect(),
+            _ => Vec::new(),
         };
         device.insert((*key).into(), J::Array(shaped));
     }

--- a/rust/tcl-bigip-report/src/model.rs
+++ b/rust/tcl-bigip-report/src/model.rs
@@ -1321,10 +1321,31 @@ pub fn collect_model_with_certs(
     title: &str,
     cert_pems: &HashMap<String, String>,
 ) -> J {
+    collect_model_with_architecture(sources, title, cert_pems, None)
+}
+
+/// [`collect_model_with_certs`] plus an optional *architecture manifest*.
+///
+/// The report always auto-detects how the loaded devices relate as tiers (an
+/// upstream device whose pool member / GTM server address is served by another
+/// device's virtual is one tier up). `manifest` is an optional JSON document
+/// (see [`crate::architecture`]) that overrides each device's role/tier and can
+/// declare links explicitly; `None` (or empty) uses pure auto-detection. A
+/// malformed manifest is reported inside the model rather than failing the build.
+#[must_use]
+#[allow(clippy::implicit_hasher)] // the caller (wasm/CLI) always uses std HashMap
+pub fn collect_model_with_architecture(
+    sources: &[Source],
+    title: &str,
+    cert_pems: &HashMap<String, String>,
+    manifest: Option<&str>,
+) -> J {
     let devices: Vec<J> = sources
         .iter()
         .map(|(uri, src)| collect_device(uri, src, cert_pems))
         .collect();
+
+    let architecture = crate::architecture::build_architecture(&devices, manifest);
 
     let mut totals: Map<String, J> = Map::new();
     for d in &devices {
@@ -1348,5 +1369,6 @@ pub fn collect_model_with_certs(
     model.insert("devices".into(), J::Array(devices));
     model.insert("totals".into(), J::Object(totals));
     model.insert("container_order".into(), J::Array(container_order));
+    model.insert("architecture".into(), architecture);
     J::Object(model)
 }

--- a/rust/tcl-bigip-report/src/model.rs
+++ b/rust/tcl-bigip-report/src/model.rs
@@ -1633,7 +1633,7 @@ pub fn collect_model_with_certs(
 ///
 /// The report always auto-detects how the loaded devices relate as tiers (an
 /// upstream device whose pool member / GTM server address is served by another
-/// device's virtual is one tier up). `manifest` is an optional JSON document
+/// device's virtual is one tier up). `manifest` is an optional Tcl script
 /// (see [`crate::architecture`]) that overrides each device's role/tier and can
 /// declare links explicitly; `None` (or empty) uses pure auto-detection. A
 /// malformed manifest is reported inside the model rather than failing the build.

--- a/rust/tcl-bigip-report/src/model.rs
+++ b/rust/tcl-bigip-report/src/model.rs
@@ -1575,6 +1575,30 @@ fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>) 
         .and_then(J::as_array)
         .map_or(0, Vec::len);
     counts.insert("secrets".into(), J::from(secret_total));
+    // Aggregate GTM + firewall/NAT object counts (for the tab badges).
+    let len_of = |keys: &[&str]| -> usize {
+        keys.iter()
+            .map(|k| device.get(*k).and_then(J::as_array).map_or(0, Vec::len))
+            .sum()
+    };
+    let gtm_total = len_of(&[
+        "gtmWideips",
+        "gtmPools",
+        "gtmServers",
+        "gtmDatacenters",
+        "gtmListeners",
+    ]);
+    counts.insert("gtm".into(), J::from(gtm_total));
+    let firewall_total = len_of(&[
+        "firewallPolicies",
+        "firewallRuleLists",
+        "firewallAddressLists",
+        "firewallPortLists",
+        "natPolicies",
+        "natSourceTranslations",
+        "natDestinationTranslations",
+    ]);
+    counts.insert("firewall".into(), J::from(firewall_total));
     device.insert("counts".into(), J::Object(counts));
 
     let ins = insights(&device);

--- a/rust/tcl-bigip-report/src/model.rs
+++ b/rust/tcl-bigip-report/src/model.rs
@@ -56,6 +56,22 @@ const GTM_CONTAINERS: &[(&str, &str)] = &[
     ("gtmListeners", ".gtm.listener"),
 ];
 
+// AFM security-firewall + NAT object containers. Surfacing these gives the
+// report a firewall / NAT posture view: the policies and rule-lists, the
+// address-/port-lists they match on, and the NAT policies and translations.
+const SECURITY_CONTAINERS: &[(&str, &str)] = &[
+    ("firewallPolicies", ".security.\"firewall-policy\""),
+    ("firewallRuleLists", ".security.\"firewall-rule-list\""),
+    ("firewallAddressLists", ".security.\"firewall-address-list\""),
+    ("firewallPortLists", ".security.\"firewall-port-list\""),
+    ("natPolicies", ".security.\"nat-policy\""),
+    ("natSourceTranslations", ".security.\"nat-source-translation\""),
+    (
+        "natDestinationTranslations",
+        ".security.\"nat-destination-translation\"",
+    ),
+];
+
 // Leaf object types that are *referenced* by something else; an empty referrer
 // set means the object is orphaned. Virtuals / virtual-addresses are entry
 // points, so they are never treated as orphans.
@@ -523,6 +539,125 @@ fn shape_gtm_listener(f: &Map<String, J>) -> J {
     o.insert("port".into(), J::String(bstr(f, "port").into()));
     o.insert("pool".into(), J::String(clean_field(f, "pool")));
     o.insert("state".into(), J::String(bstr(f, "state").into()));
+    J::Object(o)
+}
+
+// --- Security (firewall + NAT) shaping ---------------------------------------
+
+/// Shape a firewall-rule endpoint (source / destination) into flat string lists.
+fn shape_fw_endpoint(m: &Map<String, J>) -> J {
+    let mut o = Map::new();
+    o.insert("addresses".into(), J::Array(str_array(m, "addresses")));
+    o.insert(
+        "addressLists".into(),
+        J::Array(clean_arr(m, "address-lists")),
+    );
+    o.insert("ports".into(), J::Array(str_array(m, "ports")));
+    o.insert("portLists".into(), J::Array(clean_arr(m, "port-lists")));
+    J::Object(o)
+}
+
+fn shape_fw_rule(m: &Map<String, J>) -> J {
+    let empty = Map::new();
+    let src = m.get("source").and_then(J::as_object).unwrap_or(&empty);
+    let dst = m.get("destination").and_then(J::as_object).unwrap_or(&empty);
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(m, "name").into()));
+    o.insert("action".into(), J::String(bstr(m, "action").into()));
+    o.insert("ipProtocol".into(), J::String(bstr(m, "ip-protocol").into()));
+    o.insert("log".into(), J::Bool(bbool(m, "log")));
+    o.insert("source".into(), shape_fw_endpoint(src));
+    o.insert("destination".into(), shape_fw_endpoint(dst));
+    o.insert("ruleList".into(), J::String(clean_field(m, "rule-list")));
+    J::Object(o)
+}
+
+fn shape_fw_policy(f: &Map<String, J>) -> J {
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(bstr(f, "full-path").into()));
+    o.insert("rules".into(), J::Array(str_array(f, "rules")));
+    o.insert("ruleLists".into(), J::Array(clean_arr(f, "rule-lists")));
+    o.insert(
+        "description".into(),
+        J::String(bstr(f, "description").into()),
+    );
+    J::Object(o)
+}
+
+fn shape_fw_rule_list(f: &Map<String, J>) -> J {
+    let rules: Vec<J> = barr(f, "rules")
+        .iter()
+        .filter_map(J::as_object)
+        .map(shape_fw_rule)
+        .collect();
+    let rule_count = rules.len();
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(bstr(f, "full-path").into()));
+    o.insert("rules".into(), J::Array(rules));
+    o.insert("ruleCount".into(), J::from(rule_count));
+    o.insert(
+        "description".into(),
+        J::String(bstr(f, "description").into()),
+    );
+    J::Object(o)
+}
+
+fn shape_fw_address_list(f: &Map<String, J>) -> J {
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(bstr(f, "full-path").into()));
+    o.insert("addresses".into(), J::Array(str_array(f, "addresses")));
+    o.insert(
+        "addressLists".into(),
+        J::Array(clean_arr(f, "address-lists")),
+    );
+    o.insert("fqdns".into(), J::Array(str_array(f, "fqdns")));
+    o.insert(
+        "description".into(),
+        J::String(bstr(f, "description").into()),
+    );
+    J::Object(o)
+}
+
+fn shape_fw_port_list(f: &Map<String, J>) -> J {
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(bstr(f, "full-path").into()));
+    o.insert("ports".into(), J::Array(str_array(f, "ports")));
+    o.insert(
+        "description".into(),
+        J::String(bstr(f, "description").into()),
+    );
+    J::Object(o)
+}
+
+fn shape_nat_policy(f: &Map<String, J>) -> J {
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(bstr(f, "full-path").into()));
+    o.insert("rules".into(), J::Array(str_array(f, "rules")));
+    o.insert("ruleLists".into(), J::Array(clean_arr(f, "rule-lists")));
+    o.insert(
+        "description".into(),
+        J::String(bstr(f, "description").into()),
+    );
+    J::Object(o)
+}
+
+/// Shared shaper for the two NAT translation kinds (same projected shape).
+fn shape_nat_translation(f: &Map<String, J>) -> J {
+    let mut o = Map::new();
+    o.insert("name".into(), J::String(bstr(f, "name").into()));
+    o.insert("fullPath".into(), J::String(bstr(f, "full-path").into()));
+    o.insert("type".into(), J::String(bstr(f, "type").into()));
+    o.insert("addresses".into(), J::Array(str_array(f, "addresses")));
+    o.insert("ports".into(), J::Array(str_array(f, "ports")));
+    o.insert(
+        "description".into(),
+        J::String(bstr(f, "description").into()),
+    );
     J::Object(o)
 }
 
@@ -1164,6 +1299,23 @@ fn collect_device(uri: &str, source: &str, cert_pems: &HashMap<String, String>) 
             "gtmServers" => rows.iter().map(|f| shape_gtm_server(f, &gtm_used)).collect(),
             "gtmDatacenters" => rows.iter().map(shape_gtm_datacenter).collect(),
             "gtmListeners" => rows.iter().map(shape_gtm_listener).collect(),
+            _ => Vec::new(),
+        };
+        device.insert((*key).into(), J::Array(shaped));
+    }
+
+    // AFM firewall + NAT inventory (the security posture view).
+    for (key, container) in SECURITY_CONTAINERS {
+        let rows = fields_of(query(&format!("{container}[]"), &sources).unwrap_or_default());
+        let shaped: Vec<J> = match *key {
+            "firewallPolicies" => rows.iter().map(shape_fw_policy).collect(),
+            "firewallRuleLists" => rows.iter().map(shape_fw_rule_list).collect(),
+            "firewallAddressLists" => rows.iter().map(shape_fw_address_list).collect(),
+            "firewallPortLists" => rows.iter().map(shape_fw_port_list).collect(),
+            "natPolicies" => rows.iter().map(shape_nat_policy).collect(),
+            "natSourceTranslations" | "natDestinationTranslations" => {
+                rows.iter().map(shape_nat_translation).collect()
+            }
             _ => Vec::new(),
         };
         device.insert((*key).into(), J::Array(shaped));

--- a/rust/tcl-bigip-report/src/render.rs
+++ b/rust/tcl-bigip-report/src/render.rs
@@ -57,9 +57,10 @@ pub struct RenderOptions {
     /// `sys file ssl-cert` `cache-path`. Lets the certs tab parse metadata-free
     /// stanzas and reconstruct the trust chain. Empty = config metadata only.
     pub cert_pems: std::collections::HashMap<String, String>,
-    /// Optional *architecture manifest* JSON (see [`crate::architecture`]).
-    /// Declares each device's role/tier and can add explicit inter-device links,
-    /// overriding and augmenting auto-detection. Empty = pure auto-detection.
+    /// Optional *architecture manifest* — a small Tcl script (see
+    /// [`crate::architecture`]). Declares each device's role/tier and can add
+    /// explicit inter-device links, overriding and augmenting auto-detection.
+    /// Empty = pure auto-detection.
     pub architecture: Option<String>,
 }
 

--- a/rust/tcl-bigip-report/src/render.rs
+++ b/rust/tcl-bigip-report/src/render.rs
@@ -15,7 +15,6 @@ use base64::Engine as _;
 use minijinja::{AutoEscape, Environment};
 use serde_json::{Map, Value as J, json};
 
-use crate::model::collect_model_with_certs;
 use crate::query::{ReportError, Source};
 
 // The template we own (adapted from `f5report`'s `report.html.j2` for minijinja
@@ -58,6 +57,10 @@ pub struct RenderOptions {
     /// `sys file ssl-cert` `cache-path`. Lets the certs tab parse metadata-free
     /// stanzas and reconstruct the trust chain. Empty = config metadata only.
     pub cert_pems: std::collections::HashMap<String, String>,
+    /// Optional *architecture manifest* JSON (see [`crate::architecture`]).
+    /// Declares each device's role/tier and can add explicit inter-device links,
+    /// overriding and augmenting auto-detection. Empty = pure auto-detection.
+    pub architecture: Option<String>,
 }
 
 impl Default for RenderOptions {
@@ -67,6 +70,7 @@ impl Default for RenderOptions {
             generated_at: String::new(),
             embed_console: true,
             cert_pems: std::collections::HashMap::new(),
+            architecture: None,
         }
     }
 }
@@ -164,6 +168,11 @@ pub fn render_report(model: J, opts: &RenderOptions) -> Result<String, ReportErr
 
 /// Collect the model from `sources` and render it to a standalone HTML document.
 pub fn build_report(sources: &[Source], opts: &RenderOptions) -> Result<String, ReportError> {
-    let model = collect_model_with_certs(sources, &opts.title, &opts.cert_pems);
+    let model = crate::model::collect_model_with_architecture(
+        sources,
+        &opts.title,
+        &opts.cert_pems,
+        opts.architecture.as_deref(),
+    );
     render_report(model, opts)
 }

--- a/rust/tcl-bigip-report/templates/report.html.j2
+++ b/rust/tcl-bigip-report/templates/report.html.j2
@@ -75,6 +75,8 @@
   {% if architecture.manifestError %}
   <div class="insight warn"><span class="dot"></span>Manifest ignored: {{ architecture.manifestError }}</div>
   {% endif %}
+  <div class="arch-diagram diag-host" id="archDiagram" aria-label="Interactive architecture diagram — click a device to jump to it"></div>
+  <div class="arch-tiers-lbl">Devices by tier</div>
   <div class="arch-tiers">
     {% for t in architecture.tiers %}
     <div class="arch-tier">

--- a/rust/tcl-bigip-report/templates/report.html.j2
+++ b/rust/tcl-bigip-report/templates/report.html.j2
@@ -40,6 +40,18 @@
 <div class="chip {{ tone }}{{ ' chip-link' if target }}"{% if target %} data-target="{{ target }}" role="button" tabindex="0" title="Go to {{ label }}"{% endif %}><span class="chip-val">{{ value }}</span><span class="chip-lbl">{{ label }}</span></div>
 {% endmacro %}
 
+{#: Render a firewall rule endpoint (source / destination) compactly. :#}
+{% macro fw_endpoint(e) %}
+{%- if not e or (not e.addresses and not e.addressLists and not e.ports and not e.portLists) -%}
+<span class="muted">any</span>
+{%- else -%}
+{% for x in e.addresses %}<span class="tag">{{ x }}</span>{% endfor %}
+{%- for x in e.addressLists %}<span class="tag blue" title="address-list">{{ x | leaf }}</span>{% endfor %}
+{%- for x in e.ports %}<span class="tag amber">:{{ x }}</span>{% endfor %}
+{%- for x in e.portLists %}<span class="tag" title="port-list">:{{ x | leaf }}</span>{% endfor %}
+{%- endif -%}
+{% endmacro %}
+
 <section class="summary">
   {{ chip('Virtual Servers', totals.virtuals, '', 'virtuals') }}
   {{ chip('Pools', totals.pools, '', 'pools') }}
@@ -51,6 +63,61 @@
   {{ chip('Orphaned Objects', totals.orphans, 'warn' if totals.orphans else 'ok') }}
   {{ chip('SSL Certificates', totals.certificates, '', 'certificates') }}
 </section>
+
+{% if architecture and architecture.deviceCount > 1 %}
+<section class="architecture" id="architecture">
+  <div class="arch-head">
+    <h2>Architecture</h2>
+    <span class="muted">how the loaded devices relate as tiers —
+      {%- if architecture.defined %} from manifest{% else %} auto-detected from address overlap{% endif -%}
+    </span>
+  </div>
+  {% if architecture.manifestError %}
+  <div class="insight warn"><span class="dot"></span>Manifest ignored: {{ architecture.manifestError }}</div>
+  {% endif %}
+  <div class="arch-tiers">
+    {% for t in architecture.tiers %}
+    <div class="arch-tier">
+      <div class="arch-tier-lbl">Tier {{ t.tier }}</div>
+      {% for d in t.devices %}
+      <div class="arch-node arch-role-{{ d.role }}">
+        <span class="arch-node-name">{{ d.label }}</span>
+        <span class="arch-node-role">{{ d.role }}</span>
+      </div>
+      {% endfor %}
+    </div>
+    {% endfor %}
+  </div>
+  {% if architecture.links %}
+  <div class="tablewrap">
+  <table class="grid arch-links">
+    <thead><tr><th>Upstream</th><th></th><th>Downstream</th><th>Source</th><th>Evidence</th></tr></thead>
+    <tbody>
+      {% for l in architecture.links %}
+      <tr>
+        <td class="mono strong">{{ l.fromLabel }}</td>
+        <td class="arch-arrow">→</td>
+        <td class="mono strong">{{ l.toLabel }}</td>
+        <td>{% if l.source == 'auto' %}<span class="tag">auto</span>{% elif l.source == 'manifest' %}<span class="tag blue">manifest</span>{% else %}<span class="tag green">manifest + auto</span>{% endif %}</td>
+        <td class="mono">
+          {%- if l.vias %}
+          {% for v in l.vias[:4] %}<span class="tag" title="{{ v.fromObj }} → {{ v.toObj }}">{{ v.address }}{% if v.port %}:{{ v.port }}{% endif %}</span>{% endfor %}
+          {%- if l.viaCount > 4 %}<span class="muted">+{{ l.viaCount - 4 }} more</span>{% endif %}
+          {%- elif l.label %}<span class="muted">{{ l.label }}</span>
+          {%- else %}<span class="muted">—</span>{% endif %}
+        </td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  </div>
+  {% endif %}
+  <details class="arch-mermaid-src">
+    <summary>Mermaid diagram source</summary>
+    <pre class="mermaid-code">{{ architecture.mermaid }}</pre>
+  </details>
+</section>
+{% endif %}
 
 {% if devices|length > 1 %}
 <nav class="device-switch" role="tablist" aria-label="Devices">
@@ -103,6 +170,8 @@
     <button class="tab" data-panel="profiles">Profiles <span class="n">{{ d.counts.profiles }}</span></button>
     <button class="tab" data-panel="certificates">SSL Certificates <span class="n">{{ d.counts.certificates }}</span></button>
     {% if d.counts.secrets %}<button class="tab" data-panel="secrets">Secrets <span class="n">{{ d.counts.secrets }}</span></button>{% endif %}
+    {% if d.counts.gtm %}<button class="tab" data-panel="gtm">GTM / DNS <span class="n">{{ d.counts.gtm }}</span></button>{% endif %}
+    {% if d.counts.firewall %}<button class="tab" data-panel="firewall">Firewall / NAT <span class="n">{{ d.counts.firewall }}</span></button>{% endif %}
     <button class="tab" data-panel="topology">Topology</button>
     <button class="tab" data-panel="listener">Listener Matcher</button>
     <button class="tab" data-panel="apps">Apps <span class="n app-badge">0</span></button>
@@ -375,6 +444,224 @@
       </tbody>
     </table>
     </div>
+  </div>
+  {% endif %}
+
+  {#: ---------------- GTM / DNS ---------------- :#}
+  {% if d.counts.gtm %}
+  <div class="panel" data-panel="gtm">
+    <p class="lm-field-note">The GTM (BIG-IP DNS) global load-balancing tier: wide-IPs resolve a name to a pool, whose members select a <code>server</code>'s virtual server. A server's virtual-server destinations are the downstream LTM virtual addresses — the link the <a href="#architecture">Architecture</a> view uses to place this GTM in front of its LTM tiers.</p>
+
+    {% if d.gtmWideips %}
+    <h3 class="subhead">Wide-IPs <span class="n">{{ d.gtmWideips | length }}</span></h3>
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>Wide-IP</th><th>Type</th><th>Pools</th><th>Aliases</th><th>LB mode</th></tr></thead>
+      <tbody>
+      {% for w in d.gtmWideips %}
+      <tr class="searchable" data-search="{{ w.name }} {{ w.fullPath }}">
+        <td class="mono strong">{{ w.name }}</td>
+        <td>{% if w.recordType %}<span class="tag">{{ w.recordType | upper }}</span>{% endif %}</td>
+        <td class="mono">{% for p in w.pools %}<span class="tag blue">{{ p | leaf }}</span>{% endfor %}</td>
+        <td class="mono small">{% for a in w.aliases %}{{ a }}{% if not loop.last %}, {% endif %}{% endfor %}</td>
+        <td>{{ w.poolLbMode or '—' }}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    </div>
+    {% endif %}
+
+    {% if d.gtmPools %}
+    <h3 class="subhead">Pools <span class="n">{{ d.gtmPools | length }}</span></h3>
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>Pool</th><th>Type</th><th>LB mode</th><th>Members</th></tr></thead>
+      <tbody>
+      {% for p in d.gtmPools %}
+      <tr class="searchable" data-search="{{ p.name }} {{ p.fullPath }}">
+        <td class="mono strong">{{ p.name }}</td>
+        <td>{% if p.recordType %}<span class="tag">{{ p.recordType | upper }}</span>{% endif %}</td>
+        <td>{{ p.lbMode or '—' }}</td>
+        <td class="mono small">{% for m in p.members %}<span class="tag" title="{{ m.state }}">{{ m.name }}{% if m.staticTarget %} → {{ m.staticTarget }}{% endif %}</span>{% else %}<span class="muted">—</span>{% endfor %}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    </div>
+    {% endif %}
+
+    {% if d.gtmServers %}
+    <h3 class="subhead">Servers <span class="n">{{ d.gtmServers | length }}</span></h3>
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>Server</th><th>Datacenter</th><th>Product</th><th>Addresses</th><th>Virtual-server targets</th></tr></thead>
+      <tbody>
+      {% for s in d.gtmServers %}
+      <tr class="searchable" data-search="{{ s.name }} {{ s.fullPath }}">
+        <td class="mono strong">{{ s.name }}</td>
+        <td class="mono">{{ s.datacenter | leaf or '—' }}</td>
+        <td>{{ s.product or '—' }}</td>
+        <td class="mono small">{% for a in s.addresses %}{{ a }}{% if not loop.last %}, {% endif %}{% endfor %}</td>
+        <td class="mono small">{% for v in s.virtualServers %}<span class="tag green">{{ v }}</span>{% else %}<span class="muted">—</span>{% endfor %}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    </div>
+    {% endif %}
+
+    {% if d.gtmDatacenters %}
+    <h3 class="subhead">Datacenters <span class="n">{{ d.gtmDatacenters | length }}</span></h3>
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>Datacenter</th><th>Location</th><th>Contact</th></tr></thead>
+      <tbody>
+      {% for c in d.gtmDatacenters %}
+      <tr class="searchable" data-search="{{ c.name }} {{ c.fullPath }}">
+        <td class="mono strong">{{ c.name }}</td>
+        <td>{{ c.location or '—' }}</td>
+        <td>{{ c.contact or '—' }}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    </div>
+    {% endif %}
+  </div>
+  {% endif %}
+
+  {#: ---------------- Firewall / NAT ---------------- :#}
+  {% if d.counts.firewall %}
+  <div class="panel" data-panel="firewall">
+    <p class="lm-field-note">The AFM firewall and NAT posture: policies and the rule-lists they enforce, the address-/port-lists rules match on, and the NAT policies and source/destination translations.</p>
+
+    {% if d.firewallPolicies %}
+    <h3 class="subhead">Firewall policies <span class="n">{{ d.firewallPolicies | length }}</span></h3>
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>Policy</th><th>Rule-lists</th><th>Inline rules</th></tr></thead>
+      <tbody>
+      {% for p in d.firewallPolicies %}
+      <tr class="searchable" data-search="{{ p.name }} {{ p.fullPath }}">
+        <td class="mono strong">{{ p.name }}</td>
+        <td class="mono">{% for rl in p.ruleLists %}<span class="tag blue">{{ rl | leaf }}</span>{% else %}<span class="muted">—</span>{% endfor %}</td>
+        <td class="mono small">{% for r in p.rules %}<span class="tag">{{ r }}</span>{% else %}<span class="muted">—</span>{% endfor %}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    </div>
+    {% endif %}
+
+    {% if d.firewallRuleLists %}
+    <h3 class="subhead">Rule-lists <span class="n">{{ d.firewallRuleLists | length }}</span></h3>
+    {% for rl in d.firewallRuleLists %}
+    <div class="rule-list-block">
+      <div class="rule-list-name mono strong">{{ rl.name }} <span class="muted">({{ rl.ruleCount }} rule{{ '' if rl.ruleCount == 1 else 's' }})</span></div>
+      <div class="tablewrap">
+      <table class="grid fw-rules">
+        <thead><tr><th>Rule</th><th>Action</th><th>Proto</th><th>Source</th><th>Destination</th><th>Log</th></tr></thead>
+        <tbody>
+        {% for r in rl.rules %}
+        <tr class="searchable" data-search="{{ r.name }} {{ rl.name }}">
+          <td class="mono strong">{{ r.name }}</td>
+          <td><span class="tag {{ 'green' if r.action == 'accept' else 'red' if r.action in ['drop','reject'] else '' }}">{{ r.action or '—' }}</span></td>
+          <td class="mono">{{ r.ipProtocol or 'any' }}</td>
+          <td class="mono small">{{ fw_endpoint(r.source) }}</td>
+          <td class="mono small">{{ fw_endpoint(r.destination) }}{% if r.ruleList %} <span class="tag blue">list {{ r.ruleList | leaf }}</span>{% endif %}</td>
+          <td>{% if r.log %}<span class="tag amber">log</span>{% endif %}</td>
+        </tr>
+        {% endfor %}
+        </tbody>
+      </table>
+      </div>
+    </div>
+    {% endfor %}
+    {% endif %}
+
+    {% if d.firewallAddressLists %}
+    <h3 class="subhead">Address-lists <span class="n">{{ d.firewallAddressLists | length }}</span></h3>
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>Address-list</th><th>Addresses</th><th>Nested lists</th><th>FQDNs</th></tr></thead>
+      <tbody>
+      {% for a in d.firewallAddressLists %}
+      <tr class="searchable" data-search="{{ a.name }} {{ a.fullPath }}">
+        <td class="mono strong">{{ a.name }}</td>
+        <td class="mono small">{% for x in a.addresses %}<span class="tag">{{ x }}</span>{% else %}<span class="muted">—</span>{% endfor %}</td>
+        <td class="mono small">{% for x in a.addressLists %}<span class="tag blue">{{ x | leaf }}</span>{% endfor %}</td>
+        <td class="mono small">{% for x in a.fqdns %}{{ x }}{% if not loop.last %}, {% endif %}{% endfor %}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    </div>
+    {% endif %}
+
+    {% if d.firewallPortLists %}
+    <h3 class="subhead">Port-lists <span class="n">{{ d.firewallPortLists | length }}</span></h3>
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>Port-list</th><th>Ports</th></tr></thead>
+      <tbody>
+      {% for p in d.firewallPortLists %}
+      <tr class="searchable" data-search="{{ p.name }} {{ p.fullPath }}">
+        <td class="mono strong">{{ p.name }}</td>
+        <td class="mono small">{% for x in p.ports %}<span class="tag">{{ x }}</span>{% else %}<span class="muted">—</span>{% endfor %}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    </div>
+    {% endif %}
+
+    {% if d.natPolicies or d.natSourceTranslations or d.natDestinationTranslations %}
+    <h3 class="subhead">NAT</h3>
+    {% if d.natPolicies %}
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>NAT policy</th><th>Rule-lists</th><th>Rules</th></tr></thead>
+      <tbody>
+      {% for p in d.natPolicies %}
+      <tr class="searchable" data-search="{{ p.name }} {{ p.fullPath }}">
+        <td class="mono strong">{{ p.name }}</td>
+        <td class="mono">{% for rl in p.ruleLists %}<span class="tag blue">{{ rl | leaf }}</span>{% else %}<span class="muted">—</span>{% endfor %}</td>
+        <td class="mono small">{% for r in p.rules %}<span class="tag">{{ r }}</span>{% else %}<span class="muted">—</span>{% endfor %}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    </div>
+    {% endif %}
+    {% if d.natSourceTranslations or d.natDestinationTranslations %}
+    <div class="tablewrap">
+    <table class="grid">
+      <thead><tr><th>Translation</th><th>Direction</th><th>Type</th><th>Addresses</th><th>Ports</th></tr></thead>
+      <tbody>
+      {% for t in d.natSourceTranslations %}
+      <tr class="searchable" data-search="{{ t.name }} {{ t.fullPath }}">
+        <td class="mono strong">{{ t.name }}</td>
+        <td><span class="tag">source</span></td>
+        <td class="mono">{{ t.type or '—' }}</td>
+        <td class="mono small">{% for x in t.addresses %}{{ x }}{% if not loop.last %}, {% endif %}{% endfor %}</td>
+        <td class="mono small">{% for x in t.ports %}{{ x }}{% if not loop.last %}, {% endif %}{% endfor %}</td>
+      </tr>
+      {% endfor %}
+      {% for t in d.natDestinationTranslations %}
+      <tr class="searchable" data-search="{{ t.name }} {{ t.fullPath }}">
+        <td class="mono strong">{{ t.name }}</td>
+        <td><span class="tag">destination</span></td>
+        <td class="mono">{{ t.type or '—' }}</td>
+        <td class="mono small">{% for x in t.addresses %}{{ x }}{% if not loop.last %}, {% endif %}{% endfor %}</td>
+        <td class="mono small">{% for x in t.ports %}{{ x }}{% if not loop.last %}, {% endif %}{% endfor %}</td>
+      </tr>
+      {% endfor %}
+      </tbody>
+    </table>
+    </div>
+    {% endif %}
+    {% endif %}
   </div>
   {% endif %}
 

--- a/rust/tcl-bigip-report/tests/architecture.rs
+++ b/rust/tcl-bigip-report/tests/architecture.rs
@@ -1,0 +1,144 @@
+//! Integration tests for the multi-device *architecture* layer.
+//!
+//! Uses small inline SCF sources (the report engine takes `(uri, scf_text)`
+//! directly, so no UCS fixture is needed) to exercise cross-device link
+//! auto-detection and manifest overrides.
+
+use std::collections::HashMap;
+
+use serde_json::Value as J;
+use tcl_bigip_report::{Source, collect_model, collect_model_with_architecture};
+
+/// Empty cert-PEM map for the architecture-only tests.
+fn no_certs() -> HashMap<String, String> {
+    HashMap::new()
+}
+
+/// A tier-1 LTM: a virtual on 10.1.0.10 whose pool member is 10.2.0.20 — the
+/// address the tier-2 device serves. That IP overlap is the tier hop.
+const TIER1: &str = r"#TMSH-VERSION: 15.1.0
+ltm virtual /Common/edge_vs {
+    destination /Common/10.1.0.10:443
+    pool /Common/edge_pool
+}
+ltm pool /Common/edge_pool {
+    members {
+        /Common/10.2.0.20:443 {
+            address 10.2.0.20
+        }
+    }
+}
+ltm virtual-address /Common/10.1.0.10 {
+    address 10.1.0.10
+}
+";
+
+/// A tier-2 LTM: a virtual on 10.2.0.20 (the tier-1 pool member) fronting a
+/// backend on 10.3.0.30.
+const TIER2: &str = r"#TMSH-VERSION: 15.1.0
+ltm virtual /Common/app_vs {
+    destination /Common/10.2.0.20:443
+    pool /Common/app_pool
+}
+ltm pool /Common/app_pool {
+    members {
+        /Common/10.3.0.30:8080 {
+            address 10.3.0.30
+        }
+    }
+}
+ltm virtual-address /Common/10.2.0.20 {
+    address 10.2.0.20
+}
+";
+
+fn sources() -> Vec<Source> {
+    vec![
+        ("tier1.scf".to_string(), TIER1.to_string()),
+        ("tier2.scf".to_string(), TIER2.to_string()),
+    ]
+}
+
+fn arch(model: &J) -> &J {
+    model.get("architecture").expect("architecture present")
+}
+
+#[test]
+fn architecture_is_always_present() {
+    let m = collect_model(&sources(), "Estate");
+    let a = arch(&m);
+    assert_eq!(a["defined"], J::Bool(false), "no manifest -> auto only");
+    assert_eq!(a["deviceCount"], J::from(2));
+    assert_eq!(a["devices"].as_array().unwrap().len(), 2);
+}
+
+#[test]
+fn auto_detects_tier_hop() {
+    let m = collect_model(&sources(), "Estate");
+    let a = arch(&m);
+    let links = a["links"].as_array().unwrap();
+    assert_eq!(links.len(), 1, "one tier-1 -> tier-2 link");
+    let l = &links[0];
+    assert_eq!(l["from"], J::from(0));
+    assert_eq!(l["to"], J::from(1));
+    assert_eq!(l["source"], "auto");
+    // The evidencing flow is the pool member -> virtual on 10.2.0.20.
+    let via = &l["vias"].as_array().unwrap()[0];
+    assert_eq!(via["address"], "10.2.0.20");
+    assert_eq!(via["fromObj"], "/Common/edge_pool");
+    assert_eq!(via["toObj"], "/Common/app_vs");
+}
+
+#[test]
+fn tiers_are_assigned_by_depth() {
+    let m = collect_model(&sources(), "Estate");
+    let devs = arch(&m)["devices"].as_array().unwrap();
+    let tier = |i: usize| devs[i]["tier"].as_i64().unwrap();
+    assert_eq!(tier(0), 0, "the fronting device is tier 0");
+    assert_eq!(tier(1), 1, "the device it fronts is tier 1");
+}
+
+#[test]
+fn manifest_overrides_role_tier_and_label() {
+    let manifest = r#"{
+        "devices": [
+            {"match": "tier1.scf", "role": "gtm", "tier": 5, "label": "DNS Front"},
+            {"match": "tier2.scf", "role": "ltm", "label": "App Tier"}
+        ]
+    }"#;
+    let m = collect_model_with_architecture(&sources(), "Estate", &no_certs(), Some(manifest));
+    let a = arch(&m);
+    assert_eq!(a["defined"], J::Bool(true));
+    let devs = a["devices"].as_array().unwrap();
+    assert_eq!(devs[0]["role"], "gtm");
+    assert_eq!(devs[0]["tier"], J::from(5));
+    assert_eq!(devs[0]["label"], "DNS Front");
+    assert_eq!(devs[1]["label"], "App Tier");
+}
+
+#[test]
+fn manifest_adds_explicit_link() {
+    // Declare a tier2 -> tier1 link auto-detection would never find (no IP
+    // overlap in that direction).
+    let manifest = r#"{
+        "links": [ {"from": "tier2.scf", "to": "tier1.scf", "label": "mgmt"} ]
+    }"#;
+    let m = collect_model_with_architecture(&sources(), "Estate", &no_certs(), Some(manifest));
+    let links = arch(&m)["links"].as_array().unwrap();
+    // The auto 0->1 plus the manifest 1->0.
+    assert_eq!(links.len(), 2);
+    assert!(links.iter().any(|l| l["from"] == 1
+        && l["to"] == 0
+        && l["source"] == "manifest"
+        && l["label"] == "mgmt"));
+}
+
+#[test]
+fn malformed_manifest_is_reported_not_fatal() {
+    let m =
+        collect_model_with_architecture(&sources(), "Estate", &no_certs(), Some("{ this is not json"));
+    let a = arch(&m);
+    assert!(a.get("manifestError").is_some(), "parse error surfaced");
+    // Auto-detection still ran.
+    assert_eq!(a["links"].as_array().unwrap().len(), 1);
+}

--- a/rust/tcl-bigip-report/tests/architecture.rs
+++ b/rust/tcl-bigip-report/tests/architecture.rs
@@ -90,6 +90,37 @@ fn auto_detects_tier_hop() {
 }
 
 #[test]
+fn pool_member_without_address_uses_name() {
+    // A tier-1 pool member declared by keyed name only (no `address` property);
+    // the IP lives in the name. The hop must still be detected.
+    let tier1 = "#TMSH-VERSION: 15.1.0
+ltm pool /Common/edge_pool {
+    members {
+        /Common/10.2.0.20:443 { }
+    }
+}
+";
+    let tier2 = "#TMSH-VERSION: 15.1.0
+ltm virtual /Common/app_vs {
+    destination /Common/10.2.0.20:443
+}
+ltm virtual-address /Common/10.2.0.20 {
+    address 10.2.0.20
+}
+";
+    let sources: Vec<Source> = vec![
+        ("t1.scf".to_string(), tier1.to_string()),
+        ("t2.scf".to_string(), tier2.to_string()),
+    ];
+    let m = collect_model(&sources, "Estate");
+    let links = arch(&m)["links"].as_array().unwrap();
+    assert_eq!(links.len(), 1, "tier hop detected from the member name");
+    assert_eq!(links[0]["from"], 0);
+    assert_eq!(links[0]["to"], 1);
+    assert_eq!(links[0]["vias"].as_array().unwrap()[0]["address"], "10.2.0.20");
+}
+
+#[test]
 fn tiers_are_assigned_by_depth() {
     let m = collect_model(&sources(), "Estate");
     let devs = arch(&m)["devices"].as_array().unwrap();

--- a/rust/tcl-bigip-report/tests/architecture.rs
+++ b/rust/tcl-bigip-report/tests/architecture.rs
@@ -134,6 +134,34 @@ fn manifest_adds_explicit_link() {
 }
 
 #[test]
+fn tcl_manifest_overrides_and_links() {
+    // The manifest is a small Tcl script parsed with the real Tcl tokeniser.
+    let manifest = r#"
+        # architecture of this estate
+        device tier1.scf -role gtm -tier 5 -label "DNS Front"
+        device tier2.scf -role ltm -label "App Tier"
+
+        link tier2.scf tier1.scf -label mgmt
+    "#;
+    let m = collect_model_with_architecture(&sources(), "Estate", &no_certs(), Some(manifest));
+    let a = arch(&m);
+    assert_eq!(a["defined"], J::Bool(true));
+    let devs = a["devices"].as_array().unwrap();
+    assert_eq!(devs[0]["role"], "gtm");
+    assert_eq!(devs[0]["tier"], J::from(5));
+    assert_eq!(devs[0]["label"], "DNS Front", "quoted multi-word label parsed");
+    assert_eq!(devs[1]["label"], "App Tier");
+
+    // Auto 0->1 plus the manifest-declared 1->0.
+    let links = a["links"].as_array().unwrap();
+    assert_eq!(links.len(), 2);
+    assert!(links.iter().any(|l| l["from"] == 1
+        && l["to"] == 0
+        && l["source"] == "manifest"
+        && l["label"] == "mgmt"));
+}
+
+#[test]
 fn malformed_manifest_is_reported_not_fatal() {
     let m =
         collect_model_with_architecture(&sources(), "Estate", &no_certs(), Some("{ this is not json"));

--- a/rust/tcl-bigip-report/tests/architecture.rs
+++ b/rust/tcl-bigip-report/tests/architecture.rs
@@ -99,41 +99,6 @@ fn tiers_are_assigned_by_depth() {
 }
 
 #[test]
-fn manifest_overrides_role_tier_and_label() {
-    let manifest = r#"{
-        "devices": [
-            {"match": "tier1.scf", "role": "gtm", "tier": 5, "label": "DNS Front"},
-            {"match": "tier2.scf", "role": "ltm", "label": "App Tier"}
-        ]
-    }"#;
-    let m = collect_model_with_architecture(&sources(), "Estate", &no_certs(), Some(manifest));
-    let a = arch(&m);
-    assert_eq!(a["defined"], J::Bool(true));
-    let devs = a["devices"].as_array().unwrap();
-    assert_eq!(devs[0]["role"], "gtm");
-    assert_eq!(devs[0]["tier"], J::from(5));
-    assert_eq!(devs[0]["label"], "DNS Front");
-    assert_eq!(devs[1]["label"], "App Tier");
-}
-
-#[test]
-fn manifest_adds_explicit_link() {
-    // Declare a tier2 -> tier1 link auto-detection would never find (no IP
-    // overlap in that direction).
-    let manifest = r#"{
-        "links": [ {"from": "tier2.scf", "to": "tier1.scf", "label": "mgmt"} ]
-    }"#;
-    let m = collect_model_with_architecture(&sources(), "Estate", &no_certs(), Some(manifest));
-    let links = arch(&m)["links"].as_array().unwrap();
-    // The auto 0->1 plus the manifest 1->0.
-    assert_eq!(links.len(), 2);
-    assert!(links.iter().any(|l| l["from"] == 1
-        && l["to"] == 0
-        && l["source"] == "manifest"
-        && l["label"] == "mgmt"));
-}
-
-#[test]
 fn tcl_manifest_overrides_and_links() {
     // The manifest is a small Tcl script parsed with the real Tcl tokeniser.
     let manifest = r#"
@@ -163,10 +128,15 @@ fn tcl_manifest_overrides_and_links() {
 
 #[test]
 fn malformed_manifest_is_reported_not_fatal() {
-    let m =
-        collect_model_with_architecture(&sources(), "Estate", &no_certs(), Some("{ this is not json"));
+    // An unbalanced brace makes the Tcl tokeniser fail.
+    let m = collect_model_with_architecture(
+        &sources(),
+        "Estate",
+        &no_certs(),
+        Some("device tier1.scf -label {unclosed"),
+    );
     let a = arch(&m);
-    assert!(a.get("manifestError").is_some(), "parse error surfaced");
+    assert!(a.get("manifestError").is_some(), "tokeniser error surfaced");
     // Auto-detection still ran.
     assert_eq!(a["links"].as_array().unwrap().len(), 1);
 }

--- a/rust/tcl-bigip-report/tests/firewall.rs
+++ b/rust/tcl-bigip-report/tests/firewall.rs
@@ -1,0 +1,145 @@
+//! AFM security-firewall + NAT projection into the report model.
+
+use serde_json::Value as J;
+use tcl_bigip_report::{Source, collect_model};
+
+const FW: &str = r"#TMSH-VERSION: 15.1.0
+security firewall address-list /Common/webservers {
+    addresses {
+        10.0.0.0/24 { }
+        192.168.1.5 { }
+    }
+}
+security firewall port-list /Common/web-ports {
+    ports {
+        80 { }
+        443 { }
+    }
+}
+security firewall rule-list /Common/app-rules {
+    rules {
+        allow-web {
+            action accept
+            ip-protocol tcp
+            log yes
+            source {
+                address-lists {
+                    /Common/webservers
+                }
+            }
+            destination {
+                port-lists {
+                    /Common/web-ports
+                }
+            }
+        }
+        deny-all {
+            action drop
+            ip-protocol any
+        }
+    }
+}
+security firewall policy /Common/edge-policy {
+    rules {
+        app {
+            rule-list /Common/app-rules
+        }
+    }
+}
+security nat source-translation /Common/snat-xlate {
+    type dynamic-pat
+    addresses {
+        203.0.113.10 { }
+    }
+    ports {
+        1024-65535 { }
+    }
+}
+security nat destination-translation /Common/dnat-xlate {
+    type static-nat
+    addresses {
+        10.2.0.20 { }
+    }
+}
+security nat policy /Common/nat-pol {
+    rules {
+        r1 {
+            source-translation /Common/snat-xlate
+        }
+    }
+}
+";
+
+fn device() -> J {
+    let sources: Vec<Source> = vec![("fw.scf".to_string(), FW.to_string())];
+    let m = collect_model(&sources, "Firewall Estate");
+    m["devices"].as_array().unwrap()[0].clone()
+}
+
+#[test]
+fn firewall_objects_are_projected() {
+    let d = device();
+
+    let addr = d["firewallAddressLists"].as_array().unwrap();
+    assert_eq!(addr.len(), 1);
+    assert_eq!(addr[0]["name"], "webservers");
+    let addresses = addr[0]["addresses"].as_array().unwrap();
+    assert!(addresses.iter().any(|a| a == "10.0.0.0/24"));
+
+    let ports = d["firewallPortLists"].as_array().unwrap();
+    assert_eq!(ports.len(), 1);
+    assert!(ports[0]["ports"].as_array().unwrap().iter().any(|p| p == "443"));
+
+    let policies = d["firewallPolicies"].as_array().unwrap();
+    assert_eq!(policies.len(), 1);
+    assert_eq!(policies[0]["name"], "edge-policy");
+    assert_eq!(
+        policies[0]["ruleLists"].as_array().unwrap()[0],
+        "/Common/app-rules"
+    );
+}
+
+#[test]
+fn firewall_rule_list_rules_are_structured() {
+    let d = device();
+    let rls = d["firewallRuleLists"].as_array().unwrap();
+    assert_eq!(rls.len(), 1);
+    let rl = &rls[0];
+    assert_eq!(rl["ruleCount"], 2);
+    let rules = rl["rules"].as_array().unwrap();
+
+    let allow = &rules[0];
+    assert_eq!(allow["name"], "allow-web");
+    assert_eq!(allow["action"], "accept");
+    assert_eq!(allow["ipProtocol"], "tcp");
+    assert_eq!(allow["log"], J::Bool(true));
+    assert_eq!(
+        allow["source"]["addressLists"].as_array().unwrap()[0],
+        "/Common/webservers"
+    );
+    assert_eq!(
+        allow["destination"]["portLists"].as_array().unwrap()[0],
+        "/Common/web-ports"
+    );
+
+    let deny = &rules[1];
+    assert_eq!(deny["action"], "drop");
+}
+
+#[test]
+fn nat_objects_are_projected() {
+    let d = device();
+
+    let src = d["natSourceTranslations"].as_array().unwrap();
+    assert_eq!(src.len(), 1);
+    assert_eq!(src[0]["type"], "dynamic-pat");
+    assert!(src[0]["addresses"].as_array().unwrap().iter().any(|a| a == "203.0.113.10"));
+
+    let dst = d["natDestinationTranslations"].as_array().unwrap();
+    assert_eq!(dst.len(), 1);
+    assert_eq!(dst[0]["type"], "static-nat");
+
+    let pol = d["natPolicies"].as_array().unwrap();
+    assert_eq!(pol.len(), 1);
+    assert_eq!(pol[0]["name"], "nat-pol");
+}

--- a/rust/tcl-bigip-report/tests/gtm.rs
+++ b/rust/tcl-bigip-report/tests/gtm.rs
@@ -1,0 +1,122 @@
+//! GTM projection + GTM->LTM architecture linking, from inline SCF sources.
+
+use serde_json::Value as J;
+use tcl_bigip_report::{Source, collect_model};
+
+/// A GTM (DNS) device: a wide-IP -> pool -> member chain, plus a `gtm server`
+/// whose virtual-server destination (10.1.0.10:443) is the LTM tier's virtual.
+const GTM: &str = r"#TMSH-VERSION: 15.1.0
+gtm datacenter /Common/dc-east {
+    location Boston
+}
+gtm server /Common/ltm-edge {
+    datacenter /Common/dc-east
+    product bigip
+    addresses {
+        10.0.0.5 { }
+    }
+    virtual-servers {
+        app_vs {
+            destination 10.1.0.10:443
+        }
+    }
+}
+gtm pool a /Common/app_pool {
+    load-balancing-mode global-availability
+    members {
+        ltm-edge:app_vs {
+            member-order 0
+        }
+    }
+}
+gtm wideip a /Common/app.example.com {
+    pool-lb-mode topology
+    aliases { www.example.com }
+    pools {
+        app_pool {
+            order 0
+        }
+    }
+}
+";
+
+/// The LTM tier the GTM fronts: a virtual on 10.1.0.10 (the GTM server's
+/// virtual-server destination).
+const LTM: &str = r"#TMSH-VERSION: 15.1.0
+ltm virtual /Common/app_vs {
+    destination /Common/10.1.0.10:443
+    pool /Common/app_pool
+}
+ltm pool /Common/app_pool {
+    members {
+        /Common/10.9.0.9:8080 {
+            address 10.9.0.9
+        }
+    }
+}
+ltm virtual-address /Common/10.1.0.10 {
+    address 10.1.0.10
+}
+";
+
+fn model() -> J {
+    let sources: Vec<Source> = vec![
+        ("gtm.scf".to_string(), GTM.to_string()),
+        ("ltm.scf".to_string(), LTM.to_string()),
+    ];
+    collect_model(&sources, "GSLB Estate")
+}
+
+#[test]
+fn gtm_objects_are_projected() {
+    let m = model();
+    let gtm = &m["devices"].as_array().unwrap()[0];
+
+    let wideips = gtm["gtmWideips"].as_array().unwrap();
+    assert_eq!(wideips.len(), 1);
+    assert_eq!(wideips[0]["name"], "app.example.com");
+    // Wide-IP pool references use the leaf name, as written in the config.
+    assert_eq!(wideips[0]["pools"].as_array().unwrap()[0], "app_pool");
+    assert_eq!(wideips[0]["aliases"].as_array().unwrap()[0], "www.example.com");
+
+    let pools = gtm["gtmPools"].as_array().unwrap();
+    assert_eq!(pools.len(), 1);
+    assert_eq!(pools[0]["lbMode"], "global-availability");
+    assert_eq!(pools[0]["members"].as_array().unwrap()[0]["name"], "ltm-edge:app_vs");
+
+    let servers = gtm["gtmServers"].as_array().unwrap();
+    assert_eq!(servers.len(), 1);
+    assert_eq!(servers[0]["datacenter"], "/Common/dc-east");
+    let vss = servers[0]["virtualServers"].as_array().unwrap();
+    assert_eq!(vss[0], "10.1.0.10:443");
+
+    let dcs = gtm["gtmDatacenters"].as_array().unwrap();
+    assert_eq!(dcs.len(), 1);
+    assert_eq!(dcs[0]["location"], "Boston");
+}
+
+#[test]
+fn gtm_device_role_is_detected() {
+    let m = model();
+    let devs = m["architecture"]["devices"].as_array().unwrap();
+    assert_eq!(devs[0]["role"], "gtm", "the GTM device is inferred as gtm");
+    assert_eq!(devs[1]["role"], "ltm");
+}
+
+#[test]
+fn gtm_fronts_ltm_link_is_detected() {
+    let m = model();
+    let links = m["architecture"]["links"].as_array().unwrap();
+    assert_eq!(links.len(), 1, "GTM -> LTM");
+    let l = &links[0];
+    assert_eq!(l["from"], 0);
+    assert_eq!(l["to"], 1);
+    let via = &l["vias"].as_array().unwrap()[0];
+    assert_eq!(via["address"], "10.1.0.10");
+    assert_eq!(via["fromObj"], "/Common/ltm-edge");
+    assert_eq!(via["toObj"], "/Common/app_vs");
+    // Tiers: GTM tier 0, LTM tier 1.
+    let devs = m["architecture"]["devices"].as_array().unwrap();
+    assert_eq!(devs[0]["tier"], 0);
+    assert_eq!(devs[1]["tier"], 1);
+}

--- a/rust/tcl-bigip-report/tests/render_arch.rs
+++ b/rust/tcl-bigip-report/tests/render_arch.rs
@@ -60,6 +60,11 @@ fn architecture_section_renders() {
     assert!(html.contains("auto-detected"), "auto-detect note shown");
     // The GTM->LTM link with its evidencing address.
     assert!(html.contains("10.1.0.10"), "link evidence address rendered");
+    // The interactive diagram host + its wiring are present.
+    assert!(html.contains("id=\"archDiagram\""), "interactive diagram host present");
+    assert!(html.contains("initArchitecture"), "architecture init wired in topology.js");
+    // The Mermaid definition (embedded in the model) drives the diagram.
+    assert!(html.contains("flowchart LR"), "mermaid architecture diagram source present");
 }
 
 #[test]
@@ -69,6 +74,15 @@ fn gtm_and_firewall_tabs_render() {
     assert!(html.contains("app.example.com"), "wide-IP shown");
     assert!(html.contains("data-panel=\"firewall\""), "firewall panel present");
     assert!(html.contains("app-rules"), "rule-list shown");
+}
+
+/// Helper (opt-in): write a full report to `$WRITE_REPORT` for browser checks.
+#[test]
+fn write_report_for_browser() {
+    let Ok(path) = std::env::var("WRITE_REPORT") else {
+        return;
+    };
+    std::fs::write(&path, render()).expect("write report html");
 }
 
 #[test]

--- a/rust/tcl-bigip-report/tests/render_arch.rs
+++ b/rust/tcl-bigip-report/tests/render_arch.rs
@@ -1,0 +1,90 @@
+//! End-to-end HTML render check: the Architecture, GTM and Firewall/NAT
+//! sections appear in the generated report.
+
+use tcl_bigip_report::{RenderOptions, Source, build_report};
+
+const GTM: &str = r"#TMSH-VERSION: 15.1.0
+gtm datacenter /Common/dc-east { location Boston }
+gtm server /Common/ltm-edge {
+    datacenter /Common/dc-east
+    addresses { 10.0.0.5 { } }
+    virtual-servers { app_vs { destination 10.1.0.10:443 } }
+}
+gtm pool a /Common/app_pool {
+    members { ltm-edge:app_vs { } }
+}
+gtm wideip a /Common/app.example.com {
+    pools { app_pool { } }
+}
+";
+
+const LTM: &str = r"#TMSH-VERSION: 15.1.0
+ltm virtual /Common/app_vs {
+    destination /Common/10.1.0.10:443
+    pool /Common/app_pool
+}
+ltm pool /Common/app_pool {
+    members { /Common/10.9.0.9:8080 { address 10.9.0.9 } }
+}
+ltm virtual-address /Common/10.1.0.10 { address 10.1.0.10 }
+security firewall address-list /Common/webservers {
+    addresses { 10.0.0.0/24 { } }
+}
+security firewall rule-list /Common/app-rules {
+    rules {
+        allow-web {
+            action accept
+            ip-protocol tcp
+            source { address-lists { /Common/webservers } }
+        }
+    }
+}
+";
+
+fn render() -> String {
+    let sources: Vec<Source> = vec![
+        ("gtm.scf".to_string(), GTM.to_string()),
+        ("ltm.scf".to_string(), LTM.to_string()),
+    ];
+    let opts = RenderOptions {
+        embed_console: false,
+        ..RenderOptions::default()
+    };
+    build_report(&sources, &opts).expect("report renders")
+}
+
+#[test]
+fn architecture_section_renders() {
+    let html = render();
+    assert!(html.contains("class=\"architecture\""), "architecture section present");
+    assert!(html.contains("auto-detected"), "auto-detect note shown");
+    // The GTM->LTM link with its evidencing address.
+    assert!(html.contains("10.1.0.10"), "link evidence address rendered");
+}
+
+#[test]
+fn gtm_and_firewall_tabs_render() {
+    let html = render();
+    assert!(html.contains("data-panel=\"gtm\""), "GTM panel present");
+    assert!(html.contains("app.example.com"), "wide-IP shown");
+    assert!(html.contains("data-panel=\"firewall\""), "firewall panel present");
+    assert!(html.contains("app-rules"), "rule-list shown");
+}
+
+#[test]
+fn manifest_note_when_defined() {
+    let sources: Vec<Source> = vec![
+        ("gtm.scf".to_string(), GTM.to_string()),
+        ("ltm.scf".to_string(), LTM.to_string()),
+    ];
+    let opts = RenderOptions {
+        embed_console: false,
+        architecture: Some(
+            r#"{"devices":[{"match":"gtm.scf","role":"gtm","label":"DNS Edge"}]}"#.to_string(),
+        ),
+        ..RenderOptions::default()
+    };
+    let html = build_report(&sources, &opts).expect("renders");
+    assert!(html.contains("from manifest"), "manifest note shown");
+    assert!(html.contains("DNS Edge"), "manifest label applied");
+}

--- a/rust/tcl-bigip-report/tests/render_arch.rs
+++ b/rust/tcl-bigip-report/tests/render_arch.rs
@@ -93,9 +93,7 @@ fn manifest_note_when_defined() {
     ];
     let opts = RenderOptions {
         embed_console: false,
-        architecture: Some(
-            r#"{"devices":[{"match":"gtm.scf","role":"gtm","label":"DNS Edge"}]}"#.to_string(),
-        ),
+        architecture: Some("device gtm.scf -role gtm -label \"DNS Edge\"".to_string()),
         ..RenderOptions::default()
     };
     let html = build_report(&sources, &opts).expect("renders");


### PR DESCRIPTION
## Summary

This PR adds three major features to the BIG-IP report generator:

1. **Multi-device architecture layer** — When multiple configs are loaded together (e.g., GTM + LTM tier 1 + LTM tier 2), the report now auto-detects and visualizes how they relate as tiers. It does this by matching outbound targets (pool members, GTM server virtual-server destinations) against served addresses (virtual servers, virtual-addresses, GTM listeners). A new optional Tcl manifest DSL lets users explicitly declare roles, tiers, and links, which overrides and augments auto-detection. The result is rendered as an interactive Mermaid diagram and a detailed link table showing the evidence for each tier hop.

2. **GTM (BIG-IP DNS) support** — The report now projects GTM objects: wide-IPs, pools, pool members, servers, datacenters, and listeners. This surfaces the DNS load-balancing chain (wide-IP → pool → server → virtual-server destination) and enables the architecture layer to link GTM tiers to downstream LTM tiers via the server's virtual-server addresses.

3. **AFM security (firewall + NAT) support** — The report now includes firewall policies, rule-lists, address-lists, and port-lists, plus NAT policies and source/destination translations. Rules are structured to show source/destination endpoints (addresses, address-lists, ports, port-lists) and actions, giving visibility into the firewall and NAT posture alongside the load-balancing estate.

All three features integrate into the existing report model and HTML template. The architecture section only appears when multiple devices are loaded; GTM and firewall/NAT sections appear per-device when those objects are present.

## Changes

- **`rust/tcl-bigip-report/src/architecture.rs`** (new) — Core multi-device architecture logic: auto-detection via IP overlap, manifest parsing (Tcl DSL), device matching, link resolution, and Mermaid diagram generation.
- **`rust/tcl-bigip-report/src/model.rs`** — Added GTM and security object containers; new shaping functions for GTM (wideip, pool, server, datacenter, listener) and security (firewall policies/rules/lists, NAT policies/translations) objects.
- **`rust/tcl-bigip-report/src/lib.rs`** — Exported new architecture module and updated public API to include `collect_model_with_architecture`.
- **`rust/tcl-bigip-query/src/projection.rs`** — Extended projection to cover GTM and security kinds; added GTM and security object projections; updated kind tables and module routing.
- **`rust/tcl-bigip-report/templates/report.html.j2`** — Added Architecture section with device tier display, link table, and Mermaid diagram; added GTM and Firewall/NAT tabs per device.
- **`rust/bigip-report-wasm/www/index.html`** — Updated tagline and added architecture manifest UI (optional textarea for Tcl manifest input).
- **`rust/bigip-query-py/python/f5report/templates/topology.js`** — Added `initArchitecture()` to wire up interactive device node clicks in the Mermaid diagram.
- **`rust/bigip-query-py/python/f5report/templates/report.css`** — Added styles for architecture section, device tiers, links table, and Mermaid diagram.
- **Tests** — Added three new test files:
  - `rust/tcl-bigip-report/tests/architecture.rs` — Tests auto-detection, manifest parsing, tier assignment, and link resolution.
  - `rust/tcl-bigip-report/tests/gtm.rs` — Tests GTM object projection and GTM→LTM architecture linking.
  - `rust/tcl-bigip-report/tests/firewall.rs` — Tests firewall and NAT object projection.
  - `rust/tcl-bigip-report/tests/render_arch.rs` — End-to-end HTML render check for Architecture, GTM, and Firewall/NAT

https://claude.ai/code/session_01VPQqXZzWMfuVxyCe4veXFV