### PR TITLE
Fix T102 false negatives and improve diagnostic spans/fixes

### DIFF
--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -83,6 +83,33 @@ suite("Code Actions", () => {
     assert.ok(quickFix, "Should provide an option terminator quick fix");
   });
 
+  test("provides quick fix for T102 (tainted data in option position) in a plain .tcl file", async () => {
+    // T102 is dialect-general (not iRules-specific), so its `--`-insertion
+    // fix must reach the code-action response for a plain .tcl document
+    // too — not only under the f5-irules dialect.
+    await activate(docUri);
+    const diagnostics = await waitForDiagnostics(docUri, { minCount: 1 });
+
+    const t102 = diagnostics.find((d) => {
+      const code = typeof d.code === "object" ? d.code.value : d.code;
+      return code === "T102";
+    });
+    assert.ok(t102, "T102 diagnostic should be present");
+
+    const actions = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, t102.range),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => typeof a.title === "string" && a.title.includes("--"),
+        ),
+      { timeout: 10_000, label: "T102 insert '--' quick fix" },
+    )) as vscode.CodeAction[];
+
+    const quickFix = actions.find((a) => typeof a.title === "string" && a.title.includes("--"));
+    assert.ok(quickFix, "Should provide an insert '--' quick fix for T102");
+  });
+
   test("provides quick fix for W302 (catch result capture)", async () => {
     await activate(docUri);
     const diagnostics = await waitForDiagnostics(docUri, { minCount: 1 });

--- a/editors/vscode/testFixture/diagnostics.tcl
+++ b/editors/vscode/testFixture/diagnostics.tcl
@@ -15,6 +15,10 @@ if {$x == "foo"} { puts yes }
 # W304 - option-bearing command without -- for dynamic input
 regexp $pattern $x
 
+# T102 - tainted data in option position without -- terminator
+set tainted_pattern [gets stdin]
+regexp $tainted_pattern $x
+
 # E100 - stray close bracket, missing opening '['
 set y string]
 

--- a/rust/tcl-cli/tests/fixtures/registry-dump.tcl8.6-subset.golden
+++ b/rust/tcl-cli/tests/fixtures/registry-dump.tcl8.6-subset.golden
@@ -85,7 +85,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -330,7 +329,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -420,7 +418,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -510,7 +507,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -600,7 +596,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -690,7 +685,6 @@
       "terminates_block": true,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -780,7 +774,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false,
       "xc_translatable": false
     }
@@ -871,7 +864,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -961,7 +953,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -1051,7 +1042,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -1141,7 +1131,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -1596,7 +1585,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -1686,7 +1674,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -1776,7 +1763,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -1871,7 +1857,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -1961,7 +1946,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -2051,7 +2035,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -2141,7 +2124,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -2231,7 +2213,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": true
     }
   },
@@ -2357,7 +2338,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": true,
       "wasm_emits_nothing": false
     }
   },
@@ -2476,7 +2456,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -2566,7 +2545,6 @@
       "terminates_block": true,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -2656,7 +2634,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -2746,7 +2723,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -2861,7 +2837,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -2955,7 +2930,6 @@
       "terminates_block": true,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -3049,7 +3023,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -3148,7 +3121,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -3238,7 +3210,6 @@
       "terminates_block": false,
       "unsafe": true,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false,
       "xc_translatable": false
     }
@@ -3329,7 +3300,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false,
       "xc_translatable": false
     }
@@ -3421,7 +3391,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   },
@@ -3511,7 +3480,6 @@
       "terminates_block": false,
       "unsafe": false,
       "warn_missing_import": true,
-      "warn_without_terminator": false,
       "wasm_emits_nothing": false
     }
   }

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/inj.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/inj.rs
@@ -20,8 +20,10 @@
 //! option-injection taint).
 //! Pairs to `tests/test_fp_inj.py` and the §INJ entries in `docs/design/compiler/FP.md`.
 //!
-//! The T102 cases are iRules-dialect (`HTTP::uri` / `HTTP::path` taint sources),
-//! so they run under the `f5-irules` dialect rather than the default `D`.
+//! Most T102 cases here are iRules-dialect (`HTTP::uri` / `HTTP::path` taint
+//! sources), so they run under the `f5-irules` dialect rather than the
+//! default `D` — except FP-INJ-07, whose `exec` sink is excluded from the
+//! iRules dialect and so runs under `D` with a generic (`gets`) source.
 
 use super::{D, codes, fires};
 
