### PR TITLE
Add subcommand specs and fix script body recursion in Tk commands

### DIFF
--- a/editors/zed/src/generated/tcl_commands.json
+++ b/editors/zed/src/generated/tcl_commands.json
@@ -338,18 +338,26 @@
         "canvasy",
         "coords",
         "create",
+        "dchars",
         "delete",
         "dtag",
         "find",
         "focus",
         "gettags",
+        "icursor",
+        "index",
+        "insert",
+        "itemcget",
         "itemconfigure",
         "lower",
         "move",
+        "moveto",
         "postscript",
         "raise",
+        "rchars",
         "scale",
         "scan",
+        "select",
         "type",
         "xview",
         "yview"
@@ -664,7 +672,19 @@
     },
     {
       "name": "entry",
-      "summary": "Create and manipulate a single-line text entry widget."
+      "summary": "Create and manipulate a single-line text entry widget.",
+      "subcommands": [
+        "bbox",
+        "delete",
+        "get",
+        "icursor",
+        "index",
+        "insert",
+        "scan",
+        "selection",
+        "validate",
+        "xview"
+      ]
     },
     {
       "name": "eof",
@@ -1383,7 +1403,25 @@
     },
     {
       "name": "listbox",
-      "summary": "Create and manipulate a listbox widget."
+      "summary": "Create and manipulate a listbox widget.",
+      "subcommands": [
+        "activate",
+        "bbox",
+        "curselection",
+        "delete",
+        "get",
+        "index",
+        "insert",
+        "itemcget",
+        "itemconfigure",
+        "nearest",
+        "scan",
+        "see",
+        "selection",
+        "size",
+        "xview",
+        "yview"
+      ]
     },
     {
       "name": "llength",
@@ -1727,6 +1765,7 @@
       "name": "menu",
       "summary": "Create and manipulate a menu widget.",
       "subcommands": [
+        "activate",
         "add",
         "clone",
         "delete",
@@ -1739,6 +1778,7 @@
         "postcascade",
         "type",
         "unpost",
+        "xposition",
         "yposition"
       ]
     },
