### PR TITLE
Report: fix the dead wasm payload, make printing work in Firefox, brand links home

### DIFF
--- a/.claude/skills/release/SKILL.md
+++ b/.claude/skills/release/SKILL.md
@@ -1,10 +1,11 @@
 ---
 name: release
 description: >
-  Run the full release workflow: validate branch, test, generate changelog,
-  tag, push, and publish to all editor marketplaces. Asks for
-  patch/minor/major if not specified. Tag-only — no source-file edits,
-  no commit on main (main is protected).
+  Run the full release workflow: validate the release branch (2.x pre-releases
+  are cut from `rust`, 1.x stable from `main`), test, generate changelog, tag,
+  push, then let CI build and publish — approving the marketplace Environments
+  with `gh` from the release laptop. Asks for patch/minor/major if not
+  specified. Tag-only — no source-file edits, no commit on the release branch.
 allowed-tools: Bash, Read, Write, Edit, Glob, Grep, AskUserQuestion
 ---
 
@@ -15,29 +16,58 @@ Orchestrates a full release of tcl-lsp. This skill is internal to the project.
 The release is **tag-only**: every version literal in the tree is derived
 from the latest annotated tag (via `hatch-vcs` for the Python wheel and via
 the Makefile + `git describe` for every editor build). To cut a release we
-push a `vX.Y.Z` tag — there is no source-file bump and no commit on `main`.
-RELEASE_NOTES.md is the one exception, and it lands via a PR before tagging.
+push a `vX.Y.Z` tag — there is no source-file bump and no commit on the
+release branch. RELEASE_NOTES.md is the one exception, and it lands via a PR
+before tagging.
+
+## Two release lines
+
+There are two, and they are cut from **different branches**:
+
+| Line | Branch | Channel | GitHub release |
+| --- | --- | --- | --- |
+| **1.x — stable** | `main` | VS Code stable / JetBrains stable | latest |
+| **2.x — pre-release** (the Python → Rust rewrite) | `rust` | VS Code pre-release / JetBrains eap | pre-release, never "latest" |
+
+Nothing declares which line you are on except the version: `scripts/release/prerelease.sh`
+is the single source of truth, and it says a tag is a pre-release when
+**major ≥ 2 and minor is odd** (so `v2.1.8` is a pre-release; `v2.2.0` would not
+be). CI reads that same script to decide the GitHub release's prerelease flag and
+the marketplace channel — you never pass a flag by hand.
+
+The rewrite is where the work is, so in practice a release is usually a **2.1.x
+pre-release cut from `rust`**. Do not "fix" this by tagging `main`: `main` does
+not contain the 2.x work, and tagging it would ship a stale tree under a new
+version.
 
 ## Workflow
 
 Follow these steps **in order**. Stop and report on failure at any step.
 
-### 1. Branch guard
+### 1. Pick the line, then guard the branch
+
+Work out the line from the version being cut, and require the matching branch:
 
 ```bash
+# The branch this line releases from: 2.x odd-minor => `rust`, otherwise `main`.
 branch=$(git branch --show-current)
-if [ "$branch" != "main" ]; then
-  echo "ERROR: Must be on 'main' branch to release (currently on '$branch')"
+prev_tag=$(git describe --tags --abbrev=0)
+release_branch=$(git branch -r --contains "$prev_tag" \
+                   | grep -qE 'origin/(rust)$' && echo rust || echo main)
+
+if [ "$branch" != "$release_branch" ]; then
+  echo "ERROR: $release_branch is the release branch for this line (on '$branch')"
   exit 1
 fi
 ```
 
-Fail immediately if not on `main`. Do not offer to switch branches.
+If the user asks for a release from the other branch, confirm with them before
+proceeding — do not silently switch lines.
 
 ### 2. Pull latest
 
 ```bash
-git pull origin main
+git pull origin "$release_branch"
 ```
 
 ### 3. Pre-release validation
@@ -108,22 +138,24 @@ list every file touched; summarise the meaningful changes.
 
 ### 6. Land RELEASE_NOTES.md via PR
 
-Main is protected, so the release-notes commit lands via a PR:
+The release branch is protected, so the release-notes commit lands via a PR
+**against that branch** (`--base "$release_branch"` — a notes PR opened against
+`main` for a 2.x pre-release would land the notes on the wrong line):
 
 ```bash
 git checkout -b release/vX.Y.Z
 git add RELEASE_NOTES.md
 git commit -m "Add release notes for vX.Y.Z"
 git push -u origin release/vX.Y.Z
-gh pr create --title "Release vX.Y.Z notes" --body "..."
+gh pr create --base "$release_branch" --title "Release vX.Y.Z notes" --body "..."
 ```
 
 Wait for CI on the PR to go green, then ask the user to merge it (squash).
 Once merged, switch back and pull:
 
 ```bash
-git checkout main
-git pull origin main
+git checkout "$release_branch"
+git pull origin "$release_branch"
 ```
 
 ### 7. Create and push the tag
@@ -213,12 +245,43 @@ step 9.
 **VS Code and JetBrains are published by CI, not here.** When the tag's CI
 run reaches the `publish-vsix-marketplace` and `publish-jetbrains-marketplace`
 jobs, each pauses on its protected Environment (`marketplace-vscode` /
-`marketplace-jetbrains`) for your approval. After the step 8 verification
-passes, approve both deployments in the Actions run; CI then publishes the
+`marketplace-jetbrains`) waiting for a reviewer. CI then publishes the
 released, checksum-verified `.vsix` / plugin `.zip` using the Environment
-secret (`secrets.VSCE_PAT` / `secrets.JETBRAINS_TOKEN`). The laptop targets
-`make publish-vsix` / `make publish-jetbrains` remain only as fallbacks if
-the CI job fails. This step's own work is just **Sublime and Zed**.
+secret (`secrets.VSCE_PAT` / `secrets.JETBRAINS_TOKEN`) — no publish token
+ever leaves the laptop, and the channel (stable vs pre-release/eap) is derived
+from the tag by `scripts/release/prerelease.sh`, not passed by hand.
+
+**Approve both deployments with `gh`, from the release laptop, as part of this
+flow** — there is no need to open the Actions UI. Only do this once step 8 has
+passed: approving is what actually ships to the marketplaces.
+
+```bash
+tag="vX.Y.Z"
+run=$(gh run list --workflow ci.yml --commit "$(git rev-list -n1 "$tag")" \
+        --json databaseId,headBranch --jq '.[0].databaseId')
+
+# The environments waiting on a reviewer, with their ids
+gh api "repos/bitwisecook/tcl-lsp/actions/runs/$run/pending_deployments" \
+  --jq '.[] | "\(.environment.id)  \(.environment.name)  waiting=\(.current_user_can_approve)"'
+
+# Approve them (ids from above; both environments in one call)
+gh api "repos/bitwisecook/tcl-lsp/actions/runs/$run/pending_deployments" \
+  -X POST \
+  -F "environment_ids[]=<vscode-env-id>" \
+  -F "environment_ids[]=<jetbrains-env-id>" \
+  -f state=approved \
+  -f comment="Artefacts verified against SHA256SUMS ($tag)"
+
+# Then watch them through
+gh run watch "$run" --exit-status
+```
+
+If `current_user_can_approve` is `false`, the account `gh` is authenticated as
+is not a reviewer on that Environment — report that rather than trying to work
+around it. The laptop targets `make publish-vsix` / `make publish-jetbrains`
+remain only as fallbacks if a CI job itself fails.
+
+This step's own remaining work is just **Sublime and Zed**.
 
 Before asking which editors to publish, run a readiness check so any
 missing token or unclaimed namespace surfaces *before* the user picks

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# v2.1.7
+# v2.1.8
 
 **2.x alpha — pre-release channel.**
 
