### PR TITLE
Highlight command options, incl. object-method options via the registry (#748)

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,7 +236,16 @@ domain-specific token types:
 | **Binary format** | `binarySpec`, `binaryCount`, `binaryFlag` | `binary scan $data su3 x y z` — `s`, `u`, and `3` each highlighted |
 | **Clock format** | `clockPercent`, `clockSpec`, `clockModifier` | `clock format $t -format "%Y-%m-%d"` — `%`, `Y`, `m`, `d` each highlighted |
 | **Escape sequences** | `escape` | `puts "line1\nline2\t${var}"` — `\n`, `\t` highlighted inside strings |
+| **Options** | `decorator`, `optionValue`, `enumMember` | `file delete -force f` and `$chart Xaxis -name x -type value` — switches and their values get their own colours |
 | **BIG-IP config** | `object`, `ipAddress`, `port`, `partition`, `pool`, `monitor`, `profile`, `vlan`, `fqdn`, `routeDomain`, `encrypted`, `interface` | BIG-IP `.conf` files get object-aware highlighting |
+
+Command options are highlighted precisely for commands the registry knows,
+including object methods on a tracked handle — the standard `TclOO` / Tk
+pattern `set chart [ticklecharts::chart new]; $chart Xaxis -name x -type value`
+resolves `Xaxis`'s options through the registry.  Any other `-option value`
+pair on an unknown command head is highlighted by shape, while negative
+numbers (`-5`), special floats (`-inf`), substitutions (`-$var`), and the `--`
+end-of-options marker are handled per Tcl's conventions.
 
 ### Diagnostics
 

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -265,6 +265,24 @@ state), each with its own arity and side-effect classification.  See
 
 See also: [Command registry](design/compiler/command-registry.md).
 
+### ObjectClassSpec
+
+Registry metadata for a `TclOO` / megawidget class whose instances are
+dispatched as `$obj <method> …`.  Attached to the class factory command and
+carrying the class's instance methods (each a `SubCommand`), so an object
+handle's method options resolve through the registry.  See `ObjectClassSpec`
+in `tcl_registry::spec`.
+
+See also: [Command registry](design/compiler/command-registry.md).
+
+### Object handle
+
+A command name that names a `TclOO` object instance (returned by
+`Class new` / bound by `Class create name`), invoked as `$handle method …`.
+The [object-handle tracking](design/compiler/command-registry.md) harvests
+`set var [Class new]` provenance so `$var` is known to hold an instance of a
+registry-modelled class.
+
 ---
 
 ## Phase 4 — CFG construction

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -32,6 +32,10 @@ rules for the KCS/documentation split live in
   persistent per-document analysis worker model: bounded pool + per-uri
   single-writer lock for incremental edits, process pool + serialized
   warm-start seed for the cold build.
+- [tcloo-mro-lattice.md](tcloo-mro-lattice.md) — the (measured-negative)
+  `TclOO` object→class dispatch lattice experiment: why intraprocedural class
+  resolution collapses to ⊤ on real corpora, and what the shipping
+  MRO/CHA + provenance model does instead.
 
 > Past project-tracking documents (perf reports, phase trackers,
 > migration plans) are kept in [`../archive/`](../archive/) and are

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -211,6 +211,41 @@ same meaning as on CommandSpec.
 | `xc_operation` | `str \| None` | `None` | XC translation operation |
 | `forms` | `tuple[FormSpec, ...]` | `()` | Per-subcommand getter/setter forms |
 
+### ObjectClassSpec -- object-method dispatch
+
+A `TclOO` / megawidget class whose instances are dispatched as
+`$obj <method> …` is modelled by an `ObjectClassSpec` attached to the class
+*command* spec (the factory) via `CommandSpec.object_class`.  For a `TclOO`
+class the class name **is** the factory command name (`oo::class create Foo`
+binds command `Foo`), so a class spec resolves through the ordinary command
+table — no separate index (`CommandRegistry::object_class`).
+
+| Field | Type | Default | Purpose |
+|-------|------|---------|---------|
+| `class_name` | `&str` | *(required)* | Fully-qualified class name = factory command name |
+| `instance_methods` | `&[SubCommand]` | `&[]` | Methods dispatched on a handle (`Xaxis`, `Add`, …), reusing `SubCommand` (so option / enum / arg-value metadata is shared) |
+| `superclasses` | `&[&str]` | `&[]` | Direct superclass names for inherited-method resolution |
+| `allow_unknown_methods` | `bool` | `false` | Accept an unrecognised method without complaint |
+
+The class's `new` / `create` constructor returns an object handle of
+`class_name`.  Two consumers act on this:
+
+- **Object-handle tracking** (`tcl_compiler::object_types`) harvests
+  `set VAR [Class new|create …]` provenance so a variable is known to hold an
+  instance of `class_name`; it follows scalar and array-element handles across
+  the top level, procedures, and method bodies.  This is *provenance*, not the
+  object→class dispatch *lattice* prototyped in
+  [`../tcloo-mro-lattice.md`](../tcloo-mro-lattice.md), which measured as a
+  negative on real `TclOO` corpora (factory-return receivers dominate the ⊤
+  bucket); an un-provenanced (proc-parameter) receiver is deliberately left to
+  the generic shape-based option highlighting rather than resolved unsoundly.
+- **Semantic tokens** resolve a `$var method …` / `[Class new] method …`
+  dispatch against the class's `instance_methods` and colour the method plus
+  its declared options exactly like a built-in's — the object-handle half of
+  issue #748.  A method whose options are not modelled still resolves as a
+  method call; its `-option value` pairs fall through to the generic option
+  highlighting.
+
 ### FormSpec -- invocation forms
 
 A command can have multiple forms (getter vs setter):

--- a/docs/kcs/features/README.md
+++ b/docs/kcs/features/README.md
@@ -77,6 +77,7 @@ combine them when more than one form helps:
 - [kcs-feature-inlay-hints.md](kcs-feature-inlay-hints.md)
 - [kcs-feature-call-hierarchy.md](kcs-feature-call-hierarchy.md)
 - [kcs-feature-semantic-tokens.md](kcs-feature-semantic-tokens.md)
+- [kcs-feature-command-option-highlighting.md](kcs-feature-command-option-highlighting.md)
 - [kcs-feature-apl-language.md](kcs-feature-apl-language.md)
 - [kcs-feature-selection-range.md](kcs-feature-selection-range.md)
 - [kcs-feature-document-links.md](kcs-feature-document-links.md)

--- a/docs/kcs/features/kcs-feature-command-option-highlighting.md
+++ b/docs/kcs/features/kcs-feature-command-option-highlighting.md
@@ -1,0 +1,83 @@
+# KCS: feature — Command option highlighting
+
+> **Audience:** User
+> **Type:** Functionality
+
+## Applies to
+
+all-editors, analyser
+
+## Summary
+
+Words that read as `-option` switches, and the values they take, are given
+their own semantic-token colours — an option token for the switch and an
+option-value token for its argument — so a command's flags stand out from its
+positional strings.
+
+## How to use
+
+- **Editor**: Applied automatically as part of semantic highlighting. No
+  configuration; toggles with `tclLsp.features.semanticTokens`.
+
+## Operational context
+
+There are two layers, most-precise first:
+
+1. **Registry-declared options.** For a command the registry knows
+   (`lsort -index 2`, `file delete -force …`), only the switches the command
+   actually declares are highlighted, so a stray `puts -foo` stays a plain
+   string. Value-taking options colour their value too (an enum value as an
+   enum member, otherwise an option value).
+
+2. **Object-method options.** For an object handle bound by a constructor —
+   the standard `TclOO` / Tk pattern `set chart [ticklecharts::chart new]`
+   then `$chart Xaxis -name {v} -type value -min 0.4` — the handle's class is
+   tracked from the `new` call, the method is resolved against the class's
+   registry model, and its declared options and values are coloured precisely.
+   Direct `[Class new] method …` dispatch resolves the same way. See
+   [ObjectClassSpec](../../../docs/design/compiler/command-registry.md).
+
+3. **Generic fallback.** For any *unknown* command head (an object method on a
+   class not modelled in the registry, or a receiver that arrives as a proc
+   parameter), a word shaped like a clean option — a leading `-` then a
+   letter — is highlighted as an option and its following literal value as an
+   option value.
+
+The heuristic is careful about Tcl's own conventions: a negative number
+(`-5`, `-1.6`) or a special-float literal (`-inf`, `-nan`) is **not** an
+option; a substitution word (`-$var`, `-{$var}`, `-[cmd]`) keeps its own
+highlight; and the `--` end-of-options marker stops option scanning, so a
+following `-literal` is treated as a positional operand.
+
+## File-path anchors
+
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `insert_option_and_subcommand_overrides`
+  (registry options), `insert_object_method_overrides` (object methods),
+  `insert_generic_option_overrides` (fallback)
+- `rust/tcl-compiler/src/object_types.rs` — object-handle → class provenance
+- `rust/tcl-registry/src/spec.rs` — `ObjectClassSpec`
+- `rust/tcl-registry/src/commands/ticklecharts/mod.rs` — the ticklecharts pack
+
+## Failure modes
+
+- A `-option` on an unmodelled object method is highlighted by shape only, so
+  an invalid switch is not distinguished from a valid one.
+- A receiver passed through a proc parameter (or a dict value) is not
+  provenance-tracked, so it uses the generic fallback rather than the precise
+  registry path.
+- A negative-number argument that a command genuinely treats as a value is
+  correctly *not* highlighted as an option — by design.
+
+## Test anchors
+
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `unknown_head_options_classified_generically`,
+  `generic_option_scan_stops_at_double_dash`, `object_method_options_resolve_via_registry`,
+  `direct_constructor_dispatch_resolves_method`
+- `rust/tcl-compiler/src/object_types.rs` — `scalar_handle_from_constructor`
+- `rust/tcl-registry/src/commands/ticklecharts/mod.rs` — `chart_factory_and_methods_resolve`
+
+## Discoverability
+
+- [KCS feature index](README.md)
+- [Command registry](../../../docs/design/compiler/command-registry.md)
+- [Semantic tokens](kcs-feature-semantic-tokens.md)

