### PR TITLE
fix(report): wasm dies on blob: URLs (root cause); add a print progress toast

### DIFF
--- a/rust/bigip-query-wasm/build-wasm.sh
+++ b/rust/bigip-query-wasm/build-wasm.sh
@@ -37,6 +37,47 @@ wasm="$here/target/wasm32-unknown-unknown/release/bigip_query_wasm.wasm"
 echo "==> wasm-bindgen (no-modules)"
 wasm-bindgen "$wasm" --out-dir "$out" --target no-modules --no-typescript
 
+# ---------------------------------------------------------------------------
+# Make the glue's script_src probe non-fatal.
+#
+# wasm-bindgen emits, at the very top of `let wasm_bindgen = (function(){…})()`:
+#
+#     script_src = new URL(document.currentScript.src, location.href).toString();
+#
+# We inline the glue into the report, so `document.currentScript.src` is "" — and
+# `new URL("", base)` THROWS when `base` is a blob: URL, which is exactly what
+# `location.href` is when the in-browser generator opens the report as a Blob
+# (`blob:https://bitwisecook.github.io/…`). It is fine from https:// and file://,
+# which is why this only bites the hosted app.
+#
+# When that throws, the `let` initialiser never completes and `wasm_bindgen` is
+# trapped in the temporal dead zone for the whole page. Every later `typeof
+# wasm_bindgen` guard then throws ReferenceError instead of returning "undefined",
+# killing print.js, console.js and irule-format.js — no Print button, no Ctrl/Cmd-P,
+# no query console.
+#
+# `script_src` is only used to derive a default `_bg.wasm` path when the caller
+# passes no module. The report always passes explicit bytes, so it is dead weight
+# here: swallowing the failure costs nothing and leaves `script_src` undefined.
+echo "==> patching script_src probe (blob: URLs make new URL() throw)"
+python3 - "$out/bigip_query_wasm.js" <<'PY'
+import re, sys
+p = sys.argv[1]
+s = open(p, encoding="utf-8").read()
+pat = re.compile(
+    r"(\s*)script_src = new URL\(document\.currentScript\.src, location\.href\)\.toString\(\);"
+)
+if not pat.search(s):
+    raise SystemExit("script_src probe not found — did wasm-bindgen change its glue?")
+s = pat.sub(
+    lambda m: f"{m.group(1)}try {{ script_src = new URL(document.currentScript.src, location.href).toString(); }}"
+              f" catch (_) {{ script_src = undefined; }}  // blob: base throws; see build-wasm.sh",
+    s, count=1,
+)
+open(p, "w", encoding="utf-8").write(s)
+print("    patched")
+PY
+
 echo "==> wasm-opt -Os"
 wasm-opt -Os "$out/bigip_query_wasm_bg.wasm" -o "$vendor/f5query_wasm_bg.wasm"
 cp "$out/bigip_query_wasm.js" "$vendor/f5query_wasm.js"

--- a/rust/bigip-query-wasm/build-wasm.sh
+++ b/rust/bigip-query-wasm/build-wasm.sh
@@ -37,7 +37,6 @@ wasm="$here/target/wasm32-unknown-unknown/release/bigip_query_wasm.wasm"
 echo "==> wasm-bindgen (no-modules)"
 wasm-bindgen "$wasm" --out-dir "$out" --target no-modules --no-typescript
 
-# ---------------------------------------------------------------------------
 # Make the glue's script_src probe non-fatal.
 #
 # wasm-bindgen emits, at the very top of `let wasm_bindgen = (function(){…})()`:

