### PR TITLE
Fix #833: lower dict for/map bodies into the analysis CFG

### DIFF
--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -3458,6 +3458,66 @@ function ::f
 
 ---
 
+### FP-DS-10 — reads nested in a `dict for`/`dict map` body keep the store live (issue #833)
+
+- **Verdict:** FALSE POSITIVE (now fixed)
+- **Status:** locked in by `tcl-compiler/src/analyser/diagnostics/fp/ds.rs::fp_ds_10_*`
+- **Codes:** W220, W211
+- **Corpus:** any `dict for {k v} $d { … }` whose body reads an outer variable from
+  inside its own control flow — dispatch tables (`$cmd a $key` under an `if`),
+  guarded `puts $msg`, accumulators updated conditionally.
+
+#### Reproducer
+
+```tcl
+proc demo {} {
+    set x set
+    set d [dict create a true b false c true]
+    dict for {key value} $d {
+        if {$value} {
+            $x a $key
+        }
+    }
+}
+```
+
+#### Per-line reasoning
+
+1. `set x set` — assigns version 1 of `x`.
+2. `dict for {key value} $d { … }` — the body runs in the caller's frame.
+3. `if {$value} { $x a $key }` — `$x` is the **command name** of the dispatched
+   call, so it reads `x#1`; this keeps `set x set` alive.
+
+Pre-fix, `dict for`/`dict map` were re-emitted as an opaque `Barrier` in the
+analysis CFG and their body reads were recovered by a shallow word scan that only
+saw top-level `$var` / `[...]` tokens. A read one brace level deep — `$x` inside
+the `if` body — was invisible, so `set x set` looked like a dead store. The fix
+lowers the dict-for body into real CFG blocks in the analysis build (as `foreach`
+and `array for` already are), making body reads first-class SSA uses. Codegen
+keeps the byte-identical `::tcl::dict::for` barrier (built from the separate
+`build_cfg_codegen`), so emitted bytecode is unchanged.
+
+#### tclsh ground truth
+
+```
+% set x set; set d [dict create a true b false]; dict for {k v} $d { if {$v} { $x q $k } }; puts "q=$q"
+q=a
+```
+`$x` resolves to `set` at run time, so `x` is genuinely read.
+
+#### Tests
+
+- `fp_ds_10_command_name_read_in_dict_for_if_keeps_store_live` (FP — the issue repro)
+- `fp_ds_10_dict_map_variant_keeps_store_live` (FP — `dict map`)
+- `fp_ds_10_deeply_nested_read_keeps_store_live` (FP — two `if` levels deep)
+- `fp_ds_10_plain_var_read_in_dict_for_if_keeps_store_live` (FP — ordinary arg read)
+- `fp_ds_10_real_dead_store_before_dict_for_still_fires` (TP — real dead store outside body)
+- `fp_ds_10_dead_store_inside_dict_for_body_now_fires` (TP — precision gained inside the body)
+- `fp_ds_10_write_only_local_in_dict_for_body_still_flags` (FN guard — write-only local)
+- `fp_ds_10_clean_dict_for_is_silent` (TN control)
+
+---
+
 
 ## SH — shimmer (S100/S101/S102)
 

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -188,6 +188,35 @@ suite("Diagnostics", () => {
     }
   });
 
