### PR TITLE
Highlight by-reference variable and command arguments (role-general arg inference, fixes #813)

### DIFF
--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -40,6 +40,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-issue-highlight-drops-closing-delimiter.md](kcs-issue-highlight-drops-closing-delimiter.md)
   — a highlight over a braced word covers `{$condition` instead of
   `{$condition}`, dropping the closing delimiter.
+- [kcs-issue-array-element-not-highlighted-as-variable.md](kcs-issue-array-element-not-highlighted-as-variable.md)
+  — an array-element write target (`set arr(key) 1`) is not highlighted
+  as a variable.
 - [kcs-issue-duplicate-diagnostics.md](kcs-issue-duplicate-diagnostics.md)
   — the same finding is reported twice.
 - [kcs-issue-counter-numtests-array-init.md](kcs-issue-counter-numtests-array-init.md)

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -41,8 +41,8 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   — a highlight over a braced word covers `{$condition` instead of
   `{$condition}`, dropping the closing delimiter.
 - [kcs-issue-array-element-not-highlighted-as-variable.md](kcs-issue-array-element-not-highlighted-as-variable.md)
-  — an array-element write target (`set arr(key) 1`) is not highlighted
-  as a variable.
+  — a by-reference variable-name argument (`set arr(key) 1`,
+  `info exists arr(key)`) is not highlighted as a variable.
 - [kcs-issue-duplicate-diagnostics.md](kcs-issue-duplicate-diagnostics.md)
   — the same finding is reported twice.
 - [kcs-issue-counter-numtests-array-init.md](kcs-issue-counter-numtests-array-init.md)

--- a/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
+++ b/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
@@ -76,13 +76,17 @@ safe to paint as one token.
      token-collection time, so they apply on every path (local and workspace)
      with no analysis needed.
    - **Inferred user-proc roles** — a proc parameter the analyser inferred to
-     alias a caller variable via `upvar $param` (writing it →
-     `ProcArgTrait::VarWrite`, reading it → `ProcArgTrait::VarRead`).
-     Available from the single-file analysis locally, and from the workspace-
-     merged `project_proc_var_index` salsa query when a project is open, so a
-     proc defined in another file resolves too. `ProcArgTrait::DynamicNameLocal`
-     (the param's *value* names a callee-local variable) is excluded from both
-     directions — a literal name there is not the caller's variable.
+     name a variable. This covers a caller-frame `upvar $param` alias (write →
+     `ProcArgTrait::VarWrite`, read → `ProcArgTrait::VarRead`) *and* a
+     dynamic name the param's value builds (`set $p`, `set ${v}($k)`,
+     `variable $name`, `array set $a`, `namespace upvar ns $token arr` →
+     `ProcArgTrait::DynamicNameLocal`). The inference descends into `[...]`
+     command substitutions, so `return [set ${v}($k)]` is seen, and it marks
+     both the array-name and key components of a compound name. Available from
+     the single-file analysis locally, and from the workspace-merged
+     `project_proc_var_index` salsa query when a project is open, so a proc
+     defined in another file resolves too. A write elevates to a declaration; a
+     dynamic-name or read reference elevates to a plain `Variable`.
    The same single-token `Esc` geometry gate applies to every source, so a
    computed subscript stays multi-token and its inner `$var` survives.
 
@@ -94,7 +98,8 @@ safe to paint as one token.
 - `rust/tcl-lsp-db/src/lib.rs` — `project_proc_var_index` (workspace-merged
   inferred roles), `semantic_tokens` / `semantic_tokens_project` wiring
 - `rust/tcl-compiler/src/analyser/param_traits.rs` — proc parameter trait
-  inference (`upvar` → `VarWrite` / `VarRead`)
+  inference: `upvar` / `namespace upvar` aliases, dynamic names (`var_substitutions`,
+  `scan_commands_bounded` command-substitution descent), compound array names
 - `rust/tcl-registry/src/stub_overlay.rs` — `# tcl-lsp: stub … :var` / `:var_read`
   roles
 - `rust/tcl-compiler/src/segmenter.rs` — `SegmentedCommand::single_token_word`

--- a/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
+++ b/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
@@ -1,0 +1,79 @@
+# KCS: An array-element write target is not highlighted as a variable
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+all-editors
+
+## Symptom
+
+An array element used as a write target — `set arr(key) 1`,
+`incr count(hits)`, `append log(err) x`, or `unset arr(key)` — is not
+highlighted as a variable. The `arr(key)` word stays a plain string, even
+though the corresponding read (`$arr(key)`) highlights as one whole-word
+variable (issue #813).
+
+## Operational context
+
+Semantic tokens retag a command's write-target argument (registry role
+`ArgRole::VarWrite`) as a `Variable` declaration. The retag only fires for a
+word the walker can safely paint as one token. The gate was
+`is_plain_var_name`, which rejects any word containing `(`, so every array
+element — literal (`arr(key)`) or computed (`arr($i)`) — was left to the
+default classifier and rendered as a string.
+
+Excluding a **computed** subscript is deliberate: `arr($i)` lexes into several
+tokens (`arr(`, `$i`, `)`), and the inner `$i` must survive as its own
+variable sub-token. But a **literal** element (`arr(key)`) lexes as a single
+[`TokenType::Esc`](../../rust/tcl-lexer/src/tokens.rs) word, so it can be
+retagged as one variable token with no risk of clobbering an inner
+substitution.
+
+## Decision rules / contracts
+
+1. A literal array element (`name(index)` with no `$` / `[` substitution and no
+   nested delimiter in either part) is retagged as a whole-word `Variable`
+   declaration, matching how `$arr(key)` reads highlight. This is decided by
+   `is_literal_array_element` in
+   [`rust/tcl-lsp-core/src/semantic_tokens.rs`](../../rust/tcl-lsp-core/src/semantic_tokens.rs).
+2. A computed subscript (`arr($i)`) is **not** retagged — it is left to the
+   default classifier so its inner `$var` sub-tokens survive.
+3. Only the `VarWrite`-role retag (`insert_var_decl_overrides`) accepts array
+   elements. Declaration commands whose names must be scalars or whole arrays
+   (`global`, `variable`, `upvar` locals) keep using `is_plain_var_name`, since
+   an element is not a legal name there.
+
+## File-path anchors
+
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `is_literal_array_element`,
+  `insert_var_decl_overrides`
+- `rust/tcl-lexer/src/lexer.rs` — `$arr(idx)` variable lexing
+
+## Failure modes
+
+- Retagging a **computed** subscript (`arr($i)`) as one token would swallow the
+  inner `$i`, dropping its variable sub-token — the reason the gate excludes it.
+- A subscript containing a nested `(` / `)` / brace could produce an overlapping
+  span if painted as one token; `is_literal_array_element` rejects those.
+
+## Triage checklist
+
+1. Decode the semantic tokens for `set arr(key) 1` and confirm the `arr(key)`
+   word is one `Variable` token with the `declaration` modifier.
+2. Confirm `set arr($i) 1` still emits the inner `$i` as a variable sub-token.
+3. Confirm the tokens do not overlap.
+
+## Test anchors
+
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `literal_array_element_write_is_variable_declaration`,
+  `namespaced_array_element_write_is_variable_declaration`,
+  `unset_array_element_is_variable`, `is_literal_array_element_classifies`,
+  `array_element_write_not_retagged`
+
+## Related
+
+- [KCS index](README.md)
+- [Semantic Tokens feature](features/kcs-feature-semantic-tokens.md)
+- [highlight drops closing delimiter](kcs-issue-highlight-drops-closing-delimiter.md)

--- a/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
+++ b/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
@@ -1,4 +1,4 @@
-# KCS: An array-element write target is not highlighted as a variable
+# KCS: A by-reference variable-name argument is not highlighted as a variable
 
 > **Audience:** Contributor
 > **Type:** Issue
@@ -9,11 +9,17 @@ all-editors
 
 ## Symptom
 
