### PR TITLE
build(deps): bump the actions group with 4 updates (rust)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -58,7 +58,7 @@ jobs:
           fetch-tags: true
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/init@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           languages: ${{ matrix.language }}
           build-mode: ${{ matrix.build-mode }}
@@ -74,6 +74,6 @@ jobs:
                   id: py/ineffectual-statement
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/analyze@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           category: /language:${{ matrix.language }}

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -39,6 +39,6 @@ jobs:
           publish_results: true
 
       - name: Upload SARIF to code-scanning
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
         with:
           sarif_file: results.sarif

--- a/.github/workflows/vm-tests.yml
+++ b/.github/workflows/vm-tests.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@fac544c07dec837d0ccb6301d7b5580bf5edae39 # v8.2.0
+        uses: astral-sh/setup-uv@d31148d669074a8d0a63714ba94f3201e7020bc3 # v8.3.0
         with:
           enable-cache: true
 


### PR DESCRIPTION
Bumps the `actions` group with 4 pinned-SHA updates — the `rust` line counterpart to #781 (which only targeted `main`). Applied to the workflow files that exist on `rust`.

| Action | From | To |
| --- | --- | --- |
| astral-sh/setup-uv | v8.2.0 | v8.3.0 |
| github/codeql-action/init | v4.36.2 | v4.36.3 |
| github/codeql-action/analyze | v4.36.2 | v4.36.3 |
| github/codeql-action/upload-sarif | v4.36.2 | v4.36.3 |

Touches codeql.yml, scorecard.yml, vm-tests.yml (rust's ci.yml doesn't use setup-uv and there's no pages.yml).

🤖 Generated with [Claude Code](https://claude.com/claude-code)