### PR TITLE
Report generator: fix silent upload fallback, enforce no-network self-containment

### DIFF
--- a/rust/bigip-report-gen/frontend/dist/input.js
+++ b/rust/bigip-report-gen/frontend/dist/input.js
@@ -141,15 +141,45 @@
       return r.ok ? r.text() : "";
     }
   };
+  var UnavailableBackend = class {
+    constructor(reason) {
+      this.reason = reason;
+    }
+    fail() {
+      return Promise.reject(new Error(this.reason));
+    }
+    ready() {
+      return this.fail();
+    }
+    engineVersion() {
+      return this.fail();
+    }
+    probe() {
+      return this.fail();
+    }
+    generate() {
+      return this.fail();
+    }
+    buildArchitecture() {
+      return this.fail();
+    }
+    manual() {
+      return this.fail();
+    }
+  };
   function selectBackend() {
-    const w = window;
     const payload = document.getElementById("report-wasm");
-    if (typeof w.wasm_bindgen === "function" && payload && payload.textContent) {
-      const b64 = payload.textContent.trim();
-      const bin = atob(b64);
+    const inlined = payload && payload.textContent ? payload.textContent.trim() : "";
+    if (inlined) {
+      if (typeof wasm_bindgen !== "function") {
+        return new UnavailableBackend(
+          "the in-browser report engine failed to load \u2014 reload the page (your configuration was not uploaded)"
+        );
+      }
+      const bin = atob(inlined);
       const bytes = new Uint8Array(bin.length);
       for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-      return new WasmBackend(w.wasm_bindgen, bytes);
+      return new WasmBackend(wasm_bindgen, bytes);
     }
     return new ServerBackend("");
   }

--- a/rust/bigip-report-gen/frontend/src/report-backend.ts
+++ b/rust/bigip-report-gen/frontend/src/report-backend.ts
@@ -260,17 +260,67 @@ export class ServerBackend implements ReportBackend {
   }
 }
 
+/** Stand-in for the standalone in-browser app when its inlined wasm generator
+ *  is present on the page but failed to load. It performs NO network I/O: this
+ *  app's whole promise is that the config never leaves the browser, so a broken
+ *  engine must surface an error — never silently fall back to uploading via
+ *  {@link ServerBackend}. Every call rejects with the load reason, so the input
+ *  page reports it and keeps generation disabled. */
+class UnavailableBackend implements ReportBackend {
+  constructor(private reason: string) {}
+  private fail(): Promise<never> {
+    return Promise.reject(new Error(this.reason));
+  }
+  ready(): Promise<void> {
+    return this.fail();
+  }
+  engineVersion(): Promise<string> {
+    return this.fail();
+  }
+  probe(): Promise<ProbeResult> {
+    return this.fail();
+  }
+  generate(): Promise<GenerateResult> {
+    return this.fail();
+  }
+  buildArchitecture(): Promise<string> {
+    return this.fail();
+  }
+  manual(): Promise<string> {
+    return this.fail();
+  }
+}
+
+// The `no-modules` wasm-bindgen glue the standalone app inlines *ahead* of this
+// bundle declares its init function with a top-level `let wasm_bindgen = …`. A
+// top-level `let` is a global *lexical* binding: reachable as a bare identifier
+// from later classic scripts (as here), but — unlike `var`/`function` — NOT a
+// property of `window`/`globalThis`, so `window.wasm_bindgen` is always
+// `undefined`. It must be read as a bare identifier. Declared optional so the
+// `typeof` guard type-checks; `typeof` also keeps the bare reference from
+// throwing on the server page, where the glue (and this binding) are absent.
+declare const wasm_bindgen: WasmBindgen | undefined;
+
 /** Pick the backend for the current page: the inlined wasm generator when it's
  *  present (the standalone in-browser app), else the server. */
 export function selectBackend(): ReportBackend {
-  const w = window as unknown as { wasm_bindgen?: WasmBindgen };
   const payload = document.getElementById("report-wasm");
-  if (typeof w.wasm_bindgen === "function" && payload && payload.textContent) {
-    const b64 = payload.textContent.trim();
-    const bin = atob(b64);
+  const inlined = payload && payload.textContent ? payload.textContent.trim() : "";
+  // A `#report-wasm` payload means THIS is the standalone in-browser app, so the
+  // whole pipeline runs client-side and nothing is ever uploaded. In that case
+  // we must use the wasm backend — and if its glue didn't load, fail loudly
+  // rather than fall through to the uploading server backend below.
+  if (inlined) {
+    if (typeof wasm_bindgen !== "function") {
+      return new UnavailableBackend(
+        "the in-browser report engine failed to load — reload the page (your configuration was not uploaded)",
+      );
+    }
+    const bin = atob(inlined);
     const bytes = new Uint8Array(bin.length);
     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-    return new WasmBackend(w.wasm_bindgen, bytes);
+    return new WasmBackend(wasm_bindgen, bytes);
   }
+  // No inlined payload → the f5report web server page: generate server-side.
   return new ServerBackend("");
 }

--- a/rust/bigip-report-gen/python/python/f5report/web.py
+++ b/rust/bigip-report-gen/python/python/f5report/web.py
@@ -53,6 +53,16 @@ def _input_page() -> str:
     )
     css = resources.files("f5report.templates").joinpath("input.css").read_text("utf-8")
     js = resources.files("f5report.templates").joinpath("input.js").read_text("utf-8")
