### PR TITLE
fix(report): wasm dies on blob: URLs — no Print button, no Cmd-P, no console; add a print progress toast

### DIFF
--- a/rust/bigip-report-gen/frontend/dist/console.js
+++ b/rust/bigip-report-gen/frontend/dist/console.js
@@ -6,7 +6,13 @@
   (function() {
     "use strict";
     var modelEl = document.getElementById("f5-model");
-    if (!modelEl || typeof wasm_bindgen === "undefined") return;
+    var wasmReady = false;
+    try {
+      wasmReady = typeof wasm_bindgen !== "undefined";
+    } catch (_e) {
+      wasmReady = false;
+    }
+    if (!modelEl || !wasmReady) return;
     var MODEL = JSON.parse(modelEl.textContent);
     var B64 = document.getElementById("f5-wasm").textContent.trim();
     function b64ToBytes(b64) {

--- a/rust/bigip-report-gen/frontend/dist/input.js
+++ b/rust/bigip-report-gen/frontend/dist/input.js
@@ -171,7 +171,13 @@
     const payload = document.getElementById("report-wasm");
     const inlined = payload && payload.textContent ? payload.textContent.trim() : "";
     if (inlined) {
-      if (typeof wasm_bindgen !== "function") {
+      let wasmFn;
+      try {
+        wasmFn = typeof wasm_bindgen === "function" ? wasm_bindgen : void 0;
+      } catch {
+        wasmFn = void 0;
+      }
+      if (!wasmFn) {
         return new UnavailableBackend(
           "the in-browser report engine failed to load \u2014 reload the page (your configuration was not uploaded)"
         );
@@ -179,7 +185,7 @@
       const bin = atob(inlined);
       const bytes = new Uint8Array(bin.length);
       for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-      return new WasmBackend(wasm_bindgen, bytes);
+      return new WasmBackend(wasmFn, bytes);
     }
     return new ServerBackend("");
   }

--- a/rust/bigip-report-gen/frontend/dist/irule-format.js
+++ b/rust/bigip-report-gen/frontend/dist/irule-format.js
@@ -6,7 +6,13 @@
   (function() {
     "use strict";
     var wasmEl = document.getElementById("f5-wasm");
-    if (!wasmEl || typeof wasm_bindgen === "undefined") return;
+    var wasmReady = false;
+    try {
+      wasmReady = typeof wasm_bindgen !== "undefined";
+    } catch (_e) {
+      wasmReady = false;
+    }
+    if (!wasmEl || !wasmReady) return;
     function initWasm() {
       if (!window.__f5qReady) {
         var b64 = wasmEl.textContent.trim();

--- a/rust/bigip-report-gen/frontend/dist/print.js
+++ b/rust/bigip-report-gen/frontend/dist/print.js
@@ -32,7 +32,13 @@
         sections.push({ key, label: label.textContent.trim() || key });
       });
     });
-    var hasConsole = !!document.getElementById("f5-wasm") && typeof wasm_bindgen !== "undefined";
+    var wasmReady = false;
+    try {
+      wasmReady = typeof wasm_bindgen !== "undefined";
+    } catch (_e) {
+      wasmReady = false;
+    }
+    var hasConsole = !!document.getElementById("f5-wasm") && wasmReady;
     var btn = document.createElement("button");
     btn.id = "printBtn";
     btn.title = "Print / export to PDF";

--- a/rust/bigip-report-gen/frontend/src/pages/console.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/console.ts
@@ -24,7 +24,19 @@
   "use strict";
 
   var modelEl = document.getElementById("f5-model");
-  if (!modelEl || typeof wasm_bindgen === "undefined") return;
+  // A bare `typeof wasm_bindgen` THROWS, it does not return "undefined", when the
+  // glue's `let wasm_bindgen = (function(){…})(…)` initialiser failed and left the
+  // binding in the temporal dead zone (it does `new URL(document.currentScript.src,
+  // …)`, which fails for an inlined <script>). It must stay a bare identifier — a
+  // top-level `let` is not a property of globalThis — so catch instead.
+  // See pages/print.ts for the full story.
+  var wasmReady = false;
+  try {
+    wasmReady = typeof wasm_bindgen !== "undefined";
+  } catch (_e) {
+    wasmReady = false;
+  }
+  if (!modelEl || !wasmReady) return;
   var MODEL = JSON.parse(modelEl.textContent);
 
   var B64 = document.getElementById("f5-wasm").textContent.trim();

--- a/rust/bigip-report-gen/frontend/src/pages/irule-format.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/irule-format.ts
@@ -27,7 +27,19 @@
   "use strict";
 
   var wasmEl = document.getElementById("f5-wasm");
-  if (!wasmEl || typeof wasm_bindgen === "undefined") return;
+  // A bare `typeof wasm_bindgen` THROWS, it does not return "undefined", when the
+  // glue's `let wasm_bindgen = (function(){…})(…)` initialiser failed and left the
+  // binding in the temporal dead zone (it does `new URL(document.currentScript.src,
+  // …)`, which fails for an inlined <script>). It must stay a bare identifier — a
+  // top-level `let` is not a property of globalThis — so catch instead.
+  // See pages/print.ts for the full story.
+  var wasmReady = false;
+  try {
+    wasmReady = typeof wasm_bindgen !== "undefined";
+  } catch (_e) {
+    wasmReady = false;
+  }
+  if (!wasmEl || !wasmReady) return;
 
   // Share one wasm instantiation with the query console (whichever loads first
   // wins) so the module is only initialised once per report.

--- a/rust/bigip-report-gen/frontend/src/pages/print.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/print.ts
@@ -65,7 +65,30 @@
       sections.push({ key: key, label: label.textContent.trim() || key });
     });
   });
