### PR TITLE
W120 refinement: inherit package requires from entry files (#804)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1781,6 +1781,28 @@ disabled = O109
 For the complete reference, see
 [`docs/kcs/kcs-howto-suppress-diagnostics.md`](docs/kcs/kcs-howto-suppress-diagnostics.md).
 
+## Multi-file projects and `package require`
+
+In a project with an "entry" file that runs the `package require`s and then
+`source`s the rest, the individual modules use the required commands without a
+`package require` of their own.  The missing-`package require` check
+([W120](docs/kcs/codes/kcs-diagnostic-w120-missing-package-require.md)) does
+**not** flag them:
+
+- **Automatically** — the server builds a workspace `source` graph and each
+  module inherits the `package require`s of every file that (transitively)
+  `source`s it.  Only literal `source path.tcl` targets are followed.
+- **Explicitly** — when the entry file uses a computed `source` path (or you
+  prefer to pin it), list the entry files in `.tcl-lsp.ini`; their combined
+  requires then apply project-wide and the automatic path is turned off:
+
+  ```ini
+  [project]
+  entryPoints =
+      main.tcl
+      src/app.tcl
+  ```
+
 ## Diagnostic codes
 
 ### Errors

--- a/docs/design/contracts/package-loading.md
+++ b/docs/design/contracts/package-loading.md
@@ -1,4 +1,4 @@
-# KCS: Package loading contracts
+# Package loading contracts
 
 ## Symptom
 
@@ -10,131 +10,201 @@ resolved packages. iRules procs from other files are not found.
 
 The package loading system sits between the analyser (which detects
 `package require` statements) and the LSP features (which filter commands
-based on active packages). It spans four layers:
+based on active packages). It spans four layers, all native Rust:
 
-1. **Analyser** — extracts `PackageRequire` from source text.
-2. **Command registry** — gates commands via `required_package` / `tcllib_package`.
-3. **Package resolver** — scans `pkgIndex.tcl` files to find implementation sources.
-4. **Workspace index** — stores procs from resolved package files with `EntrySource.PACKAGE`.
+1. **Analyser** (`tcl-compiler`) — extracts `SignaturePackageRequire` from
+   source text during the signature scan.
+2. **Command registry** (`tcl-registry`) — gates commands via
+   `CommandSpec.required_package` / `tcllib_package`.
+3. **Package resolver** (`tcl-lsp-core::package_resolver`) — parses
+   `pkgIndex.tcl` / `tclIndex` files to find implementation sources and to
+   resolve what a `package require` transitively pulls in.
+4. **Workspace index** (`tcl-lsp-core::workspace_index`) — aggregates procs,
+   classes, invocation sites, `source` references, and `package require`
+   declarations across every analysed document.
 
-Three package sources are supported, plus the iRules cross-file equivalent:
+Per-command package knowledge lives on the `CommandSpec` in the registry's
+per-dialect spec packs, never as name-matching in a consumer (see
+[AGENTS.md](../../../AGENTS.md), "The registry is the source of truth"):
 
-| Source  | `required_package` value | Registration location                         |
-|---------|--------------------------|-----------------------------------------------|
-| Stdlib  | e.g. `"http"`, `"msgcat"` | `dialects/stdlib/`                        |
-| Tcllib  | derived from `tcllib_package` | `dialects/tcllib/`                     |
-| Tk      | `"Tk"`                   | `dialects/tk/`                            |
-| iRules  | n/a (no packages on BIG-IP) | `server/workspace/workspace_index.py` globals  |
+| Source  | `required_package` value       | Spec pack                          |
+|---------|--------------------------------|------------------------------------|
+| Stdlib  | e.g. `"http"`, `"msgcat"`      | `tcl-registry/src/commands/stdlib` |
+| Tcllib  | derived from `tcllib_package`  | `tcl-registry/src/commands/tcllib` |
+| Tk      | `"Tk"`                         | `tcl-registry/src/commands/tk`     |
+| iRules  | n/a (no packages on BIG-IP)    | `tcl-registry/src/commands/irules` |
 
 ## Decision rules / contracts
 
 ### Analyser extraction
 
 1. `package require <name>` and `package require -exact <name> <version>` are
-   recorded as `PackageRequire` in `AnalysisResult.package_requires`.
-2. `package provide` and `package ifneeded` are **not** tracked as requires.
-3. `AnalysisResult.active_package_names()` returns a `frozenset[str]` of all
-   required package names — this is the per-document filter key.
-4. Version is captured but currently only used by the package resolver, not
-   by registry filtering.
+   recorded as `SignaturePackageRequire` in `AnalysisResult.package_requires`.
+2. `package provide` is tracked separately (`package_provides`); a file that
+   *provides* a package needn't *require* it. `package ifneeded` is not a
+   require.
+3. Each `SignaturePackageRequire` carries the name, the optional version, its
+   source span, and a `conditional` flag set when the require sits inside a
+   guarded branch (`if` / `catch` / `try`), so version inference does not
+   promote a guarded `package require Tcl 8.6` to an unconditional minimum.
+4. Version is captured but currently only used by the package resolver and the
+   version-gate diagnostics, not by the per-document command filter.
 
 ### Registry filtering
 
-5. `CommandSpec.supports_packages(active_packages)` returns `True` when:
-   - `required_package is None` (unconditional command), or
-   - `active_packages is None` (no filtering), or
-   - `required_package in active_packages`.
-6. `active_packages=frozenset()` (empty set) hides all package-gated commands
-   — only core builtins remain.
-7. `active_packages=None` shows everything — backwards-compatible default.
-8. Tcllib specs set `tcllib_package`; during registry build this is
-   promoted to `required_package` so the same filtering path applies.
-9. Tk specs set `required_package="Tk"` and `warn_missing_import=False`
-   because `wish` auto-loads Tk.
+5. `CommandSpec.required_package` (or `tcllib_package`, unified by
+   `CommandSpec.owning_package()`) names the package a command belongs to;
+   `None` means an unconditional core command.
+6. Consumers gate a package command on whether its package is active for the
+   document — e.g. completion only offers Tk widgets once `Tk` is required
+   (`completion.rs`), and hover annotates the owning package (`hover.rs`).
+7. `CommandRegistry.provides_package(name)` reports whether any registry spec
+   is owned by `name` — the "is this a package the registry knows?" query the
+   W120 refinement uses to decide whether a require is resolvable.
+8. Tcllib specs set `tcllib_package`; Tk specs set `required_package = "Tk"`
+   and do not warn on a missing import, because `wish` auto-loads Tk.
 
-### Package resolver (pkgIndex.tcl)
+### Package resolver (`pkgIndex.tcl` / `tclIndex`)
 
