### PR TITLE
Release v2.1.9 notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# v2.1.8
+# v2.1.9
 
 **2.x alpha — pre-release channel.**
 
@@ -10,95 +10,106 @@ GitHub release. The stable **1.x** line stays the default for everyone who has
 not opted into pre-releases, and a `2.1.x` build never becomes the "latest"
 GitHub release or the default Marketplace download.
 
-This release is mostly about the **BIG-IP report generator**: the report now
-carries the f5-query and tcl-lsp marks, and — more usefully — it *prints*. A
-printed report is now a linear document with a running header and footer on
-every page, one section per page, and the architecture view rendered properly
-alongside the manifest that defined it.
-
-Chasing that work turned up two bugs that were never about printing, and had
-been shipping for a while: every device node in the **architecture diagram was
-invisible on screen too**, and the report's **embedded WebAssembly never
-loaded** — which quietly took the in-report query console with it. See
-**Bug Fixes**.
+This release is two deep-review passes — one across the compiler, one across
+diagnostics — plus a cluster of fixes to the BIG-IP report generator's
+printing and, more importantly, a privacy fix: the in-browser generator could
+silently upload a device configuration instead of keeping everything local.
 
 ## New Features
 
-- **The report carries the f5-query and tcl-lsp marks.** Both are inlined as
-  real `<svg>`, so they follow the report's light/dark theme and stay crisp at
-  any zoom rather than blurring like a raster logo. They lead the builder page
-  beside the title — the f5-query mark linking to the query quick start, the
-  tcl-lsp mark to the project — and sit above the attribution in the report
-  footer. A report generated without a logo of your own now uses the f5-query
-  mark in the header instead of a placeholder glyph; supplying your own logo
-  still overrides it.
-- **A report prints as a linear document.** Printing now walks every selected
-  device and section in document order rather than whatever tab happened to be
-  open, with each section starting on its own page. The architecture view gets
-  a page of its own — the diagram, the devices-by-tier breakdown, and the
-  manifest DSL that defined the estate, rendered as a code block rather than as
-  the empty box an editable textarea prints as. The f5-query manual is left out
-  of the printed copy, where a reference manual is only noise — as are the query
-  console and the listener matcher, which are tools rather than report content
-  and printed as an empty prompt and an empty form.
-- **The mark and the title are the way back.** Clicking either returns the report
-  to the view it opened in — device, tab, search, filters, expanded rows, drawer
-  and scroll position — so there is a way out of a deep drilldown that isn't the
-  browser's back button.
-
-## Bug Fixes
-
-- **The in-report f5-query console works.** The embedded WebAssembly payload was
-  the one inlined asset the template escaped, so every `/` in its base64 became
-  `&#x2f;` and decoding it threw as the page loaded. The console, the **Format
-  iRule** button and printing with diagnostics were all dead on arrival — and
-  because the failure was a silent exception at load, the page looked fine until
-  you used one of them. A test now asserts the payload survives templating.
-- **A report prints correctly in Firefox.** The running header and footer ride in
-  a table so that browsers repeat them on every page, but parking the whole
-  report in a single table put every section break inside one table cell — the
-  case Gecko gets badly wrong. Firefox printed a two-device estate as 70 pages,
-  22 of them blank, where Chrome printed the same file cleanly. Each section now
-  prints from a sheet of its own, and the same report comes out with no blank
-  pages in either browser, header and footer on every page.
-- **Empty sections no longer cost a sheet of paper.** A device with no monitors
-  printed a Monitors page: a heading, and nothing under it. On a large estate the
-  diagrams had not finished drawing before the print run started, so their pages
-  printed as empty boxes; the run now waits for the diagrams it is about to
-  print.
-- **The architecture diagram now draws its devices — on screen as well as in
-  print.** The diagram draws each device as an SVG node carrying
-  `class="device"`, and the report's own `.device { display: none }` rule — the
-  one that hides the device sections you are not looking at — was hiding those
-  nodes too. The diagram rendered as edges over blank space. The same selector
-  collision made the print dialog offer phantom devices to print.
-- **The printed report repeats its header and footer on every page.** The
-  running title and the attribution / version / copyright line were positioned
-  into the page margin, which browsers hand to the *neighbouring* page: the
-  title printed at the foot of the page before it, and the attribution across
-  the top of the page after it, on top of the content. Both now ride along on
-  every sheet, clear of the content — so a confidentiality notice set on a
-  report reaches every printed page, which is the point of setting one.
-- **`f5report` wheels ship the report's logo assets.** The vendored logo SVGs
-  were treated as build outputs and left out of the package, so a packaged
-  install would raise on first render instead of producing a report.
-- **BIG-IP object references inside `switch` arms are found.** An object
-  referenced only from a `switch` arm could be invisible to the reference graph
-  that `f5 grep`, `f5 irule trace`, `f5 query rename` and the `bigip-cleanup`
-  skill all read — where a miss is a deleted live pool, not a wrong colour. A
-  single exhaustive definition of "does this argument carry executable Tcl" now
-  backs the walk: a new argument role that can hold a script fails the build
-  until it is classified, and generative tests assert that such arguments are
-  actually walked.
+- **Tk/ttk widget instance commands are understood.** `.t instate {…} {…}`,
+  `$listbox curselection`, `$w tag configure …` and similar widget-instance
+  calls were never resolved back to the widget class that created them, so
+  none of the LSP's tooling — highlighting, hover, completion, or
+  unknown-subcommand/arity diagnostics — could see into them. Every Tk widget
+  constructor now records the class it creates, so calls on `.t`/`$w` resolve
+  to the real widget's subcommand table; a mistyped widget method is now
+  flagged like any other unknown subcommand.
+- **Completion falls back to fuzzy matching.** When a typed fragment matches
+  nothing by prefix, completion now offers the closest commands, switches,
+  subcommands, variables and methods by edit distance — `lsaerch` offers
+  `lsearch`, `lsort -ncoase` offers `-nocase`, `$bnaana` offers `$banana`.
+  Ordinary prefix completions are unaffected.
+- **New diagnostic W218** flags `args` used in a non-final parameter
+  position (`proc p {args extra} {…}`), which C Tcl silently treats as an
+  ordinary parameter rather than the variadic catch-all an author would
+  expect.
+- **More quick fixes.** Did-you-mean rename fixes for undefined-variable
+  warnings and deprecated iRules commands (IRULE2002); deterministic
+  rewrites for `append` → `lappend` (W104), unwrapping a redundant nested
+  `expr` (W114), and `file join`-ifying a manually concatenated path (W201);
+  arity errors (E002/E003/E005) now show the expected usage alongside the
+  argument count.
+- **The `tcl` CLI auto-detects each file's dialect** (`diag`/`lint`/`validate`),
+  matching the language server instead of requiring an explicit `--dialect`.
+- **Printing a BIG-IP report shows progress.** Large reports could take
+  10-20 seconds to prepare for printing with no visible feedback; a staged
+  toast now names what's happening (formatting iRules, rendering diagrams,
+  opening the print dialog).
 
 ## Improvements
 
