### PR TITLE
W003: tight per-operator spans, quick fixes, and dialect gating fixes

### DIFF
--- a/docs/design/compiler/dialects-events.md
+++ b/docs/design/compiler/dialects-events.md
@@ -41,7 +41,22 @@ KNOWN_DIALECTS = frozenset({
 ### Dialect base versions
 
 Each non-standard dialect is based on a specific Tcl runtime version.
-`DIALECT_BASE_VERSION` in `dialects.py` maps each dialect to its base:
+`DIALECT_BASE_VERSION` in `dialects.py` maps each dialect to its base.
+
+**Rust port note**: `dialects.py` and `dialects_since()` below are the
+retired Python implementation's names, kept here because the *table* of
+base versions is still the source of truth. The Rust workspace has no
+`dialects_since()` — per-command dialect gating uses the `DialectSet`
+bitflags (`TCL85_PLUS` / `TCL86_PLUS` / `TCL90_PLUS`, `rust/tcl-registry/src/dialects.rs`)
+directly on `CommandSpec.dialects`, and deliberately does **not** fold the
+vendor dialects into those flags (most standard-library commands they
+don't ship are missing because of their own restricted surface, not
+version). For version-gated *expr grammar* features specifically — TIP 201
+(`in`/`ni`) and TIP 461 (`lt`/`le`/`gt`/`ge`), the W003 diagnostic — where
+every dialect here really does inherit a real embedded Tcl core's
+operators wholesale, use `DialectSet::expr_grammar_base_version(name)`
+instead, which encodes exactly this table (including `f5-irules`'s
+runtime-vs-signature split below).
 
 | Dialect | Base version | Runtime |
 |---------|-------------|---------|

--- a/docs/kcs/codes/kcs-diagnostic-w003-dialect-invalid-expr-operator.md
+++ b/docs/kcs/codes/kcs-diagnostic-w003-dialect-invalid-expr-operator.md
@@ -19,31 +19,45 @@ Why does the analyser warn that an expression operator is not available in my di
 
 Tcl added new expression operators in specific releases. The `in` and `ni` membership operators were introduced in Tcl 8.5 (TIP 201); the string-comparison operators `lt`, `le`, `gt`, and `ge` were introduced in Tcl 9.0 (TIP 461). When the active dialect is set to an earlier version, using these operators causes a runtime `syntax error in expression` or `invalid bareword` error in the real Tcl interpreter.
 
+This also applies to the vendor dialects (F5 iApps/tmsh, the EDA-tool shells) according to their documented base Tcl version, and to F5 iRules according to its embedded Tcl 8.4.6 runtime — not the newer command signature it otherwise advertises.
+
 ## Symptoms
 
-- A yellow squiggle appears under the expression argument, with a message such as: "Expression operator 'in' is not available in the active dialect (tcl8.4); requires Tcl 8.5+ (TIP 201)."
+- A yellow squiggle appears under the operator itself (not the whole expression), with a message such as: "Expression operator 'in' is not available in dialect 'tcl8.4'; requires Tcl 8.5+ (TIP 201)."
+- Each occurrence of a gated operator gets its own squiggle — an expression using the same or different gated operators more than once reports one diagnostic per occurrence, each anchored at its own operator.
 
 ## Example that triggers it
 
 ```tcl
-# dialect: tcl8.4
+# tcl-dialect: tcl8.4
 expr {2 in {1 2 3}}
 ```
 
-The analyser reports **`W003`** on the expression argument.
+The analyser reports **`W003`** on the `in` operator.
 
 ## Fix
 
+For the common case — the whole expression is exactly one gated comparison with plain operands (a literal, a variable, a string/list literal, or a `[command]` substitution) — the editor offers a quick fix that rewrites it to a portable form:
+
 ```tcl
-# Use a dialect-compatible alternative:
-expr {[lsearch -exact {1 2 3} 2] >= 0}
+# Before:
+expr {2 in {1 2 3}}
+# After (quick fix):
+expr {([lsearch -exact {1 2 3} 2] >= 0)}
 ```
 
-Replace the dialect-restricted operator with a form supported by the active dialect, or raise the dialect setting to a version that supports the operator.
+```tcl
+# Before:
+if {$x lt $y} { ... }
+# After (quick fix):
+if {([string compare $x $y] < 0)} { ... }
+```
+
+When the operator is nested inside a larger expression, appears more than once, or has an operand that isn't a plain value (e.g. a function call like `max($a, $b)`), no quick fix is offered — rewrite it by hand, or raise the dialect setting to a version that supports the operator.
 
 ## How to suppress
 
-Add `# noqa: W003` at the end of the offending line.
+Add `# noqa: W003` at the end of the offending line. Suppression is line-based: it silences every W003 occurrence reported on that line.
 
 ## Related
 

--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -490,6 +490,8 @@ suite("Configuration Settings", () => {
     "E200",
     "W001",
     "W002",
+    "W003",
+    "W004",
     "W100",
     "W101",
     "W102",

--- a/editors/vscode/src/test/w003.test.ts
+++ b/editors/vscode/src/test/w003.test.ts
@@ -1,0 +1,126 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, waitForDiagnostics, pollUntil } from "./helper";
+
+// Fixture (`# tcl-dialect: tcl8.4`):
+//   line 1: if {$a lt $b} {        -- 'lt' at columns 7..9
+//   line 4: if {$c in $d && $e in $f} {  -- 'in' at columns 7..9 and 19..21
+
+function codeOf(d: vscode.Diagnostic): string | number | undefined {
+  return typeof d.code === "object" ? d.code?.value : d.code;
+}
+
+suite("W003 (dialect-gated expr operators)", () => {
+  const docUri = getDocUri("w003.tcl");
+
+  test("fires with a tight range covering only the operator", async () => {
+    await activate(docUri);
+    const diagnostics = await waitForDiagnostics(docUri, { minCount: 1 });
+    const w003 = diagnostics.filter((d) => codeOf(d) === "W003");
+    assert.ok(
+      w003.length >= 1,
+      `expected at least one W003, got ${JSON.stringify(diagnostics.map((d) => [codeOf(d), d.range]))}`,
+    );
+
+    const lt = w003.find((d) => d.range.start.line === 1);
+    assert.ok(
+      lt,
+      `expected a W003 on line 1 ('lt'), got ${JSON.stringify(w003.map((d) => d.range))}`,
+    );
+    assert.strictEqual(lt!.range.start.character, 7, "range must start at 'lt'");
+    assert.strictEqual(lt!.range.end.character, 9, "range must cover only 'lt'");
+    assert.ok(lt!.message.includes("TIP 461"), `message should cite TIP 461: ${lt!.message}`);
+  });
+
+  test("reports one diagnostic per occurrence, each at its own range", async () => {
+    await activate(docUri);
+    const diagnostics = await waitForDiagnostics(docUri, { minCount: 3 });
+    const w003 = diagnostics.filter((d) => codeOf(d) === "W003");
+    // line 1: 'lt'; line 4: 'in' twice.
+    assert.ok(
+      w003.length >= 3,
+      `expected 3 W003 diagnostics, got ${w003.length}: ${JSON.stringify(w003.map((d) => d.range))}`,
+    );
+    const onLine4 = w003.filter((d) => d.range.start.line === 4);
+    assert.strictEqual(
+      onLine4.length,
+      2,
+      `expected 2 W003 on line 4, got ${JSON.stringify(onLine4.map((d) => d.range))}`,
+    );
+    assert.notStrictEqual(
+      onLine4[0].range.start.character,
+      onLine4[1].range.start.character,
+      "the two 'in' occurrences must not collapse onto the same range",
+    );
+  });
+
+  test("offers a quick fix that rewrites 'lt' to a portable form", async () => {
+    await activate(docUri);
+    const diagnostics = await waitForDiagnostics(docUri, { minCount: 1 });
+    const lt = diagnostics.find((d) => codeOf(d) === "W003" && d.range.start.line === 1);
+    assert.ok(lt, "expected a W003 on line 1");
+
+    const actions = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeActionProvider", docUri, lt!.range),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => a.kind && a.kind.value === vscode.CodeActionKind.QuickFix.value && a.edit,
+        ),
+      { timeout: 10_000, label: "W003 quick fix" },
+    )) as vscode.CodeAction[];
+
+    const fix = actions.find(
+      (a) => a.edit && a.kind && a.kind.value === vscode.CodeActionKind.QuickFix.value,
+    );
+    assert.ok(
+      fix,
+      `expected a quick fix action, got titles: ${JSON.stringify(actions.map((a) => a.title))}`,
+    );
+
+    const edits = fix!.edit!.get(docUri);
+    assert.ok(
+      edits.some((e) => e.newText === "([string compare $a $b] < 0)"),
+      `unexpected edit text: ${JSON.stringify(edits.map((e) => e.newText))}`,
+    );
+  });
+
+  test("no quick fix is offered for the nested 'in' occurrences", async () => {
+    await activate(docUri);
+    const diagnostics = await waitForDiagnostics(docUri, { minCount: 3 });
+    const inHit = diagnostics.find((d) => codeOf(d) === "W003" && d.range.start.line === 4);
+    assert.ok(inHit, "expected a W003 on line 4");
+
+    const actions = ((await vscode.commands.executeCommand(
+      "vscode.executeCodeActionProvider",
+      docUri,
+      inHit!.range,
+    )) ?? []) as vscode.CodeAction[];
+    const lsearchFix = actions.find(
+      (a) => a.edit && a.edit.get(docUri).some((e) => e.newText.includes("lsearch")),
+    );
+    assert.strictEqual(
+      lsearchFix,
+      undefined,
+      "a gated operator nested in a larger expression must not offer the lsearch rewrite",
+    );
+  });
+});

