### PR TITLE
Close command/variable indirection gaps in shimmer analysis (FP-SH-13/15/18)

### DIFF
--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -4644,10 +4644,15 @@ re-deriving trace recognition — see
 
 ### FP-SH-13 — array-element writes collapse onto one SSA symbol; two stable-but-different elements must not read as one variable oscillating
 
-- **Verdict:** FALSE POSITIVE (S102) — open (documented, not fixed for S100/S101)
-- **Status:** FIXED for S102 (Rust port deep review); S100/S101 share the same
-  underlying array-element conflation and are not in scope for this fix.
-- **Codes:** S102
+- **Verdict:** FALSE POSITIVE (S100/S101/S102) — fixed
+- **Status:** FIXED for all three shimmer codes. Originally fixed for S102 only
+  (Rust port deep review); the same `array_element_symbols` exclusion is now
+  shared by the use-site (S100/S101) and phi-merge (S101) passes, so an
+  independent-element conflation no longer false-positives through *any*
+  shimmer surface. Proper per-element SSA modelling (which would let a
+  genuinely-oscillating single element still fire) remains the larger,
+  out-of-scope alternative.
+- **Codes:** S100, S101, S102
 - **Corpus:** synthetic (a per-element-stable array accumulator, the common
   Tcl idiom `set arr(id) [somefn $arr(id)]`).
 
@@ -4682,21 +4687,30 @@ proc f {} {
 `shimmer::thunking::array_element_symbols` scans every `AssignConst` /
 `AssignExpr` / `AssignValue` / `Incr` statement in the function for a raw
 target name matching `codegen::values::split_array_ref`'s `arr(key)` shape
-(reused, not re-derived) and excludes the resolved base `Symbol` from S102
-entirely — `classify_thunking_phi` bails immediately for any such symbol. The
-guard is conservative in the *unsound* direction only for coverage, not
-correctness: a genuinely oscillating single array element (this reproducer)
-now goes undetected rather than risk flagging unrelated elements — an
-accepted trade-off documented here, not a residual bug. S100/S101 (use-site
-and non-loop phi shimmer) still see the same conflated symbol and are left
-as-is; a full fix needs per-element SSA modelling, out of scope for this
-review.
+(reused, not re-derived) and excludes the resolved base `Symbol` from shimmer
+reporting entirely. It is now `pub(super)`, so all three passes share the one
+exclusion: `classify_thunking_phi` (S102), `check_invocation` / `check_incr_var`
+(S100/S101 use-site) and `classify_phi_shimmer` (S101 phi-merge) each bail for
+an array-base symbol. The guard is conservative in the *unsound* direction only
+for coverage, not correctness: a genuinely oscillating single array element
+(this reproducer) now goes undetected rather than risk flagging unrelated
+elements — an accepted trade-off documented here, not a residual bug. A full
+fix needs per-element SSA modelling (array elements collapse onto one symbol
+via `tcl_syntax::naming::normalise_var_name` stripping the `(key)` suffix
+everywhere), out of scope for this review.
 
 #### Tests
 
-- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_13_array_element_conflation_no_s102` (FP)
-- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_13_scalar_control_still_fires` (TP control)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_13_array_element_conflation_no_s102` (FP, S102)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_13_array_element_use_site_no_s100` (FP, S100)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_13_array_element_loop_use_site_no_s101` (FP, S101)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_13_array_element_phi_merge_no_s100` (FP, phi merge)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_13_scalar_control_still_fires` (TP control, S102)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_13_scalar_use_site_still_fires` (TP control, S100)
 - `rust::tcl_compiler::shimmer::thunking::tests::no_s102_for_array_element_conflation` (FP, unit level)
+- `rust::tcl_compiler::shimmer::use_site::tests::no_use_site_shimmer_for_array_element_conflation` (FP, unit level)
+- `rust::tcl_compiler::shimmer::phi::tests::no_phi_shimmer_for_array_element_conflation` (FP, unit level)
+- `rust::tcl_lsp_server::e2e::diagnostic_matrix::s100_silent_for_array_element_use_site` (FP, e2e)
 
 ---
 
@@ -4785,26 +4799,38 @@ initialiser — not where the developer needs to look.
 
 ---
 
-### FP-SH-15 — tricky command/variable indirection stays conservative (no false positives): rename, interp alias, safe sub-interpreter eval, TclOO instance variables, `args`/parameters
+### FP-SH-15 — tricky command/variable indirection: rename, interp alias, safe sub-interpreter eval, TclOO instance variables, `args`/parameters
 
-- **Verdict:** CONFIRM-CORRECT (conservative — several are also known FALSE NEGATIVE / detection-gap surfaces, documented not fixed)
-- **Status:** covered by regression tests (Rust port deep review); the
-  indirections themselves are not resolved (real detection gaps for `rename`,
-  `interp alias`, and TclOO instance variables — tracked here, not silently
-  assumed safe).
-- **Codes:** S102
+- **Verdict:** three detection gaps now CLOSED (rename, interp alias, TclOO
+  instance variables via `my variable`); the remaining surfaces stay
+  CONFIRM-CORRECT (conservative — safe sub-interpreter eval, positional
+  parameters, unknown-command result).
+- **Status:** FIXED for surfaces 1, 2, and 5. A renamed/aliased builtin now
+  resolves back to its registry spec through the lowerer's `canonical_command`
+  snapshot (threaded into `type_infer` and `ssa::uses_of`); `my variable` is
+  recognised as a namespace-style scope alias by `var_observability`. Surfaces
+  3, 6, and 7 remain intentionally conservative and are pinned by regression
+  tests.
+- **Codes:** S100, S101, S102
 - **Corpus:** synthetic (one reproducer per indirection surface).
 
 #### Reproducers and per-surface reasoning
 
-1. **`rename set myset`** — a command renamed onto a registry builtin is not
-   resolved back to that builtin's spec anywhere `type_infer` looks, so
-   `myset x …` types as an unknown `Call` (OVERDEFINED return) — same
-   conservative outcome as calling any unregistered command
-   (`fp_sh_01_overdefined_silent`). Detection gap, not a false positive.
-2. **`interp alias {} myset {} set`** — the interpreter-level alias table is
-   not consulted by `type_infer` either; same conservative OVERDEFINED
-   outcome and same gap.
+1. **`rename set myset`** *(gap now closed)* — the lowerer records the rename
+   in the same binding snapshot it already keeps for `interp alias` (gated on
+   the target being a registered builtin), so `myset x …` carries
+   `canonical_command = set`. `type_infer` types the store's def from its value
+   word (a canonical-`set` value passthrough, keyed on the `Set` lowering
+   hook), and `ssa::uses_of` scans that value like the un-aliased `set` (so a
+   braced `[expr {$x+1}]` still exposes the `$x` read and the loop-header phi
+   forms). The renamed store now oscillates int↔string exactly as `set` does,
+   firing S102. Genuine thunk — `myset` *is* `set`.
+2. **`interp alias {} myset {} set`** *(gap now closed)* — the alias table was
+   already snapshotted into `canonical_command` (PR #872 for T101); threading
+   that canonical through `type_infer` / `ssa` closes S102 identically to the
+   rename case. Codegen still emits a runtime `invokeStk` for the alias (an
+   alias is not inline-foldable — its binding may change by call time); only
+   the analysis type-lattice and def/use resolve it.
 3. **`$slave eval {...}`** (a safe sub-interpreter) — the braced body is an
    opaque string argument to `eval`, not statically-analysed Tcl source in
    this compilation unit; nothing inside it is visited. No crash, no S102.
@@ -4821,12 +4847,18 @@ initialiser — not where the developer needs to look.
    body now genuinely fires S102 (`tcl diag` on a bare `set local …` inside
    `method run {}`), so the silence on `variable x` is the scope-alias
    protection actually firing, not the method body being skipped.
-5. **`my variable x`** — *not* recognised as a scope-alias declaration at all
-   (the registry spec for `my` carries no `CREATES_SCOPE_ALIAS`/subcommand
-   table); `$x` reads the never-versioned live-in symbol, same as any unbound
-   name. A real detection blind spot for snit/TclOO instance-variable
-   shimmer reached exclusively through `my variable` — tracked here, not
-   fixed.
+5. **`my variable x`** *(blind spot now closed)* — `var_observability::stmt_gen`
+   recognises the `my variable NAME …` compound (`var_scoping::
+   my_variable_declaration_indices`, which — unlike the top-level `variable`
+   *command* — treats every argument after the `variable` subcommand word as a
+   plain instance-variable name, no name/value pairs) and marks each name as a
+   `NAMESPACE` escape. `crate::sccp::is_externally_mutable` then forces every
+   def of the instance variable to OVERDEFINED, exactly as a bare `variable x`
+   *inside* the method body is protected (FP-SH-16). The previously-latent
+   false positive — `my variable x; set x 0; while {…oscillate…}`, where the
+   local `set x 0` used to give the loop a versioned `Known(Int)` entry and
+   fire a spurious S102 — is now silent, while an unaliased sibling local in
+   the same method still fires (the protection is keyed on the declared name).
 6. **A plain positional parameter as the oscillation seed** (`proc f {p} {
    while {1} { set p [expr {$p+1}]; set p [string range $p 0 end] } }`)  — a
    parameter's entry type is unknowable at compile time (the caller may pass
@@ -4841,24 +4873,38 @@ initialiser — not where the developer needs to look.
 
 #### Why the analyser reaches that verdict
 
-None of these seven surfaces are special-cased anywhere in `shimmer/thunking.rs`
-— every one stays silent purely because the *type lattice* degrades to
-OVERDEFINED (unknown command return, live-in version 0, opaque string body) or
-the *SSA symbol* never versions at all (scope-alias `Barrier`, unrecognised
-`my variable`). No new logic was added or needed; these tests exist to pin the
-current, intentional behaviour so a future change to command resolution,
-`interp alias` handling, or `my`'s registry spec doesn't silently introduce a
-false positive through one of these paths.
+The three *closed* gaps resolve the indirection at the boundary and stay generic
+downstream, per AGENTS.md: `rename` / `interp alias` are snapshotted into the
+lowerer's alias map so a renamed/aliased builtin carries `canonical_command`,
+which `type_infer::evaluate_type_def` / `type_infer_process_statements` and
+`ssa::uses_of` consume (value-passthrough typing + value-word read scanning,
+both keyed on the registry's `Set` lowering hook, never a hardcoded name);
+`my variable` is recognised by the shared escaping-set detector
+(`var_observability`) via a `var_scoping` declaration helper, feeding the same
+`is_externally_mutable` predicate SCCP already uses. The four *remaining*
+surfaces stay silent purely because the *type lattice* degrades to OVERDEFINED
+(unknown command return, live-in version 0, opaque string body) — no shimmer
+special-casing. The tests pin both the fixes and the intentional conservatism so
+a future change can't silently regress either.
 
 #### Tests
 
-- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_rename_indirection_no_s102`
-- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_interp_alias_indirection_no_s102`
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_rename_indirection_fires_s102` (gap closed → TP)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_interp_alias_indirection_fires_s102` (gap closed → TP)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_alias_onto_non_store_no_s102` (TN control — alias onto a non-store command)
 - `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_safe_sub_interpreter_eval_no_s102`
 - `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_tcloo_instance_variable_no_s102`
-- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_my_variable_idiom_no_s102`
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_my_variable_idiom_no_s102` (now protected via scope-alias recognition)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_my_variable_locally_initialised_no_s102` (the previously-latent FP, now silent)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_my_variable_unaliased_sibling_local_still_fires` (TP control)
 - `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_parameter_seeded_oscillation_no_s102`
 - `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_15_unknown_command_result_no_s102`
+- `rust::tcl_compiler::var_observability::tests::my_variable_marks_namespace_alias`
+- `rust::tcl_compiler::alias::tests::detect_rename_basic_move`
+- `rust::tcl_compiler::type_infer::tests::aliased_set_call_types_def_from_value`
+- `rust::tcl_compiler::ssa::tests::set_value_reads_parses_braced_expr`
+- `rust::tcl_lsp_server::e2e::diagnostic_matrix::s102_fires_for_rename_indirection` (e2e)
+- `rust::tcl_lsp_server::e2e::diagnostic_matrix::s102_fires_on_defect` (e2e, interp alias)
 
 ---
 
@@ -4966,6 +5012,89 @@ alone, regardless of how many local versions it has.
 - `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_16_global_alias_locally_initialised_no_s102` (FP, now fixed)
 - `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_16_unaliased_sibling_local_still_fires` (TP control)
 - `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_16_namespace_alias_without_local_init_no_s102` (TN control)
+
+---
+
+### FP-SH-18 — a Numeric loop-body oscillation seeded by an Int entry was masked to OVERDEFINED by `type_join`'s exact-equality Known-vs-Shimmered rule
+
+- **Verdict:** FALSE NEGATIVE (S100/S101/S102) — fixed
+- **Status:** FIXED. Found but not fixed during the original S102 review and
+  flagged as a foundational `types.rs` change with broad blast radius; closed
+  here after validating the numeric refinement against the whole compiler test
+  corpus (a true-LUB, monotone lattice change).
+- **Codes:** S100, S101, S102 (any consumer of `TypeLattice`; W307/W308 also
+  consume it but are unaffected — an object-ness query does not distinguish
+  SHIMMERED from OVERDEFINED).
+- **Corpus:** synthetic.
+
+#### Reproducer (false negative, now fixed)
+
+```tcl
+proc f {n} {
+    set x 0
+    while {$n > 0} {
+        if {$n % 2} {
+            set x [expr {$x + $n}]
+        } else {
+            set x "s$x"
+        }
+        incr n -1
+    }
+    return $x
+}
+```
+
+#### Reproducer (TN control — a uniformly-numeric loop must stay silent)
+
+```tcl
+proc f {n} {
+    set x 0
+    while {$n > 0} {
+        set x [expr {$x + $n}]
+        incr n -1
+    }
+    return $x
+}
+```
+
+#### Per-line reasoning
+
+1. The loop body is self-referential (both arms read `$x`) and produces
+   `Numeric` (`expr {$x + $n}` on the loop-carried `$x`, whose type is not a
+   compile-time constant) on one arm and `String` (`"s$x"`) on the other, so
+   the bottom-of-loop join is `SHIMMERED(Numeric, String)`.
+2. The loop entry is `Known(Int)` (`set x 0`). The loop-header phi therefore
+   joins `Known(Int)` with `SHIMMERED(Numeric, String)`.
+3. Pre-fix, `type_join`'s one-Known-one-Shimmered arm matched the known type
+   against each shimmer side by **exact `TclType` equality**. `Int != Numeric`
+   and `Int != String`, so the join degraded to OVERDEFINED — and
+   `classify_thunking_phi` bails on a non-SHIMMERED header phi, silently
+   masking the genuine per-iteration numeric↔string thunk.
+
+#### Why the analyser reaches that verdict
+
+`types::type_join` now applies a **numeric refinement** before falling to
+OVERDEFINED: a `Known` numeric-family type (`Int`/`Double`/`Boolean`/`Numeric`,
+via `is_numeric_family`) meeting a numeric-family shimmer side is subsumed by
+that side, and the side widens to `Numeric` so the result stays a sound upper
+bound of the `Known` type (`Double ⊔ SHIMMERED(Int, String)` =
+`SHIMMERED(Numeric, String)`, which covers `Double` — `SHIMMERED(Int, …)` would
+not). This is deliberately **not** routed through `numeric_promotion`, whose
+`Some`-if-either-operand-is-`Double` shape would wrongly match a non-numeric
+side (`numeric_promotion(Double, String) → Numeric`) and drop it. A non-numeric
+`Known` type that matches neither side still degrades to OVERDEFINED, so the
+refinement never blanket-keeps a join SHIMMERED (the TN control's uniformly-Int
+`Known ⊔ Known` promotes to `Numeric`, never shimmers).
+
+#### Tests
+
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_18_numeric_shimmer_masked_by_int_entry_fires_s102` (FN, now TP)
+- `rust::tcl_compiler::analyser::diagnostics::fp::sh::fp_sh_18_uniform_numeric_loop_no_s102` (TN control)
+- `rust::tcl_compiler::shimmer::thunking::tests::thunking_detected_for_numeric_shimmer_masked_by_int_entry` (FN, unit level)
+- `rust::tcl_compiler::types::tests::known_int_matches_numeric_shimmer_side` (lattice unit)
+- `rust::tcl_compiler::types::tests::known_double_widens_int_shimmer_side_to_numeric` (soundness/LUB unit)
+- `rust::tcl_compiler::types::tests::known_non_numeric_no_match_still_overdefined` (guard unit)
+- `rust::tcl_lsp_server::e2e::diagnostic_matrix::s102_fires_for_numeric_shimmer_masked_by_int_entry` (e2e)
 
 ---
 

--- a/editors/vscode/src/test/precisionFalsePositives.test.ts
+++ b/editors/vscode/src/test/precisionFalsePositives.test.ts
@@ -293,3 +293,52 @@ suite("Expanded subcommand position (FP-STY-18)", () => {
     }
   });
 });
