### PR TITLE
Point the Zed APL/BIG-IP grammars at the merge commit

### DIFF
--- a/editors/vscode/src/test/errorRecovery.test.ts
+++ b/editors/vscode/src/test/errorRecovery.test.ts
@@ -86,17 +86,30 @@ function symbolNames(
   return out;
 }
 
-/** Replace the document content and resolve with the resulting diagnostics. */
+/**
+ * Replace the document content and resolve with the resulting diagnostics.
+ *
+ * `until` is what the caller is actually waiting for. The server publishes
+ * diagnostics **progressively**: a first publish can carry the lint pass alone,
+ * with the parse-recovery error arriving in a later one. Reading whatever
+ * happens to be published first (`predicate: () => true`) therefore races the
+ * analysis, and under CI load C1 saw `[W211]` and no recovery error and failed —
+ * while passing every time on an idle laptop.
+ *
+ * A test asserting a diagnostic is *present* must say so, and wait for it.
+ * A test asserting *absence* has nothing to wait for, so it keeps the settle
+ * behaviour (the default `until`).
+ */
 async function setContentAndWait(
   editor: vscode.TextEditor,
   docUri: vscode.Uri,
   content: string,
+  until: (diags: vscode.Diagnostic[]) => boolean = () => true,
 ): Promise<vscode.Diagnostic[]> {
   const fresh = nextDiagnosticsPublish(docUri, { timeout: 15_000 });
   await setTestContent(editor, content);
   await fresh;
-  // A second short wait lets the deep/async pass settle before we read.
-  return waitForDiagnostics(docUri, { timeout: 5_000, predicate: () => true });
+  return waitForDiagnostics(docUri, { timeout: 15_000, predicate: until });
 }
 
 async function symbolsFor(docUri: vscode.Uri): Promise<string[]> {
@@ -114,7 +127,12 @@ suite("Error Recovery (contract)", () => {
   test("C1: unterminated bracket is flagged", async () => {
     await activate(docUri);
     const editor = vscode.window.activeTextEditor!;
-    const diags = await setContentAndWait(editor, docUri, "set x [foo bar\nputs hi\n");
+    const diags = await setContentAndWait(
+      editor,
+      docUri,
+      "set x [foo bar\nputs hi\n",
+      hasRecoveryError,
+    );
     assert.ok(hasRecoveryError(diags), `expected a recovery error, got [${diags.map(codeOf)}]`);
   });
 
@@ -150,9 +168,11 @@ suite("Error Recovery (contract)", () => {
     // observable recovery behaviour, not a specific diagnostic code.
     await activate(docUri);
     const editor = vscode.window.activeTextEditor!;
-    const diags = await setContentAndWait(editor, docUri, "if {$x > 5\nset\n");
+    const hasArityOrShape = (ds: vscode.Diagnostic[]) =>
+      ds.some((d) => codeOf(d) === "E002" || codeOf(d) === "E004");
+    const diags = await setContentAndWait(editor, docUri, "if {$x > 5\nset\n", hasArityOrShape);
     assert.ok(
-      diags.some((d) => codeOf(d) === "E002" || codeOf(d) === "E004"),
+      hasArityOrShape(diags),
       `tail after \`if {\` should still be analysed and arity/shape-error; got [${diags.map(codeOf)}]`,
     );
   });
@@ -246,7 +266,7 @@ suite("Error Recovery (contract)", () => {
     let diags = await setContentAndWait(editor, docUri, "set x [foo bar]\nputs hi\n");
     assert.ok(!hasRecoveryError(diags), `clean start flagged: [${diags.map(codeOf)}]`);
 
-    diags = await setContentAndWait(editor, docUri, "set x [foo bar\nputs hi\n");
+    diags = await setContentAndWait(editor, docUri, "set x [foo bar\nputs hi\n", hasRecoveryError);
     assert.ok(hasRecoveryError(diags), `break not flagged: [${diags.map(codeOf)}]`);
 
     diags = await setContentAndWait(editor, docUri, "set x [foo bar]\nputs hi\n");

--- a/editors/zed/extension.toml
+++ b/editors/zed/extension.toml
@@ -72,10 +72,10 @@ requires_argument = false
 # silently keeps serving the old parser.
 [grammars.apl]
 repository = "https://github.com/bitwisecook/tcl-lsp"
-rev = "01aaf05e7af0c32277e087ea7f4be03538435944"
+rev = "21b44f1a0542a92d22a6564b0e68e1912ab95ed3"
 path = "grammars/tree-sitter-apl"
 
 [grammars.bigip]
 repository = "https://github.com/bitwisecook/tcl-lsp"
-rev = "01aaf05e7af0c32277e087ea7f4be03538435944"
+rev = "21b44f1a0542a92d22a6564b0e68e1912ab95ed3"
 path = "grammars/tree-sitter-bigip"


### PR DESCRIPTION
Follow-up to #905, which pinned both new tree-sitter grammars to `01aaf05` — a commit on the PR branch, now deleted.

Zed's `rev` is a **required, non-optional** field (`GrammarManifestEntry` in zed's `extension_manifest.rs`), so there is no floating alternative: it has to name a commit, and it should name one on `rust`.

I verified how Zed actually resolves it rather than assuming. `extension_builder.rs::checkout_repo` does:

```
git init; git remote add origin <url>
git fetch --depth 1 origin <rev>
git checkout <rev>
```

Simulated exactly that against the remote at `21b44f1`: fetch and checkout both succeed, and both grammars have their generated `src/parser.c` (plus the BIG-IP external scanner) at that commit.

Worth knowing: **bump this rev whenever either grammar changes.** Zed caches by commit, so a stale rev silently keeps serving the old parser rather than failing loudly.

(Also worth correcting something I said on #905: I claimed the old rev would "stop resolving" once the branch was deleted. That was overstated — GitHub keeps merged-PR commits reachable via `refs/pull/905/head`, so it would likely have kept working. The bump is for hygiene and correctness, not to avert a breakage.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Qa4XqiiwggvaAvBmmNZCJw