### PR TITLE
W001: fix same-file shadow false positives, {*}-expansion, span precision, Tk 9.0 gaps

### DIFF
--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -9279,11 +9279,14 @@ string reverse hello
    `string reverse hello` above drew a spurious "Unknown subcommand
    'reverse' for 'string'" even though the call never reaches the builtin
    ensemble at all.
-3. The fix queues both the "unknown subcommand" and the subcommand-level
-   "disabled in this dialect" verdicts into the same `pending_subcommand`
-   list and resolves them in `flush_arity_diagnostics`, through the
-   identical `non_proc_qnames` / `proc_offsets` / `stub_names` shadow
-   computation the arity path already uses — no duplicated logic.
+3. The fix queues the "unknown subcommand" verdict into the same
+   `pending_arity` list E002/E003/W004 already use (a wrong subcommand name
+   is the same species of "call is malformed against the resolved registry
+   signature" as a wrong argument count), and the subcommand-level "disabled
+   in this dialect" verdict into `pending_disabled_commands` (the queue the
+   whole-command W002 check uses). Both resolve through the shared
+   `UserResolutionFacts` shadow computation in `flush_arity_diagnostics` /
+   `flush_disabled_command_diagnostics` — no duplicated logic.
 4. Order-sensitivity is preserved: a top-level call *before* the shadowing
    proc's definition still reaches the real builtin (Tcl executes
    top-level commands in source order during load) and still fires; a
@@ -9313,9 +9316,10 @@ site — there is no "unknown subcommand" to report — but the identical call
 #### Why the analyser reaches that verdict
 
 `analyser/diagnostics/validity.rs::emit_w001_unknown_subcommand` queues its
-verdict into `Analyser::pending_subcommand` instead of pushing directly;
-`Analyser::flush_arity_diagnostics` drains it post-walk through the same
-shadow test as `pending_arity`, using each candidate's captured
+"unknown subcommand" verdict into `Analyser::pending_arity` — the same queue
+E002/E003/W004 already use — instead of pushing directly.
+`Analyser::flush_arity_diagnostics` drains it post-walk through
+`UserResolutionFacts::resolves_to_user`, using each candidate's captured
 call-site-resolution namespace and `enforce_order` flag (`true` for
 top-level calls, `false` inside a proc/method body).
 

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -9245,6 +9245,230 @@ the in-process analyser, exercised here:
 
 ---
 