+
+// FP-SH-13 / FP-SH-15 / FP-SH-18 — command/variable indirection and the
+// array-element / numeric-shimmer precision fixes, end-to-end through the
+// real server (fixture `shimmerIndirection.tcl`).
+//
+//   • `aliased` (lines 4–10): an `interp alias {} myset {} set` store still
+//     resolves to the real `set`, so its int/string oscillation fires S102.
+//   • `arrayelems` (lines 14–18): `arr(n)` (int) and `arr(label)` (string)
+//     collapse onto one symbol but are independent slots — no S100/S101.
+//   • `numeric` (lines 23–34): a Numeric/String oscillation seeded by an Int
+//     entry, previously masked to OVERDEFINED by `type_join` — now fires S102.
+suite("Command/variable indirection + numeric shimmer (FP-SH-13/15/18)", () => {
+  const docUri = getDocUri("shimmerIndirection.tcl");
+
+  test("aliased set and int-seeded numeric loops fire S102 (true case)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "S102"),
+    });
+    const s102Lines = linesWithCode(diags, "S102");
+    assert.ok(s102Lines.length >= 1, "expected at least one S102 (analysis ran)");
+    // The aliased-store oscillation fires inside `aliased`'s loop body (7–8).
+    assert.ok(
+      s102Lines.some((ln) => ln >= 5 && ln <= 9),
+      `expected S102 in the aliased loop (lines 5-9); got [${s102Lines}]`,
+    );
+    // The numeric/string oscillation fires inside `numeric`'s loop (>= 24).
+    assert.ok(
+      s102Lines.some((ln) => ln >= 24),
+      `expected S102 in the numeric loop (line >= 24); got [${s102Lines}]`,
+    );
+  });
+
+  test("array-element conflation stays silent for S100/S101 (false case)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "S102"),
+    });
+    // No S100/S101 on the array-element proc lines (15–18).
+    for (const code of ["S100", "S101"]) {
+      for (const ln of linesWithCode(diags, code)) {
+        assert.ok(
+          !(ln >= 14 && ln <= 18),
+          `unexpected ${code} on array-element line ${ln} (independent slots)`,
+        );
+      }
+    }
+  });
+});

--- a/editors/vscode/testFixture/shimmerIndirection.tcl
+++ b/editors/vscode/testFixture/shimmerIndirection.tcl
@@ -1,0 +1,35 @@
+interp alias {} myset {} set
+
+# Aliased `set` still resolves to the real command, so this loop-carried
+# int/string oscillation through the alias is a genuine thunk -> S102.
+proc aliased {} {
+    myset x 0
+    while {1} {
+        myset x [expr {$x + 1}]
+        myset x [string range $x 0 end]
+    }
+}
+
+# arr(n) is always int and arr(label) always string -> independent slots, not
+# one variable oscillating. Must not fire S100/S101 (FP-SH-13).
+proc arrayelems {} {
+    set arr(n) 5
+    set arr(label) "text"
+    incr arr(n)
+}
+
+# A numeric/string oscillation seeded by an int entry (`set x 0`): the loop
+# body is Numeric on one arm and String on the other. Previously masked to
+# OVERDEFINED by type_join; now fires S102 (FP-SH-18).
+proc numeric {n} {
+    set x 0
+    while {$n > 0} {
+        if {$n % 2} {
+            set x [expr {$x + $n}]
+        } else {
+            set x "s$x"
+        }
+        incr n -1
+    }
+    return $x
+}

--- a/rust/tcl-compiler/src/alias.rs
+++ b/rust/tcl-compiler/src/alias.rs
@@ -108,35 +108,36 @@ pub fn detect_interp_alias_delete(cmd_name: &str, args: &[String]) -> Option<Str
     Some(normalise_qualified_name(alias_name))
 }
 
-/// Detect a static `rename oldName newName` — both names literal text,
-/// `newName` non-empty (an empty `newName` *deletes* `oldName` rather
-/// than renaming it, per Tcl semantics, and creates no new alias).
+/// Detect a static `rename oldName newName` **move** — both names literal
+/// text, `newName` non-empty (an empty `newName` *deletes* `oldName` rather
+/// than renaming it, per Tcl semantics, and creates no new alias), and neither
+/// dynamically substituted.
 ///