@@ -2302,7 +2342,22 @@
     },
     {
       "name": "spinbox",
-      "summary": "Create and manipulate a spinbox widget."
+      "summary": "Create and manipulate a spinbox widget.",
+      "subcommands": [
+        "bbox",
+        "delete",
+        "get",
+        "icursor",
+        "identify",
+        "index",
+        "insert",
+        "invoke",
+        "scan",
+        "selection",
+        "set",
+        "validate",
+        "xview"
+      ]
     },
     {
       "name": "split",
@@ -3221,7 +3276,33 @@
     },
     {
       "name": "text",
-      "summary": "Create and manipulate a multi-line text widget."
+      "summary": "Create and manipulate a multi-line text widget.",
+      "subcommands": [
+        "bbox",
+        "compare",
+        "count",
+        "debug",
+        "delete",
+        "dlineinfo",
+        "dump",
+        "edit",
+        "get",
+        "image",
+        "index",
+        "insert",
+        "mark",
+        "peer",
+        "pendingsync",
+        "replace",
+        "scan",
+        "search",
+        "see",
+        "sync",
+        "tag",
+        "window",
+        "xview",
+        "yview"
+      ]
     },
     {
       "name": "textutil::adjust",
@@ -3446,7 +3527,20 @@
     },
     {
       "name": "ttk::notebook",
-      "summary": "Create and manipulate a themed tabbed notebook widget."
+      "summary": "Create and manipulate a themed tabbed notebook widget.",
+      "subcommands": [
+        "add",
+        "forget",
+        "hide",
+        "identify",
+        "index",
+        "insert",
+        "instate",
+        "select",
+        "state",
+        "tab",
+        "tabs"
+      ]
     },
     {
       "name": "ttk::progressbar",
@@ -3478,7 +3572,33 @@
     },
     {
       "name": "ttk::treeview",
-      "summary": "Create and manipulate a themed hierarchical multicolumn data display widget."
+      "summary": "Create and manipulate a themed hierarchical multicolumn data display widget.",
+      "subcommands": [
+        "bbox",
+        "children",
+        "column",
+        "delete",
+        "detach",
+        "exists",
+        "focus",
+        "heading",
+        "identify",
+        "index",
+        "insert",
+        "instate",
+        "item",
+        "move",
+        "next",
+        "parent",
+        "prev",
+        "see",
+        "selection",
+        "set",
+        "state",
+        "tag",
+        "xview",
+        "yview"
+      ]
     },
     {
       "name": "unicode",

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -184,11 +184,14 @@ impl Analyser {
         if cmd_name == "after" && is_integer_word(first_arg) {
             return;
         }
-        // Tk geometry managers accept `manager pathName ?args?` as a shortcut
-        // for `manager configure pathName ?args?` (grid.n / pack.n / place.n).
-        // A window path starts with `.`, which is not a valid subcommand-name
-        // first character, so this is unambiguous.
-        if matches!(cmd_name, "grid" | "pack" | "place") && first_arg.starts_with('.') {
+        // A subcommand name never starts with `.`, so a `.`-prefixed first word
+        // is a Tk window pathname, not an unknown subcommand.  This covers both
+        // the geometry-manager shortcut (`grid .w ?args?` for `grid configure
+        // .w …`, per grid.n / pack.n / place.n) and widget-creation commands
+        // (`entry .e …`, `canvas .c …`), whose registry `subcommands` describe
+        // the created widget's *instance* command rather than a first-word
+        // subcommand of the creator.  Either way `.path` is never W001.
+        if first_arg.starts_with('.') {
             return;
         }
         if sig.subcommands.contains_key(first_arg) {

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -394,6 +394,29 @@ mod diagnostics {
     }
 
     #[test]
+    fn widget_creation_pathname_is_not_a_subcommand_no_w001() {
+        // A widget-creation command's first word is a window pathname
+        // (`.e`), not a subcommand — even though the creator carries an
+        // instance-command `subcommands` table. It must never trip W001.
+        for src in [
+            "entry .e -textvariable v",
+            "canvas .c -background white",
+            "menu .m -tearoff 0",
+            "text .t -width 40",
+            "listbox .lb -listvariable items",
+            "ttk::treeview .tv",
+            "ttk::notebook .nb",
+        ] {
+            assert!(
+                !fires(src, D, "W001"),
+                "widget creation `{src}` must not fire W001",
+            );
+        }
+        // A genuine mistyped subcommand (no leading `.`) still fires.
+        assert!(fires("string bogus hello", D, "W001"));
+    }
+
+    #[test]
     fn package_prefer_is_a_real_subcommand_no_w001() {
         // `package prefer` is real in every supported dialect — tclsh returns
         // "stable". Regression #109: must not be flagged "Unknown subcommand".

--- a/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
+++ b/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
@@ -544,6 +544,44 @@ fn test_struct_list_foreachperm_body_recursion() {
     assert!(has_var, "foreachperm var not recursed: {tokens:?}");
 }
 
+#[test]
+fn test_bind_script_body_recursion() {
+    // `bind tag sequence script` — the trailing event-handler script recurses
+    // rather than being emitted as one opaque string (issue #785), so `set`
+    // inside it is a function token and `$w` a variable.
+    let mut lsp = Lsp::tcl();
+    let lg = legend(&lsp);
+    let src = "bind $w <KeyPress> {\n if {$w eq \"Menu\"} {\n  set x 1\n }\n}\n";
+    let uri = open_doc(&mut lsp, src);
+    let tokens = typed(&mut lsp, &lg, &uri);
+    // `set` recursed from the braced event-handler body.
+    let has_set = tokens
+        .iter()
+        .any(|t| covered(src, t) == "set" && t.ttype == "function");
+    assert!(has_set, "bind script body not recursed: {tokens:?}");
+    // `$w` recursed from inside the body.
+    let has_var = tokens.iter().any(|t| t.ttype == "variable");
+    assert!(has_var, "bind script body vars not recursed: {tokens:?}");
+    // `if` inside the body is a keyword.
+    let words = keyword_words(&mut lsp, &lg, &uri, src);
+    assert!(words.contains("if"), "expected `if` keyword in bind body: {words:?}");
+}
+
+#[test]
+fn test_bind_query_forms_do_not_recurse() {
+    // `bind tag` and `bind tag sequence` are query forms with no script — a
+    // braced word in a two-argument call is opaque, not a recursed body.
+    let mut lsp = Lsp::tcl();
+    let lg = legend(&lsp);
+    let src = "bind $w {puts hi}\n";
+    let uri = open_doc(&mut lsp, src);
+    let tokens = typed(&mut lsp, &lg, &uri);
+    let puts_recursed = tokens
+        .iter()
+        .any(|t| covered(src, t) == "puts" && t.ttype == "function");
+    assert!(!puts_recursed, "bind query form must not recurse a body: {tokens:?}");
+}
+
 // -- TestStructuralKeywords ----------------------------------------------
 
 /// The set of source words rendered as keyword tokens.

--- a/rust/tcl-registry/src/commands/tk/bind.rs
+++ b/rust/tcl-registry/src/commands/tk/bind.rs
@@ -25,6 +25,23 @@ const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
     connection_side: ConnectionSide::None,
 }];
 
+/// Dynamic arg-role resolver for `bind`.
+///
+/// `bind tag` and `bind tag sequence` are *query* forms that return an
+/// existing binding and carry no script.  Only the full
+/// `bind tag sequence script` form binds a script, supplied as the
+/// trailing (third) argument — optionally prefixed with `+` to append
+/// to the current binding.  That script is a deferred body: it runs
+/// later from the Tk event loop in its own dispatch context rather than
+/// the caller's frame, so `body_kind` is `Structural`.
+fn bind_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    if args.len() == 3 {
+        vec![(2, ArgRole::Body)]
+    } else {
+        Vec::new()
+    }
+}
+
 const FORMS: &[FormSpec] = &[FormSpec {
     kind: FormKind::Default,
     synopsis: "bind tag ?sequence? ?+??command?",
@@ -35,6 +52,12 @@ pub fn spec() -> CommandSpec {
         name: "bind",
         dialects: Some(DialectSet::TK_AND_TCL),
         arity: Arity::new(1, 3),
+        // The `bind tag sequence script` form's trailing script is a
+        // deferred event-handler body (runs from the Tk event loop, not
+        // the caller's frame), so recurse into it for highlighting and
+        // treat it as structural.
+        arg_role_resolver: Some(bind_arg_roles),
+        body_kind: BodyKind::Structural,
         hover: Some(HoverSnippet {
             summary: "Arrange for X event bindings on windows or tags.",
             synopsis: &[

--- a/rust/tcl-registry/src/commands/tk/canvas.rs
+++ b/rust/tcl-registry/src/commands/tk/canvas.rs
@@ -19,6 +19,22 @@
 //! `canvas` command.
 use crate::prelude::*;
 
+/// Dynamic arg-role resolver for the canvas `bind` subcommand.
+///
+/// `pathName bind tagOrId ?sequence? ?command?` — like the top-level
+/// `bind` command, only the full three-argument form binds a script,
+/// supplied as the trailing (third) argument.  It is a deferred
+/// event-handler body run later from the Tk event loop, so `body_kind`
+/// is `Structural`.  Args here are those *after* the `bind` subcommand
+/// word: `tagOrId`(0) `sequence`(1) `command`(2).
+fn canvas_bind_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    if args.len() == 3 {
+        vec![(2, ArgRole::Body)]
+    } else {
+        Vec::new()
+    }
+}
+
 /// The command's subcommands.
 const SUBCOMMANDS: &[SubCommand] = &[
     SubCommand {
@@ -38,9 +54,11 @@ const SUBCOMMANDS: &[SubCommand] = &[
     SubCommand {
         name: "bind",
         dialects: None,
-        arity: Arity::at_least(1),
+        arity: Arity::new(1, 3),
         detail: "Associate a command with a canvas item event.",
         synopsis: "pathName bind tagOrId ?sequence? ?command?",
+        arg_role_resolver: Some(canvas_bind_arg_roles),
+        body_kind: BodyKind::Structural,
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tk/canvas.rs
+++ b/rust/tcl-registry/src/commands/tk/canvas.rs
@@ -90,6 +90,13 @@ const SUBCOMMANDS: &[SubCommand] = &[
         ..SubCommand::DEFAULT
     },
     SubCommand {
+        name: "dchars",
+        arity: Arity::at_least(2),
+        detail: "Delete characters between the first and last positions in a text or line item.",
+        synopsis: "pathName dchars tagOrId first ?last?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
         name: "delete",
         arity: Arity::at_least(0),
         detail: "Delete the items given by each tagOrId.",
@@ -126,6 +133,34 @@ const SUBCOMMANDS: &[SubCommand] = &[
         ..SubCommand::DEFAULT
     },
     SubCommand {
+        name: "icursor",
+        arity: Arity::exact(2),
+        detail: "Set the insertion cursor of a text, line, or polygon item just before the given index.",
+        synopsis: "pathName icursor tagOrId index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "index",
+        arity: Arity::exact(2),
+        detail: "Return the numerical index within an item corresponding to the given index.",
+        synopsis: "pathName index tagOrId index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "insert",
+        arity: Arity::exact(3),
+        detail: "Insert a string into a text, line, or polygon item before the given index.",
+        synopsis: "pathName insert tagOrId beforeThis string",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "itemcget",
+        arity: Arity::exact(2),
+        detail: "Return the value of a configuration option for a canvas item.",
+        synopsis: "pathName itemcget tagOrId option",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
         name: "itemconfigure",
         arity: Arity::at_least(1),
         detail: "Query or modify configuration options of a canvas item.",
@@ -148,6 +183,13 @@ const SUBCOMMANDS: &[SubCommand] = &[
         ..SubCommand::DEFAULT
     },
     SubCommand {
+        name: "moveto",
+        arity: Arity::exact(3),
+        detail: "Move the items so their top-left corner is at the given position.",
+        synopsis: "pathName moveto tagOrId x y",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
         name: "postscript",
         arity: Arity::at_least(0),
         detail: "Generate a Postscript representation of the canvas.",
@@ -163,6 +205,13 @@ const SUBCOMMANDS: &[SubCommand] = &[
         ..SubCommand::DEFAULT
     },
     SubCommand {
+        name: "rchars",
+        arity: Arity::exact(4),
+        detail: "Replace the characters between first and last in a text or line item with the given string.",
+        synopsis: "pathName rchars tagOrId first last string",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
         name: "scale",
         dialects: None,
         arity: Arity::exact(5),
@@ -175,6 +224,13 @@ const SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(1),
         detail: "Implement scanning for the canvas.",
         synopsis: "pathName scan option args",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "select",
+        arity: Arity::at_least(1),
+        detail: "Manipulate the selection in text, line, or polygon items.",
+        synopsis: "pathName select option ?tagOrId arg?",
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tk/entry.rs
+++ b/rust/tcl-registry/src/commands/tk/entry.rs
@@ -268,6 +268,80 @@ const OPTIONS: &[OptionSpec] = &[
     },
 ];
 
+/// The command's subcommands.
+const SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        name: "bbox",
+        arity: Arity::exact(1),
+        detail: "Return the bounding box of the character at the given index.",
+        synopsis: "pathName bbox index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "delete",
+        arity: Arity::new(1, 2),
+        detail: "Delete characters from first through last (or just the character at first).",
+        synopsis: "pathName delete first ?last?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "get",
+        arity: Arity::exact(0),
+        detail: "Return the entry's current string contents.",
+        synopsis: "pathName get",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "icursor",
+        arity: Arity::exact(1),
+        detail: "Move the insertion cursor to just before the character at the given index.",
+        synopsis: "pathName icursor index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "index",
+        arity: Arity::exact(1),
+        detail: "Return the numerical index corresponding to the given index.",
+        synopsis: "pathName index index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "insert",
+        arity: Arity::exact(2),
+        detail: "Insert the string just before the character at the given index.",
+        synopsis: "pathName insert index string",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "scan",
+        arity: Arity::exact(2),
+        detail: "Implement fast scanning/scrolling; option is mark or dragto.",
+        synopsis: "pathName scan option arg",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "selection",
+        arity: Arity::at_least(1),
+        detail: "Manipulate the selection; option is adjust, clear, from, present, range, or to.",
+        synopsis: "pathName selection option ?arg ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "validate",
+        arity: Arity::exact(0),
+        detail: "Force revalidation of the entry using its -validatecommand.",
+        synopsis: "pathName validate",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "xview",
+        arity: Arity::at_least(0),
+        detail: "Query or change the horizontal position of the text visible in the entry.",
+        synopsis: "pathName xview ?args?",
+        ..SubCommand::DEFAULT
+    },
+];
+
 const FORMS: &[FormSpec] = &[FormSpec {
     kind: FormKind::Default,
     synopsis: "entry pathName ?option value ...?",
@@ -291,6 +365,7 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         options: OPTIONS,
         side_effects: SIDE_EFFECTS,
+        subcommands: SUBCOMMANDS,
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/tk/font.rs
+++ b/rust/tcl-registry/src/commands/tk/font.rs
@@ -25,7 +25,7 @@ const SUBCOMMANDS: &[SubCommand] = &[
         name: "actual",
         arity: Arity::at_least(1),
         detail: "Return the actual attributes of a font on the display.",
-        synopsis: "font actual font ?-displayof window? ?option?",
+        synopsis: "font actual font ?-displayof window? ?option? ?--? ?char?",
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -158,7 +158,7 @@ pub fn spec() -> CommandSpec {
         hover: Some(HoverSnippet {
             summary: "Create and inspect fonts.",
             synopsis: &[
-                "font actual font ?-displayof window? ?option?",
+                "font actual font ?-displayof window? ?option? ?--? ?char?",
                 "font configure fontname ?option? ?value option value ...?",
                 "font create ?fontname? ?option value ...?",
                 "font delete fontname ?fontname ...?",

--- a/rust/tcl-registry/src/commands/tk/listbox.rs
+++ b/rust/tcl-registry/src/commands/tk/listbox.rs
@@ -196,6 +196,122 @@ const OPTIONS: &[OptionSpec] = &[
     },
 ];
 
+/// The command's subcommands.
+const SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        name: "activate",
+        arity: Arity::exact(1),
+        detail: "Set the active element to the one at the given index.",
+        synopsis: "pathName activate index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "bbox",
+        arity: Arity::exact(1),
+        detail: "Return the bounding box of the text of the element at the given index.",
+        synopsis: "pathName bbox index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "curselection",
+        arity: Arity::exact(0),
+        detail: "Return a list of the indices of all currently selected elements.",
+        synopsis: "pathName curselection",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "delete",
+        arity: Arity::new(1, 2),
+        detail: "Delete one or more elements in the range first through last inclusive.",
+        synopsis: "pathName delete first ?last?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "get",
+        arity: Arity::new(1, 2),
+        detail: "Return the contents of the elements in the range first through last inclusive.",
+        synopsis: "pathName get first ?last?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "index",
+        arity: Arity::exact(1),
+        detail: "Return the integer index value corresponding to the given index.",
+        synopsis: "pathName index index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "insert",
+        arity: Arity::at_least(1),
+        detail: "Insert zero or more new elements just before the element at the given index.",
+        synopsis: "pathName insert index ?element ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "itemcget",
+        arity: Arity::exact(2),
+        detail: "Return the current value of the given configuration option for an item.",
+        synopsis: "pathName itemcget index option",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "itemconfigure",
+        arity: Arity::at_least(1),
+        detail: "Query or modify the configuration options of an individual item.",
+        synopsis: "pathName itemconfigure index ?option? ?value option value ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "nearest",
+        arity: Arity::exact(1),
+        detail: "Return the index of the visible element nearest to the given y-coordinate.",
+        synopsis: "pathName nearest y",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "scan",
+        arity: Arity::exact(2),
+        detail: "Implement scanning: record scan mark, or scroll relative to a mark.",
+        synopsis: "pathName scan mark|dragto x y",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "see",
+        arity: Arity::exact(1),
+        detail: "Adjust the view so that the element at the given index is visible.",
+        synopsis: "pathName see index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "selection",
+        arity: Arity::at_least(1),
+        detail: "Adjust or query the selection: anchor, clear, includes, or set.",
+        synopsis: "pathName selection option first ?last?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "size",
+        arity: Arity::exact(0),
+        detail: "Return the number of elements in the listbox.",
+        synopsis: "pathName size",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "xview",
+        arity: Arity::at_least(0),
+        detail: "Query or change the horizontal position of the listbox's view.",
+        synopsis: "pathName xview ?args?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "yview",
+        arity: Arity::at_least(0),
+        detail: "Query or change the vertical position of the listbox's view.",
+        synopsis: "pathName yview ?args?",
+        ..SubCommand::DEFAULT
+    },
+];
+
 const FORMS: &[FormSpec] = &[FormSpec {
     kind: FormKind::Default,
     synopsis: "listbox pathName ?option value ...?",
@@ -219,6 +335,7 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         options: OPTIONS,
         side_effects: SIDE_EFFECTS,
+        subcommands: SUBCOMMANDS,
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/tk/listbox.rs
+++ b/rust/tcl-registry/src/commands/tk/listbox.rs
@@ -270,7 +270,7 @@ const SUBCOMMANDS: &[SubCommand] = &[
     },
     SubCommand {
         name: "scan",
-        arity: Arity::exact(2),
+        arity: Arity::exact(3),
         detail: "Implement scanning: record scan mark, or scroll relative to a mark.",
         synopsis: "pathName scan mark|dragto x y",
         ..SubCommand::DEFAULT

--- a/rust/tcl-registry/src/commands/tk/menu.rs
+++ b/rust/tcl-registry/src/commands/tk/menu.rs
@@ -19,8 +19,93 @@
 //! `menu` command.
 use crate::prelude::*;
 
+/// Options accepted by menu entries (shared by `add`, `insert`, and
+/// `entryconfigure`). Not every option applies to every entry type, but the
+/// registry lists the full set so option values are typed correctly.
+const MENU_ENTRY_OPTIONS: &[OptionSpec] = &[
+    OptionSpec {
+        name: "-command",
+        value: OptionValue::script(),
+        detail: "Tcl command to invoke when the menu entry is invoked.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-variable",
+        value: OptionValue::var_name(),
+        detail: "Global variable tied to a checkbutton or radiobutton entry.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-label",
+        value: OptionValue::value("string"),
+        detail: "Text displayed in the menu entry.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-state",
+        value: OptionValue::value("state"),
+        detail: "State of the entry: normal, active, or disabled.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-value",
+        value: OptionValue::value("value"),
+        detail: "Value stored in the variable when a radiobutton entry is selected.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-onvalue",
+        value: OptionValue::value("value"),
+        detail: "Value stored in the variable when a checkbutton entry is on.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-offvalue",
+        value: OptionValue::value("value"),
+        detail: "Value stored in the variable when a checkbutton entry is off.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-accelerator",
+        value: OptionValue::value("string"),
+        detail: "Accelerator key text displayed at the right of the entry.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-menu",
+        value: OptionValue::value("menu"),
+        detail: "Submenu posted by a cascade entry.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+];
+
 /// The command's subcommands.
 const SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        name: "activate",
+        arity: Arity::exact(1),
+        detail: "Activate (highlight) the menu entry at the given index.",
+        synopsis: "pathName activate index",
+        ..SubCommand::DEFAULT
+    },
     SubCommand {
         name: "add",
         arity: Arity::at_least(1),
@@ -51,6 +136,7 @@ const SUBCOMMANDS: &[SubCommand] = &[
                 },
             ],
         )],
+        options: MENU_ENTRY_OPTIONS,
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -79,6 +165,7 @@ const SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(1),
         detail: "Query or modify options of a menu entry.",
         synopsis: "pathName entryconfigure index ?option value ...?",
+        options: MENU_ENTRY_OPTIONS,
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -118,6 +205,7 @@ const SUBCOMMANDS: &[SubCommand] = &[
                 },
             ],
         )],
+        options: MENU_ENTRY_OPTIONS,
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -153,6 +241,13 @@ const SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::exact(0),
         detail: "Unmap the menu so it is no longer displayed.",
         synopsis: "pathName unpost",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "xposition",
+        arity: Arity::exact(1),
+        detail: "Return the x-coordinate of the leftmost pixel of the entry at index.",
+        synopsis: "pathName xposition index",
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tk/selection.rs
+++ b/rust/tcl-registry/src/commands/tk/selection.rs
@@ -19,6 +19,24 @@
 //! `selection` command.
 use crate::prelude::*;
 
+/// Dynamic arg-role resolver for `selection handle`.
+///
+/// `selection handle ?-selection s? ?-type t? ?-format f? window command`
+/// — the trailing `command` is a command *prefix* that Tk invokes with
+/// two numbers (offset and maxChars) appended to supply selection data,
+/// so it carries [`ArgRole::CommandPrefix`] (its first word is a command
+/// reference), not a script body.  It is always the last argument; the
+/// leading option/value pairs and `window` precede it.  Args here are
+/// those *after* the `handle` subcommand word.
+fn selection_handle_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    match u8::try_from(args.len()) {
+        // window + command are both required (arity at_least(2)), so the
+        // command prefix is the final argument.
+        Ok(n) if n >= 2 => vec![(n - 1, ArgRole::CommandPrefix)],
+        _ => Vec::new(),
+    }
+}
+
 /// The command's subcommands.
 const SUBCOMMANDS: &[SubCommand] = &[
     SubCommand {
@@ -40,6 +58,7 @@ const SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(2),
         detail: "Register a handler to provide the selection data.",
         synopsis: "selection handle ?-selection sel? ?-type type? ?-format fmt? window command",
+        arg_role_resolver: Some(selection_handle_arg_roles),
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tk/spinbox.rs
+++ b/rust/tcl-registry/src/commands/tk/spinbox.rs
@@ -324,6 +324,101 @@ const OPTIONS: &[OptionSpec] = &[
     },
 ];
 
+/// The command's subcommands.
+const SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        name: "bbox",
+        arity: Arity::exact(1),
+        detail: "Return the bounding box of the character at the given index.",
+        synopsis: "pathName bbox index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "delete",
+        arity: Arity::new(1, 2),
+        detail: "Delete characters from first through last (or just the character at first).",
+        synopsis: "pathName delete first ?last?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "get",
+        arity: Arity::exact(0),
+        detail: "Return the spinbox's current string contents.",
+        synopsis: "pathName get",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "icursor",
+        arity: Arity::exact(1),
+        detail: "Move the insertion cursor to just before the character at the given index.",
+        synopsis: "pathName icursor index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "identify",
+        arity: Arity::exact(2),
+        detail: "Return the name of the spinbox element at the given coordinates.",
+        synopsis: "pathName identify x y",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "index",
+        arity: Arity::exact(1),
+        detail: "Return the numerical index corresponding to the given index.",
+        synopsis: "pathName index index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "insert",
+        arity: Arity::exact(2),
+        detail: "Insert the string just before the character at the given index.",
+        synopsis: "pathName insert index string",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "invoke",
+        arity: Arity::exact(1),
+        detail: "Invoke the up or down button, incrementing or decrementing the value.",
+        synopsis: "pathName invoke element",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "scan",
+        arity: Arity::exact(2),
+        detail: "Implement fast scanning/scrolling; option is mark or dragto.",
+        synopsis: "pathName scan option arg",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "selection",
+        arity: Arity::at_least(1),
+        detail: "Manipulate the selection; option is adjust, clear, element, from, present, range, or to.",
+        synopsis: "pathName selection option ?arg ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "set",
+        arity: Arity::new(0, 1),
+        detail: "Query or set the spinbox's string value.",
+        synopsis: "pathName set ?string?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "validate",
+        arity: Arity::exact(0),
+        detail: "Force revalidation of the spinbox using its -validatecommand.",
+        synopsis: "pathName validate",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "xview",
+        arity: Arity::at_least(0),
+        detail: "Query or change the horizontal position of the text visible in the spinbox.",
+        synopsis: "pathName xview ?args?",
+        ..SubCommand::DEFAULT
+    },
+];
+
 const FORMS: &[FormSpec] = &[FormSpec {
     kind: FormKind::Default,
     synopsis: "spinbox pathName ?option value ...?",
@@ -347,6 +442,7 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         options: OPTIONS,
         side_effects: SIDE_EFFECTS,
+        subcommands: SUBCOMMANDS,
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/tk/text.rs
+++ b/rust/tcl-registry/src/commands/tk/text.rs
@@ -18,6 +18,193 @@
 
 //! `text` command.
 use crate::prelude::*;
+
+/// `text` `tag` sub-subcommand roles. `pathName tag bind tagName sequence script`
+/// binds a deferred event-handler script (run from the Tk event loop) as its
+/// trailing word. Args here are those AFTER the `tag` subcommand word:
+/// `bind`(0) tagName(1) sequence(2) script(3).
+fn text_tag_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    if args.first() == Some(&"bind") && args.len() == 4 {
+        vec![(3, ArgRole::Body)]
+    } else {
+        Vec::new()
+    }
+}
+
+/// The command's subcommands.
+const SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        name: "bbox",
+        arity: Arity::exact(1),
+        detail: "Return the bounding box of the character at the given index.",
+        synopsis: "pathName bbox index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "compare",
+        arity: Arity::exact(3),
+        detail: "Compare two indices according to a relational operator.",
+        synopsis: "pathName compare index1 op index2",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "count",
+        arity: Arity::at_least(2),
+        detail: "Count the number of items between two indices.",
+        synopsis: "pathName count ?option ...? index1 index2",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "debug",
+        arity: Arity::new(0, 1),
+        detail: "Enable or query consistency checking of the B-tree code.",
+        synopsis: "pathName debug ?boolean?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "delete",
+        arity: Arity::at_least(1),
+        detail: "Delete a range of characters from the text.",
+        synopsis: "pathName delete index1 ?index2 ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "dlineinfo",
+        arity: Arity::exact(1),
+        detail: "Return display information for the display line containing index.",
+        synopsis: "pathName dlineinfo index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "dump",
+        arity: Arity::at_least(1),
+        detail: "Return the contents of the text widget in a parseable form.",
+        synopsis: "pathName dump ?switches? index1 ?index2?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "edit",
+        arity: Arity::at_least(1),
+        detail: "Control the undo/redo mechanism and modified flag.",
+        synopsis: "pathName edit option ?arg ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "get",
+        arity: Arity::at_least(1),
+        detail: "Return the text from the widget between the given indices.",
+        synopsis: "pathName get ?-displaychars? ?--? index1 ?index2 ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "image",
+        arity: Arity::at_least(1),
+        detail: "Manipulate images embedded in the text widget.",
+        synopsis: "pathName image option ?arg ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "index",
+        arity: Arity::exact(1),
+        detail: "Return the position of index in line.char form.",
+        synopsis: "pathName index index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "insert",
+        arity: Arity::at_least(2),
+        detail: "Insert text at the given index.",
+        synopsis: "pathName insert index chars ?tagList chars tagList ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "mark",
+        arity: Arity::at_least(1),
+        detail: "Manipulate marks within the text widget.",
+        synopsis: "pathName mark option ?arg ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "peer",
+        arity: Arity::at_least(1),
+        detail: "Create or list peer text widgets.",
+        synopsis: "pathName peer option ?arg ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "pendingsync",
+        arity: Arity::exact(0),
+        detail: "Return whether asynchronous line-height calculations are pending.",
+        synopsis: "pathName pendingsync",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "replace",
+        arity: Arity::at_least(2),
+        detail: "Replace a range of text with new text.",
+        synopsis: "pathName replace index1 index2 chars ?tagList chars tagList ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "scan",
+        arity: Arity::at_least(2),
+        detail: "Implement scanning (fast dragging) of the text widget.",
+        synopsis: "pathName scan option args",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "search",
+        arity: Arity::at_least(2),
+        detail: "Search for text matching a pattern within the widget.",
+        synopsis: "pathName search ?switches? pattern index ?stopIndex?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "see",
+        arity: Arity::exact(1),
+        detail: "Scroll the widget so the character at index is visible.",
+        synopsis: "pathName see index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "sync",
+        arity: Arity::at_least(0),
+        detail: "Control or query asynchronous line-height calculations.",
+        synopsis: "pathName sync ?-command command?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "tag",
+        arity: Arity::at_least(1),
+        detail: "Manipulate tags applied to ranges of text.",
+        synopsis: "pathName tag option ?arg ...?",
+        arg_role_resolver: Some(text_tag_arg_roles),
+        body_kind: BodyKind::Structural,
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "window",
+        arity: Arity::at_least(1),
+        detail: "Manipulate embedded windows within the text widget.",
+        synopsis: "pathName window option ?arg ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "xview",
+        arity: Arity::at_least(0),
+        detail: "Query or change the horizontal position of the text in the window.",
+        synopsis: "pathName xview ?args?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "yview",
+        arity: Arity::at_least(0),
+        detail: "Query or change the vertical position of the text in the window.",
+        synopsis: "pathName yview ?args?",
+        ..SubCommand::DEFAULT
+    },
+];
+
 const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
     target: SideEffectTarget::InterpState,
     reads: false,
@@ -323,6 +510,7 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         options: OPTIONS,
         side_effects: SIDE_EFFECTS,
+        subcommands: SUBCOMMANDS,
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/tk/tk_choosedirectory.rs
+++ b/rust/tcl-registry/src/commands/tk/tk_choosedirectory.rs
@@ -58,6 +58,22 @@ const OPTIONS: &[OptionSpec] = &[
         aliases: &[],
         min_version: None,
     },
+    OptionSpec {
+        name: "-command",
+        value: OptionValue::command_prefix("prefix"),
+        detail: "Command prefix invoked when the dialog closes; the chosen directory is appended (macOS).",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-message",
+        value: OptionValue::value("string"),
+        detail: "Message displayed in the dialog (macOS).",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
 ];
 
 const FORMS: &[FormSpec] = &[FormSpec {

--- a/rust/tcl-registry/src/commands/tk/tk_getopenfile.rs
+++ b/rust/tcl-registry/src/commands/tk/tk_getopenfile.rs
@@ -90,6 +90,22 @@ const OPTIONS: &[OptionSpec] = &[
         aliases: &[],
         min_version: None,
     },
+    OptionSpec {
+        name: "-command",
+        value: OptionValue::command_prefix("prefix"),
+        detail: "Command prefix invoked when the dialog closes; the chosen file is appended (macOS).",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-message",
+        value: OptionValue::value("string"),
+        detail: "Message displayed in the dialog (macOS).",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
 ];
 
 const FORMS: &[FormSpec] = &[FormSpec {

--- a/rust/tcl-registry/src/commands/tk/tk_getsavefile.rs
+++ b/rust/tcl-registry/src/commands/tk/tk_getsavefile.rs
@@ -90,6 +90,22 @@ const OPTIONS: &[OptionSpec] = &[
         aliases: &[],
         min_version: None,
     },
+    OptionSpec {
+        name: "-command",
+        value: OptionValue::command_prefix("prefix"),
+        detail: "Command prefix invoked when the dialog closes; the chosen file is appended (macOS).",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-message",
+        value: OptionValue::value("string"),
+        detail: "Message displayed in the dialog (macOS).",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
 ];
 
 const FORMS: &[FormSpec] = &[FormSpec {

--- a/rust/tcl-registry/src/commands/tk/tk_messagebox.rs
+++ b/rust/tcl-registry/src/commands/tk/tk_messagebox.rs
@@ -82,6 +82,14 @@ const OPTIONS: &[OptionSpec] = &[
         aliases: &[],
         min_version: None,
     },
+    OptionSpec {
+        name: "-command",
+        value: OptionValue::command_prefix("prefix"),
+        detail: "Command prefix invoked when the dialog closes; the clicked button name is appended (macOS).",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
 ];
 
 const FORMS: &[FormSpec] = &[FormSpec {

--- a/rust/tcl-registry/src/commands/tk/ttk__button.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__button.rs
@@ -159,6 +159,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/ttk__combobox.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__combobox.rs
@@ -191,6 +191,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/ttk__entry.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__entry.rs
@@ -154,6 +154,22 @@ const OPTIONS: &[OptionSpec] = &[
         aliases: &[],
         min_version: None,
     },
+    OptionSpec {
+        name: "-placeholder",
+        value: OptionValue::value("text"),
+        detail: "Help text shown when the entry is empty (Tk 8.7+).",
+        dialects: None,
+        aliases: &[],
+        min_version: Some("8.7"),
+    },
+    OptionSpec {
+        name: "-placeholderforeground",
+        value: OptionValue::value("color"),
+        detail: "Foreground colour of the placeholder text (Tk 8.7+).",
+        dialects: None,
+        aliases: &[],
+        min_version: Some("8.7"),
+    },
 ];
 
 const FORMS: &[FormSpec] = &[FormSpec {

--- a/rust/tcl-registry/src/commands/tk/ttk__entry.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__entry.rs
@@ -191,6 +191,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/ttk__frame.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__frame.rs
@@ -119,6 +119,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/ttk__label.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__label.rs
@@ -191,6 +191,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/ttk__notebook.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__notebook.rs
@@ -89,6 +89,87 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "ttk::notebook pathName ?options?",
 }];
 
+/// The command's subcommands.
+const SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        name: "add",
+        arity: Arity::at_least(1),
+        detail: "Add a new tab displaying the given window as a pane.",
+        synopsis: "pathName add window ?options?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "forget",
+        arity: Arity::exact(1),
+        detail: "Remove the tab specified by tabid and unmanage its window.",
+        synopsis: "pathName forget tabid",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "hide",
+        arity: Arity::exact(1),
+        detail: "Hide the tab specified by tabid without removing it.",
+        synopsis: "pathName hide tabid",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "identify",
+        arity: Arity::at_least(1),
+        detail: "Identify the element or tab at the given coordinates.",
+        synopsis: "pathName identify ?component? x y",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "index",
+        arity: Arity::exact(1),
+        detail: "Return the numeric index of the tab specified by tabid.",
+        synopsis: "pathName index tabid",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "insert",
+        arity: Arity::at_least(2),
+        detail: "Insert a tab at the specified position, adding or moving its window.",
+        synopsis: "pathName insert pos window ?options?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "select",
+        arity: Arity::new(0, 1),
+        detail: "Select the given tab, or return the currently selected tab.",
+        synopsis: "pathName select ?tabid?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "tab",
+        arity: Arity::at_least(1),
+        detail: "Query or modify the options of the tab specified by tabid.",
+        synopsis: "pathName tab tabid ?option? ?value ...?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "tabs",
+        arity: Arity::exact(0),
+        detail: "Return the list of windows managed by the notebook.",
+        synopsis: "pathName tabs",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "instate",
+        arity: Arity::at_least(1),
+        detail: "Test whether the widget state matches statespec, optionally running a script.",
+        synopsis: "pathName instate statespec ?script?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "state",
+        arity: Arity::new(0, 1),
+        detail: "Modify or query the widget state.",
+        synopsis: "pathName state ?stateSpec?",
+        ..SubCommand::DEFAULT
+    },
+];
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "ttk::notebook",
@@ -107,6 +188,7 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         options: OPTIONS,
         side_effects: SIDE_EFFECTS,
+        subcommands: SUBCOMMANDS,
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/tk/ttk__notebook.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__notebook.rs
@@ -184,6 +184,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/ttk__progressbar.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__progressbar.rs
@@ -135,6 +135,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/ttk__scale.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__scale.rs
@@ -143,6 +143,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/ttk__separator.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__separator.rs
@@ -87,6 +87,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/ttk__sizegrip.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__sizegrip.rs
@@ -79,6 +79,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/ttk__style.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__style.rs
@@ -129,6 +129,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         side_effects: SIDE_EFFECTS,

--- a/rust/tcl-registry/src/commands/tk/ttk__treeview.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__treeview.rs
@@ -129,6 +129,178 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "ttk::treeview pathName ?options?",
 }];
 
+/// The command's subcommands.
+const SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        name: "bbox",
+        arity: Arity::at_least(1),
+        detail: "Return the bounding box of the item, optionally restricted to a column.",
+        synopsis: "pathName bbox item ?column?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "children",
+        arity: Arity::new(1, 2),
+        detail: "Query or replace the list of children of the given item.",
+        synopsis: "pathName children item ?newchildren?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "column",
+        arity: Arity::at_least(1),
+        detail: "Query or modify the options of the specified column.",
+        synopsis: "pathName column column ?-option ?value ...??",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "delete",
+        arity: Arity::at_least(1),
+        detail: "Delete the given items and all of their descendants.",
+        synopsis: "pathName delete itemList",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "detach",
+        arity: Arity::exact(1),
+        detail: "Unlink the given items from the tree without deleting them.",
+        synopsis: "pathName detach itemList",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "exists",
+        arity: Arity::exact(1),
+        detail: "Return whether the specified item is present in the tree.",
+        synopsis: "pathName exists item",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "focus",
+        arity: Arity::new(0, 1),
+        detail: "Set the focus item, or return the current focus item.",
+        synopsis: "pathName focus ?item?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "heading",
+        arity: Arity::at_least(1),
+        detail: "Query or modify the heading options for the specified column.",
+        synopsis: "pathName heading column ?-option ?value ...??",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "identify",
+        arity: Arity::at_least(1),
+        detail: "Identify the tree component at the given coordinates.",
+        synopsis: "pathName identify ?component? x y",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "index",
+        arity: Arity::exact(1),
+        detail: "Return the integer index of the item within its parent's children.",
+        synopsis: "pathName index item",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "insert",
+        arity: Arity::at_least(2),
+        detail: "Create a new item as a child of parent at the given index.",
+        synopsis: "pathName insert parent index ?-id id? ?options?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "item",
+        arity: Arity::at_least(1),
+        detail: "Query or modify the options of the specified item.",
+        synopsis: "pathName item item ?-option ?value ...??",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "move",
+        arity: Arity::exact(3),
+        detail: "Move the item to the given position among the children of parent.",
+        synopsis: "pathName move item parent index",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "next",
+        arity: Arity::exact(1),
+        detail: "Return the identifier of the item's next sibling.",
+        synopsis: "pathName next item",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "parent",
+        arity: Arity::exact(1),
+        detail: "Return the identifier of the item's parent.",
+        synopsis: "pathName parent item",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "prev",
+        arity: Arity::exact(1),
+        detail: "Return the identifier of the item's previous sibling.",
+        synopsis: "pathName prev item",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "see",
+        arity: Arity::exact(1),
+        detail: "Ensure that the specified item is visible, scrolling if necessary.",
+        synopsis: "pathName see item",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "selection",
+        arity: Arity::new(0, 2),
+        detail: "Query or modify the set of selected items.",
+        synopsis: "pathName selection ?selop itemList?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "set",
+        arity: Arity::at_least(1),
+        detail: "Query or set the value of a column for the specified item.",
+        synopsis: "pathName set item ?column? ?value?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "tag",
+        arity: Arity::at_least(1),
+        detail: "Query or manipulate tags and their bindings and options.",
+        synopsis: "pathName tag args",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "instate",
+        arity: Arity::at_least(1),
+        detail: "Test whether the widget state matches statespec, optionally running a script.",
+        synopsis: "pathName instate statespec ?script?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "state",
+        arity: Arity::new(0, 1),
+        detail: "Modify or query the widget state.",
+        synopsis: "pathName state ?stateSpec?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "xview",
+        arity: Arity::at_least(0),
+        detail: "Query or change the horizontal position of the view.",
+        synopsis: "pathName xview ?args?",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "yview",
+        arity: Arity::at_least(0),
+        detail: "Query or change the vertical position of the view.",
+        synopsis: "pathName yview ?args?",
+        ..SubCommand::DEFAULT
+    },
+];
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "ttk::treeview",
@@ -147,6 +319,7 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         options: OPTIONS,
         side_effects: SIDE_EFFECTS,
+        subcommands: SUBCOMMANDS,
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/commands/tk/ttk__treeview.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__treeview.rs
@@ -315,6 +315,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("Tk"),
+        min_version: Some("8.5"),
         warn_missing_import: false,
         forms: FORMS,
         options: OPTIONS,

--- a/rust/tcl-registry/src/commands/tk/wm.rs
+++ b/rust/tcl-registry/src/commands/tk/wm.rs
@@ -19,6 +19,24 @@
 //! `wm` command.
 use crate::prelude::*;
 
+/// Dynamic arg-role resolver for `wm protocol`.
+///
+/// `wm protocol window` and `wm protocol window name` are *query* forms
+/// (they return the current handler, or the registered protocols) and
+/// carry no script.  Only the full `wm protocol window name command`
+/// form registers a handler, supplied as the trailing (third) argument
+/// — a deferred script run later from the window manager's event loop
+/// (e.g. the `WM_DELETE_WINDOW` callback), so `body_kind` is
+/// `Structural`.  Args here are those *after* the `protocol` subcommand
+/// word: `window`(0) `name`(1) `command`(2).
+fn wm_protocol_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    if args.len() == 3 {
+        vec![(2, ArgRole::Body)]
+    } else {
+        Vec::new()
+    }
+}
+
 /// The command's subcommands.
 const SUBCOMMANDS: &[SubCommand] = &[
     SubCommand {
@@ -137,7 +155,7 @@ const SUBCOMMANDS: &[SubCommand] = &[
     },
     SubCommand {
         name: "iconphoto",
-        arity: Arity::at_least(1),
+        arity: Arity::at_least(2),
         detail: "Set the window icon from one or more photo images.",
         synopsis: "wm iconphoto window ?-default? image1 ?image2 ...?",
         ..SubCommand::DEFAULT
@@ -196,6 +214,8 @@ const SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::new(1, 3),
         detail: "Register a handler for a window manager protocol.",
         synopsis: "wm protocol window ?name? ?command?",
+        arg_role_resolver: Some(wm_protocol_arg_roles),
+        body_kind: BodyKind::Structural,
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1503,6 +1503,75 @@ mod tests {
     }
 
     #[test]
+    fn wm_protocol_handler_is_a_body() {
+        // `wm protocol . WM_DELETE_WINDOW {script}` registers a deferred
+        // handler script as its third argument; the query forms carry none.
+        let reg = CommandRegistry::build_default();
+        assert_eq!(
+            reg.arg_indices_for_role(
+                "wm",
+                &["protocol", ".", "WM_DELETE_WINDOW", "{exit}"],
+                ArgRole::Body,
+            ),
+            // subcommand path offsets by +1 for the `protocol` word.
+            vec![3],
+            "the wm protocol handler command is a script body",
+        );
+        assert!(
+            reg.arg_indices_for_role("wm", &["protocol", ".", "WM_DELETE_WINDOW"], ArgRole::Body)
+                .is_empty(),
+            "the two-argument `wm protocol window name` query form has no script",
+        );
+        assert!(
+            reg.arg_indices_for_role("wm", &["protocol", "."], ArgRole::Body)
+                .is_empty(),
+            "the one-argument `wm protocol window` query form has no script",
+        );
+    }
+
+    #[test]
+    fn canvas_bind_subcommand_script_is_a_body() {
+        // `pathName bind tagOrId sequence script` binds a deferred handler.
+        let reg = CommandRegistry::build_default();
+        assert_eq!(
+            reg.arg_indices_for_role("canvas", &["bind", "item", "<Button>", "{p}"], ArgRole::Body),
+            vec![3],
+            "the canvas bind subcommand's trailing script is a body",
+        );
+        assert!(
+            reg.arg_indices_for_role("canvas", &["bind", "item", "<Button>"], ArgRole::Body)
+                .is_empty(),
+            "the canvas bind query form has no script",
+        );
+    }
+
+    #[test]
+    fn selection_handle_command_is_a_command_prefix() {
+        // `selection handle window command` — the trailing command is a
+        // prefix Tk appends offset/maxChars to, not a recursed script body.
+        let reg = CommandRegistry::build_default();
+        assert_eq!(
+            reg.arg_indices_for_role("selection", &["handle", ".w", "getData"], ArgRole::CommandPrefix),
+            vec![2],
+            "the selection handle command prefix is captured",
+        );
+        assert!(
+            reg.arg_indices_for_role("selection", &["handle", ".w", "getData"], ArgRole::Body)
+                .is_empty(),
+            "a command prefix is not recursed as a script body",
+        );
+        // With leading option/value pairs the command is still the last arg.
+        assert_eq!(
+            reg.arg_indices_for_role(
+                "selection",
+                &["handle", "-format", "STRING", ".w", "getData"],
+                ArgRole::CommandPrefix,
+            ),
+            vec![4],
+        );
+    }
+
+    #[test]
     fn commands_with_trait_query() {
         let reg = CommandRegistry::build_default();
         let control_flow = reg.commands_with_trait(Traits::CONTROL_FLOW);

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1546,6 +1546,28 @@ mod tests {
     }
 
     #[test]
+    fn text_tag_bind_script_is_a_body() {
+        // `pathName tag bind tagName sequence script` binds a deferred
+        // event-handler script as its trailing word (issue #785 class).
+        let reg = CommandRegistry::build_default();
+        assert_eq!(
+            reg.arg_indices_for_role(
+                "text",
+                &["tag", "bind", "sel", "<Key>", "{p}"],
+                ArgRole::Body,
+            ),
+            // `tag` subcommand offset (+1) plus index 3 within the tag args.
+            vec![4],
+            "the text tag bind trailing script is a body",
+        );
+        assert!(
+            reg.arg_indices_for_role("text", &["tag", "add", "sel", "1.0", "end"], ArgRole::Body)
+                .is_empty(),
+            "non-bind tag subcommands carry no script",
+        );
+    }
+
+    #[test]
     fn selection_handle_command_is_a_command_prefix() {
         // `selection handle window command` — the trailing command is a
         // prefix Tk appends offset/maxChars to, not a recursed script body.

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1474,6 +1474,35 @@ mod tests {
     }
 
     #[test]
+    fn bind_script_form_recurses_only_the_trailing_script() {
+        // `bind $w <KeyPress> {…}` binds a script (issue #785): the third
+        // argument is a deferred event-handler body and must be recursed for
+        // highlighting.  The `bind tag` / `bind tag sequence` query forms carry
+        // no script and must not surface a Body.
+        let reg = CommandRegistry::build_default();
+        assert_eq!(
+            reg.arg_indices_for_role("bind", &["$w", "<KeyPress>", "{…}"], ArgRole::Body),
+            vec![2],
+            "the trailing script of the three-argument form is a body",
+        );
+        // The `+script` append form is still the trailing argument.
+        assert_eq!(
+            reg.arg_indices_for_role("bind", &[".b", "<Enter>", "+{puts hi}"], ArgRole::Body),
+            vec![2],
+        );
+        assert!(
+            reg.arg_indices_for_role("bind", &["$w"], ArgRole::Body)
+                .is_empty(),
+            "the single-tag query form has no script",
+        );
+        assert!(
+            reg.arg_indices_for_role("bind", &["$w", "<KeyPress>"], ArgRole::Body)
+                .is_empty(),
+            "the tag+sequence query form has no script",
+        );
+    }
+
+    #[test]
     fn commands_with_trait_query() {
         let reg = CommandRegistry::build_default();
         let control_flow = reg.commands_with_trait(Traits::CONTROL_FLOW);

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1546,6 +1546,28 @@ mod tests {
     }
 
     #[test]
+    fn ttk_widgets_require_tk_8_5() {
+        // ttk (themed Tk) widgets were introduced in Tk 8.5, so they must be
+        // gated out when only an older Tk is guaranteed by `package require`.
+        let reg = CommandRegistry::build_default();
+        for name in ["ttk::button", "ttk::treeview", "ttk::notebook", "ttk::style"] {
+            let spec = reg.get(name).unwrap_or_else(|| panic!("{name} registered"));
+            assert!(
+                !spec.available_for_version(Some("8.4")),
+                "{name} must not be available under Tk 8.4",
+            );
+            assert!(
+                spec.available_for_version(Some("8.5")),
+                "{name} must be available under Tk 8.5",
+            );
+            assert!(
+                spec.available_for_version(None),
+                "{name} must be permissive when no Tk version is pinned",
+            );
+        }
+    }
+
+    #[test]
     fn text_tag_bind_script_is_a_body() {
         // `pathName tag bind tagName sequence script` binds a deferred
         // event-handler script as its trailing word (issue #785 class).


### PR DESCRIPTION
## Summary

This PR adds comprehensive subcommand specifications to multiple Tk widget and command definitions, and fixes script body recursion for event-handler bindings. The changes enable proper semantic analysis of deferred scripts in commands like `bind`, `wm protocol`, `canvas bind`, and `text tag bind`.

### Key Changes

1. **Script Body Recursion Fixes**
   - Added `arg_role_resolver` functions to identify deferred event-handler scripts in:
     - `bind` command (3-argument form only; query forms excluded)
     - `wm protocol` subcommand (4-argument form only)
     - `canvas bind` subcommand (3-argument form only)
     - `text tag bind` sub-subcommand (4-argument form only)
     - `selection handle` subcommand (identifies command prefix, not body)
   - These resolvers ensure only actual script bindings are recursed, not query forms

2. **Subcommand Specifications Added**
   - `text` command: 24 subcommands with proper arities and details
   - `ttk::treeview` command: 25 subcommands
   - `ttk::notebook` command: 11 subcommands
   - `listbox` command: 15 subcommands
   - `spinbox` command: 12 subcommands
   - `entry` command: 10 subcommands
   - `canvas` command: expanded with missing subcommands (dchars, icursor, index, insert, itemcget, etc.)
   - `menu` command: added activate subcommand and menu entry options

3. **Version Gating**
   - Added `min_version: Some("8.5")` to all ttk widgets (ttk::button, ttk::combobox, ttk::frame, ttk::label, ttk::notebook, ttk::progressbar, ttk::scale, ttk::separator, ttk::sizegrip, ttk::style, ttk::treeview)
   - Added `-placeholder` and `-placeholderforeground` options to ttk::entry with Tk 8.7+ version gate
   - Added `-command` and `-message` options to file dialog commands (tk_choosedirectory, tk_getopenfile, tk_getsavefile, tk_messagebox)

4. **Menu Entry Options**
   - Extracted common menu entry options (-command, -variable, -label, -state, -value, -onvalue, -offvalue, -accelerator, -menu) into MENU_ENTRY_OPTIONS constant
   - Applied to `add`, `insert`, and `entryconfigure` subcommands

## Validation

- Added comprehensive unit tests in `registry.rs`:
  - `bind_script_form_recurses_only_the_trailing_script`: Validates bind command script recursion
  - `wm_protocol_handler_is_a_body`: Validates wm protocol handler recursion
  - `canvas_bind_subcommand_script_is_a_body`: Validates canvas bind script recursion
  - `text_tag_bind_script_is_a_body`: Validates text tag bind script recursion
  - `selection_handle_command_is_a_command_prefix`: Validates selection handle command prefix
  - `ttk_widgets_require_tk_8_5`: Validates version gating for ttk widgets

- Added semantic token tests in `semantic_tokens.rs`:
  - `test_bind_script_body_recursion`: Validates that `set` and variables inside bind scripts are properly tokenized
  - `test_bind_query_forms_do_not_recurse`: Validates that query forms don't recurse

All tests pass and validate the correct identification and recursion of script bodies vs. query forms.

https://claude.ai/code/session_01R4hntZyQFgW3bysMpe1u7Y