### PR TITLE
fix(registry): console/consoleinterp eval bodies highlight (#925)

### DIFF
--- a/docs/generated/wasm-command-backing.md
+++ b/docs/generated/wasm-command-backing.md
@@ -15,10 +15,10 @@ or an explicit *not required* classification.
 | handler | 104 |
 | handler (native) | 6 |
 | stdlib | 11 |
-| not-required | 111 |
+| not-required | 105 |
 | known-gap (`RUST_ISSUE_007`) | 0 |
 | **UNCLASSIFIED** | 0 |
-| **total** | 232 |
+| **total** | 226 |
 
 | command | backing | note |
 | --- | --- | --- |
@@ -54,8 +54,6 @@ or an explicit *not required* classification.
 | `::tcl::mathop::^` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `::tcl::mathop::eq` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `::tcl::mathop::in` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
-| `::tcl::mathop::max` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
-| `::tcl::mathop::min` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `::tcl::mathop::ne` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `::tcl::mathop::ni` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `::tcl::mathop::|` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
@@ -149,9 +147,7 @@ or an explicit *not required* classification.
 | `lseq` | handler |  |
 | `lset` | handler |  |
 | `lsort` | handler |  |
-| `max` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `memory` | not-required | TCL_MEM_DEBUG-only heap-debug command |
-| `min` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `my` | handler (native) | per-object command created by TclOO method dispatch (oo_register_my) |
 | `namespace` | handler |  |
 | `ne` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
@@ -220,8 +216,6 @@ or an explicit *not required* classification.
 | `tcl::mathop::^` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `tcl::mathop::eq` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `tcl::mathop::in` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
-| `tcl::mathop::max` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
-| `tcl::mathop::min` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `tcl::mathop::ne` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `tcl::mathop::ni` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |
 | `tcl::mathop::|` | not-required | `expr` operator/function; evaluated inside `expr`, not a standalone runtime command |

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -46,6 +46,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-issue-array-element-not-highlighted-as-variable.md](kcs-issue-array-element-not-highlighted-as-variable.md)
   — a by-reference variable-name argument (`set arr(key) 1`,
   `info exists arr(key)`) is not highlighted as a variable.
+- [kcs-issue-subcommand-script-body-not-highlighted.md](kcs-issue-subcommand-script-body-not-highlighted.md)
+  — a subcommand's script argument (`console eval { ... }`) stays one opaque
+  string instead of recursing into keyword/variable/comment highlighting.
 - [kcs-issue-duplicate-diagnostics.md](kcs-issue-duplicate-diagnostics.md)
   — the same finding is reported twice.
 - [kcs-issue-counter-numtests-array-init.md](kcs-issue-counter-numtests-array-init.md)