-/// Returns `(qualified_new_name, old_name)` — the same `(alias name,
-/// target)` shape [`detect_interp_alias`] returns, so both feed the same
-/// [`CommandAliasMap`]: for every purpose this map serves (arg-role /
-/// body-form resolution, taint sink dispatch), a `rename` is
-/// indistinguishable from an `interp alias {} newName {} oldName` —
-/// calling through the new name really does invoke the old command.
+/// Returns `(old_name, new_name)` — **both raw**, unlike [`detect_interp_alias`]
+/// which pre-qualifies its alias name at the global root. `rename` binds
+/// `newName` in the *current* namespace (`rename set myset` inside
+/// `namespace eval ::ns` creates `::ns::myset`, not global `::myset`), so the
+/// caller qualifies `new` against the namespace the `rename` runs in;
+/// qualifying here would wrongly root every renamed name globally. For every
+/// purpose the alias map serves (arg-role / body-form resolution, taint sink
+/// dispatch, canonical-command typing), a `rename` is then indistinguishable
+/// from an `interp alias {} newName {} oldName` — calling through the new name
+/// really does invoke the old command.
 #[must_use]
 pub fn detect_rename(cmd_name: &str, args: &[String]) -> Option<(String, String)> {
     if cmd_name != "rename" || args.len() != 2 {
         return None;
     }
-    let old = &args[0];
-    let new = &args[1];
-    if old.is_empty() || new.is_empty() {
+    let (old, new) = (&args[0], &args[1]);
+    // `rename $old newName` / `rename oldName [x]` — a dynamic component means
+    // the true target isn't known statically; recording it verbatim would map
+    // `newName` to a literal, never-registered string like `"$old"`, silently
+    // dropping arg-role/body/sink treatment for `newName` calls instead of just
+    // leaving them unaliased. An empty `new` is a deletion, not a rename.
+    if old.is_empty() || new.is_empty() || is_dynamic_word(old) || is_dynamic_word(new) {
         return None;
     }
-    // `rename $old newName` / `rename oldName [x]` — a dynamic component
-    // means the true target isn't known statically; recording it verbatim
-    // would map `newName` to a literal, never-registered string like
-    // `"$old"`, silently dropping arg-role/body/sink treatment for
-    // `newName` calls instead of just leaving them unaliased.
-    if is_dynamic_word(old) || is_dynamic_word(new) {
-        return None;
-    }
-    Some((normalise_qualified_name(new), old.clone()))
+    Some((old.clone(), new.clone()))
 }
 
 /// Look up a command alias, namespace-aware.
@@ -245,9 +246,10 @@ mod tests {
 
     #[test]
     fn detect_rename_basic() {
+        // Returns `(old, new)` raw — the caller namespace-qualifies `new`.
         let args: Vec<String> = vec!["eval".into(), "myEval".into()];
         let result = detect_rename("rename", &args);
-        assert_eq!(result, Some(("::myEval".to_string(), "eval".to_string())));
+        assert_eq!(result, Some(("eval".to_string(), "myEval".to_string())));
     }
 
     #[test]
@@ -288,11 +290,13 @@ mod tests {
 
     #[test]
     fn detect_rename_qualified_new_name() {
+        // A `::`-qualified NEW is returned verbatim; the caller
+        // (`join_namespace`) leaves it rooted globally.
         let args: Vec<String> = vec!["eval".into(), "::ns::myEval".into()];
         let result = detect_rename("rename", &args);
         assert_eq!(
             result,
-            Some(("::ns::myEval".to_string(), "eval".to_string()))
+            Some(("eval".to_string(), "::ns::myEval".to_string()))
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
@@ -498,6 +498,85 @@ proc f {} {
     );
 }
 
+/// FP-SH-13 (extended to S100): the S102 array-element guard now also covers
+/// the use-site pass. `set arr(n) 5; set arr(label) "text"; incr arr(n)` reads
+/// the conflated `arr` symbol as STRING (the last element written), but
+/// `arr(n)` is always INT — an independent slot, not a shimmer. No S100.
+#[test]
+fn fp_sh_13_array_element_use_site_no_s100() {
+    let src = "\
+proc f {} {
+    set arr(n) 5
+    set arr(label) \"text\"
+    incr arr(n)
+}
+";
+    let got = codes(src, D);
+    assert!(
+        !got.iter().any(|c| c == "S100" || c == "S101"),
+        "FP-SH-13: array-element use-site must not fire S100/S101; got {got:?}"
+    );
+}
+
+/// FP-SH-13 (extended to S101): the same conflation inside a loop must not
+/// fire the per-iteration S101 either.
+#[test]
+fn fp_sh_13_array_element_loop_use_site_no_s101() {
+    let src = "\
+proc f {items} {
+    set arr(n) 5
+    foreach i $items {
+        set arr(label) \"text\"
+        incr arr(n)
+    }
+}
+";
+    let got = codes(src, D);
+    assert!(
+        !got.iter().any(|c| c == "S100" || c == "S101"),
+        "FP-SH-13: array-element loop use-site must not fire S101; got {got:?}"
+    );
+}
+
+/// FP-SH-13 (extended to the phi pass): a branch merge of two different array
+/// elements must not phi-shimmer the conflated base symbol.
+#[test]
+fn fp_sh_13_array_element_phi_merge_no_s100() {
+    let src = "\
+proc f {c} {
+    if {$c} {
+        set arr(n) 5
+    } else {
+        set arr(s) \"hi\"
+    }
+    return [string length $arr(n)]
+}
+";
+    let got = codes(src, D);
+    assert!(
+        !got.iter().any(|c| c == "S100" || c == "S101"),
+        "FP-SH-13: array-element phi merge must not fire S100/S101; got {got:?}"
+    );
+}
+
+/// FP-SH-13 TP control for the use-site guard: a plain scalar with the same
+/// int→string→incr shape still fires — the array guard is keyed on array-base
+/// symbols only, not a blanket use-site suppression.
+#[test]
+fn fp_sh_13_scalar_use_site_still_fires() {
+    let src = "\
+proc f {} {
+    set n hello
+    incr n
+}
+";
+    assert!(
+        fires(src, D, "S100"),
+        "FP-SH-13 TP: plain scalar use-site shimmer must still fire S100; got {:?}",
+        codes(src, D)
+    );
+}
+
 // ---------------------------------------------------------------------------
 // FP-SH-14 — a self-referential variable that oscillates through an
 // intermediate branch merge (not a direct loop-header incoming edge) is
@@ -571,12 +650,17 @@ proc f {n} {
 // oscillation seed
 // ---------------------------------------------------------------------------
 
-/// FP-SH-15: a command renamed onto `set` (`rename set myset`) is not
-/// resolved back to the registry's `set` spec for type inference, so the
-/// literal-driven oscillation through the alias is invisible — conservative
-/// (no S102), not a crash or a false positive through the indirection.
+/// FP-SH-15 (detection gap now closed): a command renamed onto `set`
+/// (`rename set myset`) resolves back to the registry's `set` spec. The
+/// lowerer records the rename in the same binding snapshot it uses for
+/// `interp alias` (so the store carries `canonical_command = set`), and
+/// `type_infer` types the def from its value word while `ssa::uses_of` scans
+/// that value like the un-aliased `set` — so the loop-carried int/string
+/// oscillation forms a header phi and fires S102. Genuine thunk, not a false
+/// positive: `myset` *is* `set`, so the per-iteration re-conversion is real
+/// (verified against tclsh — the renamed store behaves identically to `set`).
 #[test]
-fn fp_sh_15_rename_indirection_no_s102() {
+fn fp_sh_15_rename_indirection_fires_s102() {
     let src = "\
 proc f {} {
     rename set myset
@@ -587,18 +671,47 @@ proc f {} {
     }
 }
 ";
-    let got = codes(src, D);
     assert!(
-        !got.iter().any(|c| c == "S102"),
-        "FP-SH-15: rename indirection must not fire a spurious S102; got {got:?}"
+        fires(src, D, "S102"),
+        "FP-SH-15: rename-onto-set oscillation must resolve to `set` and fire S102; got {:?}",
+        codes(src, D)
     );
 }
 
-/// FP-SH-15: `interp alias {} myset {} set` is the same indirection through
-/// the interpreter's alias table rather than `rename` — same conservative,
-/// no-S102 outcome.
+/// FP-SH-15: a `rename` inside `namespace eval ::ns` binds NEW in *that*
+/// namespace (`::ns::myset`), not globally — so the namespace-qualified call
+/// resolves to `set` and fires S102. Regression for the Codex review point
+/// that qualifying NEW with `normalise_qualified_name` alone recorded a global
+/// `::myset` (missing the real `::ns::myset` calls, and mis-analysing a global
+/// `myset` that Tcl considers invalid).
 #[test]
-fn fp_sh_15_interp_alias_indirection_no_s102() {
+fn fp_sh_15_namespaced_rename_indirection_fires_s102() {
+    let src = "\
+namespace eval ::ns {
+    rename set myset
+    proc f {} {
+        myset x 0
+        while {1} {
+            myset x [expr {$x + 1}]
+            myset x [string range $x 0 end]
+        }
+    }
+}
+";
+    assert!(
+        fires(src, D, "S102"),
+        "FP-SH-15: a namespace-relative rename must bind ::ns::myset and fire S102; got {:?}",
+        codes(src, D)
+    );
+}
+
+/// FP-SH-15 (detection gap now closed): `interp alias {} myset {} set` is the
+/// same indirection through the interpreter's alias table rather than
+/// `rename` — the lowerer already records it, so threading
+/// `canonical_command` through `type_infer` / `ssa` closes it identically to
+/// the rename case. S102 fires on the genuine oscillation.
+#[test]
+fn fp_sh_15_interp_alias_indirection_fires_s102() {
     let src = "\
 interp alias {} myset {} set
 proc f {} {
@@ -609,10 +722,35 @@ proc f {} {
     }
 }
 ";
+    assert!(
+        fires(src, D, "S102"),
+        "FP-SH-15: interp-alias-onto-set oscillation must resolve to `set` and fire S102; got {:?}",
+        codes(src, D)
+    );
+}
+
+/// FP-SH-15 TN control: an `interp alias` / `rename` onto a command that is
+/// *not* a value-passthrough store must not gain a spurious oscillation. Here
+/// `myputs` aliases `puts` (no def, no value passthrough), so the loop body
+/// defines nothing and S102 cannot fire — proves the canonical-command
+/// resolution is keyed on the real command's spec, not a blanket
+/// "aliased command oscillates".
+#[test]
+fn fp_sh_15_alias_onto_non_store_no_s102() {
+    let src = "\
+interp alias {} myputs {} puts
+proc f {} {
+    set x 0
+    while {1} {
+        myputs [expr {$x + 1}]
+        myputs [string range $x 0 end]
+    }
+}
+";
     let got = codes(src, D);
     assert!(
         !got.iter().any(|c| c == "S102"),
-        "FP-SH-15: interp alias indirection must not fire a spurious S102; got {got:?}"
+        "FP-SH-15: alias onto a non-store command must not fabricate S102; got {got:?}"
     );
 }
 
@@ -689,6 +827,58 @@ oo::class create C {
     assert!(
         !got.iter().any(|c| c == "S102"),
         "FP-SH-15: 'my variable' idiom must not fire S102; got {got:?}"
+    );
+}
+
+/// FP-SH-15 (blind-spot fix, the case that was a genuine false positive):
+/// `my variable x` *followed by a local `set x 0`* used to give the loop a
+/// versioned `Known(Int)` entry and fire a spurious S102 — the instance
+/// variable's intrep is externally determined (the constructor / other
+/// methods can set it), so this must stay silent, the same protection a bare
+/// `variable x; set x 0` already had (FP-SH-16).
+#[test]
+fn fp_sh_15_my_variable_locally_initialised_no_s102() {
+    let src = "\
+oo::class create C {
+    method run {} {
+        my variable x
+        set x 0
+        while {1} {
+            set x [expr {$x + 1}]
+            set x [string range $x 0 end]
+        }
+    }
+}
+";
+    let got = codes(src, D);
+    assert!(
+        !got.iter().any(|c| c == "S102"),
+        "FP-SH-15: locally-initialised 'my variable' instance var must not fire S102; got {got:?}"
+    );
+}
+
+/// FP-SH-15 TP control: an *unaliased* plain local in the same method, with
+/// the identical oscillation, must still fire — proves the `my variable`
+/// recognition is keyed on the declared instance-variable name, not a blanket
+/// suppression of S102 inside method bodies.
+#[test]
+fn fp_sh_15_my_variable_unaliased_sibling_local_still_fires() {
+    let src = "\
+oo::class create C {
+    method run {} {
+        my variable x
+        set local 0
+        while {1} {
+            set local [expr {$local + 1}]
+            set local [string range $local 0 end]
+        }
+    }
+}
+";
+    assert!(
+        fires(src, D, "S102"),
+        "FP-SH-15 TP: an unaliased sibling local in the method must still fire S102; got {:?}",
+        codes(src, D)
     );
 }
 
