### PR TITLE
Diagnostics deep review: tight ranges, accurate fixes, registry-driven knowledge, dialect/manifest resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4313,6 +4313,7 @@ dependencies = [
  "serde_json",
  "sha2 0.10.9",
  "tar",
+ "tcl-registry",
  "tcl-sandbox",
  "tcl-syntax",
  "toml",

--- a/README.md
+++ b/README.md
@@ -64,6 +64,12 @@ All editors connect to the native Rust binary `tcl-lsp-server` over stdio
 `#!/usr/bin/tclsh`, `#!/usr/bin/wish`, and `#!/usr/bin/expect`.
 Files named `presentation` (no extension) are auto-detected as APL.
 Per-file `# tcl-dialect:` comment directives pin a specific dialect.
+The `tcl diag` / `lint` / `validate` CLI verbs apply the same per-file
+detection (directive, shebang, content, extension) unless `--dialect` is
+passed, so the CLI and the editor report the same set for the same file.
+Files named `tclpkg.tcl` are analysed as `tcl pkg` package manifests:
+their directives resolve against the manifest command set instead of
+drawing unknown-command warnings.
 
 ### VS Code
 

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -94,6 +94,7 @@ class StringCommand(CommandDef):
 |-------|------|---------|---------|
 | `subcommands` | `dict[str, SubCommand]` | `{}` | Ensemble subcommand registry.  See SubCommand section |
 | `allow_unknown_subcommands` | `bool` | `False` | Suppress W102 for unrecognised subcommands (e.g. user-defined `oo::class` methods) |
+| `default_form_first_word` | `Option<DefaultFormFirstWord>` | `None` | Value shape a non-subcommand first word may take to select the command's *default* form (`after 200 ...` — an integer first word is a delay, not an unknown subcommand). Matched via the canonical `tcl-syntax` number parser, so every Tcl integer spelling works |
 
 #### Compiler traits
 

--- a/docs/design/contracts/dialect-detection.md
+++ b/docs/design/contracts/dialect-detection.md
@@ -118,3 +118,13 @@ Dialect is re-evaluated when:
 | `.iapp`, `.iappimpl`, `.impl` | `f5-iapps` |
 | `.apl` | `f5-iapps` |
 | `.exp` | `expect` |
+
+## Command-line tools (`tcl diag` / `lint` / `validate`)
+
+The diagnostics verbs of the `tcl` CLI apply the same chain per input
+document (minus the editor language ID, which has no CLI equivalent):
+an explicit `--dialect` flag overrides everything; otherwise the
+in-source signals (comment directive, shebang, content), then the file
+extension, then the `tcl8.6` fallback decide.  This keeps `tcl diag`
+and the editor reporting the same set for the same file — an `.irul`
+input gets full iRules analysis without any flag.

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -83,6 +83,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   — why a large file's diagnostics arrive in two waves (a fast tier of
   single-file checks, then the complete deep tier), and why W120/W123 are
   held back from the first wave.
+- [kcs-qa-tclpkg-manifest-diagnostics.md](kcs-qa-tclpkg-manifest-diagnostics.md)
+  — what the editor checks inside a `tclpkg.tcl` package manifest, and
+  why its directives no longer draw "Unknown command" warnings.
 
 ## How-Tos
 

--- a/docs/kcs/kcs-qa-tclpkg-manifest-diagnostics.md
+++ b/docs/kcs/kcs-qa-tclpkg-manifest-diagnostics.md
@@ -1,0 +1,49 @@
+# KCS: What does the editor check inside a tclpkg.tcl manifest?
+
+> **Audience:** User
+> **Type:** Q&A
+
+## Applies to
+
+all-editors, tcl-lsp-cli
+
+## Question
+
+Why does my `tclpkg.tcl` package manifest no longer show "Unknown command"
+warnings, and what is checked instead?
+
+## Answer
+
+A file named `tclpkg.tcl` is a package manifest for the `tcl pkg` package
+manager. Its directives (`package`, `version`, `require`, `entry`, …) are
+not ordinary Tcl commands, and two of them (`package`, `entry`) share a
+name with a real Tcl or Tk command.
+
+The language server and `tcl diag` now recognise the manifest by its file
+name and analyse it against the manifest's own command set:
+
+- Each directive resolves to its manifest meaning — `entry main.tcl` is
+  the entry-point declaration, never the Tk `entry` widget, so no
+  "requires `package require Tk`" warning appears.
+- Directive argument counts are checked against the manifest grammar —
+  `require json` (missing the minimum version) is flagged.
+- A misspelt directive still shows "Unknown command" — the manifest
+  command set is closed, so typos surface.
+- Hovering a directive shows its synopsis, for example
+  `require <name> <minimum> ?-source <url>?`.
+
+## Example
+
+```tcl
+package demo-app
+version 0.1.0
+require json 1.0.0
+entry   main.tcl
+```
+
+Before this change every line above showed a warning; now the file is
+clean, and only genuine mistakes are flagged.
+
+The directive set lives in the command registry
+(`rust/tcl-registry/src/scoped.rs`, `TCLPKG_MANIFEST_ENV`), mirroring the
+`tcl pkg` manifest parser.

--- a/editors/vscode/src/test/precisionReview.test.ts
+++ b/editors/vscode/src/test/precisionReview.test.ts
@@ -1,0 +1,126 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, waitForDiagnostics } from "./helper";
+
+function codeOf(d: vscode.Diagnostic): string {
+  return typeof d.code === "object" && d.code !== null ? String(d.code.value) : String(d.code);
+}
+
+function withCode(diags: vscode.Diagnostic[], code: string): vscode.Diagnostic[] {
+  return diags.filter((d) => codeOf(d) === code);
+}
+
+// Diagnostics precision review — tight ranges, rename resolution, and
+// did-you-mean suggestions, asserted through the real editor client so a
+// projection bug (byte→UTF-16, span rebasing) cannot hide behind the
+// server-side e2e suite.
+//
+// Fixture layout (0-based lines):
+//   3  proc user_args {args} { … }
+//   4  rename user_args ua2
+//   5  ua2 1 2                  ← known (rename target), no W123
+//   6  user_args 9              ← W128 (vacated name)
+//   7  set x [lindex $missing 0] ← W210 tight on $missing (cols 14..22)
+//   8  puts $x
+//   9  proc greet {name} { … }
+//  10  greet a b                ← E003 tight on surplus `b` (cols 8..9)
+//  11..13  oo::class Animal { method speak }
+//  14  set pet [Animal new]
+//  15  $pet spek                ← W308 tight on `spek` (cols 5..9)
+suite("Diagnostics precision review", () => {
+  const docUri = getDocUri("precisionReview.tcl");
+
+  test("rename target is known; vacated name draws W128", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W128"),
+    });
+    assert.strictEqual(
+      withCode(diags, "W123").length,
+      0,
+      "the rename target `ua2` must not be an unknown command",
+    );
+    const w128 = withCode(diags, "W128");
+    assert.strictEqual(w128.length, 1, "the vacated `user_args` draws exactly one W128");
+    assert.strictEqual(w128[0].range.start.line, 6);
+  });
+
+  test("W210 range is tight on the nested $missing read", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W210"),
+    });
+    const w210 = withCode(diags, "W210");
+    assert.strictEqual(w210.length, 1, "one read-before-set in the fixture");
+    const r = w210[0].range;
+    assert.strictEqual(r.start.line, 7);
+    assert.strictEqual(r.start.character, 14, "range starts at $missing");
+    assert.strictEqual(r.end.character, 22, "range ends after $missing");
+  });
+
+  test("E003 range covers only the surplus argument", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "E003"),
+    });
+    const e003 = withCode(diags, "E003");
+    assert.strictEqual(e003.length, 1, "one surplus-argument call in the fixture");
+    const r = e003[0].range;
+    assert.strictEqual(r.start.line, 10);
+    assert.strictEqual(r.start.character, 8, "range starts at the surplus `b`");
+    assert.strictEqual(r.end.character, 9, "range covers exactly `b`");
+  });
+
+  test("W308 anchors the method word and suggests the MRO method", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W308"),
+    });
+    const w308 = withCode(diags, "W308");
+    assert.strictEqual(w308.length, 1, "one unknown-method dispatch in the fixture");
+    const r = w308[0].range;
+    assert.strictEqual(r.start.line, 15);
+    assert.strictEqual(r.start.character, 5, "range starts at `spek`");
+    assert.strictEqual(r.end.character, 9, "range covers exactly `spek`");
+    assert.ok(
+      w308[0].message.includes("did you mean 'speak'"),
+      `suggestion drawn from the class's methods: ${w308[0].message}`,
+    );
+  });
+
+  test("quick fix replaces exactly the typo'd method word", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "W308"),
+    });
+    const w308 = withCode(diags, "W308")[0];
+    const actions = await vscode.commands.executeCommand<vscode.CodeAction[]>(
+      "vscode.executeCodeActionProvider",
+      docUri,
+      w308.range,
+    );
+    const fix = (actions ?? []).find((a) => a.title.includes("Replace with 'speak'"));
+    assert.ok(
+      fix,
+      `expected a Replace with 'speak' quick fix, got: ${(actions ?? []).map((a) => a.title).join(", ")}`,
+    );
+  });
+});

--- a/editors/vscode/testFixture/precisionReview.tcl
+++ b/editors/vscode/testFixture/precisionReview.tcl
@@ -1,0 +1,16 @@
+# Fixture for the diagnostics precision review: tight ranges, rename
+# resolution, and did-you-mean suggestions. Line numbers are load-bearing —
+# the companion test (precisionReview.test.ts) asserts on them.
+proc user_args {args} { puts [llength $args] }
+rename user_args ua2
+ua2 1 2
+user_args 9
+set x [lindex $missing 0]
+puts $x
+proc greet {name} { puts $name }
+greet a b
+oo::class create Animal {
+    method speak {} { return woof }
+}
+set pet [Animal new]
+$pet spek

--- a/runtime/rust/build.rs
+++ b/runtime/rust/build.rs
@@ -77,6 +77,18 @@ fn main() {
         // bignum backend rather than fail the build. The bignum obj rep is
         // `#[cfg]`-gated on `have_tommath` so the rest of the runtime still
         // builds + tests.
+        //
+        // Re-probe on every build while the sources are absent: a watched
+        // path that never exists keeps the fingerprint stale, so the first
+        // build after a fetch re-runs this script and turns the tower on.
+        // (Watching the candidate directory itself is not enough — tar
+        // restores the archive's old mtimes on extraction, so the fetched
+        // tree looks *older* than the cached probe and cargo would keep the
+        // tower-less result until `build.rs` was touched by hand.)
+        if let Ok(out) = env::var("OUT_DIR") {
+            let never = PathBuf::from(out).join("force-tower-reprobe");
+            println!("cargo:rerun-if-changed={}", never.display());
+        }
         println!("cargo:warning=libtommath source not found; bignum backend disabled");
         return;
     };

--- a/runtime/rust/src/cmd_alias.rs
+++ b/runtime/rust/src/cmd_alias.rs
@@ -701,6 +701,8 @@ mod tests {
         assert_eq!(counters::double_free_count(), 0);
     }
 
