### PR TITLE
T101: registry-driven sink classification, TclOO/alias coverage gaps, tight spans, quick fix

### DIFF
--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -312,4 +312,40 @@ suite("Code Actions", () => {
     );
     assert.ok(collectFix, "Should provide a collect bootstrap quick fix");
   });
+
+  test("provides quick fix for T101 (tainted data into puts)", async () => {
+    const t101Uri = getDocUri("taint-t101.tcl");
+    await activate(t101Uri);
+    const diagnostics = await waitForDiagnostics(t101Uri, {
+      predicate: (diags) =>
+        diags.some((d) => {
+          const code = typeof d.code === "object" ? d.code.value : d.code;
+          return code === "T101";
+        }),
+    });
+
+    const t101 = diagnostics.find((d) => {
+      const code = typeof d.code === "object" ? d.code.value : d.code;
+      return code === "T101";
+    });
+    assert.ok(t101, "T101 diagnostic should be present");
+    // The diagnostic must highlight only the tainted `$x` argument, not the
+    // whole `puts $x` statement.
+    assert.strictEqual(t101.range.start.character, t101.range.end.character - 2);
+
+    const actions = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", t101Uri, t101.range),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => typeof a.title === "string" && a.title.includes("strip CR/LF"),
+        ),
+      { timeout: 10_000, label: "T101 sanitise quick fix" },
+    )) as vscode.CodeAction[];
+
+    const sanitiseFix = actions.find(
+      (a) => typeof a.title === "string" && a.title.includes("strip CR/LF"),
+    );
+    assert.ok(sanitiseFix, "Should provide a strip-CR/LF sanitise quick fix");
+  });
 });

--- a/editors/vscode/testFixture/taint-t101.tcl
+++ b/editors/vscode/testFixture/taint-t101.tcl
@@ -1,0 +1,8 @@
+# Fixture for the T101 (tainted data into `puts`) VS Code extension test.
+#
+# `gets stdin` is a taint source; the untransformed value flowing straight
+# into `puts` is the T101 output-injection sink the quick fix should offer
+# to sanitise (strip CR/LF) before printing.
+
+set x [gets stdin]
+puts $x

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sty.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sty.rs
@@ -186,6 +186,36 @@ fn fp_sty_04_lassign_destructure_channels_no_w126() {
     );
 }
 