-10. Searches all directories under configured search paths for
-    `pkgIndex.tcl` files via `os.walk`.
-11. Parses `package ifneeded <name> <version> <script>` lines.
-12. Extracts source file references from the script via two patterns:
-    - `source [file join $dir <filename>]` — `_SOURCE_JOIN_RE`
-    - `source $dir/<filename>` — `_SOURCE_DIR_RE`
-13. **Fallback**: if no source patterns matched, returns all `.tcl` files
-    in the directory (excluding `pkgIndex.tcl` itself).
-14. Version matching: exact match or prefix match (e.g. `"2"` matches `"2.9"`).
-15. Lazy scanning: `scan_packages()` is called automatically on first
-    `resolve()` or `all_package_names()` if not yet scanned.
-16. `configure()` resets the scanned state — subsequent calls rescan.
+9. `PackageResolver::scan_tree(root, max_dirs)` walks a workspace tree (each
+   directory and its immediate subdirectories, bounded by `max_dirs`) and
+   `scan_path(dir)` scans one directory, mirroring C Tcl's `tclPkgUnknown`.
+10. `parse_pkg_index` extracts `package ifneeded <name> <version> <script>`
+    entries and the source targets the script would `source` / `load`;
+    `parse_tcl_index` extracts the `auto_index` proc → file mappings from a
+    `tclIndex`.
+11. Index files are tokenised with the **real Tcl lexer**, so nested
+    `[file join $dir x]`, quoted, and braced path forms are handled
+    structurally — not by regex. The differential tests verify the output
+    against a real `tclsh`.
+12. `resolve(name, version)` returns the implementation files for the
+    best-matching version (exact or prefix match, e.g. `"2"` matches `"2.9"`).
+13. `provides(name)` reports whether the scanned database knows `name`.
+14. `transitive_available_packages(requires, read_fn)` returns the closure of
+    packages the given requires pull in — following each `ifneeded` script's
+    own `package require`s — which is how a wrapper package that internally
+    `package require Tk` makes `Tk` available (#723).
 
 ### Workspace index integration
 
-17. Resolved package files are indexed with `EntrySource.PACKAGE`.
-18. `is_background()` returns `True` for both `BACKGROUND` and `PACKAGE` entries.
-19. `remove_background_entries()` clears both `BACKGROUND` and `PACKAGE` entries
-    but preserves `OPEN` entries.
-20. Opening a file (`EntrySource.OPEN`) overrides its `PACKAGE`/`BACKGROUND` status.
+15. `WorkspaceIndex::add_document(uri, analysis)` records a document's procs,
+    classes, invocation sites, `source` targets, and `package require`s;
+    `remove_document(uri)` drops every entry from that document before a
+    re-index or on close.
+16. The server seeds the index from both editor-opened documents (via the
+    diagnostics path) and an on-disk scan of the workspace folders
+    (`scan_workspace_folders`), so unopened `.tcl` / `.tm` files are covered.
+17. Open buffers win over disk-scanned copies: `merge_workspace_scan_results`
+    re-checks the live open set at publication time and never overwrites an
+    open document's entry with a stale on-disk analysis.
+
+### Missing-`package require` refinement (W120)
+
+18. The analyser's single-file W120 knows only the requires in the current
+    document. Two workspace-level refinements are layered on top, both in the
+    server's `refine_w120_diagnostics`:
+    - **#723 transitive resolution** — a required package is resolved through
+      the workspace `pkgIndex.tcl` database; a W120 for a package that the
+      requires transitively provide is dropped. If any required package is
+      *unknowable* (neither the registry nor the database knows it), it may
+      load anything, so every W120 is conservatively dropped.
+    - **#804 cross-file inheritance** — see below.
+
+### Cross-file `package require` inheritance (W120, #804)
+
+19. A file need not carry its own `package require` for a command whose package
+    was required by an **entry** file that `source`s it.
+20. **Automatic (default).** The workspace index's `source` targets and
+    `package require`s feed a reverse-reachability walk
+    (`tcl-lsp-core::source_graph::ancestor_requires`): a module inherits the
+    requires of every file that transitively `source`s it. Only **literal**
+    `source path.tcl` targets are followed; a computed `source $dir/x.tcl`
+    yields no static edge. Path resolution is
+    `source_graph::resolve_source_target` (lexical, no filesystem access); the
+    server supplies the URI ↔ path conversion.
+21. **Explicit.** `.tcl-lsp.ini [project] entryPoints` lists the entry files
+    (relative to the folder root, or absolute). When set, the union of those
+    files' requires is treated as available for W120 across the whole folder,
+    and the automatic `source`-graph inheritance is **disabled** for that
+    folder.
+22. The inherited requires are merged with the document's own before the #723
+    transitive resolution runs, so an inherited `package require myWrapper`
+    still (transitively) pulls in whatever `myWrapper` provides.
 
 ### iRules cross-file equivalent
 
-21. iRules do not support `package require` on BIG-IP.
-22. Instead, all procs from iRules files are globally visible via
-    `WorkspaceIndex.update_irules_globals()`.
-23. Cross-file variables are shared via RULE_INIT blocks and tracked in
-    `WorkspaceIndex._irules_rule_init_vars`.
-24. `remove_background_entries()` also clears iRules globals.
+23. iRules do not support `package require` on BIG-IP, so W120 never applies
+    to the `f5-irules` dialect (the refinement early-returns when the registry
+    has no `package` command).
+24. iRules procs are instead globally visible across files through the same
+    workspace index proc aggregation the LSP cross-document features use.
 
 ### Split packages
 
-25. A single `package ifneeded` script may reference multiple source files
-    (e.g. `source [file join $dir a.tcl]; source [file join $dir b.tcl]`).
-26. The `_SOURCE_JOIN_RE` regex matches each `source [file join ...]`
-    occurrence in the script independently.
-27. **Known limitation**: the `$dir/` pattern (`_SOURCE_DIR_RE`) captures
-    trailing semicolons in filenames when multiple references appear on one
-    line. Only the last file (with no trailing `;`) will typically pass
-    `os.path.isfile`, so `_extract_source_files()` resolves just that file
-    and the others are effectively ignored. In this situation the resolver
-    does *not* fall back to the directory-listing heuristic; fallback only
-    occurs when **no** `$dir/...` candidates match.
-28. A single `pkgIndex.tcl` may declare multiple unrelated packages — each
+25. A single `package ifneeded` script may `source` multiple files
+    (`source [file join $dir a.tcl]; source [file join $dir b.tcl]`); each is
+    extracted independently by the lexer-driven parser, so no regex
+    semicolon-capture limitation applies.
+26. A single `pkgIndex.tcl` may declare multiple unrelated packages — each
     `package ifneeded` line is parsed independently.
 
 ## File-path anchors
 
-- `analyser/semantic_model.py` — `PackageRequire`, `active_package_names()`
-- `analyser/_analyser/_commands.py` — package require extraction (~line 328)
-- `compiler/registry/models.py` — `required_package`, `tcllib_package`, `supports_packages()`
-- `compiler/registry/command_registry.py` — package filtering methods
-- `dialects/stdlib/` — stdlib command specs
-- `dialects/tcllib/` — tcllib command specs
-- `dialects/tk/` — Tk command specs
-- `analyser/tk_detection.py` — `has_tk_require()`
-- `analyser/packages/resolver.py` — `PackageResolver`, pkgIndex parsing
-- `server/workspace/workspace_index.py` — `EntrySource`, iRules globals
-- `server/features/package_suggestions.py` — `rank_package_suggestions()`
-- `server/server.py` — server-side resolve-and-index orchestration
+- `tcl-compiler/src/signature_scan/types.rs` — `SignaturePackageRequire`,
+  `SignatureSource`.
+- `tcl-compiler/src/analyser/handlers.rs` — `handle_source_command`, package
+  require extraction.
+- `tcl-compiler/src/analyser/diagnostics/unresolved.rs` —
+  `emit_missing_package_require_diagnostics` (single-file W120).
+- `tcl-registry/src/spec.rs` — `CommandSpec.required_package`,
+  `tcllib_package`, `owning_package()`.
+- `tcl-registry/src/registry.rs` — `provides_package()`.
+- `tcl-registry/src/commands/{stdlib,tcllib,tk,irules}` — dialect spec packs.
+- `tcl-lsp-core/src/package_resolver.rs` — `PackageResolver`,
+  `parse_pkg_index`, `parse_tcl_index`, `transitive_available_packages`.
+- `tcl-lsp-core/src/workspace_index.rs` — `WorkspaceIndex`,
+  `WorkspacePackageRequire`, `WorkspaceSource`,
+  `source_ancestor_package_requires`.
+- `tcl-lsp-core/src/source_graph.rs` — `resolve_source_target`,
+  `resolve_under`, `ancestor_requires`.
+- `tcl-lsp-server/src/lib.rs` — `refine_w120_diagnostics`,
+  `refine_workspace_w120`, `compute_inherited_requires`,
+  `w120_inheritance_config`, `scan_workspace_folders`,
+  `build_package_resolver`.
+- `tcl-lsp-server/src/config_ini.rs` — `settings_from_ini` (`entryPoints`,
+  `libraryPaths`).
 
 ## Failure modes
 
-- **Missing completions**: `package require` not detected → `active_packages` empty → all package-gated commands hidden.
-- **False W120 diagnostics**: analyser fails to record a package require → W120 fires for commands that are actually imported.
-- **stale package index**: `configure()` not called after search path change → resolver returns old state.
-- **Split-file partial resolution**: `$dir/` pattern with semicolons misses files → some procs from the package not indexed.
-- **iRules proc not found**: `update_irules_globals()` not called for a file → its procs invisible to other iRules files.
-- **PACKAGE entries persist after close**: `remove_background_entries()` not called → stale procs from old packages linger.
+- **Missing completions**: a `package require` not detected → the package's
+  gated commands stay hidden.
+- **False W120 diagnostics**: a require not recorded, or the workspace not yet
+  scanned, → W120 fires for a command that is actually imported (directly, via
+  a wrapper package, or via an entry file that sources the module).
+- **Stale package database**: the resolver not rebuilt after a library-path or
+  workspace change → old `provides` / `resolve` results. `scan_workspace_folders`
+  rebuilds it.
+- **Unresolved cross-file inheritance**: a computed `source $dir/x.tcl` yields
+  no `source`-graph edge, so the sourced module inherits nothing — configure
+  `entryPoints` for that case.
+- **iRules proc not found**: a file not indexed → its procs invisible to other
+  iRules files.
 
 ## Test anchors
 
-- `tests/test_package_loading.py` — comprehensive cross-cutting tests
-- `tests/test_package_resolver.py` — pkgIndex parsing and resolution
-- `tests/test_tcllib.py` — tcllib registry, completion, hover, diagnostics
-- `tests/test_stdlib_registry.py` — stdlib registry and filtering
-- `tests/test_tk_registry.py` — Tk registry and commands_for_packages
-- `tests/test_tk_detection.py` — `has_tk_require()` detection
-- `tests/test_vm_package.py` — VM-level package command implementation
-- `tests/test_package_suggestions.py` — suggestion ranking
-- `tests/test_workspace_index.py` — workspace index and entry source tracking
+- `tcl-lsp-core/src/package_resolver.rs` (tests) — pkgIndex / tclIndex parsing
+  and resolution, differential-tested against `tclsh`.
+- `tcl-lsp-core/src/workspace_index.rs` (tests) — index aggregation, the
+  `source`-graph walk, and `package require` recording.
+- `tcl-lsp-core/src/source_graph.rs` (tests) — path resolution and ancestor
+  reachability.
+- `tcl-lsp-server/src/lib.rs` (tests) — `refine_w120_*`,
+  `compute_inherited_requires`, and the push/pull integration
+  (`source_graph_inheritance_suppresses_w120_in_sourced_module`,
+  `explicit_entry_point_config_suppresses_w120_project_wide`,
+  `pull_path_applies_w120_package_refinement`).
+- `tcl-registry/tests/registry_sweep.rs` — registry-wide command / package
+  coverage.
 
 ## Cross-reference: tclpkg
 

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -100,6 +100,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-howto-suppress-diagnostics.md](kcs-howto-suppress-diagnostics.md)
   — turn a diagnostic, warning, optimisation, or shimmer off inline,
   file-wide, per-project, per-editor, or globally.
