### PR TITLE
Release v2.1.13 notes

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,4 +1,4 @@
-# v2.1.12
+# v2.1.13
 
 **2.x alpha — pre-release channel.**
 
@@ -10,11 +10,14 @@ GitHub release. The stable **1.x** line stays the default for everyone who has
 not opted into pre-releases, and a `2.1.x` build never becomes the "latest"
 GitHub release or the default Marketplace download.
 
-This release continues the issue #923 differential-audit campaign — a
+v2.1.12's JetBrains build failed its own packaging check, which correctly
+blocked *both* the VS Code and JetBrains Marketplace publishes for that tag —
+so nothing from that cycle reached either Marketplace. This release fixes
+the JetBrains packaging bug and otherwise carries the same content forward:
+six more confirmed fixes from the issue #923 differential-audit campaign — a
 tclsh-vs-analyser sweep across tricky TclOO, namespace, and `interp` idioms —
-landing six more confirmed fixes to reference resolution, go-to-definition,
-and rename. It also adds platform-targeted packaging for VS Code and
-JetBrains.
+to reference resolution, go-to-definition, and rename, plus platform-targeted
+packaging for VS Code and JetBrains.
 
 ## New Features
 
@@ -32,6 +35,14 @@ JetBrains.
 
 ## Bug Fixes
 
+- **JetBrains plugin packaging includes the bundled native server binaries
+  again.** v2.1.12's plugin build silently produced a package missing all
+  six platform binaries: `prepareSandbox`'s `into("$pluginName/server")`
+  stringified an unresolved Gradle provider instead of the plugin name,
+  so the staged binaries landed under the wrong directory and never made
+  it into the distributable zip. The plugin's own packaging check caught
+  this and failed the build rather than shipping a broken package, which
+  is why v2.1.12 never reached the JetBrains or VS Code Marketplace.
 - **`superclass`, `mixin`, and (incr Tcl) `inherit` targets are tracked as
   class references.** Find All References on a base class previously
   returned only its own declaration, missing every subclass that named it,

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -11,9 +11,10 @@ not opted into pre-releases, and a `2.1.x` build never becomes the "latest"
 GitHub release or the default Marketplace download.
 
 v2.1.12's JetBrains build failed its own packaging check, which correctly
-blocked *both* the VS Code and JetBrains Marketplace publishes for that tag —
-so nothing from that cycle reached either Marketplace. This release fixes
-the JetBrains packaging bug and otherwise carries the same content forward:
+blocked the JetBrains Marketplace publish for that tag (the VS Code
+Marketplace publish is gated independently of the JetBrains build and was
+unaffected by this bug). This release fixes the JetBrains packaging bug and
+otherwise carries the same content forward:
 six more confirmed fixes from the issue #923 differential-audit campaign — a
 tclsh-vs-analyser sweep across tricky TclOO, namespace, and `interp` idioms —
 to reference resolution, go-to-definition, and rename, plus platform-targeted
@@ -42,7 +43,7 @@ packaging for VS Code and JetBrains.
   so the staged binaries landed under the wrong directory and never made
   it into the distributable zip. The plugin's own packaging check caught
   this and failed the build rather than shipping a broken package, which
-  is why v2.1.12 never reached the JetBrains or VS Code Marketplace.
+  is why v2.1.12 never reached the JetBrains Marketplace.
 - **`superclass`, `mixin`, and (incr Tcl) `inherit` targets are tracked as
   class references.** Find All References on a base class previously
   returned only its own declaration, missing every subclass that named it,


### PR DESCRIPTION
## Summary

- Add `RELEASE_NOTES.md` for the v2.1.13 pre-release (patch bump from v2.1.12): fixes the JetBrains plugin packaging bug (#965) that caused `build-jetbrains` to fail on the v2.1.12 tag, which in turn blocked both the VS Code and JetBrains Marketplace publishes for that cycle. Otherwise carries forward the same v2.1.12 content (six issue #923 differential-audit fixes, platform-targeted VSIX/JetBrains packaging), now with working JetBrains bundling.
- Tag-only release process — no source changes in this PR, `RELEASE_NOTES.md` only.

## Validation

- [x] No source changes; content summarizes the fix merged in #965 plus the carried-forward v2.1.12 changes (#961, #962, #963).

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] N/A — release notes only, no compiler/diagnostic/analysis contract changes.


---
_Generated by [Claude Code](https://claude.ai/code/session_01FtJurxb8S5LsHpFb4bTRp8)_