--- a/rust/bigip-report-gen/assets/f5query_wasm.js
+++ b/rust/bigip-report-gen/assets/f5query_wasm.js
@@ -1,7 +1,7 @@
 let wasm_bindgen = (function(exports) {
     let script_src;
     if (typeof document !== 'undefined' && document.currentScript !== null) {
-        script_src = new URL(document.currentScript.src, location.href).toString();
+        try { script_src = new URL(document.currentScript.src, location.href).toString(); } catch (_) { script_src = undefined; }  // blob: base throws; see build-wasm.sh
     }
 
     /**

--- a/rust/bigip-report-gen/frontend/dist/print.js
+++ b/rust/bigip-report-gen/frontend/dist/print.js
@@ -65,6 +65,22 @@
     function close() {
       scrim.classList.remove("open");
     }
+    var toastEl = null;
+    function toast(msg) {
+      if (!toastEl) {
+        toastEl = document.createElement("div");
+        toastEl.className = "print-toast";
+        toastEl.setAttribute("role", "status");
+        toastEl.setAttribute("aria-live", "polite");
+        toastEl.innerHTML = '<span class="print-toast-spin" aria-hidden="true"></span><span class="print-toast-msg"></span>';
+        document.body.appendChild(toastEl);
+      }
+      toastEl.querySelector(".print-toast-msg").textContent = msg;
+      toastEl.classList.add("open");
+    }
+    function toastHide() {
+      if (toastEl) toastEl.classList.remove("open");
+    }
     btn.addEventListener("click", open);
     q(".print-cancel").addEventListener("click", close);
     scrim.addEventListener("click", function(e) {
@@ -157,6 +173,7 @@
       var doFmt = q(".pfmt") && q(".pfmt").checked;
       var doDiag = q(".pdiag") && q(".pdiag").checked;
       close();
+      toast(doFmt || doDiag ? "Formatting iRules\u2026" : "Preparing print\u2026");
       deviceEls.forEach(function(dev) {
         var activeTab = dev.querySelector(".tab.active");
         var activePanel = dev.querySelector(".panel.active");
@@ -179,8 +196,11 @@
           d.classList.toggle("active", d === activeDevice);
         });
       });
-      applyIruleOptions(deviceEls, doFmt, doDiag).then(function() {
+      applyIruleOptions(deviceEls, doFmt, doDiag).catch(function() {
+      }).then(function() {
+        toast("Rendering diagrams\u2026");
         whenDrawn(deviceEls, secs, function() {
+          toast("Opening your browser\u2019s print dialog\u2026");
           markAndPrint(deviceEls, secs);
         });
       });
@@ -337,6 +357,7 @@
       });
       var done = function() {
         window.removeEventListener("afterprint", done);
+        toastHide();
         for (var i = restore.length - 1; i >= 0; i--) {
           try {
             restore[i]();
@@ -346,6 +367,7 @@
         restore = [];
       };
       window.addEventListener("afterprint", done);
+      toastHide();
       window.print();
       setTimeout(function() {
         if (restore.length) done();

--- a/rust/bigip-report-gen/frontend/src/pages/print.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/print.ts
@@ -143,7 +143,6 @@
   function open() { scrim.classList.add("open"); }
   function close() { scrim.classList.remove("open"); }
 
-  // ---- "Preparing print" toast -------------------------------------------
   // Preparing a print takes 10-20s on a large report: every chosen panel is
   // force-rendered (topology / apps / forensics draw lazily), their diagrams are
   // awaited, and iRules may be reformatted + analysed through the wasm engine.

--- a/rust/bigip-report-gen/frontend/src/pages/print.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/print.ts
@@ -142,6 +142,32 @@
 
   function open() { scrim.classList.add("open"); }
   function close() { scrim.classList.remove("open"); }
+
+  // ---- "Preparing print" toast -------------------------------------------
+  // Preparing a print takes 10-20s on a large report: every chosen panel is
+  // force-rendered (topology / apps / forensics draw lazily), their diagrams are
+  // awaited, and iRules may be reformatted + analysed through the wasm engine.
+  // `window.print()` is only reached at the very end, so without this the page
+  // just sits there after the dialog closes and looks hung.
+  var toastEl = null;
+  function toast(msg) {
+    if (!toastEl) {
+      toastEl = document.createElement("div");
+      toastEl.className = "print-toast";
+      // `status` + polite: announced by a screen reader without stealing focus.
+      toastEl.setAttribute("role", "status");
+      toastEl.setAttribute("aria-live", "polite");
+      toastEl.innerHTML =
+        '<span class="print-toast-spin" aria-hidden="true"></span>' +
+        '<span class="print-toast-msg"></span>';
+      document.body.appendChild(toastEl);
+    }
+    toastEl.querySelector(".print-toast-msg").textContent = msg;
+    toastEl.classList.add("open");
+  }
+  function toastHide() {
+    if (toastEl) toastEl.classList.remove("open");
+  }
   btn.addEventListener("click", open);
   q(".print-cancel").addEventListener("click", close);
   scrim.addEventListener("click", function (e) { if (e.target === scrim) close(); });
@@ -216,6 +242,10 @@
     var doFmt = q(".pfmt") && q(".pfmt").checked;
     var doDiag = q(".pdiag") && q(".pdiag").checked;
     close();
+    // Formatting/analysing iRules through the wasm engine is the slowest step, so
+    // name it when it is actually going to happen rather than showing a generic
+    // message for 20 seconds.
+    toast(doFmt || doDiag ? "Formatting iRules…" : "Preparing print…");
 
     // Force lazily-rendered panels (topology / apps / forensics) to draw by
     // activating each chosen tab; the rendered content persists in the DOM.
@@ -236,9 +266,18 @@
       devices.forEach(function (d) { d.classList.toggle("active", d === activeDevice); });
     });
 
-    applyIruleOptions(deviceEls, doFmt, doDiag).then(function () {
-      whenDrawn(deviceEls, secs, function () { markAndPrint(deviceEls, secs); });
-    });
+    // `.catch` before `.then`: if the wasm engine fails (or is absent), still
+    // print — just without formatting/diagnostics. Otherwise a rejected promise
+    // would leave the toast spinning forever with no print dialog behind it.
+    applyIruleOptions(deviceEls, doFmt, doDiag)
+      .catch(function () {})
+      .then(function () {
+        toast("Rendering diagrams…");
+        whenDrawn(deviceEls, secs, function () {
+          toast("Opening your browser’s print dialog…");
+          markAndPrint(deviceEls, secs);
+        });
+      });
   }
 
   // The topology / apps / architecture diagrams are laid out asynchronously, and
@@ -427,11 +466,17 @@
 
     var done = function () {
       window.removeEventListener("afterprint", done);
+      toastHide();
       // unwind everything (last-registered first)
       for (var i = restore.length - 1; i >= 0; i--) { try { restore[i](); } catch (e) {} }
       restore = [];
     };
     window.addEventListener("afterprint", done);
+    // Hide the toast BEFORE printing, not just in @media print: `window.print()`
+    // blocks until the browser's dialog is dismissed, so anything still on screen
+    // is what gets captured — and print.css alone would not stop a print-to-image
+    // path from picking it up.
+    toastHide();
     window.print();
     // Safari/Firefox sometimes skip afterprint if the dialog is cancelled fast;
     // a fallback cleanup keeps the page usable.

--- a/rust/bigip-report-gen/frontend/src/styles/print.css
+++ b/rust/bigip-report-gen/frontend/src/styles/print.css
@@ -45,7 +45,7 @@
   .expander, .code-toolbar, .irule-diags, #objDrawer, #drawerScrim,
   #globalSearch, #themeToggle, #f5qManual, .print-dialog, .print-scrim,
   #printBtn, .app-del, .app-pick, .app-pick-all, .app-save, .app-name,
-  .sys-toggle, .qc-examples {
+  .sys-toggle, .qc-examples, .print-toast {
     display: none !important;
   }
 
@@ -251,6 +251,32 @@
   display: none; align-items: center; justify-content: center; z-index: 1000;
 }
 .print-scrim.open { display: flex; }
+
+/* ---- "Preparing print" toast ------------------------------------------- */
+/* Preparing a print takes 10-20s on a large report: every chosen panel has to be
+ * force-rendered (topology / apps / forensics draw lazily), diagrams awaited, and
+ * iRules optionally reformatted + analysed through the wasm engine. `window.print()`
+ * is only called at the very end, so without this the page just sits there looking
+ * hung. Hidden in the printout itself (see the @media print block above). */
+.print-toast {
+  position: fixed; left: 50%; bottom: 28px; transform: translateX(-50%);
+  display: none; align-items: center; gap: 10px;
+  background: var(--panel, #fff); color: var(--fg, #111);
+  border: 1px solid var(--line, #ccc); border-radius: 999px;
+  padding: 10px 18px; font-size: 14px; z-index: 1001;
+  box-shadow: 0 8px 28px rgba(0,0,0,.28);
+}
+.print-toast.open { display: flex; }
+.print-toast-spin {
+  width: 14px; height: 14px; flex: none; border-radius: 50%;
+  border: 2px solid var(--line, #ccc); border-top-color: var(--accent, #0a7);
+  animation: print-toast-spin .8s linear infinite;
+}
+@keyframes print-toast-spin { to { transform: rotate(360deg); } }
+/* Respect a reduced-motion preference: keep the toast, drop the spin. */
+@media (prefers-reduced-motion: reduce) {
+  .print-toast-spin { animation: none; }
+}
 .print-dialog {
   background: var(--panel, #fff); color: var(--fg, #111);
   border: 1px solid var(--line, #ccc); border-radius: 12px;

--- a/rust/bigip-report-gen/wasm/build-wasm.sh
+++ b/rust/bigip-report-gen/wasm/build-wasm.sh
@@ -39,6 +39,49 @@ wasm="$here/target/wasm32-unknown-unknown/release/bigip_report_wasm.wasm"
 echo "==> wasm-bindgen (no-modules)"
 wasm-bindgen "$wasm" --out-dir "$out" --target no-modules --no-typescript
 
+# ---------------------------------------------------------------------------
+# Make the glue's script_src probe non-fatal.
+#
+# wasm-bindgen emits, at the top of `let wasm_bindgen = (function(){…})()`:
+#
+#     script_src = new URL(document.currentScript.src, location.href).toString();
+#
+# The glue is inlined, so `document.currentScript.src` is "" — and `new URL("",
+# base)` THROWS when `base` is a blob: URL. This page IS the in-browser generator:
+# it builds the report as a Blob and opens it, so `location.href` is
+# `blob:https://bitwisecook.github.io/…` and the probe throws every time. (It is
+# fine from https:// and file://, which is why it only bites the hosted app.)
+#
+# The `let` initialiser then never completes, trapping `wasm_bindgen` in the
+# temporal dead zone — after which every `typeof wasm_bindgen` guard throws
+# ReferenceError rather than returning "undefined", killing print.js, console.js
+# and irule-format.js (no Print button, no Ctrl/Cmd-P, no query console).
+#
+# `script_src` only derives a default `_bg.wasm` path when the caller passes no
+# module, and we always pass explicit bytes — so swallowing the failure is free.
+echo "==> patching script_src probe (blob: URLs make new URL() throw)"
+python3 - "$out"/*.js <<'PY'
+import re, sys
+pat = re.compile(
+    r"(\s*)script_src = new URL\(document\.currentScript\.src, location\.href\)\.toString\(\);"
+)
+patched = 0
+for p in sys.argv[1:]:
+    s = open(p, encoding="utf-8").read()
+    if not pat.search(s):
+        continue
+    s = pat.sub(
+        lambda m: f"{m.group(1)}try {{ script_src = new URL(document.currentScript.src, location.href).toString(); }}"
+                  f" catch (_) {{ script_src = undefined; }}  // blob: base throws; see build-wasm.sh",
+        s, count=1,
+    )
+    open(p, "w", encoding="utf-8").write(s)
+    patched += 1
+if not patched:
+    raise SystemExit("script_src probe not found — did wasm-bindgen change its glue?")
+print(f"    patched {patched} glue file(s)")
+PY
+
 # wasm-opt is intentionally NOT run. On modern rustc layouts, binaryen rebinds
 # the `__wbindgen_externrefs` export from the growable externref table onto the
 # fixed-size funcref table, so `Table.grow` throws at runtime ("could not grow

--- a/rust/bigip-report-gen/wasm/build-wasm.sh
+++ b/rust/bigip-report-gen/wasm/build-wasm.sh
@@ -39,7 +39,6 @@ wasm="$here/target/wasm32-unknown-unknown/release/bigip_report_wasm.wasm"
 echo "==> wasm-bindgen (no-modules)"
 wasm-bindgen "$wasm" --out-dir "$out" --target no-modules --no-typescript
 
-# ---------------------------------------------------------------------------
 # Make the glue's script_src probe non-fatal.
 #
 # wasm-bindgen emits, at the top of `let wasm_bindgen = (function(){…})()`:


### PR DESCRIPTION
**Follow-up to #918, which merged incomplete.** GitHub squashed only the first of that PR's three commits (its mergeable state was stuck on `UNKNOWN` and it still reported one commit at merge time), so the **root-cause fix and the toast never landed**. This restores them, unchanged.

`rust` currently has only the `try/catch` defence — which is why print works but the **wasm still fails and the iRule Format/Diagnostics fieldset is absent**.

## 1. Root cause — the glue throws on a `blob:` URL

wasm-bindgen's glue opens with:

```js
script_src = new URL(document.currentScript.src, location.href).toString();
```

The glue is **inlined**, so `document.currentScript.src` is `""` — and `new URL("", base)` **throws when `base` is a `blob:` URL**, which is exactly what `location.href` is on the hosted app (the in-browser generator builds the report as a Blob and opens it).

| base | `new URL('', base)` |
|---|---|
| `https://…` | OK |
| `file:///…` | OK |
| **`blob:https://…`** | **throws** |

Fine from disk, broken on GitHub Pages. Firefox, verbatim:

```
TypeError: URL constructor:  is not a valid URL
ReferenceError: can't access lexical declaration 'wasm_bindgen'
                before initialization              ← ×3
```

The glue is `let wasm_bindgen = (function(){…})(…)`, so that throw means the `let` never completes and the binding is trapped in the **temporal dead zone** — where `typeof` **throws** rather than returning `"undefined"`, killing `print.ts`, `console.ts` and `irule-format.ts` (the three ReferenceErrors).

`script_src` only derives a default `_bg.wasm` path when the caller passes no module, and the report always passes explicit bytes — so swallowing the failure is free. Both `build-wasm.sh` scripts now patch the probe (failing loudly if wasm-bindgen changes its glue shape); the committed `f5query_wasm.js` is patched **as text**, leaving the 8 MB `.wasm` beside it untouched.

**Effect:** the wasm actually loads again, so the query console and the iRule Format/Diagnostics fieldset come back — rather than merely degrading gracefully, which is all #918 achieved.

## 2. Print progress toast

Clicking Print closed the dialog and then did nothing visible for **10–20s**. The work is real (panels force-render, diagrams are awaited, iRules are analysed through wasm) but `window.print()` is only reached at the end, so the page looked hung.

```
Formatting iRules…                     (only when Format/Diagnostics are ticked)
Rendering diagrams…
Opening your browser’s print dialog…
```

`role=status` + `aria-live=polite`; spinner honours `prefers-reduced-motion`. Hidden **before** `window.print()`, not just in `@media print` — `window.print()` blocks until dismissed, so whatever is on screen is what a print-to-image path captures. `applyIruleOptions` gained a `.catch`, so a wasm failure prints without formatting instead of leaving the toast spinning forever.

## Verified

Fresh report generated from `samples/bigip/bigip.conf` with these commits:

```
typeof wasm_bindgen : function          (was: THROWS)
dialog fieldsets    : Sections, iRules  ← Format + Diagnostics restored
printBtn            : true
```

`make check-report-assets` (drift gate) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)