--- a/editors/zed/src/generated/tcl_commands.json
+++ b/editors/zed/src/generated/tcl_commands.json
@@ -3419,6 +3419,38 @@
       "summary": "Generate a machine-readable error"
     },
     {
+      "name": "ticklecharts::Gridlayout",
+      "summary": "Multi-chart grid layout.",
+      "subcommands": [
+        "create",
+        "new"
+      ]
+    },
+    {
+      "name": "ticklecharts::chart",
+      "summary": "Main 2D ticklecharts chart.",
+      "subcommands": [
+        "create",
+        "new"
+      ]
+    },
+    {
+      "name": "ticklecharts::chart3D",
+      "summary": "3D ticklecharts chart.",
+      "subcommands": [
+        "create",
+        "new"
+      ]
+    },
+    {
+      "name": "ticklecharts::timeline",
+      "summary": "Animated multi-chart timeline.",
+      "subcommands": [
+        "create",
+        "new"
+      ]
+    },
+    {
       "name": "time",
       "summary": "Time the execution of a script"
     },

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -123,6 +123,7 @@ pub mod loops;
 pub mod lowering;
 pub mod lowering_hooks;
 pub mod memory_ssa;
+pub mod object_types;
 // Name normalisation moved to the shared `tcl-syntax` crate; re-export so
 // `crate::naming::*` keeps resolving across the compiler.
 pub use tcl_syntax::naming;

--- a/rust/tcl-compiler/src/object_types.rs
+++ b/rust/tcl-compiler/src/object_types.rs
@@ -1,0 +1,130 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Object-handle → class-name provenance for the `$obj method …` pattern.
+//!
+//! Recognises `set VAR [Factory new|create …]` where `Factory` is a
+//! registry-modelled `TclOO` class (carries an
+//! [`ObjectClassSpec`](tcl_registry::ObjectClassSpec)), so a later
+//! `$VAR method …` dispatch can resolve the method's options through the
+//! registry — the object-handle half of issue #748.
+//!
+//! This is **provenance** tracking, not class *inference*.  The class comes
+//! directly from the constructor call, which is the accurate signal for the
+//! trackable case: the object→class binding *lattice* was measured to add no
+//! resolving power on real `TclOO` corpora (`experiments/mro_eval/RESULTS.md`
+//! — 99.8% ⊤, factory-return dominating), because a receiver that arrives as a
+//! proc parameter is inherently un-provenanced intraprocedurally.  Those
+//! receivers are left to the generic shape-based option fallback rather than
+//! resolved with a wrong-or-abstain lattice.
+
+use std::collections::{HashMap, HashSet};
+
+use tcl_registry::CommandRegistry;
+
+use crate::compilation_unit::{CompilationUnit, FunctionUnit};
+use crate::ir::Statement;
+use crate::value_shapes::parse_command_substitution;
+
+/// Map every variable that holds a registry-class object handle to the set of
+/// class names it can hold, harvested from `set VAR [Class new|create …]`
+/// across the top level, procedures, and method bodies of `cu`.
+///
+/// Keys are the assignment target verbatim — a scalar name (`chart`) or an
+/// array element (`arr(key)`) — matching the handle text a `$VAR method`
+/// dispatch presents once its leading `$` is stripped.  The map unions across
+/// scopes: a highlight-only consumer does not need per-scope precision, and a
+/// variable named `chart` that is a `ticklecharts::chart` in one proc is
+/// overwhelmingly one in another.
+#[must_use]
+pub fn registry_object_handle_classes(
+    cu: &CompilationUnit,
+    registry: &CommandRegistry,
+) -> HashMap<String, HashSet<String>> {
+    let mut out: HashMap<String, HashSet<String>> = HashMap::new();
+    let units = std::iter::once(&cu.top_level)
+        .chain(cu.procedures.values())
+        .chain(cu.methods.values());
+    for fu in units {
+        harvest_unit(fu, registry, &mut out);
+    }
+    out
+}
+
+fn harvest_unit(
+    fu: &FunctionUnit,
+    registry: &CommandRegistry,
+    out: &mut HashMap<String, HashSet<String>>,
+) {
+    for block in fu.cfg.blocks.values() {
+        for stmt in &block.statements {
+            let Statement::AssignValue { name, value, .. } = stmt else {
+                continue;
+            };
+            if let Some(class) = constructor_class(value, registry) {
+                out.entry(name.clone())
+                    .or_default()
+                    .insert(class.to_string());
+            }
+        }
+    }
+}
+
+/// The registry class named by a `[Class new|create …]` constructor value, or
+/// `None` when the value is not such a call.  A `TclOO` class command may be
+/// written with or without the leading `::` global qualifier; the registry's
+/// [`CommandRegistry::object_class`] strips it as [`CommandRegistry::get`] does.
+fn constructor_class<'r>(value: &str, registry: &'r CommandRegistry) -> Option<&'r str> {
+    let (head, args) = parse_command_substitution(value.trim())?;
+    if !args.first().is_some_and(|s| s == "new" || s == "create") {
+        return None;
+    }
+    registry.object_class(&head).map(|c| c.class_name)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compilation_unit::CompilationUnit;
+    use tcl_registry::CommandRegistry;
+
+    #[test]
+    fn scalar_handle_from_constructor() {
+        let registry = CommandRegistry::build_default();
+        let src = "set chart [ticklecharts::chart new]\n$chart Xaxis -name x\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let map = registry_object_handle_classes(&cu, &registry);
+        assert_eq!(
+            map.get("chart").map(|s| s.contains("ticklecharts::chart")),
+            Some(true),
+            "chart should be tracked as a ticklecharts::chart handle; got {map:?}"
+        );
+    }
+
+    #[test]
+    fn non_constructor_assignment_is_not_a_handle() {
+        let registry = CommandRegistry::build_default();
+        let src = "set x [expr {1 + 2}]\nset y hello\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let map = registry_object_handle_classes(&cu, &registry);
+        assert!(
+            map.is_empty(),
+            "no object handles expected for non-constructor assignments; got {map:?}"
+        );
+    }
+}

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -579,6 +579,7 @@ fn special_arg_kinds(
     head: &str,
     oo_grammar: Option<&'static DefinitionBodyGrammar>,
     arg_texts: &[&str],
+    object_classes: &ObjectClassMap,
 ) -> FxHashMap<u32, ArgOverride> {
     let mut overrides = FxHashMap::default();
 
@@ -604,6 +605,8 @@ fn special_arg_kinds(
     }
 
     insert_option_and_subcommand_overrides(seg, registry, head, &mut overrides);
+    insert_object_method_overrides(seg, registry, object_classes, &mut overrides);
+    insert_generic_option_overrides(seg, registry, head, &mut overrides);
     insert_enum_value_overrides(seg, registry, head, &mut overrides);
     insert_oo_define_keyword_overrides(seg, registry, &mut overrides);
     insert_apply_lambda_override(seg, &mut overrides);
@@ -1092,6 +1095,264 @@ fn insert_option_and_subcommand_overrides(
             }
         }
     }