+### FP-STY-17 — W001 same-file shadow suppression (proc / class / alias / ensemble / stub redefining a registry ensemble command)
+
+- **Verdict:** FALSE POSITIVE (now fixed)
+- **Status:** locked in by `rust/tcl-compiler/src/analyser/diagnostics/fp/sty.rs::fp_sty_17_*`
+- **Codes:** W001 (unknown subcommand), subcommand-level W002 (disabled-in-dialect subcommand)
+- **Corpus:** any script that re-purposes a builtin ensemble name as its own
+  proc/class/alias — e.g. a namespace-local `proc string {op args} {…}`
+  wrapper, or a compatibility shim installed via `interp alias {} info {} …`.
+
+#### Reproducer
+
+```tcl
+proc string {op args} {
+    return "shadowed:$op"
+}
+string reverse hello
+```
+
+#### Per-line reasoning
+
+1. A `proc` (or `oo::class`/snit/itcl class, `interp alias`, `namespace
+   ensemble create -command`, or an inline `# tcl-lsp: stub`) whose name
+   matches a registry ensemble command **replaces** that command at the
+   call site — Tcl resolves the user definition, not the builtin, exactly
+   as it does for any other shadowed builtin (`close`, `apply`, …).
+2. The analyser already gets this right for the sibling arity diagnostics
+   (E002/E003): `emit_arity_diagnostics` queues every subcommand arity
+   check into `pending_arity` and `flush_arity_diagnostics` drops it when
+   the call resolves to a same-file proc/class/alias/ensemble/stub. W001
+   (`emit_w001_unknown_subcommand`) used to push straight into
+   `result.diagnostics`, bypassing that shadow check entirely — so
+   `string reverse hello` above drew a spurious "Unknown subcommand
+   'reverse' for 'string'" even though the call never reaches the builtin
+   ensemble at all.
+3. The fix queues both the "unknown subcommand" and the subcommand-level
+   "disabled in this dialect" verdicts into the same `pending_subcommand`
+   list and resolves them in `flush_arity_diagnostics`, through the
+   identical `non_proc_qnames` / `proc_offsets` / `stub_names` shadow
+   computation the arity path already uses — no duplicated logic.
+4. Order-sensitivity is preserved: a top-level call *before* the shadowing
+   proc's definition still reaches the real builtin (Tcl executes
+   top-level commands in source order during load) and still fires; a
+   call inside a proc body is not order-gated (proc bodies run after the
+   whole script has loaded).
+5. The suppression is scoped to the shadowed name only — a *different*,
+   non-shadowed ensemble command in the same file still fires normally.
+
+#### tclsh ground truth (8.6.14 — confirmed by execution)
+
+```
+% proc string {op args} { return "shadowed:$op" }
+% string reverse hello
+shadowed:reverse
+% catch {string mach hello world} err; puts $err
+;# (evaluated BEFORE the proc definition, in a fresh interpreter)
+unknown or ambiguous subcommand "mach": must be bytelength, cat, compare,
+equal, first, index, is, last, length, map, match, range, repeat, replace,
+reverse, tolower, totitle, toupper, trim, trimleft, trimright, wordend, or
+wordstart
+```
+
+The user `proc string` completely replaces the builtin ensemble at the call
+site — there is no "unknown subcommand" to report — but the identical call
+*before* the proc is defined still hits the real builtin and still errors.
+
+#### Why the analyser reaches that verdict
+
+`analyser/diagnostics/validity.rs::emit_w001_unknown_subcommand` queues its
+verdict into `Analyser::pending_subcommand` instead of pushing directly;
+`Analyser::flush_arity_diagnostics` drains it post-walk through the same
+shadow test as `pending_arity`, using each candidate's captured
+call-site-resolution namespace and `enforce_order` flag (`true` for
+top-level calls, `false` inside a proc/method body).
+
+#### Tests
+
+- `fp_sty_17_proc_shadow_no_w001` (FP)
+- `fp_sty_17_alias_shadow_no_w001` (FP)
+- `fp_sty_17_class_shadow_no_w001` (FP)
+- `fp_sty_17_stub_shadow_no_w001` (FP)
+- `fp_sty_17_unshadowed_command_still_fires` (TP — a different ensemble in
+  the same file is unaffected by the shadow)
+- `fp_sty_17_call_before_shadow_definition_still_fires` (TP — top-level
+  order-sensitivity)
+- `fp_sty_17_proc_body_call_shadowed_by_later_def_no_w001` (FP — proc-body
+  calls are not order-gated)
+
+---
+
+### FP-STY-18 — W001 `{*}`-expanded subcommand position (`cmd {*}{subcmd args…}`)
+
+- **Verdict:** FALSE POSITIVE (now fixed)
+- **Status:** locked in by `rust/tcl-compiler/src/analyser/diagnostics/fp/sty.rs::fp_sty_18_*`
+- **Codes:** W001 (unknown subcommand)
+- **Corpus:** dynamic-dispatch helpers that build an ensemble call from a
+  list (`dict {*}$argsList`, or a literal `{*}{…}` spread used to keep a
+  long argument list readable) — the dynamic-variable form was already
+  exempt via the `$`/`[` substitution gate; only the literal-braced form
+  was missed.
+
+#### Reproducer
+
+```tcl
+dict {*}{create a b}
+```
+
+#### Per-line reasoning
+
+1. `{*}WORD` splices `WORD`'s **list elements**, not its literal text, into
+   the argument position. `dict {*}{create a b}` therefore calls `dict
+   create a b`, not a single subcommand literally named `"create a b"`.
+2. `emit_w001_unknown_subcommand` reads `args[0]` (`"create a b"`, the
+   whole spread word as one string) as the candidate subcommand name. It
+   is never equal to any registry subcommand, so it fired "Unknown
+   subcommand 'create a b' for 'dict'" on perfectly valid Tcl.
+3. The existing dynamic-substitution gate (`has_substitution`, checking for
+   `$`/`[`) does not catch this shape — `{create a b}` is a plain literal
+   with no substitution, so it fell through to the unknown-subcommand path.
+4. The fix threads the per-argument `{*}`-expansion flag through to the
+   emitter (mirroring the identical `arg_expand.first()` guard the
+   subcommand-arity check already applies) and skips the check outright
+   when the subcommand position is expanded — the same "abstain when the
+   effective value can't be read off the source" convention every other
+   dynamic-value gate in this emitter already follows.
+
+#### tclsh ground truth (8.6.14 — confirmed by execution)
+
+```
+% dict {*}{create a b}
+a b
+% dict {*}{bogus a b}
+unknown or ambiguous subcommand "bogus": must be append, create, exists,
+filter, for, get, incr, info, keys, lappend, map, merge, remove, replace,
+set, size, unset, update, values, or with
+```
+
+`{*}{create a b}` is a genuine, valid `dict create` call; `{*}{bogus a b}`
+is a genuine error — the check must tell them apart by evaluating the
+*spread* subcommand, not the raw source text, so it now abstains on both
+rather than misreading either.
+
+#### Why the analyser reaches that verdict
+
+`analyser/diagnostics/validity.rs::emit_w001_unknown_subcommand` now takes
+`arg_expand_in` and returns before any subcommand-name comparison when
+`arg_expand[0]` is set — identical to the guard
+`emit_arity_diagnostics`'s subcommand-arity path already had.
+
+#### Tests
+
+- `fp_sty_18_expanded_literal_subcommand_no_w001` (FP)
+- `fp_sty_18_genuine_unknown_subcommand_without_expansion_still_fires` (TP)
+
+---
+
+### FP-STY-19 — W001 missing Tk 9.0 subcommands (`wm iconbadge`, `grid`/`pack`/`place content`)
+
+- **Verdict:** FALSE POSITIVE (now fixed — registry data gap, not compiler logic)
+- **Status:** locked in by `rust/tcl-compiler/src/analyser/diagnostics/fp/sty.rs::fp_sty_19_*`
+- **Codes:** W001 (unknown subcommand), W002 (disabled-in-dialect subcommand)
+- **Corpus:** any Tk 9.0 script using the taskbar/dock icon badge API or the
+  9.0-renamed geometry-manager introspection subcommand.
+
+#### Reproducer
+
+```tcl
+wm iconbadge .win 5
+grid content .frame
+pack content .frame
+place content .frame
+```
+
+#### Per-line reasoning
+
+1. Tk 9.0 added `wm iconbadge window badge` (a short overlay label on the
+   window's taskbar/dock icon — `doc/wm.n`, absent from the 8.4/8.5/8.6
+   man pages) and renamed `grid`/`pack`/`place`'s `slaves` introspection
+   subcommand to `content` as the canonical spelling (`slaves` is kept only
+   as a documented backward-compatible synonym — `doc/grid.n`,
+   `doc/pack.n`, `doc/place.n`).
+2. None of the four were present in the registry's `SubCommand` tables at
+   all (`tcl-registry/src/commands/tk/{wm,grid,pack,place}.rs`), so every
+   ensemble/`is_known` lookup failed and the analyser reported a genuine
+   9.0 Tk API as an "Unknown subcommand" — this is a registry data
+   completeness gap, never a compiler-logic bug: the fix adds the missing
+   `SubCommand` entries, dialect-gated `TCL90_PLUS` (matching the gate
+   already used for `info cmdtype`, the other 9.0-only ensemble
+   subcommand), not any change to `emit_w001_unknown_subcommand` itself.
+3. Tk subcommands are checked regardless of the active *Tcl* dialect (the
+   `| DialectSet::TK` union in `emit_w001_unknown_subcommand`), so under an
+   explicit `tcl8.6` dialect these four now correctly downgrade to W002
+   ("disabled in the active dialect profile") rather than either firing
+   W001 or going unconditionally silent — matching the existing `package
+   files` / 8.6 precedent (FP.md has no dedicated entry for that one; see
+   `rust/tcl-compiler/tests/analyser.rs::package_files_is_disabled_under_tcl86_per_tclsh`).
+
+#### Ground truth (Tk 9.0 documentation — `doc/wm.n` / `doc/grid.n` / `doc/pack.n` / `doc/place.n`, tag `core-9-0-4`)
+
+```
+wm.n:    wm iconbadge window badge
+                Sets an icon badge for the taskbar or dock icon […]
+grid.n:  grid content master ?-option value?
+                […] this command was named "slaves" and that name is
+                kept as a synonym for backward compatibility.
+```
+
+(Confirmed by direct comparison of the `core-8-4-20` / `core-8-5-19` /
+`core-8-6-16` / `core-9-0-4` man-page tags — none of the four subcommands
+appear before 9.0.)
+
+#### Why the analyser reaches that verdict
+
+`tcl-registry/src/commands/tk/wm.rs` gains an `"iconbadge"` `SubCommand`
+entry (`dialects: Some(DialectSet::TCL90_PLUS)`); `grid.rs` / `pack.rs` /
+`place.rs` each gain a `"content"` entry with the same gate, alongside the
+pre-existing ungated `"slaves"` entry.
+
+#### Tests
+
+- `fp_sty_19_wm_iconbadge_not_unknown` (FP + the tcl8.6 W002-not-W001 verdict)
+- `fp_sty_19_grid_pack_place_content_not_unknown` (FP)
+- `fp_sty_19_genuine_unknown_wm_and_geometry_subcommands_still_fire` (TP)
+
+---
 
 ## Precision gaps (PR #498 deep-review) — ALL CLOSED
 

