### PR TITLE
CI: install stable in build-vsix and build-claude-skills

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -579,6 +579,18 @@ jobs:
           fetch-depth: 1
           fetch-tags: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
+      # `make package-vsix` / `make claude-skills` shell out to `cargo xtask`, so
+      # this job needs a toolchain. The runner image ships a pinned stable
+      # (1.96.1) and `rust-toolchain.toml`'s `channel = "stable"` resolves to
+      # *that*, not to the newest release, so cargo refuses the workspace's
+      # `rust-version`. Install the current stable explicitly.
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: stable
+          cache-key: build-vsix
+
+
       # No Python setup: the VSIX bundles native binaries and the build
       # (compile + filter-readme + vsce) is Node-only.
 
@@ -659,6 +671,18 @@ jobs:
           # HEAD; tag refs already have the tag at HEAD so don't re-fetch).
           fetch-depth: 1
           fetch-tags: ${{ !startsWith(github.ref, 'refs/tags/') }}
+
+      # `make package-vsix` / `make claude-skills` shell out to `cargo xtask`, so
+      # this job needs a toolchain. The runner image ships a pinned stable
+      # (1.96.1) and `rust-toolchain.toml`'s `channel = "stable"` resolves to
+      # *that*, not to the newest release, so cargo refuses the workspace's
+      # `rust-version`. Install the current stable explicitly.
+      - name: Set up Rust
+        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+        with:
+          toolchain: stable
+          cache-key: build-claude-skills
+
 
       - name: Build Claude skills zip (native, MCP-driven — no Python)
         run: make claude-skills


### PR DESCRIPTION
> [!WARNING]
> This failed the **v2.1.5** tag run. The incomplete prerelease and its tag have been deleted.

## What failed

`build-vsix`, on the `v2.1.5` tag ([run 29035730252](https://github.com/bitwisecook/tcl-lsp/actions/runs/29035730252)):

```
error: rustc 1.96.1 is not supported by the following packages:
  tcl-cmd-core@0.1.0 requires rustc 1.97
  tcl-core-types@0.1.0 requires rustc 1.97
  ...
make: *** [Makefile:970: ai/prompts/irules_system.md] Error 101
```

## Why

`make package-vsix` and `make claude-skills` shell out to `cargo xtask` to regenerate `ai/prompts/*`. Neither job installed a toolchain, so cargo ran as the runner image's pinned stable — **1.96.1** — and refused the workspace's `rust-version = "1.97"`.

`rust-toolchain.toml`'s `channel = "stable"` does not help: rustup resolves it to the stable *already installed on the image*, not to the newest release.

## Blast radius on the tag run

Everything else passed, including `publish-native-binaries` — so the `tcl-lsp-server-<triple>` assets from #848 landed correctly. But `publish-checksums` needs `build-vsix`, so it skipped, and both marketplace publishes skipped with it. The result was a **public prerelease with 37 assets, no VSIX and no `SHA256SUMS`**. `install.sh` aborts without `SHA256SUMS` by design, so the release was unusable. Deleted along with the tag.

## Why the earlier sweep missed it

The fix that repaired `rust-tests`, `lsp-e2e`, `rust-tests-heavy`, `github-pages` and `report-pyz` audited by grepping for `cargo` inside each step's `run:`. These two reach cargo **via `make`**, so they didn't match.

The audit is now by *reachability* — any step invoking `cargo`, `rustup`, `maturin`, `wasm-pack` **or `make`** must install a toolchain first:

```
ok      ci / pr-gate                  ok      ci / build-jetbrains
ok      ci / test-ext                 ok      ci / build-sublime
ok      ci / rust-tests               ok      ci / build-zed
ok      ci / rust-tests-heavy         ok      ci / build-vsix            <- fixed
ok      ci / lsp-e2e                  ok      ci / build-claude-skills   <- fixed
ok      ci / python                   ok      github-pages / build
ok      ci / build-server-matrix      ok      report-pyz / build
                                      ok      report-pyz / single-file-html
                                      ok      vm-tests / vm-tests
```

`build-claude-skills` passed on the tag run despite the same hole; the step is defensive there.

## After merge

Re-tag: `make release-tag V=2.1.5`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)