+}
+
+/// Generic `-option` / option-value highlighting for a command with a
+/// *computed* head not resolved by the registry — a `$obj method …` object
+/// dispatch, a `[Class new] method …`, or a multi-fragment `chartV$node …`
+/// head.
+///
+/// A *registered* command's declared option set is authoritative — `puts -foo`
+/// stays a string because `puts` declares no `-foo`
+/// ([`insert_option_and_subcommand_overrides`]).  A plain bareword head is a
+/// (possibly user-defined) command name and is left to the registry too, so
+/// `mycmd -foo` stays a string.  Only a computed head — where the real option
+/// set lives on a method / ensemble the registry does not model — is treated as
+/// the overwhelmingly-common `-switch value` shape.  This is the fallback half
+/// of issue #748: colour those pairs like any built-in's.
+///
+/// A "clean option" is a single-token [`TokenType::Esc`] word for which
+/// [`is_generic_option_word`] holds — `-<letter>…`, excluding substitution
+/// forms, negative numbers (including the `-inf` / `-nan` special-float
+/// literals), a bare `-`, and `--`.  The single-token check is what excludes
+/// `-$var` / `-{$var}` / `-[cmd]`, which keep their variable / command
+/// highlight.
+///
+/// Tcl's `--` end-of-options marker is honoured: `--` itself is coloured as an
+/// option marker, and scanning stops there — every following word is a
+/// positional operand, even if it reads like `-foo` (`$obj cfg -- -literal`
+/// leaves `-literal` a plain string).
+///
+/// The word immediately following an option is recoloured [`TokenKind::OptionValue`]
+/// when it is a literal (`Esc`/`Str`) that is not itself an option and not
+/// `--` — a `$var` / `[cmd]` value keeps its own highlight, and a following
+/// option stays an option.  Arity is unknown for an undeclared command, so at
+/// most the single adjacent value word is claimed; a boolean option followed by
+/// another option therefore claims no value.
+fn insert_generic_option_overrides(
+    seg: &tcl_compiler::segmenter::SegmentedCommand,
+    registry: &CommandRegistry,
+    head: &str,
+    overrides: &mut FxHashMap<u32, ArgOverride>,
+) {
+    // Only unknown heads — a registered command's declared option set is the
+    // authority, and a bare `-word` there (`puts -foo`) is deliberately a
+    // string.
+    if registry.get(head).is_some() {
+        return;
+    }
+    // Only a *computed* head — a `$var` / `[cmd]` substitution or a
+    // multi-fragment word (`chartV$node`) — is treated as a runtime dispatch
+    // (object handle, ensemble) whose `-switch value` pairs are options.  A
+    // plain single-token bareword head is a (possibly user-defined) command
+    // name; deferring to the registry there keeps a bareword call conservative
+    // — `mycmd -foo` stays a string, a user command's `test … -body …` is not
+    // mistaken for tcltest's, and an OO-body member (`property … -get {…}`)
+    // keeps its recursed bodies — exactly as `puts -foo` stays a string.
+    let head_is_computed = seg
+        .argv
+        .first()
+        .is_some_and(|t| matches!(t.kind, TokenType::Var | TokenType::Cmd))
+        || !seg.single_token_word.first().copied().unwrap_or(true);
+    if !head_is_computed {
+        return;
+    }
+    // The single-token literal (`Esc`) text of word `i`, or `None` for a
+    // substitution / braced / multi-fragment word.
+    let literal_word = |i: usize| -> Option<&str> {
+        (seg.single_token_word.get(i).copied().unwrap_or(false)
+            && seg
+                .argv
+                .get(i)
+                .is_some_and(|t| matches!(t.kind, TokenType::Esc)))
+        .then(|| seg.texts.get(i).map(String::as_str))
+        .flatten()
+    };
+    let mut i = 1;
+    while i < seg.texts.len() {
+        let Some(text) = literal_word(i) else {
+            i += 1;
+            continue;
+        };
+        // `--` ends option processing (Tcl convention). Colour the marker, then
+        // stop — nothing after it is an option.
+        if text == "--" {
+            if let Some(tok) = seg.argv.get(i) {
+                overrides
+                    .entry(tok.span.start())
+                    .or_insert(ArgOverride::Decorator);
+            }
+            break;
+        }
+        if !is_generic_option_word(text) {
+            i += 1;
+            continue;
+        }
+        if let Some(tok) = seg.argv.get(i) {
+            overrides
+                .entry(tok.span.start())
+                .or_insert(ArgOverride::Decorator);
+        }
+        // The immediately-following literal word is this option's value when it
+        // is not itself an option and not the `--` marker.  A `$var` / `[cmd]`
+        // value falls through the `Esc | Str` check and keeps its own highlight.
+        let vi = i + 1;
+        if let Some(val_tok) = seg.argv.get(vi)
+            && matches!(val_tok.kind, TokenType::Esc | TokenType::Str)
+            && literal_word(vi).is_none_or(|w| w != "--" && !is_generic_option_word(w))
+        {
+            overrides
+                .entry(val_tok.span.start())
+                .or_insert(ArgOverride::Kind(TokenKind::OptionValue));
+        }
+        i += 1;
+    }
+}
+
+/// Whether a literal word reads as a generic `-option` switch on an unknown
+/// command head: a leading `-` then an ASCII letter, excluding the negative
+/// special-float literals Tcl's parser accepts as numbers (`-inf`, `-Inf`,
+/// `-infinity`, `-nan`, …).  A bare `-`, `--`, and ordinary negative numbers
+/// (`-5`, `-1.6`) are already excluded by the "letter after the dash" rule.
+fn is_generic_option_word(text: &str) -> bool {
+    let Some(rest) = text.strip_prefix('-') else {
+        return false;
+    };
+    if !rest.as_bytes().first().is_some_and(u8::is_ascii_alphabetic) {
+        return false;
+    }
+    // `-inf` / `-infinity` / `-nan` are negative floating-point values, not
+    // options — Tcl's `expr` and numeric commands parse them as numbers.
+    !(rest.eq_ignore_ascii_case("inf")
+        || rest.eq_ignore_ascii_case("infinity")
+        || rest.eq_ignore_ascii_case("nan"))
+}
+
+/// Object-handle → class-name map for the current document, keyed by the
+/// handle text a `$var method` dispatch presents (minus the leading `$`) —
+/// a scalar (`chart`) or array element (`arr(key)`).  Built once per document
+/// from the [`CompilationUnit`] by
+/// [`tcl_compiler::object_types::registry_object_handle_classes`].
+type ObjectClassMap = std::collections::HashMap<String, std::collections::HashSet<String>>;
+
+/// Precise `$obj method …` highlighting via the registry's object-class model —
+/// the object-handle half of issue #748.
+///
+/// When the command head is an object handle whose class is known — a `$var`
+/// bound by `set var [Class new]` (tracked by [`tcl_compiler::object_types`]),
+/// or a direct `[Class new] method …` dispatch — and the class declares
+/// `method`, the method word is highlighted as a function and the method's
+/// declared options / option values are coloured exactly like a built-in's
+/// (`Decorator` for the switch, `EnumMember` for a closed-set value, else
+/// `OptionValue`).
+///
+/// Runs before [`insert_generic_option_overrides`]: a recognised method's
+/// options are claimed precisely first, and anything it leaves (an option not
+/// in the spec, an un-provenanced receiver) is picked up by the generic
+/// shape-based fallback.  A `$var` / `[cmd]` option value keeps its own
+/// highlight; only literal (`Esc`/`Str`) values are recoloured.
+fn insert_object_method_overrides(
+    seg: &tcl_compiler::segmenter::SegmentedCommand,
+    registry: &CommandRegistry,
+    object_classes: &ObjectClassMap,
+    overrides: &mut FxHashMap<u32, ArgOverride>,
+) {
+    let (Some(head_tok), Some(head_text), Some(method)) =
+        (seg.argv.first(), seg.texts.first(), seg.texts.get(1))
+    else {
+        return;
+    };
+    // Resolve the dispatched method's spec from the head's class(es).
+    let method_sub = match head_tok.kind {
+        TokenType::Var => object_handle_name(head_text)
+            .and_then(|name| object_classes.get(name))
+            .and_then(|classes| {
+                classes
+                    .iter()
+                    .find_map(|cls| registry.instance_method(cls, method))
+            }),
+        TokenType::Cmd => constructor_class_of_head(head_text, registry)
+            .and_then(|cls| registry.instance_method(cls, method)),
+        _ => None,
+    };
+    let Some(method_sub) = method_sub else {
+        return;
+    };
+    // Highlight the method word itself as a callable.
+    if let Some(mtok) = seg.argv.get(1) {
+        overrides
+            .entry(mtok.span.start())
+            .or_insert(ArgOverride::Kind(TokenKind::Function));
+    }
+    // Apply the method's declared options to the words after it (`skip(2)`).
+    for (i, text) in seg.texts.iter().enumerate().skip(2) {
+        if text == "--" {
+            // End-of-options marker — colour it, then stop (Tcl convention).
+            if let Some(tok) = seg.argv.get(i) {
+                overrides
+                    .entry(tok.span.start())
+                    .or_insert(ArgOverride::Decorator);
+            }
+            break;
+        }
+        if !text.starts_with('-') {
+            continue;
+        }
+        let Some(opt) = method_sub.options.iter().find(|o| o.matches(text)) else {
+            continue;
+        };
+        if let Some(tok) = seg.argv.get(i) {
+            overrides
+                .entry(tok.span.start())
+                .or_insert(ArgOverride::Decorator);
+        }
+        // Colour the option's value word(s).  A value whose role is claimed by
+        // a later token pass is left alone (parity with the command path).
+        if opt.takes_value() && !role_claimed_by_token_pass(opt.value_role()) {
+            let values = opt.value_values();
+            for vi in opt.value_indices(&seg.texts, i) {
+                let (Some(val_tok), Some(val_text)) = (seg.argv.get(vi), seg.texts.get(vi)) else {
+                    continue;
+                };
+                if !matches!(val_tok.kind, TokenType::Esc | TokenType::Str) {
+                    continue;
+                }
+                let kind = if !values.is_empty()
+                    && values.iter().any(|v| v.value == val_text.as_str())
+                {
+                    TokenKind::EnumMember
+                } else {
+                    TokenKind::OptionValue
+                };
+                overrides
+                    .entry(val_tok.span.start())
+                    .or_insert(ArgOverride::Kind(kind));
+            }
+        }
+    }
+}
+
+/// The bare handle name of a `$var` command head, matching the keys of an
+/// [`ObjectClassMap`]: strips the leading `$` and any `${…}` braces, so
+/// `$chart` → `chart`, `${chart}` → `chart`, `$arr(k)` → `arr(k)`.  Returns
+/// `None` for a head that is not a plain variable substitution.
+fn object_handle_name(head_text: &str) -> Option<&str> {
+    let rest = head_text.strip_prefix('$')?;
+    Some(
+        rest.strip_prefix('{')
+            .and_then(|r| r.strip_suffix('}'))
+            .unwrap_or(rest),
+    )
+}
+
+/// The registry class named by a direct `[Class new|create …]` command-head
+/// dispatch, or `None` when the head is not such a constructor call.
+fn constructor_class_of_head<'r>(head_text: &str, registry: &'r CommandRegistry) -> Option<&'r str> {
+    let (cmd, args) = tcl_compiler::value_shapes::parse_command_substitution(head_text)?;
+    if !args.first().is_some_and(|s| s == "new" || s == "create") {
+        return None;
+    }
+    registry.object_class(&cmd).map(|c| c.class_name)
 }
 
 /// Registry-known closed-set argument values → `EnumMember`.  The registry
