### PR TITLE
fix(report): print the analyser findings and flow diagrams; fix the version on published artefacts

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -70,6 +70,21 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history + tags: `tcl-version` resolves the release version with
+          # `git describe --tags`, and a shallow, tagless checkout makes that fail —
+          # every published artefact then reported the manifest placeholder (0.1.0)
+          # rather than the release it was cut from.
+          fetch-depth: 0
+
+      # Stamp the version from a PRISTINE tree, before anything below regenerates
+      # tracked files (build-wasm.sh rewrites assets/, the front-end build rewrites
+      # dist/). `tcl-version` prefers TCL_LSP_VERSION over `git describe`, so it
+      # cannot later mistake CI's own build output for a developer's edits and mark
+      # a published build `.dirty`.
+      - name: Stamp the release version
+        shell: bash
+        run: echo "TCL_LSP_VERSION=$(git describe --tags --always)" >> "$GITHUB_ENV"
 
       # rust-toolchain.toml pins the channel (stable). Cache both crate trees:
       # the workspace member the report links (bigip-report-gen/python) and the

--- a/.github/workflows/report-pyz.yml
+++ b/.github/workflows/report-pyz.yml
@@ -43,6 +43,21 @@ jobs:
             arch: x86_64
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history + tags: `tcl-version` resolves the release version with
+          # `git describe --tags`, and a shallow, tagless checkout makes that fail —
+          # every published artefact then reported the manifest placeholder (0.1.0)
+          # rather than the release it was cut from.
+          fetch-depth: 0
+
+      # Stamp the version from a PRISTINE tree, before anything below regenerates
+      # tracked files (build-wasm.sh rewrites assets/, the front-end build rewrites
+      # dist/). `tcl-version` prefers TCL_LSP_VERSION over `git describe`, so it
+      # cannot later mistake CI's own build output for a developer's edits and mark
+      # a published build `.dirty`.
+      - name: Stamp the release version
+        shell: bash
+        run: echo "TCL_LSP_VERSION=$(git describe --tags --always)" >> "$GITHUB_ENV"
 
       # The runner image ships a pinned stable (currently 1.96.1) and
       # `rust-toolchain.toml`'s `channel = "stable"` resolves to *that*, not to
@@ -154,6 +169,21 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          # Full history + tags: `tcl-version` resolves the release version with
+          # `git describe --tags`, and a shallow, tagless checkout makes that fail —
+          # every published artefact then reported the manifest placeholder (0.1.0)
+          # rather than the release it was cut from.
+          fetch-depth: 0
+
+      # Stamp the version from a PRISTINE tree, before anything below regenerates
+      # tracked files (build-wasm.sh rewrites assets/, the front-end build rewrites
+      # dist/). `tcl-version` prefers TCL_LSP_VERSION over `git describe`, so it
+      # cannot later mistake CI's own build output for a developer's edits and mark
+      # a published build `.dirty`.
+      - name: Stamp the release version
+        shell: bash
+        run: echo "TCL_LSP_VERSION=$(git describe --tags --always)" >> "$GITHUB_ENV"
 
       # The runner image ships a pinned stable (currently 1.96.1) and
       # `rust-toolchain.toml`'s `channel = "stable"` resolves to *that*, not to

--- a/rust/bigip-report-gen/frontend/dist/print.js
+++ b/rust/bigip-report-gen/frontend/dist/print.js
@@ -222,6 +222,15 @@
           d.classList.toggle("active", d === activeDevice);
         });
       });
+      deviceEls.forEach(function(dev) {
+        dev.querySelectorAll(".panel tr.expandable").forEach(function(row) {
+          if (row.classList.contains("open")) return;
+          row.click();
+          remember(function() {
+            if (row.classList.contains("open")) row.click();
+          });
+        });
+      });
       applyIruleOptions(deviceEls, doFmt, doDiag).catch(function() {
       }).then(function() {
         toast("Rendering diagrams\u2026");

--- a/rust/bigip-report-gen/frontend/dist/print.js
+++ b/rust/bigip-report-gen/frontend/dist/print.js
@@ -136,6 +136,27 @@
       }
       return window.__f5qReady;
     }
