### PR TITLE
DRY: shared option-skip primitive, Diagnostic builder, audit↔registry drift guard

### DIFF
--- a/rust/tcl-cmd-core/src/error.rs
+++ b/rust/tcl-cmd-core/src/error.rs
@@ -74,6 +74,33 @@ impl CmdError {
     }
 }
 
+/// Join `items` into a Tcl `must be …` alternation clause: `""`, `"a"`,
+/// `"a or b"` / `"a, or b"`, or `"a, b, or c"`.
+///
+/// `serial_comma` selects the dialect. C's ensemble `must be` formatter puts a
+/// comma before `or` even for two items (`a, or b`); `Tcl_GetIndexFromObj`
+/// omits it (`a or b`). For zero, one, or three-or-more items the two agree.
+/// This is the single source both spellings share — callers pass the flag
+/// rather than re-implementing (and re-diverging on) the join.
+#[must_use]
+pub fn join_or<S: AsRef<str>>(items: &[S], serial_comma: bool) -> String {
+    match items {
+        [] => String::new(),
+        [a] => a.as_ref().to_owned(),
+        [a, b] if !serial_comma => format!("{} or {}", a.as_ref(), b.as_ref()),
+        [head @ .., last] => {
+            let mut out = String::new();
+            for item in head {
+                out.push_str(item.as_ref());
+                out.push_str(", ");
+            }
+            out.push_str("or ");
+            out.push_str(last.as_ref());
+            out
+        }
+    }
+}
+
 impl core::fmt::Display for CmdError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.write_str(&self.message)
@@ -119,5 +146,23 @@ mod tests {
             r#"wrong # args: should be "x""#
         );
         assert_eq!(CmdError::new("z").into_message(), "z");
+    }
+
+    #[test]
+    fn join_or_matches_both_conventions() {
+        // Empty / single / three-plus agree regardless of the flag.
+        for serial in [true, false] {
+            assert_eq!(join_or::<&str>(&[], serial), "");
+            assert_eq!(join_or(&["a"], serial), "a");
+            assert_eq!(join_or(&["a", "b", "c"], serial), "a, b, or c");
+        }
+        // The two-item case is where the conventions diverge.
+        assert_eq!(join_or(&["a", "b"], true), "a, or b"); // ensemble spelling
+        assert_eq!(join_or(&["a", "b"], false), "a or b"); // Tcl_GetIndexFromObj
+        // Works over owned strings too (the ensemble/prefix callers).
+        assert_eq!(
+            join_or(&["x".to_string(), "y".to_string()], true),
+            "x, or y"
+        );
     }
 }

--- a/rust/tcl-compiler/src/analyser/bounds_checks.rs
+++ b/rust/tcl-compiler/src/analyser/bounds_checks.rs
@@ -89,25 +89,23 @@ pub(crate) fn loop_termination_diagnostics(
 
     match condition_constant(cond_text) {
         Some(false) => {
-            return vec![Diagnostic {
-                code: DiagCode::W240,
-                span: cond_tok.span,
-                message: format!("{cmd_name} condition is constant false; body never executes."),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            }];
+            return vec![Diagnostic::new(
+                DiagCode::W240,
+                cond_tok.span,
+                format!("{cmd_name} condition is constant false; body never executes."),
+                Severity::Warning,
+            )];
         }
         Some(true) if !body_may_exit(body_text, registry) => {
-            return vec![Diagnostic {
-                code: DiagCode::W241,
-                span: cond_tok.span,
-                message: format!(
+            return vec![Diagnostic::new(
+                DiagCode::W241,
+                cond_tok.span,
+                format!(
                     "{cmd_name} is provably infinite: condition is constant true and the body \
                      never leaves the loop (no break/return/error/exit/throw/tailcall)."
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            }];
+                Severity::Warning,
+            )];
         }
         Some(true) => return Vec::new(),
         None => {}
@@ -118,13 +116,12 @@ pub(crate) fn loop_termination_diagnostics(
         && let Some(reason) =
             for_is_provably_infinite(init_text, cond_text, step_text, body_text, registry)
     {
-        return vec![Diagnostic {
-            code: DiagCode::W241,
-            span: cond_tok.span,
-            message: format!("for loop is provably infinite: {reason}"),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        }];
+        return vec![Diagnostic::new(
+            DiagCode::W241,
+            cond_tok.span,
+            format!("for loop is provably infinite: {reason}"),
+            Severity::Warning,
+        )];
     }
 
     // W242 (default-off): a counter variable appears in the condition but
@@ -135,16 +132,15 @@ pub(crate) fn loop_termination_diagnostics(
     if let Some(var) = extract_counter_name(cond_text)
         && !loop_modifies_var(&var, step_text, body_text, registry)
     {
-        return vec![Diagnostic {
-            code: DiagCode::W242,
-            span: cond_tok.span,
-            message: format!(
+        return vec![Diagnostic::new(
+            DiagCode::W242,
+            cond_tok.span,
+            format!(
                 "{cmd_name} termination cannot be proven: variable '{var}' in the \
                      condition is never modified by the step or body."
             ),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        }];
+            Severity::Hint,
+        )];
     }
     Vec::new()
 }
@@ -570,17 +566,16 @@ pub(crate) fn list_index_diagnostics(
     } else {
         "lreplace touches no element (first > last after clamping)".to_string()
     };
-    vec![Diagnostic {
-        code: DiagCode::W230,
-        span: tcl_lexer::Span::new(lo_token.span.start(), hi_token.span.end()),
-        message: format!(
+    vec![Diagnostic::new(
+        DiagCode::W230,
+        tcl_lexer::Span::new(lo_token.span.start(), hi_token.span.end()),
+        format!(
             "{verb}: first='{lo_text}' resolves to {lo_index}, last='{hi_text}' resolves \
              to {hi_index} (list has {length} element{}).",
             if length == 1 { "" } else { "s" }
         ),
-        severity: Severity::Warning,
-        fixes: Vec::new(),
-    }]
+        Severity::Warning,
+    )]
 }
 
 /// The per-index `lindex` arm of W230.
@@ -599,17 +594,16 @@ fn lindex_diagnostics(args: &[String], arg_tokens: &[Token], length: i64) -> Vec
         if (0..length).contains(&resolved) {
             continue;
         }
-        out.push(Diagnostic {
-            code: DiagCode::W230,
-            span: idx_tok.span,
-            message: format!(
+        out.push(Diagnostic::new(
+            DiagCode::W230,
+            idx_tok.span,
+            format!(
                 "Index '{}' {}; lindex silently returns empty string.",
                 idx_text.trim(),
                 describe_index(resolved, length)
             ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+            Severity::Warning,
+        ));
     }
     out
 }
@@ -653,16 +647,15 @@ pub(crate) fn lset_index_diagnostics(
         if let Some(n) = parse_strict_int(stripped)
             && n < 0
         {
-            out.push(Diagnostic {
-                code: DiagCode::W231,
-                span: idx_tok.span,
-                message: format!(
+            out.push(Diagnostic::new(
+                DiagCode::W231,
+                idx_tok.span,
+                format!(
                     "lset index '{stripped}' is negative; \
                          raises 'index out of range' at runtime."
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
             continue;
         }
         // `lset` accepts the append slot (`index == length`); only
@@ -672,17 +665,16 @@ pub(crate) fn lset_index_diagnostics(
                 continue;
             };
             if resolved < 0 || resolved > length {
-                out.push(Diagnostic {
-                    code: DiagCode::W231,
-                    span: idx_tok.span,
-                    message: format!(
+                out.push(Diagnostic::new(
+                    DiagCode::W231,
+                    idx_tok.span,
+                    format!(
                         "lset index '{stripped}' {}; \
                          raises 'index out of range' at runtime.",
                         describe_index(resolved, length)
                     ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
             }
         }
     }
@@ -957,15 +949,12 @@ fn string_single_index(
     if let Some(n) = parse_strict_int(stripped)
         && n < 0
     {
-        return vec![Diagnostic {
-            code: DiagCode::W232,
-            span: idx_tok.span,
-            message: format!(
-                "string {sub}: index '{stripped}' is negative; result is empty or a no-op."
-            ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        }];
+        return vec![Diagnostic::new(
+            DiagCode::W232,
+            idx_tok.span,
+            format!("string {sub}: index '{stripped}' is negative; result is empty or a no-op."),
+            Severity::Warning,
+        )];
     }
     // `string insert` clamps other overshoots; only `string index`
     // flags an in-bounds miss.
@@ -974,16 +963,15 @@ fn string_single_index(
         && let Some(resolved) = resolve_index(stripped, len)
         && !(0..len).contains(&resolved)
     {
-        return vec![Diagnostic {
-            code: DiagCode::W232,
-            span: idx_tok.span,
-            message: format!(
+        return vec![Diagnostic::new(
+            DiagCode::W232,
+            idx_tok.span,
+            format!(
                 "string index: '{stripped}' {}; returns empty string.",
                 describe_index_string(resolved, len)
             ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        }];
+            Severity::Warning,
+        )];
     }
     Vec::new()
 }
@@ -1019,16 +1007,15 @@ fn string_pair_index(
     ) && f < 0
         && l < 0
     {
-        return vec![Diagnostic {
-            code: DiagCode::W232,
+        return vec![Diagnostic::new(
+            DiagCode::W232,
             span,
-            message: format!(
+            format!(
                 "string {sub}: both indices are negative ('{first_text}', '{last_text}'); \
                      {verb}."
             ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        }];
+            Severity::Warning,
+        )];
     }
     let Some(len) = str_len else {
         return Vec::new();
@@ -1042,17 +1029,16 @@ fn string_pair_index(
     if !pair_slice_empty(first_val, last_val, len) {
         return Vec::new();
     }
-    vec![Diagnostic {
-        code: DiagCode::W232,
+    vec![Diagnostic::new(
+        DiagCode::W232,
         span,
-        message: format!(
+        format!(
             "string {sub}: {verb}: first='{first_text}' resolves to {first_val}, \
              last='{last_text}' resolves to {last_val} (string has {len} character{}).",
             if len == 1 { "" } else { "s" }
         ),
-        severity: Severity::Warning,
-        fixes: Vec::new(),
-    }]
+        Severity::Warning,
+    )]
 }
 
 /// Human-readable description of a resolved out-of-range string index.

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -710,16 +710,15 @@ impl Analyser {
                 .as_ref()
                 .is_none_or(|r| r.get(cmd_name).is_none())
         {
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::W125,
-                span: cmd_tok.span,
-                message: format!(
+            self.result.diagnostics.push(Diagnostic::new(
+                DiagCode::W125,
+                cmd_tok.span,
+                format!(
                     "\"{cmd_name}\" used as standalone command — should be part of \
                      \"{parent}\" (check for misplaced newline)"
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
         }
 
         if resolves_to_proc
@@ -732,19 +731,19 @@ impl Analyser {
             } else {
                 format!(" {}", args.join(" "))
             };
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule5005,
-                span: cmd_tok.span,
-                message: format!(
-                    "iRules procs must be invoked with 'call': call {cmd_name}{suffix}"
-                ),
-                severity: Severity::Error,
-                fixes: vec![CodeFix {
+            self.result.diagnostics.push(
+                Diagnostic::new(
+                    DiagCode::Irule5005,
+                    cmd_tok.span,
+                    format!("iRules procs must be invoked with 'call': call {cmd_name}{suffix}"),
+                    Severity::Error,
+                )
+                .with_fixes(vec![CodeFix {
                     span: cmd_tok.span,
                     new_text: format!("call {cmd_name}"),
                     description: format!("Use 'call {cmd_name}'"),
-                }],
-            });
+                }]),
+            );
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -131,16 +131,15 @@ impl Analyser {
                 if !rebound.contains(&nqn(command)) {
                     continue; // never bound here → an ordinary external command
                 }
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W128,
-                    span: *span,
-                    message: format!(
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W128,
+                    *span,
+                    format!(
                         "Command '{command}' was renamed or deleted earlier in this \
 file; this call falls through to the 'unknown' handler."
                     ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
             }
         }
     }
@@ -375,13 +374,12 @@ file; this call falls through to the 'unknown' handler."
             if let Some(similar) = find_case_mismatch(var, defined_vars) {
                 let _ = write!(message, "; did you mean '{similar}'?");
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W220,
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W220,
                 span,
                 message,
-                severity: Severity::Hint,
-                fixes: Vec::new(),
-            });
+                Severity::Hint,
+            ));
         }
     }
 
@@ -617,13 +615,12 @@ file; this call falls through to the 'unknown' handler."
             if let Some(similar) = find_case_mismatch(&var, defined_vars) {
                 let _ = write!(message, "; did you mean '{similar}'?");
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W211,
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W211,
                 span,
                 message,
-                severity: Severity::Hint,
-                fixes: Vec::new(),
-            });
+                Severity::Hint,
+            ));
         }
     }
 
@@ -702,13 +699,12 @@ file; this call falls through to the 'unknown' handler."
                      with static value '{pretty}'; \
                      did you mean to assign a different variable?"
                 );
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::H300,
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::H300,
                     span,
                     message,
-                    severity: Severity::Hint,
-                    fixes: Vec::new(),
-                });
+                    Severity::Hint,
+                ));
             }
         }
     }
@@ -862,13 +858,12 @@ file; this call falls through to the 'unknown' handler."
                 "Parameter '{param}' of proc '{name}' is unused",
                 name = ir_proc.qualified_name,
             );
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W214,
-                span: param_spans.get(idx).copied().unwrap_or(ir_proc.span),
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W214,
+                param_spans.get(idx).copied().unwrap_or(ir_proc.span),
                 message,
-                severity: Severity::Hint,
-                fixes: Vec::new(),
-            });
+                Severity::Hint,
+            ));
         }
     }
 
@@ -1044,13 +1039,12 @@ file; this call falls through to the 'unknown' handler."
             if let Some(similar) = undefined_var_suggestion(&var, defined_vars) {
                 let _ = write!(message, "; did you mean '{similar}'?");
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W210,
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W210,
                 span,
                 message,
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
         }
     }
 
@@ -1151,13 +1145,15 @@ file; this call falls through to the 'unknown' handler."
                 // the same fix the LSP layer synthesises, now carried on the
                 // diagnostic itself so every editor surfaces it uniformly.
                 let (diag_span, fixes) = w213_span_and_fix(fu, tokens.as_ref(), var, span);
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W213,
-                    span: diag_span,
-                    message,
-                    severity: Severity::Warning,
-                    fixes,
-                });
+                self.result.diagnostics.push(
+                    super::types::Diagnostic::new(
+                        DiagCode::W213,
+                        diag_span,
+                        message,
+                        Severity::Warning,
+                    )
+                    .with_fixes(fixes),
+                );
                 continue;
             }
             // A use site that itself safely initialises the variable
@@ -1272,13 +1268,12 @@ file; this call falls through to the 'unknown' handler."
                 if let Some(similar) = undefined_var_suggestion(&name, defined_vars) {
                     let _ = write!(message, "; did you mean '{similar}'?");
                 }
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W210,
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W210,
                     span,
                     message,
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
             }
         }
     }
@@ -1459,13 +1454,12 @@ file; this call falls through to the 'unknown' handler."
                     if let Some(similar) = undefined_var_suggestion(name, defined_vars) {
                         let _ = write!(message, "; did you mean '{similar}'?");
                     }
-                    self.result.diagnostics.push(super::types::Diagnostic {
-                        code: DiagCode::W210,
+                    self.result.diagnostics.push(super::types::Diagnostic::new(
+                        DiagCode::W210,
                         span,
                         message,
-                        severity: Severity::Warning,
-                        fixes: Vec::new(),
-                    });
+                        Severity::Warning,
+                    ));
                 }
             }
         }
