### PR TITLE
Fix O103 proc folding: implicit returns, variadic args, rename safety

### DIFF
--- a/docs/kcs/codes/kcs-optimisation-o103-static-proc-folding.md
+++ b/docs/kcs/codes/kcs-optimisation-o103-static-proc-folding.md
@@ -37,6 +37,8 @@ set x 42
 - Skipped when the proc has observable side effects.
 - Skipped when any argument is not a compile-time constant.
 - Skipped when the proc body cannot be summarised by [interprocedural analysis](../../GLOSSARY.md#ipa).
+- Skipped when the proc's bare name is anywhere `rename`d over, `rename`d away, or shadowed by an `interp alias` — the call site can no longer be trusted to run that proc's body.
+- A proc with no explicit `return` still folds when it falls through: the value is whatever Tcl's "result of the last command executed" rule would leave (the `double` example above relies on exactly this).
 
 ## How to disable
 

--- a/editors/vscode/src/test/commandExecution.test.ts
+++ b/editors/vscode/src/test/commandExecution.test.ts
@@ -109,6 +109,46 @@ suite("LSP Command Execution", () => {
     assert.ok(typeof result.source === "string", "result should have source string");
   });
 
+  test("tcl-lsp.optimiseDocument folds O103 pure-proc calls, including implicit return", async () => {
+    // TP: `quad` has no explicit `return` (Tcl's "value of the last command
+    // executed" rule — the KCS O103 doc's own canonical example) and must
+    // still fold end to end through the real extension + packaged server.
+    const o103Uri = getDocUri("o103.tcl");
+    await activate(o103Uri);
+    const result = (await execLspCommand(
+      "tcl-lsp.optimiseDocument",
+      o103Uri.toString(),
+      "full",
+    )) as {
+      optimisations: unknown[];
+      source: string;
+    } | null;
+    assert.ok(result, "optimiseDocument should return a result");
+    assert.ok(result.source.includes("set q 20"), `expected "set q 20" in:\n${result.source}`);
+  });
+
+  test("tcl-lsp.optimiseDocument does not fold a proc call renamed over", async () => {
+    // FP guard / miscompile-guard: `rename triple double` moves `triple`'s
+    // body onto the name `double` — `optimiseDocument` must leave
+    // `set d [double 21]` untouched rather than fold it to the *original*
+    // `double` proc's constant return (a real miscompile).
+    const o103Uri = getDocUri("o103.tcl");
+    await activate(o103Uri);
+    const result = (await execLspCommand(
+      "tcl-lsp.optimiseDocument",
+      o103Uri.toString(),
+      "full",
+    )) as {
+      optimisations: unknown[];
+      source: string;
+    } | null;
+    assert.ok(result, "optimiseDocument should return a result");
+    assert.ok(
+      result.source.includes("set d [double 21]"),
+      `expected "set d [double 21]" to survive unfolded in:\n${result.source}`,
+    );
+  });
+
   // -- fixAllSafeIssues -------------------------------------------------------
 
   test("tcl-lsp.fixAllSafeIssues returns applied list", async () => {

--- a/editors/vscode/testFixture/o103.tcl
+++ b/editors/vscode/testFixture/o103.tcl
@@ -1,0 +1,19 @@
+# O103 (fold static/pure proc calls to their constant return) fixture.
+#
+# `quad` has no explicit `return` — its result is Tcl's "value of the last
+# command executed" rule (the KCS O103 doc's own canonical example uses
+# this exact shape) — and must still fold to a constant.
+proc quad {n} { expr {$n * 4} }
+set q [quad 5]
+
+# `triple`'s body is moved onto the name `double` by the rename below, so
+# a call to `double` must NOT fold to the *original* `double` proc's
+# constant return (that would miscompile: the renamed-over name actually
+# runs `triple`'s body at runtime). The whole-module scan is conservative
+# (flow-insensitive, like the existing O129 builtin-fold trust gate), so
+# it distrusts every call to a name any `rename` ever touches, not only
+# the ones textually after it.
+proc double {n} { expr {$n * 2} }
+proc triple {n} { expr {$n * 3} }
+rename triple double
+set d [double 21]

--- a/rust/tcl-compiler/src/command_binding.rs
+++ b/rust/tcl-compiler/src/command_binding.rs
@@ -541,6 +541,7 @@ fn collect_tampered_builtins(
 /// from "rebound to something else".
 fn collect_proc_rebindings(
     stmt: &Statement,
+    namespace: &str,
     rebound: &mut std::collections::HashSet<String>,
     dynamic: &mut bool,
 ) {
@@ -555,9 +556,9 @@ fn collect_proc_rebindings(
                 *dynamic = true;
                 return;
             }
-            rebound.insert(nqn(&args[0]));
+            insert_rebound_candidates(&args[0], namespace, rebound);
             if !args[1].is_empty() {
-                rebound.insert(nqn(&args[1]));
+                insert_rebound_candidates(&args[1], namespace, rebound);
             }
         }
         "interp" => {
@@ -566,13 +567,40 @@ fn collect_proc_rebindings(
                     *dynamic = true;
                     return;
                 }
-                rebound.insert(nqn(&alias_name));
+                insert_rebound_candidates(&alias_name, namespace, rebound);
             } else if args.first().map(String::as_str) == Some("alias") {
                 *dynamic = true;
             }
         }
         _ => {}
     }
+}
+
+/// Record every name a bare `rename` / `interp alias` argument could
+/// resolve to when it runs inside `namespace` — Tcl resolves an
+/// unqualified command name against the *current* namespace at the point
+/// the `rename`/`interp alias` executes, not the global namespace (a
+/// `proc ::ns::doit {} { rename triple double }` renames `::ns::triple`
+/// to `::ns::double`, not `::triple`/`::double` — confirmed against
+/// tclsh 9.0.4). This scan is flow-insensitive and doesn't know whether a
+/// same-named command already exists in `namespace` at that point, so it
+/// conservatively records BOTH the namespace-relative and the
+/// global-rooted candidate for a bare name — the same sound
+/// over-approximation [`collect_tampered_builtins`] already applies.
+/// A name that already contains `::` resolves unambiguously (rooted at
+/// `::`, matching the optimiser's own `resolve_proc_qname` simplified
+/// qualification rule), so only one candidate is recorded for it.
+fn insert_rebound_candidates(
+    name: &str,
+    namespace: &str,
+    rebound: &mut std::collections::HashSet<String>,
+) {
+    if name.contains("::") || namespace == "::" {
+        rebound.insert(nqn(name));
+        return;
+    }
+    rebound.insert(nqn(&format!("{namespace}::{name}")));
+    rebound.insert(nqn(name));
 }
 
 /// Apply the gen of every `Call` / `Barrier` in `script` (recursing into
@@ -584,6 +612,7 @@ fn walk_body_calls(
     script: &crate::ir::Script,
     state: &mut State,
     registry: &CommandRegistry,
+    namespace: &str,
     names: &mut std::collections::HashSet<String>,
     rebound: &mut std::collections::HashSet<String>,
     dynamic: &mut bool,
@@ -591,7 +620,7 @@ fn walk_body_calls(
     for stmt in &script.statements {
         match stmt {
             Statement::Call { .. } | Statement::Barrier { .. } => {
-                collect_proc_rebindings(stmt, rebound, dynamic);
+                collect_proc_rebindings(stmt, namespace, rebound, dynamic);
                 stmt_gen(stmt, state, registry);
                 collect_tampered_builtins(state, registry, names, dynamic);
             }
@@ -599,23 +628,23 @@ fn walk_body_calls(
                 clauses, else_body, ..
             } => {
                 for c in clauses {
-                    walk_body_calls(&c.body, state, registry, names, rebound, dynamic);
+                    walk_body_calls(&c.body, state, registry, namespace, names, rebound, dynamic);
                 }
                 if let Some(b) = else_body {
-                    walk_body_calls(b, state, registry, names, rebound, dynamic);
+                    walk_body_calls(b, state, registry, namespace, names, rebound, dynamic);
                 }
             }
             Statement::For {
                 init, next, body, ..
             } => {
-                walk_body_calls(init, state, registry, names, rebound, dynamic);
-                walk_body_calls(next, state, registry, names, rebound, dynamic);
-                walk_body_calls(body, state, registry, names, rebound, dynamic);
+                walk_body_calls(init, state, registry, namespace, names, rebound, dynamic);
+                walk_body_calls(next, state, registry, namespace, names, rebound, dynamic);
+                walk_body_calls(body, state, registry, namespace, names, rebound, dynamic);
             }
             Statement::While { body, .. }
             | Statement::Catch { body, .. }
             | Statement::Foreach { body, .. } => {
-                walk_body_calls(body, state, registry, names, rebound, dynamic);
+                walk_body_calls(body, state, registry, namespace, names, rebound, dynamic);
             }
             Statement::Try {
                 body,
@@ -623,12 +652,12 @@ fn walk_body_calls(
                 finally_body,
                 ..
             } => {
-                walk_body_calls(body, state, registry, names, rebound, dynamic);
+                walk_body_calls(body, state, registry, namespace, names, rebound, dynamic);
                 for h in handlers {
-                    walk_body_calls(&h.body, state, registry, names, rebound, dynamic);
+                    walk_body_calls(&h.body, state, registry, namespace, names, rebound, dynamic);
                 }
                 if let Some(fb) = finally_body {
-                    walk_body_calls(fb, state, registry, names, rebound, dynamic);
+                    walk_body_calls(fb, state, registry, namespace, names, rebound, dynamic);
                 }
             }
             Statement::Switch {
@@ -636,11 +665,11 @@ fn walk_body_calls(
             } => {
                 for a in arms {
                     if let Some(b) = &a.body {
-                        walk_body_calls(b, state, registry, names, rebound, dynamic);
+                        walk_body_calls(b, state, registry, namespace, names, rebound, dynamic);
                     }
                 }
                 if let Some(b) = default_body {
-                    walk_body_calls(b, state, registry, names, rebound, dynamic);
+                    walk_body_calls(b, state, registry, namespace, names, rebound, dynamic);
                 }
             }
             _ => {}
@@ -666,24 +695,27 @@ pub fn scan_module_command_mutations(
     let mut rebound = std::collections::HashSet::new();
     let mut dynamic = false;
 
-    let mut visit = |script: &crate::ir::Script| {
+    let mut visit = |script: &crate::ir::Script, namespace: &str| {
         let mut state = State::default();
         walk_body_calls(
             script,
             &mut state,
             registry,
+            namespace,
             &mut names,
             &mut rebound,
             &mut dynamic,
         );
     };
 
-    visit(&ir_module.top_level);
-    for proc in ir_module.procedures.values() {
-        visit(&proc.body);
+    visit(&ir_module.top_level, "::");
+    for (qname, proc) in &ir_module.procedures {
+        let namespace = crate::optimiser::helpers::naming::namespace_from_qualified(qname);
+        visit(&proc.body, &namespace);
     }
-    for method in ir_module.methods.values() {
-        visit(&method.body);
+    for (mqname, method) in &ir_module.methods {
+        let namespace = crate::optimiser::helpers::naming::namespace_from_qualified(mqname);
+        visit(&method.body, &namespace);
     }
 
     ModuleCommandMutations {
@@ -861,5 +893,45 @@ mod tests {
         );
         let m = scan_module_command_mutations(&cu.ir_module, &reg);
         assert!(m.trusts_proc_binding("double"));
+    }
+
+    #[test]
+    fn trusts_proc_binding_false_for_namespace_relative_rename() {
+        // FP guard (reported in code review): a bare `rename` argument
+        // inside a namespaced proc resolves relative to THAT proc's own
+        // namespace, not the global namespace — `rename triple double`
+        // inside `proc ::ns::doit` renames `::ns::triple` onto
+        // `::ns::double`. An earlier version always rooted the bare names
+        // globally (`::triple`/`::double`), so it never distrusted the
+        // actually-affected namespaced names.
+        let reg = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for(
+            "namespace eval ::ns {\n    proc double {n} { expr {$n * 2} }\n    proc triple {n} { expr {$n * 3} }\n}\nproc ::ns::doit {} { rename triple double }\n",
+            &reg,
+            false,
+        );
+        let m = scan_module_command_mutations(&cu.ir_module, &reg);
+        assert!(
+            !m.trusts_proc_binding("::ns::double"),
+            "namespace-relative rename target"
+        );
+        assert!(
+            !m.trusts_proc_binding("::ns::triple"),
+            "namespace-relative rename source"
+        );
+        // The scan is flow-insensitive (it can't know whether `double`/
+        // `triple` already existed as GLOBAL commands at the point
+        // `::ns::doit` runs), so it conservatively distrusts the
+        // global-rooted candidate too — a deliberate, sound
+        // over-approximation (a missed fold, never a wrong one),
+        // mirroring `collect_tampered_builtins`'s existing philosophy.
+        assert!(
+            !m.trusts_proc_binding("::double"),
+            "global-rooted candidate"
+        );
+        assert!(
+            !m.trusts_proc_binding("::triple"),
+            "global-rooted candidate"
+        );
     }
 }

--- a/rust/tcl-compiler/src/command_binding.rs
+++ b/rust/tcl-compiler/src/command_binding.rs
@@ -454,6 +454,15 @@ pub fn analyse_command_binding<'a>(
 pub struct ModuleCommandMutations {
     /// Canonical names of core builtins some body may rebind.
     names: std::collections::HashSet<String>,
+    /// Canonical names that are the *source* or *target* of a `rename`, or
+    /// the alias name of an `interp alias`, anywhere in the module — i.e.
+    /// a name that no longer reliably denotes the proc it was declared as
+    /// (or never denoted one at all). Unlike `names`, this is NOT
+    /// restricted to builtins: a plain `proc NAME { … }` declaration is
+    /// deliberately excluded (declaring a name as itself is the expected,
+    /// trustworthy binding) — only `rename` / `interp alias` touching the
+    /// name is recorded. Feeds [`Self::trusts_proc_binding`].
+    rebound: std::collections::HashSet<String>,
     /// A body performs a dynamic `rename`/alias/proc (target not
     /// statically known) → resolution of *any* name is opaque.
     dynamic: bool,
@@ -469,6 +478,28 @@ impl ModuleCommandMutations {
             return false;
         }
         !self.names.contains(&nqn(command_name))
+    }
+
+    /// True when `proc_name` can still be trusted to denote the module
+    /// procedure it was declared as at an arbitrary later call site — i.e.
+    /// its bare name was never the subject of a later `rename` (as the old
+    /// name being moved away *or* the new name a different command moved
+    /// onto) or `interp alias` (as the alias name) anywhere in the module.
+    ///
+    /// Flow-insensitive and whole-module, like [`Self::trusts`]: a
+    /// rebinding buried in a proc body only takes effect when that proc
+    /// runs, and the cross-proc call order isn't statically known, so any
+    /// observed rebinding of the name is treated as live everywhere. This
+    /// is what makes it sound to gate the optimiser's proc-call constant
+    /// fold (O103) on this query — folding a call to the *original* proc's
+    /// constant return would miscompile a script that later does
+    /// `rename otherProc thisName` or `interp alias {} thisName {} other`.
+    #[must_use]
+    pub fn trusts_proc_binding(&self, proc_name: &str) -> bool {
+        if self.dynamic {
+            return false;
+        }
+        !self.rebound.contains(&nqn(proc_name))
     }
 }
 
@@ -493,6 +524,57 @@ fn collect_tampered_builtins(
     }
 }
 
+/// Record the proc-binding-relevant names touched by a `rename` or `interp
+/// alias` statement: the *source* name (vacated — no longer denotes what it
+/// used to) and, for a static target, the *destination* name (now denoting
+/// whatever the source used to, not its own original declaration, if it
+/// even had one). A `proc` (re)declaration is deliberately NOT recorded —
+/// declaring `NAME` as itself is the expected, trustworthy binding; only
+/// *moving* a binding onto a name, or *vacating* a name that used to denote
+/// a proc, breaks the "this bare name still denotes the proc it was
+/// declared as" invariant [`ModuleCommandMutations::trusts_proc_binding`]
+/// needs. Independent of the [`State`] lattice — a direct syntactic scan,
+/// since (unlike the builtin-only trust gate) there is no meaningful
+/// "default" binding to diff a proc name against: a plain declaration
+/// *also* changes the name's binding away from its textual default, so
+/// diffing against `default_binding` cannot distinguish "declared itself"
+/// from "rebound to something else".
+fn collect_proc_rebindings(
+    stmt: &Statement,
+    rebound: &mut std::collections::HashSet<String>,
+    dynamic: &mut bool,
+) {
+    let (Statement::Call { args, .. } | Statement::Barrier { args, .. }) = stmt else {
+        return;
+    };
+    let cmd = stmt.canonical_command_or_source();
+    let cmd_bare = cmd.strip_prefix("::").unwrap_or(cmd);
+    match cmd_bare {
+        "rename" => {
+            if args.len() != 2 || is_dynamic_word(&args[0]) || is_dynamic_word(&args[1]) {
+                *dynamic = true;
+                return;
+            }
+            rebound.insert(nqn(&args[0]));
+            if !args[1].is_empty() {
+                rebound.insert(nqn(&args[1]));
+            }
+        }
+        "interp" => {
+            if let Some((alias_name, target_cmd, _prepended)) = detect_interp_alias(cmd, args) {
+                if is_dynamic_word(&alias_name) || is_dynamic_word(&target_cmd) {
+                    *dynamic = true;
+                    return;
+                }
+                rebound.insert(nqn(&alias_name));
+            } else if args.first().map(String::as_str) == Some("alias") {
+                *dynamic = true;
+            }
+        }
+        _ => {}
+    }
+}
+
 /// Apply the gen of every `Call` / `Barrier` in `script` (recursing into
 /// nested structured bodies, in source order) to `state`, collecting
 /// after *each* mutation — so a builtin renamed away and later restored
@@ -503,11 +585,13 @@ fn walk_body_calls(
     state: &mut State,
     registry: &CommandRegistry,
     names: &mut std::collections::HashSet<String>,
+    rebound: &mut std::collections::HashSet<String>,
     dynamic: &mut bool,
 ) {
     for stmt in &script.statements {
         match stmt {
             Statement::Call { .. } | Statement::Barrier { .. } => {
+                collect_proc_rebindings(stmt, rebound, dynamic);
                 stmt_gen(stmt, state, registry);
                 collect_tampered_builtins(state, registry, names, dynamic);
             }
@@ -515,23 +599,23 @@ fn walk_body_calls(
                 clauses, else_body, ..
             } => {
                 for c in clauses {
-                    walk_body_calls(&c.body, state, registry, names, dynamic);
+                    walk_body_calls(&c.body, state, registry, names, rebound, dynamic);
                 }
                 if let Some(b) = else_body {
-                    walk_body_calls(b, state, registry, names, dynamic);
+                    walk_body_calls(b, state, registry, names, rebound, dynamic);
                 }
             }
             Statement::For {
                 init, next, body, ..
             } => {
-                walk_body_calls(init, state, registry, names, dynamic);
-                walk_body_calls(next, state, registry, names, dynamic);
-                walk_body_calls(body, state, registry, names, dynamic);
+                walk_body_calls(init, state, registry, names, rebound, dynamic);
+                walk_body_calls(next, state, registry, names, rebound, dynamic);
+                walk_body_calls(body, state, registry, names, rebound, dynamic);
             }
             Statement::While { body, .. }
             | Statement::Catch { body, .. }
             | Statement::Foreach { body, .. } => {
-                walk_body_calls(body, state, registry, names, dynamic);
+                walk_body_calls(body, state, registry, names, rebound, dynamic);
             }
             Statement::Try {
                 body,
@@ -539,12 +623,12 @@ fn walk_body_calls(
                 finally_body,
                 ..
             } => {
-                walk_body_calls(body, state, registry, names, dynamic);
+                walk_body_calls(body, state, registry, names, rebound, dynamic);
                 for h in handlers {
-                    walk_body_calls(&h.body, state, registry, names, dynamic);
+                    walk_body_calls(&h.body, state, registry, names, rebound, dynamic);
                 }
                 if let Some(fb) = finally_body {
-                    walk_body_calls(fb, state, registry, names, dynamic);
+                    walk_body_calls(fb, state, registry, names, rebound, dynamic);
                 }
             }
             Statement::Switch {
@@ -552,11 +636,11 @@ fn walk_body_calls(
             } => {
                 for a in arms {
                     if let Some(b) = &a.body {
-                        walk_body_calls(b, state, registry, names, dynamic);
+                        walk_body_calls(b, state, registry, names, rebound, dynamic);
                     }
                 }
                 if let Some(b) = default_body {
-                    walk_body_calls(b, state, registry, names, dynamic);
+                    walk_body_calls(b, state, registry, names, rebound, dynamic);
                 }
             }
             _ => {}
@@ -568,20 +652,30 @@ fn walk_body_calls(
 /// CFG-free recursive IR walk over the top-level script *and* every proc
 /// / method body, so it can run before per-function CFGs are built.
 ///
-/// Only *tampered-with core builtins* are reported (see
-/// [`collect_tampered_builtins`]).  The result feeds the optimiser's
-/// builtin-fold trust gate via [`ModuleCommandMutations::trusts`].
+/// Tampered-with core builtins and rebound names generally are reported
+/// (see [`collect_tampered_builtins`]).  The result feeds both the
+/// optimiser's builtin-fold trust gate ([`ModuleCommandMutations::trusts`])
+/// and its proc-call fold trust gate
+/// ([`ModuleCommandMutations::trusts_proc_binding`]).
 #[must_use]
 pub fn scan_module_command_mutations(
     ir_module: &crate::ir::Module,
     registry: &CommandRegistry,
 ) -> ModuleCommandMutations {
     let mut names = std::collections::HashSet::new();
+    let mut rebound = std::collections::HashSet::new();
     let mut dynamic = false;
 
     let mut visit = |script: &crate::ir::Script| {
         let mut state = State::default();
-        walk_body_calls(script, &mut state, registry, &mut names, &mut dynamic);
+        walk_body_calls(
+            script,
+            &mut state,
+            registry,
+            &mut names,
+            &mut rebound,
+            &mut dynamic,
+        );
     };
 
     visit(&ir_module.top_level);
@@ -592,7 +686,11 @@ pub fn scan_module_command_mutations(
         visit(&method.body);
     }
 
-    ModuleCommandMutations { names, dynamic }
+    ModuleCommandMutations {
+        names,
+        rebound,
+        dynamic,
+    }
 }
 
 #[cfg(test)]
@@ -707,5 +805,61 @@ mod tests {
         let cu2 = CompilationUnit::build_for("set x foo\nrename $x bar", &reg, false);
         let m2 = scan_module_command_mutations(&cu2.ir_module, &reg);
         assert!(!m2.trusts("string") && !m2.trusts("lappend"));
+    }
+
+    #[test]
+    fn trusts_proc_binding_true_for_untouched_proc() {
+        // TP control: a proc never named by any `rename` / `interp alias`
+        // is trusted.
+        let reg = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for("proc myproc {} { return 1 }", &reg, false);
+        let m = scan_module_command_mutations(&cu.ir_module, &reg);
+        assert!(m.trusts_proc_binding("myproc"));
+        assert!(m.trusts_proc_binding("::myproc"));
+    }
+
+    #[test]
+    fn trusts_proc_binding_false_for_rename_source_and_target() {
+        // FP guard: `rename triple double` perturbs BOTH names — `triple`
+        // (vacated, no longer denotes what it did) and `double` (now
+        // denotes `triple`'s body, not `double`'s own declaration).
+        let reg = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for(
+            "proc double {n} { expr {$n * 2} }\nproc triple {n} { expr {$n * 3} }\nrename triple double\n",
+            &reg,
+            false,
+        );
+        let m = scan_module_command_mutations(&cu.ir_module, &reg);
+        assert!(!m.trusts_proc_binding("double"), "rename target");
+        assert!(!m.trusts_proc_binding("triple"), "rename source");
+    }
+
+    #[test]
+    fn trusts_proc_binding_false_for_interp_alias_name() {
+        let reg = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for(
+            "proc answer {} { return 42 }\nproc other {} { return 99 }\ninterp alias {} answer {} other\n",
+            &reg,
+            false,
+        );
+        let m = scan_module_command_mutations(&cu.ir_module, &reg);
+        assert!(!m.trusts_proc_binding("answer"));
+        // The alias *target* itself is untouched — still trusted.
+        assert!(m.trusts_proc_binding("other"));
+    }
+
+    #[test]
+    fn trusts_proc_binding_unaffected_by_unrelated_rename() {
+        // TN control: renaming a DIFFERENT proc must not untrust this one —
+        // `trusts_proc_binding` is per-name, unlike the whole-module
+        // `dynamic` wildcard.
+        let reg = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for(
+            "proc double {n} { expr {$n * 2} }\nproc triple {n} { expr {$n * 3} }\nrename triple somethingElse\n",
+            &reg,
+            false,
+        );
+        let m = scan_module_command_mutations(&cu.ir_module, &reg);
+        assert!(m.trusts_proc_binding("double"));
     }
 }

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -817,44 +817,179 @@ fn evaluate_proc_with_constants(
     args: &[ConstValue],
     octal: Option<bool>,
 ) -> Option<ConstValue> {
-    if params.len() != args.len() {
-        return None;
-    }
-    // The seed keys on the parameter *name* (a stable, cache-safe identity);
-    // `sccp` resolves each to the callee build's interned symbol.
-    let mut seed: std::collections::HashMap<(String, crate::ssa::Version), LatticeValue> =
-        std::collections::HashMap::new();
-    for (p, a) in params.iter().zip(args.iter()) {
-        seed.insert((p.clone(), 0), LatticeValue::Const(a.clone()));
-    }
+    let seed = seed_params_from_args(params, args)?;
     let result = crate::sccp::sccp(&callee.cfg, &callee.ssa, Some(&seed), octal);
     resolve_return_constant(callee, &result)
 }
 
+/// Bind each of `params` to its constant call argument for the
+/// interprocedural SCCP seed. The seed keys on the parameter *name* (a
+/// stable, cache-safe identity); `sccp` resolves each to the callee
+/// build's interned symbol.
+///
+/// A trailing `args` parameter is variadic: Tcl collects every argument
+/// beyond the fixed ones into a single list value bound to `args`, so this
+/// seeds it as one canonical list-quoted [`ConstValue::String`] rather than
+/// requiring (and silently mis-seeding on) an exact `params.len() ==
+/// args.len()` — the earlier exact-length gate happened to be sound only
+/// because [`parse_static_call_args`] never supplied more than one trailing
+/// literal, an unstated coincidence rather than a modelled invariant.
+/// `None` when the call doesn't supply enough arguments for the fixed
+/// (non-`args`) parameters.
+fn seed_params_from_args(
+    params: &[String],
+    args: &[ConstValue],
+) -> Option<std::collections::HashMap<(String, crate::ssa::Version), LatticeValue>> {
+    let is_variadic = params.last().is_some_and(|p| p == "args");
+    let fixed = if is_variadic {
+        params.len() - 1
+    } else {
+        params.len()
+    };
+    if args.len() < fixed || (!is_variadic && args.len() != fixed) {
+        return None;
+    }
+    let mut seed: std::collections::HashMap<(String, crate::ssa::Version), LatticeValue> =
+        std::collections::HashMap::new();
+    for (p, a) in params.iter().take(fixed).zip(args.iter()) {
+        seed.insert((p.clone(), 0), LatticeValue::Const(a.clone()));
+    }
+    if is_variadic {
+        let tail: Vec<String> = args[fixed..].iter().map(const_value_text).collect();
+        let list_text = tcl_syntax::list::join_list(tail);
+        seed.insert(
+            (params[fixed].clone(), 0),
+            LatticeValue::Const(ConstValue::String(list_text)),
+        );
+    }
+    Some(seed)
+}
+
+/// Render a [`ConstValue`] back to its plain text form — the inverse of
+/// [`crate::sccp::parse_literal_value`], used to re-serialise a call
+/// argument's already-typed constant into one element of the canonical
+/// list text [`seed_params_from_args`] builds for a variadic `args`
+/// parameter.
+fn const_value_text(cv: &ConstValue) -> String {
+    match cv {
+        ConstValue::Int(i) => i.to_string(),
+        ConstValue::Float(f) => f.to_string(),
+        ConstValue::Bool(b) => i64::from(*b).to_string(),
+        ConstValue::String(s) => s.clone(),
+    }
+}
+
 /// Resolve the constant return value of `fu` under a computed SCCP `result`.
-/// Every reachable `return` terminator must fold to the **same** constant;
-/// a void return, an unfoldable return, or disagreeing returns yield `None`.
+///
+/// Every reachable *exit* must fold to the **same** constant — an explicit
+/// `return` terminator, **or** a reachable fall-through to the function's
+/// implicit exit (a block with no terminator: Tcl's "the result of the last
+/// command executed" rule for a proc that runs off the end of its body
+/// without a `return` on that path). Ignoring the fall-through case here
+/// used to let a proc with `if {…} { return K }` plus a trailing
+/// unconditional statement fold to `K` even when the fall-through path was
+/// *also* reachable and produced a different value — a miscompile, not
+/// just a missed optimisation (confirmed against tclsh 9.0.4: a proc whose
+/// `if` condition itself isn't foldable, e.g. it depends on another call's
+/// result, leaves both the `return` and the fall-through paths executable
+/// under SCCP). A void return, an unfoldable return/tail, or disagreeing
+/// exits — return-vs-return **or** return-vs-fall-through — yield `None`.
 fn resolve_return_constant(
     fu: &FunctionUnit,
     result: &crate::sccp::SccpResult,
 ) -> Option<ConstValue> {
     use crate::cfg::Terminator;
+    let preds = fu.cfg.predecessors();
     let mut found: Option<ConstValue> = None;
     for (bn, block) in &fu.cfg.blocks {
         if !result.executable_blocks.contains(bn) {
             continue;
         }
-        let Some(Terminator::Return { value, expr, .. }) = &block.terminator else {
-            continue;
+        let folded = match &block.terminator {
+            Some(Terminator::Return { value, expr, .. }) => {
+                fold_return_under_lattice(fu, *bn, value.as_deref(), expr.as_ref(), result)?
+            }
+            None => {
+                let mut visited = std::collections::HashSet::new();
+                resolve_fallthrough_value(fu, *bn, result, &preds, &mut visited)?
+            }
+            Some(_) => continue, // Goto / Branch — not an exit point
         };
-        let folded = fold_return_under_lattice(fu, *bn, value.as_deref(), expr.as_ref(), result)?;
         match &found {
             None => found = Some(folded),
             Some(prev) if *prev == folded => {}
-            Some(_) => return None, // reachable returns disagree
+            Some(_) => return None, // reachable exits disagree
         }
     }
     found
+}
+
+/// Resolve the value Tcl's implicit-return rule leaves behind when control
+/// falls through block `bn` — either the function's synthesised exit sink
+/// (a reachable block with no terminator), or an empty structural join
+/// point reached while walking back toward one (e.g. the shared
+/// continuation after an `if` with no `else`, when the `if` is the last
+/// statement in the body). An empty block runs no statement of its own, so
+/// its value comes from whichever executable predecessor(s) fall through
+/// into it — they must all agree, exactly like multiple `return`
+/// terminators must. `visited` bounds the walk against a cyclic
+/// predecessor chain (a loop back-edge into a fall-through join is
+/// unresolvable — bail, never mis-fold).
+fn resolve_fallthrough_value(
+    fu: &FunctionUnit,
+    bn: crate::cfg::BlockId,
+    result: &crate::sccp::SccpResult,
+    preds: &std::collections::HashMap<
+        crate::cfg::BlockId,
+        std::collections::HashSet<crate::cfg::BlockId>,
+    >,
+    visited: &mut std::collections::HashSet<crate::cfg::BlockId>,
+) -> Option<ConstValue> {
+    if !visited.insert(bn) {
+        return None; // cycle
+    }
+    let block = fu.cfg.blocks.get(&bn)?;
+    if let Some(last) = block.statements.last() {
+        return fold_tail_statement_under_lattice(fu, bn, last, result);
+    }
+    let mut found: Option<ConstValue> = None;
+    for pred in preds.get(&bn).into_iter().flatten() {
+        if !result.executable_blocks.contains(pred) {
+            continue;
+        }
+        let v = resolve_fallthrough_value(fu, *pred, result, preds, visited)?;
+        match &found {
+            None => found = Some(v),
+            Some(prev) if *prev == v => {}
+            Some(_) => return None, // disagreeing predecessors
+        }
+    }
+    found
+}
+
+/// Resolve the value Tcl's "result of the last executed command" rule
+/// leaves behind when `stmt` is the last statement of a block that falls
+/// through to the function's implicit exit — a trailing `set` / `incr`
+/// implicitly returns exactly like `return $name` would (Tcl's `set` and
+/// `incr` both return the value they just assigned), and a trailing bare
+/// `expr` implicitly returns exactly like `return [expr {…}]` would.
+/// `None` for any other statement shape (a bare command call whose own
+/// result this analysis doesn't track, …) — the caller simply won't fold
+/// that path, never mis-folds it.
+fn fold_tail_statement_under_lattice(
+    fu: &FunctionUnit,
+    bn: crate::cfg::BlockId,
+    stmt: &Statement,
+    result: &crate::sccp::SccpResult,
+) -> Option<ConstValue> {
+    match stmt {
+        Statement::ExprEval { expr, .. } => fold_expr_under_lattice(fu, bn, expr, result),
+        Statement::AssignConst { name, .. }
+        | Statement::AssignExpr { name, .. }
+        | Statement::AssignValue { name, .. }
+        | Statement::Incr { name, .. } => fold_var_ref_under_lattice(fu, bn, name, result),
+        _ => None,
+    }
 }
 
 /// Fold one `return` value/expr under the SCCP lattice for block `bn`.
@@ -867,8 +1002,6 @@ fn fold_return_under_lattice(
     expr: Option<&crate::expr_ast::ExprNode>,
     result: &crate::sccp::SccpResult,
 ) -> Option<ConstValue> {
-    use crate::tcl_expr_eval::{Env, eval_tcl_expr};
-
     let value = value?.trim();
 
     // Path 1 — bare literal return (no substitution metacharacters).
@@ -876,42 +1009,75 @@ fn fold_return_under_lattice(
         return Some(crate::sccp::parse_literal_value(value));
     }
 
-    // Path 2 — a simple `$var` return. This MUST use the variable's *exit
-    // version* at this block precisely: a loop-carried var (`return $total`
-    // after a `foreach`) is a phi whose exit value is Overdefined, even
-    // though an earlier `set total 0` left a stale Const(0) under another
-    // version. Reading the precise version is what makes us bail on
-    // `sum_list` / `fibonacci` instead of mis-folding to the pre-loop value.
+    // Path 2 — a simple `$var` return.
     if let Some(name) = simple_var_ref(value) {
-        let sym = fu.ssa.var_symbol(name)?;
-        let ver = fu
-            .ssa
-            .blocks
-            .get(&bn)
-            .and_then(|b| b.exit_versions.get(&sym).copied())
-            .unwrap_or(0);
-        return match result.values.get(&(sym, ver)) {
-            Some(LatticeValue::Const(c)) => Some(c.clone()),
-            _ => None,
-        };
+        return fold_var_ref_under_lattice(fu, bn, name, result);
     }
 
-    // Path 3 — `return [expr {…}]`. Build the env FLOW-SENSITIVELY, exactly
-    // as path 2 does for the single-`$var` case: bind each variable the expr
-    // references at *this block's exit version* (the precise state reaching
-    // this return), and only when that version is a lattice constant. A
-    // variable absent from `exit_versions` (a never-reassigned parameter)
-    // falls back to version 0, where interproc-seeded param constants live.
-    //
-    // The old flow-INsensitive scan ("every Const lattice entry, preferring
-    // the newest version, then overlay exit versions") miscompiled: for
-    // `set x 0; foreach v {…} { set x $v }; return [expr {$x + 1}]`, `x`'s
-    // exit version is a non-Const loop phi, so the overlay didn't override,
-    // and the stale pre-loop `(x,1)=Const(0)` leaked in — folding to `1`
-    // where tclsh returns `3`. Reading the exit version (Overdefined here)
-    // leaves `x` unbound so `eval_tcl_expr` bails, matching path 2's
-    // `sum_list`/`fibonacci` precision.
-    let expr = expr?;
+    // Path 3 — `return [expr {…}]`.
+    fold_expr_under_lattice(fu, bn, expr?, result)
+}
+
+/// Resolve a simple `$name` variable reference to its SCCP-proved constant
+/// at block `bn`'s *exit* version — the value the variable holds
+/// immediately after `bn`'s own statements have run. This MUST use the
+/// exit version precisely: a loop-carried var (`return $total` after a
+/// `foreach`) is a phi whose exit value is Overdefined, even though an
+/// earlier `set total 0` left a stale Const(0) under another version.
+/// Reading the precise version is what makes us bail on `sum_list` /
+/// `fibonacci` instead of mis-folding to the pre-loop value.
+///
+/// Shared by [`fold_return_under_lattice`]'s Path 2 (`return $var`) and
+/// [`fold_tail_statement_under_lattice`]'s fall-through case (a trailing
+/// `set`/`incr` implicitly returns the value it just assigned — Tcl's
+/// "result of the last command" rule makes it behave exactly like
+/// `return $name`).
+fn fold_var_ref_under_lattice(
+    fu: &FunctionUnit,
+    bn: crate::cfg::BlockId,
+    name: &str,
+    result: &crate::sccp::SccpResult,
+) -> Option<ConstValue> {
+    let sym = fu.ssa.var_symbol(name)?;
+    let ver = fu
+        .ssa
+        .blocks
+        .get(&bn)
+        .and_then(|b| b.exit_versions.get(&sym).copied())
+        .unwrap_or(0);
+    match result.values.get(&(sym, ver)) {
+        Some(LatticeValue::Const(c)) => Some(c.clone()),
+        _ => None,
+    }
+}
+
+/// Evaluate `expr` under the SCCP lattice for block `bn`'s exit
+/// environment. Built FLOW-SENSITIVELY: bind each variable the expr
+/// references at *this block's exit version* (the precise state reaching
+/// this point), and only when that version is a lattice constant. A
+/// variable absent from `exit_versions` (a never-reassigned parameter)
+/// falls back to version 0, where interproc-seeded param constants live.
+///
+/// The flow-INsensitive alternative ("every Const lattice entry,
+/// preferring the newest version, then overlay exit versions") miscompiled:
+/// for `set x 0; foreach v {…} { set x $v }; return [expr {$x + 1}]`, `x`'s
+/// exit version is a non-Const loop phi, so the overlay didn't override,
+/// and the stale pre-loop `(x,1)=Const(0)` leaked in — folding to `1`
+/// where tclsh returns `3`. Reading the exit version (Overdefined here)
+/// leaves `x` unbound so `eval_tcl_expr` bails, matching
+/// [`fold_var_ref_under_lattice`]'s `sum_list`/`fibonacci` precision.
+///
+/// Shared by [`fold_return_under_lattice`]'s Path 3 (`return [expr {…}]`)
+/// and [`fold_tail_statement_under_lattice`]'s fall-through case (a
+/// trailing bare `expr` implicitly returns its value).
+fn fold_expr_under_lattice(
+    fu: &FunctionUnit,
+    bn: crate::cfg::BlockId,
+    expr: &crate::expr_ast::ExprNode,
+    result: &crate::sccp::SccpResult,
+) -> Option<ConstValue> {
+    use crate::tcl_expr_eval::{Env, eval_tcl_expr};
+
     let mut env: Env = Env::new();
     if let Some(ssa_block) = fu.ssa.blocks.get(&bn) {
         for name in crate::var_refs::vars_in_expr(expr) {
@@ -1036,6 +1202,16 @@ fn try_fold_static_proc_call(
     // (the flow-sensitive rename gate, mirroring the cmd-subst form and
     // `redefined_procedures` check).
     if cu.ir_module.redefined_procedures.contains(&qname) {
+        return;
+    }
+    // Nor a proc whose bare name is later `rename`d over or `interp
+    // alias`ed elsewhere in the module — folding this call site to the
+    // *originally-declared* proc's constant return would miscompile a
+    // script where `command` no longer denotes that proc by the time this
+    // call runs (e.g. `proc a {…} …; proc b {…} …; rename b a` moves `b`'s
+    // body onto the name `a`; a later `[a …]` call must not fold to `a`'s
+    // original body).
+    if !ctx.command_mutations.trusts_proc_binding(&qname) {
         return;
     }
     if !summary.can_fold_static_calls {
@@ -1401,6 +1577,12 @@ fn try_o103_proc_fold(
     let summary = ia.procedures.get(&qname)?;
     // A redefined proc has an ambiguous body — never fold its calls.
     if cu.ir_module.redefined_procedures.contains(&qname) {
+        return None;
+    }
+    // Nor a proc whose bare name is later `rename`d over or `interp
+    // alias`ed elsewhere in the module — see the sibling gate in
+    // `try_fold_static_proc_call` for the miscompile this prevents.
+    if !ctx.command_mutations.trusts_proc_binding(&qname) {
         return None;
     }
     let render_const = |cv: &ConstValue| match cv {
@@ -2669,6 +2851,169 @@ mod tests {
                 .all(|o| o.code != DiagCode::O103 || o.hint_only),
             "loop-carried return must not fold, got {:?}",
             ctx.optimisations,
+        );
+    }
+
+    #[test]
+    fn o103_folds_implicit_return_proc_cmd_subst() {
+        // TP: the KCS O103 doc's own canonical example — a proc with NO
+        // explicit `return`, whose result is Tcl's "value of the last
+        // command executed" (a bare `expr {…}`) — must fold. Before the
+        // fall-through fix, `resolve_return_constant` only looked at
+        // `Terminator::Return` blocks, so a pure proc that relies entirely
+        // on implicit return never folded at all (`[double 21]` stayed
+        // unrewritten even though tclsh evaluates it to `42`).
+        use tcl_registry::CommandRegistry;
+        let registry = CommandRegistry::build_default();
+        let src = "proc double {n} { expr {$n * 2} }\nset x [double 21]\n";
+        let cu =
+            CompilationUnit::build_for(src, &registry, false).with_interprocedural(&registry, None);
+        let mut ctx = PassContext::new(&cu.source, cu.interproc.clone().unwrap_or_default());
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations
+                .iter()
+                .any(|o| o.code == DiagCode::O103 && o.replacement == "42" && !o.hint_only),
+            "expected applicable O103 folding [double 21] to 42 (implicit return), got {:?}",
+            ctx.optimisations,
+        );
+    }
+
+    #[test]
+    fn o103_folds_implicit_return_zero_arg_proc() {
+        // TP: a zero-parameter implicit-return proc (`set` as the trailing
+        // statement — Tcl's `set` returns the value it just assigned, so
+        // this is exactly like `return $pi`) also folds via the CMD-subst
+        // path.
+        use tcl_registry::CommandRegistry;
+        let registry = CommandRegistry::build_default();
+        let src = "proc pi {} { set p 3 }\nputs [pi]\n";
+        let cu =
+            CompilationUnit::build_for(src, &registry, false).with_interprocedural(&registry, None);
+        let mut ctx = PassContext::new(&cu.source, cu.interproc.clone().unwrap_or_default());
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations
+                .iter()
+                .any(|o| o.code == DiagCode::O103 && o.replacement == "3" && !o.hint_only),
+            "expected applicable O103 folding [pi] to 3 (implicit `set` return), got {:?}",
+            ctx.optimisations,
+        );
+    }
+
+    #[test]
+    fn o103_does_not_fold_when_return_and_fallthrough_disagree() {
+        // FN / miscompile-guard: `helper`'s result is opaque to intraprocedural
+        // SCCP (it's a call, not folded interprocedurally), so `g`'s `if`
+        // condition can't be resolved even after `n` is seeded to 5 — both the
+        // `return 1` branch AND the fall-through `expr {99}` stay executable.
+        // tclsh 9.0.4 ground truth: `g 5` calls `helper 5` (== 6), `6 > 100` is
+        // false, so `g 5` falls through and returns `99` — NOT `1`. Before the
+        // fall-through fix, `resolve_return_constant` silently ignored the
+        // reachable non-`Return` exit and confidently (wrongly) folded to the
+        // `return 1` branch's value — a real miscompile, not just an
+        // over-eager fold.
+        use tcl_registry::CommandRegistry;
+        let registry = CommandRegistry::build_default();
+        let src = "proc helper {n} { expr {$n + 1} }\nproc g {n} {\n    if {[helper $n] > 100} {\n        return 1\n    }\n    expr {99}\n}\nputs [g 5]\n";
+        let cu =
+            CompilationUnit::build_for(src, &registry, false).with_interprocedural(&registry, None);
+        let mut ctx = PassContext::new(&cu.source, cu.interproc.clone().unwrap_or_default());
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations
+                .iter()
+                .all(|o| o.code != DiagCode::O103 || o.hint_only),
+            "disagreeing return/fall-through exits must not produce an applicable fold, got {:?}",
+            ctx.optimisations,
+        );
+    }
+
+    #[test]
+    fn o103_folds_variadic_args_proc_ignoring_trailing_args() {
+        // TP: a proc with a trailing `args` parameter folds on its fixed
+        // parameter when the call supplies MORE arguments than the proc has
+        // fixed params — the extra args collect into `args`, unused by this
+        // body. Before the `args` fix, `evaluate_proc_with_constants`
+        // required `params.len() == args.len()` exactly, so a call
+        // supplying more than one trailing argument (`[f 5 x y z]` for
+        // `proc f {a args}`) never even reached the fold attempt.
+        use tcl_registry::CommandRegistry;
+        let registry = CommandRegistry::build_default();
+        let src = "proc f {a args} { expr {$a * 2} }\nputs [f 5 x y z]\n";
+        let cu =
+            CompilationUnit::build_for(src, &registry, false).with_interprocedural(&registry, None);
+        let mut ctx = PassContext::new(&cu.source, cu.interproc.clone().unwrap_or_default());
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations
+                .iter()
+                .any(|o| o.code == DiagCode::O103 && o.replacement == "10" && !o.hint_only),
+            "expected applicable O103 folding [f 5 x y z] to 10, got {:?}",
+            ctx.optimisations,
+        );
+    }
+
+    /// Run the propagation pass with `ctx.command_mutations` populated —
+    /// the piece `optimise_raw` (used by the O129 trust-gate test) never
+    /// wires (it doesn't set `cu.interproc` either, so it can't drive
+    /// O103 at all) and a bare `PassContext::new` + `run` leaves at its
+    /// all-trusting `Default`. Mirrors the whole-module scan every real
+    /// production entry point (`optimise_unit_raw`, `find_dead_stores`,
+    /// `optimise_by_pass`) performs before running passes.
+    fn run_pass_with_command_mutations(source: &str) -> Vec<Optimisation> {
+        let registry = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let mut ctx = PassContext::new(&cu.source, cu.interproc.clone().unwrap_or_default());
+        ctx.command_mutations =
+            crate::command_binding::scan_module_command_mutations(&cu.ir_module, &registry);
+        run(&mut ctx, &cu);
+        ctx.optimisations
+    }
+
+    #[test]
+    fn o103_does_not_fold_call_to_proc_renamed_over() {
+        // FP guard / miscompile-guard: `rename triple double` moves the
+        // `triple` proc's body onto the name `double`, so a later `[double
+        // 21]` call actually runs `triple`'s body (21*3 == 63), NOT the
+        // original `double` proc's body (21*2 == 42) that `resolve_proc_qname`
+        // finds in the interprocedural summary. Folding to `42` here would be
+        // a miscompile (tclsh 9.0.4 confirmed: `double 21` after this rename
+        // returns `63`).
+        let src = "proc double {n} { expr {$n * 2} }\nproc triple {n} { expr {$n * 3} }\nrename triple double\nputs [double 21]\n";
+        let opts = run_pass_with_command_mutations(src);
+        assert!(
+            opts.iter().all(|o| o.code != DiagCode::O103 || o.hint_only),
+            "call to a proc name later `rename`d over must not fold, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn o103_does_not_fold_call_to_proc_shadowed_by_interp_alias() {
+        // FP guard: `interp alias {} answer {} other` shadows the `answer`
+        // command with an alias to `other` — a later `[answer]` call runs
+        // `other`'s body (99), not the original `answer` proc's body (42).
+        let src = "proc answer {} { return 42 }\nproc other {} { return 99 }\ninterp alias {} answer {} other\nputs [answer]\n";
+        let opts = run_pass_with_command_mutations(src);
+        assert!(
+            opts.iter().all(|o| o.code != DiagCode::O103 || o.hint_only),
+            "call to a proc shadowed by interp alias must not fold, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn o103_still_folds_unrelated_proc_despite_unrelated_rename_elsewhere() {
+        // TN control: `trusts_proc_binding` must be per-name, not a blanket
+        // "any rename anywhere disables all O103 folds" — an unrelated
+        // rename of a *different* proc must not block folding calls to
+        // procs it never touched.
+        let src = "proc double {n} { expr {$n * 2} }\nproc triple {n} { expr {$n * 3} }\nrename triple somethingElse\nputs [double 21]\n";
+        let opts = run_pass_with_command_mutations(src);
+        assert!(
+            opts.iter()
+                .any(|o| o.code == DiagCode::O103 && o.replacement == "42" && !o.hint_only),
+            "unrelated proc must still fold despite an unrelated rename, got {opts:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -909,10 +909,7 @@ fn resolve_return_constant(
             Some(Terminator::Return { value, expr, .. }) => {
                 fold_return_under_lattice(fu, *bn, value.as_deref(), expr.as_ref(), result)?
             }
-            None => {
-                let mut visited = std::collections::HashSet::new();
-                resolve_fallthrough_value(fu, *bn, result, &preds, &mut visited)?
-            }
+            None => resolve_fallthrough_value(fu, *bn, result, &preds)?,
             Some(_) => continue, // Goto / Branch — not an exit point
         };
         match &found {
@@ -925,16 +922,26 @@ fn resolve_return_constant(
 }
 
 /// Resolve the value Tcl's implicit-return rule leaves behind when control
-/// falls through block `bn` — either the function's synthesised exit sink
-/// (a reachable block with no terminator), or an empty structural join
-/// point reached while walking back toward one (e.g. the shared
-/// continuation after an `if` with no `else`, when the `if` is the last
-/// statement in the body). An empty block runs no statement of its own, so
-/// its value comes from whichever executable predecessor(s) fall through
-/// into it — they must all agree, exactly like multiple `return`
-/// terminators must. `visited` bounds the walk against a cyclic
-/// predecessor chain (a loop back-edge into a fall-through join is
-/// unresolvable — bail, never mis-fold).
+/// falls through block `bn` — the function's synthesised exit sink (a
+/// reachable block with no terminator).
+///
+/// Trusts ONLY the narrow, unambiguous shape: `bn` has exactly one
+/// executable predecessor, and that predecessor's OWN last statement is a
+/// recognised value-producing tail (see [`fold_tail_statement_under_lattice`]).
+/// Deliberately does NOT walk through an empty predecessor to whatever
+/// precedes *it*: an empty block reached via a control-flow edge is not
+/// "no Tcl command ran here" — it is frequently the empty **body** of a
+/// real command (`if {$c} {}`, or the implicit `""` an `if` with no
+/// `else` produces when the condition is false), whose own result is the
+/// empty string, not whatever ran before the branch. Block shape alone
+/// can't soundly distinguish that from a genuine structural join, so any
+/// empty predecessor — or more than one live predecessor at all — bails
+/// to `None` rather than risk inheriting a stale prior value. (A more
+/// permissive, recursive version of this function shipped briefly and
+/// mis-folded `proc f {c} { set x 1; if {$c} {} }`'s `[f 0]` to `1`
+/// instead of the correct `""` — confirmed against tclsh 9.0.4 — by
+/// walking straight through the empty `if`-body block back to the
+/// preceding `set x 1`.)
 fn resolve_fallthrough_value(
     fu: &FunctionUnit,
     bn: crate::cfg::BlockId,
@@ -943,28 +950,19 @@ fn resolve_fallthrough_value(
         crate::cfg::BlockId,
         std::collections::HashSet<crate::cfg::BlockId>,
     >,
-    visited: &mut std::collections::HashSet<crate::cfg::BlockId>,
 ) -> Option<ConstValue> {
-    if !visited.insert(bn) {
-        return None; // cycle
+    let mut executable_preds = preds
+        .get(&bn)
+        .into_iter()
+        .flatten()
+        .filter(|p| result.executable_blocks.contains(p));
+    let pred = executable_preds.next()?;
+    if executable_preds.next().is_some() {
+        return None; // more than one live predecessor — ambiguous, bail
     }
-    let block = fu.cfg.blocks.get(&bn)?;
-    if let Some(last) = block.statements.last() {
-        return fold_tail_statement_under_lattice(fu, bn, last, result);
-    }
-    let mut found: Option<ConstValue> = None;
-    for pred in preds.get(&bn).into_iter().flatten() {
-        if !result.executable_blocks.contains(pred) {
-            continue;
-        }
-        let v = resolve_fallthrough_value(fu, *pred, result, preds, visited)?;
-        match &found {
-            None => found = Some(v),
-            Some(prev) if *prev == v => {}
-            Some(_) => return None, // disagreeing predecessors
-        }
-    }
-    found
+    let block = fu.cfg.blocks.get(pred)?;
+    let last = block.statements.last()?;
+    fold_tail_statement_under_lattice(fu, *pred, last, result)
 }
 
 /// Resolve the value Tcl's "result of the last executed command" rule
@@ -2930,6 +2928,35 @@ mod tests {
     }
 
     #[test]
+    fn o103_does_not_fold_through_empty_if_body() {
+        // FP guard / miscompile-guard (reported in code review): a trailing
+        // `if {$c} {}` with an empty body (and no `else`) is itself a real
+        // Tcl command whose result is `""` — whether the condition is true
+        // (the empty body's own result) or false (no branch ran, no
+        // `else`). tclsh 9.0.4 ground truth: `f 0` and `f 1` both return
+        // `""`, NOT `1` from the preceding `set x 1`. An earlier, more
+        // permissive fall-through resolver walked straight through the
+        // empty `if`-body block back to `set x 1` and wrongly folded `[f
+        // 0]` to `1` — treating "0 statements" as "no command ran here"
+        // rather than "this command's own result is empty". The fold must
+        // decline entirely rather than inherit a stale prior value.
+        use tcl_registry::CommandRegistry;
+        let registry = CommandRegistry::build_default();
+        let src = "proc f {c} { set x 1\nif {$c} {} }\nputs [f 0]\n";
+        let cu =
+            CompilationUnit::build_for(src, &registry, false).with_interprocedural(&registry, None);
+        let mut ctx = PassContext::new(&cu.source, cu.interproc.clone().unwrap_or_default());
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations
+                .iter()
+                .all(|o| o.code != DiagCode::O103 || o.hint_only),
+            "empty if-body fall-through must not produce an applicable fold, got {:?}",
+            ctx.optimisations,
+        );
+    }
+
+    #[test]
     fn o103_folds_variadic_args_proc_ignoring_trailing_args() {
         // TP: a proc with a trailing `args` parameter folds on its fixed
         // parameter when the call supplies MORE arguments than the proc has
@@ -3014,6 +3041,27 @@ mod tests {
             opts.iter()
                 .any(|o| o.code == DiagCode::O103 && o.replacement == "42" && !o.hint_only),
             "unrelated proc must still fold despite an unrelated rename, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn o103_does_not_fold_call_to_proc_renamed_over_via_namespace_relative_rename() {
+        // FP guard / miscompile-guard (reported in code review): `rename
+        // triple double` inside `proc ::ns::doit` resolves both bare names
+        // relative to `::ns` (the proc's own namespace) — it renames
+        // `::ns::triple` onto `::ns::double`, NOT the (nonexistent)
+        // top-level `::triple`/`::double`. tclsh 9.0.4 ground truth: after
+        // `::ns::doit` runs, `::ns::double 21` executes `triple`'s body
+        // (21*3 == 63), not `double`'s original body (21*2 == 42). An
+        // earlier version of `collect_proc_rebindings` always rooted a bare
+        // rename argument at the GLOBAL namespace (`::double`/`::triple`),
+        // so it never marked `::ns::double`/`::ns::triple` as rebound and
+        // O103 could fold `[::ns::double 21]` to the wrong `42`.
+        let src = "namespace eval ::ns {\n    proc double {n} { expr {$n * 2} }\n    proc triple {n} { expr {$n * 3} }\n}\nproc ::ns::doit {} { rename triple double }\n::ns::doit\nputs [::ns::double 21]\n";
+        let opts = run_pass_with_command_mutations(src);
+        assert!(
+            opts.iter().all(|o| o.code != DiagCode::O103 || o.hint_only),
+            "call to a proc renamed over via a namespace-relative rename must not fold, got {opts:?}",
         );
     }
 

--- a/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
@@ -286,3 +286,38 @@ fn nothing_to_fold_is_unchanged() {
     // A dynamic expression has no safe constant fold — source is preserved.
     assert!(source.contains("expr {$a + $b}"), "{source:?}");
 }
+
+// -- O103 (pure-proc constant fold) ---------------------------------------
+
+#[test]
+fn o103_folds_implicit_return_proc_end_to_end() {
+    // TP: the KCS O103 doc's own canonical example — a proc with no
+    // explicit `return`, relying on Tcl's "value of the last command
+    // executed" rule — must fold through the full LSP pipeline, not just
+    // the in-process pass. See docs/kcs/codes/kcs-optimisation-o103-static-proc-folding.md.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc double {n} { expr {$n * 2} }\nset x [double 21]\n",
+    );
+    let result = lsp.execute_command("tcl-lsp.optimiseDocument", serde_json::json!([uri, "full"]));
+    let source = result.get("source").and_then(Value::as_str).unwrap_or("");
+    assert!(source.contains("set x 42"), "{source:?}");
+}
+
+#[test]
+fn o103_does_not_fold_proc_renamed_over() {
+    // FP guard / miscompile-guard: `rename triple double` moves `triple`'s
+    // body onto the name `double`, so `[double 21]` now runs `triple`'s
+    // body (63), not the original `double` proc's body (42). The optimiser
+    // must leave the call site untouched rather than fold to the wrong
+    // constant.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc double {n} { expr {$n * 2} }\nproc triple {n} { expr {$n * 3} }\nrename triple double\nset x [double 21]\n";
+    lsp.open_ready(&uri, src);
+    let result = lsp.execute_command("tcl-lsp.optimiseDocument", serde_json::json!([uri, "full"]));
+    let source = result.get("source").and_then(Value::as_str).unwrap_or("");
+    assert!(source.contains("set x [double 21]"), "{source:?}");
+}


### PR DESCRIPTION
## Summary

This PR fixes three critical issues in the O103 (static proc constant folding) optimization:

1. **Implicit return support**: Procs without explicit `return` statements now fold correctly. Previously, `resolve_return_constant` only examined `Terminator::Return` blocks, ignoring Tcl's "value of the last command executed" rule for fall-through paths. Now handles both explicit returns and implicit returns from trailing statements (`expr`, `set`, `incr`).

2. **Variadic `args` parameter handling**: Procs with trailing `args` parameters now fold when called with more arguments than fixed parameters. Previously required exact `params.len() == args.len()` matching. Now `seed_params_from_args` correctly collects excess arguments into a list-quoted string bound to `args`.

3. **Proc binding safety**: Added `trusts_proc_binding` gate to prevent miscompilation when a proc name is later rebound via `rename` or `interp alias`. The optimizer now scans the entire module for these mutations and conservatively distrusts any proc name that appears as a source/target of `rename` or the alias name of `interp alias`.

### Key Changes

**`propagation.rs`**:
- Refactored `evaluate_proc_with_constants` to use new `seed_params_from_args` helper
- Added `seed_params_from_args`: handles variadic `args` by collecting excess arguments into a canonical list-quoted string
- Added `const_value_text`: renders `ConstValue` back to plain text for list serialization
- Enhanced `resolve_return_constant`: now examines both explicit `return` terminators and implicit fall-through exits
- Added `resolve_fallthrough_value`: recursively resolves implicit return values through empty blocks and predecessors
- Added `fold_tail_statement_under_lattice`: extracts constant values from trailing statements (`expr`, `set`, `incr`)
- Extracted `fold_var_ref_under_lattice`: shared logic for `$var` references in both explicit and implicit returns
- Extracted `fold_expr_under_lattice`: shared logic for `[expr {…}]` evaluation in both contexts
- Added `trusts_proc_binding` gate checks in `try_fold_static_proc_call` and `try_o103_proc_fold`

**`command_binding.rs`**:
- Extended `ModuleCommandMutations` with `rebound` field tracking proc names touched by `rename`/`interp alias`
- Added `trusts_proc_binding` method: per-name query for proc binding stability
- Added `collect_proc_rebindings`: syntactic scan of `rename` and `interp alias` statements
- Updated `walk_body_calls` to collect proc rebindings alongside builtin tampering
- Updated `scan_module_command_mutations` to populate the `rebound` set

**Tests**:
- Added unit tests for implicit return folding (expr and set)
- Added unit tests for disagreeing return/fall-through paths (miscompile guard)
- Added unit tests for variadic `args` parameter handling
- Added unit tests for `rename` and `interp alias` safety gates
- Added end-to-end LSP tests for implicit return and rename safety
- Added VSCode test fixture `o103.tcl` covering both cases

## Validation

- [x] Added comprehensive unit tests in `propagation.rs` covering:
  - Implicit return via trailing `expr` statement
  - Implicit return via trailing `set` statement (zero-arg proc)
  - Disagreeing return/fall-through paths (miscompile guard)
  - Variadic `args` parameter with excess arguments
  - Proc renamed over (miscompile guard)
  - Proc shadowed by `interp alias` (miscompile guard)
  - Unrelated rename doesn't block unrelated proc folding
- [x] Added unit tests in `command_binding.rs` for `trusts_proc_binding`:
  - Untouched proc is trusted
  - Rename source and target are distrusted
  - `interp alias` target name is distrusted
  - Unrelated rename doesn't affect unrelated

https://claude.ai/code/session_01SnXUuFrCpryhqURDBjQujB