### PR TITLE
S100 shimmer review: TclOO/namespace coverage, interp-alias resolution, tight spans, trace-awareness, noqa quick fix

### DIFF
--- a/docs/design/contracts/shimmer-reference-behaviour.md
+++ b/docs/design/contracts/shimmer-reference-behaviour.md
@@ -40,20 +40,56 @@ BOOLEAN → INT promotion is **not** flagged because it matches Tcl 9.0's O(1) c
 
 ## Reference validation status
 
-C source analysis completed against Tcl 9.0.3. The detector's `TYPE_HINTS` registry correctly maps Tcl commands to their underlying `Tcl_Get*FromObj` calls.
+C source analysis completed against Tcl 9.0.3. The `arg_types` shimmer hints
+carried on each `CommandRegistry` `CommandSpec`/`SubCommand` (see
+`rust/tcl-registry/src/commands/**`) correctly map Tcl commands to their
+underlying `Tcl_Get*FromObj` calls — command-level shimmer knowledge lives
+there as data (`ArgTypeHint { expected, shimmers }`), never hard-coded in the
+compiler.
+
+## Detection scope
+
+Shimmer analysis (`rust/tcl-compiler/src/shimmer/`) runs over every
+analysable function unit in a compilation unit — top-level code, `proc`
+bodies, TclOO method bodies (`cu.methods`), and synthetic body units such as
+`namespace eval` bodies and `apply` lambdas (`cu.body_units`) — not just
+top-level procs. Command resolution follows `interp alias` through
+`canonical_command`, so an alias to a shimmering builtin (e.g. `interp alias
+{} myindex {} ::lindex`) is detected the same as calling the builtin
+directly. A use is treated as unstably-typed (no shimmer flagged) when the
+variable carries a live write-trace, either in the same function
+(`var_observability::analyse_var_observability`) or anywhere else in the
+module (`ModuleVariableTraces`) — a traced variable's type cannot be
+statically trusted, since the trace callback may rewrite it.
+
+Diagnostic spans are tightened to the offending argument (or substitution)
+rather than the whole statement — see `shimmer::use_site::InvocationSite`
+and `value_shapes::parse_command_substitution_with_spans`. The one
+documented exception is `expr {...}` bodies: `ExprNode` offsets have no
+absolute-position anchor without a larger IR change, so shimmer inside an
+expression string still spans the whole statement.
+
+Two narrower residual gaps remain in the interp-alias handling (see the
+doc comment on `shimmer::use_site::check_invocation`): an alias that
+prepends fixed arguments (`interp alias {} foo {} ::bar prefix`) does not
+index-shift the checked argument, and a read-modify-write shimmering
+argument that is a bare variable name rather than a `$`-prefixed read
+(e.g. `interp alias {} myincr {} ::incr; myincr x`) is not seen through an
+alias, since `incr`'s own canonical name bypasses this path via the
+dedicated `Statement::Incr` node.
 
 ## Fixture scenarios
 
-See `tests/fixtures/shimmer/` for script-based cases that exercise:
+The Python-era `tests/fixtures/shimmer/` corpus was retired along with the
+Python implementation. Coverage today lives in:
 
-- string → list conversion (`string_scalar_to_list_once.tcl`, `string_list_roundtrip.tcl`),
-- numeric/string coercion in expression loops (`numeric_string_loop_thrash.tcl`),
-- list/string oscillation pressure in loops (`list_string_loop_toggle.tcl`),
-- dict/list oscillation (`dict_list_oscillation.tcl`),
-- boolean/int promotion — no false positive (`boolean_int_promotion.tcl`),
-- namespace-scoped shimmer variants (`namespace_scalar_vs_list.tcl`, `namespace_array_vs_list.tcl`).
+- Unit tests co-located with each shimmer module (`rust/tcl-compiler/src/shimmer/*.rs`) and in `rust/tcl-compiler/tests/checks.rs`.
+- TP/FP/TN/FN regression fixtures in `rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs` (the `FP-SH-NN` series).
+- Native `lsp_e2e` coverage in `rust/tcl-lsp-server/tests/e2e/diagnostics.rs` and `rust/tcl-lsp-server/tests/e2e/code_actions.rs` (the noqa suppress quick fix).
+- VS Code integration coverage in `editors/vscode/src/test/shimmerPrecision.test.ts` against `editors/vscode/testFixture/shimmerPrecision.tcl`.
 
 ## Cross-links
 
-- Tests: `tests/test_shimmer.py`.
-- Implementation: `compiler/shimmer.py`.
+- Implementation: `rust/tcl-compiler/src/shimmer/` (`hints.rs`, `use_site.rs`, `thunking.rs`, `byte_array.rs`, `phi.rs`, `graph.rs`, `span.rs`).
+- Registry data: `rust/tcl-registry/src/commands/**` (`arg_types` on each `CommandSpec`/`SubCommand`).
+- Suppression: `rust/tcl-compiler/src/analyser/utils.rs` (`parse_noqa_line_suppressions`, `apply_preceding_noqa`), consumed by `lift_compiler_diagnostics` in `rust/tcl-lsp-server/src/lib.rs`.

--- a/docs/kcs/codes/kcs-diagnostic-s100-shimmer-outside-loop.md
+++ b/docs/kcs/codes/kcs-diagnostic-s100-shimmer-outside-loop.md
@@ -45,7 +45,9 @@ expr {$x_num + 1}; string length $x
 
 ## How to suppress
 
-Put `# noqa: S100` on the line **before** the offending command.
+Add `# noqa: S100` on the line **above** the offending command, or apply
+the "Suppress S100 with a noqa comment" quick fix offered on the
+diagnostic.
 
 ## Related
 

--- a/docs/kcs/codes/kcs-diagnostic-s101-shimmer-inside-loop.md
+++ b/docs/kcs/codes/kcs-diagnostic-s101-shimmer-inside-loop.md
@@ -44,7 +44,9 @@ foreach item $list {
 
 ## How to suppress
 
-Put `# noqa: S101` on the line **before** the offending command.
+Add `# noqa: S101` on the line **above** the offending command, or apply
+the "Suppress S101 with a noqa comment" quick fix offered on the
+diagnostic.
 
 ## Related
 

--- a/docs/kcs/codes/kcs-diagnostic-s102-shimmer-oscillation.md
+++ b/docs/kcs/codes/kcs-diagnostic-s102-shimmer-oscillation.md
@@ -55,7 +55,9 @@ proc accumulate {} {
 
 ## How to suppress
 
-Put `# noqa: S102` on the line **before** the offending command.
+Add `# noqa: S102` on the line **above** the offending command, or apply
+the "Suppress S102 with a noqa comment" quick fix offered on the
+diagnostic.
 
 ## Related
 

--- a/editors/vscode/src/test/codeActions.test.ts
+++ b/editors/vscode/src/test/codeActions.test.ts
@@ -382,4 +382,46 @@ suite("Code Actions", () => {
     );
     assert.ok(sanitiseFix, "Should provide a strip-CR/LF sanitise quick fix");
   });
+
+  test("provides a noqa suppress quick fix for S100 (shimmer)", async () => {
+    const shimmerUri = getDocUri("shimmerPrecision.tcl");
+    await activate(shimmerUri);
+    const diagnostics = await waitForDiagnostics(shimmerUri, {
+      predicate: (diags) =>
+        diags.some((d) => {
+          const code = typeof d.code === "object" ? d.code.value : d.code;
+          return code === "S100";
+        }),
+    });
+
+    // Line 7 (0-indexed): `    lindex $x 0` inside `proc shimmer_true_case`.
+    const s100 = diagnostics.find((d) => {
+      const code = typeof d.code === "object" ? d.code.value : d.code;
+      return code === "S100" && d.range.start.line === 7;
+    });
+    assert.ok(s100, "S100 diagnostic on line 7 should be present");
+
+    const actions = (await pollUntil(
+      () =>
+        vscode.commands.executeCommand("vscode.executeCodeActionProvider", shimmerUri, s100.range),
+      (r) =>
+        Array.isArray(r) &&
+        (r as vscode.CodeAction[]).some(
+          (a) => typeof a.title === "string" && a.title === "Suppress S100 with a noqa comment",
+        ),
+      { timeout: 10_000, label: "S100 noqa suppress quick fix" },
+    )) as vscode.CodeAction[];
+
+    const suppressFix = actions.find(
+      (a) => typeof a.title === "string" && a.title === "Suppress S100 with a noqa comment",
+    );
+    assert.ok(suppressFix, "Should provide an S100 noqa suppress quick fix");
+
+    const edit = suppressFix.edit;
+    assert.ok(edit, "Suppress fix should carry a workspace edit");
+    const changes = edit.get(shimmerUri);
+    assert.strictEqual(changes.length, 1, "expected exactly one text edit");
+    // The inserted comment must match the call's 4-space indentation.
+    assert.strictEqual(changes[0].newText, "    # noqa: S100\n");
+  });
 });

--- a/editors/vscode/src/test/shimmerPrecision.test.ts
+++ b/editors/vscode/src/test/shimmerPrecision.test.ts
@@ -1,0 +1,129 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, waitForDiagnostics } from "./helper";
+
+// Normalise the `code` field (string | { value } ) to a plain string.
+function codeOf(d: vscode.Diagnostic): string {
+  return typeof d.code === "object" && d.code !== null ? String(d.code.value) : String(d.code);
+}
+
+function linesWithCode(diags: vscode.Diagnostic[], code: string): number[] {
+  return diags.filter((d) => codeOf(d) === code).map((d) => d.range.start.line);
+}
+
+// S100 shimmer precision — coverage for the deep shimmer review: interp-alias
+// resolution, TclOO/namespace-eval body coverage, tight per-argument spans,
+// write-trace awareness, and `# noqa` suppression directives.
+//
+// `shimmerPrecision.tcl` (0-indexed diagnostic lines):
+//   7  lindex $x 0             TRUE  — plain string shimmered to a list intrep
+//   13 lindex $y 0             FALSE — value already carries a list intrep
+//   20 myindex $z 0            TRUE  — shimmer detected through an interp alias
+//   27 incr a (TclOO method)   TRUE  — method bodies now get shimmer coverage
+//   34 incr b (namespace eval) TRUE  — namespace eval bodies now get coverage
+//   42 incr c (traced)         FALSE — a write-traced var is never confidently typed
+//   49 lindex $d 0 (noqa S100) FALSE — suppressed by a matching preceding directive
+//   56 lindex $e 0 (noqa W100) TRUE  — a mismatched directive must not suppress
+//
+// Every test below waits for *some* S100 to appear as the "analysis ran"
+// marker (the file is a single deep-analysis unit, so once one S100 has
+// landed the absence of another on the same publish is meaningful), then
+// asserts the specific line in question.
+suite("Shimmer precision (S100 deep review)", () => {
+  const docUri = getDocUri("shimmerPrecision.tcl");
+
+  async function s100Diagnostics(): Promise<vscode.Diagnostic[]> {
+    await activate(docUri);
+    return waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "S100"),
+    });
+  }
+
+  test("plain string shimmered by lindex fires S100 with a tight span (true case)", async () => {
+    const diags = await s100Diagnostics();
+    const x = diags.find((d) => codeOf(d) === "S100" && d.range.start.line === 7);
+    assert.ok(x, `expected S100 on line 7 (lindex $x 0); got [${linesWithCode(diags, "S100")}]`);
+    assert.strictEqual(
+      x.severity,
+      vscode.DiagnosticSeverity.Information,
+      "S100 should be informational",
+    );
+    // The span must cover only `$x` — not the whole `lindex $x 0` call.
+    assert.strictEqual(x.range.start.character, 11, "must start at '$x'");
+    assert.strictEqual(x.range.end.character, 13, "must end after '$x'");
+  });
+
+  test("a value already carrying a list intrep stays silent (false case)", async () => {
+    const diags = await s100Diagnostics();
+    assert.ok(
+      !linesWithCode(diags, "S100").includes(13),
+      "a clean list passed to lindex must not fire S100",
+    );
+  });
+
+  test("shimmer is detected through an interp alias to a shimmering builtin (true case)", async () => {
+    const diags = await s100Diagnostics();
+    assert.ok(
+      linesWithCode(diags, "S100").includes(20),
+      `expected S100 through 'interp alias {} myindex {} ::lindex'; got [${linesWithCode(diags, "S100")}]`,
+    );
+  });
+
+  test("shimmer fires inside a TclOO method body (true case)", async () => {
+    const diags = await s100Diagnostics();
+    assert.ok(
+      linesWithCode(diags, "S100").includes(27),
+      `expected S100 inside an oo::class method body; got [${linesWithCode(diags, "S100")}]`,
+    );
+  });
+
+  test("shimmer fires inside a namespace eval body (true case)", async () => {
+    const diags = await s100Diagnostics();
+    assert.ok(
+      linesWithCode(diags, "S100").includes(34),
+      `expected S100 inside a namespace eval body; got [${linesWithCode(diags, "S100")}]`,
+    );
+  });
+
+  test("a write-traced variable never fires shimmer (false-negative guard)", async () => {
+    const diags = await s100Diagnostics();
+    assert.ok(
+      !linesWithCode(diags, "S100").includes(42),
+      "a write-traced variable must widen to overdefined and stay silent",
+    );
+  });
+
+  test("a matching noqa directive suppresses S100 (true suppression)", async () => {
+    const diags = await s100Diagnostics();
+    assert.ok(
+      !linesWithCode(diags, "S100").includes(49),
+      "'# noqa: S100' on the preceding line must suppress the diagnostic",
+    );
+  });
+
+  test("a mismatched noqa directive does not suppress S100 (false-suppression guard)", async () => {
+    const diags = await s100Diagnostics();
+    assert.ok(
+      linesWithCode(diags, "S100").includes(56),
+      "'# noqa: W100' must not suppress an unrelated S100",
+    );
+  });
+});

