### PR TITLE
Close two centralization gaps in #852's TclOO/ensemble arity checks

### DIFF
--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -106,6 +106,7 @@ class StringCommand(CommandDef):
 | `is_control_flow` | `bool` | `False` | Command is a control-flow statement (break, continue, return) |
 | `needs_start_cmd` | `bool` | `False` | Bytecode control flow: needs a `startCmd` instruction |
 | `creates_scope_alias` | `bool` | `False` | Creates a scope alias (upvar-like binding) |
+| `structurally_checked_arity` | `bool` | `False` | Registry `arity` is a descriptive floor only; a `clause_shape_check` hook owns real arity + shape validation, so the generic E002/E003 floor/ceiling check steps aside (`if`) |
 
 #### Purity and optimisation
 
@@ -120,6 +121,7 @@ class StringCommand(CommandDef):
 |-------|------|---------|---------|
 | `arg_roles` | `dict[int, ArgRole]` | `{}` | Static arg roles: `BODY`, `EXPR`, `VAR_NAME`, `VAR_READ`, `PATTERN`, etc. |
 | `arg_role_resolver` | `ArgRoleResolver \| None` | `None` | Dynamic arg-role resolution for variable-layout commands (if, try, switch) |
+| `clause_shape_check` | `ClauseShapeChecker \| None` | `None` | Validates a clause-chain shape a plain `min..=max` arity can't express (if's `elseif`/`else` chain -- see `tcl_registry::clause_shape`); the compiler dispatches on the hook's presence, not the command name |
 | `arg_types` | `dict[int, ArgTypeHint]` | `{}` | Per-argument type expectations (e.g. `INT`, `LIST`).  Drives shimmer detection |
 | `return_type` | `TclType \| None` | `None` | Return type of the command |
 | `keyword_completions` | `KeywordCompletionProvider \| None` | `None` | Keyword+scaffold completions for structural commands |

