### PR TITLE
Fix #837 + make command-prefix callbacks first-class (references, arity, call-graph, cross-file)

### DIFF
--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -825,12 +825,31 @@ function ::f
   `bgerror` (≥1), `namespace unknown` (≥1), `package unknown` (≥1),
   `regsub -command` (≥1, 9.0+), `coroinject` / `coroprobe` (Unknown),
   `chan create` / `chan push` reflected-channel handlers (≥2).
-- **tcllib:** `struct::list filter/map/fold/split` (1/1/2/1), `fileutil::find`
-  (1), the `generator` functional ensemble (16 ops — Unknown, multi-value
-  yield), `math::calculus` / `::optimize` / `::probopt` `func` callbacks (fixed,
-  man-page-pinned — via `math_ext::PREFIX_OVERRIDES`), `log::lvCmd` /
-  `lvCmdForall` (2), `uevent::bind` (≥2), `logger::walk` (Unknown),
-  `tcltest::customMatch` (2), `tk selection handle` (2).
+- **tcllib (positional prefixes):** `struct::list filter/map/fold/split`
+  (1/1/2/1), `fileutil::find` (1), the `generator` functional ensemble (16 ops —
+  Unknown, multi-value yield), `math::calculus` / `::optimize` / `::probopt`
+  `func` callbacks (fixed, man-page-pinned — via `math_ext::PREFIX_OVERRIDES`),
+  `log::lvCmd` / `lvCmdForall` (2), `uevent::bind` (≥2), `logger::walk`
+  (Unknown), `tcltest::customMatch` (2), `tk selection handle` (2),
+  `hook bind` (Unknown — resolver names the binding only in the 4-word set form).
+- **tcllib (option-value prefixes — the value of a named `-flag`, via
+  `OptionSpec`):** `mime::getbody -command` (≥1 — `uplevel` re-splits the reason
+  list), `smtp::sendmessage -tlspolicy` (2), `comm::comm send -command` (14 —
+  seven `-key value` reply pairs), `bibtex::parse -command` /
+  `-preamble/-string/-comment/-progresscommand` (2) / `-recordcommand` (4),
+  `tcl::chan::halfpipe -write-command` (2) / `-empty/-close-command` (1).  All
+  ground-truthed against tcllib source and re-run in tclsh; the option-value
+  path unions through `push_command_prefix_options` → `command_prefixes` with no
+  compiler change.
+- **Object-instance methods (via `ObjectClassSpec`):** `struct::graph`'s
+  `$g walk … -command cb` (3 — action graphName node, option-value) and
+  `struct::tree`'s `$t walkproc … cb` (3 — tree node action, trailing
+  positional).  The receiver's class comes from the analyser's `instance_classes`
+  map (`struct::graph name` or `set g [struct::graph]`); the compiler's
+  `record_command_prefix_invocations` resolves the method's prefixes via
+  `CommandRegistry::instance_method_command_prefixes`.  Correctness (W123 /
+  arity / references / not-dead) rides on the foreground invocation record.
+  `struct::tree walk`'s loop-variable *script* is not a prefix and is unmodelled.
 - **Tk (`script()`→`command_prefix` conversion — separate commit):**
   `-xscrollcommand`/`-yscrollcommand` on 8 widgets (2), `scale`/`ttk::scale
   -command` (1), `scrollbar -command` (≥2), `menu -tearoffcommand` (2).  This is
@@ -844,14 +863,18 @@ function ::f
   `-validatecommand`, `-invalidcommand` (percent-substitution, not appended
   args); the 4 macOS-only file/message-dialog `-command`s stay
   `command_prefix(Unknown)` (inert cross-platform ⇒ no arity check).
-- **Deferred (documented, not gaps):** option-value callbacks that need a full
-  `OptionSpec` array not yet modelled (`mime::getbody -command`,
-  `comm send -command`, `smtp -tlspolicy`, `bibtex -*command`,
-  `tcl::chan::halfpipe`) — allowlisted in
-  `commands_naming_a_cmdprefix_declare_a_command_prefix`; ambiguous
-  script-vs-prefix cases (`processman::onexit`, `hook bind`); and object-instance
-  method callbacks (`struct::graph`/`::tree` `$obj walk -command`) which require an
-  `ObjectClassSpec`, not a `command_prefixes` entry.
+- **Resolved script-vs-prefix:** `hook bind`'s binding is a command prefix (in
+  the tcllib list above); `processman::onexit id cmd` is instead a deferred
+  *script* (`eval $cmd`, 0 appended), modelled `ArgRole::Body` +
+  `BodyKind::Structural` — its `{…}` recurses for W123 / references but it is
+  deliberately **not** a command prefix.
+- **Remaining (documented, not gaps):** for an object-instance method callback
+  only, the call-graph *visualisation* edge and cross-file (signature-scan)
+  references still need object-type tracking threaded into the interprocedural /
+  walker passes — single-file correctness (W123 / arity / references /
+  not-dead-code) already holds via the foreground invocation record.  The
+  `cmdprefix` drift guard's allowlist (`commands_naming_a_cmdprefix_declare_a_command_prefix`)
+  is now **empty** — every synopsis that names a `cmdprefix` declares a prefix.
 
 #### Reproducer
 
@@ -915,6 +938,23 @@ all-optional-tail proc draws no arity error; a tail also claimed by a non-proc
   `tk_scroll_callback_braced_widget_path_does_not_fire_w123` (FP removed) /
   `tk_scroll_callback_bareword_undefined_head_fires_w123` (TP now caught)
 - `tcl-lsp-db::callback_arity_tk_scale_command_arity_checked` (Tk callback arity TP/TN)
+- `tcl-registry::command_prefixes_cover_option_value_callbacks` (mime/smtp/comm/
+  bibtex/halfpipe option-value prefixes — index + arity) + the `?…?`-stripping
+  drift guard that now validates them
+- `command_prefix_integration.rs::mime_getbody_command_option_is_a_callback_edge` /
+  `smtp_tlspolicy_option_fires_w123_only_when_unknown` /
+  `bibtex_recordcommand_option_is_a_callback_edge` /
+  `halfpipe_write_command_option_records_callback` (option-value TP)
+- `tcl-lsp-db::callback_arity_option_value_exactly_checked` /
+  `_mime_getbody_command_atleast_one` (option-value arity TP/TN + FP guards)
+- `command_prefix_integration.rs::hook_bind_binding_is_a_callback_edge` /
+  `hook_bind_query_form_is_not_a_callback` (resolver-driven prefix TP + FP guard) /
+  `processman_onexit_script_body_is_recursed_not_a_prefix` (script, not prefix)
+- `tcl-registry::instance_method_command_prefixes_cover_struct_graph_and_tree` +
+  `command_prefix_integration.rs::struct_graph_walk_command_records_callback_with_arity` /
+  `struct_graph_walk_command_var_handle_fires_w123_only_when_unknown` /
+  `struct_tree_walkproc_trailing_prefix_is_recorded` (object-instance methods) +
+  `tcl-lsp-db::callback_arity_struct_graph_walk_command_checked` / `_tree_walkproc_checked`
 
 ---
 

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -847,9 +847,33 @@ function ::f
   positional).  The receiver's class comes from the analyser's `instance_classes`
   map (`struct::graph name` or `set g [struct::graph]`); the compiler's
   `record_command_prefix_invocations` resolves the method's prefixes via
-  `CommandRegistry::instance_method_command_prefixes`.  Correctness (W123 /
-  arity / references / not-dead) rides on the foreground invocation record.
+  `CommandRegistry::instance_method_command_prefixes`.  This lights up W123 /
+  arity / references / call-graph edge / not-dead across **both** the whole-file
+  and the incremental/project paths (see the two follow-ups below).
   `struct::tree walk`'s loop-variable *script* is not a prefix and is unmodelled.
+- **Instance-method callbacks in the call graph + cross-file (the "long tail of
+  the long tail"):** two passes beyond the foreground analyser were taught the
+  receiver's object type, keyed off `object_types::object_handle_classes` — now
+  extended to harvest registry naming-factories (`struct::graph g` /
+  `set g [struct::graph]`) alongside its `[Class new]` + SSA/VTA signals:
+  (a) the **interprocedural** call-graph pass threads that map into
+  `scan_call_facts`, so an in-proc `$g walk … -command cb` becomes a real
+  `direct_calls` edge (call graph, O124 not-dead, purity/effects) — not just a
+  reference; (b) the **incremental per-item firewall** now binds registry
+  object-factories *eagerly* in an isolated proc body (they resolve from the
+  registry alone, no `all_classes`), where the old defer-to-graft left
+  `instance_classes` empty during the body's own callback recording — so an
+  in-proc instance callback resolves cross-file (arity + references) via
+  `project_diagnostics`, matching the whole-file walk.  (The
+  `signature_scan` walker, despite its name, indexes only class/proc
+  *definitions* — its `command_invocations` are unused for references, which come
+  from the foreground path — so it needs no object typing.)  The `OBJECT(class)`
+  typing is kept out of the SSA lattice's `return_type_for_command` on purpose:
+  W307/W308 aggregate `fu.types` object-insensitively across procs, so a
+  lattice-typed factory would leak a handle's class between same-named vars
+  (FP-OBJ-04).  Consequently object-flow through aliasing/collections is
+  syntactic-only for these factories (direct `struct::graph g` / `set g […]`
+  handles), not full VTA.
 - **Tk (`script()`→`command_prefix` conversion — separate commit):**
   `-xscrollcommand`/`-yscrollcommand` on 8 widgets (2), `scale`/`ttk::scale
   -command` (1), `scrollbar -command` (≥2), `menu -tearoffcommand` (2).  This is
@@ -868,13 +892,9 @@ function ::f
   *script* (`eval $cmd`, 0 appended), modelled `ArgRole::Body` +
   `BodyKind::Structural` — its `{…}` recurses for W123 / references but it is
   deliberately **not** a command prefix.
-- **Remaining (documented, not gaps):** for an object-instance method callback
-  only, the call-graph *visualisation* edge and cross-file (signature-scan)
-  references still need object-type tracking threaded into the interprocedural /
-  walker passes — single-file correctness (W123 / arity / references /
-  not-dead-code) already holds via the foreground invocation record.  The
-  `cmdprefix` drift guard's allowlist (`commands_naming_a_cmdprefix_declare_a_command_prefix`)
-  is now **empty** — every synopsis that names a `cmdprefix` declares a prefix.
+- **Drift guard:** the `cmdprefix` allowlist
+  (`commands_naming_a_cmdprefix_declare_a_command_prefix`) is now **empty** —
+  every synopsis that names a `cmdprefix` declares a prefix.
 
 #### Reproducer
 
@@ -953,8 +973,14 @@ all-optional-tail proc draws no arity error; a tail also claimed by a non-proc
 - `tcl-registry::instance_method_command_prefixes_cover_struct_graph_and_tree` +
   `command_prefix_integration.rs::struct_graph_walk_command_records_callback_with_arity` /
   `struct_graph_walk_command_var_handle_fires_w123_only_when_unknown` /
-  `struct_tree_walkproc_trailing_prefix_is_recorded` (object-instance methods) +
+  `struct_tree_walkproc_trailing_prefix_is_recorded` (object-instance methods —
+  now also asserting the call-graph edge) +
   `tcl-lsp-db::callback_arity_struct_graph_walk_command_checked` / `_tree_walkproc_checked`
+- `tcl-compiler::object_types::registry_naming_factory_handles` (object-handle map
+  covers `struct::graph`/`::tree` naming + return forms) +
+  `interprocedural::instance_method_callback_is_a_direct_call` (IPC call-graph edge) +
+  `tcl-lsp-db::cross_file_in_proc_instance_method_callback_arity` (the per-item
+  firewall fix — an in-proc instance callback resolves cross-file)
 
 ---
 

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -3533,6 +3533,61 @@ q=a
 
 ---
 
+### FP-DS-11 — an `uplevel` body runs in another stack frame (issue #837)
+
+- **Verdict:** FALSE POSITIVE guard + frame-aware precision (TP)
+- **Status:** locked in by `tcl-compiler/src/analyser/diagnostics/fp/ds.rs::fp_ds_11_*`
+  (and the W105 consistency arm in `fp/sty.rs::fp_sty_14_uplevel_body_participates_in_w105_like_eval`)
+- **Codes:** W220, W211, W105
+- **Corpus:** any proc that runs caller-context code via `uplevel ?level? {body}` —
+  DSL helpers, `namespace forget`/`namespace import` shims, option-setter idioms.
+
+#### Reproducer
+
+```tcl
+proc forgetXyce {} {
+    # Forgets all '::SpiceGenTcl::Xyce' commands from caller namespace
+    uplevel 1 {foreach nameSpc [namespace children ::SpiceGenTcl::Xyce] {
+        namespace forget ${nameSpc}::*
+    }}
+}
+```
+
+#### Per-line reasoning
+
+`uplevel`'s script word now carries an `ArgRole::Body` (a registry-driven
+`arg_role_resolver` that skips an optional leading `level` word), so the body is
+recursed and highlighted/analysed like every other script body instead of being
+rendered as one opaque string (the original issue #837 symptom — no highlighting
+inside the `uplevel` body). The spec is `BodyKind::Structural`: the body runs in
+the frame named by `level`, so a `$var` read inside a **braced** body resolves
+against *that* frame and does not count as a use of an enclosing-proc local of the
+same name. A value substituted at the enclosing level (`[list …]`, a quoted body,
+or a plain local read) is evaluated in the enclosing frame and keeps the local
+live.
+
+#### tclsh ground truth
+
+```
+% proc f {} { set x 1; uplevel 1 {puts $x} }
+% set x outer; f
+outer
+```
+`uplevel 1 {puts $x}` prints the *caller's* `x` (`outer`), never `f`'s local
+`x`, so `set x 1` inside `f` is genuinely a dead store.
+
+#### Tests
+
+- `fp_ds_11_caller_frame_write_is_not_an_enclosing_dead_store` (FP/TN)
+- `fp_ds_11_list_substituted_read_keeps_enclosing_store_live` (FP — `[list]` body)
+- `fp_ds_11_local_read_keeps_store_live_alongside_uplevel` (FP — local read)
+- `fp_ds_11_braced_body_only_read_is_a_frame_shifted_dead_store` (TP — frame-aware precision)
+- `fp_ds_11_real_dead_store_outside_uplevel_still_fires` (TP — enclosing analysis intact)
+- `fp_ds_11_clean_uplevel_body_is_silent` (TN control)
+- `fp_sty_14_uplevel_body_participates_in_w105_like_eval` (TP/FP — unbraced-body W105 parity with `eval`)
+
+---
+
 
 ## SH — shimmer (S100/S101/S102)
 

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -809,6 +809,63 @@ function ::f
 
 ---
 
+### FP-NAB-13 — command-prefix callbacks are first-class command references (TP)
+
+- **Verdict:** TRUE POSITIVE (precision gain) with literal-only FP guards
+- **Status:** locked in by `tcl-lsp-core/tests/command_prefix_integration.rs` +
+  `tcl-lsp-db/src/lib.rs::callback_arity_*` + `tcl-registry` `command_prefixes_*`
+- **Codes:** W123 (unknown callback), E002/E003 (callback arity)
+- **Corpus:** any `ArgRole::CommandPrefix` callback — `lsort -command`, `trace
+  add … cb`, `socket -server`, `interp alias`, `struct::list map/filter/fold`, …
+
+#### Reproducer
+
+```tcl
+proc myCompare {a b} { expr {$a - $b} }
+lsort -command myCompare $items      ;# reference + arity-checked (2 appended)
+lsort -command typoCmp   $items      ;# W123: unknown command 'typoCmp'
+proc oneArg {a} { return 0 }
+lsort -command oneArg    $items      ;# E003: too many (2 appended, max 1)
+```
+
+#### Per-line reasoning
+
+A command prefix's first word is a command **reference**, not a script or opaque
+value. The registry owns which arguments are prefixes and how many args the
+command appends to them (`CommandRegistry::command_prefixes` → `(index,
+AppendedArity)`, ground-truthed vs C Tcl 9.0). The head is recorded as a
+`command_invocations` entry (feeding find-references, rename, call-hierarchy,
+code-lens, and W123) and as a `ProcSummary.direct_calls` edge (feeding the call
+graph and O124 dead-code), so a callback-only proc is not "unused" and a typo'd
+callback name draws W123. The callback's arity is validated against the
+referenced proc, reusing the cross-file `E002`/`E003` path.
+
+**FP guards (all verified):** only a **literal bareword** head is recorded — a
+dynamic `$cb` / `[gen]` head is skipped (no W123 false-fire, no bogus edge);
+`AppendedArity::Unknown`/`AtLeast` never fire "too few"; an `args`-catch-all or
+all-optional-tail proc draws no arity error; a tail also claimed by a non-proc
+(class/alias/ensemble) is arity-less.
+
+#### tclsh ground truth
+
+```
+% proc cb {a b} {}; lsort -command cb {2 1}     ;# cb called as `cb 2 1` → 2 args
+```
+`lsort -command` appends exactly 2; `trace add variable` 3; `socket -server` 3
+— the arities the registry declares.
+
+#### Tests
+
+- `command_prefix_integration.rs::call_graph_has_callback_edge` (TP — edge)
+- `command_prefix_integration.rs::find_references_includes_callback_site` (TP)
+- `command_prefix_integration.rs::w123_fires_on_unknown_callback_but_not_a_defined_one` (TP + TN)
+- `command_prefix_integration.rs::dynamic_callback_head_is_not_recorded` (FP guard)
+- `tcl-lsp-db::callback_arity_mismatch_draws_e002` / `_too_many_draws_e003` (TP)
+- `tcl-lsp-db::callback_arity_correct_is_silent` / `_args_catchall_is_silent` /
+  `_atleast_does_not_false_fire_too_few` (TN / FP guards)
+
+---
+
 ## RBS — read-before-set (W210/W213/W214)
 
 W210 (read-before-set), W213 (`unset` on possibly-unset var, derives from RBS),

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -818,6 +818,28 @@ function ::f
 - **Corpus:** any `ArgRole::CommandPrefix` callback — `lsort -command`, `trace
   add … cb`, `socket -server`, `interp alias`, `struct::list map/filter/fold`, …
 
+#### Registry coverage (ground truth: C Tcl 9.0 / package man pages)
+
+- **Core Tcl:** `lsort -command` (2), `socket -server` (3), `trace add
+  variable` (3) / `command` (3) / `execution` (≥2), `interp alias` (≥0) /
+  `bgerror` (≥1), `namespace unknown` (≥1), `package unknown` (≥1),
+  `regsub -command` (≥1, 9.0+), `coroinject` / `coroprobe` (Unknown),
+  `chan create` / `chan push` reflected-channel handlers (≥2).
+- **tcllib:** `struct::list filter/map/fold/split` (1/1/2/1), `fileutil::find`
+  (1), the `generator` functional ensemble (16 ops — Unknown, multi-value
+  yield), `math::calculus` / `::optimize` / `::probopt` `func` callbacks (fixed,
+  man-page-pinned — via `math_ext::PREFIX_OVERRIDES`), `log::lvCmd` /
+  `lvCmdForall` (2), `uevent::bind` (≥2), `logger::walk` (Unknown),
+  `tcltest::customMatch` (2), `tk selection handle` (2).
+- **Deferred (documented, not gaps):** option-value callbacks that need a full
+  `OptionSpec` array not yet modelled (`mime::getbody -command`,
+  `comm send -command`, `smtp -tlspolicy`, `bibtex -*command`,
+  `tcl::chan::halfpipe`) — allowlisted in
+  `commands_naming_a_cmdprefix_declare_a_command_prefix`; ambiguous
+  script-vs-prefix cases (`processman::onexit`, `hook bind`); and object-instance
+  method callbacks (`struct::graph`/`::tree` `$obj walk -command`) which require an
+  `ObjectClassSpec`, not a `command_prefixes` entry.
+
 #### Reproducer
 
 ```tcl
@@ -863,6 +885,17 @@ all-optional-tail proc draws no arity error; a tail also claimed by a non-proc
 - `tcl-lsp-db::callback_arity_mismatch_draws_e002` / `_too_many_draws_e003` (TP)
 - `tcl-lsp-db::callback_arity_correct_is_silent` / `_args_catchall_is_silent` /
   `_atleast_does_not_false_fire_too_few` (TN / FP guards)
+- `command_prefix_integration.rs::namespace_unknown_handler_is_a_callback_edge` /
+  `regsub_command_prefix_fires_w123_only_when_unknown` /
+  `coroinject_records_reference_but_never_arity_checks` (deferred core commands)
+- `command_prefix_integration.rs::tcllib_struct_list_split_is_a_callback_edge` /
+  `tcllib_calculus_func_records_reference_with_fixed_arity` (tcllib)
+- `tcl-lsp-db::callback_arity_namespace_unknown_zero_param_draws_e003` /
+  `_package_unknown_variadic_handler_is_silent` / `_unknown_appended_never_fires` /
+  `_tcllib_calculus_func_arity_checked` (deferred-command arity TP/TN)
+- `tcl-registry::command_prefixes_cover_deferred_core_commands` /
+  `_cover_tcllib_callbacks` /
+  `commands_naming_a_cmdprefix_declare_a_command_prefix` (registry coverage + drift guard)
 
 ---
 

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -831,6 +831,19 @@ function ::f
   man-page-pinned — via `math_ext::PREFIX_OVERRIDES`), `log::lvCmd` /
   `lvCmdForall` (2), `uevent::bind` (≥2), `logger::walk` (Unknown),
   `tcltest::customMatch` (2), `tk selection handle` (2).
+- **Tk (`script()`→`command_prefix` conversion — separate commit):**
+  `-xscrollcommand`/`-yscrollcommand` on 8 widgets (2), `scale`/`ttk::scale
+  -command` (1), `scrollbar -command` (≥2), `menu -tearoffcommand` (2).  This is
+  a **net FP reduction**: the old `script()` recursion flagged widget paths
+  inside braced callbacks (`{.sb set}` → spurious `W123 .sb`); as a command
+  prefix the braced (non-bareword) head is dropped, so the widget-path W123
+  disappears, while a bareword user-proc callback — previously *invisible* to
+  script recursion — becomes a real reference / edge / arity-checked head.
+  **Kept as `script()` (NOT prefixes):** button-family / `menu` / `ttk::spinbox`
+  `-command` and `-postcommand` (verbatim scripts); core `spinbox -command`,
+  `-validatecommand`, `-invalidcommand` (percent-substitution, not appended
+  args); the 4 macOS-only file/message-dialog `-command`s stay
+  `command_prefix(Unknown)` (inert cross-platform ⇒ no arity check).
 - **Deferred (documented, not gaps):** option-value callbacks that need a full
   `OptionSpec` array not yet modelled (`mime::getbody -command`,
   `comm send -command`, `smtp -tlspolicy`, `bibtex -*command`,
@@ -896,6 +909,12 @@ all-optional-tail proc draws no arity error; a tail also claimed by a non-proc
 - `tcl-registry::command_prefixes_cover_deferred_core_commands` /
   `_cover_tcllib_callbacks` /
   `commands_naming_a_cmdprefix_declare_a_command_prefix` (registry coverage + drift guard)
+- `tcl-registry::tk_command_options_classified_prefix_vs_script` (Tk prefix-vs-script
+  classification — the conversion locked in)
+- `command_prefix_integration.rs::tk_scale_command_bareword_head_is_a_callback_edge` /
+  `tk_scroll_callback_braced_widget_path_does_not_fire_w123` (FP removed) /
+  `tk_scroll_callback_bareword_undefined_head_fires_w123` (TP now caught)
+- `tcl-lsp-db::callback_arity_tk_scale_command_arity_checked` (Tk callback arity TP/TN)
 
 ---
 

--- a/docs/kcs/codes/kcs-diagnostic-e002-too-few-arguments.md
+++ b/docs/kcs/codes/kcs-diagnostic-e002-too-few-arguments.md
@@ -31,6 +31,25 @@ puts
 
 The analyser reports **`E002`** on the bare `puts` token.
 
+## Command-prefix callback context
+
+`E002` also fires on a **callback proc that requires more arguments than its
+command prefix supplies**. When a command invokes a callback (`lsort -command
+cb`, `trace add … cb`, `$graph walk … -command cb`), it appends a fixed number
+of arguments; if the referenced proc has more *required* parameters than that,
+the runtime call raises "too few arguments". Here the squiggle is under the
+**callback proc name** (the head of the prefix), not under the calling command
+— look at the proc it names.
+
+```tcl
+proc cmp {a b c} { return 0 }
+lsort -command cmp {3 1 2}   ;# lsort appends only 2 → E002 on `cmp`
+```
+
+Fix by giving the extra parameters defaults (`{a b {c 0}}`) or removing them so
+the callback matches the appended-argument count. (A callback whose appended
+count is open-ended — `AtLeast(n)` — never draws `E002`.)
+
 ## Fix
 
 ```tcl

--- a/docs/kcs/codes/kcs-diagnostic-e003-too-many-arguments.md
+++ b/docs/kcs/codes/kcs-diagnostic-e003-too-many-arguments.md
@@ -31,6 +31,24 @@ incr x 1 2
 
 The analyser reports **`E003`** on the surplus argument `2`.
 
+## Command-prefix callback context
+
+`E003` also fires on a **callback proc that is too small for its command
+prefix**. When a command invokes a callback (`lsort -command cb`, `trace add
+… cb`, `$graph walk … -command cb`), it appends a fixed number of arguments; if
+the referenced proc accepts fewer, the runtime call raises "too many
+arguments". Here the squiggle is under the **callback proc name** (the head of
+the prefix), not under a surplus word at the call site — look at the proc it
+names, not the calling command's own argument list.
+
+```tcl
+proc oneArg {a} { return 0 }
+lsort -command oneArg {3 1 2}   ;# lsort appends 2 → E003 on `oneArg`
+```
+
+Fix by widening the callback's parameter list (here to `{a b}`) or giving it a
+variadic tail (`{args}`) so it absorbs every appended argument.
+
 ## Fix
 
 ```tcl

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -217,6 +217,35 @@ suite("Diagnostics", () => {
     }
   });
 
+  test("uplevel body is analysed: braced body clean, unbraced body flags W105 (#837)", async () => {
+    const uri = getDocUri("uplevel-frame.tcl");
+    await activate(uri);
+    // The unbraced substituted body (`uplevel 1 "puts $x"`) yields a W105,
+    // proving the analyser now walks the uplevel body arg.
+    const diagnostics = await waitForDiagnostics(uri, { minCount: 1 });
+    const codeOf = (d: vscode.Diagnostic) => (typeof d.code === "object" ? d.code.value : d.code);
+    const codes = diagnostics.map(codeOf);
+
+    const w105 = diagnostics.filter((d) => codeOf(d) === "W105");
+    assert.strictEqual(w105.length, 1, `expected one W105 (unbraced body), got [${codes}]`);
+    // W105 anchors to the unbraced `uplevel 1 "puts $x"` body (line 8, 0-indexed).
+    assert.strictEqual(
+      w105[0].range.start.line,
+      8,
+      `W105 should anchor to the unbraced uplevel body, got line ${w105[0].range.start.line}`,
+    );
+    // The clean braced body (forgetXyce, lines 0-4) must not carry any
+    // dead-store / read-before-set hint — it is correct caller-frame code.
+    for (const d of diagnostics) {
+      const line = d.range.start.line;
+      const code = codeOf(d);
+      assert.ok(
+        !(["W210", "W211", "W220"].includes(String(code)) && line <= 4),
+        `unexpected ${code} on the clean braced uplevel body at line ${line}`,
+      );
+    }
+  });
+
   test("W100 fires inside a catch body (analyser recurses into catch)", async () => {
     const uri = getDocUri("catchBody.tcl");
     await activate(uri);

--- a/editors/vscode/src/test/semanticTokens.test.ts
+++ b/editors/vscode/src/test/semanticTokens.test.ts
@@ -193,6 +193,57 @@ suite("Semantic Tokens", () => {
     );
   });
 
+  // Issue #837: the braced body of `uplevel ?level? {…}` runs in another stack
+  // frame but is still a Tcl script — it must recurse (its inner commands and
+  // variables highlight) instead of being emitted as one opaque string.
+  test("uplevel bodies recurse and highlight their inner commands (#837)", async () => {
+    const uri = getDocUri("uplevelBody.tcl");
+    const doc = await activate(uri);
+
+    const tokens = (await vscode.commands.executeCommand(
+      "vscode.provideDocumentSemanticTokens",
+      uri,
+    )) as vscode.SemanticTokens;
+    const legend = (await vscode.commands.executeCommand(
+      "vscode.provideDocumentSemanticTokensLegend",
+      uri,
+    )) as vscode.SemanticTokensLegend;
+    assert.ok(tokens && legend, "expected semantic tokens and a legend");
+
+    const decoded = decodeTokens(tokens, legend);
+    const textOf = (t: DecodedToken): string =>
+      doc.lineAt(t.line).text.substring(t.char, t.char + t.length);
+
+    // `foreach` and `namespace` inside the `uplevel 1 {…}` body are keywords.
+    const keywordWords = new Set(decoded.filter((t) => t.type === "keyword").map(textOf));
+    for (const word of ["foreach", "namespace", "uplevel"]) {
+      assert.ok(
+        keywordWords.has(word),
+        `expected '${word}' as a keyword token (recursed uplevel body), got ${JSON.stringify([
+          ...keywordWords,
+        ])}`,
+      );
+    }
+
+    // `set`/`puts` inside the no-level and `#0` bodies are function tokens —
+    // proof the bodies with and without a level word both recurse.
+    const functionWords = new Set(decoded.filter((t) => t.type === "function").map(textOf));
+    for (const word of ["set", "puts"]) {
+      assert.ok(
+        functionWords.has(word),
+        `expected '${word}' as a function token (recursed uplevel body), got ${JSON.stringify([
+          ...functionWords,
+        ])}`,
+      );
+    }
+
+    // The `${nameSpc}` reference deep inside the body surfaces a variable token.
+    assert.ok(
+      decoded.some((t) => t.type === "variable"),
+      "expected the recursed uplevel body to surface variable tokens",
+    );
+  });
+
   // Issue #757: a braced string literal spanning multiple lines lost its
   // highlighting (the enclosing multi-line `string` token was dropped).  It
   // must now carry a `string` token on every covered line, just like the

--- a/editors/vscode/testFixture/uplevel-frame.tcl
+++ b/editors/vscode/testFixture/uplevel-frame.tcl
@@ -1,0 +1,10 @@
+proc forgetXyce {} {
+    uplevel 1 {foreach nameSpc [namespace children ::Foo] {
+        namespace forget ${nameSpc}::*
+    }}
+}
+
+proc bad {} {
+    set x 1
+    uplevel 1 "puts $x"
+}

--- a/editors/vscode/testFixture/uplevelBody.tcl
+++ b/editors/vscode/testFixture/uplevelBody.tcl
@@ -1,0 +1,14 @@
+proc forgetXyce {} {
+    # Forgets all '::SpiceGenTcl::Xyce' commands from caller namespace
+    uplevel 1 {foreach nameSpc [namespace children ::SpiceGenTcl::Xyce] {
+        namespace forget ${nameSpc}::*
+    }}
+}
+
+proc noLevelBody {} {
+    uplevel {set counter 0}
+}
+
+proc globalBody {} {
+    uplevel #0 {puts started}
+}

--- a/editors/zed/src/generated/tcl_commands.json
+++ b/editors/zed/src/generated/tcl_commands.json
@@ -6718,7 +6718,7 @@
     },
     {
       "name": "processman::onexit",
-      "summary": "Arrange to execute the script cmd when this programe detects that process id as terminated."
+      "summary": "Arrange to execute the script cmd when this program detects that process id has terminated."
     },
     {
       "name": "processman::priority",

--- a/rust/tcl-cli/tests/fixtures/registry-dump.tcl8.6-subset.golden
+++ b/rust/tcl-cli/tests/fixtures/registry-dump.tcl8.6-subset.golden
@@ -3184,7 +3184,7 @@
       "allow_unknown_subcommands": false,
       "assigns_variable_at": null,
       "body_arg_implicit_args": 0,
-      "body_kind": "INLINE",
+      "body_kind": "STRUCTURAL",
       "deprecated_replacement": null,
       "format_string_type": null,
       "inferred_storage_type": null,

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -26,7 +26,7 @@
 
 use tcl_core_types::DiagCode;
 use tcl_lexer::{Lexer, LexerConfig, SourceMap, Span, Token, TokenType};
-use tcl_registry::{ArgRole, CommandRegistry};
+use tcl_registry::{AppendedArity, ArgRole, CommandRegistry};
 
 use crate::parsing::syntax::descend::{descend_command, descend_token};
 use crate::parsing::syntax::segment::segments_from_tree;
@@ -34,6 +34,14 @@ use crate::segmenter::SegmentedCommand;
 
 use super::state::Analyser;
 use super::types::{CodeFix, Diagnostic, Severity};
+
+/// A command head collected from a `[...]` substitution / expression scan,
+/// ready to push as a `command_invocations` entry:
+/// `(name, head-span, argc, callback_arity)`.  `argc` is the nested call's
+/// statically-known argument count (`None` when `{*}`-expanded); `callback_arity`
+/// is `Some` only for an `ArgRole::CommandPrefix` callback head (so the callback
+/// arity check runs) and `None` for an ordinary call head.
+type CollectedHead = (String, Span, Option<usize>, Option<AppendedArity>);
 
 /// Maximum nested-body recursion depth for [`Analyser::analyse_body`].
 /// `analyse_body` ↔ `process_command` ↔ `dispatch_body_arguments`
@@ -285,6 +293,7 @@ impl Analyser {
                     range: cmd_tok.span,
                     resolved_qualified_name: Some(resolved),
                     argc: arg_count,
+                    callback_arity: None,
                 },
             );
 