+  test("dict-for body nesting keeps reads alive but still catches real dead stores (#833)", async () => {
+    const uri = getDocUri("dict-for-nesting.tcl");
+    await activate(uri);
+    // The body-internal dead store yields exactly one W220, proving analysis ran
+    // AND that the analyser walked into the (now-lowered) dict-for body.
+    const diagnostics = await waitForDiagnostics(uri, { minCount: 1 });
+    const codeOf = (d: vscode.Diagnostic) => (typeof d.code === "object" ? d.code.value : d.code);
+    const codes = diagnostics.map(codeOf);
+
+    const w220 = diagnostics.filter((d) => codeOf(d) === "W220");
+    // The ONLY dead store is `set tmp 1` inside the second proc's body (line 18,
+    // 0-indexed). The `set x set` read via `$x a $key` nested in `if`/`dict for`
+    // must NOT be flagged.
+    assert.strictEqual(w220.length, 1, `expected one W220, got [${codes}]`);
+    assert.strictEqual(
+      w220[0].range.start.line,
+      18,
+      `W220 should anchor to the body-internal dead store, got line ${w220[0].range.start.line}`,
+    );
+    // No unused/dead-store hint on `x` (the command-name read keeps it live).
+    for (const d of diagnostics) {
+      const line = d.range.start.line;
+      assert.ok(
+        !((codeOf(d) === "W220" || codeOf(d) === "W211") && line === 6),
+        `unexpected ${codeOf(d)} on 'set x set' (it is read via $x) at line ${line}`,
+      );
+    }
+  });
+
   test("W100 fires inside a catch body (analyser recurses into catch)", async () => {
     const uri = getDocUri("catchBody.tcl");
     await activate(uri);

--- a/editors/vscode/testFixture/dict-for-nesting.tcl
+++ b/editors/vscode/testFixture/dict-for-nesting.tcl
@@ -1,0 +1,23 @@
+# Issue #833 regression fixture.
+#
+# Reads nested inside a `dict for` body must keep their feeding store live: here
+# `$x` is read as the command name of `$x a $key`, inside `if` inside `dict for`,
+# so `set x set` is NOT a dead store (no W220 / W211 on `x`).
+proc issue_833_clean {} {
+    set x set
+    dict for {key value} [dict create a true b false] {
+        if {$value} {
+            $x a $key
+        }
+    }
+}
+
+# A genuine dead store *inside* the (now-lowered) dict-for body still fires W220 —
+# which also proves the analyser walked into the body's own control flow.
+proc dict_for_body_dead_store {d} {
+    dict for {k v} $d {
+        set tmp 1
+        set tmp 2
+        puts $tmp
+    }
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/ds.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/ds.rs
@@ -388,3 +388,181 @@ fn fp_ds_09_interproc_mixed_callers_conservative_silent() {
         codes(src, D)
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-DS-10 — reads nested inside a `dict for`/`dict map` body keep the store
+//            live (issue #833)
+//
+// `dict for`/`dict map` run their body in the caller's frame, so the analysis
+// CFG now flattens the body into real loop blocks (like `foreach`) instead of
+// re-emitting it as an opaque barrier whose reads were recovered by a shallow
+// word scan.  That shallow scan only saw top-level `$var` / `[...]` tokens, so a
+// read one brace level deep — e.g. `$x` used as the command name of `$x a $key`
+// inside an `if` — was invisible, and the feeding `set x set` looked like a dead
+// store.  The fix makes such reads first-class SSA uses.
+// ---------------------------------------------------------------------------
+
+// The exact issue #833 reproducer: `$x` is read as the command name of the
+// dispatched call, nested inside `if {$value}` inside `dict for`.
+const FP_DS_10_REPRO: &str = "\
+proc demo {} {
+    set x set
+    set d [dict create a true b false c true]
+    dict for {key value} $d {
+        if {$value} {
+            $x a $key
+        }
+    }
+}
+";
+
+#[test]
+fn fp_ds_10_command_name_read_in_dict_for_if_keeps_store_live() {
+    // FP-DS-10: the command-name read of `x`, nested inside `if` inside
+    // `dict for`, must keep `set x set` alive — no W220 and no W211.
+    assert!(
+        !fires(FP_DS_10_REPRO, D, "W220"),
+        "FP-DS-10: nested command-name read must NOT fire W220; emitted: {:?}",
+        codes(FP_DS_10_REPRO, D)
+    );
+    assert!(
+        !fires(FP_DS_10_REPRO, D, "W211"),
+        "FP-DS-10: `x` is read, must NOT fire W211; emitted: {:?}",
+        codes(FP_DS_10_REPRO, D)
+    );
+}
+
+#[test]
+fn fp_ds_10_dict_map_variant_keeps_store_live() {
+    // FP-DS-10: `dict map` shares the same body-recovery path as `dict for`.
+    let src = "\
+proc demo {} {
+    set x set
+    set d [dict create a 1]
+    dict map {key value} $d { if {$value} { $x a $key } }
+}
+";
+    assert!(
+        !fires(src, D, "W220"),
+        "FP-DS-10: dict map nested read must NOT fire W220; emitted: {:?}",
+        codes(src, D)
+    );
+    assert!(!fires(src, D, "W211"), "emitted: {:?}", codes(src, D));
+}
+
+#[test]
+fn fp_ds_10_deeply_nested_read_keeps_store_live() {
+    // FP-DS-10: two brace levels of `if` deep inside `dict for` — the read must
+    // still reach the store through the body's own lowered control flow.
+    let src = "\
+proc demo {} {
+    set x set
+    set d [dict create a 1]
+    dict for {k v} $d {
+        if {$v} {
+            if {$k ne \"\"} {
+                $x a $k
+            }
+        }
+    }
+}
+";
+    assert!(
+        !fires(src, D, "W220"),
+        "FP-DS-10: doubly-nested read must NOT fire W220; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_10_plain_var_read_in_dict_for_if_keeps_store_live() {
+    // FP-DS-10: not just command-name reads — an ordinary `$msg` argument read
+    // nested inside `if` inside `dict for` must keep its store live too.
+    let src = "\
+proc demo {} {
+    set msg hello
+    set d [dict create a 1]
+    dict for {k v} $d {
+        if {$v} {
+            puts $msg
+        }
+    }
+}
+";
+    assert!(
+        !fires(src, D, "W220"),
+        "FP-DS-10: nested `$msg` read must NOT fire W220; emitted: {:?}",
+        codes(src, D)
+    );
+    assert!(!fires(src, D, "W211"), "emitted: {:?}", codes(src, D));
+}
+
+#[test]
+fn fp_ds_10_real_dead_store_before_dict_for_still_fires() {
+    // TP control: `set x set` is overwritten by `set x puts` before any read, so
+    // it is a genuine dead store even though a `dict for` uses the live version.
+    // Flattening the body must not mask a real dead store outside it.
+    let src = "\
+proc demo {d} {
+    set x set
+    set x puts
+    dict for {k v} $d { $x $k }
+}
+";
+    assert!(
+        fires(src, D, "W220"),
+        "FP-DS-10 TP: real dead store must still fire W220; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_10_dead_store_inside_dict_for_body_now_fires() {
+    // TP control (precision gained by the fix): a dead store *inside* the body
+    // was invisible while the body was an opaque barrier; now that the body is
+    // lowered it is a real W220.
+    let src = "\
+proc demo {d} {
+    dict for {k v} $d {
+        set tmp 1
+        set tmp 2
+        puts $tmp
+    }
+}
+";
+    assert!(
+        fires(src, D, "W220"),
+        "FP-DS-10 TP: dead store inside a dict-for body must fire W220; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_10_write_only_local_in_dict_for_body_still_flags() {
+    // FN guard: a local written but never read inside the body must still be
+    // reported — the fix must not manufacture a phantom read that hides it.
+    let src = "\
+proc demo {d} {
+    dict for {k v} $d {
+        set unusedvar 1
+        puts $k
+    }
+}
+";
+    assert!(
+        fires(src, D, "W220") || fires(src, D, "W211"),
+        "FP-DS-10 FN guard: write-only body local must still flag; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_10_clean_dict_for_is_silent() {
+    // TN control: a clean `dict for` that only reads its loop vars is silent.
+    let src = "proc demo {d} { dict for {k v} $d { puts \"$k=$v\" } }";
+    assert!(
+        codes(src, D).iter().all(|c| c != "W220" && c != "W211"),
+        "FP-DS-10 TN: clean dict for must not fire W220/W211; emitted: {:?}",
+        codes(src, D)
+    );
+}

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -853,6 +853,19 @@ impl CfgBuilder {
         }
 
         if *is_dict_iteration && !raw_args.is_empty() {
+            // `dict for`/`dict map {k v} $d body`: the body runs in the caller's
+            // frame, so the analysis CFG inlines it (shared reaching-defs / const
+            // lattice, loop vars bound, and — crucially — the body's *own* control
+            // flow lowered into real blocks, so a read nested inside an `if` /
+            // `while` / `catch` body is a first-class SSA use). Codegen barriers it
+            // to the `::tcl::dict::for`/`::tcl::dict::map` ensemble invoke below,
+            // keeping the emitted bytecode byte-identical to C Tcl. Mirrors the
+            // `array for` split above. Without the inlined body, a command-name or
+            // brace-nested `$var` read the shallow barrier-word scan can't see is
+            // lost, so the loop's outer reads look dead (issue #833).
+            if self.faithful_exceptions {
+                return self.lower_foreach(stmt, current);
+            }
             let sub = &raw_args[0];
             let qual_cmd = format!("::tcl::dict::{sub}");
             // The barrier re-emits `::tcl::dict::for {vars} $dict {body}` — the

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -1068,8 +1068,9 @@ mod unused_proc_parameters {
 
     #[test]
     fn param_used_in_dict_for_and_dict_map_bodies() {
-        // dict for/map lower to opaque ::tcl::dict::for|map barriers; the deep
-        // body scan must still see the param read (#236).
+        // dict for/map bodies are lowered into real CFG blocks in the analysis
+        // build (#833), so a param read nested in the body is a first-class SSA
+        // use — the deep body scan / text fallback (#236) is now belt-and-braces.
         let used = [
             "proc f {but} {\n    dict for {k v} $d {\n        if {$but ne \"\"} { puts $but }\n    }\n}\n",
             "proc f {scale} {\n    dict map {k v} $d { expr {$v * $scale} }\n}\n",

--- a/rust/tcl-compiler/tests/codegen.rs
+++ b/rust/tcl-compiler/tests/codegen.rs
@@ -1212,17 +1212,44 @@ fn foreach_creates_loop_cfg() {
 }
 
 #[test]
-fn dict_for_becomes_barrier() {
+fn dict_for_lowers_to_loop_cfg_for_analysis_but_barriers_for_codegen() {
+    // `dict for`'s body runs in the caller's frame, so the *analysis* CFG
+    // (`build_cfg`, faithful_exceptions on) flattens it into a foreach-style
+    // header→body→end loop — like `foreach_creates_loop_cfg` above — so the
+    // body's reads/writes and its own control flow are first-class SSA (a read
+    // nested inside an `if` in the body is no longer lost — issue #833). The
+    // *codegen* CFG (`build_cfg_codegen`, faithful off) keeps the opaque
+    // `::tcl::dict::for` barrier the inline `emit_dict_for` compiles, so the
+    // emitted bytecode stays byte-identical to C Tcl. Mirrors `array for`.
     let src = "proc dict_iter {d} { dict for {k v} $d { puts \"$k: $v\" } }";
     let ir = ir_for(src);
-    let cfg = build_cfg(&ir, false);
-    let proc_cfg = &cfg.procedures["::dict_iter"];
-    let has_barrier = proc_cfg.blocks.values().any(|b| {
+
+    // Analysis CFG: real loop blocks, no dict-for barrier.
+    let analysis = build_cfg(&ir, false);
+    let a_cfg = &analysis.procedures["::dict_iter"];
+    let names = a_cfg.block_names();
+    assert!(
+        names.iter().any(|n| n.contains("foreach_header")),
+        "analysis CFG should flatten dict for into a loop; got {names:?}"
+    );
+    assert!(names.iter().any(|n| n.contains("foreach_body")));
+    assert!(names.iter().any(|n| n.contains("foreach_end")));
+    assert!(
+        !a_cfg.blocks.values().any(|b| b.statements.iter().any(
+            |s| matches!(s, Statement::Barrier { reason, .. } if reason.contains("dict for"))
+        )),
+        "analysis CFG should not keep a dict-for barrier"
+    );
+
+    // Codegen CFG: the opaque `::tcl::dict::for` barrier is preserved.
+    let codegen = build_cfg_codegen(&ir, false);
+    let c_cfg = &codegen.procedures["::dict_iter"];
+    let has_barrier = c_cfg.blocks.values().any(|b| {
         b.statements
             .iter()
             .any(|s| matches!(s, Statement::Barrier { reason, .. } if reason.contains("dict for")))
     });
-    assert!(has_barrier);
+    assert!(has_barrier, "codegen CFG must keep the dict-for barrier");
 }
 
 // ═══════════════════════════════════════════════════════════════════

--- a/rust/tcl-compiler/tests/core_analyses.rs
+++ b/rust/tcl-compiler/tests/core_analyses.rs
@@ -942,16 +942,16 @@ mod no_read_before_set {
     }
 
     #[test]
-    fn dict_for_body_local_set_diverges() {
-        // The analyser does not recover a body-local `set fileData $k` inside the
-        // opaque `dict for` barrier, so the following `$fileData` read is flagged
-        // (W210). In Tcl the body's `set` definitely defines fileData before the
-        // read, so the read is actually safe — a sound over-warn, asserted at the
-        // actual verdict.
+    fn dict_for_body_local_set_recovered() {
+        // `dict for`/`dict map` bodies are now lowered into real CFG blocks in
+        // the analysis build (issue #833), so a body-local `set fileData $k`
+        // definitely defines `fileData` before the following `$fileData` read —
+        // no W210. (Previously the opaque barrier hid the body-local set and this
+        // safe read was a false positive.)
         let src = "proc p {} {\n    dict for {k v} {a 1 b 2} {\n        set fileData $k\n        puts $fileData\n    }\n}\n";
         assert!(
-            fires(src, "W210"),
-            "Rust flags the body-local set inside `dict for`"
+            !fires(src, "W210"),
+            "body-local set inside `dict for` must define fileData before the read"
         );
     }
 
@@ -964,14 +964,14 @@ mod no_read_before_set {
     }
 
     #[test]
-    fn dict_map_body_local_set_diverges() {
-        // `dict map` is the lmap analogue — same body-recovery gap as
-        // `dict_for_body_local_set_diverges`. The analyser flags the body-local
-        // `set out $k`'s read (W210) though it is in fact safe. Sound over-warn.
+    fn dict_map_body_local_set_recovered() {
+        // `dict map` is the lmap analogue — same body recovery as
+        // `dict_for_body_local_set_recovered` (issue #833). The body-local
+        // `set out $k` defines `out` before the `list $out` read, so no W210.
         let src = "proc p {} {\n    dict map {k v} {a 1 b 2} {\n        set out $k\n        list $out\n    }\n}\n";
         assert!(
-            fires(src, "W210"),
-            "Rust flags the body-local set inside `dict map`"
+            !fires(src, "W210"),
+            "body-local set inside `dict map` must define out before the read"
         );
     }
 

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -267,6 +267,31 @@ fn w220_silent_when_value_is_read_between() {
     assert!(!has_code(&lsp.open_ready(&uri, src), "W220"));
 }
 
+#[test]
+fn w220_silent_for_command_name_read_nested_in_dict_for_if() {
+    // Issue #833: `$x` is read as the command name of `$x a $key`, nested inside
+    // `if {$value}` inside `dict for`. Before dict-for bodies were lowered into
+    // real CFG blocks, that read was invisible and `set x set` false-fired W220.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc demo {} {\n    set x set\n    set d [dict create a true b false c true]\n    dict for {key value} $d {\n        if {$value} {\n            $x a $key\n        }\n    }\n}\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(!has_code(&diags, "W220"), "{:?}", codes(&diags));
+    assert!(!has_code(&diags, "W211"), "{:?}", codes(&diags));
+}
+
+#[test]
+fn w220_dead_store_inside_dict_for_body_fires() {
+    // Precision gained by #833's fix: a dead store *inside* the (now lowered)
+    // dict-for body is a real W220 — it was invisible while the body was opaque.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc demo {d} {\n    dict for {k v} $d {\n        set tmp 1\n        set tmp 2\n        puts $tmp\n    }\n}\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(has_code(&diags, "W220"), "{:?}", codes(&diags));
+    assert!(on_line(&diags, "W220").contains(&2));
+}
+
 // -- Clean code stays clean (cross-family negative control) --------------
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes #833: a W220 "Assignment to 'x' is never read" false positive when a variable is read *inside* a `dict for`/`dict map` body — e.g. `$x` used as the command name of `$x a $key`, nested inside `if` inside `dict for`.
- **Root cause:** `dict for`/`dict map` lower to `Statement::Foreach { is_dict_iteration: true, body: <lowered Script> }`, but the CFG builder re-emitted them as an opaque `Statement::Barrier` in *both* the analysis and codegen CFGs, discarding the lowered body. The barrier's reads were then recovered by a shallow `scan_word` that only sees top-level `$var` / `[...]` tokens and cannot descend into a braced `{…}` sub-script (the `if` body). So `$x`, one brace level deep, never became an SSA use, and the feeding `set x set` looked like a dead store. `dict for` alone (read at the body's surface) and `if` alone (real CFG blocks) both worked — only the combination lost the read.
- **Fix:** mirror the existing `array for` split — in the analysis build (`faithful_exceptions`), lower the dict-iteration `Foreach` into real header/body/end CFG blocks via `lower_foreach`, so the body's own control flow, reads, writes, phis and liveness become first-class SSA. The codegen build (`build_cfg_codegen`, faithful off) keeps the byte-identical `::tcl::dict::for`/`::tcl::dict::map` barrier that `emit_dict_for` compiles, so emitted bytecode is unchanged.
- The change is structure-driven, not a command-name match in the CFG builder (dict iteration is recognised via the existing `is_dict_iteration` lowering). It fixes the whole class of dict-for-body analysis gaps (W220/W211/W210) uniformly, makes dict-for body diagnostics consistent with `foreach`, and *gains* precision the barrier hid: a dead store **inside** a dict-for body is now detected.
- Net diff: one behavioural line (+ comment) in `cfg_builder`; the rest is tests and docs.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-compiler          # all pass (incl. new FP-DS-10; rewrote dict_for_becomes_barrier)
cargo test -p tcl-lsp-core -p tcl-cli
cargo test -p tcl-vm                # codegen unchanged (build_cfg_codegen path)
cargo test -p tcl-lsp-server --test e2e   # 594 pass, incl. new W220 dict-for tests
cargo clippy -p tcl-compiler --all-targets   # clean, no new allows
cargo fmt -p tcl-compiler -p tcl-lsp-server --check
cargo build --workspace
./target/debug/tcl diag repro.tcl   # issue repro now emits 0 diagnostics
```

Tests added:
- `tcl-compiler` FP-DS-10 (`analyser/diagnostics/fp/ds.rs`): TP/FP/TN/FN — command-name reads, `dict map`, deep nesting, plain-arg reads, real dead stores inside/outside the body, write-only body local, clean control.
- `tcl-lsp-server` e2e (`tests/e2e/diagnostics.rs`): the issue repro is silent through the server pipeline; a body-internal dead store still fires.
- vscode (`src/test/diagnostics.test.ts` + `testFixture/dict-for-nesting.tcl`).
- Rewrote `dict_for_becomes_barrier` → `dict_for_lowers_to_loop_cfg_for_analysis_but_barriers_for_codegen` to pin the analysis-vs-codegen split.
- `docs/design/compiler/FP.md`: FP-DS-10 catalogue entry.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **No** — it fixes a false positive within the existing W220 dead-store contract; the analysis-CFG shape for dict-for is an internal detail, not a documented KCS fact. `dict for` semantics in `docs/kcs/kcs-tcl-corner-cases.md` (iterates pairs as `k`/`v` locals) remain accurate.
- [x] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. **N/A**
- [x] If I added a new compiler KCS note, I linked it from both READMEs. **N/A** — no new KCS note; the FP catalogue entry lives in `docs/design/compiler/FP.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014CKxLjPnmQqJ1PFmRchg7E)_