### PR TITLE
T100: fix false negatives/positives, tighten highlighting, drop hardcoded sinks

### DIFF
--- a/docs/kcs/codes/kcs-diagnostic-t100-taint-code-execution-sink.md
+++ b/docs/kcs/codes/kcs-diagnostic-t100-taint-code-execution-sink.md
@@ -13,36 +13,52 @@ default, irule
 
 ## Question
 
-Why does the analyser flag user-controlled data flowing into `eval`, `uplevel`, `subst`, unbraced `expr`, `exec`, or a *direct* operand of braced `expr`?
+Why does the analyser flag user-controlled data flowing into `eval`, `uplevel`, `subst`, unbraced `expr`, `exec`, or a *direct, numeric-coercing* operand of braced `expr` — including one used directly in an `if`/`while`/`for` condition?
 
 ## Why
 
 T100 covers two related taint-into-evaluation hazards:
 
 1. **Code execution.** User-controlled input reaching `eval`,
-   `uplevel`, `subst`, **unbraced** `expr` (``expr $cmd + 1``), or
-   `exec` is re-parsed as Tcl syntax and can execute arbitrary
-   commands.  This is the classic injection vector.
+   `uplevel`, **unbraced** `expr` (``expr $cmd + 1``), `exec`, or
+   `subst` (unless called with `-nocommands`, or the Tcl 9.1 positive
+   form with no `-commands` — see Fix below) is re-parsed as Tcl
+   syntax and can execute arbitrary commands. This is the classic
+   injection vector. Calling through an `interp alias` or a
+   `rename`d name (`rename eval myEval; myEval $x`) is caught the
+   same way as calling the sink directly.
 
 2. **Numeric / type coercion.** A tainted value used as a *direct*
-   operand of **braced** `expr` (``expr {$data + 1}``) is NOT
-   re-parsed as code -- Tcl evaluates the expression once with
-   ``$data`` as a single operand.  But the value still flows through
-   Tcl's numeric coercion: ``"inf"`` returns inf, ``"0xff"`` parses
-   as 255 even if base-10 was intended, ``"0/0"`` raises a domain
-   error.  Decisions taken on the result can be subverted without
-   any arbitrary-code execution.
+   operand of a numeric or boolean operator inside **braced** `expr`
+   (``expr {$data + 1}``, and equally an `if {$data + 1 > 5} {…}` /
+   `while` / `for` condition) is NOT re-parsed as code -- Tcl
+   evaluates the expression once with ``$data`` as a single operand.
+   But the value still flows through Tcl's numeric coercion:
+   ``"inf"`` returns inf, ``"0xff"`` parses as 255 even if base-10
+   was intended, ``"0/0"`` raises a domain error. Decisions taken on
+   the result can be subverted without any arbitrary-code execution.
+   A tainted operand of a **pure string/list** operator (`eq`, `ne`,
+   `lt`/`le`/`gt`/`ge`, `in`/`ni`, or the iRules
+   `contains`/`starts_with`/`ends_with`/`equals`/`matches_glob`/
+   `matches_regex` forms) never coerces, so T100 does not fire for
+   it — `expr {$data eq "admin"}` is not a T100 hazard.
 
 The same code (T100) covers both because the underlying defence is
 identical: validate / pin the value's shape *before* it reaches the
 expression.  The emitted diagnostic message names the specific
 hazard ("expr operand: numeric coercion" vs "eval: code injection")
-so the appropriate remediation is obvious.
+so the appropriate remediation is obvious. The squiggle is drawn as
+tightly as the analyser can manage: the one tainted argument word for
+a command sink (`eval "prefix" $x "suffix"` underlines only `$x`),
+the tainted operand itself for a braced `expr {…}` statement, or the
+`{…}` condition text (not the whole `if`/`while`/`for` statement) for
+a branch condition.
 
 ## Symptoms
 
-- A yellow squiggle appears under the sink command, with one of:
-  - "Tainted variable ${var} used in eval; possible code injection"
+- A yellow squiggle appears under the tainted argument or operand,
+  with one of:
+  - "Tainted variable ${var} flows into eval; possible code injection"
   - "Tainted variable ${var} flows into expr operand; numeric
     coercion may misinterpret value (use Tcl numeric-validation
     guards)"
@@ -56,6 +72,17 @@ eval $uri
 
 The analyser reports **`T100`** because `uri` carries tainted data into `eval`.
 
+```tcl
+set uri [HTTP::uri]
+if {[string length $uri] > 200} {
+    log local0. "long uri"
+}
+```
+
+The analyser also reports **`T100`** here: `$uri` is a direct numeric
+operand of `>` inside the `if` condition, evaluated exactly like any
+other braced `expr` — this is not limited to a bare `expr` statement.
+
 ## Fix
 
 ```tcl
@@ -65,6 +92,13 @@ if {$uri in $allowed_commands} {
     eval $uri
 }
 ```
+
+For `subst` specifically, when only variable/backslash substitution is
+needed, add `-nocommands` — this removes the code-execution hazard
+outright rather than merely validating around it, and the analyser
+recognises it: `subst -nocommands $template` does not raise T100. A
+quick fix ("Add -nocommands to disable command substitution") is
+offered for a `subst` sink.
 
 ## How to suppress
 

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -151,6 +151,44 @@ suite("Diagnostics", () => {
     );
   });
 