-An array element used as a write target — `set arr(key) 1`,
-`incr count(hits)`, `append log(err) x`, or `unset arr(key)` — is not
-highlighted as a variable. The `arr(key)` word stays a plain string, even
-though the corresponding read (`$arr(key)`) highlights as one whole-word
-variable (issue #813).
+A variable name passed to a command by reference is not highlighted as a
+variable. This covers both directions:
+
+- **Write targets** — `set arr(key) 1`, `incr count(hits)`,
+  `append log(err) x`, `unset arr(key)`.
+- **Read references** — `info exists arr(key)`, `array names arr`,
+  `array get arr`.
+
+The name word stays a plain string, even though the corresponding
+substitution (`$arr(key)`) highlights as one whole-word variable (issue #813).
+A read of a plain scalar (`info exists scalar`) is not highlighted either.
 
 The same is true for an array element passed to a *user proc* or *stubbed
 command* that takes a variable name by reference — `myset arr(key) 1` where
@@ -38,15 +44,23 @@ safe to paint as one token.
 
 ## Decision rules / contracts
 
-1. The `VarWrite`-role retag does **not** re-derive "is this a variable" from
-   the word's text — the registry role is the authority. It retags the word
-   whenever the segmenter reports the word is a single unquoted `Esc` token
+1. The retag does **not** re-derive "is this a variable" from the word's text —
+   the declared role is the authority. It retags the word whenever the segmenter
+   reports the word is a single unquoted `Esc` token
    (`SegmentedCommand::single_token_word`), matching how `$arr(key)` reads
    highlight. This covers scalars (`x`), literal array elements (`arr(key)`),
    and namespaced names (`::ns::arr(key)`) uniformly, with no array-syntax
-   parsing. Decided in `insert_var_decl_overrides`,
+   parsing. Decided in `insert_var_role_overrides`,
    [`rust/tcl-lsp-core/src/semantic_tokens.rs`](../../rust/tcl-lsp-core/src/semantic_tokens.rs).
-2. A word with an inner substitution (`arr($i)`, `$dynamic`) is multi-token, so
+2. Both **write** and **read** roles are retagged, by *direction*:
+   - `ArgRole::VarWrite` (`set`, `incr`, `lappend`, `dict with`, …) → `Variable`
+     **with** the `declaration` modifier (it declares / writes the variable).
+   - `ArgRole::VarRead` (`info exists arr(key)`, `array names arr`,
+     `array get arr`, `dict with $d`, …) → a plain `Variable` **without** the
+     `declaration` modifier (it references an existing variable). A word that is
+     a *value*, not a name (`dict get $d k` — `$d` is a value), carries no read
+     role, so it is not retagged; only its `$d` substitution is a variable.
+3. A word with an inner substitution (`arr($i)`, `$dynamic`) is multi-token, so
    `single_token_word` is `false` and the word is left to the default
    classifier — its inner `$var` sub-tokens survive.
 3. The registry-agnostic list walkers (`global` / `variable` names, `upvar`
@@ -56,28 +70,32 @@ safe to paint as one token.
 4. The static registry role is not the *only* source of a variable-name spot.
    The same retag also unions two dynamic sources, both carried by the
    `VarNameArgRoles` index passed into the token walk:
-   - **Stub roles** — a `# tcl-lsp: stub NAME {arg:var …}` declaration. These
-     are derived from the document source at token-collection time, so they
-     apply on every path (local and workspace) with no analysis needed.
+   - **Stub roles** — a `# tcl-lsp: stub NAME {arg:var …}` (write) or `:var_read`
+     (read) declaration. These are derived from the document source at
+     token-collection time, so they apply on every path (local and workspace)
+     with no analysis needed.
    - **Inferred user-proc roles** — a proc parameter the analyser inferred to
-     alias a caller variable (`upvar $param` + write → `ProcArgTrait::VarWrite`).
+     alias a caller variable via `upvar $param` (writing it →
+     `ProcArgTrait::VarWrite`, reading it → `ProcArgTrait::VarRead`).
      Available from the single-file analysis locally, and from the workspace-
      merged `project_proc_var_index` salsa query when a project is open, so a
      proc defined in another file resolves too. `ProcArgTrait::DynamicNameLocal`
-     (the param's *value* names a callee-local variable) is excluded — a literal
-     name there is not the caller's variable.
+     (the param's *value* names a callee-local variable) is excluded from both
+     directions — a literal name there is not the caller's variable.
    The same single-token `Esc` geometry gate applies to every source, so a
    computed subscript stays multi-token and its inner `$var` survives.
 
 ## File-path anchors
 
-- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `insert_var_decl_overrides`,
-  `VarNameArgRoles`, `add_stub_var_write_roles`, `proc_var_write_indices`
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `insert_var_role_overrides`,
+  `VarNameArgRoles`, `add_stub_var_roles`, `proc_var_write_indices` /
+  `proc_var_read_indices`, `ArgOverride::VarDecl` / `VarRef`
 - `rust/tcl-lsp-db/src/lib.rs` — `project_proc_var_index` (workspace-merged
   inferred roles), `semantic_tokens` / `semantic_tokens_project` wiring
 - `rust/tcl-compiler/src/analyser/param_traits.rs` — proc parameter trait
-  inference (`upvar` → `VarWrite`)
-- `rust/tcl-registry/src/stub_overlay.rs` — `# tcl-lsp: stub … :var` roles
+  inference (`upvar` → `VarWrite` / `VarRead`)
+- `rust/tcl-registry/src/stub_overlay.rs` — `# tcl-lsp: stub … :var` / `:var_read`
+  roles
 - `rust/tcl-compiler/src/segmenter.rs` — `SegmentedCommand::single_token_word`
   (per-word single-token geometry, whose representative `argv` token spans the
   whole word)
@@ -101,8 +119,12 @@ safe to paint as one token.
 - `rust/tcl-lsp-core/src/semantic_tokens.rs` — `literal_array_element_write_is_variable_declaration`,
   `namespaced_array_element_write_is_variable_declaration`,
   `unset_array_element_is_variable`, `array_element_write_not_retagged`,
+  `varread_role_highlights_variable_name`,
+  `varread_value_argument_is_not_a_variable`,
   `stub_var_arg_highlights_array_element`,
+  `stub_var_read_arg_highlights_as_reference`,
   `user_proc_var_name_arg_highlights_array_element`,
+  `user_proc_var_read_arg_highlights_as_reference`,
   `user_proc_var_name_computed_subscript_survives`
 
 ## Related

--- a/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
+++ b/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
@@ -29,11 +29,12 @@ command* that takes a variable name by reference — `myset arr(key) 1` where
 
 Whether an argument *is* a variable-name spot is not a text-shape question —
 the [command registry](../design/compiler/command-registry.md) already answers
-it. `insert_var_decl_overrides` walks the argument indices the registry marks
-with the `ArgRole::VarWrite` role, so the target is known to be a variable
-before the walker looks at its text. The only remaining question is token
-**geometry**: can the word be painted as one whole-word `Variable` token, or
-does it contain an inner substitution that must survive as its own sub-token?
+it. `insert_var_role_overrides` walks the argument indices the registry marks
+with a by-reference variable role — `ArgRole::VarWrite` (a written target) or
+`ArgRole::VarRead` (a read reference) — so the argument is known to be a
+variable before the walker looks at its text. The only remaining question is
+token **geometry**: can the word be painted as one whole-word `Variable` token,
+or does it contain an inner substitution that must survive as its own sub-token?
 
 The old gate answered that with `is_plain_var_name`, which rejects any word
 containing `(`, so every array element — literal (`arr(key)`) or computed
@@ -63,11 +64,11 @@ safe to paint as one token.
 3. A word with an inner substitution (`arr($i)`, `$dynamic`) is multi-token, so
    `single_token_word` is `false` and the word is left to the default
    classifier — its inner `$var` sub-tokens survive.
-3. The registry-agnostic list walkers (`global` / `variable` names, `upvar`
+4. The registry-agnostic list walkers (`global` / `variable` names, `upvar`
    locals, parameter lists, loop-variable lists) still use `is_plain_var_name`,
    because those pull names out of list positions where an element genuinely may
    not be a name.
-4. The static registry role is not the *only* source of a variable-name spot.
+5. The static registry role is not the *only* source of a variable-name spot.
    The same retag also unions two dynamic sources, both carried by the
    `VarNameArgRoles` index passed into the token walk:
    - **Stub roles** — a `# tcl-lsp: stub NAME {arg:var …}` (write) or `:var_read`

--- a/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
+++ b/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
@@ -17,46 +17,52 @@ variable (issue #813).
 
 ## Operational context
 
-Semantic tokens retag a command's write-target argument (registry role
-`ArgRole::VarWrite`) as a `Variable` declaration. The retag only fires for a
-word the walker can safely paint as one token. The gate was
-`is_plain_var_name`, which rejects any word containing `(`, so every array
-element — literal (`arr(key)`) or computed (`arr($i)`) — was left to the
-default classifier and rendered as a string.
+Whether an argument *is* a variable-name spot is not a text-shape question —
+the [command registry](../design/compiler/command-registry.md) already answers
+it. `insert_var_decl_overrides` walks the argument indices the registry marks
+with the `ArgRole::VarWrite` role, so the target is known to be a variable
+before the walker looks at its text. The only remaining question is token
+**geometry**: can the word be painted as one whole-word `Variable` token, or
+does it contain an inner substitution that must survive as its own sub-token?
 
-Excluding a **computed** subscript is deliberate: `arr($i)` lexes into several
-tokens (`arr(`, `$i`, `)`), and the inner `$i` must survive as its own
-variable sub-token. But a **literal** element (`arr(key)`) lexes as a single
-[`TokenType::Esc`](../../rust/tcl-lexer/src/tokens.rs) word, so it can be
-retagged as one variable token with no risk of clobbering an inner
-substitution.
+The old gate answered that with `is_plain_var_name`, which rejects any word
+containing `(`, so every array element — literal (`arr(key)`) or computed
+(`arr($i)`) — was dropped to the default classifier and rendered as a string.
+That over-rejected: a **literal** element (`arr(key)`) lexes as a single
+[`TokenType::Esc`](../../rust/tcl-lexer/src/tokens.rs) word and is perfectly
+safe to paint as one token.
 
 ## Decision rules / contracts
 
-1. A literal array element (`name(index)` with no `$` / `[` substitution and no
-   nested delimiter in either part) is retagged as a whole-word `Variable`
-   declaration, matching how `$arr(key)` reads highlight. This is decided by
-   `is_literal_array_element` in
+1. The `VarWrite`-role retag does **not** re-derive "is this a variable" from
+   the word's text — the registry role is the authority. It retags the word
+   whenever the segmenter reports the word is a single unquoted `Esc` token
+   (`SegmentedCommand::single_token_word`), matching how `$arr(key)` reads
+   highlight. This covers scalars (`x`), literal array elements (`arr(key)`),
+   and namespaced names (`::ns::arr(key)`) uniformly, with no array-syntax
+   parsing. Decided in `insert_var_decl_overrides`,
    [`rust/tcl-lsp-core/src/semantic_tokens.rs`](../../rust/tcl-lsp-core/src/semantic_tokens.rs).
-2. A computed subscript (`arr($i)`) is **not** retagged — it is left to the
-   default classifier so its inner `$var` sub-tokens survive.
-3. Only the `VarWrite`-role retag (`insert_var_decl_overrides`) accepts array
-   elements. Declaration commands whose names must be scalars or whole arrays
-   (`global`, `variable`, `upvar` locals) keep using `is_plain_var_name`, since
-   an element is not a legal name there.
+2. A word with an inner substitution (`arr($i)`, `$dynamic`) is multi-token, so
+   `single_token_word` is `false` and the word is left to the default
+   classifier — its inner `$var` sub-tokens survive.
+3. The registry-agnostic list walkers (`global` / `variable` names, `upvar`
+   locals, parameter lists, loop-variable lists) still use `is_plain_var_name`,
+   because those pull names out of list positions where an element genuinely may
+   not be a name.
 
 ## File-path anchors
 
-- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `is_literal_array_element`,
-  `insert_var_decl_overrides`
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `insert_var_decl_overrides`
+- `rust/tcl-compiler/src/segmenter.rs` — `SegmentedCommand::single_token_word`
+  (per-word single-token geometry, whose representative `argv` token spans the
+  whole word)
 - `rust/tcl-lexer/src/lexer.rs` — `$arr(idx)` variable lexing
 
 ## Failure modes
 
 - Retagging a **computed** subscript (`arr($i)`) as one token would swallow the
-  inner `$i`, dropping its variable sub-token — the reason the gate excludes it.
-- A subscript containing a nested `(` / `)` / brace could produce an overlapping
-  span if painted as one token; `is_literal_array_element` rejects those.
+  inner `$i`, dropping its variable sub-token — the `single_token_word` gate
+  excludes it because such a word is multi-token.
 
 ## Triage checklist
 
@@ -69,8 +75,7 @@ substitution.
 
 - `rust/tcl-lsp-core/src/semantic_tokens.rs` — `literal_array_element_write_is_variable_declaration`,
   `namespaced_array_element_write_is_variable_declaration`,
-  `unset_array_element_is_variable`, `is_literal_array_element_classifies`,
-  `array_element_write_not_retagged`
+  `unset_array_element_is_variable`, `array_element_write_not_retagged`
 
 ## Related
 

--- a/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
+++ b/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
@@ -89,17 +89,28 @@ safe to paint as one token.
      dynamic-name or read reference elevates to a plain `Variable`.
    The same single-token `Esc` geometry gate applies to every source, so a
    computed subscript stays multi-token and its inner `$var` survives.
+5. The mechanism is role-general, not variable-only. A parameter the analyser
+   infers to name a **command** — used as a command head (`$cmd args`) or a
+   `CommandPrefix` argument (registry or stub `:command_prefix`) — elevates the
+   call-site literal to a `Function` (`ArgOverride::CommandRef`), so
+   `dispatch greet …` paints `greet` as a command. And a param whose value is
+   **carried through a local** (`set n $p; set $n 1` / `$n …`) still resolves
+   back to the param, via value-copy tracking in the inference, so the role is
+   not lost to an intermediate assignment.
 
 ## File-path anchors
 
 - `rust/tcl-lsp-core/src/semantic_tokens.rs` — `insert_var_role_overrides`,
-  `VarNameArgRoles`, `add_stub_var_roles`, `proc_var_write_indices` /
-  `proc_var_read_indices`, `ArgOverride::VarDecl` / `VarRef`
+  `insert_command_role_overrides`, `VarNameArgRoles`, `add_stub_var_roles`,
+  `proc_var_write_indices` / `proc_var_read_indices` / `proc_command_indices`,
+  `ArgOverride::VarDecl` / `VarRef` / `CommandRef`
 - `rust/tcl-lsp-db/src/lib.rs` — `project_proc_var_index` (workspace-merged
   inferred roles), `semantic_tokens` / `semantic_tokens_project` wiring
 - `rust/tcl-compiler/src/analyser/param_traits.rs` — proc parameter trait
   inference: `upvar` / `namespace upvar` aliases, dynamic names (`var_substitutions`,
-  `scan_commands_bounded` command-substitution descent), compound array names
+  `scan_commands_bounded` command-substitution descent), compound array names,
+  command roles (head + `CommandPrefix`), value-copy tracking (`Aliases`)
+- `rust/tcl-compiler/src/analyser/types.rs` — `ProcArgTrait::Command`
 - `rust/tcl-registry/src/stub_overlay.rs` — `# tcl-lsp: stub … :var` / `:var_read`
   roles
 - `rust/tcl-compiler/src/segmenter.rs` — `SegmentedCommand::single_token_word`

--- a/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
+++ b/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
@@ -15,6 +15,10 @@ highlighted as a variable. The `arr(key)` word stays a plain string, even
 though the corresponding read (`$arr(key)`) highlights as one whole-word
 variable (issue #813).
 
+The same is true for an array element passed to a *user proc* or *stubbed
+command* that takes a variable name by reference — `myset arr(key) 1` where
+`myset` does `upvar $varName …`, or a `# tcl-lsp: stub … :var` command.
+
 ## Operational context
 
 Whether an argument *is* a variable-name spot is not a text-shape question —
@@ -49,10 +53,31 @@ safe to paint as one token.
    locals, parameter lists, loop-variable lists) still use `is_plain_var_name`,
    because those pull names out of list positions where an element genuinely may
    not be a name.
+4. The static registry role is not the *only* source of a variable-name spot.
+   The same retag also unions two dynamic sources, both carried by the
+   `VarNameArgRoles` index passed into the token walk:
+   - **Stub roles** — a `# tcl-lsp: stub NAME {arg:var …}` declaration. These
+     are derived from the document source at token-collection time, so they
+     apply on every path (local and workspace) with no analysis needed.
+   - **Inferred user-proc roles** — a proc parameter the analyser inferred to
+     alias a caller variable (`upvar $param` + write → `ProcArgTrait::VarWrite`).
+     Available from the single-file analysis locally, and from the workspace-
+     merged `project_proc_var_index` salsa query when a project is open, so a
+     proc defined in another file resolves too. `ProcArgTrait::DynamicNameLocal`
+     (the param's *value* names a callee-local variable) is excluded — a literal
+     name there is not the caller's variable.
+   The same single-token `Esc` geometry gate applies to every source, so a
+   computed subscript stays multi-token and its inner `$var` survives.
 
 ## File-path anchors
 
-- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `insert_var_decl_overrides`
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `insert_var_decl_overrides`,
+  `VarNameArgRoles`, `add_stub_var_write_roles`, `proc_var_write_indices`
+- `rust/tcl-lsp-db/src/lib.rs` — `project_proc_var_index` (workspace-merged
+  inferred roles), `semantic_tokens` / `semantic_tokens_project` wiring
+- `rust/tcl-compiler/src/analyser/param_traits.rs` — proc parameter trait
+  inference (`upvar` → `VarWrite`)
+- `rust/tcl-registry/src/stub_overlay.rs` — `# tcl-lsp: stub … :var` roles
 - `rust/tcl-compiler/src/segmenter.rs` — `SegmentedCommand::single_token_word`
   (per-word single-token geometry, whose representative `argv` token spans the
   whole word)
@@ -75,7 +100,10 @@ safe to paint as one token.
 
 - `rust/tcl-lsp-core/src/semantic_tokens.rs` — `literal_array_element_write_is_variable_declaration`,
   `namespaced_array_element_write_is_variable_declaration`,
-  `unset_array_element_is_variable`, `array_element_write_not_retagged`
+  `unset_array_element_is_variable`, `array_element_write_not_retagged`,
+  `stub_var_arg_highlights_array_element`,
+  `user_proc_var_name_arg_highlights_array_element`,
+  `user_proc_var_name_computed_subscript_survives`
 
 ## Related
 

--- a/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
+++ b/docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md
@@ -89,7 +89,7 @@ safe to paint as one token.
      dynamic-name or read reference elevates to a plain `Variable`.
    The same single-token `Esc` geometry gate applies to every source, so a
    computed subscript stays multi-token and its inner `$var` survives.
-5. The mechanism is role-general, not variable-only. A parameter the analyser
+6. The mechanism is role-general, not variable-only. A parameter the analyser
    infers to name a **command** — used as a command head (`$cmd args`) or a
    `CommandPrefix` argument (registry or stub `:command_prefix`) — elevates the
    call-site literal to a `Function` (`ArgOverride::CommandRef`), so

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -673,10 +673,11 @@ fn apply_arg_role_traits<'p>(
                     }
                 }
             }
-            // A registry `CommandPrefix` role names a command (`rename $old new`,
-            // `interp alias {} $a {} …`).  A `$param` (or component of a
-            // dynamic name) flowing there means the param's value is a command
-            // name.  Braced words are literal — no substitution.
+            // A registry / stub `CommandPrefix` role names a command — a callback
+            // command prefix (`tcltest::customMatch`, `selection handle`, a stub
+            // `:command_prefix` arg).  A `$param` (or component of a dynamic
+            // name) flowing there means the param's value is a command name.
+            // Braced words are literal — no substitution.
             Some(ArgRole::CommandPrefix) if !braced.get(idx).copied().unwrap_or(false) => {
                 for var_name in var_substitutions(arg) {
                     if let Some(p) = lookup_param(var_name, param_set, aliases)
@@ -856,10 +857,12 @@ fn handle_namespace_upvar<'p>(
 }
 
 /// Record the `otherVar myVar` pairs shared by `upvar` and `namespace upvar`:
-/// each `otherVar` that is a `$param` reads the aliased variable (`VarRead`)
-/// and registers `myVar` as an alias for that param, so a later write through
-/// the alias upgrades it to `VarWrite`.  A `$param` in a `myVar` slot names a
-/// callee-local alias (`VarWrite`).
+/// each `otherVar` that is a `$param` reads the aliased caller variable
+/// (`VarRead`) and registers `myVar` as an alias for that param, so a later
+/// write *through the alias* (`set myVar …`) upgrades it to a genuine
+/// caller-frame `VarWrite`.  A `$param` in the `myVar` slot is different — its
+/// value names a *callee-local* alias variable, not a caller variable, so it is
+/// a `DynamicNameLocal` use (never a caller-frame `VarWrite`).
 fn record_upvar_pairs<'p>(
     pairs: &[String],
     param_set: &HashSet<&'p str>,
@@ -884,7 +887,7 @@ fn record_upvar_pairs<'p>(
             && let Some(p) = param_set.get(my_vn).copied()
             && let Some(set) = traits.get_mut(p)
         {
-            set.insert(ProcArgTrait::VarWrite);
+            mark_dynamic_name_local(set);
         }
     }
 }
@@ -1186,6 +1189,20 @@ mod tests {
         assert_trait(&traits, "var", ProcArgTrait::VarRead);
         // Write through the alias upgrades to VarWrite.
         assert_trait(&traits, "var", ProcArgTrait::VarWrite);
+    }
+
+    #[test]
+    fn upvar_my_var_slot_param_is_callee_local_not_var_write() {
+        // `upvar 1 caller $local` — the param in the `myVar` slot names the
+        // *callee-local* alias, not a caller variable, so it is a
+        // `DynamicNameLocal` use, never a caller-frame `VarWrite` (PR review).
+        let traits = infer(&["local"], "upvar 1 caller $local");
+        assert_trait(&traits, "local", ProcArgTrait::DynamicNameLocal);
+        assert!(
+            !traits.get("local").unwrap().contains(&ProcArgTrait::VarWrite),
+            "myVar-slot param must not be a caller VarWrite; got {:?}",
+            traits.get("local"),
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -131,7 +131,7 @@ pub fn infer_param_traits_with_config(
     let param_set: HashSet<&str> = params.iter().copied().collect();
     let mut traits: HashMap<&str, HashSet<ProcArgTrait>> =
         params.iter().map(|p| (*p, HashSet::new())).collect();
-    let mut upvar_aliases: HashMap<String, &str> = HashMap::new();
+    let mut aliases = Aliases::default();
 
     let ctx = ScanCtx {
         param_set: &param_set,
@@ -139,7 +139,7 @@ pub fn infer_param_traits_with_config(
         stub_overlay,
         config,
     };
-    scan_commands(body_source, &ctx, &mut traits, &mut upvar_aliases);
+    scan_commands(body_source, &ctx, &mut traits, &mut aliases);
 
     finalise_traits(traits)
 }
@@ -196,7 +196,7 @@ pub fn infer_param_traits_deep_with_config(
     let param_set: HashSet<&str> = params.iter().copied().collect();
     let mut traits: HashMap<&str, HashSet<ProcArgTrait>> =
         params.iter().map(|p| (*p, HashSet::new())).collect();
-    let mut upvar_aliases: HashMap<String, &str> = HashMap::new();
+    let mut aliases = Aliases::default();
 
     let ctx = ScanCtx {
         param_set: &param_set,
@@ -204,7 +204,7 @@ pub fn infer_param_traits_deep_with_config(
         stub_overlay,
         config,
     };
-    scan_deep(body_source, &ctx, &mut traits, &mut upvar_aliases, 0);
+    scan_deep(body_source, &ctx, &mut traits, &mut aliases, 0);
 
     finalise_traits(traits)
 }
@@ -261,6 +261,34 @@ struct ScanCtx<'p, 'r> {
     config: LexerConfig,
 }
 
+/// Mutable alias / value-copy state accumulated while scanning a proc body.
+/// Bundling the two maps keeps the scan helpers at or under the argument limit.
+#[derive(Default)]
+struct Aliases<'p> {
+    /// `myVar` (an `upvar` / `namespace upvar` alias name) → the param it
+    /// aliases, so a later `set myVar …` writes the caller's variable
+    /// (`VarWrite`).
+    upvar: HashMap<String, &'p str>,
+    /// A local name → the param whose *value* it currently holds (`set n $p`),
+    /// so a later `$n` in a name / command position resolves to that param.
+    /// Invalidated when the local is written to anything else.
+    value_copies: HashMap<String, &'p str>,
+}
+
+/// `true` when `name` is a plain scalar local identifier — the only shape a
+/// tracked value-copy target can take (`set n $p` records `n`, but `set
+/// arr(x)` / `set $n` do not).
+fn is_plain_local_name(name: &str) -> bool {
+    !name.is_empty()
+        && name
+            .bytes()
+            .next()
+            .is_some_and(|b| b.is_ascii_alphabetic() || b == b'_')
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b':')
+}
+
 /// Single-level command scan shared by both passes.  Extracts
 /// segmented commands from `source` and dispatches each through
 /// [`scan_command`].
@@ -272,9 +300,9 @@ fn scan_commands<'p>(
     source: &str,
     ctx: &ScanCtx<'p, '_>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
-    upvar_aliases: &mut HashMap<String, &'p str>,
+    aliases: &mut Aliases<'p>,
 ) {
-    scan_commands_bounded(source, ctx, traits, upvar_aliases, 0);
+    scan_commands_bounded(source, ctx, traits, aliases, 0);
 }
 
 /// [`scan_commands`] plus descent into `[...]` command substitutions, bounded
@@ -287,7 +315,7 @@ fn scan_commands_bounded<'p>(
     source: &str,
     ctx: &ScanCtx<'p, '_>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
-    upvar_aliases: &mut HashMap<String, &'p str>,
+    aliases: &mut Aliases<'p>,
     depth: u8,
 ) {
     let segments = segment_commands_with_offset_and_config(source, 0, ctx.config);
@@ -315,7 +343,7 @@ fn scan_commands_bounded<'p>(
             head_is_var,
             ctx,
             traits,
-            upvar_aliases,
+            aliases,
         );
         if depth >= MAX_DEPTH {
             continue;
@@ -327,7 +355,7 @@ fn scan_commands_bounded<'p>(
                 && let Some(inner) = word.strip_prefix('[').and_then(|w| w.strip_suffix(']'))
                 && !inner.trim().is_empty()
             {
-                scan_commands_bounded(inner, ctx, traits, upvar_aliases, depth + 1);
+                scan_commands_bounded(inner, ctx, traits, aliases, depth + 1);
             }
         }
     }
@@ -346,14 +374,14 @@ fn scan_deep<'p>(
     source: &str,
     ctx: &ScanCtx<'p, '_>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
-    upvar_aliases: &mut HashMap<String, &'p str>,
+    aliases: &mut Aliases<'p>,
     depth: u8,
 ) {
     if depth > MAX_DEPTH {
         return;
     }
 
-    scan_commands(source, ctx, traits, upvar_aliases);
+    scan_commands(source, ctx, traits, aliases);
 
     // The recursion only walks braced bodies, so we re-segment
     // here rather than threading the segmented commands through
@@ -398,7 +426,7 @@ fn scan_deep<'p>(
             if head.len() >= 2 && (head[1] == b'$' || head[1] == b'[') {
                 continue;
             }
-            scan_deep(body_text, ctx, traits, upvar_aliases, depth + 1);
+            scan_deep(body_text, ctx, traits, aliases, depth + 1);
         }
     }
 }
@@ -485,27 +513,28 @@ fn scan_command<'p>(
     head_is_var: bool,
     ctx: &ScanCtx<'p, '_>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
