### PR TITLE
feat(vscode): suppress diagnostics for files viewed only in diff editors

### DIFF
--- a/README.md
+++ b/README.md
@@ -1835,18 +1835,20 @@ For the complete reference, see
 
 When you review a change in a diff editor — a Git diff from **Source
 Control**, **Compare With…**, or **Compare with Saved** — the modified side
-is the real working file, so its squiggles show up alongside the diff.  To
-read a change without the analyser's noise, enable:
-
-```json
-"tclLsp.diagnostics.suppressInDiffEditors": true
-```
-
-A Tcl file's diagnostics are then hidden while it is shown *only* in a diff
+is the real working file, so its *whole-file* diagnostics (mostly findings
+that predate the change) would otherwise paint the diff.  By default the
+extension hides a Tcl file's diagnostics while it is shown *only* in a diff
 editor.  The moment the same file is also open in a normal editor — where
 you might be editing it — its diagnostics come back, so analysis of files
-you are working on is never affected.  This is a VS Code display choice
-only: the server keeps analysing and no diagnostics are lost.  See
+you are working on is never affected.  To keep diagnostics visible in
+diffs instead:
+
+```json
+"tclLsp.suppressDiagnosticsInDiffEditors": false
+```
+
+This is a VS Code display choice only: the server keeps analysing and no
+diagnostics are lost.  See
 [`docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md`](docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md).
 
 ## Changing how prominent a diagnostic is

--- a/README.md
+++ b/README.md
@@ -1833,22 +1833,23 @@ For the complete reference, see
 
 ### Diff and compare views (VS Code)
 
-When you review a change in a diff editor — a Git diff from **Source
-Control**, **Compare With…**, or **Compare with Saved** — the modified side
-is the real working file, so its *whole-file* diagnostics (mostly findings
-that predate the change) would otherwise paint the diff.  By default the
-extension hides a Tcl file's diagnostics while it is shown *only* in a diff
-editor.  The moment the same file is also open in a normal editor — where
-you might be editing it — its diagnostics come back, so analysis of files
-you are working on is never affected.  To keep diagnostics visible in
-diffs instead:
+The analyser never runs on diff *content* — a diff editor is two real
+documents rendered side by side, and the modified side of a Git diff from
+**Source Control** (or either side of **Compare With…**) is a real file,
+analysed like any open file.  The squiggles a diff shows are therefore that
+file's own correct, *whole-file* diagnostics, and they are shown by
+default.  Because most of those findings predate the change under review,
+you can optionally hide them while a file is shown *only* in a diff
+editor:
 
 ```json
-"tclLsp.suppressDiagnosticsInDiffEditors": false
+"tclLsp.suppressDiagnosticsInDiffEditors": true
 ```
 
-This is a VS Code display choice only: the server keeps analysing and no
-diagnostics are lost.  See
+The moment the same file is also open in a normal editor — where you might
+be editing it — its diagnostics come back, so analysis of files you are
+working on is never affected.  This is a VS Code display choice only: the
+server keeps analysing and no diagnostics are lost.  See
 [`docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md`](docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md).
 
 ## Changing how prominent a diagnostic is

--- a/README.md
+++ b/README.md
@@ -1831,6 +1831,24 @@ disabled = O109
 For the complete reference, see
 [`docs/kcs/kcs-howto-suppress-diagnostics.md`](docs/kcs/kcs-howto-suppress-diagnostics.md).
 
+### Diff and compare views (VS Code)
+
+When you review a change in a diff editor — a Git diff from **Source
+Control**, **Compare With…**, or **Compare with Saved** — the modified side
+is the real working file, so its squiggles show up alongside the diff.  To
+read a change without the analyser's noise, enable:
+
+```json
+"tclLsp.diagnostics.suppressInDiffEditors": true
+```
+
+A Tcl file's diagnostics are then hidden while it is shown *only* in a diff
+editor.  The moment the same file is also open in a normal editor — where
+you might be editing it — its diagnostics come back, so analysis of files
+you are working on is never affected.  This is a VS Code display choice
+only: the server keeps analysing and no diagnostics are lost.  See
+[`docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md`](docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md).
+
 ## Changing how prominent a diagnostic is
 
 Some checks are intentionally quiet — an unused variable

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -132,8 +132,8 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   — turn a diagnostic, warning, optimisation, or shimmer off inline,
   file-wide, per-project, per-editor, or globally.
 - [kcs-howto-hide-diagnostics-in-diff-views.md](kcs-howto-hide-diagnostics-in-diff-views.md)
-  — hide Tcl diagnostics in VS Code diff and compare editors with
-  `tclLsp.diagnostics.suppressInDiffEditors`.
+  — VS Code hides Tcl diagnostics in diff and compare editors by default;
+  control it with `tclLsp.suppressDiagnosticsInDiffEditors`.
 - [kcs-howto-configure-project-entry-points.md](kcs-howto-configure-project-entry-points.md)
   — stop W120 warnings in files loaded by an entry file, via the
   automatic `source` graph or a manual `entryPoints` list.

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -132,8 +132,8 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   — turn a diagnostic, warning, optimisation, or shimmer off inline,
   file-wide, per-project, per-editor, or globally.
 - [kcs-howto-hide-diagnostics-in-diff-views.md](kcs-howto-hide-diagnostics-in-diff-views.md)
-  — VS Code hides Tcl diagnostics in diff and compare editors by default;
-  control it with `tclLsp.suppressDiagnosticsInDiffEditors`.
+  — hide Tcl diagnostics in VS Code diff and compare editors with
+  `tclLsp.suppressDiagnosticsInDiffEditors`.
 - [kcs-howto-configure-project-entry-points.md](kcs-howto-configure-project-entry-points.md)
   — stop W120 warnings in files loaded by an entry file, via the
   automatic `source` graph or a manual `entryPoints` list.

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -131,6 +131,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-howto-suppress-diagnostics.md](kcs-howto-suppress-diagnostics.md)
   — turn a diagnostic, warning, optimisation, or shimmer off inline,
   file-wide, per-project, per-editor, or globally.
