### PR TITLE
Fix inherited method rename to include subclass call sites

### DIFF
--- a/README.md
+++ b/README.md
@@ -1807,6 +1807,7 @@ For the complete reference, see
 | W232 | Constant string index out of range -- `string index`/`range`/`replace`/`insert` silently no-op | |
 | W240 | Loop condition is constant false -- body never executes | |
 | W241 | Loop is provably infinite -- constant-true condition with no `break`/`return` | |
+| W250 | Instantiating an `oo::abstract` class -- abstract classes have no `new`/`create`; use a concrete subclass | |
 
 ### Warnings -- Variables
 

--- a/docs/kcs/codes/README.md
+++ b/docs/kcs/codes/README.md
@@ -85,6 +85,7 @@ for historical reference.
 - [W240 — loop condition is constant false](kcs-diagnostic-w240-loop-constant-false.md)
 - [W241 — loop is provably infinite](kcs-diagnostic-w241-loop-provably-infinite.md)
 - [W242 — loop termination not provable (opt-in)](kcs-diagnostic-w242-loop-termination-unprovable.md)
+- [W250 — instantiating an abstract class](kcs-diagnostic-w250-abstract-instantiation.md)
 
 ## Security (W1xx, W3xx)
 

--- a/docs/kcs/codes/kcs-diagnostic-w250-abstract-instantiation.md
+++ b/docs/kcs/codes/kcs-diagnostic-w250-abstract-instantiation.md
@@ -1,0 +1,79 @@
+# KCS: W250 — Why does the analyser warn about instantiating this class?
+
+> **Audience:** User
+> **Type:** Issue
+
+## Applies to
+
+all-editors, diagnostic, tcloo
+
+## Profiles
+
+default
+
+## Question
+
+Why does the analyser flag `SomeClass new` / `SomeClass create obj` with
+**`W250`**?
+
+## Why
+
+The class is defined with `oo::abstract`. `TclOO`'s `oo::abstract`
+metaclass *removes* the `new` and `create` constructors from the class, so
+instantiating it directly is a runtime error:
+
+```
+cannot create object: ... is abstract
+```
+
+An abstract class exists only to be subclassed — a concrete subclass keeps
+`new` / `create` and is what you instantiate. The analyser reports `W250`
+when it can see, in the current document, that the class named in a
+`Class new …` or `Class create …` call (including the assignment shape,
+`set o [Class new …]`) was created with `oo::abstract`.
+
+It is **sound**: it only fires when the class's recorded metaclass is
+`oo::abstract`, never on the `oo::abstract create Foo { … }` definition
+itself, and never on a concrete subclass.
+
+## Example that triggers it
+
+```tcl
+oo::abstract create Shape {
+    method area {} { error "subclass must override" }
+}
+
+# W250 — Shape has no `new`/`create`.
+set s [Shape new]
+Shape create shape1
+```
+
+## Fix
+
+Instantiate a concrete subclass instead of the abstract base:
+
+```tcl
+oo::abstract create Shape {
+    method area {} { error "subclass must override" }
+}
+
+oo::class create Circle {
+    superclass Shape
+    variable r
+    constructor {radius} { set r $radius }
+    method area {} { return [expr {3.14159 * $r * $r}] }
+}
+
+# Fine — Circle is concrete.
+set s [Circle new 2]
+```
+
+## How to suppress
+
+Add `# noqa: W250` at the end of the offending line, or disable the code
+via `tclLsp.diagnostics.disabled`.
+
+## Related
+
+- [KCS codes index](README.md)
+- [TclOO support in the README](../../../README.md#tcloo-support)

--- a/rust/tcl-compiler/src/analyser/class_hierarchy.rs
+++ b/rust/tcl-compiler/src/analyser/class_hierarchy.rs
@@ -203,6 +203,18 @@ pub fn resolve_class_name<S: std::hash::BuildHasher>(
         ns = ns.rsplit_once("::").map_or(String::new(), |(head, _)| head.to_string());
     }
     // Globally-unique simple-name match (the `namespace import` case).
+    //
+    // Tradeoff (deliberate, retained): this can manufacture a *wrong* edge
+    // when `name` refers to a base that isn't in the class universe (e.g. an
+    // external/library class the index never saw) yet exactly one *unrelated*
+    // indexed class happens to share the tail — the fallback then links to
+    // that unrelated class.  We keep it because (a) it is the only thing that
+    // resolves the common `namespace import` idiom where a subclass names a
+    // namespaced base bare (the `SpiceGenTcl` `superclass Device` shape), and
+    // (b) it stays sound-by-abstention on the far more common failure mode: a
+    // tail shared by two or more indexed classes never links (returns `None`).
+    // The precondition — a globally *unique* tail that is nonetheless the
+    // wrong class — is rare in practice.  Revisit if false links surface.
     let tail = name.rsplit("::").next().unwrap_or(name);
     match tail_index.get(tail) {
         Some(qs) if qs.len() == 1 => Some(qs[0].clone()),
@@ -344,16 +356,25 @@ pub fn build_class_hierarchy<S: std::hash::BuildHasher>(
     // Build direct-subclass map.  Initialise with empty sets
     // for every class so callers see a non-None entry even when
     // a class has no subclasses.
+    //
+    // A class is a subtype of both its superclasses **and** its mixins — the
+    // MRO (and thus `is_subtype` / `method_target`) already treats a mixin as
+    // a supertype, so the subclass map must be built from both edges too, or
+    // it disagrees with `is_subtype` (asymmetrically, depending on which file
+    // a mixing-in subclass happens to live in).  Union supers + mixins here.
     let mut direct_subs: HashMap<String, HashSet<String>> = HashMap::new();
     for qname in classes.keys() {
         direct_subs.insert(qname.clone(), HashSet::new());
     }
     for qname in classes.keys() {
-        if let Some(parents) = supers_map.get(qname) {
-            for parent in parents {
-                if let Some(set) = direct_subs.get_mut(parent) {
-                    set.insert(qname.clone());
-                }
+        let parents = supers_map
+            .get(qname)
+            .into_iter()
+            .flatten()
+            .chain(mixins_map.get(qname).into_iter().flatten());
+        for parent in parents {
+            if let Some(set) = direct_subs.get_mut(parent) {
+                set.insert(qname.clone());
             }
         }
     }
@@ -512,6 +533,24 @@ mod tests {
         assert_eq!(a_subs.len(), 2);
         // Leaves have empty subclass sets, never None.
         assert!(h.subclasses["::B"].is_empty());
+    }
+
+    #[test]
+    fn mixin_recorded_as_subclass_edge() {
+        // `B` mixes `M`.  `is_subtype(B, M)` is true (the MRO places the
+        // mixin as a supertype), so the subclass map must list `B` under
+        // `M` too — otherwise the two views disagree.
+        let classes = map(vec![
+            cls("::M", &[], &[], &[]),
+            cls("::A", &[], &[], &[]),
+            cls("::B", &["::A"], &["::M"], &[]),
+        ]);
+        let h = build_class_hierarchy(classes);
+        assert!(h.is_subtype("::B", "::M"));
+        assert!(h.subclasses["::M"].contains("::B"), "{:?}", h.subclasses["::M"]);
+        assert!(h.subclasses["::A"].contains("::B"));
+        // Transitive closure agrees.
+        assert!(h.transitive_subtypes["::M"].contains("::B"));
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -286,7 +286,7 @@ fn next_dispatch_target(
         let line_start = byte_offset_at(line_index, source, line, 0);
         let cursor_in_line = cursor.saturating_sub(line_start) as usize;
         let target = word_after(source, line, cursor_in_line, "nextto")?;
-        Some(canonicalise_class(analysis, &target))
+        Some(canonicalise_class(analysis, &class_q, &target))
     } else {
         None
     };
@@ -348,18 +348,24 @@ fn word_after(source: &str, line: u32, cursor_in_line: usize, keyword: &str) -> 
     (!word.is_empty()).then_some(word)
 }
 
-/// Canonicalise a class name to the qualified form keyed in `all_classes`
-/// (adds a leading `::` when that resolves).
-fn canonicalise_class(analysis: &AnalysisResult, name: &str) -> String {
-    if analysis.all_classes.contains_key(name) {
-        return name.to_string();
-    }
-    let q = format!("::{name}");
-    if analysis.all_classes.contains_key(&q) {
-        q
-    } else {
-        name.to_string()
-    }
+/// Canonicalise a written class name to the qualified form keyed in
+/// `all_classes`, **owner-aware** — resolved relative to `owner`'s namespace
+/// (the class writing the `nextto`) via the shared [`resolve_class_name`]
+/// resolver: exact, `::name`, an outward namespace walk, then a unique tail.
+/// This lets `nextto Base` reach a namespaced base class (`::Ns::Base`) named
+/// bare from a sibling in the same namespace, instead of only matching a
+/// global `::Base`.  Falls back to the written name when nothing resolves so
+/// the caller's `next_provider` lookup simply finds no target.
+fn canonicalise_class(analysis: &AnalysisResult, owner: &str, name: &str) -> String {
+    let tail_index =
+        tcl_compiler::analyser::class_hierarchy::build_tail_index(analysis.all_classes.keys());
+    tcl_compiler::analyser::class_hierarchy::resolve_class_name(
+        name,
+        owner,
+        |cand| analysis.all_classes.contains_key(cand),
+        &tail_index,
+    )
+    .unwrap_or_else(|| name.to_string())
 }
 
 /// Detect a `$obj method ...` / `[$obj method ...]` call where
@@ -748,6 +754,20 @@ mod tests {
         assert_eq!(locs.len(), 1, "{locs:?}");
         assert_eq!(locs[0].start_line, 1, "should land on A::greet");
         assert_eq!(locs[0].start_character, 11);
+    }
+
+    #[test]
+    fn jump_to_nextto_namespaced_class_method() {
+        // `nextto A` names a namespaced sibling bare from within `::Ns::C`.
+        // Owner-aware canonicalisation resolves it to `::Ns::A` (previously
+        // only a global `::A` would have matched, so this produced nothing).
+        let src = "namespace eval Ns {\n    oo::class create A {\n        method greet {} { return hi }\n    }\n    oo::class create B {\n        superclass A\n        method greet {} { next }\n    }\n    oo::class create C {\n        superclass B\n        method greet {} { nextto A }\n    }\n}\n";
+        let analysis = analyse(src);
+        // Cursor on `nextto` inside C::greet (line 10).
+        let locs = definition(src, 10, 28, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        // ::Ns::A::greet's name token is on line 2.
+        assert_eq!(locs[0].start_line, 2, "should land on ::Ns::A::greet");
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -376,11 +376,27 @@ fn build_member_ranges(
     out
 }
 
+/// Every method / classmethod / constructor / destructor body span of `cd`
+/// — the regions re-segmented for intra-class `my <member>` call sites.
+fn collect_member_bodies(cd: &tcl_compiler::analyser::types::ClassDef) -> Vec<tcl_lexer::Span> {
+    let mut bodies: Vec<tcl_lexer::Span> = cd
+        .methods
+        .values()
+        .map(|m| m.body_span)
+        .chain(cd.class_methods.values().map(|m| m.body_span))
+        .chain(cd.constructors.iter().map(|c| c.body_span))
+        .collect();
+    if let Some(d) = &cd.destructor {
+        bodies.push(d.body_span);
+    }
+    bodies
+}
+
 /// Resolve a method's declaration span plus every call site —
-/// intra-class (re-segment the class's own method bodies) and
-/// external (`$obj method` across the document).  Returns
-/// `None` when `class_q` has no method / classmethod named
-/// `method`.
+/// intra-class (re-segment the class's own method bodies plus any
+/// inheriting subclass's bodies) and external (`$obj method` across the
+/// document).  Returns `None` when `class_q` has no method / classmethod
+/// named `method`.
 pub(crate) fn method_references_for_class(
     source: &str,
     dialect: &str,
@@ -398,17 +414,24 @@ pub(crate) fn method_references_for_class(
         .or_else(|| class_def.class_methods.get(method).map(|m| m.name_span))?;
 
     let mut call_spans: Vec<Span> = Vec::new();
-    // Intra-class: re-segment every method / classmethod /
-    // ctor / dtor body for bare `method` invocations.
-    let mut bodies: Vec<Span> = class_def
-        .methods
-        .values()
-        .map(|m| m.body_span)
-        .chain(class_def.class_methods.values().map(|m| m.body_span))
-        .chain(class_def.constructors.iter().map(|c| c.body_span))
-        .collect();
-    if let Some(d) = &class_def.destructor {
-        bodies.push(d.body_span);
+    // Intra-class `my method` dispatch: re-segment every method / classmethod
+    // / ctor / dtor body for `my method` invocations.  Scan `class_q`'s own
+    // bodies **and** the bodies of every subclass that *inherits* this
+    // definition — a class whose MRO resolves `method` to `class_q` (i.e. it
+    // does not override).  A pure inheritor is not itself a rename family
+    // member (it declares no copy of `method`), but its `my method` calls
+    // dispatch to `class_q`'s definition, so they must rename with it;
+    // omitting them left those call sites pointing at the old name.  A
+    // subclass that *overrides* `method` resolves to itself, not `class_q`,
+    // so its bodies are handled under its own family entry — never here.
+    let hierarchy = analysis.class_hierarchy();
+    let mut bodies: Vec<Span> = collect_member_bodies(class_def);
+    for (other_q, other_cd) in &analysis.all_classes {
+        if other_q.as_str() != class_q
+            && hierarchy.method_target(other_q, method) == Some(class_q)
+        {
+            bodies.extend(collect_member_bodies(other_cd));
+        }
     }
     for body_span in bodies {
         if body_span.is_empty() {
@@ -496,16 +519,7 @@ fn find_class_member_references(
         // Collect call-site spans by re-segmenting every
         // method body (the analyser doesn't walk into method
         // bodies for the `command_invocations` collection).
-        let mut bodies: Vec<Span> = class_def
-            .methods
-            .values()
-            .map(|m| m.body_span)
-            .chain(class_def.class_methods.values().map(|m| m.body_span))
-            .chain(class_def.constructors.iter().map(|c| c.body_span))
-            .collect();
-        if let Some(d) = &class_def.destructor {
-            bodies.push(d.body_span);
-        }
+        let bodies: Vec<Span> = collect_member_bodies(class_def);
         let mut call_spans: Vec<Span> = Vec::new();
         for body_span in bodies {
             if body_span.is_empty() {
@@ -606,11 +620,22 @@ pub(crate) fn find_obj_method_call_sites(
     class_q: &str,
     method: &str,
 ) -> Vec<tcl_lexer::Span> {
-    // Variables of the target class.
+    // Variables whose `$obj method` dispatch resolves to `class_q`'s copy of
+    // `method` — its own instances **plus** instances of any subclass that
+    // *inherits* this definition (the subclass's MRO resolves `method` to
+    // `class_q`).  An exact-class-equality filter dropped the inheriting-
+    // subclass sites, silently leaving them pointing at the old name after an
+    // inherited-method rename.  A subclass that *overrides* `method` resolves
+    // to itself, so its instances are excluded here and rewritten under that
+    // subclass's own family entry — each site is attributed to exactly one
+    // family member (no double count).
+    let hierarchy = analysis.class_hierarchy();
     let var_set: FxHashSet<&str> = analysis
         .instance_classes
         .iter()
-        .filter(|(_, c)| c.as_str() == class_q)
+        .filter(|(_, c)| {
+            c.as_str() == class_q || hierarchy.method_target(c, method) == Some(class_q)
+        })
         .map(|(v, _)| v.as_str())
         .collect();
     if var_set.is_empty() {

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -404,7 +404,6 @@ pub(crate) fn method_references_for_class(
     class_q: &str,
     method: &str,
 ) -> Option<(tcl_lexer::Span, Vec<tcl_lexer::Span>)> {
-    use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
     use tcl_lexer::Span;
     let class_def = analysis.all_classes.get(class_q)?;
     let decl_span = class_def
@@ -433,7 +432,40 @@ pub(crate) fn method_references_for_class(
             bodies.extend(collect_member_bodies(other_cd));
         }
     }
-    for body_span in bodies {
+    call_spans.extend(scan_my_method_sites(
+        source,
+        dialect,
+        &bodies,
+        method,
+        Some(decl_span),
+    ));
+    // External `$obj method` sites.
+    call_spans.extend(find_obj_method_call_sites(
+        source, dialect, analysis, class_q, method,
+    ));
+    Some((decl_span, call_spans))
+}
+
+/// Re-segment each brace-delimited body span in `bodies` and return the
+/// name-token span of every `my <method>` invocation whose method name is
+/// `method`, skipping the token at `skip` (the declaration site, when the
+/// scanned class declares `method`).
+///
+/// Intra-class dispatch of a `TclOO` method is `my <method>` — the method
+/// name is argv[1], not the command head.  A bare head equal to the method
+/// name is *not* a call (a `TclOO` method is not a command in the body's
+/// namespace; `<method> …` without `my`/an object errors "invalid command
+/// name"), so only `my`-headed sites match.
+fn scan_my_method_sites(
+    source: &str,
+    dialect: &str,
+    bodies: &[tcl_lexer::Span],
+    method: &str,
+    skip: Option<tcl_lexer::Span>,
+) -> Vec<tcl_lexer::Span> {
+    use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
+    let mut out: Vec<tcl_lexer::Span> = Vec::new();
+    for &body_span in bodies {
         if body_span.is_empty() {
             continue;
         }
@@ -455,12 +487,6 @@ pub(crate) fn method_references_for_class(
             tcl_lexer::LexerConfig::for_dialect(dialect),
         );
         for cmd in &commands {
-            // Intra-class method dispatch is `my <method>`: the method name is
-            // argv[1], not the command head. A bare head equal to the method
-            // name is NOT a call — a TclOO method is not a command in the
-            // body's namespace, so `<method> …` without `my`/an object errors
-            // with "invalid command name". (External `$obj method` sites are
-            // appended separately below.)
             let Some(head) = cmd.argv.first() else {
                 continue;
             };
@@ -477,16 +503,39 @@ pub(crate) fn method_references_for_class(
             if n_start >= source.len() || n_end > source.len() {
                 continue;
             }
-            if &source[n_start..n_end] == method && name_tok.span != decl_span {
-                call_spans.push(name_tok.span);
+            if &source[n_start..n_end] == method && Some(name_tok.span) != skip {
+                out.push(name_tok.span);
             }
         }
     }
-    // External `$obj method` sites.
-    call_spans.extend(find_obj_method_call_sites(
-        source, dialect, analysis, class_q, method,
-    ));
-    Some((decl_span, call_spans))
+    out
+}
+
+/// Call sites of an **inherited** `method` inside `class_q`, a class that
+/// does *not* declare `method` itself but inherits it (its MRO resolves
+/// `method` to an ancestor).  Returns the intra-class `my method` sites in
+/// `class_q`'s own bodies plus the external `$obj method` sites for its
+/// instances — no declaration span (there is none in this class).
+///
+/// This is the same-document scan a purely-inheriting subclass needs when it
+/// lives in a *different* file from the method's definer: the cross-file
+/// rename opens the subclass's document and collects these sites so an
+/// inherited-method rename doesn't leave them pointing at the old name.
+#[must_use]
+pub(crate) fn inherited_method_call_sites(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    class_q: &str,
+    method: &str,
+) -> Vec<tcl_lexer::Span> {
+    let Some(class_def) = analysis.all_classes.get(class_q) else {
+        return Vec::new();
+    };
+    let bodies = collect_member_bodies(class_def);
+    let mut spans = scan_my_method_sites(source, dialect, &bodies, method, None);
+    spans.extend(find_obj_method_call_sites(source, dialect, analysis, class_q, method));
+    spans
 }
 
 /// Find a class member's declaration span plus every call

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -491,6 +491,27 @@ pub fn method_spans_in_document(
     }
 }
 
+/// Every span that renaming `method` must rewrite **within `source`** for a
+/// class `class_q` that *inherits* `method` (does not declare it): its
+/// intra-class `my method` calls and external `$obj method` sites, with no
+/// declaration span.  Empty when `class_q` is not defined in this document.
+///
+/// The server calls this for documents that contain a purely-inheriting
+/// subclass of a rename family member but no definer of their own — the
+/// cross-file complement to [`method_spans_in_document`], so an
+/// inherited-method rename reaches `my method` / `$obj method` sites that
+/// live in a subclass-only file.
+#[must_use]
+pub fn inherited_method_spans_in_document(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    class_q: &str,
+    method: &str,
+) -> Vec<tcl_lexer::Span> {
+    crate::references::inherited_method_call_sites(source, dialect, analysis, class_q, method)
+}
+
 /// The set of classes whose definition of `method` must be renamed
 /// together with `seed_class`'s: every class that **directly defines**
 /// `method` and sits in the same override-connected component as

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -811,39 +811,30 @@ fn rename_method(
         for span in body_spans {
             scan_body_for_method_calls(scan_ctx, span, &mut edits);
         }
-        // Append external `$obj method` call sites for
-        // methods / classmethods (not properties).
+        // Methods / classmethods (not properties — those aren't dispatched
+        // through the MRO) are one polymorphic name across the whole override
+        // family: a method (re)defined by a super- or sub-class renames as a
+        // unit.  For every family member — **including the class under the
+        // cursor** — pull its declaration, intra-class `my method` sites (its
+        // own bodies *and* any purely-inheriting subclass's), and external
+        // `$obj method` sites via the shared resolver.  Routing the cursor
+        // class through it too (rather than an ad-hoc self-only scan) is what
+        // catches an inheriting subclass's `my method` / `$obj method` sites
+        // when renaming from the base declaration.
         if class_def.methods.contains_key(word) || class_def.class_methods.contains_key(word) {
-            for span in crate::references::find_obj_method_call_sites(
-                source,
-                dialect,
-                analysis,
-                &class_def.qualified_name,
-                word,
-            ) {
-                edits.push(TextEdit {
-                    range: span_to_range(source, line_index, span),
-                    new_text: new_name.to_owned(),
-                });
-            }
-            // Override family: a method (re)defined by a super- or
-            // sub-class is one polymorphic name — rename every other
-            // class in the connected component that defines it, plus
-            // each of those classes' own call sites.  (Properties are
-            // excluded: they aren't dispatched through the MRO.)
             for member in override_family(analysis, &class_def.qualified_name, word) {
-                if member == class_def.qualified_name {
-                    continue;
-                }
                 let Some((decl_span, call_spans)) = crate::references::method_references_for_class(
                     source, dialect, analysis, &member, word,
                 ) else {
                     continue;
                 };
-                edits.push(TextEdit {
-                    range: span_to_range(source, line_index, decl_span),
-                    new_text: new_name.to_owned(),
-                });
+                // The cursor class's own declaration edit is already queued.
+                if member != class_def.qualified_name {
+                    edits.push(TextEdit {
+                        range: span_to_range(source, line_index, decl_span),
+                        new_text: new_name.to_owned(),
+                    });
+                }
                 for span in call_spans {
                     edits.push(TextEdit {
                         range: span_to_range(source, line_index, span),
@@ -1817,6 +1808,55 @@ mod tests {
         assert!(
             lines.contains(&1),
             "expected base Animal::speak decl (l1) renamed; got {edits:?}",
+        );
+    }
+
+    #[test]
+    fn rename_inherited_method_rewrites_subclass_instance_obj_sites() {
+        // Renaming an inherited method from the *base declaration* must also
+        // rewrite `$d method` sites where `$d` is an instance of a subclass
+        // that inherits (does not override) it — the exact-class-equality
+        // filter used to drop these, leaving them pointing at the old name.
+        let src = "oo::class create Animal {\n\
+                       method speak {} { return x }\n\
+                   }\n\
+                   oo::class create Dog {\n\
+                       superclass Animal\n\
+                   }\n\
+                   set d [Dog new]\n\
+                   $d speak\n";
+        let analysis = analyse(src);
+        // Cursor on `speak` in Animal's declaration (line 1 col 11).
+        let edits = rename(src, "tcl", 1, 11, "vocalise", &analysis, None);
+        assert!(edits.iter().all(|e| e.new_text == "vocalise"));
+        let lines: Vec<u32> = edits.iter().map(|e| e.range.start_line).collect();
+        assert!(
+            lines.contains(&1) && lines.contains(&7),
+            "expected decl (l1) + inheriting-subclass instance site (l7); got {edits:?}",
+        );
+    }
+
+    #[test]
+    fn rename_inherited_method_rewrites_pure_inheritor_my_sites() {
+        // A subclass that inherits `speak` (no override) calls `my speak`
+        // from one of its own method bodies.  That call dispatches to the
+        // base definition, so renaming the base must rewrite it — even
+        // though the subclass is not itself a rename family member.
+        let src = "oo::class create Animal {\n\
+                       method speak {} { return x }\n\
+                   }\n\
+                   oo::class create Dog {\n\
+                       superclass Animal\n\
+                       method describe {} { my speak }\n\
+                   }\n";
+        let analysis = analyse(src);
+        // Cursor on `speak` in Animal's declaration (line 1 col 11).
+        let edits = rename(src, "tcl", 1, 11, "vocalise", &analysis, None);
+        assert!(edits.iter().all(|e| e.new_text == "vocalise"));
+        let lines: Vec<u32> = edits.iter().map(|e| e.range.start_line).collect();
+        assert!(
+            lines.contains(&1) && lines.contains(&5),
+            "expected decl (l1) + `my speak` in inheriting subclass (l5); got {edits:?}",
         );
     }
 }

--- a/rust/tcl-lsp-core/src/type_hierarchy.rs
+++ b/rust/tcl-lsp-core/src/type_hierarchy.rs
@@ -24,9 +24,10 @@
 //! analysed document; cross-file super/subtypes need the workspace index
 //! (a follow-up).
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use tcl_compiler::analyser::AnalysisResult;
+use tcl_compiler::analyser::class_hierarchy::{build_tail_index, resolve_class_name};
 use tcl_compiler::analyser::types::ClassDef;
 use tcl_lexer::LineIndex;
 
@@ -78,13 +79,22 @@ pub fn prepare(
 #[must_use]
 pub fn supertypes(class_name: &str, source: &str, analysis: &AnalysisResult) -> Vec<TypeHierarchyItem> {
     let line_index = LineIndex::new(source);
-    let Some(cd) = resolve_class(class_name, analysis) else {
+    let tail_index = build_tail_index(analysis.all_classes.keys());
+    let Some(cd) = resolve_class(class_name, "", analysis, &tail_index) else {
         return Vec::new();
     };
+    // Each written super/mixin name is resolved **owner-aware** — relative to
+    // the defining class's namespace (ancestry → global → unique tail) — so a
+    // bare `superclass Base` naming a namespaced class links the same way the
+    // MRO builder linked it, instead of abstaining whenever the tail isn't
+    // globally unique.  A name that resolves back to the class itself (a self
+    // edge a tail match could otherwise manufacture) is never listed.
+    let owner = cd.qualified_name.clone();
     let mut out = Vec::new();
     let mut seen = HashSet::new();
     for name in cd.superclasses.iter().chain(cd.mixins.iter()) {
-        if let Some(target) = resolve_class(name, analysis)
+        if let Some(target) = resolve_class(name, &owner, analysis, &tail_index)
+            && target.qualified_name != owner
             && seen.insert(target.qualified_name.clone())
         {
             out.push(item_for(target, source, &line_index));
@@ -99,7 +109,8 @@ pub fn supertypes(class_name: &str, source: &str, analysis: &AnalysisResult) -> 
 #[must_use]
 pub fn subtypes(class_name: &str, source: &str, analysis: &AnalysisResult) -> Vec<TypeHierarchyItem> {
     let line_index = LineIndex::new(source);
-    let Some(cd) = resolve_class(class_name, analysis) else {
+    let tail_index = build_tail_index(analysis.all_classes.keys());
+    let Some(cd) = resolve_class(class_name, "", analysis, &tail_index) else {
         return Vec::new();
     };
     let target = cd.qualified_name.clone();
@@ -116,23 +127,26 @@ pub fn subtypes(class_name: &str, source: &str, analysis: &AnalysisResult) -> Ve
         .collect()
 }
 
-/// Resolve a class name to its `ClassDef` in the analysed document —
-/// exact, `::name`, or a unique simple-name (tail) match.
-fn resolve_class<'a>(name: &str, analysis: &'a AnalysisResult) -> Option<&'a ClassDef> {
-    if let Some(cd) = analysis.all_classes.get(name) {
-        return Some(cd);
-    }
-    let q = format!("::{}", name.trim_start_matches("::"));
-    if let Some(cd) = analysis.all_classes.get(&q) {
-        return Some(cd);
-    }
-    let tail = name.rsplit("::").next().unwrap_or(name);
-    let mut it = analysis
-        .all_classes
-        .values()
-        .filter(|cd| cd.qualified_name.rsplit("::").next() == Some(tail));
-    let first = it.next()?;
-    it.next().is_none().then_some(first)
+/// Resolve a written class `name` to its `ClassDef`, **owner-aware** via the
+/// shared [`resolve_class_name`] resolver: an exact hit, then `::name`, then a
+/// walk outward from `owner`'s namespace to the global namespace, and finally
+/// a *globally-unique* simple-name (tail) match.  `owner` is the qualified
+/// name of the class in whose body `name` was written (`""` for a top-level /
+/// already-qualified lookup).  Mirrors how the MRO builder linked the edge,
+/// so supertype resolution no longer abstains on tails the hierarchy resolves.
+fn resolve_class<'a>(
+    name: &str,
+    owner: &str,
+    analysis: &'a AnalysisResult,
+    tail_index: &HashMap<String, Vec<String>>,
+) -> Option<&'a ClassDef> {
+    let q = resolve_class_name(
+        name,
+        owner,
+        |cand| analysis.all_classes.contains_key(cand),
+        tail_index,
+    )?;
+    analysis.all_classes.get(&q)
 }
 
 /// Build a hierarchy item for `class_def` from its spans in `source`.
@@ -208,5 +222,28 @@ mod tests {
     fn supertypes_of_unknown_class_is_empty() {
         let analysis = analyse("oo::class create A {}\n");
         assert!(supertypes("::Nope", "oo::class create A {}\n", &analysis).is_empty());
+    }
+
+    #[test]
+    fn supertypes_resolve_bare_namespaced_base_owner_aware() {
+        // A subclass in `::Ns` names its base bare (`Base`); the base lives at
+        // `::Ns::Base`.  Ownerless tail resolution used to abstain here; the
+        // owner-aware resolver links it the way the MRO builder did.
+        let src = "namespace eval Ns {\n    oo::class create Base {}\n    oo::class create Sub {\n        superclass Base\n    }\n}\n";
+        let analysis = analyse(src);
+        let sup = supertypes("::Ns::Sub", src, &analysis);
+        let names: Vec<&str> = sup.iter().map(|i| i.name.as_str()).collect();
+        assert_eq!(names, vec!["::Ns::Base"], "{names:?}");
+    }
+
+    #[test]
+    fn supertypes_never_lists_the_class_itself() {
+        // A class whose own tail collides with a bare superclass name must not
+        // be reported as its own supertype.
+        let src = "oo::class create Base {}\noo::class create Derived {\n    superclass Base\n}\n";
+        let analysis = analyse(src);
+        for name in supertypes("::Derived", src, &analysis) {
+            assert_ne!(name.name, "::Derived", "self-supertype leaked");
+        }
     }
 }

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -336,6 +336,97 @@ impl WorkspaceIndex {
         seed_class: &str,
         method: &str,
     ) -> Vec<&'a WorkspaceClass> {
+        let family = self.method_family_qnames(seed_class, method);
+        let family_set: std::collections::HashSet<&str> =
+            family.iter().map(String::as_str).collect();
+        self.classes
+            .iter()
+            .filter(|c| family_set.contains(c.qualified_name.as_str()))
+            .collect()
+    }
+
+    /// Indexed classes that **inherit** `method` from the override family of
+    /// `(seed_class, method)` but do not define it themselves — the pure
+    /// inheritors whose `my method` / `$obj method` sites a rename must also
+    /// rewrite, even though they contribute no declaration.
+    ///
+    /// A class is included only when it inherits `method` (some ancestor
+    /// defines it) **and every** method-defining ancestor it can reach is in
+    /// the family.  That keeps the result sound under multiple inheritance:
+    /// if a class could resolve `method` to a definer *outside* the family
+    /// (a disjoint same-named method), it is abstained on rather than risk an
+    /// over-rename.  The workspace index carries ancestry but not a full
+    /// cross-file MRO, so this is deliberately conservative.
+    #[must_use]
+    pub fn method_inheritor_classes<'a>(
+        &'a self,
+        seed_class: &str,
+        method: &str,
+    ) -> Vec<&'a WorkspaceClass> {
+        let family = self.method_family_qnames(seed_class, method);
+        if family.is_empty() {
+            return Vec::new();
+        }
+        let family_set: std::collections::HashSet<&str> =
+            family.iter().map(String::as_str).collect();
+        let (known, tail_index) = self.class_name_universe();
+        let parents = |qname: &str| -> Vec<String> {
+            self.classes
+                .iter()
+                .find(|c| c.qualified_name == qname)
+                .map(|c| {
+                    c.superclasses
+                        .iter()
+                        .chain(c.mixins.iter())
+                        .filter_map(|s| {
+                            resolve_class_name(s, qname, |cand| known.contains(cand), &tail_index)
+                        })
+                        .collect()
+                })
+                .unwrap_or_default()
+        };
+        let defines = |qname: &str| {
+            self.classes
+                .iter()
+                .any(|c| c.qualified_name == qname && c.defined_methods.iter().any(|m| m == method))
+        };
+        self.classes
+            .iter()
+            .filter(|c| {
+                // A definer is handled by the family itself, not here.
+                if c.defined_methods.iter().any(|m| m == method)
+                    || family_set.contains(c.qualified_name.as_str())
+                {
+                    return false;
+                }
+                // Every method-defining ancestor this class can reach.
+                let mut stack = parents(&c.qualified_name);
+                let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+                let mut defining_ancestors: Vec<String> = Vec::new();
+                while let Some(p) = stack.pop() {
+                    if seen.insert(p.clone()) {
+                        if defines(&p) {
+                            defining_ancestors.push(p.clone());
+                        }
+                        stack.extend(parents(&p));
+                    }
+                }
+                // Inherits `method` (has a definer ancestor) and cannot resolve
+                // it to a definer outside the family.
+                !defining_ancestors.is_empty()
+                    && defining_ancestors.iter().all(|a| family_set.contains(a.as_str()))
+            })
+            .collect()
+    }
+
+    /// The qualified names of the override family of `(seed_class, method)`:
+    /// every indexed class that directly defines `method` and sits in the
+    /// same subtype-connected component as `seed_class` (or the ancestor that
+    /// provides `method` to it).  Shared by [`Self::method_override_family`]
+    /// and [`Self::method_inheritor_classes`].  Empty when `method` is neither
+    /// defined nor inherited from any indexed class reachable from
+    /// `seed_class`.
+    fn method_family_qnames(&self, seed_class: &str, method: &str) -> Vec<String> {
         let (known, tail_index) = self.class_name_universe();
         // Owner-aware direct parents (superclasses + mixins) of each class.
         let parents = |qname: &str| -> Vec<String> {
@@ -423,12 +514,7 @@ impl WorkspaceIndex {
                 }
             }
         }
-        let family_set: std::collections::HashSet<&str> =
-            family.iter().map(String::as_str).collect();
-        self.classes
-            .iter()
-            .filter(|c| family_set.contains(c.qualified_name.as_str()))
-            .collect()
+        family
     }
 
     /// Procs whose simple *or* qualified name starts with
@@ -650,6 +736,60 @@ mod tests {
             .map(|wc| wc.qualified_name.as_str())
             .collect();
         assert!(fam2.contains(&"::Animal") && fam2.contains(&"::Dog"), "{fam2:?}");
+    }
+
+    #[test]
+    fn cross_file_method_inheritor_classes() {
+        // Base `speak` in a.tcl; a purely-inheriting Dog (no override) in
+        // b.tcl; an unrelated Engine::speak hierarchy with its own inheritor
+        // Car in c.tcl/d.tcl.  Seeding from Animal, Dog is an inheritor and
+        // Car (disjoint hierarchy) is not.
+        let animal = analyse("oo::class create Animal {\n    method speak {} {}\n}\n");
+        let dog = analyse("oo::class create Dog {\n    superclass Animal\n    method describe {} { my speak }\n}\n");
+        let engine = analyse("oo::class create Engine {\n    method speak {} {}\n}\n");
+        let car = analyse("oo::class create Car {\n    superclass Engine\n}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &animal),
+            ("file:///b.tcl", &dog),
+            ("file:///c.tcl", &engine),
+            ("file:///d.tcl", &car),
+        ]);
+        let inheritors: Vec<&str> = index
+            .method_inheritor_classes("::Animal", "speak")
+            .iter()
+            .map(|wc| wc.qualified_name.as_str())
+            .collect();
+        assert_eq!(inheritors, vec!["::Dog"], "{inheritors:?}");
+        // A definer is never returned as an inheritor.
+        assert!(
+            !index
+                .method_inheritor_classes("::Animal", "speak")
+                .iter()
+                .any(|wc| wc.qualified_name == "::Animal"),
+        );
+    }
+
+    #[test]
+    fn method_inheritor_abstains_on_disjoint_definer_ancestor() {
+        // A class that multiply-inherits from two unrelated definers of the
+        // same method could resolve to either; the family seeded from only one
+        // must NOT claim it (sound abstention, no over-rename).
+        let a = analyse("oo::class create A {\n    method run {} {}\n}\n");
+        let b = analyse("oo::class create B {\n    method run {} {}\n}\n");
+        let both = analyse("oo::class create Both {\n    superclass A B\n}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///both.tcl", &both),
+        ]);
+        // Family seeded from A does not include B, so `Both` (which can reach
+        // B::run too) is abstained on.
+        assert!(
+            index
+                .method_inheritor_classes("::A", "run")
+                .is_empty(),
+            "must abstain when an out-of-family definer ancestor exists",
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1988,6 +1988,55 @@ impl Backend {
         Some(DocumentState::new(text, dialect))
     }
 
+    /// Cross-file super/subtype targets for the type-hierarchy walk, resolved
+    /// against the workspace class index.  Each entry is
+    /// `(document-uri, qualified-name, name-span)` for a class defined in some
+    /// (possibly other) document.
+    ///
+    /// For **subtypes**, the index resolves every class declaring `class_name`
+    /// as a direct owner-aware superclass/mixin.  For **supertypes**, the
+    /// written super/mixin names are read from the definition matching
+    /// `selected_uri` (the class under the cursor), so a homonymous `::C` in
+    /// an unrelated file can't contribute its own parents and the result is
+    /// deterministic; the union over every homonym is used only as a fallback
+    /// when the selected document isn't indexed.
+    async fn cross_hierarchy_targets(
+        &self,
+        subtypes: bool,
+        class_name: &str,
+        selected_uri: &str,
+    ) -> Vec<(String, String, tcl_lexer::Span)> {
+        let index = self.workspace_index.read().await;
+        let list = if subtypes {
+            index.subclasses_of(class_name)
+        } else {
+            let selected: Vec<&core_workspace_index::WorkspaceClass> = index
+                .classes_named(class_name)
+                .into_iter()
+                .filter(|c| c.uri == selected_uri)
+                .collect();
+            let definitions = if selected.is_empty() {
+                index.classes_named(class_name)
+            } else {
+                selected
+            };
+            let mut acc: Vec<&core_workspace_index::WorkspaceClass> = Vec::new();
+            let mut seen_super: std::collections::HashSet<String> =
+                std::collections::HashSet::new();
+            for c in definitions {
+                for s in index.supertype_classes(c) {
+                    if seen_super.insert(s.qualified_name.clone()) {
+                        acc.push(s);
+                    }
+                }
+            }
+            acc
+        };
+        list.into_iter()
+            .map(|c| (c.uri.clone(), c.qualified_name.clone(), c.name_span))
+            .collect()
+    }
+
     /// Shared supertype (`subtypes = false`) / subtype (`subtypes = true`)
     /// walk for one type-hierarchy item, resolving against the item's
     /// document.  Returns an empty list (not an error) when the document or
@@ -2041,34 +2090,9 @@ impl Backend {
         let mut seen: std::collections::HashSet<String> =
             lifted.iter().map(|i| i.name.clone()).collect();
         seen.insert(class_name.clone());
-        let targets: Vec<(String, String, tcl_lexer::Span)> = {
-            let index = self.workspace_index.read().await;
-            let list = if subtypes {
-                index.subclasses_of(&class_name)
-            } else {
-                // Owner-aware: resolve each written super/mixin name relative
-                // to the defining class's namespace (never a bare global tail
-                // guess) via the index's `supertype_classes`.  A class name
-                // can be defined in more than one indexed document; union the
-                // supertypes of **every** matching definition rather than
-                // picking an arbitrary `.first()` (whose choice — and thus the
-                // reported supertypes — depended on index insertion order).
-                let mut acc: Vec<&core_workspace_index::WorkspaceClass> = Vec::new();
-                let mut seen_super: std::collections::HashSet<String> =
-                    std::collections::HashSet::new();
-                for c in index.classes_named(&class_name) {
-                    for s in index.supertype_classes(c) {
-                        if seen_super.insert(s.qualified_name.clone()) {
-                            acc.push(s);
-                        }
-                    }
-                }
-                acc
-            };
-            list.into_iter()
-                .map(|c| (c.uri.clone(), c.qualified_name.clone(), c.name_span))
-                .collect()
-        };
+        let targets = self
+            .cross_hierarchy_targets(subtypes, &class_name, uri.as_str())
+            .await;
         for (turi, qname, name_span) in targets {
             if !seen.insert(qname.clone()) {
                 continue;
@@ -2537,11 +2561,15 @@ impl Backend {
     /// indexed yet, so the caller can fall back to the single-document
     /// path).
     ///
-    /// Soundness is bounded by the analyser's single-document instance
-    /// tracking: a `$obj method` site is only rewritten in a document that
-    /// also *defines* the family class (the same constraint under which the
-    /// site is resolvable at all), so no unresolved site is silently left
-    /// pointing at the old name that the analysis could have caught.
+    /// Coverage is bounded by the analyser's single-document instance
+    /// tracking: a `$obj method` site is only rewritten in a document the
+    /// index knows defines or inherits the family class (the same constraint
+    /// under which the site is resolvable at all), so no unresolved site is
+    /// silently left pointing at the old name that the analysis could have
+    /// caught.  Documents holding a purely-inheriting subclass (a family
+    /// member's descendant that doesn't override the method) are visited too,
+    /// so their `my method` / `$obj method` sites are not missed just because
+    /// the subclass lives in a different file from the definer.
     async fn cross_file_method_rename(
         &self,
         seed_class: &str,
@@ -2550,17 +2578,23 @@ impl Backend {
     ) -> std::collections::HashMap<Uri, Vec<TextEdit>> {
         let mut changes: std::collections::HashMap<Uri, Vec<TextEdit>> =
             std::collections::HashMap::new();
-        // Family member classes grouped by defining document.
-        let by_uri: std::collections::HashMap<String, Vec<String>> = {
+        // Classes grouped by document: the override-family definers (whose
+        // declaration + call sites rename) and the pure inheritors (whose
+        // `my method` / `$obj method` sites rename, but which declare no copy
+        // of the method).  A document may contribute either or both.
+        let by_uri: std::collections::HashMap<String, (Vec<String>, Vec<String>)> = {
             let index = self.workspace_index.read().await;
-            let mut m: std::collections::HashMap<String, Vec<String>> =
+            let mut m: std::collections::HashMap<String, (Vec<String>, Vec<String>)> =
                 std::collections::HashMap::new();
             for wc in index.method_override_family(seed_class, method) {
-                m.entry(wc.uri.clone()).or_default().push(wc.qualified_name.clone());
+                m.entry(wc.uri.clone()).or_default().0.push(wc.qualified_name.clone());
+            }
+            for wc in index.method_inheritor_classes(seed_class, method) {
+                m.entry(wc.uri.clone()).or_default().1.push(wc.qualified_name.clone());
             }
             m
         };
-        for (u, classes) in by_uri {
+        for (u, (definers, inheritors)) in by_uri {
             let Ok(parsed) = Uri::from_str(&u) else {
                 continue;
             };
@@ -2575,8 +2609,17 @@ impl Backend {
             let method_owned = method.to_owned();
             let spans: Vec<tcl_lexer::Span> = tokio::task::spawn_blocking(move || {
                 let mut all: Vec<tcl_lexer::Span> = Vec::new();
-                for cq in &classes {
+                for cq in &definers {
                     all.extend(core_rename::method_spans_in_document(
+                        &src,
+                        &dialect,
+                        &analysis,
+                        cq,
+                        &method_owned,
+                    ));
+                }
+                for cq in &inheritors {
+                    all.extend(core_rename::inherited_method_spans_in_document(
                         &src,
                         &dialect,
                         &analysis,
@@ -13450,6 +13493,48 @@ mod tests {
         assert!(
             dog_lines.contains(&2) && dog_lines.contains(&5),
             "expected override decl (l2) + call site (l5) in dog.tcl; got {:?}",
+            changes[&dog],
+        );
+    }
+
+    #[tokio::test]
+    async fn method_rename_reaches_subclass_only_document() {
+        // Animal::speak in animal.tcl; Dog *inherits* speak (no override) in
+        // dog.tcl and calls it via `my speak` and `$d speak`.  dog.tcl holds
+        // no definer, so the family-only pass never opened it; the inheritor
+        // pass must, or those sites silently keep the old name.
+        let backend = test_backend();
+        let animal = Uri::from_str("file:///animal.tcl").unwrap();
+        let dog = Uri::from_str("file:///dog.tcl").unwrap();
+        register(&backend, &animal, "oo::class create Animal {\n    method speak {} {}\n}\n").await;
+        register(
+            &backend,
+            &dog,
+            "oo::class create Dog {\n    superclass Animal\n    method describe {} { my speak }\n}\nset d [Dog new]\n$d speak\n",
+        )
+        .await;
+        let params = RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri: animal.clone() },
+                position: Position::new(1, 11), // on `speak` in Animal's decl
+            },
+            new_name: "vocalise".to_owned(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+        let edit = backend.rename(params).await.expect("ok").expect("some");
+        let changes = edit.changes.expect("changes");
+        assert!(changes.contains_key(&animal), "base doc edits missing: {changes:?}");
+        assert!(
+            changes.contains_key(&dog),
+            "subclass-only doc edits missing: {changes:?}",
+        );
+        assert!(changes.values().flatten().all(|e| e.new_text == "vocalise"));
+        // dog.tcl: `my speak` (line 2) + `$d speak` (line 5) rewritten; there
+        // is no declaration to rewrite in this file.
+        let dog_lines: Vec<u32> = changes[&dog].iter().map(|e| e.range.start.line).collect();
+        assert!(
+            dog_lines.contains(&2) && dog_lines.contains(&5),
+            "expected `my speak` (l2) + `$d speak` (l5) in dog.tcl; got {:?}",
             changes[&dog],
         );
     }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2048,12 +2048,22 @@ impl Backend {
             } else {
                 // Owner-aware: resolve each written super/mixin name relative
                 // to the defining class's namespace (never a bare global tail
-                // guess) via the index's `supertype_classes`.
-                index
-                    .classes_named(&class_name)
-                    .first()
-                    .map(|c| index.supertype_classes(c))
-                    .unwrap_or_default()
+                // guess) via the index's `supertype_classes`.  A class name
+                // can be defined in more than one indexed document; union the
+                // supertypes of **every** matching definition rather than
+                // picking an arbitrary `.first()` (whose choice — and thus the
+                // reported supertypes — depended on index insertion order).
+                let mut acc: Vec<&core_workspace_index::WorkspaceClass> = Vec::new();
+                let mut seen_super: std::collections::HashSet<String> =
+                    std::collections::HashSet::new();
+                for c in index.classes_named(&class_name) {
+                    for s in index.supertype_classes(c) {
+                        if seen_super.insert(s.qualified_name.clone()) {
+                            acc.push(s);
+                        }
+                    }
+                }
+                acc
             };
             list.into_iter()
                 .map(|c| (c.uri.clone(), c.qualified_name.clone(), c.name_span))


### PR DESCRIPTION
## Summary

Fixes method rename operations to correctly rewrite all call sites when renaming an inherited method from the base class declaration. Previously, `$obj method` calls on subclass instances and `my method` calls within purely-inheriting subclasses were silently left pointing at the old name.

### Root Cause

The rename logic used exact-class-equality filters that excluded:
1. `$obj method` sites where `$obj` is an instance of a subclass that inherits (does not override) the method
2. `my method` call sites within subclass bodies that inherit the method without overriding it

These sites dispatch through the MRO to the base definition, so they must be renamed when the base is renamed.

### Changes

**`rename.rs`:**
- Refactored the override family loop to process all family members (including the cursor class) through the shared `method_references_for_class` resolver, rather than using separate ad-hoc scans
- Removed the exact-class-equality filter that was dropping inheriting-subclass sites
- Updated comments to clarify the polymorphic nature of methods across the override family

**`references.rs`:**
- Extended `method_references_for_class` to scan not just the target class's own method bodies, but also the bodies of every subclass that *inherits* the method (resolves to the target via MRO without overriding)
- Extended `find_obj_method_call_sites` to include instances of subclasses that inherit the method, not just exact-class instances
- Added `collect_member_bodies` helper to reduce duplication
- Updated documentation to explain the MRO-based filtering

**`type_hierarchy.rs`:**
- Updated `resolve_class` to use owner-aware name resolution (via the shared `resolve_class_name` resolver) instead of simple tail matching, so supertype resolution correctly links bare names to namespaced bases
- Added tests for owner-aware resolution and self-edge prevention

**`class_hierarchy.rs`:**
- Fixed `build_class_hierarchy` to include mixin edges in the subclass map, ensuring consistency between `is_subtype` and the subclass map
- Added documentation explaining the mixin-as-supertype treatment

**`definition.rs`:**
- Updated `canonicalise_class` to use owner-aware name resolution for `nextto` targets, allowing `nextto Base` to reach namespaced bases named bare from sibling classes

**Documentation:**
- Added KCS W250 diagnostic documentation for abstract class instantiation warnings
- Updated README diagnostic table to include W250

### Tests

Added two new unit tests in `rename.rs`:
- `rename_inherited_method_rewrites_subclass_instance_obj_sites`: Verifies `$d speak` on a Dog instance is renamed when renaming the inherited method from Animal
- `rename_inherited_method_rewrites_pure_inheritor_my_sites`: Verifies `my speak` in a Dog method body is renamed when renaming the inherited method from Animal

Added tests in `type_hierarchy.rs`:
- `supertypes_resolve_bare_namespaced_base_owner_aware`: Verifies owner-aware resolution of bare superclass names
- `supertypes_never_lists_the_class_itself`: Prevents self-edges in supertype lists

Added test in `class_hierarchy.rs`:
- `mixin_recorded_as_subclass_edge`: Verifies mixin edges appear in the subclass map

Added test in `definition.rs`:
- `jump_to_nextto_namespaced_class_method`: Verifies `nextto` can reach namespaced sibling classes

## Validation

- All new unit tests pass
- Existing tests continue to pass
- Changes are localized to method/class resolution and rename logic with comprehensive test coverage

https://claude.ai/code/session_01WfigqGovtXQJFN6eEX78jp