+- [kcs-howto-configure-project-entry-points.md](kcs-howto-configure-project-entry-points.md)
+  — stop W120 warnings in files loaded by an entry file, via the
+  automatic `source` graph or a manual `entryPoints` list.
 - [kcs-howto-bind-sublime-tcl-commands.md](kcs-howto-bind-sublime-tcl-commands.md)
   — add keyboard shortcuts for the Tcl package's commands in Sublime
   Text using the bundled example keymap.

--- a/docs/kcs/codes/kcs-diagnostic-w120-missing-package-require.md
+++ b/docs/kcs/codes/kcs-diagnostic-w120-missing-package-require.md
@@ -40,6 +40,37 @@ set tok [http::geturl "https://example.com"]
 
 Add the appropriate `package require` before first use of the command.
 
+## Multi-file projects — inheriting requires from an entry file
+
+A project often has one "entry" file that runs the `package require`s
+and then `source`s its individual modules. Those modules use the
+required commands without a `package require` of their own. The server
+does **not** flag them, for two reasons:
+
+1. **Automatic (no configuration).** The server builds a workspace
+   `source` graph from the `source FILE` statements it finds. A module
+   inherits the `package require`s of every file that (transitively)
+   `source`s it, so a `package require Tk` in the entry file covers the
+   module it sources. Only literal `source path.tcl` targets are
+   followed — a computed `source $dir/x.tcl` cannot be resolved
+   statically.
+
+2. **Explicit entry points.** When the automatic path can't help — for
+   example the entry file uses a computed `source` path — list the
+   entry files in `.tcl-lsp.ini`:
+
+   ```ini
+   [project]
+   entryPoints =
+       main.tcl
+       src/app.tcl
+   ```
+
+   Their combined `package require`s are then treated as available
+   across the whole project, and the automatic `source`-graph
+   inheritance is turned off. See
+   [what config sections are valid](../kcs-qa-what-config-sections-are-valid.md).
+
 ## How to suppress
 
 Add `# noqa: W120` at the end of the offending line.

--- a/docs/kcs/kcs-howto-configure-project-entry-points.md
+++ b/docs/kcs/kcs-howto-configure-project-entry-points.md
@@ -1,0 +1,87 @@
+# KCS: How do I stop W120 warnings in files loaded by an entry file?
+
+> **Audience:** User
+> **Type:** How-To
+
+## Applies to
+
+all-editors, tcl-lsp-cli, diagnostic, warning
+
+## Question
+
+My project has one "entry" file that runs the `package require`s and
+then `source`s the rest of my files. The individual files use those
+packages' commands without their own `package require`, so I get
+[W120](codes/kcs-diagnostic-w120-missing-package-require.md) warnings
+on every one. How do I tell the server that the entry file already
+required them?
+
+## Before you start
+
+- The files that do the `source`ing and the files being sourced are all
+  inside the same workspace folder the editor opened.
+
+## Answer
+
+There are two ways. The first needs no configuration; use the second
+only when the first cannot apply.
+
+### Automatic — the workspace `source` graph
+
+The server reads every `source FILE` statement and every
+`package require NAME` across the workspace and builds a `source` graph
+from them. A file inherits the `package require`s of **every** file
+that `source`s it, directly or through a chain — so a
+`package require Tk` in the entry file covers the module it sources, and
+the module's W120 for a Tk command disappears on its own.
+
+```tcl
+# app.tcl  (the entry file)
+package require Tk
+source lib/widgets.tcl
+
+# lib/widgets.tcl  (sourced module — no package require needed)
+ttk::button .b -text OK      ;# no W120: Tk inherited from app.tcl
+```
+
+This works only for a **literal** path. A computed path the server
+cannot resolve without running the code — `source [file join $dir x.tcl]`
+or `source $module` — produces no graph edge, so the module does not
+inherit anything. Use the manual list for that case.
+
+### Manual — the `entryPoints` list
+
+List your entry files in a project `.tcl-lsp.ini` at the workspace root,
+one per line (paths relative to that folder, or absolute):
+
+```ini
+[project]
+entryPoints =
+    main.tcl
+    src/app.tcl
+```
+
+The combined `package require`s of every listed file are then treated as
+available across the **whole** project, whether or not the server can
+trace a `source` to a given file. Setting `entryPoints` turns the
+automatic `source`-graph inheritance **off** for that folder, so the
+list is the single source of truth — include every entry your project
+has.
+
+Commit `.tcl-lsp.ini` with your source so the whole team shares it. See
+[what config sections are valid](kcs-qa-what-config-sections-are-valid.md)
+for the full INI schema.
+
+## How to tell it worked
+
+The W120 squiggles under the package's commands in the sourced files
+disappear, while a genuinely missing `package require` — a command whose
+package no entry file requires — still warns.
+
+## Related
+
+- [KCS index](README.md)
+- [W120 — why does the analyser want a package require?](codes/kcs-diagnostic-w120-missing-package-require.md)
+- [What sections and keys are valid in tcl-lsp config files?](kcs-qa-what-config-sections-are-valid.md)
+- [How does tcl-lsp load configuration, and what overrides what?](kcs-qa-how-tcl-lsp-loads-configuration.md)
+- [Glossary](../GLOSSARY.md)

--- a/docs/kcs/kcs-howto-configure-project-entry-points.md
+++ b/docs/kcs/kcs-howto-configure-project-entry-points.md
@@ -18,7 +18,7 @@ required them?
 
 ## Before you start
 
-- The files that do the `source`ing and the files being sourced are all
+- The files that do the sourcing and the files being sourced are all
   inside the same workspace folder the editor opened.
 
 ## Answer

--- a/docs/kcs/kcs-qa-what-config-sections-are-valid.md
+++ b/docs/kcs/kcs-qa-what-config-sections-are-valid.md
@@ -38,6 +38,14 @@ when this section appears in the **global** XDG `config.ini`; a
   command names the analyser should recognise.
 - `libraryPaths` — one path per line, or comma-separated for one-line
   values. Extra directories for the package and source resolver.
+- `entryPoints` — one path per line, or comma-separated for one-line
+  values, relative to the folder root (or absolute). The project's
+  "main" files that run the `package require`s and `source` the rest.
+  When set, every file inherits these entries' `package require`s for
+  the missing-`package require` check
+  ([W120](codes/kcs-diagnostic-w120-missing-package-require.md)), and
+  the automatic `source`-graph inheritance is turned off. Most useful
+  in `.tcl-lsp.ini` (`[project]`).
 
 ### `[project]` (only in `.tcl-lsp.ini`)
 

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -58,6 +58,7 @@ pub mod selection_range;
 pub mod semantic_tokens;
 pub mod signature_help;
 pub mod snippets;
+pub mod source_graph;
 pub mod source_style;
 pub mod tcl_install;
 pub mod type_definition;