@@ -863,8 +1053,8 @@ fn fp_sh_09_untraced_variable_still_fires() {
 }
 
 /// FP-SH-09: the trace can be installed by a *different* proc — the
-/// module-wide `ModuleVariableTraces` fact must still widen the def, not
-/// just a same-function `analyse_var_observability` scan.
+/// module-wide variable-trace fact must still widen the def, not just a
+/// same-function `analyse_var_observability` scan.
 #[test]
 fn fp_sh_09_module_wide_trace_from_another_proc_suppresses_shimmer() {
     let src = "\
@@ -990,6 +1180,45 @@ fn fp_sh_17_regsub_output_in_arithmetic_still_fires() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// FP-SH-18 — a numeric loop-body oscillation seeded by an Int entry was
+// masked: `type_join`'s exact-equality Known-vs-Shimmered rule degraded
+// `Known(Int) ⊔ SHIMMERED(Numeric, String)` to OVERDEFINED, so the genuine
+// thunk went undetected. The numeric-refinement join keeps it SHIMMERED.
+// ---------------------------------------------------------------------------
+
+/// FP-SH-18 (detection gap now closed): a self-referential loop whose body
+/// oscillates between `Numeric` (from `expr {$x + …}` on the loop-carried
+/// `$x`) and `String`, seeded by an `Int` entry (`set x 0`). Pre-fix the
+/// loop-header phi joined `Known(Int)` with the body's `SHIMMERED(Numeric,
+/// String)` and — because `Int != Numeric` under exact equality — degraded to
+/// OVERDEFINED, silently masking the thunk. `Int` is subsumed by the `Numeric`
+/// side, so the join now stays SHIMMERED and S102 fires. Genuine thunk
+/// (verified against tclsh: the loop pays a per-iteration numeric↔string
+/// re-conversion).
+#[test]
+fn fp_sh_18_numeric_shimmer_masked_by_int_entry_fires_s102() {
+    let src = "\
+proc f {n} {
+    set x 0
+    while {$n > 0} {
+        if {$n % 2} {
+            set x [expr {$x + $n}]
+        } else {
+            set x \"s$x\"
+        }
+        incr n -1
+    }
+    return $x
+}
+";
+    assert!(
+        fires(src, D, "S102"),
+        "FP-SH-18: numeric/string oscillation seeded by an Int entry must fire S102; got {:?}",
+        codes(src, D)
+    );
+}
+
 /// FP-SH-17: a call that writes several variables under the default typing
 /// (`catch {body} resultVar optionsVar`) must not broadcast its `Int` status
 /// return onto them — `result`/`opts` (and the body's `msg`) stay overdefined,