--- a/editors/vscode/testFixture/w003.tcl
+++ b/editors/vscode/testFixture/w003.tcl
@@ -1,0 +1,7 @@
+# tcl-dialect: tcl8.4
+if {$a lt $b} {
+    puts hi
+}
+if {$c in $d && $e in $f} {
+    puts hi
+}

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -750,8 +750,7 @@ impl Analyser {
         // to guard once here for every EXPR-role emitter at once, rather
         // than duplicating the check per diagnostic.
         let qualified = crate::naming::normalise_qualified_name(cmd_name);
-        if let Some(def) = self.result.all_procs.get(&qualified)
-            && def.name_span.start() < cmd_tok.span.start()
+        if super::utils::proc_shadows_call(&self.result.all_procs, &qualified, cmd_tok.span.start())
         {
             return;
         }

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -385,7 +385,7 @@ impl Analyser {
             // commands aren't skipped — none of those handlers
             // process EXPR args themselves (they own *body*
             // recursion only), so this can't double-fire.
-            self.dispatch_expr_arguments(cmd_name, args, arg_tokens);
+            self.dispatch_expr_arguments(cmd_name, args, arg_tokens, cmd_tok);
 
             // Dispatch-site diagnostic emitters (W302 / W001 / E004 / W101
             // / W304 / W004 / E002-E003).  Extracted from this function so
@@ -732,10 +732,29 @@ impl Analyser {
     }
 
     /// Generic EXPR-argument walk via the command registry's
-    /// `ArgRole::Expr`.  Currently invokes the W110 emitter on each
-    /// EXPR-role argument.  For `expr`, multi-arg invocations are
-    /// joined with spaces before the W110 walk.
-    fn dispatch_expr_arguments(&mut self, cmd_name: &str, args: &[String], arg_tokens: &[Token]) {
+    /// `ArgRole::Expr`.  Invokes the W100 / W110 / W003 / W114
+    /// emitters on each EXPR-role argument.  For `expr`, multi-arg
+    /// invocations are joined with spaces before the W110 walk.
+    fn dispatch_expr_arguments(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        cmd_tok: Token,
+    ) {
+        // An earlier unconditional user `proc` of the same name shadows
+        // the builtin at this call site (Tcl resolves the proc, not
+        // `::expr`/`::if`/`::while`/`::for` etc.) — same rule W002 uses
+        // for an ordinary disabled-command shadow. Vanishingly rare for
+        // these particular control-flow keywords in practice, but cheap
+        // to guard once here for every EXPR-role emitter at once, rather
+        // than duplicating the check per diagnostic.
+        let qualified = crate::naming::normalise_qualified_name(cmd_name);
+        if let Some(def) = self.result.all_procs.get(&qualified)
+            && def.name_span.start() < cmd_tok.span.start()
+        {
+            return;
+        }
         let Some(registry) = self.registry.as_ref() else {
             return;
         };
@@ -757,13 +776,16 @@ impl Analyser {
 
         // Special-case ``expr ...``: when the user wrote multiple
         // arguments (``expr $a == "x"`` instead of the more common
-        // ``expr {$a eq "x"}``), anchor W110 / W003 at the full
-        // argument token range and parse the joined arguments — the
+        // ``expr {$a eq "x"}``), anchor W110 at the full argument
+        // token range and parse the joined arguments — the
         // *substituted* word values, with quote delimiters already
         // stripped by Tcl's word splitting.  So ``expr $a == "x"`` parses
         // as ``$a == x`` where ``x`` is a bareword, not an ``ExprString``,
         // and W110 (string ``==``) does NOT fire — matching what `expr`
-        // actually receives at runtime.
+        // actually receives at runtime.  W003 gets its own emitter for
+        // this shape (`emit_w003_dialect_invalid_expr_words`): a gated
+        // operator here is always its own standalone word, already at
+        // a tight span, with no offset remapping needed.
         if cmd_name == "expr" && args.len() > 1 && !arg_tokens.is_empty() {
             let span = tcl_lexer::Span::new(
                 arg_tokens[0].span.start(),
@@ -771,14 +793,24 @@ impl Analyser {
             );
             let expr_text = args.join(" ");
             self.emit_w110_string_eq_ne(&expr_text, span);
-            self.emit_w003_dialect_invalid_expr_operator(&expr_text, span);
+            self.emit_w003_dialect_invalid_expr_words(args, arg_tokens, &expr_text);
             return;
         }
 
         for idx in indices {
             if let (Some(text), Some(tok)) = (args.get(idx), arg_tokens.get(idx)) {
                 self.emit_w110_string_eq_ne(text, tok.span);
-                self.emit_w003_dialect_invalid_expr_operator(text, tok.span);
+                // W003 anchors on the argument's inner content (delimiters
+                // stripped via `content_offset`), not the raw token span —
+                // it re-slices `self.source` directly so its operator
+                // offsets always land on real bytes, byte-for-byte, even
+                // when `text` itself has been reconstructed/canonicalised
+                // by the segmenter (e.g. a quoted `"$x lt $y"` argument).
+                let content_span = tcl_lexer::Span::new(
+                    tok.span.start() + u32::from(tok.content_offset),
+                    tok.span.end(),
+                );
+                self.emit_w003_dialect_invalid_expr_operator(content_span);
                 self.emit_w114_redundant_nested_expr(text, tok.span);
             }
         }
@@ -1279,7 +1311,7 @@ impl Analyser {
             cmd_tok,
             scope_path,
         });
-        self.dispatch_expr_arguments(&cmd_name, args, arg_tokens);
+        self.dispatch_expr_arguments(&cmd_name, args, arg_tokens, cmd_tok);
         // W216 (broken brace-form array access, `${arr}(idx)` / `${arr($i)}`)
         // must reach substitution commands too: `set v [puts ${arr}(name)]`
         // hides the offending word inside a `[…]`, which the main `walk_body`

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -2218,6 +2218,343 @@ fn w003_silent_on_in_operator_in_tcl85() {
     );
 }
 
+/// Every W003 diagnostic for `src` analysed under `dialect`, alongside
+/// the exact source substring its span covers — the tight-highlight
+/// assertions below check that text directly rather than trusting
+/// hand-computed byte offsets.
+fn w003_hits(src: &str, dialect: &str) -> Vec<(String, Diagnostic)> {
+    let mut a = Analyser::new();
+    let result = a.analyse(src, dialect);
+    result
+        .diagnostics
+        .into_iter()
+        .filter(|d| d.code == DiagCode::W003)
+        .map(|d| {
+            let text = src[d.span.start() as usize..d.span.end() as usize].to_string();
+            (text, d)
+        })
+        .collect()
+}
+
+#[test]
+fn w003_tight_span_covers_only_the_operator_in_a_braced_if() {
+    // The whole condition is `$x lt $y` (11 chars); the diagnostic must
+    // highlight just the 2-byte `lt`, not the condition or the `if`.
+    let hits = w003_hits("if {$x lt $y} { puts hi }", "tcl8.4");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].0, "lt");
+}
+
+#[test]
+fn w003_tight_span_covers_only_the_operator_in_bare_expr() {
+    let hits = w003_hits("expr {2 in {1 2 3}}", "tcl8.4");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].0, "in");
+}
+
+#[test]
+fn w003_distinct_operators_each_get_their_own_tight_span() {
+    // Two *different* gated operators in one expression used to collapse
+    // onto one coarse diagnostic covering the whole condition; each must
+    // now get its own diagnostic at its own span.
+    let hits = w003_hits("if {$a lt $b && $c in $d} { puts hi }", "tcl8.4");
+    let mut texts: Vec<&str> = hits.iter().map(|(t, _)| t.as_str()).collect();
+    texts.sort_unstable();
+    assert_eq!(texts, vec!["in", "lt"], "{hits:?}");
+    // The two spans must not overlap.
+    assert_ne!(hits[0].1.span, hits[1].1.span);
+}
+
+#[test]
+fn w003_repeated_same_operator_gets_a_diagnostic_per_occurrence() {
+    let hits = w003_hits("if {$a in $b && $c in $d} { puts hi }", "tcl8.4");
+    assert_eq!(hits.len(), 2, "{hits:?}");
+    assert_eq!(hits[0].0, "in");
+    assert_eq!(hits[1].0, "in");
+    // Same text, but must anchor at two different source positions.
+    assert_ne!(hits[0].1.span.start(), hits[1].1.span.start());
+}
+
+#[test]
+fn w003_message_cites_the_relevant_tip() {
+    let hits = w003_hits("expr {2 in {1 2 3}}", "tcl8.4");
+    assert_eq!(hits.len(), 1);
+    assert!(
+        hits[0].1.message.contains("TIP 201"),
+        "{}",
+        hits[0].1.message
+    );
+    let hits = w003_hits("if {$x lt $y} { puts hi }", "tcl8.4");
+    assert_eq!(hits.len(), 1);
+    assert!(
+        hits[0].1.message.contains("TIP 461"),
+        "{}",
+        hits[0].1.message
+    );
+}
+
+#[test]
+fn w003_fires_on_all_six_gated_operators_pre_availability() {
+    // `ni`/`le`/`gt`/`ge` were only ever exercised indirectly before
+    // (only `lt` and `in` had a dedicated test); cover the full set.
+    for (src, op) in [
+        ("if {$x ni {a b c}} { puts hi }", "ni"),
+        ("if {$x le $y} { puts hi }", "le"),
+        ("if {$x gt $y} { puts hi }", "gt"),
+        ("if {$x ge $y} { puts hi }", "ge"),
+    ] {
+        let hits = w003_hits(src, "tcl8.4");
+        assert_eq!(hits.len(), 1, "{src}: {hits:?}");
+        assert_eq!(hits[0].0, op, "{src}");
+    }
+}
+
+#[test]
+fn w003_silent_on_ni_le_gt_ge_when_dialect_supports_them() {
+    // `ni` only needs 8.5+; `le`/`gt`/`ge` need 9.0+.
+    assert!(w003_hits("if {$x ni {a b c}} { puts hi }", "tcl8.5").is_empty());
+    for src in [
+        "if {$x le $y} { puts hi }",
+        "if {$x gt $y} { puts hi }",
+        "if {$x ge $y} { puts hi }",
+    ] {
+        assert!(w003_hits(src, "tcl9.0").is_empty(), "{src}");
+        assert!(w003_hits(src, "tcl8.5").len() == 1, "{src}");
+    }
+}
+
+#[test]
+fn w003_fires_on_unbraced_multiword_expr_at_a_tight_span() {
+    // `expr` is the only EXPR-role command that accepts an unbraced,
+    // multi-word expression; the gated keyword is its own Tcl word, so
+    // this exercises the separate `emit_w003_dialect_invalid_expr_words`
+    // path rather than the single-argument one above.
+    let hits = w003_hits("expr $a in $b", "tcl8.4");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].0, "in");
+    // No fix is offered for this shape (see doc comment on the emitter).
+    assert!(hits[0].1.fixes.is_empty());
+}
+
+#[test]
+fn w003_offers_lsearch_fix_for_in() {
+    let hits = w003_hits("expr {2 in {1 2 3}}", "tcl8.4");
+    assert_eq!(hits.len(), 1);
+    let fixes = &hits[0].1.fixes;
+    assert_eq!(fixes.len(), 1, "{fixes:?}");
+    assert_eq!(fixes[0].new_text, "([lsearch -exact {1 2 3} 2] >= 0)");
+}
+
+#[test]
+fn w003_offers_lsearch_fix_for_ni() {
+    let hits = w003_hits("expr {2 ni {1 2 3}}", "tcl8.4");
+    assert_eq!(hits.len(), 1);
+    let fixes = &hits[0].1.fixes;
+    assert_eq!(fixes.len(), 1, "{fixes:?}");
+    assert_eq!(fixes[0].new_text, "([lsearch -exact {1 2 3} 2] < 0)");
+}
+
+#[test]
+fn w003_offers_string_compare_fix_for_string_relational_ops() {
+    for (src, expect) in [
+        ("if {$x lt $y} { puts hi }", "([string compare $x $y] < 0)"),
+        ("if {$x le $y} { puts hi }", "([string compare $x $y] <= 0)"),
+        ("if {$x gt $y} { puts hi }", "([string compare $x $y] > 0)"),
+        ("if {$x ge $y} { puts hi }", "([string compare $x $y] >= 0)"),
+    ] {
+        let hits = w003_hits(src, "tcl8.4");
+        assert_eq!(hits.len(), 1, "{src}");
+        let fixes = &hits[0].1.fixes;
+        assert_eq!(fixes.len(), 1, "{src}: {fixes:?}");
+        assert_eq!(fixes[0].new_text, expect, "{src}");
+    }
+}
+
+#[test]
+fn w003_fix_span_replaces_exactly_the_gated_application() {
+    let src = "expr {2 in {1 2 3}}";
+    let hits = w003_hits(src, "tcl8.4");
+    let fix = &hits[0].1.fixes[0];
+    assert_eq!(
+        &src[fix.span.start() as usize..fix.span.end() as usize],
+        "2 in {1 2 3}"
+    );
+}
+
+#[test]
+fn w003_no_fix_when_operator_nested_in_a_larger_expression() {
+    // Only `in` is gated here (`&&` is fine everywhere); it is the sole
+    // W003 occurrence, but it is not the *whole* condition — rewriting
+    // just the `in` sub-expression while leaving `&& $c` around it is
+    // exactly the "nested" shape the fix deliberately declines.
+    let hits = w003_hits("if {$a in $b && $c} { puts hi }", "tcl8.4");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert!(hits[0].1.fixes.is_empty());
+}
+
+#[test]
+fn w003_no_fix_when_more_than_one_occurrence() {
+    let hits = w003_hits("if {$a lt $b && $c in $d} { puts hi }", "tcl8.4");
+    assert_eq!(hits.len(), 2);
+    assert!(hits[0].1.fixes.is_empty());
+    assert!(hits[1].1.fixes.is_empty());
+}
+
+#[test]
+fn w003_no_fix_when_operand_is_a_call() {
+    // `max($a, $b)` contains an unprotected space after the comma —
+    // splicing its rendered text bare into `lsearch`'s argument list
+    // would silently mis-word-split, so `is_simple_operand` excludes
+    // `Call` and no fix is offered even though this is the sole,
+    // top-level occurrence.
+    let hits = w003_hits("expr {max($a, $b) in $list}", "tcl8.4");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert!(hits[0].1.fixes.is_empty());
+}
+
+#[test]
+fn w003_silent_on_variable_named_like_a_gated_operator() {
+    // `$in` is a variable reference, not the `in` operator — the
+    // lexical prefilter alone can't tell the two apart, but the real
+    // expr parse must.
+    assert!(w003_hits("if {$in} { puts hi }", "tcl8.4").is_empty());
+    assert!(w003_hits("if {$ni && $lt} { puts hi }", "tcl8.4").is_empty());
+}
+
+#[test]
+fn w003_silent_on_array_element_named_like_a_gated_operator() {
+    assert!(w003_hits("if {$arr(in)} { puts hi }", "tcl8.4").is_empty());
+}
+
+#[test]
+fn w003_silent_on_quoted_string_literal_operator_word() {
+    // `"in"` is a quoted string literal, not the bareword operator.
+    let hits = w003_hits(r#"if {"in" eq $x} { puts hi }"#, "tcl8.4");
+    assert!(hits.is_empty(), "{hits:?}");
+}
+
+#[test]
+fn w003_silent_on_malformed_expression() {
+    // `lt` with no right-hand operand doesn't parse — `parse_expr`
+    // falls back to `Raw`, so W003 must stay silent rather than guess.
+    assert!(w003_hits("if {$x lt} { puts hi }", "tcl8.4").is_empty());
+}
+
+#[test]
+fn w003_dialect_is_file_wide_regardless_of_namespace_or_proc_nesting() {
+    // The active dialect is resolved once per file/analysis, not
+    // per-scope — a gated operator inside a deeply nested proc body
+    // must still be flagged.
+    let src = "namespace eval ::foo {\n  proc bar {} {\n    if {$x in $y} { return 1 }\n  }\n}\n";
+    let hits = w003_hits(src, "tcl8.4");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].0, "in");
+}
+
+#[test]
+fn w003_fires_inside_a_tcl_oo_method_body() {
+    let src = "oo::class create Foo {\n  method bar {} {\n    if {$x in $y} { return 1 }\n  }\n}\n";
+    let hits = w003_hits(src, "tcl8.4");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+    assert_eq!(hits[0].0, "in");
+}
+
+#[test]
+fn w003_fires_inside_a_sub_interpreter_eval_body() {
+    // `interp eval`'s script argument is a registry BODY role, so it is
+    // walked like any other nested script. Static analysis can't know
+    // the sub-interpreter's own Tcl version, so it reasonably applies
+    // the enclosing file's dialect uniformly.
+    let src = "interp eval $safeInterp {\n  if {$x in $y} { return 1 }\n}\n";
+    let hits = w003_hits(src, "tcl8.4");
+    assert_eq!(hits.len(), 1, "{hits:?}");
+}
+
+#[test]
+fn w003_suppressed_by_an_earlier_proc_shadowing_if() {
+    // A user `proc if {...} {...}` defined *before* the call site
+    // resolves at the call site instead of the builtin `::if` — Tcl's
+    // own name resolution, mirrored by W002's existing shadow rule and
+    // now shared by the EXPR-role dispatch (W100/W110/W003/W114 all at
+    // once, via `dispatch_expr_arguments`'s shadow guard).
+    let src = "proc if {c b} { return 1 }\nif {$x in $y} { puts hi }\n";
+    assert!(
+        w003_hits(src, "tcl8.4").is_empty(),
+        "shadowed 'if' must suppress W003"
+    );
+}
+
+#[test]
+fn w003_not_suppressed_by_a_later_proc_shadowing_if() {
+    // The shadowing proc is defined *after* this call site, so it
+    // cannot have been in effect when Tcl resolved this particular
+    // call — W003 must still fire here.
+    let src = "if {$x in $y} { puts hi }\nproc if {c b} { return 1 }\n";
+    assert_eq!(w003_hits(src, "tcl8.4").len(), 1);
+}
+
+#[test]
+fn w003_correctly_gates_eda_vendor_dialects_by_documented_base_version() {
+    // Regression for the registry fix (`DialectSet::expr_grammar_base_version`):
+    // these vendor dialects are documented as running on top of a real
+    // Tcl 8.5+ core (`docs/design/compiler/dialects-events.md`), so
+    // `in`/`ni` (TIP 201, 8.5+) must NOT be flagged for them — the old
+    // `DialectSet::TCL85_PLUS` check excluded them entirely and
+    // over-fired.
+    for dialect in [
+        "f5-iapps",
+        "xilinx-eda-tcl",
+        "intel-quartus-eda-tcl",
+        "mentor-eda-tcl",
+        "synopsys-eda-tcl",
+        "cadence-eda-tcl",
+        "expect",
+    ] {
+        assert!(
+            w003_hits("expr {2 in {1 2 3}}", dialect).is_empty(),
+            "{dialect} should support TIP 201 'in'"
+        );
+    }
+    // None of them reach Tcl 9.0, so the string-relational operators
+    // are still correctly flagged.
+    for dialect in [
+        "f5-iapps",
+        "xilinx-eda-tcl",
+        "intel-quartus-eda-tcl",
+        "mentor-eda-tcl",
+        "synopsys-eda-tcl",
+        "cadence-eda-tcl",
+        "expect",
+    ] {
+        assert_eq!(
+            w003_hits("if {$x lt $y} { puts hi }", dialect).len(),
+            1,
+            "{dialect} should still gate TIP 461 'lt'"
+        );
+    }
+}
+
+#[test]
+fn w003_f5_irules_stays_gated_on_its_tcl_8_4_runtime() {
+    // iRules advertises an 8.6-shaped command *signature* but its
+    // runtime `expr` evaluator is a genuine embedded Tcl 8.4.6 — both
+    // TIPs must be flagged, unlike the 8.5-base vendor dialects above.
+    assert_eq!(w003_hits("expr {2 in {1 2 3}}", "f5-irules").len(), 1);
+    assert_eq!(w003_hits("if {$x lt $y} { puts hi }", "f5-irules").len(), 1);
+}
+
+#[test]
+fn w003_f5_tmsh_now_gates_tip_461_but_not_tip_201() {
+    // Regression: `f5-tmsh` had no `DialectSet` bit at all, so
+    // `DialectSet::parse` returned `None` and W003 silently never fired
+    // for it — a false negative on its documented Tcl 8.5 base for
+    // `lt`/`le`/`gt`/`ge`. `expr_grammar_base_version` fixes this
+    // without touching `DialectSet::parse`'s existing per-command
+    // dialect-gating semantics.
+    assert!(w003_hits("expr {2 in {1 2 3}}", "f5-tmsh").is_empty());
+    assert_eq!(w003_hits("if {$x lt $y} { puts hi }", "f5-tmsh").len(), 1);
+}
+
 #[test]
 fn emit_variable_usage_diagnostics_is_a_noop() {
     // Hook is intentionally empty — running it must leave

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -416,6 +416,13 @@ impl Analyser {
         {
             return;
         }
+        // An earlier *unconditional* user proc with this name shadows the
+        // would-be-disabled built-in at the call site.
+        let qualified = crate::naming::normalise_qualified_name(bare);
+        if super::utils::proc_shadows_call(&self.result.all_procs, &qualified, cmd_tok.span.start())
+        {
+            return;
+        }
         // Best-effort "available in: …" hint read straight from the
         // registry spec's own dialect gate. Only resolves when the spec is
         // among the packs this registry instance loaded regardless of

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -36,7 +36,7 @@ use tcl_registry::Arity;
 use super::helpers::{has_substitution, is_ident_continue, is_integer_word};
 use crate::analyser::state::Analyser;
 use crate::analyser::types::{PendingUserCallArity, Severity};
-use crate::expr_ast::{BinOp, ExprNode};
+use crate::expr_ast::{ExprNode, render_expr};
 
 /// The argument words of one command invocation, scoped to the prefix the
 /// caller has already consumed: `args` / `arg_tokens` / `arg_expand` are the
@@ -2410,17 +2410,32 @@ in the active dialect ({}).",
     }
 
     /// **W003.** Emit "Expression operator not available in active
-    /// dialect" warning for expressions that use a Tcl 9.0 string-
-    /// comparison operator (`lt` / `le` / `gt` / `ge`, TIP 461) in a
-    /// pre-9.0 dialect, or `in` / `ni` (TIP 201, Tcl 8.5+) in
-    /// Tcl 8.4 / f5-irules.
+    /// dialect" warnings for an EXPR-role argument that uses a Tcl
+    /// 9.0 string-comparison operator (`lt` / `le` / `gt` / `ge`,
+    /// TIP 461) in a pre-9.0 dialect, or `in` / `ni` (TIP 201, Tcl
+    /// 8.5+) in an earlier one. One diagnostic is emitted per
+    /// offending operator *occurrence*, anchored at that operator's
+    /// own token span rather than the whole argument, so the
+    /// squiggle stays tight around the actual problem even inside a
+    /// large compound expression.
+    ///
+    /// `content_span` is the argument's inner content: the caller has
+    /// already stripped any wrapping `{}` / `""` / `$` via the
+    /// token's `content_offset`, so this slices `self.source`
+    /// directly instead of trusting a possibly-reconstructed text —
+    /// a quoted `"$x lt $y"` argument's word text is canonicalised to
+    /// `"${x} lt ${y}"` by the segmenter, which would misalign any
+    /// offset computed from it.
     pub(in crate::analyser) fn emit_w003_dialect_invalid_expr_operator(
         &mut self,
-        expr_text: &str,
-        diag_span: tcl_lexer::Span,
+        content_span: tcl_lexer::Span,
     ) {
-        use tcl_registry::dialects::DialectSet;
-
+        let start = content_span.start() as usize;
+        let end = content_span.end() as usize;
+        if start > end || end > self.source.len() {
+            return;
+        }
+        let expr_text = &self.source[start..end];
         // Quick lexical bail-out — the gated operators are short
         // word-shaped keywords; if none appear as a whole word we
         // can skip the parse.  Boundary check uses ASCII identifier
@@ -2431,36 +2446,158 @@ in the active dialect ({}).",
         if !contains_gated_word(expr_text) {
             return;
         }
-        let Some(active) = DialectSet::parse(&self.dialect) else {
+        let Some((pre_85, pre_90)) = self.w003_gates() else {
             return;
         };
+
+        let trimmed = expr_text.trim();
+        let parsed = crate::parse_expr(trimmed, Some(self.dialect.as_str()));
+        if matches!(parsed, ExprNode::Raw { .. }) {
+            return;
+        }
+
+        // Re-tokenise the same (trimmed) text at the flat lexical
+        // level: every gated-keyword `Operator` token here
+        // corresponds 1:1 to a `Binary` node the parse above just
+        // confirmed is real (a successful parse consumes the whole
+        // token stream, and `in`/`ni`/`lt`/`le`/`gt`/`ge` are not
+        // valid prefix/atom tokens — the only way one is consumed is
+        // as a genuine infix application). This gives an exact
+        // per-occurrence span directly from `ExprToken::start/end`
+        // without adding source-position fields to `ExprNode::Binary`
+        // (which recursive/optimiser/codegen consumers across the
+        // compiler pattern-match on by name, not span).
+        let (tokens, _) = tcl_lexer::tokenise_expr_checked(trimmed, Some(self.dialect.as_str()));
+        let gated: Vec<(&tcl_lexer::ExprToken, &'static str)> = tokens
+            .iter()
+            .filter(|t| t.kind == tcl_lexer::ExprTokenType::Operator)
+            .filter_map(|t| gated_operator_name(&t.text, pre_85, pre_90).map(|name| (t, name)))
+            .collect();
+        if gated.is_empty() {
+            return;
+        }
+
+        // A mechanical rewrite is only safe to offer when the whole
+        // argument IS exactly the one gated application (`2 in {1 2
+        // 3}`, `$x lt $y`) with plain operands: the operator nested
+        // inside a larger expression, more than one gated occurrence,
+        // or an operand that isn't a single bare-word-safe atom
+        // (`Binary`/`Unary`/`Ternary`/`Call` — e.g. `max($a, $b)`
+        // contains an unprotected space) can't be reduced to one
+        // local text replacement.
+        let fix_text = (gated.len() == 1)
+            .then_some(&parsed)
+            .and_then(|node| match node {
+                ExprNode::Binary { op, left, right }
+                    if is_simple_operand(left) && is_simple_operand(right) =>
+                {
+                    rewrite_gated_operator(op.as_str(), &render_expr(left), &render_expr(right))
+                }
+                _ => None,
+            });
+
+        // Leading whitespace `expr_text.trim()` stripped, needed to
+        // translate a `trimmed`-local offset back to an
+        // `expr_text`-local (and then absolute source) offset.
+        let trim_base = u32::try_from(expr_text.len() - expr_text.trim_start().len()).unwrap_or(0);
+
+        for (tok, op_name) in gated {
+            let op_span = tcl_lexer::Span::new(
+                content_span.start() + trim_base + tok.start,
+                // `ExprToken::end` is inclusive; `Span` is exclusive.
+                content_span.start() + trim_base + tok.end + 1,
+            );
+            let mut fixes = Vec::new();
+            if let Some(new_text) = fix_text.clone() {
+                fixes.push(super::types::CodeFix {
+                    span: tcl_lexer::Span::new(
+                        content_span.start() + trim_base,
+                        content_span.start()
+                            + trim_base
+                            + u32::try_from(trimmed.len()).unwrap_or(0),
+                    ),
+                    new_text,
+                    description: format!(
+                        "Rewrite to a form supported by dialect '{}'",
+                        self.dialect
+                    ),
+                });
+            }
+            self.result.diagnostics.push(super::types::Diagnostic {
+                code: DiagCode::W003,
+                span: op_span,
+                message: format!(
+                    "Expression operator '{op_name}' is not available in dialect '{}'; requires {}.",
+                    self.dialect,
+                    w003_tip_citation(op_name)
+                ),
+                severity: Severity::Warning,
+                fixes,
+            });
+        }
+    }
+
+    /// **W003** for the multi-word `expr a b c …` form. Tcl's `expr`
+    /// is the only EXPR-role command whose expression can be spread
+    /// across several unbraced words (`if`/`while`/`for` require
+    /// their condition to be a single Tcl word — an unbraced
+    /// multi-word condition is a Tcl arity error, not valid syntax).
+    /// Written this way, a gated operator keyword is necessarily its
+    /// own standalone Tcl word, so its `arg_tokens` entry is already
+    /// an exact, tight span — no text-offset remapping needed, unlike
+    /// the single-argument path above.
+    pub(in crate::analyser) fn emit_w003_dialect_invalid_expr_words(
+        &mut self,
+        args: &[String],
+        arg_tokens: &[tcl_lexer::Token],
+        joined_text: &str,
+    ) {
+        if !contains_gated_word(joined_text) {
+            return;
+        }
+        let Some((pre_85, pre_90)) = self.w003_gates() else {
+            return;
+        };
+        let parsed = crate::parse_expr(joined_text.trim(), Some(self.dialect.as_str()));
+        if matches!(parsed, ExprNode::Raw { .. }) {
+            return;
+        }
+        for (word, tok) in args.iter().zip(arg_tokens.iter()) {
+            let Some(op_name) = gated_operator_name(word, pre_85, pre_90) else {
+                continue;
+            };
+            self.result.diagnostics.push(super::types::Diagnostic {
+                code: DiagCode::W003,
+                span: tok.span,
+                message: format!(
+                    "Expression operator '{op_name}' is not available in dialect '{}'; requires {}.",
+                    self.dialect,
+                    w003_tip_citation(op_name)
+                ),
+                severity: Severity::Warning,
+                // The unbraced multi-word form has no single local
+                // span to rewrite in place without also re-bracing
+                // the whole expression (W100's concern, not this
+                // one) — left unfixed.
+                fixes: Vec::new(),
+            });
+        }
+    }
+
+    /// Resolve whether the active dialect gates TIP 201 (`in`/`ni`)
+    /// and/or TIP 461 (`lt`/`le`/`gt`/`ge`) `expr` operators, as
+    /// `(pre_85, pre_90)`. `None` when the active dialect string has
+    /// no documented `expr`-grammar base version, or neither TIP is
+    /// gated (nothing for W003 to check).
+    fn w003_gates(&self) -> Option<(bool, bool)> {
+        use tcl_registry::dialects::DialectSet;
+        let active = DialectSet::expr_grammar_base_version(&self.dialect)?;
         // Pre-Tcl-8.5 dialects don't accept `in` / `ni` (TIP 201).
         let pre_85 = !DialectSet::TCL85_PLUS.contains(active);
         // Pre-Tcl-9.0 dialects don't accept `lt` / `le` / `gt` / `ge`
         // (TIP 461); 9.0 and 9.1 both do.
         let pre_90 = !DialectSet::TCL90_PLUS.contains(active);
-        if !pre_85 && !pre_90 {
-            return;
-        }
-
-        let parsed = crate::parse_expr(expr_text.trim(), Some(self.dialect.as_str()));
-        if matches!(parsed, ExprNode::Raw { .. }) {
-            return;
-        }
-        let mut found: Vec<&'static str> = Vec::new();
-        walk_dialect_invalid_ops(&parsed, pre_85, pre_90, &mut found);
-        for op_name in found {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W003,
-                span: diag_span,
-                message: format!(
-                    "Expression operator '{op_name}' is not available in dialect '{}'.",
-                    self.dialect
-                ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
-        }
+        (pre_85 || pre_90).then_some((pre_85, pre_90))
     }
 }
 
@@ -2689,43 +2826,61 @@ pub(super) fn contains_gated_word(text: &str) -> bool {
     false
 }
 
-fn walk_dialect_invalid_ops(
-    node: &ExprNode,
-    pre_85: bool,
-    pre_90: bool,
-    found: &mut Vec<&'static str>,
-) {
-    match node {
-        ExprNode::Binary { op, left, right } => {
-            walk_dialect_invalid_ops(left, pre_85, pre_90, found);
-            walk_dialect_invalid_ops(right, pre_85, pre_90, found);
-            match op {
-                BinOp::In if pre_85 => found.push("in"),
-                BinOp::Ni if pre_85 => found.push("ni"),
-                BinOp::StrLt if pre_90 => found.push("lt"),
-                BinOp::StrLe if pre_90 => found.push("le"),
-                BinOp::StrGt if pre_90 => found.push("gt"),
-                BinOp::StrGe if pre_90 => found.push("ge"),
-                _ => {}
-            }
-        }
-        ExprNode::Unary { operand, .. } => {
-            walk_dialect_invalid_ops(operand, pre_85, pre_90, found);
-        }
-        ExprNode::Ternary {
-            condition,
-            true_branch,
-            false_branch,
-        } => {
-            walk_dialect_invalid_ops(condition, pre_85, pre_90, found);
-            walk_dialect_invalid_ops(true_branch, pre_85, pre_90, found);
-            walk_dialect_invalid_ops(false_branch, pre_85, pre_90, found);
-        }
-        ExprNode::Call { args, .. } => {
-            for arg in args {
-                walk_dialect_invalid_ops(arg, pre_85, pre_90, found);
-            }
-        }
-        _ => {}
+/// The gated operator name for `word`, given which TIPs are
+/// unavailable in the active dialect — `None` when `word` isn't one
+/// of the six dialect-gated keywords, or the relevant TIP is actually
+/// available (`pre_85`/`pre_90` both false for it).
+fn gated_operator_name(word: &str, pre_85: bool, pre_90: bool) -> Option<&'static str> {
+    Some(match word {
+        "in" if pre_85 => "in",
+        "ni" if pre_85 => "ni",
+        "lt" if pre_90 => "lt",
+        "le" if pre_90 => "le",
+        "gt" if pre_90 => "gt",
+        "ge" if pre_90 => "ge",
+        _ => return None,
+    })
+}
+
+/// The TIP citation to surface in the W003 message for `op_name`.
+fn w003_tip_citation(op_name: &str) -> &'static str {
+    match op_name {
+        "in" | "ni" => "Tcl 8.5+ (TIP 201)",
+        _ => "Tcl 9.0+ (TIP 461)",
     }
+}
+
+/// Whether `node` is safe to splice as a bare Tcl word into a
+/// rewritten command (`lsearch` / `string compare`) with no extra
+/// quoting: it never contains an unprotected top-level space. Plain
+/// atoms are always safe (`Literal` is bare digits, `String` already
+/// carries its own `{}`/`""` delimiters, `Var` is `$name`/`${name}`,
+/// `Command` is bracket-delimited); `Binary`/`Unary`/`Ternary` would
+/// need re-parenthesising and `Call` (`max($a, $b)`) contains an
+/// unprotected space after the comma, so none of those are rewritten.
+fn is_simple_operand(node: &ExprNode) -> bool {
+    matches!(
+        node,
+        ExprNode::Literal { .. }
+            | ExprNode::String { .. }
+            | ExprNode::Var { .. }
+            | ExprNode::Command { .. }
+    )
+}
+
+/// Build the portable rewrite for a dialect-gated `expr` operator
+/// application, or `None` if `op_name` isn't one of the six gated
+/// keywords. `left`/`right` must already be safe bare-word text (see
+/// [`is_simple_operand`]) — the caller is responsible for checking
+/// that before rendering them.
+fn rewrite_gated_operator(op_name: &str, left: &str, right: &str) -> Option<String> {
+    Some(match op_name {
+        "in" => format!("([lsearch -exact {right} {left}] >= 0)"),
+        "ni" => format!("([lsearch -exact {right} {left}] < 0)"),
+        "lt" => format!("([string compare {left} {right}] < 0)"),
+        "le" => format!("([string compare {left} {right}] <= 0)"),
+        "gt" => format!("([string compare {left} {right}] > 0)"),
+        "ge" => format!("([string compare {left} {right}] >= 0)"),
+        _ => return None,
+    })
 }

--- a/rust/tcl-compiler/src/analyser/utils.rs
+++ b/rust/tcl-compiler/src/analyser/utils.rs
@@ -23,7 +23,7 @@
 //! `signature_scan::params` so the analyser can keep its imports
 //! flat.
 
-use std::collections::HashSet;
+use std::collections::{HashMap, HashSet};
 
 use tcl_lexer::Token;
 use tcl_registry::{CommandRegistry, Traits};
@@ -237,6 +237,28 @@ pub fn recovery_known_commands<S: std::hash::BuildHasher>(
         insert_qualified_and_tail(&mut names, qname);
     }
     names
+}
+
+/// True when an earlier *unconditional* user `proc` named `qualified_name`
+/// lexically precedes `call_start` — Tcl resolves a proc over a same-named
+/// builtin/keyword at that call site, so the diagnostic that would fire
+/// against the builtin/keyword must be suppressed. Shared by W002's inline
+/// disabled-command shadow check and the EXPR-role emitters'
+/// (W100/W110/W003/W114) control-flow-keyword shadow check — both are the
+/// exact same position comparison against [`ProcDef::name_span`], just
+/// triggered from different call sites. W002's *per-item* flush path needs
+/// the fuller `UserResolutionFacts::resolves_to_user` instead (it also
+/// covers aliases/renames/classes/ensembles and namespace-qualified procs),
+/// so this simpler check isn't a fit there.
+#[must_use]
+pub fn proc_shadows_call<S: std::hash::BuildHasher>(
+    all_procs: &HashMap<String, super::types::ProcDef, S>,
+    qualified_name: &str,
+    call_start: u32,
+) -> bool {
+    all_procs
+        .get(qualified_name)
+        .is_some_and(|def| def.name_span.start() < call_start)
 }
 
 /// Insert `qname` (e.g. `::ns::foo`) — as-is, with the leading `::`

--- a/rust/tcl-lsp-server/tests/e2e/code_actions.rs
+++ b/rust/tcl-lsp-server/tests/e2e/code_actions.rs
@@ -166,6 +166,55 @@ fn test_w100_offers_brace_wrap() {
 }
 
 #[test]
+fn test_w003_offers_lsearch_fix_for_in() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "# tcl-dialect: tcl8.4\nexpr {2 in {1 2 3}}\n");
+    let w003 = with_code(&diags, "W003");
+    assert_eq!(w003.len(), 1, "{diags:?}");
+    let actions = lsp.code_actions(&uri, range((1, 0), (1, 19)), json!(w003));
+    assert!(
+        new_texts(&actions)
+            .iter()
+            .any(|nt| nt == "([lsearch -exact {1 2 3} 2] >= 0)"),
+        "{actions:?}"
+    );
+}
+
+#[test]
+fn test_w003_offers_string_compare_fix_for_lt() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "# tcl-dialect: tcl8.4\nif {$x lt $y} { puts hi }\n");
+    let w003 = with_code(&diags, "W003");
+    assert_eq!(w003.len(), 1, "{diags:?}");
+    let actions = lsp.code_actions(&uri, range((1, 0), (1, 26)), json!(w003));
+    assert!(
+        new_texts(&actions)
+            .iter()
+            .any(|nt| nt == "([string compare $x $y] < 0)"),
+        "{actions:?}"
+    );
+}
+
+#[test]
+fn test_w003_no_fix_when_operator_nested_in_larger_expression() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "# tcl-dialect: tcl8.4\nif {$a in $b && $c} { puts hi }\n",
+    );
+    let w003 = with_code(&diags, "W003");
+    assert_eq!(w003.len(), 1, "{diags:?}");
+    let actions = lsp.code_actions(&uri, range((1, 0), (1, 32)), json!(w003));
+    assert!(
+        new_texts(&actions).iter().all(|nt| !nt.contains("lsearch")),
+        "a nested occurrence must not offer the lsearch rewrite: {actions:?}"
+    );
+}
+
+#[test]
 fn test_w302_adds_result_capture_actions() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -2113,3 +2113,73 @@ fn shimmer_noqa_for_unrelated_code_does_not_suppress_s100() {
         "S100 must still fire when the preceding noqa names an unrelated code: {diags:?}"
     );
 }