--- a/rust/tcl-lsp-core/src/source_graph.rs
+++ b/rust/tcl-lsp-core/src/source_graph.rs
@@ -1,0 +1,228 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Workspace `source` graph helpers.
+//!
+//! A multi-file Tcl project commonly has an *entry* file that runs the
+//! `package require`s and then `source`s its individual modules.  Those
+//! modules use the required packages' commands without a `package require`
+//! of their own, which the single-file W120 check would flag as missing (see
+//! [`crate::package_resolver`] and the analyser's
+//! `emit_missing_package_require_diagnostics`).
+//!
+//! To resolve that, the server builds a workspace-wide `source` graph from the
+//! `source FILE` statements the analyser records per document, then lets a
+//! module inherit the `package require`s of every file that (transitively)
+//! `source`s it.  This module owns the two pure, filesystem-free pieces of that
+//! resolution: the lexical path resolution ([`resolve_source_target`]) and the
+//! reverse-reachability walk ([`ancestor_requires`]).  The server supplies the
+//! URI ↔ path conversion, keeping this logic testable without any real files.
+
+use std::collections::{HashMap, HashSet};
+use std::hash::BuildHasher;
+use std::path::{Component, Path, PathBuf};
+
+/// Resolve a literal `source` path argument written in `parent_file` to the
+/// absolute path it refers to.
+///
+/// A relative `raw_path` resolves against the **directory** of `parent_file`
+/// (Tcl's `source` is relative to the sourcing script's location); an absolute
+/// `raw_path` passes through unchanged.  The result is lexically normalised —
+/// `.` and `..` segments are folded without touching the filesystem, so a
+/// symlink is never followed and the call is cheap and deterministic.
+#[must_use]
+pub fn resolve_source_target(parent_file: &Path, raw_path: &str) -> PathBuf {
+    resolve_under(
+        parent_file.parent().unwrap_or_else(|| Path::new("")),
+        raw_path,
+    )
+}
+
+/// Resolve `raw_path` relative to the directory `base_dir` (absolute paths pass
+/// through), lexically normalised.  Used both for a `source` target (relative
+/// to the sourcing file's directory) and for a configured project entry-point
+/// path (relative to the workspace folder root).
+#[must_use]
+pub fn resolve_under(base_dir: &Path, raw_path: &str) -> PathBuf {
+    let raw = Path::new(raw_path);
+    let joined = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        base_dir.join(raw)
+    };
+    lexically_normalise(&joined)
+}
+
+/// Fold `.` and `..` segments lexically (no filesystem access). A leading `..`
+/// with nothing to pop is preserved so a path that escapes its root still
+/// resolves to a stable, comparable form.
+fn lexically_normalise(path: &Path) -> PathBuf {
+    let mut out: Vec<Component<'_>> = Vec::new();
+    for comp in path.components() {
+        match comp {
+            Component::CurDir => {}
+            Component::ParentDir => match out.last() {
+                Some(Component::Normal(_)) => {
+                    out.pop();
+                }
+                _ => out.push(comp),
+            },
+            other => out.push(other),
+        }
+    }
+    if out.is_empty() {
+        return PathBuf::from(".");
+    }
+    out.iter().collect()
+}
+
+/// The union of `package require` names from every node that transitively
+/// reaches `target` through the `source` graph.
+///
+/// `edges` are `(parent, child)` pairs meaning *`parent` `source`s `child`*;
+/// `requires` maps a node to the package names it `package require`s.  The walk
+/// follows edges in reverse (child → its parents), so `target` inherits the
+/// requires of every ancestor that sources it, directly or transitively.  Node
+/// identity is the caller's string key (the server uses document URIs); cycles
+/// are handled by a visited set.  The result is sorted and de-duplicated.
+#[must_use]
+pub fn ancestor_requires<S: BuildHasher>(
+    target: &str,
+    edges: &[(String, String)],
+    requires: &HashMap<String, Vec<String>, S>,
+) -> Vec<String> {
+    // child -> parents that source it.
+    let mut parents_of: HashMap<&str, Vec<&str>> = HashMap::new();
+    for (parent, child) in edges {
+        parents_of
+            .entry(child.as_str())
+            .or_default()
+            .push(parent.as_str());
+    }
+    let mut ancestors: HashSet<&str> = HashSet::new();
+    let mut stack: Vec<&str> = vec![target];
+    let mut visited: HashSet<&str> = HashSet::new();
+    while let Some(node) = stack.pop() {
+        if !visited.insert(node) {
+            continue;
+        }
+        if let Some(parents) = parents_of.get(node) {
+            for &parent in parents {
+                ancestors.insert(parent);
+                stack.push(parent);
+            }
+        }
+    }
+    let mut out: Vec<String> = ancestors
+        .iter()
+        .filter_map(|a| requires.get(*a))
+        .flatten()
+        .cloned()
+        .collect();
+    out.sort();
+    out.dedup();
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reqs(pairs: &[(&str, &[&str])]) -> HashMap<String, Vec<String>> {
+        pairs
+            .iter()
+            .map(|(uri, pkgs)| {
+                (
+                    (*uri).to_owned(),
+                    pkgs.iter().map(|p| (*p).to_owned()).collect(),
+                )
+            })
+            .collect()
+    }
+
+    #[test]
+    fn resolves_relative_source_against_parent_dir() {
+        let got = resolve_source_target(Path::new("/proj/app.tcl"), "lib/util.tcl");
+        assert_eq!(got, PathBuf::from("/proj/lib/util.tcl"));
+    }
+
+    #[test]
+    fn resolves_dot_and_dotdot_segments() {
+        let got = resolve_source_target(Path::new("/proj/sub/main.tcl"), "../lib/./util.tcl");
+        assert_eq!(got, PathBuf::from("/proj/lib/util.tcl"));
+    }
+
+    #[test]
+    fn absolute_source_passes_through() {
+        let got = resolve_source_target(Path::new("/proj/app.tcl"), "/opt/x/y.tcl");
+        assert_eq!(got, PathBuf::from("/opt/x/y.tcl"));
+    }
+
+    #[test]
+    fn inherits_requires_from_direct_parent() {
+        // app.tcl requires Tk and sources lib.tcl.
+        let edges = vec![("app".to_owned(), "lib".to_owned())];
+        let requires = reqs(&[("app", &["Tk", "http"]), ("lib", &[])]);
+        let got = ancestor_requires("lib", &edges, &requires);
+        assert_eq!(got, vec!["Tk".to_owned(), "http".to_owned()]);
+    }
+
+    #[test]
+    fn inherits_transitively_through_a_chain() {
+        // app -> mid -> leaf; leaf inherits from both app and mid.
+        let edges = vec![
+            ("app".to_owned(), "mid".to_owned()),
+            ("mid".to_owned(), "leaf".to_owned()),
+        ];
+        let requires = reqs(&[("app", &["Tk"]), ("mid", &["json"]), ("leaf", &[])]);
+        let mut got = ancestor_requires("leaf", &edges, &requires);
+        got.sort();
+        assert_eq!(got, vec!["Tk".to_owned(), "json".to_owned()]);
+    }
+
+    #[test]
+    fn unions_requires_from_multiple_entry_points() {
+        // Both a.tcl and b.tcl source shared.tcl with different requires.
+        let edges = vec![
+            ("a".to_owned(), "shared".to_owned()),
+            ("b".to_owned(), "shared".to_owned()),
+        ];
+        let requires = reqs(&[("a", &["Tk"]), ("b", &["http"]), ("shared", &[])]);
+        let got = ancestor_requires("shared", &edges, &requires);
+        assert_eq!(got, vec!["Tk".to_owned(), "http".to_owned()]);
+    }
+
+    #[test]
+    fn tolerates_cycles() {
+        // a -> b -> a (pathological); must not loop forever.
+        let edges = vec![
+            ("a".to_owned(), "b".to_owned()),
+            ("b".to_owned(), "a".to_owned()),
+        ];
+        let requires = reqs(&[("a", &["Tk"]), ("b", &["http"])]);
+        let got = ancestor_requires("a", &edges, &requires);
+        assert_eq!(got, vec!["Tk".to_owned(), "http".to_owned()]);
+    }
+
+    #[test]
+    fn a_root_with_no_ancestors_inherits_nothing() {
+        let edges = vec![("app".to_owned(), "lib".to_owned())];
+        let requires = reqs(&[("app", &["Tk"])]);
+        assert!(ancestor_requires("app", &edges, &requires).is_empty());
+    }
+}

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -129,14 +129,29 @@ pub struct WorkspaceSource {
     pub is_literal: bool,
 }
 
