### PR TITLE
Fix JetBrains plugin binary incompatibility with IntelliJ 2026.1+

### DIFF
--- a/.claude/skills/jetbrains-plugin-compat/SKILL.md
+++ b/.claude/skills/jetbrains-plugin-compat/SKILL.md
@@ -1,0 +1,249 @@
+---
+name: jetbrains-plugin-compat
+description: >
+  Keep the JetBrains/IntelliJ plugin (editors/jetbrains) binary-compatible
+  across IDE versions. Use when the JetBrains plugin fails Marketplace
+  verification or the local IntelliJ Plugin Verifier, when a user reports a
+  NoSuchMethodError / NoSuchFieldError / "unresolved method …$default" from the
+  plugin, when a new IntelliJ major (e.g. 2026.1+) breaks the plugin, when the
+  LspServer/LspServerManager/LspServerDescriptor (or any platform) API is
+  deprecated or moved, or before/after publishing a plugin build. Covers
+  running the verifier, reading Marketplace verdicts via the REST API,
+  root-causing moved-API / Kotlin `$default` breakage by disassembling SDK
+  module jars, and the fix patterns that survive every supported IDE.
+allowed-tools: Bash, Read, Edit, Grep, Glob, WebFetch
+---
+
+# JetBrains plugin compatibility
+
+The plugin under `editors/jetbrains` is compiled **once** against the
+`sinceBuild` floor (IntelliJ IDEA Ultimate 2024.1) and must load in **every**
+IDE from that floor to the newest release, with an open `untilBuild`. Nothing
+recompiles per IDE — the *same* bytecode is linked against whatever platform
+the user is running. So a plugin breaks when the platform API it was linked
+against changes shape underneath it: a method is removed, renamed, retyped, or
+**moved to a super-interface**, or an API is deprecated then deleted.
+
+There are two verification surfaces. Keep both green:
+
+1. **Pre-publish, local** — the IntelliJ Plugin Verifier via Gradle, over the
+   IDE list in `build.gradle.kts` (`pluginVerification.ides`).
+   `make verify-editor-jetbrains`.
+2. **Post-publish, Marketplace** — JetBrains re-runs the verifier against a
+   wide matrix of released IDEs after every upload and shows the verdicts on
+   `…/edit/versions/{stable,eap}`. Read them over the REST API with
+   `marketplace_verify.sh`. This is the only surface that covers IDE builds
+   **newer than anything in our local `ides` list** — which is exactly how the
+   `LspServer.sendRequestSync$default` breakage first surfaced (a 2.1.x build
+   flagged CRITICAL on 2026.1/2026.2 that no local target covered).
+
+Helper scripts live next to this file:
+
+- `marketplace_verify.sh` — read/schedule the Marketplace verdicts (needs the
+  maintainer token; resolved via `scripts/release/jetbrains_token.sh`).
+- `inspect_sdk.sh` — disassemble any platform API class at any IDE version
+  **without** downloading a multi-GB IDE (fetches the small per-module jar from
+  the JetBrains intellij-repository and runs `javap`).
+
+## Verdict grammar
+
+The verifier assigns each (plugin, IDE) pair one verdict:
+
+- `OK` / `WARNINGS` — **compatible**. Warnings are informational only:
+  *deprecated API*, *experimental API*, *internal API* usages. These do **not**
+  fail the build (they are not in the verifier's default `failureLevel`) and
+  must **not** be "fixed" by ripping out API the plugin still needs on older
+  IDEs. Deprecation is a heads-up to plan migration, not an error.
+- `CRITICAL` / `PROBLEMS` / `INVALID_PLUGIN` — **hard failures**. These are
+  binary incompatibilities that throw at runtime (`NoSuchMethodError`,
+  `NoSuchFieldError`, `NoClassDefFoundError`, `IllegalAccessError`). This is
+  what you must drive to zero.
+
+A jump in *deprecated* count across a major (e.g. 7 → 38 at 2026.1, when the
+whole `LspServer*` family was superseded by `LspClient*`) is expected and
+harmless. Only the CRITICAL section matters for shipping.
+
+## Workflow A — read what the Marketplace found (fastest triage)
+
+Reading verification results needs the maintainer token (the same
+`JETBRAINS_TOKEN` used to publish; it carries `READ_VERIFICATION_RESULTS`).
+The helper resolves it and **never prints it**:
+
+```bash
+# Both channels' latest builds, exits non-zero if any CRITICAL:
+.claude/skills/jetbrains-plugin-compat/marketplace_verify.sh
+
+# One channel, with the exact problem messages from each failing build:
+.claude/skills/jetbrains-plugin-compat/marketplace_verify.sh results --channel eap --full
+.claude/skills/jetbrains-plugin-compat/marketplace_verify.sh results --channel stable --version 1.11.4 --full
+
+# After uploading a build, ask the Marketplace to verify a specific IDE build
+# (e.g. the newest EAP that isn't in our local ides list yet):
+.claude/skills/jetbrains-plugin-compat/marketplace_verify.sh products --channel eap   # list IDE builds
+.claude/skills/jetbrains-plugin-compat/marketplace_verify.sh schedule --channel eap --ide IU-262.8665.176
+```
+
+`--full` prints the offending call sites straight from the report, e.g.:
+
+```
+CRITICAL  IntelliJ IDEA  IU-262.8665.176   2 compatibility problems
+  ! Invocation of unresolved method com.intellij.platform.lsp.api.LspServer.sendRequestSync$default(...)
+  ! Method com.tcllsp.jetbrains.CompilerExplorerPanel.runCompile$lambda$0(...) contains an *invokestatic* …
+  ! Method com.tcllsp.jetbrains.actions.TclLspActionBase.runCommand(...) contains an *invokestatic* …
+```
+
+Under the hood (all on `https://plugins.jetbrains.com`, `Authorization: Bearer <token>`):
+
+| purpose | endpoint |
+|---|---|
+| plugin id ↔ xmlId | `GET /api/plugins/31801` (xmlId `com.tcllsp.jetbrains`) |
+| updates in a channel | `GET /api/plugins/31801/updates?channel={stable\|eap}&size=50` (public) |
+| **verdicts for a build** | `GET /api/verifications/update/{updateId}?verificationType=INTELLIJ_COMPATIBILITY` (auth) |
+| full report for one verdict | `GET {result.fullVerificationResultUrl}` (auth) |
+| IDE builds available to verify | `GET /api/verifications/update/{updateId}/products` (auth) |
+| schedule a verification | `POST /api/verifications/update/{updateId}?ideVersion=…&verificationType=INTELLIJ_COMPATIBILITY` (auth) |
+
+`verificationType` ∈ `INTELLIJ_COMPATIBILITY` (what we want), `RESHARPER_COMPATIBILITY`, `IDE_PERFORMANCE`, `SECURITY_TOOLING`.
+`resultType` (verdict) ∈ `OK`, `WARNINGS`, `PROBLEMS`, `CRITICAL`, `INVALID_PLUGIN`, `NON_DOWNLOADABLE`, `UNABLE_TO_VERIFY`.
+
+## Workflow B — the local pre-publish gate
+
+```bash
+make verify-editor-jetbrains          # -> ./gradlew verifyPlugin
+```
+
+Targets live in `editors/jetbrains/build.gradle.kts` under
+`pluginVerification.ides`. Keep the `sinceBuild` floor **and** the newest
+verified stable major in that list. **A >=2026.1 target is load-bearing**:
+2026.1 is where the `LspServer*` API was superseded and `sendRequestSync` moved
+to the `LspClient` super-interface — without it the local verifier cannot catch
+the whole `$default` / moved-API class of failure. First run downloads each
+IDE (multi-GB, cached under `~/.gradle`); the verifier itself is static
+bytecode analysis, it does not launch the IDE.
+
+## Workflow C — root-cause a hard failure
+
+Pattern to recognise: *"Invocation of unresolved method `X.foo$default(…)`"* or
+*"unresolved method/field `X.bar`"*, with a hint *"might have been declared in
+the super interface: Y"*. That means the symbol our bytecode names literally
+(`X.foo$default`, `X.bar`) no longer exists **at `X`** in the newer platform —
+usually because it moved, was renamed, retyped, or removed.
+
+Prove exactly what changed by disassembling the class at the floor build and at
+the failing build — no IDE download needed:
+
+```bash
+S=.claude/skills/jetbrains-plugin-compat/inspect_sdk.sh
+$S 241.14494.240 com.intellij.platform.lsp.api.LspServer          # what we compiled against
+$S 262.8665.176  com.intellij.platform.lsp.api.LspServer   -c     # the failing build (-c = show bytecode)
+$S 262.8665.176  com.intellij.platform.lsp.api.LspClient          # the suspected new home
+$S --list                                                          # list available `lsp` module versions
+$S 262.8665.176  some.other.Class  platform-impl                  # a different platform module
+```
+
+For the `sendRequestSync` case this shows, unambiguously:
+
+- **241** — `LspServer` declares `sendRequestSync(int, Function1)` **and** the
+  synthetic `sendRequestSync$default(LspServer, int, Function1, int, Object)`.
+- **262** — `LspServer extends LspClient` and declares **neither**; both moved
+  to `LspClient`. `LspServer.sendRequestSync(int, Function1)` still *resolves*
+  (an interface method is inherited from a super-interface), but the **static**
+  `LspServer.sendRequestSync$default` bridge does **not** (a static call must
+  resolve at the exact owner named in the bytecode).
+
+## The Kotlin `$default` trap (and the fix)
+
+When you call a Kotlin function that has a **default parameter** and you omit
+that parameter, the compiler does **not** emit a call to the real method. It
+emits `invokestatic Owner.method$default(...)` — a synthetic static bridge
+bound to *the class that declared the method when you compiled*. If that method
+later moves to a super-interface (or the owner otherwise changes), the
+`$default` bridge is gone from the old owner and you get a `NoSuchMethodError`
+even though the real method is still perfectly callable.
+
+**Fix: pass every defaulted argument explicitly.** That makes the compiler emit
+a direct `invokeinterface Owner.method(...)` (or `invokevirtual`), which
+resolves through super-interfaces and survives the move. Prefer supplying the
+platform's own compile-time-`const` default so behaviour is byte-identical and
+the constant *inlines* (no runtime reference to it either):
+
+```kotlin
+// BEFORE — emits invokestatic LspServer.sendRequestSync$default(...)  [breaks on 2026.1+]
+val result = server.sendRequestSync { lsp4j -> lsp4j.workspaceService.executeCommand(params) }
+
+// AFTER — emits invokeinterface LspServer.sendRequestSync(int, Function1)  [resolves everywhere];
+// DEFAULT_REQUEST_TIMEOUT_MS is `const` (10_000 ms) so it inlines to a literal.
+val result = server.sendRequestSync(LspServer.DEFAULT_REQUEST_TIMEOUT_MS) { lsp4j ->
+    lsp4j.workspaceService.executeCommand(params)
+}
+```
+
+Both call sites are `TclLspActionBase.runCommand` and
+`CompilerExplorerToolWindowFactory.runCompile`. Each carries a comment pointing
+back here — **do not "simplify" them back to the no-timeout form**, that
+reintroduces the `$default` bridge.
+
+## Fix catalogue for other breakage
+
+- **Moved to a super-interface (methods, `const` fields)** — usually resolves
+  with no change (interface/const resolution walks super-interfaces). Only the
+  Kotlin `$default` static bridge is a problem → pass args explicitly (above).
+- **Renamed / removed / retyped API** — migrate to the replacement. If you must
+  keep working on *both* old and new IDEs from one binary and the signatures
+  are incompatible, dispatch reflectively (resolve by name at runtime) or gate
+  on `ApplicationInfo.build`. Do this only when a source-level call can't
+  satisfy both; it's a last resort.
+- **Deprecated API (WARNINGS only)** — do **not** remove it if the plugin still
+  supports IDEs where the replacement doesn't exist. Track the eventual removal
+  and migrate when the `sinceBuild` floor rises past the replacement's
+  introduction.
+- **Consuming newer-only API by accident** — the plugin compiles against the
+  floor SDK precisely so this fails at compile time. Never bump the compile SDK
+  to reach a newer symbol; that silently raises the effective floor.
+
+## Prove the fix at the bytecode level (gold standard)
+
+Because this is entirely about *emitted bytecode*, prove it rather than assume.
+Compile a one-method repro of the before/after against the floor SDK and
+disassemble — the fix is correct iff the `$default` `invokestatic` becomes a
+plain `invokeinterface`/`invokevirtual`:
+
+```bash
+# jars: SDK module (inspect_sdk.sh caches them under tmp/idea-sdk-jars/), lsp4j
+# from Maven Central, and kotlin-stdlib. A Kotlin compiler ships inside Gradle:
+#   /opt/gradle-*/lib/kotlin-compiler-embeddable-*.jar  (+ kotlin-stdlib/reflect/
+#   script-runtime and kotlinx-coroutines-core-jvm in the same lib dir)
+# Point -kotlin-home at a dir whose lib/ has kotlin-stdlib.jar / kotlin-reflect.jar
+# / kotlin-script-runtime.jar, then:
+kotlinc -cp "lsp-<ver>.jar:lsp4j.jar:kotlin-stdlib.jar" Repro.kt -d out
+javap -p -c -classpath out Repro | grep -iE 'invokestatic|invokeinterface|sendRequestSync'
+# BEFORE: invokestatic  LspServer.sendRequestSync$default(...)
+# AFTER:  sipush 10000  +  invokeinterface LspServer.sendRequestSync(I,Function1)
+```
+
+Then confirm the *other* direction with `inspect_sdk.sh <failing-build>`: the
+plain method resolves at the new owner (directly or inherited), and the old
+`$default` symbol is genuinely absent.
+
+## Before you ship — checklist
+
+- [ ] `make verify-editor-jetbrains` is green (0 CRITICAL) across all
+      `pluginVerification.ides`, including a >=2026.1 target.
+- [ ] Any new IntelliJ-platform call that takes a defaulted Kotlin parameter is
+      called with that parameter **explicit** (no `$default` in the bytecode).
+- [ ] The compile SDK is still the `sinceBuild` floor (`intellijIdeaUltimate`
+      in `dependencies`), not bumped to reach a newer symbol.
+- [ ] After publishing, `marketplace_verify.sh` shows no CRITICAL on the new
+      build, including IDE majors newer than the local `ides` list. Schedule a
+      run against the newest EAP if the matrix hasn't covered it yet.
+
+## Key files
+
+- `editors/jetbrains/build.gradle.kts` — compile SDK (`dependencies { … }`),
+  `sinceBuild`/`untilBuild`, and `pluginVerification.ides`.
+- `editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActionBase.kt`
+- `editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt`
+- `Makefile` — `verify-editor-jetbrains`, `build-editor-jetbrains`,
+  `publish-jetbrains`.
+- `scripts/release/jetbrains_token.sh` — token resolution (env / Keychain /
+  libsecret). The token is a secret: never echo it, never commit it.

--- a/.claude/skills/jetbrains-plugin-compat/inspect_sdk.sh
+++ b/.claude/skills/jetbrains-plugin-compat/inspect_sdk.sh
@@ -1,0 +1,123 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# inspect_sdk.sh — disassemble an IntelliJ Platform API class across IDE
+# versions WITHOUT downloading a multi-GB IDE.
+#
+# The JetBrains "intellij-repository" publishes each platform module as its
+# own small jar (the `lsp` module is ~200-450 KB), so we can fetch just the
+# module that declares the API we care about and run `javap` over the exact
+# class. This is how you prove *where* a method is declared, whether it moved
+# to a super-interface, and whether its signature changed between the version
+# we compile against (the sinceBuild floor) and the version that fails
+# verification.
+#
+# Usage:
+#   inspect_sdk.sh <version> <fully.qualified.ClassName> [module] [-c]
+#
+#   <version>      IDE platform version, e.g. 241.14494.240, 2024.1,
+#                  262.8665.176. Release builds resolve from the `releases`
+#                  repo; EAP/RC builds (…-EAP-SNAPSHOT or fresh RC build
+#                  numbers) resolve from `snapshots`. Both are tried.
+#   <ClassName>    e.g. com.intellij.platform.lsp.api.LspServer
+#   [module]       platform module jar name (default: lsp). Other useful
+#                  ones: platform-impl, analysis-api, core-api, lang-impl.
+#   [-c]           also print method bodies (javap -c), so you can see
+#                  invokestatic/invokeinterface at call sites.
+#
+# Examples:
+#   # Where does sendRequestSync live in the floor build vs a failing build?
+#   inspect_sdk.sh 241.14494.240 com.intellij.platform.lsp.api.LspServer
+#   inspect_sdk.sh 262.8665.176  com.intellij.platform.lsp.api.LspServer
+#   inspect_sdk.sh 262.8665.176  com.intellij.platform.lsp.api.LspClient
+#
+# List available versions of a module (when you need an exact build number):
+#   inspect_sdk.sh --list [module]
+#
+# Env:
+#   SDK_CACHE   where to cache downloaded jars (default: <repo>/tmp/idea-sdk-jars)
+
+set -euo pipefail
+
+REPO_BASE="https://www.jetbrains.com/intellij-repository"
+GROUP_PATH="com/jetbrains/intellij/platform"
+
+repo_root() {
+  git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null \
+    || echo "${PWD}"
+}
+CACHE="${SDK_CACHE:-$(repo_root)/tmp/idea-sdk-jars}"
+
+die() { echo "error: $*" >&2; exit 1; }
+
+need() { command -v "$1" >/dev/null 2>&1 || die "missing required tool: $1"; }
+
+list_versions() {
+  local module="${1:-lsp}"
+  echo "== available '${module}' versions (releases) =="
+  curl -sSL "${REPO_BASE}/releases/${GROUP_PATH}/${module}/maven-metadata.xml" \
+    | grep -oE '<version>[^<]+</version>' | sed -E 's|</?version>||g' | tail -25
+  echo
+  echo "== available '${module}' versions (snapshots: EAP/RC) =="
+  curl -sSL "${REPO_BASE}/snapshots/${GROUP_PATH}/${module}/maven-metadata.xml" \
+    | grep -oE '<version>[^<]+</version>' | sed -E 's|</?version>||g' | tail -25
+}
+
+# Fetch <module>-<version>.jar, trying releases then snapshots. Echoes the
+# local jar path on success.
+fetch_jar() {
+  local version="$1" module="$2"
+  local jar="${CACHE}/${module}-${version}.jar"
+  if [ -s "$jar" ] && unzip -l "$jar" >/dev/null 2>&1; then
+    echo "$jar"; return 0
+  fi
+  mkdir -p "$CACHE"
+  local repo url code
+  for repo in releases snapshots; do
+    url="${REPO_BASE}/${repo}/${GROUP_PATH}/${module}/${version}/${module}-${version}.jar"
+    code=$(curl -sSL -o "${jar}.part" -w '%{http_code}' "$url" 2>/dev/null || true)
+    if [ "$code" = "200" ] && unzip -l "${jar}.part" >/dev/null 2>&1; then
+      mv "${jar}.part" "$jar"
+      echo "fetched ${module}-${version}.jar from ${repo}" >&2
+      echo "$jar"; return 0
+    fi
+    rm -f "${jar}.part"
+  done
+  die "could not fetch ${module}-${version}.jar from releases or snapshots.
+Hint: run '$(basename "$0") --list ${module}' to see valid version strings,
+and confirm the class really lives in the '${module}' module (try another
+module name as the 3rd argument)."
+}
+
+main() {
+  need curl; need unzip; need javap
+
+  if [ "${1:-}" = "--list" ]; then
+    list_versions "${2:-lsp}"; exit 0
+  fi
+
+  local version="${1:?usage: inspect_sdk.sh <version> <class> [module] [-c]}"
+  local class="${2:?usage: inspect_sdk.sh <version> <class> [module] [-c]}"
+  local module="lsp" cflag=""
+  shift 2
+  for arg in "$@"; do
+    case "$arg" in
+      -c) cflag="-c" ;;
+      *)  module="$arg" ;;
+    esac
+  done
+
+  local jar; jar="$(fetch_jar "$version" "$module")"
+
+  echo "########## ${class}  @  ${module}-${version} ##########"
+  # javap reads classes straight out of a jar on the classpath. -p shows
+  # private/synthetic members (the $default bridges), which is the whole point.
+  javap -p ${cflag} -classpath "$jar" "$class" \
+    || die "class '${class}' not found in ${module}-${version}.jar.
+It may live in a different platform module — try a different [module] arg,
+or grep the jar: unzip -l '${jar}' | grep -i '${class##*.}'"
+}
+
+main "$@"