@@ -1033,5 +1262,27 @@ fn fp_sh_17_lassign_leftover_capture_is_list() {
     assert!(
         !got.iter().any(|c| c == "S100" || c == "S101"),
         "FP-SH-17: lassign leftover is a List used as a list — no shimmer; got {got:?}"
+    );
+}
+
+/// FP-SH-18 TN control: a loop whose body is uniformly numeric (`Int` entry,
+/// `expr`-only body) must NOT fire — the numeric refinement must not turn a
+/// clean numeric loop into a spurious shimmer.
+#[test]
+fn fp_sh_18_uniform_numeric_loop_no_s102() {
+    let src = "\
+proc f {n} {
+    set x 0
+    while {$n > 0} {
+        set x [expr {$x + $n}]
+        incr n -1
+    }
+    return $x
+}
+";
+    let got = codes(src, D);
+    assert!(
+        !got.iter().any(|c| c == "S102"),
+        "FP-SH-18: a uniformly-numeric loop must not fire S102; got {got:?}"
     );
 }

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -1071,14 +1071,23 @@ impl<'r> Lowerer<'r> {
         // Detect `interp alias {} name {} target ?args?` and static
         // `rename oldName newName` — both feed the same alias table, since
         // calling through a renamed name and calling through an `interp
-        // alias` are indistinguishable for arg-role / body-form resolution
-        // and taint sink dispatch (`interp alias {} myEval {} eval` and
-        // `rename eval myEval` both make `myEval $x` reach the `eval` sink).
+        // alias` are indistinguishable for arg-role / body-form resolution,
+        // taint sink dispatch, and canonical-command typing (`interp alias {}
+        // myEval {} eval` and `rename eval myEval` both make `myEval $x` reach
+        // the `eval` sink). `interp alias` pre-qualifies its name at the global
+        // root, but `rename` binds NEW in the *current* namespace, so qualify
+        // it against `namespace` — an unqualified `rename set myset` inside
+        // `namespace eval ::ns` binds `::ns::myset`, not global `::myset` (and
+        // global `myset` is then invalid). `join_namespace` leaves an
+        // already-`::`-qualified NEW rooted globally, matching how
+        // `resolve_alias` looks the name back up (current namespace, then
+        // global) and `command_binding`'s own namespace-relative candidates.
         let args_owned: Vec<String> = args.to_vec();
         if let Some((qualified, target, prepended)) = detect_interp_alias(cmd_name, &args_owned) {
             self.aliases.insert(qualified, (target, prepended));
-        } else if let Some((qualified, target)) = detect_rename(cmd_name, &args_owned) {
-            self.aliases.insert(qualified, (target, Vec::new()));
+        } else if let Some((old, new)) = detect_rename(cmd_name, &args_owned) {
+            self.aliases
+                .insert(join_namespace(namespace, &new), (old, Vec::new()));
         }
 
         self.record_namespace_directives(cmd_name, args, seg, namespace);

--- a/rust/tcl-compiler/src/shimmer/phi.rs
+++ b/rust/tcl-compiler/src/shimmer/phi.rs
@@ -58,11 +58,20 @@ struct PhiCtx<'a> {
     loop_blocks: &'a HashSet<String>,
     loop_body_types: &'a HashMap<Symbol, HashSet<TclType>>,
     def_map: &'a HashMap<ValueKey, tcl_lexer::Span>,
+    /// Array-base symbols excluded from shimmer reporting (FP-SH-13) — a
+    /// conflated `arr(a)`/`arr(b)` phi merges independent elements.
+    array_syms: &'a HashSet<Symbol>,
 }
 
 /// Decide whether one phi node is a genuine merge-point shimmer, returning
 /// the warning when it is (the per-phi body of [`find_phi_shimmers`]).
 fn classify_phi_shimmer(ctx: &PhiCtx<'_>, phi: &Phi, in_loop: bool) -> Option<ShimmerWarning> {
+    // Skip an array base (FP-SH-13): the `(key)` suffix is stripped before
+    // interning, so a phi over `arr` merges whatever different elements were
+    // last written — not one variable's own two intreps.
+    if ctx.array_syms.contains(&phi.name) {
+        return None;
+    }
     let lattice = ctx.types.get(&(phi.name, phi.version))?;
     if lattice.kind != TypeKind::Shimmered {
         return None;
@@ -172,6 +181,7 @@ pub(crate) fn find_phi_shimmers(
     // per-loop S102 thunking pass), built from the whole loop-block set.
     let loop_body_types =
         per_loop_body_types("", &loop_blocks, &destructure, ssa, types, &empty_by_name);
+    let array_syms = super::thunking::array_element_symbols(cfg, ssa);
     let ctx = PhiCtx {
         cfg,
         ssa,
@@ -180,6 +190,7 @@ pub(crate) fn find_phi_shimmers(
         loop_blocks: &loop_blocks,
         loop_body_types: &loop_body_types,
         def_map: &def_map,
+        array_syms: &array_syms,
     };
     let mut out = Vec::new();
 
@@ -257,6 +268,43 @@ mod tests {
         let cu = CompilationUnit::build_for("", &registry(), false);
         let fu = cu.function("::top").unwrap();
         let _ = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+    }
+
+    /// Array elements collapse onto one SSA symbol, so a phi over `arr` merges
+    /// whatever different elements each branch last wrote — not one variable's
+    /// own two intreps (FP-SH-13). `if {$c} {set arr(n) 5} else {set arr(s)
+    /// "hi"}` must not phi-shimmer `arr`.
+    #[test]
+    fn no_phi_shimmer_for_array_element_conflation() {
+        let cu = CompilationUnit::build_for(
+            "proc f {c} { if {$c} { set arr(n) 5 } else { set arr(s) \"hi\" }\n \
+             return [string length $arr(n)] }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        assert!(
+            !warnings.iter().any(|w| w.variable == "arr"),
+            "array-element conflation must not phi-shimmer: {warnings:?}"
+        );
+    }
+
+    /// TP control: a plain scalar Int/String merge still phi-shimmers — the
+    /// array guard must not blanket-silence the phi pass.
+    #[test]
+    fn phi_shimmer_still_fires_for_scalar_control() {
+        let cu = CompilationUnit::build_for(
+            "set cond [gets stdin]\nif {$cond} { set y 1 } else { set y \"hi\" }\nputs $y",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::top").unwrap();
+        let warnings = find_phi_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        assert!(
+            warnings.iter().any(|w| w.variable == "y"),
+            "plain scalar merge must still phi-shimmer: {warnings:?}"
+        );
     }
 
     /// An if/else that assigns Int on one branch and String on the other

--- a/rust/tcl-compiler/src/shimmer/thunking.rs
+++ b/rust/tcl-compiler/src/shimmer/thunking.rs
@@ -215,7 +215,12 @@ pub(super) fn per_loop_body_types(
 /// unrelated elements; reuses the same array-reference recognition
 /// [`crate::codegen::values::split_array_ref`] already provides for
 /// codegen, rather than re-deriving the `(...)` pattern here.
-fn array_element_symbols(cfg: &CfgFunction, ssa: &SsaFunction) -> HashSet<Symbol> {
+///
+/// `pub(super)` so the sibling use-site (S100/S101) and phi-merge (S101) passes
+/// share the *same* exclusion: every element of an array collapses onto one
+/// symbol for all three passes, so any one of them can conflate two
+/// stable-but-different elements into a spurious shimmer (FP-SH-13).
+pub(super) fn array_element_symbols(cfg: &CfgFunction, ssa: &SsaFunction) -> HashSet<Symbol> {
     let mut out = HashSet::new();
     for block in cfg.blocks.values() {
         for stmt in &block.statements {
@@ -756,6 +761,28 @@ mod tests {
         let fu = cu.function("::f").unwrap();
         let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
         assert!(w.is_empty(), "traced variable must not thunk: {w:?}");
+    }
+
+    /// A self-referential loop whose body-exit is `SHIMMERED(Numeric, String)`
+    /// merging with an `Int` loop entry: pre-fix `type_join` degraded
+    /// `Known(Int) ⊔ SHIMMERED(Numeric, String)` to OVERDEFINED (exact-equality
+    /// match), silently masking the genuine thunk. The numeric-refinement join
+    /// keeps the header phi SHIMMERED, so S102 now fires.
+    #[test]
+    fn thunking_detected_for_numeric_shimmer_masked_by_int_entry() {
+        let cu = CompilationUnit::build_for(
+            "proc f {n} { set x 0\n \
+             while {$n > 0} { if {$n % 2} { set x [expr {$x + $n}] } else { set x \"s$x\" }\n \
+             incr n -1 }\n return $x }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        assert!(
+            w.iter().any(|tw| tw.variable == "x"),
+            "numeric/string oscillation seeded by an Int entry must fire S102: {w:?}"
+        );
     }
 
     /// TP control for the above: the identical loop shape, untraced, must

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -73,6 +73,13 @@ pub(crate) fn find_use_site_shimmers(
     // Loop-invariance facts for the S101→S100 downgrade — only needed when
     // the function has at least one loop block.
     let loop_facts = LoopFacts::compute(cfg, ssa, &loop_blocks, registry);
+    // Array-base symbols are excluded (FP-SH-13): `normalise_var_name` strips
+    // the `(key)` suffix, so `arr(a)` and `arr(b)` share one symbol / version
+    // chain. Two individually-stable but different elements then look, at a
+    // use site, exactly like one variable holding the wrong intrep — the same
+    // conflation the S102 pass already guards. Reuse its exclusion so S100 /
+    // S101 don't false-positive on independent array elements.
+    let array_syms = super::thunking::array_element_symbols(cfg, ssa);
     let mut out: Vec<ShimmerWarning> = Vec::new();
 
     for block_id in cfg_order(cfg) {
@@ -95,6 +102,7 @@ pub(crate) fn find_use_site_shimmers(
             values,
             loop_facts: &loop_facts,
             ssa,
+            array_syms: &array_syms,
             in_loop,
             already_coerced: &mut already_coerced,
             out: &mut out,
@@ -117,6 +125,9 @@ struct UseSiteCtx<'a> {
     values: &'a HashMap<ValueKey, LatticeValue>,
     loop_facts: &'a LoopFacts,
     ssa: &'a SsaFunction,
+    /// Array-base symbols excluded from shimmer reporting (FP-SH-13) — a
+    /// conflated `arr(a)`/`arr(b)` symbol can hold either element's intrep.
+    array_syms: &'a HashSet<Symbol>,
     in_loop: bool,
     already_coerced: &'a mut HashSet<(String, u32, TclType)>,
     out: &'a mut Vec<ShimmerWarning>,
@@ -349,6 +360,12 @@ fn check_invocation(
         let Some(sym) = ctx.ssa.var_symbol(&var) else {
             continue;
         };
+        // Skip an array base (FP-SH-13): its conflated version chain mixes
+        // independent elements, so a "wrong intrep" here may just be a
+        // different element's type.
+        if ctx.array_syms.contains(&sym) {
+            continue;
+        }
         let Some(&ver) = uses.get(&sym) else { continue };
         if ver == 0 {
             continue;
@@ -526,6 +543,10 @@ fn check_incr_var(ctx: &mut UseSiteCtx<'_>, var: &str, span: Span, uses: &HashMa
     let Some(sym) = ctx.ssa.var_symbol(var) else {
         return;
     };
+    // Skip an array base (FP-SH-13) — see `check_invocation`.
+    if ctx.array_syms.contains(&sym) {
+        return;
+    }
     let Some(&ver) = uses.get(&sym) else { return };
     if ver == 0 {
         return;
@@ -959,6 +980,56 @@ mod tests {
         );
         assert_eq!(w.unwrap().from_type, TclType::String);
         assert_eq!(w.unwrap().to_type, TclType::Int);
+    }
+
+    /// Array elements collapse onto one SSA symbol (the `(key)` suffix is
+    /// stripped before interning), so two individually-stable but different
+    /// elements must not use-site shimmer against each other (FP-SH-13):
+    /// `set arr(n) 5; set arr(label) "text"; incr arr(n)` must not report
+    /// `arr` as "string used with incr" — `arr(n)` is always int.
+    #[test]
+    fn no_use_site_shimmer_for_array_element_conflation() {
+        let cu = CompilationUnit::build_for(
+            "proc f {} { set arr(n) 5\n set arr(label) \"text\"\n incr arr(n) }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        assert!(
+            warnings.is_empty(),
+            "array-element conflation must not use-site shimmer: {warnings:?}"
+        );
+    }
+
+    /// TP control: the identical shape on a plain scalar still fires — the
+    /// array guard must not blanket-silence use-site shimmer.
+    #[test]
+    fn use_site_shimmer_still_fires_for_scalar_control() {
+        let cu =
+            CompilationUnit::build_for("proc f {} { set n hello\n incr n }", &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        assert!(
+            warnings
+                .iter()
+                .any(|w| w.command == "incr" && w.variable == "n"),
+            "plain scalar must still use-site shimmer: {warnings:?}"
+        );
     }
 
     /// Variables with Unknown type do not produce false-positive shimmers.

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -949,34 +949,8 @@ pub fn uses_of(
             uses_in_assignment(stmt, scanner, registry, &mut vars_found, &mut reads_own_def);
         }
 
-        Statement::Call {
-            command,
-            args,
-            defs,
-            reads,
-            reads_own_defs,
-            tokens,
-            ..
-        } => {
-            scan_command_words(
-                command,
-                args,
-                tokens.as_ref(),
-                scanner,
-                registry,
-                &mut vars_found,
-            );
-            for name in reads {
-                if !name.is_empty() {
-                    vars_found.insert(name.clone());
-                }
-            }
-            if *reads_own_defs {
-                for name in defs {
-                    vars_found.insert(name.clone());
-                    reads_own_def.insert(name.clone());
-                }
-            }
+        Statement::Call { .. } => {
+            uses_in_call(stmt, scanner, registry, &mut vars_found, &mut reads_own_def);
         }
 
         Statement::Return { value, expr, .. } => {
@@ -1073,6 +1047,116 @@ pub fn uses_of(
 /// name-bearing variable(s) (the genuine read the dead-store / unused checks
 /// need — `defs_of` withholds the static def); a static target that the RHS
 /// also reads is recorded as read-before-write. Extracted from [`uses_of`].
+/// The value word an aliased / renamed `set` (`interp alias {} myset {} set` /
+/// `rename set myset`) stores, or `None` when the `Call` is not a
+/// value-passthrough store in the `set VAR VALUE` shape.
+///
+/// Keyed off the *canonical* command's `Set` lowering hook — the registry's
+/// own "this is a value-passthrough store" fact — so the read scan matches the
+/// un-aliased `set`, never the source spelling. The two-arg / single-def guard
+/// restricts it to the setter shape (no `interp alias` prepended args shifting
+/// the value word out of `args[1]`, and not the one-arg getter, which has no
+/// def).
+fn canonical_set_value<'a>(
+    command: &str,
+    canonical_command: Option<&str>,
+    args: &'a [String],
+    defs: &[String],
+    registry: &CommandRegistry,
+) -> Option<&'a str> {
+    if defs.len() != 1 || args.len() != 2 {
+        return None;
+    }
+    let canon = canonical_command.unwrap_or(command);
+    let is_set = registry.get(canon).and_then(|s| s.lowering_hook)
+        == Some(tcl_registry::hooks::LoweringHookId::Set);
+    is_set.then(|| args[1].as_str())
+}
+
+/// Reads of a `set`-style value word, matching what the un-aliased `set`
+/// lowering captures: an `[expr {…}]` value is parsed as an expression (so a
+/// braced `$x`, which plain word scanning would miss, is seen); any other value
+/// word is scanned for `$`-substitutions, recursing into `[...]` command
+/// substitutions.
+fn set_value_reads(
+    value: &str,
+    scanner: &mut VarReferenceScanner,
+    registry: &CommandRegistry,
+) -> BTreeSet<String> {
+    let trimmed = value.trim();
+    if let Some(inner) = trimmed.strip_prefix('[').and_then(|s| s.strip_suffix(']'))
+        && let Some(expr_arg) =
+            crate::lowering_hooks::extract_single_expr_arg(inner, &HashSet::new())
+    {
+        return vars_in_expr(&crate::parse_expr(&expr_arg, None));
+    }
+    scanner.scan_word(value, registry)
+}
+
+/// Variable reads of a [`Statement::Call`]: its head + non-body argument
+/// words, the explicit `VarRead`-role names (`reads`), a read-modify-write
+/// target (`reads_own_defs`), and — for an aliased / renamed `set` — its value
+/// word. Mirrors [`uses_in_assignment`]'s shape; extracted from [`uses_of`].
+///
+/// An aliased / renamed `set` (`interp alias {} myset {} set` / `rename set
+/// myset`) stays a runtime `Call` (codegen must not inline it — the binding may
+/// change by call time), but for def/use it reads its value word exactly as the
+/// un-aliased `set VAR VALUE` would: an `[expr {…}]` value is parsed as an
+/// expression so a braced `$x` is seen, and the target is a read-before-write
+/// whenever the value references it. Without this a loop-carried self-store
+/// (`myset x [expr {$x+1}]`) would look write-only, so no header phi would form
+/// and S102 could never fire on the aliased store.
+fn uses_in_call(
+    stmt: &Statement,
+    scanner: &mut VarReferenceScanner,
+    registry: &CommandRegistry,
+    vars_found: &mut BTreeSet<String>,
+    reads_own_def: &mut BTreeSet<String>,
+) {
+    let Statement::Call {
+        command,
+        canonical_command,
+        args,
+        defs,
+        reads,
+        reads_own_defs,
+        tokens,
+        ..
+    } = stmt
+    else {
+        return;
+    };
+    scan_command_words(
+        command,
+        args,
+        tokens.as_ref(),
+        scanner,
+        registry,
+        vars_found,
+    );
+    if let Some(value) =
+        canonical_set_value(command, canonical_command.as_deref(), args, defs, registry)
+    {
+        for v in set_value_reads(value, scanner, registry) {
+            if defs.iter().any(|d| d.as_str() == v) {
+                reads_own_def.insert(v.clone());
+            }
+            vars_found.insert(v);
+        }
+    }
+    for name in reads {
+        if !name.is_empty() {
+            vars_found.insert(name.clone());
+        }
+    }
+    if *reads_own_defs {
+        for name in defs {
+            vars_found.insert(name.clone());
+            reads_own_def.insert(name.clone());
+        }
+    }
+}
+
 fn uses_in_assignment(
     stmt: &Statement,
     scanner: &mut VarReferenceScanner,
@@ -2682,6 +2766,51 @@ mod tests {
             header_blk.phis.iter().any(|p| p.name == si),
             "header should have a phi for i"
         );
+    }
+
+    #[test]
+    fn canonical_set_value_recognises_aliased_setter_only() {
+        let reg = default_registry();
+        let s = |xs: &[&str]| xs.iter().map(|x| (*x).to_owned()).collect::<Vec<_>>();
+        // Aliased `set` (2-arg setter) → the value word.
+        assert_eq!(
+            canonical_set_value("myset", Some("set"), &s(&["x", "0"]), &s(&["x"]), &reg),
+            Some("0")
+        );
+        // One-arg getter (no def) → None.
+        assert_eq!(
+            canonical_set_value("myset", Some("set"), &s(&["x"]), &[], &reg),
+            None
+        );
+        // A non-set canonical (an aliased `puts`) → None.
+        assert_eq!(
+            canonical_set_value("myputs", Some("puts"), &s(&["x", "0"]), &s(&["x"]), &reg),
+            None
+        );
+        // No canonical + a bare non-set command → None.
+        assert_eq!(
+            canonical_set_value("frobnicate", None, &s(&["x", "0"]), &s(&["x"]), &reg),
+            None
+        );
+    }
+
+    #[test]
+    fn set_value_reads_parses_braced_expr() {
+        let reg = default_registry();
+        let mut scanner = VarReferenceScanner::new(VarScanOptions::default());
+        // A braced `[expr {…}]` value: plain word scanning misses `$x` inside
+        // the braces, so it must be parsed as an expression.
+        assert!(
+            set_value_reads("[expr {$x + 1}]", &mut scanner, &reg).contains("x"),
+            "braced expr value must expose $x as a read"
+        );
+        // A command-substitution value with a bare `$x` is caught by ordinary
+        // recursion.
+        assert!(set_value_reads("[string range $x 0 end]", &mut scanner, &reg).contains("x"));
+        // A pure var-ref value.
+        assert!(set_value_reads("$y", &mut scanner, &reg).contains("y"));
+        // A bare literal reads nothing.
+        assert!(set_value_reads("0", &mut scanner, &reg).is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -561,6 +561,60 @@ fn container_retrieval_object_type(
     Some(TypeLattice::object_of(class))
 }
 
+/// Infer the intrep a `set`-style value *word* stores.
+///
+/// The shared body of the [`Statement::AssignValue`] typing and the
+/// value-passthrough typing of a canonically-`set` [`Statement::Call`] (an
+/// aliased or renamed `set`).  A pure `$var` reference inherits the source
+/// version's type, a `[cmd …]` command substitution takes the command's
+/// declared return type (or an object-collection retrieval), an
+/// interpolated / otherwise-complex word is `String`, and a bare literal is
+/// classified by its Tcl intrep.
+fn value_word_type<S: std::hash::BuildHasher>(
+    value: &str,
+    uses: &HashMap<Symbol, u32>,
+    types: &HashMap<ValueKey, TypeLattice>,
+    registry: &CommandRegistry,
+    known_classes: &HashSet<String, S>,
+    namespace: &str,
+    ssa: &SsaFunction,
+) -> TypeLattice {
+    let stripped = value.trim();
+    // Pure variable reference: inherit source type.
+    if is_pure_var_ref(stripped) {
+        let name = normalise_var_name(stripped);
+        if let Some(&ver) = ssa.var_symbol(name).and_then(|s| uses.get(&s))
+            && ver > 0
+        {
+            return ssa
+                .var_symbol(name)
+                .and_then(|s| types.get(&(s, ver)))
+                .cloned()
+                .unwrap_or_else(TypeLattice::unknown);
+        }
+        return TypeLattice::unknown();
+    }
+    // Command substitution: [cmd ...].
+    if stripped.starts_with('[')
+        && stripped.ends_with(']')
+        && let Some((cmd, args)) = parse_command_substitution(stripped)
+    {
+        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+        // A `dict get $coll k` / `lindex $coll i` on an object-homogeneous
+        // collection yields an `OBJECT(element_class)` — resolved before
+        // the command's declared (`String`/`Overdefined`) return type.
+        if let Some(t) = container_retrieval_object_type(&cmd, &arg_refs, uses, types, ssa) {
+            return t;
+        }
+        return return_type_for_command(registry, &cmd, &arg_refs, known_classes, namespace);
+    }
+    // String interpolation or complex value.
+    if value.contains('$') || value.contains('[') {
+        return TypeLattice::of(TclType::String);
+    }
+    literal_type(value)
+}
+
 /// Infer the type produced by `stmt` under the current `types` map.
 #[must_use]
 fn evaluate_type_def<S: std::hash::BuildHasher>(
@@ -591,64 +645,57 @@ fn evaluate_type_def<S: std::hash::BuildHasher>(
         }
 
         Statement::AssignValue { value, .. } => {
-            let stripped = value.trim();
-            // Pure variable reference: inherit source type.
-            if is_pure_var_ref(stripped) {
-                let name = normalise_var_name(stripped);
-                if let Some(&ver) = ssa.var_symbol(name).and_then(|s| uses.get(&s))
-                    && ver > 0
-                {
-                    return ssa
-                        .var_symbol(name)
-                        .and_then(|s| types.get(&(s, ver)))
-                        .cloned()
-                        .unwrap_or_else(TypeLattice::unknown);
-                }
-                return TypeLattice::unknown();
-            }
-            // Command substitution: [cmd ...].
-            if stripped.starts_with('[')
-                && stripped.ends_with(']')
-                && let Some((cmd, args)) = parse_command_substitution(stripped)
-            {
-                let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-                // A `dict get $coll k` / `lindex $coll i` on an object-homogeneous
-                // collection yields an `OBJECT(element_class)` — resolved before
-                // the command's declared (`String`/`Overdefined`) return type.
-                if let Some(t) = container_retrieval_object_type(&cmd, &arg_refs, uses, types, ssa)
-                {
-                    return t;
-                }
-                return return_type_for_command(
-                    registry,
-                    &cmd,
-                    &arg_refs,
-                    known_classes,
-                    namespace,
-                );
-            }
-            // String interpolation or complex value.
-            if value.contains('$') || value.contains('[') {
-                return TypeLattice::of(TclType::String);
-            }
-            literal_type(value)
+            value_word_type(value, uses, types, registry, known_classes, namespace, ssa)
         }
 
         Statement::Incr { .. } => TypeLattice::of(TclType::Int),
 
         Statement::Call {
             command,
+            canonical_command,
             args,
             defs,
             ..
         } if !defs.is_empty() => {
+            // Resolve the source spelling through the lowerer's
+            // `canonical_command` snapshot (an `interp alias` / `rename`
+            // target) so a renamed or aliased builtin — `rename set myset` /
+            // `interp alias {} myset {} set` — is typed by the *real* command's
+            // registry spec, not left as an unknown `Call` (OVERDEFINED).
+            let canon = canonical_command.as_deref().unwrap_or(command);
             let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            // A canonically-`set` store keeps its runtime `Call` shape for
+            // codegen — an aliased / renamed command is not inline-foldable,
+            // its binding may change by call time — but for the type lattice
+            // its single def takes the *value word's* intrep verbatim, exactly
+            // as the un-aliased [`Statement::AssignValue`] path does. Keyed off
+            // the canonical command's `Set` lowering hook (the registry's own
+            // "this is a value-passthrough store" fact), never the source
+            // spelling. The two-arg / single-def guard restricts this to the
+            // `set VAR VALUE` setter shape (no `interp alias` prepended args
+            // shifting the value word out of `args[1]`, and not the one-arg
+            // getter, which has no def).
+            if defs.len() == 1
+                && arg_refs.len() == 2
+                && registry.get(canon).and_then(|s| s.lowering_hook)
+                    == Some(tcl_registry::hooks::LoweringHookId::Set)
+            {
+                return value_word_type(
+                    arg_refs[1],
+                    uses,
+                    types,
+                    registry,
+                    known_classes,
+                    namespace,
+                    ssa,
+                );
+            }
             // A `dict set/append/lappend VAR …` or `lappend VAR …` that stores
             // object handles types VAR as a collection *of* that class, so a
             // later `[dict get $VAR k] method …` retrieval resolves the element.
             // `dict set VAR ?key…? value` takes a single trailing value; the
             // `*append`/`lappend` forms take every word after the key/var.
-            if let Some((container, target, value_args)) = match (command.as_str(), &arg_refs[..]) {
+            if let Some((container, target, value_args)) = match (canon, &arg_refs[..]) {
                 ("dict", ["set", target, rest @ ..]) if !rest.is_empty() => {
                     Some((TclType::Dict, *target, &rest[rest.len() - 1..]))
                 }
@@ -685,9 +732,14 @@ fn evaluate_type_def<S: std::hash::BuildHasher>(
             // name.  The former `defs.len() > 1` heuristic guessed it from the
             // write count and mistyped every single-target destructure — a
             // `lassign $l x` target wrongly typed `List`, a `regexp … capture`
-            // wrongly typed `Int` (issue #867).
+            // wrongly typed `Int` (issue #867).  Resolved through `canon`, not
+            // the source spelling, so an aliased / renamed destructuring writer
+            // (`rename lassign mylassign`) still resolves to the real command's
+            // `VarWriteTyping` — the same canonical-command indirection the
+            // value-passthrough store above and the collection-element typing
+            // use (FP-SH-15).
             let typing = registry
-                .resolve_call(command, &arg_refs, DialectSet::empty())
+                .resolve_call(canon, &arg_refs, DialectSet::empty())
                 .map_or(VarWriteTyping::ReturnValue, |r| r.var_write_typing());
             match typing {
                 // The default typing stores the command's *return value* in the
@@ -704,7 +756,7 @@ fn evaluate_type_def<S: std::hash::BuildHasher>(
                 // `Fixed` override still applies at any def count).
                 VarWriteTyping::ReturnValue if defs.len() > 1 => TypeLattice::overdefined(),
                 VarWriteTyping::ReturnValue => {
-                    return_type_for_command(registry, command, &arg_refs, known_classes, namespace)
+                    return_type_for_command(registry, canon, &arg_refs, known_classes, namespace)
                 }
                 VarWriteTyping::Fixed(t) => TypeLattice::of(t),
                 VarWriteTyping::Destructured => TypeLattice::overdefined(),
@@ -893,10 +945,17 @@ fn type_infer_process_statements<S: std::hash::BuildHasher>(
             Statement::Barrier { .. } => TypeLattice::overdefined(),
             Statement::Call {
                 command,
+                canonical_command,
                 args,
                 defs,
                 ..
-            } if !defs.is_empty() && is_scope_alias_call(ctx.registry, command, args) => {
+            } if !defs.is_empty()
+                && is_scope_alias_call(
+                    ctx.registry,
+                    canonical_command.as_deref().unwrap_or(command),
+                    args,
+                ) =>
+            {
                 TypeLattice::overdefined()
             }
             _ => evaluate_type_def(
@@ -1454,6 +1513,33 @@ mod tests {
         });
         assert!(x_is_int, "expected x to be Int");
         assert!(y_is_int, "expected y to inherit Int type from x");
+    }
+
+    /// An aliased `set` (`interp alias {} myset {} set`) keeps its runtime
+    /// `Call` shape, but its single def takes the *value word's* intrep — the
+    /// canonical-command value-passthrough. `myset x 5` types x as Int, exactly
+    /// as `set x 5` would, so the renamed/aliased store is no longer an opaque
+    /// OVERDEFINED `Call`.
+    #[test]
+    fn aliased_set_call_types_def_from_value() {
+        use crate::compilation_unit::CompilationUnit;
+        let cu = CompilationUnit::build_for(
+            "interp alias {} myset {} set\nproc ::g {} { myset x 5\n return $x }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::g").unwrap();
+        let x_is_int = fu.types.iter().any(|((name, _), t)| {
+            fu.ssa.var_name(*name) == "x" && t.tcl_type == Some(TclType::Int)
+        });
+        assert!(
+            x_is_int,
+            "aliased `myset x 5` should type x as Int (value passthrough): {:?}",
+            fu.types
+                .iter()
+                .map(|((n, v), t)| (fu.ssa.var_name(*n), *v, t.to_string()))
+                .collect::<Vec<_>>()
+        );
     }
 
     /// `AssignValue` with a command substitution uses the command's return type.

--- a/rust/tcl-compiler/src/types.rs
+++ b/rust/tcl-compiler/src/types.rs
@@ -239,10 +239,48 @@ pub fn type_join(a: &TypeLattice, b: &TypeLattice) -> TypeLattice {
         (b, a)
     };
     let kt = known.tcl_type.unwrap();
-    if Some(kt) == shimmer.tcl_type || Some(kt) == shimmer.from_type {
+    let (from, to) = (shimmer.from_type.unwrap(), shimmer.tcl_type.unwrap());
+    // Exact match on either side: the known type is already one of the two the
+    // value shimmers between, so the merge stays that same shimmer.
+    if kt == from || kt == to {
         return shimmer.clone();
     }
+    // Numeric refinement: a `Known` numeric type (Int / Double / Boolean /
+    // Numeric) meeting a *numeric* shimmer side is subsumed by that side —
+    // `expr {$x + 1}` on an unknown-typed `$x` legitimately yields the coarser
+    // `Numeric`, so an `Int` reaching that merge is not a third, conflicting
+    // intrep. The value still oscillates between "numeric" and the other side,
+    // so it must stay SHIMMERED rather than degrade to OVERDEFINED (which
+    // silently masks the shimmer for S100/S101/S102 — a false negative). The
+    // numeric side widens to `Numeric` so the result is a sound upper bound of
+    // the `Known` type: `Double ⊔ SHIMMERED(Int, String)` = `SHIMMERED(Numeric,
+    // String)`, which covers `Double` — `SHIMMERED(Int, …)` would not. Exact
+    // equality is handled above, so widening here never narrows.
+    //
+    // NB: this must NOT be routed through `numeric_promotion`, which returns
+    // `Some` whenever *either* operand is `Double` (so `numeric_promotion(Double,
+    // String)` wrongly yields `Numeric`) — that would drop the genuinely
+    // non-numeric side. The predicate below requires *both* the known type and
+    // the matched side to be numeric-family.
+    if is_numeric_family(kt) {
+        if is_numeric_family(from) {
+            return TypeLattice::shimmered(TclType::Numeric, to);
+        }
+        if is_numeric_family(to) {
+            return TypeLattice::shimmered(from, TclType::Numeric);
+        }
+    }
     TypeLattice::overdefined()
+}
+
+/// True when `t` is a numeric-family intrep — one whose values all coerce to a
+/// number, so it is subsumed by the coarse [`TclType::Numeric`]. `Boolean`
+/// counts (Tcl booleans are `0`/`1` integers).
+fn is_numeric_family(t: TclType) -> bool {
+    matches!(
+        t,
+        TclType::Int | TclType::Double | TclType::Boolean | TclType::Numeric
+    )
 }
 
 /// Numeric promotion for Tcl types.
@@ -336,6 +374,69 @@ mod tests {
         let shimmer = TypeLattice::shimmered(TclType::Int, TclType::List);
         let known = TypeLattice::of(TclType::Dict);
         assert_eq!(type_join(&known, &shimmer).kind, TypeKind::Overdefined);
+    }
+
+    /// A `Known(Int)` meeting `SHIMMERED(Numeric, String)` must stay
+    /// SHIMMERED, not degrade to OVERDEFINED: `Int` is subsumed by the
+    /// `Numeric` side (`expr {$x + 1}` on an unknown `$x` yields `Numeric`),
+    /// so the value still oscillates numeric↔string. Degrading here silently
+    /// masks the shimmer for S100/S101/S102.
+    #[test]
+    fn known_int_matches_numeric_shimmer_side() {
+        let shimmer = TypeLattice::shimmered(TclType::Numeric, TclType::String);
+        let known = TypeLattice::of(TclType::Int);
+        let joined = type_join(&known, &shimmer);
+        assert_eq!(joined.kind, TypeKind::Shimmered);
+        assert_eq!(
+            joined,
+            TypeLattice::shimmered(TclType::Numeric, TclType::String)
+        );
+        // Symmetric.
+        assert_eq!(type_join(&shimmer, &known), joined);
+    }
+
+    /// `Boolean` (an int-family type) also matches a `Numeric` shimmer side.
+    #[test]
+    fn known_boolean_matches_numeric_shimmer_side() {
+        let shimmer = TypeLattice::shimmered(TclType::Numeric, TclType::List);
+        let known = TypeLattice::of(TclType::Boolean);
+        assert_eq!(
+            type_join(&known, &shimmer),
+            TypeLattice::shimmered(TclType::Numeric, TclType::List)
+        );
+    }
+
+    /// A `Known(Double)` meeting `SHIMMERED(Int, String)` must widen the
+    /// numeric side to `Numeric` — `SHIMMERED(Int, String)` would not be a
+    /// sound upper bound of `Double` (it does not cover `Double`). This keeps
+    /// `type_join` a true least-upper-bound.
+    #[test]
+    fn known_double_widens_int_shimmer_side_to_numeric() {
+        let shimmer = TypeLattice::shimmered(TclType::Int, TclType::String);
+        let known = TypeLattice::of(TclType::Double);
+        assert_eq!(
+            type_join(&known, &shimmer),
+            TypeLattice::shimmered(TclType::Numeric, TclType::String)
+        );
+    }
+
+    /// A non-numeric `Known` type that matches neither side of a shimmer still
+    /// degrades to OVERDEFINED — the numeric refinement must not blanket-keep
+    /// every Known/Shimmered join shimmered.
+    #[test]
+    fn known_non_numeric_no_match_still_overdefined() {
+        let shimmer = TypeLattice::shimmered(TclType::Numeric, TclType::List);
+        let known = TypeLattice::of(TclType::Dict);
+        assert_eq!(type_join(&known, &shimmer).kind, TypeKind::Overdefined);
+    }
+
+    /// An exact match on a non-numeric side is unchanged by the refinement:
+    /// `Known(List) ⊔ SHIMMERED(Int, List)` stays `SHIMMERED(Int, List)`.
+    #[test]
+    fn known_exact_non_numeric_side_unchanged() {
+        let shimmer = TypeLattice::shimmered(TclType::Int, TclType::List);
+        let known = TypeLattice::of(TclType::List);
+        assert_eq!(type_join(&known, &shimmer), shimmer);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/var_observability.rs
+++ b/rust/tcl-compiler/src/var_observability.rs
@@ -53,7 +53,8 @@ use crate::ir::Statement;
 use crate::lowering::variable_trace_write_indices;
 use crate::naming::normalise_var_name;
 use crate::var_scoping::{
-    global_declaration_indices, upvar_local_declaration_indices, variable_declaration_indices,
+    global_declaration_indices, my_variable_declaration_indices, upvar_local_declaration_indices,
+    variable_declaration_indices,
 };
 
 bitflags! {
@@ -133,6 +134,21 @@ pub(crate) fn stmt_gen(stmt: &Statement, state: &mut State, registry: &CommandRe
         }
         "variable" => {
             for i in variable_declaration_indices(args) {
+                mark(state, args, i, EscapeFlag::NAMESPACE);
+            }
+        }
+        // `my variable NAME …` (TclOO) binds each instance variable into the
+        // method's local scope — a namespace-style scope alias, exactly like a
+        // bare `variable`, but reached through the `my` dispatch so the base
+        // command word is `my` and the declared names follow a `variable`
+        // subcommand word. An instance variable's intrep is externally
+        // determined (the constructor / other methods can set it to anything),
+        // so a use-site / merge / loop-oscillation check must treat it as
+        // escaping — the same protection FP-SH-02 / FP-SH-16 give a bare
+        // `variable`. (Traces are handled below by the registry-driven
+        // `variable_trace_write_indices`, not a hardcoded `"trace"` arm.)
+        "my" => {
+            for i in my_variable_declaration_indices(args) {
                 mark(state, args, i, EscapeFlag::NAMESPACE);
             }
         }
@@ -456,6 +472,22 @@ mod tests {
                 .contains(EscapeFlag::NAMESPACE)
         );
         assert!(obs.flag_at(fu.cfg.entry, 2, "v").writes_outer_scope());
+    }
+
+    #[test]
+    fn my_variable_marks_namespace_alias() {
+        // `my variable x` (TclOO) binds an instance variable into the method
+        // scope — a namespace-style escape, exactly like a bare `variable`.
+        let c = cu("proc ::p {} { my variable x\nset x 1 }");
+        let fu = c.function("::p").unwrap();
+        let reg = registry();
+        let obs = analyse_var_observability(&fu.cfg, &reg);
+        assert!(
+            obs.flag_at(fu.cfg.entry, 2, "x")
+                .contains(EscapeFlag::NAMESPACE),
+            "my variable x should mark x as a namespace alias"
+        );
+        assert!(obs.escaping_var_names().contains("x"));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/var_scoping.rs
+++ b/rust/tcl-compiler/src/var_scoping.rs
@@ -68,6 +68,31 @@ pub fn variable_declaration_indices(args: &[String]) -> Vec<usize> {
     out
 }
 
+// my variable (TclOO instance-variable binding)
+
+/// Return indices of declared variables in the `TclOO` `my variable name
+/// ?name …?` idiom, given the args of the `my` command (so `args[0]` is the
+/// literal `"variable"` subcommand word).
+///
+/// Unlike the top-level `variable` *command* (which alternates name/value
+/// pairs), the object `variable` *method* of `oo::object` takes plain names
+/// only — every argument after the subcommand word is a declared instance
+/// variable. Substituted (`$`-prefixed) names are skipped, matching the other
+/// declaration helpers. Returns an empty vector when `args[0]` is not
+/// `"variable"`.
+#[must_use]
+pub fn my_variable_declaration_indices(args: &[String]) -> Vec<usize> {
+    if args.first().map(String::as_str) != Some("variable") {
+        return Vec::new();
+    }
+    args.iter()
+        .enumerate()
+        .skip(1)
+        .filter(|(_, a)| !a.is_empty() && !a.starts_with('$'))
+        .map(|(i, _)| i)
+        .collect()
+}
+
 // upvar / namespace upvar
 
 /// Return indices of the *local-alias* tokens in an `upvar`
@@ -179,6 +204,25 @@ mod tests {
     fn variable_decls_reject_substituted_names() {
         let args = v(&["$x", "42", "bar", "99"]);
         assert_eq!(variable_declaration_indices(&args), vec![2]);
+    }
+
+    // -- my variable --
+
+    #[test]
+    fn my_variable_decls_all_names_no_values() {
+        // Unlike the top-level `variable` command, the object `variable`
+        // method takes only names: `my variable x y z` declares x, y, z.
+        let args = v(&["variable", "x", "y", "z"]);
+        assert_eq!(my_variable_declaration_indices(&args), vec![1, 2, 3]);
+    }
+
+    #[test]
+    fn my_variable_decls_skip_substituted_and_non_variable_subcommand() {
+        let args = v(&["variable", "x", "$dyn", "y"]);
+        assert_eq!(my_variable_declaration_indices(&args), vec![1, 3]);
+        // A different `my` method (e.g. `my varname x`) is not a declaration.
+        assert!(my_variable_declaration_indices(&v(&["varname", "x"])).is_empty());
+        assert!(my_variable_declaration_indices(&[]).is_empty());
     }
 
     // -- upvar --

--- a/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
@@ -111,6 +111,12 @@ const MATRIX: &[Case] = &[
         note: "tainted var as a direct numeric operand of an if-condition (+ is a \
                coercion hazard; eq is a pure string compare and isn't)",
     },
+    Case {
+        code: "S102",
+        fire: "interp alias {} myset {} set\nproc f {n} {\n    myset x 0\n    while {$n} {\n        myset x [expr {$x + 1}]\n        myset x [string range $x 0 end]\n        incr n -1\n    }\n}\n",
+        silent: "interp alias {} myset {} set\nproc f {n} {\n    myset x 0\n    while {$n} {\n        myset x [expr {$x + 1}]\n        incr n -1\n    }\n}\n",
+        note: "an aliased `set` still resolves to the real command, so a loop-carried int/string oscillation through the alias fires S102 (FP-SH-15)",
+    },
 ];
 
 /// The set of `code` strings carried by `diags` (mirrors Python `_codes`).
@@ -233,6 +239,10 @@ fn t101_fires_on_defect() {
 fn t100_fires_on_defect() {
     assert_fires(case_for("T100"));
 }
+#[test]
+fn s102_fires_on_defect() {
+    assert_fires(case_for("S102"));
+}
 
 // -- silent cases --------------------------------------------------------
 
@@ -279,6 +289,10 @@ fn t101_silent_on_corrected_form() {
 #[test]
 fn t100_silent_on_corrected_form() {
     assert_silent(case_for("T100"));
+}
+#[test]
+fn s102_silent_on_corrected_form() {
+    assert_silent(case_for("S102"));
 }
 
 // -- TestOptimisationMatrix ----------------------------------------------
@@ -662,4 +676,60 @@ fn s102_silent_for_non_self_referential_branchy_reset() {
          set x [list 1 2]\n        }\n        incr n -1\n    }\n    return $x\n}\n",
     );
     assert!(!codes(&diags).contains("S102"), "{diags:?}");
+}
+
+#[test]
+fn s102_fires_for_rename_indirection() {
+    // FP-SH-15 detection gap closed: a builtin renamed onto a new name
+    // (`rename set myset`) resolves back to the real `set` spec, so the
+    // loop-carried int/string oscillation through the renamed store fires
+    // S102 — the same as the un-renamed `set` loop.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc f {} {\n    rename set myset\n    myset x 0\n    while {1} {\n        \
+         myset x [expr {$x + 1}]\n        myset x [string range $x 0 end]\n    }\n}\n",
+    );
+    assert!(codes(&diags).contains("S102"), "{diags:?}");
+}
+
+// NB: the `my variable` instance-variable fix (FP-SH-15 case 5) is covered by
+// the compiler-level tests (`analyser::diagnostics::fp::sh::
+// fp_sh_15_my_variable_*`, `var_observability::tests::
+// my_variable_marks_namespace_alias`) rather than here — the LSP
+// whole-document pipeline does not run shimmer analysis over TclOO method
+// bodies, so `tcl diag` (which does) is the authoritative oracle for that
+// surface, matching how FP.md's FP-SH-15 entry verified it.
+
+#[test]
+fn s100_silent_for_array_element_use_site() {
+    // FP-SH-13 extended to the use-site (S100/S101) pass: `arr(n)` is always
+    // int and `arr(label)` always string, but they collapse onto one symbol —
+    // `incr arr(n)` must not read the conflated symbol as string and fire S100.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc f {} {\n    set arr(n) 5\n    set arr(label) \"text\"\n    incr arr(n)\n}\n",
+    );
+    let cs = codes(&diags);
+    assert!(!cs.contains("S100") && !cs.contains("S101"), "{diags:?}");
+}
+
+#[test]
+fn s102_fires_for_numeric_shimmer_masked_by_int_entry() {
+    // FP-SH-18: a numeric/string oscillation seeded by an Int entry. Pre-fix
+    // the loop-header phi joined `Known(Int)` with `SHIMMERED(Numeric, String)`
+    // and degraded to OVERDEFINED (exact-equality), masking the thunk; the
+    // numeric-refinement join keeps it SHIMMERED so S102 fires.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc f {n} {\n    set x 0\n    while {$n > 0} {\n        \
+         if {$n % 2} {\n            set x [expr {$x + $n}]\n        } else {\n            \
+         set x \"s$x\"\n        }\n        incr n -1\n    }\n    return $x\n}\n",
+    );
+    assert!(codes(&diags).contains("S102"), "{diags:?}");
 }


### PR DESCRIPTION
## Summary

- Closes the four documented, conservative command/variable-indirection gaps the S102 deep review (#871) left open. All fixes are registry / shared-infrastructure-driven — no per-command knowledge is added to the compiler — and they act on `type_infer`'s type lattice generally, so S100/S101 inherit them alongside S102.
- **rename / interp alias onto a builtin** (FP-SH-15 cases 1–2): the lowerer records `rename OLD NEW` in the same alias snapshot it already keeps for `interp alias`, so a renamed/aliased builtin carries `canonical_command`. `type_infer` types a canonical-`set` store's def from its *value word* (value-passthrough, keyed on the `Set` lowering hook — the registry's own "this is a store" fact), and `ssa::uses_of` scans that value exactly as the un-aliased `set` (expr-aware, so a braced `[expr {$x+1}]` still exposes the read and the loop-header phi forms). Codegen is untouched — an aliased/renamed call stays a runtime `invokeStk` (an alias is not inline-foldable). `detect_rename` returns the raw `(old, new)` pair and the lowerer namespace-qualifies `new` via `join_namespace` (a `rename` binds NEW in the *current* namespace — `rename set myset` inside `namespace eval ::ns` creates `::ns::myset`, not global `::myset`). → `rename set myset` / `interp alias {} myset {} set` oscillations now fire S102.
- **`my variable` TclOO instance variables** (FP-SH-15 case 5): `var_observability` recognises the `my variable NAME…` compound via a new `var_scoping` declaration helper and marks each name a namespace escape, so `crate::sccp::is_externally_mutable` forces every def of a locally-initialised instance variable (`my variable x; set x 0; while {…}`) to OVERDEFINED — exactly the escape surface a bare `variable` has. This composes with #884's type-inference surface (see reconciliation below): #884 makes the `my variable x` *declaration* def OVERDEFINED via the registry, and this change forces *subsequent* `set x …` defs OVERDEFINED via escape analysis — together matching how a bare `variable` is protected on both surfaces.
- **array-element conflation for S100/S101** (FP-SH-13): the `array_element_symbols` exclusion the S102 pass already used is now `pub(super)` and shared by the use-site (S100/S101) and phi-merge (S101) passes, so two individually-stable-but-different elements (`arr(n)` int, `arr(label)` string) no longer false-positive through any shimmer surface.
- **Numeric vs Int/Double join imprecision** (FP-SH-18): `types::type_join`'s Known-vs-Shimmered rule matched by exact `TclType` equality, so `Known(Int) ⊔ SHIMMERED(Numeric, String)` degraded to OVERDEFINED and silently masked genuine thunks. A numeric refinement keeps it SHIMMERED, widening the numeric side to `Numeric` so the result is a sound upper bound (a true LUB). Deliberately *not* routed through `numeric_promotion` (which returns `Some` whenever either operand is `Double`, so it would drop the genuinely non-numeric side).
- Documentation: FP-SH-13/15 updated and FP-SH-18 added in `docs/design/compiler/FP.md`.

## Rebase reconciliation (onto `rust` after #885 / #869 / #884 merged)

Rebased onto the current `rust` tip. Three overlapping PRs merged meanwhile and were reconciled:

- **#885** (issue #867 registry-driven destructuring-writer typing) rewrote the `Call` arm of `evaluate_type_def` into a centralised `VarWriteTyping` resolution. My canonical-command indirection now composes with it: the `registry.resolve_call(…)` / `return_type_for_command(…)` in that block are routed through `canon` (the `canonical_command` snapshot), so an aliased/renamed destructuring writer (`rename lassign mylassign`) resolves to the real command's var-write spec too. For non-aliased commands `canon == command`, so #885's issue-867 tests are unaffected.
- **#885** independently claimed the `FP-SH-17` label for its destructuring-writer fix, so the numeric-join fix here renumbered `FP-SH-17` → `FP-SH-18` (heading, tests, cross-references) to avoid the collision.
- **#884** (`S100` numeric-comparison quick fix + `'my variable'` scope-alias fix) landed a **registry-driven** `my variable` fix — `oo_my.rs` gives `my`'s `variable` subcommand `creates_scope_alias: true` + a `VarWrite` arg-role resolver, consumed by `is_scope_alias_call` to widen the *declaration* def to OVERDEFINED. That is the cleaner half of my `my variable` work, so I dropped nothing but **defer to it** for the type-inference surface (my `is_scope_alias_call` already reads that registry flag). The `var_observability` escape half of this PR is retained and is *not* redundant: it protects the locally-initialised `my variable x; set x 0; …` case that #884's declaration-only widening does not (the `set x 0` reseeds a confident `Int`; only escape analysis forces it back to OVERDEFINED). Verified by `fp_sh_15_my_variable_locally_initialised_no_s102` (needs the escape surface) vs `fp_sh_15_my_variable_idiom_no_s102` (satisfied by #884's registry surface) both passing.
- **#869** (interp-alias resolution before taint-sink classification) consumes the same lowerer-populated `canonical_command` field via `Statement::canonical_command_or_source()`; the two changes read one shared fact for different diagnostic families — no mechanism is duplicated.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

- `cargo fmt --check` + `cargo clippy --workspace --all-targets -- -D warnings` (no new allows): clean.
- `make xtask-check` — generated-file / docs-index drift gates: in sync.
- `make typecheck-ts` + `make lint-ts` — TypeScript tsc + ESLint + Prettier: clean.
- `cargo test --workspace --all-features` — 12,434 passed, 0 failed (includes the native `lsp_e2e` suite); `cargo test -p tcl-compiler` — 0 failures, my tests and #884/#885's coexist.
- Each gap reproduced and verified before & after with `tcl diag`; the oracle behaviour for each is unambiguous (a renamed/aliased `set` *is* `set`; independent array elements are separate slots; an int→numeric/string oscillation is a genuine per-iteration re-conversion).

Tests added: TP/FP/TN/FN in `fp/sh.rs` (FP-SH-13/15/18); unit tests in `shimmer/{thunking,use_site,phi}.rs`, `types.rs`, `ssa.rs`, `alias.rs`, `type_infer.rs`, `var_observability.rs`, `var_scoping.rs`; `lsp_e2e` cases in `diagnostic_matrix.rs`; and a VS Code suite + fixture.

## Compiler/KCS checklist

- [x] Did this change alter a compiler fact contract? — Yes: the type-lattice join (`type_join`) and the shimmer-detection surfaces. Documented in the shimmer FP catalogue (`docs/design/compiler/FP.md`, FP-SH-13/15/18).
- [ ] KCS note under `docs/kcs/compiler/` — N/A: that directory does not exist on this branch. The `docs/kcs/codes/` S100/S101/S102 notes make no coverage claims this change contradicts, so no code-page update is required.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BujBsCwXiJPQeZBKgcUoUr