@@ -192,3 +194,103 @@ fn fp_inj_05_eval_string_fires_w101() {
         codes(FP_INJ_05_REPRO, D)
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-INJ-06 — a `PATH_PREFIXED` proof must not survive an unclassified
+// (shape-changing) command it passes through — `TaintLattice::shape_unproven`.
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fp_inj_06_string_range_strips_path_prefixed_proof() {
+    // FN regression: `string range` has no registry classification, so it
+    // could turn a `/`-anchored path into something starting with `-`
+    // (e.g. path `/-nocase/x`, `string range $p 1 end` => `-nocase/x`).
+    // PATH_PREFIXED must not survive it.
+    let src = "set p [HTTP::path]\nset stripped [string range $p 1 end]\nregexp $stripped test";
+    assert!(
+        fires(src, IRULES, "T102"),
+        "FP-INJ-06: `string range` must strip PATH_PREFIXED, T102 must fire; emitted {:?}",
+        codes(src, IRULES)
+    );
+}
+
+#[test]
+fn fp_inj_06_split_lindex_strips_path_prefixed_proof() {
+    // FN regression, realistic iRules idiom: splitting `HTTP::path` and
+    // indexing a segment can hand back attacker-controlled text with no
+    // `/`-anchoring guarantee at all (path `/-nocase/x` splits to
+    // `{{} -nocase x}`; `lindex $parts 1` is `-nocase`).
+    let src =
+        "set parts [split [HTTP::path] \"/\"]\nset second [lindex $parts 1]\nregexp $second test";
+    assert!(
+        fires(src, IRULES, "T102"),
+        "FP-INJ-06: `split`/`lindex` must strip PATH_PREFIXED, T102 must fire; emitted {:?}",
+        codes(src, IRULES)
+    );
+}
+
+#[test]
+fn fp_inj_06_pure_copy_still_suppresses() {
+    // TN control: a *pure variable copy* (no command substitution at all)
+    // is unaffected — `shape_unproven` only strips the proof for values
+    // that passed through an unclassified command, not this simpler path
+    // (already covered by FP-INJ-03, repeated here as a companion control
+    // for the two repros above).
+    let src = "set uri [HTTP::uri]\nset x $uri\nregexp $x test";
+    assert!(
+        !fires(src, IRULES, "T102"),
+        "FP-INJ-06 control: plain copy must still suppress T102; emitted {:?}",
+        codes(src, IRULES)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FP-INJ-07 — `exec -encoding <name>` must not mask the option-injection
+// scan for the arguments that follow it — the registry was missing
+// `-encoding` from `exec`'s option list entirely.
+// ---------------------------------------------------------------------------
+
+const FP_INJ_07_REPRO: &str = "\
+proc run {} {
+    set prog [gets stdin]
+    exec -encoding utf-8 $prog
+}
+";
+
+#[test]
+fn fp_inj_07_exec_encoding_does_not_mask_option_scan() {
+    // FN regression: `-encoding` takes a value (the encoding name); before
+    // the registry declared that, `option_scan_region` treated the literal
+    // encoding name as a definite positional and stopped scanning right
+    // there, hiding every tainted argument after it (including the actual
+    // program name) from T102/W304.
+    assert!(
+        fires(FP_INJ_07_REPRO, D, "T102"),
+        "FP-INJ-07: `exec -encoding utf-8 $prog` must fire T102; emitted {:?}",
+        codes(FP_INJ_07_REPRO, D)
+    );
+}
+
+#[test]
+fn fp_inj_07_exec_bare_control_still_warns() {
+    // TP control: the same taint without the `-encoding` option already
+    // fired correctly — pins the baseline this regression test compares
+    // against.
+    let src = "proc run {} {\n    set prog [gets stdin]\n    exec $prog\n}\n";
+    assert!(
+        fires(src, D, "T102"),
+        "FP-INJ-07 control: bare `exec $prog` must fire T102; emitted {:?}",
+        codes(src, D)
+    );
+}
+
+// Note: `switch` lowers to its own dedicated `Statement::Switch` IR node
+// (see `lowering/structured.rs::lower_switch`), not `Call` / `Barrier` /
+// `AssignValue` — so its subject and pattern-list arguments never reach
+// `emit_statement_warnings`'s sink dispatch at all, and T102 (like every
+// other taint-sink code) cannot fire on them regardless of taint or of
+// `reserved_trailing_words`. `reserved_trailing_words` is still correct,
+// general registry data — it fixes the reachable W304 case above (FP-NAB-05)
+// and will also cover T102 the day `switch`'s arguments become taint-visible
+// — but a same-named T102 test here would credit it for behaviour that's
+// actually caused by this separate, pre-existing statement-shape gap.

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/nab.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/nab.rs
@@ -175,6 +175,34 @@ fn fp_nab_05_braced_switch_form_should_not_fire_w304() {
 }
 
 #[test]
+fn fp_nab_05_dynamic_two_arg_switch_form_should_not_fire_w304() {
+    // FN regression: the exemption used to require the trailing word be a
+    // braced `Str` literal, missing the equally-safe dynamic 2-arg form —
+    // C Tcl's own `TclNRSwitchObjCmd` never scans either trailing word as
+    // an option once only `string` + pattern-list remain (`objc - 2`
+    // bound), regardless of whether the pattern list is a literal or a
+    // variable/command substitution.
+    let src = "proc f {x} { set cases {a {puts A} b {puts B}}; switch $x $cases }";
+    assert!(
+        !fires(src, D, "W304"),
+        "FP-NAB-05: dynamic 2-arg switch form must NOT fire W304; {:?}",
+        diags(src, D)
+    );
+}
+
+#[test]
+fn fp_nab_05_three_trailing_args_still_fires_w304() {
+    // TP control: only the *last two* trailing words are reserved: a third
+    // leading dynamic word is still a genuine option-scanning candidate.
+    let src = "proc f {a} { switch $a subject {puts hit} }";
+    assert!(
+        fires(src, D, "W304"),
+        "FP-NAB-05: a 3rd trailing dynamic word must still fire W304; {:?}",
+        diags(src, D)
+    );
+}
+
+#[test]
 fn fp_nab_05_w304_lexical_does_not_cross_proc_boundary() {
     // FP: W304 'currently resolves to ...' must not attribute an outer set to a
     // shadowing proc parameter.

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -1731,13 +1731,6 @@ impl Analyser {
     /// The diagnostic carries a code-fix that prepends `"-- "` to
     /// the positional-argument span (with a one-byte extension for
     /// `Cmd` tokens whose lexer span excludes the closing `]`).
-    ///
-    /// **Note on `warn_without_terminator`:** the registry's
-    /// `Traits::WARN_WITHOUT_TERMINATOR` flag (set on `regexp` only
-    /// today) is plumbed onto [`tcl_registry::ResolvedTerminator`]
-    /// but is not consumed.  The OFF gate
-    /// fires uniformly for non-dynamic, non-`-`-prefixed values
-    /// regardless of the trait.
     pub(in crate::analyser) fn emit_w304_missing_option_terminator(
         &mut self,
         cmd_name: &str,
@@ -1766,20 +1759,6 @@ impl Analyser {
         else {
             return;
         };
-
-        // The braced pattern-list switch form ``switch $x { pat body … }``
-        // is NOT a runtime hazard: Tcl unambiguously identifies the
-        // trailing brace as the pattern list and never consumes the
-        // preceding word as an option.  Detect the two-arg braced form
-        // (the last arg is a brace-enclosed `Str` token) and exempt it
-        // entirely.  The SPLIT form (`switch $x -nocase {body} …`, 3+
-        // args) is still flagged.
-        if cmd_name == "switch"
-            && arg_tokens.len() == 2
-            && arg_tokens.last().map(|t| t.kind) == Some(tcl_lexer::TokenType::Str)
-        {
-            return;
-        }
 
         let Some(positional_idx) = first_positional_without_terminator(args, &profile) else {
             return;
@@ -2701,12 +2680,18 @@ const IRULES_EXPR_OPS: &[&str] = &[
 /// per-resolve `HashSet` allocation on the analyser hot path.
 /// Returns `None` when a `--` is encountered (positional arguments
 /// after `--` are explicitly terminated).
+///
+/// Never scans into a command's `reserved_trailing_words` (e.g.
+/// `switch`'s trailing `string` + pattern-list, which C Tcl's own
+/// option-scanning loop excludes structurally, regardless of shape — see
+/// [`tcl_registry::spec::CommandSpec::reserved_trailing_words`]).
 fn first_positional_without_terminator(
     args: &[String],
     profile: &tcl_registry::ResolvedTerminator,
 ) -> Option<usize> {
     let mut i = profile.scan_start;
-    while i < args.len() {
+    let n = args.len().saturating_sub(profile.reserved_trailing_words);
+    while i < n {
         let arg = args[i].as_str();
         if arg == "--" {
             return None;

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -3758,8 +3758,7 @@ mod tests {
     #[test]
     fn analyse_no_w304_for_regexp_safe_literal_pattern() {
         // Pattern starts with `(` — non-dynamic, doesn't start with
-        // `-`, so the OFF gate suppresses regardless of the
-        // command's WARN_WITHOUT_TERMINATOR trait.
+        // `-`, so the OFF gate suppresses regardless of command.
         let diags = w304_diags("regexp {(a+)+$} $text\n");
         assert!(diags.is_empty(), "got {diags:?}");
     }

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -146,7 +146,7 @@ impl Diagnostic {
             },
             message: w.message.clone(),
             replacement: w.replacement.clone(),
-            fixes: Vec::new(),
+            fixes: w.fixes.clone(),
         }
     }
 

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -97,11 +97,14 @@ use crate::cfg::{BlockId, Function as CfgFunction, Terminator};
 use crate::expr_ast::ExprNode;
 use crate::interprocedural::InterproceduralAnalysis;
 use crate::ir::{CommandTokens, Statement};
+use crate::irules_checks::CodeFix;
 use crate::naming::normalise_var_name;
 use crate::rendered_properties::{RenderedProperties, RenderedValueProps};
 use crate::sccp::{SccpResult, cfg_order};
 use crate::ssa::{SsaFunction, SsaStatement, Symbol, ValueKey};
-use crate::value_shapes::{is_pure_var_ref, parse_command_substitution};
+use crate::value_shapes::{
+    is_pure_var_ref, parse_command_substitution, parse_command_substitution_with_spans,
+};
 
 // Colour lattice
 
@@ -279,6 +282,24 @@ impl TaintLattice {
             colours: self.colours & !TaintColour::TAINTED,
         }
     }
+
+    /// Strip the shape-dependent mitigation colours (`T102_SAFE`:
+    /// `PATH_PREFIXED` / `NON_DASH_PREFIXED` / `IP_ADDRESS` / `PORT` /
+    /// `FQDN`) — used when a value passes through a command with no
+    /// registry classification (not a recognised source, sanitiser,
+    /// transform, or passthrough), so its effect on the value's string
+    /// shape is unknown. A "cannot start with `-`"-style proof cannot be
+    /// assumed to survive an arbitrary unclassified transformation (e.g.
+    /// `string range`, `lindex [split ...]`) even though the underlying
+    /// taint itself must. Commands specifically known to preserve shape
+    /// should get a registry classification instead of relying on this
+    /// (conservative, over-approximating) default.
+    #[must_use]
+    pub fn shape_unproven(self) -> Self {
+        Self {
+            colours: self.colours & !TaintColour::T102_SAFE,
+        }
+    }
 }
 
 // Diagnostic type
@@ -297,9 +318,13 @@ pub struct TaintWarning {
     /// Formatted message.
     pub message: String,
     /// Optional replacement text for a code-action fix. Currently
-    /// always `None` for taint diagnostics — wired through ahead of
-    /// the rich-fix work so the `PyO3` surface stays stable.
+    /// always `None` for taint diagnostics; see `fixes` for the
+    /// insertion-style code actions taint diagnostics actually use.
     pub replacement: Option<String>,
+    /// Suggested fixes whose range is independent of `span` (insertions /
+    /// out-of-span replacements) — see `irules_checks::CodeFix`. Empty
+    /// when the diagnostic has no such fix.
+    pub fixes: Vec<CodeFix>,
 }
 
 // Source-command classification
@@ -462,11 +487,17 @@ pub(crate) fn word_taint<S: std::hash::BuildHasher>(
         if let Some(t) = interproc_call_taint(&cmd, &args, uses, taints, ctx) {
             return t;
         }
-        // Propagate from the arguments inside the command sub.
+        // Propagate from the arguments inside the command sub. `cmd` has
+        // no registry classification (source / sanitiser / passthrough all
+        // missed above), so its effect on argument shape is unknown —
+        // strip shape-dependent mitigations (`shape_unproven`) rather than
+        // optimistically assuming e.g. `PATH_PREFIXED` survives an
+        // arbitrary `string range` / `lindex [split ...]` transform.
         let mut t = TaintLattice::clean();
         for arg in &args {
             t = t.join(word_taint(arg, uses, taints, ctx));
         }
+        t = t.shape_unproven();
         // Stamp the encoder/transform colour the command adds to a
         // tainted result (e.g. `uri::encode` → `URL_ENCODED`), so a
         // later pass through the same encoder is detectable as a
@@ -1474,6 +1505,7 @@ pub fn find_destructive_file_warnings<S: std::hash::BuildHasher, E: std::hash::B
                     code: DiagCode::W313,
                     message,
                     replacement: None,
+                    fixes: Vec::new(),
                 });
                 break;
             }
@@ -1767,6 +1799,7 @@ fn emit_double_encode_warnings<S: std::hash::BuildHasher>(
                      double-encodes the value"
                 ),
                 replacement: None,
+                fixes: Vec::new(),
             });
             emitted.insert(sym);
         }
@@ -2027,11 +2060,13 @@ fn emit_statement_warnings<S: std::hash::BuildHasher>(
         emit_sink_warnings(&env, span, code, &sink_label, &sink_call, warnings);
     }
 
-    // T102: option injection — only for Call statements, after the primary
-    // sink (T100/output/log).
-    if let Statement::Call { args, .. } = stmt {
-        emit_option_injection(command, args, &env, span, registry, dialect, warnings);
-    }
+    // T102: option injection — any statement shape that resolves to a
+    // command invocation (bare `Call`, a `Barrier`, or a `set x [cmd ...]`
+    // `AssignValue`), after the primary sink (T100/output/log). Uses the
+    // same `sink_call` (command, call_args, registry) as the check above
+    // so a `set matched [regexp $pattern $s]` capture is scanned exactly
+    // like the bare `regexp $pattern $s` call it wraps.
+    emit_option_injection(&sink_call, &env, span, dialect, warnings, stmt);
 
     // Additional registry-driven SSRF / cross-interp sinks (T104 / T105),
     // which can co-occur with the primary classification.
@@ -2129,6 +2164,7 @@ fn emit_regexp_pattern_warnings<S: std::hash::BuildHasher>(
                  risk of regex injection or ReDoS"
             ),
             replacement: None,
+            fixes: Vec::new(),
         });
     }
 }