+
+// -- W003 (dialect-gated expr operators) ---------------------------------
+
+#[test]
+fn w003_tight_span_covers_only_the_operator() {
+    // The diagnostic must highlight just the 2-byte `lt`, not the whole
+    // `{$a lt $b}` condition or the enclosing `if`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "# tcl-dialect: tcl8.4\nif {$a lt $b} { puts hi }\n");
+    let w003: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("W003"))
+        .collect();
+    assert_eq!(w003.len(), 1, "{diags:?}");
+    let range = &w003[0]["range"];
+    assert_eq!(range["start"]["line"], 1);
+    assert_eq!(range["start"]["character"], 7);
+    assert_eq!(range["end"]["line"], 1);
+    assert_eq!(range["end"]["character"], 9, "span must cover only 'lt'");
+}
+
+#[test]
+fn w003_repeated_operators_get_distinct_ranges_over_the_wire() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "# tcl-dialect: tcl8.4\nif {$a in $b && $c in $d} { puts hi }\n",
+    );
+    let w003: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("W003"))
+        .collect();
+    assert_eq!(w003.len(), 2, "{diags:?}");
+    assert_ne!(w003[0]["range"], w003[1]["range"]);
+}
+
+#[test]
+fn w003_message_cites_the_relevant_tip() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "# tcl-dialect: tcl8.4\nexpr {2 in {1 2 3}}\n");
+    let w003: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("W003"))
+        .collect();
+    assert_eq!(w003.len(), 1, "{diags:?}");
+    assert!(message(w003[0]).contains("TIP 201"), "{}", message(w003[0]));
+}
+
+#[test]
+fn w003_eda_vendor_dialect_does_not_over_fire_on_in() {
+    // Regression: `xilinx-eda-tcl` is documented as running on top of a
+    // real Tcl 8.5 core, so TIP 201's `in` must not be flagged there.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "# tcl-dialect: xilinx-eda-tcl\nexpr {2 in {1 2 3}}\n");
+    assert!(!has_code(&diags, "W003"), "{diags:?}");
+}
+
+#[test]
+fn w003_f5_tmsh_flags_string_relational_operators() {
+    // Regression: `f5-tmsh` used to have no `DialectSet` bit at all, so
+    // W003 silently never fired for it.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "# tcl-dialect: f5-tmsh\nif {$a lt $b} { puts hi }\n");
+    assert!(has_code(&diags, "W003"), "{diags:?}");
+}