+#[test]
+fn tp_sty_04_puts_non_channel_literal_still_fires_w126() {
+    // TP control for FP-STY-04: `puts` now declares its `channelId`
+    // argument's position (via a dynamic `arg_role_resolver`, since the
+    // optional leading `-nonewline` shifts it), so a value that provably
+    // isn't a channel in that slot must still fire W126 — the fix above
+    // only silences the *destructured, type-unknown* case, not a
+    // genuinely wrong literal.
+    let src = "puts \"not_a_channel\" hello";
+    assert!(
+        fires(src, D, "W126"),
+        "TP: a non-channel literal in puts's channelId position must fire W126; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn tn_sty_04_puts_single_arg_is_content_not_channel() {
+    // TN control: `puts hello` has only ONE positional arg — per Tcl
+    // semantics that's the content string (written to stdout), not a
+    // channel — so no Channel-role position applies and W126 must stay
+    // silent (there is nothing to misclassify as a channel).
+    let src = "puts hello";
+    assert!(
+        !fires(src, D, "W126"),
+        "TN: puts's sole positional arg is content, not a channel; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
 // ---------------------------------------------------------------------------
 // FP-STY-05 — W302 catch fire-and-forget (bare + subcommand-aware)
 // ---------------------------------------------------------------------------

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1173,6 +1173,26 @@ impl CompilationUnit {
         self.functions().chain(extra)
     }
 
+    /// Like [`Self::all_body_function_units`] but skips complexity-guarded
+    /// bodies — the coverage-complete counterpart to
+    /// [`Self::analysable_functions`].
+    ///
+    /// `compiler_checks::run_all_checks` (SCCP / GVN / shimmer / taint) used
+    /// to iterate [`Self::analysable_functions`], which — per that method's
+    /// "backwards compatibility" note — never reached `TclOO` method bodies
+    /// or synthetic `apply`/`namespace eval` body units: a tainted value
+    /// flowing into `puts` (or any other sink) *inside a method* produced no
+    /// diagnostic at all, even though the optimiser's whole-module pass
+    /// already iterates `cu.methods` directly (`optimiser::manager`) and
+    /// `all_body_function_units` already exists for other coverage-complete
+    /// analyses (regex-source tracking). This is the drop-in replacement
+    /// that closes that gap without reintroducing a guarded body (whose
+    /// trivial lattices would contribute noise, not findings) — see
+    /// `compiler_checks::push_taint_and_module_checks`.
+    pub fn analysable_body_function_units(&self) -> impl Iterator<Item = &FunctionUnit> {
+        self.all_body_function_units().filter(|fu| !fu.complexity_guarded)
+    }
+
     /// The synthetic body units (`apply` / `namespace eval`) alone, name-sorted.
     pub fn body_function_units(&self) -> impl Iterator<Item = &FunctionUnit> {
         let mut v: Vec<&FunctionUnit> = self.body_units.values().collect();

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1190,7 +1190,8 @@ impl CompilationUnit {
     /// trivial lattices would contribute noise, not findings) — see
     /// `compiler_checks::push_taint_and_module_checks`.
     pub fn analysable_body_function_units(&self) -> impl Iterator<Item = &FunctionUnit> {
-        self.all_body_function_units().filter(|fu| !fu.complexity_guarded)
+        self.all_body_function_units()
+            .filter(|fu| !fu.complexity_guarded)
     }
 
     /// The synthetic body units (`apply` / `namespace eval`) alone, name-sorted.

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -270,7 +270,7 @@ pub fn run_all_checks_with_solved_and_patterns(
     // memoise it per procedure on the offset-0 `FnLatticeKey` (SRV-INCREMENTAL
     // 2a): an unedited procedure's checks are a cache hit instead of recomputed
     // over the whole unit every edit.
-    for fu in cu.analysable_functions() {
+    for fu in cu.analysable_body_function_units() {
         for d in function_nontaint_checks(fu, registry, dialect) {
             out.push(shift(fu, d));
         }
@@ -363,7 +363,7 @@ pub fn push_taint_and_module_checks(
     // per-function `fu.taints` for the warning families so a tainted argument
     // flowing into a callee parameter and then a sink is reported (cross-proc
     // entry-taint).
-    for fu in cu.analysable_functions() {
+    for fu in cu.analysable_body_function_units() {
         let taints = solved.taints_for(&fu.name, &fu.taints);
         for w in find_taint_warnings(
             &fu.cfg,

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -84,19 +84,19 @@
 //! [`Traits::EVALUATES_CODE`] flags inside `find_taint_warnings`.
 
 use std::collections::{HashMap, HashSet};
-use tcl_core_types::DiagCode;
+use tcl_core_types::{DiagCode, DiagFamily};
 
 use bitflags::bitflags;
 use rustc_hash::FxHashSet;
 
 use tcl_lexer::{Lexer, SourceMap, Span, TokenType, backslash_subst};
 use tcl_registry::dialects::DialectSet;
-use tcl_registry::{CommandRegistry, Traits};
+use tcl_registry::{ArgRole, CommandRegistry, Traits};
 
 use crate::cfg::{BlockId, Function as CfgFunction, Terminator};
 use crate::expr_ast::ExprNode;
 use crate::interprocedural::InterproceduralAnalysis;
-use crate::ir::Statement;
+use crate::ir::{CommandTokens, Statement};
 use crate::naming::normalise_var_name;
 use crate::rendered_properties::{RenderedProperties, RenderedValueProps};
 use crate::sccp::{SccpResult, cfg_order};
@@ -1245,87 +1245,64 @@ fn propagate_statement_taints(
 /// statement that acts as a taint sink, or `None` if the statement is
 /// not a sink.
 ///
-/// Covers:
-/// - **T100** — code-execution sinks (`eval`, `exec`, `uplevel`,
-///   `subst`, `expr` via `EVALUATES_CODE` / `TAINT_SINK` traits).
-/// - **T101** — output sinks (`puts`).
-/// - **IRULE3001 / IRULE3002 / IRULE3003 / IRULE3004** — iRules output
-///   sinks, only under the `"f5-irules"` / `"irules"` dialect. See
-///   [`classify_irules_sink`].
+/// Single registry-driven classification via
+/// [`tcl_registry::taint::classify_taint_sinks`] — no command name is
+/// matched here. The registry's most specific fact wins: a command that
+/// declares an explicit output/log sink code (`puts` → `taint_output_sink
+/// = "T101"`, `HTTP::respond` → `"IRULE3001"`, `log` → `taint_log_sink =
+/// "IRULE3003"`) is classified as that sink, even when it also carries the
+/// generic `TAINT_SINK` trait; only a command with *no* declared sink code
+/// falls back to the trait-driven **T100** code-execution classification
+/// (`EVALUATES_CODE` / `TAINT_SINK` — `eval`, `exec`, `uplevel`, `subst`,
+/// `expr`).
+///
+/// `classify_taint_sinks` is asked with an empty dialect (no
+/// `supports_dialect` filtering) so a dialect-restricted non-iRules sink
+/// (`exec` declares `NON_IRULES_OPERATORS`) keeps its T100 classification
+/// even in a registry that also has iRules specs loaded. The iRules-only
+/// sink codes (`IRULE…`, from `taint_output_sink` / `taint_log_sink` on
+/// iRules specs) are instead gated explicitly on the active document
+/// dialect via [`DiagCode::family`] — the same explicit `is_irules_dialect`
+/// gate [`find_setter_constraint_warnings`] uses for IRULE3101, rather than
+/// relying on whether the shared registry happens to have those specs
+/// loaded.
 fn classify_sink(
     registry: &CommandRegistry,
     command: &str,
     args: &[String],
     dialect: Option<&str>,
 ) -> Option<(DiagCode, String)> {
-    if let Some(spec) = registry.get(command) {
-        // T100: dangerous code-execution sinks.
-        if spec.traits.contains(Traits::EVALUATES_CODE) {
-            return Some((DiagCode::T100, command.to_owned()));
+    let subcommand = args.first().map(String::as_str);
+    let info = tcl_registry::taint::classify_taint_sinks(
+        registry,
+        command,
+        subcommand,
+        DialectSet::empty(),
+    );
+
+    if let Some(code_str) = info.output_sink.or(info.log_sink) {
+        let code: DiagCode = code_str.parse().unwrap_or_else(|_| {
+            panic!("registry declared unknown sink code {code_str:?} for {command}")
+        });
+        if code.family() == DiagFamily::IRule && !is_irules_dialect(dialect) {
+            return None;
         }
-        // expr, subst, exec also carry TAINT_SINK but not EVALUATES_CODE.
-        if spec.traits.contains(Traits::TAINT_SINK) {
-            // puts → T101 (output, not code execution).
-            if command == "puts" {
-                return Some((DiagCode::T101, "puts".to_owned()));
-            }
-            // Everything else with TAINT_SINK is T100.
-            return Some((DiagCode::T100, command.to_owned()));
-        }
+        let label = if info.output_sink_is_subcommand_qualified {
+            let canonical = subcommand
+                .and_then(|s| registry.get(command).and_then(|spec| spec.resolve_subcommand(s)))
+                .map_or_else(|| subcommand.unwrap_or_default(), |sub| sub.name);
+            format!("{command} {canonical}")
+        } else {
+            command.to_owned()
+        };
+        return Some((code, label));
     }
 
-    // iRules-dialect sinks. Kept after registry-driven T100/T101 so
-    // shared commands (currently none) would prefer the generic
-    // classification.
-    if is_irules_dialect(dialect)
-        && let Some(hit) = classify_irules_sink(registry, command, args)
-    {
-        return Some(hit);
+    if info.is_code_sink {
+        return Some((DiagCode::T100, command.to_owned()));
     }
 
     None
-}
-
-/// Classify iRules-specific output sinks.
-///
-/// Recognised sinks:
-///
-/// | Command                               | Code        | Label              |
-/// |---------------------------------------|-------------|--------------------|
-/// | `HTTP::respond`                       | `IRULE3001` | `HTTP::respond`    |
-/// | `HTTP::header insert\|replace`        | `IRULE3002` | `HTTP::header …`   |
-/// | `HTTP::cookie insert\|replace`        | `IRULE3002` | `HTTP::cookie …`   |
-/// | `HTTP::redirect`                      | `IRULE3004` | `HTTP::redirect`   |
-/// | `log`                                 | `IRULE3003` | `log`              |
-///
-/// TODO: once the Rust command registry carries `taint_hints` /
-/// `taint_output_sink_subcommands` metadata, replace the hardcoded
-/// command list with registry lookups.
-fn classify_irules_sink(
-    registry: &CommandRegistry,
-    command: &str,
-    args: &[String],
-) -> Option<(DiagCode, String)> {
-    // IRULE3002 output-sink subcommands come from the registry
-    // (`taint_output_sink_subcommands`), resolved prefix-aware so a legal
-    // abbreviation (`HTTP::cookie ins`) is not a false negative
-    // (RUST_ISSUE_023). This also removes the hardcoded `HTTP::header` /
-    // `HTTP::cookie` command list — any spec that declares output-sink
-    // subcommands participates.
-    if let Some(spec) = registry.get(command)
-        && !spec.taint_output_sink_subcommands.is_empty()
-        && let Some(sub_word) = args.first()
-        && let Some(sub) = spec.resolve_subcommand(sub_word)
-        && spec.taint_output_sink_subcommands.contains(&sub.name)
-    {
-        return Some((DiagCode::Irule3002, format!("{command} {}", sub.name)));
-    }
-    match command {
-        "HTTP::respond" => Some((DiagCode::Irule3001, command.to_owned())),
-        "HTTP::redirect" => Some((DiagCode::Irule3004, command.to_owned())),
-        "log" => Some((DiagCode::Irule3003, command.to_owned())),
-        _ => None,
-    }
 }
 
 /// Registry-driven SSRF / cross-interpreter sinks (T104 / T105),
@@ -1848,7 +1825,10 @@ pub fn find_taint_warnings_for_cu(
 ) -> Vec<TaintWarning> {
     let mut out = Vec::new();
     let solved = crate::taint_interproc::solve_interprocedural_taints(cu, registry, dialect);
-    for fu in cu.analysable_functions() {
+    // `analysable_body_function_units` (not `analysable_functions`) so a
+    // sink inside a TclOO method body — or an `apply` lambda / `namespace
+    // eval` body — is still checked; see its doc comment.
+    for fu in cu.analysable_body_function_units() {
         let exec = &fu.sccp.executable_blocks;
         let taints = solved.taints_for(&fu.name, &fu.taints);
         out.extend(find_taint_warnings(
@@ -1948,12 +1928,19 @@ fn emit_statement_warnings<S: std::hash::BuildHasher>(
         Statement::AssignValue { value, .. } => parse_command_substitution(value.trim()),
         _ => None,
     };
-    let (command, call_args): (&str, &[String]) = match stmt {
-        Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. } => {
-            (command.as_str(), args.as_slice())
+    let (command, call_args, tokens): (&str, &[String], Option<&CommandTokens>) = match stmt {
+        // Prefer the canonical target the lowerer already resolved
+        // (`stmt.canonical_command_or_source()`, populated for a resolved
+        // `interp alias`) over the source spelling, so `interp alias {}
+        // myputs {} puts; myputs $tainted` is classified against `puts`'s
+        // registry sink data instead of silently missing it because
+        // `"myputs"` isn't a registered command. Falls back to the source
+        // name unchanged when no alias was resolved (the common case).
+        Statement::Call { args, tokens, .. } | Statement::Barrier { args, tokens, .. } => {
+            (stmt.canonical_command_or_source(), args.as_slice(), tokens.as_ref())
         }
         Statement::AssignValue { .. } => match assign_parsed.as_ref() {
-            Some((cmd, sub_args)) => (cmd.as_str(), sub_args.as_slice()),
+            Some((cmd, sub_args)) => (cmd.as_str(), sub_args.as_slice(), None),
             None => return,
         },
         _ => return,
@@ -1987,6 +1974,7 @@ fn emit_statement_warnings<S: std::hash::BuildHasher>(
         command,
         args: call_args,
         registry,
+        tokens,
     };
     // Primary sink classification (T100 code-exec / T101 + iRules output / log).
     if let Some((code, sink_label)) = classify_sink(registry, command, call_args, dialect) {
@@ -2152,6 +2140,33 @@ struct SinkCall<'a> {
     /// Command registry — drives the position-aware sink filters
     /// (network-address slots, `[list]`-head recognition).
     registry: &'a CommandRegistry,
+    /// Per-word token spans for this call, when the statement carries them
+    /// (`None` for a synthetic call parsed out of an `AssignValue`'s command
+    /// substitution text, which has no token-span backing). Drives the
+    /// tight per-argument diagnostic span in [`sink_arg_span`] so the
+    /// squiggle lands on the tainted word, not the whole command.
+    tokens: Option<&'a CommandTokens>,
+}
+
+/// The tight span of the argument word that carries `name`, using the
+/// statement's per-word token spans (`call.tokens.argv`, offset by one to
+/// skip the command-name slot at index 0 — `call.args` excludes the command
+/// name, `argv` does not). Falls back to `fallback` (the whole-statement
+/// span) when no token spans are available, or `name` isn't found in any
+/// argument word (e.g. it reached the sink through an already-resolved
+/// alias with no textual match).
+fn sink_arg_span(call: &SinkCall<'_>, name: &str, fallback: Span) -> Span {
+    let Some(tokens) = call.tokens else {
+        return fallback;
+    };
+    for (i, arg) in call.args.iter().enumerate() {
+        if arg_var_names(arg).contains(name)
+            && let Some(&arg_span) = tokens.argv.get(i + 1)
+        {
+            return arg_span;
+        }
+    }
+    fallback
 }
 
 /// Positional argument strings of `args` under `spec`, skipping option
@@ -2193,12 +2208,24 @@ fn sink_var_position_safe(
     args: &[String],
     name: &str,
 ) -> bool {
+    // A value that only reaches an `ArgRole::Channel` argument slot (e.g.
+    // `puts`'s optional leading `channelId`) is a handle, not sink content
+    // — regardless of which sink code classified the call. The position
+    // comes from the command's registry-declared arg roles
+    // (`arg_role_resolver` for `puts`, since the channel slot shifts with
+    // the optional leading `-nonewline`), so a future output sink with its
+    // own channel argument is covered for free with no name check here.
+    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let channel_positions = registry.arg_indices_for_role(command, &arg_refs, ArgRole::Channel);
+    if !channel_positions.is_empty()
+        && args
+            .iter()
+            .enumerate()
+            .all(|(i, a)| channel_positions.contains(&i) || !arg_var_names(a).contains(name))
+    {
+        return true;
+    }
     match code {
-        // `puts ?-nonewline? ?channelId? string` — only the trailing
-        // content arg is an output sink; a tainted channel id is a handle.
-        DiagCode::T101 if command == "puts" => args
-            .last()
-            .is_none_or(|content| !arg_var_names(content).contains(name)),
         // T104 SSRF — only the network-address positional slots named by
         // `taint_network_sink_args`. `Some(&[])` (positions unspecified)
         // imposes no filter.
@@ -2458,7 +2485,7 @@ fn emit_sink_warnings<S: std::hash::BuildHasher>(
             _ => format!("Tainted variable ${name} flows into {sink_label}"),
         };
         warnings.push(TaintWarning {
-            span,
+            span: sink_arg_span(call, name, span),
             variable: name.to_owned(),
             sink_command: sink_label.to_owned(),
             code,
@@ -3750,17 +3777,18 @@ mod tests {
     #[test]
     fn classify_irules_sink_http_respond() {
         let reg = tcl_registry::registry_for_dialect("f5-irules");
-        let hit = classify_irules_sink(reg, "HTTP::respond", &[]);
+        let hit = classify_sink(reg, "HTTP::respond", &[], Some("f5-irules"));
         assert_eq!(hit.as_ref().map(|(c, _)| *c), Some(DiagCode::Irule3001));
     }
 
     #[test]
     fn classify_irules_sink_http_header_insert() {
         let reg = tcl_registry::registry_for_dialect("f5-irules");
-        let hit = classify_irules_sink(
+        let hit = classify_sink(
             reg,
             "HTTP::header",
             &["insert".to_owned(), "X-Foo".to_owned(), "bar".to_owned()],
+            Some("f5-irules"),
         );
         assert_eq!(hit.as_ref().map(|(c, _)| *c), Some(DiagCode::Irule3002));
         assert_eq!(hit.as_ref().unwrap().1, "HTTP::header insert");
@@ -3769,10 +3797,11 @@ mod tests {
     #[test]
     fn classify_irules_sink_http_cookie_replace() {
         let reg = tcl_registry::registry_for_dialect("f5-irules");
-        let hit = classify_irules_sink(
+        let hit = classify_sink(
             reg,
             "HTTP::cookie",
             &["replace".to_owned(), "sid".to_owned(), "val".to_owned()],
+            Some("f5-irules"),
         );
         assert_eq!(hit.as_ref().map(|(c, _)| *c), Some(DiagCode::Irule3002));
         assert_eq!(hit.as_ref().unwrap().1, "HTTP::cookie replace");
@@ -3783,10 +3812,11 @@ mod tests {
         // RUST_ISSUE_023: `HTTP::cookie ins` is a legal abbreviation of `insert`
         // and must still classify as the IRULE3002 output sink.
         let reg = tcl_registry::registry_for_dialect("f5-irules");
-        let hit = classify_irules_sink(
+        let hit = classify_sink(
             reg,
             "HTTP::cookie",
             &["ins".to_owned(), "sid".to_owned(), "val".to_owned()],
+            Some("f5-irules"),
         );
         assert_eq!(hit.as_ref().map(|(c, _)| *c), Some(DiagCode::Irule3002));
         // The label reports the canonical subcommand name.
@@ -3796,10 +3826,11 @@ mod tests {
     #[test]
     fn classify_irules_sink_http_header_remove_is_none() {
         let reg = tcl_registry::registry_for_dialect("f5-irules");
-        let hit = classify_irules_sink(
+        let hit = classify_sink(
             reg,
             "HTTP::header",
             &["remove".to_owned(), "X-Foo".to_owned()],
+            Some("f5-irules"),
         );
         assert!(hit.is_none(), "remove subcommand must not emit IRULE3002");
     }
@@ -3808,15 +3839,25 @@ mod tests {
     fn classify_irules_sink_log_and_redirect() {
         let reg = tcl_registry::registry_for_dialect("f5-irules");
         assert_eq!(
-            classify_irules_sink(reg, "log", &["local0.info".to_owned(), "x".to_owned()])
-                .as_ref()
-                .map(|(c, _)| *c),
+            classify_sink(
+                reg,
+                "log",
+                &["local0.info".to_owned(), "x".to_owned()],
+                Some("f5-irules")
+            )
+            .as_ref()
+            .map(|(c, _)| *c),
             Some(DiagCode::Irule3003),
         );
         assert_eq!(
-            classify_irules_sink(reg, "HTTP::redirect", &["https://evil".to_owned()])
-                .as_ref()
-                .map(|(c, _)| *c),
+            classify_sink(
+                reg,
+                "HTTP::redirect",
+                &["https://evil".to_owned()],
+                Some("f5-irules")
+            )
+            .as_ref()
+            .map(|(c, _)| *c),
             Some(DiagCode::Irule3004),
         );
     }
@@ -3826,6 +3867,39 @@ mod tests {
         let registry = CommandRegistry::build_default();
         let hit = classify_sink(&registry, "HTTP::respond", &["body".to_owned()], None);
         assert!(hit.is_none(), "no dialect → no IRULE3001, got {hit:?}");
+    }
+
+    #[test]
+    fn classify_sink_skips_irules_without_dialect_even_when_specs_loaded() {
+        // Stronger than `classify_sink_skips_irules_without_dialect`: the
+        // registry here *does* have the iRules specs loaded (as a shared
+        // multi-dialect registry might), so `registry.get("HTTP::respond")`
+        // succeeds. The IRULE3001 classification must still be withheld
+        // because the active *document* dialect (`None`) isn't iRules —
+        // mirrors `find_setter_constraint_warnings`'s explicit
+        // `is_irules_dialect` gate for IRULE3101.
+        let mut registry = CommandRegistry::build_default();
+        registry.load_irules();
+        assert!(registry.get("HTTP::respond").is_some());
+        let hit = classify_sink(&registry, "HTTP::respond", &["body".to_owned()], None);
+        assert!(
+            hit.is_none(),
+            "no dialect → no IRULE3001 even with iRules specs loaded, got {hit:?}"
+        );
+    }
+
+    #[test]
+    fn classify_sink_exec_stays_t100_under_irules_dialect() {
+        // `exec` declares `dialects: Some(NON_IRULES_OPERATORS)`, so it does
+        // not "support" the iRules `DialectSet`. T100 classification must
+        // not depend on `supports_dialect` — it's a plain trait fact,
+        // independent of the active document dialect — or `exec` would lose
+        // its T100 sink status the moment a registry also carries iRules
+        // specs and the document declares the iRules dialect.
+        let mut registry = CommandRegistry::build_default();
+        registry.load_irules();
+        let hit = classify_sink(&registry, "exec", &["$cmd".to_owned()], Some("f5-irules"));
+        assert_eq!(hit.as_ref().map(|(c, _)| *c), Some(DiagCode::T100));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -1289,7 +1289,11 @@ fn classify_sink(
         }
         let label = if info.output_sink_is_subcommand_qualified {
             let canonical = subcommand
-                .and_then(|s| registry.get(command).and_then(|spec| spec.resolve_subcommand(s)))
+                .and_then(|s| {
+                    registry
+                        .get(command)
+                        .and_then(|spec| spec.resolve_subcommand(s))
+                })
                 .map_or_else(|| subcommand.unwrap_or_default(), |sub| sub.name);
             format!("{command} {canonical}")
         } else {
@@ -1936,9 +1940,11 @@ fn emit_statement_warnings<S: std::hash::BuildHasher>(
         // registry sink data instead of silently missing it because
         // `"myputs"` isn't a registered command. Falls back to the source
         // name unchanged when no alias was resolved (the common case).
-        Statement::Call { args, tokens, .. } | Statement::Barrier { args, tokens, .. } => {
-            (stmt.canonical_command_or_source(), args.as_slice(), tokens.as_ref())
-        }
+        Statement::Call { args, tokens, .. } | Statement::Barrier { args, tokens, .. } => (
+            stmt.canonical_command_or_source(),
+            args.as_slice(),
+            tokens.as_ref(),
+        ),
         Statement::AssignValue { .. } => match assign_parsed.as_ref() {
             Some((cmd, sub_args)) => (cmd.as_str(), sub_args.as_slice(), None),
             None => return,

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -673,6 +673,18 @@ fn evaluate_type_def<S: std::hash::BuildHasher>(
                     namespace,
                 );
             }
+            // A command that writes more than one variable (`lassign list a
+            // b`, `scan $s $fmt a b`, `regexp ... a b`) destructures its
+            // argument into element-wise values — the command's own single
+            // `return_type` fact (`lassign` → `List`, the *leftover*
+            // elements; `regexp` → `Boolean`, the match count) describes
+            // neither def and must not be broadcast onto both. Conservative
+            // Overdefined until a per-command element-type model exists (as
+            // `collection_element_class` already provides for `dict`
+            // `lappend`, whose single-target shape never reaches this arm).
+            if defs.len() > 1 {
+                return TypeLattice::overdefined();
+            }
             return_type_for_command(registry, command, &arg_refs, known_classes, namespace)
         }
 
@@ -1015,6 +1027,69 @@ mod tests {
             &ssa,
         );
         assert_eq!(t, TypeLattice::of(TclType::Int));
+    }
+
+    #[test]
+    fn lassign_destructure_defs_are_overdefined_not_command_return_type() {
+        // TP: `lassign $pipe a b` writes TWO variables; `lassign`'s own
+        // `return_type` (List — the *leftover* elements) must not be
+        // broadcast onto both destructured targets. Pre-fix, both `a` and
+        // `b` were typed LIST, so a later channel-position use (`puts $a
+        // ...`) would falsely fire W126 ("has type LIST, not CHANNEL") —
+        // see FP-STY-04.
+        let stmt = Statement::Call {
+            span: Span::new(0, 0),
+            command: "lassign".to_owned(),
+            canonical_command: None,
+            args: vec!["$pipe".to_owned(), "a".to_owned(), "b".to_owned()],
+            defs: vec!["a".to_owned(), "b".to_owned()],
+            reads: Vec::new(),
+            reads_own_defs: false,
+            safe_on_uninit: false,
+            tokens: None,
+            foreach_groups: None,
+        };
+        let ssa = SsaFunction::trivial("::top", BlockId(0), vec!["entry".into()]);
+        let t = evaluate_type_def(
+            &stmt,
+            &HashMap::new(),
+            &HashMap::new(),
+            &registry(),
+            &HashSet::new(),
+            "::",
+            &ssa,
+        );
+        assert_eq!(t, TypeLattice::overdefined());
+    }
+
+    #[test]
+    fn single_def_command_still_uses_its_declared_return_type() {
+        // TN control: a command that writes exactly one variable (`append`)
+        // legitimately shares its return value with that variable — the
+        // `defs.len() > 1` guard must not blunt this already-precise case.
+        let stmt = Statement::Call {
+            span: Span::new(0, 0),
+            command: "append".to_owned(),
+            canonical_command: None,
+            args: vec!["result".to_owned(), "x".to_owned()],
+            defs: vec!["result".to_owned()],
+            reads: Vec::new(),
+            reads_own_defs: true,
+            safe_on_uninit: true,
+            tokens: None,
+            foreach_groups: None,
+        };
+        let ssa = SsaFunction::trivial("::top", BlockId(0), vec!["entry".into()]);
+        let t = evaluate_type_def(
+            &stmt,
+            &HashMap::new(),
+            &HashMap::new(),
+            &registry(),
+            &HashSet::new(),
+            "::",
+            &ssa,
+        );
+        assert_eq!(t, TypeLattice::of(TclType::String));
     }
 
     #[test]

--- a/rust/tcl-compiler/tests/taint.rs
+++ b/rust/tcl-compiler/tests/taint.rs
@@ -578,6 +578,20 @@ mod interprocedural_taint {
         assert!(!ws.is_empty());
         assert!(ws.iter().any(|w| w.sink_command == "eval"));
     }
+
+    #[test]
+    fn tainted_variadic_args_into_sinking_helper_warns() {
+        // `proc log {args} { puts $args }` packs every trailing actual
+        // argument into the `args` list parameter — a tainted actual must
+        // still be traced (via the interprocedural entry-taint solve's
+        // `args`-packing rule) into the sink inside the callee body.
+        let source = "proc log {args} { puts $args }\nset data [read $fd]\nlog $data\n";
+        let ws = of_code(source, D, "T101");
+        assert!(
+            !ws.is_empty(),
+            "expected T101 for tainted args-packed data, got {ws:?}"
+        );
+    }
 }
 
 // ===========================================================================
@@ -621,6 +635,30 @@ mod dangerous_sinks {
         let ws = of_code("set x [read $fd]\nsubst $x", D, "T100");
         assert!(!ws.is_empty());
     }
+
+    #[test]
+    fn coroprobe_command_prefix_sink() {
+        // `coroprobe coroName command ?arg ...?` evaluates `command` in a
+        // suspended coroutine's frame right now — it carries
+        // `Traits::EVALUATES_CODE` but (unlike `eval`/`exec`/`uplevel`) not
+        // `Traits::TAINT_SINK`, so the registry-driven sink classification
+        // must still route it to T100 via the `EVALUATES_CODE` trait rather
+        // than silently losing it now that sink classification is
+        // registry-driven instead of hardcoded per-trait checks in the
+        // compiler.
+        let ws = of_code("set cmd [read $fd]\ncoroprobe myCoro $cmd", "tcl9.0", "T100");
+        assert!(!ws.is_empty(), "expected T100 for coroprobe, got none");
+    }
+
+    #[test]
+    fn coroinject_command_prefix_sink() {
+        let ws = of_code(
+            "set cmd [read $fd]\ncoroinject myCoro $cmd",
+            "tcl9.0",
+            "T100",
+        );
+        assert!(!ws.is_empty(), "expected T100 for coroinject, got none");
+    }
 }
 
 // ===========================================================================
@@ -647,6 +685,23 @@ mod warning_messages {
 // ===========================================================================
 mod output_sinks {
     use super::*;
+
+    #[test]
+    fn puts_tainted_data_span_is_tight_around_argument() {
+        // The diagnostic must underline just the tainted `$x` argument word,
+        // not the whole `puts $x` statement — precise highlighting is what
+        // lets the developer see exactly which value is the problem.
+        let src = "set x [read $fd]\nputs $x";
+        let ws = of_code(src, D, "T101");
+        assert_eq!(ws.len(), 1);
+        let want_start = u32::try_from(src.find("$x").unwrap()).unwrap();
+        let want_end = want_start + 2; // "$x" is 2 bytes.
+        assert_eq!(
+            (ws[0].span.start(), ws[0].span.end()),
+            (want_start, want_end),
+            "expected the span to cover only `$x`, not the whole statement"
+        );
+    }
 
     #[test]
     fn puts_tainted_data() {
@@ -734,6 +789,78 @@ mod output_sinks {
     fn puts_interpolation_propagates() {
         let ws = of_code("set x [read $fd]\nputs \"data: $x\"", D, "T101");
         assert!(!ws.is_empty());
+    }
+
+    #[test]
+    fn puts_nonewline_alone_is_content_not_channel() {
+        // `puts -nonewline $x` has only ONE positional arg after the flag,
+        // so per Tcl semantics `$x` is the content written to stdout, not a
+        // channel — the `-nonewline`-shifted `ArgRole::Channel` position
+        // (declared dynamically since the channel slot moves with the
+        // optional flag) must not exempt it.
+        let ws = of_code("set x [read $fd]\nputs -nonewline $x", D, "T101");
+        assert_eq!(ws.len(), 1);
+        assert_eq!(ws[0].variable, "x");
+    }
+
+    #[test]
+    fn puts_via_interp_alias_still_fires() {
+        // `interp alias {} myputs {} puts` makes `myputs` a genuine
+        // current-interpreter alias for the real `puts` builtin. The sink
+        // classification must resolve the call through the lowerer's
+        // `canonical_command` (populated for a resolved alias) rather than
+        // the literal source spelling `"myputs"`, which isn't itself a
+        // registered command and would otherwise silently miss the sink.
+        let ws = of_code(
+            "interp alias {} myputs {} puts\nset x [read $fd]\nmyputs $x",
+            D,
+            "T101",
+        );
+        assert_eq!(ws.len(), 1, "expected T101 via interp alias, got {ws:?}");
+        assert_eq!(ws[0].variable, "x");
+    }
+
+    #[test]
+    fn puts_inside_tcloo_method_body_still_fires() {
+        // TclOO method bodies are analysable functions like any proc — the
+        // sink check must not be limited to top-level / plain-proc bodies.
+        let ws = of_code(
+            "oo::class create Foo {\n\
+             method bar {} {\n\
+             set x [read $fd]\n\
+             puts $x\n\
+             }\n\
+             }",
+            D,
+            "T101",
+        );
+        assert_eq!(
+            ws.len(),
+            1,
+            "expected T101 inside TclOO method body, got {ws:?}"
+        );
+        assert_eq!(ws[0].variable, "x");
+    }
+
+    #[test]
+    fn puts_inside_namespace_eval_body_still_fires() {
+        // `namespace eval` registers its block as a synthetic body unit
+        // (`Module::body_units`) — a fresh-frame body outside any proc —
+        // which must be covered by the same sink check as the top level.
+        let ws = of_code(
+            "namespace eval ::myns {\n\
+             set x [read $fd]\n\
+             puts $x\n\
+             }",
+            D,
+            "T101",
+        );
+        assert_eq!(
+            ws.len(),
+            1,
+            "expected T101 inside namespace eval body, got {ws:?}"
+        );
+        assert_eq!(ws[0].variable, "x");
     }
 }
 

--- a/rust/tcl-compiler/tests/taint.rs
+++ b/rust/tcl-compiler/tests/taint.rs
@@ -646,7 +646,11 @@ mod dangerous_sinks {
         // than silently losing it now that sink classification is
         // registry-driven instead of hardcoded per-trait checks in the
         // compiler.
-        let ws = of_code("set cmd [read $fd]\ncoroprobe myCoro $cmd", "tcl9.0", "T100");
+        let ws = of_code(
+            "set cmd [read $fd]\ncoroprobe myCoro $cmd",
+            "tcl9.0",
+            "T100",
+        );
         assert!(!ws.is_empty(), "expected T100 for coroprobe, got none");
     }
 

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -1624,6 +1624,12 @@ const HTML_ENCODE_PROC: &str =
     "proc html_encode {str} { string map {& &amp; < &lt; > &gt; \\\" &quot; ' &#39;} $str }";
 const REGEX_QUOTE_PROC: &str =
     "proc regex::quote {str} { regsub -all {[][{}()*+?.\\\\^$|]} $str {\\\\&} }";
+/// `string map` mapping that strips CR/LF — the fix the T101 / IRULE3003 KCS
+/// docs recommend for an output/log sink (`puts $x` / `log ... $x`): a
+/// `string map` element beginning with `"` is itself list-parsed with
+/// backslash escapes honoured, so `"\n"` / `"\r"` really do map the newline /
+/// carriage-return characters to empty, not the two-character sequences.
+const CRLF_STRIP_MAP: &str = "string map {\"\\n\" \"\" \"\\r\" \"\"}";
 
 /// Quick-fixes for context-supplied diagnostics (iRules taint encode-wrap +
 /// double-encode removal).
@@ -1801,6 +1807,71 @@ fn find_var_ref(line: &str, var: &str) -> Option<(usize, usize, String)> {
     None
 }
 
+/// T106: remove a redundant `[ENCODER $var]` wrapper → `$var`.
+fn t106_remove_redundant_encoder(line: &str, d: &ContextDiagnostic, var: &str) -> Vec<CodeAction> {
+    let Some((vstart, vend, matched)) = find_var_ref(line, var) else {
+        return Vec::new();
+    };
+    let chars: Vec<char> = line.chars().collect();
+    // Scan left for the enclosing `[`, right for `]`.
+    let mut lb = vstart;
+    while lb > 0 && chars[lb - 1] != '[' {
+        lb -= 1;
+    }
+    let mut rb = vend;
+    while rb < chars.len() && chars[rb] != ']' {
+        rb += 1;
+    }
+    if lb == 0 || rb >= chars.len() {
+        return Vec::new();
+    }
+    let start = char_col_to_utf16_local(line, lb - 1);
+    let end = char_col_to_utf16_local(line, rb + 1);
+    vec![CodeAction {
+        title: "Remove redundant encoder".to_string(),
+        edits: vec![crate::rename::TextEdit {
+            range: LspRange {
+                start_line: d.range.start_line,
+                start_character: start,
+                end_line: d.range.start_line,
+                end_character: end,
+            },
+            new_text: matched,
+        }],
+        kind: ActionKind::QuickFix,
+        command: None,
+        data_group_definition: None,
+    }]
+}
+
+/// T101 (`puts`) / IRULE3003 (`log`): wrap with a CR/LF-stripping `string
+/// map` — the fix the KCS docs for both codes recommend, since neither sink
+/// is HTML/URI-context-specific (unlike IRULE3001's response body or
+/// IRULE3002's header value) so an HTML/URL encoder would be the wrong
+/// mitigation to suggest here.
+fn strip_crlf_before_output(line: &str, d: &ContextDiagnostic, var: &str) -> Vec<CodeAction> {
+    let Some((vstart, vend, matched)) = find_var_ref(line, var) else {
+        return Vec::new();
+    };
+    let start = char_col_to_utf16_local(line, vstart);
+    let end = char_col_to_utf16_local(line, vend);
+    vec![CodeAction {
+        title: format!("Sanitise ${var} (strip CR/LF) before output"),
+        edits: vec![crate::rename::TextEdit {
+            range: LspRange {
+                start_line: d.range.start_line,
+                start_character: start,
+                end_line: d.range.start_line,
+                end_character: end,
+            },
+            new_text: format!("[{CRLF_STRIP_MAP} {matched}]"),
+        }],
+        kind: ActionKind::QuickFix,
+        command: None,
+        data_group_definition: None,
+    }]
+}
+
 fn taint_quickfix(source: &str, d: &ContextDiagnostic) -> Vec<CodeAction> {
     let line_no = d.range.start_line as usize;
     let Some(line) = source.split('\n').nth(line_no) else {
@@ -1810,41 +1881,11 @@ fn taint_quickfix(source: &str, d: &ContextDiagnostic) -> Vec<CodeAction> {
         return Vec::new();
     };
 
-    // T106: remove a redundant `[ENCODER $var]` wrapper → `$var`.
     if d.code == "T106" {
-        let Some((vstart, vend, matched)) = find_var_ref(line, &var) else {
-            return Vec::new();
-        };
-        let chars: Vec<char> = line.chars().collect();
-        // Scan left for the enclosing `[`, right for `]`.
-        let mut lb = vstart;
-        while lb > 0 && chars[lb - 1] != '[' {
-            lb -= 1;
-        }
-        let mut rb = vend;
-        while rb < chars.len() && chars[rb] != ']' {
-            rb += 1;
-        }
-        if lb == 0 || rb >= chars.len() {
-            return Vec::new();
-        }
-        let start = char_col_to_utf16_local(line, lb - 1);
-        let end = char_col_to_utf16_local(line, rb + 1);
-        return vec![CodeAction {
-            title: "Remove redundant encoder".to_string(),
-            edits: vec![crate::rename::TextEdit {
-                range: LspRange {
-                    start_line: d.range.start_line,
-                    start_character: start,
-                    end_line: d.range.start_line,
-                    end_character: end,
-                },
-                new_text: matched,
-            }],
-            kind: ActionKind::QuickFix,
-            command: None,
-            data_group_definition: None,
-        }];
+        return t106_remove_redundant_encoder(line, d, &var);
+    }
+    if d.code == "T101" || d.code == "IRULE3003" {
+        return strip_crlf_before_output(line, d, &var);
     }
 
     let (encoder, proc_template): (&str, Option<&str>) = match d.code.as_str() {

--- a/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
@@ -98,6 +98,12 @@ const MATRIX: &[Case] = &[
         silent: "proc p {cond} {\n    if {$cond} { return 1 }\n    return 0\n}\n",
         note: "constant condition",
     },
+    Case {
+        code: "T101",
+        fire: "set x [gets stdin]\nputs $x\n",
+        silent: "set x [gets stdin]\nset n [string length $x]\nputs $n\n",
+        note: "tainted data flows into puts output sink",
+    },
 ];
 
 /// The set of `code` strings carried by `diags` (mirrors Python `_codes`).
@@ -212,6 +218,10 @@ fn w302_fires_on_defect() {
 fn i230_fires_on_defect() {
     assert_fires(case_for("I230"));
 }
+#[test]
+fn t101_fires_on_defect() {
+    assert_fires(case_for("T101"));
+}
 
 // -- silent cases --------------------------------------------------------
 
@@ -250,6 +260,10 @@ fn w302_silent_on_corrected_form() {
 #[test]
 fn i230_silent_on_corrected_form() {
     assert_silent(case_for("I230"));
+}
+#[test]
+fn t101_silent_on_corrected_form() {
+    assert_silent(case_for("T101"));
 }
 
 // -- TestOptimisationMatrix ----------------------------------------------

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -405,6 +405,36 @@ fn bare_snit_instance_dispatch_is_not_e001() {
     assert!(!has_code(&lsp.open_ready(&uri, src), "E001"));
 }
 
+// -- TestT101OutputSinkSpan ------------------------------------------------
+// T101 (tainted data into `puts`) end-to-end: the diagnostic must highlight
+// only the tainted argument word, not the whole `puts $x` statement.
+
+#[test]
+fn puts_tainted_data_has_tight_argument_span() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "set x [gets stdin]\nputs $x\n";
+    let diags = lsp.open_ready(&uri, src);
+    let t101: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("T101"))
+        .collect();
+    assert_eq!(t101.len(), 1, "expected exactly one T101: {diags:?}");
+    let range = &t101[0]["range"];
+    // Line 1 (0-based) is `puts $x`; `$x` starts at character 5, ends at 7 —
+    // not the whole 7-character statement starting at character 0.
+    assert_eq!(range["start"]["line"], 1);
+    assert_eq!(
+        range["start"]["character"], 5,
+        "span must start at `$x`, not the `puts` command word: {diags:?}"
+    );
+    assert_eq!(range["end"]["line"], 1);
+    assert_eq!(
+        range["end"]["character"], 7,
+        "span must cover only `$x`: {diags:?}"
+    );
+}
+
 // -- TestSameFileCallArity ------------------------------------------------
 // End-to-end arity checks generalised beyond the builtin registry to
 // same-file proc / `interp alias` / `rename` calls. Previously, calling a

--- a/rust/tcl-lsp-server/tests/e2e/irules.rs
+++ b/rust/tcl-lsp-server/tests/e2e/irules.rs
@@ -537,7 +537,7 @@ fn braced_variable_wrapped() {
 }
 
 #[test]
-fn no_fix_for_unknown_code() {
+fn t101_wrap_strip_crlf() {
     let mut lsp = Lsp::irules();
     let actions = taint_fix(
         &mut lsp,
@@ -547,12 +547,66 @@ fn no_fix_for_unknown_code() {
         (0, 0),
         (0, 8),
     );
+    let fixes: Vec<Value> = actions
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter(|a| action_title(a).contains("strip CR/LF"))
+        .cloned()
+        .collect();
+    assert_eq!(fixes.len(), 1, "{actions:?}");
+    assert!(
+        ca_new_texts(&json!(fixes))
+            .iter()
+            .any(|s| s.contains("[string map") && s.contains("$raw]")),
+        "{fixes:?}"
+    );
+}
+
+#[test]
+fn irule3003_wrap_strip_crlf() {
+    let mut lsp = Lsp::irules();
+    let actions = taint_fix(
+        &mut lsp,
+        "log local0.info $raw\n",
+        "IRULE3003",
+        "Tainted variable $raw in log output (log); risk of log injection or log forging",
+        (0, 0),
+        (0, 16),
+    );
+    let fixes: Vec<Value> = actions
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter(|a| action_title(a).contains("strip CR/LF"))
+        .cloned()
+        .collect();
+    assert_eq!(fixes.len(), 1, "{actions:?}");
+    assert!(
+        ca_new_texts(&json!(fixes))
+            .iter()
+            .any(|s| s.contains("[string map") && s.contains("$raw]")),
+        "{fixes:?}"
+    );
+}
+
+#[test]
+fn no_fix_for_unknown_code() {
+    let mut lsp = Lsp::irules();
+    let actions = taint_fix(
+        &mut lsp,
+        "eval $raw\n",
+        "T100",
+        "Tainted variable $raw flows into eval; possible code injection",
+        (0, 0),
+        (0, 8),
+    );
     let matched: Vec<Value> = actions
         .as_array()
         .unwrap_or(&Vec::new())
         .iter()
         .filter(|a| {
-            ["HTML::encode", "URI::encode", "regex::quote", "--"]
+            ["HTML::encode", "URI::encode", "regex::quote", "--", "strip CR/LF"]
                 .iter()
                 .any(|k| action_title(a).contains(k))
         })

--- a/rust/tcl-lsp-server/tests/e2e/irules.rs
+++ b/rust/tcl-lsp-server/tests/e2e/irules.rs
@@ -606,9 +606,15 @@ fn no_fix_for_unknown_code() {
         .unwrap_or(&Vec::new())
         .iter()
         .filter(|a| {
-            ["HTML::encode", "URI::encode", "regex::quote", "--", "strip CR/LF"]
-                .iter()
-                .any(|k| action_title(a).contains(k))
+            [
+                "HTML::encode",
+                "URI::encode",
+                "regex::quote",
+                "--",
+                "strip CR/LF",
+            ]
+            .iter()
+            .any(|k| action_title(a).contains(k))
         })
         .cloned()
         .collect();

--- a/rust/tcl-registry/src/commands/tcl/puts_.rs
+++ b/rust/tcl-registry/src/commands/tcl/puts_.rs
@@ -25,12 +25,29 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "puts ?-nonewline? ?channelId? string",
 }];
 
+/// Dynamic arg-role resolver: `puts` takes one positional arg (`string`,
+/// writing to stdout) or two (`channelId string`); the optional leading
+/// `-nonewline` flag shifts which raw-arg index is the channel. Declaring
+/// the channel position lets the taint sink's position-aware filter
+/// (`sink_var_position_safe` in `tcl_compiler::taint`) recognise a tainted
+/// channel handle as a non-dangerous argument generically, with no
+/// `puts`-by-name check in the compiler.
+fn puts_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    let skip: u8 = u8::from(args.first() == Some(&"-nonewline"));
+    if args.len() - usize::from(skip) >= 2 {
+        vec![(skip, ArgRole::Channel)]
+    } else {
+        Vec::new()
+    }
+}
+
 /// Command spec for `puts`.
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "puts",
         traits: Traits::FRAMELESS_RUNTIME | Traits::BYTE_COMPILED | Traits::TAINT_SINK,
         arity: Arity::new(1, 2),
+        arg_role_resolver: Some(puts_arg_roles),
         return_type: Some(TclType::String),
         side_effects: &[SideEffect {
             target: SideEffectTarget::FileIo,

--- a/rust/tcl-registry/src/taint.rs
+++ b/rust/tcl-registry/src/taint.rs
@@ -272,8 +272,11 @@ pub fn is_sanitiser(registry: &CommandRegistry, command: &str, args: &[&str]) ->
 /// support it are ignored.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub struct TaintSinkInfo {
-    /// Dangerous code-execution sink (`eval`, `expr`, `exec`,
-    /// `uplevel`, `subst`) — T100. From [`Traits::TAINT_SINK`].
+    /// Dangerous code-execution sink (`eval`, `expr`, `exec`, `uplevel`,
+    /// `subst`, `coroprobe`/`coroinject`) — T100. From
+    /// [`Traits::TAINT_SINK`] or [`Traits::EVALUATES_CODE`] (the latter
+    /// covers commands that evaluate a runtime command reference without
+    /// being a fixed-sink builtin, e.g. `coroprobe`/`coroinject`).
     pub is_code_sink: bool,
     /// Output-sink diagnostic code (T101 / IRULE3001 / IRULE3002 /
     /// IRULE3004), if the matched subcommand qualifies.
@@ -313,7 +316,9 @@ pub fn classify_taint_sinks(
     }
 
     let mut info = TaintSinkInfo {
-        is_code_sink: spec.traits.contains(Traits::TAINT_SINK),
+        is_code_sink: spec
+            .traits
+            .intersects(Traits::TAINT_SINK | Traits::EVALUATES_CODE),
         ..TaintSinkInfo::default()
     };
 


### PR DESCRIPTION
## Summary

- T101 sink classification was hardcoded (`command == "puts"`) in the compiler even though the registry already had a fully-built, unused `classify_taint_sinks` doing this generically. Rewired `classify_sink` to use it, and generalised the `puts` channel-position exemption via a registry `ArgRole::Channel` arg-role resolver instead of a name check.
- Fixed bugs surfaced along the way:
  - `classify_taint_sinks` only checked `TAINT_SINK`, silently dropping `coroprobe`/`coroinject` (`EVALUATES_CODE`-only) from T100.
  - The compiler never used the lowerer's resolved `canonical_command`, so `interp alias {} myputs {} puts; myputs $tainted` missed T101.
  - `compiler_checks.rs` iterated `analysable_functions()`, which never reaches TclOO method bodies, `apply` lambdas, or `namespace eval` bodies — taint/SCCP/GVN/shimmer diagnostics were silently absent inside them in the live LSP pipeline. Added `analysable_body_function_units()`.
  - Wiring `puts`'s channel arg role exposed a latent type-inference bug: `lassign`'s destructured targets were typed as the command's own return type (`List`) instead of unknown, causing spurious W126.
- Precision/UX:
  - T101's diagnostic span covered the whole statement; now it targets just the tainted argument via the statement's per-word token spans.
  - Added a quick fix for T101/IRULE3003 (wrap with a CRLF-stripping `string map`, matching the KCS docs) — T101 previously had none.

## Validation

- [x] `cargo test -p tcl-registry -p tcl-compiler -p tcl-lsp-core -p tcl-lsp-server -p tcl-lsp-db -p tcl-cli` — all pass.
- [x] `cargo clippy -p tcl-registry -p tcl-compiler -p tcl-lsp-core -p tcl-lsp-server -p tcl-lsp-db -p tcl-cli --all-targets -- -D warnings` — clean, no new allows.
- [x] New unit/integration tests in `tcl-compiler` (taint), LSP e2e tests (diagnostics, quick fixes, diagnostic matrix), and a VS Code extension test.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — sink classification is now registry-driven and TclOO/alias/lambda bodies are analysed where they weren't before.
- [ ] KCS notes under `docs/kcs/compiler/` were not updated — this is a correctness/coverage fix to existing documented T100/T101 behaviour, not a change to the documented contract itself.

## Known limitations (deferred, not silently dropped)

- `rename`-based aliasing is not tracked (only `interp alias`).
- A namespace-scoped proc shadowing a builtin isn't distinguished from the builtin.
- Variable-trace-altered taint isn't modeled.
- `arg_var_names`'s hand-rolled scanner could be centralised onto the existing lexer-based `var_refs::vars_in_word` — deferred as a separate, higher-risk refactor.


---
_Generated by [Claude Code](https://claude.ai/code/session_01A561hWTbTd5EuhHim19mUU)_