-    upvar_aliases: &mut HashMap<String, &'p str>,
+    aliases: &mut Aliases<'p>,
 ) {
     let param_set = ctx.param_set;
     // A `$param` command *head* (`$cmd arg1 arg2`) means the param's value names
     // a command.  Only a genuine `$`-substitution head counts — a braced
-    // `{$cmd}` is a literal command name.
+    // `{$cmd}` is a literal command name.  Resolves value-copies, so
+    // `set c $cmd; $c …` also marks `cmd`.
     if head_is_var
         && let Some(vn) = extract_var_name(cmd_name)
-        && let Some(p) = param_set.get(vn).copied()
+        && let Some(p) = lookup_param(vn, param_set, aliases)
         && let Some(set) = traits.get_mut(p)
     {
         set.insert(ProcArgTrait::Command);
     }
-    apply_arg_role_traits(cmd_name, cmd_args, braced, ctx, traits, upvar_aliases);
+    apply_arg_role_traits(cmd_name, cmd_args, braced, ctx, traits, aliases);
     apply_eval_traits(cmd_name, cmd_args, param_set, traits);
 
     // Per-command structural handlers.
     match cmd_name {
-        "upvar" => handle_upvar(cmd_args, param_set, traits, upvar_aliases),
+        "upvar" => handle_upvar(cmd_args, param_set, traits, aliases),
         "namespace" if cmd_args.first().map(String::as_str) == Some("upvar") => {
-            handle_namespace_upvar(cmd_args, param_set, traits, upvar_aliases);
+            handle_namespace_upvar(cmd_args, param_set, traits, aliases);
         }
         "foreach" | "lmap" => handle_foreach(cmd_args, param_set, traits),
         "while" => handle_while(cmd_args, param_set, traits),
@@ -530,7 +559,7 @@ fn scan_command<'p>(
     // ``local`` was registered as an alias for some param.
     if matches!(cmd_name, "set" | "incr" | "append" | "lappend")
         && !cmd_args.is_empty()
-        && let Some(target) = upvar_aliases.get(cmd_args[0].as_str())
+        && let Some(target) = aliases.upvar.get(cmd_args[0].as_str())
         && let Some(set) = traits.get_mut(target)
     {
         set.insert(ProcArgTrait::VarWrite);
@@ -541,13 +570,44 @@ fn scan_command<'p>(
         let remaining = &cmd_args[..cmd_args.len() - 1];
         let mut i = 0;
         while i < remaining.len() {
-            if let Some(target) = upvar_aliases.get(remaining[i].as_str())
+            if let Some(target) = aliases.upvar.get(remaining[i].as_str())
                 && let Some(set) = traits.get_mut(target)
             {
                 set.insert(ProcArgTrait::VarWrite);
             }
             i += 2;
         }
+    }
+
+    // Value-copy tracking: `set n $p` makes local `n` carry param `p`'s value,
+    // so a later `$n` in a name / command position resolves to `p`.  Any other
+    // write to a tracked local invalidates the copy.  Recorded *after* the role
+    // scan so this command's effect applies only to later commands.
+    match cmd_name {
+        "set" if cmd_args.len() == 2 => {
+            let target = cmd_args[0].as_str();
+            if extract_var_name(&cmd_args[0]).is_none()
+                && is_plain_local_name(target)
+                && !param_set.contains(target)
+            {
+                match extract_var_name(&cmd_args[1])
+                    .and_then(|vn| lookup_param(vn, param_set, aliases))
+                {
+                    Some(p) => {
+                        aliases.value_copies.insert(target.to_owned(), p);
+                    }
+                    None => {
+                        aliases.value_copies.remove(target);
+                    }
+                }
+            }
+        }
+        "incr" | "append" | "lappend"
+            if cmd_args.first().is_some_and(|t| is_plain_local_name(t)) =>
+        {
+            aliases.value_copies.remove(cmd_args[0].as_str());
+        }
+        _ => {}
     }
 }
 
@@ -568,7 +628,7 @@ fn apply_arg_role_traits<'p>(
     braced: &[bool],
     ctx: &ScanCtx<'p, '_>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
-    upvar_aliases: &HashMap<String, &'p str>,
+    aliases: &Aliases<'p>,
 ) {
     let param_set = ctx.param_set;
     let arg_roles = resolve_arg_roles(cmd_name, cmd_args, ctx.registry, ctx.stub_overlay);
@@ -581,14 +641,14 @@ fn apply_arg_role_traits<'p>(
             // the whole argument *is* the param's value, evaluated as a script /
             // expression.
             Some(ArgRole::Body) => {
-                if let Some(p) = resolve_param(arg, param_set, upvar_aliases)
+                if let Some(p) = resolve_param(arg, param_set, aliases)
                     && let Some(set) = traits.get_mut(p)
                 {
                     set.insert(ProcArgTrait::Body);
                 }
             }
             Some(ArgRole::Expr) => {
-                if let Some(p) = resolve_param(arg, param_set, upvar_aliases)
+                if let Some(p) = resolve_param(arg, param_set, aliases)
                     && let Some(set) = traits.get_mut(p)
                 {
                     set.insert(ProcArgTrait::Expr);
@@ -606,7 +666,7 @@ fn apply_arg_role_traits<'p>(
                 if !braced.get(idx).copied().unwrap_or(false) =>
             {
                 for var_name in var_substitutions(arg) {
-                    if let Some(p) = lookup_param(var_name, param_set, upvar_aliases)
+                    if let Some(p) = lookup_param(var_name, param_set, aliases)
                         && let Some(set) = traits.get_mut(p)
                     {
                         mark_dynamic_name_local(set);
@@ -619,7 +679,7 @@ fn apply_arg_role_traits<'p>(
             // name.  Braced words are literal — no substitution.
             Some(ArgRole::CommandPrefix) if !braced.get(idx).copied().unwrap_or(false) => {
                 for var_name in var_substitutions(arg) {
-                    if let Some(p) = lookup_param(var_name, param_set, upvar_aliases)
+                    if let Some(p) = lookup_param(var_name, param_set, aliases)
                         && let Some(set) = traits.get_mut(p)
                     {
                         set.insert(ProcArgTrait::Command);
@@ -637,23 +697,24 @@ fn apply_arg_role_traits<'p>(
 fn resolve_param<'p>(
     arg: &str,
     param_set: &HashSet<&'p str>,
-    upvar_aliases: &HashMap<String, &'p str>,
+    aliases: &Aliases<'p>,
 ) -> Option<&'p str> {
-    lookup_param(extract_var_name(arg)?, param_set, upvar_aliases)
+    lookup_param(extract_var_name(arg)?, param_set, aliases)
 }
 
-/// Map a bare variable name to the param it is (directly, or via an `upvar`
-/// alias).  `None` when it names no known param.
+/// Map a bare variable name to the param it references — directly, via an
+/// `upvar` alias, or via a local that carries a param's value (`set n $p`).
+/// `None` when it names no known param.
 fn lookup_param<'p>(
     var_name: &str,
     param_set: &HashSet<&'p str>,
-    upvar_aliases: &HashMap<String, &'p str>,
+    aliases: &Aliases<'p>,
 ) -> Option<&'p str> {
-    if let Some(p) = param_set.get(var_name) {
-        Some(*p)
-    } else {
-        upvar_aliases.get(var_name).copied()
-    }
+    param_set
+        .get(var_name)
+        .copied()
+        .or_else(|| aliases.upvar.get(var_name).copied())
+        .or_else(|| aliases.value_copies.get(var_name).copied())
 }
 
 /// Yield each simple variable name substituted in `text` — `$name`, `${name}`,
@@ -767,7 +828,7 @@ fn handle_upvar<'p>(
     args: &[String],
     param_set: &HashSet<&'p str>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
-    upvar_aliases: &mut HashMap<String, &'p str>,
+    aliases: &mut Aliases<'p>,
 ) {
     // `upvar ?level? otherVar myVar ?otherVar myVar ...?` — an optional leading
     // level word (`1`, `#0`) shifts the first pair.
@@ -775,7 +836,7 @@ fn handle_upvar<'p>(
         .first()
         .is_some_and(|h| h.chars().all(|c| c.is_ascii_digit()) || h.starts_with('#'));
     let pairs = args.get(usize::from(has_level)..).unwrap_or(&[]);
-    record_upvar_pairs(pairs, param_set, traits, upvar_aliases);
+    record_upvar_pairs(pairs, param_set, traits, aliases);
 }
 
 /// `namespace upvar namespace ?otherVar myVar ...?` — the pairs alias namespace
@@ -787,10 +848,10 @@ fn handle_namespace_upvar<'p>(
     args: &[String],
     param_set: &HashSet<&'p str>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
-    upvar_aliases: &mut HashMap<String, &'p str>,
+    aliases: &mut Aliases<'p>,
 ) {
     if args.len() > 2 {
-        record_upvar_pairs(&args[2..], param_set, traits, upvar_aliases);
+        record_upvar_pairs(&args[2..], param_set, traits, aliases);
     }
 }
 
@@ -803,7 +864,7 @@ fn record_upvar_pairs<'p>(
     pairs: &[String],
     param_set: &HashSet<&'p str>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
-    upvar_aliases: &mut HashMap<String, &'p str>,
+    aliases: &mut Aliases<'p>,
 ) {
     let mut i = 0;
     while i + 1 < pairs.len() {
@@ -817,7 +878,7 @@ fn record_upvar_pairs<'p>(
             if let Some(set) = traits.get_mut(p) {
                 set.insert(ProcArgTrait::VarRead);
             }
-            upvar_aliases.insert(my_var.clone(), p);
+            aliases.upvar.insert(my_var.clone(), p);
         }
         if let Some(my_vn) = extract_var_name(my_var)
             && let Some(p) = param_set.get(my_vn).copied()
@@ -1211,6 +1272,47 @@ mod tests {
         assert_eq!(var_substitutions("literal"), Vec::<&str>::new());
         assert_eq!(var_substitutions("\\$escaped"), Vec::<&str>::new());
         assert_eq!(var_substitutions("$1backref"), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn value_copy_carries_param_into_name_and_command_positions() {
+        // `set n $p` copies the param's value into local `n`; a later `$n` in a
+        // name / command position then resolves back to the param.
+        assert_trait(
+            &infer(&["v"], "set n $v\nset $n 1"),
+            "v",
+            ProcArgTrait::DynamicNameLocal,
+        );
+        assert_trait(
+            &infer(&["cmd"], "set c $cmd\n$c arg"),
+            "cmd",
+            ProcArgTrait::Command,
+        );
+        // In a command substitution too.
+        assert_trait(
+            &infer(&["v"], "set n $v\nreturn [set $n]"),
+            "v",
+            ProcArgTrait::DynamicNameLocal,
+        );
+        // Transitive copies chain.
+        assert_trait(
+            &infer(&["cmd"], "set c $cmd\nset d $c\n$d arg"),
+            "cmd",
+            ProcArgTrait::Command,
+        );
+    }
+
+    #[test]
+    fn value_copy_is_invalidated_and_not_over_eager() {
+        // Reassigning the local to a non-param drops the copy, so a later `$n`
+        // no longer resolves to the original param.
+        assert!(
+            infer(&["v"], "set n $v\nset n other\nset $n 1")
+                .get("v")
+                .is_none()
+        );
+        // Merely passing the value through (never used as a name) is not a role.
+        assert!(infer(&["v"], "set n $v\nreturn $n").get("v").is_none());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -39,11 +39,16 @@
 //!
 //! Two passes are exposed:
 //!
-//! * [`infer_param_traits`] — shallow, top-level command scan
-//!   only.  Fast enough for synchronous use during analysis;
-//!   detects direct patterns like ``eval $param``, ``upvar 1
-//!   $param local``, ``foreach x $list body``.  Does not
-//!   recurse into braced body arguments.
+//! * [`infer_param_traits`] — shallow command scan.  Fast enough
+//!   for synchronous use during analysis; detects direct patterns
+//!   like ``eval $param``, ``upvar 1 $param local``, ``foreach x
+//!   $list body``.  It **does** descend into ``[...]`` command
+//!   substitutions (`return [set $v]` is a first-order use), and
+//!   recognises variable names built from parameters — a bare
+//!   ``$p``, a compound array element (``set ${v}($k)`` marks both
+//!   ``v`` and ``k``), and ``namespace upvar ns $token arr``.  It
+//!   does **not** recurse into braced *body* arguments (that is the
+//!   deep pass's job).
 //! * [`infer_param_traits_deep`] — recursive descent into
 //!   braced body args, catching traits hidden one or more
 //!   levels deep (`foreach item $items { uplevel 1 $body }`
@@ -65,7 +70,7 @@ use tcl_registry::stub_overlay::StubOverlay;
 
 use super::types::ProcArgTrait;
 use crate::segmenter::segment_commands_with_offset_and_config;
-use tcl_lexer::LexerConfig;
+use tcl_lexer::{LexerConfig, TokenType};
 
 /// Top-level shallow trait inference.  Returns a map from
 /// parameter name to a set of inferred traits.  Empty entries
@@ -269,9 +274,42 @@ fn scan_commands<'p>(
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
     upvar_aliases: &mut HashMap<String, &'p str>,
 ) {
-    let commands = extract_commands(source, ctx.config);
-    for (cmd_name, cmd_args) in &commands {
-        scan_command(cmd_name, cmd_args, ctx, traits, upvar_aliases);
+    scan_commands_bounded(source, ctx, traits, upvar_aliases, 0);
+}
+
+/// [`scan_commands`] plus descent into `[...]` command substitutions, bounded
+/// by [`MAX_DEPTH`].  A param used inside a substitution (`return [set $v]`,
+/// `set x [foo $v]`, `set ${v}($k)` wrapped in `[...]`) is a first-order use of
+/// that param, not a "deep" one, so both the shallow and deep passes see it —
+/// the substitution is where much ordinary Tcl computation happens.  Nested
+/// substitutions are reached by the recursion.
+fn scan_commands_bounded<'p>(
+    source: &str,
+    ctx: &ScanCtx<'p, '_>,
+    traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
+    upvar_aliases: &mut HashMap<String, &'p str>,
+    depth: u8,
+) {
+    let segments = segment_commands_with_offset_and_config(source, 0, ctx.config);
+    for seg in &segments {
+        if seg.texts.is_empty() {
+            continue;
+        }
+        let cmd_args: Vec<String> = seg.texts[1..].to_vec();
+        scan_command(&seg.texts[0], &cmd_args, ctx, traits, upvar_aliases);
+        if depth >= MAX_DEPTH {
+            continue;
+        }
+        // A whole-word `Cmd` token's `texts` entry is the bracketed
+        // substitution; strip the outer `[` / `]` and recurse into its script.
+        for (word, tok) in seg.texts.iter().zip(seg.argv.iter()) {
+            if tok.kind == TokenType::Cmd
+                && let Some(inner) = word.strip_prefix('[').and_then(|w| w.strip_suffix(']'))
+                && !inner.trim().is_empty()
+            {
+                scan_commands_bounded(inner, ctx, traits, upvar_aliases, depth + 1);
+            }
+        }
     }
 }
 
@@ -343,22 +381,6 @@ fn scan_deep<'p>(
             scan_deep(body_text, ctx, traits, upvar_aliases, depth + 1);
         }
     }
-}
-
-/// Extract `(command, args)` pairs from `source` via the
-/// segmenter.
-fn extract_commands(source: &str, config: LexerConfig) -> Vec<(String, Vec<String>)> {
-    let mut commands = Vec::new();
-    let segments = segment_commands_with_offset_and_config(source, 0, config);
-    for seg in segments {
-        if seg.texts.is_empty() {
-            continue;
-        }
-        let cmd_name = seg.texts[0].clone();
-        let cmd_args: Vec<String> = seg.texts[1..].to_vec();
-        commands.push((cmd_name, cmd_args));
-    }
-    commands
 }
 
 /// Extract a bare variable name from ``$var`` or ``${var}``.
@@ -457,6 +479,9 @@ fn scan_command<'p>(
     // Per-command structural handlers.
     match cmd_name {
         "upvar" => handle_upvar(cmd_args, param_set, traits, upvar_aliases),
+        "namespace" if cmd_args.first().map(String::as_str) == Some("upvar") => {
+            handle_namespace_upvar(cmd_args, param_set, traits, upvar_aliases);
+        }
         "foreach" | "lmap" => handle_foreach(cmd_args, param_set, traits),
         "while" => handle_while(cmd_args, param_set, traits),
         "for" => handle_for(cmd_args, param_set, traits),
@@ -516,38 +541,127 @@ fn apply_arg_role_traits<'p>(
 ) {
     let arg_roles = resolve_arg_roles(cmd_name, cmd_args, registry, stub_overlay);
     for (idx, arg) in cmd_args.iter().enumerate() {
-        let Some(var_name) = extract_var_name(arg) else {
-            continue;
-        };
-        let source_param = if let Some(p) = param_set.get(var_name) {
-            *p
-        } else if let Some(alias) = upvar_aliases.get(var_name) {
-            *alias
-        } else {
-            continue;
-        };
         let Ok(idx_u8) = u8::try_from(idx) else {
             continue;
         };
-        let Some(set) = traits.get_mut(source_param) else {
-            continue;
-        };
         match arg_roles.get(&idx_u8) {
+            // Body / Expr apply only to a bare `$param` (or upvar-aliased) word:
+            // the whole argument *is* the param's value, evaluated as a script /
+            // expression.
             Some(ArgRole::Body) => {
-                set.insert(ProcArgTrait::Body);
+                if let Some(p) = resolve_param(arg, param_set, upvar_aliases)
+                    && let Some(set) = traits.get_mut(p)
+                {
+                    set.insert(ProcArgTrait::Body);
+                }
             }
             Some(ArgRole::Expr) => {
-                set.insert(ProcArgTrait::Expr);
+                if let Some(p) = resolve_param(arg, param_set, upvar_aliases)
+                    && let Some(set) = traits.get_mut(p)
+                {
+                    set.insert(ProcArgTrait::Expr);
+                }
             }
-            // A registry `VarWrite` / `VarRead` role landing on a bare
-            // `$param` substitution means the param's VALUE names a
-            // CALLEE-LOCAL variable (`set $p 1`, `variable $p`,
-            // `incr $p`) — NOT a caller-frame alias.  Record the
-            // callee-local refinement, never `VarWrite` (only an
-            // `upvar`-aliased write-back is a genuine caller write).
-            Some(ArgRole::VarWrite | ArgRole::VarRead) => mark_dynamic_name_local(set),
+            // A registry / stub `VarWrite` / `VarRead` role names a variable.
+            // Every param whose value flows into that name — the whole `$p`, or
+            // a `$p` component of a compound dynamic name (`${p}($k)`,
+            // `$p($k)`) — names a CALLEE-LOCAL variable (`set $p 1`,
+            // `set ${v}($k)`, `incr $p`), NOT a caller-frame alias.  Record the
+            // callee-local refinement (never `VarWrite`; only an `upvar`-aliased
+            // write-back is a genuine caller write).
+            Some(ArgRole::VarWrite | ArgRole::VarRead) => {
+                for var_name in var_substitutions(arg) {
+                    if let Some(p) = lookup_param(var_name, param_set, upvar_aliases)
+                        && let Some(set) = traits.get_mut(p)
+                    {
+                        mark_dynamic_name_local(set);
+                    }
+                }
+            }
             _ => {}
         }
+    }
+}
+
+/// Resolve a bare `$param` / `${param}` argument to the param it references,
+/// following an `upvar` alias.  `None` when the argument is not a simple
+/// variable reference or names no known param.
+fn resolve_param<'p>(
+    arg: &str,
+    param_set: &HashSet<&'p str>,
+    upvar_aliases: &HashMap<String, &'p str>,
+) -> Option<&'p str> {
+    lookup_param(extract_var_name(arg)?, param_set, upvar_aliases)
+}
+
+/// Map a bare variable name to the param it is (directly, or via an `upvar`
+/// alias).  `None` when it names no known param.
+fn lookup_param<'p>(
+    var_name: &str,
+    param_set: &HashSet<&'p str>,
+    upvar_aliases: &HashMap<String, &'p str>,
+) -> Option<&'p str> {
+    if let Some(p) = param_set.get(var_name) {
+        Some(*p)
+    } else {
+        upvar_aliases.get(var_name).copied()
+    }
+}
+
+/// Yield each simple variable name substituted in `text` — `$name`, `${name}`,
+/// or the array *name* of an element reference — in source order.  Used to find
+/// the param(s) whose value flows into a (possibly compound) dynamic variable
+/// name such as `${v}($k)` (both `v` and `k`), `arr($k)` (just `k`), or the
+/// segmenter's normalised `${gas(idx)}` form (just `gas`).  Best-effort and
+/// highlighting-grade: a leading `\$` is skipped, and a name must start with a
+/// letter or `_` (so `$1` backrefs and `$` alone are ignored).
+fn var_substitutions(text: &str) -> Vec<&str> {
+    let bytes = text.as_bytes();
+    let mut out = Vec::new();
+    let mut i = 0;
+    while i < bytes.len() {
+        if bytes[i] != b'$' || (i > 0 && bytes[i - 1] == b'\\') {
+            i += 1;
+            continue;
+        }
+        if bytes.get(i + 1) == Some(&b'{') {
+            // `${…}` — the braced content is the variable name, but the
+            // segmenter normalises an element ref to `${gas(idx)}`, so take only
+            // the leading identifier as the name.  Advance past `${` (not past
+            // the closer) so any `$k` *inside* the braces (`${arr($k)}`) or
+            // after them (`${v}($k)`) is still scanned.
+            if let Some(rel) = text[i + 2..].find('}') {
+                push_leading_ident(&text[i + 2..i + 2 + rel], &mut out);
+            }
+            i += 2;
+        } else {
+            let mut j = i + 1;
+            while j < bytes.len()
+                && (bytes[j].is_ascii_alphanumeric() || bytes[j] == b'_' || bytes[j] == b':')
+            {
+                j += 1;
+            }
+            push_leading_ident(&text[i + 1..j], &mut out);
+            i = j.max(i + 1);
+        }
+    }
+    out
+}
+
+/// Push the leading identifier of `content` (up to the first non-`[A-Za-z0-9_:]`
+/// character) onto `out`, when it starts with a letter or `_`.  Used to peel the
+/// array *name* off an element reference (`gas(idx)` → `gas`).
+fn push_leading_ident<'a>(content: &'a str, out: &mut Vec<&'a str>) {
+    let end = content
+        .find(|c: char| !(c.is_ascii_alphanumeric() || c == '_' || c == ':'))
+        .unwrap_or(content.len());
+    let name = &content[..end];
+    if name
+        .bytes()
+        .next()
+        .is_some_and(|b| b.is_ascii_alphabetic() || b == b'_')
+    {
+        out.push(name);
     }
 }
 
