### PR TITLE
Update release notes for v2.1.4

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -16,6 +16,18 @@ GitHub release or the default Marketplace download.
   object-method options — are now recognised and highlighted from the registry,
   and option/subcommand names may be given by unambiguous prefix abbreviation
   the way Tcl itself accepts them.
+- **By-reference and array-element variable highlighting.** Variables and
+  commands passed by reference are inferred from their general argument roles
+  and highlighted accordingly, and literal array-element write targets —
+  `set arr(key) 1`, `incr count(hits)`, `unset arr(key)` — now highlight as
+  whole-word variables to match their reads (a computed subscript like
+  `arr($i)` still keeps its inner `$i` as a distinct token).
+- **Native BIG-IP report generator.** The report generator is now backed by a
+  native Rust CLI alongside the Python backend, both sharing one templating
+  layer and emitting the same single-file report, and it ships as a release
+  artefact. The interactive report also gains a clearer theme toggle (distinct
+  auto/light/dark glyphs) and object-popover titles that deep-link to the
+  object's own listing row.
 - **Reports carry provenance.** Generated reports are stamped with the git
   commit hash and gain print headers/footers for cleaner hard copies.
 
@@ -24,7 +36,15 @@ GitHub release or the default Marketplace download.
 - **Much broader registry coverage.** Comprehensive tcllib and Tk command
   coverage (including ttk and ticklecharts), plus BIG-IP config defaults,
   object specs, cross-references, and event facts — sharpening completion,
-  hover, and diagnostics across Tcl, Tk, and iRule/BIG-IP code.
+  hover, and diagnostics across Tcl, Tk, and iRule/BIG-IP code. The `::html::`
+  package table was rebuilt against html 1.6 with correct arities, return
+  types, purity flags, and version gating, and a dedicated `report::defstyle`
+  spec was added.
+- **Cross-file `package require` awareness (fewer false W120).** A module
+  sourced by an entry file that runs the requires is no longer flagged for
+  W120: the workspace now inherits `package require`s along the reverse
+  `source` graph. Optionally, `[project] entryPoints` in `.tcl-lsp.ini`
+  declares the entry files explicitly and applies their requires project-wide.
 - **Diagram rendering switched to elkjs.** Control-flow and data-flow diagrams
   now lay out with elkjs instead of Mermaid, for more stable, readable graphs.
 - **Better tcltest support.** Registry tests migrated and the `tcltest`
@@ -38,6 +58,11 @@ GitHub release or the default Marketplace download.
   dispatch so methods on objects are analysed instead of flagged as unknown.
 - **Variable highlighting.** `unset` and `global` now highlight every variable
   name in the command, not just the first.
+- **Config-file dialect now honoured for `.tcl` files.** The `dialect =` key in
+  `.tcl-lsp.ini` / `config.ini` is applied to normally-opened `.tcl` buffers;
+  the bare `tcl` language id every editor sends now defers to the per-folder
+  override and session default instead of forcing `tcl8.6`. Explicit versioned
+  ids and in-source `# tcl-dialect:` directives remain authoritative.
 
 ## Release-pipeline changes
 
@@ -45,7 +70,11 @@ GitHub release or the default Marketplace download.
   (the keyless Azure/OIDC path was rolled back after proving unreliable).
 - JetBrains pre-releases now publish to the Marketplace **eap** channel from an
   approval-gated CI job, matching the VS Code pre-release track.
-- Removed the retired Zig WASM runtime and its build infrastructure.
+- BIG-IP report and GitHub Pages builds were reworked around the shared
+  `bigip-report-gen` layout, including a fix to the single-file WASM report
+  build inputs.
+- Removed the retired Zig WASM runtime and the vendored TCL regex build
+  infrastructure.
 
 ## Using this alpha
 


### PR DESCRIPTION
Refreshes `RELEASE_NOTES.md` for the **v2.1.4** pre-release so it covers the fixes that landed after the original notes commit (`d0ab3d1a`) — the release attempt earlier today was aborted to get these in.

Newly documented since the first draft:
- By-reference and array-element variable highlighting (#814)
- Native Rust BIG-IP report generator CLI + report UX (theme toggle, popover deep-links) (#810)
- Cross-file `package require` inheritance for W120 (#808)
- Config-file dialect honoured for normally-opened `.tcl` files (#807)
- Enriched `::html::` and `report::defstyle` registry specs (#815, #809)
- Report/GitHub Pages build rework

Docs-only change; tagging `v2.1.4` follows once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)