### PR TITLE
Format 3 vscode TS files for prettier 3.9.4

### DIFF
--- a/editors/vscode/src/highlightingHealth.ts
+++ b/editors/vscode/src/highlightingHealth.ts
@@ -73,8 +73,7 @@ export function resetHighlightingHealthSession(): void {
 export type SemanticReason = "featureOff" | "editorOff" | "themeUnsupported";
 
 export type SemanticStatus =
-  | { effective: true; reason: "on" }
-  | { effective: false; reason: SemanticReason };
+  { effective: true; reason: "on" } | { effective: false; reason: SemanticReason };
 
 /**
  * The side-effecting collaborators the checks depend on. Production builds this

--- a/editors/vscode/src/test/documentLinks.test.ts
+++ b/editors/vscode/src/test/documentLinks.test.ts
@@ -27,8 +27,7 @@ suite("Document Links", () => {
     await activate(docUri);
 
     const links = (await vscode.commands.executeCommand("vscode.executeLinkProvider", docUri)) as
-      | vscode.DocumentLink[]
-      | undefined;
+      vscode.DocumentLink[] | undefined;
 
     // The server should provide clickable links for source/package require
     assert.ok(links !== undefined, "Link provider should return a result (possibly empty)");

--- a/editors/vscode/src/test/renameSymbol.test.ts
+++ b/editors/vscode/src/test/renameSymbol.test.ts
@@ -30,9 +30,7 @@ suite("Rename Symbol", () => {
     const pos = new vscode.Position(1, 5);
 
     const result = (await vscode.commands.executeCommand("vscode.prepareRename", docUri, pos)) as
-      | vscode.Range
-      | { range: vscode.Range; placeholder: string }
-      | undefined;
+      vscode.Range | { range: vscode.Range; placeholder: string } | undefined;
 
     assert.ok(result, "prepareRename should return a result for a proc name");
   });


### PR DESCRIPTION
The **v2.1.4** tag build's `test-ext` job failed at the `prettier --check` step. Local dev has prettier `3.8.4`, but the lockfile pins `3.9.4` (what CI's `npm ci` installs), and 3.9.4 collapses these union types onto one line where they fit.

`rust`-branch PRs run `rust-gate` (cargo) + `rust-lsp-e2e`, **not** `test-ext`, so the drift wasn't caught until the tag build. This reformats the 3 affected files with the pinned 3.9.4:

- `editors/vscode/src/highlightingHealth.ts`
- `editors/vscode/src/test/documentLinks.test.ts`
- `editors/vscode/src/test/renameSymbol.test.ts`

Purely cosmetic; ESLint unaffected. Needed before re-tagging v2.1.4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)