### PR TITLE
Release v2.1.12 notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,44 +1,68 @@
-# v2.1.11
+# v2.1.12
 
 **2.x alpha — pre-release channel.**
 
-A small follow-up pre-release on the **2.x** line, where the ongoing Python →
-Rust rewrite of tcl-lsp ships its alphas. It is opt-in: install it from the
-VS Code Marketplace **pre-release** channel or the JetBrains Marketplace
-**eap** channel, or download the pre-release VSIX / plugin / native binaries
-from this GitHub release. The stable **1.x** line stays the default for
-everyone who has not opted into pre-releases, and a `2.1.x` build never
-becomes the "latest" GitHub release or the default Marketplace download.
+Another pre-release on the **2.x** line, where the ongoing Python → Rust
+rewrite of tcl-lsp ships its alphas. It is opt-in: install it from the VS Code
+Marketplace **pre-release** channel or the JetBrains Marketplace **eap**
+channel, or download the pre-release VSIX / plugin / native binaries from this
+GitHub release. The stable **1.x** line stays the default for everyone who has
+not opted into pre-releases, and a `2.1.x` build never becomes the "latest"
+GitHub release or the default Marketplace download.
 
-This release addresses five Tcl name-resolution reports filed against
-v2.1.10's TclOO / `apply` / `expr` handling in the Rust LSP. Four needed a
-fix, covered below; the fifth (`$obj method` references) was already correct
-and only gained regression coverage.
+This release continues the issue #923 differential-audit campaign — a
+tclsh-vs-analyser sweep across tricky TclOO, namespace, and `interp` idioms —
+landing six more confirmed fixes to reference resolution, go-to-definition,
+and rename. It also adds platform-targeted packaging for VS Code and
+JetBrains.
+
+## New Features
+
+- **VS Code: platform-targeted VSIX packages.** The Marketplace now serves
+  six small, single-binary VSIX packages (Windows, Linux, and macOS, each on
+  x64/arm64) alongside the existing universal package, so most installs pull
+  down one platform's binary instead of the full multi-platform bundle. The
+  universal VSIX remains available for riscv64 Linux and manual
+  "Install from VSIX" side-loading.
+- **JetBrains: the plugin bundles a native server for every supported
+  platform.** Previously it shipped only a Linux x64 binary regardless of
+  the host, so macOS, Windows, and ARM users had no working install. The
+  plugin now bundles one binary per platform (matching the VS Code universal
+  build) and picks the right one at runtime.
 
 ## Bug Fixes
 
-- **Bare single-name parameter lists are highlighted correctly.** An
-  unbraced argument list — for example `apply {dir {…}}`, `proc unknown
-  args {…}`, or a snit `method`/`typemethod` declaration — was painted as a
-  plain string instead of being recognised as a parameter declaration.
-  Braced argument lists (`{a b}`) were already correct and are unaffected.
-- **`pkgIndex.tcl`'s implicit `$dir` no longer flags as read-before-set.**
-  The package loader sets `dir` before a `pkgIndex.tcl` script runs, so
-  reading it there is always safe. The suppression is scoped to files
-  literally named `pkgIndex.tcl`; other undefined reads there, and `$dir`
-  reads elsewhere, still flag as before.
-- **`my method` dispatch nested in a command substitution is found again.**
-  A call such as `return [my getOptions $key]` was previously missed by
-  find references and the member reference-count lens; it now resolves at
-  parity with a top-level `my` call.
-- **`::tcl::mathfunc::<fn>` functions used inside a nested `expr` are
-  tracked.** `[expr {Foo()}]` written inside a command substitution
-  previously recorded no invocation of the backing proc, so references,
-  rename, and arity checking missed it.
-- **`my`/`$obj` method dispatch is found inside compound and quoted words.**
-  A call embedded in a bareword or double-quoted compound word — for
-  example `return "opts: [my get]"` or `[$b get]-tail` — was missed because
-  the segmenter merges such a word into a single token; references and
-  rename now recover the nested `[…]` call from both quoted and compound
-  words. A literal `[…]` inside a braced `{…}` word is correctly left
-  untouched.
+- **`superclass`, `mixin`, and (incr Tcl) `inherit` targets are tracked as
+  class references.** Find All References on a base class previously
+  returned only its own declaration, missing every subclass that named it,
+  and renaming a class left those subclasses dangling. Covers TclOO,
+  `oo::configurable`, `[incr Tcl]`, `self mixin`, `oo::objdefine mixin`, and
+  `forward` targets, cross-file.
+- **Fully- and relatively-qualified namespace variable references now
+  resolve.** Hover, go-to-definition, references, and rename never resolved
+  a `::`-qualified variable read like `$::ns::var` or `$ns::var` at all;
+  they now resolve via the same namespace-path lookup already used for
+  qualified command resolution.
+- **Definition spans for the second and later parameters in a parameter
+  list are correct again.** Every parameter after the first in a
+  proc/`apply`/TclOO-method parameter list previously lost its own
+  definition span and fell back to pointing at the proc or method name.
+- **A definition nested inside another proc or class body no longer
+  outranks a real builtin of the same name.** The "rename the builtin away,
+  install a same-named shadow, restore it" idiom was permanently shadowing
+  the builtin for every call site in the workspace, including ones that run
+  after the shadow is renamed back off.
+- **`interp create -safe NAME` and `NAME eval {...}` are tracked
+  correctly.** The created interpreter's name was never registered as a
+  known command (causing false-positive "unknown command" diagnostics), and
+  the handle-call spelling of `interp eval` (`NAME eval {...}`, the more
+  common form in real code) was not isolated from same-named procs in
+  unrelated interpreters. Renaming or deleting an interpreter's handle
+  command now correctly retires its tracked state.
+- **Dynamic (`$var`) `namespace eval` and `oo::define` targets no longer
+  merge unrelated call sites that happen to reuse a variable name.** Two
+  lexically unrelated `namespace eval $name {...}` or `oo::define $class
+  ...` sites sharing a variable name previously collapsed into the same
+  scope, so go-to-definition/references from one could jump into a
+  completely unrelated proc, and `oo::define` could merge methods from
+  unrelated call sites into one class's document-symbol range.


### PR DESCRIPTION
## Summary

- Add `RELEASE_NOTES.md` for the v2.1.12 pre-release (patch bump from v2.1.11): six more confirmed fixes from the issue #923 differential-audit campaign (class-reference resolution for `superclass`/`mixin`/`inherit`, qualified namespace variable resolution, multi-parameter definition spans, nested-shadow vs. builtin resolution, `interp create -safe`/`NAME eval` tracking, dynamic namespace/class target isolation), plus platform-targeted VSIX packaging for VS Code and universal server bundling for JetBrains.
- Tag-only release process — no source changes in this PR, `RELEASE_NOTES.md` only.

## Validation

- [x] No source changes; content is a summary of the merged PRs since v2.1.11 (#961, #962, #963), all of which passed CI on `rust`.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] N/A — release notes only, no compiler/diagnostic/analysis contract changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FtJurxb8S5LsHpFb4bTRp8)_