### PR TITLE
CI: add workflow_dispatch to ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main, rust]
+  # Manual escape hatch: if a PR's initial `pull_request: opened` webhook
+  # is ever dropped by GitHub (rare, but has happened — no runs show up
+  # for the branch at all, not even a queued/pending one), this lets a
+  # maintainer kick off the same CI graph from the Actions tab instead of
+  # having to push a throwaway commit just to re-send the event.
+  #
+  # NOTE: workflow_dispatch lets you pick any ref, tags included, and every
+  # release/publish job is gated on `startsWith(github.ref, 'refs/tags/v')`.
+  # Dispatching against a `v*` tag therefore re-runs create-release and the
+  # marketplace publishes. Dispatch against a branch unless you mean that.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
Manual escape hatch, as requested.

If a PR's initial `pull_request: opened` webhook is ever dropped by GitHub — rare, but it happens, and the symptom is that **no** run appears for the branch, not even a queued one — this lets a maintainer kick off the same CI graph from the Actions tab rather than pushing a throwaway commit just to re-send the event.

## What a dispatch actually runs

Against a **branch**, exactly the eight gates:

```
channel  pr-gate  rust-tests  rust-tests-heavy  lsp-e2e  cargo-deny  test-ext  python
```

Every release and publish job is gated on `startsWith(github.ref, 'refs/tags/v')` and stays skipped.

> [!WARNING]
> That gate is also the hazard. `workflow_dispatch` lets you choose **any** ref from the Actions tab, tags included. Dispatching against a `v*` tag re-runs `create-release`, `publish-native-binaries`, `publish-checksums` and both marketplace publishes. The comment in the workflow says so at the point of use.

A dispatch run does not report as a PR status check, so it cannot satisfy the required checks on `rust` — it re-runs the work, and you would still need a push or a re-opened PR for the checks to attach.

🤖 Generated with [Claude Code](https://claude.com/claude-code)