### PR TITLE
Comprehensive type tracking: commit dataflow, union lattice, element inference, exact bignum tower, per-element arrays (#940)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4126,6 +4126,9 @@ name = "tcl-compiler"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "rayon",
  "regex",
  "rustc-hash",
@@ -4389,6 +4392,9 @@ name = "tcl-syntax"
 version = "0.1.0"
 dependencies = [
  "bitflags 2.13.0",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "tcl-dialect",
  "tcl-lexer",
 ]

--- a/README.md
+++ b/README.md
@@ -659,21 +659,32 @@ Tracks each variable's Tcl internal representation through the SSA type
 lattice.  When a command forces a type conversion ("shimmer"), the
 performance cost is reported — especially inside loops.
 
+A *literal* is a pure string until first read as another type, so that first,
+lossless conversion is free — a braced list literal iterated by `foreach` is
+**not** a shimmer (issue #940).  The warnings fire on a *committed* internal
+representation (from `[list]`, `[dict create]`, `expr`, …) that a later
+operation forces to a different type.
+
 ```tcl
 # S100 — single shimmer (info):
-set x "hello"
-set n [llength $x]       ;# 'x' shimmers from STRING → LIST
+set x [list 1 2 3]
+set n [string length $x]   ;# 'x' shimmers from LIST → STRING (committed list)
+
+# not a shimmer — a pure list literal read as a list is free:
+set fontSizes {10.0 12.0 16.0 24.0}
+foreach size $fontSizes { ... }
 
 # S101 — shimmer inside loop (warning):
-set s "42"
 for {set i 0} {$i < 1000} {incr i} {
-    set v [expr {$s + $i}]   ;# 's' shimmers STRING → INT on every iteration
+    set d [dict create k $i]   ;# a fresh committed dict each pass
+    set n [llength $d]         ;# 'd' shimmers DICT → LIST on every iteration
 }
 
 # S102 — type thunking (warning):
-for {set i 0} {$i < 100} {incr i} {
-    set n [llength $data]     ;# 'data' shimmers STRING → LIST
-    set data "updated $n"     ;# 'data' back to STRING — oscillates each iteration
+set acc ""
+foreach x $items {
+    lappend acc $x             ;# 'acc' is a list here
+    set acc "$acc,"            ;# back to a string — oscillates each iteration
 }
 ```
 

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -5273,6 +5273,78 @@ detection still catches genuinely alternating intreps.
 
 ---
 
+### FP-SH-21 — a pure value's first conversion is free (issue #940)
+
+- **Verdict:** FALSE POSITIVE (now fixed)
+- **Status:** locked in by `analyser/diagnostics/fp/sh.rs::fp_sh_21_*`, the
+  unit tests `shimmer/hints.rs::uncommitted_*` / `*_is_not_free`, and
+  `shimmer/use_site.rs::no_shimmer_for_foreach_header_with_pure_string` /
+  `no_shimmer_for_pure_literal_as_list`
+- **Codes:** S100 / S101 (use-site and expr-operator shimmer)
+
+#### Reproducer
+
+```tcl
+set fontSizes {10.0 12.0 16.0 24.0}
+foreach size $fontSizes { ... }   ;# was S100: "string intrep but foreach expects list"
+set empty {}
+foreach x $empty { ... }          ;# {} is the exact case in the issue title
+set a 1
+foreach b $a { ... }              ;# a "1" is still a valid 1-element list
+set d {a 1 b 2}
+dict for {k v} $d { ... }         ;# even-length list literal is a valid dict
+```
+
+#### Per-line reasoning
+
+A Tcl value is a *pure string* (`typePtr == NULL`) until something reads it as
+another type; that first read installs the intrep once, losslessly. The
+reference contract (`docs/design/contracts/shimmer-reference-behaviour.md`,
+"When shimmering does NOT occur") already states this: **pure string objects —
+first type assignment is not a shimmer**. `set fontSizes {…}` yields a pure
+string, and `foreach` merely parses it into a list intrep the first time —
+there is no cached intrep to throw away, so no shimmer.
+
+The old code typed the literal with a committed type (`literal_type` → `Int`
+for `5`, `String` for `{…}`) and treated any differing use as a shimmer, so it
+fired on the *first* — free — conversion. The fix adds
+`shimmer::hints::is_uncommitted_first_conversion`, which classifies committed-
+vs-pure generically from the type lattice plus the SCCP constant lattice (never
+by command name): `String` is always pure; a numeric type is pure only when the
+value is a compile-time constant (a folded literal push); `List`/`Dict`/
+`Object`/`ByteArray`/`Channel` are always committed. A pure value's read is
+suppressed only when it is a **valid instance** of the required type — a
+well-formed list, an even-length list for a dict, a parseable number — so a
+genuine error (`incr` on `hello`) still fires.
+
+#### tclsh ground truth (8.6 and 9.0)
+
+```
+% set fontSizes {10.0 12.0 16.0 24.0}
+% tcl::unsupported::representation $fontSizes   ;# pure string (typePtr == NULL)
+% foreach s $fontSizes {}
+% tcl::unsupported::representation $fontSizes   ;# now a list — a one-time, free parse
+% set x 5
+% tcl::unsupported::representation $x            ;# pure string, NOT a committed int
+% lindex $x 0                                    ;# first read → list, free
+% set real [list 1 2 3]
+% tcl::unsupported::representation $real          ;# committed list
+% string length $real                            ;# list -> string: a genuine shimmer (still fired)
+```
+
+#### Tests
+
+- `analyser/diagnostics/fp/sh.rs::fp_sh_21_braced_list_literal_in_foreach_silent` (FP)
+- `analyser/diagnostics/fp/sh.rs::fp_sh_21_empty_braces_in_foreach_silent` (FP)
+- `analyser/diagnostics/fp/sh.rs::fp_sh_21_scalar_literal_as_list_silent` (FP)
+- `analyser/diagnostics/fp/sh.rs::fp_sh_21_dict_literal_in_dict_for_silent` (FP)
+- `analyser/diagnostics/fp/sh.rs::fp_sh_21_committed_dict_in_foreach_still_fires` (TP control)
+- `analyser/diagnostics/fp/sh.rs::fp_sh_21_incr_on_non_integer_literal_still_fires` (TP control)
+- `analyser/diagnostics/fp/sh.rs::fp_sh_21_committed_list_as_string_still_fires` (TP control)
+- `shimmer/hints.rs::uncommitted_*` / `*_is_not_free` (predicate unit TP/FP/TN/FN)
+
+---
+
 ## OBJ — object dispatch (W307/W308) + snit modelling
 
 W307 catches stray non-literal command words (`$x foo`); W308 validates

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -5345,6 +5345,77 @@ genuine error (`incr` on `hello`) still fires.
 
 ---
 
+### FP-SH-22 — first-use commit: a second conversion is a genuine shimmer
+
+- **Verdict:** FALSE NEGATIVE (now fixed) — FP-SH-21's per-use pure-origin
+  evaluation missed the conversion a *prior* use had already committed
+- **Status:** locked in by `analyser/diagnostics/fp/sh.rs::fp_sh_22_*`, the
+  dataflow unit tests in `shimmer/commit.rs`, and the
+  `commit_dataflow_*` lsp_e2e suite
+- **Codes:** S100 / S101 (use-site, expr-operand, and `incr` shimmer)
+
+#### Reproducer
+
+```tcl
+set v 5
+expr {$v + 1}     ;# first use commits the numeric intrep (free)
+lindex $v 0       ;# second conversion: numeric → list — S100 fires
+
+set l {a 1 b 2}
+foreach i {1 2 3} {
+    llength $l    ;# list ↔ dict re-thunk on every iteration —
+    dict size $l  ;# both S101 (oracle-verified oscillation)
+}
+
+proc f {c} {
+    set a {1 2}
+    if {$c} { llength $a } else { dict size $a }  ;# each arm free (first use)
+    string length $a   ;# matches NEITHER arm — every path pays: S100 fires
+    # a post-merge `llength $a` would match one arm — only one path pays: silent
+}
+```
+
+#### Per-line reasoning
+
+The commitment state is per program point, not per SSA version — a value is
+pure before `lindex $x 0` and a list after it with no new version in between —
+so the flow-insensitive type lattice cannot carry it. `shimmer::commit` runs a
+forward **must/may** dataflow over the SCCP-executable blocks: the may-set of
+committed intreps unions at merges (bounded), `all_committed` intersects, and
+a use fires precisely when it is committed on **every** path to a rep that
+satisfies neither the required intrep nor numeric-family compatibility. That
+quantifier is what keeps the branch case sound: each arm's own conversion is a
+free first commit, and a post-merge use matching one arm pays on only one path
+(silent) while a use matching neither pays on all (fires, with path-dependent
+wording naming the possibilities). The loop re-thunk is restored via the
+existing multi-target `LoopFacts` (two distinct targets in a loop bypass the
+free-first-conversion suppression) plus the steady-state may-rep naming the
+from side.
+
+#### tclsh ground truth (8.6)
+
+```
+% set v 5; expr {$v + 1}
+% tcl::unsupported::representation $v    ;# int — committed by expr
+% lindex $v 0
+% tcl::unsupported::representation $v    ;# list — a genuine re-representation
+% set l {a 1 b 2}
+% foreach i {1 2 3} { llength $l; dict size $l }
+                                          ;# rep alternates list ↔ dict each pass
+```
+
+#### Tests
+
+- `analyser/diagnostics/fp/sh.rs::fp_sh_22_second_conversion_after_expr_commit_fires` (TP)
+- `analyser/diagnostics/fp/sh.rs::fp_sh_22_incr_after_llength_commit_fires` (TP)
+- `analyser/diagnostics/fp/sh.rs::fp_sh_22_loop_two_target_rethunk_is_s101` (TP)
+- `analyser/diagnostics/fp/sh.rs::fp_sh_22_branch_arms_first_conversions_stay_silent` (FP guard)
+- `analyser/diagnostics/fp/sh.rs::fp_sh_22_merge_use_matching_neither_arm_fires` (TP)
+- `shimmer/commit.rs` unit tests (must/may semantics, pushback)
+- lsp_e2e `commit_dataflow_*` (second conversion, loop re-thunk, path-dependent message)
+
+---
+
 ## OBJ — object dispatch (W307/W308) + snit modelling
 
 W307 catches stray non-literal command words (`$x foo`); W308 validates

--- a/docs/design/compiler/FP.md
+++ b/docs/design/compiler/FP.md
@@ -4704,13 +4704,16 @@ re-deriving trace recognition — see
 ### FP-SH-13 — array-element writes collapse onto one SSA symbol; two stable-but-different elements must not read as one variable oscillating
 
 - **Verdict:** FALSE POSITIVE (S100/S101/S102) — fixed
-- **Status:** FIXED for all three shimmer codes. Originally fixed for S102 only
-  (Rust port deep review); the same `array_element_symbols` exclusion is now
-  shared by the use-site (S100/S101) and phi-merge (S101) passes, so an
-  independent-element conflation no longer false-positives through *any*
-  shimmer surface. Proper per-element SSA modelling (which would let a
-  genuinely-oscillating single element still fire) remains the larger,
-  out-of-scope alternative.
+- **Status:** SUPERSEDED by per-element SSA modelling (type-tracking P5).
+  Constant-keyed elements now carry their own SSA symbols, so independent
+  elements cannot conflate at all — the FP this entry guards is prevented
+  structurally, and the `array_element_symbols` exclusion survives only for
+  the *base* symbols (dynamic-key and whole-array flows, which still
+  conflate by design). The flip side landed with it: the reproducer below —
+  the SAME element oscillating int ↔ string each iteration — is a genuine
+  per-iteration re-thunk and now correctly fires S102
+  (`fp_sh_13_same_element_oscillation_fires_s102`); the independent-element
+  variant (`arr(x)` int-stable, `arr(y)` string-stable) stays silent.
 - **Codes:** S100, S101, S102
 - **Corpus:** synthetic (a per-element-stable array accumulator, the common
   Tcl idiom `set arr(id) [somefn $arr(id)]`).

--- a/docs/design/compiler/README.md
+++ b/docs/design/compiler/README.md
@@ -76,6 +76,9 @@ User-facing compiler troubleshooting and how-tos live in
   and liveness.
 - [constant-folding-type-inference.md](constant-folding-type-inference.md)
   — SCCP and type lattice.
+- [type-tracking.md](type-tracking.md) — the comprehensive value-type model
+  (purity / first-use commitment, union nodes, container element types, the
+  numeric tower) with its oracle corpus and phasing.
 - [def-use-chains.md](def-use-chains.md) — def-use chain construction
   and consumer contracts.
 - [memory-ssa.md](memory-ssa.md) — memory-SSA, alias detection, and

--- a/docs/design/compiler/type-tracking.md
+++ b/docs/design/compiler/type-tracking.md
@@ -180,10 +180,15 @@ would not.
    `num-bigint` folds `2**64` / `i64::MAX + 1` / `1 << 63` to C's exact
    values (demote-when-fits; SCCP carries a bignum as its canonical decimal
    string so chained folds re-parse exactly). The operator semantics live
-   once in `tcl_syntax::number_tower` (`BigIntOps` backend trait — the
-   compiler adapts `num-bigint` behind the crate's `num-bigint` feature; the
-   faithful runtime can adapt the real libtommath `mp_int`, keeping the
-   backend swappable with zero semantic drift; the VM is the next adopter).
+   once in `tcl_syntax::number_tower` (`BigIntOps` backend trait), and every
+   backend is pinned by the shared, generic
+   `number_tower::conformance::assert_backend` corpus: the compiler and the
+   **VM** (`tcl_vm::expr`, adopted — beyond-i128 operands, `dict incr`
+   promotion, and the exact `int()`/`wide()`/`entier()`/`abs()`/`double()`
+   windows included) run it over `num-bigint`, and the faithful runtime
+   runs it over the **real libtommath `mp_int`** (`runtime/rust`'s
+   `TowerMp` adapter) — backend swappable with zero semantic drift, now
+   proven by one test per backend rather than by review.
    Float edges are oracle-pinned (`tcl_expr_eval::float_edge_oracle_table`):
    NaN comparisons are IEEE-unordered values while NaN operands/results in
    arithmetic decline (C errors), `Inf` propagates, signed zero and
@@ -191,21 +196,31 @@ would not.
    inexact bignum→double contamination declines rather than bet on rounding
    parity.
 
-### P5 (planned) — arrays as per-constant-key scalars
+### P5 — arrays as per-constant-key scalars ✅ **landed**
 
-Element inference deliberately does **not** cover arrays yet. A Tcl array is
-a collection of *variables*, not a value, and today's SSA conflates every
-`arr(key)` element onto one base symbol (`normalise_var_name` strips the
-`(key)` suffix) — the very conflation the FP-SH-13 exclusions guard against
-in the shimmer passes. The oracle corpus ("array elements behave as
-independent scalars") fixes the faithful design: give each
-**constant-keyed** element (`arr(k)`, `arr(1)`) its own SSA symbol so it
-types/commits/folds as the independent scalar it is, while a dynamic key
-(`arr($i)`) keeps the conflated base with barrier semantics (it may alias
-any element). That is an SSA/naming-layer change, not a registry fact —
-registry-side, `array set` / `array get` then read naturally as
-`DictOfPairs`-shaped bulk moves over those element variables. Landing it
-retires the FP-SH-13 exclusions for constant keys.
+A Tcl array is a collection of *variables*, not a value; the oracle corpus
+("array elements behave as independent scalars") fixes the design. Each
+**constant-keyed** element (`arr(k)`, `set {a($x)} v`'s literal `$x`) is
+its own SSA variable (`naming::element_var_name`; the def/use scanners,
+expr AST, lowering `Call` defs, and `def_use` terminator reads all report
+element-qualified names), so it types, folds, and shimmer-checks as the
+independent scalar it is — per-element hover, per-element SCCP constants,
+and the *same*-element loop oscillation now a true S102 (the pre-P5
+conflation exclusion was a forced false negative there).
+
+A dynamic key (`arr($i)`) stays on the conflated base, and its write
+**fans** as `SsaStatement::may_defs` over the array's known elements:
+each fanned def records a use of the element's prior version, and both
+SCCP and type inference **join** old with written (`set a($k) 9` over an
+INT `a(x)` stays INT; over a STRING one widens; constants become sets,
+never a wrong single fold). An element write also refreshes the base (a
+may-def carrying no value of its own — `$arr` never folds to an
+element's value) so whole-array readers (`array get`) stay ordered.
+Base-name policy sets (special vars like `env`, traced, scope-alias,
+instance/cross-event) are consulted through the element's base, keeping
+`set env(FOO) x` and traced/instance elements exempt as before. The
+FP-SH-13 exclusions remain only for the base symbols they were built
+for; element symbols get full precision.
 
 ### Boolean acceptors (companion centralisation)
 

--- a/docs/design/compiler/type-tracking.md
+++ b/docs/design/compiler/type-tracking.md
@@ -1,0 +1,188 @@
+# Type tracking — comprehensive value-type model (design)
+
+Status: **in progress** — this document is the contract for the type-tracking
+redesign started against issue #940's follow-up work. Each claim in the oracle
+corpus below is tclsh-verified (8.6.14; 9.0 differences noted where known) and
+must be locked in by a test when the corresponding phase lands.
+
+## Goals
+
+1. Model Tcl values the way **C Tcl** does — a string with at most one cached
+   internal representation (intrep) — including *purity* (`typePtr == NULL`),
+   the numeric tower (`int` wide / `bignum` / `double` / `booleanString`), and
+   per-element container types.
+2. Carry **multiple potential types** at a lattice node (bounded union), not
+   just a single `Known` type or a `Shimmered` pair.
+3. Compute **implied element types into containers** — `List<T1..Tn>` /
+   `Dict<K,V>` / `Array<...>` — wherever provable, generalising today's
+   object-only `element_class`.
+4. Track **first-use commitment** flow-sensitively: a pure value's first read
+   as type `T` commits intrep `T` at that program point; later reads as `U ≠ T`
+   are genuine shimmers. Push the committed type back to the def site for
+   visibility (hover) when all paths agree.
+5. Give the **analyser and optimiser** leverage: exact from-types for S100/
+   S101, must-vs-may warning policies over unions, list-op specialisation and
+   folding over known element types, exact bignum-aware constant folding.
+
+## Oracle corpus (tclsh 8.6.14, `tcl::unsupported::representation`)
+
+### Purity and first conversion
+
+| Program | Rep afterwards | Fact |
+|---|---|---|
+| `set x {10.0 12.0 16.0 24.0}` | `pure` | any literal is a pure string, whatever its shape |
+| `set x 5` | `pure` | number-shaped literal is NOT a committed int |
+| … then `foreach s $x` / `lindex $x 0` | `list` | first read installs the intrep once, losslessly (no shimmer) |
+| `set l [list 1 2 3]` | `list` | command results are committed |
+| … then `string length $l` | `string` | committed → different type = genuine shimmer |
+| `set v 5; expr {$v+1}` | `int` | arithmetic commits the numeric intrep |
+| … then `lindex $v 0` | `list` | second conversion = genuine shimmer (currently a known FN) |
+| `set s [string trim "a b c"]` | `pure` | string-command results are pure |
+
+### Numeric tower
+
+| Expression | Result | Result rep | Fact |
+|---|---|---|---|
+| `expr {9007199254740992+1}` | `9007199254740993` | `int` | exact integer arithmetic at 2^53 (i64 wide) |
+| `expr {9007199254740992+1.0}` | `9007199254740992.0` | `double` | one double operand contaminates; f64 precision loss is real and must be folded as C does |
+| `expr {2**64}` | `18446744073709551616` | `bignum` | wide→bignum promotion is seamless, by result magnitude |
+| `expr {$big + 1}` (bignum) | exact | `bignum` | bignum arithmetic exact |
+| `expr {$big - $big}` | `0` | `int` | bignum can demote back to wide |
+| `expr {9223372036854775807 * 2}` | exact | `bignum` | i64 overflow promotes, never wraps |
+| `expr {7/2}` / `expr {-7/2}` | `3` / `-4` | `int` | floor division |
+| `expr {-7%2}` | `1` | `int` | floor modulus |
+| `incr b` on a bignum | exact | `bignum` | incr participates in the tower |
+| `set t true; expr {$t && 1}` | — | `booleanString` | word-booleans have their own rep (keeps the spelling); numeric booleans are just `int` |
+
+Current-compiler baseline (verified via `tcl explore` optimisedSource):
+`-7/2 → -4` and `int+double → double` fold correctly; `i64max+1` and `2**64`
+are (soundly) **not** folded — the enhancement is exact bignum folding, not a
+wrapping fix.
+
+### Containers hold typed objects by reference
+
+| Program | Read-back rep | Fact |
+|---|---|---|
+| `set n [expr {2**20}]; set l2 [list $n other]; lindex $l2 0` | `int` | elements are shared `Tcl_Obj`s; a computed element **keeps its intrep** inside the list |
+| `dict create k1 [expr {1+1}] …; dict get $d k1` | `int` | same for dict values |
+| `foreach x {42 3.14 word}` | `pure` each | braced-literal elements are parsed fresh — pure |
+| `lindex [list 1 2.5 {a b}] i` (word literals) | `string` | parser literal-table words carry the plain string rep |
+| `array set arr {k 5}; expr {$arr(k)+1}` | `int` | array elements behave as independent scalars |
+
+Consequence: `List<T1..Tn>` per-position element types are **faithful to the
+runtime**, not an abstraction — `[list [expr {1+1}] "x y"]` genuinely is
+`List<Int, String>`.
+
+### Shimmer interactions (already locked in by FP-SH-20/21)
+
+- Comparison operators probe per-operand without generating a string rep and
+  fall back to string comparison — never flagged statically.
+- `string` subcommand transparency (`transparent_from`) and dual-ported reads
+  keep intreps — registry-declared, per subcommand.
+- A pure value's first conversion is free (issue #940, FP-SH-21).
+
+## Design
+
+### 1. `TypeShape` — the value-type term
+
+```text
+TypeShape ::= PureString                       ;# typePtr == NULL (any string)
+            | WideInt | Bignum | Double
+            | BooleanWord                      ;# "true"/"off"… word reps
+            | StringRep                        ;# committed UTF cache
+            | ByteArray
+            | List(Elements) | Dict(Elements)  ;# element shapes
+            | Object(class) | Channel
+Elements  ::= Exact([TypeShape; n])            ;# small, per-position (n ≤ K)
+            | Uniform(TypeShape)               ;# homogeneous, any length
+            | Unknown
+```
+
+`TclType` (registry) stays the coarse public vocabulary; `TypeShape` refines it
+inside the compiler. `Numeric` remains the abstract join of the numeric tower.
+
+### 2. Union nodes
+
+A lattice node carries a **bounded set** of possible `TypeShape`s (mirroring
+SCCP's `ConstSet`, widening to `Overdefined` beyond the bound). `Shimmered(a,b)`
+becomes the 2-union carrying its provenance; existing consumers read through
+compatibility accessors.
+
+Warning policy over unions: *must*-style diagnostics (S100 use-site, W126)
+fire only when **every** member mismatches; *may*-style notes can be introduced
+later where a single risky member justifies it.
+
+### 3. Purity and first-use commitment (flow-sensitive)
+
+Per program point, per SSA `(sym, ver)`:
+
+```text
+CommitState ::= Pure | Committed(TypeShape, first_span) | Conflict(a, b)
+```
+
+- Forward must-dataflow over SCCP-executable blocks; registry-declared shimmer
+  positions are the transfer function (a use at an `expected`-typed position
+  moves `Pure → Committed(expected)` when the value is a valid instance).
+- Join: equal commitments survive; differing ones → `Conflict` — a later use
+  matching *neither* side fires (at least one path pays), matching the
+  "multiple different dominator types" analysis.
+- Defs reset state (a new SSA version starts from its producer's shape).
+- Def-site pushback: when every use of a version commits the **same** shape,
+  expose `(def_span → shape)` for hover/inlay ("first used as: list").
+
+### 4. Numeric tower in constant folding
+
+`ConstValue` gains exact integer semantics beyond i64 (bignum), folding
+`2**64` and `i64max+1` exactly as C does, keeping floor div/mod, and modelling
+`int⊕double → double` with genuine f64 rounding. Never wrap; never fold what C
+would not.
+
+### 5. Consumers and leverage
+
+| Consumer | Today | With this design |
+|---|---|---|
+| S100/S101 use-site | single Known type; pure-first-conversion free | exact committed from-type + Conflict-aware second-conversion detection |
+| Hover/inlay | dominant single type | purity + committed shape + "first used as" pushback |
+| Optimiser const-fold | i64-bounded | exact bignum folds |
+| List-op passes | no element facts (object `element_class` only) | `lindex` fold on `Exact` elements, `llength` on `Exact(n)`, guard specialisation on `Uniform` |
+| W126/W307/W308 | single type | must-policy over unions (fewer FPs on merged paths) |
+
+## Phasing
+
+1. **P1 — commit dataflow (shimmer-local)** ✅ **landed**:
+   `shimmer::commit` (`CommitState` must/may pass over SCCP-executable
+   blocks); the use-site / expr / `incr` detectors consult it (second
+   conversions fire with the committed from-type, merges fire only when every
+   path pays, loop re-thunks are S101 with the steady-state rep);
+   `first_use_commitments_for_cu` feeds hover's
+   "string (first used as: list)". Locked in by `shimmer/commit.rs` unit
+   tests, FP-SH-22, and the `commit_dataflow_*` lsp_e2e suite.
+2. **P2 — TypeShape + unions**: introduce alongside `TypeLattice`, migrate
+   consumers via accessors; `element_class` generalises to `Elements`.
+   Unify the three ad-hoc union carriers (SCCP `ConstSet` ≤ 32, the
+   `Shimmered` pair, `class_lattice::ClassValue::Set`) behind one bounded
+   type-set primitive, un-masking the 3+-way merge collapse at
+   `types.rs` `type_join` (documented lossy point).
+3. **P3 — container element inference**: `list`/`dict create`/`lappend`
+   builders + literal parses populate `Elements`; retrieval sites read them.
+   The VM already stores per-element typed values (`IntRep::List(Rc<Vec<Value>>)`),
+   so the static facts mirror the runtime truth.
+4. **P4 — bignum-exact folding**: `ConstValue` gains exact beyond-wide
+   integers, folding `2**64` / `i64max+1` as C does. Reuse the faithful
+   runtime's tower (`runtime/rust/src/bignum.rs` — `NumVal::Wide/Big/Float`
+   with `store`'s demote-when-fits canonicalisation), which already matches
+   `docs/design/contracts/numeric-tower-and-expr-semantics.md`; today's
+   compiler folder *declines* on overflow (sound, never wraps), so this is an
+   enhancement, not a soundness fix.
+
+Each phase lands with its slice of the oracle corpus as tests (unit + FP-SH
+catalogue + lsp_e2e where user-visible).
+
+## Cross-links
+
+- `docs/design/contracts/shimmer-reference-behaviour.md` — shimmer contract.
+- `docs/design/compiler/FP.md` §FP-SH-21 — pure-first-conversion catalogue.
+- `docs/design/contracts/numeric-tower-and-expr-semantics.md` — expr numeric
+  semantics.
+- `rust/tcl-compiler/src/shimmer/hints.rs` — `is_pure_intrep` /
+  `is_valid_instance_of` building blocks.

--- a/docs/design/compiler/type-tracking.md
+++ b/docs/design/compiler/type-tracking.md
@@ -157,23 +157,67 @@ would not.
    `first_use_commitments_for_cu` feeds hover's
    "string (first used as: list)". Locked in by `shimmer/commit.rs` unit
    tests, FP-SH-22, and the `commit_dataflow_*` lsp_e2e suite.
-2. **P2 — TypeShape + unions**: introduce alongside `TypeLattice`, migrate
-   consumers via accessors; `element_class` generalises to `Elements`.
-   Unify the three ad-hoc union carriers (SCCP `ConstSet` ≤ 32, the
-   `Shimmered` pair, `class_lattice::ClassValue::Set`) behind one bounded
-   type-set primitive, un-masking the 3+-way merge collapse at
-   `types.rs` `type_join` (documented lossy point).
-3. **P3 — container element inference**: `list`/`dict create`/`lappend`
-   builders + literal parses populate `Elements`; retrieval sites read them.
-   The VM already stores per-element typed values (`IntRep::List(Rc<Vec<Value>>)`),
-   so the static facts mirror the runtime truth.
-4. **P4 — bignum-exact folding**: `ConstValue` gains exact beyond-wide
-   integers, folding `2**64` / `i64max+1` as C does. Reuse the faithful
-   runtime's tower (`runtime/rust/src/bignum.rs` — `NumVal::Wide/Big/Float`
-   with `store`'s demote-when-fits canonicalisation), which already matches
-   `docs/design/contracts/numeric-tower-and-expr-semantics.md`; today's
-   compiler folder *declines* on overflow (sound, never wraps), so this is an
-   enhancement, not a soundness fix.
+2. **P2 — TypeShape + unions** ✅ **landed**: `TypeLattice` is a bounded
+   canonical union of `TypeShape`s (`bounded_set::BoundedSet`, cap
+   `MAX_TYPE_UNION`); 3+-way merges stay tracked (phi reports every member,
+   hover/inlay render full unions), `Shimmered` survives as the ≥2-member
+   classification, numeric members collapse per the tower, and W126 runs a
+   must-policy over members. SCCP's `ConstSet` and the class lattice keep
+   their own storage deliberately — their dedup is not plain equality
+   (`cv_eq` numeric cross-equality; sorted persistent sets) — documented in
+   `bounded_set.rs`.
+3. **P3 — container element inference** ✅ **landed**: registry facts
+   (`ReturnElements` on `list`/`dict create`/`lindex`/`dict get`/`lrange`,
+   `VarElementsEffect` on `lappend`/`dict set/append/lappend`,
+   `VarWriteTyping::ElementsOf` on `lassign`/`foreach`/`lmap`) drive
+   `type_infer`'s element machinery — the old object-only
+   `collection_element_class` / `container_retrieval_object_type`
+   command-name matches are deleted. Pure/value-unknown element positions
+   stay agnostic (`None`) so FP-SH-17's pins hold; committed sources carry
+   real shapes (`[list [expr {2**20}] x]` is `List<Numeric, ?>`, and
+   `lassign` of an object list types its targets).
+4. **P4 — bignum-exact folding** ✅ **landed**: `TclValue::Big` over
+   `num-bigint` folds `2**64` / `i64::MAX + 1` / `1 << 63` to C's exact
+   values (demote-when-fits; SCCP carries a bignum as its canonical decimal
+   string so chained folds re-parse exactly). The operator semantics live
+   once in `tcl_syntax::number_tower` (`BigIntOps` backend trait — the
+   compiler adapts `num-bigint` behind the crate's `num-bigint` feature; the
+   faithful runtime can adapt the real libtommath `mp_int`, keeping the
+   backend swappable with zero semantic drift; the VM is the next adopter).
+   Float edges are oracle-pinned (`tcl_expr_eval::float_edge_oracle_table`):
+   NaN comparisons are IEEE-unordered values while NaN operands/results in
+   arithmetic decline (C errors), `Inf` propagates, signed zero and
+   denormals round-trip, `isqrt` is exact at the f64-rounding edge, and an
+   inexact bignum→double contamination declines rather than bet on rounding
+   parity.
+
+### P5 (planned) — arrays as per-constant-key scalars
+
+Element inference deliberately does **not** cover arrays yet. A Tcl array is
+a collection of *variables*, not a value, and today's SSA conflates every
+`arr(key)` element onto one base symbol (`normalise_var_name` strips the
+`(key)` suffix) — the very conflation the FP-SH-13 exclusions guard against
+in the shimmer passes. The oracle corpus ("array elements behave as
+independent scalars") fixes the faithful design: give each
+**constant-keyed** element (`arr(k)`, `arr(1)`) its own SSA symbol so it
+types/commits/folds as the independent scalar it is, while a dynamic key
+(`arr($i)`) keeps the conflated base with barrier semantics (it may alias
+any element). That is an SSA/naming-layer change, not a registry fact —
+registry-side, `array set` / `array get` then read naturally as
+`DictOfPairs`-shaped bulk moves over those element variables. Landing it
+retires the FP-SH-13 exclusions for constant keys.
+
+### Boolean acceptors (companion centralisation)
+
+C Tcl's two boolean acceptors live once in `tcl_syntax::boolean`, both
+oracle-table-pinned: `parse_boolean_strict` (`ParseBoolean` — word prefixes
+plus exactly `0`/`1`; `string is boolean`) and `truthiness`
+(`Tcl_GetBooleanFromObj` — word else any number vs zero; `NaN` is a domain
+error, `±Inf` truthy). Every former hand-rolled word list (`string is`
+const-fold, VM `as_bool`, intervals, the folder's boolean contexts, the
+type classifier, expr-simplify's vocabulary) now routes through them; the
+migration fixed two real divergences (VM treated `NaN` as truthy; the
+folder folded `!NaN`).
 
 Each phase lands with its slice of the oracle corpus as tests (unit + FP-SH
 catalogue + lsp_e2e where user-visible).

--- a/docs/design/contracts/shimmer-reference-behaviour.md
+++ b/docs/design/contracts/shimmer-reference-behaviour.md
@@ -59,17 +59,31 @@ list for a dict, or a parseable number — so a genuine runtime error (`incr` on
 `hello`) still fires. This is what fixed issue #940 (`foreach $bracedList`); see
 `docs/design/compiler/FP.md` §FP-SH-21.
 
-**Known limitation (tracked follow-up).** Because each use is evaluated against
-the *pure origin* independently — the sound, branch-safe choice — a value that a
-*dominating* earlier use has already committed to a different intrep is not
-re-flagged: straight-line `set a 1; lindex $a 0; expr {$a + 1}` genuinely
-shimmers list→int at the `expr`, but is currently silent (a false negative, not
-a false positive). Recovering it needs a shared committed-intrep forward
-dataflow across the use-site / expr / incr detectors keyed on the dominator
-tree — fire when a use's intrep differs from that committed by a *dominating*
-use of the same value. The branch case where two paths commit different types
-(`if {…} {expr {$a+1}} else {foreach x $a}`) correctly stays silent: neither use
-dominates the other, and at runtime each path is single-type.
+#### The committed-intrep dataflow (first-use commit)
+
+The follow-up above is implemented by `shimmer::commit` — a forward must/may
+dataflow over the SCCP-executable blocks, shared by the use-site, expr, and
+`incr` detectors. Per SSA value it tracks the bounded set of intreps the value
+*may* have committed on some path and whether *every* path has committed one:
+
+- **Second conversions fire with the true from-type**: straight-line
+  `set v 5; expr {$v + 1}; lindex $v 0` reports "numeric intrep but `lindex`
+  expects list" (oracle: rep `int` → `list`), with an "intrep first committed
+  here" related span. Same through `llength` → `incr` (List → Int).
+- **Branch arms stay silent, merges fire only when every path pays**: with
+  `if {$c} { llength $a } else { dict size $a }`, each arm's own first
+  conversion is free; a post-merge use matching *one* arm stays silent (only
+  the other path pays — not an every-execution claim), while a use matching
+  *neither* fires with path-dependent wording ("has path-dependent (list or
+  dict) intrep …").
+- **Loop re-thunk**: a pure value read as two distinct intreps inside a loop
+  (`llength $l` + `dict size $l` per pass) re-converts every iteration
+  (oracle: list ↔ dict) — both reads are S101, the steady-state rep naming the
+  from side.
+- **Def-site pushback**: a pure def whose every executable typed read commits
+  the same intrep exposes it via
+  `shimmer::first_use_commitments_for_cu` — hover renders
+  "string (first used as: list)" at the creation site.
 
 ## Reference validation status
 

--- a/docs/design/contracts/shimmer-reference-behaviour.md
+++ b/docs/design/contracts/shimmer-reference-behaviour.md
@@ -38,6 +38,39 @@ BOOLEAN → INT promotion is **not** flagged because it matches Tcl 9.0's O(1) c
 - Pure string objects (`typePtr == NULL`) — first type assignment is not a shimmer
 - Shared object duplication (`Tcl_DuplicateObj`) — original intrep is not affected
 
+#### How the analyser implements "first type assignment is not a shimmer"
+
+The compiler classifies committed-vs-pure generically (never by command name)
+through `shimmer::hints::is_uncommitted_first_conversion`, using the type
+lattice plus the SCCP constant lattice:
+
+- A `String`-typed value (`TclType::String` is documented "pure string, no
+  cached intrep") is always uncommitted.
+- A numeric-typed value is uncommitted only when it is a compile-time constant
+  (a constant-folded literal push, still `typePtr == NULL`); a runtime
+  `expr` / `incr` result is a committed numeric intrep.
+- `List` / `Dict` / `Object` / `ByteArray` / `Channel` are always committed
+  (only `[list]` / `[dict create]` / a constructor / `binary format` produce
+  them).
+
+A use is suppressed only when the pure value is a **valid instance** of the
+required type — a well-formed list (`Tcl_SplitList` succeeds), an even-length
+list for a dict, or a parseable number — so a genuine runtime error (`incr` on
+`hello`) still fires. This is what fixed issue #940 (`foreach $bracedList`); see
+`docs/design/compiler/FP.md` §FP-SH-21.
+
+**Known limitation (tracked follow-up).** Because each use is evaluated against
+the *pure origin* independently — the sound, branch-safe choice — a value that a
+*dominating* earlier use has already committed to a different intrep is not
+re-flagged: straight-line `set a 1; lindex $a 0; expr {$a + 1}` genuinely
+shimmers list→int at the `expr`, but is currently silent (a false negative, not
+a false positive). Recovering it needs a shared committed-intrep forward
+dataflow across the use-site / expr / incr detectors keyed on the dominator
+tree — fire when a use's intrep differs from that committed by a *dominating*
+use of the same value. The branch case where two paths commit different types
+(`if {…} {expr {$a+1}} else {foreach x $a}`) correctly stays silent: neither use
+dominates the other, and at runtime each path is single-type.
+
 ## Reference validation status
 
 C source analysis completed against Tcl 9.0.3. The `arg_types` shimmer hints

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -112,6 +112,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   a new pass to the compiler pipeline.
 - [kcs-howto-ir-cfg-ssa-diagnostics.md](kcs-howto-ir-cfg-ssa-diagnostics.md)
   — debug an IR, CFG, or SSA diagnostic end-to-end.
+- [kcs-howto-array-element-ssa-typing.md](kcs-howto-array-element-ssa-typing.md)
+  — the per-element array SSA contract: may-def joins, synthetic-def
+  skips, base-keyed policy checks.
 - [kcs-howto-work-on-fuzz-findings.md](kcs-howto-work-on-fuzz-findings.md)
   — triage, fix, test, and close a differential-fuzzer finding.
 - [kcs-howto-author-tcl-test-scripts.md](kcs-howto-author-tcl-test-scripts.md)

--- a/docs/kcs/codes/kcs-diagnostic-s100-shimmer-outside-loop.md
+++ b/docs/kcs/codes/kcs-diagnostic-s100-shimmer-outside-loop.md
@@ -58,6 +58,19 @@ a command — `[list …]`, `[dict create …]`, an object constructor, or
 read as a type it is **not** a valid instance of (`incr` on `hello`, which fails
 at runtime).
 
+It also fires on the **second** conversion of a literal: the first read commits
+the type, and a later read as a different type converts again on every run:
+
+```tcl
+set v 5
+expr {$v + 1}   ;# first read — commits the numeric type, free
+lindex $v 0     ;# second read — numeric converted to list: S100 fires here
+```
+
+The message names the type the value actually held ("has numeric intrep but
+`lindex` expects list"), and the related information points at the line that
+first committed it.
+
 ### A variable filled by a destructuring command
 
 A variable filled by a *destructuring* command — `lassign`, `scan`, `regexp`,

--- a/docs/kcs/codes/kcs-diagnostic-s100-shimmer-outside-loop.md
+++ b/docs/kcs/codes/kcs-diagnostic-s100-shimmer-outside-loop.md
@@ -35,6 +35,31 @@ The analyser reports **`S100`** because `x` is used as both an integer and a str
 
 ## When it does not fire
 
+### A pure literal used as a list, dict, or number
+
+A value written as a literal — a braced list, a quoted string, a bare word, or a
+number — is a *pure string* until something reads it as another type. That first
+read installs the internal type once, for free; there is no cached type to throw
+away, so it is **not** a shimmer. A well-formed list literal iterated by
+`foreach` (or read by `lindex`, `llength`, `dict for`, …) is silent:
+
+```tcl
+set fontSizes {10.0 12.0 16.0 24.0}
+foreach size $fontSizes { ... }    ;# no S100 — {…} is a valid list, read once for free
+set a 1
+foreach b $a { ... }               ;# no S100 — "1" is still a valid one-element list
+set d {a 1 b 2}
+dict for {k v} $d { ... }          ;# no S100 — an even-length list literal is a valid dict
+```
+
+The warning still fires when the value carries a *committed* internal type from
+a command — `[list …]`, `[dict create …]`, an object constructor, or
+`binary format` — and is then read as a different type, or when a literal is
+read as a type it is **not** a valid instance of (`incr` on `hello`, which fails
+at runtime).
+
+### A variable filled by a destructuring command
+
 A variable filled by a *destructuring* command — `lassign`, `scan`, `regexp`,
 `regsub`, or `binary scan` — is **not** flagged. These commands write list
 elements or parsed pieces whose internal type the analyser cannot know, so it

--- a/docs/kcs/kcs-howto-array-element-ssa-typing.md
+++ b/docs/kcs/kcs-howto-array-element-ssa-typing.md
@@ -1,0 +1,94 @@
+# KCS: Array elements are per-key SSA variables (typing, folding, shimmer)
+
+## Applies to
+
+- `rust/tcl-compiler` SSA construction, SCCP, type inference, shimmer and
+  dead-store/unused diagnostics; `rust/tcl-lsp-core` hover.
+
+## Symptom
+
+- A diagnostic or hover claim about `arr(k)` looks wrong: a type/constant
+  seems to leak between elements, a dead-store fires (or goes silent) on an
+  array element, or an S100/S101/S102 involves `arr(...)` names.
+
+## Operational context
+
+- Since type-tracking P5, a **constant-keyed** element (`arr(k)`;
+  `set {a($x)} v`'s literal `$x`; `${arr($i)}`'s literal `$i`) is its own
+  SSA variable named `base(key)` (`tcl_syntax::naming::element_var_name`).
+  A **dynamic** key (`arr($i)`) stays on the conflated base symbol.
+
+## Decision rules / contracts
+
+1. Element symbols type, const-fold, and shimmer-check independently —
+   the oracle rule is "array elements behave as independent scalars"
+   (tclsh-verified in `docs/design/compiler/type-tracking.md`).
+2. A dynamic-key or whole-array write **fans** over the array's known
+   elements as `SsaStatement::may_defs`. A may-def is a *may*-write: its
+   SCCP value and type are the **join** of the prior version (recorded as
+   a use on the same statement) with the written value — never the
+   written value alone.
+3. An element write also defs the base as a valueless may-def (whole-array
+   readers like `array get` see a fresh version; `$arr` never folds or
+   types as an element's value).
+4. Write-sensitive passes (W211/W220/O109/O126) must skip synthetic defs
+   — check `SsaFunction::is_synthetic_def`. The user wrote one
+   assignment, not one per fanned symbol.
+5. Base-keyed policy sets (special vars such as `env`, traced vars,
+   scope-alias/`variable` tails, instance/cross-event state) are consulted
+   through the element's **base** (`normalise_var_name` of the SSA name).
+6. W210 read-before-set stays silent for an element whose base is
+   written, aliased, or a parameter anywhere in the function; only a
+   wholly-unwritten, unaliased array's element read reports.
+7. The FP-SH-13 exclusion set (`array_element_symbols`) now contains only
+   **base** symbols. Do not re-add element symbols to it — independent
+   elements cannot conflate structurally, and the same-element oscillation
+   is a genuine S102.
+
+## Repro workflow
+
+1. Dump the SSA to see the symbols and may-defs in play:
+   `cargo run -p tcl-cli --bin tcl -- explore --show ssa --text fixture.tcl`
+   (element defs render as `arr(k)#2=...`; fanned/base may-defs appear in
+   the same statement's `defs`).
+2. Lock behaviour with a focused test at the right layer:
+   type inference (`type_infer::tests::array_elements_type_independently`,
+   `dynamic_key_write_joins_element_types`), diagnostics
+   (`rust/tcl-compiler/tests/checks.rs` dead-store/RBS cases), or e2e
+   (`diagnostic_matrix.rs` array rows).
+
+## File-path anchors
+
+- `rust/tcl-syntax/src/naming.rs` — `element_var_name{,_braced}`,
+  `array_key_is_literal`
+- `rust/tcl-compiler/src/ssa.rs` — `collect_array_elems`, `expand_defs`,
+  `SsaStatement::may_defs`, `SsaFunction::is_synthetic_def`
+- `rust/tcl-compiler/src/sccp.rs`, `rust/tcl-compiler/src/type_infer.rs`
+  — may-def join + valueless base rules
+- `rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs`,
+  `rust/tcl-compiler/src/optimiser/elimination.rs` — synthetic-def skips,
+  base-keyed policy checks
+
+## Failure modes
+
+- Treating a may-def like a real def (missing `is_synthetic_def` skip)
+  duplicates W211/W220-class reports per fanned symbol.
+- Assigning a statement's value uniformly to every def re-opens the
+  wrong-element fold (`return $arr(a)` folding to a dynamic write's
+  value) — the join rule exists precisely to prevent this.
+- Checking a base-keyed policy set with the element-qualified name makes
+  `set env(FOO) x` (and traced/instance elements) falsely reportable.
+
+## Test anchors
+
+- `rust/tcl-compiler/src/type_infer.rs` — P5 unit tests
+- `rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs` — FP-SH-13 pair
+  (independent-silent / same-element-fires)
+- `rust/tcl-compiler/tests/checks.rs` — dead-store + read-before-set rows
+- `rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs` — array rows
+
+## Discoverability
+
+- Linked from `docs/kcs/README.md`; design contract in
+  `docs/design/compiler/type-tracking.md` (P5) and
+  `docs/design/compiler/FP.md` §FP-SH-13.

--- a/editors/vscode/src/test/shimmerPrecision.test.ts
+++ b/editors/vscode/src/test/shimmerPrecision.test.ts
@@ -34,7 +34,7 @@ function linesWithCode(diags: vscode.Diagnostic[], code: string): number[] {
 // write-trace awareness, and `# noqa` suppression directives.
 //
 // `shimmerPrecision.tcl` (0-indexed diagnostic lines):
-//   7  lindex $x 0             TRUE  — plain string shimmered to a list intrep
+//   7  lindex $x 0             TRUE  — committed dict shimmered to a list intrep
 //   13 lindex $y 0             FALSE — value already carries a list intrep
 //   20 myindex $z 0            TRUE  — shimmer detected through an interp alias
 //   27 incr a (TclOO method)   TRUE  — method bodies now get shimmer coverage
@@ -68,7 +68,7 @@ suite("Shimmer precision (S100 deep review)", () => {
     return diags;
   }
 
-  test("plain string shimmered by lindex fires S100 with a tight span (true case)", async () => {
+  test("committed dict shimmered by lindex fires S100 with a tight span (true case)", async () => {
     const diags = await s100Diagnostics();
     const x = diags.find((d) => codeOf(d) === "S100" && d.range.start.line === 7);
     assert.ok(x, `expected S100 on line 7 (lindex $x 0); got [${linesWithCode(diags, "S100")}]`);
@@ -135,6 +135,54 @@ suite("Shimmer precision (S100 deep review)", () => {
     assert.ok(
       linesWithCode(diags, "S100").includes(56),
       "'# noqa: W100' must not suppress an unrelated S100",
+    );
+  });
+});
+
+// Issue #940 — a pure list literal used as a list is a free first conversion,
+// not a shimmer. `issue940Shimmer.tcl` (0-indexed lines):
+//   4  foreach $fontSizes  FALSE — braced list literal (reporter's case)
+//   6  foreach $empty      FALSE — the `{}` empty list in the issue title
+//   8  foreach $a          FALSE — a number-shaped literal is still a valid list
+//   10 dict for $d         FALSE — even-length list literal is a valid dict
+//   12 foreach $committed  TRUE  — committed dict shimmers to a list
+suite("Shimmer pure-literal suppression (issue #940)", () => {
+  const docUri = getDocUri("issue940Shimmer.tcl");
+
+  async function shimmerDiagnostics(): Promise<vscode.Diagnostic[]> {
+    await activate(docUri);
+    // The committed-dict case on line 12 is the "analysis ran" settle signal:
+    // once its S100 lands, the absence of S100/S101 on the pure-literal lines
+    // is meaningful rather than a not-yet-analysed empty set.
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "S100" && x.range.start.line === 12),
+    });
+    assert.ok(
+      linesWithCode(diags, "S100").includes(12),
+      `shimmer analysis did not settle (no committed-case S100); got [${linesWithCode(diags, "S100")}]`,
+    );
+    return diags;
+  }
+
+  test("braced list, empty {}, scalar, and dict literals do not shimmer", async () => {
+    const diags = await shimmerDiagnostics();
+    for (const line of [4, 6, 8, 10]) {
+      assert.ok(
+        !linesWithCode(diags, "S100").includes(line) &&
+          !linesWithCode(diags, "S101").includes(line),
+        `a pure list literal on line ${line} must not shimmer; got S100 [${linesWithCode(
+          diags,
+          "S100",
+        )}] S101 [${linesWithCode(diags, "S101")}]`,
+      );
+    }
+  });
+
+  test("a committed container still shimmers (true-positive control)", async () => {
+    const diags = await shimmerDiagnostics();
+    assert.ok(
+      linesWithCode(diags, "S100").includes(12),
+      "a committed dict read as a list must still fire S100",
     );
   });
 });

--- a/editors/vscode/testFixture/issue940Shimmer.tcl
+++ b/editors/vscode/testFixture/issue940Shimmer.tcl
@@ -1,0 +1,13 @@
+# Issue #940: a pure list literal is a valid list, so reading it as one is a
+# free first conversion — no S100/S101 shimmer. The committed case at the end
+# confirms a genuine container shimmer still fires.
+set fontSizes {10.0 12.0 16.0 24.0}
+foreach size $fontSizes { puts $size }
+set empty {}
+foreach x $empty { puts $x }
+set a 1
+foreach b $a { puts $b }
+set d {a 1 b 2}
+dict for {k v} $d { puts "$k=$v" }
+set committed [dict create a 1 b 2]
+foreach y $committed { puts $y }

--- a/editors/vscode/testFixture/shimmerPrecision.tcl
+++ b/editors/vscode/testFixture/shimmerPrecision.tcl
@@ -2,9 +2,9 @@
 # shimmer review (interp alias, TclOO, namespace eval, write-traces,
 # suppression directives).
 
-# True case: a stringy value gets shimmered to a list intrep by lindex.
+# True case: a committed dict intrep gets shimmered to a list by lindex.
 proc shimmer_true_case {} {
-    set x hello
+    set x [dict create a 1 b 2]
     lindex $x 0
 }
 
@@ -17,7 +17,7 @@ proc shimmer_false_case {} {
 # True case: shimmer fires through an interp alias to a shimmering builtin.
 interp alias {} myindex {} ::lindex
 proc shimmer_through_alias {} {
-    set z hello
+    set z [dict create a 1 b 2]
     myindex $z 0
 }
 
@@ -45,14 +45,14 @@ proc shimmer_traced_var {} {
 
 # Suppression directive silences the diagnostic on the following line.
 proc shimmer_suppress_directive_matches {} {
-    set d hello
+    set d [dict create a 1 b 2]
     # noqa: S100
     lindex $d 0
 }
 
 # A directive naming a different code must not silence this one.
 proc shimmer_suppress_directive_mismatches {} {
-    set e hello
+    set e [dict create a 1 b 2]
     # noqa: W100
     lindex $e 0
 }

--- a/runtime/rust/src/bignum.rs
+++ b/runtime/rust/src/bignum.rs
@@ -246,8 +246,11 @@ pub enum ArithError {
     DivideByZero,
     /// A negative shift count (`negative shift argument`).
     NegativeShift,
-    /// An exponent / shift too large to compute (`exponent too large`).
+    /// An exponent too large to compute (`exponent too large`).
     ExponentTooLarge,
+    /// A left-shift count too large to compute (`integer value too large to
+    /// represent`) — C raises this, not "exponent too large", for `<<`.
+    TooLargeToRepresent,
     /// A bignum allocation failed (out of memory).
     Alloc,
 }
@@ -831,23 +834,36 @@ pub fn bnot(a: *mut TclObj) -> Result<*mut TclObj, ArithError> {
     }
 }
 
-/// Read a non-negative shift count (integer-only). A huge bignum count is
-/// `NegativeShift` when negative, else `ExponentTooLarge`.
-fn shift_count(b: *mut TclObj) -> Result<i64, ArithError> {
+/// A validated shift count: a small non-negative wide, or a beyond-wide
+/// positive bignum. The two shift directions disagree about the huge case —
+/// `<<` raises "integer value too large to represent" while `>>` collapses
+/// to the operand's sign (`2 >> 10**20` is `0`, `-2 >> 10**20` is `-1` —
+/// tclsh 8.6/9.0 verified) — so the caller decides.
+enum ShiftCount {
+    Small(i64),
+    HugePositive,
+}
+
+/// Read a non-negative shift count (integer-only). A negative count of any
+/// width is `NegativeShift`.
+fn shift_count(b: *mut TclObj) -> Result<ShiftCount, ArithError> {
     match read_int(b)? {
-        IntVal::Wide(c) if c >= 0 => Ok(c),
+        IntVal::Wide(c) if c >= 0 => Ok(ShiftCount::Small(c)),
         IntVal::Wide(_) => Err(ArithError::NegativeShift),
         IntVal::Big(m) if mp_is_neg(&m) => Err(ArithError::NegativeShift),
-        IntVal::Big(_) => Err(ArithError::ExponentTooLarge),
+        IntVal::Big(_) => Ok(ShiftCount::HugePositive),
     }
 }
 
 /// `a << b` over the tower (integer-only). Always via the bignum path
 /// (`mp_mul_2d`); `store` demotes a small result back to a wide.
 pub fn shl(a: *mut TclObj, b: *mut TclObj) -> Result<*mut TclObj, ArithError> {
-    let count = shift_count(b)?;
+    let count = match shift_count(b)? {
+        ShiftCount::Small(c) => c,
+        ShiftCount::HugePositive => return Err(ArithError::TooLargeToRepresent),
+    };
     if count > i64::from(i32::MAX) {
-        return Err(ArithError::ExponentTooLarge);
+        return Err(ArithError::TooLargeToRepresent);
     }
     let base = int_to_mp(read_int(a)?)?;
     let mut out = Mp::zero().ok_or(ArithError::Alloc)?;
@@ -860,7 +876,17 @@ pub fn shl(a: *mut TclObj, b: *mut TclObj) -> Result<*mut TclObj, ArithError> {
 
 /// `a >> b` over the tower (integer-only, arithmetic/sign-extending).
 pub fn shr(a: *mut TclObj, b: *mut TclObj) -> Result<*mut TclObj, ArithError> {
-    let count = shift_count(b)?;
+    let count = match shift_count(b)? {
+        ShiftCount::Small(c) => c,
+        // A beyond-wide count out-shifts any operand: collapse to the sign.
+        ShiftCount::HugePositive => {
+            let neg = match read_int(a)? {
+                IntVal::Wide(w) => w < 0,
+                IntVal::Big(m) => mp_is_neg(&m),
+            };
+            return Ok(obj::new_wide_int_obj(if neg { -1 } else { 0 }));
+        }
+    };
     match read_int(a)? {
         IntVal::Wide(w) => {
             // Shifting a wide past its width saturates to 0 / -1 (sign).
@@ -1505,6 +1531,33 @@ mod tests {
         assert_eq!(shl(a, n), Err(ArithError::NegativeShift));
         drop1(a);
         drop1(n);
+        assert_eq!(crate::counters::finalize(), 0);
+    }
+
+    /// A beyond-wide positive shift count: `>>` collapses to the operand's
+    /// sign while `<<` is C's "integer value too large to represent" —
+    /// `expr {2 >> 10**20}` is `0`, `{-2 >> 10**20}` is `-1` (tclsh
+    /// 8.6/9.0 verified), never "exponent too large".
+    #[test]
+    fn huge_shift_counts() {
+        crate::counters::reset();
+        let huge = rc1(from_big_digits(false, Radix::Dec, "100000000000000000000"));
+        let two = int_obj(2);
+        let neg_two = int_obj(-2);
+        let r = rc1(shr(two, huge).expect("2 >> huge collapses"));
+        assert_eq!(string_of(r), b"0");
+        drop1(r);
+        let r = rc1(shr(neg_two, huge).expect("-2 >> huge collapses"));
+        assert_eq!(string_of(r), b"-1");
+        drop1(r);
+        assert_eq!(shl(two, huge), Err(ArithError::TooLargeToRepresent));
+        // A wide count past c_int is the same error, not "exponent".
+        let wide_count = int_obj(4_294_967_296);
+        assert_eq!(shl(two, wide_count), Err(ArithError::TooLargeToRepresent));
+        drop1(wide_count);
+        drop1(two);
+        drop1(neg_two);
+        drop1(huge);
         assert_eq!(crate::counters::finalize(), 0);
     }
 }

--- a/runtime/rust/src/bignum.rs
+++ b/runtime/rust/src/bignum.rs
@@ -1013,10 +1013,172 @@ fn store(mut mp: MpInt) -> *mut TclObj {
     obj::alloc_typed(&TCL_BIGNUM_TYPE, boxed as u64)
 }
 
+// ---------------------------------------------------------------------------
+// The shared-tower backend adapter: `BigIntOps` over the real `mp_int`.
+// ---------------------------------------------------------------------------
+
+/// The libtommath backend for the shared tower semantics
+/// (`tcl_syntax::number_tower::BigIntOps`) — the adapter that closes the
+/// tower's backend seam over the real `mp_int`. The pure-Rust adopters (the
+/// compiler's const-folder, the VM) run the identical oracle-conformance
+/// corpus over `num-bigint`; this type runs it over libtommath, so the two
+/// backends cannot drift on any covered semantic. The trait is infallible,
+/// so allocation failure — libtommath's only failure mode on these
+/// operations — panics, matching Rust's global-allocator convention.
+pub struct TowerMp(Mp);
+
+impl TowerMp {
+    /// Run `f` into a fresh `mp_int` and wrap it.
+    fn build(f: impl FnOnce(*mut MpInt) -> c_int) -> Self {
+        let mut out = Mp::zero().expect("libtommath alloc");
+        assert!(f(&mut out.0) == MP_OKAY, "libtommath alloc");
+        TowerMp(out)
+    }
+
+    /// Three-way compare via `mp_cmp`.
+    fn cmp_mp(&self, other: &Self) -> core::cmp::Ordering {
+        // SAFETY: both live mp_ints; mp_cmp returns -1/0/1.
+        match unsafe { mp_cmp(self.0.ptr(), other.0.ptr()) } {
+            n if n < 0 => core::cmp::Ordering::Less,
+            0 => core::cmp::Ordering::Equal,
+            _ => core::cmp::Ordering::Greater,
+        }
+    }
+}
+
+impl Clone for TowerMp {
+    fn clone(&self) -> Self {
+        TowerMp(Mp::copy_of(self.0.ptr()).expect("libtommath alloc"))
+    }
+}
+
+impl PartialEq for TowerMp {
+    fn eq(&self, other: &Self) -> bool {
+        self.cmp_mp(other) == core::cmp::Ordering::Equal
+    }
+}
+impl Eq for TowerMp {}
+impl PartialOrd for TowerMp {
+    fn partial_cmp(&self, other: &Self) -> Option<core::cmp::Ordering> {
+        Some(self.cmp(other))
+    }
+}
+impl Ord for TowerMp {
+    fn cmp(&self, other: &Self) -> core::cmp::Ordering {
+        self.cmp_mp(other)
+    }
+}
+
+impl core::fmt::Debug for TowerMp {
+    fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
+        // Decimal via mp_to_radix (small values only appear in test output).
+        let p = self.0.ptr();
+        // SAFETY: live mp_int; buffer sized by mp_radix_size (incl. NUL).
+        unsafe {
+            let mut size: c_int = 0;
+            if mp_radix_size(p, 10, &mut size) != MP_OKAY || size <= 0 {
+                return write!(f, "<mp?>");
+            }
+            let mut buf = vec![0u8; size as usize];
+            let mut written: usize = 0;
+            if mp_to_radix(
+                p,
+                buf.as_mut_ptr() as *mut c_char,
+                buf.len(),
+                &mut written,
+                10,
+            ) != MP_OKAY
+            {
+                return write!(f, "<mp?>");
+            }
+            let end = written.saturating_sub(1).min(buf.len());
+            write!(f, "{}", String::from_utf8_lossy(&buf[..end]))
+        }
+    }
+}
+
+impl tcl_syntax::number_tower::BigIntOps for TowerMp {
+    fn from_i64(v: i64) -> Self {
+        TowerMp(Mp::from_i64(v).expect("libtommath alloc"))
+    }
+    fn to_i64(&self) -> Option<i64> {
+        // Exact range check (`store`'s demote is deliberately conservative
+        // about i64::MIN; the trait contract is exact).
+        let min = Self::from_i64(i64::MIN);
+        let max = Self::from_i64(i64::MAX);
+        (self.cmp_mp(&min) != core::cmp::Ordering::Less
+            && self.cmp_mp(&max) != core::cmp::Ordering::Greater)
+            // SAFETY: live mp_int within i64 range.
+            .then(|| unsafe { mp_get_i64(self.0.ptr()) })
+    }
+    fn is_zero(&self) -> bool {
+        self.0 .0.used == 0
+    }
+    fn is_negative(&self) -> bool {
+        self.0 .0.used != 0 && self.0 .0.sign != 0
+    }
+    fn add(&self, other: &Self) -> Self {
+        // SAFETY (each op below): live operand mp_ints; out is initialised.
+        Self::build(|out| unsafe { mp_add(self.0.ptr(), other.0.ptr(), out) })
+    }
+    fn sub(&self, other: &Self) -> Self {
+        Self::build(|out| unsafe { mp_sub(self.0.ptr(), other.0.ptr(), out) })
+    }
+    fn mul(&self, other: &Self) -> Self {
+        Self::build(|out| unsafe { mp_mul(self.0.ptr(), other.0.ptr(), out) })
+    }
+    fn div_floor(&self, other: &Self) -> Self {
+        let (q, _) = mp_floor_divmod(&self.0, &other.0).expect("libtommath alloc");
+        TowerMp(q)
+    }
+    fn mod_floor(&self, other: &Self) -> Self {
+        let (_, r) = mp_floor_divmod(&self.0, &other.0).expect("libtommath alloc");
+        TowerMp(r)
+    }
+    fn neg(&self) -> Self {
+        Self::build(|out| unsafe { mp_neg(self.0.ptr(), out) })
+    }
+    fn pow_u32(&self, exp: u32) -> Self {
+        let e = c_int::try_from(exp).expect("exponent fits c_int (tower-capped)");
+        Self::build(|out| unsafe { mp_expt_n(self.0.ptr(), e, out) })
+    }
+    fn shl(&self, count: u32) -> Self {
+        let c = c_int::try_from(count).expect("shift count fits c_int");
+        Self::build(|out| unsafe { mp_mul_2d(self.0.ptr(), c, out) })
+    }
+    fn shr(&self, count: usize) -> Self {
+        // The tower only calls this with `count <= bit_len` (the collapse
+        // guard), so the count always fits c_int.
+        let c = c_int::try_from(count).expect("shift count fits c_int");
+        Self::build(|out| unsafe { mp_signed_rsh(self.0.ptr(), c, out) })
+    }
+    fn bitand(&self, other: &Self) -> Self {
+        Self::build(|out| unsafe { mp_and(self.0.ptr(), other.0.ptr(), out) })
+    }
+    fn bitor(&self, other: &Self) -> Self {
+        Self::build(|out| unsafe { mp_or(self.0.ptr(), other.0.ptr(), out) })
+    }
+    fn bitxor(&self, other: &Self) -> Self {
+        Self::build(|out| unsafe { mp_xor(self.0.ptr(), other.0.ptr(), out) })
+    }
+    fn bit_len(&self) -> u64 {
+        // SAFETY: live mp_int; count is non-negative.
+        u64::try_from(unsafe { mp_count_bits(self.0.ptr()) }).unwrap_or(0)
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::obj;
+
+    /// The real libtommath backend passes the shared tower conformance
+    /// corpus — the differential proof that `mp_int` and the pure-Rust
+    /// `num-bigint` backend (compiler/VM) implement identical semantics.
+    #[test]
+    fn tower_conformance_libtommath() {
+        tcl_syntax::number_tower::conformance::assert_backend::<TowerMp>();
+    }
 
     fn string_of(obj: *mut TclObj) -> Vec<u8> {
         // Force the string rep and read it back.

--- a/runtime/rust/src/expr.rs
+++ b/runtime/rust/src/expr.rs
@@ -87,6 +87,9 @@ pub(crate) fn arith_err(e: ArithError) -> ExprError {
         }
         ArithError::NegativeShift => ExprError::msg(b"negative shift argument"),
         ArithError::ExponentTooLarge => ExprError::msg(b"exponent too large"),
+        ArithError::TooLargeToRepresent => {
+            ExprError::msg(b"integer value too large to represent")
+        }
         ArithError::Alloc => ExprError::msg(b"out of memory"),
     }
 }

--- a/rust/tcl-cmd-core/src/string_is.rs
+++ b/rust/tcl-cmd-core/src/string_is.rs
@@ -130,16 +130,17 @@ fn char_class(class: &str, chars: &[char]) -> (bool, i64) {
 }
 
 fn check_boolean(chars: &[char], class: &str) -> bool {
-    // Tcl accepts `0`/`1` and any *unique* case-insensitive prefix of the
-    // boolean words (so `f`→false, `tru`→true, but `o` is ambiguous on/off).
-    let lc: String = chars.iter().collect::<String>().to_ascii_lowercase();
-    let s = lc.as_str();
-    let truthy = s == "1" || ["true", "yes", "on"].iter().any(|w| w.starts_with(s));
-    let falsy = s == "0" || ["false", "no", "off"].iter().any(|w| w.starts_with(s));
-    match class {
-        "true" => truthy && !falsy,
-        "false" => falsy && !truthy,
-        _ => truthy ^ falsy,
+    // The canonical strict acceptor (`ParseBoolean`): `0`/`1` plus any
+    // *unique* case-insensitive prefix of the boolean words (`f`→false,
+    // `tru`→true; `o` is ambiguous on/off and rejected).
+    let s: String = chars.iter().collect();
+    match tcl_syntax::boolean::parse_boolean_strict(&s) {
+        Some(value) => match class {
+            "true" => value,
+            "false" => !value,
+            _ => true,
+        },
+        None => false,
     }
 }
 

--- a/rust/tcl-compiler/Cargo.toml
+++ b/rust/tcl-compiler/Cargo.toml
@@ -30,7 +30,7 @@ authors.workspace = true
 [dependencies]
 tcl-dialect = { path = "../tcl-dialect" }
 tcl-lexer = { path = "../tcl-lexer" }
-tcl-syntax = { path = "../tcl-syntax" }
+tcl-syntax = { path = "../tcl-syntax", features = ["num-bigint"] }
 tcl-bytecode = { path = "../tcl-bytecode" }
 tcl-registry = { path = "../tcl-registry" }
 tcl-core-types = { path = "../tcl-core-types" }
@@ -39,6 +39,14 @@ thiserror = "2.0"
 unicode-general-category = "1.1.0"
 rustc-hash = { workspace = true }
 regex = "1"
+# Arbitrary-precision integers for exact `expr` constant folding (the P4
+# numeric-tower phase of docs/design/compiler/type-tracking.md): the folder
+# mirrors the VM's `num-bigint` tower so `2**64` / `i64::MAX + 1` fold to the
+# exact values C Tcl computes — never wrapped, never approximated.
+# `num-integer`/`num-traits` supply floor div/mod and primitive narrowing.
+num-bigint = "0.4"
+num-integer = "0.1"
+num-traits = "0.2"
 
 [lints]
 workspace = true

--- a/rust/tcl-compiler/src/analyser/class_lattice.rs
+++ b/rust/tcl-compiler/src/analyser/class_lattice.rs
@@ -633,13 +633,13 @@ fn seed_from_type_lattice<S: std::hash::BuildHasher + Clone>(
 ) {
     use crate::types::TypeKind;
     for ((sym, _ver), tl) in &fu.types {
-        if tl.kind != TypeKind::Known {
+        if tl.kind() != TypeKind::Known {
             continue;
         }
-        if !matches!(tl.tcl_type, Some(tcl_registry::TclType::Object)) {
+        if !matches!(tl.tcl_type(), Some(tcl_registry::TclType::Object)) {
             continue;
         }
-        let Some(class_name) = &tl.class_name else {
+        let Some(class_name) = &tl.class_name() else {
             continue;
         };
         // The type lattice's class name is already namespace-resolved by the

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -316,26 +316,7 @@ file; this call falls through to the 'unknown' handler."
             // (`set a($k) 9` defs base `a` directly): its liveness is
             // carried by the fanned element chains, which exact-name
             // liveness can't see — never report the base.
-            if !var.contains('(')
-                && fu
-                    .cfg
-                    .block_by_name(&chain.definition.block)
-                    .and_then(|b| {
-                        usize::try_from(chain.definition.statement_index)
-                            .ok()
-                            .and_then(|i| b.statements.get(i))
-                    })
-                    .is_some_and(|stmt| {
-                        matches!(
-                            stmt,
-                            Statement::AssignConst { name, .. }
-                                | Statement::AssignExpr { name, .. }
-                                | Statement::AssignValue { name, .. }
-                                | Statement::Incr { name, .. }
-                                if name.contains('(')
-                        )
-                    })
-            {
+            if !var.contains('(') && def_is_element_write(fu, &chain.definition) {
                 continue;
             }
             // Scope-aliased vars (introduced via ``global`` or
@@ -2775,4 +2756,31 @@ fn non_channel_union_label(var_type: &crate::types::TypeLattice) -> Option<Strin
             .collect::<Vec<_>>()
             .join(" | "),
     )
+}
+
+/// Whether the def site's statement is an array-element write
+/// (`set a(k) …` / `set a($k) …` / `incr a(k)`) — the base def such a
+/// write records carries no reportable liveness of its own.
+fn def_is_element_write(
+    fu: &crate::compilation_unit::FunctionUnit,
+    def: &crate::def_use::DefSite,
+) -> bool {
+    use crate::ir::Statement;
+    fu.cfg
+        .block_by_name(&def.block)
+        .and_then(|b| {
+            usize::try_from(def.statement_index)
+                .ok()
+                .and_then(|i| b.statements.get(i))
+        })
+        .is_some_and(|stmt| {
+            matches!(
+                stmt,
+                Statement::AssignConst { name, .. }
+                    | Statement::AssignExpr { name, .. }
+                    | Statement::AssignValue { name, .. }
+                    | Statement::Incr { name, .. }
+                    if name.contains('(')
+            )
+        })
 }

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -1742,7 +1742,6 @@ file; this call falls through to the 'unknown' handler."
         registry: &tcl_registry::CommandRegistry,
     ) {
         use crate::ir::Statement;
-        use crate::types::TypeKind;
         use tcl_registry::ArgRole;
 
         const STANDARD_CHANNELS: &[&str] = &["stdout", "stderr", "stdin"];
@@ -1799,16 +1798,9 @@ file; this call falls through to the 'unknown' handler."
                         let Some(var_type) = fu.types.get(&key) else {
                             continue;
                         };
-                        if var_type.kind != TypeKind::Known {
-                            continue;
-                        }
-                        let Some(tcl_type) = var_type.tcl_type else {
+                        let Some(type_label) = non_channel_union_label(var_type) else {
                             continue;
                         };
-                        if matches!(tcl_type, tcl_registry::TclType::Channel) {
-                            continue;
-                        }
-                        let type_label = format!("{tcl_type:?}").to_uppercase();
                         let message = format!(
                             "Variable '${name}' passed as channel to '{command}' \
                              has type {type_label}, not CHANNEL.",
@@ -2653,4 +2645,32 @@ fn word_references_param(body: &str, param: &str) -> bool {
         i += 1;
     }
     false
+}
+
+/// Must-policy over a channel argument's type union: `Some(label)` when
+/// EVERY member is a non-channel — whatever path ran, the value cannot be a
+/// channel — with the members rendered `"INT | STRING"` for the message. A
+/// union with any Channel member, or an Unknown / Overdefined node, returns
+/// `None`: some path may be fine.
+fn non_channel_union_label(var_type: &crate::types::TypeLattice) -> Option<String> {
+    use crate::types::{TypeKind, TypeShape};
+    if !matches!(var_type.kind(), TypeKind::Known | TypeKind::Shimmered) {
+        return None;
+    }
+    let member_types: Vec<tcl_registry::TclType> =
+        var_type.shapes().iter().map(TypeShape::coarse).collect();
+    if member_types.is_empty()
+        || member_types
+            .iter()
+            .any(|t| matches!(t, tcl_registry::TclType::Channel))
+    {
+        return None;
+    }
+    Some(
+        member_types
+            .iter()
+            .map(|t| format!("{t:?}").to_uppercase())
+            .collect::<Vec<_>>()
+            .join(" | "),
+    )
 }

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -312,6 +312,32 @@ file; this call falls through to the 'unknown' handler."
             ) {
                 continue;
             }
+            // The *direct* base def of a dynamic-key element write
+            // (`set a($k) 9` defs base `a` directly): its liveness is
+            // carried by the fanned element chains, which exact-name
+            // liveness can't see — never report the base.
+            if !var.contains('(')
+                && fu
+                    .cfg
+                    .block_by_name(&chain.definition.block)
+                    .and_then(|b| {
+                        usize::try_from(chain.definition.statement_index)
+                            .ok()
+                            .and_then(|i| b.statements.get(i))
+                    })
+                    .is_some_and(|stmt| {
+                        matches!(
+                            stmt,
+                            Statement::AssignConst { name, .. }
+                                | Statement::AssignExpr { name, .. }
+                                | Statement::AssignValue { name, .. }
+                                | Statement::Incr { name, .. }
+                                if name.contains('(')
+                        )
+                    })
+            {
+                continue;
+            }
             // Scope-aliased vars (introduced via ``global`` or
             // ``upvar``) write through to a different scope — the
             // local "no use" verdict is unsafe. Policy sets hold *base*
@@ -549,6 +575,11 @@ file; this call falls through to the 'unknown' handler."
                 continue;
             }
             let (var, version) = &chain.key;
+            // A `::`-qualified write (`set ::ns::cfg 1`) is visible to every
+            // other scope/file — single-unit dataflow cannot see its readers.
+            if var.contains("::") {
+                continue;
+            }
             if scope_aliases.contains(var) {
                 continue;
             }

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -207,6 +207,7 @@ file; this call falls through to the 'unknown' handler."
             include_var_read_roles: true,
             recurse_cmd_substitutions: true,
             include_reads_before_write: true,
+            element_qualified: false,
         });
         let mut cmd_texts: Vec<String> = Vec::new();
         for block in fu.cfg.blocks.values() {
@@ -296,19 +297,33 @@ file; this call falls through to the 'unknown' handler."
             // when the script never reads them back, so ``set auto_path …`` is
             // not a dead store.  Dialect-aware: the iRules set differs (issue
             // #831).
-            if tcl_registry::special_vars::is_externally_read(var, self.dialect()) {
+            if tcl_registry::special_vars::is_externally_read(
+                crate::naming::normalise_var_name(var),
+                self.dialect(),
+            ) {
+                continue;
+            }
+            // A synthetic may-def (base refresh / element fan) is not a
+            // write the user made — never a reportable dead store.
+            if fu.ssa.is_synthetic_def(
+                &chain.definition.block,
+                chain.definition.statement_index,
+                var,
+            ) {
                 continue;
             }
             // Scope-aliased vars (introduced via ``global`` or
             // ``upvar``) write through to a different scope — the
-            // local "no use" verdict is unsafe.
-            if scope_aliases.contains(var) {
+            // local "no use" verdict is unsafe. Policy sets hold *base*
+            // names, so an element symbol (`a(k)`) checks its base too.
+            let var_base = crate::naming::normalise_var_name(var);
+            if scope_aliases.contains(var) || scope_aliases.contains(var_base) {
                 continue;
             }
             // Cross-event vars (iRules ``::when::*`` defs/imports
             // or ``pkgIndex.tcl`` ``$dir``) may be read in
             // another event/scope at runtime.
-            if cross_event_vars.contains(var) {
+            if cross_event_vars.contains(var) || cross_event_vars.contains(var_base) {
                 continue;
             }
             // Suppress dead stores in SCCP-unreachable blocks —
@@ -540,11 +555,23 @@ file; this call falls through to the 'unknown' handler."
             if textually_referenced.contains(var) {
                 continue;
             }
+            // A synthetic may-def (base refresh / element fan) is not a
+            // write the user made — the element's own chain reports.
+            if fu.ssa.is_synthetic_def(
+                &chain.definition.block,
+                chain.definition.statement_index,
+                var,
+            ) {
+                continue;
+            }
             // Interpreter-provided special variables (``auto_path``, ``env``,
             // …) are consumed by the runtime even when the script never reads
             // them, so a bare ``set auto_path …`` is not an unused variable.
             // Dialect-aware via the special-variable registry (issue #831).
-            if tcl_registry::special_vars::is_externally_read(var, self.dialect()) {
+            if tcl_registry::special_vars::is_externally_read(
+                crate::naming::normalise_var_name(var),
+                self.dialect(),
+            ) {
                 continue;
             }
             // Only emit when no other SSA version of this var is
@@ -1004,6 +1031,31 @@ file; this call falls through to the 'unknown' handler."
             if params.contains(var.as_str()) {
                 continue;
             }
+            // An element read (`$arr(a)`) of an array whose *base* is
+            // defined, aliased, or a parameter anywhere in the function
+            // stays silent: which elements a dynamic write / whole-array
+            // command created is not statically knowable, so only a read
+            // of a wholly-unwritten, unaliased array reports. Policy sets
+            // are base-keyed, so the base is checked for those too.
+            if let Some(open) = var.find('(') {
+                let base = &var[..open];
+                let base_defined = fu.ssa.var_symbol(base).is_some_and(|sym| {
+                    fu.def_use.chains.keys().any(|(n, v)| n == base && *v > 0)
+                        || fu
+                            .ssa
+                            .blocks
+                            .values()
+                            .any(|b| b.statements.iter().any(|st| st.defs.contains_key(&sym)))
+                });
+                if base_defined
+                    || params.contains(base)
+                    || scope_aliases.contains(base)
+                    || extra_known_defined.contains(base)
+                    || supp.suppresses(base)
+                {
+                    continue;
+                }
+            }
             // A fully-qualified read (`$::myVar`, `$ns::var`) explicitly
             // targets the global / a named namespace scope, whose definition
             // may live in another proc, another namespace, or — for a
@@ -1213,6 +1265,7 @@ file; this call falls through to the 'unknown' handler."
             include_var_read_roles: false,
             recurse_cmd_substitutions: true,
             include_reads_before_write: false,
+            element_qualified: false,
         });
 
         let mut reported: FxHashSet<String> = FxHashSet::default();
@@ -2447,7 +2500,7 @@ fn w213_span_and_fix(
 /// provides a different set (its `static::` namespace, no `argv`/`env`) than
 /// standard Tcl.
 fn is_implicit_var(name: &str, dialect: &str) -> bool {
-    tcl_registry::special_vars::is_special_var(name, dialect)
+    tcl_registry::special_vars::is_special_var(crate::naming::normalise_var_name(name), dialect)
 }
 
 /// Tcl ARE metacharacters: a pattern free of these reduces to a literal

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
@@ -463,10 +463,33 @@ proc f {} {
 /// FP-SH-13: `normalise_var_name` strips the `(key)` suffix before SSA
 /// interning, so every element of an array shares one symbol / version
 /// chain.  A loop that keeps writing different-but-per-element-stable types
-/// to different array elements must not fire S102 — the elements are
+/// to *different* array elements must not fire S102 — the elements are
 /// independent runtime slots, not the same value shimmering back and forth.
+/// (Per-element SSA symbols make this precise; the *same* element
+/// oscillating is a genuine S102 — see the TP control below.)
 #[test]
 fn fp_sh_13_array_element_conflation_no_s102() {
+    let src = "\
+proc f {} {
+    set arr(x) 0
+    while {1} {
+        set arr(x) [expr {$arr(x) + 1}]
+        set arr(y) [string range z 0 end]
+    }
+}
+";
+    let got = codes(src, D);
+    assert!(
+        !got.iter().any(|c| c == "S102"),
+        "FP-SH-13: independent array elements must not fire S102; got {got:?}"
+    );
+}
+
+/// Per-element TP: the SAME element oscillating int ↔ string every
+/// iteration is a real per-iteration re-thunk (the pre-P5 conflation
+/// exclusion was a forced false negative here).
+#[test]
+fn fp_sh_13_same_element_oscillation_fires_s102() {
     let src = "\
 proc f {} {
     set arr(x) 0
@@ -478,8 +501,8 @@ proc f {} {
 ";
     let got = codes(src, D);
     assert!(
-        !got.iter().any(|c| c == "S102"),
-        "FP-SH-13: array-element writes must not fire S102; got {got:?}"
+        got.iter().any(|c| c == "S102"),
+        "the same element oscillating every iteration is a real S102; got {got:?}"
     );
 }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
@@ -1390,3 +1390,100 @@ fn fp_sh_20_ordering_compare_numeric_literal_stays_silent() {
         codes(src, D),
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-SH-21 — a pure value's first conversion is free (issue #940)
+// ---------------------------------------------------------------------------
+
+/// FP-SH-21 (issue #940): a braced list literal used as a list must NOT fire
+/// S100. `{10.0 12.0 16.0 24.0}` is a pure string (oracle: `typePtr == NULL`),
+/// and `foreach` parses it into a list intrep once, for free — the reference
+/// contract's "pure string first type assignment is not a shimmer".
+#[test]
+fn fp_sh_21_braced_list_literal_in_foreach_silent() {
+    let src = "set fontSizes {10.0 12.0 16.0 24.0}\nforeach size $fontSizes { puts $size }\n";
+    assert!(
+        !fires(src, D, "S100") && !fires(src, D, "S101"),
+        "FP-SH-21: braced list literal in foreach must not shimmer; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-21: the empty list `{}` — the exact case named in issue #940's title —
+/// is a valid (empty) list, so `foreach` over it is free.
+#[test]
+fn fp_sh_21_empty_braces_in_foreach_silent() {
+    let src = "set empty {}\nforeach x $empty { puts $x }\n";
+    assert!(
+        !fires(src, D, "S100") && !fires(src, D, "S101"),
+        "FP-SH-21: empty {{}} in foreach must not shimmer; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-21: a number-shaped or word-shaped literal is still a valid list — the
+/// define-time shape does not matter (`set a 1; foreach b $a`).
+#[test]
+fn fp_sh_21_scalar_literal_as_list_silent() {
+    for src in [
+        "set a 1\nforeach b $a { puts $b }\n",
+        "set x 5\nlindex $x 0\n",
+        "set l hello\nforeach y $l { puts $y }\n",
+    ] {
+        assert!(
+            !fires(src, D, "S100") && !fires(src, D, "S101"),
+            "FP-SH-21: scalar literal used as a list must not shimmer; got {:?}",
+            codes(src, D),
+        );
+    }
+}
+
+/// FP-SH-21: an even-length list literal is a valid dict — `dict for` over it is
+/// free.
+#[test]
+fn fp_sh_21_dict_literal_in_dict_for_silent() {
+    let src = "set d {a 1 b 2}\ndict for {k v} $d { puts \"$k=$v\" }\n";
+    assert!(
+        !fires(src, D, "S100") && !fires(src, D, "S101"),
+        "FP-SH-21: dict literal in dict for must not shimmer; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-21 TP control: a *committed* container (`[dict create]`) read as a list
+/// still fires — the pure-value suppression must not blanket-silence genuine
+/// shimmers. `foreach` on a committed Dict re-represents it (Dict → List).
+#[test]
+fn fp_sh_21_committed_dict_in_foreach_still_fires() {
+    let src = "set d [dict create a 1 b 2]\nforeach x $d { puts $x }\n";
+    assert!(
+        fires(src, D, "S100"),
+        "FP-SH-21 TP: committed dict in foreach must still shimmer; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-21 TP control: a pure string that is NOT a valid instance keeps its
+/// warning — `incr` on a non-integer literal fails at runtime, so the mismatch
+/// is real.
+#[test]
+fn fp_sh_21_incr_on_non_integer_literal_still_fires() {
+    let src = "set bad hello\nincr bad\n";
+    assert!(
+        fires(src, D, "S100"),
+        "FP-SH-21 TP: incr on a non-integer literal must still fire; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-21 TP control: a committed list read as a *string* (`string length`)
+/// still fires — the genuine `[list …]` → String shimmer is untouched.
+#[test]
+fn fp_sh_21_committed_list_as_string_still_fires() {
+    let src = "set real [list 1 2 3]\nstring length $real\n";
+    assert!(
+        fires(src, D, "S100"),
+        "FP-SH-21 TP: committed list used as a string must still fire; got {:?}",
+        codes(src, D),
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
@@ -1558,3 +1558,76 @@ fn fp_sh_22_merge_use_matching_neither_arm_fires() {
         codes(src, D),
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-SH-23 — element-tracked containers and the union lattice (P2/P3)
+// ---------------------------------------------------------------------------
+
+/// FP-SH-23: a committed element retrieved from a tracked container keeps its
+/// intrep — `lindex` on `[list [expr {…}] …]` yields the numeric element, so
+/// arithmetic on it is not a shimmer (the element is genuinely numeric by
+/// reference, oracle corpus in type-tracking.md).
+#[test]
+fn fp_sh_23_committed_element_arithmetic_silent() {
+    let src =
+        "set l [list [expr {2**20}] other]\nset first [lindex $l 0]\nset n [expr {$first + 1}]\n";
+    assert!(
+        !fires(src, D, "S100") && !fires(src, D, "S101"),
+        "FP-SH-23: a numeric element retrieved by lindex is numeric — no shimmer; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-23: a three-way branch merge stays a tracked union (previously
+/// collapsed to OVERDEFINED and silently missed) — the phi merge reports
+/// every member.
+#[test]
+fn fp_sh_23_three_way_merge_reports_all_members() {
+    let src = "proc f {c} {\n  if {$c == 1} { set x [list 1] } elseif {$c == 2} { set x [dict create a 1] } else { set x [expr {1+1}] }\n  return $x\n}\n";
+    assert!(
+        fires(src, D, "S100"),
+        "FP-SH-23: a 3-way differently-typed merge must be reported; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-23 FP-guard: the same 3-way merge where every arm produces the SAME
+/// type stays silent — the union canonicalises to a singleton.
+#[test]
+fn fp_sh_23_three_way_same_type_merge_silent() {
+    let src = "proc f {c} {\n  if {$c == 1} { set x [list 1] } elseif {$c == 2} { set x [list 2] } else { set x [list 3] }\n  return $x\n}\n";
+    assert!(
+        !fires(src, D, "S100") && !fires(src, D, "S101"),
+        "FP-SH-23 guard: same-typed 3-way merge must stay silent; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-23: exact bignum folding — `expr {2**64}` and a chained `$big + 1`
+/// fold to C Tcl's exact values, so the SCCP-driven checks see real
+/// constants, never a wrapped or declined value (P4; values tclsh-verified).
+#[test]
+fn fp_sh_23_bignum_folds_are_exact() {
+    use crate::compilation_unit::CompilationUnit;
+    use tcl_registry::CommandRegistry;
+    let registry = CommandRegistry::build_default();
+    let cu = CompilationUnit::build_for(
+        "set big [expr {2**64}]\nset next [expr {$big + 1}]",
+        &registry,
+        false,
+    );
+    let fu = cu.function("::top").unwrap();
+    let next_const = fu
+        .sccp
+        .values
+        .iter()
+        .find(|((sym, ver), _)| fu.ssa.var_name(*sym) == "next" && *ver > 0)
+        .map(|(_, v)| v.clone());
+    assert_eq!(
+        next_const,
+        Some(crate::analyses::LatticeValue::Const(
+            crate::analyses::ConstValue::String("18446744073709551617".to_owned())
+        )),
+        "the chained bignum fold must land the exact decimal"
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/sh.rs
@@ -1487,3 +1487,74 @@ fn fp_sh_21_committed_list_as_string_still_fires() {
         codes(src, D),
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-SH-22 — first-use commit: a second conversion is a genuine shimmer
+// ---------------------------------------------------------------------------
+
+/// FP-SH-22 TP: a pure literal's *first* use commits its intrep; a later use
+/// as a different type re-represents on every execution. `expr` commits the
+/// numeric intrep, then `lindex` re-reads it as a list (oracle: `set v 5;
+/// expr {$v+1}` → rep `int`; `lindex $v 0` → rep `list`).
+#[test]
+fn fp_sh_22_second_conversion_after_expr_commit_fires() {
+    let src = "set v 5\nexpr {$v + 1}\nlindex $v 0\n";
+    assert!(
+        fires(src, D, "S100"),
+        "FP-SH-22 TP: expr-committed value read as a list must fire; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-22 TP: the same chain through `llength` then `incr` — List committed,
+/// then re-read as Int.
+#[test]
+fn fp_sh_22_incr_after_llength_commit_fires() {
+    let src = "set w 5\nllength $w\nincr w\n";
+    assert!(
+        fires(src, D, "S100"),
+        "FP-SH-22 TP: llength-committed value incremented must fire; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-22 TP: a pure literal read as **two distinct intreps inside a loop**
+/// re-thunks every iteration (oracle: list ↔ dict on each pass) — the
+/// free-first-conversion suppression must not apply, and the code is the
+/// per-iteration S101.
+#[test]
+fn fp_sh_22_loop_two_target_rethunk_is_s101() {
+    let src = "set l {a 1 b 2}\nforeach i {1 2 3} {\n    llength $l\n    dict size $l\n}\n";
+    assert!(
+        fires(src, D, "S101"),
+        "FP-SH-22 TP: list/dict re-thunk inside a loop must fire S101; got {:?}",
+        codes(src, D),
+    );
+}
+
+/// FP-SH-22 FP guard: the branch case — two arms committing two different
+/// intreps — must NOT fire at either arm's own (first) conversion, and a
+/// post-merge use matching one arm stays silent (only one path pays).
+#[test]
+fn fp_sh_22_branch_arms_first_conversions_stay_silent() {
+    let src = "proc f {c} {\n  set a {1 2}\n  if {$c} { llength $a } else { string length $a }\n  llength $a\n}\n";
+    let got = codes(src, D);
+    assert!(
+        !got.iter().any(|c| c == "S100" || c == "S101"),
+        "FP-SH-22 FP: neither arm's first conversion nor a one-path-pays merge use may fire; got {got:?}"
+    );
+}
+
+/// FP-SH-22 TP: a post-merge use matching *neither* arm's committed intrep
+/// pays on every path — the multiple-different-dominator-types warning, with
+/// path-dependent wording. One arm commits List (`llength`), the other Dict
+/// (`dict size`); the `string length` read after the merge converts on both.
+#[test]
+fn fp_sh_22_merge_use_matching_neither_arm_fires() {
+    let src = "proc f {c} {\n  set a {1 2}\n  if {$c} { llength $a } else { dict size $a }\n  string length $a\n}\n";
+    assert!(
+        fires(src, D, "S100"),
+        "FP-SH-22 TP: a merge use matching neither committed arm must fire; got {:?}",
+        codes(src, D),
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -3761,19 +3761,31 @@ fn w220_scalar_overwrite_still_fires_via_analyse() {
 
 #[test]
 fn w220_braced_literal_arg_is_not_a_read() {
-    // A braced word performs no `$`-substitution, so `puts {$a(k)}` does
-    // NOT read `a(k)` — the place bridge must not treat the de-braced IR
-    // text as a read and wrongly suppress the genuine dead store on the
-    // first `set a(k)`.  (`puts $a(j)` keeps the base `a` live so `a(k)`
-    // is a W220 overwrite candidate rather than a W211.)
+    // A braced word performs no `$`-substitution at this call — but the
+    // name-level scan deliberately keeps `{$a(k)}` as a conservative
+    // liveness read (the word may be `eval`-ed / scheduled later, e.g.
+    // `after 100 {incr x}`), so under per-element SSA the mention keeps
+    // `a(k)` alive and no dead store fires. The control: an element with
+    // NO mention of any kind still reports.
     let mut a = Analyser::new();
     let r = a.analyse(
         "proc f {} { set a(k) 1; set a(j) 2; puts $a(j); puts {$a(k)} }",
         "tcl8.6",
     );
     assert!(
-        r.diagnostics.iter().any(|d| d.code == DiagCode::W220),
-        "braced literal must not suppress the a(k) dead store; got {:?}",
+        !r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W220 || d.code == DiagCode::W211),
+        "a braced mention conservatively keeps the element alive; got {:?}",
+        r.diagnostics,
+    );
+    let mut b = Analyser::new();
+    let r = b.analyse("proc f {} { set a(k) 1; set a(j) 2; puts $a(j) }", "tcl8.6");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W220 || d.code == DiagCode::W211),
+        "an unmentioned dead element write still reports; got {:?}",
         r.diagnostics,
     );
 }

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -178,18 +178,18 @@ impl Analyser {
             |fu: &crate::compilation_unit::FunctionUnit,
              out: &mut std::collections::HashMap<String, HashSet<String>>| {
                 for ((sym, _ver), tl) in &fu.types {
-                    if tl.kind != TypeKind::Known {
+                    if tl.kind() != TypeKind::Known {
                         continue;
                     }
-                    if !matches!(tl.tcl_type, Some(tcl_registry::TclType::Object)) {
+                    if !matches!(tl.tcl_type(), Some(tcl_registry::TclType::Object)) {
                         continue;
                     }
-                    let Some(class_name) = &tl.class_name else {
+                    let Some(class_name) = tl.class_name() else {
                         continue;
                     };
                     out.entry(fu.ssa.var_name(*sym).to_owned())
                         .or_default()
-                        .insert(class_name.clone());
+                        .insert(class_name.to_owned());
                 }
             };
         collect_object_types(&cu.top_level, &mut all_object_types);
@@ -1096,12 +1096,12 @@ impl Analyser {
 
             // ``Object`` return type — suppress W307; if the
             // class is known, validate the method (W308).
-            let is_object = ret_type.kind == crate::types::TypeKind::Known
-                && matches!(ret_type.tcl_type, Some(tcl_registry::TclType::Object));
+            let is_object = ret_type.kind() == crate::types::TypeKind::Known
+                && matches!(ret_type.tcl_type(), Some(tcl_registry::TclType::Object));
             if is_object {
                 if !self.disabled_diagnostics.contains("W308")
                     && let (Some(method), Some(class_name)) =
-                        (site.method_name.as_ref(), ret_type.class_name.as_ref())
+                        (site.method_name.as_ref(), ret_type.class_name().as_ref())
                 {
                     let cls_qn = self.canonicalise_class_name(class_name);
                     let cd = self.result.all_classes.get(&cls_qn).cloned();

--- a/rust/tcl-compiler/src/bounded_set.rs
+++ b/rust/tcl-compiler/src/bounded_set.rs
@@ -1,0 +1,193 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! A bounded small set — the primitive behind "small union of possibilities"
+//! lattice carriers whose dedup is plain equality.
+//!
+//! The type lattice's shape unions ([`crate::types::TypeLattice`], cap
+//! [`crate::types::MAX_TYPE_UNION`]) are built on this. Two other carriers
+//! look similar but deliberately keep their own storage, because their dedup
+//! is **not** plain `==`: SCCP's constant sets
+//! ([`crate::analyses::LatticeValue::ConstSet`]) merge under a numeric
+//! cross-equality (`cv_eq` — `Int(1)` and `Float(1.0)` unify) with a custom
+//! sort key, and the analyser's class sets ride `BTreeSet`'s always-sorted
+//! persistent-set semantics. Fold either under this primitive and those
+//! domain rules would silently change; a new carrier whose alternatives
+//! compare by ordinary equality should reach for this type instead of
+//! growing a fourth ad-hoc vec-with-cap.
+//!
+//! Semantics:
+//! - **Dedup by equality** — inserting an element already present is a no-op.
+//! - **Insertion-ordered** — iteration order is the order of first insertion,
+//!   deterministic given deterministic inputs. Carriers whose equality must be
+//!   order-independent (the type lattice) call [`BoundedSet::canonicalise`]
+//!   after building.
+//! - **Capacity is the carrier's contract** — [`BoundedSet::insert`] reports
+//!   whether the element fit; the *caller* widens its own lattice to top on
+//!   overflow (this type never silently drops).
+
+/// A deduplicated, insertion-ordered set holding at most `CAP` elements.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BoundedSet<T, const CAP: usize> {
+    items: Vec<T>,
+}
+
+impl<T, const CAP: usize> Default for BoundedSet<T, CAP> {
+    fn default() -> Self {
+        Self { items: Vec::new() }
+    }
+}
+
+impl<T: PartialEq, const CAP: usize> BoundedSet<T, CAP> {
+    /// The empty set.
+    #[must_use]
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// A one-element set. `CAP` is at least 1 for every instantiation in the
+    /// tree, so this cannot overflow.
+    #[must_use]
+    pub fn singleton(item: T) -> Self {
+        Self { items: vec![item] }
+    }
+
+    /// Build from an iterator, deduplicating. Returns `None` when the distinct
+    /// elements exceed `CAP` — the caller widens to its own top.
+    #[must_use]
+    pub fn from_iter_bounded(iter: impl IntoIterator<Item = T>) -> Option<Self> {
+        let mut set = Self::new();
+        for item in iter {
+            if !set.insert(item) {
+                return None;
+            }
+        }
+        Some(set)
+    }
+
+    /// Insert `item` unless already present. Returns `false` — and leaves the
+    /// set unchanged — when the element is new but the set is full; the caller
+    /// widens to its top element.
+    #[must_use = "a false return means the set is full and the caller must widen"]
+    pub fn insert(&mut self, item: T) -> bool {
+        if self.items.contains(&item) {
+            return true;
+        }
+        if self.items.len() >= CAP {
+            return false;
+        }
+        self.items.push(item);
+        true
+    }
+
+    /// Whether `item` is a member.
+    #[must_use]
+    pub fn contains(&self, item: &T) -> bool {
+        self.items.contains(item)
+    }
+
+    /// Number of elements.
+    #[must_use]
+    pub fn len(&self) -> usize {
+        self.items.len()
+    }
+
+    /// Whether the set is empty.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.items.is_empty()
+    }
+
+    /// Iterate in insertion (or canonical, after [`Self::canonicalise`]) order.
+    pub fn iter(&self) -> std::slice::Iter<'_, T> {
+        self.items.iter()
+    }
+
+    /// The elements as a slice.
+    #[must_use]
+    pub fn as_slice(&self) -> &[T] {
+        &self.items
+    }
+
+    /// Consume into the underlying `Vec`.
+    #[must_use]
+    pub fn into_vec(self) -> Vec<T> {
+        self.items
+    }
+}
+
+impl<T: Ord, const CAP: usize> BoundedSet<T, CAP> {
+    /// Sort into canonical order so structurally-equal sets built in different
+    /// insertion orders compare equal. Carriers that derive `PartialEq` on the
+    /// whole set (the type lattice) must canonicalise after every mutation
+    /// batch.
+    pub fn canonicalise(&mut self) {
+        self.items.sort_unstable();
+    }
+}
+
+impl<'a, T, const CAP: usize> IntoIterator for &'a BoundedSet<T, CAP> {
+    type Item = &'a T;
+    type IntoIter = std::slice::Iter<'a, T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.iter()
+    }
+}
+
+impl<T, const CAP: usize> IntoIterator for BoundedSet<T, CAP> {
+    type Item = T;
+    type IntoIter = std::vec::IntoIter<T>;
+    fn into_iter(self) -> Self::IntoIter {
+        self.items.into_iter()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn insert_dedups_and_caps() {
+        let mut s: BoundedSet<u32, 2> = BoundedSet::new();
+        assert!(s.insert(1));
+        assert!(s.insert(1), "re-inserting a member is a no-op success");
+        assert!(s.insert(2));
+        assert!(!s.insert(3), "a new element past CAP must report overflow");
+        assert_eq!(s.as_slice(), &[1, 2], "overflow leaves the set unchanged");
+    }
+
+    #[test]
+    fn from_iter_bounded_widens_past_cap() {
+        assert_eq!(
+            BoundedSet::<u32, 2>::from_iter_bounded([1, 2, 1]).map(BoundedSet::into_vec),
+            Some(vec![1, 2]),
+            "duplicates do not count against the cap"
+        );
+        assert_eq!(BoundedSet::<u32, 2>::from_iter_bounded([1, 2, 3]), None);
+    }
+
+    #[test]
+    fn canonicalise_makes_order_insensitive() {
+        let mut a: BoundedSet<u32, 4> = BoundedSet::from_iter_bounded([3, 1]).unwrap();
+        let mut b: BoundedSet<u32, 4> = BoundedSet::from_iter_bounded([1, 3]).unwrap();
+        assert_ne!(a, b, "insertion order is observable before canonicalise");
+        a.canonicalise();
+        b.canonicalise();
+        assert_eq!(a, b);
+    }
+}

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -1829,6 +1829,8 @@ impl CfgBuilder {
         match eval_tcl_expr(condition, &env) {
             Some(TclValue::Int(i)) => i != 0,
             Some(TclValue::Float(f)) => f != 0.0,
+            // A bignum is canonical (beyond i64), hence never zero.
+            Some(TclValue::Big(_)) => true,
             None => false,
         }
     }

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -387,6 +387,7 @@ pub fn shimmer_family_checks<S: std::hash::BuildHasher>(
         &fu.sccp.executable_blocks,
         registry,
         &fu.sccp.values,
+        &fu.sccp.executable_edges,
     ) {
         out.push(Diagnostic::from_shimmer(&w));
     }

--- a/rust/tcl-compiler/src/compiler_checks.rs
+++ b/rust/tcl-compiler/src/compiler_checks.rs
@@ -704,9 +704,13 @@ mod tests {
         assert_eq!(s100.severity, Severity::Info, "S100 must be Info: {s100:?}");
         assert_eq!(s100.severity.as_str(), "info");
 
-        // S101 — a per-iteration shimmer inside a loop is a warning.
+        // S101 — a per-iteration shimmer inside a loop is a warning. `$x` is a
+        // loop element of unknown value used in arithmetic: a non-constant pure
+        // string is not provably a valid number, so the conversion is flagged
+        // per iteration (unlike a list target, where any string is a valid
+        // list — see `is_uncommitted_first_conversion`).
         let cu = CompilationUnit::build_for(
-            "proc f {l} {\n  foreach x $l {\n    set b [lindex $x 0]\n  }\n}\n",
+            "proc f {l} {\n  foreach x $l {\n    set y [expr {$x + 1}]\n  }\n}\n",
             &registry(),
             false,
         );

--- a/rust/tcl-compiler/src/dataflow_graph.rs
+++ b/rust/tcl-compiler/src/dataflow_graph.rs
@@ -273,7 +273,7 @@ fn format_type<S: std::hash::BuildHasher>(
 ) -> String {
     match key.and_then(|k| types.and_then(|t| t.get(&k))) {
         None => String::new(),
-        Some(tl) => match tl.kind {
+        Some(tl) => match tl.kind() {
             TypeKind::Unknown => "UNKNOWN",
             TypeKind::Known => "KNOWN",
             TypeKind::Shimmered => "SHIMMERED",

--- a/rust/tcl-compiler/src/dataflow_graph.rs
+++ b/rust/tcl-compiler/src/dataflow_graph.rs
@@ -530,6 +530,7 @@ mod tests {
             },
             uses: Map::new(),
             defs,
+            may_defs: std::collections::HashSet::new(),
         }
     }
 
@@ -663,6 +664,7 @@ mod tests {
             },
             uses,
             defs: ydefs,
+            may_defs: std::collections::HashSet::new(),
         });
         ssa.blocks.insert(entry_id, entry);
 

--- a/rust/tcl-compiler/src/dead_stores.rs
+++ b/rust/tcl-compiler/src/dead_stores.rs
@@ -86,6 +86,15 @@ pub fn liveness_dead_stores(fu: &FunctionUnit, registry: &CommandRegistry) -> Ve
         if hidden_reads.contains(var) {
             continue;
         }
+        // A synthetic may-def (base refresh / element fan) is not a write
+        // the user made — the element's own chain reports.
+        if fu.ssa.is_synthetic_def(
+            &chain.definition.block,
+            chain.definition.statement_index,
+            var,
+        ) {
+            continue;
+        }
         // Definitions in SCCP-unreachable blocks are reported as O107.
         if !fu
             .cfg

--- a/rust/tcl-compiler/src/def_use.rs
+++ b/rust/tcl-compiler/src/def_use.rs
@@ -296,18 +296,20 @@ pub fn build_def_use_chains(ssa: &SsaFunction, cfg: Option<&CfgFunction>) -> Def
 /// overwritten store is a real dead store, not a "truly unused" var.
 fn terminator_read_vars(terminator: Option<&Terminator>) -> Vec<String> {
     match terminator {
-        Some(Terminator::Branch { condition, .. }) => condition.vars().into_iter().collect(),
+        Some(Terminator::Branch { condition, .. }) => {
+            condition.vars_element_qualified().into_iter().collect()
+        }
         Some(Terminator::Return { value, expr, .. }) => {
             let mut set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
             if let Some(v) = value {
                 set.extend(
                     crate::var_refs::scan_var_ref_forms(v)
                         .into_iter()
-                        .map(|n| crate::naming::normalise_var_name(&n).to_string()),
+                        .map(|n| crate::naming::element_var_name(&n).to_string()),
                 );
             }
             if let Some(e) = expr {
-                set.extend(e.vars());
+                set.extend(e.vars_element_qualified());
             }
             set.into_iter().collect()
         }
@@ -409,6 +411,7 @@ mod tests {
             },
             uses: HashMap::new(),
             defs,
+            may_defs: std::collections::HashSet::new(),
         }
     }
 
@@ -436,6 +439,7 @@ mod tests {
             },
             uses: u,
             defs: d,
+            may_defs: std::collections::HashSet::new(),
         }
     }
 

--- a/rust/tcl-compiler/src/def_use.rs
+++ b/rust/tcl-compiler/src/def_use.rs
@@ -265,26 +265,7 @@ pub fn build_def_use_chains(ssa: &SsaFunction, cfg: Option<&CfgFunction>) -> Def
         if let Some(cfg) = cfg
             && let Some(cfg_block) = cfg.blocks.get(bn)
         {
-            for var_name in terminator_read_vars(cfg_block.terminator.as_ref()) {
-                let version = ssa
-                    .var_symbol(&var_name)
-                    .and_then(|s| block.exit_versions.get(&s))
-                    .copied()
-                    .unwrap_or(0);
-                let key = (var_name, version);
-                add_use(
-                    &mut chains,
-                    entry_name,
-                    key,
-                    UseSite {
-                        block: block.name.clone(),
-                        kind: UseKind::Terminator,
-                        statement_index: -1,
-                        variable: String::new(),
-                        phi_version: 0,
-                    },
-                );
-            }
+            add_terminator_uses(&mut chains, entry_name, ssa, block, cfg_block);
         }
     }
 
@@ -349,6 +330,50 @@ fn add_use(
 }
 
 // Tests
+
+/// Record a block terminator's reads as uses at its exit versions. A base
+/// read (`return $opts($name)`) also reads every known constant-keyed
+/// element — keep their chains live too.
+fn add_terminator_uses(
+    chains: &mut HashMap<SsaValueKey, DefUseChain>,
+    entry_name: &str,
+    ssa: &SsaFunction,
+    block: &crate::ssa::SsaBlock,
+    cfg_block: &crate::cfg::Block,
+) {
+    for var_name in terminator_read_vars(cfg_block.terminator.as_ref()) {
+        let fanned: Vec<String> = ssa
+            .var_names()
+            .iter()
+            .filter(|n| {
+                n.len() > var_name.len()
+                    && n.starts_with(&var_name)
+                    && n.as_bytes()[var_name.len()] == b'('
+            })
+            .cloned()
+            .collect();
+        for name in std::iter::once(var_name).chain(fanned) {
+            let version = ssa
+                .var_symbol(&name)
+                .and_then(|s| block.exit_versions.get(&s))
+                .copied()
+                .unwrap_or(0);
+            let key = (name, version);
+            add_use(
+                chains,
+                entry_name,
+                key,
+                UseSite {
+                    block: block.name.clone(),
+                    kind: UseKind::Terminator,
+                    statement_index: -1,
+                    variable: String::new(),
+                    phi_version: 0,
+                },
+            );
+        }
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/rust/tcl-compiler/src/gvn.rs
+++ b/rust/tcl-compiler/src/gvn.rs
@@ -1995,6 +1995,7 @@ mod tests {
             statement: call_stmt("set", &["x", "1"]),
             uses: HashMap::new(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         };
         let occurrences =
             statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa());
@@ -2013,6 +2014,7 @@ mod tests {
             },
             uses: HashMap::new(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         };
         assert!(
             statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa()).is_empty()
@@ -2068,6 +2070,7 @@ mod tests {
             statement: stmt,
             uses,
             defs: Map::new(),
+            may_defs: std::collections::HashSet::new(),
         }
     }
 
@@ -2300,6 +2303,7 @@ mod tests {
             },
             uses: HashMap::new(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         };
         let occ = statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa());
         assert_eq!(occ.len(), 1);
@@ -2320,6 +2324,7 @@ mod tests {
             },
             uses: HashMap::new(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         };
         let occ = statement_occurrences(&registry, &stmt_ssa, "entry", 0, None, &bare_ssa());
         assert_eq!(occ.len(), 1);
@@ -2563,6 +2568,7 @@ mod tests {
             },
             uses: Map::new(),
             defs,
+            may_defs: std::collections::HashSet::new(),
         });
         // llength $i — uses map tracks `i`, not `x`.
         let mut uses_i = Map::new();
@@ -2571,6 +2577,7 @@ mod tests {
             statement: llength_on_i,
             uses: uses_i,
             defs: Map::new(),
+            may_defs: std::collections::HashSet::new(),
         });
         ssa.blocks.insert(header, h);
         ssa.blocks.insert(body, b);

--- a/rust/tcl-compiler/src/intervals.rs
+++ b/rust/tcl-compiler/src/intervals.rs
@@ -231,10 +231,10 @@ fn literal_int(node: &ExprNode) -> Option<i64> {
         return None;
     };
     let t = text.trim();
-    match t {
-        "true" | "yes" | "on" => return Some(1),
-        "false" | "no" | "off" => return Some(0),
-        _ => {}
+    // Boolean words resolve by unique prefix in expr context (`tru` is a
+    // boolean literal to C Tcl) — the canonical word acceptor.
+    if let Some(b) = tcl_syntax::boolean::parse_boolean_word(t) {
+        return Some(i64::from(b));
     }
     parse_radix_int(t)
 }

--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -105,11 +105,21 @@ pub fn defs_from_ir_script(script: &Script) -> Vec<String> {
 fn collect_defs_from_script(script: &Script, defs: &mut Vec<String>) {
     for stmt in &script.statements {
         match stmt {
-            Statement::AssignConst { name, .. }
-            | Statement::AssignExpr { name, .. }
-            | Statement::AssignValue { name, .. }
-            | Statement::Incr { name, .. } => {
-                let n = normalise_var_name(name);
+            Statement::AssignConst {
+                name, name_braced, ..
+            }
+            | Statement::AssignExpr {
+                name, name_braced, ..
+            }
+            | Statement::AssignValue {
+                name, name_braced, ..
+            }
+            | Statement::Incr {
+                name, name_braced, ..
+            } => {
+                // Element-qualified to match the SSA use scan: a collapsed
+                // arm's `set b(k) 1; puts $b(k)` must cancel its own read.
+                let n = crate::naming::element_var_name_braced(name, *name_braced);
                 if !n.is_empty() {
                     defs.push(n.to_owned());
                 }
@@ -141,7 +151,7 @@ fn collect_defs_from_script(script: &Script, defs: &mut Vec<String>) {
             } => {
                 for iter in iterators {
                     for vn in &iter.vars {
-                        let n = normalise_var_name(vn);
+                        let n = crate::naming::element_var_name(vn);
                         if !n.is_empty() {
                             defs.push(n.to_owned());
                         }

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -90,6 +90,7 @@ pub mod alias;
 pub mod analyser;
 pub mod analyses;
 pub mod auto_path_eval;
+pub mod bounded_set;
 pub mod cfg;
 pub mod cfg_builder;
 pub mod cfg_layout;

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -1957,14 +1957,16 @@ impl<'r> Lowerer<'r> {
                 .iter()
                 .filter_map(|&i| {
                     let real = i.checked_sub(prepend_n)?;
-                    args.get(real).map(|a| normalise_var_name(a).to_owned())
+                    args.get(real)
+                        .map(|a| crate::naming::element_var_name(a).to_owned())
                 })
                 .collect();
             let var_reads: Vec<String> = var_read_indices
                 .iter()
                 .filter_map(|&i| {
                     let real = i.checked_sub(prepend_n)?;
-                    args.get(real).map(|a| normalise_var_name(a).to_owned())
+                    args.get(real)
+                        .map(|a| crate::naming::element_var_name(a).to_owned())
                 })
                 .collect();
             return Statement::Call {

--- a/rust/tcl-compiler/src/memory_ssa.rs
+++ b/rust/tcl-compiler/src/memory_ssa.rs
@@ -931,6 +931,7 @@ mod tests {
                 statement: s,
                 uses: HashMap::new(),
                 defs: HashMap::new(),
+                may_defs: std::collections::HashSet::new(),
             });
         }
         let entry = BlockId(0);
@@ -1056,6 +1057,7 @@ mod tests {
             statement: call("global", &["shared"]),
             uses: HashMap::new(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         });
         let mut defs = HashMap::new();
         defs.insert(shared, 1);
@@ -1063,6 +1065,7 @@ mod tests {
             statement: call("set", &["shared", "1"]),
             uses: HashMap::new(),
             defs,
+            may_defs: std::collections::HashSet::new(),
         });
         let mut uses = HashMap::new();
         uses.insert(shared, 1);
@@ -1070,6 +1073,7 @@ mod tests {
             statement: call("puts", &["$shared"]),
             uses,
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         });
 
         ssa.blocks.insert(
@@ -1117,6 +1121,7 @@ mod tests {
             statement: call("global", &["shared"]),
             uses: HashMap::new(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         });
         let mut defs1 = HashMap::new();
         defs1.insert(shared, 1);
@@ -1124,6 +1129,7 @@ mod tests {
             statement: call("set", &["shared", "0"]),
             uses: HashMap::new(),
             defs: defs1,
+            may_defs: std::collections::HashSet::new(),
         });
         let mut uses = HashMap::new();
         uses.insert(shared, 1);
@@ -1133,6 +1139,7 @@ mod tests {
             statement: call("set", &["shared", "[expr {$shared + 1}]"]),
             uses,
             defs: defs2,
+            may_defs: std::collections::HashSet::new(),
         });
         ssa.blocks.insert(
             entry,

--- a/rust/tcl-compiler/src/object_types.rs
+++ b/rust/tcl-compiler/src/object_types.rs
@@ -105,8 +105,8 @@ fn propagate_object_flow(
         .procedures
         .values()
         .filter_map(|fu| {
-            (fu.return_type.tcl_type == Some(tcl_registry::TclType::Object))
-                .then_some(fu.return_type.class_name.as_deref())
+            (fu.return_type.tcl_type() == Some(tcl_registry::TclType::Object))
+                .then_some(fu.return_type.class_name())
                 .flatten()
                 .map(|c| (fu.name.as_str(), c))
         })
@@ -418,12 +418,12 @@ fn harvest_unit(
     // SSA values typed `OBJECT(class)` — includes collection retrievals
     // (`set p [dict get $pins $k]`) the syntactic scan above cannot see.
     for ((sym, _ver), t) in &fu.types {
-        if t.tcl_type == Some(tcl_registry::TclType::Object)
-            && let Some(class) = &t.class_name
+        if t.tcl_type() == Some(tcl_registry::TclType::Object)
+            && let Some(class) = t.class_name()
         {
             out.entry(fu.ssa.var_name(*sym).to_owned())
                 .or_default()
-                .insert(class.clone());
+                .insert(class.to_owned());
         }
     }
 }

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -490,9 +490,20 @@ fn emit_dead_stores_and_unused(
             continue;
         }
         // Skip if the variable is a scope alias — writes through
-        // global / upvar are visible in other scopes.
+        // global / upvar are visible in other scopes. Policy sets hold
+        // *base* names, so an element symbol (`a(k)`) checks its base too.
         let (var, _) = &chain.key;
-        if scope_aliases.contains(var) {
+        // A synthetic may-def (base refresh / element fan) is not a write
+        // the user made — never an O109/O126 candidate.
+        if fu.ssa.is_synthetic_def(
+            &chain.definition.block,
+            chain.definition.statement_index,
+            var,
+        ) {
+            continue;
+        }
+        let var_base = crate::naming::normalise_var_name(var);
+        if scope_aliases.contains(var) || scope_aliases.contains(var_base) {
             continue;
         }
         // Skip `::`-qualified globals: a direct write to a
@@ -504,13 +515,14 @@ fn emit_dead_stores_and_unused(
         if var.starts_with("::") {
             continue;
         }
-        // Skip cross-event vars (iRules scope).
-        if ctx.cross_event_vars.contains(var) {
+        // Skip cross-event vars (iRules scope; also TclOO instance state —
+        // both sets hold base names).
+        if ctx.cross_event_vars.contains(var) || ctx.cross_event_vars.contains(var_base) {
             continue;
         }
         // Skip a caller-local passed by name to an upvar
         // callee — the callee consumes it through the alias (O109 / O126).
-        if call_by_name.contains(var) {
+        if call_by_name.contains(var) || call_by_name.contains(var_base) {
             continue;
         }
         let any_other_live = fu
@@ -984,6 +996,7 @@ pub(crate) fn collect_rmw_hidden_reads(
         include_var_read_roles: true,
         recurse_cmd_substitutions: true,
         include_reads_before_write: true,
+        element_qualified: false,
     });
     let mut shallow = VarReferenceScanner::new(VarScanOptions::default());
     let mut out: HashSet<String> = HashSet::new();
@@ -1303,18 +1316,29 @@ mod tests {
 
     #[test]
     fn o109_array_element_overwrite_not_dead() {
-        // The place model: `set a(k) 1` is NOT a dead store — the
-        // later `set a(j) 2` bumps the name-level SSA version of base `a`, but
-        // `puts $a(k)` reads a(k) and a(k) ≠ a(j).  Goes through `optimise`,
-        // which binds the registry the place bridge needs (`run_pass` leaves it
-        // unbound, so the bare-path scalar test above is unaffected).
+        // Per-element SSA: `a(k)` and `a(j)` are independent variables, so
+        // `$a(k)` reads the value of `set a(k)` — never `set a(j)`. With a
+        // constant value the pipeline may forward + inline it and then
+        // delete the store as a *coupled* rewrite, but the forwarded value
+        // must be the same element's `1` (conflation would forward `2`).
         let opts = crate::optimiser::optimise(
             "proc f {} { set a(k) 1; set a(j) 2; puts $a(k) }",
             &registry(),
         );
         assert!(
-            opts.iter().all(|o| o.code != DiagCode::O109),
-            "no O109 expected — a(k) is read by `puts $a(k)`; got {opts:?}",
+            opts.iter()
+                .all(|o| o.code != DiagCode::O102 || o.replacement == "1"),
+            "a forwarded a(k) load must carry a(k)'s value, got {opts:?}",
+        );
+        // A non-constant element value cannot be forwarded, so the store
+        // stays live through its read — no dead-store report of any kind.
+        let live = crate::optimiser::optimise(
+            "proc f {x} { set a(k) $x; set a(j) 2; puts $a(k) }",
+            &registry(),
+        );
+        assert!(
+            live.iter().all(|o| o.code != DiagCode::O109),
+            "a(k) is read by `puts $a(k)`; got {live:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/optimiser/expr_simplify.rs
+++ b/rust/tcl-compiler/src/optimiser/expr_simplify.rs
@@ -209,7 +209,7 @@ fn try_rewrite_assign_expr(
     if !expr_uses_shadowed_mathfunc(expr, procedures)
         && let Some(val) = eval_tcl_expr_with_octal(expr, &env, octal)
     {
-        let folded = format_tcl_value(val);
+        let folded = format_tcl_value(&val);
         let original = crate::expr_ast::render_expr(expr);
         if folded != original.trim() {
             // Safe-word check: the folded value must inline as a
@@ -323,7 +323,7 @@ fn try_rewrite_expr(
     if !super::helpers::expr_simplify::expr_uses_shadowed_mathfunc(expr, procedures)
         && let Some(val) = eval_tcl_expr_with_octal(expr, &env, octal)
     {
-        let folded = format_tcl_value(val);
+        let folded = format_tcl_value(&val);
         // Compare against the original body text slice when it is
         // recoverable; the outer span covers the whole `expr …`
         // command so we look at the `ExprNode::Command`-free

--- a/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
+++ b/rust/tcl-compiler/src/optimiser/helpers/expr_simplify.rs
@@ -140,9 +140,9 @@ pub fn operand_types(fu: &FunctionUnit) -> OperandTypes {
 
 /// Whether a type-lattice element is a known numeric Tcl type.
 fn lattice_is_numeric(t: &TypeLattice) -> bool {
-    t.kind == TypeKind::Known
+    t.kind() == TypeKind::Known
         && matches!(
-            t.tcl_type,
+            t.tcl_type(),
             Some(TclType::Int | TclType::Double | TclType::Numeric | TclType::Boolean)
         )
 }
@@ -152,7 +152,7 @@ fn lattice_is_numeric(t: &TypeLattice) -> bool {
 /// excluded too, since a boolean-typed operand may hold the word `true`, which
 /// is not an integer in `expr` (`expr {true << 0}` errors).
 fn lattice_is_integer(t: &TypeLattice) -> bool {
-    t.kind == TypeKind::Known && matches!(t.tcl_type, Some(TclType::Int))
+    t.kind() == TypeKind::Known && matches!(t.tcl_type(), Some(TclType::Int))
 }
 
 /// Whether `node` is provably numeric for `expr` arithmetic — so dropping it
@@ -250,7 +250,7 @@ pub fn try_fold_expr(expr: &str, dialect: Option<&str>) -> Option<String> {
     }
     let env = Env::new();
     let value = eval_tcl_expr_with_octal(&node, &env, dialect.and_then(leading_zero_is_octal))?;
-    let rendered = format_tcl_value(value);
+    let rendered = format_tcl_value(&value);
     if rendered == trimmed {
         return None;
     }
@@ -296,7 +296,7 @@ pub fn try_fold_expr_with_constants<S: std::hash::BuildHasher>(
         }
     }
     let value = eval_tcl_expr_with_octal(&node, &env, dialect.and_then(leading_zero_is_octal))?;
-    let rendered = format_tcl_value(value);
+    let rendered = format_tcl_value(&value);
     if rendered == trimmed {
         return None;
     }
@@ -1304,12 +1304,9 @@ fn is_boolean_expr(node: &ExprNode) -> bool {
         ExprNode::Unary { op, .. } => matches!(op, UnaryOp::Not | UnaryOp::WordNot),
         ExprNode::Literal { text, .. } => {
             let t = text.trim();
-            t == "0"
-                || t == "1"
-                || matches!(
-                    t.to_ascii_lowercase().as_str(),
-                    "true" | "false" | "yes" | "no" | "on" | "off"
-                )
+            // Full spellings only, deliberately conservative for rewrite
+            // safety — the canonical vocabulary, not a private word list.
+            t == "0" || t == "1" || tcl_syntax::boolean::is_boolean_full_word(t)
         }
         _ => false,
     }
@@ -1371,10 +1368,7 @@ fn is_numeric_or_boolean_string(text: &str) -> bool {
         .trim_start_matches(['"', '{'])
         .trim_end_matches(['"', '}'])
         .trim();
-    matches!(
-        stripped.to_ascii_lowercase().as_str(),
-        "true" | "false" | "yes" | "no" | "on" | "off"
-    )
+    tcl_syntax::boolean::is_boolean_full_word(stripped)
 }
 
 /// Extract an integer literal from an [`ExprNode::Literal`],

--- a/rust/tcl-compiler/src/optimiser/helpers/literals.rs
+++ b/rust/tcl-compiler/src/optimiser/helpers/literals.rs
@@ -155,7 +155,7 @@ pub fn format_constant(value: &ConstValue) -> Option<String> {
     match value {
         ConstValue::Bool(b) => Some(if *b { "1".into() } else { "0".into() }),
         ConstValue::Int(i) => Some(i.to_string()),
-        ConstValue::Float(f) => Some(format_tcl_value(TclValue::Float(*f))),
+        ConstValue::Float(f) => Some(format_tcl_value(&TclValue::Float(*f))),
         ConstValue::String(s) => Some(s.clone()),
     }
 }

--- a/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
+++ b/rust/tcl-compiler/src/optimiser/pattern_recognition.rs
@@ -95,7 +95,7 @@ fn int_var_names(fu: &FunctionUnit) -> HashSet<String> {
 
 /// Whether a type-lattice element is a known `TclType::Int`.
 fn lattice_is_int(t: &TypeLattice) -> bool {
-    t.kind == TypeKind::Known && t.tcl_type == Some(TclType::Int)
+    t.kind() == TypeKind::Known && t.tcl_type() == Some(TclType::Int)
 }
 
 fn walk_script(ctx: &mut PassContext<'_>, script: &Script, int_vars: &HashSet<String>) {

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -237,6 +237,16 @@ fn run_load_forwarding(
         {
             continue;
         }
+        // A synthetic may-def (the element fan of a dynamic-key write, or a
+        // base refresh) is not a real reaching definition — forwarding its
+        // statement's value would forward the *other* element's literal.
+        if fu.ssa.is_synthetic_def(
+            &chain.definition.block,
+            chain.definition.statement_index,
+            var_name,
+        ) {
+            continue;
+        }
         // Find the defining statement — must be an AssignConst
         // with a literal value to forward. AssignValue without
         // substitutions could also work, but we're conservative
@@ -277,6 +287,22 @@ fn run_load_forwarding(
             let Some(use_stmt) = use_block.statements.get(use_idx) else {
                 continue;
             };
+            // A fanned may-def's prior-version read is a synthetic use —
+            // there is no `$var` in that statement to rewrite.
+            if fu
+                .ssa
+                .blocks
+                .values()
+                .find(|b| b.name == use_site.block)
+                .and_then(|b| b.statements.get(use_idx))
+                .is_some_and(|st| {
+                    fu.ssa
+                        .var_symbol(var_name)
+                        .is_some_and(|sym| st.may_defs.contains(&sym))
+                })
+            {
+                continue;
+            }
             if has_intervening_barrier(fu, &chain.definition.block, idx, &use_site.block, use_idx) {
                 continue;
             }

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -1635,7 +1635,7 @@ fn try_substitute_assign_expr(
     let env = Env::new();
     let octal = ctx.dialect.and_then(leading_zero_is_octal);
     if let Some(val) = eval_tcl_expr_with_octal(&parsed, &env, octal) {
-        let folded = format_tcl_value(val);
+        let folded = format_tcl_value(&val);
         let needs_quoting = folded.is_empty()
             || folded.contains([
                 ' ', '\t', '\n', '\r', '$', '[', ']', '{', '}', '"', '\\', '\0', ';',

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -1216,6 +1216,12 @@ pub fn evaluate_branch<S: std::hash::BuildHasher>(
         }
     }
     let v = eval_tcl_expr_with_octal(condition, &env, octal)?;
+    // A NaN condition is C's "floating point value is Not a Number" runtime
+    // error, not a truth value — folding either way would delete a branch
+    // that must raise. Decline.
+    if matches!(&v, crate::tcl_expr_eval::TclValue::Float(f) if f.is_nan()) {
+        return None;
+    }
     Some(v.is_truthy())
 }
 

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -1041,13 +1041,16 @@ pub fn evaluate_def<S: std::hash::BuildHasher>(
             // and AMOUNT is either absent (defaults to 1), a decimal
             // integer literal, or a simple `$var` reference that
             // resolves to Const(Int) via `uses`.
-            let sym = ssa.var_symbol(name);
-            let ver = sym
-                .and_then(|s| stmt_ssa.uses.get(&s))
-                .copied()
-                .unwrap_or(0);
-            let base = sym
-                .and_then(|s| values.get(&(s, ver)))
+            // A dynamic-key target (`incr a($i)`) never interns a symbol —
+            // that miss is permanent, so it must widen: returning Unknown
+            // would launder a fanned element's stale constant through
+            // `join(prev, Unknown) = prev`.
+            let Some(sym) = ssa.var_symbol(crate::naming::element_var_name(name)) else {
+                return LatticeValue::Overdefined;
+            };
+            let ver = stmt_ssa.uses.get(&sym).copied().unwrap_or(0);
+            let base = values
+                .get(&(sym, ver))
                 .cloned()
                 .unwrap_or(LatticeValue::Unknown);
             let base_int = match &base {

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -1239,6 +1239,10 @@ pub(crate) fn tcl_value_to_const(v: TclValue) -> ConstValue {
     match v {
         TclValue::Int(i) => ConstValue::Int(i),
         TclValue::Float(f) => ConstValue::Float(f),
+        // A beyond-wide integer's lattice form is its canonical decimal
+        // string — the value's one true rep, which downstream folds re-parse
+        // exactly (`set big [expr {2**64}]; expr {$big + 1}` chains).
+        TclValue::Big(b) => ConstValue::String(b.to_string()),
     }
 }
 

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -626,10 +626,42 @@ fn sccp_process_statements(
             }
             continue;
         }
+        // An element write's base def carries no scalar value of its own —
+        // `set arr(k) 5` / `set arr($i) 5` refresh `arr` for whole-array
+        // readers but must never let `$arr` fold to the element's value.
+        let element_write_base = match &stmt_ssa.statement {
+            Statement::AssignConst { name, .. }
+            | Statement::AssignExpr { name, .. }
+            | Statement::AssignValue { name, .. }
+            | Statement::Incr { name, .. }
+                if name.contains('(') =>
+            {
+                ssa.var_symbol(crate::naming::normalise_var_name(name))
+            }
+            _ => None,
+        };
         for (&var, ver) in &stmt_ssa.defs {
             let val =
-                if is_externally_mutable(ssa.var_name(var), escaping, has_dynamic_variable_trace) {
+                if is_externally_mutable(ssa.var_name(var), escaping, has_dynamic_variable_trace)
+                    || element_write_base == Some(var)
+                {
                     LatticeValue::Overdefined
+                } else if stmt_ssa.may_defs.contains(&var) {
+                    // A synthetic array-element may-def: the write may or may
+                    // not have hit this element, so its value is the JOIN of
+                    // the prior version (recorded as a use) and the written
+                    // value. The base refresh of an element write carries no
+                    // prior use — the base holds no value of its own.
+                    match stmt_ssa.uses.get(&var) {
+                        Some(prev_ver) => {
+                            let prev = values
+                                .get(&(var, *prev_ver))
+                                .cloned()
+                                .unwrap_or(LatticeValue::Overdefined);
+                            join(&prev, &evaluate_def(stmt_ssa, &*values, ssa, octal))
+                        }
+                        None => LatticeValue::Overdefined,
+                    }
                 } else {
                     evaluate_def(stmt_ssa, &*values, ssa, octal)
                 };
@@ -1768,6 +1800,7 @@ mod tests {
             },
             uses: HashMap::new(),
             defs,
+            may_defs: std::collections::HashSet::new(),
         }
     }
 
@@ -1849,6 +1882,7 @@ mod tests {
             },
             uses: HashMap::new(),
             defs,
+            may_defs: std::collections::HashSet::new(),
         });
         let mut values: HashMap<ValueKey, LatticeValue> = HashMap::new();
         let escaping: HashSet<String> = HashSet::new();
@@ -2056,6 +2090,7 @@ mod tests {
             },
             uses,
             defs,
+            may_defs: std::collections::HashSet::new(),
         };
 
         let mut values = HashMap::new();
@@ -2091,6 +2126,7 @@ mod tests {
             },
             uses,
             defs,
+            may_defs: std::collections::HashSet::new(),
         }
     }
 
@@ -2229,6 +2265,7 @@ mod tests {
             },
             uses: HashMap::new(),
             defs,
+            may_defs: std::collections::HashSet::new(),
         }
     }
 
@@ -2377,6 +2414,7 @@ mod tests {
             },
             uses: HashMap::new(),
             defs,
+            may_defs: std::collections::HashSet::new(),
         }
     }
 

--- a/rust/tcl-compiler/src/shimmer/byte_array.rs
+++ b/rust/tcl-compiler/src/shimmer/byte_array.rs
@@ -349,7 +349,7 @@ impl<'a> ByteCorruption<'a> {
             return None;
         }
         if is_pure_var_ref(a) {
-            let name = normalise_var_name(a);
+            let name = crate::naming::element_var_name(a);
             let sym = ssa.var_symbol(name)?;
             let ver = uses.get(&sym).copied().unwrap_or(0);
             return (ver > 0)

--- a/rust/tcl-compiler/src/shimmer/commit.rs
+++ b/rust/tcl-compiler/src/shimmer/commit.rs
@@ -292,10 +292,10 @@ impl CommitWalker<'_> {
 /// non-empty may-set).
 fn initial_state(ctx: &CommitCtx<'_>, key: ValueKey) -> Option<CommitState> {
     let lattice = ctx.types.get(&key)?;
-    if lattice.kind != TypeKind::Known {
+    if lattice.kind() != TypeKind::Known {
         return Some(CommitState::pure());
     }
-    let t = lattice.tcl_type?;
+    let t = lattice.tcl_type()?;
     Some(if is_pure_intrep(t, ctx.values.get(&key)) {
         CommitState::pure()
     } else {

--- a/rust/tcl-compiler/src/shimmer/commit.rs
+++ b/rust/tcl-compiler/src/shimmer/commit.rs
@@ -1,0 +1,787 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Committed-intrep forward dataflow (the "first-use commit" pass).
+//!
+//! C Tcl values are pure strings (`typePtr == NULL`) until an operation reads
+//! them as a typed value; that first read **commits** an intrep in place, and
+//! only a *later* read as a different type genuinely re-represents (shimmers).
+//! The type lattice cannot carry this — it is keyed per SSA version, and
+//! commitment happens at *uses* (a value is pure before `lindex $x 0` and a
+//! list after it, with no new version in between) — so this pass tracks it
+//! flow-sensitively per program point.
+//!
+//! Per `(symbol, version)` the state is a **must/may** pair (see
+//! [`CommitState`]): the bounded set of intreps the value *may* have committed
+//! on some path, and whether *every* path has committed one.  A mismatching use
+//! is a genuine, every-execution shimmer precisely when the value is committed
+//! on all paths and the required intrep is not among the possible ones — the
+//! "multiple different dominator types" analysis: at a merge of two branches
+//! that committed `Int` and `List`, a later use as `Dict` pays on both paths
+//! (fires), a use as `List` pays only on one (stays silent).
+//!
+//! Outputs:
+//! - [`CommitFacts`] — per-block entry states, consumed by the use-site / expr
+//!   shimmer detectors via a per-block [`CommitWalker`] that replays the same
+//!   transfer function statement by statement.
+//! - [`CommitFacts::single_commitments`] — the def-site pushback map: versions
+//!   whose *every* executable typed read committed the same intrep, for
+//!   surfacing "first used as: list" at the creation site (hover).
+
+use std::collections::{HashMap, HashSet};
+
+use tcl_lexer::Span;
+use tcl_registry::{CommandRegistry, TclType};
+
+use crate::analyses::LatticeValue;
+use crate::cfg::{BlockId, Function as CfgFunction, Terminator};
+use crate::expr_ast::{BinOp, ExprNode};
+use crate::ir::Statement;
+use crate::naming::normalise_var_name;
+use crate::sccp::cfg_order;
+use crate::ssa::{SsaFunction, Symbol, ValueKey};
+use crate::types::{TypeKind, TypeLattice};
+use crate::value_shapes::is_pure_var_ref;
+
+use super::hints::{arg_shimmer_type, is_numeric_compatible, is_pure_intrep};
+use super::use_site::foreach_header_expected_type;
+
+/// Upper bound on the tracked may-set — a value committed to more than this
+/// many distinct intreps across paths widens to "unknown" (never fires).
+const MAX_MAY_TYPES: usize = 3;
+
+/// The commitment state of one SSA value at one program point.
+#[derive(Debug, Clone, PartialEq, Eq, Default)]
+pub struct CommitState {
+    /// Intreps the value may have committed on **some** path here (bounded by
+    /// [`MAX_MAY_TYPES`]; empty ⇒ still pure on every path).
+    may: Vec<TclType>,
+    /// True when **every** executable path here has committed some intrep.
+    all_committed: bool,
+    /// True when the may-set overflowed — the state is unknown and must never
+    /// drive a warning.
+    overflowed: bool,
+    /// Earliest site that committed an intrep, for "first converted here"
+    /// related info.
+    first_span: Option<Span>,
+}
+
+impl CommitState {
+    /// The pure (uncommitted-on-every-path) state.
+    #[must_use]
+    pub fn pure() -> Self {
+        Self::default()
+    }
+
+    /// A state committed to `t` on every path.
+    #[must_use]
+    pub fn committed(t: TclType, span: Option<Span>) -> Self {
+        Self {
+            may: vec![t],
+            all_committed: true,
+            overflowed: false,
+            first_span: span,
+        }
+    }
+
+    /// Record a read of this value at a position requiring intrep `t`: the
+    /// runtime converts (or the command errors and execution stops), so the
+    /// post-state is committed to exactly `t` on the paths through here.
+    pub fn commit(&mut self, t: TclType, span: Span) {
+        if self.first_span.is_none() {
+            self.first_span = Some(span);
+        }
+        self.may.clear();
+        self.may.push(t);
+        self.all_committed = true;
+        self.overflowed = false;
+    }
+
+    /// Whether **every** executable path to this point pays a conversion for a
+    /// read requiring `expected` — committed on all paths, and no possible
+    /// committed intrep satisfies the requirement (numeric-family intreps are
+    /// interchangeable, mirroring the detectors' compatibility rule).
+    #[must_use]
+    pub fn must_pay(&self, expected: TclType) -> bool {
+        self.all_committed
+            && !self.overflowed
+            && !self.may.is_empty()
+            && !self
+                .may
+                .iter()
+                .any(|&t| t == expected || is_numeric_compatible(t, expected))
+    }
+
+    /// The single committed intrep when exactly one is possible — the precise
+    /// `from_type` for a fired warning.
+    #[must_use]
+    pub fn single_committed(&self) -> Option<TclType> {
+        (self.all_committed && !self.overflowed && self.may.len() == 1).then(|| self.may[0])
+    }
+
+    /// The single intrep the value *may* have committed, even when some path
+    /// is still pure — the steady-state rep of a loop-carried value whose
+    /// entry re-joins the pure preheader each iteration (`llength $l` /
+    /// `dict size $l` alternating: at the `llength`, `may = {Dict}` from the
+    /// back edge though the first iteration arrives pure).
+    #[must_use]
+    pub fn single_may(&self) -> Option<TclType> {
+        (!self.overflowed && self.may.len() == 1).then(|| self.may[0])
+    }
+
+    /// The committed intreps possibly held here, for the path-dependent
+    /// wording of a merge-of-different-commitments warning.
+    #[must_use]
+    pub fn may_types(&self) -> &[TclType] {
+        if self.overflowed { &[] } else { &self.may }
+    }
+
+    /// The site that first committed an intrep, when known.
+    #[must_use]
+    pub fn first_span(&self) -> Option<Span> {
+        self.first_span
+    }
+
+    /// Join with another predecessor's exit state (control-flow merge): the
+    /// may-sets union (bounded), and the value is all-paths-committed only when
+    /// both sides are.
+    fn join(&mut self, other: &Self) {
+        self.all_committed &= other.all_committed;
+        self.overflowed |= other.overflowed;
+        for &t in &other.may {
+            if !self.may.contains(&t) {
+                if self.may.len() >= MAX_MAY_TYPES {
+                    self.overflowed = true;
+                    break;
+                }
+                self.may.push(t);
+            }
+        }
+        self.first_span = match (self.first_span, other.first_span) {
+            (Some(a), Some(b)) => Some(if b.start() < a.start() { b } else { a }),
+            (a, b) => a.or(b),
+        };
+    }
+}
+
+/// One typed read extracted from a statement or terminator: variable `sym` is
+/// read at a position that installs intrep `expected`.
+#[derive(Debug, Clone, Copy)]
+struct TypedRead {
+    sym: Symbol,
+    ver: u32,
+    expected: TclType,
+    span: Span,
+}
+
+/// The fixpoint result: per-block entry commitment states.
+pub struct CommitFacts {
+    block_entry: HashMap<BlockId, HashMap<ValueKey, CommitState>>,
+    /// Per-version set of intreps committed by any executable typed read
+    /// (bounded like the may-set), for the def-site pushback.
+    use_commit_types: HashMap<ValueKey, Vec<TclType>>,
+}
+
+impl CommitFacts {
+    /// A per-block walker seeded with the block's entry state, replaying the
+    /// transfer function statement by statement in step with a detector walk.
+    #[must_use]
+    pub fn walker<'a>(&self, ctx: &CommitCtx<'a>, block_id: BlockId) -> CommitWalker<'a> {
+        CommitWalker {
+            state: self.block_entry.get(&block_id).cloned().unwrap_or_default(),
+            registry: ctx.registry,
+            ssa: ctx.ssa,
+            types: ctx.types,
+            values: ctx.values,
+        }
+    }
+
+    /// The def-site pushback map: versions that start **pure** and whose every
+    /// executable typed read committed the **same** intrep resolve to that
+    /// intrep — the "first used as" fact a hover can surface at the creation
+    /// site. Versions with conflicting or no typed reads are absent.
+    #[must_use]
+    pub fn single_commitments(&self, ctx: &CommitCtx<'_>) -> HashMap<ValueKey, TclType> {
+        self.use_commit_types
+            .iter()
+            .filter(|(key, committed)| {
+                committed.len() == 1
+                    && initial_state(ctx, **key).is_some_and(|s| s == CommitState::pure())
+            })
+            .map(|(key, committed)| (*key, committed[0]))
+            .collect()
+    }
+}
+
+/// Read-only inputs threaded through the fixpoint and the per-block walkers.
+pub struct CommitCtx<'a> {
+    /// Command registry, for `arg_types` shimmer hints and foreach headers.
+    pub registry: &'a CommandRegistry,
+    /// SSA form, for variable symbols and per-statement use versions.
+    pub ssa: &'a SsaFunction,
+    /// Per-version inferred types, for each version's initial purity.
+    pub types: &'a HashMap<ValueKey, TypeLattice>,
+    /// SCCP constants, for the numeric-literal purity distinction.
+    pub values: &'a HashMap<ValueKey, LatticeValue>,
+}
+
+/// A per-block replay of the commitment transfer function, kept in step with a
+/// detector's statement walk: query [`Self::state_of`] *before* checking a
+/// statement, then [`Self::step`] past it.
+pub struct CommitWalker<'a> {
+    state: HashMap<ValueKey, CommitState>,
+    registry: &'a CommandRegistry,
+    ssa: &'a SsaFunction,
+    types: &'a HashMap<ValueKey, TypeLattice>,
+    values: &'a HashMap<ValueKey, LatticeValue>,
+}
+
+impl CommitWalker<'_> {
+    /// The commitment state of `(sym, ver)` at the current point — versions
+    /// not yet touched start at their def's initial state ([`initial_state`]).
+    #[must_use]
+    pub fn state_of(&self, sym: Symbol, ver: u32) -> CommitState {
+        let key = (sym, ver);
+        if let Some(s) = self.state.get(&key) {
+            return s.clone();
+        }
+        let ctx = CommitCtx {
+            registry: self.registry,
+            ssa: self.ssa,
+            types: self.types,
+            values: self.values,
+        };
+        initial_state(&ctx, key).unwrap_or_default()
+    }
+
+    /// Advance the state past one statement.
+    pub fn step(&mut self, stmt: &Statement, uses: &HashMap<Symbol, u32>) {
+        let ctx = CommitCtx {
+            registry: self.registry,
+            ssa: self.ssa,
+            types: self.types,
+            values: self.values,
+        };
+        for read in typed_reads_of_statement(&ctx, stmt, uses) {
+            apply_read(&ctx, &mut self.state, read, None);
+        }
+    }
+}
+
+/// The state a version starts in at its def: pure when the producer left the
+/// value uncommitted ([`is_pure_intrep`] over the type lattice + SCCP constant
+/// — a literal, an interpolation, or a string-command result), committed to
+/// the producer's intrep otherwise (`[list …]`, `[dict create …]`, `expr`,
+/// `binary format`, …).  `None` when the version has no known type (stays
+/// pure-with-unknown: never drives a warning because `must_pay` needs a
+/// non-empty may-set).
+fn initial_state(ctx: &CommitCtx<'_>, key: ValueKey) -> Option<CommitState> {
+    let lattice = ctx.types.get(&key)?;
+    if lattice.kind != TypeKind::Known {
+        return Some(CommitState::pure());
+    }
+    let t = lattice.tcl_type?;
+    Some(if is_pure_intrep(t, ctx.values.get(&key)) {
+        CommitState::pure()
+    } else {
+        CommitState::committed(t, None)
+    })
+}
+
+/// Apply one typed read to the state map, recording the commitment (and, when
+/// `sink` is provided, accumulating the per-version committed-type set for the
+/// def-site pushback).
+fn apply_read(
+    ctx: &CommitCtx<'_>,
+    state: &mut HashMap<ValueKey, CommitState>,
+    read: TypedRead,
+    sink: Option<&mut HashMap<ValueKey, Vec<TclType>>>,
+) {
+    let key = (read.sym, read.ver);
+    let entry = state
+        .entry(key)
+        .or_insert_with(|| initial_state(ctx, key).unwrap_or_default());
+    entry.commit(read.expected, read.span);
+    if let Some(sink) = sink {
+        let committed = sink.entry(key).or_default();
+        if !committed.contains(&read.expected) && committed.len() <= MAX_MAY_TYPES {
+            committed.push(read.expected);
+        }
+    }
+}
+
+/// Compute the per-block entry commitment states for one function by forward
+/// fixpoint over the SCCP-executable blocks (must/may join at merges).
+#[must_use]
+pub fn compute_commit_facts<S: std::hash::BuildHasher, E: std::hash::BuildHasher>(
+    cfg: &CfgFunction,
+    ctx: &CommitCtx<'_>,
+    executable_blocks: &HashSet<BlockId, S>,
+    executable_edges: &HashSet<(BlockId, BlockId), E>,
+) -> CommitFacts {
+    let order = cfg_order(cfg);
+    let preds = cfg.predecessors();
+    let mut block_entry: HashMap<BlockId, HashMap<ValueKey, CommitState>> = HashMap::new();
+    let mut block_exit: HashMap<BlockId, HashMap<ValueKey, CommitState>> = HashMap::new();
+    let mut use_commit_types: HashMap<ValueKey, Vec<TclType>> = HashMap::new();
+
+    let mut changed = true;
+    while changed {
+        changed = false;
+        for &block_id in &order {
+            if !executable_blocks.contains(&block_id) {
+                continue;
+            }
+            let entry = join_entry(ctx, block_id, &preds, executable_edges, &block_exit);
+            let exit = transfer_block(ctx, cfg, block_id, entry.clone(), &mut use_commit_types);
+            if block_entry.get(&block_id) != Some(&entry) {
+                block_entry.insert(block_id, entry);
+                changed = true;
+            }
+            if block_exit.get(&block_id) != Some(&exit) {
+                block_exit.insert(block_id, exit);
+                changed = true;
+            }
+        }
+    }
+
+    CommitFacts {
+        block_entry,
+        use_commit_types,
+    }
+}
+
+/// Join the exit states of a block's executable predecessors into its entry
+/// state.  A version absent from a predecessor's exit map is at that
+/// predecessor's *initial* state along that path, so the join seeds from the
+/// initial state rather than skipping the key (skipping would claim
+/// all-paths-committed off a single committing path).
+fn join_entry<E: std::hash::BuildHasher>(
+    ctx: &CommitCtx<'_>,
+    block_id: BlockId,
+    preds: &HashMap<BlockId, HashSet<BlockId>>,
+    executable_edges: &HashSet<(BlockId, BlockId), E>,
+    block_exit: &HashMap<BlockId, HashMap<ValueKey, CommitState>>,
+) -> HashMap<ValueKey, CommitState> {
+    let mut exec_preds: Vec<BlockId> = preds
+        .get(&block_id)
+        .map(|ps| {
+            ps.iter()
+                .filter(|p| executable_edges.contains(&(**p, block_id)))
+                .copied()
+                .collect()
+        })
+        .unwrap_or_default();
+    exec_preds.sort_unstable();
+
+    let mut entry: HashMap<ValueKey, CommitState> = HashMap::new();
+    let keys: HashSet<ValueKey> = exec_preds
+        .iter()
+        .filter_map(|p| block_exit.get(p))
+        .flat_map(|m| m.keys().copied())
+        .collect();
+    for key in keys {
+        let mut acc: Option<CommitState> = None;
+        for p in &exec_preds {
+            let s = block_exit
+                .get(p)
+                .and_then(|m| m.get(&key))
+                .cloned()
+                .unwrap_or_else(|| initial_state(ctx, key).unwrap_or_default());
+            match &mut acc {
+                None => acc = Some(s),
+                Some(a) => a.join(&s),
+            }
+        }
+        if let Some(a) = acc {
+            entry.insert(key, a);
+        }
+    }
+    entry
+}
+
+/// Run the transfer function over one block's statements and terminator.
+fn transfer_block(
+    ctx: &CommitCtx<'_>,
+    cfg: &CfgFunction,
+    block_id: BlockId,
+    mut state: HashMap<ValueKey, CommitState>,
+    use_commit_types: &mut HashMap<ValueKey, Vec<TclType>>,
+) -> HashMap<ValueKey, CommitState> {
+    if let Some(ssa_block) = ctx.ssa.blocks.get(&block_id) {
+        for ss in &ssa_block.statements {
+            for read in typed_reads_of_statement(ctx, &ss.statement, &ss.uses) {
+                apply_read(ctx, &mut state, read, Some(use_commit_types));
+            }
+        }
+        // Branch-condition reads live on the terminator, evaluated after the
+        // block's statements with its exit versions.
+        if let Some(block) = cfg.blocks.get(&block_id)
+            && let Some(Terminator::Branch {
+                condition, span, ..
+            }) = &block.terminator
+        {
+            let branch_span = span.unwrap_or_else(|| Span::new(0, 0));
+            for read in typed_reads_of_expr(ctx, condition, &ssa_block.exit_versions, branch_span) {
+                apply_read(ctx, &mut state, read, Some(use_commit_types));
+            }
+        }
+    }
+    state
+}
+
+/// Extract every `$var` read of `stmt` at a position that installs a specific
+/// intrep — the transfer function's alphabet.  Mirrors the read extraction of
+/// the use-site and expr detectors (registry `arg_types` / foreach headers /
+/// `incr` / expr operand contexts), so the state the detectors consult moves
+/// exactly when the runtime converts.
+fn typed_reads_of_statement(
+    ctx: &CommitCtx<'_>,
+    stmt: &Statement,
+    uses: &HashMap<Symbol, u32>,
+) -> Vec<TypedRead> {
+    let mut out = Vec::new();
+    match stmt {
+        Statement::Call {
+            args,
+            foreach_groups,
+            ..
+        } => {
+            let lookup = stmt.canonical_command_or_source();
+            let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+            for (i, word) in args.iter().enumerate() {
+                let expected = if foreach_groups.is_some() {
+                    foreach_header_expected_type(ctx.registry, lookup)
+                } else {
+                    arg_shimmer_type(ctx.registry, lookup, &arg_refs, i)
+                };
+                if let Some(expected) = expected {
+                    push_var_read(ctx, &mut out, word, expected, stmt.span(), uses);
+                }
+            }
+        }
+        Statement::AssignValue { value, .. } => {
+            if let Some((command, args)) =
+                crate::value_shapes::parse_command_substitution(value.trim())
+            {
+                let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
+                for (i, word) in args.iter().enumerate() {
+                    if let Some(expected) = arg_shimmer_type(ctx.registry, &command, &arg_refs, i) {
+                        push_var_read(ctx, &mut out, word, expected, stmt.span(), uses);
+                    }
+                }
+            }
+        }
+        Statement::Incr { name, amount, .. } => {
+            push_var_read(
+                ctx,
+                &mut out,
+                &format!("${name}"),
+                TclType::Int,
+                stmt.span(),
+                uses,
+            );
+            if let Some(amt) = amount.as_deref().map(str::trim)
+                && amt.starts_with('$')
+            {
+                push_var_read(ctx, &mut out, amt, TclType::Int, stmt.span(), uses);
+            }
+        }
+        Statement::AssignExpr { expr, span, .. } | Statement::ExprEval { expr, span, .. } => {
+            out.extend(typed_reads_of_expr(ctx, expr, uses, *span));
+        }
+        _ => {}
+    }
+    out
+}
+
+/// Extract the typed operand reads of one expression AST: arithmetic /
+/// bitwise / shift operands read as `Numeric`, `&&`/`||` operands as
+/// `Boolean`, and the RIGHT operand of `in`/`ni` as `List`.  String
+/// comparisons are dual-ported (no conversion) and comparison operators probe
+/// per-value (statically unknowable) — neither commits.
+fn typed_reads_of_expr(
+    ctx: &CommitCtx<'_>,
+    node: &ExprNode,
+    uses: &HashMap<Symbol, u32>,
+    span: Span,
+) -> Vec<TypedRead> {
+    let mut out = Vec::new();
+    collect_expr_reads(ctx, node, uses, span, &mut out);
+    out
+}
+
+fn collect_expr_reads(
+    ctx: &CommitCtx<'_>,
+    node: &ExprNode,
+    uses: &HashMap<Symbol, u32>,
+    span: Span,
+    out: &mut Vec<TypedRead>,
+) {
+    match node {
+        ExprNode::Binary {
+            op, left, right, ..
+        } => {
+            collect_expr_reads(ctx, left, uses, span, out);
+            collect_expr_reads(ctx, right, uses, span, out);
+            match op {
+                BinOp::Add
+                | BinOp::Sub
+                | BinOp::Mul
+                | BinOp::Div
+                | BinOp::Mod
+                | BinOp::Pow
+                | BinOp::LShift
+                | BinOp::RShift
+                | BinOp::BitAnd
+                | BinOp::BitOr
+                | BinOp::BitXor => {
+                    push_expr_var_read(ctx, out, left, TclType::Numeric, span, uses);
+                    push_expr_var_read(ctx, out, right, TclType::Numeric, span, uses);
+                }
+                BinOp::And | BinOp::Or => {
+                    push_expr_var_read(ctx, out, left, TclType::Boolean, span, uses);
+                    push_expr_var_read(ctx, out, right, TclType::Boolean, span, uses);
+                }
+                BinOp::In | BinOp::Ni => {
+                    push_expr_var_read(ctx, out, right, TclType::List, span, uses);
+                }
+                _ => {}
+            }
+        }
+        ExprNode::Unary { operand, .. } => collect_expr_reads(ctx, operand, uses, span, out),
+        ExprNode::Ternary {
+            condition,
+            true_branch,
+            false_branch,
+            ..
+        } => {
+            collect_expr_reads(ctx, condition, uses, span, out);
+            collect_expr_reads(ctx, true_branch, uses, span, out);
+            collect_expr_reads(ctx, false_branch, uses, span, out);
+        }
+        _ => {}
+    }
+}
+
+/// Push a typed read for a `$var` argument word, resolving its SSA use
+/// version; non-variable words (literals, substitutions) commit nothing here —
+/// their values are not tracked variables.
+fn push_var_read(
+    ctx: &CommitCtx<'_>,
+    out: &mut Vec<TypedRead>,
+    word: &str,
+    expected: TclType,
+    span: Span,
+    uses: &HashMap<Symbol, u32>,
+) {
+    let stripped = word.trim();
+    if !is_pure_var_ref(stripped) {
+        return;
+    }
+    let var = normalise_var_name(stripped);
+    let Some(sym) = ctx.ssa.var_symbol(var) else {
+        return;
+    };
+    let Some(&ver) = uses.get(&sym) else {
+        return;
+    };
+    if ver == 0 {
+        return;
+    }
+    out.push(TypedRead {
+        sym,
+        ver,
+        expected,
+        span,
+    });
+}
+
+/// Push a typed read for an expression `Var` leaf.
+fn push_expr_var_read(
+    ctx: &CommitCtx<'_>,
+    out: &mut Vec<TypedRead>,
+    node: &ExprNode,
+    expected: TclType,
+    span: Span,
+    uses: &HashMap<Symbol, u32>,
+) {
+    if let ExprNode::Var { name, .. } = node {
+        push_var_read(
+            ctx,
+            out,
+            &format!("${}", name.trim_start_matches('$')),
+            expected,
+            span,
+            uses,
+        );
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::compilation_unit::CompilationUnit;
+    use tcl_registry::CommandRegistry;
+
+    fn registry() -> CommandRegistry {
+        CommandRegistry::build_default()
+    }
+
+    fn facts_for<'a>(
+        cu: &'a CompilationUnit,
+        registry: &'a CommandRegistry,
+        func: &str,
+    ) -> (CommitFacts, &'a crate::compilation_unit::FunctionUnit) {
+        let fu = cu.function(func).unwrap();
+        let ctx = CommitCtx {
+            registry,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            values: &fu.sccp.values,
+        };
+        let facts = compute_commit_facts(
+            &fu.cfg,
+            &ctx,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.executable_edges,
+        );
+        (facts, fu)
+    }
+
+    /// Straight-line: `expr` commits Numeric; the state at the following
+    /// statement must-pays a List read (the classic second-conversion FN).
+    #[test]
+    fn straight_line_expr_commit_then_list_must_pay() {
+        let r = registry();
+        let cu = CompilationUnit::build_for("set v 5\nexpr {$v + 1}\nlindex $v 0", &r, false);
+        let (facts, fu) = facts_for(&cu, &r, "::top");
+        let ctx = CommitCtx {
+            registry: &r,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            values: &fu.sccp.values,
+        };
+        let entry = fu.cfg.entry;
+        let mut walker = facts.walker(&ctx, entry);
+        let sym = fu.ssa.var_symbol("v").unwrap();
+        let ssa_block = fu.ssa.blocks.get(&entry).unwrap();
+        // Replay to just before the lindex call.
+        for ss in &ssa_block.statements {
+            if let Statement::Call { command, .. } = &ss.statement
+                && command == "lindex"
+            {
+                let ver = ss.uses[&sym];
+                let state = walker.state_of(sym, ver);
+                assert!(
+                    state.must_pay(TclType::List),
+                    "expr committed Numeric; lindex must pay: {state:?}"
+                );
+                assert_eq!(state.single_committed(), Some(TclType::Numeric));
+                return;
+            }
+            walker.step(&ss.statement, &ss.uses);
+        }
+        panic!("lindex statement not found");
+    }
+
+    /// Branch case: one arm commits Numeric (expr), the other List (llength).
+    /// After the merge a Dict read pays on both paths (fires); a List read
+    /// pays on only one (stays silent).
+    #[test]
+    fn merge_of_two_commitments_is_must_only_off_both() {
+        let r = registry();
+        let src = "proc f {c} {\n  set a {1 2}\n  if {$c} { expr {$a + 1} } else { llength $a }\n  dict size $a\n}\n";
+        let cu = CompilationUnit::build_for(src, &r, false);
+        let (facts, fu) = facts_for(&cu, &r, "::f");
+        let ctx = CommitCtx {
+            registry: &r,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            values: &fu.sccp.values,
+        };
+        let sym = fu.ssa.var_symbol("a").unwrap();
+        // Find the block holding the `dict size` call and replay to it.
+        for (&bid, ssa_block) in &fu.ssa.blocks {
+            let mut walker = facts.walker(&ctx, bid);
+            for ss in &ssa_block.statements {
+                if let Statement::Call { command, args, .. } = &ss.statement
+                    && command == "dict"
+                    && args.first().map(String::as_str) == Some("size")
+                {
+                    let ver = ss.uses[&sym];
+                    let state = walker.state_of(sym, ver);
+                    assert!(
+                        state.must_pay(TclType::Dict),
+                        "both arms committed non-Dict; dict read must pay: {state:?}"
+                    );
+                    assert!(
+                        !state.must_pay(TclType::List),
+                        "one arm committed List; a List read pays on one path only: {state:?}"
+                    );
+                    return;
+                }
+                walker.step(&ss.statement, &ss.uses);
+            }
+        }
+        panic!("dict size statement not found");
+    }
+
+    /// Def-site pushback: a pure literal whose only typed read is a List read
+    /// resolves to `List` in the single-commitments map.
+    #[test]
+    fn single_commitment_pushback_for_pure_literal() {
+        let r = registry();
+        let cu = CompilationUnit::build_for("set l {1 2 3}\nllength $l", &r, false);
+        let (facts, fu) = facts_for(&cu, &r, "::top");
+        let ctx = CommitCtx {
+            registry: &r,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            values: &fu.sccp.values,
+        };
+        let pushback = facts.single_commitments(&ctx);
+        let sym = fu.ssa.var_symbol("l").unwrap();
+        assert_eq!(
+            pushback.get(&(sym, 1)),
+            Some(&TclType::List),
+            "pure literal first-used-as-list must push back List: {pushback:?}"
+        );
+    }
+
+    /// A committed producer (`[dict create]`) is not "first used as" anything —
+    /// the pushback map only covers pure defs.
+    #[test]
+    fn no_pushback_for_committed_producer() {
+        let r = registry();
+        let cu = CompilationUnit::build_for("set d [dict create a 1]\nllength $d", &r, false);
+        let (facts, fu) = facts_for(&cu, &r, "::top");
+        let ctx = CommitCtx {
+            registry: &r,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            values: &fu.sccp.values,
+        };
+        let pushback = facts.single_commitments(&ctx);
+        let sym = fu.ssa.var_symbol("d").unwrap();
+        assert!(
+            !pushback.contains_key(&(sym, 1)),
+            "committed producers must not appear in the pushback map: {pushback:?}"
+        );
+    }
+}

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -38,6 +38,7 @@ use tcl_core_types::DiagCode;
 use tcl_lexer::Span;
 use tcl_registry::TclType;
 
+use crate::analyses::LatticeValue;
 use crate::cfg::{BlockId, Function as CfgFunction, Terminator};
 use crate::expr_ast::{BinOp, ExprNode};
 use crate::ir::Statement;
@@ -47,6 +48,7 @@ use crate::ssa::{SsaFunction, Symbol, ValueKey};
 use crate::types::{TypeKind, TypeLattice};
 
 use super::graph::loop_body_blocks;
+use super::hints::is_uncommitted_first_conversion;
 use super::{ShimmerWarning, type_name};
 
 /// Find expression-level shimmer warnings for a function.
@@ -64,6 +66,7 @@ pub(crate) fn find_expr_shimmers(
     ssa: &SsaFunction,
     types: &HashMap<ValueKey, TypeLattice>,
     executable_blocks: &HashSet<BlockId>,
+    values: &HashMap<ValueKey, LatticeValue>,
 ) -> Vec<ShimmerWarning> {
     let mut out = Vec::new();
     let loop_blocks = loop_body_blocks(cfg);
@@ -101,6 +104,7 @@ pub(crate) fn find_expr_shimmers(
                     let mut ctx = ExprShimmerCtx {
                         uses: &ss.uses,
                         types,
+                        values,
                         ssa,
                         stmt_span: *span,
                         expr_base: *expr_base,
@@ -129,6 +133,7 @@ pub(crate) fn find_expr_shimmers(
             let mut ctx = ExprShimmerCtx {
                 uses: &ssa_block.exit_versions,
                 types,
+                values,
                 ssa,
                 stmt_span: branch_span,
                 expr_base: *condition_base,
@@ -151,6 +156,10 @@ pub(crate) fn find_expr_shimmers(
 struct ExprShimmerCtx<'a> {
     uses: &'a HashMap<Symbol, u32>,
     types: &'a HashMap<ValueKey, TypeLattice>,
+    /// SCCP constant values, for the uncommitted-value ("pure string") check —
+    /// a pure operand that is a valid instance of the required type converts for
+    /// free, so it must not be flagged (see [`is_uncommitted_first_conversion`]).
+    values: &'a HashMap<ValueKey, LatticeValue>,
     ssa: &'a SsaFunction,
     stmt_span: Span,
     /// Absolute source offset of the expression text's first byte, when it
@@ -341,6 +350,18 @@ fn check_numeric_operand(
         current,
         TclType::String | TclType::List | TclType::Dict | TclType::ByteArray
     ) {
+        let (to_type, context_name) = match context {
+            NumericContext::Arithmetic => (TclType::Numeric, "arithmetic expression"),
+            NumericContext::Boolean => (TclType::Boolean, "boolean context"),
+        };
+        // A pure (uncommitted) operand whose value is a valid number / boolean
+        // converts for free: `set s [string trim true]; expr {$s && 1}` and a
+        // numeric-valued string in arithmetic are not shimmers. A committed
+        // List/Dict/ByteArray, or a pure string that is not a valid instance
+        // (`set s hello; expr {$s + 1}`), still fires.
+        if is_uncommitted_first_conversion(current, to_type, ctx.values.get(&(sym, ver))) {
+            return;
+        }
         // De-duplicate per (statement span, variable) within the block.
         if !ctx.seen.insert((ctx.stmt_span, base.to_owned())) {
             return;
@@ -349,10 +370,6 @@ fn check_numeric_operand(
             DiagCode::S101
         } else {
             DiagCode::S100
-        };
-        let (to_type, context_name) = match context {
-            NumericContext::Arithmetic => (TclType::Numeric, "arithmetic expression"),
-            NumericContext::Boolean => (TclType::Boolean, "boolean context"),
         };
         ctx.out.push(ShimmerWarning {
             span: ctx.operand_span(node),
@@ -407,6 +424,13 @@ fn check_list_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp) 
         current,
         TclType::String | TclType::Dict | TclType::ByteArray
     ) {
+        // A pure string is a free first conversion to a list — `set hay [string
+        // trim "a b c"]; expr {"b" in $hay}` parses it once, losslessly (oracle:
+        // the value goes pure → list). Only a committed Dict/ByteArray genuinely
+        // re-represents on the `in` list conversion.
+        if is_uncommitted_first_conversion(current, TclType::List, ctx.values.get(&(sym, ver))) {
+            return;
+        }
         if !ctx.seen.insert((ctx.stmt_span, base.to_owned())) {
             return;
         }
@@ -534,7 +558,13 @@ mod tests {
     fn no_expr_shimmer_int_in_arithmetic() {
         let cu = CompilationUnit::build_for("set x 5\nset y [expr {$x + 1}]", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         assert!(w.is_empty(), "unexpected expr shimmers: {w:?}");
     }
 
@@ -547,7 +577,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "x" && sw.from_type == TclType::String);
@@ -581,7 +617,13 @@ mod tests {
         ] {
             let cu = CompilationUnit::build_for(src, &registry(), false);
             let fu = cu.function("::top").unwrap();
-            let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+            let w = find_expr_shimmers(
+                &fu.cfg,
+                &fu.ssa,
+                &fu.types,
+                &fu.sccp.executable_blocks,
+                &fu.sccp.values,
+            );
             assert!(
                 !w.iter()
                     .any(|sw| sw.variable == "s" || sw.variable == "lst"),
@@ -602,7 +644,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let warning = w.iter().find(|sw| sw.variable == "s");
         let warning = warning.expect("string operand of && must be flagged");
         assert_eq!(warning.to_type, TclType::Boolean);
@@ -613,21 +661,53 @@ mod tests {
         );
     }
 
-    /// `in`/`ni` convert the RIGHT operand to a list — flag a String-typed
-    /// haystack (tclsh-verified genuine shimmer), leave a List-typed one and
-    /// the needle alone.
+    /// `in`/`ni` convert the RIGHT operand to a list. A *committed* Dict
+    /// haystack genuinely re-represents (Dict → List); a *pure* string haystack
+    /// does not — `[string trim "a b c"]` is a pure string (oracle: it goes pure
+    /// → list on first read), so its list conversion is free. A List-typed
+    /// haystack is already a list, and the needle is read as a string — both
+    /// silent.
     #[test]
-    fn expr_shimmer_in_membership_flags_string_haystack() {
+    fn expr_shimmer_in_membership_flags_committed_not_pure_haystack() {
+        // TP: a committed Dict haystack re-represents to a list.
         let cu = CompilationUnit::build_for(
-            "set hay [string trim \"a b c\"]\nset y [expr {\"b\" in $hay}]",
+            "set hay [dict create a 1 b 2]\nset y [expr {\"a\" in $hay}]",
             &registry(),
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
-        let warning = w.iter().find(|sw| sw.variable == "hay");
-        let warning = warning.expect("string haystack of `in` must be flagged");
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
+        let warning = w
+            .iter()
+            .find(|sw| sw.variable == "hay")
+            .expect("committed Dict haystack of `in` must be flagged");
+        assert_eq!(warning.from_type, TclType::Dict);
         assert_eq!(warning.to_type, TclType::List);
+
+        // TN (issue #940): a pure string haystack is a free first conversion.
+        let cu_pure = CompilationUnit::build_for(
+            "set hay [string trim \"a b c\"]\nset y [expr {\"b\" in $hay}]",
+            &registry(),
+            false,
+        );
+        let fu_pure = cu_pure.function("::top").unwrap();
+        let w_pure = find_expr_shimmers(
+            &fu_pure.cfg,
+            &fu_pure.ssa,
+            &fu_pure.types,
+            &fu_pure.sccp.executable_blocks,
+            &fu_pure.sccp.values,
+        );
+        assert!(
+            !w_pure.iter().any(|sw| sw.variable == "hay"),
+            "pure string haystack must not be flagged: {w_pure:?}"
+        );
 
         // A List-typed haystack is already a list — silent.
         let cu2 = CompilationUnit::build_for(
@@ -636,7 +716,13 @@ mod tests {
             false,
         );
         let fu2 = cu2.function("::top").unwrap();
-        let w2 = find_expr_shimmers(&fu2.cfg, &fu2.ssa, &fu2.types, &fu2.sccp.executable_blocks);
+        let w2 = find_expr_shimmers(
+            &fu2.cfg,
+            &fu2.ssa,
+            &fu2.types,
+            &fu2.sccp.executable_blocks,
+            &fu2.sccp.values,
+        );
         assert!(
             !w2.iter().any(|sw| sw.variable == "hay"),
             "list haystack must not be flagged: {w2:?}"
@@ -644,12 +730,18 @@ mod tests {
 
         // The needle is read as a string — a String-typed needle is silent.
         let cu3 = CompilationUnit::build_for(
-            "set needle [string trim b]\nset hay [list a b c]\nset y [expr {$needle in $hay}]",
+            "set needle [string trim b]\nset hay [dict create a 1]\nset y [expr {$needle in $hay}]",
             &registry(),
             false,
         );
         let fu3 = cu3.function("::top").unwrap();
-        let w3 = find_expr_shimmers(&fu3.cfg, &fu3.ssa, &fu3.types, &fu3.sccp.executable_blocks);
+        let w3 = find_expr_shimmers(
+            &fu3.cfg,
+            &fu3.ssa,
+            &fu3.types,
+            &fu3.sccp.executable_blocks,
+            &fu3.sccp.values,
+        );
         assert!(
             !w3.iter().any(|sw| sw.variable == "needle"),
             "the needle of `in` must not be flagged: {w3:?}"
@@ -662,7 +754,13 @@ mod tests {
         let cu =
             CompilationUnit::build_for("set x 42\nset z [expr {$x eq \"42\"}]", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "x" && sw.from_type == TclType::Int);
@@ -682,7 +780,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "x" && sw.from_type == TclType::Int);
@@ -702,7 +806,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let xs: Vec<_> = w.iter().filter(|sw| sw.variable == "x").collect();
         assert_eq!(
             xs.len(),
@@ -721,7 +831,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let s = w.iter().find(|sw| sw.variable == "x");
         assert!(s.is_some(), "expected expr shimmer for x in loop: {w:?}");
         let s = s.unwrap();
@@ -742,7 +858,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         // x is String; used with eq (string comparison) — no shimmer.
         let str_cmp_shimmers: Vec<_> = w
             .iter()
@@ -765,7 +887,13 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "b" && sw.from_type == TclType::ByteArray);
@@ -782,7 +910,13 @@ mod tests {
         let src = "set x \"hello\"\nset y [expr {$x + 1}]";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let s = w
             .iter()
             .find(|sw| sw.variable == "x")
@@ -803,7 +937,13 @@ mod tests {
         let src = "set x 42\nif {$x eq \"42\"} { set y 1 }";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let s = w
             .iter()
             .find(|sw| sw.variable == "x")
@@ -824,7 +964,13 @@ mod tests {
         let src = "proc f {} {\n  set x \"hello\"\n  set y [expr {$x * 2}]\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let s = w
             .iter()
             .find(|sw| sw.variable == "x")
@@ -848,7 +994,13 @@ mod tests {
         let src = "set x 42\nif \"$x eq 42\" { set y 1 }";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         // The quoted form substitutes before parsing, so the shimmer may or
         // may not fire; when it does, the span must contain the whole
         // fallback range and be non-degenerate.
@@ -873,7 +1025,13 @@ mod tests {
         let src = "set x \"hi\"\nset y [expr {$x + $x}]";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let xs: Vec<_> = w.iter().filter(|sw| sw.variable == "x").collect();
         assert_eq!(xs.len(), 1, "one warning per statement+var: {xs:?}");
         let first = src.find("{$x").unwrap() + 1;
@@ -899,7 +1057,13 @@ mod tests {
         let src = "set x 10\nset y 2\nset z [expr {$x lt $y}]";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(&fu.cfg, &fu.ssa, &fu.types, &fu.sccp.executable_blocks);
+        let w = find_expr_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.values,
+        );
         let s = w
             .iter()
             .find(|sw| sw.variable == "x" || sw.variable == "y")

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -352,10 +352,10 @@ fn check_numeric_operand(
         .get(&(sym, ver))
         .cloned()
         .unwrap_or_else(TypeLattice::unknown);
-    if lattice.kind != TypeKind::Known {
+    if lattice.kind() != TypeKind::Known {
         return;
     }
-    let Some(current) = lattice.tcl_type else {
+    let Some(current) = lattice.tcl_type() else {
         return;
     };
     let (to_type, context_name) = match context {
@@ -441,10 +441,10 @@ fn check_list_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp) 
         .get(&(sym, ver))
         .cloned()
         .unwrap_or_else(TypeLattice::unknown);
-    if lattice.kind != TypeKind::Known {
+    if lattice.kind() != TypeKind::Known {
         return;
     }
-    let Some(current) = lattice.tcl_type else {
+    let Some(current) = lattice.tcl_type() else {
         return;
     };
     // A prior use that committed a non-list intrep on every path makes this
@@ -520,10 +520,10 @@ fn check_string_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp
         .get(&(sym, ver))
         .cloned()
         .unwrap_or_else(TypeLattice::unknown);
-    if lattice.kind != TypeKind::Known {
+    if lattice.kind() != TypeKind::Known {
         return;
     }
-    let Some(current) = lattice.tcl_type else {
+    let Some(current) = lattice.tcl_type() else {
         return;
     };
     // A numeric variable in a string comparison does NOT lose its intrep —

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -47,9 +47,9 @@ use crate::sccp::cfg_order;
 use crate::ssa::{SsaFunction, Symbol, ValueKey};
 use crate::types::{TypeKind, TypeLattice};
 
+use super::ShimmerWarning;
 use super::graph::loop_body_blocks;
 use super::hints::is_uncommitted_first_conversion;
-use super::{ShimmerWarning, type_name};
 
 /// Find expression-level shimmer warnings for a function.
 ///
@@ -67,9 +67,17 @@ pub(crate) fn find_expr_shimmers(
     types: &HashMap<ValueKey, TypeLattice>,
     executable_blocks: &HashSet<BlockId>,
     values: &HashMap<ValueKey, LatticeValue>,
+    registry: &tcl_registry::CommandRegistry,
+    commit_facts: &super::commit::CommitFacts,
 ) -> Vec<ShimmerWarning> {
     let mut out = Vec::new();
     let loop_blocks = loop_body_blocks(cfg);
+    let commit_ctx = super::commit::CommitCtx {
+        registry,
+        ssa,
+        types,
+        values,
+    };
 
     for block_id in cfg_order(cfg) {
         if !executable_blocks.contains(&block_id) {
@@ -85,6 +93,9 @@ pub(crate) fn find_expr_shimmers(
         // operands of the same statement that name the same variable emit one
         // warning, not one per operand.
         let mut seen: HashSet<(Span, String)> = HashSet::new();
+        // The committed-intrep walker replays the commit transfer in step with
+        // this walk, so each expr's operands see the state just before it.
+        let mut commit_walker = commit_facts.walker(&commit_ctx, block_id);
 
         // 1. SSA statements: AssignExpr and ExprEval.
         for ss in &ssa_block.statements {
@@ -106,6 +117,7 @@ pub(crate) fn find_expr_shimmers(
                         types,
                         values,
                         ssa,
+                        commit: &commit_walker,
                         stmt_span: *span,
                         expr_base: *expr_base,
                         in_loop,
@@ -116,6 +128,7 @@ pub(crate) fn find_expr_shimmers(
                 }
                 _ => {}
             }
+            commit_walker.step(&ss.statement, &ss.uses);
         }
 
         // 2. Branch terminator condition (if/while/for predicate).
@@ -135,6 +148,7 @@ pub(crate) fn find_expr_shimmers(
                 types,
                 values,
                 ssa,
+                commit: &commit_walker,
                 stmt_span: branch_span,
                 expr_base: *condition_base,
                 in_loop,
@@ -161,6 +175,11 @@ struct ExprShimmerCtx<'a> {
     /// free, so it must not be flagged (see [`is_uncommitted_first_conversion`]).
     values: &'a HashMap<ValueKey, LatticeValue>,
     ssa: &'a SsaFunction,
+    /// Committed-intrep state just before this statement ([`super::commit`]) —
+    /// an operand whose value already committed a different intrep on every
+    /// path genuinely re-represents here even when the lattice sees no
+    /// mismatch.
+    commit: &'a super::commit::CommitWalker<'a>,
     stmt_span: Span,
     /// Absolute source offset of the expression text's first byte, when it
     /// is a verbatim source slice (see [`crate::ir::IfClause::condition_base`]).
@@ -339,21 +358,30 @@ fn check_numeric_operand(
     let Some(current) = lattice.tcl_type else {
         return;
     };
-    // Only flag clearly non-numeric types (String, List, Dict, ByteArray). A
-    // byte array in an arithmetic context is a textbook C Tcl shimmer: Tcl
-    // has no numeric intrep of its own, so `Tcl_GetNumberFromObj` falls back
-    // to parsing the byte array's *string* rep (each byte relabelled as a
-    // Latin-1 code point) as a number and, on success, replaces the cached
-    // byte-array intrep with Int/Double — exactly the same in-place intrep
-    // clobber as the String/List/Dict cases, just via the byte-array route.
-    if matches!(
+    let (to_type, context_name) = match context {
+        NumericContext::Arithmetic => (TclType::Numeric, "arithmetic expression"),
+        NumericContext::Boolean => (TclType::Boolean, "boolean context"),
+    };
+    // A prior use that committed a non-numeric intrep on every path makes this
+    // operand a genuine second conversion (`set v 5; llength $v; expr {$v+1}`
+    // re-represents List → Numeric) — even where the lattice type is numeric.
+    let commit_state = ctx.commit.state_of(sym, ver);
+    // Otherwise only flag clearly non-numeric types (String, List, Dict,
+    // ByteArray). A byte array in an arithmetic context is a textbook C Tcl
+    // shimmer: Tcl has no numeric intrep of its own, so `Tcl_GetNumberFromObj`
+    // falls back to parsing the byte array's *string* rep (each byte
+    // relabelled as a Latin-1 code point) as a number and, on success,
+    // replaces the cached byte-array intrep with Int/Double — exactly the same
+    // in-place intrep clobber as the String/List/Dict cases, just via the
+    // byte-array route.
+    let lattice_flags = matches!(
         current,
         TclType::String | TclType::List | TclType::Dict | TclType::ByteArray
-    ) {
-        let (to_type, context_name) = match context {
-            NumericContext::Arithmetic => (TclType::Numeric, "arithmetic expression"),
-            NumericContext::Boolean => (TclType::Boolean, "boolean context"),
-        };
+    );
+    if !commit_state.must_pay(to_type) {
+        if !lattice_flags {
+            return;
+        }
         // A pure (uncommitted) operand whose value is a valid number / boolean
         // converts for free: `set s [string trim true]; expr {$s && 1}` and a
         // numeric-valued string in arithmetic are not shimmers. A committed
@@ -362,32 +390,31 @@ fn check_numeric_operand(
         if is_uncommitted_first_conversion(current, to_type, ctx.values.get(&(sym, ver))) {
             return;
         }
-        // De-duplicate per (statement span, variable) within the block.
-        if !ctx.seen.insert((ctx.stmt_span, base.to_owned())) {
-            return;
-        }
-        let code = if ctx.in_loop {
-            DiagCode::S101
-        } else {
-            DiagCode::S100
-        };
-        ctx.out.push(ShimmerWarning {
-            span: ctx.operand_span(node),
-            variable: base.to_owned(),
-            from_type: current,
-            to_type,
-            command: format!("expr:{op:?}"),
-            in_loop: ctx.in_loop,
-            code,
-            message: format!(
-                "variable '{var}' has {from} intrep used in {context_name} \
-                 (operand of '{op}')",
-                var = base,
-                from = type_name(current),
-            ),
-            related: Vec::new(),
-        });
     }
+    let (from, from_label) = super::committed_from_label(&commit_state, current, to_type);
+    // De-duplicate per (statement span, variable) within the block.
+    if !ctx.seen.insert((ctx.stmt_span, base.to_owned())) {
+        return;
+    }
+    let code = if ctx.in_loop {
+        DiagCode::S101
+    } else {
+        DiagCode::S100
+    };
+    ctx.out.push(ShimmerWarning {
+        span: ctx.operand_span(node),
+        variable: base.to_owned(),
+        from_type: from,
+        to_type,
+        command: format!("expr:{op:?}"),
+        in_loop: ctx.in_loop,
+        code,
+        message: format!(
+            "variable '{base}' has {from_label} intrep used in {context_name} \
+             (operand of '{op}')",
+        ),
+        related: Vec::new(),
+    });
 }
 
 /// Emit a shimmer for the RIGHT operand of `in`/`ni` when its type shows an
@@ -420,10 +447,18 @@ fn check_list_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp) 
     let Some(current) = lattice.tcl_type else {
         return;
     };
-    if matches!(
+    // A prior use that committed a non-list intrep on every path makes this
+    // membership test a genuine second conversion (`expr {$v+1}` then
+    // `expr {"b" in $v}` re-represents Numeric → List).
+    let commit_state = ctx.commit.state_of(sym, ver);
+    let lattice_flags = matches!(
         current,
         TclType::String | TclType::Dict | TclType::ByteArray
-    ) {
+    );
+    if !commit_state.must_pay(TclType::List) {
+        if !lattice_flags {
+            return;
+        }
         // A pure string is a free first conversion to a list — `set hay [string
         // trim "a b c"]; expr {"b" in $hay}` parses it once, losslessly (oracle:
         // the value goes pure → list). Only a committed Dict/ByteArray genuinely
@@ -431,32 +466,32 @@ fn check_list_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp) 
         if is_uncommitted_first_conversion(current, TclType::List, ctx.values.get(&(sym, ver))) {
             return;
         }
-        if !ctx.seen.insert((ctx.stmt_span, base.to_owned())) {
-            return;
-        }
-        let code = if ctx.in_loop {
-            DiagCode::S101
-        } else {
-            DiagCode::S100
-        };
-        ctx.out.push(ShimmerWarning {
-            span: ctx.stmt_span,
-            variable: base.to_owned(),
-            from_type: current,
-            to_type: TclType::List,
-            command: format!("expr:{op:?}"),
-            in_loop: ctx.in_loop,
-            code,
-            message: format!(
-                "variable '{var}' has {from} intrep converted to a list by \
-                 '{op_word}' membership",
-                var = base,
-                from = type_name(current),
-                op_word = if matches!(op, BinOp::In) { "in" } else { "ni" },
-            ),
-            related: Vec::new(),
-        });
     }
+    let (from, from_label) = super::committed_from_label(&commit_state, current, TclType::List);
+    if !ctx.seen.insert((ctx.stmt_span, base.to_owned())) {
+        return;
+    }
+    let code = if ctx.in_loop {
+        DiagCode::S101
+    } else {
+        DiagCode::S100
+    };
+    ctx.out.push(ShimmerWarning {
+        span: ctx.stmt_span,
+        variable: base.to_owned(),
+        from_type: from,
+        to_type: TclType::List,
+        command: format!("expr:{op:?}"),
+        in_loop: ctx.in_loop,
+        code,
+        message: format!(
+            "variable '{var}' has {from_label} intrep converted to a list by \
+             '{op_word}' membership",
+            var = base,
+            op_word = if matches!(op, BinOp::In) { "in" } else { "ni" },
+        ),
+        related: Vec::new(),
+    });
 }
 
 /// Emit a shimmer if `node` is a numeric variable used in a string
@@ -553,18 +588,41 @@ mod tests {
         CommandRegistry::build_default()
     }
 
-    /// An Int variable in arithmetic — no shimmer.
-    #[test]
-    fn no_expr_shimmer_int_in_arithmetic() {
-        let cu = CompilationUnit::build_for("set x 5\nset y [expr {$x + 1}]", &registry(), false);
-        let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
+    /// Compute commit facts + run the expr detector for one function unit —
+    /// the production wiring `find_shimmer_warnings` performs.
+    fn expr_shimmers(
+        fu: &crate::compilation_unit::FunctionUnit,
+        registry: &CommandRegistry,
+    ) -> Vec<ShimmerWarning> {
+        let ctx = super::super::commit::CommitCtx {
+            registry,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            values: &fu.sccp.values,
+        };
+        let facts = super::super::commit::compute_commit_facts(
+            &fu.cfg,
+            &ctx,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.executable_edges,
+        );
+        find_expr_shimmers(
             &fu.cfg,
             &fu.ssa,
             &fu.types,
             &fu.sccp.executable_blocks,
             &fu.sccp.values,
-        );
+            registry,
+            &facts,
+        )
+    }
+
+    /// An Int variable in arithmetic — no shimmer.
+    #[test]
+    fn no_expr_shimmer_int_in_arithmetic() {
+        let cu = CompilationUnit::build_for("set x 5\nset y [expr {$x + 1}]", &registry(), false);
+        let fu = cu.function("::top").unwrap();
+        let w = expr_shimmers(fu, &registry());
         assert!(w.is_empty(), "unexpected expr shimmers: {w:?}");
     }
 
@@ -577,13 +635,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "x" && sw.from_type == TclType::String);
@@ -617,13 +669,7 @@ mod tests {
         ] {
             let cu = CompilationUnit::build_for(src, &registry(), false);
             let fu = cu.function("::top").unwrap();
-            let w = find_expr_shimmers(
-                &fu.cfg,
-                &fu.ssa,
-                &fu.types,
-                &fu.sccp.executable_blocks,
-                &fu.sccp.values,
-            );
+            let w = expr_shimmers(fu, &registry());
             assert!(
                 !w.iter()
                     .any(|sw| sw.variable == "s" || sw.variable == "lst"),
@@ -644,13 +690,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let warning = w.iter().find(|sw| sw.variable == "s");
         let warning = warning.expect("string operand of && must be flagged");
         assert_eq!(warning.to_type, TclType::Boolean);
@@ -676,13 +716,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let warning = w
             .iter()
             .find(|sw| sw.variable == "hay")
@@ -697,13 +731,7 @@ mod tests {
             false,
         );
         let fu_pure = cu_pure.function("::top").unwrap();
-        let w_pure = find_expr_shimmers(
-            &fu_pure.cfg,
-            &fu_pure.ssa,
-            &fu_pure.types,
-            &fu_pure.sccp.executable_blocks,
-            &fu_pure.sccp.values,
-        );
+        let w_pure = expr_shimmers(fu_pure, &registry());
         assert!(
             !w_pure.iter().any(|sw| sw.variable == "hay"),
             "pure string haystack must not be flagged: {w_pure:?}"
@@ -716,13 +744,7 @@ mod tests {
             false,
         );
         let fu2 = cu2.function("::top").unwrap();
-        let w2 = find_expr_shimmers(
-            &fu2.cfg,
-            &fu2.ssa,
-            &fu2.types,
-            &fu2.sccp.executable_blocks,
-            &fu2.sccp.values,
-        );
+        let w2 = expr_shimmers(fu2, &registry());
         assert!(
             !w2.iter().any(|sw| sw.variable == "hay"),
             "list haystack must not be flagged: {w2:?}"
@@ -735,13 +757,7 @@ mod tests {
             false,
         );
         let fu3 = cu3.function("::top").unwrap();
-        let w3 = find_expr_shimmers(
-            &fu3.cfg,
-            &fu3.ssa,
-            &fu3.types,
-            &fu3.sccp.executable_blocks,
-            &fu3.sccp.values,
-        );
+        let w3 = expr_shimmers(fu3, &registry());
         assert!(
             !w3.iter().any(|sw| sw.variable == "needle"),
             "the needle of `in` must not be flagged: {w3:?}"
@@ -754,13 +770,7 @@ mod tests {
         let cu =
             CompilationUnit::build_for("set x 42\nset z [expr {$x eq \"42\"}]", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "x" && sw.from_type == TclType::Int);
@@ -780,13 +790,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "x" && sw.from_type == TclType::Int);
@@ -806,13 +810,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let xs: Vec<_> = w.iter().filter(|sw| sw.variable == "x").collect();
         assert_eq!(
             xs.len(),
@@ -831,13 +829,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let s = w.iter().find(|sw| sw.variable == "x");
         assert!(s.is_some(), "expected expr shimmer for x in loop: {w:?}");
         let s = s.unwrap();
@@ -858,13 +850,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         // x is String; used with eq (string comparison) — no shimmer.
         let str_cmp_shimmers: Vec<_> = w
             .iter()
@@ -887,13 +873,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let has_shimmer = w
             .iter()
             .any(|sw| sw.variable == "b" && sw.from_type == TclType::ByteArray);
@@ -910,13 +890,7 @@ mod tests {
         let src = "set x \"hello\"\nset y [expr {$x + 1}]";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let s = w
             .iter()
             .find(|sw| sw.variable == "x")
@@ -937,13 +911,7 @@ mod tests {
         let src = "set x 42\nif {$x eq \"42\"} { set y 1 }";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let s = w
             .iter()
             .find(|sw| sw.variable == "x")
@@ -964,13 +932,7 @@ mod tests {
         let src = "proc f {} {\n  set x \"hello\"\n  set y [expr {$x * 2}]\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let s = w
             .iter()
             .find(|sw| sw.variable == "x")
@@ -994,13 +956,7 @@ mod tests {
         let src = "set x 42\nif \"$x eq 42\" { set y 1 }";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         // The quoted form substitutes before parsing, so the shimmer may or
         // may not fire; when it does, the span must contain the whole
         // fallback range and be non-degenerate.
@@ -1025,13 +981,7 @@ mod tests {
         let src = "set x \"hi\"\nset y [expr {$x + $x}]";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let xs: Vec<_> = w.iter().filter(|sw| sw.variable == "x").collect();
         assert_eq!(xs.len(), 1, "one warning per statement+var: {xs:?}");
         let first = src.find("{$x").unwrap() + 1;
@@ -1057,13 +1007,7 @@ mod tests {
         let src = "set x 10\nset y 2\nset z [expr {$x lt $y}]";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let w = find_expr_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &fu.sccp.values,
-        );
+        let w = expr_shimmers(fu, &registry());
         let s = w
             .iter()
             .find(|sw| sw.variable == "x" || sw.variable == "y")

--- a/rust/tcl-compiler/src/shimmer/expr.rs
+++ b/rust/tcl-compiler/src/shimmer/expr.rs
@@ -42,7 +42,6 @@ use crate::analyses::LatticeValue;
 use crate::cfg::{BlockId, Function as CfgFunction, Terminator};
 use crate::expr_ast::{BinOp, ExprNode};
 use crate::ir::Statement;
-use crate::naming::normalise_var_name;
 use crate::sccp::cfg_order;
 use crate::ssa::{SsaFunction, Symbol, ValueKey};
 use crate::types::{TypeKind, TypeLattice};
@@ -334,10 +333,10 @@ fn check_numeric_operand(
     op: BinOp,
     context: NumericContext,
 ) {
-    let ExprNode::Var { name, .. } = node else {
+    let ExprNode::Var { text, .. } = node else {
         return;
     };
-    let base = normalise_var_name(name);
+    let base = crate::naming::element_var_name(text);
     let Some(sym) = ctx.ssa.var_symbol(base) else {
         return;
     };
@@ -423,10 +422,10 @@ fn check_numeric_operand(
 /// then parse, which is the same replacement, but a single number is a
 /// one-element list conversion so cheap it is not worth a warning.
 fn check_list_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp) {
-    let ExprNode::Var { name, .. } = node else {
+    let ExprNode::Var { text, .. } = node else {
         return;
     };
-    let base = normalise_var_name(name);
+    let base = crate::naming::element_var_name(text);
     let Some(sym) = ctx.ssa.var_symbol(base) else {
         return;
     };
@@ -502,10 +501,10 @@ fn check_list_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp) 
 /// rewrite to the numeric-equivalent operator is generally safe — see the
 /// `BinOp::StrEq | …` match arm's doc comment in [`collect_expr_shimmers`].
 fn check_string_operand(ctx: &mut ExprShimmerCtx<'_>, node: &ExprNode, op: BinOp) {
-    let ExprNode::Var { name, .. } = node else {
+    let ExprNode::Var { text, .. } = node else {
         return;
     };
-    let base = normalise_var_name(name);
+    let base = crate::naming::element_var_name(text);
     let Some(sym) = ctx.ssa.var_symbol(base) else {
         return;
     };

--- a/rust/tcl-compiler/src/shimmer/hints.rs
+++ b/rust/tcl-compiler/src/shimmer/hints.rs
@@ -22,8 +22,18 @@
 //!   when that position has `shimmers = true` in the registry.
 //! - [`is_numeric_compatible`] — true when two types are interchangeable
 //!   in Tcl's arithmetic/boolean contexts.
+//! - [`is_uncommitted_first_conversion`] — true when reading a value as a
+//!   different type is the *first* conversion of an uncommitted (pure) value,
+//!   which Tcl performs for free rather than a genuine shimmer.
+
+use std::borrow::Cow;
 
 use tcl_registry::{CommandRegistry, TclType};
+use tcl_syntax::boolean::parse_boolean_word;
+use tcl_syntax::list::split_list;
+use tcl_syntax::number::{self, ParseFlags};
+
+use crate::analyses::{ConstValue, LatticeValue};
 
 /// Return the expected `TclType` for argument `arg_index` of `command`
 /// when that argument position is tagged `shimmers = true` in the registry.
@@ -179,6 +189,153 @@ pub fn is_numeric_compatible(current: TclType, expected: TclType) -> bool {
     matches!(
         (current, expected),
         (Int | Numeric, Boolean) | (Boolean | Numeric, Int) | (Int | Boolean, Numeric)
+    )
+}
+
+/// Whether reading a value of committed intrep `current` at a position that
+/// expects `expected` is a **free first conversion of an uncommitted value**,
+/// not a genuine shimmer.
+///
+/// The Tcl object model — oracle-verified and set out in
+/// [`docs/design/contracts/shimmer-reference-behaviour.md`](../../../../docs/design/contracts/shimmer-reference-behaviour.md)
+/// ("When shimmering does NOT occur → Pure string objects (`typePtr == NULL`) —
+/// first type assignment is not a shimmer") — is that a value whose intrep is
+/// not yet committed pays nothing the *first* time it is read as another type it
+/// is a valid instance of. A bare literal (`set l {a b c}`), an interpolated
+/// string, and any string-producing command (`string trim`, `format`, `join`)
+/// all yield such a pure value: `foreach $l` / `lindex $l 0` merely parses it
+/// into a list intrep once, losslessly. Only a **committed** container / object
+/// / byte-array intrep — produced by `[list]`, `[dict create]`, an object
+/// factory, or `binary format` — genuinely re-represents when read as another
+/// type, which is the real shimmer this analysis exists to flag.
+///
+/// `current` classifies committed-ness generically, never by command name:
+/// - [`TclType::String`] is documented "pure string, no cached intrep" — always
+///   uncommitted.
+/// - A numeric `current` ([`TclType::Int`] / [`TclType::Double`] /
+///   [`TclType::Boolean`] / [`TclType::Numeric`]) is uncommitted only when the
+///   value is a compile-time constant — a constant-folded literal push, still
+///   `typePtr == NULL`. A *runtime* `expr` / `incr` result is a committed
+///   numeric intrep whose reconversion is a genuine shimmer.
+/// - [`TclType::List`] / [`TclType::Dict`] / [`TclType::ByteArray`] /
+///   [`TclType::Object`] / [`TclType::Channel`] are always committed.
+///
+/// `const_value` is the SCCP constant for the value at this use, when known; its
+/// string form(s) drive the "valid instance of `expected`" test. A [`ConstSet`]
+/// (a merge of several literals, e.g. a phi of two `set` arms) is still a set of
+/// pure literals, so it is uncommitted and free precisely when **every** member
+/// is a valid instance. A pure value that is *not* a valid instance (e.g. `set s
+/// hello; expr {$s + 1}`, or a bad-syntax list) is **not** suppressed — its
+/// conversion would fail at runtime, which the mismatch warning is right to
+/// surface.
+///
+/// [`ConstSet`]: LatticeValue::ConstSet
+#[must_use]
+pub fn is_uncommitted_first_conversion(
+    current: TclType,
+    expected: TclType,
+    const_value: Option<&LatticeValue>,
+) -> bool {
+    is_pure_intrep(current, const_value) && is_valid_instance_of(expected, const_value)
+}
+
+/// Whether a value of lattice type `current` (with SCCP constant `const_value`,
+/// if any) has an **uncommitted** intrep — a pure string with no cached typed
+/// representation (`typePtr == NULL`).
+///
+/// `String` is always uncommitted (documented "pure string, no cached intrep").
+/// A numeric type is uncommitted only when the value is a compile-time constant
+/// (a constant-folded literal push); a runtime `expr` / `incr` result is a
+/// committed numeric intrep. `List` / `Dict` / `Object` / `ByteArray` /
+/// `Channel` are always committed. See [`is_uncommitted_first_conversion`] for
+/// the full contract.
+#[must_use]
+pub fn is_pure_intrep(current: TclType, const_value: Option<&LatticeValue>) -> bool {
+    match current {
+        TclType::String => true,
+        TclType::Int | TclType::Double | TclType::Boolean | TclType::Numeric => {
+            const_value.and_then(const_string_forms).is_some()
+        }
+        TclType::List | TclType::Dict | TclType::ByteArray | TclType::Object | TclType::Channel => {
+            false
+        }
+    }
+}
+
+/// Whether a pure value with SCCP constant `const_value` is a **valid instance**
+/// of `expected` — its first conversion would succeed and cost nothing. A
+/// constant (or constant set) must have *every* member be a valid instance; a
+/// non-constant value is presumed valid only for the permissive [`TclType::List`]
+/// (any string is a list) and keeps its warning for the stricter targets.
+#[must_use]
+pub fn is_valid_instance_of(expected: TclType, const_value: Option<&LatticeValue>) -> bool {
+    match const_value.and_then(const_string_forms) {
+        Some(forms) => forms
+            .iter()
+            .all(|s| string_is_valid_instance(Some(s), expected)),
+        None => string_is_valid_instance(None, expected),
+    }
+}
+
+/// The canonical Tcl string form(s) of an SCCP constant value, or `None` when it
+/// is not known at compile time (unknown / top). A single [`Const`] yields one
+/// form; a [`ConstSet`] — a small set of possible literals from a merge — yields
+/// each, so a caller can require *all* of them to satisfy a predicate.
+///
+/// [`Const`]: LatticeValue::Const
+/// [`ConstSet`]: LatticeValue::ConstSet
+fn const_string_forms(value: &LatticeValue) -> Option<Vec<Cow<'_, str>>> {
+    match value {
+        LatticeValue::Const(c) => Some(vec![const_value_string(c)]),
+        LatticeValue::ConstSet(cs) => Some(cs.iter().map(const_value_string).collect()),
+        LatticeValue::Unknown | LatticeValue::Overdefined => None,
+    }
+}
+
+/// The canonical Tcl string form of one SCCP constant.
+fn const_value_string(value: &ConstValue) -> Cow<'_, str> {
+    match value {
+        ConstValue::String(s) => Cow::Borrowed(s),
+        ConstValue::Int(i) => Cow::Owned(i.to_string()),
+        ConstValue::Bool(b) => Cow::Borrowed(if *b { "1" } else { "0" }),
+        ConstValue::Float(f) => Cow::Owned(number::format_double(*f)),
+    }
+}
+
+/// Whether the pure-string form `s` (`None` ⇒ the value is not a compile-time
+/// constant) is a valid instance of `expected`, so its first conversion would
+/// succeed and cost nothing.
+///
+/// A [`TclType::List`] accepts virtually any string, so a non-constant pure
+/// value is presumed a valid (free) list promotion; the stricter targets — a
+/// [`TclType::Dict`]'s even length and the numeric tower — need the constant to
+/// prove validity, and a value that cannot be proven valid keeps its warning.
+fn string_is_valid_instance(s: Option<&str>, expected: TclType) -> bool {
+    match expected {
+        TclType::List => s.is_none_or(|s| split_list(s).is_ok()),
+        TclType::Dict => s.is_some_and(|s| split_list(s).is_ok_and(|els| els.len() % 2 == 0)),
+        TclType::Int => s.is_some_and(is_valid_integer),
+        TclType::Double | TclType::Numeric => s.is_some_and(|s| number::parse_whole(s).is_some()),
+        TclType::Boolean => {
+            s.is_some_and(|s| parse_boolean_word(s).is_some() || number::parse_whole(s).is_some())
+        }
+        TclType::String | TclType::ByteArray | TclType::Object | TclType::Channel => false,
+    }
+}
+
+/// Whether `s` is a whole Tcl integer literal (`Tcl_GetWideIntFromObj` /
+/// `TCL_PARSE_INTEGER_ONLY`): decimal, `0x`/`0o`/`0b`/`0d` radix, or a bignum —
+/// but not a fractional/exponent form, which `incr`/index positions reject.
+fn is_valid_integer(s: &str) -> bool {
+    matches!(
+        number::parse_whole_with(
+            s,
+            ParseFlags {
+                integer_only: true,
+                ..ParseFlags::default()
+            },
+        ),
+        Some(number::Number::Int(_) | number::Number::Big { .. })
     )
 }
 
@@ -449,5 +606,166 @@ mod tests {
         assert!(!is_numeric_compatible(TclType::String, TclType::Int));
         assert!(!is_numeric_compatible(TclType::List, TclType::Int));
         assert!(!is_numeric_compatible(TclType::String, TclType::List));
+    }
+
+    fn s(text: &str) -> LatticeValue {
+        LatticeValue::Const(ConstValue::String(text.to_owned()))
+    }
+
+    // --- is_uncommitted_first_conversion: TN (suppress — free first conversion)
+
+    /// TN (issue #940): a pure string literal that is a well-formed list is a
+    /// free first conversion — every list-shaped constant is suppressed.
+    #[test]
+    fn uncommitted_pure_string_valid_list_is_free() {
+        for lit in ["10.0 12.0 16.0 24.0", "hello", "", "a b c", "1"] {
+            assert!(
+                is_uncommitted_first_conversion(TclType::String, TclType::List, Some(&s(lit))),
+                "pure string {lit:?} used as a list must be a free conversion"
+            );
+        }
+    }
+
+    /// TN: an even-length list constant is a valid dict — free.
+    #[test]
+    fn uncommitted_pure_string_valid_dict_is_free() {
+        assert!(is_uncommitted_first_conversion(
+            TclType::String,
+            TclType::Dict,
+            Some(&s("a 1 b 2"))
+        ));
+    }
+
+    /// TN: a constant-folded numeric literal (`set x 5`) is a pure string, so
+    /// using it as a list is free — the define-time numeric shape is irrelevant.
+    #[test]
+    fn uncommitted_const_int_used_as_list_is_free() {
+        let v = LatticeValue::Const(ConstValue::Int(5));
+        assert!(is_uncommitted_first_conversion(
+            TclType::Int,
+            TclType::List,
+            Some(&v)
+        ));
+    }
+
+    /// TN: a non-constant pure string (interpolation / string command) is
+    /// presumed a valid list — lists accept virtually any string.
+    #[test]
+    fn uncommitted_nonconst_string_as_list_is_free() {
+        assert!(is_uncommitted_first_conversion(
+            TclType::String,
+            TclType::List,
+            None
+        ));
+    }
+
+    /// TN: every member of a `ConstSet` (a phi of literals) is a valid list, so
+    /// the merge is still a free promotion.
+    #[test]
+    fn uncommitted_constset_all_valid_lists_is_free() {
+        let v = LatticeValue::ConstSet(vec![ConstValue::Int(1), ConstValue::String("a b".into())]);
+        assert!(is_uncommitted_first_conversion(
+            TclType::Int,
+            TclType::List,
+            Some(&v)
+        ));
+    }
+
+    // --- is_uncommitted_first_conversion: TP (fire — genuine shimmer / error)
+
+    /// TP: a committed container intrep (`current == List`/`Dict`/`ByteArray`)
+    /// genuinely re-represents — never a free conversion.
+    #[test]
+    fn committed_container_is_not_free() {
+        for current in [TclType::List, TclType::Dict, TclType::ByteArray] {
+            assert!(
+                !is_uncommitted_first_conversion(current, TclType::String, Some(&s("1 2 3"))),
+                "committed {current:?} must not be treated as a free conversion"
+            );
+        }
+    }
+
+    /// TP: a pure string that is NOT a valid instance keeps its warning — `set s
+    /// hello; expr {$s + 1}` and `incr` on a non-integer both fail at runtime.
+    #[test]
+    fn pure_string_invalid_instance_is_not_free() {
+        assert!(!is_uncommitted_first_conversion(
+            TclType::String,
+            TclType::Int,
+            Some(&s("hello"))
+        ));
+        assert!(!is_uncommitted_first_conversion(
+            TclType::String,
+            TclType::Numeric,
+            Some(&s("hello"))
+        ));
+        // An odd-length list is not a valid dict.
+        assert!(!is_uncommitted_first_conversion(
+            TclType::String,
+            TclType::Dict,
+            Some(&s("a 1 b"))
+        ));
+    }
+
+    /// TP: a *runtime* numeric intrep (non-constant `expr`/`incr` result) is
+    /// committed — its list conversion is a genuine shimmer.
+    #[test]
+    fn runtime_numeric_used_as_list_is_not_free() {
+        assert!(!is_uncommitted_first_conversion(
+            TclType::Int,
+            TclType::List,
+            None
+        ));
+        assert!(!is_uncommitted_first_conversion(
+            TclType::Numeric,
+            TclType::List,
+            Some(&LatticeValue::Overdefined)
+        ));
+    }
+
+    /// TP: a malformed-list constant (unmatched brace) is not a valid list.
+    #[test]
+    fn malformed_list_constant_is_not_free() {
+        assert!(!is_uncommitted_first_conversion(
+            TclType::String,
+            TclType::List,
+            Some(&s("oops {unbalanced"))
+        ));
+    }
+
+    /// FN guard: a `ConstSet` where *one* member is not a valid instance must
+    /// fire — the merge is only free when every path is valid.
+    #[test]
+    fn constset_one_invalid_member_is_not_free() {
+        let v = LatticeValue::ConstSet(vec![
+            ConstValue::String("a 1 b 2".into()),
+            ConstValue::String("bad {".into()),
+        ]);
+        assert!(!is_uncommitted_first_conversion(
+            TclType::String,
+            TclType::List,
+            Some(&v)
+        ));
+    }
+
+    #[test]
+    fn is_valid_integer_matches_tcl_forms() {
+        for ok in [
+            "5",
+            "-5",
+            "0x1f",
+            "0o17",
+            "0b101",
+            "1_000",
+            "999999999999999999999",
+        ] {
+            assert!(is_valid_integer(ok), "{ok:?} should be a valid integer");
+        }
+        for bad in ["5.0", "hello", "", "1 2", "0x"] {
+            assert!(
+                !is_valid_integer(bad),
+                "{bad:?} should not be a valid integer"
+            );
+        }
     }
 }

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -159,7 +159,13 @@ pub(crate) fn find_shimmer_warnings(
         values,
     ));
     out.extend(phi::find_phi_shimmers(cfg, ssa, types, executable_blocks));
-    out.extend(expr::find_expr_shimmers(cfg, ssa, types, executable_blocks));
+    out.extend(expr::find_expr_shimmers(
+        cfg,
+        ssa,
+        types,
+        executable_blocks,
+        values,
+    ));
     out
 }
 

--- a/rust/tcl-compiler/src/shimmer/mod.rs
+++ b/rust/tcl-compiler/src/shimmer/mod.rs
@@ -35,6 +35,7 @@
 //! | [`byte_array`]| S110 byte-array-corruption detection            |
 
 pub mod byte_array;
+pub mod commit;
 pub mod expr;
 pub mod graph;
 pub mod hints;
@@ -130,6 +131,44 @@ pub fn type_name(t: TclType) -> String {
     format!("{t:?}").to_ascii_lowercase()
 }
 
+/// Resolve the `from` side of a warning against the committed-intrep state:
+/// the single committed rep when every path agrees, a *path-dependent* label
+/// naming the possibilities when different paths committed different reps,
+/// the steady-state may-rep of a loop-carried value, or the lattice fallback.
+/// Returns the struct-level `from_type` plus the message label (they differ
+/// only in the path-dependent case, where no single `TclType` is truthful).
+///
+/// A candidate equal to `expected` never names the from side — a loop header
+/// re-joins its own conversion via the back edge (`dict for`'s list argument
+/// is already a dict on iterations 2+), and that same-type path is exactly
+/// the one *not* paying; the reported conversion is from the other state.
+#[must_use]
+pub(crate) fn committed_from_label(
+    state: &commit::CommitState,
+    fallback: TclType,
+    expected: TclType,
+) -> (TclType, String) {
+    if let Some(t) = state.single_committed()
+        && t != expected
+    {
+        return (t, type_name(t));
+    }
+    let may: Vec<TclType> = state
+        .may_types()
+        .iter()
+        .copied()
+        .filter(|&t| t != expected)
+        .collect();
+    if may.len() >= 2 {
+        let names: Vec<String> = may.iter().map(|&t| type_name(t)).collect();
+        return (fallback, format!("path-dependent ({})", names.join(" or ")));
+    }
+    if let [t] = may[..] {
+        return (t, type_name(t));
+    }
+    (fallback, type_name(fallback))
+}
+
 /// Find intrep-shimmer warnings for a single function.
 ///
 /// Runs three sub-passes in order:
@@ -148,7 +187,20 @@ pub(crate) fn find_shimmer_warnings(
     executable_blocks: &HashSet<BlockId>,
     registry: &CommandRegistry,
     values: &HashMap<ValueKey, crate::analyses::LatticeValue>,
+    executable_edges: &HashSet<(BlockId, BlockId)>,
 ) -> Vec<ShimmerWarning> {
+    // The committed-intrep dataflow (first-use commit) is shared by the
+    // use-site and expr detectors: it tells each use whether the value has
+    // already committed a different intrep on every path (a genuine second
+    // conversion) or is still pure (a free first conversion).
+    let commit_ctx = commit::CommitCtx {
+        registry,
+        ssa,
+        types,
+        values,
+    };
+    let commit_facts =
+        commit::compute_commit_facts(cfg, &commit_ctx, executable_blocks, executable_edges);
     let mut out = Vec::new();
     out.extend(use_site::find_use_site_shimmers(
         cfg,
@@ -157,6 +209,7 @@ pub(crate) fn find_shimmer_warnings(
         executable_blocks,
         registry,
         values,
+        &commit_facts,
     ));
     out.extend(phi::find_phi_shimmers(cfg, ssa, types, executable_blocks));
     out.extend(expr::find_expr_shimmers(
@@ -165,6 +218,8 @@ pub(crate) fn find_shimmer_warnings(
         types,
         executable_blocks,
         values,
+        registry,
+        &commit_facts,
     ));
     out
 }
@@ -190,7 +245,57 @@ pub fn find_shimmer_warnings_for_cu(
             &fu.sccp.executable_blocks,
             registry,
             &fu.sccp.values,
+            &fu.sccp.executable_edges,
         ));
+    }
+    out
+}
+
+/// The "first used as" intrep pushback for every function unit: variables
+/// whose def is **pure** (a literal / interpolation / string-command result)
+/// and whose every executable typed read committed the **same** intrep map to
+/// that intrep, keyed by function name then variable name (all versions must
+/// agree).  Consumed by hover to surface e.g. "pure string — first used as:
+/// list" at the creation site.
+#[must_use]
+pub fn first_use_commitments_for_cu(
+    cu: &crate::compilation_unit::CompilationUnit,
+    registry: &CommandRegistry,
+) -> HashMap<String, HashMap<String, TclType>> {
+    let mut out: HashMap<String, HashMap<String, TclType>> = HashMap::new();
+    for fu in cu.analysable_functions() {
+        let ctx = commit::CommitCtx {
+            registry,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            values: &fu.sccp.values,
+        };
+        let facts = commit::compute_commit_facts(
+            &fu.cfg,
+            &ctx,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.executable_edges,
+        );
+        // Collapse (sym, ver) → name: every version with a pushback must agree
+        // on the same intrep, else the name is dropped (conflicting uses).
+        let mut per_name: HashMap<String, Option<TclType>> = HashMap::new();
+        for ((sym, _ver), t) in facts.single_commitments(&ctx) {
+            per_name
+                .entry(fu.ssa.var_name(sym).to_owned())
+                .and_modify(|slot| {
+                    if *slot != Some(t) {
+                        *slot = None;
+                    }
+                })
+                .or_insert(Some(t));
+        }
+        let agreed: HashMap<String, TclType> = per_name
+            .into_iter()
+            .filter_map(|(name, t)| t.map(|t| (name, t)))
+            .collect();
+        if !agreed.is_empty() {
+            out.insert(fu.name.clone(), agreed);
+        }
     }
     out
 }
@@ -368,6 +473,7 @@ mod tests {
                 &sccp.executable_blocks,
                 &registry(),
                 &sccp.values,
+                &sccp.executable_edges,
             )
             .is_empty()
         );

--- a/rust/tcl-compiler/src/shimmer/phi.rs
+++ b/rust/tcl-compiler/src/shimmer/phi.rs
@@ -37,7 +37,7 @@ use tcl_registry::TclType;
 use crate::cfg::{BlockId, Function as CfgFunction};
 use crate::sccp::cfg_order;
 use crate::ssa::{Phi, SsaFunction, Symbol, ValueKey, Version};
-use crate::types::{TypeKind, TypeLattice};
+use crate::types::{TypeKind, TypeLattice, TypeShape};
 
 use super::graph::loop_body_blocks;
 use super::span::{def_range_map, phi_span};
@@ -69,6 +69,48 @@ struct PhiCtx<'a> {
     array_syms: &'a HashSet<Symbol>,
 }
 
+/// The per-predecessor type evidence of one phi's incomings, split by
+/// loop-body vs entry edges (empty-literal versions excluded).
+#[derive(Default)]
+struct IncomingTypes {
+    entry_types: HashSet<TclType>,
+    body_types: HashSet<TclType>,
+    nonempty_known: HashSet<TclType>,
+    has_shimmered_incoming: bool,
+}
+
+/// Classify each incoming version of `phi` as entry / loop-body evidence —
+/// the shared preamble of the merge-shimmer verdict.
+fn classify_incoming_types(ctx: &PhiCtx<'_>, phi: &Phi) -> IncomingTypes {
+    let empty_vers = ctx.empty_by_name.get(&phi.name);
+    let mut out = IncomingTypes::default();
+    for (pred, &inc_ver) in &phi.incoming {
+        if inc_ver == 0 {
+            continue;
+        }
+        let Some(inc_type) = ctx.types.get(&(phi.name, inc_ver)) else {
+            continue;
+        };
+        if inc_type.kind() == TypeKind::Unknown {
+            continue;
+        }
+        let is_empty = empty_vers.is_some_and(|s| s.contains(&inc_ver));
+        if inc_type.kind() == TypeKind::Known && !is_empty {
+            if let Some(t) = inc_type.tcl_type() {
+                if ctx.loop_blocks.contains(ctx.cfg.block_name(*pred)) {
+                    out.body_types.insert(t);
+                } else {
+                    out.entry_types.insert(t);
+                }
+                out.nonempty_known.insert(t);
+            }
+        } else if inc_type.kind() == TypeKind::Shimmered {
+            out.has_shimmered_incoming = true;
+        }
+    }
+    out
+}
+
 /// Decide whether one phi node is a genuine merge-point shimmer, returning
 /// the warning when it is (the per-phi body of [`find_phi_shimmers`]).
 fn classify_phi_shimmer(ctx: &PhiCtx<'_>, phi: &Phi, in_loop: bool) -> Option<ShimmerWarning> {
@@ -79,46 +121,31 @@ fn classify_phi_shimmer(ctx: &PhiCtx<'_>, phi: &Phi, in_loop: bool) -> Option<Sh
         return None;
     }
     let lattice = ctx.types.get(&(phi.name, phi.version))?;
-    if lattice.kind != TypeKind::Shimmered {
+    if lattice.kind() != TypeKind::Shimmered {
         return None;
     }
-    let from = lattice.from_type?;
-    let to = lattice.tcl_type?;
+    // Every coarse type the union tracks, in canonical order. Two members is
+    // the classic pair; three or more (previously collapsed to OVERDEFINED
+    // and silently missed) now report every merging type.
+    let members: Vec<TclType> = {
+        let mut coarse: Vec<TclType> = lattice.shapes().iter().map(TypeShape::coarse).collect();
+        coarse.dedup();
+        coarse
+    };
+    let (&from, &to) = (members.first()?, members.last()?);
 
     // Refine the SHIMMERED-phi verdict.
     // A loop-header phi is SHIMMERED on any entry-vs-body type change,
     // but the empty-accumulator promotion (`set r {}`; `lappend r …`)
     // and a branch merge whose only shimmer comes from an empty literal
     // are not real per-use intrep conversions.
-    let empty_vers = ctx.empty_by_name.get(&phi.name);
-    let mut entry_types: HashSet<TclType> = HashSet::new();
-    let mut body_types: HashSet<TclType> = HashSet::new();
-    let mut nonempty_known: HashSet<TclType> = HashSet::new();
-    let mut has_shimmered_incoming = false;
-    for (pred, &inc_ver) in &phi.incoming {
-        if inc_ver == 0 {
-            continue;
-        }
-        let Some(inc_type) = ctx.types.get(&(phi.name, inc_ver)) else {
-            continue;
-        };
-        if inc_type.kind == TypeKind::Unknown {
-            continue;
-        }
-        let is_empty = empty_vers.is_some_and(|s| s.contains(&inc_ver));
-        if inc_type.kind == TypeKind::Known && !is_empty {
-            if let Some(t) = inc_type.tcl_type {
-                if ctx.loop_blocks.contains(ctx.cfg.block_name(*pred)) {
-                    body_types.insert(t);
-                } else {
-                    entry_types.insert(t);
-                }
-                nonempty_known.insert(t);
-            }
-        } else if inc_type.kind == TypeKind::Shimmered {
-            has_shimmered_incoming = true;
-        }
-    }
+    let incoming = classify_incoming_types(ctx, phi);
+    let IncomingTypes {
+        entry_types,
+        body_types,
+        nonempty_known,
+        has_shimmered_incoming,
+    } = incoming;
     if in_loop {
         let mut all_body = body_types;
         if let Some(pl) = ctx.loop_body_types.get(&phi.name) {
@@ -148,9 +175,10 @@ fn classify_phi_shimmer(ctx: &PhiCtx<'_>, phi: &Phi, in_loop: bool) -> Option<Sh
             def_map: ctx.def_map,
             destructure: ctx.destructure,
         };
-        [to, from]
-            .into_iter()
-            .find_map(|t| per_loop_type_span(&look, ctx.loop_blocks, phi.name, t))
+        members
+            .iter()
+            .rev()
+            .find_map(|&t| per_loop_type_span(&look, ctx.loop_blocks, phi.name, t))
             .unwrap_or_else(|| phi_span(phi, ctx.ssa, ctx.def_map))
     } else {
         phi_span(phi, ctx.ssa, ctx.def_map)
@@ -185,12 +213,23 @@ fn classify_phi_shimmer(ctx: &PhiCtx<'_>, phi: &Phi, in_loop: bool) -> Option<Sh
         in_loop,
         code,
         message: format!(
-            "'{var}' merges {from} and {to} at control-flow join",
-            from = type_name(from),
-            to = type_name(to),
+            "'{var}' merges {list} at control-flow join",
+            list = join_type_names(&members),
         ),
         related,
     })
+}
+
+/// Render merged type names for the phi message: `"a and b"` for the pair,
+/// `"a, b, and c"` for a wider union.
+fn join_type_names(members: &[TclType]) -> String {
+    let names: Vec<String> = members.iter().map(|&t| type_name(t)).collect();
+    match names.as_slice() {
+        [] => String::new(),
+        [one] => one.clone(),
+        [a, b] => format!("{a} and {b}"),
+        [rest @ .., last] => format!("{}, and {last}", rest.join(", ")),
+    }
 }
 
 #[must_use]

--- a/rust/tcl-compiler/src/shimmer/span.rs
+++ b/rust/tcl-compiler/src/shimmer/span.rs
@@ -115,6 +115,7 @@ mod tests {
                 d.insert(sym, ver);
                 d
             },
+            may_defs: std::collections::HashSet::new(),
         };
         let block = SsaBlock {
             name: "entry".to_owned(),

--- a/rust/tcl-compiler/src/shimmer/thunking.rs
+++ b/rust/tcl-compiler/src/shimmer/thunking.rs
@@ -987,6 +987,31 @@ mod tests {
     /// slots, not the same value shimmering back and forth.
     #[test]
     fn no_s102_for_array_element_conflation() {
+        // Independent elements: `arr(a)` holds ints, `arr(b)` strings — with
+        // per-element SSA symbols neither oscillates, so no S102 (the
+        // pre-P5 conflation FP this test has always guarded).
+        let cu = CompilationUnit::build_for(
+            "proc f {} { set arr(a) 0\n while {1} { \
+             set arr(a) [expr {$arr(a) + 1}]\n set arr(b) [string range x 0 end] } }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let w = find_thunking_warnings(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            None::<&HashSet<String>>,
+        );
+        assert!(
+            w.is_empty(),
+            "independent array elements must not merge into an S102 report: {w:?}"
+        );
+        // The SAME element oscillating int ↔ string every iteration is a
+        // genuine per-element re-thunk — per-key symbols now see it (the
+        // pre-P5 conflation exclusion was a forced false negative here).
         let cu = CompilationUnit::build_for(
             "proc f {} { set arr(x) 0\n while {1} { \
              set arr(x) [expr {$arr(x) + 1}]\n set arr(x) [string range $arr(x) 0 end] } }",
@@ -1003,8 +1028,8 @@ mod tests {
             None::<&HashSet<String>>,
         );
         assert!(
-            w.is_empty(),
-            "array-element writes must not be conflated into an S102 report: {w:?}"
+            w.iter().any(|w| w.variable == "arr(x)"),
+            "the same element oscillating every iteration is a real S102: {w:?}"
         );
     }
 

--- a/rust/tcl-compiler/src/shimmer/thunking.rs
+++ b/rust/tcl-compiler/src/shimmer/thunking.rs
@@ -47,7 +47,7 @@ use crate::cfg::{BlockId, Function as CfgFunction};
 use crate::ir::Statement;
 use crate::sccp::cfg_order;
 use crate::ssa::{Phi, SsaFunction, Symbol, ValueKey, Version};
-use crate::types::{TypeKind, TypeLattice};
+use crate::types::{TypeKind, TypeLattice, TypeShape};
 
 use crate::codegen::values::split_array_ref;
 
@@ -191,8 +191,8 @@ pub(super) fn per_loop_body_types(
                     continue;
                 }
                 if let Some(t) = types.get(&(sym, ver))
-                    && t.kind == TypeKind::Known
-                    && let Some(tt) = t.tcl_type
+                    && t.kind() == TypeKind::Known
+                    && let Some(tt) = t.tcl_type()
                 {
                     out.entry(sym).or_default().insert(tt);
                 }
@@ -319,7 +319,7 @@ pub(super) fn per_loop_type_span(
             let matches_target = look
                 .types
                 .get(&(sym, ver))
-                .is_some_and(|t| t.kind == TypeKind::Known && t.tcl_type == Some(target));
+                .is_some_and(|t| t.kind() == TypeKind::Known && t.tcl_type() == Some(target));
             if !matches_target {
                 continue;
             }
@@ -413,7 +413,7 @@ fn classify_thunking_phi(
         return None;
     }
     let lattice = ctx.types.get(&(phi.name, phi.version))?;
-    if lattice.kind != TypeKind::Shimmered {
+    if lattice.kind() != TypeKind::Shimmered {
         // The header lattice only records oscillation that survives to the
         // loop-header phi (entry type ≠ body-exit type).  A body that
         // converts list→string→list *within one iteration* returns to the
@@ -422,8 +422,12 @@ fn classify_thunking_phi(
         // "$acc,"`).  Catch that shape from the body evidence instead.
         return classify_intra_iteration_thunk(ctx, phi, this_loop, per_loop);
     }
-    let type_a = lattice.from_type?;
-    let type_b = lattice.tcl_type?;
+    // The canonical extremes of the union name the oscillation pair; a 3+
+    // member union (now tracked instead of collapsing to OVERDEFINED) still
+    // reports its outermost pair here — the S102 message is a two-type
+    // oscillation claim, and the incoming-type analysis below drives the
+    // actual verdict.
+    let (type_a, type_b) = lattice.shimmer_extremes()?;
 
     // A loop-header phi is SHIMMERED whenever the entry type differs
     // from the body-exit type — but that includes the *one-time*
@@ -458,19 +462,18 @@ fn classify_thunking_phi(
         };
         let is_empty = empty_vers.is_some_and(|s| s.contains(&inc_ver));
         if ctx.loop_blocks.contains(ctx.cfg.block_name(*pred)) {
-            if inc_type.kind == TypeKind::Known && !is_empty {
+            if inc_type.kind() == TypeKind::Known && !is_empty {
                 has_body_incoming = true;
-                if let Some(t) = inc_type.tcl_type {
+                if let Some(t) = inc_type.tcl_type() {
                     body_types.insert(t);
                 }
-            } else if self_referential && inc_type.kind == TypeKind::Shimmered {
+            } else if self_referential && inc_type.kind() == TypeKind::Shimmered {
                 has_body_incoming = true;
-                body_types.extend(inc_type.from_type);
-                body_types.extend(inc_type.tcl_type);
+                body_types.extend(inc_type.shapes().iter().map(TypeShape::coarse));
             }
-        } else if inc_type.kind == TypeKind::Known
+        } else if inc_type.kind() == TypeKind::Known
             && !is_empty
-            && let Some(t) = inc_type.tcl_type
+            && let Some(t) = inc_type.tcl_type()
         {
             entry_types.insert(t);
         }

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -70,6 +70,7 @@ pub(crate) fn find_use_site_shimmers(
     executable_blocks: &HashSet<BlockId>,
     registry: &CommandRegistry,
     values: &HashMap<ValueKey, LatticeValue>,
+    commit_facts: &super::commit::CommitFacts,
 ) -> Vec<ShimmerWarning> {
     let loop_blocks = loop_body_blocks(cfg);
     let def_map = def_range_map(ssa);
@@ -83,6 +84,12 @@ pub(crate) fn find_use_site_shimmers(
     // conflation the S102 pass already guards. Reuse its exclusion so S100 /
     // S101 don't false-positive on independent array elements.
     let array_syms = super::thunking::array_element_symbols(cfg, ssa);
+    let commit_ctx = super::commit::CommitCtx {
+        registry,
+        ssa,
+        types,
+        values,
+    };
     let mut out: Vec<ShimmerWarning> = Vec::new();
 
     for block_id in cfg_order(cfg) {
@@ -98,20 +105,26 @@ pub(crate) fn find_use_site_shimmers(
         // later use to the *same* target in the same block is not a second
         // shimmer.
         let mut already_coerced: HashSet<(String, u32, TclType)> = HashSet::new();
-        let mut ctx = UseSiteCtx {
-            types,
-            registry,
-            def_map: &def_map,
-            values,
-            loop_facts: &loop_facts,
-            ssa,
-            array_syms: &array_syms,
-            in_loop,
-            already_coerced: &mut already_coerced,
-            out: &mut out,
-        };
+        // The committed-intrep walker replays the commit transfer function in
+        // step with this walk, so each statement's checks see the state *just
+        // before* it executes.
+        let mut commit_walker = commit_facts.walker(&commit_ctx, block_id);
         for ss in &ssa_block.statements {
+            let mut ctx = UseSiteCtx {
+                types,
+                registry,
+                def_map: &def_map,
+                values,
+                loop_facts: &loop_facts,
+                ssa,
+                array_syms: &array_syms,
+                commit: &commit_walker,
+                in_loop,
+                already_coerced: &mut already_coerced,
+                out: &mut out,
+            };
             check_statement(&mut ctx, &ss.statement, &ss.uses);
+            commit_walker.step(&ss.statement, &ss.uses);
         }
     }
 
@@ -131,6 +144,10 @@ struct UseSiteCtx<'a> {
     /// Array-base symbols excluded from shimmer reporting (FP-SH-13) — a
     /// conflated `arr(a)`/`arr(b)` symbol can hold either element's intrep.
     array_syms: &'a HashSet<Symbol>,
+    /// The committed-intrep state just before the statement being checked —
+    /// tells a use whether the value already committed a different intrep on
+    /// every path (a genuine second conversion, [`super::commit`]).
+    commit: &'a super::commit::CommitWalker<'a>,
     in_loop: bool,
     already_coerced: &'a mut HashSet<(String, u32, TclType)>,
     out: &'a mut Vec<ShimmerWarning>,
@@ -323,6 +340,40 @@ fn check_invocation(
 /// [`ShimmerWarning`] when the variable's committed type genuinely differs from
 /// what the position requires. Split out of [`check_invocation`]'s argument
 /// loop so each stays a single, readable responsibility.
+/// Resolve an argument word to a tracked variable use with a Known lattice
+/// type: the normalised name, its SSA coordinates, and the current type.
+/// `None` for complex words (which may produce the right type via their own
+/// evaluation), array bases (FP-SH-13 — a conflated version chain), live-in
+/// version 0, and Unknown/Overdefined lattice entries.
+fn resolve_tracked_var_use(
+    ctx: &UseSiteCtx<'_>,
+    word: &str,
+    uses: &HashMap<Symbol, u32>,
+) -> Option<(String, Symbol, u32, TclType)> {
+    let stripped = word.trim();
+    if !is_pure_var_ref(stripped) {
+        return None;
+    }
+    let var = normalise_var_name(stripped).to_owned();
+    let sym = ctx.ssa.var_symbol(&var)?;
+    if ctx.array_syms.contains(&sym) {
+        return None;
+    }
+    let &ver = uses.get(&sym)?;
+    if ver == 0 {
+        return None;
+    }
+    let lattice = ctx
+        .types
+        .get(&(sym, ver))
+        .cloned()
+        .unwrap_or_else(TypeLattice::unknown);
+    if lattice.kind != TypeKind::Known {
+        return None;
+    }
+    lattice.tcl_type.map(|current| (var, sym, ver, current))
+}
+
 fn check_argument(
     ctx: &mut UseSiteCtx<'_>,
     site: &InvocationSite<'_>,
@@ -345,37 +396,39 @@ fn check_argument(
         return;
     };
     let expected = expectation.expected;
-    // Only flag pure variable references — complex words may produce
-    // the right type via their own evaluation.
-    let stripped = word.trim();
-    if !is_pure_var_ref(stripped) {
-        return;
-    }
-    let var = normalise_var_name(stripped).to_owned();
-    let Some(sym) = ctx.ssa.var_symbol(&var) else {
+    let Some((var, sym, ver, current)) = resolve_tracked_var_use(ctx, word, uses) else {
         return;
     };
-    // Skip an array base (FP-SH-13): its conflated version chain mixes
-    // independent elements, so a "wrong intrep" here may just be a
-    // different element's type.
-    if ctx.array_syms.contains(&sym) {
+    // The committed-intrep state just before this statement: when a prior use
+    // (`expr`, `llength`, …) has committed a different intrep on **every**
+    // executable path, this read genuinely re-represents even where the
+    // flow-insensitive lattice sees no mismatch — `set v 5; expr {$v+1};
+    // lindex $v 0` shimmers Numeric → List though the lattice types `v` Int
+    // (pure literal). Resolved before the lattice-equality skip below so the
+    // second conversion is not masked.
+    let commit_state = ctx.commit.state_of(sym, ver);
+    if commit_state.must_pay(expected)
+        && !is_suppressed_committed(&expectation, expected, commit_state.single_committed())
+    {
+        let (from, from_label) = super::committed_from_label(&commit_state, current, expected);
+        emit_use_site_warning(
+            ctx,
+            site,
+            i,
+            &UseWarning {
+                var: &var,
+                sym,
+                ver,
+                from,
+                from_label,
+                expected,
+                related_override: commit_state
+                    .first_span()
+                    .map(|sp| vec![(sp, "intrep first committed here".to_owned())]),
+            },
+        );
         return;
     }
-    let Some(&ver) = uses.get(&sym) else { return };
-    if ver == 0 {
-        return;
-    }
-    let lattice = ctx
-        .types
-        .get(&(sym, ver))
-        .cloned()
-        .unwrap_or_else(TypeLattice::unknown);
-    if lattice.kind != TypeKind::Known {
-        return;
-    }
-    let Some(current) = lattice.tcl_type else {
-        return;
-    };
     if current == expected || is_numeric_compatible(current, expected) {
         return;
     }
@@ -405,28 +458,111 @@ fn check_argument(
     // `expected` when it is a valid instance of it. `set fontSizes {10.0
     // 12.0}; foreach s $fontSizes` (issue #940), `set x 5; lindex $x 0`, and
     // `set d {a 1 b 2}; dict for {k v} $d` are all free promotions of a pure
-    // string, not shimmers — see [`is_uncommitted_first_conversion`]. A
-    // committed container/object intrep, or a pure value that is *not* a
-    // valid instance (`incr` on a non-integer), still fires.
-    if is_uncommitted_first_conversion(current, expected, ctx.values.get(&(sym, ver))) {
+    // string, not shimmers — see [`is_uncommitted_first_conversion`].
+    //
+    // The one exception is a value read as **two or more distinct intreps
+    // inside a loop** (`llength $l` + `dict size $l` each pass): the loop
+    // entry re-joins the pure preheader path every iteration, but at runtime
+    // the converters re-thunk the value on every pass after the first —
+    // oracle-verified list↔dict oscillation — so the free-first-conversion
+    // suppression must not apply (the multi-target `LoopFacts` fact, which
+    // also drives the S101 escalation).
+    let multi_target_in_loop = ctx.in_loop
+        && ctx
+            .loop_facts
+            .use_targets
+            .get(&var)
+            .is_some_and(|targets| targets.len() >= 2);
+    if !multi_target_in_loop
+        && is_uncommitted_first_conversion(current, expected, ctx.values.get(&(sym, ver)))
+    {
         return;
     }
+    // Prefer the steady-state committed rep for the from-type (a loop-carried
+    // value whose entry re-joins the pure preheader still reads as its
+    // back-edge rep on every iteration after the first).
+    let (from, from_label) = super::committed_from_label(&commit_state, current, expected);
+    emit_use_site_warning(
+        ctx,
+        site,
+        i,
+        &UseWarning {
+            var: &var,
+            sym,
+            ver,
+            from,
+            from_label,
+            expected,
+            related_override: None,
+        },
+    );
+}
+
+/// Whether a must-pay committed conversion is still suppressed by the
+/// registry's transparency list or the numeric-current-vs-String rule (a
+/// committed numeric intrep survives a String read — the string rep is
+/// regenerated alongside in O(digits), tclsh-verified).
+fn is_suppressed_committed(
+    expectation: &ShimmerExpectation,
+    expected: TclType,
+    committed: Option<TclType>,
+) -> bool {
+    let Some(committed) = committed else {
+        // A multi-type committed state has no single rep to test transparency
+        // against; the conversion claim stands.
+        return false;
+    };
+    if expectation.is_transparent_from(committed) {
+        return true;
+    }
+    expected == TclType::String
+        && matches!(
+            committed,
+            TclType::Int | TclType::Double | TclType::Numeric | TclType::Boolean
+        )
+}
+
+/// One resolved use-site warning, ready to emit: the variable, its SSA
+/// coordinates, and the conversion being reported. `related_override`
+/// replaces the default "value defined here" related span (the committed
+/// path points at the converting use instead). `from_label` overrides the
+/// message's from-type wording (the path-dependent case, where no single
+/// `TclType` is truthful).
+struct UseWarning<'w> {
+    var: &'w str,
+    sym: Symbol,
+    ver: u32,
+    from: TclType,
+    from_label: String,
+    expected: TclType,
+    related_override: Option<Vec<(Span, String)>>,
+}
+
+/// Emit one use-site shimmer warning, honouring the per-block coercion ledger
+/// and the loop-invariance S101→S100 downgrade.
+fn emit_use_site_warning(
+    ctx: &mut UseSiteCtx<'_>,
+    site: &InvocationSite<'_>,
+    i: usize,
+    warning: &UseWarning<'_>,
+) {
     // A prior use in this block already coerced `(var, ver)` to this
     // intrep — the runtime representation has already changed, so this
     // is not a second shimmer.
-    let coercion_key = (var.clone(), ver, expected);
+    let coercion_key = (warning.var.to_owned(), warning.ver, warning.expected);
     if !ctx.already_coerced.insert(coercion_key) {
         return;
     }
-    let related: Vec<(Span, String)> = ctx
-        .def_map
-        .get(&(sym, ver))
-        .map(|&sp| vec![(sp, "value defined here".to_owned())])
-        .unwrap_or_default();
+    let related = warning.related_override.clone().unwrap_or_else(|| {
+        ctx.def_map
+            .get(&(warning.sym, warning.ver))
+            .map(|&sp| vec![(sp, "value defined here".to_owned())])
+            .unwrap_or_default()
+    });
     // A loop-invariant variable coerced to a single intrep inside the
     // loop converts once and is cached → S100, not the per-iteration
     // S101.
-    let code = if ctx.loop_facts.effective_in_loop(&var, ctx.in_loop) {
+    let code = if ctx.loop_facts.effective_in_loop(warning.var, ctx.in_loop) {
         DiagCode::S101
     } else {
         DiagCode::S100
@@ -434,18 +570,19 @@ fn check_argument(
     let span = site.arg_spans.get(i).copied().unwrap_or(site.fallback_span);
     ctx.out.push(ShimmerWarning {
         span,
-        variable: var.clone(),
-        from_type: current,
-        to_type: expected,
+        variable: warning.var.to_owned(),
+        from_type: warning.from,
+        to_type: warning.expected,
         command: site.command.to_owned(),
         in_loop: ctx.in_loop,
         code,
         message: format!(
             "variable '{var}' has {from} intrep \
              but '{cmd}' expects {to} (argument {n})",
-            from = type_name(current),
+            var = warning.var,
+            from = warning.from_label,
             cmd = site.command,
-            to = type_name(expected),
+            to = type_name(warning.expected),
             n = i + 1,
         ),
         related,
@@ -589,20 +726,36 @@ fn check_incr_var(ctx: &mut UseSiteCtx<'_>, var: &str, span: Span, uses: &HashMa
     let Some(current) = lattice.tcl_type else {
         return;
     };
-    if current == TclType::Int || is_numeric_compatible(current, TclType::Int) {
+    // A prior use that committed a non-numeric intrep on every path makes this
+    // `incr` a genuine second conversion — `set v 5; llength $v; incr v`
+    // commits List at the `llength`, then re-represents List → Int here.
+    let commit_state = ctx.commit.state_of(sym, ver);
+    let must_pay_committed = commit_state.must_pay(TclType::Int);
+    if !must_pay_committed {
+        if current == TclType::Int || is_numeric_compatible(current, TclType::Int) {
+            return;
+        }
+        // A pure value whose string form is a whole integer (`set n 0x80;
+        // incr n`, `set n 5; incr n`) promotes to `Int` for free — no shimmer.
+        // A non-integer pure string (`set n hello; incr n`) is *not* a valid
+        // instance, so it still fires: that conversion fails at runtime.
+        if is_uncommitted_first_conversion(current, TclType::Int, ctx.values.get(&(sym, ver))) {
+            return;
+        }
+    }
+    let (from, from_label) = super::committed_from_label(&commit_state, current, TclType::Int);
+    if from == TclType::Int || is_numeric_compatible(from, TclType::Int) {
         return;
     }
-    // A pure value whose string form is a whole integer (`set n 0x80; incr n`,
-    // `set n 5; incr n`) promotes to `Int` for free — no shimmer. A non-integer
-    // pure string (`set n hello; incr n`) is *not* a valid instance, so it still
-    // fires: that conversion fails at runtime.
-    if is_uncommitted_first_conversion(current, TclType::Int, ctx.values.get(&(sym, ver))) {
-        return;
-    }
-    let related: Vec<(Span, String)> = ctx
-        .def_map
-        .get(&(sym, ver))
-        .map(|&sp| vec![(sp, "value defined here".to_owned())])
+    let related: Vec<(Span, String)> = commit_state
+        .first_span()
+        .filter(|_| must_pay_committed)
+        .map(|sp| vec![(sp, "intrep first committed here".to_owned())])
+        .or_else(|| {
+            ctx.def_map
+                .get(&(sym, ver))
+                .map(|&sp| vec![(sp, "value defined here".to_owned())])
+        })
         .unwrap_or_default();
     let code = if ctx.in_loop {
         DiagCode::S101
@@ -612,15 +765,12 @@ fn check_incr_var(ctx: &mut UseSiteCtx<'_>, var: &str, span: Span, uses: &HashMa
     ctx.out.push(ShimmerWarning {
         span,
         variable: var.to_owned(),
-        from_type: current,
+        from_type: from,
         to_type: TclType::Int,
         command: "incr".to_owned(),
         in_loop: ctx.in_loop,
         code,
-        message: format!(
-            "variable '{var}' has {from} intrep but 'incr' expects int",
-            from = type_name(current),
-        ),
+        message: format!("variable '{var}' has {from_label} intrep but 'incr' expects int"),
         related,
     });
 }
@@ -635,19 +785,41 @@ mod tests {
         CommandRegistry::build_default()
     }
 
+    /// Compute commit facts + run the use-site detector for one function unit
+    /// — the production wiring `find_shimmer_warnings` performs.
+    fn use_site_shimmers(
+        fu: &crate::compilation_unit::FunctionUnit,
+        registry: &CommandRegistry,
+    ) -> Vec<ShimmerWarning> {
+        let ctx = super::super::commit::CommitCtx {
+            registry,
+            ssa: &fu.ssa,
+            types: &fu.types,
+            values: &fu.sccp.values,
+        };
+        let facts = super::super::commit::compute_commit_facts(
+            &fu.cfg,
+            &ctx,
+            &fu.sccp.executable_blocks,
+            &fu.sccp.executable_edges,
+        );
+        find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            registry,
+            &fu.sccp.values,
+            &facts,
+        )
+    }
+
     /// A String variable passed to `incr` triggers S100.
     #[test]
     fn shimmer_detected_for_string_used_with_incr() {
         let cu = CompilationUnit::build_for("set x \"hello\"\nincr x", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings
             .iter()
             .find(|w| w.command == "incr" && w.from_type == TclType::String);
@@ -664,14 +836,7 @@ mod tests {
     fn no_shimmer_for_hex_literal_string_used_with_incr() {
         let cu = CompilationUnit::build_for("set n 0x80\nincr n", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let incr_shimmers: Vec<_> = warnings.iter().filter(|w| w.command == "incr").collect();
         assert!(
             incr_shimmers.is_empty(),
@@ -684,14 +849,7 @@ mod tests {
     fn no_shimmer_for_int_used_with_incr() {
         let cu = CompilationUnit::build_for("set x 5\nincr x", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let incr_shimmers: Vec<_> = warnings.iter().filter(|w| w.command == "incr").collect();
         assert!(
             incr_shimmers.is_empty(),
@@ -711,14 +869,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings.iter().find(|w| w.command == "lindex");
         assert!(
             w.is_some(),
@@ -743,14 +894,7 @@ mod tests {
         ] {
             let cu = CompilationUnit::build_for(src, &registry(), false);
             let fu = cu.function("::top").unwrap();
-            let warnings = find_use_site_shimmers(
-                &fu.cfg,
-                &fu.ssa,
-                &fu.types,
-                &fu.sccp.executable_blocks,
-                &registry(),
-                &fu.sccp.values,
-            );
+            let warnings = use_site_shimmers(fu, &registry());
             assert!(
                 warnings.is_empty(),
                 "pure literal used as a list must not shimmer for {src:?}: {warnings:?}"
@@ -766,14 +910,7 @@ mod tests {
         let src = "set x [dict create a 1 b 2]\nlindex $x 0";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings
             .iter()
             .find(|w| w.command == "lindex")
@@ -793,14 +930,7 @@ mod tests {
         let src = "set x [dict create a 1 b 2]\nset b [lindex $x 0]";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings
             .iter()
             .find(|w| w.command == "lindex")
@@ -824,14 +954,7 @@ mod tests {
                     linsert $list_var $index_var x";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let list_w = warnings
             .iter()
             .find(|w| w.command == "linsert" && w.variable == "list_var")
@@ -859,14 +982,7 @@ mod tests {
         let src = "proc f {l} {\n    foreach x $l {\n        set b [lindex $x 0]\n    }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         assert!(
             warnings.iter().all(|w| w.command != "lindex"),
             "a pure foreach element read as a list must not shimmer: {warnings:?}"
@@ -883,14 +999,7 @@ mod tests {
         let src = "proc f {l} {\n    foreach x $l {\n        set d [dict create k $x]\n        set n [llength $d]\n    }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings
             .iter()
             .find(|w| w.command == "llength" && w.variable == "d")
@@ -915,14 +1024,7 @@ mod tests {
         let src = "proc f {} {\n    set l [dict create a 1 b 2]\n    foreach x $l { puts $x }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings
             .iter()
             .find(|w| w.command == "foreach" && w.variable == "l")
@@ -937,14 +1039,7 @@ mod tests {
         let src = "proc f {} {\n    set l [list 1 2 3]\n    foreach x $l { puts $x }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         assert!(
             warnings.iter().all(|w| w.command != "foreach"),
             "unexpected foreach header shimmer for a real list: {warnings:?}"
@@ -963,14 +1058,7 @@ mod tests {
             );
             let cu = CompilationUnit::build_for(&src, &registry(), false);
             let fu = cu.function("::f").unwrap();
-            let warnings = find_use_site_shimmers(
-                &fu.cfg,
-                &fu.ssa,
-                &fu.types,
-                &fu.sccp.executable_blocks,
-                &registry(),
-                &fu.sccp.values,
-            );
+            let warnings = use_site_shimmers(fu, &registry());
             assert!(
                 warnings.iter().all(|w| w.variable != "l"),
                 "pure string literal {literal:?} in foreach must not shimmer: {warnings:?}"
@@ -984,14 +1072,7 @@ mod tests {
         let src = "proc f {} {\n    set l [dict create a 1 b 2]\n    lmap x $l { set x $x }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings
             .iter()
             .find(|w| w.command == "lmap" && w.variable == "l")
@@ -1008,14 +1089,7 @@ mod tests {
         let src = "proc f {} {\n    set d hello\n    dict for {k v} $d { puts $k }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings
             .iter()
             .find(|w| w.command == "dict for" && w.variable == "d")
@@ -1030,14 +1104,7 @@ mod tests {
         let src = "proc f {} {\n    set d hello\n    dict map {k v} $d { set v $v }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings
             .iter()
             .find(|w| w.command == "dict map" && w.variable == "d")
@@ -1054,14 +1121,7 @@ mod tests {
         let src = "proc f {} {\n  set data [dict create a 1 b 2]\n  for {set i 0} {$i < 3} {incr i} {\n    set x [lindex $data $i]\n  }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings
             .iter()
             .find(|w| w.command == "lindex" && w.variable == "data");
@@ -1086,14 +1146,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings
             .iter()
             .find(|w| w.command == "incr" && w.variable == "step");
@@ -1118,14 +1171,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         assert!(
             warnings.is_empty(),
             "array-element conflation must not use-site shimmer: {warnings:?}"
@@ -1144,14 +1190,7 @@ mod tests {
         let cu =
             CompilationUnit::build_for("set l [list 1 2 3]\nstring length $l", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         assert!(
             warnings
                 .iter()
@@ -1166,14 +1205,7 @@ mod tests {
             false,
         );
         let fu2 = cu2.function("::top").unwrap();
-        let warnings2 = find_use_site_shimmers(
-            &fu2.cfg,
-            &fu2.ssa,
-            &fu2.types,
-            &fu2.sccp.executable_blocks,
-            &registry(),
-            &fu2.sccp.values,
-        );
+        let warnings2 = use_site_shimmers(fu2, &registry());
         assert!(
             !warnings2.iter().any(|w| w.variable == "ba"),
             "byte-array subject is transparent — no shimmer: {warnings2:?}"
@@ -1185,14 +1217,7 @@ mod tests {
         let cu =
             CompilationUnit::build_for("proc f {} { set n hello\n incr n }", &registry(), false);
         let fu = cu.function("::f").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         assert!(
             warnings
                 .iter()
@@ -1207,14 +1232,7 @@ mod tests {
         // `set x $other` — type of x is Unknown (other has no known type).
         let cu = CompilationUnit::build_for("set x $other\nlindex $x 0", &registry(), false);
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         // x has Unknown type; should not produce a shimmer.
         let lindex_shimmers: Vec<_> = warnings.iter().filter(|w| w.command == "lindex").collect();
         assert!(
@@ -1236,14 +1254,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         let w = warnings.iter().find(|w| w.variable == "x");
         assert!(
             w.is_some(),
@@ -1262,14 +1273,7 @@ mod tests {
     fn warnings_for(src: &str) -> Vec<ShimmerWarning> {
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
-        find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        )
+        use_site_shimmers(fu, &registry())
     }
 
     /// `string first`/`last` convert BOTH the needle and the haystack to the
@@ -1458,14 +1462,7 @@ mod tests {
             false,
         );
         let fu = cu.function("::top").unwrap();
-        let warnings = find_use_site_shimmers(
-            &fu.cfg,
-            &fu.ssa,
-            &fu.types,
-            &fu.sccp.executable_blocks,
-            &registry(),
-            &fu.sccp.values,
-        );
+        let warnings = use_site_shimmers(fu, &registry());
         assert!(
             warnings.iter().all(|w| w.variable != "x"),
             "unexpected shimmer through non-shimmering alias: {warnings:?}"

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -368,10 +368,10 @@ fn resolve_tracked_var_use(
         .get(&(sym, ver))
         .cloned()
         .unwrap_or_else(TypeLattice::unknown);
-    if lattice.kind != TypeKind::Known {
+    if lattice.kind() != TypeKind::Known {
         return None;
     }
-    lattice.tcl_type.map(|current| (var, sym, ver, current))
+    lattice.tcl_type().map(|current| (var, sym, ver, current))
 }
 
 fn check_argument(
@@ -720,10 +720,10 @@ fn check_incr_var(ctx: &mut UseSiteCtx<'_>, var: &str, span: Span, uses: &HashMa
         .get(&(sym, ver))
         .cloned()
         .unwrap_or_else(TypeLattice::unknown);
-    if lattice.kind != TypeKind::Known {
+    if lattice.kind() != TypeKind::Known {
         return;
     }
-    let Some(current) = lattice.tcl_type else {
+    let Some(current) = lattice.tcl_type() else {
         return;
     };
     // A prior use that committed a non-numeric intrep on every path makes this

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -39,7 +39,7 @@ use tcl_core_types::DiagCode;
 use tcl_lexer::Span;
 use tcl_registry::{CommandRegistry, TclType};
 
-use crate::analyses::{ConstValue, LatticeValue};
+use crate::analyses::LatticeValue;
 use crate::cfg::{BlockId, Function as CfgFunction};
 use crate::ir::Statement;
 use crate::naming::normalise_var_name;
@@ -51,6 +51,7 @@ use crate::value_shapes::is_pure_var_ref;
 use super::graph::loop_body_blocks;
 use super::hints::{
     ShimmerExpectation, arg_shimmer_expectation, arg_shimmer_type, is_numeric_compatible,
+    is_uncommitted_first_conversion,
 };
 use super::span::def_range_map;
 use super::{ShimmerWarning, type_name};
@@ -228,31 +229,6 @@ impl LoopFacts {
     }
 }
 
-/// True when `value` is a SCCP CONST string whose text is a hex /
-/// octal / binary integer literal (`0xff`, `0o15`, `0b1010`, optionally
-/// signed). These spellings classify as `String` by `literal_type` (the
-/// canonical stringified intrep differs from the source text) but
-/// promote cleanly to `Int` at the first arithmetic op — not a real
-/// shimmer.
-fn value_is_int_literal_string(value: Option<&LatticeValue>) -> bool {
-    let Some(LatticeValue::Const(ConstValue::String(text))) = value else {
-        return false;
-    };
-    let sign_stripped = text.strip_prefix(['+', '-']).unwrap_or(text);
-    let bytes = sign_stripped.as_bytes();
-    // Need at least a `0x`-style prefix plus one body digit.
-    if bytes.len() < 3 || bytes[0] != b'0' {
-        return false;
-    }
-    let body = &sign_stripped[2..];
-    match bytes[1] {
-        b'x' | b'X' => body.bytes().all(|c| c.is_ascii_hexdigit()),
-        b'o' | b'O' => body.bytes().all(|c| (b'0'..=b'7').contains(&c)),
-        b'b' | b'B' => body.bytes().all(|c| c == b'0' || c == b'1'),
-        _ => false,
-    }
-}
-
 /// Expected intrep for every list/dict argument of a synthetic loop-header
 /// call: the CFG builder lowers `foreach` / `lmap` / `dict for` / `dict map`
 /// to a `Statement::Call` whose `command` is that keyword (or, for the dict
@@ -272,7 +248,10 @@ fn value_is_int_literal_string(value: Option<&LatticeValue>) -> bool {
 /// `dict` subcommand table via [`arg_shimmer_type`]'s existing subcommand
 /// path, requesting sub-index 1 (both subcommands declare their dict
 /// argument there).
-fn foreach_header_expected_type(registry: &CommandRegistry, command: &str) -> Option<TclType> {
+pub(super) fn foreach_header_expected_type(
+    registry: &CommandRegistry,
+    command: &str,
+) -> Option<TclType> {
     if let Some((base, sub)) = command.split_once(' ') {
         // `arg_shimmer_type`'s subcommand path computes `sub_idx =
         // arg_index - 1`; requesting `arg_index = 2` reads sub-index 1.
@@ -334,125 +313,143 @@ fn check_invocation(
     site: &InvocationSite<'_>,
     uses: &HashMap<Symbol, u32>,
 ) {
-    let InvocationSite {
-        command,
-        lookup_command,
-        args,
-        arg_spans,
-        is_foreach_header,
-        fallback_span,
-    } = *site;
-    let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-    for (i, word) in args.iter().enumerate() {
-        let expectation = if is_foreach_header {
-            foreach_header_expected_type(ctx.registry, lookup_command).map(|expected| {
-                ShimmerExpectation {
-                    expected,
-                    transparent_from: &[],
-                }
-            })
-        } else {
-            arg_shimmer_expectation(ctx.registry, lookup_command, &arg_refs, i)
-        };
-        let Some(expectation) = expectation else {
-            continue;
-        };
-        let expected = expectation.expected;
-        // Only flag pure variable references — complex words may produce
-        // the right type via their own evaluation.
-        let stripped = word.trim();
-        if !is_pure_var_ref(stripped) {
-            continue;
-        }
-        let var = normalise_var_name(stripped).to_owned();
-        let Some(sym) = ctx.ssa.var_symbol(&var) else {
-            continue;
-        };
-        // Skip an array base (FP-SH-13): its conflated version chain mixes
-        // independent elements, so a "wrong intrep" here may just be a
-        // different element's type.
-        if ctx.array_syms.contains(&sym) {
-            continue;
-        }
-        let Some(&ver) = uses.get(&sym) else { continue };
-        if ver == 0 {
-            continue;
-        }
-        let lattice = ctx
-            .types
-            .get(&(sym, ver))
-            .cloned()
-            .unwrap_or_else(TypeLattice::unknown);
-        if lattice.kind != TypeKind::Known {
-            continue;
-        }
-        let Some(current) = lattice.tcl_type else {
-            continue;
-        };
-        if current == expected || is_numeric_compatible(current, expected) {
-            continue;
-        }
-        // The registry marks intreps this operation reads directly without
-        // installing `expected` (e.g. `string length`'s pure-byte-array fast
-        // path): those operands keep their rep — no shimmer.
-        if expectation.is_transparent_from(current) {
-            continue;
-        }
-        // A numeric lattice type does not prove a numeric *intrep*: a
-        // literal-defined `set x 42` is a pure string at runtime
-        // (tclsh-verified) with nothing for a String-installing operation to
-        // destroy, and when the numeric rep IS installed its string
-        // regenerates in O(digits). Only container intreps (List/Dict) lose
-        // real structure to a String expectation, so numeric currents stay
-        // silent there.
-        if expected == TclType::String
-            && matches!(
-                current,
-                TclType::Int | TclType::Double | TclType::Numeric | TclType::Boolean
-            )
-        {
-            continue;
-        }
-        // A prior use in this block already coerced `(var, ver)` to this
-        // intrep — the runtime representation has already changed, so this
-        // is not a second shimmer.
-        let coercion_key = (var.clone(), ver, expected);
-        if !ctx.already_coerced.insert(coercion_key) {
-            continue;
-        }
-        let related: Vec<(Span, String)> = ctx
-            .def_map
-            .get(&(sym, ver))
-            .map(|&sp| vec![(sp, "value defined here".to_owned())])
-            .unwrap_or_default();
-        // A loop-invariant variable coerced to a single intrep inside the
-        // loop converts once and is cached → S100, not the per-iteration
-        // S101.
-        let code = if ctx.loop_facts.effective_in_loop(&var, ctx.in_loop) {
-            DiagCode::S101
-        } else {
-            DiagCode::S100
-        };
-        let span = arg_spans.get(i).copied().unwrap_or(fallback_span);
-        ctx.out.push(ShimmerWarning {
-            span,
-            variable: var.clone(),
-            from_type: current,
-            to_type: expected,
-            command: command.to_owned(),
-            in_loop: ctx.in_loop,
-            code,
-            message: format!(
-                "variable '{var}' has {from} intrep \
-                 but '{cmd}' expects {to} (argument {n})",
-                from = type_name(current),
-                cmd = command,
-                to = type_name(expected),
-                n = i + 1,
-            ),
-            related,
-        });
+    let arg_refs: Vec<&str> = site.args.iter().map(String::as_str).collect();
+    for (i, word) in site.args.iter().enumerate() {
+        check_argument(ctx, site, i, word, &arg_refs, uses);
     }
+}
+
+/// Check one argument word of an invocation for an intrep mismatch, emitting a
+/// [`ShimmerWarning`] when the variable's committed type genuinely differs from
+/// what the position requires. Split out of [`check_invocation`]'s argument
+/// loop so each stays a single, readable responsibility.
+fn check_argument(
+    ctx: &mut UseSiteCtx<'_>,
+    site: &InvocationSite<'_>,
+    i: usize,
+    word: &str,
+    arg_refs: &[&str],
+    uses: &HashMap<Symbol, u32>,
+) {
+    let expectation = if site.is_foreach_header {
+        foreach_header_expected_type(ctx.registry, site.lookup_command).map(|expected| {
+            ShimmerExpectation {
+                expected,
+                transparent_from: &[],
+            }
+        })
+    } else {
+        arg_shimmer_expectation(ctx.registry, site.lookup_command, arg_refs, i)
+    };
+    let Some(expectation) = expectation else {
+        return;
+    };
+    let expected = expectation.expected;
+    // Only flag pure variable references — complex words may produce
+    // the right type via their own evaluation.
+    let stripped = word.trim();
+    if !is_pure_var_ref(stripped) {
+        return;
+    }
+    let var = normalise_var_name(stripped).to_owned();
+    let Some(sym) = ctx.ssa.var_symbol(&var) else {
+        return;
+    };
+    // Skip an array base (FP-SH-13): its conflated version chain mixes
+    // independent elements, so a "wrong intrep" here may just be a
+    // different element's type.
+    if ctx.array_syms.contains(&sym) {
+        return;
+    }
+    let Some(&ver) = uses.get(&sym) else { return };
+    if ver == 0 {
+        return;
+    }
+    let lattice = ctx
+        .types
+        .get(&(sym, ver))
+        .cloned()
+        .unwrap_or_else(TypeLattice::unknown);
+    if lattice.kind != TypeKind::Known {
+        return;
+    }
+    let Some(current) = lattice.tcl_type else {
+        return;
+    };
+    if current == expected || is_numeric_compatible(current, expected) {
+        return;
+    }
+    // The registry marks intreps this operation reads directly without
+    // installing `expected` (e.g. `string length`'s pure-byte-array fast
+    // path): those operands keep their rep — no shimmer.
+    if expectation.is_transparent_from(current) {
+        return;
+    }
+    // A numeric lattice type does not prove a numeric *intrep*: a
+    // literal-defined `set x 42` is a pure string at runtime
+    // (tclsh-verified) with nothing for a String-installing operation to
+    // destroy, and when the numeric rep IS installed its string
+    // regenerates in O(digits). Only container intreps (List/Dict) lose
+    // real structure to a String expectation, so numeric currents stay
+    // silent there.
+    if expected == TclType::String
+        && matches!(
+            current,
+            TclType::Int | TclType::Double | TclType::Numeric | TclType::Boolean
+        )
+    {
+        return;
+    }
+    // An uncommitted (pure) value — a literal, an interpolated string, or a
+    // string-producing command's result — pays nothing on its first read as
+    // `expected` when it is a valid instance of it. `set fontSizes {10.0
+    // 12.0}; foreach s $fontSizes` (issue #940), `set x 5; lindex $x 0`, and
+    // `set d {a 1 b 2}; dict for {k v} $d` are all free promotions of a pure
+    // string, not shimmers — see [`is_uncommitted_first_conversion`]. A
+    // committed container/object intrep, or a pure value that is *not* a
+    // valid instance (`incr` on a non-integer), still fires.
+    if is_uncommitted_first_conversion(current, expected, ctx.values.get(&(sym, ver))) {
+        return;
+    }
+    // A prior use in this block already coerced `(var, ver)` to this
+    // intrep — the runtime representation has already changed, so this
+    // is not a second shimmer.
+    let coercion_key = (var.clone(), ver, expected);
+    if !ctx.already_coerced.insert(coercion_key) {
+        return;
+    }
+    let related: Vec<(Span, String)> = ctx
+        .def_map
+        .get(&(sym, ver))
+        .map(|&sp| vec![(sp, "value defined here".to_owned())])
+        .unwrap_or_default();
+    // A loop-invariant variable coerced to a single intrep inside the
+    // loop converts once and is cached → S100, not the per-iteration
+    // S101.
+    let code = if ctx.loop_facts.effective_in_loop(&var, ctx.in_loop) {
+        DiagCode::S101
+    } else {
+        DiagCode::S100
+    };
+    let span = site.arg_spans.get(i).copied().unwrap_or(site.fallback_span);
+    ctx.out.push(ShimmerWarning {
+        span,
+        variable: var.clone(),
+        from_type: current,
+        to_type: expected,
+        command: site.command.to_owned(),
+        in_loop: ctx.in_loop,
+        code,
+        message: format!(
+            "variable '{var}' has {from} intrep \
+             but '{cmd}' expects {to} (argument {n})",
+            from = type_name(current),
+            cmd = site.command,
+            to = type_name(expected),
+            n = i + 1,
+        ),
+        related,
+    });
 }
 
 fn check_statement(ctx: &mut UseSiteCtx<'_>, stmt: &Statement, uses: &HashMap<Symbol, u32>) {
@@ -595,7 +592,11 @@ fn check_incr_var(ctx: &mut UseSiteCtx<'_>, var: &str, span: Span, uses: &HashMa
     if current == TclType::Int || is_numeric_compatible(current, TclType::Int) {
         return;
     }
-    if value_is_int_literal_string(ctx.values.get(&(sym, ver))) {
+    // A pure value whose string form is a whole integer (`set n 0x80; incr n`,
+    // `set n 5; incr n`) promotes to `Int` for free — no shimmer. A non-integer
+    // pure string (`set n hello; incr n`) is *not* a valid instance, so it still
+    // fires: that conversion fails at runtime.
+    if is_uncommitted_first_conversion(current, TclType::Int, ctx.values.get(&(sym, ver))) {
         return;
     }
     let related: Vec<(Span, String)> = ctx
@@ -698,12 +699,18 @@ mod tests {
         );
     }
 
-    /// An Int variable passed to `lindex` should trigger a shimmer
-    /// (Int → List at arg 0).
+    /// A *committed* Int variable passed to `lindex` triggers a shimmer
+    /// (Int → List at arg 0). The Int comes from `[llength]` (a committed
+    /// numeric intrep), not a bare literal — `set x 5; lindex $x 0` is a *pure*
+    /// value that promotes for free (see `no_shimmer_for_pure_literal_as_list`).
     #[test]
     fn shimmer_detected_for_int_used_with_lindex() {
-        let cu = CompilationUnit::build_for("set x 5\nlindex $x 0", &registry(), false);
-        let fu = cu.function("::top").unwrap();
+        let cu = CompilationUnit::build_for(
+            "proc f {lst} {\n set x [llength $lst]\n lindex $x 0\n}",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
         let warnings = find_use_site_shimmers(
             &fu.cfg,
             &fu.ssa,
@@ -715,10 +722,40 @@ mod tests {
         let w = warnings.iter().find(|w| w.command == "lindex");
         assert!(
             w.is_some(),
-            "expected lindex shimmer for Int var, got: {warnings:?}"
+            "expected lindex shimmer for committed Int var, got: {warnings:?}"
         );
         assert_eq!(w.unwrap().from_type, TclType::Int);
         assert_eq!(w.unwrap().to_type, TclType::List);
+    }
+
+    /// TN (issue #940): a *pure* literal — even a number-shaped or word-shaped
+    /// one — used as a list must NOT shimmer. `set a 1; foreach b $a` and `set x
+    /// 5; lindex $x 0` promote a pure string to a list for free (oracle: `set x
+    /// 5` is a pure string, `lindex` parses it into a 1-element list once). The
+    /// define-time shape (`1` looks integer-ish) does not make the value any
+    /// less a valid list.
+    #[test]
+    fn no_shimmer_for_pure_literal_as_list() {
+        for src in [
+            "set a 1\nforeach b $a {}",
+            "set x 5\nlindex $x 0",
+            "set p 3.14\nlindex $p 0",
+        ] {
+            let cu = CompilationUnit::build_for(src, &registry(), false);
+            let fu = cu.function("::top").unwrap();
+            let warnings = find_use_site_shimmers(
+                &fu.cfg,
+                &fu.ssa,
+                &fu.types,
+                &fu.sccp.executable_blocks,
+                &registry(),
+                &fu.sccp.values,
+            );
+            assert!(
+                warnings.is_empty(),
+                "pure literal used as a list must not shimmer for {src:?}: {warnings:?}"
+            );
+        }
     }
 
     /// The warning's span is tight around the offending `$x` argument, not
@@ -726,7 +763,7 @@ mod tests {
     /// on the variable, not have to scan the whole call.
     #[test]
     fn shimmer_span_is_tight_around_call_argument() {
-        let src = "set x 5\nlindex $x 0";
+        let src = "set x [dict create a 1 b 2]\nlindex $x 0";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
         let warnings = find_use_site_shimmers(
@@ -753,7 +790,7 @@ mod tests {
     /// whole `set b […]` statement.
     #[test]
     fn shimmer_span_is_tight_around_assign_value_substitution_argument() {
-        let src = "set x 5\nset b [lindex $x 0]";
+        let src = "set x [dict create a 1 b 2]\nset b [lindex $x 0]";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::top").unwrap();
         let warnings = find_use_site_shimmers(
@@ -778,11 +815,11 @@ mod tests {
     /// Two shimmering arguments of the *same* call each get their *own*
     /// tight span — proves the per-index span lookup, not just "arg 0's
     /// span reused everywhere". `linsert list index element`: `list_var`
-    /// (String, arg 0) expects List; `index_var` (String, arg 1) expects
-    /// Int.
+    /// (committed Dict, arg 0) expects List; `index_var` (String `world`, arg 1)
+    /// expects Int — `world` is not a valid integer, so it still fires.
     #[test]
     fn shimmer_span_is_tight_per_argument_not_reused_across_args() {
-        let src = "set list_var hello\n\
+        let src = "set list_var [dict create a 1 b 2]\n\
                     set index_var world\n\
                     linsert $list_var $index_var x";
         let cu = CompilationUnit::build_for(src, &registry(), false);
@@ -810,13 +847,15 @@ mod tests {
         assert_eq!(index_text, "$index_var", "got {index_w:?}");
     }
 
-    /// A `foreach` element variable is typed String (list elements
-    /// stringify); using it as a list intrep inside the loop body via a
-    /// `[lindex $x 0]` command substitution re-thunks each iteration —
-    /// per-iteration shimmer (S101). The substitution lives in an
-    /// `AssignValue` value, so this exercises the `AssignValue` arm.
+    /// TN: a `foreach` element variable is typed String — each element is a
+    /// *pure* string, and reading it as a list via `[lindex $x 0]` is a free
+    /// first conversion (oracle: a list element goes pure → list once, per
+    /// value). It is NOT a per-iteration shimmer: no cached intrep is thrown
+    /// away, because a fresh element value arrives each pass. The substitution
+    /// lives in an `AssignValue` value, so this also guards the `AssignValue`
+    /// arm against re-flagging pure elements.
     #[test]
-    fn shimmer_detected_for_foreach_var_used_as_list_in_cmd_sub() {
+    fn no_shimmer_for_foreach_element_used_as_list_in_cmd_sub() {
         let src = "proc f {l} {\n    foreach x $l {\n        set b [lindex $x 0]\n    }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
@@ -828,25 +867,52 @@ mod tests {
             &registry(),
             &fu.sccp.values,
         );
-        let w = warnings.iter().find(|w| w.command == "lindex");
         assert!(
-            w.is_some(),
-            "expected lindex S101 for foreach var, got: {warnings:?}"
+            warnings.iter().all(|w| w.command != "lindex"),
+            "a pure foreach element read as a list must not shimmer: {warnings:?}"
         );
-        let w = w.unwrap();
+    }
+
+    /// TP control (the committed counterpart): a *committed* value re-read as a
+    /// list inside a loop, via the same `[cmd …]`-in-`AssignValue` path, DOES
+    /// shimmer per iteration (S101). `[dict create k $x]` builds a fresh dict
+    /// each pass (defined in the loop, so not the loop-invariant downgrade), and
+    /// `[llength $d]` re-represents it list-ward every iteration.
+    #[test]
+    fn shimmer_detected_for_committed_value_as_list_in_cmd_sub() {
+        let src = "proc f {l} {\n    foreach x $l {\n        set d [dict create k $x]\n        set n [llength $d]\n    }\n}\n";
+        let cu = CompilationUnit::build_for(src, &registry(), false);
+        let fu = cu.function("::f").unwrap();
+        let warnings = find_use_site_shimmers(
+            &fu.cfg,
+            &fu.ssa,
+            &fu.types,
+            &fu.sccp.executable_blocks,
+            &registry(),
+            &fu.sccp.values,
+        );
+        let w = warnings
+            .iter()
+            .find(|w| w.command == "llength" && w.variable == "d")
+            .unwrap_or_else(|| {
+                panic!("expected llength S101 for committed dict, got: {warnings:?}")
+            });
         assert_eq!(w.code, DiagCode::S101);
-        assert_eq!(w.from_type, TclType::String);
+        assert_eq!(w.from_type, TclType::Dict);
         assert_eq!(w.to_type, TclType::List);
     }
 
     /// TP: `foreach`'s own list argument shimmers when the variable holds a
-    /// non-list intrep — the CFG builder lowers the header to a synthetic
-    /// `Statement::Call` (`command="foreach", args=[list_arg]`) that never
-    /// reaches the per-index `arg_types` path, so this is the
-    /// `foreach_header_expected_type` path specifically.
+    /// *committed* non-list intrep — the CFG builder lowers the header to a
+    /// synthetic `Statement::Call` (`command="foreach", args=[list_arg]`) that
+    /// never reaches the per-index `arg_types` path, so this is the
+    /// `foreach_header_expected_type` path specifically. A committed `Dict`
+    /// (from `[dict create]`) genuinely re-represents when foreach reads it as a
+    /// list; a *pure* string would be a free first conversion (see the
+    /// `no_shimmer_for_foreach_header_with_pure_string` TN below).
     #[test]
     fn shimmer_detected_for_foreach_header_list_argument() {
-        let src = "proc f {} {\n    set l hello\n    foreach x $l { puts $x }\n}\n";
+        let src = "proc f {} {\n    set l [dict create a 1 b 2]\n    foreach x $l { puts $x }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
         let warnings = find_use_site_shimmers(
@@ -861,7 +927,7 @@ mod tests {
             .iter()
             .find(|w| w.command == "foreach" && w.variable == "l")
             .unwrap_or_else(|| panic!("expected foreach header shimmer, got: {warnings:?}"));
-        assert_eq!(w.from_type, TclType::String);
+        assert_eq!(w.from_type, TclType::Dict);
         assert_eq!(w.to_type, TclType::List);
     }
 
@@ -885,10 +951,37 @@ mod tests {
         );
     }
 
+    /// TN (issue #940): a *pure* string literal in `foreach` must not shimmer —
+    /// `{a b c}` (and any well-formed list literal) is a valid list, and Tcl
+    /// parses it into a list intrep once, for free (oracle: the value goes pure
+    /// → list). This is the exact false positive issue #940 reported.
+    #[test]
+    fn no_shimmer_for_foreach_header_with_pure_string() {
+        for literal in ["{10.0 12.0 16.0 24.0}", "hello", "{}", "1"] {
+            let src = format!(
+                "proc f {{}} {{\n    set l {literal}\n    foreach x $l {{ puts $x }}\n}}\n"
+            );
+            let cu = CompilationUnit::build_for(&src, &registry(), false);
+            let fu = cu.function("::f").unwrap();
+            let warnings = find_use_site_shimmers(
+                &fu.cfg,
+                &fu.ssa,
+                &fu.types,
+                &fu.sccp.executable_blocks,
+                &registry(),
+                &fu.sccp.values,
+            );
+            assert!(
+                warnings.iter().all(|w| w.variable != "l"),
+                "pure string literal {literal:?} in foreach must not shimmer: {warnings:?}"
+            );
+        }
+    }
+
     /// TP: `lmap`'s list argument shares the same synthetic header shape.
     #[test]
     fn shimmer_detected_for_lmap_header_list_argument() {
-        let src = "proc f {} {\n    set l hello\n    lmap x $l { set x $x }\n}\n";
+        let src = "proc f {} {\n    set l [dict create a 1 b 2]\n    lmap x $l { set x $x }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
         let warnings = find_use_site_shimmers(
@@ -903,7 +996,7 @@ mod tests {
             .iter()
             .find(|w| w.command == "lmap" && w.variable == "l")
             .unwrap_or_else(|| panic!("expected lmap header shimmer, got: {warnings:?}"));
-        assert_eq!(w.from_type, TclType::String);
+        assert_eq!(w.from_type, TclType::Dict);
         assert_eq!(w.to_type, TclType::List);
     }
 
@@ -958,7 +1051,7 @@ mod tests {
     /// one-time S100, not the per-iteration S101.
     #[test]
     fn loop_invariant_single_target_downgrades_to_s100() {
-        let src = "proc f {} {\n  set data {1 2 3}\n  for {set i 0} {$i < 3} {incr i} {\n    set x [lindex $data $i]\n  }\n}\n";
+        let src = "proc f {} {\n  set data [dict create a 1 b 2]\n  for {set i 0} {$i < 3} {incr i} {\n    set x [lindex $data $i]\n  }\n}\n";
         let cu = CompilationUnit::build_for(src, &registry(), false);
         let fu = cu.function("::f").unwrap();
         let warnings = find_use_site_shimmers(
@@ -1132,11 +1225,13 @@ mod tests {
 
     /// TP: a call through an `interp alias` to a shimmering builtin is still
     /// detected — the registry lookup keys off the resolved
-    /// `canonical_command`, not the alias's source spelling.
+    /// `canonical_command`, not the alias's source spelling. `$x` holds a
+    /// *committed* Dict so the list conversion is a genuine shimmer (a pure
+    /// string would promote for free through the alias too).
     #[test]
     fn shimmer_detected_through_interp_alias_to_lindex() {
         let cu = CompilationUnit::build_for(
-            "interp alias {} myindex {} ::lindex\nset x hello\nmyindex $x 0",
+            "interp alias {} myindex {} ::lindex\nset x [dict create a 1 b 2]\nmyindex $x 0",
             &registry(),
             false,
         );
@@ -1155,7 +1250,7 @@ mod tests {
             "expected shimmer through interp alias, got: {warnings:?}"
         );
         let w = w.unwrap();
-        assert_eq!(w.from_type, TclType::String);
+        assert_eq!(w.from_type, TclType::Dict);
         assert_eq!(w.to_type, TclType::List);
         // The message keeps the alias spelling the user wrote, not the
         // resolved canonical target.

--- a/rust/tcl-compiler/src/shimmer/use_site.rs
+++ b/rust/tcl-compiler/src/shimmer/use_site.rs
@@ -42,7 +42,7 @@ use tcl_registry::{CommandRegistry, TclType};
 use crate::analyses::LatticeValue;
 use crate::cfg::{BlockId, Function as CfgFunction};
 use crate::ir::Statement;
-use crate::naming::normalise_var_name;
+use crate::naming::element_var_name;
 use crate::sccp::cfg_order;
 use crate::ssa::{SsaFunction, Symbol, ValueKey};
 use crate::types::{TypeKind, TypeLattice};
@@ -216,7 +216,7 @@ impl LoopFacts {
                     continue;
                 }
                 if let Some(expected) = arg_shimmer_type(registry, command, &arg_refs, i) {
-                    let var = normalise_var_name(word.trim()).to_owned();
+                    let var = element_var_name(word.trim()).to_owned();
                     self.use_targets.entry(var).or_default().insert(expected);
                 }
             }
@@ -354,7 +354,7 @@ fn resolve_tracked_var_use(
     if !is_pure_var_ref(stripped) {
         return None;
     }
-    let var = normalise_var_name(stripped).to_owned();
+    let var = element_var_name(stripped).to_owned();
     let sym = ctx.ssa.var_symbol(&var)?;
     if ctx.array_syms.contains(&sym) {
         return None;
@@ -685,11 +685,11 @@ fn check_statement(ctx: &mut UseSiteCtx<'_>, stmt: &Statement, uses: &HashMap<Sy
             // increment argument as Int.  The two checks are independent —
             // an Int target with a String `$amount` still shimmers on the
             // amount — so neither must short-circuit the other.
-            check_incr_var(ctx, normalise_var_name(name), stmt.span(), uses);
+            check_incr_var(ctx, element_var_name(name), stmt.span(), uses);
             if let Some(amt) = amount.as_deref().map(str::trim)
                 && amt.starts_with('$')
             {
-                check_incr_var(ctx, normalise_var_name(amt), stmt.span(), uses);
+                check_incr_var(ctx, element_var_name(amt), stmt.span(), uses);
             }
         }
 

--- a/rust/tcl-compiler/src/slot_allocation.rs
+++ b/rust/tcl-compiler/src/slot_allocation.rs
@@ -72,6 +72,7 @@ fn make_scanner() -> VarReferenceScanner {
         include_var_read_roles: true,
         recurse_cmd_substitutions: true,
         include_reads_before_write: false,
+        element_qualified: false,
     })
 }
 

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -913,13 +913,9 @@ fn expand_defs(direct: &[String], elems: &ArrayElems) -> Vec<String> {
 /// fanned element's prior version (the may-def join input). Both make the
 /// element chains live and upward-exposed so phi placement and liveness see
 /// them (adversarial findings F1/F2/F5 on PR #944).
-fn expand_uses(
-    direct_uses: &[String],
-    direct_defs: &[String],
-    elems: &ArrayElems,
-) -> Vec<String> {
+fn expand_uses(direct_uses: &[String], direct_defs: &[String], elems: &ArrayElems) -> Vec<String> {
     let mut out: Vec<String> = Vec::new();
-    let mut push = |n: &str, out: &mut Vec<String>| {
+    let push = |n: &str, out: &mut Vec<String>| {
         if !out.iter().any(|e| e == n) {
             out.push(n.to_owned());
         }
@@ -966,10 +962,11 @@ fn nonlocal_names_and_defsites(
         for stmt in &block.statements {
             let direct_uses = uses_of(stmt, &mut scanner, registry);
             let direct_defs = defs_of_with_registry(stmt, Some(registry));
-            for u in direct_uses
-                .iter()
-                .cloned()
-                .chain(expand_uses(&direct_uses, &direct_defs, elems))
+            for u in
+                direct_uses
+                    .iter()
+                    .cloned()
+                    .chain(expand_uses(&direct_uses, &direct_defs, elems))
             {
                 if !defined_here.contains(&u) {
                     nonlocal_names.insert(u);
@@ -1352,6 +1349,22 @@ fn uses_in_call(
         }
     }
     if *reads_own_defs {
+        for name in defs {
+            vars_found.insert(name.clone());
+            reads_own_def.insert(name.clone());
+        }
+    }
+    // A destroying command (`unset a(k)`) consumes the target's *existence*:
+    // the killed store is not dead — deleting it would make the unset error
+    // on every call. Record the prior version as a read (DESTROYS_VARIABLE,
+    // matching the pre-per-element behavior the base-level use gave).
+    let destroys = registry
+        .get(canonical_command.as_deref().unwrap_or(command))
+        .is_some_and(|spec| {
+            spec.traits
+                .contains(tcl_registry::Traits::DESTROYS_VARIABLE)
+        });
+    if destroys {
         for name in defs {
             vars_found.insert(name.clone());
             reads_own_def.insert(name.clone());

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -907,6 +907,42 @@ fn expand_defs(direct: &[String], elems: &ArrayElems) -> Vec<String> {
     out
 }
 
+/// The use-side counterpart of [`expand_defs`]: reading a base whose
+/// constant-keyed elements are known (`$a($i)`, `array get a`, `parray a`)
+/// reads *every* element, and a dynamic-key / whole-array write reads each
+/// fanned element's prior version (the may-def join input). Both make the
+/// element chains live and upward-exposed so phi placement and liveness see
+/// them (adversarial findings F1/F2/F5 on PR #944).
+fn expand_uses(
+    direct_uses: &[String],
+    direct_defs: &[String],
+    elems: &ArrayElems,
+) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut push = |n: &str, out: &mut Vec<String>| {
+        if !out.iter().any(|e| e == n) {
+            out.push(n.to_owned());
+        }
+    };
+    for u in direct_uses {
+        if let Some(els) = elems.get(u) {
+            for e in els {
+                push(e, &mut out);
+            }
+        }
+    }
+    for d in direct_defs {
+        if !d.contains('(')
+            && let Some(els) = elems.get(d)
+        {
+            for e in els {
+                push(e, &mut out);
+            }
+        }
+    }
+    out
+}
+
 fn nonlocal_names_and_defsites(
     func: &cfg::Function,
     reachable: &HashSet<BlockId>,
@@ -928,41 +964,48 @@ fn nonlocal_names_and_defsites(
         };
         let mut defined_here: FxHashSet<String> = FxHashSet::default();
         for stmt in &block.statements {
-            for u in uses_of(stmt, &mut scanner, registry) {
+            let direct_uses = uses_of(stmt, &mut scanner, registry);
+            let direct_defs = defs_of_with_registry(stmt, Some(registry));
+            for u in direct_uses
+                .iter()
+                .cloned()
+                .chain(expand_uses(&direct_uses, &direct_defs, elems))
+            {
                 if !defined_here.contains(&u) {
                     nonlocal_names.insert(u);
                 }
             }
-            for var in expand_defs(&defs_of_with_registry(stmt, Some(registry)), elems) {
+            for var in expand_defs(&direct_defs, elems) {
                 defsites.entry(var.clone()).or_default().insert(*bn);
                 defined_here.insert(var);
             }
         }
+        // Terminator reads are element-qualified like statement reads (a
+        // condition's `$a(k)` must place the element's phi), and a base
+        // read fans over known elements.
+        let mut term_uses: Vec<String> = Vec::new();
         match &block.terminator {
             Some(cfg::Terminator::Branch { condition, .. }) => {
-                for u in vars_in_expr(condition) {
-                    if !defined_here.contains(&u) {
-                        nonlocal_names.insert(u);
-                    }
-                }
+                term_uses.extend(condition.vars_element_qualified());
             }
             Some(cfg::Terminator::Return { value, expr, .. }) => {
                 if let Some(v) = value {
-                    for u in scanner.scan_word(v, registry) {
-                        if !defined_here.contains(&u) {
-                            nonlocal_names.insert(u);
-                        }
-                    }
+                    term_uses.extend(scanner.scan_word(v, registry));
                 }
                 if let Some(e) = expr {
-                    for u in vars_in_expr(e) {
-                        if !defined_here.contains(&u) {
-                            nonlocal_names.insert(u);
-                        }
-                    }
+                    term_uses.extend(e.vars_element_qualified());
                 }
             }
             _ => {}
+        }
+        for u in term_uses
+            .iter()
+            .cloned()
+            .chain(expand_uses(&term_uses, &[], elems))
+        {
+            if !defined_here.contains(&u) {
+                nonlocal_names.insert(u);
+            }
         }
     }
     (nonlocal_names, defsites)
@@ -1241,7 +1284,12 @@ fn set_value_reads(
         && let Some((expr_arg, _)) =
             crate::lowering_hooks::extract_single_expr_arg(inner, &HashSet::new())
     {
-        return vars_in_expr(&crate::parse_expr(&expr_arg, None));
+        let expr = crate::parse_expr(&expr_arg, None);
+        return if scanner.element_qualified() {
+            expr.vars_element_qualified().into_iter().collect()
+        } else {
+            vars_in_expr(&expr)
+        };
     }
     scanner.scan_word(value, registry)
 }
@@ -1664,7 +1712,7 @@ fn intern_terminator_reads(
     for block in func.blocks.values() {
         match &block.terminator {
             Some(cfg::Terminator::Branch { condition, .. }) => {
-                for u in vars_in_expr(condition) {
+                for u in condition.vars_element_qualified() {
                     interner.intern(&u);
                 }
             }
@@ -1675,7 +1723,7 @@ fn intern_terminator_reads(
                     }
                 }
                 if let Some(e) = expr {
-                    for u in vars_in_expr(e) {
+                    for u in e.vars_element_qualified() {
                         interner.intern(&u);
                     }
                 }
@@ -1859,6 +1907,13 @@ impl RenameWalk {
                 for var in &uses_list {
                     let v = self.top(var);
                     uses_map.insert(self.interner.intern(var), v);
+                }
+                // A base read (`$a($i)`, `array get a`) reads every known
+                // constant-keyed element — record their versions so the
+                // element chains are live.
+                for var in expand_uses(&uses_list, &[], elems) {
+                    let v = self.top(&var);
+                    uses_map.entry(self.interner.intern(&var)).or_insert(v);
                 }
 
                 let direct_defs = defs_of_with_registry(stmt, Some(registry));

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -107,6 +107,14 @@ pub struct SsaStatement {
     pub uses: HashMap<Symbol, Version>,
     /// Variables written: symbol → SSA version.
     pub defs: HashMap<Symbol, Version>,
+    /// The subset of [`Self::defs`] that are *synthetic* array-element
+    /// writes, not writes the statement performs itself: the base refresh
+    /// alongside an element write (`set arr(k) v` also defs `arr`), and the
+    /// element fan of a dynamic-key / whole-array write (`set arr($i) v`
+    /// defs every known `arr(*)`). Type inference **joins** across a
+    /// may-def (old type ⊔ written value); write-sensitive passes (shimmer
+    /// oscillation, dead-store) must not count one as a real write.
+    pub may_defs: HashSet<Symbol>,
 }
 
 /// A CFG basic block in SSA form.
@@ -227,6 +235,27 @@ impl SsaFunction {
     #[must_use]
     pub fn var_name(&self, sym: Symbol) -> &str {
         &self.var_names[sym.0 as usize]
+    }
+
+    /// Whether the def of `name` recorded at (`block_name`, `stmt_idx`) is a
+    /// **synthetic** array-element may-def ([`SsaStatement::may_defs`]) — the
+    /// base refresh of an element write, or the element fan of a dynamic-key
+    /// / whole-array write — rather than a write the statement performs
+    /// itself. Unused-variable / dead-store reporting skips these: the user
+    /// wrote one assignment, not one per fanned symbol.
+    #[must_use]
+    pub fn is_synthetic_def(&self, block_name: &str, stmt_idx: i32, name: &str) -> bool {
+        let Some(sym) = self.var_symbol(name) else {
+            return false;
+        };
+        let Ok(idx) = usize::try_from(stmt_idx) else {
+            return false;
+        };
+        self.blocks
+            .values()
+            .find(|b| b.name == block_name)
+            .and_then(|b| b.statements.get(idx))
+            .is_some_and(|st| st.may_defs.contains(&sym))
     }
 
     /// The [`Symbol`] a variable name resolves to, if it was interned during
@@ -370,10 +399,18 @@ pub fn defs_of_with_registry(stmt: &Statement, registry: Option<&CommandRegistry
     use tcl_registry::{ArgRole, Traits};
 
     match stmt {
-        Statement::AssignConst { name, .. }
-        | Statement::AssignExpr { name, .. }
-        | Statement::AssignValue { name, .. }
-        | Statement::Incr { name, .. } => {
+        Statement::AssignConst {
+            name, name_braced, ..
+        }
+        | Statement::AssignExpr {
+            name, name_braced, ..
+        }
+        | Statement::AssignValue {
+            name, name_braced, ..
+        }
+        | Statement::Incr {
+            name, name_braced, ..
+        } => {
             // A write-target whose *name* is value-substituted (`set $p …`,
             // `set ${tok}(k) …`) denotes the variable named by the
             // substitution's value — a place that cannot be pinned down, so it
@@ -382,7 +419,10 @@ pub fn defs_of_with_registry(stmt: &Statement, registry: Option<&CommandRegistry
             if is_dynamic_write_target(name) {
                 return Vec::new();
             }
-            vec![normalise_var_name(name).to_owned()]
+            // A constant-keyed array element defs its own variable
+            // (`arr(k)`); a dynamic key stays on the base (the rename walk
+            // fans the def over the array's known elements).
+            vec![crate::naming::element_var_name_braced(name, *name_braced).to_owned()]
         }
         Statement::Call { defs, .. } if !defs.is_empty() => defs.clone(),
         Statement::Barrier { command, args, .. } => {
@@ -415,7 +455,10 @@ pub fn defs_of_with_registry(stmt: &Statement, registry: Option<&CommandRegistry
                 if !indices.is_empty() {
                     return indices
                         .into_iter()
-                        .filter_map(|idx| args.get(idx).map(|s| normalise_var_name(s).to_owned()))
+                        .filter_map(|idx| {
+                            args.get(idx)
+                                .map(|s| crate::naming::element_var_name(s).to_owned())
+                        })
                         .filter(|n| !n.is_empty())
                         .collect();
                 }
@@ -423,7 +466,7 @@ pub fn defs_of_with_registry(stmt: &Statement, registry: Option<&CommandRegistry
             // Legacy string-match fallback for callers without a
             // registry (test helpers).
             if command == "trace" && args.len() >= 3 && args[0] == "add" && args[1] == "variable" {
-                return vec![normalise_var_name(&args[2]).to_owned()];
+                return vec![crate::naming::element_var_name(&args[2]).to_owned()];
             }
             Vec::new()
         }
@@ -730,9 +773,11 @@ pub(crate) fn compute_phi_vars(
     func: &cfg::Function,
     df: &HashMap<BlockId, HashSet<BlockId>>,
     registry: &CommandRegistry,
+    elems: &ArrayElems,
 ) -> HashMap<BlockId, HashSet<String>> {
     let reachable = func.reachable_blocks();
-    let (nonlocal_names, all_defsites) = nonlocal_names_and_defsites(func, &reachable, registry);
+    let (nonlocal_names, all_defsites) =
+        nonlocal_names_and_defsites(func, &reachable, registry, elems);
 
     // Semi-pruned SSA (Briggs et al. 1998): place phis only for *non-local*
     // (upward-exposed-use) names. A phi for a purely-local name has no reader,
@@ -773,15 +818,106 @@ pub(crate) fn compute_phi_vars(
 /// so a phi at a merge is meaningful. A name only ever read after its in-block
 /// definition (or never read) needs no phi. `defsites` is unfiltered (all
 /// defined names); the caller restricts phi placement to the non-local names.
+/// The constant-keyed elements of each array base referenced anywhere in a
+/// function: `"arr"` -> `{"arr(a)", "arr(b)"}`. Feeds [`expand_defs`]'s
+/// fan-out — a dynamic-key or whole-array write may hit any of these.
+pub(crate) type ArrayElems = FxHashMap<String, BTreeSet<String>>;
+
+/// Collect every constant-keyed array element defined or read in `func`.
+fn collect_array_elems(func: &cfg::Function, registry: &CommandRegistry) -> ArrayElems {
+    let mut scanner = VarReferenceScanner::new(VarScanOptions {
+        include_var_read_roles: true,
+        recurse_cmd_substitutions: true,
+        include_reads_before_write: false,
+        element_qualified: true,
+    });
+    let mut elems: ArrayElems = ArrayElems::default();
+    let note = |name: &str, elems: &mut ArrayElems| {
+        if let Some(open) = name.find('(') {
+            elems
+                .entry(name[..open].to_owned())
+                .or_default()
+                .insert(name.to_owned());
+        }
+    };
+    for block in func.blocks.values() {
+        for stmt in &block.statements {
+            for d in defs_of_with_registry(stmt, Some(registry)) {
+                note(&d, &mut elems);
+            }
+            for u in uses_of(stmt, &mut scanner, registry) {
+                note(&u, &mut elems);
+            }
+        }
+        match &block.terminator {
+            Some(cfg::Terminator::Branch { condition, .. }) => {
+                for u in condition.vars_element_qualified() {
+                    note(&u, &mut elems);
+                }
+            }
+            Some(cfg::Terminator::Return { value, expr, .. }) => {
+                if let Some(v) = value {
+                    for u in scanner.scan_word(v, registry) {
+                        note(&u, &mut elems);
+                    }
+                }
+                if let Some(e) = expr {
+                    for u in e.vars_element_qualified() {
+                        note(&u, &mut elems);
+                    }
+                }
+            }
+            _ => {}
+        }
+    }
+    elems
+}
+
+/// Expand a statement's direct def names with the array-element fan-out:
+///
+/// - an element def (`arr(k)`) also defs its base `arr`, so whole-array
+///   reads (`array get arr`) see a fresh version;
+/// - a base def where constant-keyed elements exist (a dynamic-key write
+///   `set arr($i) v`, or a whole-array writer like `array set`) **fans**
+///   over every known element — the write may have hit any of them.
+///
+/// The rename walk records a *use* of each fanned-only name's prior
+/// version, so type inference joins the old element type with the written
+/// value instead of trusting either.
+fn expand_defs(direct: &[String], elems: &ArrayElems) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let push = |n: String, out: &mut Vec<String>| {
+        if !out.contains(&n) {
+            out.push(n);
+        }
+    };
+    for d in direct {
+        if let Some(open) = d.find('(') {
+            push(d.clone(), &mut out);
+            push(d[..open].to_owned(), &mut out);
+        } else {
+            push(d.clone(), &mut out);
+            if let Some(els) = elems.get(d) {
+                for e in els {
+                    push(e.clone(), &mut out);
+                }
+            }
+        }
+    }
+    out
+}
+
 fn nonlocal_names_and_defsites(
     func: &cfg::Function,
     reachable: &HashSet<BlockId>,
     registry: &CommandRegistry,
+    elems: &ArrayElems,
 ) -> (FxHashSet<String>, FxHashMap<String, FxHashSet<BlockId>>) {
     let mut scanner = VarReferenceScanner::new(VarScanOptions {
         include_var_read_roles: true,
         recurse_cmd_substitutions: true,
         include_reads_before_write: false,
+        element_qualified: true,
     });
     let mut nonlocal_names: FxHashSet<String> = FxHashSet::default();
     let mut defsites: FxHashMap<String, FxHashSet<BlockId>> = FxHashMap::default();
@@ -797,7 +933,7 @@ fn nonlocal_names_and_defsites(
                     nonlocal_names.insert(u);
                 }
             }
-            for var in defs_of_with_registry(stmt, Some(registry)) {
+            for var in expand_defs(&defs_of_with_registry(stmt, Some(registry)), elems) {
                 defsites.entry(var.clone()).or_default().insert(*bn);
                 defined_here.insert(var);
             }
@@ -939,7 +1075,7 @@ pub fn uses_of(
 
     match stmt {
         Statement::ExprEval { expr, .. } => {
-            vars_found.extend(vars_in_expr(expr));
+            vars_found.extend(expr_vars_for(scanner, expr));
         }
 
         Statement::AssignConst { .. }
@@ -958,7 +1094,7 @@ pub fn uses_of(
                 vars_found.extend(scanner.scan_word(v, registry));
             }
             if let Some(e) = expr {
-                vars_found.extend(vars_in_expr(e));
+                vars_found.extend(expr_vars_for(scanner, e));
             }
         }
 
@@ -1182,8 +1318,11 @@ fn uses_in_assignment(
     vars_found: &mut BTreeSet<String>,
     reads_own_def: &mut BTreeSet<String>,
 ) {
-    let note_reads_own = |name: &str, vars_found: &BTreeSet<String>, rod: &mut BTreeSet<String>| {
-        let norm = normalise_var_name(name);
+    let note_reads_own = |name: &str,
+                          scanner: &VarReferenceScanner,
+                          vars_found: &BTreeSet<String>,
+                          rod: &mut BTreeSet<String>| {
+        let norm = scanner.canonical_name(name);
         if !norm.is_empty() && vars_found.contains(norm) {
             rod.insert(norm.to_owned());
         }
@@ -1195,11 +1334,11 @@ fn uses_in_assignment(
             }
         }
         Statement::AssignExpr { name, expr, .. } => {
-            vars_found.extend(vars_in_expr(expr));
+            vars_found.extend(expr_vars_for(scanner, expr));
             if is_dynamic_write_target(name) {
                 vars_found.extend(scanner.scan_word(name, registry));
             } else {
-                note_reads_own(name, vars_found, reads_own_def);
+                note_reads_own(name, scanner, vars_found, reads_own_def);
             }
         }
         Statement::AssignValue { name, value, .. } => {
@@ -1207,14 +1346,14 @@ fn uses_in_assignment(
             if is_dynamic_write_target(name) {
                 vars_found.extend(scanner.scan_word(name, registry));
             } else {
-                note_reads_own(name, vars_found, reads_own_def);
+                note_reads_own(name, scanner, vars_found, reads_own_def);
             }
         }
         Statement::Incr { name, amount, .. } => {
             if is_dynamic_write_target(name) {
                 vars_found.extend(scanner.scan_word(name, registry));
             } else {
-                let norm = normalise_var_name(name);
+                let norm = scanner.canonical_name(name);
                 if !norm.is_empty() {
                     vars_found.insert(norm.to_owned());
                     reads_own_def.insert(norm.to_owned());
@@ -1225,6 +1364,19 @@ fn uses_in_assignment(
             }
         }
         _ => {}
+    }
+}
+
+/// The expression-AST variable reads, named per the scanner's qualification
+/// mode — element-qualified for the SSA build, base names otherwise.
+fn expr_vars_for(
+    scanner: &VarReferenceScanner,
+    expr: &crate::expr_ast::ExprNode,
+) -> BTreeSet<String> {
+    if scanner.element_qualified() {
+        expr.vars_element_qualified().into_iter().collect()
+    } else {
+        vars_in_expr(expr)
     }
 }
 
@@ -1621,6 +1773,7 @@ impl RenameWalk {
                 include_var_read_roles: true,
                 recurse_cmd_substitutions: true,
                 include_reads_before_write: false,
+                element_qualified: true,
             }),
             interner: VarInterner::default(),
             out,
@@ -1666,6 +1819,7 @@ impl RenameWalk {
         func: &cfg::Function,
         phi_vars: &HashMap<BlockId, HashSet<String>>,
         registry: &CommandRegistry,
+        elems: &ArrayElems,
     ) {
         let bn = frame.block;
 
@@ -1707,11 +1861,32 @@ impl RenameWalk {
                     uses_map.insert(self.interner.intern(var), v);
                 }
 
+                let direct_defs = defs_of_with_registry(stmt, Some(registry));
+                let expanded = expand_defs(&direct_defs, elems);
+                // A fanned element def is a *may*-write — the dynamic-key /
+                // whole-array write may have hit it: record a use of its
+                // prior version so type inference joins old and new rather
+                // than trusting the written value alone. (The base refresh
+                // of an element write is also a may-def, but reads nothing —
+                // an extra base use would make dead-store analysis see every
+                // element write as an observation of the whole array.)
+                for var in expanded
+                    .iter()
+                    .filter(|v| !direct_defs.contains(v) && v.contains('('))
+                {
+                    let ver = self.top(var);
+                    uses_map.entry(self.interner.intern(var)).or_insert(ver);
+                }
                 let mut defs_map: HashMap<Symbol, Version> = HashMap::new();
-                for var in defs_of_with_registry(stmt, Some(registry)) {
+                let mut may_defs: HashSet<Symbol> = HashSet::new();
+                for var in expanded {
                     let ver = self.push_new(&var);
                     frame.pushed_vars.push(var.clone());
-                    defs_map.insert(self.interner.intern(&var), ver);
+                    let sym = self.interner.intern(&var);
+                    defs_map.insert(sym, ver);
+                    if !direct_defs.contains(&var) {
+                        may_defs.insert(sym);
+                    }
                 }
 
                 self.out
@@ -1722,6 +1897,7 @@ impl RenameWalk {
                         statement: stmt.clone(),
                         uses: uses_map,
                         defs: defs_map,
+                        may_defs,
                     });
             }
         }
@@ -1779,7 +1955,8 @@ pub fn build_ssa(func: &cfg::Function, registry: &CommandRegistry) -> SsaFunctio
     let idom = compute_idom_fast(func);
     let df = compute_dominance_frontier(func, &idom);
     let tree = build_dom_tree(&idom);
-    let phi_vars = compute_phi_vars(func, &df, registry);
+    let elems = collect_array_elems(func, registry);
+    let phi_vars = compute_phi_vars(func, &df, registry, &elems);
 
     // 2. Set up rename state: the transient version stacks / counters, the
     // use-scanner, name interner, and per-block outputs (keyed by variable
@@ -1802,7 +1979,7 @@ pub fn build_ssa(func: &cfg::Function, registry: &CommandRegistry) -> SsaFunctio
     while let Some(frame) = stack.last_mut() {
         match frame.phase {
             RenamePhase::Enter => {
-                walk.enter_block(frame, func, &phi_vars, registry);
+                walk.enter_block(frame, func, &phi_vars, registry, &elems);
                 frame.phase = RenamePhase::ProcessChildren;
             }
 
@@ -1959,6 +2136,7 @@ mod tests {
             },
             uses: HashMap::new(),
             defs: HashMap::from([(Symbol(0), 1)]),
+            may_defs: std::collections::HashSet::new(),
         };
         assert_eq!(stmt.defs[&Symbol(0)], 1);
         assert!(stmt.uses.is_empty());
@@ -2039,7 +2217,9 @@ mod tests {
                 "dynamic target {name:?} must not be a static def"
             );
         }
-        // A static array element keeps its concrete base as the def.
+        // A constant-keyed array element defs its own per-element variable
+        // (the rename walk adds the base def alongside); a dynamic key
+        // stays on the base.
         let arr = Statement::AssignValue {
             span: Span::new(0, 10),
             name: "arr(idx)".into(),
@@ -2048,7 +2228,26 @@ mod tests {
             value_needs_backsubst: false,
             tokens: None,
         };
-        assert_eq!(defs_of(&arr), vec!["arr"]);
+        assert_eq!(defs_of(&arr), vec!["arr(idx)"]);
+        let dyn_key = Statement::AssignValue {
+            span: Span::new(0, 10),
+            name: "arr($i)".into(),
+            name_braced: false,
+            value: "1".into(),
+            value_needs_backsubst: false,
+            tokens: None,
+        };
+        assert_eq!(defs_of(&dyn_key), vec!["arr"]);
+        // Braces suppress substitution: the key is the literal text `$i`.
+        let braced = Statement::AssignValue {
+            span: Span::new(0, 10),
+            name: "arr($i)".into(),
+            name_braced: true,
+            value: "1".into(),
+            value_needs_backsubst: false,
+            tokens: None,
+        };
+        assert_eq!(defs_of(&braced), vec!["arr($i)"]);
     }
 
     #[test]
@@ -2515,7 +2714,12 @@ mod tests {
         let dom = compute_dominators(&func);
         let idom = compute_idom(&func, &dom);
         let df = compute_dominance_frontier(&func, &idom);
-        let phi = compute_phi_vars(&func, &df, &CommandRegistry::build_default());
+        let phi = compute_phi_vars(
+            &func,
+            &df,
+            &CommandRegistry::build_default(),
+            &ArrayElems::default(),
+        );
 
         assert!(phi[&end].contains("x"), "x should need a phi at 'end'");
         assert!(
@@ -2543,7 +2747,12 @@ mod tests {
         let dom = compute_dominators(&func);
         let idom = compute_idom(&func, &dom);
         let df = compute_dominance_frontier(&func, &idom);
-        let phi = compute_phi_vars(&func, &df, &CommandRegistry::build_default());
+        let phi = compute_phi_vars(
+            &func,
+            &df,
+            &CommandRegistry::build_default(),
+            &ArrayElems::default(),
+        );
 
         for vars in phi.values() {
             assert!(!vars.contains("x"), "x should not need a phi anywhere");
@@ -2581,7 +2790,12 @@ mod tests {
         let dom = compute_dominators(&func);
         let idom = compute_idom(&func, &dom);
         let df = compute_dominance_frontier(&func, &idom);
-        let phi = compute_phi_vars(&func, &df, &CommandRegistry::build_default());
+        let phi = compute_phi_vars(
+            &func,
+            &df,
+            &CommandRegistry::build_default(),
+            &ArrayElems::default(),
+        );
 
         assert!(
             phi[&header].contains("i"),
@@ -2595,7 +2809,12 @@ mod tests {
         let dom = compute_dominators(&func);
         let idom = compute_idom(&func, &dom);
         let df = compute_dominance_frontier(&func, &idom);
-        let phi = compute_phi_vars(&func, &df, &CommandRegistry::build_default());
+        let phi = compute_phi_vars(
+            &func,
+            &df,
+            &CommandRegistry::build_default(),
+            &ArrayElems::default(),
+        );
 
         for vars in phi.values() {
             assert!(vars.is_empty(), "no defs → no phis");
@@ -2629,6 +2848,7 @@ mod tests {
             include_var_read_roles: true,
             recurse_cmd_substitutions: true,
             include_reads_before_write: false,
+            element_qualified: false,
         });
         let stmt = Statement::AssignValue {
             span: Span::new(0, 15),

--- a/rust/tcl-compiler/src/static_loops.rs
+++ b/rust/tcl-compiler/src/static_loops.rs
@@ -101,6 +101,9 @@ pub fn evaluate_expr_with_constants(
     let v = eval_tcl_expr_with_octal(expr, &tcl_env, octal)?;
     match v {
         TclValue::Int(i) => Some(i),
+        // A beyond-wide loop bound is pathological — decline static
+        // unrolling rather than saturate.
+        TclValue::Big(_) => None,
         TclValue::Float(f) => {
             if !f.is_finite() {
                 return None;

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -1180,12 +1180,27 @@ fn seed_entry_taints(
     // to the local (version > 0) is unaffected; shadowing falls out of the SSA
     // versioning, not a check here.
     for spec in tcl_registry::special_vars::special_vars_for_dialect(dialect.unwrap_or("")) {
-        if let Some(colour) = spec.read_taint
-            && let Some(sym) = ssa.var_symbol(spec.name)
-        {
+        let Some(colour) = spec.read_taint else {
+            continue;
+        };
+        if let Some(sym) = ssa.var_symbol(spec.name) {
             taints.entry((sym, 0)).or_insert(TaintLattice {
                 colours: reg_colour(colour),
             });
+        }
+        // Per-element SSA: `$env(PATH)` reads its own `env(PATH)` symbol —
+        // every constant-keyed element of a tainted special array carries
+        // the source colour at version 0 too.
+        for name in ssa.var_names() {
+            if name.len() > spec.name.len()
+                && name.starts_with(spec.name)
+                && name.as_bytes()[spec.name.len()] == b'('
+                && let Some(sym) = ssa.var_symbol(name)
+            {
+                taints.entry((sym, 0)).or_insert(TaintLattice {
+                    colours: reg_colour(colour),
+                });
+            }
         }
     }
 }

--- a/rust/tcl-compiler/src/taint.rs
+++ b/rust/tcl-compiler/src/taint.rs
@@ -3544,6 +3544,7 @@ mod tests {
             statement: stmt,
             uses: HashMap::new(),
             defs: [(x, 1u32)].into_iter().collect(),
+            may_defs: std::collections::HashSet::new(),
         };
         ssa.blocks.insert(
             entry,
@@ -3619,11 +3620,13 @@ mod tests {
             statement: assign,
             uses: HashMap::new(),
             defs: [(x, 1u32)].into_iter().collect(),
+            may_defs: std::collections::HashSet::new(),
         };
         let ssa_eval = SsaStatement {
             statement: eval_call,
             uses: [(x, 1u32)].into_iter().collect(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         };
 
         ssa.blocks.insert(
@@ -3692,6 +3695,7 @@ mod tests {
             statement: assign,
             uses: HashMap::new(),
             defs: [(ssa.intern_var("x"), 1u32)].into_iter().collect(),
+            may_defs: std::collections::HashSet::new(),
         };
         let ssa_sink = SsaStatement {
             statement: sink,
@@ -3700,6 +3704,7 @@ mod tests {
                 .map(|&(n, v)| (ssa.intern_var(n), v))
                 .collect(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         };
         ssa.blocks.insert(
             entry,
@@ -3849,16 +3854,19 @@ mod tests {
             statement: s0,
             uses: HashMap::new(),
             defs: [(x, 1u32)].into_iter().collect(),
+            may_defs: std::collections::HashSet::new(),
         };
         let ssa_s1 = SsaStatement {
             statement: s1,
             uses: [(x, 1u32)].into_iter().collect(),
             defs: [(y, 1u32)].into_iter().collect(),
+            may_defs: std::collections::HashSet::new(),
         };
         let ssa_s2 = SsaStatement {
             statement: s2,
             uses: [(y, 1u32)].into_iter().collect(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         };
         ssa.blocks.insert(
             entry,
@@ -3966,6 +3974,7 @@ mod tests {
                 statement: file_call(&["delete", "$p"]),
                 uses: [(ssa.intern_var("p"), 1u32)].into_iter().collect(),
                 defs: HashMap::new(),
+                may_defs: std::collections::HashSet::new(),
             }]
         });
         let d = w.iter().find(|w| w.code == DiagCode::W313).expect("W313");
@@ -3998,11 +4007,13 @@ mod tests {
                 statement: assign,
                 uses: [(base, 0u32)].into_iter().collect(),
                 defs: [(p, 1u32)].into_iter().collect(),
+                may_defs: std::collections::HashSet::new(),
             };
             let s1 = SsaStatement {
                 statement: file_call(&["delete", "$p"]),
                 uses: [(p, 1u32)].into_iter().collect(),
                 defs: HashMap::new(),
+                may_defs: std::collections::HashSet::new(),
             };
             vec![s0, s1]
         });
@@ -4032,6 +4043,7 @@ mod tests {
                     statement: file_call(&["delete", "/tmp/foo"]),
                     uses: HashMap::new(),
                     defs: HashMap::new(),
+                    may_defs: std::collections::HashSet::new(),
                 }]
             })
             .is_empty()
@@ -4105,6 +4117,7 @@ mod tests {
             statement: stmt,
             uses: HashMap::new(),
             defs: [(x, 1u32)].into_iter().collect(),
+            may_defs: std::collections::HashSet::new(),
         };
         ssa.blocks.insert(
             entry,
@@ -4181,11 +4194,13 @@ mod tests {
             statement: assign,
             uses: HashMap::new(),
             defs: [(pattern, 1u32)].into_iter().collect(),
+            may_defs: std::collections::HashSet::new(),
         };
         let ssa_regexp = SsaStatement {
             statement: regexp_call,
             uses: [(pattern, 1u32)].into_iter().collect(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         };
 
         ssa.blocks.insert(
@@ -4275,11 +4290,13 @@ mod tests {
             statement: assign,
             uses: HashMap::new(),
             defs: [(pattern, 1u32)].into_iter().collect(),
+            may_defs: std::collections::HashSet::new(),
         };
         let ssa_regexp = SsaStatement {
             statement: regexp_call,
             uses: [(pattern, 1u32)].into_iter().collect(),
             defs: HashMap::new(),
+            may_defs: std::collections::HashSet::new(),
         };
 
         ssa.blocks.insert(

--- a/rust/tcl-compiler/src/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/src/tcl_expr_eval.rs
@@ -54,31 +54,63 @@ use std::collections::HashMap;
 use crate::expr_ast::{BinOp, ExprNode, UnaryOp};
 
 /// Result of evaluating a constant Tcl expression.
-#[derive(Debug, Clone, Copy, PartialEq)]
+#[derive(Debug, Clone, PartialEq)]
 pub enum TclValue {
-    /// Integer value (Tcl booleans are represented as `Int(0)` / `Int(1)`).
+    /// Integer value that fits a wide (Tcl booleans are `Int(0)` / `Int(1)`).
     Int(i64),
     /// IEEE-754 double.
     Float(f64),
+    /// Integer beyond a wide — the bignum rung of the numeric tower. Folded
+    /// exactly (`expr {2**64}` → `18446744073709551616`), mirroring the VM's
+    /// `num-bigint` tower and C Tcl's seamless wide→bignum promotion; a
+    /// bignum result that fits a wide is always demoted back to `Int`
+    /// (`$big - $big` → `Int(0)`), so `Big` is canonical: only ever
+    /// beyond-`i64` magnitudes.
+    Big(num_bigint::BigInt),
 }
 
 impl TclValue {
+    /// Wrap an arbitrary-precision integer, demoting to a wide when it fits
+    /// (the canonical form — mirrors the VM's `big_value` and C Tcl's
+    /// `mp_int` narrowing).
+    #[must_use]
+    pub fn from_big(value: num_bigint::BigInt) -> Self {
+        use num_traits::ToPrimitive;
+        value.to_i64().map_or(Self::Big(value), Self::Int)
+    }
+
     /// Return the raw float representation (converting integer → float
     /// when necessary). Used by arithmetic that promotes mixed operands.
+    /// A bignum converts with the same precision loss (to ±∞ past the
+    /// double range) as C Tcl's `Tcl_GetDoubleFromObj` on a bignum.
     #[must_use]
-    pub fn as_f64(self) -> f64 {
+    pub fn as_f64(&self) -> f64 {
+        use num_traits::ToPrimitive;
         match self {
-            Self::Int(i) => i as f64,
-            Self::Float(f) => f,
+            Self::Int(i) => *i as f64,
+            Self::Float(f) => *f,
+            Self::Big(b) => b.to_f64().unwrap_or(f64::NAN),
         }
     }
 
     /// True when the value is non-zero (Tcl truthiness).
     #[must_use]
-    pub fn is_truthy(self) -> bool {
+    pub fn is_truthy(&self) -> bool {
+        use num_traits::Zero;
         match self {
-            Self::Int(i) => i != 0,
-            Self::Float(f) => f != 0.0,
+            Self::Int(i) => *i != 0,
+            Self::Float(f) => *f != 0.0,
+            Self::Big(b) => !b.is_zero(),
+        }
+    }
+
+    /// The exact arbitrary-precision view of an integer value (`None` for a
+    /// float) — the promotion step of the integer arithmetic path.
+    fn to_bigint(&self) -> Option<num_bigint::BigInt> {
+        match self {
+            Self::Int(i) => Some(num_bigint::BigInt::from(*i)),
+            Self::Big(b) => Some(b.clone()),
+            Self::Float(_) => None,
         }
     }
 }
@@ -96,13 +128,6 @@ pub enum EnvValue {
 
 /// Variable environment for evaluation.
 pub type Env = HashMap<String, EnvValue>;
-
-/// Maximum exponent for integer `**` — guards against pathological
-/// inputs like `2 ** 999_999_999`.
-///
-/// Matches C Tcl's `INST_EXPON` limit (`exponent < 2^28`), so the value
-/// is `(1 << 28) - 1`.
-const MAX_EXPONENT: i64 = (1 << 28) - 1;
 
 // Public API
 
@@ -223,6 +248,7 @@ fn eval_with_config(
 #[derive(Clone)]
 enum FoldValue {
     Int(i64),
+    Big(num_bigint::BigInt),
     Float(f64),
     Str(String),
 }
@@ -232,6 +258,7 @@ impl FoldValue {
     fn to_number(&self) -> Option<TclValue> {
         match self {
             FoldValue::Int(i) => Some(TclValue::Int(*i)),
+            FoldValue::Big(b) => Some(TclValue::from_big(b.clone())),
             FoldValue::Float(f) => Some(TclValue::Float(*f)),
             FoldValue::Str(s) => parse_literal(s),
         }
@@ -240,13 +267,15 @@ impl FoldValue {
     fn to_string_val(&self) -> String {
         match self {
             FoldValue::Str(s) => s.clone(),
-            FoldValue::Int(i) => format_tcl_value(TclValue::Int(*i)),
-            FoldValue::Float(f) => format_tcl_value(TclValue::Float(*f)),
+            FoldValue::Int(i) => format_tcl_value(&TclValue::Int(*i)),
+            FoldValue::Big(b) => b.to_string(),
+            FoldValue::Float(f) => format_tcl_value(&TclValue::Float(*f)),
         }
     }
     fn from_tcl(v: TclValue) -> FoldValue {
         match v {
             TclValue::Int(i) => FoldValue::Int(i),
+            TclValue::Big(b) => FoldValue::Big(b),
             TclValue::Float(f) => FoldValue::Float(f),
         }
     }
@@ -293,7 +322,9 @@ enum Operand {
 /// [`Operand::Ambiguous`], applying the dialect's leading-zero rule.
 fn classify_operand(value: &FoldValue, octal: Option<bool>) -> Operand {
     let s = match value {
-        FoldValue::Int(_) | FoldValue::Float(_) => return Operand::Num(value.to_number().unwrap()),
+        FoldValue::Int(_) | FoldValue::Big(_) | FoldValue::Float(_) => {
+            return Operand::Num(value.to_number().unwrap());
+        }
         FoldValue::Str(s) => s.as_str(),
     };
     if is_bare_leading_zero(s) {
@@ -380,9 +411,13 @@ impl tcl_syntax::expr::ExprOps for FoldOps<'_> {
                 } else {
                     strict_number_for_dialect(v, octal)
                 };
-                parsed.map(|t| match t {
-                    TclValue::Int(i) => Num::Int(i),
-                    TclValue::Float(f) => Num::Float(f),
+                parsed.and_then(|t| match t {
+                    TclValue::Int(i) => Some(Num::Int(i)),
+                    TclValue::Float(f) => Some(Num::Float(f)),
+                    // A beyond-wide integer argument: the math functions
+                    // dispatch over the wide/double pair, so decline rather
+                    // than approximate.
+                    TclValue::Big(_) => None,
                 })
             })
             .collect();
@@ -411,22 +446,39 @@ impl tcl_syntax::expr::ExprOps for FoldOps<'_> {
             // leading-zero run is non-zero under both), so no dialect
             // handling is needed here.
             UnaryOp::Not | UnaryOp::WordNot => {
-                let truthy = value.to_number().ok_or(())?.is_truthy();
+                // `!NaN` is the same boolean-context domain error as `?:` on
+                // NaN — decline, never fold a truth value.
+                let truthy = match value.to_number().ok_or(())? {
+                    TclValue::Float(f) if f.is_nan() => return Err(()),
+                    v => v.is_truthy(),
+                };
                 Ok(FoldValue::Int(i64::from(!truthy)))
             }
             // Arithmetic/bitwise unaries reject boolean words like the binary
             // arithmetic path (`expr {-true}`, `expr {~yes}` are errors), and
             // are dialect-sensitive the same way `arith` is (`expr {-010}`
             // is `-8` in tcl8.x, `-10` in tcl9.0).
-            UnaryOp::Pos => strict_number_for_dialect(&value, self.octal)
-                .map(FoldValue::from_tcl)
-                .ok_or(()),
+            UnaryOp::Pos => match strict_number_for_dialect(&value, self.octal).ok_or(())? {
+                // `+NaN` is "can't use non-numeric floating-point value as
+                // operand" in C — never a foldable value.
+                TclValue::Float(f) if f.is_nan() => Err(()),
+                v => Ok(FoldValue::from_tcl(v)),
+            },
             UnaryOp::Neg => match strict_number_for_dialect(&value, self.octal).ok_or(())? {
-                TclValue::Int(i) => i.checked_neg().map(FoldValue::Int).ok_or(()),
+                TclValue::Int(i) => Ok(match i.checked_neg() {
+                    Some(n) => FoldValue::Int(n),
+                    // −i64::MIN promotes to the bignum tier, exactly as C.
+                    None => FoldValue::from_tcl(TclValue::from_big(-num_bigint::BigInt::from(i))),
+                }),
+                TclValue::Big(b) => Ok(FoldValue::from_tcl(TclValue::from_big(-b))),
+                // `-NaN` is the same operand error as `+NaN` — decline.
+                TclValue::Float(f) if f.is_nan() => Err(()),
                 TclValue::Float(f) => Ok(FoldValue::Float(-f)),
             },
             UnaryOp::BitNot => match strict_number_for_dialect(&value, self.octal).ok_or(())? {
                 TclValue::Int(i) => Ok(FoldValue::Int(!i)),
+                // Two's-complement `~x` is `-x - 1` at any width.
+                TclValue::Big(b) => Ok(FoldValue::from_tcl(TclValue::from_big(-b - 1))),
                 TclValue::Float(_) => Err(()),
             },
         }
@@ -481,7 +533,13 @@ impl tcl_syntax::expr::ExprOps for FoldOps<'_> {
     }
 
     fn to_bool(&mut self, value: &FoldValue) -> Result<bool, ()> {
-        Ok(value.to_number().ok_or(())?.is_truthy())
+        // Boolean contexts (`?:`, `&&`, `||`) reject NaN — a domain error in
+        // C Tcl ("floating point value is Not a Number"), so the fold
+        // declines rather than pick a truth value.
+        match value.to_number().ok_or(())? {
+            TclValue::Float(f) if f.is_nan() => Err(()),
+            v => Ok(v.is_truthy()),
+        }
     }
     fn bool_value(&mut self, b: bool) -> FoldValue {
         FoldValue::Int(i64::from(b))
@@ -505,12 +563,14 @@ impl tcl_syntax::expr::ExprOps for FoldOps<'_> {
 /// Render a `TclValue` as a Tcl source literal. Matches Tcl's
 /// `Tcl_GetStringFromObj` output for numbers.
 #[must_use]
-pub fn format_tcl_value(v: TclValue) -> String {
+pub fn format_tcl_value(v: &TclValue) -> String {
     match v {
         TclValue::Int(i) => i.to_string(),
         // The shared canonical double formatter (also the runtime's `double`
         // string rep): integer-valued floats get `.0`, plus `Inf`/`NaN`.
-        TclValue::Float(f) => tcl_syntax::number::format_double(f),
+        TclValue::Float(f) => tcl_syntax::number::format_double(*f),
+        // A bignum's canonical string rep is its decimal spelling.
+        TclValue::Big(b) => b.to_string(),
     }
 }
 
@@ -533,15 +593,30 @@ pub fn parse_literal(text: &str) -> Option<TclValue> {
     }
     // The numeric grammar is the shared `tcl_syntax::number` (the same
     // `TclParseNumber` port the runtime const-folds with): `0x`/`0o`/`0b`,
-    // leading-zero decimal, `_` separators, `Inf`/`NaN`. The const-folder's
-    // value is `i64`/`f64`, so a magnitude past a wide (a `Big`) can't be
-    // folded — return `None` (give up), matching the old i64-overflow behaviour.
+    // leading-zero decimal, `_` separators, `Inf`/`NaN`. A magnitude past a
+    // wide builds the exact bignum (P4 of type-tracking.md), matching C
+    // Tcl's seamless promotion.
     match tcl_syntax::number::parse_whole(text)? {
         Number::Int(v) => Some(TclValue::Int(v)),
         Number::Double(d) => Some(TclValue::Float(d)),
         Number::Nan { .. } => Some(TclValue::Float(f64::NAN)),
-        Number::Big { .. } => None,
+        Number::Big {
+            negative,
+            radix,
+            digits,
+        } => big_from_parts(negative, radix, &digits),
     }
+}
+
+/// Build the exact [`TclValue`] of a beyond-wide integer literal from the
+/// shared grammar's `Number::Big` parts (mirrors the VM's `value_as_bigint`).
+fn big_from_parts(
+    negative: bool,
+    radix: tcl_syntax::number::Radix,
+    digits: &str,
+) -> Option<TclValue> {
+    let b = num_bigint::BigInt::parse_bytes(digits.as_bytes(), radix as u32)?;
+    Some(TclValue::from_big(if negative { -b } else { b }))
 }
 
 /// Parse a *strict* Tcl number — the number grammar only, **without** the
@@ -555,11 +630,16 @@ fn strict_number(value: &FoldValue) -> Option<TclValue> {
     match value {
         FoldValue::Int(i) => Some(TclValue::Int(*i)),
         FoldValue::Float(f) => Some(TclValue::Float(*f)),
+        FoldValue::Big(b) => Some(TclValue::from_big(b.clone())),
         FoldValue::Str(s) => match tcl_syntax::number::parse_whole(s)? {
             Number::Int(v) => Some(TclValue::Int(v)),
             Number::Double(d) => Some(TclValue::Float(d)),
             Number::Nan { .. } => Some(TclValue::Float(f64::NAN)),
-            Number::Big { .. } => None,
+            Number::Big {
+                negative,
+                radix,
+                digits,
+            } => big_from_parts(negative, radix, &digits),
         },
     }
 }
@@ -608,59 +688,54 @@ fn strict_number_for_dialect(value: &FoldValue, octal: Option<bool>) -> Option<T
 fn apply_binary(op: BinOp, a: TclValue, b: TclValue) -> Option<TclValue> {
     match op {
         // Arithmetic.
-        BinOp::Add => Some(arith(a, b, i64::checked_add, |x, y| x + y)?),
-        BinOp::Sub => Some(arith(a, b, i64::checked_sub, |x, y| x - y)?),
-        BinOp::Mul => Some(arith(a, b, i64::checked_mul, |x, y| x * y)?),
-        BinOp::Div => tcl_div(a, b),
-        BinOp::Mod => tcl_mod(a, b),
-        BinOp::Pow => tcl_pow(a, b),
+        BinOp::Add => Some(arith(&a, &b, i64::checked_add, |x, y| x + y, |x, y| x + y)?),
+        BinOp::Sub => Some(arith(&a, &b, i64::checked_sub, |x, y| x - y, |x, y| x - y)?),
+        BinOp::Mul => Some(arith(&a, &b, i64::checked_mul, |x, y| x * y, |x, y| x * y)?),
+        BinOp::Div => tcl_div(&a, &b),
+        BinOp::Mod => tcl_mod(&a, &b),
+        BinOp::Pow => tcl_pow(&a, &b),
 
-        // Shifts and bitwise — integer only.
-        BinOp::LShift => match (a, b) {
-            (TclValue::Int(x), TclValue::Int(y)) if (0..64).contains(&y) => {
-                // Tcl promotes a wide-overflowing left shift to a bignum, which
-                // the const-folder cannot represent. `checked_shl` guards only
-                // the shift *count* (< 64), not value overflow, so `1 << 63`
-                // would fold to the wrapped `i64::MIN`. Compute in i128 and
-                // decline (None) unless the result still fits a wide, matching
-                // the "value past a wide → None" contract Add/Sub/Mul/Pow honour.
-                let shifted = i128::from(x) << (y as u32);
-                i64::try_from(shifted).ok().map(TclValue::Int)
+        // Shifts and bitwise — integer only (wide or bignum; exact).
+        BinOp::LShift => match (&a, &b) {
+            (TclValue::Int(0), TclValue::Int(y)) if *y >= 0 => Some(TclValue::Int(0)),
+            // The shift count is capped so a folded literal stays small
+            // (`1 << 100000` is a real Tcl value but not one worth
+            // materialising into source text — decline past the cap).
+            (TclValue::Int(_) | TclValue::Big(_), TclValue::Int(y)) if (0..=256).contains(y) => {
+                let x = a.to_bigint()?;
+                Some(TclValue::from_big(x << u32::try_from(*y).ok()?))
             }
-            // `0 << y` is 0 for any non-negative count (no overflow). A non-zero
-            // shift past a wide is a bignum, and a negative count is a Tcl
-            // error — both decline (fall through to `None`).
-            (TclValue::Int(0), TclValue::Int(y)) if y >= 64 => Some(TclValue::Int(0)),
             _ => None,
         },
-        BinOp::RShift => match (a, b) {
-            (TclValue::Int(x), TclValue::Int(y)) if y >= 0 => {
+        BinOp::RShift => match (&a, &b) {
+            (TclValue::Int(x), TclValue::Int(y)) if *y >= 0 => {
                 // At y == 64 the value has been fully shifted out, so an
                 // arithmetic right shift yields the sign bit replicated
                 // (0 for non-negative, -1 for negative). Executing `x >> 64`
                 // here would panic on shift-overflow in debug builds and mask
                 // to `x >> 0` in release. The boundary is therefore `>= 64`,
                 // not `> 64` (i64 has 64 bits).
-                if y >= 64 {
-                    Some(TclValue::Int(if x >= 0 { 0 } else { -1 }))
+                if *y >= 64 {
+                    Some(TclValue::Int(if *x >= 0 { 0 } else { -1 }))
                 } else {
                     Some(TclValue::Int(x >> y))
                 }
             }
+            (TclValue::Big(x), TclValue::Int(y)) if *y >= 0 => {
+                use num_traits::Signed;
+                // A count past the operand's width collapses to the sign.
+                match usize::try_from(*y) {
+                    Ok(count) if count <= x.bits() as usize => {
+                        Some(TclValue::from_big(x.clone() >> count))
+                    }
+                    _ => Some(TclValue::Int(if x.is_negative() { -1 } else { 0 })),
+                }
+            }
             _ => None,
         },
-        BinOp::BitAnd => match (a, b) {
-            (TclValue::Int(x), TclValue::Int(y)) => Some(TclValue::Int(x & y)),
-            _ => None,
-        },
-        BinOp::BitOr => match (a, b) {
-            (TclValue::Int(x), TclValue::Int(y)) => Some(TclValue::Int(x | y)),
-            _ => None,
-        },
-        BinOp::BitXor => match (a, b) {
-            (TclValue::Int(x), TclValue::Int(y)) => Some(TclValue::Int(x ^ y)),
-            _ => None,
-        },
+        BinOp::BitAnd => bitwise(&a, &b, |x, y| x & y, |x, y| x & y),
+        BinOp::BitOr => bitwise(&a, &b, |x, y| x | y, |x, y| x | y),
+        BinOp::BitXor => bitwise(&a, &b, |x, y| x ^ y, |x, y| x ^ y),
 
         // Numeric comparison — always returns Int(0) or Int(1). A NaN operand
         // is unordered: unequal to everything, ordered against nothing.
@@ -706,14 +781,70 @@ fn apply_binary(op: BinOp, a: TclValue, b: TclValue) -> Option<TclValue> {
     }
 }
 
-fn arith<F, G>(a: TclValue, b: TclValue, int_op: F, float_op: G) -> Option<TclValue>
+/// Integer-only bitwise operator over the wide/bignum tiers (`num-bigint`'s
+/// negative-operand semantics are two's-complement, matching Tcl).
+fn bitwise<F, B>(a: &TclValue, b: &TclValue, int_op: F, big_op: B) -> Option<TclValue>
+where
+    F: FnOnce(i64, i64) -> i64,
+    B: FnOnce(&num_bigint::BigInt, &num_bigint::BigInt) -> num_bigint::BigInt,
+{
+    match (a, b) {
+        (TclValue::Int(x), TclValue::Int(y)) => Some(TclValue::Int(int_op(*x, *y))),
+        (TclValue::Big(_) | TclValue::Int(_), TclValue::Big(_) | TclValue::Int(_)) => {
+            Some(TclValue::from_big(big_op(&a.to_bigint()?, &b.to_bigint()?)))
+        }
+        _ => None,
+    }
+}
+
+/// Whether a value's `f64` view is exact — always true for wides and floats
+/// (the wide→double rounding is C's own conversion), and true for a bignum
+/// only when the conversion round-trips. An inexact bignum→double declines
+/// the fold rather than depend on rounding-parity with `TclBignumToDouble`.
+fn big_to_f64_exact(v: &TclValue) -> bool {
+    match v {
+        TclValue::Big(b) => num_traits::FromPrimitive::from_f64(v.as_f64())
+            .is_some_and(|back: num_bigint::BigInt| back == *b),
+        TclValue::Int(_) | TclValue::Float(_) => true,
+    }
+}
+
+fn arith<F, B, G>(a: &TclValue, b: &TclValue, int_op: F, big_op: B, float_op: G) -> Option<TclValue>
 where
     F: FnOnce(i64, i64) -> Option<i64>,
+    B: FnOnce(&num_bigint::BigInt, &num_bigint::BigInt) -> num_bigint::BigInt,
     G: FnOnce(f64, f64) -> f64,
 {
     match (a, b) {
-        (TclValue::Int(x), TclValue::Int(y)) => int_op(x, y).map(TclValue::Int),
-        _ => Some(TclValue::Float(float_op(a.as_f64(), b.as_f64()))),
+        // Wide fast path; overflow promotes to the exact bignum tier
+        // (never wraps, never declines — C Tcl's seamless promotion).
+        (TclValue::Int(x), TclValue::Int(y)) => Some(match int_op(*x, *y) {
+            Some(r) => TclValue::Int(r),
+            None => TclValue::from_big(big_op(
+                &num_bigint::BigInt::from(*x),
+                &num_bigint::BigInt::from(*y),
+            )),
+        }),
+        // Any float operand contaminates to double arithmetic — including a
+        // bignum operand, with C's same double-conversion rounding. Two
+        // divergence guards (oracle-pinned):
+        // - a NaN *result* is C's "domain error" (`Inf - Inf`, `Inf * 0`),
+        //   and a NaN *operand* is "can't use non-numeric floating-point
+        //   value" — both decline (the NaN result covers both);
+        // - a bignum whose double conversion is inexact declines rather
+        //   than bet on rounding parity with C's `TclBignumToDouble`.
+        (TclValue::Float(_), _) | (_, TclValue::Float(_)) => {
+            if !big_to_f64_exact(a) || !big_to_f64_exact(b) {
+                return None;
+            }
+            let r = float_op(a.as_f64(), b.as_f64());
+            if r.is_nan() {
+                return None;
+            }
+            Some(TclValue::Float(r))
+        }
+        // At least one bignum, no float: exact arbitrary precision.
+        _ => Some(TclValue::from_big(big_op(&a.to_bigint()?, &b.to_bigint()?))),
     }
 }
 
@@ -738,6 +869,23 @@ fn numeric_cmp(a: TclValue, b: TclValue) -> Option<tcl_syntax::expr::NumericComp
             NumericCompare::Ordered(ord) => NumericCompare::Ordered(ord.reverse()),
             NumericCompare::Unordered => NumericCompare::Unordered,
         },
+        // Integer-vs-integer with a bignum side is exact at any width; a
+        // bignum is canonical (beyond i64), so against a wide only the sign
+        // matters and against a double the bignum's double view is what C
+        // compares (`mp_int` → double, same rounding).
+        (TclValue::Big(x), TclValue::Big(y)) => NumericCompare::Ordered(x.cmp(&y)),
+        (TclValue::Big(x), TclValue::Int(y)) => {
+            NumericCompare::Ordered(x.cmp(&num_bigint::BigInt::from(y)))
+        }
+        (TclValue::Int(x), TclValue::Big(y)) => {
+            NumericCompare::Ordered(num_bigint::BigInt::from(x).cmp(&y))
+        }
+        (TclValue::Big(x), TclValue::Float(y)) => {
+            NumericCompare::from_partial(TclValue::Big(x).as_f64().partial_cmp(&y))
+        }
+        (TclValue::Float(x), TclValue::Big(y)) => {
+            NumericCompare::from_partial(x.partial_cmp(&TclValue::Big(y).as_f64()))
+        }
     })
 }
 
@@ -757,19 +905,34 @@ fn int_vs_double(w: i64, d: f64) -> Option<tcl_syntax::expr::NumericCompare> {
     )
 }
 
-fn tcl_div(a: TclValue, b: TclValue) -> Option<TclValue> {
+fn tcl_div(a: &TclValue, b: &TclValue) -> Option<TclValue> {
+    use num_integer::Integer;
     match (a, b) {
         (TclValue::Int(_), TclValue::Int(0)) => None,
         (TclValue::Int(x), TclValue::Int(y)) => {
             // Floor division: r and y must have the same sign,
             // otherwise subtract 1 from the truncated quotient.
-            let q = x.checked_div(y)?;
-            let r = x.checked_rem(y)?;
-            if r != 0 && (r.signum() != y.signum()) {
-                Some(TclValue::Int(q.checked_sub(1)?))
-            } else {
-                Some(TclValue::Int(q))
+            // `i64::MIN / -1` overflows a wide — promote to the bignum tier
+            // like every other integer overflow.
+            match x.checked_div(*y) {
+                Some(q) => {
+                    let r = x.checked_rem(*y)?;
+                    if r != 0 && (r.signum() != y.signum()) {
+                        Some(TclValue::Int(q.checked_sub(1)?))
+                    } else {
+                        Some(TclValue::Int(q))
+                    }
+                }
+                None => Some(TclValue::from_big(
+                    num_bigint::BigInt::from(*x).div_floor(&num_bigint::BigInt::from(*y)),
+                )),
             }
+        }
+        // Exact floor division on the bignum tier — the shared tower
+        // semantics (`tcl_syntax::number_tower`).
+        (TclValue::Big(_) | TclValue::Int(_), TclValue::Big(_) | TclValue::Int(_)) => {
+            let (x, y) = (a.to_bigint()?, b.to_bigint()?);
+            tcl_syntax::number_tower::int_div(&x, &y).map(TclValue::from_big)
         }
         _ => {
             // A non-zero numerator over a zero divisor is Inf/-Inf, a real
@@ -788,23 +951,30 @@ fn tcl_div(a: TclValue, b: TclValue) -> Option<TclValue> {
     }
 }
 
-fn tcl_mod(a: TclValue, b: TclValue) -> Option<TclValue> {
+fn tcl_mod(a: &TclValue, b: &TclValue) -> Option<TclValue> {
     match (a, b) {
         (TclValue::Int(_), TclValue::Int(0)) => None,
         (TclValue::Int(x), TclValue::Int(y)) => {
-            // Sign follows divisor.
-            let r = x.checked_rem(y)?;
+            // Sign follows divisor. `i64::MIN % -1` overflows the checked
+            // rem — the true result is 0.
+            // `i64::MIN % -1` overflows the checked rem — the true result is 0.
+            let r = x.checked_rem(*y).unwrap_or_default();
             if r != 0 && (r.signum() != y.signum()) {
-                Some(TclValue::Int(r.checked_add(y)?))
+                Some(TclValue::Int(r.checked_add(*y)?))
             } else {
                 Some(TclValue::Int(r))
             }
+        }
+        // Floor modulus on the bignum tier — the shared tower semantics.
+        (TclValue::Big(_) | TclValue::Int(_), TclValue::Big(_) | TclValue::Int(_)) => {
+            let (x, y) = (a.to_bigint()?, b.to_bigint()?);
+            tcl_syntax::number_tower::int_mod(&x, &y).map(TclValue::from_big)
         }
         _ => None, // Tcl 9.0 rejects floats for `%`.
     }
 }
 
-fn tcl_pow(a: TclValue, b: TclValue) -> Option<TclValue> {
+fn tcl_pow(a: &TclValue, b: &TclValue) -> Option<TclValue> {
     if matches!(a, TclValue::Float(_)) || matches!(b, TclValue::Float(_)) {
         let fa = a.as_f64();
         let fb = b.as_f64();
@@ -820,45 +990,24 @@ fn tcl_pow(a: TclValue, b: TclValue) -> Option<TclValue> {
         }
         return Some(TclValue::Float(r));
     }
-    // Integer path.
-    let (TclValue::Int(x), TclValue::Int(y)) = (a, b) else {
-        return None;
+    // Integer path — the shared tower semantics (`INST_EXPON`'s collapses,
+    // the 2^28 exponent ceiling, exact bignum powers). The exponent must be
+    // a wide: a beyond-wide exponent with |base| > 1 is C's "exponent too
+    // large" runtime error, and with a negative bignum exponent the result
+    // collapses to 0 (base magnitude ≥ 2 by bignum canonicality).
+    let y = match b {
+        TclValue::Int(y) => *y,
+        TclValue::Big(yy) => {
+            return if num_traits::Signed::is_negative(yy) {
+                Some(TclValue::Int(0))
+            } else {
+                None
+            };
+        }
+        TclValue::Float(_) => return None,
     };
-    if y == 0 {
-        return Some(TclValue::Int(1));
-    }
-    if y == 1 {
-        return Some(TclValue::Int(x));
-    }
-    if x == 0 {
-        return if y < 0 { None } else { Some(TclValue::Int(0)) };
-    }
-    if x == 1 {
-        return Some(TclValue::Int(1));
-    }
-    if x == -1 {
-        return Some(TclValue::Int(if y % 2 == 0 { 1 } else { -1 }));
-    }
-    if y < 0 {
-        return Some(TclValue::Int(0));
-    }
-    if y > MAX_EXPONENT {
-        return None;
-    }
-    // Overflow-checked integer power.
-    let mut base = x;
-    let mut exp = y;
-    let mut acc: i64 = 1;
-    while exp > 0 {
-        if exp & 1 == 1 {
-            acc = acc.checked_mul(base)?;
-        }
-        exp >>= 1;
-        if exp > 0 {
-            base = base.checked_mul(base)?;
-        }
-    }
-    Some(TclValue::Int(acc))
+    let x = a.to_bigint()?;
+    tcl_syntax::number_tower::int_pow(&x, y).map(TclValue::from_big)
 }
 
 // Unary operators
@@ -1453,17 +1602,22 @@ mod tests {
 
     #[test]
     fn format_tcl_value_int_and_float() {
-        assert_eq!(format_tcl_value(TclValue::Int(42)), "42");
-        assert_eq!(format_tcl_value(TclValue::Int(-7)), "-7");
-        assert_eq!(format_tcl_value(TclValue::Float(1.5)), "1.5");
+        assert_eq!(format_tcl_value(&TclValue::Int(42)), "42");
+        assert_eq!(format_tcl_value(&TclValue::Int(-7)), "-7");
+        assert_eq!(format_tcl_value(&TclValue::Float(1.5)), "1.5");
         // Integer-valued floats render with trailing .0.
-        assert_eq!(format_tcl_value(TclValue::Float(3.0)), "3.0");
+        assert_eq!(format_tcl_value(&TclValue::Float(3.0)), "3.0");
     }
 
     #[test]
-    fn overflow_returns_none() {
-        // 10 ** 100 overflows i64.
-        assert_eq!(eval_str("10 ** 100"), None);
+    fn overflow_promotes_to_exact_bignum() {
+        // 10 ** 100 overflows a wide: C Tcl promotes to a bignum and so does
+        // the folder (P4, type-tracking.md) — exactly, never wrapped.
+        let want = format!("1{}", "0".repeat(100));
+        assert_eq!(
+            eval_str("10 ** 100").map(|v| format_tcl_value(&v)),
+            Some(want)
+        );
     }
 
     // -- matches_regex is never constant-folded --
@@ -1649,14 +1803,23 @@ mod tests {
     }
 
     #[test]
-    fn lshift_overflowing_a_wide_declines() {
-        // RUST_ISSUE_069: `1 << 63` overflows a wide (Tcl → bignum
-        // 9223372036854775808), so the folder must decline, not fold the
-        // wrapped `i64::MIN`.
-        assert_eq!(eval_str("1 << 63"), None); // (TP) declines
-        assert_eq!(eval_str("1 << 64"), None); // past a wide → declines
-        assert_eq!(eval_str("2 << 62"), None); // 2^63 → declines
-        // (TN / FP-guard) In-range shifts still fold to the exact value.
+    fn lshift_overflowing_a_wide_promotes_exactly() {
+        // RUST_ISSUE_069 → P4: `1 << 63` overflows a wide; Tcl promotes to
+        // the bignum 9223372036854775808 and the folder now computes it
+        // exactly (never the wrapped `i64::MIN`).
+        assert_eq!(
+            eval_str("1 << 63").map(|v| format_tcl_value(&v)),
+            Some("9223372036854775808".to_owned())
+        );
+        assert_eq!(
+            eval_str("1 << 64").map(|v| format_tcl_value(&v)),
+            Some("18446744073709551616".to_owned())
+        );
+        assert_eq!(
+            eval_str("2 << 62").map(|v| format_tcl_value(&v)),
+            Some("9223372036854775808".to_owned())
+        );
+        // (TN / FP-guard) In-range shifts still fold to the exact wide.
         assert_eq!(eval_str("1 << 62"), Some(TclValue::Int(1i64 << 62)));
         assert_eq!(eval_str("1 << 0"), Some(TclValue::Int(1)));
         assert_eq!(eval_str("3 << 4"), Some(TclValue::Int(48)));
@@ -1665,6 +1828,155 @@ mod tests {
         assert_eq!(eval_str("0 << 100"), Some(TclValue::Int(0)));
         // A negative-magnitude shift that stays in range folds normally.
         assert_eq!(eval_str("-1 << 4"), Some(TclValue::Int(-16)));
+        // A count past the smallness cap declines — a folded literal of
+        // thousands of digits helps nobody.
+        assert_eq!(eval_str("1 << 100000"), None);
+    }
+
+    /// NaN in a boolean context is a C Tcl domain error ("floating point
+    /// value is Not a Number"), so the folder declines — it must never pick
+    /// a truth value (tclsh-verified; `Inf` IS truthy).
+    #[test]
+    fn nan_in_boolean_context_declines() {
+        assert_eq!(eval_str("NaN ? 1 : 0"), None);
+        assert_eq!(eval_str("!NaN"), None);
+        assert_eq!(eval_str("NaN && 1"), None);
+        assert_eq!(eval_str("Inf ? 1 : 0"), Some(TclValue::Int(1)));
+        assert_eq!(eval_str("!Inf"), Some(TclValue::Int(0)));
+    }
+
+    /// The float-edge oracle table (tclsh 8.6.14; 9.0 agrees). Errors fold
+    /// to `None`; values fold to C's exact canonical text:
+    ///
+    /// ```text
+    /// NaN + 1      => error (non-numeric operand)      -NaN / +NaN => error
+    /// NaN == NaN   => 0     NaN != 1.0 => 1   NaN < 1 => 0   (IEEE unordered,
+    ///                                                          NOT an error)
+    /// Inf - Inf    => error (domain)   Inf * 0 => error (domain)
+    /// Inf + 1      => Inf   -Inf * -1 => Inf   Inf == Inf => 1
+    /// 5.0 / 0      => Inf   -5.0 / 0 => -Inf   0.0/0.0 => error
+    /// 1e309        => Inf   4.9e-324 => 5e-324 (denormal round-trip)
+    /// -0.0         => -0.0  0.0 == -0.0 => 1   -0.0 + 0.0 => 0.0
+    /// isqrt(4611686018427387903) => 2147483647 (exact, not the f64 2^31)
+    /// ```
+    #[test]
+    fn float_edge_oracle_table() {
+        let fold = |e: &str| eval_str(e).map(|v| format_tcl_value(&v));
+        // NaN in arithmetic / unary: operand errors — decline.
+        assert_eq!(eval_str("NaN + 1"), None);
+        assert_eq!(eval_str("-NaN"), None);
+        assert_eq!(eval_str("+NaN"), None);
+        // NaN in comparisons: IEEE unordered values, NOT errors.
+        assert_eq!(eval_str("NaN == NaN"), Some(TclValue::Int(0)));
+        assert_eq!(eval_str("NaN != 1.0"), Some(TclValue::Int(1)));
+        assert_eq!(eval_str("NaN < 1"), Some(TclValue::Int(0)));
+        // NaN results are domain errors — decline.
+        assert_eq!(eval_str("Inf - Inf"), None);
+        assert_eq!(eval_str("Inf * 0"), None);
+        // Inf propagates as a real value.
+        assert_eq!(fold("Inf + 1"), Some("Inf".into()));
+        assert_eq!(fold("-Inf * -1"), Some("Inf".into()));
+        assert_eq!(eval_str("Inf == Inf"), Some(TclValue::Int(1)));
+        assert_eq!(
+            eval_str("Inf > 9223372036854775807"),
+            Some(TclValue::Int(1))
+        );
+        // Float division by (any) zero: ±Inf; 0.0/0.0 is the domain error.
+        assert_eq!(fold("5.0 / 0"), Some("Inf".into()));
+        assert_eq!(fold("-5.0 / 0"), Some("-Inf".into()));
+        assert_eq!(eval_str("0.0 / 0.0"), None);
+        // Overflowing literals parse to Inf; denormals round-trip.
+        assert_eq!(fold("1e309"), Some("Inf".into()));
+        assert_eq!(fold("4.9e-324"), Some("5e-324".into()));
+        assert_eq!(fold("1e-330"), Some("0.0".into()));
+        // Signed zero.
+        assert_eq!(fold("-0.0"), Some("-0.0".into()));
+        assert_eq!(eval_str("0.0 == -0.0"), Some(TclValue::Int(1)));
+        assert_eq!(fold("-0.0 + 0.0"), Some("0.0".into()));
+        // Exact integer square root at the f64-rounding edge.
+        assert_eq!(
+            eval_str("isqrt(4611686018427387903)"),
+            Some(TclValue::Int(2_147_483_647))
+        );
+        assert_eq!(
+            eval_str("isqrt(9223372036854775806)"),
+            Some(TclValue::Int(3_037_000_499))
+        );
+        // int()/round() beyond a wide: int() is dialect-divergent (8.6 wraps
+        // mod 2^64, 9.0 is exact) — decline; int(Inf)/int(NaN) are errors.
+        assert_eq!(eval_str("int(1e300)"), None);
+        assert_eq!(eval_str("int(Inf)"), None);
+        assert_eq!(eval_str("int(NaN)"), None);
+    }
+
+    /// The P4 oracle corpus (tclsh 8.6.14/9.0-verified values from
+    /// type-tracking.md): exact integer arithmetic at and beyond the wide
+    /// boundary, floor div/mod, double contamination, and bignum demotion.
+    #[test]
+    fn bignum_oracle_corpus() {
+        let fold = |e: &str| eval_str(e).map(|v| format_tcl_value(&v));
+        // Exact integer arithmetic at 2^53 (f64 would merge these).
+        assert_eq!(
+            fold("9007199254740992 + 1"),
+            Some("9007199254740993".into())
+        );
+        // One double operand contaminates — with f64's genuine rounding.
+        assert_eq!(
+            fold("9007199254740992 + 1.0"),
+            Some("9007199254740992.0".into())
+        );
+        // Wide → bignum promotion by result magnitude.
+        assert_eq!(fold("2 ** 64"), Some("18446744073709551616".into()));
+        assert_eq!(
+            fold("9223372036854775807 + 1"),
+            Some("9223372036854775808".into())
+        );
+        assert_eq!(
+            fold("9223372036854775807 * 2"),
+            Some("18446744073709551614".into())
+        );
+        // Bignum arithmetic is exact, and demotes back to a wide when the
+        // result fits.
+        assert_eq!(
+            fold("18446744073709551616 + 1"),
+            Some("18446744073709551617".into())
+        );
+        assert_eq!(
+            eval_str("18446744073709551616 - 18446744073709551616"),
+            Some(TclValue::Int(0))
+        );
+        // Floor division / modulus, both tiers.
+        assert_eq!(eval_str("7 / 2"), Some(TclValue::Int(3)));
+        assert_eq!(eval_str("-7 / 2"), Some(TclValue::Int(-4)));
+        assert_eq!(eval_str("-7 % 2"), Some(TclValue::Int(1)));
+        assert_eq!(
+            fold("-18446744073709551616 / 3"),
+            Some("-6148914691236517206".into())
+        );
+        assert_eq!(eval_str("18446744073709551617 % 2"), Some(TclValue::Int(1)));
+        // Negation off the wide edge promotes; double negation demotes back.
+        assert_eq!(
+            fold("0 - (-9223372036854775807 - 1)"),
+            Some("9223372036854775808".into())
+        );
+        // Bignum comparisons are exact (distinct beyond-2^53 values).
+        assert_eq!(
+            eval_str("18446744073709551617 > 18446744073709551616"),
+            Some(TclValue::Int(1))
+        );
+        assert_eq!(
+            eval_str("9007199254740993 == 9007199254740992"),
+            Some(TclValue::Int(0))
+        );
+        // Bitwise on the bignum tier (two's-complement).
+        assert_eq!(
+            fold("18446744073709551616 | 1"),
+            Some("18446744073709551617".into())
+        );
+        assert_eq!(
+            fold("~18446744073709551616"),
+            Some("-18446744073709551617".into())
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/src/tcl_expr_eval.rs
@@ -880,13 +880,48 @@ fn numeric_cmp(a: TclValue, b: TclValue) -> Option<tcl_syntax::expr::NumericComp
         (TclValue::Int(x), TclValue::Big(y)) => {
             NumericCompare::Ordered(num_bigint::BigInt::from(x).cmp(&y))
         }
-        (TclValue::Big(x), TclValue::Float(y)) => {
-            NumericCompare::from_partial(TclValue::Big(x).as_f64().partial_cmp(&y))
-        }
-        (TclValue::Float(x), TclValue::Big(y)) => {
-            NumericCompare::from_partial(x.partial_cmp(&TclValue::Big(y).as_f64()))
-        }
+        (TclValue::Big(x), TclValue::Float(y)) => big_vs_double(&x, y),
+        (TclValue::Float(x), TclValue::Big(y)) => match big_vs_double(&y, x) {
+            NumericCompare::Ordered(o) => NumericCompare::Ordered(o.reverse()),
+            NumericCompare::Unordered => NumericCompare::Unordered,
+        },
     })
+}
+
+/// Exact bignum-vs-double comparison — C converts the double to a bignum
+/// (`Tcl_InitBignumFromDouble`) and compares exactly, so
+/// `18446744073709551617 == 1.8446744073709552e19` is FALSE even though the
+/// bignum's rounded double view equals the float. NaN is unordered; ±Inf
+/// orders past every integer; a finite double compares by exact integer
+/// part with the fraction as tiebreak.
+fn big_vs_double(x: &num_bigint::BigInt, d: f64) -> tcl_syntax::expr::NumericCompare {
+    use std::cmp::Ordering;
+    use tcl_syntax::expr::NumericCompare;
+    if d.is_nan() {
+        return NumericCompare::Unordered;
+    }
+    if d.is_infinite() {
+        return NumericCompare::Ordered(if d > 0.0 {
+            Ordering::Less
+        } else {
+            Ordering::Greater
+        });
+    }
+    let trunc = <num_bigint::BigInt as num_traits::FromPrimitive>::from_f64(d.trunc())
+        .expect("finite double truncation is an exact integer");
+    match x.cmp(&trunc) {
+        Ordering::Equal => {
+            let frac = d.fract();
+            NumericCompare::Ordered(if frac > 0.0 {
+                Ordering::Less
+            } else if frac < 0.0 {
+                Ordering::Greater
+            } else {
+                Ordering::Equal
+            })
+        }
+        other => NumericCompare::Ordered(other),
+    }
 }
 
 /// Exact wide-vs-double comparison, declining (`None`) in the C-UB sliver
@@ -998,7 +1033,24 @@ fn tcl_pow(a: &TclValue, b: &TclValue) -> Option<TclValue> {
     let y = match b {
         TclValue::Int(y) => *y,
         TclValue::Big(yy) => {
-            return if num_traits::Signed::is_negative(yy) {
+            use num_traits::{One, Signed, Zero};
+            // The 0 / ±1 base collapses hold for ANY exponent magnitude and
+            // precede the negative-exponent rule: `0 ** -big` is C's
+            // domain error (decline the fold so it surfaces), `1 ** ±big`
+            // is 1, `(-1) ** ±big` is ±1 by exponent parity. Only then
+            // does |base| ≥ 2 collapse a negative exponent to 0.
+            let xb = a.to_bigint()?;
+            if xb.is_zero() {
+                return None;
+            }
+            if xb.is_one() {
+                return Some(TclValue::Int(1));
+            }
+            if (-&xb).is_one() {
+                let even = (yy % 2u8).is_zero();
+                return Some(TclValue::Int(if even { 1 } else { -1 }));
+            }
+            return if yy.is_negative() {
                 Some(TclValue::Int(0))
             } else {
                 None
@@ -1054,6 +1106,35 @@ fn apply_irules_string_op(op: BinOp, left: &str, right: &str) -> Option<TclValue
 
 #[cfg(test)]
 mod tests {
+    /// Adversarial-review regressions (tclsh 8.6/9.0 verified): exact
+    /// bignum↔double comparison folds, the `**` base collapses for bignum
+    /// exponents, and NaN branch conditions declining.
+    #[test]
+    fn adversarial_fold_regressions() {
+        // B7: C compares a bignum and a double EXACTLY — never through the
+        // bignum's rounded double view.
+        assert_eq!(
+            eval_str("18446744073709551617 == 1.8446744073709552e19"),
+            Some(TclValue::Int(0)),
+            "exact compare: 2^64+1 != its rounded double"
+        );
+        assert_eq!(
+            eval_str("18446744073709551617 > 1.8446744073709552e19"),
+            Some(TclValue::Int(1))
+        );
+        assert_eq!(eval_str("10**308 == 1e308"), Some(TclValue::Int(0)));
+        assert_eq!(eval_str("(2**1024) == inf"), Some(TclValue::Int(0)));
+        // B8: 0/±1 base collapses precede the negative-bignum-exponent rule.
+        assert_eq!(
+            eval_str("0**(-(2**64))"),
+            None,
+            "0 ** -big is a runtime domain error — never fold"
+        );
+        assert_eq!(eval_str("1**(-(2**64))"), Some(TclValue::Int(1)));
+        assert_eq!(eval_str("(-1)**(-(2**64))"), Some(TclValue::Int(1)));
+        assert_eq!(eval_str("(-1)**(-(2**64)-1)"), Some(TclValue::Int(-1)));
+    }
+
     use super::*;
     use crate::expr_parser::parse_expr;
 

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -44,15 +44,20 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use tcl_dialect::DialectSet;
-use tcl_registry::{CommandRegistry, TclType, VarWriteTyping};
+use tcl_registry::{CommandRegistry, ReturnElements, TclType, VarElementsEffect, VarWriteTyping};
 
+use crate::analyses::{ConstValue, LatticeValue};
 use crate::cfg::{BlockId, Function as CfgFunction, Terminator};
 use crate::expr_ast::{BinOp, ExprNode, UnaryOp};
 use crate::ir::Statement;
 use crate::naming::normalise_var_name;
 use crate::sccp::SccpResult;
+use crate::shimmer::hints::is_pure_intrep;
 use crate::ssa::{SsaFunction, Symbol, ValueKey};
-use crate::types::{TypeKind, TypeLattice, type_join};
+use crate::types::{
+    Elements, MAX_EXACT_ELEMENTS, TypeKind, TypeLattice, TypeShape, join_elements, shape_join,
+    type_join,
+};
 use crate::value_shapes::{is_pure_var_ref, parse_command_substitution};
 
 // Float literal pattern: requires a decimal point so that forms like `1e3`
@@ -62,39 +67,68 @@ fn looks_like_float(s: &str) -> bool {
     s.contains('.') && s.parse::<f64>().is_ok()
 }
 
-const BOOL_LITERALS: &[&str] = &["true", "false", "yes", "no", "on", "off"];
-
-/// True when `s` is a Tcl integer literal: decimal, or a `0x`/`0X` hex or
-/// `0b`/`0B` binary form (each optionally signed).  Hex/binary store an INT
-/// intrep (`set n 0x80; incr n` is one clean parse, not per-iteration
-/// shimmer), while `0o` octal stays STRING (the set-statement classifier
-/// excludes it).
+/// The integer-tower shape of a Tcl integer literal: decimal, or a `0x`/`0X`
+/// hex or `0b`/`0B` binary form (each optionally signed) — [`TypeShape::Int`]
+/// when the value fits a wide (`i64`), [`TypeShape::Bignum`] beyond it
+/// (`9223372036854775808`, `0xFFFFFFFFFFFFFFFF` — promotion is by magnitude,
+/// never wrapping; oracle corpus in type-tracking.md). `None` when the text
+/// is not an integer literal of these spellings — `0o` octal deliberately
+/// stays out (the set-statement classifier keeps it `String`, its canonical
+/// stringified intrep differing from the source text).
 #[must_use]
-fn is_tcl_int_literal(s: &str) -> bool {
+fn int_literal_shape(s: &str) -> Option<TypeShape> {
     if s.parse::<i64>().is_ok() {
-        return true;
+        return Some(TypeShape::Int);
     }
-    let body = s.strip_prefix(['+', '-']).unwrap_or(s);
-    if let Some(h) = body.strip_prefix("0x").or_else(|| body.strip_prefix("0X")) {
-        return !h.is_empty() && h.bytes().all(|c| c.is_ascii_hexdigit());
+    let (negative, body) = match s.strip_prefix(['+', '-']) {
+        Some(rest) => (s.starts_with('-'), rest),
+        None => (false, s),
+    };
+    let radix_body = |prefix_lower: &str, prefix_upper: &str| {
+        body.strip_prefix(prefix_lower)
+            .or_else(|| body.strip_prefix(prefix_upper))
+    };
+    let (digits, radix, valid): (&str, u32, fn(u8) -> bool) =
+        if let Some(h) = radix_body("0x", "0X") {
+            (h, 16, |c: u8| c.is_ascii_hexdigit())
+        } else if let Some(b) = radix_body("0b", "0B") {
+            (b, 2, |c: u8| matches!(c, b'0' | b'1'))
+        } else if !body.is_empty() && body.bytes().all(|c| c.is_ascii_digit()) {
+            // All-digit decimal that failed the i64 parse above: beyond a
+            // wide — the bignum rung.
+            return Some(TypeShape::Bignum);
+        } else {
+            return None;
+        };
+    if digits.is_empty() || !digits.bytes().all(valid) {
+        return None;
     }
-    if let Some(b) = body.strip_prefix("0b").or_else(|| body.strip_prefix("0B")) {
-        return !b.is_empty() && b.bytes().all(|c| matches!(c, b'0' | b'1'));
-    }
-    false
+    // A radix literal that fits i64 (sign applied) is a wide; a wider
+    // magnitude is a bignum.
+    let signed = if negative {
+        format!("-{digits}")
+    } else {
+        digits.to_owned()
+    };
+    Some(if i64::from_str_radix(&signed, radix).is_ok() {
+        TypeShape::Int
+    } else {
+        TypeShape::Bignum
+    })
 }
 
 /// Classify a literal string as its Tcl intrep type (set-statement context).
 fn literal_type(text: &str) -> TypeLattice {
     let s = text.trim();
-    if is_tcl_int_literal(s) {
-        return TypeLattice::of(TclType::Int);
+    if let Some(shape) = int_literal_shape(s) {
+        return TypeLattice::of_shape(shape);
     }
     if looks_like_float(s) {
         return TypeLattice::of(TclType::Double);
     }
-    // Case-insensitive boolean check.
-    if BOOL_LITERALS.contains(&s.to_ascii_lowercase().as_str()) {
+    // Case-insensitive boolean check (full spellings — the literal
+    // classifier's would-commit convention; prefixes commit only at use).
+    if tcl_syntax::boolean::is_boolean_full_word(s) {
         return TypeLattice::of(TclType::Boolean);
     }
     TypeLattice::of(TclType::String)
@@ -112,16 +146,25 @@ fn literal_type(text: &str) -> TypeLattice {
 fn expr_literal_type(text: &str) -> TypeLattice {
     let s = text.trim();
     let low = s.to_ascii_lowercase();
-    // Boolean first.
-    if BOOL_LITERALS.contains(&low.as_str()) {
+    // Boolean first (full spellings — see `literal_type`).
+    if tcl_syntax::boolean::is_boolean_full_word(s) {
         return TypeLattice::of(TclType::Boolean);
     }
-    // Every integer-form spelling tokenises to int in expr context.
-    if low.starts_with("0x") || low.starts_with("0o") || low.starts_with("0b") {
-        return TypeLattice::of(TclType::Int);
+    // Every integer-form spelling tokenises to an integer in expr context;
+    // the tower rung (wide vs bignum) follows the magnitude. `0o` octal —
+    // absent from the set-statement classifier — is an integer here, so it
+    // routes through the shared number grammar.
+    if let Some(shape) = int_literal_shape(s) {
+        return TypeLattice::of_shape(shape);
     }
-    if s.parse::<i64>().is_ok() {
-        return TypeLattice::of(TclType::Int);
+    if low.starts_with("0o") {
+        return match tcl_syntax::number::parse_whole(s) {
+            Some(tcl_syntax::number::Number::Int(_)) => TypeLattice::of(TclType::Int),
+            Some(tcl_syntax::number::Number::Big { .. }) => {
+                TypeLattice::of_shape(TypeShape::Bignum)
+            }
+            _ => TypeLattice::of(TclType::Numeric),
+        };
     }
     if s.parse::<f64>().is_ok() {
         return TypeLattice::of(TclType::Double);
@@ -295,7 +338,7 @@ fn infer_expr_type(node: &ExprNode, var_types: &HashMap<String, TypeLattice>) ->
                 BinOp::Add | BinOp::Sub | BinOp::Mul | BinOp::Div | BinOp::Mod | BinOp::Pow => {
                     let lt = infer_expr_type(left, var_types);
                     let rt = infer_expr_type(right, var_types);
-                    if lt.kind == TypeKind::Known && rt.kind == TypeKind::Known {
+                    if lt.kind() == TypeKind::Known && rt.kind() == TypeKind::Known {
                         arithmetic_result(&lt, &rt)
                     } else {
                         TypeLattice::of(TclType::Numeric)
@@ -343,7 +386,7 @@ fn infer_expr_type(node: &ExprNode, var_types: &HashMap<String, TypeLattice>) ->
 /// (boolean counts as int), DOUBLE anywhere → DOUBLE, otherwise
 /// NUMERIC.  Callers guarantee both operand types are `Known`.
 fn arithmetic_result(lt: &TypeLattice, rt: &TypeLattice) -> TypeLattice {
-    match (lt.tcl_type, rt.tcl_type) {
+    match (lt.tcl_type(), rt.tcl_type()) {
         (Some(TclType::Int | TclType::Boolean), Some(TclType::Int | TclType::Boolean)) => {
             TypeLattice::of(TclType::Int)
         }
@@ -436,119 +479,347 @@ fn lookup_var_type(
     types.get(&(sym, ver)).cloned()
 }
 
-/// The object class an argument *text* provably denotes: a
-/// `[Class new|create …]` constructor, or a `$var` whose tracked type is
-/// `OBJECT(class)`.  `None` when the text is not provably a single object —
-/// the signal that harvests the element class of an object collection.
-fn arg_object_class<S: std::hash::BuildHasher>(
-    text: &str,
-    uses: &HashMap<Symbol, u32>,
-    types: &HashMap<ValueKey, TypeLattice>,
-    ssa: &SsaFunction,
-    registry: &CommandRegistry,
-    known_classes: &HashSet<String, S>,
-    namespace: &str,
-) -> Option<String> {
-    let stripped = text.trim();
-    if is_pure_var_ref(stripped) {
-        let t = lookup_var_type(normalise_var_name(stripped), uses, types, ssa)?;
-        return (t.tcl_type == Some(TclType::Object))
-            .then_some(t.class_name)
-            .flatten();
-    }
-    if stripped.starts_with('[')
-        && stripped.ends_with(']')
-        && let Some((cmd, args)) = parse_command_substitution(stripped)
-    {
-        let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-        let t = return_type_for_command(registry, &cmd, &arg_refs, known_classes, namespace);
-        if t.tcl_type == Some(TclType::Object)
-            && let Some(class) = t.class_name
-        {
-            return Some(class);
+/// Shared, read-only context for the word-shape / element-inference helpers —
+/// everything a value word's type depends on at one program point.
+struct WordTypingCtx<'a, S: std::hash::BuildHasher> {
+    uses: &'a HashMap<Symbol, u32>,
+    types: &'a HashMap<ValueKey, TypeLattice>,
+    /// SCCP constants at this point — purity evidence (a numeric-typed
+    /// literal is still a pure string) and constant list/index values for
+    /// element facts.
+    values: &'a HashMap<ValueKey, LatticeValue>,
+    registry: &'a CommandRegistry,
+    known_classes: &'a HashSet<String, S>,
+    namespace: &'a str,
+    ssa: &'a SsaFunction,
+}
+
+impl<S: std::hash::BuildHasher> WordTypingCtx<'_, S> {
+    /// The SCCP constant of `name` at this site, when tracked.
+    fn const_of(&self, name: &str) -> Option<&LatticeValue> {
+        let sym = self.ssa.var_symbol(name)?;
+        let ver = *self.uses.get(&sym)?;
+        if ver == 0 {
+            return None;
         }
-        // A registry-modelled `[Class new|create]` factory is not typed through
-        // `return_type_for_command` (the class is a registered command, not a
-        // `known_classes` name), so resolve its declared object class directly.
-        if args.first().is_some_and(|a| a == "new" || a == "create") {
-            return registry
-                .object_class(&cmd)
-                .map(|c| c.class_name.to_string());
+        self.values.get(&(sym, ver))
+    }
+}
+
+/// The shape a builder argument *word* contributes as a container element,
+/// or `None` when no shape claim is defensible for downstream checks.
+///
+/// Faithful to the runtime's by-reference elements (oracle corpus,
+/// type-tracking.md): a container shares its argument objects, so a
+/// **committed** source keeps its intrep inside the container —
+/// `[list [expr {2**20}] x]` genuinely holds an int, `[list [C new]]` an
+/// object. A **pure** source (a literal word, an interpolation, a
+/// still-pure variable, a string-returning command) contributes a pure
+/// string whose downstream conversion validity depends on its *value* — a
+/// fact the type lattice cannot carry per element — so those positions stay
+/// agnostic rather than invite the FP classes either concrete claim brings
+/// (FP-SH-17 pins `lassign {1 2 3}` targets silent in both arithmetic and
+/// string comparisons). The purity split is [`is_pure_intrep`] — the same
+/// predicate the shimmer suppression uses.
+fn element_word_shape<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
+    word: &str,
+) -> Option<TypeShape> {
+    let stripped = word.trim();
+    if stripped.starts_with("{*}") {
+        return None;
+    }
+    if is_pure_var_ref(stripped) {
+        let name = normalise_var_name(stripped);
+        let t = lookup_var_type(name, ctx.uses, ctx.types, ctx.ssa)?;
+        let shape = t.single_shape()?.clone();
+        if is_pure_intrep(shape.coarse(), ctx.const_of(name)) {
+            return None;
+        }
+        return Some(shape);
+    }
+    if stripped.starts_with('[') && stripped.ends_with(']') {
+        let shape = value_word_type(ctx, stripped).single_shape()?.clone();
+        // A string-returning command (`string trim`, `format`) yields a pure
+        // result — no committed intrep enters the container.
+        if is_pure_intrep(shape.coarse(), None) {
+            return None;
+        }
+        return Some(shape);
+    }
+    // Bare literal or interpolation: a fresh pure string object of known
+    // spelling but per-element-untracked value.
+    None
+}
+
+/// Element facts for a builder's result, per the registry's
+/// [`ReturnElements`] declaration. `None` when the fact does not apply to
+/// this call shape (a multi-level `dict get`, an unknown container).
+fn return_elements_lattice<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
+    fact: ReturnElements,
+    args: &[&str],
+) -> Option<TypeLattice> {
+    match fact {
+        ReturnElements::ListOfArgs { from } => {
+            let words = args.get(usize::from(from)..).unwrap_or(&[]);
+            Some(TypeLattice::of_shape(TypeShape::List(
+                build_exact_elements(ctx, words),
+            )))
+        }
+        ReturnElements::DictOfPairs { from } => {
+            let words = args.get(usize::from(from)..).unwrap_or(&[]);
+            // Values are the odd offsets of the key/value pairs.
+            let value_words: Vec<&str> = words.iter().skip(1).step_by(2).copied().collect();
+            Some(TypeLattice::of_shape(TypeShape::Dict(uniform_elements_of(
+                ctx,
+                &value_words,
+            ))))
+        }
+        ReturnElements::ElementOf { container_arg } => {
+            // Single-step retrieval only: exactly one index/key word after
+            // the container (`lindex $l $i`, `dict get $d $k`).
+            let container_idx = usize::from(container_arg);
+            if args.len() != container_idx + 2 {
+                return None;
+            }
+            let container = args.get(container_idx)?;
+            if !is_pure_var_ref(container) {
+                return None;
+            }
+            let name = normalise_var_name(container);
+            let t = lookup_var_type(name, ctx.uses, ctx.types, ctx.ssa)?;
+            let elements = t.elements()?;
+            // A constant integer index resolves an Exact position; any
+            // other index falls back to the uniform bound.
+            let index_word = args.get(container_idx + 1)?;
+            let shape = constant_index(ctx, index_word)
+                .and_then(|i| elements.shape_at(i).cloned())
+                .or_else(|| elements.uniform_shape())?;
+            Some(TypeLattice::of_shape(shape))
+        }
+        ReturnElements::SubListOf { container_arg } => {
+            let container = args.get(usize::from(container_arg))?;
+            if !is_pure_var_ref(container) {
+                return None;
+            }
+            let name = normalise_var_name(container);
+            let elements = lookup_var_type(name, ctx.uses, ctx.types, ctx.ssa)?
+                .elements()?
+                .uniform_shape()
+                .map_or(Elements::Unknown, |u| Elements::Uniform(Box::new(u)));
+            Some(TypeLattice::of_shape(TypeShape::List(elements)))
+        }
+    }
+}
+
+/// `Exact` per-position elements for a builder's argument words, widening to
+/// a uniform bound (or no facts) past [`MAX_EXACT_ELEMENTS`] or on an
+/// `{*}`-expansion word (whose element count is unknown).
+fn build_exact_elements<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
+    words: &[&str],
+) -> Elements {
+    if words.iter().any(|w| w.trim().starts_with("{*}")) {
+        return uniform_elements_of(ctx, words);
+    }
+    if words.len() > MAX_EXACT_ELEMENTS {
+        return uniform_elements_of(ctx, words);
+    }
+    Elements::Exact(words.iter().map(|w| element_word_shape(ctx, w)).collect())
+}
+
+/// The uniform element bound of a word set: the single-shape join of every
+/// word's shape, or no facts when any word is shapeless / unjoinable.
+fn uniform_elements_of<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
+    words: &[&str],
+) -> Elements {
+    let mut acc: Option<TypeShape> = None;
+    for word in words {
+        // `{*}$expansion` contributes its *list's* element shapes, which are
+        // unknown here — no uniform claim survives.
+        let word = word.trim();
+        let shape = if let Some(expanded) = word.strip_prefix("{*}") {
+            let Some(TypeShape::List(elements)) = (if is_pure_var_ref(expanded) {
+                lookup_var_type(normalise_var_name(expanded), ctx.uses, ctx.types, ctx.ssa)
+                    .and_then(|t| t.single_shape().cloned())
+            } else {
+                None
+            }) else {
+                return Elements::Unknown;
+            };
+            match elements.uniform_shape() {
+                Some(u) => u,
+                None => return Elements::Unknown,
+            }
+        } else {
+            match element_word_shape(ctx, word) {
+                Some(s) => s,
+                None => return Elements::Unknown,
+            }
+        };
+        acc = Some(match acc {
+            None => shape,
+            Some(prev) => match shape_join(&prev, &shape) {
+                Some(joined) => joined,
+                None => return Elements::Unknown,
+            },
+        });
+    }
+    match acc {
+        Some(shape) => Elements::Uniform(Box::new(shape)),
+        None => Elements::Unknown,
+    }
+}
+
+/// The constant element index a retrieval word denotes: a literal integer
+/// (`lindex $l 0`) or a `$var` whose SCCP constant is an integer.
+fn constant_index<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
+    word: &str,
+) -> Option<usize> {
+    let word = word.trim();
+    if let Ok(i) = word.parse::<usize>() {
+        return Some(i);
+    }
+    if is_pure_var_ref(word)
+        && let Some(LatticeValue::Const(ConstValue::Int(i))) =
+            ctx.const_of(normalise_var_name(word))
+    {
+        return usize::try_from(*i).ok();
+    }
+    None
+}
+
+/// The evolved container shape after an in-place element write —
+/// `lappend var v…` / `dict set var … v` — per the registry's
+/// [`VarElementsEffect`]. Generalises the old object-only element-class
+/// harvesting: every element shape flows, so `lappend l [C new]` still
+/// yields `List<OBJECT(C)*>` and `lappend l [list 1]` now yields real
+/// element facts too.
+fn var_elements_effect_lattice<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
+    effect: VarElementsEffect,
+    target: &str,
+    args: &[&str],
+    base: usize,
+) -> TypeLattice {
+    let (container_ctor, value_words): (fn(Elements) -> TypeShape, &[&str]) = match effect {
+        VarElementsEffect::AppendsListElements { values_from } => (
+            TypeShape::List,
+            args.get(base + usize::from(values_from)..).unwrap_or(&[]),
+        ),
+        VarElementsEffect::SetsDictValue => (
+            TypeShape::Dict,
+            args.len()
+                .checked_sub(1)
+                .map_or(&[][..], |last| &args[last..]),
+        ),
+        VarElementsEffect::ExtendsDictValues { values_from } => (
+            TypeShape::Dict,
+            args.get(base + usize::from(values_from)..).unwrap_or(&[]),
+        ),
+    };
+
+    let prior = prior_container_elements(ctx, target);
+    let evolved = match effect {
+        VarElementsEffect::AppendsListElements { .. } => {
+            append_list_elements(ctx, prior, value_words)
+        }
+        // Dict values: join the new values into the prior uniform bound —
+        // per-key tracking is out of scope (documented in type-tracking.md).
+        VarElementsEffect::SetsDictValue | VarElementsEffect::ExtendsDictValues { .. } => {
+            let incoming = uniform_elements_of(ctx, value_words);
+            match prior {
+                Some(prior) => join_elements(&prior, &incoming),
+                None => incoming,
+            }
+        }
+    };
+    TypeLattice::of_shape(container_ctor(evolved))
+}
+
+/// The target variable's element facts *before* this write: its tracked
+/// container elements, or — for a pure list-shaped constant (`set l {a b};
+/// lappend l c`) — the parsed literal's per-position pure-string elements.
+/// `None` when nothing is known (including an uninitialised accumulator).
+fn prior_container_elements<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
+    target: &str,
+) -> Option<Elements> {
+    if let Some(t) = lookup_var_type(target, ctx.uses, ctx.types, ctx.ssa) {
+        if let Some(e) = t.elements() {
+            return Some(e.clone());
+        }
+        // A pure string constant parses to a known element count of pure
+        // strings — `lappend` on `{a b}` starts from two `String` elements.
+        if t.tcl_type() == Some(TclType::String)
+            && let Some(LatticeValue::Const(ConstValue::String(text))) = ctx.const_of(target)
+            && let Ok(parsed) = tcl_syntax::list::split_list(text)
+        {
+            if parsed.len() > MAX_EXACT_ELEMENTS {
+                return Some(Elements::Uniform(Box::new(TypeShape::String)));
+            }
+            return Some(Elements::Exact(
+                parsed.iter().map(|_| Some(TypeShape::String)).collect(),
+            ));
         }
     }
     None
 }
 
-/// The element class a `dict set`/`dict append`/`dict lappend`/`lappend`
-/// statement leaves on its target collection: the object class of the appended
-/// value(s), joined with the collection's prior element class so a mixed-class
-/// or non-object write widens the container back to a plain `List`/`Dict`.
-///
-/// `value_args` are the words that become element values (the value(s) after
-/// the key for `dict set/append`, or after the var for `lappend`).  `target`
-/// is the collection variable's own name, consulted for its prior element
-/// class (monotone: an unknown-typed write carries the prior class forward
-/// rather than dropping it — the fixpoint's phi joins handle genuine merges).
-#[allow(clippy::too_many_arguments)] // mirrors the type-inference context threaded through this module
-fn collection_element_class<S: std::hash::BuildHasher>(
-    target: &str,
-    value_args: &[&str],
-    container: TclType,
-    uses: &HashMap<Symbol, u32>,
-    types: &HashMap<ValueKey, TypeLattice>,
-    ssa: &SsaFunction,
-    registry: &CommandRegistry,
-    known_classes: &HashSet<String, S>,
-    namespace: &str,
-) -> TypeLattice {
-    let prior = lookup_var_type(target, uses, types, ssa)
-        .and_then(|t| t.element_class().map(str::to_owned));
-    let mut elem = prior;
-    for value in value_args {
-        let value_class =
-            arg_object_class(value, uses, types, ssa, registry, known_classes, namespace);
-        match (&elem, value_class) {
-            // No provable object class for this write — no new evidence for or
-            // against homogeneity; carry the prior class forward.
-            (_, None) => {}
-            (None, Some(v)) => elem = Some(v),
-            (Some(p), Some(v)) if *p == v => {}
-            // A different concrete class: the collection is not homogeneous.
-            (Some(_), Some(_)) => return TypeLattice::of(container),
+/// Append `value_words` as new elements after `prior`, keeping `Exact`
+/// arity when both sides pin one (the phi joins collapse mismatched
+/// loop-carried arities — see [`join_elements`] — so the fixpoint
+/// terminates).
+fn append_list_elements<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
+    prior: Option<Elements>,
+    value_words: &[&str],
+) -> Elements {
+    let appended = build_exact_elements(ctx, value_words);
+    match (prior, appended) {
+        (None, appended) => appended,
+        (Some(Elements::Exact(existing)), Elements::Exact(new)) => {
+            let mut merged = existing.into_vec();
+            merged.extend(new.into_vec());
+            if merged.len() > MAX_EXACT_ELEMENTS {
+                let shapes: Vec<TypeShape> = merged.into_iter().flatten().collect();
+                return uniform_bound_of_shapes(&shapes);
+            }
+            Elements::Exact(merged.into_boxed_slice())
         }
-    }
-    match elem {
-        Some(c) => TypeLattice::collection_of(container, c),
-        None => TypeLattice::of(container),
+        (Some(prior), appended) => {
+            // No exact arity on one side: fall back to the joint uniform
+            // bound when both sides admit one.
+            match (prior.uniform_shape(), appended.uniform_shape()) {
+                (Some(a), Some(b)) => match shape_join(&a, &b) {
+                    Some(joined) => Elements::Uniform(Box::new(joined)),
+                    None => Elements::Unknown,
+                },
+                _ => Elements::Unknown,
+            }
+        }
     }
 }
 
-/// The object type a container *retrieval* yields — `dict get $coll k` or
-/// `lindex $coll i` on a collection tracked as object-homogeneous → an
-/// `OBJECT(element_class)`.  `None` for any other shape, so the caller falls
-/// back to the command's declared return type.  Only a single-level `dict get`
-/// (one key) is modelled; a nested-path `dict get` is left untyped.
-fn container_retrieval_object_type(
-    command: &str,
-    args: &[&str],
-    uses: &HashMap<Symbol, u32>,
-    types: &HashMap<ValueKey, TypeLattice>,
-    ssa: &SsaFunction,
-) -> Option<TypeLattice> {
-    // Single-level retrieval only: `dict get $coll $key` (exactly one key) or
-    // `lindex $coll $idx`.  A nested-path `dict get` (4+ args) does not match.
-    let coll = match (command, args) {
-        ("dict", [sub, coll, _key]) if *sub == "get" => *coll,
-        ("lindex", [coll, _idx]) => *coll,
-        _ => return None,
-    };
-    if !is_pure_var_ref(coll) {
-        return None;
+/// The uniform bound over a shape list, or no facts when empty / unjoinable.
+fn uniform_bound_of_shapes(shapes: &[TypeShape]) -> Elements {
+    let mut acc: Option<TypeShape> = None;
+    for shape in shapes {
+        acc = Some(match acc {
+            None => shape.clone(),
+            Some(prev) => match shape_join(&prev, shape) {
+                Some(joined) => joined,
+                None => return Elements::Unknown,
+            },
+        });
     }
-    let class = lookup_var_type(normalise_var_name(coll), uses, types, ssa)?
-        .element_class()
-        .map(str::to_owned)?;
-    Some(TypeLattice::object_of(class))
+    match acc {
+        Some(shape) => Elements::Uniform(Box::new(shape)),
+        None => Elements::Unknown,
+    }
 }
 
 /// Infer the intrep a `set`-style value *word* stores.
@@ -561,24 +832,20 @@ fn container_retrieval_object_type(
 /// interpolated / otherwise-complex word is `String`, and a bare literal is
 /// classified by its Tcl intrep.
 fn value_word_type<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
     value: &str,
-    uses: &HashMap<Symbol, u32>,
-    types: &HashMap<ValueKey, TypeLattice>,
-    registry: &CommandRegistry,
-    known_classes: &HashSet<String, S>,
-    namespace: &str,
-    ssa: &SsaFunction,
 ) -> TypeLattice {
     let stripped = value.trim();
     // Pure variable reference: inherit source type.
     if is_pure_var_ref(stripped) {
         let name = normalise_var_name(stripped);
-        if let Some(&ver) = ssa.var_symbol(name).and_then(|s| uses.get(&s))
+        if let Some(&ver) = ctx.ssa.var_symbol(name).and_then(|s| ctx.uses.get(&s))
             && ver > 0
         {
-            return ssa
+            return ctx
+                .ssa
                 .var_symbol(name)
-                .and_then(|s| types.get(&(s, ver)))
+                .and_then(|s| ctx.types.get(&(s, ver)))
                 .cloned()
                 .unwrap_or_else(TypeLattice::unknown);
         }
@@ -590,13 +857,34 @@ fn value_word_type<S: std::hash::BuildHasher>(
         && let Some((cmd, args)) = parse_command_substitution(stripped)
     {
         let arg_refs: Vec<&str> = args.iter().map(String::as_str).collect();
-        // A `dict get $coll k` / `lindex $coll i` on an object-homogeneous
-        // collection yields an `OBJECT(element_class)` — resolved before
-        // the command's declared (`String`/`Overdefined`) return type.
-        if let Some(t) = container_retrieval_object_type(&cmd, &arg_refs, uses, types, ssa) {
-            return t;
+        // The registry's result↔element fact refines the declared return
+        // type: `[list …]` builds per-position elements, `[lindex $l 0]` /
+        // `[dict get $d k]` retrieves the container's tracked element shape
+        // (subsuming the old object-only collection retrieval — an
+        // `Object(class)` element shape IS the `OBJECT(class)` result).
+        if let Some(resolved) = ctx
+            .registry
+            .resolve_call(&cmd, &arg_refs, DialectSet::empty())
+            && let Some(fact) = resolved.return_elements()
+        {
+            // The fact's indices are relative to after the subcommand word
+            // when one matched (`dict get $d k` counts from `$d`).
+            let elem_args = if resolved.sub.is_some() {
+                arg_refs.get(1..).unwrap_or(&[])
+            } else {
+                &arg_refs[..]
+            };
+            if let Some(t) = return_elements_lattice(ctx, fact, elem_args) {
+                return t;
+            }
         }
-        return return_type_for_command(registry, &cmd, &arg_refs, known_classes, namespace);
+        return return_type_for_command(
+            ctx.registry,
+            &cmd,
+            &arg_refs,
+            ctx.known_classes,
+            ctx.namespace,
+        );
     }
     // String interpolation or complex value.
     if value.contains('$') || value.contains('[') {
@@ -605,46 +893,51 @@ fn value_word_type<S: std::hash::BuildHasher>(
     literal_type(value)
 }
 
+/// How one statement types the variable(s) it defines.
+enum DefTyping {
+    /// One lattice applied to every def of the statement.
+    Uniform(TypeLattice),
+    /// Positional element typing (`lassign`, `foreach` element vars): each
+    /// def takes its own lattice; a def absent from the map widens to
+    /// `Overdefined`.
+    PerDef(HashMap<String, TypeLattice>),
+}
+
 /// Infer the type produced by `stmt` under the current `types` map.
 #[must_use]
 fn evaluate_type_def<S: std::hash::BuildHasher>(
     stmt: &Statement,
-    uses: &HashMap<Symbol, u32>,
-    types: &HashMap<ValueKey, TypeLattice>,
-    registry: &CommandRegistry,
-    known_classes: &HashSet<String, S>,
-    namespace: &str,
-    ssa: &SsaFunction,
-) -> TypeLattice {
+    ctx: &WordTypingCtx<'_, S>,
+) -> DefTyping {
     match stmt {
-        Statement::AssignConst { value, .. } => literal_type(value),
+        Statement::AssignConst { value, .. } => DefTyping::Uniform(literal_type(value)),
 
         Statement::AssignExpr { expr, .. } => {
             // Build a name→TypeLattice map for variables used in the expression.
-            let var_types: HashMap<String, TypeLattice> = uses
+            let var_types: HashMap<String, TypeLattice> = ctx
+                .uses
                 .iter()
                 .filter_map(|(&sym, &ver)| {
                     if ver == 0 {
                         return None;
                     }
-                    let t = types.get(&(sym, ver))?;
-                    Some((ssa.var_name(sym).to_owned(), t.clone()))
+                    let t = ctx.types.get(&(sym, ver))?;
+                    Some((ctx.ssa.var_name(sym).to_owned(), t.clone()))
                 })
                 .collect();
-            infer_expr_type(expr, &var_types)
+            DefTyping::Uniform(infer_expr_type(expr, &var_types))
         }
 
-        Statement::AssignValue { value, .. } => {
-            value_word_type(value, uses, types, registry, known_classes, namespace, ssa)
-        }
+        Statement::AssignValue { value, .. } => DefTyping::Uniform(value_word_type(ctx, value)),
 
-        Statement::Incr { .. } => TypeLattice::of(TclType::Int),
+        Statement::Incr { .. } => DefTyping::Uniform(TypeLattice::of(TclType::Int)),
 
         Statement::Call {
             command,
             canonical_command,
             args,
             defs,
+            foreach_groups,
             ..
         } if !defs.is_empty() => {
             // Resolve the source spelling through the lowerer's
@@ -667,70 +960,47 @@ fn evaluate_type_def<S: std::hash::BuildHasher>(
             // getter, which has no def).
             if defs.len() == 1
                 && arg_refs.len() == 2
-                && registry.get(canon).and_then(|s| s.lowering_hook)
+                && ctx.registry.get(canon).and_then(|s| s.lowering_hook)
                     == Some(tcl_registry::hooks::LoweringHookId::Set)
             {
-                return value_word_type(
-                    arg_refs[1],
-                    uses,
-                    types,
-                    registry,
-                    known_classes,
-                    namespace,
-                    ssa,
-                );
+                return DefTyping::Uniform(value_word_type(ctx, arg_refs[1]));
             }
-            // A `dict set/append/lappend VAR …` or `lappend VAR …` that stores
-            // object handles types VAR as a collection *of* that class, so a
-            // later `[dict get $VAR k] method …` retrieval resolves the element.
-            // `dict set VAR ?key…? value` takes a single trailing value; the
-            // `*append`/`lappend` forms take every word after the key/var.
-            if let Some((container, target, value_args)) = match (canon, &arg_refs[..]) {
-                ("dict", ["set", target, rest @ ..]) if !rest.is_empty() => {
-                    Some((TclType::Dict, *target, &rest[rest.len() - 1..]))
+
+            let resolved = ctx
+                .registry
+                .resolve_call(canon, &arg_refs, DialectSet::empty());
+
+            // An in-place element write (`lappend VAR v…`, `dict set VAR … v`)
+            // evolves the target's container elements — the registry's
+            // `VarElementsEffect` fact, generalising the old object-only
+            // element-class harvesting to every element shape.
+            if let Some(effect) = resolved
+                .as_ref()
+                .and_then(tcl_registry::ResolvedCall::var_elements_effect)
+            {
+                let base = usize::from(resolved.as_ref().is_some_and(|r| r.sub.is_some()));
+                if let Some(target) = arg_refs.get(base) {
+                    return DefTyping::Uniform(var_elements_effect_lattice(
+                        ctx, effect, target, &arg_refs, base,
+                    ));
                 }
-                ("dict", ["append" | "lappend", target, _key, values @ ..])
-                    if !values.is_empty() =>
-                {
-                    Some((TclType::Dict, *target, values))
-                }
-                ("lappend", [target, values @ ..]) if !values.is_empty() => {
-                    Some((TclType::List, *target, values))
-                }
-                _ => None,
-            } {
-                return collection_element_class(
-                    target,
-                    value_args,
-                    container,
-                    uses,
-                    types,
-                    ssa,
-                    registry,
-                    known_classes,
-                    namespace,
-                );
             }
+
             // How a command types the variable(s) it *writes* is a distinct
             // fact from the value it *returns*.  A destructuring writer
-            // (`lassign`, `scan`, `regexp`, `binary scan`) returns a leftover
-            // list or a match/convert count while writing element-wise pieces;
-            // `gets` returns the character count while writing a text line;
-            // `lpop` returns the popped element while leaving a shortened list.
-            // The registry declares this per command / subcommand
-            // (`VarWriteTyping`), so the compiler never keys on the command
-            // name.  The former `defs.len() > 1` heuristic guessed it from the
-            // write count and mistyped every single-target destructure — a
-            // `lassign $l x` target wrongly typed `List`, a `regexp … capture`
-            // wrongly typed `Int` (issue #867).  Resolved through `canon`, not
-            // the source spelling, so an aliased / renamed destructuring writer
-            // (`rename lassign mylassign`) still resolves to the real command's
-            // `VarWriteTyping` — the same canonical-command indirection the
-            // value-passthrough store above and the collection-element typing
-            // use (FP-SH-15).
-            let typing = registry
-                .resolve_call(canon, &arg_refs, DialectSet::empty())
-                .map_or(VarWriteTyping::ReturnValue, |r| r.var_write_typing());
+            // (`scan`, `regexp`, `binary scan`) returns a match/convert count
+            // while writing element-wise pieces; `gets` returns the character
+            // count while writing a text line; `lassign` writes its
+            // container's *elements* positionally.  The registry declares this
+            // per command / subcommand (`VarWriteTyping`), so the compiler
+            // never keys on the command name.  Resolved through `canon`, not
+            // the source spelling, so an aliased / renamed destructuring
+            // writer (`rename lassign mylassign`) still resolves to the real
+            // command's `VarWriteTyping` (FP-SH-15).
+            let typing = resolved.as_ref().map_or(
+                VarWriteTyping::ReturnValue,
+                tcl_registry::ResolvedCall::var_write_typing,
+            );
             match typing {
                 // The default typing stores the command's *return value* in the
                 // target — meaningful only for a single-target writer (`append`,
@@ -744,12 +1014,25 @@ fn evaluate_type_def<S: std::hash::BuildHasher>(
                 // old `defs.len() > 1` fallback, now scoped to the default arm
                 // rather than a blanket heuristic (a registry `Destructured` /
                 // `Fixed` override still applies at any def count).
-                VarWriteTyping::ReturnValue if defs.len() > 1 => TypeLattice::overdefined(),
-                VarWriteTyping::ReturnValue => {
-                    return_type_for_command(registry, canon, &arg_refs, known_classes, namespace)
+                VarWriteTyping::ReturnValue if defs.len() > 1 => {
+                    DefTyping::Uniform(TypeLattice::overdefined())
                 }
-                VarWriteTyping::Fixed(t) => TypeLattice::of(t),
-                VarWriteTyping::Destructured => TypeLattice::overdefined(),
+                VarWriteTyping::ReturnValue => DefTyping::Uniform(return_type_for_command(
+                    ctx.registry,
+                    canon,
+                    &arg_refs,
+                    ctx.known_classes,
+                    ctx.namespace,
+                )),
+                VarWriteTyping::Fixed(t) => DefTyping::Uniform(TypeLattice::of(t)),
+                VarWriteTyping::Destructured => DefTyping::Uniform(TypeLattice::overdefined()),
+                VarWriteTyping::ElementsOf { container_arg } => elements_of_def_typing(
+                    ctx,
+                    &arg_refs,
+                    defs,
+                    foreach_groups.as_deref(),
+                    container_arg,
+                ),
             }
         }
 
@@ -757,7 +1040,153 @@ fn evaluate_type_def<S: std::hash::BuildHasher>(
         // statements (before CFG construction in some paths) all lack a
         // resolvable result type here — treat them conservatively as
         // overdefined.
-        _ => TypeLattice::overdefined(),
+        _ => DefTyping::Uniform(TypeLattice::overdefined()),
+    }
+}
+
+/// Positional element typing for a [`VarWriteTyping::ElementsOf`] writer.
+///
+/// Two shapes reach here:
+/// - **`lassign $l a b …`** (no `foreach_groups`): target `i` takes element
+///   `i` of the container. A tracked `Exact` container types each target
+///   from its position — a position past the container's arity is the empty
+///   string `lassign` pads with (`String`), an untracked position widens to
+///   `Overdefined` (the pre-element-tracking behaviour, issue #867).
+/// - **`foreach` / `lmap` / `dict for` headers** (`foreach_groups`
+///   present): `defs` is the flattened per-group element vars and `args`
+///   holds one container word per group. A single-var list group's element
+///   var is typed `String` (list elements stringify — the established
+///   convention the shimmer suite pins) unless the container tracks a
+///   uniform element shape; multi-var groups type var `j` from the join of
+///   the `Exact` positions congruent to `j` mod the group size, else
+///   `Overdefined` (the old multi-def behaviour). A dict group types its
+///   value var from the dict's tracked value shape when one exists.
+fn elements_of_def_typing<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
+    args: &[&str],
+    defs: &[String],
+    foreach_groups: Option<&[usize]>,
+    container_arg: u8,
+) -> DefTyping {
+    let mut per_def: HashMap<String, TypeLattice> = HashMap::new();
+
+    if let Some(groups) = foreach_groups {
+        let mut def_cursor = 0usize;
+        for (group, &nvars) in groups.iter().enumerate() {
+            let group_defs = defs.get(def_cursor..def_cursor + nvars).unwrap_or(&[]);
+            def_cursor += nvars;
+            let container_shape = args.get(group).and_then(|w| container_word_shape(ctx, w));
+            for (j, def) in group_defs.iter().enumerate() {
+                per_def.insert(
+                    def.clone(),
+                    foreach_var_lattice(container_shape.as_ref(), nvars, j),
+                );
+            }
+        }
+        return DefTyping::PerDef(per_def);
+    }
+
+    // lassign: targets follow the container word.
+    let container = args.get(usize::from(container_arg));
+    let elements = container
+        .filter(|w| is_pure_var_ref(w))
+        .and_then(|w| lookup_var_type(normalise_var_name(w), ctx.uses, ctx.types, ctx.ssa))
+        .and_then(|t| t.elements().cloned());
+    for (i, def) in defs.iter().enumerate() {
+        let lattice = match &elements {
+            Some(Elements::Exact(shapes)) => {
+                if i >= shapes.len() {
+                    // Past the container's arity: `lassign` pads with the
+                    // empty string.
+                    TypeLattice::of(TclType::String)
+                } else {
+                    shapes[i]
+                        .clone()
+                        .map_or_else(TypeLattice::overdefined, TypeLattice::of_shape)
+                }
+            }
+            _ => TypeLattice::overdefined(),
+        };
+        per_def.insert(def.clone(), lattice);
+    }
+    DefTyping::PerDef(per_def)
+}
+
+/// The container shape a `foreach` group's list word denotes, when tracked.
+fn container_word_shape<S: std::hash::BuildHasher>(
+    ctx: &WordTypingCtx<'_, S>,
+    word: &str,
+) -> Option<TypeShape> {
+    let word = word.trim();
+    if is_pure_var_ref(word) {
+        return lookup_var_type(normalise_var_name(word), ctx.uses, ctx.types, ctx.ssa)
+            .and_then(|t| t.single_shape().cloned());
+    }
+    if word.starts_with('[') && word.ends_with(']') {
+        return value_word_type(ctx, word).single_shape().cloned();
+    }
+    None
+}
+
+/// The lattice for one `foreach` element variable — var `j` of an
+/// `nvars`-wide group iterating `container_shape`.
+fn foreach_var_lattice(container_shape: Option<&TypeShape>, nvars: usize, j: usize) -> TypeLattice {
+    match container_shape {
+        Some(TypeShape::List(elements)) => {
+            if nvars == 1 {
+                match elements.uniform_shape() {
+                    Some(u) => TypeLattice::of_shape(u),
+                    // List elements stringify — the established convention.
+                    None => TypeLattice::of(TclType::String),
+                }
+            } else if let Elements::Exact(shapes) = elements {
+                // Var `j` sees positions j, j+nvars, j+2·nvars, …
+                let mut acc: Option<TypeShape> = None;
+                for shape in shapes.iter().skip(j).step_by(nvars) {
+                    let Some(shape) = shape else {
+                        return TypeLattice::overdefined();
+                    };
+                    acc = Some(match acc {
+                        None => shape.clone(),
+                        Some(prev) => match shape_join(&prev, shape) {
+                            Some(joined) => joined,
+                            None => return TypeLattice::overdefined(),
+                        },
+                    });
+                }
+                acc.map_or_else(
+                    // No positions at this stride: the var gets the empty
+                    // string `foreach` pads with.
+                    || TypeLattice::of(TclType::String),
+                    TypeLattice::of_shape,
+                )
+            } else {
+                TypeLattice::overdefined()
+            }
+        }
+        // A dict group (`dict for {k v} $d`): the key stringifies, the value
+        // takes the dict's tracked value shape. Without a tracked value
+        // shape both stay conservative (the old multi-def behaviour).
+        Some(TypeShape::Dict(elements)) => {
+            if nvars == 2 && j == 1 {
+                elements
+                    .uniform_shape()
+                    .map_or_else(TypeLattice::overdefined, TypeLattice::of_shape)
+            } else if nvars == 2 && j == 0 && elements.uniform_shape().is_some() {
+                TypeLattice::of(TclType::String)
+            } else {
+                TypeLattice::overdefined()
+            }
+        }
+        // Untracked container: a single-var group keeps the established
+        // `String` element convention; wider groups stay conservative.
+        _ => {
+            if nvars == 1 {
+                TypeLattice::of(TclType::String)
+            } else {
+                TypeLattice::overdefined()
+            }
+        }
     }
 }
 
@@ -812,6 +1241,7 @@ pub fn propagate_types<S: std::hash::BuildHasher>(
         registry,
         known_classes,
         namespace: &namespace,
+        values: &sccp.values,
         escaping: &escaping,
         has_dynamic_variable_trace: trace_facts.has_dynamic_variable_trace,
     };
@@ -904,6 +1334,9 @@ struct StatementTypingCtx<'a, S: std::hash::BuildHasher> {
     registry: &'a CommandRegistry,
     known_classes: &'a HashSet<String, S>,
     namespace: &'a str,
+    /// SCCP constants — purity evidence and constant list/index values for
+    /// the element-inference helpers (see [`WordTypingCtx::values`]).
+    values: &'a HashMap<ValueKey, LatticeValue>,
     /// Names [`crate::sccp::is_externally_mutable`] should treat as
     /// unconditionally aliased/escaping (per-function `analyse_var_observability`
     /// union'd with the caller's whole-module `extra_global_escaping` and
@@ -929,10 +1362,9 @@ fn type_infer_process_statements<S: std::hash::BuildHasher>(
         // A barrier widens every def to OVERDEFINED (it may have mutated
         // them arbitrarily); a scope-alias declaration (`global`/`variable`/
         // `upvar`/`namespace upvar`) likewise widens its defs — the
-        // imported variable's intrep is external and unknown. Every def of
-        // one statement gets the same inferred type, so compute it once.
+        // imported variable's intrep is external and unknown.
         let inferred = match stmt {
-            Statement::Barrier { .. } => TypeLattice::overdefined(),
+            Statement::Barrier { .. } => DefTyping::Uniform(TypeLattice::overdefined()),
             Statement::Call {
                 command,
                 canonical_command,
@@ -946,17 +1378,20 @@ fn type_infer_process_statements<S: std::hash::BuildHasher>(
                     args,
                 ) =>
             {
-                TypeLattice::overdefined()
+                DefTyping::Uniform(TypeLattice::overdefined())
             }
-            _ => evaluate_type_def(
-                stmt,
-                &ssa_stmt.uses,
-                types,
-                ctx.registry,
-                ctx.known_classes,
-                ctx.namespace,
-                ctx.ssa,
-            ),
+            _ => {
+                let word_ctx = WordTypingCtx {
+                    uses: &ssa_stmt.uses,
+                    types,
+                    values: ctx.values,
+                    registry: ctx.registry,
+                    known_classes: ctx.known_classes,
+                    namespace: ctx.namespace,
+                    ssa: ctx.ssa,
+                };
+                evaluate_type_def(stmt, &word_ctx)
+            }
         };
         for (&var, &ver) in &ssa_stmt.defs {
             let key = (var, ver);
@@ -964,14 +1399,23 @@ fn type_infer_process_statements<S: std::hash::BuildHasher>(
                 .get(&key)
                 .cloned()
                 .unwrap_or_else(TypeLattice::unknown);
+            let name = ctx.ssa.var_name(var);
             let def_type = if crate::sccp::is_externally_mutable(
-                ctx.ssa.var_name(var),
+                name,
                 ctx.escaping,
                 ctx.has_dynamic_variable_trace,
             ) {
                 TypeLattice::overdefined()
             } else {
-                inferred.clone()
+                match &inferred {
+                    DefTyping::Uniform(t) => t.clone(),
+                    // Positional element typing: a def the map does not
+                    // name widens to Overdefined.
+                    DefTyping::PerDef(map) => map
+                        .get(name)
+                        .cloned()
+                        .unwrap_or_else(TypeLattice::overdefined),
+                }
             };
             let merged = type_join(&old, &def_type);
             if merged != old {
@@ -1098,6 +1542,38 @@ mod tests {
         CommandRegistry::build_default()
     }
 
+    /// Evaluate one statement's def typing against empty context pieces and
+    /// return the lattice a def named `def_name` receives (`DefTyping::PerDef`
+    /// defs absent from the map widen to `Overdefined`, matching the
+    /// propagation pass).
+    fn eval_def(
+        stmt: &Statement,
+        registry: &CommandRegistry,
+        ssa: &SsaFunction,
+        def_name: &str,
+    ) -> TypeLattice {
+        let uses = HashMap::new();
+        let types = HashMap::new();
+        let values = HashMap::new();
+        let known_classes: HashSet<String> = HashSet::new();
+        let ctx = WordTypingCtx {
+            uses: &uses,
+            types: &types,
+            values: &values,
+            registry,
+            known_classes: &known_classes,
+            namespace: "::",
+            ssa,
+        };
+        match evaluate_type_def(stmt, &ctx) {
+            DefTyping::Uniform(t) => t,
+            DefTyping::PerDef(map) => map
+                .get(def_name)
+                .cloned()
+                .unwrap_or_else(TypeLattice::overdefined),
+        }
+    }
+
     fn empty_sccp(f: &Function, blocks: &[&str]) -> SccpResult {
         SccpResult {
             values: HashMap::new(),
@@ -1173,15 +1649,7 @@ mod tests {
             safe_on_uninit: false,
         };
         let ssa = SsaFunction::trivial("::top", BlockId(0), vec!["entry".into()]);
-        let t = evaluate_type_def(
-            &stmt,
-            &HashMap::new(),
-            &HashMap::new(),
-            &registry(),
-            &HashSet::new(),
-            "::",
-            &ssa,
-        );
+        let t = eval_def(&stmt, &registry(), &ssa, "__def__");
         assert_eq!(t, TypeLattice::of(TclType::Int));
     }
 
@@ -1207,15 +1675,7 @@ mod tests {
             foreach_groups: None,
         };
         let ssa = SsaFunction::trivial("::top", BlockId(0), vec!["entry".into()]);
-        let t = evaluate_type_def(
-            &stmt,
-            &HashMap::new(),
-            &HashMap::new(),
-            &registry(),
-            &HashSet::new(),
-            "::",
-            &ssa,
-        );
+        let t = eval_def(&stmt, &registry(), &ssa, "__def__");
         assert_eq!(t, TypeLattice::overdefined());
     }
 
@@ -1239,15 +1699,7 @@ mod tests {
             foreach_groups: None,
         };
         let ssa = SsaFunction::trivial("::top", BlockId(0), vec!["entry".into()]);
-        let t = evaluate_type_def(
-            &stmt,
-            &HashMap::new(),
-            &HashMap::new(),
-            &registry(),
-            &HashSet::new(),
-            "::",
-            &ssa,
-        );
+        let t = eval_def(&stmt, &registry(), &ssa, "__def__");
         assert_eq!(t, TypeLattice::overdefined());
     }
 
@@ -1270,15 +1722,7 @@ mod tests {
             foreach_groups: None,
         };
         let ssa = SsaFunction::trivial("::top", BlockId(0), vec!["entry".into()]);
-        let t = evaluate_type_def(
-            &stmt,
-            &HashMap::new(),
-            &HashMap::new(),
-            &registry(),
-            &HashSet::new(),
-            "::",
-            &ssa,
-        );
+        let t = eval_def(&stmt, &registry(), &ssa, "__def__");
         assert_eq!(t, TypeLattice::of(TclType::String));
     }
 
@@ -1309,15 +1753,7 @@ mod tests {
             foreach_groups: None,
         };
         let ssa = SsaFunction::trivial("::top", BlockId(0), vec!["entry".into()]);
-        let t = evaluate_type_def(
-            &stmt,
-            &HashMap::new(),
-            &HashMap::new(),
-            &registry(),
-            &HashSet::new(),
-            "::",
-            &ssa,
-        );
+        let t = eval_def(&stmt, &registry(), &ssa, "__def__");
         assert_eq!(t, TypeLattice::overdefined());
     }
 
@@ -1332,8 +1768,8 @@ mod tests {
         fn any_known(fu: &crate::compilation_unit::FunctionUnit, name: &str, t: TclType) -> bool {
             fu.types.iter().any(|((sym, _), lat)| {
                 fu.ssa.var_name(*sym) == name
-                    && lat.kind == TypeKind::Known
-                    && lat.tcl_type == Some(t)
+                    && lat.kind() == TypeKind::Known
+                    && lat.tcl_type() == Some(t)
             })
         }
         // Helper: is every version of `name` non-Known (OVERDEFINED/UNKNOWN)?
@@ -1341,7 +1777,7 @@ mod tests {
             fu.types
                 .iter()
                 .filter(|((sym, _), _)| fu.ssa.var_name(*sym) == name)
-                .all(|(_, lat)| lat.kind != TypeKind::Known)
+                .all(|(_, lat)| lat.kind() != TypeKind::Known)
         }
 
         // `lassign` element target — OVERDEFINED, never List.
@@ -1496,10 +1932,10 @@ mod tests {
         let fu = cu.function("::top").unwrap();
         // x should be Int; y (which copies x) should also be Int.
         let x_is_int = fu.types.iter().any(|((name, _), t)| {
-            fu.ssa.var_name(*name) == "x" && t.tcl_type == Some(TclType::Int)
+            fu.ssa.var_name(*name) == "x" && t.tcl_type() == Some(TclType::Int)
         });
         let y_is_int = fu.types.iter().any(|((name, _), t)| {
-            fu.ssa.var_name(*name) == "y" && t.tcl_type == Some(TclType::Int)
+            fu.ssa.var_name(*name) == "y" && t.tcl_type() == Some(TclType::Int)
         });
         assert!(x_is_int, "expected x to be Int");
         assert!(y_is_int, "expected y to inherit Int type from x");
@@ -1520,7 +1956,7 @@ mod tests {
         );
         let fu = cu.function("::g").unwrap();
         let x_is_int = fu.types.iter().any(|((name, _), t)| {
-            fu.ssa.var_name(*name) == "x" && t.tcl_type == Some(TclType::Int)
+            fu.ssa.var_name(*name) == "x" && t.tcl_type() == Some(TclType::Int)
         });
         assert!(
             x_is_int,
@@ -1541,7 +1977,7 @@ mod tests {
             CompilationUnit::build_for("set lst {a b c}\nset n [llength $lst]", &registry(), false);
         let fu = cu.function("::top").unwrap();
         let n_is_int = fu.types.iter().any(|((name, _), t)| {
-            fu.ssa.var_name(*name) == "n" && t.tcl_type == Some(TclType::Int)
+            fu.ssa.var_name(*name) == "n" && t.tcl_type() == Some(TclType::Int)
         });
         assert!(n_is_int, "expected n to be Int (llength return type)");
     }
@@ -1569,8 +2005,8 @@ mod tests {
         );
         let p_ok = fu.types.iter().any(|((name, _), t)| {
             fu.ssa.var_name(*name) == "p"
-                && t.tcl_type == Some(TclType::Object)
-                && t.class_name.as_deref() == Some("::Pin")
+                && t.tcl_type() == Some(TclType::Object)
+                && t.class_name() == Some("::Pin")
         });
         assert!(p_ok, "p (dict get) should be OBJECT(::Pin)");
     }
@@ -1586,8 +2022,8 @@ mod tests {
         let fu = cu.function("::top").expect("top level");
         let p_ok = fu.types.iter().any(|((name, _), t)| {
             fu.ssa.var_name(*name) == "p"
-                && t.tcl_type == Some(TclType::Object)
-                && t.class_name.as_deref() == Some("::Pin")
+                && t.tcl_type() == Some(TclType::Object)
+                && t.class_name() == Some("::Pin")
         });
         assert!(p_ok, "p (lindex) should be OBJECT(::Pin)");
     }
@@ -1629,28 +2065,28 @@ mod tests {
     #[test]
     fn math_function_calls_infer_their_return_type() {
         // (a) sqrt → Double, int → Int, bool → Boolean.
-        assert_eq!(infer_str("sqrt(2.0)").tcl_type, Some(TclType::Double));
-        assert_eq!(infer_str("sin($x)").tcl_type, Some(TclType::Double));
-        assert_eq!(infer_str("int($x)").tcl_type, Some(TclType::Int));
-        assert_eq!(infer_str("wide($x)").tcl_type, Some(TclType::Int));
-        assert_eq!(infer_str("isnan($x)").tcl_type, Some(TclType::Boolean));
+        assert_eq!(infer_str("sqrt(2.0)").tcl_type(), Some(TclType::Double));
+        assert_eq!(infer_str("sin($x)").tcl_type(), Some(TclType::Double));
+        assert_eq!(infer_str("int($x)").tcl_type(), Some(TclType::Int));
+        assert_eq!(infer_str("wide($x)").tcl_type(), Some(TclType::Int));
+        assert_eq!(infer_str("isnan($x)").tcl_type(), Some(TclType::Boolean));
         // abs is identity: abs(2) keeps the operand's Int type.
-        assert_eq!(infer_str("abs(2)").tcl_type, Some(TclType::Int));
+        assert_eq!(infer_str("abs(2)").tcl_type(), Some(TclType::Int));
         // max/min join operands: max(1, 2) stays Int.
-        assert_eq!(infer_str("max(1, 2)").tcl_type, Some(TclType::Int));
+        assert_eq!(infer_str("max(1, 2)").tcl_type(), Some(TclType::Int));
         // Tcl 9.1 C99 functions (TIP 745): double-valued, except `signbit`.
         for f in [
             "acosh", "cbrt", "exp2", "log2", "trunc", "erf", "expm1", "logb",
         ] {
             assert_eq!(
-                infer_str(&format!("{f}($x)")).tcl_type,
+                infer_str(&format!("{f}($x)")).tcl_type(),
                 Some(TclType::Double),
                 "{f} should infer Double",
             );
         }
-        assert_eq!(infer_str("signbit($x)").tcl_type, Some(TclType::Boolean));
+        assert_eq!(infer_str("signbit($x)").tcl_type(), Some(TclType::Boolean));
         // Unknown function → Numeric (conservative).
-        assert_eq!(infer_str("nope($x)").tcl_type, Some(TclType::Numeric));
+        assert_eq!(infer_str("nope($x)").tcl_type(), Some(TclType::Numeric));
     }
 
     #[test]
@@ -1658,7 +2094,7 @@ mod tests {
         // (c) bitwise / shift force Int even with untyped operands.
         for src in ["$x & $y", "$x | $y", "$x ^ $y", "$x << 2", "$x >> 2"] {
             assert_eq!(
-                infer_str(src).tcl_type,
+                infer_str(src).tcl_type(),
                 Some(TclType::Int),
                 "expected Int for `{src}`",
             );
@@ -1679,7 +2115,7 @@ mod tests {
         ] {
             let t = infer_str_dialect(src, Some("f5-irules"));
             assert_eq!(
-                t.tcl_type,
+                t.tcl_type(),
                 Some(TclType::Boolean),
                 "expected Boolean for `{src}`, got {t:?}",
             );
@@ -1689,33 +2125,33 @@ mod tests {
     #[test]
     fn arithmetic_promotes_double() {
         // `_arithmetic_result`: int + double → Double (was Numeric).
-        assert_eq!(infer_str("3 + 2.0").tcl_type, Some(TclType::Double));
+        assert_eq!(infer_str("3 + 2.0").tcl_type(), Some(TclType::Double));
         // int + int → Int.
-        assert_eq!(infer_str("3 + 4").tcl_type, Some(TclType::Int));
+        assert_eq!(infer_str("3 + 4").tcl_type(), Some(TclType::Int));
     }
 
     #[test]
     fn expr_context_literal_typing() {
         // Every integer spelling tokenises to Int in expr context — including
         // octal `0o…`, which the set-statement classifier keeps as String.
-        assert_eq!(infer_str("0o17").tcl_type, Some(TclType::Int));
-        assert_eq!(infer_str("0xff").tcl_type, Some(TclType::Int));
-        assert_eq!(infer_str("0b1010").tcl_type, Some(TclType::Int));
-        assert_eq!(infer_str("42").tcl_type, Some(TclType::Int));
-        assert_eq!(infer_str("3.14").tcl_type, Some(TclType::Double));
+        assert_eq!(infer_str("0o17").tcl_type(), Some(TclType::Int));
+        assert_eq!(infer_str("0xff").tcl_type(), Some(TclType::Int));
+        assert_eq!(infer_str("0b1010").tcl_type(), Some(TclType::Int));
+        assert_eq!(infer_str("42").tcl_type(), Some(TclType::Int));
+        assert_eq!(infer_str("3.14").tcl_type(), Some(TclType::Double));
         // The set-statement classifier still keeps octal as String.
         assert_eq!(literal_type("0o17"), TypeLattice::of(TclType::String));
         // An unrecognised literal degrades to Numeric in expr context
         // (the set-statement classifier would say String).
-        assert_eq!(expr_literal_type("nope").tcl_type, Some(TclType::Numeric));
+        assert_eq!(expr_literal_type("nope").tcl_type(), Some(TclType::Numeric));
     }
 
     #[test]
     fn bitnot_coerces_to_int() {
         // `~$x` always yields Int, regardless of the operand's type
         // (was leaking the operand type via the identity arm).
-        assert_eq!(infer_str("~$x").tcl_type, Some(TclType::Int));
-        assert_eq!(infer_str("~3.5").tcl_type, Some(TclType::Int));
+        assert_eq!(infer_str("~$x").tcl_type(), Some(TclType::Int));
+        assert_eq!(infer_str("~3.5").tcl_type(), Some(TclType::Int));
     }
 
     #[test]
@@ -1762,10 +2198,9 @@ mod tests {
             false,
         );
         let fu = cu.function("::f").unwrap();
-        let widened = fu
-            .types
-            .iter()
-            .any(|((n, _), t)| fu.ssa.var_name(*n) == "counter" && t.kind == TypeKind::Overdefined);
+        let widened = fu.types.iter().any(|((n, _), t)| {
+            fu.ssa.var_name(*n) == "counter" && t.kind() == TypeKind::Overdefined
+        });
         assert!(
             widened,
             "scope-aliased 'counter' should be OVERDEFINED: {:?}",
@@ -1790,7 +2225,7 @@ mod tests {
         let has_overdefined = fu
             .types
             .iter()
-            .any(|((n, _), t)| fu.ssa.var_name(*n) == "x" && t.kind == TypeKind::Overdefined);
+            .any(|((n, _), t)| fu.ssa.var_name(*n) == "x" && t.kind() == TypeKind::Overdefined);
         assert!(
             has_overdefined,
             "conditionally-assigned param 'x' should merge to OVERDEFINED: {:?}",
@@ -1804,7 +2239,7 @@ mod tests {
             .types
             .iter()
             .filter(|((n, _), t)| {
-                fu.ssa.var_name(*n) == "x" && matches!(t.tcl_type, Some(TclType::Int))
+                fu.ssa.var_name(*n) == "x" && matches!(t.tcl_type(), Some(TclType::Int))
             })
             .count();
         assert_eq!(
@@ -1831,11 +2266,200 @@ mod tests {
             .types
             .iter()
             .filter(|((n, _), _)| fu.ssa.var_name(*n) == "y")
-            .all(|(_, t)| matches!(t.tcl_type, Some(TclType::Int)) || t.kind == TypeKind::Unknown);
+            .all(|(_, t)| {
+                matches!(t.tcl_type(), Some(TclType::Int)) || t.kind() == TypeKind::Unknown
+            });
         assert!(
             all_int,
             "unconditionally-assigned 'y' should stay Int on every path: {:?}",
             fu.types
+        );
+    }
+
+    // --- P3: registry-driven container element inference (type-tracking.md) ---
+
+    /// Helper: the joined lattice of every version of `var` in `func`.
+    fn type_of(
+        cu: &crate::compilation_unit::CompilationUnit,
+        func: &str,
+        var: &str,
+    ) -> TypeLattice {
+        let fu = cu.function(func).unwrap();
+        let mut acc = TypeLattice::unknown();
+        for ((sym, ver), t) in &fu.types {
+            if *ver > 0 && fu.ssa.var_name(*sym) == var {
+                acc = type_join(&acc, t);
+            }
+        }
+        acc
+    }
+
+    /// Oracle: elements are shared objects — a committed computed element
+    /// keeps its intrep inside the list, and `lindex` retrieves it.
+    #[test]
+    fn list_builder_tracks_committed_element_and_lindex_retrieves_it() {
+        use crate::compilation_unit::CompilationUnit;
+        let cu = CompilationUnit::build_for(
+            "set l [list [expr {2**20}] other]\nset first [lindex $l 0]",
+            &registry(),
+            false,
+        );
+        let l = type_of(&cu, "::top", "l");
+        assert_eq!(l.tcl_type(), Some(TclType::List), "{l}");
+        let elements = l.elements().expect("tracked elements").clone();
+        assert_eq!(elements.known_len(), Some(2), "{l}");
+        assert!(
+            matches!(elements.shape_at(0), Some(s) if s.is_numeric_family()),
+            "committed element 0 keeps its numeric intrep: {l}"
+        );
+        assert_eq!(
+            elements.shape_at(1),
+            None,
+            "a literal word stays agnostic: {l}"
+        );
+        let first = type_of(&cu, "::top", "first");
+        assert!(
+            matches!(first.single_shape(), Some(s) if s.is_numeric_family()),
+            "lindex retrieves the element's shape: {first}"
+        );
+    }
+
+    /// Arity is a fact even with unknown element values: `[list $a $b]`
+    /// provably has two elements.
+    #[test]
+    fn list_builder_tracks_arity_of_unknown_words() {
+        use crate::compilation_unit::CompilationUnit;
+        let cu = CompilationUnit::build_for(
+            "proc f {a b} { set l [list $a $b]\n return $l }",
+            &registry(),
+            false,
+        );
+        let l = type_of(&cu, "::f", "l");
+        assert_eq!(
+            l.elements().and_then(Elements::known_len),
+            Some(2),
+            "arity of [list $a $b] is exactly 2: {l}"
+        );
+    }
+
+    /// The old object-collection behaviour, now through general elements:
+    /// `lappend`ing constructed objects yields `List<OBJECT(C)*>` and a
+    /// `lassign` / `lindex` retrieval resolves the class.
+    #[test]
+    fn lassign_of_committed_object_list_types_targets() {
+        use crate::compilation_unit::CompilationUnit;
+        let cu = CompilationUnit::build_for(
+            "oo::class create Foo {}\nset l [list [Foo new] [Foo new]]\nlassign $l a b",
+            &registry(),
+            false,
+        );
+        let a = type_of(&cu, "::top", "a");
+        assert_eq!(a.tcl_type(), Some(TclType::Object), "{a}");
+        assert_eq!(a.class_name(), Some("::Foo"), "{a}");
+        let b = type_of(&cu, "::top", "b");
+        assert_eq!(b.class_name(), Some("::Foo"), "{b}");
+    }
+
+    /// FP-SH-17 parity: `lassign` targets from a *pure-literal* list stay
+    /// Overdefined — no shape claim is defensible for value-dependent
+    /// conversion checks.
+    #[test]
+    fn lassign_of_literal_list_targets_stay_overdefined() {
+        use crate::compilation_unit::CompilationUnit;
+        let cu = CompilationUnit::build_for(
+            "set point [list 1 2 3]\nlassign $point x y z",
+            &registry(),
+            false,
+        );
+        let x = type_of(&cu, "::top", "x");
+        assert_eq!(x.kind(), TypeKind::Overdefined, "{x}");
+    }
+
+    /// A `lassign` target past the container's arity receives the empty
+    /// string the command pads with.
+    #[test]
+    fn lassign_past_arity_is_empty_string() {
+        use crate::compilation_unit::CompilationUnit;
+        let cu = CompilationUnit::build_for(
+            "set l [list [expr {1+1}]]\nlassign $l a b",
+            &registry(),
+            false,
+        );
+        let b = type_of(&cu, "::top", "b");
+        assert_eq!(b.tcl_type(), Some(TclType::String), "{b}");
+    }
+
+    /// `dict create` of constructed objects → `Dict<OBJECT(C)*>`; `dict get`
+    /// resolves the element class (the old object retrieval, generalised).
+    #[test]
+    fn dict_create_and_get_track_object_values() {
+        use crate::compilation_unit::CompilationUnit;
+        let cu = CompilationUnit::build_for(
+            "oo::class create Pin {}\nset pins [dict create p1 [Pin new] p2 [Pin new]]\nset p [dict get $pins p1]",
+            &registry(),
+            false,
+        );
+        let pins = type_of(&cu, "::top", "pins");
+        assert_eq!(pins.element_class(), Some("::Pin"), "{pins}");
+        let p = type_of(&cu, "::top", "p");
+        assert_eq!(p.class_name(), Some("::Pin"), "{p}");
+    }
+
+    /// `lappend var [C new]` evolves the variable's elements — the old
+    /// `collection_element_class` behaviour through the registry's
+    /// `VarElementsEffect`, aliased spellings included.
+    #[test]
+    fn lappend_object_evolves_element_class_through_rename() {
+        use crate::compilation_unit::CompilationUnit;
+        let cu = CompilationUnit::build_for(
+            "oo::class create Foo {}\nset acc [list]\nlappend acc [Foo new]\nlappend acc [Foo new]",
+            &registry(),
+            false,
+        );
+        let acc = type_of(&cu, "::top", "acc");
+        assert_eq!(acc.tcl_type(), Some(TclType::List), "{acc}");
+        assert_eq!(acc.element_class(), Some("::Foo"), "{acc}");
+    }
+
+    /// A `foreach` element var over a tracked homogeneous list takes the
+    /// element shape at its def (the loop-header phi separately joins the
+    /// live-in as Overdefined, by the conditionally-assigned rule).
+    #[test]
+    fn foreach_var_takes_uniform_element_shape() {
+        use crate::compilation_unit::CompilationUnit;
+        let cu = CompilationUnit::build_for(
+            "oo::class create Foo {}\nset l [list [Foo new] [Foo new]]\nforeach o $l { puts $o }",
+            &registry(),
+            false,
+        );
+        let fu = cu.function("::top").unwrap();
+        let has_object_def = fu.types.iter().any(|((sym, ver), t)| {
+            *ver > 0 && fu.ssa.var_name(*sym) == "o" && t.class_name() == Some("::Foo")
+        });
+        assert!(
+            has_object_def,
+            "some version of 'o' must carry the element class: {:?}",
+            fu.types
+        );
+    }
+
+    /// Bignum literals classify on the tower: a beyond-wide decimal is
+    /// `Bignum` (coarse `Int`), never wrapped and never `String`.
+    #[test]
+    fn bignum_literal_classifies_on_the_tower() {
+        assert_eq!(
+            literal_type("18446744073709551616").single_shape(),
+            Some(&TypeShape::Bignum)
+        );
+        assert_eq!(
+            literal_type("0xFFFFFFFFFFFFFFFF").single_shape(),
+            Some(&TypeShape::Bignum)
+        );
+        assert_eq!(literal_type("5").single_shape(), Some(&TypeShape::Int));
+        assert_eq!(
+            literal_type("-9223372036854775808").single_shape(),
+            Some(&TypeShape::Int),
+            "i64::MIN still fits a wide"
         );
     }
 }

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -716,7 +716,8 @@ fn var_elements_effect_lattice<S: std::hash::BuildHasher>(
                 .checked_sub(1)
                 .map_or(&[][..], |last| &args[last..]),
         ),
-        VarElementsEffect::ExtendsDictValues { values_from } => (
+        VarElementsEffect::ListifiesDictValue => (TypeShape::Dict, &[]),
+        VarElementsEffect::ExtendsDictValuesByName { values_from } => (
             TypeShape::Dict,
             args.get(base + usize::from(values_from)..).unwrap_or(&[]),
         ),
@@ -727,10 +728,49 @@ fn var_elements_effect_lattice<S: std::hash::BuildHasher>(
         VarElementsEffect::AppendsListElements { .. } => {
             append_list_elements(ctx, prior, value_words)
         }
-        // Dict values: join the new values into the prior uniform bound —
-        // per-key tracking is out of scope (documented in type-tracking.md).
-        VarElementsEffect::SetsDictValue | VarElementsEffect::ExtendsDictValues { .. } => {
+        // Dict values: join the new value shape into the prior uniform
+        // bound — per-key tracking is out of scope (type-tracking.md).
+        // Only the single-key `dict set var key value` carries the leaf
+        // word's shape; a nested path stores a *dict* under the first key
+        // (`dict get $d outer` is a dict — tclsh-verified), so the
+        // contribution is a Dict wrapper with unknown structure.
+        VarElementsEffect::SetsDictValue => {
+            let single_key = args.len().saturating_sub(base) == 3;
+            let incoming = if single_key {
+                uniform_elements_of(ctx, value_words)
+            } else {
+                Elements::Uniform(Box::new(TypeShape::Dict(Elements::Unknown)))
+            };
+            match prior {
+                Some(prior) => join_elements(&prior, &incoming),
+                None => incoming,
+            }
+        }
+        // `dict append` concatenates: value intreps do not survive, but an
+        // object's dispatch identity (the objref text) does — only
+        // object-class shapes flow into the bound (issue #797's
+        // collection-of-objects pattern); anything else contributes no
+        // element fact.
+        VarElementsEffect::ExtendsDictValuesByName { .. } => {
             let incoming = uniform_elements_of(ctx, value_words);
+            let object_only = match &incoming {
+                Elements::Uniform(shape) if matches!(**shape, TypeShape::Object(_)) => {
+                    Some(incoming.clone())
+                }
+                _ => None,
+            };
+            match (prior, object_only) {
+                (Some(prior), Some(inc)) => join_elements(&prior, &inc),
+                (Some(prior), None) => prior,
+                (None, Some(inc)) => inc,
+                (None, None) => Elements::Unknown,
+            }
+        }
+        // `dict lappend`: the key's value becomes a list (a prior scalar
+        // becomes element 0), so the wrapper is the fact and the element
+        // shapes stay unknown.
+        VarElementsEffect::ListifiesDictValue => {
+            let incoming = Elements::Uniform(Box::new(TypeShape::List(Elements::Unknown)));
             match prior {
                 Some(prior) => join_elements(&prior, &incoming),
                 None => incoming,
@@ -2552,6 +2592,74 @@ mod tests {
             !widened,
             "INT ⊔ STRING must not stay a single INT claim: {:?}",
             fu.types
+        );
+    }
+
+    /// Review-pinned dict-value semantics (tclsh 8.6/9.0 verified):
+    /// a multi-key `dict set` stores a *dict* under the first key; `dict
+    /// lappend` stores a *list*; `dict append` concatenates (intreps do
+    /// not survive), with only object dispatch-identity flowing (#797).
+    #[test]
+    fn dict_value_effects_match_oracle() {
+        let reg = tcl_registry::CommandRegistry::build_default();
+        let elements_of = |src: &str, qname: &str, var: &str| -> Vec<Option<TclType>> {
+            let cu = crate::compilation_unit::CompilationUnit::build_for(src, &reg, false);
+            let fu = cu.function(qname).unwrap();
+            fu.types
+                .iter()
+                .filter(|((sym, ver), _)| *ver > 0 && fu.ssa.var_name(*sym) == var)
+                .map(|(_, t)| {
+                    t.elements()
+                        .and_then(Elements::uniform_shape)
+                        .map(|s| s.coarse())
+                })
+                .collect()
+        };
+        // Multi-key set: the top-level value is a DICT, never the leaf shape.
+        let multi = elements_of(
+            "proc f {} {\n    set d {}\n    dict set d outer inner [expr {1}]\n    return $d\n}",
+            "::f",
+            "d",
+        );
+        assert!(
+            multi.iter().flatten().all(|t| *t == TclType::Dict),
+            "multi-key dict set stores a nested dict: {multi:?}"
+        );
+        // Single-key set keeps the leaf's shape.
+        let single = elements_of(
+            "proc f {} {\n    set d {}\n    dict set d k [expr {1}]\n    return $d\n}",
+            "::f",
+            "d",
+        );
+        assert!(
+            single
+                .iter()
+                .any(|t| matches!(t, Some(TclType::Int | TclType::Numeric))),
+            "single-key dict set keeps the leaf shape: {single:?}"
+        );
+        // lappend: the value is a LIST (elements unknown — the prior scalar
+        // becomes element 0).
+        let lap = elements_of(
+            "proc f {} {\n    set d {}\n    dict lappend d k [expr {1}]\n    return $d\n}",
+            "::f",
+            "d",
+        );
+        assert!(
+            lap.iter().flatten().all(|t| *t == TclType::List),
+            "dict lappend listifies the value: {lap:?}"
+        );
+        // append: concatenation — a numeric argument's intrep must NOT
+        // become the value's element fact.
+        let app = elements_of(
+            "proc f {} {\n    set d {}\n    dict append d k [expr {1}]\n    return $d\n}",
+            "::f",
+            "d",
+        );
+        assert!(
+            !app.iter()
+                .flatten()
+                .any(|t| matches!(t, TclType::Int | TclType::Numeric)),
+            "dict append must not claim a numeric value intrep: {app:?}"
         );
     }
 

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -1393,6 +1393,19 @@ fn type_infer_process_statements<S: std::hash::BuildHasher>(
                 evaluate_type_def(stmt, &word_ctx)
             }
         };
+        // An element write's base def carries no value type of its own —
+        // it refreshes `arr` for whole-array readers only (mirrors SCCP).
+        let element_write_base = match &ssa_stmt.statement {
+            Statement::AssignConst { name, .. }
+            | Statement::AssignExpr { name, .. }
+            | Statement::AssignValue { name, .. }
+            | Statement::Incr { name, .. }
+                if name.contains('(') =>
+            {
+                ctx.ssa.var_symbol(crate::naming::normalise_var_name(name))
+            }
+            _ => None,
+        };
         for (&var, &ver) in &ssa_stmt.defs {
             let key = (var, ver);
             let old = types
@@ -1404,8 +1417,33 @@ fn type_infer_process_statements<S: std::hash::BuildHasher>(
                 name,
                 ctx.escaping,
                 ctx.has_dynamic_variable_trace,
-            ) {
+            ) || element_write_base == Some(var)
+            {
                 TypeLattice::overdefined()
+            } else if ssa_stmt.may_defs.contains(&var) {
+                // A synthetic may-def: the write may or may not have hit
+                // this element, so its type is the JOIN of the prior
+                // version's type (recorded as a use) and the written type
+                // — `set arr($k) 9` over an INT `arr(a)` stays INT, over a
+                // STRING one widens. No prior use (a base refresh from a
+                // Call def) → Overdefined.
+                match ssa_stmt.uses.get(&var) {
+                    Some(prev_ver) => {
+                        let prev = types
+                            .get(&(var, *prev_ver))
+                            .cloned()
+                            .unwrap_or_else(TypeLattice::overdefined);
+                        let written = match &inferred {
+                            DefTyping::Uniform(t) => t.clone(),
+                            DefTyping::PerDef(map) => map
+                                .get(name)
+                                .cloned()
+                                .unwrap_or_else(TypeLattice::overdefined),
+                        };
+                        type_join(&prev, &written)
+                    }
+                    None => TypeLattice::overdefined(),
+                }
             } else {
                 match &inferred {
                     DefTyping::Uniform(t) => t.clone(),
@@ -1600,6 +1638,7 @@ mod tests {
             statement: stmt,
             uses: HashMap::new(),
             defs: defs.iter().map(|&(n, v)| (ssa.intern_var(n), v)).collect(),
+            may_defs: std::collections::HashSet::new(),
         }
     }
 
@@ -2439,6 +2478,79 @@ mod tests {
         assert!(
             has_object_def,
             "some version of 'o' must carry the element class: {:?}",
+            fu.types
+        );
+    }
+
+    /// P5: constant-keyed array elements are independent variables — each
+    /// carries its own type (the oracle's "array elements behave as
+    /// independent scalars"), and the conflated base claims nothing.
+    #[test]
+    fn array_elements_type_independently() {
+        let cu = crate::compilation_unit::CompilationUnit::build_for(
+            "proc f {} {\n    set arr(a) 5\n    set arr(b) \"hello world\"\n    return $arr(a)\n}",
+            &tcl_registry::CommandRegistry::build_default(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let type_of = |name: &str| -> Vec<Option<TclType>> {
+            fu.types
+                .iter()
+                .filter(|((sym, ver), _)| *ver > 0 && fu.ssa.var_name(*sym) == name)
+                .map(|(_, t)| t.tcl_type())
+                .collect()
+        };
+        assert!(
+            type_of("arr(a)").iter().all(|t| *t == Some(TclType::Int)),
+            "arr(a) is INT in every version: {:?}",
+            fu.types
+        );
+        assert!(
+            type_of("arr(b)")
+                .iter()
+                .all(|t| *t == Some(TclType::String)),
+            "arr(b) is STRING independently: {:?}",
+            fu.types
+        );
+        assert!(
+            type_of("arr").iter().all(Option::is_none),
+            "the base symbol claims no value type: {:?}",
+            fu.types
+        );
+    }
+
+    /// P5: a dynamic-key write is a may-write over every known element —
+    /// the element's type JOINS with the written type (INT ⊔ INT stays
+    /// INT; INT ⊔ STRING widens) instead of trusting either side.
+    #[test]
+    fn dynamic_key_write_joins_element_types() {
+        let cu = crate::compilation_unit::CompilationUnit::build_for(
+            "proc f {k} {\n    set a(x) 5\n    set a($k) 9\n    return $a(x)\n}",
+            &tcl_registry::CommandRegistry::build_default(),
+            false,
+        );
+        let fu = cu.function("::f").unwrap();
+        let final_is_int = fu.types.iter().any(|((sym, ver), t)| {
+            *ver == 2 && fu.ssa.var_name(*sym) == "a(x)" && t.tcl_type() == Some(TclType::Int)
+        });
+        assert!(
+            final_is_int,
+            "INT ⊔ INT across the may-write stays INT: {:?}",
+            fu.types
+        );
+
+        let cu = crate::compilation_unit::CompilationUnit::build_for(
+            "proc g {k} {\n    set a(x) 5\n    set a($k) \"s t\"\n    return $a(x)\n}",
+            &tcl_registry::CommandRegistry::build_default(),
+            false,
+        );
+        let fu = cu.function("::g").unwrap();
+        let widened = fu.types.iter().any(|((sym, ver), t)| {
+            *ver == 2 && fu.ssa.var_name(*sym) == "a(x)" && t.tcl_type() == Some(TclType::Int)
+        });
+        assert!(
+            !widened,
+            "INT ⊔ STRING must not stay a single INT claim: {:?}",
             fu.types
         );
     }

--- a/rust/tcl-compiler/src/types.rs
+++ b/rust/tcl-compiler/src/types.rs
@@ -308,10 +308,21 @@ pub fn shape_join(a: &TypeShape, b: &TypeShape) -> Option<TypeShape> {
 pub fn join_elements(a: &Elements, b: &Elements) -> Elements {
     match (a, b) {
         (Elements::Unknown, _) | (_, Elements::Unknown) => Elements::Unknown,
-        // An empty container contributes no elements — the identity of the
-        // element join (`set acc [list]` then `lappend acc [Foo new]` keeps
-        // the object bound through the accumulator's version joins).
-        (Elements::Exact(e), other) | (other, Elements::Exact(e)) if e.is_empty() => other.clone(),
+        // An empty container contributes no elements to the *bound* but its
+        // arity-0 fact must not vanish: joining `[list]` with `[list 1]`
+        // keeps the element bound as a `Uniform` (the accumulator idiom —
+        // `set acc [list]` then `lappend acc [Foo new]` — stays typed) while
+        // dropping the other side's `Exact` arity, which the merged value
+        // does not have (`llength` may be 0). Two empties keep arity 0.
+        (Elements::Exact(ea), Elements::Exact(eb)) if ea.is_empty() && eb.is_empty() => {
+            Elements::Exact(Box::from([]))
+        }
+        (Elements::Exact(e), other) | (other, Elements::Exact(e)) if e.is_empty() => {
+            match other.uniform_shape() {
+                Some(u) => Elements::Uniform(Box::new(u)),
+                None => Elements::Unknown,
+            }
+        }
         (Elements::Exact(ea), Elements::Exact(eb)) if ea.len() == eb.len() => Elements::Exact(
             ea.iter()
                 .zip(eb.iter())

--- a/rust/tcl-compiler/src/types.rs
+++ b/rust/tcl-compiler/src/types.rs
@@ -19,53 +19,351 @@
 //! Tcl internal representation (intrep) type lattice.
 //!
 //! Tcl values are always strings but may cache a typed internal
-//! representation. This module models the set of known intreps
-//! and defines a lattice for tracking them through SSA dataflow.
+//! representation. This module models the set of known intreps as
+//! [`TypeShape`] terms — refining the registry's coarse [`TclType`]
+//! vocabulary with the numeric tower's bignum rung and per-element container
+//! facts — and tracks a **bounded union** of possible shapes per SSA value
+//! through dataflow (`docs/design/compiler/type-tracking.md`, P2).
 //!
 //! Lattice order (bottom to top):
 //!
 //! ```text
-//! UNKNOWN  <  KNOWN(t)  <  SHIMMERED(a, b)  <  OVERDEFINED
+//! UNKNOWN  <  UNION{s}  <  UNION{s1, s2}  <  …  <  OVERDEFINED
 //! ```
+//!
+//! A singleton union is the old `KNOWN(t)`; a multi-member union generalises
+//! the old `SHIMMERED(a, b)` pair — three or more differently-typed paths now
+//! stay tracked instead of collapsing to `OVERDEFINED` (the documented lossy
+//! point of the previous pair model). [`TypeKind`] survives as the coarse
+//! classification consumers switch on.
 
 use std::fmt;
+
+use crate::bounded_set::BoundedSet;
 
 // Re-export TclType from the registry crate (single source of truth).
 pub use tcl_registry::TclType;
 
-/// Lattice element kind, ordered bottom to top.
+/// Maximum members of a type union before widening to `OVERDEFINED`. Six
+/// covers every realistic per-variable type mix (the whole shape alphabet is
+/// only ~11 constructors, and the numeric family collapses to one member).
+pub const MAX_TYPE_UNION: usize = 6;
+
+/// Maximum tracked per-position elements of a `List` shape. `list` calls with
+/// more arguments keep the container shape but drop to [`Elements::Unknown`].
+pub const MAX_EXACT_ELEMENTS: usize = 16;
+
+/// Maximum container-nesting depth a shape records (`List<List<List<…>>>`).
+/// Deeper structure widens the *inner* elements to [`Elements::Unknown`] —
+/// bounding the lattice height so fixpoints over self-referential builders
+/// (`lappend v [list $v]`) terminate.
+pub const MAX_SHAPE_DEPTH: usize = 3;
+
+/// Element facts for a `List` / `Dict` shape.
+///
+/// Faithful to the runtime: container elements are shared `Tcl_Obj`s, so a
+/// computed element keeps its intrep inside the container (oracle-verified,
+/// type-tracking.md corpus) — `[list [expr {1+1}] "x y"]` genuinely is a list
+/// whose first element carries a numeric intrep.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum Elements {
+    /// No element facts (the lattice top for element structure).
+    Unknown,
+    /// Every element's shape is subsumed by the given shape.
+    Uniform(Box<TypeShape>),
+    /// Exactly `n` elements with per-position shapes; `None` positions carry
+    /// no fact. The arity itself is a fact even when every position is
+    /// `None` (`[list $a $b]` provably has `llength` 2).
+    Exact(Box<[Option<TypeShape>]>),
+}
+
+impl Elements {
+    /// The provable element count, when the structure pins one.
+    #[must_use]
+    pub fn known_len(&self) -> Option<usize> {
+        match self {
+            Elements::Exact(shapes) => Some(shapes.len()),
+            Elements::Uniform(_) | Elements::Unknown => None,
+        }
+    }
+
+    /// The shape of element `index`, when tracked.
+    #[must_use]
+    pub fn shape_at(&self, index: usize) -> Option<&TypeShape> {
+        match self {
+            Elements::Exact(shapes) => shapes.get(index).and_then(Option::as_ref),
+            Elements::Uniform(shape) => Some(shape),
+            Elements::Unknown => None,
+        }
+    }
+
+    /// The single shape subsuming every element, when provable: a `Uniform`'s
+    /// shape, or the join of an `Exact`'s fully-known positions.
+    #[must_use]
+    pub fn uniform_shape(&self) -> Option<TypeShape> {
+        match self {
+            Elements::Uniform(shape) => Some((**shape).clone()),
+            Elements::Exact(shapes) => {
+                let mut acc: Option<TypeShape> = None;
+                for shape in &**shapes {
+                    let shape = shape.as_ref()?;
+                    acc = Some(match acc {
+                        None => shape.clone(),
+                        Some(prev) => shape_join(&prev, shape)?,
+                    });
+                }
+                acc
+            }
+            Elements::Unknown => None,
+        }
+    }
+}
+
+/// A single value-type term — the compiler-internal refinement of the
+/// registry's coarse [`TclType`] vocabulary.
+///
+/// Purity (`typePtr == NULL`) is deliberately **not** a shape: whether a
+/// value's intrep is committed is a *program-point* property tracked by the
+/// commit dataflow ([`crate::shimmer::commit`]), not a property of the value
+/// term. A [`TypeShape::String`] is the "string rep" shape; whether it is
+/// still pure at a given use is the commit pass's answer.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum TypeShape {
+    /// String rep (pure or committed UTF cache — see the purity note above).
+    String,
+    /// Integer that fits a wide (`i64`).
+    Int,
+    /// Integer beyond a wide — the bignum rung of the numeric tower
+    /// (`expr {2**64}`; promotion is by magnitude, never wrapping).
+    Bignum,
+    /// IEEE-754 double.
+    Double,
+    /// Boolean-valued (word booleans and 0/1 comparison results).
+    Boolean,
+    /// Abstract "some number" — the join of the numeric tower.
+    Numeric,
+    /// Binary data.
+    ByteArray,
+    /// Tcl list, with optional element facts.
+    List(Elements),
+    /// Tcl dict, with optional facts about its **values**.
+    Dict(Elements),
+    /// `TclOO` / snit object instance, with its class when known.
+    Object(Option<Box<str>>),
+    /// I/O channel handle.
+    Channel,
+}
+
+impl TypeShape {
+    /// The registry-vocabulary coarsening of this shape.
+    #[must_use]
+    pub fn coarse(&self) -> TclType {
+        match self {
+            TypeShape::String => TclType::String,
+            TypeShape::Int | TypeShape::Bignum => TclType::Int,
+            TypeShape::Double => TclType::Double,
+            TypeShape::Boolean => TclType::Boolean,
+            TypeShape::Numeric => TclType::Numeric,
+            TypeShape::ByteArray => TclType::ByteArray,
+            TypeShape::List(_) => TclType::List,
+            TypeShape::Dict(_) => TclType::Dict,
+            TypeShape::Object(_) => TclType::Object,
+            TypeShape::Channel => TclType::Channel,
+        }
+    }
+
+    /// The structure-free shape for a registry [`TclType`].
+    #[must_use]
+    pub fn from_coarse(t: TclType) -> Self {
+        match t {
+            TclType::String => TypeShape::String,
+            TclType::Int => TypeShape::Int,
+            TclType::Double => TypeShape::Double,
+            TclType::Boolean => TypeShape::Boolean,
+            TclType::Numeric => TypeShape::Numeric,
+            TclType::ByteArray => TypeShape::ByteArray,
+            TclType::List => TypeShape::List(Elements::Unknown),
+            TclType::Dict => TypeShape::Dict(Elements::Unknown),
+            TclType::Object => TypeShape::Object(None),
+            TclType::Channel => TypeShape::Channel,
+        }
+    }
+
+    /// Whether this shape is in the numeric family — every value coerces to a
+    /// number, so it is subsumed by the abstract [`TypeShape::Numeric`].
+    /// `Boolean` counts (Tcl booleans are `0`/`1` integers).
+    #[must_use]
+    pub fn is_numeric_family(&self) -> bool {
+        matches!(
+            self,
+            TypeShape::Int
+                | TypeShape::Bignum
+                | TypeShape::Double
+                | TypeShape::Boolean
+                | TypeShape::Numeric
+        )
+    }
+
+    /// Widen element facts nested deeper than [`MAX_SHAPE_DEPTH`] to
+    /// [`Elements::Unknown`], bounding lattice height.
+    #[must_use]
+    fn clamp_depth(self) -> Self {
+        fn clamp(shape: TypeShape, budget: usize) -> TypeShape {
+            match shape {
+                TypeShape::List(e) => TypeShape::List(clamp_elements(e, budget)),
+                TypeShape::Dict(e) => TypeShape::Dict(clamp_elements(e, budget)),
+                other => other,
+            }
+        }
+        fn clamp_elements(e: Elements, budget: usize) -> Elements {
+            // `budget` counts remaining *container* levels including the one
+            // whose elements these are; at 1 the elements themselves would
+            // exceed the cap, so they widen away.
+            if budget <= 1 {
+                return Elements::Unknown;
+            }
+            match e {
+                Elements::Uniform(s) => Elements::Uniform(Box::new(clamp(*s, budget - 1))),
+                Elements::Exact(shapes) => Elements::Exact(
+                    shapes
+                        .into_vec()
+                        .into_iter()
+                        .map(|s| s.map(|s| clamp(s, budget - 1)))
+                        .collect(),
+                ),
+                Elements::Unknown => Elements::Unknown,
+            }
+        }
+        clamp(self, MAX_SHAPE_DEPTH)
+    }
+}
+
+impl fmt::Display for TypeShape {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            TypeShape::Object(Some(class)) => write!(f, "OBJECT({class})"),
+            TypeShape::Object(None) => write!(f, "Object"),
+            TypeShape::List(e) => write_container(f, "List", e),
+            TypeShape::Dict(e) => write_container(f, "Dict", e),
+            other => write!(f, "{other:?}"),
+        }
+    }
+}
+
+/// Render `List` / `Dict` with element detail when any is tracked:
+/// `List<Int, String>` (exact), `List<Int*>` (uniform), bare `List` otherwise.
+fn write_container(f: &mut fmt::Formatter<'_>, name: &str, e: &Elements) -> fmt::Result {
+    match e {
+        Elements::Unknown => write!(f, "{name}"),
+        Elements::Uniform(shape) => write!(f, "{name}<{shape}*>"),
+        Elements::Exact(shapes) => {
+            write!(f, "{name}<")?;
+            for (i, shape) in shapes.iter().enumerate() {
+                if i > 0 {
+                    write!(f, ", ")?;
+                }
+                match shape {
+                    Some(s) => write!(f, "{s}")?,
+                    None => write!(f, "?")?,
+                }
+            }
+            write!(f, ">")
+        }
+    }
+}
+
+/// Join two shapes into a **single** shape, or `None` when no single shape
+/// short of the union covers both (the caller keeps both as union members).
+///
+/// - Equal shapes join to themselves.
+/// - Numeric-family shapes join per the tower: `Boolean ⊔ Int = Int`
+///   (booleans are 0/1 ints); anything else in the family joins to the
+///   abstract [`TypeShape::Numeric`].
+/// - Two `List`s (or two `Dict`s) join element-wise.
+/// - Two `Object`s keep the class only when it matches.
+#[must_use]
+pub fn shape_join(a: &TypeShape, b: &TypeShape) -> Option<TypeShape> {
+    use TypeShape::{Boolean, Dict, Int, List, Numeric, Object};
+    if a == b {
+        return Some(a.clone());
+    }
+    match (a, b) {
+        (Boolean, Int) | (Int, Boolean) => Some(Int),
+        _ if a.is_numeric_family() && b.is_numeric_family() => Some(Numeric),
+        (List(ea), List(eb)) => Some(List(join_elements(ea, eb))),
+        (Dict(ea), Dict(eb)) => Some(Dict(join_elements(ea, eb))),
+        (Object(ca), Object(cb)) => Some(Object((ca == cb).then(|| ca.clone()).flatten())),
+        _ => None,
+    }
+}
+
+/// Join element facts of two same-kind containers.
+///
+/// `Unknown` (no facts) absorbs; equal-arity `Exact`s join pointwise (a
+/// position keeps a shape only when a single joined shape covers both);
+/// mismatched arities and `Uniform`s fall back to a uniform bound when every
+/// tracked position admits one, else `Unknown`. Arity collapse on mismatch is
+/// what makes loop-carried growth (`lappend` under a fixpoint) converge.
+#[must_use]
+pub fn join_elements(a: &Elements, b: &Elements) -> Elements {
+    match (a, b) {
+        (Elements::Unknown, _) | (_, Elements::Unknown) => Elements::Unknown,
+        // An empty container contributes no elements — the identity of the
+        // element join (`set acc [list]` then `lappend acc [Foo new]` keeps
+        // the object bound through the accumulator's version joins).
+        (Elements::Exact(e), other) | (other, Elements::Exact(e)) if e.is_empty() => other.clone(),
+        (Elements::Exact(ea), Elements::Exact(eb)) if ea.len() == eb.len() => Elements::Exact(
+            ea.iter()
+                .zip(eb.iter())
+                .map(|(x, y)| match (x, y) {
+                    (Some(x), Some(y)) => shape_join(x, y),
+                    _ => None,
+                })
+                .collect(),
+        ),
+        _ => match (a.uniform_shape(), b.uniform_shape()) {
+            (Some(x), Some(y)) => match shape_join(&x, &y) {
+                Some(joined) => Elements::Uniform(Box::new(joined)),
+                None => Elements::Unknown,
+            },
+            _ => Elements::Unknown,
+        },
+    }
+}
+
+/// Lattice element kind, ordered bottom to top — the coarse classification
+/// consumers switch on. `Known` is a singleton union; `Shimmered` is any
+/// multi-member union (two *or more* differently-typed paths — the pair
+/// restriction of the old model is gone).
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum TypeKind {
     /// Bottom — no information.
     Unknown,
-    /// Concrete type known.
+    /// Exactly one possible shape.
     Known,
-    /// Value has been shimmered between two types.
+    /// Two or more possible shapes (the value shimmers between them).
     Shimmered,
     /// Top — too many types to track.
     Overdefined,
 }
 
-/// A single element of the type lattice.
+/// The bounded union of possible shapes at a lattice node.
+type ShapeSet = BoundedSet<TypeShape, MAX_TYPE_UNION>;
+
+/// A single element of the type lattice: `UNKNOWN`, a canonicalised bounded
+/// union of [`TypeShape`]s, or `OVERDEFINED`.
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct TypeLattice {
-    /// Lattice position.
-    pub kind: TypeKind,
-    /// The concrete type (for `Known` and `Shimmered`).
-    pub tcl_type: Option<TclType>,
-    /// The source type before shimmer (for `Shimmered` only).
-    pub from_type: Option<TclType>,
-    /// Class name (for `Object` types only).
-    pub class_name: Option<String>,
-    /// Element class (for `List` / `Dict` *of objects* only): the value is a
-    /// collection every element of which is an `OBJECT(element_class)`.  Set by
-    /// [`Self::collection_of`], harvested from `dict set/append VAR k [C new]`,
-    /// `lappend VAR [C new]`, and `list`/`dict create` of object values, and
-    /// read out at retrieval sites (`dict get` / `lindex`) so an element
-    /// dispatched as `[dict get $coll $k] method …` resolves to `C`.  A join
-    /// of two collections whose element classes differ drops it (the container
-    /// is still `List`/`Dict`, just no longer object-homogeneous).
-    pub element_class: Option<String>,
+    repr: Repr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+enum Repr {
+    Unknown,
+    /// Invariant: canonical (sorted, subsumption-reduced, numeric-collapsed),
+    /// never empty.
+    Union(ShapeSet),
+    Overdefined,
 }
 
 impl TypeLattice {
@@ -73,11 +371,7 @@ impl TypeLattice {
     #[must_use]
     pub fn unknown() -> Self {
         Self {
-            kind: TypeKind::Unknown,
-            tcl_type: None,
-            from_type: None,
-            class_name: None,
-            element_class: None,
+            repr: Repr::Unknown,
         }
     }
 
@@ -85,219 +379,237 @@ impl TypeLattice {
     #[must_use]
     pub fn overdefined() -> Self {
         Self {
-            kind: TypeKind::Overdefined,
-            tcl_type: None,
-            from_type: None,
-            class_name: None,
-            element_class: None,
+            repr: Repr::Overdefined,
         }
     }
 
-    /// A known concrete type.
+    /// A single known shape.
+    #[must_use]
+    pub fn of_shape(shape: TypeShape) -> Self {
+        Self {
+            repr: Repr::Union(ShapeSet::singleton(shape.clamp_depth())),
+        }
+    }
+
+    /// A single known coarse type (structure-free shape).
     #[must_use]
     pub fn of(t: TclType) -> Self {
-        Self {
-            kind: TypeKind::Known,
-            tcl_type: Some(t),
-            from_type: None,
-            class_name: None,
-            element_class: None,
-        }
+        Self::of_shape(TypeShape::from_coarse(t))
     }
 
     /// A known `Object` type for a specific class.
     #[must_use]
     pub fn object_of(class_name: impl Into<String>) -> Self {
-        Self {
-            kind: TypeKind::Known,
-            tcl_type: Some(TclType::Object),
-            from_type: None,
-            class_name: Some(class_name.into()),
-            element_class: None,
-        }
+        Self::of_shape(TypeShape::Object(Some(class_name.into().into_boxed_str())))
     }
 
     /// A known `List` / `Dict` whose elements are all `OBJECT(element_class)`.
     /// `container` must be [`TclType::List`] or [`TclType::Dict`]; any other
-    /// type is treated as a plain known type with no element class (callers
+    /// type is treated as a plain known type with no element facts (callers
     /// only ever pass the two container types).
     #[must_use]
     pub fn collection_of(container: TclType, element_class: impl Into<String>) -> Self {
-        let element_class =
-            matches!(container, TclType::List | TclType::Dict).then(|| element_class.into());
-        Self {
-            kind: TypeKind::Known,
-            tcl_type: Some(container),
-            from_type: None,
-            class_name: None,
-            element_class,
+        let elements = Elements::Uniform(Box::new(TypeShape::Object(Some(
+            element_class.into().into_boxed_str(),
+        ))));
+        match container {
+            TclType::List => Self::of_shape(TypeShape::List(elements)),
+            TclType::Dict => Self::of_shape(TypeShape::Dict(elements)),
+            other => Self::of(other),
         }
     }
 
-    /// A shimmered pair (canonical order: from < to by `Ord`).
+    /// A union of the two coarse types (the old "shimmered pair" constructor;
+    /// members are stored canonically, so argument order is immaterial).
     #[must_use]
     pub fn shimmered(from: TclType, to: TclType) -> Self {
-        let (a, b) = if from <= to { (from, to) } else { (to, from) };
-        Self {
-            kind: TypeKind::Shimmered,
-            tcl_type: Some(b),
-            from_type: Some(a),
-            class_name: None,
-            element_class: None,
+        Self::union_of([TypeShape::from_coarse(from), TypeShape::from_coarse(to)])
+    }
+
+    /// A union of the given shapes — canonicalised, numeric-collapsed, and
+    /// widened to `OVERDEFINED` past [`MAX_TYPE_UNION`] distinct members.
+    #[must_use]
+    pub fn union_of(shapes: impl IntoIterator<Item = TypeShape>) -> Self {
+        let mut members: Vec<TypeShape> = Vec::new();
+        for shape in shapes {
+            if !merge_member(&mut members, shape.clamp_depth()) {
+                return Self::overdefined();
+            }
+        }
+        match ShapeSet::from_iter_bounded(members) {
+            Some(mut set) if !set.is_empty() => {
+                set.canonicalise();
+                Self {
+                    repr: Repr::Union(set),
+                }
+            }
+            Some(_) => Self::unknown(),
+            None => Self::overdefined(),
+        }
+    }
+
+    /// The coarse lattice classification.
+    #[must_use]
+    pub fn kind(&self) -> TypeKind {
+        match &self.repr {
+            Repr::Unknown => TypeKind::Unknown,
+            Repr::Union(set) if set.len() == 1 => TypeKind::Known,
+            Repr::Union(_) => TypeKind::Shimmered,
+            Repr::Overdefined => TypeKind::Overdefined,
+        }
+    }
+
+    /// The union members, in canonical order (empty for `UNKNOWN` /
+    /// `OVERDEFINED`).
+    #[must_use]
+    pub fn shapes(&self) -> &[TypeShape] {
+        match &self.repr {
+            Repr::Union(set) => set.as_slice(),
+            Repr::Unknown | Repr::Overdefined => &[],
+        }
+    }
+
+    /// The single shape of a `Known` node.
+    #[must_use]
+    pub fn single_shape(&self) -> Option<&TypeShape> {
+        match self.shapes() {
+            [one] => Some(one),
+            _ => None,
+        }
+    }
+
+    /// The single *coarse* type of a `Known` node — the accessor most
+    /// consumers key their type checks on.
+    #[must_use]
+    pub fn tcl_type(&self) -> Option<TclType> {
+        self.single_shape().map(TypeShape::coarse)
+    }
+
+    /// The canonical coarse pair of a two-member union (the old
+    /// `SHIMMERED(from, to)` reading; `from` sorts before `to`). `None` for
+    /// any other node, including 3+-member unions — walk [`Self::shapes`]
+    /// there.
+    #[must_use]
+    pub fn shimmer_pair(&self) -> Option<(TclType, TclType)> {
+        match self.shapes() {
+            [a, b] => Some((a.coarse(), b.coarse())),
+            _ => None,
+        }
+    }
+
+    /// The canonical outermost coarse pair of *any* multi-member union —
+    /// `shimmer_pair` generalised to 3+-member unions for consumers whose
+    /// report is inherently a two-type claim (the S102 oscillation message).
+    #[must_use]
+    pub fn shimmer_extremes(&self) -> Option<(TclType, TclType)> {
+        match self.shapes() {
+            [] | [_] => None,
+            many => Some((many[0].coarse(), many[many.len() - 1].coarse())),
+        }
+    }
+
+    /// The class of a `Known` object node.
+    #[must_use]
+    pub fn class_name(&self) -> Option<&str> {
+        match self.single_shape()? {
+            TypeShape::Object(class) => class.as_deref(),
+            _ => None,
+        }
+    }
+
+    /// Element facts of a `Known` `List` / `Dict` node.
+    #[must_use]
+    pub fn elements(&self) -> Option<&Elements> {
+        match self.single_shape()? {
+            TypeShape::List(e) | TypeShape::Dict(e) => Some(e),
+            _ => None,
         }
     }
 
     /// The object class of this collection's elements, when it is a
     /// `List`/`Dict` known to be homogeneous in `OBJECT(class)` — the signal a
-    /// `dict get` / `lindex` retrieval reads to type its result.
+    /// `dict get` / `lindex` retrieval reads to type its result. Both element
+    /// carriers qualify: a `Uniform` object bound, and an `Exact` whose every
+    /// position holds the same class.
     #[must_use]
     pub fn element_class(&self) -> Option<&str> {
-        (self.kind == TypeKind::Known
-            && matches!(self.tcl_type, Some(TclType::List | TclType::Dict)))
-        .then_some(self.element_class.as_deref())
-        .flatten()
+        match self.elements()? {
+            Elements::Uniform(shape) => match shape.as_ref() {
+                TypeShape::Object(Some(class)) => Some(class),
+                _ => None,
+            },
+            Elements::Exact(shapes) => {
+                let TypeShape::Object(Some(class)) = shapes.first()?.as_ref()? else {
+                    return None;
+                };
+                shapes
+                    .iter()
+                    .all(|s| matches!(s, Some(TypeShape::Object(Some(c))) if c == class))
+                    .then_some(&**class)
+            }
+            Elements::Unknown => None,
+        }
     }
 }
 
 impl fmt::Display for TypeLattice {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        match self.kind {
-            TypeKind::Unknown => write!(f, "UNKNOWN"),
-            TypeKind::Overdefined => write!(f, "OVERDEFINED"),
-            TypeKind::Known if self.tcl_type == Some(TclType::Object) => {
-                write!(f, "OBJECT({})", self.class_name.as_deref().unwrap_or("?"))
-            }
-            TypeKind::Known if self.element_class().is_some() => write!(
-                f,
-                "{:?}<OBJECT({})>",
-                self.tcl_type.unwrap(),
-                self.element_class().unwrap()
-            ),
-            TypeKind::Known => write!(f, "{:?}", self.tcl_type.unwrap()),
-            TypeKind::Shimmered => write!(
-                f,
-                "SHIMMERED({:?}, {:?})",
-                self.from_type.unwrap(),
-                self.tcl_type.unwrap()
-            ),
+        match &self.repr {
+            Repr::Unknown => write!(f, "UNKNOWN"),
+            Repr::Overdefined => write!(f, "OVERDEFINED"),
+            Repr::Union(set) => match set.as_slice() {
+                [one] => write!(f, "{one}"),
+                many => {
+                    // The two-member rendering keeps the historical
+                    // `SHIMMERED(a, b)` spelling; wider unions enumerate.
+                    write!(f, "SHIMMERED(")?;
+                    for (i, shape) in many.iter().enumerate() {
+                        if i > 0 {
+                            write!(f, ", ")?;
+                        }
+                        write!(f, "{shape}")?;
+                    }
+                    write!(f, ")")
+                }
+            },
         }
     }
+}
+
+/// Merge `shape` into `members`, applying subsumption: numeric-family members
+/// collapse per [`shape_join`]'s tower rules, and same-constructor containers
+/// / objects join structurally so a union never holds two `List` members.
+/// Returns `false` when the union must widen (never happens today — the
+/// alphabet is small — but guards the cap invariant).
+fn merge_member(members: &mut Vec<TypeShape>, shape: TypeShape) -> bool {
+    let mut incoming = shape;
+    let mut i = 0;
+    while i < members.len() {
+        if let Some(joined) = shape_join(&members[i], &incoming) {
+            members.remove(i);
+            incoming = joined;
+            // Restart: the joined shape may now subsume other members
+            // (e.g. Int absorbing Boolean then meeting Double → Numeric).
+            i = 0;
+        } else {
+            i += 1;
+        }
+    }
+    members.push(incoming);
+    members.len() <= MAX_TYPE_UNION
 }
 
 /// Compute the join (least upper bound) of two type lattice elements.
 #[must_use]
 pub fn type_join(a: &TypeLattice, b: &TypeLattice) -> TypeLattice {
-    // Identity / absorbing
-    if a.kind == TypeKind::Unknown {
-        return b.clone();
-    }
-    if b.kind == TypeKind::Unknown {
-        return a.clone();
-    }
-    if a.kind == TypeKind::Overdefined || b.kind == TypeKind::Overdefined {
-        return TypeLattice::overdefined();
-    }
-
-    // Both KNOWN
-    if a.kind == TypeKind::Known && b.kind == TypeKind::Known {
-        let at = a.tcl_type.unwrap();
-        let bt = b.tcl_type.unwrap();
-        if at == bt {
-            if at == TclType::Object {
-                if a.class_name == b.class_name {
-                    return a.clone();
-                }
-                return TypeLattice::of(TclType::Object);
-            }
-            // A `List`/`Dict` carries an element class only while both sides
-            // agree it is object-homogeneous in the *same* class; otherwise the
-            // container type survives but the element class widens away.
-            if matches!(at, TclType::List | TclType::Dict) && a.element_class != b.element_class {
-                return TypeLattice::of(at);
-            }
-            return a.clone();
-        }
-        // Numeric promotion
-        if let Some(promoted) = numeric_promotion(at, bt) {
-            return TypeLattice::of(promoted);
-        }
-        return TypeLattice::shimmered(at, bt);
-    }
-
-    // Both SHIMMERED
-    if a.kind == TypeKind::Shimmered && b.kind == TypeKind::Shimmered {
-        if a == b {
-            return a.clone();
-        }
-        return TypeLattice::overdefined();
-    }
-
-    // One KNOWN, one SHIMMERED — normalise so `known` is first
-    let (known, shimmer) = if a.kind == TypeKind::Known {
-        (a, b)
-    } else {
-        (b, a)
-    };
-    let kt = known.tcl_type.unwrap();
-    let (from, to) = (shimmer.from_type.unwrap(), shimmer.tcl_type.unwrap());
-    // Exact match on either side: the known type is already one of the two the
-    // value shimmers between, so the merge stays that same shimmer.
-    if kt == from || kt == to {
-        return shimmer.clone();
-    }
-    // Numeric refinement: a `Known` numeric type (Int / Double / Boolean /
-    // Numeric) meeting a *numeric* shimmer side is subsumed by that side —
-    // `expr {$x + 1}` on an unknown-typed `$x` legitimately yields the coarser
-    // `Numeric`, so an `Int` reaching that merge is not a third, conflicting
-    // intrep. The value still oscillates between "numeric" and the other side,
-    // so it must stay SHIMMERED rather than degrade to OVERDEFINED (which
-    // silently masks the shimmer for S100/S101/S102 — a false negative). The
-    // numeric side widens to `Numeric` so the result is a sound upper bound of
-    // the `Known` type: `Double ⊔ SHIMMERED(Int, String)` = `SHIMMERED(Numeric,
-    // String)`, which covers `Double` — `SHIMMERED(Int, …)` would not. Exact
-    // equality is handled above, so widening here never narrows.
-    //
-    // NB: this must NOT be routed through `numeric_promotion`, which returns
-    // `Some` whenever *either* operand is `Double` (so `numeric_promotion(Double,
-    // String)` wrongly yields `Numeric`) — that would drop the genuinely
-    // non-numeric side. The predicate below requires *both* the known type and
-    // the matched side to be numeric-family.
-    if is_numeric_family(kt) {
-        if is_numeric_family(from) {
-            return TypeLattice::shimmered(TclType::Numeric, to);
-        }
-        if is_numeric_family(to) {
-            return TypeLattice::shimmered(from, TclType::Numeric);
+    match (&a.repr, &b.repr) {
+        (Repr::Unknown, _) => b.clone(),
+        (_, Repr::Unknown) => a.clone(),
+        (Repr::Overdefined, _) | (_, Repr::Overdefined) => TypeLattice::overdefined(),
+        (Repr::Union(sa), Repr::Union(sb)) => {
+            TypeLattice::union_of(sa.iter().chain(sb.iter()).cloned())
         }
     }
-    TypeLattice::overdefined()
-}
-
-/// True when `t` is a numeric-family intrep — one whose values all coerce to a
-/// number, so it is subsumed by the coarse [`TclType::Numeric`]. `Boolean`
-/// counts (Tcl booleans are `0`/`1` integers).
-fn is_numeric_family(t: TclType) -> bool {
-    matches!(
-        t,
-        TclType::Int | TclType::Double | TclType::Boolean | TclType::Numeric
-    )
-}
-
-/// Numeric promotion for Tcl types.
-fn numeric_promotion(a: TclType, b: TclType) -> Option<TclType> {
-    // Use an unordered pair for symmetric matching.
-    let pair = [a, b];
-    let has = |t: TclType| pair.contains(&t);
-
-    if has(TclType::Boolean) && has(TclType::Int) {
-        return Some(TclType::Int);
-    }
-    let numeric_pair = (has(TclType::Boolean) || has(TclType::Int) || has(TclType::Double))
-        && (has(TclType::Double) || has(TclType::Numeric));
-    if numeric_pair {
-        return Some(TclType::Numeric);
-    }
-    None
 }
 
 #[cfg(test)]
@@ -307,7 +619,7 @@ mod tests {
     #[test]
     fn unknown_is_bottom() {
         let u = TypeLattice::unknown();
-        assert_eq!(u.kind, TypeKind::Unknown);
+        assert_eq!(u.kind(), TypeKind::Unknown);
         let k = TypeLattice::of(TclType::Int);
         assert_eq!(type_join(&u, &k), k);
         assert_eq!(type_join(&k, &u), k);
@@ -317,8 +629,8 @@ mod tests {
     fn overdefined_is_top() {
         let o = TypeLattice::overdefined();
         let k = TypeLattice::of(TclType::Int);
-        assert_eq!(type_join(&o, &k).kind, TypeKind::Overdefined);
-        assert_eq!(type_join(&k, &o).kind, TypeKind::Overdefined);
+        assert_eq!(type_join(&o, &k).kind(), TypeKind::Overdefined);
+        assert_eq!(type_join(&k, &o).kind(), TypeKind::Overdefined);
     }
 
     #[test]
@@ -346,14 +658,44 @@ mod tests {
         let a = TypeLattice::of(TclType::Int);
         let b = TypeLattice::of(TclType::List);
         let joined = type_join(&a, &b);
-        assert_eq!(joined.kind, TypeKind::Shimmered);
+        assert_eq!(joined.kind(), TypeKind::Shimmered);
+        assert_eq!(joined.shimmer_pair(), Some((TclType::Int, TclType::List)));
     }
 
+    /// The un-masking at the heart of P2: a three-way merge of incompatible
+    /// types stays a tracked union instead of collapsing to `OVERDEFINED`
+    /// (the old pair model's documented lossy point).
     #[test]
-    fn different_shimmered_is_overdefined() {
+    fn three_way_merge_stays_tracked_union() {
+        let ab = type_join(
+            &TypeLattice::of(TclType::Int),
+            &TypeLattice::of(TclType::List),
+        );
+        let abc = type_join(&ab, &TypeLattice::of(TclType::Dict));
+        assert_eq!(abc.kind(), TypeKind::Shimmered);
+        assert_eq!(abc.shapes().len(), 3, "{abc}");
+        // And a fourth non-numeric member still tracks.
+        let abcd = type_join(&abc, &TypeLattice::of(TclType::ByteArray));
+        assert_eq!(abcd.shapes().len(), 4, "{abcd}");
+    }
+
+    /// Two disjoint shimmer pairs merge member-wise: the numeric members
+    /// collapse (`Int ⊔ Double = Numeric`) and the containers survive —
+    /// previously OVERDEFINED.
+    #[test]
+    fn different_shimmered_pairs_merge_memberwise() {
         let a = TypeLattice::shimmered(TclType::Int, TclType::List);
         let b = TypeLattice::shimmered(TclType::Double, TclType::Dict);
-        assert_eq!(type_join(&a, &b).kind, TypeKind::Overdefined);
+        let joined = type_join(&a, &b);
+        assert_eq!(joined.kind(), TypeKind::Shimmered);
+        assert_eq!(
+            joined,
+            TypeLattice::union_of([
+                TypeShape::Numeric,
+                TypeShape::List(Elements::Unknown),
+                TypeShape::Dict(Elements::Unknown)
+            ])
+        );
     }
 
     #[test]
@@ -369,47 +711,27 @@ mod tests {
         assert_eq!(type_join(&known, &shimmer), shimmer);
     }
 
-    #[test]
-    fn known_no_match_shimmered_is_overdefined() {
-        let shimmer = TypeLattice::shimmered(TclType::Int, TclType::List);
-        let known = TypeLattice::of(TclType::Dict);
-        assert_eq!(type_join(&known, &shimmer).kind, TypeKind::Overdefined);
-    }
-
     /// A `Known(Int)` meeting `SHIMMERED(Numeric, String)` must stay
-    /// SHIMMERED, not degrade to OVERDEFINED: `Int` is subsumed by the
-    /// `Numeric` side (`expr {$x + 1}` on an unknown `$x` yields `Numeric`),
-    /// so the value still oscillates numeric↔string. Degrading here silently
-    /// masks the shimmer for S100/S101/S102.
+    /// SHIMMERED: `Int` is subsumed by the `Numeric` member.
     #[test]
     fn known_int_matches_numeric_shimmer_side() {
         let shimmer = TypeLattice::shimmered(TclType::Numeric, TclType::String);
         let known = TypeLattice::of(TclType::Int);
         let joined = type_join(&known, &shimmer);
-        assert_eq!(joined.kind, TypeKind::Shimmered);
-        assert_eq!(
-            joined,
-            TypeLattice::shimmered(TclType::Numeric, TclType::String)
-        );
-        // Symmetric.
+        assert_eq!(joined, shimmer);
         assert_eq!(type_join(&shimmer, &known), joined);
     }
 
-    /// `Boolean` (an int-family type) also matches a `Numeric` shimmer side.
+    /// `Boolean` (an int-family type) also folds into a `Numeric` member.
     #[test]
     fn known_boolean_matches_numeric_shimmer_side() {
         let shimmer = TypeLattice::shimmered(TclType::Numeric, TclType::List);
         let known = TypeLattice::of(TclType::Boolean);
-        assert_eq!(
-            type_join(&known, &shimmer),
-            TypeLattice::shimmered(TclType::Numeric, TclType::List)
-        );
+        assert_eq!(type_join(&known, &shimmer), shimmer);
     }
 
-    /// A `Known(Double)` meeting `SHIMMERED(Int, String)` must widen the
-    /// numeric side to `Numeric` — `SHIMMERED(Int, String)` would not be a
-    /// sound upper bound of `Double` (it does not cover `Double`). This keeps
-    /// `type_join` a true least-upper-bound.
+    /// A `Known(Double)` meeting `SHIMMERED(Int, String)` widens the numeric
+    /// member to `Numeric` — the union stays a sound upper bound.
     #[test]
     fn known_double_widens_int_shimmer_side_to_numeric() {
         let shimmer = TypeLattice::shimmered(TclType::Int, TclType::String);
@@ -420,17 +742,18 @@ mod tests {
         );
     }
 
-    /// A non-numeric `Known` type that matches neither side of a shimmer still
-    /// degrades to OVERDEFINED — the numeric refinement must not blanket-keep
-    /// every Known/Shimmered join shimmered.
+    /// A non-numeric `Known` type meeting a 2-union becomes a 3-union —
+    /// tracked, where the pair model degraded to OVERDEFINED.
     #[test]
-    fn known_non_numeric_no_match_still_overdefined() {
+    fn known_non_numeric_no_match_becomes_three_union() {
         let shimmer = TypeLattice::shimmered(TclType::Numeric, TclType::List);
         let known = TypeLattice::of(TclType::Dict);
-        assert_eq!(type_join(&known, &shimmer).kind, TypeKind::Overdefined);
+        let joined = type_join(&known, &shimmer);
+        assert_eq!(joined.kind(), TypeKind::Shimmered);
+        assert_eq!(joined.shapes().len(), 3);
     }
 
-    /// An exact match on a non-numeric side is unchanged by the refinement:
+    /// An exact match on a non-numeric member is unchanged:
     /// `Known(List) ⊔ SHIMMERED(Int, List)` stays `SHIMMERED(Int, List)`.
     #[test]
     fn known_exact_non_numeric_side_unchanged() {
@@ -449,8 +772,83 @@ mod tests {
     fn object_different_class_widens() {
         let a = TypeLattice::object_of("Foo");
         let b = TypeLattice::object_of("Bar");
+        assert_eq!(type_join(&a, &b), TypeLattice::of(TclType::Object));
+    }
+
+    /// Element facts: same-arity exact lists join pointwise; mismatched
+    /// arities fall back to a uniform bound; a `Unknown` member absorbs.
+    #[test]
+    fn list_element_joins() {
+        let exact2 = |a: TypeShape, b: TypeShape| {
+            TypeShape::List(Elements::Exact(vec![Some(a), Some(b)].into_boxed_slice()))
+        };
+        // Pointwise: (Int, String) ⊔ (Boolean, String) = (Int, String).
+        let j = type_join(
+            &TypeLattice::of_shape(exact2(TypeShape::Int, TypeShape::String)),
+            &TypeLattice::of_shape(exact2(TypeShape::Boolean, TypeShape::String)),
+        );
+        assert_eq!(
+            j,
+            TypeLattice::of_shape(exact2(TypeShape::Int, TypeShape::String))
+        );
+        // Arity mismatch → uniform bound when one exists.
+        let j2 = type_join(
+            &TypeLattice::of_shape(exact2(TypeShape::Int, TypeShape::Int)),
+            &TypeLattice::of_shape(TypeShape::List(Elements::Exact(
+                vec![Some(TypeShape::Int)].into_boxed_slice(),
+            ))),
+        );
+        assert_eq!(
+            j2,
+            TypeLattice::of_shape(TypeShape::List(Elements::Uniform(Box::new(TypeShape::Int))))
+        );
+        // Unknown absorbs.
+        let j3 = type_join(
+            &TypeLattice::of_shape(exact2(TypeShape::Int, TypeShape::Int)),
+            &TypeLattice::of(TclType::List),
+        );
+        assert_eq!(j3, TypeLattice::of(TclType::List));
+    }
+
+    /// Homogeneous object collections keep their element class through joins
+    /// (the old `element_class` behaviour, now via `Elements`).
+    #[test]
+    fn object_collection_element_class_survives_and_widens() {
+        let a = TypeLattice::collection_of(TclType::Dict, "Foo");
+        assert_eq!(a.element_class(), Some("Foo"));
+        assert_eq!(type_join(&a, &a).element_class(), Some("Foo"));
+        let b = TypeLattice::collection_of(TclType::Dict, "Bar");
         let joined = type_join(&a, &b);
-        assert_eq!(joined, TypeLattice::of(TclType::Object));
+        // Classes differ → the container survives, the class widens away.
+        assert_eq!(joined.tcl_type(), Some(TclType::Dict));
+        assert_eq!(joined.element_class(), None);
+    }
+
+    /// Exact arity is a fact even with no per-position shapes.
+    #[test]
+    fn exact_arity_without_shapes() {
+        let l = TypeShape::List(Elements::Exact(vec![None, None].into_boxed_slice()));
+        let tl = TypeLattice::of_shape(l);
+        assert_eq!(tl.elements().and_then(Elements::known_len), Some(2));
+    }
+
+    /// Depth clamping bounds nested structure (fixpoint termination): the
+    /// shape survives but its nesting is cut at `MAX_SHAPE_DEPTH`.
+    #[test]
+    fn depth_clamp_bounds_nesting() {
+        fn max_depth(s: &TypeShape) -> usize {
+            match s {
+                TypeShape::List(Elements::Uniform(inner))
+                | TypeShape::Dict(Elements::Uniform(inner)) => 1 + max_depth(inner),
+                _ => 1,
+            }
+        }
+        let mut shape = TypeShape::Int;
+        for _ in 0..10 {
+            shape = TypeShape::List(Elements::Uniform(Box::new(shape)));
+        }
+        let tl = TypeLattice::of_shape(shape);
+        assert!(max_depth(tl.single_shape().unwrap()) <= MAX_SHAPE_DEPTH);
     }
 
     #[test]
@@ -462,6 +860,17 @@ mod tests {
         assert_eq!(
             TypeLattice::shimmered(TclType::Int, TclType::List).to_string(),
             "SHIMMERED(Int, List)"
+        );
+        assert_eq!(
+            TypeLattice::collection_of(TclType::List, "C").to_string(),
+            "List<OBJECT(C)*>"
+        );
+        assert_eq!(
+            TypeLattice::of_shape(TypeShape::List(Elements::Exact(
+                vec![Some(TypeShape::Int), None].into_boxed_slice()
+            )))
+            .to_string(),
+            "List<Int, ?>"
         );
     }
 }

--- a/rust/tcl-compiler/src/var_refs.rs
+++ b/rust/tcl-compiler/src/var_refs.rs
@@ -183,7 +183,12 @@ impl VarReferenceScanner {
                 TokenType::Var => {
                     let text = source_map.token_text(*tok);
                     let name = if self.options.element_qualified {
-                        element_var_name(text)
+                        // The `${…}` brace form substitutes nothing inside,
+                        // so its key is literal even when it spells `$x` —
+                        // the sigil-stripped token text can't show that, but
+                        // the raw span keeps the `${` prefix.
+                        let braced = source_map.text(tok.span).starts_with("${");
+                        crate::naming::element_var_name_braced(text, braced)
                     } else {
                         normalise_var_name(text)
                     };

--- a/rust/tcl-compiler/src/var_refs.rs
+++ b/rust/tcl-compiler/src/var_refs.rs
@@ -31,9 +31,10 @@ use std::collections::{BTreeSet, HashMap, VecDeque};
 use tcl_lexer::{Lexer, SourceMap, TokenType};
 use tcl_registry::{ArgRole, CommandRegistry};
 
-use crate::naming::normalise_var_name;
+use crate::naming::{element_var_name, normalise_var_name};
 
 /// Options controlling what a [`VarReferenceScanner`] looks for.
+#[allow(clippy::struct_excessive_bools)] // option flags, not a state machine
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct VarScanOptions {
     /// When `true`, also collect variable names passed as
@@ -47,6 +48,12 @@ pub struct VarScanOptions {
     /// only — intended for dead-store / unused-variable liveness recovery,
     /// kept out of SSA `uses` so read-before-set versioning is unperturbed.
     pub include_reads_before_write: bool,
+    /// When `true`, report constant-keyed array elements as their own
+    /// variables (`arr(k)`) instead of the conflated base — the SSA build's
+    /// per-element naming ([`crate::naming::element_var_name`]). Off for
+    /// name-level consumers (unused-variable liveness, scope bookkeeping),
+    /// which reason about the base.
+    pub element_qualified: bool,
 }
 
 impl Default for VarScanOptions {
@@ -55,6 +62,7 @@ impl Default for VarScanOptions {
             include_var_read_roles: false,
             recurse_cmd_substitutions: true,
             include_reads_before_write: false,
+            element_qualified: false,
         }
     }
 }
@@ -96,6 +104,24 @@ impl VarReferenceScanner {
             cache: HashMap::new(),
             order: VecDeque::new(),
             cache_size,
+        }
+    }
+
+    /// Whether this scanner reports element-qualified names
+    /// ([`VarScanOptions::element_qualified`]).
+    #[must_use]
+    pub fn element_qualified(&self) -> bool {
+        self.options.element_qualified
+    }
+
+    /// The canonical name this scanner's consumer records for a raw
+    /// variable word: element-qualified or base, per the options.
+    #[must_use]
+    pub fn canonical_name<'a>(&self, raw: &'a str) -> &'a str {
+        if self.options.element_qualified {
+            element_var_name(raw)
+        } else {
+            normalise_var_name(raw)
         }
     }
 
@@ -156,7 +182,11 @@ impl VarReferenceScanner {
             match tok.kind {
                 TokenType::Var => {
                     let text = source_map.token_text(*tok);
-                    let name = normalise_var_name(text);
+                    let name = if self.options.element_qualified {
+                        element_var_name(text)
+                    } else {
+                        normalise_var_name(text)
+                    };
                     if !name.is_empty() {
                         vars_found.insert(name.to_owned());
                     }
@@ -173,8 +203,12 @@ impl VarReferenceScanner {
         }
 
         if self.options.include_var_read_roles {
-            let role_vars =
-                scan_var_read_role_names(source, registry, self.options.include_reads_before_write);
+            let role_vars = scan_var_read_role_names(
+                source,
+                registry,
+                self.options.include_reads_before_write,
+                self.options.element_qualified,
+            );
             vars_found.extend(role_vars);
         }
 
@@ -191,6 +225,7 @@ fn scan_var_read_role_names(
     source: &str,
     registry: &CommandRegistry,
     include_rmw: bool,
+    element_qualified: bool,
 ) -> BTreeSet<String> {
     let mut result = BTreeSet::new();
     let source_map = SourceMap::new(source);
@@ -223,7 +258,11 @@ fn scan_var_read_role_names(
         }
         for idx in read_idx {
             if idx < args.len() {
-                let name = normalise_var_name(args[idx]);
+                let name = if element_qualified {
+                    element_var_name(args[idx])
+                } else {
+                    normalise_var_name(args[idx])
+                };
                 if !name.is_empty() {
                     result.insert(name.to_owned());
                 }
@@ -269,6 +308,7 @@ pub fn vars_in_word(text: &str, registry: &CommandRegistry) -> BTreeSet<String> 
         include_var_read_roles: true,
         recurse_cmd_substitutions: true,
         include_reads_before_write: false,
+        element_qualified: false,
     });
     scanner.scan_word(text, registry)
 }
@@ -431,6 +471,7 @@ mod tests {
             include_var_read_roles: false,
             recurse_cmd_substitutions: false,
             include_reads_before_write: false,
+            element_qualified: false,
         });
         // With recursion off, $inner inside [cmd $inner] should NOT be found.
         let vars = scanner.scan_word("[set x $inner]", &reg);
@@ -447,6 +488,7 @@ mod tests {
             include_var_read_roles: false,
             recurse_cmd_substitutions: true,
             include_reads_before_write: false,
+            element_qualified: false,
         });
         let vars = scanner.scan_word("[set x $inner]", &reg);
         assert!(

--- a/rust/tcl-compiler/src/var_resolve.rs
+++ b/rust/tcl-compiler/src/var_resolve.rs
@@ -89,6 +89,7 @@ fn inner_read_places(text: &str, ctx: &ResolveContext, registry: &CommandRegistr
         include_var_read_roles: true,
         recurse_cmd_substitutions: true,
         include_reads_before_write: false,
+        element_qualified: false,
     });
     let names = scanner.scan_word(text, registry);
     let mut places: Vec<Place> = names.iter().map(|n| bind_scalar(n, ctx, None)).collect();

--- a/rust/tcl-compiler/tests/core_analyses.rs
+++ b/rust/tcl-compiler/tests/core_analyses.rs
@@ -334,14 +334,14 @@ if {$total > 5} {
         // 0 → "0"; NaN → not a finite numeric literal).
         use tcl_compiler::{TclValue, format_tcl_value};
         // Non-NaN values format to their Tcl text. (Tcl booleans are Int(0/1).)
-        assert_eq!(format_tcl_value(TclValue::Int(42)), "42");
-        assert_eq!(format_tcl_value(TclValue::Int(1)), "1");
-        assert_eq!(format_tcl_value(TclValue::Int(0)), "0");
+        assert_eq!(format_tcl_value(&TclValue::Int(42)), "42");
+        assert_eq!(format_tcl_value(&TclValue::Int(1)), "1");
+        assert_eq!(format_tcl_value(&TclValue::Int(0)), "0");
         // A NaN float must not format to something an optimiser could splice
         // back as a number (it would defeat the runtime ARITH DOMAIN). The
         // formatter must not render it as a finite numeric literal like
         // "nan"/"0"/"" that would re-parse to a usable value.
-        let nan = format_tcl_value(TclValue::Float(f64::NAN));
+        let nan = format_tcl_value(&TclValue::Float(f64::NAN));
         assert!(
             !matches!(nan.parse::<f64>(), Ok(f) if f.is_finite()),
             "NaN must not render as a finite numeric literal, got {nan:?}"
@@ -403,10 +403,10 @@ mod new_lowering_analysis {
         // `hello` and items is a list.
         let cu = build("lappend items hello");
         if let Some(t) = ty(&cu.top_level, "items", 1)
-            && t.kind == TypeKind::Known
+            && t.kind() == TypeKind::Known
         {
             assert_eq!(
-                t.tcl_type,
+                t.tcl_type(),
                 Some(TclType::List),
                 "lappend result must be LIST"
             );
@@ -443,8 +443,8 @@ mod interpolation_folding {
         // value is Overdefined but the type is known).
         let cu = build("set c [expr {0+1}]\nset c \"${c}0\"");
         let t = ty(&cu.top_level, "c", 2).expect("c₂ has a type");
-        assert_eq!(t.kind, TypeKind::Known);
-        assert_eq!(t.tcl_type, Some(TclType::String));
+        assert_eq!(t.kind(), TypeKind::Known);
+        assert_eq!(t.tcl_type(), Some(TclType::String));
     }
 
     #[test]

--- a/rust/tcl-compiler/tests/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/tests/tcl_expr_eval.rs
@@ -269,18 +269,16 @@ fn exponentiation_float_negative_exponent() {
 }
 
 #[test]
-fn exponentiation_big_results_past_wide_decline_to_fold() {
-    // The folder is i64-width. tclsh (bignum) gives:
-    //   10**17=100000000000000000   (≤ i64::MAX → folds)
-    //   10**18=1000000000000000000  (≤ i64::MAX → folds)
-    //   10**19=10000000000000000000 (> i64::MAX → a Tcl `Big`)
-    // The const-folder's value is i64/f64, so a magnitude past a wide "can't
-    // fold" → None (matching the documented "value past a wide" behaviour and
-    // the in-crate `overflow_returns_none` test). Here the runtime form takes
-    // over instead.
+fn exponentiation_big_results_past_wide_stay_exact() {
+    // The folder is bignum-exact (type-tracking P4): a result past a wide
+    // promotes to the exact bignum tclsh computes — never wrapped, never
+    // declined, never a rounded double.
     assert_eq!(eval_str("10 ** 17"), Some(int(100_000_000_000_000_000)));
     assert_eq!(eval_str("10 ** 18"), Some(int(1_000_000_000_000_000_000)));
-    assert_eq!(eval_str("10 ** 19"), None); // 1e19 > i64::MAX → declined
+    assert_eq!(
+        eval_str("10 ** 19"),
+        Some(TclValue::Big("10000000000000000000".parse().unwrap()))
+    );
 }
 
 #[test]

--- a/rust/tcl-compiler/tests/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/tests/tcl_expr_eval.rs
@@ -48,7 +48,7 @@
 //!   (`None`) when they disagree (`010`: octal 8 vs decimal 10) rather than
 //!   guessing.
 //! * **`format_tcl_value`** takes a `TclValue`, so free-float cases are written
-//!   `format_tcl_value(TclValue::Float(3.14))`.
+//!   `format_tcl_value(&TclValue::Float(3.14))`.
 //!
 //! No test is `#[ignore]`d; every const-fold result here matches tclsh.
 
@@ -729,40 +729,43 @@ fn unevaluable_command_substitution_and_empty() {
 
 #[test]
 fn format_tcl_value_integers() {
-    assert_eq!(format_tcl_value(TclValue::Int(42)), "42");
-    assert_eq!(format_tcl_value(TclValue::Int(-7)), "-7");
-    assert_eq!(format_tcl_value(TclValue::Int(0)), "0");
+    assert_eq!(format_tcl_value(&TclValue::Int(42)), "42");
+    assert_eq!(format_tcl_value(&TclValue::Int(-7)), "-7");
+    assert_eq!(format_tcl_value(&TclValue::Int(0)), "0");
 }
 
 #[test]
 fn format_tcl_value_floats() {
     // Whole-valued doubles keep a trailing `.0`; fractional ones round-trip.
-    assert_eq!(format_tcl_value(TclValue::Float(3.0)), "3.0");
-    assert_eq!(format_tcl_value(TclValue::Float(3.14)), "3.14");
-    assert_eq!(format_tcl_value(TclValue::Float(42.0)), "42.0");
-    assert_eq!(format_tcl_value(TclValue::Float(-1.0)), "-1.0");
+    assert_eq!(format_tcl_value(&TclValue::Float(3.0)), "3.0");
+    assert_eq!(format_tcl_value(&TclValue::Float(3.14)), "3.14");
+    assert_eq!(format_tcl_value(&TclValue::Float(42.0)), "42.0");
+    assert_eq!(format_tcl_value(&TclValue::Float(-1.0)), "-1.0");
 }
 
 #[test]
 fn format_tcl_value_signed_zero() {
     // IEEE-754 sign bit survives: Tcl renders -0.0 as "-0.0".
-    assert_eq!(format_tcl_value(TclValue::Float(0.0)), "0.0");
-    assert_eq!(format_tcl_value(TclValue::Float(-0.0)), "-0.0");
+    assert_eq!(format_tcl_value(&TclValue::Float(0.0)), "0.0");
+    assert_eq!(format_tcl_value(&TclValue::Float(-0.0)), "-0.0");
     // -1.0 * 0.0 == -0.0 by IEEE-754.
     let neg_zero = -0.0_f64;
     assert!(neg_zero.is_sign_negative());
-    assert_eq!(format_tcl_value(TclValue::Float(neg_zero)), "-0.0");
+    assert_eq!(format_tcl_value(&TclValue::Float(neg_zero)), "-0.0");
 }
 
 #[test]
 fn format_tcl_value_specials_and_large() {
     // tclsh 9.0.3: Inf/-Inf/NaN (capitalised), and 1e308 stays scientific
     // (not a huge integer string).
-    assert_eq!(format_tcl_value(TclValue::Float(f64::INFINITY)), "Inf");
-    assert_eq!(format_tcl_value(TclValue::Float(f64::NEG_INFINITY)), "-Inf");
-    assert_eq!(format_tcl_value(TclValue::Float(f64::NAN)), "NaN");
-    assert_eq!(format_tcl_value(TclValue::Float(1e308)), "1e+308");
-    assert_eq!(format_tcl_value(TclValue::Float(-1e308)), "-1e+308");
+    assert_eq!(format_tcl_value(&TclValue::Float(f64::INFINITY)), "Inf");
+    assert_eq!(
+        format_tcl_value(&TclValue::Float(f64::NEG_INFINITY)),
+        "-Inf"
+    );
+    assert_eq!(format_tcl_value(&TclValue::Float(f64::NAN)), "NaN");
+    assert_eq!(format_tcl_value(&TclValue::Float(1e308)), "1e+308");
+    assert_eq!(format_tcl_value(&TclValue::Float(-1e308)), "-1e+308");
 }
 
 // =========================================================================

--- a/rust/tcl-compiler/tests/type_propagation.rs
+++ b/rust/tcl-compiler/tests/type_propagation.rs
@@ -740,20 +740,22 @@ fn namespaced_array_element_uses_base_array_symbol_type() {
 }
 
 #[test]
-fn braced_array_like_name_flows_under_base_array_symbol() {
-    // Braced `${a(1)}` is a whole-name load of array element a(1); the type
-    // flows under the base array symbol `a`.
+fn braced_array_like_name_flows_under_element_symbol() {
+    // Braced `${a(1)}` is a whole-name load of array element a(1); under
+    // per-element SSA (type-tracking P5) the type flows on the element's
+    // own symbol `a(1)` — the base carries no value type.
     let src = "set {a(1)} \"alpha beta\"\nset n [llength ${a(1)}]";
-    let t = var_type(src, "a").expect("a typed");
+    let t = var_type(src, "a(1)").expect("a(1) typed");
     assert_eq!(t.kind(), TypeKind::Known);
     assert_eq!(t.tcl_type(), Some(TclType::String));
 }
 
 #[test]
-fn unbraced_array_ref_normalises_to_base_array_symbol() {
-    // `set a(1) ...` normalises to the base array symbol `a`.
+fn unbraced_array_ref_is_the_element_symbol() {
+    // `set a(1) ...` writes the per-element symbol `a(1)` (type-tracking
+    // P5): its type is the element's own, and independent of siblings.
     let src = "set a(1) \"alpha beta\"\nset n [llength $a(1)]";
-    let t = var_type(src, "a").expect("a typed");
+    let t = var_type(src, "a(1)").expect("a(1) typed");
     assert_eq!(t.kind(), TypeKind::Known);
     assert_eq!(t.tcl_type(), Some(TclType::String));
 }

--- a/rust/tcl-compiler/tests/type_propagation.rs
+++ b/rust/tcl-compiler/tests/type_propagation.rs
@@ -83,7 +83,7 @@ fn var_type(src: &str, var: &str) -> Option<TypeLattice> {
 /// variable was never typed).
 fn tcl_type(src: &str, var: &str) -> TclType {
     let t = var_type(src, var).unwrap_or_else(|| panic!("no type inferred for `{var}` in {src:?}"));
-    t.tcl_type
+    t.tcl_type()
         .unwrap_or_else(|| panic!("type for `{var}` has no tcl_type: {t} in {src:?}"))
 }
 
@@ -93,16 +93,16 @@ fn tcl_type(src: &str, var: &str) -> TclType {
 fn literal_scalar_types() {
     // tclsh: `set x 42` -> 42, `string is integer 42` = 1  => Int
     let t = var_type("set x 42", "x").expect("x typed");
-    assert_eq!(t.kind, TypeKind::Known);
-    assert_eq!(t.tcl_type, Some(TclType::Int));
+    assert_eq!(t.kind(), TypeKind::Known);
+    assert_eq!(t.tcl_type(), Some(TclType::Int));
 
     // tclsh: `-7` is `string is integer` = 1 => Int
     assert_eq!(tcl_type("set x -7", "x"), TclType::Int);
 
     // tclsh: `string is integer hello` = 0, `string is double hello` = 0 => String
     let s = var_type("set x hello", "x").expect("x typed");
-    assert_eq!(s.kind, TypeKind::Known);
-    assert_eq!(s.tcl_type, Some(TclType::String));
+    assert_eq!(s.kind(), TypeKind::Known);
+    assert_eq!(s.tcl_type(), Some(TclType::String));
 
     // tclsh: `string is double 3.14` = 1, `string is integer 3.14` = 0 => Double
     assert_eq!(tcl_type("set x 3.14", "x"), TclType::Double);
@@ -121,8 +121,8 @@ fn boolean_literals_are_boolean() {
         ("set z off", "z"),
     ] {
         let t = var_type(src, var).unwrap_or_else(|| panic!("{var} typed for {src:?}"));
-        assert_eq!(t.kind, TypeKind::Known, "{src}");
-        assert_eq!(t.tcl_type, Some(TclType::Boolean), "{src}");
+        assert_eq!(t.kind(), TypeKind::Known, "{src}");
+        assert_eq!(t.tcl_type(), Some(TclType::Boolean), "{src}");
     }
 }
 
@@ -183,11 +183,11 @@ fn expr_known_int() {
     // Int or Numeric is acceptable (SCCP-dependent); this pass pins it to Int.
     let t = var_type("set x [expr {1 + 2}]", "x").expect("x typed");
     assert!(
-        matches!(t.tcl_type, Some(TclType::Int | TclType::Numeric)),
+        matches!(t.tcl_type(), Some(TclType::Int | TclType::Numeric)),
         "expected Int or Numeric, got {t}"
     );
     assert_eq!(
-        t.tcl_type,
+        t.tcl_type(),
         Some(TclType::Int),
         "Rust pins SCCP result to Int"
     );
@@ -205,7 +205,7 @@ fn phi_same_type_stays_int() {
     assert!(!all.is_empty(), "x should be typed");
     for (ver, t) in &all {
         assert_eq!(
-            t.tcl_type,
+            t.tcl_type(),
             Some(TclType::Int),
             "version {ver} should be Int, got {t}"
         );
@@ -224,7 +224,7 @@ fn phi_incompatible_types_shimmer() {
     let all = var_types(src, "::top", "x");
     let conflict: Vec<&TypeLattice> = all
         .values()
-        .filter(|t| matches!(t.kind, TypeKind::Shimmered | TypeKind::Overdefined))
+        .filter(|t| matches!(t.kind(), TypeKind::Shimmered | TypeKind::Overdefined))
         .collect();
     assert!(
         !conflict.is_empty(),
@@ -236,12 +236,12 @@ fn phi_incompatible_types_shimmer() {
     // here it is SHIMMERED(String, Int) because `String < Int` in `TclType`.
     let shim = conflict
         .iter()
-        .find(|t| t.kind == TypeKind::Shimmered)
+        .find(|t| t.kind() == TypeKind::Shimmered)
         .expect("a shimmered version");
-    let pair = (shim.from_type, shim.tcl_type);
+    let pair = shim.shimmer_pair();
     assert_eq!(
         pair,
-        (Some(TclType::String), Some(TclType::Int)),
+        Some((TclType::String, TclType::Int)),
         "merge should shimmer between Int and String, got {shim}"
     );
 }
@@ -260,7 +260,7 @@ fn barrier_does_not_drop_var_type() {
     // Both the pre-barrier Int and the in-eval String defs are present.
     let all = var_types(src, "::top", "x");
     let kinds: Vec<Option<TclType>> = {
-        let mut v: Vec<Option<TclType>> = all.values().map(|t| t.tcl_type).collect();
+        let mut v: Vec<Option<TclType>> = all.values().map(TypeLattice::tcl_type).collect();
         v.sort();
         v
     };
@@ -665,13 +665,13 @@ fn command_sub_in_expr_stays_typed() {
     // exact Int-vs-Double can't be known statically — no single Tcl analogue).
     let t = var_type("set z [expr {[some_cmd] + 1}]", "z").expect("z typed");
     assert!(matches!(
-        t.tcl_type,
+        t.tcl_type(),
         Some(TclType::Numeric | TclType::Int | TclType::Double)
     ));
     // tclsh: a fully-constant nested expr `expr {[expr {1 + 2}] + 1}` -> 4 (Int
     // at runtime); the analyser keeps the inner command-sub abstract => Numeric.
     let n = var_type("set z [expr {[expr {1 + 2}] + 1}]", "z").expect("z typed");
-    assert!(n.tcl_type.is_some(), "nested-expr result stays typed");
+    assert!(n.tcl_type().is_some(), "nested-expr result stays typed");
 }
 
 // Complex multi-operator expressions
@@ -726,7 +726,7 @@ fn namespaced_scalar_keeps_qualified_symbol_type() {
     // just conservatively OVERDEFINED, not the literal's own type.
     let src = "set ::ns::x \"alpha beta\"\nset n [llength $::ns::x]";
     let t = var_type(src, "::ns::x").expect("::ns::x typed");
-    assert_eq!(t.kind, TypeKind::Overdefined);
+    assert_eq!(t.kind(), TypeKind::Overdefined);
 }
 
 #[test]
@@ -736,7 +736,7 @@ fn namespaced_array_element_uses_base_array_symbol_type() {
     // above.
     let src = "set ::ns::arr(k) \"alpha beta\"\nset n [llength $::ns::arr(k)]";
     let t = var_type(src, "::ns::arr").expect("::ns::arr typed");
-    assert_eq!(t.kind, TypeKind::Overdefined);
+    assert_eq!(t.kind(), TypeKind::Overdefined);
 }
 
 #[test]
@@ -745,8 +745,8 @@ fn braced_array_like_name_flows_under_base_array_symbol() {
     // flows under the base array symbol `a`.
     let src = "set {a(1)} \"alpha beta\"\nset n [llength ${a(1)}]";
     let t = var_type(src, "a").expect("a typed");
-    assert_eq!(t.kind, TypeKind::Known);
-    assert_eq!(t.tcl_type, Some(TclType::String));
+    assert_eq!(t.kind(), TypeKind::Known);
+    assert_eq!(t.tcl_type(), Some(TclType::String));
 }
 
 #[test]
@@ -754,8 +754,8 @@ fn unbraced_array_ref_normalises_to_base_array_symbol() {
     // `set a(1) ...` normalises to the base array symbol `a`.
     let src = "set a(1) \"alpha beta\"\nset n [llength $a(1)]";
     let t = var_type(src, "a").expect("a typed");
-    assert_eq!(t.kind, TypeKind::Known);
-    assert_eq!(t.tcl_type, Some(TclType::String));
+    assert_eq!(t.kind(), TypeKind::Known);
+    assert_eq!(t.tcl_type(), Some(TclType::String));
 }
 
 #[test]

--- a/rust/tcl-compiler/tests/var_escape_typeinfer.rs
+++ b/rust/tcl-compiler/tests/var_escape_typeinfer.rs
@@ -136,7 +136,7 @@ fn infer_type(src: &str, qname: &str, var: &str) -> Option<TclType> {
         .iter()
         .filter(|((sym, _), _)| fu.ssa.var_name(*sym) == var)
         .max_by_key(|((_, ver), _)| *ver)
-        .and_then(|(_, t)| t.tcl_type)
+        .and_then(|(_, t)| t.tcl_type())
 }
 
 /// The inferred `TypeLattice` (kind + `tcl_type`) of `var`'s highest version
@@ -895,7 +895,7 @@ fn expr_ternary_mixed_branches_join_to_numeric() {
     // Double (`string is double` = 1, `string is integer` = 0), but the
     // static lattice over-approximates the unselected branch to Numeric.
     let lat = infer_lattice("set v [expr {1 ? 2.0 : 3}]", "v").expect("v typed");
-    assert_eq!(lat.tcl_type, Some(TclType::Numeric));
+    assert_eq!(lat.tcl_type(), Some(TclType::Numeric));
     // Two same-typed arms collapse to that concrete type.
     assert_eq!(ty("set v [expr {1 ? 5 : 9}]", "v"), TclType::Int);
 }
@@ -907,7 +907,7 @@ fn expr_unknown_function_is_numeric() {
     // pass conservatively widens to the abstract `Numeric` join (no direct
     // single-value tclsh analogue — it is the Int-or-Double lattice point).
     let lat = infer_lattice("set v [expr {not_a_real_fn($v)}]", "v").expect("v typed");
-    assert_eq!(lat.tcl_type, Some(TclType::Numeric));
+    assert_eq!(lat.tcl_type(), Some(TclType::Numeric));
 }
 
 #[test]
@@ -916,7 +916,7 @@ fn expr_arithmetic_over_untyped_var_is_numeric() {
     // pass can't decide Int vs Double, so it lands on the `Numeric` join.
     // (Top-level `$x` comes from a barrier-typed source, so it is untyped.)
     let lat = infer_lattice("set v [expr {$unknownvar + 1}]", "v").expect("v typed");
-    assert_eq!(lat.tcl_type, Some(TclType::Numeric));
+    assert_eq!(lat.tcl_type(), Some(TclType::Numeric));
 }
 
 // ===========================================================================
@@ -945,7 +945,7 @@ fn scope_alias_def_widens_to_overdefined() {
     let widened = fu
         .types
         .iter()
-        .any(|((n, _), t)| fu.ssa.var_name(*n) == "counter" && t.kind == TypeKind::Overdefined);
+        .any(|((n, _), t)| fu.ssa.var_name(*n) == "counter" && t.kind() == TypeKind::Overdefined);
     assert!(
         widened,
         "scope-aliased counter should be Overdefined: {:?}",
@@ -961,7 +961,7 @@ fn global_alias_def_widens_to_overdefined() {
     let widened = fu
         .types
         .iter()
-        .any(|((n, _), t)| fu.ssa.var_name(*n) == "g" && t.kind == TypeKind::Overdefined);
+        .any(|((n, _), t)| fu.ssa.var_name(*n) == "g" && t.kind() == TypeKind::Overdefined);
     assert!(
         widened,
         "global-aliased g should be Overdefined: {:?}",

--- a/rust/tcl-explorer-wasm/Cargo.lock
+++ b/rust/tcl-explorer-wasm/Cargo.lock
@@ -12,6 +12,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
+
+[[package]]
 name = "bitflags"
 version = "2.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -104,6 +110,34 @@ name = "memchr"
 version = "2.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "88904434abc2901f197fe8cc55f0445e7ded921dba5911dad2e2b39b48e663c4"
+
+[[package]]
+name = "num-bigint"
+version = "0.4.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c89e69e7e0f03bea5ef08013795c25018e101932225a656383bd384495ecc367"
+dependencies = [
+ "num-integer",
+ "num-traits",
+]
+
+[[package]]
+name = "num-integer"
+version = "0.1.46"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7969661fd2958a5cb096e56c8e1ad0444ac2bbcd0061bd28660485a44879858f"
+dependencies = [
+ "num-traits",
+]
+
+[[package]]
+name = "num-traits"
+version = "0.2.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
+dependencies = [
+ "autocfg",
+]
 
 [[package]]
 name = "once_cell"
@@ -257,6 +291,9 @@ name = "tcl-compiler"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "regex",
  "rustc-hash",
  "tcl-bytecode",
@@ -340,6 +377,9 @@ name = "tcl-syntax"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "tcl-dialect",
  "tcl-lexer",
 ]

--- a/rust/tcl-explorer/src/formatters.rs
+++ b/rust/tcl-explorer/src/formatters.rs
@@ -288,14 +288,30 @@ pub fn format_return_shape(s: &ProcSummary) -> String {
 /// Project a type lattice to its display string.
 #[must_use]
 pub fn format_type(tl: &TypeLattice) -> String {
-    match tl.kind {
+    match tl.kind() {
         TypeKind::Unknown => "?".to_owned(),
         TypeKind::Overdefined => "*".to_owned(),
-        TypeKind::Known => tl.tcl_type.map_or_else(|| "?".to_owned(), type_name),
-        TypeKind::Shimmered => match (tl.from_type, tl.tcl_type) {
-            (Some(from), Some(to)) => format!("shimmered({}/{})", type_name(from), type_name(to)),
-            _ => "?".to_owned(),
+        // A container with tracked element facts renders them
+        // (`List<Numeric, ?>` / `Dict<OBJECT(C)*>`); scalar shapes and
+        // fact-free containers keep the bare lowercase name.
+        TypeKind::Known => match tl.single_shape() {
+            Some(shape)
+                if !matches!(
+                    tl.elements(),
+                    None | Some(tcl_compiler::types::Elements::Unknown)
+                ) =>
+            {
+                shape.to_string()
+            }
+            _ => tl.tcl_type().map_or_else(|| "?".to_owned(), type_name),
         },
+        // A multi-member union renders every member (`shimmered(a/b)`,
+        // `shimmered(a/b/c)` for the 3+-way merges the union lattice now
+        // tracks instead of collapsing to overdefined).
+        TypeKind::Shimmered => {
+            let names: Vec<String> = tl.shapes().iter().map(|s| type_name(s.coarse())).collect();
+            format!("shimmered({})", names.join("/"))
+        }
     }
 }
 

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -698,7 +698,7 @@ fn ssa_value_detail(
             d.insert("lattice".to_owned(), json!(format_lattice(lat)));
         }
         if let Some(tl) = types.get(&(sym, ver))
-            && tl.kind != tcl_compiler::types::TypeKind::Unknown
+            && tl.kind() != tcl_compiler::types::TypeKind::Unknown
         {
             d.insert("type".to_owned(), json!(format_type(tl)));
         }
@@ -861,7 +861,7 @@ fn post_ssa_analysis(
     for key in tkeys {
         let tl = &snap.unit.types[key];
         if matches!(
-            tl.kind,
+            tl.kind(),
             tcl_compiler::types::TypeKind::Known | tcl_compiler::types::TypeKind::Shimmered
         ) {
             inferred.insert(
@@ -1168,7 +1168,7 @@ pub fn serialise_types(result: &ExplorerResult) -> Value {
                 "variable": "(return)",
                 "version": 0,
                 "type": format_type(rt),
-                "kind": type_kind_name(rt.kind),
+                "kind": type_kind_name(rt.kind()),
             }));
             let ssa = &snap.unit.ssa;
             let mut keys: Vec<_> = snap.unit.types.keys().collect();
@@ -1179,7 +1179,7 @@ pub fn serialise_types(result: &ExplorerResult) -> Value {
                     "variable": ssa.var_name(key.0),
                     "version": key.1,
                     "type": format_type(tl),
-                    "kind": type_kind_name(tl.kind),
+                    "kind": type_kind_name(tl.kind()),
                 }));
             }
             (!entries.is_empty()).then(|| json!({ "name": snap.name, "entries": entries }))

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -44,6 +44,8 @@
 //! `tcl-lsp-server::Backend::hover`; this module is the pure-CPU
 //! computation, no I/O, no async.
 
+use std::collections::HashMap;
+
 use rustc_hash::FxHashSet;
 use tcl_compiler::analyser::{AnalysisResult, ClassDef, ProcDef, VarDef};
 use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
@@ -2491,8 +2493,9 @@ fn infer_var_type_and_taint(
     var_name: &str,
 ) -> (Option<String>, Option<String>) {
     let unit = CompilationUnit::build_for(source, registry, false);
+    let first_use = tcl_compiler::shimmer::first_use_commitments_for_cu(&unit, registry);
     (
-        infer_var_type(&unit, var_name),
+        infer_var_type(&unit, var_name, &first_use),
         infer_var_taint(&unit, var_name),
     )
 }
@@ -2514,7 +2517,17 @@ fn function_units_in_order(unit: &CompilationUnit) -> Vec<&FunctionUnit> {
 /// `_infer_var_type`: returns the first function (top-level, then
 /// procs in name order) that has type entries for the variable
 /// and resolves them to a single label.
-fn infer_var_type(unit: &CompilationUnit, var_name: &str) -> Option<String> {
+///
+/// A **pure** variable — a literal / interpolation / string-command result
+/// whose intrep is not committed at the def — additionally reports the intrep
+/// its first use commits when every executable typed read agrees ("first used
+/// as"), the def-site pushback of the committed-intrep dataflow
+/// (`tcl_compiler::shimmer::first_use_commitments_for_cu`).
+fn infer_var_type(
+    unit: &CompilationUnit,
+    var_name: &str,
+    first_use: &HashMap<String, HashMap<String, TclType>>,
+) -> Option<String> {
     for func in function_units_in_order(unit) {
         let entries: Vec<&TypeLattice> = func
             .types
@@ -2535,7 +2548,20 @@ fn infer_var_type(unit: &CompilationUnit, var_name: &str) -> Option<String> {
             && known.iter().all(|t| t.tcl_type == known[0].tcl_type)
             && known.len() == entries.len()
         {
-            return Some(tcl_type_label(known[0].tcl_type.unwrap()));
+            let label = tcl_type_label(known[0].tcl_type.unwrap());
+            // A pure def whose every typed read commits one intrep reports it
+            // at the creation site: `set l {1 2 3}` first used by `llength`
+            // hovers as "string (first used as: list)".
+            if let Some(committed) = first_use
+                .get(&func.name)
+                .and_then(|vars| vars.get(var_name))
+            {
+                let committed_label = tcl_type_label(*committed);
+                if committed_label != label {
+                    return Some(format!("{label} (first used as: {committed_label})"));
+                }
+            }
+            return Some(label);
         }
         // Every version agrees on the same SHIMMERED pair.
         let shimmered: Vec<&TypeLattice> = entries
@@ -2995,6 +3021,40 @@ mod tests {
         let h = hover(src, 1, 7, &analysis, Some(&registry)).expect("hover");
         assert!(h.value.contains("**Variable** `x`"), "{}", h.value);
         assert!(h.value.contains("**Inferred intrep**: int"), "{}", h.value);
+    }
+
+    #[test]
+    fn hover_on_pure_literal_surfaces_first_used_as() {
+        // `l` is a pure list-shaped literal whose only typed read commits the
+        // list intrep — the def-site pushback of the committed-intrep
+        // dataflow surfaces "first used as: list" at the creation site.
+        let src = "set l {1 2 3}\nllength $l\n";
+        let analysis = analyse(src);
+        let registry = tcl_registry::CommandRegistry::build_default();
+        let h = hover(src, 1, 9, &analysis, Some(&registry)).expect("hover");
+        assert!(h.value.contains("**Variable** `l`"), "{}", h.value);
+        assert!(
+            h.value
+                .contains("**Inferred intrep**: string (first used as: list)"),
+            "{}",
+            h.value
+        );
+    }
+
+    #[test]
+    fn hover_committed_producer_has_no_first_used_as() {
+        // A committed producer (`[list …]`) is not "first used as" anything —
+        // its intrep is set at the def, so the pushback annotation must not
+        // appear.
+        let src = "set l [list 1 2 3]\nllength $l\n";
+        let analysis = analyse(src);
+        let registry = tcl_registry::CommandRegistry::build_default();
+        let h = hover(src, 1, 9, &analysis, Some(&registry)).expect("hover");
+        assert!(
+            !h.value.contains("first used as"),
+            "committed producers must not carry the pushback label: {}",
+            h.value
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -189,10 +189,8 @@ pub fn hover_with_profile(
             // pipeline (`CompilationUnit`), which requires a
             // registry; without one we surface just the reference
             // count.
-            let (type_info, taint_info) = match registry {
-                Some(reg) => infer_var_type_and_taint(source, reg, &var_name),
-                None => (None, None),
-            };
+            let (type_info, taint_info) =
+                var_type_annotations(source, line, character, &var_name, registry);
             return Some(Hover::markdown(var_hover_text(
                 var_def,
                 type_info.as_deref(),
@@ -2172,6 +2170,68 @@ pub fn find_var_at_position(source: &str, line: u32, character: u32) -> Option<S
         }
     }
     None
+}
+
+/// The hover type/taint annotations for the variable at the cursor. Type
+/// inference is keyed by element-qualified SSA names (`arr(idx)` is its own
+/// variable), so the lookup name comes from
+/// [`find_var_element_at_position`]; scope-chain resolution stays on the
+/// base form the caller already has.
+fn var_type_annotations(
+    source: &str,
+    line: u32,
+    character: u32,
+    var_name: &str,
+    registry: Option<&CommandRegistry>,
+) -> (Option<String>, Option<String>) {
+    let type_var = find_var_element_at_position(source, line, character)
+        .unwrap_or_else(|| var_name.to_owned());
+    match registry {
+        Some(reg) => infer_var_type_and_taint(source, reg, &type_var),
+        None => (None, None),
+    }
+}
+
+/// [`find_var_at_position`] keeping a constant array key: `$arr(idx)` under
+/// the cursor resolves to the per-element SSA variable `arr(idx)` (a dynamic
+/// key falls back to the base). Used for the type-inference lookup, which is
+/// keyed by element-qualified SSA names; scope-chain / references lookups
+/// stay on the base form.
+fn find_var_element_at_position(source: &str, line: u32, character: u32) -> Option<String> {
+    let line_text = source.split('\n').nth(line as usize)?;
+    let chars: Vec<char> = line_text.chars().collect();
+    let cursor = utf16_col_to_char_col(line_text, character).min(chars.len());
+
+    let base = find_var_at_position(source, line, character)?;
+    // Locate the ref's `(` — scan right from the cursor's var name for a
+    // literal key suffix. Walk left to the nearest `$`, then forward over
+    // the name; a following `(key)` with a literal key element-qualifies.
+    let mut pos = cursor.min(chars.len());
+    let stop_chars: &[char] = &[' ', '\t', '\n', ';', '{', '}', '[', ']', '"', '$'];
+    while pos > 0 && !stop_chars.contains(&chars[pos - 1]) {
+        pos -= 1;
+    }
+    if pos > 0 && chars[pos - 1] == '$' {
+        pos -= 1;
+    }
+    if pos < chars.len() && chars[pos] == '$' {
+        let start = pos + 1;
+        let end = scan_var_name_end(&chars, start);
+        if end > start && chars.get(end) == Some(&'(') {
+            let mut close = end + 1;
+            while close < chars.len() && chars[close] != ')' {
+                close += 1;
+            }
+            if close < chars.len() {
+                let full: String = chars[start..=close].iter().collect();
+                let qualified = tcl_syntax::naming::element_var_name(&full);
+                if qualified == full {
+                    return Some(full);
+                }
+            }
+        }
+    }
+    Some(base)
 }
 
 /// Find a `${name}` braced variable reference containing `cursor`.

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -2542,13 +2542,13 @@ fn infer_var_type(
         let known: Vec<&TypeLattice> = entries
             .iter()
             .copied()
-            .filter(|t| t.kind == TypeKind::Known && t.tcl_type.is_some())
+            .filter(|t| t.kind() == TypeKind::Known && t.tcl_type().is_some())
             .collect();
         if !known.is_empty()
-            && known.iter().all(|t| t.tcl_type == known[0].tcl_type)
+            && known.iter().all(|t| t.tcl_type() == known[0].tcl_type())
             && known.len() == entries.len()
         {
-            let label = tcl_type_label(known[0].tcl_type.unwrap());
+            let label = tcl_type_label(known[0].tcl_type().unwrap());
             // A pure def whose every typed read commits one intrep reports it
             // at the creation site: `set l {1 2 3}` first used by `llength`
             // hovers as "string (first used as: list)".
@@ -2563,29 +2563,29 @@ fn infer_var_type(
             }
             return Some(label);
         }
-        // Every version agrees on the same SHIMMERED pair.
+        // Every version agrees on the same shimmer union — render every
+        // member (`shimmered (int / list / string)` for a 3-way merge).
         let shimmered: Vec<&TypeLattice> = entries
             .iter()
             .copied()
-            .filter(|t| {
-                t.kind == TypeKind::Shimmered && t.from_type.is_some() && t.tcl_type.is_some()
-            })
+            .filter(|t| t.kind() == TypeKind::Shimmered)
             .collect();
         if !shimmered.is_empty() && shimmered.len() == entries.len() {
             let s = shimmered[0];
             if shimmered.iter().all(|t| *t == s) {
-                return Some(format!(
-                    "shimmered ({} / {})",
-                    tcl_type_label(s.from_type.unwrap()),
-                    tcl_type_label(s.tcl_type.unwrap()),
-                ));
+                let members: Vec<String> = s
+                    .shapes()
+                    .iter()
+                    .map(|shape| tcl_type_label(shape.coarse()))
+                    .collect();
+                return Some(format!("shimmered ({})", members.join(" / ")));
             }
         }
         // Mixed, but a dominant KNOWN type exists.  Pick the
         // smallest by `Ord` so the choice is deterministic.
         if let Some(t) = known
             .iter()
-            .filter_map(|t| t.tcl_type)
+            .filter_map(|t| t.tcl_type())
             .min()
             .map(tcl_type_label)
         {

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -195,18 +195,21 @@ fn short_type(t: TclType) -> &'static str {
 }
 
 /// Render a [`TypeLattice`] as its inlay display string, or `None`
-/// when the lattice carries no concrete type (Unknown / Overdefined,
-/// or a Shimmered lattice missing an endpoint).  A `Known` type shows
-/// `int`; a `Shimmered` one shows `from → to`.
+/// when the lattice carries no concrete type (Unknown / Overdefined).
+/// A `Known` type shows `int`; a shimmer union chains every member
+/// (`int → str`, or `int → list → str` for the 3+-way merges the union
+/// lattice tracks).
 fn type_display(tl: &TypeLattice) -> Option<String> {
-    match tl.kind {
-        TypeKind::Known => tl.tcl_type.map(|t| short_type(t).to_owned()),
-        TypeKind::Shimmered => match (tl.from_type, tl.tcl_type) {
-            (Some(from), Some(to)) => {
-                Some(format!("{} \u{2192} {}", short_type(from), short_type(to)))
-            }
-            _ => None,
-        },
+    match tl.kind() {
+        TypeKind::Known => tl.tcl_type().map(|t| short_type(t).to_owned()),
+        TypeKind::Shimmered => {
+            let members: Vec<&str> = tl
+                .shapes()
+                .iter()
+                .map(|shape| short_type(shape.coarse()))
+                .collect();
+            Some(members.join(" \u{2192} "))
+        }
         TypeKind::Unknown | TypeKind::Overdefined => None,
     }
 }

--- a/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
@@ -716,16 +716,17 @@ fn s102_silent_for_traced_variable() {
 
 #[test]
 fn s102_silent_for_array_element_conflation() {
-    // FP guard: array-element writes collapse onto one SSA symbol per array
-    // (the `(key)` suffix is stripped before interning) — must not be
-    // reported as one variable oscillating.
+    // FP guard (per-element SSA): different constant-keyed elements are
+    // independent variables — per-element-stable types must never read as
+    // one variable oscillating. (The SAME element oscillating is the TP
+    // case — `s102_fires_for_same_array_element_oscillation`.)
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     let diags = lsp.open_ready(
         &uri,
         "proc f {} {\n    set arr(x) 0\n    while {1} {\n        \
          set arr(x) [expr {$arr(x) + 1}]\n        \
-         set arr(x) [string range $arr(x) 0 end]\n    }\n}\n",
+         set arr(y) [string range z 0 end]\n    }\n}\n",
     );
     assert!(!codes(&diags).contains("S102"), "{diags:?}");
 }
@@ -788,9 +789,9 @@ fn s102_fires_for_rename_indirection() {
 
 #[test]
 fn s100_silent_for_array_element_use_site() {
-    // FP-SH-13 extended to the use-site (S100/S101) pass: `arr(n)` is always
-    // int and `arr(label)` always string, but they collapse onto one symbol —
-    // `incr arr(n)` must not read the conflated symbol as string and fire S100.
+    // Per-element SSA (type-tracking P5): `arr(n)` and `arr(label)` are
+    // independent variables — `incr arr(n)` reads the INT element, never a
+    // conflated symbol carrying the sibling's string.
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     let diags = lsp.open_ready(
@@ -799,6 +800,34 @@ fn s100_silent_for_array_element_use_site() {
     );
     let cs = codes(&diags);
     assert!(!cs.contains("S100") && !cs.contains("S101"), "{diags:?}");
+}
+
+#[test]
+fn array_dynamic_key_write_stays_silent_on_element_reads() {
+    // A dynamic-key write may hit any element: the element's type joins
+    // with the written type (INT ⊔ INT here), so the later `expr` read of
+    // `$cfg(a)` neither warns nor folds to the wrong constant.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc f {i} {\n    set cfg(a) 1\n    set cfg($i) 99\n    return [expr {$cfg(a) + 1}]\n}\n",
+    );
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
+#[test]
+fn s102_fires_for_same_array_element_oscillation() {
+    // The flip side of per-element precision: ONE element oscillating
+    // int ↔ string every iteration is a genuine re-thunk (the old
+    // conflation exclusion was a forced false negative here).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc f {} {\n    set arr(x) 0\n    while {1} {\n        set arr(x) [expr {$arr(x) + 1}]\n        set arr(x) [string range $arr(x) 0 end]\n    }\n}\n",
+    );
+    assert!(codes(&diags).contains("S102"), "{diags:?}");
 }
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -2458,6 +2458,66 @@ fn issue_940_committed_container_in_foreach_still_fires_s100() {
 }
 
 #[test]
+fn element_tracking_committed_lindex_retrieval_is_silent() {
+    // P3 (type-tracking.md): container elements are shared objects, so a
+    // committed numeric element retrieved by `lindex` is genuinely numeric —
+    // arithmetic on it is not a shimmer.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "set l [list [expr {2**20}] other]\nset first [lindex $l 0]\nset n [expr {$first + 1}]\nputs $n\n",
+    );
+    assert!(
+        !has_code(&diags, "S100") && !has_code(&diags, "S101"),
+        "a committed numeric element is numeric — no shimmer: {diags:?}"
+    );
+}
+
+#[test]
+fn union_lattice_three_way_merge_reports_every_type() {
+    // P2: a three-way differently-typed merge stays a tracked union
+    // (previously OVERDEFINED and silent); the phi message names every
+    // member.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc f {c} {\n  if {$c == 1} { set x [list 1] } elseif {$c == 2} { set x [dict create a 1] } else { set x [expr {1+1}] }\n  return $x\n}\n",
+    );
+    let s100: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("S100"))
+        .collect();
+    assert!(
+        s100.iter().any(|d| {
+            let m = d["message"].as_str().unwrap_or("");
+            m.contains("merges") && m.contains("list") && m.contains("dict")
+        }),
+        "the 3-way merge message must name the merging types: {s100:?}"
+    );
+}
+
+#[test]
+fn bignum_values_raise_no_false_diagnostics() {
+    // P4: beyond-wide integers classify on the tower (`Bignum`, coarse Int)
+    // and fold exactly — a bignum literal chain must publish no shimmer /
+    // type diagnostics. (The exact fold value is pinned at the compiler
+    // tier: `fp_sh_23_bignum_folds_are_exact` and the tcl_expr_eval oracle
+    // corpus.)
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "set big [expr {2**64}]\nset next [expr {$big + 1}]\nincr next\nputs $next\n",
+    );
+    assert!(
+        !has_code(&diags, "S100") && !has_code(&diags, "S101"),
+        "exact bignum arithmetic is not a shimmer: {diags:?}"
+    );
+}
+
+#[test]
 fn commit_dataflow_second_conversion_fires_s100_with_committed_from_type() {
     // First-use commit: `expr` commits the numeric intrep on a pure literal;
     // the later `lindex` genuinely re-represents it (oracle: rep int → list).

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -2387,12 +2387,13 @@ fn e103_abstains_when_missing_brace_swallows_more_than_one_statement() {
 }
 
 #[test]
-fn shimmer_incr_on_string_is_s100_info_with_tight_range() {
-    // The range must cover only the `$x` argument — not the whole `incr x`
-    // call and not the `[lindex $x 0]` substitution around it.
+fn shimmer_committed_value_with_lindex_is_s100_info_with_tight_range() {
+    // A *committed* Dict (from `[dict create]`) read as a list genuinely
+    // shimmers — a pure string literal would promote for free (issue #940). The
+    // range must cover only the `$x` argument, not the whole `lindex $x 0` call.
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
-    let diags = lsp.open_ready(&uri, "set x hello\nlindex $x 0\n");
+    let diags = lsp.open_ready(&uri, "set x [dict create a 1 b 2]\nlindex $x 0\n");
     let s100: Vec<&Value> = diags
         .iter()
         .filter(|d| code_str(d).as_deref() == Some("S100"))
@@ -2417,6 +2418,43 @@ fn clean_list_used_with_lindex_has_no_s100() {
     let uri = unique_uri("tcl");
     let diags = lsp.open_ready(&uri, "set x [list 1 2 3]\nlindex $x 0\n");
     assert!(!has_code(&diags, "S100"), "unexpected S100: {diags:?}");
+}
+
+#[test]
+fn issue_940_braced_list_literal_in_foreach_has_no_s100() {
+    // Issue #940: a braced list literal is a pure string that `foreach` parses
+    // into a list once, for free — no shimmer. Covers the reporter's exact
+    // snippet plus the `{}` empty-list case named in the issue title.
+    let mut lsp = Lsp::tcl();
+    for src in [
+        "set fontSizes {10.0 12.0 16.0 24.0}\nforeach size $fontSizes { puts $size }\n",
+        "set empty {}\nforeach x $empty { puts $x }\n",
+        "set a 1\nforeach b $a { puts $b }\n",
+        "set d {a 1 b 2}\ndict for {k v} $d { puts \"$k=$v\" }\n",
+    ] {
+        let uri = unique_uri("tcl");
+        let diags = lsp.open_ready(&uri, src);
+        assert!(
+            !has_code(&diags, "S100") && !has_code(&diags, "S101"),
+            "issue #940: pure list literal must not shimmer for {src:?}: {diags:?}"
+        );
+    }
+}
+
+#[test]
+fn issue_940_committed_container_in_foreach_still_fires_s100() {
+    // TP control: the fix must not blanket-silence genuine shimmers — a
+    // committed dict read as a list still fires.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "set d [dict create a 1 b 2]\nforeach x $d { puts $x }\n",
+    );
+    assert!(
+        has_code(&diags, "S100"),
+        "committed dict in foreach must still shimmer: {diags:?}"
+    );
 }
 
 #[test]
@@ -2604,7 +2642,7 @@ fn my_arbitrary_method_call_does_not_draw_w001() {
 fn shimmer_fires_through_interp_alias() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
-    let src = "interp alias {} myindex {} ::lindex\nset x hello\nmyindex $x 0\n";
+    let src = "interp alias {} myindex {} ::lindex\nset x [dict create a 1 b 2]\nmyindex $x 0\n";
     let diags = lsp.open_ready(&uri, src);
     assert!(
         has_code(&diags, "S100"),
@@ -2618,7 +2656,10 @@ fn shimmer_noqa_suppresses_s100() {
     // suppress it through the live publishDiagnostics pipeline.
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
-    let diags = lsp.open_ready(&uri, "set x hello\n# noqa: S100\nlindex $x 0\n");
+    let diags = lsp.open_ready(
+        &uri,
+        "set x [dict create a 1 b 2]\n# noqa: S100\nlindex $x 0\n",
+    );
     assert!(
         !has_code(&diags, "S100"),
         "S100 must be suppressed by a preceding '# noqa: S100': {diags:?}"
@@ -2629,7 +2670,10 @@ fn shimmer_noqa_suppresses_s100() {
 fn shimmer_noqa_for_unrelated_code_does_not_suppress_s100() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
-    let diags = lsp.open_ready(&uri, "set x hello\n# noqa: W100\nlindex $x 0\n");
+    let diags = lsp.open_ready(
+        &uri,
+        "set x [dict create a 1 b 2]\n# noqa: W100\nlindex $x 0\n",
+    );
     assert!(
         has_code(&diags, "S100"),
         "S100 must still fire when the preceding noqa names an unrelated code: {diags:?}"

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -2458,6 +2458,69 @@ fn issue_940_committed_container_in_foreach_still_fires_s100() {
 }
 
 #[test]
+fn commit_dataflow_second_conversion_fires_s100_with_committed_from_type() {
+    // First-use commit: `expr` commits the numeric intrep on a pure literal;
+    // the later `lindex` genuinely re-represents it (oracle: rep int → list).
+    // The message names the *committed* from-type, not the def-time shape.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set v 5\nexpr {$v + 1}\nlindex $v 0\n");
+    let s100: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("S100"))
+        .collect();
+    assert!(
+        s100.iter().any(|d| {
+            d["message"]
+                .as_str()
+                .is_some_and(|m| m.contains("numeric intrep") && m.contains("expects list"))
+        }),
+        "expected a numeric→list second-conversion S100: {diags:?}"
+    );
+}
+
+#[test]
+fn commit_dataflow_loop_rethunk_fires_s101_each_target() {
+    // A pure literal read as two distinct intreps inside a loop re-thunks
+    // per iteration (oracle: list ↔ dict every pass) — both reads are S101.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "set l {a 1 b 2}\nforeach i {1 2 3} {\n    llength $l\n    dict size $l\n}\n",
+    );
+    let s101: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("S101"))
+        .collect();
+    assert!(
+        s101.len() >= 2,
+        "expected two per-iteration re-thunk S101s: {diags:?}"
+    );
+}
+
+#[test]
+fn commit_dataflow_path_dependent_merge_message() {
+    // Two branch arms commit two different intreps; a post-merge use matching
+    // neither pays on both paths — the message names the possibilities.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc f {c} {\n  set a {1 2}\n  if {$c} { llength $a } else { dict size $a }\n  string length $a\n}\n",
+    );
+    assert!(
+        diags.iter().any(|d| {
+            code_str(d).as_deref() == Some("S100")
+                && d["message"]
+                    .as_str()
+                    .is_some_and(|m| m.contains("path-dependent"))
+        }),
+        "expected a path-dependent merge S100: {diags:?}"
+    );
+}
+
+#[test]
 fn w300_w103_silent_when_var_provably_literal() {
     // A `$var` proven to hold a compile-time literal path/filename is a known
     // constant — no more dangerous than writing it inline — so W300/W103 are

--- a/rust/tcl-registry/src/commands/tcl/dict.rs
+++ b/rust/tcl-registry/src/commands/tcl/dict.rs
@@ -73,7 +73,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(2),
         detail: "Append to a value in a dictionary.",
         synopsis: "dict append dictionaryVariable key ?string ...?",
-        var_elements_effect: Some(VarElementsEffect::ExtendsDictValues { values_from: 2 }),
+        var_elements_effect: Some(VarElementsEffect::ExtendsDictValuesByName { values_from: 2 }),
         arg_roles: &[(0, ArgRole::VarWrite)],
         arg_types: &[(
             0,
@@ -218,7 +218,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(2),
         detail: "Append list elements to a dictionary value.",
         synopsis: "dict lappend dictionaryVariable key ?value ...?",
-        var_elements_effect: Some(VarElementsEffect::ExtendsDictValues { values_from: 2 }),
+        var_elements_effect: Some(VarElementsEffect::ListifiesDictValue),
         arg_roles: &[(0, ArgRole::VarWrite)],
         mutator: true,
         safe_on_uninit: Some(DialectSet::ALL_TCL),

--- a/rust/tcl-registry/src/commands/tcl/dict.rs
+++ b/rust/tcl-registry/src/commands/tcl/dict.rs
@@ -73,6 +73,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(2),
         detail: "Append to a value in a dictionary.",
         synopsis: "dict append dictionaryVariable key ?string ...?",
+        var_elements_effect: Some(VarElementsEffect::ExtendsDictValues { values_from: 2 }),
         arg_roles: &[(0, ArgRole::VarWrite)],
         arg_types: &[(
             0,
@@ -96,6 +97,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "dict create ?key value ...?",
         pure: true,
         return_type: Some(TclType::Dict),
+        return_elements: Some(ReturnElements::DictOfPairs { from: 0 }),
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -161,6 +163,9 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "dict get dictionaryValue ?key ...?",
         pure: true,
         return_type: Some(TclType::String),
+        // Single-key form only — the compiler applies the element fact to
+        // the two-arg call shape (`dict get $d $k`).
+        return_elements: Some(ReturnElements::ElementOf { container_arg: 0 }),
         arg_types: &[(
             0,
             ArgTypeHint {
@@ -213,6 +218,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(2),
         detail: "Append list elements to a dictionary value.",
         synopsis: "dict lappend dictionaryVariable key ?value ...?",
+        var_elements_effect: Some(VarElementsEffect::ExtendsDictValues { values_from: 2 }),
         arg_roles: &[(0, ArgRole::VarWrite)],
         mutator: true,
         safe_on_uninit: Some(DialectSet::ALL_TCL),
@@ -298,6 +304,7 @@ static SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(3),
         detail: "Set a value in a dictionary.",
         synopsis: "dict set dictionaryVariable key ?key ...? value",
+        var_elements_effect: Some(VarElementsEffect::SetsDictValue),
         arg_roles: &[(0, ArgRole::VarWrite)],
         arg_types: &[(
             0,

--- a/rust/tcl-registry/src/commands/tcl/foreach_.rs
+++ b/rust/tcl-registry/src/commands/tcl/foreach_.rs
@@ -81,6 +81,7 @@ pub fn spec() -> CommandSpec {
         )],
         lowering_hook: Some(crate::hooks::LoweringHookId::Foreach),
         return_type: Some(TclType::String),
+        var_write_typing: VarWriteTyping::ElementsOf { container_arg: 0 },
         hover: Some(HoverSnippet {
             summary: "Iterate over list elements with one or more loop variables.",
             synopsis: &[

--- a/rust/tcl-registry/src/commands/tcl/lappend_.rs
+++ b/rust/tcl-registry/src/commands/tcl/lappend_.rs
@@ -40,6 +40,7 @@ pub fn spec() -> CommandSpec {
         assigns_variable_at: Some(0),
         safe_on_uninit: Some(DialectSet::ALL_TCL),
         return_type: Some(TclType::List),
+        var_elements_effect: Some(VarElementsEffect::AppendsListElements { values_from: 1 }),
         inferred_storage_type: Some(StorageType::List),
         arg_types: &[(
             0,

--- a/rust/tcl-registry/src/commands/tcl/lassign.rs
+++ b/rust/tcl-registry/src/commands/tcl/lassign.rs
@@ -50,7 +50,7 @@ pub fn spec() -> CommandSpec {
         // `lassign` writes list *elements* to its targets — of any intrep —
         // while returning the *leftover* list.  The elements are not the
         // return value, so they must not be typed `List` (issue #867).
-        var_write_typing: VarWriteTyping::Destructured,
+        var_write_typing: VarWriteTyping::ElementsOf { container_arg: 0 },
         hover: Some(HoverSnippet {
             summary: "Assign list elements to variables",
             synopsis: &["lassign list ?varName ...?"],

--- a/rust/tcl-registry/src/commands/tcl/lindex.rs
+++ b/rust/tcl-registry/src/commands/tcl/lindex.rs
@@ -35,6 +35,7 @@ pub fn spec() -> CommandSpec {
             | Traits::CSE_CANDIDATE,
         arity: Arity::at_least(1),
         return_type: Some(TclType::String),
+        return_elements: Some(ReturnElements::ElementOf { container_arg: 0 }),
         hover: Some(HoverSnippet {
             summary: "Retrieve an element from a list",
             synopsis: &["lindex list ?index ...?"],

--- a/rust/tcl-registry/src/commands/tcl/list_.rs
+++ b/rust/tcl-registry/src/commands/tcl/list_.rs
@@ -35,6 +35,7 @@ pub fn spec() -> CommandSpec {
             | Traits::PRODUCES_CANONICAL_LIST,
         arity: Arity::any(),
         return_type: Some(TclType::List),
+        return_elements: Some(ReturnElements::ListOfArgs { from: 0 }),
         hover: Some(HoverSnippet {
             summary: "Create a list",
             synopsis: &["list ?arg arg ...?", "list ?arg ...?"],

--- a/rust/tcl-registry/src/commands/tcl/lmap_.rs
+++ b/rust/tcl-registry/src/commands/tcl/lmap_.rs
@@ -74,6 +74,7 @@ pub fn spec() -> CommandSpec {
         )],
         lowering_hook: Some(crate::hooks::LoweringHookId::Lmap),
         return_type: Some(TclType::List),
+        var_write_typing: VarWriteTyping::ElementsOf { container_arg: 0 },
         hover: Some(HoverSnippet {
             summary: "Iterate over all elements in one or more lists and collect results",
             synopsis: &[

--- a/rust/tcl-registry/src/commands/tcl/lrange.rs
+++ b/rust/tcl-registry/src/commands/tcl/lrange.rs
@@ -34,6 +34,7 @@ pub fn spec() -> CommandSpec {
             | Traits::CSE_CANDIDATE,
         arity: Arity::exact(3),
         return_type: Some(TclType::List),
+        return_elements: Some(ReturnElements::SubListOf { container_arg: 0 }),
         hover: Some(HoverSnippet {
             summary: "Return one or more adjacent elements from a list",
             synopsis: &["lrange list first last"],

--- a/rust/tcl-registry/src/commands/tcl/string_.rs
+++ b/rust/tcl-registry/src/commands/tcl/string_.rs
@@ -739,16 +739,11 @@ fn is_tcl_space(c: char) -> bool {
     matches!(c, ' ' | '\t' | '\n' | '\r' | '\u{0b}' | '\u{0c}')
 }
 
-/// `Tcl_GetBoolean`: `0` / `1` plus the case-insensitive *unique*
-/// prefixes of `true` / `false` / `yes` / `no` / `on` / `off`.  Returns
-/// the boolean value, or `None` when the string is not a valid boolean.
-/// (`o` is ambiguous between `on` and `off`, so it is *not* a boolean.)
+/// `Tcl_GetBoolean`: the canonical strict acceptor — `0` / `1` plus the
+/// case-insensitive *unique* prefixes of the six boolean words. One home:
+/// [`tcl_syntax::boolean::parse_boolean_strict`] (oracle-table-pinned).
 fn tcl_bool(s: &str) -> Option<bool> {
-    match s.to_ascii_lowercase().as_str() {
-        "1" | "t" | "tr" | "tru" | "true" | "y" | "ye" | "yes" | "on" => Some(true),
-        "0" | "f" | "fa" | "fal" | "fals" | "false" | "n" | "no" | "of" | "off" => Some(false),
-        _ => None,
-    }
+    tcl_syntax::boolean::parse_boolean_strict(s)
 }
 
 /// Character classes accepted by `string is <class>`.

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -121,7 +121,7 @@ pub mod prelude {
     pub use crate::symbol_def::{DefinedSymbolKind, SymbolDef};
     pub use crate::taint::{SetterConstraint, TaintColour};
     pub use crate::traits::Traits;
-    pub use crate::types::{TclType, VarWriteTyping};
+    pub use crate::types::{ReturnElements, TclType, VarElementsEffect, VarWriteTyping};
 }
 
 // Re-export key types at crate root.
@@ -153,7 +153,7 @@ pub use special_vars::{
 pub use symbol_def::{DefinedSymbolKind, SymbolDef};
 pub use taint::{SetterConstraint, TaintColour};
 pub use traits::Traits;
-pub use types::{TclType, VarWriteTyping};
+pub use types::{ReturnElements, TclType, VarElementsEffect, VarWriteTyping};
 
 /// Crate version string.
 ///

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1527,6 +1527,24 @@ impl ResolvedCall<'_> {
         self.sub
             .map_or(self.spec.var_write_typing, |s| s.var_write_typing)
     }
+
+    /// The result↔element-structure fact for this call — the subcommand's
+    /// when one matched, else the command's. See
+    /// [`crate::types::ReturnElements`].
+    #[must_use]
+    pub fn return_elements(&self) -> Option<crate::types::ReturnElements> {
+        self.sub
+            .map_or(self.spec.return_elements, |s| s.return_elements)
+    }
+
+    /// The in-place element evolution of the written variable for this call —
+    /// the subcommand's when one matched, else the command's. See
+    /// [`crate::types::VarElementsEffect`].
+    #[must_use]
+    pub fn var_elements_effect(&self) -> Option<crate::types::VarElementsEffect> {
+        self.sub
+            .map_or(self.spec.var_elements_effect, |s| s.var_elements_effect)
+    }
 }
 
 fn pick_form<'r>(

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -39,7 +39,7 @@ use crate::side_effects::{SideEffect, StorageType};
 use crate::symbol_def::SymbolDef;
 use crate::taint::{SetterConstraint, TaintColour};
 use crate::traits::Traits;
-use crate::types::{TclType, VarWriteTyping};
+use crate::types::{ReturnElements, TclType, VarElementsEffect, VarWriteTyping};
 
 /// Dynamic argument role resolver.
 ///
@@ -314,6 +314,16 @@ pub struct CommandSpec {
     /// variables.  See [`VarWriteTyping`].  Default
     /// [`VarWriteTyping::ReturnValue`].
     pub var_write_typing: VarWriteTyping,
+
+    /// How the result value relates to container element structure
+    /// (`list` builds a list of its args; `lindex` retrieves one element) —
+    /// the per-element type-inference fact. See [`ReturnElements`].
+    pub return_elements: Option<ReturnElements>,
+
+    /// How the command evolves the container *elements* of the variable it
+    /// writes in place (`lappend` appends value words as elements). See
+    /// [`VarElementsEffect`].
+    pub var_elements_effect: Option<VarElementsEffect>,
 
     /// Per-argument type hints. Each tuple is `(arg_index, hint)`.
     pub arg_types: &'static [(u8, ArgTypeHint)],
@@ -722,6 +732,8 @@ impl CommandSpec {
         command_prefix_resolver: None,
         return_type: None,
         var_write_typing: VarWriteTyping::ReturnValue,
+        return_elements: None,
+        var_elements_effect: None,
         arg_types: &[],
         subcommands: &[],
         allow_unknown_subcommands: false,
@@ -1126,6 +1138,15 @@ pub struct SubCommand {
     /// not).  See [`VarWriteTyping`].  Default [`VarWriteTyping::ReturnValue`].
     pub var_write_typing: VarWriteTyping,
 
+    /// Result↔element-structure fact for this subcommand (`dict create`
+    /// builds a dict of its pairs; `dict get` retrieves one value). See
+    /// [`ReturnElements`].
+    pub return_elements: Option<ReturnElements>,
+
+    /// In-place element evolution of the written variable for this
+    /// subcommand (`dict set var … value`). See [`VarElementsEffect`].
+    pub var_elements_effect: Option<VarElementsEffect>,
+
     /// Per-argument type hints.
     pub arg_types: &'static [(u8, ArgTypeHint)],
 
@@ -1343,6 +1364,8 @@ impl SubCommand {
         command_prefix_resolver: None,
         return_type: None,
         var_write_typing: VarWriteTyping::ReturnValue,
+        return_elements: None,
+        var_elements_effect: None,
         arg_types: &[],
         pure: false,
         mutator: false,

--- a/rust/tcl-registry/src/types.rs
+++ b/rust/tcl-registry/src/types.rs
@@ -151,12 +151,28 @@ pub enum VarElementsEffect {
         values_from: u8,
     },
     /// `dict set var ?key …? value` — stores the final word as one value of
-    /// the variable's dict.
+    /// the variable's dict. Only the single-key form carries the leaf's
+    /// shape; a nested path (`dict set d outer inner v`) stores a *dict*
+    /// under the first key (tclsh 8.6/9.0: `dict get $d outer` is a dict),
+    /// so the consumer records a value-shape of `Dict` with unknown
+    /// structure for multi-key writes.
     SetsDictValue,
-    /// `dict append` / `dict lappend` `var key ?value …?` — extends the
-    /// variable's dict values with the words from `values_from` onward.
-    ExtendsDictValues {
-        /// 0-based index of the first value word.
+    /// `dict append var key ?value …?` — the stored value is a string
+    /// *concatenation*, so value **intreps do not survive** (tclsh 8.6:
+    /// string for both a missing and an existing key; 9.0 keeps the
+    /// argument's intrep only on the missing-key fast path). What does
+    /// survive is an object's *dispatch identity* — the objref text — so
+    /// only object-class facts flow into the value bound (the
+    /// collection-of-objects pattern, issue #797); every other shape
+    /// contributes nothing.
+    ExtendsDictValuesByName {
+        /// 0-based index of the first appended value word.
         values_from: u8,
     },
+    /// `dict lappend var key ?value …?` — the key's value becomes a *list*
+    /// (tclsh: `dict get` after `dict lappend` has list intrep; a prior
+    /// scalar value becomes element 0). The list wrapper is the fact; the
+    /// element shapes are not tracked (the prior value's shape is part of
+    /// the elements and is not statically known).
+    ListifiesDictValue,
 }

--- a/rust/tcl-registry/src/types.rs
+++ b/rust/tcl-registry/src/types.rs
@@ -80,9 +80,83 @@ pub enum VarWriteTyping {
     Fixed(TclType),
     /// The written variables receive destructured elements / parsed pieces
     /// whose static intrep is unknown and unrelated to the return value —
-    /// `lassign` (list elements of any type), `scan` / `binary scan`
-    /// (format-dependent conversions), `regexp` / `regsub` (matched
-    /// substrings).  Each target widens to *overdefined* so no downstream
-    /// type check reads a bogus intrep.
+    /// `scan` / `binary scan` (format-dependent conversions), `regexp` /
+    /// `regsub` (matched substrings).  Each target widens to *overdefined*
+    /// so no downstream type check reads a bogus intrep.
     Destructured,
+    /// The written variables receive the container argument's elements
+    /// **positionally**: target `i` takes element `i` of the container at
+    /// `container_arg` (0-based, after the command / subcommand word).
+    /// `lassign $l a b` types `a` / `b` from `$l`'s tracked per-position
+    /// element shapes when known, and widens each target to *overdefined*
+    /// otherwise (the pre-element-tracking `Destructured` behaviour).
+    /// `foreach` / `lmap` element variables share this semantic; their
+    /// group→container mapping rides the lowered statement's `foreach_groups`
+    /// metadata rather than a single argument index.
+    ElementsOf {
+        /// 0-based index of the container argument.
+        container_arg: u8,
+    },
+}
+
+/// How a command's *result value* relates to container element structure —
+/// the registry fact behind per-element type inference
+/// (`docs/design/compiler/type-tracking.md`, P3). Read by the compiler's
+/// type-propagation pass; never keyed on command names in the compiler.
+///
+/// Faithful to the runtime: container elements are shared `Tcl_Obj`s, so a
+/// builder's computed argument keeps its intrep inside the container, and a
+/// retrieval hands back the same object.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ReturnElements {
+    /// The result is a list of exactly the argument words from `from`
+    /// onward, one element per word in order (`list ?value …?`).
+    ListOfArgs {
+        /// 0-based index of the first element word.
+        from: u8,
+    },
+    /// The result is a dict built from alternating key/value words from
+    /// `from` onward (`dict create ?key value …?`); element facts describe
+    /// the **values**.
+    DictOfPairs {
+        /// 0-based index of the first key word.
+        from: u8,
+    },
+    /// The result is one element of the container argument — `lindex $l $i`
+    /// (single-index form) / `dict get $d $k` (single-key form). Multi-level
+    /// paths are outside this fact; the compiler applies it only to the
+    /// single-step call shape.
+    ElementOf {
+        /// 0-based index of the container argument.
+        container_arg: u8,
+    },
+    /// The result is a sub-list of the container argument (`lrange $l a b`):
+    /// a list whose every element is bounded by the source's uniform element
+    /// shape.
+    SubListOf {
+        /// 0-based index of the container argument.
+        container_arg: u8,
+    },
+}
+
+/// How a command evolves the container *elements* of the variable it writes
+/// in place — the registry fact that generalises the old object-only
+/// element-class harvesting to every element shape.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum VarElementsEffect {
+    /// `lappend var ?value …?` — appends each value word (from `values_from`
+    /// onward) as one new element of the variable's list.
+    AppendsListElements {
+        /// 0-based index of the first appended value word.
+        values_from: u8,
+    },
+    /// `dict set var ?key …? value` — stores the final word as one value of
+    /// the variable's dict.
+    SetsDictValue,
+    /// `dict append` / `dict lappend` `var key ?value …?` — extends the
+    /// variable's dict values with the words from `values_from` onward.
+    ExtendsDictValues {
+        /// 0-based index of the first value word.
+        values_from: u8,
+    },
 }

--- a/rust/tcl-registry/tests/registry.rs
+++ b/rust/tcl-registry/tests/registry.rs
@@ -217,11 +217,17 @@ fn var_write_typing_declares_destructuring_writers() {
             .var_write_typing()
     };
 
-    // Destructuring writers widen their targets to "unknown intrep": a list
-    // element (`lassign`) or a format-dependent conversion (`scan`), and
-    // `regexp` capture fragments.
+    // `lassign` writes its container's *elements* positionally — the P3
+    // element-inference fact, so a committed `[list ...]` source types each
+    // target from its element shape.
+    assert_eq!(
+        resolve("lassign", &["$l", "a"]),
+        VarWriteTyping::ElementsOf { container_arg: 0 },
+        "lassign must declare ElementsOf var-write typing"
+    );
+    // Format-dependent destructuring writers widen their targets to
+    // "unknown intrep": `scan` conversions and `regexp` capture fragments.
     for (name, args) in [
-        ("lassign", &["$l", "a"][..]),
         ("scan", &["$s", "%d", "a"][..]),
         ("regexp", &["re", "$s", "m"][..]),
     ] {

--- a/rust/tcl-syntax/Cargo.toml
+++ b/rust/tcl-syntax/Cargo.toml
@@ -42,7 +42,17 @@ repository.workspace = true
 authors.workspace = true
 description = "Shared Tcl parse-tree + byte-exact-semantics layer (lists, subst, expr, format) for the LSP/compiler and the WASM runtime"
 
+[features]
+# The `num-bigint` backend adapter for the shared numeric-tower semantics
+# (`number_tower::BigIntOps`) — enabled by pure-Rust adopters (the compiler's
+# const-folder, the VM); the faithful runtime keeps its libtommath `mp_int`
+# backend and implements the trait itself.
+num-bigint = ["dep:num-bigint", "dep:num-integer", "dep:num-traits"]
+
 [dependencies]
+num-bigint = { version = "0.4", optional = true }
+num-integer = { version = "0.1", optional = true }
+num-traits = { version = "0.2", optional = true }
 tcl-dialect = { path = "../tcl-dialect" }
 tcl-lexer = { path = "../tcl-lexer" }
 bitflags = "2"

--- a/rust/tcl-syntax/src/boolean.rs
+++ b/rust/tcl-syntax/src/boolean.rs
@@ -16,21 +16,50 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! Tcl boolean-word recognition (`Tcl_GetBoolean`).
+//! Tcl boolean recognition — the one home for every Tcl boolean acceptor.
 //!
-//! Tcl accepts the boolean *words* `true`/`yes`/`on` and `false`/`no`/`off`
+//! C Tcl has **two distinct acceptors**, and every consumer in this tree must
+//! use the matching one rather than hand-roll a word list:
+//!
+//! 1. **Strict boolean** ([`parse_boolean_strict`]) — `ParseBoolean` in
+//!    `tclObj.c`, the acceptor behind `string is boolean` and
+//!    `Tcl_GetBoolean`: the boolean *words* by unique case-insensitive
+//!    prefix, plus exactly the digits `0` / `1`. Nothing else — not `00`,
+//!    not `0.0`, not `0x0`, no surrounding whitespace (tclsh-verified table
+//!    in the tests).
+//! 2. **Truthiness** ([`truthiness`]) — `Tcl_GetBooleanFromObj`'s string
+//!    path, the acceptor behind every boolean *context* (`if`, `while`,
+//!    `expr`'s `?:` / `&&` / `||` / `!`): a boolean word, else **any
+//!    number** compared against zero (`2`, `-1`, `0.5`, `0x0`, `0e5`, a
+//!    bignum). `NaN` is a domain **error** in a boolean context
+//!    (tclsh: "floating point value is Not a Number"), not a truthy value;
+//!    `±Inf` is truthy.
+//!
+//! The word grammar: `true`/`yes`/`on` and `false`/`no`/`off`,
 //! case-insensitively **and by unique prefix** — `t`/`tr`/`tru` are `true`,
 //! `ye` is `yes`, `of` is `off`, `n` is `no`.  A prefix shared by a true-word
 //! and a false-word is ambiguous and rejected: `o` matches both `on` and
 //! `off`, so `expr {o}` is an error in real Tcl.
-//!
-//! Numeric booleans (`0`/`1`, and any integer under `Tcl_GetBoolean` where a
-//! non-zero value is true) are handled by the number grammar, not here.
 
 /// The canonical true-words, longest resolution set for `Tcl_GetBoolean`.
 const TRUE_WORDS: [&str; 3] = ["true", "yes", "on"];
 /// The canonical false-words.
 const FALSE_WORDS: [&str; 3] = ["false", "no", "off"];
+
+/// The six boolean words, full spellings, lowercase — for consumers that
+/// classify *literal spellings* (would-commit type classification, safe-word
+/// checks) rather than accept runtime values. Value acceptance goes through
+/// [`parse_boolean_strict`] / [`truthiness`], which also handle prefixes and
+/// numerics.
+pub const BOOLEAN_WORDS: [&str; 6] = ["true", "yes", "on", "false", "no", "off"];
+
+/// Whether `word` is one of the six boolean words spelled in full
+/// (case-insensitive) — the literal-classifier check. `tru` is *not* a full
+/// word (use [`parse_boolean_word`] for prefix acceptance).
+#[must_use]
+pub fn is_boolean_full_word(word: &str) -> bool {
+    BOOLEAN_WORDS.iter().any(|w| w.eq_ignore_ascii_case(word))
+}
 
 /// Resolve a Tcl boolean *word* (or unique prefix) to its value.
 ///
@@ -58,6 +87,45 @@ pub fn parse_boolean_word(word: &str) -> Option<bool> {
 #[must_use]
 pub fn is_boolean_word(word: &str) -> bool {
     parse_boolean_word(word).is_some()
+}
+
+/// The **strict** boolean acceptor — C's `ParseBoolean` (`tclObj.c`), the
+/// semantics of `string is boolean` and `Tcl_GetBoolean`.
+///
+/// Accepts a boolean word by unique case-insensitive prefix, plus exactly
+/// the digits `"0"` and `"1"`. Everything else — `00`, `01`, `2`, `0.0`,
+/// `0x0`, whitespace-padded spellings, the empty string — is rejected
+/// (tclsh-verified, see the oracle-table test).
+#[must_use]
+pub fn parse_boolean_strict(text: &str) -> Option<bool> {
+    match text {
+        "0" => Some(false),
+        "1" => Some(true),
+        _ => parse_boolean_word(text),
+    }
+}
+
+/// The **boolean-context** acceptor — `Tcl_GetBooleanFromObj`'s string path,
+/// the semantics of `if` / `while` conditions and `expr`'s `?:` / `&&` /
+/// `||` / `!` operands.
+///
+/// A boolean word resolves to its value; otherwise any *number* compares
+/// against zero — `2`, `-1`, `0.5`, `0x0`, `0e5`, and beyond-wide bignums
+/// (non-zero by construction) are all accepted. `NaN` is a domain **error**
+/// in a boolean context (tclsh: "floating point value is Not a Number"), so
+/// it returns `None`, as does any non-boolean non-number.
+#[must_use]
+pub fn truthiness(text: &str) -> Option<bool> {
+    if let Some(b) = parse_boolean_word(text) {
+        return Some(b);
+    }
+    match crate::number::parse_whole(text)? {
+        crate::number::Number::Int(i) => Some(i != 0),
+        // A parsed `Big` is beyond `i64`, hence never zero.
+        crate::number::Number::Big { .. } => Some(true),
+        crate::number::Number::Double(d) => Some(d != 0.0),
+        crate::number::Number::Nan { .. } => None,
+    }
 }
 
 #[cfg(test)]
@@ -92,5 +160,100 @@ mod tests {
         assert_eq!(parse_boolean_word("maybe"), None);
         assert_eq!(parse_boolean_word("1"), None); // numeric — caller's job
         assert_eq!(parse_boolean_word("trueish"), None);
+    }
+
+    /// The strict acceptor, pinned to the tclsh 8.6.14 oracle table
+    /// (`string is boolean -strict $v` — 9.0 agrees):
+    ///
+    /// ```text
+    /// 0 1                  => accepted (their digit values)
+    /// 00 01 2 -1 0.0 1.0   => rejected (numbers, but not THE digits)
+    /// 0x0 0x1              => rejected
+    /// true tru t TRUE      => true      f of off        => false
+    /// ye y                 => true      n no            => false
+    /// o                    => rejected (ambiguous on/off)
+    /// " true" "true " ""   => rejected (no trimming)
+    /// ```
+    #[test]
+    fn strict_acceptor_matches_oracle_table() {
+        for (v, want) in [
+            ("0", Some(false)),
+            ("1", Some(true)),
+            ("00", None),
+            ("01", None),
+            ("2", None),
+            ("-1", None),
+            ("0.0", None),
+            ("1.0", None),
+            ("0x0", None),
+            ("0x1", None),
+            ("true", Some(true)),
+            ("tru", Some(true)),
+            ("t", Some(true)),
+            ("TRUE", Some(true)),
+            ("f", Some(false)),
+            ("of", Some(false)),
+            ("o", None),
+            ("on", Some(true)),
+            ("off", Some(false)),
+            ("ye", Some(true)),
+            ("y", Some(true)),
+            ("n", Some(false)),
+            ("no", Some(false)),
+            (" true", None),
+            ("true ", None),
+            ("", None),
+        ] {
+            assert_eq!(parse_boolean_strict(v), want, "strict {v:?}");
+        }
+    }
+
+    /// The boolean-context acceptor, pinned to the tclsh 8.6.14 oracle table
+    /// (`expr {$v ? "T" : "F"}` — 9.0 agrees):
+    ///
+    /// ```text
+    /// 0 00 0.0 0x0 0e5 of   => false
+    /// 2 -1 0.5 true tru t on 1e0 Inf -Inf => true
+    /// o truex "yes no"      => error ("expected boolean value")
+    /// NaN nan -NaN          => error ("floating point value is Not a Number")
+    /// ```
+    #[test]
+    fn truthiness_matches_oracle_table() {
+        for (v, want) in [
+            ("0", Some(false)),
+            ("00", Some(false)),
+            ("0.0", Some(false)),
+            ("0x0", Some(false)),
+            ("0e5", Some(false)),
+            ("of", Some(false)),
+            ("2", Some(true)),
+            ("-1", Some(true)),
+            ("0.5", Some(true)),
+            ("true", Some(true)),
+            ("tru", Some(true)),
+            ("t", Some(true)),
+            ("on", Some(true)),
+            ("1e0", Some(true)),
+            ("Inf", Some(true)),
+            ("-Inf", Some(true)),
+            // A beyond-wide bignum is non-zero by construction.
+            ("18446744073709551616", Some(true)),
+            ("o", None),
+            ("truex", None),
+            ("yes no", None),
+            ("NaN", None),
+            ("nan", None),
+            ("-NaN", None),
+        ] {
+            assert_eq!(truthiness(v), want, "truthiness {v:?}");
+        }
+    }
+
+    #[test]
+    fn full_word_classifier_rejects_prefixes() {
+        assert!(is_boolean_full_word("true"));
+        assert!(is_boolean_full_word("OFF"));
+        assert!(!is_boolean_full_word("tru"));
+        assert!(!is_boolean_full_word("0"));
     }
 }

--- a/rust/tcl-syntax/src/expr/ast.rs
+++ b/rust/tcl-syntax/src/expr/ast.rs
@@ -477,31 +477,52 @@ impl ExprNode {
 
     /// Recursive variable collection helper.
     fn collect_vars(&self, out: &mut HashSet<String>) {
+        self.collect_vars_with(&|_text, name| name.to_owned(), out);
+    }
+
+    /// Every variable read in this expression, **element-qualified**: a
+    /// constant-keyed array element reports as its own variable `base(key)`,
+    /// a dynamic one as the bare base — the SSA-side counterpart of
+    /// [`Self::vars`], which normalises every reference to its base.
+    #[must_use]
+    pub fn vars_element_qualified(&self) -> HashSet<String> {
+        let mut result = HashSet::new();
+        self.collect_vars_with(
+            &|text, _name| crate::naming::element_var_name(text).to_owned(),
+            &mut result,
+        );
+        result
+    }
+
+    /// The shared walk under [`Self::vars`] / [`Self::vars_element_qualified`]:
+    /// `pick` maps a `Var` node's `(text, name)` to the reported name.
+    fn collect_vars_with(&self, pick: &dyn Fn(&str, &str) -> String, out: &mut HashSet<String>) {
         match self {
-            Self::Var { name, .. } => {
-                if !name.is_empty() {
-                    out.insert(name.clone());
+            Self::Var { text, name, .. } => {
+                let picked = pick(text, name);
+                if !picked.is_empty() {
+                    out.insert(picked);
                 }
             }
             Self::Binary { left, right, .. } => {
-                left.collect_vars(out);
-                right.collect_vars(out);
+                left.collect_vars_with(pick, out);
+                right.collect_vars_with(pick, out);
             }
             Self::Unary { operand, .. } => {
-                operand.collect_vars(out);
+                operand.collect_vars_with(pick, out);
             }
             Self::Ternary {
                 condition,
                 true_branch,
                 false_branch,
             } => {
-                condition.collect_vars(out);
-                true_branch.collect_vars(out);
-                false_branch.collect_vars(out);
+                condition.collect_vars_with(pick, out);
+                true_branch.collect_vars_with(pick, out);
+                false_branch.collect_vars_with(pick, out);
             }
             Self::Call { args, .. } => {
                 for arg in args {
-                    arg.collect_vars(out);
+                    arg.collect_vars_with(pick, out);
                 }
             }
             // Command substitutions may contain variable references,
@@ -515,26 +536,28 @@ impl ExprNode {
             // detection (W214) sees the read. Nested vars inside command
             // substitutions are left to the SSA layer, matching the
             // `Self::Command` policy above.
-            Self::Raw { text } => collect_raw_vars(text, out),
+            Self::Raw { text } => collect_raw_vars_with(text, pick, out),
         }
     }
 }
 
-/// Re-lex raw fallback text and collect top-level `$var` references
-/// into `out`.'s `VAR`-token scan but without the
-/// registry / command-substitution recursion — at the pure-AST level
-/// we stop at command boundaries (nested `[…]` vars belong to the SSA
-/// layer). A lex failure contributes no variables.
-fn collect_raw_vars(text: &str, out: &mut HashSet<String>) {
+/// Re-lex raw fallback text and collect top-level `$var` references through
+/// `pick` (the same `(text, base-name)` mapping as the AST walk).
+fn collect_raw_vars_with(
+    text: &str,
+    pick: &dyn Fn(&str, &str) -> String,
+    out: &mut HashSet<String>,
+) {
     let source_map = SourceMap::new(text);
     let Ok(tokens) = Lexer::new(text).tokenise_all() else {
         return;
     };
     for tok in &tokens {
         if tok.kind == TokenType::Var {
-            let name = normalise_var_name(source_map.token_text(*tok));
-            if !name.is_empty() {
-                out.insert(name.to_owned());
+            let raw = source_map.token_text(*tok);
+            let picked = pick(raw, normalise_var_name(raw));
+            if !picked.is_empty() {
+                out.insert(picked);
             }
         }
     }

--- a/rust/tcl-syntax/src/expr/mathfunc.rs
+++ b/rust/tcl-syntax/src/expr/mathfunc.rs
@@ -314,7 +314,21 @@ fn type_conv(name: &str, vals: &[Num]) -> Option<Num> {
         "ceil" => Some(Num::Float(v.as_f64().ceil())),
         "floor" => Some(Num::Float(v.as_f64().floor())),
         "isqrt" => match v {
-            Num::Int(i) if i >= 0 => Some(Num::Int((i as f64).sqrt() as i64)),
+            Num::Int(i) if i >= 0 => {
+                // Float sqrt is only an estimate: a near-2^62 operand rounds
+                // up in the i64→f64 conversion and lands the estimate one too
+                // high vs C's exact `mp_sqrt` (oracle:
+                // `isqrt(4611686018427387903)` is 2147483647, not 2^31).
+                // Correct to the exact integer square root.
+                let mut r = (i as f64).sqrt() as i64;
+                while r > 0 && r.checked_mul(r).is_none_or(|sq| sq > i) {
+                    r -= 1;
+                }
+                while (r + 1).checked_mul(r + 1).is_some_and(|sq| sq <= i) {
+                    r += 1;
+                }
+                Some(Num::Int(r))
+            }
             _ => None,
         },
         _ => None,

--- a/rust/tcl-syntax/src/lib.rs
+++ b/rust/tcl-syntax/src/lib.rs
@@ -49,6 +49,7 @@ pub mod list;
 pub mod mro;
 pub mod naming;
 pub mod number;
+pub mod number_tower;
 pub mod scan;
 pub mod switch_body;
 pub mod value;

--- a/rust/tcl-syntax/src/naming.rs
+++ b/rust/tcl-syntax/src/naming.rs
@@ -382,6 +382,59 @@ pub fn normalise_var_name(name: &str) -> &str {
     }
 }
 
+/// Whether an array-element key is a compile-time literal — no `$` variable
+/// or `[…]` command substitution, so the element it names is a single fixed
+/// variable (`arr(k)`, `arr(1)`), not a runtime-selected one (`arr($i)`).
+#[must_use]
+pub fn array_key_is_literal(key: &str) -> bool {
+    !key.contains('$') && !key.contains('[')
+}
+
+/// The **SSA variable name** of a reference or write-target word: the
+/// element-qualified form `base(key)` for a *constant-keyed* array element,
+/// the bare base otherwise.
+///
+/// Array elements are independent variables at runtime (each has its own
+/// value and intrep), so a constant-keyed element gets its own name — and
+/// therefore its own SSA symbol, type-lattice cell, and shimmer tracking.
+/// A dynamic key (`arr($i)`) may select any element, so it stays on the
+/// conflated base name (the SSA build fans its def over the array's known
+/// elements). A `${…}`-braced reference substitutes nothing inside the
+/// braces, so its key is always literal — `${arr($i)}` names the element
+/// whose key is the two characters `$i`.
+///
+/// ```
+/// use tcl_syntax::naming::element_var_name;
+/// assert_eq!(element_var_name("$arr(k)"), "arr(k)");
+/// assert_eq!(element_var_name("arr(k)"), "arr(k)");
+/// assert_eq!(element_var_name("$arr($i)"), "arr");
+/// assert_eq!(element_var_name("${arr($i)}"), "arr($i)");
+/// assert_eq!(element_var_name("${arr}(k)"), "arr");
+/// assert_eq!(element_var_name("$plain"), "plain");
+/// ```
+#[must_use]
+pub fn element_var_name(name: &str) -> &str {
+    element_var_name_braced(name, false)
+}
+
+/// [`element_var_name`] for a write-target word whose braced-ness is known
+/// from the lowering (`set {a($x)} v` — the braces suppressed substitution,
+/// so the key is literal even though it spells `$x`).
+#[must_use]
+pub fn element_var_name_braced(name: &str, braced_literal: bool) -> &str {
+    // `${…}` brace form: the inner text is the whole (literal) name.
+    if let Some(after) = name.strip_prefix("${")
+        && let Some(rel) = after.find('}')
+    {
+        return &after[..rel];
+    }
+    let base = name.strip_prefix('$').unwrap_or(name);
+    match split_array_name(name) {
+        (_, Some(key)) if braced_literal || array_key_is_literal(key) => base,
+        _ => normalise_var_name(name),
+    }
+}
+
 /// Return `true` when `${name}` would successfully look up `name` under the
 /// given `${…}` delimiting rule.
 ///

--- a/rust/tcl-syntax/src/naming.rs
+++ b/rust/tcl-syntax/src/naming.rs
@@ -383,11 +383,19 @@ pub fn normalise_var_name(name: &str) -> &str {
 }
 
 /// Whether an array-element key is a compile-time literal — no `$` variable
-/// or `[…]` command substitution, so the element it names is a single fixed
-/// variable (`arr(k)`, `arr(1)`), not a runtime-selected one (`arr($i)`).
+/// substitution, `[…]` command substitution, or `\` backslash substitution,
+/// so the element it names is a single fixed variable (`arr(k)`, `arr(1)`),
+/// not a runtime-selected or -decoded one (`arr($i)`, `arr(\x41)`).
+///
+/// Backslash sequences substitute in an unbraced word (`incr arr(\x41)`
+/// increments `arr(A)` — tclsh 8.6/9.0 verified), so treating them as
+/// literal would split one runtime element across two SSA symbols. They stay
+/// on the conflated base instead; a *braced* word (`set {arr(\x41)} v`)
+/// suppresses substitution and its key is literal via
+/// [`element_var_name_braced`]'s flag.
 #[must_use]
 pub fn array_key_is_literal(key: &str) -> bool {
-    !key.contains('$') && !key.contains('[')
+    !key.contains('$') && !key.contains('[') && !key.contains('\\')
 }
 
 /// The **SSA variable name** of a reference or write-target word: the
@@ -406,6 +414,7 @@ pub fn array_key_is_literal(key: &str) -> bool {
 /// ```
 /// use tcl_syntax::naming::element_var_name;
 /// assert_eq!(element_var_name("$arr(k)"), "arr(k)");
+/// assert_eq!(element_var_name("$arr(\\x41)"), "arr", "backslash keys substitute");
 /// assert_eq!(element_var_name("arr(k)"), "arr(k)");
 /// assert_eq!(element_var_name("$arr($i)"), "arr");
 /// assert_eq!(element_var_name("${arr($i)}"), "arr($i)");

--- a/rust/tcl-syntax/src/number_tower.rs
+++ b/rust/tcl-syntax/src/number_tower.rs
@@ -198,6 +198,118 @@ pub fn int_mod<B: BigIntOps>(a: &B, b: &B) -> Option<B> {
     Some(a.mod_floor(b))
 }
 
+/// The backend conformance suite: every semantic row of the tclsh oracle
+/// corpus, generic over the backend. Each adopter's test suite calls
+/// [`conformance::assert_backend`] with its own [`BigIntOps`] type — the
+/// crate's unit tests run it over an `i128` toy backend and (feature
+/// `num-bigint`) `BigInt`; the faithful runtime runs it over the real
+/// libtommath `mp_int`. A backend that passes cannot drift from the others
+/// on any covered semantic.
+pub mod conformance {
+    use super::{BigIntOps, MAX_EXPONENT, int_div, int_mod, int_pow, int_shr};
+
+    /// Panics (with the failing row) unless `B` reproduces the full oracle
+    /// corpus. `wide` must build values well beyond `i64` (e.g. `2^64`) —
+    /// backends narrower than ~130 bits cannot conform.
+    #[expect(
+        clippy::missing_panics_doc,
+        reason = "panicking on a failed row is this function's contract"
+    )]
+    pub fn assert_backend<B: BigIntOps + core::fmt::Debug>() {
+        let v = B::from_i64;
+
+        // Round-trip and demote-when-fits.
+        assert_eq!(v(i64::MAX).to_i64(), Some(i64::MAX));
+        assert_eq!(v(i64::MIN).to_i64(), Some(i64::MIN));
+        let two64 = v(2).pow_u32(64); // 18446744073709551616
+        assert_eq!(two64.to_i64(), None, "2^64 must not narrow");
+        assert!(!two64.is_negative());
+        assert!(!two64.is_zero());
+        assert!(v(0).is_zero());
+        assert!(v(-1).is_negative());
+
+        // Exact ring ops at the promotion boundary (i64::MAX + 1, -MAX - 2).
+        let big = v(i64::MAX).add(&v(1));
+        assert_eq!(big.to_i64(), None);
+        assert_eq!(big.sub(&v(1)).to_i64(), Some(i64::MAX), "demote on re-fit");
+        assert_eq!(
+            v(i64::MIN).add(&v(-1)).add(&v(1)).to_i64(),
+            Some(i64::MIN),
+            "-2^63 - 1 + 1 re-fits"
+        );
+        assert_eq!(v(3).mul(&v(-4)).to_i64(), Some(-12));
+        assert_eq!(big.neg().add(&big).to_i64(), Some(0), "x + (-x) = 0");
+
+        // Floor division and modulus (sign follows the divisor), including
+        // the beyond-wide oracle rows 2^64 % 7 = 2 and 2^64 / -3.
+        assert_eq!(int_div(&v(7), &v(2)).unwrap().to_i64(), Some(3));
+        assert_eq!(int_div(&v(-7), &v(2)).unwrap().to_i64(), Some(-4));
+        assert_eq!(int_mod(&v(-7), &v(2)).unwrap().to_i64(), Some(1));
+        assert_eq!(int_mod(&v(7), &v(-2)).unwrap().to_i64(), Some(-1));
+        assert!(int_div(&v(1), &v(0)).is_none(), "divide by zero");
+        assert!(int_mod(&v(1), &v(0)).is_none());
+        assert_eq!(int_mod(&two64, &v(7)).unwrap().to_i64(), Some(2));
+        assert_eq!(
+            int_div(&two64, &v(-3)).unwrap().to_i64(),
+            Some(-6_148_914_691_236_517_206),
+            "2^64 / -3 floors toward -inf"
+        );
+
+        // `**` collapses and guards (`INST_EXPON`).
+        assert_eq!(int_pow(&v(2), 10).unwrap().to_i64(), Some(1024));
+        assert_eq!(int_pow(&v(5), 0).unwrap().to_i64(), Some(1));
+        assert!(int_pow(&v(0), -1).is_none(), "zero by negative power");
+        assert_eq!(int_pow(&v(1), i64::MAX).unwrap().to_i64(), Some(1));
+        assert_eq!(int_pow(&v(-1), 5).unwrap().to_i64(), Some(-1));
+        assert_eq!(int_pow(&v(-1), 6).unwrap().to_i64(), Some(1));
+        assert_eq!(int_pow(&v(7), -3).unwrap().to_i64(), Some(0));
+        assert!(
+            int_pow(&v(2), MAX_EXPONENT + 1).is_none(),
+            "exponent too large"
+        );
+        assert_eq!(int_pow(&v(2), 64).unwrap(), two64, "2**64 exact");
+
+        // Shifts: exactness and the sign-collapse past the width.
+        assert_eq!(v(1).shl(63).to_i64(), None, "1<<63 exceeds i64");
+        assert_eq!(
+            v(1).shl(63).neg().to_i64(),
+            Some(i64::MIN),
+            "-(1<<63) is i64::MIN"
+        );
+        assert_eq!(int_shr(&v(-8), 1).unwrap().to_i64(), Some(-4));
+        assert_eq!(
+            int_shr(&v(-8), 1000).unwrap().to_i64(),
+            Some(-1),
+            "sign collapse"
+        );
+        assert_eq!(int_shr(&v(8), 1000).unwrap().to_i64(), Some(0));
+        assert!(int_shr(&v(8), -1).is_none(), "negative count");
+        assert_eq!(int_shr(&two64, 64).unwrap().to_i64(), Some(1), "2^64 >> 64");
+        assert_eq!(
+            int_shr(&two64.neg(), 200).unwrap().to_i64(),
+            Some(-1),
+            "-2^64 >> 200 collapses to -1"
+        );
+
+        // Two's-complement bitwise trio on negatives (the oracle rows
+        // -5 & 3 = 3, -5 | 3 = -5, -5 ^ 3 = -8) and the beyond-wide row
+        // 2^64 & 0xFF = 0.
+        assert_eq!(v(-5).bitand(&v(3)).to_i64(), Some(3));
+        assert_eq!(v(-5).bitor(&v(3)).to_i64(), Some(-5));
+        assert_eq!(v(-5).bitxor(&v(3)).to_i64(), Some(-8));
+        assert_eq!(two64.bitand(&v(0xFF)).to_i64(), Some(0));
+
+        // bit_len feeds the shift collapse: 2^64 needs 65 bits.
+        assert_eq!(two64.bit_len(), 65);
+        assert_eq!(v(0).bit_len(), 0);
+
+        // Total order (drives numeric comparisons).
+        assert!(v(-1) < v(0) && v(0) < v(1));
+        assert!(two64 > v(i64::MAX), "2^64 > i64::MAX");
+        assert!(two64.neg() < v(i64::MIN), "-2^64 < i64::MIN");
+    }
+}
+
 /// The `num-bigint` backend adapter (feature `num-bigint`) — shared by the
 /// pure-Rust adopters (the compiler's const-folder today, the VM next). The
 /// faithful runtime implements [`BigIntOps`] over the real libtommath
@@ -326,6 +438,20 @@ mod tests {
         fn bit_len(&self) -> u64 {
             u64::from(128 - self.0.unsigned_abs().leading_zeros())
         }
+    }
+
+    /// The toy backend itself passes the full conformance corpus — proving
+    /// the suite (and the semantics) are backend-agnostic.
+    #[test]
+    fn i128_backend_conforms() {
+        conformance::assert_backend::<I128>();
+    }
+
+    /// The `num-bigint` adapter passes the full conformance corpus.
+    #[cfg(feature = "num-bigint")]
+    #[test]
+    fn num_bigint_backend_conforms() {
+        conformance::assert_backend::<num_bigint::BigInt>();
     }
 
     /// Floor semantics, oracle values (`-7/2 → -4`, `-7%2 → 1`).

--- a/rust/tcl-syntax/src/number_tower.rs
+++ b/rust/tcl-syntax/src/number_tower.rs
@@ -1,0 +1,368 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The numeric-tower **operator semantics**, written once, generic over the
+//! big-integer backend.
+//!
+//! This crate already owns the tower's two string boundaries — the parse
+//! direction ([`crate::number::parse`], the `TclParseNumber` port) and the
+//! format direction ([`crate::number::format_double`], `Tcl_PrintDouble`).
+//! This module adds the third piece: the **integer operator semantics** of
+//! `tclExecute.c` (`INST_ADD` … `INST_EXPON`), so the promotion ladder,
+//! floor division/modulus, the `**` special cases, shift sign-collapse, and
+//! demote-when-fits live in exactly one place.
+//!
+//! ## The backend seam
+//!
+//! [`BigIntOps`] abstracts the arbitrary-precision integer. Adopters plug in
+//! whichever backend they are built on:
+//!
+//! - the **faithful runtime** can implement it over the real libtommath
+//!   `mp_int` (its bignum *is* `TCL_BIGNUM_TYPE`, the C-extension ABI — see
+//!   `runtime/rust/src/bignum.rs`);
+//! - the **compiler's const-folder** implements it over `num-bigint`
+//!   (`tcl_compiler::tcl_expr_eval`);
+//! - the **VM** (`tcl_vm::expr`) is the same `num-bigint` shape and is the
+//!   next planned adopter.
+//!
+//! Because every operation here takes and returns backend values (never a
+//! second bignum representation), swapping libtommath for a pure-Rust
+//! equivalent — or back — is a per-adopter choice with no semantic drift:
+//! the semantics are these functions, verified against the tclsh oracle
+//! corpus (`docs/design/compiler/type-tracking.md`) and C Tcl 9's
+//! `tclExecute.c`.
+//!
+//! ## What lives here vs the adopter
+//!
+//! Here: everything value-shaped — promotion, floor rules, `**` collapses,
+//! shift-count edge cases, two's-complement bitwise identities. In the
+//! adopter: value wrapping (demote-when-fits via [`BigIntOps::to_i64`]),
+//! error surfaces (divide-by-zero message text), and float contamination
+//! (any double operand routes the whole operation to `f64` *before* these
+//! functions are reached, mirroring `Tcl_GetNumberFromObj`).
+
+/// Maximum exponent for integer `**` — C Tcl's `INST_EXPON` limit
+/// (`exponent < 2^28`); larger exponents raise "exponent too large" at
+/// runtime, so no adopter should compute them.
+pub const MAX_EXPONENT: i64 = (1 << 28) - 1;
+
+/// The big-integer backend: the operations the tower semantics need, no
+/// more. Implementations must be exact (arbitrary precision) and use
+/// two's-complement semantics for the bitwise trio on negative values —
+/// both libtommath (`mp_and`/`mp_or`/`mp_xor` under `TCL_BIGNUM_TYPE`'s
+/// sign handling) and `num-bigint` already do.
+pub trait BigIntOps: Sized + Clone + Ord {
+    /// Construct from a wide.
+    #[must_use]
+    fn from_i64(v: i64) -> Self;
+    /// Narrow to a wide when the value fits — the demote-when-fits step
+    /// (`$big - $big` is `Int(0)`, never a one-word bignum).
+    fn to_i64(&self) -> Option<i64>;
+    /// Whether the value is zero.
+    fn is_zero(&self) -> bool;
+    /// Whether the value is negative.
+    fn is_negative(&self) -> bool;
+    /// Exact sum.
+    #[must_use]
+    fn add(&self, other: &Self) -> Self;
+    /// Exact difference.
+    #[must_use]
+    fn sub(&self, other: &Self) -> Self;
+    /// Exact product.
+    #[must_use]
+    fn mul(&self, other: &Self) -> Self;
+    /// **Floor** quotient (rounds toward −∞ — Tcl's `/`, not truncation).
+    /// Callers guarantee a non-zero divisor.
+    #[must_use]
+    fn div_floor(&self, other: &Self) -> Self;
+    /// **Floor** remainder (sign follows the divisor — Tcl's `%`).
+    /// Callers guarantee a non-zero divisor.
+    #[must_use]
+    fn mod_floor(&self, other: &Self) -> Self;
+    /// Exact negation.
+    #[must_use]
+    fn neg(&self) -> Self;
+    /// Exact power by a small non-negative exponent.
+    #[must_use]
+    fn pow_u32(&self, exp: u32) -> Self;
+    /// Left shift by a small count.
+    #[must_use]
+    fn shl(&self, count: u32) -> Self;
+    /// Arithmetic right shift by a count (sign-extending).
+    #[must_use]
+    fn shr(&self, count: usize) -> Self;
+    /// Two's-complement AND.
+    #[must_use]
+    fn bitand(&self, other: &Self) -> Self;
+    /// Two's-complement OR.
+    #[must_use]
+    fn bitor(&self, other: &Self) -> Self;
+    /// Two's-complement XOR.
+    #[must_use]
+    fn bitxor(&self, other: &Self) -> Self;
+    /// Number of bits in the magnitude (for shift-count collapse).
+    fn bit_len(&self) -> u64;
+}
+
+/// Integer `**` on the tower — C's `INST_EXPON` rules, exactly:
+///
+/// - `y == 0` → `1`; `y == 1` → the base.
+/// - base `0`: negative exponent is the "exponentiation of zero by negative
+///   power" domain error (`None`); otherwise `0`.
+/// - base `1` → `1`; base `-1` → `±1` by exponent parity — these collapse
+///   for *any* exponent magnitude.
+/// - any other base with a negative exponent → `0` (integer power rounds
+///   to zero).
+/// - exponents past [`MAX_EXPONENT`] are the "exponent too large" runtime
+///   error (`None`) — no adopter should compute them.
+#[must_use]
+pub fn int_pow<B: BigIntOps>(base: &B, exponent: i64) -> Option<B> {
+    let one = B::from_i64(1);
+    let minus_one = B::from_i64(-1);
+    if exponent == 0 {
+        return Some(one);
+    }
+    if exponent == 1 {
+        return Some(base.clone());
+    }
+    if base.is_zero() {
+        return if exponent < 0 {
+            None
+        } else {
+            Some(B::from_i64(0))
+        };
+    }
+    if *base == one {
+        return Some(one);
+    }
+    if *base == minus_one {
+        return Some(if exponent % 2 == 0 { one } else { minus_one });
+    }
+    if exponent < 0 {
+        return Some(B::from_i64(0));
+    }
+    if exponent > MAX_EXPONENT {
+        return None;
+    }
+    let exp = u32::try_from(exponent).ok()?;
+    Some(base.pow_u32(exp))
+}
+
+/// Arithmetic right shift with the width collapse: a count at or past the
+/// operand's bit length yields the replicated sign (`0` / `-1`), matching
+/// C's wide and bignum paths. A negative count is the caller's "negative
+/// shift argument" error (`None`).
+#[must_use]
+pub fn int_shr<B: BigIntOps>(value: &B, count: i64) -> Option<B> {
+    if count < 0 {
+        return None;
+    }
+    match usize::try_from(count) {
+        Ok(c) if u64::try_from(c).is_ok_and(|c64| c64 <= value.bit_len()) => Some(value.shr(c)),
+        _ => Some(B::from_i64(if value.is_negative() { -1 } else { 0 })),
+    }
+}
+
+/// Floor division on the tower. `None` on a zero divisor (the adopter's
+/// "divide by zero" error surface).
+#[must_use]
+pub fn int_div<B: BigIntOps>(a: &B, b: &B) -> Option<B> {
+    if b.is_zero() {
+        return None;
+    }
+    Some(a.div_floor(b))
+}
+
+/// Floor modulus on the tower (sign follows the divisor). `None` on a zero
+/// divisor.
+#[must_use]
+pub fn int_mod<B: BigIntOps>(a: &B, b: &B) -> Option<B> {
+    if b.is_zero() {
+        return None;
+    }
+    Some(a.mod_floor(b))
+}
+
+/// The `num-bigint` backend adapter (feature `num-bigint`) — shared by the
+/// pure-Rust adopters (the compiler's const-folder today, the VM next). The
+/// faithful runtime implements [`BigIntOps`] over the real libtommath
+/// `mp_int` instead; both backends run these identical semantics.
+#[cfg(feature = "num-bigint")]
+impl BigIntOps for num_bigint::BigInt {
+    fn from_i64(v: i64) -> Self {
+        num_bigint::BigInt::from(v)
+    }
+    fn to_i64(&self) -> Option<i64> {
+        num_traits::ToPrimitive::to_i64(self)
+    }
+    fn is_zero(&self) -> bool {
+        num_traits::Zero::is_zero(self)
+    }
+    fn is_negative(&self) -> bool {
+        num_traits::Signed::is_negative(self)
+    }
+    fn add(&self, other: &Self) -> Self {
+        self + other
+    }
+    fn sub(&self, other: &Self) -> Self {
+        self - other
+    }
+    fn mul(&self, other: &Self) -> Self {
+        self * other
+    }
+    fn div_floor(&self, other: &Self) -> Self {
+        num_integer::Integer::div_floor(self, other)
+    }
+    fn mod_floor(&self, other: &Self) -> Self {
+        num_integer::Integer::mod_floor(self, other)
+    }
+    fn neg(&self) -> Self {
+        -self
+    }
+    fn pow_u32(&self, exp: u32) -> Self {
+        self.pow(exp)
+    }
+    fn shl(&self, count: u32) -> Self {
+        self << count
+    }
+    fn shr(&self, count: usize) -> Self {
+        self >> count
+    }
+    fn bitand(&self, other: &Self) -> Self {
+        self & other
+    }
+    fn bitor(&self, other: &Self) -> Self {
+        self | other
+    }
+    fn bitxor(&self, other: &Self) -> Self {
+        self ^ other
+    }
+    fn bit_len(&self) -> u64 {
+        self.bits()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A tiny exact backend over `i128` — wide enough for every semantic
+    /// case the tests exercise, proving the semantics are backend-agnostic.
+    #[derive(Clone, PartialEq, Eq, PartialOrd, Ord, Debug)]
+    struct I128(i128);
+
+    impl BigIntOps for I128 {
+        fn from_i64(v: i64) -> Self {
+            I128(i128::from(v))
+        }
+        fn to_i64(&self) -> Option<i64> {
+            i64::try_from(self.0).ok()
+        }
+        fn is_zero(&self) -> bool {
+            self.0 == 0
+        }
+        fn is_negative(&self) -> bool {
+            self.0 < 0
+        }
+        fn add(&self, other: &Self) -> Self {
+            I128(self.0 + other.0)
+        }
+        fn sub(&self, other: &Self) -> Self {
+            I128(self.0 - other.0)
+        }
+        fn mul(&self, other: &Self) -> Self {
+            I128(self.0 * other.0)
+        }
+        fn div_floor(&self, other: &Self) -> Self {
+            I128(
+                self.0.div_euclid(other.0)
+                    - i128::from(other.0 < 0 && self.0.rem_euclid(other.0) != 0),
+            )
+        }
+        fn mod_floor(&self, other: &Self) -> Self {
+            let r = self.0.rem_euclid(other.0.abs());
+            I128(if other.0 < 0 && r != 0 {
+                r - other.0.abs()
+            } else {
+                r
+            })
+        }
+        fn neg(&self) -> Self {
+            I128(-self.0)
+        }
+        fn pow_u32(&self, exp: u32) -> Self {
+            I128(self.0.pow(exp))
+        }
+        fn shl(&self, count: u32) -> Self {
+            I128(self.0 << count)
+        }
+        fn shr(&self, count: usize) -> Self {
+            I128(self.0 >> count)
+        }
+        fn bitand(&self, other: &Self) -> Self {
+            I128(self.0 & other.0)
+        }
+        fn bitor(&self, other: &Self) -> Self {
+            I128(self.0 | other.0)
+        }
+        fn bitxor(&self, other: &Self) -> Self {
+            I128(self.0 ^ other.0)
+        }
+        fn bit_len(&self) -> u64 {
+            u64::from(128 - self.0.unsigned_abs().leading_zeros())
+        }
+    }
+
+    /// Floor semantics, oracle values (`-7/2 → -4`, `-7%2 → 1`).
+    #[test]
+    fn floor_div_mod_oracle() {
+        let v = |n: i64| I128::from_i64(n);
+        assert_eq!(int_div(&v(7), &v(2)), Some(v(3)));
+        assert_eq!(int_div(&v(-7), &v(2)), Some(v(-4)));
+        assert_eq!(int_mod(&v(-7), &v(2)), Some(v(1)));
+        assert_eq!(int_mod(&v(7), &v(-2)), Some(v(-1)));
+        assert_eq!(int_div(&v(1), &v(0)), None);
+        assert_eq!(int_mod(&v(1), &v(0)), None);
+    }
+
+    /// `**` collapses and guards (`INST_EXPON`).
+    #[test]
+    fn pow_rules() {
+        let v = |n: i64| I128::from_i64(n);
+        assert_eq!(int_pow(&v(2), 10), Some(v(1024)));
+        assert_eq!(int_pow(&v(5), 0), Some(v(1)));
+        assert_eq!(int_pow(&v(5), 1), Some(v(5)));
+        assert_eq!(int_pow(&v(0), -1), None, "zero by negative power");
+        assert_eq!(int_pow(&v(0), 3), Some(v(0)));
+        assert_eq!(int_pow(&v(1), i64::MAX), Some(v(1)));
+        assert_eq!(int_pow(&v(-1), 5), Some(v(-1)));
+        assert_eq!(int_pow(&v(-1), 6), Some(v(1)));
+        assert_eq!(int_pow(&v(7), -3), Some(v(0)), "integer power rounds to 0");
+        assert_eq!(int_pow(&v(2), MAX_EXPONENT + 1), None, "exponent too large");
+    }
+
+    /// Shift sign-collapse past the operand width.
+    #[test]
+    fn shr_collapse() {
+        let v = |n: i64| I128::from_i64(n);
+        assert_eq!(int_shr(&v(-8), 1), Some(v(-4)));
+        assert_eq!(int_shr(&v(-8), 1000), Some(v(-1)));
+        assert_eq!(int_shr(&v(8), 1000), Some(v(0)));
+        assert_eq!(int_shr(&v(8), -1), None, "negative count is an error");
+    }
+}

--- a/rust/tcl-syntax/src/value.rs
+++ b/rust/tcl-syntax/src/value.rs
@@ -361,11 +361,9 @@ mod tests {
                 .map_err(|_| ValueError::NotDouble(v.to_string()))
         }
         fn as_bool(&mut self, v: &Rc<str>) -> Result<bool, ValueError> {
-            match v.as_ref() {
-                "1" | "true" | "yes" | "on" => Ok(true),
-                "0" | "false" | "no" | "off" => Ok(false),
-                _ => Err(ValueError::NotBoolean(v.to_string())),
-            }
+            // The boolean-context acceptor (words by prefix, else any
+            // number vs zero) — the mock must honour the real contract.
+            crate::boolean::truthiness(v).ok_or_else(|| ValueError::NotBoolean(v.to_string()))
         }
         fn list_elements(&mut self, v: &Rc<str>) -> Result<Vec<Rc<str>>, ValueError> {
             Ok(v.split_whitespace().map(Rc::from).collect())

--- a/rust/tcl-vm-wasm/Cargo.lock
+++ b/rust/tcl-vm-wasm/Cargo.lock
@@ -214,6 +214,9 @@ name = "tcl-compiler"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "regex",
  "rustc-hash",
  "tcl-bytecode",
@@ -289,6 +292,9 @@ name = "tcl-syntax"
 version = "0.1.0"
 dependencies = [
  "bitflags",
+ "num-bigint",
+ "num-integer",
+ "num-traits",
  "tcl-dialect",
  "tcl-lexer",
 ]

--- a/rust/tcl-vm/Cargo.toml
+++ b/rust/tcl-vm/Cargo.toml
@@ -43,7 +43,7 @@ name = "tcl_vm"
 [dependencies]
 tcl-bytecode = { path = "../tcl-bytecode" }
 tcl-dialect = { path = "../tcl-dialect" }
-tcl-syntax = { path = "../tcl-syntax" }
+tcl-syntax = { path = "../tcl-syntax", features = ["num-bigint"] }
 tcl-runtime-api = { path = "../tcl-runtime-api" }
 tcl-cmd-core = { path = "../tcl-cmd-core" }
 tcl-platform = { path = "../tcl-platform" }
@@ -52,7 +52,9 @@ tcl-regex = { path = "../tcl-regex", features = ["cmd-core"] }
 # Arbitrary-precision integers for the `expr` tower (RUST_ISSUE_011): the VM is
 # pure Rust (no libtommath), so `num-bigint` is its bignum backend once a result
 # outgrows the `i128` fast path. `num-integer`/`num-traits` supply floor
-# div/mod, `pow`, and the primitive narrowing.
+# div/mod, `pow`, and the primitive narrowing. The `tcl-syntax` `num-bigint`
+# feature above supplies the shared tower's `BigIntOps` adapter for this same
+# `BigInt`, so the operator semantics come from `tcl_syntax::number_tower`.
 num-bigint = "0.4"
 num-integer = "0.1"
 num-traits = "0.2"

--- a/rust/tcl-vm/src/cmd_dict.rs
+++ b/rust/tcl-vm/src/cmd_dict.rs
@@ -307,28 +307,15 @@ fn dict_op(vm: &mut Vm, sub: &str, rest: &[Value]) -> Completion<Value> {
             let [varname, key, amt @ ..] = rest else {
                 return err("wrong # args: should be \"dict incr dictVarName key ?increment?\"");
             };
-            // Read the increment and the stored value over the `i128` bignum
-            // stand-in (as `incr`/`expr` do), so a sum past `i64` promotes rather
-            // than silently wrapping (RUST_ISSUE_095).
-            let inc: i128 = match amt.first() {
-                Some(v) => match v.as_i128() {
-                    Some(n) => n,
-                    None => return err(format!("expected integer but got \"{}\"", v.to_str())),
-                },
-                None => 1,
-            };
+            // The same tower addition `incr` uses (`value_ops::int_add`): a sum
+            // past `i64` promotes to `i128` and past that to an
+            // arbitrary-precision bignum, matching tclsh (RUST_ISSUE_095 —
+            // `dict incr` at `i64::MAX` yields `9223372036854775808`, never an
+            // overflow error).
+            let one = Value::int(1);
+            let inc = amt.first().unwrap_or(&one);
             dict_update(vm, varname, key, |old| {
-                let base = match old {
-                    Some(v) => match v.as_i128() {
-                        Some(n) => n,
-                        None => return Err(format!("expected integer but got \"{}\"", v.to_str())),
-                    },
-                    None => 0,
-                };
-                let sum = base
-                    .checked_add(inc)
-                    .ok_or_else(|| "integer value too large to represent".to_string())?;
-                Ok(crate::expr::int_value(sum))
+                crate::value_ops::int_add(old, inc).map_err(|e| e.message())
             })
         }
         "append" => {

--- a/rust/tcl-vm/src/cmd_math.rs
+++ b/rust/tcl-vm/src/cmd_math.rs
@@ -22,6 +22,7 @@
 // `entier`/… follow Tcl's expr numeric conversions, not lossless casts).
 #![allow(clippy::cast_precision_loss, clippy::cast_possible_truncation)]
 
+use num_traits::{FromPrimitive, Signed, ToPrimitive};
 use tcl_runtime_api::Completion;
 use tcl_syntax::number::{self, Number};
 
@@ -69,23 +70,49 @@ fn num_or_nan(v: &Value) -> Result<f64, String> {
     match number::parse_whole(v.to_str().trim()) {
         Some(Number::Nan { .. }) => Ok(f64::NAN),
         // A bignum coerces to its nearest double (overflowing to ±Inf past the
-        // double range), matching C's `Tcl_GetDoubleFromObj`.
-        Some(Number::Big {
-            negative,
-            radix,
-            digits,
-        }) => {
-            let base = radix as u32;
-            let mut acc = 0.0f64;
-            for c in digits.chars() {
-                if let Some(d) = c.to_digit(base) {
-                    acc = acc * f64::from(base) + f64::from(d);
-                }
-            }
-            Ok(if negative { -acc } else { acc })
+        // double range), matching C's `Tcl_GetDoubleFromObj` — the same
+        // `TclBignumToDouble` rounding the expr tower uses.
+        Some(Number::Big { .. }) => {
+            Ok(crate::expr::value_as_bigint(v).map_or(f64::NAN, |b| crate::expr::big_to_f64(&b)))
         }
         _ => Err(format!("expected number but got \"{}\"", v.to_str())),
     }
+}
+
+/// Coerce the argument of an integer-producing conversion (`int`/`wide`/
+/// `entier`/`round`) to a *finite* double, with C's special-value errors:
+/// NaN — spelled or typed — is "floating point value is Not a Number" and
+/// ±Inf is "integer value too large to represent" (tclsh 8.6/9.0); a
+/// non-number keeps the generic expected-number message. Callers handle
+/// integer arguments first, so a bignum never reaches here.
+fn finite_num_arg(v: &Value) -> Result<f64, String> {
+    let f = num_or_nan(v)?;
+    if f.is_nan() {
+        return Err("floating point value is Not a Number".to_string());
+    }
+    if f.is_infinite() {
+        return Err("integer value too large to represent".to_string());
+    }
+    Ok(f)
+}
+
+/// A finite double truncated toward zero, as an exact integer — `from_f64` on
+/// a finite integral double is lossless, so `int(1e300)`-style conversions
+/// see the full 10^300-scale value C does (the `None` fallback is unreachable
+/// for the finite values [`finite_num_arg`] admits).
+fn exact_trunc(f: f64) -> num_bigint::BigInt {
+    num_bigint::BigInt::from_f64(f.trunc()).unwrap_or_default()
+}
+
+/// Fold an exact integer into the signed 64-bit window (modulo 2^64, bit-cast
+/// to `i64`) — what `int()`/`wide()` do to an out-of-range value. The
+/// integer-*string* case lives in `Value::as_wide`; this is the same fold for
+/// values arriving as a bignum (a truncated double).
+fn wide_window(b: &num_bigint::BigInt) -> i64 {
+    // num-bigint's `&` is two's-complement, so the mask keeps the low 64 bits
+    // with the wrap C computes (`-1 & mask` is 2^64-1, folding back to `-1`).
+    let low = b & &num_bigint::BigInt::from(u64::MAX);
+    low.to_u64().map_or(0, u64::cast_signed)
 }
 
 /// The message and `errorCode` C raises (`tclExecute.c`, errno `EDOM`) when a
@@ -228,6 +255,11 @@ fn m_abs(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     if let Some(b) = x.as_i128() {
         return ok(crate::expr::int_value(b.saturating_abs()));
     }
+    // An integer past `i128` stays exact too: tclsh's `abs(-(2**150))` is the
+    // full 2^150, never a rounded double.
+    if let Some(b) = crate::expr::value_as_bigint(x) {
+        return ok(crate::expr::big_value(&b.abs()));
+    }
     match num_arg(x) {
         Ok(f) => ok(Value::double(f.abs())),
         Err(m) => err(m),
@@ -235,40 +267,32 @@ fn m_abs(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 }
 
 fn m_int(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
-    let x = match one(args, "int") {
-        Ok(v) => v,
-        Err(c) => return c,
-    };
-    // An integer operand is returned exactly — never round-tripped through `f64`,
-    // which would lose precision above 2^53 (`int(9007199254740993)` must stay
-    // `9007199254740993`, not become `…992`). A bignum-magnitude integer within
-    // the VM's `i128` stand-in is likewise preserved. Only a non-integer goes
-    // through the float path, where `int()` truncates toward zero
-    // (RUST_ISSUE_096, matching the `abs`/`round`/`wide` siblings).
-    if let Ok(n) = x.as_int() {
-        return ok(crate::expr::int_value(i128::from(n)));
-    }
-    if let Some(b) = x.as_i128() {
-        return ok(crate::expr::int_value(b));
-    }
-    match num_arg(x) {
-        Ok(f) => ok(Value::int(f.trunc() as i64)),
-        Err(m) => err(m),
-    }
+    int_window(args, "int")
 }
 
 fn m_wide(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
-    // `wide()` truncates to a 64-bit integer — the same width as our `int`.
-    let x = match one(args, "wide") {
+    int_window(args, "wide")
+}
+
+/// `int(x)` / `wide(x)` — one conversion since 8.6 (`int` is no longer the
+/// narrower "long"): an integer of any magnitude is taken modulo 2^64,
+/// two's-complement folded (`int(2**64 + 1)` is `1`, `int(-(2**64 + 1))` is
+/// `-1`); a double truncates toward zero first, then wraps the same way
+/// (`int(1e300)` is `0` — 10^300 divides by 2^64). The integer path is exact —
+/// never round-tripped through `f64`, which would lose precision above 2^53
+/// (`int(9007199254740993)` must stay `…993`, `RUST_ISSUE_096`).
+fn int_window(args: &[Value], name: &str) -> Completion<Value> {
+    let x = match one(args, name) {
         Ok(v) => v,
         Err(c) => return c,
     };
+    // `as_wide` is exactly this window for integer inputs of any size.
     if let Ok(n) = x.as_wide() {
         return ok(Value::int(n));
     }
-    match x.as_double() {
-        Ok(f) => ok(Value::int(f.trunc() as i64)),
-        Err(e) => err(e.message),
+    match finite_num_arg(x) {
+        Ok(f) => ok(Value::int(wide_window(&exact_trunc(f)))),
+        Err(m) => err(m),
     }
 }
 
@@ -278,8 +302,26 @@ fn m_double(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         Err(c) => return c,
     };
     match x.as_double() {
+        // A typed NaN is not a usable number here, same as the spelled one
+        // below (tclsh: "floating point value is Not a Number").
+        Ok(f) if f.is_nan() => err("floating point value is Not a Number"),
         Ok(f) => ok(Value::double(f)),
-        Err(e) => err(e.message),
+        Err(e) => {
+            // `as_double` declines integers past its range and NaN spellings;
+            // both are still numbers to `double()`: a bignum converts with
+            // C's `TclBignumToDouble` rounding (`double(2**200)` is
+            // `1.6069380442589903e+60`), NaN is the domain-style error.
+            if let Some(b) = crate::expr::value_as_bigint(x) {
+                return ok(Value::double(crate::expr::big_to_f64(&b)));
+            }
+            if matches!(
+                number::parse_whole(x.to_str().trim()),
+                Some(Number::Nan { .. })
+            ) {
+                return err("floating point value is Not a Number");
+            }
+            err(e.message)
+        }
     }
 }
 
@@ -288,11 +330,20 @@ fn m_round(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         Ok(v) => v,
         Err(c) => return c,
     };
+    // Integers of any magnitude pass through exactly (tclsh: `round(2**200)`
+    // is 2^200 itself).
     if let Ok(n) = x.as_int() {
         return ok(Value::int(n));
     }
-    match num_arg(x) {
-        Ok(f) => ok(Value::int(f.round() as i64)),
+    if let Some(b) = crate::expr::value_as_bigint(x) {
+        return ok(crate::expr::big_value(&b));
+    }
+    // Round half away from zero, then keep the result *exact*: tclsh's
+    // `round(1e300)` is the full 309-digit integer, not a saturated wide.
+    match finite_num_arg(x) {
+        Ok(f) => ok(crate::expr::big_value(
+            &num_bigint::BigInt::from_f64(f.round()).unwrap_or_default(),
+        )),
         Err(m) => err(m),
     }
 }
@@ -382,9 +433,10 @@ fn m_pow(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     }
 }
 
-/// `entier(x)` — the integer part of `x` (truncated toward zero). Like `int` but
-/// without `int`'s word-size wrap; the VM's `i64` is its bound on the bignum C
-/// would return.
+/// `entier(x)` — the exact integer value of `x`, truncated toward zero and
+/// **unbounded** (TIP 237): an integer of any magnitude passes through; a
+/// double becomes the full exact integer (`entier(1e300)` is all 309 digits),
+/// with no 64-bit window — that wrap is `int`/`wide`'s ([`int_window`]).
 fn m_entier(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let x = match one(args, "entier") {
         Ok(v) => v,
@@ -393,8 +445,11 @@ fn m_entier(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     if let Ok(n) = x.as_int() {
         return ok(Value::int(n));
     }
-    match num_arg(x) {
-        Ok(f) => ok(Value::int(f.trunc() as i64)),
+    if let Some(b) = crate::expr::value_as_bigint(x) {
+        return ok(crate::expr::big_value(&b));
+    }
+    match finite_num_arg(x) {
+        Ok(f) => ok(crate::expr::big_value(&exact_trunc(f))),
         Err(m) => err(m),
     }
 }

--- a/rust/tcl-vm/src/cmd_math.rs
+++ b/rust/tcl-vm/src/cmd_math.rs
@@ -39,6 +39,24 @@ fn num_arg(v: &Value) -> Result<f64, String> {
         .map_err(|_| format!("expected number but got \"{}\"", v.to_str()))
 }
 
+/// A double argument for the libm-backed functions: `as_double`, with an
+/// integer beyond the double-parse range coercing through the tower's
+/// correctly-rounded bignum→double conversion — `sqrt(2**200)` computes
+/// (C's `Tcl_GetDoubleFromObj` view), instead of rejecting the operand the
+/// operators already accept.
+fn libm_arg(v: &Value) -> Result<f64, String> {
+    if let Ok(d) = v.as_double() {
+        return Ok(d);
+    }
+    if let Some(b) = crate::expr::value_as_bigint(v) {
+        return Ok(crate::expr::big_to_f64(&b));
+    }
+    Err(format!(
+        "expected floating-point number but got \"{}\"",
+        v.to_str()
+    ))
+}
+
 /// Coerce `v` to a double for the classification predicates (`isnan` /
 /// `isunordered` / …), which deliberately accept a literal `NaN` — inspecting
 /// NaN/Inf is their purpose — even though a bare `NaN` is a domain error as an
@@ -252,15 +270,21 @@ fn m_abs(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     if let Ok(n) = x.as_int() {
         return ok(crate::expr::int_value(i128::from(n).abs()));
     }
-    if let Some(b) = x.as_i128() {
-        return ok(crate::expr::int_value(b.saturating_abs()));
+    if let Some(b) = x.as_i128()
+        && b != i128::MIN
+    {
+        return ok(crate::expr::int_value(b.abs()));
     }
-    // An integer past `i128` stays exact too: tclsh's `abs(-(2**150))` is the
-    // full 2^150, never a rounded double.
+    // An integer past `i128` (or exactly `-2^127`, whose magnitude has no
+    // `i128`) stays exact: tclsh's `abs(-(2**150))` is the full 2^150,
+    // never a rounded double.
     if let Some(b) = crate::expr::value_as_bigint(x) {
         return ok(crate::expr::big_value(&b.abs()));
     }
-    match num_arg(x) {
+    match num_or_nan(x) {
+        // C's domain error — `abs(nan)` is not a number (±Inf is fine:
+        // `abs(-inf)` is `inf`).
+        Ok(f) if f.is_nan() => err("floating point value is Not a Number".to_string()),
         Ok(f) => ok(Value::double(f.abs())),
         Err(m) => err(m),
     }
@@ -353,9 +377,9 @@ fn dbl_fn(args: &[Value], name: &str, f: impl Fn(f64) -> f64) -> Completion<Valu
         Ok(v) => v,
         Err(c) => return c,
     };
-    match x.as_double() {
+    match libm_arg(x) {
         Ok(d) => ok(Value::double(f(d))),
-        Err(e) => err(e.message),
+        Err(m) => err(m),
     }
 }
 
@@ -367,7 +391,7 @@ fn dom_fn(args: &[Value], name: &str, f: impl Fn(f64) -> f64) -> Completion<Valu
         Ok(v) => v,
         Err(c) => return c,
     };
-    match x.as_double() {
+    match libm_arg(x) {
         Ok(d) => {
             let r = f(d);
             if r.is_nan() && !d.is_nan() {
@@ -375,7 +399,7 @@ fn dom_fn(args: &[Value], name: &str, f: impl Fn(f64) -> f64) -> Completion<Valu
             }
             ok(Value::double(r))
         }
-        Err(e) => err(e.message),
+        Err(m) => err(m),
     }
 }
 
@@ -390,7 +414,7 @@ fn dom_fn2(args: &[Value], name: &str, f: impl Fn(f64, f64) -> f64) -> Completio
         };
         return err(format!("{which} for math function \"{name}\""));
     };
-    match (lhs.as_double(), rhs.as_double()) {
+    match (libm_arg(lhs), libm_arg(rhs)) {
         (Ok(x), Ok(y)) => {
             let r = f(x, y);
             if r.is_nan() && !x.is_nan() && !y.is_nan() {
@@ -398,7 +422,7 @@ fn dom_fn2(args: &[Value], name: &str, f: impl Fn(f64, f64) -> f64) -> Completio
             }
             ok(Value::double(r))
         }
-        (Err(e), _) | (_, Err(e)) => err(e.message),
+        (Err(m), _) | (_, Err(m)) => err(m),
     }
 }
 
@@ -421,7 +445,7 @@ fn m_pow(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
         };
         return err(format!("{which} for math function \"pow\""));
     };
-    match (b.as_double(), e.as_double()) {
+    match (libm_arg(b), libm_arg(e)) {
         (Ok(bb), Ok(ee)) => {
             let r = bb.powf(ee);
             if r.is_nan() && !bb.is_nan() && !ee.is_nan() {
@@ -429,7 +453,7 @@ fn m_pow(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
             }
             ok(Value::double(r))
         }
-        (Err(er), _) | (_, Err(er)) => err(er.message),
+        (Err(m), _) | (_, Err(m)) => err(m),
     }
 }
 
@@ -464,6 +488,14 @@ fn m_isqrt(_vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     };
     let n = if let Ok(n) = x.as_int() {
         n
+    } else if let Some(b) = crate::expr::value_as_bigint(x) {
+        // Beyond-wide integers take the exact arbitrary-precision floor
+        // root — tclsh's `isqrt(2**200)` is the full 2^100, never a
+        // rounded double.
+        if num_traits::Signed::is_negative(&b) {
+            return err_with_code("square root of negative argument", DOMAIN_CODE);
+        }
+        return ok(crate::expr::big_value(&num_integer::Roots::sqrt(&b)));
     } else {
         match num_arg(x) {
             Ok(f) => f.trunc() as i64,
@@ -516,12 +548,12 @@ fn min_max(args: &[Value], name: &str, want_max: bool) -> Completion<Value> {
     // not `2.0`. A non-numeric argument reports the integer-flavoured
     // "expected number but got …".
     let mut best = first;
-    let mut best_d = match num_arg(first) {
+    let mut best_d = match num_arg(first).or_else(|m| libm_arg(first).map_err(|_| m)) {
         Ok(d) => d,
         Err(m) => return err(m),
     };
     for a in rest {
-        let d = match num_arg(a) {
+        let d = match num_arg(a).or_else(|m| libm_arg(a).map_err(|_| m)) {
             Ok(d) => d,
             Err(m) => return err(m),
         };

--- a/rust/tcl-vm/src/command.rs
+++ b/rust/tcl-vm/src/command.rs
@@ -1022,8 +1022,9 @@ fn cmd_puts(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
 /// variable starts at 0). The numeric-tower addition goes through the shared
 /// [`ValueOps::int_add`](tcl_syntax::value::ValueOps::int_add) seam (the same one
 /// the bytecode `incr` opcodes and the WASM runtime use), so the number-model
-/// behaviour is identical everywhere: the VM has no bignum, so an overflowing
-/// `incr` reports `integer value too large to represent` instead of wrapping.
+/// behaviour is identical everywhere: an overflowing `incr` promotes through
+/// the integer tower (`i128`, then an arbitrary-precision bignum), matching
+/// tclsh, instead of wrapping or erroring.
 fn cmd_incr(vm: &mut Vm, args: &[Value]) -> Completion<Value> {
     let (name, amount) = match args {
         [name] => (name.to_str(), Value::int(1)),

--- a/rust/tcl-vm/src/exec.rs
+++ b/rust/tcl-vm/src/exec.rs
@@ -2473,20 +2473,13 @@ impl Vm {
                 let name = lvt_name(imm_at(instr, 1));
                 let key = pop(f).to_str().to_string();
                 let cur = self.get_var(&name).unwrap_or_else(Value::empty);
+                let inc = Value::int(amount);
                 let updated = dict_update_single(&cur, &key, |old| {
-                    // Add over the `i128` bignum stand-in (as `incr`/`expr` do) so
-                    // a sum past `i64` promotes rather than silently wrapping
-                    // (`RUST_ISSUE_095`).
-                    let base = match old {
-                        Some(v) => v.as_i128().ok_or_else(|| {
-                            err(format!("expected integer but got \"{}\"", v.to_str()))
-                        })?,
-                        None => 0,
-                    };
-                    let sum = base
-                        .checked_add(i128::from(amount))
-                        .ok_or_else(|| err("integer value too large to represent"))?;
-                    Ok(crate::expr::int_value(sum))
+                    // The same tower addition `incr` uses (`value_ops::int_add`):
+                    // a sum past `i64` promotes to `i128` and past that to an
+                    // arbitrary-precision bignum rather than erroring, matching
+                    // tclsh (`RUST_ISSUE_095`).
+                    crate::value_ops::int_add(old, &inc).map_err(|e| err(e.message()))
                 });
                 match updated {
                     Ok(result) => {
@@ -3386,9 +3379,10 @@ impl Vm {
     /// The current cell is read exactly as before (scalar or `arr(key)`), but the
     /// arithmetic goes through the shared [`tcl_syntax::value::ValueOps::int_add`]
     /// seam — the same one `incr`'s command core uses — so the number-model
-    /// behaviour is identical across the compiled and dispatched paths. The VM
-    /// has no bignum, so an overflowing `incr` reports `integer value too large to
-    /// represent` rather than silently wrapping (the old `wrapping_add` bug).
+    /// behaviour is identical across the compiled and dispatched paths: a sum
+    /// past `i64` promotes through the integer tower (`i128`, then an
+    /// arbitrary-precision bignum), matching tclsh, rather than wrapping (the
+    /// old `wrapping_add` bug) or erroring.
     fn incr_var(
         &mut self,
         f: &mut Frame,

--- a/rust/tcl-vm/src/expr.rs
+++ b/rust/tcl-vm/src/expr.rs
@@ -34,38 +34,86 @@ use num_traits::{FromPrimitive, Signed, ToPrimitive, Zero};
 use tcl_runtime_api::Code;
 use tcl_syntax::expr::{BinOp, ExprOps, NumericCompare, UnaryOp};
 use tcl_syntax::number::{self, Number};
+use tcl_syntax::number_tower;
 
 use crate::error::TclError;
 use crate::interp::Vm;
 use crate::value::Value;
 
 /// A coerced numeric operand. `Big` carries an out-of-`i64` integer that still
-/// fits `i128` — the fast integer tier; an operand or result beyond `i128`
-/// promotes to the arbitrary-precision [`BigInt`] path (`RUST_ISSUE_011`) rather
-/// than wrapping.
-#[derive(Clone, Copy)]
+/// fits `i128` — the fast integer tier; `Huge` is the arbitrary-precision tier
+/// beyond it (`RUST_ISSUE_011`), so no integer magnitude wraps, errors, or
+/// degrades to a lossy `double`.
 enum Num {
     Int(i64),
     Big(i128),
+    Huge(BigInt),
     Dbl(f64),
 }
 
-fn num_f(n: Num) -> f64 {
+fn num_f(n: &Num) -> f64 {
     match n {
-        Num::Int(i) => i as f64,
-        Num::Big(i) => i as f64,
-        Num::Dbl(f) => f,
+        Num::Int(i) => *i as f64,
+        Num::Big(i) => *i as f64,
+        // Float contagion converts a bignum operand rather than refusing it —
+        // C's `Tcl_GetNumberFromObj` + `TclBignumToDouble` rounding.
+        Num::Huge(b) => big_to_f64(b),
+        Num::Dbl(f) => *f,
     }
 }
 
-/// The integer (`i128`) view of a non-float operand, for the integer arithmetic
-/// path. `None` for a float (which routes to `dbl_arith`).
-fn num_i128(n: Num) -> Option<i128> {
+/// The integer (`i128`) view of a fast-tier operand, for the integer arithmetic
+/// path. `None` for a float (which routes to `dbl_arith`) and for an integer
+/// past `i128` (which routes to `big_arith`).
+fn num_i128(n: &Num) -> Option<i128> {
     match n {
-        Num::Int(i) => Some(i128::from(i)),
-        Num::Big(i) => Some(i),
+        Num::Int(i) => Some(i128::from(*i)),
+        Num::Big(i) => Some(*i),
+        Num::Huge(_) | Num::Dbl(_) => None,
+    }
+}
+
+/// The exact bignum view of an integer operand (`None` for a float), for the
+/// arbitrary-precision path when the `i128` fast tier can't hold both operands.
+fn num_as_bigint(n: &Num) -> Option<BigInt> {
+    match n {
+        Num::Int(i) => Some(BigInt::from(*i)),
+        Num::Big(i) => Some(BigInt::from(*i)),
+        Num::Huge(b) => Some(b.clone()),
         Num::Dbl(_) => None,
     }
+}
+
+/// The nearest `f64` to an arbitrary-precision integer — C's
+/// `TclBignumToDouble`: round-to-nearest-even over the *full* value, overflowing
+/// to `±Inf` past the double range. (`num-bigint`'s `to_f64` truncates to the
+/// top 64 bits before rounding, which mis-rounds a tie whose deciding bits sit
+/// below the truncation — e.g. `2**127 + 2**74 + 1` must round up.)
+pub(crate) fn big_to_f64(b: &BigInt) -> f64 {
+    let mag = b.magnitude();
+    let bits = mag.bits();
+    let f = if bits <= 64 {
+        // Every bit is present in one word: the primitive u64→f64 cast is
+        // exactly the round-to-nearest-even C performs.
+        mag.to_u64().map_or(0.0, |m| m as f64)
+    } else if bits > 1024 {
+        // Past `DBL_MAX_EXP` no finite double exists; C returns ±HUGE_VAL.
+        f64::INFINITY
+    } else {
+        // Keep the top 64 bits. The dropped remainder matters only when the
+        // kept part sits exactly on a rounding tie (its low 11 bits are one
+        // half-ulp), where any dropped bit must break the tie upward.
+        let excess = bits - 64;
+        let mut top = (mag >> excess).to_u64().unwrap_or(u64::MAX);
+        let dropped_nonzero = mag.trailing_zeros().is_some_and(|tz| tz < excess);
+        if top & 0x7FF == 0x400 && dropped_nonzero {
+            top += 1;
+        }
+        // `excess` ≤ 960 here, so the exponent fits `i32` and the power-of-two
+        // scale is exact.
+        (top as f64) * 2f64.powi(i32::try_from(excess).unwrap_or(i32::MAX))
+    };
+    if b.is_negative() { -f } else { f }
 }
 
 /// Wrap an `i128` arithmetic result as a value: a plain wide when it fits,
@@ -106,48 +154,40 @@ pub(crate) fn value_as_bigint(v: &Value) -> Option<BigInt> {
 
 /// Integer arithmetic in arbitrary precision — the promotion target of the
 /// `i128` fast path ([`int_arith`]) on overflow, and the direct path when an
-/// operand already exceeds `i128`. Div/mod are floor (sign of divisor), matching
-/// Tcl; bit ops use two's-complement (`num-bigint`'s semantics = Tcl's).
+/// operand already exceeds `i128`. The value semantics — floor div/mod, the
+/// `**` collapses, the shift edge rules, two's-complement bit ops — are the
+/// shared tower's ([`number_tower`]); this adopter adds the error surfaces
+/// (message text) and the count/exponent narrowing.
 fn big_arith(op: BinOp, x: &BigInt, y: &BigInt) -> Result<Value, TclError> {
     use BinOp::{Add, BitAnd, BitOr, BitXor, Div, LShift, Mod, Mul, Pow, RShift, Sub};
     let r = match op {
         Add => x + y,
         Sub => x - y,
         Mul => x * y,
-        Div => {
-            if y.is_zero() {
-                return Err(divzero());
-            }
-            x.div_floor(y)
-        }
-        Mod => {
-            if y.is_zero() {
-                return Err(divzero());
-            }
-            x.mod_floor(y)
-        }
+        Div => number_tower::int_div(x, y).ok_or_else(divzero)?,
+        Mod => number_tower::int_mod(x, y).ok_or_else(divzero)?,
         Pow => return big_pow(x, y),
-        LShift | RShift => {
-            let Some(shift) = y.to_usize() else {
-                if y.is_negative() {
-                    return Err(TclError::new("negative shift argument"));
-                }
-                // A shift wider than any representable result: `<<` overflows to
-                // an enormous value (unrepresentable — but such a huge shift is a
-                // pathological program), `>>` collapses to the sign.
-                return Ok(big_value(
-                    &(if matches!(op, RShift) && x.is_negative() {
-                        BigInt::from(-1)
-                    } else {
-                        BigInt::zero()
-                    }),
-                ));
-            };
-            if matches!(op, LShift) {
-                x << shift
-            } else {
-                x >> shift
+        LShift => {
+            if y.is_negative() {
+                return Err(TclError::new("negative shift argument"));
             }
+            // C's left-shift count must fit an `int` (`mp_mul_2d`): past
+            // `INT_MAX` it raises the overflow error rather than attempt an
+            // astronomic result (tclsh: `2 << 2**32` errors).
+            let count = y
+                .to_u32()
+                .filter(|&c| i32::try_from(c).is_ok())
+                .ok_or_else(|| TclError::new("integer value too large to represent"))?;
+            number_tower::BigIntOps::shl(x, count)
+        }
+        RShift => {
+            // A count past `i64` collapses exactly like any count past the
+            // operand width, so fold it to a same-sign stand-in for the tower.
+            let count = y
+                .to_i64()
+                .unwrap_or(if y.is_negative() { -1 } else { i64::MAX });
+            number_tower::int_shr(x, count)
+                .ok_or_else(|| TclError::new("negative shift argument"))?
         }
         BitAnd => x & y,
         BitOr => x | y,
@@ -157,35 +197,26 @@ fn big_arith(op: BinOp, x: &BigInt, y: &BigInt) -> Result<Value, TclError> {
     Ok(big_value(&r))
 }
 
-/// `x ** y` in arbitrary precision. A negative exponent on an integer base is `0`
-/// except for `±1` (C's `TclExecute` integer-power rule); a huge exponent that
-/// can't fit `u32` is only reachable with `|base| <= 1` (else the result is
-/// astronomically large), so those collapse to the base-driven value.
+/// `x ** y` in arbitrary precision, via the tower's
+/// [`int_pow`](number_tower::int_pow). An exponent past `i64` folds to an
+/// equal-sign, equal-parity stand-in: beyond [`number_tower::MAX_EXPONENT`]
+/// only the `0`/`±1` collapses remain computable, and those depend on nothing
+/// but the exponent's sign and parity (tclsh: `2 ** 10**20` is "exponent too
+/// large" while `(-1) ** 10**20` is `1`).
 fn big_pow(x: &BigInt, y: &BigInt) -> Result<Value, TclError> {
-    if y.is_negative() {
-        let r = if x == &BigInt::from(1) {
-            1
-        } else if x == &BigInt::from(-1) {
-            if y.is_even() { 1 } else { -1 }
-        } else if x.is_zero() {
-            return Err(TclError::new("exponentiation of zero by negative power"));
-        } else {
-            0
-        };
-        return Ok(Value::int(r));
+    let exponent = y.to_i64().unwrap_or(match (y.is_negative(), y.is_even()) {
+        (true, true) => -2,
+        (true, false) => -1,
+        (false, true) => number_tower::MAX_EXPONENT + 1,
+        (false, false) => number_tower::MAX_EXPONENT + 2,
+    });
+    match number_tower::int_pow(x, exponent) {
+        Some(r) => Ok(big_value(&r)),
+        // `int_pow` declines exactly two cases: a zero base with a negative
+        // exponent (the domain error) and an exponent past the C limit.
+        None if x.is_zero() => Err(TclError::new("exponentiation of zero by negative power")),
+        None => Err(TclError::new("exponent too large")),
     }
-    if let Some(exp) = y.to_u32() {
-        return Ok(big_value(&x.pow(exp)));
-    }
-    // Exponent beyond `u32`: only `|x| <= 1` yields a representable result.
-    let r = if x == &BigInt::from(1) || x.is_zero() {
-        x.clone()
-    } else if x == &BigInt::from(-1) {
-        BigInt::from(if y.is_even() { 1 } else { -1 })
-    } else {
-        return Err(TclError::new("exponent too large"));
-    };
-    Ok(big_value(&r))
 }
 
 fn to_num(v: &Value) -> Result<Num, TclError> {
@@ -195,13 +226,18 @@ fn to_num(v: &Value) -> Result<Num, TclError> {
     if let Some(b) = v.as_i128() {
         return Ok(Num::Big(b));
     }
-    match v.as_double() {
-        Ok(f) => Ok(Num::Dbl(f)),
-        Err(_) => Err(TclError::new(format!(
-            "can't use non-numeric string \"{}\" as operand of arithmetic",
-            v.to_str()
-        ))),
+    if let Ok(f) = v.as_double() {
+        return Ok(Num::Dbl(f));
     }
+    // `as_double` declines an integer past `i128` (keeping the tower exact); it
+    // is still a numeric operand — the arbitrary-precision tier.
+    if let Some(b) = value_as_bigint(v) {
+        return Ok(Num::Huge(b));
+    }
+    Err(TclError::new(format!(
+        "can't use non-numeric string \"{}\" as operand of arithmetic",
+        v.to_str()
+    )))
 }
 
 /// Regenerate the canonical numeric string rep of an `expr` result
@@ -249,6 +285,11 @@ fn to_num_operand(v: &Value, side: &str, op: BinOp) -> Result<Num, TclError> {
     if let Ok(f) = v.as_double() {
         return Ok(Num::Dbl(f));
     }
+    // An integer past `i128` is a numeric operand (the arbitrary-precision
+    // tier), not an operand-type error.
+    if let Some(b) = value_as_bigint(v) {
+        return Ok(Num::Huge(b));
+    }
     // `nan` (and `±NaN`) is a valid floating-point *value* that simply cannot be
     // an arithmetic operand — C words that differently from a non-number string.
     let s = v.to_str();
@@ -286,7 +327,11 @@ fn unary_operand_err(v: &Value, op: &str) -> TclError {
     TclError::new(format!("cannot use {desc} \"{s}\" as operand of \"{op}\""))
 }
 
-/// Floored integer division (Tcl `/`: rounds toward negative infinity).
+/// Floored integer division (Tcl `/`: rounds toward negative infinity) — the
+/// `i128` fast-tier mirror of `tcl_syntax::number_tower::int_div`. The orphan
+/// rule forbids implementing the tower's `BigIntOps` for a primitive in this
+/// crate, so the fast tier hand-rolls the same floor rule; the bignum tier
+/// ([`big_arith`]) calls the tower directly.
 fn fdiv(x: i128, y: i128) -> i128 {
     let q = x.wrapping_div(y);
     let r = x.wrapping_rem(y);
@@ -297,7 +342,9 @@ fn fdiv(x: i128, y: i128) -> i128 {
     }
 }
 
-/// Floored integer modulo (Tcl `%`: result takes the sign of the divisor).
+/// Floored integer modulo (Tcl `%`: result takes the sign of the divisor) —
+/// the `i128` fast-tier mirror of `tcl_syntax::number_tower::int_mod`, kept
+/// hand-rolled for the same orphan-rule reason as [`fdiv`].
 fn fmod_i(x: i128, y: i128) -> i128 {
     let r = x.wrapping_rem(y);
     if r != 0 && ((r < 0) != (y < 0)) {
@@ -426,26 +473,29 @@ pub fn arith(op: BinOp, a: &Value, b: &Value) -> Result<Value, TclError> {
     let x = to_num_operand(a, "left", op)?;
     let y = to_num_operand(b, "right", op)?;
     // Fast integer path: both operands fit `i128` (promotes to bignum on overflow).
-    if let (Some(xi), Some(yi)) = (num_i128(x), num_i128(y)) {
+    if let (Some(xi), Some(yi)) = (num_i128(&x), num_i128(&y)) {
         return int_arith(op, xi, yi);
     }
     // Not both `i128`-fit. When *both* are integers (an operand already past
     // `i128`), stay exact via the arbitrary-precision path (`RUST_ISSUE_011`).
-    if let (Some(xb), Some(yb)) = (value_as_bigint(a), value_as_bigint(b)) {
+    if let (Some(xb), Some(yb)) = (num_as_bigint(&x), num_as_bigint(&y)) {
         return big_arith(op, &xb, &yb);
     }
-    // At least one operand is a genuine float (or non-number).
+    // At least one operand is a genuine float.
     if is_int_only(op) {
         // An integer-only operator with a float operand: that operand is the
         // error (a huge-integer operand took the bignum path above). Name the
         // offending side (left wins if both are floats, matching C's order).
-        if value_as_bigint(a).is_none() {
+        if matches!(x, Num::Dbl(_)) {
             Err(float_operand_err(a, "left", op))
         } else {
             Err(float_operand_err(b, "right", op))
         }
     } else {
-        dbl_arith(op, num_f(x), num_f(y))
+        // Float contagion: the integer operand — bignum included — converts to
+        // its nearest double (`num_f`), then the operation is pure `f64`
+        // (tclsh: `2**200 + 1.5` is `1.6069380442589903e+60`, not an error).
+        dbl_arith(op, num_f(&x), num_f(&y))
     }
 }
 
@@ -578,26 +628,24 @@ pub fn compare(op: BinOp, a: &Value, b: &Value) -> Result<bool, TclError> {
 pub fn unary(op: UnaryOp, v: &Value) -> Result<Value, TclError> {
     use UnaryOp::{BitNot, Neg, Not, Pos, WordNot};
     match op {
-        // `to_num` promotes an out-of-wide literal to `Big`, so `-2^63` (and the
-        // rest of the i128 range) negates correctly: `int_value` narrows
-        // `-9223372036854775808` back to the most-negative wide. A non-numeric
-        // operand is the C operand-type error (`as operand of "-"`).
+        // `to_num` promotes an out-of-wide literal to `Big` (then `Huge`), so
+        // `-2^63` — and any magnitude beyond — negates exactly: `int_value` /
+        // `big_value` narrow back to a wide when the result re-fits. A
+        // non-numeric operand is the C operand-type error (`as operand of "-"`).
         Neg => match to_num(v) {
             Ok(Num::Int(n)) => Ok(Value::int(n.wrapping_neg())),
             Ok(Num::Big(b)) => Ok(int_value(b.wrapping_neg())),
-            // A huge integer (past `i128`) coerces to `Num::Dbl`; negate it
-            // exactly as a bignum, not as a lossy float (`RUST_ISSUE_011`).
-            Ok(Num::Dbl(f)) => {
-                Ok(value_as_bigint(v).map_or_else(|| Value::double(-f), |b| big_value(&-b)))
-            }
+            // An integer past `i128` negates exactly in arbitrary precision,
+            // never as a lossy float (`RUST_ISSUE_011`).
+            Ok(Num::Huge(b)) => Ok(big_value(&-b)),
+            Ok(Num::Dbl(f)) => Ok(Value::double(-f)),
             Err(_) => Err(unary_operand_err(v, "-")),
         },
         Pos => match to_num(v) {
             Ok(Num::Int(n)) => Ok(Value::int(n)),
             Ok(Num::Big(b)) => Ok(int_value(b)),
-            Ok(Num::Dbl(f)) => {
-                Ok(value_as_bigint(v).map_or_else(|| Value::double(f), |b| big_value(&b)))
-            }
+            Ok(Num::Huge(b)) => Ok(big_value(&b)),
+            Ok(Num::Dbl(f)) => Ok(Value::double(f)),
             Err(_) => Err(unary_operand_err(v, "+")),
         },
         // `~` needs an integer; a double is a "floating-point value" operand
@@ -605,11 +653,9 @@ pub fn unary(op: UnaryOp, v: &Value) -> Result<Value, TclError> {
         BitNot => match to_num(v) {
             Ok(Num::Int(n)) => Ok(Value::int(!n)),
             Ok(Num::Big(b)) => Ok(int_value(!b)),
-            // A huge integer bit-complements exactly (`~x == -x-1`); a real float
-            // is the operand error.
-            Ok(Num::Dbl(_)) => value_as_bigint(v)
-                .map_or_else(|| Err(unary_operand_err(v, "~")), |b| Ok(big_value(&!b))),
-            Err(_) => Err(unary_operand_err(v, "~")),
+            // An integer past `i128` bit-complements exactly (`~x == -x-1`).
+            Ok(Num::Huge(b)) => Ok(big_value(&!b)),
+            Ok(Num::Dbl(_)) | Err(_) => Err(unary_operand_err(v, "~")),
         },
         // `!` accepts any boolean (incl. numbers and the boolean words); a NaN or
         // non-numeric non-boolean is the operand error (not "expected boolean").
@@ -808,6 +854,23 @@ mod tests {
                 .to_string(),
             "9223372036854775808"
         );
+        // The shared-tower oracle rows (tclsh 8.6/9.0): floor div/mod at and
+        // beyond the wide boundary, the shift width-collapse, and `1 << 63`
+        // crossing into bignum.
+        assert_eq!(big(BinOp::Mod, "18446744073709551616", "7"), "2");
+        assert_eq!(
+            big(BinOp::Div, "18446744073709551616", "-3"),
+            "-6148914691236517206"
+        );
+        assert_eq!(big(BinOp::RShift, "18446744073709551616", "64"), "1");
+        assert_eq!(big(BinOp::RShift, "-18446744073709551616", "200"), "-1");
+        assert_eq!(
+            arith(BinOp::LShift, &Value::int(1), &Value::int(63))
+                .unwrap()
+                .to_str()
+                .to_string(),
+            "9223372036854775808"
+        );
         // Exact bignum comparison — an `f64` would collapse `2^100` and `2^100+1`.
         let (a, b) = (
             "1267650600228229401496703205376",
@@ -830,7 +893,214 @@ mod tests {
                 .to_string(),
             format!("-{b}")
         );
+        assert_eq!(
+            unary(UnaryOp::BitNot, &Value::string("18446744073709551616"))
+                .unwrap()
+                .to_str()
+                .to_string(),
+            "-18446744073709551617"
+        );
         assert!(arith(BinOp::Pow, &Value::int(0), &Value::int(-1)).is_err());
+    }
+
+    /// Operands already past `i128` are numeric (`Num::Huge`), not the
+    /// non-numeric-string operand error: they reach the arbitrary-precision
+    /// path in `arith`/`unary` and stay exact. All rows pinned to tclsh
+    /// 8.6.14 (`2**200` is the 61-digit 16069…376).
+    #[test]
+    fn operands_past_i128_reach_the_bignum_path() {
+        const P200: &str = "1606938044258990275541962092341162602522202993782792835301376";
+        let big = |op: BinOp, a: &str, b: &str| {
+            arith(op, &Value::string(a), &Value::string(b))
+                .unwrap()
+                .to_str()
+                .to_string()
+        };
+        // tclsh: 2**200 + 1 (the divergence that motivated the gap fix).
+        assert_eq!(
+            big(BinOp::Add, P200, "1"),
+            "1606938044258990275541962092341162602522202993782792835301377"
+        );
+        // tclsh: floor div/mod, shifts and bit ops over a beyond-i128 operand.
+        assert_eq!(big(BinOp::Mod, P200, "7"), "4");
+        assert_eq!(
+            big(BinOp::Div, P200, "-3"),
+            "-535646014752996758513987364113720867507400997927597611767126"
+        );
+        assert_eq!(big(BinOp::RShift, P200, "137"), "9223372036854775808");
+        assert_eq!(
+            big(BinOp::RShift, &format!("-{P200}"), "500"),
+            "-1",
+            "sign collapse past the width"
+        );
+        assert_eq!(big(BinOp::BitAnd, P200, "255"), "0");
+        assert_eq!(
+            big(BinOp::BitOr, P200, "1"),
+            "1606938044258990275541962092341162602522202993782792835301377"
+        );
+        // Unary over a beyond-i128 operand: exact negate / complement / pass.
+        assert_eq!(
+            unary(UnaryOp::Neg, &Value::string(P200))
+                .unwrap()
+                .to_str()
+                .to_string(),
+            format!("-{P200}")
+        );
+        assert_eq!(
+            unary(UnaryOp::BitNot, &Value::string(P200))
+                .unwrap()
+                .to_str()
+                .to_string(),
+            "-1606938044258990275541962092341162602522202993782792835301377"
+        );
+        assert_eq!(
+            unary(UnaryOp::Pos, &Value::string(P200))
+                .unwrap()
+                .to_str()
+                .to_string(),
+            P200
+        );
+        // Error surfaces on the bignum path keep C's message text.
+        let div0 = arith(BinOp::Div, &Value::string(P200), &Value::int(0)).unwrap_err();
+        assert_eq!(div0.message, "divide by zero");
+        let mod0 = arith(BinOp::Mod, &Value::string(P200), &Value::int(0)).unwrap_err();
+        assert_eq!(mod0.message, "divide by zero");
+    }
+
+    /// The `**` and shift guards of the shared tower, with C's message text:
+    /// the exponent limit is `MAX_EXPONENT` (2^28 - 1 — tclsh errors at
+    /// `2**268435456` where the old code computed a 33 MB number), a bignum
+    /// exponent keeps the `0`/`±1` collapses, and a left-shift count past
+    /// `INT_MAX` is C's overflow error rather than an astronomic attempt.
+    #[test]
+    fn pow_and_shift_guards_match_c() {
+        let errmsg = |op: BinOp, a: &Value, b: &Value| arith(op, a, b).unwrap_err().message;
+        // tclsh: expr {2**268435456} → exponent too large (268435455 is legal).
+        assert_eq!(
+            errmsg(BinOp::Pow, &Value::int(2), &Value::int(268_435_456)),
+            "exponent too large"
+        );
+        assert_eq!(
+            errmsg(BinOp::Pow, &Value::int(2), &Value::int(5_000_000_000)),
+            "exponent too large"
+        );
+        // tclsh: a beyond-i64 exponent still collapses for |base| <= 1 —
+        // parity included — and errors for any other base.
+        let huge = "99999999999999999999";
+        let pow = |a: i64, b: &str| {
+            arith(BinOp::Pow, &Value::int(a), &Value::string(b))
+                .unwrap()
+                .to_str()
+                .to_string()
+        };
+        assert_eq!(pow(1, huge), "1");
+        assert_eq!(pow(-1, huge), "-1"); // odd exponent
+        assert_eq!(pow(-1, "99999999999999999998"), "1"); // even exponent
+        assert_eq!(pow(0, huge), "0");
+        assert_eq!(
+            errmsg(BinOp::Pow, &Value::int(2), &Value::string(huge)),
+            "exponent too large"
+        );
+        assert_eq!(
+            errmsg(
+                BinOp::Pow,
+                &Value::int(0),
+                &Value::string(format!("-{huge}"))
+            ),
+            "exponentiation of zero by negative power"
+        );
+        // tclsh: expr {2 << 4294967296} → integer value too large to
+        // represent (count must fit C's int); negative counts keep their
+        // error on both tiers.
+        assert_eq!(
+            errmsg(BinOp::LShift, &Value::int(2), &Value::int(4_294_967_296)),
+            "integer value too large to represent"
+        );
+        assert_eq!(
+            errmsg(
+                BinOp::LShift,
+                &Value::int(2),
+                &Value::string("99999999999999999999")
+            ),
+            "integer value too large to represent"
+        );
+        assert_eq!(
+            errmsg(
+                BinOp::RShift,
+                &Value::string("18446744073709551616"),
+                &Value::int(-1)
+            ),
+            "negative shift argument"
+        );
+        // tclsh: a beyond-wide right-shift count collapses to the sign.
+        let big = |op: BinOp, a: &str, b: &str| {
+            arith(op, &Value::string(a), &Value::string(b))
+                .unwrap()
+                .to_str()
+                .to_string()
+        };
+        assert_eq!(big(BinOp::RShift, "2", huge), "0");
+        assert_eq!(big(BinOp::RShift, "-2", huge), "-1");
+    }
+
+    /// Float contagion over bignum operands: C converts the integer with
+    /// `TclBignumToDouble` (round-to-nearest-even over the full value) and
+    /// computes in `f64` — it does not refuse. Rows pinned to tclsh 8.6.14,
+    /// including the tie whose deciding bit sits below the top 64 (2^127 +
+    /// 2^74 + 1 must round *up*; a bare 64-bit truncation rounds it down).
+    #[test]
+    fn bignum_float_contagion_matches_c() {
+        let s = |t: &str| Value::string(t);
+        let f = |op: BinOp, a: &Value, b: &Value| arith(op, a, b).unwrap().to_str().to_string();
+        // tclsh: expr {1.5 + 18446744073709551616} — the *value* is exactly
+        // 2^64 (tclsh: entier of it is 18446744073709551616). tclsh 8.6
+        // prints it "1.844674407370955e+19", which does not round-trip (it
+        // re-parses as 2^64 - 2048); this toolchain's `format_double` is
+        // pinned to the shortest *round-tripping* form.
+        assert_eq!(
+            f(BinOp::Add, &Value::double(1.5), &s("18446744073709551616")),
+            "1.8446744073709552e+19"
+        );
+        // tclsh: expr {2**200 + 1.5} → 1.6069380442589903e+60
+        let p200 = "1606938044258990275541962092341162602522202993782792835301376";
+        assert_eq!(
+            f(BinOp::Add, &s(p200), &Value::double(1.5)),
+            "1.6069380442589903e+60"
+        );
+        // Round-to-nearest-even ties: 2^127+2^74 is exactly halfway (stays
+        // even → 2^127), 2^127+2^74+1 is just above it (rounds up).
+        assert_eq!(
+            f(
+                BinOp::Mul,
+                &s("170141183460469250621153235194464960512"),
+                &Value::double(1.0)
+            ),
+            "1.7014118346046923e+38"
+        );
+        assert_eq!(
+            f(
+                BinOp::Mul,
+                &s("170141183460469250621153235194464960513"),
+                &Value::double(1.0)
+            ),
+            "1.7014118346046927e+38"
+        );
+        // Past the double range the conversion overflows to Inf, as C's
+        // `TclBignumToDouble` does (tclsh: expr {1.0 + 10**309} → Inf).
+        let p1100 = arith(BinOp::Pow, &Value::int(2), &Value::int(1100)).unwrap();
+        assert_eq!(f(BinOp::Add, &p1100, &Value::double(1.0)), "Inf");
+        // An integer-only operator still rejects the *float* operand — the
+        // bignum side is fine (tclsh 9 wording, sided).
+        let e = arith(BinOp::Mod, &s(p200), &Value::double(1.5)).unwrap_err();
+        assert_eq!(
+            e.message,
+            "cannot use floating-point value \"1.5\" as right operand of \"%\""
+        );
+        let e = arith(BinOp::Mod, &Value::double(1.5), &s(p200)).unwrap_err();
+        assert_eq!(
+            e.message,
+            "cannot use floating-point value \"1.5\" as left operand of \"%\""
+        );
     }
 
     #[test]
@@ -858,7 +1128,7 @@ mod tests {
         assert!(!compare(BinOp::Eq, &big, &dbl).unwrap());
         assert!(compare(BinOp::Gt, &big, &dbl).unwrap());
         assert!(compare(BinOp::Lt, &dbl, &big).unwrap());
-        // Integers past i128 (lossy `Dbl` in `to_num`) against a double —
+        // Integers past i128 (the `CmpNum::Big` tier) against a double —
         // the bignum-vs-double arm: 2¹³⁰ vs 1.5×2¹³⁰-ish.
         let huge = Value::string("1361129467683753853853498429727072845824"); // 2^130
         assert!(compare(BinOp::Gt, &huge, &Value::double(1e39)).unwrap());

--- a/rust/tcl-vm/src/expr.rs
+++ b/rust/tcl-vm/src/expr.rs
@@ -171,6 +171,11 @@ fn big_arith(op: BinOp, x: &BigInt, y: &BigInt) -> Result<Value, TclError> {
             if y.is_negative() {
                 return Err(TclError::new("negative shift argument"));
             }
+            // C checks the zero base before the count: `0 << huge` is 0,
+            // not the count-overflow error.
+            if num_traits::Zero::is_zero(x) {
+                return Ok(Value::int(0));
+            }
             // C's left-shift count must fit an `int` (`mp_mul_2d`): past
             // `INT_MAX` it raises the overflow error rather than attempt an
             // astronomic result (tclsh: `2 << 2**32` errors).
@@ -433,7 +438,14 @@ fn dbl_arith(op: BinOp, x: f64, y: f64) -> Result<Value, TclError> {
         Sub => x - y,
         Mul => x * y,
         Div => x / y,
-        Pow => x.powf(y),
+        Pow => {
+            // C raises the domain error before computing (`tclExecute.c`
+            // EXPONENT_OF_ZERO): `0.0 ** -1` is an error, never Inf.
+            if x == 0.0 && y < 0.0 {
+                return Err(TclError::new("exponentiation of zero by negative power"));
+            }
+            x.powf(y)
+        }
         _ => {
             return Err(TclError::new(
                 "can't use floating-point value as operand of this operator",
@@ -633,7 +645,9 @@ pub fn unary(op: UnaryOp, v: &Value) -> Result<Value, TclError> {
         // `big_value` narrow back to a wide when the result re-fits. A
         // non-numeric operand is the C operand-type error (`as operand of "-"`).
         Neg => match to_num(v) {
-            Ok(Num::Int(n)) => Ok(Value::int(n.wrapping_neg())),
+            // `-i64::MIN` does not fit a wide — promote through the i128
+            // tier exactly (a *computed* MIN reaches this arm as `Int`).
+            Ok(Num::Int(n)) => Ok(int_value(-i128::from(n))),
             Ok(Num::Big(b)) => Ok(int_value(b.wrapping_neg())),
             // An integer past `i128` negates exactly in arbitrary precision,
             // never as a lossy float (`RUST_ISSUE_011`).

--- a/rust/tcl-vm/src/value.rs
+++ b/rust/tcl-vm/src/value.rs
@@ -242,24 +242,22 @@ impl Value {
         let s = self.to_str();
         let t = s.trim();
         if let Some(num) = number::parse_whole(t) {
-            return Ok(match num {
-                Number::Int(n) => n != 0,
-                Number::Double(f) => f != 0.0,
-                Number::Big { .. } | Number::Nan { .. } => true,
-            });
+            return match num {
+                Number::Int(n) => Ok(n != 0),
+                Number::Double(f) => Ok(f != 0.0),
+                // A parsed `Big` is beyond `i64`, hence never zero.
+                Number::Big { .. } => Ok(true),
+                // NaN is a domain error in a boolean context (tclsh 8.6/9.0:
+                // "floating point value is Not a Number"), never truthy.
+                Number::Nan { .. } => Err(TclError::new("floating point value is Not a Number")),
+            };
         }
-        // C's `ParseBoolean` accepts any unambiguous case-insensitive *prefix*
-        // of true / false / yes / no / on / off (`tclObj.c`). A bare `o` is
-        // ambiguous between `on` and `off`, so it needs at least two characters.
-        let lower = t.to_ascii_lowercase();
-        match lower.chars().next() {
-            Some('t') if "true".starts_with(lower.as_str()) => Ok(true),
-            Some('y') if "yes".starts_with(lower.as_str()) => Ok(true),
-            Some('f') if "false".starts_with(lower.as_str()) => Ok(false),
-            Some('n') if "no".starts_with(lower.as_str()) => Ok(false),
-            Some('o') if lower.len() >= 2 && "on".starts_with(lower.as_str()) => Ok(true),
-            Some('o') if lower.len() >= 2 && "off".starts_with(lower.as_str()) => Ok(false),
-            _ => Err(TclError::new(format!(
+        // The canonical word acceptor (`ParseBoolean`, tclObj.c): any
+        // unambiguous case-insensitive prefix of the six boolean words —
+        // one home in `tcl_syntax::boolean`, oracle-table-pinned.
+        match tcl_syntax::boolean::parse_boolean_word(t) {
+            Some(b) => Ok(b),
+            None => Err(TclError::new(format!(
                 "expected boolean value but got {}",
                 list::describe_bad_value(&s)
             ))),
@@ -320,5 +318,26 @@ mod tests {
         assert!(Value::string("yes").as_bool().unwrap());
         assert!(!Value::string("off").as_bool().unwrap());
         assert!(Value::string("3").as_bool().unwrap());
+    }
+
+    /// The boolean-context acceptor, oracle-pinned (tclsh 8.6/9.0): word
+    /// prefixes resolve, any number compares against zero, `Inf` is truthy —
+    /// and `NaN` is a domain error ("floating point value is Not a Number"),
+    /// never a truth value.
+    #[test]
+    fn boolean_context_matches_oracle() {
+        assert!(Value::string("tru").as_bool().unwrap());
+        assert!(!Value::string("of").as_bool().unwrap());
+        assert!(Value::string("0.5").as_bool().unwrap());
+        assert!(!Value::string("0x0").as_bool().unwrap());
+        assert!(Value::string("Inf").as_bool().unwrap());
+        assert!(Value::string("18446744073709551616").as_bool().unwrap());
+        let err = Value::string("NaN").as_bool().unwrap_err();
+        assert!(
+            err.message.contains("Not a Number"),
+            "NaN must be the C domain error, got: {}",
+            err.message
+        );
+        assert!(Value::string("o").as_bool().is_err(), "ambiguous prefix");
     }
 }

--- a/rust/tcl-vm/src/value_ops.rs
+++ b/rust/tcl-vm/src/value_ops.rs
@@ -35,6 +35,36 @@ use tcl_syntax::value::{ValueError, ValueOps};
 use crate::interp::Vm;
 use crate::value::Value;
 
+/// `incr` / `dict incr` addition over the same integer tower `expr` uses: a
+/// sum past `i64` promotes to `i128` (e.g. `incr` at `i64::MAX` yields
+/// `9223372036854775808`), and one past `i128` promotes to an
+/// **arbitrary-precision bignum** rather than erroring — matching tclsh
+/// (`RUST_ISSUE_095`/`RUST_ISSUE_011`/`RUST_ISSUE_171`). A free function so the
+/// `dict incr` paths (command and `DICT_INCR_IMM` opcode) share it without
+/// needing the [`ValueOps`] receiver.
+pub(crate) fn int_add(a: Option<&Value>, b: &Value) -> Result<Value, ValueError> {
+    // Fast `i128` tier: both operands fit and the sum doesn't overflow.
+    let x_small = a.map_or(Some(0), Value::as_i128);
+    if let (Some(x), Some(y)) = (x_small, b.as_i128())
+        && let Some(sum) = x.checked_add(y)
+    {
+        return Ok(crate::expr::int_value(sum));
+    }
+    // Bignum tier: an operand (or the sum) exceeds `i128`. A non-integer
+    // operand is still the `NotInteger` error — the stored value's error
+    // surfacing before the increment's, as in C.
+    let to_big = |v: &Value| {
+        crate::expr::value_as_bigint(v)
+            .ok_or_else(|| ValueError::NotInteger(v.to_str().to_string()))
+    };
+    let xb = match a {
+        Some(v) => to_big(v)?,
+        None => num_bigint::BigInt::from(0),
+    };
+    let yb = to_big(b)?;
+    Ok(crate::expr::big_value(&(xb + yb)))
+}
+
 impl ValueOps for Vm {
     type Value = Value;
 
@@ -71,31 +101,10 @@ impl ValueOps for Vm {
             .map_err(|_| ValueError::NotInteger(v.to_str().to_string()))
     }
 
-    /// `incr` / `dict incr` addition over the same integer tower `expr` uses: a
-    /// sum past `i64` promotes to `i128` (e.g. `incr` at `i64::MAX` yields
-    /// `9223372036854775808`), and one past `i128` promotes to an
-    /// **arbitrary-precision bignum** rather than erroring — matching tclsh
-    /// (`RUST_ISSUE_095`/`RUST_ISSUE_011`/`RUST_ISSUE_171`).
+    /// The tower addition shared with `dict incr` — see the free
+    /// [`int_add`], which this merely re-exposes at the `ValueOps` seam.
     fn int_add(&mut self, a: Option<&Value>, b: &Value) -> Result<Value, ValueError> {
-        // Fast `i128` tier: both operands fit and the sum doesn't overflow.
-        let x_small = a.map_or(Some(0), Value::as_i128);
-        if let (Some(x), Some(y)) = (x_small, b.as_i128())
-            && let Some(sum) = x.checked_add(y)
-        {
-            return Ok(crate::expr::int_value(sum));
-        }
-        // Bignum tier: an operand (or the sum) exceeds `i128`. A non-integer
-        // operand is still the `NotInteger` error.
-        let to_big = |v: &Value| {
-            crate::expr::value_as_bigint(v)
-                .ok_or_else(|| ValueError::NotInteger(v.to_str().to_string()))
-        };
-        let xb = match a {
-            Some(v) => to_big(v)?,
-            None => num_bigint::BigInt::from(0),
-        };
-        let yb = to_big(b)?;
-        Ok(crate::expr::big_value(&(xb + yb)))
+        int_add(a, b)
     }
 
     fn as_double(&mut self, v: &Value) -> Result<f64, ValueError> {

--- a/rust/tcl-vm/tests/cmd_collections_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_collections_e2e.rs
@@ -421,6 +421,37 @@ fn dict_incr() {
     assert_eq!(msg, "expected integer but got \"x\"");
 }
 
+/// `dict incr` promotes through the same integer tower as `incr`/`expr`
+/// (`value_ops::int_add`): a sum past `i64` becomes the exact bignum, never
+/// the old "integer value too large to represent" error (`RUST_ISSUE_095`).
+#[test]
+fn dict_incr_promotes_past_wide() {
+    // tclsh 8.6/9.0: the default-increment (compiled `DICT_INCR_IMM`) path
+    // at i64::MAX promotes.
+    assert_eq!(
+        run("set d {k 9223372036854775807}\ndict incr d k\nset d").1,
+        "k 9223372036854775808"
+    );
+    // tclsh: two i64::MAX increments accumulate exactly (the increment is
+    // beyond the opcode's immediate, driving the command path).
+    assert_eq!(
+        run("set d {}\ndict incr d k 9223372036854775807\n\
+             dict incr d k 9223372036854775807\ndict get $d k")
+        .1,
+        "18446744073709551614"
+    );
+    // tclsh: a bignum increment (past i64) is itself legal and exact.
+    assert_eq!(
+        run("set d {k 5}\ndict incr d k 18446744073709551616\ndict get $d k").1,
+        "18446744073709551621"
+    );
+    // tclsh: a stored bignum value keeps promoting.
+    assert_eq!(
+        run("set d {k 18446744073709551616}\ndict incr d k\ndict get $d k").1,
+        "18446744073709551617"
+    );
+}
+
 /// `dict append` concatenates strings to the value (creating it empty);
 /// `dict lappend` appends list elements.
 #[test]

--- a/rust/tcl-vm/tests/cmd_math_expr_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_math_expr_e2e.rs
@@ -632,6 +632,100 @@ fn expr_runtime_integer_promotion() {
     );
 }
 
+/// The 61-digit value of `2**200`, an integer past the VM's `i128` fast tier —
+/// operands this size exercise the arbitrary-precision (`num-bigint`) path.
+const P200: &str = "1606938044258990275541962092341162602522202993782792835301376";
+
+#[test]
+fn expr_runtime_bignum_operands_past_i128() {
+    // An operand already past i128 (e.g. a prior 2**200 result) is numeric —
+    // it reaches the exact bignum path instead of erroring as a non-numeric
+    // string (the RUST_ISSUE_011 operand gap).  tclsh 8.6/9.0:
+    expr_ab(
+        P200,
+        "1",
+        "$a + $b",
+        "1606938044258990275541962092341162602522202993782792835301377",
+    );
+    expr_ab(P200, "7", "$a % $b", "4");
+    expr_ab(
+        P200,
+        "-3",
+        "$a / $b",
+        "-535646014752996758513987364113720867507400997927597611767126",
+    );
+    expr_ab(P200, "137", "$a >> $b", "9223372036854775808");
+    expr_ab(P200, "255", "$a & $b", "0");
+    // Unary over a beyond-i128 operand: exact negate and complement.
+    cmd_eq(&format!("set a {P200}; expr {{-$a}}"), &format!("-{P200}"));
+    cmd_eq(
+        &format!("set a {P200}; expr {{~$a}}"),
+        "-1606938044258990275541962092341162602522202993782792835301377",
+    );
+    // The bignum tier keeps C's error text.  tclsh: divide by zero
+    expr_ab_err(P200, "0", "$a / $b", "divide by zero");
+    expr_ab_err(P200, "0", "$a % $b", "divide by zero");
+}
+
+#[test]
+fn expr_runtime_bignum_float_contagion() {
+    // A bignum operand mixed with a float converts to its nearest double
+    // (C's `TclBignumToDouble`, round-to-nearest-even) and computes in f64 —
+    // never an error.  tclsh 8.6/9.0 agree on the *values*; the printed forms
+    // here are this toolchain's shortest round-trip rendering (tclsh 8.6's
+    // printer emits "1.844674407370955e+19" for exactly 2^64, a string that
+    // re-parses as 2^64 - 2048; `entier(1.5 + 18446744073709551616)` in 8.6
+    // confirms the value is 18446744073709551616).
+    expr_ab(
+        "1.5",
+        "18446744073709551616",
+        "$a + $b",
+        "1.8446744073709552e+19",
+    );
+    expr_ab(
+        "1.5",
+        "18446744073709551616",
+        "$a * $b",
+        "2.7670116110564327e+19",
+    );
+    // tclsh 8.6/9.0: expr {2**200 + 1.5} → 1.6069380442589903e+60
+    expr_ab(P200, "1.5", "$a + $b", "1.6069380442589903e+60");
+    // An integer-only operator still faults the *float* side (Tcl 9 wording).
+    expr_ab_err(
+        P200,
+        "1.5",
+        "$a % $b",
+        "cannot use floating-point value \"1.5\" as right operand of \"%\"",
+    );
+}
+
+#[test]
+fn expr_runtime_pow_and_shift_limits() {
+    // tclsh 8.6/9.0: the `**` exponent limit is 2^28 - 1; past it the result
+    // is "exponent too large" (never computed), while |base| <= 1 collapses
+    // for any exponent magnitude, parity included.
+    expr_ab_err("2", "268435456", "$a ** $b", "exponent too large");
+    expr_ab_err(
+        "2",
+        "99999999999999999999",
+        "$a ** $b",
+        "exponent too large",
+    );
+    expr_ab("1", "99999999999999999999", "$a ** $b", "1");
+    expr_ab("-1", "99999999999999999999", "$a ** $b", "-1"); // odd
+    expr_ab("-1", "99999999999999999998", "$a ** $b", "1"); // even
+    // tclsh: a left-shift count must fit C's int (`2 << 2**32` errors); a
+    // right-shift by any huge count collapses to the sign.
+    expr_ab_err(
+        "2",
+        "4294967296",
+        "$a << $b",
+        "integer value too large to represent",
+    );
+    expr_ab("2", "99999999999999999999", "$a >> $b", "0");
+    expr_ab("-2", "99999999999999999999", "$a >> $b", "-1");
+}
+
 #[test]
 fn expr_runtime_ipow_negative_exponent() {
     // The integer `ipow` negative-exponent special cases (variable operands).
@@ -830,6 +924,87 @@ fn mathfunc_wide_truncates_out_of_range_literal() {
     // tclsh 8.6/9.0: wide(0x8000000000000000) -> -9223372036854775808
     expr_eq("wide(0x8000000000000000)", "-9223372036854775808");
     expr_eq("wide(0xFFFFFFFFFFFFFFFF)", "-1");
+}
+
+#[test]
+fn mathfunc_int_wide_are_the_64bit_window() {
+    // int() and wide() are the same mod-2^64 window in 8.6+: an integer of
+    // any magnitude folds two's-complement; a double truncates toward zero
+    // first, then wraps the same way (variable args defeat const folding).
+    // tclsh 8.6/9.0:
+    cmd_eq("set x 18446744073709551617; expr {int($x)}", "1");
+    cmd_eq("set x 18446744073709551617; expr {wide($x)}", "1");
+    cmd_eq("set x -18446744073709551617; expr {int($x)}", "-1");
+    cmd_eq("set x 1e300; expr {int($x)}", "0"); // 10^300 divides by 2^64
+    cmd_eq("set x 1e300; expr {wide($x)}", "0");
+    cmd_eq("set x -1e300; expr {int($x)}", "0");
+    cmd_eq("set x 1.5e19; expr {int($x)}", "-3446744073709551616");
+    cmd_eq("set x 2.5e19; expr {int($x)}", "6553255926290448384");
+    cmd_eq(
+        "set x 9223372036854775808.0; expr {int($x)}",
+        "-9223372036854775808",
+    );
+    // Inf cannot wrap; NaN is not a number at all.  tclsh 8.6/9.0:
+    cmd_err(
+        "set x Inf; expr {int($x)}",
+        "integer value too large to represent",
+    );
+    cmd_err(
+        "set x Inf; expr {wide($x)}",
+        "integer value too large to represent",
+    );
+    cmd_err(
+        "set x NaN; expr {int($x)}",
+        "floating point value is Not a Number",
+    );
+}
+
+#[test]
+fn mathfunc_entier_round_are_exact_unbounded() {
+    // entier()/round() are exact and *unbounded* — no 64-bit window.  tclsh
+    // 8.6/9.0 return the full 301-digit integer for 1e300 (the exact value of
+    // the nearest double to 10^300), where int()/wide() wrap to 0.
+    let full_1e300 = "1000000000000000052504760255204420248704468581108159154915854115511802457988908195786371375080447864043704443832883878176942523235360430575644792184786706982848387200926575803737830233794788090059368953234970799945081119038967640880074652742780142494579258788820056842838115669472196386865459400540160";
+    cmd_eq("set x 1e300; expr {entier($x)}", full_1e300);
+    cmd_eq("set x 1e300; expr {round($x)}", full_1e300);
+    cmd_eq("set x 1.5e19; expr {entier($x)}", "15000000000000000000");
+    // Integers of any magnitude pass through exactly.  tclsh: round(2**200)
+    // is 2^200 itself.
+    cmd_eq(&format!("set x {P200}; expr {{round($x)}}"), P200);
+    cmd_eq(&format!("set x {P200}; expr {{entier($x)}}"), P200);
+    cmd_err(
+        "set x Inf; expr {entier($x)}",
+        "integer value too large to represent",
+    );
+    cmd_err(
+        "set x NaN; expr {round($x)}",
+        "floating point value is Not a Number",
+    );
+}
+
+#[test]
+fn mathfunc_abs_and_double_stay_bignum_exact() {
+    // abs() of an integer past i64 — or past i128 — is the exact magnitude,
+    // never a rounded double.  tclsh 8.6/9.0 (2^64 and 2^150):
+    cmd_eq(
+        "set x -18446744073709551616; expr {abs($x)}",
+        "18446744073709551616",
+    );
+    cmd_eq(
+        "set x -1427247692705959881058285969449495136382746624; expr {abs($x)}",
+        "1427247692705959881058285969449495136382746624",
+    );
+    // double() of a bignum is C's `TclBignumToDouble` conversion.
+    // tclsh 8.6/9.0: double(2**200) → 1.6069380442589903e+60
+    cmd_eq(
+        &format!("set x {P200}; expr {{double($x)}}"),
+        "1.6069380442589903e+60",
+    );
+    // tclsh 8.6/9.0: double(nan) is the NaN domain error.
+    cmd_err(
+        "set x NaN; expr {double($x)}",
+        "floating point value is Not a Number",
+    );
 }
 
 #[test]

--- a/rust/tcl-vm/tests/run_script.rs
+++ b/rust/tcl-vm/tests/run_script.rs
@@ -779,9 +779,10 @@ fn incr_and_var_substitution() {
 /// `incr` routed through the shared `tcl_cmd_core::var::incr_value` core (the
 /// `VarStore` read + `ValueOps::int_add` tower seam). Covers the unset → 0 start,
 /// array elements (the name carries `base(key)`; the VM parses it), and the
-/// canonical coercion errors. Crucially, the VM has no bignum, so an overflowing
-/// `incr` now **errors** (`integer value too large to represent`) rather than
-/// silently wrapping as the old hand-rolled `wrapping_add` did.
+/// canonical coercion errors. Crucially, an overflowing `incr` now **promotes**
+/// through the integer tower (`i128`, then an arbitrary-precision bignum),
+/// matching tclsh, rather than silently wrapping as the old hand-rolled
+/// `wrapping_add` did.
 #[test]
 fn incr_shared_core() {
     // Unset variable starts at 0 (no prior `set`).


### PR DESCRIPTION
## Summary

- Fixes #940's reported S100 false positive (`set fontSizes {10.0 12.0 16.0 24.0}; foreach size $fontSizes` — a pure value's first conversion is free) and lands the full type-tracking programme it motivated (`docs/design/compiler/type-tracking.md`, P1–P5), with every semantic claim pinned to live tclsh 8.6.14 oracle probes (9.0 agreeing).
- **P1 — committed-intrep dataflow**: a must/may pass tracks where a value's intrep is actually committed; second conversions fire with the committed from-type, merges fire only when every path pays, and hover reports "string (first used as: list)".
- **P2 — union type lattice**: `TypeLattice` is a bounded canonical union of `TypeShape` terms over the new `BoundedSet` primitive; 3+-way merges stay tracked instead of collapsing to `OVERDEFINED` (phi messages name every member, hover/inlay render full unions, W126 runs must-policy over members).
- **P3 — registry-driven element inference**: `ReturnElements` / `VarElementsEffect` / `VarWriteTyping::ElementsOf` registry facts drive container element typing (`[list [expr {2**20}] x]` is `List<Numeric, ?>`, `lassign` of an object list types its targets); the compiler's hardcoded command-name matches are deleted.
- **P4 — exact bignum folding**: `2**64`, `i64::MAX+1`, chained `$big + 1` fold to C's exact values with demote-when-fits; float edges oracle-pinned (NaN/Inf/signed-zero/denormals; a genuine `isqrt` off-by-one at the f64-rounding edge fixed).
- **P5 — per-element array SSA**: constant-keyed `arr(k)` is its own SSA variable (independent types, constants, shimmer; per-element hover); dynamic-key writes fan as `may_defs` whose SCCP/type values **join** old with written; write-sensitive diagnostics skip synthetic defs; base-keyed policies (`env`, traced, aliases, instance state) checked through the element's base. The same-element int↔string loop oscillation is now a true S102; FP-SH-13's conflation FP is prevented structurally.
- **Number tower centralised**: operator semantics (`INST_EXPON` collapses, floor div/mod, shift sign-collapse, 2^28 exponent ceiling) live once in `tcl_syntax::number_tower` behind the `BigIntOps` backend trait. The **VM adopted it** (25 live-verified divergences fixed: beyond-i128 operands, `dict incr` promotion, exact `int()`/`wide()`/`entier()`/`abs()`/`double()`, correctly-rounded bignum→double), and the backend seam is proven executable: `conformance::assert_backend` runs the identical oracle corpus over the i128 toy, num-bigint (compiler/VM), and the **real libtommath `mp_int`** (runtime `TowerMp` FFI adapter).
- **Booleans centralised**: both C acceptors (`ParseBoolean` prefixes + exactly `0`/`1`; boolean-context truthiness) live once in `tcl_syntax::boolean`, oracle-table-pinned; seven hand-rolled word lists migrated; two real divergences fixed (VM treated `NaN` as truthy; the folder folded `!NaN` where C errors).
- Known remaining gap, documented and unchanged: bignum arguments to `isqrt`/`max`/`min`/`floor`/`sqrt` still error where C computes (pre-existing).

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `make rust-check` — green (fmt + clippy pedantic `-D warnings` + drift gates)
  - `cargo test -p tcl-compiler` — 4427 lib + 6389 integration passing
  - `cargo test -p tcl-lsp-core --lib` — 1004 passing
  - `cargo test -p tcl-lsp-server --test e2e` — 892 passing
  - `cargo test -p tcl-vm` — 710 passing (+10 new)
  - `runtime/rust`: `cargo test` — 387 passing incl. the real-`mp_int` tower conformance; `cargo clippy --all-targets` — 0 warnings
  - `make tcl-vm-wasm` — builds and passes its node self-check
  - Oracle values verified against live `tclsh8.6` before each pinned test

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **Yes** — type lattice shape, SSA variable naming for array elements, may-def join semantics, shimmer/dead-store precision.
- [x] If yes, I updated at least one relevant KCS note: added `docs/kcs/kcs-howto-array-element-ssa-typing.md` (decision rules, repro workflow, anchors, failure modes). Note: the template's `docs/kcs/compiler/` directory does not exist in the repo — the note follows the actual flat `docs/kcs/` layout.
- [x] If I added a new compiler KCS note, I linked it from `docs/kcs/README.md`. (No `docs/kcs/compiler/README.md` exists — see above.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GQCW4Zg9YRPuuBYnJaTGRP

---
_Generated by [Claude Code](https://claude.ai/code/session_01GQCW4Zg9YRPuuBYnJaTGRP)_