### PR TITLE
Fix TclOO method code-lens reference count (issue #864)

### DIFF
--- a/editors/vscode/src/test/codeLens.test.ts
+++ b/editors/vscode/src/test/codeLens.test.ts
@@ -111,6 +111,53 @@ suite("Code Lens", () => {
     );
   });
 
+  // Regression for issue #864: the reference-count lens above a TclOO method
+  // must count external `$obj method` dispatch, not just intra-class calls.
+  // `puts [$b get foo]` (with `set b [Bar new]`) is one reference to `get`.
+  test("method lens counts external \\$obj method dispatch", async () => {
+    const refsUri = getDocUri("codeLensMethodRefs.tcl");
+    await activate(refsUri);
+    // Method / member lenses are informational: the server attaches their
+    // count eagerly as `command.title` (no separate resolve round-trip), so
+    // poll until the lenses on the member lines under test carry a title.
+    const lenses = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100),
+      (r) => {
+        const ls = r as vscode.CodeLens[] | undefined;
+        if (!ls) return false;
+        const titledLines = new Set(
+          ls
+            .filter((l) => l.command && typeof l.command.title === "string")
+            .map((l) => l.range.start.line),
+        );
+        // `method get` on line 6, `method unused` on line 10.
+        return [6, 10].every((line) => titledLines.has(line));
+      },
+      { timeout: 10_000, label: "resolved method code lenses" },
+    )) as vscode.CodeLens[] | undefined;
+    assert.ok(lenses, "codeLens result should not be null");
+
+    const titleByLine = new Map<number, string>();
+    for (const lens of lenses) {
+      if (lens.command && typeof lens.command.title === "string") {
+        titleByLine.set(lens.range.start.line, lens.command.title);
+      }
+    }
+
+    // Line 6: `method get` — dispatched once via `puts [$b get foo]`.
+    assert.strictEqual(
+      titleByLine.get(6),
+      "1 reference",
+      `TclOO method with an external \$obj dispatch: got "${titleByLine.get(6)}"`,
+    );
+    // Line 10: `method unused` — never dispatched.
+    assert.strictEqual(
+      titleByLine.get(10),
+      "0 references",
+      `uncalled TclOO method: got "${titleByLine.get(10)}"`,
+    );
+  });
+
   // Regression for issue #724: the reference-count lens must be *clickable* —
   // its resolved command must invoke `tcl-lsp.showReferences` with the URI,
   // anchor position, and reference locations. A bare title with no command is

--- a/editors/vscode/testFixture/codeLensMethodRefs.tcl
+++ b/editors/vscode/testFixture/codeLensMethodRefs.tcl
@@ -1,0 +1,16 @@
+oo::class create Bar {
+    variable _options
+    constructor {args} {
+        set _options $args
+    }
+
+    method get {key} {
+        return [dict get $_options $key]
+    }
+
+    method unused {} {
+        return {}
+    }
+}
+set b [Bar new]
+puts [$b get foo]

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -31,11 +31,14 @@
 //!   <inst>`, and inheritance references in
 //!   `analysis.command_invocations`.
 //!
-//! Per-method / classmethod reference-count lenses:
-//! each member declaration's name span gets a `N references`
-//! lens counting call sites discovered by re-segmenting every
-//! sibling method body in the class (the analyser doesn't
-//! walk into method bodies for `command_invocations`).
+//! Per-method / classmethod reference-count lenses: each member
+//! declaration's name span gets a `N references` lens whose count comes
+//! from [`crate::references::method_references_for_class`] — the same
+//! resolver Find All References and rename use — so the lens and the peek
+//! always agree.  That resolver counts intra-class `my method` dispatch,
+//! external `$obj method` call sites (matched through the analyser's
+//! `instance_classes` variable-type tracking), and the sites of any
+//! subclass that inherits the definition (issue #864).
 //!
 //! Cross-document reference counts: when the
 //! caller threads a [`crate::workspace_index::WorkspaceIndex`]
@@ -44,10 +47,12 @@
 //!
 //! Limitations:
 //!
-//! * `[$obj methodName]` call sites *outside* the class body
-//!   are not counted — that needs analyser-side variable-type
-//!   tracking so the provider knows which object's class to
-//!   match against.
+//! * Method lens counts are current-document only (matching the method
+//!   peek, which is also single-document): an `$obj method` site in a
+//!   *sibling* document is not counted, because resolving a cross-file
+//!   object's class needs whole-workspace instance-type flow the index
+//!   does not yet carry.  Proc / class lenses do fold in cross-document
+//!   command-head call sites via the workspace index.
 //! * The lens carries a static label rather than an inline
 //!   "show references" jump-out; the editor's built-in
 //!   references command can be invoked from the lens itself.
@@ -154,41 +159,41 @@ pub fn code_lenses(
             command: String::new(),
             qname: class_def.qualified_name.clone(),
         });
-        // Per-method / classmethod / property lenses inside
-        // the class body.  Counts call sites discovered by re-
-        // segmenting every sibling method body (the analyser
-        // doesn't walk into method bodies for
-        // `command_invocations`).
-        emit_class_member_lenses(source, dialect, class_def, &line_index, &mut lenses);
+        // Per-method / classmethod lenses inside the class body.  The count
+        // is derived from the *same* resolver the peek (Find All References)
+        // uses — `references::method_references_for_class` — so the lens
+        // title and the peek can never drift (issue #864).  That resolver
+        // counts both intra-class `my method` dispatch and external
+        // `$obj method` call sites (via `instance_classes` type tracking),
+        // plus the call sites of any subclass that inherits this definition.
+        emit_class_member_lenses(source, dialect, qname, class_def, analysis, &line_index, &mut lenses);
     }
 
     lenses
 }
 
