### PR TITLE
O101: fix constant-folding correctness gaps

### DIFF
--- a/docs/kcs/codes/kcs-optimisation-o101-integer-expression-folding.md
+++ b/docs/kcs/codes/kcs-optimisation-o101-integer-expression-folding.md
@@ -34,7 +34,11 @@ expr {2 + 3}
 ## Safety conditions
 
 - Skipped when any operand is not a compile-time constant.
-- Skipped when the expression involves floating-point division that could lose precision.
+- Skipped when an operand comes from an embedded command substitution (`[…]`).
+- Skipped when a leading-zero operand (`010`) is ambiguous between octal and decimal and the document's Tcl dialect/version isn't known.
+- Skipped on a domain error, such as `0.0/0.0` or a negative exponent of `0`, or when the result would need arbitrary-precision (bignum) arithmetic.
+- Skipped when `expr` itself, or a math function used in the expression (`abs`, `sqrt`, …), has been renamed, aliased, or redefined by a `proc`.
+- Skipped when a variable's value can't be proven unchanged across an intervening call — for example, a helper procedure that writes the same global/namespace variable, or a variable under a `trace` installed anywhere in the file.
 
 ## How to disable
 

--- a/editors/vscode/src/test/commandExecution.test.ts
+++ b/editors/vscode/src/test/commandExecution.test.ts
@@ -156,7 +156,11 @@ suite("LSP Command Execution", () => {
   test("tcl-lsp.optimiseDocument folds a plain constant expr but not a shadowed-mathfunc one", async () => {
     const o101Uri = getDocUri("optimisation-o101.tcl");
     await activate(o101Uri);
-    const result = (await execLspCommand("tcl-lsp.optimiseDocument", o101Uri.toString(), "full")) as {
+    const result = (await execLspCommand(
+      "tcl-lsp.optimiseDocument",
+      o101Uri.toString(),
+      "full",
+    )) as {
       optimisations: unknown[];
       source: string;
     } | null;

--- a/editors/vscode/src/test/commandExecution.test.ts
+++ b/editors/vscode/src/test/commandExecution.test.ts
@@ -149,6 +149,28 @@ suite("LSP Command Execution", () => {
     );
   });
 
+  // O101 (fold constant integer expressions): one true-positive fold and one
+  // guarded false-positive (a user-defined ::tcl::mathfunc:: shadowing the
+  // builtin) in the same fixture, since the shadow gate is name-specific
+  // rather than whole-module.
+  test("tcl-lsp.optimiseDocument folds a plain constant expr but not a shadowed-mathfunc one", async () => {
+    const o101Uri = getDocUri("optimisation-o101.tcl");
+    await activate(o101Uri);
+    const result = (await execLspCommand("tcl-lsp.optimiseDocument", o101Uri.toString(), "full")) as {
+      optimisations: unknown[];
+      source: string;
+    } | null;
+    assert.ok(result, "optimiseDocument should return a result");
+    assert.ok(
+      result.source.includes("return 3"),
+      `plain 'expr {1 + 2}' should fold to 'return 3': ${result.source}`,
+    );
+    assert.ok(
+      result.source.includes("expr {triple(2)}"),
+      `shadowed-mathfunc call must not fold: ${result.source}`,
+    );
+  });
+
   // -- fixAllSafeIssues -------------------------------------------------------
 
   test("tcl-lsp.fixAllSafeIssues returns applied list", async () => {

--- a/editors/vscode/testFixture/optimisation-o101.tcl
+++ b/editors/vscode/testFixture/optimisation-o101.tcl
@@ -1,0 +1,21 @@
+# Fixture for the O101 (fold constant integer expressions) VS Code
+# extension test — covers one true-positive fold and one guarded
+# false-positive (a user-defined ::tcl::mathfunc:: shadows the builtin).
+
+proc ::tcl::mathfunc::triple {x} {
+    return [expr {$x * 3}]
+}
+
+proc guarded {} {
+    # `triple` is shadowed above, so O101 must NOT fold this call —
+    # folding it would assume the builtin math function, not the
+    # user-defined override.
+    return [expr {triple(2)}]
+}
+
+proc unguarded {} {
+    # An ordinary constant expression, unaffected by the mathfunc
+    # shadowing above (the shadow gate is name-specific, not
+    # whole-module) — O101 folds this to `return 3`.
+    return [expr {1 + 2}]
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -2009,6 +2009,7 @@ fn memoized_compilation_unit_diagnostics_match_whole_file() {
                         true,
                         req.upvar_procs.clone(),
                         req.proc_params.clone(),
+                        req.global_write_procs.clone(),
                     );
                     let pc = crate::compilation_unit::decode_param_constants(req.param_constants);
                     let known_classes: std::collections::HashSet<String> =
@@ -2020,6 +2021,7 @@ fn memoized_compilation_unit_diagnostics_match_whole_file() {
                         &registry,
                         pc.as_ref(),
                         &known_classes,
+                        Some(req.module_traces),
                     );
                     cache.insert(key, fu.clone());
                     fu
@@ -2103,6 +2105,7 @@ fn memoized_compilation_unit_shift_correctness() {
                     true,
                     req.upvar_procs.clone(),
                     req.proc_params.clone(),
+                    req.global_write_procs.clone(),
                 );
                 let pc = crate::compilation_unit::decode_param_constants(req.param_constants);
                 let fu = FunctionUnit::build_with_param_constants(

--- a/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
@@ -1,0 +1,447 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Per-proc summary of global/namespace variable writes.
+//!
+//! Mirrors [`super::upvar_info`]'s shape and role in the pipeline, for the
+//! complementary correctness gap: `upvar_info` tells a caller which of
+//! *its own* frame variables a callee will alias and write; this module
+//! tells a caller which *global/namespace* variables a callee will alias
+//! (via `global` / `variable` / `upvar #0`) and write, so that
+//! [`super::CfgBuilder::apply_upvar_invalidation`] can widen a call's
+//! `defs` for those too. Without this, SCCP treats a bare global/namespace
+//! name as an ordinary private local across an opaque call — unsound
+//! (`proc mutate {} { global x; set x 99 }; set x 5; mutate; expr {$x+1}`
+//! must not fold to `6`; tclsh yields `100`).
+//!
+//! ## Flow-insensitive, sound over-approximation
+//!
+//! Real Tcl style declares `global`/`variable` before using the name, but
+//! this scan does not depend on that ordering: it first unions every
+//! `global` / `variable` / `upvar #0` declaration in the whole proc body
+//! (via the shared [`crate::var_observability::stmt_gen`] recognition
+//! logic — reused, not re-derived) into one flag state, then checks every
+//! write-target name found anywhere in the body against that *complete*
+//! state. A write on a conditional branch that never executes together
+//! with the declaring branch is still counted — the goal is soundness
+//! (never *miss* a global write), not maximal precision.
+//!
+//! Dynamic (non-literal) `global`/`variable`/`upvar` targets are silently
+//! skipped, mirroring [`super::upvar_info::record_upvar_call`]'s existing
+//! "can't classify → don't record" policy for dynamic `upvar` sources —
+//! this is an accepted, pre-existing-class residual gap, not new
+//! unsoundness (a name we can't prove is global/namespace-aliased is
+//! simply not added to `names`; it is never wrongly *excluded* from an
+//! outer-scope alias that *is* statically classifiable).
+
+use std::collections::{BTreeSet, HashMap};
+
+use crate::ir::{Module, Script, Statement};
+use crate::ir_helpers::nested_bodies;
+use crate::naming::normalise_var_name;
+use crate::var_observability::{State, stmt_gen};
+
+/// Per-proc summary: the outer-scope (global/namespace) variable names a
+/// proc's body writes while aliased via `global` / `variable` / `upvar #0`.
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct GlobalWriteInfo {
+    /// Literal outer-scope names this proc's body writes.
+    pub names: BTreeSet<String>,
+}
+
+impl GlobalWriteInfo {
+    /// True when the proc's body writes no outer-scope name.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.names.is_empty()
+    }
+}
+
+/// Detect, for every proc in `module`, which outer-scope (global/
+/// namespace) variable names its body writes — see the module doc for the
+/// two-pass, flow-insensitive algorithm. Both the qualified and short
+/// forms are registered for every proc, matching
+/// [`super::detect_upvar_procs`]'s convention (the caller-side lookup at
+/// [`super::CfgBuilder::apply_upvar_invalidation`] resolves a `Statement::
+/// Call::command` by whichever spelling appears in source).
+///
+/// Then closes the per-proc summaries transitively over the direct-call
+/// graph (a proc that calls a global-writing proc also "writes" those
+/// names, recursively) via a bounded fixpoint — monotonic set-union, so
+/// recursive/mutually-recursive cycles terminate safely.
+#[must_use]
+pub fn detect_global_write_procs(module: &Module) -> HashMap<String, GlobalWriteInfo> {
+    let mut own: HashMap<String, GlobalWriteInfo> = HashMap::new();
+    let mut direct_calls: HashMap<String, BTreeSet<String>> = HashMap::new();
+    for (qname, proc) in &module.procedures {
+        let info = own_body_global_writes(&proc.body);
+        let calls = direct_call_targets(&proc.body);
+        for key in registered_keys(qname) {
+            own.insert(key.clone(), info.clone());
+            direct_calls.insert(key, calls.clone());
+        }
+    }
+
+    // Transitive closure: monotonic union over direct-callee summaries.
+    // Bounded by the number of registered names, so an adversarial call
+    // graph still terminates.
+    let mut changed = true;
+    let mut guard = 0usize;
+    while changed && guard <= own.len() {
+        changed = false;
+        guard += 1;
+        let snapshot = own.clone();
+        for (caller, callees) in &direct_calls {
+            let Some(target_summary) = own.get_mut(caller) else {
+                continue;
+            };
+            for callee in callees {
+                let Some(source_summary) = snapshot.get(callee) else {
+                    continue;
+                };
+                for name in &source_summary.names {
+                    if target_summary.names.insert(name.clone()) {
+                        changed = true;
+                    }
+                }
+            }
+        }
+    }
+
+    own
+}
+
+/// Both the short and fully-qualified forms of `qname`, matching
+/// [`super::detect_upvar_procs`]'s registration convention.
+fn registered_keys(qname: &str) -> Vec<String> {
+    let mut keys = vec![qname.to_owned()];
+    if let Some((_, short)) = qname.rsplit_once("::")
+        && !short.is_empty()
+    {
+        keys.push(short.to_owned());
+    }
+    keys
+}
+
+/// Pass 1: union every `global` / `variable` declaration in `body` into one
+/// flag state (order-independent), *and* separately collect the
+/// (local-alias-name → real-outer-name) map for `upvar #0` / `upvar 0` /
+/// `namespace upvar` declarations — those alias a *different* local name to
+/// the outer one, so a write to the local name must be attributed to the
+/// outer name, not recorded under the local spelling.  `global`/`variable`
+/// are identity aliases (the declared name *is* the outer name), so they
+/// stay in the flag-state path.  Pass 2: walk `body` again collecting every
+/// write-target name, resolving each through the alias map first and
+/// falling back to the flag-state identity check.
+fn own_body_global_writes(body: &Script) -> GlobalWriteInfo {
+    let mut state = State::default();
+    let mut renamed_aliases: HashMap<String, String> = HashMap::new();
+    accumulate_state(body, &mut state, &mut renamed_aliases);
+
+    let mut names = BTreeSet::new();
+    collect_write_targets(body, &state, &renamed_aliases, &mut names);
+    GlobalWriteInfo { names }
+}
+
+fn accumulate_state(
+    script: &Script,
+    state: &mut State,
+    renamed_aliases: &mut HashMap<String, String>,
+) {
+    for stmt in &script.statements {
+        stmt_gen(stmt, state);
+        collect_renamed_outer_alias(stmt, renamed_aliases);
+        for body in nested_bodies(stmt) {
+            accumulate_state(body, state, renamed_aliases);
+        }
+    }
+}
+
+/// Record (local → outer) for a literal `upvar #0`/`upvar 0` (global) or
+/// `namespace upvar` (namespace) declaration whose *source* word is also
+/// literal. Reuses [`crate::var_scoping::upvar_local_declaration_indices`]
+/// for the local-name index — the source word is always the immediately
+/// preceding argument (the `(src, dst)` pairing both
+/// [`crate::var_observability::stmt_gen`] and
+/// [`super::upvar_info::upvar_pairs`] rely on).
+fn collect_renamed_outer_alias(stmt: &Statement, renamed_aliases: &mut HashMap<String, String>) {
+    let (Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. }) = stmt
+    else {
+        return;
+    };
+    let cmd = command.as_str();
+    let is_ns_upvar = cmd == "namespace" && args.first().map(String::as_str) == Some("upvar");
+    let is_global_level =
+        cmd == "upvar" && !args.is_empty() && matches!(args[0].trim(), "#0" | "0");
+    if !is_ns_upvar && !is_global_level {
+        return;
+    }
+    for local_idx in crate::var_scoping::upvar_local_declaration_indices(cmd, args) {
+        let Some(src_idx) = local_idx.checked_sub(1) else {
+            continue;
+        };
+        let (Some(src), Some(dst)) = (args.get(src_idx), args.get(local_idx)) else {
+            continue;
+        };
+        if src.starts_with('$') || dst.starts_with('$') {
+            continue; // dynamic — can't classify, matches upvar_info's policy.
+        }
+        let src_name = normalise_var_name(src);
+        let dst_name = normalise_var_name(dst);
+        if !src_name.is_empty() && !dst_name.is_empty() {
+            renamed_aliases.insert(dst_name.to_owned(), src_name.to_owned());
+        }
+    }
+}
+
+fn collect_write_targets(
+    script: &Script,
+    state: &State,
+    renamed_aliases: &HashMap<String, String>,
+    names: &mut BTreeSet<String>,
+) {
+    for stmt in &script.statements {
+        for target in own_write_targets(stmt) {
+            let target = normalise_var_name(&target);
+            if let Some(outer) = renamed_aliases.get(target) {
+                names.insert(outer.clone());
+            } else if state.get(target).is_some_and(|f| f.writes_outer_scope()) {
+                names.insert(target.to_owned());
+            }
+        }
+        for body in nested_bodies(stmt) {
+            collect_write_targets(body, state, renamed_aliases, names);
+        }
+    }
+}
+
+/// The variable name(s) `stmt` itself directly writes — its own `name`
+/// field for the direct-assignment statement kinds, `Call::defs` for a
+/// direct call to a registry-known var-mutating builtin (`incr x`,
+/// `lappend x …`, …; the registry-driven mechanism already used
+/// throughout the compiler — see `AGENTS.md`'s "registry is the source of
+/// truth"), plus any embedded builtin var-mutator command substitution in
+/// the statement's own value/argument text (`set y [incr x]`), reusing
+/// [`super::CfgBuilder::builtin_write_defs_from_text`] — the same helper
+/// [`super::CfgBuilder::apply_upvar_invalidation`] already uses for this
+/// exact embedded-substitution shape.
+///
+/// Excludes `global` / `variable` / `upvar` / `namespace upvar` / `trace`
+/// themselves: the registry may record their declared name in `Call::defs`
+/// (they do create a local binding), but declaring an alias does not write
+/// the *value* of the variable it aliases — only a subsequent assignment
+/// through that alias does.
+fn own_write_targets(stmt: &Statement) -> Vec<String> {
+    let mut out = Vec::new();
+    match stmt {
+        Statement::AssignConst { name, .. }
+        | Statement::AssignExpr { name, .. }
+        | Statement::AssignValue { name, .. }
+        | Statement::Incr { name, .. } => out.push(name.clone()),
+        Statement::Call {
+            command,
+            args,
+            defs,
+            ..
+        } => {
+            let cmd = command.trim_start_matches("::");
+            let is_ns_upvar =
+                cmd == "namespace" && args.first().map(String::as_str) == Some("upvar");
+            if !is_ns_upvar && !matches!(cmd, "global" | "variable" | "upvar" | "trace") {
+                out.extend(defs.iter().cloned());
+            }
+        }
+        _ => {}
+    }
+    for text in stmt_embedded_texts(stmt) {
+        out.extend(super::CfgBuilder::builtin_write_defs_from_text(text));
+    }
+    out
+}
+
+/// Value/argument text fields that may embed a `[cmd …]` command
+/// substitution whose head is a builtin var-mutator — the same fields
+/// [`super::CfgBuilder::apply_upvar_invalidation`]'s embedded-substitution
+/// scan inspects.
+fn stmt_embedded_texts(stmt: &Statement) -> Vec<&str> {
+    match stmt {
+        Statement::AssignValue { value, .. } if value.contains('[') => vec![value.as_str()],
+        Statement::Call { args, .. } => args
+            .iter()
+            .filter(|a| a.contains('['))
+            .map(String::as_str)
+            .collect(),
+        _ => Vec::new(),
+    }
+}
+
+/// Direct-call targets in `body` — the command name of every
+/// `Statement::Call`, recursed into every nested body. Used to build the
+/// call graph for the transitive-closure step; resolution against
+/// `module.procedures` (qualified vs. short name) happens at the lookup
+/// site in [`detect_global_write_procs`].
+fn direct_call_targets(body: &Script) -> BTreeSet<String> {
+    let mut calls = BTreeSet::new();
+    collect_direct_calls(body, &mut calls);
+    calls
+}
+
+fn collect_direct_calls(script: &Script, calls: &mut BTreeSet<String>) {
+    for stmt in &script.statements {
+        if let Statement::Call { command, .. } = stmt {
+            calls.insert(command.clone());
+        }
+        for body in nested_bodies(stmt) {
+            collect_direct_calls(body, calls);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::lowering::lower_to_ir;
+    use tcl_registry::CommandRegistry;
+
+    fn module(src: &str) -> Module {
+        lower_to_ir(src, &CommandRegistry::build_default())
+    }
+
+    #[test]
+    fn empty_module_has_no_writes() {
+        let m = module("");
+        assert!(detect_global_write_procs(&m).is_empty());
+    }
+
+    #[test]
+    fn proc_with_no_global_write_is_empty() {
+        let m = module("proc ::p {} { set x 1 }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().is_empty());
+    }
+
+    #[test]
+    fn direct_global_write_recorded() {
+        // The `mutate` repro: global x; set x 99.
+        let m = module("proc ::mutate {} { global x; set x 99 }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::mutate").unwrap().names.contains("x"));
+        // Registered under both the qualified and short forms.
+        assert!(info.get("mutate").unwrap().names.contains("x"));
+    }
+
+    #[test]
+    fn variable_namespace_write_recorded() {
+        let m = module("proc ::ns::p {} { variable v; set v 1 }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::ns::p").unwrap().names.contains("v"));
+    }
+
+    #[test]
+    fn upvar_hash_zero_counts_as_global() {
+        let m = module("proc ::p {} { upvar #0 g local; set local 1 }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().names.contains("g"));
+        // Not the local alias name — recording "local" would be a no-op at
+        // the caller (no such caller-frame variable), missing the real "g".
+        assert!(!info.get("::p").unwrap().names.contains("local"));
+    }
+
+    #[test]
+    fn namespace_upvar_rename_resolves_to_outer_name() {
+        let m = module("proc ::ns::p {} { namespace upvar ::ns nsvar localvar\nset localvar 1 }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::ns::p").unwrap().names.contains("nsvar"));
+        assert!(!info.get("::ns::p").unwrap().names.contains("localvar"));
+    }
+
+    #[test]
+    fn caller_frame_upvar_is_not_a_global_write() {
+        // `upvar 1` aliases the *caller* frame, not global/namespace —
+        // must not be treated as an outer-scope write.
+        let m = module("proc ::p {} { upvar 1 caller_x local; set local 1 }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().is_empty());
+    }
+
+    #[test]
+    fn read_only_global_is_not_a_write() {
+        let m = module("proc ::p {} { global x; puts $x }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().is_empty());
+    }
+
+    #[test]
+    fn write_on_conditional_branch_still_counted() {
+        // Sound over-approximation: flow-insensitive, so a write inside
+        // an `if` still counts even though it may not always execute.
+        let m = module("proc ::p {} { global x\nif {$c} { set x 1 } }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().names.contains("x"));
+    }
+
+    #[test]
+    fn declaration_after_write_still_counted() {
+        // Flow-insensitive union: order within the body doesn't matter.
+        let m = module("proc ::p {} { set x 1\nglobal x }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().names.contains("x"));
+    }
+
+    #[test]
+    fn embedded_incr_in_command_substitution_recorded() {
+        let m = module("proc ::p {} { global x\nset y [incr x] }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().names.contains("x"));
+    }
+
+    #[test]
+    fn transitive_closure_through_direct_call() {
+        // `outer` calls `mutate`, which writes global x — `outer`'s
+        // summary must include `x` too (transitive).
+        let m = module("proc ::mutate {} { global x; set x 99 }\nproc ::outer {} { mutate }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::outer").unwrap().names.contains("x"));
+    }
+
+    #[test]
+    fn recursive_proc_terminates_and_includes_write() {
+        let m = module(
+            "proc ::p {n} { if {$n == 0} { return }\n global x\n incr x\n p [expr {$n-1}] }",
+        );
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().names.contains("x"));
+    }
+
+    #[test]
+    fn mutually_recursive_procs_share_the_write() {
+        let m = module("proc ::a {} { global x; set x 1; b }\nproc ::b {} { a }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::a").unwrap().names.contains("x"));
+        assert!(info.get("::b").unwrap().names.contains("x"));
+    }
+
+    #[test]
+    fn unrelated_global_write_is_not_confused_with_other_procs() {
+        let m =
+            module("proc ::mutate_y {} { global y; set y 1 }\nproc ::p {} { global x; set x 1 }");
+        let info = detect_global_write_procs(&m);
+        assert!(info.get("::p").unwrap().names.contains("x"));
+        assert!(!info.get("::p").unwrap().names.contains("y"));
+    }
+}

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -37,6 +37,7 @@ use crate::ir::{CommandTokens, Module, Script, Statement};
 use crate::ir_helpers::defs_from_ir_script;
 use crate::naming::normalise_var_name;
 
+use self::global_write_info::GlobalWriteInfo;
 use self::upvar_info::{UpvarInfo, collect_upvar_targets};
 
 /// Choose the [`CommandTokens`] for a "frozen" `while`/`for` runtime call.
@@ -108,6 +109,7 @@ fn all_str_tokens(cmd: &str, args: &[String]) -> CommandTokens {
 }
 
 mod cfg_lower;
+pub mod global_write_info;
 pub mod upvar_info;
 
 /// Mutable block used during construction, frozen into [`Block`] at the end.
@@ -135,6 +137,12 @@ pub(crate) struct CfgBuilder {
     /// wiring to resolve param-based upvar sources (`upvar 1 $param
     /// local`) against the actual call-site argument.
     proc_params: HashMap<String, Vec<String>>,
+    /// Map from command name to the outer-scope (global/namespace) variable
+    /// names that proc's body writes (see [`global_write_info`]), used to
+    /// widen caller-side `defs` at a call site exactly like `upvar_procs` —
+    /// so SCCP treats a global/namespace name as overdefined across an
+    /// opaque call that writes it, not as an ordinary untouched local.
+    global_write_procs: HashMap<String, GlobalWriteInfo>,
     /// Stack of `(break_target, continue_target)` block names for the
     /// enclosing loops, so `break` / `continue` in a body lower to a CFG
     /// edge.  Without this a `while 1 { … break }` exit block is
@@ -180,13 +188,14 @@ const MAX_LOWER_DEPTH: usize = 256;
 
 impl CfgBuilder {
     fn new(inline_loops: bool) -> Self {
-        Self::new_with_upvars(inline_loops, HashMap::new(), HashMap::new())
+        Self::new_with_upvars(inline_loops, HashMap::new(), HashMap::new(), HashMap::new())
     }
 
     fn new_with_upvars(
         inline_loops: bool,
         upvar_procs: HashMap<String, UpvarInfo>,
         proc_params: HashMap<String, Vec<String>>,
+        global_write_procs: HashMap<String, GlobalWriteInfo>,
     ) -> Self {
         Self {
             counter: 0,
@@ -196,6 +205,7 @@ impl CfgBuilder {
             inline_loops,
             upvar_procs,
             proc_params,
+            global_write_procs,
             loop_stack: Vec::new(),
             exception_edges: Vec::new(),
             faithful_exceptions: false,
@@ -231,25 +241,42 @@ impl CfgBuilder {
     /// tokens whose head is a known upvar proc; merges those defs
     /// into the host Call when possible, or emits a synthetic
     /// `<upvar-invalidate>` Call before a non-Call host.
+    ///
+    /// The same two forms also widen `defs` with `global_write_procs`
+    /// (a callee that writes an outer-scope name via `global`/`variable`/
+    /// `upvar #0`, see [`global_write_info`]) — a global name doesn't
+    /// depend on call-site arguments, so no params-based mapping is
+    /// needed, just the literal name list.
     fn apply_upvar_invalidation(&self, mut stmt: Statement) -> Vec<Statement> {
-        // 1. Direct-call extras: command is a known upvar proc.
+        // 1. Direct-call extras: command is a known upvar proc / a proc that
+        //    writes outer-scope names.
         let direct_extras: Vec<String> = match &stmt {
-            Statement::Call { command, args, .. } => self
-                .upvar_procs
-                .get(command.as_str())
-                .map(|info| {
-                    let params: &[String] = self
-                        .proc_params
-                        .get(command.as_str())
-                        .map_or(&[][..], Vec::as_slice);
-                    info.caller_side_defs(args, params)
-                })
-                .unwrap_or_default(),
+            Statement::Call { command, args, .. } => {
+                let mut extras = self
+                    .upvar_procs
+                    .get(command.as_str())
+                    .map(|info| {
+                        let params: &[String] = self
+                            .proc_params
+                            .get(command.as_str())
+                            .map_or(&[][..], Vec::as_slice);
+                        info.caller_side_defs(args, params)
+                    })
+                    .unwrap_or_default();
+                if let Some(info) = self.global_write_procs.get(command.as_str()) {
+                    for name in &info.names {
+                        if !extras.contains(name) {
+                            extras.push(name.clone());
+                        }
+                    }
+                }
+                extras
+            }
             _ => Vec::new(),
         };
 
         // 2. Embedded-substitution extras: walk text for
-        //    `[upvar_proc arg]` substitutions.
+        //    `[upvar_proc arg]` / `[global_write_proc arg]` substitutions.
         let texts: Vec<&str> = match &stmt {
             Statement::AssignValue { value, .. } if value.contains('[') => vec![value.as_str()],
             Statement::Call { args, .. } => args
@@ -262,6 +289,11 @@ impl CfgBuilder {
         let mut embedded_extras: Vec<String> = Vec::new();
         for text in texts {
             for d in self.upvar_defs_from_text(text) {
+                if !embedded_extras.contains(&d) {
+                    embedded_extras.push(d);
+                }
+            }
+            for d in self.global_write_defs_from_text(text) {
                 if !embedded_extras.contains(&d) {
                     embedded_extras.push(d);
                 }
@@ -358,6 +390,47 @@ impl CfgBuilder {
             for d in info.caller_side_defs(&raw_args, params) {
                 if !defs.contains(&d) {
                     defs.push(d);
+                }
+            }
+        }
+        defs
+    }
+
+    /// Scan *text* for `[command_substitution]` tokens and accumulate the
+    /// outer-scope (global/namespace) names any embedded call to a known
+    /// global-writing proc writes — the embedded-substitution analogue of
+    /// [`Self::upvar_defs_from_text`], for the same soundness reason: a
+    /// global write reached via `set y [mutate]` is just as real as one
+    /// reached via a bare `mutate` statement.
+    fn global_write_defs_from_text(&self, text: &str) -> Vec<String> {
+        use tcl_lexer::{Lexer, SourceMap, TokenType};
+
+        if self.global_write_procs.is_empty() || !text.contains('[') {
+            return Vec::new();
+        }
+
+        let sm = SourceMap::new(text);
+        let lexer = Lexer::new(text);
+        let Ok(tokens) = lexer.tokenise_all() else {
+            return Vec::new();
+        };
+
+        let mut defs: Vec<String> = Vec::new();
+        for tok in &tokens {
+            if tok.kind != TokenType::Cmd {
+                continue;
+            }
+            let inner = sm.token_text(*tok);
+            let words = words_from_text(inner);
+            let Some(cmd) = words.first() else {
+                continue;
+            };
+            let Some(info) = self.global_write_procs.get(cmd.as_str()) else {
+                continue;
+            };
+            for name in &info.names {
+                if !defs.contains(name) {
+                    defs.push(name.clone());
                 }
             }
         }
@@ -1033,14 +1106,25 @@ pub fn detect_upvar_procs(module: &Module) -> HashMap<String, UpvarInfo> {
     result
 }
 
-/// Return the upvar-procs map and the parameter-list map used by
-/// the CFG builder's upvar-invalidation pass.  Both the qualified
-/// and short forms are registered for every proc.
+/// Module-wide CFG-determining context: the upvar-procs map, the
+/// parameter-list map, and the global-write-procs map
+/// ([`global_write_info::detect_global_write_procs`]) [`prepare_cfg_context`]
+/// returns. The single canonical definition [`crate::compilation_unit`]
+/// reuses for its own `CfgContext` alias, so the two never drift apart.
+pub type CfgContext = (
+    HashMap<String, UpvarInfo>,
+    HashMap<String, Vec<String>>,
+    HashMap<String, GlobalWriteInfo>,
+);
+
+/// Return the upvar-procs map, the parameter-list map, and the
+/// global-write-procs map ([`global_write_info::detect_global_write_procs`])
+/// used by the CFG builder's call-site invalidation pass.  Both the
+/// qualified and short forms are registered for every proc.
 #[must_use]
-pub fn prepare_cfg_context(
-    module: &Module,
-) -> (HashMap<String, UpvarInfo>, HashMap<String, Vec<String>>) {
+pub fn prepare_cfg_context(module: &Module) -> CfgContext {
     let upvar_procs = detect_upvar_procs(module);
+    let global_write_procs = global_write_info::detect_global_write_procs(module);
     let mut proc_params: HashMap<String, Vec<String>> = HashMap::new();
     // Iterate procedures in a deterministic (qualified-name) order: a *short*
     // name shared by two procedures (`::a::x` and `::b::x`) is inserted by both,
@@ -1059,7 +1143,7 @@ pub fn prepare_cfg_context(
         }
         proc_params.insert(qname.clone(), proc.params.clone());
     }
-    (upvar_procs, proc_params)
+    (upvar_procs, proc_params, global_write_procs)
 }
 
 /// Build CFGs for a whole module: top-level script + each procedure.
@@ -1091,10 +1175,15 @@ pub fn build_cfg_codegen(module: &Module, defer_top_level: bool) -> CfgModule {
 }
 
 fn build_cfg_inner(module: &Module, defer_top_level: bool, faithful: bool) -> CfgModule {
-    let (upvar_procs, proc_params) = prepare_cfg_context(module);
+    let (upvar_procs, proc_params, global_write_procs) = prepare_cfg_context(module);
 
     let new_builder = |inline: bool| {
-        let b = CfgBuilder::new_with_upvars(inline, upvar_procs.clone(), proc_params.clone());
+        let b = CfgBuilder::new_with_upvars(
+            inline,
+            upvar_procs.clone(),
+            proc_params.clone(),
+            global_write_procs.clone(),
+        );
         if faithful {
             b.with_faithful_exceptions()
         } else {
@@ -1137,22 +1226,27 @@ pub fn build_cfg_function(name: &str, script: &Script, inline_loops: bool) -> Fu
 /// hasher); the signature is generalised over `BuildHasher` and rehashes
 /// into the builder's default-hashed maps on entry.
 #[must_use]
-pub fn build_cfg_function_with_upvars<S1, S2>(
+pub fn build_cfg_function_with_upvars<S1, S2, S3>(
     name: &str,
     script: &Script,
     inline_loops: bool,
     upvar_procs: HashMap<String, UpvarInfo, S1>,
     proc_params: HashMap<String, Vec<String>, S2>,
+    global_write_procs: HashMap<String, GlobalWriteInfo, S3>,
 ) -> Function
 where
     S1: std::hash::BuildHasher,
     S2: std::hash::BuildHasher,
+    S3: std::hash::BuildHasher,
 {
     // Rehash into the builder's default-hashed maps (cheap, once per function).
     let upvar_procs: HashMap<String, UpvarInfo> = upvar_procs.into_iter().collect();
     let proc_params: HashMap<String, Vec<String>> = proc_params.into_iter().collect();
-    let mut builder = CfgBuilder::new_with_upvars(inline_loops, upvar_procs, proc_params)
-        .with_faithful_exceptions();
+    let global_write_procs: HashMap<String, GlobalWriteInfo> =
+        global_write_procs.into_iter().collect();
+    let mut builder =
+        CfgBuilder::new_with_upvars(inline_loops, upvar_procs, proc_params, global_write_procs)
+            .with_faithful_exceptions();
     builder.build_function(name, script)
 }
 
@@ -1978,7 +2072,7 @@ mod tests {
     #[test]
     fn prepare_cfg_context_registers_params_for_all_procs() {
         let module = lower_module("proc ::ns::p {a b} { upvar 1 $a x }\nproc q {c} {}");
-        let (_upvar_procs, proc_params) = prepare_cfg_context(&module);
+        let (_upvar_procs, proc_params, _global_write_procs) = prepare_cfg_context(&module);
         assert_eq!(
             proc_params.get("::ns::p"),
             Some(&vec!["a".to_string(), "b".to_string()]),

--- a/rust/tcl-compiler/src/codegen/expressions.rs
+++ b/rust/tcl-compiler/src/codegen/expressions.rs
@@ -27,7 +27,7 @@ use tcl_lexer::backslash_subst;
 use super::values::{parse_braced_scalar_ref, parse_simple_var_ref};
 use super::{CodegenCtx, Op, Operand, bytecode_imm};
 use crate::expr_ast::{BinOp, ExprNode, UnaryOp, render_expr};
-use crate::tcl_expr_eval::{Env, TclValue, eval_tcl_expr};
+use crate::tcl_expr_eval::{Env, TclValue, eval_tcl_expr_with_octal};
 
 /// Operators whose constant integer value `eval_tcl_expr` computes soundly and
 /// which C Tcl folds at compile time: arithmetic, shift, bitwise, logical, and
@@ -248,7 +248,13 @@ impl CodegenCtx<'_> {
             ExprNode::Unary { op, .. } => unaryop_folds(*op),
             _ => false,
         };
-        if foldable && let Some(TclValue::Int(i)) = eval_tcl_expr(node, &Env::new()) {
+        if foldable
+            && let Some(TclValue::Int(i)) = eval_tcl_expr_with_octal(
+                node,
+                &Env::new(),
+                Some(self.registry.leading_zero_is_octal()),
+            )
+        {
             self.push_lit(&i.to_string());
             return true;
         }

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -46,13 +46,13 @@ use crate::taint::{TaintLattice, propagate_taints};
 use crate::type_infer::propagate_types;
 use crate::types::TypeLattice;
 
-/// Module-wide CFG-determining context (upvar summaries + proc params) shared
-/// by every procedure/method build so each rebuilt CFG matches the whole-module
-/// build.  Produced by [`crate::cfg_builder::prepare_cfg_context`].
-type CfgContext = (
-    HashMap<String, crate::cfg_builder::upvar_info::UpvarInfo>,
-    HashMap<String, Vec<String>>,
-);
+/// Module-wide CFG-determining context (upvar summaries + proc params +
+/// global-write summaries) shared by every procedure/method build so each
+/// rebuilt CFG matches the whole-module build.  Produced by
+/// [`crate::cfg_builder::prepare_cfg_context`]; re-exported here under the
+/// same name for this file's existing call sites (the canonical definition
+/// lives in [`crate::cfg_builder::CfgContext`]).
+type CfgContext = crate::cfg_builder::CfgContext;
 
 /// One procedure's **offset-0** baseline-lattice build request, handed to the
 /// [`ProcLatticeCache`] callback by [`CompilationUnit::build_for_memoized`].
@@ -79,6 +79,15 @@ pub struct LatticeRequest<'a> {
     /// Module-wide `proc -> params` context (from
     /// [`crate::cfg_builder::prepare_cfg_context`]).
     pub proc_params: &'a HashMap<String, Vec<String>>,
+    /// Module-wide `proc -> outer-scope write summary` context (from
+    /// [`crate::cfg_builder::prepare_cfg_context`]).
+    pub global_write_procs:
+        &'a HashMap<String, crate::cfg_builder::global_write_info::GlobalWriteInfo>,
+    /// Module-wide variable-trace summary (from
+    /// [`crate::var_observability::scan_module_variable_traces`]), so SCCP
+    /// forces `Overdefined` on a name traced by a *different* proc — not
+    /// just one traced within this procedure's own body.
+    pub module_traces: &'a crate::var_observability::ModuleVariableTraces,
     /// Analysis dialect — selects the registry the lattice pipeline runs under.
     pub dialect: &'a str,
     /// Interprocedural caller-uniform-literal SCCP seeds for this procedure
@@ -223,6 +232,7 @@ impl FunctionUnit {
             registry,
             param_constants,
             &HashSet::new(),
+            None,
         )
     }
 
@@ -235,6 +245,14 @@ impl FunctionUnit {
     /// entry points default to an empty set (no object typing); the
     /// compilation-unit builders ([`Self::build_for`] and friends) source the
     /// real set from [`crate::signature_scan`].
+    ///
+    /// `module_traces` (from
+    /// [`crate::var_observability::scan_module_variable_traces`]) is the
+    /// module-wide variable-trace fact, so a name traced by a *different*
+    /// proc still forces SCCP to `Overdefined` here.  `None` for the
+    /// module-context-free entry points ([`Self::build`],
+    /// [`Self::build_with_param_constants`]) and for isolated single-function
+    /// rebuilds that have no module to scan.
     #[must_use]
     pub fn build_with_param_constants_and_classes(
         name: impl Into<String>,
@@ -248,6 +266,7 @@ impl FunctionUnit {
             >,
         >,
         known_classes: &HashSet<String>,
+        module_traces: Option<&crate::var_observability::ModuleVariableTraces>,
     ) -> Self {
         // Complexity guard (block-count half): a pathologically large body
         // would cost seconds of SSA + dataflow for near-zero findings, so skip
@@ -268,6 +287,7 @@ impl FunctionUnit {
             &ssa,
             param_constants,
             Some(registry.leading_zero_is_octal()),
+            module_traces,
         );
         // Surface `[info exists X]` / `[array exists X]`
         // folds (parameter → exists, never-defined non-param → absent)
@@ -577,6 +597,13 @@ impl CompilationUnit {
         // every passthrough callsite is replaced with a Statement::Block
         // that splices the body inline.
         crate::inline_uplevel::inline_uplevel_passthrough(&mut ir_module, registry);
+        // Module-wide variable-trace fact (F4b): a name traced by *any* proc
+        // in the module must be treated as externally mutable everywhere,
+        // since the relative call order between the proc that installs the
+        // trace and the code that reads/writes the name isn't statically
+        // known. Computed once and shared by every function build below (and
+        // the memoised path), mirroring `call_site_constants`/`known_classes`.
+        let module_traces = crate::var_observability::scan_module_variable_traces(&ir_module);
         let cfg_module = build_cfg(&ir_module, defer_top_level);
         // Collect call-site literal arg values per user proc so each
         // callee's SCCP can fold a param every caller passes the same literal
@@ -601,6 +628,7 @@ impl CompilationUnit {
             registry,
             None,
             &known_class_set,
+            Some(&module_traces),
         );
         // Module-wide upvar/param context — the CFG-determining context a
         // procedure body is rebuilt under.  Computed once and shared by every
@@ -649,7 +677,12 @@ impl CompilationUnit {
             // procedure has a real body, (c) the module context is available,
             // and (d) the seeds encode into the hashable key form.
             let memoised = match (cache.as_mut(), proc, cfg_context.as_ref(), encoded_pc) {
-                (Some(memo), Some(proc), Some((upvar_procs, proc_params)), Some(encoded_pc)) => {
+                (
+                    Some(memo),
+                    Some(proc),
+                    Some((upvar_procs, proc_params, global_write_procs)),
+                    Some(encoded_pc),
+                ) => {
                     // Normalise the body to offset 0 so a shifted-but-unchanged
                     // procedure produces an identical request (memo hit).
                     let mut body = proc.body.clone();
@@ -660,6 +693,8 @@ impl CompilationUnit {
                         params,
                         upvar_procs,
                         proc_params,
+                        global_write_procs,
+                        module_traces: &module_traces,
                         dialect,
                         param_constants: &encoded_pc,
                         known_classes: &known_classes,
@@ -682,14 +717,25 @@ impl CompilationUnit {
                     registry,
                     param_constants.as_ref(),
                     &known_class_set,
+                    Some(&module_traces),
                 )
             });
             procedures.insert(qname.clone(), fu);
         }
-        let methods =
-            Self::build_method_units(&ir_module, cfg_context.as_ref(), &known_class_set, registry);
-        let body_units =
-            Self::build_body_units(&ir_module, cfg_context.as_ref(), &known_class_set, registry);
+        let methods = Self::build_method_units(
+            &ir_module,
+            cfg_context.as_ref(),
+            &known_class_set,
+            registry,
+            &module_traces,
+        );
+        let body_units = Self::build_body_units(
+            &ir_module,
+            cfg_context.as_ref(),
+            &known_class_set,
+            registry,
+            &module_traces,
+        );
         // Build the cross-event scope from the
         // ``::when::*`` subset of procedures.  ``None`` when no
         // ``when`` block is present so non-iRules consumers
@@ -731,11 +777,12 @@ impl CompilationUnit {
         cfg_context: Option<&CfgContext>,
         known_class_set: &HashSet<String>,
         registry: &CommandRegistry,
+        module_traces: &crate::var_observability::ModuleVariableTraces,
     ) -> HashMap<String, FunctionUnit> {
         if ir_module.methods.is_empty() {
             return HashMap::new();
         }
-        let (upvar_procs, proc_params) =
+        let (upvar_procs, proc_params, global_write_procs) =
             cfg_context.expect("cfg_context computed when methods are present");
         ir_module
             .methods
@@ -747,6 +794,7 @@ impl CompilationUnit {
                     true,
                     upvar_procs.clone(),
                     proc_params.clone(),
+                    global_write_procs.clone(),
                 );
                 // Body-byte half of the complexity guard (the block-count
                 // half is applied inside `build`); skip an oversized
@@ -764,6 +812,7 @@ impl CompilationUnit {
                         registry,
                         None,
                         known_class_set,
+                        Some(module_traces),
                     )
                 };
                 (mqname.clone(), fu)
@@ -788,11 +837,12 @@ impl CompilationUnit {
         cfg_context: Option<&CfgContext>,
         known_class_set: &HashSet<String>,
         registry: &CommandRegistry,
+        module_traces: &crate::var_observability::ModuleVariableTraces,
     ) -> HashMap<String, FunctionUnit> {
         if ir_module.body_units.is_empty() {
             return HashMap::new();
         }
-        let (upvar_procs, proc_params) =
+        let (upvar_procs, proc_params, global_write_procs) =
             cfg_context.expect("cfg_context computed when body units are present");
         ir_module
             .body_units
@@ -804,6 +854,7 @@ impl CompilationUnit {
                     true,
                     upvar_procs.clone(),
                     proc_params.clone(),
+                    global_write_procs.clone(),
                 );
                 // Same body-byte complexity guard as procs/methods: a huge
                 // generated lambda body contributes trivial lattices instead of
@@ -819,6 +870,7 @@ impl CompilationUnit {
                         registry,
                         None,
                         known_class_set,
+                        Some(module_traces),
                     )
                 };
                 (qname.clone(), fu)
@@ -1254,7 +1306,7 @@ mod tests {
                    namespace eval ::b { proc x {p2 extra} { set q $p2 } }
 ";
         let m = lower_to_ir_with_config(src, &reg, tcl_lexer::LexerConfig::default());
-        let (_, proc_params) = crate::cfg_builder::prepare_cfg_context(&m);
+        let (_, proc_params, _) = crate::cfg_builder::prepare_cfg_context(&m);
         // `::b::x` sorts after `::a::x`, so the short name `x` deterministically
         // resolves to `::b::x`'s parameters on every run.
         assert_eq!(

--- a/rust/tcl-compiler/src/dataflow_graph.rs
+++ b/rust/tcl-compiler/src/dataflow_graph.rs
@@ -561,7 +561,7 @@ mod tests {
         ssa.blocks.insert(entry_id, entry);
 
         let du = build_def_use_chains(&ssa, Some(&cfg));
-        let sccp_result = sccp(&cfg, &ssa, None, None);
+        let sccp_result = sccp(&cfg, &ssa, None, None, None);
         let g = extract_function_dataflow::<std::collections::hash_map::RandomState>(
             "::top",
             &ssa,

--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -31,6 +31,65 @@ use crate::expr_ast::ExprNode;
 use crate::ir::{Script, Statement};
 use crate::naming::normalise_var_name;
 
+/// The nested script bodies a structured-control-flow statement contains —
+/// every shape a flow-*insensitive* whole-body walk needs to recurse into
+/// (`If`/`For`/`While`/`Foreach`/`Catch`/`Block`/`UpFrame`/`Switch`/`Try`).
+/// `pub(crate)` so both [`crate::cfg_builder::global_write_info`] (per-proc
+/// global-write summaries) and [`crate::var_observability`] (module-wide
+/// trace-target summaries) share one recursive-descent shape instead of each
+/// re-deriving it.
+///
+/// Distinct from [`collect_defs_from_script`]'s per-statement match: that
+/// walk also extracts *defs* at each nesting level (iteration variables,
+/// catch/try result vars) as part of the same pass, so it isn't a drop-in
+/// replacement for a caller that only wants "which scripts nest inside this
+/// statement".
+#[must_use]
+pub(crate) fn nested_bodies(stmt: &Statement) -> Vec<&Script> {
+    match stmt {
+        Statement::If {
+            clauses, else_body, ..
+        } => {
+            let mut bodies: Vec<&Script> = clauses.iter().map(|c| &c.body).collect();
+            if let Some(e) = else_body {
+                bodies.push(e);
+            }
+            bodies
+        }
+        Statement::For {
+            init, next, body, ..
+        } => vec![init, next, body],
+        Statement::While { body, .. }
+        | Statement::Foreach { body, .. }
+        | Statement::Catch { body, .. }
+        | Statement::Block { body, .. }
+        | Statement::UpFrame { body, .. } => vec![body],
+        Statement::Switch {
+            arms, default_body, ..
+        } => {
+            let mut bodies: Vec<&Script> = arms.iter().filter_map(|a| a.body.as_ref()).collect();
+            if let Some(d) = default_body {
+                bodies.push(d);
+            }
+            bodies
+        }
+        Statement::Try {
+            body,
+            handlers,
+            finally_body,
+            ..
+        } => {
+            let mut bodies = vec![body];
+            bodies.extend(handlers.iter().map(|h| &h.body));
+            if let Some(f) = finally_body {
+                bodies.push(f);
+            }
+            bodies
+        }
+        _ => Vec::new(),
+    }
+}
+
 /// Collect all variable names defined anywhere inside a script (recursive).
 ///
 /// Walks through structured IR nodes (`If`, `For`, `While`, `Foreach`,

--- a/rust/tcl-compiler/src/optimiser/branch_folding.rs
+++ b/rust/tcl-compiler/src/optimiser/branch_folding.rs
@@ -185,9 +185,16 @@ fn propagate_into_branches(ctx: &mut PassContext<'_>, fu: &FunctionUnit) {
 
         // O115: a branch condition that is itself a redundant `[expr {…}]`
         // wrapper (`if {[expr {$x}]} …`) unwraps to its inner expression.
-        // Checked before the constant cascade.
+        // Checked before the constant cascade. Unlike the rest of this
+        // cascade — which folds the condition text using Tcl's own
+        // internal expr evaluation (never a command dispatch, so
+        // `rename`/`interp alias`-ing `expr` cannot affect it) — this
+        // specific rewrite assumes the embedded `[expr {…}]` substring is
+        // a genuine command substitution dispatching to builtin `expr`,
+        // so it alone needs the trust gate.
         if let Some(unwrapped) = try_unwrap_expr_in_expr(inner)
             && unwrapped != inner
+            && ctx.command_mutations.trusts("expr")
         {
             ctx.report(Optimisation::new(
                 DiagCode::O115,
@@ -985,5 +992,48 @@ mod tests {
             .find(|o| o.code == DiagCode::O115)
             .expect("expected an O115 unwrap on the branch condition");
         assert_eq!(o115.replacement, "{$x}");
+    }
+
+    #[test]
+    fn renamed_expr_blocks_branch_condition_unwrap() {
+        // FP guard: `if {[expr {$x}]} …` embeds a genuine command
+        // substitution — once `expr` is renamed anywhere in the module,
+        // `[expr {$x}]` no longer means "evaluate $x as an expression", so
+        // the O115 unwrap must not fire.
+        let source = "rename expr real_expr\nif {[expr {$x}]} { puts a } else { puts b }";
+        let reg = registry();
+        let cu = CompilationUnit::build_for(source, &reg, false);
+        let mut ctx = build_ctx(&cu.source);
+        ctx.command_mutations =
+            crate::command_binding::scan_module_command_mutations(&cu.ir_module, &reg);
+        super::super::run_passes(&mut ctx, &cu, &[PassId::BranchFolding]);
+        assert!(
+            ctx.optimisations.iter().all(|o| o.code != DiagCode::O115),
+            "must not unwrap through a renamed expr: {:?}",
+            ctx.optimisations,
+        );
+    }
+
+    #[test]
+    fn plain_branch_condition_fold_unaffected_by_expr_rename() {
+        // TN/control: `if`/`while` conditions are evaluated by Tcl's own
+        // internal expr engine, never by dispatching a command literally
+        // named "expr" — so renaming `expr` elsewhere in the module must
+        // NOT block a plain (no explicit `[expr {…}]` substring) constant
+        // branch fold.
+        let source = "rename expr real_expr\nif {2 + 2 == 4} { puts a } else { puts b }";
+        let reg = registry();
+        let cu = CompilationUnit::build_for(source, &reg, false);
+        let mut ctx = build_ctx(&cu.source);
+        ctx.command_mutations =
+            crate::command_binding::scan_module_command_mutations(&cu.ir_module, &reg);
+        super::super::run_passes(&mut ctx, &cu, &PassId::all());
+        assert!(
+            ctx.optimisations
+                .iter()
+                .any(|o| o.code == DiagCode::O101 || o.code == DiagCode::O112),
+            "plain condition fold must be unaffected by an unrelated expr rename: {:?}",
+            ctx.optimisations,
+        );
     }
 }

--- a/rust/tcl-compiler/src/optimiser/expr_simplify.rs
+++ b/rust/tcl-compiler/src/optimiser/expr_simplify.rs
@@ -57,7 +57,9 @@
 use crate::compilation_unit::CompilationUnit;
 use crate::expr_ast::ExprNode;
 use crate::ir::{Script, Statement};
-use crate::tcl_expr_eval::{Env, eval_tcl_expr, format_tcl_value};
+use crate::tcl_expr_eval::{
+    Env, eval_tcl_expr_with_octal, format_tcl_value, leading_zero_is_octal,
+};
 use tcl_core_types::DiagCode;
 use tcl_lexer::Span;
 
@@ -68,79 +70,76 @@ use super::{Optimisation, PassContext};
 /// in `cu`.
 pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
     use super::helpers::expr_simplify::operand_types;
+    let procedures = &cu.ir_module.procedures;
     let top_numeric = operand_types(&cu.top_level);
-    walk_script(
-        ctx,
-        &cu.ir_module.top_level,
-        ctx.dialect,
-        Some(&top_numeric),
-    );
+    walk_script(ctx, &cu.ir_module.top_level, Some(&top_numeric), procedures);
     for (qname, proc) in &cu.ir_module.procedures {
         let numeric = cu.procedures.get(qname).map(operand_types);
-        walk_script(ctx, &proc.body, ctx.dialect, numeric.as_ref());
+        walk_script(ctx, &proc.body, numeric.as_ref(), procedures);
     }
 }
+
+type Procedures = std::collections::HashMap<String, crate::ir::Procedure>;
 
 fn walk_script(
     ctx: &mut PassContext<'_>,
     script: &Script,
-    dialect: Option<&str>,
     numeric: NumericCtx<'_>,
+    procedures: &Procedures,
 ) {
     for stmt in &script.statements {
-        walk_statement(ctx, stmt, dialect, numeric);
+        walk_statement(ctx, stmt, numeric, procedures);
     }
-    let _ = dialect;
 }
 
 fn walk_statement(
     ctx: &mut PassContext<'_>,
     stmt: &Statement,
-    dialect: Option<&str>,
     numeric: NumericCtx<'_>,
+    procedures: &Procedures,
 ) {
     match stmt {
         Statement::ExprEval { span, expr } => {
-            try_rewrite_expr(ctx, *span, expr);
+            try_rewrite_expr(ctx, *span, expr, procedures);
         }
         Statement::AssignExpr {
             span, name, expr, ..
         } => {
-            try_rewrite_assign_expr(ctx, *span, name, expr, numeric);
+            try_rewrite_assign_expr(ctx, *span, name, expr, numeric, procedures);
         }
         Statement::If {
             clauses, else_body, ..
         } => {
             for c in clauses {
-                walk_script(ctx, &c.body, dialect, numeric);
+                walk_script(ctx, &c.body, numeric, procedures);
             }
             if let Some(body) = else_body {
-                walk_script(ctx, body, dialect, numeric);
+                walk_script(ctx, body, numeric, procedures);
             }
         }
         Statement::While { body, .. } | Statement::Catch { body, .. } => {
-            walk_script(ctx, body, dialect, numeric);
+            walk_script(ctx, body, numeric, procedures);
         }
         Statement::For {
             init, next, body, ..
         } => {
-            walk_script(ctx, init, dialect, numeric);
-            walk_script(ctx, body, dialect, numeric);
-            walk_script(ctx, next, dialect, numeric);
+            walk_script(ctx, init, numeric, procedures);
+            walk_script(ctx, body, numeric, procedures);
+            walk_script(ctx, next, numeric, procedures);
         }
-        Statement::Foreach { body, .. } => walk_script(ctx, body, dialect, numeric),
+        Statement::Foreach { body, .. } => walk_script(ctx, body, numeric, procedures),
         Statement::Try {
             body,
             handlers,
             finally_body,
             ..
         } => {
-            walk_script(ctx, body, dialect, numeric);
+            walk_script(ctx, body, numeric, procedures);
             for h in handlers {
-                walk_script(ctx, &h.body, dialect, numeric);
+                walk_script(ctx, &h.body, numeric, procedures);
             }
             if let Some(fb) = finally_body {
-                walk_script(ctx, fb, dialect, numeric);
+                walk_script(ctx, fb, numeric, procedures);
             }
         }
         Statement::Switch {
@@ -148,11 +147,11 @@ fn walk_statement(
         } => {
             for a in arms {
                 if let Some(b) = &a.body {
-                    walk_script(ctx, b, dialect, numeric);
+                    walk_script(ctx, b, numeric, procedures);
                 }
             }
             if let Some(db) = default_body {
-                walk_script(ctx, db, dialect, numeric);
+                walk_script(ctx, db, numeric, procedures);
             }
         }
         _ => {}
@@ -175,9 +174,11 @@ fn try_rewrite_assign_expr(
     name: &str,
     expr: &ExprNode,
     numeric: NumericCtx<'_>,
+    procedures: &Procedures,
 ) {
     use super::helpers::expr_simplify::{
-        expr_has_command_subst, instcombine_expr_typed, try_strength_reduce_expr_typed,
+        expr_has_command_subst, expr_uses_shadowed_mathfunc, instcombine_expr_typed,
+        try_strength_reduce_expr_typed,
     };
     use super::helpers::spans::full_rewrite_span;
 
@@ -189,10 +190,25 @@ fn try_rewrite_assign_expr(
     if expr_has_command_subst(expr) {
         return;
     }
+    // All three rewrites below (full fold, instcombine, strength-reduce)
+    // assume `[expr {…}]` still has builtin arithmetic semantics — a
+    // `rename`/`interp alias`/redefining `proc` anywhere in the module
+    // invalidates that, so decline outright.
+    if !ctx.command_mutations.trusts("expr") {
+        return;
+    }
 
-    // 1. Full constant fold.
+    // 1. Full constant fold. Only when no math-function call in the
+    // expression is shadowed by a user-defined `::tcl::mathfunc::<name>`
+    // proc — evaluating it would use builtin semantics that no longer
+    // apply. (instcombine / strength-reduce below are pure syntactic
+    // identities that don't evaluate a call's result, so they're
+    // unaffected by a shadowed math function.)
     let env = Env::new();
-    if let Some(val) = eval_tcl_expr(expr, &env) {
+    let octal = ctx.dialect.map(leading_zero_is_octal);
+    if !expr_uses_shadowed_mathfunc(expr, procedures)
+        && let Some(val) = eval_tcl_expr_with_octal(expr, &env, octal)
+    {
         let folded = format_tcl_value(val);
         let original = crate::expr_ast::render_expr(expr);
         if folded != original.trim() {
@@ -264,7 +280,20 @@ fn collapse_assign_expr_wrapper(name: &str, simplified: &str) -> String {
     format!("set {name} [expr {{{simplified}}}]")
 }
 
-fn try_rewrite_expr(ctx: &mut PassContext<'_>, span: Span, expr: &ExprNode) {
+fn try_rewrite_expr(
+    ctx: &mut PassContext<'_>,
+    span: Span,
+    expr: &ExprNode,
+    procedures: &Procedures,
+) {
+    // Both rewrites below assume this statement's `expr` — and, for the
+    // O115 unwrap, any nested `[expr {…}]` inside it — is the untouched
+    // builtin. A `rename`/`interp alias`/redefining `proc` anywhere in the
+    // module invalidates that assumption for every occurrence, so decline
+    // outright rather than fold with semantics that no longer apply.
+    if !ctx.command_mutations.trusts("expr") {
+        return;
+    }
     // O115: unwrap `[expr {…}]` in expression context. Detected
     // from the expression AST so the rewrite sees the parsed
     // form (the source span on `ExprEval` does not always cover
@@ -290,7 +319,10 @@ fn try_rewrite_expr(ctx: &mut PassContext<'_>, span: Span, expr: &ExprNode) {
     if matches!(expr, ExprNode::Raw { .. }) {
         return;
     }
-    if let Some(val) = eval_tcl_expr(expr, &env) {
+    let octal = ctx.dialect.map(leading_zero_is_octal);
+    if !super::helpers::expr_simplify::expr_uses_shadowed_mathfunc(expr, procedures)
+        && let Some(val) = eval_tcl_expr_with_octal(expr, &env, octal)
+    {
         let folded = format_tcl_value(val);
         // Compare against the original body text slice when it is
         // recoverable; the outer span covers the whole `expr …`
@@ -328,6 +360,20 @@ mod tests {
         ctx.optimisations
     }
 
+    /// Like [`run_pass`] but populates `ctx.command_mutations` from the
+    /// whole module, the way the real pipeline (`manager::optimise_unit_raw`)
+    /// does — needed to exercise the `expr`-redefinition trust gate, since
+    /// a bare `PassContext::new` defaults to "trusts everything".
+    fn run_pass_with_mutations(source: &str) -> Vec<Optimisation> {
+        let reg = registry();
+        let cu = CompilationUnit::build_for(source, &reg, false);
+        let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
+        ctx.command_mutations =
+            crate::command_binding::scan_module_command_mutations(&cu.ir_module, &reg);
+        run(&mut ctx, &cu);
+        ctx.optimisations
+    }
+
     #[test]
     fn constant_expr_folds_to_literal() {
         let opts = run_pass("expr {1 + 2}");
@@ -357,6 +403,77 @@ mod tests {
             opts.iter()
                 .all(|o| o.code != DiagCode::O101 && o.code != DiagCode::O115),
             "unexpected rewrite: {opts:?}",
+        );
+    }
+
+    #[test]
+    fn renamed_expr_is_not_folded() {
+        // FP guard: once `expr` has been renamed anywhere in the module,
+        // `expr {1 + 2}` no longer means "evaluate the arithmetic
+        // expression" — it means "call whatever `expr` now resolves to"
+        // (here, nothing — the builtin was moved to `real_expr`). O101
+        // must not fold it as if the builtin were still in place.
+        let opts = run_pass_with_mutations("rename expr real_expr\nexpr {1 + 2}");
+        assert!(
+            opts.iter().all(|o| o.code != DiagCode::O101),
+            "must not fold a renamed expr: {opts:?}",
+        );
+    }
+
+    #[test]
+    fn ordinary_mathfunc_call_still_folds() {
+        // TN/control: no override present — abs(-5) folds as usual.
+        let opts = run_pass("expr {abs(-5)}");
+        assert!(
+            opts.iter()
+                .any(|o| o.code == DiagCode::O101 && o.replacement == "5"),
+            "expected O101 fold of abs(-5), got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn shadowed_mathfunc_call_is_not_folded() {
+        // FP guard: `proc ::tcl::mathfunc::abs` shadows the builtin `abs`
+        // math function everywhere in the module — O101 must not fold
+        // `abs(-5)` to `5` using builtin semantics that no longer apply.
+        let opts = run_pass("proc ::tcl::mathfunc::abs {x} { return 999 }\nexpr {abs(-5)}");
+        assert!(
+            opts.iter().all(|o| o.code != DiagCode::O101),
+            "must not fold a shadowed math function: {opts:?}",
+        );
+    }
+
+    #[test]
+    fn shadowed_mathfunc_in_assign_expr_is_not_folded() {
+        // Same guard, `set x [expr {…}]` form.
+        let opts = run_pass("proc ::tcl::mathfunc::abs {x} { return 999 }\nset v [expr {abs(-5)}]");
+        assert!(
+            opts.iter().all(|o| o.code != DiagCode::O101),
+            "must not fold a shadowed math function in AssignExpr: {opts:?}",
+        );
+    }
+
+    #[test]
+    fn ordinary_expr_still_folds_under_mutation_scan() {
+        // TN/TP control: a module with *no* rename/alias touching `expr`
+        // still folds normally even when `command_mutations` is populated
+        // from a real scan (proves the gate isn't over-broad).
+        let opts = run_pass_with_mutations("expr {1 + 2}");
+        assert!(
+            opts.iter()
+                .any(|o| o.code == DiagCode::O101 && o.replacement == "3"),
+            "expected O101 fold under an unrelated mutation scan, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn renamed_expr_nested_unwrap_is_not_rewritten() {
+        // FP guard: the O115 redundant-nested-expr unwrap also assumes
+        // both layers of `[expr {…}]` are builtin calls.
+        let opts = run_pass_with_mutations("rename expr real_expr\nexpr {[expr {$x + 1}]}");
+        assert!(
+            opts.iter().all(|o| o.code != DiagCode::O115),
+            "must not unwrap through a renamed expr: {opts:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
+++ b/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
@@ -55,7 +55,9 @@ use crate::compilation_unit::FunctionUnit;
 use crate::expr_ast::{BinOp, ExprNode, ExprOffset, render_expr};
 use crate::expr_parser::parse_expr;
 use crate::naming::normalise_var_name;
-use crate::tcl_expr_eval::{Env, eval_tcl_expr, format_tcl_value};
+use crate::tcl_expr_eval::{
+    Env, eval_tcl_expr_with_octal, format_tcl_value, leading_zero_is_octal,
+};
 use crate::types::{TclType, TypeKind, TypeLattice};
 
 /// Operand type facts for the current function: which variable names are
@@ -184,15 +186,33 @@ fn node_provably_integer(node: &ExprNode, numeric: NumericCtx<'_>) -> bool {
     }
 }
 
-/// Whether the (delimiter-stripped) text of an `expr` string literal parses
-/// as an integer or float — the SCCP-inlined-constant case.
-fn is_numeric_string(text: &str) -> bool {
-    let t = text
-        .trim()
+/// Strip the surrounding `"…"` / `{…}` delimiters (if any) from an `expr`
+/// literal or a propagated constant's value text, for the numeric
+/// classifiers below.
+fn strip_literal_delims(text: &str) -> &str {
+    text.trim()
         .trim_start_matches(['"', '{'])
         .trim_end_matches(['"', '}'])
-        .trim();
-    !t.is_empty() && (t.parse::<i64>().is_ok() || t.parse::<f64>().is_ok())
+        .trim()
+}
+
+/// Whether the (delimiter-stripped) text of an `expr` string literal or a
+/// propagated constant's value parses as a Tcl number — the SCCP-inlined-
+/// constant case. Backed by the shared `tcl_syntax::number` grammar (the
+/// same one the const-folder and [`is_integer_string`] use) rather than
+/// Rust's own `str::parse`, which rejects Tcl's `0x`/`0o`/`0b` prefixes and
+/// `_` digit separators — a hex/octal/binary constant is a real Tcl number
+/// and must classify as one here, or two callers (the O120 eq/ne string-
+/// compare promotion gate and the O100/O101 constant-substitution binder)
+/// wrongly treat it as "provably not a number".
+fn is_numeric_string(text: &str) -> bool {
+    use tcl_syntax::number::Number;
+    let t = strip_literal_delims(text);
+    !t.is_empty()
+        && matches!(
+            tcl_syntax::number::parse_whole(t),
+            Some(Number::Int(_) | Number::Big { .. } | Number::Double(_) | Number::Nan { .. })
+        )
 }
 
 /// Whether the (delimiter-stripped) text of an `expr` literal parses as a Tcl
@@ -201,13 +221,8 @@ fn is_numeric_string(text: &str) -> bool {
 /// so it agrees with the const-folder.
 fn is_integer_string(text: &str) -> bool {
     use tcl_syntax::number::Number;
-    let t = text
-        .trim()
-        .trim_start_matches(['"', '{'])
-        .trim_end_matches(['"', '}'])
-        .trim();
     matches!(
-        tcl_syntax::number::parse_whole(t),
+        tcl_syntax::number::parse_whole(strip_literal_delims(text)),
         Some(Number::Int(_) | Number::Big { .. })
     )
 }
@@ -234,7 +249,7 @@ pub fn try_fold_expr(expr: &str, dialect: Option<&str>) -> Option<String> {
         return None;
     }
     let env = Env::new();
-    let value = eval_tcl_expr(&node, &env)?;
+    let value = eval_tcl_expr_with_octal(&node, &env, dialect.map(leading_zero_is_octal))?;
     let rendered = format_tcl_value(value);
     if rendered == trimmed {
         return None;
@@ -280,7 +295,7 @@ pub fn try_fold_expr_with_constants<S: std::hash::BuildHasher>(
             env.insert(name.clone(), EnvValue::Str(value.clone()));
         }
     }
-    let value = eval_tcl_expr(&node, &env)?;
+    let value = eval_tcl_expr_with_octal(&node, &env, dialect.map(leading_zero_is_octal))?;
     let rendered = format_tcl_value(value);
     if rendered == trimmed {
         return None;
@@ -402,8 +417,12 @@ pub fn substitute_expr_constants<S: std::hash::BuildHasher>(
     }
 }
 
+/// Whether `text` is safe to inline as a bare (unquoted) token when
+/// substituting a constant into `expr` text. Delegates to
+/// [`is_numeric_string`] — the same Tcl-number grammar, not a locally
+/// re-implemented Rust-`str::parse` approximation.
 fn is_numeric_literal(text: &str) -> bool {
-    text.trim().parse::<i64>().is_ok() || text.trim().parse::<f64>().is_ok()
+    is_numeric_string(text)
 }
 
 // instcombine / strength-reduce / strlen / streq
@@ -1402,6 +1421,54 @@ pub fn expr_has_command_subst(node: &ExprNode) -> bool {
     }
 }
 
+/// Return `true` when `node` invokes a Tcl math function (`abs(...)`,
+/// `max(...)`, …) whose name is shadowed by a user-defined
+/// `::tcl::mathfunc::<name>` proc anywhere in the module.
+///
+/// Math functions are not `CommandSpec`s — they live in the shared
+/// `tcl_syntax::expr::mathfunc` dispatch table the const-folder and the
+/// runtime both consume — so there is no registry purity/redefinition fact
+/// to consult the way [`crate::command_binding::ModuleCommandMutations`]
+/// covers ordinary commands. The module's own `proc` definitions are the
+/// only source of truth: real Tcl compiles `abs(x)` to a `tcl::mathfunc::abs`
+/// command invocation and only falls back to the C builtin when nothing
+/// shadows it, so folding `abs(-5)` to `5` is unsound whenever
+/// `::tcl::mathfunc::abs` has been (re)defined.
+#[must_use]
+pub fn expr_uses_shadowed_mathfunc<S: std::hash::BuildHasher>(
+    node: &ExprNode,
+    procedures: &std::collections::HashMap<String, crate::ir::Procedure, S>,
+) -> bool {
+    match node {
+        ExprNode::Call { function, args, .. } => {
+            let key = format!("::tcl::mathfunc::{}", function.to_ascii_lowercase());
+            procedures.contains_key(&key)
+                || args
+                    .iter()
+                    .any(|a| expr_uses_shadowed_mathfunc(a, procedures))
+        }
+        ExprNode::Binary { left, right, .. } => {
+            expr_uses_shadowed_mathfunc(left, procedures)
+                || expr_uses_shadowed_mathfunc(right, procedures)
+        }
+        ExprNode::Unary { operand, .. } => expr_uses_shadowed_mathfunc(operand, procedures),
+        ExprNode::Ternary {
+            condition,
+            true_branch,
+            false_branch,
+        } => {
+            expr_uses_shadowed_mathfunc(condition, procedures)
+                || expr_uses_shadowed_mathfunc(true_branch, procedures)
+                || expr_uses_shadowed_mathfunc(false_branch, procedures)
+        }
+        ExprNode::Literal { .. }
+        | ExprNode::Var { .. }
+        | ExprNode::Raw { .. }
+        | ExprNode::String { .. }
+        | ExprNode::Command { .. } => false,
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -1658,6 +1725,46 @@ mod tests {
         assert!(is_numeric_string("\"3.5\""));
         assert!(!is_numeric_string("\"abc\""));
         assert!(!is_numeric_string(""));
+    }
+
+    #[test]
+    fn is_numeric_string_recognises_non_decimal_tcl_numbers() {
+        // TP: hex/octal/binary/underscore-separated forms are real Tcl
+        // numbers (tclsh: 0x1a==26, 0o17==15, 0b101==5, 1_000==1000) — the
+        // shared `tcl_syntax::number` grammar accepts them even though
+        // Rust's own `str::parse::<i64>/<f64>` (the previous
+        // implementation) rejects all four.
+        for text in ["0x1a", "0o17", "0b101", "1_000", "\"0x1a\""] {
+            assert!(is_numeric_string(text), "{text:?} should be numeric");
+        }
+        // TN control: still rejects genuine non-numbers.
+        assert!(!is_numeric_string("hello"));
+        assert!(!is_numeric_string("0xzz"));
+    }
+
+    #[test]
+    fn is_numeric_literal_agrees_with_is_numeric_string() {
+        // is_numeric_literal (the substitute_expr_constants bare-vs-quoted
+        // gate) now delegates to the same grammar, so a hex constant
+        // inlines bare instead of being needlessly quoted.
+        assert!(is_numeric_literal("0x1a"));
+        assert!(!is_numeric_literal("hello"));
+    }
+
+    #[test]
+    fn hex_string_literal_is_not_wrongly_promoted_to_streq() {
+        // FP guard: `"0x1a" == $y` must NOT promote to `eq` (O120) — 0x1a
+        // is a genuine Tcl number (tclsh: `expr {"0x1a" == 26}` -> 1, a
+        // numeric compare), so treating it as "provably non-numeric" would
+        // silently turn a numeric comparison into a string comparison.
+        // Before the fix, `is_numeric_string("0x1a")` was false, so
+        // `node_provably_non_numeric` wrongly returned true for this
+        // literal and the eq/ne promotion fired.
+        let (out, changed) = try_eq_ne_string_compare_simplify_expr("\"0x1a\" == $y");
+        assert!(
+            !changed,
+            "hex literal must not be promoted to string eq, got {out:?}"
+        );
     }
 
     // try_strlen_simplify_expr

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -743,12 +743,21 @@ fn walk_statement(
                 expr.as_ref(),
                 *braced,
                 constants,
+                &cu.ir_module.procedures,
             );
         }
         Statement::AssignExpr {
             span, name, expr, ..
         } => {
-            try_substitute_assign_expr(ctx, *span, name, expr, constants, numeric);
+            try_substitute_assign_expr(
+                ctx,
+                *span,
+                name,
+                expr,
+                constants,
+                numeric,
+                &cu.ir_module.procedures,
+            );
         }
         Statement::If {
             clauses, else_body, ..
@@ -818,8 +827,8 @@ fn evaluate_proc_with_constants(
     octal: Option<bool>,
 ) -> Option<ConstValue> {
     let seed = seed_params_from_args(params, args)?;
-    let result = crate::sccp::sccp(&callee.cfg, &callee.ssa, Some(&seed), octal);
-    resolve_return_constant(callee, &result)
+    let result = crate::sccp::sccp(&callee.cfg, &callee.ssa, Some(&seed), octal, None);
+    resolve_return_constant(callee, &result, octal)
 }
 
 /// Bind each of `params` to its constant call argument for the
@@ -897,6 +906,7 @@ fn const_value_text(cv: &ConstValue) -> String {
 fn resolve_return_constant(
     fu: &FunctionUnit,
     result: &crate::sccp::SccpResult,
+    octal: Option<bool>,
 ) -> Option<ConstValue> {
     use crate::cfg::Terminator;
     let preds = fu.cfg.predecessors();
@@ -906,10 +916,15 @@ fn resolve_return_constant(
             continue;
         }
         let folded = match &block.terminator {
-            Some(Terminator::Return { value, expr, .. }) => {
-                fold_return_under_lattice(fu, *bn, value.as_deref(), expr.as_ref(), result)?
-            }
-            None => resolve_fallthrough_value(fu, *bn, result, &preds)?,
+            Some(Terminator::Return { value, expr, .. }) => fold_return_under_lattice(
+                fu,
+                *bn,
+                value.as_deref(),
+                expr.as_ref(),
+                result,
+                octal,
+            )?,
+            None => resolve_fallthrough_value(fu, *bn, result, &preds, octal)?,
             Some(_) => continue, // Goto / Branch — not an exit point
         };
         match &found {
@@ -950,6 +965,7 @@ fn resolve_fallthrough_value(
         crate::cfg::BlockId,
         std::collections::HashSet<crate::cfg::BlockId>,
     >,
+    octal: Option<bool>,
 ) -> Option<ConstValue> {
     let mut executable_preds = preds
         .get(&bn)
@@ -962,7 +978,7 @@ fn resolve_fallthrough_value(
     }
     let block = fu.cfg.blocks.get(pred)?;
     let last = block.statements.last()?;
-    fold_tail_statement_under_lattice(fu, *pred, last, result)
+    fold_tail_statement_under_lattice(fu, *pred, last, result, octal)
 }
 
 /// Resolve the value Tcl's "result of the last executed command" rule
@@ -979,9 +995,10 @@ fn fold_tail_statement_under_lattice(
     bn: crate::cfg::BlockId,
     stmt: &Statement,
     result: &crate::sccp::SccpResult,
+    octal: Option<bool>,
 ) -> Option<ConstValue> {
     match stmt {
-        Statement::ExprEval { expr, .. } => fold_expr_under_lattice(fu, bn, expr, result),
+        Statement::ExprEval { expr, .. } => fold_expr_under_lattice(fu, bn, expr, result, octal),
         Statement::AssignConst { name, .. }
         | Statement::AssignExpr { name, .. }
         | Statement::AssignValue { name, .. }
@@ -999,6 +1016,7 @@ fn fold_return_under_lattice(
     value: Option<&str>,
     expr: Option<&crate::expr_ast::ExprNode>,
     result: &crate::sccp::SccpResult,
+    octal: Option<bool>,
 ) -> Option<ConstValue> {
     let value = value?.trim();
 
@@ -1013,7 +1031,7 @@ fn fold_return_under_lattice(
     }
 
     // Path 3 — `return [expr {…}]`.
-    fold_expr_under_lattice(fu, bn, expr?, result)
+    fold_expr_under_lattice(fu, bn, expr?, result, octal)
 }
 
 /// Resolve a simple `$name` variable reference to its SCCP-proved constant
@@ -1073,8 +1091,9 @@ fn fold_expr_under_lattice(
     bn: crate::cfg::BlockId,
     expr: &crate::expr_ast::ExprNode,
     result: &crate::sccp::SccpResult,
+    octal: Option<bool>,
 ) -> Option<ConstValue> {
-    use crate::tcl_expr_eval::{Env, eval_tcl_expr};
+    use crate::tcl_expr_eval::{Env, eval_tcl_expr_with_octal};
 
     let mut env: Env = Env::new();
     if let Some(ssa_block) = fu.ssa.blocks.get(&bn) {
@@ -1088,7 +1107,7 @@ fn fold_expr_under_lattice(
             }
         }
     }
-    let v = eval_tcl_expr(expr, &env)?;
+    let v = eval_tcl_expr_with_octal(expr, &env, octal)?;
     Some(crate::sccp::tcl_value_to_const(v))
 }
 
@@ -1268,14 +1287,21 @@ fn try_fold_return_terminator(
     expr: Option<&crate::expr_ast::ExprNode>,
     _braced: bool,
     constants: &std::collections::HashMap<String, String>,
+    procedures: &std::collections::HashMap<String, crate::ir::Procedure>,
 ) {
     use crate::naming::normalise_var_name;
 
     // O115: `return [expr {[expr {E}]}]` → `return [expr {E}]`. Checked
-    // before the `expr`-gate below because the return value of a cmd-sub
-    // also populates `expr`, yet the redundant-nested-expr collapse
-    // operates on the raw value text.
-    if let Some(collapsed) = value.and_then(|raw| o115_redundant_nested_expr(raw.trim())) {
+    // before the `expr.is_some()` early-return below because the return
+    // value of a cmd-sub also populates `expr`, yet the redundant-nested-
+    // expr collapse operates on the raw value text. Also requires `expr`
+    // to be untouched anywhere in the module (mirrors the O129
+    // builtin-fold trust check) — both the outer and inner `[expr {…}]`
+    // are genuine command substitutions, and a shadowed `expr` no longer
+    // has builtin semantics.
+    if ctx.command_mutations.trusts("expr")
+        && let Some(collapsed) = value.and_then(|raw| o115_redundant_nested_expr(raw.trim()))
+    {
         ctx.report(Optimisation::new(
             DiagCode::O115,
             "Remove redundant nested expr",
@@ -1286,10 +1312,13 @@ fn try_fold_return_terminator(
     }
 
     // O101: a constant `[expr {…}]` return value folds to its value
-    // (`return [expr {1 + 2}]` → `return 3`).
+    // (`return [expr {1 + 2}]` → `return 3`). Same trust requirement as
+    // the O115 check above — a shadowed `expr` no longer has builtin
+    // semantics and must not be folded as if it did.
     if let Some(inner) = value
         .map(str::trim)
         .and_then(|t| t.strip_prefix('[').and_then(|s| s.strip_suffix(']')))
+        && ctx.command_mutations.trusts("expr")
     {
         let mut parts = inner.splitn(2, char::is_whitespace);
         if parts.next() == Some("expr") {
@@ -1298,7 +1327,10 @@ fn try_fold_return_terminator(
                 .strip_prefix('{')
                 .and_then(|b| b.strip_suffix('}'))
                 .unwrap_or(body);
-            if let Some(folded) = super::helpers::expr_simplify::try_fold_expr(body, ctx.dialect)
+            let body_node = crate::expr_parser::parse_expr(body, ctx.dialect);
+            if !super::helpers::expr_simplify::expr_uses_shadowed_mathfunc(&body_node, procedures)
+                && let Some(folded) =
+                    super::helpers::expr_simplify::try_fold_expr(body, ctx.dialect)
                 && !folded.contains(['$', '['])
             {
                 ctx.report(Optimisation::new(
@@ -1359,18 +1391,36 @@ fn try_substitute_assign_expr(
     expr: &crate::expr_ast::ExprNode,
     constants: &std::collections::HashMap<String, String>,
     numeric: NumericCtx<'_>,
+    procedures: &std::collections::HashMap<String, crate::ir::Procedure>,
 ) {
     use super::helpers::expr_simplify::{
-        expr_has_command_subst, instcombine_expr_typed, substitute_expr_constants,
+        expr_has_command_subst, expr_uses_shadowed_mathfunc, instcombine_expr_typed,
+        substitute_expr_constants,
     };
     use super::helpers::spans::full_rewrite_span;
     use crate::expr_parser::parse_expr;
-    use crate::tcl_expr_eval::{Env, eval_tcl_expr, format_tcl_value};
+    use crate::tcl_expr_eval::{
+        Env, eval_tcl_expr_with_octal, format_tcl_value, leading_zero_is_octal,
+    };
 
     if matches!(expr, crate::expr_ast::ExprNode::Raw { .. }) {
         return;
     }
     if expr_has_command_subst(expr) {
+        return;
+    }
+    // `expr` renamed/aliased anywhere in the module means the source's
+    // `[expr {…}]` no longer has builtin semantics — do not propagate a
+    // rewrite computed as if it did.
+    if !ctx.command_mutations.trusts("expr") {
+        return;
+    }
+    // A math-function call in the expression shadowed by a user-defined
+    // `::tcl::mathfunc::<name>` proc means folding it would use builtin
+    // semantics that no longer apply. Substitution doesn't change which
+    // function names are called, so checking the pre-substitution AST is
+    // sufficient.
+    if expr_uses_shadowed_mathfunc(expr, procedures) {
         return;
     }
     let expr_text = crate::expr_ast::render_expr(expr);
@@ -1385,7 +1435,8 @@ fn try_substitute_assign_expr(
     // keep the expression wrapper around the substituted text.
     let parsed = parse_expr(&result.text, ctx.dialect);
     let env = Env::new();
-    if let Some(val) = eval_tcl_expr(&parsed, &env) {
+    let octal = ctx.dialect.map(leading_zero_is_octal);
+    if let Some(val) = eval_tcl_expr_with_octal(&parsed, &env, octal) {
         let folded = format_tcl_value(val);
         let needs_quoting = folded.is_empty()
             || folded.contains([
@@ -1455,12 +1506,32 @@ fn try_o101_expr_arg_fold(
     ctx: &PassContext<'_>,
     inner: &str,
     constants: &std::collections::HashMap<String, String>,
+    procedures: &std::collections::HashMap<String, crate::ir::Procedure>,
 ) -> Option<String> {
     let mut parts = inner.splitn(2, char::is_whitespace);
     if parts.next() != Some("expr") {
         return None;
     }
+    // `expr` renamed/aliased anywhere in the module — a shadowed `expr` no
+    // longer has builtin semantics, so this text no longer means what it
+    // looks like. Mirrors the O129 builtin-fold gate (`try_o129_fold`).
+    if !ctx.command_mutations.trusts("expr") {
+        return None;
+    }
     let raw_body = parts.next().unwrap_or("").trim();
+    let body = raw_body
+        .strip_prefix('{')
+        .and_then(|b| b.strip_suffix('}'))
+        .unwrap_or(raw_body);
+    // A math-function call shadowed by a user-defined
+    // `::tcl::mathfunc::<name>` proc anywhere in the module means folding
+    // it would use builtin semantics that no longer apply.
+    if super::helpers::expr_simplify::expr_uses_shadowed_mathfunc(
+        &crate::expr_parser::parse_expr(body, ctx.dialect),
+        procedures,
+    ) {
+        return None;
+    }
     let folded =
         if let Some(braced_body) = raw_body.strip_prefix('{').and_then(|b| b.strip_suffix('}')) {
             super::helpers::expr_simplify::try_fold_expr_with_constants(
@@ -1494,8 +1565,12 @@ fn visit_call_cmd_subst_folds(
             continue;
         };
         // O115: collapse a redundant double-`expr` cmd-sub in this
-        // argument value position (needs no interproc summary).
-        if let Some(collapsed) = o115_redundant_nested_expr(text) {
+        // argument value position (needs no interproc summary). Requires
+        // `expr` untouched anywhere in the module — both layers are
+        // genuine command substitutions.
+        if ctx.command_mutations.trusts("expr")
+            && let Some(collapsed) = o115_redundant_nested_expr(text)
+        {
             ctx.report(Optimisation::new(
                 DiagCode::O115,
                 "Remove redundant nested expr",
@@ -1508,7 +1583,9 @@ fn visit_call_cmd_subst_folds(
         // position (`return [expr {1 + 2}]` → `return 3`). The general
         // `AssignExpr` / `ExprEval` expr folds don't reach a cmd-sub
         // embedded in a `Call` argument, so handle it here.
-        if let Some(folded) = try_o101_expr_arg_fold(ctx, inner, constants) {
+        if let Some(folded) =
+            try_o101_expr_arg_fold(ctx, inner, constants, &cu.ir_module.procedures)
+        {
             ctx.report(Optimisation::new(
                 DiagCode::O101,
                 "Fold constant expression",
@@ -2546,6 +2623,37 @@ mod tests {
     }
 
     #[test]
+    fn shadowed_mathfunc_cmd_sub_arg_not_folded() {
+        // FP guard: `proc ::tcl::mathfunc::abs` shadows the builtin
+        // everywhere in the module — the cmd-sub-argument O101 fold path
+        // (try_o101_expr_arg_fold) must not fold `abs(-5)` using builtin
+        // semantics.
+        let opts = run_pass("proc ::tcl::mathfunc::abs {x} { return 999 }\nputs [expr {abs(-5)}]");
+        assert!(
+            opts.iter().all(|o| o.code != DiagCode::O101),
+            "must not fold a shadowed math function in a cmd-sub argument: {opts:?}",
+        );
+    }
+
+    #[test]
+    fn shadowed_mathfunc_return_value_not_folded() {
+        // FP guard: `return [expr {…}]` folding must also respect the
+        // math-function shadow gate.
+        use tcl_registry::CommandRegistry;
+        let reg = CommandRegistry::build_default();
+        let source =
+            "proc ::tcl::mathfunc::abs {x} { return 999 }\nproc f {} { return [expr {abs(-5)}] }";
+        let cu = CompilationUnit::build_for(source, &reg, false).with_interprocedural(&reg, None);
+        let mut ctx = PassContext::new(&cu.source, cu.interproc.clone().unwrap_or_default());
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations.iter().all(|o| o.code != DiagCode::O101),
+            "must not fold a shadowed math function in a return value: {:?}",
+            ctx.optimisations,
+        );
+    }
+
+    #[test]
     fn quoted_expr_cmd_sub_arg_not_folded_under_constants() {
         // `puts [expr "$a + $b"]` is the quoted form — it uses textual
         // substitution, so we conservatively never fold it.
@@ -2554,6 +2662,75 @@ mod tests {
             opts.iter()
                 .all(|o| !(o.code == DiagCode::O101 && o.replacement == "7")),
             "quoted expr must not fold under constants, got {opts:?}",
+        );
+    }
+
+    /// Like [`run_pass`] but populates `ctx.command_mutations` from the
+    /// whole module, the way the real pipeline does — needed to exercise
+    /// the `expr`-redefinition trust gate.
+    fn run_pass_with_mutations(source: &str) -> Vec<Optimisation> {
+        let reg = registry();
+        let cu = CompilationUnit::build_for(source, &reg, false);
+        let mut ctx = PassContext::new(&cu.source, InterproceduralAnalysis::default());
+        ctx.command_mutations =
+            crate::command_binding::scan_module_command_mutations(&cu.ir_module, &reg);
+        run(&mut ctx, &cu);
+        ctx.optimisations
+    }
+
+    #[test]
+    fn renamed_expr_cmd_sub_arg_not_folded() {
+        // FP guard: once `expr` is renamed anywhere in the module,
+        // `puts [expr {$a + $b}]` no longer calls the builtin evaluator.
+        let opts = run_pass_with_mutations(
+            "rename expr real_expr\nset a 3\nset b 4\nputs [expr {$a + $b}]",
+        );
+        assert!(
+            opts.iter().all(|o| o.code != DiagCode::O101),
+            "must not fold a cmd-sub through a renamed expr: {opts:?}",
+        );
+    }
+
+    #[test]
+    fn renamed_expr_assign_expr_substitution_not_folded() {
+        // FP guard: `set x [expr {$a + $b}]` (the AssignExpr form,
+        // try_substitute_assign_expr) must also respect the trust gate.
+        let opts = run_pass_with_mutations("rename expr real_expr\nset a 3\nset x [expr {$a + 1}]");
+        assert!(
+            opts.iter()
+                .all(|o| !(o.code == DiagCode::O100 || o.code == DiagCode::O101)),
+            "must not propagate/fold set x [expr {{…}}] through a renamed expr: {opts:?}",
+        );
+    }
+
+    #[test]
+    fn ordinary_expr_cmd_sub_arg_still_folds_under_mutation_scan() {
+        // TN/control: an unrelated module-wide mutation scan (no rename of
+        // `expr` itself) must not block the fold.
+        let opts = run_pass_with_mutations("set a 3\nset b 4\nputs [expr {$a + $b}]");
+        assert!(
+            opts.iter()
+                .any(|o| o.code == DiagCode::O101 && o.replacement == "7"),
+            "expected O101 fold under an unrelated mutation scan, got {opts:?}",
+        );
+    }
+
+    #[test]
+    fn renamed_expr_return_value_not_folded() {
+        // FP guard: `return [expr {…}]` folding (try_fold_return_terminator)
+        // must also respect the trust gate.
+        use tcl_registry::CommandRegistry;
+        let reg = CommandRegistry::build_default();
+        let source = "rename expr real_expr\nproc f {} { return [expr {1 + 2}] }";
+        let cu = CompilationUnit::build_for(source, &reg, false).with_interprocedural(&reg, None);
+        let mut ctx = PassContext::new(&cu.source, cu.interproc.clone().unwrap_or_default());
+        ctx.command_mutations =
+            crate::command_binding::scan_module_command_mutations(&cu.ir_module, &reg);
+        run(&mut ctx, &cu);
+        assert!(
+            ctx.optimisations.iter().all(|o| o.code != DiagCode::O101),
+            "must not fold a renamed expr in a return value: {:?}",
+            ctx.optimisations,
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -916,14 +916,9 @@ fn resolve_return_constant(
             continue;
         }
         let folded = match &block.terminator {
-            Some(Terminator::Return { value, expr, .. }) => fold_return_under_lattice(
-                fu,
-                *bn,
-                value.as_deref(),
-                expr.as_ref(),
-                result,
-                octal,
-            )?,
+            Some(Terminator::Return { value, expr, .. }) => {
+                fold_return_under_lattice(fu, *bn, value.as_deref(), expr.as_ref(), result, octal)?
+            }
             None => resolve_fallthrough_value(fu, *bn, result, &preds, octal)?,
             Some(_) => continue, // Goto / Branch — not an exit point
         };

--- a/rust/tcl-compiler/src/optimiser/structure_elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/structure_elimination.rs
@@ -49,7 +49,7 @@ use crate::analyses::{ConstValue, LatticeValue};
 use crate::compilation_unit::{CompilationUnit, FunctionUnit};
 use crate::ir::{Script, Statement, SwitchArm, SwitchMode};
 use crate::naming::normalise_var_name;
-use crate::tcl_expr_eval::{Env, EnvValue, eval_tcl_expr};
+use crate::tcl_expr_eval::{Env, EnvValue, eval_tcl_expr_with_octal, leading_zero_is_octal};
 
 use super::helpers::literals::is_plain_literal;
 use super::helpers::spans::full_rewrite_span;
@@ -174,7 +174,8 @@ fn visit_while(ctx: &mut PassContext<'_>, stmt: &Statement, env: &Env) {
     else {
         return;
     };
-    if let Some(val) = eval_tcl_expr(condition, env)
+    if let Some(val) =
+        eval_tcl_expr_with_octal(condition, env, ctx.dialect.map(leading_zero_is_octal))
         && !val.is_truthy()
     {
         ctx.report(Optimisation::new(
@@ -200,7 +201,8 @@ fn visit_for(ctx: &mut PassContext<'_>, stmt: &Statement, env: &Env) {
     else {
         return;
     };
-    if let Some(val) = eval_tcl_expr(condition, env)
+    if let Some(val) =
+        eval_tcl_expr_with_octal(condition, env, ctx.dialect.map(leading_zero_is_octal))
         && !val.is_truthy()
     {
         if init.statements.is_empty() {
@@ -270,8 +272,9 @@ fn try_eliminate_if(
     else_span: Option<tcl_lexer::Span>,
     env: &Env,
 ) {
+    let octal = ctx.dialect.map(leading_zero_is_octal);
     for clause in clauses {
-        let Some(val) = eval_tcl_expr(&clause.condition, env) else {
+        let Some(val) = eval_tcl_expr_with_octal(&clause.condition, env, octal) else {
             return;
         };
         if val.is_truthy() {

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -32,7 +32,8 @@ use crate::cfg::{BlockId, Function as CfgFunction, Terminator};
 use crate::expr_ast::ExprNode;
 use crate::ir::Statement;
 use crate::ssa::{SsaFunction, SsaStatement, Symbol, ValueKey};
-use crate::tcl_expr_eval::{Env, EnvValue, TclValue, eval_tcl_expr, eval_tcl_expr_with_octal};
+use crate::tcl_expr_eval::{Env, EnvValue, TclValue, eval_tcl_expr_with_octal};
+use crate::var_observability::ModuleVariableTraces;
 
 // Public aliases
 
@@ -238,6 +239,7 @@ pub fn sccp(
     ssa: &SsaFunction,
     param_constants: Option<&HashMap<(String, crate::ssa::Version), LatticeValue>>,
     octal: Option<bool>,
+    module_traces: Option<&ModuleVariableTraces>,
 ) -> SccpResult {
     let preds = compute_predecessors(cfg);
     let mut values: HashMap<ValueKey, LatticeValue> = HashMap::new();
@@ -308,7 +310,14 @@ pub fn sccp(
                 }
 
                 // Statements.
-                changed |= sccp_process_statements(&mut values, ssa_block, ssa, &escaping);
+                changed |= sccp_process_statements(
+                    &mut values,
+                    ssa_block,
+                    ssa,
+                    &escaping,
+                    octal,
+                    module_traces,
+                );
 
                 // Terminator.
                 let inputs = TerminatorInputs {
@@ -438,9 +447,19 @@ fn branch_deferrable(
 }
 
 /// A name is externally mutable (and so never a constant) when it is global /
-/// namespace-qualified or escapes via alias / trace.
-fn is_externally_mutable(name: &str, escaping: &HashSet<String>) -> bool {
-    name.starts_with("::") || escaping.contains(name)
+/// namespace-qualified, escapes via alias / trace *within this function*, or
+/// is traced *anywhere in the module* (a `trace add variable` installed by a
+/// different proc, reached through a call whose order relative to this
+/// read/write isn't statically known — see
+/// [`ModuleVariableTraces`]'s module doc for the repro this closes).
+fn is_externally_mutable(
+    name: &str,
+    escaping: &HashSet<String>,
+    module_traces: Option<&ModuleVariableTraces>,
+) -> bool {
+    name.starts_with("::")
+        || escaping.contains(name)
+        || module_traces.is_some_and(|t| t.is_traced(name))
 }
 
 /// Join phi values from edge-executable predecessors for one block. Returns
@@ -491,6 +510,8 @@ fn sccp_process_statements(
     ssa_block: &crate::ssa::SsaBlock,
     ssa: &SsaFunction,
     escaping: &HashSet<String>,
+    octal: Option<bool>,
+    module_traces: Option<&ModuleVariableTraces>,
 ) -> bool {
     let mut changed = false;
     for stmt_ssa in &ssa_block.statements {
@@ -526,10 +547,10 @@ fn sccp_process_statements(
             continue;
         }
         for (&var, ver) in &stmt_ssa.defs {
-            let val = if is_externally_mutable(ssa.var_name(var), escaping) {
+            let val = if is_externally_mutable(ssa.var_name(var), escaping, module_traces) {
                 LatticeValue::Overdefined
             } else {
-                evaluate_def(stmt_ssa, &*values, ssa)
+                evaluate_def(stmt_ssa, &*values, ssa, octal)
             };
             if set_value(values, (var, *ver), &val) {
                 changed = true;
@@ -816,12 +837,13 @@ pub fn evaluate_def<S: std::hash::BuildHasher>(
     stmt_ssa: &SsaStatement,
     values: &HashMap<ValueKey, LatticeValue, S>,
     ssa: &SsaFunction,
+    octal: Option<bool>,
 ) -> LatticeValue {
     match &stmt_ssa.statement {
         Statement::AssignConst { value, .. } => LatticeValue::Const(parse_literal_value(value)),
         Statement::AssignExpr { expr, .. } => {
             let env = env_from_uses(&stmt_ssa.uses, values, ssa);
-            match eval_tcl_expr(expr, &env) {
+            match eval_tcl_expr_with_octal(expr, &env, octal) {
                 Some(v) => LatticeValue::Const(tcl_value_to_const(v)),
                 None => LatticeValue::Overdefined,
             }
@@ -831,7 +853,7 @@ pub fn evaluate_def<S: std::hash::BuildHasher>(
             // (no command substitution), a simple `$var` that
             // resolves to a lattice Const, or a `[cmd args...]`
             // that try_fold_cmd_subst recognises.
-            fold_assign_value(value, &stmt_ssa.uses, values, ssa)
+            fold_assign_value(value, &stmt_ssa.uses, values, ssa, octal)
         }
         Statement::Call {
             command,
@@ -858,7 +880,7 @@ pub fn evaluate_def<S: std::hash::BuildHasher>(
                     if arg.starts_with('[')
                         && arg.ends_with(']')
                         && let Some(LatticeValue::Const(ConstValue::String(s))) =
-                            try_fold_cmd_subst(arg, &stmt_ssa.uses, values, ssa)
+                            try_fold_cmd_subst(arg, &stmt_ssa.uses, values, ssa, octal)
                     {
                         return Some(s.split_ascii_whitespace().map(str::to_owned).collect());
                     }
@@ -979,7 +1001,7 @@ fn branch_decision(
     values: &HashMap<ValueKey, LatticeValue>,
     octal: Option<bool>,
 ) -> Option<bool> {
-    loop_summary_decision(cfg, ssa, bn, condition, values)
+    loop_summary_decision(cfg, ssa, bn, condition, values, octal)
         .or_else(|| evaluate_branch(ssa_block, condition, values, octal, ssa))
 }
 
@@ -1005,6 +1027,7 @@ fn loop_summary_decision(
     bn: BlockId,
     condition: &ExprNode,
     values: &HashMap<ValueKey, LatticeValue>,
+    octal: Option<bool>,
 ) -> Option<bool> {
     let node = cfg.loop_nodes.get(&bn)?;
     let start_ssa = ssa.blocks.get(&node.entry_block)?;
@@ -1018,8 +1041,9 @@ fn loop_summary_decision(
         &node.for_stmt,
         &start_env,
         crate::static_loops::DEFAULT_MAX_STATIC_LOOP_ITERS,
+        octal,
     )?;
-    let v = crate::static_loops::evaluate_expr_with_constants(condition, &summarised)?;
+    let v = crate::static_loops::evaluate_expr_with_constants(condition, &summarised, octal)?;
     Some(v != 0)
 }
 
@@ -1201,6 +1225,7 @@ fn fold_assign_value<S1: std::hash::BuildHasher, S2: std::hash::BuildHasher>(
     uses: &HashMap<Symbol, crate::ssa::Version, S1>,
     values: &HashMap<ValueKey, LatticeValue, S2>,
     ssa: &SsaFunction,
+    octal: Option<bool>,
 ) -> LatticeValue {
     let stripped = value.trim();
     // Plain literal.
@@ -1214,7 +1239,7 @@ fn fold_assign_value<S1: std::hash::BuildHasher, S2: std::hash::BuildHasher>(
     // Command substitution.
     if stripped.starts_with('[')
         && stripped.ends_with(']')
-        && let Some(lv) = try_fold_cmd_subst(stripped, uses, values, ssa)
+        && let Some(lv) = try_fold_cmd_subst(stripped, uses, values, ssa, octal)
     {
         return lv;
     }
@@ -1280,6 +1305,7 @@ fn try_fold_cmd_subst<S1: std::hash::BuildHasher, S2: std::hash::BuildHasher>(
     uses: &HashMap<Symbol, crate::ssa::Version, S1>,
     values: &HashMap<ValueKey, LatticeValue, S2>,
     ssa: &SsaFunction,
+    octal: Option<bool>,
 ) -> Option<LatticeValue> {
     // `[list ...]` — reuse the codegen fold.
     if let Some(folded) = crate::codegen::helpers::fold_list_cmd(value) {
@@ -1350,7 +1376,8 @@ fn try_fold_cmd_subst<S1: std::hash::BuildHasher, S2: std::hash::BuildHasher>(
         } else {
             env_from_uses_numeric(uses, values, ssa)
         };
-        return eval_tcl_expr(&expr, &env).map(|v| LatticeValue::Const(tcl_value_to_const(v)));
+        return eval_tcl_expr_with_octal(&expr, &env, octal)
+            .map(|v| LatticeValue::Const(tcl_value_to_const(v)));
     }
 
     None
@@ -1687,7 +1714,9 @@ mod tests {
             &mut values,
             &block,
             &ssa,
-            &escaping
+            &escaping,
+            None,
+            None
         ));
         assert_eq!(
             values.get(&(x, 2)),
@@ -1735,7 +1764,7 @@ mod tests {
         ssa.blocks.get_mut(&entry).unwrap().statements.push(stmt);
         let x = ssa.var_symbol("x").unwrap();
 
-        let r = sccp(&f, &ssa, None, None);
+        let r = sccp(&f, &ssa, None, None, None);
         assert!(r.executable_blocks.contains(&entry));
         assert_eq!(
             r.values.get(&(x, 1)),
@@ -1765,7 +1794,7 @@ mod tests {
         });
         let ssa = make_ssa(&f, vec![]);
 
-        let r = sccp(&f, &ssa, None, None);
+        let r = sccp(&f, &ssa, None, None, None);
         assert!(r.executable_blocks.contains(&t));
         assert!(!r.executable_blocks.contains(&e));
         assert_eq!(r.constant_branches.len(), 1);
@@ -1796,7 +1825,7 @@ mod tests {
         });
         let ssa = make_ssa(&f, vec![]);
 
-        let r = sccp(&f, &ssa, None, None);
+        let r = sccp(&f, &ssa, None, None, None);
         assert!(!r.executable_blocks.contains(&t));
         assert!(r.executable_blocks.contains(&e));
     }
@@ -1829,7 +1858,7 @@ mod tests {
         });
         let ssa = make_ssa(&f, vec![]);
 
-        let r = sccp(&f, &ssa, None, None);
+        let r = sccp(&f, &ssa, None, None, None);
         assert!(r.executable_blocks.contains(&t));
         assert!(r.executable_blocks.contains(&e));
         assert!(r.constant_branches.is_empty());
@@ -1840,12 +1869,12 @@ mod tests {
         let mut ssa = bare_ssa();
         let s_int = assign_const_stmt(&mut ssa, "x", "42", 1);
         assert_eq!(
-            evaluate_def(&s_int, &HashMap::new(), &ssa),
+            evaluate_def(&s_int, &HashMap::new(), &ssa, None),
             LatticeValue::Const(ConstValue::Int(42))
         );
         let s_str = assign_const_stmt(&mut ssa, "x", "hello", 1);
         assert_eq!(
-            evaluate_def(&s_str, &HashMap::new(), &ssa),
+            evaluate_def(&s_str, &HashMap::new(), &ssa, None),
             LatticeValue::Const(ConstValue::String("hello".into()))
         );
     }
@@ -1890,7 +1919,7 @@ mod tests {
         values.insert((a, 1), LatticeValue::Const(ConstValue::Int(2)));
 
         assert_eq!(
-            evaluate_def(&stmt_ssa, &values, &ssa),
+            evaluate_def(&stmt_ssa, &values, &ssa, None),
             LatticeValue::Const(ConstValue::Int(5))
         );
     }
@@ -1931,7 +1960,7 @@ mod tests {
         let mut values = HashMap::new();
         values.insert((x, 1), LatticeValue::Const(ConstValue::Int(5)));
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Const(ConstValue::Int(6))
         );
     }
@@ -1944,7 +1973,7 @@ mod tests {
         let mut values = HashMap::new();
         values.insert((x, 1), LatticeValue::Const(ConstValue::Int(3)));
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Const(ConstValue::Int(13))
         );
     }
@@ -1957,7 +1986,7 @@ mod tests {
         let mut values = HashMap::new();
         values.insert((x, 1), LatticeValue::Const(ConstValue::Int(10)));
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Const(ConstValue::Int(8))
         );
     }
@@ -1974,7 +2003,7 @@ mod tests {
         values.insert((x, 1), LatticeValue::Const(ConstValue::Int(6)));
         values.insert((y, 1), LatticeValue::Const(ConstValue::Int(4)));
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Const(ConstValue::Int(10))
         );
     }
@@ -1985,7 +2014,10 @@ mod tests {
         let stmt = incr_stmt(&mut ssa, "x", None, 1, 2);
         let values = HashMap::new();
         // No entry for x@1 → base is Unknown → result Unknown.
-        assert_eq!(evaluate_def(&stmt, &values, &ssa), LatticeValue::Unknown);
+        assert_eq!(
+            evaluate_def(&stmt, &values, &ssa, None),
+            LatticeValue::Unknown
+        );
     }
 
     #[test]
@@ -1996,7 +2028,7 @@ mod tests {
         let mut values = HashMap::new();
         values.insert((x, 1), LatticeValue::Overdefined);
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Overdefined
         );
     }
@@ -2009,7 +2041,7 @@ mod tests {
         let mut values = HashMap::new();
         values.insert((x, 1), LatticeValue::Const(ConstValue::Int(1)));
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Overdefined
         );
     }
@@ -2089,7 +2121,7 @@ mod tests {
     fn evaluate_def_foreach_literal_list_folds_constset() {
         let mut ssa = bare_ssa();
         let stmt = foreach_stmt(&mut ssa, "v", "{1 2 3}", 1);
-        let result = evaluate_def(&stmt, &HashMap::new(), &ssa);
+        let result = evaluate_def(&stmt, &HashMap::new(), &ssa, None);
         match result {
             LatticeValue::ConstSet(ref vs) => {
                 assert_eq!(vs.len(), 3);
@@ -2106,7 +2138,7 @@ mod tests {
         // same element CONSTSET as the braced-literal form (issue #777).
         let mut ssa = bare_ssa();
         let stmt = foreach_stmt(&mut ssa, "v", "[list a b c]", 1);
-        let result = evaluate_def(&stmt, &HashMap::new(), &ssa);
+        let result = evaluate_def(&stmt, &HashMap::new(), &ssa, None);
         match result {
             LatticeValue::ConstSet(ref vs) => {
                 assert_eq!(vs.len(), 3);
@@ -2122,7 +2154,7 @@ mod tests {
         let mut ssa = bare_ssa();
         let stmt = foreach_stmt(&mut ssa, "v", "{only}", 1);
         assert_eq!(
-            evaluate_def(&stmt, &HashMap::new(), &ssa),
+            evaluate_def(&stmt, &HashMap::new(), &ssa, None),
             LatticeValue::Const(ConstValue::String("only".into()))
         );
     }
@@ -2138,7 +2170,7 @@ mod tests {
             (lst, 1),
             LatticeValue::Const(ConstValue::String("a b c".into())),
         );
-        let result = evaluate_def(&stmt, &values, &ssa);
+        let result = evaluate_def(&stmt, &values, &ssa, None);
         match result {
             LatticeValue::ConstSet(ref vs) => assert_eq!(vs.len(), 3),
             other => panic!("expected ConstSet, got {other:?}"),
@@ -2152,7 +2184,7 @@ mod tests {
         let lst = ssa.intern_var("lst");
         stmt.uses.insert(lst, 1);
         // Empty lattice — var not bound.
-        let result = evaluate_def(&stmt, &HashMap::new(), &ssa);
+        let result = evaluate_def(&stmt, &HashMap::new(), &ssa, None);
         assert_eq!(result, LatticeValue::Overdefined);
     }
 
@@ -2165,7 +2197,7 @@ mod tests {
             panic!();
         };
         defs.push("w".into());
-        let result = evaluate_def(&stmt, &HashMap::new(), &ssa);
+        let result = evaluate_def(&stmt, &HashMap::new(), &ssa, None);
         assert_eq!(result, LatticeValue::Overdefined);
     }
 
@@ -2193,7 +2225,7 @@ mod tests {
         let mut ssa = bare_ssa();
         let stmt = assign_value_stmt(&mut ssa, "x", "hello", 1);
         assert_eq!(
-            evaluate_def(&stmt, &HashMap::new(), &ssa),
+            evaluate_def(&stmt, &HashMap::new(), &ssa, None),
             LatticeValue::Const(ConstValue::String("hello".into()))
         );
     }
@@ -2203,7 +2235,7 @@ mod tests {
         let mut ssa = bare_ssa();
         let stmt = assign_value_stmt(&mut ssa, "x", "42", 1);
         assert_eq!(
-            evaluate_def(&stmt, &HashMap::new(), &ssa),
+            evaluate_def(&stmt, &HashMap::new(), &ssa, None),
             LatticeValue::Const(ConstValue::Int(42))
         );
     }
@@ -2217,7 +2249,7 @@ mod tests {
         let mut values = HashMap::new();
         values.insert((x, 1), LatticeValue::Const(ConstValue::Int(7)));
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Const(ConstValue::Int(7))
         );
     }
@@ -2226,7 +2258,7 @@ mod tests {
     fn evaluate_def_assign_value_folds_list_cmd() {
         let mut ssa = bare_ssa();
         let stmt = assign_value_stmt(&mut ssa, "x", "[list a b c]", 1);
-        let result = evaluate_def(&stmt, &HashMap::new(), &ssa);
+        let result = evaluate_def(&stmt, &HashMap::new(), &ssa, None);
         match result {
             LatticeValue::Const(ConstValue::String(s)) => assert_eq!(s, "a b c"),
             other => panic!("expected Const(String), got {other:?}"),
@@ -2238,7 +2270,7 @@ mod tests {
         let mut ssa = bare_ssa();
         let stmt = assign_value_stmt(&mut ssa, "n", "[llength {a b c d}]", 1);
         assert_eq!(
-            evaluate_def(&stmt, &HashMap::new(), &ssa),
+            evaluate_def(&stmt, &HashMap::new(), &ssa, None),
             LatticeValue::Const(ConstValue::Int(4))
         );
     }
@@ -2248,7 +2280,7 @@ mod tests {
         let mut ssa = bare_ssa();
         let stmt = assign_value_stmt(&mut ssa, "n", "[string length \"hello\"]", 1);
         assert_eq!(
-            evaluate_def(&stmt, &HashMap::new(), &ssa),
+            evaluate_def(&stmt, &HashMap::new(), &ssa, None),
             LatticeValue::Const(ConstValue::Int(5))
         );
     }
@@ -2258,7 +2290,7 @@ mod tests {
         let mut ssa = bare_ssa();
         let stmt = assign_value_stmt(&mut ssa, "x", "[expr {1 + 2}]", 1);
         assert_eq!(
-            evaluate_def(&stmt, &HashMap::new(), &ssa),
+            evaluate_def(&stmt, &HashMap::new(), &ssa, None),
             LatticeValue::Const(ConstValue::Int(3))
         );
     }
@@ -2267,7 +2299,7 @@ mod tests {
     fn evaluate_def_assign_value_folds_format_literal() {
         let mut ssa = bare_ssa();
         let stmt = assign_value_stmt(&mut ssa, "s", "[format \"%d-%d\" 1 2]", 1);
-        match evaluate_def(&stmt, &HashMap::new(), &ssa) {
+        match evaluate_def(&stmt, &HashMap::new(), &ssa, None) {
             LatticeValue::Const(ConstValue::String(s)) => assert_eq!(s, "1-2"),
             other => panic!("expected Const(String), got {other:?}"),
         }
@@ -2295,7 +2327,7 @@ mod tests {
             LatticeValue::Const(ConstValue::String("beta".into())),
         );
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Overdefined
         );
     }
@@ -2314,7 +2346,7 @@ mod tests {
         values.insert((a, 1), LatticeValue::Const(ConstValue::Int(3)));
         values.insert((b, 1), LatticeValue::Const(ConstValue::Int(4)));
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Const(ConstValue::Int(7))
         );
     }
@@ -2339,7 +2371,7 @@ mod tests {
             LatticeValue::Const(ConstValue::String("beta".into())),
         );
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Const(ConstValue::Int(0))
         );
     }
@@ -2349,7 +2381,7 @@ mod tests {
         let mut ssa = bare_ssa();
         let stmt = assign_value_stmt(&mut ssa, "x", "[nonexistent_fold args]", 1);
         assert_eq!(
-            evaluate_def(&stmt, &HashMap::new(), &ssa),
+            evaluate_def(&stmt, &HashMap::new(), &ssa, None),
             LatticeValue::Overdefined
         );
     }
@@ -2366,7 +2398,7 @@ mod tests {
             LatticeValue::Const(ConstValue::String("a b c".into())),
         );
         assert_eq!(
-            evaluate_def(&stmt, &values, &ssa),
+            evaluate_def(&stmt, &values, &ssa, None),
             LatticeValue::Const(ConstValue::Int(3))
         );
     }
@@ -2444,7 +2476,7 @@ mod tests {
             "proc ::p {} { for {set i 0} {$i < 10} {incr i} {}\n if {$i == 10} { return yes } else { return no } }",
         );
         let fu = c.function("::p").unwrap();
-        let r = sccp(&fu.cfg, &fu.ssa, None, None);
+        let r = sccp(&fu.cfg, &fu.ssa, None, None, None);
         let cb = r
             .constant_branches
             .iter()
@@ -2457,7 +2489,7 @@ mod tests {
             "proc ::a {} { set j 0\n for {set k 5} {$k > 0} {incr k -1} { incr j }\n if {$j == 5} { return yes } else { return no } }",
         );
         let fa = ca.function("::a").unwrap();
-        let ra = sccp(&fa.cfg, &fa.ssa, None, None);
+        let ra = sccp(&fa.cfg, &fa.ssa, None, None, None);
         let cba = ra
             .constant_branches
             .iter()
@@ -2471,7 +2503,7 @@ mod tests {
             "proc ::q {n} { for {set i 0} {$i < $n} {incr i} {}\n if {$i == 10} { return yes } else { return no } }",
         );
         let fq = cq.function("::q").unwrap();
-        let rq = sccp(&fq.cfg, &fq.ssa, None, None);
+        let rq = sccp(&fq.cfg, &fq.ssa, None, None, None);
         assert!(
             !rq.constant_branches
                 .iter()
@@ -2529,7 +2561,7 @@ mod tests {
 
         let cg = cu(global_src);
         let fg = cg.function("::p").unwrap();
-        let rg = sccp(&fg.cfg, &fg.ssa, None, None);
+        let rg = sccp(&fg.cfg, &fg.ssa, None, None, None);
         assert!(
             rg.constant_branches.is_empty(),
             "global var must not fold a constant branch"
@@ -2537,7 +2569,7 @@ mod tests {
 
         let cl = cu(local_src);
         let fl = cl.function("::p").unwrap();
-        let rl = sccp(&fl.cfg, &fl.ssa, None, None);
+        let rl = sccp(&fl.cfg, &fl.ssa, None, None, None);
         assert!(
             !rl.constant_branches.is_empty(),
             "local var should still fold the constant branch"

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -260,7 +260,7 @@ mod tests {
     fn find_shimmer_warnings_empty_function() {
         let f = Function::new("::top", "entry");
         let ssa = crate::ssa::build_ssa(&f, &registry());
-        let sccp = crate::sccp::sccp(&f, &ssa, None, None);
+        let sccp = crate::sccp::sccp(&f, &ssa, None, None, None);
         let types: HashMap<ValueKey, TypeLattice> = HashMap::new();
         assert!(
             find_shimmer_warnings(

--- a/rust/tcl-compiler/src/static_loops.rs
+++ b/rust/tcl-compiler/src/static_loops.rs
@@ -29,7 +29,7 @@ use std::collections::HashMap;
 use crate::expr_ast::{ExprNode, expr_text};
 use crate::ir::{IfClause, Script, Statement, SwitchArm, SwitchMode};
 use crate::naming::normalise_var_name;
-use crate::tcl_expr_eval::{Env, EnvValue, TclValue, eval_tcl_expr};
+use crate::tcl_expr_eval::{Env, EnvValue, TclValue, eval_tcl_expr_with_octal};
 
 /// Default cap on iteration count — beyond this we give up and
 /// return `None` rather than simulate any further.
@@ -92,9 +92,13 @@ pub fn parse_literal_value(text: &str) -> StaticValue {
 /// integer-valued float), `None` otherwise. Booleans collapse into
 /// `i64` (0/1) for simpler call-sites.
 #[must_use]
-pub fn evaluate_expr_with_constants(expr: &ExprNode, env: &StaticEnv) -> Option<i64> {
+pub fn evaluate_expr_with_constants(
+    expr: &ExprNode,
+    env: &StaticEnv,
+    octal: Option<bool>,
+) -> Option<i64> {
     let tcl_env = env_as_tcl_env(env);
-    let v = eval_tcl_expr(expr, &tcl_env)?;
+    let v = eval_tcl_expr_with_octal(expr, &tcl_env, octal)?;
     match v {
         TclValue::Int(i) => Some(i),
         TclValue::Float(f) => {
@@ -204,19 +208,21 @@ fn resolve_switch_pattern(pattern: &str) -> String {
 /// Returns `true` when the statement is in the supported subset;
 /// `false` when it should abort the whole summarisation (call,
 /// barrier, unhandled structured form, etc.).
-fn exec_statement(stmt: &Statement, env: &mut StaticEnv) -> bool {
+fn exec_statement(stmt: &Statement, env: &mut StaticEnv, octal: Option<bool>) -> bool {
     match stmt {
         Statement::AssignConst { name, value, .. } => {
             env.insert(name.clone(), parse_literal_value(value));
             true
         }
-        Statement::AssignExpr { name, expr, .. } => match evaluate_expr_with_constants(expr, env) {
-            Some(v) => {
-                env.insert(name.clone(), StaticValue::Int(v));
-                true
+        Statement::AssignExpr { name, expr, .. } => {
+            match evaluate_expr_with_constants(expr, env, octal) {
+                Some(v) => {
+                    env.insert(name.clone(), StaticValue::Int(v));
+                    true
+                }
+                None => false,
             }
-            None => false,
-        },
+        }
         Statement::AssignValue { name, value, .. } => {
             if value.contains('[') {
                 return false;
@@ -261,41 +267,46 @@ fn exec_statement(stmt: &Statement, env: &mut StaticEnv) -> bool {
         }
         Statement::If {
             clauses, else_body, ..
-        } => exec_if(clauses, else_body.as_ref(), env),
+        } => exec_if(clauses, else_body.as_ref(), env, octal),
         Statement::Switch {
             subject,
             arms,
             default_body,
             mode,
             ..
-        } => exec_switch(subject, arms, default_body.as_ref(), *mode, env),
+        } => exec_switch(subject, arms, default_body.as_ref(), *mode, env, octal),
         // Calls, barriers, returns, loops (other than the
         // top-level summarised `for`) — out of supported subset.
         _ => false,
     }
 }
 
-fn exec_script(script: &Script, env: &mut StaticEnv) -> bool {
+fn exec_script(script: &Script, env: &mut StaticEnv, octal: Option<bool>) -> bool {
     for stmt in &script.statements {
-        if !exec_statement(stmt, env) {
+        if !exec_statement(stmt, env, octal) {
             return false;
         }
     }
     true
 }
 
-fn exec_if(clauses: &[IfClause], else_body: Option<&Script>, env: &mut StaticEnv) -> bool {
+fn exec_if(
+    clauses: &[IfClause],
+    else_body: Option<&Script>,
+    env: &mut StaticEnv,
+    octal: Option<bool>,
+) -> bool {
     for clause in clauses {
-        let Some(cond) = evaluate_expr_with_constants(&clause.condition, env) else {
+        let Some(cond) = evaluate_expr_with_constants(&clause.condition, env, octal) else {
             return false;
         };
         if cond != 0 {
-            return exec_script(&clause.body, env);
+            return exec_script(&clause.body, env, octal);
         }
     }
     match else_body {
         None => true,
-        Some(body) => exec_script(body, env),
+        Some(body) => exec_script(body, env, octal),
     }
 }
 
@@ -305,6 +316,7 @@ fn exec_switch(
     default_body: Option<&Script>,
     _mode: SwitchMode,
     env: &mut StaticEnv,
+    octal: Option<bool>,
 ) -> bool {
     let Some(subject_value) = resolve_switch_subject(subject, env) else {
         return false;
@@ -326,7 +338,7 @@ fn exec_switch(
     let body = selected_body.or(default_body);
     match body {
         None => true,
-        Some(b) => exec_script(b, env),
+        Some(b) => exec_script(b, env, octal),
     }
 }
 
@@ -344,15 +356,16 @@ pub fn summarise_static_for(
     body: &Script,
     initial_constants: &StaticEnv,
     max_iterations: u64,
+    octal: Option<bool>,
 ) -> Option<StaticEnv> {
     let mut env: StaticEnv = initial_constants.clone();
 
-    if !exec_script(init, &mut env) {
+    if !exec_script(init, &mut env, octal) {
         return None;
     }
     let mut iterations: u64 = 0;
     loop {
-        let cond = evaluate_expr_with_constants(condition, &env)?;
+        let cond = evaluate_expr_with_constants(condition, &env, octal)?;
         if cond == 0 {
             break;
         }
@@ -360,10 +373,10 @@ pub fn summarise_static_for(
         if iterations > max_iterations {
             return None;
         }
-        if !exec_script(body, &mut env) {
+        if !exec_script(body, &mut env, octal) {
             return None;
         }
-        if !exec_script(next_script, &mut env) {
+        if !exec_script(next_script, &mut env, octal) {
             return None;
         }
     }
@@ -378,6 +391,7 @@ pub fn summarise_for_statement(
     stmt: &Statement,
     initial_constants: &StaticEnv,
     max_iterations: u64,
+    octal: Option<bool>,
 ) -> Option<StaticEnv> {
     let Statement::For {
         init,
@@ -397,6 +411,7 @@ pub fn summarise_for_statement(
         body,
         initial_constants,
         max_iterations,
+        octal,
     )
 }
 
@@ -496,8 +511,16 @@ mod tests {
         let cond = parse_expr("$i < 5", None);
         let next_script = script_of(vec![incr("i", None)]);
         let body = empty_script();
-        let env = summarise_static_for(&init, &cond, &next_script, &body, &StaticEnv::new(), 1000)
-            .expect("summarised");
+        let env = summarise_static_for(
+            &init,
+            &cond,
+            &next_script,
+            &body,
+            &StaticEnv::new(),
+            1000,
+            None,
+        )
+        .expect("summarised");
         assert_eq!(env.get("i"), Some(&StaticValue::Int(5)));
     }
 
@@ -508,8 +531,16 @@ mod tests {
         let cond = parse_expr("$i < 3", None);
         let next_script = script_of(vec![incr("i", None)]);
         let body = script_of(vec![incr("total", None)]);
-        let env = summarise_static_for(&init, &cond, &next_script, &body, &StaticEnv::new(), 1000)
-            .expect("summarised");
+        let env = summarise_static_for(
+            &init,
+            &cond,
+            &next_script,
+            &body,
+            &StaticEnv::new(),
+            1000,
+            None,
+        )
+        .expect("summarised");
         assert_eq!(env.get("total"), Some(&StaticValue::Int(3)));
         assert_eq!(env.get("i"), Some(&StaticValue::Int(3)));
     }
@@ -520,8 +551,15 @@ mod tests {
         let cond = parse_expr("$i < 10000", None);
         let next_script = script_of(vec![incr("i", None)]);
         let body = empty_script();
-        let result =
-            summarise_static_for(&init, &cond, &next_script, &body, &StaticEnv::new(), 100);
+        let result = summarise_static_for(
+            &init,
+            &cond,
+            &next_script,
+            &body,
+            &StaticEnv::new(),
+            100,
+            None,
+        );
         assert!(result.is_none(), "should exceed the 100-iter cap");
     }
 
@@ -544,8 +582,16 @@ mod tests {
             foreach_groups: None,
         }]);
         assert!(
-            summarise_static_for(&init, &cond, &next_script, &body, &StaticEnv::new(), 1000)
-                .is_none()
+            summarise_static_for(
+                &init,
+                &cond,
+                &next_script,
+                &body,
+                &StaticEnv::new(),
+                1000,
+                None
+            )
+            .is_none()
         );
     }
 
@@ -591,8 +637,16 @@ mod tests {
             else_body: Some(script_of(vec![assign_const("x", "20")])),
             else_span: None,
         }]);
-        let env = summarise_static_for(&init, &cond, &next_script, &body, &StaticEnv::new(), 1000)
-            .expect("summarised");
+        let env = summarise_static_for(
+            &init,
+            &cond,
+            &next_script,
+            &body,
+            &StaticEnv::new(),
+            1000,
+            None,
+        )
+        .expect("summarised");
         assert_eq!(env.get("i"), Some(&StaticValue::Int(3)));
         assert_eq!(env.get("x"), Some(&StaticValue::Int(20)));
     }
@@ -604,8 +658,16 @@ mod tests {
         let cond = parse_expr("$i < 1", None);
         let next_script = script_of(vec![incr("i", None)]);
         let body = script_of(vec![mode_switch()]);
-        let env = summarise_static_for(&init, &cond, &next_script, &body, &StaticEnv::new(), 1000)
-            .expect("summarised");
+        let env = summarise_static_for(
+            &init,
+            &cond,
+            &next_script,
+            &body,
+            &StaticEnv::new(),
+            1000,
+            None,
+        )
+        .expect("summarised");
         assert_eq!(env.get("v"), Some(&StaticValue::Int(1)));
     }
 
@@ -616,8 +678,15 @@ mod tests {
         let cond = parse_expr("$i < 1", None);
         let next_script = script_of(vec![incr("i", None)]);
         let body = script_of(vec![mode_switch()]);
-        let result =
-            summarise_static_for(&init, &cond, &next_script, &body, &StaticEnv::new(), 1000);
+        let result = summarise_static_for(
+            &init,
+            &cond,
+            &next_script,
+            &body,
+            &StaticEnv::new(),
+            1000,
+            None,
+        );
         assert!(result.is_none(), "unresolvable switch subject should bail");
     }
 
@@ -636,7 +705,8 @@ mod tests {
             raw_args: Vec::new(),
             raw_tokens: None,
         };
-        let env = summarise_for_statement(&for_stmt, &StaticEnv::new(), 100).expect("summarised");
+        let env =
+            summarise_for_statement(&for_stmt, &StaticEnv::new(), 100, None).expect("summarised");
         assert_eq!(env.get("i"), Some(&StaticValue::Int(2)));
     }
 
@@ -647,7 +717,7 @@ mod tests {
         let mut env = StaticEnv::new();
         env.insert("x".into(), StaticValue::Int(5));
         assert_eq!(
-            evaluate_expr_with_constants(&parse_expr("$x + 3", None), &env),
+            evaluate_expr_with_constants(&parse_expr("$x + 3", None), &env, None),
             Some(8)
         );
     }
@@ -655,7 +725,7 @@ mod tests {
     #[test]
     fn evaluate_expr_integer_valued_float() {
         assert_eq!(
-            evaluate_expr_with_constants(&parse_expr("6.0 / 2", None), &StaticEnv::new()),
+            evaluate_expr_with_constants(&parse_expr("6.0 / 2", None), &StaticEnv::new(), None),
             Some(3)
         );
     }
@@ -663,7 +733,7 @@ mod tests {
     #[test]
     fn evaluate_expr_fractional_float_none() {
         assert_eq!(
-            evaluate_expr_with_constants(&parse_expr("1.5", None), &StaticEnv::new()),
+            evaluate_expr_with_constants(&parse_expr("1.5", None), &StaticEnv::new(), None),
             None
         );
     }

--- a/rust/tcl-compiler/src/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/src/tcl_expr_eval.rs
@@ -308,13 +308,14 @@ impl tcl_syntax::expr::ExprOps for FoldOps<'_> {
         // function itself accepts boolean words (the registry of that fact is
         // the mathfunc module, not a name check here).
         let boolean_ok = accepts_boolean_operand(&name);
+        let octal = self.octal;
         let nums: Option<Vec<Num>> = args
             .iter()
             .map(|v| {
                 let parsed = if boolean_ok {
                     v.to_number()
                 } else {
-                    strict_number(v)
+                    strict_number_for_dialect(v, octal)
                 };
                 parsed.map(|t| match t {
                     TclValue::Int(i) => Num::Int(i),
@@ -331,28 +332,37 @@ impl tcl_syntax::expr::ExprOps for FoldOps<'_> {
     fn arith(&mut self, op: BinOp, left: FoldValue, right: FoldValue) -> Result<FoldValue, ()> {
         // Arithmetic operands are strict numbers: Tcl's `+`/`-`/`*`/… read
         // them with `Tcl_GetNumberFromObj`, which rejects boolean words, so
-        // `expr {true + 0}` is an error, not `1`. `strict_number` omits the
-        // boolean coercion `to_number`/`parse_literal` add.
-        let a = strict_number(&left).ok_or(())?;
-        let b = strict_number(&right).ok_or(())?;
+        // `expr {true + 0}` is an error, not `1`. `strict_number_for_dialect`
+        // omits the boolean coercion `to_number`/`parse_literal` add, and
+        // additionally honours the dialect's leading-zero rule (see its doc).
+        let a = strict_number_for_dialect(&left, self.octal).ok_or(())?;
+        let b = strict_number_for_dialect(&right, self.octal).ok_or(())?;
         apply_binary(op, a, b).map(FoldValue::from_tcl).ok_or(())
     }
     fn unary(&mut self, op: UnaryOp, value: FoldValue) -> Result<FoldValue, ()> {
         match op {
             // Logical negation *does* take a boolean (`expr {!true}` → 0), so
-            // it keeps the boolean-accepting `to_number` coercion.
+            // it keeps the boolean-accepting `to_number` coercion. Truthiness
+            // of a bare leading-zero operand is dialect-invariant (a run of
+            // zero digits is zero under either reading, and any other
+            // leading-zero run is non-zero under both), so no dialect
+            // handling is needed here.
             UnaryOp::Not | UnaryOp::WordNot => {
                 let truthy = value.to_number().ok_or(())?.is_truthy();
                 Ok(FoldValue::Int(i64::from(!truthy)))
             }
             // Arithmetic/bitwise unaries reject boolean words like the binary
-            // arithmetic path (`expr {-true}`, `expr {~yes}` are errors).
-            UnaryOp::Pos => strict_number(&value).map(FoldValue::from_tcl).ok_or(()),
-            UnaryOp::Neg => match strict_number(&value).ok_or(())? {
+            // arithmetic path (`expr {-true}`, `expr {~yes}` are errors), and
+            // are dialect-sensitive the same way `arith` is (`expr {-010}`
+            // is `-8` in tcl8.x, `-10` in tcl9.0).
+            UnaryOp::Pos => strict_number_for_dialect(&value, self.octal)
+                .map(FoldValue::from_tcl)
+                .ok_or(()),
+            UnaryOp::Neg => match strict_number_for_dialect(&value, self.octal).ok_or(())? {
                 TclValue::Int(i) => i.checked_neg().map(FoldValue::Int).ok_or(()),
                 TclValue::Float(f) => Ok(FoldValue::Float(-f)),
             },
-            UnaryOp::BitNot => match strict_number(&value).ok_or(())? {
+            UnaryOp::BitNot => match strict_number_for_dialect(&value, self.octal).ok_or(())? {
                 TclValue::Int(i) => Ok(FoldValue::Int(!i)),
                 TclValue::Float(_) => Err(()),
             },
@@ -478,6 +488,45 @@ fn strict_number(value: &FoldValue) -> Option<TclValue> {
             Number::Big { .. } => None,
         },
     }
+}
+
+/// Like [`strict_number`] but for the arithmetic/unary/math-function
+/// operand path, which — unlike [`strict_number`]'s comparison callers —
+/// must honour the active dialect's leading-zero rule: `Some(true)` = tcl8.x
+/// octal (`010` → 8; `08`/`09` are invalid octal, and Tcl raises an error
+/// for them in arithmetic context, so this declines rather than guess),
+/// `Some(false)` = tcl9.0 decimal (`010` → 10, matching the shared grammar
+/// [`strict_number`] already applies).
+///
+/// `None` (dialect unknown) folds only when the octal and decimal readings
+/// *agree* — e.g. `07` is `7` under both (`7` is a valid octal digit), so
+/// it isn't actually ambiguous — and declines when they disagree (`010`:
+/// octal 8 vs decimal 10) or either reading is invalid (`08`/`09`: invalid
+/// octal, valid decimal). This is more precise than blanket-declining every
+/// bare leading-zero operand under an unknown dialect while staying sound:
+/// the two candidate dialects are the only readings a real Tcl interpreter
+/// could apply.
+///
+/// Unlike [`classify_operand`], a leading-zero operand that fails to parse
+/// under the active dialect always declines (`None`) here rather than
+/// falling back to a string classification — arithmetic has no string
+/// fallback in Tcl (`expr {08 + 1}` is a runtime error under the 8.x octal
+/// rule, not a string operation), so "can't fold" is the only sound outcome.
+fn strict_number_for_dialect(value: &FoldValue, octal: Option<bool>) -> Option<TclValue> {
+    let FoldValue::Str(s) = value else {
+        return strict_number(value);
+    };
+    if is_bare_leading_zero(s) {
+        return match octal {
+            Some(true) => parse_octal_literal(s),
+            Some(false) => strict_number(value),
+            None => match (parse_octal_literal(s), strict_number(value)) {
+                (Some(o), Some(d)) if o == d => Some(o),
+                _ => None,
+            },
+        };
+    }
+    strict_number(value)
 }
 
 // Binary operators
@@ -623,12 +672,18 @@ fn tcl_div(a: TclValue, b: TclValue) -> Option<TclValue> {
             }
         }
         _ => {
-            let fa = a.as_f64();
-            let fb = b.as_f64();
-            if fb == 0.0 {
+            // A non-zero numerator over a zero divisor is Inf/-Inf, a real
+            // (foldable) Tcl value — only 0.0/0.0 is a domain error
+            // (tclsh: `expr {5.0/0.0}` -> Inf, `expr {0.0/0.0}` errors).
+            // IEEE-754 division naturally produces NaN for exactly that
+            // case, so decline on NaN rather than blanket-declining
+            // whenever the divisor is zero — the same pattern `tcl_pow`'s
+            // float path already uses below.
+            let r = a.as_f64() / b.as_f64();
+            if r.is_nan() {
                 return None;
             }
-            Some(TclValue::Float(fa / fb))
+            Some(TclValue::Float(r))
         }
     }
 }
@@ -905,6 +960,58 @@ mod tests {
     }
 
     #[test]
+    fn dialect_aware_leading_zero_folds_in_arithmetic() {
+        // TP: the octal-vs-decimal split must also apply to arithmetic /
+        // unary / math-function operands, not just comparisons. Each value
+        // verified against real tclsh8.6: `010 + 1` = 9 (octal 8+1),
+        // `010 * 2` = 16, `-010` = -8, `abs(-010)` = 8.
+        let eval_d = |expr: &str, dialect: &str| {
+            eval_tcl_expr_in_dialect(&parse_expr(expr, None), &Env::new(), dialect)
+        };
+        for d in ["tcl8.4", "tcl8.5", "tcl8.6", "f5-irules", "f5-iapps"] {
+            assert_eq!(eval_d("010 + 1", d), Some(TclValue::Int(9)), "{d}");
+            assert_eq!(eval_d("010 * 2", d), Some(TclValue::Int(16)), "{d}");
+            assert_eq!(eval_d("-010", d), Some(TclValue::Int(-8)), "{d}");
+            assert_eq!(eval_d("abs(-010)", d), Some(TclValue::Int(8)), "{d}");
+        }
+        // tcl9.0 decimal (TIP 472): `010 + 1` = 11 (decimal 10+1).
+        assert_eq!(eval_d("010 + 1", "tcl9.0"), Some(TclValue::Int(11)));
+        assert_eq!(eval_d("-010", "tcl9.0"), Some(TclValue::Int(-10)));
+    }
+
+    #[test]
+    fn dialect_blind_arithmetic_declines_on_bare_leading_zero() {
+        // FN guard (regression for the fix): when the dialect is genuinely
+        // unknown (plain `eval_tcl_expr`, no octal info at all), arithmetic
+        // on a bare leading-zero literal whose octal and decimal readings
+        // *disagree* must decline rather than silently pick one — `010` is
+        // octal 8 vs decimal 10.
+        assert_eq!(eval_str("010 + 1"), None);
+        assert_eq!(eval_str("-010"), None);
+        assert_eq!(eval_str("abs(-010)"), None);
+        // Unaffected: no leading-zero operand, arithmetic still folds.
+        assert_eq!(eval_str("10 + 1"), Some(TclValue::Int(11)));
+        // Unaffected: `07` is 7 under both readings (7 is a valid octal
+        // digit), so a dialect-blind fold is still sound here.
+        assert_eq!(eval_str("07 + 1"), Some(TclValue::Int(8)));
+    }
+
+    #[test]
+    fn invalid_octal_arithmetic_declines_under_octal_dialect() {
+        // TN: `08 + 1` is a genuine Tcl *error* under the 8.x octal rule
+        // (`08` is not valid octal — tclsh: "invalid bareword \"08\"") —
+        // the const-folder has no error channel, so it must decline (defer
+        // to the runtime, which will raise the real error) rather than
+        // guess a decimal reading.
+        let eval_d = |expr: &str, dialect: &str| {
+            eval_tcl_expr_in_dialect(&parse_expr(expr, None), &Env::new(), dialect)
+        };
+        assert_eq!(eval_d("08 + 1", "tcl8.6"), None);
+        // Decimal dialect reads `08` as 8, so this is fine there.
+        assert_eq!(eval_d("08 + 1", "tcl9.0"), Some(TclValue::Int(9)));
+    }
+
+    #[test]
     fn leading_zero_is_octal_only_excludes_tcl9() {
         assert!(leading_zero_is_octal("tcl8.4"));
         assert!(leading_zero_is_octal("tcl8.5"));
@@ -966,7 +1073,26 @@ mod tests {
     fn division_by_zero() {
         assert_eq!(eval_str("1 / 0"), None);
         assert_eq!(eval_str("1 % 0"), None);
-        assert_eq!(eval_str("1.0 / 0.0"), None);
+        // tclsh: `expr {0.0/0.0}` is a domain error (NaN) — declines.
+        assert_eq!(eval_str("0.0 / 0.0"), None);
+    }
+
+    #[test]
+    fn float_division_by_zero_with_nonzero_numerator_folds_to_infinity() {
+        // TP (fixes a previous over-conservative decline): tclsh:
+        // `expr {1.0/0.0}` -> Inf, `expr {-1.0/0.0}` -> -Inf,
+        // `expr {1.0/-0.0}` -> -Inf. A non-zero numerator over a zero
+        // divisor is a real, foldable IEEE value, not a domain error —
+        // only 0.0/0.0 itself errors.
+        assert_eq!(eval_str("1.0 / 0.0"), Some(TclValue::Float(f64::INFINITY)));
+        assert_eq!(
+            eval_str("-1.0 / 0.0"),
+            Some(TclValue::Float(f64::NEG_INFINITY))
+        );
+        assert_eq!(
+            eval_str("1.0 / -0.0"),
+            Some(TclValue::Float(f64::NEG_INFINITY))
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/var_observability.rs
+++ b/rust/tcl-compiler/src/var_observability.rs
@@ -94,7 +94,12 @@ impl EscapeFlag {
 }
 
 /// A per-variable flag map; absent names default to `EscapeFlag::empty()`.
-type State = HashMap<String, EscapeFlag>;
+///
+/// `pub(crate)` so [`crate::cfg_builder::global_write_info`] can thread the
+/// same state type through its own flow-insensitive whole-body walk (it
+/// reuses [`stmt_gen`] rather than re-deriving the `global`/`variable`/
+/// `upvar` recognition logic).
+pub(crate) type State = HashMap<String, EscapeFlag>;
 
 /// Variable named by a `trace` command, or `None`.  Recognises both the
 /// `trace add variable NAME …` (8.5+) and the 8.4 `trace variable NAME …`
@@ -120,7 +125,11 @@ fn mark(state: &mut State, args: &[String], idx: usize, flag: EscapeFlag) {
 }
 
 /// Apply `stmt`'s alias / trace declarations to `state` in place.
-fn stmt_gen(stmt: &Statement, state: &mut State) {
+///
+/// `pub(crate)`: reused by [`crate::cfg_builder::global_write_info`] for its
+/// own flow-insensitive whole-body scan — the recognition logic for
+/// `global` / `variable` / `upvar` / `trace` lives here once.
+pub(crate) fn stmt_gen(stmt: &Statement, state: &mut State) {
     let (Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. }) = stmt
     else {
         return;
@@ -307,6 +316,131 @@ pub fn analyse_var_observability(cfg: &CfgFunction) -> VarObservability<'_> {
     }
 }
 
+/// Module-wide (flow-insensitive, call-order-independent) summary of every
+/// `trace add variable` / `trace variable` target across the whole module —
+/// top level, every proc, every method — the [`crate::command_binding::
+/// ModuleCommandMutations`] pattern applied to variable traces instead of
+/// command bindings.
+///
+/// [`analyse_var_observability`]'s flow-sensitive `TRACED` flag only
+/// recognises a trace that is added *and read in the same function body*: a
+/// trace installed by one proc and observed through a variable read in a
+/// *different* proc — reached via a call whose relative order isn't
+/// statically known — is invisible to it. That gap is real and unsound:
+///
+/// ```tcl
+/// proc install_trace {} { trace add variable ::x write {apply {a {set ::x 99}}} }
+/// set x 5
+/// install_trace
+/// set x 6
+/// puts [expr {$x + 1}]     ;# tclsh: 100 (the trace fires on `set x 6`).
+/// ```
+///
+/// Rather than a full interprocedural call-order fixpoint, this takes the
+/// same sound over-approximation `ModuleCommandMutations` does: a name traced
+/// *anywhere* in the module is treated as traced *everywhere*, for the
+/// lifetime of the module (a later `trace remove` does not "untrace" it here
+/// — the fact is flow-insensitive by design, so it only ever prevents an
+/// unsound fold, never causes one).
+#[derive(Debug, Clone, Default, PartialEq, Eq, Hash)]
+pub struct ModuleVariableTraces {
+    /// Literal variable names traced anywhere in the module.
+    names: std::collections::BTreeSet<String>,
+    /// A body traces a dynamically-computed target (`trace add variable
+    /// $name write …`) — resolution of *any* name is opaque, mirroring
+    /// [`crate::command_binding::ModuleCommandMutations`]'s `dynamic` flag.
+    dynamic: bool,
+}
+
+impl ModuleVariableTraces {
+    /// True when `name` is traced somewhere in the module (or the module
+    /// traces a dynamically-computed target, which could be any name).
+    #[must_use]
+    pub fn is_traced(&self, name: &str) -> bool {
+        self.dynamic || self.names.contains(canonical_outer_name(name))
+    }
+}
+
+/// Canonicalise a variable name for module-wide outer-scope matching: strip
+/// a `$`/`${…}`/array-index wrapper (via [`normalise_var_name`]), then a
+/// single leading `::` — the top-level scope *is* the global namespace, so
+/// `trace add variable ::x …` and a bare top-level `set x …` name the same
+/// variable, and must canonicalise to the same string for [`ModuleVariableTraces::is_traced`]
+/// to recognise them as one. A deeper `::ns::x` is left with its remaining
+/// `::` intact: a bare local can never collide with it, and any *direct*
+/// reference to `::ns::x` elsewhere is already unconditionally treated as
+/// externally mutable by SCCP's own `starts_with("::")` rule, so this lookup
+/// is never reached for that spelling.
+fn canonical_outer_name(name: &str) -> &str {
+    let n = normalise_var_name(name);
+    n.strip_prefix("::").unwrap_or(n)
+}
+
+/// Scan `module` for every `trace add variable` / `trace variable` target —
+/// top level, every proc, every method — recursing into nested control-flow
+/// bodies via [`crate::ir_helpers::nested_bodies`].
+#[must_use]
+pub fn scan_module_variable_traces(module: &crate::ir::Module) -> ModuleVariableTraces {
+    let mut names = std::collections::BTreeSet::new();
+    let mut dynamic = false;
+
+    let mut visit = |script: &crate::ir::Script| {
+        walk_trace_targets(script, &mut names, &mut dynamic);
+    };
+    visit(&module.top_level);
+    for proc in module.procedures.values() {
+        visit(&proc.body);
+    }
+    for method in module.methods.values() {
+        visit(&method.body);
+    }
+
+    ModuleVariableTraces { names, dynamic }
+}
+
+fn walk_trace_targets(
+    script: &crate::ir::Script,
+    names: &mut std::collections::BTreeSet<String>,
+    dynamic: &mut bool,
+) {
+    for stmt in &script.statements {
+        record_trace_target(stmt, names, dynamic);
+        for body in crate::ir_helpers::nested_bodies(stmt) {
+            walk_trace_targets(body, names, dynamic);
+        }
+    }
+}
+
+/// Record `stmt`'s trace target (if any) into `names`, or set `dynamic` when
+/// the target is not a literal name. Mirrors [`stmt_gen`]'s `"trace"` arm,
+/// but module-wide rather than keyed into a per-block flag state.
+fn record_trace_target(
+    stmt: &Statement,
+    names: &mut std::collections::BTreeSet<String>,
+    dynamic: &mut bool,
+) {
+    let (Statement::Call { args, .. } | Statement::Barrier { args, .. }) = stmt else {
+        return;
+    };
+    let canon = stmt.canonical_command_or_source();
+    if canon.strip_prefix("::").unwrap_or(canon) != "trace" {
+        return;
+    }
+    let Some(target) = trace_target(args) else {
+        return;
+    };
+    if target.starts_with('$') {
+        *dynamic = true;
+        return;
+    }
+    let name = canonical_outer_name(target);
+    if name.is_empty() {
+        *dynamic = true;
+        return;
+    }
+    names.insert(name.to_owned());
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -383,5 +517,81 @@ mod tests {
         let obs = analyse_var_observability(&fu.cfg);
         assert!(obs.escaping_var_names().is_empty());
         assert!(EscapeFlag::empty().is_empty());
+    }
+
+    fn module(src: &str) -> crate::ir::Module {
+        crate::lowering::lower_to_ir(src, &CommandRegistry::build_default())
+    }
+
+    #[test]
+    fn empty_module_traces_nothing() {
+        let m = module("");
+        assert_eq!(scan_module_variable_traces(&m), ModuleVariableTraces::default());
+    }
+
+    #[test]
+    fn top_level_trace_recorded() {
+        let m = module("trace add variable ::x write cb");
+        let t = scan_module_variable_traces(&m);
+        assert!(t.is_traced("::x"));
+        assert!(t.is_traced("x"));
+        assert!(!t.is_traced("y"));
+    }
+
+    #[test]
+    fn trace_inside_helper_proc_recorded_module_wide() {
+        // The F4b repro: the trace is installed by a *different* proc than
+        // the one reading the variable — a module-wide, not per-function,
+        // fact.
+        let m = module("proc install_trace {} { trace add variable ::x write cb }\nset x 5");
+        let t = scan_module_variable_traces(&m);
+        assert!(t.is_traced("x"));
+    }
+
+    #[test]
+    fn legacy_8_4_trace_variable_spelling_recorded() {
+        let m = module("proc p {} { trace variable v w cb }");
+        let t = scan_module_variable_traces(&m);
+        assert!(t.is_traced("v"));
+    }
+
+    #[test]
+    fn trace_inside_nested_control_flow_recorded() {
+        let m = module("proc p {} { if {$c} { trace add variable v write cb } }");
+        let t = scan_module_variable_traces(&m);
+        assert!(t.is_traced("v"));
+    }
+
+    #[test]
+    fn unrelated_name_not_traced() {
+        let m = module("proc p {} { trace add variable v write cb }");
+        let t = scan_module_variable_traces(&m);
+        assert!(!t.is_traced("other"));
+    }
+
+    #[test]
+    fn dynamic_trace_target_forces_every_name_traced() {
+        let m = module("proc p {name} { trace add variable $name write cb }");
+        let t = scan_module_variable_traces(&m);
+        assert!(t.is_traced("anything"));
+        assert!(t.is_traced("x"));
+    }
+
+    #[test]
+    fn trace_removed_later_still_counted_flow_insensitively() {
+        // By design (module doc): the fact is flow-insensitive, so a later
+        // `trace remove` does not "untrace" the name — this only ever
+        // prevents an unsound fold, never causes one.
+        let m =
+            module("proc p {} { trace add variable v write cb\ntrace remove variable v write cb }");
+        let t = scan_module_variable_traces(&m);
+        assert!(t.is_traced("v"));
+    }
+
+    #[test]
+    fn method_body_trace_recorded() {
+        let m = module("oo::class create C {\n method m {} { trace add variable v write cb }\n}");
+        let t = scan_module_variable_traces(&m);
+        assert!(t.is_traced("v"));
     }
 }

--- a/rust/tcl-compiler/src/var_observability.rs
+++ b/rust/tcl-compiler/src/var_observability.rs
@@ -526,7 +526,10 @@ mod tests {
     #[test]
     fn empty_module_traces_nothing() {
         let m = module("");
-        assert_eq!(scan_module_variable_traces(&m), ModuleVariableTraces::default());
+        assert_eq!(
+            scan_module_variable_traces(&m),
+            ModuleVariableTraces::default()
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/tests/compiler_analysis_residual.rs
+++ b/rust/tcl-compiler/tests/compiler_analysis_residual.rs
@@ -949,6 +949,7 @@ fn rebased_units(base: &str, shifted: &str) -> (CompilationUnit, CompilationUnit
                     true,
                     req.upvar_procs.clone(),
                     req.proc_params.clone(),
+                    req.global_write_procs.clone(),
                 );
                 let pc =
                     tcl_compiler::compilation_unit::decode_param_constants(req.param_constants);

--- a/rust/tcl-compiler/tests/optimiser_coverage.rs
+++ b/rust/tcl-compiler/tests/optimiser_coverage.rs
@@ -263,6 +263,161 @@ fn o101_constant_folding_ternary_unary_logical() {
     assert!(opt_absent("set v [expr {$x + 1}]", TCL, "O101"));
 }
 
+#[test]
+fn o101_dialect_octal_arithmetic() {
+    // TP: `010` is octal 8 under tcl8.x/f5-irules (this suite's default
+    // dialect, TCL = "tcl8.6") — tclsh8.6: `010 + 1` = 9, `010 * 2` = 16,
+    // `-010` = -8. Before the dialect-aware fix these folded to the
+    // decimal reading (11, 20, -10) — a miscompile.
+    assert!(optimised("set v [expr {010 + 1}]", TCL).contains("set v 9"));
+    assert!(optimised("set v [expr {010 * 2}]", TCL).contains("set v 16"));
+    assert!(optimised("set v [expr {-010}]", TCL).contains("set v -8"));
+    assert!(optimised("set v [expr {010 + 1}]", IR).contains("set v 9"));
+
+    // TP (control): the same source under plain tcl9.0 reads `010` as
+    // decimal (TIP 472) — tclsh9.0: `010 + 1` = 11.
+    assert!(optimised("set v [expr {010 + 1}]", "tcl9.0").contains("set v 11"));
+
+    // FN guard: `08` is invalid octal under tcl8.x (Tcl raises an error —
+    // tclsh8.6: `expr {08 + 1}` -> "invalid bareword \"08\"") so the
+    // const-folder must decline rather than guess a decimal reading.
+    assert!(opt_absent("set v [expr {08 + 1}]", TCL, "O101"));
+    // Unaffected under tcl9.0, where `08` is decimal 8.
+    assert!(optimised("set v [expr {08 + 1}]", "tcl9.0").contains("set v 9"));
+}
+
+#[test]
+fn o101_expr_redefinition_guard() {
+    // FP guard: once `expr` is renamed, `expr {1 + 2}` no longer calls the
+    // builtin evaluator — O101 must not fold it.
+    assert!(opt_absent(
+        "rename expr real_expr\nexpr {1 + 2}",
+        TCL,
+        "O101"
+    ));
+    // TN/control: an unrelated rename elsewhere in the module doesn't
+    // block the fold (the gate is keyed on `expr` specifically).
+    assert!(opt_fires(
+        "rename puts real_puts\nexpr {1 + 2}",
+        TCL,
+        "O101"
+    ));
+}
+
+#[test]
+fn o101_mathfunc_redefinition_guard() {
+    // FP guard: `proc ::tcl::mathfunc::abs` shadows the builtin math
+    // function everywhere in the module — real Tcl compiles `abs(x)` to a
+    // `tcl::mathfunc::abs` command invocation, so once that's
+    // user-defined, `expr {abs(-5)}` no longer means "call the C abs".
+    assert!(opt_absent(
+        "proc ::tcl::mathfunc::abs {x} { return 999 }\nexpr {abs(-5)}",
+        TCL,
+        "O101"
+    ));
+    // TN/control: no override present, folds as usual. tclsh: abs(-5)=5.
+    assert!(optimised("set v [expr {abs(-5)}]", TCL).contains("set v 5"));
+}
+
+#[test]
+fn o101_global_write_across_call_guard() {
+    // FP guard (repro A): `mutate` writes the global `x` via `global x; set x
+    // 99`, called between the top-level `set x 5` and the `expr {$x + 1}`
+    // read. tclsh: `mutate` runs before the `puts`, so `x` is 99 there —
+    // `expr {$x + 1}` is 100, NOT 6. Before the CFG builder widened the
+    // call's `defs` with the callee's global-write summary, SCCP treated `x`
+    // as still holding the SSA value from the top-level `set x 5` across the
+    // opaque `mutate` call, and O101 wrongly folded to `puts 6`.
+    assert!(opt_absent(
+        "proc mutate {} { global x; set x 99 }\nset x 5\nmutate\nputs [expr {$x + 1}]",
+        TCL,
+        "O101"
+    ));
+
+    // TN/control: an unrelated global write in a *different* proc must not
+    // widen `x` — the fix is name-precise, not a coarse "any call may
+    // mutate any global" widening. tclsh: `mutate_y` never touches `x`, so
+    // `expr {$x + 1}` is still 6 and O101 correctly folds it.
+    assert!(
+        optimised(
+            "proc mutate_y {} { global y; incr y }\nset x 5\nmutate_y\nputs [expr {$x + 1}]",
+            TCL,
+        )
+        .contains("puts 6")
+    );
+
+    // TP (transitive): `outer` doesn't write `x` itself but calls `mutate`,
+    // which does — the call-graph closure must still invalidate `x` at the
+    // `outer` call site. tclsh: same 100 result as the direct-call repro.
+    assert!(opt_absent(
+        "proc mutate {} { global x; set x 99 }\nproc outer {} { mutate }\nset x 5\nouter\nputs [expr {$x + 1}]",
+        TCL,
+        "O101"
+    ));
+
+    // TP (namespace variable): `variable` writes are outer-scope too.
+    // tclsh: same reasoning as the `global` repro — 100, not 6.
+    assert!(opt_absent(
+        "namespace eval ::ns { variable x 5 }\nproc ::ns::mutate {} { variable x; set x 99 }\nset ::ns::x 5\n::ns::mutate\nputs [expr {$::ns::x + 1}]",
+        TCL,
+        "O101"
+    ));
+
+    // TP (embedded command substitution): the same soundness gap reached via
+    // `set y [mutate]` rather than a bare `mutate` statement — the
+    // embedded-substitution scan must catch it too.
+    assert!(opt_absent(
+        "proc mutate {} { global x; set x 99; return 1 }\nset x 5\nset y [mutate]\nputs [expr {$x + 1}]",
+        TCL,
+        "O101"
+    ));
+
+    // TP (conditional-branch write): sound over-approximation — a global
+    // write on a branch that may not execute still invalidates the name at
+    // the call site (the analysis is flow-insensitive by design).
+    assert!(opt_absent(
+        "proc mutate {} { global x\nif {$::cond} { set x 99 } }\nset x 5\nmutate\nputs [expr {$x + 1}]",
+        TCL,
+        "O101"
+    ));
+}
+
+#[test]
+fn o101_module_wide_variable_trace_guard() {
+    // FP guard (repro B): a trace on `x` is installed by `install_trace`, a
+    // *different* proc than the code performing the final `set x 6` / read
+    // — the flow-sensitive TRACED flag (installed and read in the same
+    // function body) can't see this; it needs the module-wide fact. tclsh:
+    // the write trace rewrites `x` to 99 on every write, so `set x 6` really
+    // leaves `x` == 99 and `expr {$x + 1}` is 100, NOT 7.
+    assert!(opt_absent(
+        "proc install_trace {} { trace add variable ::x write {apply {a {set ::x 99}}} }\nset x 5\ninstall_trace\nset x 6\nputs [expr {$x + 1}]",
+        TCL,
+        "O101"
+    ));
+
+    // TN/control: an unrelated trace (on a different variable) must not
+    // widen `x` — the fix is name-precise. tclsh: `y` is never written by
+    // this trace, `x` stays a plain local, so `expr {$x + 1}` still folds.
+    assert!(
+        optimised(
+            "trace add variable y write cb\nset x 6\nputs [expr {$x + 1}]",
+            TCL,
+        )
+        .contains("puts 7")
+    );
+
+    // TP (trace removed later still declines to fold): the fact is
+    // flow-insensitive by design — a later `trace remove` does not
+    // "untrace" a name for this analysis, so this only ever prevents an
+    // otherwise-unsound fold, it never wrongly blocks one tclsh agrees with.
+    assert!(opt_absent(
+        "trace add variable x write cb\ntrace remove variable x write cb\nset x 6\nputs [expr {$x + 1}]",
+        TCL,
+        "O101"
+    ));
+}
+
 // ===========================================================================
 // O102 — fold [expr {...}] command substitution
 // ===========================================================================

--- a/rust/tcl-compiler/tests/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/tests/tcl_expr_eval.rs
@@ -41,9 +41,12 @@
 //!   `10 ** 18` (≤ `i64::MAX`) still folds. See
 //!   [`exponentiation_big_results_past_wide_decline_to_fold`].
 //! * **Dialect-aware leading zero.** The 8.x-vs-9.0 octal rule is resolved via
-//!   the explicit [`eval_tcl_expr_in_dialect`] entry point. A bare leading-zero
-//!   operand under an *unknown* dialect is deliberately declined (`None`) rather
-//!   than guessed.
+//!   the explicit [`eval_tcl_expr_in_dialect`] entry point, and applies to
+//!   arithmetic/unary/math-function operands as well as comparisons. A bare
+//!   leading-zero operand under an *unknown* dialect folds only when the
+//!   octal and decimal readings agree (`07` is `7` either way) and declines
+//!   (`None`) when they disagree (`010`: octal 8 vs decimal 10) rather than
+//!   guessing.
 //! * **`format_tcl_value`** takes a `TclValue`, so free-float cases are written
 //!   `format_tcl_value(TclValue::Float(3.14))`.
 //!
@@ -208,10 +211,14 @@ fn modulo_sign_follows_divisor() {
 
 #[test]
 fn division_and_modulo_by_zero_decline() {
-    // tclsh: all are "divide by zero" errors → not foldable (None).
+    // tclsh: integer division/modulo by zero are "divide by zero" errors →
+    // not foldable (None). A float division by zero with a non-zero
+    // numerator is a real IEEE value (Inf), not an error — tclsh:
+    // `expr {1.0/0}` -> Inf; only 0.0/0.0 itself is a domain error.
     assert_eq!(eval_str("1 / 0"), None);
     assert_eq!(eval_str("1 % 0"), None);
-    assert_eq!(eval_str("1.0 / 0"), None);
+    assert_eq!(eval_str("1.0 / 0"), Some(float(f64::INFINITY)));
+    assert_eq!(eval_str("0.0 / 0"), None);
 }
 
 // =========================================================================
@@ -226,6 +233,11 @@ fn exponentiation_integer_and_float() {
     assert_eq!(eval_str("2 ** 10"), Some(int(1024)));
     assert_eq!(eval_str("4 ** 2"), Some(int(16)));
     assert_eq!(eval_str("0xff ** 2"), Some(int(65025)));
+    // `07` is unambiguous under a dialect-blind fold: it reads as 7 under
+    // both the octal rule (a valid octal digit) and the decimal rule, so
+    // this still folds even without dialect info (unlike `010`, whose
+    // octal/decimal readings disagree — see `dialect_blind_arithmetic_
+    // declines_on_bare_leading_zero` in src/tcl_expr_eval.rs).
     assert_eq!(eval_str("18 ** 07"), Some(int(612_220_032)));
     assert_eq!(eval_str("0xff ** 0x3"), Some(int(16_581_375)));
     assert_eq!(eval_str("5 ** 0"), Some(int(1)));

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -37,6 +37,7 @@ use std::collections::{BTreeSet, HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use tcl_compiler::cfg_builder::build_cfg_function_with_upvars;
+use tcl_compiler::cfg_builder::global_write_info::GlobalWriteInfo;
 use tcl_compiler::cfg_builder::upvar_info::UpvarInfo;
 use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit, LatticeRequest};
 use tcl_compiler::compiler_checks::{DiagCode, Diagnostic as CompilerCheck};
@@ -45,6 +46,7 @@ use tcl_compiler::ir::Script;
 use tcl_compiler::optimiser::Optimisation;
 use tcl_compiler::ssa::ValueKey;
 use tcl_compiler::taint::TaintLattice;
+use tcl_compiler::var_observability::ModuleVariableTraces;
 // The compiler's per-proc return-taint summary (the colour-aware transfer
 // function the interprocedural fixpoint converges) — aliased to avoid clashing
 // with this crate's `ProcTaintSummary` (the *interproc-analysis* projection in
@@ -681,18 +683,24 @@ pub fn item_body_analysis<'db>(db: &'db dyn TclDb, key: ItemBodyKey<'db>) -> Arc
     ))
 }
 
-/// Interned module-wide CFG context (`upvar_procs` + `proc_params` from
-/// `prepare_cfg_context`), the context a procedure body's CFG is built under.
-/// Interned once per build and shared by every [`FnLatticeKey`] so a procedure's
-/// key stays small and the per-build interning cost is `O(procs)`, not
-/// `O(procs²)`.  The entry vecs are sorted by name before interning so an equal
-/// context (regardless of hash-map iteration order) yields the same id.
+/// Interned module-wide context (`upvar_procs` + `proc_params` +
+/// `global_write_procs` from `prepare_cfg_context`, plus the module-wide
+/// variable-trace fact from `scan_module_variable_traces`) that a
+/// procedure body's CFG + SCCP lattice is built under. Interned once per
+/// build and shared by every [`FnLatticeKey`] so a procedure's key stays
+/// small and the per-build interning cost is `O(procs)`, not `O(procs²)`.
+/// The entry vecs are sorted by name before interning so an equal context
+/// (regardless of hash-map iteration order) yields the same id.
 #[salsa::interned]
 pub struct CfgContext<'db> {
     #[returns(ref)]
     pub upvar_ctx: Vec<(String, UpvarInfo)>,
     #[returns(ref)]
     pub proc_params: Vec<(String, Vec<String>)>,
+    #[returns(ref)]
+    pub global_write_ctx: Vec<(String, GlobalWriteInfo)>,
+    #[returns(ref)]
+    pub module_traces: ModuleVariableTraces,
 }
 
 /// Interned identity of one procedure's **offset-0** baseline lattice
@@ -752,8 +760,17 @@ pub fn function_lattice<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<
     let upvar: HashMap<String, UpvarInfo> = context.upvar_ctx(db).iter().cloned().collect();
     let proc_params: HashMap<String, Vec<String>> =
         context.proc_params(db).iter().cloned().collect();
+    let global_write_procs: HashMap<String, GlobalWriteInfo> =
+        context.global_write_ctx(db).iter().cloned().collect();
     let registry = db.registry(key.dialect(db));
-    let cfg = build_cfg_function_with_upvars(key.qname(db), key.body(db), true, upvar, proc_params);
+    let cfg = build_cfg_function_with_upvars(
+        key.qname(db),
+        key.body(db),
+        true,
+        upvar,
+        proc_params,
+        global_write_procs,
+    );
     let param_constants =
         tcl_compiler::compilation_unit::decode_param_constants(key.param_constants(db));
     let known_classes: HashSet<String> = key.known_classes(db).iter().cloned().collect();
@@ -764,6 +781,7 @@ pub fn function_lattice<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<
         &registry,
         param_constants.as_ref(),
         &known_classes,
+        Some(context.module_traces(db)),
     ))
 }
 
@@ -889,7 +907,19 @@ fn build_unit_with_keys<'db>(
                 .map(|(k, v)| (k.clone(), v.clone()))
                 .collect();
             proc_params.sort_by(|a, b| a.0.cmp(&b.0));
-            CfgContext::new(db, upvar, proc_params)
+            let mut global_write: Vec<(String, GlobalWriteInfo)> = req
+                .global_write_procs
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect();
+            global_write.sort_by(|a, b| a.0.cmp(&b.0));
+            CfgContext::new(
+                db,
+                upvar,
+                proc_params,
+                global_write,
+                req.module_traces.clone(),
+            )
         });
         let key = FnLatticeKey::new(
             db,

--- a/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
@@ -349,7 +349,10 @@ fn expr_redefinition_blocks_fold() {
     // invokes the builtin evaluator — O101 must leave it unrewritten.
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
-    lsp.open_ready(&uri, "rename expr real_expr\nproc p {} { return [expr {1 + 2}] }\n");
+    lsp.open_ready(
+        &uri,
+        "rename expr real_expr\nproc p {} { return [expr {1 + 2}] }\n",
+    );
     let result = lsp.execute_command("tcl-lsp.optimiseDocument", serde_json::json!([uri, "full"]));
     let source = result.get("source").and_then(Value::as_str).unwrap_or("");
     assert!(source.contains("expr {1 + 2}"), "{source:?}");

--- a/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
@@ -321,3 +321,67 @@ fn o103_does_not_fold_proc_renamed_over() {
     let source = result.get("source").and_then(Value::as_str).unwrap_or("");
     assert!(source.contains("set x [double 21]"), "{source:?}");
 }
+
+// O101 deep-review (F1-F4) end-to-end coverage: each case exercises the real
+// server's own dialect detection / whole-module scan, not just the compiler
+// API directly, per the review's "editor-facing" requirement.
+
+#[test]
+fn irules_dialect_leading_zero_folds_as_octal() {
+    // TP: opened with the `tcl-irule` language id, so the server's own
+    // dialect detection selects iRules' octal-leading-zero reading (same as
+    // tcl8.x) — tclsh8.6/iRules: `010 + 1` == 9 (octal 8 + 1), not 11.
+    let mut lsp = Lsp::irules();
+    let uri = unique_uri("irule");
+    lsp.open_ready_lang(
+        &uri,
+        "when RULE_INIT {\n log local0. [expr {010 + 1}]\n}\n",
+        "tcl-irule",
+    );
+    let result = lsp.execute_command("tcl-lsp.optimiseDocument", serde_json::json!([uri, "full"]));
+    let source = result.get("source").and_then(Value::as_str).unwrap_or("");
+    assert!(source.contains("log local0. 9"), "{source:?}");
+}
+
+#[test]
+fn expr_redefinition_blocks_fold() {
+    // FP guard (F2): once `expr` is renamed, `[expr {1 + 2}]` no longer
+    // invokes the builtin evaluator — O101 must leave it unrewritten.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "rename expr real_expr\nproc p {} { return [expr {1 + 2}] }\n");
+    let result = lsp.execute_command("tcl-lsp.optimiseDocument", serde_json::json!([uri, "full"]));
+    let source = result.get("source").and_then(Value::as_str).unwrap_or("");
+    assert!(source.contains("expr {1 + 2}"), "{source:?}");
+    assert!(!source.contains("return 3"), "{source:?}");
+}
+
+#[test]
+fn expr_not_redefined_still_folds() {
+    // TN/control: the same source with no `rename` still folds normally —
+    // proves the F2 guard is keyed on an actual rebinding, not a blanket
+    // regression.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "proc p {} { return [expr {1 + 2}] }\n");
+    let result = lsp.execute_command("tcl-lsp.optimiseDocument", serde_json::json!([uri, "full"]));
+    let source = result.get("source").and_then(Value::as_str).unwrap_or("");
+    assert!(source.contains("return 3"), "{source:?}");
+}
+
+#[test]
+fn global_write_across_opaque_call_blocks_fold() {
+    // FP guard (F4a): `mutate` writes the global `x` via `global x; set x
+    // 99`, called between the top-level `set x 5` and the `expr {$x + 1}`
+    // read. tclsh: `x` is 99 by the time `puts` runs, so the correct value
+    // is 100 — O101 must not fold this to `puts 6`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc mutate {} { global x; set x 99 }\nset x 5\nmutate\nputs [expr {$x + 1}]\n",
+    );
+    let result = lsp.execute_command("tcl-lsp.optimiseDocument", serde_json::json!([uri, "full"]));
+    let source = result.get("source").and_then(Value::as_str).unwrap_or("");
+    assert!(!source.contains("puts 6"), "{source:?}");
+}


### PR DESCRIPTION
## Summary

Deep review of O101 (fold constant integer expressions) surfaced six independently-verified correctness/precision defects, all fixed via existing shared mechanisms rather than new per-command special-casing:

- **Dialect-blind octal handling**: arithmetic/unary/mathfunc folding ignored the registry's `leading_zero_is_octal()` dialect flag that comparisons already honoured, so `expr {010 + 1}` folded to the wrong constant under tcl8.x/f5-irules. Threaded the dialect-aware entry points to every O101 call site (optimiser passes, SCCP, static-loop simulation, codegen).
- **`expr`/math-function rename or shadowing** (`rename expr`, a user-defined `proc ::tcl::mathfunc::NAME`) was never checked before folding — added `ModuleCommandMutations` trust gates and a shadowed-mathfunc AST walk at every O101/O115 fold site.
- **Interprocedural soundness**: SCCP treated a global/namespace variable as untouched across an opaque proc call, letting a callee's `global x; set x ...` silently disappear from constant propagation. Added `cfg_builder::global_write_info` (a per-proc summary, transitively closed over the call graph) that widens `Call.defs` exactly like the existing upvar-invalidation pass, plus a module-wide variable-trace fact (`var_observability::ModuleVariableTraces`) so a trace installed by one proc correctly forces `Overdefined` on a name read elsewhere.
- **Centralised** three divergent numeric-string classifiers onto the shared `tcl_syntax::number` grammar, and float division-by-zero now matches tclsh's non-zero-numerator `Inf`/`-Inf` behaviour instead of unconditionally declining.

All new logic reuses existing registry/CFG/SCCP infrastructure; no command knowledge was hardcoded into the compiler and no new clippy allows were added.

Also includes: a rebase onto `origin/rust`'s latest fixes (arity-checking gaps, the O103 proc-folding fix, version stamping), with a hand-resolved conflict in `propagation.rs` where this PR's dialect-aware `octal` threading was re-merged into `origin/rust`'s new fallthrough/variadic-args O103 fold logic.

## Validation

- [x] `cargo test -p tcl-compiler --lib` — 3719 passed
- [x] `make rust-check` (fmt + clippy `--workspace --all-targets -D warnings` + generated-file/doc drift checks) — clean
- [x] `cargo test -p tcl-lsp-server --test e2e -- diagnostic_matrix` — O101 lsp_e2e tests pass
- [x] `make test-ext` (VS Code extension integration suite, native server) — passes

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — O101's fold/decline conditions.
- [x] Updated the diagnostic-code KCS note: `docs/kcs/codes/kcs-optimisation-o101-integer-expression-folding.md` (there is no `docs/kcs/compiler/` note for this optimiser pass to update).
- [ ] N/A — no new KCS note added; the existing O101 note was updated in place.