+    # Same self-contained CSP as the standalone app and the generated report,
+    # but `connect-src 'self'` (not 'none'): this page's ServerBackend POSTs the
+    # config to this same server's /probe and /generate. No external origin is
+    # ever reachable, so nothing is uploaded off-box.
+    csp = (
+        "default-src 'none'; script-src 'unsafe-inline' 'wasm-unsafe-eval'; "
+        "style-src 'unsafe-inline'; img-src data: blob:; connect-src 'self'; "
+        "base-uri 'none'; form-action 'none'"
+    )
+    tmpl = tmpl.replace("__CSP__", csp)
     tmpl = tmpl.replace("__STYLES__", f"<style>{css}</style>")
     tmpl = tmpl.replace("__WASM_PAYLOAD__", "")  # no wasm → the page uses ServerBackend
     tmpl = tmpl.replace("__INPUT_JS__", f"<script>{js}</script>")

--- a/rust/bigip-report-gen/python/tests/test_report.py
+++ b/rust/bigip-report-gen/python/tests/test_report.py
@@ -139,6 +139,11 @@ def test_build_report_html_self_contained():
     assert 'src="http' not in html
     assert "<link " not in html
     assert "cdn." not in html.split('<script id="f5-model"')[0]
+    # …and enforced in the browser: a CSP that forbids ALL network egress
+    # (connect-src 'none'), so the config a report carries can never be phoned
+    # home even if a future change or injected data tried to.
+    assert "Content-Security-Policy" in html
+    assert "connect-src 'none'" in html
 
 
 def test_wasm_console_embedded_when_vendored():

--- a/rust/bigip-report-gen/python/tests/test_web.py
+++ b/rust/bigip-report-gen/python/tests/test_web.py
@@ -32,7 +32,13 @@ def _get(url: str) -> str:
 
 
 def test_builder_page_and_version(server):
-    assert "selectBackend" in _get(server + "/")  # the shared input controller
+    page = _get(server + "/")
+    assert "selectBackend" in page  # the shared input controller
+    # The __CSP__ placeholder is substituted, and the server page's policy allows
+    # only same-origin connections (its ServerBackend POSTs to /generate) — never
+    # an external origin, and never a leftover unsubstituted placeholder.
+    assert "__CSP__" not in page
+    assert "Content-Security-Policy" in page and "connect-src 'self'" in page
     assert _get(server + "/version").strip()  # engine version string
     assert "F5 QUERY DSL" in _get(server + "/manual")  # embedded manual
 