+  test("T100 fires for a tainted if-condition operand but not for a pure string compare", async () => {
+    const taintUri = getDocUri("diagnostics-taint-t100.tcl");
+    await activate(taintUri);
+    const diagnostics = await waitForDiagnostics(taintUri, { minCount: 2 });
+
+    const t100 = diagnostics.filter((d) => {
+      const code = typeof d.code === "object" ? d.code.value : d.code;
+      return code === "T100";
+    });
+
+    // Two T100 hits: the direct `eval $cmd` sink, and `$n` as a numeric
+    // operand of `+` inside the `if` condition — conditions aren't a bare
+    // `expr` statement, but are evaluated exactly like one.
+    assert.ok(t100.length >= 2, `Expected at least 2 T100 diagnostics, got ${t100.length}`);
+    assert.ok(
+      t100.every((d) => d.severity === vscode.DiagnosticSeverity.Warning),
+      "T100 should be a warning",
+    );
+    assert.ok(
+      t100.some((d) => d.message.includes("eval")),
+      `Expected a T100 for the eval sink, got: ${t100.map((d) => d.message).join("; ")}`,
+    );
+    assert.ok(
+      t100.some((d) => d.message.includes("numeric coercion")),
+      `Expected a T100 for the if-condition numeric operand, got: ${t100.map((d) => d.message).join("; ")}`,
+    );
+
+    // The `if {$who eq "admin"}` branch (pure string compare) and the
+    // `subst -nocommands $template` call (command substitution disabled)
+    // must not raise T100 at all.
+    assert.ok(
+      t100.every((d) => !d.message.includes("who") && !d.message.includes("template")),
+      `Neither $who (eq compare) nor $template (subst -nocommands) should raise T100, got: ${t100
+        .map((d) => d.message)
+        .join("; ")}`,
+    );
+  });
+
   test("W125 does not fire for correctly placed else", async () => {
     const orphanedUri = getDocUri("diagnostics-orphaned.tcl");
     await activate(orphanedUri);

--- a/editors/vscode/testFixture/diagnostics-taint-t100.tcl
+++ b/editors/vscode/testFixture/diagnostics-taint-t100.tcl
@@ -1,0 +1,24 @@
+# T100 - tainted data flowing into a code-execution / numeric-coercion sink
+
+# Direct sink: tainted $cmd flows into eval — should produce T100.
+set cmd [gets stdin]
+eval $cmd
+
+# Branch condition: $n is a direct numeric operand of `+` inside the `if`
+# condition, evaluated exactly like any other braced expr — should also
+# produce T100, even though it never reaches a bare `expr` statement.
+set n [gets stdin]
+if {$n + 1 > 5} {
+    puts big
+}
+
+# Pure string comparison: `eq` never coerces, so this must NOT produce T100.
+set who [gets stdin]
+if {$who eq "admin"} {
+    puts ok
+}
+
+# subst -nocommands disables the only hazard T100 warns about — must NOT
+# produce T100 (the recommended fix for the subst code-injection case).
+set template [gets stdin]
+subst -nocommands $template

--- a/rust/tcl-compiler/src/alias.rs
+++ b/rust/tcl-compiler/src/alias.rs
@@ -98,6 +98,29 @@ pub fn detect_interp_alias_delete(cmd_name: &str, args: &[String]) -> Option<Str
     Some(normalise_qualified_name(alias_name))
 }
 
+/// Detect a static `rename oldName newName` — both names literal text,
+/// `newName` non-empty (an empty `newName` *deletes* `oldName` rather
+/// than renaming it, per Tcl semantics, and creates no new alias).
+///
+/// Returns `(qualified_new_name, old_name)` — the same `(alias name,
+/// target)` shape [`detect_interp_alias`] returns, so both feed the same
+/// [`CommandAliasMap`]: for every purpose this map serves (arg-role /
+/// body-form resolution, taint sink dispatch), a `rename` is
+/// indistinguishable from an `interp alias {} newName {} oldName` —
+/// calling through the new name really does invoke the old command.
+#[must_use]
+pub fn detect_rename(cmd_name: &str, args: &[String]) -> Option<(String, String)> {
+    if cmd_name != "rename" || args.len() != 2 {
+        return None;
+    }
+    let old = &args[0];
+    let new = &args[1];
+    if old.is_empty() || new.is_empty() {
+        return None;
+    }
+    Some((normalise_qualified_name(new), old.clone()))
+}
+
 /// Look up a command alias, namespace-aware.
 ///
 /// Returns `(target_cmd, prepended_args)` or `None`.
@@ -172,6 +195,42 @@ mod tests {
     fn detect_non_alias() {
         let args: Vec<String> = vec!["eval".into(), "{}".into(), "puts hello".into()];
         assert!(detect_interp_alias("interp", &args).is_none());
+    }
+
+    #[test]
+    fn detect_rename_basic() {
+        let args: Vec<String> = vec!["eval".into(), "myEval".into()];
+        let result = detect_rename("rename", &args);
+        assert_eq!(result, Some(("::myEval".to_string(), "eval".to_string())));
+    }
+
+    #[test]
+    fn detect_rename_wrong_command() {
+        let args: Vec<String> = vec!["eval".into(), "myEval".into()];
+        assert!(detect_rename("puts", &args).is_none());
+    }
+
+    #[test]
+    fn detect_rename_deletion_form_is_not_an_alias() {
+        // `rename oldName {}` *deletes* oldName — not a rename.
+        let args: Vec<String> = vec!["eval".into(), String::new()];
+        assert!(detect_rename("rename", &args).is_none());
+    }
+
+    #[test]
+    fn detect_rename_wrong_arity() {
+        assert!(detect_rename("rename", &["eval".to_string()]).is_none());
+        assert!(detect_rename("rename", &[]).is_none());
+    }
+
+    #[test]
+    fn detect_rename_qualified_new_name() {
+        let args: Vec<String> = vec!["eval".into(), "::ns::myEval".into()];
+        let result = detect_rename("rename", &args);
+        assert_eq!(
+            result,
+            Some(("::ns::myEval".to_string(), "eval".to_string()))
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/alias.rs
+++ b/rust/tcl-compiler/src/alias.rs
@@ -24,7 +24,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use crate::naming::normalise_qualified_name;
+use crate::naming::{is_dynamic_word, normalise_qualified_name};
 
 /// Alias store: qualified name → (target command, prepended args).
 pub type CommandAliasMap = HashMap<String, (String, Vec<String>)>;
@@ -53,6 +53,16 @@ pub fn detect_interp_alias(
     let prepended: Vec<String> = args[5..].to_vec();
 
     if !matches!(src_path.as_str(), "" | "{}") || !matches!(target_path.as_str(), "" | "{}") {
+        return None;
+    }
+    // A dynamic target (`interp alias {} myEval {} $target`) cannot be
+    // resolved to a static command name; recording it verbatim would map
+    // `myEval` to the literal, never-registered string `"$target"`,
+    // silently dropping arg-role/body/sink treatment for `myEval` calls
+    // instead of just leaving them unaliased. A dynamic alias name
+    // (`interp alias {} $name {} eval`) is safe to skip too — the
+    // resulting key can never match a real call's literal command word.
+    if is_dynamic_word(alias_name) || is_dynamic_word(target_cmd) {
         return None;
     }
 
@@ -116,6 +126,14 @@ pub fn detect_rename(cmd_name: &str, args: &[String]) -> Option<(String, String)
     let old = &args[0];
     let new = &args[1];
     if old.is_empty() || new.is_empty() {
+        return None;
+    }
+    // `rename $old newName` / `rename oldName [x]` — a dynamic component
+    // means the true target isn't known statically; recording it verbatim
+    // would map `newName` to a literal, never-registered string like
+    // `"$old"`, silently dropping arg-role/body/sink treatment for
+    // `newName` calls instead of just leaving them unaliased.
+    if is_dynamic_word(old) || is_dynamic_word(new) {
         return None;
     }
     Some((normalise_qualified_name(new), old.clone()))
@@ -198,6 +216,34 @@ mod tests {
     }
 
     #[test]
+    fn detect_interp_alias_rejects_dynamic_target() {
+        // `interp alias {} myEval {} $target` — the true target isn't
+        // known statically; must not map `myEval` to the literal string
+        // `"$target"` (which would silently drop arg-role/sink treatment
+        // for `myEval` calls instead of just leaving them unaliased).
+        let args: Vec<String> = vec![
+            "alias".into(),
+            "{}".into(),
+            "myEval".into(),
+            "{}".into(),
+            "$target".into(),
+        ];
+        assert!(detect_interp_alias("interp", &args).is_none());
+    }
+
+    #[test]
+    fn detect_interp_alias_rejects_dynamic_name() {
+        let args: Vec<String> = vec![
+            "alias".into(),
+            "{}".into(),
+            "$name".into(),
+            "{}".into(),
+            "eval".into(),
+        ];
+        assert!(detect_interp_alias("interp", &args).is_none());
+    }
+
+    #[test]
     fn detect_rename_basic() {
         let args: Vec<String> = vec!["eval".into(), "myEval".into()];
         let result = detect_rename("rename", &args);
@@ -208,6 +254,23 @@ mod tests {
     fn detect_rename_wrong_command() {
         let args: Vec<String> = vec!["eval".into(), "myEval".into()];
         assert!(detect_rename("puts", &args).is_none());
+    }
+
+    #[test]
+    fn detect_rename_rejects_dynamic_old_name() {
+        // `rename $old eval` — the true source isn't known statically;
+        // must not map `eval` to the literal string `"$old"` (which would
+        // silently drop arg-role/sink treatment for genuine `eval` calls
+        // later in the same script instead of just leaving them
+        // unaliased).
+        let args: Vec<String> = vec!["$old".into(), "eval".into()];
+        assert!(detect_rename("rename", &args).is_none());
+    }
+
+    #[test]
+    fn detect_rename_rejects_dynamic_new_name() {
+        let args: Vec<String> = vec!["eval".into(), "myEval[x]".into()];
+        assert!(detect_rename("rename", &args).is_none());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -29,7 +29,7 @@ use tcl_registry::hooks::LoweringHookId;
 use tcl_registry::prelude::DialectSet;
 use tcl_registry::{ArgRole, CommandRegistry};
 
-use crate::alias::{CommandAliasMap, detect_interp_alias, resolve_alias};
+use crate::alias::{CommandAliasMap, detect_interp_alias, detect_rename, resolve_alias};
 use crate::ir::{
     CommandTokens, ForeachIterator, MethodDef, MethodKind, Module, Procedure, Script, Statement,
 };
@@ -1068,10 +1068,17 @@ impl<'r> Lowerer<'r> {
         let cmd_name = seg.name();
         let args = seg.args();
 
-        // Detect `interp alias {} name {} target ?args?`.
+        // Detect `interp alias {} name {} target ?args?` and static
+        // `rename oldName newName` — both feed the same alias table, since
+        // calling through a renamed name and calling through an `interp
+        // alias` are indistinguishable for arg-role / body-form resolution
+        // and taint sink dispatch (`interp alias {} myEval {} eval` and
+        // `rename eval myEval` both make `myEval $x` reach the `eval` sink).
         let args_owned: Vec<String> = args.to_vec();
         if let Some((qualified, target, prepended)) = detect_interp_alias(cmd_name, &args_owned) {
             self.aliases.insert(qualified, (target, prepended));
+        } else if let Some((qualified, target)) = detect_rename(cmd_name, &args_owned) {
+            self.aliases.insert(qualified, (target, Vec::new()));
         }
 
         self.record_namespace_directives(cmd_name, args, seg, namespace);

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -1266,12 +1266,30 @@ fn propagate_statement_taints(
 /// gate [`find_setter_constraint_warnings`] uses for IRULE3101, rather than
 /// relying on whether the shared registry happens to have those specs
 /// loaded.
+///
+/// Before any of that, a command declaring
+/// [`tcl_registry::CommandSpec::taint_sink_gate`] gets one more check: when
+/// this call's own option flags disable its hazard (`subst -nocommands`),
+/// the call is not a sink at all, regardless of which code it would
+/// otherwise have classified as.
 fn classify_sink(
     registry: &CommandRegistry,
     command: &str,
     args: &[String],
     dialect: Option<&str>,
 ) -> Option<(DiagCode, String)> {
+    // A call whose own option flags disable this command's hazard for
+    // *this* invocation (e.g. `subst -nocommands $tainted`) is not a sink
+    // at all — checked before any classification below.
+    if let Some(spec) = registry.get(command)
+        && let Some(gate) = spec.taint_sink_gate
+    {
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        if !gate(&arg_refs) {
+            return None;
+        }
+    }
+
     let subcommand = args.first().map(String::as_str);
     let info = tcl_registry::taint::classify_taint_sinks(
         registry,
@@ -1889,6 +1907,14 @@ pub fn find_taint_warnings<S: std::hash::BuildHasher, E: std::hash::BuildHasher>
         for ssa_stmt in &ssa_block.statements {
             emit_statement_warnings(ssa_stmt, taints, registry, dialect, &mut warnings, ssa);
         }
+        let branch_ctx = BranchTaintCtx {
+            ssa_block,
+            ssa,
+            taints,
+            registry,
+            dialect,
+        };
+        emit_branch_condition_warnings(cfg, bn, &branch_ctx, &mut warnings);
     }
 
     warnings
@@ -1912,13 +1938,21 @@ fn emit_statement_warnings<S: std::hash::BuildHasher>(
     let stmt = &ssa_stmt.statement;
     let span = stmt.span();
 
-    // AssignExpr / ExprEval: any tainted variable in the expression
-    // is a T100 violation (direct expr injection).
-    if matches!(
-        stmt,
-        Statement::AssignExpr { .. } | Statement::ExprEval { .. }
-    ) {
-        emit_expr_warnings(&ssa_stmt.uses, taints, span, warnings, ssa);
+    // AssignExpr / ExprEval: a tainted variable in a numeric-coercion
+    // position of the expression is a T100 violation (direct expr
+    // injection) — see `collect_coercion_operands` for which operator
+    // positions coerce and which (string/list comparisons) don't.
+    let expr = match stmt {
+        Statement::AssignExpr { expr, .. } | Statement::ExprEval { expr, .. } => Some(expr),
+        _ => None,
+    };
+    if let Some(expr) = expr {
+        let resolve = |name: &str| {
+            let sym = ssa.var_symbol(name)?;
+            let ver = *ssa_stmt.uses.get(&sym)?;
+            Some((sym, ver))
+        };
+        emit_expr_coercion_warnings(expr, None, span, resolve, taints, warnings);
         return;
     }
 
@@ -1932,14 +1966,20 @@ fn emit_statement_warnings<S: std::hash::BuildHasher>(
         Statement::AssignValue { value, .. } => parse_command_substitution(value.trim()),
         _ => None,
     };
+    // Prefer the canonical target the lowerer already resolved
+    // (`stmt.canonical_command_or_source()`, populated for a resolved
+    // `interp alias` or static `rename`) over the source spelling, so
+    // `interp alias {} myEval {} eval; myEval $tainted` (or `rename eval
+    // myEval; myEval $tainted`) is classified against `eval`'s registry
+    // sink data instead of silently missing it because `"myEval"` isn't a
+    // registered command. Falls back to the source name unchanged when no
+    // alias/rename was resolved (the common case). `tokens` carries the
+    // per-argument-word spans used to narrow a sink warning's highlight to
+    // the one tainted argument (`tight_arg_span`) — only available for a
+    // real `Call`/`Barrier` statement; the `AssignValue` fallback
+    // re-parses a nested `[cmd …]` out of the `set` RHS text and has no
+    // per-word spans for it, so it falls back to the whole-statement span.
     let (command, call_args, tokens): (&str, &[String], Option<&CommandTokens>) = match stmt {
-        // Prefer the canonical target the lowerer already resolved
-        // (`stmt.canonical_command_or_source()`, populated for a resolved
-        // `interp alias`) over the source spelling, so `interp alias {}
-        // myputs {} puts; myputs $tainted` is classified against `puts`'s
-        // registry sink data instead of silently missing it because
-        // `"myputs"` isn't a registered command. Falls back to the source
-        // name unchanged when no alias was resolved (the common case).
         Statement::Call { args, tokens, .. } | Statement::Barrier { args, tokens, .. } => (
             stmt.canonical_command_or_source(),
             args.as_slice(),
@@ -2093,37 +2133,296 @@ fn emit_regexp_pattern_warnings<S: std::hash::BuildHasher>(
     }
 }
 
-/// Emit T100 warnings for every tainted use in an expression context.
-fn emit_expr_warnings<S: std::hash::BuildHasher>(
-    uses: &HashMap<Symbol, u32>,
+/// One `ExprNode::Var` occurrence sitting in a numeric-coercion-relevant
+/// operator position — the KCS T100 "expr operand: numeric coercion"
+/// hazard (see [`collect_coercion_operands`]).
+struct CoercionOperand {
+    name: String,
+    /// Offset of this occurrence relative to the expr's own source text,
+    /// when known. `None` for a var recovered from an unparsed
+    /// [`ExprNode::Raw`] fallback, which carries no per-occurrence
+    /// position.
+    rel_span: Option<(u32, u32)>,
+}
+
+/// `true` when a binary operator attempts numeric (or, for `And`/`Or`,
+/// boolean) coercion of its operands — Tcl's arithmetic, bitwise, shift,
+/// numeric-comparison, and logical operators all do. The pure string/list
+/// operators (`eq`/`ne`/`lt`/`le`/`gt`/`ge`, `in`/`ni`, and the iRules
+/// word-comparison forms `contains`/`starts_with`/`ends_with`/`equals`/
+/// `matches_glob`/`matches_regex`) never coerce — `expr {$tainted eq
+/// "danger"}` carries no numeric-coercion hazard at all, so flagging it
+/// with that message would be a false positive.
+const fn binop_coerces(op: crate::expr_ast::BinOp) -> bool {
+    use crate::expr_ast::BinOp;
+    !matches!(
+        op,
+        BinOp::StrEq
+            | BinOp::StrNe
+            | BinOp::StrLt
+            | BinOp::StrLe
+            | BinOp::StrGt
+            | BinOp::StrGe
+            | BinOp::In
+            | BinOp::Ni
+            | BinOp::Contains
+            | BinOp::StartsWith
+            | BinOp::EndsWith
+            | BinOp::StrEquals
+            | BinOp::MatchesGlob
+            | BinOp::MatchesRegex
+    )
+}
+
+/// Collect every `Var` occurrence of `expr` that sits in a position where
+/// Tcl attempts numeric or boolean coercion of the operand.
+///
+/// `in_context` is the coercion status of `expr` itself as seen by its
+/// parent (the top-level call passes `true`: a braced expr's overall
+/// result is used as a number/boolean by its caller). Recursion rules:
+///
+/// - `Binary`: both children inherit [`binop_coerces`] of the operator —
+///   a string-safe operator (`eq`, `in`, …) clears the context for its
+///   *own* operands, but a nested coercing sub-expression on either side
+///   still flags independently (`($a + 1) eq "3"` still flags `$a`).
+/// - `Unary`: all five unary operators (arithmetic negation, bitwise
+///   complement, logical `!`/`not`) coerce their operand.
+/// - `Ternary`: the condition is always boolean-coerced; each branch
+///   *inherits* the ternary's own context, since whichever branch's value
+///   flows out stands in for the ternary as a whole in the parent
+///   operator (`($c ? $tainted : 0) + 1` must still flag `$tainted`).
+/// - `Call` (a math function): every argument is numeric, regardless of
+///   context.
+/// - `Command` (`[cmd …]`, a nested command substitution): opaque — its
+///   contents are a separate statement's own arguments, not an expr
+///   operand at all, so this walk does not descend into it. If `cmd` is
+///   itself a T100/T101/… sink, that nested statement's own sink
+///   classification already covers it.
+/// - `Raw` (unparsed fallback text): position-blind but conservative —
+///   every variable found by [`ExprNode::vars`] is flagged (`rel_span:
+///   None`) regardless of `in_context`, since the parser gave up and the
+///   operator structure inside is unknown; erring towards a false
+///   positive here is safer than silently dropping coverage.
+fn collect_coercion_operands(expr: &ExprNode, in_context: bool, out: &mut Vec<CoercionOperand>) {
+    match expr {
+        ExprNode::Var {
+            name, start, end, ..
+        } => {
+            if in_context && !name.is_empty() {
+                out.push(CoercionOperand {
+                    name: name.clone(),
+                    rel_span: Some((*start, *end)),
+                });
+            }
+        }
+        ExprNode::Literal { .. } | ExprNode::String { .. } | ExprNode::Command { .. } => {}
+        ExprNode::Binary { op, left, right } => {
+            let child_ctx = binop_coerces(*op);
+            collect_coercion_operands(left, child_ctx, out);
+            collect_coercion_operands(right, child_ctx, out);
+        }
+        ExprNode::Unary { operand, .. } => {
+            collect_coercion_operands(operand, true, out);
+        }
+        ExprNode::Ternary {
+            condition,
+            true_branch,
+            false_branch,
+        } => {
+            collect_coercion_operands(condition, true, out);
+            collect_coercion_operands(true_branch, in_context, out);
+            collect_coercion_operands(false_branch, in_context, out);
+        }
+        ExprNode::Call { args, .. } => {
+            for arg in args {
+                collect_coercion_operands(arg, true, out);
+            }
+        }
+        ExprNode::Raw { text } => {
+            for name in (ExprNode::Raw { text: text.clone() }).vars() {
+                out.push(CoercionOperand {
+                    name,
+                    rel_span: None,
+                });
+            }
+        }
+    }
+}
+
+/// Emit T100 warnings for numeric-coercion-risk operands of a braced
+/// `expr` — an `AssignExpr`/`ExprEval` statement, or an `if`/`while`/`for`
+/// branch condition (see [`emit_branch_condition_warnings`]).
+///
+/// `resolve` maps a variable name occurring in `expr` to the `(Symbol,
+/// SSA version)` reaching this point; a `None` result skips that
+/// occurrence (no binding here). `base_offset`, when `Some`, is the
+/// absolute source offset of `expr`'s own text — `ExprNode::Var` offsets
+/// are relative to it, so a hit's absolute span is computable; `None`
+/// (or a `Raw`-derived hit with no `rel_span`) falls back to
+/// `fallback_span`, the caller's coarser span for the whole expr.
+fn emit_expr_coercion_warnings<S: std::hash::BuildHasher>(
+    expr: &ExprNode,
+    base_offset: Option<u32>,
+    fallback_span: Span,
+    resolve: impl Fn(&str) -> Option<(Symbol, u32)>,
     taints: &HashMap<ValueKey, TaintLattice, S>,
-    span: Span,
     warnings: &mut Vec<TaintWarning>,
-    ssa: &SsaFunction,
 ) {
-    for (&sym, &ver) in uses {
-        let name = ssa.var_name(sym);
-        if is_seeded_global_v0(name, ver) {
+    let mut hits = Vec::new();
+    collect_coercion_operands(expr, true, &mut hits);
+    let mut emitted: FxHashSet<Symbol> = FxHashSet::default();
+    for hit in hits {
+        let Some((sym, ver)) = resolve(&hit.name) else {
+            continue;
+        };
+        if is_seeded_global_v0(&hit.name, ver) || !emitted.insert(sym) {
             continue;
         }
         let t = taints
             .get(&(sym, ver))
             .copied()
             .unwrap_or(TaintLattice::clean());
-        if t.is_tainted() {
-            warnings.push(TaintWarning {
-                span,
-                variable: name.to_owned(),
-                sink_command: "expr".to_owned(),
-                code: DiagCode::T100,
-                message: format!(
-                    "Tainted variable ${name} flows into expr operand; \
-                     numeric coercion may misinterpret value \
-                     (use Tcl numeric-validation guards)"
-                ),
-                replacement: None,
-            });
+        if !t.is_tainted() {
+            continue;
         }
+        let span = match (hit.rel_span, base_offset) {
+            (Some((s, e)), Some(base)) => Span::new(base + s, base + e),
+            _ => fallback_span,
+        };
+        warnings.push(TaintWarning {
+            span,
+            variable: hit.name.clone(),
+            sink_command: "expr".to_owned(),
+            code: DiagCode::T100,
+            message: format!(
+                "Tainted variable ${} flows into expr operand; \
+                 numeric coercion may misinterpret value \
+                 (use Tcl numeric-validation guards)",
+                hit.name
+            ),
+            replacement: None,
+        });
+    }
+}
+
+/// Per-block context for the branch-condition taint scan, bundled so
+/// [`emit_branch_condition_warnings`] / [`emit_branch_condition_nested_command_warnings`]
+/// stay under the 7-argument clippy limit — mirrors [`TaintScan`] /
+/// [`SinkCall`] elsewhere in this module.
+struct BranchTaintCtx<'a, S> {
+    /// The condition's own block — `exit_versions` gives the SSA version of
+    /// each condition variable reaching the terminator.
+    ssa_block: &'a crate::ssa::SsaBlock,
+    ssa: &'a SsaFunction,
+    taints: &'a HashMap<ValueKey, TaintLattice, S>,
+    registry: &'a CommandRegistry,
+    dialect: Option<&'a str>,
+}
+
+/// Emit taint warnings for a block's `if`/`while`/`for` branch condition:
+/// T100 for a numeric-coercion-risk operand directly in the condition
+/// expression, plus the full sink family for any nested `[cmd …]`
+/// command substitution the condition contains (see
+/// [`emit_branch_condition_nested_command_warnings`]).
+///
+/// Branch conditions live on `Terminator::Branch`, not in
+/// `ssa_block.statements` — `find_taint_warnings`'s per-statement scan
+/// never reaches them, so without this dedicated pass a condition like
+/// `if {$tainted + 1 > 5} { … }` raised no T100 at all, even though it is
+/// evaluated exactly like any other braced `expr`. Resolves each
+/// condition variable's SSA version via the block's `exit_versions` (the
+/// version reaching the terminator), mirroring how
+/// [`crate::sccp::branch_decision`]'s constant-folding reads the same
+/// condition. Uses the condition's own span (tight — just the `{…}` text,
+/// not the enclosing `if`/`while`/`for` statement) for every hit: unlike
+/// `AssignExpr`/`ExprEval`, no absolute per-variable offset is threaded
+/// through the CFG-flattened `Terminator::Branch`, so this falls back to
+/// the whole-condition span rather than a per-operand one.
+fn emit_branch_condition_warnings<S: std::hash::BuildHasher>(
+    cfg: &CfgFunction,
+    bn: BlockId,
+    ctx: &BranchTaintCtx<'_, S>,
+    warnings: &mut Vec<TaintWarning>,
+) {
+    let Some(block) = cfg.blocks.get(&bn) else {
+        return;
+    };
+    let Some(Terminator::Branch {
+        condition, span, ..
+    }) = &block.terminator
+    else {
+        return;
+    };
+    let Some(fallback_span) = span else {
+        return;
+    };
+    let resolve = |name: &str| {
+        let sym = ctx.ssa.var_symbol(name)?;
+        let ver = ctx.ssa_block.exit_versions.get(&sym).copied().unwrap_or(0);
+        Some((sym, ver))
+    };
+    emit_expr_coercion_warnings(
+        condition,
+        None,
+        *fallback_span,
+        resolve,
+        ctx.taints,
+        warnings,
+    );
+    emit_branch_condition_nested_command_warnings(condition, ctx, *fallback_span, warnings);
+}
+
+/// Emit sink warnings for `[cmd …]` command substitutions nested inside a
+/// branch condition (e.g. `if {[exec $x] eq "ok"} { … }`).
+///
+/// A nested command substitution executes exactly like any other
+/// statement's, but the CFG builder's synthetic `<cond>` placeholder
+/// statement (`cfg_lower::lower_if`/`lower_for`/`lower_while`) records
+/// only `catch`/`regexp`-style output vars for W210 — not the real
+/// command name or arguments — so `find_taint_warnings`'s per-statement
+/// scan has nothing to dispatch `classify_sink` against for it. Uses
+/// [`ExprNode::command_texts`] to recover each nested `[cmd …]` verbatim
+/// (already the shape `classify_sink`/`emit_sink_warnings` expect, the
+/// same one the `AssignValue` "owned fallback" path re-parses), resolves
+/// its argument variables' SSA versions the same way as the coercion
+/// scan above, and reuses the very same sink classification and warning
+/// emission every other call site in this module goes through — no new
+/// per-command knowledge, just a new place a command's arguments can
+/// come from.
+fn emit_branch_condition_nested_command_warnings<S: std::hash::BuildHasher>(
+    condition: &ExprNode,
+    ctx: &BranchTaintCtx<'_, S>,
+    fallback_span: Span,
+    warnings: &mut Vec<TaintWarning>,
+) {
+    for text in condition.command_texts() {
+        let Some((command, call_args)) = parse_command_substitution(&text) else {
+            continue;
+        };
+        let Some((code, sink_label)) =
+            classify_sink(ctx.registry, &command, &call_args, ctx.dialect)
+        else {
+            continue;
+        };
+        let mut uses: HashMap<Symbol, u32> = HashMap::new();
+        for name in arg_var_names(&text) {
+            if let Some(sym) = ctx.ssa.var_symbol(&name) {
+                let ver = ctx.ssa_block.exit_versions.get(&sym).copied().unwrap_or(0);
+                uses.insert(sym, ver);
+            }
+        }
+        let env = TaintScan {
+            uses: &uses,
+            taints: ctx.taints,
+            ssa: ctx.ssa,
+        };
+        let sink_call = SinkCall {
+            command: &command,
+            args: &call_args,
+            registry: ctx.registry,
+            tokens: None,
+        };
+        emit_sink_warnings(&env, fallback_span, code, &sink_label, &sink_call, warnings);
     }
 }
 
@@ -2146,11 +2445,13 @@ struct SinkCall<'a> {
     /// Command registry — drives the position-aware sink filters
     /// (network-address slots, `[list]`-head recognition).
     registry: &'a CommandRegistry,
-    /// Per-word token spans for this call, when the statement carries them
-    /// (`None` for a synthetic call parsed out of an `AssignValue`'s command
-    /// substitution text, which has no token-span backing). Drives the
-    /// tight per-argument diagnostic span in [`sink_arg_span`] so the
-    /// squiggle lands on the tainted word, not the whole command.
+    /// Per-word source spans for this call, when available (`Statement::Call`
+    /// / `Statement::Barrier` carry them; the `AssignValue` "owned fallback"
+    /// path — a nested `[cmd …]` re-parsed out of a `set` RHS — does not, so
+    /// `None` there, and the synthetic sink call built for a nested `[cmd
+    /// …]` inside a branch condition also passes `None`). Drives
+    /// [`sink_arg_span`]'s per-argument highlighting; `None` falls every hit
+    /// back to the whole-statement span.
     tokens: Option<&'a CommandTokens>,
 }
 
@@ -2160,7 +2461,10 @@ struct SinkCall<'a> {
 /// name, `argv` does not). Falls back to `fallback` (the whole-statement
 /// span) when no token spans are available, or `name` isn't found in any
 /// argument word (e.g. it reached the sink through an already-resolved
-/// alias with no textual match).
+/// alias with no textual match). Narrows the T100/T101-family highlight
+/// from "the whole sink statement" down to "the one argument word that
+/// carries the tainted value" — e.g. `eval "prefix" $x "suffix"` underlines
+/// only `$x`.
 fn sink_arg_span(call: &SinkCall<'_>, name: &str, fallback: Span) -> Span {
     let Some(tokens) = call.tokens else {
         return fallback;
@@ -4387,6 +4691,320 @@ mod tests {
         assert!(
             warnings[0].span.start() > warnings[1].span.start(),
             "expected name order (aaa before bbb) regardless of source order: {warnings:?}",
+        );
+    }
+
+    /// TP: `interp alias {} myEval {} eval; myEval $x` still raises T100 —
+    /// `classify_sink` dispatches on `Statement::canonical_command_or_source()`,
+    /// so the alias resolves to `eval` even though the source spells the call
+    /// `myEval`, which is not itself a registered command.
+    #[test]
+    fn t100_fires_through_interp_alias_indirection() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "interp alias {} myEval {} eval\n\
+                       set x [gets stdin]\n\
+                       myEval $x\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().any(|w| w.code == DiagCode::T100),
+            "expected T100 through the `myEval` alias for `eval`, got {warnings:?}",
+        );
+    }
+
+    /// TP: `rename eval myEval; myEval $x` also raises T100 — the same
+    /// `CommandAliasMap` mechanism `interp alias` uses now also recognises
+    /// a static `rename oldName newName` (`detect_rename`), so a renamed
+    /// built-in resolves through `canonical_command_or_source()` exactly
+    /// like an `interp alias`.
+    #[test]
+    fn t100_fires_through_rename_indirection() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "rename eval myEval\n\
+                       set x [gets stdin]\n\
+                       myEval $x\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().any(|w| w.code == DiagCode::T100),
+            "expected T100 through the `myEval` rename of `eval`, got {warnings:?}",
+        );
+    }
+
+    /// TN: without the alias, a plain user command named `myEval` is not a
+    /// sink at all — proves the alias fix above isn't matching on the bare
+    /// name.
+    #[test]
+    fn t100_silent_for_unaliased_lookalike_command() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "proc myEval {x} { return $x }\n\
+                       set x [gets stdin]\n\
+                       myEval $x\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().all(|w| w.code != DiagCode::T100),
+            "a user proc named myEval must not be treated as the eval sink, got {warnings:?}",
+        );
+    }
+
+    /// TP: `puts $tainted` still raises T101 (not T100) end-to-end, now via
+    /// the registry-driven `taint_output_sink` dispatch in `classify_sink`
+    /// rather than a hardcoded `command == "puts"` match.
+    #[test]
+    fn t101_fires_for_puts_via_registry_driven_dispatch() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "set x [gets stdin]\nputs $x\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().any(|w| w.code == DiagCode::T101),
+            "expected T101 for tainted puts, got {warnings:?}",
+        );
+        assert!(
+            warnings.iter().all(|w| w.code != DiagCode::T100),
+            "puts must not also raise T100, got {warnings:?}",
+        );
+    }
+
+    /// FP fix / TN: `subst -nocommands $tainted` — the exact mitigation
+    /// `subst`'s own hover snippet recommends — must not raise T100, since
+    /// `-nocommands` disables the only hazard (command substitution) the
+    /// code names.
+    #[test]
+    fn t100_silent_for_subst_nocommands() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "set x [gets stdin]\nsubst -nocommands $x\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().all(|w| w.code != DiagCode::T100),
+            "subst -nocommands must not raise T100, got {warnings:?}",
+        );
+    }
+
+    /// TP regression: plain `subst $tainted` (no flags) keeps raising T100 —
+    /// the new sink gate must not suppress the common, genuinely dangerous
+    /// default-options call.
+    #[test]
+    fn t100_fires_for_subst_without_nocommands() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "set x [gets stdin]\nsubst $x\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().any(|w| w.code == DiagCode::T100),
+            "expected T100 for bare `subst $x`, got {warnings:?}",
+        );
+    }
+
+    /// TN: the Tcl 9.1 positive option form without `-commands` is equally
+    /// safe — `-variables` alone never runs command substitution.
+    #[test]
+    fn t100_silent_for_subst_positive_form_without_commands() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "set x [gets stdin]\nsubst -variables $x\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().all(|w| w.code != DiagCode::T100),
+            "subst -variables (Tcl 9.1 positive form) must not raise T100, got {warnings:?}",
+        );
+    }
+
+    /// TP: the Tcl 9.1 positive form *with* `-commands` present stays a sink.
+    #[test]
+    fn t100_fires_for_subst_positive_form_with_commands() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "set x [gets stdin]\nsubst -variables -commands $x\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().any(|w| w.code == DiagCode::T100),
+            "expected T100 for `subst -variables -commands $x`, got {warnings:?}",
+        );
+    }
+
+    /// FN fix — TP: a tainted variable used directly in an `if` branch
+    /// condition is evaluated exactly like any other braced `expr`, but
+    /// conditions live on `Terminator::Branch`, not in `ssa_block.statements`,
+    /// so the per-statement scan alone never reached them. Confirmed
+    /// previously absent by direct testing before `emit_branch_condition_warnings`
+    /// was added.
+    #[test]
+    fn t100_fires_for_tainted_if_condition() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source =
+            "proc f {} {\n  set x [gets stdin]\n  if {$x + 1 > 5} {\n    puts big\n  }\n}\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        let hit = warnings
+            .iter()
+            .find(|w| w.code == DiagCode::T100)
+            .unwrap_or_else(|| panic!("expected T100 for tainted if-condition, got {warnings:?}"));
+        // Tight span: just the `{...}` condition text, not the whole
+        // `if {...} { puts big }` statement (which also spans the body).
+        let text = &source[hit.span.start() as usize..hit.span.end() as usize];
+        assert!(
+            text.contains("$x + 1 > 5") && !text.contains("puts"),
+            "expected a condition-only span, got {text:?}",
+        );
+    }
+
+    /// TP: the same hazard through `while` and `for` conditions.
+    #[test]
+    fn t100_fires_for_tainted_while_and_for_conditions() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        for source in [
+            "proc f {} {\n  set x [gets stdin]\n  while {$x < 10} {\n    incr x\n  }\n}\n",
+            "proc f {} {\n  set x [gets stdin]\n  for {set i 0} {$i < $x} {incr i} {\n    puts $i\n  }\n}\n",
+        ] {
+            let cu = CompilationUnit::build_for(source, &registry, false)
+                .with_interprocedural(&registry, None);
+            let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+            assert!(
+                warnings.iter().any(|w| w.code == DiagCode::T100),
+                "expected T100 for tainted loop condition in {source:?}, got {warnings:?}",
+            );
+        }
+    }
+
+    /// FP fix / TN: `if {$tainted eq "admin"}` raises nothing — `eq` is a
+    /// pure string comparison with no numeric coercion, so neither the
+    /// "numeric coercion" message nor any other T100 variant applies. This
+    /// also proves the branch-condition pass reuses the same
+    /// `collect_coercion_operands` operator-context filter as the
+    /// `AssignExpr`/`ExprEval` path, not a re-implementation that flags
+    /// every variable indiscriminately.
+    #[test]
+    fn t100_silent_for_string_only_if_condition() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source =
+            "proc f {} {\n  set x [gets stdin]\n  if {$x eq \"admin\"} {\n    puts ok\n  }\n}\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().all(|w| w.code != DiagCode::T100),
+            "eq is a pure string compare, expected no T100, got {warnings:?}",
+        );
+    }
+
+    /// FP fix — TN: a tainted variable that only appears inside a nested
+    /// `[cmd $x]` command substitution within a braced expr must not be
+    /// flagged as an "expr operand: numeric coercion" hit — it flows into
+    /// that nested call's own argument, a completely different risk
+    /// category (code execution, if `cmd` is itself dangerous) which that
+    /// call's own sink classification already covers independently.
+    #[test]
+    fn t100_expr_operand_message_not_raised_for_var_only_in_nested_command_sub() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        // `string length` is a sanitiser (fixed numeric return) and not a
+        // sink, so the nested call itself raises nothing either — isolating
+        // the "expr operand" false positive this test targets.
+        let source = "proc f {} {\n  set x [gets stdin]\n  if {[string length $x] > 5} {\n    puts big\n  }\n}\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().all(|w| w.code != DiagCode::T100),
+            "$x only reaches a nested command-sub argument, not a direct \
+             expr operand; expected no T100, got {warnings:?}",
+        );
+    }
+
+    /// TP: a tainted variable nested through a nested command sub still
+    /// raises T100 when that nested command is *itself* a sink.
+    #[test]
+    fn t100_fires_when_nested_command_sub_is_itself_a_sink() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "proc f {} {\n  set x [gets stdin]\n  if {[exec $x] eq \"ok\"} {\n    puts ok\n  }\n}\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().any(|w| w.code == DiagCode::T100),
+            "expected T100 from the nested `exec $x`, got {warnings:?}",
+        );
+    }
+
+    /// TP: `$tainted` inside a ternary branch still flags when the ternary
+    /// itself sits in a numeric-coercion position — the branch's value
+    /// stands in for the ternary as a whole in the parent operator.
+    #[test]
+    fn t100_fires_for_tainted_var_through_ternary_branch_in_coercing_context() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "proc f {c} {\n  set x [gets stdin]\n  if {($c ? $x : 0) + 1 > 5} {\n    puts big\n  }\n}\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().any(|w| w.code == DiagCode::T100),
+            "expected T100 for $x flowing through a coerced ternary branch, got {warnings:?}",
+        );
+    }
+
+    /// TP: the ternary *condition* is always boolean-coerced, regardless of
+    /// the ternary's own surrounding context.
+    #[test]
+    fn t100_fires_for_tainted_var_in_ternary_condition() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source =
+            "proc f {} {\n  set x [gets stdin]\n  if {$x ? \"a\" : \"b\"} {\n    puts ok\n  }\n}\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        assert!(
+            warnings.iter().any(|w| w.code == DiagCode::T100),
+            "expected T100 for tainted ternary condition, got {warnings:?}",
+        );
+    }
+
+    /// Precision: `eval "prefix" $x "suffix"` underlines only the `$x`
+    /// argument word (2 characters), not the whole `eval "prefix" $x
+    /// "suffix"` statement — `tight_arg_span` narrows the highlight to the
+    /// one argument word that actually carries the tainted value, using the
+    /// real per-word source spans a compiled `Statement::Call` carries.
+    #[test]
+    fn t100_span_is_the_tainted_argument_word_not_the_whole_statement() {
+        use crate::compilation_unit::CompilationUnit;
+        let registry = CommandRegistry::build_default();
+        let source = "proc f {} {\n  set x [gets stdin]\n  eval \"prefix\" $x \"suffix\"\n}\n";
+        let cu = CompilationUnit::build_for(source, &registry, false)
+            .with_interprocedural(&registry, None);
+        let warnings = find_taint_warnings_for_cu(&cu, &registry, None);
+        let hit = warnings
+            .iter()
+            .find(|w| w.code == DiagCode::T100)
+            .unwrap_or_else(|| panic!("expected T100, got {warnings:?}"));
+        let text = &source[hit.span.start() as usize..hit.span.end() as usize];
+        assert_eq!(
+            text, "$x",
+            "expected the tight `$x` argument span, got {text:?} from {hit:?}",
         );
     }
 }