@@ -10,123 +10,69 @@ GitHub release. The stable **1.x** line stays the default for everyone who has
 not opted into pre-releases, and a `2.1.x` build never becomes the "latest"
 GitHub release or the default Marketplace download.
 
-This release is a correctness audit of **semantic highlighting**. Every token
-the server emits was diffed against the retired 1.x implementation over ~30k
-lines of real Tcl — the Tcl 8.6 and 9.0 core libraries, plus `ruff`, `zesty`,
-`ticklecharts` and `tomato` — and every difference was chased to a cause. The
-result restores everything the Rust rewrite had dropped, fixes a long list of
-things *both* implementations got wrong, and brings back first-class
-highlighting for BIG-IP configs and iApp APL presentations.
+This release is mostly about the **BIG-IP report generator**: the report now
+carries the f5-query and tcl-lsp marks, and — more usefully — it *prints*. A
+printed report is now a linear document with a running header and footer on
+every page, one section per page, and the architecture view rendered properly
+alongside the manifest that defined it.
 
-One fix reaches beyond highlighting: an object referenced only from a `switch`
-arm was invisible to the BIG-IP reference graph, which `f5 grep`, `f5 irule
-trace`, `f5 query rename` and the `bigip-cleanup` skill all read. See **Bug
-Fixes**.
+Chasing the printing work turned up a bug that was never about printing: every
+device node in the **architecture diagram was invisible on screen too**. See
+**Bug Fixes**.
 
 ## New Features
 
-- **BIG-IP config highlighting is back, and works for the first time.** A
-  `bigip.conf` / `.scf` now gets a real token stream — partitions, pools,
-  monitors, profiles, VLANs, interfaces, IP addresses, ports, route domains,
-  FQDNs, usernames and encrypted values — instead of every line being painted
-  as one flat string. `samples/bigip/bigip.conf` previously *crashed* the 1.x
-  server outright and produced 272 whole-line strings under 2.1.6; it now
-  yields 374 correctly-typed, non-overlapping tokens.
-- **Embedded iRules inside a BIG-IP config are highlighted as Tcl.** A
-  `ltm rule /Common/x { when HTTP_REQUEST { … } }` body is code, not config, and
-  is now walked with the iRules dialect — object references included, so
-  `pool /Common/api_pool` inside a config reads exactly as it does in a
-  standalone `.irul`.
-- **APL (iApp presentation) highlighting is back.** All ten `apl*` token types —
-  sections, field types, field names, attributes, validators, directives,
-  `define` names, the `optional` guard — and the `[ … ]` bracket expressions
-  that embed Tcl are now walked as Tcl, as the feature has always documented.
-- **Expect scripts highlight.** `expect { pat body … }` — the central construct
-  of every Expect script — was rendering as flat per-line strings, its clause
-  bodies never recursed. Patterns, `-re` regex mode, the `timeout` / `eof` /
-  `full_buffer` keywords and every clause body now highlight, and
-  `expect_before` / `expect_after` / `expect_user` / `expect_background` /
-  `expect_tty` come with them.
-- **TclOO reads as objects, not strings.** Method names carry the standard LSP
-  `method` type at their declaration *and* at their call sites (`my m`,
-  `$obj m`); class names carry `class`; `superclass` / `mixin` / `export` /
-  `filter` / `forward` arguments are typed as the class or method they name.
-  Proc, method and constructor parameters carry the standard `parameter` type
-  again, so a theme can tell an argument from an ordinary local.
-
-## Improvements
-
-- **The token vocabulary is coherent and enforced.** 57 types — 16 standard LSP
-  plus six closed families (regex, `format`/`scan`, `clock`, `binary`, BIG-IP,
-  APL). Every type each dialect emits is either a standard LSP type or mapped to
-  an editor scope, and two tests now hold that line — including for the narrow
-  dialects (the versioned Tcls, the five EDA tools, Expect), which reach the same
-  sub-tokenisers a plain `.tcl` file does.
-- **Shared lexical rules are now shared.** Tcl's backslash-escape widths and the
-  literal/escape split live once, beside the evaluator that defines them; the
-  `{pattern body …}` clause-list split lives once, shared by the token walker and
-  the iRules object walker. Each had grown private copies that had already
-  drifted apart.
-- **Clause lists are registry data.** `switch` and Expect's `expect` are the same
-  construct, described once in the command registry rather than matched by name
-  in the walker.
+- **The report carries the f5-query and tcl-lsp marks.** Both are inlined as
+  real `<svg>`, so they follow the report's light/dark theme and stay crisp at
+  any zoom rather than blurring like a raster logo. They lead the builder page
+  beside the title — the f5-query mark linking to the query quick start, the
+  tcl-lsp mark to the project — and sit above the attribution in the report
+  footer. A report generated without a logo of your own now uses the f5-query
+  mark in the header instead of a placeholder glyph; supplying your own logo
+  still overrides it.
+- **A report prints as a linear document.** Printing now walks every selected
+  device and section in document order rather than whatever tab happened to be
+  open, with each section starting on its own page. The architecture view gets
+  a page of its own — the diagram, the devices-by-tier breakdown, and the
+  manifest DSL that defined the estate, rendered as a code block rather than as
+  the empty box an editable textarea prints as. The f5-query manual is left out
+  of the printed copy, where a reference manual is only noise.
 
 ## Bug Fixes
 
-- **Objects referenced from a `switch` arm were invisible to the BIG-IP
-  reference graph.** A `switch` case list is not a body, so the iRules
-  object-reference walker never descended into one — and a pool used only inside
-  a `switch` arm is an entirely ordinary iRule:
+- **The architecture diagram now draws its devices — on screen as well as in
+  print.** The diagram draws each device as an SVG node carrying
+  `class="device"`, and the report's own `.device { display: none }` rule — the
+  one that hides the device sections you are not looking at — was hiding those
+  nodes too. The diagram rendered as edges over blank space. The same selector
+  collision made the print dialog offer phantom devices to print.
+- **The printed report repeats its header and footer on every page.** The
+  running title and the attribution / version / copyright line were positioned
+  into the page margin, which browsers hand to the *neighbouring* page: the
+  title printed at the foot of the page before it, and the attribution across
+  the top of the page after it, on top of the content. Both now ride along on
+  every sheet, clear of the content — so a confidentiality notice set on a
+  report reaches every printed page, which is the point of setting one.
+- **`f5report` wheels ship the report's logo assets.** The vendored logo SVGs
+  were treated as build outputs and left out of the package, so a packaged
+  install would raise on first render instead of producing a report.
+- **BIG-IP object references inside `switch` arms are found.** An object
+  referenced only from a `switch` arm could be invisible to the reference graph
+  that `f5 grep`, `f5 irule trace`, `f5 query rename` and the `bigip-cleanup`
+  skill all read — where a miss is a deleted live pool, not a wrong colour. A
+  single exhaustive definition of "does this argument carry executable Tcl" now
+  backs the walk: a new argument role that can hold a script fails the build
+  until it is classified, and generative tests assert that such arguments are
+  actually walked.
 
