### PR TITLE
S100: numeric-comparison quick fix, 'my variable' scope-alias fix

### DIFF
--- a/docs/design/compiler/constant-folding-type-inference.md
+++ b/docs/design/compiler/constant-folding-type-inference.md
@@ -58,6 +58,20 @@ bytecode-level shortcut.
 - **Variable traces**: tclsh does not fold through variables (observable side
   effects), so our bytecode matches the non-folded output
 
+Type inference applies a related but distinct widening for traced names: a
+`trace add variable ... write` callback runs synchronously inside the `set`
+that triggers it and can rewrite the value (and hence intrep) to anything,
+so every SSA def of a module-traced name is widened to `OVERDEFINED`
+regardless of statement kind (`AssignConst`/`AssignValue`/`Incr`/`Call`
+alike) — see `propagate_types` in `rust/tcl-compiler/src/type_infer.rs`,
+fed by `scan_module_variable_traces` in
+`rust/tcl-compiler/src/var_observability.rs`. This is deliberately narrower
+than SCCP's `global`/`upvar`/`namespace` escaping set: mere globalness
+doesn't retroactively invalidate a fresh local `set` for *type* purposes
+the way it does for cross-call *constant-value* folding, so widening on
+that broader set would silence shimmer detection for the common
+global-variable case without a matching soundness need.
+
 ### Type inference lattice
 
 ```
@@ -86,6 +100,14 @@ the type lattice records `SHIMMERED(from_type, to_type)`.  This triggers:
 - S100: Value accessed as incompatible type
 - S101: Implicit shimmer
 - S102: Cross-command type conflict
+
+Shimmer/thunking/byte-array analysis runs per body unit — every `proc`,
+every TclOO method, and every synthetic unit (`apply` lambda,
+`namespace eval` block) gets its own CFG/SSA and type-inference pass; a
+unit not reachable from the "top-level procs only" enumeration silently
+gets no shimmer analysis at all, which is why new call-site shapes should
+be checked against `all_body_function_units()` rather than a
+procs-only iterator.
 
 ### Interaction with optimisation passes
 

--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -300,6 +300,50 @@ suite("Code Actions", () => {
     assert.ok(removeFix.edit, "the quick fix should carry a workspace edit");
   });
 
+  // S101 deep-review quick fix: a numeric var compared via `eq` against a
+  // numeric literal offers a mechanical `==` rewrite.
+  test("provides numeric comparison quick fix for S100 (eq on numeric operands)", async () => {
+    const shimmerUri = getDocUri("shimmer-s101.tcl");
+    await activate(shimmerUri);
+    const diagnostics = await waitForDiagnostics(shimmerUri, {
+      predicate: (diags) =>
+        diags.some((d) => (typeof d.code === "object" ? d.code.value : d.code) === "S100"),
+    });
+    const s100 = diagnostics.find((d) => {
+      const code = typeof d.code === "object" ? d.code.value : d.code;
+      return code === "S100";
+    });
+    assert.ok(s100, "S100 diagnostic should be present");
+
+    const actions = (await pollUntil(
+      () =>
+        vscode.commands.executeCommand(
+          "vscode.executeCodeActionProvider",
+          shimmerUri,
+          s100.range,
+        ),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => typeof a.title === "string" && a.title.includes("numeric comparison"),
+        ),
+      { timeout: 10_000, label: "S100 numeric comparison quick fix" },
+    )) as vscode.CodeAction[];
+
+    const quickFix = actions.find(
+      (a) => typeof a.title === "string" && a.title.includes("numeric comparison"),
+    );
+    assert.ok(quickFix, "Should provide a numeric comparison quick fix");
+
+    const edit = quickFix.edit;
+    assert.ok(edit, "quick fix should carry a workspace edit");
+    const edits = edit.get(shimmerUri);
+    assert.ok(
+      edits.some((e) => e.newText === "=="),
+      `expected a newText of '==', got ${JSON.stringify(edits.map((e) => e.newText))}`,
+    );
+  });
+
   test("provides guided collect bootstrap fix for IRULE1005", async () => {
     await activate(irulesDocUri);
     // IRULE1005 is a deep diagnostic — it fires after the initial basic

--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -317,11 +317,7 @@ suite("Code Actions", () => {
 
     const actions = (await pollUntil(
       () =>
-        vscode.commands.executeCommand(
-          "vscode.executeCodeActionProvider",
-          shimmerUri,
-          s100.range,
-        ),
+        vscode.commands.executeCommand("vscode.executeCodeActionProvider", shimmerUri, s100.range),
       (r) =>
         Array.isArray(r) &&
         (r as vscode.CodeAction[]).some(

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -494,9 +494,7 @@ suite("Diagnostics", () => {
     });
     assert.ok(
       !diagnostics.some(
-        (d) =>
-          (codeOf(d) === "S100" || codeOf(d) === "S101") &&
-          /'count'/.test(d.message),
+        (d) => (codeOf(d) === "S100" || codeOf(d) === "S101") && /'count'/.test(d.message),
       ),
       `'my variable'-linked instance var must not spuriously shimmer: ${diagnostics
         .filter((d) => codeOf(d) === "S100" || codeOf(d) === "S101")

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -415,6 +415,95 @@ suite("Diagnostics", () => {
     );
   });
 
+  // S101 deep-review: a true-positive per-iteration shimmer in a plain proc,
+  // the same shape inside a TclOO method body (methods previously fell
+  // through a fresh-rebuild-only fix — see tcl-lsp-db's `proc_taint_solve`),
+  // and a guarded false positive via `my variable` (an object-instance
+  // variable's real intrep depends on another method's last write, not the
+  // nominal return type of `my`).
+  test("S101 fires for a per-iteration shimmer inside a plain proc and a TclOO method", async () => {
+    const uri = getDocUri("shimmer-s101.tcl");
+    await activate(uri);
+    const codeOf = (d: vscode.Diagnostic) => (typeof d.code === "object" ? d.code.value : d.code);
+    const diagnostics = await waitForDiagnostics(uri, {
+      predicate: (diags) => diags.filter((d) => codeOf(d) === "S101").length >= 2,
+    });
+    const s101 = diagnostics.filter((d) => codeOf(d) === "S101");
+    assert.strictEqual(
+      s101.length,
+      2,
+      `expected exactly two S101s (plain proc + TclOO method), got [${diagnostics.map(codeOf)}]`,
+    );
+    for (const d of s101) {
+      assert.strictEqual(d.severity, vscode.DiagnosticSeverity.Warning, "S101 should be a warning");
+      assert.ok(
+        /lindex.*expects list/.test(d.message),
+        `S101 message should name the shimmering command, got: ${d.message}`,
+      );
+    }
+    // `shimmerLoop`'s `set y [lindex $x 0]`, 0-indexed line 11.
+    assert.ok(
+      s101.some((d) => d.range.start.line === 11),
+      `expected an S101 anchored to the plain-proc loop (line 11), got ${JSON.stringify(s101.map((d) => d.range.start))}`,
+    );
+    // `Counter::scan`'s `set y [lindex $x 0]`, 0-indexed line 35. Tight
+    // highlighting: TclOO method bodies reach the live diagnostics path
+    // through the fresh (non-memoised) fallback, which carries real source
+    // text, so the span narrows to exactly the `$x` argument rather than
+    // the whole `set y [lindex $x 0]` statement — see
+    // `nested_call_arg_spans` in `tcl-compiler`'s shimmer use-site pass.
+    const methodShimmer = s101.find((d) => d.range.start.line === 35);
+    assert.ok(
+      methodShimmer,
+      `expected an S101 anchored to the TclOO method loop (line 35), got ${JSON.stringify(s101.map((d) => d.range.start))}`,
+    );
+    assert.strictEqual(methodShimmer.range.start.character, 26);
+    assert.strictEqual(methodShimmer.range.end.character, 28);
+  });
+
+  test("S100 fires for a numeric var in a string comparison and offers a fix hint", async () => {
+    const uri = getDocUri("shimmer-s101.tcl");
+    await activate(uri);
+    const codeOf = (d: vscode.Diagnostic) => (typeof d.code === "object" ? d.code.value : d.code);
+    const diagnostics = await waitForDiagnostics(uri, {
+      predicate: (diags) => diags.some((d) => codeOf(d) === "S100"),
+    });
+    const s100 = diagnostics.find((d) => codeOf(d) === "S100");
+    assert.ok(s100, `expected an S100, got [${diagnostics.map(codeOf)}]`);
+    assert.strictEqual(
+      s100.severity,
+      vscode.DiagnosticSeverity.Information,
+      "S100 should be information severity",
+    );
+    assert.ok(
+      s100.message.includes("=="),
+      `S100 message should suggest the numeric '==' rewrite, got: ${s100.message}`,
+    );
+    // `numericEqShimmer`'s `set z [expr {$n eq 42}]`, 0-indexed line 17.
+    assert.strictEqual(s100.range.start.line, 17);
+  });
+
+  test("S100/S101 silent for a TclOO instance variable linked via `my variable`", async () => {
+    const uri = getDocUri("shimmer-s101.tcl");
+    await activate(uri);
+    // Settle on the loop shimmers firing first (the fixture always produces
+    // them), then assert the `my variable`-linked `count` never shimmers.
+    const codeOf = (d: vscode.Diagnostic) => (typeof d.code === "object" ? d.code.value : d.code);
+    const diagnostics = await waitForDiagnostics(uri, {
+      predicate: (diags) => diags.filter((d) => codeOf(d) === "S101").length >= 2,
+    });
+    assert.ok(
+      !diagnostics.some(
+        (d) =>
+          (codeOf(d) === "S100" || codeOf(d) === "S101") &&
+          /'count'/.test(d.message),
+      ),
+      `'my variable'-linked instance var must not spuriously shimmer: ${diagnostics
+        .filter((d) => codeOf(d) === "S100" || codeOf(d) === "S101")
+        .map((d) => d.message)}`,
+    );
+  });
+
   // Issue #777: object commands bound by `CLASS create NAME` and iterated via
   // `foreach elem [list c1 l1 …]` are known commands, so dispatching `$elem`
   // must not fire W307. Analysis has settled once the unknown-class commands

--- a/editors/vscode/testFixture/shimmer-s101.tcl
+++ b/editors/vscode/testFixture/shimmer-s101.tcl
@@ -1,0 +1,39 @@
+# Fixture for the S101 (shimmer inside loop) deep-review VS Code extension
+# tests. Covers: a true-positive per-iteration shimmer in a plain proc, the
+# same shape inside a TclOO method body (methods previously fell through a
+# fresh-rebuild-only fix — see tcl-lsp-db's proc_taint_solve), a guarded
+# false positive via `my variable` (an object-instance variable's real
+# intrep depends on another method's last write, not the nominal return
+# type of `my`), and a numeric eq/ne quick fix (S100) on a sibling shimmer
+# check that landed in the same review.
+
+proc shimmerLoop {items} {
+    foreach x $items {
+        set y [lindex $x 0]
+    }
+}
+
+proc numericEqShimmer {} {
+    set n 42
+    set z [expr {$n eq 42}]
+    return $z
+}
+
+oo::class create Counter {
+    variable count
+
+    constructor {} {
+        set count 0
+    }
+
+    method bump {} {
+        my variable count
+        incr count
+    }
+
+    method scan {items} {
+        foreach x $items {
+            set y [lindex $x 0]
+        }
+    }
+}

--- a/editors/zed/src/generated/tcl_commands.json
+++ b/editors/zed/src/generated/tcl_commands.json
@@ -5914,7 +5914,10 @@
     },
     {
       "name": "my",
-      "summary": "invoke a method on the current object"
+      "summary": "invoke a method on the current object",
+      "subcommands": [
+        "variable"
+      ]
     },
     {
       "name": "nameserv::bind",

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -372,7 +372,7 @@ impl FunctionUnit {
             params.iter().map(String::as_str).collect();
         sccp.constant_branches
             .extend(crate::sccp::existence_constant_branches(&cfg, &param_set));
-        let types = propagate_types(&cfg, &ssa, &sccp, registry, known_classes);
+        let types = propagate_types(&cfg, &ssa, &sccp, registry, known_classes, module_traces);
         let return_type = crate::type_infer::infer_function_return_type(
             &cfg,
             &sccp,

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -284,10 +284,15 @@ pub fn run_all_checks_with_solved_and_patterns(
     // memoise it per procedure on the offset-0 `FnLatticeKey` (SRV-INCREMENTAL
     // 2a): an unedited procedure's checks are a cache hit instead of recomputed
     // over the whole unit every edit.
+    //
     // Walks `cu.analysable_body_function_units()` (top-level + procedures +
     // TclOO/snit methods + synthetic `apply`/`namespace eval` body units,
-    // complexity-guarded bodies excluded) — see that method's doc comment
-    // for why this reaches further than `cu.analysable_functions()`.
+    // complexity-guarded bodies excluded), not `cu.analysable_functions()` —
+    // the latter deliberately excludes methods and body units for unrelated
+    // historical reasons (see its doc comment) and doing so here silently
+    // dropped every one of these diagnostic families from inside a method or
+    // lambda body, even though `cu.methods`/`cu.body_units` are built
+    // through the identical CFG/SSA/SCCP/type pipeline as `cu.procedures`.
     for fu in cu.analysable_body_function_units() {
         // `cu.source` is safe to pass whole here (not just this function's own
         // slice): every unit `analysable_body_function_units()` yields from a

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -39,8 +39,8 @@ use crate::irules_checks::{
 use crate::path_concat::{PathConcatWarning, find_path_concat_warnings};
 use crate::sccp::ConstantBranch;
 use crate::shimmer::{
-    ShimmerWarning, ThunkingWarning, find_byte_array_warnings, find_shimmer_warnings,
-    find_thunking_warnings,
+    ShimmerInputs, ShimmerWarning, ThunkingWarning, find_byte_array_warnings,
+    find_shimmer_warnings, find_thunking_warnings,
 };
 use crate::taint::{
     TaintWarning, find_destructive_file_warnings, find_setter_constraint_warnings,
@@ -82,6 +82,13 @@ pub struct Diagnostic {
     /// check has no such fix. Consumers emit one `TextEdit` per fix at its own
     /// `span`.
     pub fixes: Vec<CodeFix>,
+    /// Secondary spans with a human-readable label giving context for the
+    /// primary diagnostic (e.g. shimmer's "value defined here" pointing at
+    /// the def site of the variable whose intrep is being flagged). Empty
+    /// when the check has no useful related context. Consumers lower this to
+    /// their native "related information" concept (LSP
+    /// `DiagnosticRelatedInformation`).
+    pub related: Vec<(Span, String)>,
 }
 
 impl Diagnostic {
@@ -100,6 +107,7 @@ impl Diagnostic {
             ),
             replacement: None,
             fixes: Vec::new(),
+            related: Vec::new(),
         }
     }
 
@@ -117,7 +125,8 @@ impl Diagnostic {
             },
             message: w.message.clone(),
             replacement: None,
-            fixes: Vec::new(),
+            fixes: w.fixes.clone(),
+            related: w.related.clone(),
         }
     }
 
@@ -130,6 +139,7 @@ impl Diagnostic {
             message: w.message.clone(),
             replacement: None,
             fixes: Vec::new(),
+            related: w.related.clone(),
         }
     }
 
@@ -147,6 +157,7 @@ impl Diagnostic {
             message: w.message.clone(),
             replacement: w.replacement.clone(),
             fixes: Vec::new(),
+            related: Vec::new(),
         }
     }
 
@@ -166,6 +177,7 @@ impl Diagnostic {
             message: w.message.clone(),
             replacement: w.replacement.clone(),
             fixes: w.fixes.clone(),
+            related: Vec::new(),
         }
     }
 
@@ -178,6 +190,7 @@ impl Diagnostic {
             message: r.message.clone(),
             replacement: None,
             fixes: Vec::new(),
+            related: Vec::new(),
         }
     }
 
@@ -194,6 +207,7 @@ impl Diagnostic {
             message: w.message.clone(),
             replacement: w.replacement.clone(),
             fixes: Vec::new(),
+            related: Vec::new(),
         }
     }
 }