@@ -1643,15 +1637,12 @@ file; this call falls through to the 'unknown' handler."
                 (DiagCode::I230, msg)
             };
 
-            self.result.diagnostics.push(super::types::Diagnostic {
+            self.result.diagnostics.push(super::types::Diagnostic::new(
                 code,
                 span,
                 message,
-                // I230/I231 are observational (LSP `Information`);
-                // they previously collapsed to `Hint`.
-                severity: Severity::Info,
-                fixes: Vec::new(),
-            });
+                Severity::Info,
+            ));
         }
     }
 
@@ -1706,14 +1697,12 @@ file; this call falls through to the 'unknown' handler."
                     cb.condition,
                 )
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::I230,
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::I230,
                 span,
                 message,
-                // I230 is observational (LSP `Information`).
-                severity: Severity::Info,
-                fixes: Vec::new(),
-            });
+                Severity::Info,
+            ));
         }
     }
 
@@ -1812,13 +1801,12 @@ file; this call falls through to the 'unknown' handler."
                             "Variable '${name}' passed as channel to '{command}' \
                              has type {type_label}, not CHANNEL.",
                         );
-                        self.result.diagnostics.push(super::types::Diagnostic {
-                            code: DiagCode::W126,
-                            span: arg_span,
+                        self.result.diagnostics.push(super::types::Diagnostic::new(
+                            DiagCode::W126,
+                            arg_span,
                             message,
-                            severity: Severity::Warning,
-                            fixes: Vec::new(),
-                        });
+                            Severity::Warning,
+                        ));
                     } else {
                         // Literal — strip surrounding braces / quotes.
                         let literal = arg_text
@@ -1836,13 +1824,12 @@ file; this call falls through to the 'unknown' handler."
                             "String literal '{literal}' used as channel argument to \
                              '{command}' — expected a channel from open/socket/chan create.",
                         );
-                        self.result.diagnostics.push(super::types::Diagnostic {
-                            code: DiagCode::W126,
-                            span: arg_span,
+                        self.result.diagnostics.push(super::types::Diagnostic::new(
+                            DiagCode::W126,
+                            arg_span,
                             message,
-                            severity: Severity::Warning,
-                            fixes: Vec::new(),
-                        });
+                            Severity::Warning,
+                        ));
                     }
                 }
             }
@@ -1904,15 +1891,12 @@ file; this call falls through to the 'unknown' handler."
             } else {
                 "Modulo"
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W233,
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W233,
                 span,
-                message: format!(
-                    "{verb} by a provably-zero divisor — raises 'divide by zero' at runtime."
-                ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                format!("{verb} by a provably-zero divisor — raises 'divide by zero' at runtime."),
+                Severity::Warning,
+            ));
         }
     }
 
@@ -1968,16 +1952,15 @@ file; this call falls through to the 'unknown' handler."
             } else {
                 "silently returns the empty string"
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: f.code,
-                span: fu.abs_span(f.span),
-                message: format!(
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                f.code,
+                fu.abs_span(f.span),
+                format!(
                     "{}: index ${} {rng}, {bound} \u{2014} {outcome}.",
                     f.command, f.index_var
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
         }
     }
 
@@ -2131,13 +2114,12 @@ file; this call falls through to the 'unknown' handler."
                 None
             })
             .unwrap_or(stmt_span);
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W124,
+        self.result.diagnostics.push(super::types::Diagnostic::new(
+            DiagCode::W124,
             span,
-            message: message.to_string(),
+            message.to_string(),
             severity,
-            fixes: Vec::new(),
-        });
+        ));
     }
 
     /// IRULE4005 — racy ``static::`` cross-event flow.
@@ -2181,13 +2163,12 @@ file; this call falls through to the 'unknown' handler."
                          the same virtual server; concurrent writes can produce unpredictable \
                          results."
                     );
-                    self.result.diagnostics.push(super::types::Diagnostic {
-                        code: DiagCode::Irule4005,
+                    self.result.diagnostics.push(super::types::Diagnostic::new(
+                        DiagCode::Irule4005,
                         span,
                         message,
-                        severity: Severity::Warning,
-                        fixes: Vec::new(),
-                    });
+                        Severity::Warning,
+                    ));
                 }
             }
         }

--- a/rust/tcl-compiler/src/analyser/diagnostics/security.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/security.rs
@@ -153,15 +153,14 @@ impl Analyser {
             return;
         }
         let span = cmd_tok.span;
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W302,
+        self.result.diagnostics.push(super::types::Diagnostic::new(
+            DiagCode::W302,
             span,
-            message: "catch without a result variable silently swallows errors. \
+            "catch without a result variable silently swallows errors. \
 Consider capturing the result: catch {\u{2026}} result"
                 .to_string(),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+            Severity::Hint,
+        ));
     }
 
     /// **W101.** Emit "eval with string concatenation" warning
@@ -260,16 +259,18 @@ Consider capturing the result: catch {\u{2026}} result"
         // Only offered when the substituted word is itself the quoted string
         // (`eval_list_fix` returns empty otherwise).
         let fixes = self.eval_list_fix(anchor);
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W101,
-            span: anchor.span,
-            message: format!(
-                "{cmd_name} with substituted arguments risks code injection. \
+        self.result.diagnostics.push(
+            super::types::Diagnostic::new(
+                DiagCode::W101,
+                anchor.span,
+                format!(
+                    "{cmd_name} with substituted arguments risks code injection. \
 Prefer direct invocation or {{*}}$cmdList to preserve argument boundaries."
-            ),
-            severity: Severity::Warning,
-            fixes,
-        });
+                ),
+                Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// Build the `eval [list …]` rewrite fix for a W101 diagnostic whose
@@ -486,16 +487,15 @@ word as one argument; no re-parsing)"
             if self.resolve_var_token_literal(tok).is_some() {
                 return;
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W300,
-                span: tok.span,
-                message: format!(
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W300,
+                tok.span,
+                format!(
                     "{cmd_name} with a dynamic path (variable or command substitution) \
 executes arbitrary Tcl code. Ensure the path is not influenced by untrusted input."
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
         }
     }
 
@@ -522,17 +522,16 @@ executes arbitrary Tcl code. Ensure the path is not influenced by untrusted inpu
                 continue;
             };
             if self.inner_head_performs_substitution(inner) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W309,
-                    span: tok.span,
-                    message: format!(
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W309,
+                    tok.span,
+                    format!(
                         "{cmd_name} with [subst] creates double substitution: \
 subst expands $var and [cmd], then {cmd_name} re-parses the result as Tcl. \
 This is a code-injection risk. Use [format] or [string map] for safe templating."
                     ),
-                    severity: Severity::Error,
-                    fixes: Vec::new(),
-                });
+                    Severity::Error,
+                ));
                 break;
             }
         }
@@ -568,16 +567,15 @@ This is a code-injection risk. Use [format] or [string map] for safe templating.
         if remaining.len() > 1 {
             // Multiple args = concat behaviour = danger.
             if self.args_have_substitution(arg_tokens, arg_single) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W301,
-                    span: remaining_toks[0].span,
-                    message: format!(
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W301,
+                    remaining_toks[0].span,
+                    format!(
                         "{cmd_name} with multiple arguments concatenates them into \
 a script (like eval). Use a single braced body or {{*}}$cmdList to avoid injection."
                     ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
             }
         } else if let Some(tok) = remaining_toks.first() {
             // Single arg — unbraced + substituted (and not [list …]).
@@ -597,16 +595,15 @@ a script (like eval). Use a single braced body or {{*}}$cmdList to avoid injecti
                 return;
             }
             if self.args_have_substitution(arg_tokens, arg_single) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W301,
-                    span: tok.span,
-                    message: format!(
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W301,
+                    tok.span,
+                    format!(
                         "{cmd_name} with an unbraced script argument may cause \
 double substitution. Use braces: {cmd_name} 1 {{...}}"
                     ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
             }
         }
     }
@@ -643,16 +640,15 @@ double substitution. Use braces: {cmd_name} 1 {{...}}"
         // concatenates them, like `eval`.
         if concatenates && script_args.len() > 1 {
             if self.args_have_substitution(arg_tokens, arg_single) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W312,
-                    span: script_toks[0].span,
-                    message: format!(
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W312,
+                    script_toks[0].span,
+                    format!(
                         "{cmd_name} {sub_name} with multiple arguments concatenates \
 them into a script (like eval). Use a single braced body to avoid injection."
                     ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
             }
             return;
         }
@@ -662,16 +658,15 @@ them into a script (like eval). Use a single braced body to avoid injection."
             return;
         }
         if self.args_have_substitution(arg_tokens, arg_single) {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W312,
-                span: tok.span,
-                message: format!(
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W312,
+                tok.span,
+                format!(
                     "{cmd_name} {sub_name} with an unbraced script argument may \
 cause code injection. Use braces: {cmd_name} {sub_name} $child {{...}}"
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
         }
     }
 
@@ -773,13 +768,12 @@ cause code injection. Use braces: {cmd_name} {sub_name} $child {{...}}"
 scope, or use [format] / [string map] for safe templating.",
             mitigations.join(" ")
         );
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W102,
-            span: tok.span,
+        self.result.diagnostics.push(super::types::Diagnostic::new(
+            DiagCode::W102,
+            tok.span,
             message,
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+            Severity::Warning,
+        ));
     }
 
     /// **W103.** Emit "open with a pipeline" when `open`'s first
@@ -832,13 +826,12 @@ Ensure the command is not influenced by untrusted input."
                     ),
                 )
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W103,
-                span: tok.span,
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W103,
+                tok.span,
                 message,
                 severity,
-                fixes: Vec::new(),
-            });
+            ));
         } else if matches!(
             tok.kind,
             tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd
@@ -851,32 +844,30 @@ Ensure the command is not influenced by untrusted input."
             // argument stays a Warning (it may resolve to a `|`-pipeline).
             if let Some(literal) = self.resolve_var_token_literal(tok) {
                 if literal.starts_with('|') {
-                    self.result.diagnostics.push(super::types::Diagnostic {
-                        code: DiagCode::W103,
-                        span: tok.span,
-                        message: format!(
+                    self.result.diagnostics.push(super::types::Diagnostic::new(
+                        DiagCode::W103,
+                        tok.span,
+                        format!(
                             "{cmd_name} with a pipeline (\"|\") executes an external command. \
 Ensure the command is not influenced by untrusted input."
                         ),
-                        severity: Severity::Hint,
-                        fixes: Vec::new(),
-                    });
+                        Severity::Hint,
+                    ));
                 }
                 return;
             }
             // A `$var` or `[cmd]`-computed first argument is equally dynamic —
             // either may resolve to a `|`-prefixed pipeline.
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W103,
-                span: tok.span,
-                message: format!(
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W103,
+                tok.span,
+                format!(
                     "{cmd_name} with a dynamic argument (variable or command substitution): \
 if the value starts with \"|\", it will execute a command pipeline. Validate input \
 or use explicit I/O commands."
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
         }
     }
 
@@ -908,16 +899,15 @@ or use explicit I/O commands."
         // `(a|a)+`.
         for (pattern, tok) in patterns {
             if has_redos_shape(&pattern) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W303,
-                    span: tok.span,
-                    message: "Regular expression may be vulnerable to catastrophic \
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W303,
+                    tok.span,
+                    "Regular expression may be vulnerable to catastrophic \
 backtracking (ReDoS). Nested quantifiers like (a+)+ can cause exponential \
 matching time on crafted input."
                         .to_string(),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
             }
         }
     }
@@ -989,15 +979,12 @@ matching time on crafted input."
         } else {
             ". Use braces '{...}' to prevent substitution."
         };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W306,
-            span: tok.span,
-            message: format!(
-                "Literal expected in {cmd_name} pattern \u{2014} found {found}{advice}"
-            ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result.diagnostics.push(super::types::Diagnostic::new(
+            DiagCode::W306,
+            tok.span,
+            format!("Literal expected in {cmd_name} pattern \u{2014} found {found}{advice}"),
+            Severity::Warning,
+        ));
     }
 
     /// **W127.** A literal at a closed-value argument index is not in the
@@ -1062,13 +1049,15 @@ matching time on crafted input."
             }
         }
         for hit in hits {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W127,
-                span: hit.span,
-                message: hit.message,
-                severity: Severity::Warning,
-                fixes: hit.fixes,
-            });
+            self.result.diagnostics.push(
+                super::types::Diagnostic::new(
+                    DiagCode::W127,
+                    hit.span,
+                    hit.message,
+                    Severity::Warning,
+                )
+                .with_fixes(hit.fixes),
+            );
         }
     }
 
@@ -1135,13 +1124,15 @@ matching time on crafted input."
             }
         }
         for hit in hits {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W127,
-                span: hit.span,
-                message: hit.message,
-                severity: Severity::Warning,
-                fixes: hit.fixes,
-            });
+            self.result.diagnostics.push(
+                super::types::Diagnostic::new(
+                    DiagCode::W127,
+                    hit.span,
+                    hit.message,
+                    Severity::Warning,
+                )
+                .with_fixes(hit.fixes),
+            );
         }
     }
 
@@ -1186,16 +1177,15 @@ matching time on crafted input."
                 continue;
             };
             if is_literal_credential_value(value, val_tok) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W310,
-                    span: val_tok.span,
-                    message: format!(
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W310,
+                    val_tok.span,
+                    format!(
                         "Hardcoded credential in {text} argument. Store secrets in \
 environment variables or a vault, not in source code."
                     ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
                 return; // one diagnostic per command
             }
         }
@@ -1222,16 +1212,15 @@ environment variables or a vault, not in source code."
                         (args.get(cred_arg), arg_tokens.get(cred_arg))
                     && is_literal_credential_value(value, val_tok)
                 {
-                    self.result.diagnostics.push(super::types::Diagnostic {
-                        code: DiagCode::W310,
-                        span: val_tok.span,
-                        message: format!(
+                    self.result.diagnostics.push(super::types::Diagnostic::new(
+                        DiagCode::W310,
+                        val_tok.span,
+                        format!(
                             "Hardcoded credential in {header_name} header value. \
 Store secrets in environment variables or a vault, not in source code."
                         ),
-                        severity: Severity::Warning,
-                        fixes: Vec::new(),
-                    });
+                        Severity::Warning,
+                    ));
                 }
             }
         }

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -790,13 +790,7 @@ fn body_references_param_namespace_qualified() {
 }
 
 fn diag(code: DiagCode, span: Span, msg: &str) -> Diagnostic {
-    Diagnostic {
-        code,
-        span,
-        message: msg.to_string(),
-        severity: Severity::Warning,
-        fixes: Vec::new(),
-    }
+    Diagnostic::new(code, span, msg.to_string(), Severity::Warning)
 }
 
 #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -485,13 +485,10 @@ impl Analyser {
                     description: format!("Replace with '{best}'"),
                 });
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W123,
-                span: inv.range,
-                message,
-                severity: Severity::Hint,
-                fixes,
-            });
+            self.result.diagnostics.push(
+                super::types::Diagnostic::new(DiagCode::W123, inv.range, message, Severity::Hint)
+                    .with_fixes(fixes),
+            );
         }
         self.result.command_invocations = invocations;
     }
@@ -638,13 +635,15 @@ impl Analyser {
                 new_text: format!("package require {pkg}\n"),
                 description: format!("Add 'package require {pkg}'"),
             };