+    var SEV_ORDER = ["error", "warning", "info", "hint"];
+    function diagsTable(res) {
+      var diags = res.diagnostics || [];
+      var el = document.createElement("div");
+      el.className = "print-diags";
+      if (!diags.length) {
+        el.innerHTML = '<div class="print-diags-empty">No analyser findings \u2014 clean iRule.</div>';
+        return el;
+      }
+      var counts = res.counts || {};
+      var summary = SEV_ORDER.filter(function(s) {
+        return counts[s];
+      }).map(function(s) {
+        return '<span class="diag-badge diag-' + s + '">' + counts[s] + " " + s + (counts[s] > 1 ? "s" : "") + "</span>";
+      }).join("");
+      var rows = diags.map(function(d) {
+        return '<li class="diag-row diag-' + d.severity + '"><span class="diag-sev diag-' + d.severity + '">' + esc(d.severity) + '</span><span class="diag-code">' + esc(d.code) + '</span><span class="diag-loc">' + d.line + ":" + d.col + '</span><span class="diag-msg">' + esc(d.message) + "</span></li>";
+      }).join("");
+      el.innerHTML = '<div class="print-diags-head">Analyser findings' + (summary ? " " + summary : "") + '</div><ul class="diag-list">' + rows + "</ul>";
+      return el;
+    }
     function applyIruleOptions(deviceEls, doFmt, doDiag) {
       if (!doFmt && !doDiag) return Promise.resolve();
       return initWasm().then(function() {
@@ -150,6 +171,11 @@
               if (doDiag) {
                 var res = JSON.parse(wasm_bindgen.analyze_irule(src));
                 pre.innerHTML = res.html;
+                var table = diagsTable(res);
+                pre.parentNode.insertBefore(table, pre.nextSibling);
+                remember(function() {
+                  if (table.parentNode) table.parentNode.removeChild(table);
+                });
               } else if (doFmt) {
                 pre.innerHTML = wasm_bindgen.format_irule(src);
               }

--- a/rust/bigip-report-gen/frontend/src/pages/print.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/print.ts
@@ -308,6 +308,28 @@
       devices.forEach(function (d) { d.classList.toggle("active", d === activeDevice); });
     });
 
+    // Open the expandable rows for real, rather than only revealing their
+    // `tr.detail` with CSS at mark time.
+    //
+    // Each iRule's control-flow diagram is drawn lazily by irule-flow.ts, off the
+    // row's *click* handler. Revealing the detail row with `.print-include` never
+    // fires that handler, so the diagram never drew and every iRule printed with an
+    // empty bordered box above its code. Worse, whenDrawn() then sat waiting the
+    // full 8s for `<svg>`s that could never appear — so this also cost most of the
+    // delay before the print dialog opened.
+    //
+    // Clicking is a toggle, so only open rows that are closed, and close them again
+    // on restore.
+    deviceEls.forEach(function (dev) {
+      dev.querySelectorAll(".panel tr.expandable").forEach(function (row) {
+        if (row.classList.contains("open")) return;
+        row.click();
+        remember(function () {
+          if (row.classList.contains("open")) row.click();
+        });
+      });
+    });
+
     // `.catch` before `.then`: if the wasm engine fails (or is absent), still
     // print — just without formatting/diagnostics. Otherwise a rejected promise
     // would leave the toast spinning forever with no print dialog behind it.

--- a/rust/bigip-report-gen/frontend/src/pages/print.ts
+++ b/rust/bigip-report-gen/frontend/src/pages/print.ts
@@ -211,6 +211,46 @@
     return window.__f5qReady;
   }
 