--- a/rust/tcl-lsp-server/tests/e2e/tcl91.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcl91.rs
@@ -111,3 +111,19 @@ fn lt_operator_flags_w003_in_86() {
     let diags = lsp.open_ready(&uri, "# tcl-dialect: tcl8.6\nexpr {$a lt $b}\n");
     assert!(codes(&diags).contains("W003"));
 }
+
+#[test]
+fn ge_operator_no_w003_in_91() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "# tcl-dialect: tcl9.1\nexpr {$a ge $b}\n");
+    assert!(!codes(&diags).contains("W003"));
+}
+
+#[test]
+fn ge_operator_flags_w003_in_86() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "# tcl-dialect: tcl8.6\nexpr {$a ge $b}\n");
+    assert!(codes(&diags).contains("W003"));
+}

--- a/rust/tcl-registry/src/dialects.rs
+++ b/rust/tcl-registry/src/dialects.rs
@@ -889,6 +889,46 @@ impl DialectSet {
             .filter_map(|&bit| bit.canonical_name())
             .collect()
     }
+
+    /// Resolve `name` to the Tcl core-grammar version its `expr` evaluator
+    /// behaves like, for version-gated *language grammar* features — e.g.
+    /// TIP 201 (`in`/`ni`, 8.5+) and TIP 461 (`lt`/`le`/`gt`/`ge`, 9.0+).
+    ///
+    /// Distinct from [`Self::parse`] + `TCL85_PLUS`/`TCL90_PLUS`, which model
+    /// per-*command* dialect gating and deliberately keep vendor dialects
+    /// (the EDA tools, F5 iApps/tmsh) as their own bits rather than folding
+    /// them into a Tcl version — most standard-library commands they don't
+    /// ship are missing because of their own restricted command surface, not
+    /// because of version. Expr grammar is different: every dialect here is
+    /// either plain Tcl or a vendor shell embedding a real Tcl core, so it
+    /// inherits that embedded core's operators wholesale. `f5-irules` is the
+    /// one case where the two deliberately disagree: it advertises an
+    /// 8.6-shaped command *signature* but its `expr` evaluator is a genuine
+    /// embedded Tcl 8.4.6, so version-*dependent behaviour* (this included)
+    /// follows 8.4, not 8.6.
+    ///
+    /// Source: the per-dialect base-Tcl-version table in
+    /// `docs/design/compiler/dialects-events.md`. Returns `None` for
+    /// `f5-bigip` (a custom config parser, not Tcl at all) and for any name
+    /// this table has no documented base version for (`tk`, `bpf`) — callers
+    /// should treat `None` as "can't reason about this dialect's grammar
+    /// version," not "assume plain Tcl."
+    #[must_use]
+    pub fn expr_grammar_base_version(name: &str) -> Option<Self> {
+        Some(match name {
+            "tcl8.4" | "f5-irules" => Self::TCL84,
+            "tcl8.5"
+            | "f5-iapps"
+            | "f5-tmsh"
+            | "xilinx-eda-tcl"
+            | "intel-quartus-eda-tcl"
+            | "mentor-eda-tcl" => Self::TCL85,
+            "tcl8.6" | "synopsys-eda-tcl" | "cadence-eda-tcl" | "expect" => Self::TCL86,
+            "tcl9.0" => Self::TCL90,
+            "tcl9.1" => Self::TCL91,
+            _ => return None,
+        })
+    }
 }
 
 #[cfg(test)]