--- a/docs/kcs/kcs-issue-subcommand-script-body-not-highlighted.md
+++ b/docs/kcs/kcs-issue-subcommand-script-body-not-highlighted.md
@@ -1,0 +1,151 @@
+# KCS: A subcommand's script argument is not highlighted as a body
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+all-editors
+
+## Symptom
+
+A script argument to a subcommand-dispatch command renders as one opaque,
+unhighlighted string — no keyword, comment, variable, or nested-command
+colouring inside the braces — even though the identical script pasted at the
+top level highlights normally.
+
+Reported for `console eval { ... }` (issue #925): `console` and `eval`
+highlight as a command, but everything inside the `{...}` stays plain text.
+The same shape existed for `consoleinterp eval script` / `consoleinterp
+record script` (used from inside a `console eval` body to reach back into the
+attached interpreter) and for `ttk::treeview`/`ttk::notebook`'s `instate
+statespec ?script?`.
+
+## Operational context
+
+Whether an argument *is* a script body isn't a text-shape question — the
+[command registry](../design/compiler/command-registry.md) answers it via
+`ArgRole::Body`. `collect_script`'s override pass calls
+`CommandRegistry::arg_indices_for_role` for every command head; for a
+subcommand-dispatch command it only consults the matched `SubCommand`'s
+`arg_roles` / `arg_role_resolver` when the parent `CommandSpec` actually has a
+non-empty `subcommands` table — `spec.subcommands.is_empty()` short-circuits
+straight to the (irrelevant) top-level `arg_roles` first. A command modelled
+as a flat `CommandSpec` — no `SubCommand` table at all, just a generic
+`"console subcommand ?arg ...?"` synopsis string and empty `arg_roles` — can
+never contribute a `Body` role for any of its subcommands, no matter how
+their `detail`/`synopsis` text reads. `console` was exactly this: registered
+via the shared flat-command builder in `tk_extra_cmds.rs` alongside genuinely
+subcommand-less commands like `bindtags`. `consoleinterp` was not registered
+at all. `ttk::treeview`/`ttk::notebook` *did* have a `SubCommand` table, but
+their `instate` entry declared `arity: Arity::at_least(1)` (no upper bound)
+and no `arg_roles`, even though its own `detail` text says "optionally
+running a script".
+
+## Decision rules / contracts
+
+1. A subcommand whose manual page shows a `script` (or `body`) argument needs
+   an explicit `arg_roles: &[(N, ArgRole::Body)]` (or `arg_role_resolver`) on
+   that `SubCommand` entry — never inferred from arity or synopsis text.
+   Modelled in
+   [`rust/tcl-registry/src/commands/tk/console.rs`](../../rust/tcl-registry/src/commands/tk/console.rs),
+   mirroring `interp eval`
+   ([`rust/tcl-registry/src/commands/tcl/interp.rs`](../../rust/tcl-registry/src/commands/tcl/interp.rs)).
+2. A command that *looks* flat (a generic `"cmd subcommand ?arg ...?"`
+   synopsis, registered through a shared simple-command builder) may still
+   dispatch subcommands with materially different argument shapes. Skimming
+   the synopsis string is not a substitute for checking the real per-version
+   manual page (or C source, for an internal command like `consoleinterp`)
+   before deciding a command needs a `SubCommand` table — see
+   `docs/design/compiler/command-registry.md` for the `arg_roles` /
+   `arg_role_resolver` / `assigns_variable_at` priority order.
+3. A subcommand that evaluates code in a *different* interpreter from the
+   caller's (the Tk console has its own interpreter; `console eval` runs in
+   it, `consoleinterp eval`/`record` cross back into the interpreter the
+   console is attached to) is a cross-interpreter sink — `T105`, declared via
+   `taint_interp_eval_subcommands` on the parent `CommandSpec` — not the
+   same-interpreter `T100` sink `eval`/`uplevel` are (`Traits::TAINT_SINK`).
+   Get the sink category right, not just the highlighting: both were wired up
+   together in the `console`/`consoleinterp` fix.
+4. Declaring a role correctly in the registry does not guarantee the LSP can
+   reach it at every real call site. `ttk::treeview instate`/`ttk::notebook
+   instate` are now modelled correctly, but this codebase has no
+   widget-path-to-widget-type tracking, so a realistic `$w instate ... {...}`
+   (where `$w` is a variable) never resolves to the `ttk::treeview`/
+   `ttk::notebook` `SubCommand` table today — only a literal `ttk::treeview
+   instate ...` head would. Fixing the registry data ahead of the resolution
+   that would make it observable is still correct (the contract the registry
+   makes to every consumer must be accurate regardless of which consumers
+   currently exercise it), but do not claim a behavioural fix you cannot
+   demonstrate — see the Test anchors below for how the two cases are
+   verified differently.
+5. This class of bug lives entirely in registry data. The recursion
+   mechanism itself (`ArgOverride::BodyScript` inside `collect_script`,
+   [`rust/tcl-lsp-core/src/semantic_tokens.rs`](../../rust/tcl-lsp-core/src/semantic_tokens.rs))
+   is generic and already correct for every command that declares the role —
+   do not special-case a command name in the walker to work around a missing
+   registry entry.
+
+## File-path anchors
+
+- `rust/tcl-registry/src/commands/tk/console.rs` — `console` (`eval` / `hide`
+  / `show` / `title`) and `consoleinterp` (`eval` / `record`) specs
+- `rust/tcl-registry/src/commands/tk/ttk__treeview.rs`,
+  `rust/tcl-registry/src/commands/tk/ttk__notebook.rs` — `instate` arity +
+  `ArgRole::Body` fix
+- `rust/tcl-registry/src/registry.rs` — `CommandRegistry::arg_indices_for_role`
+  (the subcommand-table short-circuit)
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` — `collect_script`,
+  `insert_role_overrides`, `ArgOverride::BodyScript`
+- `rust/tcl-compiler/src/taint.rs` — `classify_network_interp_sinks` (T105,
+  reads `taint_interp_eval_subcommands`)
+
+## Failure modes
+
+- A command registered through a shared "simple flat command" builder (see
+  `tk_extra_cmds.rs`'s `cmd()` helper) silently drops any subcommand
+  structure the real command has — the builder has no `subcommands` field to
+  fill in, so nothing fails loudly; the command just never highlights or
+  taint-classifies its body correctly.
+- Setting `ArgRole::Body` without also checking whether the eval crosses an
+  interpreter boundary misclassifies the taint sink category (`T100` vs
+  `T105`).
+- Declaring the role correctly but assuming that alone makes it observable at
+  every call site overclaims the fix — check whether the LSP can actually
+  resolve the call site's head to that spec (see rule 4 above).
+
+## Triage checklist
+
+1. Decode the semantic tokens for a minimal repro (`cmd sub {body}`) and
+   confirm the body's inner tokens (a `$var`, a nested `[cmd]`) appear as
+   their own token kinds rather than the whole `{...}` staying one `String`.
+2. Check whether the command has a non-empty `subcommands` table at all — a
+   flat `CommandSpec` can never contribute a subcommand-level `Body` role.
+3. If it does, confirm the matched `SubCommand`'s `arg_roles` (or
+   `arg_role_resolver`) actually marks the script argument's index.
+4. If the script crosses into a different interpreter, confirm
+   `taint_interp_eval_subcommands` lists the subcommand for `T105`, instead
+   of (or in addition to) any `T100` classification.
+5. Confirm the LSP can actually resolve a realistic call site's head to the
+   spec you edited — a corrected `SubCommand` on a widget class is invisible
+   until (if) widget-path → widget-type resolution exists.
+
+## Test anchors
+
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` —
+  `console_eval_body_recurses_into_script`,
+  `consoleinterp_eval_and_record_bodies_recurse_into_script`
+- `rust/tcl-registry/src/commands/tk/mod.rs` —
+  `console_and_consoleinterp_eval_bodies_are_registered_correctly`,
+  `ttk_instate_script_arg_is_a_body_with_tight_arity`
+- `rust/tcl-compiler/src/taint.rs` —
+  `t105_cross_interp_for_tainted_console_eval`,
+  `t105_cross_interp_for_tainted_consoleinterp_eval_and_record`
+
+## Related
+
+- [KCS index](README.md)
+- [array element not highlighted as variable](kcs-issue-array-element-not-highlighted-as-variable.md)
+- [Semantic Tokens feature](features/kcs-feature-semantic-tokens.md)
+- [Command registry design doc](../design/compiler/command-registry.md)
+- [Glossary](../GLOSSARY.md)

--- a/editors/zed/src/generated/tcl_commands.json
+++ b/editors/zed/src/generated/tcl_commands.json
@@ -963,7 +963,21 @@
     },
     {
       "name": "console",
-      "summary": "Control the debugging console window (hide/show/eval/…)."
+      "summary": "Control the debugging console window.",
+      "subcommands": [
+        "eval",
+        "hide",
+        "show",
+        "title"
+      ]
+    },
+    {
+      "name": "consoleinterp",
+      "summary": "Evaluate or record a script in the console's attached interpreter.",
+      "subcommands": [
+        "eval",
+        "record"
+      ]
     },
     {
       "name": "const",

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -3755,6 +3755,39 @@ mod tests {
     }
 
     #[test]
+    fn t105_cross_interp_for_tainted_console_eval() {
+        // `console eval $x` with tainted `$x` → cross-interp (T105): the
+        // script runs in the separate console interpreter, the same
+        // category as `interp eval` (issue #925).
+        let sink = call_stmt("console", &["eval", "$x"]);
+        let w = warnings_for_tainted_sink(sink, &[("x", 1)]);
+        let t105 = w
+            .iter()
+            .find(|w| w.code == DiagCode::T105 && w.variable == "x");
+        assert!(t105.is_some(), "expected T105 for console eval; got {w:?}");
+        assert_eq!(t105.unwrap().sink_command, "console eval");
+    }
+
+    #[test]
+    fn t105_cross_interp_for_tainted_consoleinterp_eval_and_record() {
+        // `consoleinterp eval $x` / `consoleinterp record $x` with tainted
+        // `$x` → cross-interp (T105): both cross back into the interpreter
+        // the console is attached to (issue #925 follow-up).
+        for sub in ["eval", "record"] {
+            let sink = call_stmt("consoleinterp", &[sub, "$x"]);
+            let w = warnings_for_tainted_sink(sink, &[("x", 1)]);
+            let t105 = w
+                .iter()
+                .find(|w| w.code == DiagCode::T105 && w.variable == "x");
+            assert!(
+                t105.is_some(),
+                "expected T105 for consoleinterp {sub}; got {w:?}"
+            );
+            assert_eq!(t105.unwrap().sink_command, format!("consoleinterp {sub}"));
+        }
+    }
+
+    #[test]
     fn t106_double_encode_through_uri_encode() {
         // `set x [URI::encode $tainted]` stamps URL_ENCODED on x; passing
         // x back through `URI::encode` double-encodes → T106.

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -6746,6 +6746,36 @@ mod tests {
     }
 
     #[test]
+    fn console_eval_body_recurses_into_script() {
+        // `console eval {puts $x}` (issue #925) — the `console eval` script
+        // argument is a body (ArgRole::Body via the `console` SubCommand
+        // table), so it recurses: `$x` inside the braces resolves as a
+        // Variable rather than the whole `{...}` staying one opaque string.
+        let toks = decode_full("console eval {puts $x}\n", "tk", &reg());
+        assert!(
+            toks.iter()
+                .any(|(_, _, _, k, _)| *k == TokenKind::Variable as u32),
+            "expected $x resolved inside the `console eval` body; got {toks:?}"
+        );
+    }
+
+    #[test]
+    fn consoleinterp_eval_and_record_bodies_recurse_into_script() {
+        // `consoleinterp eval`/`record` (issue #925 follow-up) — both take a
+        // script argument that should recurse the same way `console eval`
+        // does.
+        for sub in ["eval", "record"] {
+            let src = format!("consoleinterp {sub} {{puts $x}}\n");
+            let toks = decode_full(&src, "tk", &reg());
+            assert!(
+                toks.iter()
+                    .any(|(_, _, _, k, _)| *k == TokenKind::Variable as u32),
+                "expected $x resolved inside `consoleinterp {sub}` body; got {toks:?}"
+            );
+        }
+    }
+
+    #[test]
     fn option_enum_value_is_enum_member() {
         // `button .b -relief raised` — the closed-set option value is coloured
         // as an EnumMember (Phase 5), not a generic OptionValue.

--- a/rust/tcl-registry/src/commands/tk/console.rs
+++ b/rust/tcl-registry/src/commands/tk/console.rs
@@ -1,0 +1,174 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `console` — control the Tk debugging console window — and
+//! `consoleinterp`, the command the console interpreter uses to reach back
+//! into the interpreter it is attached to.  Both are missing from
+//! `Tcl_EvalObjEx`-style single-body forms without a `SubCommand` table, so
+//! `console eval script` / `consoleinterp eval script` /
+//! `consoleinterp record script` previously had no declared `ArgRole::Body`
+//! argument and the semantic-token walker left `script` as an opaque string
+//! instead of recursing into it (issue #925).
+use crate::prelude::*;
+
+const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
+    target: SideEffectTarget::InterpState,
+    reads: false,
+    writes: true,
+    connection_side: ConnectionSide::None,
+}];
+
+static CONSOLE_SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        name: "eval",
+        arity: Arity::exact(1),
+        detail: "Evaluate a script in the console's own interpreter.",
+        synopsis: "console eval script",
+        arg_roles: &[(0, ArgRole::Body)],
+        // Runs an arbitrary script in the console interpreter — dynamic-dispatch
+        // consumers (memory-SSA clobber classification, side-effect analysis)
+        // key off this, as with `interp eval`.
+        traits: Traits::EVALUATES_CODE,
+        return_type: Some(TclType::String),
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "hide",
+        arity: Arity::exact(0),
+        detail: "Hide (unmap) the console window.",
+        synopsis: "console hide",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "show",
+        arity: Arity::exact(0),
+        detail: "Show (map and raise) the console window, creating it if it does not yet exist.",
+        synopsis: "console show",
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "title",
+        arity: Arity::new(0, 1),
+        detail: "Query or set the console window's title.",
+        synopsis: "console title ?newTitle?",
+        return_type: Some(TclType::String),
+        ..SubCommand::DEFAULT
+    },
+];
+
+const CONSOLE_FORMS: &[FormSpec] = &[FormSpec {
+    kind: FormKind::Default,
+    synopsis: "console subcommand ?arg ...?",
+}];
+
+/// `console` — control the Tk debugging console window.
+pub fn console_spec() -> CommandSpec {
+    CommandSpec {
+        name: "console",
+        dialects: Some(DialectSet::TK_AND_TCL),
+        traits: Traits::DYNAMIC_EVAL_BODY,
+        arity: Arity::at_least(1),
+        subcommands: CONSOLE_SUBCOMMANDS,
+        hover: Some(HoverSnippet {
+            summary: "Control the debugging console window.",
+            synopsis: &[
+                "console eval script",
+                "console hide",
+                "console show",
+                "console title ?newTitle?",
+            ],
+            snippet: "Manages the Tk debugging console, a text-widget UI backed by its own Tcl interpreter distinct from the caller's. `console eval` runs script in that console interpreter, not the caller's.",
+            source: "Tk man page console.n",
+            examples: "",
+            return_value: "",
+        }),
+        required_package: Some("Tk"),
+        warn_missing_import: false,
+        // `console eval` crosses into the separate console interpreter —
+        // cross-interpreter code injection (T105), the same category as
+        // `interp eval`.
+        taint_interp_eval_subcommands: &["eval"],
+        forms: CONSOLE_FORMS,
+        side_effects: SIDE_EFFECTS,
+        ..CommandSpec::DEFAULT
+    }
+}
+
+static CONSOLEINTERP_SUBCOMMANDS: &[SubCommand] = &[
+    SubCommand {
+        name: "eval",
+        arity: Arity::exact(1),
+        detail: "Evaluate a script in the interpreter the console is attached to.",
+        synopsis: "consoleinterp eval script",
+        arg_roles: &[(0, ArgRole::Body)],
+        traits: Traits::EVALUATES_CODE,
+        return_type: Some(TclType::String),
+        ..SubCommand::DEFAULT
+    },
+    SubCommand {
+        name: "record",
+        arity: Arity::exact(1),
+        detail: "Evaluate a script in the attached interpreter and record it in the console's command history.",
+        synopsis: "consoleinterp record script",
+        arg_roles: &[(0, ArgRole::Body)],
+        traits: Traits::EVALUATES_CODE,
+        return_type: Some(TclType::String),
+        ..SubCommand::DEFAULT
+    },
+];
+
+const CONSOLEINTERP_FORMS: &[FormSpec] = &[FormSpec {
+    kind: FormKind::Default,
+    synopsis: "consoleinterp subcommand script",
+}];
+
+/// `consoleinterp` — available inside the console interpreter created by
+/// `console eval`/`console show`; evaluates or records a script in the
+/// interpreter the console is attached to (typically the main application
+/// interpreter). See `library/console.tcl` (`EvalAttached`, `ConsoleInvoke`)
+/// and `generic/tkConsole.c` (`InterpreterObjCmd`) in the Tk source.
+pub fn consoleinterp_spec() -> CommandSpec {
+    CommandSpec {
+        name: "consoleinterp",
+        dialects: Some(DialectSet::TK_AND_TCL),
+        traits: Traits::DYNAMIC_EVAL_BODY,
+        arity: Arity::at_least(1),
+        subcommands: CONSOLEINTERP_SUBCOMMANDS,
+        hover: Some(HoverSnippet {
+            summary: "Evaluate or record a script in the console's attached interpreter.",
+            synopsis: &["consoleinterp eval script", "consoleinterp record script"],
+            snippet: "Available inside the console interpreter. Both subcommands run script in the interpreter the console is attached to; `record` additionally adds it to the console's command history.",
+            source: "Tk source tkConsole.c (InterpreterObjCmd)",
+            examples: "",
+            return_value: "",
+        }),
+        required_package: Some("Tk"),
+        warn_missing_import: false,
+        // Both subcommands cross back into the attached interpreter —
+        // cross-interpreter code injection (T105).
+        taint_interp_eval_subcommands: &["eval", "record"],
+        forms: CONSOLEINTERP_FORMS,
+        side_effects: SIDE_EFFECTS,
+        ..CommandSpec::DEFAULT
+    }
+}
+
+/// All `console`/`consoleinterp` command specs.
+pub fn specs() -> Vec<CommandSpec> {
+    vec![console_spec(), consoleinterp_spec()]
+}

--- a/rust/tcl-registry/src/commands/tk/mod.rs
+++ b/rust/tcl-registry/src/commands/tk/mod.rs
@@ -27,6 +27,7 @@ mod canvas;
 mod checkbutton;
 mod clipboard;
 mod common;
+mod console;
 mod destroy;
 mod entry;
 mod event;
@@ -88,6 +89,7 @@ pub fn tk_command_specs() -> Vec<CommandSpec> {
     let mut specs = tk_command_specs_raw();
     specs.extend(ttk_extra::specs());
     specs.extend(tk_extra_cmds::specs());
+    specs.extend(console::specs());
     // The themed-widget set (`ttk::*`) was introduced with Tk 8.5.  Stamp the
     // package `min_version` here rather than in every ttk spec file so the
     // gate stays in one place.
@@ -208,12 +210,75 @@ mod tests {
             "tk_setPalette",
             "tk_focusNext",
             "tk_focusPrev",
+            "console",
+            "consoleinterp",
         ] {
             assert!(has(c), "tk command `{c}` is registered");
         }
         // ttk::spinbox is gated to 8.5 like the rest of the themed set.
         let spin = specs.iter().find(|s| s.name == "ttk::spinbox").unwrap();
         assert_eq!(spin.min_version, Some("8.5"));
+    }
+
+    #[test]
+    fn console_and_consoleinterp_eval_bodies_are_registered_correctly() {
+        use crate::{ArgRole, Arity};
+        // Issue #925: `console eval` / `consoleinterp eval` / `consoleinterp
+        // record` each take exactly one script argument that must resolve as
+        // `ArgRole::Body` (so the LSP recurses into it) and must be listed as
+        // a cross-interpreter eval sink (T105) — same shape as `interp eval`.
+        // Stable across Tk 8.4-9.0 (no `min_version` gate on any subcommand).
+        let specs = tk_command_specs();
+
+        let console = specs.iter().find(|s| s.name == "console").unwrap();
+        assert_eq!(console.min_version, None);
+        assert_eq!(console.taint_interp_eval_subcommands, &["eval"]);
+        let console_eval = console.resolve_subcommand("eval").unwrap();
+        assert_eq!(console_eval.arity, Arity::exact(1));
+        assert_eq!(console_eval.arg_role_at(0), Some(ArgRole::Body));
+        for name in ["hide", "show", "title"] {
+            let sub = console.resolve_subcommand(name).unwrap();
+            assert_eq!(sub.arg_role_at(0), None, "`console {name}` has no body arg");
+        }
+
+        let consoleinterp = specs.iter().find(|s| s.name == "consoleinterp").unwrap();
+        assert_eq!(consoleinterp.min_version, None);
+        assert_eq!(
+            consoleinterp.taint_interp_eval_subcommands,
+            &["eval", "record"]
+        );
+        for name in ["eval", "record"] {
+            let sub = consoleinterp.resolve_subcommand(name).unwrap();
+            assert_eq!(sub.arity, Arity::exact(1));
+            assert_eq!(sub.arg_role_at(0), Some(ArgRole::Body));
+        }
+    }
+
+    #[test]
+    fn ttk_instate_script_arg_is_a_body_with_tight_arity() {
+        // Found while auditing for issue #925 siblings: `pathName instate
+        // statespec ?script?` runs `script` as `if {[pathName instate
+        // statespec]} script` per the ttk::widget manual page — a real body,
+        // same shape as `console eval`, but was declared with an unbounded
+        // `Arity::at_least(1)` and no `ArgRole::Body`. Note: unlike
+        // `console`/`consoleinterp`, this is a data-correctness fix only —
+        // the LSP has no widget-path → widget-type tracking, so a real
+        // `.w instate ...` call never resolves to this SubCommand table
+        // (only a literal `ttk::treeview instate ...`/`ttk::notebook instate
+        // ...` head would); it's registered for when/if that resolution is
+        // added.
+        use crate::{ArgRole, Arity};
+        let specs = tk_command_specs();
+        for widget in ["ttk::treeview", "ttk::notebook"] {
+            let spec = specs.iter().find(|s| s.name == widget).unwrap();
+            let instate = spec.resolve_subcommand("instate").unwrap();
+            assert_eq!(instate.arity, Arity::new(1, 2), "{widget} instate arity");
+            assert_eq!(
+                instate.arg_role_at(1),
+                Some(ArgRole::Body),
+                "{widget} instate script arg"
+            );
+        }
     }
 
     #[test]

