### PR TITLE
Fix W210/W211/W220 false positives on tricky Tcl scoping; add per-code severity override (#941)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1831,6 +1831,29 @@ disabled = O109
 For the complete reference, see
 [`docs/kcs/kcs-howto-suppress-diagnostics.md`](docs/kcs/kcs-howto-suppress-diagnostics.md).
 
+## Changing how prominent a diagnostic is
+
+Some checks are intentionally quiet — an unused variable
+([W211](docs/kcs/codes/kcs-diagnostic-w211-variable-set-not-used.md)), a dead
+store, or a style hint render at *hint* severity, a faint underline that is
+easy to miss.  Rather than turn a check off, you can re-level it per code so the
+editor shows it more (or less) prominently:
+
+```json
+{ "tclLsp.diagnosticSeverity.W211": "warning" }
+```
+
+Accepted values are `"error"`, `"warning"`, `"information"`, and `"hint"`, plus
+`"default"` (keep the analyser's built-in severity).  This changes only how the
+diagnostic is displayed — never whether the analysis runs.  Any diagnostic code
+can be re-levelled with `tclLsp.diagnosticSeverity.<CODE>`; combine it with the
+`tclLsp.diagnostics.<CODE>` on/off toggle above.  In `.tcl-lsp.ini`:
+
+```ini
+[diagnosticSeverity]
+W211 = warning
+```
+
 ## Multi-file projects and `package require`
 
 In a project with an "entry" file that runs the `package require`s and then

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -2131,12 +2131,79 @@ Companion: `compiler/ir.py:IRBlock` use-extraction now reads `source_args[1]`
 so `namespace eval $ns {…}`'s `$ns` is recovered as a read of `ns` (was
 invisible pre-fix — would have looked unused).
 
+#### Refinement (issue #941) — the *pure-read* alias
+
+The original fix recognised the alias-def but its reproducer wrote through the
+alias before reading (`set var 99; return $var`), so the read consumed a
+concrete definition. The **pure-read** shape — `upvar 1 $name v; return $v`,
+with no intervening write — still fired W210, because a later
+"dynamic-upvar-local" override *re-enabled* the read-before-set on any dynamic
+target. That override was inconsistent: the *literal*-target twin
+(`upvar 1 outer v; return $v`) has identical runtime risk — both raise
+`can't read` only when the caller variable is missing — yet was silent. Since
+`upvar 1 $name v` is the standard pass-by-reference-for-reading idiom (e.g.
+`proc getField {arrayName field} {upvar 1 $arrayName arr; return $arr($field)}`),
+the override false-fired on every such accessor.
+
+The override was removed: a scope-aliased local is now suppressed for W210
+regardless of whether the `upvar` target is literal or dynamic, matching C Tcl
+(the two forms are indistinguishable at runtime) and the codebase's
+"assume the may-run path does run" stance. An *unrelated* local — not an
+alias, never set — is absent from the scope-alias set and still fires.
+
 #### Tests
 
-- `tests/test_fp_rbs.py::test_FP_RBS_08_dynamic_upvar_target_silent` (FP, the
-  `upvar 1 $name var` pattern)
-- `tests/test_fp_rbs.py::test_FP_RBS_08_unrelated_local_still_fires` (TP
-  control — a local that's *not* aliased and never set still fires W210)
+- `tests/unused_var_tricky_features.rs::upvar_dynamic_target::*` (Rust; the
+  pure-read FP, the literal/dynamic parity control, and the unrelated-local TP)
+- `src/analyser/diagnostics/fp/rbs.rs::fp_rbs_08_*` (in-crate; set-then-read
+  silent + unrelated-local TP)
+- `src/analyser/state.rs::w210_dynamic_target_upvar_alias_read_is_silent`
+- `tests/fp_depth.rs::dynamic_upvar_local_unconditional_read_silent_w210`
+
+---
+
+### FP-RBS-11 — top-level global consumed only by a proc read (issue #941)
+
+- **Verdict:** FALSE POSITIVE (W211 / W220) — a global assigned at the top
+  level (`set cfg 1`, which runs in the global namespace) and read only inside
+  a proc (`proc f {} {global cfg; return $cfg}`, or `$::cfg`) looked like a
+  dead store / unused variable to single-unit dataflow, which sees the
+  top-level script and each proc as separate function units.
+- **Status:** FIXED (issue #941). The read-side mirror of the existing
+  `globals_written_by_procs` (which already suppresses the reverse direction:
+  a proc *write* feeding a top-level read, keeping W210 quiet). A new
+  `globals_read_by_procs` folds the bare tails of every proc's qualified
+  (`$::x`) reads and its `global`-aliased reads into the top-level unit's
+  cross-scope suppression set, which both W220 and W211 honour. Independently,
+  the W211 emitter now exempts `::`-qualified names, matching the W220 and W210
+  emitters (a `set ::ns::cfg 1` names an externally-consumable global).
+- **Codes:** W211, W220
+- **Corpus:** the "config global set at the top, read inside handlers" shape.
+
+#### Reproducer
+
+```tcl
+proc f {} { global cfg; return $cfg }
+set cfg 1          ;# was W220 — but `f` reads it
+puts [f]
+```
+
+#### tclsh ground truth
+
+`proc f {} {global cfg; return $cfg}; set cfg 1; f` → `1`. The top-level
+assignment is the value the proc returns, so it is neither dead nor unused.
+
+#### TP control (must still fire)
+
+```tcl
+proc f {} { return 0 }
+set cfg 1          ;# W211 — no proc (and nothing else) ever reads cfg
+puts [f]
+```
+
+#### Tests
+
+- `tests/unused_var_tricky_features.rs::cross_scope_globals::*`
 
 ---
 

--- a/docs/kcs/codes/kcs-diagnostic-w211-variable-set-not-used.md
+++ b/docs/kcs/codes/kcs-diagnostic-w211-variable-set-not-used.md
@@ -21,7 +21,7 @@ Unused variables waste memory and make the code harder to read; they often indic
 
 ## Symptoms
 
-- A yellow squiggle appears under the variable name, with the message "variable set but never used".
+- A faint hint-severity underline (the subtle "three dots") appears under the variable name, with the message "variable set but never used". Raise its prominence with `tclLsp.diagnosticSeverity.W211` (see [How to suppress](#how-to-suppress)).
 
 ## Example that triggers it
 
@@ -42,7 +42,22 @@ puts $result
 
 ## How to suppress
 
-Add `# noqa: W211` at the end of the offending line.
+Add `# noqa: W211` at the end of the offending line, or set
+`tclLsp.diagnostics.W211` to `false` to turn the check off entirely.
+
+## How to change its severity
+
+If the default hint is too subtle (or too loud), re-level it without disabling
+it. In VS Code settings:
+
+```json
+{ "tclLsp.diagnosticSeverity.W211": "warning" }
+```
+
+Accepted values are `"error"`, `"warning"`, `"information"`, and `"hint"` (the
+default). Any diagnostic code can be re-levelled with
+`tclLsp.diagnosticSeverity.<CODE>`; this changes only how the editor renders the
+diagnostic, never the analysis.
 
 ## Related
 

--- a/docs/kcs/features/kcs-feature-unused-variables.md
+++ b/docs/kcs/features/kcs-feature-unused-variables.md
@@ -16,7 +16,7 @@ all-editors, MCP, Claude skill, warning
 | Context | How |
 |---------|-----|
 | Any LSP editor | Hint-level diagnostics (faded text) on unused assignments and parameters |
-| VS Code settings | Toggle per-code via `tclLsp.diagnostics.W211`, `.W214`, `.W220` |
+| VS Code settings | Toggle per-code via `tclLsp.diagnostics.W211`, `.W214`, `.W220`; change how prominent each is via `tclLsp.diagnosticSeverity.W211` (etc.) |
 | MCP | `analyze` / `validate` tools include W211/W214/W220 in results |
 | Claude Code | `/irule-validate`, `/tcl-validate` |
 | Optimiser | O126 code action removes unused variable assignments; O109 removes dead stores |
@@ -24,6 +24,7 @@ all-editors, MCP, Claude skill, warning
 ## How to use
 
 - **Editor**: Unused variables appear as faded (hint-severity) diagnostics. Hover to see the message. Use the lightbulb quick-fix to apply O126 (remove unused variable) or O109 (remove dead store).
+- **Make them more prominent**: The default hint severity renders as a faint underline (the "three dots" some users find hard to spot). Raise it per code with `tclLsp.diagnosticSeverity.W211` set to `"warning"`, `"error"`, `"information"`, or `"hint"` (the default). This changes only how the editor displays the diagnostic — the analysis is unchanged. Any diagnostic code can be re-levelled the same way (`tclLsp.diagnosticSeverity.<CODE>`).
 - **Disable diagnostics per code**: Set `tclLsp.diagnostics.W211` to `false` to suppress unused-variable hints. Same for `W214` (parameters) and `W220` (dead stores).
 - **Disable the quick-fix code actions**: Set `tclLsp.optimiser.O126` to `false` to disable unused-variable removal, or `tclLsp.optimiser.O109` to `false` for dead-store removal. Disable the entire optimiser with `tclLsp.optimiser.enabled`.
 - **Suppress for a single variable**: Prefix the variable name with `_` (e.g., `set _unused [expr {1+1}]`). Variables starting with `_` are excluded from W211 and O126 checks.
@@ -201,26 +202,47 @@ The analysis uses the compiler's CFG/SSA intermediate representation to trace va
 
 O126 runs as a high-priority elimination pass (priority 10, higher than O109 at 8) so that unused-variable removals are preferred over dead-store removals when both apply to the same statement.
 
+## Tricky scopes are recognised, not flagged
+
+A variable can be *used* through a Tcl surface that single-file dataflow does
+not see in the same frame. These are recognised, so they never draw a false
+unused / read-before-set hint:
+
+- **`upvar` pass-by-reference** — `upvar 1 $varName local` (dynamic target) and
+  `upvar 1 caller local` (literal) are treated identically: reading the alias is
+  not read-before-set, and writing through it is not a dead store. This is the
+  standard accessor idiom (`upvar 1 $arrayName arr; return $arr($key)`) and no
+  longer fires (issue #941).
+- **Cross-scope globals** — a global assigned at the top level (`set cfg 1`) and
+  read only inside a proc (`global cfg; … $cfg`, or `$::cfg`) is used, not a
+  dead store; the reverse (a proc writing a global a top-level read consumes) is
+  suppressed too.
+- **Namespaces, `variable`, TclOO, traces, `eval`, `scan`/`regexp` out-vars,
+  `dict with`** — a namespace `variable` shared across procs, a TclOO instance
+  `variable` / `my variable`, a write-traced variable, a variable read inside an
+  inlined `eval` body, and names written by an out-var command are all counted
+  as uses.
+
 ## File-path anchors
 
-- `compiler/core_analyses.py` — `_unused_variables()`, `_unused_parameters()` analysis
-- `analyser/_analyser/_diag_var_lifecycle.py` — W211/W214 diagnostic emission
-- `compiler/optimiser/_elimination.py` — O126 unused variable removal, O109 dead store elimination
-- `compiler/optimiser/_types.py` — O126 priority in `_OPT_PRIORITY`
-- `compiler/connection_scope.py` — iRules cross-event variable tracking
+- `rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs` — `emit_unused_variable_diagnostics` (W211), `emit_dead_store_diagnostics` (W220), `emit_read_before_set_diagnostics` (W210)
+- `rust/tcl-compiler/src/analyser/diagnostics/helpers.rs` — `globals_written_by_procs` / `globals_read_by_procs` cross-scope global suppression, `build_undef_suppression`
+- `rust/tcl-compiler/src/optimiser/elimination.rs` — `scan_scope_aliases` (upvar/global/variable/trace aliasing), O126/O109 elimination
+- `rust/tcl-compiler/src/connection_scope.rs` — iRules cross-event variable tracking
+- `rust/tcl-lsp-server/src/lib.rs` — `settings_severity_overrides` / `apply_severity_overrides` (per-code severity override)
 
 ## Failure modes
 
-- False positive on a variable used via `upvar`, `uplevel`, or trace callbacks (mitigated by IRBarrier/IRCall exclusions).
-- W211 not emitted when variable appears used only in unreachable code — SCCP executable-block analysis handles this correctly.
+- W211 not emitted when a variable appears used only in unreachable code — SCCP executable-block analysis handles this correctly.
 - O126/O109 remove a `set` whose command substitution had side effects — only pure assignments are eligible for removal.
+- `uplevel 0 {…}` (evaluate in the *current* frame) is treated as a separate frame, so a variable used only inside its body may still be flagged. Rare; tracked as a residual (`uplevel #0` and `uplevel 1` correctly denote a different frame).
 
 ## Test anchors
 
-- `tests/test_upstream_var.py` — comprehensive W211/W210/W220 test suite
-- `tests/test_analyser.py` — W214 unused parameter tests
-- `tests/test_checks.py` — W211 cross-event variable suppression
-- `tests/test_optimiser.py` — O109/O126 elimination tests
+- `rust/tcl-compiler/tests/unused_var_tricky_features.rs` — TP/FP/TN suite across upvar, cross-scope globals, namespaces, TclOO, traces, `eval`, `args`, `::mathop`
+- `rust/tcl-compiler/tests/alias_scoping.rs` — upvar/global/variable aliasing lifecycle
+- `rust/tcl-compiler/src/analyser/diagnostics/fp/{rbs,ds}.rs` — FP precision catalogue for read-before-set / dead-store
+- `rust/tcl-compiler/tests/analyser.rs` — W214 unused parameter tests
 
 ## Discoverability
 

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3606,11 +3606,53 @@
             "markdownDescription": "**E001:** Missing dispatch word — e.g. bare `string` without a subcommand, or `$obj` with no TclOO method.",
             "order": 0
           },
+          "tclLsp.diagnosticSeverity.E001": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **E001:** Missing dispatch word — e.g. bare `string` without a subcommand, or `$obj` with no TclOO method.",
+            "order": 0
+          },
           "tclLsp.diagnostics.E002": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**E002:** Too few arguments for command.",
+            "order": 1
+          },
+          "tclLsp.diagnosticSeverity.E002": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **E002:** Too few arguments for command.",
             "order": 1
           },
           "tclLsp.diagnostics.E003": {
@@ -3620,6 +3662,27 @@
             "markdownDescription": "**E003:** Too many arguments for command.",
             "order": 2
           },
+          "tclLsp.diagnosticSeverity.E003": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **E003:** Too many arguments for command.",
+            "order": 2
+          },
           "tclLsp.diagnostics.E005": {
             "scope": "resource",
             "type": "boolean",
@@ -3627,11 +3690,53 @@
             "markdownDescription": "**E005:** Wrong argument-count shape for command — an in-range count that doesn't fit the command's key/value-pair or paired-argument pattern (e.g. an odd `dict create` tail, an unpaired `foreach` list, or a `switch` count matching neither its shorthand nor its pattern/body-pair form).",
             "order": 3
           },
+          "tclLsp.diagnosticSeverity.E005": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **E005:** Wrong argument-count shape for command — an in-range count that doesn't fit the command's key/value-pair or paired-argument pattern (e.g. an odd `dict create` tail, an unpaired `foreach` list, or a `switch` count matching neither its shorthand nor its pattern/body-pair form).",
+            "order": 3
+          },
           "tclLsp.diagnostics.E200": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**E200:** Unterminated command — the parser could not tell where it ends (missing `]` / `\"` / `}`).",
