### PR TITLE
Stamp the release version into every user-facing binary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -479,7 +479,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y gcc-aarch64-linux-gnu gcc-riscv64-linux-gnu qemu-user
 
+      # Stamp the release version into every user-facing binary. The
+      # tcl-version crate prefers this over `git describe`; without it a tag
+      # build would still be correct, but this avoids depending on the checkout
+      # having tags fetched.
       - name: Cross-compile native binaries (server + mcp + CLIs)
+        env:
+          TCL_LSP_VERSION: ${{ github.ref_name }}
         shell: bash
         run: |
           set -euo pipefail

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,17 @@ on:
     tags: ["v*"]
   pull_request:
     branches: [main, rust]
+  # Manual escape hatch: if a PR's initial `pull_request: opened` webhook
+  # is ever dropped by GitHub (rare, but has happened — no runs show up
+  # for the branch at all, not even a queued/pending one), this lets a
+  # maintainer kick off the same CI graph from the Actions tab instead of
+  # having to push a throwaway commit just to re-send the event.
+  #
+  # NOTE: workflow_dispatch lets you pick any ref, tags included, and every
+  # release/publish job is gated on `startsWith(github.ref, 'refs/tags/v')`.
+  # Dispatching against a `v*` tag therefore re-runs create-release and the
+  # marketplace publishes. Dispatch against a branch unless you mean that.
+  workflow_dispatch:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1393,6 +1393,7 @@ dependencies = [
  "tcl-irules",
  "tcl-lsp-core",
  "tcl-registry",
+ "tcl-version",
  "tokio",
  "ureq",
 ]
@@ -4086,6 +4087,7 @@ dependencies = [
  "tcl-pkg",
  "tcl-registry",
  "tcl-sandbox",
+ "tcl-version",
 ]
 
 [[package]]
@@ -4268,6 +4270,7 @@ dependencies = [
  "tcl-lsp-core",
  "tcl-lsp-db",
  "tcl-registry",
+ "tcl-version",
  "temp-env",
  "tokio",
  "tower",
@@ -4290,6 +4293,7 @@ dependencies = [
  "tcl-lexer",
  "tcl-lsp-core",
  "tcl-registry",
+ "tcl-version",
  "tokio",
 ]
 
@@ -4358,6 +4362,10 @@ dependencies = [
  "bitflags 2.13.0",
  "tcl-lexer",
 ]
+
+[[package]]
+name = "tcl-version"
+version = "0.1.0"
 
 [[package]]
 name = "tcl-vm"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,6 +49,7 @@
 [workspace]
 resolver = "2"
 members = [
+    "rust/tcl-version",
     "rust/tcl-core-types",
     "rust/tcl-lexer",
     "rust/tcl-syntax",

--- a/rust/f5-cli/Cargo.toml
+++ b/rust/f5-cli/Cargo.toml
@@ -32,6 +32,7 @@ name = "f5-query"
 path = "src/main.rs"
 
 [dependencies]
+tcl-version = { path = "../tcl-version" }
 clap = { version = "4", features = ["derive", "wrap_help"] }
 clap_complete = "4"
 anyhow = "1"

--- a/rust/f5-cli/src/cli.rs
+++ b/rust/f5-cli/src/cli.rs
@@ -34,7 +34,8 @@ use clap::{Args, Parser, Subcommand};
 #[command(
     name = "f5-query",
     bin_name = "f5-query",
-    version,
+    // See tcl-cli: the release version comes from the tag, not the manifest.
+    version = tcl_version::VERSION,
     about = "Inspect, transform, and query F5 BIG-IP configs and iRules.",
     disable_help_subcommand = true,
     propagate_version = true

--- a/rust/tcl-cli/Cargo.toml
+++ b/rust/tcl-cli/Cargo.toml
@@ -32,6 +32,7 @@ name = "tcl"
 path = "src/main.rs"
 
 [dependencies]
+tcl-version = { path = "../tcl-version" }
 tcl-diagram = { path = "../tcl-diagram" }
 clap = { version = "4", features = ["derive", "wrap_help"] }
 clap_complete = "4"

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -34,7 +34,9 @@ use clap::{Args, Parser, Subcommand};
 #[derive(Debug, Parser)]
 #[command(
     name = "tcl",
-    version,
+    // Not clap's default (CARGO_PKG_VERSION): the workspace manifest carries
+    // 0.1.0 and is never bumped, because releases are tag-only.
+    version = tcl_version::VERSION,
     about = "Unified Tcl toolchain CLI.",
     disable_help_subcommand = true,
     propagate_version = true

--- a/rust/tcl-lsp-server/Cargo.toml
+++ b/rust/tcl-lsp-server/Cargo.toml
@@ -32,6 +32,7 @@ name = "tcl-lsp-server"
 path = "src/main.rs"
 
 [dependencies]
+tcl-version = { path = "../tcl-version" }
 tcl-lexer = { path = "../tcl-lexer" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-compiler = { path = "../tcl-compiler" }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -5091,7 +5091,8 @@ impl LanguageServer for Backend {
                 // Protocol identity must match the editor's
                 // expectations ("tcl-lsp"), not the crate/binary name.
                 name: "tcl-lsp".to_owned(),
-                version: Some(env!("CARGO_PKG_VERSION").to_owned()),
+                // The release version from the tag, not the manifest's 0.1.0.
+                version: Some(tcl_version::VERSION.to_owned()),
             }),
             ..Default::default()
         })