-  var hasConsole = !!document.getElementById("f5-wasm") && typeof wasm_bindgen !== "undefined";
+  // `typeof wasm_bindgen` looks safe and is NOT.
+  //
+  // The wasm-bindgen glue is emitted as `let wasm_bindgen = (function(){…})(…)`,
+  // and its first act is `new URL(document.currentScript.src, location.href)` —
+  // which throws `TypeError: Invalid URL` when the glue is inlined into the
+  // report, because an inline <script> has no `src`. The `let` initialiser then
+  // never completes, so the binding sits in the temporal dead zone for the rest
+  // of the page — and `typeof` on a TDZ binding THROWS `ReferenceError` rather
+  // than returning "undefined".
+  //
+  // That killed this entire IIFE at load: no Print button, and Ctrl/Cmd-P never
+  // bound, so it fell through to the browser's own print dialog.
+  //
+  // It has to stay a bare identifier — a top-level `let` is a lexical binding,
+  // not a property of `globalThis`, so `globalThis.wasm_bindgen` is `undefined`
+  // even when the glue loaded fine. So catch instead: TDZ (or absent) → no
+  // console features, but the rest of printing still works.
+  var wasmReady = false;
+  try {
+    wasmReady = typeof wasm_bindgen !== "undefined";
+  } catch (_e) {
+    wasmReady = false; // glue failed; binding trapped in the TDZ
+  }
+  var hasConsole = !!document.getElementById("f5-wasm") && wasmReady;
 
   // ---- Build the Print button + dialog ----------------------------------
   var btn = document.createElement("button");