-            new_diags.push(super::types::Diagnostic {
-                code: DiagCode::W120,
-                span: inv.range,
-                message: format!("\"{}\" requires `package require {pkg}`", inv.name),
-                severity: Severity::Warning,
-                fixes: vec![fix],
-            });
+            new_diags.push(
+                super::types::Diagnostic::new(
+                    DiagCode::W120,
+                    inv.range,
+                    format!("\"{}\" requires `package require {pkg}`", inv.name),
+                    Severity::Warning,
+                )
+                .with_fixes(vec![fix]),
+            );
         }
         self.result.diagnostics.extend(new_diags);
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/usage.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/usage.rs
@@ -120,17 +120,14 @@ Use braces: {{ \u{2026} }}"
             )
         };
         let new_text = format!("{{{body_text}}}");
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W105,
-            span: body_tok.span,
-            message,
-            severity,
-            fixes: vec![super::types::CodeFix {
-                span: body_tok.span,
-                new_text,
-                description: "Wrap code block in braces".to_string(),
-            }],
-        });
+        self.result.diagnostics.push(
+            super::types::Diagnostic::new(DiagCode::W105, body_tok.span, message, severity)
+                .with_fixes(vec![super::types::CodeFix {
+                    span: body_tok.span,
+                    new_text,
+                    description: "Wrap code block in braces".to_string(),
+                }]),
+        );
     }
 
     /// W100: an expression argument (`expr` / `if` / `while`
@@ -274,17 +271,15 @@ Use braces: {{ \u{2026} }}"
         } else {
             text
         };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W100,
-            span,
-            message,
-            severity,
-            fixes: vec![super::types::CodeFix {
-                span,
-                new_text: format!("{{{fix_inner}}}"),
-                description: "Wrap expression in braces".to_string(),
-            }],
-        });
+        self.result.diagnostics.push(
+            super::types::Diagnostic::new(DiagCode::W100, span, message, severity).with_fixes(
+                vec![super::types::CodeFix {
+                    span,
+                    new_text: format!("{{{fix_inner}}}"),
+                    description: "Wrap expression in braces".to_string(),
+                }],
+            ),
+        );
     }
 
     /// W311: a channel configured with `-encoding binary` *and*
@@ -324,17 +319,16 @@ Use braces: {{ \u{2026} }}"
                 .or(binary_tok)
                 .or_else(|| arg_tokens.first());
             if let Some(tok) = target {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W311,
-                    span: tok.span,
-                    message: "Channel configured with -encoding binary and a non-binary \
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W311,
+                    tok.span,
+                    "Channel configured with -encoding binary and a non-binary \
                               -translation. Binary encoding implies no translation; the \
                               conflicting -translation may silently corrupt data or enable \
                               encoding-differential attacks."
                         .to_string(),
-                    severity: super::types::Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    super::types::Severity::Warning,
+                ));
             }
         }
     }
@@ -382,16 +376,15 @@ Use braces: {{ \u{2026} }}"
                 && (fmt[i] == b'u' || fmt[i] == b's')
             {
                 let modifier = fmt[i] as char;
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W200,
-                    span: fmt_tok.span,
-                    message: format!(
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W200,
+                    fmt_tok.span,
+                    format!(
                         "signed/unsigned modifier '{modifier}' on binary format specifier \
                          requires Tcl 8.5+"
                     ),
-                    severity: super::types::Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    super::types::Severity::Warning,
+                ));
                 i += 1;
             }
             if i < fmt.len() && fmt[i] == b'*' {
@@ -441,13 +434,12 @@ Use braces: {{ \u{2026} }}"
                     use std::fmt::Write as _;
                     let _ = write!(message, " Did you mean '{s}'?");
                 }
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W121,
-                    span: tok.span,
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W121,
+                    tok.span,
                     message,
-                    severity: super::types::Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    super::types::Severity::Warning,
+                ));
             }
         }
     }
@@ -555,17 +547,11 @@ Use braces: {{ \u{2026} }}"
                         }]
                     })
                     .unwrap_or_default();
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W108,
-                    span,
-                    message: format!(
+                self.result.diagnostics.push(super::types::Diagnostic::new(DiagCode::W108, span, format!(
                         "Non-ASCII character U+{:04X} '{ch}' \u{2014} outside the standard ASCII \
                          printable/whitespace set",
                         ch as u32
-                    ),
-                    severity: super::types::Severity::Warning,
-                    fixes,
-                });
+                    ), super::types::Severity::Warning).with_fixes(fixes));
             }
             if flagged_here {
                 seen.insert(tok.span.start());
@@ -607,16 +593,18 @@ Use braces: {{ \u{2026} }}"
                     .w104_lappend_fix(args, arg_tokens, arg_expand, cmd_tok)
                     .into_iter()
                     .collect();
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W104,
-                    span: tok.span,
-                    message: "append with space-separated values looks like list \
+                self.result.diagnostics.push(
+                    super::types::Diagnostic::new(
+                        DiagCode::W104,
+                        tok.span,
+                        "append with space-separated values looks like list \
                               construction. Use [lappend] instead to safely handle values \
                               containing spaces, braces, or backslashes."
-                        .to_string(),
-                    severity: super::types::Severity::Hint,
-                    fixes,
-                });
+                            .to_string(),
+                        super::types::Severity::Hint,
+                    )
+                    .with_fixes(fixes),
+                );
                 return;
             }
         }
@@ -772,13 +760,12 @@ Use braces: {{ \u{2026} }}"
         } else {
             super::types::Severity::Warning
         };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W106,
+        self.result.diagnostics.push(super::types::Diagnostic::new(
+            DiagCode::W106,
             span,
             message,
             severity,
-            fixes: Vec::new(),
-        });
+        ));
     }
 
     /// Argument indices (0-based, command-name excluded) that `cmd` reads as a
@@ -888,16 +875,15 @@ Use braces: {{ \u{2026} }}"
                 .copied()
                 .unwrap_or(bare)
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W212,
-                span: tok.span,
-                message: format!(
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W212,
+                tok.span,
+                format!(
                     "'{display_cmd}' expects a variable name, got substitution (${bare}). \
                      Did you mean '{suggestion}'?"
                 ),
-                severity: super::types::Severity::Warning,
-                fixes: Vec::new(),
-            });
+                super::types::Severity::Warning,
+            ));
         }
     }
 
@@ -965,17 +951,19 @@ Use braces: {{ \u{2026} }}"
 (the brace form is documented to apply no further substitution to its \
 content); use `{corrected}` to access the array element with index substitution"
                         );
-                        self.result.diagnostics.push(super::types::Diagnostic {
-                            code: DiagCode::W216,
-                            span,
-                            message,
-                            severity: Severity::Warning,
-                            fixes: vec![super::types::CodeFix {
+                        self.result.diagnostics.push(
+                            super::types::Diagnostic::new(
+                                DiagCode::W216,
+                                span,
+                                message,
+                                Severity::Warning,
+                            )
+                            .with_fixes(vec![super::types::CodeFix {
                                 span,
                                 new_text: corrected.clone(),
                                 description: format!("Replace with `{corrected}`"),
-                            }],
-                        });
+                            }]),
+                        );
                     }
                 }
                 continue;
@@ -1009,17 +997,14 @@ content); use `{corrected}` to access the array element with index substitution"
                 "`${{{text}}}({inner})` is parsed as scalar `${{{text}}}` followed by \
 literal text `({inner})`; did you mean `{corrected}` for array element access?"
             );
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W216,
-                span,
-                message,
-                severity: Severity::Warning,
-                fixes: vec![super::types::CodeFix {
-                    span,
-                    new_text: corrected.clone(),
-                    description: format!("Replace with `{corrected}`"),
-                }],
-            });
+            self.result.diagnostics.push(
+                super::types::Diagnostic::new(DiagCode::W216, span, message, Severity::Warning)
+                    .with_fixes(vec![super::types::CodeFix {
+                        span,
+                        new_text: corrected.clone(),
+                        description: format!("Replace with `{corrected}`"),
+                    }]),
+            );
         }
     }
 
@@ -1054,13 +1039,15 @@ literal text `({inner})`; did you mean `{corrected}` for array element access?"
         let fixes = w114_unwrap_fix(slice, open, close, nested_span)
             .into_iter()
             .collect();
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W114,
-            span: nested_span,
-            message: "Redundant nested [expr] \u{2014} already in expression context".to_string(),
-            severity: super::types::Severity::Warning,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            super::types::Diagnostic::new(
+                DiagCode::W114,
+                nested_span,
+                "Redundant nested [expr] \u{2014} already in expression context".to_string(),
+                super::types::Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// **W110.** Emit "use `eq`/`ne` instead of `==`/`!=` for
@@ -1136,13 +1123,10 @@ literal text `({inner})`; did you mean `{corrected}` for array element access?"
 comparison in expressions to avoid ambiguous \
 numeric/string coercion."
         );
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W110,
-            span,
-            message,
-            severity: Severity::Hint,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            super::types::Diagnostic::new(DiagCode::W110, span, message, Severity::Hint)
+                .with_fixes(fixes),
+        );
     }
 
     /// Map a W110 operator offset (within the emitter's `expr_text`) to

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -246,16 +246,15 @@ pub(super) fn arity_verdict(
         return None;
     }
     if !positional_any_expand && nargs_min < min {
-        Some(crate::analyser::types::Diagnostic {
-            code: DiagCode::E002,
+        Some(crate::analyser::types::Diagnostic::new(
+            DiagCode::E002,
             span,
-            message: format!(
+            format!(
                 "Too few arguments for '{display_name}': expected at least {min}, \
 got {nargs_min}{usage_suffix}"
             ),
-            severity: Severity::Error,
-            fixes: Vec::new(),
-        })
+            Severity::Error,
+        ))
     } else if !arity.is_unlimited() && nargs_min > max {
         // Highlight only the surplus arguments when the caller could
         // isolate them (the whole command otherwise), and offer to delete
@@ -273,31 +272,32 @@ got {nargs_min}{usage_suffix}"
             ),
             None => (span, Vec::new()),
         };
-        Some(crate::analyser::types::Diagnostic {
-            code: DiagCode::E003,
-            span: e003_span,
-            message: format!(
-                "Too many arguments for '{display_name}': expected at most {max}, \
+        Some(
+            crate::analyser::types::Diagnostic::new(
+                DiagCode::E003,
+                e003_span,
+                format!(
+                    "Too many arguments for '{display_name}': expected at most {max}, \
 got {nargs_min}{usage_suffix}"
-            ),
-            severity: Severity::Error,
-            fixes,
-        })
+                ),
+                Severity::Error,
+            )
+            .with_fixes(fixes),
+        )
     } else if !positional_any_expand
         && arity.step != 0
         && !(nargs_min - min).is_multiple_of(usize::from(arity.step))
     {
-        Some(crate::analyser::types::Diagnostic {
-            code: DiagCode::E005,
+        Some(crate::analyser::types::Diagnostic::new(
+            DiagCode::E005,
             span,
-            message: format!(
+            format!(
                 "Wrong argument-count shape for '{display_name}': expected {}, \
 got {nargs_min}{usage_suffix}",
                 describe_step_shape(arity)
             ),
-            severity: Severity::Error,
-            fixes: Vec::new(),
-        })
+            Severity::Error,
+        ))
     } else {
         None
     }
@@ -588,13 +588,12 @@ impl Analyser {
         let suffix = registry.get(bare).map_or(String::new(), |spec| {
             dialect_availability_suffix(spec.dialects)
         });
-        let diag = super::types::Diagnostic {
-            code: DiagCode::W002,
-            span: cmd_tok.span,
-            message: format!("'{cmd_name}' is disabled in the active dialect profile{suffix}"),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        };
+        let diag = super::types::Diagnostic::new(
+            DiagCode::W002,
+            cmd_tok.span,
+            format!("'{cmd_name}' is disabled in the active dialect profile{suffix}"),
+            Severity::Warning,
+        );
         let ns = self.command_resolution_namespace(scope_path);
         let enforce_order = !self.scope_path_in_proc_body(scope_path);
         self.pending_disabled_commands
@@ -773,13 +772,8 @@ impl Analyser {
             cmd_name.to_string(),
             ns,
             enforce_order,
-            super::types::Diagnostic {
-                code: DiagCode::W001,
-                span,
-                message,
-                severity: Severity::Warning,
-                fixes,
-            },
+            super::types::Diagnostic::new(DiagCode::W001, span, message, Severity::Warning)
+                .with_fixes(fixes),
         ));
     }
 
@@ -838,15 +832,12 @@ impl Analyser {
                     dialect_availability_suffix(sub.dialects.or(spec.dialects))
                 })
         });
-        let diag = super::types::Diagnostic {
-            code: DiagCode::W002,
+        let diag = super::types::Diagnostic::new(
+            DiagCode::W002,
             span,
-            message: format!(
-                "'{cmd_name} {first_arg}' is disabled in the active dialect profile{suffix}"
-            ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        };
+            format!("'{cmd_name} {first_arg}' is disabled in the active dialect profile{suffix}"),
+            Severity::Warning,
+        );
         let ns = self.command_resolution_namespace(scope_path);
         let enforce_order = !self.scope_path_in_proc_body(scope_path);
         self.pending_disabled_commands
@@ -981,13 +972,12 @@ impl Analyser {
                         cmd_name.to_string(),
                         ns,
                         enforce_order,
-                        super::types::Diagnostic {
-                            code: DiagCode::E001,
-                            span: cmd_tok.span,
-                            message: format!("'{cmd_name}' requires a subcommand"),
-                            severity: Severity::Error,
-                            fixes: Vec::new(),
-                        },
+                        super::types::Diagnostic::new(
+                            DiagCode::E001,
+                            cmd_tok.span,
+                            format!("'{cmd_name}' requires a subcommand"),
+                            Severity::Error,
+                        ),
                     ));
                     return;
                 };
@@ -2091,13 +2081,10 @@ impl Analyser {
 
         let fixes = self.e004_fixes(args, arg_tokens, error);
 
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::E004,
-            span,
-            message,
-            severity: Severity::Error,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            super::types::Diagnostic::new(DiagCode::E004, span, message, Severity::Error)
+                .with_fixes(fixes),
+        );
     }
 
     /// Code fixes for [`Self::emit_e004_clause_shape_diagnostic`]. See
@@ -2308,13 +2295,10 @@ impl Analyser {
 
         let (severity, message, origin) =
             self.classify_w304(tok, is_dynamic, looks_like_option, &command_label);
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W304,
-            span: diag_span,
-            message,
-            severity,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            super::types::Diagnostic::new(DiagCode::W304, diag_span, message, severity)
+                .with_fixes(fixes),
+        );
         if let Some(origin_diag) = origin {
             self.result.diagnostics.push(origin_diag);
         }
@@ -2375,16 +2359,18 @@ impl Analyser {
             new_text: format!("-- {slice}"),
             description: "Insert '--' so the following words are variable names".to_string(),
         }];
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::W217,
-            span: diag_span,
-            message: "`unset` unsets no variable here — `-nocomplain` / `--` are consumed as \
+        self.result.diagnostics.push(
+            super::types::Diagnostic::new(
+                DiagCode::W217,
+                diag_span,
+                "`unset` unsets no variable here — `-nocomplain` / `--` are consumed as \
 options. To unset a variable whose name begins with `-`, put `--` before it \
 (e.g. `unset -- -nocomplain`)."
-                .to_string(),
-            severity: Severity::Warning,
-            fixes,
-        });
+                    .to_string(),
+                Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// Emit the per-item path's pending W304 diagnostics, classifying each
@@ -2398,13 +2384,10 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
         let pending = std::mem::take(&mut self.pending_w304);
         for (tok, command_label, fixes, diag_span) in pending {
             let (severity, message, origin) = self.classify_w304(tok, true, false, &command_label);
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W304,
-                span: diag_span,
-                message,
-                severity,
-                fixes,
-            });
+            self.result.diagnostics.push(
+                super::types::Diagnostic::new(DiagCode::W304, diag_span, message, severity)
+                    .with_fixes(fixes),
+            );
             if let Some(origin_diag) = origin {
                 self.result.diagnostics.push(origin_diag);
             }