@@ -306,6 +315,7 @@ impl Analyser {
                         // iRules `call PROC ...` indirection — arity not
                         // cross-file-checked here; skip conservatively.
                         argc: None,
+                        callback_arity: None,
                     },
                 );
             }
@@ -314,6 +324,12 @@ impl Analyser {
             // substitutions and record each nested head as its own
             // ``CommandInvocation``.
             self.record_nested_invocations_from_args(cmd_name, args, arg_tokens_in);
+
+            // Record `ArgRole::CommandPrefix` callback heads (`lsort -command
+            // myCompare`, `trace add … cb`) as command invocations too, so
+            // find-references / rename / call-hierarchy / code-lens / W123 /
+            // callback-arity see the callback exactly like a direct call.
+            self.record_command_prefix_invocations(cmd_name, args, arg_tokens, arg_single);
 
             // Run the per-command syntactic checks on commands nested inside
             // ``[…]`` substitutions — the main walk never descends a
@@ -891,6 +907,45 @@ impl Analyser {
         }
     }
 
+    /// Record each [`tcl_registry::arg_role::ArgRole::CommandPrefix`] callback
+    /// head of this call (`lsort -command myCompare`, `trace add … cb`,
+    /// `interp alias {} a {} target`) as a `CommandInvocation`, so the
+    /// callback is a first-class command reference: find-references, rename,
+    /// call-hierarchy, code-lens usage counts, W123 unknown-command, and the
+    /// callback-arity check all see it exactly like a direct call.  Only a
+    /// literal bareword head is recorded (see
+    /// [`crate::signature_scan::command_prefix`]); a dynamic `$cb` / `[..]`
+    /// head stays unrecorded so W123 doesn't false-fire.
+    fn record_command_prefix_invocations(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        arg_single: &[bool],
+    ) {
+        let Some(registry) = self.registry.as_ref() else {
+            return;
+        };
+        let invs = crate::signature_scan::command_prefix::command_prefix_invocations(
+            registry, cmd_name, args, arg_tokens, arg_single,
+        );
+        for inv in invs {
+            let resolved = self.resolve_command_qualified_name(&inv.head);
+            self.result.command_invocations.push(
+                crate::signature_scan::types::SignatureCommandInvocation {
+                    name: inv.head,
+                    range: inv.span,
+                    resolved_qualified_name: Some(resolved),
+                    // Bareword head → 0 baked args; the legacy direct-call
+                    // arity path skips (`None`), the callback-arity check reads
+                    // `callback_arity`.
+                    argc: None,
+                    callback_arity: Some(inv.appended),
+                },
+            );
+        }
+    }
+
     /// Walk every argument's source slice for ``[cmd ...]``
     /// substitutions and record each nested head as its own
     /// ``CommandInvocation``.  Extracted from