--- a/rust/bigip-report-gen/frontend/src/report-backend.ts
+++ b/rust/bigip-report-gen/frontend/src/report-backend.ts
@@ -311,7 +311,16 @@ export function selectBackend(): ReportBackend {
   // we must use the wasm backend — and if its glue didn't load, fail loudly
   // rather than fall through to the uploading server backend below.
   if (inlined) {
-    if (typeof wasm_bindgen !== "function") {
+    // A bare `typeof` THROWS (not "undefined") when the glue's `let` initialiser
+    // failed and trapped the binding in the TDZ. It must stay a bare identifier —
+    // a top-level `let` is not a property of globalThis. See pages/print.ts.
+    let wasmFn: WasmBindgen | undefined;
+    try {
+      wasmFn = typeof wasm_bindgen === "function" ? wasm_bindgen : undefined;
+    } catch {
+      wasmFn = undefined;
+    }
+    if (!wasmFn) {
       return new UnavailableBackend(
         "the in-browser report engine failed to load — reload the page (your configuration was not uploaded)",
       );
@@ -319,7 +328,7 @@ export function selectBackend(): ReportBackend {
     const bin = atob(inlined);
     const bytes = new Uint8Array(bin.length);
     for (let i = 0; i < bin.length; i++) bytes[i] = bin.charCodeAt(i);
-    return new WasmBackend(wasm_bindgen, bytes);
+    return new WasmBackend(wasmFn, bytes);
   }
   // No inlined payload → the f5report web server page: generate server-side.
   return new ServerBackend("");


### PR DESCRIPTION
Three commits: the **root cause**, a **defence in depth**, and the **missing print feedback**.

## 1. Root cause — the glue throws on a `blob:` URL

wasm-bindgen's glue opens with:

```js
script_src = new URL(document.currentScript.src, location.href).toString();
```

We **inline** the glue, so `document.currentScript.src` is `""`. And `new URL("", base)` **throws when `base` is a `blob:` URL** — which is exactly what `location.href` is on the hosted app, because the in-browser generator builds the report as a Blob and opens it.

| base | `new URL('', base)` |
|---|---|
| `https://…` | OK |
| `file:///…` | OK |
| **`blob:https://…`** | **throws** |

That's why it works from disk and breaks on GitHub Pages.

Firefox, from a real affected report:

```
TypeError: URL constructor:  is not a valid URL
ReferenceError: can't access lexical declaration 'wasm_bindgen'
                before initialization              ← ×3
```

## 2. Why one failed `new URL` kills the Print button

The glue is `let wasm_bindgen = (function(){…})(…)`. When that initialiser throws, the **`let` never completes**, so `wasm_bindgen` is trapped in the **temporal dead zone** for the whole page.

**`typeof` on a TDZ binding THROWS `ReferenceError`** — it does *not* return `"undefined"`. So `typeof wasm_bindgen !== "undefined"`, the guard written specifically to be safe, is the thing that throws. `print.ts` runs it at IIFE top level, so the module dies **before** creating the Print button or binding Ctrl/Cmd-P — hence the browser's own dialog. `console.ts` and `irule-format.ts` die the same way: that's the three ReferenceErrors.

Both `build-wasm.sh` scripts now wrap the probe in `try/catch` (failing loudly if wasm-bindgen ever changes its glue shape, rather than silently not patching), and the committed `f5query_wasm.js` is patched in place — it's text, so the 8 MB `.wasm` beside it is untouched.

The four `typeof wasm_bindgen` guards are also wrapped in `try/catch`, so no single failing script can poison a global for the whole page again.

> Note: `globalThis.wasm_bindgen` is **not** the fix, and `report-backend.ts` already said why — a top-level `let` is a lexical binding, not a property of `globalThis`, so it reads `undefined` even when the glue loaded fine. It would have silently disabled the console on *healthy* reports. Tried it, backed it out.

## 3. Print progress toast

Clicking Print closed the dialog and then did nothing visible for **10–20s** on a large report. The work is real — panels force-render (topology/apps/forensics draw lazily), diagrams are awaited, iRules are optionally reformatted and analysed — but `window.print()` is only reached at the end, so the page looked hung.

A toast now names the stage:

```
Formatting iRules…                     (only when Format/Diagnostics are ticked)
Rendering diagrams…
Opening your browser’s print dialog…
```

`role=status` + `aria-live=polite`; spinner honours `prefers-reduced-motion`. Hidden **before** `window.print()`, not just in `@media print` — `window.print()` blocks until dismissed, so whatever is on screen is what a print-to-image path captures. `applyIruleOptions` gained a `.catch` so a wasm failure prints without formatting rather than leaving the toast spinning forever.

## Verified

Against a real generated report whose glue throws:

| | before | after |
|---|---|---|
| Print button | ❌ | ✅ |
| Ctrl/Cmd-P | ❌ browser dialog | ✅ chooser |
| `typeof wasm_bindgen` | THROWS | `function` |
| iRule Format/Diagnostics fieldset | ❌ absent | ✅ present |
| print progress | none | staged toast |

🤖 Generated with [Claude Code](https://claude.com/claude-code)