+  var SEV_ORDER = ["error", "warning", "info", "hint"];
+
+  // `analyze_irule` returns `{ html, diagnostics[], counts }`. `html` only wraps
+  // each finding's range in an underline span — the MESSAGES live in
+  // `diagnostics[]`. On screen they are listed in the `.irule-diags` panel, which
+  // print.css hides (it is interactive chrome, and print.ts never builds one for
+  // the print run anyway). So a printed report used to carry underlined code and
+  // no findings at all: the underline told you *where*, and nothing told you *what*.
+  //
+  // Render the findings into the printout instead, next to the iRule they belong
+  // to. Screen-hidden, so it never flashes up mid-print-run.
+  function diagsTable(res) {
+    var diags = res.diagnostics || [];
+    var el = document.createElement("div");
+    el.className = "print-diags";
+    if (!diags.length) {
+      el.innerHTML = '<div class="print-diags-empty">No analyser findings — clean iRule.</div>';
+      return el;
+    }
+    var counts = res.counts || {};
+    var summary = SEV_ORDER.filter(function (s) { return counts[s]; })
+      .map(function (s) {
+        return '<span class="diag-badge diag-' + s + '">' + counts[s] + " " + s + (counts[s] > 1 ? "s" : "") + "</span>";
+      })
+      .join("");
+    var rows = diags
+      .map(function (d) {
+        return '<li class="diag-row diag-' + d.severity + '">' +
+          '<span class="diag-sev diag-' + d.severity + '">' + esc(d.severity) + "</span>" +
+          '<span class="diag-code">' + esc(d.code) + "</span>" +
+          '<span class="diag-loc">' + d.line + ":" + d.col + "</span>" +
+          '<span class="diag-msg">' + esc(d.message) + "</span></li>";
+      })
+      .join("");
+    el.innerHTML =
+      '<div class="print-diags-head">Analyser findings' + (summary ? " " + summary : "") + "</div>" +
+      '<ul class="diag-list">' + rows + "</ul>";
+    return el;
+  }
+
   // Apply Format / Diagnostics to every iRule body inside the print scope.
   function applyIruleOptions(deviceEls, doFmt, doDiag) {
     if (!doFmt && !doDiag) return Promise.resolve();
@@ -224,6 +264,9 @@
             if (doDiag) {
               var res = JSON.parse(wasm_bindgen.analyze_irule(src));
               pre.innerHTML = res.html;
+              var table = diagsTable(res);
+              pre.parentNode.insertBefore(table, pre.nextSibling);
+              remember(function () { if (table.parentNode) table.parentNode.removeChild(table); });
             } else if (doFmt) {
               pre.innerHTML = wasm_bindgen.format_irule(src);
             }

--- a/rust/bigip-report-gen/frontend/src/styles/print.css
+++ b/rust/bigip-report-gen/frontend/src/styles/print.css
@@ -243,7 +243,58 @@
   pre.code.tcl .tk-comment, pre.code.conf .tk-comment { color: #6a737d !important; font-style: italic; }
   /* diagnostic underlines still visible in print */
   pre.code.tcl .diag { text-decoration: underline; }
+
+  /* The findings themselves, printed under the iRule they belong to. The
+     underline spans above say *where*; nothing said *what* — the on-screen
+     `.irule-diags` panel is interactive chrome and is hidden in print, and the
+     analyser's messages live in `diagnostics[]`, not in the annotated html.
+     print.ts builds these during the print run (see diagsTable). */
+  .print-diags {
+    display: block !important;
+    break-inside: avoid;
+    margin: 6px 0 12px;
+    border: 1px solid #ddd;
+    border-radius: 6px;
+    font-family: var(--sans, system-ui, sans-serif);
+  }
+  .print-diags-head {
+    font: 650 10px/1.4 var(--sans, system-ui, sans-serif);
+    padding: 5px 8px;
+    border-bottom: 1px solid #ddd;
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    align-items: center;
+  }
+  .print-diags-empty { padding: 6px 8px; font-size: 9.5px; color: #555; }
+  .print-diags .diag-list {
+    list-style: none; margin: 0; padding: 2px 0;
+    max-height: none; overflow: visible;   /* the on-screen panel scrolls; paper cannot */
+  }
+  .print-diags .diag-row {
+    display: grid;
+    grid-template-columns: auto auto auto 1fr;
+    gap: 6px;
+    align-items: baseline;
+    padding: 3px 8px;
+    font-size: 9.5px;
+    break-inside: avoid;
+  }
+  .print-diags .diag-loc, .print-diags .diag-code {
+    font-family: var(--mono, ui-monospace, monospace);
+    color: #555;
+  }
+  .print-diags .diag-msg { color: #111; }
+  /* The severity/badge chips are deliberately NOT restyled here: the rule above
+     ("Neutralise dark tag/badge backgrounds") already flattens them to a light,
+     bordered, ink-friendly chip. Forcing the on-screen severity colour back would
+     print white-on-light-grey, i.e. invisible. The severity is spelled out as text
+     in the chip, so nothing is lost. */
 }
+
+/* Only ever printed: built during the print run, so keep it off the screen or it
+   flashes up under each iRule while the report is being prepared. */
+.print-diags { display: none; }
 
 /* ---- The print dialog (screen only) ----------------------------------- */
 .print-scrim {

--- a/rust/bigip-report-gen/python/Cargo.lock
+++ b/rust/bigip-report-gen/python/Cargo.lock
@@ -146,6 +146,7 @@ dependencies = [
  "tcl-f5mku",
  "tcl-lexer",
  "tcl-registry",
+ "tcl-version",
 ]
 
 [[package]]

--- a/rust/tcl-version/build.rs
+++ b/rust/tcl-version/build.rs
@@ -43,7 +43,9 @@ fn main() {
         println!("cargo:rerun-if-changed=../../{p}");
     }
 
-    let base = env_version()
+    let stamped = env_version();
+    let base = stamped
+        .clone()
         .or_else(git_describe)
         .unwrap_or_else(|| env!("CARGO_PKG_VERSION").to_owned());
 
@@ -57,7 +59,16 @@ fn main() {
     // `…+g4c5a8f8.dirty` from a modified tree. Semver build metadata (`+…`) is
     // ignored for precedence, so this stays a legal version string.
     let hash = env_hash().or_else(git_hash);
-    let dirty = git_is_dirty();
+
+    // `.dirty` means "a developer built this from a modified tree", and it must
+    // not fire in CI. A workflow that ships an artefact regenerates TRACKED files
+    // on the way (build-wasm.sh rewrites assets/, build-report-assets rewrites
+    // dist/), so by the time the crate compiles the tree is dirty *by
+    // construction* — and every published build would claim to be a dev build.
+    //
+    // An explicit `TCL_LSP_VERSION` is the signal that a pipeline, not a person,
+    // decided what this is. Trust it and skip the check.
+    let dirty = stamped.is_none() && git_is_dirty();
 
     // Normalise whatever `git describe` produced down to the bare
     // `<tag>[-<n>]` core: it may carry its own `-dirty` and `-g<hash>`, both of


### PR DESCRIPTION
Four fixes, all found by reading an actual printed PDF and a hosted report.

## 1. The analyser findings were never printed

Ticking **"Show diagnostics + optimiser suggestions"** produced underlined iRule code and **no findings anywhere**. The underline said *where*; nothing said *what*.

`analyze_irule` returns `{ html, diagnostics[], counts }`. `html` only wraps each finding's range in an underline span — **the messages live in `diagnostics[]`**, which the print path threw away. On screen they're in the `.irule-diags` panel, but that's interactive chrome (it scrolls) and `print.css` hides it, rightly. So nothing rendered them for print.

They now print under the iRule they belong to: severity, code, `line:col`, message, with a per-severity summary.

The severity chips are **deliberately not restyled** — `print.css` already flattens tag/badge backgrounds to a light, ink-friendly chip, and forcing the on-screen colour back would print **white-on-light-grey, i.e. invisible**. (I wrote that bug, caught it before pushing.)

## 2. iRule flow diagrams printed as empty boxes

Every iRule had an empty bordered box above its code — **except the ones whose row happened to be expanded on screen**, which printed perfectly. That inconsistency is the tell.

`irule-flow.ts` draws the graph lazily off the row's **click** handler. The print run reveals `tr.detail` with CSS, which never fires it — so no diagram rendered for any row the user hadn't opened by hand.

It also cost most of the wait: `whenDrawn()` then polled for `<svg>`s that could never appear and burned its full **8s deadline** before printing the empty boxes. Fixing it should noticeably shorten the pre-print delay.

Rows are now opened for real (click is a toggle, so only closed rows are clicked, and they're closed again on restore).

**Measured: 0 of 5 flow diagrams rendered before, 5 of 5 after.**

## 3. Published artefacts reported `0.1.0` and claimed to be dirty dev builds

The hosted generator reported `query engine v0.1.0+g00da9f0e.dirty`. Both halves wrong:

- **`0.1.0`** — `github-pages.yml` and `report-pyz.yml` check out shallow with no tags, so `git describe --tags` finds nothing and `tcl-version` falls back to the manifest placeholder. `ci.yml` already sets `TCL_LSP_VERSION` on the release path for exactly this reason; these two never adopted it. They now fetch full history and stamp the version **from a pristine tree, before any build runs**.
- **`.dirty`** — those workflows regenerate **tracked** files on the way (`build-wasm.sh` rewrites `assets/`, the front-end build rewrites `dist/`), so the tree is dirty *by construction* by the time the crate compiles, and every published build announced itself as a developer's modified checkout. `.dirty` now only fires when the version was **not** explicitly stamped: an explicit `TCL_LSP_VERSION` means a pipeline, not a person, decided what this is.

Verified against a deliberately dirty tree:

```
dev, no env          2.1.8-10+g47dde37d.dirty   (still marked, correctly)
TCL_LSP_VERSION set  2.1.8-10+g47dde37d         (no false .dirty)
release tag          2.1.8+g47dde37d
```

## 4. Lockfile

`tcl-version` was added to the python binding's `Cargo.toml` in #915 but its `Cargo.lock` was never regenerated. Cargo patches it silently on build, which is why nothing failed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)