@@ -2301,6 +2337,7 @@ fn emit_expr_coercion_warnings<S: std::hash::BuildHasher>(
                 hit.name
             ),
             replacement: None,
+            fixes: Vec::new(),
         });
     }
 }
@@ -2801,12 +2838,14 @@ fn emit_sink_warnings<S: std::hash::BuildHasher>(
             code,
             message,
             replacement: None,
+            fixes: Vec::new(),
         });
         emitted.insert(sym);
     }
 }
 
-/// Emit T102 warnings for option injection into a `WARN_WITHOUT_TERMINATOR` command.
+/// Emit T102 warnings for option injection into a command declaring a `--`
+/// option terminator.
 ///
 /// A T102 violation occurs when a tainted pure-variable-reference argument
 /// is passed to a command at a position that can be misinterpreted as a
@@ -2832,14 +2871,19 @@ fn arg_can_be_option(arg: &str) -> bool {
 /// Tcl scans for `-switch` args from `scan_start` until the first definite
 /// positional literal (one that cannot begin with `-`) or `--`. A literal
 /// `-option` that takes a value also consumes the following arg.
+/// `reserved_trailing_words` excludes a command's structurally-fixed
+/// trailing words (e.g. `switch`'s `string` + pattern-list) from the scan
+/// entirely, regardless of their shape — see
+/// [`tcl_registry::spec::CommandSpec::reserved_trailing_words`].
 fn option_scan_region(
     args: &[String],
     scan_start: usize,
     options: &[tcl_registry::hover::OptionSpec],
+    reserved_trailing_words: usize,
 ) -> HashSet<usize> {
     let mut region: HashSet<usize> = HashSet::new();
     let mut i = scan_start;
-    let n = args.len();
+    let n = args.len().saturating_sub(reserved_trailing_words);
     while i < n {
         let arg = &args[i];
         if arg == "--" {
@@ -2865,22 +2909,77 @@ fn option_scan_region(
     region
 }
 
+/// Resolve a tight per-argument span for a T102 diagnostic, so the
+/// highlighted range (and its `--`-insertion fix) covers only the
+/// offending argument rather than the whole statement.
+///
+/// - `Call` / `Barrier`: the argument's own token span, read directly off
+///   `tokens.argv` (offset by 1 to skip the command-name word — `argv[0]`
+///   is the command, `argv[i + 1]` is `args[i]`).
+/// - `AssignValue` (`set x [cmd ...]`): the embedded command has no
+///   token of its own on *this* statement — `tokens.argv[2]` is the
+///   whole bracketed value word (`argv[0]` = `set`, `argv[1]` = the
+///   variable name, `argv[2]` = the `[...]` value), so the argument's
+///   position is re-located inside that word's own text via
+///   `parse_command_substitution_with_spans` and offset by the value
+///   word's span start.
+///
+/// Returns `None` when the token data needed isn't available (e.g.
+/// synthetic/test-built IR with `tokens: None`) — callers fall back to
+/// the whole-statement span in that case. A tight span is a
+/// highlighting nicety, never a correctness requirement, so this never
+/// panics or guesses.
+fn t102_arg_span(stmt: &Statement, arg_index: usize) -> Option<Span> {
+    match stmt {
+        Statement::Call {
+            tokens: Some(t), ..
+        }
+        | Statement::Barrier {
+            tokens: Some(t), ..
+        } => t.argv.get(arg_index + 1).copied(),
+        Statement::AssignValue {
+            value,
+            tokens: Some(t),
+            ..
+        } => {
+            let value_span = t.argv.get(2)?;
+            let (_cmd, args) = parse_command_substitution_with_spans(value)?;
+            let (_text, arg_span) = args.get(arg_index)?;
+            Some(Span::new(
+                value_span.start() + arg_span.start(),
+                value_span.start() + arg_span.end(),
+            ))
+        }
+        _ => None,
+    }
+}
+
 /// Emit `T102` (option injection) for tainted variables that sit in an
 /// option-scanning position of a command declaring a `--` terminator.
 ///
 /// The option-terminator profile
 /// (`resolve_option_terminator`) supplies the subcommand-aware command
 /// label and the scan start, `option_scan_region` filters positions, and
-/// the `T102_SAFE` colour set mitigates.
+/// the `T102_SAFE` colour set mitigates. Each warning is anchored at the
+/// offending argument's own span (falling back to the whole statement's
+/// span when the tight span can't be resolved) and carries a `--`
+/// insertion fix alongside it. Takes `sink_call` (rather than separate
+/// `command`/`args`/`registry` parameters) since that's already built at
+/// the one call site for the primary sink classification — reusing it
+/// keeps this under clippy's argument-count lint without an `#[allow]`.
 fn emit_option_injection<S: std::hash::BuildHasher>(
-    command: &str,
-    args: &[String],
+    sink_call: &SinkCall<'_>,
     env: &TaintScan<'_, S>,
     span: Span,
-    registry: &CommandRegistry,
     dialect: Option<&str>,
     warnings: &mut Vec<TaintWarning>,
+    stmt: &Statement,
 ) {
+    let &SinkCall {
+        command,
+        args,
+        registry,
+    } = sink_call;
     let (uses, taints, ssa) = (env.uses, env.taints, env.ssa);
     let args_str: Vec<&str> = args.iter().map(String::as_str).collect();
     let Some(profile) =
@@ -2897,7 +2996,12 @@ fn emit_option_injection<S: std::hash::BuildHasher>(
         None => command.to_owned(),
     };
 
-    let region = option_scan_region(args, profile.scan_start, profile.options);
+    let region = option_scan_region(
+        args,
+        profile.scan_start,
+        profile.options,
+        profile.reserved_trailing_words,
+    );
     if region.is_empty() {
         return;
     }
@@ -2936,8 +3040,25 @@ fn emit_option_injection<S: std::hash::BuildHasher>(
             if t.colours.intersects(TaintColour::T102_SAFE) {
                 continue;
             }
+            // Anchor the diagnostic (and its fix) at the offending
+            // argument itself when the source tokens are available;
+            // fall back to the whole statement's span otherwise (no
+            // fix in that case — a fabricated span could misplace the
+            // insertion, e.g. before the command name rather than the
+            // argument).
+            let (warn_span, fixes) = match t102_arg_span(stmt, i) {
+                Some(tight) => (
+                    tight,
+                    vec![CodeFix {
+                        span: Span::new(tight.start(), tight.start()),
+                        new_text: "-- ".to_owned(),
+                        description: "Insert '--' option terminator".to_owned(),
+                    }],
+                ),
+                None => (span, Vec::new()),
+            };
             warnings.push(TaintWarning {
-                span,
+                span: warn_span,
                 variable: var.clone(),
                 sink_command: cmd_label.clone(),
                 code: DiagCode::T102,
@@ -2946,6 +3067,7 @@ fn emit_option_injection<S: std::hash::BuildHasher>(
                      without '--' terminator; risk of option injection"
                 ),
                 replacement: None,
+                fixes,
             });
             emitted.insert(sym);
         }
@@ -3014,6 +3136,7 @@ pub fn find_setter_constraint_warnings<S: std::hash::BuildHasher, E: std::hash::
                     code: constraint.code,
                     message: constraint.message.to_owned(),
                     replacement: None,
+                    fixes: Vec::new(),
                 };
 
                 // Literal: neither `$` nor `[`.
@@ -4364,6 +4487,137 @@ mod tests {
         assert!(
             warnings.iter().all(|w| w.code != DiagCode::T102),
             "no T102 when `--` precedes the tainted path, got {warnings:?}",
+        );
+    }
+
+    /// FN regression (see `emit_statement_warnings`): T102 must fire for
+    /// a `set matched [regexp $pattern $s]` capture exactly as it does for
+    /// the bare `regexp $pattern $s` call it wraps — the earlier code only
+    /// ran the option-injection check on `Statement::Call`, silently
+    /// skipping the (dominant, in real Tcl) `set x [cmd ...]` idiom.
+    #[test]
+    fn t102_fires_for_assign_value_wrapped_call() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let cu = CompilationUnit::build_for(
+            "set pattern [gets stdin]\nset result [regexp $pattern $haystack]",
+            &registry,
+            false,
+        );
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_taint_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.taints,
+            &fu.sccp.executable_blocks,
+            &registry,
+            Some("tcl8.6"),
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.code == DiagCode::T102 && w.variable == "pattern"),
+            "expected T102 for tainted $pattern inside `set result [regexp ...]`, got {warnings:?}"
+        );
+    }
+
+    /// T102's diagnostic span must cover only the offending argument
+    /// (`$pattern`), not the whole statement — tight enough that the
+    /// editor squiggle sits on the actual problem, matching what W304
+    /// already does for the same position.
+    #[test]
+    fn t102_span_is_tight_around_the_tainted_argument_bare_call() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let src = "set pattern [gets stdin]\nregexp $pattern $haystack";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_taint_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.taints,
+            &fu.sccp.executable_blocks,
+            &registry,
+            Some("tcl8.6"),
+        );
+        let t102 = warnings
+            .iter()
+            .find(|w| w.code == DiagCode::T102)
+            .expect("expected a T102 warning");
+        let slice = &src[t102.span.start() as usize..t102.span.end() as usize];
+        assert_eq!(
+            slice, "$pattern",
+            "T102 span should cover exactly the tainted argument, got {slice:?} from {t102:?}"
+        );
+    }
+
+    /// Same tight-span requirement for the `set x [cmd ...]` shape: the
+    /// embedded command's argument has no token of its own on the
+    /// `AssignValue` statement, so the span is re-derived from the
+    /// bracketed value text — this pins that derivation to the exact
+    /// same byte range as the bare-call case above.
+    #[test]
+    fn t102_span_is_tight_around_the_tainted_argument_assign_value() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let src = "set pattern [gets stdin]\nset result [regexp $pattern $haystack]";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_taint_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.taints,
+            &fu.sccp.executable_blocks,
+            &registry,
+            Some("tcl8.6"),
+        );
+        let t102 = warnings
+            .iter()
+            .find(|w| w.code == DiagCode::T102)
+            .expect("expected a T102 warning");
+        let slice = &src[t102.span.start() as usize..t102.span.end() as usize];
+        assert_eq!(
+            slice, "$pattern",
+            "T102 span should cover exactly the tainted argument, got {slice:?} from {t102:?}"
+        );
+    }
+
+    /// T102 must carry a `--`-insertion fix anchored immediately before
+    /// the tainted argument, so applying it turns the flagged call into
+    /// the documented safe form (`regexp -- $pattern ...`).
+    #[test]
+    fn t102_carries_insert_terminator_fix_at_the_argument_start() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let src = "set pattern [gets stdin]\nregexp $pattern $haystack";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_taint_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.taints,
+            &fu.sccp.executable_blocks,
+            &registry,
+            Some("tcl8.6"),
+        );
+        let t102 = warnings
+            .iter()
+            .find(|w| w.code == DiagCode::T102)
+            .expect("expected a T102 warning");
+        assert_eq!(t102.fixes.len(), 1, "expected exactly one fix: {t102:?}");
+        let fix = &t102.fixes[0];
+        assert_eq!(
+            fix.span.start(),
+            fix.span.end(),
+            "fix must be a pure insertion"
+        );
+        assert_eq!(fix.span.start(), t102.span.start());
+        assert_eq!(fix.new_text, "-- ");
+        let mut fixed = src.to_owned();
+        fixed.insert_str(fix.span.start() as usize, &fix.new_text);
+        assert_eq!(
+            fixed,
+            "set pattern [gets stdin]\nregexp -- $pattern $haystack"
         );
     }
 

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -2975,10 +2975,17 @@ fn emit_option_injection<S: std::hash::BuildHasher>(
     warnings: &mut Vec<TaintWarning>,
     stmt: &Statement,
 ) {
+    // `tokens` is unused here: T102's own `t102_arg_span(stmt, arg_index)`
+    // re-derives the tight per-argument span directly from `stmt` (it
+    // already knows the exact `arg_index` from `option_scan_region`'s
+    // iteration, so an index-based lookup is more precise than
+    // `sink_arg_span`'s name-based scan, which could mismatch when the
+    // same variable name occurs in more than one scanned position).
     let &SinkCall {
         command,
         args,
         registry,
+        tokens: _,
     } = sink_call;
     let (uses, taints, ssa) = (env.uses, env.taints, env.ssa);
     let args_str: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -4618,6 +4625,82 @@ mod tests {
         assert_eq!(
             fixed,
             "set pattern [gets stdin]\nregexp -- $pattern $haystack"
+        );
+    }
+
+    /// `interp alias {} myregexp {} regexp` makes `myregexp` behave
+    /// exactly like `regexp` at runtime (tclsh 9.0.4-verified), including
+    /// its option parsing — so a tainted argument reaching `myregexp`
+    /// must trip T102 just as it would through the bare `regexp` name.
+    /// `emit_statement_warnings`'s `canonical_command_or_source()` dispatch
+    /// (shared by the whole sink family, see the `t100_fires_through_*`
+    /// tests) resolves the alias for registry classification, while the
+    /// message and span still anchor on the alias call the source
+    /// actually wrote.
+    #[test]
+    fn t102_fires_through_an_interp_alias() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let src = "interp alias {} myregexp {} regexp\nset pattern [gets stdin]\nmyregexp $pattern $haystack";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_taint_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.taints,
+            &fu.sccp.executable_blocks,
+            &registry,
+            Some("tcl8.6"),
+        );
+        let t102 = warnings
+            .iter()
+            .find(|w| w.code == DiagCode::T102)
+            .unwrap_or_else(|| {
+                panic!("expected a T102 warning through the alias, got {warnings:?}")
+            });
+        assert_eq!(t102.variable, "pattern");
+        assert!(
+            t102.message.contains("'regexp'"),
+            "message should name the resolved target command, got {:?}",
+            t102.message
+        );
+        // The span/fix still anchor on the alias call's own argument,
+        // not some fabricated position for the aliased-to command.
+        assert_eq!(t102.fixes.len(), 1);
+        let fix = &t102.fixes[0];
+        let mut fixed = src.to_owned();
+        fixed.insert_str(fix.span.start() as usize, &fix.new_text);
+        assert_eq!(
+            fixed,
+            "interp alias {} myregexp {} regexp\nset pattern [gets stdin]\nmyregexp -- $pattern $haystack"
+        );
+    }
+
+    /// `rename regexp myregexp` resolves through the same `CommandAliasMap`
+    /// mechanism as `interp alias` (`detect_rename`, see the T100 sibling
+    /// tests `t100_fires_through_rename_indirection` /
+    /// `t100_silent_for_unaliased_lookalike_command`), so T102 must also
+    /// fire through a renamed command name, not just an `interp alias`.
+    #[test]
+    fn t102_fires_through_a_rename() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let src = "rename regexp myregexp\nset pattern [gets stdin]\nmyregexp $pattern $haystack";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_taint_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.taints,
+            &fu.sccp.executable_blocks,
+            &registry,
+            Some("tcl8.6"),
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.code == DiagCode::T102 && w.variable == "pattern"),
+            "expected T102 for tainted $pattern through the `myregexp` rename, got {warnings:?}"
         );
     }
 