+- [kcs-howto-hide-diagnostics-in-diff-views.md](kcs-howto-hide-diagnostics-in-diff-views.md)
+  — hide Tcl diagnostics in VS Code diff and compare editors with
+  `tclLsp.diagnostics.suppressInDiffEditors`.
 - [kcs-howto-configure-project-entry-points.md](kcs-howto-configure-project-entry-points.md)
   — stop W120 warnings in files loaded by an entry file, via the
   automatic `source` graph or a manual `entryPoints` list.

--- a/docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md
+++ b/docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md
@@ -9,50 +9,59 @@ VS Code, diagnostic
 
 ## Question
 
-How do I stop Tcl errors and warnings from appearing while I review a
-change in a Git diff, in **Compare With…**, or in **Compare with Saved**?
+Why do Tcl errors and warnings not appear while I review a change in a Git
+diff, in **Compare With…**, or in **Compare with Saved** — and how do I
+control that?
 
 ## Before you start
 
 - Use VS Code. This setting is a VS Code display choice; other editors
   do not have it.
 - Know that a diff editor's right-hand side is the real working file, so
-  it is analysed like any open file — that is why its squiggles appear in
-  the diff.
+  it is analysed like any open file. The squiggles it would show are the
+  file's **whole-file** diagnostics — mostly findings that predate the
+  change you are reviewing — not diagnostics about the change itself.
 
 ## Answer
 
-Turn on `tclLsp.diagnostics.suppressInDiffEditors`.
+By default the extension hides a Tcl file's diagnostics while it is shown
+**only** in a diff editor, so you can read a change without the analyser's
+noise. This is controlled by `tclLsp.suppressDiagnosticsInDiffEditors`
+(default: on).
+
+If the same file is also open in a normal editor — where you might be
+editing it — its diagnostics stay visible there, so analysis of files you
+are working on is never dimmed.
+
+To keep diagnostics visible in diffs instead:
 
 1. Open **Settings** (`Ctrl+,` / `Cmd+,`).
-2. Search for `suppressInDiffEditors`.
-3. Tick **Tcl Lsp › Diagnostics: Suppress In Diff Editors**.
+2. Search for `suppressDiagnosticsInDiffEditors`.
+3. Untick **Tcl Lsp: Suppress Diagnostics In Diff Editors**.
 
 Or add it to `settings.json`:
 
 ```json
-"tclLsp.diagnostics.suppressInDiffEditors": true
+"tclLsp.suppressDiagnosticsInDiffEditors": false
 ```
 