--- a/docs/kcs/codes/kcs-diagnostic-w001-unknown-subcommand.md
+++ b/docs/kcs/codes/kcs-diagnostic-w001-unknown-subcommand.md
@@ -19,6 +19,8 @@ Why do I see a warning on a subcommand that the analyser does not recognise?
 
 An unrecognised subcommand usually means a typo or a version mismatch. At runtime, Tcl will raise an error because the ensemble or command does not support that subcommand.
 
+W001 does not fire when the command name itself resolves to something other than the built-in ensemble — a same-file `proc`, an `oo::class`/snit/itcl class, an `interp alias`, or a `namespace ensemble create -command` all take priority over a built-in of the same name, exactly as Tcl resolves them at the call site. For example, a script that defines its own `proc string {op args} {...}` is never flagged for `string reverse $x`, because that call never reaches the built-in `string` ensemble at all.
+
 ## Symptoms
 
 - A yellow squiggle appears under the subcommand token, with the message "unknown subcommand 'foo' for 'string'".

--- a/editors/vscode/src/test/precisionFalsePositives.test.ts
+++ b/editors/vscode/src/test/precisionFalsePositives.test.ts
@@ -228,3 +228,68 @@ suite("Dollar-before-close-quote (FP-STY-15)", () => {
     );
   });
 });
+
+// FP-STY-17 — same-file shadow suppression for W001 (unknown subcommand).
+//
+// Line 6 (`string reverse hello`, proc shadow) and line 9 (`info bogus`,
+// alias shadow) must stay silent for W001 — the call resolves to the
+// same-file proc/alias, not the registry ensemble. Line 12 (`dict bogus a
+// b`, untouched by either shadow) MUST fire W001 — the marker that
+// analysis ran.
+suite("Ensemble-command shadow suppression (FP-STY-17)", () => {
+  const docUri = getDocUri("ensembleShadowing.tcl");
+
+  test("unshadowed ensemble fires W001 (true case)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W001"),
+    });
+    const w001Lines = linesWithCode(diags, "W001");
+    assert.ok(
+      w001Lines.includes(12),
+      `expected W001 on unshadowed 'dict bogus' (line 12); got [${w001Lines}]`,
+    );
+  });
+
+  test("proc/alias shadowed ensemble calls stay silent (false case)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W001"),
+    });
+    for (const ln of linesWithCode(diags, "W001")) {
+      assert.ok([6, 9].includes(ln) === false, `unexpected W001 on shadowed-call line ${ln}`);
+    }
+  });
+});
+
+// FP-STY-18 — `{*}`-expanded subcommand position for W001.
+//
+// Line 4 (`dict {*}{create a b}`) splices list elements into the argument
+// list — a genuine valid call — and must stay silent for W001. Line 5
+// (`dict bogus a b`, unexpanded) MUST fire W001 (the marker that analysis
+// ran).
+suite("Expanded subcommand position (FP-STY-18)", () => {
+  const docUri = getDocUri("expandedSubcommand.tcl");
+
+  test("genuine unknown subcommand without expansion fires W001 (true case)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W001"),
+    });
+    const w001Lines = linesWithCode(diags, "W001");
+    assert.ok(
+      w001Lines.includes(5),
+      `expected W001 on unexpanded 'dict bogus' (line 5); got [${w001Lines}]`,
+    );
+  });
+
+  test("{*}-expanded literal subcommand stays silent (false case)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W001"),
+    });
+    for (const ln of linesWithCode(diags, "W001")) {
+      assert.notStrictEqual(ln, 4, `unexpected W001 on {*}-expanded line ${ln}`);
+    }
+  });
+});

--- a/editors/vscode/testFixture/ensembleShadowing.tcl
+++ b/editors/vscode/testFixture/ensembleShadowing.tcl
@@ -1,0 +1,13 @@
+# FP-STY-17 fixture: a same-file proc/alias that shadows a registry ensemble
+# command must suppress W001 on calls through the shadowed name; an
+# unshadowed ensemble in the same file must still fire.
+proc string {op args} {
+    return "shadowed:$op"
+}
+string reverse hello
+proc myInfo {op args} { return $op }
+interp alias {} info {} myInfo
+info bogus
+# `dict` is untouched by either shadow above — a genuine unknown subcommand
+# here must still fire W001 (the marker that analysis ran).
+dict bogus a b

--- a/editors/vscode/testFixture/expandedSubcommand.tcl
+++ b/editors/vscode/testFixture/expandedSubcommand.tcl
@@ -1,0 +1,6 @@
+# FP-STY-18 fixture: a `{*}`-expanded subcommand word splices its list
+# elements into the argument list, so the literal source text must never be
+# compared against the subcommand set. The unexpanded genuine typo below
+# must still fire W001 (the marker that analysis ran).
+dict {*}{create a b}
+dict bogus a b

--- a/editors/zed/src/generated/tcl_commands.json
+++ b/editors/zed/src/generated/tcl_commands.json
@@ -2230,6 +2230,7 @@
         "bbox",
         "columnconfigure",
         "configure",
+        "content",
         "forget",
         "info",
         "location",
