### PR TITLE
Fix W002 false positives + centralise Tcl bareword command resolution

### DIFF
--- a/docs/design/compiler/namespace-resolution.md
+++ b/docs/design/compiler/namespace-resolution.md
@@ -11,55 +11,90 @@ why a procedure call is not matched to its definition.
 Tcl uses `::` as the namespace separator with `::` as the global namespace.
 `normalise_qualified_name()` canonicalises names, and lowering propagates
 namespace context so that `proc` definitions inside `namespace eval` receive
-fully qualified names.  Interprocedural analysis uses namespace-aware call
-resolution.
+fully qualified names. Same-file call resolution (the analyser's shadow /
+arity-suppression checks, the optimiser's interprocedural proc-identity
+resolution, and interprocedural/taint analysis's call-graph edges) all
+resolve a bareword call the same way, via one shared candidate-list
+function.
 
-Source: `shared/naming.py`,
-`compiler/lowering.py`,
-`compiler/interprocedural.py`
+Source: `rust/tcl-syntax/src/naming.rs`,
+`rust/tcl-compiler/src/lowering/mod.rs`,
+`rust/tcl-compiler/src/interprocedural.rs`
 
 ## Content
 
 ### `normalise_qualified_name()`
 
-```python
-normalise_qualified_name("helper")          → "::helper"
-normalise_qualified_name("::helper")        → "::helper"
-normalise_qualified_name("mylib::helper")   → "::mylib::helper"
-normalise_qualified_name("::::foo::::bar")  → "::foo::bar"
+```rust
+normalise_qualified_name("helper")          // → "::helper"
+normalise_qualified_name("::helper")        // → "::helper"
+normalise_qualified_name("mylib::helper")   // → "::mylib::helper"
+normalise_qualified_name("::::foo::::bar")  // → "::foo::bar"
 ```
 
 Rules: strip trailing `::`, collapse multiple `::` runs, ensure leading `::`.
 
 ### Namespace context propagation during lowering
 
-`_lower_command()` carries a `namespace` parameter:
+Lowering threads a `namespace` parameter through the walk:
 
-1. Top-level: `namespace="::"`
-2. `namespace eval mylib { ... }`:
-   - `_join_namespace("::", "mylib")` → `"::mylib"`
-   - Body lowered with `namespace="::mylib"`
-3. `proc helper` inside `::mylib`:
-   - `_qualify_proc_name("::mylib", "helper")` → `"::mylib::helper"`
+1. Top-level: `namespace = "::"`.
+2. `namespace eval mylib { ... }`: joins to `"::mylib"`; the body lowers
+   with that namespace.
+3. `proc helper` inside `::mylib` is qualified to `"::mylib::helper"`.
 
-### Call resolution in interprocedural analysis
+### Bareword call resolution: `bareword_resolution_candidates()`
 
-`resolve_internal_call("helper", "::mylib::compute", known_procs)`:
+`tcl_syntax::naming::bareword_resolution_candidates(namespace, cmd_name)`
+returns the candidate qualified names for a call, in the priority order Tcl
+itself uses — current namespace first, then global:
 
-1. Extract namespace parts from caller: `["mylib"]`
-2. Try `::mylib::helper` → found → return it
-3. If not found, try `::helper` (global namespace)
-4. Walk up the hierarchy until found or return `None`
+```rust
+bareword_resolution_candidates("::mylib", "helper")       // → ["::mylib::helper", "::helper"]
+bareword_resolution_candidates("::mylib", "other::helper") // → ["::mylib::other::helper", "::other::helper"]
+bareword_resolution_candidates("::mylib", "::helper")      // → ["::helper"]
+bareword_resolution_candidates("::", "helper")             // → ["::helper"]
+```
+
+The rule is **exactly two levels** — the caller's own namespace, then
+global — never every enclosing ancestor namespace. Real Tcl command lookup
+does not walk intermediate namespaces absent an explicit `namespace path`,
+which none of these consumers model: a `::a::b::c::caller` calling bare
+`foo` does **not** reach a `::a::foo` defined in the grandparent namespace,
+even though `::a` encloses `::a::b::c`. This also applies to a *relative
+dotted* word (`other::helper`, containing `::` but not starting with it) —
+it is still resolved against the current namespace first, not rooted
+straight at global (confirmed against tclsh 9.0.4: calling `other::helper`
+from inside `namespace eval ::mylib { … }` reaches `::mylib::other::helper`
+before `::other::helper`, when both exist).
+
+Every same-file resolution consumer builds its own candidates through this
+one function and then walks them against its own lookup table (procedures,
+aliases, classes, …), so a fix to the rule — or a bug in it — cannot drift
+between call sites:
+
+- **Analyser** — `Analyser::resolve_proc_call` (go-to-definition / symbol
+  lookup) and `UserResolutionFacts::resolves_to_user` (the W002
+  disabled-in-dialect and E002/E003 builtin-arity same-file shadow
+  suppression checks) compute the caller's namespace from the live scope
+  tree via `Analyser::command_resolution_namespace`.
+- **Optimiser** — `resolve_proc_qname` (O103 static-proc-call folding)
+  computes it the same way, from the enclosing proc's scope.
+- **Interprocedural / taint** — `resolve_internal_call` computes the
+  caller's namespace from its own qualified name
+  (`namespace_parts_from_proc`, since interprocedural analysis works over
+  IR qnames rather than a live scope tree).
 
 ### Resulting IR module
 
-```python
-IRModule(
-    procedures={
-        "::mylib::helper": IRProcedure(name="helper", ...),
-        "::mylib::compute": IRProcedure(name="compute", ...),
+```rust
+Module {
+    procedures: {
+        "::mylib::helper": Procedure { name: "helper", .. },
+        "::mylib::compute": Procedure { name: "compute", .. },
     },
-)
+    ..
+}
 ```
 
 All procedure names in the IR module are fully qualified.
@@ -67,14 +102,19 @@ All procedure names in the IR module are fully qualified.
 ## Decision rule
 
 - Always pass names through `normalise_qualified_name()` before using them
-  as dictionary keys or comparison targets.
+  as map keys or comparison targets.
+- Always build same-file call-resolution candidates through
+  `bareword_resolution_candidates()` rather than hand-rolling the
+  current-namespace/global logic again — every prior hand-rolled copy
+  carried at least one of the two bugs above.
 - If a procedure call fails to resolve, check that the caller's namespace
-  context was propagated correctly through lowering.
+  context was propagated correctly through lowering (or, for the analyser,
+  through the scope tree).
 - `normalise_var_name()` is for variables (handles `::` prefix only);
   `normalise_qualified_name()` is for procedures and commands.
 
 ## Related docs
 
 - [Example 26 in walkthroughs](../../../docs/design/example-script-walkthroughs.md#example-26-namespace-resolution)
-- [kcs-compiler-pipeline-overview.md](../../../docs/design/compiler/compiler-pipeline-overview.md)
-- [kcs-interprocedural-analysis.md](../../../docs/design/compiler/interprocedural-analysis.md)
+- [compiler-pipeline-overview.md](../../../docs/design/compiler/compiler-pipeline-overview.md)
+- [interprocedural-analysis.md](../../../docs/design/compiler/interprocedural-analysis.md)

--- a/docs/kcs/codes/kcs-diagnostic-w002-command-disabled-in-dialect.md
+++ b/docs/kcs/codes/kcs-diagnostic-w002-command-disabled-in-dialect.md
@@ -21,12 +21,18 @@ Some Tcl dialects (e.g. iRules) deliberately restrict the set of available comma
 
 ## Symptoms
 
-- A yellow squiggle appears under the command name, with the message "command 'exec' is disabled in the iRules dialect".
+- A yellow squiggle appears under the command name (or, for a version-gated
+  subcommand such as `package files`, under `command subcommand` together),
+  with a message like "'exec' is disabled in the active dialect profile
+  (available in: tcl8.4, tcl8.5, tcl8.6, tcl9.0, tcl9.1, f5-iapps, …)". The
+  "available in" list is read straight from the command's registry entry, so
+  it names every dialect the command actually works in — a quick way to tell
+  whether switching the file's dialect would fix it.
 
 ## Example that triggers it
 
 ```tcl
-# dialect: irules
+# tcl-dialect: f5-irules
 exec ls /tmp
 ```
 
@@ -40,6 +46,14 @@ log local0. "listing not available in iRules"
 ```
 
 Use only commands permitted by the active dialect.
+
+W002 only fires for a **literal** command name that the registry can
+statically resolve as *known somewhere, disabled here* — a `$var`/`[cmd]`
+command head is a runtime dispatch (see W307's KCS note instead), and a call
+that resolves to a same-file `proc`, `interp alias`, static `rename` target,
+`TclOO`/snit/itcl class, `namespace ensemble create` namespace, or `#
+tcl-lsp: stub` declaration is never flagged — Tcl resolves the call to that
+definition, not to the disabled builtin, so there is nothing to warn about.
 
 ## How to suppress
 

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -594,9 +594,7 @@ suite("Diagnostics", () => {
       `expected W002 on the unshadowed 'dict create' call (line ${unshadowedLine})`,
     );
     assert.ok(
-      diagnostics.some(
-        (d) => codeOf(d) === "W002" && /available in: tcl8\.5/.test(d.message),
-      ),
+      diagnostics.some((d) => codeOf(d) === "W002" && /available in: tcl8\.5/.test(d.message)),
       `expected the W002 message to name the dialects dict is available in: ` +
         `${diagnostics.map((d) => d.message).join("; ")}`,
     );

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -562,6 +562,58 @@ suite("Diagnostics", () => {
   // BLT/Rbc idiom) with no `package require`, plus one genuinely-unknown
   // command. The package database resolves the library commands exactly as
   // go-to-definition does, so they must NOT be flagged "Unknown command"
+  // W002 (disabled-in-dialect command): a genuinely disabled command with no
+  // shadowing definition must fire, while a same-file proc / interp alias /
+  // forward-declared proc-body shadow — resolved with Tcl's real
+  // namespace-then-global, load-order-aware rules — must not.
+  test("W002 fires only for the unshadowed disabled call, not the shadowed ones", async () => {
+    const uri = getDocUri("w002.tcl");
+    const doc = await activate(uri);
+    const codeOf = (d: vscode.Diagnostic) => (typeof d.code === "object" ? d.code.value : d.code);
+
+    const text = doc.getText();
+    const lineOf = (needle: string): number => {
+      const idx = text.indexOf(needle);
+      assert.ok(idx >= 0, `fixture must contain ${JSON.stringify(needle)}`);
+      return doc.positionAt(idx).line;
+    };
+    const unshadowedLine = lineOf("dict create a 1");
+    const namespaceShadowedLine = lineOf("dict foo bar");
+    const aliasShadowedLine = lineOf("aliasedDisabled foo bar");
+    const forwardDeclaredLine = lineOf("lmap x {1 2 3}");
+
+    const w002On = (diags: vscode.Diagnostic[], line: number) =>
+      diags.some((d) => codeOf(d) === "W002" && d.range.start.line === line);
+
+    const diagnostics = await waitForDiagnostics(uri, {
+      predicate: (diags) => w002On(diags, unshadowedLine),
+    });
+
+    assert.ok(
+      w002On(diagnostics, unshadowedLine),
+      `expected W002 on the unshadowed 'dict create' call (line ${unshadowedLine})`,
+    );
+    assert.ok(
+      diagnostics.some(
+        (d) => codeOf(d) === "W002" && /available in: tcl8\.5/.test(d.message),
+      ),
+      `expected the W002 message to name the dialects dict is available in: ` +
+        `${diagnostics.map((d) => d.message).join("; ")}`,
+    );
+    assert.ok(
+      !w002On(diagnostics, namespaceShadowedLine),
+      `a namespace-scoped shadowing proc must suppress W002 (line ${namespaceShadowedLine})`,
+    );
+    assert.ok(
+      !w002On(diagnostics, aliasShadowedLine),
+      `an interp alias establishing the name must suppress W002 (line ${aliasShadowedLine})`,
+    );
+    assert.ok(
+      !w002On(diagnostics, forwardDeclaredLine),
+      `a forward-declared proc-body shadow must suppress W002 (line ${forwardDeclaredLine})`,
+    );
+  });
+
   // (W123) — while the genuine unknown still is. `xcDiagnostics` stays off.
   test("auto_path library commands are not unknown (issue #832)", async () => {
     const uri = getDocUri("autoloadLibrary.tcl");

--- a/editors/vscode/testFixture/w002.tcl
+++ b/editors/vscode/testFixture/w002.tcl
@@ -1,0 +1,28 @@
+# tcl-dialect: tcl8.4
+
+# `dict` is Tcl 8.5+; nothing in this file shadows the bare global name, so
+# this call must fire W002.
+dict create a 1
+
+# A namespace-scoped proc shadows the disabled builtin for unqualified calls
+# resolved inside that namespace (current-namespace-then-global) — must NOT
+# fire.
+namespace eval ::ns {
+    proc dict {args} { return $args }
+    dict foo bar
+}
+
+# `interp alias` establishing the name is a real command exactly like a proc
+# would be — must NOT fire.
+interp alias {} aliasedDisabled {} list
+proc use_alias {} {
+    aliasedDisabled foo bar
+}
+
+# A forward-declared proc — defined *after* this call site textually, but the
+# call only runs once the whole file has loaded (deferred inside another
+# proc's body) — must NOT fire. `lmap` is Tcl 8.6+, also disabled under 8.4.
+proc use_lmap {} {
+    lmap x {1 2 3} {expr {$x * 2}}
+}
+proc lmap {args} { return $args }

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -647,8 +647,8 @@ impl Analyser {
         if cmd_name == "catch" {
             self.emit_w302_catch_no_result_var(args, cmd_tok, arg_tokens, arg_single);
         }
-        self.emit_w001_unknown_subcommand(cmd_name, args, cmd_tok, arg_tokens);
-        self.emit_w002_disabled_command(cmd_name, cmd_tok);
+        self.emit_w001_unknown_subcommand(cmd_name, args, cmd_tok, arg_tokens, scope_path);
+        self.emit_w002_disabled_command(cmd_name, cmd_tok, scope_path);
         if let Some(checker) = self
             .registry
             .as_ref()

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/nab.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/nab.rs
@@ -310,5 +310,158 @@ fn tk_command_option_body_is_analysed() {
     );
 }
 
+// FP-NAB-13 — W002 disabled-in-dialect suppression must honour the same
+// same-file resolution rules as the builtin-arity suppression check
+// (namespace-scoped shadowing, load-order for top-level vs proc-body calls,
+// `interp alias`, static `rename`, and — for the subcommand form — a
+// shadowed ensemble head), while a genuinely disabled command with no
+// same-file definition anywhere must still fire.
+
+// TN — no shadow anywhere: the plain disabled-command case must still fire.
+#[test]
+fn fp_nab_13_no_shadow_still_fires_w002() {
+    assert!(
+        fires("dict create a 1", "tcl8.4", "W002"),
+        "FP-NAB-13 TN: a genuinely disabled command with no shadow must fire W002; {:?}",
+        diags("dict create a 1", "tcl8.4")
+    );
+}
+
+// FP — a namespace-scoped proc shadows the disabled builtin for unqualified
+// calls resolved inside that namespace (current-namespace-then-global, the
+// same rule the builtin-arity check already honoured).
+#[test]
+fn fp_nab_13_namespace_scoped_proc_shadow_silent() {
+    let src = "namespace eval ::ns {\n    proc dict {args} { return $args }\n    dict foo bar\n}\n";
+    assert!(
+        !fires(src, "tcl8.4", "W002"),
+        "FP-NAB-13: a namespace-scoped shadowing proc must suppress W002; {:?}",
+        diags(src, "tcl8.4")
+    );
+}
+
+// FP — a forward-declared proc (defined *after* the call, but inside a proc
+// body that only runs once the whole file has loaded) shadows the disabled
+// builtin. Proc-body calls are not order-gated.
+#[test]
+fn fp_nab_13_forward_declared_proc_body_shadow_silent() {
+    let src = "proc use_dict {} {\n    dict create a 1\n}\nproc dict {args} { return $args }\n";
+    assert!(
+        !fires(src, "tcl8.4", "W002"),
+        "FP-NAB-13: a proc-body call to a forward-declared shadowing proc must suppress W002; {:?}",
+        diags(src, "tcl8.4")
+    );
+}
+
+// FN guard — the same forward-declared proc, called at the *top level*
+// before its own definition, must still fire: top-level commands run in
+// source order during load, so the builtin is what actually runs there.
+#[test]
+fn fp_nab_13_top_level_call_before_shadow_still_fires() {
+    let src = "dict create a 1\nproc dict {args} { return $args }\n";
+    assert!(
+        fires(src, "tcl8.4", "W002"),
+        "FP-NAB-13 FN guard: a top-level call before its shadowing proc's \
+         definition must still fire W002; {:?}",
+        diags(src, "tcl8.4")
+    );
+}
+
+// FP — `interp alias` establishing the disabled name shadows it exactly like
+// a proc would.
+#[test]
+fn fp_nab_13_interp_alias_shadow_silent() {
+    let src = "interp alias {} dict {} list\ndict create a 1\n";
+    assert!(
+        !fires(src, "tcl8.4", "W002"),
+        "FP-NAB-13: an interp alias establishing the name must suppress W002; {:?}",
+        diags(src, "tcl8.4")
+    );
+}
+
+// FP — a static `rename` that moves an existing proc onto the disabled name
+// shadows it exactly like a direct `proc` definition would.
+#[test]
+fn fp_nab_13_rename_shadow_silent() {
+    let src = "proc myimpl {args} { return $args }\nrename myimpl dict\ndict create a 1\n";
+    assert!(
+        !fires(src, "tcl8.4", "W002"),
+        "FP-NAB-13: a rename establishing the name must suppress W002; {:?}",
+        diags(src, "tcl8.4")
+    );
+}
+
+// FP — the subcommand-level W002 form (a version-gated *subcommand*, e.g.
+// `package files`) is likewise suppressed when the whole ensemble command's
+// own name is shadowed by a user proc — the call never reaches the registry
+// ensemble at all.
+#[test]
+fn fp_nab_13_subcommand_form_shadowed_ensemble_head_silent() {
+    let src = "proc package {args} { return $args }\npackage files mypackage\n";
+    assert!(
+        !fires(src, "tcl8.6", "W002"),
+        "FP-NAB-13: a shadowed ensemble head must suppress the subcommand-form W002; {:?}",
+        diags(src, "tcl8.6")
+    );
+}
+
+// TN — the subcommand form's shadow check is specific to the *base* command
+// name; an unrelated proc elsewhere must not spuriously suppress it.
+#[test]
+fn fp_nab_13_subcommand_form_unrelated_proc_still_fires() {
+    let src = "proc unrelated {} {}\npackage files mypackage\n";
+    assert!(
+        fires(src, "tcl8.6", "W002"),
+        "FP-NAB-13 TN: an unrelated proc must not suppress the subcommand-form W002; {:?}",
+        diags(src, "tcl8.6")
+    );
+}
+
+// FP — an inline `# tcl-lsp: stub` declaration establishes the disabled name
+// as a document-global command, unqualified.
+#[test]
+fn fp_nab_13_stub_declaration_shadow_silent() {
+    let src = "# tcl-lsp: stubs-begin\n\
+               # tcl-lsp: stub dict {args:var} -loop\n\
+               # tcl-lsp: stubs-end\n\
+               dict create a 1\n";
+    assert!(
+        !fires(src, "tcl8.4", "W002"),
+        "FP-NAB-13: an inline stub declaration must suppress W002; {:?}",
+        diags(src, "tcl8.4")
+    );
+}
+
+// FP — a `TclOO` class bound to the disabled name is a real command exactly
+// like a proc would be (the class-create form binds the factory command
+// under that name). `oo::class` itself needs Tcl 8.6+, so this uses
+// `lremove` (Tcl 9.0+) under `tcl8.6` rather than `dict` under `tcl8.4`.
+#[test]
+fn fp_nab_13_tcloo_class_shadow_silent() {
+    let src = "oo::class create lremove {\n    constructor {} {}\n}\nlremove create\n";
+    assert!(
+        !fires(src, "tcl8.6", "W002"),
+        "FP-NAB-13: a TclOO class bound to the name must suppress W002; {:?}",
+        diags(src, "tcl8.6")
+    );
+}
+
+// The message enrichment: the "(available in: …)" suffix is read straight
+// from the registry's own dialect gate, so it lists exactly the dialects the
+// command supports — never a hardcoded per-command string.
+#[test]
+fn fp_nab_13_message_names_available_dialects() {
+    let ds = diags("dict create a 1", "tcl8.4");
+    let msg = ds
+        .iter()
+        .find(|(c, _)| c == "W002")
+        .map(|(_, m)| m.as_str())
+        .unwrap_or_default();
+    assert!(
+        msg.contains("available in: tcl8.5, tcl8.6, tcl9.0, tcl9.1"),
+        "W002 message should name the dialects dict is available in; got {msg:?}"
+    );
+}
+
 // FP-NAB-03 control — an impure proc using puts comes out pure=False. Covered
 // as a Rust interproc-purity structure test elsewhere (not a diagnostic).

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -1227,6 +1227,45 @@ fn e003_proc_body_call_not_order_gated() {
     );
 }
 
+#[test]
+fn e003_static_rename_onto_builtin_name_suppresses_arity() {
+    // `rename OLD NEW` moves OLD's identity onto NEW — `rename myimpl
+    // close` makes `close` a real command backed by `myimpl`'s own
+    // 3-parameter signature, not the registry `close` builtin (max 2), so
+    // a 3-argument call must not fire E003.  Order-gated the same way as a
+    // proc: the rename statement must lexically precede a top-level call.
+    let src = "proc myimpl {a b c} { return $a }\nrename myimpl close\nclose 1 2 3\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::E003),
+        "no E003 expected — close was renamed onto myimpl's 3-arg signature, got {:?}",
+        r.diagnostics
+    );
+}
+
+#[test]
+fn e003_top_level_call_before_rename_onto_builtin_still_fires() {
+    // The mirror image of `e003_top_level_call_before_shadowing_proc_fires`
+    // for a rename target: a top-level call *before* the `rename` runs
+    // still reaches the original builtin at load time.
+    let src = "close 1 2 3\nproc myimpl {a b c} { return $a }\nrename myimpl close\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    let e003: Vec<&Diagnostic> = r
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == DiagCode::E003)
+        .collect();
+    assert_eq!(
+        e003.len(),
+        1,
+        "expected E003 on the top-level close before the rename took effect, got {:?}",
+        r.diagnostics
+    );
+    assert_eq!(e003[0].span.start(), 0, "wrong call flagged");
+}
+
 // Same-file proc / TclOO forward / `interp alias` / `rename` arity
 // (generalises E002/E003 beyond the builtin registry).
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -167,30 +167,16 @@ fn dialect_availability_suffix(dialects: Option<tcl_registry::prelude::DialectSe
     format!(" (available in: {})", names.join(", "))
 }
 
-/// Namespace-qualify `cmd_name`'s resolution candidates the Tcl way:
-/// current namespace first, then global. Shared by the
-/// builtin-shadowing suppression check
-/// ([`Analyser::flush_arity_diagnostics`]) and the same-file proc/alias/
-/// rename resolution chase
-/// ([`Analyser::resolve_indirect_call_target`]), so both walk the
-/// identical candidate order.
-///
-/// A name containing `::` but not starting with it (`inner::p`) is
-/// still *relative* — Tcl resolves it against the current namespace
-/// before falling back to global (confirmed against tclsh 9.0.4:
-/// calling `inner::p` from inside `namespace eval ::ns { … }` reaches
-/// `::ns::inner::p`, not `::inner::p`, when both exist). Only a
-/// leading `::` is a genuinely absolute name.
+/// Namespace-qualify `cmd_name`'s resolution candidates the Tcl way: current
+/// namespace first, then global. Shared by the builtin-shadowing suppression
+/// check ([`Analyser::flush_arity_diagnostics`]) and the same-file
+/// proc/alias/rename resolution chase
+/// ([`Analyser::resolve_indirect_call_target`]), so both walk the identical
+/// candidate order — and, via [`crate::naming::bareword_resolution_candidates`],
+/// the identical order the optimiser's interprocedural proc resolution uses,
+/// so a fix to the rule can't drift between the two.
 fn qualify_candidates(ns: &str, cmd_name: &str) -> Vec<String> {
-    if cmd_name.starts_with("::") {
-        return vec![cmd_name.to_owned()];
-    }
-    let global = format!("::{cmd_name}");
-    if ns == "::" {
-        return vec![global];
-    }
-    let relative = format!("{ns}::{cmd_name}");
-    vec![relative, global]
+    crate::naming::bareword_resolution_candidates(ns, cmd_name)
 }
 
 /// Whole-file facts needed to decide whether a same-file call resolves to a

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -150,6 +150,23 @@ pub(super) fn arity_verdict(
     }
 }
 