@@ -2190,6 +2451,12 @@ struct ScriptCtx<'a> {
     /// retroactively re-tag an earlier same-named command.  Empty when the
     /// document has no `namespace import`.
     head_aliases: &'a FxHashMap<String, (String, u32)>,
+    /// Object-handle → class-name provenance for the whole document, so a
+    /// `$var method …` dispatch can resolve the method's options through the
+    /// registry's object-class model (issue #748).  Empty when no
+    /// [`CompilationUnit`] is available or the document creates no tracked
+    /// object handles.
+    object_classes: &'a ObjectClassMap,
 }
 
 fn collect_switch_case_list(
@@ -2598,8 +2865,14 @@ fn collect_script(
         // hot path to a single bridging allocation per command.
         let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
 
-        let mut overrides =
-            special_arg_kinds(&seg, registry, resolved_head, ctx.oo_grammar, &arg_texts);
+        let mut overrides = special_arg_kinds(
+            &seg,
+            registry,
+            resolved_head,
+            ctx.oo_grammar,
+            &arg_texts,
+            ctx.object_classes,
+        );
         // Regex-source tracking: retag a `set` value word that feeds a regexp
         // pattern as a (substitution-aware) regex.  Keyed on the def-site word
         // start; the compiler-supplied span is authoritative for the fragment
@@ -3049,6 +3322,14 @@ fn collect_entries(
     // lookups) unless the document actually imports something.
     let head_aliases = imported_command_aliases(source, dialect, registry);
 
+    // Object-handle → class provenance (`set chart [ticklecharts::chart new]`
+    // → `chart`), so a `$chart Xaxis -name …` dispatch resolves the method's
+    // options through the registry (issue #748).  Empty without a
+    // `CompilationUnit` or when the document creates no tracked object handles.
+    let object_classes: ObjectClassMap = cu.map_or_else(ObjectClassMap::default, |cu| {
+        tcl_compiler::object_types::registry_object_handle_classes(cu, registry)
+    });
+
     // Walk every segmented command (recursing into braced bodies, braced
     // expressions, and `[…]` command substitutions) and classify each token.
     let ctx = ScriptCtx {
@@ -3059,6 +3340,7 @@ fn collect_entries(
         oo_grammar: None,
         regex_sources: &regex_sources,
         head_aliases: &head_aliases,
+        object_classes: &object_classes,
     };
     collect_script(ctx, source, 0, &mut entries, 0);
 
@@ -3681,6 +3963,86 @@ mod tests {
     }
 
     #[test]
+    fn unknown_head_options_classified_generically() {
+        // The ngspice / ticklecharts pattern (issue #748): `$chart Xaxis -name
+        // {v(anode), V} -type value -min 0.4` — the head `$chart` is an object
+        // handle, unknown to the registry, so its `-switch value` pairs are
+        // highlighted by the generic heuristic.
+        let ks = kinds(
+            "$chart Xaxis -name {v} -type value -min 0.4\n",
+            "tcl",
+            &reg(),
+        );
+        assert!(
+            ks.contains(&(TokenKind::Decorator as u32)),
+            "expected -name/-type/-min decorators on an unknown head; got {ks:?}"
+        );
+        assert!(
+            ks.contains(&(TokenKind::OptionValue as u32)),
+            "expected option values on an unknown head; got {ks:?}"
+        );
+        // A negative number is not an option: `$obj move -5 10`.
+        let ks = kinds("$obj move -5 10\n", "tcl", &reg());
+        assert!(
+            !ks.contains(&(TokenKind::Decorator as u32)),
+            "-5 is a negative number, not an option; got {ks:?}"
+        );
+        // A `-$var` substitution word is not an option.
+        let ks = kinds("$obj configure -$flag v\n", "tcl", &reg());
+        assert!(
+            !ks.contains(&(TokenKind::Decorator as u32)),
+            "-$flag is a substitution, not an option; got {ks:?}"
+        );
+        // A known command keeps the strict declared-option behaviour: `puts
+        // -foo` stays a string even though the generic pass exists.
+        let ks = kinds("puts -foo\n", "tcl", &reg());
+        assert!(
+            !ks.contains(&(TokenKind::Decorator as u32)),
+            "a known command's undeclared -foo must stay a string; got {ks:?}"
+        );
+        // A plain bareword unknown head is a (possibly user-defined) command
+        // name, not a computed dispatch: `mycmd -foo bar` stays a string so a
+        // user proc's argument is not mistaken for an option.
+        let ks = kinds("mycmd -foo bar\n", "tcl", &reg());
+        assert!(
+            !ks.contains(&(TokenKind::Decorator as u32)),
+            "a bareword user command's -foo must stay a string; got {ks:?}"
+        );
+        // Negative special-float literals are numbers, not options: `-inf`,
+        // `-Inf`, `-nan` all start with a letter but Tcl parses them as values.
+        let ks = kinds("$obj set -inf\n", "tcl", &reg());
+        assert!(
+            !ks.contains(&(TokenKind::Decorator as u32)),
+            "-inf is a negative float literal, not an option; got {ks:?}"
+        );
+        let ks = kinds("$obj set -NaN\n", "tcl", &reg());
+        assert!(
+            !ks.contains(&(TokenKind::Decorator as u32)),
+            "-NaN is a float literal, not an option; got {ks:?}"
+        );
+    }
+
+    #[test]
+    fn generic_option_scan_stops_at_double_dash() {
+        // Tcl's `--` ends option processing: `-real` before it is an option,
+        // the `--` is the marker, and `-literal` after it is a positional
+        // operand (a plain string), not an option.
+        // Columns: `-real` at 9, `1` at 15, `--` at 17, `-literal` at 20.
+        let mut deco: Vec<u32> = decode_full("$obj cfg -real 1 -- -literal\n", "tcl", &reg())
+            .iter()
+            .filter(|(_, _, _, k, _)| *k == TokenKind::Decorator as u32)
+            .map(|&(_, c, _, _, _)| c)
+            .collect();
+        deco.sort_unstable();
+        // Exactly `-real` (9) and `--` (17) — never `-literal` (20).
+        assert_eq!(
+            deco,
+            vec![9, 17],
+            "expected -real and -- as the only decorators, not -literal after --; got {deco:?}"
+        );
+    }
+
+    #[test]
     fn value_taking_option_value_classified_as_option_value() {
         // `lsort -index 2 $l` — `-index` takes a value, so the literal `2` is
         // an option value (distinct from the `-index` decorator).
@@ -3964,6 +4326,60 @@ mod tests {
                 assert!(c1 >= c0 + len0, "overlap; toks={toks:?}");
             }
         }
+    }
+
+    #[test]
+    fn object_method_options_resolve_via_registry() {
+        // The ngspice / ticklecharts pattern (issue #748), end-to-end through
+        // the CompilationUnit: `set chart [ticklecharts::chart new]` binds the
+        // handle's class, so `$chart Xaxis -name … -type value …` resolves the
+        // method and its declared options through the registry's object-class
+        // model — the precise path, not the shape-based fallback.
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        let registry = reg();
+        let src = "set chart [ticklecharts::chart new]\n$chart Xaxis -name {v(anode), V} -type value -min 0.4 -splitLine {show True}\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let toks = decode_semantic(&full_with_cu(src, "tcl9.0", &registry, Some(&cu)));
+        let ks: Vec<u32> = toks.iter().map(|&(_, _, _, k, _)| k).collect();
+        // `Xaxis` resolved as a callable method.
+        assert!(
+            ks.contains(&(TokenKind::Function as u32)),
+            "expected Xaxis as a Function token; got {ks:?}"
+        );
+        // `-name` / `-type` / `-min` / `-splitLine` are decorators.
+        assert!(
+            ks.iter()
+                .filter(|&&k| k == TokenKind::Decorator as u32)
+                .count()
+                >= 4,
+            "expected the four axis options as decorators; got {ks:?}"
+        );
+        // `-type value` is a closed-set member; `-min 0.4` a generic value.
+        assert!(
+            ks.contains(&(TokenKind::EnumMember as u32)),
+            "expected -type's `value` as an EnumMember; got {ks:?}"
+        );
+        assert!(
+            ks.contains(&(TokenKind::OptionValue as u32)),
+            "expected -min's `0.4` as an OptionValue; got {ks:?}"
+        );
+    }
+
+    #[test]
+    fn direct_constructor_dispatch_resolves_method() {
+        // A direct `[Class new] method …` dispatch (no intermediate variable)
+        // resolves the method and its options through the registry too.
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        let registry = reg();
+        let src = "[ticklecharts::chart new] Yaxis -name Y -max 10\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let toks = decode_semantic(&full_with_cu(src, "tcl9.0", &registry, Some(&cu)));
+        let ks: Vec<u32> = toks.iter().map(|&(_, _, _, k, _)| k).collect();
+        assert!(
+            ks.contains(&(TokenKind::Decorator as u32))
+                && ks.contains(&(TokenKind::OptionValue as u32)),
+            "expected -name/-max decorators + values on direct dispatch; got {ks:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-registry/src/commands/mod.rs
+++ b/rust/tcl-registry/src/commands/mod.rs
@@ -33,4 +33,5 @@ pub mod sdc_base;
 pub mod stdlib;
 pub mod tcl;
 pub mod tcllib;
+pub mod ticklecharts;
 pub mod tk;

--- a/rust/tcl-registry/src/commands/ticklecharts/mod.rs
+++ b/rust/tcl-registry/src/commands/ticklecharts/mod.rs
@@ -1,0 +1,500 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The `ticklecharts` package — a `TclOO` wrapper around Apache `ECharts` by
+//! nico-robert (<https://github.com/nico-robert/ticklecharts>).
+//!
+//! The public entry points are `oo::class`es (`ticklecharts::chart`,
+//! `ticklecharts::chart3D`, `ticklecharts::timeline`, `ticklecharts::Gridlayout`,
+//! …) instantiated with `new`; the returned object handle is then dispatched as
+//! `$chart Xaxis -name … -type value …`.  Each such method forwards its
+//! `-option value` pairs to a namespace proc that declares them via
+//! ticklecharts' `setdef` DSL, so the option surface is static and enumerable
+//! from source — but very large (hundreds of options across ~27 series types).
+//!
+//! This pack models the class factories via [`ObjectClassSpec`] and the chart
+//! object's methods with their most-used options, so `$chart Xaxis -name …`
+//! resolves its switches through the registry (issue #748).  It is deliberately
+//! **staged**: the axis methods and the common series/global switches are
+//! covered; the full per-series option tables are a follow-up best produced by
+//! generating from the ticklecharts `setdef` source rather than by hand.  A
+//! method whose options are not yet modelled still resolves as a method call —
+//! its `-option value` pairs fall through to the generic option highlighting.
+
+use crate::prelude::*;
+
+/// A value-taking option (`-name value`) — the ticklecharts norm (even
+/// booleans are written `-opt True`).
+const fn vopt(name: &'static str, detail: &'static str) -> OptionSpec {
+    OptionSpec {
+        name,
+        value: OptionValue::value(""),
+        detail,
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    }
+}
+
+/// A value-taking option introduced in a specific `ECharts` version.
+const fn vopt_since(
+    name: &'static str,
+    detail: &'static str,
+    min_version: &'static str,
+) -> OptionSpec {
+    OptionSpec {
+        name,
+        value: OptionValue::value(""),
+        detail,
+        dialects: None,
+        aliases: &[],
+        min_version: Some(min_version),
+    }
+}
+
+/// A closed-set (enumerated) value option (`-type value|category|time|log`).
+const fn eopt(name: &'static str, detail: &'static str, values: &'static [ArgValue]) -> OptionSpec {
+    OptionSpec {
+        name,
+        value: OptionValue::enumerated(values, false, ""),
+        detail,
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    }
+}
+
+/// An instance method with declared options.
+const fn method(
+    name: &'static str,
+    detail: &'static str,
+    options: &'static [OptionSpec],
+) -> SubCommand {
+    SubCommand {
+        name,
+        detail,
+        options,
+        ..SubCommand::DEFAULT
+    }
+}
+
+const AXIS_TYPE_VALUES: &[ArgValue] = &[
+    ArgValue {
+        value: "value",
+        detail: "Numerical axis.",
+    },
+    ArgValue {
+        value: "category",
+        detail: "Category axis.",
+    },
+    ArgValue {
+        value: "time",
+        detail: "Time axis.",
+    },
+    ArgValue {
+        value: "log",
+        detail: "Logarithmic axis.",
+    },
+];
+
+/// Options shared by the cartesian / polar axis methods (`Xaxis`, `Yaxis`,
+/// `RadiusAxis`, `AngleAxis`).  Extracted from `ticklecharts::xAxis`
+/// (`axis.tcl`); the polar axes accept a near-identical set.
+const AXIS_OPTIONS: &[OptionSpec] = &[
+    vopt("-id", "Component ID."),
+    vopt("-show", "Whether to show the axis."),
+    eopt("-type", "Axis type.", AXIS_TYPE_VALUES),
+    vopt("-data", "Category data (category axis)."),
+    vopt("-gridIndex", "Index of the grid this axis belongs to."),
+    vopt_since(
+        "-alignTicks",
+        "Align split lines of multiple axes.",
+        "5.3.0",
+    ),
+    vopt("-position", "Axis position."),
+    vopt("-offset", "Offset of this axis from the default position."),
+    vopt("-name", "Axis name."),
+    vopt("-nameLocation", "Location of the axis name."),
+    vopt("-nameTextStyle", "Text style of the axis name."),
+    vopt("-nameGap", "Gap between axis name and axis line."),
+    vopt("-nameRotate", "Rotation of the axis name."),
+    vopt("-nameTruncate", "Truncation rule for the axis name."),
+    vopt("-inverse", "Whether the axis is inverted."),
+    vopt("-boundaryGap", "Boundary gap on both sides of the axis."),
+    vopt("-min", "Minimum value of the axis."),
+    vopt("-max", "Maximum value of the axis."),
+    vopt("-scale", "Whether the scale excludes zero."),
+    vopt("-splitNumber", "Number of segments the axis is split into."),
+    vopt("-minInterval", "Minimum gap between split lines."),
+    vopt("-maxInterval", "Maximum gap between split lines."),
+    vopt("-interval", "Manual gap between split lines."),
+    vopt("-logBase", "Base of the logarithm (log axis)."),
+    vopt("-silent", "Whether the axis is silent (no events)."),
+    vopt("-triggerEvent", "Whether axis labels trigger events."),
+    vopt("-axisLine", "Axis line settings."),
+    vopt("-axisTick", "Axis tick settings."),
+    vopt("-minorTick", "Minor tick settings."),
+    vopt("-axisLabel", "Axis label settings."),
+    vopt("-splitLine", "Split line settings."),
+    vopt("-minorSplitLine", "Minor split line settings."),
+    vopt("-splitArea", "Split area settings."),
+    vopt("-axisPointer", "Axis pointer settings."),
+    vopt("-zlevel", "Z-level for the canvas layer."),
+    vopt("-z", "Z-depth within the same z-level."),
+    vopt("-polarIndex", "Index of the polar coordinate (polar axes)."),
+    vopt("-startAngle", "Starting angle (angle axis)."),
+    vopt("-clockwise", "Whether the angle axis increases clockwise."),
+];
+
+/// Options common to the series adders (`AddLineSeries`, `AddBarSeries`, …) and
+/// the generic `Add` dispatcher.  Extracted from `ticklecharts::lineSeries` /
+/// `barSeries` (`series.tcl`); each series type also has type-specific options
+/// not yet modelled here.
+const SERIES_OPTIONS: &[OptionSpec] = &[
+    vopt("-id", "Series ID."),
+    vopt("-name", "Series name."),
+    vopt("-type", "Series type."),
+    vopt_since(
+        "-colorBy",
+        "Strategy for assigning colours to data.",
+        "5.2.0",
+    ),
+    vopt("-coordinateSystem", "Coordinate system the series uses."),
+    vopt("-xAxisIndex", "Index of the x axis to use."),
+    vopt("-yAxisIndex", "Index of the y axis to use."),
+    vopt("-symbol", "Symbol of the data points."),
+    vopt("-symbolSize", "Size of the data-point symbols."),
+    vopt("-symbolRotate", "Rotation of the data-point symbols."),
+    vopt("-showSymbol", "Whether to show the symbols."),
+    vopt("-smooth", "Whether the line is smoothed."),
+    vopt("-stack", "Name of the stack group."),
+    vopt(
+        "-legendHoverLink",
+        "Whether to link legend hover to the series.",
+    ),
+    vopt("-connectNulls", "Whether to connect across null points."),
+    vopt(
+        "-clip",
+        "Whether to clip the series to the coordinate system.",
+    ),
+    vopt("-step", "Whether the line is a step line."),
+    vopt("-lineStyle", "Line style settings."),
+    vopt("-areaStyle", "Area style settings."),
+    vopt("-itemStyle", "Item (data point) style settings."),
+    vopt("-label", "Data label settings."),
+    vopt("-labelLine", "Label guide line settings."),
+    vopt("-emphasis", "Emphasis (hover) state settings."),
+    vopt("-blur", "Blur (faded) state settings."),
+    vopt("-select", "Select state settings."),
+    vopt("-markPoint", "Mark point settings."),
+    vopt("-markLine", "Mark line settings."),
+    vopt("-markArea", "Mark area settings."),
+    vopt("-tooltip", "Per-series tooltip settings."),
+    vopt("-data", "Series data."),
+    vopt("-encode", "Data-dimension to axis encoding."),
+    vopt("-datasetIndex", "Index of the dataset to use."),
+    vopt("-animation", "Whether the series is animated."),
+    vopt("-zlevel", "Z-level for the canvas layer."),
+    vopt("-z", "Z-depth within the same z-level."),
+];
+
+/// Top-level global-option switches accepted by `SetOptions` (`chart.tcl:874`);
+/// each delegates to a same-named component proc (`ticklecharts::title`,
+/// `legend`, …) with its own option block.
+const SETOPTIONS_SWITCHES: &[OptionSpec] = &[
+    vopt("-backgroundColor", "Chart background colour."),
+    vopt("-color", "Default series colour palette."),
+    vopt("-title", "Title component."),
+    vopt("-legend", "Legend component."),
+    vopt("-grid", "Cartesian grid component."),
+    vopt("-tooltip", "Global tooltip component."),
+    vopt("-toolbox", "Toolbox component."),
+    vopt("-dataZoom", "Data-zoom component."),
+    vopt("-visualMap", "Visual-map component."),
+    vopt("-dataset", "Dataset component."),
+    vopt("-polar", "Polar coordinate component."),
+    vopt("-radiusAxis", "Radius axis (polar)."),
+    vopt("-angleAxis", "Angle axis (polar)."),
+    vopt("-radar", "Radar coordinate component."),
+    vopt("-parallel", "Parallel coordinate component."),
+    vopt("-parallelAxis", "Parallel axis component."),
+    vopt("-singleAxis", "Single axis component."),
+    vopt("-brush", "Brush (selection) component."),
+    vopt("-axisPointer", "Global axis pointer component."),
+    vopt("-geo", "Geographic coordinate component."),
+    vopt("-calendar", "Calendar coordinate component."),
+    vopt("-aria", "Accessibility (ARIA) component."),
+    vopt("-graphic", "Graphic-element component."),
+    vopt("-textStyle", "Global text style."),
+    vopt("-animation", "Whether global animation is enabled."),
+    vopt("-darkMode", "Whether dark mode is enabled."),
+];
+
+/// The `chart` class methods (`chart.tcl`).  The axis and `SetOptions`
+/// switches are modelled; the series adders share [`SERIES_OPTIONS`]; the
+/// render / export accessors take no `-option` switches.
+const CHART_METHODS: &[SubCommand] = &[
+    method("Xaxis", "Configure the cartesian X axis.", AXIS_OPTIONS),
+    method("Yaxis", "Configure the cartesian Y axis.", AXIS_OPTIONS),
+    method(
+        "RadiusAxis",
+        "Configure the polar radius axis.",
+        AXIS_OPTIONS,
+    ),
+    method("AngleAxis", "Configure the polar angle axis.", AXIS_OPTIONS),
+    method("SingleAxis", "Configure a single axis.", AXIS_OPTIONS),
+    method("ParallelAxis", "Configure a parallel axis.", AXIS_OPTIONS),
+    method(
+        "SetOptions",
+        "Set global chart options.",
+        SETOPTIONS_SWITCHES,
+    ),
+    method("AddLineSeries", "Add a line series.", SERIES_OPTIONS),
+    method("AddBarSeries", "Add a bar series.", SERIES_OPTIONS),
+    method("AddPieSeries", "Add a pie series.", SERIES_OPTIONS),
+    method("AddScatterSeries", "Add a scatter series.", SERIES_OPTIONS),
+    method("AddFunnelSeries", "Add a funnel series.", SERIES_OPTIONS),
+    method("AddRadarSeries", "Add a radar series.", SERIES_OPTIONS),
+    method("AddHeatmapSeries", "Add a heatmap series.", SERIES_OPTIONS),
+    method(
+        "AddSunburstSeries",
+        "Add a sunburst series.",
+        SERIES_OPTIONS,
+    ),
+    method("AddTreeSeries", "Add a tree series.", SERIES_OPTIONS),
+    method(
+        "AddThemeRiverSeries",
+        "Add a theme-river series.",
+        SERIES_OPTIONS,
+    ),
+    method("AddSankeySeries", "Add a sankey series.", SERIES_OPTIONS),
+    method(
+        "AddPictorialBarSeries",
+        "Add a pictorial-bar series.",
+        SERIES_OPTIONS,
+    ),
+    method(
+        "AddCandlestickSeries",
+        "Add a candlestick series.",
+        SERIES_OPTIONS,
+    ),
+    method(
+        "AddParallelSeries",
+        "Add a parallel series.",
+        SERIES_OPTIONS,
+    ),
+    method("AddGaugeSeries", "Add a gauge series.", SERIES_OPTIONS),
+    method("AddGraphSeries", "Add a graph series.", SERIES_OPTIONS),
+    method(
+        "AddWordCloudSeries",
+        "Add a word-cloud series.",
+        SERIES_OPTIONS,
+    ),
+    method("AddBoxPlotSeries", "Add a box-plot series.", SERIES_OPTIONS),
+    method("AddTreeMapSeries", "Add a treemap series.", SERIES_OPTIONS),
+    method("AddMapSeries", "Add a map series.", SERIES_OPTIONS),
+    method("AddLinesSeries", "Add a lines series.", SERIES_OPTIONS),
+    method("Add", "Add a series by type name.", SERIES_OPTIONS),
+    method("AddGraphic", "Add a graphic element.", &[]),
+    method("RadarCoordinate", "Configure the radar coordinate.", &[]),
+    method("AddJSON", "Add raw JSON options.", &[]),
+    method("Render", "Render the chart to an HTML file.", &[]),
+    method("toHTML", "Return the chart as an HTML string.", &[]),
+    method("toJSON", "Return the chart options as JSON.", &[]),
+    method("get", "Get the chart option dictionary.", &[]),
+    method("options", "Get the chart options.", &[]),
+];
+
+static CHART_CLASS: ObjectClassSpec = ObjectClassSpec {
+    class_name: "ticklecharts::chart",
+    instance_methods: CHART_METHODS,
+    superclasses: &[],
+    allow_unknown_methods: false,
+};
+
+/// The `chart3D` class methods (`chart3D.tcl`).  Options for the 3D axes and
+/// series are not yet modelled — the methods resolve as calls and their
+/// switches fall through to generic option highlighting.
+const CHART3D_METHODS: &[SubCommand] = &[
+    method("Xaxis3D", "Configure the 3D X axis.", &[]),
+    method("Yaxis3D", "Configure the 3D Y axis.", &[]),
+    method("Zaxis3D", "Configure the 3D Z axis.", &[]),
+    method("AddLine3DSeries", "Add a 3D line series.", &[]),
+    method("AddBar3DSeries", "Add a 3D bar series.", &[]),
+    method("AddSurfaceSeries", "Add a surface series.", &[]),
+    method("AddScatter3DSeries", "Add a 3D scatter series.", &[]),
+    method("AddLines3DSeries", "Add a 3D lines series.", &[]),
+    method("Add", "Add a 3D series by type name.", &[]),
+    method(
+        "SetOptions",
+        "Set global chart options.",
+        SETOPTIONS_SWITCHES,
+    ),
+    method("Render", "Render the chart to an HTML file.", &[]),
+    method("toHTML", "Return the chart as an HTML string.", &[]),
+    method("toJSON", "Return the chart options as JSON.", &[]),
+];
+
+static CHART3D_CLASS: ObjectClassSpec = ObjectClassSpec {
+    class_name: "ticklecharts::chart3D",
+    instance_methods: CHART3D_METHODS,
+    superclasses: &[],
+    allow_unknown_methods: false,
+};
+
+/// The `timeline` class methods (`timeline.tcl`); render / export are
+/// re-exported from `chart`.
+const TIMELINE_METHODS: &[SubCommand] = &[
+    method("Add", "Add a chart to the timeline.", &[]),
+    method("SetOptions", "Set timeline options.", SETOPTIONS_SWITCHES),
+    method("Render", "Render the timeline to an HTML file.", &[]),
+    method("toHTML", "Return the timeline as an HTML string.", &[]),
+    method("toJSON", "Return the timeline options as JSON.", &[]),
+];
+
+static TIMELINE_CLASS: ObjectClassSpec = ObjectClassSpec {
+    class_name: "ticklecharts::timeline",
+    instance_methods: TIMELINE_METHODS,
+    superclasses: &[],
+    allow_unknown_methods: false,
+};
+
+/// The `Gridlayout` class methods (`layout.tcl`); most accessors are copied
+/// from `chart`.
+const GRIDLAYOUT_METHODS: &[SubCommand] = &[
+    method("Add", "Add a chart to the grid layout.", &[]),
+    method(
+        "SetGlobalOptions",
+        "Set global layout options.",
+        SETOPTIONS_SWITCHES,
+    ),
+    method("Render", "Render the layout to an HTML file.", &[]),
+    method("toHTML", "Return the layout as an HTML string.", &[]),
+    method("toJSON", "Return the layout options as JSON.", &[]),
+];
+
+static GRIDLAYOUT_CLASS: ObjectClassSpec = ObjectClassSpec {
+    class_name: "ticklecharts::Gridlayout",
+    instance_methods: GRIDLAYOUT_METHODS,
+    superclasses: &[],
+    allow_unknown_methods: false,
+};
+
+/// The `new` / `create` constructor subcommands shared by every class factory.
+const CTOR_SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        name: "new",
+        detail: "Create a new object with an auto-generated command name.",
+        synopsis: "new",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "create",
+        detail: "Create a new object with the given command name.",
+        synopsis: "create name",
+        ..SubCommand::DEFAULT
+    },
+];
+
+fn class_spec(
+    name: &'static str,
+    summary: &'static str,
+    object_class: &'static ObjectClassSpec,
+) -> CommandSpec {
+    CommandSpec {
+        name,
+        // A desktop Tcl charting package — available in every Tcl version but
+        // never in the iRules / iApps / EDA dialects (where it has no place and
+        // would otherwise inflate their valid-command counts).
+        dialects: Some(DialectSet::ALL_TCL),
+        arity: Arity::at_least(1),
+        subcommands: CTOR_SUBCOMMANDS,
+        allow_unknown_subcommands: true,
+        required_package: Some("ticklecharts"),
+        object_class: Some(object_class),
+        hover: Some(HoverSnippet {
+            summary,
+            synopsis: &["ticklecharts::CLASS new", "ticklecharts::CLASS create name"],
+            snippet: "A ticklecharts (Apache ECharts) class. Instantiate with `new`, then configure the returned object handle with its methods.",
+            source: "ticklecharts (nico-robert)",
+            examples: "",
+            return_value: "",
+        }),
+        ..CommandSpec::DEFAULT
+    }
+}
+
+/// All command specs contributed by the `ticklecharts` package.
+#[must_use]
+pub fn ticklecharts_command_specs() -> Vec<CommandSpec> {
+    vec![
+        class_spec(
+            "ticklecharts::chart",
+            "Main 2D ticklecharts chart.",
+            &CHART_CLASS,
+        ),
+        class_spec(
+            "ticklecharts::chart3D",
+            "3D ticklecharts chart.",
+            &CHART3D_CLASS,
+        ),
+        class_spec(
+            "ticklecharts::timeline",
+            "Animated multi-chart timeline.",
+            &TIMELINE_CLASS,
+        ),
+        class_spec(
+            "ticklecharts::Gridlayout",
+            "Multi-chart grid layout.",
+            &GRIDLAYOUT_CLASS,
+        ),
+    ]
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::CommandRegistry;
+
+    #[test]
+    fn chart_factory_and_methods_resolve() {
+        let reg = CommandRegistry::build_default();
+        // The factory command carries the object-class metadata.
+        let class = reg
+            .object_class("ticklecharts::chart")
+            .expect("chart factory has an object class");
+        assert_eq!(class.class_name, "ticklecharts::chart");
+        // A declared instance method resolves, with its options.
+        let xaxis = reg
+            .instance_method("ticklecharts::chart", "Xaxis")
+            .expect("Xaxis method resolves");
+        assert!(
+            xaxis.options.iter().any(|o| o.name == "-name"),
+            "Xaxis declares -name"
+        );
+        assert!(
+            xaxis.options.iter().any(|o| o.name == "-splitLine"),
+            "Xaxis declares -splitLine"
+        );
+        // An undeclared method does not resolve.
+        assert!(
+            reg.instance_method("ticklecharts::chart", "NoSuchMethod")
+                .is_none(),
+            "unknown method must not resolve"
+        );
+    }
+}

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -97,7 +97,7 @@ pub mod prelude {
     };
     pub use crate::patterns::{FormatType, PatternType};
     pub use crate::side_effects::{ConnectionSide, SideEffect, SideEffectTarget, StorageType};
-    pub use crate::spec::{BytePayloadSpec, CommandSpec, SubCommand};
+    pub use crate::spec::{BytePayloadSpec, CommandSpec, ObjectClassSpec, SubCommand};
     pub use crate::taint::{SetterConstraint, TaintColour};
     pub use crate::traits::Traits;
     pub use crate::types::TclType;
@@ -116,7 +116,7 @@ pub use dialects::{
 pub use hover::ArgValue;
 pub use patterns::{FormatType, PatternType};
 pub use registry::{CommandRegistry, ResolvedTerminator};
-pub use spec::{BytePayloadSpec, CommandSpec, SubCommand};
+pub use spec::{BytePayloadSpec, CommandSpec, ObjectClassSpec, SubCommand};
 pub use taint::{SetterConstraint, TaintColour};
 pub use traits::Traits;
 pub use types::TclType;

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -148,6 +148,7 @@ fn all_dialect_command_names() -> &'static FxHashSet<&'static str> {
         add(crate::commands::stdlib::stdlib_command_specs());
         add(crate::commands::tcllib::tcllib_command_specs());
         add(crate::commands::argparse::argparse_command_specs());
+        add(crate::commands::ticklecharts::ticklecharts_command_specs());
         add(crate::commands::itcl::itcl_command_specs());
         add(crate::commands::tk::tk_command_specs());
         add(crate::commands::irules::irules_command_specs());
@@ -217,6 +218,9 @@ impl CommandRegistry {
             registry.insert(spec);
         }
         for spec in crate::commands::argparse::argparse_command_specs() {
+            registry.insert(spec);
+        }
+        for spec in crate::commands::ticklecharts::ticklecharts_command_specs() {
             registry.insert(spec);
         }
         for spec in crate::commands::itcl::itcl_command_specs() {
@@ -366,6 +370,46 @@ impl CommandRegistry {
     /// Return all registered command names.
     pub fn command_names(&self) -> impl Iterator<Item = &str> {
         self.by_name.keys().map(String::as_str)
+    }
+
+    /// The [`ObjectClassSpec`] for a `TclOO` / megawidget class named
+    /// `class_name`, or `None` when it is not a registry-modelled class.
+    ///
+    /// For a `TclOO` class the class name is the factory command name
+    /// (`oo::class create Foo` binds command `Foo`), so this resolves through
+    /// the ordinary command table — no separate index.  A leading `::` falls
+    /// back to the bare name, as with [`Self::get`].
+    #[must_use]
+    pub fn object_class(&self, class_name: &str) -> Option<&crate::spec::ObjectClassSpec> {
+        self.get(class_name).and_then(|s| s.object_class)
+    }
+
+    /// Resolve an instance method `method` on class `class_name`, walking
+    /// declared superclasses breadth-first.  Returns the owning class's
+    /// [`SubCommand`] method spec, or `None` when unresolved.
+    #[must_use]
+    pub fn instance_method(
+        &self,
+        class_name: &str,
+        method: &str,
+    ) -> Option<&crate::spec::SubCommand> {
+        let mut queue = vec![class_name.to_string()];
+        let mut seen = std::collections::HashSet::new();
+        while let Some(cls) = queue.pop() {
+            if !seen.insert(cls.clone()) {
+                continue;
+            }
+            let Some(class_spec) = self.object_class(&cls) else {
+                continue;
+            };
+            if let Some(m) = class_spec.instance_method(method) {
+                return Some(m);
+            }
+            for sup in class_spec.superclasses {
+                queue.push((*sup).to_string());
+            }
+        }
+        None
     }
 
     /// Whether `pkg` is a package the registry knows about — i.e. at

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -85,6 +85,56 @@ impl Default for BytePayloadSpec {
     }
 }
 
+/// Metadata for a `TclOO` / megawidget class whose instances are dispatched as
+/// `$obj <method> …`.
+///
+/// Attached to the class *command* spec (the factory — e.g.
+/// `ticklecharts::chart`, created by `oo::class create`) via
+/// [`CommandSpec::object_class`].  For a `TclOO` class the class name **is** the
+/// factory command name, so the registry resolves a class spec by looking the
+/// name up in the ordinary command table (no separate index) — see
+/// [`crate::CommandRegistry::object_class`].
+///
+/// The class's `new` / `create` constructor returns an object handle of
+/// `class_name`; a later `$handle method …` dispatch resolves `method` against
+/// [`Self::instance_methods`], which reuse the [`SubCommand`] shape so option /
+/// enum / arg-value highlighting, arity, and hover work identically to an
+/// ensemble subcommand.  This is the registry half of the object-method
+/// pattern: knowing the class of an object handle (via the compiler's
+/// object-type tracking) plus the class's methods lets `$chart Xaxis -name …`
+/// light up its options precisely rather than by shape alone (issue #748).
+#[derive(Debug)]
+pub struct ObjectClassSpec {
+    /// Fully-qualified class name — equal to the factory command name for a
+    /// `TclOO` class (`"ticklecharts::chart"`).
+    pub class_name: &'static str,
+
+    /// Instance methods dispatched on an object handle (`Xaxis`, `Add`,
+    /// `SetOptions`, …), in declaration order.  Reuses [`SubCommand`].
+    pub instance_methods: &'static [SubCommand],
+
+    /// Direct superclass names, for inherited-method resolution.  Each is
+    /// itself a class command name resolvable via
+    /// [`crate::CommandRegistry::object_class`].  Empty = none.
+    pub superclasses: &'static [&'static str],
+
+    /// Whether an unrecognised instance method is accepted without complaint
+    /// (a class with a dynamic `unknown` handler or runtime-generated
+    /// methods).  Highlighting-only today; reserved for a future
+    /// unknown-method diagnostic.
+    pub allow_unknown_methods: bool,
+}
+
+impl ObjectClassSpec {
+    /// Look up an instance method by name (this class only — no superclass
+    /// walk; the registry's [`crate::CommandRegistry::instance_method`] does
+    /// the inherited resolution).
+    #[must_use]
+    pub fn instance_method(&self, name: &str) -> Option<&SubCommand> {
+        self.instance_methods.iter().find(|m| m.name == name)
+    }
+}
+
 /// Unified command metadata — the single source of truth.
 ///
 /// Every consumer (compiler, analyser, codegen, LSP, formatter, diagram
@@ -368,6 +418,11 @@ pub struct CommandSpec {
     /// the registry is what lets a new definer be *data*, not new
     /// `match cmd_name` logic in the compiler / analyser / LSP.
     pub definition_body: Option<&'static crate::definer::DefinitionBodyGrammar>,
+
+    /// Object-class metadata — `Some` when this command is a `TclOO` /
+    /// megawidget class factory whose `new` / `create` returns an object handle
+    /// dispatched as `$obj <method> …`.  See [`ObjectClassSpec`].
+    pub object_class: Option<&'static ObjectClassSpec>,
 }
 
 impl CommandSpec {
@@ -427,6 +482,7 @@ impl CommandSpec {
         deprecated_replacement: None,
         byte_array_payload: None,
         definition_body: None,
+        object_class: None,
     };
 
     /// Run this command's constant folder for `args` under the optimiser's


### PR DESCRIPTION
## Summary

- Fixes the ngspice case from #748: `set chart [ticklecharts::chart new]; $chart Xaxis -name {v(anode), V} -type value -min 0.4 …` — every option previously fell through to a plain `string` token because `$chart` is a TclOO object handle, not a registry command.
- **Registry-precise object-method options.** New `ObjectClassSpec` schema lets the registry model a class factory whose `new`/`create` returns a handle dispatched as `$obj method …`, with per-method options (no prior schema modelled instance methods+options — even Tk widgets only model creation options). `CommandRegistry::object_class` / `::instance_method` resolve through the ordinary command table (a TclOO class name *is* its factory command name — no separate index).
- **Object-handle provenance.** `tcl_compiler::object_types::registry_object_handle_classes` tracks `set VAR [Class new|create]` (scalar + array handles) across the top level, procs, and method bodies. This is provenance, **not** the object→class dispatch lattice that #783 measured as a negative on this exact SpiceGenTcl corpus (99.8% ⊤, factory-returns dominating); un-provenanced (proc-parameter) receivers fall back to the generic pass rather than being resolved unsoundly.
- **Semantic tokens.** `insert_object_method_overrides` colours the method (`Function`) plus its declared options (`Decorator`), enum values (`EnumMember`), and generic values (`OptionValue`); a direct `[Class new] method …` dispatch resolves the same way. It runs before the generic fallback so the precise path wins.
- **Generic fallback.** `insert_generic_option_overrides` highlights `-option value` pairs on any *computed* head (`$var` / `[cmd]` / multi-fragment). Careful about Tcl conventions: negative numbers (`-5`), special floats (`-inf`/`-nan`), and substitutions (`-$var`) are not options; the `--` end-of-options marker stops scanning. A plain **bareword** head defers to the registry, so `mycmd -foo`, a user `test … -body`, and OO-body `property … -get {…}` are unaffected (`puts -foo` still stays a string).
- **ticklecharts pack** (staged): `chart` / `chart3D` / `timeline` / `Gridlayout` factories with instance methods; the axis methods and common series / `SetOptions` switches carry their options (full per-series option tables are a follow-up, best generated from the `setdef` source). Gated to Tcl dialects (not iRules / iApps / EDA).
- Docs: new KCS feature note, `ObjectClassSpec` contract section in `command-registry.md`, glossary entries, README token-type row; also indexed the pre-existing `tcloo-mro-lattice.md` design doc (unblocks the docs-index gate).

Net diff: 15 files, +1334 / −4 (the four deletions are intentional call-site/export replacements — no unrelated formatting churn).

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-registry -p tcl-compiler -p tcl-lsp-core     # all green
cargo test -p tcl-lsp-server --test e2e                        # 586 passed / 0 failed
cargo xtask kcs-index-links                                    # KCS docs checks passed
cargo clippy -p tcl-registry -p tcl-compiler -p tcl-lsp-core --all-targets   # no warnings on changed files
```

New coverage: `unknown_head_options_classified_generically`, `generic_option_scan_stops_at_double_dash`, `object_method_options_resolve_via_registry`, `direct_constructor_dispatch_resolves_method` (tcl-lsp-core); `scalar_handle_from_constructor` (tcl-compiler); `chart_factory_and_methods_resolve` (tcl-registry).

Note: I could not produce a green `make test-slow` stamp — the base tree currently fails `cargo fmt --check` on ~99 files untouched by this PR (the floating-stable rustfmt drifted vs. the last repo format). This change adds no formatting churn of its own; the CI `pr-gate` fmt result is a pre-existing, repo-wide condition independent of this branch.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — Yes: adds object-handle → class provenance (`tcl_compiler::object_types`) and the `ObjectClassSpec` registry contract.
- [x] If yes, I updated at least one relevant KCS note — `docs/kcs/features/kcs-feature-command-option-highlighting.md`, plus the `ObjectClassSpec` section in `docs/design/compiler/command-registry.md` and glossary entries. (This is a highlighting/registry feature, so the note lives under `docs/kcs/features/`, not `docs/kcs/compiler/`.)
- [x] New note linked from its index — `docs/kcs/features/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015KFsHiEksbRgHEDVUi1QeY

---
_Generated by [Claude Code](https://claude.ai/code/session_015KFsHiEksbRgHEDVUi1QeY)_