### PR TITLE
Fix #832: recognise commands defined in auto_path library files (W123)

### DIFF
--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -716,6 +716,21 @@ about them.  The *fix* is to ship per-package stub bundles; that's
 catalogued as an open task in `fp-audit-todo.md` (not a precision
 issue).
 
+**Workspace-level refinement (issue #832).**  The *single-file analyser*
+verdict above is unchanged — it cannot see beyond the document.  But the
+LSP server *does* have the project's package database (`pkgIndex.tcl` /
+`tclIndex` across the workspace + the resolved `auto_path`), the same
+knowledge go-to-definition uses.  A W123 whose command that database can
+resolve — a library proc a `tclIndex` auto-loads with no `package
+require` (the BLT/Rbc idiom), or a command an available package's
+implementation defines — is refined away by `refine_workspace_w123`
+(alongside the W120 refinement, and independent of the `xcDiagnostics`
+toggle), so it never reaches the editor.  This is a resolvability lookup
+driven entirely by the resolver, never a command-name allowlist.  Locked
+in by `autoload_library_command_suppresses_w123_issue_832` /
+`pkgindex_package_source_command_suppresses_w123` (server) and the
+`auto_loads_command` / `package_defined_commands` unit tests (resolver).
+
 #### tclsh ground truth
 
 ```

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -253,4 +253,29 @@ suite("Diagnostics", () => {
       `dispatch over created object names must not fire W307, got [${codes}]`,
     );
   });
+
+  // Issue #832: `autoloadLibrary.tcl` calls two commands the workspace's
+  // `rbclib/tclIndex` auto-loads (`Rbc_ActiveLegend` / `Rbc_ZoomStack`, the
+  // BLT/Rbc idiom) with no `package require`, plus one genuinely-unknown
+  // command. The package database resolves the library commands exactly as
+  // go-to-definition does, so they must NOT be flagged "Unknown command"
+  // (W123) — while the genuine unknown still is. `xcDiagnostics` stays off.
+  test("auto_path library commands are not unknown (issue #832)", async () => {
+    const uri = getDocUri("autoloadLibrary.tcl");
+    await activate(uri);
+    const codeOf = (d: vscode.Diagnostic) => (typeof d.code === "object" ? d.code.value : d.code);
+    const w123On = (diags: vscode.Diagnostic[], line: number) =>
+      diags.some((d) => codeOf(d) === "W123" && d.range.start.line === line);
+    // Settle on the loaded-database state: the genuine unknown (line 2) is
+    // flagged AND the library calls (lines 0-1) are not — the exact fixed shape.
+    const diagnostics = await waitForDiagnostics(uri, {
+      predicate: (diags) => w123On(diags, 2) && !w123On(diags, 0) && !w123On(diags, 1),
+    });
+    assert.ok(!w123On(diagnostics, 0), "Rbc_ActiveLegend (auto-loaded) must not be W123");
+    assert.ok(!w123On(diagnostics, 1), "Rbc_ZoomStack (auto-loaded) must not be W123");
+    assert.ok(
+      w123On(diagnostics, 2),
+      "the genuinely-unknown command must still be W123 (check stays live)",
+    );
+  });
 });

--- a/editors/vscode/testFixture/autoloadLibrary.tcl
+++ b/editors/vscode/testFixture/autoloadLibrary.tcl
@@ -1,0 +1,3 @@
+Rbc_ActiveLegend .g
+Rbc_ZoomStack .g
+definitely_unknown_cmd .g

--- a/editors/vscode/testFixture/rbclib/graph.tcl
+++ b/editors/vscode/testFixture/rbclib/graph.tcl
@@ -1,0 +1,4 @@
+# Auto-loaded library procs (BLT/Rbc idiom) — reachable by bare name via the
+# sibling tclIndex, with no `package require` in the caller.
+proc Rbc_ActiveLegend {graph} {}
+proc Rbc_ZoomStack {graph args} {}

--- a/editors/vscode/testFixture/rbclib/tclIndex
+++ b/editors/vscode/testFixture/rbclib/tclIndex
@@ -1,0 +1,3 @@
+# Tcl autoload index file, version 2.0
+set auto_index(Rbc_ActiveLegend) [list source [file join $dir graph.tcl]]
+set auto_index(Rbc_ZoomStack) [list source [file join $dir graph.tcl]]

--- a/rust/tcl-lsp-core/src/package_resolver.rs
+++ b/rust/tcl-lsp-core/src/package_resolver.rs
@@ -774,6 +774,52 @@ impl PackageResolver {
     pub fn auto_command_names(&self) -> Vec<&str> {
         self.auto_index.keys().map(String::as_str).collect()
     }
+
+    /// Whether the scanned `auto_path` can auto-load the bare command `cmd`
+    /// (used in `namespace`) — i.e. some `tclIndex` on the path maps one of its
+    /// [`auto_qualify`] candidates to a defining file.
+    ///
+    /// This is the package-database analogue of the built-in command registry:
+    /// a command an installed library makes available through its auto-load
+    /// index is as *resolvable* as a built-in, so the unknown-command (W123)
+    /// check must treat it as known rather than flag it (issue #832). The
+    /// decision is data-driven — it never matches on a specific command name.
+    #[must_use]
+    pub fn auto_loads_command(&self, cmd: &str, namespace: &str) -> bool {
+        !self.resolve_auto_command(cmd, namespace).is_empty()
+    }
+
+    /// The union of command names defined by the implementation files of every
+    /// package in `available`, each resolved to its source files (via
+    /// [`Self::resolve`]) and then read + parsed by the caller-supplied
+    /// `defined_commands` extractor.
+    ///
+    /// The extractor is injected (rather than parsing here) so the command-name
+    /// discovery can run through the compiler's registry-driven symbol-definer
+    /// machinery — the same `proc` / `oo::class` / `interp alias` set the
+    /// analyser records — instead of a hand-rolled `proc`-name scan. Keeping it
+    /// out of the resolver also keeps this crate's package database free of a
+    /// compile dependency on the analyser and makes the method unit-testable
+    /// with a stub extractor.
+    ///
+    /// Used by the W123 refinement for a command provided by a `pkgIndex.tcl`
+    /// package with no `tclIndex` (so [`Self::auto_loads_command`] can't see it)
+    /// that the document's requires — or the requires it inherits from a
+    /// `source` ancestor / entry point — pull in.
+    #[must_use]
+    pub fn package_defined_commands(
+        &self,
+        available: &[String],
+        defined_commands: &dyn Fn(&Path) -> Vec<String>,
+    ) -> HashSet<String> {
+        let mut out = HashSet::new();
+        for pkg in available {
+            for file in self.resolve(pkg, None) {
+                out.extend(defined_commands(&file));
+            }
+        }
+        out
+    }
 }
 
 /// List the `*.tcl` files directly in `dir` (the `pkg_mkIndex` fallback).

--- a/rust/tcl-lsp-core/src/package_resolver/tests.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/tests.rs
@@ -450,3 +450,114 @@ fn resolver_first_provider_wins() {
     resolver.scan_path(&second);
     assert_eq!(resolver.resolve("dup", None), vec![first.join("dup.tcl")]);
 }
+
+// ---------------------------------------------------------------------------
+// `auto_loads_command` — the W123 "command defined in library path" oracle
+// (issue #832).  A library that ships a `tclIndex` makes its procs auto-loadable
+// by bare name with no `package require`, exactly the Rbc_* / BLT idiom in the
+// issue.  These pin the TP / FP / TN / FN arms of that resolvability check.
+// ---------------------------------------------------------------------------
+
+/// TN control — the resolvability oracle answers *yes* for a command the scanned
+/// `tclIndex` genuinely provides, so the W123 that would fire on it is a true
+/// negative (correctly not flagged).
+#[test]
+fn auto_loads_command_true_for_tclindex_global_proc() {
+    let td = TempDir::new("autoloads-tn");
+    let dir = td.path();
+    // A BLT/Rbc-style library dir: a global proc registered by an auto_mkindex
+    // `tclIndex` (global names stored without a leading `::`, per auto_qualify).
+    write(&dir.join("graph.tcl"), "proc Rbc_ActiveLegend {graph} {}\n");
+    write(
+        &dir.join("tclIndex"),
+        "# Tcl autoload index file, version 2.0\n\
+         set auto_index(Rbc_ActiveLegend) [list source [file join $dir graph.tcl]]\n",
+    );
+    let mut resolver = PackageResolver::new();
+    resolver.scan_path(dir);
+    assert!(
+        resolver.auto_loads_command("Rbc_ActiveLegend", "::"),
+        "a global proc in a scanned tclIndex must be reported auto-loadable"
+    );
+}
+
+/// TP control — a genuinely-unknown command (no index maps it) must *not* be
+/// reported resolvable, so its W123 correctly stands (a true positive).
+#[test]
+fn auto_loads_command_false_for_unknown_name() {
+    let td = TempDir::new("autoloads-tp");
+    let dir = td.path();
+    write(&dir.join("graph.tcl"), "proc Rbc_ActiveLegend {graph} {}\n");
+    write(
+        &dir.join("tclIndex"),
+        "# Tcl autoload index file, version 2.0\n\
+         set auto_index(Rbc_ActiveLegend) [list source [file join $dir graph.tcl]]\n",
+    );
+    let mut resolver = PackageResolver::new();
+    resolver.scan_path(dir);
+    // A typo of the real command is not in the index → not resolvable.
+    assert!(
+        !resolver.auto_loads_command("Rbc_ActveLegend", "::"),
+        "a name no tclIndex declares must not be reported auto-loadable"
+    );
+    // An empty resolver knows nothing.
+    assert!(!PackageResolver::new().auto_loads_command("Rbc_ActiveLegend", "::"));
+}
+
+/// A namespaced auto-load key resolves for a bare call inside that namespace but
+/// not for the same tail in the global namespace — the `auto_qualify` candidate
+/// order is honoured, not a blanket tail match.
+#[test]
+fn auto_loads_command_respects_namespace_qualification() {
+    let td = TempDir::new("autoloads-ns");
+    let dir = td.path();
+    write(&dir.join("h.tcl"), "proc ::http::geturl {u} {}\n");
+    write(
+        &dir.join("tclIndex"),
+        "# Tcl autoload index file, version 2.0\n\
+         set auto_index(::http::geturl) [list source [file join $dir h.tcl]]\n",
+    );
+    let mut resolver = PackageResolver::new();
+    resolver.scan_path(dir);
+    assert!(resolver.auto_loads_command("geturl", "::http"));
+    assert!(!resolver.auto_loads_command("geturl", "::"));
+}
+
+// ---------------------------------------------------------------------------
+// `package_defined_commands` — the secondary W123 oracle for a `pkgIndex`-only
+// package (no `tclIndex`) whose implementation source files define the command.
+// The extractor is injected; here a stub stands in for the analyser.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn package_defined_commands_unions_available_package_sources() {
+    let td = TempDir::new("pkgcmds");
+    let dir = td.path();
+    write(&dir.join("mylib.tcl"), "proc mylib::draw {} {}\n");
+    write(
+        &dir.join("pkgIndex.tcl"),
+        "package ifneeded mylib 1.0 [list source [file join $dir mylib.tcl]]\n",
+    );
+    let mut resolver = PackageResolver::new();
+    resolver.scan_path(dir);
+    // Stub extractor: report the tail `draw` for the resolved implementation
+    // file (standing in for the registry-driven analyser extraction).
+    let extract = |path: &Path| -> Vec<String> {
+        if path.file_name().and_then(|n| n.to_str()) == Some("mylib.tcl") {
+            vec!["draw".to_owned()]
+        } else {
+            Vec::new()
+        }
+    };
+    let cmds = resolver.package_defined_commands(&["mylib".to_owned()], &extract);
+    assert!(
+        cmds.contains("draw"),
+        "available package's command surfaced"
+    );
+    // A package the paths don't know contributes nothing (no source files).
+    let none = resolver.package_defined_commands(&["absent".to_owned()], &extract);
+    assert!(none.is_empty());
+    // No available packages ⇒ empty, extractor never consulted.
+    let empty = resolver.package_defined_commands(&[], &extract);
+    assert!(empty.is_empty());
+}

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -854,9 +854,13 @@ async fn run_diagnostics_analyser_path(
 
     // #804: extra requires this document inherits from configured entry points
     // or its `source` ancestors, resolved against the live workspace index.
-    // Only computed when there is a W120 to refine — otherwise the index lock
-    // and `source`-graph walk are wasted work on the hot diagnostics path.
-    let inherited_requires = if analyser_diags.iter().any(|d| d.code == DiagCode::W120) {
+    // Only computed when there is a W120 or W123 to refine (#832 uses inherited
+    // requires for its package-source resolution) — otherwise the index lock and
+    // `source`-graph walk are wasted work on the hot diagnostics path.
+    let inherited_requires = if analyser_diags
+        .iter()
+        .any(|d| d.code == DiagCode::W120 || d.code == DiagCode::W123)
+    {
         let index = inputs.workspace_index.read().await;
         compute_inherited_requires(
             &index,
@@ -926,6 +930,17 @@ async fn refine_and_lift_diagnostics(
         inherited_requires,
         package_resolver,
         registry,
+    )
+    .await;
+    // #832: drop any W123 (unknown command) the package database can resolve —
+    // an auto-loaded library command (`tclIndex`) or a command an available
+    // package's implementation defines. Always on, like the W120 refinement.
+    let analyser_diags = refine_workspace_w123(
+        analyser_diags,
+        analysis.as_ref(),
+        inherited_requires,
+        package_resolver,
+        inputs.dialect,
     )
     .await;
 
@@ -4435,7 +4450,10 @@ impl Backend {
         // `source` ancestors of this document. Only computed when there is a
         // W120 to refine, matching the push path — otherwise the workspace-index
         // lock and `source`-graph walk are avoidable work.
-        let inherited_requires = if analyser_diags.iter().any(|d| d.code == DiagCode::W120) {
+        let inherited_requires = if analyser_diags
+            .iter()
+            .any(|d| d.code == DiagCode::W120 || d.code == DiagCode::W123)
+        {
             self.inherited_package_requires(uri).await
         } else {
             Vec::new()
@@ -4446,6 +4464,17 @@ impl Backend {
             &inherited_requires,
             &self.package_resolver,
             &registry,
+        )
+        .await;
+        // #832: drop any W123 the package database can resolve (auto-loaded
+        // library command, or an available package's defined command), mirroring
+        // the push path so pull and push stay behaviour-identical.
+        let analyser_diags = refine_workspace_w123(
+            analyser_diags,
+            analysis.as_ref(),
+            &inherited_requires,
+            &self.package_resolver,
+            &dialect,
         )
         .await;
         let style_line_length = self.resolved_style_line_length(uri).await;
@@ -8607,6 +8636,122 @@ async fn refine_workspace_w120(
     refine_w120_diagnostics(analyser_diags, &pkg_requires, &resolver, registry)
 }
 
+/// Extract the unknown-command name from a W123 message
+/// (`"Unknown command 'NAME'"`, optionally `+ "; did you mean 'X'?"`) — the
+/// first single-quoted token, the bare name the analyser failed to resolve.
+/// Mirrors `tcl_lsp_db`'s private `w123_command`.
+fn w123_command_name(message: &str) -> Option<&str> {
+    let start = message.find('\'')? + 1;
+    let rest = &message[start..];
+    let end = rest.find('\'')?;
+    Some(&rest[..end])
+}
+
+/// The bare (unqualified) names of every command a source file defines — procs
+/// and classes — discovered through the analyser's registry-driven
+/// symbol-definer walk. The set of *defining* commands (`proc`, `oo::class`,
+/// `interp alias`, an ensemble, …) comes from each command spec's
+/// [`SymbolDef`](tcl_registry::symbol_def::SymbolDef) in the command registry,
+/// never a hand-rolled `proc`-name scan — so a library that defines commands
+/// with any registry-known definer is understood the same way. `structure_only`
+/// skips diagnostic emission (the dominant cost) while building the identical
+/// declaration structure.
+fn defined_command_tails(text: &str, dialect: &str) -> Vec<String> {
+    let mut analyser = Analyser::new().structure_only();
+    let result = analyser.analyse(text, dialect);
+    result
+        .all_procs
+        .values()
+        .map(|p| p.name.clone())
+        .chain(result.all_classes.values().map(|c| c.name.clone()))
+        .filter(|n| !n.is_empty())
+        .collect()
+}
+
+/// Pure core of the workspace W123 refinement: drop every unknown-command
+/// (W123) diagnostic whose command the package database can resolve.
+///
+/// A command is resolvable when either
+/// * the scanned `auto_path` auto-loads it — a `tclIndex` maps its bare name,
+///   the "command defined in library path" case of issue #832 (a BLT/Rbc-style
+///   library whose procs auto-load with no `package require`), or
+/// * one of the packages available to the document (`available`) defines it in
+///   an implementation source file (a `pkgIndex`-only package with no
+///   `tclIndex`).
+///
+/// This is the diagnostic dual of go-to-definition: a command the server can
+/// resolve to a real library definition must not be reported "unknown". The
+/// check is entirely data-driven — the resolver is queried *by the flagged
+/// name*, never matched against a hard-coded command list.
+fn refine_w123_diagnostics(
+    diags: Vec<tcl_compiler::analyser::Diagnostic>,
+    available: &[String],
+    resolver: &PackageResolver,
+    dialect: &str,
+) -> Vec<tcl_compiler::analyser::Diagnostic> {
+    // Command names the document's available packages define via their
+    // `pkgIndex` implementation files. Empty in the common no-`package require`
+    // case (where auto-load alone carries the fix), so no file is read then.
+    let package_commands = if available.is_empty() {
+        HashSet::new()
+    } else {
+        resolver.package_defined_commands(available, &|path| {
+            std::fs::read_to_string(path)
+                .map(|text| defined_command_tails(&text, dialect))
+                .unwrap_or_default()
+        })
+    };
+    diags
+        .into_iter()
+        .filter(|d| {
+            if d.code != DiagCode::W123 {
+                return true;
+            }
+            let Some(name) = w123_command_name(&d.message) else {
+                return true;
+            };
+            // A bare W123 head is a global-namespace call (the analyser skips
+            // `::`-qualified heads), so resolve auto-load against `::`.
+            !(resolver.auto_loads_command(name, "::") || package_commands.contains(name))
+        })
+        .collect()
+}
+
+/// Apply the issue-#832 workspace W123 refinement to `analyser_diags`: resolve
+/// each unknown-command diagnostic against the shared package database and drop
+/// any whose command an installed library / available package provides. Shared
+/// by the push path ([`refine_and_lift_diagnostics`]) and the pull path
+/// ([`Backend::full_diagnostics_for`]) so both stay behaviour-identical, and —
+/// like the W120 refinement — always on, independent of the cross-file
+/// `xcDiagnostics` toggle: a library-provided command is ambient, like a
+/// built-in, so suppressing its false "unknown" is pure precision, not a
+/// cross-file inference the user opts into.
+///
+/// The common case (no W123) skips the resolver lock and all filesystem work.
+async fn refine_workspace_w123(
+    analyser_diags: Vec<tcl_compiler::analyser::Diagnostic>,
+    analysis: &AnalysisResult,
+    inherited_requires: &[String],
+    package_resolver: &Arc<RwLock<PackageResolver>>,
+    dialect: &str,
+) -> Vec<tcl_compiler::analyser::Diagnostic> {
+    if !analyser_diags.iter().any(|d| d.code == DiagCode::W123) {
+        return analyser_diags;
+    }
+    // Packages available to the document: its own `package require`s (empty
+    // whenever a W123 survived — the analyser drops every W123 once a file has
+    // any `package require`) plus those inherited from entry points / `source`
+    // ancestors (#804).
+    let mut available: Vec<String> = analysis
+        .package_requires
+        .iter()
+        .map(|pr| pr.name.clone())
+        .collect();
+    available.extend(inherited_requires.iter().cloned());
+    let resolver = package_resolver.read().await;
+    refine_w123_diagnostics(analyser_diags, &available, &resolver, dialect)
+}
+
 /// The extra `package require` names available to `uri` for the #804 W120
 /// refinement: from the project's configured entry points when set (which
 /// disables auto-detection), else from the workspace `source` graph — every
@@ -11510,6 +11655,142 @@ mod tests {
             !diag_codes(&refined).iter().any(|c| c == "W120"),
             "the pull path must refine away the W120 once the workspace proves \
              http is transitively available, got: {:?}",
+            diag_codes(&refined),
+        );
+    }
+
+    /// Issue #832 (the reported bug): a command defined in a library on the
+    /// `auto_path` — a `tclIndex` auto-loads it by bare name, the BLT/Rbc idiom —
+    /// must NOT be flagged "Unknown command" (W123), *with `xcDiagnostics` left
+    /// off* (its default), because the package database resolves it exactly as
+    /// go-to-definition does.
+    ///
+    /// * TN (must-stay-silent): the caller uses `Rbc_ActiveLegend`, which the
+    ///   scanned `tclIndex` declares → no W123.
+    /// * TP (must-fire control): a typo the index does not declare → W123 stands.
+    /// * FN-guard: an empty database makes the real command genuinely unknowable
+    ///   → W123 fires — proving suppression is data-driven, not a name allowlist.
+    #[tokio::test]
+    async fn autoload_library_command_suppresses_w123_issue_832() {
+        let backend = test_backend();
+        // A library dir on the auto_path: global procs registered by a `tclIndex`,
+        // auto-loadable by bare name with no `package require`.
+        let lib = TmpWs::new("rbc-lib");
+        lib.write(
+            "rbc/graph.tcl",
+            "proc Rbc_ActiveLegend {graph} {}\nproc Rbc_ZoomStack {graph args} {}\n",
+        );
+        lib.write(
+            "rbc/tclIndex",
+            "# Tcl autoload index file, version 2.0\n\
+             set auto_index(Rbc_ActiveLegend) [list source [file join $dir graph.tcl]]\n\
+             set auto_index(Rbc_ZoomStack) [list source [file join $dir graph.tcl]]\n",
+        );
+        {
+            let mut resolver = PackageResolver::new();
+            resolver.scan_tree(&lib.0, 100);
+            *backend.package_resolver.write().await = resolver;
+        }
+        let uri = Uri::from_str("file:///app.tcl").unwrap();
+
+        // TN: the real library commands — no `package require` in the caller —
+        // must not be flagged, with xcDiagnostics at its default (off).
+        let ok_src = "Rbc_ActiveLegend .g\nRbc_ZoomStack .g\n";
+        let diags = backend
+            .full_diagnostics_for(&uri, ok_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            !diag_codes(&diags).iter().any(|c| c == "W123"),
+            "a command the auto_path tclIndex provides must not be W123 (#832), got: {:?}",
+            diag_codes(&diags),
+        );
+
+        // TP control: a typo the index does not declare stays flagged.
+        let typo_src = "Rbc_ActveLegend .g\n";
+        let typo = backend
+            .full_diagnostics_for(&uri, typo_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            diag_codes(&typo).iter().any(|c| c == "W123"),
+            "a command no index provides must still be W123, got: {:?}",
+            diag_codes(&typo),
+        );
+
+        // FN-guard: with an EMPTY database the real command is unknowable ⇒ W123
+        // fires — suppression is driven by the database, not a name allowlist.
+        *backend.package_resolver.write().await = PackageResolver::new();
+        let empty = backend
+            .full_diagnostics_for(&uri, ok_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            diag_codes(&empty).iter().any(|c| c == "W123"),
+            "with no package database the command is genuinely unknown ⇒ W123, got: {:?}",
+            diag_codes(&empty),
+        );
+    }
+
+    /// Issue #832 secondary path: a `pkgIndex`-only package (no `tclIndex`) whose
+    /// implementation defines the command, made available to a sourced module by
+    /// an entry file's `package require`, suppresses the module's W123. The
+    /// package's source files are consulted through the analyser's
+    /// registry-driven definer walk (`proc` / `oo::class` / … from the command
+    /// registry's `SymbolDef`s), not a `proc`-name scan.
+    #[tokio::test]
+    async fn pkgindex_package_source_command_suppresses_w123() {
+        let backend = test_backend();
+        // A pkgIndex-only package whose source defines a global proc.
+        let ws = TmpWs::new("pkgsrc-w123");
+        ws.write(
+            "mylib/mylib.tcl",
+            "package provide mylib 1.0\nproc draw_widget {w} {}\n",
+        );
+        ws.write(
+            "mylib/pkgIndex.tcl",
+            "package ifneeded mylib 1.0 [list source [file join $dir mylib.tcl]]\n",
+        );
+        {
+            let mut resolver = PackageResolver::new();
+            resolver.scan_tree(&ws.0, 100);
+            *backend.package_resolver.write().await = resolver;
+        }
+        let util = Uri::from_file_path("/proj/lib/util.tcl").unwrap();
+        // The module calls `draw_widget` with no local `package require`.
+        let util_src = "draw_widget .w\n";
+
+        // Control (FN would be a bug here): without an entry file requiring mylib,
+        // the module inherits nothing, so `draw_widget` is genuinely unknown ⇒ W123.
+        let unrefined = backend
+            .full_diagnostics_for(&util, util_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            diag_codes(&unrefined).iter().any(|c| c == "W123"),
+            "without an inherited require the command is unknown ⇒ W123, got: {:?}",
+            diag_codes(&unrefined),
+        );
+
+        // Index an entry file that requires mylib and sources lib/util.tcl, so the
+        // module inherits the `mylib` require via the workspace `source` graph.
+        {
+            let mut a = tcl_compiler::analyser::Analyser::new();
+            let analysis = a
+                .analyse("package require mylib\nsource lib/util.tcl\n", "tcl8.6")
+                .clone();
+            let app = Uri::from_file_path("/proj/app.tcl").unwrap();
+            backend
+                .workspace_index
+                .write()
+                .await
+                .add_document(app.as_str(), &analysis);
+        }
+
+        // TN: the inherited `mylib` require makes `draw_widget` resolvable via the
+        // package's implementation source ⇒ the W123 is refined away.
+        let refined = backend
+            .full_diagnostics_for(&util, util_src.to_owned(), "tcl8.6".to_owned(), "tcl")
+            .await;
+        assert!(
+            !diag_codes(&refined).iter().any(|c| c == "W123"),
+            "an available package's source-defined command must not be W123, got: {:?}",
             diag_codes(&refined),
         );
     }

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -888,3 +888,78 @@ fn report_object_methods_have_no_unknown_command() {
         "report object methods resolve: {diags:?}"
     );
 }
+
+// -- Issue #832: command defined in an auto_path library ------------------
+// A command a `tclIndex` on the configured `libraryPaths` auto-loads (the
+// BLT/Rbc idiom: `Rbc_ZoomStack` / `Rbc_ActiveLegend`) must not be flagged
+// "Unknown command" (W123), end-to-end against the packaged server, with
+// `xcDiagnostics` left at its default (off).  The package database resolves the
+// command exactly as go-to-definition does; the diagnostic must agree.
+
+/// Per-call counter so repeat runs don't collide on the temp dir.
+static RBC_LIB_N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+#[test]
+fn autoload_library_command_not_unknown_issue_832() {
+    use std::sync::atomic::Ordering;
+
+    // A library dir with a `tclIndex` that auto-loads two global procs by bare
+    // name — no `package require` needed, the exact shape from the issue.
+    let libdir = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-rbc-{}-{}",
+        std::process::id(),
+        RBC_LIB_N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let pkgdir = libdir.join("rbc");
+    std::fs::create_dir_all(&pkgdir).expect("mk rbc lib dir");
+    std::fs::write(
+        pkgdir.join("graph.tcl"),
+        "proc Rbc_ActiveLegend {graph} {}\nproc Rbc_ZoomStack {graph args} {}\n",
+    )
+    .expect("write graph.tcl");
+    std::fs::write(
+        pkgdir.join("tclIndex"),
+        "# Tcl autoload index file, version 2.0\n\
+         set auto_index(Rbc_ActiveLegend) [list source [file join $dir graph.tcl]]\n\
+         set auto_index(Rbc_ZoomStack) [list source [file join $dir graph.tcl]]\n",
+    )
+    .expect("write tclIndex");
+
+    // Point the server's auto_path (`libraryPaths`) at the library's parent dir;
+    // `scan_path` descends into the `rbc/` subdir (C-Tcl auto_path rule) at
+    // startup, so its `tclIndex` enters the package database.
+    let mut lsp = Lsp::with_config(serde_json::json!({
+        "features": { "linkedEditingRange": true },
+        "libraryPaths": [ libdir.to_string_lossy() ],
+    }));
+
+    let uri = unique_uri("tcl");
+    let src = "Rbc_ActiveLegend .g\nRbc_ZoomStack .g\n";
+    lsp.open_document(&uri, src);
+
+    // The package database is (re)built asynchronously at startup; poll the
+    // deterministic pull path until it is live (W123 clears) or the deadline.
+    let mut diags = lsp.pull_diagnostics(&uri);
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while has_code(&diags, "W123") && std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+        diags = lsp.pull_diagnostics(&uri);
+    }
+    assert!(
+        !has_code(&diags, "W123"),
+        "auto_path library commands must not be W123 (#832), got: {:?}",
+        codes(&diags),
+    );
+
+    // Control: a typo the `tclIndex` does not declare still fires W123 — the
+    // database is loaded and the check is data-driven, not disabled wholesale.
+    let typo = unique_uri("tcl");
+    let tdiags = lsp.open_ready(&typo, "Rbc_ActveLegend .g\n");
+    assert!(
+        has_code(&tdiags, "W123"),
+        "a command no index declares must still be W123, got: {:?}",
+        codes(&tdiags),
+    );
+
+    let _ = std::fs::remove_dir_all(&libdir);
+}


### PR DESCRIPTION
## Summary

- Fixes #832: a command defined in a library reachable via `package require` / the `auto_path` (the BLT/Rbc `Rbc_ActiveLegend` idiom — auto-loaded by a `tclIndex` with no explicit `package require` in the caller) was flagged **"Unknown command" (W123)** even though the LSP resolves its definition and all references.
- **Root cause:** navigation resolves against the `WorkspaceIndex` / package database, but the W123 check was single-file plus an optional cross-file pass over the salsa `Project` gated behind `xcDiagnostics` (default off). The `PackageResolver` — which scans the `auto_path` and already knows every auto-loadable command name (`tclIndex`) — was wired only into W120, never W123.
- **Fix:** wire that authoritative, centralised package-database knowledge into the unknown-command decision, always on (like the existing W120 refinement), independent of `xcDiagnostics`:
  - `PackageResolver::auto_loads_command` — is a bare command resolvable via the scanned `auto_path` auto-load index? (`auto_qualify`-driven, **by name**.)
  - `PackageResolver::package_defined_commands` — commands an available package's source files define, extracted through an injected closure that runs the analyser's **registry `SymbolDef` walk** (`proc` / `oo::class` / `interp alias` / …), never a hard-coded `proc`-name scan.
  - `refine_workspace_w123` (server, push **and** pull paths) drops any W123 the package database can resolve, alongside the W120 refinement.
- The decision is entirely data-driven — the resolver is queried by the flagged name, never matched against a command allowlist, so nothing is encoded in the compiler/runtime stack. `FP.md` catalogue updated to record the workspace-level refinement. No new clippy allows.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-lsp-core --lib package_resolver     # resolver TP/FP/TN/FN oracles
cargo test -p tcl-lsp-core --lib                       # 858 passed
cargo test -p tcl-lsp-db --lib                         # 42 passed (cross-file W123 unchanged)
cargo test -p tcl-lsp-server --lib                     # 187 passed (push/pull suppression + controls)
cargo test -p tcl-lsp-server --test e2e                # 593 passed (incl. autoload_library_command_not_unknown_issue_832)
cargo clippy -p tcl-lsp-core -p tcl-lsp-server --all-targets -- -D warnings   # clean, no new allows
cargo fmt -p tcl-lsp-core -p tcl-lsp-server -- --check                        # clean
npx prettier --check src/test/diagnostics.test.ts                            # clean (editors/vscode)
```

Test coverage added:
- **TP/FP/TN/FN** unit tests for the resolver oracles (real command resolvable, typo not, namespace qualification honoured, package-source union).
- **Server** push/pull suppression tests for both the auto-load and pkgIndex-source paths, each with typo and empty-database controls proving the check is data-driven.
- **lsp_e2e** test against the packaged server binary (`libraryPaths` → `tclIndex`).
- **VS Code** integration test with a `tclIndex` fixture inside the workspace.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — **No.** The single-file analyser still emits W123 identically; the fix is a workspace-level LSP refinement layered on top (the diagnostic dual of go-to-definition), exactly like the existing W120 refinement. The FP.md `FP-NAB-11` verdict for the analyser stays TRUE POSITIVE, with a note added documenting the new server-level resolution.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — n/a (no contract change)
- [ ] If I added a new compiler KCS note, I linked it from both README files. — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MKmrptjmoz9GFHo2FsFVTt

---
_Generated by [Claude Code](https://claude.ai/code/session_01MKmrptjmoz9GFHo2FsFVTt)_