-  ```tcl
-  switch -glob [HTTP::uri] {
-      "/api/*" { pool /Common/api_pool }
-      default  { pool /Common/web_pool }
-  }
-  ```
+## Improvements
 
-  `f5 grep` missed the iRule routing to a pool, `f5 irule trace` reported no pool
-  references for it, `f5 query rename` counted 2 referrers where there were 3 —
-  and **`bigip-cleanup` would have generated a delete for a live pool.** All
-  three tools now see the full graph.
-- **Quoted and braced literals lost their closing delimiter.** `"hello world"`
-  was highlighted as `"hello world`, `{a b}` as `{a b`, `${var}` as `${var`. An
-  *escaped* string lost both delimiters.
-- **Backslash escape widths were wrong.** `\xhh`, `\uhhhh`, `\Uhhhhhhhh` and
-  octal `\ooo` were all treated as a backslash plus one character, so `\x41` was
-  highlighted as an escape `\x` followed by a string `41`.
-- **Array references with a computed index painted as strings.** `set env($lo)`,
-  `unset UnknownPending($name)` — a pattern used throughout Tcl's own `init.tcl`
-  and `package.tcl`.
-- **A regular expression's closing `)` was typed as a quantifier**, not a group
-  delimiter.
-- **`expr` emitted no token at all for `(`, `)`, `?` and `:`.**
-- **An empty procedure body emitted its closing brace as a function.**
-  `proc p {args} {}` produced a stray `}` token.
-- **A quoted string containing `::` was typed as a namespace**, losing any escape
-  inside it.
-- **`defaultLibrary` was lost** on commands reached through a `namespace import`
-  alias and on a built-in's namespace prefix (`tcl::mathop::`).
-- **APL diagnostics were reported a column short** after any astral character —
-  positions counted code points rather than UTF-16 units.
-- **The JetBrains plugin failed to load on IntelliJ 2026.1+.** Compiled against
-  the 2024.1 floor, it called platform LSP methods whose Kotlin default-argument
-  bridges no longer exist in 2026.1 / 2026.2, so Marketplace verification
-  reported two critical `unresolved method` problems and the plugin broke at
-  runtime on current IDEs.
-
-## Breaking Changes
-
-- **New semantic token types.** The legend gains `parameter`, `method`, `class`,
-  the twelve BIG-IP types and the ten `apl*` types. Themes that style tokens by
-  type may want rules for them; all are either standard LSP types (styled out of
-  the box) or already mapped to TextMate scopes by the shipped editor
-  integrations.
-- **`interface` is renamed `bigipInterface`.** The 1.x legend reused the standard
-  LSP `interface` type for a BIG-IP network interface, which shadows its real
-  meaning. A custom theme rule keyed on `interface:tcl-bigip` must be renamed.
-- **Procedure and method parameters are now `parameter`, not `variable`.** A
-  theme that colours `variable` and expects parameters to match will see them
-  change; `parameter` is a standard LSP type and is styled by default.
-- **`switch`'s `default` arm is now a `keyword`**, not a string — matching
-  Expect's `timeout` / `eof`, which likewise match no text.
+- **The APL and BIG-IP editor grammars match what the server sees.** Both
+  dialects shipped with the *Tcl* grammar, which contains no BIG-IP and no APL
+  rules, so a `bigip.conf` was painted with Tcl rules until the language server
+  answered and replaced the highlighting wholesale. Each dialect now has its own
+  tree-sitter grammar, with `ltm rule` bodies and APL `[ … ]` expressions
+  highlighted as Tcl exactly as the server walks them.
+- **The Zed grammars resolve.** Both new grammars were pinned to a commit on a
+  branch that no longer exists, which Zed cannot fetch; they now name a commit
+  on the release line.

--- a/rust/bigip-report-gen/frontend/dist/print.js
+++ b/rust/bigip-report-gen/frontend/dist/print.js
@@ -18,12 +18,13 @@
       var name = t && t.textContent.trim() || dev.getAttribute("data-name") || "";
       return name || "Device " + (i + 1);
     }
+    var TOOLS = { console: true, listener: true };
     var sections = [];
     var seen = {};
     devices.forEach(function(dev) {
       dev.querySelectorAll(".tabs .tab[data-panel]").forEach(function(tab) {
         var key = tab.dataset.panel;
-        if (seen[key]) return;
+        if (seen[key] || TOOLS[key]) return;
         seen[key] = true;
         var label = tab.cloneNode(true);
         var n = label.querySelector(".n");
@@ -173,20 +174,59 @@
         });
       });
       applyIruleOptions(deviceEls, doFmt, doDiag).then(function() {
-        setTimeout(function() {
+        whenDrawn(deviceEls, secs, function() {
           markAndPrint(deviceEls, secs);
-        }, 700);
+        });
       });