@@ -966,6 +1006,37 @@ mod tests {
         );
         assert_eq!(DialectSet::TCL84.member_names(), vec!["tcl8.4"]);
         assert!(DialectSet::empty().member_names().is_empty());
+    }
+
+    #[test]
+    fn expr_grammar_base_version_matches_documented_runtime_bases() {
+        let base = DialectSet::expr_grammar_base_version;
+        // Plain Tcl versions map to themselves.
+        assert_eq!(base("tcl8.4"), Some(DialectSet::TCL84));
+        assert_eq!(base("tcl9.1"), Some(DialectSet::TCL91));
+        // iRules' *runtime* base (8.4.6) wins over its 8.6-shaped command
+        // signature — version-dependent behaviour follows the runtime.
+        assert_eq!(base("f5-irules"), Some(DialectSet::TCL84));
+        // EDA / F5 vendor shells inherit their documented embedded core —
+        // unlike `DialectSet::TCL85_PLUS`, which deliberately excludes them.
+        for d in [
+            "f5-iapps",
+            "f5-tmsh",
+            "xilinx-eda-tcl",
+            "intel-quartus-eda-tcl",
+            "mentor-eda-tcl",
+        ] {
+            assert_eq!(base(d), Some(DialectSet::TCL85), "{d}");
+        }
+        for d in ["synopsys-eda-tcl", "cadence-eda-tcl", "expect"] {
+            assert_eq!(base(d), Some(DialectSet::TCL86), "{d}");
+        }
+        // Not Tcl at all / no documented base version: stay `None` rather
+        // than guessing.
+        assert_eq!(base("f5-bigip"), None);
+        assert_eq!(base("tk"), None);
+        assert_eq!(base("bpf"), None);
+        assert_eq!(base("nonsense"), None);
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- W003 (dialect-gated expr operator: `in`/`ni` under TIP 201, `lt`/`le`/`gt`/`ge` under TIP 461) was anchored at the whole EXPR-role argument (or the whole unbraced `expr` word range), so a large condition lit up entirely and repeated/distinct gated operators in one expression collapsed onto duplicate diagnostics at the identical coarse span. Both emitters (single braced-argument path and the unbraced multi-word `expr a op b` form) now anchor one diagnostic per occurrence at that operator's own token span.
- Added a quick fix (`in`/`ni` → `lsearch -exact`, `lt`/`le`/`gt`/`ge` → `string compare`) for the safe case where the whole argument is exactly one gated application with plain (non-compound) operands. The LSP code-actions provider already lifts any diagnostic's `CodeFix`es generically, so no editor-side wiring was needed beyond adding the extension test.
- Registry fix: gating used `DialectSet::TCL85_PLUS`/`TCL90_PLUS` directly, which excludes the EDA/F5 vendor dialects entirely (they over-fired on `in`/`ni` despite being documented as running on a real Tcl 8.5+/8.6+ core), and `f5-tmsh` had no `DialectSet` bit at all (so W003 silently never fired for it, missing `lt`/`le`/`gt`/`ge`). Added `DialectSet::expr_grammar_base_version`, a registry-level per-dialect base-Tcl-version table dedicated to expr-grammar TIP gating, separate from the per-command availability bitflags.
- `dispatch_expr_arguments` (hosting W100/W110/W003/W114) now shares one shadow guard: an earlier unconditional user `proc` of the same name (`expr`/`if`/`while`/`for`) suppresses these diagnostics, mirroring W002's existing rule.
- Fixed the KCS doc's pragma typo (`# dialect:` → `# tcl-dialect:`) and brought its example/message in line with the new per-TIP message text.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-compiler -p tcl-registry --lib` — 3746 + 278 passed, 0 failed
  - `cargo clippy -p tcl-compiler -p tcl-registry -p tcl-lsp-server -p tcl-lsp-core --all-targets` — clean
  - `make rust-check` (fmt + clippy + xtask drift gates) — clean
  - `cargo test --workspace --all-features` — full pass, 0 failures
  - `make check-all` (TS + Rust + Python gates) — clean
  - VS Code extension test suite (targeted `w003.test.ts` + full `configSettings.test.ts` regression sweep) — clean

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract?
- [x] If yes, I updated at least one relevant KCS note (`docs/kcs/codes/kcs-diagnostic-w003-dialect-invalid-expr-operator.md`) and the design doc (`docs/design/compiler/dialects-events.md`).
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md` — N/A, no new note added (existing note updated in place).

Tests: TP/FP/TN/FN analyser unit tests (tight spans, multi-occurrence, fix eligibility/ineligibility, namespace/TclOO/sub-interpreter nesting, proc-shadow suppression, EDA/tmsh dialect regressions), lsp_e2e coverage (range/message/quick-fix over the wire), and VS Code extension tests (diagnostic range, quick fix, no-fix-when-nested).


---
_Generated by [Claude Code](https://claude.ai/code/session_01AoDKAKn4TWBJWp77jCKvsG)_