+    // Needs the numeric tower: the child's `dbl` proc computes via `expr`.
+    #[cfg(have_tommath)]
     #[test]
     fn child_interpreters() {
         // `interp create`/`eval`/`exists`/`children`/`delete` + the child as a
@@ -736,6 +738,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: alias targets are `expr`-backed (`padd`) and `::tcl::mathop::*`.
+    #[cfg(have_tommath)]
     #[test]
     fn cross_interp_aliases() {
         // A child alias delegating to a parent command (both syntaxes), and
@@ -765,6 +769,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: the `-safe` hidden-list assert compares via `expr`.
+    #[cfg(have_tommath)]
     #[test]
     fn hidden_commands_and_safe() {
         // `interp hide`/`expose`/`invokehidden` + `interp create -safe`.

--- a/runtime/rust/src/cmd_clock.rs
+++ b/runtime/rust/src/cmd_clock.rs
@@ -95,7 +95,9 @@ fn clock_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     }
 }
 
-#[cfg(test)]
+// Module-gated on the tower: the sole test (and so the `leak_free`/`run`
+// helpers) needs `expr` for its numeric asserts.
+#[cfg(all(test, have_tommath))]
 mod tests {
     use crate::counters;
     use crate::interp::{Code, Interp};

--- a/runtime/rust/src/cmd_control.rs
+++ b/runtime/rust/src/cmd_control.rs
@@ -522,6 +522,8 @@ fn if_cmd(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 }
 
 /// `wrong # args: no script following "<token>" argument` (C's `missingScript`).
+/// Tower-gated with its only callers (`if`'s clause scan).
+#[cfg(have_tommath)]
 fn no_script_following(interp: &mut Interp, token: &[u8]) -> Code {
     let mut m = b"wrong # args: no script following \"".to_vec();
     m.extend_from_slice(token);
@@ -953,6 +955,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: the continue/break cases branch via `if`.
+    #[cfg(have_tommath)]
     #[test]
     fn lmap_collects_results() {
         leak_free(|i| {

--- a/runtime/rust/src/cmd_coro.rs
+++ b/runtime/rust/src/cmd_coro.rs
@@ -709,6 +709,8 @@ mod tests {
         i.result_bytes()
     }
 
+    // Needs the numeric tower: the generator body loops via `for`.
+    #[cfg(have_tommath)]
     #[test]
     fn coroutine_yield_resume_and_info() {
         let mut i = Interp::new();
@@ -755,6 +757,8 @@ mod tests {
         assert_eq!(i.eval_str(b"::tcl::unsupported::corotype"), Code::Error);
     }
 
+    // Needs the numeric tower: the coroutine body parks in `while`.
+    #[cfg(have_tommath)]
     #[test]
     fn deleting_a_suspended_coroutine_is_clean() {
         let mut i = Interp::new();
@@ -768,6 +772,8 @@ mod tests {
         assert_eq!(run(&mut i, b"p 2 3"), b"5");
     }
 
+    // Needs the numeric tower: the coroutine body parks in `while`.
+    #[cfg(have_tommath)]
     #[test]
     fn coroprobe_reads_and_mutates_suspended_context() {
         use crate::interp::Code;
@@ -796,6 +802,8 @@ mod tests {
         assert_eq!(i.result_bytes(), b"can't read \"nope\": no such variable");
     }
 
+    // Needs the numeric tower: the coroutine body parks in `while`.
+    #[cfg(have_tommath)]
     #[test]
     fn coroinject_runs_on_next_resume() {
         use crate::interp::Code;

--- a/runtime/rust/src/cmd_dict.rs
+++ b/runtime/rust/src/cmd_dict.rs
@@ -1140,6 +1140,8 @@ mod tests {
         assert_eq!(b, b"key \"z\" not known in dictionary");
     }
 
+    // Needs the numeric tower: the filter scripts test via `expr`.
+    #[cfg(have_tommath)]
     #[test]
     fn filter_key_value_via_shared_core() {
         // `key`/`value` globs now come from `tcl_cmd_core::dict`.

--- a/runtime/rust/src/cmd_error.rs
+++ b/runtime/rust/src/cmd_error.rs
@@ -609,6 +609,8 @@ mod tests {
 
     /// `eval`/`uplevel`/`foreach` add a `("<cmd>" body line N)` frame; inline
     /// `if`/`while`/`for`/`switch` do not (tclsh 9.0).
+    // Needs the numeric tower: the inline-`if` frame case dispatches `if`.
+    #[cfg(have_tommath)]
     #[test]
     fn body_frame_commands() {
         leak_free(|i| {

--- a/runtime/rust/src/cmd_info.rs
+++ b/runtime/rust/src/cmd_info.rs
@@ -671,6 +671,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: `info functions` needs the `::tcl::mathfunc::*` table.
+    #[cfg(have_tommath)]
     #[test]
     fn info_cmdtype_loaded_functions() {
         leak_free(|i| {
@@ -736,6 +738,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: membership asserts go through `expr`.
+    #[cfg(have_tommath)]
     #[test]
     fn info_vars_locals_globals() {
         leak_free(|i| {
@@ -765,6 +769,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: membership asserts go through `expr`.
+    #[cfg(have_tommath)]
     #[test]
     fn info_commands_procs_namespaced() {
         leak_free(|i| {

--- a/runtime/rust/src/cmd_list.rs
+++ b/runtime/rust/src/cmd_list.rs
@@ -745,6 +745,8 @@ mod tests {
         b
     }
 
+    // Needs the numeric tower: `-command` comparators are `expr` lambdas.
+    #[cfg(have_tommath)]
     #[test]
     fn lsort_shared_core() {
         // Pinned against tclsh 9.0 (each case leak-checked by `ok`/`run`).
@@ -1045,6 +1047,8 @@ mod tests {
         );
     }
 
+    // Needs the numeric tower: `-command` comparators are `expr` lambdas.
+    #[cfg(have_tommath)]
     #[test]
     fn lsort_options() {
         assert_eq!(ok(b"lsort {c a b}"), b"a b c");

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -1339,6 +1339,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: the linked var is bumped via `expr`.
+    #[cfg(have_tommath)]
     #[test]
     fn namespace_upvar_links_local_to_ns_var() {
         leak_free(|i| {

--- a/runtime/rust/src/cmd_oo.rs
+++ b/runtime/rust/src/cmd_oo.rs
@@ -6839,6 +6839,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: `$obj eval` runs `expr`.
+    #[cfg(have_tommath)]
     #[test]
     fn object_builtin_variable_varname_eval() {
         leak_free(|i| {
@@ -7204,6 +7206,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: method bodies compute via `expr`.
+    #[cfg(have_tommath)]
     #[test]
     fn private_method_scope_and_unknown_listing() {
         leak_free(|i| {
@@ -7442,6 +7446,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: `forward` targets `::tcl::mathop::+`.
+    #[cfg(have_tommath)]
     #[test]
     fn objdefine_forward_mixin_unexport_copy() {
         leak_free(|i| {

--- a/runtime/rust/src/cmd_trace.rs
+++ b/runtime/rust/src/cmd_trace.rs
@@ -768,6 +768,8 @@ mod tests {
         });
     }
 
+    // Needs the numeric tower: the traced proc body is `if`+`expr` (quoted in the pinned log).
+    #[cfg(have_tommath)]
     #[test]
     fn step_trace_recursion_installs_once() {
         leak_free(|i| {

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -725,6 +725,7 @@ pub struct InterpState {
     /// The `expr rand()`/`srand()` PRNG seed (C's `iPtr->randSeed`); `None`
     /// until first seeded (lazily from a nondeterministic source on first
     /// `rand()`, or explicitly by `srand()`). Kept in `[1, 2^31-2]`.
+    #[cfg(have_tommath)]
     rand_seed: Cell<Option<i64>>,
     /// The TIP 348 error stack (`info errorstack` / the options-dict
     /// `-errorstack`): a flat list of element *values* built bottom-up as an
@@ -756,6 +757,7 @@ pub struct InterpState {
     limits: RefCell<LimitSet>,
     /// Free-running counter that throttles wall-clock polling for the `time`
     /// limit (see [`Interp::limit_check_tick`]).
+    #[cfg(have_tommath)]
     limit_tick: Cell<u32>,
     /// `interp debug -frame` — the TIP 280 frame-debug switch. A one-way latch
     /// (once on, stays on), seeded from `env(TCL_INTERP_DEBUG_FRAME)` at create.
@@ -971,6 +973,7 @@ impl Interp {
             events: RefCell::new(crate::cmd_event::EventQueue::default()),
             coros: RefCell::new(std::collections::BTreeMap::new()),
             ensemble_rewrite: RefCell::new(None),
+            #[cfg(have_tommath)]
             rand_seed: Cell::new(None),
             error_stack: RefCell::new(Vec::new()),
             reset_error_stack: Cell::new(true),
@@ -978,6 +981,7 @@ impl Interp {
             result: Cell::new(result),
             cmd_arena: RefCell::new(CmdArena::default()),
             limits: RefCell::new(LimitSet::default()),
+            #[cfg(have_tommath)]
             limit_tick: Cell::new(0),
             debug_frame: Cell::new(false),
         }));
@@ -3853,6 +3857,7 @@ impl Interp {
     /// source line) so command substitutions inside an `if`/`while`/`for`
     /// expression report their file-absolute line (TIP 280). Returns the previous
     /// `line_base` to hand back to [`restore_line_base`](Self::restore_line_base).
+    #[cfg(have_tommath)]
     pub(crate) fn push_cond_line_base(&self, line: u32) -> Option<u32> {
         self.cmd_frames.borrow_mut().last_mut().map(|top| {
             let old = top.line_base;
@@ -3862,6 +3867,7 @@ impl Interp {
     }
 
     /// Restore a `line_base` saved by [`push_cond_line_base`](Self::push_cond_line_base).
+    #[cfg(have_tommath)]
     pub(crate) fn restore_line_base(&self, old: u32) {
         if let Some(top) = self.cmd_frames.borrow_mut().last_mut() {
             top.line_base = old;
@@ -4528,6 +4534,7 @@ impl Interp {
     /// `expr srand(n)`: reset the PRNG seed to `n` (C's `ExprSrandFunc` — mask
     /// to 31 bits, avoid the LCG's two fixed points), then return the first
     /// `rand()` of the new sequence.
+    #[cfg(have_tommath)]
     pub(crate) fn srand(&self, n: i64) -> f64 {
         let mut seed = n & 0x7FFF_FFFF;
         if seed == 0 || seed == 0x7FFF_FFFF {
@@ -4540,6 +4547,7 @@ impl Interp {
     /// `expr rand()`: advance the Park–Miller minimal-standard LCG and return a
     /// double in `(0, 1)` (C's `ExprRandFunc`). Seeds nondeterministically on
     /// first use if `srand` hasn't run.
+    #[cfg(have_tommath)]
     pub(crate) fn rand_next(&self) -> f64 {
         // Constants from `ExprRandFunc`: IA=16807, IM=2^31-1, IQ=127773, IR=2836.
         const RAND_IA: i64 = 16807;
@@ -5201,6 +5209,7 @@ impl Interp {
 
     /// Whether this interp's `time` limit has elapsed (an absolute wall-clock
     /// deadline). `false` when no time limit is set.
+    #[cfg(have_tommath)]
     pub(crate) fn time_limit_exceeded(&self) -> bool {
         match self.limits.borrow().time_value {
             Some((secs, millis)) => {
@@ -5213,6 +5222,7 @@ impl Interp {
 
     /// Whether a `time` limit is configured at all — the cheap guard the loop
     /// commands check before paying for a wall-clock read.
+    #[cfg(have_tommath)]
     pub(crate) fn has_time_limit(&self) -> bool {
         self.limits.borrow().time_value.is_some()
     }
@@ -5222,6 +5232,7 @@ impl Interp {
     /// its `Code`. Called from the loop commands (`while`/`for`) each iteration
     /// so an unbounded loop under `interp limit $i time` terminates. A guarded
     /// no-op when no time limit is set.
+    #[cfg(have_tommath)]
     pub(crate) fn limit_check_tick(&mut self) -> Option<Code> {
         if !self.has_time_limit() {
             return None;
@@ -5949,6 +5960,7 @@ impl Interp {
 
     /// `subst` — substitute variables / commands / backslashes in `src` per
     /// `flags`, propagating errors (an unset variable or a failing `[...]`).
+    #[cfg(have_tommath)]
     pub(crate) fn do_subst(
         &mut self,
         src: &[u8],

--- a/rust/tcl-cli-support/src/input.rs
+++ b/rust/tcl-cli-support/src/input.rs
@@ -69,6 +69,24 @@ pub struct InputDocument {
     pub path: Option<PathBuf>,
 }
 
+impl InputDocument {
+    /// The analysis dialect for this document.
+    ///
+    /// An explicitly-passed `--dialect` wins; otherwise the registry's
+    /// standard detection runs over the document (a `# tcl-dialect:` /
+    /// shebang / content signal, then the file extension), falling back to
+    /// `tcl8.6` — the same priority order the LSP server applies, so `tcl
+    /// diag` and the editor report the same set for the same file.
+    #[must_use]
+    pub fn effective_dialect(&self, explicit: Option<&str>) -> String {
+        if let Some(d) = explicit {
+            return d.to_string();
+        }
+        let filename = self.path.as_deref().and_then(Path::to_str);
+        tcl_registry::dialects::detect_dialect(&self.source, filename, "tcl8.6").to_string()
+    }
+}
+
 /// `pkgIndex.tcl` is always accepted; otherwise the extension must be known.
 fn is_supported_source_file(path: &Path) -> bool {
     if path.file_name().is_some_and(|n| n == "pkgIndex.tcl") {

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -75,9 +75,11 @@ pub struct InputArgs {
     #[arg(long = "package-path", value_name = "DIR")]
     pub package_path: Vec<PathBuf>,
 
-    /// Dialect profile for parsing and registry lookups.
-    #[arg(long, default_value = "tcl8.6", value_name = "DIALECT")]
-    pub dialect: String,
+    /// Dialect profile for parsing and registry lookups. Defaults to
+    /// per-file auto-detection (a `# tcl-dialect:` directive, shebang,
+    /// content signals, then the file extension), falling back to tcl8.6.
+    #[arg(long, value_name = "DIALECT")]
+    pub dialect: Option<String>,
 
     /// Do not recurse into input directories.
     #[arg(long = "no-recursive")]
@@ -86,6 +88,19 @@ pub struct InputArgs {
     /// Output path ('-' or omitted for stdout).
     #[arg(long, short, value_name = "FILE")]
     pub output: Option<PathBuf>,
+}
+
+impl InputArgs {
+    /// The `--dialect` value with the historical `tcl8.6` fallback — for
+    /// verbs that take one dialect for the whole invocation (transforms,
+    /// graphs, explore).  The diagnostics verbs (`diag` / `lint` /
+    /// `validate`) instead resolve per document via
+    /// [`tcl_cli_support::InputDocument::effective_dialect`], which layers
+    /// in-source / filename detection under an explicit flag.
+    #[must_use]
+    pub fn dialect_or_default(&self) -> &str {
+        self.dialect.as_deref().unwrap_or("tcl8.6")
+    }
 }
 
 /// Paired `--colour` / `--no-colour` toggle (resolved against config + TTY).

--- a/rust/tcl-cli/src/commands/compile.rs
+++ b/rust/tcl-cli/src/commands/compile.rs
@@ -62,7 +62,7 @@ fn maybe_optimise(source: &str, registry: &CommandRegistry, optimise_on: bool) -
 /// `tcl dis` — compile source and emit human-readable bytecode disassembly.
 pub fn run_dis(input: &InputArgs, optimise_on: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let registry = registry_for_dialect(&input.dialect);
+    let registry = registry_for_dialect(input.dialect_or_default());
     let source = maybe_optimise(&combine_sources(&documents), registry, optimise_on);
 
     let ir = lower_to_ir_for_bytecode(&source, registry);
@@ -161,7 +161,7 @@ fn run_compwasm_tree_walker(
     wat_output: Option<&std::path::Path>,
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let registry = registry_for_dialect(&input.dialect);
+    let registry = registry_for_dialect(input.dialect_or_default());
     let source = combine_sources(&documents);
 
     let ir = lower_to_ir(&source, registry);

--- a/rust/tcl-cli/src/commands/diag.rs
+++ b/rust/tcl-cli/src/commands/diag.rs
@@ -26,7 +26,7 @@ use std::collections::HashSet;
 
 use serde::Serialize;
 use tcl_cli_support::{
-    OutputTarget, read_input_documents, registry_for_dialect, write_text_output,
+    InputDocument, OutputTarget, read_input_documents, registry_for_dialect, write_text_output,
 };
 use tcl_compiler::analyser::{Analyser, Severity};
 use tcl_compiler::compilation_unit::CompilationUnit;
@@ -142,11 +142,15 @@ struct Row {
 /// domain of the `optimise` verb, so they are dropped here — the same split the
 /// server draws with its optimiser toggle. Rows come back in a deterministic
 /// `(line, column, code)` order; `disabled` removes `--disable`d codes.
-fn collect_rows(source: &str, dialect: &str, disabled: &HashSet<String>) -> Vec<Row> {
+fn collect_rows(document: &InputDocument, dialect: &str, disabled: &HashSet<String>) -> Vec<Row> {
+    let source = document.source.as_str();
     let line_index = LineIndex::new(source);
     let mut rows: Vec<Row> = Vec::new();
 
-    let result = Analyser::new().analyse(source, dialect);
+    let file_path = document.path.as_deref().map(|p| p.display().to_string());
+    let result = Analyser::new()
+        .with_file_path(file_path)
+        .analyse(source, dialect);
     for d in &result.diagnostics {
         if disabled.contains(d.code.as_str()) {
             continue;
@@ -197,7 +201,8 @@ pub fn run_diag(input: &InputArgs, diag: &DiagArgs) -> anyhow::Result<u8> {
     let mut diagnostic_count = 0usize;
 
     for document in &documents {
-        let rows = collect_rows(&document.source, &input.dialect, &disabled);
+        let dialect = document.effective_dialect(input.dialect.as_deref());
+        let rows = collect_rows(document, &dialect, &disabled);
         let mut items = Vec::with_capacity(rows.len());
         for r in rows {
             diagnostic_count += 1;
@@ -253,7 +258,8 @@ pub fn run_validate(input: &InputArgs, diag: &DiagArgs) -> anyhow::Result<u8> {
 
     let mut errors: Vec<ValidateError> = Vec::new();
     for document in &documents {
-        for r in collect_rows(&document.source, &input.dialect, &disabled) {
+        let dialect = document.effective_dialect(input.dialect.as_deref());
+        for r in collect_rows(document, &dialect, &disabled) {
             if r.severity == Severity::Error {
                 errors.push(ValidateError {
                     file: document.label.clone(),

--- a/rust/tcl-cli/src/commands/diagram.rs
+++ b/rust/tcl-cli/src/commands/diagram.rs
@@ -37,11 +37,11 @@ use crate::cli::InputArgs;
 pub fn run_diagram(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&input.dialect);
+    let registry = registry_for_dialect(input.dialect_or_default());
     let data = diagram::diagram_data_with_config(
         &source,
         registry,
-        tcl_lexer::LexerConfig::for_dialect(&input.dialect),
+        tcl_lexer::LexerConfig::for_dialect(input.dialect_or_default()),
     );
 
     let target = OutputTarget::from_arg(input.output.as_deref());

--- a/rust/tcl-cli/src/commands/explore.rs
+++ b/rust/tcl-cli/src/commands/explore.rs
@@ -44,10 +44,10 @@ pub fn run_explore(
     let source = combine_sources(&documents);
 
     if tui {
-        return run_tui(&source, &input.dialect);
+        return run_tui(&source, input.dialect_or_default());
     }
 
-    let result = tcl_explorer::run_pipeline(&source, &input.dialect);
+    let result = tcl_explorer::run_pipeline(&source, input.dialect_or_default());
     let value = tcl_explorer::serialise_result(&result);
 
     let target = OutputTarget::from_arg(input.output.as_deref());

--- a/rust/tcl-cli/src/commands/graphs.rs
+++ b/rust/tcl-cli/src/commands/graphs.rs
@@ -190,7 +190,7 @@ fn collect_scope_entries(
 pub fn run_symbols(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let source = combine_sources(&documents);
-    let result = Analyser::new().analyse(&source, &input.dialect);
+    let result = Analyser::new().analyse(&source, input.dialect_or_default());
     let line_index = LineIndex::new(&source);
 
     let mut entries = detect_event_entries(&source, &line_index);
@@ -201,7 +201,7 @@ pub fn run_symbols(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     if json {
         let payload = SymbolsPayload {
             count: entries.len(),
-            dialect: input.dialect.clone(),
+            dialect: input.dialect_or_default().to_string(),
             inputs: documents.iter().map(|d| d.label.clone()).collect(),
             symbols: entries,
         };
@@ -302,7 +302,7 @@ fn append_symbolgraph_scope(lines: &mut Vec<String>, scope: &Value, depth: usize
 pub fn run_symbolgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let source = combine_sources(&documents);
-    let data = graphs::symbol_graph(&source, &input.dialect);
+    let data = graphs::symbol_graph(&source, input.dialect_or_default());
 
     let summary = data.get("summary").cloned().unwrap_or_else(|| json!({}));
     let count = |key: &str| summary.get(key).and_then(Value::as_i64).unwrap_or(0);
@@ -338,8 +338,8 @@ pub fn run_symbolgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> 
 pub fn run_callgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&input.dialect);
-    let data = graphs::call_graph(&source, registry, &input.dialect);
+    let registry = registry_for_dialect(input.dialect_or_default());
+    let data = graphs::call_graph(&source, registry, input.dialect_or_default());
 
     let target = OutputTarget::from_arg(input.output.as_deref());
 
@@ -426,8 +426,8 @@ pub fn run_callgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
 pub fn run_dataflow(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&input.dialect);
-    let data = graphs::dataflow_graph(&source, registry, &input.dialect);
+    let registry = registry_for_dialect(input.dialect_or_default());
+    let data = graphs::dataflow_graph(&source, registry, input.dialect_or_default());
 
     let target = OutputTarget::from_arg(input.output.as_deref());
 

--- a/rust/tcl-cli/src/commands/highlight.rs
+++ b/rust/tcl-cli/src/commands/highlight.rs
@@ -40,9 +40,9 @@ pub fn run_highlight(input: &InputArgs, format: &str, colour: &ColourArgs) -> an
     let target = OutputTarget::from_arg(input.output.as_deref());
 
     let mut out = if format == "html" {
-        highlight_html(&source, &input.dialect)
+        highlight_html(&source, input.dialect_or_default())
     } else if resolve_use_colour(colour.colour, colour.no_colour, &target) {
-        highlight_ansi(&source, &input.dialect)
+        highlight_ansi(&source, input.dialect_or_default())
     } else {
         source
     };

--- a/rust/tcl-cli/src/commands/minimize.rs
+++ b/rust/tcl-cli/src/commands/minimize.rs
@@ -369,7 +369,7 @@ pub fn run_minimize(input: &InputArgs, no_rename: bool, json: bool) -> anyhow::R
 
     let mut results: Vec<MinimizeItem> = Vec::new();
     for document in &documents {
-        match minimize_diagnostic(&document.source, code, rename, &input.dialect) {
+        match minimize_diagnostic(&document.source, code, rename, input.dialect_or_default()) {
             Ok(r) => results.push(MinimizeItem {
                 file: document.label.clone(),
                 code: r.code,

--- a/rust/tcl-cli/src/commands/misc.rs
+++ b/rust/tcl-cli/src/commands/misc.rs
@@ -78,7 +78,7 @@ pub fn run_find_legacy(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let source = combine_sources(&documents);
 
-    let result = Analyser::new().analyse(&source, &input.dialect);
+    let result = Analyser::new().analyse(&source, input.dialect_or_default());
     let line_index = LineIndex::new(&source);
 
     let issues: Vec<LegacyIssue> = result
@@ -102,7 +102,7 @@ pub fn run_find_legacy(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     if json {
         let payload = LegacyPayload {
             count: issues.len(),
-            dialect: input.dialect.clone(),
+            dialect: input.dialect_or_default().to_string(),
             issues,
         };
         let rendered = ensure_ascii(&serde_json::to_string_pretty(&payload)?);

--- a/rust/tcl-cli/src/commands/transform.rs
+++ b/rust/tcl-cli/src/commands/transform.rs
@@ -53,12 +53,12 @@ pub fn run_format(
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&input.dialect);
+    let registry = registry_for_dialect(input.dialect_or_default());
 
     let mut config = FormatterConfig {
         // Tokenise with the dialect's rules so, e.g., an iRule's `}{` (valid in
         // TMM) parses as two words and is re-emitted as `} {`.
-        lexer_config: tcl_lexer::LexerConfig::for_dialect(&input.dialect),
+        lexer_config: tcl_lexer::LexerConfig::for_dialect(input.dialect_or_default()),
         ..Default::default()
     };
     if let Some(size) = indent_size {
@@ -90,7 +90,7 @@ pub fn run_format(
         &formatted,
         use_colour,
         DEFAULT_TAB_WIDTH,
-        &input.dialect,
+        input.dialect_or_default(),
     )?;
     Ok(0)
 }
@@ -108,8 +108,8 @@ pub fn run_opt(
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&input.dialect);
-    let dialect = Some(input.dialect.as_str());
+    let registry = registry_for_dialect(input.dialect_or_default());
+    let dialect = Some(input.dialect_or_default());
 
     let profile = OptimisationProfile::parse(profile);
     let mut disabled: HashSet<String> = profile_to_disabled(profile)
@@ -168,7 +168,7 @@ pub fn run_opt(
         &rendered,
         use_colour,
         DEFAULT_TAB_WIDTH,
-        &input.dialect,
+        input.dialect_or_default(),
     )?;
 
     if !target.is_stdout() {
@@ -192,19 +192,23 @@ pub fn run_minify(
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(&input.dialect);
+    let registry = registry_for_dialect(input.dialect_or_default());
 
     let target = OutputTarget::from_arg(input.output.as_deref());
     let use_colour = tcl_cli_support::resolve_use_colour(colour.colour, colour.no_colour, &target);
 
     let (rendered, map) = if aggressive {
-        let result = minify_tcl_aggressive(&source, &input.dialect, isolated, registry);
+        let result = minify_tcl_aggressive(&source, input.dialect_or_default(), isolated, registry);
         (result.source, Some(result.symbol_map))
     } else if compact {
-        let (minified, sm) = minify_tcl_compact(&source, &input.dialect, isolated, registry);
+        let (minified, sm) =
+            minify_tcl_compact(&source, input.dialect_or_default(), isolated, registry);
         (minified, Some(sm))
     } else {
-        (minify_tcl(&source, &input.dialect, registry), None)
+        (
+            minify_tcl(&source, input.dialect_or_default(), registry),
+            None,
+        )
     };
 
     write_highlighted_output(
@@ -212,7 +216,7 @@ pub fn run_minify(
         &rendered,
         use_colour,
         DEFAULT_TAB_WIDTH,
-        &input.dialect,
+        input.dialect_or_default(),
     )?;
 
     if let Some(path) = symbol_map {

--- a/rust/tcl-compiler/src/analyser/class_hierarchy.rs
+++ b/rust/tcl-compiler/src/analyser/class_hierarchy.rs
@@ -160,6 +160,24 @@ impl ClassHierarchy {
             .map(|((cls, _meth), provider)| (cls.clone(), provider.clone()))
             .collect()
     }
+
+    /// Every method name callable on `class_name` — instance and class
+    /// methods declared anywhere on its linearised MRO — sorted and
+    /// deduplicated.  Feeds the W308 "did you mean…?" suggestion list;
+    /// empty for an unknown class.
+    #[must_use]
+    pub fn known_methods(&self, class_name: &str) -> Vec<String> {
+        let mut out: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        if let Some(mro) = self.mro_map.get(class_name) {
+            for ancestor in mro {
+                if let Some(cd) = self.classes.get(ancestor) {
+                    out.extend(cd.methods.keys().cloned());
+                    out.extend(cd.class_methods.keys().cloned());
+                }
+            }
+        }
+        out.into_iter().collect()
+    }
 }
 
 /// Build a [`ClassHierarchy`] from a dict of class definitions.

--- a/rust/tcl-compiler/src/analyser/class_lattice.rs
+++ b/rust/tcl-compiler/src/analyser/class_lattice.rs
@@ -442,15 +442,11 @@ fn import_prefix(pattern: &str) -> String {
 }
 
 /// Join a namespace prefix and a (possibly-relative) name into a fully
-/// qualified `::`-name, collapsing duplicate separators.
+/// qualified `::`-name — the canonical [`crate::naming`] join.  Notably an
+/// *absolute* `name` keeps its own namespace (the previous local join
+/// re-prefixed `::other::C` under the current namespace).
 fn qualify(prefix: &str, name: &str) -> String {
-    let p = prefix.trim_end_matches("::");
-    let n = name.trim_start_matches("::");
-    if p.is_empty() || p == "::" {
-        format!("::{n}")
-    } else {
-        format!("{p}::{n}")
-    }
+    crate::naming::qualify(prefix, name)
 }
 
 /// Resolve a possibly-bare / namespace-relative class name to a qualified

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1350,6 +1350,14 @@ impl Analyser {
         // the IRULE5005 emitter never sees it.  Matches the top-level
         // `process_command` ordering (proc-resolution after site recording).
         self.emit_proc_resolution_diagnostics(&cmd_name, args, cmd_tok, scope_path);
+        // A `package require` nested in a `[…]` substitution still runs — the
+        // guarded-optional-dependency idiom puts it exactly there
+        // (`if {[catch {package require Tk} err]} { … fallback … }`), and the
+        // body collector descends `catch`'s script argument to reach it. Without
+        // this, W120 ("requires `package require Tk`") false-positives on every
+        // file using the standard guard, and the W123 conservative
+        // any-require-seen gate never engages.
+        self.handle_package_command(&cmd_name, cmd_tok, args, arg_tokens);
         // A `catch SCRIPT ?resultVar? ?optionsVar?` nested in a `[...]`
         // substitution (`set out [catch {…} msg]`, `if {[catch {…} e]} …`)
         // still binds its result/options variables in the enclosing scope, so

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -357,6 +357,7 @@ impl Analyser {
             self.record_var_or_cmd_command_site(
                 cmd_tok,
                 args,
+                arg_tokens,
                 arg_expand_in.get(1..).unwrap_or(&[]),
                 scope_path,
             );
@@ -1340,6 +1341,7 @@ impl Analyser {
         self.record_var_or_cmd_command_site(
             cmd_tok,
             args,
+            arg_tokens,
             arg_expand.get(1..).unwrap_or(&[]),
             scope_path,
         );
@@ -1500,10 +1502,16 @@ impl Analyser {
         &mut self,
         cmd_tok: Token,
         args: &[String],
+        arg_tokens: &[Token],
         arg_expand: &[bool],
         scope_path: &[usize],
     ) {
         let in_method = self.scope_path_in_method_body(scope_path);
+        // Content span of the method word (delimiters trimmed) — the tight
+        // W308 anchor and "did you mean" fix target.
+        let method_span = arg_tokens.first().map(|t| {
+            tcl_lexer::Span::new(t.span.start() + u32::from(t.content_offset), t.span.end())
+        });
         match cmd_tok.kind {
             TokenType::Var => {
                 let sm = tcl_lexer::SourceMap::new(&self.source);
@@ -1524,6 +1532,7 @@ impl Analyser {
                 self.var_command_sites.push(super::state::VarCommandSite {
                     var_name,
                     method_name,
+                    method_span,
                     cmd_span: cmd_tok.span,
                     in_method,
                     argc: args.len(),
@@ -1537,6 +1546,7 @@ impl Analyser {
                 self.cmd_command_sites.push(super::state::CmdCommandSite {
                     cmd_text,
                     method_name,
+                    method_span,
                     cmd_span: cmd_tok.span,
                     in_method,
                 });

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -282,10 +282,28 @@ impl Analyser {
                 &cbn_proc_index,
             ));
             cross_event_vars.extend(traced_globals.iter().cloned());
+            // Consumer-side cross-event suppression for W210: a variable
+            // another event on the same connection defines (and the event
+            // registry's scope gate accepted the pair) is set by the time
+            // this event reads it — `set g 1` in HTTP_REQUEST feeds
+            // `set x $g` in HTTP_RESPONSE, so the read is not
+            // read-before-set. `cross_event_imports` is exactly that set;
+            // without threading it here the RBS pass saw only an empty
+            // `extra_known_defined` and flagged every such read.
+            let extra_known_defined: HashSet<String> =
+                if let Some(scope) = cu.connection_scope.as_ref() {
+                    if qname.starts_with("::when::") {
+                        scope.cross_event_imports.iter().cloned().collect()
+                    } else {
+                        HashSet::new()
+                    }
+                } else {
+                    HashSet::new()
+                };
             self.emit_cfg_ssa_diagnostics_for_function_full(
                 fu,
                 &cu.ir_module,
-                &HashSet::new(),
+                &extra_known_defined,
                 &cross_event_vars,
             );
             self.emit_channel_diagnostics(fu, registry);

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -419,10 +419,15 @@ file; this call falls through to the 'unknown' handler."
 
     /// Narrow a whole-command span to the `$var` read token for *var*,
     /// returning that token's absolute span — or `None` when no matching
-    /// top-level `Var` token is found (e.g. the read is nested inside a
-    /// quoted/compound word, where the caller falls back to the command
-    /// span).  W210 anchors at the variable read, not the command-start
-    /// column.
+    /// `Var` token is found anywhere in the statement (the caller falls
+    /// back to the command span).  W210 anchors at the variable read, not
+    /// the command-start column.
+    ///
+    /// The read is frequently nested inside a command substitution
+    /// (`set x [cmd $var]`, `if {[llength $var]} …`), so the scan descends
+    /// into `Cmd` tokens' inner scripts rather than stopping at the
+    /// top-level word walk.  Braced (`Str`) words are literal text — a
+    /// `$var` inside one is not a read — so they are never descended.
     fn narrow_to_read_var(&self, stmt_span: tcl_lexer::Span, var: &str) -> Option<tcl_lexer::Span> {
         // De-sigil + drop any array-index suffix so `$a(k)` / `${a}` / `$a`
         // all compare equal to the chain's scalar/element base name.
@@ -433,19 +438,58 @@ file; this call falls through to the 'unknown' handler."
             );
             inner.split('(').next().unwrap_or(inner)
         }
+        /// First `$target` `Var` token within `slice` (whose absolute start
+        /// is `abs_base`), descending into command-substitution contents.
+        /// `depth` bounds pathological nesting.
+        fn find_var(
+            slice: &str,
+            abs_base: u32,
+            target: &str,
+            config: tcl_lexer::LexerConfig,
+            depth: u8,
+        ) -> Option<tcl_lexer::Span> {
+            if depth > 4 {
+                return None;
+            }
+            let sm = tcl_lexer::SourceMap::new(slice);
+            let toks = tcl_lexer::Lexer::with_source_map(tcl_lexer::SourceMap::new(slice), config)
+                .tokenise_all()
+                .ok()?;
+            for t in &toks {
+                match t.kind {
+                    tcl_lexer::TokenType::Var if base(sm.token_text(*t)) == target => {
+                        return Some(tcl_lexer::Span::new(
+                            t.span.start() + abs_base,
+                            t.span.end() + abs_base,
+                        ));
+                    }
+                    // A `[…]` word: recurse into its inner script (the span
+                    // covers `[inner` and excludes the closing `]`; the
+                    // content starts past the opening bracket).
+                    tcl_lexer::TokenType::Cmd => {
+                        let content_start = t.span.start() as usize + usize::from(t.content_offset);
+                        let content_end = t.span.end() as usize;
+                        if let Some(inner) = slice.get(content_start..content_end)
+                            && inner.contains('$')
+                            && let Some(found) = find_var(
+                                inner,
+                                abs_base + t.span.start() + u32::from(t.content_offset),
+                                target,
+                                config,
+                                depth + 1,
+                            )
+                        {
+                            return Some(found);
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            None
+        }
         let target = base(var);
-        let start = stmt_span.start();
         let slice = source_slice(&self.source, stmt_span)?;
-        let sm = tcl_lexer::SourceMap::new(&slice);
-        let toks = tcl_lexer::Lexer::with_source_map(
-            tcl_lexer::SourceMap::new(&slice),
-            self.lexer_config(),
-        )
-        .tokenise_all()
-        .ok()?;
-        toks.iter()
-            .find(|t| t.kind == tcl_lexer::TokenType::Var && base(sm.token_text(**t)) == target)
-            .map(|t| tcl_lexer::Span::new(t.span.start() + start, t.span.end() + start))
+        find_var(&slice, stmt_span.start(), target, self.lexer_config(), 0)
     }
 
     /// W211 — unused-variable hint.
@@ -1979,7 +2023,8 @@ file; this call falls through to the 'unknown' handler."
                     }
                 }
                 if let Some((msg, sev)) = diag {
-                    self.emit_ip_diag_at_def(fu, *key, &msg, sev, &mut seen_offsets);
+                    let literal = &text[quad.start..quad.end];
+                    self.emit_ip_diag_at_def(fu, *key, &msg, sev, Some(literal), &mut seen_offsets);
                     break;
                 }
             }
@@ -1988,7 +2033,14 @@ file; this call falls through to the 'unknown' handler."
             for candidate in find_ipv6_candidates(text) {
                 if Ipv6Addr::from_str(candidate).is_err() {
                     let msg = format!("Invalid IPv6 address '{candidate}'.");
-                    self.emit_ip_diag_at_def(fu, *key, &msg, Severity::Error, &mut seen_offsets);
+                    self.emit_ip_diag_at_def(
+                        fu,
+                        *key,
+                        &msg,
+                        Severity::Error,
+                        Some(candidate),
+                        &mut seen_offsets,
+                    );
                     break;
                 }
             }
@@ -1996,12 +2048,18 @@ file; this call falls through to the 'unknown' handler."
     }
 
     /// Helper for [`Self::emit_invalid_ip_diagnostics`].
+    ///
+    /// Anchors on the offending IP `literal` within the def statement when
+    /// it appears verbatim in the source (with non-address bytes on both
+    /// sides), falling back to the whole statement span when the constant
+    /// was folded from parts the source never spells out.
     fn emit_ip_diag_at_def(
         &mut self,
         fu: &crate::compilation_unit::FunctionUnit,
         key: crate::ssa::ValueKey,
         message: &str,
         severity: Severity,
+        literal: Option<&str>,
         seen_offsets: &mut FxHashSet<u32>,
     ) {
         let (sym, version) = key;
@@ -2018,13 +2076,36 @@ file; this call falls through to the 'unknown' handler."
         let Some(stmt) = block.statements.get(idx) else {
             return;
         };
-        let span = fu.abs_span(stmt.span());
-        if span.is_empty() {
+        let stmt_span = fu.abs_span(stmt.span());
+        if stmt_span.is_empty() {
             return;
         }
-        if !seen_offsets.insert(span.start()) {
+        if !seen_offsets.insert(stmt_span.start()) {
             return;
         }
+        // Tight anchor: the literal's own bytes inside the statement, when
+        // the source spells it out directly.
+        let span = literal
+            .and_then(|lit| {
+                let slice = source_slice(&self.source, stmt_span)?;
+                let is_addr_byte = |b: u8| b.is_ascii_hexdigit() || b == b'.' || b == b':';
+                let mut from = 0;
+                while let Some(off) = slice[from..].find(lit) {
+                    let start = from + off;
+                    let end = start + lit.len();
+                    let left_ok = start == 0 || !is_addr_byte(slice.as_bytes()[start - 1]);
+                    let right_ok = end >= slice.len() || !is_addr_byte(slice.as_bytes()[end]);
+                    if left_ok && right_ok {
+                        return Some(tcl_lexer::Span::new(
+                            stmt_span.start() + u32::try_from(start).ok()?,
+                            stmt_span.start() + u32::try_from(end).ok()?,
+                        ));
+                    }
+                    from = start + 1;
+                }
+                None
+            })
+            .unwrap_or(stmt_span);
         self.result.diagnostics.push(super::types::Diagnostic {
             code: DiagCode::W124,
             span,

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
@@ -882,13 +882,18 @@ oo::class create C {
     );
 }
 
-/// FP-SH-15: a proc parameter's entry type is unknown (the caller can pass
-/// anything) — `propagate_types` forces a live-in (SSA version 0) to
-/// OVERDEFINED, so a loop that oscillates a plain positional parameter must
-/// not fire S102. Mirrors [`fp_sh_02_variable_alias_no_shimmer`]'s aliasing
-/// rationale, but for an ordinary (unaliased) parameter.
+/// TP (formerly FP-SH-15): a plain positional parameter oscillated by the
+/// loop body IS thunking — the per-iteration cost (`expr` re-parses the
+/// string arm; `string range` re-stringifies the int arm) is invariant of
+/// what the caller passed in, so the unknown (OVERDEFINED) *entry* type is
+/// no reason to abstain.  The old guard encoded the header-phi path's
+/// evidence limitation; the intra-iteration path proves the cost from the
+/// body's own defs, exactly as the unaliased-local sibling
+/// ([`fp_sh_15_unaliased_method_local_still_fires`]) always expected.  A
+/// genuinely aliased variable (`global` / `variable` / `upvar`) still
+/// abstains — see [`fp_sh_15_tcloo_instance_variable_no_s102`].
 #[test]
-fn fp_sh_15_parameter_seeded_oscillation_no_s102() {
+fn tp_sh_15_parameter_seeded_oscillation_fires_s102() {
     let src = "\
 proc f {p} {
     while {1} {
@@ -897,10 +902,10 @@ proc f {p} {
     }
 }
 ";
-    let got = codes(src, D);
     assert!(
-        !got.iter().any(|c| c == "S102"),
-        "FP-SH-15: parameter-seeded oscillation must not fire S102; got {got:?}"
+        fires(src, D, "S102"),
+        "a parameter oscillated by the body thunks per iteration; got {:?}",
+        codes(src, D)
     );
 }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -53,15 +53,6 @@ pub(super) fn is_word_byte(b: u8) -> bool {
     b.is_ascii_alphanumeric() || b == b'_'
 }
 
-/// Whether `word` is a literal Tcl integer (decimal, with an optional
-/// leading sign).  Used by the W001 unknown-subcommand check to let
-/// `after <ms>` through — `after`'s first word is a delay in
-/// milliseconds, not a subcommand, when it parses as an integer.
-pub(super) fn is_integer_word(word: &str) -> bool {
-    let digits = word.strip_prefix(['+', '-']).unwrap_or(word);
-    !digits.is_empty() && digits.bytes().all(|b| b.is_ascii_digit())
-}
-
 /// One dotted-quad match found in a value: the four octet substrings and
 /// the byte offset where it begins (for context checks like a preceding
 /// `/`).

--- a/rust/tcl-compiler/src/analyser/diagnostics/security.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/security.rs
@@ -1239,6 +1239,7 @@ fn w127_suggestion_fix(
     span: tcl_lexer::Span,
     message: &mut String,
 ) -> Vec<crate::analyser::types::CodeFix> {
+    use std::fmt::Write as _;
     let suggestions = crate::text::suggest_similar(
         value,
         allowed.iter().copied(),
@@ -1248,7 +1249,6 @@ fn w127_suggestion_fix(
     let Some(best) = suggestions.first() else {
         return Vec::new();
     };
-    use std::fmt::Write as _;
     let _ = write!(message, "; did you mean '{best}'?");
     vec![crate::analyser::types::CodeFix {
         span,

--- a/rust/tcl-compiler/src/analyser/diagnostics/security.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/security.rs
@@ -865,7 +865,7 @@ matching time on crafted input."
         arg_tokens: &[tcl_lexer::Token],
         cmd_tok: tcl_lexer::Token,
     ) {
-        let mut hits: Vec<(String, tcl_lexer::Span)> = Vec::new();
+        let mut hits: Vec<W127Hit> = Vec::new();
         if let Some(registry) = self.registry.as_ref() {
             let Some(spec) = registry.get(cmd_name) else {
                 return;
@@ -914,13 +914,13 @@ matching time on crafted input."
                 }
             }
         }
-        for (message, span) in hits {
+        for hit in hits {
             self.result.diagnostics.push(super::types::Diagnostic {
                 code: DiagCode::W127,
-                span,
-                message,
+                span: hit.span,
+                message: hit.message,
                 severity: Severity::Warning,
-                fixes: Vec::new(),
+                fixes: hit.fixes,
             });
         }
     }
@@ -938,7 +938,7 @@ matching time on crafted input."
         arg_tokens: &[tcl_lexer::Token],
         cmd_tok: tcl_lexer::Token,
     ) {
-        let mut hits: Vec<(String, tcl_lexer::Span)> = Vec::new();
+        let mut hits: Vec<W127Hit> = Vec::new();
         if let Some(registry) = self.registry.as_ref() {
             let Some(spec) = registry.get(cmd_name) else {
                 return;
@@ -970,30 +970,30 @@ matching time on crafted input."
                         {
                             continue;
                         }
-                        let allowed_list = allowed
-                            .iter()
-                            .map(|av| av.value)
-                            .collect::<Vec<_>>()
-                            .join(", ");
+                        let allowed_names: Vec<&str> = allowed.iter().map(|av| av.value).collect();
+                        let allowed_list = allowed_names.join(", ");
                         let span = arg_tokens.get(vi).map_or(cmd_tok.span, |t| t.span);
-                        hits.push((
-                            format!(
-                                "Invalid value '{value}' for option '{arg}' on '{cmd_name}'; expected one of: {allowed_list}"
-                            ),
+                        let mut message = format!(
+                            "Invalid value '{value}' for option '{arg}' on '{cmd_name}'; expected one of: {allowed_list}"
+                        );
+                        let fixes = w127_suggestion_fix(value, &allowed_names, span, &mut message);
+                        hits.push(W127Hit {
+                            message,
                             span,
-                        ));
+                            fixes,
+                        });
                     }
                 }
                 i += 1 + vals.len();
             }
         }
-        for (message, span) in hits {
+        for hit in hits {
             self.result.diagnostics.push(super::types::Diagnostic {
                 code: DiagCode::W127,
-                span,
-                message,
+                span: hit.span,
+                message: hit.message,
                 severity: Severity::Warning,
-                fixes: Vec::new(),
+                fixes: hit.fixes,
             });
         }
     }
@@ -1191,7 +1191,7 @@ fn w127_closed_hit(
     accept_prefix: bool,
     opt_names: &std::collections::HashSet<&str>,
     display_name: &str,
-) -> Option<(String, tcl_lexer::Span)> {
+) -> Option<W127Hit> {
     if allowed.is_empty() || value.contains('$') || value.contains('[') || opt_names.contains(value)
     {
         return None;
@@ -1211,10 +1211,50 @@ fn w127_closed_hit(
         return None;
     }
     let allowed_list = allowed.join(", ");
-    Some((
-        format!("Invalid value '{value}' for '{display_name}'; expected one of: {allowed_list}"),
+    let mut message =
+        format!("Invalid value '{value}' for '{display_name}'; expected one of: {allowed_list}");
+    let fixes = w127_suggestion_fix(value, allowed, span, &mut message);
+    Some(W127Hit {
+        message,
         span,
-    ))
+        fixes,
+    })
+}
+
+/// One W127 finding: the message, its anchor, and the "did you mean…?"
+/// replace fix (empty when no allowed value is close enough).
+struct W127Hit {
+    message: String,
+    span: tcl_lexer::Span,
+    fixes: Vec<crate::analyser::types::CodeFix>,
+}
+
+/// Append a "; did you mean 'X'?" suffix to `message` and build the
+/// replace fix when one allowed value sits within the length-scaled edit
+/// budget of `value`.  The allowed set is already in the message, so a
+/// missing suggestion loses nothing.
+fn w127_suggestion_fix(
+    value: &str,
+    allowed: &[&str],
+    span: tcl_lexer::Span,
+    message: &mut String,
+) -> Vec<crate::analyser::types::CodeFix> {
+    let suggestions = crate::text::suggest_similar(
+        value,
+        allowed.iter().copied(),
+        1,
+        crate::text::scaled_max_distance(value),
+    );
+    let Some(best) = suggestions.first() else {
+        return Vec::new();
+    };
+    use std::fmt::Write as _;
+    let _ = write!(message, "; did you mean '{best}'?");
+    vec![crate::analyser::types::CodeFix {
+        span,
+        new_text: (*best).to_string(),
+        description: format!("Replace with '{best}'"),
+    }]
 }
 
 /// True when the **source** slice `raw` (backslashes intact) carries a

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -7723,3 +7723,87 @@ fn tcltest_import_is_namespace_scoped() {
         test t {d} { expr $x+1 } {}\n";
     assert_eq!(count_code(top_level, "W100"), 1);
 }
+
+/// tclpkg manifest whole-file scoped environment (`tcl_registry::scoped::
+/// file_scope_env` keyed on the `tclpkg.tcl` basename): directives resolve
+/// against the environment, never against same-named Tcl/Tk commands.
+mod tclpkg_manifest_env {
+    use super::*;
+
+    const MANIFEST: &str = "\
+package     demo-app
+version     0.1.0
+description \"A demo\"
+license     MIT
+author      \"Dev <dev@example.org>\"
+
+tcl >=8.6
+
+require json    1.0.0
+require http    2.9.0
+
+dev-require tcltest 2.5.0
+
+provides demo::serve
+entry    main.tcl
+";
+
+    fn diags_for(path: Option<&str>) -> Vec<Diagnostic> {
+        let mut analyser =
+            crate::analyser::Analyser::new().with_file_path(path.map(str::to_string));
+        analyser.analyse(MANIFEST, "tcl8.6").diagnostics
+    }
+
+    /// TN: every directive resolves in the manifest environment — no
+    /// unknown-command / unknown-subcommand / missing-package noise.
+    #[test]
+    fn manifest_directives_resolve_cleanly() {
+        let diags = diags_for(Some("/proj/tclpkg.tcl"));
+        assert!(
+            diags.is_empty(),
+            "a valid manifest must produce no diagnostics: {diags:?}"
+        );
+    }
+
+    /// TP control: the same text WITHOUT the manifest file name is plain
+    /// Tcl — the directives draw their usual diagnostics (the environment
+    /// must never leak into ordinary documents).
+    #[test]
+    fn plain_tcl_document_still_flags_directives() {
+        let diags = diags_for(Some("/proj/other.tcl"));
+        assert!(
+            diags.iter().any(|d| d.code == DiagCode::W123),
+            "outside a manifest the directives are unknown commands: {diags:?}"
+        );
+    }
+
+    /// TP: a typo'd directive still draws W123 — the environment is closed.
+    #[test]
+    fn manifest_typo_directive_fires_w123() {
+        let mut analyser =
+            crate::analyser::Analyser::new().with_file_path(Some("/proj/tclpkg.tcl".to_string()));
+        let result = analyser.analyse("package demo\nverison 0.1.0\n", "tcl8.6");
+        assert!(
+            result
+                .diagnostics
+                .iter()
+                .any(|d| d.code == DiagCode::W123 && d.message.contains("verison")),
+            "a typo'd directive must stay unknown: {:?}",
+            result.diagnostics
+        );
+    }
+
+    /// TP: a directive arity error is checked against the manifest
+    /// grammar (`require <name> <minimum> ?-source <url>?`).
+    #[test]
+    fn manifest_directive_arity_checked() {
+        let mut analyser =
+            crate::analyser::Analyser::new().with_file_path(Some("/proj/tclpkg.tcl".to_string()));
+        let result = analyser.analyse("package demo\nrequire json\n", "tcl8.6");
+        assert!(
+            result.diagnostics.iter().any(|d| d.code == DiagCode::E002),
+            "`require` with one argument is below the directive's minimum: {:?}",
+            result.diagnostics
+        );
+    }
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -36,13 +36,15 @@ use crate::analyser::types::Severity;
 
 /// The "known command name" sets consulted by the W123 unresolved-command
 /// pass: registry names enabled in the active dialect, the simple-name tails
-/// of user procs / classes / aliases / ensemble commands, inline-stub names,
-/// and the deduplicated candidate list for "did you mean…?" suggestions.
+/// of user procs / classes / aliases / rename targets / ensemble commands,
+/// inline-stub names, and the deduplicated candidate list for "did you
+/// mean…?" suggestions.
 struct W123KnownNames {
     registry_names: HashSet<String>,
     proc_tail_names: HashSet<String>,
     class_tail_names: HashSet<String>,
     alias_names: HashSet<String>,
+    rename_target_names: HashSet<String>,
     ensemble_cmds: HashSet<String>,
     stub_names: HashSet<String>,
     candidates: Vec<String>,
@@ -66,6 +68,7 @@ impl Analyser {
     /// - User-defined proc tail or absolute name.
     /// - User-defined class tail or absolute name.
     /// - Command alias tail.
+    /// - Static `rename OLD NEW` target tail.
     /// - Ensemble namespace tail.
     ///
     /// Idempotency: ``self.unresolved_commands_emitted`` guards
@@ -193,6 +196,24 @@ impl Analyser {
             .filter_map(|qn| qn.rsplit_once("::").map(|(_, t)| t.to_string()))
             .filter(|s| !s.is_empty())
             .collect();
+        // A static `rename OLD NEW` binds `NEW` to whatever `OLD` denoted —
+        // `NEW` is a callable command from the rename onward, so calls to it
+        // must not draw W123 (the same-file arity resolver already validates
+        // them against `OLD`'s signature via `renamed_commands`). Deletion is
+        // order-gated exactly like `alias_names` above: a `NEW` whose most
+        // recent action in the file is a deletion (`rename NEW {}`, or `NEW`
+        // renamed away again) is no longer callable at file end.
+        let rename_target_names: HashSet<String> = self
+            .renamed_commands
+            .keys()
+            .filter(|qn| {
+                self.deleted_commands
+                    .get(qn.as_str())
+                    .is_none_or(|&del_off| self.rename_offsets.get(qn.as_str()) > Some(&del_off))
+            })
+            .filter_map(|qn| qn.rsplit_once("::").map(|(_, t)| t.to_string()))
+            .filter(|s| !s.is_empty())
+            .collect();
         let ensemble_cmds: HashSet<String> = self
             .ensemble_namespaces
             .iter()
@@ -209,6 +230,7 @@ impl Analyser {
         candidates.extend(proc_tail_names.iter().cloned());
         candidates.extend(class_tail_names.iter().cloned());
         candidates.extend(alias_names.iter().cloned());
+        candidates.extend(rename_target_names.iter().cloned());
         candidates.extend(ensemble_cmds.iter().cloned());
         candidates.extend(stub_names.iter().cloned());
         // User-declared extra commands (`tclLsp.extraCommands`) are known.
@@ -224,6 +246,7 @@ impl Analyser {
             proc_tail_names,
             class_tail_names,
             alias_names,
+            rename_target_names,
             ensemble_cmds,
             stub_names,
             candidates,
@@ -274,6 +297,9 @@ impl Analyser {
             if known.alias_names.contains(name) {
                 continue;
             }
+            if known.rename_target_names.contains(name) {
+                continue;
+            }
             if known.ensemble_cmds.contains(name) {
                 continue;
             }
@@ -321,14 +347,19 @@ impl Analyser {
                 continue;
             }
 
-            // "Did you mean…?" suggestion
-            // via Levenshtein (max 1 suggestion, max distance 2).
+            // "Did you mean…?" suggestion via edit distance (max 1
+            // suggestion, budget scaled to the name's length so a short
+            // typo can't match an unrelated short command).
             // ``candidate_strs`` was
             // deduplicated above so every name in it is unique;
             // copying the slice per invocation is cheap (Vec of
             // ``&str`` references).
-            let suggestions =
-                crate::text::suggest_similar(name, candidate_strs.iter().copied(), 1, 2);
+            let suggestions = crate::text::suggest_similar(
+                name,
+                candidate_strs.iter().copied(),
+                1,
+                crate::text::scaled_max_distance(name),
+            );
             let mut message = format!("Unknown command '{name}'");
             let mut fixes: Vec<super::types::CodeFix> = Vec::new();
             if let Some(best) = suggestions.first() {
@@ -459,6 +490,14 @@ impl Analyser {
                 continue;
             };
             if spec.required_package.is_none() {
+                continue;
+            }
+            // A head resolved by a scoped command environment at its call
+            // site is that environment's command, not the package-gated
+            // registry command it happens to share a name with — `entry`
+            // in a tclpkg manifest is the entry-point directive, never the
+            // Tk widget, so no `package require Tk` is missing.
+            if self.is_scoped_command_resolved(&inv.name, inv.range) {
                 continue;
             }
             best.entry(inv.name.as_str())

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -60,27 +60,49 @@ struct ArityWords<'a> {
 /// [`Analyser::check_simple_arity`]'s original inline formula exactly;
 /// shared here so [`Analyser::queue_user_call_arity_candidate`] doesn't
 /// reimplement it.
-/// The tight E003 highlight: the span covering the run of *surplus*
-/// positional arguments, from the first argument past the command's `max`
-/// up to the last argument. `positional_start` is the index of the first
-/// positional word (after any leading option flags), `max` the command's
-/// maximum positional count. Returns `None` — so [`arity_verdict`] falls
-/// back to the whole-command span — when the positional region contains a
-/// `{*}` expansion (which makes "the first surplus word" ambiguous) or the
-/// index arithmetic can't land on a real token.
+/// The tight E003 anchor: the span covering the run of *surplus*
+/// positional arguments (from the first argument past the command's `max`
+/// up to the last argument), plus where a "remove surplus arguments" fix
+/// should start deleting — the end of the last *kept* word, so the fix
+/// also removes the separating whitespace.
+pub(super) struct ExcessArgs {
+    /// Span of the surplus argument run (diagnostic anchor).
+    pub span: tcl_lexer::Span,
+    /// Deletion start for the removal fix (end of the preceding word).
+    pub delete_from: u32,
+}
+
+/// Compute the [`ExcessArgs`] anchor. `positional_start` is the index of
+/// the first positional word (after any leading option flags), `max` the
+/// command's maximum positional count, `fallback_delete_from` the widened
+/// end of whatever word precedes the first positional (the command head or
+/// subcommand word) for the `max == 0` case. Returns `None` — so
+/// [`arity_verdict`] falls back to the whole-command span — when the
+/// positional region contains a `{*}` expansion (which makes "the first
+/// surplus word" ambiguous) or the index arithmetic can't land on a real
+/// token.
 fn excess_positional_span(
     arg_tokens: &[tcl_lexer::Token],
     arg_expand: &[bool],
     positional_start: usize,
     max: usize,
-) -> Option<tcl_lexer::Span> {
+    source: &str,
+    fallback_delete_from: u32,
+) -> Option<ExcessArgs> {
     if (positional_start..arg_tokens.len()).any(|i| arg_expand.get(i).copied().unwrap_or(false)) {
         return None;
     }
     let first_excess = positional_start.checked_add(max)?;
     let first = arg_tokens.get(first_excess)?;
     let last = arg_tokens.last()?;
-    Some(tcl_lexer::Span::new(first.span.start(), last.span.end()))
+    let delete_from = match first_excess.checked_sub(1).and_then(|i| arg_tokens.get(i)) {
+        Some(prev) => widen_token_end(*prev, source),
+        None => fallback_delete_from,
+    };
+    Some(ExcessArgs {
+        span: tcl_lexer::Span::new(first.span.start(), widen_token_end(*last, source)),
+        delete_from,
+    })
 }
 
 fn count_positionals(args: &[String], arg_expand: &[bool], start: usize) -> (usize, bool) {
@@ -114,7 +136,12 @@ fn widen_token_end(tok: tcl_lexer::Token, source: &str) -> u32 {
         _ => return tok.span.end(),
     };
     let end = tok.span.end();
-    if tcl_lexer::SourceMap::new(source).token_text(tok).is_empty() {
+    // Empty content (`{}` / `[]` / `""`) — the span's end already sits past
+    // the closer.  Detected arithmetically (content start reaching the end)
+    // rather than by slicing the source, so a token whose span outruns the
+    // supplied text (unit tests drive the walk with detached tokens) never
+    // panics.
+    if tok.span.start() + u32::from(tok.content_offset) >= end {
         return end;
     }
     if source.as_bytes().get(end as usize) == Some(&closer) {
@@ -170,7 +197,7 @@ pub(super) fn arity_verdict(
     nargs_min: usize,
     positional_any_expand: bool,
     span: tcl_lexer::Span,
-    excess_span: Option<tcl_lexer::Span>,
+    excess: Option<ExcessArgs>,
 ) -> Option<crate::analyser::types::Diagnostic> {
     let min = usize::from(arity.min);
     let max = usize::from(arity.max);
@@ -195,18 +222,30 @@ pub(super) fn arity_verdict(
             fixes: Vec::new(),
         })
     } else if !arity.is_unlimited() && nargs_min > max {
+        // Highlight only the surplus arguments when the caller could
+        // isolate them (the whole command otherwise), and offer to delete
+        // exactly that run (plus the separating whitespace). E002/E005 keep
+        // the whole-command anchor: a too-few or wrong-shape count has no
+        // specific surplus word to point at.
+        let (e003_span, fixes) = match &excess {
+            Some(ex) => (
+                ex.span,
+                vec![crate::analyser::types::CodeFix {
+                    span: tcl_lexer::Span::new(ex.delete_from, ex.span.end()),
+                    new_text: String::new(),
+                    description: "Remove surplus argument(s)".to_string(),
+                }],
+            ),
+            None => (span, Vec::new()),
+        };
         Some(crate::analyser::types::Diagnostic {
             code: DiagCode::E003,
-            // Highlight only the surplus arguments when the caller could
-            // isolate them (the whole command otherwise). E002/E005 keep the
-            // whole-command anchor: a too-few or wrong-shape count has no
-            // specific surplus word to point at.
-            span: excess_span.unwrap_or(span),
+            span: e003_span,
             message: format!(
                 "Too many arguments for '{display_name}': expected at most {max}, got {nargs_min}"
             ),
             severity: Severity::Error,
-            fixes: Vec::new(),
+            fixes,
         })
     } else if !positional_any_expand
         && arity.step != 0
@@ -1040,11 +1079,13 @@ impl Analyser {
         // A class / alias / ensemble / stub match suppresses regardless
         // of definition order; a *proc* match additionally honours
         // `enforce_order` (in-order/reachability gate).
-        let excess_span = excess_positional_span(
+        let excess = excess_positional_span(
             arg_tokens,
             arg_expand,
             positional_start,
             usize::from(sig.arity.max),
+            &self.source,
+            widen_token_end(cmd_tok, &self.source),
         );
         if let Some(diag) = arity_verdict(
             display_name,
@@ -1052,7 +1093,7 @@ impl Analyser {
             nargs_min,
             positional_any_expand,
             full_span,
-            excess_span,
+            excess,
         ) {
             self.pending_arity
                 .push((resolution_name.to_string(), ns, enforce_order, diag));
@@ -1104,14 +1145,21 @@ impl Analyser {
         };
         // Positional args (and so the surplus run) start after the lambda
         // literal at index 1.
-        let excess_span = excess_positional_span(arg_tokens, arg_expand, 1, usize::from(arity.max));
+        let excess = excess_positional_span(
+            arg_tokens,
+            arg_expand,
+            1,
+            usize::from(arity.max),
+            &self.source,
+            widen_token_end(cmd_tok, &self.source),
+        );
         if let Some(diag) = arity_verdict(
             "apply",
             arity,
             nargs_min,
             positional_any_expand,
             full_span,
-            excess_span,
+            excess,
         ) {
             let ns = self.command_resolution_namespace(scope_path);
             let enforce_order = !self.scope_path_in_proc_body(scope_path);
@@ -1223,13 +1271,31 @@ impl Analyser {
             let Some(arity) = self.resolve_indirect_call_target(&cand, &facts.proc_offsets) else {
                 continue;
             };
+            // The surplus-run anchor: only computable now that the resolved
+            // arity's `max` is known. `arg_spans` is empty under `{*}`
+            // expansion, so `.get(max)` naturally abstains there.
+            let excess = (!arity.is_unlimited())
+                .then(|| {
+                    let max = usize::from(arity.max);
+                    let first = cand.arg_spans.get(max)?;
+                    let last = cand.arg_spans.last()?;
+                    let delete_from = match max.checked_sub(1).and_then(|i| cand.arg_spans.get(i)) {
+                        Some(prev) => prev.end(),
+                        None => cand.head_end,
+                    };
+                    Some(ExcessArgs {
+                        span: tcl_lexer::Span::new(first.start(), last.end()),
+                        delete_from,
+                    })
+                })
+                .flatten();
             if let Some(diag) = arity_verdict(
                 &cand.cmd_name,
                 arity,
                 cand.nargs_min,
                 cand.positional_any_expand,
                 cand.full_span,
-                None,
+                excess,
             ) {
                 self.result.diagnostics.push(diag);
             }
@@ -1525,6 +1591,16 @@ impl Analyser {
             Some(last) => tcl_lexer::Span::new(cmd_tok.span.start(), last.span.end()),
             None => cmd_tok.span,
         };
+        // Argument-word spans for the flush-time E003 surplus anchor —
+        // omitted under `{*}` expansion, where the surplus run is ambiguous.
+        let arg_spans: Vec<tcl_lexer::Span> = if positional_any_expand {
+            Vec::new()
+        } else {
+            arg_tokens
+                .iter()
+                .map(|t| widened_word_span(*t, &self.source))
+                .collect()
+        };
         self.pending_user_call_arity.push(PendingUserCallArity {
             cmd_name: cmd_name.to_string(),
             ns: self.command_resolution_namespace(scope_path),
@@ -1533,6 +1609,8 @@ impl Analyser {
             full_span,
             nargs_min,
             positional_any_expand,
+            arg_spans,
+            head_end: widen_token_end(cmd_tok, &self.source),
         });
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -65,6 +65,7 @@ struct ArityWords<'a> {
 /// up to the last argument), plus where a "remove surplus arguments" fix
 /// should start deleting — the end of the last *kept* word, so the fix
 /// also removes the separating whitespace.
+#[derive(Clone, Copy)]
 pub(super) struct ExcessArgs {
     /// Span of the surplus argument run (diagnostic anchor).
     pub span: tcl_lexer::Span,
@@ -637,12 +638,12 @@ impl Analyser {
         arg_expand_in: &[bool],
         scope_path: &[usize],
     ) {
-        use super::dispatch::{CommandSignature, signature_for_command};
+        use super::dispatch::CommandSignature;
         use tcl_registry::prelude::DialectSet;
 
-        let Some(registry) = self.registry.as_ref() else {
+        if self.registry.is_none() {
             return;
-        };
+        }
         let Some(first_arg) = args.first() else {
             // Empty arg list — E001 path; not in scope here.
             return;
@@ -722,40 +723,14 @@ impl Analyser {
         // depend on facts not yet known mid-walk.
         let ns = self.command_resolution_namespace(scope_path);
         let enforce_order = !self.scope_path_in_proc_body(scope_path);
-        if let Some(CommandSignature::WithSubcommands(any_sig)) =
-            signature_for_command(registry, cmd_name, DialectSet::all())
-            && any_sig.is_known(first_arg)
-        {
-            let span = match arg_tokens.first() {
-                Some(sub_tok) => tcl_lexer::Span::new(cmd_tok.span.start(), sub_tok.span.end()),
-                None => cmd_tok.span,
-            };
-            // Best-effort "available in: …" hint from the registry's own
-            // dialect gate on the matching `SubCommand` entry (falling back
-            // to the parent command's, the same inheritance
-            // `emit_w004_dialect_invalid_option` uses). An abbreviated
-            // `first_arg` that doesn't literally match a `SubCommand.name`
-            // just yields no hint — the base message stays accurate either
-            // way.
-            let suffix = registry.get(cmd_name).map_or(String::new(), |spec| {
-                spec.subcommands
-                    .iter()
-                    .find(|s| s.name == first_arg.as_str())
-                    .map_or(String::new(), |sub| {
-                        dialect_availability_suffix(sub.dialects.or(spec.dialects))
-                    })
-            });
-            let diag = super::types::Diagnostic {
-                code: DiagCode::W002,
-                span,
-                message: format!(
-                    "'{cmd_name} {first_arg}' is disabled in the active dialect profile{suffix}"
-                ),
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            };
-            self.pending_disabled_commands
-                .push((cmd_name.to_string(), ns, enforce_order, diag));
+        if self.queue_w002_other_dialect_subcommand(
+            cmd_name,
+            first_arg,
+            cmd_tok,
+            arg_tokens,
+            &ns,
+            enforce_order,
+        ) {
             return;
         }
         let mut message = format!("Unknown subcommand '{first_arg}' for '{cmd_name}'");
@@ -795,6 +770,68 @@ impl Analyser {
                 fixes,
             },
         ));
+    }
+
+    /// The disabled-in-other-dialect half of the W001 check: when the
+    /// unknown subcommand *exists* under some other dialect (`info cmdtype`
+    /// is real but 9.0-only), queue a W002 disabled-in-dialect diagnostic —
+    /// with a best-effort "available in: …" hint from the registry's own
+    /// dialect gate on the matching [`tcl_registry::SubCommand`] entry
+    /// (falling back to the parent command's, the same inheritance
+    /// `emit_w004_dialect_invalid_option` uses; an abbreviated `first_arg`
+    /// that doesn't literally match a `SubCommand.name` just yields no
+    /// hint) — and return `true` so the caller skips the "Unknown
+    /// subcommand" path with its misleading spelling suggestion.
+    fn queue_w002_other_dialect_subcommand(
+        &mut self,
+        cmd_name: &str,
+        first_arg: &str,
+        cmd_tok: tcl_lexer::Token,
+        arg_tokens: &[tcl_lexer::Token],
+        ns: &str,
+        enforce_order: bool,
+    ) -> bool {
+        use super::dispatch::{CommandSignature, signature_for_command};
+        use tcl_registry::prelude::DialectSet;
+        let Some(registry) = self.registry.as_ref() else {
+            return false;
+        };
+        let Some(CommandSignature::WithSubcommands(any_sig)) =
+            signature_for_command(registry, cmd_name, DialectSet::all())
+        else {
+            return false;
+        };
+        if !any_sig.is_known(first_arg) {
+            return false;
+        }
+        let span = match arg_tokens.first() {
+            Some(sub_tok) => tcl_lexer::Span::new(cmd_tok.span.start(), sub_tok.span.end()),
+            None => cmd_tok.span,
+        };
+        let suffix = registry.get(cmd_name).map_or(String::new(), |spec| {
+            spec.subcommands
+                .iter()
+                .find(|s| s.name == first_arg)
+                .map_or(String::new(), |sub| {
+                    dialect_availability_suffix(sub.dialects.or(spec.dialects))
+                })
+        });
+        let diag = super::types::Diagnostic {
+            code: DiagCode::W002,
+            span,
+            message: format!(
+                "'{cmd_name} {first_arg}' is disabled in the active dialect profile{suffix}"
+            ),
+            severity: Severity::Warning,
+            fixes: Vec::new(),
+        };
+        self.pending_disabled_commands.push((
+            cmd_name.to_string(),
+            ns.to_string(),
+            enforce_order,
+            diag,
+        ));
+        true
     }
 
     /// **E002 / E003.** Argument-count check for simple (non-

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -33,7 +33,7 @@ use rustc_hash::{FxHashMap, FxHashSet};
 use tcl_core_types::DiagCode;
 use tcl_registry::Arity;
 
-use super::helpers::{has_substitution, is_ident_continue, is_integer_word};
+use super::helpers::{has_substitution, is_ident_continue};
 use crate::analyser::state::Analyser;
 use crate::analyser::types::{PendingUserCallArity, Severity};
 use crate::expr_ast::{ExprNode, render_expr};
@@ -567,8 +567,8 @@ impl Analyser {
     ///
     /// When emission is warranted, includes a "did you mean…?"
     /// suffix using [`crate::text::suggest_similar`] over the
-    /// known subcommand set (max 1 suggestion within edit
-    /// distance 3), and anchors the diagnostic at the subcommand token's
+    /// known subcommand set (max 1 suggestion within the length-scaled
+    /// edit-distance budget), and anchors the diagnostic at the subcommand token's
     /// *content* range only ([`subcommand_content_span`]) — not the command
     /// name — so the squiggle sits tightly on the one word that is actually
     /// wrong, matching the "did you mean" fix's replacement range.
@@ -642,12 +642,14 @@ impl Analyser {
         if sig.allow_unknown {
             return;
         }
-        // `after` dispatches on `cancel` / `idle` / `info`, but its first word
-        // may instead be a millisecond delay (`after 200 {…}`).  An integer
-        // first word is a valid time argument, not an unknown subcommand, so
-        // it must not trip W001.  (Non-integer, non-subcommand words such as
-        // `after foo` remain genuine errors and still fire.)
-        if cmd_name == "after" && is_integer_word(first_arg) {
+        // A command may declare a *default* form selected by a first word of
+        // a particular value shape rather than a subcommand — `after`
+        // dispatches on `cancel` / `idle` / `info`, but an integer first word
+        // is a millisecond delay (`after 200 {…}`), not an unknown
+        // subcommand. The shape comes from the spec's
+        // `default_form_first_word`; no command is named here. (Non-matching
+        // words such as `after foo` remain genuine errors and still fire.)
+        if sig.matches_default_form(first_arg) {
             return;
         }
         // A subcommand name never starts with `.`, so a `.`-prefixed first word
@@ -719,7 +721,12 @@ impl Analyser {
         }
         let mut message = format!("Unknown subcommand '{first_arg}' for '{cmd_name}'");
         let candidates: Vec<&str> = sig.subcommands.keys().map(String::as_str).collect();
-        let suggestions = crate::text::suggest_similar(first_arg, candidates.iter().copied(), 1, 3);
+        let suggestions = crate::text::suggest_similar(
+            first_arg,
+            candidates.iter().copied(),
+            1,
+            crate::text::scaled_max_distance(first_arg),
+        );
         let mut fixes: Vec<super::types::CodeFix> = Vec::new();
         // Anchor the squiggle at the subcommand token's content range only —
         // not the command name — so it sits tightly on the one word that is

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -319,16 +319,76 @@ impl Analyser {
             let mut classes_sorted: Vec<&str> = class_names.iter().map(String::as_str).collect();
             classes_sorted.sort_unstable();
             let cls_display = classes_sorted.join(", ");
-            let message = format!("Unknown method '{method_name}' on class '{cls_display}'");
-            return Some(super::types::Diagnostic {
-                code: DiagCode::W308,
-                span: site.cmd_span,
-                message,
-                severity: Severity::Warning,
-                fixes: Vec::new(),
-            });
+            return Some(self.w308_diagnostic(
+                method_name,
+                &cls_display,
+                &classes_sorted,
+                Some(hierarchy),
+                site.method_span,
+                site.cmd_span,
+            ));
         }
         None
+    }
+
+    /// Build the W308 (unknown method) diagnostic: anchored on the method
+    /// *word* when the dispatch site recorded one (falling back to the
+    /// command-head span), with a "did you mean…?" suggestion drawn from
+    /// every method callable on the candidate classes — their MRO-resolved
+    /// methods plus the implicit `TclOO` object builtins — and a replace
+    /// fix targeting the same word.
+    fn w308_diagnostic(
+        &self,
+        method: &str,
+        cls_display: &str,
+        class_names: &[&str],
+        hierarchy: Option<&super::class_hierarchy::ClassHierarchy>,
+        method_span: Option<tcl_lexer::Span>,
+        cmd_span: tcl_lexer::Span,
+    ) -> super::types::Diagnostic {
+        // Candidate methods for the suggestion: MRO methods of every
+        // candidate class, locally-declared methods (for classes the
+        // hierarchy may not index), and the implicit object builtins.
+        let mut candidates: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for cls in class_names {
+            if let Some(h) = hierarchy {
+                candidates.extend(h.known_methods(cls));
+            }
+            if let Some(cd) = self.result.all_classes.get(*cls) {
+                candidates.extend(cd.methods.keys().cloned());
+                candidates.extend(cd.class_methods.keys().cloned());
+            }
+        }
+        for builtin in ["cget", "configure", "create", "destroy", "new"] {
+            candidates.insert(builtin.to_string());
+        }
+        let suggestions = crate::text::suggest_similar(
+            method,
+            candidates.iter().map(String::as_str),
+            1,
+            crate::text::scaled_max_distance(method),
+        );
+        let mut message = format!("Unknown method '{method}' on class '{cls_display}'");
+        let mut fixes: Vec<super::types::CodeFix> = Vec::new();
+        let span = method_span.unwrap_or(cmd_span);
+        if let Some(best) = suggestions.first() {
+            use std::fmt::Write as _;
+            let _ = write!(message, "; did you mean '{best}'?");
+            if let Some(fix_span) = method_span {
+                fixes.push(super::types::CodeFix {
+                    span: fix_span,
+                    new_text: (*best).to_string(),
+                    description: format!("Replace with '{best}'"),
+                });
+            }
+        }
+        super::types::Diagnostic {
+            code: DiagCode::W308,
+            span,
+            message,
+            severity: Severity::Warning,
+            fixes,
+        }
     }
 
     /// **E001** (`TclOO` form) — `$obj` invoked with no method word at all.
@@ -1039,13 +1099,15 @@ impl Analyser {
                     let method_ok =
                         self.validate_method_on_class(&cls_qn, method, cd.as_ref(), hierarchy);
                     if !method_ok {
-                        self.result.diagnostics.push(super::types::Diagnostic {
-                            code: DiagCode::W308,
-                            span: site.cmd_span,
-                            message: format!("Unknown method '{method}' on class '{class_name}'"),
-                            severity: Severity::Warning,
-                            fixes: Vec::new(),
-                        });
+                        let diag = self.w308_diagnostic(
+                            method,
+                            class_name,
+                            &[cls_qn.as_str()],
+                            hierarchy,
+                            site.method_span,
+                            site.cmd_span,
+                        );
+                        self.result.diagnostics.push(diag);
                     }
                 }
                 continue;

--- a/rust/tcl-compiler/src/analyser/dispatch.rs
+++ b/rust/tcl-compiler/src/analyser/dispatch.rs
@@ -88,6 +88,11 @@ pub struct SubcommandSig {
     /// spec that sets `arity.min == 0` on a `WithSubcommands` command
     /// gets the same treatment automatically.
     pub subcommand_required: bool,
+    /// The value shape a non-subcommand first word may take to select the
+    /// command's *default* form (`after 200 …`), copied from
+    /// [`tcl_registry::CommandSpec::default_form_first_word`]. `None` =
+    /// every first word must be a known subcommand.
+    pub default_form_first_word: Option<tcl_registry::DefaultFormFirstWord>,
 }
 
 impl SubcommandSig {
@@ -119,6 +124,15 @@ impl SubcommandSig {
     #[must_use]
     pub fn is_known(&self, word: &str) -> bool {
         self.resolve(word).is_some()
+    }
+
+    /// Whether `word` matches the spec-declared default-form value shape
+    /// (`after 200 …` — an integer first word is the default form, not an
+    /// unknown subcommand). `false` when the spec declares no default form.
+    #[must_use]
+    pub fn matches_default_form(&self, word: &str) -> bool {
+        self.default_form_first_word
+            .is_some_and(|shape| shape.matches(word))
     }
 }
 
@@ -193,6 +207,7 @@ pub fn signature_for_command(
             subcommands: subs,
             allow_unknown: spec.allow_unknown_subcommands,
             subcommand_required: spec.arity.min > 0,
+            default_form_first_word: spec.default_form_first_word,
         }));
     }
 
@@ -250,6 +265,8 @@ pub fn signature_for_scoped_command(scoped: &ScopedCommand) -> CommandSignature 
             subcommands: subs,
             allow_unknown: scoped.allow_unknown_subcommands,
             subcommand_required: scoped.arity.min > 0,
+            // Scoped ensembles declare no non-subcommand default form.
+            default_form_first_word: None,
         });
     }
     CommandSignature::Simple(CommandSig {

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -69,13 +69,7 @@ fn overridable_library_procs() -> &'static std::collections::HashSet<String> {
 /// `ns_prefix` is the namespace **without** a leading `::` — the
 /// convention used throughout the analyser walker.
 pub(super) fn qualify(ns_prefix: &str, name: &str) -> String {
-    if name.starts_with("::") {
-        name.to_string()
-    } else if ns_prefix.is_empty() {
-        format!("::{name}")
-    } else {
-        format!("::{ns_prefix}::{name}")
-    }
+    crate::naming::qualify(ns_prefix, name)
 }
 
 /// Condense a definition's description argument into a single-line outline

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -143,9 +143,16 @@ impl Analyser {
         }
 
         // --- pass 1: shell (defer proc/method bodies) ---
+        // Whole-file scoped environment (tclpkg manifests) — same seeding as
+        // `analyse`, so the per-item path resolves file-scoped directives
+        // identically (gated by the corpus `per_item == analyse` test).
+        let file_env_pushed = self.seed_file_scope_env(source);
         self.defer_proc_bodies = true;
         self.walk_commands_top_level(&commands, false);
         self.defer_proc_bodies = false;
+        if file_env_pushed {
+            self.body_scope_stack.pop();
+        }
 
         // --- pass 2: fill each deferred body ---
         // Returns `Err(fallback_result)` for the patterns the isolated-body

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -40,6 +40,9 @@ pub struct VarCommandSite {
     /// Optional method name when the call shape is
     /// ``$obj method args…``.
     pub method_name: Option<String>,
+    /// Content span of the method-name word (delimiters trimmed), when
+    /// [`Self::method_name`] is present — the tight anchor for W308.
+    pub method_span: Option<Span>,
     /// Span of the command-head token.
     pub cmd_span: Span,
     /// True when the call site is inside a class method body.
@@ -68,6 +71,9 @@ pub struct CmdCommandSite {
     pub cmd_text: String,
     /// Optional method name.
     pub method_name: Option<String>,
+    /// Content span of the method-name word (delimiters trimmed), when
+    /// [`Self::method_name`] is present — the tight anchor for W308.
+    pub method_span: Option<Span>,
     /// Span of the command-head token.
     pub cmd_span: Span,
     /// True when inside a class method body.
@@ -1014,11 +1020,17 @@ impl Analyser {
         );
         self.line_offsets = Some(compute_line_offsets(source));
 
+        // Whole-file scoped environment (tclpkg manifests) — same seeding as
+        // `analyse`, spanning every chunk's walk.
+        let file_env_pushed = self.seed_file_scope_env(source);
         let mut snapshots: Vec<super::snapshot::AnalyserSnapshot> =
             Vec::with_capacity(chunk_commands.len());
         for cmds in chunk_commands {
             self.analyse_commands_inner(&cmds);
             snapshots.push(self.snapshot());
+        }
+        if file_env_pushed {
+            self.body_scope_stack.pop();
         }
 
         // Same diagnostic-emission tail as ``analyse``.

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -559,6 +559,18 @@ impl Analyser {
         self
     }
 
+    /// Set the source-file path, returning `self` for builder-style
+    /// configuration.  Path-keyed behaviour: `pkgIndex.tcl` suppresses
+    /// dead-store / unused hints for the loader-supplied `$dir`, and a
+    /// file with a registry whole-file scoped environment (`tclpkg.tcl`
+    /// manifests — [`tcl_registry::scoped::file_scope_env`]) is analysed
+    /// with that environment ambient.
+    #[must_use]
+    pub fn with_file_path(mut self, path: Option<String>) -> Self {
+        self.file_path = path;
+        self
+    }
+
     /// Supply a pre-built [`crate::compilation_unit::CompilationUnit`] for the
     /// CFG/SSA diagnostic tail, so [`Self::emit_cfg_ssa_diagnostics`] consumes
     /// it (once) instead of rebuilding the whole-file unit.  The supplied unit
@@ -698,7 +710,11 @@ impl Analyser {
         // ``recover_missing_open_brace`` (for switch with a forgotten
         // body brace), ``detect_stolen_close_brace`` (E103), and the
         // generic E200 partial-command emitter.
+        let file_env_pushed = self.seed_file_scope_env(source);
         self.walk_commands_top_level(&commands, ghost_recovery_applied);
+        if file_env_pushed {
+            self.body_scope_stack.pop();
+        }
 
         // Run the diagnostic-emission orchestrator and the post-pass
         // filters:
@@ -1081,7 +1097,11 @@ impl Analyser {
         self.result.stub_commands = stub_cmds;
         self.result.stub_expr_defs = stub_exprs;
 
+        let file_env_pushed = self.seed_file_scope_env(source);
         self.analyse_commands_inner(commands);
+        if file_env_pushed {
+            self.body_scope_stack.pop();
+        }
 
         if finalise {
             self.run_diagnostic_emitters(source);
@@ -1375,6 +1395,33 @@ impl Analyser {
         self.defer_proc_bodies = false;
         self.deferred_bodies.clear();
         self.cu_override = None;
+    }
+
+    /// Seed the whole-file scoped command environment for this document, if
+    /// its file name declares one
+    /// ([`tcl_registry::scoped::file_scope_env`]) — the file-level analogue
+    /// of the `body_scope` push in `dispatch_body_arguments`.  Records the
+    /// whole-document region (so the post-walk W123/W120 passes and the LSP
+    /// providers resolve scoped heads by position) and pushes the
+    /// environment so the in-walk arity / subcommand checks resolve them
+    /// too.  Returns whether an environment was pushed, so the caller can
+    /// balance the stack after its walk.
+    pub(super) fn seed_file_scope_env(&mut self, source: &str) -> bool {
+        let Some(env) = self
+            .file_path
+            .as_deref()
+            .and_then(tcl_registry::scoped::file_scope_env)
+        else {
+            return false;
+        };
+        self.result
+            .scoped_command_regions
+            .push(super::types::ScopedBodyRegion {
+                span: Span::new(0, u32::try_from(source.len()).unwrap_or(u32::MAX)),
+                env,
+            });
+        self.body_scope_stack.push(env);
+        true
     }
 }
 

--- a/rust/tcl-compiler/src/analyser/tk_checks.rs
+++ b/rust/tcl-compiler/src/analyser/tk_checks.rs
@@ -208,7 +208,7 @@ impl Analyser {
             }
 
             // TK1003: unknown option for the widget command.
-            self.emit_tk1003_unknown_options(cmd_name, args, cmd_tok);
+            self.emit_tk1003_unknown_options(cmd_name, args, arg_tokens, cmd_tok);
         }
 
         // Track geometry-manager usage for the post-walk TK1001 check.
@@ -224,35 +224,80 @@ impl Analyser {
         }
     }
 
-    /// TK1003 — buffer `-option` arguments that the widget command does not
-    /// declare.  A lone `-` / `--` is skipped, and the check is silent when
-    /// the command has no registry spec (so unknown widgets never false
-    /// positive).
-    fn emit_tk1003_unknown_options(&mut self, cmd_name: &str, args: &[String], cmd_tok: Token) {
+    /// TK1003 — buffer `-option` words that the widget command does not
+    /// declare.  The check is silent when the command has no registry spec
+    /// (so unknown widgets never false positive).
+    ///
+    /// Widget-creation options are alternating `-option value` pairs
+    /// (`Tk_ConfigureWidget`), so the scan walks pairs: an option word is
+    /// validated and its *value* word skipped — a value that itself starts
+    /// with `-` (`-padx -2`) is data, never an unknown option.  A unique
+    /// prefix of a declared option is accepted, matching Tk's
+    /// abbreviation rule; an ambiguous prefix abstains.  A non-`-` word in
+    /// option position ends the scan (Tk itself errors there).  Each
+    /// finding anchors on the offending option word and carries a "did you
+    /// mean…?" replace fix drawn from the declared option set.
+    fn emit_tk1003_unknown_options(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        cmd_tok: Token,
+    ) {
         let Some(registry) = self.registry.as_ref() else {
             return;
         };
         let Some(spec) = registry.get(cmd_name) else {
             return;
         };
-        let known: std::collections::HashSet<&str> = spec.switch_names(None).into_iter().collect();
-        let mut unknown: Vec<String> = Vec::new();
-        for arg in &args[1..] {
-            if arg.starts_with('-')
-                && !arg.starts_with("--")
-                && arg.len() > 1
-                && !known.contains(arg.as_str())
-            {
-                unknown.push(arg.clone());
+        let known: Vec<&str> = spec.switch_names(None);
+        let mut findings: Vec<(String, tcl_lexer::Span)> = Vec::new();
+        let mut i = 1;
+        while i < args.len() {
+            let arg = &args[i];
+            if !arg.starts_with('-') || arg == "-" || arg.starts_with("--") {
+                // Non-option word in option position — Tk stops parsing
+                // options here, so anything after is not ours to judge.
+                break;
             }
+            // Dynamic option word (`-$style`, `-[pick]`) — unknowable.
+            if arg.contains('$') || arg.contains('[') {
+                i += 2;
+                continue;
+            }
+            let exact = known.contains(&arg.as_str());
+            let prefix_hits = known.iter().filter(|k| k.starts_with(arg.as_str())).count();
+            if !exact && prefix_hits == 0 {
+                let span = arg_tokens.get(i).map_or(cmd_tok.span, |t| t.span);
+                findings.push((arg.clone(), span));
+            }
+            // Skip the option's value word.
+            i += 2;
         }
-        for arg in unknown {
+        for (arg, span) in findings {
+            let suggestions = crate::text::suggest_similar(
+                &arg,
+                known.iter().copied(),
+                1,
+                crate::text::scaled_max_distance(&arg),
+            );
+            let mut message = format!("Unknown option '{arg}' for {cmd_name}.");
+            let mut fixes: Vec<super::types::CodeFix> = Vec::new();
+            if let Some(best) = suggestions.first() {
+                use std::fmt::Write as _;
+                let _ = write!(message, " Did you mean '{best}'?");
+                fixes.push(super::types::CodeFix {
+                    span,
+                    new_text: (*best).to_string(),
+                    description: format!("Replace with '{best}'"),
+                });
+            }
             self.tk_pending_diags.push(Diagnostic {
                 code: DiagCode::Tk1003,
-                span: cmd_tok.span,
-                message: format!("Unknown option '{arg}' for {cmd_name}."),
+                span,
+                message,
                 severity: Severity::Hint,
-                fixes: Vec::new(),
+                fixes,
             });
         }
     }

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -138,6 +138,14 @@ pub struct PendingUserCallArity {
     /// bound already exceeds the max; matches the identical convention
     /// in the registry-command arity check.
     pub positional_any_expand: bool,
+    /// Widened source span of each argument word (closer included), so the
+    /// flush — which only then knows the resolved arity's `max` — can
+    /// anchor E003 on the surplus run and target the removal fix.  Empty
+    /// when the call has a `{*}` expansion (the surplus run is ambiguous).
+    pub arg_spans: Vec<Span>,
+    /// Widened end of the command-head word: the removal fix's deletion
+    /// start when every positional argument is surplus (`max == 0`).
+    pub head_end: u32,
 }
 
 /// Which `TclOO` instantiation form introduced a [`PendingCtorArity`] —

--- a/rust/tcl-compiler/src/codegen/helpers.rs
+++ b/rust/tcl-compiler/src/codegen/helpers.rs
@@ -343,13 +343,17 @@ pub fn fold_cmd_args(value: &str, prefix: &str) -> Option<String> {
         .strip_prefix(&full_prefix)
         .and_then(|s| s.strip_suffix(']'))?;
 
-    // Resolve backslash-newline continuations to a single space.
-    let inner = resolve_backslash_newline(inner);
+    // Canonical C-rule continuation collapse (`\<LF>`/`\<CR>`/`\<CRLF>` +
+    // following spaces/tabs → one space) — UTF-8-safe, unlike the retired
+    // local byte-by-byte copy, which pushed each byte through `char::from`
+    // and mangled multi-byte characters.
+    let inner = tcl_syntax::backslash::collapse_brace_continuations_str(inner);
+    let inner = inner.as_ref();
 
     // Cannot fold across a `{*}` argument expansion: it turns one braced word
     // into *several* arguments, so a naive literal fold would mis-read `{*}` as
     // the braced word `*`. Bail to the normal (expansion-aware) codegen.
-    if has_expand_marker(&inner) {
+    if has_expand_marker(inner) {
         return None;
     }
 
@@ -368,35 +372,13 @@ pub fn fold_cmd_args(value: &str, prefix: &str) -> Option<String> {
     // argument's *value* is what `list` quotes: braced words are verbatim, while
     // quoted and bare words are backslash-decoded first (so `"\x00"` becomes a
     // NUL byte and `"a\tb"` an embedded tab, not the literal escape text).
-    let args = split_list_values(&inner);
+    let args = split_list_values(inner);
     Some(
         args.iter()
             .map(|a| tcl_list_element(a))
             .collect::<Vec<_>>()
             .join(" "),
     )
-}
-
-/// Resolve backslash-newline continuations (`\<newline><whitespace>`)
-/// to a single space, matching the regex `\\\n\s*` replaced with a space.
-fn resolve_backslash_newline(s: &str) -> String {
-    let mut result = String::with_capacity(s.len());
-    let bytes = s.as_bytes();
-    let mut i = 0;
-    while i < bytes.len() {
-        if bytes[i] == b'\\' && i + 1 < bytes.len() && bytes[i + 1] == b'\n' {
-            result.push(' ');
-            i += 2;
-            // Skip trailing whitespace
-            while i < bytes.len() && matches!(bytes[i], b' ' | b'\t' | b'\n' | b'\r') {
-                i += 1;
-            }
-        } else {
-            result.push(char::from(bytes[i]));
-            i += 1;
-        }
-    }
-    result
 }
 
 /// Whether `s` contains a `{*}` argument-expansion operator: a `{*}` at a word

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1195,6 +1195,23 @@ impl CompilationUnit {
         std::iter::once(&self.top_level).chain(procs)
     }
 
+    /// Instance-variable names in scope for the named function when it is a
+    /// `TclOO`/snit *method* body (class-level `variable` declarations plus
+    /// the method's own) — the alias-shaped names the shimmer thunking pass
+    /// abstains on (their writes escape to the object, so the local SSA
+    /// version chain is not the whole story).  `None` for procs and the top
+    /// level.
+    #[must_use]
+    pub fn method_instance_vars(
+        &self,
+        function_name: &str,
+    ) -> Option<&std::collections::HashSet<String>> {
+        self.ir_module
+            .methods
+            .get(function_name)
+            .map(|m| &m.instance_vars)
+    }
+
     /// Like [`Self::functions`] but skips the functions the complexity guard
     /// excluded from deep analysis (oversized bodies). Per-proc diagnostic and
     /// optimiser passes iterate this so a guarded body — whose `ssa` and

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -507,8 +507,8 @@ impl FunctionUnit {
 
     /// Populate memory-SSA on demand. Returns `self` for chaining.
     #[must_use]
-    pub fn with_memory_ssa(mut self) -> Self {
-        self.memory_ssa = Some(build_memory_ssa(&self.ssa));
+    pub fn with_memory_ssa(mut self, registry: &tcl_registry::CommandRegistry) -> Self {
+        self.memory_ssa = Some(build_memory_ssa(&self.ssa, registry));
         self
     }
 
@@ -1162,11 +1162,11 @@ impl CompilationUnit {
 
     /// Populate memory-SSA on the top-level and every procedure.
     #[must_use]
-    pub fn with_memory_ssa(mut self) -> Self {
-        self.top_level = self.top_level.with_memory_ssa();
+    pub fn with_memory_ssa(mut self, registry: &tcl_registry::CommandRegistry) -> Self {
+        self.top_level = self.top_level.with_memory_ssa(registry);
         let mut out: HashMap<String, FunctionUnit> = HashMap::with_capacity(self.procedures.len());
         for (k, fu) in self.procedures.drain() {
-            out.insert(k, fu.with_memory_ssa());
+            out.insert(k, fu.with_memory_ssa(registry));
         }
         self.procedures = out;
         self
@@ -1808,7 +1808,8 @@ mod tests {
 
     #[test]
     fn with_memory_ssa_populates_optional() {
-        let cu = CompilationUnit::build_for("set x 1", &registry(), false).with_memory_ssa();
+        let cu =
+            CompilationUnit::build_for("set x 1", &registry(), false).with_memory_ssa(&registry());
         assert!(cu.top_level.memory_ssa.is_some());
     }
 

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -34,7 +34,6 @@ use crate::gvn::{find_loop_invariants, find_partial_redundancies, find_redundanc
 use crate::irules_checks::{
     CodeFix, IrulesCheckWarning, find_collect_flow_warnings, find_generic_static_name_warnings,
     find_hoistable_set_warnings, find_http_flow_warnings, find_unguarded_drop_warnings,
-    find_unnormalised_getter_warnings,
 };
 use crate::path_concat::{PathConcatWarning, find_path_concat_warnings};
 use crate::sccp::ConstantBranch;
@@ -278,7 +277,8 @@ pub fn run_all_checks_with_solved_and_patterns(
     // (SRV-INCREMENTAL 2a): an unedited procedure's checks are a cache hit
     // instead of recomputed over the whole unit every edit.
     for fu in cu.analysable_body_function_units() {
-        for d in function_nontaint_checks(fu, registry, dialect) {
+        for d in function_nontaint_checks(fu, registry, dialect, cu.method_instance_vars(&fu.name))
+        {
             out.push(shift(fu, d));
         }
     }
@@ -309,6 +309,7 @@ pub fn function_nontaint_checks(
     fu: &FunctionUnit,
     registry: &CommandRegistry,
     dialect: Option<&str>,
+    instance_vars: Option<&std::collections::HashSet<String>>,
 ) -> Vec<Diagnostic> {
     let mut out: Vec<Diagnostic> = Vec::new();
     for cb in &fu.sccp.constant_branches {
@@ -323,7 +324,7 @@ pub fn function_nontaint_checks(
     for r in find_loop_invariants(registry, &fu.cfg, &fu.ssa, dialect) {
         out.push(Diagnostic::from_redundant(&r));
     }
-    out.extend(shimmer_family_checks(fu, registry, dialect));
+    out.extend(shimmer_family_checks(fu, registry, dialect, instance_vars));
     out
 }
 
@@ -344,6 +345,7 @@ pub fn shimmer_family_checks(
     fu: &FunctionUnit,
     registry: &CommandRegistry,
     dialect: Option<&str>,
+    instance_vars: Option<&std::collections::HashSet<String>>,
 ) -> Vec<Diagnostic> {
     let mut out: Vec<Diagnostic> = Vec::new();
     for w in find_shimmer_warnings(
@@ -356,7 +358,13 @@ pub fn shimmer_family_checks(
     ) {
         out.push(Diagnostic::from_shimmer(&w));
     }
-    for w in find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks) {
+    for w in find_thunking_warnings(
+        &fu.cfg,
+        &fu.ssa,
+        &fu.types,
+        &fu.sccp.executable_blocks,
+        instance_vars,
+    ) {
         out.push(Diagnostic::from_thunking(&w));
     }
     let payload_layouts = if is_irules_dialect(dialect) {
@@ -481,11 +489,20 @@ pub fn push_taint_and_module_checks(
 }
 
 /// Append the iRules-dialect module-level checks (IRULE5002/5004 +
-/// IRULE1005-1008/1201/1202/4004 + the unnormalised-getter warning).
+/// IRULE1005-1008/1201/1202/4004).
 ///
 /// Each helper is dialect-gated internally (returns empty for non-iRules
 /// dialects), so calling them unconditionally is correct.  Split out of
 /// [`run_all_checks`] to keep that aggregator within the line budget.
+///
+/// The unnormalised-getter warning (IRULE3102) is deliberately *not*
+/// aggregated here: the analyser's per-command emitter
+/// (`analyser::irules_event_checks`) owns it for the LSP/CLI stream — it
+/// anchors on the getter word itself and reaches nested `[…]`
+/// substitutions through the nested-segment dispatch.  Emitting the
+/// CFG-side scan (`find_unnormalised_getter_warnings`, still used by the
+/// compiler explorer's own view) here as well double-reported every site
+/// with a second, wider span.
 fn push_irules_flow_checks(
     cu: &CompilationUnit,
     registry: &CommandRegistry,
@@ -493,9 +510,6 @@ fn push_irules_flow_checks(
     generic_patterns: Option<&[String]>,
     out: &mut Vec<Diagnostic>,
 ) {
-    for w in find_unnormalised_getter_warnings(cu, registry, dialect) {
-        out.push(Diagnostic::from_irules_check(&w));
-    }
     for w in find_unguarded_drop_warnings(cu, dialect) {
         out.push(Diagnostic::from_irules_check(&w));
     }
@@ -742,16 +756,38 @@ mod tests {
     }
 
     #[test]
-    fn run_all_checks_reports_irule3102_end_to_end() {
+    fn run_all_checks_does_not_double_report_irule3102() {
+        // IRULE3102 ownership: the analyser's per-command emitter
+        // (`analyser::irules_event_checks`) reports it for the LSP/CLI
+        // stream with a tight getter-word anchor; aggregating the CFG-side
+        // scan here as well double-reported every site with a second,
+        // wider span. `run_all_checks` must therefore stay silent — the
+        // analyser end-to-end assertion lives alongside.
         let cu = CompilationUnit::build_for("set u [HTTP::uri]", &registry(), false)
             .with_interprocedural(&registry(), Some("f5-irules"));
         let diagnostics = run_all_checks(&cu, &registry(), Some("f5-irules"));
-        let hit = diagnostics
+        assert!(
+            diagnostics.iter().all(|d| d.code != DiagCode::Irule3102),
+            "run_all_checks must not double-report IRULE3102: {diagnostics:?}"
+        );
+
+        // The analyser stream owns the code (single, tight instance).
+        let mut analyser = crate::analyser::Analyser::new();
+        let result = analyser.analyse(
+            "when HTTP_REQUEST {\n    set u [HTTP::uri]\n}\n",
+            "f5-irules",
+        );
+        let hits: Vec<_> = result
+            .diagnostics
             .iter()
-            .find(|d| d.code == DiagCode::Irule3102)
-            .unwrap_or_else(|| panic!("expected IRULE3102, got {diagnostics:?}"));
-        assert_eq!(hit.category, "irules");
-        assert_eq!(hit.severity, Severity::Warning);
+            .filter(|d| d.code == DiagCode::Irule3102)
+            .collect();
+        assert_eq!(
+            hits.len(),
+            1,
+            "the analyser stream reports IRULE3102 exactly once: {:?}",
+            result.diagnostics
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -305,11 +305,11 @@ pub fn run_all_checks_with_solved_and_patterns(
 /// procedure's checks are a cache hit.  The S110 `*::payload` byte-command set is
 /// dialect-gated (empty outside iRules).
 #[must_use]
-pub fn function_nontaint_checks(
+pub fn function_nontaint_checks<S: std::hash::BuildHasher>(
     fu: &FunctionUnit,
     registry: &CommandRegistry,
     dialect: Option<&str>,
-    instance_vars: Option<&std::collections::HashSet<String>>,
+    instance_vars: Option<&std::collections::HashSet<String, S>>,
 ) -> Vec<Diagnostic> {
     let mut out: Vec<Diagnostic> = Vec::new();
     for cb in &fu.sccp.constant_branches {
@@ -341,11 +341,11 @@ pub fn function_nontaint_checks(
 /// `namespace eval` body. The S110 `*::payload` byte-command set is
 /// dialect-gated (empty outside iRules).
 #[must_use]
-pub fn shimmer_family_checks(
+pub fn shimmer_family_checks<S: std::hash::BuildHasher>(
     fu: &FunctionUnit,
     registry: &CommandRegistry,
     dialect: Option<&str>,
-    instance_vars: Option<&std::collections::HashSet<String>>,
+    instance_vars: Option<&std::collections::HashSet<String, S>>,
 ) -> Vec<Diagnostic> {
     let mut out: Vec<Diagnostic> = Vec::new();
     for w in find_shimmer_warnings(

--- a/rust/tcl-compiler/src/memory_ssa.rs
+++ b/rust/tcl-compiler/src/memory_ssa.rs
@@ -42,6 +42,7 @@
 //! - `compute_aliases` + `build_memory_ssa` driver.
 
 use std::collections::{BTreeSet, HashMap};
+use tcl_registry::{CommandRegistry, Traits};
 
 use crate::cfg::BlockId;
 use crate::ir::Statement;
@@ -417,22 +418,39 @@ pub fn detect_namespace_variable(stmt: &Statement) -> Vec<String> {
         .collect()
 }
 
+/// The spec-declared trait set that classifies a call as a memory clobber.
+const CLOBBER_TRAITS: Traits = Traits::EVALUATES_CODE.union(Traits::CREATES_BARRIER);
+
 /// True if `stmt` may clobber arbitrary memory locations.
 ///
 /// Barriers always clobber. A static-body [`Statement::UpFrame`]
 /// (barrier-relaxed `uplevel`) clobbers because its body runs in a
 /// caller's frame and can touch arbitrary caller locals or globals.
-/// Calls clobber when their command name matches an explicit
-/// dynamic-dispatch name (`eval`, `uplevel`, `interp eval`,
-/// `namespace eval`).
+/// Calls clobber when the registry marks the resolved command (or the
+/// resolved subcommand — `interp eval`, `namespace eval`) as evaluating
+/// code or acting as a barrier ([`Traits::EVALUATES_CODE`] |
+/// [`Traits::CREATES_BARRIER`]) — the same spec-declared classification
+/// `side_effects.rs` dispatches on, replacing the old hardcoded name list
+/// (whose compound `"interp eval"` spellings never matched a bare
+/// `command` field, silently under-clobbering those calls).
 #[must_use]
-pub fn is_clobber(stmt: &Statement) -> bool {
+pub fn is_clobber(stmt: &Statement, registry: &CommandRegistry) -> bool {
     match stmt {
         Statement::Barrier { .. } | Statement::UpFrame { .. } => true,
-        Statement::Call { command, .. } => matches!(
-            command.as_str(),
-            "eval" | "uplevel" | "interp eval" | "namespace eval"
-        ),
+        Statement::Call { command, args, .. } => {
+            let Some(spec) = registry.get(command) else {
+                return false;
+            };
+            if spec.traits.intersects(CLOBBER_TRAITS) {
+                return true;
+            }
+            // Subcommand-level classification (`interp eval`, `namespace
+            // eval`, …) — resolve the first word the way ensemble dispatch
+            // does and consult its traits.
+            args.first()
+                .and_then(|sub| spec.resolve_subcommand(sub))
+                .is_some_and(|sub| sub.traits.intersects(CLOBBER_TRAITS))
+        }
         _ => false,
     }
 }
@@ -584,7 +602,7 @@ pub fn compute_aliases(ssa: &SsaFunction) -> Vec<AliasSet> {
 /// Walks blocks in dominator-tree order (reverse iteration for
 /// stack emulation) for consistent versioning.
 #[must_use]
-pub fn build_memory_ssa(ssa: &SsaFunction) -> MemorySsaFunction {
+pub fn build_memory_ssa(ssa: &SsaFunction, registry: &CommandRegistry) -> MemorySsaFunction {
     let alias_sets = compute_aliases(ssa);
     let aliased_names: BTreeSet<String> = alias_sets.iter().flat_map(AliasSet::names).collect();
 
@@ -629,7 +647,7 @@ pub fn build_memory_ssa(ssa: &SsaFunction) -> MemorySsaFunction {
             let stmt = &stmt_ssa.statement;
             let idx_i32 = i32::try_from(idx).unwrap_or(i32::MAX);
 
-            if is_clobber(stmt) {
+            if is_clobber(stmt, registry) {
                 version_counter += 1;
                 memory_ops.push(MemoryOp::new_clobber(version_counter, bn, idx_i32));
                 // Fall through — a barrier that also defines
@@ -878,10 +896,28 @@ mod tests {
 
     #[test]
     fn is_clobber_barrier_and_eval() {
-        assert!(is_clobber(&barrier("eval", &["x"])));
-        assert!(is_clobber(&call("eval", &["script"])));
-        assert!(is_clobber(&call("uplevel", &["1", "script"])));
-        assert!(!is_clobber(&call("set", &["x", "1"])));
+        let reg = CommandRegistry::build_default();
+        assert!(is_clobber(&barrier("eval", &["x"]), &reg));
+        assert!(is_clobber(&call("eval", &["script"]), &reg));
+        assert!(is_clobber(&call("uplevel", &["1", "script"]), &reg));
+        assert!(!is_clobber(&call("set", &["x", "1"]), &reg));
+    }
+
+    /// The old hardcoded name list spelt these as the compound strings
+    /// `"interp eval"` / `"namespace eval"`, which a bare `command` field
+    /// never matches — so the subcommand-resolved forms silently escaped
+    /// the clobber classification.  The registry path resolves the
+    /// subcommand word (unique prefixes included) and reads its traits.
+    #[test]
+    fn is_clobber_resolves_code_evaluating_subcommands() {
+        let reg = CommandRegistry::build_default();
+        assert!(is_clobber(&call("interp", &["eval", "{}", "script"]), &reg));
+        assert!(is_clobber(
+            &call("namespace", &["eval", "ns", "script"]),
+            &reg
+        ));
+        assert!(!is_clobber(&call("namespace", &["current"]), &reg));
+        assert!(!is_clobber(&call("interp", &["exists", "x"]), &reg));
     }
 
     // -- compute_aliases + build_memory_ssa --
@@ -941,7 +977,7 @@ mod tests {
         assert!(set.contains_name("b"));
         assert!(set.contains_name("x"));
 
-        let m = build_memory_ssa(&ssa);
+        let m = build_memory_ssa(&ssa, &CommandRegistry::build_default());
         assert!(m.may_alias("a", "b"), "a and b share caller x");
     }
 
@@ -974,7 +1010,7 @@ mod tests {
     #[test]
     fn build_memory_ssa_empty_function() {
         let ssa = make_ssa_with_entry_stmts(Vec::new());
-        let m = build_memory_ssa(&ssa);
+        let m = build_memory_ssa(&ssa, &CommandRegistry::build_default());
         assert!(m.alias_sets.is_empty());
         assert!(m.memory_ops.is_empty());
         assert_eq!(m.count_defs, 0);
@@ -985,7 +1021,7 @@ mod tests {
     #[test]
     fn build_memory_ssa_emits_clobber_for_eval() {
         let ssa = make_ssa_with_entry_stmts(vec![call("eval", &["foo"])]);
-        let m = build_memory_ssa(&ssa);
+        let m = build_memory_ssa(&ssa, &CommandRegistry::build_default());
         assert_eq!(m.count_clobbers, 1);
         assert_eq!(m.memory_ops[0].kind, MemoryOpKind::Clobber);
         assert_eq!(m.memory_ops[0].location.name, "*");
@@ -1002,9 +1038,9 @@ mod tests {
             body: crate::ir::Script::new(),
             tokens: None,
         };
-        assert!(is_clobber(&upframe));
+        assert!(is_clobber(&upframe, &CommandRegistry::build_default()));
         let ssa = make_ssa_with_entry_stmts(vec![upframe]);
-        let m = build_memory_ssa(&ssa);
+        let m = build_memory_ssa(&ssa, &CommandRegistry::build_default());
         assert_eq!(m.count_clobbers, 1);
         assert_eq!(m.memory_ops[0].kind, MemoryOpKind::Clobber);
     }
@@ -1047,7 +1083,7 @@ mod tests {
             },
         );
         ssa.dominator_tree.insert(entry, Vec::new());
-        let m = build_memory_ssa(&ssa);
+        let m = build_memory_ssa(&ssa, &CommandRegistry::build_default());
         assert_eq!(m.count_defs, 1);
         assert_eq!(m.count_uses, 1);
         // Version for def must be > version visible at preceding
@@ -1109,7 +1145,7 @@ mod tests {
             },
         );
         ssa.dominator_tree.insert(entry, Vec::new());
-        let m = build_memory_ssa(&ssa);
+        let m = build_memory_ssa(&ssa, &CommandRegistry::build_default());
         // The def and use from the self-referential statement (index 2).
         let self_def = m
             .memory_ops

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -353,8 +353,8 @@ fn check_numeric_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinO
             in_loop: ctx.in_loop,
             code,
             message: format!(
-                "{code}: variable '{var}' has {from} intrep used in arithmetic \
-                 expression (op {op:?})",
+                "variable '{var}' has {from} intrep used in arithmetic \
+                 expression (operand of '{op}')",
                 var = base,
                 from = type_name(current),
             ),
@@ -419,7 +419,7 @@ fn check_string_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp
             in_loop: ctx.in_loop,
             code,
             message: format!(
-                "{code}: numeric variable '{base}' used in string comparison (op {op:?}); \
+                "numeric variable '{base}' used in string comparison ('{op}'); \
                  if a numeric comparison was intended, use '{numeric_op}' instead"
             ),
             related: Vec::new(),

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -189,12 +189,12 @@ pub fn find_thunking_warnings_for_cu(
 /// Identifies variables that oscillate between two intrep types across
 /// loop iterations, causing a type conversion on every pass (S102).
 #[must_use]
-pub(crate) fn find_thunking_warnings(
+pub(crate) fn find_thunking_warnings<S: std::hash::BuildHasher>(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
     types: &HashMap<ValueKey, TypeLattice>,
     executable_blocks: &HashSet<BlockId>,
-    extra_scope_aliases: Option<&HashSet<String>>,
+    extra_scope_aliases: Option<&HashSet<String, S>>,
 ) -> Vec<ThunkingWarning> {
     thunking::find_thunking_warnings(cfg, ssa, types, executable_blocks, extra_scope_aliases)
 }
@@ -285,6 +285,15 @@ mod tests {
             )
             .is_empty()
         );
-        assert!(find_thunking_warnings(&f, &ssa, &types, &sccp.executable_blocks, None).is_empty());
+        assert!(
+            find_thunking_warnings(
+                &f,
+                &ssa,
+                &types,
+                &sccp.executable_blocks,
+                None::<&HashSet<String>>
+            )
+            .is_empty()
+        );
     }
 }

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -178,6 +178,7 @@ pub fn find_thunking_warnings_for_cu(
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
+            cu.method_instance_vars(&fu.name),
         ));
     }
     out
@@ -193,8 +194,9 @@ pub(crate) fn find_thunking_warnings(
     ssa: &SsaFunction,
     types: &HashMap<ValueKey, TypeLattice>,
     executable_blocks: &HashSet<BlockId>,
+    extra_scope_aliases: Option<&HashSet<String>>,
 ) -> Vec<ThunkingWarning> {
-    thunking::find_thunking_warnings(cfg, ssa, types, executable_blocks)
+    thunking::find_thunking_warnings(cfg, ssa, types, executable_blocks, extra_scope_aliases)
 }
 
 /// Find byte-array-corruption warnings (S110) for a single function.
@@ -283,6 +285,6 @@ mod tests {
             )
             .is_empty()
         );
-        assert!(find_thunking_warnings(&f, &ssa, &types, &sccp.executable_blocks).is_empty());
+        assert!(find_thunking_warnings(&f, &ssa, &types, &sccp.executable_blocks, None).is_empty());
     }
 }

--- a/rust/tcl-compiler/src/shimmer/phi.rs
+++ b/rust/tcl-compiler/src/shimmer/phi.rs
@@ -158,7 +158,7 @@ fn classify_phi_shimmer(ctx: &PhiCtx<'_>, phi: &Phi, in_loop: bool) -> Option<Sh
         in_loop,
         code,
         message: format!(
-            "{code}: '{var}' merges {from} and {to} at control-flow join",
+            "'{var}' merges {from} and {to} at control-flow join",
             from = type_name(from),
             to = type_name(to),
         ),

--- a/rust/tcl-compiler/src/shimmer/thunking.rs
+++ b/rust/tcl-compiler/src/shimmer/thunking.rs
@@ -365,6 +365,10 @@ struct ThunkCtx<'a> {
     /// excluded from S102 entirely, since their conflated version chain
     /// mixes independent elements under one phi.
     array_syms: &'a HashSet<Symbol>,
+    /// Names declared as scope aliases in this function (`global` /
+    /// `variable` / `upvar` / `namespace upvar`) — the intra-iteration
+    /// path abstains on them (alias-unsoundness, FP-SH-02/15).
+    scope_aliases: &'a HashSet<String>,
 }
 
 /// Decide whether a loop-header phi genuinely thunks (oscillates between
@@ -513,7 +517,10 @@ fn classify_thunking_phi(
 /// `Shimmered`-header path applies via [`loop_self_referential`].  Empty
 /// initialiser versions and destructure-foreach blocks are already excluded
 /// by [`per_loop_body_types`]; array-element symbols were excluded by the
-/// caller.
+/// caller.  Scope-aliased variables (`global` / `variable` / `upvar`
+/// declarations — [`ThunkCtx::scope_aliases`]) abstain: their SSA version
+/// chain does not correspond to a single local slot, the same
+/// alias-unsoundness rationale the FP-SH-02/15 guards established.
 fn classify_intra_iteration_thunk(
     ctx: &ThunkCtx<'_>,
     phi: &Phi,
@@ -522,6 +529,9 @@ fn classify_intra_iteration_thunk(
 ) -> Option<ThunkingWarning> {
     let body_types = per_loop.get(&phi.name)?;
     if body_types.len() < 2 {
+        return None;
+    }
+    if ctx.scope_aliases.contains(ctx.ssa.var_name(phi.name)) {
         return None;
     }
     if !loop_self_referential(ctx.ssa, this_loop, phi.name) {
@@ -578,6 +588,7 @@ pub(crate) fn find_thunking_warnings(
     ssa: &SsaFunction,
     types: &HashMap<ValueKey, TypeLattice>,
     executable_blocks: &HashSet<BlockId>,
+    extra_scope_aliases: Option<&HashSet<String>>,
 ) -> Vec<ThunkingWarning> {
     let loop_blocks = loop_body_blocks(cfg);
     let succs = build_successors(cfg);
@@ -589,6 +600,14 @@ pub(crate) fn find_thunking_warnings(
     let empty_by_name = empty_value_versions(ssa);
     let destructure = destructure_foreach_blocks(cfg);
     let array_syms = array_element_symbols(cfg, ssa);
+    // Alias-shaped names: explicit `global`/`variable`/`upvar` declarations
+    // in this body, plus the caller-supplied implicit set (a method's
+    // class-declared instance variables, which never appear as statements
+    // in the method's own CFG).
+    let mut scope_aliases = crate::optimiser::elimination::scan_scope_aliases(cfg);
+    if let Some(extra) = extra_scope_aliases {
+        scope_aliases.extend(extra.iter().cloned());
+    }
 
     let ctx = ThunkCtx {
         cfg,
@@ -599,6 +618,7 @@ pub(crate) fn find_thunking_warnings(
         def_map: &def_map,
         destructure: &destructure,
         array_syms: &array_syms,
+        scope_aliases: &scope_aliases,
     };
 
     for block_id in cfg_order(cfg) {
@@ -654,7 +674,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(w.is_empty(), "unexpected thunking warnings: {w:?}");
     }
 
@@ -669,7 +695,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(w.is_empty(), "sibling loops must not thunk: {w:?}");
     }
 
@@ -683,7 +715,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(w.is_empty(), "accumulator promotion must not thunk: {w:?}");
     }
 
@@ -699,7 +737,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::g").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert_eq!(w.len(), 1, "intra-iteration oscillation must thunk: {w:?}");
         assert_eq!(w[0].variable, "acc");
         assert_eq!(w[0].code, tcl_core_types::DiagCode::S102);
@@ -717,7 +761,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::h").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(
             w.is_empty(),
             "fresh-per-pass variable must not thunk: {w:?}"
@@ -734,7 +784,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::k").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(w.is_empty(), "uniform self-reference must not thunk: {w:?}");
     }
 
@@ -743,7 +799,13 @@ mod tests {
     fn thunking_empty_source() {
         let cu = CompilationUnit::build_for("", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(w.is_empty());
     }
 
@@ -752,7 +814,13 @@ mod tests {
     fn no_thunking_for_no_loop_variables() {
         let cu = CompilationUnit::build_for("while {1} { puts \"hello\" }", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(w.is_empty(), "unexpected thunking: {w:?}");
     }
 
@@ -770,7 +838,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         let has_thunking = w
             .iter()
             .any(|tw| tw.variable == "x" && tw.code == DiagCode::S102);
@@ -791,7 +865,13 @@ mod tests {
                     set x [string range $x 0 end] } }";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert_eq!(w.len(), 1, "expected exactly one S102 warning: {w:?}");
         let while_pos = u32::try_from(src.find("while").unwrap()).unwrap();
         assert!(
@@ -818,7 +898,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(
             w.iter().any(|tw| tw.variable == "x"),
             "expected S102 for the self-referential branchy oscillation, got: {w:?}"
@@ -840,7 +926,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(
             w.is_empty(),
             "non-self-referential branchy reset must not thunk: {w:?}"
@@ -861,7 +953,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(
             w.is_empty(),
             "array-element writes must not be conflated into an S102 report: {w:?}"
@@ -884,7 +982,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(w.is_empty(), "traced variable must not thunk: {w:?}");
     }
 
@@ -903,7 +1007,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(
             w.iter().any(|tw| tw.variable == "x"),
             "numeric/string oscillation seeded by an Int entry must fire S102: {w:?}"
@@ -921,7 +1031,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            None,
+        );
         assert!(
             w.iter().any(|tw| tw.variable == "x"),
             "untraced control must still fire S102: {w:?}"

--- a/rust/tcl-compiler/src/shimmer/thunking.rs
+++ b/rust/tcl-compiler/src/shimmer/thunking.rs
@@ -385,7 +385,13 @@ fn classify_thunking_phi(
     }
     let lattice = ctx.types.get(&(phi.name, phi.version))?;
     if lattice.kind != TypeKind::Shimmered {
-        return None;
+        // The header lattice only records oscillation that survives to the
+        // loop-header phi (entry type ≠ body-exit type).  A body that
+        // converts list→string→list *within one iteration* returns to the
+        // entry type by the join, leaving the header `Known` — yet every
+        // pass still pays both conversions (`lappend acc …; set acc
+        // "$acc,"`).  Catch that shape from the body evidence instead.
+        return classify_intra_iteration_thunk(ctx, phi, this_loop, per_loop);
     }
     let type_a = lattice.from_type?;
     let type_b = lattice.tcl_type?;
@@ -485,7 +491,72 @@ fn classify_thunking_phi(
         type_b,
         code: DiagCode::S102,
         message: format!(
-            "S102: '{var}' oscillates between {a} and {b} across \
+            "'{var}' oscillates between {a} and {b} across \
+             loop iterations (thunking)",
+            a = type_name(type_a),
+            b = type_name(type_b),
+        ),
+        related,
+    })
+}
+
+/// Decide whether a loop variable thunks *within* each iteration even
+/// though its loop-header phi is not `Shimmered`: the body's own defs carry
+/// two (or more) distinct KNOWN intreps for a self-referential variable, so
+/// every pass re-converts between them — `lappend acc $x; set acc "$acc,"`
+/// costs a string→list parse and a list→string regeneration per iteration
+/// while the header phi sees a consistent string.
+///
+/// The self-reference requirement keeps fresh-per-pass variables (branch
+/// arms assigning independent literals of different types) out: those have
+/// no prior-pass value to reinterpret — the same evidence standard the
+/// `Shimmered`-header path applies via [`loop_self_referential`].  Empty
+/// initialiser versions and destructure-foreach blocks are already excluded
+/// by [`per_loop_body_types`]; array-element symbols were excluded by the
+/// caller.
+fn classify_intra_iteration_thunk(
+    ctx: &ThunkCtx<'_>,
+    phi: &Phi,
+    this_loop: &HashSet<String>,
+    per_loop: &HashMap<Symbol, HashSet<TclType>>,
+) -> Option<ThunkingWarning> {
+    let body_types = per_loop.get(&phi.name)?;
+    if body_types.len() < 2 {
+        return None;
+    }
+    if !loop_self_referential(ctx.ssa, this_loop, phi.name) {
+        return None;
+    }
+    // Deterministic pair selection: order by display name so the message
+    // and anchor never depend on hash iteration order.
+    let mut sorted: Vec<TclType> = body_types.iter().copied().collect();
+    sorted.sort_by_key(|t| type_name(*t));
+    let (type_a, type_b) = (sorted[0], sorted[1]);
+    let span = [type_b, type_a]
+        .into_iter()
+        .find_map(|t| per_loop_type_span(ctx, this_loop, phi.name, t))
+        .unwrap_or_else(|| phi_span(phi, ctx.ssa, ctx.def_map));
+    let related: Vec<_> = phi
+        .incoming
+        .iter()
+        .filter_map(|(pred_block, &ver)| {
+            ctx.def_map.get(&(phi.name, ver)).copied().map(|sp| {
+                (
+                    sp,
+                    format!("version from '{}'", ctx.cfg.block_name(*pred_block)),
+                )
+            })
+        })
+        .collect();
+    let var = ctx.ssa.var_name(phi.name);
+    Some(ThunkingWarning {
+        span,
+        variable: var.to_owned(),
+        type_a,
+        type_b,
+        code: DiagCode::S102,
+        message: format!(
+            "'{var}' oscillates between {a} and {b} across \
              loop iterations (thunking)",
             a = type_name(type_a),
             b = type_name(type_b),
@@ -496,8 +567,11 @@ fn classify_thunking_phi(
 
 /// Find thunking warnings for a function.
 ///
-/// Returns one [`ThunkingWarning`] per loop-header phi node whose type
-/// lattice is `Shimmered` and whose incomings genuinely oscillate.
+/// Returns one [`ThunkingWarning`] per loop-header phi node that genuinely
+/// oscillates: either its type lattice is `Shimmered` and the incomings
+/// re-introduce the entry type each pass, or the loop body itself defines
+/// the (self-referential) variable with two distinct intreps within one
+/// iteration ([`classify_intra_iteration_thunk`]).
 #[must_use]
 pub(crate) fn find_thunking_warnings(
     cfg: &CfgFunction,
@@ -611,6 +685,57 @@ mod tests {
         let fu = cu.function("::f").unwrap();
         let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
         assert!(w.is_empty(), "accumulator promotion must not thunk: {w:?}");
+    }
+
+    /// TP: intra-iteration oscillation — the body converts list→string
+    /// within each pass (`lappend acc …; set acc "$acc,"`), so the header
+    /// phi sees a consistent string yet every iteration pays both
+    /// conversions.  The `Shimmered`-header gate alone missed this shape.
+    #[test]
+    fn s102_for_intra_iteration_oscillation() {
+        let cu = CompilationUnit::build_for(
+            "proc g {items} { set acc \"\"\n foreach x $items { lappend acc $x\n set acc \"$acc,\" }\n return $acc }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::g").unwrap();
+        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        assert_eq!(w.len(), 1, "intra-iteration oscillation must thunk: {w:?}");
+        assert_eq!(w[0].variable, "acc");
+        assert_eq!(w[0].code, tcl_core_types::DiagCode::S102);
+    }
+
+    /// FP guard: a variable reset from independent literals of different
+    /// types each pass (never reading its own prior value) has no
+    /// prior-pass value to reinterpret — the intra-iteration path must not
+    /// fire without self-reference.
+    #[test]
+    fn no_intra_iteration_s102_for_fresh_per_pass_variable() {
+        let cu = CompilationUnit::build_for(
+            "proc h {items c} { foreach x $items { if {$c} { set v 1 } else { set v \"s\" }\n puts $v } }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::h").unwrap();
+        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        assert!(
+            w.is_empty(),
+            "fresh-per-pass variable must not thunk: {w:?}"
+        );
+    }
+
+    /// TN: a self-referential accumulator held at ONE intrep throughout
+    /// (`set n [expr {$n + 1}]`) — a single body type is not oscillation.
+    #[test]
+    fn no_intra_iteration_s102_for_uniform_self_reference() {
+        let cu = CompilationUnit::build_for(
+            "proc k {items} { set n 0\n foreach x $items { set n [expr {$n + 1}] }\n return $n }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::k").unwrap();
+        let w = find_thunking_warnings(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        assert!(w.is_empty(), "uniform self-reference must not thunk: {w:?}");
     }
 
     /// Empty source: no thunking warnings and no panic.

--- a/rust/tcl-compiler/src/shimmer/thunking.rs
+++ b/rust/tcl-compiler/src/shimmer/thunking.rs
@@ -583,12 +583,12 @@ fn classify_intra_iteration_thunk(
 /// the (self-referential) variable with two distinct intreps within one
 /// iteration ([`classify_intra_iteration_thunk`]).
 #[must_use]
-pub(crate) fn find_thunking_warnings(
+pub(crate) fn find_thunking_warnings<S: std::hash::BuildHasher>(
     cfg: &CfgFunction,
     ssa: &SsaFunction,
     types: &HashMap<ValueKey, TypeLattice>,
     executable_blocks: &HashSet<BlockId>,
-    extra_scope_aliases: Option<&HashSet<String>>,
+    extra_scope_aliases: Option<&HashSet<String, S>>,
 ) -> Vec<ThunkingWarning> {
     let loop_blocks = loop_body_blocks(cfg);
     let succs = build_successors(cfg);
@@ -679,7 +679,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(w.is_empty(), "unexpected thunking warnings: {w:?}");
     }
@@ -700,7 +700,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(w.is_empty(), "sibling loops must not thunk: {w:?}");
     }
@@ -720,7 +720,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(w.is_empty(), "accumulator promotion must not thunk: {w:?}");
     }
@@ -742,7 +742,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert_eq!(w.len(), 1, "intra-iteration oscillation must thunk: {w:?}");
         assert_eq!(w[0].variable, "acc");
@@ -766,7 +766,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(
             w.is_empty(),
@@ -789,7 +789,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(w.is_empty(), "uniform self-reference must not thunk: {w:?}");
     }
@@ -804,7 +804,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(w.is_empty());
     }
@@ -819,7 +819,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(w.is_empty(), "unexpected thunking: {w:?}");
     }
@@ -843,7 +843,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         let has_thunking = w
             .iter()
@@ -870,7 +870,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert_eq!(w.len(), 1, "expected exactly one S102 warning: {w:?}");
         let while_pos = u32::try_from(src.find("while").unwrap()).unwrap();
@@ -903,7 +903,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(
             w.iter().any(|tw| tw.variable == "x"),
@@ -931,7 +931,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(
             w.is_empty(),
@@ -958,7 +958,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(
             w.is_empty(),
@@ -987,7 +987,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(w.is_empty(), "traced variable must not thunk: {w:?}");
     }
@@ -1012,7 +1012,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(
             w.iter().any(|tw| tw.variable == "x"),
@@ -1036,7 +1036,7 @@ mod tests {
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
-            None,
+            None::<&HashSet<String>>,
         );
         assert!(
             w.iter().any(|tw| tw.variable == "x"),

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -414,11 +414,12 @@ fn check_invocation(
             in_loop: ctx.in_loop,
             code,
             message: format!(
-                "{code}: variable '{var}' has {from} intrep \
-                 but '{cmd}' expects {to} at arg {i}",
+                "variable '{var}' has {from} intrep \
+                 but '{cmd}' expects {to} (argument {n})",
                 from = type_name(current),
                 cmd = command,
                 to = type_name(expected),
+                n = i + 1,
             ),
             related,
         });
@@ -587,7 +588,7 @@ fn check_incr_var(ctx: &mut UseSiteCtx<'_>, var: &str, span: Span, uses: &HashMa
         in_loop: ctx.in_loop,
         code,
         message: format!(
-            "{code}: variable '{var}' has {from} intrep but 'incr' expects int",
+            "variable '{var}' has {from} intrep but 'incr' expects int",
             from = type_name(current),
         ),
         related,

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -48,13 +48,7 @@ use super::types::{
 /// `ns_prefix` is expected to be the call-site namespace **without**
 /// a leading `::` (the walker carries it that way by convention).
 pub(super) fn qualify(ns_prefix: &str, name: &str) -> String {
-    if name.starts_with("::") {
-        name.to_string()
-    } else if ns_prefix.is_empty() {
-        format!("::{name}")
-    } else {
-        format!("::{ns_prefix}::{name}")
-    }
+    crate::naming::qualify(ns_prefix, name)
 }
 
 /// Insert a class record under `result.classes`, computing the

--- a/rust/tcl-compiler/src/text.rs
+++ b/rust/tcl-compiler/src/text.rs
@@ -30,7 +30,12 @@
 
 use std::collections::HashSet;
 
-/// Levenshtein edit distance between two strings.
+/// Edit distance between two strings — optimal string alignment
+/// (restricted Damerau–Levenshtein): insertions, deletions,
+/// substitutions, and **adjacent transpositions** each count as one
+/// edit.  A transposed pair (`ste` → `set`) is the single most common
+/// real-world typo, so counting it as one edit instead of two keeps
+/// such names inside the "did you mean…?" distance budget.
 ///
 /// O(len(a) × len(b)) time, O(min(len(a), len(b))) space.
 #[must_use]
@@ -49,18 +54,39 @@ fn edit_distance_inner(longer: &[char], shorter: &[char]) -> usize {
     if shorter.is_empty() {
         return longer.len();
     }
+    // Rolling three-row DP: `prev2` (i-2), `prev` (i-1), `curr` (i).
+    // The transposition case reads `prev2[j-1]`.
+    let mut prev2: Vec<usize> = Vec::new();
     let mut prev: Vec<usize> = (0..=shorter.len()).collect();
     for (i, &ca) in longer.iter().enumerate() {
         let mut curr: Vec<usize> = Vec::with_capacity(shorter.len() + 1);
         curr.push(i + 1);
         for (j, &cb) in shorter.iter().enumerate() {
             let cost = usize::from(ca != cb);
-            let v = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+            let mut v = (prev[j + 1] + 1).min(curr[j] + 1).min(prev[j] + cost);
+            if i > 0 && j > 0 && ca == shorter[j - 1] && longer[i - 1] == cb {
+                v = v.min(prev2[j - 1] + 1);
+            }
             curr.push(v);
         }
-        prev = curr;
+        prev2 = std::mem::replace(&mut prev, curr);
     }
     prev[shorter.len()]
+}
+
+/// The "did you mean…?" distance budget for a name of `chars` characters:
+/// one edit per three whole characters, at least 1, at most 3.
+///
+/// A fixed budget over-suggests on short names (with a budget of 2, a
+/// 3-character typo like `ua2` "matches" the entirely unrelated `cat`;
+/// with 3, the 7-character `require` "matches" `re_quote`) and
+/// under-suggests on long ones.  Scaling by length keeps suggestions
+/// plausible at both ends: 1–5 chars → 1 edit, 6–8 → 2, 9+ → 3.
+/// Transpositions count as one edit ([`edit_distance`] is OSA), so the
+/// common swapped-pair typo stays within budget even on short names.
+#[must_use]
+pub fn scaled_max_distance(name: &str) -> usize {
+    (name.chars().count() / 3).clamp(1, 3)
 }
 
 /// Suggest up to `max_suggestions` candidates from `candidates`

--- a/rust/tcl-compiler/tests/alias_scoping.rs
+++ b/rust/tcl-compiler/tests/alias_scoping.rs
@@ -122,7 +122,7 @@ fn mem(source: &str, proc: &str) -> MemorySsaFunction {
             },
             |(_, f)| f,
         );
-    build_memory_ssa(&build_ssa(f, registry()))
+    build_memory_ssa(&build_ssa(f, registry()), registry())
 }
 
 /// Every diagnostic code the full pipeline surfaces for `src`, mirroring the

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -1424,14 +1424,13 @@ mod unresolved_command {
 
     #[test]
     fn other_dynamic_providers_do_not_suppress_w123_rust_behaviour() {
-        // The analyser sets `has_dynamic_providers` for `load` / `rename` /
+        // The analyser sets `has_dynamic_providers` for `load` /
         // `namespace import` / `lappend auto_path` but still emits W123 for the
         // unknown command (the suppression is scoped to `package require`). This
         // matches tclsh for the `load` case: `load mylib.so` of a missing file
         // does NOT define `mycommand` (`info commands mycommand` stays empty).
         for src in [
             "load mylib.so\nmycommand arg1",
-            "rename puts myputs\nmyputs hello",
             "namespace import ::foo::*\nbar arg",
             "lappend auto_path /opt/mylib\nmycmd arg",
         ] {
@@ -1440,6 +1439,16 @@ mod unresolved_command {
                 "expected W123 (Rust verdict) for {src:?}"
             );
         }
+    }
+
+    #[test]
+    fn static_rename_target_is_a_known_command() {
+        // A static `rename OLD NEW` *defines* NEW (confirmed against tclsh
+        // 9.0.4: `rename puts myputs; info commands myputs` lists it), so a
+        // call to the renamed name must not draw W123 — while a genuinely
+        // unknown name in the same file still does.
+        assert!(w123("rename puts myputs\nmyputs hello").is_empty());
+        assert_eq!(w123("rename puts myputs\nmyputz hello").len(), 1);
     }
 
     #[test]

--- a/rust/tcl-compiler/tests/dataflow.rs
+++ b/rust/tcl-compiler/tests/dataflow.rs
@@ -136,7 +136,7 @@ fn build_graph(cu: &CompilationUnit) -> DataFlowGraph {
 
 /// Build the data-flow graph for `source`, with memory-SSA populated.
 fn graph_for(source: &str) -> DataFlowGraph {
-    let cu = build_cu(source).with_memory_ssa();
+    let cu = build_cu(source).with_memory_ssa(&CommandRegistry::build_default());
     build_graph(&cu)
 }
 
@@ -496,7 +496,7 @@ fn dataflow_prebuilt_cu() {
     // the same ≥2 defs. The API *only* consumes pre-built per-function inputs,
     // so this is the same path as `build_graph` but spelled out: reuse one
     // `CompilationUnit`.
-    let cu = build_cu("set x 1\nset y $x").with_memory_ssa();
+    let cu = build_cu("set x 1\nset y $x").with_memory_ssa(&CommandRegistry::build_default());
     let g = build_graph(&cu);
     assert!(g.total_defs() >= 2);
 }

--- a/rust/tcl-compiler/tests/pipeline_coverage.rs
+++ b/rust/tcl-compiler/tests/pipeline_coverage.rs
@@ -747,7 +747,8 @@ mod compilation_unit_build {
 
     #[test]
     fn with_memory_ssa_populates_top_and_procs() {
-        let cu = build("proc f {} { set x 1; return $x }").with_memory_ssa();
+        let cu = build("proc f {} { set x 1; return $x }")
+            .with_memory_ssa(&CommandRegistry::build_default());
         assert!(cu.top_level.memory_ssa.is_some());
         assert!(cu.function("::f").unwrap().memory_ssa.is_some());
     }

--- a/rust/tcl-compiler/tests/text_utils.rs
+++ b/rust/tcl-compiler/tests/text_utils.rs
@@ -55,10 +55,14 @@ fn test_single_substitution() {
 
 #[test]
 fn test_transposition() {
-    // Levenshtein counts a transposition as 2 operations (one
-    // delete + one insert, or two substitutions). Damerau would
-    // score this as 1 — but both impls here are plain Levenshtein.
-    assert_eq!(edit_distance("puts", "pust"), 2);
+    // Optimal string alignment (restricted Damerau–Levenshtein): an
+    // adjacent transposition is ONE edit, not the two plain Levenshtein
+    // charges. The swapped-pair typo is the most common real-world
+    // misspelling, so `pust` must stay within a one-edit "did you
+    // mean…?" budget of `puts`.
+    assert_eq!(edit_distance("puts", "pust"), 1);
+    // A non-adjacent swap is not a transposition — still two edits.
+    assert_eq!(edit_distance("abcd", "dbca"), 2);
 }
 
 #[test]

--- a/rust/tcl-explorer/src/lib.rs
+++ b/rust/tcl-explorer/src/lib.rs
@@ -132,7 +132,7 @@ pub fn run_pipeline(source: &str, dialect: &str) -> ExplorerResult {
     // `aliases` list degrades to empty.
     let unit = CompilationUnit::build_for_with_config(source, registry, false, config)
         .with_interprocedural(registry, Some(dialect))
-        .with_memory_ssa();
+        .with_memory_ssa(registry);
 
     ExplorerResult {
         source: source.to_owned(),

--- a/rust/tcl-lsp-core/src/completion.rs
+++ b/rust/tcl-lsp-core/src/completion.rs
@@ -1187,20 +1187,22 @@ fn event_name_completions(partial: &str) -> Vec<CompletionItem> {
 }
 
 fn subcommand_completions(spec: &tcl_registry::CommandSpec, partial: &str) -> Vec<CompletionItem> {
-    let mut names: Vec<&str> = spec
+    let mut subs: Vec<&tcl_registry::SubCommand> = spec
         .subcommands
         .iter()
-        .map(|sub| sub.name)
-        .filter(|n| partial.is_empty() || n.starts_with(partial))
+        .filter(|sub| partial.is_empty() || sub.name.starts_with(partial))
         .collect();
-    names.sort_unstable();
-    names
-        .into_iter()
-        .map(|name| CompletionItem {
-            label: name.to_owned(),
-            insert_text: name.to_owned(),
+    subs.sort_unstable_by_key(|sub| sub.name);
+    subs.into_iter()
+        .map(|sub| CompletionItem {
+            label: sub.name.to_owned(),
+            insert_text: sub.name.to_owned(),
             kind: CompletionKind::Function,
-            detail: None,
+            // Surface the registry's one-line description, exactly as the
+            // sub-subcommand / scoped-op / arg-value completions already do
+            // — `string <TAB>` shows what each operation does, not a bare
+            // name list.
+            detail: (!sub.detail.is_empty()).then(|| sub.detail.to_owned()),
             sort_text: None,
             is_snippet: false,
             filter_text: None,

--- a/rust/tcl-lsp-core/src/graphs.rs
+++ b/rust/tcl-lsp-core/src/graphs.rs
@@ -984,7 +984,7 @@ fn memory_function_json(
 pub fn memory_alias_graph(source: &str, registry: &CommandRegistry, dialect: &str) -> Value {
     let cu = CompilationUnit::build_for(source, registry, false)
         .with_interprocedural(registry, Some(dialect))
-        .with_memory_ssa();
+        .with_memory_ssa(registry);
 
     let mut functions: Vec<Value> = vec![memory_function_json(
         "::top",

--- a/rust/tcl-lsp-db/examples/cc_diff.rs
+++ b/rust/tcl-lsp-db/examples/cc_diff.rs
@@ -38,7 +38,7 @@ fn main() {
     let src = std::fs::read_to_string(root.join(&rel)).expect("read FILE");
 
     let db = TclDatabase::default();
-    let file = SourceFile::new(&db, src.clone(), dialect.clone());
+    let file = SourceFile::new(&db, src.clone(), dialect.clone(), None);
     let cfg = AnalyserConfig::new(
         &db,
         Vec::new(),

--- a/rust/tcl-lsp-db/examples/fa_diff.rs
+++ b/rust/tcl-lsp-db/examples/fa_diff.rs
@@ -41,7 +41,7 @@ fn main() {
         Vec::new(),
         None,
     );
-    let file = SourceFile::new(&db, src.clone(), dialect.clone());
+    let file = SourceFile::new(&db, src.clone(), dialect.clone(), None);
     let inc = file_analysis_incremental(&db, file, cfg);
     let full = file_analysis(&db, file, cfg);
 

--- a/rust/tcl-lsp-db/examples/stress_concurrent_analysis.rs
+++ b/rust/tcl-lsp-db/examples/stress_concurrent_analysis.rs
@@ -447,7 +447,7 @@ fn main() {
         Vec::new(),
         None,
     );
-    let file = SourceFile::new(&db, base_text.clone(), params.dialect.clone());
+    let file = SourceFile::new(&db, base_text.clone(), params.dialect.clone(), None);
 
     // Readers each hold their own `TclDatabase` handle, refreshed from the
     // shared `db_handle` before every query — the exact "clone a fresh,

--- a/rust/tcl-lsp-db/examples/tail_profile.rs
+++ b/rust/tcl-lsp-db/examples/tail_profile.rs
@@ -88,7 +88,7 @@ fn main() {
         Vec::new(),
         None,
     );
-    let file = SourceFile::new(&db, src.clone(), dialect.to_owned());
+    let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
     let _ = file_analysis_incremental(&db, file, cfg);
     let _ = compiler_check_diagnostics(&db, file, cfg);
 
@@ -216,7 +216,7 @@ fn rerun_breadth(src: &str, dialect: &str, fallback_pos: usize, n_functions: usi
         Vec::new(),
         None,
     );
-    let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned());
+    let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned(), None);
     let _ = file_analysis_incremental(&db, file, cfg);
     let _ = compiler_check_diagnostics(&db, file, cfg);
     let cold: Vec<String> = std::mem::take(&mut *log.lock().unwrap());

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -143,6 +143,13 @@ pub struct SourceFile {
     pub text: String,
     #[returns(ref)]
     pub dialect: String,
+    /// Source-file path (from the document URI), or `None` for in-memory
+    /// text.  Path-keyed analysis behaviour: `pkgIndex.tcl` suppresses
+    /// dead-store/unused hints on the loader-supplied `$dir`, and a file
+    /// with a registry whole-file scoped environment (`tclpkg.tcl`
+    /// manifests) is analysed with that environment ambient.
+    #[returns(ref)]
+    pub path: Option<String>,
 }
 
 /// Analyser configuration mirrored from the editor (the former
@@ -186,7 +193,8 @@ pub fn file_analysis(
     let extra: HashSet<String> = config.extra_commands(db).iter().cloned().collect();
     let mut analyser = Analyser::with_disabled_diagnostics(disabled)
         .with_non_ascii_mode(config.non_ascii_mode(db))
-        .with_extra_commands(extra);
+        .with_extra_commands(extra)
+        .with_file_path(file.path(db).clone());
     Arc::new(analyser.analyse(file.text(db), file.dialect(db)))
 }
 
@@ -1337,10 +1345,12 @@ pub fn function_checks<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<V
     let dialect = key.dialect(db);
     let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
     let registry = db.registry(dialect);
+    // Per-procedure memo — procs have no implicit instance variables.
     Arc::new(tcl_compiler::compiler_checks::function_nontaint_checks(
         &fu,
         &registry,
         dialect_opt,
+        None,
     ))
 }
 
@@ -1481,6 +1491,7 @@ pub fn proc_taint_solve<'db>(
                     fu,
                     &registry,
                     dialect_opt,
+                    None,
                 ) {
                     fn_checks.push(d);
                 }
@@ -1500,7 +1511,12 @@ pub fn proc_taint_solve<'db>(
     // they carry absolute spans already and need no rebase, same as the
     // `None` arm above.
     for fu in cu.analysable_methods_and_body_units() {
-        for d in tcl_compiler::compiler_checks::shimmer_family_checks(fu, &registry, dialect_opt) {
+        for d in tcl_compiler::compiler_checks::shimmer_family_checks(
+            fu,
+            &registry,
+            dialect_opt,
+            cu.method_instance_vars(&fu.name),
+        ) {
             fn_checks.push(d);
         }
     }
@@ -2046,7 +2062,8 @@ pub fn file_analysis_incremental(
     let text = file.text(db).clone();
     let mut analyser = Analyser::with_disabled_diagnostics(disabled_vec.iter().cloned().collect())
         .with_non_ascii_mode(non_ascii)
-        .with_extra_commands(extra_commands);
+        .with_extra_commands(extra_commands)
+        .with_file_path(file.path(db).clone());
 
     // Build the CFG/SSA tail's compilation unit with per-procedure lattices
     // memoised by `function_lattice`, and feed it through the analyser's
@@ -2399,7 +2416,7 @@ mod tests {
         let src = "proc countdown {n} {\n    puts $n\n    if {$n <= 0} { return }\n    countdown [expr {$n - 1}]\n}\n";
         let db = TclDatabase::default();
         let registry = db.registry(dialect);
-        let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned());
+        let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned(), None);
         let got = compiler_check_diagnostics(&db, file, cfg(&db));
         let want = compiler_check_diagnostics_uncached(src, &registry, dialect, None);
         assert!(
@@ -2415,7 +2432,7 @@ mod tests {
     #[test]
     fn file_analysis_matches_direct_analyse() {
         let db = TclDatabase::default();
-        let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned());
+        let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned(), None);
         let got = file_analysis(&db, file, cfg(&db));
 
         let mut direct = Analyser::new();
@@ -2427,7 +2444,7 @@ mod tests {
     #[test]
     fn document_symbols_match_direct() {
         let db = TclDatabase::default();
-        let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned());
+        let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned(), None);
         let got = document_symbols(&db, file, cfg(&db));
         let expected = tcl_lsp_core::document_symbols::document_symbols(SRC, "tcl");
         assert_eq!(got, expected);
@@ -2436,7 +2453,7 @@ mod tests {
     #[test]
     fn semantic_tokens_match_direct() {
         let db = TclDatabase::default();
-        let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned());
+        let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned(), None);
         let got = semantic_tokens(&db, file, cfg(&db));
         let reg = db.registry("tcl");
         let expected = tcl_lsp_core::semantic_tokens::full(SRC, "tcl", &reg);
@@ -2459,7 +2476,7 @@ mod tests {
     fn semantic_tokens_retags_constant_regex_source_true_positive() {
         let src = "set my_re \".*abc\"\nregexp $my_re $s\n";
         let db = TclDatabase::default();
-        let file = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned());
+        let file = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned(), None);
         let enriched = semantic_tokens(&db, file, cfg(&db));
         let reg = db.registry("tcl9.0");
         let coarse = tcl_lsp_core::semantic_tokens::full(src, "tcl9.0", &reg);
@@ -2479,7 +2496,7 @@ mod tests {
     fn semantic_tokens_skips_retag_for_non_constant_pattern_true_negative() {
         let src = "proc match {re s} {\n    regexp $re $s\n}\n";
         let db = TclDatabase::default();
-        let file = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned());
+        let file = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned(), None);
         let enriched = semantic_tokens(&db, file, cfg(&db));
         let reg = db.registry("tcl9.0");
         let coarse = tcl_lsp_core::semantic_tokens::full(src, "tcl9.0", &reg);
@@ -2513,7 +2530,7 @@ mod tests {
             registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
-        let file = SourceFile::new(&db, SRC.to_owned(), "tcl8.6".to_owned());
+        let file = SourceFile::new(&db, SRC.to_owned(), "tcl8.6".to_owned(), None);
 
         // Diagnostics-first order: the worker analyses, then a token request
         // arrives for the same revision.
@@ -2589,11 +2606,13 @@ mod tests {
             &db,
             "oo::configurable create ::Pin { property node }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let main = SourceFile::new(
             &db,
             "set p [::Pin new]\n$p configure -node n1\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let project = Project::new(&db, vec![lib, main]);
 
@@ -2640,11 +2659,13 @@ mod tests {
             &db,
             "oo::configurable create ::Pin { property node }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let main = SourceFile::new(
             &db,
             "proc ::helper {a b} { return [expr {$a + $b}] }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let project = Project::new(&db, vec![lib, main]);
 
@@ -2680,11 +2701,13 @@ mod tests {
             &db,
             "oo::configurable create ::Pin { property node }\n".to_owned(),
             "tcl9.0".to_owned(),
+            None,
         );
         let user = SourceFile::new(
             &db,
             "[::Pin new] configure -node 5\n".to_owned(),
             "tcl9.0".to_owned(),
+            None,
         );
         let project = Project::new(&db, vec![lib, user]);
         let cross = semantic_tokens_project(&db, user, cfg(&db), project);
@@ -2714,11 +2737,13 @@ mod tests {
             &db,
             "oo::class create ::Pin { method a {} {} }\n".to_owned(),
             "tcl9.0".to_owned(),
+            None,
         );
         let b = SourceFile::new(
             &db,
             "oo::class create ::Pin { method b {} {} }\n".to_owned(),
             "tcl9.0".to_owned(),
+            None,
         );
         // Both orderings must agree (and both must drop the ambiguous class).
         for files in [vec![a, b], vec![b, a]] {
@@ -2735,7 +2760,7 @@ mod tests {
     #[test]
     fn folding_matches_direct() {
         let db = TclDatabase::default();
-        let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned());
+        let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned(), None);
         let got = folding_ranges(&db, file);
         let reg = db.registry("tcl");
         let expected = tcl_lsp_core::folding::folding_ranges(SRC, "tcl", &reg);
@@ -2747,7 +2772,7 @@ mod tests {
         use salsa::Setter as _;
         let mut db = TclDatabase::default();
         let config = cfg(&db);
-        let file = SourceFile::new(&db, "proc a {} {}\n".to_owned(), "tcl".to_owned());
+        let file = SourceFile::new(&db, "proc a {} {}\n".to_owned(), "tcl".to_owned(), None);
         assert!(
             file_analysis(&db, file, config)
                 .all_procs
@@ -2765,7 +2790,7 @@ mod tests {
         use std::collections::BTreeSet;
         let db = TclDatabase::default();
         let src = "proc p {} {}\noo::class create K {}\nnamespace eval z { proc q {} {} }\n";
-        let file = SourceFile::new(&db, src.to_owned(), "tcl".to_owned());
+        let file = SourceFile::new(&db, src.to_owned(), "tcl".to_owned(), None);
         let decls = file_decls(&db, file);
         let analysis = file_analysis(&db, file, cfg(&db));
         let want_procs: BTreeSet<String> = analysis.all_procs.keys().cloned().collect();
@@ -2781,7 +2806,12 @@ mod tests {
     fn item_sigs_track_signatures() {
         use tcl_compiler::analyser::ItemKind;
         let db = TclDatabase::default();
-        let file = SourceFile::new(&db, "proc greet {name} {}\n".to_owned(), "tcl".to_owned());
+        let file = SourceFile::new(
+            &db,
+            "proc greet {name} {}\n".to_owned(),
+            "tcl".to_owned(),
+            None,
+        );
         let sigs = item_sigs(&db, file);
         let greet = sigs
             .iter()
@@ -2796,7 +2826,7 @@ mod tests {
     fn item_tree_recomputes_on_edit() {
         use salsa::Setter as _;
         let mut db = TclDatabase::default();
-        let file = SourceFile::new(&db, "proc a {} {}\n".to_owned(), "tcl".to_owned());
+        let file = SourceFile::new(&db, "proc a {} {}\n".to_owned(), "tcl".to_owned(), None);
         assert!(file_decls(&db, file).procs.contains("::a"));
         file.set_text(&mut db).to("proc b {} {}\n".to_owned());
         let after = file_decls(&db, file);
@@ -2814,7 +2844,7 @@ mod tests {
             "namespace eval n { proc f {y} { set z $y } }\nset g 1\nputs $g\n",
             "oo::class create K {\n  method m {a} { set n $a }\n}\nproc p {} { set q 1 }\n",
         ] {
-            let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned());
+            let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
             let inc = file_analysis_incremental(&db, file, cfg);
             let full = file_analysis(&db, file, cfg);
             assert_eq!(*inc, *full, "incremental != full for:\n{src}");
@@ -2844,6 +2874,7 @@ mod tests {
             &db,
             "proc a {} { set x 11111 }\nproc b {} { set y 22222 }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let _ = file_analysis_incremental(&db, file, cfg);
         let init = std::mem::take(&mut *log.lock().unwrap());
@@ -2897,6 +2928,7 @@ mod tests {
             "oo::class create K {\n  method a {} { set x 11111 }\n  method b {} { set y 22222 }\n}\n"
                 .to_owned(),
             "tcl8.6".to_owned(),
+         None,
         );
         let _ = file_analysis_incremental(&db, file, cfg);
         let init = std::mem::take(&mut *log.lock().unwrap());
@@ -2940,7 +2972,7 @@ mod tests {
             ),
             ("when HTTP_REQUEST { set u [HTTP::uri] }\n", "f5-irules"),
         ] {
-            let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned());
+            let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned(), None);
             let got = compiler_check_diagnostics(
                 &db,
                 file,
@@ -2996,7 +3028,7 @@ mod tests {
         // not exercise stale-cache reuse, which is the point.
         let mut db = TclDatabase::default();
         let registry = db.registry(dialect);
-        let file = SourceFile::new(&db, versions[0].to_owned(), dialect.to_owned());
+        let file = SourceFile::new(&db, versions[0].to_owned(), dialect.to_owned(), None);
         for src in versions {
             file.set_text(&mut db).to(src.to_owned());
             let got = compiler_check_diagnostics(
@@ -3088,7 +3120,7 @@ mod tests {
         let mut state = [1usize, 1, 1, 1];
         let mut db = TclDatabase::default();
         let registry = db.registry(dialect);
-        let file = SourceFile::new(&db, assemble(&state), dialect.to_owned());
+        let file = SourceFile::new(&db, assemble(&state), dialect.to_owned(), None);
 
         for iter in 0..250 {
             let slot = (next() as usize) % state.len();
@@ -3145,6 +3177,7 @@ mod tests {
              proc c {} { set z 33333 }\n"
                 .to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let _ = compiler_check_diagnostics(
             &db,
@@ -3212,6 +3245,7 @@ mod tests {
              proc c {} { puts 33333 }\n"
                 .to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let _ = compiler_check_diagnostics(&db, file, cfg(&db));
         assert_eq!(
@@ -3270,6 +3304,7 @@ mod tests {
              proc c {} { puts 33333 }\n"
                 .to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let _ = compiler_check_diagnostics(&db, file, cfg(&db));
         assert_eq!(
@@ -3340,6 +3375,7 @@ mod tests {
              proc c {} { set z 33333 }\n"
                 .to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let _ = compiler_check_diagnostics(
             &db,
@@ -3402,11 +3438,13 @@ mod tests {
             &db,
             "proc a {} { set x 1 }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let b = SourceFile::new(
             &db,
             "proc b {} { set y 2 }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let project = Project::new(&db, vec![a, b]);
 
@@ -3473,8 +3511,14 @@ mod tests {
             &db,
             "proc helper {x y} { set z 1 }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
-        let b = SourceFile::new(&db, "proc other {} {}\n".to_owned(), "tcl8.6".to_owned());
+        let b = SourceFile::new(
+            &db,
+            "proc other {} {}\n".to_owned(),
+            "tcl8.6".to_owned(),
+            None,
+        );
         let project = Project::new(&db, vec![a, b]);
 
         // Cold: `helper` is a 2-param proc → arity (2, 2).
@@ -3554,10 +3598,11 @@ mod tests {
             &db,
             "proc foo {x} {}\nproc bar {y} {}\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         // `b` calls `foo` with one arg — resolves cross-file, fits arity (1, 1),
         // so its diagnostics are empty.  It never references `bar`.
-        let b = SourceFile::new(&db, "foo 1\n".to_owned(), "tcl8.6".to_owned());
+        let b = SourceFile::new(&db, "foo 1\n".to_owned(), "tcl8.6".to_owned(), None);
         let project = Project::new(&db, vec![a, b]);
 
         assert!(
@@ -3624,11 +3669,17 @@ mod tests {
     fn project_diagnostics_suppresses_cross_file_w123() {
         let db = TclDatabase::default();
         let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
-        let a = SourceFile::new(&db, "helper foo bar\n".to_owned(), "tcl8.6".to_owned());
+        let a = SourceFile::new(
+            &db,
+            "helper foo bar\n".to_owned(),
+            "tcl8.6".to_owned(),
+            None,
+        );
         let b = SourceFile::new(
             &db,
             "proc helper {x y} { return $x }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let has_helper_w123 = |diags: &[tcl_compiler::analyser::types::Diagnostic]| {
             diags
@@ -3679,16 +3730,16 @@ mod tests {
         let mk = |b_text: &str| -> Vec<(String, u32, u32, String)> {
             let db = TclDatabase::default();
             let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
-            let a = SourceFile::new(&db, a_text.to_owned(), "tcl8.6".to_owned());
-            let b = SourceFile::new(&db, b_text.to_owned(), "tcl8.6".to_owned());
+            let a = SourceFile::new(&db, a_text.to_owned(), "tcl8.6".to_owned(), None);
+            let b = SourceFile::new(&db, b_text.to_owned(), "tcl8.6".to_owned(), None);
             let project = Project::new(&db, vec![a, b]);
             diag_keys(&project_diagnostics(&db, a, cfg, project))
         };
 
         let mut db = TclDatabase::default();
         let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
-        let a = SourceFile::new(&db, a_text.to_owned(), "tcl8.6".to_owned());
-        let b = SourceFile::new(&db, b_variants[0].to_owned(), "tcl8.6".to_owned());
+        let a = SourceFile::new(&db, a_text.to_owned(), "tcl8.6".to_owned(), None);
+        let b = SourceFile::new(&db, b_variants[0].to_owned(), "tcl8.6".to_owned(), None);
         let project = Project::new(&db, vec![a, b]);
 
         let mut rng = 0x1234_5678_9abc_def0_u64;
@@ -3737,16 +3788,16 @@ mod tests {
         let mk = |a_text: &str, b_text: &str| -> Vec<(String, u32, u32, String)> {
             let db = TclDatabase::default();
             let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
-            let a = SourceFile::new(&db, a_text.to_owned(), "tcl8.6".to_owned());
-            let b = SourceFile::new(&db, b_text.to_owned(), "tcl8.6".to_owned());
+            let a = SourceFile::new(&db, a_text.to_owned(), "tcl8.6".to_owned(), None);
+            let b = SourceFile::new(&db, b_text.to_owned(), "tcl8.6".to_owned(), None);
             let project = Project::new(&db, vec![a, b]);
             diag_keys(&project_diagnostics(&db, a, cfg, project))
         };
 
         let mut db = TclDatabase::default();
         let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
-        let a = SourceFile::new(&db, a_variants[0].to_owned(), "tcl8.6".to_owned());
-        let b = SourceFile::new(&db, b_variants[0].to_owned(), "tcl8.6".to_owned());
+        let a = SourceFile::new(&db, a_variants[0].to_owned(), "tcl8.6".to_owned(), None);
+        let b = SourceFile::new(&db, b_variants[0].to_owned(), "tcl8.6".to_owned(), None);
         let project = Project::new(&db, vec![a, b]);
 
         let mut rng = 0x0f0f_1234_dead_beef_u64;
@@ -3789,6 +3840,7 @@ mod tests {
             &db,
             "proc helper {x y} { return $x }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let has = |diags: &[tcl_compiler::analyser::types::Diagnostic], code: &str| {
             diags
@@ -3797,7 +3849,7 @@ mod tests {
         };
 
         // 3 args to a 2-param proc → E003 (too many), and the W123 is suppressed.
-        let a3 = SourceFile::new(&db, "helper a b c\n".to_owned(), "tcl8.6".to_owned());
+        let a3 = SourceFile::new(&db, "helper a b c\n".to_owned(), "tcl8.6".to_owned(), None);
         let p3 = Project::new(&db, vec![a3, b]);
         let d3 = project_diagnostics(&db, a3, cfg, p3);
         assert!(
@@ -3814,7 +3866,7 @@ mod tests {
         );
 
         // Correct arity (2 args) → no arity error and no W123.
-        let a2 = SourceFile::new(&db, "helper a b\n".to_owned(), "tcl8.6".to_owned());
+        let a2 = SourceFile::new(&db, "helper a b\n".to_owned(), "tcl8.6".to_owned(), None);
         let p2 = Project::new(&db, vec![a2, b]);
         let d2 = project_diagnostics(&db, a2, cfg, p2);
         assert!(
@@ -3839,6 +3891,7 @@ mod tests {
              namespace eval ns { proc Widget {x} {} }\n"
                 .to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         // The arity table must record `Widget` as resolvable but arity-less
         // (mixed), so it can never draw an arity error.
@@ -3852,7 +3905,12 @@ mod tests {
         );
         // A calls `Widget new extra` (3 args) — fits no proc arity, but resolves to
         // the class → neither an arity error nor W123.
-        let a = SourceFile::new(&db, "Widget new extra\n".to_owned(), "tcl8.6".to_owned());
+        let a = SourceFile::new(
+            &db,
+            "Widget new extra\n".to_owned(),
+            "tcl8.6".to_owned(),
+            None,
+        );
         let proj = Project::new(&db, vec![a, b]);
         let d = project_diagnostics(&db, a, cfg, proj);
         assert!(
@@ -3883,9 +3941,10 @@ mod tests {
             &db,
             "proc onNode {a b} { }\n".to_owned(),
             "tcl9.0".to_owned(),
+            None,
         );
         let has_e003 = |src: &str| {
-            let a = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned());
+            let a = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned(), None);
             let p = Project::new(&db, vec![a, b]);
             project_diagnostics(&db, a, cfg, p)
                 .iter()
@@ -3906,11 +3965,13 @@ mod tests {
             &db,
             "proc onNode {a b c} { }\n".to_owned(),
             "tcl9.0".to_owned(),
+            None,
         );
         let a_ok = SourceFile::new(
             &db,
             "proc build {} {\n struct::graph g\n g walk root -command onNode\n}\n".to_owned(),
             "tcl9.0".to_owned(),
+            None,
         );
         let p_ok = Project::new(&db, vec![a_ok, b3]);
         assert!(
@@ -3935,8 +3996,9 @@ mod tests {
             &db,
             "proc helper {x y} { return $x }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
-        let a = SourceFile::new(&db, "helper a b c\n".to_owned(), "tcl8.6".to_owned());
+        let a = SourceFile::new(&db, "helper a b c\n".to_owned(), "tcl8.6".to_owned(), None);
         let proj = Project::new(&db, vec![a, b]);
         let has = |diags: &[tcl_compiler::analyser::types::Diagnostic], code: &str| {
             diags
@@ -3983,6 +4045,7 @@ mod tests {
             &db,
             "proc helper {x y} { return $x }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let has = |diags: &[tcl_compiler::analyser::types::Diagnostic], code: &str| {
             diags.iter().any(|d| d.code.as_str() == code)
@@ -3997,7 +4060,7 @@ mod tests {
         );
 
         // Wrong arity (3 args to a 2-param proc) → E003 still fires; no W123.
-        let bad = SourceFile::new(&db, "helper a b c\n".to_owned(), "tcl8.6".to_owned());
+        let bad = SourceFile::new(&db, "helper a b c\n".to_owned(), "tcl8.6".to_owned(), None);
         let pb = Project::new(&db, vec![bad, b]);
         let d_bad = project_diagnostics(&db, bad, cfg, pb);
         assert!(
@@ -4011,7 +4074,7 @@ mod tests {
         );
 
         // Correct arity → no arity error and no W123 (resolved, W123 disabled).
-        let ok = SourceFile::new(&db, "helper a b\n".to_owned(), "tcl8.6".to_owned());
+        let ok = SourceFile::new(&db, "helper a b\n".to_owned(), "tcl8.6".to_owned(), None);
         let pok = Project::new(&db, vec![ok, b]);
         let d_ok = project_diagnostics(&db, ok, cfg, pok);
         assert!(
@@ -4031,7 +4094,7 @@ mod tests {
         let db = TclDatabase::default();
         let src = "mylibsend foo\n";
         let has_w123 = |cfg: AnalyserConfig| {
-            let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned());
+            let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
             file_analysis_incremental(&db, file, cfg)
                 .diagnostics
                 .iter()
@@ -4063,9 +4126,10 @@ mod tests {
             &db,
             "oo::class create Widget { method draw {} {} }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         // A invokes the `Widget` class command (defined cross-file).
-        let a = SourceFile::new(&db, "Widget new\n".to_owned(), "tcl8.6".to_owned());
+        let a = SourceFile::new(&db, "Widget new\n".to_owned(), "tcl8.6".to_owned(), None);
         let proj = Project::new(&db, vec![a, b]);
         let d = project_diagnostics(&db, a, cfg, proj);
         assert!(
@@ -4094,11 +4158,12 @@ mod tests {
             "proc two {a b} {}\nproc opt {a {b 1}} {}\nproc variadic {a args} {}\nproc none {} {}\n"
                 .to_owned(),
             "tcl8.6".to_owned(),
+         None,
         );
         // The cross-file arity code drawn by calling `src` (file A over {A, B}):
         // Some("E002") too few, Some("E003") too many, None if it fits.
         let arity_code = |src: &str| -> Option<String> {
-            let a = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned());
+            let a = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
             let proj = Project::new(&db, vec![a, b]);
             project_diagnostics(&db, a, cfg, proj)
                 .iter()
@@ -4162,9 +4227,10 @@ mod tests {
             &db,
             "proc opt {a {b 5} c} {}\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let arity_code = |src: &str| -> Option<String> {
-            let a = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned());
+            let a = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
             let proj = Project::new(&db, vec![a, b]);
             project_diagnostics(&db, a, cfg, proj)
                 .iter()
@@ -4197,12 +4263,18 @@ mod tests {
     fn cross_file_arity_skips_expanded_call() {
         let db = TclDatabase::default();
         let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
-        let b = SourceFile::new(&db, "proc two {a b} {}\n".to_owned(), "tcl8.6".to_owned());
+        let b = SourceFile::new(
+            &db,
+            "proc two {a b} {}\n".to_owned(),
+            "tcl8.6".to_owned(),
+            None,
+        );
         // `two {*}$lst` — one literal word, `{*}`-expanded → runtime arity unknown.
         let a = SourceFile::new(
             &db,
             "set lst {1 2 3}\ntwo {*}$lst\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let proj = Project::new(&db, vec![a, b]);
         let d = project_diagnostics(&db, a, cfg, proj);
@@ -4230,12 +4302,14 @@ mod tests {
             &db,
             "proc helper {x y} { return $x }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         // `helper` called with 3 args inside a `[…]` substitution → too many.
         let a = SourceFile::new(
             &db,
             "set x [helper a b c]\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let proj = Project::new(&db, vec![a, b]);
         let d = project_diagnostics(&db, a, cfg, proj);
@@ -4256,7 +4330,7 @@ mod tests {
     fn callback_arity_codes(src: &str) -> Vec<(String, String)> {
         let db = TclDatabase::default();
         let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
-        let f = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned());
+        let f = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned(), None);
         let proj = Project::new(&db, vec![f]);
         project_diagnostics(&db, f, cfg, proj)
             .iter()
@@ -4567,7 +4641,7 @@ mod tests {
                    namespace eval ::b { proc x {p} { set q $p; return $q } }\n\
                    proc top {} { set z 1 }\n";
         let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
-        let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned());
+        let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
         let _ = file_analysis_incremental(&db, file, cfg);
         log.lock().unwrap().clear();
         // Pure whole-file shift: prepend a blank line (every proc shifts, none
@@ -4609,6 +4683,7 @@ mod tests {
             &db,
             "proc a {} { set x 11111 }\nproc b {} { set y 22222 }\n".to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let _ = file_analysis_incremental(&db, file, cfg);
         let init = std::mem::take(&mut *log.lock().unwrap());
@@ -4668,6 +4743,7 @@ mod tests {
              proc d {} { set w 44444 }\n"
                 .to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let _ = file_analysis_incremental(&db, file, cfg);
         let _ = compiler_check_diagnostics(&db, file, cfg);
@@ -4746,6 +4822,7 @@ mod tests {
              proc caller {} { target 42 }\n"
                 .to_owned(),
             "tcl8.6".to_owned(),
+            None,
         );
         let _ = file_analysis_incremental(&db, file, cfg);
         assert_eq!(
@@ -4815,7 +4892,7 @@ mod tests {
         };
 
         // tcl8.6: default == for_dialect, so the two consumers share one build.
-        let file86 = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned());
+        let file86 = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
         let _ = file_analysis_incremental(&db, file86, cfg);
         let _ = compiler_check_diagnostics(&db, file86, cfg);
         assert_eq!(
@@ -4826,7 +4903,7 @@ mod tests {
 
         // tcl8.4: for_dialect disables `{*}` expansion, so the configs differ
         // and each consumer builds its own unit (two executions).
-        let file84 = SourceFile::new(&db, src.to_owned(), "tcl8.4".to_owned());
+        let file84 = SourceFile::new(&db, src.to_owned(), "tcl8.4".to_owned(), None);
         let _ = file_analysis_incremental(&db, file84, cfg);
         let _ = compiler_check_diagnostics(&db, file84, cfg);
         assert_eq!(

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1350,7 +1350,7 @@ pub fn function_checks<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<V
         &fu,
         &registry,
         dialect_opt,
-        None,
+        None::<&std::collections::HashSet<String>>,
     ))
 }
 
@@ -1491,7 +1491,7 @@ pub fn proc_taint_solve<'db>(
                     fu,
                     &registry,
                     dialect_opt,
-                    None,
+                    None::<&std::collections::HashSet<String>>,
                 ) {
                     fn_checks.push(d);
                 }

--- a/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
+++ b/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
@@ -95,7 +95,7 @@ fn compiler_check_memo_matches_uncached_graphops() {
         return;
     };
     let db = TclDatabase::default();
-    let file = SourceFile::new(&db, src.clone(), dialect.to_owned());
+    let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
     let got = compiler_check_diagnostics(&db, file, default_config(&db));
     let registry = db.registry(dialect);
     let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None);
@@ -125,7 +125,7 @@ fn compiler_check_memo_matches_uncached_init() {
         return;
     };
     let db = TclDatabase::default();
-    let file = SourceFile::new(&db, src.clone(), dialect.to_owned());
+    let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
     let got = compiler_check_diagnostics(&db, file, default_config(&db));
     let registry = db.registry(dialect);
     let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None);
@@ -167,7 +167,7 @@ fn compiler_check_memo_matches_uncached_over_corpus() {
         if src.is_empty() || src.len() > 400_000 {
             continue;
         }
-        let file = SourceFile::new(&db, src.clone(), dialect.to_owned());
+        let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
         let got = compiler_check_diagnostics(&db, file, default_config(&db));
         let registry = db.registry(dialect);
         let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None);
@@ -260,7 +260,7 @@ fn compiler_check_memo_matches_uncached_under_corpus_edits() {
         }
         let mut db = TclDatabase::default();
         let registry = db.registry(dialect);
-        let file = SourceFile::new(&db, base.clone(), dialect.to_owned());
+        let file = SourceFile::new(&db, base.clone(), dialect.to_owned(), None);
 
         for _ in 0..8 {
             let blanks = (next() as usize) % 4; // offset shift above the real procs

--- a/rust/tcl-lsp-db/tests/file_analysis_corpus.rs
+++ b/rust/tcl-lsp-db/tests/file_analysis_corpus.rs
@@ -87,7 +87,7 @@ fn alias_declared_outside_body_matches_full() {
         Vec::new(),
         None,
     );
-    let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned());
+    let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
     let inc = file_analysis_incremental(&db, file, cfg);
     let full = file_analysis(&db, file, cfg);
     assert_eq!(
@@ -116,7 +116,7 @@ fn rename_declared_outside_body_matches_full() {
         Vec::new(),
         None,
     );
-    let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned());
+    let file = SourceFile::new(&db, src.to_owned(), "tcl8.6".to_owned(), None);
     let inc = file_analysis_incremental(&db, file, cfg);
     let full = file_analysis(&db, file, cfg);
     assert_eq!(
@@ -169,7 +169,7 @@ fn file_analysis_incremental_matches_full_over_corpus() {
                     Vec::new(),
                     None,
                 );
-                let file = SourceFile::new(&db, src.clone(), dialect.to_owned());
+                let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
                 let inc = file_analysis_incremental(&db, file, cfg);
                 let full = file_analysis(&db, file, cfg);
                 (inc.diagnostics != full.diagnostics).then(|| {

--- a/rust/tcl-lsp-db/tests/project_diagnostics_corpus.rs
+++ b/rust/tcl-lsp-db/tests/project_diagnostics_corpus.rs
@@ -144,11 +144,11 @@ fn project_diagnostics_incremental_matches_fresh_over_corpus() {
             let db = TclDatabase::default();
             let cfg = AnalyserConfig::new(&db, Vec::new(), NonAsciiMode::Default, Vec::new(), None);
             let mut files = vec![
-                SourceFile::new(&db, lib.to_owned(), dialect.to_owned()),
-                SourceFile::new(&db, caller.to_owned(), dialect.to_owned()),
+                SourceFile::new(&db, lib.to_owned(), dialect.to_owned(), None),
+                SourceFile::new(&db, caller.to_owned(), dialect.to_owned(), None),
             ];
             for (src, dia) in &real {
-                files.push(SourceFile::new(&db, src.clone(), dia.clone()));
+                files.push(SourceFile::new(&db, src.clone(), dia.clone(), None));
             }
             let project = Project::new(&db, files.clone());
             (db, cfg, files, project)

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2323,7 +2323,8 @@ impl Backend {
             file.set_text(&mut *db).to(text);
             file.set_dialect(&mut *db).to(dialect);
         } else {
-            let file = tcl_lsp_db::SourceFile::new(&*db, text, dialect);
+            let path = uri.to_file_path().map(|p| p.display().to_string());
+            let file = tcl_lsp_db::SourceFile::new(&*db, text, dialect, path);
             files.insert(uri.clone(), file);
             // Membership changed — re-set the `Project` file set.
             let mut project = self.db_project.lock().await;
@@ -2361,7 +2362,8 @@ impl Backend {
                 file.set_text(&mut *db).to(text.clone());
                 file.set_dialect(&mut *db).to(dialect.clone());
             } else {
-                let file = tcl_lsp_db::SourceFile::new(&*db, text.clone(), dialect.clone());
+                let path = uri.to_file_path().map(|p| p.display().to_string());
+                let file = tcl_lsp_db::SourceFile::new(&*db, text.clone(), dialect.clone(), path);
                 files.insert(uri.clone(), file);
                 membership_changed = true;
             }

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -59,6 +59,8 @@ mod irules;
 mod navigation;
 #[path = "e2e/navigation_extras.rs"]
 mod navigation_extras;
+#[path = "e2e/precision_review.rs"]
+mod precision_review;
 #[path = "e2e/recovery.rs"]
 mod recovery;
 #[path = "e2e/references.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/precision_review.rs
+++ b/rust/tcl-lsp-server/tests/e2e/precision_review.rs
@@ -1,0 +1,378 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! End-to-end coverage for the diagnostics precision review: tight ranges,
+//! did-you-mean suggestions and their quick fixes, and the false-positive
+//! classes the review eliminated.  Each area carries its TP (fires), FP
+//! guard (must not fire), and — where a fix exists — the fix payload.
+
+use crate::common::{Lsp, unique_uri};
+
+use serde_json::Value;
+
+fn code_str(d: &Value) -> String {
+    match d.get("code") {
+        Some(Value::String(s)) => s.clone(),
+        Some(other) => other.to_string(),
+        None => "None".to_owned(),
+    }
+}
+
+fn codes(diags: &[Value]) -> Vec<String> {
+    diags.iter().map(code_str).collect()
+}
+
+fn find<'a>(diags: &'a [Value], code: &str) -> Option<&'a Value> {
+    diags.iter().find(|d| code_str(d) == code)
+}
+
+fn range_of(d: &Value) -> (i64, i64, i64, i64) {
+    let r = &d["range"];
+    (
+        r["start"]["line"].as_i64().unwrap(),
+        r["start"]["character"].as_i64().unwrap(),
+        r["end"]["line"].as_i64().unwrap(),
+        r["end"]["character"].as_i64().unwrap(),
+    )
+}
+
+fn message_of(d: &Value) -> String {
+    d["message"].as_str().unwrap_or_default().to_owned()
+}
+
+// -- W123 / rename resolution ---------------------------------------------
+
+/// FP guard: `rename OLD NEW` binds NEW — calling the renamed name is not an
+/// unknown command.  TP control: the vacated OLD name still draws W128.
+#[test]
+fn rename_target_is_known_and_old_name_flags_w128() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc user_args {args} { puts [llength $args] }\nrename user_args ua2\nua2 1 2\nuser_args 9\n",
+    );
+    assert!(
+        !codes(&diags).iter().any(|c| c == "W123"),
+        "the rename target must be a known command: {diags:?}"
+    );
+    assert!(
+        codes(&diags).iter().any(|c| c == "W128"),
+        "the vacated source name still draws W128: {diags:?}"
+    );
+}
+
+/// Suggestion-budget guard: a 3-character unknown command must not fish an
+/// unrelated command out of the registry (the old fixed budget suggested
+/// 'cat' for 'ua2').
+#[test]
+fn short_unknown_command_gets_no_far_suggestion() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "zq9 1 2\n");
+    let d = find(&diags, "W123").expect("W123 fires for a genuinely unknown command");
+    assert!(
+        !message_of(d).contains("did you mean"),
+        "no candidate is within one edit of 'zq9': {}",
+        message_of(d)
+    );
+}
+
+// -- W210 nested-read narrowing + cross-event suppression ------------------
+
+/// The read-before-set squiggle sits on the `$foo` read nested inside the
+/// command substitution, not on the whole `set` command.
+#[test]
+fn w210_range_is_tight_on_nested_read() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set x [lindex $foo 0]\nputs $x\n");
+    let d = find(&diags, "W210").expect("W210 fires for the unset $foo");
+    // `$foo` occupies characters 14..18 of line 0.
+    assert_eq!(range_of(d), (0, 14, 0, 18), "range must cover exactly $foo");
+}
+
+/// iRules cross-event flow: a variable set in `HTTP_REQUEST` is defined by the
+/// time `HTTP_RESPONSE` reads it — no read-before-set.  TP control: a name no
+/// event defines still fires.
+#[test]
+fn w210_silent_on_cross_event_read_but_fires_on_undefined() {
+    let mut lsp = Lsp::irules();
+    let uri = unique_uri("irule");
+    let diags = lsp.open_ready_lang(
+        &uri,
+        "when HTTP_REQUEST {\n    set g 1\n}\nwhen HTTP_RESPONSE {\n    set x $g\n    puts $x\n}\n",
+        "tcl-irule",
+    );
+    assert!(
+        !codes(&diags).iter().any(|c| c == "W210"),
+        "cross-event defined variable is not read-before-set: {diags:?}"
+    );
+
+    let uri2 = unique_uri("irule");
+    let diags2 = lsp.open_ready_lang(
+        &uri2,
+        "when HTTP_RESPONSE {\n    set x $neverdefined\n    puts $x\n}\n",
+        "tcl-irule",
+    );
+    assert!(
+        codes(&diags2).iter().any(|c| c == "W210"),
+        "a name no event defines still fires W210: {diags2:?}"
+    );
+}
+
+// -- W308 method word + suggestion + fix -----------------------------------
+
+const OO_SRC: &str = "oo::class create Animal {\n    method speak {} { return woof }\n}\nset a [Animal new]\n$a spek\n";
+
+/// The unknown-method squiggle sits on the method word, the message carries
+/// the MRO-derived suggestion, and the attached fix replaces exactly that
+/// word.
+#[test]
+fn w308_anchors_method_word_with_mro_suggestion() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, OO_SRC);
+    let d = find(&diags, "W308").expect("W308 fires for the typo'd method");
+    // `spek` occupies characters 3..7 of line 4.
+    assert_eq!(range_of(d), (4, 3, 4, 7), "range must cover exactly `spek`");
+    assert!(
+        message_of(d).contains("did you mean 'speak'"),
+        "suggestion comes from the class's methods: {}",
+        message_of(d)
+    );
+}
+
+/// FP guard for the suggestion: a method name nowhere near any declared
+/// method gets no suggestion (and the diagnostic still fires).
+#[test]
+fn w308_no_far_suggestion() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "oo::class create Animal {\n    method speak {} { return woof }\n}\nset a [Animal new]\n$a zz9\n",
+    );
+    let d = find(&diags, "W308").expect("W308 fires");
+    assert!(
+        !message_of(d).contains("did you mean"),
+        "no method is within one edit of 'zz9': {}",
+        message_of(d)
+    );
+}
+
+// -- E003 surplus-argument anchoring + removal fix --------------------------
+
+/// The too-many-arguments squiggle covers only the surplus run — for a
+/// same-file proc resolved at flush time as much as for a registry command.
+#[test]
+fn e003_range_covers_surplus_run_for_proc_and_builtin() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "proc greet {name} { puts $name }\ngreet a b\n");
+    let d = find(&diags, "E003").expect("E003 fires for the surplus argument");
+    // Line 1 is `greet a b`; the surplus `b` is character 8..9.
+    assert_eq!(range_of(d), (1, 8, 1, 9), "range must cover exactly `b`");
+
+    let uri2 = unique_uri("tcl");
+    let diags2 = lsp.open_ready(&uri2, "string length abc def ghi\n");
+    let d2 = find(&diags2, "E003").expect("E003 fires for the builtin");
+    // Surplus run `def ghi` is characters 18..25.
+    assert_eq!(range_of(d2), (0, 18, 0, 25));
+}
+
+// -- W124 literal anchoring --------------------------------------------------
+
+/// The invalid-IP squiggle covers the literal itself, not the whole `set`.
+#[test]
+fn w124_range_is_tight_on_the_literal() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set ip 10.0.0.999\nputs $ip\n");
+    let d = find(&diags, "W124").expect("W124 fires for the over-255 octet");
+    // `10.0.0.999` occupies characters 7..17 of line 0.
+    assert_eq!(range_of(d), (0, 7, 0, 17));
+}
+
+// -- after: registry default-form first word ---------------------------------
+
+/// `after <ms>` selects the default form for every Tcl integer spelling —
+/// including the radix forms the old decimal-only check rejected — while a
+/// non-integer word still draws the unknown-subcommand warning.
+#[test]
+fn after_integer_first_word_is_not_a_subcommand() {
+    let mut lsp = Lsp::tcl();
+    for src in ["after 200 {puts hi}\n", "after 0x10 {puts hi}\n"] {
+        let uri = unique_uri("tcl");
+        let diags = lsp.open_ready(&uri, src);
+        assert!(
+            !codes(&diags).iter().any(|c| c == "W001"),
+            "{src:?} is the default delayed form: {diags:?}"
+        );
+    }
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "after soon {puts hi}\n");
+    assert!(
+        codes(&diags).iter().any(|c| c == "W001"),
+        "a non-integer, non-subcommand word still fires W001: {diags:?}"
+    );
+}
+
+// -- W120 guarded package require --------------------------------------------
+
+/// The guarded-optional-dependency idiom satisfies W120; an unguarded use
+/// still fires.
+#[test]
+fn w120_silent_on_guarded_require_fires_without() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "if {[catch {package require Tk} err]} {\n    exit 0\n}\ncanvas .c -width 10\n",
+    );
+    assert!(
+        !codes(&diags).iter().any(|c| c == "W120"),
+        "the require inside the catch guard counts: {diags:?}"
+    );
+
+    let uri2 = unique_uri("tcl");
+    let diags2 = lsp.open_ready(&uri2, "canvas .c -width 10\n");
+    assert!(
+        codes(&diags2).iter().any(|c| c == "W120"),
+        "without any require, W120 fires: {diags2:?}"
+    );
+}
+
+// -- TK1003 pair-aware option scan -------------------------------------------
+
+/// The unknown-option hint anchors on the offending word with a suggestion;
+/// option *values* starting with `-` and legal unique-prefix abbreviations
+/// stay silent.
+#[test]
+fn tk1003_tight_anchor_suggestion_and_fp_guards() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "package require Tk\nbutton .b -comand {puts hi}\nlabel .l -padx -2 -text ok\nentry .e -wid 20\n",
+    );
+    let tk: Vec<&Value> = diags.iter().filter(|d| code_str(d) == "TK1003").collect();
+    assert_eq!(
+        tk.len(),
+        1,
+        "only the real typo fires — not the -2 value, not the -wid abbreviation: {diags:?}"
+    );
+    // `-comand` occupies characters 10..17 of line 1.
+    assert_eq!(range_of(tk[0]), (1, 10, 1, 17));
+    assert!(
+        message_of(tk[0]).contains("Did you mean '-command'"),
+        "suggestion from the declared option set: {}",
+        message_of(tk[0])
+    );
+}
+
+// -- IRULE3102 single ownership ----------------------------------------------
+
+/// Exactly one IRULE3102 per getter site, anchored on the getter word.
+#[test]
+fn irule3102_fires_once_with_tight_anchor() {
+    let mut lsp = Lsp::irules();
+    let uri = unique_uri("irule");
+    let diags = lsp.open_ready_lang(
+        &uri,
+        "when HTTP_REQUEST {\n    set u [HTTP::uri]\n    puts $u\n}\n",
+        "tcl-irule",
+    );
+    let hits: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d) == "IRULE3102")
+        .collect();
+    assert_eq!(hits.len(), 1, "one emitter owns the code: {diags:?}");
+    // `HTTP::uri` inside the brackets occupies characters 11..20 of line 1.
+    assert_eq!(range_of(hits[0]), (1, 11, 1, 20));
+}
+
+// -- W127 did-you-mean fix -----------------------------------------------------
+
+/// The invalid-enum-value warning names the closest allowed value.
+#[test]
+fn w127_suggests_closest_allowed_value() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "string is alnun \"abc\"\n");
+    let d = find(&diags, "W127").expect("W127 fires for the misspelt class");
+    assert!(
+        message_of(d).contains("did you mean 'alnum'"),
+        "suggestion from the allowed set: {}",
+        message_of(d)
+    );
+}
+
+// -- tclpkg manifest environment ----------------------------------------------
+
+/// A `tclpkg.tcl` manifest resolves its directives against the registry's
+/// whole-file environment: no unknown-command / package noise, while a
+/// typo'd directive still fires (closed environment).
+#[test]
+fn tclpkg_manifest_directives_resolve() {
+    let mut lsp = Lsp::tcl();
+    let uri = format!("file:///e2e/{}_manifest/tclpkg.tcl", std::process::id());
+    let diags = lsp.open_ready(
+        &uri,
+        "package demo-app\nversion 0.1.0\nrequire json 1.0.0\nprovides demo::serve\nentry main.tcl\n",
+    );
+    assert!(
+        diags.is_empty(),
+        "a valid manifest produces no diagnostics: {diags:?}"
+    );
+
+    let uri2 = format!("file:///e2e/{}_manifest2/tclpkg.tcl", std::process::id());
+    let diags2 = lsp.open_ready(&uri2, "package demo-app\nverison 0.1.0\n");
+    assert!(
+        codes(&diags2).iter().any(|c| c == "W123"),
+        "a typo'd directive stays unknown in the closed environment: {diags2:?}"
+    );
+}
+
+// -- S102 intra-iteration thunking ---------------------------------------------
+
+/// The textbook oscillation fires even though the loop-header type is
+/// consistent; the hardened single-representation loop stays silent.
+#[test]
+fn s102_intra_iteration_oscillation_matrix() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc j {items} {\n    set acc \"\"\n    foreach x $items {\n        lappend acc $x\n        set acc \"$acc,\"\n    }\n    return $acc\n}\n",
+    );
+    assert!(
+        codes(&diags).iter().any(|c| c == "S102"),
+        "intra-iteration oscillation thunks: {diags:?}"
+    );
+
+    let uri2 = unique_uri("tcl");
+    let diags2 = lsp.open_ready(
+        &uri2,
+        "proc j {items} {\n    set parts [list]\n    foreach x $items {\n        lappend parts $x\n    }\n    return [join $parts ,]\n}\n",
+    );
+    assert!(
+        !codes(&diags2).iter().any(|c| c == "S102"),
+        "a single-representation accumulator does not thunk: {diags2:?}"
+    );
+}

--- a/rust/tcl-pkg/Cargo.toml
+++ b/rust/tcl-pkg/Cargo.toml
@@ -44,3 +44,6 @@ chrono = { version = "0.4", default-features = false, features = ["clock"] }
 
 [lints]
 workspace = true
+
+[dev-dependencies]
+tcl-registry = { path = "../tcl-registry" }

--- a/rust/tcl-pkg/src/manifest.rs
+++ b/rust/tcl-pkg/src/manifest.rs
@@ -45,6 +45,13 @@ static TCL_CONSTRAINT_RE: LazyLock<Regex> = LazyLock::new(|| {
         .expect("constraint regex compiles")
 });
 
+/// The manifest directive names, for cross-crate drift tests (the registry's
+/// `TCLPKG_MANIFEST_ENV` scoped environment must describe exactly this set).
+#[must_use]
+pub fn directive_names() -> &'static [&'static str] {
+    DIRECTIVES
+}
+
 const DIRECTIVES: &[&str] = &[
     "package",
     "version",

--- a/rust/tcl-pkg/tests/manifest_env_drift.rs
+++ b/rust/tcl-pkg/tests/manifest_env_drift.rs
@@ -1,0 +1,53 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Drift gate: the registry's `tclpkg.tcl` whole-file scoped environment
+//! (`TCLPKG_MANIFEST_ENV`) must describe exactly the directive set this
+//! crate's manifest evaluator accepts — the two live in different crates
+//! (command surface is registry data; evaluation is `tcl-pkg`), so a
+//! directive added to one without the other fails here, not in an editor.
+
+use std::collections::BTreeSet;
+
+#[test]
+fn registry_manifest_env_matches_evaluator_directives() {
+    let evaluator: BTreeSet<&str> = tcl_pkg::manifest::directive_names()
+        .iter()
+        .copied()
+        .collect();
+    let registry: BTreeSet<&str> = tcl_registry::scoped::TCLPKG_MANIFEST_ENV
+        .commands
+        .iter()
+        .map(|c| c.name)
+        .collect();
+    assert_eq!(
+        registry, evaluator,
+        "tcl-registry TCLPKG_MANIFEST_ENV and tcl-pkg manifest DIRECTIVES have drifted"
+    );
+}
+
+/// The registry file-scope hook resolves the manifest by basename, from any
+/// directory, and never for other names.
+#[test]
+fn file_scope_env_keys_on_the_manifest_basename() {
+    assert!(tcl_registry::scoped::file_scope_env("/proj/tclpkg.tcl").is_some());
+    assert!(tcl_registry::scoped::file_scope_env("tclpkg.tcl").is_some());
+    assert!(tcl_registry::scoped::file_scope_env(r"C:\proj\tclpkg.tcl").is_some());
+    assert!(tcl_registry::scoped::file_scope_env("/proj/other.tcl").is_none());
+    assert!(tcl_registry::scoped::file_scope_env("/proj/pkgIndex.tcl").is_none());
+}

--- a/rust/tcl-registry/src/commands/tcl/after_.rs
+++ b/rust/tcl-registry/src/commands/tcl/after_.rs
@@ -106,6 +106,9 @@ pub fn spec() -> CommandSpec {
         arity: Arity::at_least(1),
         arg_role_resolver: Some(after_arg_roles),
         subcommands: SUBCOMMANDS,
+        // `after 200 …` — an integer first word selects the default
+        // delayed-execution form rather than dispatching on a subcommand.
+        default_form_first_word: Some(DefaultFormFirstWord::Integer),
         return_type: Some(TclType::String),
         side_effects: &[SideEffect {
             target: SideEffectTarget::InterpState,

--- a/rust/tcl-registry/src/commands/tcl/interp.rs
+++ b/rust/tcl-registry/src/commands/tcl/interp.rs
@@ -173,6 +173,9 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "interp eval path arg ?arg ...?",
         return_type: Some(TclType::String),
         arg_roles: &[(1, ArgRole::Body)],
+        // Runs an arbitrary script — dynamic-dispatch consumers (memory-SSA
+        // clobber classification, side-effect analysis) key off this.
+        traits: Traits::EVALUATES_CODE,
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -172,6 +172,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // proc param read only inside the body looks used).  The body's
         // `$var` reads are excluded from caller-local read recovery.
         body_kind: BodyKind::Structural,
+        // Runs an arbitrary script that can touch namespace/global state —
+        // dynamic-dispatch consumers (memory-SSA clobber classification)
+        // key off this.
+        traits: Traits::EVALUATES_CODE,
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -216,6 +220,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         return_type: Some(TclType::String),
         // Like `eval`, the script runs in the namespace frame.
         body_kind: BodyKind::Structural,
+        traits: Traits::EVALUATES_CODE,
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/dialects.rs
+++ b/rust/tcl-registry/src/dialects.rs
@@ -654,20 +654,46 @@ const CONTENT_SIGNATURES: &[(&str, &[&str])] = &[
 ];
 
 /// Whether `marker` appears in `haystack` at a word boundary on its **left**
-/// (start-of-string or a non-word byte before it). Unlike [`has_word`] this
-/// puts no constraint on the byte after the marker, so command-prefix markers
-/// like `tmsh::` / `quartus_` (followed by more identifier) still match.
+/// (start-of-string or a non-word byte before it). A marker whose final
+/// character is itself a word byte (`interact`, `spawn`, `vsim`) also
+/// requires a word boundary on its **right** — `interactive` must not match
+/// `interact`. A marker ending in a non-word byte (`tmsh::`, `iapp::`) is a
+/// command-*prefix* form: the identifier that follows is expected, so no
+/// right constraint applies. The one prefix marker ending in a word byte,
+/// `quartus_` (`_` is a word byte), keeps prefix semantics by ending in `_`
+/// — treat a trailing `_` as an explicit "identifier continues" marker.
 fn contains_token(haystack: &str, marker: &str) -> bool {
     let hbytes = haystack.as_bytes();
+    let whole_word = marker
+        .as_bytes()
+        .last()
+        .is_some_and(|&b| is_word_byte(b) && b != b'_');
     let mut i = 0;
     while let Some(off) = haystack[i..].find(marker) {
         let start = i + off;
-        if start == 0 || !is_word_byte(hbytes[start - 1]) {
+        let left_ok = start == 0 || !is_word_byte(hbytes[start - 1]);
+        let end = start + marker.len();
+        let right_ok = !whole_word || end >= hbytes.len() || !is_word_byte(hbytes[end]);
+        if left_ok && right_ok {
             return true;
         }
         i = start + 1;
     }
     false
+}
+
+/// `source` with full-line comments removed (lines whose first non-blank
+/// byte is `#`), so a dialect marker mentioned in prose — a header like
+/// `# Source: user-reported interactive session` — can never flip the
+/// detected dialect. Mid-line `;# …` tails are left in place: they are rare
+/// in practice and a structural strip would need a full lex, which
+/// [`scan_tokens_for_tcl_version`] already provides for the version guard.
+fn strip_comment_lines(source: &str) -> String {
+    source
+        .lines()
+        .filter(|line| !line.trim_start().starts_with('#'))
+        .collect::<Vec<_>>()
+        .join("\n")
 }
 
 /// Detect a dialect from a script's *content* signatures (iRules `when`,
@@ -676,8 +702,9 @@ fn detect_from_content(head: &str) -> Option<&'static str> {
     if has_irules_when(head) {
         return Some("f5-irules");
     }
+    let code = strip_comment_lines(head);
     for (dialect, markers) in CONTENT_SIGNATURES {
-        if markers.iter().any(|m| contains_token(head, m)) {
+        if markers.iter().any(|m| contains_token(&code, m)) {
             return Some(dialect);
         }
     }

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -112,7 +112,8 @@ pub mod prelude {
     pub use crate::scoped::{ScopedCommand, ScopedCommandEnv};
     pub use crate::side_effects::{ConnectionSide, SideEffect, SideEffectTarget, StorageType};
     pub use crate::spec::{
-        BytePayloadSpec, CaseListSpec, CommandSpec, ObjectClassSpec, SubCommand, SubSubCommand,
+        BytePayloadSpec, CaseListSpec, CommandSpec, DefaultFormFirstWord, ObjectClassSpec,
+        SubCommand, SubSubCommand,
     };
     pub use crate::symbol_def::{DefinedSymbolKind, SymbolDef};
     pub use crate::taint::{SetterConstraint, TaintColour};
@@ -136,7 +137,8 @@ pub use hover::ArgValue;
 pub use patterns::{FormatType, PatternType};
 pub use registry::{CommandRegistry, ResolvedCall, ResolvedTerminator};
 pub use spec::{
-    BytePayloadSpec, CaseListSpec, CommandSpec, ObjectClassSpec, SubCommand, SubSubCommand,
+    BytePayloadSpec, CaseListSpec, CommandSpec, DefaultFormFirstWord, ObjectClassSpec, SubCommand,
+    SubSubCommand,
 };
 pub use special_vars::{
     SPECIAL_VARS, SpecialVarKey, SpecialVarKind, SpecialVarSpec, VarAccess, VarOrigin,

--- a/rust/tcl-registry/src/scoped.rs
+++ b/rust/tcl-registry/src/scoped.rs
@@ -340,3 +340,165 @@ pub const REPORT_DEFSTYLE_ENV: ScopedCommandEnv = ScopedCommandEnv {
     include_sibling_definitions: true,
     allow_unknown_commands: false,
 };
+
+// ---------------------------------------------------------------------------
+// tclpkg — the `tclpkg.tcl` package-manifest directive environment.
+//
+// A manifest is a Tcl script evaluated in a deprivileged interpreter that
+// defines exactly these directive commands (see
+// `rust/tcl-pkg/src/manifest.rs`, `DIRECTIVES` + `apply_directive`, which is
+// the runtime source of truth for names and arities — a drift test in
+// `tcl-pkg` asserts the two stay aligned).  Several directives shadow real
+// Tcl/Tk commands (`package`, `entry`), so the environment must *replace*
+// normal resolution for its names inside a manifest file rather than merge
+// with it — exactly what a scoped environment does.
+// ---------------------------------------------------------------------------
+
+/// Build a hover snippet for a tclpkg manifest directive.
+const fn manifest_hover(summary: &'static str, synopsis: &'static str) -> HoverSnippet {
+    HoverSnippet {
+        summary,
+        synopsis: &[],
+        snippet: synopsis,
+        source: "tclpkg manifest (tcl pkg)",
+        examples: "",
+        return_value: "",
+    }
+}
+
+/// A tclpkg manifest directive (all are plain commands, no subcommands).
+const fn manifest_directive(
+    name: &'static str,
+    arity: Arity,
+    detail: &'static str,
+    synopsis: &'static str,
+) -> ScopedCommand {
+    ScopedCommand {
+        name,
+        arity,
+        subcommands: &[],
+        allow_unknown_subcommands: false,
+        detail,
+        hover: Some(manifest_hover(detail, synopsis)),
+    }
+}
+
+/// The tclpkg manifest directive set — names and arities mirror
+/// `tcl-pkg`'s `manifest.rs` (`require_arity` calls in `apply_directive`).
+const TCLPKG_MANIFEST_COMMANDS: &[ScopedCommand] = &[
+    manifest_directive(
+        "package",
+        Arity::exact(1),
+        "declare the package name",
+        "package <name>",
+    ),
+    manifest_directive(
+        "version",
+        Arity::exact(1),
+        "declare the package version",
+        "version <semver>",
+    ),
+    manifest_directive(
+        "description",
+        Arity::exact(1),
+        "one-line package description",
+        "description <text>",
+    ),
+    manifest_directive(
+        "license",
+        Arity::exact(1),
+        "SPDX licence identifier",
+        "license <spdx-id>",
+    ),
+    manifest_directive(
+        "author",
+        Arity::exact(1),
+        "package author (repeatable)",
+        "author <name-and-email>",
+    ),
+    manifest_directive(
+        "homepage",
+        Arity::exact(1),
+        "project homepage URL",
+        "homepage <url>",
+    ),
+    manifest_directive(
+        "tcl",
+        Arity::exact(1),
+        "required Tcl version constraint",
+        "tcl <constraint>  (e.g. tcl >=8.6)",
+    ),
+    manifest_directive(
+        "require",
+        Arity::new(2, 4),
+        "production dependency",
+        "require <name> <minimum> ?-source <url>?",
+    ),
+    manifest_directive(
+        "dev-require",
+        Arity::new(2, 4),
+        "development-only dependency",
+        "dev-require <name> <minimum> ?-source <url>?",
+    ),
+    manifest_directive(
+        "replace",
+        Arity::exact(3),
+        "replace a transitive dependency's source",
+        "replace <name> <version> <source-url>",
+    ),
+    manifest_directive(
+        "exclude",
+        Arity::exact(2),
+        "exclude a transitive dependency version",
+        "exclude <name> <version>",
+    ),
+    manifest_directive(
+        "provides",
+        Arity::exact(1),
+        "namespace or capability provided (repeatable)",
+        "provides <name>",
+    ),
+    manifest_directive(
+        "entry",
+        Arity::exact(1),
+        "application entry-point script",
+        "entry <script.tcl>",
+    ),
+    manifest_directive(
+        "build",
+        Arity::new(1, 2),
+        "declarative build script (never auto-run)",
+        "build <script.tcl> ?-network?",
+    ),
+];
+
+/// The whole-file environment of a `tclpkg.tcl` package manifest.
+///
+/// Closed (`allow_unknown_commands: false`): the manifest evaluator rejects
+/// non-directive commands, so a typo'd directive should still draw W123.
+pub const TCLPKG_MANIFEST_ENV: ScopedCommandEnv = ScopedCommandEnv {
+    name: "tclpkg manifest",
+    commands: TCLPKG_MANIFEST_COMMANDS,
+    include_sibling_definitions: false,
+    allow_unknown_commands: false,
+};
+
+/// File-name-keyed ambient environments: a document whose file *basename*
+/// matches is analysed with the environment ambient across the whole
+/// document — the file-level analogue of [`ScopedCommandEnv`] on a command
+/// body.  Purely registry data; consumers look the file up here rather than
+/// matching names themselves.
+pub const FILE_SCOPED_ENVS: &[(&str, &ScopedCommandEnv)] = &[("tclpkg.tcl", &TCLPKG_MANIFEST_ENV)];
+
+/// The whole-file scoped environment for a document at `file_path`, if any.
+///
+/// Matches on the path's final component (`/` or `\` separated), so both
+/// `/proj/tclpkg.tcl` and a bare `tclpkg.tcl` resolve.
+#[must_use]
+pub fn file_scope_env(file_path: &str) -> Option<&'static ScopedCommandEnv> {
+    let base = file_path.rsplit(['/', '\\']).next().unwrap_or(file_path);
+    FILE_SCOPED_ENVS
+        .iter()
+        .find(|(name, _)| *name == base)
+        .map(|(_, env)| *env)
+}

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -55,6 +55,40 @@ pub type ArgRoleResolver = fn(args: &[&str]) -> Vec<(u8, ArgRole)>;
 /// [`CommandSpec::command_prefixes`] table — either may be set.
 pub type CommandPrefixResolver = fn(args: &[&str]) -> Vec<(u8, crate::arg_role::AppendedArity)>;
 
+/// The value shape a *non-subcommand* first word may take for a command
+/// whose first word usually dispatches to a subcommand.
+///
+/// `after` is the canonical case: `after cancel|idle|info …` dispatch on a
+/// subcommand, but `after 200 …` selects the default delayed-execution form
+/// — an integer first word is not an unknown subcommand. Carrying the shape
+/// here keeps that knowledge out of the analyser: the unknown-subcommand
+/// check (W001) asks the resolved signature whether the word matches the
+/// declared default-form shape instead of naming any command.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum DefaultFormFirstWord {
+    /// An integer first word (any Tcl integer spelling — decimal, `0x…`,
+    /// `0o…`, `0b…`, optional sign, `_` separators) selects the default
+    /// form.
+    Integer,
+}
+
+impl DefaultFormFirstWord {
+    /// Whether `word` matches this default-form shape.
+    ///
+    /// [`Self::Integer`] accepts exactly what `Tcl_GetIntFromObj` accepts
+    /// syntactically, via the canonical [`tcl_syntax::number`] parser
+    /// (`TclParseNumber` port) in integer-only, whole-string mode.
+    #[must_use]
+    pub fn matches(self, word: &str) -> bool {
+        match self {
+            Self::Integer => matches!(
+                tcl_syntax::number::parse_whole(word),
+                Some(tcl_syntax::number::Number::Int(_) | tcl_syntax::number::Number::Big { .. })
+            ),
+        }
+    }
+}
+
 /// Layout of a `<proto>::payload` byte-array command for the S110
 /// byte-array-corruption check.
 ///
@@ -277,6 +311,12 @@ pub struct CommandSpec {
 
     /// Whether unknown subcommands are accepted (for dialect packs).
     pub allow_unknown_subcommands: bool,
+
+    /// For a subcommand-dispatching command whose first word may instead be
+    /// a plain value selecting the default form (`after 200 …`), the value
+    /// shape that word takes. `None` = every first word must be a known
+    /// subcommand. See [`DefaultFormFirstWord`].
+    pub default_form_first_word: Option<DefaultFormFirstWord>,
 
     /// Hover documentation.
     pub hover: Option<HoverSnippet>,
@@ -625,6 +665,7 @@ impl CommandSpec {
         arg_types: &[],
         subcommands: &[],
         allow_unknown_subcommands: false,
+        default_form_first_word: None,
         hover: None,
         forms: &[],
         command_forms: &[],

--- a/rust/tcl-syntax/src/naming.rs
+++ b/rust/tcl-syntax/src/naming.rs
@@ -301,6 +301,30 @@ pub fn normalise_qualified_name(name: &str) -> String {
     format!("::{}", parts.join("::"))
 }
 
+/// Join a namespace `prefix` and a (possibly-relative) `name` into a fully
+/// qualified, `::`-rooted name — the canonical Tcl qualification rule:
+///
+/// * An **absolute** `name` (leading `::`) ignores the prefix entirely —
+///   `qualify("::ns", "::other::C")` is `::other::C`, never re-prefixed.
+/// * A relative `name` resolves under `prefix`, which may be given rooted
+///   (`::a::b`) or unrooted (`a::b`); duplicate separators collapse.
+/// * An empty / root prefix roots the name at `::`.
+///
+/// The one shared join for the analyser / signature-scan / class-lattice
+/// qualifiers, so the absolute-name rule cannot drift between them.
+#[must_use]
+pub fn qualify(prefix: &str, name: &str) -> String {
+    if name.starts_with("::") {
+        return normalise_qualified_name(name);
+    }
+    let p = prefix.trim_start_matches("::").trim_end_matches("::");
+    if p.is_empty() {
+        normalise_qualified_name(name)
+    } else {
+        normalise_qualified_name(&format!("{p}::{name}"))
+    }
+}
+
 /// Candidate qualified names for Tcl's real bareword command/procedure
 /// resolution, in priority order: the current namespace first, then global.
 ///
@@ -402,6 +426,23 @@ pub fn is_dynamic_word(word: &str) -> bool {
 
 #[cfg(test)]
 mod tests {
+
+    #[test]
+    fn qualify_joins_relative_names_under_rooted_and_unrooted_prefixes() {
+        assert_eq!(qualify("::ns", "C"), "::ns::C");
+        assert_eq!(qualify("ns", "C"), "::ns::C");
+        assert_eq!(qualify("::a::b", "c::D"), "::a::b::c::D");
+        assert_eq!(qualify("", "C"), "::C");
+        assert_eq!(qualify("::", "C"), "::C");
+    }
+
+    #[test]
+    fn qualify_keeps_absolute_names_absolute() {
+        // The class-lattice regression: an absolute name must never be
+        // re-prefixed under the current namespace.
+        assert_eq!(qualify("::ns", "::other::C"), "::other::C");
+        assert_eq!(qualify("ns", "::C"), "::C");
+    }
     use super::*;
 
     #[test]

--- a/rust/tcl-syntax/src/naming.rs
+++ b/rust/tcl-syntax/src/naming.rs
@@ -318,6 +318,16 @@ pub fn qualify(prefix: &str, name: &str) -> String {
         return normalise_qualified_name(name);
     }
     let p = prefix.trim_start_matches("::").trim_end_matches("::");
+    if name.is_empty() {
+        // The empty-name entity (`proc {} {} {}`): a trailing separator
+        // names the `{}` command/variable in the qualified namespace
+        // ([`ends_with_separator`]) — `::` at the root, `::p::` inside `p`.
+        return if p.is_empty() {
+            "::".to_owned()
+        } else {
+            format!("::{p}::")
+        };
+    }
     if p.is_empty() {
         normalise_qualified_name(name)
     } else {
@@ -434,6 +444,14 @@ mod tests {
         assert_eq!(qualify("::a::b", "c::D"), "::a::b::c::D");
         assert_eq!(qualify("", "C"), "::C");
         assert_eq!(qualify("::", "C"), "::C");
+    }
+
+    #[test]
+    fn qualify_names_the_empty_entity_with_a_trailing_separator() {
+        // `proc {} {} {}` — the empty-name command is the `{}` entity the
+        // trailing separator denotes.
+        assert_eq!(qualify("", ""), "::");
+        assert_eq!(qualify("::ns", ""), "::ns::");
     }
 
     #[test]

--- a/samples/diagnostics/S101_shimmer_merge/example.tcl
+++ b/samples/diagnostics/S101_shimmer_merge/example.tcl
@@ -1,31 +1,63 @@
-# S101: Shimmer — variable changes internal representation at merge point
-# Source: SpiceGenTcl/examples/ngspice/dc/diode_iv.tcl:30
+# S101: Shimmer — paths carrying different internal representations merge
+# Source: SpiceGenTcl/examples/ngspice/dc/diode_iv.tcl:30 (motivating file)
 #
-# In Tcl, every value has an internal representation (intrep). When a
-# value is used as a string and then as a list (or vice versa), Tcl
-# must re-parse it — this is called "shimmering". In hot loops, this
-# wastes CPU time re-converting between representations.
+# In C Tcl every value is a Tcl_Obj holding a string representation and at
+# most ONE cached internal representation (intrep) — list, dict, int, …
+# The two are dual-ported: generating the string rep of a list (e.g.
+# interpolating "$xs" into a message) KEEPS the list intrep, so reading a
+# value both ways is not, by itself, a shimmer.  A shimmer happens when an
+# operation must REPLACE the cached intrep — using a string-built value as
+# a list forces a parse; using a list-built value as a dict rebuilds the
+# hash — and the old intrep is discarded.
 #
-# Expected: tclsh runs without error — demonstrates the shimmer pattern.
+# S101 fires when two control-flow paths assign DIFFERENT intreps to the
+# same variable and converge inside a loop: past the join every typed use
+# must be prepared to convert, and the conversion repeats each iteration.
+# (The same merge outside a loop is a one-time conversion — S100.)
+#
+# Expected: tclsh runs without error — demonstrates the merge pattern.
 
-# Build a list by appending formatted strings (string intrep)
-# Then use it as a list (list intrep) — causes shimmer
+# The separator is built as a LIST on one arm and a STRING on the other.
+# Past the join, [lindex $sep 0] must re-parse the string arm's value on
+# every iteration that took the else branch — S101 fires at the join (and
+# at the loop-carried merge with the pre-loop initialiser).
+proc render {rows fancy} {
+    set sep ""
+    foreach row $rows {
+        if {$fancy} {
+            set sep [list "|" "-"]
+        } else {
+            set sep "--"
+        }
+        puts "[lindex $sep 0] $row"
+    }
+}
+render {a b} 1
+render {c d} 0
+
+# The fix: build the SAME representation on both arms, so the join carries
+# one intrep and the list use never re-parses.  No S101 here.
+proc render_clean {rows fancy} {
+    foreach row $rows {
+        if {$fancy} {
+            set sep [list "|" "-"]
+        } else {
+            set sep [list "--"]
+        }
+        puts "[lindex $sep 0] $row"
+    }
+}
+render_clean {a b} 1
+
+# NOT a shimmer (dual-ported reads): building a list and *reading* it as a
+# string only generates the string rep alongside the intact list intrep —
+# the later lindex/llength calls reuse the cached list without re-parsing.
 set xydata {}
 foreach x {1.0 2.0 3.0} y {0.5 1.5 2.5} {
-    set xf [format "%.3f" $x]
-    set yf [format "%.3f" $y]
-    # lappend treats xydata as a list
-    lappend xydata [list $xf $yf]
+    lappend xydata [list [format "%.3f" $x] [format "%.3f" $y]]
 }
-
-# Now use xydata as a string (triggers shimmer back to string)
 puts "as string: $xydata"
-
-# And as a list again (shimmer back to list)
 puts "first element: [lindex $xydata 0]"
 puts "length: [llength $xydata]"
-
-# The fix: keep the variable in one representation consistently
-# Either always use list operations, or convert once at the end.
 
 puts "S101 test complete"

--- a/samples/diagnostics/S102_type_thunking/example.tcl
+++ b/samples/diagnostics/S102_type_thunking/example.tcl
@@ -1,31 +1,41 @@
-# S102: Type thunking — variable oscillates between representations each loop
-# Source: SpiceGenTcl/examples/ngspice/dc/diode_iv.tcl:22
+# S102: Type thunking — a variable oscillates between representations
+# every loop iteration
+# Source: SpiceGenTcl/examples/ngspice/dc/diode_iv.tcl:22 (motivating file)
 #
-# The variable alternates between string and list intrep on each loop
-# iteration, causing continuous re-parsing. This is worse than S101
-# because it happens every iteration, not just at boundaries.
+# C Tcl values are dual-ported (string rep + one cached intrep), so a
+# value converts only when an operation REPLACES the cached intrep.  A
+# loop body that alternates a self-referential variable between two
+# intreps pays that replacement on every single pass: here `lappend`
+# parses the string back into a list, then the interpolating `set`
+# discards the list for a fresh string — two conversions per iteration.
+# This is worse than S101 (a merge-point shimmer) because the cost scales
+# with the iteration count, not with the number of joins.
 #
 # Expected: tclsh runs without error — shows the oscillation pattern.
 
-# Pattern from diode_iv.tcl: build xydata as list, then use as string
-set xydata ""
-foreach x {1.0 2.0 3.0 4.0 5.0} y {0.1 0.2 0.3 0.4 0.5} {
-    set xf [format "%.3f" $x]
-    set yf [format "%.3f" [expr {-$y}]]
-    # lappend forces list intrep
-    lappend xydata [list $xf $yf]
-    # if we did: set xydata "$xydata ..." — forces string intrep
-    # the oscillation between the two causes type thunking
+# S102 fires: `acc` is list inside `lappend`, string after the
+# interpolation, list again on the next pass's `lappend`, …
+proc join_with_commas {items} {
+    set acc ""
+    foreach x $items {
+        lappend acc $x
+        set acc "$acc,"
+    }
+    return $acc
 }
-puts "xydata: $xydata"
+puts "oscillating: [join_with_commas {1 2 3}]"
 
-# Better pattern: stay in list intrep throughout the loop
-set xydata_clean [list]
-foreach x {1.0 2.0 3.0 4.0 5.0} y {0.1 0.2 0.3 0.4 0.5} {
-    set xf [format "%.3f" $x]
-    set yf [format "%.3f" [expr {-$y}]]
-    lappend xydata_clean [list $xf $yf]
+# The fix: stay in ONE representation inside the loop and convert once at
+# the end.  No S102 here — the accumulator is a list on every pass (the
+# initial empty-string→list promotion on the first pass is a one-time
+# cost, not thunking).
+proc join_with_commas_clean {items} {
+    set parts [list]
+    foreach x $items {
+        lappend parts $x
+    }
+    return "[join $parts ,],"
 }
-puts "clean:  $xydata_clean"
+puts "clean:       [join_with_commas_clean {1 2 3}]"
 
 puts "S102 test complete"

--- a/samples/diagnostics/W002_disabled_command/example.tcl
+++ b/samples/diagnostics/W002_disabled_command/example.tcl
@@ -1,4 +1,5 @@
 # W002: Command disabled in active dialect profile
+# tcl-dialect: tcl8.6
 # Source: SpiceGenTcl/src/generalClasses.tcl (oo::configurable, lremove)
 #         SpiceGenTcl/src/ltspice/specElementsClassesLtspice.tcl (oo::abstract)
 #

--- a/samples/diagnostics/W304_missing_double_dash/example.tcl
+++ b/samples/diagnostics/W304_missing_double_dash/example.tcl
@@ -1,23 +1,35 @@
 # W304: Missing '--' option terminator before substituted input
+# tcl-dialect: tcl9.0
 # Source: SpiceGenTcl/src/generalClasses.tcl (lsearch, regexp, switch)
 #         SpiceGenTcl/src/ngspice/netlistParserClassNgspice.tcl
 #
-# The diagnostic should ideally be a tristate:
-#   OFF     - value structurally cannot start with '-'
-#   POSSIBLE - value comes from user input, could start with '-'
-#   ALWAYS  - value is known to start with '-'
+# The diagnostic is a tristate, driven by what the analyser can prove
+# about the first positional argument:
+#   OFF      - value structurally cannot be parsed as an option
+#   POSSIBLE - dynamic value; could start with '-'         -> info W304
+#   ALWAYS   - value is known to start with '-'            -> warning W304
 #
-# Of 24 W304 sites in SpiceGenTcl, 19 are false positives because the
-# value structurally cannot begin with '-'.
+# Two structural facts (verified against the Tcl 9.0.4 C sources) shape
+# when the check can fire at all:
+#
+#   * `switch` scans options only while `i < objc-2` (tclCmdMZ.c), so the
+#     last two words -- the string and a braced pattern/body list -- are
+#     positionally protected. `switch $opt {...}` is safe even when $opt
+#     is "-Wall"; only the separate-args form exposes the string word.
+#   * `lsearch` has NO `--` terminator at all (its option table in
+#     tclCmdIL.c has no "--" entry -- `lsearch -- $l $x` is a runtime
+#     error), and its final two words (list, pattern) are likewise
+#     positionally protected. W304 therefore never applies to lsearch.
 #
 # Expected: tclsh 9.0 runs without error.
 
 # ---------------------------------------------------------------
-# CASE 1: OFF - value structurally cannot start with '-'
-# These should NOT fire W304 (currently false positives).
+# CASE 1: OFF - the value cannot be misparsed as an option.
+# None of these fire W304.
 # ---------------------------------------------------------------
 
-# 1a. switch on argparse output with fixed value set
+# 1a. switch on argparse output with fixed value set - braced-list form,
+#     string word positionally protected (i < objc-2).
 # Source: generalClasses.tcl:749 - $action is always add/get/set/delete
 set action "get"
 switch $action {
@@ -36,10 +48,19 @@ if {[regexp {^\.include\s+(.+)} $netlist_line -> filename]} {
     puts "regexp on netlist: $filename"
 }
 
-# 1c. lsearch on parsed data - elements are SPICE tokens, not options
+# 1c. lsearch is immune by construction: the needle is one of the final
+#     two words, which the option scan never reaches - and lsearch takes
+#     no '--' anyway, so there is nothing to insert.
 # Source: netlistParserClassNgspice.tcl:320
 set tokens {tran 1n 100n uic}
 puts "lsearch on tokens: [lsearch -exact $tokens uic]"
+proc find_in_list {haystack needle} {
+    # $needle may be user input ("-verbose") - still safe: it is the
+    # final word, outside the option scan window.
+    return [lsearch $haystack $needle]
+}
+set items {apple -verbose banana -debug cherry}
+puts "lsearch positional needle: [find_in_list $items -verbose]"
 
 # 1d. HTTP path always starts with '/'
 set path "/api/v1/data"
@@ -54,77 +75,63 @@ if {[regexp -nocase {^v\(([^)]+)\)$} $vecname -> node]} {
     puts "regexp on vector name: $node"
 }
 
-# 1f. switch on netlist element types: r, c, l, v, i, d, ...
-# Source: netlistParserClassNgspice.tcl:201
-set elemtype "r"
-switch $elemtype {
-    r { set r "resistor" }
-    c { set r "capacitor" }
-    v { set r "voltage source" }
-    default { set r "other" }
-}
-puts "switch on element type: $r"
-
-# ---------------------------------------------------------------
-# CASE 2: POSSIBLE - value could start with '-'
-# These SHOULD fire W304.
-# ---------------------------------------------------------------
-
-# 2a. list iteration over user-provided items
-# Source: generalClasses.tcl:210
-proc find_in_list {haystack needle} {
-    # $needle is user input - could be "-exact" or "-verbose"
-    set idx [lsearch $haystack $needle]
-    return $idx
-}
-set items {apple -verbose banana -debug cherry}
-puts "lsearch no --: [find_in_list $items -verbose]"
-
-# 2b. with '--': safe regardless of content
-proc find_in_list_safe {haystack needle} {
-    set idx [lsearch -- $haystack $needle]
-    return $idx
-}
-puts "lsearch with --: [find_in_list_safe $items -verbose]"
-
-# 2c. regexp validating user string that might start with '-'
-# Source: generalClasses.tcl:2958
-set user_input "hello"
-if {[regexp -- {^[a-zA-Z_]\w*$} $user_input]} {
-    puts "regexp on user input: valid identifier"
-}
-
-# 2d. switch on user-provided parameter
-set user_opt "value"
-switch -- $user_opt {
-    value   { puts "switch with --: matched value" }
-    default { puts "switch with --: default" }
-}
-
-# ---------------------------------------------------------------
-# CASE 3: ALWAYS - value known to start with '-'
-# '--' is mandatory here.
-# ---------------------------------------------------------------
-
-# 3a. constructed option strings: "-$name"
-# Source: generalClasses.tcl constructs "-$name" from parameters
+# 1f. braced-list switch on a value KNOWN to start with '-': still safe,
+#     because the string word sits inside the protected final two words.
 set name "Wall"
 set opt "-$name"
-switch -- $opt {
+switch $opt {
     -Wall   { set r "all warnings" }
     -O2     { set r "optimise" }
     default { set r "unknown flag" }
 }
-puts "switch on -\$name: $r"
+puts "switch on -\$name (braced form, safe): $r"
 
-# 3b. searching for option-like strings in a list
-set flags {-O2 -Wall -Werror -pedantic}
-puts "lsearch for flag: [lsearch -- $flags -Wall]"
+# ---------------------------------------------------------------
+# CASE 2: POSSIBLE - dynamic value could start with '-'.
+# These fire W304 at info severity.
+# ---------------------------------------------------------------
 
-# 3c. regexp matching option-like patterns
+# 2a. separate-args switch: the string word is inside the option scan
+#     window (objc > 3), so a dynamic value needs '--'.
+proc classify {user_opt} {
+    switch $user_opt value { return "matched" } default { return "other" }
+}
+puts "separate-args switch: [classify value]"
+
+# 2b. the same call hardened: '--' terminates the option scan.
+proc classify_safe {user_opt} {
+    switch -- $user_opt value { return "matched" } default { return "other" }
+}
+puts "separate-args switch with --: [classify_safe -verbose]"
+
+# 2c. regexp with a dynamic pattern word: could start with '-'.
+proc match_any {pattern str} {
+    return [regexp $pattern $str]
+}
+puts "regexp dynamic pattern: [match_any {b.n} "banana"]"
+
+# 2d. hardened: '--' before the pattern makes any content safe.
+proc match_any_safe {pattern str} {
+    return [regexp -- $pattern $str]
+}
+puts "regexp dynamic pattern with --: [match_any_safe -- "a--b"]"
+
+# ---------------------------------------------------------------
+# CASE 3: ALWAYS - the value is known to start with '-'.
+# Fires W304 at warning severity (the misparse is certain).
+# ---------------------------------------------------------------
+
+# 3a. a regexp pattern variable that provably holds "-verbose": without
+#     '--' the pattern word is parsed as an (unknown) option and the
+#     command errors at run time.
 set flag "-verbose"
-if {[regexp -- {^-(\w+)$} $flag -> flagname]} {
-    puts "regexp on flag: $flagname"
+if {[catch {regexp $flag "some -verbose text"} err]} {
+    puts "regexp on -\$flag without -- errors: $err"
+}
+
+# 3b. hardened with '--': the same value parses as the pattern.
+if {[regexp -- $flag "some -verbose text"]} {
+    puts "regexp on -\$flag with -- matches"
 }
 
 puts "W304 test complete"


### PR DESCRIPTION
## Summary

Deep review of every diagnostic family (E/W/I/H, S shimmer, T taint, O optimisation, IRULE, TK) for correctness and precision, with the Tcl 9.0.4 C sources as the oracle. All fixes target the most general form; command knowledge moved into `tcl-registry` data rather than consumer branches.

- **Tight highlighting** — W210 descends into `[…]` substitutions (anchors `$var`, not the whole `set`); W308 anchors the unknown *method* word; TK1003 anchors the offending `-option`; W124 anchors the invalid IP literal's own bytes; E003 anchors the surplus-argument run, including the same-file proc/alias/rename/TclOO path whose arity is only known at flush time.
- **False positives eliminated** (each verified against tclsh 9.0.4) — `rename OLD NEW` defines NEW (no W123 on the renamed name; W128 stays on the vacated one); iRules cross-event reads no longer draw W210 (the connection scope's registry-gated import set now feeds the RBS suppression); W120 recognises the guarded `if {[catch {package require Tk} err]}` idiom; IRULE3102 is emitted once (analyser owns it; the CFG-side scan stays explorer-only); TK1003 no longer flags option values starting with `-` (`-padx -2`) nor Tk's legal unique-prefix abbreviations; dialect content signatures no longer flip a file to `expect` because a comment contains "interactive".
- **Suggestions & quick fixes** — edit distance upgraded to OSA (adjacent transposition = 1 edit) with a length-scaled budget (`ua2` no longer suggests `cat`); new did-you-mean + replace fixes on W308 (from the receiver's MRO), TK1003, and W127; "Remove surplus argument(s)" fix on E003; subcommand completions surface registry `detail`.
- **Registry as source of truth** — new `CommandSpec::default_form_first_word` replaces the hardcoded `after ` check (canonical number parser, so `0x10` works); memory-SSA clobber classification is trait-driven (`EVALUATES_CODE`/`CREATES_BARRIER`, subcommand-resolved — the old `"interp eval"` compound strings never matched, silently under-clobbering); `interp eval` / `namespace eval` / `namespace inscope` subcommand specs stamped accordingly; tclpkg manifest directives are a registry `ScopedCommandEnv` keyed on the `tclpkg.tcl` basename, with a `tcl-pkg` drift test.
- **Name resolution from the file** — salsa `SourceFile` now carries the document path; the manifest environment and the previously-dead `pkgIndex.tcl` `$dir` suppression are live in the editor (whole-file, per-item incremental, and chunked walks all seed the file scope). The CLI (`tcl diag`/`lint`/`validate`) now auto-detects the per-document dialect exactly like the server (explicit `--dialect` overrides), so `.irul` inputs get full iRules analysis.
- **Shimmer** — S102 gains an intra-iteration path (`lappend acc $x; set acc "$acc,"` thunks even though the loop-header type is consistent), abstaining on scope-aliased names and class-declared instance variables (`MethodDef.instance_vars` threaded via the new `CompilationUnit::method_instance_vars`); shimmer messages no longer embed their own code, use 1-based argument numbers, and render operators as symbols.
- **Centralisation** — one canonical `tcl_syntax::naming::qualify` (fixes class-lattice re-prefixing absolute names; preserves the trailing-separator `{}` entity rule); codegen's backslash-newline collapse uses the canonical C-rule helper (the retired local copy mangled multi-byte UTF-8).
- **Samples reasoned end-to-end** — W304 rewritten against verified `switch`/`lsearch` option-scan semantics (`i < objc-2` trailing-word protection; `lsearch` accepts no `--`, so the old "safe" examples were runtime errors); S101/S102 rewritten to genuinely fire with dual-ported intrep semantics explained; `# tcl-dialect:` pins added where the diagnostic depends on the profile.
- **Runtime port test suite** — `make runtime-rust-test` on a fresh checkout (no fetched `tmp/` Tcl tree, so `build.rs` disables the numeric tower) failed 21 tests that drive tower-gated commands (`expr`, `if`/`while`/`for`, `::tcl::math*`). Those tests are now `have_tommath`-gated per the crate's own convention, the lib items whose only callers are tower-gated are gated too (the tower-less build is warning-free under `-D warnings`), and a `build.rs` staleness trap is fixed: the tower-less probe result was cached un-invalidatably, so fetching the Tcl tree later (whose tar-restored mtimes predate the cached probe) never turned the tower on until `build.rs` was touched by hand.

Three stale tests that pinned the old behaviours were updated with tclsh-verified rationale (rename-target W123, plain-Levenshtein transposition, empty-name proc key). No new clippy allows — every lint fixed structurally (Copy anchor struct, extracted W002 helper, generic hashers, module const).

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make rust-check      # fmt + clippy (pedantic) + xtask drift gates — clean
make check-all       # multi-language lint + typecheck — PASSED
CARGO_INCREMENTAL=0 cargo test --workspace --all-features --no-fail-fast
                     # 283 test binaries green on the final tree
make test-ext        # VS Code extension: 644 passing, 0 failing
make test-emacs      # eglot regression suite — PASS
make runtime-rust-test   # 380 passed (tower on); 309 passed, 0 warnings tower-less
make runtime-rust-lint   # fmt + clippy -D warnings — clean in both tower configs
cargo xtask kcs-index-links   # KCS docs checks passed
```

New coverage: `rust/tcl-lsp-server/tests/e2e/precision_review.rs` (15 tests pinning exact ranges, suggestions, fix payloads, FP guards), `editors/vscode/src/test/precisionReview.test.ts` + fixture (5 tests through the real editor client), `rust/tcl-pkg/tests/manifest_env_drift.rs`, plus TP/FP/TN/FN unit tests beside each changed emitter.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract?
- [x] If yes, I updated at least one relevant KCS note under `docs/kcs/`: new `kcs-qa-tclpkg-manifest-diagnostics.md`; `docs/design/contracts/dialect-detection.md` gains the CLI column; `docs/design/compiler/command-registry.md` documents `default_form_first_word`; README documents CLI dialect auto-detection and manifest analysis.
- [x] If I added a new compiler KCS note, I linked it from both:
  - `docs/kcs/compiler/README.md` — n/a (the new note is a top-level Q&A, linked from `docs/kcs/README.md`; the `kcs-index-links` gate passes)
  - `docs/kcs/README.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015V1JMsgz6R6bR9yQNiMgaU

---
_Generated by [Claude Code](https://claude.ai/code/session_015V1JMsgz6R6bR9yQNiMgaU)_