### PR TITLE
Remove TCL regex vendoring references

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -84,12 +84,6 @@ var*.txt
 *.chars
 *.tcltestout
 
-# Zig WASM runtime was removed in #800; the `runtime/zig/` tree is now only a
-# locally-fetched vendored-source build artefact (vendor/tcl-regex/*, with
-# .fetch.lock / .stamp markers), never source. Ignore it so a stale local copy
-# isn't proposed for commit.
-/runtime/zig/
-
 # Rust workspace (editors/zed keeps its own local .gitignore for its target/)
 /target/
 rust/tcl-lsp-rust/.venv/

--- a/Makefile
+++ b/Makefile
@@ -835,7 +835,6 @@ ensure-tcl-deps: ## Install Tcl shells needed by Tcl/tclpkg tests and bytecode c
 		SKIP_RUST=1 \
 		SKIP_WASMTIME=1 \
 		SKIP_BINARYEN=1 \
-		SKIP_TCL_REGEX=1 \
 		SKIP_EMACS=1 \
 		SKIP_XVFB=1 \
 		SKIP_TSHARK=1 \
@@ -855,7 +854,6 @@ ensure-rust-deps: ## Install Rust/rustup + wasm32-wasip2 target needed by check-
 			SKIP_KOTLINC=1 \
 			SKIP_WASMTIME=1 \
 			SKIP_BINARYEN=1 \
-			SKIP_TCL_REGEX=1 \
 			SKIP_EMACS=1 \
 			SKIP_XVFB=1 \
 			SKIP_TSHARK=1 \
@@ -881,7 +879,6 @@ ensure-emacs-deps: ## Install Emacs needed by test-emacs
 			SKIP_RUST=1 \
 			SKIP_WASMTIME=1 \
 			SKIP_BINARYEN=1 \
-			SKIP_TCL_REGEX=1 \
 			SKIP_XVFB=1 \
 			SKIP_TSHARK=1 \
 			SKIP_OPENSSL=1 \
@@ -903,7 +900,6 @@ ensure-vscode-test-deps: ## Install xvfb for Linux headless VS Code extension te
 		SKIP_RUST=1 \
 		SKIP_WASMTIME=1 \
 		SKIP_BINARYEN=1 \
-		SKIP_TCL_REGEX=1 \
 		SKIP_EMACS=1 \
 		SKIP_TSHARK=1 \
 		SKIP_OPENSSL=1 \

--- a/docs/design/compiler/wasm-runtime-primitives.md
+++ b/docs/design/compiler/wasm-runtime-primitives.md
@@ -265,7 +265,7 @@ The intended trim policy:
   records in TZif are dead weight for our renderer.
 
 The trimmer should live in `scripts/trim_tzdata.py` and run at