+/// One `package require NAME` declaration recorded in the index.
+///
+/// Lets a module inherit the requires of the entry file(s) that `source` it,
+/// so the workspace W120 refinement does not flag a command whose package is
+/// required upstream (see [`crate::source_graph`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspacePackageRequire {
+    /// Document containing the `package require` statement.
+    pub uri: String,
+    /// Required package name (the `NAME` argument).
+    pub name: String,
+}
+
 /// Cross-document aggregate of proc / class definitions,
-/// command-invocation sites, and `source` references.
+/// command-invocation sites, `source` references, and
+/// `package require` declarations.
 #[derive(Debug, Clone, Default)]
 pub struct WorkspaceIndex {
     procs: Vec<WorkspaceProc>,
     classes: Vec<WorkspaceClass>,
     invocations: Vec<WorkspaceInvocation>,
     sources: Vec<WorkspaceSource>,
+    package_requires: Vec<WorkspacePackageRequire>,
 }
 
 impl WorkspaceIndex {
@@ -206,6 +221,12 @@ impl WorkspaceIndex {
                 is_literal: target.is_literal,
             });
         }
+        for pr in &analysis.package_requires {
+            self.package_requires.push(WorkspacePackageRequire {
+                uri: uri.to_owned(),
+                name: pr.name.clone(),
+            });
+        }
     }
 
     /// Drop every entry that came from `uri` (used before
@@ -215,12 +236,68 @@ impl WorkspaceIndex {
         self.classes.retain(|c| c.uri != uri);
         self.invocations.retain(|i| i.uri != uri);
         self.sources.retain(|s| s.uri != uri);
+        self.package_requires.retain(|pr| pr.uri != uri);
     }
 
     /// Every indexed `source FILE` reference.
     #[must_use]
     pub fn sources(&self) -> &[WorkspaceSource] {
         &self.sources
+    }
+
+    /// Every indexed `package require NAME` declaration.
+    #[must_use]
+    pub fn package_requires(&self) -> &[WorkspacePackageRequire] {
+        &self.package_requires
+    }
+
+    /// The package names `uri` `package require`s, de-duplicated. Used to seed
+    /// the workspace W120 refinement from an explicitly configured project
+    /// entry file.
+    #[must_use]
+    pub fn package_requires_for(&self, uri: &str) -> Vec<String> {
+        let mut out: Vec<String> = self
+            .package_requires
+            .iter()
+            .filter(|pr| pr.uri == uri)
+            .map(|pr| pr.name.clone())
+            .collect();
+        out.sort();
+        out.dedup();
+        out
+    }
+
+    /// The union of `package require` names from every document that
+    /// transitively `source`s `target_uri`.
+    ///
+    /// `resolve(parent_uri, raw_path)` maps a literal `source` path written in
+    /// `parent_uri` to the child document's URI (the server supplies the
+    /// URI ↔ path conversion); a `None` return drops that unresolvable edge.
+    /// Only literal `source` targets are followed — a `source $dir/x.tcl` whose
+    /// path is computed at runtime cannot be resolved statically.  The
+    /// reachability walk and requires union live in
+    /// [`crate::source_graph::ancestor_requires`].
+    #[must_use]
+    pub fn source_ancestor_package_requires(
+        &self,
+        target_uri: &str,
+        resolve: impl Fn(&str, &str) -> Option<String>,
+    ) -> Vec<String> {
+        let edges: Vec<(String, String)> = self
+            .sources
+            .iter()
+            .filter(|s| s.is_literal)
+            .filter_map(|s| resolve(&s.uri, &s.raw_path).map(|child| (s.uri.clone(), child)))
+            .collect();
+        let mut requires: std::collections::HashMap<String, Vec<String>> =
+            std::collections::HashMap::new();
+        for pr in &self.package_requires {
+            requires
+                .entry(pr.uri.clone())
+                .or_default()
+                .push(pr.name.clone());
+        }
+        crate::source_graph::ancestor_requires(target_uri, &edges, &requires)
     }
 
     /// Every indexed proc.
@@ -882,5 +959,61 @@ mod tests {
         assert!(!index.invocations().is_empty());
         index.remove_document("file:///a.tcl");
         assert!(index.invocations().is_empty());
+    }
+
+    #[test]
+    fn indexes_and_removes_package_requires() {
+        let a = analyse("package require Tk\npackage require http\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///a.tcl", &a);
+        assert_eq!(
+            index.package_requires_for("file:///a.tcl"),
+            vec!["Tk".to_owned(), "http".to_owned()]
+        );
+        index.remove_document("file:///a.tcl");
+        assert!(index.package_requires().is_empty());
+    }
+
+    #[test]
+    fn source_ancestor_requires_walks_the_graph() {
+        // app.tcl requires Tk and sources lib/util.tcl; util inherits Tk.
+        let app = analyse("package require Tk\nsource lib/util.tcl\n");
+        let util = analyse("proc u {} {}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///proj/app.tcl", &app),
+            ("file:///proj/lib/util.tcl", &util),
+        ]);
+        // Resolver mirrors the server's: join the raw path onto the parent's
+        // directory (path portion of the file URI).
+        let resolve = |parent: &str, raw: &str| -> Option<String> {
+            let dir = parent.rsplit_once('/').map(|(d, _)| d)?;
+            Some(format!("{dir}/{raw}"))
+        };
+        let got = index.source_ancestor_package_requires("file:///proj/lib/util.tcl", resolve);
+        assert_eq!(got, vec!["Tk".to_owned()]);
+        // The entry file itself inherits nothing.
+        assert!(
+            index
+                .source_ancestor_package_requires("file:///proj/app.tcl", resolve)
+                .is_empty()
+        );
+    }
+
+    #[test]
+    fn source_ancestor_requires_ignores_nonliteral_sources() {
+        // A computed `source $path` produces no resolvable edge.
+        let app = analyse("package require Tk\nsource $dir/util.tcl\n");
+        let util = analyse("proc u {} {}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///proj/app.tcl", &app),
+            ("file:///proj/util.tcl", &util),
+        ]);
+        let resolve =
+            |_p: &str, _r: &str| -> Option<String> { panic!("non-literal must not resolve") };
+        assert!(
+            index
+                .source_ancestor_package_requires("file:///proj/util.tcl", resolve)
+                .is_empty()
+        );
     }
 }

--- a/rust/tcl-lsp-server/src/config_ini.rs
+++ b/rust/tcl-lsp-server/src/config_ini.rs
@@ -193,6 +193,19 @@ pub fn settings_from_ini(content: &str, layer: Layer) -> Value {
             );
         }
     }
+    // `entryPoints` — the project's "main" files that run the `package
+    // require`s and `source` the rest. When set, W120 auto source-graph
+    // inheritance is disabled and every file inherits these entries' requires.
+    // Accepts one path per line (configparser continuation) or a comma list.
+    if let Some(raw) = section_value(&sections, top, "entryPoints") {
+        let entries = parse_path_list(raw);
+        if !entries.is_empty() {
+            out.insert(
+                "entryPoints".to_owned(),
+                Value::Array(entries.into_iter().map(Value::String).collect()),
+            );
+        }
+    }
 
     insert_diagnostics(&sections, &mut out);
     insert_optimiser(&sections, &mut out);

--- a/rust/tcl-lsp-server/src/config_ini/tests.rs
+++ b/rust/tcl-lsp-server/src/config_ini/tests.rs
@@ -36,6 +36,23 @@ fn global_section_top_level_keys() {
 }
 
 #[test]
+fn project_entry_points_list() {
+    // Newline-continuation list of entry files under [project].
+    let ini = "[project]\n\
+               entryPoints =\n\
+               \x20   main.tcl\n\
+               \x20   src/app.tcl\n";
+    let s = settings_from_ini(ini, Layer::Project);
+    assert_eq!(s["entryPoints"], json!(["main.tcl", "src/app.tcl"]));
+    // A comma-separated one-liner is equivalent.
+    let comma = settings_from_ini("[project]\nentryPoints = main.tcl, src/app.tcl\n", Layer::Project);
+    assert_eq!(comma["entryPoints"], json!(["main.tcl", "src/app.tcl"]));
+    // Absent key ⇒ no entryPoints emitted (auto-detection stays on).
+    let none = settings_from_ini("[project]\ndialect = tcl9.0\n", Layer::Project);
+    assert!(none.get("entryPoints").is_none());
+}
+
+#[test]
 fn project_layer_reads_project_section_only() {
     let ini = "[global]\ndialect = tcl8.6\n[project]\ndialect = tcl9.0\n";
     // As a project file, the [project] dialect is honoured and [global] ignored.

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -310,6 +310,13 @@ struct DiagInputs {
     workspace_index: Arc<RwLock<core_workspace_index::WorkspaceIndex>>,
     /// Package database for the W120 workspace-refinement post-filter (#723).
     package_resolver: Arc<RwLock<PackageResolver>>,
+    /// `.tcl-lsp.ini [project] entryPoints` for this document's folder (#804):
+    /// when non-empty, the W120 refinement inherits these entries' requires and
+    /// disables the automatic `source`-graph inheritance.
+    entry_points: Vec<String>,
+    /// The document's workspace-folder root, used to resolve relative
+    /// `entry_points` to file URIs. `None` for a no-folder session.
+    folder_root: Option<PathBuf>,
     /// The salsa db handle.  Each run clones a *fresh, short-lived* snapshot and
     /// drops it immediately, so an idle worker never holds a clone across the
     /// debounce sleep (which would block the next edit's `set_text` — salsa's
@@ -691,6 +698,8 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
         documents,
         workspace_index,
         package_resolver,
+        entry_points,
+        folder_root,
         db,
         db_project,
         pull_diag_cache,
@@ -765,6 +774,8 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
             db_project: &db_project,
             workspace_index: &workspace_index,
             package_resolver: &package_resolver,
+            entry_points: &entry_points,
+            folder_root: folder_root.as_deref(),
             xc_diagnostics,
         },
     )