--- a/rust/tcl-compiler/src/uri_split.rs
+++ b/rust/tcl-compiler/src/uri_split.rs
@@ -896,6 +896,7 @@ fn check_statement<S: std::hash::BuildHasher>(
             code: DiagCode::Irule3103,
             message: split_message(ctx.families, &uri_cmd, &sep),
             replacement: None,
+            fixes: Vec::new(),
         });
         return;
     }
@@ -914,6 +915,7 @@ fn check_statement<S: std::hash::BuildHasher>(
                     code: DiagCode::Irule3103,
                     message: comparison_message(ctx.families, &uri_cmd, "string match", component),
                     replacement: None,
+                    fixes: Vec::new(),
                 });
             }
         } else if sub_cmd == "string first" && pattern.chars().any(|c| QUERY_CHARS.contains(&c)) {
@@ -924,6 +926,7 @@ fn check_statement<S: std::hash::BuildHasher>(
                 code: DiagCode::Irule3103,
                 message: string_first_message(ctx.families, &uri_cmd, &pattern),
                 replacement: None,
+                fixes: Vec::new(),
             });
         }
     }
@@ -940,6 +943,7 @@ fn check_statement<S: std::hash::BuildHasher>(
                 code: DiagCode::Irule3103,
                 message: expr_hit_message(ctx.families, &uri_cmd, &op_name, &component),
                 replacement: None,
+                fixes: Vec::new(),
             });
         }
     }