+            "order": 4
+          },
+          "tclLsp.diagnosticSeverity.E200": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **E200:** Unterminated command — the parser could not tell where it ends (missing `]` / `\"` / `}`).",
             "order": 4
           }
         }
@@ -3674,11 +3779,53 @@
             "markdownDescription": "**W001:** Unknown subcommand.",
             "order": 0
           },
+          "tclLsp.diagnosticSeverity.W001": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W001:** Unknown subcommand.",
+            "order": 0
+          },
           "tclLsp.diagnostics.W002": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W002:** Command is disabled in active dialect profile.",
+            "order": 1
+          },
+          "tclLsp.diagnosticSeverity.W002": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W002:** Command is disabled in active dialect profile.",
             "order": 1
           },
           "tclLsp.diagnostics.W003": {
@@ -3688,11 +3835,53 @@
             "markdownDescription": "**W003:** Expression operator not available in active dialect.",
             "order": 2
           },
+          "tclLsp.diagnosticSeverity.W003": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W003:** Expression operator not available in active dialect.",
+            "order": 2
+          },
           "tclLsp.diagnostics.W004": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W004:** Command option is not available in the active dialect.",
+            "order": 3
+          },
+          "tclLsp.diagnosticSeverity.W004": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W004:** Command option is not available in the active dialect.",
             "order": 3
           },
           "tclLsp.diagnostics.W100": {
@@ -3702,11 +3891,53 @@
             "markdownDescription": "**W100:** Unbraced expression argument — prevents byte-compilation and risks double substitution. Escalates to Error when the argument provably contains a substitution.",
             "order": 4
           },
+          "tclLsp.diagnosticSeverity.W100": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W100:** Unbraced expression argument — prevents byte-compilation and risks double substitution. Escalates to Error when the argument provably contains a substitution.",
+            "order": 4
+          },
           "tclLsp.diagnostics.W104": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W104:** String concatenation for list building — use `lappend` instead.",
+            "order": 5
+          },
+          "tclLsp.diagnosticSeverity.W104": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W104:** String concatenation for list building — use `lappend` instead.",
             "order": 5
           },
           "tclLsp.diagnostics.W105": {
@@ -3716,11 +3947,53 @@
             "markdownDescription": "**W105:** Unbraced code block or missing `variable` declaration in `namespace eval`. Escalates to Error when the block provably contains a substitution (double-substitution risk).",
             "order": 6
           },
+          "tclLsp.diagnosticSeverity.W105": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W105:** Unbraced code block or missing `variable` declaration in `namespace eval`. Escalates to Error when the block provably contains a substitution (double-substitution risk).",
+            "order": 6
+          },
           "tclLsp.diagnostics.W106": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W106:** Dangerous unbraced `switch` body — risks double substitution.",
+            "order": 7
+          },
+          "tclLsp.diagnosticSeverity.W106": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W106:** Dangerous unbraced `switch` body — risks double substitution.",
             "order": 7
           },
           "tclLsp.diagnostics.W108": {
@@ -3730,11 +4003,53 @@
             "markdownDescription": "**W108:** Non-ASCII characters in token content.",
             "order": 8
           },
+          "tclLsp.diagnosticSeverity.W108": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W108:** Non-ASCII characters in token content.",
+            "order": 8
+          },
           "tclLsp.diagnostics.W110": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W110:** Use `eq`/`ne` instead of `==`/`!=` for string comparison.",
+            "order": 9
+          },
+          "tclLsp.diagnosticSeverity.W110": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W110:** Use `eq`/`ne` instead of `==`/`!=` for string comparison.",
             "order": 9
           },
           "tclLsp.diagnostics.W111": {
@@ -3744,11 +4059,53 @@
             "markdownDescription": "**W111:** Line exceeds maximum length (see `tclLsp.style.lineLength`).",
             "order": 10
           },
+          "tclLsp.diagnosticSeverity.W111": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W111:** Line exceeds maximum length (see `tclLsp.style.lineLength`).",
+            "order": 10
+          },
           "tclLsp.diagnostics.W112": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W112:** Trailing whitespace.",
+            "order": 11
+          },
+          "tclLsp.diagnosticSeverity.W112": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W112:** Trailing whitespace.",
             "order": 11
           },
           "tclLsp.diagnostics.W113": {
@@ -3758,11 +4115,53 @@
             "markdownDescription": "**W113:** Procedure shadows built-in command.",
             "order": 12
           },
+          "tclLsp.diagnosticSeverity.W113": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W113:** Procedure shadows built-in command.",
+            "order": 12
+          },
           "tclLsp.diagnostics.W114": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W114:** Redundant nested `[expr {...}]` — already in expression context.",
+            "order": 13
+          },
+          "tclLsp.diagnosticSeverity.W114": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W114:** Redundant nested `[expr {...}]` — already in expression context.",
             "order": 13
           },
           "tclLsp.diagnostics.W115": {
@@ -3772,11 +4171,53 @@
             "markdownDescription": "**W115:** Backslash-newline in comment silently swallows the next line.",
             "order": 14
           },
+          "tclLsp.diagnosticSeverity.W115": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W115:** Backslash-newline in comment silently swallows the next line.",
+            "order": 14
+          },
           "tclLsp.diagnostics.W116": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W116:** Stub command shadows built-in command.",
+            "order": 15
+          },
+          "tclLsp.diagnosticSeverity.W116": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W116:** Stub command shadows built-in command.",
             "order": 15
           },
           "tclLsp.diagnostics.W117": {
@@ -3786,11 +4227,53 @@
             "markdownDescription": "**W117:** Stub expression definition shadows built-in function or operator.",
             "order": 16
           },
+          "tclLsp.diagnosticSeverity.W117": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W117:** Stub expression definition shadows built-in function or operator.",
+            "order": 16
+          },
           "tclLsp.diagnostics.W118": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W118:** Inconsistent line endings.",
+            "order": 17
+          },
+          "tclLsp.diagnosticSeverity.W118": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W118:** Inconsistent line endings.",
             "order": 17
           },
           "tclLsp.diagnostics.W120": {
@@ -3800,11 +4283,53 @@
             "markdownDescription": "**W120:** Command used without a corresponding `package require`.",
             "order": 18
           },
+          "tclLsp.diagnosticSeverity.W120": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W120:** Command used without a corresponding `package require`.",
+            "order": 18
+          },
           "tclLsp.diagnostics.W121": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W121:** Subnet mask has non-contiguous bits.",
+            "order": 19
+          },
+          "tclLsp.diagnosticSeverity.W121": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W121:** Subnet mask has non-contiguous bits.",
             "order": 19
           },
           "tclLsp.diagnostics.W122": {
@@ -3814,11 +4339,53 @@
             "markdownDescription": "**W122:** Mistyped IPv4 address (octet > 255 or leading zero).",
             "order": 20
           },
+          "tclLsp.diagnosticSeverity.W122": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W122:** Mistyped IPv4 address (octet > 255 or leading zero).",
+            "order": 20
+          },
           "tclLsp.diagnostics.W124": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W124:** Invalid IP address literal.",
+            "order": 21
+          },
+          "tclLsp.diagnosticSeverity.W124": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W124:** Invalid IP address literal.",
             "order": 21
           },
           "tclLsp.diagnostics.W125": {
@@ -3828,11 +4395,53 @@
             "markdownDescription": "**W125:** Orphaned control-flow keyword used as standalone command.",
             "order": 22
           },
+          "tclLsp.diagnosticSeverity.W125": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W125:** Orphaned control-flow keyword used as standalone command.",
+            "order": 22
+          },
           "tclLsp.diagnostics.W126": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W126:** Non-channel value in channel argument position.",
+            "order": 23
+          },
+          "tclLsp.diagnosticSeverity.W126": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W126:** Non-channel value in channel argument position.",
             "order": 23
           },
           "tclLsp.diagnostics.W127": {
@@ -3842,11 +4451,53 @@
             "markdownDescription": "**W127:** Value not in the command's allowed set.",
             "order": 24
           },
+          "tclLsp.diagnosticSeverity.W127": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W127:** Value not in the command's allowed set.",
+            "order": 24
+          },
           "tclLsp.diagnostics.W128": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W128:** Command called after it was renamed or deleted earlier in this file; the call falls through to the `unknown` handler.",
+            "order": 25
+          },
+          "tclLsp.diagnosticSeverity.W128": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W128:** Command called after it was renamed or deleted earlier in this file; the call falls through to the `unknown` handler.",
             "order": 25
           },
           "tclLsp.diagnostics.W135": {
@@ -3856,11 +4507,53 @@
             "markdownDescription": "**W135:** Command requires a newer package version than the resolved `package require`.",
             "order": 26
           },
+          "tclLsp.diagnosticSeverity.W135": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W135:** Command requires a newer package version than the resolved `package require`.",
+            "order": 26
+          },
           "tclLsp.diagnostics.W136": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W136:** Option requires a newer package version than the resolved `package require`.",
+            "order": 27
+          },
+          "tclLsp.diagnosticSeverity.W136": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W136:** Option requires a newer package version than the resolved `package require`.",
             "order": 27
           },
           "tclLsp.diagnostics.W137": {
@@ -3870,11 +4563,53 @@
             "markdownDescription": "**W137:** Argument value requires a newer Tcl version than the dialect provides.",
             "order": 28
           },
+          "tclLsp.diagnosticSeverity.W137": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W137:** Argument value requires a newer Tcl version than the dialect provides.",
+            "order": 28
+          },
           "tclLsp.diagnostics.W138": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W138:** Format/scan conversion requires a newer Tcl version than the dialect provides.",
+            "order": 29
+          },
+          "tclLsp.diagnosticSeverity.W138": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W138:** Format/scan conversion requires a newer Tcl version than the dialect provides.",
             "order": 29
           },
           "tclLsp.diagnostics.W139": {
@@ -3884,11 +4619,53 @@
             "markdownDescription": "**W139:** Command/option removed at the resolved package version (present only in earlier releases).",
             "order": 30
           },
+          "tclLsp.diagnosticSeverity.W139": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W139:** Command/option removed at the resolved package version (present only in earlier releases).",
+            "order": 30
+          },
           "tclLsp.diagnostics.W200": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W200:** `exec` result not captured or binary format modifier requires newer Tcl.",
+            "order": 31
+          },
+          "tclLsp.diagnosticSeverity.W200": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W200:** `exec` result not captured or binary format modifier requires newer Tcl.",
             "order": 31
           },
           "tclLsp.diagnostics.W201": {
@@ -3898,11 +4675,53 @@
             "markdownDescription": "**W201:** Manual path concatenation — use `file join` instead.",
             "order": 32
           },
+          "tclLsp.diagnosticSeverity.W201": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W201:** Manual path concatenation — use `file join` instead.",
+            "order": 32
+          },
           "tclLsp.diagnostics.W230": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W230:** Constant list index out of range — lindex/lrange/lreplace silently return empty or clamp.",
+            "order": 33
+          },
+          "tclLsp.diagnosticSeverity.W230": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W230:** Constant list index out of range — lindex/lrange/lreplace silently return empty or clamp.",
             "order": 33
           },
           "tclLsp.diagnostics.W231": {
@@ -3912,11 +4731,53 @@
             "markdownDescription": "**W231:** Constant list index out of range — lset raises a runtime error.",
             "order": 34
           },
+          "tclLsp.diagnosticSeverity.W231": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W231:** Constant list index out of range — lset raises a runtime error.",
+            "order": 34
+          },
           "tclLsp.diagnostics.W232": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W232:** Constant string index out of range — string index/range/replace/insert silently return empty or no-op.",
+            "order": 35
+          },
+          "tclLsp.diagnosticSeverity.W232": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W232:** Constant string index out of range — string index/range/replace/insert silently return empty or no-op.",
             "order": 35
           },
           "tclLsp.diagnostics.W233": {
@@ -3926,11 +4787,53 @@
             "markdownDescription": "**W233:** Division or modulo by a provably-zero divisor — raises 'divide by zero' at runtime.",
             "order": 36
           },
+          "tclLsp.diagnosticSeverity.W233": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W233:** Division or modulo by a provably-zero divisor — raises 'divide by zero' at runtime.",
+            "order": 36
+          },
           "tclLsp.diagnostics.W240": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W240:** Loop condition is a constant false — body never executes.",
+            "order": 37
+          },
+          "tclLsp.diagnosticSeverity.W240": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W240:** Loop condition is a constant false — body never executes.",
             "order": 37
           },
           "tclLsp.diagnostics.W241": {
@@ -3940,11 +4843,53 @@
             "markdownDescription": "**W241:** Loop is provably infinite — constant-true condition with no break/return, zero/wrong-direction counter step.",
             "order": 38
           },
+          "tclLsp.diagnosticSeverity.W241": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W241:** Loop is provably infinite — constant-true condition with no break/return, zero/wrong-direction counter step.",
+            "order": 38
+          },
           "tclLsp.diagnostics.W250": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W250:** Instantiating an `oo::abstract` class — abstract classes cannot be created directly; use a concrete subclass.",
+            "order": 39
+          },
+          "tclLsp.diagnosticSeverity.W250": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W250:** Instantiating an `oo::abstract` class — abstract classes cannot be created directly; use a concrete subclass.",
             "order": 39
           },
           "tclLsp.diagnostics.W308": {
@@ -3954,11 +4899,53 @@
             "markdownDescription": "**W308:** Unknown TclOO method — the method is not defined on the receiver's statically-known class or any of its superclasses.",
             "order": 40
           },
+          "tclLsp.diagnosticSeverity.W308": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W308:** Unknown TclOO method — the method is not defined on the receiver's statically-known class or any of its superclasses.",
+            "order": 40
+          },
           "tclLsp.diagnostics.W314": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W314:** Definition has no absolute (fully-qualified) name — an all-colon name or namespace segment (e.g. a proc or namespace named `:`) is reachable only by relative lookup.",
+            "order": 41
+          },
+          "tclLsp.diagnosticSeverity.W314": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W314:** Definition has no absolute (fully-qualified) name — an all-colon name or namespace segment (e.g. a proc or namespace named `:`) is reachable only by relative lookup.",
             "order": 41
           }
         }
@@ -3974,11 +4961,53 @@
             "markdownDescription": "**W210:** Variable read before set.",
             "order": 0
           },
+          "tclLsp.diagnosticSeverity.W210": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W210:** Variable read before set.",
+            "order": 0
+          },
           "tclLsp.diagnostics.W211": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W211:** Variable set but never used.",
+            "order": 1
+          },
+          "tclLsp.diagnosticSeverity.W211": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W211:** Variable set but never used.",
             "order": 1
           },
           "tclLsp.diagnostics.W212": {
@@ -3988,11 +5017,53 @@
             "markdownDescription": "**W212:** Variable substitution where name expected (`set $x`, `incr $x`, `info exists $x`, etc.).",
             "order": 2
           },
+          "tclLsp.diagnosticSeverity.W212": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W212:** Variable substitution where name expected (`set $x`, `incr $x`, `info exists $x`, etc.).",
+            "order": 2
+          },
           "tclLsp.diagnostics.W213": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W213:** Variable may not exist — use `unset -nocomplain` to suppress the error.",
