### PR TITLE
Fix all 5 critical RUST_ISSUES bugs (SCCP/inline/fold miscompiles, semantic-tokens panic, dead test-slow gate)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -180,7 +180,7 @@ The project uses GNU Make. Key targets:
 |--------------------|------------------------------------------|
 | `make rust-check`  | **Rust PR gate** — `check-rust` (cargo `fmt --check` + `clippy`) + `xtask-check` (generated-file / docs-index drift gates via `cargo xtask …`). Mirrors the GitHub Actions `pr-gate` job. |
 | `make check-all`   | **Pre-push gate** — full lint + typecheck across **every** language: TypeScript via ESLint + Prettier + tsc, Rust via `cargo fmt --check` + `cargo clippy`. On success writes `tmp/check-all.stamp`; the pre-push hook requires this. |
-| `make test-slow`   | **Pre-PR gate** — must pass before opening a PR. Runs everything: optional dep check (or install when `AUTO_INSTALL_DEPS=1`) + `capture-bytecode-refs` + `prep-pr` + `check-rust` + tclpkg (`test-tclpkg-tcl`) + VS Code extension (`test-ext`) + Emacs eglot (`test-emacs`) + VSIX smoke (`_prep-pr-smoke`) + the full Rust workspace test suite (`test-rust`, which includes the native lsp_e2e) + the Rust runtime port (`runtime-rust-test` — the standalone `runtime/rust` crate is excluded from the workspace, so `test-rust` does not cover it). Drives every phase through `scripts/dev/test-slow-runner.sh`, which keeps going past failures and prints one consolidated PASS/FAIL summary at the end. On success writes the committed `.test-slow.stamp` (CI PR gate) plus the local `tmp/check-all.stamp` and `tmp/test-slow.stamp`. **`git add .test-slow.stamp` and commit it with your PR.** Release-only docs (`RELEASE_NOTES.md`, `docs/sphinx/changelog.md`) are excluded from the fingerprint, so a single green run before merge stays valid through the release tag — the release flow **verifies** this stamp rather than re-running the gate. |
+| `make test-slow`   | **Pre-PR gate** — must pass before opening a PR. Runs everything: optional dep check (or install when `AUTO_INSTALL_DEPS=1`) + `capture-bytecode-refs` + `prep-pr` + `check-rust` + VS Code extension (`test-ext`) + Emacs eglot (`test-emacs`) + VSIX smoke (`_prep-pr-smoke`) + the full Rust workspace test suite (`test-rust`, which includes the native lsp_e2e) + the Rust runtime port (`runtime-rust-test` — the standalone `runtime/rust` crate is excluded from the workspace, so `test-rust` does not cover it). Drives every phase through `scripts/dev/test-slow-runner.sh`, which keeps going past failures and prints one consolidated PASS/FAIL summary at the end. On success writes the committed `.test-slow.stamp` (CI PR gate) plus the local `tmp/check-all.stamp` and `tmp/test-slow.stamp`. **`git add .test-slow.stamp` and commit it with your PR.** Release-only docs (`RELEASE_NOTES.md`, `docs/sphinx/changelog.md`) are excluded from the fingerprint, so a single green run before merge stays valid through the release tag — the release flow **verifies** this stamp rather than re-running the gate. |
 | `make verify-test-slow-stamp` | Verify the committed `.test-slow.stamp` matches the current tree — the same content-fingerprint check the GitHub `test-slow-stamp` PR job runs. Fails loudly if the tree changed since the last green `test-slow`. Note: running **any** make target other than this one, `test-slow`, or `help` deletes `.test-slow.stamp`, so re-run `make test-slow` (which rewrites it) as the final step before committing. |
 | `make install-test-deps` | One-shot setup: install **everything** `test-slow` needs (the system toolchain — all of `ensure-test-deps`). The target to run on a fresh checkout before `make test-slow`. Same platform coverage as `ensure-test-deps`. |
 | `make ensure-test-deps` | Install the optional `test-slow` toolchain (`tclsh9.0`, `node`+`npm`, `kotlinc`, Rust/rustup, Wasmtime, Binaryen, wasi-sdk, emacs, xvfb, …) on Debian/Ubuntu (apt-get), CentOS/RHEL/Rocky/Alma/Fedora (dnf or yum), or macOS (Homebrew). Idempotent. Builds Tcl 9 from `tmp/tcl9.0.3/` since most distros don't package it yet. Skip individual tools with `SKIP_TCLSH=1`, `SKIP_NODE=1`, `SKIP_KOTLINC=1`, `SKIP_RUST=1`, … Run `bash scripts/dev/ensure-test-deps.sh --check` for a non-mutating report of what would be installed. |
@@ -355,13 +355,12 @@ then the rest in parallel):
 2. **prep-pr** — format (Prettier) + codegen (`cargo xtask`) + lint + typecheck
    (tsc) + editor-settings drift check + `test-rust`
 3. **check-rust** — Rust lint/typecheck
-4. **tclpkg** (`test-tclpkg-tcl`) — pure-Tcl package-manager tests
-5. **VS Code extension** (`test-ext`) — xvfb if no DISPLAY
-6. **Emacs eglot** (`test-emacs`)
-7. **VSIX smoke** (`_prep-pr-smoke`)
-8. **Rust workspace** (`test-rust`) — `cargo test --workspace --all-features`,
+4. **VS Code extension** (`test-ext`) — xvfb if no DISPLAY
+5. **Emacs eglot** (`test-emacs`)
+6. **VSIX smoke** (`_prep-pr-smoke`)
+7. **Rust workspace** (`test-rust`) — `cargo test --workspace --all-features`,
    including the native lsp_e2e suite (`rust/tcl-lsp-server/tests/*_e2e.rs`)
-9. **Rust runtime port** (`runtime-rust-test`) — `cargo test` in the standalone
+8. **Rust runtime port** (`runtime-rust-test`) — `cargo test` in the standalone
    `runtime/rust` crate (excluded from the workspace, so `test-rust` misses it):
    the leak round-trip + parse/eval unit suite
 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,6 @@ REPORT_SHARED_DIR := $(ROOT)rust/bigip-report-gen/frontend
 # builds the Rust → WASM core + Mermaid into it, and `build.rs` embeds the whole
 # bundle into the `tcl` binary (served by `tcl explore --serve`).
 EXPLORER_STATIC := $(ROOT)rust/tcl-cli/gui