@@ -2441,13 +2424,12 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                 .map(|s| (s.name.clone(), s.range))
                 .collect();
             for (name, span) in hits {
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::W116,
+                self.result.diagnostics.push(Diagnostic::new(
+                    DiagCode::W116,
                     span,
-                    message: format!("Stub command '{name}' shadows built-in command."),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    format!("Stub command '{name}' shadows built-in command."),
+                    Severity::Warning,
+                ));
             }
         }
 
@@ -2471,15 +2453,12 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                 } else {
                     "operator"
                 };
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::W117,
+                self.result.diagnostics.push(Diagnostic::new(
+                    DiagCode::W117,
                     span,
-                    message: format!(
-                        "Stub expression {kind_label} '{name}' shadows built-in {kind_label}."
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    format!("Stub expression {kind_label} '{name}' shadows built-in {kind_label}."),
+                    Severity::Warning,
+                ));
             }
         }
     }
@@ -2518,13 +2497,15 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
         } else {
             Vec::new()
         };
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::Irule2002,
-            span: cmd_tok.span,
-            message: format!("'{cmd_name}' is deprecated in iRules. Use '{replacement}' instead."),
-            severity: Severity::Warning,
-            fixes,
-        });
+        self.result.diagnostics.push(
+            super::types::Diagnostic::new(
+                DiagCode::Irule2002,
+                cmd_tok.span,
+                format!("'{cmd_name}' is deprecated in iRules. Use '{replacement}' instead."),
+                Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// **IRULE2001.** Warn that `matchclass` is deprecated — use
@@ -2584,15 +2565,17 @@ options. To unset a variable whose name begins with `-`, put `--` before it \
                 }]
             })
             .unwrap_or_default();
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::Irule2001,
-            span: cmd_tok.span,
-            message: "'matchclass' is deprecated since BIG-IP v10. \
+        self.result.diagnostics.push(
+            super::types::Diagnostic::new(
+                DiagCode::Irule2001,
+                cmd_tok.span,
+                "'matchclass' is deprecated since BIG-IP v10. \
 Use 'class match <item> <operator> <class>' instead."
-                .to_string(),
-            severity: Severity::Warning,
-            fixes,
-        });
+                    .to_string(),
+                Severity::Warning,
+            )
+            .with_fixes(fixes),
+        );
     }
 
     /// Classify the positional value for W304: tristate severity,
@@ -2633,16 +2616,15 @@ This value is reported at INFO because '{var_text}' currently resolves to \
 static literal '{resolved_text}'. Keep '--' to guard against future \
 option-injection regressions if the variable changes."
                     );
-                    let origin = super::types::Diagnostic {
-                        code: DiagCode::W304,
-                        span: resolved_span,
-                        message: format!(
+                    let origin = super::types::Diagnostic::new(
+                        DiagCode::W304,
+                        resolved_span,
+                        format!(
                             "'{var_text}' is currently assigned static \
 literal '{resolved_text}' here; this is why the diagnostic is INFO."
                         ),
-                        severity: Severity::Suggestion,
-                        fixes: Vec::new(),
-                    };
+                        Severity::Suggestion,
+                    );
                     return (Severity::Suggestion, message, Some(origin));
                 }
             }
@@ -2831,17 +2813,17 @@ before this value so it is treated as data, not an option."
                     let sub_suffix = sub_name.map_or(String::new(), |n| format!(" {n}"));
                     let consumed = 1 + opt.value_word_count(args, i);
                     let fixes = self.w004_remove_option_fix(arg, arg_tokens, i, consumed);
-                    let diag = super::types::Diagnostic {
-                        code: DiagCode::W004,
+                    let diag = super::types::Diagnostic::new(
+                        DiagCode::W004,
                         span,
-                        message: format!(
+                        format!(
                             "Option '{arg}' on '{cmd_name}'{sub_suffix} is not available \
 in the active dialect ({}).",
                             self.dialect
                         ),
-                        severity: Severity::Warning,
-                        fixes,
-                    };
+                        Severity::Warning,
+                    )
+                    .with_fixes(fixes);
                     let ns = self.command_resolution_namespace(scope_path);
                     let enforce_order = !self.scope_path_in_proc_body(scope_path);
                     self.pending_arity
@@ -3004,17 +2986,11 @@ in the active dialect ({}).",
                     ),
                 });
             }
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W003,
-                span: op_span,
-                message: format!(
+            self.result.diagnostics.push(super::types::Diagnostic::new(DiagCode::W003, op_span, format!(
                     "Expression operator '{op_name}' is not available in dialect '{}'; requires {}.",
                     self.dialect,
                     w003_tip_citation(op_name)
-                ),
-                severity: Severity::Warning,
-                fixes,
-            });
+                ), Severity::Warning).with_fixes(fixes));
         }
     }
 
@@ -3047,21 +3023,11 @@ in the active dialect ({}).",
             let Some(op_name) = gated_operator_name(word, pre_85, pre_90) else {
                 continue;
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W003,
-                span: tok.span,
-                message: format!(
+            self.result.diagnostics.push(super::types::Diagnostic::new(DiagCode::W003, tok.span, format!(
                     "Expression operator '{op_name}' is not available in dialect '{}'; requires {}.",
                     self.dialect,
                     w003_tip_citation(op_name)
-                ),
-                severity: Severity::Warning,
-                // The unbraced multi-word form has no single local
-                // span to rewrite in place without also re-bracing
-                // the whole expression (W100's concern, not this
-                // one) — left unfixed.
-                fixes: Vec::new(),
-            });
+                ), Severity::Warning));
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -375,13 +375,8 @@ impl Analyser {
                 });
             }
         }
-        super::types::Diagnostic {
-            code: DiagCode::W308,
-            span,
-            message,
-            severity: Severity::Warning,
-            fixes,
-        }
+        super::types::Diagnostic::new(DiagCode::W308, span, message, Severity::Warning)
+            .with_fixes(fixes)
     }
 
     /// **E001** (`TclOO` form) — `$obj` invoked with no method word at all.
@@ -425,13 +420,12 @@ impl Analyser {
         if !all_tcloo {
             return None;
         }
-        Some(super::types::Diagnostic {
-            code: DiagCode::E001,
-            span: site.cmd_span,
-            message: format!("'{}' requires a method", site.var_name),
-            severity: Severity::Error,
-            fixes: Vec::new(),
-        })
+        Some(super::types::Diagnostic::new(
+            DiagCode::E001,
+            site.cmd_span,
+            format!("'{}' requires a method", site.var_name),
+            Severity::Error,
+        ))
     }
 
     /// Check a resolved `$obj method …` dispatch's argument count
@@ -954,13 +948,12 @@ impl Analyser {
 
             // **W307 path.**  Variable not a known Object.
             if !self.w307_site_suppressed(site, &w307_ctx) {
-                self.result.diagnostics.push(super::types::Diagnostic {
-                    code: DiagCode::W307,
-                    span: site.cmd_span,
-                    message: "Non-literal command name — cannot statically analyze".to_string(),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                self.result.diagnostics.push(super::types::Diagnostic::new(
+                    DiagCode::W307,
+                    site.cmd_span,
+                    "Non-literal command name — cannot statically analyze".to_string(),
+                    Severity::Warning,
+                ));
             }
         }
         // Restore the sites list — snapshot/restore expects it
@@ -1040,13 +1033,12 @@ impl Analyser {
                     self.oo_self_method_returns_literal(site.cmd_span.start(), method)
                 });
                 if returns_literal {
-                    self.result.diagnostics.push(super::types::Diagnostic {
-                        code: DiagCode::W307,
-                        span: site.cmd_span,
-                        message: "Non-literal command name — cannot statically analyze".to_string(),
-                        severity: Severity::Warning,
-                        fixes: Vec::new(),
-                    });
+                    self.result.diagnostics.push(super::types::Diagnostic::new(
+                        DiagCode::W307,
+                        site.cmd_span,
+                        "Non-literal command name — cannot statically analyze".to_string(),
+                        Severity::Warning,
+                    ));
                 }
                 continue;
             }
@@ -1116,13 +1108,12 @@ impl Analyser {
 
             // Type is unknown — emit W307 (only the emit-half
             // for the residual unknown-type case).
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W307,
-                span: site.cmd_span,
-                message: "Non-literal command name — cannot statically analyze".to_string(),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W307,
+                site.cmd_span,
+                "Non-literal command name — cannot statically analyze".to_string(),
+                Severity::Warning,
+            ));
         }
         self.cmd_command_sites = cmd_sites;
     }
@@ -1164,15 +1155,12 @@ impl Analyser {
             |sub: Option<&String>| matches!(sub.map(String::as_str), Some("new" | "create"));
         let mut diags: Vec<super::types::Diagnostic> = Vec::new();
         let mut flag = |span: tcl_lexer::Span, class: &str| {
-            diags.push(super::types::Diagnostic {
-                code: DiagCode::W250,
+            diags.push(super::types::Diagnostic::new(
+                DiagCode::W250,
                 span,
-                message: format!(
-                    "Instantiating abstract class '{class}' — use a concrete subclass"
-                ),
-                severity: super::types::Severity::Warning,
-                fixes: Vec::new(),
-            });
+                format!("Instantiating abstract class '{class}' — use a concrete subclass"),
+                super::types::Severity::Warning,
+            ));
         };
         let units = std::iter::once(&cu.top_level)
             .chain(cu.procedures.values())

--- a/rust/tcl-compiler/src/analyser/diagnostics/version_gate.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/version_gate.rs
@@ -197,13 +197,7 @@ impl Analyser {
                     ),
                 ),
             };
-            new_diags.push(Diagnostic {
-                code,
-                span: site.span,
-                message,
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            new_diags.push(Diagnostic::new(code, site.span, message, Severity::Warning));
         }
         self.result.diagnostics.extend(new_diags);
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/widget_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/widget_command.rs
@@ -189,16 +189,15 @@ impl Analyser {
                 .iter()
                 .find(|s: &&SubCommand| s.name == site.subcommand)
             else {
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::W001,
-                    span: site.subcommand_span,
-                    message: format!(
+                self.result.diagnostics.push(Diagnostic::new(
+                    DiagCode::W001,
+                    site.subcommand_span,
+                    format!(
                         "Unknown subcommand '{}' for widget '{class}'",
                         site.subcommand
                     ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
                 continue;
             };
             if site.has_expand {

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -507,13 +507,12 @@ impl Analyser {
                 format!(" ({})", self.dialect)
             };
             let message = format!("Procedure '{raw_name}' shadows built-in command{dialect_label}");
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W113,
-                span: name_span,
+            self.result.diagnostics.push(super::types::Diagnostic::new(
+                DiagCode::W113,
+                name_span,
                 message,
-                severity: super::types::Severity::Warning,
-                fixes: Vec::new(),
-            });
+                super::types::Severity::Warning,
+            ));
         }
     }
 
@@ -538,14 +537,8 @@ impl Analyser {
                 continue;
             }
             let span = param_spans.get(i).copied().unwrap_or(fallback_tok.span);
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::W218,
-                span,
-                message: "`args` here is an ordinary parameter — it only has its special                           collect-the-rest meaning as the final parameter. Move it last, or                           rename it if a plain parameter is intended."
-                    .to_string(),
-                severity: super::types::Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result.diagnostics.push(super::types::Diagnostic::new(DiagCode::W218, span, "`args` here is an ordinary parameter — it only has its special                           collect-the-rest meaning as the final parameter. Move it last, or                           rename it if a plain parameter is intended."
+                    .to_string(), super::types::Severity::Warning));
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/irules_event_checks.rs
+++ b/rust/tcl-compiler/src/analyser/irules_event_checks.rs
@@ -297,13 +297,12 @@ impl Analyser {
                     })
                 });
             if let Some(info) = hint {
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::Irule1001,
-                    span: cmd_tok.span,
-                    message: format!("'{cmd_name}' {info}."),
-                    severity: Severity::Hint,
-                    fixes: Vec::new(),
-                });
+                self.result.diagnostics.push(Diagnostic::new(
+                    DiagCode::Irule1001,
+                    cmd_tok.span,
+                    format!("'{cmd_name}' {info}."),
+                    Severity::Hint,
+                ));
             }
             return;
         }
@@ -321,13 +320,12 @@ impl Analyser {
                 }
                 hint.push('.');
             }
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule1001,
-                span: cmd_tok.span,
-                message: format!("'{cmd_name}' cannot be used in {event}.{hint}"),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            self.result.diagnostics.push(Diagnostic::new(
+                DiagCode::Irule1001,
+                cmd_tok.span,
+                format!("'{cmd_name}' cannot be used in {event}.{hint}"),
+                Severity::Warning,
+            ));
             return;
         }
 
@@ -341,13 +339,12 @@ impl Analyser {
                     format!("'{cmd_name}' may not work in {event}: {desc}.")
                 }
             };
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule1001,
-                span: cmd_tok.span,
+            self.result.diagnostics.push(Diagnostic::new(
+                DiagCode::Irule1001,
+                cmd_tok.span,
                 message,
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
         }
     }
 
@@ -370,16 +367,15 @@ impl Analyser {
         if !body_decrements(&args[1], &var_name) {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule5003,
-            span: tok.span,
-            message: format!(
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule5003,
+            tok.span,
+            format!(
                 "Loop condition '${var_name} != 0' can miss zero if decremented past it. \
                  Consider '${var_name} > 0'."
             ),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+            Severity::Hint,
+        ));
     }
 
     /// **IRULE5006.** A top-level-only command (`when` / `proc` /
@@ -395,13 +391,12 @@ impl Analyser {
         if !is_top_level {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule5006,
-            span: cmd_tok.span,
-            message: format!("'{cmd_name}' is only valid at the top level of an iRule."),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule5006,
+            cmd_tok.span,
+            format!("'{cmd_name}' is only valid at the top level of an iRule."),
+            Severity::Warning,
+        ));
     }
 
     /// **IRULE5007.** An event-context command (one with event
@@ -427,15 +422,12 @@ impl Analyser {
         if !requires_event {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule5007,
-            span: cmd_tok.span,
-            message: format!(
-                "'{cmd_name}' requires an event context — use it inside a `when` block."
-            ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule5007,
+            cmd_tok.span,
+            format!("'{cmd_name}' requires an event context — use it inside a `when` block."),
+            Severity::Warning,
+        ));
     }
 
     /// **IRULE1002.** `when` references an unknown iRules event name.
@@ -458,13 +450,12 @@ impl Analyser {
         if event_registry().is_known(event_name) {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule1002,
-            span: tok.span,
-            message: format!("Unknown iRules event '{event_name}'. Check the event name spelling."),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule1002,
+            tok.span,
+            format!("Unknown iRules event '{event_name}'. Check the event name spelling."),
+            Severity::Warning,
+        ));
     }
 
     /// **IRULE2003.** Unsafe iRules command (context escalation).
@@ -476,13 +467,12 @@ impl Analyser {
         if !is_unsafe {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule2003,
-            span: cmd_tok.span,
-            message: format!("'{cmd_name}' is unsafe in iRules and may allow context escalation"),
-            severity: Severity::Error,
-            fixes: Vec::new(),
-        });
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule2003,
+            cmd_tok.span,
+            format!("'{cmd_name}' is unsafe in iRules and may allow context escalation"),
+            Severity::Error,
+        ));
     }
 
     /// **IRULE3102.** `HTTP::path` / `HTTP::uri` / `HTTP::query` getter
@@ -504,13 +494,12 @@ impl Analyser {
         if !fires {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule3102,
-            span: cmd_tok.span,
-            message: crate::irules_checks::format_message(cmd_name),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule3102,
+            cmd_tok.span,
+            crate::irules_checks::format_message(cmd_name),
+            Severity::Warning,
+        ));
     }
 
     /// **IRULE1003.** Deprecated iRules event referenced by `when`.