+            "order": 3
+          },
+          "tclLsp.diagnosticSeverity.W213": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W213:** Variable may not exist — use `unset -nocomplain` to suppress the error.",
             "order": 3
           },
           "tclLsp.diagnostics.W214": {
@@ -4002,11 +5073,53 @@
             "markdownDescription": "**W214:** Unused proc parameter — argument is declared but never read in the procedure body.",
             "order": 4
           },
+          "tclLsp.diagnosticSeverity.W214": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W214:** Unused proc parameter — argument is declared but never read in the procedure body.",
+            "order": 4
+          },
           "tclLsp.diagnostics.W215": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W215:** Variable name unreachable via $-substitution (creatable via set/info exists/upvar but no $-form can read it).",
+            "order": 5
+          },
+          "tclLsp.diagnosticSeverity.W215": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W215:** Variable name unreachable via $-substitution (creatable via set/info exists/upvar but no $-form can read it).",
             "order": 5
           },
           "tclLsp.diagnostics.W216": {
@@ -4016,11 +5129,53 @@
             "markdownDescription": "**W216:** Broken brace-form array element reference — ``${arr}(x)`` parses as scalar+literal, ``${arr($foo)}`` does not substitute the index.",
             "order": 6
           },
+          "tclLsp.diagnosticSeverity.W216": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W216:** Broken brace-form array element reference — ``${arr}(x)`` parses as scalar+literal, ``${arr($foo)}`` does not substitute the index.",
+            "order": 6
+          },
           "tclLsp.diagnostics.W217": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W217:** `unset` unsets nothing — every argument is consumed as an option (`-nocomplain` / `--`); prefix a `-`-named variable with `--`.",
+            "order": 7
+          },
+          "tclLsp.diagnosticSeverity.W217": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W217:** `unset` unsets nothing — every argument is consumed as an option (`-nocomplain` / `--`); prefix a `-`-named variable with `--`.",
             "order": 7
           },
           "tclLsp.diagnostics.W218": {
@@ -4030,11 +5185,53 @@
             "markdownDescription": "**W218:** `args` in a non-final parameter position is an ordinary parameter — it only collects the rest as the last formal.",
             "order": 8
           },
+          "tclLsp.diagnosticSeverity.W218": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W218:** `args` in a non-final parameter position is an ordinary parameter — it only collects the rest as the last formal.",
+            "order": 8
+          },
           "tclLsp.diagnostics.W220": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W220:** Dead store — variable set but overwritten before use.",
+            "order": 9
+          },
+          "tclLsp.diagnosticSeverity.W220": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W220:** Dead store — variable set but overwritten before use.",
             "order": 9
           }
         }
@@ -4050,11 +5247,53 @@
             "markdownDescription": "**W101:** `eval` with string concatenation — code injection risk.",
             "order": 0
           },
+          "tclLsp.diagnosticSeverity.W101": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W101:** `eval` with string concatenation — code injection risk.",
+            "order": 0
+          },
           "tclLsp.diagnostics.W102": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W102:** `subst` on variable input — code injection risk.",
+            "order": 1
+          },
+          "tclLsp.diagnosticSeverity.W102": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W102:** `subst` on variable input — code injection risk.",
             "order": 1
           },
           "tclLsp.diagnostics.W103": {
@@ -4064,11 +5303,53 @@
             "markdownDescription": "**W103:** `open` with pipeline `|` — command injection risk.",
             "order": 2
           },
+          "tclLsp.diagnosticSeverity.W103": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W103:** `open` with pipeline `|` — command injection risk.",
+            "order": 2
+          },
           "tclLsp.diagnostics.W300": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W300:** `source` with variable argument — code execution risk.",
+            "order": 3
+          },
+          "tclLsp.diagnosticSeverity.W300": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W300:** `source` with variable argument — code execution risk.",
             "order": 3
           },
           "tclLsp.diagnostics.W301": {
@@ -4078,11 +5359,53 @@
             "markdownDescription": "**W301:** `uplevel` with string-built script — injection risk.",
             "order": 4
           },
+          "tclLsp.diagnosticSeverity.W301": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W301:** `uplevel` with string-built script — injection risk.",
+            "order": 4
+          },
           "tclLsp.diagnostics.W302": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W302:** `catch` without result variable — errors are silently swallowed.",
+            "order": 5
+          },
+          "tclLsp.diagnosticSeverity.W302": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W302:** `catch` without result variable — errors are silently swallowed.",
             "order": 5
           },
           "tclLsp.diagnostics.W303": {
@@ -4092,11 +5415,53 @@
             "markdownDescription": "**W303:** Regexp vulnerable to catastrophic backtracking (ReDoS).",
             "order": 6
           },
+          "tclLsp.diagnosticSeverity.W303": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W303:** Regexp vulnerable to catastrophic backtracking (ReDoS).",
+            "order": 6
+          },
           "tclLsp.diagnostics.W304": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W304:** Missing option terminator `--` on option-bearing commands.",
+            "order": 7
+          },
+          "tclLsp.diagnosticSeverity.W304": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W304:** Missing option terminator `--` on option-bearing commands.",
             "order": 7
           },
           "tclLsp.diagnostics.W306": {
@@ -4106,11 +5471,53 @@
             "markdownDescription": "**W306:** Substitution in literal-expected argument position.",
             "order": 8
           },
+          "tclLsp.diagnosticSeverity.W306": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W306:** Substitution in literal-expected argument position.",
+            "order": 8
+          },
           "tclLsp.diagnostics.W307": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W307:** Non-literal command name — variable or command substitution as command.",
+            "order": 9
+          },
+          "tclLsp.diagnosticSeverity.W307": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W307:** Non-literal command name — variable or command substitution as command.",
             "order": 9
           },
           "tclLsp.diagnostics.W309": {
@@ -4120,11 +5527,53 @@
             "markdownDescription": "**W309:** `eval`/`uplevel` with `subst` — double substitution risk.",
             "order": 10
           },
+          "tclLsp.diagnosticSeverity.W309": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W309:** `eval`/`uplevel` with `subst` — double substitution risk.",
+            "order": 10
+          },
           "tclLsp.diagnostics.W313": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W313:** Destructive file operation with variable path — path-traversal risk.",
+            "order": 11
+          },
+          "tclLsp.diagnosticSeverity.W313": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W313:** Destructive file operation with variable path — path-traversal risk.",
             "order": 11
           }
         }
@@ -4140,11 +5589,53 @@
             "markdownDescription": "**H300:** Possible paste error — repeated assignment to same variable with same value.",
             "order": 0
           },
+          "tclLsp.diagnosticSeverity.H300": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **H300:** Possible paste error — repeated assignment to same variable with same value.",
+            "order": 0
+          },
           "tclLsp.diagnostics.I230": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**I230:** Constant branch condition — the alternate branch is provably unreachable.",
+            "order": 1
+          },
+          "tclLsp.diagnosticSeverity.I230": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **I230:** Constant branch condition — the alternate branch is provably unreachable.",
             "order": 1
           },
           "tclLsp.diagnostics.I231": {
@@ -4154,6 +5645,27 @@
             "markdownDescription": "**I231:** Constant switch arm condition — the arm is provably unreachable.",
             "order": 2
           },
+          "tclLsp.diagnosticSeverity.I231": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **I231:** Constant switch arm condition — the arm is provably unreachable.",
+            "order": 2
+          },
           "tclLsp.diagnostics.W123": {
             "scope": "resource",
             "type": "boolean",
@@ -4161,11 +5673,53 @@
             "markdownDescription": "**W123:** Unresolved command — not found in registry, user procs, or `unknown` handler.",
             "order": 3
           },
+          "tclLsp.diagnosticSeverity.W123": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W123:** Unresolved command — not found in registry, user procs, or `unknown` handler.",
+            "order": 3
+          },
           "tclLsp.diagnostics.W242": {
             "scope": "resource",
             "type": "boolean",
             "default": false,
             "markdownDescription": "**W242:** Loop termination cannot be proven — counter not provably modified by the loop body or step.",
+            "order": 4
+          },
+          "tclLsp.diagnosticSeverity.W242": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W242:** Loop termination cannot be proven — counter not provably modified by the loop body or step.",
             "order": 4
           }
         }
@@ -4188,11 +5742,53 @@
             "markdownDescription": "**S100:** Single shimmer outside a loop — object internal representation changed.",
             "order": 0
           },
+          "tclLsp.diagnosticSeverity.S100": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **S100:** Single shimmer outside a loop — object internal representation changed.",
+            "order": 0
+          },
           "tclLsp.diagnostics.S101": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**S101:** Shimmer inside a loop body — per-iteration representation conversion cost.",
+            "order": 1
+          },
+          "tclLsp.diagnosticSeverity.S101": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **S101:** Shimmer inside a loop body — per-iteration representation conversion cost.",
             "order": 1
           },
           "tclLsp.diagnostics.S102": {
@@ -4202,6 +5798,27 @@
             "markdownDescription": "**S102:** Variable oscillates between two types across loop iterations.",
             "order": 2
           },
+          "tclLsp.diagnosticSeverity.S102": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **S102:** Variable oscillates between two types across loop iterations.",
+            "order": 2
+          },
           "tclLsp.diagnostics.S103": {
             "scope": "resource",
             "type": "boolean",
@@ -4209,11 +5826,53 @@
             "markdownDescription": "**S103:** Mutation of a potentially shared value copies it — Tcl duplicates a shared value before a `lappend`/`lset`/`dict` write.",
             "order": 3
           },
+          "tclLsp.diagnosticSeverity.S103": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **S103:** Mutation of a potentially shared value copies it — Tcl duplicates a shared value before a `lappend`/`lset`/`dict` write.",
+            "order": 3
+          },
           "tclLsp.diagnostics.S110": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**S110:** Byte-array value coerced to a string by a string operation — binary representation corrupted.",
+            "order": 4
+          },
+          "tclLsp.diagnosticSeverity.S110": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **S110:** Byte-array value coerced to a string by a string operation — binary representation corrupted.",
             "order": 4
           }
         }
@@ -4229,11 +5888,53 @@
             "markdownDescription": "**T100:** Tainted data flows into a dangerous sink: `eval`/`uplevel`/`subst`/unbraced-`expr`/`exec` (code-execution); braced `expr` operands (numeric/type-coercion).",
             "order": 0
           },
+          "tclLsp.diagnosticSeverity.T100": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **T100:** Tainted data flows into a dangerous sink: `eval`/`uplevel`/`subst`/unbraced-`expr`/`exec` (code-execution); braced `expr` operands (numeric/type-coercion).",
+            "order": 0
+          },
           "tclLsp.diagnostics.T101": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**T101:** Tainted data flows into an output command (`puts`).",
+            "order": 1
+          },
+          "tclLsp.diagnosticSeverity.T101": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **T101:** Tainted data flows into an output command (`puts`).",
             "order": 1
           },
           "tclLsp.diagnostics.T102": {
@@ -4243,6 +5944,27 @@
             "markdownDescription": "**T102:** Tainted data in option position without `--` terminator — option injection risk.",
             "order": 2
           },
+          "tclLsp.diagnosticSeverity.T102": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **T102:** Tainted data in option position without `--` terminator — option injection risk.",
+            "order": 2
+          },
           "tclLsp.diagnostics.T104": {
             "scope": "resource",
             "type": "boolean",
@@ -4250,11 +5972,53 @@
             "markdownDescription": "**T104:** Tainted data in a network-address argument (e.g. `socket`) — SSRF risk.",
             "order": 3
           },
+          "tclLsp.diagnosticSeverity.T104": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **T104:** Tainted data in a network-address argument (e.g. `socket`) — SSRF risk.",
+            "order": 3
+          },
           "tclLsp.diagnostics.T105": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**T105:** Tainted data in a cross-interpreter eval subcommand (`interp eval`/`invokehidden`) — code-execution risk.",
+            "order": 4
+          },
+          "tclLsp.diagnosticSeverity.T105": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **T105:** Tainted data in a cross-interpreter eval subcommand (`interp eval`/`invokehidden`) — code-execution risk.",
             "order": 4
           }
         }
@@ -4270,11 +6034,53 @@
             "markdownDescription": "**IRULE1001:** Command invalid or ineffective in this iRules event.",
             "order": 0
           },
+          "tclLsp.diagnosticSeverity.IRULE1001": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE1001:** Command invalid or ineffective in this iRules event.",
+            "order": 0
+          },
           "tclLsp.diagnostics.IRULE1002": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1002:** Unknown iRules event name.",
+            "order": 1
+          },
+          "tclLsp.diagnosticSeverity.IRULE1002": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE1002:** Unknown iRules event name.",
             "order": 1
           },
           "tclLsp.diagnostics.IRULE1003": {
@@ -4284,11 +6090,53 @@
             "markdownDescription": "**IRULE1003:** Deprecated iRules event.",
             "order": 2
           },
+          "tclLsp.diagnosticSeverity.IRULE1003": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE1003:** Deprecated iRules event.",
+            "order": 2
+          },
           "tclLsp.diagnostics.IRULE1004": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1004:** `when` block missing explicit `priority`.",
+            "order": 3
+          },
+          "tclLsp.diagnosticSeverity.IRULE1004": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE1004:** `when` block missing explicit `priority`.",
             "order": 3
           },
           "tclLsp.diagnostics.IRULE1005": {
@@ -4298,11 +6146,53 @@
             "markdownDescription": "**IRULE1005:** Data event without a matching `*::collect` call.",
             "order": 4
           },
+          "tclLsp.diagnosticSeverity.IRULE1005": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE1005:** Data event without a matching `*::collect` call.",
+            "order": 4
+          },
           "tclLsp.diagnostics.IRULE1006": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1006:** `*::payload` without a matching `*::collect` call.",
+            "order": 5
+          },
+          "tclLsp.diagnosticSeverity.IRULE1006": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE1006:** `*::payload` without a matching `*::collect` call.",
             "order": 5
           },
           "tclLsp.diagnostics.IRULE1007": {
@@ -4312,11 +6202,53 @@
             "markdownDescription": "**IRULE1007:** `*::collect` without a matching `*::release` on the same connection side.",
             "order": 6
           },
+          "tclLsp.diagnosticSeverity.IRULE1007": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE1007:** `*::collect` without a matching `*::release` on the same connection side.",
+            "order": 6
+          },
           "tclLsp.diagnostics.IRULE1008": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1008:** `*::release` without a matching `*::collect` on the same connection side.",
+            "order": 7
+          },
+          "tclLsp.diagnosticSeverity.IRULE1008": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE1008:** `*::release` without a matching `*::collect` on the same connection side.",
             "order": 7
           },
           "tclLsp.diagnostics.IRULE1201": {
@@ -4326,11 +6258,53 @@
             "markdownDescription": "**IRULE1201:** HTTP command used after `HTTP::respond`/`HTTP::redirect`.",
             "order": 8
           },
+          "tclLsp.diagnosticSeverity.IRULE1201": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE1201:** HTTP command used after `HTTP::respond`/`HTTP::redirect`.",
+            "order": 8
+          },
           "tclLsp.diagnostics.IRULE1202": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE1202:** Multiple `HTTP::respond`/`HTTP::redirect` on different branches.",