+/// Format the "(available in: …)" suffix for a W002 message from a
+/// command/subcommand's registry-declared dialect restriction — entirely
+/// data-driven from [`tcl_registry::CommandSpec::dialects`] /
+/// [`tcl_registry::SubCommand::dialects`], never a per-command name check.
+/// Empty when `dialects` is `None` (unrestricted) or has no primitive
+/// member (defensive; a restricted spec always has at least one).
+fn dialect_availability_suffix(dialects: Option<tcl_registry::prelude::DialectSet>) -> String {
+    let Some(dialects) = dialects else {
+        return String::new();
+    };
+    let names = dialects.member_names();
+    if names.is_empty() {
+        return String::new();
+    }
+    format!(" (available in: {})", names.join(", "))
+}
+
 /// Namespace-qualify `cmd_name`'s resolution candidates the Tcl way:
 /// current namespace first, then global. Shared by the
 /// builtin-shadowing suppression check
@@ -174,6 +191,112 @@ fn qualify_candidates(ns: &str, cmd_name: &str) -> Vec<String> {
     }
     let relative = format!("{ns}::{cmd_name}");
     vec![relative, global]
+}
+
+/// Whole-file facts needed to decide whether a same-file call resolves to a
+/// user definition rather than falling through to a registry builtin.
+///
+/// Shared by the two same-file "does this call resolve away from the
+/// builtin" suppression checks — [`Analyser::flush_arity_diagnostics`]
+/// (suppress a builtin arity mismatch) and
+/// [`Analyser::flush_disabled_command_diagnostics`] (suppress a
+/// disabled-in-dialect warning) — both need the identical resolution rule,
+/// so a fix to one (e.g. the `rename`-target gap this closed) automatically
+/// applies to the other. Built once per flush pass over the fully-merged
+/// post-walk facts (`all_procs` / `all_classes` / `command_aliases` /
+/// `renamed_commands` / `ensemble_namespaces` — populated cross-item after
+/// every per-item body has been grafted).
+///
+/// Owns its data (rather than borrowing `Analyser`) so a flush loop can
+/// build it once up front and then freely take/mutate other `Analyser`
+/// fields (`pending_arity`, `result.diagnostics`, …) while iterating —
+/// borrowing through a whole-`&Analyser` build call would otherwise pin the
+/// borrow checker's view to "all of `self`" for the facts' lifetime.
+struct UserResolutionFacts {
+    /// Fully-qualified names that unconditionally denote a user command once
+    /// declared anywhere in the file: `TclOO`/snit/itcl classes, `interp
+    /// alias` names, and `namespace ensemble create` namespaces. Not
+    /// order-gated — a deliberately permissive, false-negative-avoiding
+    /// convention (a genuinely order-violating call is rare enough that
+    /// abstaining from a real builtin-mismatch report is the safer trade).
+    non_proc_qnames: FxHashSet<String>,
+    /// Qualified proc name → its definition token offset.
+    proc_offsets: FxHashMap<String, u32>,
+    /// Qualified *new* name (a static `rename OLD NEW`) → the `rename`
+    /// statement's token offset. `rename` moves an existing command's
+    /// identity onto `NEW`, so once in effect `NEW` is a real command
+    /// exactly like a proc definition — order-gated the same way.
+    rename_offsets: FxHashMap<String, u32>,
+    /// Document-global `# tcl-lsp: stub` command names (unqualified).
+    stub_names: std::collections::HashSet<String>,
+}
+
+impl UserResolutionFacts {
+    fn build(a: &Analyser) -> Self {
+        let mut non_proc_qnames: FxHashSet<String> = FxHashSet::default();
+        non_proc_qnames.extend(a.result.all_classes.keys().cloned());
+        non_proc_qnames.extend(a.result.command_aliases.keys().cloned());
+        non_proc_qnames.extend(a.ensemble_namespaces.iter().cloned());
+        let proc_offsets: FxHashMap<String, u32> = a
+            .result
+            .all_procs
+            .iter()
+            .map(|(qname, def)| (qname.clone(), def.name_span.start()))
+            .collect();
+        let rename_offsets: FxHashMap<String, u32> = a
+            .result
+            .renamed_commands
+            .keys()
+            .filter_map(|new_qname| {
+                a.rename_offsets
+                    .get(new_qname)
+                    .map(|&off| (new_qname.clone(), off))
+            })
+            .collect();
+        let stub_names = super::utils::scan_stub_command_names(&a.source);
+        Self {
+            non_proc_qnames,
+            proc_offsets,
+            rename_offsets,
+            stub_names,
+        }
+    }
+
+    /// Whether a call to `cmd_name` (resolved at `ns`, at byte offset
+    /// `call_off`) resolves to a user-declared proc, class, alias, rename
+    /// target, ensemble, or stub, rather than falling through to the
+    /// registry builtin that produced the candidate diagnostic.
+    ///
+    /// `enforce_order` gates **proc** and **rename** shadowing to a
+    /// definition that lexically precedes the call: true for a top-level
+    /// call site (the module body, a `namespace eval` body, or a
+    /// conditional), which executes in source order during load, so a
+    /// same-named definition appearing later in the file has not run yet. A
+    /// proc-body call (`enforce_order == false`) runs only after the whole
+    /// file has loaded, so any same-named definition anywhere in the file is
+    /// already in effect. Classes / aliases / ensembles / stubs always exist
+    /// by run time and are never order-gated.
+    fn resolves_to_user(
+        &self,
+        cmd_name: &str,
+        ns: &str,
+        enforce_order: bool,
+        call_off: u32,
+    ) -> bool {
+        let bare = cmd_name.rsplit("::").next().unwrap_or(cmd_name);
+        let candidates = qualify_candidates(ns, cmd_name);
+        candidates.iter().any(|c| {
+            self.non_proc_qnames.contains(c.as_str())
+                || self
+                    .proc_offsets
+                    .get(c.as_str())
+                    .is_some_and(|&off| !enforce_order || off < call_off)
+                || self
+                    .rename_offsets
+                    .get(c.as_str())
+                    .is_some_and(|&off| !enforce_order || off < call_off)
+        }) || self.stub_names.contains(bare)
+    }
 }
 
 /// Shift a resolved [`Arity`] down by an `interp alias` / `TclOO`