@@ -529,13 +518,12 @@ impl Analyser {
         if !is_deprecated_event(event_name) {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule1003,
-            span: tok.span,
-            message: format!("'{event_name}' event is deprecated."),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule1003,
+            tok.span,
+            format!("'{event_name}' event is deprecated."),
+            Severity::Warning,
+        ));
     }
 
     /// **IRULE1004.** `when` block missing an explicit `priority`.
@@ -553,15 +541,13 @@ impl Analyser {
         if args.len() >= 2 && args[1] == "priority" {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule1004,
-            span: cmd_tok.span,
-            message:
-                "'when' missing an explicit priority. Add 'priority <N>' to control execution order."
-                    .to_string(),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule1004,
+            cmd_tok.span,
+            "'when' missing an explicit priority. Add 'priority <N>' to control execution order."
+                .to_string(),
+            Severity::Hint,
+        ));
     }
 
     /// **IRULE2101.** Heavy `regexp` in a high-frequency event.
@@ -573,16 +559,15 @@ impl Analyser {
         if !is_hot_event(event) {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule2101,
-            span: cmd_tok.span,
-            message: format!(
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule2101,
+            cmd_tok.span,
+            format!(
                 "'regexp' in {event} may be expensive at high traffic volumes. \
                  Consider 'string match', 'switch -glob', or a data-group lookup."
             ),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+            Severity::Hint,
+        ));
     }
 
     /// **IRULE5001.** Ungated `log` in a high-frequency event.
@@ -594,17 +579,16 @@ impl Analyser {
         if !is_hot_event(event) {
             return;
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule5001,
-            span: cmd_tok.span,
-            message: format!(
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule5001,
+            cmd_tok.span,
+            format!(
                 "'log' in {event} fires on every request. \
                  Set a debug flag in CLIENT_ACCEPTED (e.g. set debug 0) and gate with \
                  if {{$debug}} {{...}}."
             ),
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+            Severity::Hint,
+        ));
     }
 
     /// **IRULE4001.** Write to a `static::` variable outside `RULE_INIT`.
@@ -621,17 +605,16 @@ impl Analyser {
         let Some(var_name) = static_var_from_set(cmd_name, args) else {
             return;
         };
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule4001,
-            span: cmd_tok.span,
-            message: format!(
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule4001,
+            cmd_tok.span,
+            format!(
                 "Writing to '{var_name}' outside RULE_INIT is dangerous. \
                  static:: variables are shared across all connections; \
                  concurrent writes can cause race conditions."
             ),
-            severity: Severity::Warning,
-            fixes: Vec::new(),
-        });
+            Severity::Warning,
+        ));
     }
 
     /// **IRULE4003.** Variable scoping concern across `when` events.
@@ -682,13 +665,12 @@ impl Analyser {
         if concerns.len() > 1 {
             msg = format!("{msg}; {}", concerns[1..].join("; "));
         }
-        self.result.diagnostics.push(Diagnostic {
-            code: DiagCode::Irule4003,
-            span: cmd_tok.span,
-            message: msg,
-            severity: Severity::Hint,
-            fixes: Vec::new(),
-        });
+        self.result.diagnostics.push(Diagnostic::new(
+            DiagCode::Irule4003,
+            cmd_tok.span,
+            msg,
+            Severity::Hint,
+        ));
     }
 
     /// **IRULE6001.** Global namespace variable usage (CMP pinning).
@@ -705,17 +687,16 @@ impl Analyser {
             && let Some(var_name) = args.first()
         {
             let static_name = format!("static::{var_name}");
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule6001,
-                span: cmd_tok.span,
-                message: format!(
+            self.result.diagnostics.push(Diagnostic::new(
+                DiagCode::Irule6001,
+                cmd_tok.span,
+                format!(
                     "'global {var_name}' imports from the global namespace, \
                      forcing CMP compatibility mode and pinning the virtual server \
                      to a single TMM. Use '{static_name}' instead."
                 ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
             return;
         }
 
@@ -726,21 +707,23 @@ impl Analyser {
             let fix_span = var_write_index(cmd_name)
                 .and_then(|idx| arg_tokens.get(idx))
                 .map_or(cmd_tok.span, |t| t.span);
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule6001,
-                span: fix_span,
-                message: format!(
-                    "Global namespace variable '{var_name}' forces CMP compatibility \
+            self.result.diagnostics.push(
+                Diagnostic::new(
+                    DiagCode::Irule6001,
+                    fix_span,
+                    format!(
+                        "Global namespace variable '{var_name}' forces CMP compatibility \
                      mode, pinning the virtual server to a single TMM. \
                      Use '{static_name}' instead."
-                ),
-                severity: Severity::Warning,
-                fixes: vec![CodeFix {
+                    ),
+                    Severity::Warning,
+                )
+                .with_fixes(vec![CodeFix {
                     span: fix_span,
                     new_text: static_name.clone(),
                     description: format!("Replace '{var_name}' with '{static_name}'"),
-                }],
-            });
+                }]),
+            );
             return;
         }
 
@@ -753,22 +736,24 @@ impl Analyser {
             let fix_span = var_write_index(cmd_name)
                 .and_then(|idx| arg_tokens.get(idx))
                 .map_or(cmd_tok.span, |t| t.span);
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::Irule6001,
-                span: fix_span,
-                message: format!(
-                    "'{bare}' in RULE_INIT is implicitly global — RULE_INIT \
+            self.result.diagnostics.push(
+                Diagnostic::new(
+                    DiagCode::Irule6001,
+                    fix_span,
+                    format!(
+                        "'{bare}' in RULE_INIT is implicitly global — RULE_INIT \
                      runs at the global namespace scope. This forces CMP \
                      compatibility mode, pinning the virtual server to a \
                      single TMM. Use '{static_name}' instead."
-                ),
-                severity: Severity::Warning,
-                fixes: vec![CodeFix {
+                    ),
+                    Severity::Warning,
+                )
+                .with_fixes(vec![CodeFix {
                     span: fix_span,
                     new_text: static_name.clone(),
                     description: format!("Replace '{bare}' with '{static_name}'"),
-                }],
-            });
+                }]),
+            );
         }
     }
 }

--- a/rust/tcl-compiler/src/analyser/recovery.rs
+++ b/rust/tcl-compiler/src/analyser/recovery.rs
@@ -366,17 +366,19 @@ impl Analyser {
             // would shift the insertion one byte past the
             // intended location.
             let insert_span = tcl_lexer::Span::new(diag_span.end(), diag_span.end());
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::E101,
-                span: diag_span,
-                message: "Missing '{' after switch — body cases follow without braces".to_string(),
-                severity: super::types::Severity::Error,
-                fixes: vec![super::types::CodeFix {
+            self.result.diagnostics.push(
+                super::types::Diagnostic::new(
+                    DiagCode::E101,
+                    diag_span,
+                    "Missing '{' after switch — body cases follow without braces".to_string(),
+                    super::types::Severity::Error,
+                )
+                .with_fixes(vec![super::types::CodeFix {
                     span: insert_span,
                     new_text: " {".to_string(),
                     description: "Insert missing '{'".to_string(),
-                }],
-            });
+                }]),
+            );
         }
 
         case_count
@@ -504,17 +506,19 @@ impl Analyser {
         let insert_span = tcl_lexer::Span::new(abs_insert, abs_insert);
 
         if !self.disabled_diagnostics.contains("E103") {
-            self.result.diagnostics.push(super::types::Diagnostic {
-                code: DiagCode::E103,
-                span: stolen_span,
-                message: "Missing '}' — a nested body consumed this closing brace".to_string(),
-                severity: super::types::Severity::Error,
-                fixes: vec![super::types::CodeFix {
+            self.result.diagnostics.push(
+                super::types::Diagnostic::new(
+                    DiagCode::E103,
+                    stolen_span,
+                    "Missing '}' — a nested body consumed this closing brace".to_string(),
+                    super::types::Severity::Error,
+                )
+                .with_fixes(vec![super::types::CodeFix {
                     span: insert_span,
                     new_text: format!("{indent}}}\n"),
                     description: "Insert missing '}'".to_string(),
-                }],
-            });
+                }]),
+            );
         }
         true
     }
@@ -556,13 +560,12 @@ impl Analyser {
         // matching the E201/E202/E203 convention, so the squiggle sits on
         // the actual problem instead of underlining unrelated source.
         let anchor = last_delim_tok.map_or(cmd.span.start(), |t| t.span.start());
-        self.result.diagnostics.push(super::types::Diagnostic {
-            code: DiagCode::E200,
-            span: Span::new(anchor, anchor),
-            message: suffix.to_string(),
-            severity: super::types::Severity::Error,
-            fixes: Vec::new(),
-        });
+        self.result.diagnostics.push(super::types::Diagnostic::new(
+            DiagCode::E200,
+            Span::new(anchor, anchor),
+            suffix.to_string(),
+            super::types::Severity::Error,
+        ));
     }
 
     /// Constant-folded view of [`Self::builtin_command_names`].

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -830,13 +830,12 @@ impl Analyser {
                 use std::fmt::Write as _;
                 let _ = write!(message, "; did you mean '{best}'?");
             }
-            self.result.diagnostics.push(Diagnostic {
-                code: DiagCode::W215,
-                span: site_span,
+            self.result.diagnostics.push(Diagnostic::new(
+                DiagCode::W215,
+                site_span,
                 message,
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+                Severity::Warning,
+            ));
         }
 
         if let Some(elem) = element {
@@ -846,17 +845,16 @@ impl Analyser {
                 Cow::Borrowed(elem)
             };
             if runtime_element.contains(')') {
-                self.result.diagnostics.push(Diagnostic {
-                    code: DiagCode::W215,
-                    span: site_span,
-                    message: "array element index contains ')'; the element can be created \
+                self.result.diagnostics.push(Diagnostic::new(
+                    DiagCode::W215,
+                    site_span,
+                    "array element index contains ')'; the element can be created \
                               and read via ``set arr(idx) ...`` / ``[set \"arr(idx)\"]``, but \
                               is not reachable via $-substitution (``$arr(idx)`` reads up \
                               to the first ``)`` and stops there)"
                         .to_string(),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                    Severity::Warning,
+                ));
             }
         }
     }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -976,13 +976,12 @@ impl Analyser {
                 // Any unexpected lexer warning → catch-all E200.
                 _ => DiagCode::E200,
             };
-            self.result.diagnostics.push(super::types::Diagnostic {
+            self.result.diagnostics.push(super::types::Diagnostic::new(
                 code,
-                span: Span::new(w.offset, w.offset),
-                message: w.message,
-                severity: super::types::Severity::Error,
-                fixes: Vec::new(),
-            });
+                Span::new(w.offset, w.offset),
+                w.message,
+                super::types::Severity::Error,
+            ));
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/syntax_checks.rs
+++ b/rust/tcl-compiler/src/analyser/syntax_checks.rs
@@ -143,13 +143,12 @@ fn detect_e201<S: std::hash::BuildHasher>(
         return d;
     }
     // Fallback: highlight just the opening `[`, no fix.
-    Diagnostic {
-        code: DiagCode::E201,
-        span: Span::new(bracket_off, bracket_off),
-        message: "missing close-bracket".to_string(),
-        severity: Severity::Error,
-        fixes: Vec::new(),
-    }
+    Diagnostic::new(
+        DiagCode::E201,
+        Span::new(bracket_off, bracket_off),
+        "missing close-bracket".to_string(),
+        Severity::Error,
+    )
 }
 
 /// Build an E201 anchored from the `[` to `insert_idx`-in-content, with
@@ -163,17 +162,17 @@ fn e201_with_insert(
     let insert_off = content_start + u32::try_from(insert_idx).unwrap_or(0);
     // Diagnostic end: the last content byte before the insertion.
     let diag_end = content_start + u32::try_from(insert_idx.saturating_sub(1)).unwrap_or(0);
-    Diagnostic {
-        code: DiagCode::E201,
-        span: Span::new(bracket_off, diag_end.max(bracket_off)),
-        message: "missing close-bracket".to_string(),
-        severity: Severity::Error,
-        fixes: vec![CodeFix {
-            span: Span::new(insert_off, insert_off),
-            new_text: "]".to_string(),
-            description: fix_desc.to_string(),
-        }],
-    }
+    Diagnostic::new(
+        DiagCode::E201,
+        Span::new(bracket_off, diag_end.max(bracket_off)),
+        "missing close-bracket".to_string(),
+        Severity::Error,
+    )
+    .with_fixes(vec![CodeFix {
+        span: Span::new(insert_off, insert_off),
+        new_text: "]".to_string(),
+        description: fix_desc.to_string(),
+    }])
 }
 
 /// E201 heuristic: a `#` comment line follows — insert `]` at the end of
@@ -441,29 +440,28 @@ fn detect_e202<S: std::hash::BuildHasher>(
             if known.contains(extract_first_word(stripped)) {
                 // Virtual `"` right after the opening `"`.
                 let insert_off = quote_off + 1;
-                return Diagnostic {
-                    code: DiagCode::E202,
-                    span: diag_span,
-                    message: "missing \"".to_string(),
-                    severity: Severity::Error,
-                    fixes: vec![CodeFix {
-                        span: Span::new(insert_off, insert_off),
-                        new_text: "\"".to_string(),
-                        description: "Insert missing '\"' to close string".to_string(),
-                    }],
-                };
+                return Diagnostic::new(
+                    DiagCode::E202,
+                    diag_span,
+                    "missing \"".to_string(),
+                    Severity::Error,
+                )
+                .with_fixes(vec![CodeFix {
+                    span: Span::new(insert_off, insert_off),
+                    new_text: "\"".to_string(),
+                    description: "Insert missing '\"' to close string".to_string(),
+                }]);
             }
             // First non-blank line isn't a known command — stop.
             break;
         }
     }
-    Diagnostic {
-        code: DiagCode::E202,
-        span: diag_span,
-        message: "missing \"".to_string(),
-        severity: Severity::Error,
-        fixes: Vec::new(),
-    }
+    Diagnostic::new(
+        DiagCode::E202,
+        diag_span,
+        "missing \"".to_string(),
+        Severity::Error,
+    )
 }
 
 /// Build the E203 diagnostic for an unterminated `{`: the de-indented
@@ -491,21 +489,20 @@ fn detect_e203<S: std::hash::BuildHasher>(
     // known-command-name universe.
     let expr_role = registry.is_some_and(|reg| unterminated_arg_is_expr(tok, cmd, reg));
     if let Some(fix) = e203_brace_fix(tok, source, content_start, known, expr_role) {
-        return Diagnostic {
-            code: DiagCode::E203,
-            span: diag_span,
-            message: "missing close-brace".to_string(),
-            severity: Severity::Error,
-            fixes: vec![fix],
-        };
+        return Diagnostic::new(
+            DiagCode::E203,
+            diag_span,
+            "missing close-brace".to_string(),
+            Severity::Error,
+        )
+        .with_fixes(vec![fix]);
     }
-    Diagnostic {
-        code: DiagCode::E203,
-        span: diag_span,
-        message: "missing close-brace".to_string(),
-        severity: Severity::Error,
-        fixes: Vec::new(),
-    }
+    Diagnostic::new(
+        DiagCode::E203,
+        diag_span,
+        "missing close-brace".to_string(),
+        Severity::Error,
+    )
 }
 
 /// `true` when the unterminated brace-word token `tok` sits in an
@@ -807,13 +804,13 @@ fn make_e100(
         bracket_off
     };
 
-    Diagnostic {
-        code: DiagCode::E100,
-        span: Span::new(diag_start.min(bracket_off), bracket_end),
-        message: "Unmatched ']' \u{2014} missing opening '['?".to_string(),
-        severity: Severity::Error,
-        fixes,
-    }
+    Diagnostic::new(
+        DiagCode::E100,
+        Span::new(diag_start.min(bracket_off), bracket_end),
+        "Unmatched ']' \u{2014} missing opening '['?".to_string(),
+        Severity::Error,
+    )
+    .with_fixes(fixes)
 }
 
 /// Find where the missing `[` should go.  Heuristics, in order: a