@@ -780,6 +791,9 @@ struct AnalyserPathInputs<'a> {
     db_project: &'a Arc<Mutex<Option<tcl_lsp_db::Project>>>,
     workspace_index: &'a Arc<RwLock<core_workspace_index::WorkspaceIndex>>,
     package_resolver: &'a Arc<RwLock<PackageResolver>>,
+    /// #804 W120 inheritance for this document's folder (see [`DiagInputs`]).
+    entry_points: &'a [String],
+    folder_root: Option<&'a Path>,
     xc_diagnostics: bool,
 }
 
@@ -837,10 +851,22 @@ async fn run_diagnostics_analyser_path(
             ControlFlow::Break(settled) => return settled,
         };
 
+    // #804: extra requires this document inherits from configured entry points
+    // or its `source` ancestors, resolved against the live workspace index.
+    let inherited_requires = {
+        let index = inputs.workspace_index.read().await;
+        compute_inherited_requires(
+            &index,
+            delivery.uri,
+            inputs.entry_points,
+            inputs.folder_root,
+        )
+    };
     let result = refine_and_lift_diagnostics(
         &analysis,
         analyser_diags,
         &compiler_diags,
+        &inherited_requires,
         inputs.package_resolver,
         inputs.registry,
         lift_inputs,
@@ -881,15 +907,18 @@ async fn refine_and_lift_diagnostics(
     analysis: &Arc<AnalysisResult>,
     analyser_diags: Vec<tcl_compiler::analyser::Diagnostic>,
     compiler_diags: &Arc<tcl_lsp_db::CompilerDiagnostics>,
+    inherited_requires: &[String],
     package_resolver: &Arc<RwLock<PackageResolver>>,
     registry: &Arc<CommandRegistry>,
     inputs: &LiftInputs<'_>,
 ) -> Result<Vec<tower_lsp_server::ls_types::Diagnostic>, tokio::task::JoinError> {
-    // #723: refine the analyser's single-file W120 against the workspace
-    // package database (shared with the pull path via `refine_workspace_w120`).
+    // #723 + #804: refine the analyser's single-file W120 against the workspace
+    // package database and the requires inherited from entry points / `source`
+    // ancestors (shared with the pull path via `refine_workspace_w120`).
     let analyser_diags = refine_workspace_w120(
         analyser_diags,
         analysis.as_ref(),
+        inherited_requires,
         package_resolver,
         registry,
     )
@@ -1385,6 +1414,12 @@ struct FolderConfig {
     generic_variable_patterns: FolderGenericPatterns,
     /// `tclLsp.libraryPaths` override; `None` inherits the global set.
     library_paths: Option<Vec<String>>,
+    /// `.tcl-lsp.ini [project] entryPoints` — the project's "main" files (paths
+    /// relative to the folder root). When set, the W120 workspace refinement
+    /// treats these entries' `package require`s as available across the folder
+    /// and disables the automatic `source`-graph inheritance. `None` / empty
+    /// leaves auto-detection on.
+    entry_points: Option<Vec<String>>,
 }
 
 /// Pick the value associated with the **longest** folder URI that `uri` sits
@@ -4166,6 +4201,7 @@ impl Backend {
         let generic_variable_patterns = self.resolved_generic_variable_patterns(uri).await;
         let style_line_length = self.resolved_style_line_length(uri).await;
         let diagnostics_enabled = self.feature_enabled("diagnostics", uri).await;
+        let (entry_points, folder_root) = self.w120_inheritance_config(uri).await;
         DiagInputs {
             client: self.client.clone(),
             registry,
@@ -4178,6 +4214,8 @@ impl Backend {
             documents: Arc::clone(&self.documents),
             workspace_index: Arc::clone(&self.workspace_index),
             package_resolver: Arc::clone(&self.package_resolver),
+            entry_points,
+            folder_root,
             db: Arc::clone(&self.db),
             db_files: Arc::clone(&self.db_files),
             db_project: Arc::clone(&self.db_project),
@@ -4193,6 +4231,39 @@ impl Backend {
                 .client_supports_pull_diagnostics
                 .load(std::sync::atomic::Ordering::Relaxed),
         }
+    }
+
+    /// The project entry points and folder root that govern the #804 W120
+    /// inheritance for `uri`: the longest matching workspace folder's
+    /// `.tcl-lsp.ini [project] entryPoints` (empty ⇒ automatic `source`-graph
+    /// mode) and that folder's filesystem root (to resolve relative entry
+    /// paths).
+    async fn w120_inheritance_config(&self, uri: &Uri) -> (Vec<String>, Option<PathBuf>) {
+        let configs = self.folder_configs.lock().await;
+        let mut best: Option<&(Uri, FolderConfig)> = None;
+        for entry in configs.iter() {
+            if uri_under_folder(uri.as_str(), entry.0.as_str())
+                && best.is_none_or(|b| entry.0.as_str().len() > b.0.as_str().len())
+            {
+                best = Some(entry);
+            }
+        }
+        match best {
+            Some((folder, fc)) => (
+                fc.entry_points.clone().unwrap_or_default(),
+                folder.to_file_path().map(std::borrow::Cow::into_owned),
+            ),
+            None => (Vec::new(), None),
+        }
+    }
+
+    /// The extra `package require` names `uri` inherits for the W120 refinement
+    /// (#804), resolved live against the current workspace index. Empty in the
+    /// common single-file / no-project case.
+    async fn inherited_package_requires(&self, uri: &Uri) -> Vec<String> {
+        let (entry_points, folder_root) = self.w120_inheritance_config(uri).await;
+        let index = self.workspace_index.read().await;
+        compute_inherited_requires(&index, uri, &entry_points, folder_root.as_deref())
     }
 
     /// Build the **complete** diagnostic set for a document — analyser +
@@ -4304,9 +4375,13 @@ impl Backend {
         // database, mirroring the push path's `refine_and_lift_diagnostics`, so a
         // workspace whose `pkgIndex.tcl`/`libraryPaths` prove a required package
         // transitively provides the flagged package suppresses the false W120.
+        // #804: also inherit the requires of the project's entry files / the
+        // `source` ancestors of this document.
+        let inherited_requires = self.inherited_package_requires(uri).await;
         let analyser_diags = refine_workspace_w120(
             analyser_diags,
             analysis.as_ref(),
+            &inherited_requires,
             &self.package_resolver,
             &registry,
         )
@@ -7985,6 +8060,20 @@ fn parse_folder_config(cfg: &serde_json::Value) -> Option<FolderConfig> {
                 .collect(),
         );
     }
+    // `.tcl-lsp.ini [project] entryPoints` per-folder value.
+    if let Some(points) = obj
+        .get("entryPoints")
+        .and_then(serde_json::Value::as_array)
+    {
+        fc.entry_points = Some(
+            points
+                .iter()
+                .filter_map(serde_json::Value::as_str)
+                .filter(|s| !s.is_empty())
+                .map(str::to_owned)
+                .collect(),
+        );
+    }
     // The disabled-diagnostics and non-ASCII helpers expect the value wrapped
     // under `tclLsp`; the per-folder pull hands us the section content directly.
     let wrapped = serde_json::json!({ "tclLsp": cfg });
@@ -8413,22 +8502,76 @@ fn refine_w120_diagnostics(
 async fn refine_workspace_w120(
     analyser_diags: Vec<tcl_compiler::analyser::Diagnostic>,
     analysis: &AnalysisResult,
+    inherited_requires: &[String],
     package_resolver: &Arc<RwLock<PackageResolver>>,
     registry: &CommandRegistry,
 ) -> Vec<tcl_compiler::analyser::Diagnostic> {
     if !analyser_diags.iter().any(|d| d.code == DiagCode::W120) {
         return analyser_diags;
     }
-    let pkg_requires: Vec<String> = analysis
+    // The document's own `package require`s plus any inherited from the
+    // project's entry files / `source` ancestors (#804): a module `source`d by
+    // an entry that already required the package should not be flagged.
+    let mut pkg_requires: Vec<String> = analysis
         .package_requires
         .iter()
         .map(|pr| pr.name.clone())
         .collect();
+    pkg_requires.extend(inherited_requires.iter().cloned());
     if pkg_requires.is_empty() {
         return analyser_diags;
     }
     let resolver = package_resolver.read().await;
     refine_w120_diagnostics(analyser_diags, &pkg_requires, &resolver, registry)
+}
+
+/// The extra `package require` names available to `uri` for the #804 W120
+/// refinement: from the project's configured entry points when set (which
+/// disables auto-detection), else from the workspace `source` graph — every
+/// file that transitively `source`s `uri` shares its requires.  Operates on an
+/// already-locked index so both the push and pull paths can call it.
+fn compute_inherited_requires(
+    index: &core_workspace_index::WorkspaceIndex,
+    uri: &Uri,
+    entry_points: &[String],
+    folder_root: Option<&Path>,
+) -> Vec<String> {
+    if entry_points.is_empty() {
+        return index.source_ancestor_package_requires(uri.as_str(), resolve_source_uri);
+    }
+    // Explicit entry points: the union of their requires, project-wide.
+    let mut out: Vec<String> = Vec::new();
+    for ep in entry_points {
+        if let Some(entry_uri) = entry_point_uri(ep, folder_root) {
+            out.extend(index.package_requires_for(&entry_uri));
+        }
+    }
+    out.sort();
+    out.dedup();
+    out
+}
+
+/// Resolve a literal `source` path written in `parent_uri` to the child
+/// document's URI string, keyed the same way the workspace index keys
+/// documents (`Uri::from_file_path`).  `None` for a non-`file:` URI or an
+/// unmappable path.
+fn resolve_source_uri(parent_uri: &str, raw_path: &str) -> Option<String> {
+    let parent = Uri::from_str(parent_uri).ok()?;
+    let parent_path = parent.to_file_path()?;
+    let child = tcl_lsp_core::source_graph::resolve_source_target(parent_path.as_ref(), raw_path);
+    Uri::from_file_path(&child).map(|u| u.as_str().to_owned())
+}
+
+/// Resolve a configured entry-point path (relative to `folder_root`, or
+/// absolute) to its document URI string.
+fn entry_point_uri(entry: &str, folder_root: Option<&Path>) -> Option<String> {
+    let raw = Path::new(entry);
+    let path = if raw.is_absolute() {
+        raw.to_path_buf()
+    } else {
+        tcl_lsp_core::source_graph::resolve_under(folder_root?, entry)
+    };
+    Uri::from_file_path(&path).map(|u| u.as_str().to_owned())
 }
 
 /// The package name a W120 says is missing, read from its quick-fix
@@ -9654,6 +9797,93 @@ mod tests {
         assert!(
             has_w120(&out),
             "plain doesn't provide Tk ⇒ W120 kept: {out:?}"
+        );
+    }
+
+    // ---- #804 W120 entry-point / source-graph inheritance ------------------
+
+    fn ws_index(docs: &[(&Uri, &str)]) -> core_workspace_index::WorkspaceIndex {
+        let analyses: Vec<(String, tcl_compiler::analyser::AnalysisResult)> = docs
+            .iter()
+            .map(|(uri, src)| {
+                let mut a = tcl_compiler::analyser::Analyser::new();
+                ((*uri).as_str().to_owned(), a.analyse(src, "tcl8.6").clone())
+            })
+            .collect();
+        core_workspace_index::WorkspaceIndex::from_documents(
+            analyses.iter().map(|(u, a)| (u.as_str(), a)),
+        )
+    }
+
+    #[test]
+    fn source_uri_resolution_matches_from_file_path() {
+        // The resolver must produce the exact URI string the index keys the
+        // child document by, or the graph edge won't connect.
+        let app = Uri::from_file_path("/proj/app.tcl").unwrap();
+        let child = resolve_source_uri(app.as_str(), "lib/util.tcl").unwrap();
+        let expected = Uri::from_file_path("/proj/lib/util.tcl").unwrap();
+        assert_eq!(child, expected.as_str());
+    }
+
+    #[test]
+    fn auto_source_graph_inherits_entry_requires() {
+        // app.tcl requires Tk and sources lib/util.tcl; util inherits Tk, so a
+        // Tk W120 in util is suppressed with no configuration at all.
+        let app = Uri::from_file_path("/proj/app.tcl").unwrap();
+        let util = Uri::from_file_path("/proj/lib/util.tcl").unwrap();
+        let index = ws_index(&[
+            (&app, "package require Tk\nsource lib/util.tcl\n"),
+            (&util, "proc u {} {}\n"),
+        ]);
+        let inherited = compute_inherited_requires(&index, &util, &[], None);
+        assert_eq!(inherited, vec!["Tk".to_owned()]);
+        // The entry file itself inherits nothing.
+        assert!(compute_inherited_requires(&index, &app, &[], None).is_empty());
+    }
+
+    #[test]
+    fn explicit_entry_points_override_source_graph() {
+        // main.tcl requires Tk but does NOT source other.tcl; with main.tcl set
+        // as an entry point, other.tcl still inherits Tk (project-wide), and the
+        // auto source-graph is bypassed entirely.
+        let root = PathBuf::from("/proj");
+        let main = Uri::from_file_path("/proj/main.tcl").unwrap();
+        let other = Uri::from_file_path("/proj/other.tcl").unwrap();
+        let index = ws_index(&[
+            (&main, "package require Tk\n"),
+            (&other, "proc o {} {}\n"),
+        ]);
+        // Auto mode: other.tcl is not sourced by main, so it inherits nothing.
+        assert!(compute_inherited_requires(&index, &other, &[], Some(&root)).is_empty());
+        // Explicit entry point: other.tcl inherits main.tcl's Tk.
+        let entries = vec!["main.tcl".to_owned()];
+        let inherited = compute_inherited_requires(&index, &other, &entries, Some(&root));
+        assert_eq!(inherited, vec!["Tk".to_owned()]);
+    }
+
+    #[test]
+    fn entry_point_paths_resolve_relative_and_absolute() {
+        let root = PathBuf::from("/proj");
+        let rel = entry_point_uri("src/main.tcl", Some(&root)).unwrap();
+        assert_eq!(
+            rel,
+            Uri::from_file_path("/proj/src/main.tcl").unwrap().as_str()
+        );
+        let abs = entry_point_uri("/opt/app.tcl", Some(&root)).unwrap();
+        assert_eq!(abs, Uri::from_file_path("/opt/app.tcl").unwrap().as_str());
+        // A relative entry with no folder root can't be resolved.
+        assert!(entry_point_uri("main.tcl", None).is_none());
+    }
+
+    #[test]
+    fn folder_config_parses_entry_points() {
+        let cfg = serde_json::json!({
+            "entryPoints": ["main.tcl", "src/app.tcl"],
+        });
+        let fc = parse_folder_config(&cfg).unwrap();
+        assert_eq!(
+            fc.entry_points,
+            Some(vec!["main.tcl".to_owned(), "src/app.tcl".to_owned()])
         );
     }
 
@@ -11117,6 +11347,117 @@ mod tests {
             !diag_codes(&refined).iter().any(|c| c == "W120"),
             "the pull path must refine away the W120 once the workspace proves \
              http is transitively available, got: {:?}",
+            diag_codes(&refined),
+        );
+    }
+
+    /// #804: a module `source`d by an entry file that ran `package require`
+    /// inherits that require, so the sourced module's W120 for the same package
+    /// is suppressed by the automatic workspace `source` graph — no config.
+    #[tokio::test]
+    async fn source_graph_inheritance_suppresses_w120_in_sourced_module() {
+        let backend = test_backend();
+        // Resolver that knows `http` (so the require is not "unknowable").
+        let http_ws = TmpWs::new("srcgraph-http");
+        http_ws.write(
+            "http/http.tcl",
+            "package provide http 2.9\nproc http::register {a b c} {}\n",
+        );
+        http_ws.write(
+            "http/pkgIndex.tcl",
+            "package ifneeded http 2.9 [list source [file join $dir http.tcl]]\n",
+        );
+        {
+            let mut resolver = PackageResolver::new();
+            resolver.scan_tree(&http_ws.0, 100);
+            *backend.package_resolver.write().await = resolver;
+        }
+        let app = Uri::from_file_path("/proj/app.tcl").unwrap();
+        let util = Uri::from_file_path("/proj/lib/util.tcl").unwrap();
+        // util.tcl uses http::register with no local `package require`.
+        let util_src = "http::register foo 80 bar\n";
+
+        // Control: with the entry file NOT indexed, util inherits nothing, so
+        // the single-file W120 stands.
+        let unrefined = backend
+            .full_diagnostics_for(&util, util_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            diag_codes(&unrefined).iter().any(|c| c == "W120"),
+            "without the entry file indexed the W120 must stand, got: {:?}",
+            diag_codes(&unrefined),
+        );
+
+        // Index the entry file: it requires http and sources lib/util.tcl.
+        {
+            let mut a = tcl_compiler::analyser::Analyser::new();
+            let analysis = a
+                .analyse("package require http\nsource lib/util.tcl\n", "tcl8.6")
+                .clone();
+            backend
+                .workspace_index
+                .write()
+                .await
+                .add_document(app.as_str(), &analysis);
+        }
+        let refined = backend
+            .full_diagnostics_for(&util, util_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            !diag_codes(&refined).iter().any(|c| c == "W120"),
+            "the sourced module must inherit the entry file's `package require http`, got: {:?}",
+            diag_codes(&refined),
+        );
+    }
+
+    /// #804: an explicitly configured `[project] entryPoints` makes that entry
+    /// file's requires available project-wide even when it does NOT `source` the
+    /// module — and it disables the automatic source-graph path.
+    #[tokio::test]
+    async fn explicit_entry_point_config_suppresses_w120_project_wide() {
+        let backend = test_backend();
+        let http_ws = TmpWs::new("entrypt-http");
+        http_ws.write(
+            "http/http.tcl",
+            "package provide http 2.9\nproc http::register {a b c} {}\n",
+        );
+        http_ws.write(
+            "http/pkgIndex.tcl",
+            "package ifneeded http 2.9 [list source [file join $dir http.tcl]]\n",
+        );
+        {
+            let mut resolver = PackageResolver::new();
+            resolver.scan_tree(&http_ws.0, 100);
+            *backend.package_resolver.write().await = resolver;
+        }
+        let folder = Uri::from_file_path("/proj").unwrap();
+        let main = Uri::from_file_path("/proj/main.tcl").unwrap();
+        let other = Uri::from_file_path("/proj/other.tcl").unwrap();
+        // main.tcl requires http but does NOT source other.tcl.
+        {
+            let mut a = tcl_compiler::analyser::Analyser::new();
+            let analysis = a.analyse("package require http\n", "tcl8.6").clone();
+            backend
+                .workspace_index
+                .write()
+                .await
+                .add_document(main.as_str(), &analysis);
+        }
+        // Configure main.tcl as the project entry point.
+        {
+            let fc = FolderConfig {
+                entry_points: Some(vec!["main.tcl".to_owned()]),
+                ..FolderConfig::default()
+            };
+            *backend.folder_configs.lock().await = vec![(folder.clone(), fc)];
+        }
+        let other_src = "http::register foo 80 bar\n";
+        let refined = backend
+            .full_diagnostics_for(&other, other_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            !diag_codes(&refined).iter().any(|c| c == "W120"),
+            "an explicit entry point's requires must apply project-wide, got: {:?}",
             diag_codes(&refined),
         );
     }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -853,7 +853,9 @@ async fn run_diagnostics_analyser_path(
 
     // #804: extra requires this document inherits from configured entry points
     // or its `source` ancestors, resolved against the live workspace index.
-    let inherited_requires = {
+    // Only computed when there is a W120 to refine — otherwise the index lock
+    // and `source`-graph walk are wasted work on the hot diagnostics path.
+    let inherited_requires = if analyser_diags.iter().any(|d| d.code == DiagCode::W120) {
         let index = inputs.workspace_index.read().await;
         compute_inherited_requires(
             &index,
@@ -861,6 +863,8 @@ async fn run_diagnostics_analyser_path(
             inputs.entry_points,
             inputs.folder_root,
         )
+    } else {
+        Vec::new()
     };
     let result = refine_and_lift_diagnostics(
         &analysis,
@@ -4376,8 +4380,14 @@ impl Backend {
         // workspace whose `pkgIndex.tcl`/`libraryPaths` prove a required package
         // transitively provides the flagged package suppresses the false W120.
         // #804: also inherit the requires of the project's entry files / the
-        // `source` ancestors of this document.
-        let inherited_requires = self.inherited_package_requires(uri).await;
+        // `source` ancestors of this document. Only computed when there is a
+        // W120 to refine, matching the push path — otherwise the workspace-index
+        // lock and `source`-graph walk are avoidable work.
+        let inherited_requires = if analyser_diags.iter().any(|d| d.code == DiagCode::W120) {
+            self.inherited_package_requires(uri).await
+        } else {
+            Vec::new()
+        };
         let analyser_diags = refine_workspace_w120(
             analyser_diags,
             analysis.as_ref(),


### PR DESCRIPTION
## Summary

Implements cross-file `package require` inheritance for the W120 (missing-`package require`) diagnostic refinement. A module no longer needs its own `package require` when the package is required by an entry file that `source`s it.

Two mechanisms are supported:

1. **Automatic (default).** The server builds a workspace `source` graph from literal `source FILE` statements and `package require` declarations. A module inherits the requires of every file that transitively `source`s it, so a `package require Tk` in an entry file covers modules it sources.

2. **Explicit entry points.** When the automatic path can't help (e.g., computed `source` paths), list entry files in `.tcl-lsp.ini [project] entryPoints`. Their combined requires are then available across the whole folder, and automatic `source`-graph inheritance is disabled for that folder.

### Key changes

- **New module `tcl-lsp-core::source_graph`** — pure, filesystem-free helpers for lexical path resolution (`resolve_source_target`, `resolve_under`) and reverse-reachability walks (`ancestor_requires`) on the `source` graph.

- **`WorkspaceIndex` extensions** — tracks `package require` declarations per document; provides `package_requires_for(uri)` to query a file's requires and `source_ancestor_package_requires(uri, resolve)` to walk the graph and collect inherited requires.

- **`DiagInputs` and `AnalyserPathInputs`** — carry the configured entry points and folder root so the W120 refinement can compute inherited requires.

- **`refine_workspace_w120` signature change** — now accepts `inherited_requires: &[String]` and merges them with the document's own before the #723 transitive resolution.

- **Configuration parsing** — `.tcl-lsp.ini [project] entryPoints` is parsed as a newline-continuation or comma-separated list of entry file paths (relative to folder root, or absolute).

- **Documentation** — updated `docs/design/contracts/package-loading.md` with the full contract; added `docs/kcs/kcs-howto-configure-project-entry-points.md` (user how-to); updated W120 diagnostic docs and README.

### Testing

- Added unit tests in `workspace_index.rs` for indexing and removing package requires, and for the `source_ancestor_package_requires` graph walk.
- Added unit tests in `source_graph.rs` for path resolution (`resolve_source_target`, `resolve_under`, lexical normalisation) and the `ancestor_requires` reachability walk (direct parent, transitive chain, multiple entry points, cycles, root with no ancestors).
- Added integration test in `lib.rs` for the full W120 refinement with entry points and source-graph modes.
- Added config parsing test in `config_ini/tests.rs` for `entryPoints` as a newline-continuation list.

## Validation

- [x] Unit tests added and passing for `source_graph` module (path resolution, ancestor walk, cycle handling).
- [x] Unit tests added and passing for `WorkspaceIndex` package-require tracking and graph walk.
- [x] Integration tests added and passing for W120 refinement with explicit entry points and automatic source-graph modes.
- [x] Config parsing tests added and passing for `[project] entryPoints` list parsing.

## Compiler/KCS checklist

- [x] This change alters the W120 diagnostic contract (adds cross-file inheritance).
- [x] Updated `docs/design/contracts/package-loading.md` with the full contract (rules 19–22).
- [x] Added new KCS how-to: `docs/kcs/kcs-howto-configure-project-entry-points.md`.
- [x] Linked the new how-to from `docs/kcs/README.md`.
- [x] Updated W120 diagnostic docs (`docs/kcs/codes/kcs-diagnostic-w120-missing-package-require.md`) with multi-file project guidance.
- [x] Updated README.md with a brief overview of the feature.

https://claude.ai/code/session_01WP5UetBsYd5xyzqvEC7vw6