@@ -971,6 +975,7 @@ fn check_branch_terminator(
             code: DiagCode::Irule3103,
             message: expr_hit_message(ctx.families, &uri_cmd, &op_name, &component),
             replacement: None,
+            fixes: Vec::new(),
         });
     }
 }

--- a/rust/tcl-compiler/src/value_shapes.rs
+++ b/rust/tcl-compiler/src/value_shapes.rs
@@ -141,7 +141,7 @@ pub fn parse_command_substitution_with_spans(text: &str) -> Option<(String, Vec<
     let mut prev_kind = TokenType::Eol;
     let mut saw_terminator = false;
 
-    for tok in &tokens {
+    for (idx, tok) in tokens.iter().enumerate() {
         match tok.kind {
             TokenType::Comment | TokenType::Sep => {
                 prev_kind = tok.kind;
@@ -161,6 +161,40 @@ pub fn parse_command_substitution_with_spans(text: &str) -> Option<(String, Vec<
             return None;
         }
         let (word_text, tok_end) = widened_token_text(inner, tok)?;
+        // Two closing delimiters the raw token stream can leave
+        // unclaimed by any token's span, needing manual recovery here:
+        //
+        // - The `in_quote` closing `"` — unlike `Str`/`Cmd`, there is no
+        //   dedicated token kind for a double-quoted word to attach
+        //   `group_closer()` to, so a trailing `"` immediately after the
+        //   last fragment of a quoted word (e.g. `"/api/*"`, or `"a[foo]"`
+        //   right after the nested command substitution's own widened
+        //   `]`) is silently dropped.
+        // - A non-degenerate braced-var's closing `}` (`${p}`) — `Var`
+        //   also covers the unbraced `$name` form, which has no closer at
+        //   all, so `group_closer()` can't unconditionally claim `}` for
+        //   the whole kind the way it does for `Str`/`Cmd`.
+        //
+        // Only claim the byte when the *next* token doesn't already start
+        // there (e.g. `"a$b"` emits the closing `"` as its own adjacent
+        // token — nothing orphaned to recover in that shape, and claiming
+        // it here too would double it).
+        let next_start = tokens.get(idx + 1).map(|t| t.span.start());
+        let orphaned_closer = match inner.as_bytes().get(tok_end as usize) {
+            Some(b'"') => true,
+            Some(b'}') if tok.kind == TokenType::Var => true,
+            _ => false,
+        } && next_start != Some(tok_end);
+        let (word_text, tok_end) = if orphaned_closer {
+            let start = usize::try_from(tok.span.start()).ok()?;
+            let widened_end = tok_end as usize + 1;
+            (
+                inner.get(start..widened_end)?.to_owned(),
+                u32::try_from(widened_end).unwrap_or(u32::MAX),
+            )
+        } else {
+            (word_text, tok_end)
+        };
         let abs_span = Span::new(base + tok.span.start(), base + tok_end);
         if matches!(prev_kind, TokenType::Sep | TokenType::Eol) || words.is_empty() {
             words.push((word_text, abs_span));
@@ -392,5 +426,80 @@ mod tests {
         let (x_text, x_span) = &args[1];
         assert_eq!(x_text, "x");
         assert_eq!(&text[x_span.start() as usize..x_span.end() as usize], "x");
+    }
+
+    /// A non-degenerate braced variable reference (`${p}`, real name
+    /// inside the braces) keeps its closing `}` — the raw `Var` token's
+    /// span excludes it (same inner-end convention as `Str`/`Cmd`), and
+    /// `Var` has no `group_closer()` entry since the *unbraced* `$name`
+    /// form has no closer at all to unconditionally claim.
+    #[test]
+    fn spans_braced_var_keeps_closing_brace() {
+        let text = "[file normalize ${p}]";
+        let (cmd, args) = parse_command_substitution_with_spans(text).unwrap();
+        assert_eq!(cmd, "file");
+        assert_eq!(args[1].0, "${p}");
+        assert_eq!(
+            &text[args[1].1.start() as usize..args[1].1.end() as usize],
+            "${p}"
+        );
+    }
+
+    /// Control: an unbraced `$name` reference must not gain a spurious
+    /// trailing `}` from the fix above.
+    #[test]
+    fn spans_unbraced_var_unaffected() {
+        let text = "[file normalize $p]";
+        let (cmd, args) = parse_command_substitution_with_spans(text).unwrap();
+        assert_eq!(cmd, "file");
+        assert_eq!(args[1].0, "$p");
+    }
+
+    /// A double-quoted word with no embedded substitution keeps its
+    /// closing `"` in the returned text — the lexer's raw token span for
+    /// the final content fragment excludes it (there is no dedicated
+    /// token kind for a quoted word to attach `group_closer()` to, unlike
+    /// `Str`/`Cmd`), so it must be recovered from the one-byte gap that
+    /// widening otherwise leaves unclaimed.
+    #[test]
+    fn spans_quoted_word_keeps_closing_quote() {
+        let text = r#"[string match "/api/*" $uri]"#;
+        let (cmd, args) = parse_command_substitution_with_spans(text).unwrap();
+        assert_eq!(cmd, "string");
+        assert_eq!(args[1].0, "\"/api/*\"");
+        assert_eq!(
+            &text[args[1].1.start() as usize..args[1].1.end() as usize],
+            "\"/api/*\""
+        );
+    }
+
+    /// Same recovery applies when the quoted word's last fragment follows
+    /// an embedded command substitution rather than being the whole word.
+    #[test]
+    fn spans_quoted_word_with_nested_command_sub_keeps_closing_quote() {
+        let text = r#"[string match "a[foo]b" $c]"#;
+        let (cmd, args) = parse_command_substitution_with_spans(text).unwrap();
+        assert_eq!(cmd, "string");
+        assert_eq!(args[1].0, "\"a[foo]b\"");
+        assert_eq!(
+            &text[args[1].1.start() as usize..args[1].1.end() as usize],
+            "\"a[foo]b\""
+        );
+    }
+
+    /// Control: when the closing quote directly follows an embedded
+    /// `$var` substitution, the lexer already emits it as its own
+    /// adjacent token (no gap) — confirms the fix above doesn't
+    /// double-append in that shape.
+    #[test]
+    fn spans_quoted_word_after_var_substitution_keeps_closing_quote() {
+        let text = r#"[string match "a$b" $c]"#;
+        let (cmd, args) = parse_command_substitution_with_spans(text).unwrap();
+        assert_eq!(cmd, "string");
+        assert_eq!(args[1].0, "\"a$b\"");
+        assert_eq!(
+            &text[args[1].1.start() as usize..args[1].1.end() as usize],
+            "\"a$b\""
+        );
     }
 }

--- a/rust/tcl-compiler/src/value_shapes.rs
+++ b/rust/tcl-compiler/src/value_shapes.rs
@@ -111,12 +111,8 @@ pub fn is_braced_whole_name_array_ref(text: &str) -> bool {
 /// argument). Callers that need full Tcl list quoting handle it upstream.
 #[must_use]
 pub fn parse_command_substitution(text: &str) -> Option<(String, Vec<String>)> {
-    let stripped = text.trim();
-    let inner = stripped.strip_prefix('[')?.strip_suffix(']')?.trim();
-    let mut parts = split_top_level_words(inner).into_iter();
-    let cmd = parts.next()?;
-    let args: Vec<String> = parts.collect();
-    Some((cmd, args))
+    let (command, args) = parse_command_substitution_with_spans(text)?;
+    Some((command, args.into_iter().map(|(text, _)| text).collect()))
 }
 
 /// Like [`parse_command_substitution`], but additionally returns each
@@ -125,11 +121,11 @@ pub fn parse_command_substitution(text: &str) -> Option<(String, Vec<String>)> {
 /// to anchor on the specific offending argument rather than the whole
 /// substitution.
 ///
-/// Uses the real [`Lexer`] rather than [`split_top_level_words`]'s
-/// hand-rolled bracket/brace counter, so word boundaries follow Tcl's
-/// actual quoting rules (this also makes it correct on inputs the counter
-/// gets wrong, e.g. a `#` comment or an escaped delimiter at the top
-/// level). Returns `None` for the same shapes as
+/// Uses the real [`Lexer`] rather than a hand-rolled bracket/brace
+/// counter, so word boundaries follow Tcl's actual quoting rules (this
+/// also makes it correct on inputs a naive counter gets wrong, e.g. a
+/// `#` comment or an escaped delimiter at the top level). Returns `None`
+/// for the same shapes as
 /// [`parse_command_substitution`], plus when the bracket body doesn't lex
 /// as a single command (an embedded `;`/newline followed by more words).
 #[must_use]
@@ -211,57 +207,6 @@ fn widened_token_text(inner: &str, tok: &tcl_lexer::Token) -> Option<(String, u3
         widened.to_owned(),
         u32::try_from(widened_end).unwrap_or(u32::MAX),
     ))
-}
-
-/// Split a command body into words on top-level whitespace, keeping
-/// `[...]` / `{...}` / `"..."` groups and backslash escapes intact.
-fn split_top_level_words(s: &str) -> Vec<String> {
-    let mut words = Vec::new();
-    let mut cur = String::new();
-    let mut brackets = 0i32;
-    let mut braces = 0i32;
-    let mut in_quote = false;
-    let mut chars = s.chars();
-    while let Some(c) = chars.next() {
-        match c {
-            '\\' => {
-                cur.push(c);
-                if let Some(n) = chars.next() {
-                    cur.push(n);
-                }
-            }
-            '"' if brackets <= 0 && braces <= 0 => {
-                in_quote = !in_quote;
-                cur.push(c);
-            }
-            '[' if !in_quote => {
-                brackets += 1;
-                cur.push(c);
-            }
-            ']' if !in_quote => {
-                brackets -= 1;
-                cur.push(c);
-            }
-            '{' if !in_quote => {
-                braces += 1;
-                cur.push(c);
-            }
-            '}' if !in_quote => {
-                braces -= 1;
-                cur.push(c);
-            }
-            c if c.is_ascii_whitespace() && brackets <= 0 && braces <= 0 && !in_quote => {
-                if !cur.is_empty() {
-                    words.push(std::mem::take(&mut cur));
-                }
-            }
-            _ => cur.push(c),
-        }
-    }
-    if !cur.is_empty() {
-        words.push(cur);
-    }
-    words
 }
 
 #[cfg(test)]

--- a/rust/tcl-compiler/src/var_observability.rs
+++ b/rust/tcl-compiler/src/var_observability.rs
@@ -259,7 +259,7 @@ impl VarObservability<'_> {
             collect_traced(&state, &mut names);
             if let Some(blk) = self.cfg.blocks.get(block) {
                 for stmt in &blk.statements {
-                    stmt_gen(stmt, &mut state);
+                    stmt_gen(stmt, &mut state, self.registry);
                     collect_traced(&state, &mut names);
                 }
             }
@@ -477,7 +477,8 @@ mod tests {
     fn traced_var_names_excludes_untraced_aliases() {
         let c = cu("proc ::p {} { global g\nset g 1\ntrace add variable t write cb\nset t 1 }");
         let fu = c.function("::p").unwrap();
-        let obs = analyse_var_observability(&fu.cfg);
+        let reg = registry();
+        let obs = analyse_var_observability(&fu.cfg, &reg);
         assert!(obs.escaping_var_names().contains("g"));
         assert!(obs.escaping_var_names().contains("t"));
         assert!(

--- a/rust/tcl-lsp-server/tests/e2e/code_actions.rs
+++ b/rust/tcl-lsp-server/tests/e2e/code_actions.rs
@@ -24,8 +24,11 @@
 //! editor does — so quick-fix offers are exercised against real (or, where a
 //! specific range matters, fabricated) diagnostics.
 //!
-//! The F5 iRules code actions (collect-bootstrap, taint quick-fixes, profile
-//! headers) run against the dedicated iRules server in `irules_e2e.rs`.
+//! The F5 iRules-only code actions (collect-bootstrap, the IRULE3001/3002
+//! wrap-with-encode taint fixes, profile headers) run against the dedicated
+//! iRules server in `irules.rs`. T102 (tainted data in option position) is
+//! dialect-general — not an iRules-specific check — so its `--`-insertion
+//! fix is exercised here against the plain `tcl` dialect.
 
 use crate::common::{Lsp, unique_uri};
 
@@ -342,6 +345,57 @@ fn test_w004_offers_remove_option_fix() {
         new_texts(&actions).iter().any(String::is_empty),
         "the remove-option fix deletes text (empty newText): {:?}",
         new_texts(&actions)
+    );
+}
+
+/// T102 (option injection) is dialect-general, not iRules-specific, so its
+/// `--`-insertion fix must reach the code-action response for a plain `tcl`
+/// document too — not only under `f5-irules` (see `irules::t102_insert_double_dash`).
+#[test]
+fn test_t102_insert_double_dash_default_dialect() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "set pattern [gets stdin]\nregexp $pattern $haystack\n",
+    );
+    let t102 = with_code(&diags, "T102");
+    assert!(
+        !t102.is_empty(),
+        "expected a T102 diagnostic to drive the quick fix, got {diags:?}"
+    );
+    let t102_range = t102[0]["range"].clone();
+    let actions = code_actions_only(&mut lsp, &uri, t102_range, json!(t102), &["quickfix"]);
+    let fixes: Vec<Value> = actions
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter(|a| action_title(a).contains("--"))
+        .cloned()
+        .collect();
+    assert!(
+        !fixes.is_empty(),
+        "expected at least one '--' quick fix, got {actions:?}"
+    );
+    assert!(new_texts(&json!(fixes)).iter().any(|s| s == "-- "));
+}
+
+/// The `set matched [regexp $pattern $s]` capture idiom must fire T102
+/// exactly like the bare `regexp $pattern $s` call it wraps — a false
+/// negative in the taint pass's statement-shape handling, not a code-action
+/// concern, but only observable end-to-end through published diagnostics.
+#[test]
+fn test_t102_fires_for_assign_value_wrapped_call() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "set pattern [gets stdin]\nset result [regexp $pattern $haystack]\n",
+    );
+    let t102 = with_code(&diags, "T102");
+    assert!(
+        !t102.is_empty(),
+        "expected T102 for tainted $pattern inside `set result [regexp ...]`, got {diags:?}"
     );
 }
 

--- a/rust/tcl-registry/examples/dump_specs.rs
+++ b/rust/tcl-registry/examples/dump_specs.rs
@@ -119,7 +119,6 @@ const BOOL_TRAITS: &[(&str, Traits)] = &[
     ("creates_dynamic_barrier", Traits::CREATES_DYNAMIC_BARRIER),
     ("has_loop_body", Traits::HAS_LOOP_BODY),
     ("never_inline_body", Traits::NEVER_INLINE_BODY),
-    ("warn_without_terminator", Traits::WARN_WITHOUT_TERMINATOR),
     ("evaluates_code", Traits::EVALUATES_CODE),
     ("performs_substitution", Traits::PERFORMS_SUBSTITUTION),
     ("opens_channel", Traits::OPENS_CHANNEL),

--- a/rust/tcl-registry/src/command_snapshot.rs
+++ b/rust/tcl-registry/src/command_snapshot.rs
@@ -94,7 +94,6 @@ const TRAIT_FLAGS: &[(&str, Traits)] = &[
     ("taint_sink", Traits::TAINT_SINK),
     ("terminates_block", Traits::TERMINATES_BLOCK),
     ("unsafe", Traits::UNSAFE),
-    ("warn_without_terminator", Traits::WARN_WITHOUT_TERMINATOR),
     ("wasm_emits_nothing", Traits::WASM_EMITS_NOTHING),
 ];
 

--- a/rust/tcl-registry/src/commands/tcl/exec_.rs
+++ b/rust/tcl-registry/src/commands/tcl/exec_.rs
@@ -51,6 +51,14 @@ pub fn spec() -> CommandSpec {
         options: const {
             &[
                 OptionSpec {
+                    name: "-encoding",
+                    value: OptionValue::value("encodingName"),
+                    detail: "",
+                    dialects: None,
+                    aliases: &[],
+                    min_version: None,
+                },
+                OptionSpec {
                     name: "-ignorestderr",
                     value: OptionValue::flag(),
                     detail: "",

--- a/rust/tcl-registry/src/commands/tcl/regexp_.rs
+++ b/rust/tcl-registry/src/commands/tcl/regexp_.rs
@@ -102,9 +102,7 @@ const REGEXP_HOVER: HoverSnippet = HoverSnippet {
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "regexp",
-        traits: Traits::BYTE_COMPILED
-            | Traits::WARN_WITHOUT_TERMINATOR
-            | Traits::FRAME_HASH_BUILTIN,
+        traits: Traits::BYTE_COMPILED | Traits::FRAME_HASH_BUILTIN,
         arity: Arity::at_least(1),
         return_type: Some(TclType::Int),
         side_effects: &[SideEffect {

--- a/rust/tcl-registry/src/commands/tcl/switch_.rs
+++ b/rust/tcl-registry/src/commands/tcl/switch_.rs
@@ -172,6 +172,11 @@ pub fn spec() -> CommandSpec {
         }),
         forms: FORMS,
         side_effects: SIDE_EFFECTS,
+        // `TclNRSwitchObjCmd` (generic/tclCmdMZ.c) only scans for `-flag`
+        // words up to `objc - 2`: the trailing `string` and
+        // pattern-list-or-first-pattern words are never mistaken for
+        // options, even when dynamic/tainted and starting with `-`.
+        reserved_trailing_words: 2,
         ..CommandSpec::DEFAULT
     }
 }

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1047,12 +1047,6 @@ impl CommandRegistry {
     /// command), so a linear scan at the call site is cheaper than
     /// a `HashSet` build.
     ///
-    /// `warn_without_terminator` lifts the
-    /// [`Traits::WARN_WITHOUT_TERMINATOR`] flag from the matched
-    /// command spec and surfaces it on `ResolvedTerminator`, but the
-    /// current W304 emitter does not consume it.  Kept on the resolver
-    /// for future emit logic and so the registry API doesn't need to
-    /// change when consumers start gating on it.
     #[must_use]
     pub fn resolve_option_terminator(
         &self,
@@ -1065,8 +1059,6 @@ impl CommandRegistry {
         } else {
             self.get_for_dialect(name, dialect)?
         };
-
-        let warn_flag = spec.traits.contains(Traits::WARN_WITHOUT_TERMINATOR);
 
         // Subcommand-scoped first. Resolve the subcommand word the same way
         // ensemble dispatch does — accepting a unique prefix abbreviation
@@ -1084,7 +1076,7 @@ impl CommandRegistry {
                 scan_start: 1,
                 subcommand: Some(sub.name),
                 options: sub.options,
-                warn_without_terminator: warn_flag,
+                reserved_trailing_words: 0,
             });
         }
 
@@ -1096,7 +1088,7 @@ impl CommandRegistry {
                 scan_start: 0,
                 subcommand: None,
                 options: spec.options,
-                warn_without_terminator: warn_flag,
+                reserved_trailing_words: spec.reserved_trailing_words,
             });
         }
 
@@ -1196,13 +1188,11 @@ pub struct ResolvedTerminator {
     /// require.  Per-command counts are small; a linear scan is
     /// cheaper than a heap-allocated set on the analyser hot path.
     pub options: &'static [crate::hover::OptionSpec],
-    /// Lifted from [`Traits::WARN_WITHOUT_TERMINATOR`] on the matched
-    /// command spec.  The current W304
-    /// emitter does not consume the flag (it is stored but never read).
-    /// Kept on the
-    /// type so future emit logic can gate on it without an API
-    /// change.
-    pub warn_without_terminator: bool,
+    /// Trailing words (after the command name) that are never scanned as
+    /// option candidates — see [`crate::spec::CommandSpec::reserved_trailing_words`].
+    /// `0` for every subcommand-scoped match (no subcommand currently
+    /// needs the reservation) and for any form without one declared.
+    pub reserved_trailing_words: usize,
 }
 
 /// Outcome of [`CommandRegistry::resolve_call`].
@@ -3156,7 +3146,6 @@ mod tests {
             .expect("regexp declares -- at the form level");
         assert_eq!(profile.scan_start, 0);
         assert!(profile.subcommand.is_none());
-        assert!(profile.warn_without_terminator);
         // ``-start`` takes a value; ``-nocase`` does not.
         // ``-start`` takes a value; ``-nocase`` does not.  The
         // resolver returns the borrowed options slice; callers
@@ -3191,17 +3180,6 @@ mod tests {
         // ``file mtime`` has no ``--`` terminator.
         let profile = reg.resolve_option_terminator("file", &["mtime", "$p"], DialectSet::empty());
         assert!(profile.is_none(), "got {profile:?}");
-    }
-
-    #[test]
-    fn resolve_option_terminator_warn_flag_off_for_non_regexp() {
-        let reg = CommandRegistry::build_default();
-        // ``unset`` declares ``--`` but does not carry the
-        // ``WARN_WITHOUT_TERMINATOR`` trait — only ``regexp`` does.
-        let profile = reg
-            .resolve_option_terminator("unset", &["$x"], DialectSet::empty())
-            .expect("unset declares --");
-        assert!(!profile.warn_without_terminator);
     }
 
     // -- ``is_canonical_list_command`` (W101 safe-idiom driver)

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -290,6 +290,23 @@ pub struct CommandSpec {
     /// Options declared on the command (for completion and arity adjustment).
     pub options: &'static [OptionSpec],
 
+    /// Number of trailing words (after the command name) that C Tcl's own
+    /// option-scanning loop never treats as option candidates, regardless
+    /// of their syntactic shape — a structural arity fact, not a taint or
+    /// dialect concern. `switch`'s C implementation
+    /// (`TclNRSwitchObjCmd`/`generic/tclCmdMZ.c`) scans for `-flag` words
+    /// only up to `objc - 2`, so the trailing `string` and
+    /// pattern-list-or-first-pattern words are *never* mistaken for
+    /// options even when they're a tainted variable or command
+    /// substitution beginning with `-` — hence `switch $x $caseListVar`
+    /// needs no `--` terminator. Consumed by
+    /// [`crate::registry::CommandRegistry::resolve_option_terminator`]'s
+    /// `reserved_trailing_words` on [`crate::registry::ResolvedTerminator`],
+    /// which both W304 and T102's option-scan-region walk cap their scan
+    /// against. Default `0` (no reservation) keeps every existing spec
+    /// correct.
+    pub reserved_trailing_words: usize,
+
     /// Enumerable positional-argument values, keyed by 0-based
     /// argument index *after* the command name.  Drives command-level
     /// value completion — e.g. iRules `when EVENT timing enable|disable`
@@ -538,6 +555,7 @@ impl CommandSpec {
         closed_value_args: &[],
         event_requires: None,
         options: &[],
+        reserved_trailing_words: 0,
         arg_values: &[],
         body_kind: BodyKind::Plain,
         body_arg_implicit_args: 0,

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -108,8 +108,6 @@ bitflags! {
         // Safety
         /// Inherently dangerous command.
         const UNSAFE                    = 1 << 29;
-        /// Warn about option injection without `--` terminator.
-        const WARN_WITHOUT_TERMINATOR   = 1 << 30;
         /// Password option command.
         const PASSWORD_OPTION           = 1 << 31;
 

--- a/rust/tcl-registry/tests/registry_sweep.rs
+++ b/rust/tcl-registry/tests/registry_sweep.rs
@@ -124,7 +124,6 @@ const ALL_TRAITS: &[Traits] = &[
     Traits::IS_UNESCAPE,
     Traits::PRODUCES_CANONICAL_LIST,
     Traits::UNSAFE,
-    Traits::WARN_WITHOUT_TERMINATOR,
     Traits::PASSWORD_OPTION,
     Traits::IS_SIDE_SWITCH,
     Traits::IRULES_TOP_LEVEL_ONLY,


### PR DESCRIPTION
## Summary

This PR fixes multiple issues with T102 (option injection) diagnostics and improves the taint analysis:

1. **False negative fix**: T102 now fires for `set x [cmd ...]` wrapped calls, not just bare `Call` statements. The option-injection check was only running on `Statement::Call`, silently skipping the dominant `set x [cmd ...]` idiom in real Tcl code.

2. **Shape-dependent mitigation stripping**: Added `TaintLattice::shape_unproven()` to strip `T102_SAFE` mitigations when a tainted value passes through an unclassified command (one with no registry classification). This prevents false negatives where shape proofs like `PATH_PREFIXED` incorrectly survive arbitrary transformations like `string range` or `lindex [split ...]`.

3. **Tight diagnostic spans**: T102 warnings now anchor to the offending argument's own span rather than the whole statement, providing better editor highlighting. For `Call`/`Barrier` statements, this uses the token's direct span; for `AssignValue` (`set x [cmd ...]`), it re-derives the span from the bracketed value text using the new `parse_command_substitution_spanned()` function.

4. **Code-action fixes**: T102 diagnostics now carry `--` insertion fixes via the new `CodeFix` struct in the `TaintWarning`, enabling quick-fix support in editors.

5. **Registry improvements**:
   - Replaced `WARN_WITHOUT_TERMINATOR` trait with `reserved_trailing_words` field on `CommandSpec`, which more accurately models structural arity facts (e.g., `switch` never scans its last 2 arguments as options).
   - Added `-encoding` option to `exec` command spec (was missing, causing option-scan masking).
   - Updated `switch` spec to declare `reserved_trailing_words: 2`.

6. **W304 fix**: Removed overly-specific exemption for braced `switch` patterns; now correctly handles dynamic 2-arg form (`switch $x $caseListVar`) via the `reserved_trailing_words` mechanism.

## Validation

- Added comprehensive unit tests in `taint.rs`:
  - `t102_fires_for_assign_value_wrapped_call()` — regression test for the false negative
  - `t102_span_is_tight_around_the_tainted_argument_bare_call()` — span tightness for `Call`
  - `t102_span_is_tight_around_the_tainted_argument_assign_value()` — span tightness for `AssignValue`

- Added false-positive regression tests in `fp/inj.rs`:
  - `fp_inj_06_string_range_strips_path_prefixed_proof()` — `string range` must strip `PATH_PREFIXED`
  - `fp_inj_06_split_lindex_strips_path_prefixed_proof()` — `split`/`lindex` must strip proof
  - `fp_inj_06_pure_copy_still_suppresses()` — control: plain copy still suppresses T102
  - `fp_inj_07_exec_encoding_does_not_mask_option_scan()` — `-encoding` option fix
  - `fp_inj_07_exec_bare_control_still_warns()` — control baseline

- Added false-positive regression tests in `fp/nab.rs`:
  - `fp_nab_05_dynamic_two_arg_switch_form_should_not_fire_w304()` — dynamic 2-arg form exemption
  - `fp_nab_05_three_trailing_args_still_fires_w304()` — control: 3+ args still fire

- Added end-to-end tests in `code_actions.rs` and VSCode test suite verifying T102 quick-fix delivery in plain `.tcl` files.

- Updated golden registry dump to reflect removal of `warn_without_terminator` trait.

## Compiler/KCS checklist

- [x] This change alters compiler fact contracts:
  - `T

https://claude.ai/code/session_01LHcf83hVZGvCyx93z5TYg5