--- a/.claude/skills/jetbrains-plugin-compat/marketplace_verify.sh
+++ b/.claude/skills/jetbrains-plugin-compat/marketplace_verify.sh
@@ -77,7 +77,15 @@ resolve_update() {
   [ -n "$update" ] && { echo "$update"; return; }
   local tmp; tmp="$(mktemp)"
   local q="/api/plugins/${PLUGIN_ID}/updates?size=50"
-  [ -n "$channel" ] && q="${q}&channel=${channel}"
+  # The public Stable channel is the *default/empty* Marketplace channel (this
+  # repo publishes stable as `channels = listOf("default")`). Querying
+  # `&channel=stable` (or `default`) targets a nonexistent named channel and
+  # returns nothing, so normalise those to no channel filter. Only a real named
+  # channel like `eap` gets the query parameter.
+  case "$channel" in
+    ""|stable|default) : ;;
+    *) q="${q}&channel=${channel}" ;;
+  esac
   local code; code="$(api GET "$q" "$tmp")"
   [ "$code" = "200" ] || { rm -f "$tmp"; die "updates list failed (HTTP $code)"; }
   python3 - "$tmp" "$version" <<'PY'
@@ -190,9 +198,16 @@ main() {
         local u; u="$(resolve_update "$channel" "$version" "$update")"
         print_results "$u" "${channel:-${version:-explicit}}" "$full" || rc=1
       else
-        # No selector: health-check both channels' latest builds.
+        # No selector: health-check both channels' latest builds. A channel we
+        # cannot resolve (bad token, API error, no updates) must FAIL the gate,
+        # not be silently skipped — otherwise the command could print OK having
+        # verified nothing.
         for ch in stable eap; do
-          local u; u="$(resolve_update "$ch" "" "")" || continue
+          local u
+          if ! u="$(resolve_update "$ch" "" "")"; then
+            echo "!! could not resolve latest '$ch' update — failing the gate" >&2
+            rc=1; continue
+          fi
           print_results "$u" "$ch latest" "$full" || rc=1
           echo
         done

--- a/.claude/skills/jetbrains-plugin-compat/marketplace_verify.sh
+++ b/.claude/skills/jetbrains-plugin-compat/marketplace_verify.sh
@@ -1,0 +1,207 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+# SPDX-License-Identifier: AGPL-3.0-or-later
+#
+# marketplace_verify.sh — read (and optionally schedule) the JetBrains
+# Marketplace's own IntelliJ-Plugin-Verifier results for our plugin, the same
+# verdicts shown on the plugin's "…/edit/versions/{stable,eap}" admin page.
+#
+# The Marketplace runs the verifier against a matrix of released IDE builds
+# after every upload and exposes the results over its REST API. Reading them
+# requires the maintainer token (READ_VERIFICATION_RESULTS permission); the
+# token is resolved via scripts/release/jetbrains_token.sh (env var, macOS
+# Keychain, or libsecret) and is NEVER printed or written to disk here.
+#
+# This is the *post-publish* half of the compatibility story. It tells you how
+# a build that is already on the Marketplace fares against IDE versions newer
+# than anything in build.gradle.kts's local `pluginVerification.ides` list —
+# which is exactly how the LspServer.sendRequestSync$default breakage first
+# surfaced (a 2.1.x build flagged CRITICAL on 2026.1/2026.2 that our local
+# verifier targets never covered). Use `make verify-editor-jetbrains` for the
+# pre-publish gate; use this to read what the Marketplace found afterward.
+#
+# Usage:
+#   marketplace_verify.sh [results] [--channel eap|stable] [--version X.Y.Z]
+#                         [--update <id>] [--full]
+#   marketplace_verify.sh products  [--channel eap|stable] [--version X.Y.Z]
+#                         [--update <id>]
+#   marketplace_verify.sh schedule  --ide <ideVersion> [--update <id>]
+#                         [--channel eap|stable] [--version X.Y.Z]
+#
+#   results   (default)  Per-IDE verdict table. Exits non-zero if any verdict
+#                        is CRITICAL / PROBLEMS / INVALID_PLUGIN, so it can gate
+#                        a release. With no --channel, checks BOTH channels'
+#                        latest builds. --full also prints the exact problem
+#                        messages from each failing build's report.
+#   products             List the IDE builds the Marketplace can verify against
+#                        (the input to `schedule --ide`).
+#   schedule             Enqueue a verification run for one IDE build (the
+#                        "Schedule Verification" button). Side-effecting.
+#
+# Env overrides:
+#   JB_PLUGIN_ID   numeric Marketplace plugin id (default: 31801)
+#   JETBRAINS_TOKEN  token (else resolved via jetbrains_token.sh)
+
+set -euo pipefail
+
+BASE="https://plugins.jetbrains.com"
+PLUGIN_ID="${JB_PLUGIN_ID:-31801}"
+VTYPE="INTELLIJ_COMPATIBILITY"   # the plugin-verifier compatibility results
+
+die() { echo "error: $*" >&2; exit 2; }
+need() { command -v "$1" >/dev/null 2>&1 || die "missing required tool: $1"; }
+
+repo_root() {
+  git -C "$(dirname "${BASH_SOURCE[0]}")" rev-parse --show-toplevel 2>/dev/null || echo "$PWD"
+}
+
+resolve_token() {
+  if [ -n "${JETBRAINS_TOKEN:-}" ]; then printf '%s' "$JETBRAINS_TOKEN"; return 0; fi
+  local script; script="$(repo_root)/scripts/release/jetbrains_token.sh"
+  [ -x "$script" ] && "$script" 2>/dev/null && return 0
+  die "no Marketplace token: set \$JETBRAINS_TOKEN or store it for jetbrains_token.sh"
+}
+
+# GET/POST with bearer auth. Token stays in the header only; never echoed.
+api() { # api <method> <url-path> [outfile]
+  local method="$1" path="$2" out="${3:-/dev/stdout}"
+  curl -sSL -X "$method" -H "Authorization: Bearer $TOKEN" \
+       -o "$out" -w '%{http_code}' "$BASE$path"
+}
+
+# Resolve an update id from --update, or --version within --channel, or the
+# latest build in the channel. Echoes the update id.
+resolve_update() {
+  local channel="$1" version="$2" update="$3"
+  [ -n "$update" ] && { echo "$update"; return; }
+  local tmp; tmp="$(mktemp)"
+  local q="/api/plugins/${PLUGIN_ID}/updates?size=50"
+  [ -n "$channel" ] && q="${q}&channel=${channel}"
+  local code; code="$(api GET "$q" "$tmp")"
+  [ "$code" = "200" ] || { rm -f "$tmp"; die "updates list failed (HTTP $code)"; }
+  python3 - "$tmp" "$version" <<'PY'
+import sys,json
+ups=json.load(open(sys.argv[1])); want=sys.argv[2]
+ups=ups if isinstance(ups,list) else ups.get("updates",[])
+if not ups: sys.exit("no updates in channel")
+if want:
+    m=[u for u in ups if u.get("version")==want]
+    if not m: sys.exit(f"version {want} not found in channel")
+    print(m[0]["id"])
+else:
+    print(ups[0]["id"])
+PY
+  rm -f "$tmp"
+}
+
+fetch_results() { # fetch_results <update_id> -> json on stdout
+  local update="$1" tmp; tmp="$(mktemp)"
+  local code; code="$(api GET "/api/verifications/update/${update}?verificationType=${VTYPE}" "$tmp")"
+  [ "$code" = "200" ] || { cat "$tmp" >&2; rm -f "$tmp"; die "results fetch failed (HTTP $code)"; }
+  cat "$tmp"; rm -f "$tmp"
+}
+
+print_results() { # print_results <update_id> <label> <full?>
+  local update="$1" label="$2" full="$3"
+  local jf; jf="$(mktemp)"; fetch_results "$update" > "$jf"
+  echo "== update $update ($label) — INTELLIJ_COMPATIBILITY =="
+  local rc
+  # NB: `python3 -` reads the program from the heredoc, which exhausts stdin,
+  # so the results JSON is passed by file path (argv[1]) rather than piped in.
+  rc="$(TOKEN="$TOKEN" BASE="$BASE" FULL="$full" python3 - "$jf" <<'PY'
+import sys,json,os,urllib.request
+d=json.load(open(sys.argv[1]))
+items=d if isinstance(d,list) else d.get("data") or [d]
+bad={"CRITICAL","PROBLEMS","INVALID_PLUGIN"}
+print(f"  {'VERDICT':10} {'PRODUCT':14} {'IDE':22} SUMMARY")
+fails=0
+for r in sorted(items,key=lambda r:(r.get('resultType',''), (r.get('availableProduct') or {}).get('ideVersion',''))):
+    rt=r.get("resultType","?")
+    ap=r.get("availableProduct") or {}
+    prod=ap.get("productName") or ap.get("product") or "?"
+    ide=ap.get("ideVersion") or "?"
+    vv=(r.get("verificationVerdict") or "").split(". ")[0][:52]
+    print(f"  {rt:10} {prod:14} {ide:22} {vv}")
+    if rt in bad:
+        fails+=1
+        if os.environ.get("FULL")=="1":
+            url=r.get("fullVerificationResultUrl")
+            if url:
+                req=urllib.request.Request(os.environ['BASE']+url,
+                    headers={'Authorization':'Bearer '+os.environ['TOKEN']})
+                try:
+                    rep=json.load(urllib.request.urlopen(req))
+                except Exception as e:
+                    print(f"      (could not fetch report: {e})"); continue
+                seen=set()
+                def walk(o):
+                    if isinstance(o,dict):
+                        for v in o.values(): yield from walk(v)
+                    elif isinstance(o,list):
+                        for v in o: yield from walk(v)
+                    elif isinstance(o,str): yield o
+                for s in walk(rep):
+                    if ("unresolved method" in s or "NoSuchMethodError" in s
+                            or "Invocation of" in s) and s not in seen:
+                        seen.add(s); print("      ! "+s[:200])
+print(f"__FAILS__{fails}")
+PY
+)"
+  rm -f "$jf"
+  echo "$rc" | grep -v '^__FAILS__'
+  local n; n="$(printf '%s' "$rc" | sed -n 's/^__FAILS__//p')"
+  return "$(( n > 0 ? 1 : 0 ))"
+}
+
+main() {
+  need curl; need python3
+  local cmd="results" channel="" version="" update="" full="0" ide=""
+  [ $# -gt 0 ] && case "$1" in results|products|schedule) cmd="$1"; shift;; esac
+  while [ $# -gt 0 ]; do
+    case "$1" in
+      --channel) channel="$2"; shift 2;;
+      --version) version="$2"; shift 2;;
+      --update)  update="$2"; shift 2;;
+      --ide)     ide="$2"; shift 2;;
+      --full)    full="1"; shift;;
+      *) die "unknown arg: $1";;
+    esac
+  done
+  TOKEN="$(resolve_token)"; [ -n "$TOKEN" ] || die "empty token"
+
+  case "$cmd" in
+    products)
+      local u; u="$(resolve_update "$channel" "$version" "$update")"
+      api GET "/api/verifications/update/${u}/products" /tmp/_p.json >/dev/null
+      python3 -c 'import json;[print(p["ideVersion"],"\t",p.get("productName")) for p in json.load(open("/tmp/_p.json"))]'
+      ;;
+    schedule)
+      [ -n "$ide" ] || die "schedule needs --ide <ideVersion> (see: $0 products)"
+      local u; u="$(resolve_update "$channel" "$version" "$update")"
+      echo "scheduling INTELLIJ_COMPATIBILITY verification of update $u against $ide …"
+      local code; code="$(api POST "/api/verifications/update/${u}?ideVersion=${ide}&verificationType=${VTYPE}" /tmp/_s.json)"
+      echo "HTTP $code"; cat /tmp/_s.json; echo
+      [ "$code" = "200" ] || [ "$code" = "201" ] || die "schedule failed"
+      ;;
+    results)
+      local rc=0
+      if [ -n "$channel" ] || [ -n "$version" ] || [ -n "$update" ]; then
+        local u; u="$(resolve_update "$channel" "$version" "$update")"
+        print_results "$u" "${channel:-${version:-explicit}}" "$full" || rc=1
+      else
+        # No selector: health-check both channels' latest builds.
+        for ch in stable eap; do
+          local u; u="$(resolve_update "$ch" "" "")" || continue
+          print_results "$u" "$ch latest" "$full" || rc=1
+          echo
+        done
+      fi
+      [ "$rc" = 0 ] && echo "OK: no CRITICAL/PROBLEMS/INVALID_PLUGIN verdicts." \
+                    || echo "FAIL: at least one build has compatibility problems."
+      return "$rc"
+      ;;
+  esac
+}
+
+main "$@"