-With the setting on, a Tcl file's diagnostics are hidden while it is shown
-**only** in a diff editor. If the same file is also open in a normal editor
-— where you might be editing it — its diagnostics stay visible there, so
-analysis of files you are working on is never dimmed.
-
-The change takes effect immediately: no window reload, and no edit to the
-file. Turning the setting back off restores the diagnostics straight away.
-
-This never changes what the [Tcl Language Server](../GLOSSARY.md#lsp)
+Changes take effect immediately: no window reload, and no edit to the
+file. This never changes what the [Tcl Language Server](../GLOSSARY.md#lsp)
 computes. The server keeps analysing every open file; the setting only
 decides whether VS Code paints the result while the file is being viewed
 as a diff, so no report is lost.
 
+The setting is deliberately **not** under `tclLsp.diagnostics.*` — that
+section is reserved for per-code on/off toggles (for example
+`tclLsp.diagnostics.W100`), and the server reads every boolean key in it
+as a diagnostic code.
+
 ## How to tell it worked
 
 Open a modified `.tcl` file from the **Source Control** view. With the
-setting on, the diff opens without squiggles or entries in the
-**Problems** panel for that file. Open the same file normally and the
-diagnostics reappear.
+setting on (the default), the diff opens without squiggles or entries in
+the **Problems** panel for that file. Open the same file normally and the
+diagnostics appear.
 
 ## Related
 

--- a/docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md
+++ b/docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md
@@ -9,41 +9,39 @@ VS Code, diagnostic
 
 ## Question
 
-Why do Tcl errors and warnings not appear while I review a change in a Git
-diff, in **Compare With…**, or in **Compare with Saved** — and how do I
-control that?
+How do I stop Tcl errors and warnings from appearing while I review a
+change in a Git diff, in **Compare With…**, or in **Compare with Saved**?
 
 ## Before you start
 
 - Use VS Code. This setting is a VS Code display choice; other editors
   do not have it.
-- Know that a diff editor's right-hand side is the real working file, so
-  it is analysed like any open file. The squiggles it would show are the
-  file's **whole-file** diagnostics — mostly findings that predate the
-  change you are reviewing — not diagnostics about the change itself.
+- Know what the squiggles in a diff are. The analyser never runs on diff
+  content — a diff editor is two real documents shown side by side, and
+  the right-hand side of a Git diff is the real working file, analysed
+  like any open file. The diagnostics you see are that file's own
+  correct, whole-file diagnostics — mostly findings that predate the
+  change you are reviewing, which is why hiding them can help.
 
 ## Answer
 
-By default the extension hides a Tcl file's diagnostics while it is shown
-**only** in a diff editor, so you can read a change without the analyser's
-noise. This is controlled by `tclLsp.suppressDiagnosticsInDiffEditors`
-(default: on).
-
-If the same file is also open in a normal editor — where you might be
-editing it — its diagnostics stay visible there, so analysis of files you
-are working on is never dimmed.
-
-To keep diagnostics visible in diffs instead:
+Diagnostics are shown in diffs by default. To hide them while a file is
+shown **only** in a diff editor, turn on
+`tclLsp.suppressDiagnosticsInDiffEditors`:
 
 1. Open **Settings** (`Ctrl+,` / `Cmd+,`).
 2. Search for `suppressDiagnosticsInDiffEditors`.
-3. Untick **Tcl Lsp: Suppress Diagnostics In Diff Editors**.
+3. Tick **Tcl Lsp: Suppress Diagnostics In Diff Editors**.
 
 Or add it to `settings.json`:
 
 ```json
-"tclLsp.suppressDiagnosticsInDiffEditors": false
+"tclLsp.suppressDiagnosticsInDiffEditors": true
 ```
+
+If the same file is also open in a normal editor — where you might be
+editing it — its diagnostics stay visible there, so analysis of files you
+are working on is never dimmed.
 
 Changes take effect immediately: no window reload, and no edit to the
 file. This never changes what the [Tcl Language Server](../GLOSSARY.md#lsp)
@@ -59,9 +57,9 @@ as a diagnostic code.
 ## How to tell it worked
 
 Open a modified `.tcl` file from the **Source Control** view. With the
-setting on (the default), the diff opens without squiggles or entries in
-the **Problems** panel for that file. Open the same file normally and the
-diagnostics appear.
+setting on, the diff opens without squiggles or entries in the
+**Problems** panel for that file. Open the same file normally and the
+diagnostics reappear.
 
 ## Related
 

--- a/docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md
+++ b/docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md
@@ -1,0 +1,61 @@
+# KCS: How do I hide Tcl diagnostics in diff and compare views?
+
+> **Audience:** User
+> **Type:** How-To
+
+## Applies to
+
+VS Code, diagnostic
+
+## Question
+
+How do I stop Tcl errors and warnings from appearing while I review a
+change in a Git diff, in **Compare With…**, or in **Compare with Saved**?
+
+## Before you start
+
+- Use VS Code. This setting is a VS Code display choice; other editors
+  do not have it.
+- Know that a diff editor's right-hand side is the real working file, so
+  it is analysed like any open file — that is why its squiggles appear in
+  the diff.
+
+## Answer
+
+Turn on `tclLsp.diagnostics.suppressInDiffEditors`.
+
+1. Open **Settings** (`Ctrl+,` / `Cmd+,`).
+2. Search for `suppressInDiffEditors`.
+3. Tick **Tcl Lsp › Diagnostics: Suppress In Diff Editors**.
+
+Or add it to `settings.json`:
+
+```json
+"tclLsp.diagnostics.suppressInDiffEditors": true
+```
+
+With the setting on, a Tcl file's diagnostics are hidden while it is shown
+**only** in a diff editor. If the same file is also open in a normal editor
+— where you might be editing it — its diagnostics stay visible there, so
+analysis of files you are working on is never dimmed.
+
+The change takes effect immediately: no window reload, and no edit to the
+file. Turning the setting back off restores the diagnostics straight away.
+
+This never changes what the [Tcl Language Server](../GLOSSARY.md#lsp)
+computes. The server keeps analysing every open file; the setting only
+decides whether VS Code paints the result while the file is being viewed
+as a diff, so no report is lost.
+
+## How to tell it worked
+
+Open a modified `.tcl` file from the **Source Control** view. With the
+setting on, the diff opens without squiggles or entries in the
+**Problems** panel for that file. Open the same file normally and the
+diagnostics reappear.
+
+## Related
+
+- [KCS index](README.md)
+- [How do I turn a diagnostic, optimisation, or shimmer off?](kcs-howto-suppress-diagnostics.md)
+- [Glossary](../GLOSSARY.md)

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3061,8 +3061,8 @@
           "tclLsp.suppressDiagnosticsInDiffEditors": {
             "scope": "resource",
             "type": "boolean",
-            "default": true,
-            "description": "Hide Tcl diagnostics (errors and warnings) for a file while it is shown only in a diff editor — a Git change in Source Control, 'Compare With…', or 'Compare with Saved'. On by default; set to false to keep seeing diagnostics in diffs. The file always keeps its diagnostics when it is also open in a normal editor, so analysis of files you are editing is never affected. Purely a client-side display choice; the server keeps analysing. (Deliberately not under tclLsp.diagnostics.*, which is reserved for per-code on/off toggles.)",
+            "default": false,
+            "description": "Hide Tcl diagnostics (errors and warnings) for a file while it is shown only in a diff editor — a Git change in Source Control, 'Compare With…', or 'Compare with Saved'. Diagnostics in a diff are the underlying file's own full-file diagnostics (the analyser never runs on diff content), so they are shown by default; enable this to read changes without the analyser's noise. The file always keeps its diagnostics when it is also open in a normal editor. Purely a client-side display choice; the server keeps analysing. (Deliberately not under tclLsp.diagnostics.*, which is reserved for per-code on/off toggles.)",
             "order": 6
           }
         }

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3057,6 +3057,13 @@
             "default": true,
             "description": "Warn when semantic highlighting can't reach a Tcl file (wrong language association, or semantic highlighting disabled), which leaves grammar-only colouring that mis-highlights keywords inside braced string arguments. Each notice can also be dismissed permanently via its 'Don't show again' button.",
             "order": 5
+          },
+          "tclLsp.diagnostics.suppressInDiffEditors": {
+            "scope": "resource",
+            "type": "boolean",
+            "default": false,
+            "description": "Hide Tcl diagnostics (errors and warnings) for a file while it is shown only in a diff editor — a Git change in Source Control, 'Compare With…', or 'Compare with Saved'. The file keeps its diagnostics when it is also open in a normal editor, so analysis of files you are editing is never affected. Purely a client-side display choice; the server keeps analysing.",
+            "order": 6
           }
         }
       },

--- a/editors/vscode/package.json
+++ b/editors/vscode/package.json
@@ -3058,11 +3058,11 @@
             "description": "Warn when semantic highlighting can't reach a Tcl file (wrong language association, or semantic highlighting disabled), which leaves grammar-only colouring that mis-highlights keywords inside braced string arguments. Each notice can also be dismissed permanently via its 'Don't show again' button.",
             "order": 5
           },
-          "tclLsp.diagnostics.suppressInDiffEditors": {
+          "tclLsp.suppressDiagnosticsInDiffEditors": {
             "scope": "resource",
             "type": "boolean",
-            "default": false,
-            "description": "Hide Tcl diagnostics (errors and warnings) for a file while it is shown only in a diff editor — a Git change in Source Control, 'Compare With…', or 'Compare with Saved'. The file keeps its diagnostics when it is also open in a normal editor, so analysis of files you are editing is never affected. Purely a client-side display choice; the server keeps analysing.",
+            "default": true,
+            "description": "Hide Tcl diagnostics (errors and warnings) for a file while it is shown only in a diff editor — a Git change in Source Control, 'Compare With…', or 'Compare with Saved'. On by default; set to false to keep seeing diagnostics in diffs. The file always keeps its diagnostics when it is also open in a normal editor, so analysis of files you are editing is never affected. Purely a client-side display choice; the server keeps analysing. (Deliberately not under tclLsp.diagnostics.*, which is reserved for per-code on/off toggles.)",
             "order": 6
           }
         }