--- a/rust/tcl-compiler/tests/side_effects_binding.rs
+++ b/rust/tcl-compiler/tests/side_effects_binding.rs
@@ -822,6 +822,20 @@ fn stmt_command(stmt: &Statement) -> &str {
     stmt.canonical_command_or_source()
 }
 
+/// Source-surface command spelling of a statement — never the resolved
+/// canonical name. `Statement::canonical_command_or_source()` now also
+/// resolves through a static `rename` (`tcl_compiler::alias::detect_rename`),
+/// not just `interp alias`, so a test that locates a statement *by its
+/// literal source text* (e.g. "the bare `b` call after `rename a b`") must
+/// not use it — `canonical_command_or_source()` would return `"a"` there,
+/// not `"b"`.
+fn stmt_source_command(stmt: &Statement) -> &str {
+    match stmt {
+        Statement::Call { command, .. } | Statement::Barrier { command, .. } => command.as_str(),
+        _ => "",
+    }
+}
+
 /// Binding of `query` at the first statement whose command (canonical-or-source)
 /// equals `canonical`.
 fn binding_at_command(
@@ -842,12 +856,14 @@ fn binding_at_command(
     panic!("no statement with command {canonical:?}");
 }
 
-/// Index of the first statement in the entry block whose command equals `name`.
+/// Index of the first statement in the entry block whose *source-surface*
+/// command equals `name` (not the alias/rename-resolved canonical name —
+/// see [`stmt_source_command`]).
 fn stmt_idx_in_entry(cfg: &tcl_compiler::cfg::Function, name: &str) -> usize {
     let blk = cfg.blocks.get(&cfg.entry).expect("entry block");
     blk.statements
         .iter()
-        .position(|s| stmt_command(s) == name)
+        .position(|s| stmt_source_command(s) == name)
         .unwrap_or_else(|| panic!("no statement {name:?} in entry block"))
 }
 

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -1872,6 +1872,41 @@ fn strip_crlf_before_output(line: &str, d: &ContextDiagnostic, var: &str) -> Vec
     }]
 }
 