@@ -887,13 +884,13 @@ fn make_e102(tok: &Token, rel: usize, source: &str) -> Diagnostic {
     let fixes = stray_brace_fix(tok, brace_off, source)
         .into_iter()
         .collect();
-    Diagnostic {
-        code: DiagCode::E102,
-        span: Span::new(brace_off, brace_off + 1),
-        message: "Unmatched '}' \u{2014} missing opening '{'?".to_string(),
-        severity: Severity::Error,
-        fixes,
-    }
+    Diagnostic::new(
+        DiagCode::E102,
+        Span::new(brace_off, brace_off + 1),
+        "Unmatched '}' \u{2014} missing opening '{'?".to_string(),
+        Severity::Error,
+    )
+    .with_fixes(fixes)
 }
 
 /// Build a fix that deletes a stray `}` and its line, when the line

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -165,15 +165,12 @@ impl Analyser {
             // always exists, so it is never flagged.
             let parent = parent_widget_path(path);
             if !parent.is_empty() && parent != "." && !self.tk_created_widgets.contains(parent) {
-                self.tk_pending_diags.push(Diagnostic {
-                    code: DiagCode::Tk1002,
-                    span: cmd_tok.span,
-                    message: format!(
-                        "Widget path '{path}' references non-existent parent '{parent}'."
-                    ),
-                    severity: Severity::Warning,
-                    fixes: Vec::new(),
-                });
+                self.tk_pending_diags.push(Diagnostic::new(
+                    DiagCode::Tk1002,
+                    cmd_tok.span,
+                    format!("Widget path '{path}' references non-existent parent '{parent}'."),
+                    Severity::Warning,
+                ));
             }
 
             // TK1003: unknown option for the widget command.
@@ -261,13 +258,9 @@ impl Analyser {
                     description: format!("Replace with '{best}'"),
                 });
             }
-            self.tk_pending_diags.push(Diagnostic {
-                code: DiagCode::Tk1003,
-                span,
-                message,
-                severity: Severity::Hint,
-                fixes,
-            });
+            self.tk_pending_diags.push(
+                Diagnostic::new(DiagCode::Tk1003, span, message, Severity::Hint).with_fixes(fixes),
+            );
         }
     }
 