--- a/rust/bigip-report-gen/rust/tests/report.rs
+++ b/rust/bigip-report-gen/rust/tests/report.rs
@@ -215,6 +215,13 @@ fn build_report_html_self_contained() {
     // fine — they are user-initiated navigation, not loaded to run the report.
     assert!(!html.contains("src=\"http"), "no remote script/image src");
     assert!(!html.contains("<link "), "no external stylesheet links");
+    // …and enforced in the browser: a CSP that forbids ALL network egress
+    // (connect-src 'none'), so the config a report carries can never be phoned
+    // home even if a future change or injected data tried to.
+    assert!(
+        html.contains("Content-Security-Policy") && html.contains("connect-src 'none'"),
+        "report carries a no-network CSP"
+    );
     // The wasm console + embedded config are present.
     assert!(html.contains("id=\"f5-wasm\""), "wasm blob embedded");
     // …and the blob must still be *decodable*. The template autoescapes by

--- a/rust/bigip-report-gen/templates/input.html
+++ b/rust/bigip-report-gen/templates/input.html
@@ -8,6 +8,13 @@
 <html lang="en" data-theme="auto">
 <head>
 <meta charset="utf-8">
+<!-- Content-Security-Policy, substituted per backend (see build-wasm.sh /
+     web.py). The in-browser app is fully self-contained and gets `connect-src
+     'none'` so it can NEVER make a network request — the config never leaves the
+     browser; the f5report server page gets `connect-src 'self'` so its
+     ServerBackend can reach its own /probe and /generate. Either way no external
+     origin is reachable. -->
+<meta http-equiv="Content-Security-Policy" content="__CSP__">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="referrer" content="no-referrer">
 <title>F5 BIG-IP Report Generator</title>

--- a/rust/bigip-report-gen/templates/report.html.j2
+++ b/rust/bigip-report-gen/templates/report.html.j2
@@ -3,6 +3,14 @@
 <html lang="en" data-theme="auto" data-generator="bitwisecook-bigip-report-generator" data-generator-url="https://github.com/bitwisecook" data-report-id="{{ report_id }}">
 <head>
 <meta charset="utf-8">
+<!-- The report is fully self-contained — every asset is inlined and it makes NO
+     network requests. This CSP enforces that in the browser: it permits the
+     inlined machinery (inline scripts/styles, the wasm f5-query console, data/
+     blob images and blob downloads) but forbids all network egress, so the
+     config a report carries can never be phoned home even if a future change
+     (or injected data) tried to. `connect-src 'none'` blocks fetch/XHR/
+     WebSocket/beacon; `img-src data: blob:` blocks image-beacon exfiltration. -->
+<meta http-equiv="Content-Security-Policy" content="default-src 'none'; script-src 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none'; base-uri 'none'; form-action 'none'">
 <meta name="viewport" content="width=device-width, initial-scale=1">
 <meta name="generator" content="bitwisecook BIG-IP Report Generator & f5-query — https://github.com/bitwisecook">
 <meta name="author" content="bitwisecook (https://github.com/bitwisecook)">

--- a/rust/bigip-report-gen/wasm/build-wasm.sh
+++ b/rust/bigip-report-gen/wasm/build-wasm.sh
@@ -81,15 +81,27 @@ LOGOS = {
     "__LOGO_TCL_LSP__": "logo-tcl-lsp.svg",
     "__LOGO_TCL_LSP_DARK__": "logo-tcl-lsp-dark.svg",
 }
+# The standalone in-browser app is fully self-contained: forbid ALL network
+# egress so nothing it reads can ever be uploaded (`connect-src 'none'`). The
+# allowances cover only the inlined machinery — inline scripts/styles, wasm
+# instantiation, data/blob images and blob downloads. Mirrors the CSP baked into
+# the generated report; the f5report server page instead uses `connect-src
+# 'self'` (see web.py), the only difference.
+CSP = (
+    "default-src 'none'; script-src 'unsafe-inline' 'wasm-unsafe-eval'; "
+    "style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none'; "
+    "base-uri 'none'; form-action 'none'"
+)
 # str.replace is a literal replace (not regex), so backslashes/ampersands in the
 # payload are safe.
+tmpl = tmpl.replace("__CSP__", CSP)
 tmpl = tmpl.replace("__STYLES__", "<style>" + css + "</style>")
 tmpl = tmpl.replace("__WASM_PAYLOAD__", payload)
 tmpl = tmpl.replace("__INPUT_JS__", "<script>" + js + "</script>")
 for tok, name in LOGOS.items():
     mark = open(os.path.join(assets_dir, name), encoding="utf-8").read()
     tmpl = tmpl.replace(tok, mark)
-for tok in ("__STYLES__", "__WASM_PAYLOAD__", "__INPUT_JS__", *LOGOS):
+for tok in ("__CSP__", "__STYLES__", "__WASM_PAYLOAD__", "__INPUT_JS__", *LOGOS):
     if tok in tmpl:
         raise SystemExit(f"placeholder {tok} substitution failed")
 open(out_path, "w", encoding="utf-8").write(tmpl)


### PR DESCRIPTION
## Summary

- **Fix the in-browser generator silently uploading configs (the `405 Not Allowed` / "no longer completely local" report).** `selectBackend()` detected the inlined wasm engine via `window.wasm_bindgen`, but the `no-modules` wasm-bindgen glue declares its init function with a top-level `let wasm_bindgen = …`. A top-level `let` is a global *lexical* binding — reachable as a bare identifier but **not** a property of `window`/`globalThis` — so `window.wasm_bindgen` was always `undefined` and the code silently fell through to the uploading `ServerBackend`. On GitHub Pages (static hosting) that POST surfaced as `405`; everywhere it broke the "nothing is uploaded" guarantee. Now it reads the bare `wasm_bindgen` global (the way the compiler-explorer worker already does). Hardened so that when the `#report-wasm` payload is present but the glue fails to load, it fails loudly via a non-networking `UnavailableBackend` rather than falling back to upload.
- **Enforce self-containment with a no-network CSP** so "everything runs in your browser, nothing is uploaded" is enforced by the browser, not just a property we try to preserve. Both self-contained artifacts — the generated report and the standalone in-browser generator — now carry `default-src 'none'; script-src 'unsafe-inline' 'wasm-unsafe-eval'; style-src 'unsafe-inline'; img-src data: blob:; connect-src 'none'; base-uri 'none'; form-action 'none'`. `connect-src 'none'` blocks fetch/XHR/WebSocket/beacon; `img-src data: blob:` blocks image-beacon exfiltration. The allowances cover only the inlined machinery (inline scripts/styles, wasm instantiation, data/blob images, blob downloads).
- The **f5report web-server** page — the one place server-side generation is by design — gets the same policy with `connect-src 'self'` (its `ServerBackend` POSTs to its own `/probe` and `/generate`); still no external origin is reachable. The policy is substituted into the `__CSP__` placeholder by `build-wasm.sh` (app) and `web.py` (server); the report template carries the strict policy directly.

Rebased onto the latest `rust` (on top of the logo-squircle unification, #912).

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

- `cd rust/bigip-report-gen/frontend && npx tsc --noEmit -p tsconfig.json && node build.mjs` — front-end typechecks and builds; emitted `dist/input.js` references the bare `wasm_bindgen` global.
- `cd rust/bigip-report-gen/rust && cargo +1.97.0 test --test report self_contained` → `build_report_html_self_contained ... ok` (the env's default rustc 1.94 is older than the pinned 1.97, so I installed 1.97 to build). Test now also asserts the report carries `connect-src 'none'`.
- Headless-Chromium verification of the exact CSP: inline scripts/styles apply, wasm instantiates (`'wasm-unsafe-eval'`), `createObjectURL` blob downloads work, and a **real ELK diagram layout** (`elk.bundled.js`) runs main-thread with **zero** CSP violations — while external `fetch` and external `<img>` are both blocked. Also empirically confirmed `window.wasm_bindgen` is `undefined` while bare `wasm_bindgen` resolves, and that the bare `typeof` guard is safe on the server page (no glue).
- Replayed both `input.html` substitution paths: the standalone app resolves to `connect-src 'none'`, the server page to `connect-src 'self'`, with no leftover `__CSP__` placeholder in either.

Not run locally (require the pinned toolchain + maturin, unavailable here; covered in CI): the Python `f5report` test suite — the assertions I added (`test_report.py`, `test_web.py`) mirror the passing Rust test against the same shared template.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **No** — the change is confined to the BIG-IP report generator front-end (`report-backend.ts`), its templates (`report.html.j2`, `input.html`), the wasm/server build glue, and their tests. No compiler behaviour, diagnostics, or analysis contract is touched.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A
- [ ] If I added a new compiler KCS note, I linked it from both … — N/A

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NWov4NG27HNnqH8kZx9bHm

---
_Generated by [Claude Code](https://claude.ai/code/session_01NWov4NG27HNnqH8kZx9bHm)_