-- **The APL and BIG-IP editor grammars match what the server sees.** Both
-  dialects shipped with the *Tcl* grammar, which contains no BIG-IP and no APL
-  rules, so a `bigip.conf` was painted with Tcl rules until the language server
-  answered and replaced the highlighting wholesale. Each dialect now has its own
-  tree-sitter grammar, with `ltm rule` bodies and APL `[ … ]` expressions
-  highlighted as Tcl exactly as the server walks them.
-- **The Zed grammars resolve.** Both new grammars were pinned to a commit on a
-  branch that no longer exists, which Zed cannot fetch; they now name a commit
-  on the release line.
+- **Diagnostic ranges are noticeably tighter.** Expression-shimmer warnings
+  (S100/S101) now anchor the specific operand rather than the whole
+  statement; W313 anchors the dynamic path argument; W110 anchors the `==`/
+  `!=` operator itself; I230 quotes a bare `$n` condition the way the source
+  actually spells it.
+- **Numeric comparisons match tclsh exactly.** `==`, `<`, and the rest of the
+  comparison operators now compare int/double operands using C Tcl's own
+  rules instead of a lossy promotion to `f64`, fixing wide-integer and
+  bignum boundary cases.
+- **Go-to-definition and hover are namespace-aware.** Proc and class lookups
+  now walk the enclosing namespace chain (current → ancestors → global)
+  instead of matching by exact string, and command-option matching
+  (`lsort`, `lsearch`, `trace`, `tcl::prefix match`, `string is`, …) now
+  reproduces tclsh's abbreviation rules and error wording exactly.
+- **Fewer false positives:** a `rename`d command's new name is no longer
+  flagged as unknown; iRules reading a variable across events no longer
+  draws a read-before-set warning; a dialect-disabled class/type definer no
+  longer cascades a wall of follow-on "unknown command" warnings; comments
+  containing ordinary punctuation like em-dashes or smart quotes no longer
+  trip the Trojan-source scanner (invisible/direction-altering characters
+  still do); `TK1003` no longer flags legal option-value or abbreviated-flag
+  forms; a comment merely containing a word like "interactive" no longer
+  flips a file's detected dialect.
+- **W128 recognises `ClassName destroy`**, so a TclOO/snit instance obtained
+  after its class was destroyed is now flagged the same way a destroyed
+  instance already was.
+- **Printed BIG-IP reports are more complete and more legible.** Diagnostics
+  and optimiser suggestions found by the analyser now actually print under
+  each iRule (previously only the underlines printed, with no messages);
+  iRule flow diagrams print for every iRule, not just the ones expanded on
+  screen before printing; a diagram smaller than the page prints at its
+  natural size instead of being stretched up to full width with
+  oversized labels; the tcl-lsp and f5-query marks render at a consistent
+  size wherever they appear together.
+
+## Bug Fixes
+
+- **The in-browser BIG-IP report generator could silently upload a device
+  configuration.** Its "is the local engine available" check tested
+  `window.wasm_bindgen`, but the inlined engine only ever defines a bare
+  `wasm_bindgen` global — so the check always failed and the generator
+  silently fell back to a network backend. On static hosting (GitHub Pages)
+  that surfaced as an outright `405` error; everywhere else it quietly broke
+  the "nothing leaves your browser" guarantee. Both the standalone generator
+  and every generated report now also enforce a strict
+  network-blocking content-security-policy in the browser itself, so the
+  no-upload guarantee no longer depends solely on application code.
+- **A generated report's Print button, Ctrl/Cmd-P, and embedded query
+  console could all be dead on arrival.** The inlined WebAssembly loader
+  throws when the page's own URL is a `blob:` URL — exactly what the
+  in-browser generator uses to open a finished report — which silently
+  poisoned a shared binding and took the Print button, its keyboard
+  shortcut, and the report's query console down with it. Reports opened
+  from disk or a normal URL were unaffected, which is why this shipped
+  unnoticed.
+- **Reports and CLI/MCP version output showed a placeholder `0.1.0`**
+  instead of the released version, and could claim to be a "dirty"
+  developer build even when built by CI from a clean release tag.
+- **`console eval` and `consoleinterp eval`/`record` script bodies are now
+  highlighted** instead of rendering as one opaque unhighlighted string.
+- **References, rename, and call hierarchy now find fully-qualified and
+  relative namespace-qualified calls**, including a proc invoked by its
+  fully-qualified name from inside a callback script — previously only
+  exact-form matches within the same namespace were found.


### PR DESCRIPTION
Adds `RELEASE_NOTES.md` for the v2.1.9 pre-release, summarising the compiler and diagnostics deep-review passes plus the BIG-IP report generator fixes merged since v2.1.8.

Tag-only release per `docs/design/contracts/release-and-publish.md` — no source changes, notes only. `make release-tag V=2.1.9` follows once this merges.

---
_Generated by [Claude Code](https://claude.ai/code/session_01J92vkWBMxt6geGnL38iCeY)_