+            "order": 9
+          },
+          "tclLsp.diagnosticSeverity.IRULE1202": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE1202:** Multiple `HTTP::respond`/`HTTP::redirect` on different branches.",
             "order": 9
           },
           "tclLsp.diagnostics.IRULE2001": {
@@ -4340,11 +6314,53 @@
             "markdownDescription": "**IRULE2001:** Deprecated `matchclass` — use `class match` instead.",
             "order": 10
           },
+          "tclLsp.diagnosticSeverity.IRULE2001": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE2001:** Deprecated `matchclass` — use `class match` instead.",
+            "order": 10
+          },
           "tclLsp.diagnostics.IRULE2002": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE2002:** Deprecated iRules command.",
+            "order": 11
+          },
+          "tclLsp.diagnosticSeverity.IRULE2002": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE2002:** Deprecated iRules command.",
             "order": 11
           },
           "tclLsp.diagnostics.IRULE2003": {
@@ -4354,11 +6370,53 @@
             "markdownDescription": "**IRULE2003:** Unsafe iRules command.",
             "order": 12
           },
+          "tclLsp.diagnosticSeverity.IRULE2003": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE2003:** Unsafe iRules command.",
+            "order": 12
+          },
           "tclLsp.diagnostics.IRULE2101": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE2101:** Heavy `regexp` in a high-frequency event — consider `string match` or data-group.",
+            "order": 13
+          },
+          "tclLsp.diagnosticSeverity.IRULE2101": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE2101:** Heavy `regexp` in a high-frequency event — consider `string match` or data-group.",
             "order": 13
           },
           "tclLsp.diagnostics.IRULE5001": {
@@ -4368,11 +6426,53 @@
             "markdownDescription": "**IRULE5001:** Ungated `log` in a high-frequency event.",
             "order": 14
           },
+          "tclLsp.diagnosticSeverity.IRULE5001": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE5001:** Ungated `log` in a high-frequency event.",
+            "order": 14
+          },
           "tclLsp.diagnostics.IRULE5002": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE5002:** `drop`/`reject`/`discard` without `event disable all` or `return`.",
+            "order": 15
+          },
+          "tclLsp.diagnosticSeverity.IRULE5002": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE5002:** `drop`/`reject`/`discard` without `event disable all` or `return`.",
             "order": 15
           },
           "tclLsp.diagnostics.IRULE5004": {
@@ -4382,11 +6482,53 @@
             "markdownDescription": "**IRULE5004:** `DNS::return` without `return`.",
             "order": 16
           },
+          "tclLsp.diagnosticSeverity.IRULE5004": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE5004:** `DNS::return` without `return`.",
+            "order": 16
+          },
           "tclLsp.diagnostics.IRULE5005": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE5005:** Direct proc invocation without `call` — use `call proc_name`.",
+            "order": 17
+          },
+          "tclLsp.diagnosticSeverity.IRULE5005": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE5005:** Direct proc invocation without `call` — use `call proc_name`.",
             "order": 17
           },
           "tclLsp.diagnostics.IRULE5006": {
@@ -4396,11 +6538,53 @@
             "markdownDescription": "**IRULE5006:** Top-level-only command used inside a nested body.",
             "order": 18
           },
+          "tclLsp.diagnosticSeverity.IRULE5006": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE5006:** Top-level-only command used inside a nested body.",
+            "order": 18
+          },
           "tclLsp.diagnostics.IRULE5007": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE5007:** Event-context command used at top level outside a `when` block.",
+            "order": 19
+          },
+          "tclLsp.diagnosticSeverity.IRULE5007": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE5007:** Event-context command used at top level outside a `when` block.",
             "order": 19
           },
           "tclLsp.diagnostics.IRULE3001": {
@@ -4410,11 +6594,53 @@
             "markdownDescription": "**IRULE3001:** Tainted data in HTTP response body.",
             "order": 20
           },
+          "tclLsp.diagnosticSeverity.IRULE3001": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE3001:** Tainted data in HTTP response body.",
+            "order": 20
+          },
           "tclLsp.diagnostics.IRULE3002": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE3002:** Tainted data in HTTP header or cookie value.",
+            "order": 21
+          },
+          "tclLsp.diagnosticSeverity.IRULE3002": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE3002:** Tainted data in HTTP header or cookie value.",
             "order": 21
           },
           "tclLsp.diagnostics.IRULE3003": {
@@ -4424,11 +6650,53 @@
             "markdownDescription": "**IRULE3003:** Tainted data in `log` command — log injection risk.",
             "order": 22
           },
+          "tclLsp.diagnosticSeverity.IRULE3003": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE3003:** Tainted data in `log` command — log injection risk.",
+            "order": 22
+          },
           "tclLsp.diagnostics.IRULE3004": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE3004:** Tainted data in an `HTTP::redirect` URL — open-redirect risk.",
+            "order": 23
+          },
+          "tclLsp.diagnosticSeverity.IRULE3004": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE3004:** Tainted data in an `HTTP::redirect` URL — open-redirect risk.",
             "order": 23
           },
           "tclLsp.diagnostics.IRULE3101": {
@@ -4438,11 +6706,53 @@
             "markdownDescription": "**IRULE3101:** `HTTP::uri`/`HTTP::path` set to value not provably starting with `/`.",
             "order": 24
           },
+          "tclLsp.diagnosticSeverity.IRULE3101": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE3101:** `HTTP::uri`/`HTTP::path` set to value not provably starting with `/`.",
+            "order": 24
+          },
           "tclLsp.diagnostics.IRULE3102": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE3102:** `HTTP::path`/`HTTP::uri`/`HTTP::query` getter used without `-normalized`.",
+            "order": 25
+          },
+          "tclLsp.diagnosticSeverity.IRULE3102": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE3102:** `HTTP::path`/`HTTP::uri`/`HTTP::query` getter used without `-normalized`.",
             "order": 25
           },
           "tclLsp.diagnostics.IRULE4001": {
@@ -4452,11 +6762,53 @@
             "markdownDescription": "**IRULE4001:** Write to `static::` variable outside `RULE_INIT`.",
             "order": 26
           },
+          "tclLsp.diagnosticSeverity.IRULE4001": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE4001:** Write to `static::` variable outside `RULE_INIT`.",
+            "order": 26
+          },
           "tclLsp.diagnostics.IRULE4002": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE4002:** Generic `static::` variable name — collision likely across iRules.",
+            "order": 27
+          },
+          "tclLsp.diagnosticSeverity.IRULE4002": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE4002:** Generic `static::` variable name — collision likely across iRules.",
             "order": 27
           },
           "tclLsp.diagnostics.IRULE4003": {
@@ -4466,6 +6818,27 @@
             "markdownDescription": "**IRULE4003:** Variable scoping concern across events.",
             "order": 28
           },
+          "tclLsp.diagnosticSeverity.IRULE4003": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE4003:** Variable scoping concern across events.",
+            "order": 28
+          },
           "tclLsp.diagnostics.IRULE4004": {
             "scope": "resource",
             "type": "boolean",
@@ -4473,11 +6846,53 @@
             "markdownDescription": "**IRULE4004:** Constant `set` in per-request event could be hoisted to an earlier once-per-connection event.",
             "order": 29
           },
+          "tclLsp.diagnosticSeverity.IRULE4004": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE4004:** Constant `set` in per-request event could be hoisted to an earlier once-per-connection event.",
+            "order": 29
+          },
           "tclLsp.diagnostics.IRULE4005": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**IRULE4005:** Potential race — `static::` variable written outside `RULE_INIT` and read in another event.",
+            "order": 30
+          },
+          "tclLsp.diagnosticSeverity.IRULE4005": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **IRULE4005:** Potential race — `static::` variable written outside `RULE_INIT` and read in another event.",
             "order": 30
           },
           "tclLsp.diagnostics.genericVariablePatterns": {
@@ -4503,11 +6918,53 @@
             "markdownDescription": "**W130:** tclpkg.tcl requires package but it is not in tclpkg.lock — run 'tcl pkg install'.",
             "order": 0
           },
+          "tclLsp.diagnosticSeverity.W130": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W130:** tclpkg.tcl requires package but it is not in tclpkg.lock — run 'tcl pkg install'.",
+            "order": 0
+          },
           "tclLsp.diagnostics.W131": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W131:** tclpkg.lock is out of sync with tclpkg.tcl — run 'tcl pkg install'.",
+            "order": 1
+          },
+          "tclLsp.diagnosticSeverity.W131": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W131:** tclpkg.lock is out of sync with tclpkg.tcl — run 'tcl pkg install'.",
             "order": 1
           },
           "tclLsp.diagnostics.W132": {
@@ -4517,6 +6974,27 @@
             "markdownDescription": "**W132:** tclpkg.lock integrity mismatch — CAS hash differs from lockfile.",
             "order": 2
           },
+          "tclLsp.diagnosticSeverity.W132": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W132:** tclpkg.lock integrity mismatch — CAS hash differs from lockfile.",
+            "order": 2
+          },
           "tclLsp.diagnostics.W133": {
             "scope": "resource",
             "type": "boolean",
@@ -4524,11 +7002,53 @@
             "markdownDescription": "**W133:** tclpkg.tcl directive not permitted in safe mode.",
             "order": 3
           },
+          "tclLsp.diagnosticSeverity.W133": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W133:** tclpkg.tcl directive not permitted in safe mode.",
+            "order": 3
+          },
           "tclLsp.diagnostics.W134": {
             "scope": "resource",
             "type": "boolean",
             "default": true,
             "markdownDescription": "**W134:** Package resolved but no pkgIndex.tcl found — 'package require' will fail at runtime.",
+            "order": 4
+          },
+          "tclLsp.diagnosticSeverity.W134": {
+            "scope": "resource",
+            "type": "string",
+            "default": "default",
+            "enum": [
+              "default",
+              "error",
+              "warning",
+              "information",
+              "hint"
+            ],
+            "enumDescriptions": [
+              "Use the analyser's built-in severity",
+              "Report as an error",
+              "Report as a warning",
+              "Report as information",
+              "Report as a hint (faded)"
+            ],
+            "markdownDescription": "Display severity for **W134:** Package resolved but no pkgIndex.tcl found — 'package require' will fail at runtime.",
             "order": 4
           }
         }

--- a/editors/vscode/src/test/diagnostics.test.ts
+++ b/editors/vscode/src/test/diagnostics.test.ts
@@ -108,6 +108,58 @@ suite("Diagnostics", () => {
     assert.strictEqual(w302.severity, vscode.DiagnosticSeverity.Hint, "W302 should be a hint");
   });
 
