### PR TITLE
Fix systemic test-ext flakiness: wait on signals that actually arrive

### DIFF
--- a/editors/vscode/src/test/closedFileRetention.test.ts
+++ b/editors/vscode/src/test/closedFileRetention.test.ts
@@ -20,7 +20,8 @@ import * as assert from "assert";
 import * as vscode from "vscode";
 import {
   getDocUri,
-  activate,
+  activateViaWorkbench,
+  documentClosed,
   waitForDiagnostics,
   waitForDeepDiagnostics,
   getServerLogSize,
@@ -40,7 +41,11 @@ suite("Closed-file diagnostics retention (#865)", () => {
   }
 
   test("problems survive closing the editor tab", async () => {
-    await activate(docUri);
+    // Must be opened through the workbench: an extension-initiated
+    // `openTextDocument` pins the text model for up to three minutes, and a
+    // pinned document never closes — so the close this test is about would
+    // never reach the server. See `activateViaWorkbench`.
+    await activateViaWorkbench(docUri);
     // The fixture's `set y 1` (assigned, never read) guarantees a W211, proving
     // the analyser ran while the file was open.
     const opened = await waitForDiagnostics(docUri, {
@@ -51,14 +56,21 @@ suite("Closed-file diagnostics retention (#865)", () => {
       `open file must surface W211: [${opened.map(codeOf)}]`,
     );
 
-    // Close every editor — VS Code sends textDocument/didClose. Capture the log
-    // offset first so we wait for the *close's* republish, not the open one.
+    // Close every editor. Subscribe to the document-close event *first*: closing
+    // the tab is what VS Code does synchronously, but disposing the document —
+    // the event vscode-languageclient turns into `textDocument/didClose` — is a
+    // separate, later step, and it is that step the server reacts to. Capture
+    // the log offset too, so the wait below matches the *close's* republish
+    // rather than the open's.
+    const closed = documentClosed(docUri);
     const sinceClose = getServerLogSize();
     await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    await closed;
 
     // The server re-analyses the on-disk file and republishes its diagnostics;
-    // wait for that republish's deep-diagnostics marker, then assert the W211 is
-    // still present rather than cleared.
+    // `did_close` emits an unconditional deep-diagnostics marker once that has
+    // been delivered, so waiting on it is exact rather than best-effort. Then
+    // assert the W211 is still present rather than cleared.
     await waitForDeepDiagnostics(docUri, { since: sinceClose });
     const retained = vscode.languages.getDiagnostics(docUri);
     assert.ok(

--- a/editors/vscode/src/test/configSettings.test.ts
+++ b/editors/vscode/src/test/configSettings.test.ts
@@ -1067,31 +1067,34 @@ suite("Configuration Settings", () => {
   // ── Optimiser enabled toggle behavioral test ─────────────────────
   test("disabling optimiser.enabled suppresses O1xx diagnostics", async () => {
     const docUri = getDocUri("diagnostics.tcl");
-    // Snapshot the server log index before activating so the
-    // ``waitForDeepDiagnostics`` calls below only match this test's
-    // deep-pass log lines, not stale ones from earlier tests.
-    const sinceOpen = getServerLogSize();
     await activate(docUri);
 
     const codeOf = (d: vscode.Diagnostic) =>
       String(typeof d.code === "object" ? d.code.value : d.code);
     const isO1xx = (code: string) => /^O1\d\d$/.test(code);
 
-    // Wait for the server to publish its ``[timing] deep diagnostics``
-    // log line for this URI — that's the direct signal that the deep
-    // pass (where O1xx hints come from) has finished and published.
-    await waitForDeepDiagnostics(docUri, { since: sinceOpen });
-    const before = vscode.languages.getDiagnostics(docUri);
-    const o1xxBefore = before.filter((d) => isO1xx(codeOf(d)));
-    // The re-trigger edit below appends to the live buffer and is never
-    // saved; snapshot the original text so it can be restored in `finally`
-    // regardless of whether the test body completes or throws, rather than
-    // leaving diagnostics.tcl's editor buffer permanently dirtied for every
-    // later test that reuses the same fixture.
+    // The buffer edits below are never saved; snapshot the original text so it
+    // can be restored in `finally` regardless of whether the test body
+    // completes or throws, rather than leaving diagnostics.tcl's editor buffer
+    // permanently dirtied for every later test that reuses the same fixture.
     const originalText = vscode.window.activeTextEditor!.document.getText();
 
     const config = vscode.workspace.getConfiguration("tclLsp.optimiser");
     try {
+      // Both O1xx snapshots are anchored on an *edit*, because an edit is the
+      // only action that is guaranteed to make the server re-analyse and emit a
+      // fresh ``[timing] deep diagnostics`` line.  `activate()` is not: nothing
+      // in this suite ever closes a document (VS Code keeps extension-opened
+      // documents alive long past their tab), so a fixture an earlier test
+      // already opened is still open, and re-showing it sends the server
+      // nothing at all — a wait anchored on it would only ever be satisfied by
+      // some unrelated background re-analysis happening to land inside the
+      // window, which is exactly the race that made this test flaky.
+      const sinceBaseline = getServerLogSize();
+      await setTestContent(vscode.window.activeTextEditor!, originalText + " ");
+      await waitForDeepDiagnostics(docUri, { since: sinceBaseline });
+      const o1xxBefore = vscode.languages.getDiagnostics(docUri).filter((d) => isO1xx(codeOf(d)));
+
       await config.update("enabled", false, undefined);
       // 20s, matching waitForDeepDiagnostics's default: under the full
       // suite's background load (workspace warm-up, the #844 progressive
@@ -1102,14 +1105,13 @@ suite("Configuration Settings", () => {
         timeout: 20000,
       });
 
-      // Re-trigger analysis with a noop edit; snapshot the log
-      // index so the follow-up wait only matches the post-edit run.
+      // Re-trigger analysis under the new setting with another noop edit —
+      // trailing whitespace only, so the two snapshots differ solely by the
+      // optimiser toggle.
       const sinceEdit = getServerLogSize();
-      const editor = vscode.window.activeTextEditor!;
-      await setTestContent(editor, editor.document.getText() + " ");
+      await setTestContent(vscode.window.activeTextEditor!, originalText + "  ");
       await waitForDeepDiagnostics(docUri, { since: sinceEdit });
-      const after = vscode.languages.getDiagnostics(docUri);
-      const o1xxAfter = after.filter((d) => isO1xx(codeOf(d)));
+      const o1xxAfter = vscode.languages.getDiagnostics(docUri).filter((d) => isO1xx(codeOf(d)));
 
       if (o1xxBefore.length > 0) {
         assert.strictEqual(

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -300,19 +300,25 @@ suite("Diagnostics", () => {
   test("clean file produces no diagnostics", async () => {
     const cleanUri = getDocUri("simple.tcl");
 
-    // Disable optimiser so info-level suggestions (O1xx) don't count.
+    // Disable optimiser so info-level suggestions (O1xx) don't count.  This
+    // must be written at the *workspace* target: the test fixture's
+    // `.vscode/settings.json` pins `tclLsp.optimiser.enabled` to `true`, and
+    // workspace settings outrank user (Global) ones — so a Global write could
+    // never take effect here, and the wait below could only ever succeed by
+    // accident, when an earlier test in the run had happened to delete the
+    // workspace key on its way out.  `index.ts` restores the fixture file's
+    // bytes after the run, as it does for the other config tests.
     const config = vscode.workspace.getConfiguration("tclLsp.optimiser");
-    await config.update("enabled", false, vscode.ConfigurationTarget.Global);
+    await config.update("enabled", false, vscode.ConfigurationTarget.Workspace);
 
     try {
       // Wait on the server's resolved config (message passing) rather than a
       // fixed sleep, so the optimiser.enabled=false round-trip is observed to
       // have applied before analysing.  Kept inside the `try` so a wait
-      // timeout still restores the global setting in `finally`.  20s,
-      // matching waitForDeepDiagnostics's default: under the full suite's
-      // background load (workspace warm-up, the #844 progressive
-      // diagnostics race, …) this round-trip routinely needs more than the
-      // 5s generic default.
+      // timeout still restores the setting in `finally`.  20s, matching
+      // waitForDeepDiagnostics's default: under the full suite's background
+      // load (workspace warm-up, the #844 progressive diagnostics race, …)
+      // this round-trip routinely needs more than the 5s generic default.
       await waitForEffectiveConfig(cleanUri, (cfg) => cfg.optimiser_enabled === false, {
         label: "optimiser.enabled = false",
         timeout: 20000,
@@ -332,7 +338,11 @@ suite("Diagnostics", () => {
         `Expected no diagnostics for simple.tcl, got ${diagnostics.length}: ${diagnostics.map((d) => d.code).join(", ")}`,
       );
     } finally {
-      await config.update("enabled", undefined, vscode.ConfigurationTarget.Global);
+      await config.update("enabled", undefined, vscode.ConfigurationTarget.Workspace);
+      await waitForEffectiveConfig(cleanUri, (cfg) => cfg.optimiser_enabled === true, {
+        label: "optimiser.enabled restored",
+        timeout: 20000,
+      });
     }
   });
 

--- a/editors/vscode/src/test/helper.ts
+++ b/editors/vscode/src/test/helper.ts
@@ -365,6 +365,80 @@ export async function activate(docUri: vscode.Uri): Promise<vscode.TextDocument>
 }
 
 /**
+ * Open *docUri* through the **workbench** (the ``vscode.open`` command) rather
+ * than ``workspace.openTextDocument``, then hand off to [`activate`].
+ *
+ * Use this — and only this — when a test needs the document to actually *close*
+ * later.  ``workspace.openTextDocument`` (which ``activate`` calls, and which
+ * ``window.showTextDocument(uri)`` calls internally) makes VS Code's main
+ * thread take a model reference on the extension host's behalf and park it in a
+ * ``BoundModelReferenceCollection``.  That collection releases a reference only
+ * after **three minutes**, or once 60 of them have piled up (it then drops the
+ * oldest ten), or on a delete/rename of the file — *never* when the editor tab
+ * closes.  While the reference is held the underlying text model cannot be
+ * disposed, so ``workspace.onDidCloseTextDocument`` does not fire, so
+ * vscode-languageclient never sends ``textDocument/didClose``: a test that
+ * closes the tab and waits for the server to react waits for something that
+ * (within any usable budget) never happens.
+ *
+ * Opening through the workbench takes no such reference — the editor is the
+ * model's only holder, exactly as when a user clicks the file in the Explorer.
+ * The subsequent ``openTextDocument`` inside ``activate`` then resolves against
+ * the already-registered document instead of asking the main thread to open
+ * (and pin) it, so the document is still unpinned when the tab closes.
+ */
+export async function activateViaWorkbench(docUri: vscode.Uri): Promise<vscode.TextDocument> {
+  await vscode.commands.executeCommand("vscode.open", docUri);
+  // The main thread registers the new model with the extension host over a
+  // separate channel from the command's own reply, so the document is not
+  // guaranteed to be visible here the instant `vscode.open` resolves.  Wait
+  // until it is: `activate`'s `openTextDocument` must find it already present,
+  // or it will fall back to the pinning path this function exists to avoid.
+  await pollUntil(
+    () => vscode.workspace.textDocuments.some((d) => d.uri.toString() === docUri.toString()),
+    (registered) => registered,
+    { label: `${docUri.toString()} registered with the extension host` },
+  );
+  return activate(docUri);
+}
+
+/**
+ * Resolve once VS Code closes the *document* for *docUri* — the event that
+ * drives vscode-languageclient's ``textDocument/didClose``.
+ *
+ * Closing an editor tab is **not** the same thing: the document survives its
+ * last editor whenever something still holds a reference to the underlying
+ * model (see [`activateViaWorkbench`]).  A test that closes tabs and expects
+ * the server to see a close must wait on this, not on the close command
+ * resolving — and must have opened the document via [`activateViaWorkbench`],
+ * or the wait will (correctly) time out.
+ *
+ * Register **before** issuing the close so the event cannot be missed.
+ */
+export function documentClosed(docUri: vscode.Uri, opts?: { timeout?: number }): Promise<void> {
+  const timeout = opts?.timeout ?? 20_000;
+  const uri = docUri.toString();
+  return new Promise<void>((resolve, reject) => {
+    const disposable = vscode.workspace.onDidCloseTextDocument((doc) => {
+      if (doc.uri.toString() !== uri) return;
+      disposable.dispose();
+      clearTimeout(timer);
+      resolve();
+    });
+    const timer = setTimeout(() => {
+      disposable.dispose();
+      reject(
+        new Error(
+          `Timeout waiting for onDidCloseTextDocument on ${uri} — the document is ` +
+            `still open despite its editor closing, so the server never received a ` +
+            `textDocument/didClose (was it opened with activateViaWorkbench?)`,
+        ),
+      );
+    }, timeout);
+  });
+}
+
+/**
  * Poll for diagnostics on the given URI until ``minCount`` are available
  * or ``predicate`` returns truthy, whichever comes first.  Combines event
  * listening with periodic polling for robustness.


### PR DESCRIPTION
`test-ext` (a required check) fails intermittently on `rust`, and the failing test varies by machine — `closedFileRetention` in CI (3/3 on 3440e648b), `configSettings` + `diagnostics` locally. It is blocking the v2.1.6 tag.

Three distinct bugs, all one family: **waits anchored on signals that were never guaranteed to arrive.** A previous fix raised `waitForDeepDiagnostics`'s timeout 5s → 20s; that treated the symptom, so this change deliberately contains no timeout bumps, sleeps, or skips.

### 1. VS Code never delivers `didClose` in this harness

An extension-initiated `workspace.openTextDocument` makes the main thread take a model reference and park it in a `BoundModelReferenceCollection`, which releases it only after **three minutes**, once 60 pile up, or on delete/rename — **never when the editor tab closes**. While it's held the text model can't be disposed, so `onDidCloseTextDocument` never fires and vscode-languageclient never sends `textDocument/didClose`.

Measured on the unmodified suite: `closeAllEditors` at **+0.66s**, `didClose` for `closedFileRetention.tcl` at **+54.4s**.

So the test waited for a marker its own close could not produce inside 20s. It passed locally only when an unrelated background reschedule happened to emit a matching marker; in CI that coin-flip loses (`logSize 16→16` — the server emitted nothing, because it correctly never saw a close). The assertion was also **vacuous**: the file never closed, so of course its diagnostics survived.

Adds `activateViaWorkbench` (opens via the `vscode.open` workbench command, which takes no such reference) and `documentClosed` (resolves on the real close event). The test now exercises #865 for the first time.

### 2. `waitForDeepDiagnostics` after `activate()` is unsound

Because nothing was ever closed, a fixture an earlier test opened was still open — so `activate()` merely re-shows it and sends the server nothing: no analysis, no marker. The wait was only ever satisfied by an unrelated background run landing inside the window. Both O1xx snapshots are now anchored on an **edit**, the only action guaranteed to make the server re-analyse and emit a fresh marker.

### 3. A config target that could never win

The clean-file test wrote `optimiser.enabled` at **Global**, but `testFixture/.vscode/settings.json` pins it at **Workspace**, which outranks Global — so the wait could never succeed on merit, only when the configSettings test happened to delete the workspace key on its way out (and when *that* test died early, this one was doomed). Now written at the Workspace target, with the restore awaited.

### Verification

- `make test-ext` × **4 consecutive clean runs**: 614 passing, 0 failing.
- The three tests now settle in **177ms / 297ms / 2.2s** instead of timing out at 20s (suite: ~1m → ~30s).
- `make lint` clean. No Rust touched, so no `rust-check` needed; no fixture drift.

Test-only change — no shipped code affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qa4XqiiwggvaAvBmmNZCJw