### PR TITLE
fix(release): tolerate build-metadata suffix in MCP smoke-test version check

### DIFF
--- a/scripts/release/smoke_installer.sh
+++ b/scripts/release/smoke_installer.sh
@@ -168,7 +168,10 @@ else
     init='{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2024-11-05","capabilities":{},"clientInfo":{"name":"smoke","version":"0"}}}'
     if reply=$(printf '%s\n' "$init" | "$mcp" 2>/dev/null | head -1) && [ -n "$reply" ]; then
         case "$reply" in
-            *'"serverInfo"'*"\"version\":\"$expected\""*)
+            # The version value may carry build metadata after the tag (e.g.
+            # "2.1.9+g6a6bc87e", same scheme as `tcl`/`f5` --version above) —
+            # match on the tag as a prefix of the quoted value, not full equality.
+            *'"serverInfo"'*"\"version\":\"$expected"*'"'*)
                 pass "MCP server answers initialize and reports $expected" ;;
             *'"serverInfo"'*)
                 fail "MCP server answered initialize but not with $expected


### PR DESCRIPTION
## Summary

Found while running `scripts/release/smoke_installer.sh v2.1.9` as part of post-tag verification for the v2.1.9 release: the script reported `FAILED`, but the underlying release artefact is fine — the smoke test itself has a false-positive bug.

- `tcl-mcp`'s `initialize` response correctly reports `"version":"2.1.9+g6a6bc87e"` — the same `X.Y.Z+g<hash>` scheme `tcl --version` / `f5 --version` already report for this exact release (`tcl 2.1.9+g6a6bc87e`, `f5-query 2.1.9+g6a6bc87e`).
- The `tcl`/`f5` `--version` checks (`scripts/release/smoke_installer.sh:133`) already tolerate this via a loose substring match: `*"$expected"*`.
- The MCP check (added in #911) instead required the literal, fully-closed substring `"version":"$expected"` with nothing between the tag and the closing quote — so the correct, intentional build-metadata suffix (added by #915, which merged shortly after #911) makes it fail every time at a real tag.

Fix: match the tag as a prefix of the quoted version value, allowing anything (including a `+g<hash>` suffix) before the closing quote — same tolerance as the `--version` checks, just anchored to the JSON key.

## Validation

Re-ran `scripts/release/smoke_installer.sh v2.1.9` against the real published v2.1.9 release with the fix applied — full pass, including the MCP check:

```
== MCP server ==
  [ok]   MCP server answers initialize and reports 2.1.9
== Summary ==
  Installer smoke test passed for v2.1.9.
```

Also re-verified all 39 assets in `SHA256SUMS` against the published binaries (all `OK`) as part of the same verification pass — this PR only touches the smoke test's own assertion, not the release artefacts, which were already correct.


---
_Generated by [Claude Code](https://claude.ai/code/session_01J92vkWBMxt6geGnL38iCeY)_