### PR TITLE
fix(f5-cli): verify SSH host keys via known_hosts and de-collide fetch names

### DIFF
--- a/rust/f5-cli/src/commands/fetch.rs
+++ b/rust/f5-cli/src/commands/fetch.rs
@@ -134,12 +134,22 @@ fn fetch_scf(creds: &Credentials, args: &FetchArgs) -> Result<FetchResult, Strin
     }
 }
 
+/// Build the remote artefact name for a fetch started at `fetched_at`.
+///
+/// Millisecond (not second) resolution: two fetches against the same device
+/// started within the same second would otherwise derive the identical
+/// remote filename and one save/download could clobber or read the other's
+/// artefact.
+fn fetch_artefact_name(fetched_at: chrono::DateTime<Utc>) -> String {
+    format!("f5_fetch_{}", fetched_at.timestamp_millis())
+}
+
 /// The live SSH flow: save the config on the device via `tmsh`, pull the
 /// artefact back over the SFTP subsystem, and (for a UCS-only fetch) reconstruct
 /// the SCF locally.
 fn via_ssh(creds: &Credentials, args: &FetchArgs) -> Result<FetchResult, String> {
     let fetched_at = Utc::now();
-    let name = format!("f5_fetch_{}", fetched_at.timestamp());
+    let name = fetch_artefact_name(fetched_at);
     let (scf_text, ucs_data) = ssh::fetch(creds, args.fmt, args.timeout, &name)?;
     Ok(FetchResult {
         host: creds.host.clone(),
@@ -157,7 +167,7 @@ fn via_ssh(creds: &Credentials, args: &FetchArgs) -> Result<FetchResult, String>
 /// failure (propagate).
 fn via_rest(creds: &Credentials, args: &FetchArgs) -> Result<FetchResult, RestError> {
     let fetched_at = Utc::now();
-    let name = format!("f5_fetch_{}", fetched_at.timestamp());
+    let name = fetch_artefact_name(fetched_at);
     rest::save_ucs(creds, &name, args.insecure, args.timeout)?;
     let ucs_data = rest::download(
         creds,
@@ -240,4 +250,26 @@ fn write_result(result: &FetchResult, out_dir: &Path) -> Result<(), String> {
     );
     std::fs::write(out_dir.join("fetch.meta"), meta).map_err(|e| e.to_string())?;
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn fetch_artefact_name_differs_within_the_same_second() {
+        let base = Utc::now();
+        let a = fetch_artefact_name(base);
+        let b = fetch_artefact_name(base + chrono::Duration::milliseconds(1));
+        assert_ne!(
+            a, b,
+            "two fetches within the same second must not derive the same remote artefact name"
+        );
+    }
+
+    #[test]
+    fn fetch_artefact_name_is_stable_for_the_same_instant() {
+        let at = Utc::now();
+        assert_eq!(fetch_artefact_name(at), fetch_artefact_name(at));
+    }
 }

--- a/rust/f5-cli/src/commands/fetch.rs
+++ b/rust/f5-cli/src/commands/fetch.rs
@@ -136,12 +136,17 @@ fn fetch_scf(creds: &Credentials, args: &FetchArgs) -> Result<FetchResult, Strin
 
 /// Build the remote artefact name for a fetch started at `fetched_at`.
 ///
-/// Millisecond (not second) resolution: two fetches against the same device
-/// started within the same second would otherwise derive the identical
-/// remote filename and one save/download could clobber or read the other's
-/// artefact.
+/// Millisecond (not second) resolution plus the calling process's PID: two
+/// fetches against the same device — each `f5-query` invocation is its own
+/// process — started within the same millisecond would otherwise still
+/// derive the identical remote filename and one save/download could clobber
+/// or read the other's artefact.
 fn fetch_artefact_name(fetched_at: chrono::DateTime<Utc>) -> String {
-    format!("f5_fetch_{}", fetched_at.timestamp_millis())
+    format!(
+        "f5_fetch_{}_{}",
+        fetched_at.timestamp_millis(),
+        std::process::id()
+    )
 }
 
 /// The live SSH flow: save the config on the device via `tmsh`, pull the
@@ -271,5 +276,14 @@ mod tests {
     fn fetch_artefact_name_is_stable_for_the_same_instant() {
         let at = Utc::now();
         assert_eq!(fetch_artefact_name(at), fetch_artefact_name(at));
+    }
+
+    #[test]
+    fn fetch_artefact_name_embeds_the_process_id() {
+        // Distinguishes concurrent `f5-query` invocations (separate
+        // processes) that land in the same millisecond, e.g. a fast batch
+        // launch of several fetches.
+        let name = fetch_artefact_name(Utc::now());
+        assert!(name.ends_with(&format!("_{}", std::process::id())));
     }
 }

--- a/rust/f5-cli/src/commands/remote/auth.rs
+++ b/rust/f5-cli/src/commands/remote/auth.rs
@@ -46,8 +46,9 @@ pub struct Credentials {
 }
 
 /// The XDG config directory holding `hosts.toml` (`$XDG_CONFIG_HOME/f5` or
-/// `~/.config/f5`).
-fn xdg_config_dir() -> PathBuf {
+/// `~/.config/f5`). Also used by the SSH transport to persist its
+/// `known_hosts` store (see [`super::ssh`]).
+pub(super) fn xdg_config_dir() -> PathBuf {
     if let Some(base) = env::var_os("XDG_CONFIG_HOME").filter(|v| !v.is_empty()) {
         return PathBuf::from(base).join("f5");
     }

--- a/rust/f5-cli/src/commands/remote/ssh.rs
+++ b/rust/f5-cli/src/commands/remote/ssh.rs
@@ -31,17 +31,18 @@
 //! not exercised by the offline tests; only the pure command/path builders are
 //! unit-tested.
 
+use std::path::{Path, PathBuf};
 use std::sync::Arc;
 use std::time::Duration;
 
 use russh::client;
-use russh::keys::ssh_key;
+use russh::keys::{known_hosts, ssh_key};
 use russh::{ChannelMsg, Disconnect};
 use russh_sftp::client::SftpSession;
 use russh_sftp::protocol::OpenFlags;
 use tokio::io::AsyncReadExt as _;
 
-use super::auth::Credentials;
+use super::auth::{Credentials, xdg_config_dir};
 
 /// The `tmsh` command that writes an SCF for `name`, and the path it lands at.
 fn scf_save(name: &str) -> (String, String) {
@@ -59,19 +60,98 @@ fn ucs_save(name: &str) -> (String, String) {
     )
 }
 
-/// Server-key handler: accept the presented host key unconditionally
-/// (`StrictHostKeyChecking=accept-new` semantics — a fetch to a fresh device
-/// should not fail on an unknown key).
-struct AcceptServerKey;
+/// Where accepted SSH host keys are persisted, in OpenSSH `known_hosts`
+/// format — under the tool's own config dir (`$XDG_CONFIG_HOME/f5` or
+/// `~/.config/f5`), independent of the user's real `~/.ssh/known_hosts`.
+fn known_hosts_path() -> PathBuf {
+    xdg_config_dir().join("known_hosts")
+}
+
+/// The result of checking a presented host key against the persisted store.
+#[derive(Debug, PartialEq)]
+enum HostKeyCheck {
+    /// Matches the key previously recorded for this host: safe to proceed.
+    Known,
+    /// No entry recorded for this host yet (`StrictHostKeyChecking=accept-new`
+    /// semantics): the caller should persist the key and proceed.
+    New,
+    /// A *different* key is on record for this host — a man-in-the-middle, or
+    /// the device was re-imaged / re-keyed. Must not proceed silently.
+    Changed { line: usize },
+    /// The `known_hosts` store could not be read or parsed for some other
+    /// reason (I/O error, corrupt entry). Fail closed rather than guess.
+    Unreadable(String),
+}
+
+/// Check `key` for `host:port` against the `known_hosts`-format store at
+/// `path`, without side effects.
+fn verify_host_key(host: &str, port: u16, key: &ssh_key::PublicKey, path: &Path) -> HostKeyCheck {
+    match known_hosts::check_known_hosts_path(host, port, key, path) {
+        Ok(true) => HostKeyCheck::Known,
+        Ok(false) => HostKeyCheck::New,
+        Err(russh::keys::Error::KeyChanged { line }) => HostKeyCheck::Changed { line },
+        Err(e) => HostKeyCheck::Unreadable(e.to_string()),
+    }
+}
+
+/// Server-key handler: verifies the presented host key against the persisted
+/// `known_hosts` store (`StrictHostKeyChecking=accept-new` semantics — an
+/// unknown host is trusted on first use and its key recorded; a *known* host
+/// presenting a *different* key is rejected rather than silently accepted).
+struct AcceptServerKey {
+    host: String,
+    port: u16,
+    known_hosts_path: PathBuf,
+}
 
 impl client::Handler for AcceptServerKey {
     type Error = russh::Error;
 
     async fn check_server_key(
         &mut self,
-        _server_public_key: &ssh_key::PublicKey,
+        server_public_key: &ssh_key::PublicKey,
     ) -> Result<bool, Self::Error> {
-        Ok(true)
+        match verify_host_key(
+            &self.host,
+            self.port,
+            server_public_key,
+            &self.known_hosts_path,
+        ) {
+            HostKeyCheck::Known => Ok(true),
+            HostKeyCheck::New => {
+                if let Err(e) = known_hosts::learn_known_hosts_path(
+                    &self.host,
+                    self.port,
+                    server_public_key,
+                    &self.known_hosts_path,
+                ) {
+                    eprintln!(
+                        "warning: could not record host key for {} in {}: {e}",
+                        self.host,
+                        self.known_hosts_path.display()
+                    );
+                }
+                Ok(true)
+            }
+            HostKeyCheck::Changed { line } => {
+                eprintln!(
+                    "error: host key for {} does not match the key recorded at {}:{line} — \
+                     refusing to connect. This may indicate a man-in-the-middle attack; if the \
+                     device's key legitimately changed, remove the stale entry from that file.",
+                    self.host,
+                    self.known_hosts_path.display()
+                );
+                Ok(false)
+            }
+            HostKeyCheck::Unreadable(e) => {
+                eprintln!(
+                    "error: could not verify the host key for {} against {}: {e}",
+                    self.host,
+                    self.known_hosts_path.display()
+                );
+                Ok(false)
+            }
+        }
     }
 }
 
@@ -79,7 +159,12 @@ impl client::Handler for AcceptServerKey {
 async fn connect(credentials: &Credentials) -> Result<client::Handle<AcceptServerKey>, String> {
     let config = Arc::new(client::Config::default());
     let addr = (credentials.host.as_str(), credentials.ssh_port);
-    let mut handle = client::connect(config, addr, AcceptServerKey)
+    let handler = AcceptServerKey {
+        host: credentials.host.clone(),
+        port: credentials.ssh_port,
+        known_hosts_path: known_hosts_path(),
+    };
+    let mut handle = client::connect(config, addr, handler)
         .await
         .map_err(|e| format!("ssh connect to {}: {e}", credentials.host))?;
     let auth = handle
@@ -233,6 +318,8 @@ pub fn fetch(
 
 #[cfg(test)]
 mod tests {
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
     use super::*;
 
     #[test]
@@ -250,5 +337,117 @@ mod tests {
         let (command, path) = ucs_save("f5_fetch_1");
         assert_eq!(command, "tmsh save sys ucs f5_fetch_1");
         assert_eq!(path, "/var/local/ucs/f5_fetch_1.ucs");
+    }
+
+    // Two distinct ed25519 test-vector public keys (arbitrary, not secrets —
+    // the same pair `russh` uses in its own `known_hosts` test suite).
+    const KEY_A: &str = "AAAAC3NzaC1lZDI1NTE5AAAAIJdD7y3aLq454yWBdwLWbieU1ebz9/cu7/QEXn9OIeZJ";
+    const KEY_B: &str = "AAAAC3NzaC1lZDI1NTE5AAAAIA6rWI3G1sz07DnfFlrouTcysQlj2P+jpNSOEWD9OJ3X";
+
+    fn key(base64: &str) -> ssh_key::PublicKey {
+        russh::keys::parse_public_key_base64(base64).expect("parse test public key")
+    }
+
+    static COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+    /// A throwaway directory under the system temp dir, removed on drop.
+    struct TempDir {
+        path: PathBuf,
+    }
+
+    impl TempDir {
+        fn new() -> Self {
+            let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+            let mut path = std::env::temp_dir();
+            path.push(format!("f5-cli-ssh-known-hosts-{}-{n}", std::process::id()));
+            std::fs::create_dir_all(&path).expect("create temp dir");
+            Self { path }
+        }
+
+        fn known_hosts(&self) -> PathBuf {
+            self.path.join("known_hosts")
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.path);
+        }
+    }
+
+    #[test]
+    fn verify_host_key_reports_new_for_unknown_host() {
+        let dir = TempDir::new();
+        assert_eq!(
+            verify_host_key("bigip.example.com", 22, &key(KEY_A), &dir.known_hosts()),
+            HostKeyCheck::New
+        );
+    }
+
+    #[test]
+    fn verify_host_key_reports_new_when_store_does_not_exist() {
+        let dir = TempDir::new();
+        // The directory (and file) were never created — a fresh install.
+        let missing = dir.path.join("does-not-exist").join("known_hosts");
+        assert_eq!(
+            verify_host_key("bigip.example.com", 22, &key(KEY_A), &missing),
+            HostKeyCheck::New
+        );
+    }
+
+    #[test]
+    fn verify_host_key_reports_known_after_learning() {
+        let dir = TempDir::new();
+        let path = dir.known_hosts();
+        known_hosts::learn_known_hosts_path("bigip.example.com", 22, &key(KEY_A), &path)
+            .expect("learn host key");
+        assert_eq!(
+            verify_host_key("bigip.example.com", 22, &key(KEY_A), &path),
+            HostKeyCheck::Known
+        );
+    }
+
+    #[test]
+    fn verify_host_key_reports_changed_for_a_different_key() {
+        let dir = TempDir::new();
+        let path = dir.known_hosts();
+        known_hosts::learn_known_hosts_path("bigip.example.com", 22, &key(KEY_A), &path)
+            .expect("learn host key");
+        assert!(matches!(
+            verify_host_key("bigip.example.com", 22, &key(KEY_B), &path),
+            HostKeyCheck::Changed { .. }
+        ));
+    }
+
+    #[test]
+    fn verify_host_key_is_new_for_a_different_host_in_the_same_store() {
+        let dir = TempDir::new();
+        let path = dir.known_hosts();
+        known_hosts::learn_known_hosts_path("bigip-a.example.com", 22, &key(KEY_A), &path)
+            .expect("learn host key");
+        // A second, unrelated host isn't affected by the first host's entry —
+        // it gets its own trust-on-first-use, not a spurious `Changed`.
+        assert_eq!(
+            verify_host_key("bigip-b.example.com", 22, &key(KEY_B), &path),
+            HostKeyCheck::New
+        );
+    }
+
+    #[test]
+    fn verify_host_key_distinguishes_non_standard_ports() {
+        let dir = TempDir::new();
+        let path = dir.known_hosts();
+        known_hosts::learn_known_hosts_path("bigip.example.com", 2222, &key(KEY_A), &path)
+            .expect("learn host key");
+        // Same host, default port 22: no entry recorded for *that* port/host
+        // pair, so it's still new rather than matching the :2222 entry.
+        assert_eq!(
+            verify_host_key("bigip.example.com", 22, &key(KEY_A), &path),
+            HostKeyCheck::New
+        );
+        assert_eq!(
+            verify_host_key("bigip.example.com", 2222, &key(KEY_A), &path),
+            HostKeyCheck::Known
+        );
     }
 }

--- a/rust/f5-cli/src/commands/remote/ssh.rs
+++ b/rust/f5-cli/src/commands/remote/ssh.rs
@@ -94,6 +94,46 @@ fn verify_host_key(host: &str, port: u16, key: &ssh_key::PublicKey, path: &Path)
     }
 }
 
+/// Decide whether to proceed with `key` for `host:port`, persisting it to
+/// `path` on first sight. Fails closed (returns `false`) whenever trust can't
+/// actually be established: a recorded mismatch, an unreadable store, *or* a
+/// new key that could not be written — trust-on-first-use only holds if the
+/// key is actually persisted, since a key that silently fails to save would
+/// leave this host looking "unknown" (not "changed") on every later
+/// connection, defeating the check entirely.
+fn accept_host_key(host: &str, port: u16, key: &ssh_key::PublicKey, path: &Path) -> bool {
+    match verify_host_key(host, port, key, path) {
+        HostKeyCheck::Known => true,
+        HostKeyCheck::New => match known_hosts::learn_known_hosts_path(host, port, key, path) {
+            Ok(()) => true,
+            Err(e) => {
+                eprintln!(
+                    "error: could not record host key for {host} in {}: {e} — refusing to \
+                     connect, since the key could not be persisted for future verification",
+                    path.display()
+                );
+                false
+            }
+        },
+        HostKeyCheck::Changed { line } => {
+            eprintln!(
+                "error: host key for {host} does not match the key recorded at {}:{line} — \
+                 refusing to connect. This may indicate a man-in-the-middle attack; if the \
+                 device's key legitimately changed, remove the stale entry from that file.",
+                path.display()
+            );
+            false
+        }
+        HostKeyCheck::Unreadable(e) => {
+            eprintln!(
+                "error: could not verify the host key for {host} against {}: {e}",
+                path.display()
+            );
+            false
+        }
+    }
+}
+
 /// Server-key handler: verifies the presented host key against the persisted
 /// `known_hosts` store (`StrictHostKeyChecking=accept-new` semantics — an
 /// unknown host is trusted on first use and its key recorded; a *known* host
@@ -111,47 +151,12 @@ impl client::Handler for AcceptServerKey {
         &mut self,
         server_public_key: &ssh_key::PublicKey,
     ) -> Result<bool, Self::Error> {
-        match verify_host_key(
+        Ok(accept_host_key(
             &self.host,
             self.port,
             server_public_key,
             &self.known_hosts_path,
-        ) {
-            HostKeyCheck::Known => Ok(true),
-            HostKeyCheck::New => {
-                if let Err(e) = known_hosts::learn_known_hosts_path(
-                    &self.host,
-                    self.port,
-                    server_public_key,
-                    &self.known_hosts_path,
-                ) {
-                    eprintln!(
-                        "warning: could not record host key for {} in {}: {e}",
-                        self.host,
-                        self.known_hosts_path.display()
-                    );
-                }
-                Ok(true)
-            }
-            HostKeyCheck::Changed { line } => {
-                eprintln!(
-                    "error: host key for {} does not match the key recorded at {}:{line} — \
-                     refusing to connect. This may indicate a man-in-the-middle attack; if the \
-                     device's key legitimately changed, remove the stale entry from that file.",
-                    self.host,
-                    self.known_hosts_path.display()
-                );
-                Ok(false)
-            }
-            HostKeyCheck::Unreadable(e) => {
-                eprintln!(
-                    "error: could not verify the host key for {} against {}: {e}",
-                    self.host,
-                    self.known_hosts_path.display()
-                );
-                Ok(false)
-            }
-        }
+        ))
     }
 }
 
@@ -449,5 +454,61 @@ mod tests {
             verify_host_key("bigip.example.com", 2222, &key(KEY_A), &path),
             HostKeyCheck::Known
         );
+    }
+
+    #[test]
+    fn accept_host_key_accepts_and_persists_a_new_host() {
+        let dir = TempDir::new();
+        let path = dir.known_hosts();
+        assert!(accept_host_key("bigip.example.com", 22, &key(KEY_A), &path));
+        assert_eq!(
+            verify_host_key("bigip.example.com", 22, &key(KEY_A), &path),
+            HostKeyCheck::Known
+        );
+    }
+
+    #[test]
+    fn accept_host_key_accepts_a_matching_known_host() {
+        let dir = TempDir::new();
+        let path = dir.known_hosts();
+        known_hosts::learn_known_hosts_path("bigip.example.com", 22, &key(KEY_A), &path)
+            .expect("learn host key");
+        assert!(accept_host_key("bigip.example.com", 22, &key(KEY_A), &path));
+    }
+
+    #[test]
+    fn accept_host_key_rejects_a_changed_key() {
+        let dir = TempDir::new();
+        let path = dir.known_hosts();
+        known_hosts::learn_known_hosts_path("bigip.example.com", 22, &key(KEY_A), &path)
+            .expect("learn host key");
+        assert!(!accept_host_key(
+            "bigip.example.com",
+            22,
+            &key(KEY_B),
+            &path
+        ));
+    }
+
+    #[test]
+    fn accept_host_key_fails_closed_when_the_store_cannot_be_written() {
+        let dir = TempDir::new();
+        // Make the known_hosts *parent* a regular file, so `create_dir_all`
+        // inside `learn_known_hosts_path` cannot succeed regardless of
+        // privilege level (unlike a plain permission bit, this also fails
+        // when tests run as root).
+        let blocked_parent = dir.path.join("blocked");
+        std::fs::write(&blocked_parent, b"not a directory").expect("create blocking file");
+        let path = blocked_parent.join("known_hosts");
+
+        // Without the fail-closed fix this would return `true` despite never
+        // having persisted the key, silently defeating verification on every
+        // later connection to this host.
+        assert!(!accept_host_key(
+            "bigip.example.com",
+            22,
+            &key(KEY_A),
+            &path
+        ));
     }
 }


### PR DESCRIPTION
## Summary

- `f5-cli`'s SSH fetch transport (`rust/f5-cli/src/commands/remote/ssh.rs`) accepted every presented SSH host key unconditionally, so `f5 fetch --transport ssh` (and the `auto` REST-fallback path) had no protection against a man-in-the-middle. `AcceptServerKey::check_server_key` now checks against a persisted OpenSSH-style `known_hosts` file under the tool's XDG config dir (`$XDG_CONFIG_HOME/f5/known_hosts`, via `russh::keys::known_hosts`), trusting an unknown host on first use and recording its key, but rejecting a host that presents a key different from the one on record (with a clear stderr warning, rather than silently connecting).
- `via_ssh`/`via_rest` in `rust/f5-cli/src/commands/fetch.rs` derived the remote fetch artefact name from second-resolution `timestamp()`, so two fetches against the same device starting within the same second could derive the same remote filename and clobber/overwrite each other's saved SCF/UCS artefact. Switched to millisecond resolution (`timestamp_millis()`).

Fixes #861.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo build -p f5-cli`
  - `cargo test -p f5-cli` (all tests pass, including new unit tests for host-key verification/persistence in `ssh.rs` and artefact-name uniqueness in `fetch.rs`)
  - `cargo fmt -p f5-cli -- --check`
  - `cargo clippy -p f5-cli --all-targets -- -D warnings`

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No, this only touches the `f5-cli` remote SSH transport.
- [ ] N/A
- [ ] N/A


---
_Generated by [Claude Code](https://claude.ai/code/session_01JM9BrL5RypfwrRzMZDvNhm)_