+  test("tclLsp.diagnosticSeverity.W211 re-levels the unused-variable hint (#941)", async () => {
+    const uri = getDocUri("deadStoreDedup.tcl");
+    await activate(uri);
+    const codeOf = (d: vscode.Diagnostic) =>
+      typeof d.code === "object" && d.code !== null ? String(d.code.value) : String(d.code);
+    const w211Severity = (diags: readonly vscode.Diagnostic[]) =>
+      diags.find((d) => codeOf(d) === "W211")?.severity;
+    const config = vscode.workspace.getConfiguration("tclLsp.diagnosticSeverity");
+    try {
+      // Default: `set x 1` is an unused variable at hint severity (the faint
+      // underline #941 is about).
+      const base = await waitForDiagnostics(uri, {
+        predicate: (d) => d.some((x) => codeOf(x) === "W211"),
+      });
+      assert.strictEqual(
+        w211Severity(base),
+        vscode.DiagnosticSeverity.Hint,
+        "W211 defaults to Hint",
+      );
+
+      // Override to warning: the same diagnostic must now publish as a warning.
+      await config.update("W211", "warning", vscode.ConfigurationTarget.Workspace);
+      const raised = await waitForDiagnostics(uri, {
+        predicate: (d) =>
+          d.some((x) => codeOf(x) === "W211" && x.severity === vscode.DiagnosticSeverity.Warning),
+      });
+      assert.strictEqual(
+        w211Severity(raised),
+        vscode.DiagnosticSeverity.Warning,
+        "override raises W211 to Warning",
+      );
+
+      // A code the user did not override keeps its emitted severity (W220 on
+      // `set y 1` stays a hint) — the override is per-code, not global.
+      const w220 = raised.find((d) => codeOf(d) === "W220");
+      if (w220) {
+        assert.strictEqual(
+          w220.severity,
+          vscode.DiagnosticSeverity.Hint,
+          "an un-overridden code keeps its emitted severity",
+        );
+      }
+    } finally {
+      // Reset and confirm the diagnostic returns to its default hint severity.
+      await config.update("W211", undefined, vscode.ConfigurationTarget.Workspace);
+      await waitForDiagnostics(uri, {
+        predicate: (d) =>
+          d.some((x) => codeOf(x) === "W211" && x.severity === vscode.DiagnosticSeverity.Hint),
+      });
+    }
+  });
+
   test("W125 fires for orphaned else/elseif on separate line", async () => {
     const orphanedUri = getDocUri("diagnostics-orphaned.tcl");
     await activate(orphanedUri);

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -73,7 +73,7 @@ use rustc_hash::FxHashSet;
 use tcl_lexer::SourceMap;
 
 use helpers::{
-    build_undef_suppression, collect_defined_vars, collect_existence_guards,
+    build_undef_suppression, collect_defined_vars, collect_existence_guards, globals_read_by_procs,
     globals_written_by_procs,
 };
 
@@ -240,6 +240,13 @@ impl Analyser {
             &cbn_proc_index,
         ));
         top_level_cross_event_vars.extend(traced_globals.iter().cloned());
+        // A global a helper proc *reads* (`proc f {} { global cfg; return $cfg
+        // }` or `$::cfg`) consumes the top-level `set cfg …` that runs in the
+        // shared global namespace — the read-side mirror of `globals_written`
+        // above. Fold those names in so the top-level assignment is neither a
+        // dead store (W220) nor an unused variable (W211): both emitters honour
+        // this set (W211 via `textually_referenced.extend(cross_event_vars)`).
+        top_level_cross_event_vars.extend(globals_read_by_procs(cu));
 
         // Top-level first, then procedures in insertion order —
         // matches the iteration order of

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -537,6 +537,17 @@ file; this call falls through to the 'unknown' handler."
             if scope_aliases.contains(var) {
                 continue;
             }
+            // A fully-qualified name (`::cfg`, `::ns::cfg`) explicitly targets
+            // the global / a named namespace scope, whose reader may live in
+            // another proc, another namespace, or another file that single-unit
+            // dataflow can't see. The W220 dead-store and W210 read-before-set
+            // passes already exempt `::`-qualified names as externally
+            // consumable; W211 does the same so `set ::ns::cfg 1` at the top
+            // level isn't flagged unused merely because this unit holds no
+            // reader.
+            if var.contains("::") {
+                continue;
+            }
             if textually_referenced.contains(var) {
                 continue;
             }
@@ -1014,11 +1025,18 @@ file; this call falls through to the 'unknown' handler."
             if var.contains("::") {
                 continue;
             }
-            // A dynamic-target upvar local is possibly-unset, so its
-            // scope-alias status must not suppress the read-before-set (an
-            // unconditional `$local` read still fires; an `[info exists local]`
-            // guard suppresses it per-use below).
-            if scope_aliases.contains(var) && !supp.dynamic_upvar_locals.contains(var) {
+            // A scope-aliased local (`global` / `variable` / `upvar` /
+            // `namespace upvar` — literal *or* dynamic target) is bound to a
+            // variable in another scope, so reading it is not read-before-set.
+            // `upvar 1 $name local` and `upvar 1 outer local` are semantically
+            // identical: both raise `can't read` only when the *caller*
+            // variable is missing — a runtime condition, not a static one — so
+            // the dynamic target is suppressed exactly like the literal one
+            // (matching C Tcl and the "assume the may-run path does run" stance
+            // the loop / cross-event passes already take). This is the standard
+            // Tcl pass-by-reference idiom; a genuinely unrelated local that is
+            // not an alias is absent from `scope_aliases` and still fires.
+            if scope_aliases.contains(var) {
                 continue;
             }
             if extra_known_defined.contains(var) {

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -392,12 +392,6 @@ pub(super) struct UndefSuppression {
     /// `$tmp` read in the same expression looks read-before-set.  Name-level,
     /// suppress-only.
     cmd_sub_writes: FxHashSet<String>,
-    /// Locals aliased to a *dynamic* upvar target (`upvar 1 $name local`).
-    /// The alias may resolve to a non-existent caller variable, so the local
-    /// is possibly-unset: read-before-set must *override* the scope-alias
-    /// suppression and fire on an unconditional read (an `[info exists]` guard
-    /// still suppresses it per-use).
-    pub(super) dynamic_upvar_locals: HashSet<String>,
     /// `(name, version)` pairs killed by an `unset` — undef at their reads,
     /// so a direct read of one is read-before-set just like a version-0
     /// origin.
@@ -651,7 +645,6 @@ pub(super) fn build_undef_suppression(
     );
     let mut s = UndefSuppression {
         cmd_sub_writes: collect_expr_cmd_sub_writes(fu, considered),
-        dynamic_upvar_locals: crate::optimiser::elimination::scan_dynamic_upvar_locals(&fu.cfg),
         killed,
         can_undef,
         loop_entry_only_undef,
@@ -957,6 +950,77 @@ pub(super) fn globals_written_by_procs(
             }
         }
         for n in global_aliases.intersection(&written) {
+            result.insert(n.clone());
+        }
+    }
+    result
+}
+
+/// Compute the set of global variable names that any procedure in `cu`
+/// **reads**.
+///
+/// The read-side mirror of [`globals_written_by_procs`]: a top-level
+/// assignment (`set cfg …`, which runs in the global namespace) is not a
+/// dead store (W220) or unused variable (W211) when a helper proc consumes
+/// it — exactly as a top-level *read* is not read-before-set (W210) when a
+/// helper proc populates it.  A proc reads a global when it either:
+///
+/// 1. reads a fully-qualified name (`$::cfg`, `$::ns::cfg` — bare tail
+///    `cfg`), which always resolves outside the proc's own frame, or
+/// 2. declares `global cfg` and then reads `cfg` in the same body.
+///
+/// Name-level and deliberately permissive (the global namespace is shared
+/// between the top-level script and every proc, so a same-named read may be
+/// the consumer): the alternative is a false unused / dead-store hint on the
+/// extremely common "config global set at the top, read inside procs" shape.
+/// `variable` / `upvar` aliases are *not* counted — they bind the current
+/// namespace / a caller frame, not the global scope, so they cannot consume
+/// a global-scope top-level `set`.
+pub(super) fn globals_read_by_procs(
+    cu: &crate::compilation_unit::CompilationUnit,
+) -> HashSet<String> {
+    use crate::ir::Statement;
+    let mut result: HashSet<String> = HashSet::new();
+    for fu in cu.procedures.values() {
+        // Names the proc declares as global-scope aliases (`global cfg`).
+        let mut global_aliases: FxHashSet<String> = FxHashSet::default();
+        for block in fu.cfg.blocks.values() {
+            for stmt in &block.statements {
+                if let Statement::Call { command, defs, .. } = stmt
+                    && command == "global"
+                {
+                    for d in defs {
+                        global_aliases.insert(d.clone());
+                    }
+                }
+            }
+        }
+        // Names the proc reads.  The def-use chains already fold in the
+        // `return $x` terminator and branch-condition reads that the raw
+        // per-statement `uses` miss, so a chain carrying any use marks its
+        // name as read.
+        let mut read: FxHashSet<String> = FxHashSet::default();
+        for (key, chain) in &fu.def_use.chains {
+            if !chain.uses.is_empty() {
+                read.insert(key.0.clone());
+            }
+        }
+        // (1) A fully-qualified read always targets the global / a named
+        // namespace scope; its bare tail is the consumable global name.
+        for name in &read {
+            if let Some(bare) = name.strip_prefix("::") {
+                let tail = bare
+                    .trim_start_matches(':')
+                    .rsplit("::")
+                    .next()
+                    .unwrap_or(bare);
+                if !tail.is_empty() {
+                    result.insert(tail.to_string());
+                }
+            }
+        }
+        // (2) A `global cfg` alias the body reads is a read of global `cfg`.
+        for n in global_aliases.intersection(&read) {
             result.insert(n.clone());
         }
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -1006,16 +1006,20 @@ pub(super) fn globals_read_by_procs(
             }
         }
         // (1) A fully-qualified read always targets the global / a named
-        // namespace scope; its bare tail is the consumable global name.
+        // namespace scope. Strip only the *leading* `::` — mirroring
+        // `globals_written_by_procs` above — so a truly-global read (`$::cfg`,
+        // one segment once the leading `::` is gone) collapses to the bare
+        // name a top-level `set cfg` produces, while a *namespaced* read
+        // (`$::n::cfg`) keeps its `n::` qualification intact. Collapsing to
+        // just the last segment (the tail) would conflate `::n::cfg` with an
+        // unrelated bare `::cfg` of the same tail — a different storage cell —
+        // and could mask a genuinely-unused top-level global that happens to
+        // share a name with a namespaced variable read elsewhere.
         for name in &read {
             if let Some(bare) = name.strip_prefix("::") {
-                let tail = bare
-                    .trim_start_matches(':')
-                    .rsplit("::")
-                    .next()
-                    .unwrap_or(bare);
-                if !tail.is_empty() {
-                    result.insert(tail.to_string());
+                let bare = bare.trim_start_matches(':');
+                if !bare.is_empty() {
+                    result.insert(bare.to_string());
                 }
             }
         }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -2058,23 +2058,36 @@ mod tests {
     }
 
     #[test]
-    fn w210_dynamic_target_upvar_is_possibly_unset() {
-        // TP-W210: `upvar 1 $varName local` aliases `local` to the caller var
-        // named by `$varName`; if that var doesn't exist the alias is a no-op
-        // and an unconditional `$local` read errors — so W210 fires.
+    fn w210_dynamic_target_upvar_alias_read_is_silent() {
+        // Issue #941. `upvar 1 $varName local` aliases `local` to the caller
+        // variable named by `$varName` — the standard Tcl pass-by-reference
+        // idiom. Reading `$local` is not read-before-set: it errors only when
+        // the *caller* variable is missing, exactly the runtime condition that
+        // would make the *literal*-target twin (`upvar 1 caller local`) error
+        // too. tclsh 8.6/9.0 confirm the two forms are semantically identical,
+        // so the analyser treats them alike — both silent. (Reverses the old
+        // dynamic-target override, which flagged only the dynamic form and thus
+        // fired on every by-name read helper.)
         let codes = rbs_codes("proc foo {varName} {\n  upvar 1 $varName local\n  puts $local\n}\n");
         assert!(
-            codes.iter().any(|c| c == "W210"),
-            "dynamic-target upvar read: {codes:?}"
+            !codes.iter().any(|c| c == "W210"),
+            "dynamic-target upvar alias read must be silent: {codes:?}"
         );
-        // A *literal*-target upvar aliases a concrete caller var, so the local
-        // is treated as bound — no W210.
+        // Parity: the literal-target twin is silent too (always was).
         let codes = rbs_codes("proc foo {} {\n  upvar 1 caller local\n  puts $local\n}\n");
         assert!(
             !codes.iter().any(|c| c == "W210"),
             "literal-target upvar: {codes:?}"
         );
-        // An `[info exists local]` guard suppresses the read.
+        // TP control: an *unrelated* local — not the alias, never set — is not a
+        // scope alias, so it still fires W210.
+        let codes =
+            rbs_codes("proc foo {varName} {\n  upvar 1 $varName local\n  puts $unrelated\n}\n");
+        assert!(
+            codes.iter().any(|c| c == "W210"),
+            "unrelated non-alias local must still fire W210: {codes:?}"
+        );
+        // An `[info exists local]` guard suppresses the read (always did).
         let codes = rbs_codes(
             "proc foo {varName} {\n  upvar 1 $varName local\n  if {[info exists local]} { puts $local }\n}\n",
         );

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -929,44 +929,6 @@ pub(crate) fn collect_textual_var_references(
     out
 }
 
-/// Local names bound by an `upvar` (or `namespace upvar`) whose *caller
-/// target* is dynamic (`$name` / `[cmd]`).  Such an alias may resolve to a
-/// non-existent caller variable, so the local is possibly-unset: an
-/// unconditional read of it is a read-before-set (W210).  Kept separate from
-/// [`scan_scope_aliases`] (which still records the local for W211/W220, since
-/// a *write* through the alias is observable) — only the W210 read-before-set
-/// pass consults this set to *override* the scope-alias suppression.
-pub(crate) fn scan_dynamic_upvar_locals(cfg: &CfgFunction) -> HashSet<String> {
-    let mut out: HashSet<String> = HashSet::new();
-    for block in cfg.blocks.values() {
-        for stmt in &block.statements {
-            let Statement::Call { command, args, .. } = stmt else {
-                continue;
-            };
-            // `upvar ?level? caller local …` or `namespace upvar ns caller local …`.
-            let start = match command.as_str() {
-                "upvar" => {
-                    let has_level = args
-                        .first()
-                        .is_some_and(|a| a.starts_with('#') || a.parse::<i64>().is_ok());
-                    usize::from(has_level)
-                }
-                "namespace" if args.first().map(String::as_str) == Some("upvar") => 2,
-                _ => continue,
-            };
-            let mut i = start;
-            while i + 1 < args.len() {
-                let caller = &args[i];
-                if caller.starts_with('$') || caller.starts_with('[') {
-                    out.insert(crate::naming::normalise_var_name(&args[i + 1]).to_owned());
-                }
-                i += 2;
-            }
-        }
-    }
-    out
-}
-
 /// Variable names read *inside command substitutions* that the shallow word
 /// scan misses — chiefly a read-modify-write command's target buried in a
 /// substitution (`lappend r [incr i $j]` reads `i`), plus vars read via a

--- a/rust/tcl-compiler/tests/fp_depth.rs
+++ b/rust/tcl-compiler/tests/fp_depth.rs
@@ -484,28 +484,49 @@ proc f {} {
         );
     }
 
-    // --- dynamic_upvar_locals override (scan_dynamic_upvar_locals) ---
+    // --- dynamic upvar alias reads (issue #941) ---
 
     #[test]
-    fn dynamic_upvar_local_unconditional_read_fires_w210() {
-        // `upvar 1 $name v` aliases `v` to a *dynamic* caller var that may not
-        // exist, so an unconditional `$v` read is read-before-set: the dynamic
-        // upvar override fires W210 even though `v` is a scope alias.
-        // (The in-crate FP-RBS-08 pins the *silent* set-then-read; this pins
-        // the bare-read override.)
+    fn dynamic_upvar_local_unconditional_read_silent_w210() {
+        // `upvar 1 $name v` aliases `v` to the caller variable *named by* the
+        // runtime value of `$name` — the standard Tcl pass-by-reference idiom
+        // (`proc getField {arrayName field} { upvar 1 $arrayName arr; return
+        // $arr($field) }`). Reading `$v` is not read-before-set: it errors only
+        // when the *caller* variable is missing, which is exactly the runtime
+        // condition that makes the *literal*-target `upvar 1 outer v` error too
+        // — and that form is (correctly) silent. tclsh 8.6/9.0 confirm the two
+        // are semantically identical, so the analyser treats them alike (#941;
+        // reverses the earlier dynamic-target override, which flagged only the
+        // dynamic form and so fired on every by-name read helper).
         let src = "proc f {name} { upvar 1 $name v\n puts $v }\n";
         assert!(
+            !fires(src, D, "W210"),
+            "dynamic-upvar alias read must be silent like the literal form; emitted {:?}",
+            codes(src, D)
+        );
+        // Parity control: the literal-target twin is silent too.
+        assert!(
+            !fires("proc f {} { upvar 1 outer v\n puts $v }\n", D, "W210"),
+            "literal-target upvar alias read must stay silent"
+        );
+    }
+
+    #[test]
+    fn dynamic_upvar_unrelated_local_still_fires_w210() {
+        // TP control: an *unrelated* local — not the alias, never set — is not
+        // in the scope-alias set and must still fire W210.
+        let src = "proc f {name} { upvar 1 $name v\n return $unrelated }\n";
+        assert!(
             fires(src, D, "W210"),
-            "unconditional read of a dynamic-upvar local must fire W210; emitted {:?}",
+            "an unrelated (non-alias, unset) local must still fire W210; emitted {:?}",
             codes(src, D)
         );
     }
 
     #[test]
     fn dynamic_upvar_local_info_exists_guarded_read_silent() {
-        // The same dynamic-upvar local guarded by `[info exists v]` is safe per
-        // use — the existence guard suppresses the override. tclsh: the guard
-        // is the entire safety. Analyser policy: silent (guarded).
+        // The same dynamic-upvar local guarded by `[info exists v]` is silent
+        // too (guarded), as it always was.
         let src =
             "proc f {name} { upvar 1 $name v\n if {[info exists v]} { return $v }\n return {} }\n";
         assert!(

--- a/rust/tcl-compiler/tests/unused_var_tricky_features.rs
+++ b/rust/tcl-compiler/tests/unused_var_tricky_features.rs
@@ -1,0 +1,346 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Variable-lifecycle diagnostics (W210 / W211 / W220) across the *tricky* Tcl
+//! surfaces of issue #941: `upvar` pass-by-reference, cross-scope globals,
+//! namespaces, `variable`, `eval`, `trace`, `TclOO`, `interp`, the `::tcl` /
+//! `::mathop` namespaces, and `args` parameters.
+//!
+//! ## Why these live together
+//!
+//! The unused-variable / read-before-set family is exactly where a
+//! "tricky feature" leaks: a variable can look dead to single-unit dataflow
+//! while a *different* Tcl scope reads or writes it — through an `upvar` alias,
+//! the shared global namespace, a trace, or an inlined `eval` body. Each case
+//! here is one of:
+//!
+//!   * **FP** — must stay **silent**: the variable *is* used through a tricky
+//!     surface, so a diagnostic would be a false positive.
+//!   * **TP** — must still **fire**: a genuine unused / read-before-set that the
+//!     FP fixes must not mask.
+//!   * **TN** — a tricky surface the analyser already models correctly and must
+//!     keep modelling (regression guard).
+//!
+//! ## C-Tcl ground truth
+//!
+//! W210 ("read before set") and W213 ("unset nothing") mirror a real
+//! `can't read` / `can't unset` runtime error, so their reproducers are pinned
+//! to `tclsh` behaviour. W211 / W220 are pure liveness lints with no direct
+//! runtime analogue, but the *binding* facts they depend on (an `upvar` alias
+//! writing the caller cell, a `global` read seeing a top-level `set`, a trace
+//! observing a write) were confirmed against real `tclsh8.6` (and hold
+//! identically on `tclsh9.0` — the C Tcl 9 truth oracle — for every construct
+//! here, which uses only 8.4-era scoping semantics). Citations use `// tclsh:`.
+
+use tcl_compiler::analyser::Analyser;
+use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_compiler::compiler_checks::run_all_checks;
+use tcl_registry::registry_for_dialect;
+
+/// Default dialect: the C Tcl 9 truth oracle (issue #941). The scoping
+/// constructs exercised here behave identically on 8.4–9.0.
+const D: &str = "tcl9.0";
+
+/// Every diagnostic code the full user-facing pipeline surfaces for `src`
+/// under `dialect`: the analyser pass plus the `run_all_checks` compiler-checks
+/// pass, with optimisation codes excluded — exactly what `tcl diag` reports.
+fn codes(src: &str, dialect: &str) -> Vec<String> {
+    let mut out: Vec<String> = Analyser::new()
+        .analyse(src, dialect)
+        .diagnostics
+        .iter()
+        .map(|d| d.code.to_string())
+        .collect();
+    let registry = registry_for_dialect(dialect);
+    let cu = CompilationUnit::build_for(src, registry, false);
+    for d in run_all_checks(&cu, registry, Some(dialect)) {
+        if d.code.is_optimisation() {
+            continue;
+        }
+        out.push(d.code.to_string());
+    }
+    out
+}
+
+/// True when `code` appears anywhere in the merged diagnostic set for `src`.
+fn fires(src: &str, code: &str) -> bool {
+    codes(src, D).iter().any(|c| c == code)
+}
+
+/// True when *none* of the variable-lifecycle codes fire for `src` — the
+/// assertion an FP / TN reproducer wants.
+fn lifecycle_silent(src: &str) -> bool {
+    !codes(src, D)
+        .iter()
+        .any(|c| matches!(c.as_str(), "W210" | "W211" | "W213" | "W220"))
+}
+
+// ===========================================================================
+// upvar — dynamic-target pass-by-reference (the #941 headline FP)
+//
+// `upvar ?level? otherVar myVar` binds the *local* `myVar` to the caller-frame
+// variable named by `otherVar`. `otherVar` may be a literal *or* a runtime
+// value (`$name`); the two are semantically identical — each errors only when
+// the caller variable is missing. The analyser used to flag the dynamic form
+// alone, firing on the single most common Tcl pass-by-reference idiom.
+// ===========================================================================
+mod upvar_dynamic_target {
+    use super::*;
+
+    #[test]
+    fn fp_dynamic_upvar_pure_read_is_silent() {
+        // tclsh: `proc f {n} {upvar 1 $n a; return $a}; set x 9; f x` → 9 (no
+        // error). Reading the alias is not read-before-set.
+        assert!(
+            lifecycle_silent("proc f {n} { upvar 1 $n a\n return $a }\n"),
+            "dynamic upvar alias read fired: {:?}",
+            codes("proc f {n} { upvar 1 $n a\n return $a }\n", D)
+        );
+    }
+
+    #[test]
+    fn fp_dynamic_upvar_array_getter_is_silent() {
+        // The canonical accessor helper: alias an array by name, read an
+        // element. tclsh: works whenever the caller array exists.
+        assert!(lifecycle_silent(
+            "proc getField {arrayName field} { upvar 1 $arrayName arr\n return $arr($field) }\n"
+        ));
+    }
+
+    #[test]
+    fn fp_dynamic_upvar_hash_level_is_silent() {
+        // `upvar #0 $global local` — alias a namespaced global by computed name
+        // (the tcllib picoirc idiom). Must be silent like the relative form.
+        assert!(lifecycle_silent(
+            "proc f {ctx} { upvar #0 $ctx state\n return $state }\n"
+        ));
+    }
+
+    #[test]
+    fn parity_literal_and_dynamic_upvar_agree() {
+        // The whole point: the literal- and dynamic-target twins must reach the
+        // *same* verdict (both silent), because tclsh treats them identically.
+        let dynamic = lifecycle_silent("proc f {n} { upvar 1 $n a\n return $a }\n");
+        let literal = lifecycle_silent("proc f {} { upvar 1 outer a\n return $a }\n");
+        assert!(dynamic && literal, "dynamic={dynamic} literal={literal}");
+    }
+
+    #[test]
+    fn tp_unrelated_local_after_upvar_still_fires() {
+        // TP control: `$unrelated` is not the alias, is never set, and is not a
+        // scope alias — a genuine read-before-set. tclsh: `can't read
+        // "unrelated"`.
+        assert!(
+            fires("proc f {n} { upvar 1 $n a\n return $unrelated }\n", "W210"),
+            "unrelated unset local must fire W210"
+        );
+    }
+
+    #[test]
+    fn tn_dynamic_upvar_write_through_alias_is_not_dead_store() {
+        // TN: writing through the alias reaches the caller cell, so it is not a
+        // dead store even though this frame never reads it back. tclsh:
+        // `proc f {n} {upvar 1 $n a; set a 5}; set x 0; f x; set x` → 5.
+        assert!(lifecycle_silent("proc f {n} { upvar 1 $n a\n set a 5 }\n"));
+    }
+
+    #[test]
+    fn tn_guarded_dynamic_upvar_read_is_silent() {
+        // An `[info exists a]` guard makes the read safe on every path.
+        assert!(lifecycle_silent(
+            "proc f {n} { upvar 1 $n a\n if {[info exists a]} { return $a }\n return {} }\n"
+        ));
+    }
+}
+
+// ===========================================================================
+// Cross-scope globals — the top-level script and every proc share the global
+// namespace, so a top-level `set` is "used" when a proc reads it (and the
+// existing reverse direction, a proc write feeding a top-level read).
+// ===========================================================================
+mod cross_scope_globals {
+    use super::*;
+
+    #[test]
+    fn fp_top_level_global_read_by_proc_via_global_decl() {
+        // tclsh: `proc f {} {global cfg; return $cfg}; set cfg 1; f` → 1. The
+        // top-level `set cfg 1` feeds the proc, so it is not a dead store.
+        assert!(lifecycle_silent(
+            "proc f {} { global cfg\n return $cfg }\nset cfg 1\nputs [f]\n"
+        ));
+    }
+
+    #[test]
+    fn fp_top_level_global_read_by_proc_via_qualified_ref() {
+        // Same, read through a fully-qualified `$::cfg` rather than a `global`
+        // declaration.
+        assert!(lifecycle_silent(
+            "proc f {} { return $::cfg }\nset cfg 1\nputs [f]\n"
+        ));
+    }
+
+    #[test]
+    fn fp_top_level_namespace_var_read_by_proc() {
+        // A namespaced `set ::n::cfg 1` consumed by `variable cfg; $cfg` inside
+        // an `::n::` proc. The qualified top-level name is externally
+        // consumable, so W211 must not fire.
+        assert!(lifecycle_silent(
+            "namespace eval ::n {}\nproc ::n::f {} { variable cfg\n return $cfg }\nset ::n::cfg 1\n"
+        ));
+    }
+
+    #[test]
+    fn tn_reverse_direction_proc_writes_global_top_reads() {
+        // The pre-existing mirror: a proc populates the global before the
+        // top-level read. Must stay silent (regression guard for
+        // `globals_written_by_procs`).
+        assert!(lifecycle_silent(
+            "proc setup {} { global cfg\n set cfg 1 }\nsetup\nputs $cfg\n"
+        ));
+    }
+
+    #[test]
+    fn tp_genuine_top_level_dead_store_still_fires() {
+        // TP: no proc (and no top-level reader) ever reads `cfg`, so the
+        // top-level `set` is genuinely unused. The FP fix must not mask this.
+        assert!(
+            fires("proc f {} { return 0 }\nset cfg 1\nputs [f]\n", "W211"),
+            "a top-level global no proc reads must still fire W211"
+        );
+    }
+
+    #[test]
+    fn tp_bare_local_unused_still_fires() {
+        // TP: an ordinary proc-local that is set and never read.
+        assert!(fires("proc f {} { set tmp 5\n return 1 }\n", "W211"));
+    }
+}
+
+// ===========================================================================
+// Tricky surfaces the analyser already models — regression guards (TN).
+// Each `set` here is consumed through a feature that is NOT a plain `$var`
+// read in the same frame; the analyser must keep recognising the use.
+// ===========================================================================
+mod already_modelled_surfaces {
+    use super::*;
+
+    #[test]
+    fn tn_namespace_variable_used_by_qualified_proc() {
+        // A namespace `variable` written in the eval body and read in a member
+        // proc — a real cross-proc use.
+        assert!(lifecycle_silent(
+            "namespace eval ::a { variable counter 0 }\nproc ::a::bump {} { variable counter\n incr counter }\n"
+        ));
+    }
+
+    #[test]
+    fn tn_eval_body_uses_local_in_current_frame() {
+        // `eval {…}` runs in the current frame; the inlined body's read counts.
+        assert!(lifecycle_silent("proc f {} { set c 5\n eval {incr c} }\n"));
+    }
+
+    #[test]
+    fn tn_trace_add_variable_only_var_is_observed() {
+        // A write trace observes every write, so `set x 1` is not dead even with
+        // no `$x` read. tclsh: the trace callback fires on the write.
+        assert!(lifecycle_silent(
+            "proc f {} { set x 0\n trace add variable x write ::onwrite\n set x 1 }\nproc onwrite {a b op} {}\n"
+        ));
+    }
+
+    #[test]
+    fn tn_tcloo_instance_variable_across_methods() {
+        // A TclOO instance `variable` written in one method, read in another —
+        // a cross-method use through the object's private namespace.
+        assert!(lifecycle_silent(
+            "oo::class create C {\n variable n\n method inc {} { incr n }\n method get {} { return $n }\n}\n"
+        ));
+    }
+
+    #[test]
+    fn tn_tcloo_my_variable_binding() {
+        // `my variable state` binds the instance variable into method scope.
+        assert!(lifecycle_silent(
+            "oo::class create C {\n method a {} { my variable state\n set state 1 }\n method b {} { my variable state\n return $state }\n}\n"
+        ));
+    }
+
+    #[test]
+    fn tn_args_parameter_collects_rest() {
+        // The variadic `args` parameter is consumed by `llength`.
+        assert!(lifecycle_silent(
+            "proc f {args} { return [llength $args] }\n"
+        ));
+    }
+
+    #[test]
+    fn tn_default_parameter_used_in_body() {
+        // An optional parameter with a default, used in the body.
+        assert!(lifecycle_silent(
+            "proc f {a {b 5}} { return [expr {$a + $b}] }\n"
+        ));
+    }
+
+    #[test]
+    fn tn_mathop_namespace_command_result_used() {
+        // `::tcl::mathop::+` is a real command whose result is consumed.
+        assert!(lifecycle_silent(
+            "set r [::tcl::mathop::+ 1 2 3]\nputs $r\n"
+        ));
+    }
+
+    #[test]
+    fn tn_scan_writes_vars_by_name_then_read() {
+        // `scan` writes `a` / `b` by name; both are then read.
+        assert!(lifecycle_silent(
+            "proc f {s} { scan $s \"%d %d\" a b\n return [expr {$a + $b}] }\n"
+        ));
+    }
+
+    #[test]
+    fn tn_dict_with_injects_keys_as_locals() {
+        // `dict with d {…}` unpacks the dict keys as locals in the body.
+        assert!(lifecycle_silent(
+            "proc f {d} { dict with d { return $name } }\n"
+        ));
+    }
+}
+
+// ===========================================================================
+// Read-before-set TPs on tricky surfaces — the FP suppressions above must not
+// leak into genuine errors.
+// ===========================================================================
+mod read_before_set_tps {
+    use super::*;
+
+    #[test]
+    fn tp_plain_read_before_set() {
+        // tclsh: `proc f {} {puts $u}` → `can't read "u"`.
+        assert!(fires("proc f {} { puts $u }\n", "W210"));
+    }
+
+    #[test]
+    fn tp_namespace_local_never_set_read() {
+        // A bare local in a namespaced proc, never set nor aliased, read
+        // directly — a genuine read-before-set.
+        assert!(fires(
+            "namespace eval ::n {}\nproc ::n::f {} { return $missing }\n",
+            "W210"
+        ));
+    }
+}

--- a/rust/tcl-compiler/tests/unused_var_tricky_features.rs
+++ b/rust/tcl-compiler/tests/unused_var_tricky_features.rs
@@ -225,6 +225,24 @@ mod cross_scope_globals {
     }
 
     #[test]
+    fn tp_namespaced_read_does_not_mask_unrelated_bare_global() {
+        // TP (regression, code-review finding): a proc reading a *namespaced*
+        // variable `$::n::cfg` must not be mistaken for a read of the
+        // unrelated bare global `::cfg` merely because they share a tail
+        // name — the two are different storage cells. Collapsing a
+        // qualified read to its last segment (rather than keeping the
+        // remainder after the leading `::`, as `globals_written_by_procs`
+        // does) would wrongly suppress this genuinely-unused top-level `cfg`.
+        assert!(
+            fires(
+                "namespace eval ::n {}\nproc reader {} { return $::n::cfg }\nset cfg 1\nputs done\n",
+                "W211"
+            ),
+            "a namespaced read of ::n::cfg must not suppress the unrelated bare ::cfg dead store"
+        );
+    }
+
+    #[test]
     fn tp_bare_local_unused_still_fires() {
         // TP: an ordinary proc-local that is set and never read.
         assert!(fires("proc f {} { set tmp 5\n return 1 }\n", "W211"));

--- a/rust/tcl-lsp-server/src/config_ini.rs
+++ b/rust/tcl-lsp-server/src/config_ini.rs
@@ -211,6 +211,7 @@ pub fn settings_from_ini(content: &str, layer: Layer) -> Value {
     }
 
     insert_diagnostics(&sections, &mut out);
+    insert_diagnostic_severity(&sections, &mut out);
     insert_optimiser(&sections, &mut out);
 
     // [shimmer] / [xcDiagnostics]: enabled.
@@ -289,6 +290,29 @@ fn insert_diagnostics(sections: &[Section], out: &mut Map<String, Value>) {
     }
     if !diag.is_empty() {
         out.insert("diagnostics".to_owned(), Value::Object(diag));
+    }
+}
+
+/// `[diagnosticSeverity]`: each `CODE = severity` entry → a `diagnosticSeverity`
+/// object of `{CODE: "severity"}`, the nested shape the server's
+/// `settings_severity_overrides` parses. The severity strings are passed
+/// through verbatim; that parser validates them (case-insensitive `error` /
+/// `warning` / `information` / `info` / `hint`) and skips any it does not
+/// recognise, so an unknown value here simply leaves the code's emitted
+/// severity untouched.
+fn insert_diagnostic_severity(sections: &[Section], out: &mut Map<String, Value>) {
+    let Some(section) = sections.iter().find(|s| s.name == "diagnosticSeverity") else {
+        return;
+    };
+    let mut sev = Map::new();
+    for (code, value) in &section.entries {
+        let value = value.trim();
+        if !value.is_empty() {
+            sev.insert(code.clone(), Value::String(value.to_owned()));
+        }
+    }
+    if !sev.is_empty() {
+        out.insert("diagnosticSeverity".to_owned(), Value::Object(sev));
     }
 }
 

--- a/rust/tcl-lsp-server/src/config_ini/tests.rs
+++ b/rust/tcl-lsp-server/src/config_ini/tests.rs
@@ -102,6 +102,24 @@ fn multiline_disabled_codes_list() {
 }
 
 #[test]
+fn diagnostic_severity_section() {
+    // `[diagnosticSeverity]` entries pass through verbatim as the nested
+    // `diagnosticSeverity` object `settings_severity_overrides` parses;
+    // validation (and skip-unknown) happens there, not here.
+    let ini = "[diagnosticSeverity]\n\
+               W211 = warning\n\
+               W220 = Error\n\
+               W210 = nonsense\n";
+    let s = settings_from_ini(ini, Layer::Global);
+    assert_eq!(s["diagnosticSeverity"]["W211"], json!("warning"));
+    assert_eq!(s["diagnosticSeverity"]["W220"], json!("Error"));
+    assert_eq!(s["diagnosticSeverity"]["W210"], json!("nonsense"));
+    // Absent section -> no key at all (leave the current overrides untouched).
+    let none = settings_from_ini("[diagnostics]\ndisabled = W111\n", Layer::Global);
+    assert!(none.get("diagnosticSeverity").is_none());
+}
+
+#[test]
 fn extra_commands_multiline() {
     // Continuation form of `extraCommands`, equivalent to the comma form.
     // `::`-qualified

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -495,6 +495,10 @@ struct DiagInputs {
     client: Client,
     registry: Arc<CommandRegistry>,
     disabled: HashSet<String>,
+    /// `tclLsp.diagnosticSeverity.<CODE>` per-code LSP severity overrides,
+    /// resolved for this document's folder. Applied as a display-side re-label
+    /// to the lifted diagnostics; empty ⇒ no overrides.
+    severity_overrides: HashMap<String, tower_lsp_server::ls_types::DiagnosticSeverity>,
     /// `tclLsp.extraCommands` — names treated as known by W123.
     extra_commands: HashSet<String>,
     /// `tclLsp.diagnostics.genericVariablePatterns` — IRULE4002 generic-name
@@ -1204,6 +1208,7 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
         client,
         registry,
         disabled,
+        severity_overrides,
         extra_commands,
         generic_variable_patterns,
         style_line_length,
@@ -1277,6 +1282,7 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
         text: &text,
         dialect: &dialect,
         disabled: &disabled,
+        severity_overrides: &severity_overrides,
         opt_disabled: &opt_disabled,
         optimiser_enabled,
         style_line_length,
@@ -1577,6 +1583,7 @@ async fn publish_fast_tier(
     let analysis_lifts = Arc::clone(analysis);
     let text = lift_inputs.text.to_owned();
     let disabled = lift_inputs.disabled.clone();
+    let severity_overrides = lift_inputs.severity_overrides.clone();
     let style_line_length = lift_inputs.style_line_length;
     let lifted = tokio::task::spawn_blocking(move || {
         let mut diagnostics = lift_analyser_diagnostics(&text, &fast);
@@ -1586,6 +1593,7 @@ async fn publish_fast_tier(
             &disabled,
             style_line_length as usize,
         ));
+        apply_severity_overrides(&mut diagnostics, &severity_overrides);
         diagnostics
     })
     .await;
@@ -1600,6 +1608,11 @@ struct LiftInputs<'a> {
     text: &'a str,
     dialect: &'a str,
     disabled: &'a HashSet<String>,
+    /// `tclLsp.diagnosticSeverity.<CODE>` per-code LSP severity overrides,
+    /// applied as a display-side re-label once the lift completes; empty ⇒
+    /// no overrides (see [`apply_severity_overrides`]).
+    severity_overrides:
+        &'a std::collections::HashMap<String, tower_lsp_server::ls_types::DiagnosticSeverity>,
     opt_disabled: &'a HashSet<String>,
     optimiser_enabled: bool,
     style_line_length: u32,
@@ -1645,6 +1658,7 @@ async fn refine_and_lift_diagnostics(
     let analysis_lifts = Arc::clone(analysis);
     let lift_text = inputs.text.to_owned();
     let disabled = inputs.disabled.clone();
+    let severity_overrides = inputs.severity_overrides.clone();
     let opt_disabled = inputs.opt_disabled.clone();
     let optimiser_enabled = inputs.optimiser_enabled;
     let style_line_length = inputs.style_line_length;
@@ -1678,6 +1692,7 @@ async fn refine_and_lift_diagnostics(
                 &analysis_lifts.suppressed_lines,
             ));
         }
+        apply_severity_overrides(&mut diagnostics, &severity_overrides);
         diagnostics
     })
     .await
@@ -1855,6 +1870,12 @@ pub struct Backend {
     /// = false`). Threaded into every analyser build so the disabled
     /// codes are filtered, and consulted by the source-style pass.
     disabled_diagnostics: Mutex<HashSet<String>>,
+    /// Per-code LSP severity overrides (`tclLsp.diagnosticSeverity.<CODE>`).
+    /// A purely display-side re-labelling applied to the lifted diagnostics
+    /// after analysis: a listed code is published at the chosen severity,
+    /// leaving its range / message / code untouched. Empty ⇒ no overrides
+    /// (the analyser's emitted severity stands).
+    severity_overrides: Mutex<HashMap<String, tower_lsp_server::ls_types::DiagnosticSeverity>>,
     /// Cross-document proc / class definition index, maintained
     /// incrementally as documents open / change / close.  Lets
     /// completion enumerate procs from sibling files.
@@ -2263,6 +2284,10 @@ enum FolderGenericPatterns {
 struct FolderConfig {
     feature_toggles: FeatureToggles,
     disabled_diagnostics: Option<HashSet<String>>,
+    /// `tclLsp.diagnosticSeverity` per-code LSP severity overrides; `None`
+    /// inherits the process-global map (`Some`, possibly empty, when the
+    /// folder's config sets the section in either shape).
+    severity_overrides: Option<HashMap<String, tower_lsp_server::ls_types::DiagnosticSeverity>>,
     non_ascii_mode: Option<NonAsciiMode>,
     optimiser_enabled: Option<bool>,
     optimiser_profile: Option<tcl_compiler::optimiser::profiles::OptimisationProfile>,
@@ -2347,6 +2372,7 @@ impl Backend {
             folder_db_configs: Arc::new(Mutex::new(Vec::new())),
             non_ascii_mode: Mutex::new(NonAsciiMode::Default),
             disabled_diagnostics: Mutex::new(default_disabled_set()),
+            severity_overrides: Mutex::new(HashMap::new()),
             workspace_index: Arc::new(RwLock::new(core_workspace_index::WorkspaceIndex::new())),
             package_resolver: Arc::new(RwLock::new(PackageResolver::new())),
             autoloaded_library_uris: Arc::new(Mutex::new(HashSet::new())),
@@ -2831,6 +2857,9 @@ impl Backend {
         }
         if let Some(disabled) = settings_disabled_diagnostics(opts) {
             *self.disabled_diagnostics.lock().await = disabled;
+        }
+        if let Some(overrides) = settings_severity_overrides(opts) {
+            *self.severity_overrides.lock().await = overrides;
         }
     }
 
@@ -5527,6 +5556,9 @@ impl Backend {
         if let Some(disabled) = settings_disabled_diagnostics(&wrapped) {
             *self.disabled_diagnostics.lock().await = disabled;
         }
+        if let Some(overrides) = settings_severity_overrides(&wrapped) {
+            *self.severity_overrides.lock().await = overrides;
+        }
     }
 
     /// Store the per-folder editor configs and refresh the per-folder salsa
@@ -5918,6 +5950,24 @@ impl Backend {
         (disabled, non_ascii_mode, optimiser_enabled, opt_disabled)
     }
 
+    /// Resolve the per-code severity overrides for `uri`: the longest-matching
+    /// folder's `tclLsp.diagnosticSeverity` map when set, else the process-global
+    /// map. Mirrors the `disabled_diagnostics` resolution in
+    /// [`Self::resolved_analysis_settings`].
+    async fn resolved_severity_overrides(
+        &self,
+        uri: &Uri,
+    ) -> std::collections::HashMap<String, tower_lsp_server::ls_types::DiagnosticSeverity> {
+        let folder = {
+            let configs = self.folder_configs.lock().await;
+            longest_folder_match(&configs, uri).cloned()
+        };
+        match folder.and_then(|f| f.severity_overrides) {
+            Some(m) => m,
+            None => self.severity_overrides.lock().await.clone(),
+        }
+    }
+
     /// Resolve the formatter line length for `uri` (per-folder override, else
     /// the global `tclLsp.formatting.lineLength`).
     async fn resolved_line_length(&self, uri: &Uri) -> u32 {
@@ -6029,6 +6079,7 @@ impl Backend {
     async fn diag_inputs(&self, uri: &Uri, dialect: &str) -> DiagInputs {
         let (disabled, non_ascii_mode, optimiser_enabled, opt_disabled) =
             self.resolved_analysis_settings(uri).await;
+        let severity_overrides = self.resolved_severity_overrides(uri).await;
         let registry = self.registry_for_dialect(dialect).await;
         let xc_diagnostics = self.xc_diagnostics_enabled(uri).await;
         let cross_file_resolution = self.cross_file_resolution_enabled(uri).await;
@@ -6045,6 +6096,7 @@ impl Backend {
             client: self.client.clone(),
             registry,
             disabled,
+            severity_overrides,
             extra_commands,
             generic_variable_patterns,
             style_line_length,
@@ -6273,6 +6325,7 @@ impl Backend {
         )
         .await;
         let style_line_length = self.resolved_style_line_length(uri).await;
+        let severity_overrides = self.resolved_severity_overrides(uri).await;
         tokio::task::spawn_blocking(move || {
             let mut diagnostics = lift_analyser_diagnostics(&text, &analyser_diags);
             append_brace_expr_perf_hints(&mut diagnostics, optimiser_enabled, &opt_disabled);
@@ -6300,6 +6353,7 @@ impl Backend {
                     &analysis.suppressed_lines,
                 ));
             }
+            apply_severity_overrides(&mut diagnostics, &severity_overrides);
             diagnostics
         })
         .await
@@ -7204,6 +7258,9 @@ impl LanguageServer for Backend {
         }
         if let Some(disabled) = settings_disabled_diagnostics(&params.settings) {
             *self.disabled_diagnostics.lock().await = disabled;
+        }
+        if let Some(overrides) = settings_severity_overrides(&params.settings) {
+            *self.severity_overrides.lock().await = overrides;
         }
         // VS Code (and the e2e harness) push an empty/partial payload as a
         // signal to re-pull the full resolved config via
@@ -10506,6 +10563,64 @@ fn settings_disabled_diagnostics(settings: &serde_json::Value) -> Option<HashSet
     found.then_some(set)
 }
 
+/// Map a `tclLsp.diagnosticSeverity.<CODE>` config value to an LSP severity
+/// (case-insensitive). `"error"`, `"warning"`, `"information"` / `"info"`, and
+/// `"hint"` select the matching [`DiagnosticSeverity`]; anything else —
+/// including `"default"` and `""` — yields `None`, meaning "no override" (the
+/// analyser's emitted severity stands).
+fn parse_severity_value(s: &str) -> Option<tower_lsp_server::ls_types::DiagnosticSeverity> {
+    use tower_lsp_server::ls_types::DiagnosticSeverity;
+    if s.eq_ignore_ascii_case("error") {
+        Some(DiagnosticSeverity::ERROR)
+    } else if s.eq_ignore_ascii_case("warning") {
+        Some(DiagnosticSeverity::WARNING)
+    } else if s.eq_ignore_ascii_case("information") || s.eq_ignore_ascii_case("info") {
+        Some(DiagnosticSeverity::INFORMATION)
+    } else if s.eq_ignore_ascii_case("hint") {
+        Some(DiagnosticSeverity::HINT)
+    } else {
+        None
+    }
+}
+
+/// Parse per-code LSP severity overrides from a `tclLsp` settings payload,
+/// accepting the nested object (`{"tclLsp":{"diagnosticSeverity":{"W211":"warning"}}}`)
+/// and the flat-dotted (`{"tclLsp.diagnosticSeverity.W211":"warning"}`) shapes.
+/// Returns `Some(map)` (possibly empty) when the section is present in either
+/// shape, else `None` (so the caller leaves the current map untouched). Entries
+/// whose value is not a recognised severity string ([`parse_severity_value`])
+/// are skipped, so the analyser's emitted severity stands for them. Mirrors
+/// [`settings_disabled_diagnostics`].
+fn settings_severity_overrides(
+    settings: &serde_json::Value,
+) -> Option<std::collections::HashMap<String, tower_lsp_server::ls_types::DiagnosticSeverity>> {
+    if let Some(map) = settings
+        .get("tclLsp")
+        .and_then(|v| v.get("diagnosticSeverity"))
+        .and_then(serde_json::Value::as_object)
+    {
+        let mut overrides = HashMap::new();
+        for (code, v) in map {
+            if let Some(severity) = v.as_str().and_then(parse_severity_value) {
+                overrides.insert(code.clone(), severity);
+            }
+        }
+        return Some(overrides);
+    }
+    let obj = settings.as_object()?;
+    let mut overrides = HashMap::new();
+    let mut found = false;
+    for (k, v) in obj {
+        if let Some(code) = k.strip_prefix("tclLsp.diagnosticSeverity.") {
+            found = true;
+            if let Some(severity) = v.as_str().and_then(parse_severity_value) {
+                overrides.insert(code.to_owned(), severity);
+            }
+        }
+    }
+    found.then_some(overrides)
+}
+
 /// Parse one folder's resolved `tclLsp` config object into a [`FolderConfig`]
 /// of overrides.  Keys absent from the object stay `None` / empty so the
 /// resolver inherits the process-global value.  Returns `None` when `cfg` is
@@ -10650,6 +10765,7 @@ fn parse_folder_config(cfg: &serde_json::Value) -> Option<FolderConfig> {
     let wrapped = serde_json::json!({ "tclLsp": cfg });
     fc.non_ascii_mode = settings_non_ascii_mode(&wrapped);
     fc.disabled_diagnostics = settings_disabled_diagnostics(&wrapped);
+    fc.severity_overrides = settings_severity_overrides(&wrapped);
     Some(fc)
 }
 
@@ -11371,6 +11487,28 @@ fn append_brace_expr_perf_hints(
         })
         .collect();
     diagnostics.extend(hints);
+}
+
+/// Apply user severity overrides (`tclLsp.diagnosticSeverity.<CODE>`) to the
+/// lifted diagnostics: a code present in `overrides` is re-published at the
+/// chosen [`DiagnosticSeverity`], leaving its range/message/code untouched.
+/// A no-op when `overrides` is empty (the common case), so the hot path pays
+/// nothing. The analyser's emitted severity stands for any code not listed.
+fn apply_severity_overrides(
+    diagnostics: &mut [tower_lsp_server::ls_types::Diagnostic],
+    overrides: &std::collections::HashMap<String, tower_lsp_server::ls_types::DiagnosticSeverity>,
+) {
+    use tower_lsp_server::ls_types::NumberOrString;
+    if overrides.is_empty() {
+        return;
+    }
+    for d in diagnostics.iter_mut() {
+        if let Some(NumberOrString::String(code)) = &d.code
+            && let Some(&severity) = overrides.get(code)
+        {
+            d.severity = Some(severity);
+        }
+    }
 }
 
 /// Lift the source-style pass (W111 line length,
@@ -13041,6 +13179,75 @@ mod tests {
         assert!(got.contains("W210") && !got.contains("W211"));
         // No diagnostics config -> None (leave current set untouched).
         assert!(settings_disabled_diagnostics(&serde_json::json!({"x": 1})).is_none());
+    }
+
+    #[test]
+    fn settings_severity_overrides_nested_and_flat() {
+        use tower_lsp_server::ls_types::DiagnosticSeverity;
+        // Nested shape: recognised values map (case-insensitively); "default"
+        // and unknown values mean "no override" and are skipped.
+        let nested = serde_json::json!({
+            "tclLsp": {"diagnosticSeverity": {
+                "W211": "warning",
+                "W220": "Error",
+                "W210": "info",
+                "W214": "default",
+                "W111": "loud",
+            }}
+        });
+        let got = settings_severity_overrides(&nested).unwrap();
+        assert_eq!(got.get("W211"), Some(&DiagnosticSeverity::WARNING));
+        assert_eq!(got.get("W220"), Some(&DiagnosticSeverity::ERROR));
+        assert_eq!(got.get("W210"), Some(&DiagnosticSeverity::INFORMATION));
+        assert!(!got.contains_key("W214"), "'default' must not override");
+        assert!(!got.contains_key("W111"), "unknown value must be skipped");
+        // Flat-dotted shape.
+        let flat = serde_json::json!({
+            "tclLsp.diagnosticSeverity.W211": "hint",
+            "tclLsp.diagnosticSeverity.S100": "warning",
+        });
+        let got = settings_severity_overrides(&flat).unwrap();
+        assert_eq!(got.get("W211"), Some(&DiagnosticSeverity::HINT));
+        assert_eq!(got.get("S100"), Some(&DiagnosticSeverity::WARNING));
+        // No diagnosticSeverity section -> None (leave current map untouched);
+        // an explicit empty section -> Some(empty) (clear all overrides).
+        assert!(settings_severity_overrides(&serde_json::json!({"x": 1})).is_none());
+        let cleared =
+            settings_severity_overrides(&serde_json::json!({"tclLsp": {"diagnosticSeverity": {}}}))
+                .unwrap();
+        assert!(cleared.is_empty());
+    }
+
+    #[test]
+    fn apply_severity_overrides_relabels_only_listed_codes() {
+        use tower_lsp_server::ls_types::{
+            Diagnostic, DiagnosticSeverity, NumberOrString, Position, Range,
+        };
+        let mk = |code: &str, sev: DiagnosticSeverity| Diagnostic {
+            range: Range::new(Position::new(0, 0), Position::new(0, 1)),
+            severity: Some(sev),
+            code: Some(NumberOrString::String(code.to_owned())),
+            code_description: None,
+            source: Some("tcl-lsp".to_owned()),
+            message: String::new(),
+            related_information: None,
+            tags: None,
+            data: None,
+        };
+        let mut diags = vec![
+            mk("W211", DiagnosticSeverity::HINT),
+            mk("W220", DiagnosticSeverity::HINT),
+        ];
+        let overrides =
+            std::collections::HashMap::from([("W211".to_owned(), DiagnosticSeverity::WARNING)]);
+        apply_severity_overrides(&mut diags, &overrides);
+        assert_eq!(diags[0].severity, Some(DiagnosticSeverity::WARNING));
+        // A code not in the map keeps its emitted severity.
+        assert_eq!(diags[1].severity, Some(DiagnosticSeverity::HINT));
+        // An empty map is a no-op.
+        let before = diags.clone();
+        apply_severity_overrides(&mut diags, &std::collections::HashMap::new());
+        assert_eq!(diags, before);
     }
 
     #[test]
@@ -14823,6 +15030,7 @@ mod tests {
             folder_db_configs: Arc::new(Mutex::new(Vec::new())),
             non_ascii_mode: Mutex::new(NonAsciiMode::Default),
             disabled_diagnostics: Mutex::new(default_disabled_set()),
+            severity_overrides: Mutex::new(HashMap::new()),
             workspace_index: Arc::new(RwLock::new(core_workspace_index::WorkspaceIndex::new())),
             package_resolver: Arc::new(RwLock::new(PackageResolver::new())),
             autoloaded_library_uris: Arc::new(Mutex::new(HashSet::new())),

--- a/rust/tcl-lsp-server/tests/e2e/config.rs
+++ b/rust/tcl-lsp-server/tests/e2e/config.rs
@@ -357,3 +357,95 @@ fn repeated_cycles_keep_provider_working() {
         assert!(!is_empty(&lsp.hover(&uri, 0, 2)));
     }
 }
+
+// -- Per-code severity override (issue #941) ------------------------------
+//
+// `tclLsp.diagnosticSeverity.<CODE>` re-levels how prominently a diagnostic is
+// published, without changing the analysis. LSP severity ints: 1=Error,
+// 2=Warning, 3=Information, 4=Hint.
+
+/// The published severity of the first `code` diagnostic in `diags`, if any.
+fn severity_of(diags: &[Value], code: &str) -> Option<i64> {
+    diags
+        .iter()
+        .find(|d| d.get("code").and_then(Value::as_str) == Some(code))
+        .and_then(|d| d.get("severity"))
+        .and_then(Value::as_i64)
+}
+
+#[test]
+fn diagnostic_severity_override_relevels_a_diagnostic() {
+    use std::time::{Duration, Instant};
+
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    // `tmp` is set but never read → W211, emitted at Hint (4) by default.
+    lsp.open_document(&uri, "proc f {} { set tmp 5 }\n");
+    let base = lsp.pull_diagnostics(&uri);
+    assert_eq!(
+        severity_of(&base, "W211"),
+        Some(4),
+        "W211 must default to Hint (4); got {base:?}"
+    );
+
+    // Raise W211 to a warning (2) via didChangeConfiguration; the analysis is
+    // unchanged, only the published severity moves. Poll the deterministic pull
+    // path until the re-pulled config takes effect.
+    lsp.apply_configuration(json!({ "diagnosticSeverity": { "W211": "warning" } }));
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut diags = lsp.pull_diagnostics(&uri);
+    while severity_of(&diags, "W211") != Some(2) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+        diags = lsp.pull_diagnostics(&uri);
+    }
+    assert_eq!(
+        severity_of(&diags, "W211"),
+        Some(2),
+        "override must re-level W211 to Warning (2); got {diags:?}"
+    );
+
+    // Reset to default (empty override) and confirm it returns to Hint.
+    lsp.apply_configuration(json!({ "diagnosticSeverity": {} }));
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut diags = lsp.pull_diagnostics(&uri);
+    while severity_of(&diags, "W211") != Some(4) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+        diags = lsp.pull_diagnostics(&uri);
+    }
+    assert_eq!(
+        severity_of(&diags, "W211"),
+        Some(4),
+        "clearing the override must restore Hint (4); got {diags:?}"
+    );
+}
+
+#[test]
+fn diagnostic_severity_override_is_per_code() {
+    use std::time::{Duration, Instant};
+
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    // Two hint-severity lifecycle codes: W211 (`x` unused) and W220 (`y` dead
+    // store, overwritten before read).
+    let src = "proc f {} { set x 1\n set y 1\n set y 2\n return $y }\n";
+    lsp.open_document(&uri, src);
+
+    // Override only W211 → error (1); W220 must keep its emitted Hint (4).
+    lsp.apply_configuration(json!({ "diagnosticSeverity": { "W211": "error" } }));
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let mut diags = lsp.pull_diagnostics(&uri);
+    while severity_of(&diags, "W211") != Some(1) && Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+        diags = lsp.pull_diagnostics(&uri);
+    }
+    assert_eq!(
+        severity_of(&diags, "W211"),
+        Some(1),
+        "W211 must be overridden to Error (1); got {diags:?}"
+    );
+    assert_eq!(
+        severity_of(&diags, "W220"),
+        Some(4),
+        "an un-overridden code (W220) must keep its emitted Hint (4); got {diags:?}"
+    );
+}

--- a/rust/xtask/src/gen_vscode_package.rs
+++ b/rust/xtask/src/gen_vscode_package.rs
@@ -107,6 +107,7 @@ fn scope_for(key: &str) -> Option<&'static str> {
     const PREFIXES: &[(&str, &str)] = &[
         ("tclLsp.formatting.", "language-overridable"),
         ("tclLsp.style.", "language-overridable"),
+        ("tclLsp.diagnosticSeverity.", "resource"),
         ("tclLsp.diagnostics.", "resource"),
         ("tclLsp.optimiser.", "resource"),
         ("tclLsp.shimmer.", "resource"),
@@ -241,6 +242,33 @@ fn diagnostic_sections() -> Vec<Value> {
             );
             m.insert("order".to_owned(), json!(i));
             props.insert(key.clone(), scoped_prop(&key, m));
+            // Per-code severity override — how prominently the editor renders
+            // this diagnostic. `default` keeps the analyser's emitted severity
+            // (issue #941: raise a subtle hint like W211 to a warning/error).
+            let sev_key = format!("tclLsp.diagnosticSeverity.{code}");
+            let mut sm = Map::new();
+            sm.insert("type".to_owned(), json!("string"));
+            sm.insert("default".to_owned(), json!("default"));
+            sm.insert(
+                "enum".to_owned(),
+                json!(["default", "error", "warning", "information", "hint"]),
+            );
+            sm.insert(
+                "enumDescriptions".to_owned(),
+                json!([
+                    "Use the analyser's built-in severity",
+                    "Report as an error",
+                    "Report as a warning",
+                    "Report as information",
+                    "Report as a hint (faded)",
+                ]),
+            );
+            sm.insert(
+                "markdownDescription".to_owned(),
+                json!(format!("Display severity for **{code}:** {description}")),
+            );
+            sm.insert("order".to_owned(), json!(i));
+            props.insert(sev_key.clone(), scoped_prop(&sev_key, sm));
         }
         inject_special_trailing_props(title, diags.len(), &mut props);
 


### PR DESCRIPTION
## Summary

- Fixed two oracle-verified false positives in the unused-variable / read-before-set family, both in variable-lifecycle scoping across "tricky" Tcl surfaces:
  - **Dynamic-target `upvar` pass-by-reference** (`upvar 1 $name local`) fired **W210** on a pure read even though the literal-target twin (`upvar 1 outer local`) was already silent. `tclsh8.6`/`9.0` confirm the two forms are semantically identical — both error only when the *caller* variable is missing, a runtime condition, not a static one. Removed the inconsistent `dynamic_upvar_locals` override that made the analyser treat them differently; this is the single most common Tcl pass-by-reference accessor idiom (`proc getField {arrayName field} { upvar 1 $arrayName arr; return $arr($field) }`).
  - **Cross-scope globals**: a variable set at the top level and read only inside a proc (`proc f {} { global cfg; return $cfg }`, or via `$::cfg`) was flagged **W211**/**W220** as unused/dead, because single-unit dataflow can't see the proc's read. Added `globals_read_by_procs`, the read-side mirror of the existing `globals_written_by_procs` (which already suppressed the reverse direction for W210). Also made **W211** exempt `::`-qualified names, matching the existing W210/W220 behaviour.
- Surveyed every other "tricky" surface named in the issue — namespaces, `variable`, `eval`/`uplevel`/`subst`, `trace`, `rename`, `unknown`, `interp` (safe/sub-interpreters, `interp alias`), TclOO (+ snit/[incr Tcl]), the `::tcl`/`::mathop` namespaces, `source`/`package require`/`autoIndex`, and `args`/default proc params — via three independent research passes over the registry and compiler. All are already correctly and **generically** modelled through registry traits/hooks (`Traits::CREATES_SCOPE_ALIAS`, `ESTABLISHES_VARIABLE_TRACE`, `AnalyserHookId`, `CommandTableEffect`, `DefinerFamily` + `DefinitionBodyGrammar`), with no hardcoded `match cmd_name { "foo" => ... }` special-casing added or needed in the compiler/analyser for this work.
- Made **diagnostic severity configurable** — the issue's literal ask. `tclLsp.diagnosticSeverity.<CODE>` (VS Code setting, `initializationOptions`/`workspace/didChangeConfiguration`, and `.tcl-lsp.ini` `[diagnosticSeverity]`) lets a user raise W211's default faint hint to warning/error (or re-level any code). Implemented as a pure display-side re-label applied after the analyser runs — the analysis itself is never affected, and the mechanism mirrors the existing `disabled_diagnostics` plumbing exactly (same folder-resolution, same two JSON shapes).
- Regenerated the VS Code settings catalogue (`cargo xtask gen-editor-settings`) — 120 new per-code `tclLsp.diagnosticSeverity.*` settings.
- Updated KCS docs (`kcs-diagnostic-w211-variable-set-not-used.md`, `kcs-feature-unused-variables.md`), the FP/TP catalogue (`docs/design/compiler/FP.md`, new entries FP-RBS-08 refinement + FP-RBS-11), and the README.

## Validation

- `make test-rust` (`cargo test --workspace --all-features`, includes the native lsp_e2e suite) — **green**.
- `make check-all` (TS + Rust lint/typecheck, mirrors `pr-gate` + full-tree checks) — **green**.
- `make test-ext` (VS Code extension integration tests against the native server) — **green**, 656 passing, including a new severity-override test.
- `make test-emacs` (headless eglot regression suite) — **green** (one pre-existing, tracked `XFAIL` for issue #333, an upstream eglot bug unrelated to this change).
- `make runtime-rust-test` — **one pre-existing failure**, unrelated to this change: `cmd_namespace::tests::dispatch_matches_every_conformance_vector` in the standalone `runtime/rust` crate (a `tcl_runtime` interpreter dispatch bug: `invalid command name "if"` inside a proc body). Verified this file is byte-identical to this branch's merge-base with `rust` and is not touched anywhere in this diff — the failure predates this branch. Flagging here for visibility; happy to file a separate issue if useful.
- `cargo fmt --check` / `cargo clippy --workspace --all-features` (pedantic) — clean, **no new `#[allow]`s added**.
- New test coverage: `rust/tcl-compiler/tests/unused_var_tricky_features.rs` (25 TP/FP/TN tests across upvar, cross-scope globals, namespaces, TclOO, traces, `eval`, `args`, `::mathop`), unit tests for the severity parser/apply logic and `.tcl-lsp.ini` section, 2 native `lsp_e2e` tests for the severity override, and a VS Code integration test.
- I ran these locally against the exact tip this PR is built from (`0a845b0`).

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — the W210/W211 suppression conditions for scope-aliased variables.
- [x] Updated the relevant KCS notes: `docs/kcs/codes/kcs-diagnostic-w211-variable-set-not-used.md`, `docs/kcs/features/kcs-feature-unused-variables.md` (both already existed and are linked from their respective READMEs — no new note needed).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UzzKjDV3xy1gzjRxq7LGBb)_