-/// Emit per-member reference-count lenses for every method,
-/// classmethod, and property in `class_def`.  Call sites are
-/// discovered by re-segmenting each method body.
+/// Emit per-member reference-count lenses for every method and classmethod
+/// in `class_def`.  The count for each member is the number of call sites
+/// [`references::method_references_for_class`] resolves — the single source
+/// of truth also used by Find All References and rename — so the lens title
+/// and the peek can never drift.  That resolver covers intra-class
+/// `my method` dispatch, external `$obj method` sites (resolved through the
+/// analyser's `instance_classes` variable-type tracking), and the call sites
+/// of any subclass that inherits (does not override) this definition.
 fn emit_class_member_lenses(
     source: &str,
     dialect: &str,
+    class_q: &str,
     class_def: &tcl_compiler::analyser::ClassDef,
+    analysis: &AnalysisResult,
     line_index: &LineIndex,
     lenses: &mut Vec<CodeLens>,
 ) {
-    let body_spans: Vec<tcl_lexer::Span> = class_def
-        .methods
-        .values()
-        .map(|m| m.body_span)
-        .chain(class_def.class_methods.values().map(|m| m.body_span))
-        .chain(class_def.constructors.iter().map(|c| c.body_span))
-        .chain(class_def.destructor.iter().map(|d| d.body_span))
-        .collect();
-    let calls_for = |word: &str, decl_span: tcl_lexer::Span| -> usize {
-        let mut count = 0;
-        for span in &body_spans {
-            count += count_method_calls_in_body(source, dialect, *span, word, decl_span);
-        }
-        count
+    // Reference count for one member, matching the peek exactly: the number
+    // of call sites (declaration excluded) the shared resolver returns.
+    let member_ref_count = |name: &str| -> usize {
+        crate::references::method_references_for_class(source, dialect, analysis, class_q, name)
+            .map_or(0, |(_decl, calls)| calls.len())
     };
     let push_lens = |name_span: tcl_lexer::Span, title: String, lenses: &mut Vec<CodeLens>| {
         let start = line_index.position_at_utf16(name_span.start(), source);
@@ -207,77 +212,20 @@ fn emit_class_member_lenses(
             qname: String::new(),
         });
     };
-    for m in class_def.methods.values() {
+    for m in class_def
+        .methods
+        .values()
+        .chain(class_def.class_methods.values())
+    {
         if m.name_span.is_empty() {
             continue;
         }
         push_lens(
             m.name_span,
-            reference_count_title(calls_for(&m.name, m.name_span)),
+            reference_count_title(member_ref_count(&m.name)),
             lenses,
         );
     }
-    for m in class_def.class_methods.values() {
-        if m.name_span.is_empty() {
-            continue;
-        }
-        push_lens(
-            m.name_span,
-            reference_count_title(calls_for(&m.name, m.name_span)),
-            lenses,
-        );
-    }
-}
-
-/// Count call sites in `body_span` whose head token equals
-/// `word`, skipping the declaration site at `decl_span`.
-fn count_method_calls_in_body(
-    source: &str,
-    dialect: &str,
-    body_span: tcl_lexer::Span,
-    word: &str,
-    decl_span: tcl_lexer::Span,
-) -> usize {
-    use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
-    if body_span.is_empty() {
-        return 0;
-    }
-    let mut start = body_span.start() as usize;
-    let mut end = body_span.end() as usize;
-    if start >= source.len() || end > source.len() || start > end {
-        return 0;
-    }
-    if source.as_bytes().get(start) == Some(&b'{') {
-        start += 1;
-    }
-    if end > start && source.as_bytes().get(end - 1) == Some(&b'}') {
-        end -= 1;
-    }
-    let body_text = &source[start..end];
-    let commands = segment_commands_with_offset_and_config(
-        body_text,
-        u32::try_from(start).unwrap_or(body_span.start()),
-        tcl_lexer::LexerConfig::for_dialect(dialect),
-    );
-    let mut count = 0;
-    for cmd in &commands {
-        let Some(head) = cmd.argv.first() else {
-            continue;
-        };
-        let h_start = head.span.start() as usize;
-        let h_end = head.span.end() as usize;
-        if h_start >= source.len() || h_end > source.len() {
-            continue;
-        }
-        if &source[h_start..h_end] != word {
-            continue;
-        }
-        if head.span.start() == decl_span.start() && head.span.end() == decl_span.end() {
-            continue;
-        }
-        count += 1;
-    }
-    count
 }
 
 fn reference_count_title(count: usize) -> String {
@@ -431,8 +379,10 @@ mod tests {
 
     #[test]
     fn lens_counts_method_calls_within_class_body() {
-        // `greet` is called twice from `twice`'s body.
-        let src = "oo::class create C {\n    method greet {} {}\n    method twice {} { greet ; greet }\n}\n";
+        // Intra-class self-dispatch in TclOO is `my greet`, not a bare
+        // `greet` (a bare word resolves as a normal command, never the
+        // object's method).  `greet` is dispatched twice from `twice`.
+        let src = "oo::class create C {\n    method greet {} {}\n    method twice {} { my greet ; my greet }\n}\n";
         let analysis = analyse(src);
         if analysis.all_classes.is_empty() {
             return;
@@ -445,6 +395,25 @@ mod tests {
             .find(|l| l.range.start_line == 1)
             .expect("greet lens");
         assert_eq!(greet_lens.command_title, "2 references", "{lenses:?}");
+    }
+
+    #[test]
+    fn lens_bare_word_in_method_body_is_not_a_self_dispatch() {
+        // FP guard: a bare `greet` inside a sibling method body is a normal
+        // command call, NOT TclOO self-dispatch (that is `my greet`), so it
+        // must not be counted as a reference to the method.  The old
+        // head-token heuristic wrongly counted these.
+        let src = "oo::class create C {\n    method greet {} {}\n    method other {} { greet ; greet }\n}\n";
+        let analysis = analyse(src);
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let greet_lens = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("greet lens");
+        assert_eq!(greet_lens.command_title, "0 references", "{lenses:?}");
     }
 
     #[test]
@@ -624,5 +593,245 @@ mod tests {
             "0 references",
             "{lenses:?}"
         );
+    }
+
+    // -- issue #864: method lens must count external `$obj method` sites --
+    //
+    // TP  — a real reference (`$obj method`, `my method`) is counted.
+    // FP  — a non-reference (`dict get`, a bare word) is *not* counted.
+    // TN  — a method with genuinely no references reads `0 references`.
+    // FN  — the regression: the external `$obj method` call the old
+    //       body-head heuristic missed is now counted.
+
+    /// The exact source from issue #864.
+    const ISSUE_864_SRC: &str = concat!(
+        "oo::class create Bar {\n",
+        "   variable _options\n",
+        "    constructor {args} {\n",
+        "         set _options $args\n",
+        "    }\n",
+        "\n",
+        "    method get {key} {\n",
+        "        return [dict get $_options $key]\n",
+        "    }\n",
+        "\n",
+        "}\n",
+        "set b [Bar new]\n",
+        "puts [$b get foo]\n",
+    );
+
+    #[test]
+    fn lens_counts_external_obj_method_call_issue_864() {
+        // FN-regression + TP: `puts [$b get foo]` references `Bar`'s `get`
+        // via an instance whose class is known (`set b [Bar new]`).  The
+        // lens on `method get` (line 6) must read `1 reference`, not the
+        // `0 references` the head-scan heuristic produced.
+        let analysis = analyse(ISSUE_864_SRC);
+        assert!(!analysis.all_classes.is_empty(), "class not analysed");
+        let lenses = code_lenses(ISSUE_864_SRC, "tcl", Some(&analysis), None, "");
+        let get_lens = lenses
+            .iter()
+            .find(|l| l.range.start_line == 6)
+            .expect("method get lens on line 6");
+        assert_eq!(get_lens.command_title, "1 reference", "{lenses:?}");
+    }
+
+    #[test]
+    fn lens_matches_peek_for_issue_864_method() {
+        // The lens count and Find All References must agree exactly.
+        assert_lens_matches_references(ISSUE_864_SRC, 6);
+    }
+
+    #[test]
+    fn lens_does_not_count_dict_get_as_method_ref() {
+        // FP guard: the method is named `get` and its own body contains
+        // `dict get $_options $key`.  The `get` word there is the `dict`
+        // ensemble subcommand, not a dispatch of the method, so it must not
+        // inflate the count.  With only the external `$b get foo`, the count
+        // is exactly 1.
+        let analysis = analyse(ISSUE_864_SRC);
+        let lenses = code_lenses(ISSUE_864_SRC, "tcl", Some(&analysis), None, "");
+        let get_lens = lenses
+            .iter()
+            .find(|l| l.range.start_line == 6)
+            .expect("method get lens");
+        assert_eq!(get_lens.command_title, "1 reference", "{lenses:?}");
+    }
+
+    #[test]
+    fn lens_counts_multiple_external_obj_method_calls() {
+        // TP: two distinct instances each dispatch `bark` once.
+        let src = concat!(
+            "oo::class create Dog {\n",
+            "    method bark {} {}\n",
+            "}\n",
+            "set a [Dog new]\n",
+            "set b [Dog new]\n",
+            "$a bark\n",
+            "puts [$b bark]\n",
+        );
+        let analysis = analyse(src);
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let bark = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("bark lens");
+        assert_eq!(bark.command_title, "2 references", "{lenses:?}");
+    }
+
+    #[test]
+    fn lens_counts_obj_method_from_create_instance() {
+        // TP: `Dog create rex` binds `rex` as a Dog instance command, so
+        // `rex bark` is a method dispatch.
+        let src = concat!(
+            "oo::class create Dog {\n",
+            "    method bark {} {}\n",
+            "}\n",
+            "Dog create rex\n",
+            "rex bark\n",
+        );
+        let analysis = analyse(src);
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let bark = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("bark lens");
+        assert_eq!(bark.command_title, "1 reference", "{lenses:?}");
+    }
+
+    #[test]
+    fn lens_counts_inherited_method_on_subclass_instance() {
+        // TP + inheritance: `Base`'s `speak` is inherited by `Derived`; a
+        // `Derived` instance dispatching `speak` resolves to `Base`'s copy,
+        // so it counts toward `Base::speak`'s lens.
+        let src = concat!(
+            "oo::class create Base {\n",
+            "    method speak {} {}\n",
+            "}\n",
+            "oo::class create Derived {\n",
+            "    superclass Base\n",
+            "}\n",
+            "set d [Derived new]\n",
+            "$d speak\n",
+        );
+        let analysis = analyse(src);
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let speak = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("speak lens");
+        assert_eq!(speak.command_title, "1 reference", "{lenses:?}");
+    }
+
+    #[test]
+    fn lens_counts_namespaced_class_method() {
+        // TP: a class defined inside a namespace, instance created and its
+        // method dispatched — the qualified-name resolution must hold up.
+        let src = concat!(
+            "namespace eval app {\n",
+            "    oo::class create Widget {\n",
+            "        method render {} {}\n",
+            "    }\n",
+            "}\n",
+            "set w [app::Widget new]\n",
+            "$w render\n",
+        );
+        let analysis = analyse(src);
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        // `method render` sits on line 2.
+        let render = lenses
+            .iter()
+            .find(|l| l.range.start_line == 2)
+            .expect("render lens");
+        assert_eq!(render.command_title, "1 reference", "{lenses:?}");
+        assert_lens_matches_references(src, 2);
+    }
+
+    #[test]
+    fn lens_counts_obj_method_call_inside_proc_body() {
+        // TP: the dispatch lives inside a proc body, which the top-level
+        // segment scan skips — the resolver descends proc bodies explicitly.
+        let src = concat!(
+            "oo::class create Dog {\n",
+            "    method bark {} {}\n",
+            "}\n",
+            "set d [Dog new]\n",
+            "proc run {} {\n",
+            "    global d\n",
+            "    $d bark\n",
+            "}\n",
+        );
+        let analysis = analyse(src);
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let bark = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("bark lens");
+        assert_eq!(bark.command_title, "1 reference", "{lenses:?}");
+    }
+
+    #[test]
+    fn lens_unknown_instance_method_is_not_counted() {
+        // TN/FP guard: `$x bark` where `x` has no recorded class is not a
+        // resolvable dispatch, so it must not count toward `Dog::bark`.
+        let src = concat!(
+            "oo::class create Dog {\n",
+            "    method bark {} {}\n",
+            "}\n",
+            "$x bark\n",
+        );
+        let analysis = analyse(src);
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let bark = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("bark lens");
+        assert_eq!(bark.command_title, "0 references", "{lenses:?}");
+    }
+
+    #[test]
+    fn lens_classmethod_count_matches_peek() {
+        // A class-side method (`classmethod`) gets a lens, and its count must
+        // equal the peek exactly.  External class-side dispatch (`Factory
+        // build`) is not an instance-receiver form, so the count is 0 here —
+        // and the peek agrees, which is the invariant under test.
+        let src = concat!(
+            "oo::class create Factory {\n",
+            "    classmethod build {} {}\n",
+            "}\n",
+            "Factory build\n",
+        );
+        let analysis = analyse(src);
+        // Locate the classmethod lens by name span; skip if the analyser
+        // build for this dialect didn't record the class-side method.
+        let build_span = match analysis
+            .all_classes
+            .values()
+            .find_map(|c| c.class_methods.get("build"))
+        {
+            Some(m) if !m.name_span.is_empty() => m.name_span,
+            _ => return,
+        };
+        let li = LineIndex::new(src);
+        let name_line = li.position_at_utf16(build_span.start(), src).line;
+        assert_lens_matches_references(src, name_line);
     }
 }

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -166,7 +166,15 @@ pub fn code_lenses(
         // counts both intra-class `my method` dispatch and external
         // `$obj method` call sites (via `instance_classes` type tracking),
         // plus the call sites of any subclass that inherits this definition.
-        emit_class_member_lenses(source, dialect, qname, class_def, analysis, &line_index, &mut lenses);
+        emit_class_member_lenses(
+            source,
+            dialect,
+            qname,
+            class_def,
+            analysis,
+            &line_index,
+            &mut lenses,
+        );
     }
 
     lenses
@@ -730,6 +738,38 @@ mod tests {
             .find(|l| l.range.start_line == 1)
             .expect("speak lens");
         assert_eq!(speak.command_title, "1 reference", "{lenses:?}");
+    }
+
+    #[test]
+    fn lens_matches_peek_for_inherited_method_with_subclass_my_dispatch() {
+        // Codex #881: the lens uses `method_references_for_class`, which counts
+        // a `my speak` call in an *inheriting* subclass body; the peek from the
+        // declaration must count it too (it now shares that resolver), so lens
+        // and peek can't drift.  Here `Base::speak` is referenced by `Derived`'s
+        // `my speak` and by `$d speak` — two sites.
+        let src = concat!(
+            "oo::class create Base {\n",
+            "    method speak {} {}\n",
+            "}\n",
+            "oo::class create Derived {\n",
+            "    superclass Base\n",
+            "    method twice {} { my speak }\n",
+            "}\n",
+            "set d [Derived new]\n",
+            "$d speak\n",
+        );
+        let analysis = analyse(src);
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let speak = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("speak lens");
+        assert_eq!(speak.command_title, "2 references", "{lenses:?}");
+        // Lens and peek (from the `Base::speak` declaration) must agree.
+        assert_lens_matches_references(src, 1);
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -140,8 +140,8 @@ pub fn definition(
     // declaration.  Checked before the proc lookup so a method
     // call resolves to the method even when a same-named proc
     // exists.
-    if let Some((inst, method)) = instance_method_at_cursor(source, line, character)
-        && let Some(class_q) = analysis.instance_classes.get(&inst)
+    if let Some((inst, method, is_dollar)) = instance_method_at_cursor(source, line, character)
+        && let Some(class_q) = receiver_instance_class(analysis, &inst, is_dollar)
         && let Some(span) = lookup_method_in_class(analysis, class_q, &method)
     {
         return vec![span_to_range(source, &line_index, span)];
@@ -367,21 +367,27 @@ fn canonicalise_class(analysis: &AnalysisResult, owner: &str, name: &str) -> Str
     .unwrap_or_else(|| name.to_string())
 }
 
-/// Detect a `$obj method ...` / `[$obj method ...]` call where
-/// the cursor sits on the *method-name* token.  Returns
-/// `(instance_var_name, method_name)`.
+/// Detect a `$obj method ...` / `[$obj method ...]` or
+/// `objcmd method ...` call where the cursor sits on the *method-name*
+/// token.  Returns `(receiver_name, method_name, receiver_is_dollar)`:
+/// `receiver_is_dollar` is `true` for a `$var` / `${var}` receiver (a
+/// variable holding an object) and `false` for a bare object-command
+/// receiver (`objcmd`, e.g. one bound by `CLASS create objcmd`).
 ///
-/// The instance variable must be the command-segment head (a
-/// single `$name` / `${name}` token immediately preceding the
-/// method), so the method sits at word-index 1.  Command
-/// segments are delimited by `;`, `[`, `{`, and the line start
-/// — a single-line approximation that covers the common editor
-/// cases.
+/// The receiver must be the command-segment head (a single token
+/// immediately preceding the method), so the method sits at word-index 1.
+/// Command segments are delimited by `;`, `[`, `{`, and the line start —
+/// a single-line approximation that covers the common editor cases.
+///
+/// Whether a bare receiver actually resolves to a class is decided by
+/// [`receiver_instance_class`], which gates bare receivers on
+/// `created_instance_commands` (so a plain variable's bare name — never a
+/// valid dispatch — does not resolve).
 pub(crate) fn instance_method_at_cursor(
     source: &str,
     line: u32,
     character: u32,
-) -> Option<(String, String)> {
+) -> Option<(String, String, bool)> {
     let line_text = source.split('\n').nth(line as usize)?;
     let chars: Vec<char> = line_text.chars().collect();
     let col = utf16_col_to_char_col(line_text, character).min(chars.len());
@@ -411,21 +417,57 @@ pub(crate) fn instance_method_at_cursor(
         }
     }
     // The head must be exactly one whitespace-delimited token
-    // (the instance var), so the method is word-index 1.
+    // (the receiver), so the method is word-index 1.
     let prefix: String = chars[seg_start..wstart].iter().collect();
     let head_tokens: Vec<&str> = prefix.split_whitespace().collect();
     if head_tokens.len() != 1 {
         return None;
     }
     let head = head_tokens[0];
-    let inst = head.strip_prefix('$')?;
-    let inst = inst
-        .strip_prefix('{')
-        .map_or(inst, |r| r.strip_suffix('}').unwrap_or(r));
-    if inst.is_empty() {
-        return None;
+    if let Some(rest) = head.strip_prefix('$') {
+        // `$var` / `${var}` receiver — a variable holding an object.
+        let inst = rest
+            .strip_prefix('{')
+            .map_or(rest, |r| r.strip_suffix('}').unwrap_or(r));
+        if inst.is_empty() {
+            return None;
+        }
+        Some((inst.to_string(), method, true))
+    } else {
+        // Bare `objcmd` receiver — a plain word naming an object command.
+        // Substituted / decorated heads (`[…]`, `{…}`, quoted) are not bare
+        // object commands; `receiver_instance_class` further gates this on
+        // `created_instance_commands`.
+        if head.is_empty() || head.contains(['[', ']', '{', '}', '"', '(', ')', '$']) {
+            return None;
+        }
+        Some((head.to_string(), method, false))
     }
-    Some((inst.to_string(), method))
+}
+
+/// Resolve a method-dispatch receiver at the cursor (as returned by
+/// [`instance_method_at_cursor`]) to its class's qualified name.
+///
+/// A `$var` receiver (`is_dollar`) is any object-holding variable, looked
+/// up in `instance_classes`.  A bare receiver is a valid dispatch only when
+/// it names an object *command* (`CLASS create NAME`) — a plain variable's
+/// bare name (`set v [CLASS new]` then `v method`) is not a command and must
+/// not resolve — so it is additionally gated on `created_instance_commands`.
+///
+/// Shared by the definition / references / rename / hover cursor paths so
+/// they agree on which receivers dispatch (and, via
+/// `method_references_for_class`, so those match the code-lens count).
+pub(crate) fn receiver_instance_class<'a>(
+    analysis: &'a AnalysisResult,
+    receiver: &str,
+    is_dollar: bool,
+) -> Option<&'a String> {
+    let class = analysis.instance_classes.get(receiver)?;
+    if is_dollar || analysis.created_instance_commands.contains(receiver) {
+        Some(class)
+    } else {
+        None
+    }
 }
 
 /// Look up an alias by name.  Accepts the alias's simple or
@@ -1065,16 +1107,65 @@ mod tests {
     }
 
     #[test]
-    fn instance_method_at_cursor_detects_dollar_head() {
-        let src = "$d bark\n";
-        let got = instance_method_at_cursor(src, 0, 4);
-        assert_eq!(got, Some(("d".to_string(), "bark".to_string())));
+    fn definition_resolves_bare_created_instance_command_method() {
+        // Codex #881: `Dog create rex` then `rex bark` — cursor on the bare
+        // `bark` jumps to the method declaration, mirroring `$obj bark`.
+        let src = "oo::class create Dog {\n    method bark {} {}\n}\nDog create rex\nrex bark\n";
+        let analysis = analyse(src);
+        // Line 4 `rex bark` — `bark` starts at col 4.
+        let locs = definition(src, 4, 4, &analysis);
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        assert_eq!(locs[0].start_line, 1);
     }
 
     #[test]
-    fn instance_method_at_cursor_rejects_non_dollar_head() {
-        // `foo bark` — head is a bare word, not an instance var.
+    fn definition_bare_var_receiver_without_dollar_does_not_resolve() {
+        // `set d [Dog new]` binds `d` as a variable; a bare `d bark` (no `$`)
+        // is not a valid dispatch, so it must not resolve to the method.
+        let src = "oo::class create Dog {\n    method bark {} {}\n}\nset d [Dog new]\nd bark\n";
+        let analysis = analyse(src);
+        let locs = definition(src, 4, 2, &analysis);
+        assert!(locs.is_empty(), "{locs:?}");
+    }
+
+    #[test]
+    fn instance_method_at_cursor_detects_dollar_head() {
+        let src = "$d bark\n";
+        let got = instance_method_at_cursor(src, 0, 4);
+        assert_eq!(got, Some(("d".to_string(), "bark".to_string(), true)));
+    }
+
+    #[test]
+    fn instance_method_at_cursor_reports_bare_head_as_non_dollar() {
+        // `foo bark` — a bare-word receiver (an object command); reported
+        // with `is_dollar == false`.  Whether it actually resolves to a
+        // class is decided later by `receiver_instance_class`.
         let src = "foo bark\n";
+        assert_eq!(
+            instance_method_at_cursor(src, 0, 5),
+            Some(("foo".to_string(), "bark".to_string(), false))
+        );
+    }
+
+    #[test]
+    fn instance_method_at_cursor_rejects_substituted_head() {
+        // `[x] bark` — a command-substitution head is not a bare object
+        // command.
+        let src = "[x] bark\n";
         assert_eq!(instance_method_at_cursor(src, 0, 5), None);
+    }
+
+    #[test]
+    fn receiver_instance_class_gates_bare_on_created_commands() {
+        // `set b [Bar new]` binds `b` as a variable; `Bar create rex` binds
+        // `rex` as an object command.  A bare receiver resolves only for the
+        // command (`rex`), not the variable (`b`); a `$`-receiver resolves
+        // for either.
+        let src =
+            "oo::class create Bar {\n    method get {} {}\n}\nset b [Bar new]\nBar create rex\n";
+        let analysis = analyse(src);
+        assert!(receiver_instance_class(&analysis, "rex", false).is_some());
+        assert!(receiver_instance_class(&analysis, "b", false).is_none());
+        assert!(receiver_instance_class(&analysis, "b", true).is_some());
     }
 }

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -235,9 +235,10 @@ pub fn hover_with_dialect(
     // instance's class is known, render the method summary.
     // Checked before the proc lookup so a method call wins over
     // a same-named proc.
-    if let Some((inst, method)) =
+    if let Some((inst, method, is_dollar)) =
         crate::definition::instance_method_at_cursor(source, line, character)
-        && let Some(class_q) = analysis.instance_classes.get(&inst)
+        && let Some(class_q) =
+            crate::definition::receiver_instance_class(analysis, &inst, is_dollar)
         && let Some(text) = obj_method_hover_text(analysis, class_q, &method)
     {
         return Some(Hover::markdown(text));

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -333,8 +333,9 @@ fn instance_method_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
         analysis,
         include_declaration,
     } = *ctx;
-    let (inst, method) = crate::definition::instance_method_at_cursor(source, line, character)?;
-    let class_q = analysis.instance_classes.get(&inst)?;
+    let (inst, method, is_dollar) =
+        crate::definition::instance_method_at_cursor(source, line, character)?;
+    let class_q = crate::definition::receiver_instance_class(analysis, &inst, is_dollar)?;
     let (decl_span, call_spans) =
         method_references_for_class(source, dialect, analysis, class_q, &method)?;
     Some(build_member_ranges(
@@ -576,19 +577,26 @@ fn find_class_member_references(
         if !(body.start() < cursor_offset && cursor_offset < body.end()) {
             continue;
         }
-        let name_span: Option<Span> = class_def
-            .methods
-            .get(word)
-            .map(|m| m.name_span)
-            .or_else(|| class_def.class_methods.get(word).map(|m| m.name_span))
-            .or_else(|| class_def.properties.get(word).map(|p| p.name_span));
-        let decl_span = name_span?;
-        // Collect call-site spans by re-segmenting every
-        // method body (the analyser doesn't walk into method
-        // bodies for the `command_invocations` collection).
-        let bodies: Vec<Span> = collect_member_bodies(class_def);
+        // Methods / classmethods: defer to the shared resolver — the *same*
+        // one the code lens counts with — so the peek and the lens can never
+        // drift.  It covers intra-class `my method` dispatch, external
+        // `$obj method` / bare `objcmd method` sites, and the call sites of
+        // any subclass that inherits (does not override) this definition
+        // (which the class-local scan below would miss).
+        if class_def.methods.contains_key(word) || class_def.class_methods.contains_key(word) {
+            return method_references_for_class(
+                source,
+                dialect,
+                analysis,
+                &class_def.qualified_name,
+                word,
+            );
+        }
+        // Properties: no `$obj prop` dispatch and no inheritance model, so a
+        // class-local `my <prop>` scan is the whole story.
+        let decl_span = class_def.properties.get(word).map(|p| p.name_span)?;
         let mut call_spans: Vec<Span> = Vec::new();
-        for body_span in bodies {
+        for body_span in collect_member_bodies(class_def) {
             if body_span.is_empty() {
                 continue;
             }
@@ -610,14 +618,9 @@ fn find_class_member_references(
                 tcl_lexer::LexerConfig::for_dialect(dialect),
             );
             for cmd in &commands {
-                // Intra-class dispatch of a method/classmethod is `my <member>`
-                // — the member name is argv[1], not the command head. A bare
-                // head equal to the member name is NOT a call (a TclOO method is
-                // not a command in the body's namespace; `<member> …` without
-                // `my`/an object errors with "invalid command name"), and a
-                // property is read as `$prop`, never as a command head either —
-                // so matching the head produced both false positives (bare
-                // heads) and false negatives (`my <member>` missed).
+                // A property is read as `$prop`, never as a command head; the
+                // only command-form reference is `my <prop>` (its generated
+                // accessor).  Match that, at argv[1].
                 let Some(head) = cmd.argv.first() else {
                     continue;
                 };
@@ -640,27 +643,8 @@ fn find_class_member_references(
                 if &source[n_start..n_end] != word {
                     continue;
                 }
-                // Skip the declaration site itself (cannot happen — the
-                // declaration sits outside method bodies — but defensive).
-                if name_tok.span.start() == decl_span.start()
-                    && name_tok.span.end() == decl_span.end()
-                {
-                    continue;
-                }
                 call_spans.push(name_tok.span);
             }
-        }
-        // Append external `$obj method` call sites for
-        // methods / classmethods (not properties — those
-        // aren't dispatched as `$obj prop`).
-        if class_def.methods.contains_key(word) || class_def.class_methods.contains_key(word) {
-            call_spans.extend(find_obj_method_call_sites(
-                source,
-                dialect,
-                analysis,
-                &class_def.qualified_name,
-                word,
-            ));
         }
         return Some((decl_span, call_spans));
     }
@@ -1416,7 +1400,11 @@ mod tests {
         assert_eq!(sites.len(), 1, "{sites:?}");
         // The matched span is the `bark` method-name token of `rex bark`.
         let s = sites[0];
-        assert_eq!(&src[s.start() as usize..s.end() as usize], "bark", "{sites:?}");
+        assert_eq!(
+            &src[s.start() as usize..s.end() as usize],
+            "bark",
+            "{sites:?}"
+        );
     }
 
     #[test]
@@ -1432,6 +1420,19 @@ mod tests {
     }
 
     #[test]
+    fn references_from_cursor_on_bare_obj_command_call_site() {
+        // Codex #881 (symmetry): invoking Find All References with the cursor
+        // ON the `bark` token of a bare `rex bark` dispatch must resolve — not
+        // only the declaration-based peek.  `rex` is at col 0, `bark` at col 4.
+        let src = "oo::class create Dog {\n    method bark {} {}\n}\nDog create rex\nrex bark\n";
+        let analysis = analyse(src);
+        let refs = references(src, "tcl", 4, 4, &analysis, true);
+        let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+        assert!(lines.contains(&1), "decl missing: {refs:?}");
+        assert!(lines.contains(&4), "call site missing: {refs:?}");
+    }
+
+    #[test]
     fn bare_set_var_receiver_is_not_matched_without_dollar() {
         // FP guard: `set d [Dog new]` binds `d` as a *variable*, not a
         // command.  A bare `d bark` (no `$`) is NOT a valid dispatch in Tcl,
@@ -1439,6 +1440,9 @@ mod tests {
         let src = "oo::class create Dog {\n    method bark {} {}\n}\nset d [Dog new]\nd bark\n";
         let analysis = analyse(src);
         let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark");
-        assert!(sites.is_empty(), "bare var receiver wrongly matched: {sites:?}");
+        assert!(
+            sites.is_empty(),
+            "bare var receiver wrongly matched: {sites:?}"
+        );
     }
 }

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -708,12 +708,22 @@ pub(crate) fn find_obj_method_call_sites(
     if var_set.is_empty() {
         return Vec::new();
     }
+    // Receivers that are also *object commands* — bound by `CLASS create NAME`
+    // (so `NAME` is a command, dispatched bare as `NAME method`, not `$NAME
+    // method`).  A `set v [CLASS new]` receiver is a *variable* only and never
+    // enters this set, so a bare `v method` is (correctly) not matched.
+    let cmd_set: FxHashSet<&str> = var_set
+        .iter()
+        .copied()
+        .filter(|name| analysis.created_instance_commands.contains(*name))
+        .collect();
     let mut out: Vec<tcl_lexer::Span> = Vec::new();
     let mut seen: FxHashSet<(u32, u32)> = FxHashSet::default();
     let ctx = ObjMethodScan {
         source,
         dialect,
         var_set: &var_set,
+        cmd_set: &cmd_set,
         method,
     };
 
@@ -752,14 +762,17 @@ pub(crate) fn find_obj_method_call_sites(
     out
 }
 
-/// Read-only context for the `$v method` call-site scan: the document
-/// `source`, its `dialect`, the set of in-scope instance variable names
-/// (`var_set`), and the `method` being looked up.
+/// Read-only context for the object-method call-site scan: the document
+/// `source`, its `dialect`, the `method` being looked up, and two receiver
+/// sets — `var_set` matches `$v method` dispatch (variables holding an
+/// object, keyed by bare name) and `cmd_set` matches `NAME method` dispatch
+/// (object *commands* bound by `CLASS create NAME`).
 #[derive(Clone, Copy)]
 struct ObjMethodScan<'a> {
     source: &'a str,
     dialect: &'a str,
     var_set: &'a FxHashSet<&'a str>,
+    cmd_set: &'a FxHashSet<&'a str>,
     method: &'a str,
 }
 
@@ -818,17 +831,25 @@ fn scan_obj_method_region(
         tcl_lexer::LexerConfig::for_dialect(ctx.dialect),
     );
     for cmd in &commands {
-        // Head `$v` + method at argv[1].
-        if let (Some(head), Some(method_tok)) = (cmd.argv.first(), cmd.argv.get(1))
-            && head.kind == TokenType::Var
-        {
+        // Head + method at argv[1].  Two dispatch shapes resolve to the same
+        // receiver class: `$v method` (head is a `$`-var whose bare name is in
+        // `var_set`) and `NAME method` (head is a bare word naming an object
+        // command in `cmd_set`).
+        if let (Some(head), Some(method_tok)) = (cmd.argv.first(), cmd.argv.get(1)) {
             let h_start = head.span.start() as usize;
             let h_end = head.span.end() as usize;
             if h_start < source.len() && h_end <= source.len() {
                 let raw = &source[h_start..h_end];
-                if let Some(name) = strip_var_decoration(raw)
-                    && ctx.var_set.contains(name)
-                {
+                let receiver_matches = if head.kind == TokenType::Var {
+                    strip_var_decoration(raw).is_some_and(|name| ctx.var_set.contains(name))
+                } else {
+                    // A bare-word object command (`rex bark`).  `cmd_set` holds
+                    // only plain names, and a braced / bracketed / substituted
+                    // head's source slice keeps its delimiters (`{rex}`, `[x]`),
+                    // so an exact match admits only a genuine bare word.
+                    ctx.cmd_set.contains(raw)
+                };
+                if receiver_matches {
                     let m_start = method_tok.span.start() as usize;
                     let m_end = method_tok.span.end() as usize;
                     if m_start < source.len()
@@ -1382,5 +1403,42 @@ mod tests {
         let analysis = analyse(src);
         let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark");
         assert_eq!(sites.len(), 1, "{sites:?}");
+    }
+
+    #[test]
+    fn find_obj_method_call_sites_matches_bare_created_instance_command() {
+        // `Dog create rex` binds `rex` as an object *command*; `rex bark` is a
+        // bare-word method dispatch (not `$rex bark`).  The scan resolves it
+        // through `created_instance_commands`.
+        let src = "oo::class create Dog {\n    method bark {} {}\n}\nDog create rex\nrex bark\n";
+        let analysis = analyse(src);
+        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark");
+        assert_eq!(sites.len(), 1, "{sites:?}");
+        // The matched span is the `bark` method-name token of `rex bark`.
+        let s = sites[0];
+        assert_eq!(&src[s.start() as usize..s.end() as usize], "bark", "{sites:?}");
+    }
+
+    #[test]
+    fn references_include_bare_created_instance_command_site() {
+        // Full peek: cursor on the `method bark` decl surfaces the bare
+        // `rex bark` dispatch as a reference.
+        let src = "oo::class create Dog {\n    method bark {} {}\n}\nDog create rex\nrex bark\n";
+        let analysis = analyse(src);
+        let refs = references(src, "tcl", 1, 11, &analysis, true);
+        let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+        assert!(lines.contains(&1), "decl missing: {refs:?}");
+        assert!(lines.contains(&4), "bare `rex bark` site missing: {refs:?}");
+    }
+
+    #[test]
+    fn bare_set_var_receiver_is_not_matched_without_dollar() {
+        // FP guard: `set d [Dog new]` binds `d` as a *variable*, not a
+        // command.  A bare `d bark` (no `$`) is NOT a valid dispatch in Tcl,
+        // so it must not be matched — only `$d bark` counts.
+        let src = "oo::class create Dog {\n    method bark {} {}\n}\nset d [Dog new]\nd bark\n";
+        let analysis = analyse(src);
+        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark");
+        assert!(sites.is_empty(), "bare var receiver wrongly matched: {sites:?}");
     }
 }

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -246,9 +246,10 @@ pub fn prepare_rename(
     // rename UI on `prepare_rename` should still see it as
     // renameable.  Resolve `$obj`'s class and confirm a method
     // of that name exists.
-    if let Some((inst, method)) =
+    if let Some((inst, method, is_dollar)) =
         crate::definition::instance_method_at_cursor(source, line, character)
-        && let Some(class_q) = analysis.instance_classes.get(&inst)
+        && let Some(class_q) =
+            crate::definition::receiver_instance_class(analysis, &inst, is_dollar)
         && let Some(class_def) = analysis.all_classes.get(class_q)
     {
         let member = class_def
@@ -345,10 +346,11 @@ pub fn rename(
     // on the method-name token of an instance-method call and
     // `$obj`'s class is known, rename the method across its
     // declaration + all call sites (intra-class + external).
-    if let Some((inst, method)) =
+    if let Some((inst, method, is_dollar)) =
         crate::definition::instance_method_at_cursor(source, line, character)
         && method == word
-        && let Some(class_q) = analysis.instance_classes.get(&inst)
+        && let Some(class_q) =
+            crate::definition::receiver_instance_class(analysis, &inst, is_dollar)
         && let Some(edits) = rename_method_in_class(
             source,
             dialect,
@@ -446,10 +448,11 @@ pub fn method_rename_target(
     let line_index = LineIndex::new(source);
     let (word, _s, _e) = find_word_span_at_position(source, line, character)?;
     // External `$obj method` — resolve `$obj`'s class.
-    if let Some((inst, method)) =
+    if let Some((inst, method, is_dollar)) =
         crate::definition::instance_method_at_cursor(source, line, character)
         && method == word
-        && let Some(class_q) = analysis.instance_classes.get(&inst)
+        && let Some(class_q) =
+            crate::definition::receiver_instance_class(analysis, &inst, is_dollar)
     {
         return Some((class_q.clone(), method));
     }
@@ -1676,7 +1679,28 @@ mod tests {
         }
         let lines: Vec<u32> = edits.iter().map(|e| e.range.start_line).collect();
         assert!(lines.contains(&1), "decl not renamed: {edits:?}");
-        assert!(lines.contains(&4), "bare `rex bark` site not renamed: {edits:?}");
+        assert!(
+            lines.contains(&4),
+            "bare `rex bark` site not renamed: {edits:?}"
+        );
+    }
+
+    #[test]
+    fn rename_method_from_cursor_on_bare_obj_command_call_site() {
+        // Codex #881 (symmetry): triggering rename with the cursor ON the
+        // `bark` token of a bare `rex bark` dispatch rewrites the declaration
+        // and the call site — not only the declaration-triggered rename.
+        let src = "oo::class create Dog {\n    method bark {} {}\n}\nDog create rex\nrex bark\n";
+        let analysis = analyse(src);
+        // Line 4 `rex bark` — cursor on `bark` (col 4).
+        let edits = rename(src, "tcl", 4, 4, "yip", &analysis, None);
+        assert!(edits.len() >= 2, "{edits:?}");
+        for e in &edits {
+            assert_eq!(e.new_text, "yip");
+        }
+        let lines: Vec<u32> = edits.iter().map(|e| e.range.start_line).collect();
+        assert!(lines.contains(&1), "decl not renamed: {edits:?}");
+        assert!(lines.contains(&4), "call site not renamed: {edits:?}");
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -1664,6 +1664,22 @@ mod tests {
     }
 
     #[test]
+    fn rename_method_rewrites_bare_created_instance_command_site() {
+        // `Dog create rex` binds `rex` as an object command, so renaming
+        // `bark` must also rewrite the bare `rex bark` dispatch — the same
+        // shared resolver drives the peek, the lens, and the rename.
+        let src = "oo::class create Dog {\n    method bark {} {}\n}\nDog create rex\nrex bark\n";
+        let analysis = analyse(src);
+        let edits = rename(src, "tcl", 1, 11, "yip", &analysis, None);
+        for e in &edits {
+            assert_eq!(e.new_text, "yip");
+        }
+        let lines: Vec<u32> = edits.iter().map(|e| e.range.start_line).collect();
+        assert!(lines.contains(&1), "decl not renamed: {edits:?}");
+        assert!(lines.contains(&4), "bare `rex bark` site not renamed: {edits:?}");
+    }
+
+    #[test]
     fn rename_method_from_external_call_site() {
         // Triggering rename from the external `$d bark` site
         // rewrites the declaration + all sites.

--- a/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
+++ b/rust/tcl-lsp-core/tests/lsp_lens_links_symbols.rs
@@ -496,13 +496,14 @@ fn lens_carries_qualified_name_in_data() {
 
 #[test]
 fn lens_counts_method_calls_inside_class_body() {
-    // tclsh: inside `oo::class create C`, method `greet` is called twice from
-    // method `twice`'s body. The class members are real (info class methods C
-    // -> greet twice), and the lens on `greet` counts the two in-body calls.
+    // tclsh: inside `oo::class create C`, method `greet` is dispatched twice
+    // from method `twice`'s body.  TclOO self-dispatch is `my greet` — a bare
+    // `greet` resolves as a normal command, never the object's method — and
+    // the lens on `greet` counts the two `my greet` calls.
     let src = concat!(
         "oo::class create C {\n",
         "    method greet {} {}\n",
-        "    method twice {} { greet ; greet }\n",
+        "    method twice {} { my greet ; my greet }\n",
         "}\n",
     );
     let analysis = analyse(src);

--- a/rust/tcl-lsp-server/tests/e2e/editor_features.rs
+++ b/rust/tcl-lsp-server/tests/e2e/editor_features.rs
@@ -159,6 +159,68 @@ fn test_unresolved_call_scoped_to_namespace() {
     assert_eq!(b["command"]["title"], json!("0 references"));
 }
 
+/// Title of the method / member lens anchored on `line` (0-based).  Member
+/// lenses are informational: their eager `command.title` is authoritative
+/// and needs no `codeLens/resolve`.
+fn member_lens_title_on_line(ls: &[Value], line: i64) -> Option<String> {
+    ls.iter()
+        .find(|l| l["range"]["start"]["line"].as_i64() == Some(line))
+        .and_then(|l| l["command"]["title"].as_str())
+        .map(str::to_owned)
+}
+
+#[test]
+fn test_method_lens_counts_external_obj_dispatch_issue_864() {
+    // Regression for issue #864: the lens above `method get` must count the
+    // external `$b get foo` dispatch (`set b [Bar new]`), reading
+    // "1 reference" rather than the "0 references" the old heuristic showed.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "oo::class create Bar {\n\
+         \x20  variable _options\n\
+         \x20   constructor {args} {\n\
+         \x20        set _options $args\n\
+         \x20   }\n\
+         \n\
+         \x20   method get {key} {\n\
+         \x20       return [dict get $_options $key]\n\
+         \x20   }\n\
+         \n\
+         }\n\
+         set b [Bar new]\n\
+         puts [$b get foo]\n",
+    );
+    let ls = lenses(&mut lsp, &uri);
+    // `method get` is on line 6 (0-based).
+    let title = member_lens_title_on_line(&ls, 6)
+        .unwrap_or_else(|| panic!("no method lens on line 6: {ls:?}"));
+    assert_eq!(title, "1 reference", "{ls:?}");
+    // The lens count must equal Find All References (declaration excluded) on
+    // the `get` method-name token (`    method get` → col 11).
+    let refs = match lsp.references(&uri, 6, 11, false) {
+        Value::Array(a) => a,
+        _ => Vec::new(),
+    };
+    assert_eq!(refs.len(), 1, "peek disagrees with lens: {refs:?}");
+}
+
+#[test]
+fn test_method_lens_zero_when_uncalled() {
+    // TN: an instance method with no dispatch site reads "0 references".
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "oo::class create Solo {\n    method lonely {} {}\n}\nSolo new\n",
+    );
+    let ls = lenses(&mut lsp, &uri);
+    let title = member_lens_title_on_line(&ls, 1)
+        .unwrap_or_else(|| panic!("no method lens on line 1: {ls:?}"));
+    assert_eq!(title, "0 references", "{ls:?}");
+}
+
 // -- TestDocumentLinks ---------------------------------------------------
 
 #[test]


### PR DESCRIPTION
## Summary

- Fixes #864: the `N references` code lens above a TclOO `method` / `classmethod` reported `0 references` even when the method was dispatched (the screenshot showed `0 references` on `method get` despite `puts [$b get foo]`).
- Root cause: `code_lens.rs` counted method references with a private heuristic (`count_method_calls_in_body`) that scanned sibling method bodies for a bare command **head** equal to the method name. That never matches real TclOO dispatch — intra-class self-calls are `my method` (name at argv[1], not the head) and `$obj method` calls are external to the class body — so it both missed genuine references and could miscount unrelated bare words.
- Fix (centralisation): the lens count now comes from `references::method_references_for_class` — the single resolver Find All References and rename already use — so the lens title and the peek can never drift. It counts intra-class `my method` dispatch, external `$obj method` sites (via the analyser's `instance_classes` variable-type tracking), and the call sites of any subclass that inherits the definition. The divergent `count_method_calls_in_body` helper is removed.
- Generalised `find_obj_method_call_sites` to also match bare object-command receivers bound by `CLASS create NAME` (`rex bark`), resolved through `created_instance_commands`, so the peek, the lens, and rename all recognise that idiomatic dispatch form. A `set v [CLASS new]` receiver is a variable only, so a bare `v method` is correctly not matched.
- No new command-name hardcoding and no `match cmd_name` special-casing — the change removes a heuristic and leans on analyser-tracked data, matching the registry-as-source-of-truth principle. No new `#[allow]`s.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
cargo test -p tcl-lsp-core --lib          # 919 passed
cargo test -p tcl-lsp-server --test e2e   # 702 passed
cargo clippy -p tcl-lsp-core -p tcl-lsp-server --all-targets -- -D warnings   # clean, no new allows
# editors/vscode: npx tsc -p ./ --noEmit (only pre-existing generated-asset error), eslint + prettier clean
```

New tests:
- Unit (TP/FP/TN/FN) in `code_lens.rs`: external `$obj` dispatch counted; `dict get` ensemble-subcommand and bare words *not* counted; uncalled method → 0; inheritance; namespaced classes; bare instance-command dispatch; classmethod lens==peek.
- `references.rs` / `rename.rs`: tests for the new bare-receiver (`CLASS create NAME`) dispatch form.
- Native e2e (`editor_features.rs`): `textDocument/codeLens` asserts `1 reference` on the issue snippet, and `0 references` for an uncalled method.
- VS Code integration test + `codeLensMethodRefs.tcl` fixture.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **No** — the change is entirely in the LSP layer (`tcl-lsp-core`). It *consumes* existing analyser facts (`instance_classes`, `created_instance_commands`) but does not change how they are produced.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. (N/A)
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`. (N/A)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_014AKA8QMUiz5sutSs5co6j2)_