### PR TITLE
fix(jetbrains): resolve pluginName lazily in prepareSandbox into()

### DIFF
--- a/editors/jetbrains/build.gradle.kts
+++ b/editors/jetbrains/build.gradle.kts
@@ -128,7 +128,7 @@ tasks {
     // stages the whole ``server/`` tree here.
     prepareSandbox {
         from(layout.projectDirectory.dir("server")) {
-            into("$pluginName/server")
+            into(pluginName.map { "$it/server" })
         }
     }
 }


### PR DESCRIPTION
## Summary

- The `v2.1.12` tag's `build-jetbrains` CI job failed `verify-jetbrains-server`: the built plugin zip (145K) was missing all six bundled native server binaries, even though `make build-editor-jetbrains` staged them correctly under `editors/jetbrains/server/<platform>-<arch>/` before invoking Gradle.
- Root cause: `into("$pluginName/server")` in `prepareSandbox` interpolates `pluginName` — a Gradle `Provider<String>`, not a plain `String` — via Kotlin string-template `.toString()` at configuration time, before the provider resolves. The staged files landed under a bogus directory name instead of the real `<pluginName>/server` path that `buildPlugin` archives, so they silently never reached the distributable zip despite `prepareSandbox` reporting success.
- Fix: resolve the provider lazily, matching JetBrains' own documented ["Bundling Extra Files"](https://plugins.jetbrains.com/docs/intellij/tools-intellij-platform-gradle-plugin-recipes.html) recipe for the IntelliJ Platform Gradle Plugin 2.x, which uses the identical `pluginName.map { "$it/extra" }` form.

## Validation

- [ ] Could not run `./gradlew buildPlugin` locally — this session's egress policy blocks the pinned Gradle 9.6.0 wrapper distribution download (the same restriction noted in PR #961). `build-jetbrains` only runs on tag pushes (`if: startsWith(github.ref, 'refs/tags/v')`, `needs: [create-release, build-server-matrix]`), so there's no cheap way to exercise it outside a real release tag — verifying this fix is part of cutting `v2.1.13`.
- [x] Confirmed the fix matches the exact pattern in JetBrains' own official recipe docs, and confirmed no other occurrence of the same `$pluginName`-interpolation anti-pattern exists elsewhere in the Gradle build.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] N/A — JetBrains Gradle packaging only, no compiler/diagnostic/analysis contract changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FtJurxb8S5LsHpFb4bTRp8)_