+/// Build the "add `-nocommands`" T100 quick-fix for a `subst` sink:
+/// inserts `-nocommands` right after the standalone `subst` word on
+/// `line`, or no action when the line doesn't contain one (defensive —
+/// the caller already matched the diagnostic message, so this should
+/// always find it).
+fn subst_nocommands_fix(line: &str, line_no: u32) -> Vec<CodeAction> {
+    let bytes = line.as_bytes();
+    let Some(start) = line.find("subst") else {
+        return Vec::new();
+    };
+    let word_start_ok = start == 0 || !bytes[start - 1].is_ascii_alphanumeric();
+    let after = start + "subst".len();
+    let word_end_ok = bytes.get(after).is_none_or(|c| !c.is_ascii_alphanumeric());
+    if !word_start_ok || !word_end_ok {
+        return Vec::new();
+    }
+    let insert_char_col = line[..after].chars().count();
+    let insert_col = char_col_to_utf16_local(line, insert_char_col);
+    vec![CodeAction {
+        title: "Add -nocommands to disable command substitution".to_string(),
+        edits: vec![crate::rename::TextEdit {
+            range: LspRange {
+                start_line: line_no,
+                start_character: insert_col,
+                end_line: line_no,
+                end_character: insert_col,
+            },
+            new_text: " -nocommands".to_string(),
+        }],
+        kind: ActionKind::QuickFix,
+        command: None,
+        data_group_definition: None,
+    }]
+}
+
 fn taint_quickfix(source: &str, d: &ContextDiagnostic) -> Vec<CodeAction> {
     let line_no = d.range.start_line as usize;
     let Some(line) = source.split('\n').nth(line_no) else {
@@ -1886,6 +1921,16 @@ fn taint_quickfix(source: &str, d: &ContextDiagnostic) -> Vec<CodeAction> {
     }
     if d.code == "T101" || d.code == "IRULE3003" {
         return strip_crlf_before_output(line, d, &var);
+    }
+
+    // T100 on a `subst` sink: `-nocommands` disables the only hazard the
+    // diagnostic names (command substitution) without changing the call's
+    // variable/backslash substitution behaviour — exactly the mitigation
+    // `subst`'s own hover snippet recommends. Other T100 sinks (`eval`,
+    // `uplevel`, `exec`, a braced `expr` operand) have no equivalent
+    // single-flag fix, so this only fires for the `subst` sink label.
+    if d.code == "T100" && d.message.contains(" into subst;") {
+        return subst_nocommands_fix(line, d.range.start_line);
     }
 
     let (encoder, proc_template): (&str, Option<&str>) = match d.code.as_str() {

--- a/rust/tcl-lsp-core/tests/code_actions_depth.rs
+++ b/rust/tcl-lsp-core/tests/code_actions_depth.rs
@@ -636,6 +636,56 @@ fn context_t106_removes_redundant_encoder_wrapper() {
 }
 
 #[test]
+fn context_t100_subst_offers_nocommands_fix() {
+    // T100 on a `subst` sink offers a mechanical, single-flag fix:
+    // `-nocommands` disables the only hazard the diagnostic names (command
+    // substitution) without touching the call's variable/backslash
+    // substitution behaviour — the exact mitigation `subst`'s own hover
+    // snippet recommends.
+    let src = "set out [subst $tainted]\n";
+    let diags = vec![ContextDiagnostic {
+        code: "T100".to_string(),
+        message: "Tainted variable $tainted flows into subst; possible code injection".to_string(),
+        range: cursor(0, 9),
+    }];
+    let actions = context_diagnostic_actions(src, &diags);
+    let fix = find(&actions, "-nocommands").expect("a T100 subst -nocommands fix");
+    assert_eq!(fix.kind, ActionKind::QuickFix);
+    assert_eq!(fix.edits.len(), 1);
+    assert!(
+        edits_well_formed(fix) && edits_in_bounds(fix, src),
+        "{fix:?}"
+    );
+    assert_eq!(fix.edits[0].new_text, " -nocommands");
+    // Applying the edit at its own range must produce a well-formed
+    // `subst -nocommands $tainted` call.
+    let col = fix.edits[0].range.start_character as usize;
+    let line = src.lines().next().unwrap();
+    let mut patched = line.to_string();
+    patched.insert_str(col, &fix.edits[0].new_text);
+    assert_eq!(patched, "set out [subst -nocommands $tainted]");
+}
+
+#[test]
+fn context_t100_non_subst_sink_offers_no_fix() {
+    // T100 on a non-`subst` sink (`eval`) has no single-flag mitigation, so
+    // no quick fix is offered — matches the diagnostic's own hover advice
+    // (`{*}$cmdList` / direct invocation), neither of which is a mechanical
+    // same-shape rewrite.
+    let src = "eval $tainted\n";
+    let diags = vec![ContextDiagnostic {
+        code: "T100".to_string(),
+        message: "Tainted variable $tainted flows into eval; possible code injection".to_string(),
+        range: cursor(0, 5),
+    }];
+    let actions = context_diagnostic_actions(src, &diags);
+    assert!(
+        find(&actions, "-nocommands").is_none(),
+        "eval sink must not offer the subst-only fix: {actions:?}"
+    );
+}
+
+#[test]
 fn context_irule3001_wraps_tainted_var_with_html_encode() {
     // IRULE3001 (reflected XSS) offers an `[html_encode $var]` wrap, and — since
     // `html_encode` is a user proc, not a built-in — inserts the helper proc at

--- a/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
@@ -104,6 +104,13 @@ const MATRIX: &[Case] = &[
         silent: "set x [gets stdin]\nset n [string length $x]\nputs $n\n",
         note: "tainted data flows into puts output sink",
     },
+    Case {
+        code: "T100",
+        fire: "proc p {} {\n    set x [gets stdin]\n    if {$x + 1 > 5} {\n        puts big\n    }\n}\n",
+        silent: "proc p {} {\n    set x [gets stdin]\n    if {$x eq \"5\"} {\n        puts big\n    }\n}\n",
+        note: "tainted var as a direct numeric operand of an if-condition (+ is a \
+               coercion hazard; eq is a pure string compare and isn't)",
+    },
 ];
 
 /// The set of `code` strings carried by `diags` (mirrors Python `_codes`).
@@ -222,6 +229,10 @@ fn i230_fires_on_defect() {
 fn t101_fires_on_defect() {
     assert_fires(case_for("T101"));
 }
+#[test]
+fn t100_fires_on_defect() {
+    assert_fires(case_for("T100"));
+}
 
 // -- silent cases --------------------------------------------------------
 
@@ -264,6 +275,10 @@ fn i230_silent_on_corrected_form() {
 #[test]
 fn t101_silent_on_corrected_form() {
     assert_silent(case_for("T101"));
+}
+#[test]
+fn t100_silent_on_corrected_form() {
+    assert_silent(case_for("T100"));
 }
 
 // -- TestOptimisationMatrix ----------------------------------------------

--- a/rust/tcl-lsp-server/tests/e2e/irules.rs
+++ b/rust/tcl-lsp-server/tests/e2e/irules.rs
@@ -512,6 +512,32 @@ fn t102_insert_double_dash() {
 }
 
 #[test]
+fn t100_subst_add_nocommands() {
+    let mut lsp = Lsp::irules();
+    let actions = taint_fix(
+        &mut lsp,
+        "subst $tainted\n",
+        "T100",
+        "Tainted variable $tainted flows into subst; possible code injection",
+        (0, 0),
+        (0, 14),
+    );
+    let fixes: Vec<Value> = actions
+        .as_array()
+        .unwrap_or(&Vec::new())
+        .iter()
+        .filter(|a| action_title(a).contains("-nocommands"))
+        .cloned()
+        .collect();
+    assert_eq!(fixes.len(), 1);
+    assert!(
+        ca_new_texts(&json!(fixes))
+            .iter()
+            .any(|s| s.contains("-nocommands"))
+    );
+}
+
+#[test]
 fn braced_variable_wrapped() {
     let mut lsp = Lsp::irules();
     let actions = taint_fix(

--- a/rust/tcl-registry/src/commands/tcl/subst_.rs
+++ b/rust/tcl-registry/src/commands/tcl/subst_.rs
@@ -108,6 +108,43 @@ fn fold_subst(args: &[&str]) -> Option<String> {
     Some((*s).to_owned())
 }
 
+/// Whether a `subst` call — given its argument words, excluding the
+/// command name — performs *command* substitution, the only hazard T100
+/// warns about for this command (variable and backslash substitution alone
+/// cannot execute anything). Drives `CommandSpec::taint_sink_gate`, so
+/// `subst -nocommands $tainted` — the exact mitigation this command's own
+/// hover snippet recommends — no longer trips the code-injection sink it
+/// was written to avoid.
+///
+/// The legacy negative options (`-nobackslashes`/`-nocommands`/
+/// `-novariables`) default every substitution *on*, each disabling one;
+/// `-nocommands` anywhere disables command substitution outright. Tcl
+/// 9.1's positive options (`-backslashes`/`-commands`/`-variables`) invert
+/// that: default every substitution *off*, each enabling one, so command
+/// substitution then runs only when `-commands` is itself present. Tcl
+/// rejects mixing the two families in one call, so seeing any positive
+/// flag switches this scan to positive mode; option scanning stops at the
+/// first non-flag word (the `string` operand).
+fn subst_evaluates_commands(args: &[&str]) -> bool {
+    let mut positive_mode = false;
+    let mut nocommands = false;
+    let mut commands = false;
+    for &a in args {
+        match a {
+            "-commands" => {
+                commands = true;
+                positive_mode = true;
+            }
+            "-backslashes" | "-variables" => positive_mode = true,
+            "-nocommands" => nocommands = true,
+            "--" => break,
+            _ if a.starts_with('-') => {}
+            _ => break,
+        }
+    }
+    if positive_mode { commands } else { !nocommands }
+}
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "subst",
@@ -129,13 +166,59 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         options: OPTIONS,
         side_effects: SIDE_EFFECTS,
+        taint_sink_gate: Some(subst_evaluates_commands),
         ..CommandSpec::DEFAULT
     }
 }
 
 #[cfg(test)]
 mod tests {
-    use super::fold_subst;
+    use super::{fold_subst, subst_evaluates_commands};
+
+    #[test]
+    fn subst_evaluates_commands_default_is_true() {
+        assert!(subst_evaluates_commands(&["$tainted"]));
+    }
+
+    #[test]
+    fn subst_evaluates_commands_legacy_nocommands_disables() {
+        assert!(!subst_evaluates_commands(&["-nocommands", "$tainted"]));
+        // Order-independent, and other legacy negatives don't interfere.
+        assert!(!subst_evaluates_commands(&[
+            "-novariables",
+            "-nocommands",
+            "$tainted"
+        ]));
+    }
+
+    #[test]
+    fn subst_evaluates_commands_legacy_other_negatives_leave_commands_on() {
+        assert!(subst_evaluates_commands(&["-novariables", "$tainted"]));
+        assert!(subst_evaluates_commands(&["-nobackslashes", "$tainted"]));
+    }
+
+    #[test]
+    fn subst_evaluates_commands_positive_form_requires_explicit_commands() {
+        // Tcl 9.1 positive form: everything defaults off, so
+        // `-variables` alone never runs command substitution.
+        assert!(!subst_evaluates_commands(&["-variables", "$tainted"]));
+        assert!(!subst_evaluates_commands(&["-backslashes", "$tainted"]));
+        assert!(subst_evaluates_commands(&["-commands", "$tainted"]));
+        assert!(subst_evaluates_commands(&[
+            "-variables",
+            "-commands",
+            "$tainted"
+        ]));
+    }
+
+    #[test]
+    fn subst_evaluates_commands_stops_scanning_at_the_string_operand() {
+        // Only flags *before* the string operand matter — a `-nocommands`-
+        // shaped word after it (an arity-error call shape) is the string
+        // argument's own trailing content, not a switch, and must not
+        // suppress the sink.
+        assert!(subst_evaluates_commands(&["$x", "-nocommands"]));
+    }
 
     #[test]
     fn subst_folds_only_substitution_free_strings() {

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -375,6 +375,20 @@ pub struct CommandSpec {
     /// `eval`/`uplevel`. `None` = no suppression colour.
     pub taint_sink_safe_colour: Option<TaintColour>,
 
+    /// Whether a call's own option flags make this command's taint-sink
+    /// classification live for *this* invocation, given its raw argument
+    /// words — checked before any sink code (T100 code-execution,
+    /// `taint_output_sink`, `taint_log_sink`) is assigned. `None` = the
+    /// sink always applies (the common case: `eval`/`uplevel`/`exec`/`expr`
+    /// take no flag that changes their hazard). `Some(f)` calls `f(args)`
+    /// (args excluding the command name); a `false` result suppresses sink
+    /// classification entirely for that call. Exists for commands like
+    /// `subst`, whose `-nocommands` flag (or, from Tcl 9.1, an
+    /// `-backslashes`/`-variables` positive form with no `-commands`)
+    /// disables the only hazard T100 warns about — see
+    /// `tcl_registry::commands::tcl::subst_::subst_evaluates_commands`.
+    pub taint_sink_gate: Option<fn(&[&str]) -> bool>,
+
     /// Option flags whose value carries a secret (e.g. `-password`,
     /// `-headers`) — drives credential-exposure checks. Empty = none.
     pub credential_options: &'static [&'static str],
@@ -536,6 +550,7 @@ impl CommandSpec {
         taint_transform: None,
         taint_double_encode_colour: None,
         taint_sink_safe_colour: None,
+        taint_sink_gate: None,
         credential_options: &[],
         sensitive_headers: &[],
         setter_constraints: &[],

--- a/rust/tcl-registry/src/taint.rs
+++ b/rust/tcl-registry/src/taint.rs
@@ -570,6 +570,7 @@ mod tests {
         assert!(c.taint_transform.is_none());
         assert!(c.taint_double_encode_colour.is_none());
         assert!(c.taint_sink_safe_colour.is_none());
+        assert!(c.taint_sink_gate.is_none());
         assert!(c.credential_options.is_empty());
         assert!(c.sensitive_headers.is_empty());
         assert!(c.setter_constraints.is_empty());


### PR DESCRIPTION
## Summary

- Deep review of T100 (tainted data into a code-execution / numeric-coercion sink) surfaced several correctness and precision defects, fixed via existing registry/CFG/SSA mechanisms rather than new per-command special-casing:
  - **False negative**: `if`/`while`/`for` conditions live on `Terminator::Branch`, not the statement list the taint scanner walked, so `if {$tainted + 1 > 5} { ... }` never raised T100. Added a dedicated pass (mirroring how SCCP already reads the same condition), plus a sub-pass for nested `[cmd $x]` calls inside a condition (`if {[exec $x] eq "ok"}`).
  - **False negative**: `classify_sink` dispatched on a statement's raw source-surface command name, discarding the `canonical_command` the lowerer resolves for `interp alias`. `interp alias {} myEval {} eval; myEval $x` was silently missed. Extended alias resolution to also recognise a static `rename oldName newName`.
  - **False positive**: braced-expr operands of pure string/list operators (`eq`, `ne`, `in`, `contains`, ...) were flagged with the "numeric coercion" message even though those operators never coerce. Rewrote the expr scan to walk the AST and classify by operator context, which also fixed variables used only inside a nested `[cmd $x]` substitution being wrongly flagged as expr operands.
  - **False positive**: `subst -nocommands $x` (and the Tcl 9.1 positive form without `-commands`) tripped T100 even though `-nocommands` disables the only hazard the diagnostic names — the tool's own hover snippet recommends this exact fix. Added a `taint_sink_gate` hook on `CommandSpec` so a call's own flags can suppress its sink classification.
  - **Precision**: sink warnings now use the real per-word source spans a compiled `Call`/`Barrier` carries, so `eval "prefix" $x "suffix"` underlines only `$x` instead of the whole statement.
  - **Centralisation**: removed two hardcoded command-name matches (`command == "puts"`, and a `HTTP::respond`/`HTTP::redirect`/`log` match) — both commands' registry specs already carried the `taint_output_sink`/`taint_log_sink` fields needed to dispatch generically.
  - Added a "-nocommands" quick fix for a `subst` T100 sink.
- No command knowledge was hardcoded into the compiler and no new clippy allows were added.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `make rust-check` (fmt, clippy `-D warnings`, drift gates) — pass
  - `make check-all` (workspace-wide clippy, TypeScript lint, Python typecheck) — pass
  - `cargo test -p tcl-compiler -p tcl-registry -p tcl-lsp-core -p tcl-lsp-server --all-features` — pass (all touched crates, including the full native `lsp_e2e` suite: 3740 tcl-compiler lib tests, 898 tcl-lsp-core lib tests, 633 tcl-lsp-server e2e tests, all green)
  - `npm test` in `editors/vscode` for the new diagnostics fixture test — pass
  - ~25 new unit tests across `taint.rs`/`alias.rs`/`subst_.rs` (TP/FP/TN/FN coverage for every fix above), 3 lsp_e2e tests, 2 code-action unit tests, and a VS Code extension test with a new fixture

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — T100 detection/highlighting behaviour changed (new TP coverage, FP removal, tighter spans).
- [x] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. Updated `docs/kcs/codes/kcs-diagnostic-t100-taint-code-execution-sink.md` to reflect the new coverage.
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`. N/A — existing note was updated, not a new one added.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Fd92ephgaXyEa4m3bBtrK1)_