--- a/docs/design/compiler/fp-audit-todo.md
+++ b/docs/design/compiler/fp-audit-todo.md
@@ -471,6 +471,20 @@ can simplify this" suggestion. None swept yet.
   documented-and-silently dropped (`command_prefix.rs`'s module doc), which
   the `apply_callback_arity`'s always-zero `baked` argument confirms is a
   live, unexercised code path.
+  **2026-07-10 follow-up — two centralization gaps in the above closed:**
+  (1) the `new`/`create` constructor-arity check missed `createWithNamespace`
+  entirely (`ClassName createWithNamespace name ::ns ?args?` — the three
+  keywords' word layout is shared with `oo_class_arg_roles`'s identical
+  class-*definition* shapes) — `PendingCtorArity`'s `is_create: bool` is now
+  `CtorForm::{New,Create,CreateWithNamespace}`, each with its own leading-
+  word bump. (2) `handle_namespace_ensemble`'s `-command` extraction scanned
+  every word for literal equality with `-command`, so another option's value
+  word that happened to read `-command` (e.g. a pathological `-map` value)
+  could be misread as the flag itself — `namespace ensemble create`'s option
+  surface (`-command`/`-map`/`-parameters`/`-prefixes`/`-subcommands`/
+  `-unknown`, verified against this project's own `cmd_namespace.rs` VM
+  implementation) is now registry data (`ENSEMBLE_CREATE_OPTIONS`), walked
+  by declared value arity like every other option-skip in the analyser.
 - [x] **E004** malformed `if` — RESOLVED (0 corpus firings; verified against
   Tcl 9.0.4's `TclNRIfObjCmd`/`IfConditionCallback` C source and tclsh 8.6
   rather than a corpus sweep, since real-world malformed `if`s don't occur):

--- a/docs/design/compiler/fp-audit-todo.md
+++ b/docs/design/compiler/fp-audit-todo.md
@@ -471,7 +471,21 @@ can simplify this" suggestion. None swept yet.
   documented-and-silently dropped (`command_prefix.rs`'s module doc), which
   the `apply_callback_arity`'s always-zero `baked` argument confirms is a
   live, unexercised code path.
-- [ ] **E004** malformed control flow (0) — synthetic.
+- [x] **E004** malformed `if` — RESOLVED (0 corpus firings; verified against
+  Tcl 9.0.4's `TclNRIfObjCmd`/`IfConditionCallback` C source and tclsh 8.6
+  rather than a corpus sweep, since real-world malformed `if`s don't occur):
+  cleared a genuine FP — `if else {a}` / `if elseif {a}` are structurally
+  well-formed (the bareword sits in the condition slot, never keyword-matched
+  there; real Tcl fails at expression evaluation instead, a distinct problem).
+  Also fixed a redundant-diagnostic bug (a malformed `if` drew both a generic
+  E002 and E004 for the same defect — `if`'s registry arity floor is now
+  descriptive-only, gated by `Traits::STRUCTURALLY_CHECKED_ARITY`), replaced
+  the generic "Malformed 'if' command" message with Tcl's own precise wording
+  per sub-case, and narrowed every span from the whole statement to the
+  offending word(s). The clause-chain walk itself moved into `tcl-registry`
+  (`commands::tcl::if_::walk_if`, exposed as a `clause_shape_check` hook on
+  `CommandSpec`) so it is shared with the `if_arg_roles` highlighting
+  resolver instead of being re-implemented in the compiler.
 - [ ] **E200** shimmer parse error (0) — synthetic.
 - [ ] **H300** possible paste error (0 corpus) — synthetic.
 

--- a/docs/design/rust/compiler-pipeline-parity.md
+++ b/docs/design/rust/compiler-pipeline-parity.md
@@ -963,7 +963,7 @@ Rust: `rust/tcl-compiler/src/analyser/*`, `compiler_checks.rs`, `irules_checks.r
 | Per-item incremental | — (none) | per_item.rs, item_tree.rs, state.rs | ➕ | Rust-ahead: offset-stable item identity + per-body memoisation, fuzzer-gated byte-identical to `analyse`. |
 | MRO algorithm | mro.py:38 `_tcloo_dfs` (two-pass DFS + late placement) | mro.rs:91 | ✅ | **Not C3** — both implement TclOO's `tclOOCall.c` two-pass DFS (correct for TclOO). |
 | Class hierarchy (CHA) | class_hierarchy.py | class_hierarchy.rs | ➕ | Parity + Rust defensive backfill/re-linearise. Non-deterministic `errors` order only (benign). |
-| TclOO construct coverage | _analyser/_oo.py (full) | analyser/oo.rs, handlers.rs | ❗ | Rust gaps: `oo::class` accepts only `create` (drops `new`/`createWithNamespace`); `initialise` body not walked; `property -get/-set` accessor bodies not walked. |
+| TclOO construct coverage | _analyser/_oo.py (full) | analyser/oo.rs, handlers.rs | ✅ | Stale-note fix: the three gaps previously listed here (`oo::class` dropping `new`/`createWithNamespace`; `initialise` body not walked; `property -get/-set` accessor bodies not walked) are all covered — see `oo_class_create_with_namespace_is_recognised`, `oo_initialise_body_is_walked`, `oo_property_accessor_bodies_are_walked` in `oo.rs`. |
 | snit support | _oo.py:492-790 + class_names.py | — | ❌ | **Largest OO gap** — no snit handling in the Rust analyser. |
 | Signature discovery | analyser/signature_scan.py | signature_scan/* | ✅ | Full parity (proc/namespace/import/package/source/interp-alias/oo::class/itcl::class, conditional recursion, tcllib factory resolver). |
 | proc lookup / reference matching | analyser/proc_lookup.py | signature_help.rs:322 | ✅ | Identical 3-way name predicate. |

--- a/docs/design/rust/compiler-pipeline-parity.md
+++ b/docs/design/rust/compiler-pipeline-parity.md
@@ -835,7 +835,7 @@ Rust: `rust/tcl-compiler/src/analyser/*`, `compiler_checks.rs`, `irules_checks.r
 | E001 | Missing subcommand (bare `string`) | compiler_checks.py:716 | — | ❌ | Deferred (diagnostics.rs:3541 comment). Arity E002/E003 ported; empty/missing-subcommand not. |
 | E002 | Too few arguments | compiler_checks.py:929 | diagnostics.rs:3826 | ✅ | Registry-signature driven both. |
 | E003 | Too many arguments | compiler_checks.py:930 | diagnostics.rs:3841 | ✅ | |
-| E004 | Parse/internal error | compiler_checks.py:69 | state.rs:3073 | ✅ | |
+| E004 | Malformed `if` clause shape | compiler_checks.py:69 | validity.rs:`emit_e004_clause_shape_diagnostic` (registry `commands::tcl::if_::walk_if` hook) | ✅ | Rust exceeds parity: precise per-clause messages/spans, no leading-else FP, no redundant E002 |
 | E100 | Syntax | checks/_syntax.py:18 | syntax_checks.rs:691 | ✅ | |
 | E101 | Unclosed bracket / missing open brace | _analyser/_utils.py:134 | recovery.rs:310 | ✅ | Same insert-`{` CodeFix. |
 | E102 | Syntax | checks/_syntax.py:117 | syntax_checks.rs:756 | ✅ | |

--- a/docs/kcs/codes/kcs-diagnostic-e002-too-few-arguments.md
+++ b/docs/kcs/codes/kcs-diagnostic-e002-too-few-arguments.md
@@ -19,7 +19,7 @@ Why do I see a red squiggle saying a command was called with too few arguments?
 
 Calling a command with fewer arguments than it requires will always raise a runtime error. Catching this statically prevents unexpected failures in production.
 
-This check is not limited to builtin commands: it also applies to same-file `proc` calls, `interp alias` targets (shifted by any prepended arguments), `rename`d commands (which keep the original's arity), TclOO methods and `forward`s (including `forward NAME my TARGET ?ARG…?`, the idiom for forwarding to a sibling or inherited method), TclOO constructor calls (`ClassName new ?args?` / `ClassName create name ?args?`, checked against the nearest explicit `constructor` in the class's inheritance chain — a class with no `constructor` anywhere in its hierarchy is never checked, since `TclOO`'s built-in default constructor accepts any number of arguments), and direct calls to an inline `apply {{params} body} ?args?` lambda.
+This check is not limited to builtin commands: it also applies to same-file `proc` calls, `interp alias` targets (shifted by any prepended arguments), `rename`d commands (which keep the original's arity), TclOO methods and `forward`s (including `forward NAME my TARGET ?ARG…?`, the idiom for forwarding to a sibling or inherited method), TclOO constructor calls (`ClassName new ?args?` / `ClassName create name ?args?` / `ClassName createWithNamespace name ::ns ?args?`, checked against the nearest explicit `constructor` in the class's inheritance chain — a class with no `constructor` anywhere in its hierarchy is never checked, since `TclOO`'s built-in default constructor accepts any number of arguments), and direct calls to an inline `apply {{params} body} ?args?` lambda.
 
 ## Symptoms
 

--- a/docs/kcs/codes/kcs-diagnostic-e003-too-many-arguments.md
+++ b/docs/kcs/codes/kcs-diagnostic-e003-too-many-arguments.md
@@ -19,7 +19,7 @@ Why do I see a red squiggle saying a command was called with too many arguments?
 
 Passing more arguments than a command accepts will raise a runtime error. The extra words are never silently ignored, so the script will fail.
 
-This check is not limited to builtin commands: it also applies to same-file `proc` calls, `interp alias` targets (shifted by any prepended arguments), `rename`d commands (which keep the original's arity), TclOO methods and `forward`s (including `forward NAME my TARGET ?ARG…?`, the idiom for forwarding to a sibling or inherited method), TclOO constructor calls (`ClassName new ?args?` / `ClassName create name ?args?`, checked against the nearest explicit `constructor` in the class's inheritance chain), and direct calls to an inline `apply {{params} body} ?args?` lambda.
+This check is not limited to builtin commands: it also applies to same-file `proc` calls, `interp alias` targets (shifted by any prepended arguments), `rename`d commands (which keep the original's arity), TclOO methods and `forward`s (including `forward NAME my TARGET ?ARG…?`, the idiom for forwarding to a sibling or inherited method), TclOO constructor calls (`ClassName new ?args?` / `ClassName create name ?args?` / `ClassName createWithNamespace name ::ns ?args?`, checked against the nearest explicit `constructor` in the class's inheritance chain), and direct calls to an inline `apply {{params} body} ?args?` lambda.
 
 ## Symptoms
 

--- a/docs/kcs/codes/kcs-diagnostic-e004-invalid-argument-count.md
+++ b/docs/kcs/codes/kcs-diagnostic-e004-invalid-argument-count.md
@@ -1,4 +1,4 @@
-# KCS: E004 — Why does the analyser flag extra words after `else`?
+# KCS: E004 — Why does the analyser say my `if` is malformed?
 
 > **Audience:** User
 > **Type:** Issue
@@ -13,31 +13,76 @@ default
 
 ## Question
 
-Why do I see a red squiggle on extra words following `else` in an `if` statement?
+Why do I see a red squiggle saying my `if` statement is malformed, or has extra words after `else`?
 
 ## Why
 
-Tcl's `if` command expects the `else` clause to be followed by a braced body. Bare words after `else` are not valid syntax and will cause a runtime error.
+Tcl's `if` command has a specific shape: a condition, an optional `then`
+keyword, and a body — optionally repeated after `elseif`, and optionally
+finished with an `else` (or an unlabelled trailing) body:
+
+```
+if expr1 ?then? body1 ?elseif expr2 ?then? body2 ...? ?else? ?bodyN?
+```
+
+Any call that doesn't fit this shape — a condition with nothing after it, a
+dangling `elseif`/`else` with no body, or words trailing the final body — will
+always raise a runtime error, so the analyser catches it statically. `E004`
+reports the *exact* piece that's missing or extra, and anchors the squiggle
+tightly on it rather than the whole `if` statement.
+
+**A leading `else` or `elseif` is not itself an error.** `if else {a}` is
+structurally well-formed — `else` there is just the condition text (an
+ill-typed one: Tcl will fail evaluating it as a boolean expression, a
+different problem `E004` doesn't cover), not a keyword. `then`, `elseif`, and
+`else` are only ever meaningful in the specific positions the shape above
+describes.
 
 ## Symptoms
 
-- A red squiggle appears after the `else` keyword, with the message "invalid argument count: extra words after 'else'".
+- A squiggle on the condition, `then`, `elseif`, or `else` word, with a
+  message like `No script following "1" argument` or `No expression after
+  "elseif" argument`.
+- A squiggle on the word(s) trailing the last recognised body, with the
+  message `Extra words after "else" clause in "if" command`.
 
 ## Example that triggers it
+
+```tcl
+if {$x}
+```
+
+The analyser reports **`E004`** — `No script following "$x" argument` — on
+the condition: there's no body to run.
 
 ```tcl
 if {$x} {puts yes} else extra
 ```
 
-The analyser reports **`E004`** on the unexpected word `extra`.
+The analyser reports **`E004`** — `Extra words after "else" clause in "if"
+command` — on the unexpected word `extra`.
 
 ## Fix
+
+For a missing body, add one:
 
 ```tcl
 if {$x} {puts yes} else {puts no}
 ```
 
-Wrap the else-branch body in braces so the parser recognises it as a script block.
+For extra trailing words, either wrap them into the final body or remove
+them, depending on what you meant:
+
+```tcl
+if {$x} {puts yes} else {puts no; puts also-no}
+```
+
+Most editors offer a quick fix for both directions: **merge trailing words
+into the body** (for extra words) or **remove incomplete trailing clause**
+(for a dangling `elseif`/`else` with nothing after it). Neither fix is
+offered when the very first clause (the initial condition + body) never
+completed — there's no well-formed prefix to fall back to, so the editor
+won't guess a body for you.
 
 ## How to suppress
 
@@ -48,4 +93,4 @@ Add `# noqa: E004` at the end of the offending line.
 - [KCS codes index](README.md)
 - [Diagnostics feature](../features/kcs-feature-diagnostics.md)
 - [lowering](../../GLOSSARY.md#lowering)
-- Related codes: `E001`
+- Related codes: `E001`, `E002`, `E003`

--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -116,6 +116,92 @@ suite("Code Actions", () => {
     assert.ok(resultOptsFix, "Should provide a result+options capture quick fix");
   });
 
+  test("provides merge-into-body quick fix for E004 extra words", async () => {
+    const e004Uri = getDocUri("diagnostics-e004.tcl");
+    await activate(e004Uri);
+    const diagnostics = await waitForDiagnostics(e004Uri, { minCount: 3 });
+
+    const extraWords = diagnostics.find(
+      (d) => d.message === 'Extra words after "else" clause in "if" command',
+    );
+    assert.ok(extraWords, "extra-words E004 diagnostic should be present");
+
+    const actions = (await pollUntil(
+      () =>
+        vscode.commands.executeCommand(
+          "vscode.executeCodeActionProvider",
+          e004Uri,
+          extraWords.range,
+        ),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => typeof a.title === "string" && a.title.toLowerCase().includes("merge"),
+        ),
+      { timeout: 10_000, label: "E004 extra-words merge quick fix" },
+    )) as vscode.CodeAction[];
+
+    const mergeFix = actions.find(
+      (a) => typeof a.title === "string" && a.title.toLowerCase().includes("merge"),
+    );
+    assert.ok(mergeFix, "Should provide a merge-into-body quick fix");
+  });
+
+  test("provides remove-clause quick fix for a dangling E004 elseif", async () => {
+    const e004Uri = getDocUri("diagnostics-e004.tcl");
+    await activate(e004Uri);
+    const diagnostics = await waitForDiagnostics(e004Uri, { minCount: 3 });
+
+    const danglingElseif = diagnostics.find((d) => d.message === 'No script following "2" argument');
+    assert.ok(danglingElseif, "dangling-elseif E004 diagnostic should be present");
+
+    const actions = (await pollUntil(
+      () =>
+        vscode.commands.executeCommand(
+          "vscode.executeCodeActionProvider",
+          e004Uri,
+          danglingElseif.range,
+        ),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => typeof a.title === "string" && a.title.toLowerCase().includes("remove"),
+        ),
+      { timeout: 10_000, label: "E004 dangling-clause remove quick fix" },
+    )) as vscode.CodeAction[];
+
+    const removeFix = actions.find(
+      (a) => typeof a.title === "string" && a.title.toLowerCase().includes("remove"),
+    );
+    assert.ok(removeFix, "Should provide a remove-incomplete-clause quick fix");
+  });
+
+  test("offers no quick fix for an E004 whose first clause never completed", async () => {
+    const e004Uri = getDocUri("diagnostics-e004.tcl");
+    await activate(e004Uri);
+    const diagnostics = await waitForDiagnostics(e004Uri, { minCount: 3 });
+
+    const bareCondition = diagnostics.find((d) => d.message === 'No script following "1" argument');
+    assert.ok(bareCondition, "bare-condition E004 diagnostic should be present");
+
+    // No well-formed prefix exists to fall back to, so no quick fix should
+    // ever be offered here — a single read is enough (there is nothing to
+    // wait for; the assertion is that it never appears).
+    const actions = (await vscode.commands.executeCommand(
+      "vscode.executeCodeActionProvider",
+      e004Uri,
+      bareCondition.range,
+    )) as vscode.CodeAction[] | undefined;
+    const quickFixes = (actions ?? []).filter(
+      (a) => a.kind && a.kind.value === vscode.CodeActionKind.QuickFix.value,
+    );
+    assert.strictEqual(
+      quickFixes.length,
+      0,
+      `expected no quick fix, got: ${quickFixes.map((a) => a.title).join("; ")}`,
+    );
+  });
+
   test("provides guided collect bootstrap fix for IRULE1005", async () => {
     await activate(irulesDocUri);
     // IRULE1005 is a deep diagnostic — it fires after the initial basic

--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -152,7 +152,9 @@ suite("Code Actions", () => {
     await activate(e004Uri);
     const diagnostics = await waitForDiagnostics(e004Uri, { minCount: 3 });
 
-    const danglingElseif = diagnostics.find((d) => d.message === 'No script following "2" argument');
+    const danglingElseif = diagnostics.find(
+      (d) => d.message === 'No script following "2" argument',
+    );
     assert.ok(danglingElseif, "dangling-elseif E004 diagnostic should be present");
 
     const actions = (await pollUntil(

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -138,6 +138,95 @@ suite("Diagnostics", () => {
     );
   });
 
+  test("E004 fires for each malformed `if` clause shape, precisely and not for well-formed ones", async () => {
+    const e004Uri = getDocUri("diagnostics-e004.tcl");
+    await activate(e004Uri);
+    const diagnostics = await waitForDiagnostics(e004Uri, { minCount: 3 });
+
+    const e004 = diagnostics.filter((d) => {
+      const code = typeof d.code === "object" ? d.code.value : d.code;
+      return code === "E004";
+    });
+
+    // Exactly the three genuinely malformed `if`s in the fixture — the
+    // leading-`else`-as-condition and the well-formed elseif/else chain
+    // must not add a fourth or fifth.
+    assert.strictEqual(
+      e004.length,
+      3,
+      `Expected exactly 3 E004 diagnostics, got ${e004.length}: ${e004.map((d) => `${d.range.start.line}:${d.message}`).join("; ")}`,
+    );
+
+    const messages = e004.map((d) => d.message);
+    assert.ok(
+      messages.some((m) => m === 'No script following "1" argument'),
+      `Expected the "if {1}" case's message, got: ${messages.join("; ")}`,
+    );
+    assert.ok(
+      messages.some((m) => m === 'No script following "2" argument'),
+      `Expected the dangling "elseif {2}" case's message, got: ${messages.join("; ")}`,
+    );
+    assert.ok(
+      messages.some((m) => m === 'Extra words after "else" clause in "if" command'),
+      `Expected the extra-words case's message, got: ${messages.join("; ")}`,
+    );
+
+    // Every E004 is an error. The fixture's `if` heads sit at lines 3, 6,
+    // and 11 — a diagnostic landing on line 6 or 11 would mean the span
+    // regressed to whole-statement.
+    for (const d of e004) {
+      assert.strictEqual(d.severity, vscode.DiagnosticSeverity.Error, "E004 should be an error");
+    }
+    const byMessage = new Map(e004.map((d) => [d.message, d.range]));
+
+    // `if {1}` is a single-line statement, so its own tight anchor and a
+    // (hypothetical) whole-statement span would coincide on the line —
+    // the single-line range itself is the tight-anchoring proof here.
+    const conditionRange = byMessage.get('No script following "1" argument');
+    assert.strictEqual(conditionRange?.start.line, 3, `"if {1}" should anchor on line 3`);
+    assert.strictEqual(
+      conditionRange?.start.line,
+      conditionRange?.end.line,
+      `"if {1}" should anchor on a single line, got ${JSON.stringify(conditionRange)}`,
+    );
+
+    // The dangling `elseif {2}` sits on line 8; anchoring on line 6 (the
+    // `if` head) would mean the span regressed to whole-statement.
+    const elseifRange = byMessage.get('No script following "2" argument');
+    assert.strictEqual(elseifRange?.start.line, 8, `dangling "elseif {2}" should anchor on line 8`);
+    assert.strictEqual(
+      elseifRange?.start.line,
+      elseifRange?.end.line,
+      `dangling "elseif {2}" should anchor on a single line, got ${JSON.stringify(elseifRange)}`,
+    );
+
+    // The recognised final (multi-line) body legitimately spans several
+    // lines — the tightness property here is that it starts *after* the
+    // `if` head (line 11), not that it is single-line.
+    const extraWordsRange = byMessage.get('Extra words after "else" clause in "if" command');
+    assert.ok(
+      extraWordsRange !== undefined && extraWordsRange.start.line > 11,
+      `extra-words should anchor past line 11 (the \`if\` head), got ${JSON.stringify(extraWordsRange)}`,
+    );
+  });
+
+  test("E004 does not fire for a leading `else` bareword condition or a well-formed elseif/else chain", async () => {
+    const e004Uri = getDocUri("diagnostics-e004.tcl");
+    await activate(e004Uri);
+    const diagnostics = await waitForDiagnostics(e004Uri, { minCount: 3 });
+
+    const e004 = diagnostics.filter((d) => {
+      const code = typeof d.code === "object" ? d.code.value : d.code;
+      return code === "E004";
+    });
+    // Neither the `if else { ... }` fixture block (lines 20-23) nor the
+    // well-formed elseif/else chain (lines 25-32) contributes an E004.
+    assert.ok(
+      e004.every((d) => d.range.start.line < 19),
+      `Expected no E004 at/after line 19 (the leading-else and well-formed blocks), got: ${e004.map((d) => `${d.range.start.line}:${d.message}`).join("; ")}`,
+    );
+  });
+
   test("clean file produces no diagnostics", async () => {
     const cleanUri = getDocUri("simple.tcl");
 

--- a/editors/vscode/src/test/errorRecovery.test.ts
+++ b/editors/vscode/src/test/errorRecovery.test.ts
@@ -141,14 +141,19 @@ suite("Error Recovery (contract)", () => {
   });
 
   test("C2: a command after an unterminated braced expression is analysed", async () => {
-    // `if {$x > 5` is an unterminated braced *expression*; recovery must let the
-    // following command be analysed — a bare `set` still raises its arity error.
+    // `if {$x > 5` is an unterminated braced *expression*; recovery must let
+    // the swallowed tail still be analysed as code. The unclosed brace runs
+    // to EOF, so `if`'s own single (swallowed) argument is itself an
+    // arity/shape defect: E002 (a plain arity floor) or the more precise
+    // E004 (`if`'s dedicated clause-shape check, which subsumes E002 for
+    // `if`) — either is acceptable here, since this suite asserts
+    // observable recovery behaviour, not a specific diagnostic code.
     await activate(docUri);
     const editor = vscode.window.activeTextEditor!;
     const diags = await setContentAndWait(editor, docUri, "if {$x > 5\nset\n");
     assert.ok(
-      diags.some((d) => codeOf(d) === "E002"),
-      `tail \`set\` after \`if {\` should arity-error; got [${diags.map(codeOf)}]`,
+      diags.some((d) => codeOf(d) === "E002" || codeOf(d) === "E004"),
+      `tail after \`if {\` should still be analysed and arity/shape-error; got [${diags.map(codeOf)}]`,
     );
   });
 

--- a/editors/vscode/testFixture/diagnostics-e004.tcl
+++ b/editors/vscode/testFixture/diagnostics-e004.tcl
@@ -1,0 +1,33 @@
+# E004 - malformed `if` clause shape
+
+# Condition with no body — E004, "No script following "1" argument"
+if {1}
+
+# Dangling elseif with no body — E004
+if {1} {
+    puts a
+} elseif {2}
+
+# Extra words after the recognised final body — E004
+if {1} {
+    puts a
+} {
+    puts b
+} {
+    puts c
+}
+
+# Leading `else` as the condition — well-formed (fails at expression
+# evaluation instead, a distinct problem), so this must NOT produce E004.
+if else {
+    puts a
+}
+
+# Well-formed elseif/else chain — no E004.
+if {1} {
+    puts a
+} elseif {2} {
+    puts b
+} else {
+    puts c
+}

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -621,7 +621,10 @@ impl Analyser {
     /// - **W001** (unknown subcommand on a `SubcommandSig` command) —
     ///   before `handle_namespace_eval_command` so `namespace foo` is
     ///   flagged.
-    /// - **E004** (malformed `if`).
+    /// - **E004** (malformed `if`) — dispatched generically off the
+    ///   resolved spec's `clause_shape_check` hook, not off `cmd_name`,
+    ///   so `if` is the trigger today only because it is the one
+    ///   command carrying that hook.
     /// - **W101** (`eval` with substituted args) — before body-walk
     ///   dispatch so the `ArgRole::Body` recursion into the `eval`
     ///   body still runs.
@@ -645,8 +648,13 @@ impl Analyser {
         }
         self.emit_w001_unknown_subcommand(cmd_name, args, cmd_tok, arg_tokens);
         self.emit_w002_disabled_command(cmd_name, cmd_tok);
-        if cmd_name == "if" {
-            self.emit_e004_malformed_if(args, cmd_tok, arg_tokens);
+        if let Some(checker) = self
+            .registry
+            .as_ref()
+            .and_then(|r| r.get(cmd_name))
+            .and_then(|spec| spec.clause_shape_check)
+        {
+            self.emit_e004_clause_shape_diagnostic(cmd_name, checker, args, cmd_tok, arg_tokens);
         }
         self.emit_w101_eval_string_concat(cmd_name, args, arg_tokens, arg_single);
         // W102 / W103 / W300 / W301 / W309 / W312 security-injection

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -3849,9 +3849,16 @@ fn tcloo_constructor_createwithnamespace_arity_accounts_for_two_mandatory_words(
     // parameters — same word layout as the sibling class-*definition*
     // shape `oo::class createWithNamespace Name ::ns body` (see
     // `oo_class_arg_roles`), just with constructor args standing in for
-    // the definition body.
-    let src =
-        |call: &str| format!("oo::class create Widget {{ constructor {{a b}} {{ }} }}\n{call}\n");
+    // the definition body. Unlike `new`/`create`, `createWithNamespace` is
+    // unexported by default (confirmed against `runtime/rust/src/cmd_oo.rs`'s
+    // `oo_class_factory`), so the class must `export` it for an external
+    // call to even reach the constructor — see the companion
+    // `..._is_not_checked_when_not_exported` test for the unexported case.
+    let src = |call: &str| {
+        format!(
+            "oo::class create Widget {{ constructor {{a b}} {{ }}; export createWithNamespace }}\n{call}\n"
+        )
+    };
     assert_eq!(
         e00x_codes_for(&src("Widget createWithNamespace fido ::ns 1")),
         vec!["E002".to_owned()]
@@ -3869,6 +3876,22 @@ fn tcloo_constructor_createwithnamespace_arity_accounts_for_two_mandatory_words(
         vec!["E002".to_owned()],
         "the mandatory object-name and namespace words themselves must be enforced"
     );
+}
+
+#[test]
+fn tcloo_constructor_createwithnamespace_is_not_checked_when_not_exported() {
+    // `createWithNamespace` is unexported by default (confirmed against
+    // `runtime/rust/src/cmd_oo.rs`'s `oo_class_factory`: `cwn_ok =
+    // !block_unexported || cwn_exp`) — an external call to a class that
+    // never `export`s it raises "unknown method" at run time and never
+    // reaches the constructor, so it must not be arity-checked. This is
+    // the false positive Codex flagged on the companion test above before
+    // the `cd.exports` gate was added.
+    let src = "\
+oo::class create Widget { constructor {a b} { } }
+Widget createWithNamespace fido ::ns 1
+";
+    assert_eq!(e00x_codes_for(src), Vec::<String>::new());
 }
 
 #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -3843,6 +3843,35 @@ fn tcloo_constructor_create_arity_accounts_for_mandatory_name() {
 }
 
 #[test]
+fn tcloo_constructor_createwithnamespace_arity_accounts_for_two_mandatory_words() {
+    // `createWithNamespace` consumes two mandatory words (the object name
+    // and the target namespace) ahead of the constructor's own
+    // parameters — same word layout as the sibling class-*definition*
+    // shape `oo::class createWithNamespace Name ::ns body` (see
+    // `oo_class_arg_roles`), just with constructor args standing in for
+    // the definition body.
+    let src =
+        |call: &str| format!("oo::class create Widget {{ constructor {{a b}} {{ }} }}\n{call}\n");
+    assert_eq!(
+        e00x_codes_for(&src("Widget createWithNamespace fido ::ns 1")),
+        vec!["E002".to_owned()]
+    );
+    assert_eq!(
+        e00x_codes_for(&src("Widget createWithNamespace fido ::ns 1 2")),
+        Vec::<String>::new()
+    );
+    assert_eq!(
+        e00x_codes_for(&src("Widget createWithNamespace fido ::ns 1 2 3")),
+        vec!["E003".to_owned()]
+    );
+    assert_eq!(
+        e00x_codes_for(&src("Widget createWithNamespace fido ::ns")),
+        vec!["E002".to_owned()],
+        "the mandatory object-name and namespace words themselves must be enforced"
+    );
+}
+
+#[test]
 fn tcloo_constructor_arity_is_inherited_through_superclass() {
     // `Sub` declares no constructor of its own — `Base`'s is inherited
     // (confirmed against tclsh 9.0.4: a subclass with no `constructor`

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -1033,6 +1033,28 @@ impl Analyser {
                 if !is_tcloo_metaclass(self.registry.as_ref(), &cd.metaclass) {
                     continue; // snit / itcl — `new`/`create` mean something else
                 }
+                // Unlike `new`/`create` (exported by default — only an explicit
+                // `unexport` blocks an external call), `createWithNamespace` is
+                // *unexported by default*: an external `ClassName
+                // createWithNamespace …` (every call this candidate queue can
+                // even see — a literal `my createWithNamespace` never resolves
+                // `my` as a class name, so it never reaches here) raises
+                // "unknown method" and never touches the constructor unless the
+                // class explicitly `export`s it (confirmed against this
+                // project's own `runtime/rust/src/cmd_oo.rs`'s
+                // `oo_class_factory`: `cwn_ok = !block_unexported ||
+                // cwn_exp`). Order-insensitively checking the whole file's
+                // `exports` set (rather than only exports in effect by
+                // `cand.call_off`) trades a vanishingly rare false negative — an
+                // export that lexically follows a top-level call — for
+                // eliminating a real false positive on every default-unexported
+                // class, consistent with this pass's abstain-when-unsure
+                // convention.
+                if matches!(cand.form, super::types::CtorForm::CreateWithNamespace)
+                    && !cd.exports.contains("createWithNamespace")
+                {
+                    continue;
+                }
                 let Some(provider) = hierarchy.constructor_provider(class_qn, &self.source) else {
                     continue; // no explicit constructor anywhere in the MRO —
                     // TclOO's inherited default accepts any argument count

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -560,11 +560,15 @@ impl Analyser {
         );
 
         // `TclOO` constructor-call arity (`ClassName new ?args?` /
-        // `ClassName create name ?args?`) — queued unconditionally whenever
-        // the first word is literally `new`/`create`, independent of
+        // `ClassName create name ?args?` / `ClassName createWithNamespace
+        // name ::ns ?args?`) — queued unconditionally whenever the first
+        // word is literally one of those three keywords, independent of
         // whether `cmd_name` resolves to anything at all; a call whose head
         // isn't a locally-known class is silently dropped at flush time.
-        if matches!(args.first().map(String::as_str), Some("new" | "create")) {
+        if matches!(
+            args.first().map(String::as_str),
+            Some("new" | "create" | "createWithNamespace")
+        ) {
             self.queue_ctor_arity_candidate(
                 cmd_name,
                 &ArityWords {
@@ -984,24 +988,26 @@ impl Analyser {
 
     /// Idempotent: drains `pending_ctor_arity`, so a second call is a no-op.
     ///
-    /// Resolves each queued `ClassName new` / `ClassName create name`
-    /// candidate against `all_classes` (fully populated post-walk, after
-    /// every per-item body has been grafted) using the same current-
-    /// namespace-then-global resolution and top-level order gate as the
-    /// same-file proc/alias arity path. Only genuine `TclOO` classes
-    /// (`oo::class` / `oo::configurable` / `oo::abstract` / `oo::singleton`
-    /// metaclasses) are checked — snit/itcl classes use an entirely
-    /// different instantiation protocol (`TypeName instanceName ?args?`,
-    /// never `new`/`create`), so their (unrelated) `new`/`create` calls, if
-    /// any, must not be arity-checked against a `TclOO` constructor.
+    /// Resolves each queued `ClassName new` / `ClassName create name` /
+    /// `ClassName createWithNamespace name ::ns` candidate against
+    /// `all_classes` (fully populated post-walk, after every per-item body
+    /// has been grafted) using the same current-namespace-then-global
+    /// resolution and top-level order gate as the same-file proc/alias
+    /// arity path. Only genuine `TclOO` classes (`oo::class` /
+    /// `oo::configurable` / `oo::abstract` / `oo::singleton` metaclasses)
+    /// are checked — snit/itcl classes use an entirely different
+    /// instantiation protocol (`TypeName instanceName ?args?`, never
+    /// `new`/`create`/`createWithNamespace`), so their (unrelated) calls,
+    /// if any, must not be arity-checked against a `TclOO` constructor.
     ///
     /// A candidate resolving to a class with no explicit constructor
     /// anywhere in its MRO is dropped — `TclOO`'s inherited default
     /// constructor accepts any argument count (confirmed against tclsh
-    /// 9.0.4). `create`'s mandatory leading object-name word is folded into
-    /// the expected bound (`bump_arity`) before comparison, so its arity
-    /// message reads in terms of `create`'s own full argument list, not the
-    /// constructor's.
+    /// 9.0.4). Each form's mandatory leading words
+    /// ([`super::types::CtorForm::extra_leading_words`]) are folded into
+    /// the expected bound (`bump_arity`) before comparison, so the arity
+    /// message reads in terms of the call's own full argument list, not
+    /// the constructor's.
     pub fn flush_ctor_arity_diagnostics(&mut self) {
         if self.pending_ctor_arity.is_empty() {
             return;
@@ -1058,16 +1064,8 @@ impl Analyser {
                     continue;
                 };
                 let arity = crate::signature_scan::arity::arity_of(&ctor.params);
-                let arity = if cand.is_create {
-                    bump_arity(arity, 1)
-                } else {
-                    arity
-                };
-                let display_name = format!(
-                    "{} {}",
-                    cand.class_name,
-                    if cand.is_create { "create" } else { "new" }
-                );
+                let arity = bump_arity(arity, cand.form.extra_leading_words());
+                let display_name = format!("{} {}", cand.class_name, cand.form.as_str());
                 if let Some(diag) = arity_verdict(
                     &display_name,
                     arity,
@@ -1129,15 +1127,16 @@ impl Analyser {
 
     /// Queue a `TclOO` constructor-call (`ClassName new ?args?` /
     /// `ClassName create name ?args?`) arity candidate. Queued
-    /// unconditionally by every call whose first word is `new`/`create`
-    /// (the caller's guard) — [`Self::flush_ctor_arity_diagnostics`]
-    /// resolves it post-walk against `all_classes`, which mid-walk may not
-    /// yet hold a forward-referenced class. A call whose head doesn't
-    /// resolve to a locally-known class is silently dropped at flush time,
-    /// exactly like [`Self::queue_user_call_arity_candidate`].
+    /// unconditionally by every call whose first word is
+    /// `new`/`create`/`createWithNamespace` (the caller's guard) —
+    /// [`Self::flush_ctor_arity_diagnostics`] resolves it post-walk against
+    /// `all_classes`, which mid-walk may not yet hold a forward-referenced
+    /// class. A call whose head doesn't resolve to a locally-known class is
+    /// silently dropped at flush time, exactly like
+    /// [`Self::queue_user_call_arity_candidate`].
     ///
-    /// `words.args` still has `new`/`create` at index 0; the positional
-    /// count starts at index 1 so the keyword itself is never counted.
+    /// `words.args` still has the keyword at index 0; the positional count
+    /// starts at index 1 so the keyword itself is never counted.
     fn queue_ctor_arity_candidate(
         &mut self,
         cmd_name: &str,
@@ -1153,7 +1152,11 @@ impl Analyser {
             arg_expand,
             cmd_tok,
         } = *words;
-        let is_create = args[0] == "create";
+        let form = match args[0].as_str() {
+            "create" => super::types::CtorForm::Create,
+            "createWithNamespace" => super::types::CtorForm::CreateWithNamespace,
+            _ => super::types::CtorForm::New,
+        };
         let (nargs_min, positional_any_expand) = count_positionals(args, arg_expand, 1);
         let full_span = match arg_tokens.last() {
             Some(last) => tcl_lexer::Span::new(cmd_tok.span.start(), last.span.end()),
@@ -1164,7 +1167,7 @@ impl Analyser {
                 class_name: cmd_name.to_string(),
                 ns: self.command_resolution_namespace(scope_path),
                 enforce_order: !self.scope_path_in_proc_body(scope_path),
-                is_create,
+                form,
                 call_off: cmd_tok.span.start(),
                 full_span,
                 nargs_min,

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -72,6 +72,42 @@ fn count_positionals(args: &[String], arg_expand: &[bool], start: usize) -> (usi
     (nargs_min, any_expand)
 }
 
+/// Widen a single braced (`Str`) / bracketed (`Cmd`) word token's `end`
+/// to cover its own closing delimiter — the per-token equivalent of the
+/// segmenter's `widen_word_end` (`crate::segmenter`, private to its own
+/// recovery logic, so duplicated here rather than exposed cross-module).
+/// Per the lexer's inner-end convention (see `AGENTS.md`, "Word-token
+/// closing delimiters"), a non-empty braced/bracketed word's `end()`
+/// already sits on the closer byte, one short of covering it; an empty
+/// `{}` / `[]` already has `end()` past the closer, so it is left alone
+/// (widening it could swallow an unrelated adjacent `}` / `]` from
+/// whatever encloses this word — `RUST_ISSUE_527`). Any other token kind
+/// (a bareword, `then`/`elseif`/`else`, a `Var`, …) has no closer to
+/// widen for.
+fn widen_token_end(tok: tcl_lexer::Token, source: &str) -> u32 {
+    let closer = match tok.kind {
+        tcl_lexer::TokenType::Str => b'}',
+        tcl_lexer::TokenType::Cmd => b']',
+        _ => return tok.span.end(),
+    };
+    let end = tok.span.end();
+    if tcl_lexer::SourceMap::new(source).token_text(tok).is_empty() {
+        return end;
+    }
+    if source.as_bytes().get(end as usize) == Some(&closer) {
+        end + 1
+    } else {
+        end
+    }
+}
+
+/// A single word token's full source span, closing delimiter included
+/// (see [`widen_token_end`]) — for anchoring a diagnostic tightly on one
+/// whole word rather than dropping its last byte.
+fn widened_word_span(tok: tcl_lexer::Token, source: &str) -> tcl_lexer::Span {
+    tcl_lexer::Span::new(tok.span.start(), widen_token_end(tok, source))
+}
+
 /// Compare a resolved [`Arity`] against an observed positional-argument
 /// count and build the E002 / E003 diagnostic, or `None` when the count
 /// fits. Shared by the registry-command arity path
@@ -654,6 +690,12 @@ impl Analyser {
     /// for the subcommand path), so the leading-option scan and
     /// positional count operate on the same coordinate system as
     /// `sig`.
+    ///
+    /// A `sig` carrying [`tcl_registry::Traits::STRUCTURALLY_CHECKED_ARITY`]
+    /// (`if`) is skipped entirely: its registry `arity` is a descriptive
+    /// floor only, and its dedicated structural diagnostic (E004) already
+    /// covers every too-few-/malformed-shape case this generic check
+    /// would otherwise duplicate.
     fn check_simple_arity(
         &mut self,
         resolution_name: &str,
@@ -662,6 +704,12 @@ impl Analyser {
         words: &ArityWords<'_>,
         scope_path: &[usize],
     ) {
+        if sig
+            .traits
+            .contains(tcl_registry::Traits::STRUCTURALLY_CHECKED_ARITY)
+        {
+            return;
+        }
         let ArityWords {
             args,
             arg_tokens,
@@ -1257,136 +1305,198 @@ impl Analyser {
         None
     }
 
-    /// **E004.** Emit "Malformed `if` command" / "Extra words after
-    /// `else` clause" errors when an `if` invocation's structural
-    /// shape doesn't match `if COND BODY ?elseif COND BODY ...?
-    /// ?else BODY?`.
+    /// **E004.** Emit a precise "malformed `if`" diagnostic from a
+    /// registry [`tcl_registry::ClauseShapeChecker`] hook — the grammar
+    /// walk itself lives once, in `tcl-registry`
+    /// (`commands::tcl::if_::walk_if`), shared with the `if_arg_roles`
+    /// highlighting resolver, so this emitter never re-parses `if`'s
+    /// shape independently.
     ///
-    /// Fires when an `if` invocation's syntactic shape is invalid.
-    /// The cases:
+    /// Dispatched generically off the resolved command spec's
+    /// `clause_shape_check` hook (see
+    /// [`Self::emit_dispatch_site_diagnostics`]) rather than
+    /// `cmd_name == "if"`, so a namespace-qualified `::if` is covered
+    /// too — registry name resolution already normalises the leading
+    /// `::` for every command. `if` is the only hook today, so the
+    /// diagnostic code below is hardcoded to `E004`; a second hook
+    /// consumer would need this to carry its own code.
     ///
-    /// - `"malformed if"` — empty arg list, or no clauses after
-    ///   the full walk.
-    /// - `"malformed if else clause"` — bare `else` with no body
-    ///   following.
-    /// - `'extra words after "else" clause'` — `else BODY` with
-    ///   one or more trailing words.
-    /// - `"malformed if clause"` — condition with no body
-    ///   (with or without an intervening `then` keyword).
+    /// Verified against Tcl 9.0.4's `TclNRIfObjCmd` /
+    /// `IfConditionCallback` (`generic/tclCmdIL.c`) and tclsh 8.6 (same
+    /// algorithm): a leading `else`/`elseif` bareword condition
+    /// (`if else {a}`) is *not* a malformed `if` — it is a well-formed
+    /// `if` whose condition fails at expression-evaluation time (an
+    /// invalid-bareword error), a distinct problem this diagnostic does
+    /// not own.
     ///
-    /// Detected analyser-side at the `if`-command dispatch site
-    /// rather than by walking lowered IR, matching the established
-    /// W302 / W001 dispatch-site pattern.  This also covers a case
-    /// `lowering/structured.rs::lower_if` doesn't: it currently
-    /// doesn't produce an "extra words after else" barrier at all.
-    ///
-    /// Severity: `Error`.  No code fixes.  Span anchors at the
-    /// command-head token through the last argument-token end (the
-    /// full command source range).
-    pub(in crate::analyser) fn emit_e004_malformed_if(
+    /// Anchors on the offending word(s) — the dangling keyword or
+    /// condition for a missing expression/script, or just the extra
+    /// words for a trailing-words error — not the whole `if` statement,
+    /// which can span many lines in an `elseif` chain. Offers a code fix
+    /// only where one is unambiguous:
+    /// - **extra words** — merge them into the final recognised body by
+    ///   wrapping the untouched source slice from that body through the
+    ///   last extra word in one more brace pair (preserves original
+    ///   word delimiters and whitespace verbatim; no re-parsing);
+    /// - **a dangling `elseif`/`else` clause following at least one
+    ///   complete clause** — remove it, restoring the last well-formed
+    ///   prefix;
+    /// - a missing *first* clause (`if` alone, or `if {cond}` with
+    ///   nothing else) offers no fix: there is no well-formed prefix to
+    ///   fall back to, and inventing a body would be a guess, not a
+    ///   mechanical fix.
+    pub(in crate::analyser) fn emit_e004_clause_shape_diagnostic(
         &mut self,
+        cmd_name: &str,
+        checker: tcl_registry::ClauseShapeChecker,
         args: &[String],
         cmd_tok: tcl_lexer::Token,
         arg_tokens: &[tcl_lexer::Token],
     ) {
-        let full_span = match arg_tokens.last() {
-            Some(last) => tcl_lexer::Span::new(cmd_tok.span.start(), last.span.end()),
-            None => cmd_tok.span,
-        };
-        let push_malformed = |this: &mut Self| {
-            this.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::E004,
-                span: full_span,
-                message: "Malformed 'if' command".to_string(),
-                severity: Severity::Error,
-                fixes: Vec::new(),
-            });
-        };
-        let push_extra_words = |this: &mut Self| {
-            this.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::E004,
-                span: full_span,
-                message: "Extra words after \"else\" clause in \"if\" command".to_string(),
-                severity: Severity::Error,
-                fixes: Vec::new(),
-            });
+        use tcl_registry::ClauseShapeError;
+
+        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let Some(error) = checker(&arg_strs) else {
+            return;
         };
 
-        if args.is_empty() {
-            push_malformed(self);
-            return;
-        }
+        let word_span = |i: usize| {
+            arg_tokens
+                .get(i)
+                .map_or(cmd_tok.span, |t| widened_word_span(*t, &self.source))
+        };
 
-        // Mandatory first clause: ``COND ?then? BODY``.  A leading ``else`` /
-        // ``elseif`` keyword sits in the condition slot — Tcl would take it as a
-        // bareword condition (a runtime error), but structurally it's an
-        // almost-certain misplaced keyword, so it's linted as malformed (see
-        // ``analyse_emits_e004_for_if_with_only_else``).
-        if args[0] == "else" || args[0] == "elseif" {
-            push_malformed(self);
-            return;
-        }
-        let mut i = 1; // args[0] is the condition
-        if i < args.len() && args[i] == "then" {
-            i += 1;
-        }
-        if i >= args.len() {
-            // Condition (or ``COND then``) with no body — ``if {1}`` / ``if {1}
-            // then``.
-            push_malformed(self);
-            return;
-        }
-        i += 1; // consume the first body
+        let (span, message) = match error {
+            ClauseShapeError::MissingExpr { after: None } => (
+                cmd_tok.span,
+                format!("No expression after \"{cmd_name}\" argument"),
+            ),
+            ClauseShapeError::MissingExpr { after: Some(i) } => (
+                word_span(i),
+                format!(
+                    "No expression after \"{}\" argument",
+                    args.get(i).map_or("", String::as_str)
+                ),
+            ),
+            ClauseShapeError::MissingBody { after: i } => (
+                word_span(i),
+                format!(
+                    "No script following \"{}\" argument",
+                    args.get(i).map_or("", String::as_str)
+                ),
+            ),
+            ClauseShapeError::ExtraWords { first_extra } => {
+                let start = arg_tokens.get(first_extra).map(|t| t.span.start());
+                let end = arg_tokens.last().map(|t| widen_token_end(*t, &self.source));
+                let span = match (start, end) {
+                    (Some(s), Some(e)) => tcl_lexer::Span::new(s, e),
+                    _ => cmd_tok.span,
+                };
+                // Matches Tcl's own message text exactly: `Tcl_IfObjCmd`
+                // builds this from a *static* string, always naming "if"
+                // literally — never the invoked spelling (unlike the
+                // other two messages above, which do use it).
+                (
+                    span,
+                    "Extra words after \"else\" clause in \"if\" command".to_string(),
+                )
+            }
+        };
 
-        // Optional tail: an ``elseif`` chain, a final ``else BODY``, or a bare
-        // implicit-else BODY (Tcl allows ``if {c} {then} {else}`` with no
-        // ``else`` keyword).
-        while i < args.len() {
-            if args[i] == "elseif" {
-                i += 1; // consume ``elseif``
-                if i >= args.len() {
-                    // ``elseif`` with no condition.
-                    push_malformed(self);
-                    return;
-                }
-                i += 1; // condition
-                if i < args.len() && args[i] == "then" {
-                    i += 1;
-                }
-                if i >= args.len() {
-                    // ``elseif COND`` with no body.
-                    push_malformed(self);
-                    return;
-                }
-                i += 1; // body
-                continue;
+        let fixes = self.e004_fixes(args, arg_tokens, error);
+
+        self.result.diagnostics.push(super::types::Diagnostic {
+            code: DiagCode::E004,
+            span,
+            message,
+            severity: Severity::Error,
+            fixes,
+        });
+    }
+
+    /// Code fixes for [`Self::emit_e004_clause_shape_diagnostic`]. See
+    /// that method's doc comment for which cases get a fix and why.
+    fn e004_fixes(
+        &self,
+        args: &[String],
+        arg_tokens: &[tcl_lexer::Token],
+        error: tcl_registry::ClauseShapeError,
+    ) -> Vec<super::types::CodeFix> {
+        use tcl_registry::ClauseShapeError;
+
+        match error {
+            ClauseShapeError::ExtraWords { first_extra } => {
+                // `first_extra >= 2` always: the walk only reaches
+                // `ExtraWords` after consuming the mandatory first
+                // clause's body (index >= 1), so the recognised final
+                // body this merges from is always in range.
+                let Some(body_tok) = arg_tokens.get(first_extra - 1) else {
+                    return Vec::new();
+                };
+                let Some(last_tok) = arg_tokens.last() else {
+                    return Vec::new();
+                };
+                let start = body_tok.span.start();
+                let end = widen_token_end(*last_tok, &self.source);
+                let Some(slice) = self.source.get(start as usize..end as usize) else {
+                    return Vec::new();
+                };
+                vec![super::types::CodeFix {
+                    span: tcl_lexer::Span::new(start, end),
+                    new_text: format!("{{{slice}}}"),
+                    description: "Merge trailing words into the if body".to_string(),
+                }]
             }
-            if args[i] == "else" {
-                i += 1; // consume ``else``
-                if i >= args.len() {
-                    // ``else`` with no body following.
-                    push_malformed(self);
-                    return;
-                }
-                i += 1; // else body
-                if i < args.len() {
-                    // ``else BODY <extra...>``.
-                    push_extra_words(self);
-                    return;
-                }
-                return; // ``… else BODY`` — well-formed.
+            ClauseShapeError::MissingExpr {
+                after: Some(kw_idx),
+            } => {
+                // A dangling `elseif` always follows a complete clause
+                // (the walk only reaches the `elseif`/`else` lookup after
+                // consuming one), so removing from the keyword onward
+                // always restores a well-formed prefix.
+                self.remove_dangling_clause_fix(kw_idx, arg_tokens)
             }
-            // A bare word here is the implicit-else body (no ``else`` keyword).
-            // Exactly one is well-formed; any trailing words are the "extra
-            // words after else" error Tcl reports for ``if {1} {a} {b} {c}``.
-            i += 1;
-            if i < args.len() {
-                push_extra_words(self);
-                return;
+            ClauseShapeError::MissingBody { after } => {
+                // `after` names the last present word of the *dangling*
+                // clause (a condition, `then`, or `else`) — walk back to
+                // the `elseif`/`else` keyword that opened it. Word 0 is
+                // never a real keyword (it is always the mandatory first
+                // condition, whatever its text), so the search excludes
+                // it — `after` staying at 0 or 1 there means the very
+                // first clause never completed, and no prefix fix
+                // exists.
+                let Some(start_idx) = (1..=after)
+                    .rev()
+                    .find(|&k| args.get(k).is_some_and(|w| w == "elseif" || w == "else"))
+                else {
+                    return Vec::new();
+                };
+                self.remove_dangling_clause_fix(start_idx, arg_tokens)
             }
-            return; // implicit ``… else`` — well-formed.
+            ClauseShapeError::MissingExpr { after: None } => Vec::new(),
         }
-        // Ran out exactly after a clause (``if {1} {a}``) — well-formed.
+    }
+
+    /// A [`super::types::CodeFix`] removing every word from
+    /// `arg_tokens[start_idx]` through the end of the command —
+    /// restoring the well-formed `if` prefix that precedes a dangling
+    /// trailing clause.
+    fn remove_dangling_clause_fix(
+        &self,
+        start_idx: usize,
+        arg_tokens: &[tcl_lexer::Token],
+    ) -> Vec<super::types::CodeFix> {
+        let (Some(start_tok), Some(last_tok)) = (arg_tokens.get(start_idx), arg_tokens.last())
+        else {
+            return Vec::new();
+        };
+        let start = start_tok.span.start();
+        let end = widen_token_end(*last_tok, &self.source);
+        vec![super::types::CodeFix {
+            span: tcl_lexer::Span::new(start, end),
+            new_text: String::new(),
+            description: "Remove incomplete trailing clause".to_string(),
+        }]
     }
 
     /// **W304.** Emit "Missing option terminator (`--`)" diagnostics

--- a/rust/tcl-compiler/src/analyser/dispatch.rs
+++ b/rust/tcl-compiler/src/analyser/dispatch.rs
@@ -32,7 +32,7 @@ use std::collections::{BTreeSet, HashMap};
 
 use tcl_registry::prelude::{DialectSet, OptionSpec};
 use tcl_registry::scoped::ScopedCommand;
-use tcl_registry::{ArgRole, Arity, CommandRegistry};
+use tcl_registry::{ArgRole, Arity, CommandRegistry, Traits};
 
 /// Signature for a simple Tcl command.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -42,6 +42,14 @@ pub struct CommandSig {
     /// Static arg-index → role map (0-based, after the command
     /// name). Args not listed default to ``ArgRole::Value``.
     pub arg_roles: HashMap<u8, ArgRole>,
+    /// Behavioural trait flags, copied from the resolved
+    /// [`tcl_registry::CommandSpec::traits`]. Consulted by
+    /// [`crate::analyser::diagnostics::validity`]'s arity check to skip
+    /// the generic E002/E003 floor/ceiling diagnostic for a command
+    /// carrying [`Traits::STRUCTURALLY_CHECKED_ARITY`] (its own
+    /// dedicated structural diagnostic owns arity instead).
+    pub traits: Traits,
+
     /// Declared option / switch names valid in the active dialect.
     /// Leading arguments matching one of these are skipped before
     /// counting positional args for the E002 / E003 arity check.
@@ -175,6 +183,7 @@ pub fn signature_for_command(
                 CommandSig {
                     arity: sub.arity,
                     arg_roles,
+                    traits: sub.traits,
                     leading_options,
                     leading_option_specs,
                 },
@@ -201,6 +210,7 @@ pub fn signature_for_command(
     Some(CommandSignature::Simple(CommandSig {
         arity: spec.arity,
         arg_roles,
+        traits: spec.traits,
         leading_options,
         leading_option_specs,
     }))
@@ -229,6 +239,7 @@ pub fn signature_for_scoped_command(scoped: &ScopedCommand) -> CommandSignature 
                 CommandSig {
                     arity: sub.arity,
                     arg_roles,
+                    traits: sub.traits,
                     // Scoped ensemble operations declare no option flags.
                     leading_options: BTreeSet::new(),
                     leading_option_specs: Vec::new(),
@@ -244,6 +255,9 @@ pub fn signature_for_scoped_command(scoped: &ScopedCommand) -> CommandSignature 
     CommandSignature::Simple(CommandSig {
         arity: scoped.arity,
         arg_roles: HashMap::new(),
+        // `ScopedCommand` itself carries no `traits` — only its
+        // (reused-`SubCommand`) ensemble operations do.
+        traits: Traits::empty(),
         leading_options: BTreeSet::new(),
         leading_option_specs: Vec::new(),
     })

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -960,6 +960,14 @@ impl Analyser {
     /// reason (an unresolved name) rather than the right one (a
     /// dynamically-defined ensemble the analyser can't see the
     /// subcommand map of).
+    ///
+    /// `namespace ensemble create`'s options are registry data
+    /// (`ENSEMBLE_CREATE_OPTIONS` in `tcl-registry`'s `namespace_`
+    /// module), not a hardcoded name list — walking by each option's
+    /// declared value arity (rather than a bare `opt == "-command"` scan
+    /// over every word) is what keeps another option's *value* word
+    /// (`-map`'s dict, `-subcommands`' list, …) from ever being misread as
+    /// `-command`'s own flag or value.
     pub fn handle_namespace_ensemble(
         &mut self,
         cmd_name: &str,
@@ -977,17 +985,35 @@ impl Analyser {
             self.ensemble_namespaces.insert(ns.clone());
         }
         let ns_prefix = ns.trim_start_matches(':');
-        for (i, opt) in args.iter().enumerate().skip(2) {
-            let Some(value) = (opt == "-command").then(|| args.get(i + 1)).flatten() else {
+
+        let dialect = tcl_registry::prelude::DialectSet::parse(&self.dialect);
+        let option_specs: Vec<&tcl_registry::hover::OptionSpec> = self
+            .registry
+            .as_ref()
+            .and_then(|r| r.get("namespace"))
+            .and_then(|spec| spec.subcommand("ensemble").map(|sub| (spec.dialects, sub)))
+            .map(|(parent_dialects, sub)| sub.option_specs(dialect, parent_dialects))
+            .unwrap_or_default();
+
+        let opts = &args[2..];
+        let mut i = 0usize;
+        while i < opts.len() {
+            let Some(spec) = option_specs.iter().find(|o| o.matches(opts[i].as_str())) else {
+                i += 1;
                 continue;
             };
-            // A dynamic value (`$var` / `[cmd]`) can't be resolved
-            // statically — leave it unrecorded, same convention as every
-            // other literal-only command-name extraction in this module.
-            if value.is_empty() || value.starts_with('$') || value.starts_with('[') {
-                continue;
+            if spec.name == "-command"
+                && let Some(value) = opts.get(i + 1)
+            {
+                // A dynamic value (`$var` / `[cmd]`) can't be resolved
+                // statically — leave it unrecorded, same convention as
+                // every other literal-only command-name extraction in
+                // this module.
+                if !(value.is_empty() || value.starts_with('$') || value.starts_with('[')) {
+                    self.ensemble_namespaces.insert(qualify(ns_prefix, value));
+                }
             }
-            self.ensemble_namespaces.insert(qualify(ns_prefix, value));
+            i += 1 + spec.value_word_count(opts, i);
         }
     }
 
@@ -3136,6 +3162,8 @@ mod tests {
     fn handle_namespace_ensemble_command_option_recorded() {
         use crate::analyser::types::{Scope, ScopeKind};
         let mut a = Analyser::new();
+        // `-command` recognition is registry-driven (`ENSEMBLE_CREATE_OPTIONS`).
+        a.registry = Some(tcl_registry::CommandRegistry::build_default());
         a.result
             .global_scope
             .children
@@ -3158,6 +3186,8 @@ mod tests {
     fn handle_namespace_ensemble_command_option_qualifies_relative_name() {
         use crate::analyser::types::{Scope, ScopeKind};
         let mut a = Analyser::new();
+        // `-command` recognition is registry-driven (`ENSEMBLE_CREATE_OPTIONS`).
+        a.registry = Some(tcl_registry::CommandRegistry::build_default());
         a.result
             .global_scope
             .children
@@ -3196,6 +3226,45 @@ mod tests {
         assert_eq!(
             a.ensemble_namespaces,
             std::collections::HashSet::from(["::myns".to_string()])
+        );
+    }
+
+    #[test]
+    fn handle_namespace_ensemble_other_options_value_word_is_not_mistaken_for_command_flag() {
+        // Regression: before the registry-driven option walk, the scan
+        // checked *every* word for literal equality with `-command`,
+        // including another option's own value word — `-map`'s value
+        // here is (pathologically, but syntactically legally) the string
+        // `-command`. A word-by-word scan misreads that value as the
+        // `-command` flag itself and steals the *next* word (the real
+        // `-command`'s own flag) as if it were a namespace name. Walking
+        // by each option's declared value arity instead correctly skips
+        // `-map`'s whole value before ever looking for `-command` again,
+        // so only the genuine `-command ::real::target` is recorded.
+        use crate::analyser::types::{Scope, ScopeKind};
+        let mut a = Analyser::new();
+        a.registry = Some(tcl_registry::CommandRegistry::build_default());
+        a.result
+            .global_scope
+            .children
+            .push(Scope::new(ScopeKind::Namespace, "myns"));
+        a.handle_namespace_ensemble(
+            "namespace",
+            &[
+                "ensemble".to_string(),
+                "create".to_string(),
+                "-map".to_string(),
+                "-command".to_string(),
+                "-command".to_string(),
+                "::real::target".to_string(),
+            ],
+            &[0],
+        );
+        assert_eq!(
+            a.ensemble_namespaces,
+            std::collections::HashSet::from(["::myns".to_string(), "::real::target".to_string()]),
+            "only the genuine -command flag's value must be recorded, \
+             not -map's value word that happens to read \"-command\""
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -3280,171 +3280,320 @@ mod tests {
     //
     // Fires ``Severity::Error`` when an ``if`` invocation's structural
     // shape doesn't match
-    // ``if COND BODY ?elseif COND BODY ...? ?else BODY?``.
-    // Detection is analyser-side rather than via IR-walk.
+    // ``if COND BODY ?elseif COND BODY ...? ?else BODY?``.  Detection
+    // reads `tcl_registry::commands::tcl::if_::check_if_shape` via the
+    // spec's `clause_shape_check` hook — the grammar itself is not
+    // reimplemented here (see `emit_e004_clause_shape_diagnostic`).
+    // Every case is cross-checked against tclsh 8.6 and Tcl 9.0.4's
+    // `TclNRIfObjCmd` source; see the truth table in
+    // `tcl-registry/src/commands/tcl/if_.rs`'s own tests for the
+    // grammar-level cases this integration layer doesn't repeat.
+
+    fn e004_diags(src: &str) -> Vec<crate::analyser::types::Diagnostic> {
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl");
+        r.diagnostics
+            .into_iter()
+            .filter(|d| d.code == DiagCode::E004)
+            .collect()
+    }
+
+    fn span_text(src: &str, span: tcl_lexer::Span) -> &str {
+        &src[span.start() as usize..span.end() as usize]
+    }
+
+    // -- TP: genuinely malformed shapes, with the precise message and a
+    // tight span (not the whole `if` statement).
 
     #[test]
-    fn analyse_emits_e004_for_extra_words_after_else() {
-        // ``if {1} { a } else { b } extra`` — extra words follow the
-        // ``else`` clause.
-        let mut a = Analyser::new();
-        let r = a.analyse("if {1} { a } else { b } extra\n", "tcl");
-        let e004: Vec<_> = r
-            .diagnostics
-            .iter()
-            .filter(|d| d.code == DiagCode::E004)
-            .collect();
-        assert_eq!(e004.len(), 1, "got {:?}", r.diagnostics);
-        assert!(
-            e004[0].message.contains("Extra words after \"else\""),
-            "got {:?}",
-            e004[0].message
+    fn tp_bare_if_names_the_invoked_command_in_the_message() {
+        // ``if`` alone — no expression at all.  Message and span both
+        // name "if" itself (real Tcl: `no expression after "if"
+        // argument`), and this must be the *only* diagnostic for the
+        // line — no redundant generic arity error alongside it (see
+        // `no_duplicate_e002_alongside_e004`).
+        let src = "if\n";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+        assert_eq!(e004[0].message, "No expression after \"if\" argument");
+        assert_eq!(span_text(src, e004[0].span), "if");
+    }
+
+    #[test]
+    fn tp_condition_without_body_names_the_condition_text() {
+        // ``if {1}`` — real Tcl: `no script following "1" argument`.
+        let src = "if {1}\n";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+        assert_eq!(e004[0].message, "No script following \"1\" argument");
+        assert_eq!(span_text(src, e004[0].span), "{1}");
+    }
+
+    #[test]
+    fn tp_then_keyword_without_body_names_then() {
+        // ``if {1} then`` — real Tcl: `no script following "then"
+        // argument`.
+        let src = "if {1} then\n";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+        assert_eq!(e004[0].message, "No script following \"then\" argument");
+        assert_eq!(span_text(src, e004[0].span), "then");
+    }
+
+    #[test]
+    fn tp_bare_else_without_body_names_else() {
+        // ``if {1} { a } else`` — real Tcl: `no script following
+        // "else" argument`.
+        let src = "if {1} { a } else\n";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+        assert_eq!(e004[0].message, "No script following \"else\" argument");
+        assert_eq!(span_text(src, e004[0].span), "else");
+    }
+
+    #[test]
+    fn tp_elseif_without_expr_names_elseif() {
+        // ``if {1} { a } elseif`` — real Tcl: `no expression after
+        // "elseif" argument`.
+        let src = "if {1} { a } elseif\n";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+        assert_eq!(e004[0].message, "No expression after \"elseif\" argument");
+        assert_eq!(span_text(src, e004[0].span), "elseif");
+    }
+
+    #[test]
+    fn tp_elseif_condition_without_body_names_the_condition_text() {
+        // ``if {1} { a } elseif {2}`` — real Tcl: `no script
+        // following "2" argument`.
+        let src = "if {1} { a } elseif {2}\n";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+        assert_eq!(e004[0].message, "No script following \"2\" argument");
+        assert_eq!(span_text(src, e004[0].span), "{2}");
+    }
+
+    #[test]
+    fn tp_extra_words_after_explicit_else_anchors_only_the_extra_words() {
+        // ``if {1} { a } else { b } extra`` — the span covers just
+        // "extra", not the whole statement.
+        let src = "if {1} { a } else { b } extra\n";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+        assert_eq!(
+            e004[0].message,
+            "Extra words after \"else\" clause in \"if\" command"
         );
+        assert_eq!(span_text(src, e004[0].span), "extra");
         assert!(matches!(e004[0].severity, crate::analyser::Severity::Error));
     }
 
     #[test]
-    fn analyse_emits_e004_for_bare_else_without_body() {
-        // ``if {1} { a } else`` — bare ``else`` keyword with no
-        // body.
-        let mut a = Analyser::new();
-        let r = a.analyse("if {1} { a } else\n", "tcl");
-        let e004: Vec<_> = r
-            .diagnostics
-            .iter()
-            .filter(|d| d.code == DiagCode::E004)
-            .collect();
-        assert_eq!(e004.len(), 1, "got {:?}", r.diagnostics);
-        assert!(
-            e004[0].message.contains("Malformed 'if'"),
-            "got {:?}",
-            e004[0].message
-        );
+    fn tp_extra_words_after_implicit_else_anchors_only_the_extra_word() {
+        // ``if {1} { a } { b } { c }`` — implicit else (no ``else``
+        // keyword); "c" is the first extra word.
+        let src = "if {1} { a } { b } { c }\n";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+        assert_eq!(span_text(src, e004[0].span), "{ c }");
     }
 
     #[test]
-    fn analyse_emits_e004_for_condition_without_body() {
-        // ``if {1}`` — condition with no body following.
-        let mut a = Analyser::new();
-        let r = a.analyse("if {1}\n", "tcl");
-        let e004: Vec<_> = r
-            .diagnostics
-            .iter()
-            .filter(|d| d.code == DiagCode::E004)
-            .collect();
-        assert_eq!(e004.len(), 1, "got {:?}", r.diagnostics);
-        assert!(
-            e004[0].message.contains("Malformed 'if'"),
-            "got {:?}",
-            e004[0].message
-        );
+    fn tp_qualified_double_colon_if_is_checked_too() {
+        // ``::if`` names the same global command as ``if`` — registry
+        // name resolution strips the leading ``::`` for every command,
+        // so the dispatch-generic hook lookup picks this up without any
+        // `if`-specific handling in the compiler.
+        let src = "::if {1} { a } { b } { c }\n";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+    }
+
+    // -- FP fixed: a leading `else`/`elseif` is a well-formed `if` whose
+    // condition happens to be that bareword — not a malformed `if`.
+    // Verified against tclsh 8.6: both raise `invalid bareword "else"` /
+    // `"elseif"` at *expression*-evaluation time, never a `wrong # args`
+    // structural error.
+
+    #[test]
+    fn fp_leading_else_is_not_malformed() {
+        let r_diags = e004_diags("if else { x }\n");
+        assert!(r_diags.is_empty(), "got {r_diags:?}");
     }
 
     #[test]
-    fn analyse_emits_e004_for_then_keyword_without_body() {
-        // ``if {1} then`` — condition + ``then`` keyword without
-        // body.
-        let mut a = Analyser::new();
-        let r = a.analyse("if {1} then\n", "tcl");
-        let e004: Vec<_> = r
-            .diagnostics
-            .iter()
-            .filter(|d| d.code == DiagCode::E004)
-            .collect();
-        assert_eq!(e004.len(), 1, "got {:?}", r.diagnostics);
-        assert!(
-            e004[0].message.contains("Malformed 'if'"),
-            "got {:?}",
-            e004[0].message
-        );
+    fn fp_leading_elseif_is_not_malformed() {
+        let r_diags = e004_diags("if elseif { x }\n");
+        assert!(r_diags.is_empty(), "got {r_diags:?}");
     }
 
     #[test]
-    fn analyse_emits_e004_for_if_with_only_else() {
-        // ``if else { x }`` — no condition+body clause before the
-        // else, so the malformed-if check fires.
-        let mut a = Analyser::new();
-        let r = a.analyse("if else { x }\n", "tcl");
-        let e004: Vec<_> = r
-            .diagnostics
-            .iter()
-            .filter(|d| d.code == DiagCode::E004)
-            .collect();
-        assert_eq!(e004.len(), 1, "got {:?}", r.diagnostics);
-        assert!(
-            e004[0].message.contains("Malformed 'if'"),
-            "got {:?}",
-            e004[0].message
-        );
+    fn fp_else_in_elseif_condition_slot_is_not_malformed() {
+        // ``if {1} { a } elseif else { b }`` — "else" sits in the
+        // *elseif's* condition slot, never keyword-matched there
+        // either (verified against tclsh 8.6: runs body "a", not a
+        // wrong-#args error).
+        let r_diags = e004_diags("if {1} { a } elseif else { b }\n");
+        assert!(r_diags.is_empty(), "got {r_diags:?}");
+    }
+
+    // -- TN: well-formed shapes never flagged.
+
+    #[test]
+    fn tn_single_clause_if() {
+        assert!(e004_diags("if {1} { a }\n").is_empty());
     }
 
     #[test]
-    fn analyse_no_e004_for_valid_if() {
-        // ``if {1} { a }`` — single-clause without else.  No E004.
-        let mut a = Analyser::new();
-        let r = a.analyse("if {1} { a }\n", "tcl");
-        assert!(
-            !r.diagnostics.iter().any(|d| d.code == DiagCode::E004),
-            "got {:?}",
-            r.diagnostics
-        );
+    fn tn_if_else() {
+        assert!(e004_diags("if {1} { a } else { b }\n").is_empty());
     }
 
     #[test]
-    fn analyse_no_e004_for_valid_if_else() {
-        // ``if {1} { a } else { b }`` — well-formed.  No E004.
-        let mut a = Analyser::new();
-        let r = a.analyse("if {1} { a } else { b }\n", "tcl");
-        assert!(
-            !r.diagnostics.iter().any(|d| d.code == DiagCode::E004),
-            "got {:?}",
-            r.diagnostics
-        );
+    fn tn_if_elseif_else_chain() {
+        assert!(e004_diags("if {$a} { x } elseif {$b} { y } else { z }\n").is_empty());
     }
 
     #[test]
-    fn analyse_no_e004_for_valid_if_elseif_chain() {
-        // ``if {a} { x } elseif {b} { y } else { z }`` — full
-        // shape.  No E004.
-        let mut a = Analyser::new();
-        let r = a.analyse("if {$a} { x } elseif {$b} { y } else { z }\n", "tcl");
-        assert!(
-            !r.diagnostics.iter().any(|d| d.code == DiagCode::E004),
-            "got {:?}",
-            r.diagnostics
-        );
+    fn tn_if_with_then_keyword() {
+        assert!(e004_diags("if {1} then { a }\n").is_empty());
     }
 
     #[test]
-    fn analyse_no_e004_for_if_with_then_keyword() {
-        // ``if {1} then { a }`` — explicit ``then`` keyword is
-        // accepted by Tcl.  No E004.
-        let mut a = Analyser::new();
-        let r = a.analyse("if {1} then { a }\n", "tcl");
-        assert!(
-            !r.diagnostics.iter().any(|d| d.code == DiagCode::E004),
-            "got {:?}",
-            r.diagnostics
-        );
+    fn tn_implicit_else_single_body() {
+        // ``if {1} { a } { b }`` — one implicit-else body, no keyword.
+        assert!(e004_diags("if {1} { a } { b }\n").is_empty());
     }
 
     #[test]
-    fn analyse_e004_anchors_at_full_command_range() {
-        // Span runs from the ``if`` keyword through the last arg
-        // token's end.
-        let mut a = Analyser::new();
-        let src = "if {1} { a } else { b } extra\n";
-        let r = a.analyse(src, "tcl");
-        let e004: Vec<_> = r
-            .diagnostics
-            .iter()
-            .filter(|d| d.code == DiagCode::E004)
-            .collect();
-        assert_eq!(e004.len(), 1);
-        let span = e004[0].span;
-        let text = &src[span.start() as usize..span.end() as usize];
-        assert!(text.starts_with("if"), "span starts at {text:?}");
-        assert!(text.contains("extra"), "span text {text:?}");
+    fn tn_inside_tcloo_method_body() {
+        // `if` structural checking is generic body-walking — it must
+        // fire the same way inside a TclOO method body as at top level.
+        let src = "oo::class create C {\n  method m {} {\n    if {1} { a } { b } { c }\n  }\n}\n";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+    }
+
+    // -- FN (documented, intentional scope boundary): a renamed `if` is
+    // not checked. `if`'s registry `clause_shape_check` hook is looked
+    // up by resolving `cmd_name` as written — namespace-qualification
+    // (`::if`) resolves through it (see
+    // `tp_qualified_double_colon_if_is_checked_too`), but a `rename if
+    // myif` target does not, since that requires chasing the same
+    // same-file rename/alias graph the arity checker's
+    // `resolve_indirect_call_target` uses — a distinct, heavier
+    // mechanism not wired up to this dispatch-site check. Real Tcl
+    // *does* validate a renamed `if`'s shape (the C source's own doc
+    // comment: `Tcl_IfObjCmd` runs for "if" or "the name to which if was
+    // renamed"), so this is a genuine, narrow gap — not a false
+    // negative this test is happy about, just one it pins so a future
+    // fix shows up as an intentional behaviour change.
+    #[test]
+    fn fn_renamed_if_is_not_currently_checked() {
+        let src = "rename if myif\nmyif {1} { a } { b } { c }\n";
+        let e004 = e004_diags(src);
+        assert!(e004.is_empty(), "got {e004:?}");
+    }
+
+    // -- Redundant-diagnostic fix: `if`'s registry `arity` floor no
+    // longer produces a second, generic E002 alongside the precise
+    // E004 for the same defect.
+
+    #[test]
+    fn no_duplicate_e002_alongside_e004() {
+        for src in ["if\n", "if {1}\n"] {
+            let mut a = Analyser::new();
+            let r = a.analyse(src, "tcl");
+            assert!(
+                !r.diagnostics.iter().any(|d| d.code == DiagCode::E002),
+                "src={src:?} got {:?}",
+                r.diagnostics
+            );
+            assert!(
+                r.diagnostics.iter().any(|d| d.code == DiagCode::E004),
+                "src={src:?} got {:?}",
+                r.diagnostics
+            );
+        }
+    }
+
+    // -- Code fixes.
+
+    fn apply_fix(src: &str, fix: &crate::analyser::types::CodeFix) -> String {
+        let mut fixed = src.to_string();
+        fixed.replace_range(
+            fix.span.start() as usize..fix.span.end() as usize,
+            &fix.new_text,
+        );
+        fixed
+    }
+
+    #[test]
+    fn fix_merges_extra_words_into_the_final_body() {
+        let src = "if {1} { a } { b } { c }";
+        let e004 = e004_diags(src);
+        assert_eq!(e004.len(), 1, "got {e004:?}");
+        assert_eq!(e004[0].fixes.len(), 1, "got {:?}", e004[0].fixes);
+        let fixed = apply_fix(src, &e004[0].fixes[0]);
+        assert_eq!(fixed, "if {1} { a } {{ b } { c }}");
+        // The fixed source must itself be shape-well-formed.
+        assert!(e004_diags(&fixed).is_empty(), "fixed={fixed:?}");
+    }
+
+    #[test]
+    fn fix_merges_extra_words_after_explicit_else() {
+        let src = "if {1} { a } else { b } extra";
+        let e004 = e004_diags(src);
+        assert_eq!(e004[0].fixes.len(), 1, "got {:?}", e004[0].fixes);
+        let fixed = apply_fix(src, &e004[0].fixes[0]);
+        assert_eq!(fixed, "if {1} { a } else {{ b } extra}");
+        assert!(e004_diags(&fixed).is_empty(), "fixed={fixed:?}");
+    }
+
+    #[test]
+    fn fix_removes_dangling_elseif_clause() {
+        let src = "if {1} { a } elseif";
+        let e004 = e004_diags(src);
+        assert_eq!(e004[0].fixes.len(), 1, "got {:?}", e004[0].fixes);
+        assert_eq!(e004[0].fixes[0].new_text, "");
+        let fixed = apply_fix(src, &e004[0].fixes[0]);
+        assert_eq!(fixed, "if {1} { a } ");
+        assert!(e004_diags(&fixed).is_empty(), "fixed={fixed:?}");
+    }
+
+    #[test]
+    fn fix_removes_dangling_else_with_no_body() {
+        let src = "if {1} { a } else";
+        let e004 = e004_diags(src);
+        assert_eq!(e004[0].fixes.len(), 1, "got {:?}", e004[0].fixes);
+        let fixed = apply_fix(src, &e004[0].fixes[0]);
+        assert_eq!(fixed, "if {1} { a } ");
+        assert!(e004_diags(&fixed).is_empty(), "fixed={fixed:?}");
+    }
+
+    #[test]
+    fn fix_removes_dangling_elseif_condition_without_body() {
+        let src = "if {1} { a } elseif {2}";
+        let e004 = e004_diags(src);
+        assert_eq!(e004[0].fixes.len(), 1, "got {:?}", e004[0].fixes);
+        let fixed = apply_fix(src, &e004[0].fixes[0]);
+        assert_eq!(fixed, "if {1} { a } ");
+        assert!(e004_diags(&fixed).is_empty(), "fixed={fixed:?}");
+    }
+
+    #[test]
+    fn no_fix_offered_when_the_first_clause_never_completed() {
+        // ``if`` / ``if {1}`` — there is no well-formed prefix to fall
+        // back to, so no fix is offered (never a guessed body).
+        for src in ["if", "if {1}", "if {1} then"] {
+            let e004 = e004_diags(src);
+            assert_eq!(e004.len(), 1, "src={src:?}");
+            assert!(
+                e004[0].fixes.is_empty(),
+                "src={src:?} got {:?}",
+                e004[0].fixes
+            );
+        }
     }
 
     // -- W304 missing-option-terminator emitter

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -140,11 +140,60 @@ pub struct PendingUserCallArity {
     pub positional_any_expand: bool,
 }
 
+/// Which `TclOO` instantiation form introduced a [`PendingCtorArity`] —
+/// `oo::class` (and every other `IS_OO_METACLASS` command) inherits all
+/// three from its own metaclass protocol, and an ordinary class inherits
+/// them from `oo::class` in turn, so `ClassName new/create/createWithNamespace
+/// ?args?` all reach the same constructor. Each form has a different count
+/// of mandatory leading words that are *not* part of the constructor's own
+/// argument list — confirmed against tclsh 9.0.4 and matching
+/// `oo_class_arg_roles`'s identical word layout for the sibling
+/// class-*definition* shapes (`oo::class create Name body` / `new body` /
+/// `createWithNamespace Name ::ns body`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum CtorForm {
+    /// `ClassName new ?args?` — every word after `new` is a constructor arg.
+    New,
+    /// `ClassName create name ?args?` — the mandatory object-name word is
+    /// not part of the constructor's own arguments.
+    Create,
+    /// `ClassName createWithNamespace name ::ns ?args?` — the mandatory
+    /// object-name and namespace words are not part of the constructor's
+    /// own arguments.
+    CreateWithNamespace,
+}
+
+impl CtorForm {
+    /// Count of mandatory leading words to fold into the constructor's
+    /// arity bound before comparing it against the call site — see
+    /// [`Self`]'s own doc comment.
+    #[must_use]
+    pub fn extra_leading_words(self) -> u16 {
+        match self {
+            CtorForm::New => 0,
+            CtorForm::Create => 1,
+            CtorForm::CreateWithNamespace => 2,
+        }
+    }
+
+    /// The keyword as written at the call site, for the diagnostic's
+    /// display name.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            CtorForm::New => "new",
+            CtorForm::Create => "create",
+            CtorForm::CreateWithNamespace => "createWithNamespace",
+        }
+    }
+}
+
 /// A queued `TclOO` constructor-call arity candidate — `ClassName new
-/// ?args?` / `ClassName create name ?args?` — mirroring
-/// [`PendingUserCallArity`]'s architecture exactly: queued unconditionally
-/// whenever a call's first word is literally `new`/`create` (regardless of
-/// whether the head even resolves to a class), and resolved post-walk
+/// ?args?` / `ClassName create name ?args?` / `ClassName createWithNamespace
+/// name ::ns ?args?` — mirroring [`PendingUserCallArity`]'s architecture
+/// exactly: queued unconditionally whenever a call's first word is
+/// literally one of those three keywords (regardless of whether the head
+/// even resolves to a class), and resolved post-walk
 /// ([`super::state::Analyser::flush_ctor_arity_diagnostics`]) once
 /// `all_classes` — and thus the class hierarchy a constructor may be
 /// inherited through — is fully populated.  A candidate that doesn't
@@ -162,16 +211,15 @@ pub struct PendingCtorArity {
     /// — a top-level `Dog new` must have `Dog`'s definition lexically
     /// precede it; a call inside a proc/method body is not order-gated.
     pub enforce_order: bool,
-    /// `true` for `create` (whose first word after the keyword is a
-    /// mandatory object name, not part of the constructor's own
-    /// arguments), `false` for `new`.
-    pub is_create: bool,
+    /// Which of `new`/`create`/`createWithNamespace` this call used.
+    pub form: CtorForm,
     /// Offset of the class-name token, for the top-level order gate.
     pub call_off: u32,
     /// Full diagnostic span (class-name head through the last argument).
     pub full_span: Span,
-    /// Lower-bound positional count of the words *after* `new`/`create`
-    /// (for `create`, this includes the mandatory object-name word).
+    /// Lower-bound positional count of the words *after* the keyword (for
+    /// `create`/`createWithNamespace`, this includes their mandatory
+    /// leading words).
     pub nargs_min: usize,
     /// Whether any positional word is `{*}`-expanded — same convention as
     /// [`PendingUserCallArity::positional_any_expand`].

--- a/rust/tcl-lsp-server/tests/e2e/code_actions.rs
+++ b/rust/tcl-lsp-server/tests/e2e/code_actions.rs
@@ -207,6 +207,68 @@ fn test_w302_no_fix_when_result_present() {
     assert!(new_texts(&actions).is_empty());
 }
 
+#[test]
+fn test_e004_extra_words_offers_merge_into_body_fix() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "if {1} {a} {b} {c}\n");
+    let e004 = with_code(&diags, "E004");
+    assert!(!e004.is_empty(), "expected an E004 diagnostic");
+    let actions = code_actions_only(
+        &mut lsp,
+        &uri,
+        range((0, 15), (0, 18)),
+        json!(e004),
+        &["quickfix"],
+    );
+    assert!(
+        titles(&actions)
+            .iter()
+            .any(|t| t.to_lowercase().contains("merge"))
+    );
+    assert!(new_texts(&actions).iter().any(|nt| nt == "{{b} {c}}"));
+}
+
+#[test]
+fn test_e004_dangling_elseif_offers_remove_clause_fix() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "if {1} {a} elseif\n");
+    let e004 = with_code(&diags, "E004");
+    assert!(!e004.is_empty(), "expected an E004 diagnostic");
+    let actions = code_actions_only(
+        &mut lsp,
+        &uri,
+        range((0, 12), (0, 18)),
+        json!(e004),
+        &["quickfix"],
+    );
+    assert!(
+        titles(&actions)
+            .iter()
+            .any(|t| t.to_lowercase().contains("remove"))
+    );
+    assert!(new_texts(&actions).iter().any(String::is_empty));
+}
+
+#[test]
+fn test_e004_missing_first_clause_offers_no_fix() {
+    // `if {1}` has no well-formed prefix to fall back to — no fix.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "if {1}\n");
+    let e004 = with_code(&diags, "E004");
+    assert!(!e004.is_empty(), "expected an E004 diagnostic");
+    let actions = code_actions_only(
+        &mut lsp,
+        &uri,
+        range((0, 3), (0, 6)),
+        json!(e004),
+        &["quickfix"],
+    );
+    assert!(new_texts(&actions).is_empty(), "got {actions:?}");
+}
+
 // -- TestRefactorActions -------------------------------------------------
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -73,6 +73,15 @@ fn message(d: &Value) -> &str {
     d.get("message").and_then(Value::as_str).unwrap_or("")
 }
 
+/// Diagnostics from `diags` carrying `code`.
+fn with_code(diags: &[Value], code: &str) -> Vec<Value> {
+    diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some(code))
+        .cloned()
+        .collect()
+}
+
 // -- TestPushDiagnostics -------------------------------------------------
 
 #[test]
@@ -100,6 +109,113 @@ fn arity_error_is_e002_with_error_severity() {
         .collect();
     assert!(!e002.is_empty());
     assert_eq!(e002[0].get("severity").and_then(Value::as_i64), Some(1)); // Error
+}
+
+// -- E004 malformed `if` — end-to-end. Each message/range is
+// cross-checked against tclsh 8.6 and Tcl 9.0.4's `Tcl_IfObjCmd` source
+// in the unit-level truth table (`tcl-registry`'s
+// `commands::tcl::if_::tests`, `tcl-compiler`'s `analyser::state::tests`
+// `tp_*` / `fp_*` / `tn_*` cases); this layer only asserts the
+// diagnostic survives the full LSP round trip (server → JSON-RPC →
+// `publishDiagnostics`) with the right code, message, and — critically
+// — a *tight* range, not the whole statement.
+
+/// A diagnostic's `range` as `((start_line, start_char), (end_line, end_char))`.
+fn diag_range(d: &Value) -> ((i64, i64), (i64, i64)) {
+    let get = |path: &[&str]| -> i64 {
+        let mut v = d.get("range").expect("diagnostic has a range");
+        for p in path {
+            v = v.get(p).unwrap_or(&Value::Null);
+        }
+        v.as_i64().unwrap_or(-1)
+    };
+    (
+        (get(&["start", "line"]), get(&["start", "character"])),
+        (get(&["end", "line"]), get(&["end", "character"])),
+    )
+}
+
+#[test]
+fn e004_bare_if_names_the_invoked_command_and_anchors_on_it() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "if\n");
+    let e004 = with_code(&diags, "E004");
+    assert_eq!(e004.len(), 1, "got {diags:?}");
+    assert_eq!(message(&e004[0]), "No expression after \"if\" argument");
+    assert_eq!(diag_range(&e004[0]), ((0, 0), (0, 2)));
+}
+
+#[test]
+fn e004_condition_without_body_anchors_on_the_condition_word() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "if {1}\n");
+    let e004 = with_code(&diags, "E004");
+    assert_eq!(e004.len(), 1, "got {diags:?}");
+    assert_eq!(message(&e004[0]), "No script following \"1\" argument");
+    assert_eq!(diag_range(&e004[0]), ((0, 3), (0, 6)));
+}
+
+#[test]
+fn e004_extra_words_anchors_only_the_extra_word_not_the_whole_statement() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "if {1} {a} {b} {c}\n");
+    let e004 = with_code(&diags, "E004");
+    assert_eq!(e004.len(), 1, "got {diags:?}");
+    assert_eq!(
+        message(&e004[0]),
+        "Extra words after \"else\" clause in \"if\" command"
+    );
+    // Just "{c}" (columns 15..18) — not the whole `if ... {c}` statement.
+    assert_eq!(diag_range(&e004[0]), ((0, 15), (0, 18)));
+}
+
+#[test]
+fn e004_leading_else_bareword_condition_is_not_flagged() {
+    // `if else {a}` — "else" is a well-formed (if ill-typed) condition,
+    // not a malformed `if`; see the FP fix in
+    // `tcl-compiler`'s `analyser::state::tests::fp_leading_else_is_not_malformed`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "if else {a}\n");
+    assert!(with_code(&diags, "E004").is_empty(), "got {diags:?}");
+}
+
+#[test]
+fn e004_qualified_double_colon_if_is_checked() {
+    // `::if` names the same global command as `if` — the E004 dispatch
+    // is generic on the resolved spec's hook, not on the literal
+    // `cmd_name == "if"` text, so registry `::`-stripping picks this up
+    // for free.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "::if {1} {a} {b} {c}\n");
+    assert_eq!(with_code(&diags, "E004").len(), 1, "got {diags:?}");
+}
+
+#[test]
+fn e004_well_formed_elseif_chain_has_no_e004() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "if {$a} {\n  puts a\n} elseif {$b} {\n  puts b\n} else {\n  puts c\n}\n",
+    );
+    assert!(with_code(&diags, "E004").is_empty(), "got {diags:?}");
+}
+
+#[test]
+fn e004_no_duplicate_e002_for_the_same_malformed_if() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "if {1}\n");
+    assert_eq!(with_code(&diags, "E004").len(), 1, "got {diags:?}");
+    assert!(
+        with_code(&diags, "E002").is_empty(),
+        "E004 must not carry a redundant generic E002 alongside it: {diags:?}"
+    );
 }
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/recovery.rs
+++ b/rust/tcl-lsp-server/tests/e2e/recovery.rs
@@ -272,13 +272,19 @@ fn c2_bare_set_after_break_still_arity_errors() {
 #[test]
 fn c2_bare_set_after_unterminated_expr_brace_still_analysed() {
     // An unterminated braced *expression* (`if {…`) must also recover so the
-    // following command is analysed — a bare `set` still arity-errors.
+    // swallowed tail is still analysed as code — the unclosed brace runs to
+    // EOF, so `if`'s own single (swallowed) argument is itself an arity /
+    // shape defect: E002 (a plain arity floor) or the more precise E004
+    // (`if`'s dedicated clause-shape check, which subsumes E002 for `if` —
+    // see `tcl-compiler`'s `no_duplicate_e002_alongside_e004`) — either is
+    // acceptable here, since this suite asserts observable recovery
+    // behaviour, not a specific diagnostic code.
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     let diags = lsp.open_ready(&uri, "if {$x > 5\nset\n");
     assert!(
-        codes(&diags).contains("E002"),
-        "tail `set` after `if {{` should arity-error; got {:?}",
+        codes(&diags).contains("E002") || codes(&diags).contains("E004"),
+        "tail after `if {{` should still be analysed and arity/shape-error; got {:?}",
         codes(&diags)
     );
 }

--- a/rust/tcl-lsp-server/tests/e2e/recovery.rs
+++ b/rust/tcl-lsp-server/tests/e2e/recovery.rs
@@ -270,21 +270,31 @@ fn c2_bare_set_after_break_still_arity_errors() {
 }
 
 #[test]
-fn c2_bare_set_after_unterminated_expr_brace_still_analysed() {
-    // An unterminated braced *expression* (`if {…`) must also recover so the
-    // swallowed tail is still analysed as code — the unclosed brace runs to
-    // EOF, so `if`'s own single (swallowed) argument is itself an arity /
-    // shape defect: E002 (a plain arity floor) or the more precise E004
-    // (`if`'s dedicated clause-shape check, which subsumes E002 for `if` —
-    // see `tcl-compiler`'s `no_duplicate_e002_alongside_e004`) — either is
-    // acceptable here, since this suite asserts observable recovery
-    // behaviour, not a specific diagnostic code.
+fn c2_if_with_unterminated_expr_brace_flags_its_own_malformed_clause() {
+    // Unlike an unterminated *bracket* substitution (`[foo bar`, whose
+    // content is still live Tcl-command syntax the parser keeps
+    // recognising even without a closing `]` — see
+    // `c2_bare_set_after_break_still_arity_errors`), an unterminated
+    // *brace* word has no such inherent structure: the lexer can't know in
+    // advance it will be handed to `if` as a script argument, so with no
+    // closing `}` the whole remainder of the file — condition *and*
+    // `set\n` — is swallowed as one opaque, unparsed span (confirmed via
+    // `tcl explore --show structuralIndex`: 1 unterminated brace, 0
+    // command boundaries beyond EOF, the entire tail folded into a single
+    // "inert" span). So `set` is genuinely never re-tokenised as its own
+    // command here — this does *not* exercise the same tail-recovery path
+    // the bracket sibling test does. What *is* still true, and is what
+    // this test actually verifies: `if`'s own single swallowed argument
+    // (condition only, no body) is itself an arity/shape defect — E002 (a
+    // plain arity floor) or the more precise E004 (`if`'s dedicated
+    // clause-shape check, which subsumes E002 for `if` — see
+    // `tcl-compiler`'s `no_duplicate_e002_alongside_e004`).
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     let diags = lsp.open_ready(&uri, "if {$x > 5\nset\n");
     assert!(
         codes(&diags).contains("E002") || codes(&diags).contains("E004"),
-        "tail after `if {{` should still be analysed and arity/shape-error; got {:?}",
+        "if's own malformed (condition-only) clause should still arity/shape-error; got {:?}",
         codes(&diags)
     );
 }

--- a/rust/tcl-registry/src/clause_shape.rs
+++ b/rust/tcl-registry/src/clause_shape.rs
@@ -1,0 +1,71 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Clause-chain shape validation — for commands whose set of valid
+//! argument shapes isn't a single `min..=max` [`crate::Arity`] range.
+//!
+//! `if`'s grammar (`expr ?then? body (elseif expr ?then? body)* (else
+//! body)?`) is the first (and, today, only) consumer: a plain arity range
+//! can express "at least 2 words" but not "an `elseif` must be followed by
+//! an expression and a body" or "nothing may trail the final body". A
+//! command with this shape of grammar sets
+//! [`crate::spec::CommandSpec::clause_shape_check`] to a
+//! [`ClauseShapeChecker`] that walks its own argument list and reports the
+//! first defect, so the compiler's diagnostic for it (`if`'s `E004`) reads
+//! registry data instead of re-parsing the grammar itself. A command
+//! carrying the hook also sets [`crate::Traits::STRUCTURALLY_CHECKED_ARITY`]
+//! so the generic arity floor/ceiling check steps aside — the hook owns
+//! arity together with clause shape, so a malformed call gets one precise
+//! diagnostic rather than a redundant generic one alongside it.
+
+/// A structural defect in a command's clause-chain shape, reported by a
+/// [`ClauseShapeChecker`].
+///
+/// Word indices are 0-based into the command's arguments *after* the
+/// command name, matching every other by-position hook
+/// (`ArgRoleResolver`).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ClauseShapeError {
+    /// A clause that requires a sub-expression word never got one.
+    MissingExpr {
+        /// Index of the last present word that introduced the missing
+        /// expression (e.g. an `elseif` keyword) — `None` when the
+        /// command has no arguments at all, in which case the caller
+        /// should name the command's own invoked spelling rather than a
+        /// word.
+        after: Option<usize>,
+    },
+    /// A clause that requires a body word never got one.
+    MissingBody {
+        /// Index of the last present word (a condition, a `then`
+        /// keyword, or a terminal keyword such as `else`).
+        after: usize,
+    },
+    /// One or more words trail the last recognised clause.
+    ExtraWords {
+        /// Index of the first extra word.
+        first_extra: usize,
+    },
+}
+
+/// Validate a command's clause-chain shape.
+///
+/// Called with the command's arguments (excluding the command name).
+/// Returns the first structural defect, or `None` for any shape the
+/// command accepts.
+pub type ClauseShapeChecker = fn(args: &[&str]) -> Option<ClauseShapeError>;

--- a/rust/tcl-registry/src/commands/tcl/if_.rs
+++ b/rust/tcl-registry/src/commands/tcl/if_.rs
@@ -20,6 +20,131 @@
 
 use crate::prelude::*;
 
+/// Result of one pass over an `if` invocation's argument words: the
+/// per-word [`ArgRole`] assignments [`if_arg_roles`] returns, and — for
+/// the compiler's E004 diagnostic — the first structural defect, if any.
+/// Walking the grammar exactly once for both consumers is what keeps
+/// them from drifting apart the way two independent re-implementations
+/// eventually would.
+struct IfWalk {
+    roles: Vec<(u8, ArgRole)>,
+    error: Option<ClauseShapeError>,
+}
+
+/// Walk an `if` invocation's argument words against the grammar C Tcl's
+/// `Tcl_IfObjCmd` accepts: `expr ?then? body (elseif expr ?then? body)*
+/// (else body)?`. Verified word-for-word against `TclNRIfObjCmd` /
+/// `IfConditionCallback` in Tcl 9.0.4's `generic/tclCmdIL.c`, and
+/// cross-checked against tclsh 8.6 (the same algorithm, unchanged since
+/// at least Tcl 8.4).
+///
+/// Two properties fall out of mirroring the real grammar rather than
+/// keyword-matching every position:
+///
+/// - A condition slot (`args[0]`, or the word right after `elseif`) is
+///   *never* keyword-matched — `if else {a}` and `if elseif {a}` are
+///   structurally well-formed `if`s whose single condition happens to be
+///   the bareword `else` / `elseif`; real Tcl evaluates it as a boolean
+///   expression and fails there (an invalid-bareword error), not as a
+///   malformed `if`. Only `then` (right after a fresh condition) and
+///   `elseif` / `else` (once a clause is complete) are ever
+///   keyword-matched, matching `IfConditionCallback` exactly.
+/// - Once a clause completes, at most one more bare word is accepted as
+///   the implicit-else body; anything past it is `ExtraWords`, matching
+///   Tcl's `wrong # args: extra words after "else" clause` — whether or
+///   not an explicit `else` keyword introduced that body.
+fn walk_if(args: &[&str]) -> IfWalk {
+    let mut roles = Vec::new();
+    let n = args.len();
+
+    let push_role = |roles: &mut Vec<(u8, ArgRole)>, index: usize, role: ArgRole| {
+        if let Ok(idx) = u8::try_from(index) {
+            roles.push((idx, role));
+        }
+    };
+
+    if n == 0 {
+        return IfWalk {
+            roles,
+            error: Some(ClauseShapeError::MissingExpr { after: None }),
+        };
+    }
+
+    // Mandatory first condition — position 0, never keyword-matched.
+    let mut i: usize = 0;
+    push_role(&mut roles, i, ArgRole::Expr);
+    i += 1;
+    if i < n && args[i] == "then" {
+        push_role(&mut roles, i, ArgRole::Keyword);
+        i += 1;
+    }
+    if i >= n {
+        return IfWalk {
+            roles,
+            error: Some(ClauseShapeError::MissingBody { after: i - 1 }),
+        };
+    }
+    push_role(&mut roles, i, ArgRole::Body);
+    i += 1;
+
+    loop {
+        if i >= n {
+            return IfWalk { roles, error: None };
+        }
+        if args[i] == "elseif" {
+            let kw_idx = i;
+            push_role(&mut roles, i, ArgRole::Keyword);
+            i += 1;
+            if i >= n {
+                return IfWalk {
+                    roles,
+                    error: Some(ClauseShapeError::MissingExpr {
+                        after: Some(kw_idx),
+                    }),
+                };
+            }
+            // The elseif's condition — position-only, never keyword-matched
+            // (see the `if elseif else {a}` case in the doc comment above).
+            push_role(&mut roles, i, ArgRole::Expr);
+            i += 1;
+            if i < n && args[i] == "then" {
+                push_role(&mut roles, i, ArgRole::Keyword);
+                i += 1;
+            }
+            if i >= n {
+                return IfWalk {
+                    roles,
+                    error: Some(ClauseShapeError::MissingBody { after: i - 1 }),
+                };
+            }
+            push_role(&mut roles, i, ArgRole::Body);
+            i += 1;
+            continue;
+        }
+        if args[i] == "else" {
+            let kw_idx = i;
+            push_role(&mut roles, i, ArgRole::Keyword);
+            i += 1;
+            if i >= n {
+                return IfWalk {
+                    roles,
+                    error: Some(ClauseShapeError::MissingBody { after: kw_idx }),
+                };
+            }
+            push_role(&mut roles, i, ArgRole::Body);
+            i += 1;
+            let error = (i < n).then_some(ClauseShapeError::ExtraWords { first_extra: i });
+            return IfWalk { roles, error };
+        }
+        // Implicit else: the first bare word is the body; anything past it
+        // is unreachable in real Tcl and a structural error here.
+        push_role(&mut roles, i, ArgRole::Body);
+        i += 1;
+        let error = (i < n).then_some(ClauseShapeError::ExtraWords { first_extra: i });
+        return IfWalk { roles, error };
+    }
+}
+
 const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
     target: SideEffectTarget::Unknown,
     reads: true,
@@ -39,68 +164,22 @@ const FORMS: &[FormSpec] = &[FormSpec {
 /// `Expr` (conditions) or `Body` (scripts). The structural keyword
 /// words themselves (`then`/`elseif`/`else`) carry `ArgRole::Keyword`
 /// so the semantic-token layer highlights them as keywords rather
-/// than strings.
+/// than strings. Delegates to [`walk_if`] — the same grammar walk
+/// that drives [`check_if_shape`], so highlighting and the E004
+/// diagnostic can never disagree about where a clause starts.
 fn if_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
-    let mut roles = Vec::new();
-    let mut i: usize = 0;
-    let n = args.len();
+    walk_if(args).roles
+}
 
-    let push_role = |roles: &mut Vec<(u8, ArgRole)>, index: usize, role: ArgRole| {
-        if let Ok(idx) = u8::try_from(index) {
-            roles.push((idx, role));
-        }
-    };
-
-    // First condition
-    if i < n {
-        push_role(&mut roles, i, ArgRole::Expr);
-        i += 1;
-    }
-    // Optional 'then'
-    if i < n && args[i] == "then" {
-        push_role(&mut roles, i, ArgRole::Keyword);
-        i += 1;
-    }
-    // First body
-    if i < n {
-        push_role(&mut roles, i, ArgRole::Body);
-        i += 1;
-    }
-
-    while i < n {
-        let kw = args[i];
-        if kw == "elseif" {
-            push_role(&mut roles, i, ArgRole::Keyword);
-            i += 1;
-            if i < n {
-                push_role(&mut roles, i, ArgRole::Expr);
-                i += 1;
-            }
-            if i < n && args[i] == "then" {
-                push_role(&mut roles, i, ArgRole::Keyword);
-                i += 1;
-            }
-            if i < n {
-                push_role(&mut roles, i, ArgRole::Body);
-                i += 1;
-            }
-            continue;
-        }
-        if kw == "else" {
-            push_role(&mut roles, i, ArgRole::Keyword);
-            if i + 1 < n {
-                push_role(&mut roles, i + 1, ArgRole::Body);
-            }
-            break;
-        }
-        // Implicit else: trailing word with no keyword
-        if i == n - 1 {
-            push_role(&mut roles, i, ArgRole::Body);
-            break;
-        }
-        i += 1;
-    }
-    roles
+/// Validate an `if` invocation's structural shape.
+///
+/// Runs the same clause-chain walk [`if_arg_roles`] uses for
+/// highlighting and returns the first defect [`walk_if`] finds, or
+/// `None` for any shape C Tcl accepts — including a bare leading
+/// `else` / `elseif` (`if else {a}`): see [`walk_if`]'s doc comment for
+/// why that is structurally well-formed rather than a malformed `if`.
+fn check_if_shape(args: &[&str]) -> Option<ClauseShapeError> {
+    walk_if(args).error
 }
 
 /// Command spec for `if`.
@@ -112,9 +191,14 @@ pub fn spec() -> CommandSpec {
             | Traits::CONTROL_FLOW
             | Traits::LANGUAGE_KEYWORD
             | Traits::HAS_BOOLEAN_COND
-            | Traits::NEVER_INLINE_BODY,
+            | Traits::NEVER_INLINE_BODY
+            | Traits::STRUCTURALLY_CHECKED_ARITY,
+        // The floor here is purely descriptive (hover / hint text): the real
+        // minimum is enforced by `clause_shape_check`, which also covers the
+        // `elseif`/`else` chain shape a plain range can't express.
         arity: Arity::at_least(2),
         arg_role_resolver: Some(if_arg_roles),
+        clause_shape_check: Some(check_if_shape),
         lowering_hook: Some(crate::hooks::LoweringHookId::If),
         return_type: Some(TclType::String),
         arg_types: &[(
@@ -138,5 +222,216 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         side_effects: SIDE_EFFECTS,
         ..CommandSpec::DEFAULT
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Every case here was cross-checked against tclsh 8.6 and against
+    /// Tcl 9.0.4's `TclNRIfObjCmd` / `IfConditionCallback` source
+    /// (`generic/tclCmdIL.c`), which implement the identical structural
+    /// walk.  TN cases (well-formed shapes) and FN-shaped cases
+    /// (structurally valid shapes that fail for an unrelated reason at
+    /// runtime — an invalid-bareword condition) are `None`; TP cases
+    /// (genuinely malformed shapes) are `Some`.
+    fn shape(src: &str) -> Option<ClauseShapeError> {
+        let words: Vec<&str> = src.split_whitespace().collect();
+        check_if_shape(&words)
+    }
+
+    #[test]
+    fn empty_args_is_missing_expr_with_no_word() {
+        assert_eq!(
+            shape(""),
+            Some(ClauseShapeError::MissingExpr { after: None })
+        );
+    }
+
+    #[test]
+    fn condition_only_is_missing_body_after_condition() {
+        // `if {1}`
+        assert_eq!(shape("1"), Some(ClauseShapeError::MissingBody { after: 0 }));
+    }
+
+    #[test]
+    fn condition_then_is_missing_body_after_then() {
+        // `if {1} then`
+        assert_eq!(
+            shape("1 then"),
+            Some(ClauseShapeError::MissingBody { after: 1 })
+        );
+    }
+
+    #[test]
+    fn condition_body_is_well_formed() {
+        assert_eq!(shape("1 a"), None);
+    }
+
+    #[test]
+    fn condition_then_body_is_well_formed() {
+        assert_eq!(shape("1 then a"), None);
+    }
+
+    #[test]
+    fn implicit_else_single_body_is_well_formed() {
+        // `if {1} {a} {b}`
+        assert_eq!(shape("1 a b"), None);
+    }
+
+    #[test]
+    fn implicit_else_extra_words_is_extra_words_at_first_extra() {
+        // `if {1} {a} {b} {c}` — "c" (index 3) is the first extra word.
+        assert_eq!(
+            shape("1 a b c"),
+            Some(ClauseShapeError::ExtraWords { first_extra: 3 })
+        );
+    }
+
+    #[test]
+    fn implicit_else_many_extra_words_still_anchors_first_extra() {
+        // `if {1} {a} {b} {c} {d}`
+        assert_eq!(
+            shape("1 a b c d"),
+            Some(ClauseShapeError::ExtraWords { first_extra: 3 })
+        );
+    }
+
+    #[test]
+    fn explicit_else_body_is_well_formed() {
+        assert_eq!(shape("1 a else b"), None);
+    }
+
+    #[test]
+    fn else_without_body_is_missing_body_after_else() {
+        // `if {1} {a} else`
+        assert_eq!(
+            shape("1 a else"),
+            Some(ClauseShapeError::MissingBody { after: 2 })
+        );
+    }
+
+    #[test]
+    fn else_body_extra_words_is_extra_words_at_first_extra() {
+        // `if {1} {a} else {b} {c}`
+        assert_eq!(
+            shape("1 a else b c"),
+            Some(ClauseShapeError::ExtraWords { first_extra: 4 })
+        );
+    }
+
+    #[test]
+    fn elseif_chain_no_else_is_well_formed() {
+        assert_eq!(shape("a x elseif b y"), None);
+    }
+
+    #[test]
+    fn elseif_chain_with_else_is_well_formed() {
+        assert_eq!(shape("a x elseif b y else z"), None);
+    }
+
+    #[test]
+    fn elseif_without_expr_is_missing_expr_after_elseif() {
+        // `if {1} {a} elseif`
+        assert_eq!(
+            shape("1 a elseif"),
+            Some(ClauseShapeError::MissingExpr { after: Some(2) })
+        );
+    }
+
+    #[test]
+    fn elseif_condition_without_body_is_missing_body_after_condition() {
+        // `if {1} {a} elseif {2}`
+        assert_eq!(
+            shape("1 a elseif 2"),
+            Some(ClauseShapeError::MissingBody { after: 3 })
+        );
+    }
+
+    #[test]
+    fn elseif_then_without_body_is_missing_body_after_then() {
+        // `if {1} {a} elseif {2} then`
+        assert_eq!(
+            shape("1 a elseif 2 then"),
+            Some(ClauseShapeError::MissingBody { after: 4 })
+        );
+    }
+
+    #[test]
+    fn elseif_chain_then_implicit_else_is_well_formed() {
+        // `if {1} {a} elseif {2} {b} {c}` — an elseif clause followed by
+        // a bare implicit-else body is well-formed (verified against
+        // tclsh 8.6: runs body "a", not a wrong-#args error).
+        assert_eq!(shape("1 a elseif 2 b c"), None);
+    }
+
+    #[test]
+    fn elseif_chain_then_implicit_else_extra_words() {
+        // `if {1} {a} elseif {2} {b} {c} {d}` — "d" (index 6) is the
+        // first word to trail the implicit-else body.
+        assert_eq!(
+            shape("1 a elseif 2 b c d"),
+            Some(ClauseShapeError::ExtraWords { first_extra: 6 })
+        );
+    }
+
+    // -- Leading `else`/`elseif`: the condition slot is never
+    // keyword-matched, so these are structurally well-formed (the
+    // bareword condition fails at expression-evaluation time instead —
+    // a distinct, unrelated problem this check does not own).
+
+    #[test]
+    fn leading_else_is_well_formed_condition_bareword() {
+        // `if else {a}` — "else" is just the (ill-typed) condition text.
+        assert_eq!(shape("else a"), None);
+    }
+
+    #[test]
+    fn leading_elseif_is_well_formed_condition_bareword() {
+        // `if elseif {a}`
+        assert_eq!(shape("elseif a"), None);
+    }
+
+    #[test]
+    fn else_as_elseif_condition_is_well_formed() {
+        // `if {1} {a} elseif else {b}` — "else" sits in the *elseif's
+        // condition* slot, never keyword-matched there either.
+        assert_eq!(shape("1 a elseif else b"), None);
+    }
+
+    #[test]
+    fn then_as_implicit_else_body_with_trailing_word_is_extra_words() {
+        // `if {1} {a} then {b}` — "then" is only ever keyword-matched
+        // right after a *fresh* condition; here it is the implicit-else
+        // body candidate, and "b" (index 3) is the extra word.
+        assert_eq!(
+            shape("1 a then b"),
+            Some(ClauseShapeError::ExtraWords { first_extra: 3 })
+        );
+    }
+
+    #[test]
+    fn else_as_implicit_else_body_is_well_formed() {
+        // `if {1} {a} else then` — "then" here is just the else-branch
+        // body text, not a keyword.
+        assert_eq!(shape("1 a else then"), None);
+    }
+
+    #[test]
+    fn if_arg_roles_matches_walk_if_roles() {
+        // `if_arg_roles` must be a pure delegation to `walk_if` — assert
+        // it, so the two can never drift back apart.
+        for src in [
+            "1 a",
+            "1 then a",
+            "1 a else b",
+            "a x elseif b y else z",
+            "1 a b c",
+            "else a",
+        ] {
+            let words: Vec<&str> = src.split_whitespace().collect();
+            assert_eq!(if_arg_roles(&words), walk_if(&words).roles, "src={src:?}");
+        }
     }
 }

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -25,6 +25,66 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "namespace subcommand ?arg ...?",
 }];
 
+/// `namespace ensemble create`'s options — verified against this project's
+/// own `namespace ensemble` implementation
+/// (`runtime/rust/src/cmd_namespace.rs`'s `ens_create` /
+/// `apply_ensemble_option`), whose "bad option" error text enumerates
+/// exactly these six. Every one takes a single value word — `create` (and
+/// `configure`'s update form) both parse strict `-option value` pairs, no
+/// bare flags. `-namespace` is deliberately excluded: it's a read-only
+/// property `configure` can report but neither `create` nor `configure`
+/// accepts as a setter (rejected by `apply_ensemble_option`'s `_` arm).
+static ENSEMBLE_CREATE_OPTIONS: &[OptionSpec] = &[
+    OptionSpec {
+        name: "-command",
+        value: OptionValue::value("name"),
+        detail: "Name of the ensemble's dispatch command (default: the namespace's own name).",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-map",
+        value: OptionValue::value("dict"),
+        detail: "Maps subcommand names to target command prefixes.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-parameters",
+        value: OptionValue::value("list"),
+        detail: "Parameter names inserted between the ensemble command and the subcommand.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-prefixes",
+        value: OptionValue::value("boolean"),
+        detail: "Whether unambiguous subcommand prefixes are accepted.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-subcommands",
+        value: OptionValue::value("list"),
+        detail: "Explicit list of valid subcommand names.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-unknown",
+        value: OptionValue::value("prefix"),
+        detail: "Command prefix invoked for an unrecognised subcommand.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+];
+
 static SUBCOMMANDS: &[SubCommand] = &[
     SubCommand {
         name: "children",
@@ -68,6 +128,12 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "namespace ensemble subcommand ?arg ...?",
         return_type: Some(TclType::String),
         dialects: Some(DialectSet::TCL85_PLUS),
+        // Shared by `create`/`configure` (see `ENSEMBLE_CREATE_OPTIONS`'s
+        // own doc comment) — `ensemble`'s own dispatch (`create` /
+        // `configure` / `exists`) isn't modelled as nested subcommands, so
+        // this covers the whole `namespace ensemble …` surface rather than
+        // just `create`'s.
+        options: ENSEMBLE_CREATE_OPTIONS,
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -56,6 +56,7 @@ pub mod base_objects;
 pub mod bigip;
 pub mod body_kind;
 pub mod cache;
+pub mod clause_shape;
 pub mod command_snapshot;
 pub mod commands;
 pub mod const_fold;
@@ -91,6 +92,7 @@ pub mod prelude {
     pub use crate::arg_role::{AppendedArity, ArgRole};
     pub use crate::arity::Arity;
     pub use crate::body_kind::BodyKind;
+    pub use crate::clause_shape::{ClauseShapeChecker, ClauseShapeError};
     pub use crate::definer::{DefinerFamily, DefinitionBodyGrammar, MemberKind, MemberSpec};
     pub use crate::dialects::DialectSet;
     pub use crate::events::EventRequires;
@@ -120,6 +122,7 @@ pub use arity::Arity;
 pub use bigip::{BigipObjectSpec, BigipPropertySpec, BigipRegistry, ValueKind};
 pub use body_kind::BodyKind;
 pub use cache::registry_for_dialect;
+pub use clause_shape::{ClauseShapeChecker, ClauseShapeError};
 pub use dialects::{
     DETECT_SCAN_BYTES, KNOWN_DIALECTS, available_dialects, detect_dialect,
     detect_dialect_directive, detect_dialect_from_source, dialect_from_extension,

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -25,6 +25,7 @@
 use crate::arg_role::ArgRole;
 use crate::arity::Arity;
 use crate::body_kind::BodyKind;
+use crate::clause_shape::ClauseShapeChecker;
 use crate::dialects::DialectSet;
 use crate::forms::{CommandForm, SubCommandForm};
 use crate::hooks::{
@@ -177,6 +178,14 @@ pub struct CommandSpec {
 
     /// Dynamic argument role resolver (for variable-layout commands).
     pub arg_role_resolver: Option<ArgRoleResolver>,
+
+    /// Clause-chain shape validator, for a command whose valid argument
+    /// shapes aren't a single `min..=max` [`Arity`] range (`if`'s
+    /// `elseif`/`else` chain). See [`crate::clause_shape`]. A command
+    /// carrying this hook should also set
+    /// [`Traits::STRUCTURALLY_CHECKED_ARITY`] so the generic arity
+    /// floor/ceiling check steps aside in its favour.
+    pub clause_shape_check: Option<ClauseShapeChecker>,
 
     /// Static [`ArgRole::CommandPrefix`] positions and their appended arities
     /// (`lsort` positional forms, `socket -server` handled via options).  Each
@@ -490,6 +499,7 @@ impl CommandSpec {
         arity: Arity::any(),
         arg_roles: &[],
         arg_role_resolver: None,
+        clause_shape_check: None,
         command_prefixes: &[],
         command_prefix_resolver: None,
         return_type: None,

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -239,6 +239,16 @@ bitflags! {
         /// collector.
         const WASM_EMITS_NOTHING        = 1 << 52;
 
+        /// The registry's simple `min..=max` [`crate::Arity`] is a coarse
+        /// floor/ceiling only — this command's real grammar is a clause
+        /// chain validated by [`crate::spec::CommandSpec::clause_shape_check`]
+        /// (`if`'s `elseif`/`else` chain). The generic arity floor/ceiling
+        /// diagnostic (E002/E003) skips a command carrying this trait so its
+        /// dedicated structural diagnostic owns arity together with clause
+        /// shape — one precise diagnostic per malformed call instead of a
+        /// redundant generic one alongside it.
+        const STRUCTURALLY_CHECKED_ARITY = 1 << 54;
+
         /// The command concatenates its *entire* argument list into a single
         /// expression (`expr` — `expr $a + $b` evaluates the one expression
         /// `$a + $b`). This differs from commands whose expression is a single


### PR DESCRIPTION
## Summary

- TclOO constructor-call arity checking (`E002`/`E003`) recognized only `new`/`create`, missing `createWithNamespace` — the third instantiation keyword the adjacent class-*definition*-detection code already handled. `PendingCtorArity`'s `is_create: bool` is now a `CtorForm { New, Create, CreateWithNamespace }` enum, each carrying its own leading-word arity bump (0/1/2), mirroring the word layout `oo_class_arg_roles` already used for the sibling class-definition shapes.
- `namespace ensemble create`'s `-command` extraction scanned every word for literal equality with `"-command"`, so another option's *value* word that happened to read `-command` (e.g. a pathological `-map` value) could be misread as the flag itself. Added the real `namespace ensemble create` option surface (`-command`/`-map`/`-parameters`/`-prefixes`/`-subcommands`/`-unknown`, verified against this project's own `cmd_namespace.rs` VM implementation) as registry `OptionSpec` data, and walk it by declared value arity — the same option-skip idiom already used elsewhere in the analyser.
- Corrected a stale row in `compiler-pipeline-parity.md` claiming TclOO `initialise`/`property` bodies and `createWithNamespace` weren't handled — they already are (confirmed by passing `oo.rs` tests).
- Updated the E002/E003 KCS notes for the constructor-arity scope change.

## Validation

- [x] `cargo test -p tcl-registry -p tcl-compiler -p tcl-lsp-server` — 0 failures across ~3700 tests, including new regression tests for both fixes.
- [x] `cargo clippy -p tcl-registry -p tcl-compiler -p tcl-lsp-server --all-targets -- -D warnings` — clean.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — the TclOO constructor-arity check (E002/E003) now also covers `createWithNamespace`.
- [x] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`: `docs/kcs/codes/kcs-diagnostic-e002-too-few-arguments.md` and `-e003-too-many-arguments.md`.
- [x] No new KCS note was added (existing notes updated in place), so the linking checklist item doesn't apply.


---
_Generated by [Claude Code](https://claude.ai/code/session_01YMFUV4Sn3obcx7oo1WAyeC)_