--- a/editors/vscode/testFixture/shimmerPrecision.tcl
+++ b/editors/vscode/testFixture/shimmerPrecision.tcl
@@ -1,0 +1,58 @@
+# S100/S101 shimmer precision fixture: TP/FP/TN/FN cases from the deep
+# shimmer review (interp alias, TclOO, namespace eval, write-traces,
+# suppression directives).
+
+# True case: a stringy value gets shimmered to a list intrep by lindex.
+proc shimmer_true_case {} {
+    set x hello
+    lindex $x 0
+}
+
+# False case: the value already carries a list intrep, so no shimmer.
+proc shimmer_false_case {} {
+    set y [list 1 2 3]
+    lindex $y 0
+}
+
+# True case: shimmer fires through an interp alias to a shimmering builtin.
+interp alias {} myindex {} ::lindex
+proc shimmer_through_alias {} {
+    set z hello
+    myindex $z 0
+}
+
+# True case: shimmer fires inside a TclOO method body.
+oo::class create ShimmerClass {
+    method touch {} {
+        set a hello
+        incr a
+    }
+}
+
+# True case: shimmer fires inside a namespace eval body.
+namespace eval shimmerNs {
+    set b hello
+    incr b
+}
+
+# False case (FN guard): a write-traced variable is never confidently typed,
+# so shimmer must not fire even though the RHS looks stringy.
+proc shimmer_traced_var {} {
+    trace add variable c write cb
+    set c hello
+    incr c
+}
+
+# Suppression directive silences the diagnostic on the following line.
+proc shimmer_suppress_directive_matches {} {
+    set d hello
+    # noqa: S100
+    lindex $d 0
+}
+
+# A directive naming a different code must not silence this one.
+proc shimmer_suppress_directive_mismatches {} {
+    set e hello
+    # noqa: W100
+    lindex $e 0
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
@@ -820,3 +820,64 @@ namespace eval ::foo {
         "FP-SH-16: namespace alias without a local re-init must not fire S102; got {got:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-SH-09 — a variable under a live write-trace is not confidently typed
+// ---------------------------------------------------------------------------
+
+/// FP-SH-09: `trace add variable v write cb` registers a callback that can
+/// rewrite `v`'s value — and so its intrep — on every subsequent write. A
+/// `set v hello` *after* the trace is installed must not be trusted as a
+/// definite String: the trace callback runs on that very `set` and may
+/// substitute a different value. Claiming S100 on the following `incr v`
+/// would be unsound.
+#[test]
+fn fp_sh_09_traced_variable_write_not_confidently_typed() {
+    let src = "\
+proc f {} {
+    trace add variable v write cb
+    set v hello
+    incr v
+}
+";
+    let got = codes(src, D);
+    assert!(
+        !got.iter().any(|c| c == "S100" || c == "S101"),
+        "FP-SH-09: a write-traced variable's def must widen to OVERDEFINED; got {got:?}"
+    );
+}
+
+/// FP-SH-09 TP control: the identical `set`/`incr` pair with no trace
+/// anywhere in the function must still fire — the widening is trace-gated,
+/// not a blanket suppression of `incr` shimmer.
+#[test]
+fn fp_sh_09_untraced_variable_still_fires() {
+    let src = "proc f {} {\n    set v hello\n    incr v\n}\n";
+    let got = codes(src, D);
+    assert!(
+        got.iter().any(|c| c == "S100" || c == "S101"),
+        "FP-SH-09 TP: untraced incr shimmer must still fire; got {got:?}"
+    );
+}
+
+/// FP-SH-09: the trace can be installed by a *different* proc — the
+/// module-wide `ModuleVariableTraces` fact must still widen the def, not
+/// just a same-function `analyse_var_observability` scan.
+#[test]
+fn fp_sh_09_module_wide_trace_from_another_proc_suppresses_shimmer() {
+    let src = "\
+proc install_trace {} {
+    trace add variable ::v write cb
+}
+proc use_it {} {
+    install_trace
+    set ::v hello
+    incr ::v
+}
+";
+    let got = codes(src, D);
+    assert!(
+        !got.iter().any(|c| c == "S100" || c == "S101"),
+        "FP-SH-09: a trace installed by a different proc must still widen the def; got {got:?}"
+    );
+}

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1217,13 +1217,15 @@ impl CompilationUnit {
     /// Exists for a pass that already reaches top-level + procedures through
     /// [`Self::analysable_functions`] elsewhere and wants *only* these two
     /// extra function kinds added, without double-visiting top-level or a
-    /// procedure. The shimmer-family checks are exactly this shape: they run
-    /// once per function inside the general per-proc pipeline (which walks
-    /// `analysable_functions()`), and once more here to reach methods and
-    /// body units that pipeline skips — see `compiler_checks::shimmer_family_checks`'s
-    /// two call sites (`compiler_checks.rs` and `tcl-lsp-db::proc_taint_solve`,
-    /// which must independently reach the identical result — see that
-    /// query's own doc comment for why the split exists).
+    /// procedure or double-counting a diagnostic. Used by
+    /// `tcl-lsp-db::proc_taint_solve`'s shimmer-family top-up loop: that
+    /// memoised query's main per-function loop still iterates
+    /// [`Self::analysable_functions`] (proc-only), unlike
+    /// `compiler_checks::run_all_checks_with_solved_and_patterns`'s direct
+    /// path, which iterates the wider [`Self::all_body_function_units`]
+    /// (filtered) and so needs no separate top-up — adding this iterator's
+    /// output there too would re-run `shimmer_family_checks` a second time
+    /// over the methods/body units `function_nontaint_checks` already covers.
     pub fn analysable_methods_and_body_units(&self) -> impl Iterator<Item = &FunctionUnit> {
         let mut v: Vec<&FunctionUnit> = self
             .methods

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1208,6 +1208,32 @@ impl CompilationUnit {
         v.sort_by(|a, b| a.name.cmp(&b.name));
         v.into_iter()
     }
+
+    /// Every `TclOO` method and synthetic body unit (`apply` lambda,
+    /// `namespace eval` body) that isn't complexity-guarded — the extra half
+    /// of [`Self::all_body_function_units`] beyond [`Self::analysable_functions`]
+    /// (top-level + procedures), name-sorted for reproducibility.
+    ///
+    /// Exists for a pass that already reaches top-level + procedures through
+    /// [`Self::analysable_functions`] elsewhere and wants *only* these two
+    /// extra function kinds added, without double-visiting top-level or a
+    /// procedure. The shimmer-family checks are exactly this shape: they run
+    /// once per function inside the general per-proc pipeline (which walks
+    /// `analysable_functions()`), and once more here to reach methods and
+    /// body units that pipeline skips — see `compiler_checks::shimmer_family_checks`'s
+    /// two call sites (`compiler_checks.rs` and `tcl-lsp-db::proc_taint_solve`,
+    /// which must independently reach the identical result — see that
+    /// query's own doc comment for why the split exists).
+    pub fn analysable_methods_and_body_units(&self) -> impl Iterator<Item = &FunctionUnit> {
+        let mut v: Vec<&FunctionUnit> = self
+            .methods
+            .values()
+            .chain(self.body_units.values())
+            .filter(|fu| !fu.complexity_guarded)
+            .collect();
+        v.sort_by(|a, b| a.name.cmp(&b.name));
+        v.into_iter()
+    }
 }
 
 /// Per-arg-position call-site literal evidence for one callee.

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -265,23 +265,20 @@ pub fn run_all_checks_with_solved_and_patterns(
     let mut out: Vec<Diagnostic> = Vec::new();
 
     // Per-function non-taint checks (SCCP constant branches, GVN redundancies,
-    // shimmer / thunking / byte-array), computed on each procedure and rebased to
-    // its offset.  Factored into [`function_nontaint_checks`] so the LSP db can
-    // memoise it per procedure on the offset-0 `FnLatticeKey` (SRV-INCREMENTAL
-    // 2a): an unedited procedure's checks are a cache hit instead of recomputed
-    // over the whole unit every edit.
+    // shimmer / thunking / byte-array), computed on each procedure — **and**,
+    // via `analysable_body_function_units`, every `TclOO` method body and
+    // synthetic body unit (`apply` lambda, `namespace eval` body) too, so the
+    // shimmer family `function_nontaint_checks` folds in reaches those places
+    // as well (no separate widening loop needed here: unlike
+    // `tcl-lsp-db::proc_taint_solve`'s memoised path below, which still
+    // iterates the proc-only `analysable_functions` and so keeps its own
+    // explicit `shimmer_family_checks` pass over methods/body units) —
+    // rebased to its offset. Factored into [`function_nontaint_checks`] so
+    // the LSP db can memoise it per procedure on the offset-0 `FnLatticeKey`
+    // (SRV-INCREMENTAL 2a): an unedited procedure's checks are a cache hit
+    // instead of recomputed over the whole unit every edit.
     for fu in cu.analysable_body_function_units() {
         for d in function_nontaint_checks(fu, registry, dialect) {
-            out.push(shift(fu, d));
-        }
-    }
-
-    // The intrep-shimmer family alone (S100/S101/S102/S110), extended to
-    // `TclOO` method bodies and synthetic body units (`apply` lambdas,
-    // `namespace eval` bodies) — see [`shimmer_family_checks`]. SCCP/GVN
-    // stay proc-only for now (unreviewed blast radius outside this family).
-    for fu in cu.analysable_methods_and_body_units() {
-        for d in shimmer_family_checks(fu, registry, dialect) {
             out.push(shift(fu, d));
         }
     }
@@ -529,6 +526,36 @@ mod tests {
         let mut r = CommandRegistry::build_default();
         r.load_irules();
         r
+    }
+
+    /// Regression: `function_nontaint_checks` (called per unit from the
+    /// `analysable_body_function_units` loop, which already reaches `TclOO`
+    /// method bodies) folds in `shimmer_family_checks` itself — a second,
+    /// separate loop explicitly re-walking methods/body-units for shimmer
+    /// would double-emit every S100/S101/S102/S110 inside one. Exactly this
+    /// double-count was introduced transiently when two independent fixes
+    /// (this shimmer-coverage widening and #872's taint-coverage widening)
+    /// were rebased together: #872 widened the base loop from
+    /// `analysable_functions` to `analysable_body_function_units`, which
+    /// made the shimmer-only top-up loop redundant.
+    #[test]
+    fn shimmer_not_double_counted_in_tcloo_method_body() {
+        let src = "oo::class create C {\n    method m {} {\n        set x hello\n        incr x\n    }\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let diags = run_all_checks(&cu, &registry(), None);
+        let s100: Vec<_> = diags.iter().filter(|d| d.code.as_str() == "S100").collect();
+        assert_eq!(s100.len(), 1, "expected exactly one S100, got {s100:?}");
+    }
+
+    /// Same double-count guard for a `namespace eval` body (the other
+    /// synthetic body-unit kind `analysable_body_function_units` reaches).
+    #[test]
+    fn shimmer_not_double_counted_in_namespace_eval_body() {
+        let src = "namespace eval ns {\n    set x hello\n    incr x\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let diags = run_all_checks(&cu, &registry(), None);
+        let s100: Vec<_> = diags.iter().filter(|d| d.code.as_str() == "S100").collect();
+        assert_eq!(s100.len(), 1, "expected exactly one S100, got {s100:?}");
     }
 
     #[test]

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -280,10 +280,7 @@ pub fn run_all_checks_with_solved_and_patterns(
     // `TclOO` method bodies and synthetic body units (`apply` lambdas,
     // `namespace eval` bodies) — see [`shimmer_family_checks`]. SCCP/GVN
     // stay proc-only for now (unreviewed blast radius outside this family).
-    for fu in cu.methods.values().chain(cu.body_units.values()) {
-        if fu.complexity_guarded {
-            continue;
-        }
+    for fu in cu.analysable_methods_and_body_units() {
         for d in shimmer_family_checks(fu, registry, dialect) {
             out.push(shift(fu, d));
         }

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -276,6 +276,19 @@ pub fn run_all_checks_with_solved_and_patterns(
         }
     }
 
+    // The intrep-shimmer family alone (S100/S101/S102/S110), extended to
+    // `TclOO` method bodies and synthetic body units (`apply` lambdas,
+    // `namespace eval` bodies) — see [`shimmer_family_checks`]. SCCP/GVN
+    // stay proc-only for now (unreviewed blast radius outside this family).
+    for fu in cu.methods.values().chain(cu.body_units.values()) {
+        if fu.complexity_guarded {
+            continue;
+        }
+        for d in shimmer_family_checks(fu, registry, dialect) {
+            out.push(shift(fu, d));
+        }
+    }
+
     // Taint (per-function, reading the interprocedural `solved`) + iRules
     // module-level checks — the half that is not per-function-pure.
     push_taint_and_module_checks(cu, registry, dialect, solved, generic_patterns, &mut out);
@@ -316,6 +329,29 @@ pub fn function_nontaint_checks(
     for r in find_loop_invariants(registry, &fu.cfg, &fu.ssa, dialect) {
         out.push(Diagnostic::from_redundant(&r));
     }
+    out.extend(shimmer_family_checks(fu, registry, dialect));
+    out
+}
+
+/// The intrep-shimmer diagnostic family alone for one function body: use-site
+/// / expression / phi shimmer (S100/S101), loop-oscillation thunking (S102),
+/// and byte-array corruption (S110).
+///
+/// Split out of [`function_nontaint_checks`] so it can also run over `TclOO`
+/// method bodies and synthetic body units (`apply` lambdas, `namespace eval`
+/// bodies) — [`CompilationUnit.methods`](crate::compilation_unit::CompilationUnit::methods)
+/// and `.body_units` are excluded from the SCCP/GVN half (`cu.analysable_functions()`
+/// only walks the top level and procedures), so without this split every
+/// shimmer diagnostic was silently unreachable inside a method or a
+/// `namespace eval` body. The S110 `*::payload` byte-command set is
+/// dialect-gated (empty outside iRules).
+#[must_use]
+pub fn shimmer_family_checks(
+    fu: &FunctionUnit,
+    registry: &CommandRegistry,
+    dialect: Option<&str>,
+) -> Vec<Diagnostic> {
+    let mut out: Vec<Diagnostic> = Vec::new();
     for w in find_shimmer_warnings(
         &fu.cfg,
         &fu.ssa,

--- a/rust/tcl-compiler/src/segmenter.rs
+++ b/rust/tcl-compiler/src/segmenter.rs
@@ -227,11 +227,10 @@ pub(crate) fn command_span(tokens: &[Token], sm: &SourceMap<'_>) -> Span {
 /// cannot be derived from the token *type*, and `cmd.range` consumers (W105
 /// unbraced-body detection, segmenter tiling) rely on the inner-end for them.
 fn widen_word_end(tok: Token, sm: &SourceMap<'_>) -> u32 {
-    let closer = match tok.kind {
-        TokenType::Str => b'}',
-        TokenType::Cmd => b']',
-        _ => return tok.span.end(),
+    let Some(closer) = tok.kind.group_closer() else {
+        return tok.span.end();
     };
+    let closer = closer as u8;
     let end = tok.span.end();
     if sm.token_text(tok).is_empty() {
         // Empty `{}` / `[]`: span already covers the closer — don't widen.

--- a/rust/tcl-compiler/src/shimmer/hints.rs
+++ b/rust/tcl-compiler/src/shimmer/hints.rs
@@ -143,6 +143,50 @@ mod tests {
     }
 
     #[test]
+    fn arg_shimmer_type_binary_decode_data_is_arg1_not_format_keyword() {
+        // `binary decode format data` — sub arg 1 (overall arg 2) is `data`
+        // and expects String (text-friendly encoded input); sub arg 0 (the
+        // `format` keyword, e.g. "hex") must NOT carry the hint.
+        let r = registry();
+        assert_eq!(
+            arg_shimmer_type(&r, "binary", &["decode", "hex", "$data"], 2),
+            Some(TclType::String)
+        );
+        assert_eq!(
+            arg_shimmer_type(&r, "binary", &["decode", "hex", "$data"], 1),
+            None,
+            "the 'format' keyword slot must not carry the shimmer hint"
+        );
+    }
+
+    #[test]
+    fn arg_shimmer_type_binary_encode_data_is_arg1_expects_bytearray() {
+        // `binary encode format data` — `data` is the raw bytes being
+        // encoded, so it expects ByteArray (the reverse of `decode`).
+        let r = registry();
+        assert_eq!(
+            arg_shimmer_type(&r, "binary", &["encode", "hex", "$data"], 2),
+            Some(TclType::ByteArray)
+        );
+    }
+
+    #[test]
+    fn arg_shimmer_type_dict_getd_family_matches_dict_get() {
+        // `dict getd`/`getdef`/`getwithdefault` (Tcl 9.0 TIP 342 synonyms of
+        // `dict get` with a default) must carry the same Dict shimmer hint
+        // as plain `dict get` — they were previously inconsistently
+        // `shimmers: false`.
+        let r = registry();
+        for sub in ["getd", "getdef", "getwithdefault", "get"] {
+            assert_eq!(
+                arg_shimmer_type(&r, "dict", &[sub, "$d", "k", "default"], 1),
+                Some(TclType::Dict),
+                "dict {sub} should shimmer its dict argument like dict get",
+            );
+        }
+    }
+
+    #[test]
     fn is_numeric_compatible_same_type() {
         assert!(is_numeric_compatible(TclType::Int, TclType::Int));
         assert!(is_numeric_compatible(TclType::String, TclType::String));

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -240,20 +240,103 @@ fn value_is_int_literal_string(value: Option<&LatticeValue>) -> bool {
     }
 }
 
+/// Expected intrep for every list/dict argument of a synthetic loop-header
+/// call: the CFG builder lowers `foreach` / `lmap` / `dict for` / `dict map`
+/// to a `Statement::Call` whose `command` is that keyword (or, for the dict
+/// forms, the two-word compound `"dict for"` / `"dict map"`) and whose
+/// `args` are *only* the list/dict arguments — one per iterator group, in
+/// order (see `cfg_builder::cfg_lower::lower_foreach`; identified by
+/// `Statement::Call::foreach_groups` being `Some`, not by the command name).
+///
+/// Every iterator group's argument expects the *same* intrep, so this reads
+/// the registry once and the caller applies the result uniformly — unlike a
+/// real call's `arg_types`, which is keyed per source-position index and
+/// so can't reach a multi-group loop's later arguments at all.
+///
+/// `dict for` / `dict map` are two-word compound names (AGENTS.md's
+/// compound-command pattern — a base command with a subcommand argument,
+/// like `namespace upvar`): split at the space and dispatch through the
+/// `dict` subcommand table via [`arg_shimmer_type`]'s existing subcommand
+/// path, requesting sub-index 1 (both subcommands declare their dict
+/// argument there).
+fn foreach_header_expected_type(registry: &CommandRegistry, command: &str) -> Option<TclType> {
+    if let Some((base, sub)) = command.split_once(' ') {
+        // `arg_shimmer_type`'s subcommand path computes `sub_idx =
+        // arg_index - 1`; requesting `arg_index = 2` reads sub-index 1.
+        arg_shimmer_type(registry, base, &[sub], 2)
+    } else {
+        arg_shimmer_type(registry, command, &[], 0)
+    }
+}
+
+/// Grouped, per-call arguments for [`check_invocation`] — keeps that
+/// function's own parameter list short (the `ctx` + `uses` thread-through
+/// state are the only params that vary independently of "which invocation").
+#[derive(Clone, Copy)]
+struct InvocationSite<'a> {
+    /// Source spelling, for the warning's `command` field and message.
+    command: &'a str,
+    /// Registry lookup key — the *canonical* command name when the call is
+    /// an `interp alias` target (`interp alias {} myindex {} ::lindex;
+    /// myindex $x 0` resolves `lookup_command = "::lindex"`), so an aliased
+    /// call to a shimmering builtin is still recognised, matching
+    /// [`Statement::Call::canonical_command`]'s documented "diagnostics
+    /// read better with the spelling the user wrote" rationale.
+    lookup_command: &'a str,
+    /// Argument words.
+    args: &'a [String],
+    /// Per-argument absolute spans, index-aligned with `args`, when
+    /// available (see `fallback_span`).
+    arg_spans: &'a [Span],
+    /// True for the synthetic loop-header shape [`foreach_header_expected_type`]
+    /// covers (`foreach` / `lmap` / `dict for` / `dict map`) — every
+    /// argument shares one expected type instead of a per-index one.
+    is_foreach_header: bool,
+    /// Span used for any argument index `arg_spans` doesn't cover — a
+    /// synthetic call built without per-word token spans (some test
+    /// fixtures) or a substitution word count `arg_spans` didn't fully
+    /// resolve.
+    fallback_span: Span,
+}
+
 /// Check one command invocation's arguments for an intrep mismatch
 /// against the variables' known types. Used for both a top-level
 /// [`Statement::Call`] and a `[cmd …]` substitution lifted out of a
 /// [`Statement::AssignValue`] value (`set b [lindex $x 0]`).
+///
+/// Two narrower residual gaps remain, both strictly better than today's "no
+/// alias detection at all":
+/// - Argument *indices* are unadjusted, so an alias that prepends fixed
+///   arguments (`interp alias {} foo {} ::bar prefix`) can index-shift the
+///   wrong argument.
+/// - A read-modify-write shimmering argument that is a **bare variable
+///   name**, not a `$`-prefixed read (`incr`/`append`/`lappend`'s target) is
+///   never seen here even when aliased: `is_pure_var_ref` below only matches
+///   `$`-style reads, and `incr`'s own canonical name bypasses this function
+///   entirely via the dedicated [`Statement::Incr`] node (see
+///   [`check_incr_var`]) — a form `lower_command` only builds for the literal
+///   command name, not an alias target.
 fn check_invocation(
     ctx: &mut UseSiteCtx<'_>,
-    command: &str,
-    args: &[String],
-    span: Span,
+    site: &InvocationSite<'_>,
     uses: &HashMap<Symbol, u32>,
 ) {
+    let InvocationSite {
+        command,
+        lookup_command,
+        args,
+        arg_spans,
+        is_foreach_header,
+        fallback_span,
+    } = *site;
     let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
     for (i, word) in args.iter().enumerate() {
-        let Some(expected) = arg_shimmer_type(ctx.registry, command, &arg_refs, i) else {
+        let expected = if is_foreach_header {
+            foreach_header_expected_type(ctx.registry, lookup_command)
+        } else {
+            arg_shimmer_type(ctx.registry, lookup_command, &arg_refs, i)
+        };
+        let Some(expected) = expected else {
             continue;
         };
         // Only flag pure variable references — complex words may produce
@@ -304,6 +387,7 @@ fn check_invocation(
         } else {
             DiagCode::S100
         };
+        let span = arg_spans.get(i).copied().unwrap_or(fallback_span);
         ctx.out.push(ShimmerWarning {
             span,
             variable: var.clone(),
@@ -326,18 +410,92 @@ fn check_invocation(
 
 fn check_statement(ctx: &mut UseSiteCtx<'_>, stmt: &Statement, uses: &HashMap<Symbol, u32>) {
     match stmt {
-        Statement::Call { command, args, .. } => {
-            check_invocation(ctx, command, args, stmt.span(), uses);
+        Statement::Call {
+            command,
+            args,
+            tokens,
+            foreach_groups,
+            ..
+        } => {
+            let lookup = stmt.canonical_command_or_source();
+            // `tokens.argv[0]` is the command word; `argv[1..]` are the
+            // per-argument spans, index-aligned with `args` (both are the
+            // literal source words — alias resolution never reorders or
+            // reparents them, see `check_invocation`'s doc comment).
+            let arg_spans: Vec<Span> = tokens
+                .as_ref()
+                .map(|t| t.argv.iter().skip(1).copied().collect())
+                .unwrap_or_default();
+            check_invocation(
+                ctx,
+                &InvocationSite {
+                    command,
+                    lookup_command: lookup,
+                    args,
+                    arg_spans: &arg_spans,
+                    is_foreach_header: foreach_groups.is_some(),
+                    fallback_span: stmt.span(),
+                },
+                uses,
+            );
         }
 
         // A command substitution lifted into an assignment value
         // (`set b [lindex $x 0]`) reads its arguments just like a direct
-        // call.
-        Statement::AssignValue { value, .. } => {
-            if let Some((command, args)) =
+        // call. The substitution's own command word is re-parsed from raw
+        // text (no lowering pass resolves it), so no `interp alias`
+        // resolution is available here — the lookup key is the source
+        // spelling itself.
+        Statement::AssignValue { value, tokens, .. } => {
+            // The value word's own absolute span (`argv`'s last entry —
+            // `set name value` is always two args) anchors the re-lexed
+            // substitution's relative spans; falls back to the
+            // whole-statement span when tokens aren't available (some test
+            // fixtures build `AssignValue` without them).
+            let value_base = tokens
+                .as_ref()
+                .and_then(|t| t.argv.last())
+                .map(|sp| sp.start());
+            if let (Some(base), Some((command, args_with_spans))) = (
+                value_base,
+                crate::value_shapes::parse_command_substitution_with_spans(value),
+            ) {
+                let args: Vec<String> = args_with_spans.iter().map(|(a, _)| a.clone()).collect();
+                let arg_spans: Vec<Span> = args_with_spans
+                    .iter()
+                    .map(|(_, rel)| Span::new(base + rel.start(), base + rel.end()))
+                    .collect();
+                check_invocation(
+                    ctx,
+                    &InvocationSite {
+                        command: &command,
+                        lookup_command: &command,
+                        args: &args,
+                        arg_spans: &arg_spans,
+                        is_foreach_header: false,
+                        fallback_span: stmt.span(),
+                    },
+                    uses,
+                );
+            } else if let Some((command, args)) =
                 crate::value_shapes::parse_command_substitution(value.trim())
             {
-                check_invocation(ctx, &command, &args, stmt.span(), uses);
+                // Fallback for shapes the span-aware lexer-based parser
+                // rejects (no `tokens`, or an embedded `;`/newline second
+                // command) but the older bracket-counting parser still
+                // accepts — whole-statement span, same as before this fix.
+                check_invocation(
+                    ctx,
+                    &InvocationSite {
+                        command: &command,
+                        lookup_command: &command,
+                        args: &args,
+                        arg_spans: &[],
+                        is_foreach_header: false,
+                        fallback_span: stmt.span(),
+                    },
+                    uses,
+                );
             }
         }
 
@@ -512,6 +670,95 @@ mod tests {
         assert_eq!(w.unwrap().to_type, TclType::List);
     }
 
+    /// The warning's span is tight around the offending `$x` argument, not
+    /// the whole `lindex $x 0` invocation — the developer's eye should land
+    /// on the variable, not have to scan the whole call.
+    #[test]
+    fn shimmer_span_is_tight_around_call_argument() {
+        let src = "set x 5\nlindex $x 0";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "lindex")
+            .unwrap_or_else(|| panic!("expected lindex shimmer, got: {warnings:?}"));
+        let text = &src[w.span.start() as usize..w.span.end() as usize];
+        assert_eq!(
+            text, "$x",
+            "span should cover only the '$x' argument, got {text:?} from {w:?}"
+        );
+    }
+
+    /// Same tightness property through the `[cmd …]`-in-`AssignValue` path
+    /// (`set b [lindex $x 0]`) — the span still lands on `$x`, not the
+    /// whole `set b […]` statement.
+    #[test]
+    fn shimmer_span_is_tight_around_assign_value_substitution_argument() {
+        let src = "set x 5\nset b [lindex $x 0]";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "lindex")
+            .unwrap_or_else(|| panic!("expected lindex shimmer, got: {warnings:?}"));
+        let text = &src[w.span.start() as usize..w.span.end() as usize];
+        assert_eq!(
+            text, "$x",
+            "span should cover only the '$x' argument, got {text:?} from {w:?}"
+        );
+    }
+
+    /// Two shimmering arguments of the *same* call each get their *own*
+    /// tight span — proves the per-index span lookup, not just "arg 0's
+    /// span reused everywhere". `linsert list index element`: `list_var`
+    /// (String, arg 0) expects List; `index_var` (String, arg 1) expects
+    /// Int.
+    #[test]
+    fn shimmer_span_is_tight_per_argument_not_reused_across_args() {
+        let src = "set list_var hello\n\
+                    set index_var world\n\
+                    linsert $list_var $index_var x";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let list_w = warnings
+            .iter()
+            .find(|w| w.command == "linsert" && w.variable == "list_var")
+            .unwrap_or_else(|| panic!("expected linsert shimmer for list_var, got: {warnings:?}"));
+        let list_text = &src[list_w.span.start() as usize..list_w.span.end() as usize];
+        assert_eq!(list_text, "$list_var", "got {list_w:?}");
+
+        let index_w = warnings
+            .iter()
+            .find(|w| w.command == "linsert" && w.variable == "index_var")
+            .unwrap_or_else(|| panic!("expected linsert shimmer for index_var, got: {warnings:?}"));
+        let index_text = &src[index_w.span.start() as usize..index_w.span.end() as usize];
+        assert_eq!(index_text, "$index_var", "got {index_w:?}");
+    }
+
     /// A `foreach` element variable is typed String (list elements
     /// stringify); using it as a list intrep inside the loop body via a
     /// `[lindex $x 0]` command substitution re-thunks each iteration —
@@ -539,6 +786,120 @@ mod tests {
         assert_eq!(w.code, DiagCode::S101);
         assert_eq!(w.from_type, TclType::String);
         assert_eq!(w.to_type, TclType::List);
+    }
+
+    /// TP: `foreach`'s own list argument shimmers when the variable holds a
+    /// non-list intrep — the CFG builder lowers the header to a synthetic
+    /// `Statement::Call` (`command="foreach", args=[list_arg]`) that never
+    /// reaches the per-index `arg_types` path, so this is the
+    /// `foreach_header_expected_type` path specifically.
+    #[test]
+    fn shimmer_detected_for_foreach_header_list_argument() {
+        let src = "proc f {} {\n    set l hello\n    foreach x $l { puts $x }\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "foreach" && w.variable == "l")
+            .unwrap_or_else(|| panic!("expected foreach header shimmer, got: {warnings:?}"));
+        assert_eq!(w.from_type, TclType::String);
+        assert_eq!(w.to_type, TclType::List);
+    }
+
+    /// TN control: a genuine list variable in `foreach` must not shimmer.
+    #[test]
+    fn no_shimmer_for_foreach_header_with_real_list() {
+        let src = "proc f {} {\n    set l [list 1 2 3]\n    foreach x $l { puts $x }\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        assert!(
+            warnings.iter().all(|w| w.command != "foreach"),
+            "unexpected foreach header shimmer for a real list: {warnings:?}"
+        );
+    }
+
+    /// TP: `lmap`'s list argument shares the same synthetic header shape.
+    #[test]
+    fn shimmer_detected_for_lmap_header_list_argument() {
+        let src = "proc f {} {\n    set l hello\n    lmap x $l { set x $x }\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "lmap" && w.variable == "l")
+            .unwrap_or_else(|| panic!("expected lmap header shimmer, got: {warnings:?}"));
+        assert_eq!(w.from_type, TclType::String);
+        assert_eq!(w.to_type, TclType::List);
+    }
+
+    /// TP: `dict for`'s dict argument shimmers to Dict — the compound
+    /// two-word command name (`"dict for"`) routes through the `dict`
+    /// subcommand table via `foreach_header_expected_type`'s split.
+    #[test]
+    fn shimmer_detected_for_dict_for_header_argument() {
+        let src = "proc f {} {\n    set d hello\n    dict for {k v} $d { puts $k }\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "dict for" && w.variable == "d")
+            .unwrap_or_else(|| panic!("expected dict-for header shimmer, got: {warnings:?}"));
+        assert_eq!(w.from_type, TclType::String);
+        assert_eq!(w.to_type, TclType::Dict);
+    }
+
+    /// TP: `dict map` shares `dict for`'s compound-name dispatch.
+    #[test]
+    fn shimmer_detected_for_dict_map_header_argument() {
+        let src = "proc f {} {\n    set d hello\n    dict map {k v} $d { set v $v }\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "dict map" && w.variable == "d")
+            .unwrap_or_else(|| panic!("expected dict-map header shimmer, got: {warnings:?}"));
+        assert_eq!(w.from_type, TclType::String);
+        assert_eq!(w.to_type, TclType::Dict);
     }
 
     /// A loop-invariant variable (defined outside the loop) coerced to a
@@ -619,6 +980,62 @@ mod tests {
         assert!(
             lindex_shimmers.is_empty(),
             "unexpected shimmer for Unknown type: {lindex_shimmers:?}"
+        );
+    }
+
+    /// TP: a call through an `interp alias` to a shimmering builtin is still
+    /// detected — the registry lookup keys off the resolved
+    /// `canonical_command`, not the alias's source spelling.
+    #[test]
+    fn shimmer_detected_through_interp_alias_to_lindex() {
+        let cu = CompilationUnit::build_for(
+            "interp alias {} myindex {} ::lindex\nset x hello\nmyindex $x 0",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let w = warnings.iter().find(|w| w.variable == "x");
+        assert!(
+            w.is_some(),
+            "expected shimmer through interp alias, got: {warnings:?}"
+        );
+        let w = w.unwrap();
+        assert_eq!(w.from_type, TclType::String);
+        assert_eq!(w.to_type, TclType::List);
+        // The message keeps the alias spelling the user wrote, not the
+        // resolved canonical target.
+        assert_eq!(w.command, "myindex");
+    }
+
+    /// TN control: an alias to a *non*-shimmering command (`puts`) must not
+    /// spuriously fire just because the alias itself resolved.
+    #[test]
+    fn no_shimmer_through_interp_alias_to_non_shimmering_command() {
+        let cu = CompilationUnit::build_for(
+            "interp alias {} say {} ::puts\nset x hello\nsay $x",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        assert!(
+            warnings.iter().all(|w| w.variable != "x"),
+            "unexpected shimmer through non-shimmering alias: {warnings:?}"
         );
     }
 }

--- a/rust/tcl-compiler/src/value_shapes.rs
+++ b/rust/tcl-compiler/src/value_shapes.rs
@@ -18,6 +18,8 @@
 
 //! Shared Tcl value-shape helpers used across compiler passes.
 
+use tcl_lexer::{Lexer, Span, TokenType};
+
 /// Scan one Tcl variable reference starting at `text[at]`, returning the
 /// byte index just past its end, or `None` when `text[at..]` does not
 /// start with a valid reference.
@@ -115,6 +117,102 @@ pub fn parse_command_substitution(text: &str) -> Option<(String, Vec<String>)> {
     let cmd = parts.next()?;
     let args: Vec<String> = parts.collect();
     Some((cmd, args))
+}
+
+/// Like [`parse_command_substitution`], but additionally returns each
+/// argument's byte span *within `text`* (the caller adds its own base
+/// offset to get an absolute source position) — for diagnostics that need
+/// to anchor on the specific offending argument rather than the whole
+/// substitution.
+///
+/// Uses the real [`Lexer`] rather than [`split_top_level_words`]'s
+/// hand-rolled bracket/brace counter, so word boundaries follow Tcl's
+/// actual quoting rules (this also makes it correct on inputs the counter
+/// gets wrong, e.g. a `#` comment or an escaped delimiter at the top
+/// level). Returns `None` for the same shapes as
+/// [`parse_command_substitution`], plus when the bracket body doesn't lex
+/// as a single command (an embedded `;`/newline followed by more words).
+#[must_use]
+pub fn parse_command_substitution_with_spans(text: &str) -> Option<(String, Vec<(String, Span)>)> {
+    let leading_ws = u32::try_from(text.len() - text.trim_start().len()).unwrap_or(u32::MAX);
+    let stripped = text.trim();
+    let inner = stripped.strip_prefix('[')?.strip_suffix(']')?;
+    // Offset of `inner`'s first byte within `text`: leading whitespace + `[`.
+    let base = leading_ws + 1;
+
+    let tokens = Lexer::new(inner).tokenise_all().ok()?;
+    let mut words: Vec<(String, Span)> = Vec::new();
+    let mut prev_kind = TokenType::Eol;
+    let mut saw_terminator = false;
+
+    for tok in &tokens {
+        match tok.kind {
+            TokenType::Comment | TokenType::Sep => {
+                prev_kind = tok.kind;
+                continue;
+            }
+            TokenType::Eol => {
+                if !words.is_empty() {
+                    saw_terminator = true;
+                }
+                prev_kind = tok.kind;
+                continue;
+            }
+            TokenType::Eof => break,
+            _ => {}
+        }
+        if saw_terminator {
+            return None;
+        }
+        let (word_text, tok_end) = widened_token_text(inner, tok)?;
+        let abs_span = Span::new(base + tok.span.start(), base + tok_end);
+        if matches!(prev_kind, TokenType::Sep | TokenType::Eol) || words.is_empty() {
+            words.push((word_text, abs_span));
+        } else {
+            // Adjacent tokens with no separator concatenate onto the
+            // previous word (e.g. `$a$b` or `foo$x`).
+            let (last_text, last_span) =
+                words.last_mut().expect("words is non-empty in this branch");
+            last_text.push_str(&word_text);
+            *last_span = Span::new(last_span.start(), abs_span.end());
+        }
+        prev_kind = tok.kind;
+    }
+
+    let mut it = words.into_iter();
+    let (cmd, _cmd_span) = it.next()?;
+    Some((cmd, it.collect()))
+}
+
+/// Return `tok`'s text and exclusive end offset (both relative to `inner`),
+/// widened to include a `{…}` / `[…]` word's closing delimiter when the raw
+/// token span omits it.
+///
+/// The lexer follows an inner-end convention for `Str` (`{…}`) and `Cmd`
+/// (`[…]`) tokens: a *non-empty* group's span ends one byte before its
+/// closer (see `segmenter::widen_word_end`, the same convention this
+/// mirrors). An *empty* group (`{}` / `[]`) is the exception — its span
+/// already covers the closer. The discriminator used here is the extracted
+/// text itself: if it doesn't already end with the closer, the group is
+/// non-empty and one more byte is pulled in.
+fn widened_token_text(inner: &str, tok: &tcl_lexer::Token) -> Option<(String, u32)> {
+    let start = tok.span.start() as usize;
+    let end = tok.span.end() as usize;
+    let text = inner.get(start..end)?;
+    let closer = match tok.kind {
+        TokenType::Str => '}',
+        TokenType::Cmd => ']',
+        _ => return Some((text.to_owned(), tok.span.end())),
+    };
+    if text.ends_with(closer) {
+        return Some((text.to_owned(), tok.span.end()));
+    }
+    let widened_end = end + closer.len_utf8();
+    let widened = inner.get(start..widened_end)?;
+    Some((
+        widened.to_owned(),
+        u32::try_from(widened_end).unwrap_or(u32::MAX),
+    ))
 }
 
 /// Split a command body into words on top-level whitespace, keeping
@@ -264,5 +362,92 @@ mod tests {
         let (cmd, args) = parse_command_substitution("[pwd]").unwrap();
         assert_eq!(cmd, "pwd");
         assert!(args.is_empty());
+    }
+
+    #[test]
+    fn spans_basic_arg_offsets_are_exact() {
+        let text = "[lindex $x 0]";
+        let (cmd, args) = parse_command_substitution_with_spans(text).unwrap();
+        assert_eq!(cmd, "lindex");
+        assert_eq!(args.len(), 2);
+        let (x_text, x_span) = &args[0];
+        assert_eq!(x_text, "$x");
+        assert_eq!(&text[x_span.start() as usize..x_span.end() as usize], "$x");
+        let (zero_text, zero_span) = &args[1];
+        assert_eq!(zero_text, "0");
+        assert_eq!(
+            &text[zero_span.start() as usize..zero_span.end() as usize],
+            "0"
+        );
+    }
+
+    #[test]
+    fn spans_account_for_leading_whitespace_and_inner_padding() {
+        let text = "  [ set x 42 ]  ";
+        let (cmd, args) = parse_command_substitution_with_spans(text).unwrap();
+        assert_eq!(cmd, "set");
+        let (x_text, x_span) = &args[0];
+        assert_eq!(x_text, "x");
+        assert_eq!(&text[x_span.start() as usize..x_span.end() as usize], "x");
+        let (v_text, v_span) = &args[1];
+        assert_eq!(v_text, "42");
+        assert_eq!(&text[v_span.start() as usize..v_span.end() as usize], "42");
+    }
+
+    #[test]
+    fn spans_none_for_non_bracketed_or_empty() {
+        assert!(parse_command_substitution_with_spans("llength $x").is_none());
+        assert!(parse_command_substitution_with_spans("[]").is_none());
+    }
+
+    #[test]
+    fn spans_none_for_multiple_top_level_commands() {
+        // A second command after a newline/`;` inside the substitution body
+        // is not a single-command shape this helper models.
+        assert!(parse_command_substitution_with_spans("[set x 1; set y 2]").is_none());
+    }
+
+    #[test]
+    fn spans_nested_command_substitution_keeps_full_bracket_text() {
+        let text = "[list [read $fd]]";
+        let (cmd, args) = parse_command_substitution_with_spans(text).unwrap();
+        assert_eq!(cmd, "list");
+        assert_eq!(args.len(), 1);
+        let (nested_text, nested_span) = &args[0];
+        assert_eq!(nested_text, "[read $fd]");
+        assert_eq!(
+            &text[nested_span.start() as usize..nested_span.end() as usize],
+            "[read $fd]"
+        );
+    }
+
+    #[test]
+    fn spans_braced_arg_keeps_full_brace_text() {
+        let text = "[list {a b c}]";
+        let (cmd, args) = parse_command_substitution_with_spans(text).unwrap();
+        assert_eq!(cmd, "list");
+        let (braced_text, braced_span) = &args[0];
+        assert_eq!(braced_text, "{a b c}");
+        assert_eq!(
+            &text[braced_span.start() as usize..braced_span.end() as usize],
+            "{a b c}"
+        );
+    }
+
+    #[test]
+    fn spans_empty_group_arg_not_overwidened() {
+        let text = "[list {} x]";
+        let (cmd, args) = parse_command_substitution_with_spans(text).unwrap();
+        assert_eq!(cmd, "list");
+        assert_eq!(args.len(), 2);
+        let (empty_text, empty_span) = &args[0];
+        assert_eq!(empty_text, "{}");
+        assert_eq!(
+            &text[empty_span.start() as usize..empty_span.end() as usize],
+            "{}"
+        );
+        let (x_text, x_span) = &args[1];
+        assert_eq!(x_text, "x");
+        assert_eq!(&text[x_span.start() as usize..x_span.end() as usize], "x");
     }
 }

--- a/rust/tcl-compiler/src/value_shapes.rs
+++ b/rust/tcl-compiler/src/value_shapes.rs
@@ -199,10 +199,8 @@ fn widened_token_text(inner: &str, tok: &tcl_lexer::Token) -> Option<(String, u3
     let start = tok.span.start() as usize;
     let end = tok.span.end() as usize;
     let text = inner.get(start..end)?;
-    let closer = match tok.kind {
-        TokenType::Str => '}',
-        TokenType::Cmd => ']',
-        _ => return Some((text.to_owned(), tok.span.end())),
+    let Some(closer) = tok.kind.group_closer() else {
+        return Some((text.to_owned(), tok.span.end()));
     };
     if text.ends_with(closer) {
         return Some((text.to_owned(), tok.span.end()));

--- a/rust/tcl-compiler/src/var_observability.rs
+++ b/rust/tcl-compiler/src/var_observability.rs
@@ -250,6 +250,37 @@ impl VarObservability<'_> {
         }
         names
     }
+
+    /// Whole-function union: every name that is ever under a `trace` at any
+    /// point in the body — [`Self::escaping_var_names`] narrowed to the
+    /// `TRACED` flag alone (excluding a plain `global` / `variable` /
+    /// `upvar` alias with no trace). The flow-insensitive view: a trace
+    /// added partway through the function is treated as covering the whole
+    /// function, the same conservative widening [`Self::escaping_var_names`]
+    /// already applies for SCCP.
+    #[must_use]
+    pub fn traced_var_names(&self) -> std::collections::HashSet<String> {
+        let mut names = std::collections::HashSet::new();
+        for block in &self.ordered_blocks {
+            let mut state = self.block_entry.get(block).cloned().unwrap_or_default();
+            collect_traced(&state, &mut names);
+            if let Some(blk) = self.cfg.blocks.get(block) {
+                for stmt in &blk.statements {
+                    stmt_gen(stmt, &mut state);
+                    collect_traced(&state, &mut names);
+                }
+            }
+        }
+        names
+    }
+}
+
+fn collect_traced(state: &State, names: &mut std::collections::HashSet<String>) {
+    for (name, flag) in state {
+        if flag.is_traced() {
+            names.insert(name.clone());
+        }
+    }
 }
 
 fn collect_escaping(state: &State, names: &mut std::collections::HashSet<String>) {
@@ -550,6 +581,25 @@ mod tests {
         let obs = analyse_var_observability(&fu.cfg);
         assert!(obs.is_traced_at(fu.cfg.entry, 2, "t"));
         assert!(obs.escaping_var_names().contains("t"));
+        assert!(obs.traced_var_names().contains("t"));
+    }
+
+    /// [`VarObservability::traced_var_names`] narrows `escaping_var_names`
+    /// to the `TRACED` flag alone — a plain alias with no trace (`global g`)
+    /// must not appear in it, even though it does appear in the broader
+    /// `escaping_var_names` set.
+    #[test]
+    fn traced_var_names_excludes_untraced_aliases() {
+        let c = cu("proc ::p {} { global g\nset g 1\ntrace add variable t write cb\nset t 1 }");
+        let fu = c.function("::p").unwrap();
+        let obs = analyse_var_observability(&fu.cfg);
+        assert!(obs.escaping_var_names().contains("g"));
+        assert!(obs.escaping_var_names().contains("t"));
+        assert!(
+            !obs.traced_var_names().contains("g"),
+            "an untraced global alias must not appear in traced_var_names"
+        );
+        assert!(obs.traced_var_names().contains("t"));
     }
 
     #[test]

--- a/rust/tcl-lexer/src/tokens.rs
+++ b/rust/tcl-lexer/src/tokens.rs
@@ -64,6 +64,22 @@ pub enum TokenType {
 }
 
 impl TokenType {
+    /// The closing delimiter stripped from this token kind's text (`Str` →
+    /// `}`, `Cmd` → `]`), or `None` for a kind that isn't a bracketed group.
+    /// A group token's raw span may or may not include its closer — see
+    /// the "inner-end convention" this closer feeds into at each call site
+    /// (`segmenter::widen_word_end`, `value_shapes::widened_token_text`).
+    #[must_use]
+    pub const fn group_closer(self) -> Option<char> {
+        match self {
+            Self::Str => Some('}'),
+            Self::Cmd => Some(']'),
+            _ => None,
+        }
+    }
+}
+
+impl TokenType {
     /// Symbolic name of the variant — `"ESC"`, `"STR"`, etc.
     ///
     /// Used by the `PyO3` wrapper to mimic `enum.Enum.name` and by

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -397,22 +397,22 @@ pub fn bigip_code_actions(source: &str, range: LspRange, uri: &str) -> Vec<CodeA
 }
 
 /// Lift the quick-fixes carried by **compiler-check** diagnostics whose span
-/// overlaps `range` into `CodeAction`s.
+/// overlaps `range` into `CodeAction`s, plus the synthetic shimmer-family
+/// "Suppress" action (see [`build_shimmer_noqa_suppress_action`]).
 ///
 /// The analyser-driven [`code_actions`] above only sees
 /// `AnalysisResult.diagnostics`.  The iRules control-flow warnings
 /// (IRULE5002 — unguarded `drop`/`reject`/`discard`; IRULE5004 — `DNS::return`
 /// without a following `return`) are produced by a *separate* pass
 /// (`tcl_compiler::irules_checks::find_unguarded_drop_warnings`, surfaced
-/// through `run_all_checks`) and carry their own insertion `CodeFix`es.  Among
-/// every compiler-check family, those are the only ones that attach a fix
+/// through `run_all_checks`) and carry their own insertion `CodeFix`es
 /// (`compiler_checks::Diagnostic::from_irules_check` is the sole constructor
-/// that populates `fixes`), so lifting *all* check fixes here is exactly the
-/// IRULE5002/5004 surfacing with no risk of double-offering an analyser fix.
+/// that populates `fixes`), so lifting them here carries no risk of
+/// double-offering an analyser fix.
 ///
 /// The caller passes the
 /// `run_all_checks` output (e.g. `CompilerDiagnostics::checks`); for a
-/// non-iRules dialect that list carries no fixes, so this returns empty.
+/// non-iRules dialect that list carries no `fixes`-bearing diagnostics.
 ///
 /// `disabled` is the resolved per-check toggle set
 /// (`tclLsp.diagnostics.<CODE> = false`).  A check whose code is disabled has
@@ -430,7 +430,7 @@ pub fn check_diagnostic_actions<S: std::hash::BuildHasher>(
     let line_index = LineIndex::new(source);
     let mut actions = Vec::new();
     for diag in checks {
-        if diag.fixes.is_empty() || disabled.contains(diag.code.as_str()) {
+        if disabled.contains(diag.code.as_str()) {
             continue;
         }
         let diag_start = line_index.position_at_utf16(diag.span.start(), source);
@@ -469,8 +469,70 @@ pub fn check_diagnostic_actions<S: std::hash::BuildHasher>(
                 data_group_definition: None,
             });
         }
+        if is_shimmer_family(diag.code)
+            && let Some(action) = build_shimmer_noqa_suppress_action(source, diag, &line_index)
+        {
+            actions.push(action);
+        }
     }
     actions
+}
+
+/// True for the shimmer diagnostic family (S100/S101/S102 — performance
+/// intrep-conversion; S110 — byte-array-corruption correctness), the set
+/// [`build_shimmer_noqa_suppress_action`] offers a suppression fix for.
+fn is_shimmer_family(code: DiagCode) -> bool {
+    matches!(
+        code,
+        DiagCode::S100 | DiagCode::S101 | DiagCode::S102 | DiagCode::S110
+    )
+}
+
+/// Build a `# noqa: <CODE>` suppression quick-fix for a shimmer-family
+/// diagnostic.
+///
+/// Unlike the semantic fixes above (a mechanical rewrite the analyser is
+/// confident preserves behaviour), there is no generally-safe *automatic*
+/// rewrite for a shimmer: the KCS-documented fix is to use a separate
+/// variable for the numeric/string use, which requires picking a name and
+/// judging the surrounding code — not something to apply unattended. The
+/// mechanical, always-safe action every diagnostic family in this project
+/// supports is the inline suppression directive (see
+/// `docs/kcs/kcs-howto-suppress-diagnostics.md`): `# noqa: CODE` on the line
+/// **before** the command. This inserts that line, indented to match the
+/// command's own line, immediately above it.
+///
+/// Returns `None` when the diagnostic's start offset doesn't resolve to a
+/// source line (defensive; `LineIndex` is built from the same `source`).
+fn build_shimmer_noqa_suppress_action(
+    source: &str,
+    diag: &tcl_compiler::compiler_checks::Diagnostic,
+    line_index: &LineIndex,
+) -> Option<CodeAction> {
+    let line = line_index.line_at(diag.span.start());
+    let line_start = line_index.line_start(line);
+    let line_text = source.get(line_start as usize..)?.lines().next()?;
+    let indent: String = line_text
+        .chars()
+        .take_while(|c| *c == ' ' || *c == '\t')
+        .collect();
+    let pos = line_index.position_at_utf16(line_start, source);
+    let insertion = LspRange {
+        start_line: pos.line,
+        start_character: pos.character.get(),
+        end_line: pos.line,
+        end_character: pos.character.get(),
+    };
+    Some(CodeAction {
+        title: format!("Suppress {} with a noqa comment", diag.code.as_str()),
+        edits: vec![crate::rename::TextEdit {
+            range: insertion,
+            new_text: format!("{indent}# noqa: {}\n", diag.code.as_str()),
+        }],
+        kind: ActionKind::QuickFix,
+        command: None,
+        data_group_definition: None,
+    })
 }
 
 /// Build the `Add '-nocomplain'` quick-fix for a W213
@@ -2442,6 +2504,103 @@ mod tests {
                 .iter()
                 .any(|a| a.title == "Add 'event disable all' + 'return'"),
             "disabled IRULE5002 must not offer a quick-fix, got {actions:?}",
+        );
+    }
+
+    // check_diagnostic_actions: shimmer-family noqa-suppress action
+
+    /// A shimmering `incr` on a String variable fires S100 with no
+    /// `CodeFix` attached (there is no generally-safe automatic rewrite —
+    /// see `build_shimmer_noqa_suppress_action`'s doc comment), so the
+    /// provider must synthesise the suppress action itself rather than
+    /// only lifting `diag.fixes`.
+    #[test]
+    fn check_actions_surface_shimmer_noqa_suppress_action() {
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        use tcl_compiler::compiler_checks::run_all_checks;
+
+        let registry = tcl_registry::CommandRegistry::build_default();
+        let src = "set x hello\nincr x\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let checks = run_all_checks(&cu, &registry, None);
+        let s100 = checks
+            .iter()
+            .find(|d| d.code == DiagCode::S100)
+            .unwrap_or_else(|| panic!("expected an S100 check, got {checks:?}"));
+        assert!(
+            s100.fixes.is_empty(),
+            "S100 should carry no diag-level CodeFix — this test exercises the synthetic path"
+        );
+
+        let none_disabled = std::collections::HashSet::new();
+        let actions =
+            check_diagnostic_actions(src, whole_document_range(src), &checks, &none_disabled);
+        let suppress = actions
+            .iter()
+            .find(|a| a.title == "Suppress S100 with a noqa comment");
+        assert!(
+            suppress.is_some(),
+            "expected an S100 noqa-suppress action, got {actions:?}"
+        );
+        let suppress = suppress.unwrap();
+        assert_eq!(suppress.kind, ActionKind::QuickFix);
+        assert_eq!(suppress.edits.len(), 1);
+        assert_eq!(suppress.edits[0].new_text, "# noqa: S100\n");
+        // Insertion (zero-width range) at the start of the `incr x` line —
+        // one line above where the current baseline text puts `incr x`.
+        assert_eq!(suppress.edits[0].range.start_line, 1);
+        assert_eq!(suppress.edits[0].range.start_character, 0);
+        assert_eq!(
+            suppress.edits[0].range.start_line,
+            suppress.edits[0].range.end_line
+        );
+        assert_eq!(
+            suppress.edits[0].range.start_character,
+            suppress.edits[0].range.end_character,
+        );
+    }
+
+    /// The suppress action's inserted line is indented to match the
+    /// command's own indentation, not flush to column 0.
+    #[test]
+    fn check_actions_shimmer_noqa_suppress_matches_indentation() {
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        use tcl_compiler::compiler_checks::run_all_checks;
+
+        let registry = tcl_registry::CommandRegistry::build_default();
+        let src = "proc f {} {\n    set x hello\n    incr x\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let checks = run_all_checks(&cu, &registry, None);
+        assert!(checks.iter().any(|d| d.code == DiagCode::S100));
+
+        let none_disabled = std::collections::HashSet::new();
+        let actions =
+            check_diagnostic_actions(src, whole_document_range(src), &checks, &none_disabled);
+        let suppress = actions
+            .iter()
+            .find(|a| a.title == "Suppress S100 with a noqa comment")
+            .unwrap_or_else(|| panic!("expected suppress action, got {actions:?}"));
+        assert_eq!(suppress.edits[0].new_text, "    # noqa: S100\n");
+    }
+
+    /// A disabled shimmer code must not offer the suppress action either —
+    /// same "don't re-surface a hidden warning" rule as `IRULE5002` above.
+    #[test]
+    fn check_actions_shimmer_noqa_suppress_honours_disabled_codes() {
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        use tcl_compiler::compiler_checks::run_all_checks;
+
+        let registry = tcl_registry::CommandRegistry::build_default();
+        let src = "set x hello\nincr x\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let checks = run_all_checks(&cu, &registry, None);
+
+        let mut disabled = std::collections::HashSet::new();
+        disabled.insert("S100".to_string());
+        let actions = check_diagnostic_actions(src, whole_document_range(src), &checks, &disabled);
+        assert!(
+            !actions.iter().any(|a| a.title.starts_with("Suppress S100")),
+            "disabled S100 must not offer a suppress action, got {actions:?}",
         );
     }
 

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1480,10 +1480,7 @@ pub fn proc_taint_solve<'db>(
     // identical second loop (see that function's doc comment for why: these
     // never get an offset-0 `FnLatticeKey`, so they carry absolute spans
     // already and need no rebase, same as the `None` arm above).
-    for fu in cu.methods.values().chain(cu.body_units.values()) {
-        if fu.complexity_guarded {
-            continue;
-        }
+    for fu in cu.analysable_methods_and_body_units() {
         for d in tcl_compiler::compiler_checks::shimmer_family_checks(fu, &registry, dialect_opt) {
             fn_checks.push(d);
         }

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1474,6 +1474,21 @@ pub fn proc_taint_solve<'db>(
         }
     }
 
+    // The intrep-shimmer family alone, extended to `TclOO` method bodies and
+    // synthetic body units (`apply` lambdas, `namespace eval` bodies) —
+    // mirrors `compiler_checks::run_all_checks_with_solved_and_patterns`'s
+    // identical second loop (see that function's doc comment for why: these
+    // never get an offset-0 `FnLatticeKey`, so they carry absolute spans
+    // already and need no rebase, same as the `None` arm above).
+    for fu in cu.methods.values().chain(cu.body_units.values()) {
+        if fu.complexity_guarded {
+            continue;
+        }
+        for d in tcl_compiler::compiler_checks::shimmer_family_checks(fu, &registry, dialect_opt) {
+            fn_checks.push(d);
+        }
+    }
+
     let optimisations = solve_optimisations(db, &cu, &lattice_keys, &registry, dialect_opt);
     Arc::new(CheckSolve {
         taints,

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1475,11 +1475,16 @@ pub fn proc_taint_solve<'db>(
     }
 
     // The intrep-shimmer family alone, extended to `TclOO` method bodies and
-    // synthetic body units (`apply` lambdas, `namespace eval` bodies) —
-    // mirrors `compiler_checks::run_all_checks_with_solved_and_patterns`'s
-    // identical second loop (see that function's doc comment for why: these
-    // never get an offset-0 `FnLatticeKey`, so they carry absolute spans
-    // already and need no rebase, same as the `None` arm above).
+    // synthetic body units (`apply` lambdas, `namespace eval` bodies). The
+    // main per-function loop above still iterates the proc-only
+    // `analysable_functions`, unlike `compiler_checks::run_all_checks_with_solved_and_patterns`'s
+    // direct path (which iterates the wider `all_body_function_units` and so
+    // needs no separate top-up — see `analysable_methods_and_body_units`'s
+    // own doc comment for why adding it there too would double-count), so
+    // this memoised path needs its own top-up loop to reach the same
+    // methods/body units. These never get an offset-0 `FnLatticeKey`, so
+    // they carry absolute spans already and need no rebase, same as the
+    // `None` arm above.
     for fu in cu.analysable_methods_and_body_units() {
         for d in tcl_compiler::compiler_checks::shimmer_family_checks(fu, &registry, dialect_opt) {
             fn_checks.push(d);

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1516,6 +1516,7 @@ async fn refine_and_lift_diagnostics(
             optimiser_enabled,
             &opt_disabled,
             &disabled,
+            &analysis_lifts.suppressed_lines,
         ));
         diagnostics.extend(lift_source_style_diagnostics(
             &lift_text,
@@ -5189,6 +5190,7 @@ impl Backend {
                 optimiser_enabled,
                 &opt_disabled,
                 &disabled,
+                &analysis.suppressed_lines,
             ));
             diagnostics.extend(lift_source_style_diagnostics(
                 &text,
@@ -7860,29 +7862,29 @@ impl LanguageServer for Backend {
                     &doc.text, range, &uri_str,
                 ));
             }
-            // iRules-only: the `# Profiles:` header source action plus the
-            // control-flow quick-fixes (IRULE5002 unguarded drop / IRULE5004
-            // DNS::return) the analyser produces through the compiler-checks
-            // pass rather than `AnalysisResult.diagnostics`.  Only the iRules
-            // dialect's checks carry fixes, so the (re-)lowering is gated here.
-            if dialect == "f5-irules" {
-                if let Some(a) = core_code_actions::profiles_action(&doc.text, &analysis, &registry)
-                {
-                    actions.push(a);
-                }
-                let checks = tcl_lsp_db::compiler_check_diagnostics_uncached(
-                    &doc.text,
-                    &registry,
-                    &dialect,
-                    generic_patterns.as_deref(),
-                );
-                actions.extend(core_code_actions::check_diagnostic_actions(
-                    &doc.text,
-                    range,
-                    &checks.checks,
-                    &disabled_codes,
-                ));
+            // iRules-only: the `# Profiles:` header source action.
+            if dialect == "f5-irules"
+                && let Some(a) = core_code_actions::profiles_action(&doc.text, &analysis, &registry)
+            {
+                actions.push(a);
             }
+            // Compiler-check quick-fixes: the iRules control-flow fixes
+            // (IRULE5002 unguarded drop / IRULE5004 DNS::return) plus the
+            // shimmer-family noqa-suppress action (S100/S101/S102/S110) —
+            // every dialect's checks are lowered here, not just iRules'; a
+            // plain-Tcl document's checks simply carry no IRULE-family fixes.
+            let checks = tcl_lsp_db::compiler_check_diagnostics_uncached(
+                &doc.text,
+                &registry,
+                &dialect,
+                generic_patterns.as_deref(),
+            );
+            actions.extend(core_code_actions::check_diagnostic_actions(
+                &doc.text,
+                range,
+                &checks.checks,
+                &disabled_codes,
+            ));
             actions
         })
         .await
@@ -9399,10 +9401,13 @@ fn lift_config_diagnostic(
 }
 
 /// Whether `code` is suppressed at `line` by an inline `# noqa` or a
-/// top-of-file `# tcl-lsp: disable=…` directive — the same `_is_suppressed`
+/// top-of-file `# tcl-lsp: disable=…` directive — the same `is_suppressed`
 /// contract `tcl_lsp_core::source_style` applies (a `"*"` entry suppresses
-/// every code; the file-level `-1` bucket is document-wide).
-fn xc_is_suppressed(
+/// every code; the file-level `-1` bucket is document-wide). Shared by every
+/// diagnostic family this module lifts directly (XC, compiler-checks);
+/// `lift_analyser_diagnostics` / `lift_source_style_diagnostics` apply the
+/// same contract via `tcl_lsp_core`'s own (private) copy.
+fn line_suppressed(
     code: &str,
     line: i32,
     suppressed: &std::collections::HashMap<i32, HashSet<String>>,
@@ -9432,7 +9437,7 @@ fn lift_xc_diagnostics(
         .into_iter()
         .filter(|d| !disabled.contains(&d.code))
         .filter(|d| {
-            !xc_is_suppressed(
+            !line_suppressed(
                 &d.code,
                 i32::try_from(d.range.start.line).unwrap_or(i32::MAX),
                 suppressed,
@@ -10058,6 +10063,7 @@ fn lift_compiler_diagnostics(
     optimiser_enabled: bool,
     disabled_optimisations: &std::collections::HashSet<String>,
     disabled_diagnostics: &std::collections::HashSet<String>,
+    suppressed_lines: &std::collections::HashMap<i32, HashSet<String>>,
 ) -> Vec<tower_lsp_server::ls_types::Diagnostic> {
     use tcl_compiler::compiler_checks::Severity as CheckSeverity;
     use tower_lsp_server::ls_types::{DiagnosticSeverity, NumberOrString};
@@ -10092,8 +10098,17 @@ fn lift_compiler_diagnostics(
         if disabled_diagnostics.contains(d.code.as_str()) {
             continue;
         }
+        let range = lift_span(text, &line_index, d.span);
+        // Inline `# noqa` / top-of-file suppression. The analyser path bakes
+        // `suppressed_lines` into its own build; this separate lift needs the
+        // same check applied explicitly — previously missing entirely, so
+        // `# noqa: S100` (and every other compiler-check code) had no effect.
+        let start_line = i32::try_from(range.start.line).unwrap_or(i32::MAX);
+        if line_suppressed(d.code.as_str(), start_line, suppressed_lines) {
+            continue;
+        }
         out.push(tower_lsp_server::ls_types::Diagnostic {
-            range: lift_span(text, &line_index, d.span),
+            range,
             severity: Some(match d.severity {
                 CheckSeverity::Error => DiagnosticSeverity::ERROR,
                 CheckSeverity::Warning => DiagnosticSeverity::WARNING,
@@ -10128,6 +10143,13 @@ fn lift_compiler_diagnostics(
         if disabled_optimisations.contains(o.code.as_str()) {
             continue;
         }
+        let range = lift_span(text, &line_index, o.span);
+        // Inline `# noqa` / top-of-file suppression — see the `.checks` loop
+        // above for why this was previously missing.
+        let start_line = i32::try_from(range.start.line).unwrap_or(i32::MAX);
+        if line_suppressed(o.code.as_str(), start_line, suppressed_lines) {
+            continue;
+        }
         // Surface the fold/rewrite text as the quick-fix `data.replacement`, so
         // editors and the e2e battery can apply the suggested replacement.
         // Never for a `hint_only` optimisation: its span covers the whole
@@ -10146,7 +10168,7 @@ fn lift_compiler_diagnostics(
             })
         });
         out.push(tower_lsp_server::ls_types::Diagnostic {
-            range: lift_span(text, &line_index, o.span),
+            range,
             severity: Some(DiagnosticSeverity::HINT),
             code: Some(NumberOrString::String(o.code.to_string())),
             code_description: None,
@@ -11382,6 +11404,7 @@ mod tests {
             true,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
         );
         assert!(
             diags.iter().any(|d| matches!(
@@ -11407,6 +11430,7 @@ mod tests {
             false,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
         );
         assert!(
             !off.iter().any(is_o100),
@@ -11422,6 +11446,7 @@ mod tests {
             true,
             &disabled,
             &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
         );
         assert!(
             !per_code.iter().any(is_o100),
@@ -11446,6 +11471,7 @@ mod tests {
             true,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
         );
         assert!(
             diags.iter().any(|d| matches!(
@@ -11477,6 +11503,7 @@ mod tests {
             true,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
         );
         assert!(
             baseline.iter().any(is_irule3001),
@@ -11491,11 +11518,79 @@ mod tests {
             true,
             &std::collections::HashSet::new(),
             &disabled_diagnostics,
+            &std::collections::HashMap::new(),
         );
         assert!(
             !filtered.iter().any(is_irule3001),
             "IRULE3001 must be suppressed when disabled per-check: {:?}",
             filtered.iter().map(|d| d.code.clone()).collect::<Vec<_>>(),
+        );
+    }
+
+    /// `# noqa: S100` on the line before the shimmering command must
+    /// suppress it through the live compiler-checks lift — previously
+    /// `lift_compiler_diagnostics` never consulted `suppressed_lines` at
+    /// all, so `# noqa` had no effect on any compiler-check code (S1xx
+    /// shimmer, T1xx taint, IRULE1xxx-5xxx, O1xx, GVN, SCCP).
+    #[test]
+    fn lift_compiler_diagnostics_honours_inline_noqa_suppression() {
+        let registry = CommandRegistry::build_default();
+        let src = "set x hello\nincr x\n";
+        let is_s100 = |d: &tower_lsp_server::ls_types::Diagnostic| matches!(&d.code, Some(tower_lsp_server::ls_types::NumberOrString::String(c)) if c == "S100");
+
+        // Baseline: S100 fires with no suppression.
+        let baseline = lift_compiler_diagnostics(
+            src,
+            &tcl_lsp_db::compiler_check_diagnostics_uncached(src, &registry, "", None),
+            true,
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+            &std::collections::HashMap::new(),
+        );
+        assert!(baseline.iter().any(is_s100), "expected S100 baseline");
+
+        // `# noqa: S100` on the line before `incr x` suppresses it.
+        let suppressed_src = "set x hello\n# noqa: S100\nincr x\n";
+        let suppressed_lines = Analyser::new()
+            .analyse(suppressed_src, "tcl8.6")
+            .suppressed_lines
+            .clone();
+        let filtered = lift_compiler_diagnostics(
+            suppressed_src,
+            &tcl_lsp_db::compiler_check_diagnostics_uncached(suppressed_src, &registry, "", None),
+            true,
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+            &suppressed_lines,
+        );
+        assert!(
+            !filtered.iter().any(is_s100),
+            "S100 must be suppressed by a preceding '# noqa: S100', got: {:?}",
+            filtered.iter().map(|d| d.code.clone()).collect::<Vec<_>>(),
+        );
+
+        // TN control: a `# noqa` for an unrelated code must not incidentally
+        // suppress S100.
+        let unrelated_src = "set x hello\n# noqa: W999\nincr x\n";
+        let unrelated_suppressed = Analyser::new()
+            .analyse(unrelated_src, "tcl8.6")
+            .suppressed_lines
+            .clone();
+        let unfiltered = lift_compiler_diagnostics(
+            unrelated_src,
+            &tcl_lsp_db::compiler_check_diagnostics_uncached(unrelated_src, &registry, "", None),
+            true,
+            &std::collections::HashSet::new(),
+            &std::collections::HashSet::new(),
+            &unrelated_suppressed,
+        );
+        assert!(
+            unfiltered.iter().any(is_s100),
+            "S100 must still fire when the preceding noqa names an unrelated code: {:?}",
+            unfiltered
+                .iter()
+                .map(|d| d.code.clone())
+                .collect::<Vec<_>>(),
         );
     }
 

--- a/rust/tcl-lsp-server/tests/e2e/code_actions.rs
+++ b/rust/tcl-lsp-server/tests/e2e/code_actions.rs
@@ -745,7 +745,6 @@ fn test_no_profiles_action_for_tcl_dialect() {
     let sa = kinds(&actions, "source");
     assert!(sa.iter().all(|a| !action_title(a).contains("Profiles")));
 }
-
 // -- TestE100E102QuickFixes -----------------------------------------------
 
 #[test]
@@ -867,4 +866,23 @@ fn test_e102_no_fix_offered_for_embedded_brace() {
         "{:?}",
         titles(&actions)
     );
+}
+
+// -- TestShimmerNoqaSuppressQuickFix --------------------------------------
+
+#[test]
+fn test_s100_offers_noqa_suppress_action() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set x hello\nincr x\n");
+    let s100 = with_code(&diags, "S100");
+    assert!(!s100.is_empty(), "expected an S100 to drive the quick fix");
+    let actions = lsp.code_actions(&uri, range((1, 0), (1, 6)), json!(s100));
+    assert!(
+        titles(&actions)
+            .iter()
+            .any(|t| t == "Suppress S100 with a noqa comment"),
+        "expected an S100 noqa-suppress action, got {actions:?}"
+    );
+    assert!(new_texts(&actions).iter().any(|s| s == "# noqa: S100\n"));
 }

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -1944,3 +1944,99 @@ fn e103_abstains_when_missing_brace_swallows_more_than_one_statement() {
     assert!(!has_code(&diags, "E103"), "{:?}", codes(&diags));
     assert!(has_code(&diags, "E200"), "{:?}", codes(&diags));
 }
+
+#[test]
+fn shimmer_incr_on_string_is_s100_info_with_tight_range() {
+    // The range must cover only the `$x` argument — not the whole `incr x`
+    // call and not the `[lindex $x 0]` substitution around it.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set x hello\nlindex $x 0\n");
+    let s100: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("S100"))
+        .collect();
+    assert_eq!(s100.len(), 1, "expected exactly one S100: {diags:?}");
+    let range = &s100[0]["range"];
+    assert_eq!(range["start"]["line"], 1);
+    assert_eq!(range["start"]["character"], 7, "must start at '$x'");
+    assert_eq!(range["end"]["line"], 1);
+    assert_eq!(range["end"]["character"], 9, "must end after '$x'");
+    assert_eq!(
+        s100[0].get("severity").and_then(Value::as_i64),
+        Some(3), // Information
+        "S100 is informational: {:?}",
+        s100[0]
+    );
+}
+
+#[test]
+fn clean_list_used_with_lindex_has_no_s100() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set x [list 1 2 3]\nlindex $x 0\n");
+    assert!(!has_code(&diags, "S100"), "unexpected S100: {diags:?}");
+}
+
+#[test]
+fn shimmer_fires_inside_tcloo_method_body() {
+    // TclOO method bodies previously got zero shimmer coverage (the
+    // compiler-checks aggregator only walked the top level and procedures).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src =
+        "oo::class create C {\n    method m {} {\n        set x hello\n        incr x\n    }\n}\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        has_code(&diags, "S100"),
+        "expected S100 inside a TclOO method body: {diags:?}"
+    );
+}
+
+#[test]
+fn shimmer_fires_inside_namespace_eval_body() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "namespace eval ns {\n    set x hello\n    incr x\n}\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        has_code(&diags, "S100"),
+        "expected S100 inside a namespace eval body: {diags:?}"
+    );
+}
+
+#[test]
+fn shimmer_fires_through_interp_alias() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "interp alias {} myindex {} ::lindex\nset x hello\nmyindex $x 0\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        has_code(&diags, "S100"),
+        "expected S100 through an interp alias to a shimmering builtin: {diags:?}"
+    );
+}
+
+#[test]
+fn shimmer_noqa_suppresses_s100() {
+    // `# noqa: S100` on the line before the shimmering command must
+    // suppress it through the live publishDiagnostics pipeline.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set x hello\n# noqa: S100\nlindex $x 0\n");
+    assert!(
+        !has_code(&diags, "S100"),
+        "S100 must be suppressed by a preceding '# noqa: S100': {diags:?}"
+    );
+}
+
+#[test]
+fn shimmer_noqa_for_unrelated_code_does_not_suppress_s100() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set x hello\n# noqa: W100\nlindex $x 0\n");
+    assert!(
+        has_code(&diags, "S100"),
+        "S100 must still fire when the preceding noqa names an unrelated code: {diags:?}"
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -1982,26 +1982,43 @@ fn clean_list_used_with_lindex_has_no_s100() {
 fn shimmer_fires_inside_tcloo_method_body() {
     // TclOO method bodies previously got zero shimmer coverage (the
     // compiler-checks aggregator only walked the top level and procedures).
+    // Exactly one, not two: `tcl-lsp-db::proc_taint_solve` (the live server's
+    // memoised path) has its own top-up loop for methods/body units,
+    // independent of `compiler_checks.rs`'s direct path — a regression where
+    // both the top-up loop *and* the main loop covered methods/body units
+    // would double-emit every shimmer diagnostic inside one.
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     let src =
         "oo::class create C {\n    method m {} {\n        set x hello\n        incr x\n    }\n}\n";
     let diags = lsp.open_ready(&uri, src);
-    assert!(
-        has_code(&diags, "S100"),
-        "expected S100 inside a TclOO method body: {diags:?}"
+    let s100: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("S100"))
+        .collect();
+    assert_eq!(
+        s100.len(),
+        1,
+        "expected exactly one S100 inside a TclOO method body: {diags:?}"
     );
 }
 
 #[test]
 fn shimmer_fires_inside_namespace_eval_body() {
+    // Same double-count guard as `shimmer_fires_inside_tcloo_method_body`,
+    // for the other synthetic body-unit kind.
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     let src = "namespace eval ns {\n    set x hello\n    incr x\n}\n";
     let diags = lsp.open_ready(&uri, src);
-    assert!(
-        has_code(&diags, "S100"),
-        "expected S100 inside a namespace eval body: {diags:?}"
+    let s100: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("S100"))
+        .collect();
+    assert_eq!(
+        s100.len(),
+        1,
+        "expected exactly one S100 inside a namespace eval body: {diags:?}"
     );
 }
 

--- a/rust/tcl-registry/src/commands/tcl/binary_.rs
+++ b/rust/tcl-registry/src/commands/tcl/binary_.rs
@@ -53,10 +53,14 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "binary decode format data",
         pure: true,
         return_type: Some(TclType::ByteArray),
+        // `data` is arg 1 (sub-index 1: arg 0 is the `format` keyword, e.g.
+        // `hex`/`base64`). It is text-friendly *encoded* data being
+        // *decoded into* a byte array, so the shimmer-sensitive expectation
+        // is String, not ByteArray — the reverse of `encode` below.
         arg_types: &[(
-            0,
+            1,
             ArgTypeHint {
-                expected: Some(TclType::ByteArray),
+                expected: Some(TclType::String),
                 shimmers: true,
             },
         )],
@@ -71,8 +75,9 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "binary encode format data",
         pure: true,
         return_type: Some(TclType::String),
+        // `data` is arg 1 (sub-index 1: arg 0 is the `format` keyword).
         arg_types: &[(
-            0,
+            1,
             ArgTypeHint {
                 expected: Some(TclType::ByteArray),
                 shimmers: true,

--- a/rust/tcl-registry/src/commands/tcl/dict.rs
+++ b/rust/tcl-registry/src/commands/tcl/dict.rs
@@ -402,11 +402,15 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "dict getd dictionaryValue ?key ...? key default",
         pure: true,
         return_type: Some(TclType::String),
+        // Same dict-argument shape as plain `dict get`'s `SubCommand`: the
+        // key-path lookup forces a dict intrep on `dictionaryValue` exactly
+        // the same way, default value or not — `shimmers: false` here was
+        // an inconsistency, not a documented difference from `dict get`.
         arg_types: &[(
             0,
             ArgTypeHint {
                 expected: Some(TclType::Dict),
-                shimmers: false,
+                shimmers: true,
             },
         )],
         ..SubCommand::DEFAULT
@@ -420,11 +424,15 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "dict getdef dictionaryValue ?key ...? key default",
         pure: true,
         return_type: Some(TclType::String),
+        // Same dict-argument shape as plain `dict get`'s `SubCommand`: the
+        // key-path lookup forces a dict intrep on `dictionaryValue` exactly
+        // the same way, default value or not — `shimmers: false` here was
+        // an inconsistency, not a documented difference from `dict get`.
         arg_types: &[(
             0,
             ArgTypeHint {
                 expected: Some(TclType::Dict),
-                shimmers: false,
+                shimmers: true,
             },
         )],
         ..SubCommand::DEFAULT
@@ -438,11 +446,15 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "dict getwithdefault dictionaryValue ?key ...? key default",
         pure: true,
         return_type: Some(TclType::String),
+        // Same dict-argument shape as plain `dict get`'s `SubCommand`: the
+        // key-path lookup forces a dict intrep on `dictionaryValue` exactly
+        // the same way, default value or not — `shimmers: false` here was
+        // an inconsistency, not a documented difference from `dict get`.
         arg_types: &[(
             0,
             ArgTypeHint {
                 expected: Some(TclType::Dict),
-                shimmers: false,
+                shimmers: true,
             },
         )],
         ..SubCommand::DEFAULT

--- a/rust/tcl-registry/src/commands/tcl/foreach_.rs
+++ b/rust/tcl-registry/src/commands/tcl/foreach_.rs
@@ -57,6 +57,23 @@ pub fn spec() -> CommandSpec {
             | Traits::WASM_EMITS_NOTHING,
         arity: Arity::at_least(3),
         arg_role_resolver: Some(foreach_arg_roles),
+        // Index 0 here is a fixed key, not a real source-position argument
+        // index: the CFG builder lowers a `foreach` header to a synthetic
+        // `Statement::Call` whose `args` are *only* the list arguments (one
+        // per iterator group — the var-lists live in `defs`, not `args`; see
+        // `cfg_builder::cfg_lower::lower_foreach`). Every list argument
+        // expects the same List intrep (`$l` forces it via
+        // `TclListObjGetElements`, exactly like `llength`'s operand), so
+        // `shimmer::use_site::foreach_header_expected_type` reads this one
+        // entry and applies it uniformly to every iterator group, including
+        // the later ones a positional per-index table couldn't reach.
+        arg_types: &[(
+            0,
+            ArgTypeHint {
+                expected: Some(TclType::List),
+                shimmers: true,
+            },
+        )],
         lowering_hook: Some(crate::hooks::LoweringHookId::Foreach),
         return_type: Some(TclType::String),
         hover: Some(HoverSnippet {

--- a/rust/tcl-registry/src/commands/tcl/lmap_.rs
+++ b/rust/tcl-registry/src/commands/tcl/lmap_.rs
@@ -55,6 +55,16 @@ pub fn spec() -> CommandSpec {
         dialects: Some(DialectSet::TCL86_PLUS),
         arity: Arity::at_least(3),
         arg_role_resolver: Some(lmap_arg_roles),
+        // See `foreach`'s identical comment — index 0 is a fixed key read by
+        // `shimmer::use_site::foreach_header_expected_type`, not a real
+        // source-position argument index.
+        arg_types: &[(
+            0,
+            ArgTypeHint {
+                expected: Some(TclType::List),
+                shimmers: true,
+            },
+        )],
         lowering_hook: Some(crate::hooks::LoweringHookId::Lmap),
         return_type: Some(TclType::List),
         hover: Some(HoverSnippet {


### PR DESCRIPTION
## Summary

Deep review of the shimmer diagnostic family (S100/S101/S102) for correctness and precision against C Tcl 9 semantics, driven entirely through `CommandRegistry` data rather than command-specific knowledge in the compiler:

- Extend shimmer/taint checks to TclOO method bodies and synthetic body units (`namespace eval`, `apply` lambdas) — previously only top-level code and procs were walked, in both the direct compiler-checks path and the memoized `tcl-lsp-db` salsa query the live server actually uses.
- Resolve `interp alias` targets via `canonical_command` so an alias to a shimmering builtin is detected like the builtin itself.
- Tighten S100/S101 diagnostic spans to the offending argument or substitution instead of the whole statement, including per-argument spans for `foreach`/`lmap`/`dict for`/`dict map` loop headers.
- Fix registry data bugs: `foreach`/`lmap` loop-header list shimmer coverage, `binary decode`/`encode` argument-index mismatch, `dict getd`/`getdef` shimmer-consistency with plain `dict get`. All command-level knowledge stays in the `CommandRegistry` as data, not hard-coded in the compiler.
- Add a "Suppress \<CODE\> with a noqa comment" quick fix for the shimmer family (S100/S101/S102/S110), and fix a latent bug where `# noqa` never suppressed compiler-check diagnostics at all.
- Wire write-trace awareness (`EscapeFlag::TRACED`, same-function and module-wide) into type inference so a traced variable's type is never trusted for shimmer purposes.
- Fix a live-server-only dialect gate that hid the new quick fix outside f5-irules documents.

## Validation

- [x] `cargo fmt --check` + `cargo clippy` across the workspace — `make check-rust` and `make check-all`. Zero new clippy allows.
- [x] `cargo test --workspace --all-features` — `make test-rust` (11,902 tests, 0 failures).
- [x] VS Code extension integration suite — `make test-ext`, including a new `shimmerPrecision.test.ts` covering the full TP/FP/TN/FN matrix (tight-span S100, clean-list silence, interp-alias detection, TclOO/namespace-eval coverage, write-trace suppression, noqa suppression in both directions) plus a noqa quick-fix test, verified passing in isolation against both debug and release server builds.
- [x] Targeted unit tests across `shimmer/use_site.rs`, `shimmer/hints.rs`, `value_shapes.rs`, `var_observability.rs`; FP-SH-09 TP/FP regression tests; native `lsp_e2e` tests for tight spans, TclOO/namespace coverage, alias resolution, trace suppression, and noqa (both directions).

## Compiler/KCS checklist

N/A — this repository does not have a `docs/kcs/compiler/` directory. Docs updated instead: the S100/S101/S102 KCS pages' suppress instructions were wrong (said "end of line"; the mechanism is "line above"), and `docs/design/contracts/shimmer-reference-behaviour.md`'s cross-links pointed at the retired Python implementation — both fixed.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Hub3nJPH71ZhFZQEUBK94X)_