@@ -273,13 +396,23 @@ impl Analyser {
     /// **W002** — the command is disabled in the active dialect profile: it
     /// exists in the registry but not for the active dialect (e.g. `dict` under
     /// `tcl8.4`, added in 8.5).  Only a *literal* command head is checked — a
-    /// `$obj` / `[cmd]` head is W307's concern — and an earlier unconditional
-    /// user-proc definition that shadows the built-in suppresses it (Tcl
-    /// resolves the proc at the call site).
+    /// `$obj` / `[cmd]` head is W307's concern.
+    ///
+    /// Queues the candidate onto [`Self::pending_disabled_commands`] rather
+    /// than emitting inline: whether the call actually reaches the disabled
+    /// builtin depends on same-file facts (a shadowing proc / class / `interp
+    /// alias` / static `rename` / `namespace ensemble create`) that may not
+    /// be fully known until the whole file (or, on the per-item path, every
+    /// grafted body) has been walked — a forward-declared shadowing proc is
+    /// the common case a same-pass check would miss entirely.
+    /// [`Self::flush_disabled_command_diagnostics`] resolves every candidate
+    /// post-walk using the same current-namespace-then-global resolution and
+    /// top-level order gate as [`Self::flush_arity_diagnostics`].
     pub(in crate::analyser) fn emit_w002_disabled_command(
         &mut self,
         cmd_name: &str,
         cmd_tok: tcl_lexer::Token,
+        scope_path: &[usize],
     ) {
         use tcl_registry::prelude::DialectSet;
         // A dynamic command head (`$obj method`, `[lookup] arg`) is resolved at
@@ -308,32 +441,29 @@ impl Analyser {
         {
             return;
         }
-        // An earlier *unconditional* user proc with this name shadows the
-        // would-be-disabled built-in at the call site.
-        let qualified = crate::naming::normalise_qualified_name(bare);
-        if let Some(def) = self.result.all_procs.get(&qualified)
-            && def.name_span.start() < cmd_tok.span.start()
-        {
-            return;
-        }
+        // Best-effort "available in: …" hint read straight from the
+        // registry spec's own dialect gate. Only resolves when the spec is
+        // among the packs this registry instance loaded regardless of
+        // dialect (core Tcl / stdlib / tcllib / Tk / itcl / …, via
+        // `CommandRegistry::build_default`); a command exclusive to a
+        // *different* dialect family (e.g. an iRules-only name referenced
+        // from a `tcl8.6` file) isn't loaded here, so `get` returns `None`
+        // and the message falls back to the plain form — never wrong, just
+        // sometimes less specific.
+        let suffix = registry.get(bare).map_or(String::new(), |spec| {
+            dialect_availability_suffix(spec.dialects)
+        });
         let diag = super::types::Diagnostic {
             code: DiagCode::W002,
             span: cmd_tok.span,
-            message: format!("'{cmd_name}' is disabled in the active dialect profile"),
+            message: format!("'{cmd_name}' is disabled in the active dialect profile{suffix}"),
             severity: Severity::Warning,
             fixes: Vec::new(),
         };
-        // Per-item path (isolated body): the body's own `all_procs` couldn't
-        // prove a shadow, but a *sibling/enclosing* user proc still might.  That
-        // is a cross-item fact, so defer the shadow re-check to the tail (over
-        // the merged `all_procs`).  `capture_global_reads.is_some()` marks the
-        // isolated-body analysis; on the whole-file path it is `None` and W002 is
-        // emitted inline exactly as before.
-        if self.capture_global_reads.is_some() {
-            self.pending_disabled_commands.push((qualified, diag));
-        } else {
-            self.result.diagnostics.push(diag);
-        }
+        let ns = self.command_resolution_namespace(scope_path);
+        let enforce_order = !self.scope_path_in_proc_body(scope_path);
+        self.pending_disabled_commands
+            .push((cmd_name.to_string(), ns, enforce_order, diag));
     }
 
     /// Resolve a command's signature, honouring the active scoped command
@@ -366,6 +496,7 @@ impl Analyser {
         args: &[String],
         cmd_tok: tcl_lexer::Token,
         arg_tokens: &[tcl_lexer::Token],
+        scope_path: &[usize],
     ) {
         use super::dispatch::{CommandSignature, signature_for_command};
         use tcl_registry::prelude::DialectSet;
@@ -432,6 +563,12 @@ impl Analyser {
         // whole commands (`emit_w002_disabled_command`): it EXISTS, just not
         // here, so it must be reported as disabled-in-dialect rather than as an
         // "Unknown subcommand" with a misleading spelling suggestion.
+        //
+        // Deferred exactly like the whole-command form: whether `cmd_name`
+        // itself resolves to the registry ensemble (rather than a same-file
+        // proc/alias/rename/class/ensemble that shadows it — e.g. `proc
+        // package {args} {…}` fully overriding the `package` ensemble) can
+        // depend on facts not yet known mid-walk.
         if let Some(CommandSignature::WithSubcommands(any_sig)) =
             signature_for_command(registry, cmd_name, DialectSet::all())
             && any_sig.is_known(first_arg)
@@ -440,15 +577,34 @@ impl Analyser {
                 Some(sub_tok) => tcl_lexer::Span::new(cmd_tok.span.start(), sub_tok.span.end()),
                 None => cmd_tok.span,
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
+            // Best-effort "available in: …" hint from the registry's own
+            // dialect gate on the matching `SubCommand` entry (falling back
+            // to the parent command's, the same inheritance
+            // `emit_w004_dialect_invalid_option` uses). An abbreviated
+            // `first_arg` that doesn't literally match a `SubCommand.name`
+            // just yields no hint — the base message stays accurate either
+            // way.
+            let suffix = registry.get(cmd_name).map_or(String::new(), |spec| {
+                spec.subcommands
+                    .iter()
+                    .find(|s| s.name == first_arg.as_str())
+                    .map_or(String::new(), |sub| {
+                        dialect_availability_suffix(sub.dialects.or(spec.dialects))
+                    })
+            });
+            let diag = super::types::Diagnostic {
                 code: DiagCode::W002,
                 span,
                 message: format!(
-                    "'{cmd_name} {first_arg}' is disabled in the active dialect profile"
+                    "'{cmd_name} {first_arg}' is disabled in the active dialect profile{suffix}"
                 ),
                 severity: Severity::Warning,
                 fixes: Vec::new(),
-            });
+            };
+            let ns = self.command_resolution_namespace(scope_path);
+            let enforce_order = !self.scope_path_in_proc_body(scope_path);
+            self.pending_disabled_commands
+                .push((cmd_name.to_string(), ns, enforce_order, diag));
             return;
         }
         let mut message = format!("Unknown subcommand '{first_arg}' for '{cmd_name}'");
@@ -851,106 +1007,80 @@ impl Analyser {
         }
     }
 
-    /// Post-walk flush of the [`Self::pending_arity`] candidates
-    /// collected by [`Self::emit_arity_diagnostics`].
+    /// Post-walk flush of the [`Self::pending_disabled_commands`] candidates
+    /// collected by [`Self::emit_w002_disabled_command`] and the subcommand
+    /// form embedded in [`Self::emit_w001_unknown_subcommand`].
     ///
     /// Runs after the command walk completes, when `all_procs`,
-    /// `all_classes`, `command_aliases`, `ensemble_namespaces` and the
-    /// inline stub set are fully populated.  A candidate is dropped
-    /// only when the call **resolves to** a user definition rather than
-    /// the builtin whose registry arity produced it — resolution
-    /// follows Tcl's rule for unqualified commands (the call-site
-    /// namespace, then global `::`), using the namespace captured at
-    /// emit time.  So `proc ::ns::close {...}` suppresses a `close`
-    /// call inside `::ns` (and a qualified `::ns::close ...`), but a
-    /// `close` call in another namespace still resolves to the builtin
-    /// and is checked.  Document-global declarations — inline
-    /// `# tcl-lsp: stub`s — suppress by bare name regardless of
-    /// namespace.
+    /// `all_classes`, `command_aliases`, `renamed_commands` and
+    /// `ensemble_namespaces` are fully populated (post cross-item merge on
+    /// the per-item path). A candidate is dropped exactly when
+    /// [`UserResolutionFacts::resolves_to_user`] says the call resolves to a
+    /// user definition rather than the builtin the candidate warns about —
+    /// the identical resolution rule [`Self::flush_arity_diagnostics`] uses
+    /// to suppress a builtin-arity mismatch, so e.g. a namespace-scoped `proc
+    /// ::ns::dict {...}` correctly suppresses a `dict` call inside `::ns`,
+    /// and an `interp alias {} dict {} …` / `rename myimpl dict` /
+    /// `oo::class create dict {…}` established anywhere in the file
+    /// (unconditionally for aliases/classes/ensembles/stubs; only when
+    /// lexically preceding a top-level call for a proc/rename target)
+    /// likewise suppresses it.
     ///
-    /// Suppression by a shadowing **proc** also honours definition
-    /// reachability: a top-level call (one whose
-    /// `enforce_order` flag is set — module body, `namespace eval`
-    /// body, or a conditional) is silenced only when the proc's
-    /// definition lexically precedes it, since top-level commands run
-    /// in source order during load (so a `close x y z` *before* a later
-    /// `proc close` still reaches the builtin).  Proc-body calls run
-    /// after load and are not order-gated.  Classes / aliases /
-    /// ensembles / stubs always exist at run time and are never
-    /// order-gated.  (Excluding *conditionally* defined procs would
-    /// need the CFG dominator model, which is not modelled here.)
-    ///
-    /// Emit the per-item path's pending W002 (disabled-in-dialect command)
-    /// diagnostics, re-applying the user-proc-shadowing suppression against the
-    /// merged `all_procs` (a cross-item fact unavailable to an isolated body).
-    /// No-op on the whole-file `analyse` path (W002 is emitted inline there, so
-    /// `pending_disabled_commands` is empty) — keeping the two paths
-    /// byte-identical.  The position guard (`name_span.start() < call.start()`)
-    /// matches the inline check, so a unique-named proc resolves identically
-    /// whether checked inline or here (duplicate proc names already force the
-    /// per-item path to fall back).
+    /// Idempotent: drains `pending_disabled_commands`, so a second call is a
+    /// no-op.
     pub(in crate::analyser) fn flush_disabled_command_diagnostics(&mut self) {
+        if self.pending_disabled_commands.is_empty() {
+            return;
+        }
+        let facts = UserResolutionFacts::build(self);
         let pending = std::mem::take(&mut self.pending_disabled_commands);
-        for (qualified, diag) in pending {
-            if let Some(def) = self.result.all_procs.get(&qualified)
-                && def.name_span.start() < diag.span.start()
-            {
+        for (cmd_name, ns, enforce_order, diag) in pending {
+            let call_off = diag.span.start();
+            if facts.resolves_to_user(&cmd_name, &ns, enforce_order, call_off) {
                 continue;
             }
             self.result.diagnostics.push(diag);
         }
     }
 
+    /// Post-walk flush of the [`Self::pending_arity`] / [`Self::pending_user_call_arity`]
+    /// candidates collected by [`Self::emit_arity_diagnostics`] and
+    /// [`Self::queue_user_call_arity_candidate`].
+    ///
+    /// The [`Self::pending_arity`] half drops a candidate exactly when
+    /// [`UserResolutionFacts::resolves_to_user`] says the call **resolves
+    /// to** a user definition rather than the builtin whose registry arity
+    /// produced it — resolution follows Tcl's rule for unqualified commands
+    /// (the call-site namespace, then global `::`), using the namespace
+    /// captured at emit time.  So `proc ::ns::close {...}` suppresses a
+    /// `close` call inside `::ns` (and a qualified `::ns::close ...`), but a
+    /// `close` call in another namespace still resolves to the builtin and
+    /// is checked.  Document-global declarations — inline `# tcl-lsp:
+    /// stub`s — suppress by bare name regardless of namespace.
+    ///
+    /// Suppression by a shadowing **proc** or **rename target** also honours
+    /// definition reachability: a top-level call (one whose `enforce_order`
+    /// flag is set — module body, `namespace eval` body, or a conditional)
+    /// is silenced only when the definition lexically precedes it, since
+    /// top-level commands run in source order during load (so a `close x y
+    /// z` *before* a later `proc close` still reaches the builtin).
+    /// Proc-body calls run after load and are not order-gated.  Classes /
+    /// aliases / ensembles / stubs always exist at run time and are never
+    /// order-gated.  (Excluding *conditionally* defined procs would need the
+    /// CFG dominator model, which is not modelled here.)
+    ///
     /// Idempotent: drains `pending_arity` and `pending_user_call_arity`,
     /// so a second call is a no-op.
     pub fn flush_arity_diagnostics(&mut self) {
         if self.pending_arity.is_empty() && self.pending_user_call_arity.is_empty() {
             return;
         }
-        // Fully-qualified non-proc user-command names the calls may
-        // resolve to (classes / aliases keyed by qualified name;
-        // ensemble namespaces *are* the command name).  These always
-        // exist by the time the script runs, so they suppress the
-        // builtin arity check regardless of definition order.
-        let mut non_proc_qnames: FxHashSet<&str> = FxHashSet::default();
-        non_proc_qnames.extend(self.result.all_classes.keys().map(String::as_str));
-        non_proc_qnames.extend(self.result.command_aliases.keys().map(String::as_str));
-        non_proc_qnames.extend(self.ensemble_namespaces.iter().map(String::as_str));
-        // Qualified proc name → definition offset (the proc-name
-        // token start).  A shadowing proc only silences a *top-level*
-        // call (`enforce_order`) when its definition lexically
-        // precedes the call; proc-body calls are not order-gated.
-        // Conditional / nested definitions are still treated as
-        // shadowing here — distinguishing unconditionally-reachable
-        // definitions needs the CFG dominator model, which is not
-        // modelled here.
-        let proc_offsets: FxHashMap<&str, u32> = self
-            .result
-            .all_procs
-            .iter()
-            .map(|(qname, def)| (qname.as_str(), def.name_span.start()))
-            .collect();
-        // Inline stubs are document-global and unqualified.
-        let stub_names = super::utils::scan_stub_command_names(&self.source);
+        let facts = UserResolutionFacts::build(self);
 
         let pending = std::mem::take(&mut self.pending_arity);
         for (cmd_name, ns, enforce_order, diag) in pending {
-            let bare = cmd_name.rsplit("::").next().unwrap_or(&cmd_name);
-            // Candidate qualified names this call could resolve to.
-            let candidates = qualify_candidates(&ns, &cmd_name);
-            // A proc shadows only when reachable at the call: top-level
-            // calls require the definition to lexically precede them
-            // (`def_off < call_off`); proc-body calls accept any
-            // same-named definition.  Classes / aliases / ensembles /
-            // stubs are not order-gated.
             let call_off = diag.span.start();
-            let resolves_to_user = candidates.iter().any(|c| {
-                non_proc_qnames.contains(c.as_str())
-                    || proc_offsets
-                        .get(c.as_str())
-                        .is_some_and(|&def_off| !enforce_order || def_off < call_off)
-            }) || stub_names.contains(bare);
-            if resolves_to_user {
+            if facts.resolves_to_user(&cmd_name, &ns, enforce_order, call_off) {
                 continue;
             }
             self.result.diagnostics.push(diag);
@@ -968,10 +1098,10 @@ impl Analyser {
         let user_pending = std::mem::take(&mut self.pending_user_call_arity);
         for cand in user_pending {
             let bare = cand.cmd_name.rsplit("::").next().unwrap_or(&cand.cmd_name);
-            if stub_names.contains(bare) {
+            if facts.stub_names.contains(bare) {
                 continue;
             }
-            let Some(arity) = self.resolve_indirect_call_target(&cand, &proc_offsets) else {
+            let Some(arity) = self.resolve_indirect_call_target(&cand, &facts.proc_offsets) else {
                 continue;
             };
             if let Some(diag) = arity_verdict(
@@ -1261,7 +1391,7 @@ impl Analyser {
     fn resolve_indirect_call_target(
         &self,
         cand: &PendingUserCallArity,
-        proc_offsets: &FxHashMap<&str, u32>,
+        proc_offsets: &FxHashMap<String, u32>,
     ) -> Option<Arity> {
         const MAX_HOPS: u8 = 8;
         let mut cur = cand.cmd_name.clone();

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -2220,20 +2220,19 @@ impl Analyser {
         }
     }
 
-    /// Resolve a command name to the `ProcDef` that implements
-    /// it, walking the scope chain from `scope_path` outwards.
+    /// Resolve a command name to the `ProcDef` that implements it, following
+    /// Tcl's real bareword command resolution via
+    /// [`crate::naming::bareword_resolution_candidates`] — the current
+    /// namespace (computed by [`Self::command_resolution_namespace`]) first,
+    /// then global, exactly two levels, never every enclosing ancestor
+    /// namespace on the scope chain (Tcl's own command lookup does not walk
+    /// intermediate namespaces absent an explicit `namespace path`).
     ///
-    /// Candidate name build-up:
+    /// Shared with the optimiser's identical same-file resolution
+    /// (`resolve_proc_qname`) and the disabled-command / arity suppression
+    /// checks' resolution (`UserResolutionFacts::resolves_to_user`) so the
+    /// three can't diverge on the same rule.
     ///
-    /// - Absolute name (`::foo`) → look up directly.
-    /// - Qualified relative (`a::b`) → prepend `::` and look up.
-    /// - Bare name → walk up the scope chain; for every
-    ///   ``namespace`` scope on the chain, prepend its name and
-    ///   try; finally fall back to global ``::name``.
-    ///
-    /// All candidate names are run through
-    /// [`crate::naming::normalise_qualified_name`] so the lookup
-    /// keys match the canonical form ``result.all_procs`` uses.
     /// Returns the first matching ``ProcDef`` (by reference into
     /// ``result.all_procs``), or `None` if no candidate is known.
     #[must_use]
@@ -2242,54 +2241,13 @@ impl Analyser {
         cmd_name: &str,
         scope_path: &[usize],
     ) -> Option<&super::types::ProcDef> {
-        use std::collections::HashSet;
         if cmd_name.is_empty() {
             return None;
         }
-
-        let mut candidates: Vec<String> = Vec::new();
-        let mut seen: HashSet<String> = HashSet::new();
-        let mut add_candidate = |raw: &str| {
-            let qname = crate::naming::normalise_qualified_name(raw);
-            if qname.is_empty() || seen.contains(&qname) {
-                return;
-            }
-            seen.insert(qname.clone());
-            candidates.push(qname);
-        };
-
-        if cmd_name.starts_with("::") {
-            add_candidate(cmd_name);
-        } else if cmd_name.contains("::") {
-            add_candidate(&format!("::{cmd_name}"));
-        } else {
-            // Walk the scope chain — every namespace scope on the
-            // chain contributes a candidate ``<ns_name>::<cmd>``.
-            // The walk is longest-first (current scope before its
-            // ancestors).
-            let mut cursor: &super::types::Scope = &self.result.global_scope;
-            let mut walked: Vec<&super::types::Scope> = vec![cursor];
-            for &idx in scope_path {
-                let Some(child) = cursor.children.get(idx) else {
-                    break;
-                };
-                walked.push(child);
-                cursor = child;
-            }
-            for scope in walked.iter().rev() {
-                if scope.kind == super::types::ScopeKind::Namespace {
-                    add_candidate(&format!("{}::{cmd_name}", scope.name));
-                }
-            }
-            add_candidate(&format!("::{cmd_name}"));
-        }
-
-        for qname in &candidates {
-            if let Some(proc) = self.result.all_procs.get(qname) {
-                return Some(proc);
-            }
-        }
-        None
+        let ns = self.command_resolution_namespace(scope_path);
+        crate::naming::bareword_resolution_candidates(&ns, cmd_name)
+            .into_iter()
+            .find_map(|qname| self.result.all_procs.get(&qname))
     }
 
     /// Static element count for a `{*}`-expanded word.
@@ -3780,6 +3738,78 @@ mod tests {
         let resolved = a.resolve_proc_call("a::b", &[]);
         assert!(resolved.is_some());
         assert_eq!(resolved.unwrap().qualified_name, "::a::b");
+    }
+
+    #[test]
+    fn resolve_proc_call_relative_dotted_name_prefers_current_namespace() {
+        // A relative dotted word (`ns2::inner`, containing `::` but not
+        // starting with it) must resolve against the current namespace
+        // first, not be rooted straight at global (confirmed against tclsh
+        // 9.0.4 — see `bareword_resolution_candidates`).
+        use crate::analyser::types::{Scope, ScopeKind};
+        let mut a = Analyser::new();
+        for qname in ["::ns2::inner", "::ns::ns2::inner"] {
+            a.result.all_procs.insert(
+                qname.to_string(),
+                super::ProcDef {
+                    name: "inner".to_string(),
+                    qualified_name: qname.to_string(),
+                    params: Vec::new(),
+                    name_span: span(0, 0),
+                    body_span: span(0, 0),
+                    doc: String::new(),
+                    param_traits: std::collections::HashMap::new(),
+                },
+            );
+        }
+        a.result
+            .global_scope
+            .children
+            .push(Scope::new(ScopeKind::Namespace, "ns"));
+        let resolved = a.resolve_proc_call("ns2::inner", &[0]);
+        assert_eq!(
+            resolved.unwrap().qualified_name,
+            "::ns::ns2::inner",
+            "must prefer the current-namespace proc over the root one",
+        );
+        // Falls back to the root proc when there is no current-namespace
+        // candidate.
+        let resolved = a.resolve_proc_call("ns2::inner", &[]);
+        assert_eq!(resolved.unwrap().qualified_name, "::ns2::inner");
+    }
+
+    #[test]
+    fn resolve_proc_call_does_not_walk_ancestor_namespaces() {
+        // Real Tcl bareword resolution is exactly two levels — current
+        // namespace, then global — absent an explicit `namespace path`. A
+        // proc defined in a *grandparent* namespace must not resolve for a
+        // bare call from a nested `::a::b::c` scope.
+        use crate::analyser::types::{Scope, ScopeKind};
+        let mut a = Analyser::new();
+        let mut ns_a = Scope::new(ScopeKind::Namespace, "a");
+        let mut ns_b = Scope::new(ScopeKind::Namespace, "b");
+        ns_b.children.push(Scope::new(ScopeKind::Namespace, "c"));
+        ns_a.children.push(ns_b);
+        a.result.global_scope.children.push(ns_a);
+        // scope_path [0] = ::a — define `foo` there.
+        a.handle_proc_command(
+            "proc",
+            &["foo".to_string(), String::new(), String::new()],
+            &[
+                esc_tok(span(5, 8)),
+                str_tok(span(9, 11)),
+                str_tok(span(12, 14)),
+            ],
+            &[0],
+        );
+        // Resolving from ::a::b::c (scope_path [0, 0, 0]) must NOT reach
+        // the grandparent's ::a::foo.
+        assert!(
+            a.resolve_proc_call("foo", &[0, 0, 0]).is_none(),
+            "a grandparent-namespace proc must not resolve for a bare call",
+        );
+        // Control: resolving directly from ::a still finds it.
+        assert!(a.resolve_proc_call("foo", &[0]).is_some());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -464,12 +464,12 @@ impl Analyser {
                 self.record_var_read(&name, shift(span, delta), &[]);
             }
         }
-        // Re-defer the body's would-be-W002 sites with rebased spans; the tail
-        // re-applies the shadow check against the merged `all_procs`.
-        for (qname, mut diag) in frag.disabled_commands {
-            diag.span = shift(diag.span, delta);
-            self.pending_disabled_commands.push((qname, diag));
-        }
+        // Re-defer the body's would-be-W002 sites (already rebased by
+        // `rebase_fragment`); the tail re-applies the shadow check against
+        // the merged `all_procs` / `command_aliases` / `renamed_commands` /
+        // `all_classes` / `ensemble_namespaces`.
+        self.pending_disabled_commands
+            .extend(frag.disabled_commands);
         // Re-defer the body's source-dependent W304 sites, rebasing the token,
         // fix, and diagnostic spans to absolute; the tail classifies each `$var`
         // against the full file source.
@@ -506,12 +506,16 @@ pub struct BodyFragment {
     /// Qualified (`::`/`static::`) reads that missed the isolated body's empty
     /// enclosing global scope; replayed on the shell's real globals at graft.
     global_reads: Vec<(String, tcl_lexer::Span)>,
-    /// W002 (disabled-in-dialect command) sites whose user-proc-shadowing
-    /// suppression depends on the file's full `all_procs` (a cross-item fact the
-    /// isolated body lacks): `(qualified call name, deferred diagnostic)`.  The
-    /// graft rebases the diagnostic span and re-defers it; the tail re-checks the
-    /// shadow against the merged `all_procs`.
-    disabled_commands: Vec<(String, super::types::Diagnostic)>,
+    /// W002 (disabled-in-dialect command) sites — always deferred (see
+    /// [`super::state::Analyser::pending_disabled_commands`]), so this is
+    /// simply the isolated body's own queue: `(command name, call-site
+    /// namespace, enforce_order, deferred diagnostic)`, the same shape as
+    /// [`Self::pending_arity`]. `rebase_fragment` rebases the diagnostic span
+    /// in place; the graft re-defers it onto the shell's queue and the tail
+    /// re-checks the shadow against the merged `all_procs` /
+    /// `command_aliases` / `renamed_commands` / `all_classes` /
+    /// `ensemble_namespaces`.
+    disabled_commands: Vec<(String, String, bool, super::types::Diagnostic)>,
     /// Deferred W304 (missing `--`) sites whose `$var` classification needs the
     /// whole-file most-recent-`set` resolution (invisible to an isolated body).
     /// The graft rebases the token + fix + diagnostic spans; the tail classifies
@@ -780,6 +784,9 @@ fn rebase_fragment(frag: &mut BodyFragment, d: u32, line_delta: i32) {
         }
     }
     for (_, _, _, diag) in &mut frag.pending_arity {
+        rebase_diag(diag, d);
+    }
+    for (_, _, _, diag) in &mut frag.disabled_commands {
         rebase_diag(diag, d);
     }
     for cand in &mut frag.pending_user_call_arity {

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -346,17 +346,23 @@ pub struct Analyser {
     /// def — one of the divergences the per-item path must reproduce.  `None` on
     /// the whole-file `analyse` path (reads resolve against the populated scope).
     pub(super) capture_global_reads: Option<Vec<(String, tcl_lexer::Span)>>,
-    /// Deferred W002 (disabled-in-dialect command) diagnostics whose
-    /// user-proc-shadowing suppression is a **cross-item** fact (the file's full
-    /// `all_procs`).  On the per-item path an isolated body has only its own
-    /// procs, so a would-be-W002 site that the body can't prove shadowed is
-    /// captured here (qualified call name + the built diagnostic) instead of
-    /// emitted; [`Self::graft_proc_body`] rebases the span and
-    /// [`Self::flush_disabled_command_diagnostics`] re-applies the shadow check
-    /// against the merged `all_procs` in the tail.  Empty on the whole-file
-    /// `analyse` path (W002 is emitted inline there), so the tail flush is a
-    /// no-op — byte-identical.
-    pub(super) pending_disabled_commands: Vec<(String, super::types::Diagnostic)>,
+    /// Deferred W002 (disabled-in-dialect command) diagnostics — both the
+    /// whole-command form ([`Self::emit_w002_disabled_command`]) and the
+    /// subcommand form embedded in
+    /// [`Self::emit_w001_unknown_subcommand`]. Always deferred (never emitted
+    /// inline) because the user-definition-shadowing suppression check needs
+    /// the fully-merged, whole-file facts (`all_procs`, `command_aliases`,
+    /// `renamed_commands`, `all_classes`, `ensemble_namespaces`) — on the
+    /// per-item path an isolated body only has its own, so a would-be-W002
+    /// site that the body can't prove shadowed is captured here as `(command
+    /// name, call-site namespace, enforce_order, diagnostic)` — the same
+    /// shape as [`Self::pending_arity`] — and [`Self::graft_proc_body`]
+    /// rebases the span via [`super::per_item::rebase_fragment`].
+    /// [`Self::flush_disabled_command_diagnostics`] resolves every candidate
+    /// (both paths alike) against the merged facts in the tail, using the
+    /// same current-namespace-then-global resolution and top-level order gate
+    /// as [`Self::flush_arity_diagnostics`].
+    pub(super) pending_disabled_commands: Vec<(String, String, bool, super::types::Diagnostic)>,
     /// Deferred W304 (missing `--` option terminator) diagnostics whose
     /// severity/message depend on resolving a `$var` against the **most recent
     /// literal `set` in the whole file** ([`last_literal_set_value_for_var`],

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -349,13 +349,18 @@ pub fn collect_call_by_name_reads(
 
 // Call-target resolution
 
-/// Resolve a command name to a qualified procedure name if it
-/// refers to one defined in `known`.
+/// Resolve a command name to a qualified procedure name if it refers to one
+/// defined in `known`, via [`crate::naming::bareword_resolution_candidates`]
+/// — Tcl's real bareword resolution: an absolute name (`::foo`) is looked up
+/// directly; a relative *dotted* name (`inner::p`) resolves against the
+/// caller's own namespace first, then global; a bare name tries the
+/// caller's namespace then global — exactly two levels, never every
+/// enclosing ancestor namespace (Tcl's own command lookup does not walk
+/// intermediate namespaces absent an explicit `namespace path`).
 ///
-/// Rules mirror Tcl's name resolution: absolute names (starting
-/// with `::`) are looked up directly; names containing `::` but
-/// not starting with it are treated as global-relative; bare
-/// names are resolved by walking up the caller's namespace path.
+/// Shared with the analyser's identical same-file resolution
+/// (`Analyser::resolve_proc_call`) and the optimiser's
+/// (`resolve_proc_qname`) so the three can't diverge on the same rule.
 #[must_use]
 pub fn resolve_internal_call<S: std::hash::BuildHasher>(
     command: &str,
@@ -365,36 +370,15 @@ pub fn resolve_internal_call<S: std::hash::BuildHasher>(
     if command.is_empty() {
         return None;
     }
-
-    if command.starts_with("::") {
-        let qname = normalise_qualified_name(command);
-        return known.contains(qname.as_str()).then_some(qname);
-    }
-
-    if command.contains("::") {
-        let qname = normalise_qualified_name(&format!("::{command}"));
-        return known.contains(qname.as_str()).then_some(qname);
-    }
-
     let ns_parts = namespace_parts_from_proc(caller_qname);
-    for depth in (0..=ns_parts.len()).rev() {
-        let mut candidate = String::from("::");
-        for (i, part) in ns_parts[..depth].iter().enumerate() {
-            if i > 0 {
-                candidate.push_str("::");
-            }
-            candidate.push_str(part);
-        }
-        if depth > 0 {
-            candidate.push_str("::");
-        }
-        candidate.push_str(command);
-        let qname = normalise_qualified_name(&candidate);
-        if known.contains(qname.as_str()) {
-            return Some(qname);
-        }
-    }
-    None
+    let ns = if ns_parts.is_empty() {
+        "::".to_owned()
+    } else {
+        format!("::{}", ns_parts.join("::"))
+    };
+    crate::naming::bareword_resolution_candidates(&ns, command)
+        .into_iter()
+        .find(|qname| known.contains(qname.as_str()))
 }
 
 /// Top-level call-target resolver. Convenience wrapper that
@@ -2157,7 +2141,8 @@ mod tests {
 
     #[test]
     fn resolve_relative_with_segments() {
-        // `foo::bar` from any caller → `::foo::bar`.
+        // `foo::bar` from a global-level caller → `::foo::bar` (the only
+        // candidate, since the caller's own namespace is already `::`).
         let known = known_set(&["::foo::bar"]);
         assert_eq!(
             resolve_internal_call("foo::bar", "::top", &known),
@@ -2166,13 +2151,40 @@ mod tests {
     }
 
     #[test]
-    fn resolve_bare_walks_caller_namespace() {
-        // caller `::ns::a::caller` + bare `helper` → try
-        // `::ns::a::helper`, `::ns::helper`, `::helper` in order.
+    fn resolve_relative_dotted_name_prefers_caller_namespace() {
+        // A relative dotted word (`ns2::inner`) resolves against the
+        // caller's own namespace first, not straight at global (confirmed
+        // against tclsh 9.0.4 — see `bareword_resolution_candidates`).
+        let known = known_set(&["::ns::ns2::inner", "::ns2::inner"]);
+        assert_eq!(
+            resolve_internal_call("ns2::inner", "::ns::caller", &known),
+            Some("::ns::ns2::inner".into()),
+            "must prefer the caller-namespace proc over the root one",
+        );
+        // No caller-namespace candidate → falls back to the root proc.
+        assert_eq!(
+            resolve_internal_call("ns2::inner", "::top", &known),
+            Some("::ns2::inner".into()),
+        );
+    }
+
+    #[test]
+    fn resolve_bare_does_not_walk_ancestor_namespaces() {
+        // Real Tcl bareword resolution is exactly two levels — the
+        // caller's own namespace, then global — absent an explicit
+        // `namespace path`. A proc defined in a *grandparent* namespace
+        // must not resolve for a bare call from `::ns::a::caller`.
         let known = known_set(&["::ns::helper"]);
         assert_eq!(
             resolve_internal_call("helper", "::ns::a::caller", &known),
-            Some("::ns::helper".into())
+            None,
+            "a grandparent-namespace proc must not resolve for a bare call",
+        );
+        // Control: the *direct* enclosing namespace still resolves.
+        let known2 = known_set(&["::ns::a::helper"]);
+        assert_eq!(
+            resolve_internal_call("helper", "::ns::a::caller", &known2),
+            Some("::ns::a::helper".into()),
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -1271,16 +1271,20 @@ fn parse_static_call_args(
 
 /// Resolve a call's head word to a procedure qname that has an
 /// interprocedural summary, following Tcl's real bareword command
-/// resolution:
+/// resolution via [`crate::naming::bareword_resolution_candidates`] —
+/// current namespace first, then global, exactly two levels, never every
+/// enclosing ancestor namespace (Tcl's own command lookup does not walk
+/// intermediate namespaces absent an explicit `namespace path`, which this
+/// analysis does not model — a body using it is more conservatively left
+/// unresolved here rather than risk folding to the wrong proc).
 ///
-/// * a `::`-qualified word is taken as-is;
-/// * a word containing `::` (relative-qualified) is rooted at `::`;
-/// * a bare word resolves against the *current* namespace, then falls back
-///   to the global namespace — exactly two levels, **not** every enclosing
-///   ancestor namespace. Tcl's own command lookup does not walk
-///   intermediate namespaces absent an explicit `namespace path` (which
-///   this analysis does not model — a body using it is more conservatively
-///   left unresolved here rather than risk folding to the wrong proc).
+/// Shared with the analyser's identical same-file resolution chase
+/// (`Analyser::resolve_indirect_call_target`) so the two can't diverge on
+/// the same rule — a relative dotted word (`inner::p`) previously resolved
+/// straight to `::inner::p` here, rooted at global, when real Tcl (and the
+/// analyser side) tries the *current* namespace first
+/// (`{namespace}::inner::p`); two procs of that shape in different
+/// namespaces could fold a call to the wrong one's constant return.
 ///
 /// Returns the first candidate that has a summary, else `None`.
 fn resolve_proc_qname(
@@ -1291,35 +1295,9 @@ fn resolve_proc_qname(
     if command.is_empty() {
         return None;
     }
-    if command.starts_with("::") || command.contains("::") {
-        let qname = if command.starts_with("::") {
-            command.to_owned()
-        } else {
-            format!("::{command}")
-        };
-        return ia.procedures.contains_key(&qname).then_some(qname);
-    }
-    let current = qualify_in_namespace(namespace, command);
-    if ia.procedures.contains_key(&current) {
-        return Some(current);
-    }
-    if namespace != "::" {
-        let global = format!("::{command}");
-        if ia.procedures.contains_key(&global) {
-            return Some(global);
-        }
-    }
-    None
-}
-
-/// Qualify a bare `command` name against `namespace` (`"::"` for the root),
-/// without the doubled `::::` a naive `format!` would produce at the root.
-fn qualify_in_namespace(namespace: &str, command: &str) -> String {
-    if namespace == "::" {
-        format!("::{command}")
-    } else {
-        format!("{namespace}::{command}")
-    }
+    crate::naming::bareword_resolution_candidates(namespace, command)
+        .into_iter()
+        .find(|qname| ia.procedures.contains_key(qname))
 }
 
 /// O103: if `command` resolves to a proc with `can_fold_static_calls`
@@ -2517,6 +2495,42 @@ mod tests {
         assert_eq!(
             resolve_proc_qname("foo", "::a::b::c", &ia2).as_deref(),
             Some("::a::b::c::foo"),
+        );
+    }
+
+    #[test]
+    fn resolve_proc_qname_relative_dotted_word_prefers_current_namespace() {
+        // A relative *dotted* word (`ns2::inner`, containing `::` but not
+        // starting with it) must resolve against the current namespace
+        // first, not be rooted straight at global — the same rule
+        // `bareword_resolution_candidates` documents (confirmed against
+        // tclsh 9.0.4). Two procs of this shape exist here, one nested
+        // under `::ns` and one at the root; a bare `ns2::inner` call from
+        // inside `::ns` must reach the nearer one.
+        let module = crate::lowering::lower_to_ir(
+            "proc ns2::inner {} { return 1 }\n\
+             namespace eval ::ns {\n proc ns2::inner {} { return 2 }\n proc caller {} { ns2::inner }\n}",
+            &registry(),
+        );
+        let ia = crate::interprocedural::build_interprocedural_analysis(
+            &module,
+            &registry(),
+            None,
+            crate::interprocedural::ObjectTypeMap::none(),
+        );
+        assert!(ia.procedures.contains_key("::ns2::inner"));
+        assert!(ia.procedures.contains_key("::ns::ns2::inner"));
+        assert_eq!(
+            resolve_proc_qname("ns2::inner", "::ns", &ia).as_deref(),
+            Some("::ns::ns2::inner"),
+            "a relative dotted call must prefer the current-namespace proc \
+             over the root one",
+        );
+        // Falls back to the root proc when there is no current-namespace
+        // candidate.
+        assert_eq!(
+            resolve_proc_qname("ns2::inner", "::other", &ia).as_deref(),
+            Some("::ns2::inner"),
         );
     }
 

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -369,6 +369,167 @@ fn history_unknown_subcommand_is_still_w001_not_e001() {
     assert!(!has_code(&diags, "E001"));
 }
 
+// -- W002 (disabled-in-dialect command), end to end -----------------------
+
+/// The `(character, character)` span of the first diagnostic carrying `code`
+/// on `line`, or `None` if there isn't one.
+fn range_on_line(diags: &[Value], code: &str, line: i64) -> Option<(i64, i64)> {
+    diags.iter().find_map(|d| {
+        if code_str(d).as_deref() != Some(code) {
+            return None;
+        }
+        let range = d.get("range")?;
+        let start = range.get("start")?;
+        if start.get("line")?.as_i64()? != line {
+            return None;
+        }
+        let end = range.get("end")?;
+        Some((
+            start.get("character")?.as_i64()?,
+            end.get("character")?.as_i64()?,
+        ))
+    })
+}
+
+#[test]
+fn disabled_command_is_w002_with_a_tight_span() {
+    // `dict` is Tcl 8.5+; under `tcl8.4` the call is disabled, and the
+    // squiggle must cover exactly the 4-character `dict` token — not the
+    // whole line — so the editor highlights only the offending name.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "# tcl-dialect: tcl8.4\ndict create a 1\n");
+    let w002: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("W002"))
+        .collect();
+    assert_eq!(w002.len(), 1, "expected exactly one W002: {diags:?}");
+    assert_eq!(
+        message(w002[0]),
+        "'dict' is disabled in the active dialect profile \
+         (available in: tcl8.5, tcl8.6, tcl9.0, tcl9.1)"
+    );
+    assert_eq!(
+        range_on_line(&diags, "W002", 1),
+        Some((0, 4)),
+        "the span must cover exactly 'dict' on line 1: {diags:?}"
+    );
+}
+
+#[test]
+fn disabled_command_enabled_in_active_dialect_is_clean() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "# tcl-dialect: tcl9.0\ndict create a 1\n");
+    assert!(
+        !has_code(&diags, "W002"),
+        "dict is native in 9.0: {diags:?}"
+    );
+}
+
+#[test]
+fn disabled_subcommand_is_w002_with_a_command_plus_subcommand_span() {
+    // `package files` is Tcl 9.0+; the squiggle covers `package files`
+    // (command head through the subcommand word), not the whole call.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "package files mypackage\n");
+    assert!(
+        !has_code(&diags, "W001"),
+        "must not report as unknown: {diags:?}"
+    );
+    assert_eq!(
+        range_on_line(&diags, "W002", 0),
+        Some((0, 13)),
+        "the span must cover 'package files' (13 chars): {diags:?}"
+    );
+}
+
+#[test]
+fn disabled_command_shadowed_by_namespace_scoped_proc_is_clean() {
+    // A namespace-scoped `proc dict` shadows the disabled builtin for
+    // unqualified calls resolved inside that namespace — Tcl's real
+    // current-namespace-then-global resolution rule, not merely "was `dict`
+    // defined anywhere in the file".
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "# tcl-dialect: tcl8.4\nnamespace eval ::ns {\n    proc dict {args} { return $args }\n    dict foo bar\n}\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        !has_code(&diags, "W002"),
+        "a namespace-scoped shadowing proc must suppress W002: {diags:?}"
+    );
+}
+
+#[test]
+fn disabled_command_shadowed_by_forward_declared_proc_body_is_clean() {
+    // The shadowing proc is declared *after* the call site textually, but
+    // the call only runs (inside another proc's body) once the whole file
+    // has loaded — so the later definition is already in effect.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "# tcl-dialect: tcl8.4\nproc use_dict {} {\n    dict create a 1\n}\nproc dict {args} { return $args }\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        !has_code(&diags, "W002"),
+        "a forward-declared proc-body shadow must suppress W002: {diags:?}"
+    );
+}
+
+#[test]
+fn disabled_command_top_level_call_before_shadowing_proc_still_fires() {
+    // The mirror image: a *top-level* call before its shadowing proc's
+    // definition still reaches the disabled builtin at load time.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "# tcl-dialect: tcl8.4\ndict create a 1\nproc dict {args} { return $args }\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        has_code(&diags, "W002"),
+        "a top-level call before its shadowing proc must still fire W002: {diags:?}"
+    );
+}
+
+#[test]
+fn disabled_command_shadowed_by_interp_alias_is_clean() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "# tcl-dialect: tcl8.4\ninterp alias {} dict {} list\ndict create a 1\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        !has_code(&diags, "W002"),
+        "an interp alias establishing the name must suppress W002: {diags:?}"
+    );
+}
+
+#[test]
+fn disabled_command_shadowed_by_rename_is_clean() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "# tcl-dialect: tcl8.4\nproc myimpl {args} { return $args }\nrename myimpl dict\ndict create a 1\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        !has_code(&diags, "W002"),
+        "a rename establishing the name must suppress W002: {diags:?}"
+    );
+}
+
+#[test]
+fn disabled_subcommand_form_shadowed_by_ensemble_head_proc_is_clean() {
+    // A user `proc package` overrides the *whole* ensemble command — the
+    // call never reaches the registry `package files` subcommand check.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc package {args} { return $args }\npackage files mypackage\n",
+    );
+    assert!(
+        !has_code(&diags, "W002"),
+        "a shadowed ensemble head must suppress the subcommand-form W002: {diags:?}"
+    );
+}
+
 #[test]
 fn bare_tcloo_object_dispatch_is_e001() {
     // `set o [Dog new]; $o` — TclOO's per-object dispatcher requires a

--- a/rust/tcl-registry/src/dialects.rs
+++ b/rust/tcl-registry/src/dialects.rs
@@ -832,6 +832,63 @@ impl DialectSet {
             _ => return None,
         })
     }
+
+    /// The canonical dialect name for a single-bit set — the inverse of
+    /// [`Self::parse`]. `None` for an empty set, a combinator flag with no
+    /// single dialect name (`ALL_TCL`, `TCL85_PLUS`, …), or a multi-bit set.
+    #[must_use]
+    pub fn canonical_name(self) -> Option<&'static str> {
+        Some(match self {
+            Self::BPF => "bpf",
+            Self::TCL84 => "tcl8.4",
+            Self::TCL85 => "tcl8.5",
+            Self::TCL86 => "tcl8.6",
+            Self::TCL90 => "tcl9.0",
+            Self::TCL91 => "tcl9.1",
+            Self::IRULES => "f5-irules",
+            Self::IAPPS => "f5-iapps",
+            Self::TK => "tk",
+            Self::EXPECT => "expect",
+            Self::SYNOPSYS => "synopsys-eda-tcl",
+            Self::CADENCE => "cadence-eda-tcl",
+            Self::XILINX => "xilinx-eda-tcl",
+            Self::QUARTUS => "intel-quartus-eda-tcl",
+            Self::MENTOR => "mentor-eda-tcl",
+            _ => return None,
+        })
+    }
+
+    /// The canonical dialect names of every single bit set in `self`, in
+    /// declaration order (`TCL84` before `TCL85` before … before `MENTOR`) —
+    /// so a Tcl-version run always lists lowest-to-highest.  Combinator bits
+    /// with no single name (see [`Self::canonical_name`]) contribute nothing;
+    /// every *primitive* dialect this set contains is still listed via its
+    /// own bit.
+    #[must_use]
+    pub fn member_names(self) -> Vec<&'static str> {
+        const PRIMITIVES: &[DialectSet] = &[
+            DialectSet::TCL84,
+            DialectSet::TCL85,
+            DialectSet::TCL86,
+            DialectSet::TCL90,
+            DialectSet::TCL91,
+            DialectSet::IRULES,
+            DialectSet::IAPPS,
+            DialectSet::TK,
+            DialectSet::EXPECT,
+            DialectSet::SYNOPSYS,
+            DialectSet::CADENCE,
+            DialectSet::XILINX,
+            DialectSet::QUARTUS,
+            DialectSet::MENTOR,
+            DialectSet::BPF,
+        ];
+        PRIMITIVES
+            .iter()
+            .filter(|&&bit| self.contains(bit))
+            .filter_map(|&bit| bit.canonical_name())
+            .collect()
+    }
 }
 
 #[cfg(test)]
@@ -858,6 +915,57 @@ mod tests {
         assert_eq!(DialectSet::parse("tcl8.6"), Some(DialectSet::TCL86));
         assert_eq!(DialectSet::parse("f5-irules"), Some(DialectSet::IRULES));
         assert_eq!(DialectSet::parse("unknown"), None);
+    }
+
+    #[test]
+    fn canonical_name_is_the_exact_inverse_of_parse() {
+        // Every name `parse` accepts round-trips through `canonical_name`
+        // back to the identical string, for every primitive dialect.
+        for name in [
+            "bpf",
+            "tcl8.4",
+            "tcl8.5",
+            "tcl8.6",
+            "tcl9.0",
+            "tcl9.1",
+            "f5-irules",
+            "f5-iapps",
+            "tk",
+            "expect",
+            "synopsys-eda-tcl",
+            "cadence-eda-tcl",
+            "xilinx-eda-tcl",
+            "intel-quartus-eda-tcl",
+            "mentor-eda-tcl",
+        ] {
+            let bit = DialectSet::parse(name).unwrap_or_else(|| panic!("{name} must parse"));
+            assert_eq!(bit.canonical_name(), Some(name));
+        }
+    }
+
+    #[test]
+    fn canonical_name_is_none_for_combinators_and_empty() {
+        assert_eq!(DialectSet::empty().canonical_name(), None);
+        assert_eq!(DialectSet::ALL_TCL.canonical_name(), None);
+        assert_eq!(DialectSet::TCL85_PLUS.canonical_name(), None);
+        assert_eq!(
+            (DialectSet::TCL84 | DialectSet::TCL85).canonical_name(),
+            None
+        );
+    }
+
+    #[test]
+    fn member_names_lists_lowest_tcl_version_first() {
+        assert_eq!(
+            DialectSet::ALL_TCL.member_names(),
+            vec!["tcl8.4", "tcl8.5", "tcl8.6", "tcl9.0", "tcl9.1"]
+        );
+        assert_eq!(
+            DialectSet::TCL85_PLUS.member_names(),
+            vec!["tcl8.5", "tcl8.6", "tcl9.0", "tcl9.1"]
+        );
+        assert_eq!(DialectSet::TCL84.member_names(), vec!["tcl8.4"]);
+        assert!(DialectSet::empty().member_names().is_empty());
     }
 
     #[test]

--- a/rust/tcl-syntax/src/naming.rs
+++ b/rust/tcl-syntax/src/naming.rs
@@ -301,6 +301,48 @@ pub fn normalise_qualified_name(name: &str) -> String {
     format!("::{}", parts.join("::"))
 }
 
+/// Candidate qualified names for Tcl's real bareword command/procedure
+/// resolution, in priority order: the current namespace first, then global.
+///
+/// * An absolute name (`::foo`, `::ns::foo`) is taken as-is — one candidate.
+/// * A relative name containing `::` (`inner::p`) is still resolved against
+///   the current namespace first, **not** rooted straight at global: calling
+///   `inner::p` from inside `namespace eval ::ns { … }` reaches
+///   `::ns::inner::p` before `::inner::p`, when both exist (confirmed
+///   against tclsh 9.0.4). Only a *leading* `::` is genuinely absolute.
+/// * A bare name (`foo`) tries `{namespace}::foo` then `::foo` — exactly two
+///   levels, never every enclosing ancestor namespace (Tcl's own command
+///   lookup does not walk intermediate namespaces absent an explicit
+///   `namespace path`, which this does not model).
+///
+/// Shared by every same-file "resolve this call the way Tcl would" consumer
+/// — the analyser's same-file shadow/arity-suppression checks and the
+/// optimiser's interprocedural proc-identity resolution — so a fix to the
+/// resolution rule (or a bug in it) can't drift between them.
+///
+/// ```
+/// use tcl_syntax::naming::bareword_resolution_candidates;
+/// assert_eq!(bareword_resolution_candidates("::ns", "::foo"), vec!["::foo"]);
+/// assert_eq!(
+///     bareword_resolution_candidates("::ns", "inner::p"),
+///     vec!["::ns::inner::p", "::inner::p"],
+/// );
+/// assert_eq!(bareword_resolution_candidates("::ns", "foo"), vec!["::ns::foo", "::foo"]);
+/// assert_eq!(bareword_resolution_candidates("::", "foo"), vec!["::foo"]);
+/// ```
+#[must_use]
+pub fn bareword_resolution_candidates(namespace: &str, cmd_name: &str) -> Vec<String> {
+    if cmd_name.starts_with("::") {
+        return vec![cmd_name.to_owned()];
+    }
+    let global = format!("::{cmd_name}");
+    if namespace == "::" {
+        return vec![global];
+    }
+    let relative = format!("{namespace}::{cmd_name}");
+    vec![relative, global]
+}
+
 /// Split a Tcl variable reference into `(base, element)`.
 ///
 /// Strips `$` / `${…}` substitution sigils first, then separates the


### PR DESCRIPTION
## Summary

A deep review of W002 ("command disabled in the active dialect profile") found the same-file shadowing suppression check was much narrower than its sibling (the builtin-arity suppression check), producing several real false positives:

- **Namespace-blind**: shadow detection only ever checked the *global* qualified name (`normalise_qualified_name(bare)` → `::name`), so a namespace-scoped `proc ::ns::dict {...}` never suppressed W002 for `dict` calls resolved inside `::ns` — Tcl's real current-namespace-then-global resolution was never consulted.
- **Wrong order-gating**: the check always order-gated the shadowing proc's definition against the call site, even for calls inside another proc's *body* — but proc-body calls only run after the whole file has loaded, so a forward-declared shadowing proc (a very common "helpers defined after use" pattern) was incorrectly still flagged.
- **`interp alias` / static `rename` were never consulted** — a script legitimately providing the disabled name via `interp alias {} dict {} …` or `rename myimpl dict` still drew W002.
- **The subcommand form** (e.g. `package files`, version-gated in the registry) never checked whether the *base* ensemble command itself was shadowed by a user proc — `proc package {args} {…}` still let `package files …` fire, even though the call never reaches the registry ensemble at all.

## Fix — W002

- Rearchitected both W002 emitters (`emit_w002_disabled_command` and the subcommand form embedded in `emit_w001_unknown_subcommand`) to always defer to a post-walk flush — mirroring the arity-check's `pending_arity` pipeline — instead of the previous inline-on-whole-file / deferred-on-per-item split, so forward references resolve correctly on both paths.
- Extracted a shared `UserResolutionFacts` resolver (namespace + order-aware resolution against `all_procs` / `all_classes` / `command_aliases` / `renamed_commands` / `ensemble_namespaces` / inline stubs) used by both `flush_disabled_command_diagnostics` and `flush_arity_diagnostics`, so the two checks can't drift apart again — this also fixed an identical `rename`-target blind spot the arity check independently had.
- Enriched the W002 message with a registry-driven `(available in: tcl8.5, tcl8.6, …)` hint — entirely data-driven from `CommandSpec.dialects` / `SubCommand.dialects` via two new generic `DialectSet` methods (`canonical_name`, `member_names`); no per-command logic added anywhere.
- Updated the W002 KCS note (also fixed a stale `# dialect:` pragma example and message text that predated the current wording).

## Fix — centralising Tcl bareword command resolution (post-rebase follow-up)

Rebasing onto `origin/rust` (which had since merged #857/#858/#859, closing related arity/rename gaps) surfaced that the current-namespace-then-global resolution rule `UserResolutionFacts` relies on had **three other independent, hand-rolled implementations** elsewhere in the codebase, each subtly buggy in one or both of the same two ways:

- A relative dotted word (`inner::p`, containing `::` but not starting with it) was rooted straight at global instead of trying the current namespace first (confirmed wrong against tclsh 9.0.4).
- `Analyser::resolve_proc_call` (go-to-definition / W125 / IRULE5005 / tcltest-symbol suppression) and `interprocedural::resolve_internal_call` (interprocedural + taint analysis call-graph edges) both walked *every* enclosing ancestor namespace instead of exactly two levels — the same over-approximation bug #859 had already found and fixed in the optimiser's `resolve_proc_qname`, but which was never touched in these two siblings.

Extracted the one correct, tclsh-verified algorithm into `tcl_syntax::naming::bareword_resolution_candidates` and rewired all four call sites (the W002/E002/E003 shadow-suppression checks, `resolve_proc_call`, `resolve_proc_qname`, `resolve_internal_call`) to build their candidate list through it, so a fix — or a bug — in the rule can no longer drift between them. Also rewrote the stale Python-era `docs/design/compiler/namespace-resolution.md`, which had been documenting the ancestor-walk bug as the intended design.

No new `#[allow(...)]`/`#[expect(...)]` were added anywhere in this PR.

## Validation

- `cargo test -p tcl-compiler -p tcl-registry -p tcl-syntax` — full suite, **3812 tests, 0 failures**, including 11 TP/FP/TN/FN unit tests for W002 (`fp_nab_13_*`), 4 arity/rename regression tests, and 5 new namespace-resolution regression tests (one per fixed call site, pinning both the relative-dotted-name and ancestor-namespace-walk fixes).
- `cargo test -p tcl-lsp-server --test e2e` — **679 tests, 0 failures**, including 9 new native lsp_e2e tests for W002 with span-tightness assertions.
- `make test-ext` — full VS Code extension suite, including a new fixture (`testFixture/w002.tcl`) and integration test; passed cleanly (isolated re-run of the suites that flaked under repeated heavy Electron/xvfb runs during my own iteration confirmed environmental, not a regression).
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --check` — clean.
- `make rust-check` (fmt + clippy + all `xtask` drift/generation gates) — clean, nothing needed regenerating.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — W002's shadow-suppression scope widened (namespace-aware, alias/rename/ensemble-aware) with a dialect-availability hint; the shared bareword-resolution fix also changes `resolve_proc_call` / `resolve_internal_call` / `resolve_proc_qname` behaviour for relative-dotted names and ancestor-namespace calls.
- [x] Updated relevant docs: `docs/kcs/codes/kcs-diagnostic-w002-command-disabled-in-dialect.md` and `docs/design/compiler/namespace-resolution.md` (existing docs updated in place — no new note needing separate linking).