-TCLPKG_TCL_DIR  := $(ROOT)tooling/tclpkg/tcl
 
 # Committed test-slow proof.  `.test-slow.stamp` certifies that
 # `make test-slow` passed against the current tree (the CI PR gate and
@@ -174,7 +173,6 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 .PHONY: rust-check check-all test-slow verify-test-slow-stamp prep-pr install-hooks
 # Tests
 .PHONY: test test-ext test-ext-rust test-emacs test-rust rust-server rust-tcl rust-f5 rust-mcp rust-clis ensure-server-cross-deps server-cross-build server-cross-build-all mcp-cross-build-all cli-cross-build-all server-cross-test server-cross-test-build print-server-targets-all
-.PHONY: test-tclpkg-tcl
 .PHONY: capture-bytecode-refs
 .PHONY: xtask-check xtask-kcs-index-links xtask-diag-tables xtask-gen-editor-catalogs xtask-gen-editor-settings xtask-gen-vscode-package xtask-gen-jetbrains-catalog xtask-gen-ai-diagnostics xtask-audit-option-dialects
 # Lint / format / typecheck
@@ -339,10 +337,9 @@ format: format-ts ## Format TypeScript code
 
 # The lsp_e2e suite is now native: rust/tcl-lsp-server/tests/*_e2e.rs, run by
 # `cargo test` (see test-rust). The old Python pytest drivers were retired.
