### PR TITLE
Extend E100/E201-E203 recovery's known-command hierarchy to rename, workspace, and package layers

### DIFF
--- a/editors/vscode/src/test/errorRecovery.test.ts
+++ b/editors/vscode/src/test/errorRecovery.test.ts
@@ -309,6 +309,65 @@ suite("Error Recovery (known-command generality)", () => {
       `tail proc not recovered past a namespace-qualified call; symbols=[${names}]`,
     );
   });
+
+  // The known-command signal extends past this file's own procs/classes/
+  // aliases to two more layers: a `rename OLD NEW` target (this file), a
+  // proc defined in a *different* workspace file the on-disk scan indexes
+  // without ever being opened (`workspaceSiblingHelper.tcl`), and a command
+  // a `package require`d library provides (`mypkglib/pkgIndex.tcl`, scanned
+  // the same way the pre-existing `rbclib` auto-load fixture is). Each is
+  // proven live the same way as the `my_helper` case above: a bare `string`
+  // chained onto the same line has no subcommand, which always draws its
+  // own E001 ("requires a subcommand") once analysed — independent of
+  // whatever recognised the target head.
+
+  test("a renamed command recovers the tail", async () => {
+    await activate(docUri);
+    const editor = vscode.window.activeTextEditor!;
+    const diags = await setContentAndWait(
+      editor,
+      docUri,
+      "rename puts my_puts\n\nset q {\n  aaa\nmy_puts hi; string\n",
+    );
+    assert.ok(hasRecoveryError(diags), `expected a recovery error: [${diags.map(codeOf)}]`);
+    assert.ok(
+      diags.some((d) => codeOf(d) === "E001"),
+      `renamed-command tail call should be live code (chained bare \`string\` \
+       has no subcommand): [${diags.map(codeOf)}]`,
+    );
+  });
+
+  test("a proc defined in a different workspace file recovers the tail", async () => {
+    await activate(docUri);
+    const editor = vscode.window.activeTextEditor!;
+    await setTestContent(editor, "set q {\n  aaa\nworkspace_helper 1; string\n");
+    const diags = await waitForDiagnostics(docUri, {
+      timeout: 15_000,
+      predicate: (ds) => ds.some((d) => codeOf(d) === "E001"),
+    });
+    assert.ok(hasRecoveryError(diags), `expected a recovery error: [${diags.map(codeOf)}]`);
+    assert.ok(
+      diags.some((d) => codeOf(d) === "E001"),
+      `a call to a sibling-file proc should be live code (chained bare \`string\` \
+       has no subcommand): [${diags.map(codeOf)}]`,
+    );
+  });
+
+  test("a command from a package-required library recovers the tail", async () => {
+    await activate(docUri);
+    const editor = vscode.window.activeTextEditor!;
+    await setTestContent(editor, "package require mypkg\nset q {\n  aaa\nmypkg_helper 1; string\n");
+    const diags = await waitForDiagnostics(docUri, {
+      timeout: 15_000,
+      predicate: (ds) => ds.some((d) => codeOf(d) === "E001"),
+    });
+    assert.ok(hasRecoveryError(diags), `expected a recovery error: [${diags.map(codeOf)}]`);
+    assert.ok(
+      diags.some((d) => codeOf(d) === "E001"),
+      `a call to a package-provided command should be live code (chained bare \
+       \`string\` has no subcommand): [${diags.map(codeOf)}]`,
+    );
+  });
 });
 
 suite("Error Recovery (short-form unterminated quote / brace)", () => {

--- a/editors/vscode/testFixture/mypkglib/impl.tcl
+++ b/editors/vscode/testFixture/mypkglib/impl.tcl
@@ -1,0 +1,4 @@
+# The recovery "known-command generality" package fixture
+# (`errorRecovery.test.ts`): `mypkg`'s sole command, resolved via
+# `package require mypkg` against this workspace-scanned `pkgIndex.tcl`.
+proc mypkg_helper {x} {return $x}

--- a/editors/vscode/testFixture/mypkglib/pkgIndex.tcl
+++ b/editors/vscode/testFixture/mypkglib/pkgIndex.tcl
@@ -1,0 +1,1 @@
+package ifneeded mypkg 1.0 [list source [file join $dir impl.tcl]]

--- a/editors/vscode/testFixture/workspaceSiblingHelper.tcl
+++ b/editors/vscode/testFixture/workspaceSiblingHelper.tcl
@@ -1,0 +1,5 @@
+# A sibling workspace file for the recovery "known-command generality"
+# tests (`errorRecovery.test.ts`): a proc the on-disk workspace scan
+# indexes without this file ever being opened in an editor tab, so a
+# break in a different open document can recover past a call to it.
+proc workspace_helper {x} {return $x}

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -221,6 +221,7 @@ impl Analyser {
         self.recovery_known_commands = super::utils::recovery_known_commands(
             source,
             self.registry.as_ref().expect("registry just stashed"),
+            &self.extra_commands,
         );
         let known: HashSet<&str> = self
             .recovery_known_commands

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -659,6 +659,7 @@ impl Analyser {
         self.recovery_known_commands = super::utils::recovery_known_commands(
             source,
             self.registry.as_ref().expect("registry just stashed"),
+            &self.extra_commands,
         );
         let known_commands: HashSet<&str> = self
             .recovery_known_commands
@@ -976,6 +977,7 @@ impl Analyser {
         self.recovery_known_commands = super::utils::recovery_known_commands(
             source,
             self.registry.as_ref().expect("registry just stashed"),
+            &self.extra_commands,
         );
         self.line_offsets = Some(compute_line_offsets(source));
 
@@ -1050,6 +1052,7 @@ impl Analyser {
         self.recovery_known_commands = super::utils::recovery_known_commands(
             source,
             self.registry.as_ref().expect("registry just stashed"),
+            &self.extra_commands,
         );
         self.line_offsets = Some(compute_line_offsets(source));
 

--- a/rust/tcl-compiler/src/analyser/utils.rs
+++ b/rust/tcl-compiler/src/analyser/utils.rs
@@ -196,19 +196,33 @@ pub fn scan_stub_command_names(source: &str) -> HashSet<String> {
 /// own `proc`s, so a break just before a call to one of them falls back to
 /// the imprecise generic diagnostic (or, worse, the recovery point is never
 /// found at all and the rest of the document goes unanalysed). This unions
-/// the registry names with every proc / class / command-alias name the
-/// document itself defines — qualified and unqualified tail — using the same
-/// fast, non-lowering scan [`crate::signature_scan::extract_signatures`]
-/// already uses for background-indexed files, so recovery recognises a
-/// document's own procs as readily as a builtin.
+/// the registry names with every proc / class / command-alias /
+/// rename-target name the document itself defines — qualified and
+/// unqualified tail — using the same fast, non-lowering scan
+/// [`crate::signature_scan::extract_signatures`] already uses for
+/// background-indexed files, so recovery recognises a document's own procs
+/// as readily as a builtin.
 ///
-/// Gated on [`tcl_lexer::script_is_complete`]: recovery only ever runs on a
-/// document with an unclosed delimiter, so a complete script skips the extra
-/// scan entirely — zero added cost on the overwhelmingly common well-formed
-/// edit.
+/// `extra` is unioned in unconditionally alongside the registry — the same
+/// user-declared / LSP-layer-resolved name set [`super::state::Analyser::extra_commands`]
+/// already carries for the W123 unresolved-command check (`tclLsp.extraCommands`,
+/// widened one layer up in `tcl-lsp-server` with workspace- and package-resolved
+/// names on the recovery path — see `widen_recovery_extra_commands` there). It is
+/// a plain in-memory set by the time it reaches here, so folding it in costs
+/// nothing extra beyond the registry union already does.
+///
+/// Gated on [`tcl_lexer::script_is_complete`]: the in-file signature scan only
+/// ever runs on a document with an unclosed delimiter, so a complete script
+/// skips that extra scan entirely — zero added cost on the overwhelmingly
+/// common well-formed edit.
 #[must_use]
-pub fn recovery_known_commands(source: &str, registry: &CommandRegistry) -> HashSet<String> {
+pub fn recovery_known_commands<S: std::hash::BuildHasher>(
+    source: &str,
+    registry: &CommandRegistry,
+    extra: &HashSet<String, S>,
+) -> HashSet<String> {
     let mut names: HashSet<String> = registry.command_names().map(str::to_owned).collect();
+    names.extend(extra.iter().cloned());
     if tcl_lexer::script_is_complete(source) {
         return names;
     }
@@ -218,6 +232,7 @@ pub fn recovery_known_commands(source: &str, registry: &CommandRegistry) -> Hash
         .keys()
         .chain(sig.classes.keys())
         .chain(sig.command_aliases.keys())
+        .chain(sig.renames.keys())
     {
         insert_qualified_and_tail(&mut names, qname);
     }
@@ -231,7 +246,17 @@ pub fn recovery_known_commands(source: &str, registry: &CommandRegistry) -> Hash
 /// original fully-qualified form: `signature_scan::qualify` always prepends
 /// `::`, and a recovery-point call can be written either way
 /// (`::ns::foo` or `ns::foo`), so both must be recognised.
-fn insert_qualified_and_tail(names: &mut HashSet<String>, qname: &str) {
+///
+/// `pub` (not just `pub(super)`) because `tcl-lsp-server` reuses this exact
+/// three-form insertion when widening the recovery known-command set with
+/// workspace-indexed and package-resolved names one layer up — those names
+/// carry the same `::`-qualified shape and need the same recognition rules,
+/// so this is the single place that logic lives rather than a second,
+/// independently-maintained copy.
+pub fn insert_qualified_and_tail<S: std::hash::BuildHasher>(
+    names: &mut HashSet<String, S>,
+    qname: &str,
+) {
     if !qname.is_empty() {
         names.insert(qname.to_string());
     }
@@ -1329,9 +1354,20 @@ proc foo {} {}
 
     #[test]
     fn recovery_known_commands_includes_registry_names() {
-        let known = recovery_known_commands("set x [foo\n", &registry());
+        let known = recovery_known_commands("set x [foo\n", &registry(), &HashSet::new());
         assert!(known.contains("set"));
         assert!(known.contains("puts"));
+    }
+
+    #[test]
+    fn recovery_known_commands_includes_extra_even_for_a_complete_script() {
+        // `extra` (the LSP-layer-widened `extraCommands` set) is unioned in
+        // unconditionally, same as the registry — unlike the in-file
+        // signature scan it is not gated on `script_is_complete`, since it
+        // costs nothing extra to fold in a set the caller already built.
+        let extra: HashSet<String> = ["workspace_helper".to_string()].into_iter().collect();
+        let known = recovery_known_commands("set x 1\n", &registry(), &extra);
+        assert!(known.contains("workspace_helper"));
     }
 
     #[test]
@@ -1340,7 +1376,11 @@ proc foo {} {}
         // well-formed document (however many procs it defines) never pays
         // for it, and its user-defined names are simply absent (recovery
         // never runs on complete input anyway).
-        let known = recovery_known_commands("proc my_helper {} {}\nmy_helper\n", &registry());
+        let known = recovery_known_commands(
+            "proc my_helper {} {}\nmy_helper\n",
+            &registry(),
+            &HashSet::new(),
+        );
         assert!(!known.contains("my_helper"));
         assert!(known.contains("proc")); // registry names are always present
     }
@@ -1348,7 +1388,7 @@ proc foo {} {}
     #[test]
     fn recovery_known_commands_adds_user_proc_qualified_and_tail() {
         let src = "namespace eval myns {\n  proc helper {x} {return $x}\n}\n\nset q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry());
+        let known = recovery_known_commands(src, &registry(), &HashSet::new());
         assert!(
             known.contains("myns::helper"),
             "expected the qualified name: {known:?}"
@@ -1366,7 +1406,7 @@ proc foo {} {}
         // Tcl syntax), so the leading-`::` form must be recognised
         // alongside the stripped/tail forms asserted above.
         let src = "namespace eval myns {\n  proc helper {x} {return $x}\n}\n\nset q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry());
+        let known = recovery_known_commands(src, &registry(), &HashSet::new());
         assert!(
             known.contains("::myns::helper"),
             "expected the fully-qualified leading-:: form: {known:?}"
@@ -1377,15 +1417,48 @@ proc foo {} {}
     fn recovery_known_commands_adds_user_class_and_alias() {
         let src =
             "oo::class create Widget {}\ninterp alias {} greet {} puts hi\n\nset q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry());
+        let known = recovery_known_commands(src, &registry(), &HashSet::new());
         assert!(known.contains("Widget"), "{known:?}");
         assert!(known.contains("greet"), "{known:?}");
     }
 
     #[test]
+    fn recovery_known_commands_adds_rename_target() {
+        let src = "rename puts my_puts\n\nset q {\nunclosed\n";
+        let known = recovery_known_commands(src, &registry(), &HashSet::new());
+        assert!(
+            known.contains("my_puts"),
+            "expected the rename target: {known:?}"
+        );
+    }
+
+    #[test]
+    fn recovery_known_commands_adds_namespaced_rename_target() {
+        let src = "namespace eval myns {\n  rename puts loud_puts\n}\n\nset q {\nunclosed\n";
+        let known = recovery_known_commands(src, &registry(), &HashSet::new());
+        assert!(
+            known.contains("myns::loud_puts"),
+            "expected the qualified rename target: {known:?}"
+        );
+        assert!(
+            known.contains("loud_puts"),
+            "expected the unqualified tail: {known:?}"
+        );
+    }
+
+    #[test]
+    fn recovery_known_commands_rename_to_empty_deletes_not_defines() {
+        // `rename OLD {}` deletes OLD; it must not introduce an empty-string
+        // "command name".
+        let src = "rename puts {}\n\nset q {\nunclosed\n";
+        let known = recovery_known_commands(src, &registry(), &HashSet::new());
+        assert!(!known.contains(""));
+    }
+
+    #[test]
     fn recovery_known_commands_does_not_invent_undefined_names() {
         let src = "set q {\nunclosed\n";
-        let known = recovery_known_commands(src, &registry());
+        let known = recovery_known_commands(src, &registry(), &HashSet::new());
         assert!(!known.contains("not_a_real_proc"));
         assert!(!known.contains("unclosed")); // plain data, not a definition
     }

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -35,7 +35,7 @@ use super::ctx::{FactoryCandidate, ProcBodyInfo, ScanCtx};
 use super::params::parse_param_list;
 use super::types::{
     SignatureAutoPathEntry, SignatureClass, SignatureCommandAlias, SignatureNamespaceImport,
-    SignaturePackageRequire, SignatureProc, SignatureScanResult, SignatureSource,
+    SignaturePackageRequire, SignatureProc, SignatureRename, SignatureScanResult, SignatureSource,
 };
 
 /// Fully qualify `name` within `ns_prefix` following Tcl scoping.
@@ -306,6 +306,32 @@ pub(super) fn handle_interp(texts: &[String], result: &mut SignatureScanResult) 
             qualified_name: qualified,
             target,
             extras,
+        },
+    );
+}
+
+/// Handler for `rename OLD NEW`.
+///
+/// `NEW` becomes a callable command name subject to ordinary namespace
+/// resolution (like `proc`, unlike `interp alias`'s always-global
+/// aliasName), so it is qualified against `ns_prefix`. `rename OLD {}`
+/// deletes `OLD` rather than introducing a new name, so an empty `NEW`
+/// is skipped.
+pub(super) fn handle_rename(texts: &[String], ns_prefix: &str, result: &mut SignatureScanResult) {
+    if texts.len() < 3 {
+        return;
+    }
+    let old_name = texts[1].clone();
+    let new_name = &texts[2];
+    if new_name.is_empty() {
+        return;
+    }
+    let qualified = qualify(ns_prefix, new_name);
+    result.renames.insert(
+        qualified.clone(),
+        SignatureRename {
+            qualified_name: qualified,
+            target: old_name,
         },
     );
 }
@@ -816,6 +842,61 @@ mod tests {
         let mut result = SignatureScanResult::default();
         handle_interp(&texts, &mut result);
         assert!(result.command_aliases.is_empty());
+    }
+
+    #[test]
+    fn handle_rename_records_qualified_target() {
+        let texts = vec![
+            "rename".to_string(),
+            "puts".to_string(),
+            "my_puts".to_string(),
+        ];
+        let mut result = SignatureScanResult::default();
+        handle_rename(&texts, "", &mut result);
+        assert_eq!(result.renames.len(), 1);
+        let rename = result.renames.get("::my_puts").expect("inserted");
+        assert_eq!(rename.target, "puts");
+        assert_eq!(rename.qualified_name, "::my_puts");
+    }
+
+    #[test]
+    fn handle_rename_qualifies_against_ns_prefix() {
+        let texts = vec![
+            "rename".to_string(),
+            "puts".to_string(),
+            "loud_puts".to_string(),
+        ];
+        let mut result = SignatureScanResult::default();
+        handle_rename(&texts, "myns", &mut result);
+        assert!(result.renames.contains_key("::myns::loud_puts"));
+    }
+
+    #[test]
+    fn handle_rename_absolute_new_name_ignores_ns_prefix() {
+        let texts = vec![
+            "rename".to_string(),
+            "puts".to_string(),
+            "::top_puts".to_string(),
+        ];
+        let mut result = SignatureScanResult::default();
+        handle_rename(&texts, "myns", &mut result);
+        assert!(result.renames.contains_key("::top_puts"));
+    }
+
+    #[test]
+    fn handle_rename_to_empty_string_deletes_and_is_skipped() {
+        let texts = vec!["rename".to_string(), "puts".to_string(), String::new()];
+        let mut result = SignatureScanResult::default();
+        handle_rename(&texts, "", &mut result);
+        assert!(result.renames.is_empty());
+    }
+
+    #[test]
+    fn handle_rename_too_few_args_is_a_no_op() {
+        let texts = vec!["rename".to_string(), "puts".to_string()];
+        let mut result = SignatureScanResult::default();
+        handle_rename(&texts, "", &mut result);
+        assert!(result.renames.is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/signature_scan/mod.rs
+++ b/rust/tcl-compiler/src/signature_scan/mod.rs
@@ -150,6 +150,20 @@ mod tests {
     }
 
     #[test]
+    fn rename_recorded_qualified_and_namespaced() {
+        let r = run("rename puts my_puts\nnamespace eval ns { rename set my_set }");
+        assert!(r.renames.contains_key("::my_puts"));
+        assert_eq!(r.renames["::my_puts"].target, "puts");
+        assert!(r.renames.contains_key("::ns::my_set"));
+    }
+
+    #[test]
+    fn rename_to_empty_deletes_not_recorded() {
+        let r = run("rename puts {}");
+        assert!(r.renames.is_empty());
+    }
+
+    #[test]
     fn tcllib_factory_wrapper_emits_synthetic_proc() {
         let src = "
             proc DEFC {name args body} {

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -136,6 +136,21 @@ pub struct SignatureCommandAlias {
     pub extras: Vec<String>,
 }
 
+/// A `rename OLD NEW` recorded by the signature scanner.
+///
+/// `NEW` becomes a callable command name subject to ordinary command-name
+/// resolution — like `proc`, a bare `NEW` inside a `namespace eval` is
+/// namespace-relative, unlike `interp alias`'s always-global aliasName. Only
+/// recorded when `NEW` is non-empty: `rename OLD {}` deletes `OLD` rather
+/// than introducing a new name.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureRename {
+    /// Fully-qualified new command name (with leading `::`).
+    pub qualified_name: String,
+    /// The old command name text as written at the call site.
+    pub target: String,
+}
+
 /// A `namespace import` recorded by the signature scanner.
 ///
 /// Records both direct `namespace import PATTERN` calls and the
@@ -229,6 +244,8 @@ pub struct SignatureScanResult {
     /// Every local-interpreter `interp alias`, keyed by alias
     /// qualified name.
     pub command_aliases: BTreeMap<String, SignatureCommandAlias>,
+    /// Every `rename OLD NEW`, keyed by the new qualified name.
+    pub renames: BTreeMap<String, SignatureRename>,
     /// Every recorded `namespace import` (direct + conjectured).
     pub namespace_imports: Vec<SignatureNamespaceImport>,
     /// Every `auto_path` mutation (one record per path element).

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -133,6 +133,7 @@ pub(super) fn scan(
             "package" => handlers::handle_package(texts, argv, conditional, &mut ctx.result),
             "source" => handlers::handle_source(texts, argv, &mut ctx.result),
             "interp" => handlers::handle_interp(texts, &mut ctx.result),
+            "rename" => handlers::handle_rename(texts, ns_prefix, &mut ctx.result),
             // Every stock `TclOO` metaclass creates a class via the same
             // `METACLASS create NAME ?BODY?` interface — `oo::configurable`
             // (property-bearing), `oo::abstract`, and `oo::singleton` included,

--- a/rust/tcl-compiler/tests/signature_scan.rs
+++ b/rust/tcl-compiler/tests/signature_scan.rs
@@ -170,6 +170,34 @@ fn alias_with_prepended_args() {
 }
 
 // ---------------------------------------------------------------------------
+// rename
+// ---------------------------------------------------------------------------
+
+#[test]
+fn simple_rename() {
+    let r = run("rename puts my_puts");
+    assert!(r.renames.contains_key("::my_puts"));
+    let rn = &r.renames["::my_puts"];
+    assert_eq!(rn.target, "puts");
+    assert_eq!(rn.qualified_name, "::my_puts");
+}
+
+#[test]
+fn rename_in_namespace_eval_is_namespace_relative() {
+    // Unlike `interp alias` (always global), a bare NEW name is qualified
+    // against the enclosing namespace — the same rule `proc` follows.
+    let r = run("namespace eval math { rename + plus }");
+    assert!(r.renames.contains_key("::math::plus"));
+}
+
+#[test]
+fn rename_to_empty_string_deletes_and_is_not_recorded() {
+    // `rename OLD {}` deletes OLD; no new name is introduced.
+    let r = run("rename puts {}");
+    assert!(r.renames.is_empty());
+}
+
+// ---------------------------------------------------------------------------
 // oo::class
 // ---------------------------------------------------------------------------
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -775,6 +775,9 @@ async fn compute_base_analysis(
     disabled: &HashSet<String>,
     extra_commands: &HashSet<String>,
     non_ascii_mode: NonAsciiMode,
+    registry: &CommandRegistry,
+    workspace_index: &Arc<RwLock<core_workspace_index::WorkspaceIndex>>,
+    package_resolver: &Arc<RwLock<PackageResolver>>,
 ) -> ControlFlow<bool, Arc<AnalysisResult>> {
     let &SalsaAnalysisCtx {
         db,
@@ -784,6 +787,52 @@ async fn compute_base_analysis(
         text,
         dialect,
     } = ctx;
+
+    // A document with an unclosed delimiter needs a wider "known command"
+    // universe than the folder/global-scoped `extra_commands` salsa input
+    // carries: the workspace's own procs/classes and the commands *this*
+    // document's `package require`s resolve to (the recovery known-command
+    // hierarchy — see `tcl_compiler::analyser::utils::recovery_known_commands`,
+    // which this widens one layer up). Resolving that is real work (a
+    // workspace-index read, package-database lookup + file reads) and is
+    // inherently per-document — a document's own `package require`s decide
+    // which package commands apply, which the shared, folder/global-scoped
+    // salsa `AnalyserConfig` cannot express — so this bypasses the cached path
+    // entirely and only runs on this rare, edit-transient branch, mirroring
+    // `recovery_known_commands`'s own `script_is_complete` gate: a
+    // well-formed document pays nothing extra.
+    if !tcl_lexer::script_is_complete(text) {
+        let widened = widen_recovery_extra_commands(
+            extra_commands,
+            text,
+            dialect,
+            registry,
+            workspace_index,
+            package_resolver,
+        )
+        .await;
+        let (a_text, a_dialect, a_disabled) =
+            (text.to_owned(), dialect.to_owned(), disabled.clone());
+        return match tokio::task::spawn_blocking(move || {
+            Backend::configured_analyser(a_disabled, non_ascii_mode, widened)
+                .analyse(&a_text, &a_dialect)
+                .clone()
+        })
+        .await
+        {
+            Ok(analysis) => ControlFlow::Continue(Arc::new(analysis)),
+            Err(e) => {
+                eprintln!(
+                    "tcl-lsp: recovery-path diagnostics worker panicked for {} (is_panic={}); \
+                     skipping this document's diagnostics to avoid a retry livelock",
+                    uri.as_str(),
+                    e.is_panic(),
+                );
+                ControlFlow::Break(true)
+            }
+        };
+    }
+
     if let Some(file) = file {
         // Clone a fresh, short-lived snapshot for just this read and move it
         // into the worker; it drops when the read finishes, so it never holds
@@ -833,6 +882,72 @@ async fn compute_base_analysis(
         .unwrap_or_default();
         ControlFlow::Continue(analysis)
     }
+}
+
+/// Widen `base` (the resolved `tclLsp.extraCommands`) with the workspace's
+/// own proc/class names and the commands available to `text` through package
+/// resolution — the LSP-layer name-resolution hierarchy the unclosed-
+/// delimiter recovery heuristics need beyond what a single-file `Analyser`
+/// can see on its own. `tcl_compiler::analyser::utils::recovery_known_commands`
+/// unions the registry with the document's own signature scan; this unions
+/// one layer further out: every workspace-indexed proc/class (regardless of
+/// which file defines it — `WorkspaceIndex::procs`/`classes`), every
+/// auto-loadable command the scanned library paths provide (`tclIndex`-style,
+/// no `package require` needed — mirrors the #832 W123 refinement), and, when
+/// `text` itself `package require`s something, the commands that package's
+/// resolved implementation files define.
+///
+/// `text`'s own `package require`s are read via a fresh signature scan
+/// (mirroring `recovery_known_commands`'s own in-file scan) rather than
+/// `WorkspaceIndex::package_requires_for` — the index only learns a
+/// document's requires from an *already-published* analysis, which this
+/// document, being analysed for the first time right now, cannot yet have.
+///
+/// Workspace names go through `tcl_compiler::analyser::utils::insert_qualified_and_tail`
+/// — the same three-form (as-is / `::`-stripped / tail) insertion
+/// `recovery_known_commands` uses for a document's own procs/classes/
+/// aliases/renames — rather than a second, hand-rolled copy: a workspace
+/// proc referenced by its absolute `::ns::name` form needs recognising just
+/// as much as one referenced relatively.
+///
+/// Only called from [`compute_base_analysis`]'s `!script_is_complete`
+/// recovery branch — never on the well-formed-document hot path.
+async fn widen_recovery_extra_commands(
+    base: &HashSet<String>,
+    text: &str,
+    dialect: &str,
+    registry: &CommandRegistry,
+    workspace_index: &Arc<RwLock<core_workspace_index::WorkspaceIndex>>,
+    package_resolver: &Arc<RwLock<PackageResolver>>,
+) -> HashSet<String> {
+    let mut names = base.clone();
+    {
+        let index = workspace_index.read().await;
+        for p in index.procs() {
+            tcl_compiler::analyser::utils::insert_qualified_and_tail(&mut names, &p.qualified_name);
+        }
+        for c in index.classes() {
+            tcl_compiler::analyser::utils::insert_qualified_and_tail(&mut names, &c.qualified_name);
+        }
+    }
+    let requires: Vec<String> = tcl_compiler::signature_scan::extract_signatures(text, registry)
+        .package_requires
+        .into_iter()
+        .map(|pr| pr.name)
+        .collect();
+    let resolver = package_resolver.read().await;
+    for name in resolver.auto_command_names() {
+        names.insert(name.trim_start_matches("::").to_owned());
+    }
+    if !requires.is_empty() {
+        let commands = resolver.package_defined_commands(&requires, &|path| {
+            std::fs::read_to_string(path)
+                .map(|text| defined_command_tails(&text, dialect))
+                .unwrap_or_default()
+        });
+        names.extend(commands);
+    }
+    names
 }
 
 /// The cross-file analyser diagnostics for the deep tier: `project_diagnostics`
@@ -1123,6 +1238,9 @@ async fn run_diagnostics_analyser_path(
         lift_inputs.disabled,
         inputs.extra_commands,
         inputs.non_ascii_mode,
+        inputs.registry,
+        inputs.workspace_index,
+        inputs.package_resolver,
     )
     .shared();
 

--- a/rust/tcl-lsp-server/tests/e2e/recovery.rs
+++ b/rust/tcl-lsp-server/tests/e2e/recovery.rs
@@ -646,6 +646,229 @@ fn absolute_namespace_qualified_proc_call_recovers_the_tail() {
 }
 
 // --------------------------------------------------------------------------- //
+// Full name-resolution hierarchy — the known-command signal recovery consults
+// extends past the registry + this-file's own procs/classes/aliases to two
+// more layers: a `rename OLD NEW` target (this file), a proc defined in a
+// *different* indexed workspace file, and a command a `package require`d
+// library provides. Each layer gets a positive case (the swallowed call's own
+// line is proven live — a `string` call chained onto the same line has no
+// subcommand, which always draws its own E001 ("requires a subcommand") once
+// analysed, independent of whatever recognised the target head) and a
+// negative case (a name from none of these sources must still fall back
+// honestly — no E001, since a line that stays swallowed opaque text is never
+// analysed at all).
+// --------------------------------------------------------------------------- //
+
+#[test]
+fn renamed_command_recovers_the_tail() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "rename puts my_puts\n\nset q {\n  aaa\nmy_puts hi; string\n",
+    );
+    assert!(
+        has_recovery_error(&diags),
+        "unterminated {{ should flag; got {:?}",
+        codes(&diags)
+    );
+    assert!(
+        diags.iter().any(|d| code_str(d) == "E001"),
+        "the renamed-command call's line should be live code (proven by the \
+         chained bare `string`'s own \
+         missing-subcommand error); got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn undefined_name_after_rename_statement_falls_back_honestly() {
+    // The file *does* define a rename, but the swallowed call targets a
+    // different, undefined name — no false positive from having a rename
+    // statement merely present anywhere in the document.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "rename puts my_puts\n\nset q {\n  aaa\nnot_my_puts hi; string\n",
+    );
+    assert!(has_recovery_error(&diags), "got {:?}", codes(&diags));
+    assert!(
+        !diags.iter().any(|d| code_str(d) == "E001"),
+        "an undefined name unrelated to the rename must not be mis-recovered; \
+         got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn sibling_workspace_file_proc_recovers_the_tail() {
+    let mut lsp = Lsp::tcl();
+    // Indexed first — `open_ready` blocks until this document's
+    // `workspace_state.update` fires, so its proc is in the workspace index
+    // before the broken document below is even opened.
+    let sibling = unique_uri("tcl");
+    lsp.open_ready(&sibling, "proc workspace_helper {x} {return $x}\n");
+
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set q {\n  aaa\nworkspace_helper 1; string\n");
+    assert!(
+        has_recovery_error(&diags),
+        "unterminated {{ should flag; got {:?}",
+        codes(&diags)
+    );
+    assert!(
+        diags.iter().any(|d| code_str(d) == "E001"),
+        "a call to a sibling-file proc should be live code (proven by the \
+         chained bare `string`'s own \
+         missing-subcommand error); got {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn absolute_sibling_workspace_file_proc_call_recovers_the_tail() {
+    // Mirrors `absolute_namespace_qualified_proc_call_recovers_the_tail`
+    // (the in-file case, above) one layer out: a workspace-indexed proc
+    // referenced in absolute syntax (`::workspace_helper`, leading `::`)
+    // must be recognised just as readily as the bare form.
+    let mut lsp = Lsp::tcl();
+    let sibling = unique_uri("tcl");
+    lsp.open_ready(&sibling, "proc workspace_helper {x} {return $x}\n");
+
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set q {\n  aaa\n::workspace_helper 1; string\n");
+    assert!(
+        has_recovery_error(&diags),
+        "unterminated {{ should flag; got {:?}",
+        codes(&diags)
+    );
+    assert!(
+        diags.iter().any(|d| code_str(d) == "E001"),
+        "an absolute call to a sibling-file proc should be live code (proven \
+         by the chained bare `string`'s own missing-subcommand error); got \
+         {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn undefined_name_with_workspace_sibling_present_falls_back_honestly() {
+    // A sibling file is indexed (so the workspace lookup isn't a no-op), but
+    // the swallowed call targets a name no sibling defines.
+    let mut lsp = Lsp::tcl();
+    let sibling = unique_uri("tcl");
+    lsp.open_ready(&sibling, "proc workspace_helper {x} {return $x}\n");
+
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set q {\n  aaa\nnot_workspace_helper 1; string\n");
+    assert!(has_recovery_error(&diags), "got {:?}", codes(&diags));
+    assert!(
+        !diags.iter().any(|d| code_str(d) == "E001"),
+        "an undefined name must not be mis-recovered just because *some* \
+         workspace sibling is indexed; got {:?}",
+        codes(&diags)
+    );
+}
+
+/// Per-call counter so repeat runs of the package-fixture tests don't collide
+/// on the temp dir (mirrors `diagnostics.rs`'s `RBC_LIB_N`).
+static PKG_LIB_N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Write a `pkgIndex.tcl` + implementation file declaring `mypkg`, providing
+/// `mypkg_helper`, under a fresh temp dir; returns the dir (whose *parent* is
+/// the `libraryPaths` root — `PackageResolver::scan_path` descends one level,
+/// mirroring the `rbc/tclIndex` fixture in `diagnostics.rs`).
+fn write_mypkg_fixture() -> std::path::PathBuf {
+    use std::sync::atomic::Ordering;
+    let libdir = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-mypkg-{}-{}",
+        std::process::id(),
+        PKG_LIB_N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let pkgdir = libdir.join("mypkg");
+    std::fs::create_dir_all(&pkgdir).expect("mk mypkg lib dir");
+    std::fs::write(
+        pkgdir.join("impl.tcl"),
+        "proc mypkg_helper {x} {return $x}\n",
+    )
+    .expect("write impl.tcl");
+    std::fs::write(
+        pkgdir.join("pkgIndex.tcl"),
+        "package ifneeded mypkg 1.0 [list source [file join $dir impl.tcl]]\n",
+    )
+    .expect("write pkgIndex.tcl");
+    libdir
+}
+
+#[test]
+fn package_required_library_command_recovers_the_tail() {
+    let libdir = write_mypkg_fixture();
+    let mut lsp = Lsp::with_config(json!({
+        "libraryPaths": [ libdir.to_string_lossy() ],
+    }));
+    let uri = unique_uri("tcl");
+    lsp.open_document(
+        &uri,
+        "package require mypkg\nset q {\n  aaa\nmypkg_helper 1; string\n",
+    );
+
+    // The package database is (re)built asynchronously at startup; poll the
+    // deterministic pull path until recovery reflects it or the deadline
+    // (mirrors `autoload_library_command_not_unknown_issue_832`).
+    let mut diags = lsp.pull_diagnostics(&uri);
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while !diags.iter().any(|d| code_str(d) == "E001") && std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+        diags = lsp.pull_diagnostics(&uri);
+    }
+    assert!(
+        has_recovery_error(&diags),
+        "unterminated {{ should flag; got {:?}",
+        codes(&diags)
+    );
+    assert!(
+        diags.iter().any(|d| code_str(d) == "E001"),
+        "a call to a package-provided command should be live code (proven by \
+         the chained bare `string`'s own \
+         missing-subcommand error); got {:?}",
+        codes(&diags)
+    );
+
+    let _ = std::fs::remove_dir_all(&libdir);
+}
+
+#[test]
+fn undefined_name_with_package_required_falls_back_honestly() {
+    // The package is required and resolvable, but the swallowed call targets
+    // a name `mypkg` does not provide.
+    let libdir = write_mypkg_fixture();
+    let mut lsp = Lsp::with_config(json!({
+        "libraryPaths": [ libdir.to_string_lossy() ],
+    }));
+    let uri = unique_uri("tcl");
+    lsp.open_document(
+        &uri,
+        "package require mypkg\nset q {\n  aaa\nnot_mypkg_helper 1; string\n",
+    );
+
+    // Give the (irrelevant, but concurrently loading) package database the
+    // same settling window as the positive case before asserting the
+    // steady-state result.
+    std::thread::sleep(Duration::from_millis(500));
+    let diags = lsp.pull_diagnostics(&uri);
+    assert!(has_recovery_error(&diags), "got {:?}", codes(&diags));
+    assert!(
+        !diags.iter().any(|d| code_str(d) == "E001"),
+        "an undefined name must not be mis-recovered just because *some* \
+         required package is resolvable; got {:?}",
+        codes(&diags)
+    );
+
+    let _ = std::fs::remove_dir_all(&libdir);
+}
+
+// --------------------------------------------------------------------------- //
 // Short-form unterminated quote / brace — a delimiter left open with content
 // on the *same* line as the opener (the overwhelmingly common real-world
 // typo) must be flagged exactly like a long multi-line run. Before this fix,


### PR DESCRIPTION
## Summary

- Extends #863's "known command" recovery signal (registry + a document's own procs/classes/aliases) two layers further: `rename OLD NEW` targets (this file), procs/classes defined in *other* indexed workspace files, and commands a `package require`d library provides.
- `rename OLD NEW`: the signature scanner now records rename targets (`SignatureRename` / `SignatureScanResult.renames`), mirroring the existing `interp alias` handler. `NEW` is namespace-qualified the same way `proc` is (unlike `interp alias`, which is always global). `recovery_known_commands` folds `renames.keys()` into its union.
- Workspace + package layers: `tcl-lsp-server` widens the known-command set with every workspace-indexed proc/class, every auto-loadable command the scanned library paths provide, and the commands a document's own `package require` resolves to via `PackageResolver`. Only runs on the `!script_is_complete` recovery path (mirrors `recovery_known_commands`'s own gate) and bypasses the folder-scoped salsa-cached analysis path, since a document's package requires are inherently per-document — read via a fresh signature scan rather than `WorkspaceIndex::package_requires_for`, since the index only learns a document's requires from an already-published analysis this document (being analysed for the first time right now) cannot yet have.
- `recovery_known_commands` also now unions in `extra_commands` unconditionally, closing a gap where `tclLsp.extraCommands` and the new workspace/package names never actually reached the recovery heuristics.
- Centralisation: `insert_qualified_and_tail` (the as-is / `::`-stripped / tail three-form name insertion) is now `pub` and reused by the workspace/package widening in `tcl-lsp-server`, rather than a second hand-rolled copy — that copy was missing the as-is (leading-`::`) form, the exact same gap Codex review caught and fixed for the in-file case in #863, just one layer out. Caught and fixed during this review, with a regression test (fails without the fix, passes with it).

## Validation

- `cargo test -p tcl-compiler --lib --test signature_scan` — 3806 + 48 passed.
- `cargo test -p tcl-lsp-server --test e2e` — 677 passed.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all --check` — clean.
- `make rust-check` — all drift gates (KCS index links, diag tables, editor catalogs, Zed queries, VS Code/JetBrains/AI generated files) pass.
- VS Code extension suite (`npm test`, filtered to `Error Recovery`) — 22/22, including the 3 new positive-case tests with new `mypkglib`/`workspaceSiblingHelper.tcl` fixtures.
- New tests verified to fail without their fix and pass with it (rename/workspace/package positive cases, and the leading-`::` centralisation fix).

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? No — this is a behavioural refinement within existing E100/E201/E202/E203 contracts (widening the "known command" recovery signal), same scope as #863, which established "no new KCS notes required" for this class of change.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`.
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01EL7eFQgrbCzvazuesBjUA6)_