--- a/rust/tcl-lsp-server/tests/e2e/server_version.rs
+++ b/rust/tcl-lsp-server/tests/e2e/server_version.rs
@@ -20,8 +20,10 @@
 //!
 //! The smallest real round-trip: boot the live server and read the version it
 //! reports in the `initialize` response's `serverInfo`. Guards against the
-//! banner regressing to a `dev` fallback, and pins the reported version to the
-//! workspace crate version (`CARGO_PKG_VERSION`) the compiled banner comes from.
+//! banner regressing to a `dev` fallback, and pins the reported version to
+//! `tcl_version::VERSION` — the release version resolved from the tag, which is
+//! what the compiled banner carries. The workspace manifest's `0.1.0` is never
+//! bumped, so `CARGO_PKG_VERSION` is deliberately not the source here.
 
 use crate::common::Lsp;
 
@@ -39,12 +41,15 @@ fn initialize_reports_version() {
         !reported.is_empty() && reported != "vdev" && reported != "dev",
         "server fell back to a dev version banner: {reported:?}"
     );
-    // The native binary reports the workspace crate version verbatim.
-    let expected = env!("CARGO_PKG_VERSION");
+    // The native binary reports the tag-resolved release version verbatim.
+    // Both the test and the binary compile against the same `tcl-version` crate,
+    // so this holds for a release build (`2.1.5`) and a working-tree build
+    // (`2.1.5-3-gabc1234`) alike.
+    let expected = tcl_version::VERSION;
     assert_eq!(
         reported, expected,
-        "native server reported version {reported:?}, expected the workspace crate \
-         version {expected:?} (CARGO_PKG_VERSION)"
+        "native server reported version {reported:?}, expected the tag-resolved \
+         release version {expected:?} (tcl_version::VERSION)"
     );
 }
 

--- a/rust/tcl-mcp/Cargo.toml
+++ b/rust/tcl-mcp/Cargo.toml
@@ -32,6 +32,7 @@ name = "tcl-mcp"
 path = "src/main.rs"
 
 [dependencies]
+tcl-version = { path = "../tcl-version" }
 tcl-diagram = { path = "../tcl-diagram" }
 tcl-lsp-core = { path = "../tcl-lsp-core" }
 tcl-compiler = { path = "../tcl-compiler" }

--- a/rust/tcl-mcp/src/main.rs
+++ b/rust/tcl-mcp/src/main.rs
@@ -57,7 +57,8 @@ impl ServerHandler for TclMcp {
             );
         // Keep a stable server identity so existing MCP clients see no change.
         "tcl-lsp".clone_into(&mut info.server_info.name);
-        env!("CARGO_PKG_VERSION").clone_into(&mut info.server_info.version);
+        // The release version from the tag, not the manifest's 0.1.0.
+        tcl_version::VERSION.clone_into(&mut info.server_info.version);
         info
     }
 

--- a/rust/tcl-version/Cargo.toml
+++ b/rust/tcl-version/Cargo.toml
@@ -1,0 +1,17 @@
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+[package]
+name = "tcl-version"
+description = "The release version stamped into every user-facing binary."
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+repository.workspace = true
+authors.workspace = true
+publish = false
+
+[dependencies]

--- a/rust/tcl-version/build.rs
+++ b/rust/tcl-version/build.rs
@@ -1,0 +1,65 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Resolve the version every user-facing binary reports, in this order:
+//!
+//! 1. `TCL_LSP_VERSION` — set by CI from the tag, and by the Makefile from
+//!    `git describe`. Authoritative when present.
+//! 2. `git describe --tags --always --dirty` — a working-tree build gets
+//!    `2.1.5-3-gabc1234` so a dev binary never claims to be a release.
+//! 3. `CARGO_PKG_VERSION` — the manifest's `0.1.0`. Only reached when the
+//!    source tree has no tags and no env override (a vendored crate, say).
+//!
+//! Releases are tag-only: no version literal is bumped in the tree, so the tag
+//! is the single source of truth. See `scripts/release/tag.sh`.
+
+use std::process::Command;
+
+fn main() {
+    // A change to either input must re-run this script, or the binary keeps a
+    // stale version baked in from a previous build.
+    println!("cargo:rerun-if-env-changed=TCL_LSP_VERSION");
+    for p in [".git/HEAD", ".git/refs/tags", ".git/packed-refs"] {
+        println!("cargo:rerun-if-changed=../../{p}");
+    }
+
+    let version = env_version()
+        .or_else(git_describe)
+        .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_owned());
+
+    println!("cargo:rustc-env=TCL_LSP_RESOLVED_VERSION={version}");
+}
+
+/// `TCL_LSP_VERSION`, with a leading `v` stripped so `v2.1.5` and `2.1.5` are
+/// equivalent — CI passes `github.ref_name`, which carries the `v`.
+fn env_version() -> Option<String> {
+    let raw = std::env::var("TCL_LSP_VERSION").ok()?;
+    let trimmed = raw.trim();
+    if trimmed.is_empty() {
+        return None;
+    }
+    Some(strip_v(trimmed).to_owned())
+}
+
+fn git_describe() -> Option<String> {
+    let out = Command::new("git")
+        .args(["describe", "--tags", "--always", "--dirty"])
+        .current_dir(env!("CARGO_MANIFEST_DIR"))
+        .output()
+        .ok()?;
+    if !out.status.success() {
+        return None;
+    }
+    let s = String::from_utf8(out.stdout).ok()?;
+    let s = s.trim();
+    if s.is_empty() {
+        return None;
+    }
+    Some(strip_v(s).to_owned())
+}
+
+fn strip_v(s: &str) -> &str {
+    s.strip_prefix('v').unwrap_or(s)
+}