--- a/rust/tcl-registry/src/commands/tk/tk_extra_cmds.rs
+++ b/rust/tcl-registry/src/commands/tk/tk_extra_cmds.rs
@@ -18,11 +18,13 @@
 
 //! Additional standalone Tk commands not previously registered — `bindtags`,
 //! `tk_optionMenu`, `tk_dialog`, `tk_setPalette`, `tk_bisque`,
-//! `tk_focusNext`, `tk_focusPrev`, `tk_focusFollowsMouse`, and `console`.
+//! `tk_focusNext`, `tk_focusPrev`, and `tk_focusFollowsMouse`.
 //!
 //! Synopses are taken from the Tk 8.6 manual pages.  (`tk busy` and
 //! `tk fontchooser` are already modelled as sub-commands of the `tk`
-//! command.)  Available in a `wish` / `package require Tk` interpreter.
+//! command; `console` and `consoleinterp` have their own file, `console.rs`,
+//! since they need a `SubCommand` table.)  Available in a `wish` /
+//! `package require Tk` interpreter.
 
 use crate::prelude::*;
 
@@ -112,13 +114,6 @@ pub fn specs() -> Vec<CommandSpec> {
             Arity::exact(0),
             &["tk_focusFollowsMouse"],
             "Change focus behaviour so focus follows the mouse pointer.",
-            &[],
-        ),
-        cmd(
-            "console",
-            Arity::at_least(1),
-            &["console subcommand ?arg ...?"],
-            "Control the debugging console window (hide/show/eval/…).",
             &[],
         ),
     ]