-runtime build time (idempotent, like `fetch_tcl_regex.sh`).
+runtime build time (idempotent, a build-time fetch/generate step).
 Output goes to a data blob under `runtime/rust/` and is embedded
 into the runtime binary (via Rust's `include_bytes!`) from the clock module.
 

--- a/docs/design/runtime/c-extension-abi.md
+++ b/docs/design/runtime/c-extension-abi.md
@@ -287,6 +287,15 @@ halves and partial in the `Tcl_Obj`/shared-memory layer, which is inherently
 
 ## 10. The regex engine is the first C library
 
+> **Superseded.** This section argued for keeping the C Henry-Spencer engine as
+> the runtime's first vendored C library. That is no longer the design: the ARE
+> engine is now the pure-Rust `tcl-regex` crate (bit-for-bit fidelity —
+> backreferences, lookahead, POSIX leftmost-longest — verified against
+> `reg.test`), with **no C compiled, vendored, or fetched**. The direction is
+> reversed: rather than C being linked into the runtime, C consumers link the
+> *Rust* engine through the `regex_capi` C-ABI shim (`TclReComp`/`TclReExec`/…).
+> The rationale below is retained as historical context.
+
 Tcl's Henry Spencer ARE engine is already C, already compiled into the runtime
 (the vendored `tcl-regex` engine). Once "compile C against the runtime" exists,
 the regex engine *is* the first such C library — keeping it gives bit-for-bit

--- a/docs/design/runtime/memory-management.md
+++ b/docs/design/runtime/memory-management.md
@@ -13,8 +13,9 @@ because it never bump-allocates; the refcount discipline (#2, #3,
 and Phase MM-B) still applies:
 
 1. **Heap incoherence with wasi-libc.**  The
-   vendored Spencer regex engine called `MALLOC`/`FREE` which bind
-   to wasi-libc's dlmalloc.  dlmalloc's heap starts at `__heap_base`
+   vendored Spencer regex engine (since removed — the ARE engine is
+   now the pure-Rust `tcl-regex` crate) called `MALLOC`/`FREE` which
+   bind to wasi-libc's dlmalloc.  dlmalloc's heap starts at `__heap_base`
    and grows upward.  A bump allocator started at a fixed offset
    (originally 64 KB, then 17 MB after the Phase 1.3 data-segment
    fix) and *also* grew upward.  On heavy regex workloads —

--- a/docs/design/runtime/runtime-execution-gaps.md
+++ b/docs/design/runtime/runtime-execution-gaps.md
@@ -182,10 +182,11 @@ emitted modules link against. Most subsystems are **partial**:
 - **builtins (`cmds/`)** — a large surface runs (drives the unmodified Tcl 9
   library to `package require tcltest`), but the tcltest sweep is incomplete
   (e.g. `dict.test` 272/373, `lrange` 1759/1766); per-command parity ongoing.
-- **regex** — the **C** Henry-Spencer ARE engine is linked today (`have_regex`,
-  `build.rs` + FFI shim); the **Rust port of the algorithm is the end-stage
-  swap** (`tcl-regex` already exists workspace-side, so a convergence, not a
-  fresh port).
+- **regex** — the pure-Rust `tcl-regex` ARE engine drives `regexp`/`regsub`.
+  The former **C** Henry-Spencer engine (`build.rs` + FFI shim, `have_regex`)
+  has been removed, so regex now builds on `wasm32` too; nothing vendors or
+  fetches the C sources. C consumers still link the engine — through the
+  pure-Rust `regex_capi` C-ABI shim (`TclReComp`/`TclReExec`/…), not C sources.
 - **OO / coroutines** — `cmd_oo.rs` (TclOO: classes, super-classes, `oo::define`,
   method dispatch) and `cmd_coro.rs` are implemented here; native stack-swap +
   threads are `cfg`-gated off under the `BrowserHost` capability host on wasm32.

--- a/docs/design/rust/scripts-retirement-triage.md
+++ b/docs/design/rust/scripts-retirement-triage.md
@@ -270,7 +270,9 @@ artifact, so there is nothing to port; they die with Python:
 
 - `dev/ensure-test-deps.sh`, `dev/resolve-tcl-library.sh`, `dev/tclsh_check.sh`,
   `dev/test-slow-runner.sh`, `test-slow-stamp.sh`, `worktree-fingerprint.sh`,
-  `fetch_tcl_regex.sh`, `build/render_logo.sh`, `screenshots.sh`. **Keep.**
+  `build/render_logo.sh`, `screenshots.sh`. **Keep.**
+  (`fetch_tcl_regex.sh` retired with the C Henry-Spencer regex vendoring — the
+  ARE engine is now the pure-Rust `tcl-regex` crate.)
 
 ### B6 — Release / install shell (backend-agnostic)
 

--- a/runtime/rust/src/lib.rs
+++ b/runtime/rust/src/lib.rs
@@ -46,11 +46,12 @@
 //! re-exports and the wasm `memory`/table exports land in T1.6.
 
 // On `wasm32-unknown-unknown` the native-only features — coroutines (native
-// stack swap + threads), the ARE regex FFI, and the libtommath bignum tower —
-// are all cfg-disabled (see the `BrowserHost`, `have_regex`, and `have_tommath`
-// gates below), so the machinery that drives them (coroutine context fields and
-// swap methods, the OO exec frame, the rand seed, the conditional line-base
-// bookkeeping) is unreachable on that target. Native is the primary build where
+// stack swap + threads) and the libtommath bignum tower — are cfg-disabled (see
+// the `BrowserHost` and `have_tommath` gates below), so the machinery that
+// drives them (coroutine context fields and swap methods, the OO exec frame,
+// the rand seed, the conditional line-base bookkeeping) is unreachable on that
+// target. (The ARE regex engine is the pure-Rust `tcl-regex` crate now, not a
+// C FFI, so it builds on wasm32 too — no gate.) Native is the primary build where
 // `clippy -D warnings` runs and nothing is dead; only the wasm32 build sees this
 // dead code, so the allow is scoped to that target alone.
 #![cfg_attr(target_arch = "wasm32", allow(dead_code, unused_imports))]


### PR DESCRIPTION
## Summary

Remove references to the TCL regex vendoring system (`fetch_tcl_regex.sh` and `SKIP_TCL_REGEX` flags) that has been retired in favor of the pure-Rust `tcl-regex` crate.

Changes:
- Remove `/runtime/zig/` from `.gitignore` (the associated comment about TCL regex vendoring is no longer relevant)
- Remove `SKIP_TCL_REGEX=1` flags from four dependency installation targets in the Makefile (`ensure-tcl-deps`, `ensure-rust-deps`, `ensure-emacs-deps`, `ensure-vscode-test-deps`)
- Update documentation to reflect that `fetch_tcl_regex.sh` has been retired and replaced with the Rust `tcl-regex` crate
- Clarify that similar build-time fetch/generate steps are now handled differently

## Validation

- No testing needed; these are configuration and documentation updates reflecting an already-completed migration to the Rust regex implementation.

https://claude.ai/code/session_012Wt8zK4G4mnAmZJtn6MWo1