--- a/rust/tcl-version/src/lib.rs
+++ b/rust/tcl-version/src/lib.rs
@@ -1,0 +1,23 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The version every user-facing binary reports.
+//!
+//! Resolved at compile time by `build.rs` from `TCL_LSP_VERSION`, else
+//! `git describe`, else the manifest version. The workspace manifest carries
+//! `0.1.0` and is never bumped: releases are tag-only, so the annotated tag is
+//! the single source of truth.
+//!
+//! ```ignore
+//! #[command(version = tcl_version::VERSION)]
+//! struct Cli { /* … */ }
+//! ```
+
+/// The resolved release version, without a leading `v` (e.g. `2.1.5`).
+///
+/// A build from a working tree between releases reports `git describe` output
+/// (`2.1.5-3-gabc1234`, `-dirty` when the tree is modified), so a development
+/// binary never claims to be a release.
+pub const VERSION: &str = env!("TCL_LSP_RESOLVED_VERSION");


### PR DESCRIPTION
`tcl --version` reports `tcl 0.1.0`. So does `f5 --version` (`f5-query 0.1.0`), the LSP `serverInfo.version`, and the MCP `server_info.version`.

Cause: clap's derived `version` reads `CARGO_PKG_VERSION`, which is the workspace manifest's `version = "0.1.0"`, inherited by all 74 crates. **v2.1.4 shipped the same way** — I downloaded its published `tcl-aarch64-apple-darwin` to confirm — so this isn't a regression, but `scripts/release/smoke_installer.sh` has been failing its version checks on every release because of it.

## Why not just bump the manifest

Releases are **tag-only**. `scripts/release/tag.sh` tags a clean tree and no version literal is bumped in source, because the annotated tag is the single source of truth. Hard-coding `2.1.5` would go stale the moment `2.1.6` is tagged, and would need a bump commit before every release.

## What this does instead

A new `tcl-version` crate exposes one constant, resolved at compile time by its `build.rs`:

| | Source | Result |
|---|---|---|
| 1 | `TCL_LSP_VERSION` (CI sets it from `github.ref_name`, `v` stripped) | `2.1.5` |
| 2 | `git describe --tags --always --dirty` | `2.1.5-1-ga951b9b6-dirty` |
| 3 | `CARGO_PKG_VERSION` — only when neither is available (vendored tree) | `0.1.0` |

A development build therefore **cannot claim to be a release**. `build-server-matrix` sets the env var explicitly rather than leaning on `git describe`, because its checkout doesn't fetch tags.

## Scope

Wired into the four user-facing surfaces only:

- `tcl --version`
- `f5-query --version`
- LSP `initialize` → `serverInfo.version`
- MCP `initialize` → `server_info.version`

The internal `VERSION` consts in `tcl-compiler` / `tcl-registry` / `tcl-lexer` / `tcl-lsp-core`, and `tcl-vm`'s `RUNTIME_VERSION`, deliberately keep their own crate versions — they identify a *component*, not the release.

`Cargo.toml`'s `version = "0.1.0"` is **unchanged**.

## Test change

`tests/e2e/server_version.rs` pinned `serverInfo.version` to `CARGO_PKG_VERSION`. It now pins to `tcl_version::VERSION`, which holds for a release build *and* a working-tree build, since the test and the binary compile against the same crate.

## Verified

```
TCL_LSP_VERSION=v2.1.5   tcl --version       -> tcl 2.1.5
TCL_LSP_VERSION=v2.1.5   f5-query --version  -> f5-query 2.1.5
(no env)                 tcl --version       -> tcl 2.1.5-1-ga951b9b69-dirty
LSP  initialize -> serverInfo:  name=tcl-lsp version=2.1.5
MCP  initialize -> server_info: name=tcl-lsp version=2.1.5
```

Full 609-test `lsp_e2e` suite passes; `cargo fmt --check`, `clippy -D warnings` and `make xtask-check` all clean.

## Still outstanding

`smoke_installer.sh` also fails on `tcl-mcp --help`, which doesn't exist — it's an MCP stdio server and answers `ConnectionClosed("initialize request")`. And it installs into the real `~/.claude/skills` regardless of `TCL_LSP_PREFIX`. Both are separate from this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)