-
-test-tclpkg-tcl: ensure-tcl-deps ## Run pure-Tcl tclpkg tests (requires tclsh8.6+)
-	@echo "==> Running pure-Tcl tclpkg tests"
-	cd $(TCLPKG_TCL_DIR) && for t in tests/*_test.tcl; do tclsh8.6 "$$t" || exit 1; done
+# The pure-Tcl tclpkg suite (formerly `test-tclpkg-tcl`, driven out of the
+# retired `tooling/tclpkg/tcl` tree) is likewise gone: tclpkg is now the
+# `tcl-pkg` Rust crate, exercised by `test-rust`.
 
 lint-ts: $(NPM_STAMP) ## Lint/format-check TypeScript extension code
 	@echo "==> Linting TypeScript code (ESLint + Prettier check)"
@@ -781,7 +778,7 @@ check-all: ## Full lint + typecheck (TS, Rust); writes tmp/check-all.stamp on su
 # subsumes check-all by running prep-pr).
 #
 # Covers: prep-pr (format/codegen/lint/typecheck/test-rust/parity) +
-# Rust lint/typecheck + tclpkg + VS Code extension + Emacs eglot +
+# Rust lint/typecheck + VS Code extension + Emacs eglot +
 # VSIX smoke + Rust workspace tests + the Rust runtime port
 # (runtime-rust-test — the standalone runtime/rust crate is excluded from
 # the workspace, so cargo test --workspace does not cover it).
@@ -804,7 +801,7 @@ test-slow: ## Comprehensive local gate (everything); writes tmp/check-all.stamp 
 	@NPROC="$(NPROC)" MAKE="$(MAKE)" \
 		bash $(ROOT)scripts/dev/test-slow-runner.sh \
 			--serial "capture-bytecode-refs prep-pr" \
-			--parallel "check-rust test-tclpkg-tcl test-ext _prep-pr-smoke test-emacs test-rust runtime-rust-test"
+			--parallel "check-rust test-ext _prep-pr-smoke test-emacs test-rust runtime-rust-test"
 	@mkdir -p $(ROOT)tmp
 	@# Committed proof for the CI PR gate (content fingerprint of the
 	@# tree, excluding the stamp itself).  Written before the local tmp

--- a/RUST_ISSUES.md
+++ b/RUST_ISSUES.md
@@ -19,15 +19,15 @@ Direct gate runs (fmt, clippy, `cargo test --workspace --all-features`, `cargo x
 - **signed-vs-unsigned / bounded-int semantics** — eBPF emits unsigned `DIV`/`MOD`/`RSH` for signed Tcl ints; the VM wraps `<<`/`**` past i128 where the runtime promotes to bignum.
 - **retired-Python tooling leftovers** — a nonexistent `tooling/` tree breaks `make test-slow`, and stale `uv`/`pytest`/`.pyz` references linger in scripts, workflows, and the session hook.
 
-## Critical (5)
+## Critical (5) — ✅ all fixed
 
-| # | Subsystem | Location | Issue | Verified |
-|---|---|---|---|---|
-| [001](rust-issues/RUST_ISSUE_001.md) | Compiler middle-end (CFG/SSA/SCCP/optimiser) | `rust/tcl-compiler/src/sccp.rs:455-457` | SCCP's phi join skips version-0 incoming operands, so a parameter's (or any live-in's) runtime value silently vanishes from the merge and the phi fol… | ✓ |
-| [002](rust-issues/RUST_ISSUE_002.md) | Compiler middle-end (CFG/SSA/SCCP/optimiser) | `rust/tcl-compiler/src/inline_uplevel.rs:183-227` | uplevel-passthrough inlining splices the body into the caller without rejecting return/break/continue, changing return-code semantics |  |
-| [003](rust-issues/RUST_ISSUE_003.md) | Compiler middle-end (CFG/SSA/SCCP/optimiser) | `rust/tcl-compiler/src/optimiser/propagation.rs:903-915` | fold_return_under_lattice Path 3 builds the eval env flow-insensitively from *every* Const lattice entry ("preferring a non-zero version"), and the e… |  |
-| [004](rust-issues/RUST_ISSUE_004.md) | LSP display features | `rust/tcl-lsp-core/src/semantic_tokens.rs:4597` | fixed 2-byte escape slice splits a multibyte char and panics the whole semantic-tokens request | ✓ |
-| [005](rust-issues/RUST_ISSUE_005.md) | Build tooling & CI | `Makefile:35,343-345` | test-tclpkg-tcl cd's into tooling/tclpkg/tcl, which does not exist on this branch, so the mandatory make test-slow gate can never pass. [VERIFIED: no… | ✓ |
+| Fixed | # | Subsystem | Location | Issue | Verified |
+|---|---|---|---|---|---|
+| ✅ | [001](rust-issues/RUST_ISSUE_001.md) | Compiler middle-end (CFG/SSA/SCCP/optimiser) | `rust/tcl-compiler/src/sccp.rs:455-457` | SCCP's phi join skips version-0 incoming operands, so a parameter's (or any live-in's) runtime value silently vanishes from the merge and the phi fol… | ✓ |
+| ✅ | [002](rust-issues/RUST_ISSUE_002.md) | Compiler middle-end (CFG/SSA/SCCP/optimiser) | `rust/tcl-compiler/src/inline_uplevel.rs:183-227` | uplevel-passthrough inlining splices the body into the caller without rejecting return/break/continue, changing return-code semantics |  |
+| ✅ | [003](rust-issues/RUST_ISSUE_003.md) | Compiler middle-end (CFG/SSA/SCCP/optimiser) | `rust/tcl-compiler/src/optimiser/propagation.rs:903-915` | fold_return_under_lattice Path 3 builds the eval env flow-insensitively from *every* Const lattice entry ("preferring a non-zero version"), and the e… |  |
+| ✅ | [004](rust-issues/RUST_ISSUE_004.md) | LSP display features | `rust/tcl-lsp-core/src/semantic_tokens.rs:4597` | fixed 2-byte escape slice splits a multibyte char and panics the whole semantic-tokens request | ✓ |
+| ✅ | [005](rust-issues/RUST_ISSUE_005.md) | Build tooling & CI | `Makefile:35,343-345` | test-tclpkg-tcl cd's into tooling/tclpkg/tcl, which does not exist on this branch, so the mandatory make test-slow gate can never pass. [VERIFIED: no… | ✓ |
 
 ## High (55)
 

--- a/rust-issues/RUST_ISSUE_001.md
+++ b/rust-issues/RUST_ISSUE_001.md
@@ -7,10 +7,21 @@
 | **Severity** | critical |
 | **Subsystem** | Compiler middle-end (CFG/SSA/SCCP/optimiser) |
 | **Location** | `rust/tcl-compiler/src/sccp.rs:455-457` |
-| **Status** | Open |
+| **Status** | Fixed |
 | **Verification** | Verified firsthand by reviewer |
 
 ## Finding
 
 rust/tcl-compiler/src/sccp.rs:455-457 — SCCP's phi join skips version-0 incoming operands, so a parameter's (or any live-in's) runtime value silently vanishes from the merge and the phi folds to the defined-arm constant.
 `proc p {c x} { if {$c} { set x 5 }; if {$x == 5} {A} else {B} }` — phi for `x` at the merge has incoming `{entry:0, then:1}`; `if incoming_ver == 0 { continue; }` drops the caller's `x`, phi = `Const(5)`, the second branch folds always-true: else-arm becomes SCCP-unreachable (O107 "Eliminate unreachable dead code" deletes live code, branch_folding emits O101 rewriting `{$x == 5}`→`{1}`, `sccp_constants_for` propagates `x=5` elsewhere). `seed_live_in_roots`'s own doc says live-ins are seeded Overdefined precisely so they don't "silently vanish from any phi", but the seeder also excludes v0 phi feeds (`if *inc > 0`) and the phi loop never looks v0 up. The sibling interval pass does it right (`intervals.rs:569-574` joins TOP for `inc == 0`), confirming intent. Confidence: high
+
+## Resolution
+
+Fixed. `sccp_process_phis` no longer skips a version-0 incoming operand: it
+joins the live-in value in (defaulting to `Overdefined` when unseeded), so a
+phi merging a live-in with a defined-arm constant correctly widens to
+`Overdefined` — mirroring the interval pass, which joins `TOP` for `inc == 0`.
+`seed_live_in_roots` now also records version-0 phi feeds so `(name, 0)` is
+pinned `Overdefined` in the lattice. Regression tests:
+`phi_join_widens_version_zero_livein_to_overdefined` and
+`phi_join_defaults_missing_version_zero_feed_to_overdefined` in `sccp.rs`.

--- a/rust-issues/RUST_ISSUE_002.md
+++ b/rust-issues/RUST_ISSUE_002.md
@@ -7,10 +7,26 @@
 | **Severity** | critical |
 | **Subsystem** | Compiler middle-end (CFG/SSA/SCCP/optimiser) |
 | **Location** | `rust/tcl-compiler/src/inline_uplevel.rs:183-227` |
-| **Status** | Open |
+| **Status** | Fixed |
 | **Verification** | Reported by review agent (confidence: high) |
 
 ## Finding
 
 rust/tcl-compiler/src/inline_uplevel.rs:183-227 — uplevel-passthrough inlining splices the body into the caller without rejecting `return`/`break`/`continue`, changing return-code semantics.
 `proc run {b} { uplevel 1 $b }; proc c {} { run { return 5 }; puts after }` — real Tcl: TCL_RETURN propagates through `uplevel` and is absorbed at `run`'s proc boundary, so `c` prints "after"; after `inline_uplevel_passthrough` (run unconditionally in `CompilationUnit::build_for_inner`, compilation_unit.rs:579) the spliced `return 5` returns from `c`, so downstream CFG/codegen/dead-code analysis treat `puts after` as unreachable. `body_has_frame_reach` gates only `uplevel|upvar|UpFrame` — the general inliner (`inlining/mod.rs`, `has_irreturn_in_unsafe_scope`) shows the return gate was known-needed and is absent here. Confidence: high
+
+## Resolution
+
+Fixed. Both uplevel-passthrough inlining paths (`static_passthrough_body` and
+the `ParamBody` callsite rewriter) now reject a body that can complete with a
+`return`/`break`/`continue` escaping its own top level, via the new
+`body_has_completion_escape`. The erased passthrough proc boundary is what
+decremented a `return`'s level and turned a raw `break`/`continue` into an
+`invoked "…" outside of a loop` error; splicing directly would leak those codes
+into the caller. Loops absorb `break`/`continue` in their own body (but not
+`return`); `catch` absorbs every non-`OK` code, so neither contributes an
+escape. Regression tests: `static_passthrough_with_{return,bare_break,
+bare_continue}_rejected`, `static_passthrough_with_{loop_absorbed_break,
+catch_absorbed_return}_allowed`, `static_passthrough_return_inside_loop_still_
+rejected`, and `param_body_passthrough_{return_callsite_not_inlined,
+plain_callsite_still_inlined}` in `inline_uplevel.rs`.

--- a/rust-issues/RUST_ISSUE_003.md
+++ b/rust-issues/RUST_ISSUE_003.md
@@ -7,10 +7,23 @@
 | **Severity** | critical |
 | **Subsystem** | Compiler middle-end (CFG/SSA/SCCP/optimiser) |
 | **Location** | `rust/tcl-compiler/src/optimiser/propagation.rs:903-915` |
-| **Status** | Open |
+| **Status** | Fixed |
 | **Verification** | Reported by review agent (confidence: high) |
 
 ## Finding
 
 rust/tcl-compiler/src/optimiser/propagation.rs:903-915 — `fold_return_under_lattice` Path 3 builds the eval env flow-insensitively from *every* Const lattice entry ("preferring a non-zero version"), and the exit-version overlay only overrides when the exit version is itself Const — so a stale pre-loop/other-arm constant leaks into the fold.
 `proc f {} { set x 0; foreach v {1 2} { set x $v }; return [expr {$x + 1}] }` — at the return, `x`'s exit version is a ConstSet phi (not overlaid), but `(x,1)=Const(0)` binds `x=0`; the fold yields `1`, and the argument-sensitive O103 path (propagation.rs:1425-1437, gated only on `summary.pure`) emits an applicable rewrite replacing `[f]` with `1` while tclsh returns `3`. Path 2's own comment ("Reading the precise version is what makes us bail on sum_list") documents the invariant Path 3 violates. Confidence: high
+
+## Resolution
+
+Fixed. `fold_return_under_lattice` Path 3 now builds the eval env
+flow-sensitively, exactly as Path 2 does: each variable the `[expr {…}]`
+references is bound at *this block's exit version* (falling back to version 0
+for a never-reassigned parameter, where interproc-seeded constants live), and
+only when that version is a lattice `Const`. A variable whose exit version is a
+non-`Const` phi is left unbound, so `eval_tcl_expr` bails rather than folding
+against a stale pre-loop/other-arm constant. Regression tests:
+`return_expr_does_not_fold_stale_pre_loop_constant` (the miscompile) and
+`return_expr_folds_argument_sensitive_constant` (the `[::add 2 4]` → 6 control)
+in `propagation.rs`.

--- a/rust-issues/RUST_ISSUE_004.md
+++ b/rust-issues/RUST_ISSUE_004.md
@@ -7,10 +7,18 @@
 | **Severity** | critical |
 | **Subsystem** | LSP display features |
 | **Location** | `rust/tcl-lsp-core/src/semantic_tokens.rs:4597` |
-| **Status** | Open |
+| **Status** | Fixed |
 | **Verification** | Verified firsthand by reviewer |
 
 ## Finding
 
 rust/tcl-lsp-core/src/semantic_tokens.rs:4597 — fixed 2-byte escape slice splits a multibyte char and panics the whole semantic-tokens request.
 `puts "\é"` (backslash immediately before any non-ASCII char; also `"a\你b"`, `"\€"`) yields a String token whose raw content `\é` reaches `push_escape_subtokens` (:3939). At the backslash the code slices two bytes, landing inside `é`: `let esc = &text[i..(i + 2).min(text.len())];` — `.min()` bounds length but not char boundary → panic, dropping all highlighting for the document. (Sibling push_regsub_subtokens:878 and regex scan_are_escape are ASCII-guarded; this one is not.) Confidence: high
+
+## Resolution
+
+Fixed. `push_escape_subtokens` now advances past a backslash escape by the
+escaped character's real UTF-8 width (`\` + one full `char`) instead of a fixed
+2 bytes, so `\<non-ASCII>` (`\é`, `\你`, `\€`) no longer slices inside a
+multi-byte char and panics the request. Regression test:
+`escape_before_multibyte_char_does_not_panic` in `semantic_tokens.rs`.

--- a/rust-issues/RUST_ISSUE_005.md
+++ b/rust-issues/RUST_ISSUE_005.md
@@ -7,10 +7,19 @@
 | **Severity** | critical |
 | **Subsystem** | Build tooling & CI |
 | **Location** | `Makefile:35,343-345` |
-| **Status** | Open |
+| **Status** | Fixed |
 | **Verification** | Verified firsthand by reviewer |
 
 ## Finding
 
 Makefile:35,343-345 — `test-tclpkg-tcl` cd's into `tooling/tclpkg/tcl`, which does not exist on this branch, so the mandatory `make test-slow` gate can never pass. [VERIFIED: no tooling/ dir; git ls-files tooling → 0 matches; runner runs it in the parallel batch, exits non-zero, make aborts before `test-slow-stamp.sh write` → explains the missing committed .test-slow.stamp / G5.]
 `TCLPKG_TCL_DIR := $(ROOT)tooling/tclpkg/tcl`; `cd $(TCLPKG_TCL_DIR) && for t in tests/*_test.tcl; ...`. `test-slow` runs `test-tclpkg-tcl` (Makefile:807) with no SKIP var → FAIL → stamp never written → `release`/`publish-*` (depend on verify-test-slow-stamp) fail, and ci.yml `test-slow-stamp` job fails any PR to main. Confidence: high
+
+## Resolution
+
+Fixed. The `test-tclpkg-tcl` target, its `.PHONY` entry, the `TCLPKG_TCL_DIR`
+variable, and its slot in the `test-slow` parallel batch were all removed. The
+`tooling/tclpkg/tcl` tree is a retired-Python leftover; tclpkg is now the
+`tcl-pkg` Rust crate, exercised by `test-rust`, so no pure-Tcl tclpkg suite
+exists to run. `make test-slow` no longer invokes a target that `cd`s into a
+nonexistent directory, so the gate can write `.test-slow.stamp` again.

--- a/rust/tcl-compiler/src/inline_uplevel.rs
+++ b/rust/tcl-compiler/src/inline_uplevel.rs
@@ -106,7 +106,7 @@ fn static_passthrough_body(proc: &Procedure) -> Option<Script> {
         Statement::UpFrame {
             frame_shift, body, ..
         } if *frame_shift == 1 => {
-            if body_has_frame_reach(body) {
+            if body_has_frame_reach(body) || body_has_completion_escape(body) {
                 None
             } else {
                 Some(body.clone())
@@ -224,6 +224,106 @@ fn statement_has_frame_reach(stmt: &Statement) -> bool {
         }
         _ => false,
     }
+}
+
+/// True if *script* can complete with a `return` / `break` / `continue`
+/// that escapes the script's own top level.
+///
+/// The passthrough proc we are about to erase is
+/// `proc P {…} { uplevel 1 $body }`: `uplevel` is transparent to every
+/// completion code, so the body's code flows to *P*'s proc boundary,
+/// which (a) decrements a `return`'s level — absorbing `return 5` so the
+/// caller carries on — and (b) turns a raw `break`/`continue` into an
+/// `invoked "…" outside of a loop` error. Splicing the body directly
+/// into the caller removes that boundary: a spliced `return` now returns
+/// the *caller's* proc, and a spliced `break`/`continue` now drives the
+/// caller's enclosing loop instead of erroring. Both change observable
+/// behaviour, so decline the inline when the body can escape this way.
+///
+/// `in_loop` tracks whether a loop *within the body* would absorb a bare
+/// `break`/`continue`; `catch` absorbs every non-`OK` code, so its body
+/// can never contribute an escape.
+#[must_use]
+pub fn body_has_completion_escape(script: &Script) -> bool {
+    script
+        .statements
+        .iter()
+        .any(|s| statement_has_completion_escape(s, false))
+}
+
+fn statement_has_completion_escape(stmt: &Statement, in_loop: bool) -> bool {
+    match stmt {
+        // `return` propagates to the proc boundary regardless of any
+        // enclosing loop, so it always escapes the body.
+        Statement::Return { .. } => true,
+        // A bare `break`/`continue` escapes unless a loop *inside the
+        // body* absorbs it.
+        Statement::Call { command, .. } | Statement::Barrier { command, .. }
+            if matches!(command.as_str(), "break" | "continue") =>
+        {
+            !in_loop
+        }
+        // Loop bodies absorb `break`/`continue`; their init/next scripts
+        // (for `for`) run in the enclosing context and do not.
+        Statement::For {
+            init, next, body, ..
+        } => statement_scripts_escape(&[init, next], in_loop) || body_iter_escape(body, true),
+        Statement::While { body, .. } | Statement::Foreach { body, .. } => {
+            body_iter_escape(body, true)
+        }
+        Statement::If {
+            clauses, else_body, ..
+        } => {
+            clauses.iter().any(|c| body_iter_escape(&c.body, in_loop))
+                || else_body
+                    .as_ref()
+                    .is_some_and(|b| body_iter_escape(b, in_loop))
+        }
+        Statement::Switch {
+            arms, default_body, ..
+        } => {
+            arms.iter().any(|a| {
+                a.body
+                    .as_ref()
+                    .is_some_and(|b| body_iter_escape(b, in_loop))
+            }) || default_body
+                .as_ref()
+                .is_some_and(|b| body_iter_escape(b, in_loop))
+        }
+        Statement::Block { body, .. } | Statement::UpFrame { body, .. } => {
+            body_iter_escape(body, in_loop)
+        }
+        // `try` may re-raise a `return`/`break`/`continue` from its body,
+        // handlers, or finally clause; conservatively treat any as an escape.
+        Statement::Try {
+            body,
+            handlers,
+            finally_body,
+            ..
+        } => {
+            body_iter_escape(body, in_loop)
+                || handlers.iter().any(|h| body_iter_escape(&h.body, in_loop))
+                || finally_body
+                    .as_ref()
+                    .is_some_and(|b| body_iter_escape(b, in_loop))
+        }
+        // Everything else — including `catch`, which intercepts every non-`OK`
+        // completion code and turns it into a value so nothing inside it can
+        // escape — contributes no escape. `catch` is deliberately NOT recursed
+        // into for that reason.
+        _ => false,
+    }
+}
+
+fn body_iter_escape(script: &Script, in_loop: bool) -> bool {
+    script
+        .statements
+        .iter()
+        .any(|s| statement_has_completion_escape(s, in_loop))
+}
+
+fn statement_scripts_escape(scripts: &[&Script], in_loop: bool) -> bool {
+    scripts.iter().any(|s| body_iter_escape(s, in_loop))
 }
 
 /// Rewrite every passthrough callsite in *module* to splice the
@@ -385,7 +485,7 @@ fn try_inline_callsite(
             }
             let literal = &args[0];
             let inlined = lower_literal_script(literal, namespace, registry);
-            if body_has_frame_reach(&inlined) {
+            if body_has_frame_reach(&inlined) || body_has_completion_escape(&inlined) {
                 return None;
             }
             Some(Statement::Block {
@@ -531,6 +631,80 @@ mod tests {
         // expressed as a same-frame inline.
         let m = lower_to_ir("proc reset {} { uplevel #0 {set counter 0} }", &reg());
         assert!(detect_static_passthrough(&m).is_empty());
+    }
+
+    #[test]
+    fn static_passthrough_with_return_rejected() {
+        // Splicing a `return` into the caller would return the CALLER's
+        // proc; the erased passthrough boundary used to absorb it.
+        let m = lower_to_ir("proc run {} { uplevel 1 {return 5} }", &reg());
+        assert!(detect_static_passthrough(&m).is_empty());
+    }
+
+    #[test]
+    fn static_passthrough_with_bare_break_rejected() {
+        let m = lower_to_ir("proc run {} { uplevel 1 {break} }", &reg());
+        assert!(detect_static_passthrough(&m).is_empty());
+    }
+
+    #[test]
+    fn static_passthrough_with_bare_continue_rejected() {
+        let m = lower_to_ir("proc run {} { uplevel 1 {continue} }", &reg());
+        assert!(detect_static_passthrough(&m).is_empty());
+    }
+
+    #[test]
+    fn static_passthrough_with_loop_absorbed_break_allowed() {
+        // A `break` fully contained in a loop within the body is absorbed by
+        // that loop and never escapes, so the inline stays safe.
+        let m = lower_to_ir(
+            "proc run {} { uplevel 1 {foreach x {1 2} { break }} }",
+            &reg(),
+        );
+        assert_eq!(detect_static_passthrough(&m).len(), 1);
+    }
+
+    #[test]
+    fn static_passthrough_with_catch_absorbed_return_allowed() {
+        // `catch` intercepts every non-OK completion code, so a `return`
+        // inside it cannot escape the body.
+        let m = lower_to_ir("proc run {} { uplevel 1 {catch {return 5}} }", &reg());
+        assert_eq!(detect_static_passthrough(&m).len(), 1);
+    }
+
+    #[test]
+    fn static_passthrough_return_inside_loop_still_rejected() {
+        // A loop absorbs break/continue but NOT return, so a return nested in
+        // a loop still escapes to the proc boundary.
+        let m = lower_to_ir(
+            "proc run {} { uplevel 1 {foreach x {1 2} { return $x }} }",
+            &reg(),
+        );
+        assert!(detect_static_passthrough(&m).is_empty());
+    }
+
+    #[test]
+    fn param_body_passthrough_return_callsite_not_inlined() {
+        // The dispatcher shape is still a candidate, but a callsite whose
+        // literal body escapes with `return` must not be spliced.
+        let mut m = lower_to_ir(
+            "proc dispatcher {body} { uplevel 1 $body }\ndispatcher { return 5 }",
+            &reg(),
+        );
+        inline_uplevel_passthrough(&mut m, &reg());
+        assert_eq!(count_blocks(&m.top_level), 0);
+    }
+
+    #[test]
+    fn param_body_passthrough_plain_callsite_still_inlined() {
+        // Control: a non-escaping literal body is inlined as before, so the
+        // completion-escape gate hasn't disabled the optimisation wholesale.
+        let mut m = lower_to_ir(
+            "proc dispatcher {body} { uplevel 1 $body }\ndispatcher { set counter 0 }",
+            &reg(),
+        );
+        inline_uplevel_passthrough(&mut m, &reg());
+        assert_eq!(count_blocks(&m.top_level), 1);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -896,35 +896,36 @@ fn fold_return_under_lattice(
         };
     }
 
-    // Path 3 — `return [expr {…}]` / interpolation. Build the env from every
-    // lattice constant (so version-0 params, absent from `exit_versions`, are
-    // bound), preferring a non-zero version, then overlay the block-exit
-    // versions for precise local state. Only used for the expr/interpolation
-    // form (the simple-`$var` precision above is handled by path 2).
+    // Path 3 — `return [expr {…}]`. Build the env FLOW-SENSITIVELY, exactly
+    // as path 2 does for the single-`$var` case: bind each variable the expr
+    // references at *this block's exit version* (the precise state reaching
+    // this return), and only when that version is a lattice constant. A
+    // variable absent from `exit_versions` (a never-reassigned parameter)
+    // falls back to version 0, where interproc-seeded param constants live.
+    //
+    // The old flow-INsensitive scan ("every Const lattice entry, preferring
+    // the newest version, then overlay exit versions") miscompiled: for
+    // `set x 0; foreach v {…} { set x $v }; return [expr {$x + 1}]`, `x`'s
+    // exit version is a non-Const loop phi, so the overlay didn't override,
+    // and the stale pre-loop `(x,1)=Const(0)` leaked in — folding to `1`
+    // where tclsh returns `3`. Reading the exit version (Overdefined here)
+    // leaves `x` unbound so `eval_tcl_expr` bails, matching path 2's
+    // `sum_list`/`fibonacci` precision.
+    let expr = expr?;
     let mut env: Env = Env::new();
-    let mut chosen_ver: std::collections::HashMap<crate::ssa::Symbol, crate::ssa::Version> =
-        std::collections::HashMap::new();
-    for ((sym, ver), lv) in &result.values {
-        if let LatticeValue::Const(c) = lv {
-            let take = chosen_ver.get(sym).is_none_or(|prev| *ver > *prev);
-            if take {
-                chosen_ver.insert(*sym, *ver);
-                env.insert(fu.ssa.var_name(*sym).to_owned(), const_to_env_value(c));
-            }
-        }
-    }
     if let Some(ssa_block) = fu.ssa.blocks.get(&bn) {
-        for (&sym, ver) in &ssa_block.exit_versions {
-            if let Some(LatticeValue::Const(c)) = result.values.get(&(sym, *ver)) {
+        for name in crate::var_refs::vars_in_expr(expr) {
+            let Some(sym) = fu.ssa.var_symbol(&name) else {
+                continue;
+            };
+            let ver = ssa_block.exit_versions.get(&sym).copied().unwrap_or(0);
+            if let Some(LatticeValue::Const(c)) = result.values.get(&(sym, ver)) {
                 env.insert(fu.ssa.var_name(sym).to_owned(), const_to_env_value(c));
             }
         }
     }
-    if let Some(expr) = expr {
-        let v = eval_tcl_expr(expr, &env)?;
-        return Some(crate::sccp::tcl_value_to_const(v));
-    }
-    None
+    let v = eval_tcl_expr(expr, &env)?;
+    Some(crate::sccp::tcl_value_to_const(v))
 }
 
 /// Convert a [`ConstValue`] to the expr-folder's [`EnvValue`].
@@ -2281,6 +2282,55 @@ mod tests {
         assert!(
             ctx.optimisations.iter().any(|o| o.code == DiagCode::O103),
             "expected O103 static-proc fold, got {:?}",
+            ctx.optimisations,
+        );
+    }
+
+    #[test]
+    fn return_expr_does_not_fold_stale_pre_loop_constant() {
+        // `x` is overwritten by the loop, so its exit version at the return is
+        // a non-Const phi (Overdefined). `::f` is pure but has no
+        // argument-independent constant return, so `[::f]` reaches the
+        // argument-sensitive fold's `fold_return_under_lattice` Path 3. That
+        // fold must NOT leak the pre-loop `set x 0`: tclsh returns 3 (x ends
+        // at 2), so folding `[::f]` to 1 would be a miscompile.
+        use tcl_registry::CommandRegistry;
+        let registry = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for(
+            "proc ::f {} { set x 0; foreach v {1 2} { set x $v }; return [expr {$x + 1}] }\nputs [::f]",
+            &registry,
+            false,
+        )
+        .with_interprocedural(&registry, None);
+        let mut ctx = PassContext::new(&cu.source, cu.interproc.clone().unwrap_or_default());
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations.iter().all(|o| o.code != DiagCode::O103),
+            "loop-overwritten var must not fold from a stale pre-loop constant, got {:?}",
+            ctx.optimisations,
+        );
+    }
+
+    #[test]
+    fn return_expr_folds_argument_sensitive_constant() {
+        // Control: the argument-sensitive Path 3 still folds when the return
+        // expr genuinely depends only on the constant call arguments — the
+        // documented `[::add 2 4]` → 6 case (params bound at version 0).
+        use tcl_registry::CommandRegistry;
+        let registry = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for(
+            "proc ::add {a b} { return [expr {$a + $b}] }\nputs [::add 2 4]",
+            &registry,
+            false,
+        )
+        .with_interprocedural(&registry, None);
+        let mut ctx = PassContext::new(&cu.source, cu.interproc.clone().unwrap_or_default());
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations
+                .iter()
+                .any(|o| o.code == DiagCode::O103 && o.replacement == "6"),
+            "expected O103 folding [::add 2 4] to 6, got {:?}",
             ctx.optimisations,
         );
     }

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -362,9 +362,14 @@ fn seed_live_in_roots<S: std::hash::BuildHasher>(
         for phi in &ssa_block.phis {
             defined_keys.insert((phi.name, phi.version));
             for inc in phi.incoming.values() {
-                if *inc > 0 {
-                    used_keys.insert((phi.name, *inc));
-                }
+                // Record every phi feed, including the version-0 (entry /
+                // live-in) incoming: it is never a def, so it drops through
+                // to the `used_keys.difference(&defined_keys)` seeding below
+                // and is pinned `Overdefined`. This is what lets the phi
+                // join at [`sccp_process_phis`] see the caller's value
+                // instead of silently dropping it and folding to the
+                // defined-arm constant.
+                used_keys.insert((phi.name, *inc));
             }
         }
         for s in &ssa_block.statements {
@@ -453,11 +458,23 @@ fn sccp_process_phis(
         let mut phi_val = LatticeValue::Unknown;
         for pred in incoming_exec {
             let incoming_ver = phi.incoming.get(pred).copied().unwrap_or(0);
-            if incoming_ver == 0 {
-                continue;
-            }
+            // A version-0 incoming is the entry / live-in root (a proc
+            // parameter, global, or other caller-supplied value). Its
+            // runtime value is unknown at compile time, so it joins in as
+            // `Overdefined` — never skipped. Skipping it would let a phi
+            // that merges a live-in with a defined-arm constant fold to
+            // that constant, miscompiling any `if {$param} { set x k }`
+            // followed by a test on `x`. This mirrors the interval pass,
+            // which joins `TOP` for `inc == 0` (intervals.rs:570-574).
+            // `seed_live_in_roots` pins `(name, 0)` `Overdefined`; the
+            // explicit default keeps the join correct even if a feed was
+            // never seeded.
             let key: ValueKey = (phi.name, incoming_ver);
-            let candidate = values.get(&key).cloned().unwrap_or(LatticeValue::Unknown);
+            let candidate = values.get(&key).cloned().unwrap_or(if incoming_ver == 0 {
+                LatticeValue::Overdefined
+            } else {
+                LatticeValue::Unknown
+            });
             phi_val = join(&phi_val, &candidate);
         }
         if set_value(values, (phi.name, phi.version), &phi_val) {
@@ -1601,6 +1618,57 @@ mod tests {
             }
         }
         ssa
+    }
+
+    #[test]
+    fn phi_join_widens_version_zero_livein_to_overdefined() {
+        // A phi merging a version-0 live-in (a proc parameter / global /
+        // other caller-supplied root) with a defined-arm constant must widen
+        // to Overdefined — the caller's value cannot vanish from the merge.
+        // Otherwise `if {$c} { set x 5 }; if {$x == 5} {A} else {B}` folds the
+        // second test always-true and deletes the else arm. Mirrors the
+        // interval pass joining TOP for `inc == 0` (intervals.rs:570-574).
+        let mut ssa = bare_ssa();
+        let x = ssa.intern_var("x");
+        let mut block = empty_ssa_block("merge");
+        block.phis.push(crate::ssa::Phi {
+            name: x,
+            version: 2,
+            incoming: HashMap::from([(BlockId(1), 0), (BlockId(2), 1)]),
+        });
+        // `seed_live_in_roots` pins the version-0 root Overdefined.
+        let mut values: HashMap<ValueKey, LatticeValue> = HashMap::new();
+        values.insert((x, 0), LatticeValue::Overdefined);
+        values.insert((x, 1), LatticeValue::Const(ConstValue::Int(5)));
+        assert!(sccp_process_phis(
+            &mut values,
+            &block,
+            &[BlockId(1), BlockId(2)]
+        ));
+        assert_eq!(values.get(&(x, 2)), Some(&LatticeValue::Overdefined));
+    }
+
+    #[test]
+    fn phi_join_defaults_missing_version_zero_feed_to_overdefined() {
+        // Defence in depth: even if a version-0 feed was never seeded, the
+        // join must treat it as Overdefined rather than skipping it (which
+        // would leave the phi holding the defined-arm constant).
+        let mut ssa = bare_ssa();
+        let x = ssa.intern_var("x");
+        let mut block = empty_ssa_block("merge");
+        block.phis.push(crate::ssa::Phi {
+            name: x,
+            version: 2,
+            incoming: HashMap::from([(BlockId(1), 0), (BlockId(2), 1)]),
+        });
+        let mut values: HashMap<ValueKey, LatticeValue> = HashMap::new();
+        values.insert((x, 1), LatticeValue::Const(ConstValue::Int(5)));
+        assert!(sccp_process_phis(
+            &mut values,
+            &block,
+            &[BlockId(1), BlockId(2)]
+        ));
+        assert_eq!(values.get(&(x, 2)), Some(&LatticeValue::Overdefined));
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -4593,8 +4593,14 @@ fn push_escape_subtokens(
                     entries,
                 );
             }
-            // Minimal `\X` (two chars); richer `\uHHHH` widths aren't handled.
-            let esc = &text[i..(i + 2).min(text.len())];
+            // Minimal `\X` (backslash + one full character); richer
+            // `\uHHHH` widths aren't handled. `X` may be multi-byte
+            // (`\é`, `\你`, `\€`), so advance by the escaped char's real
+            // UTF-8 width rather than a fixed 2 bytes — a fixed +2 would
+            // slice inside the char and panic the whole request.
+            let esc_char_len = text[i + 1..].chars().next().map_or(1, char::len_utf8);
+            let esc_end = i + 1 + esc_char_len;
+            let esc = &text[i..esc_end];
             push_subtoken(
                 source,
                 line_index,
@@ -4604,7 +4610,7 @@ fn push_escape_subtokens(
                 entries,
             );
             emitted = true;
-            i += 2;
+            i = esc_end;
             run_start = i;
         } else {
             i += 1;
@@ -6924,6 +6930,26 @@ mod tests {
         );
         // `\d` is an ARE class shortcut → char class.
         assert!(ks.contains(&(TokenKind::RegexpCharClass as u32)), "{ks:?}");
+    }
+
+    #[test]
+    fn escape_before_multibyte_char_does_not_panic() {
+        // Regression: `\<non-ASCII>` inside a string used to slice a fixed 2
+        // bytes at the backslash, landing inside the multi-byte char and
+        // panicking the whole semantic-tokens request. The escape must span
+        // the backslash plus the full UTF-8 char.
+        for src in [
+            "puts \"\\é\"\n",
+            "puts \"a\\你b\"\n",
+            "puts \"\\€\"\n",
+            "puts \"x\\é\\你\"\n",
+        ] {
+            let ks = kinds(src, "tcl", &reg());
+            assert!(
+                ks.contains(&(TokenKind::Escape as u32)),
+                "expected an Escape sub-token for {src:?}, got {ks:?}",
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
+++ b/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
@@ -139,6 +139,16 @@ fn invariant_corpus() -> Vec<(&'static str, &'static str)> {
             "multibyte_string",
             "set greeting \"héllo wörld café\"\nputs $greeting\n",
         ),
+        // A backslash immediately before a non-ASCII char used to slice a
+        // fixed 2 bytes at the escape, splitting the multibyte char and
+        // panicking the whole semanticTokens/full request. The escape now
+        // spans the backslash plus the full UTF-8 char; drive it through the
+        // server so the bounds/overlap invariants (and non-panic) are checked.
+        ("escape_before_multibyte", "puts \"\\é\"\nset after 1\n"),
+        (
+            "escape_before_multibyte_run",
+            "puts \"x\\é\\你\\€y\"\nset after 1\n",
+        ),
         ("emoji_string", "set e \"😀 tcl 🚀 rocks 🐫\"\nputs $e\n"),
         ("emoji_then_code", "puts \"🚀\"\nset after 1\n"),
         (
@@ -198,6 +208,30 @@ fn test_tokens_strictly_non_overlapping_dense_line() {
     let uri = open_doc(&mut lsp, source);
     let raw = lsp.semantic_tokens(&uri);
     assert!(semantic_token_violations(&raw, source, &types_ref, &mods_ref).is_empty());
+}
+
+#[test]
+fn test_escape_before_multibyte_char_does_not_panic() {
+    // Regression: `\<non-ASCII>` (`\é`, `\你`, `\€`) inside a string used to
+    // slice a fixed 2 bytes at the backslash, landing inside the multibyte
+    // char and panicking the whole `textDocument/semanticTokens/full`
+    // request. Drive the real request through the server and require it to
+    // succeed AND emit an `escape` sub-token for the `\X` run.
+    let mut lsp = Lsp::tcl();
+    let legend_names = legend(&lsp);
+    for source in [
+        "puts \"\\é\"\n",
+        "puts \"a\\你b\"\n",
+        "puts \"\\€\"\n",
+        "puts \"x\\é\\你\"\n",
+    ] {
+        let uri = open_doc(&mut lsp, source);
+        let toks = typed(&mut lsp, &legend_names, &uri);
+        assert!(
+            toks.iter().any(|t| t.ttype == "escape"),
+            "expected an `escape` token for {source:?}, got {toks:?}",
+        );
+    }
 }
 
 // -- TestCoreTokens ------------------------------------------------------


### PR DESCRIPTION
## Summary

Fixes every issue in the **Critical (5)** bucket of `RUST_ISSUES.md`. Each fix is general — it carries the correct information through the compiler/registry stack rather than special-casing a symptom.

- **001 — `rust/tcl-compiler/src/sccp.rs` (SCCP phi join, miscompile):** the phi join dropped version-0 (entry/live-in) incoming operands, so a phi merging a caller-supplied value with a defined-arm constant folded to that constant and deleted live code (`if {$c} { set x 5 }; if {$x == 5} …`). The join now treats a version-0 feed as `Overdefined`, mirroring the interval pass which joins `TOP` for `inc == 0`; `seed_live_in_roots` also pins `(name, 0)` `Overdefined` so the lattice is consistent.
- **002 — `rust/tcl-compiler/src/inline_uplevel.rs` (uplevel-passthrough inlining, wrong return codes):** splicing a body into the caller dropped the passthrough proc boundary that decrements a `return`'s level and turns a raw `break`/`continue` into an error. A new `body_has_completion_escape` gate declines the inline when the body can complete abnormally — loops absorb `break`/`continue` (not `return`), `catch` absorbs every code. Wired into both the static and param-body paths.
- **003 — `rust/tcl-compiler/src/optimiser/propagation.rs` (`fold_return_under_lattice` Path 3, miscompile):** the eval env was built flow-insensitively ("every `Const`, prefer newest version"), leaking a stale pre-loop constant past a loop that overwrites the var (`set x 0; foreach v {…} { set x $v }; return [expr {$x + 1}]` folded to `1`, tclsh returns `3`). It now binds each referenced variable at its block-exit version like Path 2, so a non-`Const` exit version leaves the var unbound and the fold bails.
- **004 — `rust/tcl-lsp-core/src/semantic_tokens.rs` (panic):** a backslash escape before a non-ASCII char (`\é`, `\你`, `\€`) sliced a fixed 2 bytes, splitting the multibyte char and panicking the whole semantic-tokens request. It now advances by the escaped char's real UTF-8 width.
- **005 — `Makefile` (mandatory gate can never pass):** `test-tclpkg-tcl` `cd`'d into the retired `tooling/tclpkg/tcl` tree, so `make test-slow` aborted before writing `.test-slow.stamp`. The dead target and all its references are removed; tclpkg is now the `tcl-pkg` Rust crate, exercised by `test-rust`.

Adds focused regression tests for 001–004 (the 002/003 tests were confirmed to fail against the buggy logic and pass with the fix). The tracker (`RUST_ISSUES.md` + the five `rust-issues/RUST_ISSUE_00N.md` files) is updated to tick these off.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-compiler          # 3486 passed
cargo test -p tcl-lsp-core          # 823 passed (lib) + integration bins, all green
cargo build -p tcl-compiler -p tcl-lsp-core
cargo fmt  (added code is rustfmt-clean on the 1.96 toolchain)
cargo clippy -p tcl-compiler -p tcl-lsp-core --lib   # no new warnings
```

Note: this environment's floating "stable" toolchain resolved to 1.94.1 (below the enforced 1.96 MSRV), so the commands above were run with `+1.96`. The diff is kept to only the fixed files — the branch's pre-existing fmt/clippy drift (tracked as issues 055/056) is left untouched.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **No** — these fixes bring SCCP, the return-fold pass, and uplevel-passthrough inlining back in line with contracts the code already documents (live-ins are seeded `Overdefined` "precisely so they don't silently vanish from any phi"; a return-fold must read the precise exit version — Path 2's own comment states this). They correct implementations to uphold the existing contract rather than changing it.
- [ ] ~~If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`.~~ N/A — no contract change.
- [ ] ~~If I added a new compiler KCS note, I linked it from both READMEs.~~ N/A — no new KCS note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018hWQYvx7dVtUTTJPBHyd6u