--- a/editors/vscode/src/diffAnalysis.ts
+++ b/editors/vscode/src/diffAnalysis.ts
@@ -19,16 +19,21 @@
 import * as vscode from "vscode";
 
 /**
- * Optional per-resource suppression of Tcl diagnostics for documents that are
- * only being viewed in a diff editor — a Git change (Source Control), "Compare
- * With…", "Compare with Saved", and similar.
+ * Per-resource suppression of Tcl diagnostics for documents that are only being
+ * viewed in a diff editor — a Git change (Source Control), "Compare With…",
+ * "Compare with Saved", and similar. On by default;
+ * `tclLsp.suppressDiagnosticsInDiffEditors: false` keeps diagnostics visible
+ * in diffs. (Deliberately NOT under `tclLsp.diagnostics.*` — the server treats
+ * every boolean key in that section as a per-code on/off toggle, so a
+ * client-only key there would leak into `disabled_diagnostics` and the
+ * config-file export.)
  *
  * "Diff editor" is a purely client-side concept: the language server publishes
  * diagnostics per URI and has no idea an editor is rendering that URI as a diff.
  * The modified side of a Git diff is the real working-tree file (`file:` scheme)
- * and is analysed exactly like any open file, so its squiggles show up in the
- * diff. When the user just wants to read a change without the analyser's noise,
- * `tclLsp.diagnostics.suppressInDiffEditors` lets them hide it.
+ * and is analysed exactly like any open file, so its *whole-file* diagnostics —
+ * mostly findings that predate the change under review — would otherwise paint
+ * the diff.
  *
  * The gating happens in the `handleDiagnostics` middleware: the real diagnostics
  * are remembered per URI, but an empty set is handed to the client whenever the
@@ -36,8 +41,8 @@ import * as vscode from "vscode";
  * normal editor keeps its diagnostics, so active editing is never dimmed.
  */
 
-const CONFIG_SECTION = "tclLsp.diagnostics";
-const CONFIG_KEY = "suppressInDiffEditors";
+const CONFIG_SECTION = "tclLsp";
+const CONFIG_KEY = "suppressDiagnosticsInDiffEditors";
 const CONFIG_PATH = `${CONFIG_SECTION}.${CONFIG_KEY}`;
 
 /** The client's diagnostic sink — the `next` handed to the middleware. */
