### PR TITLE
Replace fixed delays with deterministic barriers in tests

### DIFF
--- a/editors/vscode/src/test/codeLens.test.ts
+++ b/editors/vscode/src/test/codeLens.test.ts
@@ -18,7 +18,7 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { activate, getDocUri, pollUntil, sleep } from "./helper";
+import { activate, getDocUri, pollUntil } from "./helper";
 
 suite("Code Lens", () => {
   const docUri = getDocUri("procs.tcl");
@@ -118,12 +118,18 @@ suite("Code Lens", () => {
   test("resolved lens invokes the showReferences command with locations", async () => {
     const refsUri = getDocUri("codeLensRefs.tcl");
     await activate(refsUri);
-    await sleep(500);
-    const lenses = (await vscode.commands.executeCommand(
-      "vscode.executeCodeLensProvider",
-      refsUri,
-      100,
-    )) as vscode.CodeLens[] | undefined;
+    // Poll the provider (message passing) until the server has published its
+    // first batch of lenses, rather than sleeping on a fixed delay.
+    const lenses = await pollUntil(
+      () =>
+        vscode.commands.executeCommand(
+          "vscode.executeCodeLensProvider",
+          refsUri,
+          100,
+        ) as Thenable<vscode.CodeLens[] | undefined>,
+      (ls) => Array.isArray(ls) && ls.length > 0,
+      { label: "codeLens published" },
+    );
     assert.ok(lenses, "codeLens result should not be null");
 
     const withCommand = lenses.filter((l) => l.command && l.command.command);

--- a/editors/vscode/src/test/codeLens.test.ts
+++ b/editors/vscode/src/test/codeLens.test.ts
@@ -122,11 +122,9 @@ suite("Code Lens", () => {
     // first batch of lenses, rather than sleeping on a fixed delay.
     const lenses = await pollUntil(
       () =>
-        vscode.commands.executeCommand(
-          "vscode.executeCodeLensProvider",
-          refsUri,
-          100,
-        ) as Thenable<vscode.CodeLens[] | undefined>,
+        vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100) as Thenable<
+          vscode.CodeLens[] | undefined
+        >,
       (ls) => Array.isArray(ls) && ls.length > 0,
       { label: "codeLens published" },
     );

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -18,7 +18,7 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate, sleep, waitForDiagnostics } from "./helper";
+import { getDocUri, activate, waitForDiagnostics, waitForEffectiveConfig } from "./helper";
 
 suite("Diagnostics", () => {
   const docUri = getDocUri("diagnostics.tcl");
@@ -145,9 +145,12 @@ suite("Diagnostics", () => {
     const config = vscode.workspace.getConfiguration("tclLsp.optimiser");
     await config.update("enabled", false, vscode.ConfigurationTarget.Global);
 
-    // Allow the pull-model config round-trip to complete so the
-    // server applies optimiser.enabled=false before analysing.
-    await sleep(500);
+    // Wait on the server's resolved config (message passing) rather than a
+    // fixed sleep, so the optimiser.enabled=false round-trip is observed to
+    // have applied before analysing.
+    await waitForEffectiveConfig(cleanUri, (cfg) => cfg.optimiser_enabled === false, {
+      label: "optimiser.enabled = false",
+    });
 
     try {
       await activate(cleanUri);

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -145,14 +145,15 @@ suite("Diagnostics", () => {
     const config = vscode.workspace.getConfiguration("tclLsp.optimiser");
     await config.update("enabled", false, vscode.ConfigurationTarget.Global);
 
-    // Wait on the server's resolved config (message passing) rather than a
-    // fixed sleep, so the optimiser.enabled=false round-trip is observed to
-    // have applied before analysing.
-    await waitForEffectiveConfig(cleanUri, (cfg) => cfg.optimiser_enabled === false, {
-      label: "optimiser.enabled = false",
-    });
-
     try {
+      // Wait on the server's resolved config (message passing) rather than a
+      // fixed sleep, so the optimiser.enabled=false round-trip is observed to
+      // have applied before analysing.  Kept inside the `try` so a wait
+      // timeout still restores the global setting in `finally`.
+      await waitForEffectiveConfig(cleanUri, (cfg) => cfg.optimiser_enabled === false, {
+        label: "optimiser.enabled = false",
+      });
+
       await activate(cleanUri);
 
       // Wait briefly for any diagnostics to appear (proving none arrive)

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -384,12 +384,46 @@ impl Lsp {
 
     /// Force `uri`'s analysis snapshot to `text` at `version` and block until it
     /// is built. Returns `version`.
+    ///
+    /// The barrier is a **synchronous `textDocument/diagnostic` pull request**,
+    /// not an await on a version-tagged `publishDiagnostics` push. That push is
+    /// produced by the server's debounced, coalescing diagnostics scheduler, and
+    /// a no-op full replace (`text` == the buffer's current content) is a salsa
+    /// cache hit: the push tagged with this *exact* version can be legitimately
+    /// coalesced away or delayed far past the timeout under CI load, so awaiting
+    /// it tripped the barrier's 30s timeout intermittently — a flake, not an
+    /// oracle divergence. The pull handler instead reads the *live* buffer and
+    /// returns once diagnostics for the document's current revision are settled
+    /// (served from the push cache when it already published that revision, else
+    /// computed synchronously on demand). It is therefore a deterministic
+    /// "analysis settled at the final content" signal the debounce/coalescer
+    /// cannot suppress, with [`Lsp::request`]'s own timeout as the safety net.
     pub fn settle_analysis(&mut self, uri: &str, version: i64, text: &str) -> i64 {
-        let cursor = self.notification_cursor();
         self.replace_document(uri, version, text);
-        self.await_diagnostics_version(uri, Some(version), DEFAULT_TIMEOUT);
-        self.await_log(&["workspace_state.update", uri], DEFAULT_TIMEOUT, cursor);
+        let _ = self.pull_diagnostics(uri);
         version
+    }
+
+    /// Issue a synchronous `textDocument/diagnostic` pull request for `uri` and
+    /// return the reported diagnostics. The pull handler reads the *live* buffer
+    /// and computes (or returns the already-settled) diagnostics for the current
+    /// revision, so — unlike the debounced push channel — the response is a
+    /// deterministic barrier: it only returns once the server has analysed the
+    /// document's latest content, and cannot be dropped by the diagnostics
+    /// debounce/coalescer.
+    pub fn pull_diagnostics(&mut self, uri: &str) -> Vec<Value> {
+        let report = self.request(
+            "textDocument/diagnostic",
+            json!({ "textDocument": { "uri": uri } }),
+        );
+        // A `full` report carries `items`; an `unchanged` report (only returned
+        // when a matching `previousResultId` is replayed, which this never sends)
+        // carries none.
+        report
+            .get("items")
+            .and_then(Value::as_array)
+            .cloned()
+            .unwrap_or_default()
     }
 
     // -- awaiting --------------------------------------------------------


### PR DESCRIPTION
## Summary

Replace flaky fixed-delay sleeps with deterministic synchronous barriers in LSP test infrastructure and VS Code extension tests:

- **Rust LSP tests**: Refactor `settle_analysis()` to use a synchronous `textDocument/diagnostic` pull request instead of awaiting a debounced `publishDiagnostics` push. The pull handler reads the live buffer and returns once diagnostics are settled, providing a deterministic "analysis complete" signal that the debounce/coalescer cannot suppress. Add new `pull_diagnostics()` helper method to issue diagnostic pull requests.

- **VS Code extension tests**: Replace fixed `sleep(500)` delays with deterministic polling:
  - `codeLens.test.ts`: Poll the code lens provider until lenses are published, rather than sleeping.
  - `diagnostics.test.ts`: Poll the server's effective config until `optimiser.enabled=false` is observed, rather than sleeping.

These changes eliminate intermittent test timeouts caused by debounced diagnostics being coalesced away or delayed under CI load, while maintaining the same safety guarantees through request timeouts.

## Validation

- Existing test infrastructure and test suites validate the changes
- The refactored `settle_analysis()` maintains the same contract (returns version after analysis is settled)
- New `pull_diagnostics()` method is used by `settle_analysis()` and can be reused elsewhere
- VS Code test changes replace sleeps with equivalent polling logic using existing `pollUntil()` helper

https://claude.ai/code/session_01A6YXsZdmV3CPWJ8BcnykWm