--- a/Makefile
+++ b/Makefile
@@ -159,7 +159,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 .PHONY: smoke-vsix
 # Packaging + publish + release
 .PHONY: build-editors build-editor-vsix verify-vsix install package-vsix publish-vsix
-.PHONY: build-editor-jetbrains publish-jetbrains build-editor-sublime publish-sublime build-editor-zed publish-zed publish-all publish-verify publish-flow
+.PHONY: build-editor-jetbrains verify-editor-jetbrains publish-jetbrains build-editor-sublime publish-sublime build-editor-zed publish-zed publish-all publish-verify publish-flow
 .PHONY: release release-tag release-sums
 # Rust runtime port
 .PHONY: runtime-rust-test runtime-rust-lint zed-query-check vm-test vm-lint
@@ -1222,6 +1222,16 @@ $(JB_PLUGIN): rust-server
 	@echo ""
 	@echo "Built: $(JB_PLUGIN)"
 	@ls -lh $(JB_PLUGIN)
+
+verify-editor-jetbrains: ## Run the IntelliJ Plugin Verifier over the JetBrains plugin (binary-compat gate)
+	@echo "==> Verifying JetBrains plugin against the configured IDE targets"
+	@# Runs the JetBrains IntelliJ Plugin Verifier (bytecode-level binary
+	@# compatibility analysis) against every IDE in the pluginVerification.ides
+	@# block of build.gradle.kts. This is what catches the moved-API /
+	@# `sendRequestSync$default` class of NoSuchMethodError regressions before
+	@# they ship. Downloads each target IDE on first run (multi-GB, cached).
+	@# See the jetbrains-plugin-compat skill for reading the verdicts.
+	cd $(JB_DIR) && ./gradlew verifyPlugin
 
 publish-jetbrains: build-editor-jetbrains ## Publish JetBrains plugin to JetBrains Marketplace
 	@echo "==> Resolving JetBrains Marketplace credentials"