@@ -200,5 +205,5 @@ export class DiffDiagnosticsSuppressor implements vscode.Disposable {
 
 /** Whether diff-editor suppression is enabled for the given resource. */
 function isSuppressionEnabled(uri: vscode.Uri): boolean {
-  return vscode.workspace.getConfiguration(CONFIG_SECTION, uri).get<boolean>(CONFIG_KEY, false);
+  return vscode.workspace.getConfiguration(CONFIG_SECTION, uri).get<boolean>(CONFIG_KEY, true);
 }

--- a/editors/vscode/src/diffAnalysis.ts
+++ b/editors/vscode/src/diffAnalysis.ts
@@ -1,0 +1,204 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as vscode from "vscode";
+
+/**
+ * Optional per-resource suppression of Tcl diagnostics for documents that are
+ * only being viewed in a diff editor — a Git change (Source Control), "Compare
+ * With…", "Compare with Saved", and similar.
+ *
+ * "Diff editor" is a purely client-side concept: the language server publishes
+ * diagnostics per URI and has no idea an editor is rendering that URI as a diff.
+ * The modified side of a Git diff is the real working-tree file (`file:` scheme)
+ * and is analysed exactly like any open file, so its squiggles show up in the
+ * diff. When the user just wants to read a change without the analyser's noise,
+ * `tclLsp.diagnostics.suppressInDiffEditors` lets them hide it.
+ *
+ * The gating happens in the `handleDiagnostics` middleware: the real diagnostics
+ * are remembered per URI, but an empty set is handed to the client whenever the
+ * URI is shown *exclusively* in diff editors. A file that is also open in a
+ * normal editor keeps its diagnostics, so active editing is never dimmed.
+ */
+
+const CONFIG_SECTION = "tclLsp.diagnostics";
+const CONFIG_KEY = "suppressInDiffEditors";
+const CONFIG_PATH = `${CONFIG_SECTION}.${CONFIG_KEY}`;
+
+/** The client's diagnostic sink — the `next` handed to the middleware. */
+type ApplyDiagnostics = (uri: vscode.Uri, diagnostics: vscode.Diagnostic[]) => void;
+
+/** URIs shown in normal editors vs in diff editors, as `Uri.toString()` keys. */
+export interface TabUriSets {
+  normal: Set<string>;
+  diff: Set<string>;
+}
+
+/**
+ * Split the URIs across every open tab into those shown in a normal text editor
+ * and those shown in a diff editor. Both sides of a diff (original and modified)
+ * count as diff. Non-text tabs (webviews, notebooks, terminals) are ignored.
+ */
+export function collectTabUriSets(groups: readonly vscode.TabGroup[]): TabUriSets {
+  const normal = new Set<string>();
+  const diff = new Set<string>();
+  for (const group of groups) {
+    for (const tab of group.tabs) {
+      const input = tab.input;
+      if (input instanceof vscode.TabInputText) {
+        normal.add(input.uri.toString());
+      } else if (input instanceof vscode.TabInputTextDiff) {
+        diff.add(input.original.toString());
+        diff.add(input.modified.toString());
+      }
+    }
+  }
+  return { normal, diff };
+}
+
+/**
+ * The URIs shown *only* in diff editors — present on a diff side and in no normal
+ * editor tab. A file open both ways is deliberately excluded so its diagnostics
+ * survive while it is being edited.
+ */
+export function diffOnlyUris(sets: TabUriSets): Set<string> {
+  const out = new Set<string>();
+  for (const uri of sets.diff) {
+    if (!sets.normal.has(uri)) {
+      out.add(uri);
+    }
+  }
+  return out;
+}
+
+/** Keys present in exactly one of the two sets. */
+export function symmetricDifference(a: Set<string>, b: Set<string>): Set<string> {
+  const out = new Set<string>();
+  for (const x of a) {
+    if (!b.has(x)) out.add(x);
+  }
+  for (const x of b) {
+    if (!a.has(x)) out.add(x);
+  }
+  return out;
+}
+
+/**
+ * Decide what to hand the client for one URI: the real diagnostics, or an empty
+ * set when suppression is enabled for that resource and the URI is diff-only.
+ */
+export function displayDiagnostics(
+  uri: vscode.Uri,
+  diagnostics: vscode.Diagnostic[],
+  diffOnly: Set<string>,
+  isEnabled: (uri: vscode.Uri) => boolean,
+): vscode.Diagnostic[] {
+  if (diagnostics.length === 0 || !diffOnly.has(uri.toString())) {
+    return diagnostics;
+  }
+  return isEnabled(uri) ? [] : diagnostics;
+}
+
+/**
+ * Tracks diff editors and gates diagnostics accordingly. Install its
+ * [`handleDiagnostics`](#handleDiagnostics) as the language client's
+ * `handleDiagnostics` middleware and add the instance to the extension's
+ * subscriptions so its listeners are cleaned up on deactivate.
+ */
+export class DiffDiagnosticsSuppressor implements vscode.Disposable {
+  private readonly disposables: vscode.Disposable[] = [];
+  /** The last real diagnostics the server pushed, keyed by `Uri.toString()`. */
+  private readonly latest = new Map<
+    string,
+    { uri: vscode.Uri; diagnostics: vscode.Diagnostic[] }
+  >();
+  /** The client's diagnostic sink, captured from the middleware's `next`. */
+  private apply?: ApplyDiagnostics;
+  /** URIs currently shown exclusively in diff editors. */
+  private diffOnly: Set<string>;
+
+  constructor() {
+    this.diffOnly = diffOnlyUris(collectTabUriSets(vscode.window.tabGroups.all));
+    this.disposables.push(
+      vscode.window.tabGroups.onDidChangeTabs(() => this.onTabsChanged()),
+      vscode.workspace.onDidChangeConfiguration((e) => {
+        if (e.affectsConfiguration(CONFIG_PATH)) {
+          this.reapplyAll();
+        }
+      }),
+      vscode.workspace.onDidCloseTextDocument((doc) => {
+        this.latest.delete(doc.uri.toString());
+      }),
+    );
+  }
+
+  /**
+   * `Middleware.handleDiagnostics` entry point. Remembers the server's real
+   * diagnostics for the URI, then forwards either those or an empty set.
+   */
+  handleDiagnostics(
+    uri: vscode.Uri,
+    diagnostics: vscode.Diagnostic[],
+    next: ApplyDiagnostics,
+  ): void {
+    this.apply = next;
+    this.latest.set(uri.toString(), { uri, diagnostics });
+    next(uri, this.display(uri, diagnostics));
+  }
+
+  private display(uri: vscode.Uri, diagnostics: vscode.Diagnostic[]): vscode.Diagnostic[] {
+    return displayDiagnostics(uri, diagnostics, this.diffOnly, isSuppressionEnabled);
+  }
+
+  private onTabsChanged(): void {
+    const previous = this.diffOnly;
+    this.diffOnly = diffOnlyUris(collectTabUriSets(vscode.window.tabGroups.all));
+    // A URI whose diff-only status is unchanged already shows the right set;
+    // only the ones that flipped need re-evaluating.
+    for (const key of symmetricDifference(previous, this.diffOnly)) {
+      this.reapply(key);
+    }
+  }
+
+  private reapplyAll(): void {
+    for (const key of this.latest.keys()) {
+      this.reapply(key);
+    }
+  }
+
+  private reapply(key: string): void {
+    const entry = this.latest.get(key);
+    if (!entry || !this.apply) {
+      return;
+    }
+    this.apply(entry.uri, this.display(entry.uri, entry.diagnostics));
+  }
+
+  dispose(): void {
+    for (const d of this.disposables) {
+      d.dispose();
+    }
+    this.disposables.length = 0;
+    this.latest.clear();
+  }
+}
+
+/** Whether diff-editor suppression is enabled for the given resource. */
+function isSuppressionEnabled(uri: vscode.Uri): boolean {
+  return vscode.workspace.getConfiguration(CONFIG_SECTION, uri).get<boolean>(CONFIG_KEY, false);
+}

--- a/editors/vscode/src/diffAnalysis.ts
+++ b/editors/vscode/src/diffAnalysis.ts
@@ -19,21 +19,25 @@
 import * as vscode from "vscode";
 
 /**
- * Per-resource suppression of Tcl diagnostics for documents that are only being
- * viewed in a diff editor — a Git change (Source Control), "Compare With…",
- * "Compare with Saved", and similar. On by default;
- * `tclLsp.suppressDiagnosticsInDiffEditors: false` keeps diagnostics visible
- * in diffs. (Deliberately NOT under `tclLsp.diagnostics.*` — the server treats
- * every boolean key in that section as a per-code on/off toggle, so a
- * client-only key there would leak into `disabled_diagnostics` and the
- * config-file export.)
+ * Optional per-resource suppression of Tcl diagnostics for documents that are
+ * only being viewed in a diff editor — a Git change (Source Control), "Compare
+ * With…", "Compare with Saved", and similar. Off by default:
+ * `tclLsp.suppressDiagnosticsInDiffEditors: true` hides them while reviewing.
+ * (Deliberately NOT under `tclLsp.diagnostics.*` — the server treats every
+ * boolean key in that section as a per-code on/off toggle, so a client-only
+ * key there would leak into `disabled_diagnostics` and the config-file
+ * export.)
  *
  * "Diff editor" is a purely client-side concept: the language server publishes
  * diagnostics per URI and has no idea an editor is rendering that URI as a diff.
- * The modified side of a Git diff is the real working-tree file (`file:` scheme)
- * and is analysed exactly like any open file, so its *whole-file* diagnostics —
- * mostly findings that predate the change under review — would otherwise paint
- * the diff.
+ * The analyser never runs on diff *content* — a diff editor is two real
+ * documents rendered side by side. The modified side of a Git diff is the
+ * working-tree file (`file:` scheme), analysed exactly like any open file, so
+ * the squiggles a diff shows are that file's own correct, current, *whole-file*
+ * diagnostics (the `git:` original side is outside the document selector and
+ * never analysed). They are shown by default; this setting is for reading a
+ * change without the analyser's noise, since most findings predate the change
+ * under review.
  *
  * The gating happens in the `handleDiagnostics` middleware: the real diagnostics
  * are remembered per URI, but an empty set is handed to the client whenever the
@@ -205,5 +209,5 @@ export class DiffDiagnosticsSuppressor implements vscode.Disposable {
 
 /** Whether diff-editor suppression is enabled for the given resource. */
 function isSuppressionEnabled(uri: vscode.Uri): boolean {
-  return vscode.workspace.getConfiguration(CONFIG_SECTION, uri).get<boolean>(CONFIG_KEY, true);
+  return vscode.workspace.getConfiguration(CONFIG_SECTION, uri).get<boolean>(CONFIG_KEY, false);
 }

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -72,6 +72,7 @@ import {
 } from "./compilerExplorer";
 import { openTkPreview, tkPreviewDocChanged, tkPreviewEditorChanged } from "./tkPreviewPanel";
 import { registerHighlightingHealthChecks } from "./highlightingHealth";
+import { DiffDiagnosticsSuppressor } from "./diffAnalysis";
 import { TCL_LANGUAGE_IDS, isTclLanguage } from "./languageIds";
 
 const execFileAsync = promisify(execFile);
@@ -356,6 +357,13 @@ export async function activate(context: ExtensionContext) {
     options: { cwd: path.dirname(rustBin) },
   };
 
+  // Optional suppression of diagnostics for files viewed only in a diff editor
+  // (Git changes, "Compare With…"); gated by
+  // `tclLsp.diagnostics.suppressInDiffEditors` (default off). Installed as the
+  // `handleDiagnostics` middleware below.
+  const diffSuppressor = new DiffDiagnosticsSuppressor();
+  context.subscriptions.push(diffSuppressor);
+
   const clientOptions: LanguageClientOptions = {
     documentSelector: [
       ...[...TCL_LANGUAGE_IDS].flatMap((lang) => [
@@ -373,6 +381,8 @@ export async function activate(context: ExtensionContext) {
       ],
     },
     middleware: {
+      handleDiagnostics: (uri, diagnostics, next) =>
+        diffSuppressor.handleDiagnostics(uri, diagnostics, next),
       workspace: {
         // Pull path: server requests configuration via workspace/configuration
         // for each workspace folder (plus an unscoped fallback request).

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -357,9 +357,9 @@ export async function activate(context: ExtensionContext) {
     options: { cwd: path.dirname(rustBin) },
   };
 
-  // Optional suppression of diagnostics for files viewed only in a diff editor
+  // Suppression of diagnostics for files viewed only in a diff editor
   // (Git changes, "Compare With…"); gated by
-  // `tclLsp.diagnostics.suppressInDiffEditors` (default off). Installed as the
+  // `tclLsp.suppressDiagnosticsInDiffEditors` (default on). Installed as the
   // `handleDiagnostics` middleware below.
   const diffSuppressor = new DiffDiagnosticsSuppressor();
   context.subscriptions.push(diffSuppressor);

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -357,9 +357,9 @@ export async function activate(context: ExtensionContext) {
     options: { cwd: path.dirname(rustBin) },
   };
 
-  // Suppression of diagnostics for files viewed only in a diff editor
+  // Optional suppression of diagnostics for files viewed only in a diff editor
   // (Git changes, "Compare With…"); gated by
-  // `tclLsp.suppressDiagnosticsInDiffEditors` (default on). Installed as the
+  // `tclLsp.suppressDiagnosticsInDiffEditors` (default off). Installed as the
   // `handleDiagnostics` middleware below.
   const diffSuppressor = new DiffDiagnosticsSuppressor();
   context.subscriptions.push(diffSuppressor);

--- a/editors/vscode/src/test/diffAnalysis.test.ts
+++ b/editors/vscode/src/test/diffAnalysis.test.ts
@@ -1,0 +1,193 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import {
+  collectTabUriSets,
+  diffOnlyUris,
+  displayDiagnostics,
+  symmetricDifference,
+} from "../diffAnalysis";
+import { activate, getDocUri, pollUntil, waitForDiagnostics } from "./helper";
+
+function fakeTab(input: unknown): vscode.Tab {
+  return { input } as unknown as vscode.Tab;
+}
+
+function fakeGroup(...tabs: vscode.Tab[]): vscode.TabGroup {
+  return { tabs } as unknown as vscode.TabGroup;
+}
+
+function diag(message: string): vscode.Diagnostic {
+  return new vscode.Diagnostic(
+    new vscode.Range(0, 0, 0, 1),
+    message,
+    vscode.DiagnosticSeverity.Warning,
+  );
+}
+
+suite("Diff Editor Diagnostics Suppression", () => {
+  const a = vscode.Uri.file("/w/a.tcl").toString();
+  const b = vscode.Uri.file("/w/b.tcl").toString();
+  const c = vscode.Uri.file("/w/c.tcl").toString();
+
+  suite("collectTabUriSets", () => {
+    test("classifies normal and diff tabs, ignoring other tab kinds", () => {
+      const uriA = vscode.Uri.file("/w/a.tcl");
+      const uriB = vscode.Uri.file("/w/b.tcl");
+      const groups = [
+        fakeGroup(
+          fakeTab(new vscode.TabInputText(uriA)),
+          fakeTab(new vscode.TabInputTextDiff(uriB, uriA)),
+          fakeTab(new vscode.TabInputTerminal()),
+        ),
+      ];
+
+      const sets = collectTabUriSets(groups);
+
+      assert.deepStrictEqual([...sets.normal].sort(), [a].sort());
+      assert.deepStrictEqual([...sets.diff].sort(), [a, b].sort());
+    });
+
+    test("returns empty sets when no text tabs are open", () => {
+      const sets = collectTabUriSets([fakeGroup(fakeTab(new vscode.TabInputTerminal()))]);
+      assert.strictEqual(sets.normal.size, 0);
+      assert.strictEqual(sets.diff.size, 0);
+    });
+  });
+
+  suite("diffOnlyUris", () => {
+    test("includes a URI shown only in a diff editor", () => {
+      const result = diffOnlyUris({ normal: new Set(), diff: new Set([a]) });
+      assert.deepStrictEqual([...result], [a]);
+    });
+
+    test("excludes a URI also open in a normal editor", () => {
+      const result = diffOnlyUris({ normal: new Set([a]), diff: new Set([a, b]) });
+      assert.deepStrictEqual([...result], [b]);
+    });
+
+    test("excludes a URI shown only in a normal editor", () => {
+      const result = diffOnlyUris({ normal: new Set([a]), diff: new Set() });
+      assert.strictEqual(result.size, 0);
+    });
+  });
+
+  suite("symmetricDifference", () => {
+    test("returns keys present in exactly one set", () => {
+      const result = symmetricDifference(new Set([a, b]), new Set([b, c]));
+      assert.deepStrictEqual([...result].sort(), [a, c].sort());
+    });
+
+    test("is empty for equal sets", () => {
+      assert.strictEqual(symmetricDifference(new Set([a, b]), new Set([a, b])).size, 0);
+    });
+  });
+
+  suite("displayDiagnostics", () => {
+    const uri = vscode.Uri.file("/w/a.tcl");
+    const diags = [diag("W100")];
+    const enabled = () => true;
+    const disabled = () => false;
+
+    test("suppresses to empty when enabled and diff-only", () => {
+      const out = displayDiagnostics(uri, diags, new Set([a]), enabled);
+      assert.strictEqual(out.length, 0);
+    });
+
+    test("passes diagnostics through when the setting is disabled", () => {
+      const out = displayDiagnostics(uri, diags, new Set([a]), disabled);
+      assert.strictEqual(out, diags);
+    });
+
+    test("passes diagnostics through when the URI is not diff-only", () => {
+      const out = displayDiagnostics(uri, diags, new Set(), enabled);
+      assert.strictEqual(out, diags);
+    });
+
+    test("leaves an already-empty set untouched", () => {
+      const empty: vscode.Diagnostic[] = [];
+      const out = displayDiagnostics(uri, empty, new Set([a]), enabled);
+      assert.strictEqual(out, empty);
+    });
+  });
+
+  // End-to-end: drive a real diff editor and the language server, and confirm
+  // the setting hides — and later restores — the file's diagnostics.
+  suite("end-to-end", () => {
+    const docUri = getDocUri("diagnostics.tcl");
+    const originalUri = getDocUri("formatting.tcl");
+    const diagCfg = () => vscode.workspace.getConfiguration("tclLsp.diagnostics");
+
+    teardown(async () => {
+      await diagCfg().update("suppressInDiffEditors", undefined, undefined);
+      await vscode.commands.executeCommand("workbench.action.closeAllEditors");
+    });
+
+    test("hides diagnostics for a file shown only in a diff editor, then restores them", async () => {
+      await diagCfg().update("suppressInDiffEditors", true, undefined);
+
+      // Baseline: the file is open in a normal editor, so — even with the
+      // setting on — its diagnostics are visible (it is not diff-only).
+      await activate(docUri);
+      const baseline = await waitForDiagnostics(docUri, { minCount: 1 });
+      assert.ok(baseline.length > 0, "expected the fixture to produce diagnostics");
+
+      // Open the same file as the modified side of a diff editor…
+      await vscode.commands.executeCommand(
+        "vscode.diff",
+        originalUri,
+        docUri,
+        "diagnostics.tcl (diff-suppression test)",
+      );
+      // …then close its normal tab, leaving it shown only in the diff.
+      await closeNormalTabsFor(docUri);
+
+      await pollUntil(
+        () => vscode.languages.getDiagnostics(docUri).length,
+        (n) => n === 0,
+        { label: "diagnostics suppressed while diff-only", timeout: 15_000 },
+      );
+
+      // Turning the setting off brings them straight back — no edit needed.
+      await diagCfg().update("suppressInDiffEditors", false, undefined);
+      await pollUntil(
+        () => vscode.languages.getDiagnostics(docUri).length,
+        (n) => n > 0,
+        { label: "diagnostics restored after disabling the setting", timeout: 15_000 },
+      );
+    });
+  });
+});
+
+/** Close every *normal* editor tab showing `uri` (leaving diff tabs open). */
+async function closeNormalTabsFor(uri: vscode.Uri): Promise<void> {
+  const targets: vscode.Tab[] = [];
+  for (const group of vscode.window.tabGroups.all) {
+    for (const tab of group.tabs) {
+      const input = tab.input;
+      if (input instanceof vscode.TabInputText && input.uri.toString() === uri.toString()) {
+        targets.push(tab);
+      }
+    }
+  }
+  if (targets.length > 0) {
+    await vscode.window.tabGroups.close(targets);
+  }
+}

--- a/editors/vscode/src/test/diffAnalysis.test.ts
+++ b/editors/vscode/src/test/diffAnalysis.test.ts
@@ -129,19 +129,25 @@ suite("Diff Editor Diagnostics Suppression", () => {
   });
 
   // End-to-end: drive a real diff editor and the language server, and confirm
-  // the setting hides — and later restores — the file's diagnostics.
+  // the default-on setting hides — and disabling it restores — the file's
+  // diagnostics.
   suite("end-to-end", () => {
     const docUri = getDocUri("diagnostics.tcl");
     const originalUri = getDocUri("formatting.tcl");
-    const diagCfg = () => vscode.workspace.getConfiguration("tclLsp.diagnostics");
+    const cfg = () => vscode.workspace.getConfiguration("tclLsp");
 
     teardown(async () => {
-      await diagCfg().update("suppressInDiffEditors", undefined, undefined);
+      await cfg().update("suppressDiagnosticsInDiffEditors", undefined, undefined);
       await vscode.commands.executeCommand("workbench.action.closeAllEditors");
     });
 
+    test("suppressDiagnosticsInDiffEditors defaults to true", () => {
+      assert.strictEqual(cfg().get<boolean>("suppressDiagnosticsInDiffEditors"), true);
+    });
+
     test("hides diagnostics for a file shown only in a diff editor, then restores them", async () => {
-      await diagCfg().update("suppressInDiffEditors", true, undefined);
+      // No explicit update here: the suppression must kick in from the
+      // setting's default (on).
 
       // Baseline: the file is open in a normal editor, so — even with the
       // setting on — its diagnostics are visible (it is not diff-only).
@@ -166,7 +172,7 @@ suite("Diff Editor Diagnostics Suppression", () => {
       );
 
       // Turning the setting off brings them straight back — no edit needed.
-      await diagCfg().update("suppressInDiffEditors", false, undefined);
+      await cfg().update("suppressDiagnosticsInDiffEditors", false, undefined);
       await pollUntil(
         () => vscode.languages.getDiagnostics(docUri).length,
         (n) => n > 0,

--- a/editors/vscode/src/test/diffAnalysis.test.ts
+++ b/editors/vscode/src/test/diffAnalysis.test.ts
@@ -129,7 +129,7 @@ suite("Diff Editor Diagnostics Suppression", () => {
   });
 
   // End-to-end: drive a real diff editor and the language server, and confirm
-  // the default-on setting hides — and disabling it restores — the file's
+  // the opt-in setting hides — and disabling it restores — the file's
   // diagnostics.
   suite("end-to-end", () => {
     const docUri = getDocUri("diagnostics.tcl");
@@ -141,13 +141,14 @@ suite("Diff Editor Diagnostics Suppression", () => {
       await vscode.commands.executeCommand("workbench.action.closeAllEditors");
     });
 
-    test("suppressDiagnosticsInDiffEditors defaults to true", () => {
-      assert.strictEqual(cfg().get<boolean>("suppressDiagnosticsInDiffEditors"), true);
+    test("suppressDiagnosticsInDiffEditors defaults to false", () => {
+      // Diagnostics in a diff are the underlying file's own diagnostics (the
+      // analyser never runs on diff content), so they stay visible by default.
+      assert.strictEqual(cfg().get<boolean>("suppressDiagnosticsInDiffEditors"), false);
     });
 
     test("hides diagnostics for a file shown only in a diff editor, then restores them", async () => {
-      // No explicit update here: the suppression must kick in from the
-      // setting's default (on).
+      await cfg().update("suppressDiagnosticsInDiffEditors", true, undefined);
 
       // Baseline: the file is open in a normal editor, so — even with the
       // setting on — its diagnostics are visible (it is not diff-only).


### PR DESCRIPTION
## Summary

- Adds `tclLsp.suppressDiagnosticsInDiffEditors` (boolean, default **off**): when enabled, Tcl diagnostics are hidden for a file while it is shown **only** in a VS Code diff/compare editor — a Git change in **Source Control**, **Compare With…**, or **Compare with Saved**. Fixes #939.
- **Why diagnostics stay visible by default:** the analyser never runs on diff *content*. A diff editor is two real documents rendered side by side; the modified side of a Git diff is the working-tree file, analysed like any open file (the `git:` original side sits outside the document selector and is never analysed). The squiggles a diff shows are therefore the underlying file's own correct, current diagnostics — so showing them is the right default, and suppression is the opt-in #939 asked for (most whole-file findings predate the change under review, which makes diffs noisy to read).
- "Diff editor" is a purely client-side concept the language server cannot see, so gating lives in the VS Code extension's `handleDiagnostics` middleware (`editors/vscode/src/diffAnalysis.ts`): the real diagnostics are remembered per URI, but an empty set is delivered whenever suppression is enabled and the URI is shown **exclusively** in diff editors.
- A file also open in a normal editor keeps its diagnostics, so analysis of files being edited is never dimmed. Tab and configuration changes re-evaluate affected URIs, so squiggles return the instant a diff is closed or the setting is turned off — no edit or reload needed. The server keeps analysing throughout; no diagnostics are lost.
- The setting is deliberately **top-level**, not under `tclLsp.diagnostics.*`: the server reads every boolean key in that section as a per-code on/off toggle (`settings_disabled_diagnostics`), so a client-only key there would leak into `disabled_diagnostics` and the `[diagnostics]` section written by **Export Settings to Config File**. (Flagged by Codex review; verified against the server source.)
- Docs: new README subsection under "Suppressing diagnostics" and a new KCS how-to (`docs/kcs/kcs-howto-hide-diagnostics-in-diff-views.md`, linked from `docs/kcs/README.md`).
- Uses only tab APIs stable since VS Code 1.67 (`TabInputText`, `TabInputTextDiff`, `tabGroups.onDidChangeTabs`), well within the pinned `^1.95.0` engine — no API bump needed.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make lint                                   # ESLint + Prettier (+ Python ruff) — clean
make rust-check                             # cargo fmt + clippy + all xtask drift gates — pass
make check-all                              # multi-language push gate — pass
npx tsc --noEmit -p editors/vscode          # TypeScript typecheck — clean
cargo xtask gen-vscode-package --check      # package.json sections in sync (re-run per revision)
cargo xtask kcs-index-links                 # KCS index links pass (re-run per revision)
TCL_LSP_SERVER_BIN=target/release/tcl-lsp-server make test-ext
                                            # full VS Code extension suite, re-run per revision:
                                            # 669 passing (includes the 13-test diff-suppression
                                            # suite with an end-to-end diff-editor test)
make test-rust                              # full Rust workspace suite
```

`make test-rust` run alongside the other suites hit the two `semantic_tokens_reference_client::large_file_*` latency-barrier timeouts that the test harness itself labels the known CPU-starvation flake when run unisolated under parallel load; the isolated `lsp-e2e` CI job — which the harness names as the authoritative isolated run for these tests — is green on this Rust tree (unchanged by this PR).

The end-to-end test opens a real diff editor and the language server, confirms the file's diagnostics vanish once suppression is enabled and the file is shown only in the diff, and reappear when the setting is turned off.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — **No.** This is a VS Code client-side display feature; the analyser and every compiler fact are untouched (the server still publishes the same diagnostics; the extension only decides whether to paint them in a diff editor).
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A.
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`. — N/A (the added note is a user how-to under `docs/kcs/`, linked from `docs/kcs/README.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hg1fy1BaCgbQQRUhrcrNiF