@@ -6292,6 +6293,7 @@
       "summary": "Geometry manager that packs slaves around the edges of a cavity.",
       "subcommands": [
         "configure",
+        "content",
         "forget",
         "info",
         "propagate",
@@ -6564,6 +6566,7 @@
       "summary": "Geometry manager for fixed or rubber-sheet placement.",
       "subcommands": [
         "configure",
+        "content",
         "forget",
         "info",
         "slaves"
@@ -9712,6 +9715,7 @@
         "geometry",
         "grid",
         "group",
+        "iconbadge",
         "iconbitmap",
         "iconify",
         "iconmask",

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -647,7 +647,14 @@ impl Analyser {
         if cmd_name == "catch" {
             self.emit_w302_catch_no_result_var(args, cmd_tok, arg_tokens, arg_single);
         }
-        self.emit_w001_unknown_subcommand(cmd_name, args, cmd_tok, arg_tokens, scope_path);
+        self.emit_w001_unknown_subcommand(
+            cmd_name,
+            args,
+            cmd_tok,
+            arg_tokens,
+            arg_expand_in,
+            scope_path,
+        );
         self.emit_w002_disabled_command(cmd_name, cmd_tok, scope_path);
         if let Some(checker) = self
             .registry

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sty.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sty.rs
@@ -971,3 +971,200 @@ fn fp_sty_16_path_with_command_sub_still_fires() {
         codes(src, D)
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-STY-17 — W001 same-file shadow suppression (proc / class / alias /
+// ensemble / stub redefining a registry ensemble command)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fp_sty_17_proc_shadow_no_w001() {
+    // FP-STY-17: a same-file `proc string {...}` completely replaces the
+    // builtin ensemble at the call site — `string reverse hello` resolves to
+    // the user proc, not the registry's `string` subcommand set, so it must
+    // NOT fire W001, exactly as the sibling E002/E003 arity check already
+    // abstains for a shadowed builtin.
+    let src = "proc string {op args} { return \"shadowed:$op\" }\nstring reverse hello\n";
+    assert!(
+        !fires(src, D, "W001"),
+        "FP-STY-17: proc-shadowed ensemble call must NOT fire W001; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_sty_17_alias_shadow_no_w001() {
+    // FP-STY-17: `interp alias {} info {} myInfo` points `info` at an alias
+    // target — a call through it must not be checked against the registry
+    // `info` ensemble's subcommand set.
+    let src = "proc myInfo {op args} { return $op }\ninterp alias {} info {} myInfo\ninfo bogus\n";
+    assert!(
+        !fires(src, D, "W001"),
+        "FP-STY-17: alias-shadowed ensemble call must NOT fire W001; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_sty_17_class_shadow_no_w001() {
+    // FP-STY-17: `oo::class create array {...}` makes `array` the class's own
+    // object command (dispatching `new`/`create`, not the registry `array`
+    // ensemble's subcommand set) — `array create obj` must not fire W001
+    // even though `create` is not a real `array` subcommand.
+    let src = "oo::class create array {\n    constructor {} {}\n}\narray create obj\n";
+    assert!(
+        !fires(src, D, "W001"),
+        "FP-STY-17: class-shadowed ensemble call must NOT fire W001; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_sty_17_stub_shadow_no_w001() {
+    // FP-STY-17: an inline `# tcl-lsp: stub` declaration is a document-global
+    // promise that the command exists (e.g. injected by a test harness or a
+    // package the analyser doesn't see the source of) — it must suppress
+    // W001 exactly like it suppresses the arity checks.
+    let src = "# tcl-lsp: stub string\nstring reverse hello\n";
+    assert!(
+        !fires(src, D, "W001"),
+        "FP-STY-17: stub-shadowed ensemble call must NOT fire W001; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_sty_17_unshadowed_command_still_fires() {
+    // TP control: shadowing `string` must not blind the analyser to a
+    // genuine unknown subcommand on a *different*, unshadowed ensemble in
+    // the same file.
+    let src = "proc string {op args} { return $op }\ninfo bogus\n";
+    assert!(
+        fires(src, D, "W001"),
+        "FP-STY-17 TP: an unshadowed ensemble must still fire W001; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_sty_17_call_before_shadow_definition_still_fires() {
+    // TP control: Tcl executes top-level commands in source order during
+    // load, so a call *before* the shadowing proc's definition still reaches
+    // the real builtin and still errors — confirmed against tclsh 8.6.14:
+    // `catch {string mach x y} e` before `proc string {...}` still raises
+    // "unknown or ambiguous subcommand". W001 must still fire here.
+    let src = "string mach hello world\nproc string {op args} { return $op }\n";
+    assert!(
+        fires(src, D, "W001"),
+        "FP-STY-17 TP: a call before the shadowing definition must still fire W001; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_sty_17_proc_body_call_shadowed_by_later_def_no_w001() {
+    // FP-STY-17: unlike a top-level call, a call inside a proc body runs
+    // only after the whole script has loaded — a `proc string {...}`
+    // appearing *after* the caller's own definition still shadows it, so no
+    // W001.
+    let src =
+        "proc caller {} {\n    string reverse hello\n}\nproc string {op args} { return $op }\n";
+    assert!(
+        !fires(src, D, "W001"),
+        "FP-STY-17: a proc-body call shadowed by a later definition must NOT fire W001; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FP-STY-18 — W001 `{*}`-expanded subcommand position (`cmd {*}{subcmd args…}`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fp_sty_18_expanded_literal_subcommand_no_w001() {
+    // FP-STY-18: `{*}{create a b}` splices the *elements* `create`, `a`, `b`
+    // into the argument list — confirmed against tclsh 8.6.14: `dict
+    // {*}{create a b}` evaluates `dict create a b`. The raw source text
+    // `"create a b"` must never be compared against the subcommand set.
+    let src = "dict {*}{create a b}";
+    assert!(
+        !fires(src, D, "W001"),
+        "FP-STY-18: {{*}}-expanded literal subcommand must NOT fire W001; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_sty_18_genuine_unknown_subcommand_without_expansion_still_fires() {
+    // TP control: the same subcommand set, unexpanded, still fires on a
+    // genuine unknown subcommand.
+    assert!(
+        fires("dict bogus a b", D, "W001"),
+        "FP-STY-18 TP: a genuine unknown subcommand must still fire W001; emitted: {:?}",
+        codes("dict bogus a b", D)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FP-STY-19 — missing Tk 9.0 subcommands (`wm iconbadge`, `grid`/`pack`/
+// `place content`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn fp_sty_19_wm_iconbadge_not_unknown() {
+    // FP-STY-19: `wm iconbadge` is a genuine Tk 9.0+ subcommand (wm.n) that
+    // was missing from the registry entirely, so it drew a spurious
+    // "Unknown subcommand" under every dialect (Tk subcommands are checked
+    // regardless of the active Tcl dialect). Under tcl9.0 it is fully known.
+    assert!(
+        !fires("wm iconbadge .win 5", "tcl9.0", "W001"),
+        "FP-STY-19: wm iconbadge must NOT fire W001 under tcl9.0; emitted: {:?}",
+        codes("wm iconbadge .win 5", "tcl9.0")
+    );
+    // Under tcl8.6 it is a genuine subcommand that doesn't exist before 9.0
+    // — the correct diagnostic is W002 (disabled in this dialect profile),
+    // never W001, mirroring the `package files` / tcl8.6 precedent.
+    assert!(
+        !fires("wm iconbadge .win 5", D, "W001"),
+        "FP-STY-19: wm iconbadge must NOT fire W001 under tcl8.6; emitted: {:?}",
+        codes("wm iconbadge .win 5", D)
+    );
+    assert!(
+        fires("wm iconbadge .win 5", D, "W002"),
+        "FP-STY-19: wm iconbadge under tcl8.6 must fire W002 (disabled in dialect); emitted: {:?}",
+        codes("wm iconbadge .win 5", D)
+    );
+}
+
+#[test]
+fn fp_sty_19_grid_pack_place_content_not_unknown() {
+    // FP-STY-19: Tk 9.0 renamed `slaves` to `content` (grid.n/pack.n/
+    // place.n) as the canonical spelling; it was missing from the registry
+    // entirely for all three geometry managers.
+    for src in [
+        "grid content .frame",
+        "pack content .frame",
+        "place content .frame",
+    ] {
+        assert!(
+            !fires(src, "tcl9.0", "W001"),
+            "FP-STY-19: {src:?} must NOT fire W001 under tcl9.0; emitted: {:?}",
+            codes(src, "tcl9.0")
+        );
+    }
+}
+
+#[test]
+fn fp_sty_19_genuine_unknown_wm_and_geometry_subcommands_still_fire() {
+    // TP control: real typos on the same commands still fire.
+    assert!(
+        fires("wm bogus .win", "tcl9.0", "W001"),
+        "FP-STY-19 TP: wm bogus must still fire W001; emitted: {:?}",
+        codes("wm bogus .win", "tcl9.0")
+    );
+    assert!(
+        fires("grid bogus .frame", "tcl9.0", "W001"),
+        "FP-STY-19 TP: grid bogus must still fire W001; emitted: {:?}",
+        codes("grid bogus .frame", "tcl9.0")
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -167,6 +167,20 @@ fn dialect_availability_suffix(dialects: Option<tcl_registry::prelude::DialectSe
     format!(" (available in: {})", names.join(", "))
 }
 
+/// The *content* range of a subcommand word token — excluding a wrapper
+/// delimiter (`{…}` / `"…"`) when present.  Wrapper tokens carry the opening
+/// delimiter via `content_offset` and intentionally exclude the closing
+/// delimiter from `span.end` (see the word-token closing-delimiter
+/// convention); using the content range gives `length` (not `{length}` /
+/// `"length"`) for a wrapped subcommand and is identical to the full span for
+/// a bare `Esc` word (`content_offset == 0`). Shared by the W001 diagnostic
+/// span and its "did you mean" [`CodeFix`](super::types::CodeFix) span so the
+/// squiggle and the quick-fix target the same text.
+fn subcommand_content_span(tok: tcl_lexer::Token) -> tcl_lexer::Span {
+    let content_start = tok.span.start() + u32::from(tok.content_offset);
+    tcl_lexer::Span::new(content_start, tok.span.end())
+}
+
 /// Namespace-qualify `cmd_name`'s resolution candidates the Tcl way: current
 /// namespace first, then global. Shared by the builtin-shadowing suppression
 /// check ([`Analyser::flush_arity_diagnostics`]) and the same-file
@@ -354,31 +368,6 @@ pub(super) fn is_tcloo_metaclass(
 }
 
 impl Analyser {
-    /// **W001.** Emit "Unknown subcommand" warning for commands
-    /// whose registry signature is a [`SubcommandSig`](super::dispatch::SubcommandSig)
-    /// when the first argument doesn't resolve to a known subcommand.
-    ///
-    /// Skips:
-    ///
-    /// - commands the registry doesn't know (no signature),
-    /// - simple-command signatures (no subcommand dispatch),
-    /// - signatures with `allow_unknown == true` (generated
-    ///   dialect packs),
-    /// - first-arg values containing ``$`` / ``[`` (dynamic
-    ///   substitution — runtime-resolved),
-    /// - empty arg lists (handled by the E001 emitter).
-    ///
-    /// When emission is warranted, includes a "did you mean…?"
-    /// suffix using [`crate::text::suggest_similar`] over the
-    /// known subcommand set (max 1 suggestion within edit
-    /// distance 3).
-    ///
-    /// One case is not handled: a subcommand position that is
-    /// ``{*}``-expanded (``arg_expand[0]``). ``process_command`` does
-    /// not currently thread the expansion flag through; the literal-
-    /// text ``$`` / ``[`` gate covers the dynamic-substitution case,
-    /// and ``{*}LITERAL`` for an unknown subcommand is rare enough in
-    /// practice that the gap is acceptable.
     /// **W002** — the command is disabled in the active dialect profile: it
     /// exists in the registry but not for the active dialect (e.g. `dict` under
     /// `tcl8.4`, added in 8.5).  Only a *literal* command head is checked — a
@@ -476,12 +465,53 @@ impl Analyser {
         super::dispatch::signature_for_command(registry, cmd_name, dialect)
     }
 
+    /// **W001.** Emit "Unknown subcommand" warning for commands
+    /// whose registry signature is a [`SubcommandSig`](super::dispatch::SubcommandSig)
+    /// when the first argument doesn't resolve to a known subcommand.
+    ///
+    /// Skips:
+    ///
+    /// - commands the registry doesn't know (no signature),
+    /// - simple-command signatures (no subcommand dispatch),
+    /// - signatures with `allow_unknown == true` (generated
+    ///   dialect packs),
+    /// - a `{*}`-expanded subcommand word (`cmd {*}bogus …`) — its literal
+    ///   text is not what ends up in the subcommand position at run time,
+    /// - first-arg values containing ``$`` / ``[`` (dynamic
+    ///   substitution — runtime-resolved),
+    /// - empty arg lists (handled by the E001 emitter).
+    ///
+    /// When emission is warranted, includes a "did you mean…?"
+    /// suffix using [`crate::text::suggest_similar`] over the
+    /// known subcommand set (max 1 suggestion within edit
+    /// distance 3), and anchors the diagnostic at the subcommand token's
+    /// *content* range only ([`subcommand_content_span`]) — not the command
+    /// name — so the squiggle sits tightly on the one word that is actually
+    /// wrong, matching the "did you mean" fix's replacement range.
+    ///
+    /// A verdict is not pushed directly: the genuinely-unknown-subcommand
+    /// case is queued into [`Analyser::pending_arity`] — the same queue the
+    /// sibling E002/E003 arity check and W004 use, since a wrong subcommand
+    /// name is the same species of "call is malformed against the resolved
+    /// registry signature" as a wrong argument count — and the
+    /// subcommand-level-disabled-in-dialect case into
+    /// [`Analyser::pending_disabled_commands`] (the same queue
+    /// [`Self::emit_w002_disabled_command`] uses). Both are resolved
+    /// post-walk through [`UserResolutionFacts`], the identical shadow
+    /// computation every one of those checks shares. This covers the same
+    /// tricky-Tcl surface: a same-file `proc string {…}`, an `oo::class` /
+    /// snit / itcl class named `string`, an `interp alias` pointed at
+    /// `string`, a `namespace ensemble create -command string`, a static
+    /// `rename` target, or an inline `# tcl-lsp: stub string` all resolve
+    /// the call to something the registry ensemble signature has nothing to
+    /// do with, so none of them may draw a false "unknown subcommand".
     pub(in crate::analyser) fn emit_w001_unknown_subcommand(
         &mut self,
         cmd_name: &str,
         args: &[String],
         cmd_tok: tcl_lexer::Token,
         arg_tokens: &[tcl_lexer::Token],
+        arg_expand_in: &[bool],
         scope_path: &[usize],
     ) {
         use super::dispatch::{CommandSignature, signature_for_command};
@@ -494,6 +524,16 @@ impl Analyser {
             // Empty arg list — E001 path; not in scope here.
             return;
         };
+        // A `{*}`-expanded subcommand word (`cmd {*}bogus …`) splices
+        // ``bogus``'s *elements* into the subcommand position at run time,
+        // not its literal text — a multi-element literal (`cmd {*}{a b}`)
+        // would otherwise be misread as one bogus subcommand named `"a b"`.
+        // `arg_expand_in` is parallel to the full argv (command name at
+        // index 0); drop that slot so it lines up with `args`.
+        let arg_expand: &[bool] = arg_expand_in.get(1..).unwrap_or(&[]);
+        if arg_expand.first().copied().unwrap_or(false) {
+            return;
+        }
         // Dynamic-value subcommand position — can't resolve statically.
         if arg_tokens
             .first()
@@ -555,6 +595,8 @@ impl Analyser {
         // proc/alias/rename/class/ensemble that shadows it — e.g. `proc
         // package {args} {…}` fully overriding the `package` ensemble) can
         // depend on facts not yet known mid-walk.
+        let ns = self.command_resolution_namespace(scope_path);
+        let enforce_order = !self.scope_path_in_proc_body(scope_path);
         if let Some(CommandSignature::WithSubcommands(any_sig)) =
             signature_for_command(registry, cmd_name, DialectSet::all())
             && any_sig.is_known(first_arg)
@@ -587,8 +629,6 @@ impl Analyser {
                 severity: Severity::Warning,
                 fixes: Vec::new(),
             };
-            let ns = self.command_resolution_namespace(scope_path);
-            let enforce_order = !self.scope_path_in_proc_body(scope_path);
             self.pending_disabled_commands
                 .push((cmd_name.to_string(), ns, enforce_order, diag));
             return;
@@ -597,46 +637,34 @@ impl Analyser {
         let candidates: Vec<&str> = sig.subcommands.keys().map(String::as_str).collect();
         let suggestions = crate::text::suggest_similar(first_arg, candidates.iter().copied(), 1, 3);
         let mut fixes: Vec<super::types::CodeFix> = Vec::new();
+        // Anchor the squiggle at the subcommand token's content range only —
+        // not the command name — so it sits tightly on the one word that is
+        // actually wrong; the "did you mean" fix targets the identical range.
+        let span = match arg_tokens.first() {
+            Some(sub_tok) => subcommand_content_span(*sub_tok),
+            None => cmd_tok.span,
+        };
         if let Some(best) = suggestions.first() {
             use std::fmt::Write as _;
             let _ = write!(message, "; did you mean '{best}'?");
-            if let Some(sub_tok) = arg_tokens.first() {
-                // Target the *content* range of the subcommand
-                // token rather than its full span.  Wrapper tokens
-                // (`Str` braced, `Esc` quoted) carry the opening
-                // delimiter via ``content_offset`` and intentionally
-                // exclude the closing delimiter from ``span.end``;
-                // replacing the full span would leave a stray
-                // ``}`` / ``"`` behind (e.g. ``string {lenght}`` →
-                // ``string length}``).  Using the content range
-                // ([span.start + content_offset, span.end)) gives
-                // ``{length}`` / ``"length"`` for the wrapped forms
-                // and remains identical to the full span for bare
-                // ``Esc`` words (``content_offset == 0``).
-                let content_start = sub_tok.span.start() + u32::from(sub_tok.content_offset);
-                let fix_span = tcl_lexer::Span::new(content_start, sub_tok.span.end());
-                fixes.push(super::types::CodeFix {
-                    span: fix_span,
-                    new_text: (*best).to_string(),
-                    description: format!("Replace with '{best}'"),
-                });
-            }
+            fixes.push(super::types::CodeFix {
+                span,
+                new_text: (*best).to_string(),
+                description: format!("Replace with '{best}'"),
+            });
         }
-        // Anchor at the command-head + subcommand-name range so
-        // the squiggle covers ``cmd subname`` rather than the
-        // entire invocation: combine the command token with the
-        // subcommand arg token.
-        let span = match arg_tokens.first() {
-            Some(sub_tok) => tcl_lexer::Span::new(cmd_tok.span.start(), sub_tok.span.end()),
-            None => cmd_tok.span,
-        };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W001,
-            span,
-            message,
-            severity: Severity::Warning,
-            fixes,
-        });
+        self.pending_arity.push((
+            cmd_name.to_string(),
+            ns,
+            enforce_order,
+            super::types::Diagnostic {
+                code: DiagCode::W001,
+                span,
+                message,
+                severity: Severity::Warning,
+                fixes,
+            },
+        ));
     }
 
     /// **E002 / E003.** Argument-count check for simple (non-
@@ -1058,10 +1086,11 @@ impl Analyser {
     /// Idempotent: drains `pending_arity` and `pending_user_call_arity`,
     /// so a second call is a no-op.
     ///
-    /// `pending_arity` carries both E002/E003 arity candidates and W004
-    /// (dialect-invalid-option) candidates (see its field doc); the
-    /// resolution loop below never inspects `diag.code`, so both share the
-    /// identical shadowing suppression with no special-casing.
+    /// `pending_arity` carries E002/E003 arity candidates, W004
+    /// (dialect-invalid-option) candidates, and W001 (unknown-subcommand)
+    /// candidates (see its field doc); the resolution loop below never
+    /// inspects `diag.code`, so all three share the identical shadowing
+    /// suppression with no special-casing.
     pub fn flush_arity_diagnostics(&mut self) {
         if self.pending_arity.is_empty() && self.pending_user_call_arity.is_empty() {
             return;

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -270,12 +270,13 @@ pub struct Analyser {
     /// per command) cost ``O(log N)`` instead of ``O(N)`` per
     /// call.  ``None`` outside an active analysis run.
     pub line_offsets: Option<Vec<usize>>,
-    /// Candidate E002 / E003 arity diagnostics **and** W004
-    /// (dialect-invalid-option) diagnostics collected during the command
-    /// walk, as `(command name, call-site namespace, enforce_order,
-    /// diagnostic)`.  Both are "this registry builtin's rule was
-    /// violated" candidates with the identical suppression condition, so
-    /// they share one queue.  Emitted in a post-walk pass
+    /// Candidate E002 / E003 arity diagnostics, W004
+    /// (dialect-invalid-option) diagnostics, **and** W001 (unknown
+    /// subcommand) diagnostics collected during the command walk, as
+    /// `(command name, call-site namespace, enforce_order, diagnostic)`.
+    /// All three are "this registry builtin's rule was violated" candidates
+    /// with the identical suppression condition, so they share one queue.
+    /// Emitted in a post-walk pass
     /// ([`Self::flush_arity_diagnostics`]) so a command that resolves
     /// to a user-defined proc / class / alias / ensemble / stub —
     /// which may be defined *after* its call site — suppresses the
@@ -3240,7 +3241,11 @@ mod tests {
     }
 
     #[test]
-    fn analyse_w001_anchors_at_cmd_plus_subcommand_range() {
+    fn analyse_w001_anchors_at_subcommand_token_only() {
+        // The squiggle sits tightly on the offending word alone — not the
+        // command name too — matching the "did you mean" fix's replacement
+        // range and the KCS doc's documented "squiggle under the subcommand
+        // token" behaviour.
         let mut a = Analyser::new();
         let src = "string bogus $x\n";
         let r = a.analyse(src, "tcl");
@@ -3252,7 +3257,7 @@ mod tests {
         assert_eq!(w001.len(), 1);
         let span = w001[0].span;
         let text = &src[span.start() as usize..span.end() as usize];
-        assert_eq!(text, "string bogus", "got {text:?}");
+        assert_eq!(text, "bogus", "got {text:?}");
     }
 
     #[test]
@@ -3316,6 +3321,88 @@ mod tests {
             assert_eq!(fixed, expected, "src={src:?} fixes={:?}", w001[0].fixes);
             assert!(!fixed.contains("lenght"), "src={src:?} fixed={fixed:?}");
         }
+    }
+
+    #[test]
+    fn analyse_w001_diagnostic_span_matches_fix_span() {
+        // The squiggle and the "did you mean" quick-fix must target the
+        // identical range — otherwise accepting the fix visibly leaves part
+        // of the squiggled text unchanged.
+        let mut a = Analyser::new();
+        let src = "string lenght $x\n";
+        let r = a.analyse(src, "tcl");
+        let w001: Vec<_> = r
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == DiagCode::W001)
+            .collect();
+        assert_eq!(w001.len(), 1, "got {:?}", r.diagnostics);
+        let fix = w001[0]
+            .fixes
+            .first()
+            .expect("expected a 'did you mean' fix");
+        assert_eq!(w001[0].span, fix.span, "got {:?}", w001[0]);
+    }
+
+    #[test]
+    fn analyse_w001_no_diagnostic_at_all_when_shadowed_by_proc() {
+        // A same-file `proc string {...}` must suppress W001 (and its
+        // subcommand-level W002 sibling) completely — not just avoid the
+        // specific message text. See FP-STY-17 in docs/design/compiler/FP.md.
+        let mut a = Analyser::new();
+        let src = "proc string {op args} { return $op }\nstring reverse hello\n";
+        let r = a.analyse(src, "tcl");
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| matches!(d.code, DiagCode::W001 | DiagCode::W002)),
+            "got {:?}",
+            r.diagnostics
+        );
+    }
+
+    #[test]
+    fn analyse_w001_shadow_suppression_is_scoped_to_the_shadowed_name() {
+        // Shadowing `string` must not suppress W001 for a genuinely unknown
+        // subcommand on a different, unshadowed ensemble in the same file.
+        let mut a = Analyser::new();
+        let src = "proc string {op args} { return $op }\ninfo bogus\n";
+        let r = a.analyse(src, "tcl");
+        let w001: Vec<_> = r
+            .diagnostics
+            .iter()
+            .filter(|d| d.code == DiagCode::W001)
+            .collect();
+        assert_eq!(w001.len(), 1, "got {:?}", r.diagnostics);
+        assert!(w001[0].message.contains("'info'"), "got {:?}", w001[0]);
+    }
+
+    #[test]
+    fn analyse_no_w001_for_expanded_literal_subcommand() {
+        // `{*}{create a b}` splices the elements `create`, `a`, `b` into the
+        // argument list (confirmed against tclsh 8.6.14) — the raw source
+        // text "create a b" must never be compared against the subcommand
+        // set. See FP-STY-18 in docs/design/compiler/FP.md.
+        let mut a = Analyser::new();
+        let r = a.analyse("dict {*}{create a b}\n", "tcl");
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == DiagCode::W001),
+            "got {:?}",
+            r.diagnostics
+        );
+    }
+
+    #[test]
+    fn analyse_w001_still_fires_for_unexpanded_unknown_subcommand() {
+        // TP control for the `{*}`-expansion skip: the identical subcommand
+        // set, without expansion, still fires on a genuine typo.
+        let mut a = Analyser::new();
+        let r = a.analyse("dict bogus a b\n", "tcl");
+        assert!(
+            r.diagnostics.iter().any(|d| d.code == DiagCode::W001),
+            "got {:?}",
+            r.diagnostics
+        );
     }
 
     // -- E004 malformed-if emitter

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -437,6 +437,24 @@ mod diagnostics {
     }
 
     #[test]
+    fn proc_shadowing_ensemble_command_suppresses_w001() {
+        // tclsh8.6: `proc string {op args} {...}` completely replaces the
+        // builtin `string` ensemble at the call site — `string reverse x`
+        // dispatches to the user proc, not the registry subcommand set, so
+        // it must not be flagged "Unknown subcommand".  See FP-STY-17.
+        let src = "proc string {op args} { return $op }\nstring reverse x\n";
+        assert!(!fires(src, D, "W001"), "got {:?}", analyser_diags(src, D));
+    }
+
+    #[test]
+    fn ensemble_shadowing_does_not_hide_a_genuinely_unknown_subcommand() {
+        // The proc-shadow suppression above is scoped to `string` only — a
+        // different, unshadowed ensemble in the same file still fires.
+        let src = "proc string {op args} { return $op }\ninfo bogus\n";
+        assert!(fires(src, D, "W001"), "got {:?}", analyser_diags(src, D));
+    }
+
+    #[test]
     fn error_diagnostics_have_a_span() {
         // The error anchors at the start of the script. The diagnostic carries
         // a byte `span`; assert it starts at offset 0 (the `set` token).

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -592,6 +592,62 @@ fn disabled_subcommand_form_shadowed_by_ensemble_head_proc_is_clean() {
 }
 
 #[test]
+fn w001_span_covers_only_the_subcommand_word() {
+    // The squiggle must sit tightly on the offending word alone — not the
+    // command name too. `string bogus $x`: "string " is 7 characters, so
+    // "bogus" spans [7, 12).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "string bogus $x\n");
+    let w001: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("W001"))
+        .collect();
+    assert_eq!(w001.len(), 1, "expected exactly one W001: {diags:?}");
+    let range = &w001[0]["range"];
+    assert_eq!(range["start"]["line"], 0);
+    assert_eq!(
+        range["start"]["character"], 7,
+        "span must start at 'bogus', not 'string'"
+    );
+    assert_eq!(range["end"]["line"], 0);
+    assert_eq!(
+        range["end"]["character"], 12,
+        "span must cover only 'bogus'"
+    );
+}
+
+#[test]
+fn proc_shadowing_ensemble_command_suppresses_w001() {
+    // FP regression (FP-STY-17): a same-file `proc string {...}` replaces
+    // the builtin `string` ensemble at the call site, end to end.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc string {op args} { return $op }\nstring reverse hello\n",
+    );
+    assert!(
+        !has_code(&diags, "W001"),
+        "proc-shadowed ensemble call must not fire W001: {diags:?}"
+    );
+}
+
+#[test]
+fn unshadowed_ensemble_command_still_fires_w001_alongside_a_shadowed_one() {
+    // TP control paired with the FP above: shadowing `string` must not
+    // blind the server to a genuine unknown subcommand on a different
+    // ensemble in the same file.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "proc string {op args} { return $op }\ninfo bogus\n");
+    assert!(
+        has_code(&diags, "W001"),
+        "unshadowed ensemble must still fire W001: {diags:?}"
+    );
+}
+
+#[test]
 fn bare_tcloo_object_dispatch_is_e001() {
     // `set o [Dog new]; $o` — TclOO's per-object dispatcher requires a
     // method word before it attempts any method lookup.

--- a/rust/tcl-registry/src/commands/tk/grid.rs
+++ b/rust/tcl-registry/src/commands/tk/grid.rs
@@ -52,6 +52,14 @@ const SUBCOMMANDS: &[SubCommand] = &[
         ..SubCommand::DEFAULT
     },
     SubCommand {
+        name: "content",
+        arity: Arity::at_least(1),
+        detail: "Return a list of all slaves in the grid for the master (9.0+ name for `slaves`).",
+        synopsis: "grid content master ?-option value?",
+        dialects: Some(DialectSet::TCL90_PLUS),
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
         name: "forget",
         arity: Arity::at_least(1),
         detail: "Remove each slave from the grid for its master.",

--- a/rust/tcl-registry/src/commands/tk/pack.rs
+++ b/rust/tcl-registry/src/commands/tk/pack.rs
@@ -30,6 +30,14 @@ const SUBCOMMANDS: &[SubCommand] = &[
         ..SubCommand::DEFAULT
     },
     SubCommand {
+        name: "content",
+        arity: Arity::exact(1),
+        detail: "Return a list of all slaves in the packing order for the master (9.0+ name for `slaves`).",
+        synopsis: "pack content master",
+        dialects: Some(DialectSet::TCL90_PLUS),
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
         name: "forget",
         arity: Arity::at_least(1),
         detail: "Remove each slave from the packing order for its master.",

--- a/rust/tcl-registry/src/commands/tk/place.rs
+++ b/rust/tcl-registry/src/commands/tk/place.rs
@@ -30,6 +30,14 @@ const SUBCOMMANDS: &[SubCommand] = &[
         ..SubCommand::DEFAULT
     },
     SubCommand {
+        name: "content",
+        arity: Arity::exact(1),
+        detail: "Return a list of all slaves managed by the placer for the window (9.0+ name for `slaves`).",
+        synopsis: "place content window",
+        dialects: Some(DialectSet::TCL90_PLUS),
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
         name: "forget",
         arity: Arity::exact(1),
         detail: "Cause the placer to stop managing the geometry of the window.",

--- a/rust/tcl-registry/src/commands/tk/wm.rs
+++ b/rust/tcl-registry/src/commands/tk/wm.rs
@@ -126,6 +126,14 @@ const SUBCOMMANDS: &[SubCommand] = &[
         ..SubCommand::DEFAULT
     },
     SubCommand {
+        name: "iconbadge",
+        arity: Arity::exact(2),
+        detail: "Set a badge (a short overlay label) on the window's taskbar/dock icon.",
+        synopsis: "wm iconbadge window badge",
+        dialects: Some(DialectSet::TCL90_PLUS),
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
         name: "iconbitmap",
         arity: Arity::new(1, 2),
         detail: "Set or query the bitmap for when the window is iconified.",


### PR DESCRIPTION
## Summary

Deep correctness/precision review of **W001** ("unknown subcommand"), covering the analyser logic, registry data, and highlighting precision.

- **Same-file shadow suppression (false positive).** `emit_w001_unknown_subcommand` used to push its verdict straight into `result.diagnostics`, bypassing the post-walk shadow-check the sibling E002/E003 arity check already gets. A `proc string {...}` / `oo::class create string {...}` / `interp alias {} info {} myInfo` / `namespace ensemble create -command NAME` / inline `# tcl-lsp: stub` that redefines a registry ensemble command completely replaces it at the call site (Tcl always resolves the user definition first), so calls through the shadowed name drew a spurious "Unknown subcommand". Fixed by deferring W001 (and its subcommand-level W002 sibling) through the same `pending_arity`-style queue and shadow computation (`non_proc_qnames` / `proc_offsets` / `stub_names`) in `flush_arity_diagnostics`, including the same top-level-call order-sensitivity gate. See FP-STY-17.
- **`{*}`-expanded subcommand position (false positive).** `cmd {*}{subcmd args…}` splices the word's *elements*, not its literal text, into the argument list — `dict {*}{create a b}` is a genuine `dict create a b` call, but the raw source text `"create a b"` was being compared against the subcommand set as one bogus name. Now skipped via the same `arg_expand` guard the subcommand-arity check already had. See FP-STY-18.
- **Highlighting precision.** The diagnostic span covered `cmd subname` (e.g. `string bogus`); the KCS doc already documented "a squiggle appears under the *subcommand token*" and the "did you mean" quick-fix already targeted the subcommand only, so the wider squiggle disagreed with both the fix and the docs. Tightened to the subcommand token's content range, matching W127's sibling convention.
- **Registry data gaps (false positive, not compiler logic).** `wm iconbadge` and the Tk 9.0 canonical `grid`/`pack`/`place content` subcommand (the 9.0 rename of `slaves`) were entirely missing from the registry, so genuine Tk 9.0 API calls were reported as unknown. Added, dialect-gated `TCL90_PLUS` (matching `info cmdtype`'s existing gate). See FP-STY-19.
- Reviewed and confirmed clean (no bug, no fix needed): TclOO/snit/itcl method dispatch never routes through W001 (structurally guaranteed — a `$obj method` head can never match a registry key); safe/sub-interpreters and `trace add execution` have no special-casing and none is needed; `namespace ensemble create -map` custom subcommand maps are a known, low-priority, pre-existing false-negative gap (not chased this round, per the review's explicit prioritisation).

All command-level data changes went into the `tcl-registry` `CommandSpec`/`SubCommand` tables, per the project's registry-is-the-source-of-truth rule — no per-command names were added to the compiler/analyser. No new `#[allow(...)]`/`#[expect(...)]` clippy suppressions were added.

## Validation

- `cargo test -p tcl-compiler` (lib + all 49 integration test binaries) — 0 failures
- `cargo test -p tcl-registry` — 0 failures
- `cargo test -p tcl-lsp-server --test e2e` (633 tests) — 0 failures
- `make test-rust` (full Cargo workspace, all ~37 crates) — 0 failures
- `make rust-check` / `make check-all` — clean
- VS Code extension: new precision-regression tests pass; verified against a clean baseline build that the ~31 unrelated failures in that suite (semantic tokens, server health, unicode positions, variable completion) are pre-existing environment flakiness, not caused by this change
- `make gen-editor-settings` run and the regenerated Zed command catalog committed alongside the registry data change

New tests added: `fp_sty_17_*` / `fp_sty_18_*` / `fp_sty_19_*` (`rust/tcl-compiler/src/analyser/diagnostics/fp/sty.rs`, paired with new `docs/design/compiler/FP.md` catalogue entries), analyser-level unit tests (`state.rs`, `diagnostics/tests.rs`), integration tests (`tests/analyser.rs`), lsp_e2e tests (`rust/tcl-lsp-server/tests/e2e/diagnostics.rs`), and VS Code extension precision-regression tests + fixtures (`precisionFalsePositives.test.ts`, `testFixture/ensembleShadowing.tcl`, `testFixture/expandedSubcommand.tcl`).

## Compiler/KCS checklist

- [x] Did this change alter a compiler fact contract? No diagnostic code, severity, or message format changed — only span precision and false-positive suppression.
- [x] Updated `docs/kcs/codes/kcs-diagnostic-w001-unknown-subcommand.md` with the shadow-suppression behaviour.
- [x] No new KCS note was needed (existing W001 note covers this).


---
_Generated by [Claude Code](https://claude.ai/code/session_016RfGbHXqv7WCZn6h11gy2s)_