--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -77,9 +77,19 @@ intellijPlatform {
     pluginVerification {
         freeArgs = listOf("-offline")
         ides {
+            // Verify against the sinceBuild floor and a spread of newer
+            // majors. The 2026.1 entry is load-bearing: 2026.1 is where the
+            // deprecated LspServer/LspServerManager/LspServerDescriptor API was
+            // superseded by LspClient*, and where `sendRequestSync` moved up to
+            // the LspClient super-interface. Without a >=2026.1 target the
+            // verifier cannot catch the `LspServer.sendRequestSync$default`
+            // class of binary incompatibility (see the jetbrains-plugin-compat
+            // skill). Keep the newest verified stable major here as JetBrains
+            // ships it.
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2024.1")
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.1.7.1")
             create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2025.2.6.2")
+            create(org.jetbrains.intellij.platform.gradle.IntelliJPlatformType.IntellijIdeaUltimate, "2026.1.4")
         }
     }
 

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/CompilerExplorerToolWindowFactory.kt
@@ -297,7 +297,18 @@ internal class CompilerExplorerPanel(private val project: Project) : Disposable 
                     return@executeOnPooledThread
                 }
 
-                val result = server.sendRequestSync { lsp4j ->
+                // Pass the timeout explicitly. Omitting it makes Kotlin emit a
+                // call to the synthetic `LspServer.sendRequestSync$default`
+                // bridge, which is bound to the exact class that declared the
+                // method when we compiled (2024.1). In 2026.1+ `sendRequestSync`
+                // moved up to the `LspClient` super-interface, so that bridge no
+                // longer resolves as `LspServer.sendRequestSync$default` and the
+                // plugin fails verification / throws NoSuchMethodError at runtime.
+                // The default value is a compile-time const (10_000 ms) that
+                // inlines, so behaviour is unchanged and there is no runtime
+                // reference to the constant. Do not "simplify" this back to the
+                // no-timeout form. See the jetbrains-plugin-compat skill.
+                val result = server.sendRequestSync(LspServer.DEFAULT_REQUEST_TIMEOUT_MS) { lsp4j ->
                     lsp4j.workspaceService.executeCommand(
                         org.eclipse.lsp4j.ExecuteCommandParams(
                             "tcl-lsp.compilerExplorer",

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActionBase.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/actions/TclLspActionBase.kt
@@ -31,6 +31,7 @@ import com.intellij.openapi.progress.ProgressIndicator
 import com.intellij.openapi.progress.Task
 import com.intellij.openapi.project.Project
 import com.intellij.openapi.ui.Messages
+import com.intellij.platform.lsp.api.LspServer
 import com.intellij.platform.lsp.api.LspServerManager
 import com.intellij.testFramework.LightVirtualFile
 import com.tcllsp.jetbrains.TclFileType
@@ -109,7 +110,17 @@ abstract class TclLspActionBase : AnAction() {
                 return
             }
 
-            val result = server.sendRequestSync { lsp4j ->
+            // Pass the timeout explicitly. Omitting it makes Kotlin emit a call
+            // to the synthetic `LspServer.sendRequestSync$default` bridge, bound
+            // to the class that declared the method when we compiled (2024.1).
+            // In 2026.1+ `sendRequestSync` moved up to the `LspClient`
+            // super-interface, so that bridge no longer resolves as
+            // `LspServer.sendRequestSync$default` and the plugin fails
+            // verification / throws NoSuchMethodError at runtime. The default is
+            // a compile-time const (10_000 ms) that inlines, so behaviour is
+            // unchanged. Do not "simplify" this back to the no-timeout form.
+            // See the jetbrains-plugin-compat skill.
+            val result = server.sendRequestSync(LspServer.DEFAULT_REQUEST_TIMEOUT_MS) { lsp4j ->
                 lsp4j.workspaceService.executeCommand(
                     ExecuteCommandParams(commandId, args)
                 )


### PR DESCRIPTION
## Summary

- The JetBrains plugin (compiled once against the 2024.1 `sinceBuild` floor) failed Marketplace verification with **2 CRITICAL** problems on IntelliJ IDEA **2026.1.4 / 2026.2**: `Invocation of unresolved method com.intellij.platform.lsp.api.LspServer.sendRequestSync$default(...)` in `CompilerExplorerPanel.runCompile` and `TclLspActionBase.runCommand`.
- **Root cause:** both sites call `server.sendRequestSync { … }` and omit the defaulted `timeout` param, so Kotlin lowers the call to `invokestatic LspServer.sendRequestSync$default(…)` — a synthetic bridge bound to the exact declaring class at compile time. In 2026.1 the deprecated `LspServer*` API was superseded by `LspClient*` and `sendRequestSync` moved up to the new `LspClient` super-interface. The real method still resolves on `LspServer` (inherited via the super-interface), but the **static** `$default` bridge does not → unresolved reference → `NoSuchMethodError` at runtime.
- **Fix:** pass the timeout explicitly at both sites, using the platform's own `LspServer.DEFAULT_REQUEST_TIMEOUT_MS`. This makes Kotlin emit a plain `invokeinterface LspServer.sendRequestSync(int, Function1)` — which resolves on every supported IDE. `DEFAULT_REQUEST_TIMEOUT_MS` is a compile-time `const` (`10_000` ms) that **inlines to a literal**, so behaviour is byte-identical and there is no runtime reference to the constant either.
- **Regression prevention:**
  - `build.gradle.kts`: added a **2026.1.4** target to `pluginVerification.ides`. A `>=2026.1` target is required to catch this whole moved-API / `$default` class of break — every older target reports *Compatible*.
  - `Makefile`: added `verify-editor-jetbrains` (`./gradlew verifyPlugin`) as a first-class binary-compat gate.
  - New **`.claude/skills/jetbrains-plugin-compat`** skill documenting how to keep the plugin compatible: run the verifier, read Marketplace verdicts over the REST API (`marketplace_verify.sh`, token resolved via `scripts/release/jetbrains_token.sh`, never embedded), root-cause moved-API / `$default` failures by disassembling per-version SDK module jars (`inspect_sdk.sh`), and the fix patterns that survive every supported IDE.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Bytecode-level proof (the change is entirely about emitted bytecode, so it was verified rather than assumed):

- Disassembled the real SDK module jars from the JetBrains intellij-repository — `javap -p` on `com.intellij.platform.lsp.api.LspServer` @ `241.14494.240` (declares `sendRequestSync` + `sendRequestSync$default`) vs @ `262.8665.176` (declares neither; `LspServer extends LspClient`, both moved to `LspClient`).
- Compiled a before/after repro against the 241 jar with the embeddable Kotlin compiler and disassembled:
  - **Before:** `invokestatic LspServer.sendRequestSync$default(...)`
  - **After:** `sipush 10000` + `invokeinterface LspServer.sendRequestSync(I, Function1)`
- Confirmed against the live Marketplace verifier report for update `1105244` (2.1.6): the two CRITICAL entries name exactly these two call sites; the fix removes the only `$default` references. `bash -n` clean on both new helper scripts; `make verify-editor-jetbrains` is the pre-publish gate going forward.

> Note: the full `./gradlew verifyPlugin` run downloads multi-GB IDEs and was not executed in this environment; the fix is proven at the bytecode/linkage level above and via the Marketplace's own verifier output.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **No** — editor-integration/build only; no compiler, diagnostic, or analysis behaviour changes.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A
- [ ] If I added a new compiler KCS note, I linked it from both: — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019YvsYpn9UMMgnAK8Bj9Xre

---
_Generated by [Claude Code](https://claude.ai/code/session_019YvsYpn9UMMgnAK8Bj9Xre)_