### PR TITLE
CI: install stable explicitly in github-pages and report-pyz

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -74,6 +74,17 @@ jobs:
       # rust-toolchain.toml pins the channel (stable). Cache both crate trees:
       # the workspace member the report links (bigip-report-gen/python) and the
       # standalone WASM crate (tcl-explorer-wasm has its own lockfile).
+      # The runner image ships a pinned stable (currently 1.96.1) and
+      # `rust-toolchain.toml`'s `channel = "stable"` resolves to *that*, not to
+      # the newest release — so cargo refuses the workspace's `rust-version`.
+      # Install the current stable explicitly.  `cache: false` because the
+      # Swatinem cache is configured separately below.
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: stable
+          cache: false
+
       - name: Cache cargo + build
         uses: Swatinem/rust-cache@c19371144df3bb44fab255c43d04cbc2ab54d1c4 # v2.9.1
         with:

--- a/.github/workflows/report-pyz.yml
+++ b/.github/workflows/report-pyz.yml
@@ -51,6 +51,15 @@ jobs:
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
 
+      # The runner image ships a pinned stable (currently 1.96.1) and
+      # `rust-toolchain.toml`'s `channel = "stable"` resolves to *that*, not to
+      # the newest release — so cargo refuses the workspace's `rust-version`.
+      # Install the current stable explicitly.
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: stable
+
       # abi3 wheels run on any CPython >= 3.9; build on a current one.
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
@@ -152,6 +161,15 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # The runner image ships a pinned stable (currently 1.96.1) and
+      # `rust-toolchain.toml`'s `channel = "stable"` resolves to *that*, not to
+      # the newest release — so cargo refuses the workspace's `rust-version`.
+      # Install the current stable explicitly.
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: stable
 
       # The generator page inlines the front-end bundle (input.js), so build the
       # shared front-end first. Node is preinstalled on the runner.


### PR DESCRIPTION
## What broke

`github-pages` failed on the merge commit for #842 — [run 29027304167](https://github.com/bitwisecook/tcl-lsp/actions/runs/29027304167):

```
error: rustc 1.96.1 is not supported by the following packages:
Error: `cargo build` failed
```

## Why

The same trap #842 fixed *inside* `ci.yml`, missed in the workflows outside it. These jobs build Rust with the runner's preinstalled rustup. `rust-toolchain.toml`'s `channel = "stable"` resolves to the stable **already on the image** (1.96.1), not to the newest release. Once `rust-version` became `1.97`, cargo refused the workspace.

`pr-gate` never had the problem because it asks `setup-rust-toolchain` for `stable`, which installs the current one.

## Fix

A `Set up Rust` step in the three affected jobs, with `cache: false` where a Swatinem cache is already configured separately so the two don't fight.

| Workflow | Job | Was |
|---|---|---|
| `github-pages.yml` | `build` | no toolchain setup — **failed on merge** |
| `report-pyz.yml` | `build` | no toolchain setup |
| `report-pyz.yml` | `single-file-html` | no toolchain setup |

`report-pyz` would have failed identically on the next tag. It wasn't caught because it doesn't run on branch pushes.

## Audit

Every workflow checked rather than just the one that shouted. `codeql` analyses Python/TypeScript only; `vm-tests` already sets the toolchain up. Every job that shells out to `cargo`, `maturin`, `rustup` or `wasm-pack` now installs stable first:

```
github-pages / build               ok
report-pyz / build                 ok
report-pyz / single-file-html      ok
ci / pr-gate                       ok
ci / rust-tests                    ok
ci / rust-tests-heavy              ok
ci / lsp-e2e                       ok
ci / build-server-matrix           ok
```

Until this lands, `github-pages` fails on every push to `rust`. The eight `ci.yml` gates are unaffected and green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)