### PR TITLE
feat(vscode,jetbrains): platform-targeted VSIXes + universal JetBrains bundling

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -512,7 +512,8 @@ jobs:
   # supported platform.  Each runner builds its host's target triples (with
   # cross-linkers for the foreign Linux arches), smoke-tests the native one,
   # and uploads the binaries preserving `target/<triple>/release/`.  build-vsix
-  # downloads them all and bundles a single universal VSIX.
+  # downloads them all and packages both the untargeted universal VSIX and
+  # six platform-targeted VSIXes (one per vsce --target platform).
   #
   # Per the no-marketplace-tokens invariant this uses only GitHub's built-in
   # token — nothing is published to a marketplace here.
@@ -652,7 +653,9 @@ jobs:
           fi
           gh release upload "$tag" out/* --clobber
 
-  # Build: universal VSIX package (bundles every native server binary)
+  # Build: the untargeted universal VSIX (bundles every native server
+  # binary) plus six platform-targeted VSIXes, one per vsce --target
+  # platform, so the Marketplace serves each client only its own binary.
   build-vsix:
     if: startsWith(github.ref, 'refs/tags/v')
     # test-ext runs as a no-op-success for pre-release tags (its test step is
@@ -733,14 +736,55 @@ jobs:
       - name: Install npm dependencies
         run: cd editors/vscode && npm ci
 
-      # Bundle all seven native binaries into one universal VSIX.
-      - name: Build and verify VSIX
+      # Bundle all seven native binaries into one untargeted "universal"
+      # VSIX — the Marketplace's fallback for any client with no dedicated
+      # targeted package below (namely riscv64 Linux — vsce has no --target
+      # string for it), and the artefact for a manual "Install from VSIX"
+      # side-load.
+      - name: Build and verify universal VSIX
         run: make package-vsix BUNDLED_TARGETS="$(make -s print-server-targets-all)"
 
       - uses: ./.github/actions/sign-and-upload
         with:
-          artefact-glob: "build/*.vsix"
-          artefact-name: vsix
+          artefact-glob: "build/tcl-lsp-vscode-*-universal.vsix"
+          artefact-name: vsix-universal
+
+      # Six small, single-binary VSIXes, one per vsce --target platform
+      # (win32/linux/darwin x x64/arm64), so the Marketplace serves each
+      # client only its own binary instead of the universal VSIX above. See
+      # package-vsix-targets in the Makefile.
+      - name: Build and verify platform-targeted VSIXes
+        run: make package-vsix-targets
+
+      - uses: ./.github/actions/sign-and-upload
+        with:
+          artefact-glob: "build/tcl-lsp-vscode-*-win32-x64.vsix"
+          artefact-name: vsix-win32-x64
+
+      - uses: ./.github/actions/sign-and-upload
+        with:
+          artefact-glob: "build/tcl-lsp-vscode-*-win32-arm64.vsix"
+          artefact-name: vsix-win32-arm64
+
+      - uses: ./.github/actions/sign-and-upload
+        with:
+          artefact-glob: "build/tcl-lsp-vscode-*-linux-x64.vsix"
+          artefact-name: vsix-linux-x64
+
+      - uses: ./.github/actions/sign-and-upload
+        with:
+          artefact-glob: "build/tcl-lsp-vscode-*-linux-arm64.vsix"
+          artefact-name: vsix-linux-arm64
+
+      - uses: ./.github/actions/sign-and-upload
+        with:
+          artefact-glob: "build/tcl-lsp-vscode-*-darwin-x64.vsix"
+          artefact-name: vsix-darwin-x64
+
+      - uses: ./.github/actions/sign-and-upload
+        with:
+          artefact-glob: "build/tcl-lsp-vscode-*-darwin-arm64.vsix"
+          artefact-name: vsix-darwin-arm64
 
   # ---------------------------------------------------------------------
   # build-claude-skills builds the AI zipapp first (since `make

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -830,9 +830,13 @@ jobs:
           artefact-name: claude-skills
 
   # Build: JetBrains plugin
+  # Universal plugin: bundles every SERVER_TARGETS_JETBRAINS platform (all
+  # seven SERVER_TARGET_MAP triples except riscv64 Linux, which no official
+  # JetBrains IDE build targets). Reuses build-server-matrix's cross-compiled
+  # binaries rather than cross-compiling again — same source build-vsix uses.
   build-jetbrains:
     if: startsWith(github.ref, 'refs/tags/v')
-    needs: [create-release]
+    needs: [create-release, build-server-matrix]
     runs-on: ubuntu-24.04
     permissions:
       contents: write        # gh release upload
@@ -847,12 +851,12 @@ jobs:
           fetch-depth: 1
           fetch-tags: ${{ !startsWith(github.ref, 'refs/tags/') }}
 
-      # `make build-editor-jetbrains` bundles the native tcl-lsp-server binary,
-      # so the Rust toolchain is required (no Python).
-      - name: Set up Rust
-        uses: actions-rust-lang/setup-rust-toolchain@46268bd060767258de96ed93c1251119784f2ab6 # v1.16.1
+      - name: Download native server binaries
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
-          toolchain: stable
+          pattern: server-bins-*
+          path: target
+          merge-multiple: true
 
       - name: Set up Java 17
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
@@ -864,10 +868,10 @@ jobs:
             editors/jetbrains/*.gradle*
             editors/jetbrains/gradle/wrapper/gradle-wrapper.properties
 
-      - name: Build JetBrains plugin
+      - name: Build JetBrains plugin (universal — every platform except riscv64)
         env:
           GRADLE_OPTS: -Dorg.gradle.daemon=false
-        run: make build-editor-jetbrains
+        run: make build-editor-jetbrains JB_BUNDLED_TARGETS="$(make -s print-server-targets-jetbrains)"
 
       - uses: ./.github/actions/sign-and-upload
         with:

--- a/INSTALL-editors.md
+++ b/INSTALL-editors.md
@@ -15,8 +15,8 @@ the standalone editors (Neovim/Emacs/Helix) point at
 
 | Editor | Artefact | Install |
 |--------|----------|---------|
-| [VS Code](#vs-code) | `tcl-lsp-vscode-<v>.vsix` | `code --install-extension`, or VS Code Marketplace |
-| [Cursor / Windsurf / VSCodium / Theia / code-server / Gitpod / Codespaces](#vs-code) | same `.vsix` | Sideload the `.vsix` (`code --install-extension` style) |
+| [VS Code](#vs-code) | `tcl-lsp-vscode-<v>-universal.vsix` (manual) or an auto-selected platform package | `code --install-extension`, or VS Code Marketplace |
+| [Cursor / Windsurf / VSCodium / Theia / code-server / Gitpod / Codespaces](#vs-code) | `tcl-lsp-vscode-<v>-universal.vsix` | Sideload the `.vsix` (`code --install-extension` style) |
 | [Sublime Text](#sublime-text) | `Tcl.sublime-package` | Package Control: install **Tcl-LSP**, or copy into `Installed Packages/` |
 | [JetBrains](#jetbrains) | `tcl-lsp-jetbrains-<v>.zip` | Settings > Plugins > Install from Disk |
 | [Neovim](#neovim) | `tcl-lsp-server-<v>.pyz` | Lua config |
@@ -54,10 +54,12 @@ are installed — see the per-editor sections below.
 
 Install from the VS Code Marketplace
 (<https://marketplace.visualstudio.com/items?itemName=bitwisecook.tcl-lsp>),
-or sideload the bundled `.vsix`:
+which serves a small package containing only your platform's binary
+automatically, or download and sideload the `-universal` package (bundles
+every platform in one file, so it works regardless of your OS/architecture):
 
 ```sh
-code --install-extension ~/Downloads/tcl-lsp-vscode-<v>.vsix
+code --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix
 ```
 
 Configure under **Settings > Extensions > Tcl**. No Python interpreter
@@ -68,16 +70,17 @@ to run against a local build, point `tclLsp.rustServerPath` at a
 
 ### VS Code-compatible editors
 
-The same `.vsix` works in editors that cannot use the Microsoft
+The `-universal` package works in editors that cannot use the Microsoft
 Marketplace (Cursor, Windsurf, VSCodium, Eclipse Theia, code-server /
-Coder, Gitpod, GitHub Codespaces Theia builds). Download from the
-GitHub release and sideload through the editor's Extensions UI, or
-via the CLI:
+Coder, Gitpod, GitHub Codespaces Theia builds) — it bundles every
+platform's binary in one file, so there's no need to pick the right one
+by hand. Download it from the GitHub release and sideload through the
+editor's Extensions UI, or via the CLI:
 
 ```sh
-cursor   --install-extension ~/Downloads/tcl-lsp-vscode-<v>.vsix
-codium   --install-extension ~/Downloads/tcl-lsp-vscode-<v>.vsix
-code-server --install-extension ~/Downloads/tcl-lsp-vscode-<v>.vsix
+cursor   --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix
+codium   --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix
+code-server --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix
 ```
 
 (Windsurf, Theia, and Gitpod all surface the same drag-and-drop or
@@ -185,15 +188,17 @@ extension auto-downloads the LSP server on first use.
 
 ## VS Code-compatible editors
 
-These editors load the VS Code `.vsix` unchanged. Download
-`tcl-lsp-vscode-<v>.vsix` from [Releases](https://github.com/bitwisecook/tcl-lsp/releases/latest)
+These editors load the VS Code `.vsix` unchanged. Download the
+`-universal` package, `tcl-lsp-vscode-<v>-universal.vsix` (it bundles
+every platform's binary in one file) from
+[Releases](https://github.com/bitwisecook/tcl-lsp/releases/latest)
 and install with the editor's own CLI.
 
 | Editor | Install command |
 |--------|-----------------|
-| **Cursor** | `cursor --install-extension ~/Downloads/tcl-lsp-vscode-<v>.vsix` |
-| **Windsurf** | `windsurf --install-extension ~/Downloads/tcl-lsp-vscode-<v>.vsix` |
-| **VSCodium** | `codium --install-extension ~/Downloads/tcl-lsp-vscode-<v>.vsix` |
+| **Cursor** | `cursor --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix` |
+| **Windsurf** | `windsurf --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix` |
+| **VSCodium** | `codium --install-extension ~/Downloads/tcl-lsp-vscode-<v>-universal.vsix` |
 | **code-server** (Coder) | Drag-drop into the Extensions side panel, or `code-server --install-extension <path>` |
 | **GitHub Codespaces** | Extensions side panel > `...` > **Install from VSIX…** |
 | **Gitpod** | Same as Codespaces — open the workspace and install from VSIX |

--- a/Makefile
+++ b/Makefile
@@ -71,7 +71,12 @@ VSCE_PRERELEASE_FLAG := $(if $(filter true,$(IS_PRERELEASE)),--pre-release,)
 JETBRAINS_CHANNEL   := $(if $(filter true,$(IS_PRERELEASE)),eap,)
 
 # Derived paths
-VSIX_FILE      := $(BUILD_DIR)/tcl-lsp-vscode-$(VERSION).vsix
+VSIX_FILE      := $(BUILD_DIR)/tcl-lsp-vscode-$(VERSION)-universal.vsix
+# Set (via a recursive `$(MAKE) VSCE_TARGET=...`) to bake a `vsce package
+# --target <platform>` tag into the $(VSIX_FILE) recipe below.  Empty by
+# default, which packages the untargeted "universal" VSIX.
+# package-vsix-targets drives this for the six platform-targeted packages.
+VSCE_TARGET ?=
 # Self-contained BIG-IP report .pyz (native `_engine` + MiniJinja bundled by shiv).
 # Native + abi3, so the artefact is OS/arch-specific but runs on any CPython
 # >= 3.9 for that platform; the tag keeps CI matrix outputs from clobbering.
@@ -89,10 +94,20 @@ VSCE_PUBLISHER := bitwisecook
 # Cargo build profile for the native Rust LSP server (rust-server target).
 PROFILE ?= release
 
-# Native-server cross-compilation.  The universal VSIX bundles one
-# `tcl-lsp-server` binary per supported platform under
-# `server/<platform>-<arch>/`.  Each entry maps a Rust target triple to the
-# VSIX bundle directory (which equals Node's `process.platform-process.arch`).
+# Native-server cross-compilation.  Two VS Code packaging strategies share
+# this one 7-triple matrix:
+#   - $(VSIX_FILE), the untargeted "universal" VSIX: bundles one
+#     `tcl-lsp-server` binary per platform under `server/<platform>-<arch>/`.
+#     Published with no vsce --target, it is the Marketplace's fallback for
+#     any client with no dedicated targeted package below (namely riscv64
+#     Linux — vsce has no --target string for it), and the artefact for a
+#     manual "Install from VSIX" side-load.
+#   - package-vsix-targets: six small, single-binary VSIXes, one per vsce
+#     --target platform, so the Marketplace serves each client only its own
+#     binary instead of all seven.
+# Each SERVER_TARGET_MAP entry maps a Rust target triple to the VSIX bundle
+# directory, which equals Node's `process.platform-process.arch` AND (for
+# six of the seven) a valid vsce --target string.
 SERVER_TARGET_MAP := \
 	x86_64-apple-darwin:darwin-x64 \
 	aarch64-apple-darwin:darwin-arm64 \
@@ -102,6 +117,13 @@ SERVER_TARGET_MAP := \
 	x86_64-pc-windows-msvc:win32-x64 \
 	aarch64-pc-windows-msvc:win32-arm64
 SERVER_TARGETS_ALL := $(foreach p,$(SERVER_TARGET_MAP),$(firstword $(subst :, ,$(p))))
+
+# vsce's supported --target platform strings (see "Platform-specific
+# extensions" at code.visualstudio.com/api/working-with-extensions/publishing-extension).
+# Six of the seven SERVER_TARGET_MAP bundle dirs are also valid vsce
+# targets; linux-riscv64 is not (vsce has no RISC-V target), so riscv64
+# Linux users get the untargeted $(VSIX_FILE) fallback instead.
+VSCE_TARGETS := win32-x64 win32-arm64 linux-x64 linux-arm64 darwin-x64 darwin-arm64
 
 # Targets the current host can build natively / with cross-linkers.  Linux
 # builds the three Linux triples (x86_64 native + aarch64/riscv64 cross);
@@ -115,9 +137,10 @@ else
   SERVER_TARGETS_HOST := x86_64-pc-windows-msvc aarch64-pc-windows-msvc
 endif
 
-# The set of triples staged into the universal VSIX.  Defaults to the
-# host-buildable subset (a partial-universal VSIX for local dev); CI overrides
-# with the full matrix: `make package-vsix BUNDLED_TARGETS="$(SERVER_TARGETS_ALL)"`.
+# The set of triples staged into $(VSIX_FILE) (the universal/fallback VSIX).
+# Defaults to the host-buildable subset (a partial-universal VSIX for local
+# dev); CI overrides with the full matrix: `make package-vsix
+# BUNDLED_TARGETS="$(SERVER_TARGETS_ALL)"`.
 BUNDLED_TARGETS ?= $(SERVER_TARGETS_HOST)
 
 # This host's own Rust target triple — the one binary cargo can always build
@@ -159,6 +182,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 .PHONY: smoke-vsix
 # Packaging + publish + release
 .PHONY: build-editors build-editor-vsix verify-vsix install package-vsix publish-vsix
+.PHONY: build-editor-vsix-targets package-vsix-targets publish-vsix-targets
 .PHONY: build-editor-jetbrains verify-editor-jetbrains publish-jetbrains build-editor-sublime publish-sublime build-editor-zed publish-zed publish-all publish-verify publish-flow
 .PHONY: release release-tag release-sums
 # Rust runtime port
@@ -245,8 +269,8 @@ $(VSIX_FILE): $(OUT_DIR)/extension.js $(EXT_DIR)/package.json $(EXT_DIR)/.vscode
 	mkdir -p $(STAGE_DIR)/docs/screenshots
 	cp $(SCREENSHOT_DIR)/*.png $(SCREENSHOT_DIR)/*.gif $(STAGE_DIR)/docs/screenshots/
 	cp "$(ROOT)docs/Tcl LSP Logo-8bit-256.png" $(STAGE_DIR)/docs/icon.png
-	@echo "==> Packaging .vsix (stripped, not obfuscated)$(if $(VSCE_PRERELEASE_FLAG), [pre-release],)"
-	cd $(STAGE_DIR) && $(VSCE) package $(VSCE_PRERELEASE_FLAG) --allow-missing-repository --no-update-package-json --no-git-tag-version -o $(VSIX_FILE)
+	@echo "==> Packaging .vsix (stripped, not obfuscated)$(if $(VSCE_PRERELEASE_FLAG), [pre-release],)$(if $(VSCE_TARGET), [target: $(VSCE_TARGET)],)"
+	cd $(STAGE_DIR) && $(VSCE) package $(VSCE_PRERELEASE_FLAG) $(if $(VSCE_TARGET),--target $(VSCE_TARGET),) --allow-missing-repository --no-update-package-json --no-git-tag-version -o $(VSIX_FILE)
 	@echo ""
 	@echo "Built: $(VSIX_FILE)"
 	@ls -lh $(VSIX_FILE)
@@ -296,6 +320,50 @@ verify-vsix: $(VSIX_FILE) ## Fail if dev/cache artifacts leaked into the .vsix
 			exit 1; \
 		fi; \
 		echo "==> VSIX bundles $$have/$$want native server binaries"
+
+# ---------------------------------------------------------------------------
+# Platform-targeted VSIX packaging — six small, single-binary VSIXes
+# published with `vsce package/publish --target <platform>` so the
+# Marketplace serves each client only its own binary instead of the
+# untargeted $(VSIX_FILE) above.  Reuses the $(VSIX_FILE) rule verbatim via
+# recursive `$(MAKE)` calls that override BUNDLED_TARGETS/VSCE_TARGET/
+# VSIX_FILE per target, so staging and verify-vsix's checks never drift
+# from the universal build's.
+# ---------------------------------------------------------------------------
+
+build-editor-vsix-targets: lint test compile package-vsix-targets ## Build the six platform-targeted .vsix files (tests must pass first)
+
+package-vsix-targets: ## Package the six platform-targeted VSIXes (CI; skips lint/test)
+	@set -eu; \
+	for vt in $(VSCE_TARGETS); do \
+		triple=""; \
+		for pair in $(SERVER_TARGET_MAP); do \
+			t="$${pair%%:*}"; d="$${pair##*:}"; \
+			[ "$$d" = "$$vt" ] && triple="$$t"; \
+		done; \
+		if [ -z "$$triple" ]; then echo "ERROR: no SERVER_TARGET_MAP entry for vsce target $$vt"; exit 1; fi; \
+		out="$(BUILD_DIR)/tcl-lsp-vscode-$(VERSION)-$$vt.vsix"; \
+		echo "==> Packaging platform-targeted VSIX: $$vt ($$triple)"; \
+		$(MAKE) --no-print-directory package-vsix BUNDLED_TARGETS="$$triple" VSCE_TARGET="$$vt" VSIX_FILE="$$out"; \
+	done
+	@echo "==> Built $(words $(VSCE_TARGETS)) platform-targeted VSIXes"
+
+publish-vsix-targets: package-vsix-targets ## Publish the six platform-targeted .vsix files to the VS Code Marketplace (laptop fallback; CI is the primary path)
+	@set -eu; \
+	for vt in $(VSCE_TARGETS); do \
+		f="$(BUILD_DIR)/tcl-lsp-vscode-$(VERSION)-$$vt.vsix"; \
+		echo "==> Publishing $$f to VS Code Marketplace"; \
+		if [ -n "$$VSCE_PAT" ]; then \
+			(cd $(STAGE_DIR) && $(VSCE) publish $(VSCE_PRERELEASE_FLAG) --packagePath "$$f"); \
+		elif az account show >/dev/null 2>&1; then \
+			(cd $(STAGE_DIR) && $(VSCE) publish $(VSCE_PRERELEASE_FLAG) --azure-credential --packagePath "$$f"); \
+		else \
+			echo "    No Azure CLI session for keyless publishing."; \
+			echo "    Run:  az login --allow-no-subscriptions"; \
+			echo "    (or set VSCE_PAT to use the legacy stored-PAT path instead.)"; \
+			exit 1; \
+		fi; \
+	done
 
 # Test targets
 
@@ -1317,7 +1385,7 @@ publish-zed: build-editor-zed ## Publish Zed extension (prep local PR branch for
 
 # Release
 
-release: package-vsix claude-skills build-editor-jetbrains build-editor-sublime build-editor-zed release-sums ## Build all release artifacts (parity with tagged CI release jobs)
+release: package-vsix package-vsix-targets claude-skills build-editor-jetbrains build-editor-sublime build-editor-zed release-sums ## Build all release artifacts (parity with tagged CI release jobs)
 	@echo ""
 	@echo "Built release artifacts in $(BUILD_DIR)"
 
@@ -1326,7 +1394,7 @@ release: package-vsix claude-skills build-editor-jetbrains build-editor-sublime 
 # SHA256SUMS itself and its signature bundle); this target mirrors that
 # selection so developers can compare locally-built SUMS against the
 # published file.
-release-sums: claude-skills package-vsix build-editor-jetbrains build-editor-sublime build-editor-zed
+release-sums: claude-skills package-vsix package-vsix-targets build-editor-jetbrains build-editor-sublime build-editor-zed
 	@cd $(BUILD_DIR) && \
 	    if command -v sha256sum >/dev/null 2>&1; then h="sha256sum"; \
 	    else h="shasum -a 256"; fi; \
@@ -1344,7 +1412,7 @@ release-sums: claude-skills package-vsix build-editor-jetbrains build-editor-sub
 release-tag: ## Create + push the annotated release tag (V=x.y.z)
 	@bash $(ROOT)scripts/release/tag.sh $(V)
 
-publish-all: publish-vsix publish-jetbrains publish-sublime publish-zed ## Publish to all editor marketplaces
+publish-all: publish-vsix publish-vsix-targets publish-jetbrains publish-sublime publish-zed ## Publish to all editor marketplaces
 
 publish-verify: ## Sanity-check publishing readiness (credentials, tool versions, remote reach) without shipping
 	@bash $(ROOT)scripts/release/publish_verify.sh

--- a/Makefile
+++ b/Makefile
@@ -143,6 +143,14 @@ endif
 # BUNDLED_TARGETS="$(SERVER_TARGETS_ALL)"`.
 BUNDLED_TARGETS ?= $(SERVER_TARGETS_HOST)
 
+# JetBrains ships one universal plugin bundling every platform except
+# riscv64 Linux — no official JetBrains IDE build targets it, and the IDE's
+# own CpuArch detection only distinguishes x86/ARM anyway. Derived from
+# SERVER_TARGETS_ALL (not hardcoded) so a future 8th non-riscv target picks
+# this up automatically.
+SERVER_TARGETS_JETBRAINS := $(filter-out riscv64gc-unknown-linux-gnu,$(SERVER_TARGETS_ALL))
+JB_BUNDLED_TARGETS ?= $(filter-out riscv64gc-unknown-linux-gnu,$(SERVER_TARGETS_HOST))
+
 # This host's own Rust target triple — the one binary cargo can always build
 # with no cross toolchain.  Used by the `smoke-vsix` gate for a dependency-light
 # native-only VSIX (the full multi-platform build is CI's job).
@@ -183,7 +191,7 @@ TS_SRCS  := $(shell find $(EXT_DIR)/src -name '*.ts' 2>/dev/null)
 # Packaging + publish + release
 .PHONY: build-editors build-editor-vsix verify-vsix install package-vsix publish-vsix
 .PHONY: build-editor-vsix-targets package-vsix-targets publish-vsix-targets
-.PHONY: build-editor-jetbrains verify-editor-jetbrains publish-jetbrains build-editor-sublime publish-sublime build-editor-zed publish-zed publish-all publish-verify publish-flow
+.PHONY: build-editor-jetbrains verify-jetbrains-server verify-editor-jetbrains publish-jetbrains build-editor-sublime publish-sublime build-editor-zed publish-zed publish-all publish-verify publish-flow
 .PHONY: release release-tag release-sums
 # Rust runtime port
 .PHONY: runtime-rust-test runtime-rust-lint zed-query-check vm-test vm-lint
@@ -198,7 +206,7 @@ help: ## Show this help
 	@grep -E '^[a-zA-Z][a-zA-Z0-9_-]*:.*?## ' $(MAKEFILE_LIST) | \
 		awk 'BEGIN {FS = ":.*?## "}; {printf "  \033[36m%-24s\033[0m %s\n", $$1, $$2}'
 
-build-editors: build-editor-vsix build-editor-jetbrains build-editor-sublime build-editor-zed ## Build all editor extension artefacts (VS Code / JetBrains / Sublime / Zed)
+build-editors: build-editor-vsix build-editor-vsix-targets build-editor-jetbrains build-editor-sublime build-editor-zed ## Build all editor extension artefacts (VS Code / JetBrains / Sublime / Zed)
 
 build-editor-vsix: lint test compile verify-vsix ## Build the .vsix (tests must pass first)
 install: package-vsix ## Build and install the .vsix into VS Code
@@ -333,7 +341,12 @@ verify-vsix: $(VSIX_FILE) ## Fail if dev/cache artifacts leaked into the .vsix
 
 build-editor-vsix-targets: lint test compile package-vsix-targets ## Build the six platform-targeted .vsix files (tests must pass first)
 
-package-vsix-targets: ## Package the six platform-targeted VSIXes (CI; skips lint/test)
+# Depends on package-vsix (not just compile) even though the two artefacts
+# are otherwise independent: both stage through the same $(STAGE_DIR), so
+# under `make -j` (e.g. `make -j release`) an unordered pair would race —
+# one recipe's `rm -rf $(STAGE_DIR)` can wipe the other's in-flight staging.
+# This edge forces the universal build to finish first every time.
+package-vsix-targets: package-vsix ## Package the six platform-targeted VSIXes (CI; skips lint/test)
 	@set -eu; \
 	for vt in $(VSCE_TARGETS); do \
 		triple=""; \
@@ -353,7 +366,7 @@ publish-vsix-targets: package-vsix-targets ## Publish the six platform-targeted 
 	for vt in $(VSCE_TARGETS); do \
 		f="$(BUILD_DIR)/tcl-lsp-vscode-$(VERSION)-$$vt.vsix"; \
 		echo "==> Publishing $$f to VS Code Marketplace"; \
-		if [ -n "$$VSCE_PAT" ]; then \
+		if [ -n "$${VSCE_PAT:-}" ]; then \
 			(cd $(STAGE_DIR) && $(VSCE) publish $(VSCE_PRERELEASE_FLAG) --packagePath "$$f"); \
 		elif az account show >/dev/null 2>&1; then \
 			(cd $(STAGE_DIR) && $(VSCE) publish $(VSCE_PRERELEASE_FLAG) --azure-credential --packagePath "$$f"); \
@@ -779,6 +792,9 @@ cli-cross-build-all: ## Cross-compile tcl + f5-query for all 7 targets (release-
 
 print-server-targets-all: ## Print the full set of native-server target triples (CI helper)
 	@echo $(SERVER_TARGETS_ALL)
+
+print-server-targets-jetbrains: ## Print the JetBrains-eligible target triples — SERVER_TARGETS_ALL minus riscv64 (CI helper)
+	@echo $(SERVER_TARGETS_JETBRAINS)
 
 server-cross-test: ## Smoke-test built tcl-lsp-server binaries (QEMU on Linux, native on macOS)
 	@bash $(ROOT)scripts/test-cross-server.sh
@@ -1265,23 +1281,52 @@ package-vsix: compile $(VSIX_FILE) verify-vsix ## Package VSIX (skip lint/test, 
 JB_DIR     := $(ROOT)editors/jetbrains
 JB_PLUGIN  := $(BUILD_DIR)/tcl-lsp-jetbrains-$(VERSION).zip
 
-build-editor-jetbrains: $(JB_PLUGIN) ## Build JetBrains plugin (.zip)
+build-editor-jetbrains: $(JB_PLUGIN) verify-jetbrains-server ## Build JetBrains plugin (.zip), universal across all platforms except riscv64
 
-$(JB_PLUGIN): rust-server
+# $(JB_PLUGIN)'s own prerequisites are staged binaries checked at recipe
+# time (below), not tracked by Make as file dependencies — so without a
+# forcing prerequisite, a stale zip from a previous run would silently
+# survive untouched after only the native binaries were rebuilt. The old
+# `rust-server` prerequisite happened to force this (it's phony); this
+# sentinel keeps that always-rebuild behaviour explicit now that staging
+# no longer depends on rust-server building just one binary.
+.PHONY: jb-plugin-force
+jb-plugin-force:
+
+$(JB_PLUGIN): jb-plugin-force
 	@echo "==> Building JetBrains plugin"
 	@# build.gradle.kts reads RELEASE_VERSION from the environment first, so
 	@# the gradle.properties source file is never mutated by the build.
 	@# Copy shared resources into plugin resources
 	mkdir -p $(JB_DIR)/src/main/resources/syntaxes
 	cp $(EXT_DIR)/syntaxes/tcl.tmLanguage.json $(JB_DIR)/src/main/resources/syntaxes/
-	@# Bundle the native LSP server binary into a staging dir outside
-	@# ``src/main/resources/``.  ``build.gradle.kts`` registers a
-	@# ``prepareSandbox`` copy that picks the binary up from here and drops it
-	@# at the plugin root in the distribution — same layout JetBrains' own
-	@# Prisma ORM plugin uses to ship its bundled language server.
-	mkdir -p $(JB_DIR)/server
-	cp $(ROOT)target/$(PROFILE)/tcl-lsp-server $(JB_DIR)/server/tcl-lsp-server
-	chmod +x $(JB_DIR)/server/tcl-lsp-server
+	@# Bundle one native LSP server binary per platform into server/<dir>/,
+	@# the same layout and SERVER_TARGET_MAP the VS Code universal VSIX
+	@# uses (minus riscv64 — see SERVER_TARGETS_JETBRAINS).
+	@# ``build.gradle.kts`` registers a ``prepareSandbox`` copy that picks up
+	@# the whole tree from here and drops it at the plugin root in the
+	@# distribution — same layout JetBrains' own Prisma ORM plugin uses to
+	@# ship its bundled language server.
+	rm -rf $(JB_DIR)/server
+	@set -eu; \
+		missing=""; \
+		for pair in $(SERVER_TARGET_MAP); do \
+			triple="$${pair%%:*}"; dir="$${pair##*:}"; \
+			case " $(JB_BUNDLED_TARGETS) " in *" $$triple "*) ;; *) continue;; esac; \
+			case "$$triple" in *windows*) exe="tcl-lsp-server.exe";; *) exe="tcl-lsp-server";; esac; \
+			src="$(ROOT)target/$$triple/release/$$exe"; \
+			if [ ! -f "$$src" ]; then missing="$$missing $$triple"; continue; fi; \
+			mkdir -p "$(JB_DIR)/server/$$dir"; \
+			cp "$$src" "$(JB_DIR)/server/$$dir/$$exe"; \
+			chmod +x "$(JB_DIR)/server/$$dir/$$exe"; \
+			echo "    server/$$dir/$$exe"; \
+		done; \
+		if [ -n "$$missing" ]; then \
+			echo "ERROR: missing built server binaries for:$$missing"; \
+			echo "Build them first: make server-cross-build  (host targets)"; \
+			echo "             or:  make server-cross-build-all  (all 7 — needs cross deps)"; \
+			exit 1; \
+		fi
 	@# Extract compiler explorer HTML from VS Code extension
 	cd $(EXT_DIR) && node -e " \
 		const {getWebviewHtml} = require('./out/compilerExplorerHtml'); \
@@ -1294,6 +1339,28 @@ $(JB_PLUGIN): rust-server
 	@echo ""
 	@echo "Built: $(JB_PLUGIN)"
 	@ls -lh $(JB_PLUGIN)
+
+verify-jetbrains-server: $(JB_PLUGIN) ## Fail if the JetBrains plugin is missing an expected platform server binary
+	@echo "==> Verifying JetBrains plugin server binaries"
+	@set -euo pipefail; \
+		entries="$$(unzip -Z1 $(JB_PLUGIN))"; \
+		want=0; have=0; missing=""; \
+		for pair in $(SERVER_TARGET_MAP); do \
+			triple="$${pair%%:*}"; dir="$${pair##*:}"; \
+			case " $(JB_BUNDLED_TARGETS) " in *" $$triple "*) ;; *) continue;; esac; \
+			case "$$triple" in *windows*) exe="tcl-lsp-server.exe";; *) exe="tcl-lsp-server";; esac; \
+			want=$$((want+1)); \
+			if echo "$$entries" | grep -q "/server/$$dir/$$exe$$"; then \
+				have=$$((have+1)); \
+			else \
+				missing="$$missing server/$$dir/$$exe"; \
+			fi; \
+		done; \
+		if [ -n "$$missing" ]; then \
+			echo "JetBrains plugin missing expected native server binaries:$$missing"; \
+			exit 1; \
+		fi; \
+		echo "==> JetBrains plugin bundles $$have/$$want native server binaries"
 
 verify-editor-jetbrains: ## Run the IntelliJ Plugin Verifier over the JetBrains plugin (binary-compat gate)
 	@echo "==> Verifying JetBrains plugin against the configured IDE targets"

--- a/README.md
+++ b/README.md
@@ -185,7 +185,10 @@ Document, Apply Safe Quick Fixes, Apply All Optimisations.
 A full IntelliJ Platform plugin (`.zip`) for IntelliJ IDEA 2024.1+ and other
 JetBrains IDEs.  Includes a dedicated settings panel (Settings > Tools > Tcl
 Language Server) with toggles for every feature, diagnostic code, and
-formatting option.
+formatting option.  One universal plugin bundles a native `tcl-lsp-server`
+binary for macOS, Linux, and Windows on x64 and arm64 (six platforms; no
+riscv64 — no official JetBrains IDE build targets it) and launches the one
+matching your machine.
 
 Features a **Compiler Explorer tool window** with JCEF browser for inspecting
 IR, CFG, SSA, and optimiser output directly inside the IDE.

--- a/README.md
+++ b/README.md
@@ -2251,7 +2251,7 @@ make test
 make build-editor-vsix
 
 # Install in VS Code
-code --install-extension tcl-lsp-vscode-0.1.0.vsix
+code --install-extension tcl-lsp-vscode-0.1.0-universal.vsix
 ```
 
 ## Build targets
@@ -2260,9 +2260,11 @@ Run `make help` to see all targets:
 
 | Target | Description |
 |--------|-------------|
-| `make build-editor-vsix` | Build the .vsix (tests must pass first) |
-| `make install` | Build and install the .vsix into VS Code |
-| `make package-vsix` | Package VSIX (skip lint/test, for CI) |
+| `make build-editor-vsix` | Build the universal .vsix, bundling every platform (tests must pass first) |
+| `make build-editor-vsix-targets` | Build the six platform-targeted .vsix files (tests must pass first) |
+| `make install` | Build and install the universal .vsix into VS Code |
+| `make package-vsix` | Package the universal VSIX (skip lint/test, for CI) |
+| `make package-vsix-targets` | Package the six platform-targeted VSIXes (skip lint/test, for CI) |
 | `make test` | Run all tests (Rust workspace + VS Code extension) |
 | `make test-rust` | Run the Rust workspace tests (incl. the native LSP e2e suite) |
 | `make test-ext` | Run VS Code extension integration tests |
@@ -2294,7 +2296,11 @@ manifest fields use `0.0.0-dev`).
 `make build-editor-vsix` is the main entry point.  It runs the test suite first and will
 not package a .vsix if any test fails.  Packaging uses an isolated staging
 directory under `build/vsix-stage/`, and the output file lands under
-`build/` as `tcl-lsp-<version>.vsix`.
+`build/` as `tcl-lsp-vscode-<version>-universal.vsix`.  `make
+build-editor-vsix-targets` packages six more platform-targeted `.vsix`
+files the same way, each named `tcl-lsp-vscode-<version>-<platform>.vsix`
+and bundling only that platform's native binary — see
+[the multi-platform VSIX how-to](docs/kcs/kcs-howto-build-multiplatform-vsix.md).
 
 On macOS, `make screenshots` prefers a small Swift window-probe helper when
 `swiftc` is available, so captures use deterministic

--- a/docs/design/contracts/release-and-publish.md
+++ b/docs/design/contracts/release-and-publish.md
@@ -179,8 +179,13 @@ the secret is reachable by no other job.
 * Build every release artefact: the native binaries (`tcl`, `f5-query`,
   `tcl-lsp-server`, `tcl-mcp`) via `cargo build` / the cross-build targets,
   plus `make build-editor-jetbrains` / `make build-editor-sublime` /
-  `make build-editor-zed` / `make package-vsix` and the Claude-skills zip.
-  The VSIX bundles the native `tcl-lsp-server` binaries — no `.pyz`.
+  `make build-editor-zed` / `make package-vsix package-vsix-targets` and
+  the Claude-skills zip. The VS Code artefact is seven VSIX packages: one
+  untargeted universal package bundling every native `tcl-lsp-server`
+  binary (the Marketplace's fallback for riscv64 Linux, and the artefact
+  for a manual side-load), plus six platform-targeted packages built with
+  `vsce package --target <platform>`, each bundling only its own binary —
+  no `.pyz`.
 * Sign every artefact with sigstore (OIDC + `github.token` — no
   configured secrets).
 * Generate SBOMs (`anchore/sbom-action`).
@@ -208,9 +213,9 @@ stored, is a design conversation: it requires updating this contract and
 
 ## File-path anchors
 
-- [`Makefile`](../../../Makefile) — `publish-vsix`, `publish-jetbrains`,
-  `publish-sublime`, `publish-zed`, `publish-all`, `publish-verify`,
-  `publish-flow`, `release-tag`.
+- [`Makefile`](../../../Makefile) — `publish-vsix`, `publish-vsix-targets`,
+  `publish-jetbrains`, `publish-sublime`, `publish-zed`, `publish-all`,
+  `publish-verify`, `publish-flow`, `release-tag`.
 - [`.github/workflows/ci.yml`](../../../.github/workflows/ci.yml) —
   builds artefacts, attests them, attaches them to the Release, and runs
   the two marketplace publish jobs.  Every `secrets.*` reference sits in a

--- a/docs/design/contracts/release-and-publish.md
+++ b/docs/design/contracts/release-and-publish.md
@@ -185,7 +185,10 @@ the secret is reachable by no other job.
   binary (the Marketplace's fallback for riscv64 Linux, and the artefact
   for a manual side-load), plus six platform-targeted packages built with
   `vsce package --target <platform>`, each bundling only its own binary —
-  no `.pyz`.
+  no `.pyz`. The JetBrains artefact is one universal plugin bundling every
+  native `tcl-lsp-server` binary except riscv64 Linux (no official
+  JetBrains IDE build targets it), since JetBrains Marketplace has no
+  per-platform equivalent of vsce's `--target` yet.
 * Sign every artefact with sigstore (OIDC + `github.token` — no
   configured secrets).
 * Generate SBOMs (`anchore/sbom-action`).

--- a/docs/kcs/kcs-howto-build-multiplatform-vsix.md
+++ b/docs/kcs/kcs-howto-build-multiplatform-vsix.md
@@ -9,9 +9,8 @@ VS Code
 
 ## Question
 
-How do I build the universal `.vsix` that bundles a native
-`tcl-lsp-server` binary for every supported platform, and how do I add a
-new platform?
+How do I build the VSIX packages that cover every supported platform, and
+how do I add a new platform?
 
 ## Before you start
 
@@ -22,16 +21,32 @@ new platform?
 
 ## Answer
 
-The extension no longer ships a Python server. Instead the `.vsix` is a
-single **universal** package that bundles one native `tcl-lsp-server`
-binary per platform under `server/<platform>-<arch>/`, and the extension
-launches the one matching the user's machine. The supported set is seven
-targets: macOS, Linux, and Windows on x64 and arm64, plus Linux riscv64.
+The extension no longer ships a Python server. Instead, VS Code gets
+**seven** `.vsix` packages built from one native `tcl-lsp-server` binary
+per platform:
+
+- **Six platform-targeted packages** — `win32-x64`, `win32-arm64`,
+  `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64` — each bundles
+  only its own platform's binary under `server/<platform>-<arch>/`, built
+  with `vsce package --target <platform>`. The Marketplace serves each
+  client only the package matching its OS and architecture.
+- **One untargeted "universal" package** bundles all seven binaries (the
+  six above plus `linux-riscv64`), built with no `--target`. The
+  Marketplace falls back to this package for any client with no dedicated
+  targeted package — namely riscv64 Linux, since vsce has no `--target`
+  string for it — and it also serves as the package for a manual
+  "Install from VSIX" side-load.
+
+Either way, the extension launches whichever `server/<platform>-<arch>/`
+binary matches the user's machine; it needs no code to know which kind of
+package it shipped in.
 
 The Rust-target-to-bundle-directory map is the single source of truth in
 `SERVER_TARGET_MAP` in the [`Makefile`](../../Makefile). The bundle
 directory name equals Node's `process.platform-process.arch` — for
-example `aarch64-apple-darwin` ships as `server/darwin-arm64/`.
+example `aarch64-apple-darwin` ships as `server/darwin-arm64/` — and, for
+six of the seven, is also a valid vsce `--target` string (`VSCE_TARGETS`,
+also in the `Makefile`).
 
 ### Build locally
 
@@ -41,44 +56,61 @@ example `aarch64-apple-darwin` ships as `server/darwin-arm64/`.
 2. Smoke-test the binaries: `make server-cross-test` (native arches run
    directly, foreign Linux arches run under QEMU, and anything this host
    cannot run is skipped loudly).
-3. Package and verify: `make package-vsix`. This stages every built
-   binary into `server/<dir>/` and runs `make verify-vsix`, which fails
-   if the package contains a `.pyz` or is missing a requested binary.
+3. Package and verify the universal package: `make package-vsix`. This
+   stages every built binary into `server/<dir>/` and runs `make
+   verify-vsix`, which fails if the package contains a `.pyz` or is
+   missing a requested binary.
+4. Package and verify the six platform-targeted packages: `make
+   package-vsix-targets`. Each needs the corresponding native binary
+   already built (step 1); `SERVER_TARGET_MAP` resolves each platform
+   name to its triple.
 
-A local build produces a *partial*-universal `.vsix` covering only the
-targets your host can build. To bundle all seven, build every target
-first, then `make package-vsix BUNDLED_TARGETS="$(make -s
-print-server-targets-all)"`.
+A local `make package-vsix` produces a *partial*-universal `.vsix`
+covering only the targets your host can build. To bundle all seven,
+build every target first, then `make package-vsix
+BUNDLED_TARGETS="$(make -s print-server-targets-all)"`.
 
 ### Build for release
 
-The real release artefact is built by CI: the tag-triggered
+The real release artefacts are built by CI: the tag-triggered
 `build-server-matrix` job compiles all seven binaries on native runners
-(macOS, Ubuntu, and Windows), and `build-vsix` downloads them and
-packages one universal `.vsix`. See
+(macOS, Ubuntu, and Windows), and `build-vsix` downloads them, then runs
+both `make package-vsix BUNDLED_TARGETS="$(make -s
+print-server-targets-all)"` (the universal package) and `make
+package-vsix-targets` (the six targeted packages). See
 [`release-and-publish.md`](../design/contracts/release-and-publish.md).
-No marketplace token is used in CI — publishing stays on the
-maintainer's laptop via `make publish-vsix`.
+All seven publish to the VS Code Marketplace from CI's
+`publish-vsix-marketplace` job (`secrets.VSCE_PAT` on the protected
+`marketplace-vscode` Environment); `make publish-vsix
+publish-vsix-targets` remain laptop fallbacks for when that job fails.
 
 ### Add a new platform
 
 1. Add one `triple:dir` entry to `SERVER_TARGET_MAP` in the `Makefile`.
-2. Add the triple to the matching runner in the `build-server-matrix`
+2. If vsce supports a `--target` string for the new platform, add it to
+   `VSCE_TARGETS` too (also in the `Makefile`) so it gets its own
+   targeted package; otherwise it is covered only by the universal
+   fallback package, like riscv64 Linux today.
+3. Add the triple to the matching runner in the `build-server-matrix`
    matrix in [`ci.yml`](../../.github/workflows/ci.yml), and add any new
    cross-linker to `.cargo/config.toml`.
-3. Add the triple to `scripts/test-cross-server.sh` so it is
+4. Add the triple to `scripts/test-cross-server.sh` so it is
    smoke-tested.
 
 The extension needs no change: it derives the lookup directory from
-`process.platform-process.arch` at runtime.
+`process.platform-process.arch` at runtime, regardless of which package
+it was installed from.
 
 ## How to tell it worked
 
-`make package-vsix` ends with `==> VSIX bundles N/N native server
-binaries`, and `unzip -Z1 build/*.vsix | grep -E 'server/|\.pyz'` lists
-the `server/<dir>/tcl-lsp-server` entries with no `.pyz`. After
-installing the `.vsix`, the **Tcl Language Server** output channel shows
-`Rust mode: using native server .../server/<platform>-<arch>/tcl-lsp-server`,
+`make package-vsix` and each iteration of `make package-vsix-targets` end
+with `==> VSIX bundles N/N native server binaries`, and `unzip -Z1
+build/tcl-lsp-vscode-*-universal.vsix | grep -E 'server/|\.pyz'` lists
+the `server/<dir>/tcl-lsp-server` entries with no `.pyz` (swap in a
+`*-<platform>.vsix` filename to check a targeted package — it should list
+exactly one `server/<dir>/` entry). After installing any of the seven
+`.vsix` files, the **Tcl Language Server** output channel shows `Rust
+mode: using native server .../server/<platform>-<arch>/tcl-lsp-server`,
 and diagnostics and hovers work with no Python on the `PATH`.
 
 ## Related

--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -113,18 +113,21 @@ tasks {
         archiveBaseName.set("tcl-lsp-jetbrains")
     }
 
-    // Drop the bundled native LSP server binary under ``server/`` at the
-    // plugin root (next to ``lib/``) in the distribution so we can execute
-    // it directly from the install directory.  Putting it inside
-    // ``src/main/resources/`` would bundle it into the plugin jar, where it
-    // can't be spawned via a ``jar:file:...!/...`` URL and we'd be forced to
-    // extract to ``${tmpdir}`` at runtime (with a cache-invalidation dance on
-    // plugin upgrades — see ``TclLspServerDescriptor.findBundledServer``).
-    // Same pattern JetBrains' own Prisma ORM plugin uses to ship its native
+    // Drop one bundled native LSP server binary per platform under
+    // ``server/<platform>-<arch>/`` at the plugin root (next to ``lib/``)
+    // in the distribution — one universal plugin covering every platform
+    // except riscv64 Linux (``SERVER_TARGETS_JETBRAINS`` in the Makefile),
+    // the same ``<platform>-<arch>`` naming the VS Code extension uses.
+    // Putting it inside ``src/main/resources/`` would bundle it into the
+    // plugin jar, where it can't be spawned via a ``jar:file:...!/...`` URL
+    // and we'd be forced to extract to ``${tmpdir}`` at runtime (with a
+    // cache-invalidation dance on plugin upgrades — see
+    // ``TclLspServerDescriptor.findBundledServer``).  Same pattern
+    // JetBrains' own Prisma ORM plugin uses to ship its native
     // ``prisma-language-server`` binaries.  ``make build-editor-jetbrains``
-    // stages ``target/release/tcl-lsp-server`` here.
+    // stages the whole ``server/`` tree here.
     prepareSandbox {
-        from(layout.projectDirectory.file("server/tcl-lsp-server")) {
+        from(layout.projectDirectory.dir("server")) {
             into("$pluginName/server")
         }
     }

--- a/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerDescriptor.kt
+++ b/editors/jetbrains/src/main/kotlin/com/tcllsp/jetbrains/TclLspServerDescriptor.kt
@@ -26,6 +26,7 @@ import com.intellij.openapi.project.Project
 import com.intellij.openapi.util.SystemInfo
 import com.intellij.openapi.vfs.VirtualFile
 import com.intellij.platform.lsp.api.ProjectWideLspServerDescriptor
+import com.intellij.util.system.CpuArch
 import com.tcllsp.jetbrains.settings.TclLspSettings
 import org.eclipse.lsp4j.ConfigurationItem
 import java.io.File
@@ -77,10 +78,11 @@ class TclLspServerDescriptor(project: Project) :
         val serverBinary = findBundledServer()
         if (serverBinary == null) {
             notifyError(
-                "Tcl LSP: bundled server (${bundledServerName()}) not found. " +
-                "Set the server path in Settings > Tools > Tcl Language Server."
+                "Tcl LSP: bundled server (${bundledServerName()}) not found for " +
+                "platform ${bundledPlatformDir()}. Set the server path in " +
+                "Settings > Tools > Tcl Language Server."
             )
-            throw IllegalStateException("Bundled ${bundledServerName()} not found")
+            throw IllegalStateException("Bundled ${bundledServerName()} not found for ${bundledPlatformDir()}")
         }
 
         // JetBrains extracts plugin files without preserving the +x bit, so
@@ -109,6 +111,22 @@ class TclLspServerDescriptor(project: Project) :
     private fun bundledServerName(): String =
         if (SystemInfo.isWindows) "tcl-lsp-server.exe" else "tcl-lsp-server"
 
+    // Plugin bundle directory for the current platform, e.g. `darwin-arm64`,
+    // `linux-x64`, `win32-arm64` — matches SERVER_TARGET_MAP's bundle-dir
+    // naming (and the VS Code extension's `bundlePlatformDir()`) so both
+    // editors describe platforms the same way. The plugin is universal
+    // across every platform except riscv64 Linux (no official JetBrains IDE
+    // build targets it), so CpuArch's x86/ARM distinction is sufficient.
+    private fun bundledPlatformDir(): String {
+        val os = when {
+            SystemInfo.isWindows -> "win32"
+            SystemInfo.isMac -> "darwin"
+            else -> "linux"
+        }
+        val arch = if (CpuArch.isArm64()) "arm64" else "x64"
+        return "$os-$arch"
+    }
+
     // Locate a dev-checkout native server binary from the configured
     // ``serverPath``.  The path may point directly at the binary, or at a
     // checkout root under which we probe ``target/{release,debug}/`` for a
@@ -133,24 +151,28 @@ class TclLspServerDescriptor(project: Project) :
     }
 
     private fun findBundledServer(): String? {
-        // ``build.gradle.kts``'s ``prepareSandbox`` task copies the bundled
-        // native LSP server binary to ``server/tcl-lsp-server`` under the
-        // plugin install root (next to ``lib/``), so we can execute it
-        // directly from the install directory.  We deliberately avoid
-        // putting it inside the plugin jar (``src/main/resources/``) because
-        // an executable can't be spawned from a ``jar:file:...!/...`` URL
-        // and we'd have to extract on first use, then re-extract on every
-        // plugin upgrade (the bug fixed in PR #448).  Pattern matches
-        // JetBrains' own Prisma ORM plugin which ships its native
-        // ``prisma-language-server`` binaries the same way.
+        // ``build.gradle.kts``'s ``prepareSandbox`` task copies one bundled
+        // native LSP server binary per platform to
+        // ``server/<platform>-<arch>/tcl-lsp-server`` under the plugin
+        // install root (next to ``lib/``), so we can execute the one
+        // matching this machine directly from the install directory.  We
+        // deliberately avoid putting it inside the plugin jar
+        // (``src/main/resources/``) because an executable can't be spawned
+        // from a ``jar:file:...!/...`` URL and we'd have to extract on first
+        // use, then re-extract on every plugin upgrade (the bug fixed in PR
+        // #448).  Pattern matches JetBrains' own Prisma ORM plugin which
+        // ships its native ``prisma-language-server`` binaries the same way.
         val pluginDir = findPluginInstallDir() ?: return null
         val name = bundledServerName()
-        val server = File(pluginDir, "server/$name")
-        if (server.exists()) return server.absolutePath
-        // Defensive: tolerate an install layout that drops the binary at the
+        val platformServer = File(pluginDir, "server/${bundledPlatformDir()}/$name")
+        if (platformServer.exists()) return platformServer.absolutePath
+        // Defensive fallbacks: tolerate a flat server/<name> (pre-universal
+        // single-platform layout) or an install that drops the binary at the
         // plugin root or inside ``lib/``.  Shouldn't happen with the current
         // build but keeps a user's working install working if anyone changes
         // ``prepareSandbox``.
+        val flatServer = File(pluginDir, "server/$name")
+        if (flatServer.exists()) return flatServer.absolutePath
         val rootServer = File(pluginDir, name)
         if (rootServer.exists()) return rootServer.absolutePath
         val libServer = File(pluginDir, "lib/$name")

--- a/editors/vscode/src/extension.ts
+++ b/editors/vscode/src/extension.ts
@@ -194,7 +194,8 @@ const RUST_SERVER_EXE = process.platform === "win32" ? "tcl-lsp-server.exe" : "t
 
 // VSIX bundle directory for the current platform, e.g. `darwin-arm64`,
 // `linux-x64`, `linux-riscv64`, `win32-arm64`.  Node's `process.platform` /
-// `process.arch` map 1:1 onto the directory names the universal VSIX ships
+// `process.arch` map 1:1 onto the directory names every VSIX (the
+// universal package and each of the six platform-targeted packages) ships
 // under `server/<platform>-<arch>/` (and onto VS Code's own target slugs).
 function bundlePlatformDir(): string {
   return `${process.platform}-${process.arch}`;
@@ -221,7 +222,9 @@ function resolveRustServer(
   // keep getting the packaged binary.  Only consult the bundled binary when no
   // serverPath is set.
   if (!configuredServerPath.trim()) {
-    // Packaged install: the universal VSIX bundles one binary per platform.
+    // Packaged install: whichever VSIX this is (the universal package, or
+    // one of the six platform-targeted packages), it ships this platform's
+    // binary at the same server/<platform>-<arch>/ path.
     const bundled = path.join(extensionPath, "server", bundlePlatformDir(), RUST_SERVER_EXE);
     if (existsSync(bundled)) {
       return bundled;

--- a/scripts/release/vsce_publish.sh
+++ b/scripts/release/vsce_publish.sh
@@ -17,8 +17,8 @@
 #
 # SPDX-License-Identifier: AGPL-3.0-or-later
 
-# vsce_publish.sh — publish an already-built VSIX to the VS Code Marketplace
-# using the local (committed-lockfile) vsce binary.
+# vsce_publish.sh — publish every already-built VSIX to the VS Code
+# Marketplace using the local (committed-lockfile) vsce binary.
 #
 # Invoked by the `publish-vsix-marketplace` job in .github/workflows/ci.yml
 # with VSCE_PAT in the environment (an approval-gated marketplace-vscode
@@ -28,10 +28,16 @@
 # workflow stays thin and this credential-adjacent step is reviewable in one
 # place.
 #
-# Usage:  scripts/release/vsce_publish.sh [TAG] [VSIX]
-#         TAG  defaults to the tag in $GITHUB_REF (refs/tags/<TAG>).
-#         VSIX defaults to the single *.vsix under dist/ (downloaded and
-#              checksum-verified by the workflow before this runs).
+# Usage:  scripts/release/vsce_publish.sh [TAG] [VSIX...]
+#         TAG   defaults to the tag in $GITHUB_REF (refs/tags/<TAG>).
+#         VSIX  defaults to every *.vsix under dist/ (downloaded and
+#               checksum-verified by the workflow before this runs): the
+#               untargeted universal package plus six platform-targeted
+#               ones.  Each targeted package already carries its target
+#               platform in the vsix manifest (baked in by `vsce package
+#               --target` at build time), so publish never passes --target
+#               again — see "Platform-specific extensions" in the VS Code
+#               publishing docs.
 #
 # Authenticates via VSCE_PAT, which `vsce publish` reads from the environment
 # (the keyless Azure/OIDC path was rolled back after it proved unreliable).
@@ -45,7 +51,14 @@ set -euo pipefail
 
 here="$(cd "$(dirname "$0")" && pwd)"
 tag="${1:-${GITHUB_REF#refs/tags/}}"
-vsix="${2:-$(ls dist/*.vsix)}"
+if [ "$#" -gt 0 ]; then
+    shift
+fi
+if [ "$#" -gt 0 ]; then
+    vsixes=("$@")
+else
+    vsixes=(dist/*.vsix)
+fi
 
 prerelease_flag=""
 if [ "$(bash "$here/prerelease.sh" "$tag")" = "true" ]; then
@@ -54,5 +67,7 @@ if [ "$(bash "$here/prerelease.sh" "$tag")" = "true" ]; then
 fi
 
 : "${VSCE_PAT:?VSCE_PAT must be set (marketplace-vscode Environment secret)}"
-echo "Publishing $vsix via vsce (VSCE_PAT)"
-editors/vscode/node_modules/.bin/vsce publish $prerelease_flag --packagePath "$vsix"
+for vsix in "${vsixes[@]}"; do
+    echo "Publishing $vsix via vsce (VSCE_PAT)"
+    editors/vscode/node_modules/.bin/vsce publish $prerelease_flag --packagePath "$vsix"
+done


### PR DESCRIPTION
## Summary

**VS Code**
- Now ships 6 additional platform-targeted VSIX packages (`win32-x64`, `win32-arm64`, `linux-x64`, `linux-arm64`, `darwin-x64`, `darwin-arm64`) built with `vsce package --target <platform>`, so the Marketplace serves each client only its own binary instead of the full 7-platform bundle.
- The existing universal package is renamed to `tcl-lsp-vscode-<version>-universal.vsix` and kept as the Marketplace fallback for riscv64 Linux (vsce has no `--target` string for it) and as the artefact for a manual "Install from VSIX" side-load.
- `Makefile`: new `package-vsix-targets` / `build-editor-vsix-targets` / `publish-vsix-targets` reuse the existing `$(VSIX_FILE)`/`verify-vsix` rule via recursive `make` calls that override `BUNDLED_TARGETS`/`VSCE_TARGET`/`VSIX_FILE` per platform. `release`/`release-sums`/`publish-all`/`build-editors` updated so local parity builds still cover every artefact.
- `ci.yml`: `build-vsix` now builds, attests, and uploads all seven VSIX packages. `scripts/release/vsce_publish.sh` now loops over every downloaded `.vsix` instead of assuming one.

**JetBrains**
- Previously bundled a single Linux-x64 binary with no per-platform layout at all — macOS/Windows/ARM users had no working install. Now bundles one binary per platform under `server/<platform>-<arch>/` (same layout/`SERVER_TARGET_MAP` as the VS Code universal VSIX), covering everything except riscv64 Linux (no official JetBrains IDE build targets it).
- `TclLspServerDescriptor.bundledPlatformDir()` picks the matching binary at runtime via `SystemInfo` + `CpuArch`, mirroring the VS Code extension's `bundlePlatformDir()`. `build.gradle.kts`'s `prepareSandbox` now copies the whole `server/` tree instead of one fixed file.
- `ci.yml`'s `build-jetbrains` now downloads `build-server-matrix`'s cross-compiled binaries instead of building only the host's own, and no longer needs a Rust toolchain step.
- JetBrains Marketplace has no per-platform-target equivalent of vsce's `--target` yet (confirmed via JetBrains' own community forum — a proof-of-concept exists internally but isn't shipped), so "bundle everything in one universal plugin" is the right model here, unlike VS Code.

**Also fixes two bugs a Codex review caught on this PR's first commit:**
- `publish-vsix-targets` referenced `$VSCE_PAT` unguarded under `set -u`, so the documented no-PAT/keyless-Azure fallback path aborted instead of running when `VSCE_PAT` was genuinely unset (not just empty). Fixed with `${VSCE_PAT:-}`.
- `package-vsix` and `package-vsix-targets` both stage through the shared `$(STAGE_DIR)`; as unordered sibling prerequisites of `release`, `make -j release` could run them concurrently and race. Added an explicit `package-vsix-targets: package-vsix` dependency edge to serialize them.

Sublime is intentionally untouched in this change (planned direction: download-on-demand, similar to how Zed already works, since Sublime — like JetBrains until now — has no platform-specific-package mechanism either).

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `make check-all` (full TypeScript + Rust + Python lint/typecheck) — passed clean, re-run after every batch of changes.
  - VS Code: built the native `tcl-lsp-server` release binary locally and ran the real packaging flow — `make package-vsix BUNDLED_TARGETS="x86_64-unknown-linux-gnu" VSCE_TARGET="linux-x64" VSIX_FILE=".../test-linux-x64.vsix"` — confirmed exactly one `server/linux-x64/tcl-lsp-server` entry and `TargetPlatform="linux-x64"` in the manifest; confirmed the untargeted universal package builds with no `TargetPlatform` attribute.
  - JetBrains: confirmed the Makefile staging change lands the binary at `server/linux-x64/tcl-lsp-server` (not the old flat path). Could **not** run a full `./gradlew buildPlugin` in this sandbox — its pinned Gradle 9.6.0 wrapper download is blocked by this session's egress policy, and the pre-installed Gradle 8.14.3 is below the `intellij-platform` Gradle plugin's 9.0 floor. The Kotlin/Gradle changes rely on manual review plus CI's `build-jetbrains` job, which has full network access — watching this PR's CI for that.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No, this change is build/CI/packaging only; it does not touch compiler, diagnostic, or analysis behaviour.