@@ -298,16 +291,15 @@ impl Analyser {
         for (parent, usage) in geometry {
             if usage.managers.contains("pack") && usage.managers.contains("grid") {
                 for (_manager, span) in usage.sites {
-                    self.result.diagnostics.push(Diagnostic {
-                        code: DiagCode::Tk1001,
+                    self.result.diagnostics.push(Diagnostic::new(
+                        DiagCode::Tk1001,
                         span,
-                        message: format!(
+                        format!(
                             "Geometry manager conflict: cannot mix 'pack' and 'grid' \
                              in the same parent '{parent}'."
                         ),
-                        severity: Severity::Warning,
-                        fixes: Vec::new(),
-                    });
+                        Severity::Warning,
+                    ));
                 }
             }
         }

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -102,6 +102,36 @@ pub struct Diagnostic {
     pub fixes: Vec<CodeFix>,
 }
 
+impl Diagnostic {
+    /// A diagnostic anchored at `span` carrying `code`, `message`, and
+    /// `severity`, with no suggested fix — the common case. Chain
+    /// [`Self::with_fix`] / [`Self::with_fixes`] to attach quick-fixes.
+    #[must_use]
+    pub fn new(code: DiagCode, span: Span, message: impl Into<String>, severity: Severity) -> Self {
+        Self {
+            code,
+            span,
+            message: message.into(),
+            severity,
+            fixes: Vec::new(),
+        }
+    }
+
+    /// Attach one suggested [`CodeFix`], keeping any already present.
+    #[must_use]
+    pub fn with_fix(mut self, fix: CodeFix) -> Self {
+        self.fixes.push(fix);
+        self
+    }
+
+    /// Attach the suggested [`CodeFix`] list, replacing any already set.
+    #[must_use]
+    pub fn with_fixes(mut self, fixes: Vec<CodeFix>) -> Self {
+        self.fixes = fixes;
+        self
+    }
+}
+
 /// One same-file user-call arity candidate, buffered during the command
 /// walk for post-walk resolution against same-file procs / `TclOO`
 /// forwards / `interp alias` / static `rename` targets — the set the

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -58,50 +58,14 @@
 //! See the per-section notes below.
 
 use tcl_compiler::analyser::{Analyser, Severity};
-use tcl_compiler::compilation_unit::CompilationUnit;
-use tcl_compiler::compiler_checks::run_all_checks;
-use tcl_registry::registry_for_dialect;
 
 /// Default dialect for reproducers that are not dialect-sensitive.
 const D: &str = "tcl8.6";
 
-/// Every diagnostic code the full pipeline surfaces for `src` under `dialect`,
-/// mirroring the user-facing `tcl diag` path: the analyser pass plus the
-/// `run_all_checks` compiler-checks pass (shimmer / taint / dead-store), with
-/// optimisation codes excluded exactly as `diag` excludes them.
-///
-/// Copied verbatim from `src/analyser/diagnostics/fp/mod.rs::codes`.
-fn codes(src: &str, dialect: &str) -> Vec<String> {
-    let mut out: Vec<String> = Analyser::new()
-        .analyse(src, dialect)
-        .diagnostics
-        .iter()
-        .map(|d| d.code.to_string())
-        .collect();
-    let registry = registry_for_dialect(dialect);
-    let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
-    for d in run_all_checks(&cu, registry, dialect_opt) {
-        if d.code.is_optimisation() {
-            continue;
-        }
-        out.push(d.code.to_string());
-    }
-    out
-}
-
-/// True if `code` appears anywhere in the full diagnostic set for `src`.
-fn fires(src: &str, dialect: &str, code: &str) -> bool {
-    codes(src, dialect).iter().any(|c| c == code)
-}
-
-/// Count of how many times `code` appears in the merged diagnostic set.
-fn count(src: &str, dialect: &str, code: &str) -> usize {
-    codes(src, dialect)
-        .iter()
-        .filter(|c| c.as_str() == code)
-        .count()
-}
+// The merged-pipeline `codes` / `fires` / `count` helpers live in the shared
+// `common` module (previously copy-pasted across the analyser test files).
+mod common;
+use common::{codes, count, fires};
 
 /// Full `(code, message)` pairs from the *analyser pass only* — used when a
 /// test pins a message substring or message-scoped count (the analyser

--- a/rust/tcl-compiler/tests/checks.rs
+++ b/rust/tcl-compiler/tests/checks.rs
@@ -95,43 +95,10 @@ const D: &str = "tcl8.6";
 /// iRules dialect for the F5-specific checks.
 const IR: &str = "f5-irules";
 
-/// Every diagnostic code the full pipeline surfaces for `src` under `dialect`,
-/// mirroring the user-facing `tcl diag` path: the analyser pass plus the
-/// `run_all_checks` compiler-checks pass (shimmer / taint / dead-store), with
-/// optimisation codes excluded exactly as `diag` excludes them.
-///
-/// Copied verbatim from `analyser.rs` (← `src/analyser/diagnostics/fp/mod.rs::codes`).
-fn codes(src: &str, dialect: &str) -> Vec<String> {
-    let mut out: Vec<String> = Analyser::new()
-        .analyse(src, dialect)
-        .diagnostics
-        .iter()
-        .map(|d| d.code.to_string())
-        .collect();
-    let registry = registry_for_dialect(dialect);
-    let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
-    for d in run_all_checks(&cu, registry, dialect_opt) {
-        if d.code.is_optimisation() {
-            continue;
-        }
-        out.push(d.code.to_string());
-    }
-    out
-}
-
-/// True if `code` appears anywhere in the full diagnostic set for `src`.
-fn fires(src: &str, dialect: &str, code: &str) -> bool {
-    codes(src, dialect).iter().any(|c| c == code)
-}
-
-/// Count of how many times `code` appears in the merged diagnostic set.
-fn count(src: &str, dialect: &str, code: &str) -> usize {
-    codes(src, dialect)
-        .iter()
-        .filter(|c| c.as_str() == code)
-        .count()
-}
+// The merged-pipeline `codes` / `fires` / `count` helpers live in the shared
+// `common` module (previously copy-pasted across the analyser test files).
+mod common;
+use common::{codes, count, fires};
 
 /// Full `(code, message, severity, fix-new-texts)` tuples from the *analyser
 /// pass only* — used when a test pins a message substring, a severity,

--- a/rust/tcl-compiler/tests/common/mod.rs
+++ b/rust/tcl-compiler/tests/common/mod.rs
@@ -248,3 +248,43 @@ fn first_debug_diff<T: std::fmt::Debug>(got: &T, want: &T) -> String {
     }
     format!("len {} vs {}", g.len(), w.len())
 }
+
+use tcl_compiler::analyser::Analyser;
+use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_compiler::compiler_checks::run_all_checks;
+use tcl_registry::registry_for_dialect;
+
+/// The merged analyser + compiler-checks diagnostic codes for `src` under
+/// `dialect`, excluding optimisation-only findings — the canonical helper the
+/// `analyser` / `checks` / `fp` test files share (previously copy-pasted).
+pub fn codes(src: &str, dialect: &str) -> Vec<String> {
+    let mut out: Vec<String> = Analyser::new()
+        .analyse(src, dialect)
+        .diagnostics
+        .iter()
+        .map(|d| d.code.to_string())
+        .collect();
+    let registry = registry_for_dialect(dialect);
+    let cu = CompilationUnit::build_for(src, registry, false);
+    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
+    for d in run_all_checks(&cu, registry, dialect_opt) {
+        if d.code.is_optimisation() {
+            continue;
+        }
+        out.push(d.code.to_string());
+    }
+    out
+}
+
+/// True if diagnostic `code` appears in [`codes`] for `src` under `dialect`.
+pub fn fires(src: &str, dialect: &str, code: &str) -> bool {
+    codes(src, dialect).iter().any(|c| c == code)
+}
+
+/// How many times diagnostic `code` appears in [`codes`] for `src`/`dialect`.
+pub fn count(src: &str, dialect: &str, code: &str) -> usize {
+    codes(src, dialect)
+        .iter()
+        .filter(|c| c.as_str() == code)
+        .count()
+}

--- a/rust/tcl-compiler/tests/compiler_analysis_residual.rs
+++ b/rust/tcl-compiler/tests/compiler_analysis_residual.rs
@@ -63,7 +63,6 @@
 //! a deliberate sound over-approximation (it never fires a false W210); those
 //! cases assert the conservative `false` return and say so.
 
-use tcl_compiler::analyser::Analyser;
 use tcl_compiler::auto_path_eval::evaluate_auto_path_expr;
 use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
 use tcl_compiler::inlining::{
@@ -90,32 +89,10 @@ fn reg() -> CommandRegistry {
     CommandRegistry::build_default()
 }
 
-/// Every diagnostic code the analyser + `run_all_checks` surface for `src`
-/// (optimisation codes excluded) — the W210/W211/W220 surface used by the
-/// place-bridge and scan-predicate end-to-end proofs.
-fn codes(src: &str, dialect: &str) -> Vec<String> {
-    use tcl_compiler::compiler_checks::run_all_checks;
-    let mut out: Vec<String> = Analyser::new()
-        .analyse(src, dialect)
-        .diagnostics
-        .iter()
-        .map(|d| d.code.to_string())
-        .collect();
-    let registry = registry_for_dialect(dialect);
-    let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
-    for d in run_all_checks(&cu, registry, dialect_opt) {
-        if d.code.is_optimisation() {
-            continue;
-        }
-        out.push(d.code.to_string());
-    }
-    out
-}
-
-fn fires(src: &str, dialect: &str, code: &str) -> bool {
-    codes(src, dialect).iter().any(|c| c == code)
-}
+// The merged-pipeline `codes` / `fires` helpers live in the shared `common`
+// module (previously copy-pasted across the analyser test files).
+mod common;
+use common::{codes, fires};
 
 /// `O107` (unreachable dead code) is an optimiser-pass suggestion, not an
 /// analyser/`run_all_checks` diagnostic — union the optimiser output to test

--- a/rust/tcl-compiler/tests/fp_depth.rs
+++ b/rust/tcl-compiler/tests/fp_depth.rs
@@ -76,33 +76,10 @@ const D: &str = "tcl8.6";
 /// iRules dialect for the T102 path-prefixed taint cases.
 const IRULES: &str = "f5-irules";
 
-/// Every diagnostic code the user-facing `tcl diag` path surfaces for `src`:
-/// the analyser pass plus `run_all_checks` (shimmer / taint / dead-store),
-/// with optimisation codes excluded. Copied verbatim from
-/// `src/analyser/diagnostics/fp/mod.rs::codes`.
-fn codes(src: &str, dialect: &str) -> Vec<String> {
-    let mut out: Vec<String> = Analyser::new()
-        .analyse(src, dialect)
-        .diagnostics
-        .iter()
-        .map(|d| d.code.to_string())
-        .collect();
-    let registry = registry_for_dialect(dialect);
-    let cu = CompilationUnit::build_for(src, registry, false);
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
-    for d in run_all_checks(&cu, registry, dialect_opt) {
-        if d.code.is_optimisation() {
-            continue;
-        }
-        out.push(d.code.to_string());
-    }
-    out
-}
-
-/// True if `code` appears anywhere in the `tcl diag` surface for `src`.
-fn fires(src: &str, dialect: &str, code: &str) -> bool {
-    codes(src, dialect).iter().any(|c| c == code)
-}
+// The merged-pipeline `codes` / `fires` helpers live in the shared `common`
+// module (previously copy-pasted across the analyser test files).
+mod common;
+use common::{codes, fires};
 
 /// Full diagnostic codes INCLUDING the optimiser's suggestions — needed for
 /// O107 (unreachable dead code), which the optimiser emits, not the analyser.

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1716,25 +1716,17 @@ fn insert_regex_overrides(
     head: &str,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
-    if !registry
-        .get(head)
-        .and_then(|s| s.pattern_type)
-        .is_some_and(|p| p == tcl_registry::patterns::PatternType::Regex)
-    {
+    let Some(spec) = registry.get(head) else {
+        return;
+    };
+    if spec.pattern_type != Some(tcl_registry::patterns::PatternType::Regex) {
         return;
     }
     let args = &seg.texts[1..];
-    let mut idx = 0;
-    while idx < args.len() && args[idx].starts_with('-') && args[idx] != "--" {
-        if args[idx] == "-start" && idx + 1 < args.len() {
-            idx += 2;
-        } else {
-            idx += 1;
-        }
-    }
-    if idx < args.len() && args[idx] == "--" {
-        idx += 1;
-    }
+    // Skip the command's leading switches (`-start` consumes a value; `--`
+    // terminates) via the shared, arity-aware scanner keyed on the registry's
+    // own option table — no re-hardcoded `-start`.
+    let idx = tcl_registry::first_positional_index(spec.options, args, 0);
     // `args[idx]` is the pattern; its whole-word span is `seg.argv[idx + 1]`
     // (argv[0] is the command head).  Sub-tokenise only the *literal*
     // fragments of the word as regex: in `"abc$var.*"` the `abc` / `.*`

--- a/rust/tcl-lsp-server/tests/e2e/bigip.rs
+++ b/rust/tcl-lsp-server/tests/e2e/bigip.rs
@@ -34,8 +34,8 @@
 //! basename (`bigip.conf`), so `bigip_uri` fixes the basename while making the
 //! directory unique per call.
 
-use crate::common::Lsp;
 use crate::common::helpers::*;
+use crate::common::{Lsp, codes};
 
 use serde_json::Value;
 use std::collections::BTreeSet;
@@ -80,18 +80,6 @@ ltm rule /Common/r {
     }
 }
 ";
-
-/// The set of `code` strings on a diagnostics array (mirrors `_codes`).
-fn codes(diags: &[Value]) -> BTreeSet<String> {
-    diags
-        .iter()
-        .map(|d| match d.get("code") {
-            Some(Value::String(s)) => s.clone(),
-            Some(other) => other.to_string(),
-            None => "None".to_owned(),
-        })
-        .collect()
-}
 
 /// The symbol `name`s from a (possibly hierarchical) document-symbol result.
 fn symbol_name_list(result: &Value) -> Vec<Option<String>> {

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -1155,6 +1155,20 @@ fn auto_reply(msg: &Value, shared: &Arc<Shared>) {
     let _ = stdin.flush();
 }
 
+/// The set of diagnostic `code` values in an LSP `publishDiagnostics` payload —
+/// the canonical helper the diagnostics-oriented e2e tests share (previously
+/// copy-pasted per file).
+pub fn codes(diags: &[Value]) -> std::collections::BTreeSet<String> {
+    diags
+        .iter()
+        .map(|d| match d.get("code") {
+            Some(Value::String(s)) => s.clone(),
+            Some(other) => other.to_string(),
+            None => "None".to_owned(),
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests {
     use super::{BARRIER_TIMEOUT_MARKER, latency_barrier_timeout_note};

--- a/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
@@ -28,10 +28,9 @@
 //! parametrise the same way, so each matrix row is unrolled into its own
 //! `#[test]` for the fire case and the silent case.
 
-use crate::common::{Lsp, unique_uri};
+use crate::common::{Lsp, codes, unique_uri};
 
 use serde_json::Value;
-use std::collections::BTreeSet;
 
 /// One matrix row: a code with a source that MUST raise it and the corrected
 /// source that MUST NOT.
@@ -154,18 +153,6 @@ const MATRIX: &[Case] = &[
         note: "typo'd widget option; `package require Tk` enables the Tk overlay in a plain .tcl buffer",
     },
 ];
-
-/// The set of `code` strings carried by `diags` (mirrors Python `_codes`).
-fn codes(diags: &[Value]) -> BTreeSet<String> {
-    diags
-        .iter()
-        .map(|d| match d.get("code") {
-            Some(Value::String(s)) => s.clone(),
-            Some(other) => other.to_string(),
-            None => "None".to_owned(),
-        })
-        .collect()
-}
 
 /// A diagnostic's `code`, stringified.
 fn code_str(d: &Value) -> String {

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -22,23 +22,11 @@
 //! advertises no pull provider, so these assert on the `publishDiagnostics` the
 //! server pushes after analysis, keyed by version.
 
-use crate::common::{Lsp, unique_uri};
+use crate::common::{Lsp, codes, unique_uri};
 
 use serde_json::Value;
 use std::collections::BTreeSet;
 use std::time::Duration;
-
-/// The set of `code` strings carried by `diags` (mirrors Python `_codes`).
-fn codes(diags: &[Value]) -> BTreeSet<String> {
-    diags
-        .iter()
-        .map(|d| match d.get("code") {
-            Some(Value::String(s)) => s.clone(),
-            Some(other) => other.to_string(),
-            None => "None".to_owned(),
-        })
-        .collect()
-}
 
 /// Whether any diagnostic carries `code`.
 fn has_code(diags: &[Value], code: &str) -> bool {

--- a/rust/tcl-lsp-server/tests/e2e/edit_tracking_stress.rs
+++ b/rust/tcl-lsp-server/tests/e2e/edit_tracking_stress.rs
@@ -41,6 +41,7 @@
 //! not load-bearing — a deterministic, hostile mix of
 //! insert/delete/replace/newline/astral edits is.
 
+use crate::common::codes;
 use crate::common::helpers::*;
 use crate::common::{Lsp, Rng, unique_uri};
 
@@ -413,18 +414,6 @@ fn toks(tokens: &[SemToken]) -> Vec<(i64, i64, i64, i64, i64)> {
     tokens
         .iter()
         .map(|t| (t.line, t.char, t.length, t.ttype, t.modifiers))
-        .collect()
-}
-
-/// The set of diagnostic `code` strings.
-fn codes(diags: &[Value]) -> std::collections::BTreeSet<String> {
-    diags
-        .iter()
-        .map(|d| match d.get("code") {
-            Some(Value::String(s)) => s.clone(),
-            Some(other) => other.to_string(),
-            None => "None".to_owned(),
-        })
         .collect()
 }
 

--- a/rust/tcl-lsp-server/tests/e2e/tcl91.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcl91.rs
@@ -22,6 +22,7 @@
 //! dialect is pinned with a `# tcl-dialect: tcl9.1` directive (server-side source
 //! detection), and behaviour is observed through completion + diagnostics.
 
+use crate::common::codes;
 use crate::common::helpers::*;
 use crate::common::{Lsp, unique_uri};
 
@@ -32,18 +33,6 @@ use std::collections::BTreeSet;
 /// The set of completion labels from a completion result.
 fn labels(result: &Value) -> BTreeSet<String> {
     completion_labels(result).into_iter().collect()
-}
-
-/// The set of `code` strings carried by `diags`.
-fn codes(diags: &[Value]) -> BTreeSet<String> {
-    diags
-        .iter()
-        .map(|d| match d.get("code") {
-            Some(Value::String(s)) => s.clone(),
-            Some(other) => other.to_string(),
-            None => "None".to_owned(),
-        })
-        .collect()
 }
 
 /// Open a buffer pinned to `dialect` and complete a command-position word.

--- a/rust/tcl-registry/src/commands/tcl/fconfigure_.rs
+++ b/rust/tcl-registry/src/commands/tcl/fconfigure_.rs
@@ -100,6 +100,14 @@ const OPTIONS: &[OptionSpec] = &[
         aliases: &[],
         min_version: None,
     },
+    OptionSpec {
+        name: "-profile",
+        value: OptionValue::value("profile"),
+        detail: "Encoding error profile: strict/tcl8/replace (Tcl 9.0+).",
+        dialects: Some(DialectSet::TCL90_PLUS),
+        aliases: &[],
+        min_version: None,
+    },
 ];
 
 pub fn spec() -> CommandSpec {

--- a/rust/tcl-registry/src/commands/tcl/regexp_.rs
+++ b/rust/tcl-registry/src/commands/tcl/regexp_.rs
@@ -32,22 +32,10 @@ const FORMS: &[FormSpec] = &[FormSpec {
 /// `VarWrite` for every trailing capture var dynamically (the leading-option
 /// shift means a static slot list cannot place them).
 fn regexp_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
-    let mut i = 0;
-    while i < args.len() {
-        let a = args[i];
-        if a == "--" {
-            i += 1;
-            break;
-        }
-        if a.starts_with('-') {
-            i += 1;
-            if a == "-start" && i < args.len() {
-                i += 1;
-            }
-            continue;
-        }
-        break;
-    }
+    // Leading switches (`-start` consumes a value; `--` terminates) are skipped
+    // via the shared, arity-aware scanner driven by `REGEXP_OPTIONS`, so the
+    // value-taking set lives in exactly one place.
+    let i = first_positional_index(REGEXP_OPTIONS, args, 0);
     let capture_start = i + 2; // skip pattern + string
     (capture_start..args.len())
         .filter_map(|j| u8::try_from(j).ok().map(|j| (j, ArgRole::VarWrite)))

--- a/rust/tcl-registry/src/commands/tcl/regsub_.rs
+++ b/rust/tcl-registry/src/commands/tcl/regsub_.rs
@@ -33,22 +33,9 @@ const FORMS: &[FormSpec] = &[FormSpec {
 /// static slot cannot place it).  Omitting `varName` (Tcl 8.7+/9 returns the
 /// substituted string instead) simply yields no `VarWrite` index.
 fn regsub_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
-    let mut i = 0;
-    while i < args.len() {
-        let a = args[i];
-        if a == "--" {
-            i += 1;
-            break;
-        }
-        if a.starts_with('-') {
-            i += 1;
-            if a == "-start" && i < args.len() {
-                i += 1;
-            }
-            continue;
-        }
-        break;
-    }
+    // Leading switches (`-start` consumes a value; `--` terminates) are skipped
+    // via the shared, arity-aware scanner driven by `OPTIONS`.
+    let i = first_positional_index(OPTIONS, args, 0);
     // exp (i), string (i+1), subSpec (i+2), varName (i+3).
     let var_idx = i + 3;
     (var_idx < args.len())
@@ -73,19 +60,21 @@ fn regsub_command_prefixes(args: &[&str]) -> Vec<(u8, AppendedArity)> {
             i += 1;
             break;
         }
-        if a.starts_with('-') {
-            // `-command` and its unambiguous abbreviations (`-c`..`-comman`);
-            // no other regsub switch begins with `-c`.
-            if a.len() >= 2 && "-command".starts_with(a) {
-                has_command = true;
-            }
-            i += 1;
-            if a == "-start" && i < args.len() {
-                i += 1;
-            }
-            continue;
+        if !a.starts_with('-') {
+            break;
         }
-        break;
+        // `-command` and its unambiguous abbreviations (`-c`..`-comman`); no
+        // other regsub switch begins with `-c`. Checked on the *option* word
+        // before advancing, so a following value word is never misread.
+        if a.len() >= 2 && "-command".starts_with(a) {
+            has_command = true;
+        }
+        // Skip the switch and the value word(s) it consumes — arity sourced
+        // from the registry `OPTIONS` (no re-hardcoded `-start`).
+        i += 1 + OPTIONS
+            .iter()
+            .find(|o| o.matches(a))
+            .map_or(0, |o| o.value_word_count(args, i));
     }
     let sub_idx = i + 2;
     if has_command && sub_idx < args.len() {

--- a/rust/tcl-registry/src/commands/tcl/switch_.rs
+++ b/rust/tcl-registry/src/commands/tcl/switch_.rs
@@ -32,32 +32,76 @@ const FORMS: &[FormSpec] = &[FormSpec {
     synopsis: "switch ?options? string pattern body ?pattern body ...?",
 }];
 
-/// Options that consume a following value argument.
-const SWITCH_VALUE_OPTIONS: &[&str] = &["-matchvar", "-indexvar"];
+/// `switch` switches. `-matchvar`/`-indexvar` consume a following `varName`;
+/// the rest are boolean flags. Single source of truth for both `spec()` and
+/// [`switch_arg_roles`] — the value-arity lives here, not in a parallel list.
+const SWITCH_OPTIONS: &[OptionSpec] = &[
+    OptionSpec {
+        name: "-exact",
+        value: OptionValue::flag(),
+        detail: "Exact string compare mode.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-glob",
+        value: OptionValue::flag(),
+        detail: "Glob pattern mode.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-regexp",
+        value: OptionValue::flag(),
+        detail: "Regular expression mode.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-nocase",
+        value: OptionValue::flag(),
+        detail: "Case-insensitive matching.",
+        dialects: Some(DialectSet::TCL85_PLUS),
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-matchvar",
+        value: OptionValue::value("varName"),
+        detail: "Store match in variable (regexp mode).",
+        dialects: Some(DialectSet::TCL85_PLUS),
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "-indexvar",
+        value: OptionValue::value("varName"),
+        detail: "Store match indices in variable (regexp mode).",
+        dialects: Some(DialectSet::TCL85_PLUS),
+        aliases: &[],
+        min_version: None,
+    },
+    OptionSpec {
+        name: "--",
+        value: OptionValue::flag(),
+        detail: "End of options.",
+        dialects: None,
+        aliases: &[],
+        min_version: None,
+    },
+];
 
 /// Dynamic arg role resolver for `switch`.
 ///
 /// Skips option flags (including value-consuming options like
-/// `-matchvar`/`-indexvar`), then identifies pattern/body pairs
-/// or a single braced-list body.
+/// `-matchvar`/`-indexvar`, whose arity comes from [`SWITCH_OPTIONS`]), then
+/// identifies pattern/body pairs or a single braced-list body.
 fn switch_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
-    let mut i: usize = 0;
-    // Skip option flags.
-    while i < args.len() {
-        let a = args[i];
-        if a == "--" {
-            i += 1;
-            break;
-        }
-        if !a.starts_with('-') {
-            break;
-        }
-        if SWITCH_VALUE_OPTIONS.contains(&a) {
-            i += 2;
-        } else {
-            i += 1;
-        }
-    }
+    // Skip leading switches via the shared, arity-aware scanner.
+    let mut i = first_positional_index(SWITCH_OPTIONS, args, 0);
     // Skip switch value.
     if i < args.len() {
         i += 1;
@@ -105,66 +149,7 @@ pub fn spec() -> CommandSpec {
         arg_role_resolver: Some(switch_arg_roles),
         lowering_hook: Some(crate::hooks::LoweringHookId::Switch),
         return_type: Some(TclType::String),
-        options: const {
-            &[
-                OptionSpec {
-                    name: "-exact",
-                    value: OptionValue::flag(),
-                    detail: "Exact string compare mode.",
-                    dialects: None,
-                    aliases: &[],
-                    min_version: None,
-                },
-                OptionSpec {
-                    name: "-glob",
-                    value: OptionValue::flag(),
-                    detail: "Glob pattern mode.",
-                    dialects: None,
-                    aliases: &[],
-                    min_version: None,
-                },
-                OptionSpec {
-                    name: "-regexp",
-                    value: OptionValue::flag(),
-                    detail: "Regular expression mode.",
-                    dialects: None,
-                    aliases: &[],
-                    min_version: None,
-                },
-                OptionSpec {
-                    name: "-nocase",
-                    value: OptionValue::flag(),
-                    detail: "Case-insensitive matching.",
-                    dialects: Some(DialectSet::TCL85_PLUS),
-                    aliases: &[],
-                    min_version: None,
-                },
-                OptionSpec {
-                    name: "-matchvar",
-                    value: OptionValue::value("varName"),
-                    detail: "Store match in variable (regexp mode).",
-                    dialects: Some(DialectSet::TCL85_PLUS),
-                    aliases: &[],
-                    min_version: None,
-                },
-                OptionSpec {
-                    name: "-indexvar",
-                    value: OptionValue::value("varName"),
-                    detail: "Store match indices in variable (regexp mode).",
-                    dialects: Some(DialectSet::TCL85_PLUS),
-                    aliases: &[],
-                    min_version: None,
-                },
-                OptionSpec {
-                    name: "--",
-                    value: OptionValue::flag(),
-                    detail: "End of options.",
-                    dialects: None,
-                    aliases: &[],
-                    min_version: None,
-                },
-            ]
-        },
+        options: SWITCH_OPTIONS,
         hover: Some(HoverSnippet {
             summary: "Pattern-based branching on a subject string.",
             synopsis: &[

--- a/rust/tcl-registry/src/hover.rs
+++ b/rust/tcl-registry/src/hover.rs
@@ -457,6 +457,50 @@ impl OptionSpec {
     }
 }
 
+/// Index of the first positional argument in `args`, scanning from `scan_start`.
+///
+/// Skips the leading option words of a command whose options are `options`:
+///
+/// * a `--` terminator is consumed and scanning stops (the next word is the
+///   first positional);
+/// * a recognised option (canonical name or alias, via [`OptionSpec::matches`])
+///   is skipped along with the value word(s) it consumes at that position —
+///   arity-aware via [`OptionSpec::value_word_count`], so a value that itself
+///   looks like a flag (`-start -3`) is not re-scanned;
+/// * an unrecognised `-word` is treated as a value-less flag (skip one word),
+///   matching the leading-option-skip convention shared by the analyser and
+///   semantic-token loops;
+/// * the first word that does not start with `-` ends the scan.
+///
+/// This is the single source of the "where do a command's leading options end"
+/// logic — every `arg_role_resolver` and pattern-position loop routes through
+/// it rather than re-hardcoding which options take a value. Returns `args.len()`
+/// when every word is an option (no positional present).
+#[must_use]
+pub fn first_positional_index<S: AsRef<str>>(
+    options: &[OptionSpec],
+    args: &[S],
+    scan_start: usize,
+) -> usize {
+    let mut i = scan_start;
+    while i < args.len() {
+        let word = args[i].as_ref();
+        if !word.starts_with('-') {
+            break;
+        }
+        if word == "--" {
+            i += 1;
+            break;
+        }
+        let value_words = options
+            .iter()
+            .find(|o| o.matches(word))
+            .map_or(0, |o| o.value_word_count(args, i));
+        i += 1 + value_words;
+    }
+    i
+}
+
 /// Completion / hover metadata for a single enumerable
 /// positional-argument value.
 ///
@@ -549,5 +593,76 @@ mod tests {
             min_version: None,
         };
         assert!(opt.supports_dialect(None, Some(DialectSet::TCL90)));
+    }
+
+    /// A `regexp`/`regsub`-shaped option table: `-start` takes an index value,
+    /// the rest are boolean flags, and `--` terminates.
+    const REGEXP_LIKE: &[OptionSpec] = &[
+        OptionSpec {
+            name: "-nocase",
+            ..OptionSpec::DEFAULT
+        },
+        OptionSpec {
+            name: "-all",
+            ..OptionSpec::DEFAULT
+        },
+        OptionSpec {
+            name: "-start",
+            value: OptionValue::value("index"),
+            ..OptionSpec::DEFAULT
+        },
+        OptionSpec {
+            name: "--",
+            ..OptionSpec::DEFAULT
+        },
+    ];
+
+    #[test]
+    fn first_positional_index_skips_flags_and_value_words() {
+        // No options → arg 0 is the first positional.
+        assert_eq!(first_positional_index(REGEXP_LIKE, &["exp", "str"], 0), 0);
+        // Boolean flags skip one word each.
+        assert_eq!(
+            first_positional_index(REGEXP_LIKE, &["-nocase", "-all", "exp", "str"], 0),
+            2
+        );
+        // `-start` consumes its value word — the value is *not* counted as the
+        // pattern (the ISSUE_022 regression: name-only skips got this wrong).
+        assert_eq!(
+            first_positional_index(REGEXP_LIKE, &["-start", "3", "exp", "str"], 0),
+            2
+        );
+        // Mixed flags plus a value-taking option.
+        assert_eq!(
+            first_positional_index(REGEXP_LIKE, &["-nocase", "-start", "3", "exp"], 0),
+            3
+        );
+    }
+
+    #[test]
+    fn first_positional_index_handles_terminator_and_edges() {
+        // `--` is consumed; the next word is the first positional even if it
+        // looks like a flag.
+        assert_eq!(
+            first_positional_index(REGEXP_LIKE, &["-nocase", "--", "-weird", "str"], 0),
+            2
+        );
+        // A `-start`-looking value after `--` is a positional, not an option.
+        assert_eq!(first_positional_index(REGEXP_LIKE, &["--", "-start"], 0), 1);
+        // Unrecognised `-word` is treated as a value-less flag.
+        assert_eq!(
+            first_positional_index(REGEXP_LIKE, &["-mystery", "exp"], 0),
+            1
+        );
+        // Every word an option → returns the length (no positional).
+        assert_eq!(
+            first_positional_index(REGEXP_LIKE, &["-nocase", "-all"], 0),
+            2
+        );
+        // `scan_start` skips a leading subcommand word.
+        assert_eq!(
+            first_positional_index(REGEXP_LIKE, &["sub", "-nocase", "exp"], 1),
+            2
+        );
     }
 }

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -108,7 +108,8 @@ pub mod prelude {
         VersionedConstFoldFn, WasmCodegenHookId,
     };
     pub use crate::hover::{
-        ArgValue, FormKind, FormSpec, HoverSnippet, OptionArg, OptionArity, OptionSpec, OptionValue,
+        ArgValue, FormKind, FormSpec, HoverSnippet, OptionArg, OptionArity, OptionSpec,
+        OptionValue, first_positional_index,
     };
     pub use crate::patterns::{FormatType, PatternType};
     pub use crate::scoped::{ScopedCommand, ScopedCommandEnv};
@@ -136,7 +137,7 @@ pub use dialects::{
     DETECT_SCAN_BYTES, KNOWN_DIALECTS, available_dialects, detect_dialect,
     detect_dialect_directive, detect_dialect_from_source, dialect_from_extension,
 };
-pub use hover::ArgValue;
+pub use hover::{ArgValue, first_positional_index};
 pub use patterns::{FormatType, PatternType};
 pub use registry::{CommandRegistry, ResolvedCall, ResolvedTerminator};
 pub use spec::{

--- a/rust/tcl-vm/src/cmd_list.rs
+++ b/rust/tcl-vm/src/cmd_list.rs
@@ -273,9 +273,7 @@ fn lpop_remove(
     let (first, rest) = indices.split_first().expect("lpop has at least one index");
     let spec = first.to_str();
     let Some(idx) = crate::command::resolve_index(&spec, items.len()) else {
-        return Err(err(format!(
-            "bad index \"{spec}\": must be integer?[+-]integer? or end?[+-]integer?"
-        )));
+        return Err(crate::command::bad_index(&spec));
     };
     if idx < 0 || usize::try_from(idx).is_ok_and(|i| i >= items.len()) {
         return Err(err(format!("index \"{spec}\" out of range")));

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -1015,6 +1015,14 @@ pub(crate) fn resolve_index(spec: &str, len: usize) -> Option<isize> {
     tcl_cmd_core::index::resolve_opt(spec, len).and_then(|i| isize::try_from(i).ok())
 }
 
+/// The canonical `bad index "<spec>": …` failure, sharing its wording with the
+/// [`tcl_cmd_core::index::bad_index`] single source so the VM's inline index
+/// opcodes and the `l*`/`string` commands can't drift from the message the
+/// index parser itself produces.
+pub(crate) fn bad_index(spec: &str) -> Completion<Value> {
+    err(tcl_cmd_core::index::bad_index(spec).into_message())
+}
+
 /// A formal parameter name must be a scalar: not an array element (`a(1)`) and
 /// not namespace-qualified (`a::b`). Scans left-to-right like C's `TclCreateProc`
 /// — the first `(` with a trailing `)` is an array element, the first `::` is a

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -481,11 +481,7 @@ fn imm_index_value(v: &Value, len: usize) -> isize {
 /// compiled path rejects `linsert a b` like the command does (linsert-2.2).
 fn checked_index_value(v: &Value, len: usize) -> Result<isize, Completion<Value>> {
     let s = v.to_str();
-    crate::command::resolve_index(&s, len).ok_or_else(|| {
-        err(format!(
-            "bad index \"{s}\": must be integer?[+-]integer? or end?[+-]integer?"
-        ))
-    })
+    crate::command::resolve_index(&s, len).ok_or_else(|| crate::command::bad_index(&s))
 }
 
 /// List element at signed index, or empty when out of range.
@@ -519,9 +515,7 @@ pub(crate) fn lset_descend(
     let len = elems.len();
     let spec_str = spec.to_str();
     let Some(idx) = crate::command::resolve_index(&spec_str, len) else {
-        return Err(err(format!(
-            "bad index \"{spec_str}\": must be integer?[+-]integer? or end?[+-]integer?"
-        )));
+        return Err(crate::command::bad_index(&spec_str));
     };
     if idx < 0 || usize::try_from(idx).unwrap_or(usize::MAX) > len {
         return Err(err(format!("index \"{spec_str}\" out of range")));
@@ -2482,11 +2476,7 @@ impl Vm {
                 let string = pop(f).to_str().to_string();
                 let chars: Vec<char> = string.chars().collect();
                 let len = chars.len();
-                let bad = |spec: &str| {
-                    err(format!(
-                        "bad index \"{spec}\": must be integer?[+-]integer? or end?[+-]integer?"
-                    ))
-                };
+                let bad = crate::command::bad_index;
                 let first_s = first.to_str();
                 let last_s = last.to_str();
                 let Some(from) = crate::command::resolve_index(&first_s, len) else {

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -43,17 +43,6 @@ use crate::value::Value;
 /// A deeper nesting is a catchable error, not a native stack overflow.
 pub(crate) const RECURSION_LIMIT: usize = 1000;
 
-/// Render a subcommand list as C's ensemble `must be …` clause — note the
-/// ensemble formatter puts a comma before `or` even for two items
-/// (`x1, or x2`), unlike `Tcl_GetIndexFromObj`.
-fn oxford_or(items: &[String]) -> String {
-    match items {
-        [] => String::new(),
-        [a] => a.clone(),
-        [head @ .., last] => format!("{}, or {last}", head.join(", ")),
-    }
-}
-
 /// Parse an `interp recursionlimit` integer the way C's `Tcl_GetIntFromObj`
 /// reports: a decimal that overflows `i64` is "too large to represent", a
 /// non-numeric value is "expected integer but got …".
@@ -83,7 +72,10 @@ fn resolve_limit_opt<'a>(arg: &str, opts: &'a [&'a str]) -> Result<&'a str, Stri
         _ if opts.contains(&arg) => Ok(opts[opts.iter().position(|o| *o == arg).unwrap()]),
         _ => Err(format!(
             "bad option \"{arg}\": must be {}",
-            oxford_or(&opts.iter().map(|o| (*o).to_string()).collect::<Vec<_>>())
+            tcl_cmd_core::error::join_or(
+                &opts.iter().map(|o| (*o).to_string()).collect::<Vec<_>>(),
+                true
+            )
         )),
     }
 }
@@ -1436,7 +1428,7 @@ impl Vm {
             }
             None => err(format!(
                 "unknown or ambiguous subcommand \"{sub}\": must be {}",
-                oxford_or(&subs)
+                tcl_cmd_core::error::join_or(&subs, true)
             )),
         }
     }

--- a/rust/xtask/src/audit_option_dialects.rs
+++ b/rust/xtask/src/audit_option_dialects.rs
@@ -904,4 +904,39 @@ mod tests {
         keys.dedup();
         assert_eq!(keys.len(), total, "probe table has duplicate keys");
     }
+
+    /// Drift guard: every probed `(command, subcommand, option)` must be a real
+    /// registry [`tcl_registry::hover::OptionSpec`]. This ties the audit's
+    /// option set to the registry single source of truth — a probe cannot name
+    /// an option the registry does not declare, and a renamed or removed option
+    /// fails here rather than silently producing a stale `supported_in`. The
+    /// audit runs every probe against every built Tcl version, so the existence
+    /// check is deliberately dialect-agnostic (`None`).
+    #[test]
+    fn probe_options_exist_in_registry() {
+        use tcl_registry::CommandRegistry;
+        let reg = CommandRegistry::build_default();
+        let missing: Vec<String> = PROBES
+            .iter()
+            .filter(|&&(cmd, sub, opt, _)| {
+                let Some(spec) = reg.get(cmd) else {
+                    return true;
+                };
+                match sub {
+                    None => spec.find_option(opt, None, None).is_none(),
+                    Some(s) => !spec.resolve_subcommand(s).is_some_and(|sc| {
+                        sc.option_specs(None, spec.dialects)
+                            .iter()
+                            .any(|o| o.matches(opt))
+                    }),
+                }
+            })
+            .map(|&(cmd, sub, opt, _)| label(cmd, sub, opt))
+            .collect();
+        assert!(
+            missing.is_empty(),
+            "probe options absent from the registry OptionSpec (the audit has \
+             drifted from the single source of truth): {missing:?}"
+        );
+    }
 }


### PR DESCRIPTION
## Summary

Rebased onto the latest `rust` (`33b87f5f`) and **scoped down to the DRY work
that is still additive** after the two upstream diagnostics deep-reviews
(#922/#929/#930) and the `OptionTable` centralisation. Behaviour-preserving;
net **−726 lines**.

Four commits:

- **`first_positional_index`** (`tcl-registry`) — one arity-aware
  "skip leading `-options` (each value-taking option consumes its value words
  via `OptionSpec::value_word_count`), stop at `--`" scanner, replacing the
  hand-rolled, `-start`-hardcoding copies in the registry arg-role resolvers
  (`regexp`/`regsub`/`switch`) and `tcl-lsp-core`'s `insert_regex_overrides`
  (which previously couldn't reach the compiler's `pub(crate)` skip). The switch
  option table is lifted to a named `const` and the redundant
  `SWITCH_VALUE_OPTIONS` parallel list dropped, so value-arity lives only in the
  `OptionSpec` table. *(All option declarations stay in the verbose
  `OptionSpec { … }` form — no constructor churn.)*
- **`Diagnostic` builder** (`tcl-compiler` analyser) —
  `Diagnostic::new(code, span, message, severity)` + `.with_fix()`/
  `.with_fixes()` replaces ~130 hand-written 5-field literals (with
  `fixes: Vec::new()` repeated as pure noise) across every analyser pass.
  Field values are identical; the analyser suites (which assert exact
  codes/spans) stay green.
- **Error/audit centralisation** — `tcl_cmd_core::error::join_or` unifies the
  VM's ensemble Oxford-comma joiner; the dialect audit is now sourced from the
  registry `OptionSpec` tables (`probe_options_exist_in_registry` ties audit ↔
  registry), which surfaced and fixed a real gap: **`fconfigure -profile`**
  (TIP 656 / Tcl 9.0) was missing from the registry.
- **Test-helper hoist** — the copy-pasted `codes`/`fires`/`count` (compiler) and
  `codes(diags)` (LSP e2e) helpers move into the existing shared `common`
  modules.

### Deliberately dropped vs the earlier revision

- **`OptionSpec` constructor conversion** — reverted; the registry stays verbose
  and explicit for contributors (maintainer preference).
- **VM `wrong_args` helper** — upstream already added the identical
  `err_wrong_args` (`interp.rs`); mine would duplicate it.
- **VM `unambiguous_prefix`** — superseded by upstream's new
  `tcl_cmd_core::prefix::OptionTable` (the canonical prefix matcher).

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

On the rebased branch (base `rust` @ `33b87f5f`), from `rust/`:

- `cargo test -p tcl-registry -p tcl-cmd-core -p tcl-vm -p tcl-compiler -p tcl-lsp-core -p tcl-lsp-server -p xtask` — **8,823 passed; 0 failed; 3 ignored** (83 suites). One pre-existing timing-flake, `rapid_edits_deliver_diagnostics_in_version_order_without_loss`, tripped its own `≥2 in-flight publishes` precondition under load (the same test binary is non-deterministic in isolation — passes some runs, fails others); my diff touches nothing in the delivery/debounce path (only `semantic_tokens.rs`), and the diagnostic it did publish was correct.
- `cargo clippy -p tcl-registry -p tcl-cmd-core -p tcl-vm -p tcl-compiler -p tcl-lsp-core -p tcl-lsp-server -p xtask --all-targets` (pedantic) — 0 warnings.
- `cargo fmt --all --check` — clean.
- `make xtask-check` (8 editor-catalog / DiagCode / Zed / grammar drift gates) — all "in sync"; `probe_options_exist_in_registry` (audit↔registry) — passes.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **No** — the `Diagnostic`
  builder is a byte-for-byte-preserving reflow of existing emission sites; the
  analyser suites that assert exact diagnostic codes/spans stay green.
- [ ] If yes, I updated at least one relevant KCS note. — n/a
- [ ] If I added a new compiler KCS note, I linked it from both READMEs. — n/a

🤖 Generated with [Claude Code](https://claude.com/claude-code)