@@ -607,17 +721,46 @@ fn handle_upvar<'p>(
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
     upvar_aliases: &mut HashMap<String, &'p str>,
 ) {
-    let mut start = 0usize;
-    if !args.is_empty() {
-        let head = args[0].as_str();
-        if head.chars().all(|c| c.is_ascii_digit()) || head.starts_with('#') {
-            start = 1;
-        }
+    // `upvar ?level? otherVar myVar ?otherVar myVar ...?` — an optional leading
+    // level word (`1`, `#0`) shifts the first pair.
+    let has_level = args
+        .first()
+        .is_some_and(|h| h.chars().all(|c| c.is_ascii_digit()) || h.starts_with('#'));
+    let pairs = args.get(usize::from(has_level)..).unwrap_or(&[]);
+    record_upvar_pairs(pairs, param_set, traits, upvar_aliases);
+}
+
+/// `namespace upvar namespace ?otherVar myVar ...?` — the pairs alias namespace
+/// variables named by `otherVar` (`$token`) into locals.  Structurally
+/// identical to [`handle_upvar`] once the `upvar` sub-command word and the
+/// `namespace` word are skipped.  `args` is the whole sub-command arg list:
+/// `["upvar", namespace, otherVar, myVar, …]`, so the pairs start at index 2.
+fn handle_namespace_upvar<'p>(
+    args: &[String],
+    param_set: &HashSet<&'p str>,
+    traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
+    upvar_aliases: &mut HashMap<String, &'p str>,
+) {
+    if args.len() > 2 {
+        record_upvar_pairs(&args[2..], param_set, traits, upvar_aliases);
     }
-    let mut i = start;
-    while i + 1 < args.len() {
-        let other_var = &args[i];
-        let my_var = &args[i + 1];
+}
+
+/// Record the `otherVar myVar` pairs shared by `upvar` and `namespace upvar`:
+/// each `otherVar` that is a `$param` reads the aliased variable (`VarRead`)
+/// and registers `myVar` as an alias for that param, so a later write through
+/// the alias upgrades it to `VarWrite`.  A `$param` in a `myVar` slot names a
+/// callee-local alias (`VarWrite`).
+fn record_upvar_pairs<'p>(
+    pairs: &[String],
+    param_set: &HashSet<&'p str>,
+    traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
+    upvar_aliases: &mut HashMap<String, &'p str>,
+) {
+    let mut i = 0;
+    while i + 1 < pairs.len() {
+        let other_var = &pairs[i];
+        let my_var = &pairs[i + 1];
         i += 2;
 
         if let Some(other_vn) = extract_var_name(other_var)
@@ -950,6 +1093,111 @@ mod tests {
                 !traits.get(p).unwrap().contains(&ProcArgTrait::VarWrite),
                 "{p}: callee-local lassign target must not be VarWrite, got {:?}",
                 traits.get(p),
+            );
+        }
+    }
+
+    #[test]
+    fn command_substitution_is_scanned() {
+        // A param used inside a `[...]` substitution is a first-order use — the
+        // shallow scan must descend into it.  `return [set $v 1]` names a
+        // callee-local variable via `$v` → DynamicNameLocal (+ VarRead).
+        let traits = infer(&["v"], "return [set $v 1]");
+        assert_trait(&traits, "v", ProcArgTrait::DynamicNameLocal);
+        assert_trait(&traits, "v", ProcArgTrait::VarRead);
+        // The read form (single-arg `set`) is scanned identically.
+        let traits = infer(&["v"], "return [set $v]");
+        assert_trait(&traits, "v", ProcArgTrait::DynamicNameLocal);
+    }
+
+    #[test]
+    fn command_substitution_plain_value_is_not_a_var_name() {
+        // `[string length $x]` reads `$x` as a value, not a variable name, so
+        // no role is recorded — the descent must not over-mark ordinary reads.
+        let traits = infer(&["x"], "return [string length $x]");
+        assert!(
+            traits.get("x").is_none_or(HashSet::is_empty),
+            "plain value read must record no trait, got {:?}",
+            traits.get("x"),
+        );
+    }
+
+    #[test]
+    fn compound_dynamic_array_name_marks_components() {
+        // `set ${v}($k) 1` — both the array-name param `v` and the key param
+        // `k` flow into a dynamic variable name, so both are DynamicNameLocal
+        // (+ VarRead).  This is the shape behind `return [set ${v}($k)]`.
+        for body in ["set ${v}($k) 1", "set $v($k) 1", "return [set ${v}($k)]"] {
+            let traits = infer(&["v", "k"], body);
+            for p in ["v", "k"] {
+                assert_trait(&traits, p, ProcArgTrait::DynamicNameLocal);
+                assert_trait(&traits, p, ProcArgTrait::VarRead);
+            }
+        }
+        // A literal array name with a `$k` key marks only the key.
+        let traits = infer(&["k"], "set arr($k) 1");
+        assert_trait(&traits, "k", ProcArgTrait::DynamicNameLocal);
+    }
+
+    #[test]
+    fn var_substitutions_finds_compound_components() {
+        assert_eq!(var_substitutions("$v"), vec!["v"]);
+        assert_eq!(var_substitutions("${v}($k)"), vec!["v", "k"]);
+        assert_eq!(var_substitutions("$v($k)"), vec!["v", "k"]);
+        assert_eq!(var_substitutions("arr($k)"), vec!["k"]);
+        assert_eq!(var_substitutions("literal"), Vec::<&str>::new());
+        assert_eq!(var_substitutions("\\$escaped"), Vec::<&str>::new());
+        assert_eq!(var_substitutions("$1backref"), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn namespace_upvar_dynamic_name_reads_other_var() {
+        // `namespace upvar ns $token arr` — the token/state-array idiom, with a
+        // dynamic `$token` naming the namespace variable aliased into `arr`.
+        // The pairs start after the `namespace` word (index 2 of the
+        // sub-command args), so `$token` is the *other* var → VarRead, and a
+        // later write through the `arr` alias upgrades it to VarWrite.
+        let traits = infer(&["token"], "namespace upvar ns $token arr");
+        assert_trait(&traits, "token", ProcArgTrait::VarRead);
+        let traits = infer(&["token"], "namespace upvar ns $token arr\nset arr 1");
+        assert_trait(&traits, "token", ProcArgTrait::VarWrite);
+    }
+
+    #[test]
+    fn real_world_by_reference_patterns_are_inferred() {
+        // The dominant variable-name-by-reference shapes mined from the tcllib /
+        // Tcl-library corpus (`http`, `smtp`, `ftp`, … token idiom).  Each names
+        // a variable via a parameter, so each must record a read/write trait.
+        let has_var = |body: &str, p: &str| {
+            let t = infer(&[p], body);
+            t.get(p).is_some_and(|s| {
+                s.contains(&ProcArgTrait::VarRead) || s.contains(&ProcArgTrait::VarWrite)
+            })
+        };
+        for (body, p) in [
+            ("upvar 1 $varname data", "varname"),
+            ("upvar 0 $token state", "token"),
+            ("upvar #0 $token state", "token"),
+            ("upvar $v local", "v"),
+            ("variable $name", "name"),
+            ("array set $a {x 1}", "a"),
+            ("array get $a", "a"),
+            ("array names $a", "a"),
+            ("unset $v", "v"),
+            ("dict set $d k 1", "d"),
+            ("incr $counter", "counter"),
+            ("append $resultVar x", "resultVar"),
+            ("lappend $pages_var p", "pages_var"),
+            ("set ${tok}(state) connected", "tok"),
+            ("set $gas(idx) 1", "gas"),
+            ("namespace upvar ns $v local", "v"),
+            ("foreach k [array names $a] { puts $k }", "a"),
+            ("return [set ${token}($field)]", "token"),
+        ] {
+            assert!(
+                has_var(body, p),
+                "expected a by-reference var trait for `{p}` in `{body}`; got {:?}",
+                infer(&[p], body).get(p),
             );
         }
     }

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -296,7 +296,15 @@ fn scan_commands_bounded<'p>(
             continue;
         }
         let cmd_args: Vec<String> = seg.texts[1..].to_vec();
-        scan_command(&seg.texts[0], &cmd_args, ctx, traits, upvar_aliases);
+        // Per-arg "braced literal" flags: a single `Str` word (`{…}`) suppresses
+        // substitution, so a `$k` inside it is literal text, not a param ref.
+        let braced: Vec<bool> = (1..seg.texts.len())
+            .map(|i| {
+                seg.argv.get(i).is_some_and(|t| t.kind == TokenType::Str)
+                    && seg.single_token_word.get(i).copied().unwrap_or(false)
+            })
+            .collect();
+        scan_command(&seg.texts[0], &cmd_args, &braced, ctx, traits, upvar_aliases);
         if depth >= MAX_DEPTH {
             continue;
         }
@@ -460,20 +468,13 @@ fn resolve_arg_roles(
 fn scan_command<'p>(
     cmd_name: &str,
     cmd_args: &[String],
+    braced: &[bool],
     ctx: &ScanCtx<'p, '_>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
     upvar_aliases: &mut HashMap<String, &'p str>,
 ) {
     let param_set = ctx.param_set;
-    apply_arg_role_traits(
-        cmd_name,
-        cmd_args,
-        param_set,
-        traits,
-        upvar_aliases,
-        ctx.registry,
-        ctx.stub_overlay,
-    );
+    apply_arg_role_traits(cmd_name, cmd_args, braced, ctx, traits, upvar_aliases);
     apply_eval_traits(cmd_name, cmd_args, param_set, traits);
 
     // Per-command structural handlers.
@@ -530,16 +531,23 @@ fn scan_command<'p>(
 /// ``ArgRole::Body`` / ``Expr`` / ``VarWrite`` / ``VarRead`` to
 /// the matching parameter trait set when an arg is a simple
 /// ``$param`` reference (or aliases an upvar'd one).
+///
+/// `braced[i]` is `true` when argument `i` was a braced (`{…}`) literal word,
+/// in which case **no substitution occurs**: `set {arr($k)} 1` names the literal
+/// variable `arr($k)`, so the `$k` inside must not be read as a substitution
+/// (issue #814 review).  The braced guard applies only to the variable-name
+/// roles; a braced `Body` / `Expr` word still substitutes internally when Tcl
+/// evaluates it, and the deep pass recurses into it.
 fn apply_arg_role_traits<'p>(
     cmd_name: &str,
     cmd_args: &[String],
-    param_set: &HashSet<&'p str>,
+    braced: &[bool],
+    ctx: &ScanCtx<'p, '_>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
     upvar_aliases: &HashMap<String, &'p str>,
-    registry: &CommandRegistry,
-    stub_overlay: Option<&StubOverlay>,
 ) {
-    let arg_roles = resolve_arg_roles(cmd_name, cmd_args, registry, stub_overlay);
+    let param_set = ctx.param_set;
+    let arg_roles = resolve_arg_roles(cmd_name, cmd_args, ctx.registry, ctx.stub_overlay);
     for (idx, arg) in cmd_args.iter().enumerate() {
         let Ok(idx_u8) = u8::try_from(idx) else {
             continue;
@@ -568,8 +576,11 @@ fn apply_arg_role_traits<'p>(
             // `$p($k)`) — names a CALLEE-LOCAL variable (`set $p 1`,
             // `set ${v}($k)`, `incr $p`), NOT a caller-frame alias.  Record the
             // callee-local refinement (never `VarWrite`; only an `upvar`-aliased
-            // write-back is a genuine caller write).
-            Some(ArgRole::VarWrite | ArgRole::VarRead) => {
+            // write-back is a genuine caller write).  A braced word is a literal
+            // name — no substitution — so no param flows into it.
+            Some(ArgRole::VarWrite | ArgRole::VarRead)
+                if !braced.get(idx).copied().unwrap_or(false) =>
+            {
                 for var_name in var_substitutions(arg) {
                     if let Some(p) = lookup_param(var_name, param_set, upvar_aliases)
                         && let Some(set) = traits.get_mut(p)
@@ -1119,6 +1130,21 @@ mod tests {
             traits.get("x").is_none_or(HashSet::is_empty),
             "plain value read must record no trait, got {:?}",
             traits.get("x"),
+        );
+    }
+
+    #[test]
+    fn braced_var_name_has_no_substitution() {
+        // `set {arr($k)} 1` — the braces make `arr($k)` a *literal* variable
+        // name, so `$k` is not a substitution and must not mark `k` (issue #814
+        // review: the segmenter drops the braces, so the guard is by token kind).
+        assert!(infer(&["k"], "set {arr($k)} 1").get("k").is_none());
+        assert!(infer(&["p"], "set {$p} 1").get("p").is_none());
+        // The unbraced form *does* substitute, so it still marks the component.
+        assert_trait(
+            &infer(&["k"], "set arr($k) 1"),
+            "k",
+            ProcArgTrait::DynamicNameLocal,
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -304,7 +304,19 @@ fn scan_commands_bounded<'p>(
                     && seg.single_token_word.get(i).copied().unwrap_or(false)
             })
             .collect();
-        scan_command(&seg.texts[0], &cmd_args, &braced, ctx, traits, upvar_aliases);
+        // The head names a command by *substitution* only when it lexes as a
+        // `Var` word (`$cmd` / `${cmd}`); a braced `{$cmd}` or bareword head is
+        // a literal command name, not a param reference.
+        let head_is_var = seg.argv.first().is_some_and(|t| t.kind == TokenType::Var);
+        scan_command(
+            &seg.texts[0],
+            &cmd_args,
+            &braced,
+            head_is_var,
+            ctx,
+            traits,
+            upvar_aliases,
+        );
         if depth >= MAX_DEPTH {
             continue;
         }
@@ -448,6 +460,7 @@ fn resolve_arg_roles(
         ArgRole::Expr,
         ArgRole::VarWrite,
         ArgRole::VarRead,
+        ArgRole::CommandPrefix,
     ] {
         for idx in registry.arg_indices_for_role(command, &arg_strs, role) {
             if let Ok(idx_u8) = u8::try_from(idx) {
@@ -469,11 +482,22 @@ fn scan_command<'p>(
     cmd_name: &str,
     cmd_args: &[String],
     braced: &[bool],
+    head_is_var: bool,
     ctx: &ScanCtx<'p, '_>,
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
     upvar_aliases: &mut HashMap<String, &'p str>,
 ) {
     let param_set = ctx.param_set;
+    // A `$param` command *head* (`$cmd arg1 arg2`) means the param's value names
+    // a command.  Only a genuine `$`-substitution head counts — a braced
+    // `{$cmd}` is a literal command name.
+    if head_is_var
+        && let Some(vn) = extract_var_name(cmd_name)
+        && let Some(p) = param_set.get(vn).copied()
+        && let Some(set) = traits.get_mut(p)
+    {
+        set.insert(ProcArgTrait::Command);
+    }
     apply_arg_role_traits(cmd_name, cmd_args, braced, ctx, traits, upvar_aliases);
     apply_eval_traits(cmd_name, cmd_args, param_set, traits);
 
@@ -586,6 +610,19 @@ fn apply_arg_role_traits<'p>(
                         && let Some(set) = traits.get_mut(p)
                     {
                         mark_dynamic_name_local(set);
+                    }
+                }
+            }
+            // A registry `CommandPrefix` role names a command (`rename $old new`,
+            // `interp alias {} $a {} …`).  A `$param` (or component of a
+            // dynamic name) flowing there means the param's value is a command
+            // name.  Braced words are literal — no substitution.
+            Some(ArgRole::CommandPrefix) if !braced.get(idx).copied().unwrap_or(false) => {
+                for var_name in var_substitutions(arg) {
+                    if let Some(p) = lookup_param(var_name, param_set, upvar_aliases)
+                        && let Some(set) = traits.get_mut(p)
+                    {
+                        set.insert(ProcArgTrait::Command);
                     }
                 }
             }
@@ -1174,6 +1211,35 @@ mod tests {
         assert_eq!(var_substitutions("literal"), Vec::<&str>::new());
         assert_eq!(var_substitutions("\\$escaped"), Vec::<&str>::new());
         assert_eq!(var_substitutions("$1backref"), Vec::<&str>::new());
+    }
+
+    #[test]
+    fn param_used_as_command_head_is_command() {
+        // `$cmd arg1 arg2` — the param's value is the command word, so it names
+        // a command.  Works at the top level and inside a `[...]` substitution.
+        assert_trait(&infer(&["cmd"], "$cmd a b"), "cmd", ProcArgTrait::Command);
+        assert_trait(
+            &infer(&["cmd"], "return [$cmd x]"),
+            "cmd",
+            ProcArgTrait::Command,
+        );
+        // A braced `{$cmd}` head is a *literal* command name — no substitution.
+        assert!(infer(&["cmd"], "{$cmd} arg").get("cmd").is_none());
+        // A param merely read as a value is not a command.
+        assert!(infer(&["x"], "puts $x").get("x").is_none());
+    }
+
+    #[test]
+    fn stub_command_prefix_role_is_command() {
+        // A stub-declared `command_prefix` argument names a command, so a
+        // `$param` there is inferred `Command`.
+        let overlay = make_overlay(vec![stub_sig(
+            "on_event",
+            &[("event", ArgRole::Value), ("handler", ArgRole::CommandPrefix)],
+        )]);
+        let registry = CommandRegistry::build_default();
+        let traits = infer_param_traits(&["h"], "on_event click $h", &registry, Some(&overlay));
+        assert_trait(&traits, "h", ProcArgTrait::Command);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -164,6 +164,12 @@ pub enum ProcArgTrait {
     /// `DynamicNameLocal` without also being a genuine `VarWrite`.
     /// See PR #498 / #499 (deep-review finding 10 / 6).
     DynamicNameLocal,
+    /// The parameter's **value** is used as a **command name** — either the
+    /// command word of an invocation (``$cmd arg1 arg2``) or a registry
+    /// ``CommandPrefix`` argument (``rename $old new``, ``interp alias {} $a
+    /// {} …``).  Passing a literal at the call site therefore names a command,
+    /// which a consumer can resolve (call graph) or highlight as a command.
+    Command,
 }
 
 impl ProcArgTrait {
@@ -178,6 +184,7 @@ impl ProcArgTrait {
             ProcArgTrait::Expr => "expr",
             ProcArgTrait::LoopList => "loop_list",
             ProcArgTrait::DynamicNameLocal => "dynamic_name_local",
+            ProcArgTrait::Command => "command",
         }
     }
 }

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -165,10 +165,12 @@ pub enum ProcArgTrait {
     /// See PR #498 / #499 (deep-review finding 10 / 6).
     DynamicNameLocal,
     /// The parameter's **value** is used as a **command name** — either the
-    /// command word of an invocation (``$cmd arg1 arg2``) or a registry
-    /// ``CommandPrefix`` argument (``rename $old new``, ``interp alias {} $a
-    /// {} …``).  Passing a literal at the call site therefore names a command,
-    /// which a consumer can resolve (call graph) or highlight as a command.
+    /// command word of an invocation (``$cmd arg1 arg2``) or a registry / stub
+    /// ``CommandPrefix`` callback argument (a command prefix such as
+    /// ``tcltest::customMatch``'s matcher, ``selection handle``'s handler, or a
+    /// stub ``:command_prefix`` argument).  Passing a literal at the call site
+    /// therefore names a command, which a consumer can resolve (call graph) or
+    /// highlight as a command.
     Command,
 }
 

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -412,15 +412,16 @@ fn proc_var_write_indices(proc: &ProcDef) -> Vec<u32> {
     proc_indices_with_trait(proc, |traits| traits.contains(&ProcArgTrait::VarWrite))
 }
 
-/// The 0-based argument indices of a proc's parameters that the analyser
-/// inferred to *alias a caller variable read by the proc*
-/// ([`ProcArgTrait::VarRead`]) via `upvar`.  A parameter that is only a
-/// [`ProcArgTrait::DynamicNameLocal`] (its value names a *callee-local*
-/// variable — `set $p …`, always co-emitted with `VarRead`) is excluded, since
-/// a literal name there does not reference the caller's variable.
+/// The 0-based argument indices of a proc's parameters whose value the analyser
+/// inferred to name a variable that is *read* — either a caller-frame
+/// [`ProcArgTrait::VarRead`] `upvar` alias, or a
+/// [`ProcArgTrait::DynamicNameLocal`] whose value names a callee-local variable
+/// read (`set $p`, `set ${v}($k)`).  Both mean the literal at the call site is
+/// a variable name, so both elevate to a read reference — the highlighter does
+/// not need to distinguish caller-frame from callee-local.
 fn proc_var_read_indices(proc: &ProcDef) -> Vec<u32> {
     proc_indices_with_trait(proc, |traits| {
-        traits.contains(&ProcArgTrait::VarRead) && !traits.contains(&ProcArgTrait::DynamicNameLocal)
+        traits.contains(&ProcArgTrait::VarRead) || traits.contains(&ProcArgTrait::DynamicNameLocal)
     })
 }
 
@@ -5713,6 +5714,44 @@ mod tests {
     }
 
     #[test]
+    fn user_proc_dynamic_name_read_args_highlight() {
+        // A proc that reads a dynamic variable name built from its parameters
+        // inside a command substitution — `return [set ${v}($k)]` — infers a
+        // read role for both `v` and `k`, so the literal call-site args
+        // (`b aa foo`) highlight as plain `Variable` references.  Exercises the
+        // full path: cmd-substitution recursion + compound-name inference in
+        // the analyser, through to the token retag.
+        use tcl_compiler::analyser::Analyser;
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        let registry = reg();
+        let src = "array set aa {foo 1}\n\
+                   proc b {v k} {\n\
+                       return [set ${v}($k)]\n\
+                   }\n\
+                   b aa foo\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let analysis = Analyser::new().analyse(src, "tcl9.0");
+        let toks = decode_semantic(&full_with_cu_and_analysis(
+            src,
+            "tcl9.0",
+            &registry,
+            Some(&cu),
+            Some(&analysis),
+        ));
+        // On the call line (`b aa foo`, line 4) both `aa` (col 2) and `foo`
+        // (col 5) highlight as plain `Variable` references (no declaration).
+        let refs: Vec<_> = toks
+            .iter()
+            .filter(|&&(line, _, _, k, m)| line == 4 && k == TokenKind::Variable as u32 && m == 0)
+            .collect();
+        assert!(
+            refs.iter().any(|&&(_, col, _, _, _)| col == 2)
+                && refs.iter().any(|&&(_, col, _, _, _)| col == 5),
+            "expected `aa` and `foo` as variable references on the call line; got {toks:?}"
+        );
+    }
+
+    #[test]
     fn method_body_recurses_in_class_definition_script() {
         // `oo::class create C { method m {} { set z 3 } }` — the method body
         // must be tokenised (C Tcl evaluates it as a script), so `set` reads
@@ -7316,3 +7355,4 @@ mod tests {
         );
     }
 }
+

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -76,7 +76,8 @@
 //! iRules object-reference highlighting (the code-relevant half
 //! of the BIG-IP taxonomy) is handled.
 
-use rustc_hash::FxHashMap;
+use rustc_hash::{FxHashMap, FxHashSet};
+use tcl_compiler::analyser::types::{ProcArgTrait, ProcDef};
 use tcl_compiler::analyser::{AnalysisResult, ClassHierarchy};
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
@@ -295,6 +296,135 @@ fn is_operator_command(name: &str) -> bool {
     )
 }
 
+/// Extra "this argument names a written variable" positions for commands the
+/// static [`CommandRegistry`] does not model — user procs whose parameters the
+/// analyser inferred to alias a caller variable (`upvar $param` + write), and
+/// `# tcl-lsp: stub … :var` declarations.  Keyed by command / proc name; each
+/// value is the 0-based argument indices (head excluded) that name a written
+/// variable.  Lets the `VarWrite` retag highlight `myset arr(key) …` the same
+/// way it highlights `set arr(key) …` (issue #813 follow-up).
+///
+/// Built from an [`AnalysisResult`] (single file) or merged across a project's
+/// files.  Empty (and cost-free) on the pure-segmentation path, where only the
+/// static registry roles apply.  Stub roles are source-derived and unioned in
+/// at token-collection time, so they apply on every path without threading.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct VarNameArgRoles {
+    by_name: FxHashMap<String, Vec<u32>>,
+}
+
+impl VarNameArgRoles {
+    /// Infer the variable-name argument positions of every proc in `analysis`.
+    #[must_use]
+    pub fn from_analysis(analysis: &AnalysisResult) -> Self {
+        Self::from_procs(analysis.all_procs.values())
+    }
+
+    /// Infer from an iterator of proc definitions — a single file's, or a whole
+    /// project's files chained together.  A proc name that resolves to
+    /// *different* index sets across the iterator is dropped as ambiguous, so
+    /// the result is independent of iteration order — matching the highlight-
+    /// only, sound-by-abstention posture of the cross-file class index.
+    #[must_use]
+    pub fn from_procs<'a>(procs: impl IntoIterator<Item = &'a ProcDef>) -> Self {
+        let mut by_name: FxHashMap<String, Vec<u32>> = FxHashMap::default();
+        let mut ambiguous: FxHashSet<String> = FxHashSet::default();
+        for proc in procs {
+            let indices = proc_var_write_indices(proc);
+            if indices.is_empty() {
+                continue;
+            }
+            for key in proc_name_keys(proc) {
+                if ambiguous.contains(&key) {
+                    continue;
+                }
+                match by_name.get(&key) {
+                    Some(existing) if *existing != indices => {
+                        by_name.remove(&key);
+                        ambiguous.insert(key);
+                    }
+                    Some(_) => {}
+                    None => {
+                        by_name.insert(key, indices.clone());
+                    }
+                }
+            }
+        }
+        Self { by_name }
+    }
+
+    /// `true` when no command carries an inferred variable-name argument.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_name.is_empty()
+    }
+
+    /// Copy every entry into `out` without overwriting a name already present
+    /// (registry / stub roles that landed first win).
+    fn extend_into(&self, out: &mut FxHashMap<String, Vec<u32>>) {
+        for (name, indices) in &self.by_name {
+            out.entry(name.clone()).or_insert_with(|| indices.clone());
+        }
+    }
+}
+
+/// The 0-based argument indices of a proc's parameters that the analyser
+/// inferred to *alias a caller variable* ([`ProcArgTrait::VarWrite`]) — so a
+/// literal name passed there names the caller's variable.
+/// [`ProcArgTrait::DynamicNameLocal`] (the param's *value* names a callee-local
+/// variable) is excluded: a literal at such a position is not the caller's
+/// variable.
+fn proc_var_write_indices(proc: &ProcDef) -> Vec<u32> {
+    proc.params
+        .iter()
+        .enumerate()
+        .filter(|(_, p)| {
+            proc.param_traits
+                .get(&p.name)
+                .is_some_and(|traits| traits.contains(&ProcArgTrait::VarWrite))
+        })
+        .filter_map(|(i, _)| u32::try_from(i).ok())
+        .collect()
+}
+
+/// Every name a call site might use for `proc`: the bare name, the qualified
+/// name, and the qualified name without its leading `::`.
+fn proc_name_keys(proc: &ProcDef) -> Vec<String> {
+    let mut keys = vec![proc.name.clone()];
+    let stripped = proc.qualified_name.trim_start_matches("::");
+    if stripped != proc.name {
+        keys.push(stripped.to_owned());
+    }
+    if proc.qualified_name != proc.name && proc.qualified_name != stripped {
+        keys.push(proc.qualified_name.clone());
+    }
+    keys
+}
+
+/// Add `# tcl-lsp: stub … :var` variable-name argument positions from the
+/// document `source` to `out`.  Source-derived, so it applies on every token
+/// path (local and workspace) without threading.  Cheap-gated: the line scan
+/// runs only when the source mentions `stub`.
+fn add_stub_var_write_roles(source: &str, out: &mut FxHashMap<String, Vec<u32>>) {
+    if !source.contains("stub") {
+        return;
+    }
+    let (stub_cmds, _exprs) = tcl_compiler::analyser::utils::scan_source_for_stubs(source);
+    let overlay = tcl_compiler::analyser::types::build_stub_overlay(&stub_cmds);
+    for (name, sig) in overlay.iter() {
+        let indices: Vec<u32> = sig
+            .args
+            .iter()
+            .enumerate()
+            .filter(|(_, a)| a.role == tcl_registry::ArgRole::VarWrite)
+            .filter_map(|(i, _)| u32::try_from(i).ok())
+            .collect();
+        if !indices.is_empty() {
+            out.entry(name.to_owned()).or_insert(indices);
+        }
+    }
+}
+
 /// Compute semantic tokens for the entire document.
 #[must_use]
 pub fn full(source: &str, dialect: &str, registry: &CommandRegistry) -> SemanticTokens {
@@ -333,12 +463,14 @@ pub fn full_with_cu_and_analysis(
     cu: Option<&CompilationUnit>,
     analysis: Option<&AnalysisResult>,
 ) -> SemanticTokens {
-    full_with_cu_and_classes(
+    let proc_roles = analysis.map(VarNameArgRoles::from_analysis);
+    full_with_cu_and_classes_and_roles(
         source,
         dialect,
         registry,
         cu,
         analysis.map(AnalysisResult::class_hierarchy),
+        proc_roles.as_ref(),
     )
 }
 
@@ -354,7 +486,25 @@ pub fn full_with_cu_and_classes(
     cu: Option<&CompilationUnit>,
     classes: Option<&ClassHierarchy>,
 ) -> SemanticTokens {
-    let entries = collect_entries(source, dialect, registry, cu, classes);
+    full_with_cu_and_classes_and_roles(source, dialect, registry, cu, classes, None)
+}
+
+/// [`full_with_cu_and_classes`] with the workspace-merged inferred variable-name
+/// argument roles ([`VarNameArgRoles`]), so a `myproc arr(key) …` call whose
+/// `myproc` parameter aliases a caller variable highlights its array-element
+/// target like `set arr(key) …` (issue #813 follow-up).  The project path
+/// passes a cross-file index; `None` restricts the retag to the static registry
+/// roles (plus source-derived stub roles).
+#[must_use]
+pub fn full_with_cu_and_classes_and_roles(
+    source: &str,
+    dialect: &str,
+    registry: &CommandRegistry,
+    cu: Option<&CompilationUnit>,
+    classes: Option<&ClassHierarchy>,
+    proc_roles: Option<&VarNameArgRoles>,
+) -> SemanticTokens {
+    let entries = collect_entries(source, dialect, registry, cu, classes, proc_roles);
     encode_entries(&entries)
 }
 
@@ -397,13 +547,15 @@ pub fn range_with_cu_and_analysis(
     cu: Option<&CompilationUnit>,
     analysis: Option<&AnalysisResult>,
 ) -> SemanticTokens {
-    range_with_cu_and_classes(
+    let proc_roles = analysis.map(VarNameArgRoles::from_analysis);
+    range_with_cu_and_classes_and_roles(
         source,
         dialect,
         range,
         registry,
         cu,
         analysis.map(AnalysisResult::class_hierarchy),
+        proc_roles.as_ref(),
     )
 }
 
@@ -418,7 +570,22 @@ pub fn range_with_cu_and_classes(
     cu: Option<&CompilationUnit>,
     classes: Option<&ClassHierarchy>,
 ) -> SemanticTokens {
-    let mut entries = collect_entries(source, dialect, registry, cu, classes);
+    range_with_cu_and_classes_and_roles(source, dialect, range, registry, cu, classes, None)
+}
+
+/// [`range_with_cu_and_classes`] with the workspace-merged inferred
+/// variable-name argument roles (see [`full_with_cu_and_classes_and_roles`]).
+#[must_use]
+pub fn range_with_cu_and_classes_and_roles(
+    source: &str,
+    dialect: &str,
+    range: crate::definition::LspRange,
+    registry: &CommandRegistry,
+    cu: Option<&CompilationUnit>,
+    classes: Option<&ClassHierarchy>,
+    proc_roles: Option<&VarNameArgRoles>,
+) -> SemanticTokens {
+    let mut entries = collect_entries(source, dialect, registry, cu, classes, proc_roles);
     entries.retain(|(line, col, _, _, _)| {
         // Half-open interval per LSP `Range` semantics: start is
         // inclusive, end is exclusive.
@@ -658,6 +825,7 @@ fn special_arg_kinds(
     object_collections: &ObjectClassMap,
     classes: Option<&ClassHierarchy>,
     dialect: DialectSet,
+    extra_var_write: &FxHashMap<String, Vec<u32>>,
 ) -> FxHashMap<u32, ArgOverride> {
     let mut overrides = FxHashMap::default();
 
@@ -702,7 +870,7 @@ fn special_arg_kinds(
     insert_ref_var_overrides(seg, &mut overrides);
     insert_loop_var_overrides(seg, registry, head, arg_texts, &mut overrides);
     insert_param_list_overrides(seg, registry, head, arg_texts, &mut overrides);
-    insert_var_decl_overrides(seg, registry, head, &mut overrides);
+    insert_var_decl_overrides(seg, registry, head, extra_var_write, &mut overrides);
 
     overrides
 }
@@ -1962,23 +2130,30 @@ fn insert_apply_lambda_override(
 /// / `incr` / `append` / `lappend` / `lassign` / `global` / `variable` / … ,
 /// which the query [`CommandRegistry::arg_indices_for_role`] resolves
 /// (including subcommand and dynamic-resolver commands such as `dict set`).
-/// The registry has already decided this argument is a variable-name spot; the
-/// only remaining question is token geometry.  A word that lexes as a single
-/// unquoted [`TokenType::Esc`] token — a scalar (`x`), a literal array element
+/// The argument is *known* to be a variable-name spot — not from the word's
+/// text, but from a declared role: the static registry `ArgRole::VarWrite`, a
+/// `# tcl-lsp: stub … :var` declaration, or a user-proc parameter the analyser
+/// inferred to alias a caller variable (`extra_var_write`).  The only remaining
+/// question is token geometry.  A word that lexes as a single unquoted
+/// [`TokenType::Esc`] token — a scalar (`x`), a literal array element
 /// (`arr(key)`), or a namespaced name (`::ns::arr(key)`) — is retagged as one
 /// whole-word `Variable` token, matching how the `$arr(key)` read highlights
-/// (issue #813).  A word with an inner substitution (`arr($i)`, `$dynamic`)
-/// is multi-token (`single_token_word` is `false`), so it is left to the
-/// default classifier and its inner `$var` sub-tokens survive.
+/// (issue #813).  A word with an inner substitution (`arr($i)`, `$dynamic`) is
+/// multi-token (`single_token_word` is `false`), so it is left to the default
+/// classifier and its inner `$var` sub-tokens survive.
 fn insert_var_decl_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
     head: &str,
+    extra_var_write: &FxHashMap<String, Vec<u32>>,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
     let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
-    for i in registry.arg_indices_for_role(head, &arg_texts, tcl_registry::ArgRole::VarWrite) {
-        // `i` is 0-based after the command name → word at index `i + 1`.
+    // `i` is 0-based after the command name → word at index `i + 1`.  A word is
+    // retagged only when it is a single unquoted `Esc` token — the geometry that
+    // makes it safe to paint whole (scalars, literal array elements, namespaced
+    // names), while a substitution-bearing word stays multi-token.
+    let mut retag = |i: usize| {
         if let Some(tok) = seg.argv.get(i + 1)
             && seg.single_token_word.get(i + 1) == Some(&true)
             && matches!(tok.kind, TokenType::Esc)
@@ -1987,6 +2162,14 @@ fn insert_var_decl_overrides(
             overrides
                 .entry(tok.span.start())
                 .or_insert(ArgOverride::VarDecl);
+        }
+    };
+    for i in registry.arg_indices_for_role(head, &arg_texts, tcl_registry::ArgRole::VarWrite) {
+        retag(i);
+    }
+    if let Some(indices) = extra_var_write.get(head) {
+        for &i in indices {
+            retag(i as usize);
         }
     }
 }
@@ -2913,6 +3096,13 @@ struct ScriptCtx<'a> {
     /// in a method body resolve against the enclosing class's MRO — the single
     /// most common `TclOO` dispatch form.  `None` outside any class body.
     enclosing_class: Option<&'a str>,
+    /// Extra variable-name (`ArgRole::VarWrite`) argument positions the static
+    /// registry doesn't model, keyed by command / proc name: source-derived
+    /// `# tcl-lsp: stub … :var` roles unioned with the analyser's inferred
+    /// user-proc parameter roles.  The `VarWrite` retag reads this alongside
+    /// the registry so a `myproc arr(key) …` call highlights its array-element
+    /// target (issue #813 follow-up).  Empty on the pure-segmentation path.
+    extra_var_write: &'a FxHashMap<String, Vec<u32>>,
 }
 
 fn collect_switch_case_list(
@@ -3343,6 +3533,7 @@ fn collect_script(
             ctx.object_collections,
             ctx.classes,
             DialectSet::parse(ctx.dialect).unwrap_or(DialectSet::ALL_TCL),
+            ctx.extra_var_write,
         );
         // `my method …` inside a class body resolves against the enclosing
         // class's MRO (the most common `TclOO` dispatch form).
@@ -4041,9 +4232,21 @@ fn collect_entries(
     registry: &CommandRegistry,
     cu: Option<&CompilationUnit>,
     classes: Option<&ClassHierarchy>,
+    proc_roles: Option<&VarNameArgRoles>,
 ) -> Vec<Entry> {
     let mut entries: Vec<Entry> = Vec::new();
     let line_index = LineIndex::new(source);
+
+    // Extra variable-name (`ArgRole::VarWrite`) argument positions the static
+    // registry doesn't model: source-derived `# tcl-lsp: stub … :var` roles
+    // (every path) unioned with the analyser's inferred user-proc roles
+    // (`proc_roles`, when the caller supplied an analysis / project index).
+    // Empty (and lookup-free) when neither source contributes.
+    let mut extra_var_write: FxHashMap<String, Vec<u32>> = FxHashMap::default();
+    add_stub_var_write_roles(source, &mut extra_var_write);
+    if let Some(roles) = proc_roles {
+        roles.extend_into(&mut extra_var_write);
+    }
 
     // Regex-source spans: the def-site literal words (`set my_re ".*"`) whose
     // variable flows into a `regexp`/`regsub` pattern, keyed by word start so
@@ -4106,6 +4309,7 @@ fn collect_entries(
         object_collections: &object_collections,
         classes,
         enclosing_class: None,
+        extra_var_write: &extra_var_write,
     };
     collect_script(ctx, source, 0, &mut entries, 0);
 
@@ -5201,6 +5405,100 @@ mod tests {
                 "expected a variable token; got {toks:?} for {src:?}"
             );
         }
+    }
+
+    #[test]
+    fn stub_var_arg_highlights_array_element() {
+        // A `# tcl-lsp: stub` with a `:var` argument marks that position a
+        // variable-name spot, so a literal array element passed there
+        // highlights like `set arr(key) …` — even on the registry-only path,
+        // since stub roles are derived from the document source (issue #813
+        // follow-up).
+        let src = "# tcl-lsp: stubs-begin\n\
+                   # tcl-lsp: stub mywrite {varName:var value}\n\
+                   # tcl-lsp: stubs-end\n\
+                   mywrite arr(key) 1\n";
+        let toks = decode_full(src, "tcl", &reg());
+        let decl = toks.iter().any(|(line, _, _, k, m)| {
+            *line == 3 && *k == TokenKind::Variable as u32 && *m == MOD_DECLARATION
+        });
+        assert!(
+            decl,
+            "expected the stubbed :var array element to highlight; got {toks:?}"
+        );
+    }
+
+    #[test]
+    fn user_proc_var_name_arg_highlights_array_element() {
+        // A user proc whose parameter the analyser infers to alias a caller
+        // variable (`upvar $varName` + write) makes a literal array element at
+        // that call-site position a variable-name spot — so `myset arr(key) 1`
+        // highlights `arr(key)` like `set arr(key) 1` (issue #813 follow-up).
+        // The plumbing is analysis-driven, so it needs the enriched path.
+        use tcl_compiler::analyser::Analyser;
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        let registry = reg();
+        let src = "proc myset {varName value} {\n\
+                     upvar 1 $varName v\n\
+                     set v $value\n\
+                   }\n\
+                   myset arr(key) 1\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let analysis = Analyser::new().analyse(src, "tcl9.0");
+        let decl_on_call = |toks: &[(u32, u32, u32, u32, u32)]| {
+            toks.iter().any(|&(line, _, _, k, m)| {
+                line == 4 && k == TokenKind::Variable as u32 && m == MOD_DECLARATION
+            })
+        };
+        // Without analysis, `myset` is an unknown command → `arr(key)` at the
+        // call stays a plain string.
+        let plain = decode_semantic(&full_with_cu(src, "tcl9.0", &registry, Some(&cu)));
+        assert!(
+            !decl_on_call(&plain),
+            "no proc-role highlight without analysis; got {plain:?}"
+        );
+        // With analysis, the inferred `varName` role retags `arr(key)`.
+        let toks = decode_semantic(&full_with_cu_and_analysis(
+            src,
+            "tcl9.0",
+            &registry,
+            Some(&cu),
+            Some(&analysis),
+        ));
+        assert!(
+            decl_on_call(&toks),
+            "expected arr(key) at the myset call to highlight; got {toks:?}"
+        );
+    }
+
+    #[test]
+    fn user_proc_var_name_computed_subscript_survives() {
+        // `myset arr($i) 1` — even with the proc role, a computed subscript is
+        // multi-token, so it is not painted whole and the inner `$i` survives.
+        use tcl_compiler::analyser::Analyser;
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        let registry = reg();
+        let src = "proc myset {varName value} {\n\
+                     upvar 1 $varName v\n\
+                     set v $value\n\
+                   }\n\
+                   myset arr($i) 1\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let analysis = Analyser::new().analyse(src, "tcl9.0");
+        let toks = decode_semantic(&full_with_cu_and_analysis(
+            src,
+            "tcl9.0",
+            &registry,
+            Some(&cu),
+            Some(&analysis),
+        ));
+        let inner_i = toks
+            .iter()
+            .any(|&(line, _, _, k, _)| line == 4 && k == TokenKind::Variable as u32);
+        assert!(
+            inner_i,
+            "expected the inner $i on the call line to survive; got {toks:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -5493,16 +5493,32 @@ mod tests {
 
     #[test]
     fn unset_array_element_is_variable() {
-        // `unset arr(key)` — the literal element is a variable, and a computed
-        // subscript (`unset arr($i)`) still leaves the inner `$i` sub-token.
-        for src in ["unset arr(key)\n", "unset arr($i)\n"] {
-            let toks = decode_full(src, "tcl", &reg());
-            assert!(
-                toks.iter()
-                    .any(|(_, _, _, k, _)| *k == TokenKind::Variable as u32),
-                "expected a variable token; got {toks:?} for {src:?}"
-            );
-        }
+        // `unset arr(key)` — `unset` is a VarWrite command, so the literal
+        // element retags as one whole-word `Variable` declaration spanning
+        // `arr(key)` (col 6, len 8).
+        let toks = decode_full("unset arr(key)\n", "tcl", &reg());
+        let whole = toks.iter().any(|(_, col, len, k, m)| {
+            *col == 6 && *len == 8 && *k == TokenKind::Variable as u32 && *m == MOD_DECLARATION
+        });
+        assert!(
+            whole,
+            "expected `arr(key)` as one variable declaration; got {toks:?}"
+        );
+        // `unset arr($i)` — the computed subscript stays multi-token: the inner
+        // `$i` (col 10) survives as its own variable, and the whole word is not
+        // painted (no declaration at the word start, col 6).
+        let toks = decode_full("unset arr($i)\n", "tcl", &reg());
+        let inner_i = toks
+            .iter()
+            .any(|(_, col, _, k, _)| *col == 10 && *k == TokenKind::Variable as u32);
+        assert!(inner_i, "expected the inner `$i` variable; got {toks:?}");
+        let painted_whole = toks.iter().any(|(_, col, _, k, m)| {
+            *col == 6 && *k == TokenKind::Variable as u32 && *m == MOD_DECLARATION
+        });
+        assert!(
+            !painted_whole,
+            "computed subscript must not retag the whole word; got {toks:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1962,11 +1962,14 @@ fn insert_apply_lambda_override(
 /// / `incr` / `append` / `lappend` / `lassign` / `global` / `variable` / … ,
 /// which the query [`CommandRegistry::arg_indices_for_role`] resolves
 /// (including subcommand and dynamic-resolver commands such as `dict set`).
-/// A plain bareword name, or a literal array element (`arr(key)`), is retagged
-/// as one whole-word `Variable` token — matching how `$arr(key)` reads
-/// highlight (issue #813).  A `$`-computed subscript (`arr($i)`), a
-/// `$`-computed name, or a quoted word is left to the default classifier so its
-/// inner `$var` sub-tokens survive.
+/// The registry has already decided this argument is a variable-name spot; the
+/// only remaining question is token geometry.  A word that lexes as a single
+/// unquoted [`TokenType::Esc`] token — a scalar (`x`), a literal array element
+/// (`arr(key)`), or a namespaced name (`::ns::arr(key)`) — is retagged as one
+/// whole-word `Variable` token, matching how the `$arr(key)` read highlights
+/// (issue #813).  A word with an inner substitution (`arr($i)`, `$dynamic`)
+/// is multi-token (`single_token_word` is `false`), so it is left to the
+/// default classifier and its inner `$var` sub-tokens survive.
 fn insert_var_decl_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
@@ -1975,11 +1978,11 @@ fn insert_var_decl_overrides(
 ) {
     let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
     for i in registry.arg_indices_for_role(head, &arg_texts, tcl_registry::ArgRole::VarWrite) {
-        // `i` is 0-based after the command name → token at `seg.argv[i + 1]`.
-        if let (Some(text), Some(tok)) = (seg.texts.get(i + 1), seg.argv.get(i + 1))
+        // `i` is 0-based after the command name → word at index `i + 1`.
+        if let Some(tok) = seg.argv.get(i + 1)
+            && seg.single_token_word.get(i + 1) == Some(&true)
             && matches!(tok.kind, TokenType::Esc)
             && !tok.in_quote
-            && (is_plain_var_name(text) || is_literal_array_element(text))
         {
             overrides
                 .entry(tok.span.start())
@@ -1995,27 +1998,6 @@ fn is_plain_var_name(text: &str) -> bool {
     // braced words, and the stray `}` / `)` the degenerate empty-brace (`{}`)
     // span clamp can leave in sub-tokenised list content.
     !text.is_empty() && !text.contains(['(', ')', '$', '[', ']', '{', '}', '"', ' '])
-}
-
-/// `true` when `text` is an array-element reference `name(index)` whose name
-/// and index are both literal — no substitution (`$` / `[`) or nested
-/// delimiter inside.  Such a word lexes as a single [`TokenType::Esc`] token,
-/// so it is safe to retag as one whole-word `Variable` token.  A `$`-computed
-/// subscript (`arr($i)`) is excluded: it lexes into several tokens (`arr(`,
-/// `$i`, `)`) whose inner `$i` must survive as its own variable sub-token.
-fn is_literal_array_element(text: &str) -> bool {
-    let Some(open) = text.find('(') else {
-        return false;
-    };
-    // A non-empty scalar name, followed by a `(...)` subscript that closes the
-    // word.  `open == 0` (`(x)`) has no name; a missing trailing `)` is not a
-    // complete element.
-    if open == 0 || !text.ends_with(')') {
-        return false;
-    }
-    let name = &text[..open];
-    let index = &text[open + 1..text.len() - 1];
-    is_plain_var_name(name) && !index.contains(['$', '[', ']', '(', ')', '{', '}', '"', ' '])
 }
 
 /// `switch … { pat body … }` — the braced case list (the final word, when
@@ -5219,23 +5201,6 @@ mod tests {
                 "expected a variable token; got {toks:?} for {src:?}"
             );
         }
-    }
-
-    #[test]
-    fn is_literal_array_element_classifies() {
-        assert!(is_literal_array_element("arr(key)"));
-        assert!(is_literal_array_element("arr(1)"));
-        assert!(is_literal_array_element("arr(a,b)"));
-        assert!(is_literal_array_element("::ns::arr(key)"));
-        assert!(is_literal_array_element("arr()"));
-        // Computed subscript / name — must survive as sub-tokens.
-        assert!(!is_literal_array_element("arr($i)"));
-        assert!(!is_literal_array_element("arr([x])"));
-        // Not an element.
-        assert!(!is_literal_array_element("scalar"));
-        assert!(!is_literal_array_element("(x)"));
-        assert!(!is_literal_array_element("arr(key"));
-        assert!(!is_literal_array_element("$arr(key)"));
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1962,9 +1962,11 @@ fn insert_apply_lambda_override(
 /// / `incr` / `append` / `lappend` / `lassign` / `global` / `variable` / … ,
 /// which the query [`CommandRegistry::arg_indices_for_role`] resolves
 /// (including subcommand and dynamic-resolver commands such as `dict set`).
-/// Only a plain bareword name is retagged — an array element (`arr(x)`), a
-/// `$`-computed name, or a quoted word is left to the default classifier so
-/// its inner `$var` sub-tokens survive.
+/// A plain bareword name, or a literal array element (`arr(key)`), is retagged
+/// as one whole-word `Variable` token — matching how `$arr(key)` reads
+/// highlight (issue #813).  A `$`-computed subscript (`arr($i)`), a
+/// `$`-computed name, or a quoted word is left to the default classifier so its
+/// inner `$var` sub-tokens survive.
 fn insert_var_decl_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
@@ -1977,7 +1979,7 @@ fn insert_var_decl_overrides(
         if let (Some(text), Some(tok)) = (seg.texts.get(i + 1), seg.argv.get(i + 1))
             && matches!(tok.kind, TokenType::Esc)
             && !tok.in_quote
-            && is_plain_var_name(text)
+            && (is_plain_var_name(text) || is_literal_array_element(text))
         {
             overrides
                 .entry(tok.span.start())
@@ -1993,6 +1995,27 @@ fn is_plain_var_name(text: &str) -> bool {
     // braced words, and the stray `}` / `)` the degenerate empty-brace (`{}`)
     // span clamp can leave in sub-tokenised list content.
     !text.is_empty() && !text.contains(['(', ')', '$', '[', ']', '{', '}', '"', ' '])
+}
+
+/// `true` when `text` is an array-element reference `name(index)` whose name
+/// and index are both literal — no substitution (`$` / `[`) or nested
+/// delimiter inside.  Such a word lexes as a single [`TokenType::Esc`] token,
+/// so it is safe to retag as one whole-word `Variable` token.  A `$`-computed
+/// subscript (`arr($i)`) is excluded: it lexes into several tokens (`arr(`,
+/// `$i`, `)`) whose inner `$i` must survive as its own variable sub-token.
+fn is_literal_array_element(text: &str) -> bool {
+    let Some(open) = text.find('(') else {
+        return false;
+    };
+    // A non-empty scalar name, followed by a `(...)` subscript that closes the
+    // word.  `open == 0` (`(x)`) has no name; a missing trailing `)` is not a
+    // complete element.
+    if open == 0 || !text.ends_with(')') {
+        return false;
+    }
+    let name = &text[..open];
+    let index = &text[open + 1..text.len() - 1];
+    is_plain_var_name(name) && !index.contains(['$', '[', ']', '(', ')', '{', '}', '"', ' '])
 }
 
 /// `switch … { pat body … }` — the braced case list (the final word, when
@@ -5139,6 +5162,80 @@ mod tests {
                 .any(|(_, _, _, k, _)| *k == TokenKind::Variable as u32),
             "expected inner $i variable token; got {toks:?}"
         );
+    }
+
+    #[test]
+    fn literal_array_element_write_is_variable_declaration() {
+        // A literal array-element write target highlights as one whole-word
+        // `Variable` declaration, matching the `$arr(key)` read (issue #813).
+        for src in [
+            "set arr(key) 1\n",
+            "incr count(hits)\n",
+            "append log(err) x\n",
+        ] {
+            let toks = decode_full(src, "tcl", &reg());
+            let decl = toks.iter().any(|(_, _, _, k, m)| {
+                *k == TokenKind::Variable as u32 && *m == MOD_DECLARATION
+            });
+            assert!(
+                decl,
+                "expected an array-element variable declaration; got {toks:?} for {src:?}"
+            );
+        }
+        // The target `arr(key)` is a single token spanning the whole element.
+        let toks = decode_full("set arr(key) 1\n", "tcl", &reg());
+        let whole = toks.iter().any(|(_, col, len, k, m)| {
+            *col == 4 && *len == 8 && *k == TokenKind::Variable as u32 && *m == MOD_DECLARATION
+        });
+        assert!(
+            whole,
+            "expected a single length-8 variable token over `arr(key)`; got {toks:?}"
+        );
+        assert_non_overlapping("set arr(key) 1\n", &reg());
+    }
+
+    #[test]
+    fn namespaced_array_element_write_is_variable_declaration() {
+        // A namespaced array (`::ns::arr(key)`) is still a plain element.
+        let toks = decode_full("set ::ns::arr(key) 1\n", "tcl", &reg());
+        let decl = toks.iter().any(|(_, _, _, k, m)| {
+            *k == TokenKind::Variable as u32 && *m == MOD_DECLARATION
+        });
+        assert!(
+            decl,
+            "expected a variable declaration for the namespaced array element; got {toks:?}"
+        );
+    }
+
+    #[test]
+    fn unset_array_element_is_variable() {
+        // `unset arr(key)` — the literal element is a variable, and a computed
+        // subscript (`unset arr($i)`) still leaves the inner `$i` sub-token.
+        for src in ["unset arr(key)\n", "unset arr($i)\n"] {
+            let toks = decode_full(src, "tcl", &reg());
+            assert!(
+                toks.iter()
+                    .any(|(_, _, _, k, _)| *k == TokenKind::Variable as u32),
+                "expected a variable token; got {toks:?} for {src:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn is_literal_array_element_classifies() {
+        assert!(is_literal_array_element("arr(key)"));
+        assert!(is_literal_array_element("arr(1)"));
+        assert!(is_literal_array_element("arr(a,b)"));
+        assert!(is_literal_array_element("::ns::arr(key)"));
+        assert!(is_literal_array_element("arr()"));
+        // Computed subscript / name — must survive as sub-tokens.
+        assert!(!is_literal_array_element("arr($i)"));
+        assert!(!is_literal_array_element("arr([x])"));
+        // Not an element.
+        assert!(!is_literal_array_element("scalar"));
+        assert!(!is_literal_array_element("(x)"));
+        assert!(!is_literal_array_element("arr(key"));
+        assert!(!is_literal_array_element("$arr(key)"));
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -314,6 +314,10 @@ fn is_operator_command(name: &str) -> bool {
 pub struct VarNameArgRoles {
     write: FxHashMap<String, Vec<u32>>,
     read: FxHashMap<String, Vec<u32>>,
+    /// Argument positions whose value the analyser inferred to name a *command*
+    /// ([`ProcArgTrait::Command`] — a `$param` command head or a `CommandPrefix`
+    /// argument), so a literal call-site arg highlights as a command.
+    command: FxHashMap<String, Vec<u32>>,
 }
 
 impl VarNameArgRoles {
@@ -336,36 +340,43 @@ impl VarNameArgRoles {
     pub fn from_procs<'a>(procs: impl IntoIterator<Item = &'a ProcDef>) -> Self {
         let mut write = RoleMapBuilder::default();
         let mut read = RoleMapBuilder::default();
+        let mut command = RoleMapBuilder::default();
         for proc in procs {
             let keys = proc_name_keys(proc);
             write.insert(&keys, &proc_var_write_indices(proc));
             read.insert(&keys, &proc_var_read_indices(proc));
+            command.insert(&keys, &proc_command_indices(proc));
         }
         Self {
             write: write.finish(),
             read: read.finish(),
+            command: command.finish(),
         }
     }
 
-    /// `true` when no command carries an inferred variable-name argument.
+    /// `true` when no command carries an inferred by-reference argument.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.write.is_empty() && self.read.is_empty()
+        self.write.is_empty() && self.read.is_empty() && self.command.is_empty()
     }
 
-    /// Copy the write / read entries into `out_write` / `out_read` without
+    /// Copy the write / read / command entries into the `out_*` maps without
     /// overwriting a name already present (source-derived stub roles that
     /// landed first win).
     fn extend_into(
         &self,
         out_write: &mut FxHashMap<String, Vec<u32>>,
         out_read: &mut FxHashMap<String, Vec<u32>>,
+        out_command: &mut FxHashMap<String, Vec<u32>>,
     ) {
         for (name, indices) in &self.write {
             out_write.entry(name.clone()).or_insert_with(|| indices.clone());
         }
         for (name, indices) in &self.read {
             out_read.entry(name.clone()).or_insert_with(|| indices.clone());
+        }
+        for (name, indices) in &self.command {
+            out_command.entry(name.clone()).or_insert_with(|| indices.clone());
         }
     }
 }
@@ -429,6 +440,14 @@ fn proc_var_read_indices(proc: &ProcDef) -> Vec<u32> {
     })
 }
 
+/// The 0-based argument indices of a proc's parameters whose value the analyser
+/// inferred to name a *command* ([`ProcArgTrait::Command`] — a `$param` command
+/// head or a `CommandPrefix` argument), so a literal at the call site highlights
+/// as a command.
+fn proc_command_indices(proc: &ProcDef) -> Vec<u32> {
+    proc_indices_with_trait(proc, |traits| traits.contains(&ProcArgTrait::Command))
+}
+
 /// Shared body of [`proc_var_write_indices`] / [`proc_var_read_indices`]: the
 /// positions of the parameters whose inferred trait set satisfies `keep`.
 fn proc_indices_with_trait(
@@ -457,8 +476,9 @@ fn proc_name_keys(proc: &ProcDef) -> Vec<String> {
     keys
 }
 
-/// Add `# tcl-lsp: stub … :var` (written) and `:var_read` (read) variable-name
-/// argument positions from the document `source` to `out_write` / `out_read`.
+/// Add `# tcl-lsp: stub` by-reference argument positions from the document
+/// `source` to the `out_*` maps: `:var` (written) → `out_write`, `:var_read`
+/// (read) → `out_read`, and `:command_prefix` (a command) → `out_command`.
 /// Source-derived, so it applies on every token path (local and workspace)
 /// without threading.  Cheap-gated: the line scan runs only when the source
 /// mentions `stub`.
@@ -466,6 +486,7 @@ fn add_stub_var_roles(
     source: &str,
     out_write: &mut FxHashMap<String, Vec<u32>>,
     out_read: &mut FxHashMap<String, Vec<u32>>,
+    out_command: &mut FxHashMap<String, Vec<u32>>,
 ) {
     if !source.contains("stub") {
         return;
@@ -481,13 +502,15 @@ fn add_stub_var_roles(
             .collect::<Vec<u32>>()
     };
     for (name, sig) in overlay.iter() {
-        let write = indices_for(sig, tcl_registry::ArgRole::VarWrite);
-        if !write.is_empty() {
-            out_write.entry(name.to_owned()).or_insert(write);
-        }
-        let read = indices_for(sig, tcl_registry::ArgRole::VarRead);
-        if !read.is_empty() {
-            out_read.entry(name.to_owned()).or_insert(read);
+        for (role, out) in [
+            (tcl_registry::ArgRole::VarWrite, &mut *out_write),
+            (tcl_registry::ArgRole::VarRead, &mut *out_read),
+            (tcl_registry::ArgRole::CommandPrefix, &mut *out_command),
+        ] {
+            let indices = indices_for(sig, role);
+            if !indices.is_empty() {
+                out.entry(name.to_owned()).or_insert(indices);
+            }
         }
     }
 }
@@ -723,6 +746,10 @@ enum ArgOverride {
     /// with **no** `declaration` modifier: it references an existing variable
     /// rather than declaring one.
     VarRef,
+    /// A command name passed as an argument (`ArgRole::CommandPrefix`, or a proc
+    /// parameter the analyser inferred to be a `Command`) → `Function`: the
+    /// literal names a command the callee invokes.
+    CommandRef,
     /// The `{params body ?ns?}` lambda literal argument of `apply` — its
     /// second list element (the body) is re-segmented as a script.
     ApplyLambda,
@@ -899,6 +926,7 @@ fn special_arg_kinds(
     dialect: DialectSet,
     extra_var_write: &FxHashMap<String, Vec<u32>>,
     extra_var_read: &FxHashMap<String, Vec<u32>>,
+    extra_command: &FxHashMap<String, Vec<u32>>,
 ) -> FxHashMap<u32, ArgOverride> {
     let mut overrides = FxHashMap::default();
 
@@ -951,6 +979,7 @@ fn special_arg_kinds(
         extra_var_read,
         &mut overrides,
     );
+    insert_command_role_overrides(seg, registry, head, extra_command, &mut overrides);
 
     overrides
 }
@@ -2265,6 +2294,41 @@ fn insert_var_role_overrides(
     }
 }
 
+/// A command name passed as an argument — the registry `CommandPrefix` role
+/// (`tk selection … -command`, a stub `:command_prefix`), or a proc parameter
+/// the analyser inferred to be a `Command` (`extra_command`: `$cmd` used as a
+/// head, or flowing into a command-name position).  Retag the literal at the
+/// call site as a `Function`, gated by the same single-token `Esc` geometry as
+/// the variable retag, so `dispatch mycmd …` paints `mycmd` as a command.
+fn insert_command_role_overrides(
+    seg: &tcl_compiler::segmenter::SegmentedCommand,
+    registry: &CommandRegistry,
+    head: &str,
+    extra_command: &FxHashMap<String, Vec<u32>>,
+    overrides: &mut FxHashMap<u32, ArgOverride>,
+) {
+    let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
+    let mut retag = |i: usize| {
+        if let Some(tok) = seg.argv.get(i + 1)
+            && seg.single_token_word.get(i + 1) == Some(&true)
+            && matches!(tok.kind, TokenType::Esc)
+            && !tok.in_quote
+        {
+            overrides
+                .entry(tok.span.start())
+                .or_insert(ArgOverride::CommandRef);
+        }
+    };
+    for i in registry.arg_indices_for_role(head, &arg_texts, tcl_registry::ArgRole::CommandPrefix) {
+        retag(i);
+    }
+    if let Some(indices) = extra_command.get(head) {
+        for &i in indices {
+            retag(i as usize);
+        }
+    }
+}
+
 /// `true` when `text` is a plain (non-array, non-substituted) variable name
 /// — the safe case to retag as a whole-word `Variable` declaration token.
 fn is_plain_var_name(text: &str) -> bool {
@@ -3200,6 +3264,13 @@ struct ScriptCtx<'a> {
     /// retag as a plain `Variable` (no `declaration` modifier), since a read
     /// references an existing variable.  Empty on the pure-segmentation path.
     extra_var_read: &'a FxHashMap<String, Vec<u32>>,
+    /// Extra command-name (`ArgRole::CommandPrefix` / inferred
+    /// `ProcArgTrait::Command`) argument positions, keyed by command / proc
+    /// name: stub `:command_prefix` roles unioned with the analyser's inferred
+    /// user-proc `Command` params.  These retag as a `Function` so a literal
+    /// command name passed to a dispatcher highlights as a command.  Empty on
+    /// the pure-segmentation path.
+    extra_command: &'a FxHashMap<String, Vec<u32>>,
 }
 
 fn collect_switch_case_list(
@@ -3632,6 +3703,7 @@ fn collect_script(
             DialectSet::parse(ctx.dialect).unwrap_or(DialectSet::ALL_TCL),
             ctx.extra_var_write,
             ctx.extra_var_read,
+            ctx.extra_command,
         );
         // `my method …` inside a class body resolves against the enclosing
         // class's MRO (the most common `TclOO` dispatch form).
@@ -3734,6 +3806,7 @@ fn verbatim_token_kind(ov: ArgOverride) -> Option<(TokenKind, u32)> {
         ArgOverride::Decorator => Some((TokenKind::Decorator, 0)),
         ArgOverride::VarDecl => Some((TokenKind::Variable, MOD_DECLARATION)),
         ArgOverride::VarRef => Some((TokenKind::Variable, 0)),
+        ArgOverride::CommandRef => Some((TokenKind::Function, 0)),
         ArgOverride::SubcommandKeyword => Some((TokenKind::Keyword, MOD_DEFAULT_LIBRARY)),
         ArgOverride::ProcNameDef => Some((TokenKind::Function, MOD_DEFINITION)),
         _ => None,
@@ -3830,6 +3903,7 @@ fn emit_arg_token(
             | ArgOverride::Decorator
             | ArgOverride::VarDecl
             | ArgOverride::VarRef
+            | ArgOverride::CommandRef
             | ArgOverride::SubcommandKeyword
             | ArgOverride::ProcNameDef,
         ) => {}
@@ -4345,9 +4419,15 @@ fn collect_entries(
     // Empty (and lookup-free) when neither source contributes.
     let mut extra_var_write: FxHashMap<String, Vec<u32>> = FxHashMap::default();
     let mut extra_var_read: FxHashMap<String, Vec<u32>> = FxHashMap::default();
-    add_stub_var_roles(source, &mut extra_var_write, &mut extra_var_read);
+    let mut extra_command: FxHashMap<String, Vec<u32>> = FxHashMap::default();
+    add_stub_var_roles(
+        source,
+        &mut extra_var_write,
+        &mut extra_var_read,
+        &mut extra_command,
+    );
     if let Some(roles) = proc_roles {
-        roles.extend_into(&mut extra_var_write, &mut extra_var_read);
+        roles.extend_into(&mut extra_var_write, &mut extra_var_read, &mut extra_command);
     }
 
     // Regex-source spans: the def-site literal words (`set my_re ".*"`) whose
@@ -4413,6 +4493,7 @@ fn collect_entries(
         enclosing_class: None,
         extra_var_write: &extra_var_write,
         extra_var_read: &extra_var_read,
+        extra_command: &extra_command,
     };
     collect_script(ctx, source, 0, &mut entries, 0);
 
@@ -5752,6 +5833,41 @@ mod tests {
             refs.iter().any(|&&(_, col, _, _, _)| col == 2)
                 && refs.iter().any(|&&(_, col, _, _, _)| col == 5),
             "expected `aa` and `foo` as variable references on the call line; got {toks:?}"
+        );
+    }
+
+    #[test]
+    fn user_proc_command_arg_highlights_as_function() {
+        // A dispatcher proc invokes its parameter as a command (`$cmd …`), so
+        // the analyser infers `cmd` is a `Command`.  The literal command name at
+        // the call site (`dispatch greet …`) then highlights as a `Function`.
+        use tcl_compiler::analyser::Analyser;
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        let registry = reg();
+        let src = "proc dispatch {cmd arg} {\n\
+                     $cmd $arg\n\
+                   }\n\
+                   dispatch greet hello\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let analysis = Analyser::new().analyse(src, "tcl9.0");
+        // Without analysis, `greet` is an unknown command's plain string arg.
+        let plain = decode_semantic(&full_with_cu(src, "tcl9.0", &registry, Some(&cu)));
+        let greet_fn = |toks: &[(u32, u32, u32, u32, u32)]| {
+            toks.iter()
+                .any(|&(line, col, _, k, _)| line == 3 && col == 9 && k == TokenKind::Function as u32)
+        };
+        assert!(!greet_fn(&plain), "no command role without analysis; got {plain:?}");
+        // With analysis, `greet` (col 9 on the call line) highlights as a command.
+        let toks = decode_semantic(&full_with_cu_and_analysis(
+            src,
+            "tcl9.0",
+            &registry,
+            Some(&cu),
+            Some(&analysis),
+        ));
+        assert!(
+            greet_fn(&toks),
+            "expected `greet` at the dispatch call to highlight as a Function; got {toks:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -298,11 +298,13 @@ fn is_operator_command(name: &str) -> bool {
 
 /// Extra "this argument names a written variable" positions for commands the
 /// static [`CommandRegistry`] does not model — user procs whose parameters the
-/// analyser inferred to alias a caller variable (`upvar $param` + write), and
-/// `# tcl-lsp: stub … :var` declarations.  Keyed by command / proc name; each
-/// value is the 0-based argument indices (head excluded) that name a written
-/// variable.  Lets the `VarWrite` retag highlight `myset arr(key) …` the same
-/// way it highlights `set arr(key) …` (issue #813 follow-up).
+/// analyser inferred to alias a caller variable (`upvar $param`), and
+/// `# tcl-lsp: stub … :var` / `:var_read` declarations.  Keyed by command /
+/// proc name; each value is the 0-based argument indices (head excluded) that
+/// name a variable — split by direction, since a *written* target highlights as
+/// a `Variable` declaration and a *read* reference as a plain `Variable`.  Lets
+/// the retag highlight `myset arr(key) …` / `myexists arr(key)` the same way it
+/// highlights `set arr(key) …` / `info exists arr(key)` (issue #813 follow-up).
 ///
 /// Built from an [`AnalysisResult`] (single file) or merged across a project's
 /// files.  Empty (and cost-free) on the pure-segmentation path, where only the
@@ -310,7 +312,8 @@ fn is_operator_command(name: &str) -> bool {
 /// at token-collection time, so they apply on every path without threading.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct VarNameArgRoles {
-    by_name: FxHashMap<String, Vec<u32>>,
+    write: FxHashMap<String, Vec<u32>>,
+    read: FxHashMap<String, Vec<u32>>,
 }
 
 impl VarNameArgRoles {
@@ -327,62 +330,110 @@ impl VarNameArgRoles {
     /// only, sound-by-abstention posture of the cross-file class index.
     #[must_use]
     pub fn from_procs<'a>(procs: impl IntoIterator<Item = &'a ProcDef>) -> Self {
-        let mut by_name: FxHashMap<String, Vec<u32>> = FxHashMap::default();
-        let mut ambiguous: FxHashSet<String> = FxHashSet::default();
+        let mut write = RoleMapBuilder::default();
+        let mut read = RoleMapBuilder::default();
         for proc in procs {
-            let indices = proc_var_write_indices(proc);
-            if indices.is_empty() {
-                continue;
-            }
-            for key in proc_name_keys(proc) {
-                if ambiguous.contains(&key) {
-                    continue;
-                }
-                match by_name.get(&key) {
-                    Some(existing) if *existing != indices => {
-                        by_name.remove(&key);
-                        ambiguous.insert(key);
-                    }
-                    Some(_) => {}
-                    None => {
-                        by_name.insert(key, indices.clone());
-                    }
-                }
-            }
+            let keys = proc_name_keys(proc);
+            write.insert(&keys, &proc_var_write_indices(proc));
+            read.insert(&keys, &proc_var_read_indices(proc));
         }
-        Self { by_name }
+        Self {
+            write: write.finish(),
+            read: read.finish(),
+        }
     }
 
     /// `true` when no command carries an inferred variable-name argument.
     #[must_use]
     pub fn is_empty(&self) -> bool {
-        self.by_name.is_empty()
+        self.write.is_empty() && self.read.is_empty()
     }
 
-    /// Copy every entry into `out` without overwriting a name already present
-    /// (registry / stub roles that landed first win).
-    fn extend_into(&self, out: &mut FxHashMap<String, Vec<u32>>) {
-        for (name, indices) in &self.by_name {
-            out.entry(name.clone()).or_insert_with(|| indices.clone());
+    /// Copy the write / read entries into `out_write` / `out_read` without
+    /// overwriting a name already present (source-derived stub roles that
+    /// landed first win).
+    fn extend_into(
+        &self,
+        out_write: &mut FxHashMap<String, Vec<u32>>,
+        out_read: &mut FxHashMap<String, Vec<u32>>,
+    ) {
+        for (name, indices) in &self.write {
+            out_write.entry(name.clone()).or_insert_with(|| indices.clone());
+        }
+        for (name, indices) in &self.read {
+            out_read.entry(name.clone()).or_insert_with(|| indices.clone());
         }
     }
 }
 
+/// Accumulates one direction's `name → arg indices` map while dropping any name
+/// that resolves to conflicting index sets (abstain-on-conflict), so the merged
+/// result is independent of insertion order.
+#[derive(Default)]
+struct RoleMapBuilder {
+    map: FxHashMap<String, Vec<u32>>,
+    ambiguous: FxHashSet<String>,
+}
+
+impl RoleMapBuilder {
+    fn insert(&mut self, keys: &[String], indices: &[u32]) {
+        if indices.is_empty() {
+            return;
+        }
+        for key in keys {
+            if self.ambiguous.contains(key) {
+                continue;
+            }
+            match self.map.get(key) {
+                Some(existing) if existing.as_slice() != indices => {
+                    self.map.remove(key);
+                    self.ambiguous.insert(key.clone());
+                }
+                Some(_) => {}
+                None => {
+                    self.map.insert(key.clone(), indices.to_vec());
+                }
+            }
+        }
+    }
+
+    fn finish(self) -> FxHashMap<String, Vec<u32>> {
+        self.map
+    }
+}
+
 /// The 0-based argument indices of a proc's parameters that the analyser
-/// inferred to *alias a caller variable* ([`ProcArgTrait::VarWrite`]) — so a
-/// literal name passed there names the caller's variable.
-/// [`ProcArgTrait::DynamicNameLocal`] (the param's *value* names a callee-local
-/// variable) is excluded: a literal at such a position is not the caller's
-/// variable.
+/// inferred to *alias a caller variable written by the proc*
+/// ([`ProcArgTrait::VarWrite`]) — so a literal name passed there names the
+/// caller's variable.  [`ProcArgTrait::DynamicNameLocal`] (the param's *value*
+/// names a callee-local variable) is excluded: a literal there is not the
+/// caller's variable.
 fn proc_var_write_indices(proc: &ProcDef) -> Vec<u32> {
+    proc_indices_with_trait(proc, |traits| traits.contains(&ProcArgTrait::VarWrite))
+}
+
+/// The 0-based argument indices of a proc's parameters that the analyser
+/// inferred to *alias a caller variable read by the proc*
+/// ([`ProcArgTrait::VarRead`]) via `upvar`.  A parameter that is only a
+/// [`ProcArgTrait::DynamicNameLocal`] (its value names a *callee-local*
+/// variable — `set $p …`, always co-emitted with `VarRead`) is excluded, since
+/// a literal name there does not reference the caller's variable.
+fn proc_var_read_indices(proc: &ProcDef) -> Vec<u32> {
+    proc_indices_with_trait(proc, |traits| {
+        traits.contains(&ProcArgTrait::VarRead) && !traits.contains(&ProcArgTrait::DynamicNameLocal)
+    })
+}
+
+/// Shared body of [`proc_var_write_indices`] / [`proc_var_read_indices`]: the
+/// positions of the parameters whose inferred trait set satisfies `keep`.
+fn proc_indices_with_trait(
+    proc: &ProcDef,
+    keep: impl Fn(&std::collections::HashSet<ProcArgTrait>) -> bool,
+) -> Vec<u32> {
     proc.params
         .iter()
         .enumerate()
-        .filter(|(_, p)| {
-            proc.param_traits
-                .get(&p.name)
-                .is_some_and(|traits| traits.contains(&ProcArgTrait::VarWrite))
-        })
+        .filter(|(_, p)| proc.param_traits.get(&p.name).is_some_and(&keep))
         .filter_map(|(i, _)| u32::try_from(i).ok())
         .collect()
 }
@@ -401,26 +452,37 @@ fn proc_name_keys(proc: &ProcDef) -> Vec<String> {
     keys
 }
 
-/// Add `# tcl-lsp: stub … :var` variable-name argument positions from the
-/// document `source` to `out`.  Source-derived, so it applies on every token
-/// path (local and workspace) without threading.  Cheap-gated: the line scan
-/// runs only when the source mentions `stub`.
-fn add_stub_var_write_roles(source: &str, out: &mut FxHashMap<String, Vec<u32>>) {
+/// Add `# tcl-lsp: stub … :var` (written) and `:var_read` (read) variable-name
+/// argument positions from the document `source` to `out_write` / `out_read`.
+/// Source-derived, so it applies on every token path (local and workspace)
+/// without threading.  Cheap-gated: the line scan runs only when the source
+/// mentions `stub`.
+fn add_stub_var_roles(
+    source: &str,
+    out_write: &mut FxHashMap<String, Vec<u32>>,
+    out_read: &mut FxHashMap<String, Vec<u32>>,
+) {
     if !source.contains("stub") {
         return;
     }
     let (stub_cmds, _exprs) = tcl_compiler::analyser::utils::scan_source_for_stubs(source);
     let overlay = tcl_compiler::analyser::types::build_stub_overlay(&stub_cmds);
-    for (name, sig) in overlay.iter() {
-        let indices: Vec<u32> = sig
-            .args
+    let indices_for = |sig: &tcl_registry::stub_overlay::StubSig, role: tcl_registry::ArgRole| {
+        sig.args
             .iter()
             .enumerate()
-            .filter(|(_, a)| a.role == tcl_registry::ArgRole::VarWrite)
+            .filter(|(_, a)| a.role == role)
             .filter_map(|(i, _)| u32::try_from(i).ok())
-            .collect();
-        if !indices.is_empty() {
-            out.entry(name.to_owned()).or_insert(indices);
+            .collect::<Vec<u32>>()
+    };
+    for (name, sig) in overlay.iter() {
+        let write = indices_for(sig, tcl_registry::ArgRole::VarWrite);
+        if !write.is_empty() {
+            out_write.entry(name.to_owned()).or_insert(write);
+        }
+        let read = indices_for(sig, tcl_registry::ArgRole::VarRead);
+        if !read.is_empty() {
+            out_read.entry(name.to_owned()).or_insert(read);
         }
     }
 }
@@ -651,6 +713,11 @@ enum ArgOverride {
     /// A variable name a command declares / writes (`ArgRole::VarWrite`) →
     /// `Variable` + `declaration` modifier.
     VarDecl,
+    /// A variable name a command reads by reference (`ArgRole::VarRead` —
+    /// `info exists arr(key)`, `array names arr`, `dict with $d`) → `Variable`
+    /// with **no** `declaration` modifier: it references an existing variable
+    /// rather than declaring one.
+    VarRef,
     /// The `{params body ?ns?}` lambda literal argument of `apply` — its
     /// second list element (the body) is re-segmented as a script.
     ApplyLambda,
@@ -826,6 +893,7 @@ fn special_arg_kinds(
     classes: Option<&ClassHierarchy>,
     dialect: DialectSet,
     extra_var_write: &FxHashMap<String, Vec<u32>>,
+    extra_var_read: &FxHashMap<String, Vec<u32>>,
 ) -> FxHashMap<u32, ArgOverride> {
     let mut overrides = FxHashMap::default();
 
@@ -870,7 +938,14 @@ fn special_arg_kinds(
     insert_ref_var_overrides(seg, &mut overrides);
     insert_loop_var_overrides(seg, registry, head, arg_texts, &mut overrides);
     insert_param_list_overrides(seg, registry, head, arg_texts, &mut overrides);
-    insert_var_decl_overrides(seg, registry, head, extra_var_write, &mut overrides);
+    insert_var_role_overrides(
+        seg,
+        registry,
+        head,
+        extra_var_write,
+        extra_var_read,
+        &mut overrides,
+    );
 
     overrides
 }
@@ -2131,21 +2206,24 @@ fn insert_apply_lambda_override(
 /// which the query [`CommandRegistry::arg_indices_for_role`] resolves
 /// (including subcommand and dynamic-resolver commands such as `dict set`).
 /// The argument is *known* to be a variable-name spot — not from the word's
-/// text, but from a declared role: the static registry `ArgRole::VarWrite`, a
-/// `# tcl-lsp: stub … :var` declaration, or a user-proc parameter the analyser
-/// inferred to alias a caller variable (`extra_var_write`).  The only remaining
-/// question is token geometry.  A word that lexes as a single unquoted
-/// [`TokenType::Esc`] token — a scalar (`x`), a literal array element
-/// (`arr(key)`), or a namespaced name (`::ns::arr(key)`) — is retagged as one
-/// whole-word `Variable` token, matching how the `$arr(key)` read highlights
-/// (issue #813).  A word with an inner substitution (`arr($i)`, `$dynamic`) is
-/// multi-token (`single_token_word` is `false`), so it is left to the default
-/// classifier and its inner `$var` sub-tokens survive.
-fn insert_var_decl_overrides(
+/// text, but from a declared role: the static registry `ArgRole::VarWrite` /
+/// `ArgRole::VarRead`, a `# tcl-lsp: stub … :var` / `:var_read` declaration, or
+/// a user-proc parameter the analyser inferred to alias a caller variable
+/// (`extra_var_write` / `extra_var_read`).  A **written** target retags as a
+/// `Variable` declaration; a **read** reference as a plain `Variable` (it names
+/// an existing variable, not a new one).  The only remaining question is token
+/// geometry.  A word that lexes as a single unquoted [`TokenType::Esc`] token —
+/// a scalar (`x`), a literal array element (`arr(key)`), or a namespaced name
+/// (`::ns::arr(key)`) — is retagged as one whole-word token, matching how the
+/// `$arr(key)` read highlights (issue #813).  A word with an inner substitution
+/// (`arr($i)`, `$dynamic`) is multi-token (`single_token_word` is `false`), so
+/// it is left to the default classifier and its inner `$var` sub-tokens survive.
+fn insert_var_role_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
     head: &str,
     extra_var_write: &FxHashMap<String, Vec<u32>>,
+    extra_var_read: &FxHashMap<String, Vec<u32>>,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
     let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
@@ -2153,23 +2231,31 @@ fn insert_var_decl_overrides(
     // retagged only when it is a single unquoted `Esc` token — the geometry that
     // makes it safe to paint whole (scalars, literal array elements, namespaced
     // names), while a substitution-bearing word stays multi-token.
-    let mut retag = |i: usize| {
+    let mut retag = |i: usize, ov: ArgOverride| {
         if let Some(tok) = seg.argv.get(i + 1)
             && seg.single_token_word.get(i + 1) == Some(&true)
             && matches!(tok.kind, TokenType::Esc)
             && !tok.in_quote
         {
-            overrides
-                .entry(tok.span.start())
-                .or_insert(ArgOverride::VarDecl);
+            overrides.entry(tok.span.start()).or_insert(ov);
         }
     };
+    // Writes first: a declaration wins over a read reference at the same
+    // position (`dict with`'s arg 0 carries both roles).
     for i in registry.arg_indices_for_role(head, &arg_texts, tcl_registry::ArgRole::VarWrite) {
-        retag(i);
+        retag(i, ArgOverride::VarDecl);
     }
     if let Some(indices) = extra_var_write.get(head) {
         for &i in indices {
-            retag(i as usize);
+            retag(i as usize, ArgOverride::VarDecl);
+        }
+    }
+    for i in registry.arg_indices_for_role(head, &arg_texts, tcl_registry::ArgRole::VarRead) {
+        retag(i, ArgOverride::VarRef);
+    }
+    if let Some(indices) = extra_var_read.get(head) {
+        for &i in indices {
+            retag(i as usize, ArgOverride::VarRef);
         }
     }
 }
@@ -3103,6 +3189,12 @@ struct ScriptCtx<'a> {
     /// the registry so a `myproc arr(key) …` call highlights its array-element
     /// target (issue #813 follow-up).  Empty on the pure-segmentation path.
     extra_var_write: &'a FxHashMap<String, Vec<u32>>,
+    /// Extra variable-name (`ArgRole::VarRead`) argument positions the static
+    /// registry doesn't model — the read-side counterpart of `extra_var_write`
+    /// (stub `:var_read` roles and inferred user-proc `VarRead` params).  These
+    /// retag as a plain `Variable` (no `declaration` modifier), since a read
+    /// references an existing variable.  Empty on the pure-segmentation path.
+    extra_var_read: &'a FxHashMap<String, Vec<u32>>,
 }
 
 fn collect_switch_case_list(
@@ -3534,6 +3626,7 @@ fn collect_script(
             ctx.classes,
             DialectSet::parse(ctx.dialect).unwrap_or(DialectSet::ALL_TCL),
             ctx.extra_var_write,
+            ctx.extra_var_read,
         );
         // `my method …` inside a class body resolves against the enclosing
         // class's MRO (the most common `TclOO` dispatch form).
@@ -3635,6 +3728,7 @@ fn verbatim_token_kind(ov: ArgOverride) -> Option<(TokenKind, u32)> {
         ArgOverride::Kind(kind) => Some((kind, 0)),
         ArgOverride::Decorator => Some((TokenKind::Decorator, 0)),
         ArgOverride::VarDecl => Some((TokenKind::Variable, MOD_DECLARATION)),
+        ArgOverride::VarRef => Some((TokenKind::Variable, 0)),
         ArgOverride::SubcommandKeyword => Some((TokenKind::Keyword, MOD_DEFAULT_LIBRARY)),
         ArgOverride::ProcNameDef => Some((TokenKind::Function, MOD_DEFINITION)),
         _ => None,
@@ -3730,6 +3824,7 @@ fn emit_arg_token(
             ArgOverride::Kind(_)
             | ArgOverride::Decorator
             | ArgOverride::VarDecl
+            | ArgOverride::VarRef
             | ArgOverride::SubcommandKeyword
             | ArgOverride::ProcNameDef,
         ) => {}
@@ -4237,15 +4332,17 @@ fn collect_entries(
     let mut entries: Vec<Entry> = Vec::new();
     let line_index = LineIndex::new(source);
 
-    // Extra variable-name (`ArgRole::VarWrite`) argument positions the static
-    // registry doesn't model: source-derived `# tcl-lsp: stub … :var` roles
+    // Extra variable-name argument positions the static registry doesn't model,
+    // split by direction (written → `Variable` declaration, read → plain
+    // `Variable`): source-derived `# tcl-lsp: stub … :var` / `:var_read` roles
     // (every path) unioned with the analyser's inferred user-proc roles
     // (`proc_roles`, when the caller supplied an analysis / project index).
     // Empty (and lookup-free) when neither source contributes.
     let mut extra_var_write: FxHashMap<String, Vec<u32>> = FxHashMap::default();
-    add_stub_var_write_roles(source, &mut extra_var_write);
+    let mut extra_var_read: FxHashMap<String, Vec<u32>> = FxHashMap::default();
+    add_stub_var_roles(source, &mut extra_var_write, &mut extra_var_read);
     if let Some(roles) = proc_roles {
-        roles.extend_into(&mut extra_var_write);
+        roles.extend_into(&mut extra_var_write, &mut extra_var_read);
     }
 
     // Regex-source spans: the def-site literal words (`set my_re ".*"`) whose
@@ -4310,6 +4407,7 @@ fn collect_entries(
         classes,
         enclosing_class: None,
         extra_var_write: &extra_var_write,
+        extra_var_read: &extra_var_read,
     };
     collect_script(ctx, source, 0, &mut entries, 0);
 
@@ -5408,6 +5506,48 @@ mod tests {
     }
 
     #[test]
+    fn varread_role_highlights_variable_name() {
+        // A read-role variable-name argument (`info exists`, `array names`)
+        // highlights its name as a plain `Variable` — no `declaration`
+        // modifier, since a read references an existing variable (issue #813
+        // follow-up / read side).
+        for src in [
+            "info exists arr(key)\n",
+            "info exists scalar\n",
+            "array names arr\n",
+            "array get arr\n",
+        ] {
+            let toks = decode_full(src, "tcl", &reg());
+            let var_ref = toks.iter().any(|(_, _, _, k, m)| {
+                *k == TokenKind::Variable as u32 && *m == 0
+            });
+            assert!(
+                var_ref,
+                "expected a plain Variable reference for {src:?}; got {toks:?}"
+            );
+            // A read must not carry the declaration modifier.
+            let decl = toks.iter().any(|(_, _, _, k, m)| {
+                *k == TokenKind::Variable as u32 && *m == MOD_DECLARATION
+            });
+            assert!(!decl, "a read must not declare; got {toks:?} for {src:?}");
+        }
+    }
+
+    #[test]
+    fn varread_value_argument_is_not_a_variable() {
+        // `dict get $d k` — `$d` is a value (a dict), not a var-name spot, so
+        // the read-role retag must not fire on it; only the `$d` substitution
+        // itself is a variable, and `k` (the key) is a plain string.
+        let toks = decode_full("dict get $d k\n", "tcl", &reg());
+        // Exactly one variable: the `$d` substitution.
+        let vars = toks
+            .iter()
+            .filter(|(_, _, _, k, _)| *k == TokenKind::Variable as u32)
+            .count();
+        assert_eq!(vars, 1, "only `$d` is a variable; got {toks:?}");
+    }
+
+    #[test]
     fn stub_var_arg_highlights_array_element() {
         // A `# tcl-lsp: stub` with a `:var` argument marks that position a
         // variable-name spot, so a literal array element passed there
@@ -5426,6 +5566,29 @@ mod tests {
             decl,
             "expected the stubbed :var array element to highlight; got {toks:?}"
         );
+    }
+
+    #[test]
+    fn stub_var_read_arg_highlights_as_reference() {
+        // A `# tcl-lsp: stub … :var_read` argument marks a read-position
+        // variable name, so a literal array element there highlights as a plain
+        // `Variable` reference (no `declaration` modifier).
+        let src = "# tcl-lsp: stubs-begin\n\
+                   # tcl-lsp: stub myexists {varName:var_read}\n\
+                   # tcl-lsp: stubs-end\n\
+                   myexists arr(key)\n";
+        let toks = decode_full(src, "tcl", &reg());
+        let var_ref = toks.iter().any(|(line, _, _, k, m)| {
+            *line == 3 && *k == TokenKind::Variable as u32 && *m == 0
+        });
+        assert!(
+            var_ref,
+            "expected the stubbed :var_read array element as a reference; got {toks:?}"
+        );
+        let decl_on_call = toks.iter().any(|(line, _, _, k, m)| {
+            *line == 3 && *k == TokenKind::Variable as u32 && *m == MOD_DECLARATION
+        });
+        assert!(!decl_on_call, "a read must not declare; got {toks:?}");
     }
 
     #[test]
@@ -5498,6 +5661,38 @@ mod tests {
         assert!(
             inner_i,
             "expected the inner $i on the call line to survive; got {toks:?}"
+        );
+    }
+
+    #[test]
+    fn user_proc_var_read_arg_highlights_as_reference() {
+        // A proc that only *reads* its upvar'd parameter (`upvar $varName v`
+        // then reads `v`) infers a `VarRead` role, so a literal name at the
+        // call site highlights as a plain `Variable` reference — no
+        // `declaration` modifier.
+        use tcl_compiler::analyser::Analyser;
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        let registry = reg();
+        let src = "proc myexists {varName} {\n\
+                     upvar 1 $varName v\n\
+                     return [info exists v]\n\
+                   }\n\
+                   myexists arr(key)\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let analysis = Analyser::new().analyse(src, "tcl9.0");
+        let toks = decode_semantic(&full_with_cu_and_analysis(
+            src,
+            "tcl9.0",
+            &registry,
+            Some(&cu),
+            Some(&analysis),
+        ));
+        let ref_on_call = toks
+            .iter()
+            .any(|&(line, _, _, k, m)| line == 4 && k == TokenKind::Variable as u32 && m == 0);
+        assert!(
+            ref_on_call,
+            "expected arr(key) at the myexists call as a reference; got {toks:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -324,10 +324,14 @@ impl VarNameArgRoles {
     }
 
     /// Infer from an iterator of proc definitions — a single file's, or a whole
-    /// project's files chained together.  A proc name that resolves to
-    /// *different* index sets across the iterator is dropped as ambiguous, so
-    /// the result is independent of iteration order — matching the highlight-
-    /// only, sound-by-abstention posture of the cross-file class index.
+    /// project's files chained together.  A proc name that resolves to two
+    /// *different non-empty* index sets across the iterator is dropped as
+    /// ambiguous, so the result is independent of iteration order — matching the
+    /// highlight-only, sound-by-abstention posture of the cross-file class
+    /// index.  An empty index set (the proc has no by-reference argument in that
+    /// direction) never participates: it neither seeds nor conflicts an entry,
+    /// so a definition that contributes roles is not cancelled by one that
+    /// contributes none.
     #[must_use]
     pub fn from_procs<'a>(procs: impl IntoIterator<Item = &'a ProcDef>) -> Self {
         let mut write = RoleMapBuilder::default();

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -59,7 +59,7 @@ use tcl_compiler::analyser::{
 use tcl_compiler::signature_scan::types::ParamDef;
 use tcl_lsp_core::document_symbols::DocumentSymbol;
 use tcl_lsp_core::folding::FoldingRange;
-use tcl_lsp_core::semantic_tokens::SemanticTokens;
+use tcl_lsp_core::semantic_tokens::{SemanticTokens, VarNameArgRoles};
 use tcl_registry::CommandRegistry;
 use tcl_registry::dialects::DialectSet;
 
@@ -2104,6 +2104,32 @@ pub fn project_class_index(
     Arc::new(build_class_hierarchy(merged))
 }
 
+/// The project's workspace-merged inferred variable-name argument roles: every
+/// file's user-proc parameter roles — a parameter the analyser inferred to
+/// alias a caller variable (`upvar $param` + write) — unioned into one
+/// cross-file index, so a `myproc arr(key) …` call highlights its array-element
+/// target even when `myproc` is defined in another file (issue #813 follow-up).
+///
+/// A proc name defined with *conflicting* roles across files is dropped as
+/// ambiguous by [`VarNameArgRoles::from_procs`], so the merged index is
+/// order-independent — matching the abstention posture of
+/// [`project_class_index`].
+#[salsa::tracked]
+pub fn project_proc_var_index(
+    db: &dyn TclDb,
+    project: Project,
+    config: AnalyserConfig,
+) -> Arc<VarNameArgRoles> {
+    let analyses: Vec<Arc<AnalysisResult>> = project
+        .files(db)
+        .iter()
+        .map(|&file| file_analysis(db, file, config))
+        .collect();
+    Arc::new(VarNameArgRoles::from_procs(
+        analyses.iter().flat_map(|a| a.all_procs.values()),
+    ))
+}
+
 /// [`semantic_tokens`] resolved against the **workspace-merged** class index, so
 /// a `$obj method …` dispatch on a class defined in another project file
 /// resolves too.  The server calls this when a [`Project`] is available; the
@@ -2118,12 +2144,14 @@ pub fn semantic_tokens_project(
     let registry = db.registry(file.dialect(db));
     let cu = document_compilation_unit(db, file);
     let classes = project_class_index(db, project, config);
-    tcl_lsp_core::semantic_tokens::full_with_cu_and_classes(
+    let proc_roles = project_proc_var_index(db, project, config);
+    tcl_lsp_core::semantic_tokens::full_with_cu_and_classes_and_roles(
         file.text(db),
         file.dialect(db),
         &registry,
         Some(&cu),
         Some(&classes),
+        Some(&proc_roles),
     )
 }
 


### PR DESCRIPTION
## Summary

Fixes #813. What began as "an array element used as a write target (`set arr(key) 1`) isn't highlighted as a variable" is generalised into **role-general by-reference argument inference**: a literal passed to a command (builtin, stubbed, or user proc) that uses it *by reference* now highlights according to the role the callee gives it — a variable it writes/reads, or a command it invokes.

The retag is driven by declared **roles**, never by re-parsing a word's text; the only text question left is token **geometry** (can the word be painted whole, or does it contain an inner substitution that must survive).

## What it covers

**Variables — both directions, three role sources:**
- Writes (`set arr(key) 1`, `incr count(hits)`, `unset arr(key)`, `dict with`) → `Variable` + `declaration`; reads (`info exists arr(key)`, `array names arr`) → plain `Variable`.
- Static registry `ArgRole::VarWrite`/`VarRead`, `# tcl-lsp: stub … :var`/`:var_read`, and analyser-inferred user-proc params — from the single-file analysis locally and a workspace-merged `project_proc_var_index` salsa query for cross-file procs.
- Dynamic names built from params: `set ${v}($k)`, command-substitution descent (`return [set $v]`), compound array components, `namespace upvar ns $token arr` — verified against a corpus sweep of the tcllib / Tcl-library token-array idiom.

**Commands (`ProcArgTrait::Command` → `ArgOverride::CommandRef`):**
- A param used as a command head (`$cmd args`) or a `CommandPrefix` argument (registry or stub `:command_prefix`) elevates the call-site literal to a `Function`, so `dispatch greet …` paints `greet` as a command. (`rename $old` / `interp alias … $a` use the generic `Name` role — also var/proc/namespace names — so they are deliberately not blanket-marked.)

**Value-carried names/commands:**
- A param whose value flows through a local (`set n $v; set $n 1`, `set c $cmd; $c …`) still resolves back to the param — transitive, invalidated on reassignment, no false positives for pass-through.

## Approach

Whether an argument *is* a by-reference spot is answered by the declared role, not the word's text. A word that lexes as a single unquoted `Esc` token (`SegmentedCommand::single_token_word`) is painted whole (scalars, literal array elements `arr(key)`, namespaced names); a word with an inner substitution (`arr($i)`) stays multi-token and its inner `$var` survives. A braced word (`{arr($k)}`) is a literal — no substitution — and is guarded accordingly.

> An earlier iteration used a bespoke `is_literal_array_element()` string classifier; it was **replaced** by the registry-role + `single_token_word` geometry approach above, which is more general and needs no array-syntax parsing — so that classifier is not in the shipped diff.

## Key changes

- `rust/tcl-compiler/src/analyser/param_traits.rs` — role-general parameter inference: `upvar` / `namespace upvar` aliases, dynamic names (`var_substitutions`, `scan_commands_bounded` command-substitution descent), compound array names, command roles (head + `CommandPrefix`), value-copy tracking (`Aliases`). Braced words are excluded from substitution scanning.
- `rust/tcl-compiler/src/analyser/types.rs` — `ProcArgTrait::Command`.
- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `VarNameArgRoles` (write / read / command arg indices from inferred proc traits + stub roles), `insert_var_role_overrides` / `insert_command_role_overrides`, new `ArgOverride::VarRef` / `CommandRef`.
- `rust/tcl-lsp-db/src/lib.rs` — `project_proc_var_index` salsa query (workspace-merged inferred roles), wired into `semantic_tokens` / `semantic_tokens_project`.
- KCS note `docs/kcs/kcs-issue-array-element-not-highlighted-as-variable.md` + index link.

## Test coverage

Analyser inference — `rust/tcl-compiler/src/analyser/param_traits.rs`:

| Test | Asserts |
|---|---|
| `command_substitution_is_scanned` | a param used inside `[...]` (`return [set $v]`) is a first-order use |
| `command_substitution_plain_value_is_not_a_var_name` | `[string length $x]` records no role — no over-marking of value reads |
| `compound_dynamic_array_name_marks_components` | `set ${v}($k)` / `$v($k)` mark both `v` and `k` |
| `var_substitutions_finds_compound_components` | the component extractor handles `${v}($k)`, `arr($k)`, `\$esc`, `$1` |
| `braced_var_name_has_no_substitution` | `set {arr($k)} 1` is literal — `$k` not marked (regression: PR review) |
| `namespace_upvar_dynamic_name_reads_other_var` | `namespace upvar ns $token arr` reads `$token`; write-through upgrades |
| `real_world_by_reference_patterns_are_inferred` | corpus sweep: `upvar $token`, `variable $name`, `array set/get $a`, `unset $v`, `dict set $d`, `incr/append/lappend $x`, `set ${tok}(f)`, `$gas(idx)`, `namespace upvar`, `[array names $a]` |
| `param_used_as_command_head_is_command` | `$cmd a b` (and in `[...]`) is a command; braced `{$cmd}` and value reads are not |
| `stub_command_prefix_role_is_command` | a stub `:command_prefix` arg names a command |
| `value_copy_carries_param_into_name_and_command_positions` | `set n $v; set $n 1` / `set c $cmd; $c …`, incl. cmd-sub and transitive copies |
| `value_copy_is_invalidated_and_not_over_eager` | reassignment drops the copy; pure pass-through records nothing |

Highlighter — `rust/tcl-lsp-core/src/semantic_tokens.rs`:

| Test | Asserts |
|---|---|
| `literal_array_element_write_is_variable_declaration` | `set arr(key) 1` / `incr count(hits)` / `append log(err) x` → whole-word `Variable` decl |
| `namespaced_array_element_write_is_variable_declaration` | `set ::ns::arr(key) 1` → variable decl |
| `unset_array_element_is_variable` | `unset arr(key)` → one whole-word decl; `unset arr($i)` keeps inner `$i`, not painted whole |
| `array_element_write_not_retagged` | `set arr($i) 1` computed subscript leaves inner `$i` |
| `varread_role_highlights_variable_name` | `info exists arr(key)` / `array names arr` / `array get arr` → plain `Variable` (no decl) |
| `varread_value_argument_is_not_a_variable` | `dict get $d k` — only `$d`, not `k` |
| `stub_var_arg_highlights_array_element` | `# tcl-lsp: stub … :var` write target highlights |
| `stub_var_read_arg_highlights_as_reference` | `:var_read` arg highlights as a reference |
| `user_proc_var_name_arg_highlights_array_element` | a proc that upvars+writes its param → call-site `arr(key)` as decl |
| `user_proc_var_read_arg_highlights_as_reference` | a proc that upvars+reads → call-site arg as reference |
| `user_proc_var_name_computed_subscript_survives` | `myset arr($i) 1` keeps inner `$i` |
| `user_proc_dynamic_name_read_args_highlight` | end-to-end `b aa foo` → `set ${v}($k)` (cmd-sub + compound) highlights `aa`/`foo` |
| `user_proc_command_arg_highlights_as_function` | dispatcher proc → call-site command name as `Function`; absent without analysis |

Every stage was regression-tested: the full **tcl-compiler** suite (the inferred traits feed dead-store / unused-variable diagnostics), **core/db**, and the **582-test server e2e** suite, all green.

> Note: `edit_tracking_stress` is timing-flaky under full parallel load — a diagnostics-wait timeout that hits a different seed each run and always passes in isolation. If a CI `edit_tracking_stress::*` job times out, it's environmental, not this change; rerun rather than diagnose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FeQeLw5fCeMSJknGNSLyFJ