+    }
+    function whenDrawn(deviceEls, secs, done) {
+      var deadline = Date.now() + 8e3;
+      (function poll() {
+        var undrawn = 0;
+        deviceEls.forEach(function(dev) {
+          secs.forEach(function(key) {
+            var panel = dev.querySelector('.panel[data-panel="' + key + '"]');
+            if (!panel) return;
+            panel.querySelectorAll(".diag-host").forEach(function(host) {
+              if (!host.querySelector("svg") && !host.textContent.trim()) undrawn++;
+            });
+          });
+        });
+        if (!undrawn || Date.now() > deadline) {
+          done();
+          return;
+        }
+        setTimeout(poll, 150);
+      })();
+    }
+    function isEmptySection(dev, key) {
+      var tab = dev.querySelector('.tab[data-panel="' + key + '"]');
+      var badge = tab && tab.querySelector(".n");
+      if (badge && /^\s*0\s*$/.test(badge.textContent)) return true;
+      var panel = dev.querySelector('.panel[data-panel="' + key + '"]');
+      if (!panel) return true;
+      if (panel.querySelector("tbody tr, svg, pre, .card, .cert-row, .app-detail")) return false;
+      return !panel.textContent.trim();
     }
     function parkInSheet(nodes) {
       if (!nodes.length) return;
-      var head = document.querySelector(".print-running-head");
-      var foot = document.querySelector(".print-running-foot");
       var sheet = document.createElement("table");
       sheet.className = "print-sheet";
-      sheet.innerHTML = '<thead class="print-sheet-head"><tr><th>' + (head && head.innerHTML || "") + '</th></tr></thead><tfoot class="print-sheet-foot"><tr><td>' + (foot && foot.innerHTML || "") + '</td></tr></tfoot><tbody><tr><td class="print-sheet-body"></td></tr></tbody>';
+      sheet.innerHTML = '<thead class="print-sheet-head"><tr><th></th></tr></thead><tfoot class="print-sheet-foot"><tr><td></td></tr></tfoot><tbody><tr><td class="print-sheet-body"></td></tr></tbody>';
       var cell = sheet.querySelector(".print-sheet-body");
       nodes[0].parentNode.insertBefore(sheet, nodes[0]);
+      [
+        [".print-running-head", "thead th"],
+        [".print-running-foot", "tfoot td"]
+      ].forEach(function(pair) {
+        var el = document.querySelector(pair[0]);
+        if (!el) return;
+        var parent = el.parentNode, next = el.nextSibling;
+        remember(function() {
+          parent.insertBefore(el, next);
+        });
+        sheet.querySelector(pair[1]).appendChild(el);
+      });
       nodes.forEach(function(n) {
         var parent = n.parentNode, next = n.nextSibling;
         remember(function() {
@@ -238,7 +278,7 @@
         });
         secs.forEach(function(key) {
           var panel = dev.querySelector('.panel[data-panel="' + key + '"]');
-          if (!panel) return;
+          if (!panel || isEmptySection(dev, key)) return;
           panel.classList.add("print-include");
           remember(function() {
             panel.classList.remove("print-include");

--- a/rust/bigip-report-gen/frontend/dist/print.js
+++ b/rust/bigip-report-gen/frontend/dist/print.js
@@ -208,34 +208,39 @@
       if (panel.querySelector("tbody tr, svg, pre, .card, .cert-row, .app-detail")) return false;
       return !panel.textContent.trim();
     }
-    function parkInSheet(nodes) {
+    function parkInSheets(nodes) {
       if (!nodes.length) return;
-      var sheet = document.createElement("table");
-      sheet.className = "print-sheet";
-      sheet.innerHTML = '<thead class="print-sheet-head"><tr><th></th></tr></thead><tfoot class="print-sheet-foot"><tr><td></td></tr></tfoot><tbody><tr><td class="print-sheet-body"></td></tr></tbody>';
-      var cell = sheet.querySelector(".print-sheet-body");
-      nodes[0].parentNode.insertBefore(sheet, nodes[0]);
-      [
-        [".print-running-head", "thead th"],
-        [".print-running-foot", "tfoot td"]
-      ].forEach(function(pair) {
-        var el = document.querySelector(pair[0]);
-        if (!el) return;
-        var parent = el.parentNode, next = el.nextSibling;
-        remember(function() {
-          parent.insertBefore(el, next);
-        });
-        sheet.querySelector(pair[1]).appendChild(el);
-      });
-      nodes.forEach(function(n) {
+      var headSrc = document.querySelector(".print-running-head");
+      var footSrc = document.querySelector(".print-running-foot");
+      var host = document.createElement("div");
+      host.className = "print-host";
+      nodes[0].parentNode.insertBefore(host, nodes[0]);
+      function runner(cell, src, tag) {
+        if (!src || !cell) return;
+        var clone = src.cloneNode(true);
+        clone.innerHTML = clone.innerHTML.replace(
+          /(id="|url\(#|href="#)([A-Za-z][\w.:-]*)/g,
+          function(_m, prefix, id) {
+            return prefix + tag + "-" + id;
+          }
+        );
+        cell.appendChild(clone);
+      }
+      nodes.forEach(function(n, i) {
+        var sheet = document.createElement("table");
+        sheet.className = "print-sheet";
+        sheet.innerHTML = '<thead class="print-sheet-head"><tr><th></th></tr></thead><tfoot class="print-sheet-foot"><tr><td></td></tr></tfoot><tbody><tr><td class="print-sheet-body"></td></tr></tbody>';
+        runner(sheet.querySelector("thead th"), headSrc, "sh" + i);
+        runner(sheet.querySelector("tfoot td"), footSrc, "sf" + i);
         var parent = n.parentNode, next = n.nextSibling;
         remember(function() {
           parent.insertBefore(n, next);
         });
-        cell.appendChild(n);
+        host.appendChild(sheet);
+        sheet.querySelector(".print-sheet-body").appendChild(n);
       });
       remember(function() {
-        if (sheet.parentNode) sheet.parentNode.removeChild(sheet);
+        if (host.parentNode) host.parentNode.removeChild(host);
       });
     }
     function prepArchitecture() {
@@ -309,7 +314,17 @@
         });
       }
       var arch = prepArchitecture();
-      parkInSheet([summary, arch].filter(Boolean).concat(deviceEls));
+      var order = [];
+      if (summary) order.push(summary);
+      if (arch) order.push(arch);
+      deviceEls.forEach(function(dev) {
+        order.push(dev);
+        secs.forEach(function(key) {
+          var panel = dev.querySelector('.panel[data-panel="' + key + '"]');
+          if (panel && panel.classList.contains("print-include")) order.push(panel);
+        });
+      });
+      parkInSheets(order);
       document.documentElement.classList.add("printing");
       remember(function() {
         document.documentElement.classList.remove("printing");

--- a/rust/bigip-report-gen/frontend/dist/report.js
+++ b/rust/bigip-report-gen/frontend/dist/report.js
@@ -116,6 +116,45 @@
       }
       sel.addEventListener("change", apply);
     });
+    (function brandHome() {
+      var homes = document.querySelectorAll(".brand-home");
+      if (!homes.length) return;
+      var openDevice = document.querySelector(".dev-tab.active");
+      var openTabs = [];
+      document.querySelectorAll("article.device[data-dev]").forEach(function(dev) {
+        openTabs.push({ dev, tab: dev.querySelector(".tab.active") });
+      });
+      function reset(ev) {
+        if (ev) ev.preventDefault();
+        if (openDevice) openDevice.click();
+        openTabs.forEach(function(o) {
+          if (o.tab) o.tab.click();
+        });
+        var search2 = document.getElementById("globalSearch");
+        if (search2 && search2.value) {
+          search2.value = "";
+          search2.dispatchEvent(new Event("input", { bubbles: true }));
+        }
+        document.querySelectorAll(".partition-filter").forEach(function(sel) {
+          if (sel.selectedIndex !== 0) {
+            sel.selectedIndex = 0;
+            sel.dispatchEvent(new Event("change", { bubbles: true }));
+          }
+        });
+        document.querySelectorAll("article.device.show-system-on").forEach(function(d) {
+          d.classList.remove("show-system-on");
+        });
+        document.querySelectorAll("tr.expandable.open, tr.detail.open").forEach(function(r) {
+          r.classList.remove("open");
+        });
+        var close = document.querySelector("#objDrawer .drawer-close");
+        if (close && document.getElementById("objDrawer").classList.contains("open")) close.click();
+        window.scrollTo({ top: 0, behavior: "smooth" });
+      }
+      homes.forEach(function(a) {
+        a.addEventListener("click", reset);
+      });
+    })();
     document.querySelectorAll("tr.expandable").forEach(function(row) {
       var detail = row.nextElementSibling;
       if (!detail || !detail.classList.contains("detail")) return;

--- a/rust/bigip-report-gen/frontend/src/pages/print.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/print.ts
@@ -265,38 +265,56 @@
   // the running title and attribution — the browser then repeats them on every
   // sheet and reserves the room. `.print-running-head` / `.print-running-foot`
   // in the template are the (hidden) source of that markup.
-  function parkInSheet(nodes) {
+  // ONE sheet per section, not one sheet for the whole report. A forced page
+  // break *inside* a table cell is the case Gecko gets wrong — Firefox emitted
+  // page after blank page from it — so each section is parked in a table of its
+  // own and the breaks fall between the tables, at block level, where both
+  // engines agree. Each sheet repeats its own head/foot over the pages it spans.
+  function parkInSheets(nodes) {
     if (!nodes.length) return;
-    var sheet = document.createElement("table");
-    sheet.className = "print-sheet";
-    sheet.innerHTML =
-      '<thead class="print-sheet-head"><tr><th></th></tr></thead>' +
-      '<tfoot class="print-sheet-foot"><tr><td></td></tr></tfoot>' +
-      '<tbody><tr><td class="print-sheet-body"></td></tr></tbody>';
-    var cell = sheet.querySelector(".print-sheet-body");
-    nodes[0].parentNode.insertBefore(sheet, nodes[0]);
+    var headSrc = document.querySelector(".print-running-head");
+    var footSrc = document.querySelector(".print-running-foot");
 
-    // The running head/foot are MOVED in, not copied: they carry the project
-    // marks as inline <svg>, and a copy would duplicate every gradient id.
-    [
-      [".print-running-head", "thead th"],
-      [".print-running-foot", "tfoot td"],
-    ].forEach(function (pair) {
-      var el = document.querySelector(pair[0]);
-      if (!el) return;
-      var parent = el.parentNode, next = el.nextSibling;
-      remember(function () { parent.insertBefore(el, next); });
-      sheet.querySelector(pair[1]).appendChild(el);
-    });
+    // All sheets live side by side at top level: a panel parked in a table still
+    // nested inside its device's table would put the forced break back inside a
+    // cell, which is the very thing this avoids.
+    var host = document.createElement("div");
+    host.className = "print-host";
+    nodes[0].parentNode.insertBefore(host, nodes[0]);
 
-    nodes.forEach(function (n) {
+    // The running head/foot carry the marks as inline <svg>, so a clone per
+    // sheet would repeat every gradient id. Re-namespace each copy's ids and the
+    // url(#…) / href="#…" references that point at them.
+    function runner(cell, src, tag) {
+      if (!src || !cell) return;
+      var clone = src.cloneNode(true);
+      clone.innerHTML = clone.innerHTML.replace(
+        /(id="|url\(#|href="#)([A-Za-z][\w.:-]*)/g,
+        function (_m, prefix, id) { return prefix + tag + "-" + id; }
+      );
+      cell.appendChild(clone);
+    }
+
+    nodes.forEach(function (n, i) {
+      var sheet = document.createElement("table");
+      sheet.className = "print-sheet";
+      sheet.innerHTML =
+        '<thead class="print-sheet-head"><tr><th></th></tr></thead>' +
+        '<tfoot class="print-sheet-foot"><tr><td></td></tr></tfoot>' +
+        '<tbody><tr><td class="print-sheet-body"></td></tr></tbody>';
+      runner(sheet.querySelector("thead th"), headSrc, "sh" + i);
+      runner(sheet.querySelector("tfoot td"), footSrc, "sf" + i);
+
       var parent = n.parentNode, next = n.nextSibling;
       remember(function () { parent.insertBefore(n, next); });
-      cell.appendChild(n);
+      host.appendChild(sheet);
+      sheet.querySelector(".print-sheet-body").appendChild(n);
     });
-    // Unwound first (restore runs last-registered-first): drops the table, then
-    // each node goes back where it came from.
-    remember(function () { if (sheet.parentNode) sheet.parentNode.removeChild(sheet); });
+
+    // Unwound first (restore runs last-registered-first): the host and its
+    // tables go, then every node is put back where it came from — panels before
+    // the device they belong to, since they were registered after it.
+    remember(function () { if (host.parentNode) host.parentNode.removeChild(host); });
   }
 
   // The cross-device architecture view is a top-level section, not a device tab,
@@ -359,15 +377,27 @@
     });
 
     // Linearise: the estate summary, the architecture view (when the report has
-    // one), then each device — all parked in the running-head/foot sheet, in
-    // document order, so the printed page follows the on-screen one.
+    // one), then each device — its heading block, then one section at a time —
+    // in document order, so the printed page follows the on-screen one. Each of
+    // these becomes a sheet of its own, and a sheet is a page.
     var summary = document.querySelector("section.summary");
     if (summary) {
       summary.classList.add("print-include");
       remember(function () { summary.classList.remove("print-include"); });
     }
     var arch = prepArchitecture();
-    parkInSheet([summary, arch].filter(Boolean).concat(deviceEls));
+
+    var order = [];
+    if (summary) order.push(summary);
+    if (arch) order.push(arch);
+    deviceEls.forEach(function (dev) {
+      order.push(dev);
+      secs.forEach(function (key) {
+        var panel = dev.querySelector('.panel[data-panel="' + key + '"]');
+        if (panel && panel.classList.contains("print-include")) order.push(panel);
+      });
+    });
+    parkInSheets(order);
 
     document.documentElement.classList.add("printing");
     remember(function () { document.documentElement.classList.remove("printing"); });

--- a/rust/bigip-report-gen/frontend/src/pages/print.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/print.ts
@@ -46,6 +46,11 @@
     var name = (t && t.textContent.trim()) || dev.getAttribute("data-name") || "";
     return name || "Device " + (i + 1);
   }
+  // Interactive tools rather than report content: the query console prints as an
+  // empty prompt and the listener matcher as an empty form. Neither is offered
+  // in the dialog, and print.css hides them for the raw Ctrl-P path too.
+  var TOOLS = { console: true, listener: true };
+
   // Union of sections (data-panel) across all devices, first-seen order, with a
   // human label taken from the tab text (minus its count badge).
   var sections = [];
@@ -53,7 +58,7 @@
   devices.forEach(function (dev) {
     dev.querySelectorAll(".tabs .tab[data-panel]").forEach(function (tab) {
       var key = tab.dataset.panel;
-      if (seen[key]) return;
+      if (seen[key] || TOOLS[key]) return;
       seen[key] = true;
       var label = tab.cloneNode(true);
       var n = label.querySelector(".n"); if (n) n.remove();
@@ -209,9 +214,46 @@
     });
 
     applyIruleOptions(deviceEls, doFmt, doDiag).then(function () {
-      // wait for async Mermaid renders to settle, then mark + print
-      setTimeout(function () { markAndPrint(deviceEls, secs); }, 700);
+      whenDrawn(deviceEls, secs, function () { markAndPrint(deviceEls, secs); });
     });
+  }
+
+  // The topology / apps / architecture diagrams are laid out asynchronously, and
+  // on a large estate that takes well past the fixed delay this used to allow —
+  // printing early gave pages with an empty diagram box on them. Wait for the
+  // panels being printed to actually have their <svg>, and cap the wait so a
+  // host that legitimately never draws one ("no linked objects") can't hang the
+  // print run.
+  function whenDrawn(deviceEls, secs, done) {
+    var deadline = Date.now() + 8000;
+    (function poll() {
+      var undrawn = 0;
+      deviceEls.forEach(function (dev) {
+        secs.forEach(function (key) {
+          var panel = dev.querySelector('.panel[data-panel="' + key + '"]');
+          if (!panel) return;
+          panel.querySelectorAll(".diag-host").forEach(function (host) {
+            if (!host.querySelector("svg") && !host.textContent.trim()) undrawn++;
+          });
+        });
+      });
+      if (!undrawn || Date.now() > deadline) { done(); return; }
+      setTimeout(poll, 150);
+    })();
+  }
+
+  // An empty section still costs a sheet of paper: its own forced page, a
+  // heading, and nothing under it. A device with no monitors should simply not
+  // have a Monitors page. Judged on the tab's count badge where it has one, and
+  // otherwise on whether the panel drew anything at all.
+  function isEmptySection(dev, key) {
+    var tab = dev.querySelector('.tab[data-panel="' + key + '"]');
+    var badge = tab && tab.querySelector(".n");
+    if (badge && /^\s*0\s*$/.test(badge.textContent)) return true;
+    var panel = dev.querySelector('.panel[data-panel="' + key + '"]');
+    if (!panel) return true;
+    if (panel.querySelector("tbody tr, svg, pre, .card, .cert-row, .app-detail")) return false;
+    return !panel.textContent.trim();
   }
 
   // ---- Running head/foot on every printed page --------------------------
@@ -225,16 +267,28 @@
   // in the template are the (hidden) source of that markup.
   function parkInSheet(nodes) {
     if (!nodes.length) return;
-    var head = document.querySelector(".print-running-head");
-    var foot = document.querySelector(".print-running-foot");
     var sheet = document.createElement("table");
     sheet.className = "print-sheet";
     sheet.innerHTML =
-      '<thead class="print-sheet-head"><tr><th>' + ((head && head.innerHTML) || "") + "</th></tr></thead>" +
-      '<tfoot class="print-sheet-foot"><tr><td>' + ((foot && foot.innerHTML) || "") + "</td></tr></tfoot>" +
+      '<thead class="print-sheet-head"><tr><th></th></tr></thead>' +
+      '<tfoot class="print-sheet-foot"><tr><td></td></tr></tfoot>' +
       '<tbody><tr><td class="print-sheet-body"></td></tr></tbody>';
     var cell = sheet.querySelector(".print-sheet-body");
     nodes[0].parentNode.insertBefore(sheet, nodes[0]);
+
+    // The running head/foot are MOVED in, not copied: they carry the project
+    // marks as inline <svg>, and a copy would duplicate every gradient id.
+    [
+      [".print-running-head", "thead th"],
+      [".print-running-foot", "tfoot td"],
+    ].forEach(function (pair) {
+      var el = document.querySelector(pair[0]);
+      if (!el) return;
+      var parent = el.parentNode, next = el.nextSibling;
+      remember(function () { parent.insertBefore(el, next); });
+      sheet.querySelector(pair[1]).appendChild(el);
+    });
+
     nodes.forEach(function (n) {
       var parent = n.parentNode, next = n.nextSibling;
       remember(function () { parent.insertBefore(n, next); });
@@ -285,7 +339,7 @@
       remember(function () { dev.classList.remove("print-include"); });
       secs.forEach(function (key) {
         var panel = dev.querySelector('.panel[data-panel="' + key + '"]');
-        if (!panel) return;
+        if (!panel || isEmptySection(dev, key)) return;
         panel.classList.add("print-include");
         remember(function () { panel.classList.remove("print-include"); });
         // printed section heading

--- a/rust/bigip-report-gen/frontend/src/pages/report.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/report.ts
@@ -149,6 +149,55 @@
     sel.addEventListener("change", apply);
   });
 
+  // --- the mark + title are the way home ------------------------------------
+  // Clicking either returns the report to the view it opened in. The opening
+  // view is *recorded* here rather than assumed, so it stays right if the
+  // default tab ever changes (a report with front-matter opens on that tab, not
+  // on Virtual Servers). A reload would be the other way to do this, but a
+  // report opened from a blob: URL — straight out of the in-browser generator —
+  // cannot be reloaded, and this keeps it working there too.
+  (function brandHome() {
+    var homes = document.querySelectorAll(".brand-home");
+    if (!homes.length) return;
+
+    var openDevice = document.querySelector(".dev-tab.active");
+    var openTabs = [];
+    document.querySelectorAll("article.device[data-dev]").forEach(function (dev) {
+      openTabs.push({ dev: dev, tab: dev.querySelector(".tab.active") });
+    });
+
+    function reset(ev) {
+      if (ev) ev.preventDefault();
+      // the device that was showing, and the tab each device was showing
+      if (openDevice) openDevice.click();
+      openTabs.forEach(function (o) { if (o.tab) o.tab.click(); });
+      // filters and drilldowns: search, partition, system rows, expanded rows
+      var search = document.getElementById("globalSearch");
+      if (search && search.value) {
+        search.value = "";
+        search.dispatchEvent(new Event("input", { bubbles: true }));
+      }
+      document.querySelectorAll(".partition-filter").forEach(function (sel) {
+        if (sel.selectedIndex !== 0) {
+          sel.selectedIndex = 0;
+          sel.dispatchEvent(new Event("change", { bubbles: true }));
+        }
+      });
+      document.querySelectorAll("article.device.show-system-on").forEach(function (d) {
+        d.classList.remove("show-system-on");
+      });
+      document.querySelectorAll("tr.expandable.open, tr.detail.open").forEach(function (r) {
+        r.classList.remove("open");
+      });
+      // any open object drawer, and back to the top
+      var close = document.querySelector("#objDrawer .drawer-close");
+      if (close && document.getElementById("objDrawer").classList.contains("open")) close.click();
+      window.scrollTo({ top: 0, behavior: "smooth" });
+    }
+
+    homes.forEach(function (a) { a.addEventListener("click", reset); });
+  })();
+
   // --- expandable rows (pool members, iRule bodies, data-group records) -----
   document.querySelectorAll("tr.expandable").forEach(function (row) {
     var detail = row.nextElementSibling;

--- a/rust/bigip-report-gen/frontend/src/styles/print.css
+++ b/rust/bigip-report-gen/frontend/src/styles/print.css
@@ -29,6 +29,10 @@
    * those too — blanking the diagram. */
   .printing article.device { display: none !important; }
   .printing article.device.print-include { display: block !important; }
+  /* Interactive tools, never report content — they print as an empty prompt and
+     an empty form. print.ts drops them from the dialog; this covers the raw
+     Ctrl-P path, where whichever tab is open would otherwise print. */
+  .panel[data-panel="console"], .panel[data-panel="listener"] { display: none !important; }
   .printing .panel { display: none !important; }
   .printing .panel.print-include { display: block !important; }
   /* Detail rows the user chose to include must be expanded. */
@@ -54,10 +58,39 @@
    * `table.print-sheet` and copies the running head/foot into its thead/tfoot;
    * the source elements stay hidden. The head carries the document title, the
    * foot the attribution + version + git build hash + copyright notice. */
+  /* Only ever shown once print.ts has moved them into the sheet. */
   .print-running-head, .print-running-foot { display: none !important; }
+  .print-sheet-head .print-running-head,
+  .print-sheet-foot .print-running-foot {
+    display: flex !important;
+    align-items: center;
+    gap: 7px;
+    min-width: 0;
+  }
+  .print-sheet-foot .print-running-foot { justify-content: center; }
+  /* The marks ride the running head/foot, so every printed page is branded.
+     Forced colour-adjust: without it a browser drops them as "backgrounds". */
+  .print-mark { display: inline-flex; align-items: center; gap: 5px; flex: none; }
+  .print-mark svg, .print-mark img {
+    display: block;
+    width: auto;
+    -webkit-print-color-adjust: exact;
+    print-color-adjust: exact;
+  }
+  .print-sheet-head .print-mark svg, .print-sheet-head .print-mark img { height: 17px; }
+  .print-sheet-foot .print-mark svg { height: 13px; }
+  .print-run-title { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 
   .print-sheet { width: 100%; border-collapse: collapse; table-layout: fixed; }
   .print-sheet-body { padding: 0; vertical-align: top; }
+  /* The sheet's own row holds the entire report, so it must be free to break —
+     the blanket `tr { break-inside: avoid }` below would otherwise ask the
+     browser to keep the whole document on a single page. */
+  .print-sheet > thead > tr, .print-sheet > tbody > tr, .print-sheet > tfoot > tr,
+  .print-sheet > tbody > tr > td {
+    break-inside: auto !important;
+    page-break-inside: auto !important;
+  }
   .print-sheet-head th, .print-sheet-foot td {
     font-family: var(--sans, system-ui, sans-serif);
     color: #555;

--- a/rust/bigip-report-gen/frontend/src/styles/print.css
+++ b/rust/bigip-report-gen/frontend/src/styles/print.css
@@ -81,7 +81,10 @@
   .print-sheet-foot .print-mark svg { height: 13px; }
   .print-run-title { overflow: hidden; white-space: nowrap; text-overflow: ellipsis; }
 
-  .print-sheet { width: 100%; border-collapse: collapse; table-layout: fixed; }
+  /* min-height, so a short section's sheet still fills the page and its tfoot is
+     pushed to the foot of the paper instead of floating under the content. A
+     table shorter than the page would otherwise end wherever its rows end. */
+  .print-sheet { width: 100%; min-height: 100vh; border-collapse: collapse; table-layout: fixed; }
   .print-sheet-body { padding: 0; vertical-align: top; }
   /* The sheet's own row holds the entire report, so it must be free to break —
      the blanket `tr { break-inside: avoid }` below would otherwise ask the
@@ -117,21 +120,25 @@
   .foot { display: none !important; }
 
   /* ---- Page structure: a section per page, with a printed heading ----- */
-  .panel.print-include,
-  article.device.print-include,
-  .architecture.print-include {
+  /* The break lives on the sheet, at block level *between* the tables — never
+     inside a cell, which is where Gecko falls apart (it emitted a page, then 20
+     blank ones, for a forced break inside a cell). One sheet, one section, one
+     fresh page; the first must not push a leading blank page. */
+  .print-sheet {
     break-before: page;
     page-break-before: always;
   }
-  /* the first printed panel of the run must not push a leading blank page */
-  article.device.print-include > .panel.print-include:first-of-type {
+  .print-host > .print-sheet:first-child {
     break-before: auto;
     page-break-before: avoid;
   }
-  /* …nor whatever leads the sheet (the architecture view, or the first device) */
-  .print-sheet-body > :first-child {
-    break-before: auto !important;
-    page-break-before: avoid !important;
+  /* Nothing may trail the last sheet: any leftover margin or padding past it
+     spills onto one more sheet of paper, which prints as a wholly blank page. */
+  html, body, .print-host { margin: 0 !important; padding: 0 !important; }
+  .print-sheet { margin: 0; }
+  .print-host > .print-sheet:last-child {
+    break-after: avoid;
+    page-break-after: avoid;
   }
 
   /* ---- Architecture: its own page, diagram + the manifest that defined it -- */

--- a/rust/bigip-report-gen/frontend/src/styles/report.css
+++ b/rust/bigip-report-gen/frontend/src/styles/report.css
@@ -54,15 +54,25 @@ code{font-family:var(--mono)}
 .topbar{position:sticky;top:0;z-index:20;display:flex;align-items:center;justify-content:space-between;
   gap:16px;padding:12px 22px;background:var(--panel);border-bottom:1px solid var(--line)}
 .brand{display:flex;align-items:center;gap:14px}
-.logo{display:grid;place-items:center;width:38px;height:38px;border-radius:10px;
-  background:linear-gradient(135deg,var(--accent),var(--blue));color:#fff;font-size:20px}
+/* The mark and the title are the way back to the report's opening view — a link,
+   but it should read as the brand, not as link text. */
+.brand-home{display:inline-flex;color:inherit;text-decoration:none;border-radius:10px}
+.brand-home:focus-visible{outline:2px solid var(--accent,#2563eb);outline-offset:2px}
+.topbar h1 .brand-home:hover{text-decoration:underline}
+/* 58px is the height of the text stack beside it — the title, the meta line and
+ * the attribution — so the mark squares off the whole brand block rather than
+ * floating against it. Sized in px, not stretched to the sibling: flex resolves
+ * an item's width from its content before the stretched height is known, so a
+ * square that takes its width from its height cannot be expressed that way. */
+.logo{display:grid;place-items:center;width:58px;height:58px;border-radius:10px;
+  background:linear-gradient(135deg,var(--accent),var(--blue));color:#fff;font-size:26px}
 /* User-supplied report logo (inlined data-URI): show at its aspect ratio, no
  * gradient background. Capped so a wide wordmark or tall badge both fit. */
-.logo-custom{background:none;width:auto;height:38px;max-width:160px;object-fit:contain;border-radius:6px}
+.logo-custom{background:none;width:auto;height:58px;max-width:220px;object-fit:contain;border-radius:6px}
 /* Fallback when no report logo was supplied: the f5-query squircle, inlined as
  * <svg>. It brings its own rounded background, so drop the gradient tile. */
 .logo-mark{background:none;border-radius:0}
-.logo-mark svg{display:block;width:38px;height:38px}
+.logo-mark svg{display:block;width:58px;height:58px}
 .topbar h1{font-size:17px}
 .sub{margin:2px 0 0;color:var(--muted);font-size:12px}
 .topbar-actions{display:flex;align-items:center;gap:10px}
@@ -268,7 +278,7 @@ pre.code.tcl .diag.flash{background:rgba(191,135,0,.25);border-radius:3px}
 /* The marks lead the footer, centred above the attribution text. */
 .foot-logos{display:flex;gap:18px;align-items:center;justify-content:center;margin:0 0 12px;color:var(--muted)}
 .foot-logo{display:inline-flex;align-items:center;color:inherit;opacity:.85;transition:opacity .12s}
-.foot-logo svg{display:block;height:24px;width:auto}
+.foot-logo svg{display:block;height:36px;width:auto}
 a.foot-logo{text-decoration:none}
 a.foot-logo:hover,a.foot-logo:focus-visible{opacity:1;outline:none}
 /* The tcl-lsp mark ships a light and a dark squircle and the report emits both;

--- a/rust/bigip-report-gen/rust/tests/report.rs
+++ b/rust/bigip-report-gen/rust/tests/report.rs
@@ -217,6 +217,24 @@ fn build_report_html_self_contained() {
     assert!(!html.contains("<link "), "no external stylesheet links");
     // The wasm console + embedded config are present.
     assert!(html.contains("id=\"f5-wasm\""), "wasm blob embedded");
+    // …and the blob must still be *decodable*. The template autoescapes by
+    // default, which rewrites every `/` in the base64 as `&#x2f;`; `atob()` then
+    // throws on load and the console, the iRule Format button and
+    // print-with-diagnostics all die silently. Assert the payload is base64.
+    let payload = html
+        .split_once("id=\"f5-wasm\" type=\"application/octet-stream\">")
+        .expect("wasm script tag")
+        .1
+        .split_once("</script>")
+        .expect("closing tag")
+        .0;
+    assert!(
+        !payload.is_empty()
+            && payload
+                .bytes()
+                .all(|b| b.is_ascii_alphanumeric() || matches!(b, b'+' | b'/' | b'=')),
+        "wasm payload must be raw base64 — no HTML-escaped characters"
+    );
     assert!(html.contains("data-panel=\"console\""), "console panel");
     assert!(html.contains("wasm_bindgen"), "wasm glue");
     assert!(

--- a/rust/bigip-report-gen/templates/report.html.j2
+++ b/rust/bigip-report-gen/templates/report.html.j2
@@ -26,9 +26,14 @@
        inlines the same mark, and ids are document-global, so this copy's ids
        (all of them `f5q-…`, along with every url(#…) that points at them) are
        re-prefixed — two copies of `f5q-a` would be a duplicate id. #}
-    {% if logo %}<img class="logo logo-custom" src="{{ logo }}" alt="Report logo">{% else %}<span class="logo logo-mark" role="img" aria-label="f5-query">{{ logo_f5q_svg | replace("f5q-", "hdrf5q-") | safe }}</span>{% endif %}
+    {# The mark and the title are the way back: clicking either returns the
+       report to the view it opened in (report.js). Screen only — the topbar is
+       not printed, and the running head that is carries no link. #}
+    <a class="brand-home" href="#" title="Back to the report's opening view">
+      {% if logo %}<img class="logo logo-custom" src="{{ logo }}" alt="Report logo">{% else %}<span class="logo logo-mark" role="img" aria-label="f5-query">{{ logo_f5q_svg | replace("f5q-", "hdrf5q-") | safe }}</span>{% endif %}
+    </a>
     <div>
-      <h1>{{ title }}</h1>
+      <h1><a class="brand-home" href="#" title="Back to the report's opening view">{{ title }}</a></h1>
       <p class="sub">
         Generated {{ generated_at }} ·
         {{ devices|length }} device{{ 's' if devices|length != 1 else '' }} ·
@@ -986,9 +991,19 @@
   <p class="print-only attrib">{% if copyright %}{{ copyright }} — {% endif %}BIG-IP Report Generator, tcl-lsp &amp; f5-query by © 2026 bitwisecook — https://github.com/bitwisecook/tcl-lsp</p>
 </footer>
 
-<!-- Print-only running header/footer, repeated on every printed page (see print.css). -->
-<div class="print-running-head" aria-hidden="true">{{ title }}</div>
-<div class="print-running-foot" aria-hidden="true">{% if copyright %}{{ copyright }} · {% endif %}BIG-IP Report Generator, tcl-lsp &amp; f5-query by © 2026 bitwisecook · version {{ version }} · https://github.com/bitwisecook/tcl-lsp</div>
+{# Print-only running header/footer, repeated on every printed page: print.ts
+   moves these two into the thead/tfoot of the print sheet (see print.css).
+   They carry the marks as well as the text, so every printed page is branded.
+   The ids are re-prefixed because the on-screen header/footer already inline
+   the same SVGs and ids are document-global. #}
+<div class="print-running-head" aria-hidden="true">
+  <span class="print-mark">{% if logo %}<img src="{{ logo }}" alt="">{% else %}{{ logo_f5q_svg | replace("f5q-", "prnh-") | safe }}{% endif %}</span>
+  <span class="print-run-title">{{ title }}</span>
+</div>
+<div class="print-running-foot" aria-hidden="true">
+  <span class="print-mark">{{ logo_f5q_svg | replace("f5q-", "prnf-") | safe }}{{ logo_tcl_lsp_svg | replace("tcl-", "prnt-") | safe }}</span>
+  <span class="print-run-text">{% if copyright %}{{ copyright }} · {% endif %}BIG-IP Report Generator, tcl-lsp &amp; f5-query by © 2026 bitwisecook · version {{ version }} · https://github.com/bitwisecook/tcl-lsp</span>
+</div>
 
 <script>
 {{ report_js | safe }}
@@ -1023,7 +1038,11 @@
 </script>
 {% if has_console %}
 <!-- in-browser query engine: wasm-bindgen glue + base64 wasm (the f5-query DSL compiled to WebAssembly) -->
-<script id="f5-wasm" type="application/octet-stream">{{ wasm_b64 }}</script>
+{# `safe`: base64 is A–Za–z0–9+/= — no HTML-special character, so nothing to
+   escape and nothing to inject. Without it autoescape rewrites every `/` as
+   `&#x2f;`, and `atob()` then throws on the payload: the console, the iRule
+   Format button and print-with-diagnostics all die on page load. #}
+<script id="f5-wasm" type="application/octet-stream">{{ wasm_b64 | safe }}</script>
 <script>{{ wasm_glue | safe }}</script>
 <script>
 {{ console_js | safe }}


### PR DESCRIPTION
Follow-ups from testing #907 against a real estate report. Three of these are bugs that were **already shipping**, not regressions from that PR.

## The embedded wasm never loaded (pre-existing)

`{{ wasm_b64 }}` was the one inlined asset without `| safe`, so autoescape rewrote every `/` in the base64 as `&#x2f;` and `atob()` threw on page load. The in-report **f5-query console**, the **iRule Format** button and **print-with-diagnostics** were all dead on arrival — ticking "Format iRule code" in the print dialog threw *before* `window.print()`, which is why the browser's print dialog never opened.

Base64 has no HTML-special character, so there is nothing to escape and nothing to inject. A test now asserts the payload is raw base64, because the failure is silent until runtime.

## Firefox printed 70 pages, 22 of them blank

The running head/foot ride in a table's `thead`/`tfoot` — the only construct a browser repeats per page *and* reserves room for. But parking the whole report in **one** such table put every forced section break inside a single table cell, which is the case Gecko gets badly wrong. Chrome printed the same file correctly, which is how it got through.

Each section now gets its own sheet, all siblings at top level, so the forced breaks fall *between* tables at block level. Verified by printing the same report through **headless Firefox and headless Chrome**:

| | before | after |
| --- | --- | --- |
| Firefox | 70 pages, 22 blank | 39 pages, **0 blank** |
| Chrome | 47 pages, 0 blank | 41 pages, **0 blank** |

Running head and footer on every page in both; every section starts at the top of a page; the sheet fills the page so a short section's footer sits at the foot of the paper rather than floating under the content.

## The rest of the printout

- **Blank pages of our own making**: an empty section still claimed a sheet of paper (a device with no monitors printed a Monitors page with a heading and nothing under it), and on a large estate the asynchronously-laid-out diagrams had not finished drawing within the fixed 700ms the print run waited, so their panels printed as empty boxes. Empty sections are skipped; the run now waits for the diagrams it is about to print (bounded).
- **The query console and listener matcher are tools, not report content** — they printed as an empty prompt and an empty form. Dropped from the print dialog, and hidden for the raw Ctrl-P path.
- **The marks now ride the running head and foot**, so every printed page is branded.

## Header

The marks are 1.5× larger — 58px in the header (the height of the title/meta/attribution stack beside it) and 36px in the footer. The mark and the title are now the way back: clicking either returns the report to the view it opened in (device, tab, search, filters, expanded rows, drawer, scroll). The opening view is recorded at load rather than assumed, and a reload would not do — a report opened straight from the in-browser generator lives on a `blob:` URL.

## Release skill

Also folds in the release-skill fix: it hard-failed unless on `main`, but 2.x pre-releases are cut from `rust` (`main` does not contain v2.1.7). It now picks the branch from the version being cut, and approves the two protected marketplace Environments with `gh` from the release laptop instead of telling you to click through the Actions UI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)