@@ -973,7 +1028,7 @@ impl Analyser {
         // immutable source borrow has ended.
         let heads = {
             let sm = SourceMap::new(&self.source);
-            let mut heads: Vec<(String, Span, Option<usize>)> = Vec::new();
+            let mut heads: Vec<CollectedHead> = Vec::new();
             // `arg_tok` is the *merged* argv token.  For a compound word
             // whose first fragment is a `[…]` substitution (`[foo]bar`,
             // `[foo]$x`, `[foo]bar[baz]`), `segments_from_tree` widens the
@@ -1253,7 +1308,7 @@ impl Analyser {
         let config = self.lexer_config();
         let heads = {
             let sm = SourceMap::new(&self.source);
-            let mut heads: Vec<(String, Span, Option<usize>)> = Vec::new();
+            let mut heads: Vec<CollectedHead> = Vec::new();
             collect_expr_substitutions(&sm, self.registry.as_ref(), expr_tok, config, &mut heads);
             heads
         };
@@ -1265,8 +1320,8 @@ impl Analyser {
     /// statically-known argument count (`None` when `{*}`-expanded), so a wrong-arg
     /// call to a cross-file proc *inside a substitution* (`set x [helper a b c]`)
     /// still draws the cross-file arity error.
-    fn push_collected_heads(&mut self, heads: Vec<(String, Span, Option<usize>)>) {
-        for (name, range, argc) in heads {
+    fn push_collected_heads(&mut self, heads: Vec<CollectedHead>) {
+        for (name, range, argc, callback_arity) in heads {
             let resolved = self.resolve_command_qualified_name(&name);
             self.result.command_invocations.push(
                 crate::signature_scan::types::SignatureCommandInvocation {
@@ -1274,6 +1329,7 @@ impl Analyser {
                     range,
                     resolved_qualified_name: Some(resolved),
                     argc,
+                    callback_arity,
                 },
             );
         }
@@ -1317,6 +1373,7 @@ impl Analyser {
                     resolved_qualified_name: Some(resolved),
                     // Nested `[cmd ...]` head, no recorded argument list — arity skip.
                     argc: None,
+                    callback_arity: None,
                 },
             );
         }
@@ -1548,7 +1605,7 @@ fn collect_substitution_heads(
     registry: Option<&CommandRegistry>,
     cmd_tok: Token,
     config: LexerConfig,
-    out: &mut Vec<(String, Span, Option<usize>)>,
+    out: &mut Vec<CollectedHead>,
 ) {
     if cmd_tok.kind != TokenType::Cmd || sm.token_text(cmd_tok).is_empty() {
         return;
@@ -1578,7 +1635,7 @@ fn record_command_invocations(
     registry: Option<&CommandRegistry>,
     seg: &SegmentedCommand,
     config: LexerConfig,
-    out: &mut Vec<(String, Span, Option<usize>)>,
+    out: &mut Vec<CollectedHead>,
 ) {
     // Head — record the `word_piece` form in `texts[0]` for *every*
     // command, whatever the head's kind: a bare word, a `$var`
@@ -1588,7 +1645,25 @@ fn record_command_invocations(
     if let (Some(&head), Some(name)) = (seg.argv.first(), seg.texts.first())
         && !name.is_empty()
     {
-        out.push((name.clone(), head.span, segment_argc(seg)));
+        out.push((name.clone(), head.span, segment_argc(seg), None));
+    }
+    // Command-prefix callback heads of this nested command (`return [lsort
+    // -command myCompare $l]`): recorded with their appended arity so a
+    // callback inside a `[...]` substitution is a first-class reference and is
+    // arity-checked, exactly like a top-level one.
+    if let (Some(registry), Some(name)) = (registry, seg.texts.first()) {
+        let arg_texts: Vec<String> = seg.texts.iter().skip(1).cloned().collect();
+        let arg_tokens: Vec<Token> = seg.argv.iter().skip(1).copied().collect();
+        let arg_single: Vec<bool> = seg.single_token_word.iter().skip(1).copied().collect();
+        for inv in crate::signature_scan::command_prefix::command_prefix_invocations(
+            registry,
+            name,
+            &arg_texts,
+            &arg_tokens,
+            &arg_single,
+        ) {
+            out.push((inv.head, inv.span, None, Some(inv.appended)));
+        }
     }
     // Nested ``[...]`` substitutions in any position (args, or embedded
     // in a quoted word — both are `Cmd` tokens in the command's token
@@ -1661,7 +1736,7 @@ fn collect_expr_substitutions(
     registry: Option<&CommandRegistry>,
     expr_tok: Token,
     config: LexerConfig,
-    out: &mut Vec<(String, Span, Option<usize>)>,
+    out: &mut Vec<CollectedHead>,
 ) {
     if expr_tok.kind != TokenType::Str || sm.token_text(expr_tok).is_empty() {
         return;

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -926,9 +926,37 @@ impl Analyser {
         let Some(registry) = self.registry.as_ref() else {
             return;
         };
-        let invs = crate::signature_scan::command_prefix::command_prefix_invocations(
+        let mut invs = crate::signature_scan::command_prefix::command_prefix_invocations(
             registry, cmd_name, args, arg_tokens, arg_single,
         );
+        // Instance-method dispatch: `$obj method …` / `objName method …` where
+        // the receiver's class is a registry-modelled object class and the
+        // method declares a command prefix (`$g walk … -command cb`,
+        // `$t walkproc … cb`).  The receiver's class comes from the progressive
+        // `instance_classes` map (bound by a prior `struct::graph name` /
+        // `set g [Class new]`), keyed by the bare handle (leading `$` stripped).
+        if let Some(method) = args.first() {
+            // The handle is a bare object command (`objName method …`) or a
+            // variable dispatch, whose head reconstructs as `$g` or `${g}` — map
+            // all three to the `instance_classes` key (the bare name).
+            let receiver = cmd_name.strip_prefix('$').map_or(cmd_name, |v| {
+                v.strip_prefix('{')
+                    .and_then(|b| b.strip_suffix('}'))
+                    .unwrap_or(v)
+            });
+            if let Some(class) = self.result.instance_classes.get(receiver) {
+                invs.extend(
+                    crate::signature_scan::command_prefix::instance_method_command_prefix_invocations(
+                        registry,
+                        class,
+                        method,
+                        args.get(1..).unwrap_or(&[]),
+                        arg_tokens.get(1..).unwrap_or(&[]),
+                        arg_single.get(1..).unwrap_or(&[]),
+                    ),
+                );
+            }
+        }
         for inv in invs {
             let resolved = self.resolve_command_qualified_name(&inv.head);
             self.result.command_invocations.push(
@@ -1560,11 +1588,25 @@ impl Analyser {
         let inner = inner.strip_prefix('[')?.strip_suffix(']')?;
         let mut words = inner.split_whitespace();
         let class = words.next()?;
-        let subcmd = words.next()?;
-        if subcmd != "new" && subcmd != "create" {
-            return None;
+        // TclOO constructor: `set g [Class new|create ...]`.
+        if let Some(subcmd) = words.next()
+            && (subcmd == "new" || subcmd == "create")
+            && let Some(uc) = self.resolve_user_class(class)
+        {
+            return Some(uc);
         }
-        self.resolve_user_class(class)
+        // Registry object-factory whose *return value* is an instance of its own
+        // class — `set g [struct::graph]` / `set g [struct::graph name]`.  A
+        // `creates_instance_at` spec marks a naming factory (`struct::graph
+        // ?name?`) whose result is the object command, so the assigned var holds
+        // an instance of `class` regardless of whether a name was passed.
+        if let Some(reg) = self.registry.as_ref()
+            && reg.object_class(class).is_some()
+            && reg.get(class).is_some_and(|s| s.creates_instance_at.is_some())
+        {
+            return Some(class.to_string());
+        }
+        None
     }
 }
 

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1473,43 +1473,36 @@ impl Analyser {
     /// Best-effort and not flow-sensitive: the last assignment
     /// to a given name wins.
     pub(crate) fn record_instance_creation(&mut self, cmd_name: &str, args: &[String]) {
-        // Per-item isolated proc body: `all_classes` is empty here, so the class
-        // can't be resolved.  Capture the raw `(command, args)` for the two
-        // instance-creation shapes and let the graft replay them against the
-        // shell's full `all_classes` instead (see `pending_instances`).
+        // Registry object-factories (`struct::graph g` naming form, `set g
+        // [struct::graph …]` return form) resolve from the registry alone — no
+        // `all_classes` — so bind them IMMEDIATELY, even inside an isolated proc
+        // body.  Deferring these (as the per-item firewall does for user-class
+        // instances) would leave `instance_classes` empty during that body's own
+        // `$g walk … -command cb` recording, dropping the callback edge /
+        // reference for an in-proc instance-method callback and diverging the
+        // incremental path from the whole-file walk.
+        let bound_registry_factory = self.record_registry_factory_instance(cmd_name, args);
+
+        // Per-item isolated proc body: a *user*-class instance can't be resolved
+        // here (`all_classes` is empty), so capture the raw `(command, args)` for
+        // the two instance-creation shapes and let the graft replay them against
+        // the shell's full `all_classes` instead (see `pending_instances`).
         if let Some(pending) = self.pending_instances.as_mut() {
             let shape_a =
                 cmd_name == "set" && args.len() >= 2 && args[1].trim_start().starts_with('[');
             let shape_b = args.len() >= 2 && args[0] == "create";
-            if shape_a || shape_b {
+            // A registry factory already bound above needs no user-class replay.
+            if (shape_a || shape_b) && !bound_registry_factory {
                 pending.push((cmd_name.to_owned(), args.to_vec()));
             }
             return;
         }
-        // Registry-driven object factory: a command whose spec declares
-        // `creates_instance_at` binds the object command it names positionally
-        // (`report::report reportName columns …`) so a later `reportName
-        // <method>` / `$var method` dispatch resolves through the command's
-        // `object_class`.  The naming shape is registry data — no hardcoded
-        // `create` / `new` idiom.
-        let factory = self
-            .registry
-            .as_ref()
-            .and_then(|r| r.get(cmd_name))
-            .and_then(|s| {
-                s.creates_instance_at
-                    .map(|idx| (idx, s.object_class.map(|oc| oc.class_name.to_string())))
-            });
-        if let Some((idx, class_name)) = factory
-            && let Some(name) = args.get(idx as usize)
-            && is_plain_created_name(name)
-        {
-            let class = class_name.unwrap_or_else(|| cmd_name.to_string());
-            self.result.instance_classes.insert(name.clone(), class);
-            self.result.created_instance_commands.insert(name.clone());
+        if bound_registry_factory {
             return;
         }
-        // Pattern A: `set VAR [CLASS new|create ...]`.
+        // Pattern A: `set VAR [CLASS new|create ...]` — a *user* class (the
+        // registry-factory subset is handled by `record_registry_factory_instance`
+        // above).
         if cmd_name == "set"
             && args.len() >= 2
             && let Some(class_q) = self.class_from_constructor_subst(&args[1])
@@ -1539,6 +1532,65 @@ impl Analyser {
                 self.result.created_instance_commands.insert(name.clone());
             }
         }
+    }
+
+    /// Bind an object handle created by a *registry* object-factory — one
+    /// resolvable from the registry alone (no `all_classes`), so it is recorded
+    /// eagerly even inside an isolated proc body (unlike a user-class instance,
+    /// which must defer to the graft).  Two shapes:
+    ///
+    /// * naming factory  `struct::graph g`         → `g` (via `creates_instance_at`)
+    /// * factory return  `set g [struct::graph …]` → `g`
+    ///
+    /// Returns whether a binding was recorded.
+    fn record_registry_factory_instance(&mut self, cmd_name: &str, args: &[String]) -> bool {
+        // Naming factory: a command whose spec declares `creates_instance_at`
+        // binds the object command it names positionally (`report::report
+        // reportName …`, `struct::graph g`) — the naming shape is registry data,
+        // no hardcoded `create` / `new` idiom.
+        let factory = self
+            .registry
+            .as_ref()
+            .and_then(|r| r.get(cmd_name))
+            .and_then(|s| {
+                s.creates_instance_at
+                    .map(|idx| (idx, s.object_class.map(|oc| oc.class_name.to_string())))
+            });
+        if let Some((idx, class_name)) = factory
+            && let Some(name) = args.get(idx as usize)
+            && is_plain_created_name(name)
+        {
+            let class = class_name.unwrap_or_else(|| cmd_name.to_string());
+            self.result.instance_classes.insert(name.clone(), class);
+            self.result.created_instance_commands.insert(name.clone());
+            return true;
+        }
+        // Factory-return: `set g [struct::graph …]` — the registry-factory subset
+        // of `class_from_constructor_subst`.  A user-class `[Class new]` returns
+        // `None` here and is left to Pattern A / the graft (it needs `all_classes`).
+        if cmd_name == "set"
+            && args.len() >= 2
+            && let Some(class) = self.registry_factory_class_from_subst(&args[1])
+        {
+            self.result.instance_classes.insert(args[0].clone(), class);
+            return true;
+        }
+        false
+    }
+
+    /// The class named by a `[factory …]` command-substitution when `factory` is
+    /// a registry object-factory (`struct::graph` / `struct::tree` — a
+    /// `creates_instance_at` + `object_class` command whose result is an instance
+    /// of its own class).  `None` for a user-class `[Class new]` (which needs
+    /// `all_classes`, resolved by `class_from_constructor_subst`).
+    fn registry_factory_class_from_subst(&self, value: &str) -> Option<String> {
+        let inner = value.trim().strip_prefix('[')?.strip_suffix(']')?;
+        let head = inner.split_whitespace().next()?;
+        let reg = self.registry.as_ref()?;
+        if reg.get(head).is_some_and(|s| s.creates_instance_at.is_some()) {
+            return reg.object_class(head).map(|c| c.class_name.to_string());
+        }
+        None
     }
 
     /// Whether `head` is a plausible external-package class command in a

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1559,6 +1559,10 @@ impl Analyser {
         if let Some((idx, class_name)) = factory
             && let Some(name) = args.get(idx as usize)
             && is_plain_created_name(name)
+            // A `?name?` slot can instead hold a deserialise *operator*
+            // (`struct::graph = $serial` / `:= ` / `as ` / `deserialize `), which
+            // names no object command — never bind the operator token itself.
+            && !matches!(name.as_str(), "=" | ":=" | "as" | "deserialize")
         {
             let class = class_name.unwrap_or_else(|| cmd_name.to_string());
             self.result.instance_classes.insert(name.clone(), class);

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -218,7 +218,7 @@ impl Analyser {
                 &cu.ir_module,
                 registry,
                 Some(self.dialect.as_str()),
-                &std::collections::HashMap::new(),
+                crate::interprocedural::ObjectTypeMap::none(),
             );
             crate::interprocedural::build_proc_index_from_summaries(&ia)
         };

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -211,10 +211,14 @@ impl Analyser {
         // store.  `collect_call_by_name_reads` then yields the suppressed
         // names per function, merged into the dead-store `cross_event_vars`.
         let cbn_proc_index = {
+            // The call-by-name proc index (W220) needs only direct proc→proc
+            // reachability, not object-instance callback edges, so no
+            // object-type map is threaded here.
             let ia = crate::interprocedural::build_interprocedural_analysis(
                 &cu.ir_module,
                 registry,
                 Some(self.dialect.as_str()),
+                &std::collections::HashMap::new(),
             );
             crate::interprocedural::build_proc_index_from_summaries(&ia)
         };

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/ds.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/ds.rs
@@ -566,3 +566,95 @@ fn fp_ds_10_clean_dict_for_is_silent() {
         codes(src, D)
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-DS-11 — an `uplevel` body runs in another stack frame; its variable
+//            references belong to that frame, not the enclosing proc
+//            (issue #837)
+//
+// `uplevel ?level? {body}` now carries an `ArgRole::Body` on its script word
+// (a registry-driven `arg_role_resolver`), so the body is recursed and
+// analysed like every other script body instead of being an opaque string.
+// The spec is also `BodyKind::Structural`: the body evaluates in the frame
+// named by `level`, so a `$var` read inside a *braced* body resolves against
+// that frame — it does NOT count as a use of an enclosing-proc local of the
+// same name.  A value substituted at the enclosing level (`[list …]`, a
+// quoted body, or a plain local read) is evaluated in the enclosing frame and
+// keeps the local live, exactly as before.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fp_ds_11_caller_frame_write_is_not_an_enclosing_dead_store() {
+    // FP/TN: `set counter 0` writes the *caller's* `counter`; the enclosing
+    // proc has no `counter` local, so nothing is a dead store here.
+    let src = "proc f {} { uplevel 1 {set counter 0} }";
+    assert!(
+        !fires(src, D, "W220") && !fires(src, D, "W211"),
+        "FP-DS-11: a caller-frame write must not flag an enclosing dead store; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_11_list_substituted_read_keeps_enclosing_store_live() {
+    // FP: `[list puts $x]` is built in the enclosing frame — `$x` reads the
+    // enclosing `x`, so `set x 1` is live.  Structural must NOT skip a
+    // command-substitution body (only a braced one shifts frame).
+    let src = "proc f {} { set x 1\n uplevel 1 [list puts $x] }";
+    assert!(
+        !fires(src, D, "W220"),
+        "FP-DS-11: a `[list]`-substituted read keeps the enclosing store live; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_11_local_read_keeps_store_live_alongside_uplevel() {
+    // FP: `x` is read locally before the uplevel, so it is unambiguously
+    // live regardless of the frame-shifted body's own `$x`.
+    let src = "proc f {} { set x 1\n puts $x\n uplevel 1 {puts $x} }";
+    assert!(
+        !fires(src, D, "W220"),
+        "FP-DS-11: a local read keeps the store live; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_11_braced_body_only_read_is_a_frame_shifted_dead_store() {
+    // TP (frame-aware precision): `$x` appears *only* inside the braced
+    // `uplevel 1 {…}` body, which reads the caller's frame — so the enclosing
+    // `set x 1` is genuinely never read in `f` and is a real dead store.
+    let src = "proc f {} { set x 1\n uplevel 1 {puts $x} }";
+    assert!(
+        fires(src, D, "W220"),
+        "FP-DS-11 TP: an enclosing store read only in a braced uplevel body is dead; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_11_real_dead_store_outside_uplevel_still_fires() {
+    // TP: an ordinary dead store in the enclosing proc, next to an uplevel,
+    // still fires — recursing the body has not masked enclosing analysis.
+    let src = "proc f {} { set dead 1\n uplevel 1 {set counter 0} }";
+    assert!(
+        fires(src, D, "W220"),
+        "FP-DS-11 TP: a real dead store beside an uplevel still fires; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_11_clean_uplevel_body_is_silent() {
+    // TN control: a clean braced body that only uses its own loop var is
+    // silent — the body is analysed, not flagged.
+    let src = "proc f {} { uplevel 1 {foreach x $l { puts $x }} }";
+    assert!(
+        codes(src, D)
+            .iter()
+            .all(|c| c != "W220" && c != "W211" && c != "W210"),
+        "FP-DS-11 TN: a clean uplevel body must be silent; emitted: {:?}",
+        codes(src, D)
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sty.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sty.rs
@@ -782,6 +782,32 @@ fn fp_sty_14_composite_body_still_fires() {
     );
 }
 
+#[test]
+fn fp_sty_14_uplevel_body_participates_in_w105_like_eval() {
+    // Issue #837: now that `uplevel`'s script word carries `ArgRole::Body`, the
+    // W105 unbraced-body check applies to it exactly as it does to `eval`.
+    // TP: a quoted interpolated body past the level word is an inline script
+    // woven from substitutions — brace it.
+    assert!(
+        fires("uplevel 1 \"do $script\"", D, "W105"),
+        "FP-STY-14: an unbraced substituted uplevel body must fire W105; emitted: {:?}",
+        codes("uplevel 1 \"do $script\"", D)
+    );
+    // FP: a braced body is already correct — no W105.
+    assert!(
+        !fires("uplevel 1 {do $script}", D, "W105"),
+        "FP-STY-14: a braced uplevel body must NOT fire W105; emitted: {:?}",
+        codes("uplevel 1 {do $script}", D)
+    );
+    // FP: a single bare-variable body (`uplevel $script`, implicit level 1) is
+    // a script reference, not an inline block — the brace-fix would be wrong.
+    assert!(
+        !fires("uplevel $script", D, "W105"),
+        "FP-STY-14: a single bare-variable uplevel body must NOT fire W105; emitted: {:?}",
+        codes("uplevel $script", D)
+    );
+}
+
 // ---------------------------------------------------------------------------
 // FP-STY-15 — lexer: $ before a closing " merged the quoted word with the next
 // (E002 / E205 / W306)

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -4055,6 +4055,7 @@ fn analyse_w123_package_require_gate_suppresses_when_recorded() {
             range: Span::new(25, 35),
             resolved_qualified_name: None,
             argc: Some(0),
+            callback_arity: None,
         });
     let registry = tcl_registry::CommandRegistry::build_default();
     a.emit_unresolved_command_diagnostics(&registry);

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -885,7 +885,7 @@ impl CompilationUnit {
             &self.ir_module,
             registry,
             dialect,
-            &object_types,
+            crate::interprocedural::ObjectTypeMap(&object_types),
         );
 
         // Re-run taint with the new summary + dialect. We borrow
@@ -946,7 +946,7 @@ impl CompilationUnit {
             &self.ir_module,
             registry,
             dialect,
-            &object_types,
+            crate::interprocedural::ObjectTypeMap(&object_types),
         );
 
         // Top level is built fresh (no offset-0 lattice key), so its taint

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -878,10 +878,14 @@ impl CompilationUnit {
         registry: &CommandRegistry,
         dialect: Option<&str>,
     ) -> Self {
+        // Object-handle → class map (SSA/VTA-derived) so a `$g walk … -command
+        // cb` instance-method callback becomes a call-graph / reachability edge.
+        let object_types = crate::object_types::object_handle_classes(&self, registry);
         let interproc = crate::interprocedural::build_interprocedural_analysis(
             &self.ir_module,
             registry,
             dialect,
+            &object_types,
         );
 
         // Re-run taint with the new summary + dialect. We borrow
@@ -937,10 +941,12 @@ impl CompilationUnit {
         dialect: Option<&str>,
         taint_cb: &mut TaintCascadeCallback<'_>,
     ) -> Self {
+        let object_types = crate::object_types::object_handle_classes(&self, registry);
         let interproc = crate::interprocedural::build_interprocedural_analysis(
             &self.ir_module,
             registry,
             dialect,
+            &object_types,
         );
 
         // Top level is built fresh (no offset-0 lattice key), so its taint

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -455,14 +455,16 @@ pub fn namespace_parts_from_proc(qname: &str) -> Vec<String> {
 /// - `effect_reads` / `effect_writes` — union over the direct
 ///   side-effects and the transitive closure's.
 #[must_use]
+#[allow(clippy::implicit_hasher)] // object_types comes from object_handle_classes (std hasher)
 pub fn build_interprocedural_analysis(
     ir_module: &crate::ir::Module,
     registry: &tcl_registry::CommandRegistry,
     dialect: Option<&str>,
+    object_types: &HashMap<String, HashSet<String>>,
 ) -> InterproceduralAnalysis {
     let known: HashSet<String> = ir_module.procedures.keys().cloned().collect();
 
-    let local = scan_all_procs(ir_module, &known, registry, dialect);
+    let local = scan_all_procs(ir_module, &known, registry, dialect, object_types);
     let transitive_calls = compute_all_transitive_calls(&known, &local);
     let pure = fixpoint_pure(&local);
     let (effect_reads, effect_writes) = fixpoint_effects(&local);
@@ -486,6 +488,7 @@ pub fn build_interprocedural_analysis(
         &pure,
         &effect_reads,
         &effect_writes,
+        object_types,
     );
 
     InterproceduralAnalysis {
@@ -505,6 +508,7 @@ pub fn build_interprocedural_analysis(
 /// unproven peer method (sound: false negatives only). A redefined
 /// method is forced impure (we can't prove which body a dispatch
 /// runs).
+#[allow(clippy::too_many_arguments)] // interprocedural context threaded through
 fn build_method_summaries(
     ir_module: &crate::ir::Module,
     known: &HashSet<String>,
@@ -513,6 +517,7 @@ fn build_method_summaries(
     pure: &HashMap<String, bool>,
     effect_reads: &HashMap<String, EffectRegion>,
     effect_writes: &HashMap<String, EffectRegion>,
+    object_types: &HashMap<String, HashSet<String>>,
 ) -> HashMap<String, MethodSummary> {
     if ir_module.methods.is_empty() {
         return HashMap::new();
@@ -535,6 +540,7 @@ fn build_method_summaries(
             registry,
             dialect,
             params: &params,
+            object_types,
         };
         scan_script(&method.body, ctx, &mut facts);
         // Fall-through exit is non-constant (O103); see `scan_proc`.
@@ -769,12 +775,13 @@ fn scan_all_procs(
     known: &HashSet<String>,
     registry: &tcl_registry::CommandRegistry,
     dialect: Option<&str>,
+    object_types: &HashMap<String, HashSet<String>>,
 ) -> HashMap<String, LocalFacts> {
     let mut local: HashMap<String, LocalFacts> = HashMap::with_capacity(known.len());
     for (qname, proc) in &ir_module.procedures {
         local.insert(
             qname.clone(),
-            scan_proc(qname, proc, known, registry, dialect),
+            scan_proc(qname, proc, known, registry, dialect, object_types),
         );
     }
     local
@@ -1009,6 +1016,7 @@ fn scan_proc(
     known: &HashSet<String>,
     registry: &tcl_registry::CommandRegistry,
     dialect: Option<&str>,
+    object_types: &HashMap<String, HashSet<String>>,
 ) -> LocalFacts {
     let mut facts = LocalFacts {
         local_pure: true,
@@ -1021,6 +1029,7 @@ fn scan_proc(
         registry,
         dialect,
         params: &params,
+        object_types,
     };
     scan_script(&proc.body, ctx, &mut facts);
     // If the body can fall off the end, its implicit exit returns the
@@ -1045,6 +1054,11 @@ struct ScanCtx<'a> {
     registry: &'a tcl_registry::CommandRegistry,
     dialect: Option<&'a str>,
     params: &'a HashSet<String>,
+    /// Object-handle → candidate class names for this module
+    /// ([`crate::object_types::object_handle_classes`]), so a `$g walk …
+    /// -command cb` instance-method dispatch resolves its callback to a
+    /// call-graph edge.  Empty when built without a `CompilationUnit`.
+    object_types: &'a HashMap<String, HashSet<String>>,
 }
 
 fn scan_script(script: &crate::ir::Script, ctx: ScanCtx<'_>, facts: &mut LocalFacts) {
@@ -1089,6 +1103,35 @@ fn scan_call_facts(command: &str, args: &[String], ctx: ScanCtx<'_>, facts: &mut
             && let Some(target) = resolve_internal_call(word, caller, known)
         {
             facts.direct_calls.insert(target);
+        }
+    }
+
+    // Object-instance method-callback dispatch — `$g walk … -command cb` /
+    // `objName walkproc … cb`.  The receiver's class(es) come from the
+    // module's object-handle map (SSA/VTA-derived); resolve the *method's*
+    // command prefixes (`instance_method_command_prefixes`) so a bareword
+    // callback that names an in-module proc becomes a call-graph edge, exactly
+    // like a top-level prefix.  Over-approximate across candidate classes — an
+    // extra reachability edge is sound (never a missed edge / false dead-code).
+    if let Some(method) = args.first()
+        && !ctx.object_types.is_empty()
+    {
+        let receiver = extract_var_name(command).unwrap_or(command);
+        if let Some(classes) = ctx.object_types.get(receiver) {
+            for class in classes {
+                for (idx, _appended) in
+                    registry.instance_method_command_prefixes(class, method, &arg_strs[1..])
+                {
+                    // `idx` is relative to the words after the method name, so
+                    // the callback word is `args[idx + 1]`.
+                    if let Some(word) = args.get(idx + 1).and_then(|a| a.split_whitespace().next())
+                        && is_plain_proc_name(word)
+                        && let Some(target) = resolve_internal_call(word, caller, known)
+                    {
+                        facts.direct_calls.insert(target);
+                    }
+                }
+            }
         }
     }
 
@@ -2164,13 +2207,34 @@ mod tests {
     fn build(source: &str) -> InterproceduralAnalysis {
         let registry = CommandRegistry::build_default();
         let cu = CompilationUnit::build_for(source, &registry, false);
-        build_interprocedural_analysis(&cu.ir_module, &registry, None)
+        build_interprocedural_analysis(&cu.ir_module, &registry, None, &HashMap::new())
     }
 
     #[test]
     fn empty_module_has_no_summaries() {
         let ia = build("");
         assert!(ia.procedures.is_empty());
+    }
+
+    #[test]
+    fn instance_method_callback_is_a_direct_call() {
+        // `with_interprocedural` computes the object-handle map, so a
+        // `$g walk … -command cb` instance-method callback inside a proc body
+        // resolves through the receiver's class and becomes a `direct_calls`
+        // edge (feeding the call graph + O124 not-dead).
+        let registry = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for(
+            "proc onNode {a g n} {}\nproc build {} { struct::graph g\n g walk root -command onNode }\n",
+            &registry,
+            false,
+        )
+        .with_interprocedural(&registry, Some("tcl9.0"));
+        let summary = &cu.interproc.as_ref().expect("interproc").procedures["::build"];
+        assert!(
+            summary.direct_calls.iter().any(|c| c == "::onNode"),
+            "build's summary must carry a direct_call to onNode via the instance-method callback; got {:?}",
+            summary.direct_calls,
+        );
     }
 
     #[test]
@@ -2624,7 +2688,8 @@ mod effect_propagation_tests {
             "proc p {} { if {[matchclass [HTTP::uri] equals $::l]} {} }",
         ] {
             let module = lower_to_ir(src, &reg);
-            let ia = build_interprocedural_analysis(&module, &reg, Some("f5-irules"));
+            let ia =
+                build_interprocedural_analysis(&module, &reg, Some("f5-irules"), &HashMap::new());
             let s = ia.procedures.get("::p").expect("proc ::p in IA");
             assert!(
                 s.effect_reads.contains(EffectRegion::HTTP_STATE),
@@ -2635,7 +2700,8 @@ mod effect_propagation_tests {
 
         // Plain statement: nested arg effects are NOT propagated.
         let module = lower_to_ir("proc q {} { matchclass [HTTP::uri] equals $::l }", &reg);
-        let ia = build_interprocedural_analysis(&module, &reg, Some("f5-irules"));
+        let ia =
+            build_interprocedural_analysis(&module, &reg, Some("f5-irules"), &HashMap::new());
         let s = ia.procedures.get("::q").expect("proc ::q in IA");
         assert!(
             !s.effect_reads.contains(EffectRegion::HTTP_STATE),

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -1075,6 +1075,23 @@ fn scan_call_facts(command: &str, args: &[String], ctx: ScanCtx<'_>, facts: &mut
         resolve_internal_call(command, caller, known)
     };
 
+    // Command-prefix callbacks (`lsort -command myCompare`, `trace add … cb`,
+    // `interp alias {} a {} target`) are call edges too: the referenced proc is
+    // reachable, so a callback-only proc is not dead (O124) and appears in the
+    // call graph. Registry-driven via `command_prefixes` — no command-name
+    // matching here. Literal single-identifier heads only (`is_plain_proc_name`
+    // rejects dynamic `$cb` / bracketed heads), mirroring the reference
+    // extractor's bareword guard.
+    let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+    for (idx, _appended) in registry.command_prefixes(command, &arg_strs) {
+        if let Some(word) = args.get(idx).and_then(|a| a.split_whitespace().next())
+            && is_plain_proc_name(word)
+            && let Some(target) = resolve_internal_call(word, caller, known)
+        {
+            facts.direct_calls.insert(target);
+        }
+    }
+
     // A call that resolves to an internal proc contributes ONLY a
     // call-graph edge — its purity / effects flow through the
     // interprocedural fixpoints from the callee's summary, so the

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -433,6 +433,30 @@ pub fn namespace_parts_from_proc(qname: &str) -> Vec<String> {
 
 // Summary building (partial)
 
+/// The object-handle → candidate-class map
+/// ([`crate::object_types::object_handle_classes`]) supplied to the call-graph
+/// pass so a `$g walk … -command cb` instance-method callback resolves to a
+/// `direct_calls` edge.  A borrow-only newtype: it gives the public
+/// [`build_interprocedural_analysis`] a named parameter instead of a bare
+/// `HashMap` (whose default hasher would otherwise trip
+/// `clippy::implicit_hasher`).  Use [`ObjectTypeMap::none()`] when no object
+/// typing is available (an IR-only caller, or a context that needs no callback
+/// edges).
+#[derive(Clone, Copy)]
+pub struct ObjectTypeMap<'a>(pub &'a HashMap<String, HashSet<String>>);
+
+impl ObjectTypeMap<'static> {
+    /// The empty map — no object-handle typing (no instance-method callback
+    /// edges).  Backed by a process-wide empty map so it needs no local.
+    #[must_use]
+    pub fn none() -> Self {
+        ObjectTypeMap(&EMPTY_OBJECT_TYPES)
+    }
+}
+
+static EMPTY_OBJECT_TYPES: std::sync::LazyLock<HashMap<String, HashSet<String>>> =
+    std::sync::LazyLock::new(HashMap::new);
+
 /// Build conservative interprocedural summaries for every
 /// procedure in `ir_module`.
 ///
@@ -455,13 +479,13 @@ pub fn namespace_parts_from_proc(qname: &str) -> Vec<String> {
 /// - `effect_reads` / `effect_writes` — union over the direct
 ///   side-effects and the transitive closure's.
 #[must_use]
-#[allow(clippy::implicit_hasher)] // object_types comes from object_handle_classes (std hasher)
 pub fn build_interprocedural_analysis(
     ir_module: &crate::ir::Module,
     registry: &tcl_registry::CommandRegistry,
     dialect: Option<&str>,
-    object_types: &HashMap<String, HashSet<String>>,
+    object_types: ObjectTypeMap<'_>,
 ) -> InterproceduralAnalysis {
+    let object_types = object_types.0;
     let known: HashSet<String> = ir_module.procedures.keys().cloned().collect();
 
     let local = scan_all_procs(ir_module, &known, registry, dialect, object_types);
@@ -479,7 +503,10 @@ pub fn build_interprocedural_analysis(
     );
 
     // Summarise TclOO method bodies into `MethodSummary` entries
-    // (consumed by the O126 `my <method>` purity gate).
+    // (consumed by the O126 `my <method>` purity gate).  Method bodies are not
+    // iterated by the call graph and an unresolved `$obj method` self-dispatch
+    // already forces the method impure, so instance-method callback typing adds
+    // nothing here — method summaries need no object-type map.
     let methods = build_method_summaries(
         ir_module,
         &known,
@@ -488,7 +515,6 @@ pub fn build_interprocedural_analysis(
         &pure,
         &effect_reads,
         &effect_writes,
-        object_types,
     );
 
     InterproceduralAnalysis {
@@ -508,7 +534,6 @@ pub fn build_interprocedural_analysis(
 /// unproven peer method (sound: false negatives only). A redefined
 /// method is forced impure (we can't prove which body a dispatch
 /// runs).
-#[allow(clippy::too_many_arguments)] // interprocedural context threaded through
 fn build_method_summaries(
     ir_module: &crate::ir::Module,
     known: &HashSet<String>,
@@ -517,7 +542,6 @@ fn build_method_summaries(
     pure: &HashMap<String, bool>,
     effect_reads: &HashMap<String, EffectRegion>,
     effect_writes: &HashMap<String, EffectRegion>,
-    object_types: &HashMap<String, HashSet<String>>,
 ) -> HashMap<String, MethodSummary> {
     if ir_module.methods.is_empty() {
         return HashMap::new();
@@ -540,7 +564,8 @@ fn build_method_summaries(
             registry,
             dialect,
             params: &params,
-            object_types,
+            // Method bodies are not call-graph nodes; no object-type map needed.
+            object_types: ObjectTypeMap::none().0,
         };
         scan_script(&method.body, ctx, &mut facts);
         // Fall-through exit is non-constant (O103); see `scan_proc`.
@@ -2207,7 +2232,7 @@ mod tests {
     fn build(source: &str) -> InterproceduralAnalysis {
         let registry = CommandRegistry::build_default();
         let cu = CompilationUnit::build_for(source, &registry, false);
-        build_interprocedural_analysis(&cu.ir_module, &registry, None, &HashMap::new())
+        build_interprocedural_analysis(&cu.ir_module, &registry, None, ObjectTypeMap::none())
     }
 
     #[test]
@@ -2689,7 +2714,7 @@ mod effect_propagation_tests {
         ] {
             let module = lower_to_ir(src, &reg);
             let ia =
-                build_interprocedural_analysis(&module, &reg, Some("f5-irules"), &HashMap::new());
+                build_interprocedural_analysis(&module, &reg, Some("f5-irules"), ObjectTypeMap::none());
             let s = ia.procedures.get("::p").expect("proc ::p in IA");
             assert!(
                 s.effect_reads.contains(EffectRegion::HTTP_STATE),
@@ -2701,7 +2726,7 @@ mod effect_propagation_tests {
         // Plain statement: nested arg effects are NOT propagated.
         let module = lower_to_ir("proc q {} { matchclass [HTTP::uri] equals $::l }", &reg);
         let ia =
-            build_interprocedural_analysis(&module, &reg, Some("f5-irules"), &HashMap::new());
+            build_interprocedural_analysis(&module, &reg, Some("f5-irules"), ObjectTypeMap::none());
         let s = ia.procedures.get("::q").expect("proc ::q in IA");
         assert!(
             !s.effect_reads.contains(EffectRegion::HTTP_STATE),

--- a/rust/tcl-compiler/src/object_types.rs
+++ b/rust/tcl-compiler/src/object_types.rs
@@ -381,16 +381,37 @@ fn harvest_unit(
     registry: &CommandRegistry,
     out: &mut HashMap<String, HashSet<String>>,
 ) {
-    // Syntactic constructor assignments: `set VAR [Class new|create …]`.
+    // Syntactic constructor assignments (`set VAR [Class new|create …]`) and
+    // naming object-factories (`struct::graph myG` — the created object command
+    // is `myG`, not a `set` target the SSA lattice can carry).
     for block in fu.cfg.blocks.values() {
         for stmt in &block.statements {
-            let Statement::AssignValue { name, value, .. } = stmt else {
-                continue;
-            };
-            if let Some(class) = constructor_class(value, registry) {
-                out.entry(name.clone())
-                    .or_default()
-                    .insert(class.to_string());
+            match stmt {
+                Statement::AssignValue { name, value, .. } => {
+                    if let Some(class) = constructor_class(value, registry) {
+                        out.entry(name.clone())
+                            .or_default()
+                            .insert(class.to_string());
+                    }
+                }
+                // A registry naming factory (`creates_instance_at` + a class)
+                // names the new object command positionally, e.g. `struct::graph
+                // myG` / `struct::tree myT`.  Only a plain bareword name binds
+                // (the `= | := | as | deserialize` operator forms and dynamic
+                // `$name` do not create a statically-known handle).
+                Statement::Call { command, args, .. } => {
+                    if let Some(spec) = registry.get(command)
+                        && let Some(idx) = spec.creates_instance_at
+                        && let Some(oc) = spec.object_class
+                        && let Some(name) = args.get(idx as usize)
+                        && is_plain_object_name(name)
+                    {
+                        out.entry(name.clone())
+                            .or_default()
+                            .insert(oc.class_name.to_string());
+                    }
+                }
+                _ => {}
             }
         }
     }
@@ -413,10 +434,28 @@ fn harvest_unit(
 /// [`CommandRegistry::object_class`] strips it as [`CommandRegistry::get`] does.
 fn constructor_class<'r>(value: &str, registry: &'r CommandRegistry) -> Option<&'r str> {
     let (head, args) = parse_command_substitution(value.trim())?;
-    if !args.first().is_some_and(|s| s == "new" || s == "create") {
-        return None;
+    // `[Class new|create …]` — or a registry naming factory returning its own
+    // instance (`[struct::graph]` / `[struct::graph name]`), matching the SSA
+    // lattice's `return_type_for_command` object-factory typing so the syntactic
+    // and lattice signals agree.
+    if args.first().is_some_and(|s| s == "new" || s == "create") {
+        return registry.object_class(&head).map(|c| c.class_name);
     }
-    registry.object_class(&head).map(|c| c.class_name)
+    registry
+        .get(&head)
+        .filter(|s| s.creates_instance_at.is_some())
+        .and_then(|s| s.object_class)
+        .map(|c| c.class_name)
+}
+
+/// Whether `name` is a plain object-command name a naming factory binds — a
+/// bareword, not a `$var` / `[subst]` and not one of the `struct` deserialise
+/// operator words (`= | := | as | deserialize`) that occupy the name slot when
+/// the object is built from a source instead of freshly named.
+fn is_plain_object_name(name: &str) -> bool {
+    !name.is_empty()
+        && !name.starts_with(['$', '[', '{'])
+        && !matches!(name, "=" | ":=" | "as" | "deserialize")
 }
 
 #[cfg(test)]
@@ -436,6 +475,33 @@ mod tests {
             Some(true),
             "chart should be tracked as a ticklecharts::chart handle; got {map:?}"
         );
+    }
+
+    #[test]
+    fn registry_naming_factory_handles() {
+        // A registry object-factory names its instance either positionally
+        // (`struct::graph g`) or as a substitution result (`set g [struct::graph]`)
+        // — both must be tracked as `struct::graph` handles for `$g walk …`
+        // method-callback resolution.
+        let registry = CommandRegistry::build_default();
+        for (src, key) in [
+            ("struct::graph myG\nmyG walk root -command cb\n", "myG"),
+            ("set g [struct::graph]\n$g walk root -command cb\n", "g"),
+            ("struct::tree myT\nmyT walkproc root cb\n", "myT"),
+        ] {
+            let cu = CompilationUnit::build_for(src, &registry, false);
+            let map = object_handle_classes(&cu, &registry);
+            let class = if src.contains("tree") {
+                "struct::tree"
+            } else {
+                "struct::graph"
+            };
+            assert_eq!(
+                map.get(key).map(|s| s.contains(class)),
+                Some(true),
+                "`{src}` should track {key} as a {class} handle; got {map:?}"
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-compiler/src/object_types.rs
+++ b/rust/tcl-compiler/src/object_types.rs
@@ -505,6 +505,29 @@ mod tests {
     }
 
     #[test]
+    fn registry_factory_operator_form_binds_nothing() {
+        // `struct::graph = $serial` puts a deserialise *operator* (`=`) in the
+        // `?name?` slot — it names no object command, so neither
+        // `object_handle_classes` nor the analyser's `instance_classes` may bind
+        // it (a bogus `=` handle would suppress real W123/W307 and mis-resolve a
+        // command literally named `=`).
+        let registry = CommandRegistry::build_default();
+        for op in ["=", ":=", "as", "deserialize"] {
+            let src = format!("struct::graph {op} $serial\n");
+            let cu = CompilationUnit::build_for(&src, &registry, false);
+            assert!(
+                !object_handle_classes(&cu, &registry).contains_key(op),
+                "`struct::graph {op}` must not track `{op}` as an object handle"
+            );
+            let r = crate::analyser::Analyser::new().analyse(&src, "tcl9.0");
+            assert!(
+                !r.instance_classes.contains_key(op),
+                "`struct::graph {op}` must not bind `{op}` in instance_classes"
+            );
+        }
+    }
+
+    #[test]
     fn non_constructor_assignment_is_not_a_handle() {
         let registry = CommandRegistry::build_default();
         let src = "set x [expr {1 + 2}]\nset y hello\n";

--- a/rust/tcl-compiler/src/optimiser/manager.rs
+++ b/rust/tcl-compiler/src/optimiser/manager.rs
@@ -776,7 +776,12 @@ pub fn optimise_raw(
         tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
     );
     let object_types = crate::object_types::object_handle_classes(&cu, registry);
-    let ia = build_interprocedural_analysis(&cu.ir_module, registry, dialect, &object_types);
+    let ia = build_interprocedural_analysis(
+        &cu.ir_module,
+        registry,
+        dialect,
+        crate::interprocedural::ObjectTypeMap(&object_types),
+    );
     let mut ctx = PassContext::with_dialect(&cu.source, ia, dialect);
     ctx.registry = Some(registry);
     // The whole-module builtin-fold trust gate (O129).

--- a/rust/tcl-compiler/src/optimiser/manager.rs
+++ b/rust/tcl-compiler/src/optimiser/manager.rs
@@ -775,7 +775,8 @@ pub fn optimise_raw(
         false,
         tcl_lexer::LexerConfig::for_dialect(dialect.unwrap_or_default()),
     );
-    let ia = build_interprocedural_analysis(&cu.ir_module, registry, dialect);
+    let object_types = crate::object_types::object_handle_classes(&cu, registry);
+    let ia = build_interprocedural_analysis(&cu.ir_module, registry, dialect, &object_types);
     let mut ctx = PassContext::with_dialect(&cu.source, ia, dialect);
     ctx.registry = Some(registry);
     // The whole-module builtin-fold trust gate (O129).

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -2062,7 +2062,12 @@ mod tests {
             "namespace eval ::ns {\n proc inner {} { return 1 }\n proc outer {} { inner }\n}",
             &registry(),
         );
-        let ia = crate::interprocedural::build_interprocedural_analysis(&module, &registry(), None);
+        let ia = crate::interprocedural::build_interprocedural_analysis(
+            &module,
+            &registry(),
+            None,
+            &std::collections::HashMap::new(),
+        );
         assert!(
             ia.procedures.contains_key("::ns::inner"),
             "expected ::ns::inner in IA, got {:?}",

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -2066,7 +2066,7 @@ mod tests {
             &module,
             &registry(),
             None,
-            &std::collections::HashMap::new(),
+            crate::interprocedural::ObjectTypeMap::none(),
         );
         assert!(
             ia.procedures.contains_key("::ns::inner"),

--- a/rust/tcl-compiler/src/signature_scan/command_prefix.rs
+++ b/rust/tcl-compiler/src/signature_scan/command_prefix.rs
@@ -1,0 +1,93 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Shared extraction of [`ArgRole::CommandPrefix`] callback heads.
+//!
+//! A command prefix (`lsort -command myCompare`, `trace add variable v w cb`,
+//! `socket -server accept`) has a command name as its first word, invoked at
+//! runtime with further args appended.  This module is the single place that
+//! turns a call's prefix arguments into referenced command heads, so the
+//! foreground analyser ([`crate::analyser`]) and the background signature scan
+//! ([`super::walker`]) record them identically into `command_invocations` —
+//! feeding find-references, call-hierarchy, call-graph, code-lens, W123, and
+//! the callback-arity check off one substrate.
+//!
+//! Only a **literal bareword** head is recorded (a single `Esc` token, not
+//! quoted, not a `$var`/`[cmd]` substitution) — mirroring the highlight guard
+//! in `tcl_lsp_core::semantic_tokens`.  A dynamic head can't be resolved to a
+//! proc and recording it would false-fire W123; a braced multi-word prefix
+//! (`{cmd extra}`) is out of scope (it fails the single-`Esc` geometry, as it
+//! does for highlighting) and left as a documented follow-up.
+//!
+//! [`ArgRole::CommandPrefix`]: tcl_registry::arg_role::ArgRole::CommandPrefix
+
+use tcl_lexer::{Span, Token, TokenType};
+use tcl_registry::{AppendedArity, CommandRegistry};
+
+/// A command-prefix callback head extracted from a call site.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct CommandPrefixInvocation {
+    /// The callback command name (the prefix's first word).
+    pub head: String,
+    /// Source span of the head token.
+    pub span: Span,
+    /// How many args the calling command appends when it invokes the callback.
+    pub appended: AppendedArity,
+}
+
+/// Extract the command-prefix callback heads of a call.
+///
+/// `name` is the command head; `arg_texts` / `arg_tokens` / `arg_single` are
+/// the per-argument reconstructed text, representative token, and
+/// single-token flag for the words *after* the head (parallel, 0-indexed) —
+/// the same slices `registry.command_prefixes` indexes into.
+pub(crate) fn command_prefix_invocations(
+    registry: &CommandRegistry,
+    name: &str,
+    arg_texts: &[String],
+    arg_tokens: &[Token],
+    arg_single: &[bool],
+) -> Vec<CommandPrefixInvocation> {
+    let arg_strs: Vec<&str> = arg_texts.iter().map(String::as_str).collect();
+    let mut out = Vec::new();
+    for (idx, appended) in registry.command_prefixes(name, &arg_strs) {
+        let (Some(&tok), Some(text)) = (arg_tokens.get(idx), arg_texts.get(idx)) else {
+            continue;
+        };
+        if is_literal_bareword_head(tok, text, arg_single.get(idx).copied().unwrap_or(false)) {
+            out.push(CommandPrefixInvocation {
+                head: text.clone(),
+                span: tok.span,
+                appended,
+            });
+        }
+    }
+    out
+}
+
+/// Whether `tok`/`text` is a literal bareword command head — a single `Esc`
+/// token, unquoted, with no leading `$`/`[` substitution.  Mirrors the
+/// highlight retag guard so recording and highlighting agree exactly.
+fn is_literal_bareword_head(tok: Token, text: &str, single_token: bool) -> bool {
+    single_token
+        && tok.kind == TokenType::Esc
+        && !tok.in_quote
+        && !text.is_empty()
+        && !text.starts_with('$')
+        && !text.starts_with('[')
+}

--- a/rust/tcl-compiler/src/signature_scan/command_prefix.rs
+++ b/rust/tcl-compiler/src/signature_scan/command_prefix.rs
@@ -80,6 +80,42 @@ pub(crate) fn command_prefix_invocations(
     out
 }
 
+/// Extract the command-prefix callback heads of an object instance-method
+/// dispatch `$obj method method_args…` (`$g walk … -command cb`,
+/// `$t walkproc … cb`).
+///
+/// `class` is the receiver's resolved class; `method` is the dispatched method
+/// name; the `method_*` slices are the reconstructed text, representative
+/// token, and single-token flag for the words *after* the method name
+/// (parallel, 0-indexed) — the slices [`CommandRegistry::instance_method_command_prefixes`]
+/// indexes into.  Same literal-bareword guard as [`command_prefix_invocations`].
+///
+/// [`CommandRegistry::instance_method_command_prefixes`]: tcl_registry::CommandRegistry::instance_method_command_prefixes
+pub(crate) fn instance_method_command_prefix_invocations(
+    registry: &CommandRegistry,
+    class: &str,
+    method: &str,
+    method_arg_texts: &[String],
+    method_arg_tokens: &[Token],
+    method_arg_single: &[bool],
+) -> Vec<CommandPrefixInvocation> {
+    let arg_strs: Vec<&str> = method_arg_texts.iter().map(String::as_str).collect();
+    let mut out = Vec::new();
+    for (idx, appended) in registry.instance_method_command_prefixes(class, method, &arg_strs) {
+        let (Some(&tok), Some(text)) = (method_arg_tokens.get(idx), method_arg_texts.get(idx)) else {
+            continue;
+        };
+        if is_literal_bareword_head(tok, text, method_arg_single.get(idx).copied().unwrap_or(false)) {
+            out.push(CommandPrefixInvocation {
+                head: text.clone(),
+                span: tok.span,
+                appended,
+            });
+        }
+    }
+    out
+}
+
 /// Whether `tok`/`text` is a literal bareword command head — a single `Esc`
 /// token, unquoted, with no leading `$`/`[` substitution.  Mirrors the
 /// highlight retag guard so recording and highlighting agree exactly.

--- a/rust/tcl-compiler/src/signature_scan/ctx.rs
+++ b/rust/tcl-compiler/src/signature_scan/ctx.rs
@@ -92,7 +92,7 @@ pub(super) struct ProcBodyInfo {
 
 /// Mutable scan context threaded through the walker.
 #[derive(Debug, Default)]
-pub(super) struct ScanCtx {
+pub(super) struct ScanCtx<'r> {
     /// Public result accumulator.
     pub(super) result: SignatureScanResult,
     /// Factory-call candidates collected during pass 1.
@@ -106,6 +106,11 @@ pub(super) struct ScanCtx {
     /// built once by `extract_signatures`.  Empty in `Default`
     /// (used only by focused unit tests).
     pub(super) skip_heads: std::collections::HashSet<String>,
+    /// The command registry, used to resolve `ArgRole::CommandPrefix`
+    /// callback positions + arities so background-scanned files record
+    /// callback heads (`lsort -command cb`) as command invocations.  `None`
+    /// in `Default` (focused unit tests that don't exercise prefixes).
+    pub(super) registry: Option<&'r tcl_registry::CommandRegistry>,
 }
 
 /// Factory-skip heads that are **not** registered commands and so

--- a/rust/tcl-compiler/src/signature_scan/mod.rs
+++ b/rust/tcl-compiler/src/signature_scan/mod.rs
@@ -54,6 +54,7 @@
 //!
 //! [`ParamDef`]: types::ParamDef
 
+pub(crate) mod command_prefix;
 mod ctx;
 mod factory;
 mod handlers;
@@ -75,7 +76,10 @@ pub use types::SignatureScanResult;
 #[must_use]
 pub fn extract_signatures(source: &str, registry: &CommandRegistry) -> SignatureScanResult {
     let known_commands: std::collections::HashSet<&str> = registry.command_names().collect();
-    let mut ctx = ScanCtx::default();
+    let mut ctx = ScanCtx {
+        registry: Some(registry),
+        ..ScanCtx::default()
+    };
     // Heads that match the factory-wrapper token shape but are not
     // factories: registry commands carrying `NOT_PROC_FACTORY` (using
     // any-spec semantics so a dialect-shadowed core head still counts)

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -201,6 +201,14 @@ pub struct SignatureCommandInvocation {
     /// arities is a wrong-argument-count error.  `{*}`-expanded args make the true
     /// count unknown, recorded as `None` so arity checking conservatively skips.
     pub argc: Option<usize>,
+    /// `Some(arity)` when this invocation is a **command-prefix callback head**
+    /// (`lsort -command myCompare` records `myCompare` with the appended
+    /// arity), `None` for an ordinary direct call.  For a callback head `argc`
+    /// is the count of *baked* prefix args (0 for a bare word); the callback
+    /// arity check validates `baked + appended` against the referenced proc,
+    /// and the legacy direct-call arity path skips it (`argc` unset ⇒ no false
+    /// "wrong # args").
+    pub callback_arity: Option<tcl_registry::AppendedArity>,
 }
 
 /// The full result returned by `extract_signatures`.

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -42,10 +42,13 @@ use std::collections::HashSet;
 
 use tcl_lexer::{Token, TokenType};
 
+use super::command_prefix::command_prefix_invocations;
 use super::ctx::ScanCtx;
 use super::handlers;
 use super::types::SignatureCommandInvocation;
-use crate::segmenter::{segment_commands_with_offset, segment_commands_with_recovery};
+use crate::segmenter::{
+    SegmentedCommand, segment_commands_with_offset, segment_commands_with_recovery,
+};
 
 /// Walk *source* as a Tcl script, emitting records for every command
 /// the dispatcher recognises.
@@ -106,7 +109,13 @@ pub(super) fn scan(
                 // document is reopened in the foreground.
                 resolved_qualified_name: None,
                 argc: arg_count,
+                callback_arity: None,
             });
+        // Record command-prefix callback heads (`lsort -command cb`, `trace
+        // add … cb`, …) as their own invocations so background-scanned files
+        // feed find-references / call-hierarchy / usage counts / callback
+        // arity through the same substrate as ordinary calls.
+        record_command_prefix_invocations(&cmd, head, ctx);
         let texts = &cmd.texts;
         let argv = &cmd.argv;
         match head {
@@ -162,6 +171,44 @@ pub(super) fn scan(
                 handlers::maybe_record_factory_candidate(head, texts, argv, ns_prefix, ctx);
             }
         }
+    }
+}
+
+/// Record `cmd`'s [`tcl_registry::arg_role::ArgRole::CommandPrefix`] callback
+/// heads (`lsort -command cb`, `trace add … cb`) as command invocations, so a
+/// background-scanned file's callbacks feed find-references / call-hierarchy /
+/// usage counts / callback-arity through the same substrate as ordinary calls.
+///
+/// No-op when the context carries no registry (focused unit tests) or the call
+/// has no arguments.
+fn record_command_prefix_invocations(cmd: &SegmentedCommand, head: &str, ctx: &mut ScanCtx<'_>) {
+    let Some(registry) = ctx.registry else {
+        return;
+    };
+    if cmd.texts.len() < 2 || cmd.argv.len() < 2 || cmd.single_token_word.len() < 2 {
+        return;
+    }
+    let invs = command_prefix_invocations(
+        registry,
+        head,
+        &cmd.texts[1..],
+        &cmd.argv[1..],
+        &cmd.single_token_word[1..],
+    );
+    for inv in invs {
+        ctx.result
+            .command_invocations
+            .push(SignatureCommandInvocation {
+                name: inv.head,
+                range: inv.span,
+                // Signature scan skips scope resolution (walker contract).
+                resolved_qualified_name: None,
+                // Bareword head → 0 baked args; the legacy direct-call arity
+                // path skips (`None`), the callback-arity check reads
+                // `callback_arity`.
+                argc: None,
+                callback_arity: Some(inv.appended),
+            });
     }
 }
 

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -216,6 +216,15 @@ pub(crate) fn return_type_for_command<S: std::hash::BuildHasher>(
         Some(t) => TypeLattice::of(t),
         None => TypeLattice::overdefined(),
     }
+    // NB: a registry naming-factory (`struct::graph ?name?`) is deliberately
+    // *not* typed `OBJECT(class)` in the SSA lattice here.  The W307/W308
+    // object-dispatch checks aggregate `fu.types` object-insensitively across
+    // procs (`var_command::aggregate_object_types`), so lattice-typing a
+    // factory result would leak a handle's class from one proc to a same-named
+    // untyped var in another (regressing FP-OBJ-04).  The factory-return
+    // provenance lives instead in `object_types::object_handle_classes` (a
+    // highlight/callback-only, imprecision-tolerant map), which harvests these
+    // factories syntactically without feeding the diagnostic aggregate.
 }
 
 /// Infer the type produced by an expression AST node.

--- a/rust/tcl-compiler/tests/inlining_interproc_residual.rs
+++ b/rust/tcl-compiler/tests/inlining_interproc_residual.rs
@@ -114,7 +114,7 @@ fn inlined(source: &str) -> Module {
 fn interproc(source: &str) -> InterproceduralAnalysis {
     let r = reg();
     let cu = CompilationUnit::build_for(source, &r, false);
-    build_interprocedural_analysis(&cu.ir_module, &r, None)
+    build_interprocedural_analysis(&cu.ir_module, &r, None, &std::collections::HashMap::new())
 }
 
 /// Count statement-position calls to `command` in a flat statement list.
@@ -777,7 +777,7 @@ fn inline_module_with_no_procs_at_all_is_unchanged() {
 fn call_by_name_reads(source: &str, caller_qname: &str) -> HashSet<String> {
     let r = reg();
     let cu = CompilationUnit::build_for(source, &r, false);
-    let ia = build_interprocedural_analysis(&cu.ir_module, &r, None);
+    let ia = build_interprocedural_analysis(&cu.ir_module, &r, None, &std::collections::HashMap::new());
     let index = build_proc_index_from_summaries(&ia);
     let fu = cu.function(caller_qname).expect("caller proc");
     collect_call_by_name_reads(&fu.cfg, &index)

--- a/rust/tcl-compiler/tests/inlining_interproc_residual.rs
+++ b/rust/tcl-compiler/tests/inlining_interproc_residual.rs
@@ -85,7 +85,7 @@ use std::collections::HashSet;
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::inlining::{count_statements, inline_module};
 use tcl_compiler::interprocedural::{
-    Arity, ConstantReturn, InterproceduralAnalysis, ProcArgTrait, ProcIndex,
+    Arity, ConstantReturn, InterproceduralAnalysis, ObjectTypeMap, ProcArgTrait, ProcIndex,
     build_interprocedural_analysis, build_proc_index_from_summaries, collect_call_by_name_reads,
 };
 use tcl_compiler::ir::{Module, Statement};
@@ -114,7 +114,7 @@ fn inlined(source: &str) -> Module {
 fn interproc(source: &str) -> InterproceduralAnalysis {
     let r = reg();
     let cu = CompilationUnit::build_for(source, &r, false);
-    build_interprocedural_analysis(&cu.ir_module, &r, None, &std::collections::HashMap::new())
+    build_interprocedural_analysis(&cu.ir_module, &r, None, ObjectTypeMap::none())
 }
 
 /// Count statement-position calls to `command` in a flat statement list.
@@ -777,7 +777,7 @@ fn inline_module_with_no_procs_at_all_is_unchanged() {
 fn call_by_name_reads(source: &str, caller_qname: &str) -> HashSet<String> {
     let r = reg();
     let cu = CompilationUnit::build_for(source, &r, false);
-    let ia = build_interprocedural_analysis(&cu.ir_module, &r, None, &std::collections::HashMap::new());
+    let ia = build_interprocedural_analysis(&cu.ir_module, &r, None, ObjectTypeMap::none());
     let index = build_proc_index_from_summaries(&ia);
     let fu = cu.function(caller_qname).expect("caller proc");
     collect_call_by_name_reads(&fu.cfg, &index)

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -6022,6 +6022,44 @@ mod tests {
     }
 
     #[test]
+    fn command_prefix_callback_head_highlights_as_function() {
+        // A registry `CommandPrefix` callback head retags as a Function — driven
+        // by the declarative role (no analysis needed).  Covers a core
+        // `-command` and a Tk `scale -command` (the script→prefix conversion):
+        // under the old `script()` a bareword single-word callback head was not
+        // recursed, so it did not highlight; as a prefix it now does.
+        let registry = reg();
+        let slice = |src: &str, line: u32, col: u32, len: u32| -> String {
+            src.lines()
+                .nth(line as usize)
+                .and_then(|l| l.get(col as usize..(col + len) as usize))
+                .unwrap_or_default()
+                .to_owned()
+        };
+        let highlights_fn = |src: &str, name: &str| {
+            decode_full(src, "tcl9.0", &registry)
+                .iter()
+                .any(|&(line, col, len, k, _)| {
+                    k == TokenKind::Function as u32 && slice(src, line, col, len) == name
+                })
+        };
+        assert!(
+            highlights_fn(
+                "proc myCompare {a b} { expr {$a - $b} }\nlsort -command myCompare {3 1 2}\n",
+                "myCompare",
+            ),
+            "the lsort -command callback head must highlight as a Function"
+        );
+        assert!(
+            highlights_fn(
+                "proc onScale {v} { }\nscale .s -command onScale\n",
+                "onScale",
+            ),
+            "the Tk scale -command callback head must highlight as a Function (script→prefix conversion)"
+        );
+    }
+
+    #[test]
     fn method_body_recurses_in_class_definition_script() {
         // `oo::class create C { method m {} { set z 3 } }` — the method body
         // must be tokenised (C Tcl evaluates it as a script), so `set` reads

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -7091,6 +7091,115 @@ mod tests {
         );
     }
 
+    /// True if any token in `src` covers exactly `text` with kind `kind`.
+    fn has_token_kind(
+        src: &str,
+        dialect: &str,
+        registry: &CommandRegistry,
+        text: &str,
+        kind: TokenKind,
+    ) -> bool {
+        decode_full(src, dialect, registry)
+            .iter()
+            .any(|&(l, c, len, k, _)| {
+                k == kind as u32
+                    && src
+                        .lines()
+                        .nth(l as usize)
+                        .and_then(|line| {
+                            let s = line.char_indices().nth(c as usize).map(|(i, _)| i)?;
+                            let e = line
+                                .char_indices()
+                                .nth((c + len) as usize)
+                                .map_or(line.len(), |(i, _)| i);
+                            line.get(s..e)
+                        })
+                        .is_some_and(|got| got == text)
+            })
+    }
+
+    #[test]
+    fn uplevel_body_recurses_as_script() {
+        // Issue #837: the braced body of `uplevel ?level? {body}` runs in
+        // another stack frame but is still a Tcl script — it must be
+        // recursed and highlighted, not rendered as one opaque string.
+        let registry = reg();
+
+        // `uplevel 1 {body}` — literal relative level, body at arg 1.
+        let src = "uplevel 1 {foreach x $l { puts $x }}\n";
+        assert!(
+            has_token_kind(src, "tcl9.0", &registry, "foreach", TokenKind::Keyword),
+            "uplevel 1 body: `foreach` must tokenise as a keyword; got {:?}",
+            decode_full(src, "tcl9.0", &registry)
+        );
+        assert!(
+            has_token_kind(src, "tcl9.0", &registry, "puts", TokenKind::Function),
+            "uplevel 1 body: `puts` must tokenise as a function"
+        );
+
+        // `uplevel {body}` — no level, body at arg 0.
+        let src = "uplevel {foreach x $l { puts $x }}\n";
+        assert!(
+            has_token_kind(src, "tcl9.0", &registry, "foreach", TokenKind::Keyword),
+            "uplevel (no level) body: `foreach` must tokenise as a keyword"
+        );
+
+        // `uplevel #0 {body}` — absolute global level.
+        let src = "uplevel #0 {foreach x $l { puts $x }}\n";
+        assert!(
+            has_token_kind(src, "tcl9.0", &registry, "foreach", TokenKind::Keyword),
+            "uplevel #0 body: `foreach` must tokenise as a keyword"
+        );
+
+        // `uplevel $lvl {body}` — dynamic level word, body still recurses.
+        let src = "uplevel $lvl {foreach x $l { puts $x }}\n";
+        assert!(
+            has_token_kind(src, "tcl9.0", &registry, "foreach", TokenKind::Keyword),
+            "uplevel $lvl body: `foreach` must tokenise as a keyword"
+        );
+    }
+
+    #[test]
+    fn uplevel_dynamic_body_not_recursed() {
+        // `uplevel 1 $body` — the body is a bare variable, not a braced
+        // literal, so it stays a `$body` variable token (the const-lattice
+        // lowering resolves it on the compiler side, not the token layer).
+        let registry = reg();
+        let src = "uplevel 1 $body\n";
+        assert!(
+            has_token_kind(src, "tcl9.0", &registry, "$body", TokenKind::Variable),
+            "uplevel 1 $body: the body variable must stay a variable token; got {:?}",
+            decode_full(src, "tcl9.0", &registry)
+        );
+    }
+
+    #[test]
+    fn uplevel_issue_837_repro_recurses() {
+        // The exact reproducer from issue #837 — a `foreach` /
+        // `namespace children` / `namespace forget` body inside
+        // `uplevel 1 {…}` must highlight, not sit inside one string.
+        let registry = reg();
+        let src = "proc forgetXyce {} {\n    uplevel 1 {foreach nameSpc [namespace children ::SpiceGenTcl::Xyce] {\n        namespace forget ${nameSpc}::*\n    }}\n}\n";
+        assert!(
+            has_token_kind(src, "tcl9.0", &registry, "foreach", TokenKind::Keyword),
+            "issue #837: `foreach` inside the uplevel body must be a keyword; got {:?}",
+            decode_full(src, "tcl9.0", &registry)
+        );
+        assert!(
+            has_token_kind(src, "tcl9.0", &registry, "namespace", TokenKind::Keyword)
+                || has_token_kind(src, "tcl9.0", &registry, "namespace", TokenKind::Function),
+            "issue #837: `namespace` inside the uplevel body must be highlighted"
+        );
+        // The `${nameSpc}` reference deep inside the body highlights as a
+        // variable — proof the whole body was re-lexed, not stringified.
+        assert!(
+            decode_full(src, "tcl9.0", &registry)
+                .iter()
+                .any(|&(_, _, _, k, _)| k == TokenKind::Variable as u32),
+            "issue #837: a variable token is expected from the recursed body"
+        );
+    }
+
     #[test]
     fn operator_command_head_classified_as_operator() {
         // `+ 3 4` — the operator head is `operator`, not `function`.

--- a/rust/tcl-lsp-core/tests/command_prefix_integration.rs
+++ b/rust/tcl-lsp-core/tests/command_prefix_integration.rs
@@ -1,0 +1,112 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `ArgRole::CommandPrefix` deep-integration: a command-prefix callback
+//! (`lsort -command myCompare`) is a first-class command reference across the
+//! call graph, find-references, and unknown-command (W123) — all registry
+//! driven. Default dialect tcl9.0 (the ground-truth oracle).
+
+use tcl_lsp_core::graphs;
+use tcl_registry::CommandRegistry;
+
+/// The nested form (`return [lsort …]`) — the common real shape.
+const SRC: &str = "proc myCompare {a b} { expr {$a - $b} }\nproc doSort {items} {\n    return [lsort -command myCompare $items]\n}\n";
+
+#[test]
+fn call_graph_has_callback_edge() {
+    let reg = CommandRegistry::build_default();
+    let g = graphs::call_graph(SRC, &reg, "tcl9.0");
+    let edges = g["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("doSort")
+                && e["callee"].as_str().unwrap_or("").contains("myCompare")
+        }),
+        "expected a doSort→myCompare callback edge; got {g}"
+    );
+}
+
+#[test]
+fn command_invocations_record_callback_head_with_arity() {
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let r = a.analyse(SRC, "tcl9.0");
+    assert!(
+        r.command_invocations
+            .iter()
+            .any(|i| i.name == "myCompare" && i.callback_arity.is_some()),
+        "the nested lsort callback must record a myCompare invocation with callback_arity"
+    );
+}
+
+#[test]
+fn find_references_includes_callback_site() {
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let r = a.analyse(SRC, "tcl9.0");
+    // Cursor on `myCompare` in its definition (line 0, char 6).
+    let refs = tcl_lsp_core::references::references(SRC, "tcl9.0", 0, 6, &r, true);
+    assert!(
+        refs.iter().any(|rg| rg.start_line == 2),
+        "find-references must include the lsort -command callback on line 2; got {refs:?}"
+    );
+}
+
+#[test]
+fn w123_fires_on_unknown_callback_but_not_a_defined_one() {
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    // Unknown callback head → W123.
+    let bad = "lsort -command nonexistentCb {a b}\n";
+    let codes: Vec<_> = a
+        .analyse(bad, "tcl9.0")
+        .diagnostics
+        .iter()
+        .map(|d| d.code.to_string())
+        .collect();
+    assert!(
+        codes.iter().any(|c| c == "W123"),
+        "an unknown callback head must fire W123; got {codes:?}"
+    );
+    // Defined callback → no W123.
+    let ok = "proc realCb {a b} {expr {$a-$b}}\nlsort -command realCb {a b}\n";
+    let codes2: Vec<_> = a
+        .analyse(ok, "tcl9.0")
+        .diagnostics
+        .iter()
+        .map(|d| d.code.to_string())
+        .collect();
+    assert!(
+        !codes2.iter().any(|c| c == "W123"),
+        "a defined callback must NOT fire W123; got {codes2:?}"
+    );
+}
+
+#[test]
+fn dynamic_callback_head_is_not_recorded() {
+    // `lsort -command $cb` — a dynamic head can't resolve to a proc, so it is
+    // neither recorded (no W123 false-fire) nor a call-graph edge.
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let r = a.analyse(
+        "proc f {cb l} { return [lsort -command $cb $l] }\n",
+        "tcl9.0",
+    );
+    assert!(
+        !r.command_invocations
+            .iter()
+            .any(|i| i.callback_arity.is_some()),
+        "a dynamic `$cb` callback head must not be recorded as a command-prefix invocation"
+    );
+}

--- a/rust/tcl-lsp-core/tests/command_prefix_integration.rs
+++ b/rust/tcl-lsp-core/tests/command_prefix_integration.rs
@@ -232,3 +232,69 @@ fn tcllib_calculus_func_records_reference_with_fixed_arity() {
         "the calculus func callback carries its man-page-pinned Exactly(1) arity"
     );
 }
+
+/// Tk `script()→command_prefix` conversion (highest-risk change).  A bareword
+/// user-proc scroll/scale callback that was previously *invisible* (script
+/// recursion never recorded a single-word head) is now a first-class reference
+/// + call-graph edge.
+#[test]
+fn tk_scale_command_bareword_head_is_a_callback_edge() {
+    let reg = CommandRegistry::build_default();
+    let src = "proc onScale {v} { puts $v }\nproc build {} {\n    scale .s -command onScale\n}\n";
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    let edges = g["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("build")
+                && e["callee"].as_str().unwrap_or("").contains("onScale")
+        }),
+        "expected a build→onScale edge from `scale -command`; got {g}"
+    );
+}
+
+#[test]
+fn tk_scroll_callback_braced_widget_path_does_not_fire_w123() {
+    // The pre-conversion `script()` recursion flagged `.sb` inside `{.sb set}`
+    // as an unknown command (a widget-path FP).  As a command prefix the braced
+    // head is not a literal bareword, so it is dropped — no W123.  (Regression
+    // guard for the conversion's headline benefit.)
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let src = "listbox .lb -yscrollcommand {.sb set}\n";
+    let codes: Vec<_> = a
+        .analyse(src, "tcl9.0")
+        .diagnostics
+        .iter()
+        .map(|d| d.code.to_string())
+        .collect();
+    assert!(
+        !codes.iter().any(|c| c == "W123"),
+        "a braced widget-path scroll callback must not draw a widget-path W123; got {codes:?}"
+    );
+}
+
+#[test]
+fn tk_scroll_callback_bareword_undefined_head_fires_w123() {
+    // A bareword scroll callback head that resolves to no proc is a genuine
+    // typo — now caught (it was silently missed under `script()`).
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let bad = "listbox .lb -yscrollcommand missingScroller\n";
+    let codes: Vec<_> = a
+        .analyse(bad, "tcl9.0")
+        .diagnostics
+        .iter()
+        .map(|d| d.code.to_string())
+        .collect();
+    assert!(
+        codes.iter().any(|c| c == "W123"),
+        "an unknown bareword scroll callback head must fire W123; got {codes:?}"
+    );
+    // A defined head is silent.
+    let ok = "proc myScroller {first last} { }\nlistbox .lb -yscrollcommand myScroller\n";
+    assert!(
+        !a.analyse(ok, "tcl9.0")
+            .diagnostics
+            .iter()
+            .any(|d| d.code.to_string() == "W123"),
+        "a defined scroll callback head must not fire W123"
+    );
+}

--- a/rust/tcl-lsp-core/tests/command_prefix_integration.rs
+++ b/rust/tcl-lsp-core/tests/command_prefix_integration.rs
@@ -441,3 +441,71 @@ fn processman_onexit_script_body_is_recursed_not_a_prefix() {
         "the processman::onexit script body's inner call must be recorded as an invocation"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Object-instance method callbacks — the prefix is on a method of a created
+// object command (`struct::graph name` / `set g [struct::graph]`), resolved
+// through the class's ObjectClassSpec + the receiver's tracked type.  Foreground
+// analysis (single-file diagnostics, call graph, in-file references).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn struct_graph_walk_command_records_callback_with_arity() {
+    // `struct::graph myG` names the instance; `myG walk … -command cb` resolves
+    // `cb` through the graph class's `walk` method (option-value prefix), so the
+    // bareword head is recorded as an invocation carrying the Exactly(3)
+    // callback arity (feeding references + the callback-arity check).  (The
+    // call-graph *edge* additionally needs interprocedural object-type tracking,
+    // which is a documented follow-up; correctness — W123 / arity / not-dead —
+    // rides on this invocation record.)
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let src = "proc onNode {action g node} { }\nproc build {} {\n    struct::graph myG\n    myG walk root -command onNode\n}\n";
+    let r = a.analyse(src, "tcl9.0");
+    assert!(
+        r.command_invocations.iter().any(|i| {
+            i.name == "onNode"
+                && i.callback_arity
+                    == Some(tcl_registry::AppendedArity::Exactly(3))
+        }),
+        "`myG walk -command onNode` must record an onNode invocation with Exactly(3) callback arity"
+    );
+}
+
+#[test]
+fn struct_graph_walk_command_var_handle_fires_w123_only_when_unknown() {
+    // The `set g [struct::graph]` handle form types `g`, so `$g walk … -command`
+    // resolves too.  Unknown head → W123; defined 3-param head → silent.
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let bad = "set g [struct::graph]\n$g walk root -command noSuchNodeProc\n";
+    assert!(
+        a.analyse(bad, "tcl9.0")
+            .diagnostics
+            .iter()
+            .any(|d| d.code.to_string() == "W123"),
+        "an unknown `$g walk -command` head must fire W123"
+    );
+    let ok = "proc onNode {action g node} { }\nset g [struct::graph]\n$g walk root -command onNode\n";
+    assert!(
+        !a.analyse(ok, "tcl9.0")
+            .diagnostics
+            .iter()
+            .any(|d| d.code.to_string() == "W123"),
+        "a defined `$g walk -command` head must not fire W123"
+    );
+}
+
+#[test]
+fn struct_tree_walkproc_trailing_prefix_is_recorded() {
+    // `struct::tree` instance `walkproc node … cmdprefix` — a *trailing
+    // positional* prefix (resolver-driven), unlike graph's option-value one.
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let src = "proc onN {tree node action} { }\nproc build {} {\n    struct::tree myT\n    myT walkproc root onN\n}\n";
+    let r = a.analyse(src, "tcl9.0");
+    assert!(
+        r.command_invocations.iter().any(|i| {
+            i.name == "onN"
+                && i.callback_arity == Some(tcl_registry::AppendedArity::Exactly(3))
+        }),
+        "`myT walkproc … onN` must record an onN invocation with Exactly(3) callback arity"
+    );
+}

--- a/rust/tcl-lsp-core/tests/command_prefix_integration.rs
+++ b/rust/tcl-lsp-core/tests/command_prefix_integration.rs
@@ -454,10 +454,7 @@ fn struct_graph_walk_command_records_callback_with_arity() {
     // `struct::graph myG` names the instance; `myG walk … -command cb` resolves
     // `cb` through the graph class's `walk` method (option-value prefix), so the
     // bareword head is recorded as an invocation carrying the Exactly(3)
-    // callback arity (feeding references + the callback-arity check).  (The
-    // call-graph *edge* additionally needs interprocedural object-type tracking,
-    // which is a documented follow-up; correctness — W123 / arity / not-dead —
-    // rides on this invocation record.)
+    // callback arity (feeding references + the callback-arity check).
     let mut a = tcl_compiler::analyser::Analyser::new();
     let src = "proc onNode {action g node} { }\nproc build {} {\n    struct::graph myG\n    myG walk root -command onNode\n}\n";
     let r = a.analyse(src, "tcl9.0");
@@ -468,6 +465,17 @@ fn struct_graph_walk_command_records_callback_with_arity() {
                     == Some(tcl_registry::AppendedArity::Exactly(3))
         }),
         "`myG walk -command onNode` must record an onNode invocation with Exactly(3) callback arity"
+    );
+    // The interprocedural pass now tracks the receiver's object type, so the
+    // callback is also a real call-graph edge (build → onNode).
+    let reg = CommandRegistry::build_default();
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    assert!(
+        g["edges"].as_array().expect("edges").iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("build")
+                && e["callee"].as_str().unwrap_or("").contains("onNode")
+        }),
+        "`myG walk -command onNode` must form a build→onNode call-graph edge; got {g}"
     );
 }
 
@@ -507,5 +515,15 @@ fn struct_tree_walkproc_trailing_prefix_is_recorded() {
                 && i.callback_arity == Some(tcl_registry::AppendedArity::Exactly(3))
         }),
         "`myT walkproc … onN` must record an onN invocation with Exactly(3) callback arity"
+    );
+    // …and a build→onN call-graph edge via the interprocedural object typing.
+    let reg = CommandRegistry::build_default();
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    assert!(
+        g["edges"].as_array().expect("edges").iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("build")
+                && e["callee"].as_str().unwrap_or("").contains("onN")
+        }),
+        "`myT walkproc … onN` must form a build→onN call-graph edge; got {g}"
     );
 }

--- a/rust/tcl-lsp-core/tests/command_prefix_integration.rs
+++ b/rust/tcl-lsp-core/tests/command_prefix_integration.rs
@@ -298,3 +298,78 @@ fn tk_scroll_callback_bareword_undefined_head_fires_w123() {
         "a defined scroll callback head must not fire W123"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Option-value callbacks — the prefix is the value of a named `-flag`, resolved
+// through the command's `OptionSpec` array (no `command_prefixes` table entry).
+// These flow through the identical generic substrate, so a bareword head lights
+// up call-graph / references / W123 / arity with zero per-command code.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn mime_getbody_command_option_is_a_callback_edge() {
+    let reg = CommandRegistry::build_default();
+    let src = "proc onChunk {reason args} { puts $reason }\nproc fetchBody {tok} {\n    mime::getbody $tok -command onChunk\n}\n";
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    let edges = g["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("fetchBody")
+                && e["callee"].as_str().unwrap_or("").contains("onChunk")
+        }),
+        "expected a fetchBody→onChunk edge from `mime::getbody -command`; got {g}"
+    );
+}
+
+#[test]
+fn smtp_tlspolicy_option_fires_w123_only_when_unknown() {
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    // Unknown -tlspolicy head → W123.
+    let bad = "smtp::sendmessage $tok -tlspolicy noSuchPolicy\n";
+    assert!(
+        a.analyse(bad, "tcl9.0")
+            .diagnostics
+            .iter()
+            .any(|d| d.code.to_string() == "W123"),
+        "an unknown -tlspolicy callback head must fire W123"
+    );
+    // Defined head → silent.
+    let ok = "proc tlsDecider {code diag} { return secure }\nsmtp::sendmessage $tok -tlspolicy tlsDecider\n";
+    assert!(
+        !a.analyse(ok, "tcl9.0")
+            .diagnostics
+            .iter()
+            .any(|d| d.code.to_string() == "W123"),
+        "a defined -tlspolicy callback head must not fire W123"
+    );
+}
+
+#[test]
+fn bibtex_recordcommand_option_is_a_callback_edge() {
+    let reg = CommandRegistry::build_default();
+    let src = "proc saveRecord {token type key data} { }\nproc parseBib {text} {\n    bibtex::parse -recordcommand saveRecord $text\n}\n";
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    let edges = g["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("parseBib")
+                && e["callee"].as_str().unwrap_or("").contains("saveRecord")
+        }),
+        "expected a parseBib→saveRecord edge from `bibtex::parse -recordcommand`; got {g}"
+    );
+}
+
+#[test]
+fn halfpipe_write_command_option_records_callback() {
+    let reg = CommandRegistry::build_default();
+    let src = "proc onWrite {chan bytes} { }\nproc mk {} {\n    tcl::chan::halfpipe -write-command onWrite\n}\n";
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    let edges = g["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("mk")
+                && e["callee"].as_str().unwrap_or("").contains("onWrite")
+        }),
+        "expected an mk→onWrite edge from `tcl::chan::halfpipe -write-command`; got {g}"
+    );
+}

--- a/rust/tcl-lsp-core/tests/command_prefix_integration.rs
+++ b/rust/tcl-lsp-core/tests/command_prefix_integration.rs
@@ -373,3 +373,71 @@ fn halfpipe_write_command_option_records_callback() {
         "expected an mk→onWrite edge from `tcl::chan::halfpipe -write-command`; got {g}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Resolver-based prefix (`hook bind`) and script-vs-prefix disambiguation
+// (`processman::onexit`).
+// ---------------------------------------------------------------------------
+
+#[test]
+fn hook_bind_binding_is_a_callback_edge() {
+    // `hook bind subject hook observer binding` — the 4-word set form's final
+    // word is a command prefix (resolver-driven, Unknown arity).
+    let reg = CommandRegistry::build_default();
+    let src = "proc onEvent {args} { }\nproc wire {} {\n    hook bind subj myHook obs onEvent\n}\n";
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    let edges = g["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("wire")
+                && e["callee"].as_str().unwrap_or("").contains("onEvent")
+        }),
+        "expected a wire→onEvent edge from `hook bind`; got {g}"
+    );
+}
+
+#[test]
+fn hook_bind_query_form_is_not_a_callback() {
+    // The 3-word query form (`hook bind subject hook observer`) names no
+    // callback — a bareword there is a plain observer id, so no spurious W123.
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let src = "hook bind subj myHook someObserver\n";
+    assert!(
+        !a.analyse(src, "tcl9.0")
+            .diagnostics
+            .iter()
+            .any(|d| d.code.to_string() == "W123"),
+        "the 3-arg `hook bind` query form must not fire W123 on the observer word"
+    );
+}
+
+#[test]
+fn processman_onexit_script_body_is_recursed_not_a_prefix() {
+    // `processman::onexit id cmd` — `cmd` is a deferred *script* (Body role, run
+    // later via `eval` in its own dispatch context), not a command prefix.  So
+    // its braced contents are recursed as a script: a typo inside fires W123 and
+    // a defined command is recorded / silent.  (Unlike a prefix, the `cmd` word
+    // itself is not a callback head, and — deferred — it forms no enclosing-proc
+    // call edge.)
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let bad = "processman::onexit $pid { noSuchCleanupProc }\n";
+    assert!(
+        a.analyse(bad, "tcl9.0")
+            .diagnostics
+            .iter()
+            .any(|d| d.code.to_string() == "W123"),
+        "an unknown command inside the processman::onexit script must fire W123 (body recursed)"
+    );
+    // A defined command inside the script is recorded as an invocation (feeding
+    // references) and draws no W123.
+    let ok = "proc cleanup {} { }\nprocessman::onexit $pid { cleanup }\n";
+    let r = a.analyse(ok, "tcl9.0");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code.to_string() == "W123"),
+        "a defined command inside the processman::onexit script must not fire W123"
+    );
+    assert!(
+        r.command_invocations.iter().any(|i| i.name == "cleanup"),
+        "the processman::onexit script body's inner call must be recorded as an invocation"
+    );
+}

--- a/rust/tcl-lsp-core/tests/command_prefix_integration.rs
+++ b/rust/tcl-lsp-core/tests/command_prefix_integration.rs
@@ -110,3 +110,125 @@ fn dynamic_callback_head_is_not_recorded() {
         "a dynamic `$cb` callback head must not be recorded as a command-prefix invocation"
     );
 }
+
+/// The deferred core-Tcl callback surfaces are wired through the same generic
+/// substrate — no per-command code — so a registry-declared prefix on
+/// `namespace unknown` / `package unknown` / `regsub -command` /
+/// `coroinject` lights up call-graph, references, and W123 automatically.
+#[test]
+fn namespace_unknown_handler_is_a_callback_edge() {
+    let reg = CommandRegistry::build_default();
+    let src = "proc onUnknown {args} { puts $args }\nproc install {} {\n    namespace unknown onUnknown\n}\n";
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    let edges = g["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("install")
+                && e["callee"].as_str().unwrap_or("").contains("onUnknown")
+        }),
+        "expected an install→onUnknown edge from `namespace unknown`; got {g}"
+    );
+}
+
+#[test]
+fn regsub_command_prefix_fires_w123_only_when_unknown() {
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    // `regsub -command` with an unknown head → W123 on the prefix.
+    let bad = "regsub -command {(\\w+)} $s missingCb out\n";
+    let codes: Vec<_> = a
+        .analyse(bad, "tcl9.0")
+        .diagnostics
+        .iter()
+        .map(|d| d.code.to_string())
+        .collect();
+    assert!(
+        codes.iter().any(|c| c == "W123"),
+        "an unknown regsub -command head must fire W123; got {codes:?}"
+    );
+    // A defined head → recorded, no W123. (Without `-command` the same word is a
+    // replacement template and is never treated as a command.)
+    let ok = "proc doSub {whole} { string toupper $whole }\nregsub -command {(\\w+)} $s doSub out\n";
+    let r = a.analyse(ok, "tcl9.0");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code.to_string() == "W123"),
+        "a defined regsub -command head must not fire W123"
+    );
+    assert!(
+        r.command_invocations.iter().any(|i| i.name == "doSub"),
+        "regsub -command must record a reference to its head"
+    );
+    // No `-command`: the third positional is a template, not a command.
+    let template = "regsub {(\\w+)} $s missingCb out\n";
+    assert!(
+        !a.analyse(template, "tcl9.0")
+            .diagnostics
+            .iter()
+            .any(|d| d.code.to_string() == "W123"),
+        "a plain regsub subSpec must never be treated as a command"
+    );
+}
+
+#[test]
+fn coroinject_records_reference_but_never_arity_checks() {
+    // `coroinject`'s appended arity is Unknown (depends on the yield point), so
+    // the injected command is a reference/W123 surface but is never arity-checked.
+    let reg = CommandRegistry::build_default();
+    let src = "proc worker {args} { yield }\nproc kick {c} {\n    coroinject $c worker extra\n}\n";
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    let edges = g["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("kick")
+                && e["callee"].as_str().unwrap_or("").contains("worker")
+        }),
+        "expected a kick→worker edge from `coroinject`; got {g}"
+    );
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let r = a.analyse(src, "tcl9.0");
+    let inj = r
+        .command_invocations
+        .iter()
+        .find(|i| i.name == "worker")
+        .expect("coroinject records the injected command");
+    assert_eq!(
+        inj.callback_arity,
+        Some(tcl_registry::AppendedArity::Unknown),
+        "coroinject's callback arity is Unknown so it is never flagged too-few/too-many"
+    );
+}
+
+/// tcllib callbacks flow through the same substrate.  This exercises two tcllib
+/// paths at once: a sub-command-offset callback (`struct::list split`, arg after
+/// the sub-command word) and a full-name math callback declared via the
+/// `PREFIX_OVERRIDES` side table.
+#[test]
+fn tcllib_struct_list_split_is_a_callback_edge() {
+    let reg = CommandRegistry::build_default();
+    let src = "proc isEven {n} { expr {$n % 2 == 0} }\nproc part {items} {\n    struct::list split $items isEven evens odds\n}\n";
+    let g = graphs::call_graph(src, &reg, "tcl9.0");
+    let edges = g["edges"].as_array().expect("edges array");
+    assert!(
+        edges.iter().any(|e| {
+            e["caller"].as_str().unwrap_or("").contains("part")
+                && e["callee"].as_str().unwrap_or("").contains("isEven")
+        }),
+        "expected a part→isEven edge from `struct::list split`; got {g}"
+    );
+}
+
+#[test]
+fn tcllib_calculus_func_records_reference_with_fixed_arity() {
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let src = "proc f {x} { expr {$x * $x} }\nmath::calculus::integral 0 1 100 f\n";
+    let r = a.analyse(src, "tcl9.0");
+    let inv = r
+        .command_invocations
+        .iter()
+        .find(|i| i.name == "f")
+        .expect("math::calculus::integral records its func callback");
+    assert_eq!(
+        inv.callback_arity,
+        Some(tcl_registry::AppendedArity::Exactly(1)),
+        "the calculus func callback carries its man-page-pinned Exactly(1) arity"
+    );
+}

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -393,21 +393,31 @@ pub fn command_arity<'db>(
 fn cross_file_arity_diagnostic(
     name: &str,
     span: tcl_lexer::Span,
-    argc: usize,
+    argc: (usize, Option<usize>),
     candidates: &[(usize, usize)],
 ) -> Option<tcl_compiler::analyser::types::Diagnostic> {
     use tcl_compiler::analyser::types::{Diagnostic, Severity};
+    // `argc` is the caller's supplied arg-count RANGE `(lo, hi)`: an ordinary
+    // call is exact (`(k, Some(k))`); a command-prefix callback with an
+    // `AtLeast(n)` arity is open-ended (`(baked+n, None)`).  Flag too-few only
+    // when even the MOST args the caller can supply (`hi`) is below the proc's
+    // `min`, and too-many only when even the FEWEST args (`lo`) exceeds `max` —
+    // so an open-ended callback never false-fires "too few".
+    let (lo, hi) = argc;
     let min = candidates.iter().map(|&(lo, _)| lo).min()?;
     let max = candidates.iter().map(|&(_, hi)| hi).max()?;
-    let (code, message) = if argc < min {
+    let (code, message) = if hi.is_some_and(|h| h < min) {
         (
             DiagCode::E002,
-            format!("Too few arguments for '{name}': expected at least {min}, got {argc}"),
+            format!(
+                "Too few arguments for '{name}': expected at least {min}, got {}",
+                hi.unwrap_or(lo)
+            ),
         )
-    } else if max != usize::MAX && argc > max {
+    } else if max != usize::MAX && lo > max {
         (
             DiagCode::E003,
-            format!("Too many arguments for '{name}': expected at most {max}, got {argc}"),
+            format!("Too many arguments for '{name}': expected at most {max}, got {lo}"),
         )
     } else {
         return None;
@@ -472,13 +482,61 @@ pub fn apply_cross_file_resolution<S: std::hash::BuildHasher>(
         if let Some(candidates) = arities.get(name)
             && !candidates.is_empty()
             && let Some(Some(argc)) = argc_by_span.get(&(span.start(), span.end()))
-            && let Some(diag) = cross_file_arity_diagnostic(name, *span, *argc, candidates)
+            && let Some(diag) =
+                cross_file_arity_diagnostic(name, *span, (*argc, Some(*argc)), candidates)
             && !is_disabled(diag.code.as_str())
         {
             out.push(diag);
         }
     }
+    apply_callback_arity(&mut out, invocations, arities, &is_disabled);
     out
+}
+
+/// Validate command-prefix **callback** arity: for each recorded callback head
+/// (`lsort -command myCompare` → `myCompare` with `callback_arity =
+/// Exactly(2)`), check that the referenced project proc accepts the arguments
+/// the calling command appends.
+///
+/// The effective arg count is a RANGE — `baked` args already in the prefix
+/// (`{myCmp extra}` bakes one; a bare word bakes zero) plus the command's
+/// appended arity (`Exactly(n)` ⇒ `(n, Some(n))`, `AtLeast(n)` ⇒ `(n, None)`).
+/// Skipped for `Unknown`/absent arities and for tails the project resolves
+/// with a non-proc (empty candidate list), reusing the same E002/E003 codes,
+/// disable filter, and message shape as the direct-call cross-file check.
+/// Same-file callbacks are covered too: `project_command_arities` aggregates
+/// every file, so a same-file proc's arity is in `arities`.
+fn apply_callback_arity<S: std::hash::BuildHasher>(
+    out: &mut Vec<tcl_compiler::analyser::types::Diagnostic>,
+    invocations: &[tcl_compiler::signature_scan::types::SignatureCommandInvocation],
+    arities: &HashMap<String, Vec<(usize, usize)>, S>,
+    is_disabled: impl Fn(&str) -> bool,
+) {
+    for inv in invocations {
+        let Some(appended) = inv.callback_arity else {
+            continue;
+        };
+        if !appended.is_checkable() {
+            continue;
+        }
+        // Tail-resolve the callback head against the project arity table.
+        let tail = inv.name.rsplit("::").next().unwrap_or(&inv.name);
+        let Some(candidates) = arities.get(tail) else {
+            continue;
+        };
+        if candidates.is_empty() {
+            continue;
+        }
+        // Baked args already present in the prefix (0 for a bareword head).
+        let baked = inv.argc.unwrap_or(0);
+        let lo = baked + appended.min() as usize;
+        let hi = appended.max().map(|m| baked + m as usize);
+        if let Some(diag) = cross_file_arity_diagnostic(&inv.name, inv.range, (lo, hi), candidates)
+            && !is_disabled(diag.code.as_str())
+        {
+            out.push(diag);
+        }
+    }
 }
 
 /// Analyser diagnostics for `file` resolved against the project:
@@ -530,6 +588,14 @@ pub fn project_diagnostics(
     }
     for (_, name) in &analysis.unresolved_command_sites {
         tails.insert(name.as_str());
+    }
+    // Command-prefix callback heads (`lsort -command myCompare`) resolve (they
+    // are not W123/unresolved), so their target proc's arity would not be
+    // loaded — pull each callback tail in so `apply_callback_arity` can check it.
+    for inv in &analysis.command_invocations {
+        if inv.callback_arity.is_some() {
+            tails.insert(inv.name.rsplit("::").next().unwrap_or(&inv.name));
+        }
     }
     let mut arities: HashMap<String, Vec<(usize, usize)>> = HashMap::new();
     for tail in tails {
@@ -3729,6 +3795,75 @@ mod tests {
             !d.iter()
                 .any(|x| x.code == DiagCode::W123 && x.message.contains("helper")),
             "the nested call still resolves cross-file (no W123)"
+        );
+    }
+
+    /// Analyse a single-file project and return its diagnostic codes+messages.
+    fn callback_arity_codes(src: &str) -> Vec<(String, String)> {
+        let db = TclDatabase::default();
+        let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
+        let f = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned());
+        let proj = Project::new(&db, vec![f]);
+        project_diagnostics(&db, f, cfg, proj)
+            .iter()
+            .map(|d| (d.code.as_str().to_owned(), d.message.clone()))
+            .collect()
+    }
+
+    #[test]
+    fn callback_arity_mismatch_draws_e002() {
+        // `lsort -command` appends 2 (Exactly(2)); `badCb` needs 3 → E002 too few.
+        let d =
+            callback_arity_codes("proc badCb {a b c} { return 0 }\nlsort -command badCb {3 1 2}\n");
+        assert!(
+            d.iter().any(|(c, m)| c == "E002" && m.contains("badCb")),
+            "a callback proc needing 3 args used where 2 are appended must draw E002; got {d:?}"
+        );
+    }
+
+    #[test]
+    fn callback_arity_correct_is_silent() {
+        // A 2-arg callback matches lsort's Exactly(2) → no arity error (TN).
+        let d =
+            callback_arity_codes("proc goodCb {a b} { return 0 }\nlsort -command goodCb {3 1 2}\n");
+        assert!(
+            !d.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "a correctly-sized callback must draw no arity error; got {d:?}"
+        );
+    }
+
+    #[test]
+    fn callback_arity_too_many_draws_e003() {
+        // A 1-param callback where lsort appends 2 → E003 too many.
+        let d =
+            callback_arity_codes("proc oneArg {a} { return 0 }\nlsort -command oneArg {3 1 2}\n");
+        assert!(
+            d.iter().any(|(c, m)| c == "E003" && m.contains("oneArg")),
+            "a 1-param callback fed 2 args must draw E003; got {d:?}"
+        );
+    }
+
+    #[test]
+    fn callback_arity_args_catchall_is_silent() {
+        // FP guard: an `args` catch-all accepts any count → no arity error.
+        let d =
+            callback_arity_codes("proc anyN {args} { return 0 }\nlsort -command anyN {3 1 2}\n");
+        assert!(
+            !d.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "an `args`-catchall callback must draw no arity error; got {d:?}"
+        );
+    }
+
+    #[test]
+    fn callback_arity_atleast_does_not_false_fire_too_few() {
+        // FP guard: `trace add variable` appends 3 (AtLeast? no — Exactly(3)); use
+        // `trace add execution` (AtLeast(2)) against a 4-param handler.  The
+        // open-ended max means "too few" must not fire even though `min`=2 < 4.
+        let src = "proc h {a b c d} { return 0 }\ntrace add execution somecmd enter h\n";
+        let d = callback_arity_codes(src);
+        assert!(
+            !d.iter().any(|(c, _)| c == "E002"),
+            "an AtLeast(2) callback must not false-fire E002 against a 4-param handler; got {d:?}"
         );
     }
 

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -3891,6 +3891,30 @@ mod tests {
     }
 
     #[test]
+    fn callback_arity_tk_scale_command_arity_checked() {
+        // Post-conversion: `scale -command` appends the new value (Exactly(1)).
+        // A 0-param callback can't accept it → E003; a bareword 1-param callback
+        // is silent (TN).
+        let bad = callback_arity_codes("proc onChange {} { }\nscale .s -command onChange\n");
+        assert!(
+            bad.iter().any(|(c, m)| c == "E003" && m.contains("onChange")),
+            "a 0-param `scale -command` callback (1 appended) must draw E003; got {bad:?}"
+        );
+        let ok = callback_arity_codes("proc onChange {v} { }\nscale .s -command onChange\n");
+        assert!(
+            !ok.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "a correct 1-param scale callback must be silent; got {ok:?}"
+        );
+        // A braced widget-path scroll callback is never arity-checked (not a
+        // literal bareword head) — no false arity error.
+        let widget = callback_arity_codes("listbox .lb -yscrollcommand {.sb set}\n");
+        assert!(
+            !widget.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "a braced widget-path scroll callback must not draw an arity error; got {widget:?}"
+        );
+    }
+
+    #[test]
     fn callback_arity_tcllib_calculus_func_arity_checked() {
         // `math::calculus::integral begin end nosteps func` calls `func x`
         // (Exactly(1), man-page-pinned).  A 2-param func is under-fed → E002.

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -3867,6 +3867,61 @@ mod tests {
         );
     }
 
+    #[test]
+    fn callback_arity_namespace_unknown_zero_param_draws_e003() {
+        // `namespace unknown h` invokes `h cmd ?args...?` (AtLeast(1)); a 0-param
+        // handler can never accept the appended command name → E003 too-many. A
+        // real bug (ground truth: tclsh 9.0 raises "called with too many args").
+        let d = callback_arity_codes("proc h {} { return 0 }\nnamespace unknown h\n");
+        assert!(
+            d.iter().any(|(c, m)| c == "E003" && m.contains("'h'")),
+            "a 0-param `namespace unknown` handler must draw E003; got {d:?}"
+        );
+    }
+
+    #[test]
+    fn callback_arity_package_unknown_variadic_handler_is_silent() {
+        // FP guard: `package unknown` appends AtLeast(1); an `args` handler
+        // absorbs any count → no arity error (the canonical handler shape).
+        let d = callback_arity_codes("proc h {args} { return 0 }\npackage unknown h\n");
+        assert!(
+            !d.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "a variadic `package unknown` handler must draw no arity error; got {d:?}"
+        );
+    }
+
+    #[test]
+    fn callback_arity_tcllib_calculus_func_arity_checked() {
+        // `math::calculus::integral begin end nosteps func` calls `func x`
+        // (Exactly(1), man-page-pinned).  A 2-param func is under-fed → E002.
+        let d = callback_arity_codes(
+            "proc f {x y} { expr {$x + $y} }\nmath::calculus::integral 0 1 100 f\n",
+        );
+        assert!(
+            d.iter().any(|(c, m)| c == "E002" && m.contains("'f'")),
+            "a 2-param func where calculus::integral appends 1 must draw E002; got {d:?}"
+        );
+        // The correct 1-param shape is silent (TN).
+        let ok =
+            callback_arity_codes("proc f {x} { expr {$x * 2} }\nmath::calculus::integral 0 1 100 f\n");
+        assert!(
+            !ok.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "a correct 1-param calculus func must be silent; got {ok:?}"
+        );
+    }
+
+    #[test]
+    fn callback_arity_unknown_appended_never_fires() {
+        // FP guard: `coroinject`/`coroprobe` carry `Unknown` appended arity
+        // (depends on the yield point), so the injected command is a reference
+        // only — never arity-checked, whatever its param count.
+        let d = callback_arity_codes("proc h {} { return 0 }\ncoroinject myCoro h\n");
+        assert!(
+            !d.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "an Unknown-arity callback must never draw an arity error; got {d:?}"
+        );
+    }
+
     /// Regression (whole-file-shift determinism): a pure prepend that shifts every
     /// procedure must leave every `function_lattice` a cache hit — reliably, not by
     /// HashMap-seed luck.  Before `prepare_cfg_context` was made deterministic, the

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -3512,6 +3512,53 @@ mod tests {
         );
     }
 
+    /// Object-instance method callbacks resolve cross-file — including when the
+    /// dispatch is **inside a proc body**, which the incremental per-item
+    /// firewall (`file_analysis_incremental`, used by `project_diagnostics`)
+    /// otherwise missed because it defers instance creation to the graft.
+    /// Registry object-factories now bind eagerly in an isolated body, so the
+    /// in-body `$g walk … -command cb` records the callback and its arity is
+    /// resolved against the other file.
+    #[test]
+    fn cross_file_in_proc_instance_method_callback_arity() {
+        let db = TclDatabase::default();
+        let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
+        // B defines onNode with 2 params; `graph walk -command` appends 3.
+        let b = SourceFile::new(&db, "proc onNode {a b} { }\n".to_owned(), "tcl9.0".to_owned());
+        let has_e003 = |src: &str| {
+            let a = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned());
+            let p = Project::new(&db, vec![a, b]);
+            project_diagnostics(&db, a, cfg, p)
+                .iter()
+                .any(|d| d.code.as_str() == "E003" && d.message.contains("onNode"))
+        };
+        // Named factory + dispatch both inside a proc body.
+        assert!(
+            has_e003("proc build {} {\n struct::graph g\n g walk root -command onNode\n}\n"),
+            "in-proc `struct::graph g; g walk -command onNode` must resolve cross-file arity (E003)"
+        );
+        // Handle form (`set g [struct::graph]`) inside a proc body.
+        assert!(
+            has_e003("proc build {} {\n set g [struct::graph]\n $g walk root -command onNode\n}\n"),
+            "in-proc `set g [struct::graph]; $g walk -command onNode` must resolve cross-file arity"
+        );
+        // Correct arity (3 params) is silent.
+        let b3 = SourceFile::new(&db, "proc onNode {a b c} { }\n".to_owned(), "tcl9.0".to_owned());
+        let a_ok = SourceFile::new(
+            &db,
+            "proc build {} {\n struct::graph g\n g walk root -command onNode\n}\n".to_owned(),
+            "tcl9.0".to_owned(),
+        );
+        let p_ok = Project::new(&db, vec![a_ok, b3]);
+        assert!(
+            !project_diagnostics(&db, a_ok, cfg, p_ok)
+                .iter()
+                .any(|d| (d.code.as_str() == "E003" || d.code.as_str() == "E002")
+                    && d.message.contains("onNode")),
+            "a correct 3-param in-proc instance callback must be silent cross-file"
+        );
+    }
+
     /// Cross-file arity honours `disabled_diagnostics`:
     /// the synthesized arity error is produced *after* the analyser's own code
     /// filter (and the LSP lift doesn't re-filter), so it must replicate it —

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -3997,6 +3997,41 @@ mod tests {
         );
     }
 
+    #[test]
+    fn callback_arity_struct_graph_walk_command_checked() {
+        // `$g walk … -command cb` (object instance method) appends 3 (action
+        // graphName node).  A 2-param callback is over-fed → E003; a 3-param one
+        // is silent.  Exercises both the named (`struct::graph name`) and handle
+        // (`set g [struct::graph]`) instance forms.
+        let bad = callback_arity_codes(
+            "proc twoP {a b} { }\nstruct::graph myG\nmyG walk root -command twoP\n",
+        );
+        assert!(
+            bad.iter().any(|(c, m)| c == "E003" && m.contains("'twoP'")),
+            "a 2-param graph walk -command callback (3 appended) must draw E003; got {bad:?}"
+        );
+        let ok = callback_arity_codes(
+            "proc threeP {a b c} { }\nset g [struct::graph]\n$g walk root -command threeP\n",
+        );
+        assert!(
+            !ok.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "a correct 3-param graph walk callback must be silent; got {ok:?}"
+        );
+    }
+
+    #[test]
+    fn callback_arity_struct_tree_walkproc_checked() {
+        // `$t walkproc … cmdprefix` (trailing positional prefix) appends 3 (tree
+        // node action).  A 2-param callback → E003.
+        let bad = callback_arity_codes(
+            "proc twoP {a b} { }\nstruct::tree myT\nmyT walkproc root twoP\n",
+        );
+        assert!(
+            bad.iter().any(|(c, m)| c == "E003" && m.contains("'twoP'")),
+            "a 2-param tree walkproc callback (3 appended) must draw E003; got {bad:?}"
+        );
+    }
+
     /// Regression (whole-file-shift determinism): a pure prepend that shifts every
     /// procedure must leave every `function_lattice` a cache hit — reliably, not by
     /// HashMap-seed luck.  Before `prepare_cfg_context` was made deterministic, the

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -3946,6 +3946,57 @@ mod tests {
         );
     }
 
+    #[test]
+    fn callback_arity_option_value_exactly_checked() {
+        // `smtp -tlspolicy` and `halfpipe -write-command` both append exactly 2;
+        // a 1-param callback is over-fed → E003, a 2-param callback is silent.
+        let smtp_bad =
+            callback_arity_codes("proc pol {code} { }\nsmtp::sendmessage $t -tlspolicy pol\n");
+        assert!(
+            smtp_bad.iter().any(|(c, m)| c == "E003" && m.contains("'pol'")),
+            "a 1-param -tlspolicy callback (2 appended) must draw E003; got {smtp_bad:?}"
+        );
+        let smtp_ok =
+            callback_arity_codes("proc pol {code diag} { }\nsmtp::sendmessage $t -tlspolicy pol\n");
+        assert!(
+            !smtp_ok.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "a correct 2-param -tlspolicy callback must be silent; got {smtp_ok:?}"
+        );
+        let pipe_bad =
+            callback_arity_codes("proc w {chan} { }\ntcl::chan::halfpipe -write-command w\n");
+        assert!(
+            pipe_bad.iter().any(|(c, m)| c == "E003" && m.contains("'w'")),
+            "a 1-param -write-command callback (2 appended) must draw E003; got {pipe_bad:?}"
+        );
+    }
+
+    #[test]
+    fn callback_arity_mime_getbody_command_atleast_one() {
+        // `mime::getbody -command` appends AtLeast(1) (reason keyword + optional
+        // payload).  A 0-param callback can't accept the reason word → E003; the
+        // canonical `{reason args}` shape is silent (open-ended max ⇒ no
+        // false "too many").
+        let bad = callback_arity_codes("proc cb {} { }\nmime::getbody $t -command cb\n");
+        assert!(
+            bad.iter().any(|(c, m)| c == "E003" && m.contains("'cb'")),
+            "a 0-param mime -command callback must draw E003; got {bad:?}"
+        );
+        let ok = callback_arity_codes("proc cb {reason args} { }\nmime::getbody $t -command cb\n");
+        assert!(
+            !ok.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "a `{{reason args}}` mime -command callback must be silent; got {ok:?}"
+        );
+        // FP guard: comm's 14-arg reply callback is virtually always `{args}` —
+        // the catch-all absorbs all 14 → no arity error.
+        let comm = callback_arity_codes(
+            "proc reply {args} { }\ncomm::comm send -command reply $id {list x}\n",
+        );
+        assert!(
+            !comm.iter().any(|(c, _)| c == "E002" || c == "E003"),
+            "a variadic comm -command reply handler must be silent; got {comm:?}"
+        );
+    }
+
     /// Regression (whole-file-shift determinism): a pure prepend that shifts every
     /// procedure must leave every `function_lattice` a cache hit — reliably, not by
     /// HashMap-seed luck.  Before `prepare_cfg_context` was made deterministic, the

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -52,6 +52,78 @@ const DEFAULT_TIMEOUT: Duration = Duration::from_secs(30);
 /// Longer default for `initialize` / `request` without an explicit deadline.
 const REQUEST_TIMEOUT: Duration = Duration::from_mins(1);
 
+/// A greppable marker every latency-barrier timeout carries, so a CI-log scan
+/// (human or tooling) can classify the failure without reading the prose.
+const BARRIER_TIMEOUT_MARKER: &str = "LATENCY-BARRIER-TIMEOUT";
+
+/// Diagnostic footer appended to every latency-barrier timeout panic in this
+/// harness (`request_timeout`, `await_diagnostics_version`, `await_log`,
+/// `await_notification`, and the config-settle barrier).
+///
+/// A barrier timeout means the server did not *respond* within the deadline — a
+/// latency failure, categorically distinct from an oracle/content divergence
+/// (those panic with "diverged" / "alignment broke" instead). On CI the
+/// dominant cause is the test process being denied CPU on an oversubscribed
+/// runner, not a server defect: the latency-sensitive e2e stress tests
+/// (`edit_tracking_stress::*` and the semantic-token latency benchmark) can
+/// starve each other, which is exactly why `.config/nextest.toml` isolates them
+/// into a single-slot `heavy-lsp-e2e` group and the dedicated `lsp-e2e` CI job
+/// runs them that way and stays green.
+///
+/// Rather than leave every investigator to re-derive that from a bare "timed
+/// out" message, we *probe scheduling health at the moment of giving up*: a
+/// short sleep the OS honours many-fold late is direct, in-log evidence that
+/// the runner is starving this process, so the timeout is a scheduling artefact
+/// rather than a hang. If the probe finds the scheduler healthy it says so,
+/// redirecting the investigation toward a real server-latency regression.
+fn latency_barrier_timeout_note() -> String {
+    // Sample how late the scheduler wakes us from a short, known sleep. On an
+    // unloaded machine `actual ≈ target` (a few percent over, from timer
+    // granularity); under heavy oversubscription the wake is delayed many-fold.
+    // Median of a handful of samples so one unlucky context switch can't skew
+    // the verdict. This runs only on the already-failing path, so its ~100 ms
+    // cost is irrelevant.
+    const TARGET: Duration = Duration::from_millis(20);
+    const SAMPLES: usize = 5;
+    let mut ratios = [0f64; SAMPLES];
+    for r in &mut ratios {
+        let t = Instant::now();
+        std::thread::sleep(TARGET);
+        *r = t.elapsed().as_secs_f64() / TARGET.as_secs_f64();
+    }
+    ratios.sort_by(|a, b| a.partial_cmp(b).expect("sleep ratios are finite"));
+    let median = ratios[SAMPLES / 2];
+
+    // >=2.5x late is far outside timer-granularity noise and only happens when
+    // the OS cannot schedule this thread promptly — i.e. the runner is starved.
+    let verdict = if median >= 2.5 {
+        format!(
+            "PROBE: CPU STARVATION CONFIRMED — a {TARGET:?} sleep is waking {median:.1}x late \
+             right now, so the OS is denying this test process CPU. The barrier above expired on \
+             scheduling delay, NOT a server hang or a buffer-tracking bug. This is the known \
+             flake: re-run the job."
+        )
+    } else {
+        format!(
+            "PROBE: could not confirm starvation — a {TARGET:?} sleep woke {median:.1}x late, \
+             within normal timer noise. The runner looks healthy *now*; if this repeats with a \
+             healthy probe, suspect a real server-latency regression (a hang/deadlock or a \
+             genuinely slow analysis), not CPU starvation."
+        )
+    };
+
+    format!(
+        "\n\n{BARRIER_TIMEOUT_MARKER} — this is a TIMEOUT (the server did not respond in time), \
+         NOT an oracle/content divergence (those fail with \"diverged\" / \"alignment broke\").\n\
+         {verdict}\n\
+         CONTEXT: the latency-sensitive e2e stress tests are isolated into the single-slot \
+         `heavy-lsp-e2e` nextest group (.config/nextest.toml) so they never starve each other; \
+         the dedicated `lsp-e2e` CI job runs them isolated and stays green. A timeout seen only in \
+         the *unisolated* `rust-tests` job (which runs them amid the full parallel suite) is the \
+         known CPU-starvation flake."
+    )
+}
+
 /// Process-wide counter so `unique_uri` never collides across tests in one
 /// integration-test binary (each binary is its own process).
 static URI_COUNTER: AtomicU64 = AtomicU64::new(0);
@@ -308,8 +380,9 @@ impl Lsp {
             }
             assert!(
                 Instant::now() < deadline,
-                "timed out after {timeout:?} waiting for response to {method:?}; stderr:\n{}",
-                self.stderr_text()
+                "timed out after {timeout:?} waiting for response to {method:?}; stderr:\n{}{}",
+                self.stderr_text(),
+                latency_barrier_timeout_note(),
             );
             std::thread::sleep(Duration::from_millis(2));
         }
@@ -478,10 +551,15 @@ impl Lsp {
                 return diags;
             }
             let remaining = deadline.saturating_duration_since(Instant::now());
-            assert!(
-                !remaining.is_zero(),
-                "no publishDiagnostics for {uri:?} version {version:?} within {timeout:?}"
-            );
+            if remaining.is_zero() {
+                // Release the notifications lock before the (sleeping) probe so
+                // the reader thread isn't blocked while we diagnose the timeout.
+                drop(notes);
+                panic!(
+                    "no publishDiagnostics for {uri:?} version {version:?} within {timeout:?}{}",
+                    latency_barrier_timeout_note()
+                );
+            }
             let (guard, _) = self
                 .shared
                 .notify_cv
@@ -511,10 +589,15 @@ impl Lsp {
                 }
             }
             let remaining = deadline.saturating_duration_since(Instant::now());
-            assert!(
-                !remaining.is_zero(),
-                "no window/logMessage containing all of {needles:?} within {timeout:?}"
-            );
+            if remaining.is_zero() {
+                // Release the notifications lock before the (sleeping) probe so
+                // the reader thread isn't blocked while we diagnose the timeout.
+                drop(notes);
+                panic!(
+                    "no window/logMessage containing all of {needles:?} within {timeout:?}{}",
+                    latency_barrier_timeout_note()
+                );
+            }
             let (guard, _) = self
                 .shared
                 .notify_cv
@@ -536,10 +619,15 @@ impl Lsp {
                 return note.clone();
             }
             let remaining = deadline.saturating_duration_since(Instant::now());
-            assert!(
-                !remaining.is_zero(),
-                "no {method:?} notification within {timeout:?}"
-            );
+            if remaining.is_zero() {
+                // Release the notifications lock before the (sleeping) probe so
+                // the reader thread isn't blocked while we diagnose the timeout.
+                drop(notes);
+                panic!(
+                    "no {method:?} notification within {timeout:?}{}",
+                    latency_barrier_timeout_note()
+                );
+            }
             let (guard, _) = self
                 .shared
                 .notify_cv
@@ -761,7 +849,10 @@ impl Lsp {
             }
             std::thread::sleep(Duration::from_millis(50));
         }
-        panic!("config did not settle within {DEFAULT_TIMEOUT:?}; last: {last}");
+        panic!(
+            "config did not settle within {DEFAULT_TIMEOUT:?}; last: {last}{}",
+            latency_barrier_timeout_note()
+        );
     }
 }
 
@@ -867,4 +958,35 @@ fn auto_reply(msg: &Value, shared: &Arc<Shared>) {
     let _ = write!(stdin, "Content-Length: {}\r\n\r\n", body.len());
     let _ = stdin.write_all(&body);
     let _ = stdin.flush();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{BARRIER_TIMEOUT_MARKER, latency_barrier_timeout_note};
+
+    /// The footer every barrier timeout carries must keep classifying the
+    /// failure as a *timeout* (not an oracle divergence), render the live
+    /// scheduling probe, and point at the `heavy-lsp-e2e` isolation — so a
+    /// future edit that guts the message is caught here rather than in a
+    /// midnight CI triage. (Regression guard for the self-diagnosing barrier.)
+    #[test]
+    fn barrier_timeout_note_is_self_classifying() {
+        let note = latency_barrier_timeout_note();
+        assert!(
+            note.contains(BARRIER_TIMEOUT_MARKER),
+            "note must carry the greppable marker; got:\n{note}"
+        );
+        assert!(
+            note.contains("TIMEOUT") && note.contains("NOT an oracle/content divergence"),
+            "note must distinguish a timeout from a content divergence; got:\n{note}"
+        );
+        assert!(
+            note.contains("PROBE:"),
+            "note must render the live scheduling-health probe verdict; got:\n{note}"
+        );
+        assert!(
+            note.contains("heavy-lsp-e2e") && note.contains("rust-tests"),
+            "note must point at the nextest isolation and the unisolated job; got:\n{note}"
+        );
+    }
 }

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -292,6 +292,32 @@ fn w220_dead_store_inside_dict_for_body_fires() {
     assert!(on_line(&diags, "W220").contains(&2));
 }
 
+#[test]
+fn uplevel_issue_837_body_is_silent_through_server() {
+    // Issue #837: the exact reproducer must produce no diagnostics through the
+    // packaged server — the recursed `uplevel` body is clean Tcl.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc forgetXyce {} {\n    uplevel 1 {foreach nameSpc [namespace children ::Foo] {\n        namespace forget ${nameSpc}::*\n    }}\n}\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        diags.is_empty(),
+        "issue #837 repro must be silent: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn uplevel_unbraced_substituted_body_fires_w105_through_server() {
+    // Now that `uplevel`'s body is registry-known, an unbraced substituted body
+    // fires W105 end-to-end, exactly as `eval` does — guiding the user to brace it.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc f {} {\n    uplevel 1 \"puts $x\"\n}\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(has_code(&diags, "W105"), "{:?}", codes(&diags));
+}
+
 // -- Clean code stays clean (cross-family negative control) --------------
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
+++ b/rust/tcl-lsp-server/tests/e2e/semantic_tokens.rs
@@ -608,6 +608,63 @@ fn test_struct_list_foreachperm_body_recursion() {
 }
 
 #[test]
+fn test_uplevel_body_recursion() {
+    // Issue #837: the braced body of `uplevel ?level? {…}` is a script and
+    // must recurse end-to-end through the packaged server — `foreach` inside
+    // it is a keyword and `puts` a function, not one opaque string.
+    let mut lsp = Lsp::tcl();
+    let lg = legend(&lsp);
+    for src in [
+        "uplevel 1 {foreach x $l { puts $x }}\n",
+        "uplevel {foreach x $l { puts $x }}\n",
+        "uplevel #0 {foreach x $l { puts $x }}\n",
+    ] {
+        let uri = open_doc(&mut lsp, src);
+        let tokens = typed(&mut lsp, &lg, &uri);
+        let has_foreach = tokens
+            .iter()
+            .any(|t| t.ttype == "keyword" && covered(src, t) == "foreach");
+        assert!(
+            has_foreach,
+            "uplevel body not recursed for {src:?}: {tokens:?}"
+        );
+        let has_puts = tokens
+            .iter()
+            .any(|t| t.ttype == "function" && covered(src, t) == "puts");
+        assert!(
+            has_puts,
+            "uplevel body `puts` not recursed for {src:?}: {tokens:?}"
+        );
+    }
+}
+
+#[test]
+fn test_uplevel_issue_837_repro_recursion() {
+    // The exact reproducer from issue #837 — the `namespace children` /
+    // `namespace forget` body inside `uplevel 1 {…}` highlights end-to-end.
+    let mut lsp = Lsp::tcl();
+    let lg = legend(&lsp);
+    let src = "proc forgetXyce {} {\n    uplevel 1 {foreach nameSpc [namespace children ::SpiceGenTcl::Xyce] {\n        namespace forget ${nameSpc}::*\n    }}\n}\n";
+    let uri = open_doc(&mut lsp, src);
+    let tokens = typed(&mut lsp, &lg, &uri);
+    let has_foreach = tokens
+        .iter()
+        .any(|t| t.ttype == "keyword" && covered(src, t) == "foreach");
+    assert!(
+        has_foreach,
+        "issue #837 body `foreach` not recursed: {tokens:?}"
+    );
+    // `namespace` appears twice inside the body; at least one must highlight.
+    let has_namespace = tokens
+        .iter()
+        .any(|t| covered(src, t) == "namespace" && (t.ttype == "keyword" || t.ttype == "function"));
+    assert!(
+        has_namespace,
+        "issue #837 body `namespace` not recursed: {tokens:?}"
+    );
+}
+
+#[test]
 fn test_bind_script_body_recursion() {
     // `bind tag sequence script` — the trailing event-handler script recurses
     // rather than being emitted as one opaque string (issue #785), so `set`

--- a/rust/tcl-registry/src/arg_role.rs
+++ b/rust/tcl-registry/src/arg_role.rs
@@ -68,8 +68,68 @@ pub enum ArgRole {
     /// name, invoked at runtime with further arguments appended (`lsort
     /// -command cmdPrefix`, trace callbacks).  Distinct from `Body` (a
     /// complete script to recurse) and from a generic `Value`: the first word
-    /// is a callable reference, not a script.  Declarative for now — captured
-    /// so callback-aware tooling can resolve the prefix later; marking such a
-    /// value `Body` would wrongly recurse a bareword proc name as a script.
+    /// is a callable reference, not a script — marking such a value `Body`
+    /// would wrongly recurse a bareword proc name as a script.
+    ///
+    /// A first-class command **reference**: the compiler records the prefix
+    /// head as a call site (highlighting, find-references, call graph,
+    /// call-hierarchy, dead-code, W123) and — via the paired
+    /// [`AppendedArity`] — checks the callback's arity.  The number of args
+    /// the calling command appends lives in the registry beside the role
+    /// (`CommandSpec::command_prefixes` / `command_prefix_resolver`, or an
+    /// option's [`crate::hover::OptionArg::appended_arity`]), never in the
+    /// compiler.
     CommandPrefix,
+}
+
+/// How many arguments a command appends to a [`ArgRole::CommandPrefix`]
+/// callback when it invokes it.
+///
+/// Sourced from C Tcl 9.0 behaviour (`lsort -command` appends 2, `trace add
+/// variable` appends 3, `socket -server` appends 3, …).  Paired with a
+/// `CommandPrefix` declaration so the arity checker can validate that the
+/// referenced proc accepts `baked_args + appended` arguments, where
+/// `baked_args` are any words already present in the prefix itself
+/// (`{myCmp extra}` bakes one).
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+#[non_exhaustive]
+pub enum AppendedArity {
+    /// Exactly `n` args are appended (`lsort -command` → `Exactly(2)`).
+    Exactly(u8),
+    /// At least `n` args are appended; the maximum is unbounded or
+    /// form-dependent (`trace add execution` → `AtLeast(2)`, `regsub
+    /// -command` → `AtLeast(1)`, variadic `interp alias` → `AtLeast(0)`).
+    AtLeast(u8),
+    /// The appended count can't be determined statically — no arity check.
+    /// The default, so a bare `CommandPrefix` declaration is arity-inert.
+    #[default]
+    Unknown,
+}
+
+impl AppendedArity {
+    /// The minimum number of appended args (0 when [`Unknown`](Self::Unknown)).
+    #[must_use]
+    pub const fn min(self) -> u8 {
+        match self {
+            Self::Exactly(n) | Self::AtLeast(n) => n,
+            Self::Unknown => 0,
+        }
+    }
+
+    /// The maximum number of appended args, or `None` when unbounded /
+    /// unknown.
+    #[must_use]
+    pub const fn max(self) -> Option<u8> {
+        match self {
+            Self::Exactly(n) => Some(n),
+            Self::AtLeast(_) | Self::Unknown => None,
+        }
+    }
+
+    /// Whether an arity check should run at all — `false` for
+    /// [`Unknown`](Self::Unknown), whose count is indeterminate.
+    #[must_use]
+    pub const fn is_checkable(self) -> bool {
+        !matches!(self, Self::Unknown)
+    }
 }

--- a/rust/tcl-registry/src/commands/stdlib/tcltest__custommatch.rs
+++ b/rust/tcl-registry/src/commands/stdlib/tcltest__custommatch.rs
@@ -32,8 +32,10 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         required_package: Some("tcltest"),
-        // 0 = the new mode name, 1 = a command prefix (`command expected actual`).
-        arg_roles: &[(0, ArgRole::Name), (1, ArgRole::CommandPrefix)],
+        // 0 = the new mode name; 1 = a command prefix invoked as
+        // `command expected actual` → 2 appended args (`Exactly(2)`).
+        arg_roles: &[(0, ArgRole::Name)],
+        command_prefixes: &[(1, AppendedArity::Exactly(2))],
         // `customMatch MODE command` always defines a new match mode; the
         // backing command (arg 1) is shown as the outline detail.
         defines_symbol: Some(SymbolDef::new(0, DefinedSymbolKind::Matcher).with_detail(1)),

--- a/rust/tcl-registry/src/commands/tcl/chan_.rs
+++ b/rust/tcl-registry/src/commands/tcl/chan_.rs
@@ -176,6 +176,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Create a channel from a Tcl command.",
         synopsis: "chan create mode cmdPrefix",
         return_type: Some(TclType::Channel),
+        // `cmdPrefix` (index 1) is the reflected-channel handler, invoked as
+        // `cmdPrefix subcommand channelId ?args...?` — every method appends at
+        // least the subcommand and channel id ⇒ AtLeast(2).
+        command_prefixes: &[(1, AppendedArity::AtLeast(2))],
         side_effects: &[SideEffect {
             target: SideEffectTarget::InterpState,
             reads: false,
@@ -323,6 +327,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "chan push channelId cmdPrefix",
         mutator: true,
         return_type: Some(TclType::String),
+        // `cmdPrefix` (index 1) is the transform handler, invoked as
+        // `cmdPrefix subcommand handle ?args...?` (a reflected-transform
+        // dispatch) — minimum appended is subcommand + handle ⇒ AtLeast(2).
+        command_prefixes: &[(1, AppendedArity::AtLeast(2))],
         side_effects: &[SideEffect {
             target: SideEffectTarget::FileIo,
             reads: false,

--- a/rust/tcl-registry/src/commands/tcl/coroinject.rs
+++ b/rust/tcl-registry/src/commands/tcl/coroinject.rs
@@ -40,6 +40,10 @@ pub fn spec() -> CommandSpec {
         traits: Traits::EVALUATES_CODE,
         dialects: Some(DialectSet::TCL90_PLUS),
         arity: Arity::at_least(2),
+        // `coroinject coroName command ?arg ...?` — `command` (index 1) is a
+        // command prefix injected into the coroutine and invoked with the
+        // yield's args appended (variadic ⇒ Unknown).
+        command_prefixes: &[(1, AppendedArity::Unknown)],
         return_type: Some(TclType::String),
         side_effects: SIDE_EFFECTS,
         hover: Some(HoverSnippet {

--- a/rust/tcl-registry/src/commands/tcl/coroprobe.rs
+++ b/rust/tcl-registry/src/commands/tcl/coroprobe.rs
@@ -39,6 +39,10 @@ pub fn spec() -> CommandSpec {
         traits: Traits::EVALUATES_CODE,
         dialects: Some(DialectSet::TCL90_PLUS),
         arity: Arity::at_least(2),
+        // `coroprobe coroName command ?arg ...?` — `command` (index 1) is a
+        // command prefix run in the coroutine's context with runtime args
+        // appended (variadic ⇒ Unknown: a reference, not arity-checked).
+        command_prefixes: &[(1, AppendedArity::Unknown)],
         return_type: Some(TclType::String),
         side_effects: SIDE_EFFECTS,
         hover: Some(HoverSnippet {

--- a/rust/tcl-registry/src/commands/tcl/interp.rs
+++ b/rust/tcl-registry/src/commands/tcl/interp.rs
@@ -31,6 +31,31 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "interp subcommand ?arg arg ...?",
 }];
 
+/// `interp alias srcPath srcCmd targetPath targetCmd ?arg ...?` (create form) —
+/// `targetCmd` (index 3, after the `alias` subcommand word) is a command prefix
+/// invoked with the aliased command's runtime args appended to any baked
+/// `?arg...?`, so the count is variadic (`Unknown`, referenced but not
+/// arity-checked). The 2-arg query form (`interp alias srcPath srcCmd`) has no
+/// target.
+fn interp_alias_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
+    if args.len() >= 4 {
+        vec![(3, AppendedArity::Unknown)]
+    } else {
+        Vec::new()
+    }
+}
+
+/// `interp bgerror path ?cmdPrefix?` — the optional background-error handler
+/// (index 1, after `bgerror`) is a command prefix invoked with the error
+/// message + return options (variadic ⇒ `Unknown`).
+fn interp_bgerror_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
+    if args.len() >= 2 {
+        vec![(1, AppendedArity::Unknown)]
+    } else {
+        Vec::new()
+    }
+}
+
 static SUBCOMMANDS: &[SubCommand] = &[
     SubCommand {
         name: "alias",
@@ -38,6 +63,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Manage command aliases.",
         synopsis: "interp alias path cmd",
         return_type: Some(TclType::List),
+        command_prefix_resolver: Some(interp_alias_command_prefixes),
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -57,6 +83,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Get or set background error handler.",
         synopsis: "interp bgerror path ?cmdPrefix?",
         return_type: Some(TclType::String),
+        command_prefix_resolver: Some(interp_bgerror_command_prefixes),
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcl/lsort_.rs
+++ b/rust/tcl-registry/src/commands/tcl/lsort_.rs
@@ -98,7 +98,8 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-command",
-        value: OptionValue::command_prefix("cmdPrefix"),
+        // Invoked as `cmdPrefix elem1 elem2` → 2 appended args.
+        value: OptionValue::command_prefix_n("cmdPrefix", AppendedArity::Exactly(2)),
         detail: "Use a custom comparison command prefix.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -181,6 +181,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "namespace unknown ?script?",
         return_type: Some(TclType::String),
         dialects: Some(DialectSet::NON_IRULES_OPERATORS),
+        // The optional handler (index 0 after `unknown` → arg 1) is a command
+        // prefix invoked with the unknown command name + its args appended
+        // (variadic ⇒ AtLeast(1)). The zero-arg query form has no prefix.
+        command_prefixes: &[(0, AppendedArity::AtLeast(1))],
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcl/package_.rs
+++ b/rust/tcl-registry/src/commands/tcl/package_.rs
@@ -122,6 +122,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Supplies a command to invoke during package require if no suitable version can be found.",
         synopsis: "package unknown ?command?",
         return_type: Some(TclType::String),
+        // The optional handler (index 0 after `unknown` → arg 1) is a command
+        // prefix invoked as `command name ?requirement ...?` when a package is
+        // missing (AtLeast(1): the package name is always passed).
+        command_prefixes: &[(0, AppendedArity::AtLeast(1))],
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcl/regsub_.rs
+++ b/rust/tcl-registry/src/commands/tcl/regsub_.rs
@@ -58,6 +58,45 @@ fn regsub_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
         .collect()
 }
 
+/// `regsub -command ?switches? exp string cmdPrefix ?varName?` (Tcl 9.0+, TIP
+/// 463): with `-command` present, the `subSpec` positional (index `i+2` after
+/// the leading switches) is not a replacement template but a command prefix
+/// called once per match with the whole match + capture-group substrings
+/// appended — a variadic count (`AtLeast(1)`: the whole match is always
+/// passed). Without `-command`, `subSpec` is an ordinary string (no prefix).
+fn regsub_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
+    let mut i = 0;
+    let mut has_command = false;
+    while i < args.len() {
+        let a = args[i];
+        if a == "--" {
+            i += 1;
+            break;
+        }
+        if a.starts_with('-') {
+            // `-command` and its unambiguous abbreviations (`-c`..`-comman`);
+            // no other regsub switch begins with `-c`.
+            if a.len() >= 2 && "-command".starts_with(a) {
+                has_command = true;
+            }
+            i += 1;
+            if a == "-start" && i < args.len() {
+                i += 1;
+            }
+            continue;
+        }
+        break;
+    }
+    let sub_idx = i + 2;
+    if has_command && sub_idx < args.len() {
+        u8::try_from(sub_idx)
+            .map(|s| vec![(s, AppendedArity::AtLeast(1))])
+            .unwrap_or_default()
+    } else {
+        Vec::new()
+    }
+}
+
 /// Command spec for `regsub`.
 const OPTIONS: &[OptionSpec] = &[
     OptionSpec {
@@ -160,6 +199,7 @@ pub fn spec() -> CommandSpec {
         // pattern validation.
         pattern_type: Some(PatternType::Regex),
         arg_role_resolver: Some(regsub_arg_roles),
+        command_prefix_resolver: Some(regsub_command_prefixes),
         forms: FORMS,
         ..CommandSpec::DEFAULT
     }

--- a/rust/tcl-registry/src/commands/tcl/socket_.rs
+++ b/rust/tcl-registry/src/commands/tcl/socket_.rs
@@ -45,7 +45,8 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-server",
-        value: OptionValue::command_prefix("command"),
+        // Accept callback invoked as `command channel addr port` → 3 args.
+        value: OptionValue::command_prefix_n("command", AppendedArity::Exactly(3)),
         detail: "Server accept callback.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tcl/trace.rs
+++ b/rust/tcl-registry/src/commands/tcl/trace.rs
@@ -57,6 +57,62 @@ fn trace_remove_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
     Vec::new()
 }
 
+/// The invoked arity of a `trace add/remove <type> name ops cmdPrefix`
+/// callback (C Tcl 9.0): a `variable` trace fires `cmdPrefix name1 name2 op`
+/// (3), a `command` trace fires `cmdPrefix oldName newName op` (3), an
+/// `execution` trace fires 2–4 args (`enter`/`leave`/`enterstep`/`leavestep`),
+/// so `AtLeast(2)`.  A `remove` only references the handler (it is matched, not
+/// invoked), so it carries `Unknown` — recorded as a reference, not
+/// arity-checked.
+fn trace_type_command_prefix(args: &[&str], installing: bool) -> Vec<(u8, AppendedArity)> {
+    // args after the subcommand word: `type name ops cmdPrefix` (index 3).
+    if args.len() <= 3 {
+        return Vec::new();
+    }
+    let arity = if installing {
+        match args.first().copied() {
+            Some("variable" | "command") => AppendedArity::Exactly(3),
+            Some("execution") => AppendedArity::AtLeast(2),
+            _ => AppendedArity::Unknown,
+        }
+    } else {
+        AppendedArity::Unknown
+    };
+    vec![(3, arity)]
+}
+
+fn trace_add_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
+    trace_type_command_prefix(args, true)
+}
+
+fn trace_remove_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
+    trace_type_command_prefix(args, false)
+}
+
+/// Deprecated `trace variable name ops command` / `trace vdelete …` — the
+/// command prefix is the 3rd word (index 2).  `variable` installs a
+/// variable trace (`command name1 name2 op` → 3 args); `vdelete` only
+/// references the handler (`Unknown`).
+fn trace_legacy_command_prefix(args: &[&str], installing: bool) -> Vec<(u8, AppendedArity)> {
+    if args.len() <= 2 {
+        return Vec::new();
+    }
+    let arity = if installing {
+        AppendedArity::Exactly(3)
+    } else {
+        AppendedArity::Unknown
+    };
+    vec![(2, arity)]
+}
+
+fn trace_variable_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
+    trace_legacy_command_prefix(args, true)
+}
+
+fn trace_vdelete_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
+    trace_legacy_command_prefix(args, false)
+}
+
 static SUBCOMMANDS: &[SubCommand] = &[
     SubCommand {
         name: "add",
@@ -65,6 +121,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Arrange for a command to be executed on the specified operation.",
         synopsis: "trace add type name ops commandPrefix",
         arg_role_resolver: Some(trace_add_arg_roles),
+        command_prefix_resolver: Some(trace_add_command_prefixes),
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -84,6 +141,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Remove a trace.",
         synopsis: "trace remove type name ops commandPrefix",
         arg_role_resolver: Some(trace_remove_arg_roles),
+        command_prefix_resolver: Some(trace_remove_command_prefixes),
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -92,6 +150,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::exact(3),
         detail: "Arrange for command to be executed whenever variable name is accessed. Deprecated in favour of trace add variable.",
         synopsis: "trace variable name ops command",
+        command_prefix_resolver: Some(trace_variable_command_prefixes),
         // Deprecated legacy form; removed in Tcl 9.0 (8.4-8.6 only).
         dialects: Some(DialectSet::TCL8X),
         ..SubCommand::DEFAULT
@@ -102,6 +161,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::exact(3),
         detail: "Delete a variable trace. Deprecated in favour of trace remove variable.",
         synopsis: "trace vdelete name ops command",
+        command_prefix_resolver: Some(trace_vdelete_command_prefixes),
         // Deprecated legacy form; removed in Tcl 9.0 (8.4-8.6 only).
         dialects: Some(DialectSet::TCL8X),
         ..SubCommand::DEFAULT

--- a/rust/tcl-registry/src/commands/tcl/uplevel_.rs
+++ b/rust/tcl-registry/src/commands/tcl/uplevel_.rs
@@ -32,6 +32,64 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "uplevel ?level? arg ?arg ...?",
 }];
 
+/// Whether `word` is *literally* an `uplevel` frame level.
+///
+/// Mirrors C Tcl's `TclObjGetFrame` first-character dispatch: an argument
+/// is consumed as a level iff it begins with `#` (absolute frame, `#0`) or
+/// a digit (relative frame, `1`). A literal level is the frame selector
+/// even with no script following it (`uplevel 1` alone is a wrong-#args
+/// error, but `1` is still a level, not a command named `1`).
+fn word_is_literal_level(word: &str) -> bool {
+    matches!(word.as_bytes().first(), Some(&b) if b == b'#' || b.is_ascii_digit())
+}
+
+/// Whether `word` is a *substituted* level selector — `$lvl` or
+/// `[expr {$n-1}]`.
+///
+/// Its runtime value can't be inspected from source, so it only counts as
+/// a level when a script word follows it: `uplevel $lvl {…}` shifts frame,
+/// but a lone `uplevel $body` is an implicit-level-1 script whose body *is*
+/// that argument. The arg-role layer only needs to know a level is
+/// *present* — enough to place the body word one slot later so its braced
+/// script recurses.
+fn word_is_dynamic_level(word: &str) -> bool {
+    word.starts_with('$') || (word.starts_with('[') && word.ends_with(']'))
+}
+
+/// Index of the first *script* word in an `uplevel` argument list — `1`
+/// when a leading `level` word is present, else `0`.
+fn uplevel_script_start(args: &[&str]) -> usize {
+    match args.first() {
+        Some(w) if word_is_literal_level(w) => 1,
+        // A substituted level only separates from the script when a script
+        // word follows (`uplevel $lvl {…}`); a lone `uplevel $body` is a body.
+        Some(w) if args.len() >= 2 && word_is_dynamic_level(w) => 1,
+        _ => 0,
+    }
+}
+
+/// Dynamic arg-role resolver for `uplevel ?level? arg ?arg ...?`.
+///
+/// `uplevel` evaluates a script — the concatenation of its trailing
+/// arguments — in the stack frame named by an optional leading `level`
+/// word, so the script's position is data-dependent and can't be a fixed
+/// [`CommandSpec::arg_roles`] entry (unlike `eval`, whose body is always
+/// arg 0). Marks the first script word [`ArgRole::Body`] so the
+/// semantic-token layer, the green-tree descent, and every other
+/// registry-driven body consumer recurse it as a real script instead of
+/// rendering it as an opaque string (issue #837). Only a braced word
+/// actually recurses — each consumer keeps its own `Str`-token guard — so
+/// a bare `$body` / command-substitution body stays a value here and is
+/// resolved by the compiler's const-lattice lowering instead.
+fn uplevel_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    let start = uplevel_script_start(args);
+    u8::try_from(start)
+        .ok()
+        .filter(|&i| (i as usize) < args.len())
+        .map(|i| vec![(i, ArgRole::Body)])
+        .unwrap_or_default()
+}
+
 /// Command spec for `uplevel`.
 pub fn spec() -> CommandSpec {
     CommandSpec {
@@ -46,6 +104,13 @@ pub fn spec() -> CommandSpec {
             | Traits::CREATES_DYNAMIC_BARRIER
             | Traits::DYNAMIC_EVAL_BODY,
         arity: Arity::at_least(1),
+        // The body runs in another stack frame (the `level`), not the
+        // caller's, so its variable references belong to that frame — mark
+        // the body `Structural` so SSA skips it when scanning the enclosing
+        // block's dataflow (it is still recursed for highlighting / its own
+        // scope), exactly as `proc` / `namespace eval` bodies are.
+        body_kind: BodyKind::Structural,
+        arg_role_resolver: Some(uplevel_arg_roles),
         lowering_hook: Some(crate::hooks::LoweringHookId::Uplevel),
         return_type: Some(TclType::String),
         hover: Some(HoverSnippet {

--- a/rust/tcl-registry/src/commands/tcllib/channels_docs.rs
+++ b/rust/tcl-registry/src/commands/tcllib/channels_docs.rs
@@ -111,12 +111,6 @@ const VIRTCHAN_CMDS: &[Row] = &[
         "This command creates a new connected pair of fifo channels and returns their handles, as a list containing two.",
     ),
     (
-        "tcl::chan::halfpipe",
-        Arity::at_least(0),
-        &["tcl::chan::halfpipe"],
-        "This command creates a halfpipe channel and configures it with the callbacks to run when the channel is closed.",
-    ),
-    (
         "tcl::chan::memchan",
         Arity::exact(0),
         &["tcl::chan::memchan"],
@@ -256,9 +250,57 @@ const VIRTCHAN_CMDS: &[Row] = &[
     ),
 ];
 
+/// Options for `tcl::chan::halfpipe`.  All three fire through the one
+/// `method Call {o args} { uplevel #0 [list {*}$options($o) {*}$args] }`
+/// (halfpipe.tcl 189-192), the clean `[list {*}prefix {*}args]` idiom, so the
+/// appended-word count equals the number of args passed at each call site.
+/// There is no `-read-command`.
+const HALFPIPE_OPTIONS: &[OptionSpec] = &[
+    OptionSpec {
+        name: "-write-command",
+        // `my Call -write-command $c $bytes` (115) → channel handle + bytes.
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
+        detail: "Invoked on a write with the channel handle and the written bytes.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-empty-command",
+        // `my Call -empty-command $channel` (184) → channel handle only.
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(1)),
+        detail: "Invoked when the buffer drains, with the channel handle.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-close-command",
+        // `my Call -close-command $c` (51) → channel handle only.
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(1)),
+        detail: "Invoked when the channel is closed, with the channel handle.",
+        ..OptionSpec::DEFAULT
+    },
+];
+
+/// `tcl::chan::halfpipe` — structured so its callback options carry command
+/// prefixes.
+fn halfpipe_spec() -> CommandSpec {
+    CommandSpec {
+        name: "tcl::chan::halfpipe",
+        arity: Arity::at_least(0),
+        hover: Some(HoverSnippet::brief(
+            "This command creates a halfpipe channel and configures it with the callbacks to run when the channel is closed.",
+            &["tcl::chan::halfpipe ?-write-command cmd? ?-empty-command cmd? ?-close-command cmd?"],
+            "tcllib virtchannel package",
+        )),
+        options: HALFPIPE_OPTIONS,
+        tcllib_package: Some("tcl::chan::halfpipe"),
+        required_package: Some("tcl::chan::halfpipe"),
+        ..CommandSpec::DEFAULT
+    }
+}
+
 /// All doctools + virtual-channel command specs.
 pub fn specs() -> Vec<CommandSpec> {
     let mut specs = rows("doctools", DOCTOOLS_CMDS);
     specs.extend(self_pkg_rows(VIRTCHAN_CMDS));
+    specs.push(halfpipe_spec());
     specs
 }

--- a/rust/tcl-registry/src/commands/tcllib/clients.rs
+++ b/rust/tcl-registry/src/commands/tcllib/clients.rs
@@ -573,6 +573,19 @@ const UEVENT_CMDS: &[Row] = &[
     ),
 ];
 
+/// Command-prefix callback positions for commands in the flat [`Row`] tables
+/// above (which cannot carry a `command_prefixes` field), applied by name in
+/// [`specs`].  Index is relative to the args after the command name.
+///
+/// Ground truth: the `log` man page pins the message-writer command to
+/// `cmd level text` (Exactly(2)); `uevent::bind`'s handler is triggered as
+/// `command tag event ?details?` — details is optional, so AtLeast(2).
+const PREFIX_OVERRIDES: &[(&str, &[(u8, AppendedArity)])] = &[
+    ("log::lvCmd", &[(1, AppendedArity::Exactly(2))]),
+    ("log::lvCmdForall", &[(0, AppendedArity::Exactly(2))]),
+    ("uevent::bind", &[(2, AppendedArity::AtLeast(2))]),
+];
+
 /// All client / logging package command specs.
 pub fn specs() -> Vec<CommandSpec> {
     let mut specs = Vec::new();
@@ -582,5 +595,11 @@ pub fn specs() -> Vec<CommandSpec> {
     specs.extend(rows("pop3", POP3_CMDS));
     specs.extend(rows("irc", IRC_CMDS));
     specs.extend(rows("uevent", UEVENT_CMDS));
+    // Patch in the callback positions the flat `Row` tables can't express.
+    for spec in &mut specs {
+        if let Some(&(_, prefixes)) = PREFIX_OVERRIDES.iter().find(|&&(n, _)| n == spec.name) {
+            spec.command_prefixes = prefixes;
+        }
+    }
     specs
 }

--- a/rust/tcl-registry/src/commands/tcllib/data_ext.rs
+++ b/rust/tcl-registry/src/commands/tcllib/data_ext.rs
@@ -42,6 +42,30 @@ fn rows(pkg: &'static str, table: &'static [Row]) -> Vec<CommandSpec> {
         .collect()
 }
 
+/// Options for `comm::comm send`.
+const COMM_SEND_OPTIONS: &[OptionSpec] = &[
+    OptionSpec {
+        name: "-async",
+        value: OptionValue::flag(),
+        detail: "Return immediately; the result is discarded (or delivered via -command).",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-command",
+        // Asynchronous "futures" reply callback.  comm.tcl 1367-1375 builds a
+        // fixed 7-pair option list (`-id -serial -chan -code -errorcode
+        // -errorinfo -result`) and fires `uplevel #0 $callback $args`, which
+        // re-splits it into exactly 14 words.  (Distinct from the channel-level
+        // `configure -command` incoming-message hook, which appends only 1.)
+        // Real callbacks use `proc cb {args} {array set r $args …}`, so the
+        // arity check is silent unless a fixed-arity proc is wired up wrong.
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(14)),
+        detail: "Deliver the reply asynchronously to this command prefix (invoked \
+with the 7 -key/value reply pairs appended).",
+        ..OptionSpec::DEFAULT
+    },
+];
+
 /// The `comm::comm` ensemble's sub-commands.
 const COMM_SUBS: &[SubCommand] = &[
     SubCommand {
@@ -49,6 +73,7 @@ const COMM_SUBS: &[SubCommand] = &[
         arity: Arity::at_least(2),
         detail: "This invokes the given command in the interpreter named by id.",
         synopsis: "comm::comm send -async -command id cmd",
+        options: COMM_SEND_OPTIONS,
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcllib/data_structures.rs
+++ b/rust/tcl-registry/src/commands/tcllib/data_structures.rs
@@ -66,6 +66,104 @@ fn creator(
     }
 }
 
+/// Like [`creator`] but binds the created object command to an
+/// [`ObjectClassSpec`] whose instance methods carry command-prefix callbacks.
+/// `struct::graph name` / `struct::tree name` name the new object command
+/// positionally (index 0 — the `?name?`), so `creates_instance_at` types it and
+/// a later `name walk … -command cb` resolves the callback through the class.
+fn object_creator(
+    name: &'static str,
+    synopsis: &'static [&'static str],
+    summary: &'static str,
+    class: &'static ObjectClassSpec,
+) -> CommandSpec {
+    CommandSpec {
+        creates_instance_at: Some(0),
+        object_class: Some(class),
+        ..creator(name, synopsis, summary)
+    }
+}
+
+/// `struct::graph` instance `walk node … -command cmd` (`graph_tcl.tcl` `_walk`,
+/// 2675).  At each visited node it runs `lappend cmdcpy <enter|leave> $name
+/// $node; uplevel 1 $cmdcpy`, appending three words — the action keyword, the
+/// graph name, and the node — so `-command` is a prefix of `Exactly(3)`.
+const STRUCT_GRAPH_WALK_OPTIONS: &[OptionSpec] = &[
+    OptionSpec {
+        name: "-dir",
+        value: OptionValue::value("forward|backward"),
+        detail: "Walk direction: forward (default) or backward.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-order",
+        value: OptionValue::value("pre|post|both"),
+        detail: "Visit order: pre (default), post, or both.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-type",
+        value: OptionValue::value("bfs|dfs"),
+        detail: "Traversal type: dfs (default) or bfs.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-command",
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(3)),
+        detail: "Command prefix invoked at each node with (action graphName node) appended.",
+        ..OptionSpec::DEFAULT
+    },
+];
+
+const STRUCT_GRAPH_METHODS: &[SubCommand] = &[SubCommand {
+    name: "walk",
+    arity: Arity::at_least(1),
+    detail: "Walk the graph from node, invoking -command at each visited node.",
+    synopsis: "graphName walk node ?-dir forward|backward? ?-order pre|post|both? ?-type bfs|dfs? -command cmd",
+    options: STRUCT_GRAPH_WALK_OPTIONS,
+    ..SubCommand::DEFAULT
+}];
+
+static STRUCT_GRAPH_CLASS: ObjectClassSpec = ObjectClassSpec {
+    class_name: "struct::graph",
+    instance_methods: STRUCT_GRAPH_METHODS,
+    superclasses: &[],
+    // Only `walk` is modelled for its callback; every other method
+    // (`node insert`, `arc …`, `get`, …) passes through unflagged.
+    allow_unknown_methods: true,
+};
+
+/// `struct::tree` instance `walkproc node … cmdprefix` (`tree_tcl.tcl` `_walkproc`,
+/// 1856).  The trailing `cmdprefix` is a positional command prefix invoked as
+/// `lappend cmd $tree $node $action; uplevel 2 $cmd` — three appended words
+/// (tree, node, action) ⇒ `Exactly(3)`.  (`walk … loopvar script` is a
+/// loop-variable *script*, not a prefix, so it is not modelled here.)
+fn struct_tree_walkproc_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
+    // args are the words after `walkproc`: `node ?-order o? ?-type t? ?--?
+    // cmdprefix`.  The prefix is always the final word (node is required, so
+    // len ≥ 2 for a real prefix).
+    match u8::try_from(args.len()) {
+        Ok(n) if n >= 2 => vec![(n - 1, AppendedArity::Exactly(3))],
+        _ => Vec::new(),
+    }
+}
+
+const STRUCT_TREE_METHODS: &[SubCommand] = &[SubCommand {
+    name: "walkproc",
+    arity: Arity::at_least(2),
+    detail: "Walk the tree from node, invoking the trailing command prefix at each node.",
+    synopsis: "treeName walkproc node ?-order pre|post|in|both? ?-type bfs|dfs? cmdprefix",
+    command_prefix_resolver: Some(struct_tree_walkproc_command_prefixes),
+    ..SubCommand::DEFAULT
+}];
+
+static STRUCT_TREE_CLASS: ObjectClassSpec = ObjectClassSpec {
+    class_name: "struct::tree",
+    instance_methods: STRUCT_TREE_METHODS,
+    superclasses: &[],
+    allow_unknown_methods: true,
+};
+
 /// The `tar` package.
 const TAR_CMDS: &[Row] = &[
     (
@@ -210,15 +308,17 @@ pub fn specs() -> Vec<CommandSpec> {
     specs.extend(rows("pki", PKI_CMDS));
     specs.extend(rows("map::slippy", MAP_SLIPPY_CMDS));
     specs.extend([
-        creator(
+        object_creator(
             "struct::graph",
             &["struct::graph ?name? ?=|:=|as|deserialize source?"],
             "Create a directed-graph object command.",
+            &STRUCT_GRAPH_CLASS,
         ),
-        creator(
+        object_creator(
             "struct::tree",
             &["struct::tree ?name? ?=|:=|as|deserialize source?"],
             "Create a tree object command.",
+            &STRUCT_TREE_CLASS,
         ),
         creator(
             "struct::matrix",

--- a/rust/tcl-registry/src/commands/tcllib/ensembles.rs
+++ b/rust/tcl-registry/src/commands/tcllib/ensembles.rs
@@ -495,13 +495,28 @@ fn debug_spec() -> CommandSpec {
     }
 }
 
+/// `hook bind subject hook observer binding` (hook.tcl 97-137) sets `binding`
+/// — a command prefix fired via `uplevel #0 [list {*}$binding {*}$args]` when
+/// the hook is called, so the appended count is whatever the matching
+/// `hook call subject hook ?arg…?` passes ⇒ `Unknown`.  The 1/2/3-arg forms
+/// are query variants (and an empty 4th arg is a delete), so only the full
+/// four-word set form names a callback.
+fn hook_bind_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
+    if args.len() == 4 {
+        vec![(3, AppendedArity::Unknown)]
+    } else {
+        Vec::new()
+    }
+}
+
 /// The `hook` ensemble's sub-commands.
 const HOOK_SUBS: &[SubCommand] = &[
     SubCommand {
         name: "bind",
         arity: Arity::at_least(0),
         detail: "This subcommand is used to create, update, delete, and query hook bindings.",
-        synopsis: "hook bind",
+        synopsis: "hook bind ?subject? ?hook? ?observer? ?binding?",
+        command_prefix_resolver: Some(hook_bind_command_prefixes),
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcllib/ensembles.rs
+++ b/rust/tcl-registry/src/commands/tcllib/ensembles.rs
@@ -111,6 +111,10 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Apply a function to every element of a generator, returning a new generator of the results.",
         synopsis: "generator map function generator",
+        // `function` (index 0) is applied per element.  The generator may yield
+        // multiple values per step, so the appended count is not statically
+        // fixed ⇒ Unknown (a reference, not arity-checked).
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -118,6 +122,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Another classic functional programming gem.",
         synopsis: "generator filter predicate generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -125,6 +130,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(3),
         detail: "This is the classic left-fold operation.",
         synopsis: "generator reduce function zero generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -132,6 +138,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(3),
         detail: "This is an alias for the reduce command.",
         synopsis: "generator foldl function zero generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -139,6 +146,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(3),
         detail: "This is the right-associative version of reduce.",
         synopsis: "generator foldr function zero generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -146,6 +154,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Returns true if all elements of the generator satisfy the given predicate.",
         synopsis: "generator all predicate generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -174,6 +183,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Given a function which maps a value to a series of values, and a generator of values of that type, returns a genera",
         synopsis: "generator concatMap function generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -188,6 +198,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Removes all elements from the front of the generator that satisfy the predicate.",
         synopsis: "generator dropWhile predicate generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -202,6 +213,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "A version of foldl that takes the zero argument from the first element of the generator.",
         synopsis: "generator foldl1 function generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -209,6 +221,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(3),
         detail: "A version of foldl that supplies the integer index of each element as the first argument to the function.",
         synopsis: "generator foldli function zero generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -216,6 +229,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(3),
         detail: "Right-associative version of foldli.",
         synopsis: "generator foldri function zero generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -258,6 +272,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Returns an infinite generator formed by repeatedly applying the function to the initial argument.",
         synopsis: "generator iterate function init",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -279,6 +294,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Returns 1 if any of the elements of the generator satisfy the predicate.",
         synopsis: "generator or predicate generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -308,6 +324,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Returns a generator of the first elements in the argument generator that satisfy the predicate.",
         synopsis: "generator takeWhile predicate generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -315,6 +332,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Splits the generator into lists of elements using the predicate to identify delimiters.",
         synopsis: "generator splitWhen predicate generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -322,6 +340,7 @@ const GENERATOR_SUBS: &[SubCommand] = &[
         arity: Arity::exact(3),
         detail: "Similar to foldl, but returns a generator of all of the intermediate values for the accumulator argument.",
         synopsis: "generator scanl function zero generator",
+        command_prefixes: &[(0, AppendedArity::Unknown)],
         ..SubCommand::DEFAULT
     },
 ];

--- a/rust/tcl-registry/src/commands/tcllib/fileutil__find.rs
+++ b/rust/tcl-registry/src/commands/tcllib/fileutil__find.rs
@@ -43,6 +43,11 @@ pub fn spec() -> CommandSpec {
             examples: "",
             return_value: "",
         }),
+        // `filtercmd` (index 1) is invoked as `filtercmd name` for each
+        // candidate file/dir → 1 appended arg.  The registry drops the entry
+        // for the shorter `?basedir?`-only and zero-arg query forms (idx≥argc),
+        // so a static table is safe here.
+        command_prefixes: &[(1, AppendedArity::Exactly(1))],
         forms: FORMS,
         side_effects: SIDE_EFFECTS,
         tcllib_package: Some("fileutil"),

--- a/rust/tcl-registry/src/commands/tcllib/logger__walk.rs
+++ b/rust/tcl-registry/src/commands/tcllib/logger__walk.rs
@@ -43,6 +43,10 @@ pub fn spec() -> CommandSpec {
             examples: "",
             return_value: "",
         }),
+        // `command` (index 1) is applied to each walked service.  The man page
+        // does not pin the appended-arg count, so treat it as a reference-only
+        // prefix (Unknown ⇒ never arity-checked).
+        command_prefixes: &[(1, AppendedArity::Unknown)],
         forms: FORMS,
         side_effects: SIDE_EFFECTS,
         tcllib_package: Some("logger"),

--- a/rust/tcl-registry/src/commands/tcllib/math_ext.rs
+++ b/rust/tcl-registry/src/commands/tcllib/math_ext.rs
@@ -2365,10 +2365,106 @@ const GROUPS: &[(&str, &[Row])] = &[
     ("math::trig", MATH__TRIG_CMDS),
 ];
 
+/// Command-prefix callback positions for the numerical packages.  The flat
+/// [`Row`] tables above cannot carry a `command_prefixes` field, so these are
+/// applied by name in [`specs`].  Index is relative to the args after the
+/// command name (these are full command names, not sub-commands).
+///
+/// Ground truth: the `math::calculus`, `math::optimize`, and `math::probopt`
+/// man pages, each of which pins the `func` argument's signature (a procedure
+/// taking a fixed number of arguments) — so these are `Exactly(n)`, unlike the
+/// variadic/ambiguous callbacks elsewhere that stay `Unknown`.
+const PREFIX_OVERRIDES: &[(&str, &[(u8, AppendedArity)])] = &[
+    // `integral begin end nosteps func` — func(x).
+    ("math::calculus::integral", &[(3, AppendedArity::Exactly(1))]),
+    // `integral2D xinterval yinterval func` — func(x y).
+    (
+        "math::calculus::integral2D",
+        &[(2, AppendedArity::Exactly(2))],
+    ),
+    (
+        "math::calculus::integral2D_accurate",
+        &[(2, AppendedArity::Exactly(2))],
+    ),
+    // `integral3D xinterval yinterval zinterval func` — func(x y z).
+    (
+        "math::calculus::integral3D",
+        &[(3, AppendedArity::Exactly(3))],
+    ),
+    (
+        "math::calculus::integral3D_accurate",
+        &[(3, AppendedArity::Exactly(3))],
+    ),
+    // `qk15 xstart xend func nosteps` — func(x).
+    ("math::calculus::qk15", &[(2, AppendedArity::Exactly(1))]),
+    (
+        "math::calculus::qk15_detailed",
+        &[(2, AppendedArity::Exactly(1))],
+    ),
+    // ODE steppers `… t tstep xvec func` — func(t xvec) (xvec is one list).
+    (
+        "math::calculus::eulerStep",
+        &[(3, AppendedArity::Exactly(2))],
+    ),
+    ("math::calculus::heunStep", &[(3, AppendedArity::Exactly(2))]),
+    (
+        "math::calculus::rungeKuttaStep",
+        &[(3, AppendedArity::Exactly(2))],
+    ),
+    // `boundaryValueSecondOrder coeff_func force_func …` — two prefixes, each f(x).
+    (
+        "math::calculus::boundaryValueSecondOrder",
+        &[(0, AppendedArity::Exactly(1)), (1, AppendedArity::Exactly(1))],
+    ),
+    // `newtonRaphson func deriv initval` — func(x) and deriv(x).
+    (
+        "math::calculus::newtonRaphson",
+        &[(0, AppendedArity::Exactly(1)), (1, AppendedArity::Exactly(1))],
+    ),
+    // Root finders `f xb xe eps` — f(x).
+    (
+        "math::calculus::regula_falsi",
+        &[(0, AppendedArity::Exactly(1))],
+    ),
+    (
+        "math::calculus::root_bisection",
+        &[(0, AppendedArity::Exactly(1))],
+    ),
+    (
+        "math::calculus::root_secant",
+        &[(0, AppendedArity::Exactly(1))],
+    ),
+    (
+        "math::calculus::root_brent",
+        &[(0, AppendedArity::Exactly(1))],
+    ),
+    (
+        "math::calculus::root_chandrupatla",
+        &[(0, AppendedArity::Exactly(1))],
+    ),
+    // `math::optimize::{minimum,maximum} begin end func maxerr` — func(x).
+    ("math::optimize::minimum", &[(2, AppendedArity::Exactly(1))]),
+    ("math::optimize::maximum", &[(2, AppendedArity::Exactly(1))]),
+    // Probabilistic optimisers `function bounds args` — objective(coordVec) as
+    // one list argument.
+    ("math::probopt::pso", &[(0, AppendedArity::Exactly(1))]),
+    ("math::probopt::sce", &[(0, AppendedArity::Exactly(1))]),
+    ("math::probopt::diffev", &[(0, AppendedArity::Exactly(1))]),
+    ("math::probopt::lipoMax", &[(0, AppendedArity::Exactly(1))]),
+    ("math::probopt::adaLipoMax", &[(0, AppendedArity::Exactly(1))]),
+];
+
 /// All command specs in this group.
 pub fn specs() -> Vec<CommandSpec> {
-    GROUPS
+    let mut out: Vec<CommandSpec> = GROUPS
         .iter()
         .flat_map(|&(pkg, table)| rows(pkg, table))
-        .collect()
+        .collect();
+    // Patch in the callback positions the flat `Row` tables can't express.
+    for spec in &mut out {
+        if let Some(&(_, prefixes)) = PREFIX_OVERRIDES.iter().find(|&&(n, _)| n == spec.name) {
+            spec.command_prefixes = prefixes;
+        }
+    }
+    out
 }

--- a/rust/tcl-registry/src/commands/tcllib/mime__getbody.rs
+++ b/rust/tcl-registry/src/commands/tcllib/mime__getbody.rs
@@ -23,6 +23,29 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "mime::getbody token ?options?",
 }];
 
+const OPTIONS: &[OptionSpec] = &[
+    OptionSpec {
+        name: "-decode",
+        value: OptionValue::flag(),
+        detail: "Decode the body according to its content-transfer-encoding.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-command",
+        // Async mode.  mime invokes the prefix via `uplevel #0 $cmd [list …]`
+        // at seven sites (mime.tcl 1671-1754): the terminal `[list end]`
+        // appends 1 word, while `[list data $chunk]` / `[list error $reason]`
+        // append 2 — because `uplevel` re-splits the list word.  So the min is
+        // 1 → AtLeast(1) (never fires "too few" against a 1-arg callback; the
+        // package's own default `getbodyaux {token reason {fragment {}}}` is
+        // exactly this shape).
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::AtLeast(1)),
+        detail: "Process the body asynchronously: the prefix is invoked with a \
+reason keyword (data / end / error) and, for data / error, one payload word.",
+        ..OptionSpec::DEFAULT
+    },
+];
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "mime::getbody",
@@ -37,6 +60,7 @@ pub fn spec() -> CommandSpec {
             return_value: "The body content.",
         }),
         forms: FORMS,
+        options: OPTIONS,
         tcllib_package: Some("mime"),
         required_package: Some("mime"),
         ..CommandSpec::DEFAULT

--- a/rust/tcl-registry/src/commands/tcllib/misc_ext.rs
+++ b/rust/tcl-registry/src/commands/tcllib/misc_ext.rs
@@ -1995,12 +1995,8 @@ const PROCESSMAN_CMDS: &[Row] = &[
         &["processman::killexe name"],
         "Kill a process identified by the executable.",
     ),
-    (
-        "processman::onexit",
-        Arity::exact(2),
-        &["processman::onexit id cmd"],
-        "Arrange to execute the script cmd when this programe detects that process id as terminated.",
-    ),
+    // `processman::onexit` is modelled separately ([`processman_onexit_spec`]):
+    // its `cmd` is a deferred *script*, not a command prefix.
     (
         "processman::priority",
         Arity::exact(2),
@@ -2822,6 +2818,31 @@ const GROUPS: &[(&str, &[Row])] = &[
     ("zipfile::decode", ZIPFILE__DECODE_CMDS),
 ];
 
+/// `processman::onexit id cmd` — arranges to run `cmd` when process `id`
+/// terminates.  Source (processman.tcl 178/256) fires it as a bare
+/// `eval $cmd` with **nothing** appended: `cmd` is a deferred Tcl *script*, not
+/// a command prefix (so it is deliberately NOT a `command_prefixes` entry).
+/// Modelled with `ArgRole::Body` + `BodyKind::Structural` — the same shape as
+/// `tcltest::loadscript` — so a literal `{…}` script records its inner calls
+/// (references / W123 / call-graph) while SSA does not bind its vars to the
+/// caller's frame (the eval happens later, in `::processman::events`).
+fn processman_onexit_spec() -> CommandSpec {
+    CommandSpec {
+        name: "processman::onexit",
+        arity: Arity::exact(2),
+        hover: Some(HoverSnippet::brief(
+            "Arrange to execute the script cmd when this program detects that process id has terminated.",
+            &["processman::onexit id cmd"],
+            "tcllib processman package",
+        )),
+        tcllib_package: Some("processman"),
+        required_package: Some("processman"),
+        arg_roles: &[(1, ArgRole::Body)],
+        body_kind: BodyKind::Structural,
+        ..CommandSpec::DEFAULT
+    }
+}
+
 /// All command specs in this group.
 pub fn specs() -> Vec<CommandSpec> {
     GROUPS
@@ -2831,5 +2852,6 @@ pub fn specs() -> Vec<CommandSpec> {
         // return type, purity, and `min_version`) rather than the shared
         // 4-tuple [`Row`], so it is appended separately (issue #811).
         .chain(html_rows(HTML_CMDS))
+        .chain(std::iter::once(processman_onexit_spec()))
         .collect()
 }

--- a/rust/tcl-registry/src/commands/tcllib/misc_pkgs.rs
+++ b/rust/tcl-registry/src/commands/tcllib/misc_pkgs.rs
@@ -359,14 +359,10 @@ const NMEA_CMDS: &[Row] = &[
     ),
 ];
 
-/// The `bibtex` package.
+/// The `bibtex` package.  `bibtex::parse` is modelled separately
+/// ([`bibtex_parse_spec`]) because its callback options carry command
+/// prefixes.
 const BIBTEX_CMDS: &[Row] = &[
-    (
-        "bibtex::parse",
-        Arity::at_least(0),
-        &["bibtex::parse"],
-        "This is the general form of the command for parsing a bibliography.",
-    ),
     (
         "bibtex::wait",
         Arity::exact(1),
@@ -433,6 +429,84 @@ const RCS_CMDS: &[Row] = &[
     ),
 ];
 
+/// Options for `bibtex::parse`.  Every callback is dispatched through the one
+/// `::bibtex::Callback token type args` proc (bibtex.tcl 265-272), which fires
+/// `eval $cmd [linsert $args 0 $token]` — so each prefix is invoked with the
+/// parser `token` first, then that callback's own payload words (verified vs
+/// the default-callback signatures `AddRecord {token type key recdata}` /
+/// `addStrings {token strings}` and re-run in tclsh).
+const BIBTEX_PARSE_OPTIONS: &[OptionSpec] = &[
+    OptionSpec {
+        name: "-command",
+        // `Callback $token {} $result` (bibtex.tcl 294) — batch mode: token +
+        // the whole accumulated records list.
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
+        detail: "Batch callback invoked once at EOF with the token and the full record list.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-recordcommand",
+        // `Callback $token record [Tidy $type] [string trim $key] [ParseBlock
+        // $rest]` (395-396) — token, type, key, recdata.
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(4)),
+        detail: "Per-record callback invoked with token, entry type, key, and record data.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-preamblecommand",
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
+        detail: "Per-preamble callback invoked with token and the preamble text.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-stringcommand",
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
+        detail: "Per-@string callback invoked with token and the string macro(s).",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-commentcommand",
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
+        detail: "Per-comment callback invoked with token and the comment text.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-progresscommand",
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
+        detail: "Progress callback invoked with token and a percentage.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-channel",
+        value: OptionValue::channel("chan"),
+        detail: "Parse incrementally from this channel instead of a text string.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-casesensitivestrings",
+        value: OptionValue::value("bool"),
+        detail: "Treat @string macro names case-sensitively.",
+        ..OptionSpec::DEFAULT
+    },
+];
+
+/// `bibtex::parse` — structured so its callback options carry command prefixes.
+fn bibtex_parse_spec() -> CommandSpec {
+    CommandSpec {
+        name: "bibtex::parse",
+        arity: Arity::at_least(0),
+        hover: Some(HoverSnippet::brief(
+            "This is the general form of the command for parsing a bibliography.",
+            &["bibtex::parse ?options? ?text?"],
+            "tcllib bibtex package",
+        )),
+        options: BIBTEX_PARSE_OPTIONS,
+        tcllib_package: Some("bibtex"),
+        required_package: Some("bibtex"),
+        ..CommandSpec::DEFAULT
+    }
+}
+
 /// All additional-package command specs.
 pub fn specs() -> Vec<CommandSpec> {
     let mut specs = Vec::new();
@@ -442,6 +516,7 @@ pub fn specs() -> Vec<CommandSpec> {
     specs.extend(rows("javascript", JAVASCRIPT_CMDS));
     specs.extend(rows("nmea", NMEA_CMDS));
     specs.extend(rows("bibtex", BIBTEX_CMDS));
+    specs.push(bibtex_parse_spec());
     specs.extend(rows("rcs", RCS_CMDS));
     specs
 }

--- a/rust/tcl-registry/src/commands/tcllib/smtp__sendmessage.rs
+++ b/rust/tcl-registry/src/commands/tcllib/smtp__sendmessage.rs
@@ -30,6 +30,68 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "smtp::sendmessage token ?options?",
 }];
 
+const OPTIONS: &[OptionSpec] = &[
+    OptionSpec {
+        name: "-servers",
+        value: OptionValue::value("list"),
+        detail: "List of SMTP servers to try, in order.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-ports",
+        value: OptionValue::value("list"),
+        detail: "List of ports matching -servers.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-username",
+        value: OptionValue::value("user"),
+        detail: "Username for SMTP authentication.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-password",
+        value: OptionValue::value("pass"),
+        detail: "Password for SMTP authentication.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-usetls",
+        value: OptionValue::value("bool"),
+        detail: "Whether to attempt STARTTLS negotiation.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-tlspolicy",
+        // smtp.tcl 766-768: `eval $options(-tlspolicy) [list $code]
+        // [list $diagnostic]` — each value is separately list-wrapped, so eval
+        // appends exactly two words: the SMTP response code and the diagnostic
+        // text (kept one word by its own list-wrap).
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
+        detail: "Command prefix consulted before STARTTLS; invoked with the SMTP \
+response code and diagnostic text, and must return secure / insecure.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-originator",
+        value: OptionValue::value("addr"),
+        detail: "Originator address override.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-recipients",
+        value: OptionValue::value("list"),
+        detail: "Explicit recipient list override.",
+        ..OptionSpec::DEFAULT
+    },
+    OptionSpec {
+        name: "-header",
+        value: OptionValue::value("{key value}"),
+        detail: "A single header as a {key value} pair; may be repeated.",
+        ..OptionSpec::DEFAULT
+    },
+];
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "smtp::sendmessage",
@@ -46,6 +108,7 @@ pub fn spec() -> CommandSpec {
             return_value: "",
         }),
         forms: FORMS,
+        options: OPTIONS,
         side_effects: SIDE_EFFECTS,
         tcllib_package: Some("smtp"),
         required_package: Some("smtp"),

--- a/rust/tcl-registry/src/commands/tcllib/struct__list.rs
+++ b/rust/tcl-registry/src/commands/tcllib/struct__list.rs
@@ -185,6 +185,10 @@ const SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::new(2, 4),
         detail: "Split a list using a command prefix as filter.",
         synopsis: "struct::list split sequence cmdprefix ?passVar? ?failVar?",
+        // The twin of `filter`: cmdprefix invoked as `cmdprefix element` → 1
+        // appended arg.  `passVar`/`failVar` are result out-variables, not
+        // prefixes.
+        command_prefixes: &[(1, AppendedArity::Exactly(1))],
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcllib/struct__list.rs
+++ b/rust/tcl-registry/src/commands/tcllib/struct__list.rs
@@ -54,6 +54,8 @@ const SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Return elements matching a condition.",
         synopsis: "struct::list filter sequence cmdprefix",
+        // cmdprefix invoked as `cmdprefix element` → 1 appended arg.
+        command_prefixes: &[(1, AppendedArity::Exactly(1))],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -76,6 +78,8 @@ const SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::exact(3),
         detail: "Left-fold a list with an accumulator.",
         synopsis: "struct::list fold sequence initialValue cmdprefix",
+        // cmdprefix invoked as `cmdprefix accumulator element` → 2 appended args.
+        command_prefixes: &[(2, AppendedArity::Exactly(2))],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -112,6 +116,8 @@ const SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::exact(2),
         detail: "Apply a command to each element and collect results.",
         synopsis: "struct::list map sequence cmdprefix",
+        // cmdprefix invoked as `cmdprefix element` → 1 appended arg.
+        command_prefixes: &[(1, AppendedArity::Exactly(1))],
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tk/canvas.rs
+++ b/rust/tcl-registry/src/commands/tk/canvas.rs
@@ -330,7 +330,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-xscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for communicating with horizontal scrollbars.",
         dialects: None,
         aliases: &[],
@@ -338,7 +338,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-yscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for communicating with vertical scrollbars.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/entry.rs
+++ b/rust/tcl-registry/src/commands/tk/entry.rs
@@ -180,7 +180,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-xscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for communicating with horizontal scrollbars.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/listbox.rs
+++ b/rust/tcl-registry/src/commands/tk/listbox.rs
@@ -116,7 +116,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-xscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for communicating with horizontal scrollbars.",
         dialects: None,
         aliases: &[],
@@ -124,7 +124,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-yscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for communicating with vertical scrollbars.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/menu.rs
+++ b/rust/tcl-registry/src/commands/tk/menu.rs
@@ -397,8 +397,8 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-tearoffcommand",
-        value: OptionValue::script(),
-        detail: "Tcl command to invoke when the menu is torn off.",
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
+        detail: "Command prefix invoked when the menu is torn off (the parent menu path and the torn-off menu path are appended).",
         dialects: None,
         aliases: &[],
         min_version: None,

--- a/rust/tcl-registry/src/commands/tk/scale.rs
+++ b/rust/tcl-registry/src/commands/tk/scale.rs
@@ -140,8 +140,8 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-command",
-        value: OptionValue::script(),
-        detail: "Tcl command prefix invoked when the scale value changes.",
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(1)),
+        detail: "Tcl command prefix invoked when the scale value changes (the new value is appended).",
         dialects: None,
         aliases: &[],
         min_version: None,

--- a/rust/tcl-registry/src/commands/tk/scrollbar.rs
+++ b/rust/tcl-registry/src/commands/tk/scrollbar.rs
@@ -36,8 +36,8 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-command",
-        value: OptionValue::script(),
-        detail: "Command prefix to invoke when the scrollbar is moved.",
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::AtLeast(2)),
+        detail: "Command prefix to invoke when the scrollbar is moved (`moveto frac` appends 2, `scroll n units|pages` appends 3).",
         dialects: None,
         aliases: &[],
         min_version: None,

--- a/rust/tcl-registry/src/commands/tk/selection.rs
+++ b/rust/tcl-registry/src/commands/tk/selection.rs
@@ -28,11 +28,12 @@ use crate::prelude::*;
 /// reference), not a script body.  It is always the last argument; the
 /// leading option/value pairs and `window` precede it.  Args here are
 /// those *after* the `handle` subcommand word.
-fn selection_handle_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+fn selection_handle_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
     match u8::try_from(args.len()) {
         // window + command are both required (arity at_least(2)), so the
-        // command prefix is the final argument.
-        Ok(n) if n >= 2 => vec![(n - 1, ArgRole::CommandPrefix)],
+        // command prefix is the final argument.  Tk invokes it with `offset
+        // maxChars` appended → 2 args (`Exactly(2)`).
+        Ok(n) if n >= 2 => vec![(n - 1, AppendedArity::Exactly(2))],
         _ => Vec::new(),
     }
 }
@@ -58,7 +59,7 @@ const SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(2),
         detail: "Register a handler to provide the selection data.",
         synopsis: "selection handle ?-selection sel? ?-type type? ?-format fmt? window command",
-        arg_role_resolver: Some(selection_handle_arg_roles),
+        command_prefix_resolver: Some(selection_handle_command_prefixes),
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tk/spinbox.rs
+++ b/rust/tcl-registry/src/commands/tk/spinbox.rs
@@ -268,7 +268,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-xscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for communicating with horizontal scrollbars.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/text.rs
+++ b/rust/tcl-registry/src/commands/tk/text.rs
@@ -375,7 +375,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-xscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for communicating with horizontal scrollbars.",
         dialects: None,
         aliases: &[],
@@ -383,7 +383,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-yscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for communicating with vertical scrollbars.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/ttk__combobox.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__combobox.rs
@@ -100,7 +100,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-xscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for horizontal scroll communication.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/ttk__entry.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__entry.rs
@@ -84,7 +84,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-xscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for horizontal scroll communication.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/commands/tk/ttk__scale.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__scale.rs
@@ -76,8 +76,8 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-command",
-        value: OptionValue::script(),
-        detail: "Script to evaluate when the scale value changes.",
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(1)),
+        detail: "Command prefix invoked when the scale value changes (the new value is appended).",
         dialects: None,
         aliases: &[],
         min_version: None,

--- a/rust/tcl-registry/src/commands/tk/ttk__treeview.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__treeview.rs
@@ -76,7 +76,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-xscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for horizontal scroll communication.",
         dialects: None,
         aliases: &[],
@@ -84,7 +84,7 @@ const OPTIONS: &[OptionSpec] = &[
     },
     OptionSpec {
         name: "-yscrollcommand",
-        value: OptionValue::script(),
+        value: OptionValue::command_prefix_n("prefix", AppendedArity::Exactly(2)),
         detail: "Command prefix for vertical scroll communication.",
         dialects: None,
         aliases: &[],

--- a/rust/tcl-registry/src/hover.rs
+++ b/rust/tcl-registry/src/hover.rs
@@ -18,7 +18,7 @@
 
 //! Documentation and completion metadata for LSP features.
 
-use crate::arg_role::ArgRole;
+use crate::arg_role::{AppendedArity, ArgRole};
 use crate::body_kind::BodyKind;
 use crate::dialects::DialectSet;
 
@@ -107,6 +107,11 @@ pub struct OptionArg {
     /// Hint text for the value (e.g. `"channel"`), migrated from the old
     /// `value_hint` field.
     pub hint: &'static str,
+    /// When `role` is [`ArgRole::CommandPrefix`], how many arguments the
+    /// command appends to the callback when it invokes it — drives the
+    /// callback-arity check.  [`AppendedArity::Unknown`] (the default) for
+    /// every other role and for prefixes whose count is indeterminate.
+    pub appended_arity: AppendedArity,
 }
 
 impl OptionArg {
@@ -119,6 +124,7 @@ impl OptionArg {
         values: &[],
         closed: false,
         hint: "",
+        appended_arity: AppendedArity::Unknown,
     };
 }
 
@@ -205,12 +211,28 @@ impl OptionValue {
 
     /// A command-prefix value (`lsort -command cmdPrefix`): the first word is a
     /// command invoked with runtime args appended, not a script body to
-    /// recurse (see [`ArgRole::CommandPrefix`]).
+    /// recurse (see [`ArgRole::CommandPrefix`]).  The appended count is
+    /// [`AppendedArity::Unknown`] (no arity check); use
+    /// [`command_prefix_n`](Self::command_prefix_n) when it is known.
     #[must_use]
     pub const fn command_prefix(hint: &'static str) -> Self {
         Self::Takes(OptionArg {
             role: ArgRole::CommandPrefix,
             hint,
+            ..OptionArg::DEFAULT
+        })
+    }
+
+    /// A command-prefix value whose invoked-arity is known — `lsort -command`
+    /// appends 2 (`command_prefix_n("cmdPrefix", AppendedArity::Exactly(2))`),
+    /// `-xscrollcommand` appends 2, `socket -server` appends 3.  Drives the
+    /// callback-arity check against the referenced proc.
+    #[must_use]
+    pub const fn command_prefix_n(hint: &'static str, appended: AppendedArity) -> Self {
+        Self::Takes(OptionArg {
+            role: ArgRole::CommandPrefix,
+            hint,
+            appended_arity: appended,
             ..OptionArg::DEFAULT
         })
     }
@@ -313,6 +335,16 @@ impl OptionSpec {
         match self.value {
             OptionValue::Flag => None,
             OptionValue::Takes(arg) => arg.also_role,
+        }
+    }
+
+    /// The appended-arity of a [`ArgRole::CommandPrefix`] value
+    /// ([`AppendedArity::Unknown`] for a flag or any other role).
+    #[must_use]
+    pub const fn value_appended_arity(&self) -> AppendedArity {
+        match self.value {
+            OptionValue::Flag => AppendedArity::Unknown,
+            OptionValue::Takes(arg) => arg.appended_arity,
         }
     }
 

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -88,7 +88,7 @@ pub mod version;
 /// `use crate::prelude::*;` in each command file brings in all the
 /// types needed to construct a `CommandSpec`.
 pub mod prelude {
-    pub use crate::arg_role::ArgRole;
+    pub use crate::arg_role::{AppendedArity, ArgRole};
     pub use crate::arity::Arity;
     pub use crate::body_kind::BodyKind;
     pub use crate::definer::{DefinerFamily, DefinitionBodyGrammar, MemberKind, MemberSpec};
@@ -115,7 +115,7 @@ pub mod prelude {
 }
 
 // Re-export key types at crate root.
-pub use arg_role::ArgRole;
+pub use arg_role::{AppendedArity, ArgRole};
 pub use arity::Arity;
 pub use bigip::{BigipObjectSpec, BigipPropertySpec, BigipRegistry, ValueKind};
 pub use body_kind::BodyKind;

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1999,6 +1999,34 @@ mod tests {
             reg.command_prefixes("uevent::bind", &["tag", "ev", "cb"]),
             vec![(2, AppendedArity::AtLeast(2))],
         );
+
+        // `hook bind subject hook observer binding` — the 4-word set form names
+        // a command prefix (Unknown appended: the count is whatever the matching
+        // `hook call` passes); the shorter query forms name none.
+        assert_eq!(
+            reg.command_prefixes("hook", &["bind", "sub", "hk", "obs", "cb"]),
+            vec![(4, AppendedArity::Unknown)],
+        );
+        assert!(
+            reg.command_prefixes("hook", &["bind", "sub", "hk", "obs"])
+                .is_empty(),
+            "the 3-arg `hook bind` query form has no callback prefix",
+        );
+
+        // `processman::onexit id cmd` — `cmd` is a deferred *script* (`eval $cmd`,
+        // 0 appended), NOT a command prefix: it must declare none.
+        assert!(
+            reg.command_prefixes("processman::onexit", &["$pid", "cb"])
+                .is_empty(),
+            "processman::onexit cmd is a script body, not a command prefix",
+        );
+        assert_eq!(
+            reg.get("processman::onexit")
+                .and_then(|s| s.arg_roles.iter().find(|(i, _)| *i == 1))
+                .map(|(_, r)| *r),
+            Some(ArgRole::Body),
+            "processman::onexit cmd (index 1) must carry the Body script role",
+        );
     }
 
     #[test]

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1847,6 +1847,202 @@ mod tests {
     }
 
     #[test]
+    fn command_prefixes_cover_deferred_core_commands() {
+        // Version-gated / resolver-driven callback tails wired in the deferred
+        // pass. Ground-truthed vs tclsh 9.0 (all are 8.7/9.0-era surfaces).
+        let reg = CommandRegistry::build_default();
+
+        // `regsub -command re str cmdPrefix ?var?` (TIP 463, 9.0): with
+        // `-command` the subSpec slot is a prefix called per match with the
+        // whole match + capture groups appended (variadic ⇒ AtLeast(1)). The
+        // slot index tracks the leading-switch shift.
+        assert_eq!(
+            reg.command_prefixes("regsub", &["-command", "re", "s", "cb"]),
+            vec![(3, AppendedArity::AtLeast(1))],
+        );
+        assert_eq!(
+            reg.command_prefixes("regsub", &["-all", "-command", "re", "s", "cb"]),
+            vec![(4, AppendedArity::AtLeast(1))],
+        );
+        // `-c` is an unambiguous abbreviation of `-command`.
+        assert_eq!(
+            reg.command_prefixes("regsub", &["-c", "re", "s", "cb"]),
+            vec![(3, AppendedArity::AtLeast(1))],
+        );
+        // Without `-command`, subSpec is a replacement template, not a prefix.
+        assert!(
+            reg.command_prefixes("regsub", &["re", "s", "template"])
+                .is_empty(),
+            "plain regsub subSpec is not a command prefix",
+        );
+        // `--` terminates switches, so a following `-command`-looking word is a
+        // pattern, not the flag.
+        assert!(
+            reg.command_prefixes("regsub", &["--", "-command", "s", "template"])
+                .is_empty(),
+            "`--` disables -command detection",
+        );
+
+        // `namespace unknown handler` → handler(cmd ?arg...?) = AtLeast(1). The
+        // zero-arg query form carries no prefix.
+        assert_eq!(
+            reg.command_prefixes("namespace", &["unknown", "handler"]),
+            vec![(1, AppendedArity::AtLeast(1))],
+        );
+        assert!(
+            reg.command_prefixes("namespace", &["unknown"]).is_empty(),
+            "the namespace-unknown query form has no command prefix",
+        );
+
+        // `package unknown handler` → handler(name ?requirement...?) = AtLeast(1).
+        assert_eq!(
+            reg.command_prefixes("package", &["unknown", "handler"]),
+            vec![(1, AppendedArity::AtLeast(1))],
+        );
+        assert!(
+            reg.command_prefixes("package", &["unknown"]).is_empty(),
+            "the package-unknown query form has no command prefix",
+        );
+
+        // `coroinject`/`coroprobe coroName command ?arg...?` — the injected
+        // command's appended arity depends on the coroutine's yield point, so
+        // it is a reference-only prefix (Unknown ⇒ never arity-checked).
+        assert_eq!(
+            reg.command_prefixes("coroinject", &["myCoro", "cb", "x"]),
+            vec![(1, AppendedArity::Unknown)],
+        );
+        assert_eq!(
+            reg.command_prefixes("coroprobe", &["myCoro", "cb"]),
+            vec![(1, AppendedArity::Unknown)],
+        );
+
+        // `chan create mode cmdPrefix` / `chan push channelId cmdPrefix` — the
+        // reflected-channel/transform handler is invoked as `cmdPrefix
+        // subcommand handle ?args...?` ⇒ AtLeast(2).
+        assert_eq!(
+            reg.command_prefixes("chan", &["create", "rw", "handler"]),
+            vec![(2, AppendedArity::AtLeast(2))],
+        );
+        assert_eq!(
+            reg.command_prefixes("chan", &["push", "$ch", "xform"]),
+            vec![(2, AppendedArity::AtLeast(2))],
+        );
+    }
+
+    #[test]
+    fn command_prefixes_cover_tcllib_callbacks() {
+        // tcllib callback tails wired in the deferred pass.  Fixed arities are
+        // ground-truthed against the package man pages; ambiguous/variadic tails
+        // are Unknown (reference-only).
+        let reg = CommandRegistry::build_default();
+
+        // `struct::list split seq cmdprefix` — the twin of filter: cmdprefix(el).
+        assert_eq!(
+            reg.command_prefixes("struct::list", &["split", "$s", "cb"]),
+            vec![(2, AppendedArity::Exactly(1))],
+        );
+        // `fileutil::find basedir filtercmd` — filtercmd(name).  Shorter forms
+        // carry no prefix (idx≥argc dropped).
+        assert_eq!(
+            reg.command_prefixes("fileutil::find", &["/base", "flt"]),
+            vec![(1, AppendedArity::Exactly(1))],
+        );
+        assert!(
+            reg.command_prefixes("fileutil::find", &["/base"]).is_empty(),
+            "the basedir-only fileutil::find form has no filter prefix",
+        );
+
+        // generator functional ops: reference-only (multi-value yield ⇒ Unknown).
+        assert_eq!(
+            reg.command_prefixes("generator", &["map", "fn", "$g"]),
+            vec![(1, AppendedArity::Unknown)],
+        );
+        assert_eq!(
+            reg.command_prefixes("generator", &["filter", "pred", "$g"]),
+            vec![(1, AppendedArity::Unknown)],
+        );
+
+        // math::calculus func callbacks (man-page-pinned fixed arities).
+        assert_eq!(
+            reg.command_prefixes("math::calculus::integral", &["0", "1", "100", "f"]),
+            vec![(3, AppendedArity::Exactly(1))],
+        );
+        assert_eq!(
+            reg.command_prefixes("math::calculus::integral3D", &["xi", "yi", "zi", "f"]),
+            vec![(3, AppendedArity::Exactly(3))],
+        );
+        // `newtonRaphson func deriv initval` — two prefixes, each f(x).
+        assert_eq!(
+            reg.command_prefixes("math::calculus::newtonRaphson", &["f", "d", "0.5"]),
+            vec![
+                (0, AppendedArity::Exactly(1)),
+                (1, AppendedArity::Exactly(1)),
+            ],
+        );
+        // `math::probopt::pso function bounds ?args?` — objective(coordVec).
+        assert_eq!(
+            reg.command_prefixes("math::probopt::pso", &["obj", "bnds", "-iter", "50"]),
+            vec![(0, AppendedArity::Exactly(1))],
+        );
+
+        // log message-writer callbacks — `cmd level text` (Exactly(2)).
+        assert_eq!(
+            reg.command_prefixes("log::lvCmd", &["debug", "writer"]),
+            vec![(1, AppendedArity::Exactly(2))],
+        );
+        assert_eq!(
+            reg.command_prefixes("log::lvCmdForall", &["writer"]),
+            vec![(0, AppendedArity::Exactly(2))],
+        );
+        // `uevent::bind tag event command` — command(tag event ?details?).
+        assert_eq!(
+            reg.command_prefixes("uevent::bind", &["tag", "ev", "cb"]),
+            vec![(2, AppendedArity::AtLeast(2))],
+        );
+    }
+
+    #[test]
+    fn commands_naming_a_cmdprefix_declare_a_command_prefix() {
+        // Drift guard: any command whose synopsis literally names a `cmdprefix`
+        // argument must declare a `CommandPrefix` (static table, resolver, or
+        // command-prefix option) so callbacks light up references / call-graph /
+        // W123 / arity.  The allowlist holds genuinely-deferred option-value
+        // callbacks that need a full `OptionSpec` array not yet modelled.
+        const DEFERRED_OPTION_PREFIX: &[&str] = &["mime::getbody"];
+        let reg = CommandRegistry::build_default();
+        let mut gaps = Vec::new();
+        for name in reg.command_names() {
+            if DEFERRED_OPTION_PREFIX.contains(&name) {
+                continue;
+            }
+            let spec = reg.get(name).expect("registered");
+            let mut synopses: Vec<&str> = Vec::new();
+            if let Some(h) = &spec.hover {
+                synopses.extend(h.synopsis.iter().copied());
+            }
+            synopses.extend(spec.forms.iter().map(|f| f.synopsis));
+            synopses.extend(spec.subcommands.iter().map(|s| s.synopsis));
+            for syn in synopses {
+                if !syn.to_ascii_lowercase().contains("cmdprefix") {
+                    continue;
+                }
+                // Probe with the synopsis words after the command name; a
+                // declared prefix yields a non-empty result.
+                let args: Vec<&str> = syn.split_whitespace().skip(1).collect();
+                if reg.command_prefixes(name, &args).is_empty() {
+                    gaps.push(format!("{name}: {syn}"));
+                }
+            }
+        }
+        gaps.sort();
+        assert!(
+            gaps.is_empty(),
+            "commands whose synopsis names a cmdprefix but declare no CommandPrefix:\n{}",
+            gaps.join("\n"),
+        );
+    }
+
+    #[test]
     fn arg_indices_for_role_command_prefix_matches_command_prefixes() {
         // The delegation invariant: `arg_indices_for_role(CommandPrefix)` is
         // exactly the positions `command_prefixes` reports — so highlighting,
@@ -1857,6 +2053,10 @@ mod tests {
             ("socket", &["-server", "accept", "9000"][..]),
             ("tcltest::customMatch", &["exact", "cmp"][..]),
             ("selection", &["handle", ".w", "getData"][..]),
+            ("regsub", &["-command", "re", "s", "cb"][..]),
+            ("namespace", &["unknown", "handler"][..]),
+            ("package", &["unknown", "handler"][..]),
+            ("coroinject", &["myCoro", "cb", "x"][..]),
         ] {
             let via_role = reg.arg_indices_for_role(name, args, ArgRole::CommandPrefix);
             let via_prefixes: Vec<usize> = reg

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -2002,6 +2002,64 @@ mod tests {
     }
 
     #[test]
+    fn tk_command_options_classified_prefix_vs_script() {
+        // The Tk `script()→command_prefix` conversion (separate commit, highest
+        // risk).  Locks in the classification: appended-arg callbacks are
+        // prefixes (references / call-graph / W123 / arity); verbatim scripts and
+        // percent-substitution callbacks stay `script()` (Body, not recorded as a
+        // reference).  Ground truth: Tk 8.6/9.0 man pages.
+        let reg = CommandRegistry::build_default();
+
+        // PREFIXES — scroll callbacks append `first last` (2).
+        for widget in ["listbox", "text", "canvas", "entry", "spinbox"] {
+            assert_eq!(
+                reg.command_prefixes(widget, &[".w", "-xscrollcommand", "cb"]),
+                vec![(2, AppendedArity::Exactly(2))],
+                "{widget} -xscrollcommand must be a prefix appending 2",
+            );
+        }
+        // scale / ttk::scale append the new value (1).
+        assert_eq!(
+            reg.command_prefixes("scale", &[".s", "-command", "cb"]),
+            vec![(2, AppendedArity::Exactly(1))],
+        );
+        assert_eq!(
+            reg.command_prefixes("ttk::scale", &[".s", "-command", "cb"]),
+            vec![(2, AppendedArity::Exactly(1))],
+        );
+        // scrollbar -command: `moveto frac` (2) or `scroll n units` (3) ⇒ AtLeast(2).
+        assert_eq!(
+            reg.command_prefixes("scrollbar", &[".sb", "-command", "cb"]),
+            vec![(2, AppendedArity::AtLeast(2))],
+        );
+        // menu -tearoffcommand appends the parent + torn-off menu paths (2).
+        assert_eq!(
+            reg.command_prefixes("menu", &[".m", "-tearoffcommand", "cb"]),
+            vec![(2, AppendedArity::Exactly(2))],
+        );
+
+        // NOT prefixes — verbatim action scripts and percent-substitution
+        // callbacks are `script()`, never recorded as a command reference.
+        for (widget, opt) in [
+            ("button", "-command"),
+            ("checkbutton", "-command"),
+            ("radiobutton", "-command"),
+            ("menu", "-command"),
+            ("menu", "-postcommand"),
+            ("ttk::combobox", "-postcommand"),
+            ("spinbox", "-command"),        // percent-substitution (%W %s %d)
+            ("spinbox", "-validatecommand"), // percent-substitution
+            ("entry", "-validatecommand"),  // percent-substitution
+            ("entry", "-invalidcommand"),   // percent-substitution
+        ] {
+            assert!(
+                reg.command_prefixes(widget, &[".w", opt, "cb"]).is_empty(),
+                "{widget} {opt} must stay a script, not a command prefix",
+            );
+        }
+    }
+
+    #[test]
     fn commands_naming_a_cmdprefix_declare_a_command_prefix() {
         // Drift guard: any command whose synopsis literally names a `cmdprefix`
         // argument must declare a `CommandPrefix` (static table, resolver, or

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1490,6 +1490,46 @@ mod tests {
     }
 
     #[test]
+    fn uplevel_body_arg_role_skips_optional_level() {
+        // Issue #837: `uplevel ?level? {body}` — the body word's index depends
+        // on whether a leading `level` word is present. The registry resolver
+        // is the single source of truth every body consumer (semantic tokens,
+        // green-tree descent, SSA) queries.
+        let reg = CommandRegistry::build_default();
+        // Literal relative level → body at 1.
+        assert_eq!(
+            reg.arg_indices_for_role("uplevel", &["1", "{set x 1}"], ArgRole::Body),
+            vec![1]
+        );
+        // Absolute `#0` level → body at 1.
+        assert_eq!(
+            reg.arg_indices_for_role("uplevel", &["#0", "{set x 1}"], ArgRole::Body),
+            vec![1]
+        );
+        // No level → body at 0.
+        assert_eq!(
+            reg.arg_indices_for_role("uplevel", &["{set x 1}"], ArgRole::Body),
+            vec![0]
+        );
+        // Dynamic level followed by a script → body at 1.
+        assert_eq!(
+            reg.arg_indices_for_role("uplevel", &["$lvl", "{set x 1}"], ArgRole::Body),
+            vec![1]
+        );
+        // A lone dynamic word is the body itself (implicit level 1) → body at 0.
+        assert_eq!(
+            reg.arg_indices_for_role("uplevel", &["$body"], ArgRole::Body),
+            vec![0]
+        );
+        // Bodyless `uplevel 1` (a wrong-#args error) exposes no body word — the
+        // literal level must not be mis-tagged as a script.
+        assert!(
+            reg.arg_indices_for_role("uplevel", &["1"], ArgRole::Body)
+                .is_empty()
+        );
+    }
+
+    #[test]
     fn if_marks_structural_keywords() {
         let reg = CommandRegistry::build_default();
         let args = [

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -444,6 +444,45 @@ impl CommandRegistry {
         None
     }
 
+    /// Resolve the [`ArgRole::CommandPrefix`] positions and appended arities for
+    /// an instance-method dispatch `$obj method method_args…`.
+    ///
+    /// `method_args` are the words *after* the method name.  Mirrors the
+    /// subcommand arm of [`Self::command_prefixes`] (static
+    /// [`SubCommand::command_prefixes`] table ∪ `command_prefix_resolver` ∪
+    /// command-prefix options), but keyed on the object's class + method rather
+    /// than a top-level command — so `$g walk … -command cb` (option value) and
+    /// `$t walkproc … cb` (trailing positional, resolver) light up the same
+    /// references / call-graph / W123 / arity substrate.  Returned indices are
+    /// relative to `method_args` (0 = first word after the method name).
+    ///
+    /// [`SubCommand::command_prefixes`]: crate::spec::SubCommand::command_prefixes
+    #[must_use]
+    pub fn instance_method_command_prefixes(
+        &self,
+        class_name: &str,
+        method: &str,
+        method_args: &[&str],
+    ) -> Vec<(usize, AppendedArity)> {
+        let Some(m) = self.instance_method(class_name, method) else {
+            return Vec::new();
+        };
+        let n = method_args.len();
+        let mut out: Vec<(usize, AppendedArity)> = Vec::new();
+        if let Some(resolver) = m.command_prefix_resolver {
+            out.extend(
+                resolver(method_args)
+                    .into_iter()
+                    .map(|(i, a)| (i as usize, a)),
+            );
+        } else {
+            out.extend(m.command_prefixes.iter().map(|(i, a)| (*i as usize, *a)));
+        }
+        push_command_prefix_options(&mut out, m.options, method_args, 0);
+        out.retain(|&(idx, _)| idx < n);
+        out
+    }
+
     /// Whether `pkg` is a package the registry knows about — i.e. at
     /// least one registered command declares it as its
     /// [`required_package`](crate::CommandSpec::required_package).
@@ -2108,6 +2147,58 @@ mod tests {
             reg.command_prefixes("tcl::chan::halfpipe", &["-read-command", "cb"])
                 .is_empty(),
             "halfpipe has no -read-command",
+        );
+    }
+
+    #[test]
+    fn instance_method_command_prefixes_cover_struct_graph_and_tree() {
+        // Object-instance method callbacks — the prefix is on a method of a
+        // created object command (`$g walk … -command cb`, `$t walkproc … cb`),
+        // resolved through the class's ObjectClassSpec.  Indices are relative to
+        // the words after the method name.
+        let reg = CommandRegistry::build_default();
+
+        // struct::graph `walk node … -command cb` — option-value prefix,
+        // Exactly(3) (action graphName node).
+        assert_eq!(
+            reg.instance_method_command_prefixes(
+                "struct::graph",
+                "walk",
+                &["root", "-order", "pre", "-command", "cb"],
+            ),
+            vec![(4, AppendedArity::Exactly(3))],
+        );
+        assert_eq!(
+            reg.instance_method_command_prefixes("struct::graph", "walk", &["root", "-command", "cb"]),
+            vec![(2, AppendedArity::Exactly(3))],
+        );
+
+        // struct::tree `walkproc node … cmdprefix` — trailing positional prefix
+        // (resolver), Exactly(3) (tree node action).  The prefix is the final
+        // word regardless of intervening `-order`/`-type` options.
+        assert_eq!(
+            reg.instance_method_command_prefixes("struct::tree", "walkproc", &["root", "cb"]),
+            vec![(1, AppendedArity::Exactly(3))],
+        );
+        assert_eq!(
+            reg.instance_method_command_prefixes(
+                "struct::tree",
+                "walkproc",
+                &["root", "-type", "dfs", "cb"],
+            ),
+            vec![(3, AppendedArity::Exactly(3))],
+        );
+        // `walkproc node` with no prefix word yet names none.
+        assert!(
+            reg.instance_method_command_prefixes("struct::tree", "walkproc", &["root"])
+                .is_empty(),
+            "a walkproc with only the node names no prefix",
+        );
+        // An unmodelled method / class resolves to nothing.
+        assert!(
+            reg.instance_method_command_prefixes("struct::graph", "get", &["x"])
+                .is_empty(),
+            "an unmodelled instance method has no command prefix",
         );
     }
 

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -27,7 +27,7 @@ use std::sync::OnceLock;
 
 use rustc_hash::{FxHashMap, FxHashSet};
 
-use crate::arg_role::ArgRole;
+use crate::arg_role::{AppendedArity, ArgRole};
 use crate::arity::Arity;
 use crate::dialects::DialectSet;
 use crate::forms::CommandForm;
@@ -192,6 +192,33 @@ fn push_option_value_roles(
             let vals = opt.value_indices(args, i);
             if opt.value_role() == Some(role) || opt.value_also_role() == Some(role) {
                 out.extend(vals.iter().copied());
+            }
+            i += 1 + vals.len();
+        } else {
+            i += 1;
+        }
+    }
+}
+
+/// Collect option values whose role is [`ArgRole::CommandPrefix`], paired with
+/// the option's [`AppendedArity`] — the option-side companion to
+/// [`push_option_value_roles`], used by [`CommandRegistry::command_prefixes`].
+fn push_command_prefix_options(
+    out: &mut Vec<(usize, AppendedArity)>,
+    options: &[crate::hover::OptionSpec],
+    args: &[&str],
+    scan_start: usize,
+) {
+    let mut i = scan_start;
+    while i < args.len() {
+        if args[i] == "--" {
+            break;
+        }
+        if let Some(opt) = options.iter().find(|o| o.matches(args[i])) {
+            let vals = opt.value_indices(args, i);
+            if opt.value_role() == Some(ArgRole::CommandPrefix) {
+                let arity = opt.value_appended_arity();
+                out.extend(vals.iter().map(|&v| (v, arity)));
             }
             i += 1 + vals.len();
         } else {
@@ -782,6 +809,16 @@ impl CommandRegistry {
     /// equivalent of `arg_indices_for_role()`.
     #[must_use]
     pub fn arg_indices_for_role(&self, name: &str, args: &[&str], role: ArgRole) -> Vec<usize> {
+        // `CommandPrefix` positions (with their appended arities) are owned by
+        // [`Self::command_prefixes`]; delegate so highlighting, param-trait
+        // inference, and the call-reference extractor all read one source.
+        if role == ArgRole::CommandPrefix {
+            return self
+                .command_prefixes(name, args)
+                .into_iter()
+                .map(|(i, _)| i)
+                .collect();
+        }
         let Some(spec) = self.get(name) else {
             return Vec::new();
         };
@@ -834,6 +871,58 @@ impl CommandRegistry {
         // Value-taking options carry roles at their (dynamic) value positions.
         push_option_value_roles(&mut out, spec.options, args, 0, role);
         out.retain(|&idx| idx < n);
+        out
+    }
+
+    /// Resolve [`ArgRole::CommandPrefix`] argument positions and their
+    /// [`AppendedArity`] for a concrete call.
+    ///
+    /// The single source of truth for command-prefix callbacks — unions the
+    /// three declaration mechanisms (static [`CommandSpec::command_prefixes`]
+    /// table, [`CommandSpec::command_prefix_resolver`], and `command_prefix`
+    /// option values), for the top-level command or its resolved subcommand.
+    /// Mirrors [`Self::arg_indices_for_role`]'s subcommand offset / `--`
+    /// handling. Consumers: highlighting, find-references / call-hierarchy /
+    /// call-graph recording, and the callback-arity check.
+    ///
+    /// For subcommand-based commands pass the subcommand as `args[0]`.
+    #[must_use]
+    pub fn command_prefixes(&self, name: &str, args: &[&str]) -> Vec<(usize, AppendedArity)> {
+        let Some(spec) = self.get(name) else {
+            return Vec::new();
+        };
+        let n = args.len();
+        let mut out: Vec<(usize, AppendedArity)> = Vec::new();
+
+        if !spec.subcommands.is_empty()
+            && !args.is_empty()
+            && let Some(sub) = spec.resolve_subcommand(args[0])
+        {
+            if let Some(resolver) = sub.command_prefix_resolver {
+                out.extend(
+                    resolver(&args[1..])
+                        .into_iter()
+                        .map(|(i, a)| (i as usize + 1, a)),
+                );
+            } else {
+                out.extend(
+                    sub.command_prefixes
+                        .iter()
+                        .map(|(i, a)| (*i as usize + 1, *a)),
+                );
+            }
+            push_command_prefix_options(&mut out, sub.options, args, 1);
+            out.retain(|&(idx, _)| idx < n);
+            return out;
+        }
+
+        if let Some(resolver) = spec.command_prefix_resolver {
+            out.extend(resolver(args).into_iter().map(|(i, a)| (i as usize, a)));
+        } else {
+            out.extend(spec.command_prefixes.iter().map(|(i, a)| (*i as usize, *a)));
+        }
+        push_command_prefix_options(&mut out, spec.options, args, 0);
+        out.retain(|&(idx, _)| idx < n);
         out
     }
 
@@ -1677,6 +1766,106 @@ mod tests {
             vec![1],
             "the -command value should carry the CommandPrefix role",
         );
+    }
+
+    #[test]
+    fn command_prefixes_carry_verified_arities() {
+        // Ground-truthed vs real tclsh (stable 8.6→9.0). `command_prefixes`
+        // is the single source of truth for both the position and the
+        // appended arity.
+        let reg = CommandRegistry::build_default();
+        // `lsort -command cmp {a b}` → cmp invoked as `cmp x y` (2 appended).
+        assert_eq!(
+            reg.command_prefixes("lsort", &["-command", "cmp", "{a b}"]),
+            vec![(1, AppendedArity::Exactly(2))],
+        );
+        // `socket -server accept 9000` → accept invoked as `accept ch a p` (3).
+        assert_eq!(
+            reg.command_prefixes("socket", &["-server", "accept", "9000"]),
+            vec![(1, AppendedArity::Exactly(3))],
+        );
+        // Positional (migrated from arg_roles): `tcltest::customMatch mode cmd`
+        // → `cmd expected actual` (2).
+        assert_eq!(
+            reg.command_prefixes("tcltest::customMatch", &["exact", "cmp"]),
+            vec![(1, AppendedArity::Exactly(2))],
+        );
+        // Dynamic resolver (migrated): `selection handle window cmd` → the
+        // last arg, invoked as `cmd offset maxChars` (2).
+        assert_eq!(
+            reg.command_prefixes("selection", &["handle", ".w", "getData"]),
+            vec![(2, AppendedArity::Exactly(2))],
+        );
+    }
+
+    #[test]
+    fn command_prefixes_cover_core_callback_commands() {
+        // Ground-truthed vs real tclsh 8.6/9.0 (stable). Locks in the Phase-2
+        // coverage of trace / interp / tcllib callbacks.
+        let reg = CommandRegistry::build_default();
+        // `trace add variable v w cb` → cb(name1 name2 op) = 3.
+        assert_eq!(
+            reg.command_prefixes("trace", &["add", "variable", "v", "write", "cb"]),
+            vec![(4, AppendedArity::Exactly(3))],
+        );
+        // `trace add command c ops cb` → cb(old new op) = 3.
+        assert_eq!(
+            reg.command_prefixes("trace", &["add", "command", "c", "rename", "cb"]),
+            vec![(4, AppendedArity::Exactly(3))],
+        );
+        // `trace add execution c ops cb` → 2..4 args ⇒ AtLeast(2).
+        assert_eq!(
+            reg.command_prefixes("trace", &["add", "execution", "c", "enter", "cb"]),
+            vec![(4, AppendedArity::AtLeast(2))],
+        );
+        // Deprecated `trace variable v ops cb` → cb at index 3, 3 appended args.
+        assert_eq!(
+            reg.command_prefixes("trace", &["variable", "v", "write", "cb"]),
+            vec![(3, AppendedArity::Exactly(3))],
+        );
+        // `interp alias {} a {} target x` (create form) → target at index 3,
+        // variadic. The 2-arg query form has no target.
+        assert_eq!(
+            reg.command_prefixes("interp", &["alias", "{}", "a", "{}", "target"]),
+            vec![(4, AppendedArity::Unknown)],
+        );
+        assert!(
+            reg.command_prefixes("interp", &["alias", "{}", "a"])
+                .is_empty(),
+            "the interp-alias query form has no command prefix",
+        );
+        // tcllib: `struct::list filter seq cb` (1), `map seq cb` (1),
+        // `fold seq init cb` (2).
+        assert_eq!(
+            reg.command_prefixes("struct::list", &["filter", "$s", "cb"]),
+            vec![(2, AppendedArity::Exactly(1))],
+        );
+        assert_eq!(
+            reg.command_prefixes("struct::list", &["fold", "$s", "0", "cb"]),
+            vec![(3, AppendedArity::Exactly(2))],
+        );
+    }
+
+    #[test]
+    fn arg_indices_for_role_command_prefix_matches_command_prefixes() {
+        // The delegation invariant: `arg_indices_for_role(CommandPrefix)` is
+        // exactly the positions `command_prefixes` reports — so highlighting,
+        // param-traits, and the call-reference extractor never drift.
+        let reg = CommandRegistry::build_default();
+        for (name, args) in [
+            ("lsort", &["-command", "cmp", "{a b}"][..]),
+            ("socket", &["-server", "accept", "9000"][..]),
+            ("tcltest::customMatch", &["exact", "cmp"][..]),
+            ("selection", &["handle", ".w", "getData"][..]),
+        ] {
+            let via_role = reg.arg_indices_for_role(name, args, ArgRole::CommandPrefix);
+            let via_prefixes: Vec<usize> = reg
+                .command_prefixes(name, args)
+                .into_iter()
+                .map(|(i, _)| i)
+                .collect();
+            assert_eq!(via_role, via_prefixes, "delegation mismatch for {name}");
+        }
     }
 
     #[test]

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -2002,6 +2002,88 @@ mod tests {
     }
 
     #[test]
+    fn command_prefixes_cover_option_value_callbacks() {
+        // Option-value callbacks — the prefix is the value of a named `-flag`,
+        // resolved through each command's `OptionSpec` array.  Arities are
+        // ground-truthed against tcllib source (verified by re-running the exact
+        // `uplevel`/`eval`/`{*}` idioms in tclsh — `uplevel`/`eval` re-split a
+        // `[list …]` word, `[list {*}pfx {*}args]` keeps one word per element).
+        let reg = CommandRegistry::build_default();
+
+        // `mime::getbody token -command cb` — async body callback.  uplevel
+        // re-splits `[list end]` → 1 word, `[list data $c]` → 2 ⇒ AtLeast(1).
+        assert_eq!(
+            reg.command_prefixes("mime::getbody", &["tok", "-command", "cb"]),
+            vec![(2, AppendedArity::AtLeast(1))],
+        );
+        // `-decode` before `-command` is a value-less flag: the scan skips it
+        // without swallowing the callback.
+        assert_eq!(
+            reg.command_prefixes("mime::getbody", &["tok", "-decode", "-command", "cb"]),
+            vec![(3, AppendedArity::AtLeast(1))],
+        );
+
+        // `smtp::sendmessage tok -tlspolicy pol` — `eval $pol [list $code]
+        // [list $diag]` ⇒ Exactly(2).  A preceding value-taking option's value
+        // is skipped, not mistaken for the callback.
+        assert_eq!(
+            reg.command_prefixes("smtp::sendmessage", &["tok", "-tlspolicy", "pol"]),
+            vec![(2, AppendedArity::Exactly(2))],
+        );
+        assert_eq!(
+            reg.command_prefixes(
+                "smtp::sendmessage",
+                &["tok", "-servers", "mail.x", "-tlspolicy", "pol"],
+            ),
+            vec![(4, AppendedArity::Exactly(2))],
+        );
+
+        // `comm::comm send -command cb id cmd` — 7 `-key value` reply pairs ⇒
+        // Exactly(14).  Subcommand-relative option scan offsets by 1.
+        assert_eq!(
+            reg.command_prefixes("comm::comm", &["send", "-command", "cb", "id", "cmd"]),
+            vec![(2, AppendedArity::Exactly(14))],
+        );
+
+        // `bibtex::parse` — every callback prepends the parser token, then its
+        // own payload words: `-command`/`-*command` ⇒ Exactly(2), except
+        // `-recordcommand` ⇒ Exactly(4) (token type key recdata).
+        assert_eq!(
+            reg.command_prefixes("bibtex::parse", &["-recordcommand", "cb", "text"]),
+            vec![(1, AppendedArity::Exactly(4))],
+        );
+        assert_eq!(
+            reg.command_prefixes("bibtex::parse", &["-command", "cb"]),
+            vec![(1, AppendedArity::Exactly(2))],
+        );
+        assert_eq!(
+            reg.command_prefixes("bibtex::parse", &["-progresscommand", "cb"]),
+            vec![(1, AppendedArity::Exactly(2))],
+        );
+
+        // `tcl::chan::halfpipe` — clean `[list {*}pfx {*}args]` idiom: write
+        // appends (chan bytes) ⇒ 2, empty/close append (chan) ⇒ 1.  No
+        // `-read-command` exists.
+        assert_eq!(
+            reg.command_prefixes("tcl::chan::halfpipe", &["-write-command", "cb"]),
+            vec![(1, AppendedArity::Exactly(2))],
+        );
+        assert_eq!(
+            reg.command_prefixes("tcl::chan::halfpipe", &["-close-command", "cb"]),
+            vec![(1, AppendedArity::Exactly(1))],
+        );
+        assert_eq!(
+            reg.command_prefixes("tcl::chan::halfpipe", &["-empty-command", "cb"]),
+            vec![(1, AppendedArity::Exactly(1))],
+        );
+        assert!(
+            reg.command_prefixes("tcl::chan::halfpipe", &["-read-command", "cb"])
+                .is_empty(),
+            "halfpipe has no -read-command",
+        );
+    }
+
+    #[test]
     fn tk_command_options_classified_prefix_vs_script() {
         // The Tk `script()→command_prefix` conversion (separate commit, highest
         // risk).  Locks in the classification: appended-arg callbacks are
@@ -2064,9 +2146,10 @@ mod tests {
         // Drift guard: any command whose synopsis literally names a `cmdprefix`
         // argument must declare a `CommandPrefix` (static table, resolver, or
         // command-prefix option) so callbacks light up references / call-graph /
-        // W123 / arity.  The allowlist holds genuinely-deferred option-value
-        // callbacks that need a full `OptionSpec` array not yet modelled.
-        const DEFERRED_OPTION_PREFIX: &[&str] = &["mime::getbody"];
+        // W123 / arity.  The allowlist holds genuinely-deferred callbacks that
+        // still need modelling; it is empty now that the option-value
+        // callbacks (`mime::getbody -command`, …) carry `OptionSpec` arrays.
+        const DEFERRED_OPTION_PREFIX: &[&str] = &[];
         let reg = CommandRegistry::build_default();
         let mut gaps = Vec::new();
         for name in reg.command_names() {
@@ -2085,8 +2168,15 @@ mod tests {
                     continue;
                 }
                 // Probe with the synopsis words after the command name; a
-                // declared prefix yields a non-empty result.
-                let args: Vec<&str> = syn.split_whitespace().skip(1).collect();
+                // declared prefix yields a non-empty result.  Strip the `?…?`
+                // optionality markers so an option-value prefix
+                // (`?-command cmdprefix?`) presents its bare `-command` /
+                // `cmdprefix` words to the option scanner.
+                let args: Vec<&str> = syn
+                    .split_whitespace()
+                    .skip(1)
+                    .map(|w| w.trim_matches('?'))
+                    .collect();
                 if reg.command_prefixes(name, &args).is_empty() {
                     gaps.push(format!("{name}: {syn}"));
                 }

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -47,6 +47,13 @@ use crate::types::TclType;
 /// `(arg_index, role)` pairs.
 pub type ArgRoleResolver = fn(args: &[&str]) -> Vec<(u8, ArgRole)>;
 
+/// Resolver for variable-layout [`ArgRole::CommandPrefix`] positions and their
+/// appended arities (`trace add …`, `interp alias`, `selection handle`) where
+/// the prefix index depends on the actual arguments. Returns
+/// `(arg_index, appended_arity)` pairs.  Paired with the static
+/// [`CommandSpec::command_prefixes`] table — either may be set.
+pub type CommandPrefixResolver = fn(args: &[&str]) -> Vec<(u8, crate::arg_role::AppendedArity)>;
+
 /// Layout of a `<proto>::payload` byte-array command for the S110
 /// byte-array-corruption check.
 ///
@@ -170,6 +177,18 @@ pub struct CommandSpec {
 
     /// Dynamic argument role resolver (for variable-layout commands).
     pub arg_role_resolver: Option<ArgRoleResolver>,
+
+    /// Static [`ArgRole::CommandPrefix`] positions and their appended arities
+    /// (`lsort` positional forms, `socket -server` handled via options).  Each
+    /// tuple is `(arg_index, appended_arity)`; the index carries
+    /// `ArgRole::CommandPrefix` *and* the arity for the callback check.
+    /// `arg_indices_for_role(CommandPrefix)` reports exactly these indices
+    /// (unioned with option/resolver prefixes) so highlighting stays in sync.
+    pub command_prefixes: &'static [(u8, crate::arg_role::AppendedArity)],
+
+    /// Dynamic command-prefix resolver for variable-layout callbacks
+    /// (`trace add …`, `interp alias`, `selection handle`).
+    pub command_prefix_resolver: Option<CommandPrefixResolver>,
 
     /// Return type of the command.
     pub return_type: Option<TclType>,
@@ -471,6 +490,8 @@ impl CommandSpec {
         arity: Arity::any(),
         arg_roles: &[],
         arg_role_resolver: None,
+        command_prefixes: &[],
+        command_prefix_resolver: None,
         return_type: None,
         arg_types: &[],
         subcommands: &[],
@@ -831,6 +852,13 @@ pub struct SubCommand {
     /// Dynamic argument role resolver.
     pub arg_role_resolver: Option<ArgRoleResolver>,
 
+    /// Static command-prefix positions + appended arities (after the
+    /// subcommand word), e.g. `trace add variable`'s callback.
+    pub command_prefixes: &'static [(u8, crate::arg_role::AppendedArity)],
+
+    /// Dynamic command-prefix resolver (after the subcommand word).
+    pub command_prefix_resolver: Option<CommandPrefixResolver>,
+
     /// Return type.
     pub return_type: Option<TclType>,
 
@@ -1002,6 +1030,8 @@ impl SubCommand {
         hover: None,
         arg_roles: &[],
         arg_role_resolver: None,
+        command_prefixes: &[],
+        command_prefix_resolver: None,
         return_type: None,
         arg_types: &[],
         pure: false,


### PR DESCRIPTION
## Summary

- **Fix #837** — recurse an `uplevel` body as a script via a registry-driven body role, instead of treating it as an opaque value.
- **Make `ArgRole::CommandPrefix` a first-class command reference.** A callback head (`lsort -command cmp`, `trace add … cb`, `socket -server accept`) is now recorded as a `command_invocation` **and** a `ProcSummary.direct_calls` edge, so it feeds find-references, rename, call-hierarchy, code-lens, unknown-command (W123), and a new **callback-arity check** (E002/E003) — all registry-driven, with literal-bareword-only FP guards (a dynamic `$cb`/`[gen]` head is never recorded).
- **Registry coverage of the callback long tail** (arities ground-truthed against C Tcl 9.0 / tcllib source and re-run in `tclsh`):
  - core Tcl + tcllib **positional** prefixes (`struct::list`, `fileutil::find`, `generator`, `math::calculus`, `namespace/package unknown`, `regsub -command`, `chan create/push`, …);
  - Tk **`script()` → `command_prefix` conversion** (scroll/scale/scrollbar/menu) — a net FP reduction (`{.sb set}` no longer draws a spurious `W123 .sb`) while a bareword user-proc callback becomes a real reference;
  - **option-value** callbacks via `OptionSpec` (`mime::getbody -command`, `smtp -tlspolicy`, `comm send -command`, `bibtex::parse -*command`, `tcl::chan::halfpipe -*-command`);
  - **script-vs-prefix** disambiguation (`hook bind` is a prefix; `processman::onexit` is a deferred script — `ArgRole::Body`/`Structural`, not a prefix);
  - **object-instance method** callbacks via `ObjectClassSpec` (`struct::graph $g walk -command`, `struct::tree $t walkproc`).
- **Cross-cutting object typing (the last mile):**
  - the **interprocedural call-graph** pass now tracks the receiver's object type (via `object_handle_classes`, extended to harvest registry naming-factories), so `$g walk … -command cb` forms a real `direct_calls` edge — call graph, O124 not-dead, purity;
  - the **incremental per-item firewall** now binds registry object-factories eagerly in an isolated proc body, so an **in-proc** instance callback resolves cross-file (arity + references) via `project_diagnostics`, matching the whole-file walk.
- Note (documented in FP.md): the factory object type is deliberately kept **out of the SSA lattice** — W307/W308 aggregate `fu.types` object-insensitively across procs, so lattice-typing a factory would leak a handle's class between same-named vars (FP-OBJ-04).

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-registry -p tcl-compiler -p tcl-lsp-core -p tcl-lsp-db` → **415 / 5904 / 1712 / 61 passed, 0 failed**
  - `cargo clippy -p tcl-registry -p tcl-compiler -p tcl-lsp-core -p tcl-lsp-db` → clean (no new warnings)
  - `make xtask-check` → all generated-table / editor-catalog drift gates pass (the only catalog delta is the regenerated `editors/zed/src/generated/tcl_commands.json`)
  - Rebased onto the latest `rust` (`28fd528`) and re-ran all of the above green.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — **No.** It broadens what `command_invocations` / `ProcSummary.direct_calls` *contain* (callback heads now included) within the existing contracts; the meaning of W123 / E002 / E003 / call-graph edges is unchanged.
- [x] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A per the above; the full design + FP rationale (TP/FP/TN guards, `tclsh` ground truth, the FP-OBJ-04 lattice trade-off, the walker-is-not-the-references-vehicle finding) is documented in **`docs/design/compiler/FP.md` → FP-NAB-13**. No existing `docs/kcs/compiler/` note covers this surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01A7Jm7KFaiT43LYcpjgQVhJ

---
_Generated by [Claude Code](https://claude.ai/code/session_01A7Jm7KFaiT43LYcpjgQVhJ)_