@@ -270,8 +284,20 @@ pub fn run_all_checks_with_solved_and_patterns(
     // memoise it per procedure on the offset-0 `FnLatticeKey` (SRV-INCREMENTAL
     // 2a): an unedited procedure's checks are a cache hit instead of recomputed
     // over the whole unit every edit.
+    // Walks `cu.analysable_body_function_units()` (top-level + procedures +
+    // TclOO/snit methods + synthetic `apply`/`namespace eval` body units,
+    // complexity-guarded bodies excluded) — see that method's doc comment
+    // for why this reaches further than `cu.analysable_functions()`.
     for fu in cu.analysable_body_function_units() {
-        for d in function_nontaint_checks(fu, registry, dialect) {
+        // `cu.source` is safe to pass whole here (not just this function's own
+        // slice): every unit `analysable_body_function_units()` yields from a
+        // plain `CompilationUnit::build` (as opposed to the LSP db's offset-0
+        // memoised `function_lattice`/`function_checks` salsa query — see
+        // `function_nontaint_checks`'s doc comment) carries spans already
+        // absolute against `cu.source` (`base_offset == 0`), so
+        // `find_operator_fix`'s `source[stmt_span...]` slice lands on the
+        // right text without any per-function rebasing.
+        for d in function_nontaint_checks(fu, registry, dialect, &cu.source) {
             out.push(shift(fu, d));
         }
     }
@@ -297,11 +323,30 @@ pub fn run_all_checks_with_solved_and_patterns(
 /// keyed on the offset-0 `FnLatticeKey` (SRV-INCREMENTAL 2a) — an unedited
 /// procedure's checks are a cache hit.  The S110 `*::payload` byte-command set is
 /// dialect-gated (empty outside iRules).
+///
+/// `source` feeds two source-derived shimmer refinements: the expr pass's
+/// eq/ne/lt/le/gt/ge quick fix (see `shimmer::expr::find_operator_fix`) and
+/// the use-site pass's tight per-argument span for a `[cmd …]` substitution
+/// embedded in a `set`/`AssignValue` (see
+/// `shimmer::use_site::nested_call_arg_spans`) — both need to locate exact
+/// text within the statement's own source span. `source` must therefore be
+/// **absolute against `fu`'s own spans** — correct when called on a
+/// freshly-built (non-memoised) `FunctionUnit` (`base_offset == 0`; every
+/// `run_all_checks*` caller here passes `&cu.source` for exactly this
+/// reason), but the LSP db's offset-0 memoised
+/// `function_lattice`/`function_checks` salsa query passes `""` instead
+/// (its `fu` spans are relative to the procedure's own offset-0 body, not
+/// `source` — using a real string there would silently slice the wrong text).
+/// An empty string safely yields no fix and no tight span (both callees
+/// bounds-check and fall back to a wider default), never a wrong one — only
+/// the diagnostic messages themselves are unaffected either way, since they
+/// need no source access.
 #[must_use]
 pub fn function_nontaint_checks(
     fu: &FunctionUnit,
     registry: &CommandRegistry,
     dialect: Option<&str>,
+    source: &str,
 ) -> Vec<Diagnostic> {
     let mut out: Vec<Diagnostic> = Vec::new();
     for cb in &fu.sccp.constant_branches {
@@ -316,14 +361,30 @@ pub fn function_nontaint_checks(
     for r in find_loop_invariants(registry, &fu.cfg, &fu.ssa, dialect) {
         out.push(Diagnostic::from_redundant(&r));
     }
-    for w in find_shimmer_warnings(
-        &fu.cfg,
-        &fu.ssa,
-        &fu.types,
-        &fu.sccp.executable_blocks,
+    // `ModuleCommandMutations::default()` ("trusts everything") rather than a
+    // real module-wide scan: this function is memoised per procedure by the
+    // LSP db's salsa `FnLatticeKey` query (see this function's doc comment),
+    // keyed only on this procedure's own offset-0 body, so a real scan result
+    // computed from the whole module would go stale the moment a *different*
+    // procedure's `rename`/`interp alias` changed without also touching this
+    // one. Threading a real, cache-key-aware scan through here needs the same
+    // `#[salsa::interned]` treatment `ModuleVariableTraces` already received
+    // for `CfgContext` (see `tcl-lsp-db`) — a follow-up, not yet done. Until
+    // then this path keeps today's behaviour (every literal command name is
+    // trusted); [`find_shimmer_warnings_for_cu`] (the compiler-explorer / MCP
+    // / CLI whole-unit entry point, which rebuilds fresh every call and has
+    // no incremental cache to go stale) already computes and uses the real
+    // module-wide facts.
+    for w in find_shimmer_warnings(&ShimmerInputs {
+        cfg: &fu.cfg,
+        ssa: &fu.ssa,
+        types: &fu.types,
+        executable_blocks: &fu.sccp.executable_blocks,
         registry,
-        &fu.sccp.values,
-    ) {
+        values: &fu.sccp.values,
+        mutations: &crate::command_binding::ModuleCommandMutations::default(),
+        source,
+    }) {
         out.push(Diagnostic::from_shimmer(&w));
     }
     for w in find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks) {

--- a/rust/tcl-compiler/src/shimmer/byte_array.rs
+++ b/rust/tcl-compiler/src/shimmer/byte_array.rs
@@ -267,6 +267,7 @@ fn byte_warning(
         code: DiagCode::S110,
         message,
         related,
+        fixes: Vec::new(),
     }
 }
 

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -41,6 +41,7 @@ use tcl_registry::TclType;
 use crate::cfg::{BlockId, Function as CfgFunction, Terminator};
 use crate::expr_ast::{BinOp, ExprNode};
 use crate::ir::Statement;
+use crate::irules_checks::CodeFix;
 use crate::naming::normalise_var_name;
 use crate::sccp::cfg_order;
 use crate::ssa::{SsaFunction, Symbol, ValueKey};
@@ -58,12 +59,18 @@ use super::{ShimmerWarning, type_name};
 ///    `if`/`while`/`for` construct.  Variable versions are resolved from
 ///    the block's `exit_versions` map (the versions live at the end of
 ///    the block, which is when the condition is evaluated).
+///
+/// `source` is the whole compilation unit's source text — used only to build
+/// the eq/ne/lt/le/gt/ge → ==/!=/</<=/>/>= quick fix (see
+/// [`find_operator_fix`]); every span computed elsewhere in this pass is
+/// already absolute and needs no source access.
 #[must_use]
 pub(crate) fn find_expr_shimmers(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
     types: &HashMap<ValueKey, TypeLattice>,
     executable_blocks: &HashSet<BlockId>,
+    source: &str,
 ) -> Vec<ShimmerWarning> {
     let mut out = Vec::new();
     let loop_blocks = loop_body_blocks(cfg);
@@ -93,6 +100,7 @@ pub(crate) fn find_expr_shimmers(
                         types,
                         ssa,
                         stmt_span: *span,
+                        source,
                         in_loop,
                         seen: &mut seen,
                         out: &mut out,
@@ -117,6 +125,7 @@ pub(crate) fn find_expr_shimmers(
                 types,
                 ssa,
                 stmt_span: branch_span,
+                source,
                 in_loop,
                 seen: &mut seen,
                 out: &mut out,
@@ -130,7 +139,7 @@ pub(crate) fn find_expr_shimmers(
 
 /// Read-only context + warning sinks threaded through one expr walk.
 ///
-/// `uses` / `stmt_span` / `in_loop` are constant for a single
+/// `uses` / `stmt_span` / `source` / `in_loop` are constant for a single
 /// `collect_expr_shimmers` recursion (they describe the statement whose expr
 /// is being walked); `seen` / `out` accumulate de-duplicated warnings.
 struct ExprShimmerCtx<'a> {
@@ -138,6 +147,7 @@ struct ExprShimmerCtx<'a> {
     types: &'a HashMap<ValueKey, TypeLattice>,
     ssa: &'a SsaFunction,
     stmt_span: Span,
+    source: &'a str,
     in_loop: bool,
     seen: &'a mut HashSet<(Span, String)>,
     out: &'a mut Vec<ShimmerWarning>,
@@ -190,14 +200,28 @@ fn collect_expr_shimmers(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode) {
                 }
 
                 // String comparison operators: operands should be String.
+                // When *both* sides are provably numeric-safe (a numeric
+                // literal, or a variable whose tracked type is numeric), the
+                // rewrite to the operator's numeric equivalent
+                // (eq→==, ne→!=, lt→<, le→<=, gt→>, ge→>=) is
+                // semantics-preserving — Tcl's numeric comparison agrees with
+                // the string comparison whenever both operands are numbers —
+                // so a `CodeFix` is attached; otherwise only the (unfixable)
+                // warning fires (e.g. `$n eq "abc"` — rewriting to `==` would
+                // change a well-defined "always false" string compare into a
+                // runtime "non-numeric string" error).
                 BinOp::StrEq
                 | BinOp::StrNe
                 | BinOp::StrLt
                 | BinOp::StrLe
                 | BinOp::StrGt
                 | BinOp::StrGe => {
-                    check_string_operand(ctx, left, *op);
-                    check_string_operand(ctx, right, *op);
+                    let fix = (operand_looks_numeric(left, ctx.uses, ctx.types, ctx.ssa)
+                        && operand_looks_numeric(right, ctx.uses, ctx.types, ctx.ssa))
+                    .then(|| find_operator_fix(ctx.source, ctx.stmt_span, *op))
+                    .flatten();
+                    check_string_operand(ctx, left, *op, fix.clone());
+                    check_string_operand(ctx, right, *op, fix);
                 }
 
                 _ => {}
@@ -312,8 +336,17 @@ fn check_numeric_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinO
     let Some(current) = lattice.tcl_type else {
         return;
     };
-    // Only flag clearly non-numeric types (String, List, Dict).
-    if matches!(current, TclType::String | TclType::List | TclType::Dict) {
+    // Only flag clearly non-numeric types (String, List, Dict, ByteArray). A
+    // byte array in an arithmetic context is a textbook C Tcl shimmer: Tcl
+    // has no numeric intrep of its own, so `Tcl_GetNumberFromObj` falls back
+    // to parsing the byte array's *string* rep (each byte relabelled as a
+    // Latin-1 code point) as a number and, on success, replaces the cached
+    // byte-array intrep with Int/Double — exactly the same in-place intrep
+    // clobber as the String/List/Dict cases, just via the byte-array route.
+    if matches!(
+        current,
+        TclType::String | TclType::List | TclType::Dict | TclType::ByteArray
+    ) {
         // De-duplicate per (statement span, variable) within the block.
         if !ctx.seen.insert((ctx.stmt_span, base.to_owned())) {
             return;
@@ -338,13 +371,24 @@ fn check_numeric_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinO
                 from = type_name(current),
             ),
             related: Vec::new(),
+            fixes: Vec::new(),
         });
     }
 }
 
 /// Emit a shimmer if `node` is a numeric variable used in a string
 /// comparison.  S101 inside a loop body, S100 outside one.
-fn check_string_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp) {
+///
+/// `fix` — precomputed once per `Binary` node by the caller (identical for
+/// both operands, since it targets the shared operator token) — is attached
+/// only when the rewrite is provably safe; see the `BinOp::StrEq | …` match
+/// arm's doc comment in [`collect_expr_shimmers`].
+fn check_string_operand(
+    ctx: &mut ExprShimmerCtx<'_>,
+    node: &ExprNode,
+    op: BinOp,
+    fix: Option<CodeFix>,
+) {
     let ExprNode::Var { name, .. } = node else {
         return;
     };
@@ -383,6 +427,15 @@ fn check_string_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp
         } else {
             DiagCode::S100
         };
+        let numeric_op = numeric_equivalent(op);
+        let hint = if fix.is_some() {
+            format!("; use '{numeric_op}' instead — both operands are numeric")
+        } else {
+            format!(
+                "; if a numeric comparison was intended, use '{numeric_op}' \
+                 instead (only safe when the other operand is provably numeric too)"
+            )
+        };
         ctx.out.push(ShimmerWarning {
             span: ctx.stmt_span,
             variable: base.to_owned(),
@@ -392,12 +445,84 @@ fn check_string_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp
             in_loop: ctx.in_loop,
             code,
             message: format!(
-                "{code}: numeric variable '{base}' used in string comparison (op {op:?}); \
-                 consider using == or != instead"
+                "{code}: numeric variable '{base}' used in string comparison (op {op:?}){hint}"
             ),
             related: Vec::new(),
+            fixes: fix.into_iter().collect(),
         });
     }
+}
+
+/// The numeric-comparison equivalent of a string-comparison `BinOp` (the
+/// direction [`find_operator_fix`] rewrites towards). Panics on any other
+/// variant — only ever called with `BinOp::Str{Eq,Ne,Lt,Le,Gt,Ge}` from
+/// [`check_string_operand`]'s single call site.
+fn numeric_equivalent(op: BinOp) -> &'static str {
+    match op {
+        BinOp::StrEq => "==",
+        BinOp::StrNe => "!=",
+        BinOp::StrLt => "<",
+        BinOp::StrLe => "<=",
+        BinOp::StrGt => ">",
+        BinOp::StrGe => ">=",
+        _ => unreachable!("numeric_equivalent called with a non-string-comparison BinOp"),
+    }
+}
+
+/// Locate the source text of a `BinOp::Str{Eq,Ne,Lt,Le,Gt,Ge}` operator
+/// within `stmt_span`'s slice of `source` and build a [`CodeFix`] rewriting
+/// it to its numeric equivalent (`numeric_equivalent`).
+///
+/// The operator word (`eq`, `ne`, `lt`, `le`, `gt`, `ge`) must appear
+/// **exactly once**, as a standalone word (bounded by non-identifier
+/// characters), within the statement's source slice — `None` otherwise
+/// (source unavailable, operator not found, or more than one occurrence
+/// makes the target ambiguous — e.g. `$x eq $y && $z eq $w`, two `expr`
+/// operators in one statement no per-statement span can disambiguate; the
+/// warning still fires, only the mechanical fix is withheld). This is a
+/// deliberately conservative textual scan, not a re-parse — the same
+/// "narrow, well-documented approximation" pattern already used elsewhere in
+/// this codebase (e.g. `irules_checks::is_getter_form`) for fix-only, never
+/// diagnosis-affecting, text lookups.
+fn find_operator_fix(source: &str, stmt_span: Span, op: BinOp) -> Option<CodeFix> {
+    let word = match op {
+        BinOp::StrEq => "eq",
+        BinOp::StrNe => "ne",
+        BinOp::StrLt => "lt",
+        BinOp::StrLe => "le",
+        BinOp::StrGt => "gt",
+        BinOp::StrGe => "ge",
+        _ => return None,
+    };
+    let start = usize::try_from(stmt_span.start()).ok()?;
+    let end = usize::try_from(stmt_span.end()).ok()?;
+    let slice = source.get(start..end)?;
+
+    let is_word_char = |c: char| c.is_alphanumeric() || c == '_';
+    let mut matches = slice.match_indices(word).filter(|&(i, _)| {
+        let before_ok = slice[..i]
+            .chars()
+            .next_back()
+            .is_none_or(|c| !is_word_char(c));
+        let after_ok = slice[i + word.len()..]
+            .chars()
+            .next()
+            .is_none_or(|c| !is_word_char(c));
+        before_ok && after_ok
+    });
+    let (offset, _) = matches.next()?;
+    if matches.next().is_some() {
+        return None;
+    }
+
+    let abs_start = stmt_span.start() + u32::try_from(offset).ok()?;
+    let abs_end = abs_start + u32::try_from(word.len()).ok()?;
+    let numeric_op = numeric_equivalent(op);
+    Some(CodeFix {
+        span: Span::new(abs_start, abs_end),
+        new_text: numeric_op.to_owned(),
+        description: format!("Use numeric comparison '{numeric_op}' instead of '{word}'"),
+    })
 }
 
 #[cfg(test)]
@@ -415,8 +540,41 @@ mod tests {
     fn no_expr_shimmer_int_in_arithmetic() {
         let cu = CompilationUnit::build_for("set x 5\nset y [expr {$x + 1}]", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
         assert!(w.is_empty(), "unexpected expr shimmers: {w:?}");
+    }
+
+    /// A byte-array-typed variable used in arithmetic shimmers to Numeric —
+    /// the same in-place intrep clobber as String/List/Dict, reached via
+    /// `Tcl_GetNumberFromObj` falling back to the byte array's string rep.
+    #[test]
+    fn expr_shimmer_bytearray_in_arithmetic() {
+        let cu = CompilationUnit::build_for(
+            "set b [binary format c* {49 50}]\nset y [expr {$b + 1}]",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::top").unwrap();
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
+        let has_shimmer = w
+            .iter()
+            .any(|sw| sw.variable == "b" && sw.from_type == TclType::ByteArray);
+        assert!(
+            has_shimmer,
+            "expected bytearray-in-arithmetic shimmer, got: {w:?}"
+        );
     }
 
     /// A String variable used in arithmetic should produce S100.
@@ -428,7 +586,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "x" && sw.from_type == TclType::String);
@@ -449,7 +613,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
         assert!(
             w.iter().any(|sw| sw.variable == "s"),
             "string == numeric literal must shimmer: {w:?}"
@@ -461,7 +631,13 @@ mod tests {
             false,
         );
         let fu2 = cu2.function("::top").unwrap();
-        let w2 = find_expr_shimmers(&fu2.cfg, &fu2.ssa, &fu2.types, &fu2.sccp.executable_blocks);
+        let w2 = find_expr_shimmers(
+            &fu2.cfg,
+            &fu2.ssa,
+            &fu2.types,
+            &fu2.sccp.executable_blocks,
+            &cu2.source,
+        );
         assert!(
             !w2.iter().any(|sw| sw.variable == "s"),
             "string == string must not shimmer: {w2:?}"
@@ -474,7 +650,13 @@ mod tests {
         let cu =
             CompilationUnit::build_for("set x 42\nset z [expr {$x eq \"42\"}]", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "x" && sw.from_type == TclType::Int);
@@ -494,7 +676,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "x" && sw.from_type == TclType::Int);
@@ -514,7 +702,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
         let xs: Vec<_> = w.iter().filter(|sw| sw.variable == "x").collect();
         assert_eq!(
             xs.len(),
@@ -533,7 +727,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
         let s = w.iter().find(|sw| sw.variable == "x");
         assert!(s.is_some(), "expected expr shimmer for x in loop: {w:?}");
         let s = s.unwrap();
@@ -554,7 +754,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
         // x is String; used with eq (string comparison) — no shimmer.
         let str_cmp_shimmers: Vec<_> = w
             .iter()
@@ -563,6 +769,121 @@ mod tests {
         assert!(
             str_cmp_shimmers.is_empty(),
             "unexpected String-in-string-cmp shimmer: {str_cmp_shimmers:?}"
+        );
+    }
+
+    /// (TP) Both sides of `eq` are numeric (an Int var, an integer literal) —
+    /// the rewrite to `==` is semantics-preserving, so a `CodeFix` is
+    /// attached, targeting exactly the `eq` token's own span.
+    #[test]
+    fn expr_shimmer_eq_both_numeric_gets_fix() {
+        let src = "set x 42\nset z [expr {$x eq 42}]";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::top").unwrap();
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
+        let s = w
+            .iter()
+            .find(|sw| sw.variable == "x")
+            .unwrap_or_else(|| panic!("expected an Int-in-string-cmp shimmer, got: {w:?}"));
+        let fix = s
+            .fixes
+            .first()
+            .unwrap_or_else(|| panic!("expected a fix for both-numeric eq, got: {s:?}"));
+        assert_eq!(fix.new_text, "==");
+        let op_start = src.find(" eq ").unwrap() + 1;
+        assert_eq!(
+            (fix.span.start(), fix.span.end()),
+            (
+                u32::try_from(op_start).unwrap(),
+                u32::try_from(op_start + 2).unwrap()
+            ),
+            "fix span must cover exactly the 'eq' token: {fix:?}"
+        );
+    }
+
+    /// (FP guard) `$n eq "abc"` — `abc` is not numeric, so rewriting to `==`
+    /// would turn a well-defined "always false" string compare into a Tcl
+    /// runtime error ("expected integer but got \"abc\""). The warning still
+    /// fires (informational), but no fix is offered.
+    #[test]
+    fn expr_shimmer_eq_non_numeric_sibling_gets_no_fix() {
+        let src = "set n 5\nset z [expr {$n eq \"abc\"}]";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::top").unwrap();
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
+        let s = w
+            .iter()
+            .find(|sw| sw.variable == "n")
+            .unwrap_or_else(|| panic!("expected an Int-in-string-cmp shimmer, got: {w:?}"));
+        assert!(
+            s.fixes.is_empty(),
+            "must not offer an unsafe rewrite when the sibling isn't numeric: {s:?}"
+        );
+    }
+
+    /// (TP) `le`/`ge`/etc. rewrite to their numeric equivalents too, not just
+    /// `eq`/`ne`.
+    #[test]
+    fn expr_shimmer_le_both_numeric_gets_fix() {
+        let src = "set x 3\nset y 5\nset z [expr {$x le $y}]";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::top").unwrap();
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
+        let s = w
+            .iter()
+            .find(|sw| sw.variable == "x" || sw.variable == "y")
+            .unwrap_or_else(|| panic!("expected an Int-in-string-cmp shimmer, got: {w:?}"));
+        let fix = s
+            .fixes
+            .first()
+            .unwrap_or_else(|| panic!("expected a fix for both-numeric le, got: {s:?}"));
+        assert_eq!(fix.new_text, "<=");
+    }
+
+    /// (Ambiguity guard) Two `eq` operators in one statement — the operator
+    /// word isn't unique within the statement span, so the fix is withheld
+    /// (the warning itself still fires).
+    #[test]
+    fn expr_shimmer_ambiguous_duplicate_operator_gets_no_fix() {
+        let src = "set x 1\nset y 2\nset z [expr {($x eq 1) && ($y eq 2)}]";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::top").unwrap();
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &cu.source,
+        );
+        let shimmers: Vec<_> = w
+            .iter()
+            .filter(|sw| sw.variable == "x" || sw.variable == "y")
+            .collect();
+        assert!(
+            !shimmers.is_empty(),
+            "expected Int-in-string-cmp shimmers, got: {w:?}"
+        );
+        assert!(
+            shimmers.iter().all(|s| s.fixes.is_empty()),
+            "ambiguous duplicate operator must not offer a fix: {shimmers:?}"
         );
     }
 }

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -498,18 +498,9 @@ fn find_operator_fix(source: &str, stmt_span: Span, op: BinOp) -> Option<CodeFix
     let end = usize::try_from(stmt_span.end()).ok()?;
     let slice = source.get(start..end)?;
 
-    let is_word_char = |c: char| c.is_alphanumeric() || c == '_';
-    let mut matches = slice.match_indices(word).filter(|&(i, _)| {
-        let before_ok = slice[..i]
-            .chars()
-            .next_back()
-            .is_none_or(|c| !is_word_char(c));
-        let after_ok = slice[i + word.len()..]
-            .chars()
-            .next()
-            .is_none_or(|c| !is_word_char(c));
-        before_ok && after_ok
-    });
+    let mut matches = slice
+        .match_indices(word)
+        .filter(|&(i, _)| super::is_standalone_word_at(slice, i, word.len()));
     let (offset, _) = matches.next()?;
     if matches.next().is_some() {
         return None;

--- a/rust/tcl-compiler/src/shimmer/hints.rs
+++ b/rust/tcl-compiler/src/shimmer/hints.rs
@@ -23,7 +23,7 @@
 //! - [`is_numeric_compatible`] — true when two types are interchangeable
 //!   in Tcl's arithmetic/boolean contexts.
 
-use tcl_registry::{CommandRegistry, TclType};
+use tcl_registry::{CommandRegistry, TclType, Traits};
 
 /// Return the expected `TclType` for argument `arg_index` of `command`
 /// when that argument position is tagged `shimmers = true` in the registry.
@@ -61,11 +61,62 @@ pub fn arg_shimmer_type(
             .and_then(|(_, h)| if h.shimmers { h.expected } else { None });
     }
 
-    let needle = u8::try_from(arg_index).ok()?;
-    spec.arg_types
-        .iter()
-        .find(|(i, _)| *i == needle)
-        .and_then(|(_, h)| if h.shimmers { h.expected } else { None })
+    let fixed = u8::try_from(arg_index).ok().and_then(|needle| {
+        spec.arg_types
+            .iter()
+            .find(|(i, _)| *i == needle)
+            .and_then(|(_, h)| if h.shimmers { h.expected } else { None })
+    });
+    fixed.or_else(|| loop_list_header_shimmer_type(spec, args, arg_index))
+}
+
+/// Return `Some(TclType::List)` for any in-range `arg_index` of a
+/// `Traits::LOOP_LIST_HEADER` command (`foreach`, `lmap`).
+///
+/// Registry-driven and command-name-agnostic — keyed purely on the trait
+/// bit, so any future command declaring `LOOP_LIST_HEADER` picks this up for
+/// free rather than needing its own hardcoded arm here. The list arguments
+/// can't be expressed as fixed-position `arg_types` entries because their
+/// count varies with the number of `varList`/`list` pairs; this structural
+/// rule is the general form the fixed-index table can't capture.
+///
+/// This command shape reaches the shimmer pass in two different `args`
+/// encodings, both of which this rule must cover:
+///
+/// - **Opaque / non-inlined calls** (`cfg_builder::lower_foreach_dispatch`'s
+///   non-inlined arm, taken for namespace-qualified loop vars or when body
+///   inlining is off): `args` is the literal source shape, `varList list
+///   ?varList list ...? body` — *every* position through the last `list` is
+///   genuinely List-shimmering, not just the `list` slots: `Tcl_ForeachObjCmd`
+///   calls `Tcl_ListObjGetElements` on **both** the `varList` grouping words
+///   and the data `list` words (splitting `varList` into its member variable
+///   names requires exactly the same list-object conversion). Only the final
+///   `body` word is not — but a `$var` used as a foreach body, while
+///   syntactically legal, is not a pattern real Tcl code uses, so the
+///   (already narrow, since `check_invocation`/`record_use_targets` only
+///   ever act on a `$`-prefixed pure-var-ref word to begin with) residual
+///   risk of over-claiming that one slot is negligible next to the false
+///   negatives from excluding the `varList` slots would otherwise cause.
+/// - **Inlined calls** (the default; `cfg_builder::cfg_lower::lower_foreach`'s
+///   synthetic `var_def` `Statement::Call`): `args` is a *different*,
+///   list-only encoding — one entry per iterator's data list, no `varList`
+///   words and no `body` at all (`iterators.iter().map(|it|
+///   it.list_arg.clone())`). Every position here is unconditionally a list.
+///
+/// Since a single `(command, args, arg_index)` triple can't tell which
+/// encoding produced it, and *every* position is a genuine list position in
+/// the inlined encoding while all but the last are in the opaque one, "every
+/// in-range position" is the rule that is correct for one encoding and
+/// correct-except-for-a-practically-unreachable-slot for the other.
+fn loop_list_header_shimmer_type(
+    spec: &tcl_registry::CommandSpec,
+    args: &[&str],
+    arg_index: usize,
+) -> Option<TclType> {
+    if !spec.traits.contains(Traits::LOOP_LIST_HEADER) {
+        return None;
+    }
+    (arg_index < args.len()).then_some(TclType::List)
 }
 
 /// Return `true` when the two types are numerically compatible — i.e. a
@@ -93,6 +144,71 @@ mod tests {
 
     fn registry() -> CommandRegistry {
         CommandRegistry::build_default()
+    }
+
+    #[test]
+    fn arg_shimmer_type_foreach_opaque_shape_list_and_varlist_positions() {
+        // Opaque (non-inlined) call shape: literal source args `varList list
+        // body`. Both the varList (arg 0) and list (arg 1) positions are
+        // List-shimmering — `Tcl_ForeachObjCmd` list-splits both — the body
+        // (arg 2) is out of range once excluded... but since this rule
+        // covers every in-range position (see the function's doc comment),
+        // arg 2 also reports List here; `check_invocation` never reaches it
+        // in practice since a real body is never a pure `$var` reference.
+        let r = registry();
+        let args = ["x", "$l", "body"];
+        assert_eq!(
+            arg_shimmer_type(&r, "foreach", &args, 0),
+            Some(TclType::List)
+        );
+        assert_eq!(
+            arg_shimmer_type(&r, "foreach", &args, 1),
+            Some(TclType::List)
+        );
+    }
+
+    #[test]
+    fn arg_shimmer_type_foreach_inlined_shape_single_list_is_list() {
+        // Inlined call shape (the default): the synthetic `var_def` Call's
+        // `args` is list-only, one entry per iterator — `foreach x $l {...}`
+        // becomes `args = ["$l"]`, arg 0.
+        let r = registry();
+        assert_eq!(
+            arg_shimmer_type(&r, "foreach", &["$l"], 0),
+            Some(TclType::List)
+        );
+    }
+
+    #[test]
+    fn arg_shimmer_type_foreach_inlined_shape_multi_iterator_all_list() {
+        // `foreach a $la b $lb {...}` inlined: `args = ["$la", "$lb"]` — both
+        // positions are list positions.
+        let r = registry();
+        let args = ["$la", "$lb"];
+        assert_eq!(
+            arg_shimmer_type(&r, "foreach", &args, 0),
+            Some(TclType::List)
+        );
+        assert_eq!(
+            arg_shimmer_type(&r, "foreach", &args, 1),
+            Some(TclType::List)
+        );
+    }
+
+    #[test]
+    fn arg_shimmer_type_lmap_single_list_is_list() {
+        let r = registry();
+        assert_eq!(
+            arg_shimmer_type(&r, "lmap", &["$l"], 0),
+            Some(TclType::List)
+        );
+    }
+
+    #[test]
+    fn arg_shimmer_type_foreach_out_of_range_index_is_none() {
+        let r = registry();
+        assert_eq!(arg_shimmer_type(&r, "foreach", &["$l"], 1), None);
+        assert_eq!(arg_shimmer_type(&r, "foreach", &[], 0), None);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -132,6 +132,30 @@ pub(crate) struct ShimmerInputs<'a> {
     pub source: &'a str,
 }
 
+/// Whether `text[start..start + len]` is bounded by non-identifier
+/// characters (or a text boundary) on both sides — i.e. it appears as a
+/// standalone word, not as a substring of a larger identifier.
+///
+/// Shared by [`expr::find_operator_fix`] and
+/// [`use_site::nested_call_arg_spans`], both of which locate a
+/// mechanical-fix target by scanning already-parsed source text rather
+/// than re-parsing it (see `find_operator_fix`'s doc comment for why this
+/// textual-scan approximation is safe here).
+fn is_standalone_word_at(text: &str, start: usize, len: usize) -> bool {
+    fn is_word_char(c: char) -> bool {
+        c.is_alphanumeric() || c == '_'
+    }
+    let before_ok = text[..start]
+        .chars()
+        .next_back()
+        .is_none_or(|c| !is_word_char(c));
+    let after_ok = text[start + len..]
+        .chars()
+        .next()
+        .is_none_or(|c| !is_word_char(c));
+    before_ok && after_ok
+}
+
 /// Find intrep-shimmer warnings for a single function.
 ///
 /// Runs three sub-passes in order:
@@ -168,18 +192,16 @@ pub(crate) fn find_shimmer_warnings(inputs: &ShimmerInputs<'_>) -> Vec<ShimmerWa
 /// [`crate::gvn::find_redundancies_for_cu`]) so downstream tooling — the
 /// compiler explorer, the MCP server — can run the analysis without
 /// re-deriving per-function inputs. Walks every statically-analysable body
-/// in `cu.all_body_function_units()` order — top-level, every procedure,
-/// **and** every `TclOO`/snit method body and synthetic body unit (`apply`
-/// lambda, `namespace eval` block). `cu.functions()`/`analysable_functions()`
-/// deliberately skip methods and body units (kept for the per-proc passes'
-/// established behaviour — see their doc comments); shimmer has no such
-/// constraint, and skipping them silently dropped every shimmer/thunking/
-/// byte-array finding inside a method or lambda body even though the CFG /
-/// SSA / type pipeline already analyses them soundly (`cu.methods` /
-/// `cu.body_units` are built through the identical pipeline as
-/// `cu.procedures`). The complexity guard is re-applied by hand since
-/// `all_body_function_units` — unlike `analysable_functions` — doesn't
-/// filter it out.
+/// in `cu.analysable_body_function_units()` order — top-level, every
+/// procedure, **and** every `TclOO`/snit method body and synthetic body unit
+/// (`apply` lambda, `namespace eval` block). `cu.functions()`/
+/// `analysable_functions()` deliberately skip methods and body units (kept
+/// for the per-proc passes' established behaviour — see their doc
+/// comments); shimmer has no such constraint, and skipping them silently
+/// dropped every shimmer/thunking/byte-array finding inside a method or
+/// lambda body even though the CFG / SSA / type pipeline already analyses
+/// them soundly (`cu.methods` / `cu.body_units` are built through the
+/// identical pipeline as `cu.procedures`).
 ///
 /// `mutations` (module-wide `rename`/`interp alias`/proc-redefinition facts)
 /// is computed once here via
@@ -193,10 +215,7 @@ pub fn find_shimmer_warnings_for_cu(
 ) -> Vec<ShimmerWarning> {
     let mutations = crate::command_binding::scan_module_command_mutations(&cu.ir_module, registry);
     let mut out = Vec::new();
-    for fu in cu
-        .all_body_function_units()
-        .filter(|fu| !fu.complexity_guarded)
-    {
+    for fu in cu.analysable_body_function_units() {
         out.extend(find_shimmer_warnings(&ShimmerInputs {
             cfg: &fu.cfg,
             ssa: &fu.ssa,
@@ -218,10 +237,7 @@ pub fn find_thunking_warnings_for_cu(
     cu: &crate::compilation_unit::CompilationUnit,
 ) -> Vec<ThunkingWarning> {
     let mut out = Vec::new();
-    for fu in cu
-        .all_body_function_units()
-        .filter(|fu| !fu.complexity_guarded)
-    {
+    for fu in cu.analysable_body_function_units() {
         out.extend(find_thunking_warnings(
             &fu.cfg,
             &fu.ssa,
@@ -275,10 +291,7 @@ pub fn find_byte_array_warnings_for_cu(
 ) -> Vec<ShimmerWarning> {
     let payload_layouts = registry.byte_array_payload_layouts();
     let mut out = Vec::new();
-    for fu in cu
-        .all_body_function_units()
-        .filter(|fu| !fu.complexity_guarded)
-    {
+    for fu in cu.analysable_body_function_units() {
         out.extend(find_byte_array_warnings(
             &fu.cfg,
             &fu.ssa,

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -73,6 +73,12 @@ pub struct ShimmerWarning {
     pub message: String,
     /// Related spans + labels for diagnostic context.
     pub related: Vec<(Span, String)>,
+    /// Suggested fixes, when a mechanical, semantics-preserving rewrite is
+    /// available (e.g. `expr`'s numeric-var-in-string-comparison shimmer:
+    /// `eq`/`ne`/`lt`/`le`/`gt`/`ge` → `==`/`!=`/`<`/`<=`/`>`/`>=`). Empty for
+    /// most shimmer findings — the general case is a performance advisory
+    /// with no single canonical rewrite the LSP could safely automate.
+    pub fixes: Vec<crate::irules_checks::CodeFix>,
 }
 
 /// A variable that oscillates between two types across loop iterations.
@@ -106,6 +112,26 @@ pub fn type_name(t: TclType) -> String {
     format!("{t:?}").to_ascii_lowercase()
 }
 
+/// The per-function inputs every shimmer sub-pass draws from — bundled so
+/// [`find_shimmer_warnings`] takes one argument instead of eight
+/// (`clippy::too_many_arguments`); each sub-pass still takes only the
+/// individual fields it actually needs.
+pub(crate) struct ShimmerInputs<'a> {
+    pub cfg: &'a CfgFunction,
+    pub ssa: &'a SsaFunction,
+    pub types: &'a HashMap<ValueKey, TypeLattice>,
+    pub executable_blocks: &'a HashSet<BlockId>,
+    pub registry: &'a CommandRegistry,
+    pub values: &'a HashMap<ValueKey, crate::analyses::LatticeValue>,
+    /// Module-wide `rename`/`interp alias`/proc-redefinition facts — see
+    /// [`use_site::find_use_site_shimmers`]'s doc comment.
+    pub mutations: &'a crate::command_binding::ModuleCommandMutations,
+    /// Whole compilation-unit source text, used only to build the expr
+    /// pass's eq/ne/lt/le/gt/ge quick fix — see
+    /// [`expr::find_operator_fix`].
+    pub source: &'a str,
+}
+
 /// Find intrep-shimmer warnings for a single function.
 ///
 /// Runs three sub-passes in order:
@@ -117,25 +143,22 @@ pub fn type_name(t: TclType) -> String {
 /// 3. **Expression** ([`expr`]): arithmetic/comparison operators used with
 ///    the wrong operand type (S100).
 #[must_use]
-pub(crate) fn find_shimmer_warnings(
-    cfg: &CfgFunction,
-    ssa: &SsaFunction,
-    types: &HashMap<ValueKey, TypeLattice>,
-    executable_blocks: &HashSet<BlockId>,
-    registry: &CommandRegistry,
-    values: &HashMap<ValueKey, crate::analyses::LatticeValue>,
-) -> Vec<ShimmerWarning> {
+pub(crate) fn find_shimmer_warnings(inputs: &ShimmerInputs<'_>) -> Vec<ShimmerWarning> {
     let mut out = Vec::new();
-    out.extend(use_site::find_use_site_shimmers(
-        cfg,
-        ssa,
-        types,
-        executable_blocks,
-        registry,
-        values,
+    out.extend(use_site::find_use_site_shimmers(inputs));
+    out.extend(phi::find_phi_shimmers(
+        inputs.cfg,
+        inputs.ssa,
+        inputs.types,
+        inputs.executable_blocks,
     ));
-    out.extend(phi::find_phi_shimmers(cfg, ssa, types, executable_blocks));
-    out.extend(expr::find_expr_shimmers(cfg, ssa, types, executable_blocks));
+    out.extend(expr::find_expr_shimmers(
+        inputs.cfg,
+        inputs.ssa,
+        inputs.types,
+        inputs.executable_blocks,
+        inputs.source,
+    ));
     out
 }
 
@@ -144,35 +167,61 @@ pub(crate) fn find_shimmer_warnings(
 /// Public `*_for_cu` entry point (mirroring
 /// [`crate::gvn::find_redundancies_for_cu`]) so downstream tooling — the
 /// compiler explorer, the MCP server — can run the analysis without
-/// re-deriving per-function inputs. Walks each function's SSA / type /
-/// SCCP results in `cu.functions()` order.
+/// re-deriving per-function inputs. Walks every statically-analysable body
+/// in `cu.all_body_function_units()` order — top-level, every procedure,
+/// **and** every `TclOO`/snit method body and synthetic body unit (`apply`
+/// lambda, `namespace eval` block). `cu.functions()`/`analysable_functions()`
+/// deliberately skip methods and body units (kept for the per-proc passes'
+/// established behaviour — see their doc comments); shimmer has no such
+/// constraint, and skipping them silently dropped every shimmer/thunking/
+/// byte-array finding inside a method or lambda body even though the CFG /
+/// SSA / type pipeline already analyses them soundly (`cu.methods` /
+/// `cu.body_units` are built through the identical pipeline as
+/// `cu.procedures`). The complexity guard is re-applied by hand since
+/// `all_body_function_units` — unlike `analysable_functions` — doesn't
+/// filter it out.
+///
+/// `mutations` (module-wide `rename`/`interp alias`/proc-redefinition facts)
+/// is computed once here via
+/// [`crate::command_binding::scan_module_command_mutations`] and shared by
+/// every function's use-site pass — see [`use_site::find_use_site_shimmers`]'s
+/// doc comment for how it gates command-name trust.
 #[must_use]
 pub fn find_shimmer_warnings_for_cu(
     cu: &crate::compilation_unit::CompilationUnit,
     registry: &CommandRegistry,
 ) -> Vec<ShimmerWarning> {
+    let mutations = crate::command_binding::scan_module_command_mutations(&cu.ir_module, registry);
     let mut out = Vec::new();
-    for fu in cu.analysable_functions() {
-        out.extend(find_shimmer_warnings(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
+    for fu in cu
+        .all_body_function_units()
+        .filter(|fu| !fu.complexity_guarded)
+    {
+        out.extend(find_shimmer_warnings(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
             registry,
-            &fu.sccp.values,
-        ));
+            values: &fu.sccp.values,
+            mutations: &mutations,
+            source: &cu.source,
+        }));
     }
     out
 }
 
 /// Find every thunking warning across a whole compilation unit. See
-/// [`find_shimmer_warnings_for_cu`].
+/// [`find_shimmer_warnings_for_cu`] (including method/body-unit coverage).
 #[must_use]
 pub fn find_thunking_warnings_for_cu(
     cu: &crate::compilation_unit::CompilationUnit,
 ) -> Vec<ThunkingWarning> {
     let mut out = Vec::new();
-    for fu in cu.analysable_functions() {
+    for fu in cu
+        .all_body_function_units()
+        .filter(|fu| !fu.complexity_guarded)
+    {
         out.extend(find_thunking_warnings(
             &fu.cfg,
             &fu.ssa,
@@ -226,7 +275,10 @@ pub fn find_byte_array_warnings_for_cu(
 ) -> Vec<ShimmerWarning> {
     let payload_layouts = registry.byte_array_payload_layouts();
     let mut out = Vec::new();
-    for fu in cu.analysable_functions() {
+    for fu in cu
+        .all_body_function_units()
+        .filter(|fu| !fu.complexity_guarded)
+    {
         out.extend(find_byte_array_warnings(
             &fu.cfg,
             &fu.ssa,
@@ -255,6 +307,155 @@ mod tests {
         assert_eq!(type_name(TclType::List), "list");
     }
 
+    /// A per-iteration shimmer inside a `TclOO` method body must fire exactly
+    /// like the identical code in an ordinary `proc` — `find_shimmer_warnings_for_cu`
+    /// must walk `cu.methods`, not just `cu.procedures`/`cu.top_level`
+    /// (`cu.analysable_functions()` deliberately excludes methods; this CU-level
+    /// entry point must use the coverage-complete `all_body_function_units()`
+    /// instead — see its doc comment).
+    #[test]
+    fn shimmer_fires_inside_tcloo_method_body() {
+        let src = "oo::class create Foo {\n  method run {items} {\n    foreach x $items {\n      set y [lindex $x 0]\n      incr x\n    }\n  }\n}\n";
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, &registry(), false);
+        assert!(
+            !cu.methods.is_empty(),
+            "expected a TclOO method unit to be built"
+        );
+        let warnings = find_shimmer_warnings_for_cu(&cu, &registry());
+        assert!(
+            warnings.iter().any(|w| w.code == DiagCode::S101),
+            "expected an S101 shimmer inside the method body, got: {warnings:?}"
+        );
+    }
+
+    /// The same coverage gap for S102 (thunking) — a genuine loop-body
+    /// oscillation inside a method must still fire.
+    #[test]
+    fn thunking_fires_inside_tcloo_method_body() {
+        let src = "oo::class create Foo {\n  method run {n} {\n    set x 0\n    while {$n} {\n      set x \"s\"\n      set x [list 1]\n    }\n    return $x\n  }\n}\n";
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, &registry(), false);
+        let warnings = find_thunking_warnings_for_cu(&cu);
+        assert!(
+            warnings.iter().any(|w| w.code == DiagCode::S102),
+            "expected an S102 thunking warning inside the method body, got: {warnings:?}"
+        );
+    }
+
+    /// (TP) A call through an `interp alias`-created name is checked exactly
+    /// like a call to its target: `li` aliases `lindex`, so `li $x 0` on an
+    /// Int-typed `x` shimmers Int→List, identically to calling `lindex`
+    /// directly.
+    #[test]
+    fn shimmer_fires_through_interp_alias() {
+        let src = "interp alias {} li {} lindex\nproc f {} {\n  set x 5\n  li $x 0\n}\n";
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, &registry(), false);
+        let warnings = find_shimmer_warnings_for_cu(&cu, &registry());
+        let w = warnings.iter().find(|w| w.variable == "x");
+        assert!(
+            w.is_some(),
+            "expected a shimmer through the 'li' alias to lindex, got: {warnings:?}"
+        );
+        assert_eq!(w.unwrap().to_type, TclType::List);
+    }
+
+    /// (TN control) The identical code with no alias in play still fires —
+    /// confirms `shimmer_fires_through_interp_alias` isn't vacuously true.
+    #[test]
+    fn shimmer_fires_for_direct_lindex_call_control() {
+        let src = "proc f {} {\n  set x 5\n  lindex $x 0\n}\n";
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, &registry(), false);
+        let warnings = find_shimmer_warnings_for_cu(&cu, &registry());
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.variable == "x" && w.command == "lindex"),
+            "expected the direct-call control to still fire: {warnings:?}"
+        );
+    }
+
+    /// (FP guard) `rename incr {}` deletes the builtin `incr` module-wide —
+    /// any later `incr`-shaped call cannot be trusted to mean Tcl's builtin
+    /// (the interpreter would in fact raise "invalid command name" at
+    /// runtime), so `find_shimmer_warnings_for_cu` must not claim an
+    /// incr-shimmer for it.
+    #[test]
+    fn no_shimmer_for_incr_after_module_wide_rename() {
+        let src = "rename incr {}\nproc f {} {\n  set x \"hello\"\n  incr x\n}\n";
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, &registry(), false);
+        let warnings = find_shimmer_warnings_for_cu(&cu, &registry());
+        assert!(
+            !warnings.iter().any(|w| w.command == "incr"),
+            "incr must not be trusted after a module-wide rename: {warnings:?}"
+        );
+    }
+
+    /// (TN control) Without the `rename`, the identical `incr` call still
+    /// fires — confirms the guard above isn't vacuous.
+    #[test]
+    fn shimmer_fires_for_incr_without_rename_control() {
+        let src = "proc f {} {\n  set x \"hello\"\n  incr x\n}\n";
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, &registry(), false);
+        let warnings = find_shimmer_warnings_for_cu(&cu, &registry());
+        assert!(
+            warnings.iter().any(|w| w.command == "incr"),
+            "expected the no-rename control to still fire: {warnings:?}"
+        );
+    }
+
+    /// (FP guard) A `rename lindex myLindex` moves the builtin away from the
+    /// bare `lindex` spelling module-wide; a later literal `lindex` call
+    /// (now denoting whatever the module rebound it to, or nothing at all)
+    /// must not be trusted as the original builtin.
+    #[test]
+    fn no_shimmer_for_lindex_after_module_wide_rename() {
+        let src = "rename lindex myLindex\nproc f {} {\n  set x 5\n  lindex $x 0\n}\n";
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, &registry(), false);
+        let warnings = find_shimmer_warnings_for_cu(&cu, &registry());
+        assert!(
+            !warnings.iter().any(|w| w.command == "lindex"),
+            "lindex must not be trusted after a module-wide rename: {warnings:?}"
+        );
+    }
+
+    /// (FP guard) `my variable count` links `count` to the object's
+    /// instance-variable storage — it does not itself assign `count` any
+    /// value, so its true intrep depends on whatever *other* method last set
+    /// it to (not knowable locally). Before the registry fix (`oo_my.rs`'s
+    /// `variable` subcommand: `creates_scope_alias` + an `arg_role_resolver`
+    /// so `count` is even recognised as a def in the first place), the
+    /// generic `Statement::Call` fallback typed `count` from `my`'s own
+    /// nominal `return_type: Some(TclType::String)` — spuriously claiming
+    /// `count` is a fresh `String` and firing an S100 shimmer on `incr
+    /// count` that has nothing to do with the variable's real, externally-set
+    /// value.
+    #[test]
+    fn no_shimmer_for_incr_on_tcloo_instance_variable() {
+        let src = "oo::class create Foo {\n  method bump {} {\n    my variable count\n    incr count\n  }\n}\n";
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, &registry(), false);
+        let warnings = find_shimmer_warnings_for_cu(&cu, &registry());
+        assert!(
+            !warnings.iter().any(|w| w.variable == "count"),
+            "'my variable'-linked instance var must not spuriously shimmer: {warnings:?}"
+        );
+    }
+
+    /// (TN control) A genuinely *local* variable in the same method body
+    /// still shimmers normally — `my variable` linkage must not blanket-
+    /// suppress shimmer detection for the whole method
+    /// (`shimmer_fires_inside_tcloo_method_body` already covers this more
+    /// broadly; this variant specifically confirms the suppression is
+    /// scoped to the linked name, not the enclosing method).
+    #[test]
+    fn shimmer_still_fires_for_local_var_alongside_instance_variable() {
+        let src = "oo::class create Foo {\n  method bump {} {\n    my variable count\n    set local \"hello\"\n    incr local\n  }\n}\n";
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, &registry(), false);
+        let warnings = find_shimmer_warnings_for_cu(&cu, &registry());
+        assert!(
+            warnings.iter().any(|w| w.variable == "local"),
+            "local var shimmer must still fire alongside 'my variable': {warnings:?}"
+        );
+    }
+
     /// API smoke-test: both entry points accept an empty function.
     #[test]
     fn find_shimmer_warnings_empty_function() {
@@ -263,14 +464,16 @@ mod tests {
         let sccp = crate::sccp::sccp(&f, &ssa, None, None, None);
         let types: HashMap<ValueKey, TypeLattice> = HashMap::new();
         assert!(
-            find_shimmer_warnings(
-                &f,
-                &ssa,
-                &types,
-                &sccp.executable_blocks,
-                &registry(),
-                &sccp.values
-            )
+            find_shimmer_warnings(&ShimmerInputs {
+                cfg: &f,
+                ssa: &ssa,
+                types: &types,
+                executable_blocks: &sccp.executable_blocks,
+                registry: &registry(),
+                values: &sccp.values,
+                mutations: &crate::command_binding::ModuleCommandMutations::default(),
+                source: "",
+            })
             .is_empty()
         );
         assert!(find_thunking_warnings(&f, &ssa, &types, &sccp.executable_blocks).is_empty());

--- a/rust/tcl-compiler/src/shimmer/phi.rs
+++ b/rust/tcl-compiler/src/shimmer/phi.rs
@@ -154,6 +154,7 @@ fn classify_phi_shimmer(ctx: &PhiCtx<'_>, phi: &Phi, in_loop: bool) -> Option<Sh
             to = type_name(to),
         ),
         related,
+        fixes: Vec::new(),
     })
 }
 

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -40,7 +40,8 @@ use tcl_lexer::Span;
 use tcl_registry::{CommandRegistry, TclType};
 
 use crate::analyses::{ConstValue, LatticeValue};
-use crate::cfg::{BlockId, Function as CfgFunction};
+use crate::cfg::Function as CfgFunction;
+use crate::command_binding::ModuleCommandMutations;
 use crate::ir::Statement;
 use crate::naming::normalise_var_name;
 use crate::sccp::cfg_order;
@@ -59,20 +60,43 @@ use super::{ShimmerWarning, type_name};
 /// argument words against the registry's `arg_types`, and emits a
 /// [`ShimmerWarning`] for each type mismatch where the variable's known
 /// type differs from what the command requires.
+///
+/// `mutations` (module-wide `rename` / `interp alias` / proc-redefinition
+/// facts, from [`crate::command_binding::scan_module_command_mutations`])
+/// gates whether a literal command spelling may still be trusted to denote
+/// its registry builtin: a body that renames `incr`/`lindex`/… away (or
+/// shadows it with a user proc) makes every occurrence of that bare name
+/// untrustworthy module-wide (the sound over-approximation
+/// `ModuleCommandMutations` already uses for the optimiser's builtin-fold
+/// gate — see its doc comment), so the corresponding shimmer check is
+/// suppressed rather than risk a false claim about a command that may no
+/// longer mean what its name suggests. An `interp alias`-created name is
+/// additionally *resolved* to its target via
+/// [`crate::ir::Statement::canonical_command_or_source`] before the lookup,
+/// so a call through the alias is checked exactly like a call to the target
+/// itself.
+///
+/// `inputs.source` is the whole compilation unit's source text — used only
+/// to recover a tight per-argument span for a `[cmd …]` substitution
+/// embedded in a `Statement::AssignValue` (`set y [lindex $x 0]`), which
+/// carries no per-word `CommandTokens` of its own; see
+/// [`check_invocation`]'s doc comment and [`nested_call_arg_spans`].
 #[must_use]
-pub(crate) fn find_use_site_shimmers(
-    cfg: &CfgFunction,
-    ssa: &SsaFunction,
-    types: &HashMap<ValueKey, TypeLattice>,
-    executable_blocks: &HashSet<BlockId>,
-    registry: &CommandRegistry,
-    values: &HashMap<ValueKey, LatticeValue>,
-) -> Vec<ShimmerWarning> {
+pub(crate) fn find_use_site_shimmers(inputs: &super::ShimmerInputs<'_>) -> Vec<ShimmerWarning> {
+    let cfg = inputs.cfg;
+    let ssa = inputs.ssa;
+    let types = inputs.types;
+    let executable_blocks = inputs.executable_blocks;
+    let registry = inputs.registry;
+    let values = inputs.values;
+    let mutations = inputs.mutations;
+    let source = inputs.source;
+
     let loop_blocks = loop_body_blocks(cfg);
     let def_map = def_range_map(ssa);
     // Loop-invariance facts for the S101→S100 downgrade — only needed when
     // the function has at least one loop block.
-    let loop_facts = LoopFacts::compute(cfg, ssa, &loop_blocks, registry);
+    let loop_facts = LoopFacts::compute(cfg, ssa, &loop_blocks, registry, mutations);
     let mut out: Vec<ShimmerWarning> = Vec::new();
 
     for block_id in cfg_order(cfg) {
@@ -95,6 +119,8 @@ pub(crate) fn find_use_site_shimmers(
             values,
             loop_facts: &loop_facts,
             ssa,
+            mutations,
+            source,
             in_loop,
             already_coerced: &mut already_coerced,
             out: &mut out,
@@ -117,6 +143,8 @@ struct UseSiteCtx<'a> {
     values: &'a HashMap<ValueKey, LatticeValue>,
     loop_facts: &'a LoopFacts,
     ssa: &'a SsaFunction,
+    mutations: &'a ModuleCommandMutations,
+    source: &'a str,
     in_loop: bool,
     already_coerced: &'a mut HashSet<(String, u32, TclType)>,
     out: &'a mut Vec<ShimmerWarning>,
@@ -146,6 +174,7 @@ impl LoopFacts {
         ssa: &SsaFunction,
         loop_blocks: &HashSet<String>,
         registry: &CommandRegistry,
+        mutations: &ModuleCommandMutations,
     ) -> Self {
         let mut facts = Self::default();
         if loop_blocks.is_empty() {
@@ -167,7 +196,7 @@ impl LoopFacts {
             }
             if let Some(cb) = cfg.blocks.get(&id) {
                 for stmt in &cb.statements {
-                    facts.record_use_targets(stmt, registry);
+                    facts.record_use_targets(stmt, registry, mutations);
                 }
             }
         }
@@ -177,8 +206,16 @@ impl LoopFacts {
     /// Record the expected intrep of every `$var` argument at a shimmering
     /// position of `stmt` (a direct call or a `[cmd …]` substitution
     /// inside an assignment value).
-    fn record_use_targets(&mut self, stmt: &Statement, registry: &CommandRegistry) {
+    fn record_use_targets(
+        &mut self,
+        stmt: &Statement,
+        registry: &CommandRegistry,
+        mutations: &ModuleCommandMutations,
+    ) {
         let mut record = |command: &str, args: &[String]| {
+            if !mutations.trusts(command) {
+                return;
+            }
             let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
             for (i, word) in args.iter().enumerate() {
                 if !word.trim_start().starts_with('$') {
@@ -191,7 +228,7 @@ impl LoopFacts {
             }
         };
         match stmt {
-            Statement::Call { command, args, .. } => record(command, args),
+            Statement::Call { args, .. } => record(stmt.canonical_command_or_source(), args),
             Statement::AssignValue { value, .. } => {
                 if let Some((command, args)) =
                     crate::value_shapes::parse_command_substitution(value.trim())
@@ -244,11 +281,25 @@ fn value_is_int_literal_string(value: Option<&LatticeValue>) -> bool {
 /// against the variables' known types. Used for both a top-level
 /// [`Statement::Call`] and a `[cmd …]` substitution lifted out of a
 /// [`Statement::AssignValue`] value (`set b [lindex $x 0]`).
+///
+/// `arg_spans` — the call's own per-word spans, when available, in
+/// command-name-then-args order (so arg `i` is `arg_spans[i + 1]`) — narrows
+/// each warning's span to just the offending `$var` argument rather than the
+/// whole statement, so a shimmer on one argument of a multi-argument call
+/// (`dict get $bigMap $key1 $key2`) underlines only that argument. For a
+/// top-level `Statement::Call` this is `tokens.argv`; for the
+/// [`Statement::AssignValue`] embedded-command-substitution case (whose own
+/// `tokens` describe the outer `set`'s words, not the nested call's) it is
+/// computed by locating the substitution text directly in `ctx.source` — see
+/// [`nested_call_arg_spans`]. `None` (source unavailable, or the
+/// substitution text can't be located unambiguously) falls back to `span`,
+/// the whole statement.
 fn check_invocation(
     ctx: &mut UseSiteCtx<'_>,
     command: &str,
     args: &[String],
     span: Span,
+    arg_spans: Option<&[Span]>,
     uses: &HashMap<Symbol, u32>,
 ) {
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
@@ -304,8 +355,12 @@ fn check_invocation(
         } else {
             DiagCode::S100
         };
+        let arg_span = arg_spans
+            .and_then(|s| s.get(i + 1))
+            .copied()
+            .unwrap_or(span);
         ctx.out.push(ShimmerWarning {
-            span,
+            span: arg_span,
             variable: var.clone(),
             from_type: current,
             to_type: expected,
@@ -320,32 +375,121 @@ fn check_invocation(
                 to = type_name(expected),
             ),
             related,
+            fixes: Vec::new(),
         });
     }
 }
 
+/// Recover absolute per-argument spans for the arguments of a `[cmd ARG…]`
+/// command substitution embedded in a `Statement::AssignValue`'s `value`
+/// text (`set y [lindex $x 0]`). Such statements carry no per-word
+/// `CommandTokens` for the *nested* call — only the outer `set`'s own words
+/// — so this locates each argument directly in `source`: first the
+/// substitution text itself (`sub_text`, e.g. `"[lindex $x 0]"`) within the
+/// statement's source slice, then each argument word in turn from a cursor
+/// that only advances, so repeated words (`[lindex $x $x]`) each resolve to
+/// their own occurrence in order rather than all matching the first one.
+///
+/// Returns spans in the same command-name-then-args convention as
+/// [`crate::ir::CommandTokens::argv`] (index 0 is an unused placeholder, arg
+/// `i` is index `i + 1`) so [`check_invocation`] can index either source
+/// identically. Returns `None` — callers fall back to the whole-statement
+/// span — when `source` is empty (offset-0 memoised queries don't carry
+/// source text; see `compiler_checks::function_nontaint_checks`'s doc
+/// comment) or the substitution text can't be located unambiguously (it
+/// must appear in the statement's source slice exactly once).
+fn nested_call_arg_spans(
+    source: &str,
+    stmt_span: Span,
+    sub_text: &str,
+    args: &[String],
+) -> Option<Vec<Span>> {
+    if source.is_empty() {
+        return None;
+    }
+    let stmt_start = usize::try_from(stmt_span.start()).ok()?;
+    let stmt_end = usize::try_from(stmt_span.end()).ok()?;
+    let stmt_text = source.get(stmt_start..stmt_end)?;
+    let sub_start = stmt_text.find(sub_text)?;
+    if stmt_text[sub_start + 1..].contains(sub_text) {
+        return None;
+    }
+
+    let is_word_char = |c: char| c.is_alphanumeric() || c == '_';
+    let mut cursor = 0usize;
+    let mut spans = vec![Span::empty(stmt_span.start())];
+    for arg in args {
+        let found = sub_text[cursor..]
+            .match_indices(arg.as_str())
+            .find_map(|(i, _)| {
+                let abs = cursor + i;
+                let before_ok = sub_text[..abs]
+                    .chars()
+                    .next_back()
+                    .is_none_or(|c| !is_word_char(c));
+                let after_ok = sub_text[abs + arg.len()..]
+                    .chars()
+                    .next()
+                    .is_none_or(|c| !is_word_char(c));
+                (before_ok && after_ok).then_some(abs)
+            })?;
+        cursor = found + arg.len();
+        let abs_start = stmt_span.start() + u32::try_from(sub_start + found).ok()?;
+        let abs_end = abs_start + u32::try_from(arg.len()).ok()?;
+        spans.push(Span::new(abs_start, abs_end));
+    }
+    Some(spans)
+}
+
 fn check_statement(ctx: &mut UseSiteCtx<'_>, stmt: &Statement, uses: &HashMap<Symbol, u32>) {
     match stmt {
-        Statement::Call { command, args, .. } => {
-            check_invocation(ctx, command, args, stmt.span(), uses);
+        Statement::Call { args, tokens, .. } => {
+            // Resolve through an `interp alias` target (`canonical_command_or_source`
+            // falls back to the source spelling when there's no alias) and
+            // require the resolved name to still be trusted module-wide — a
+            // body that `rename`s it away, or redefines it as a user proc,
+            // makes every occurrence of the bare name untrustworthy (see this
+            // function's doc comment).
+            let command = stmt.canonical_command_or_source();
+            if ctx.mutations.trusts(command) {
+                let arg_spans = tokens.as_ref().map(|t| t.argv.as_slice());
+                check_invocation(ctx, command, args, stmt.span(), arg_spans, uses);
+            }
         }
 
         // A command substitution lifted into an assignment value
         // (`set b [lindex $x 0]`) reads its arguments just like a direct
-        // call.
+        // call. The statement's own `tokens` (when present) describe the
+        // outer `set`'s words, not the nested substitution's, so per-argument
+        // spans are instead recovered from the source text directly — see
+        // [`nested_call_arg_spans`].
         Statement::AssignValue { value, .. } => {
-            if let Some((command, args)) =
-                crate::value_shapes::parse_command_substitution(value.trim())
+            let trimmed = value.trim();
+            if let Some((command, args)) = crate::value_shapes::parse_command_substitution(trimmed)
+                && ctx.mutations.trusts(&command)
             {
-                check_invocation(ctx, &command, &args, stmt.span(), uses);
+                let arg_spans = nested_call_arg_spans(ctx.source, stmt.span(), trimmed, &args);
+                check_invocation(
+                    ctx,
+                    &command,
+                    &args,
+                    stmt.span(),
+                    arg_spans.as_deref(),
+                    uses,
+                );
             }
         }
 
-        Statement::Incr { name, amount, .. } => {
-            // `incr` reads both its target variable and (when present) its
-            // increment argument as Int.  The two checks are independent —
-            // an Int target with a String `$amount` still shimmers on the
-            // amount — so neither must short-circuit the other.
+        // `incr` reads both its target variable and (when present) its
+        // increment argument as Int.  The two checks are independent — an
+        // Int target with a String `$amount` still shimmers on the amount —
+        // so neither must short-circuit the other. `incr` is lowered to this
+        // dedicated statement purely lexically (no alias/rename resolution
+        // happens at that point — see `lowering/hooks/incr.rs`), so the
+        // *only* available mitigation for a renamed-away `incr` is to
+        // suppress the check entirely when the module untrusts the name;
+        // there is no alternate target name to redirect the check to.
+        Statement::Incr { name, amount, .. } if ctx.mutations.trusts("incr") => {
             check_incr_var(ctx, normalise_var_name(name), stmt.span(), uses);
             if let Some(amt) = amount.as_deref().map(str::trim)
                 && amt.starts_with('$')
@@ -412,6 +556,7 @@ fn check_incr_var(ctx: &mut UseSiteCtx<'_>, var: &str, span: Span, uses: &HashMa
             from = type_name(current),
         ),
         related,
+        fixes: Vec::new(),
     });
 }
 
@@ -419,6 +564,7 @@ fn check_incr_var(ctx: &mut UseSiteCtx<'_>, var: &str, span: Span, uses: &HashMa
 mod tests {
     use super::*;
     use crate::compilation_unit::CompilationUnit;
+    use crate::shimmer::ShimmerInputs;
     use tcl_registry::CommandRegistry;
 
     fn registry() -> CommandRegistry {
@@ -430,14 +576,16 @@ mod tests {
     fn shimmer_detected_for_string_used_with_incr() {
         let cu = CompilationUnit::build_for("set x \"hello\"\nincr x", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = find_use_site_shimmers(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
+            registry: &registry(),
+            values: &fu.sccp.values,
+            mutations: &ModuleCommandMutations::default(),
+            source: &cu.source,
+        });
         let w = warnings
             .iter()
             .find(|w| w.command == "incr" && w.from_type == TclType::String);
@@ -454,14 +602,16 @@ mod tests {
     fn no_shimmer_for_hex_literal_string_used_with_incr() {
         let cu = CompilationUnit::build_for("set n 0x80\nincr n", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = find_use_site_shimmers(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
+            registry: &registry(),
+            values: &fu.sccp.values,
+            mutations: &ModuleCommandMutations::default(),
+            source: &cu.source,
+        });
         let incr_shimmers: Vec<_> = warnings.iter().filter(|w| w.command == "incr").collect();
         assert!(
             incr_shimmers.is_empty(),
@@ -474,14 +624,16 @@ mod tests {
     fn no_shimmer_for_int_used_with_incr() {
         let cu = CompilationUnit::build_for("set x 5\nincr x", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = find_use_site_shimmers(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
+            registry: &registry(),
+            values: &fu.sccp.values,
+            mutations: &ModuleCommandMutations::default(),
+            source: &cu.source,
+        });
         let incr_shimmers: Vec<_> = warnings.iter().filter(|w| w.command == "incr").collect();
         assert!(
             incr_shimmers.is_empty(),
@@ -495,14 +647,16 @@ mod tests {
     fn shimmer_detected_for_int_used_with_lindex() {
         let cu = CompilationUnit::build_for("set x 5\nlindex $x 0", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = find_use_site_shimmers(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
+            registry: &registry(),
+            values: &fu.sccp.values,
+            mutations: &ModuleCommandMutations::default(),
+            source: &cu.source,
+        });
         let w = warnings.iter().find(|w| w.command == "lindex");
         assert!(
             w.is_some(),
@@ -510,6 +664,42 @@ mod tests {
         );
         assert_eq!(w.unwrap().from_type, TclType::Int);
         assert_eq!(w.unwrap().to_type, TclType::List);
+    }
+
+    /// The warning span is the offending `$var` argument itself, not the
+    /// whole call — precision matters more the more other arguments a call
+    /// has: `dict get $badMap key1 key2` should underline just `$badMap`,
+    /// not the whole three-argument statement.
+    #[test]
+    fn shimmer_span_is_the_argument_not_the_whole_statement() {
+        let src = "set badMap 5\ndict get $badMap key1 key2";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_use_site_shimmers(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
+            registry: &registry(),
+            values: &fu.sccp.values,
+            mutations: &ModuleCommandMutations::default(),
+            source: &cu.source,
+        });
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "dict" && w.variable == "badMap")
+            .unwrap_or_else(|| panic!("expected a dict-get shimmer, got: {warnings:?}"));
+        let stmt_start = u32::try_from(src.find("dict get").unwrap()).unwrap();
+        let stmt_end = u32::try_from(src.len()).unwrap();
+        let arg_start = u32::try_from(src.find("$badMap").unwrap()).unwrap();
+        let arg_end = arg_start + u32::try_from("$badMap".len()).unwrap();
+        assert_eq!(
+            (w.span.start(), w.span.end()),
+            (arg_start, arg_end),
+            "expected the span to cover exactly '$badMap' ({arg_start}..{arg_end}), \
+             not the whole statement ({stmt_start}..{stmt_end}): got {:?}",
+            w.span
+        );
     }
 
     /// A `foreach` element variable is typed String (list elements
@@ -522,14 +712,16 @@ mod tests {
         let src = "proc f {l} {\n    foreach x $l {\n        set b [lindex $x 0]\n    }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = find_use_site_shimmers(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
+            registry: &registry(),
+            values: &fu.sccp.values,
+            mutations: &ModuleCommandMutations::default(),
+            source: &cu.source,
+        });
         let w = warnings.iter().find(|w| w.command == "lindex");
         assert!(
             w.is_some(),
@@ -539,6 +731,21 @@ mod tests {
         assert_eq!(w.code, DiagCode::S101);
         assert_eq!(w.from_type, TclType::String);
         assert_eq!(w.to_type, TclType::List);
+        // Tight highlighting: `set b [lindex $x 0]` is a `Statement::
+        // AssignValue` (the `[lindex …]` is a command substitution nested in
+        // the value, not a top-level `Statement::Call`), which carries no
+        // per-word tokens of its own — the span must still cover just the
+        // `$x` argument, recovered from source via `nested_call_arg_spans`,
+        // not the whole `set b [lindex $x 0]` statement.
+        let arg_start = u32::try_from(src.find("$x").unwrap()).unwrap();
+        let arg_end = arg_start + u32::try_from("$x".len()).unwrap();
+        assert_eq!(
+            (w.span.start(), w.span.end()),
+            (arg_start, arg_end),
+            "expected the span to cover exactly '$x' ({arg_start}..{arg_end}), \
+             not the whole statement: got {:?}",
+            w.span
+        );
     }
 
     /// A loop-invariant variable (defined outside the loop) coerced to a
@@ -549,14 +756,16 @@ mod tests {
         let src = "proc f {} {\n  set data {1 2 3}\n  for {set i 0} {$i < 3} {incr i} {\n    set x [lindex $data $i]\n  }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = find_use_site_shimmers(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
+            registry: &registry(),
+            values: &fu.sccp.values,
+            mutations: &ModuleCommandMutations::default(),
+            source: &cu.source,
+        });
         let w = warnings
             .iter()
             .find(|w| w.command == "lindex" && w.variable == "data");
@@ -581,14 +790,16 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = find_use_site_shimmers(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
+            registry: &registry(),
+            values: &fu.sccp.values,
+            mutations: &ModuleCommandMutations::default(),
+            source: &cu.source,
+        });
         let w = warnings
             .iter()
             .find(|w| w.command == "incr" && w.variable == "step");
@@ -600,20 +811,52 @@ mod tests {
         assert_eq!(w.unwrap().to_type, TclType::Int);
     }
 
+    /// `foreach x $s { ... }` where `$s` is String-typed (e.g. also used as
+    /// a plain string elsewhere) shimmers on `foreach`'s own list argument —
+    /// iterating requires a List intrep. Exercises the
+    /// `Traits::LOOP_LIST_HEADER`-driven structural rule in `hints.rs`.
+    #[test]
+    fn shimmer_detected_for_foreach_list_argument_itself() {
+        let src =
+            "proc f {} {\n  set s \"a b c\"\n  string length $s\n  foreach x $s { puts $x }\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_use_site_shimmers(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
+            registry: &registry(),
+            values: &fu.sccp.values,
+            mutations: &ModuleCommandMutations::default(),
+            source: &cu.source,
+        });
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "foreach" && w.variable == "s");
+        assert!(
+            w.is_some(),
+            "expected foreach shimmer for String var 's', got: {warnings:?}"
+        );
+        assert_eq!(w.unwrap().to_type, TclType::List);
+    }
+
     /// Variables with Unknown type do not produce false-positive shimmers.
     #[test]
     fn no_shimmer_for_unknown_type() {
         // `set x $other` — type of x is Unknown (other has no known type).
         let cu = CompilationUnit::build_for("set x $other\nlindex $x 0", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = find_use_site_shimmers(&ShimmerInputs {
+            cfg: &fu.cfg,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            executable_blocks: &fu.sccp.executable_blocks,
+            registry: &registry(),
+            values: &fu.sccp.values,
+            mutations: &ModuleCommandMutations::default(),
+            source: &cu.source,
+        });
         // x has Unknown type; should not produce a shimmer.
         let lindex_shimmers: Vec<_> = warnings.iter().filter(|w| w.command == "lindex").collect();
         assert!(

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -70,11 +70,20 @@ use super::{ShimmerWarning, type_name};
 /// `ModuleCommandMutations` already uses for the optimiser's builtin-fold
 /// gate — see its doc comment), so the corresponding shimmer check is
 /// suppressed rather than risk a false claim about a command that may no
-/// longer mean what its name suggests. An `interp alias`-created name is
-/// additionally *resolved* to its target via
-/// [`crate::ir::Statement::canonical_command_or_source`] before the lookup,
-/// so a call through the alias is checked exactly like a call to the target
-/// itself.
+/// longer mean what its name suggests. For a top-level [`Statement::Call`],
+/// an `interp alias`-created name is additionally *resolved* to its target
+/// via [`crate::ir::Statement::canonical_command_or_source`] before the
+/// lookup, so a call through the alias is checked exactly like a call to
+/// the target itself — `canonical_command` is populated at IR-lowering
+/// time from the module-wide alias table. A `[cmd …]` substitution
+/// embedded in a `Statement::AssignValue` has no such pre-resolved field
+/// (it's parsed ad hoc from source text by
+/// [`crate::value_shapes::parse_command_substitution`], not lowered as its
+/// own bound `Statement::Call`), so an alias used in that position is
+/// looked up — and `mutations.trusts()`-gated — under its literal alias
+/// spelling: `set y [li $x 0]` is not checked as a `lindex` call. Exposing
+/// the lowering pass's alias table for this ad-hoc lookup too is a known
+/// gap, not yet done.
 ///
 /// `inputs.source` is the whole compilation unit's source text — used only
 /// to recover a tight per-argument span for a `[cmd …]` substitution
@@ -415,7 +424,6 @@ fn nested_call_arg_spans(
         return None;
     }
 
-    let is_word_char = |c: char| c.is_alphanumeric() || c == '_';
     let mut cursor = 0usize;
     let mut spans = vec![Span::empty(stmt_span.start())];
     for arg in args {
@@ -423,15 +431,7 @@ fn nested_call_arg_spans(
             .match_indices(arg.as_str())
             .find_map(|(i, _)| {
                 let abs = cursor + i;
-                let before_ok = sub_text[..abs]
-                    .chars()
-                    .next_back()
-                    .is_none_or(|c| !is_word_char(c));
-                let after_ok = sub_text[abs + arg.len()..]
-                    .chars()
-                    .next()
-                    .is_none_or(|c| !is_word_char(c));
-                (before_ok && after_ok).then_some(abs)
+                super::is_standalone_word_at(sub_text, abs, arg.len()).then_some(abs)
             })?;
         cursor = found + arg.len();
         let abs_start = stmt_span.start() + u32::try_from(sub_start + found).ok()?;
@@ -462,7 +462,10 @@ fn check_statement(ctx: &mut UseSiteCtx<'_>, stmt: &Statement, uses: &HashMap<Sy
         // call. The statement's own `tokens` (when present) describe the
         // outer `set`'s words, not the nested substitution's, so per-argument
         // spans are instead recovered from the source text directly — see
-        // [`nested_call_arg_spans`].
+        // [`nested_call_arg_spans`]. Unlike the `Statement::Call` arm above,
+        // `command` here is *not* resolved through `interp alias` — see
+        // this module's top doc comment for why (no pre-lowered
+        // `canonical_command` exists for an ad-hoc-parsed substitution).
         Statement::AssignValue { value, .. } => {
             let trimmed = value.trim();
             if let Some((command, args)) = crate::value_shapes::parse_command_substitution(trimmed)

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -700,6 +700,25 @@ fn evaluate_type_def<S: std::hash::BuildHasher>(
 ///
 /// Returns a map from `(variable_name, ssa_version)` to inferred
 /// `TypeLattice`. Values absent from the map are implicitly `Unknown`.
+///
+/// `module_traces` (from
+/// [`crate::var_observability::scan_module_variable_traces`]) is the
+/// module-wide variable-trace fact: a `trace add variable` write callback
+/// runs synchronously as part of the `set` that triggers it and can rewrite
+/// the value (and hence intrep) to anything, so a def of a traced name can't
+/// be trusted to hold the type its own assignment text suggests — even a
+/// plain local `set x 5` might not leave `x` holding `Int` if a trace
+/// intercepts it. Every def of a traced name is therefore widened to
+/// `Overdefined`, mirroring the SCCP `LatticeValue` treatment in
+/// [`crate::sccp::sccp`]. `None` for module-context-free callers and
+/// isolated single-function rebuilds that have no module to scan —
+/// deliberately *not* the broader `global`/`upvar`/`namespace` escaping set
+/// SCCP also
+/// consults: mere globalness doesn't retroactively invalidate a fresh local
+/// `set` for *type* purposes the way it does for cross-call *constant-value*
+/// folding, so widening on that broader set here would silence shimmer
+/// detection for the (extremely common) global-variable case without a
+/// matching soundness need — see FP-SH-02.
 #[must_use]
 pub fn propagate_types<S: std::hash::BuildHasher>(
     cfg: &CfgFunction,
@@ -707,6 +726,7 @@ pub fn propagate_types<S: std::hash::BuildHasher>(
     sccp: &SccpResult,
     registry: &CommandRegistry,
     known_classes: &HashSet<String, S>,
+    module_traces: Option<&crate::var_observability::ModuleVariableTraces>,
 ) -> HashMap<ValueKey, TypeLattice> {
     let preds = cfg.predecessors();
     let order = crate::sccp::cfg_order(cfg);
@@ -793,28 +813,43 @@ pub fn propagate_types<S: std::hash::BuildHasher>(
                 // mutated them arbitrarily); a scope-alias declaration
                 // (`global`/`variable`/`upvar`/`namespace upvar`) likewise
                 // widens its defs — the imported variable's intrep is
-                // external and unknown.'s
-                // barrier + `alias_cmds` arms.  Every def of one statement
-                // gets the same inferred type, so compute it once.
-                let inferred = match stmt {
-                    Statement::Barrier { .. } => TypeLattice::overdefined(),
-                    Statement::Call {
-                        command,
-                        args,
-                        defs,
-                        ..
-                    } if !defs.is_empty() && is_scope_alias_call(registry, command, args) => {
-                        TypeLattice::overdefined()
+                // external and unknown. A def of a module-traced name is
+                // widened the same way regardless of statement kind — a
+                // write-trace callback runs synchronously inside the write
+                // that triggers it and can silently rewrite the value (see
+                // this function's doc comment) — checked generically over
+                // `ssa_stmt.defs` rather than matched per `Statement`
+                // variant, so it applies uniformly to
+                // `AssignConst`/`AssignValue`/`AssignExpr`/`Incr`/`Call`
+                // alike. Every def of one statement gets the same inferred
+                // type, so compute it once.
+                let traced = ssa_stmt
+                    .defs
+                    .keys()
+                    .any(|&sym| module_traces.is_some_and(|mt| mt.is_traced(ssa.var_name(sym))));
+                let inferred = if traced {
+                    TypeLattice::overdefined()
+                } else {
+                    match stmt {
+                        Statement::Barrier { .. } => TypeLattice::overdefined(),
+                        Statement::Call {
+                            command,
+                            args,
+                            defs,
+                            ..
+                        } if !defs.is_empty() && is_scope_alias_call(registry, command, args) => {
+                            TypeLattice::overdefined()
+                        }
+                        _ => evaluate_type_def(
+                            stmt,
+                            &ssa_stmt.uses,
+                            &types,
+                            registry,
+                            known_classes,
+                            &namespace,
+                            ssa,
+                        ),
                     }
-                    _ => evaluate_type_def(
-                        stmt,
-                        &ssa_stmt.uses,
-                        &types,
-                        registry,
-                        known_classes,
-                        &namespace,
-                        ssa,
-                    ),
                 };
                 for (&var, &ver) in &ssa_stmt.defs {
                     let key = (var, ver);
@@ -1003,7 +1038,7 @@ mod tests {
             },
         );
         let x = ssa.var_symbol("x").unwrap();
-        let types = propagate_types(&f, &ssa, &sccp, &registry(), &HashSet::new());
+        let types = propagate_types(&f, &ssa, &sccp, &registry(), &HashSet::new(), None);
         assert_eq!(types.get(&(x, 1)), Some(&TypeLattice::of(TclType::Int)));
     }
 
@@ -1173,7 +1208,7 @@ mod tests {
         let mut sccp = empty_sccp(&cfg, &["entry", "exit"]);
         sccp.executable_edges.insert((entry, exit));
 
-        let types = propagate_types(&cfg, &ssa, &sccp, &registry(), &HashSet::new());
+        let types = propagate_types(&cfg, &ssa, &sccp, &registry(), &HashSet::new(), None);
         // x@1 (entry) should be Int.
         assert_eq!(types.get(&(x, 1)), Some(&TypeLattice::of(TclType::Int)));
         // x@2 (phi in exit) should propagate Int from entry.

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -2403,6 +2403,44 @@ mod tests {
     }
 
     #[test]
+    fn check_actions_surface_s100_eq_numeric_fix_on_plain_tcl() {
+        // A plain-Tcl (no dialect) document — the S1xx shimmer family's
+        // eq/ne/lt/le/gt/ge -> ==/!=/</<=/>/>= quick fix
+        // (`shimmer::expr::find_operator_fix`) must reach `code_action`
+        // regardless of dialect. Also proves the `f5-irules`-only gate that
+        // used to wrap this call in `tcl-lsp-server::code_action` (now
+        // lifted) isn't still silently required.
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        use tcl_compiler::compiler_checks::run_all_checks;
+
+        let registry = tcl_registry::CommandRegistry::build_default();
+        let src = "set x 42\nset z [expr {$x eq 42}]\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let checks = run_all_checks(&cu, &registry, None);
+        assert!(
+            checks
+                .iter()
+                .any(|d| d.code == DiagCode::S100 && !d.fixes.is_empty()),
+            "expected an S100 check with a fix, got {checks:?}",
+        );
+
+        let none_disabled = std::collections::HashSet::new();
+        let actions =
+            check_diagnostic_actions(src, whole_document_range(src), &checks, &none_disabled);
+        let fix = actions
+            .iter()
+            .find(|a| a.title.contains("Use numeric comparison"));
+        assert!(
+            fix.is_some(),
+            "expected the eq->== quick-fix action, got {actions:?}"
+        );
+        let fix = fix.unwrap();
+        assert_eq!(fix.kind, ActionKind::QuickFix);
+        assert_eq!(fix.edits.len(), 1);
+        assert_eq!(fix.edits[0].new_text, "==");
+    }
+
+    #[test]
     fn check_actions_empty_without_fixes() {
         // Checks with no fixes (or an out-of-range diagnostic) yield nothing.
         let src = "set x 1\n";

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1461,8 +1461,8 @@ pub fn proc_taint_solve<'db>(
     // seeds `lattice_keys` for) falls back to the direct per-function computation
     // on the *already-rebased* built unit (no offset add).
     //
-    // Walks `cu.all_body_function_units()`, not `cu.analysable_functions()` —
-    // the latter excludes methods and body units (see its doc comment), which
+    // Walks `cu.analysable_body_function_units()`, not `cu.analysable_functions()`
+    // — the latter excludes methods and body units (see its doc comment), which
     // silently dropped every shimmer/thunking/byte-array/SCCP/GVN finding from
     // inside a method or `apply`/`namespace eval` body in the *live* push/pull
     // diagnostics path, even after `compiler_checks::run_all_checks_with_
@@ -1473,10 +1473,7 @@ pub fn proc_taint_solve<'db>(
     // memoisation this function's `lattice_memo` callback populates), so a
     // method/body-unit `fu` here always — correctly — takes the fallback arm.
     let mut fn_checks: Vec<CompilerCheck> = Vec::new();
-    for fu in cu
-        .all_body_function_units()
-        .filter(|fu| !fu.complexity_guarded)
-    {
+    for fu in cu.analysable_body_function_units() {
         match lattice_keys.get(&fu.name) {
             Some(&key) => {
                 let body_offset = cu

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1317,6 +1317,30 @@ pub fn proc_summary_cascade<'db>(
 /// offset-0 [`function_lattice`] unit, *before* `rebase_function_unit`); the
 /// caller adds the procedure's `body_offset`.  A body edit re-runs only the
 /// edited procedure's checks; every other proc is a cache hit.
+///
+/// Passes `""` for `function_nontaint_checks`'s `source` param, not the
+/// document text: `fu`'s spans here are offset-0 (relative to this
+/// procedure's own body), so slicing the whole document at those offsets
+/// would land on the wrong text. This costs two things, both source-derived
+/// and both falling back to a safe, wider default rather than a wrong one:
+/// the shimmer expr pass's eq/ne/lt/le/gt/ge quick fix, and the use-site
+/// pass's tight per-argument span for a `[cmd …]` substitution embedded in
+/// a `set`/`AssignValue` (`set y [lindex $x 0]` — see
+/// `tcl_compiler::shimmer::use_site::nested_call_arg_spans`), which widens
+/// to the whole statement instead of just `$x`. A top-level bare call
+/// (`dict get $badMap key1 key2`) is unaffected either way — its tight span
+/// comes from `CommandTokens`, not source search. Both costs are real only
+/// for the *cached live-diagnostics* path (a regular top-level procedure,
+/// reached through this `FnLatticeKey`-memoised query); `run_all_checks`
+/// callers (`code_action`, the compiler explorer, the CLI, and — via the
+/// `None`-arm fallback below `proc_taint_solve`'s call site — `TclOO` methods
+/// and other body units) always re-derive with real source, so they get
+/// both the fix and the tight span. Passing the true offset-0 body slice
+/// here instead of `""` (mirroring `solve_optimisations`'s
+/// `cu.source.get(body_offset..body_end)`) is a documented follow-up: it
+/// needs threading `body_source` into this query as a new tracked-fn
+/// parameter, which every call site building a `FnLatticeKey` would then
+/// need to supply. See `function_nontaint_checks`'s doc comment.
 #[salsa::tracked]
 pub fn function_checks<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<Vec<CompilerCheck>> {
     let fu = function_lattice(db, key);
@@ -1327,6 +1351,7 @@ pub fn function_checks<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<V
         &fu,
         &registry,
         dialect_opt,
+        "",
     ))
 }
 
@@ -1431,10 +1456,27 @@ pub fn proc_taint_solve<'db>(
     // **offset-0** spans (it runs on the offset-0 `function_lattice` unit), so we
     // add the procedure's `body_offset` here — the same rebase the whole-module
     // build's `rebase_function_unit` applies.  A proc without a lattice key (e.g.
-    // the top level, or a complexity-guarded body) falls back to the direct
-    // per-function computation on the *already-rebased* built unit (no offset add).
+    // the top level, a complexity-guarded body, or — see below — a `TclOO`/snit
+    // method or synthetic body unit, none of which the memoisation pass above
+    // seeds `lattice_keys` for) falls back to the direct per-function computation
+    // on the *already-rebased* built unit (no offset add).
+    //
+    // Walks `cu.all_body_function_units()`, not `cu.analysable_functions()` —
+    // the latter excludes methods and body units (see its doc comment), which
+    // silently dropped every shimmer/thunking/byte-array/SCCP/GVN finding from
+    // inside a method or `apply`/`namespace eval` body in the *live* push/pull
+    // diagnostics path, even after `compiler_checks::run_all_checks_with_
+    // solved_and_patterns` was fixed to cover them — this function has its own,
+    // parallel per-procedure assembly (for the salsa incremental cache) and
+    // needed the identical fix. `lattice_keys` only ever contains regular
+    // procedure entries (methods/body units aren't part of the offset-0
+    // memoisation this function's `lattice_memo` callback populates), so a
+    // method/body-unit `fu` here always — correctly — takes the fallback arm.
     let mut fn_checks: Vec<CompilerCheck> = Vec::new();
-    for fu in cu.analysable_functions() {
+    for fu in cu
+        .all_body_function_units()
+        .filter(|fu| !fu.complexity_guarded)
+    {
         match lattice_keys.get(&fu.name) {
             Some(&key) => {
                 let body_offset = cu
@@ -1462,11 +1504,14 @@ pub fn proc_taint_solve<'db>(
             None => {
                 // The built unit's fallback fus (complexity-guarded / top level)
                 // carry **absolute** spans already (`base_offset == 0`), so the
-                // per-function checks need no rebase.
+                // per-function checks need no rebase — and `cu.source` is safe to
+                // pass directly for the same reason (see
+                // `function_nontaint_checks`'s doc comment on its `source` param).
                 for d in tcl_compiler::compiler_checks::function_nontaint_checks(
                     fu,
                     &registry,
                     dialect_opt,
+                    &cu.source,
                 ) {
                     fn_checks.push(d);
                 }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2468,6 +2468,34 @@ impl Backend {
         self.db_file_analysis(uri).await
     }
 
+    /// [`cached_analysis`], but for compiler-check/optimiser diagnostics —
+    /// the same salsa-memoised [`tcl_lsp_db::compiler_check_diagnostics`]
+    /// query [`compute_compiler_diags`] uses on the push-diagnostics path,
+    /// so a feature that only needs `CompilerDiagnostics` (e.g. `code_action`'s
+    /// compiler-check quick-fix lowering) shares that per-procedure
+    /// memoisation instead of paying for
+    /// [`tcl_lsp_db::compiler_check_diagnostics_uncached`]'s full rebuild on
+    /// every request. `None` when the document has no `SourceFile` input yet
+    /// (the caller falls back to the uncached build, as [`analysis_for`]
+    /// does for [`cached_analysis`]) or a concurrent edit cancelled the read.
+    async fn cached_compiler_diagnostics(
+        &self,
+        uri: &Uri,
+    ) -> Option<Arc<tcl_lsp_db::CompilerDiagnostics>> {
+        let file = (*self.db_files.lock().await).get(uri).copied()?;
+        let config = self.resolved_db_config(uri).await;
+        let snapshot = self.db.lock().await.clone();
+        tokio::task::spawn_blocking(move || {
+            salsa::Cancelled::catch(|| {
+                tcl_lsp_db::compiler_check_diagnostics(&snapshot, file, config)
+            })
+            .ok()
+        })
+        .await
+        .ok()
+        .flatten()
+    }
+
     /// Resolve an analysis for the document.  Consults the
     /// cache first; computes a fresh analysis when no entry
     /// exists.  Returns a shared `Arc` the caller can move into
@@ -7847,9 +7875,15 @@ impl LanguageServer for Backend {
         let context_diags = lift_context_diagnostics(&params.context.diagnostics);
         let dialect = doc.dialect.clone();
         let uri_str = uri.as_str().to_string();
-        // IRULE4002 generic-name patterns for the iRules-only compiler-checks
-        // code-action lowering below (uncached, off the salsa path).
+        // IRULE4002 generic-name patterns — only consulted by the uncached
+        // fallback below, when `cached_checks` is `None`.
         let generic_patterns = self.generic_variable_patterns.lock().await.clone();
+        // The compiler-check quick-fix lowering below needs `CompilerDiagnostics`
+        // for this document; reuse the salsa-memoised build shared with the
+        // push-diagnostics path (`compute_compiler_diags`) when one exists,
+        // rather than unconditionally paying for a from-scratch parse/CFG/SSA/
+        // SCCP/type-inference rebuild on every `code_action` request.
+        let cached_checks = self.cached_compiler_diagnostics(&uri).await;
         let actions = tokio::task::spawn_blocking(move || {
             let mut actions = core_code_actions::code_actions(&doc.text, range, Some(&analysis));
             actions.extend(core_code_actions::package_require_actions(
@@ -7884,12 +7918,15 @@ impl LanguageServer for Backend {
             // above, which meant a fix on a plain-Tcl document was silently
             // dropped even though `check_diagnostic_actions` itself has no
             // iRules-specific behaviour.
-            let checks = tcl_lsp_db::compiler_check_diagnostics_uncached(
-                &doc.text,
-                &registry,
-                &dialect,
-                generic_patterns.as_deref(),
-            );
+            let checks = match cached_checks {
+                Some(c) => c,
+                None => Arc::new(tcl_lsp_db::compiler_check_diagnostics_uncached(
+                    &doc.text,
+                    &registry,
+                    &dialect,
+                    generic_patterns.as_deref(),
+                )),
+            };
             actions.extend(core_code_actions::check_diagnostic_actions(
                 &doc.text,
                 range,

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1151,6 +1151,7 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
         optimiser_enabled,
         style_line_length,
         xc_diagnostics,
+        uri,
     };
     run_diagnostics_analyser_path(
         &delivery,
@@ -1459,6 +1460,10 @@ struct LiftInputs<'a> {
     optimiser_enabled: bool,
     style_line_length: u32,
     xc_diagnostics: bool,
+    /// The document URI — needed to build compiler-check `relatedInformation`
+    /// `Location`s (`lift_compiler_diagnostics`), which always point back
+    /// into the same document.
+    uri: &'a Uri,
 }
 
 /// Refine the analyser's single-file W120 against the workspace package
@@ -1505,6 +1510,7 @@ async fn refine_and_lift_diagnostics(
     let style_line_length = inputs.style_line_length;
     let xc_for_irules = inputs.xc_diagnostics && inputs.dialect == "f5-irules";
     let compiler_diags = Arc::clone(compiler_diags);
+    let lift_uri = inputs.uri.clone();
     tokio::task::spawn_blocking(move || {
         // `analyser_diags` is the cross-file-filtered set when `xcDiagnostics` is
         // on (else identical to `analysis_lifts.diagnostics`).
@@ -1516,6 +1522,7 @@ async fn refine_and_lift_diagnostics(
             optimiser_enabled,
             &opt_disabled,
             &disabled,
+            &lift_uri,
         ));
         diagnostics.extend(lift_source_style_diagnostics(
             &lift_text,
@@ -5180,6 +5187,7 @@ impl Backend {
         )
         .await;
         let style_line_length = self.resolved_style_line_length(uri).await;
+        let lift_uri = uri.clone();
         tokio::task::spawn_blocking(move || {
             let mut diagnostics = lift_analyser_diagnostics(&text, &analyser_diags);
             append_brace_expr_perf_hints(&mut diagnostics, optimiser_enabled, &opt_disabled);
@@ -5189,6 +5197,7 @@ impl Backend {
                 optimiser_enabled,
                 &opt_disabled,
                 &disabled,
+                &lift_uri,
             ));
             diagnostics.extend(lift_source_style_diagnostics(
                 &text,
@@ -7860,29 +7869,33 @@ impl LanguageServer for Backend {
                     &doc.text, range, &uri_str,
                 ));
             }
-            // iRules-only: the `# Profiles:` header source action plus the
-            // control-flow quick-fixes (IRULE5002 unguarded drop / IRULE5004
-            // DNS::return) the analyser produces through the compiler-checks
-            // pass rather than `AnalysisResult.diagnostics`.  Only the iRules
-            // dialect's checks carry fixes, so the (re-)lowering is gated here.
-            if dialect == "f5-irules" {
-                if let Some(a) = core_code_actions::profiles_action(&doc.text, &analysis, &registry)
-                {
-                    actions.push(a);
-                }
-                let checks = tcl_lsp_db::compiler_check_diagnostics_uncached(
-                    &doc.text,
-                    &registry,
-                    &dialect,
-                    generic_patterns.as_deref(),
-                );
-                actions.extend(core_code_actions::check_diagnostic_actions(
-                    &doc.text,
-                    range,
-                    &checks.checks,
-                    &disabled_codes,
-                ));
+            // iRules-only: the `# Profiles:` header source action.
+            if dialect == "f5-irules"
+                && let Some(a) = core_code_actions::profiles_action(&doc.text, &analysis, &registry)
+            {
+                actions.push(a);
             }
+            // Compiler-check quick-fixes (`Diagnostic::fixes` — today the
+            // iRules-only IRULE5002/5004 control-flow fixes, but the lowering
+            // itself is dialect-generic: any compiler-checks diagnostic with a
+            // `CodeFix` — including a future shimmer S1xx fix — surfaces here
+            // regardless of dialect). Previously gated to `dialect ==
+            // "f5-irules"` alongside the truly iRules-specific `profiles_action`
+            // above, which meant a fix on a plain-Tcl document was silently
+            // dropped even though `check_diagnostic_actions` itself has no
+            // iRules-specific behaviour.
+            let checks = tcl_lsp_db::compiler_check_diagnostics_uncached(
+                &doc.text,
+                &registry,
+                &dialect,
+                generic_patterns.as_deref(),
+            );
+            actions.extend(core_code_actions::check_diagnostic_actions(
+                &doc.text,
+                range,
+                &checks.checks,
+                &disabled_codes,
+            ));
             actions
         })
         .await
@@ -10058,9 +10071,12 @@ fn lift_compiler_diagnostics(
     optimiser_enabled: bool,
     disabled_optimisations: &std::collections::HashSet<String>,
     disabled_diagnostics: &std::collections::HashSet<String>,
+    uri: &Uri,
 ) -> Vec<tower_lsp_server::ls_types::Diagnostic> {
     use tcl_compiler::compiler_checks::Severity as CheckSeverity;
-    use tower_lsp_server::ls_types::{DiagnosticSeverity, NumberOrString};
+    use tower_lsp_server::ls_types::{
+        DiagnosticRelatedInformation, DiagnosticSeverity, Location, NumberOrString,
+    };
 
     let line_index = tcl_lexer::LineIndex::new_lsp(text);
     let mut out: Vec<tower_lsp_server::ls_types::Diagnostic> = Vec::new();
@@ -10092,6 +10108,22 @@ fn lift_compiler_diagnostics(
         if disabled_diagnostics.contains(d.code.as_str()) {
             continue;
         }
+        // Secondary context spans (e.g. shimmer's "value defined here" /
+        // phi's "version from '<block>'" — see `ShimmerWarning::related`) —
+        // `None` rather than `Some(vec![])` when there are none, matching
+        // the LSP convention other diagnostics in this lift already follow.
+        let related_information = (!d.related.is_empty()).then(|| {
+            d.related
+                .iter()
+                .map(|(span, label)| DiagnosticRelatedInformation {
+                    location: Location {
+                        uri: uri.clone(),
+                        range: lift_span(text, &line_index, *span),
+                    },
+                    message: label.clone(),
+                })
+                .collect()
+        });
         out.push(tower_lsp_server::ls_types::Diagnostic {
             range: lift_span(text, &line_index, d.span),
             severity: Some(match d.severity {
@@ -10104,7 +10136,7 @@ fn lift_compiler_diagnostics(
             code_description: None,
             source: Some("tcl-lsp".to_string()),
             message: d.message,
-            related_information: None,
+            related_information,
             tags: None,
             data: None,
         });
@@ -11382,6 +11414,7 @@ mod tests {
             true,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
+            &Uri::from_str("file:///s101_test.tcl").unwrap(),
         );
         assert!(
             diags.iter().any(|d| matches!(
@@ -11393,6 +11426,53 @@ mod tests {
         );
         // Every lifted diagnostic carries the shared source tag.
         assert!(diags.iter().all(|d| d.source.as_deref() == Some("tcl-lsp")));
+    }
+
+    /// An S101 phi-shimmer's `related` spans (`ShimmerWarning::related`,
+    /// wired through `compiler_checks::Diagnostic::related` — see
+    /// `from_shimmer`) must reach the client as LSP `relatedInformation`,
+    /// pointing back at the same document `uri` this lift was called with.
+    #[test]
+    fn lift_compiler_diagnostics_surfaces_shimmer_related_information() {
+        let registry = CommandRegistry::build_default();
+        // `x` merges Int (then-branch) and String (else-branch) at the phi —
+        // an out-of-loop S100 phi shimmer whose `related` spans point at
+        // both branches' `set x` definitions (see `phi.rs`'s
+        // `phi_shimmer_emitted_for_int_string_merge` unit test for the
+        // equivalent compiler-level assertion).
+        let src =
+            "set cond [gets stdin]\nif {$cond} { set x 1 } else { set x \"hello\" }\nputs $x\n";
+        let uri = Uri::from_str("file:///phi_shimmer.tcl").unwrap();
+        let diags = lift_compiler_diagnostics(
+            src,
+            &tcl_lsp_db::compiler_check_diagnostics_uncached(src, &registry, "", None),
+            true,
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+            &uri,
+        );
+        let shimmer = diags
+            .iter()
+            .find(|d| {
+                matches!(
+                    &d.code,
+                    Some(tower_lsp_server::ls_types::NumberOrString::String(c)) if c == "S100"
+                )
+            })
+            .unwrap_or_else(|| panic!("expected an S100 phi shimmer, got: {diags:?}"));
+        let related = shimmer
+            .related_information
+            .as_ref()
+            .filter(|r| !r.is_empty())
+            .unwrap_or_else(|| panic!("expected non-empty relatedInformation, got: {shimmer:?}"));
+        assert!(
+            related.iter().all(|r| r.location.uri == uri),
+            "related location must point back at the same document: {related:?}"
+        );
+        assert!(
+            related.iter().any(|r| r.message.contains("version from")),
+            "expected a 'version from <block>' related label, got: {related:?}"
+        );
     }
 
     #[test]
@@ -11407,6 +11487,7 @@ mod tests {
             false,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
+            &Uri::from_str("file:///s101_test.tcl").unwrap(),
         );
         assert!(
             !off.iter().any(is_o100),
@@ -11422,6 +11503,7 @@ mod tests {
             true,
             &disabled,
             &std::collections::HashSet::new(),
+            &Uri::from_str("file:///s101_test.tcl").unwrap(),
         );
         assert!(
             !per_code.iter().any(is_o100),
@@ -11446,6 +11528,7 @@ mod tests {
             true,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
+            &Uri::from_str("file:///s101_test.tcl").unwrap(),
         );
         assert!(
             diags.iter().any(|d| matches!(
@@ -11477,6 +11560,7 @@ mod tests {
             true,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
+            &Uri::from_str("file:///s101_test.tcl").unwrap(),
         );
         assert!(
             baseline.iter().any(is_irule3001),
@@ -11491,6 +11575,7 @@ mod tests {
             true,
             &std::collections::HashSet::new(),
             &disabled_diagnostics,
+            &Uri::from_str("file:///s101_test.tcl").unwrap(),
         );
         assert!(
             !filtered.iter().any(is_irule3001),

--- a/rust/tcl-lsp-server/tests/e2e/code_actions.rs
+++ b/rust/tcl-lsp-server/tests/e2e/code_actions.rs
@@ -166,6 +166,59 @@ fn test_w100_offers_brace_wrap() {
 }
 
 #[test]
+fn test_s100_eq_numeric_offers_numeric_comparison_fix() {
+    // S101 deep-review quick fix: a numeric var compared via `eq` against a
+    // numeric literal offers a mechanical `==` rewrite. Also proves the
+    // `code_action` handler's former `dialect == "f5-irules"` gate around
+    // compiler-check fixes (now lifted) doesn't still silently swallow this
+    // on a plain-Tcl document — `Lsp::tcl()`, not `Lsp::irules()`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set x 42\nset z [expr {$x eq 42}]\n");
+    let s100 = with_code(&diags, "S100");
+    assert!(
+        !s100.is_empty(),
+        "expected an S100 diagnostic to drive the quick fix, got {diags:?}"
+    );
+    let actions = lsp.code_actions(&uri, range((0, 0), (1, 25)), json!(s100));
+    assert!(
+        titles(&actions)
+            .iter()
+            .any(|t| t.contains("Use numeric comparison")),
+        "expected the eq->== quick-fix action, got {:?}",
+        titles(&actions)
+    );
+    assert!(
+        new_texts(&actions).iter().any(|nt| nt == "=="),
+        "expected a newText of '==', got {:?}",
+        new_texts(&actions)
+    );
+}
+
+#[test]
+fn test_s100_eq_non_numeric_sibling_offers_no_fix() {
+    // FP guard: `$n eq "abc"` — rewriting to `==` would turn a well-defined
+    // "always false" string compare into a Tcl runtime error, so no fix is
+    // offered (the diagnostic still fires, informationally).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set n 5\nset z [expr {$n eq \"abc\"}]\n");
+    let s100 = with_code(&diags, "S100");
+    assert!(
+        !s100.is_empty(),
+        "expected an S100 diagnostic, got {diags:?}"
+    );
+    let actions = lsp.code_actions(&uri, range((0, 0), (1, 30)), json!(s100));
+    assert!(
+        !titles(&actions)
+            .iter()
+            .any(|t| t.contains("Use numeric comparison")),
+        "must not offer an unsafe rewrite when the sibling isn't numeric: {:?}",
+        titles(&actions)
+    );
+}
+
+#[test]
 fn test_w302_adds_result_capture_actions() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");

--- a/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
@@ -536,3 +536,214 @@ fn global_hidden_inside_uplevel_body_in_proc_is_not_folded() {
         "must not fold `puts $g` to the stale literal 4: {source:?}"
     );
 }
+
+// S101 deep-review end-to-end coverage: exercises the real server's own
+// dialect detection / whole-module scan / TclOO method pipeline, per the
+// review's "editor-facing" requirement — the compiler-level TP/FP/TN/FN
+// coverage lives in `rust/tcl-compiler/src/shimmer/*.rs` and
+// `rust/tcl-compiler/src/compiler_checks.rs`.
+
+#[test]
+fn s101_fires_for_shimmer_inside_loop() {
+    // TP: `$x` is a foreach element (String-typed) used as a List via
+    // `lindex` on every iteration — the canonical S101 case.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc f {items} {\n  foreach x $items {\n    set y [lindex $x 0]\n  }\n}\n",
+    );
+    assert!(
+        codes(&diags).contains("S101"),
+        "expected S101 for the in-loop shimmer, got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn s101_fires_inside_tcloo_method_body() {
+    // TP (deep-review finding): before the fix, `find_shimmer_warnings_for_cu`
+    // / `run_all_checks`'s per-function loop iterated `cu.analysable_functions()`,
+    // which excludes TclOO method bodies — this exact per-iteration shimmer
+    // fired for an equivalent plain `proc` but was silently dropped for a
+    // `method`. See `shimmer::find_shimmer_warnings_for_cu`'s doc comment.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "oo::class create Foo {\n  method run {items} {\n    foreach x $items {\n      set y [lindex $x 0]\n    }\n  }\n}\n",
+    );
+    assert!(
+        codes(&diags).contains("S101"),
+        "expected S101 inside the TclOO method body, got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn s101_related_information_points_at_the_definition_site() {
+    // Precision: a phi-merge shimmer's `relatedInformation` must point back
+    // at the branch that defined the conflicting value, not be silently
+    // dropped (`ShimmerWarning::related` → `compiler_checks::Diagnostic::related`
+    // → LSP `relatedInformation` — see `lift_compiler_diagnostics`).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "set cond [gets stdin]\nif {$cond} { set x 1 } else { set x \"hello\" }\nputs $x\n",
+    );
+    let shimmer = diags
+        .iter()
+        .find(|d| d.get("code").and_then(Value::as_str) == Some("S100"))
+        .unwrap_or_else(|| panic!("expected an S100 phi shimmer, got {:?}", codes(&diags)));
+    let related = shimmer
+        .get("relatedInformation")
+        .and_then(Value::as_array)
+        .filter(|r| !r.is_empty())
+        .unwrap_or_else(|| panic!("expected non-empty relatedInformation, got {shimmer:?}"));
+    assert!(
+        related.iter().any(|r| r
+            .get("message")
+            .and_then(Value::as_str)
+            .unwrap_or("")
+            .contains("version from")),
+        "{related:?}"
+    );
+}
+
+#[test]
+fn s101_silent_for_incr_after_module_wide_rename() {
+    // FP guard: `rename incr {}` deletes the builtin module-wide — a later
+    // `incr`-shaped call can no longer be trusted to mean Tcl's builtin, so
+    // no incr-shimmer should be claimed for it.
+    //
+    // Driven through `tcl-lsp.compilerExplorer` (which calls
+    // `find_shimmer_warnings_for_cu`, a fresh whole-unit rebuild), not the
+    // live `open_ready` push-diagnostics path: `ModuleCommandMutations` is a
+    // *module-wide* fact, and threading it through the salsa-incremental
+    // per-procedure diagnostics cache (`tcl_lsp_db::function_checks`) needs
+    // the same `#[salsa::interned]` treatment `ModuleVariableTraces` already
+    // received for `CfgContext` — a documented follow-up, not yet done (see
+    // `compiler_checks::function_nontaint_checks`'s doc comment). The live
+    // path currently still reports the (harmless, non-fix-bearing) message;
+    // this test covers the surface that already gets the full fix:
+    // compiler-explorer / MCP-server / CLI / `code_action` (all of which
+    // rebuild fresh, uncached, per call).
+    let mut lsp = Lsp::tcl();
+    let src = "rename incr {}\nproc f {items} {\n  foreach x $items {\n    incr x\n  }\n}\n";
+    let result = lsp.execute_command("tcl-lsp.compilerExplorer", serde_json::json!([src, "tcl"]));
+    let shimmer = result
+        .get("shimmer")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        !shimmer
+            .iter()
+            .any(|w| { w.get("command").and_then(Value::as_str) == Some("incr") }),
+        "incr must not be trusted after a module-wide rename: {shimmer:?}"
+    );
+}
+
+#[test]
+fn s101_fires_for_incr_without_rename_control_via_explorer() {
+    // TN/control: the identical code with no `rename` still fires through
+    // the same `compilerExplorer` surface — proves the guard above is keyed
+    // on an actual rebinding, not a blanket regression of that surface.
+    let mut lsp = Lsp::tcl();
+    let src = "proc f {items} {\n  foreach x $items {\n    incr x\n  }\n}\n";
+    let result = lsp.execute_command("tcl-lsp.compilerExplorer", serde_json::json!([src, "tcl"]));
+    let shimmer = result
+        .get("shimmer")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        shimmer
+            .iter()
+            .any(|w| w.get("command").and_then(Value::as_str) == Some("incr")),
+        "expected the no-rename control to still fire: {shimmer:?}"
+    );
+}
+
+#[test]
+fn s101_fires_through_interp_alias() {
+    // TP: a call through an `interp alias`-created name is checked exactly
+    // like a call to its target.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "interp alias {} li {} lindex\nproc f {items} {\n  foreach x $items {\n    li $x 0\n  }\n}\n",
+    );
+    assert!(
+        codes(&diags).contains("S101"),
+        "expected S101 through the 'li' alias to lindex, got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn no_s100_shimmer_for_tcloo_instance_variable() {
+    // FP guard: `my variable count` links an object-instance variable whose
+    // true intrep depends on another method's last write, not the nominal
+    // return type of `my`. Before the registry fix (`oo_my.rs`'s `variable`
+    // subcommand), this spuriously claimed a String->Int shimmer.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "oo::class create Foo {\n  method bump {} {\n    my variable count\n    incr count\n  }\n}\n",
+    );
+    assert!(
+        !diags.iter().any(|d| {
+            matches!(d.get("code").and_then(Value::as_str), Some("S100" | "S101"))
+                && d.get("message")
+                    .and_then(Value::as_str)
+                    .unwrap_or("")
+                    .contains("'count'")
+        }),
+        "'my variable'-linked instance var must not spuriously shimmer: {diags:?}"
+    );
+}
+
+#[test]
+fn s101_tight_span_for_nested_command_substitution_via_explorer() {
+    // Precision: `set y [lindex $x 0]` is a `Statement::AssignValue` (the
+    // `[lindex …]` is a command substitution nested in the value, not a
+    // top-level `Statement::Call`), which carries no per-word tokens of its
+    // own for the nested call — the single most common shape a shimmer
+    // arises in. The highlighted span must still cover just `$x`, recovered
+    // from source via `nested_call_arg_spans`, not the whole statement.
+    //
+    // Driven through `tcl-lsp.compilerExplorer` (a fresh, uncached rebuild
+    // with real source text) rather than live `open_ready`: the LSP db's
+    // offset-0 memoised `function_checks` salsa query passes `""` as source
+    // for a regular top-level procedure's *cached* diagnostics, so that path
+    // still falls back to the whole-statement span — a documented, safe
+    // (never-wrong, just wider) limitation; see `function_checks`'s doc
+    // comment in `tcl-lsp-db`.
+    let mut lsp = Lsp::tcl();
+    let src = "proc f {items} {\n  foreach x $items {\n    set y [lindex $x 0]\n  }\n}\n";
+    let result = lsp.execute_command("tcl-lsp.compilerExplorer", serde_json::json!([src, "tcl"]));
+    let shimmer = result
+        .get("shimmer")
+        .and_then(Value::as_array)
+        .cloned()
+        .unwrap_or_default();
+    let w = shimmer
+        .iter()
+        .find(|w| w.get("command").and_then(Value::as_str) == Some("lindex"))
+        .unwrap_or_else(|| panic!("expected a lindex shimmer, got {shimmer:?}"));
+    let range = w.get("range").unwrap_or_else(|| panic!("no range: {w:?}"));
+    let start = range.get("startOffset").and_then(Value::as_u64).unwrap();
+    let end = range.get("endOffset").and_then(Value::as_u64).unwrap();
+    let arg_start = src.find("$x").unwrap() as u64;
+    let arg_end = arg_start + "$x".len() as u64;
+    assert_eq!(
+        (start, end),
+        (arg_start, arg_end),
+        "expected the span to cover exactly '$x' ({arg_start}..{arg_end}), \
+         not the whole statement: got {w:?}"
+    );
+}

--- a/rust/tcl-registry/src/commands/tcl/dict.rs
+++ b/rust/tcl-registry/src/commands/tcl/dict.rs
@@ -402,11 +402,14 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "dict getd dictionaryValue ?key ...? key default",
         pure: true,
         return_type: Some(TclType::String),
+        // Reads the dictionary value exactly like `dict get` (Tcl 9's
+        // `TclDictGetWithDefault` requires the same dict intrep conversion)
+        // — must shimmer identically, not `false`.
         arg_types: &[(
             0,
             ArgTypeHint {
                 expected: Some(TclType::Dict),
-                shimmers: false,
+                shimmers: true,
             },
         )],
         ..SubCommand::DEFAULT
@@ -420,11 +423,13 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "dict getdef dictionaryValue ?key ...? key default",
         pure: true,
         return_type: Some(TclType::String),
+        // See `getd` above — same `TclDictGetWithDefault` dict-read path as
+        // `dict get`.
         arg_types: &[(
             0,
             ArgTypeHint {
                 expected: Some(TclType::Dict),
-                shimmers: false,
+                shimmers: true,
             },
         )],
         ..SubCommand::DEFAULT
@@ -438,11 +443,13 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "dict getwithdefault dictionaryValue ?key ...? key default",
         pure: true,
         return_type: Some(TclType::String),
+        // See `getd` above — same `TclDictGetWithDefault` dict-read path as
+        // `dict get`.
         arg_types: &[(
             0,
             ArgTypeHint {
                 expected: Some(TclType::Dict),
-                shimmers: false,
+                shimmers: true,
             },
         )],
         ..SubCommand::DEFAULT

--- a/rust/tcl-registry/src/commands/tcl/oo_my.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_my.rs
@@ -23,6 +23,45 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "my method ?arg ...?",
 }];
 
+/// Every argument after the `variable` subcommand word is a variable name to
+/// link (`my variable a b c` links all of `a`, `b`, `c`), so — unlike a
+/// fixed-position `arg_roles` entry — this must be a resolver: the SSA
+/// def-extraction generic in `lowering/mod.rs::lower_default` (via
+/// `CommandRegistry::arg_indices_for_role`) calls it with the sub-relative
+/// args (everything after `variable`) and offsets the returned indices by
+/// `+1` for the subcommand word automatically.
+fn my_variable_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    (0..args.len())
+        .filter_map(|i| u8::try_from(i).ok())
+        .map(|i| (i, ArgRole::VarWrite))
+        .collect()
+}
+
+/// `my` forwards to an arbitrary method name, but `my variable ?name ...?`
+/// is `TclOO`'s own reserved dispatch — the per-object-namespace analogue of
+/// the top-level `variable` command (links each `name` to the object's
+/// private-namespace storage, same as `oo::define CLASS { variable name }`
+/// does for every method body). Modelled as the one recognised subcommand so
+/// [`Traits::CREATES_SCOPE_ALIAS`]'s per-subcommand sibling
+/// (`creates_scope_alias`) picks it up generically — the compiler's
+/// `is_scope_alias_call` widens its defs to `Overdefined` exactly like
+/// `global`/`variable`/`upvar`/`namespace upvar`, so a variable linked this
+/// way (whose true intrep may have been set by a *different* method) is not
+/// misreported as a local shimmer. Every other `my <method>` form still
+/// resolves to `None` here (no matching subcommand name) and is otherwise
+/// unaffected.
+const SUBCOMMANDS: &[SubCommand] = &[SubCommand {
+    name: "variable",
+    arity: Arity::at_least(1),
+    detail: "Link the named object-instance variable(s) into the current method's local scope.",
+    synopsis: "my variable ?name ...?",
+    return_type: Some(TclType::String),
+    arg_role_resolver: Some(my_variable_arg_roles),
+    creates_scope_alias: true,
+    dialects: Some(DialectSet::TCL86_PLUS),
+    ..SubCommand::DEFAULT
+}];
+
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "my",
@@ -30,6 +69,7 @@ pub fn spec() -> CommandSpec {
         dialects: Some(DialectSet::TCL86_PLUS),
         arity: Arity::at_least(1),
         return_type: Some(TclType::String),
+        subcommands: SUBCOMMANDS,
         hover: Some(HoverSnippet {
             summary: "invoke a method on the current object",
             synopsis: &["my method ?arg ...?"],


### PR DESCRIPTION
## Summary

This branch's original, broader scope (precision, tight highlighting, quick fixes) was independently superseded by #877 ("S100 shimmer review"), which landed most of the same ground: TclOO/namespace coverage, interp-alias resolution, tight spans, trace-awareness. This PR now contains only the two pieces that were still unique after #877 merged:

- New quick fix: `eq`/`ne`/`lt`/`le`/`gt`/`ge` against provably-numeric operands offers a mechanical rewrite to the numeric operator (`==`, `!=`, `<`, `<=`, `>`, `>=`). Withheld when the operator word isn't uniquely locatable in the statement's source span (ambiguous target). Also extends the arithmetic-shimmer check to byte arrays (the same in-place intrep clobber as String/List/Dict, reached via `Tcl_GetNumberFromObj`'s string-rep fallback).
- Registry fix: `my variable` (TclOO's per-object-namespace analogue of `global`/top-level `variable`) is now modelled as a subcommand with `creates_scope_alias: true`, so the compiler's existing `is_scope_alias_call` widens its defs to Overdefined — a linked instance variable no longer spuriously shimmers just because its nominal `my` return type looks stringy.

## Validation

- `cargo test -p tcl-compiler -p tcl-registry -p tcl-lsp-db -p tcl-lsp-server -p tcl-lsp-core --lib` (5,456 tests, 0 failures)
- `cargo test -p tcl-lsp-server --test e2e` (725 tests, 0 failures)
- `cargo clippy -p tcl-compiler -p tcl-registry -p tcl-lsp-db -p tcl-lsp-server -p tcl-lsp-core --all-targets` (zero warnings)
- `cargo fmt --all -- --check`
- `cargo xtask gen-editor-catalogs --check`, `cargo xtask diag-tables --check`, `cargo xtask kcs-index-links`

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract?
  - Yes: the numeric-comparison quick fix and byte-array arithmetic-shimmer coverage are additive checks within the existing shimmer-family contract; `my variable`'s scope-alias trait uses the existing `is_scope_alias_call`/Overdefined mechanism unchanged.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`.
  - N/A — no new fact contract, just data/coverage additions to existing mechanisms already documented for #877.