--- a/rust/tcl-registry/src/commands/tk/ttk__notebook.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__notebook.rs
@@ -156,9 +156,15 @@ const SUBCOMMANDS: &[SubCommand] = &[
     },
     SubCommand {
         name: "instate",
-        arity: Arity::at_least(1),
+        arity: Arity::new(1, 2),
         detail: "Test whether the widget state matches statespec, optionally running a script.",
         synopsis: "pathName instate statespec ?script?",
+        // `script`, when given, runs as `if {[pathName instate statespec]} script`
+        // — a real Tcl body. (The LSP has no widget-path → widget-type
+        // tracking yet, so this only takes effect for a literal
+        // `ttk::notebook instate ...` head, not realistic `$w instate ...`
+        // usage; declared correctly regardless, per the registry contract.)
+        arg_roles: &[(1, ArgRole::Body)],
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tk/ttk__treeview.rs
+++ b/rust/tcl-registry/src/commands/tk/ttk__treeview.rs
@@ -273,9 +273,15 @@ const SUBCOMMANDS: &[SubCommand] = &[
     },
     SubCommand {
         name: "instate",
-        arity: Arity::at_least(1),
+        arity: Arity::new(1, 2),
         detail: "Test whether the widget state matches statespec, optionally running a script.",
         synopsis: "pathName instate statespec ?script?",
+        // `script`, when given, runs as `if {[pathName instate statespec]} script`
+        // — a real Tcl body. (The LSP has no widget-path → widget-type
+        // tracking yet, so this only takes effect for a literal
+        // `ttk::treeview instate ...` head, not realistic `$w instate ...`
+        // usage; declared correctly regardless, per the registry contract.)
+        arg_roles: &[(1, ArgRole::Body)],
         ..SubCommand::DEFAULT
     },
     SubCommand {


### PR DESCRIPTION
## Summary

- Fixes #925: `console eval { ... }` rendered its whole script body as one
  opaque, unhighlighted string. `console` was registered as a flat
  `CommandSpec` with no `SubCommand` table, so the semantic-token walker had
  no declared `ArgRole::Body` to recurse into (`arg_indices_for_role` only
  reads subcommand-level roles once a `subcommands` table exists at all).
- Gave `console` a proper `SubCommand` table (`eval` / `hide` / `show` /
  `title`) and registered `consoleinterp` (`eval` / `record`), which was
  missing from the registry entirely — both are used from inside a
  `console eval` body to reach the interpreter the console is attached to
  (per the reporter's own follow-up: "`consoleinterp eval script` /
  `consoleinterp record script` need to be checked too").
- `console eval` and `consoleinterp eval`/`record` each cross into a
  *separate* interpreter, so both are wired into the `T105`
  cross-interpreter-eval taint sink (`taint_interp_eval_subcommands`, the
  same mechanism `interp eval` uses) rather than the same-interpreter `T100`
  sink `eval`/`uplevel` carry.
- Verified `console`/`consoleinterp`'s subcommand set and signatures against
  the Tk 8.4 and 9.0 manual pages plus `tkConsole.c` (`InterpreterObjCmd`):
  unchanged across that whole range, so no `min_version` gate is needed on
  any subcommand.
- While auditing the registry for the same bug shape (a subcommand whose
  `detail` text promises a script argument but declares no `Body` role and/or
  an unbounded arity), found and fixed the identical gap on
  `ttk::treeview`/`ttk::notebook`'s `instate statespec ?script?`
  (`Arity::at_least(1)` → `Arity::new(1, 2)`, added `ArgRole::Body`). This
  corrects the registry data but has **no observable effect yet** — this LSP
  has no widget-path → widget-type tracking, so a realistic `$w instate ...`
  never resolves to this `SubCommand` table today (only a literal
  `ttk::treeview instate ...` head would). Registered correctly for when/if
  that resolution lands; documented as a known gap rather than overclaimed as
  a behavioural fix.
- Regenerated `editors/zed/src/generated/tcl_commands.json` (drift from the
  new `consoleinterp` entry + `console`'s new subcommand list) and
  `docs/generated/wasm-command-backing.md` (unrelated **pre-existing**
  drift — bogus `tcl::mathop::min`/`max` entries were already removed from
  `mathop_generated.rs` in an earlier commit, but the doc was never
  regenerated; confirmed via a stash-and-diff that this drift exists on
  `rust`'s tip independent of this change).
- Added a KCS note,
  [`docs/kcs/kcs-issue-subcommand-script-body-not-highlighted.md`](https://github.com/bitwisecook/tcl-lsp/blob/claude/issue-925-registry-compiler-9ai7ir/docs/kcs/kcs-issue-subcommand-script-body-not-highlighted.md),
  documenting the general failure class and decision rules, linked from
  `docs/kcs/README.md`.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-registry`
  - `cargo test -p tcl-lsp-core`
  - `cargo test -p tcl-compiler`
  - `make rust-check` (fmt + clippy + the full `xtask-check` drift gate,
    including editor-catalog / Zed-query / TextMate-keyword regeneration
    checks — all pass in sync with the registry after this change)
  - `make test-rust` (full Rust workspace suite, including the native
    `lsp_e2e` suite — all green)
  - `cargo xtask kcs-index-links` (validates the new KCS note's links/index
    coverage)

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? **No** — it adds/
      corrects registry *data* only. The `ArgRole::Body` recursion mechanism,
      the `T105` taint-sink classification, and the `SubCommand` arity check
      are all pre-existing, unchanged contracts (`interp eval` already
      exercises the same paths).
- [x] KCS note added:
      [`docs/kcs/kcs-issue-subcommand-script-body-not-highlighted.md`](https://github.com/bitwisecook/tcl-lsp/blob/claude/issue-925-registry-compiler-9ai7ir/docs/kcs/kcs-issue-subcommand-script-body-not-highlighted.md),
      linked from `docs/kcs/README.md`. (This repo has no `docs/kcs/compiler/`
      directory; placed alongside the closest precedent for this issue shape,
      `kcs-issue-array-element-not-highlighted-as-variable.md`.)


---
_Generated by [Claude Code](https://claude.ai/code/session_01LtKMXmJ9NNRnTcLWSk1vRG)_