### PR TITLE
fix(lsp): classmethod codeLens + reference fixes (issue #956)

### DIFF
--- a/.claude/skills/lsp-client/SKILL.md
+++ b/.claude/skills/lsp-client/SKILL.md
@@ -2,10 +2,10 @@
 name: lsp-client
 description: >
   Use when verifying Tcl LSP server behavior: semantic tokens, diagnostics,
-  formatting, hover, completion, definition, references, code actions,
-  optimizations, document symbols, diagram extraction, event/command registry
-  lookups, or benchmarking server performance and collecting timing logs.
-  Tests the server directly over JSON-RPC without VS Code.
+  formatting, hover, completion, definition, references, code lenses, code
+  actions, optimizations, document symbols, diagram extraction, event/command
+  registry lookups, or benchmarking server performance and collecting timing
+  logs. Tests the server directly over JSON-RPC without VS Code.
 allowed-tools: Bash, Read
 ---
 
@@ -37,6 +37,7 @@ The script auto-detects the `tcl-lsp/` server directory.  Override with
 | `completion` | `<file.tcl> <line> <col>` | Show completions at a 0-based position |
 | `definition` | `<file.tcl> <line> <col>` | Show go-to-definition locations |
 | `references` | `<file.tcl> <line> <col>` | Show all reference locations |
+| `code-lens` | `<file.tcl>` | Show code lenses (reference-count lenses), auto-resolving each via `codeLens/resolve` |
 | `code-actions` | `<file.tcl> <l> <c> <el> <ec>` | Show code actions in a 0-based range |
 | `optimize` | `<file.tcl>` | Show optimization suggestions and rewritten source |
 | `symbols` | `<file.tcl>` | Show document symbol hierarchy (procs, events, namespaces, variables) |
@@ -149,6 +150,22 @@ Shows the markdown content the editor would display on hover.
 ### Completions
 Shows label, kind (Keyword, Function, Variable), and detail.
 
+### Code Lenses
+Shows every reference-count lens, resolved.  Proc / class / method /
+classmethod lenses are all returned lazily (range + `data`, no `command`)
+so the server can recompute the count at resolve time — `code-lens` calls
+`codeLens/resolve` on each one automatically, the way a real editor does,
+rather than showing the raw unresolved list:
+```
+=== Code Lenses (2 lenses) ===
+  0:17-0:20  '1 reference'  [tcl-lsp.showReferences, 3 args]
+  6:11-6:14  '1 reference'  [tcl-lsp.showReferences, 3 args]
+```
+A lens whose `command` carries an empty command id renders as
+`[inert — empty command id]` — a lens in that shape is clickable-broken
+(the "reference is not active" defect, #724 / #956): it shows a count but
+does nothing when clicked.
+
 ### Bench
 Measures wall-clock time from request to semantic token response, plus
 server-side timing breakdown from `[timing]` log entries:
@@ -201,6 +218,7 @@ to filter to just `[timing]` entries for performance analysis.
 python3 .claude/skills/lsp-client/lsp_client.py semantic-tokens tcl-lsp/samples/for_screenshots/03-completions.tcl
 python3 .claude/skills/lsp-client/lsp_client.py diagnostics tcl-lsp/editors/vscode/testFixture/diagnostics.tcl
 python3 .claude/skills/lsp-client/lsp_client.py hover tcl-lsp/editors/vscode/testFixture/procs.tcl 1 6
+python3 .claude/skills/lsp-client/lsp_client.py code-lens tcl-lsp/editors/vscode/testFixture/objMethodDispatch.tcl
 python3 .claude/skills/lsp-client/lsp_client.py optimize tcl-lsp/samples/for_screenshots/22-optimiser-before.tcl
 python3 .claude/skills/lsp-client/lsp_client.py symbols tcl-lsp/samples/for_screenshots/ai-scene.irul
 python3 .claude/skills/lsp-client/lsp_client.py diagram tcl-lsp/samples/for_screenshots/ai-scene.irul

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -1048,6 +1048,64 @@ def cmd_references(client: LspClient, uri: str, line: int, col: int) -> None:
     print_locations(result, "References")
 
 
+def print_code_lenses(lenses: list[dict] | None) -> None:
+    """Print code-lens results, one line per lens.
+
+    Shows the anchor range, the resolved title when the lens carries a
+    `command`, and `(unresolved)` plus the `data` payload when it does
+    not — the lazy shape a proc/class/method/classmethod reference-count
+    lens takes before the client calls `codeLens/resolve` (see
+    `cmd_code_lens`, which resolves every lens automatically).
+    """
+    if not lenses:
+        lenses = []
+    print(f"=== Code Lenses ({len(lenses)} lenses) ===")
+    if not lenses:
+        print("  (none)")
+        return
+    for lens in lenses:
+        r = lens.get("range", {})
+        s = r.get("start", {})
+        e = r.get("end", {})
+        pos = f"{s.get('line', 0)}:{s.get('character', 0)}-{e.get('line', 0)}:{e.get('character', 0)}"
+        command = lens.get("command")
+        if command:
+            title = command.get("title", "?")
+            cmd_name = command.get("command", "")
+            if cmd_name:
+                arg_count = len(command.get("arguments") or [])
+                print(f"  {pos}  {title!r}  [{cmd_name}, {arg_count} args]")
+            else:
+                print(f"  {pos}  {title!r}  [inert — empty command id]")
+        else:
+            data = lens.get("data", {})
+            print(f"  {pos}  (unresolved)  data={data!r}")
+
+
+def cmd_code_lens(client: LspClient, uri: str) -> None:
+    """Request code lenses, then resolve every unresolved one.
+
+    Proc / class / method / classmethod reference-count lenses are
+    returned lazily (range + `data`, no `command`) so the server can
+    recompute the count against the live document at resolve time; a
+    real editor always calls `codeLens/resolve` before display, so this
+    mirrors that round-trip instead of only showing the raw lazy list.
+    """
+    lenses = client.send_request(
+        "textDocument/codeLens", {"textDocument": {"uri": uri}}
+    )
+    if not lenses:
+        print_code_lenses(lenses)
+        return
+    resolved = []
+    for lens in lenses:
+        if lens.get("command"):
+            resolved.append(lens)
+        else:
+            resolved.append(client.send_request("codeLens/resolve", lens))
+    print_code_lenses(resolved)
+
+
 def cmd_code_actions(
     client: LspClient,
     uri: str,
@@ -1530,6 +1588,12 @@ examples:
     p.add_argument("line", type=int, help="Line (0-based)")
     p.add_argument("col", type=int, help="Column (0-based)")
 
+    # code-lens
+    p = sub.add_parser(
+        "code-lens", help="Show code lenses (reference-count lenses), resolved"
+    )
+    p.add_argument("file", help="Tcl file to analyze")
+
     # code-actions
     p = sub.add_parser("code-actions", help="Show code actions in a range")
     p.add_argument("file", help="Tcl file")
@@ -1683,6 +1747,8 @@ examples:
                     cmd_definition(client, uri, args.line, args.col)
                 case "references":
                     cmd_references(client, uri, args.line, args.col)
+                case "code-lens":
+                    cmd_code_lens(client, uri)
                 case "code-actions":
                     cmd_code_actions(
                         client, uri, args.line, args.col, args.end_line, args.end_col

--- a/README.md
+++ b/README.md
@@ -384,9 +384,12 @@ puts [add 3 4]           ;# ← reference to 'add'
 References follow `TclOO` dispatch, too. A method is found through every
 `$obj method` call on a tracked instance, every intra-class `my method`
 dispatch, and `next` / `nextto` super-dispatch — including calls nested in a
-`[…]` substitution or embedded in a quoted / compound word. Expr math
-functions resolve to their backing proc, so a `proc ::tcl::mathfunc::foo` is
-found (and renamed) from every `foo(...)` used inside `expr`.
+`[…]` substitution or embedded in a quoted / compound word. A `classmethod`
+dispatches on the class's own command rather than an instance, so it is found
+through every bare `ClassName method` call, including from a subclass's own
+command when the subclass inherits (does not override) the classmethod. Expr
+math functions resolve to their backing proc, so a `proc ::tcl::mathfunc::foo`
+is found (and renamed) from every `foo(...)` used inside `expr`.
 
 A class is found through every use of its name, not only `<Class> new`. A
 `superclass`, `mixin`, or `[incr Tcl]` `inherit` argument that names the class

--- a/docs/kcs/features/kcs-feature-code-lens.md
+++ b/docs/kcs/features/kcs-feature-code-lens.md
@@ -5,7 +5,8 @@
 
 ## Summary
 
-Reference counts shown above each proc definition. Click the lens to find all references.
+Reference counts shown above each proc, class, TclOO method, and classmethod
+definition. Click the lens to find all references.
 
 ## Applies to
 
@@ -13,11 +14,16 @@ all-editors, analyser
 
 ## Question
 
-What are the numbers that appear above my proc definitions?
+What are the numbers that appear above my proc, class, and method definitions?
 
 ## How to use
 
-Code lenses appear automatically above every `proc` definition in a Tcl or iRules file. Each lens shows how many references exist to that proc across the current file (and the workspace, if indexing is enabled). Click the lens to open the Find References panel.
+Code lenses appear automatically above every `proc` definition, every
+`oo::class create` declaration, and every TclOO `method` / `classmethod`
+inside a class body, in a Tcl or iRules file. Each lens shows how many
+references exist to that symbol across the current file (and the workspace,
+for procs and classes, if indexing is enabled). Click the lens to open the
+Find References panel.
 
 No configuration is needed. The feature can be toggled with `tclLsp.features.codeLens`.
 
@@ -30,9 +36,24 @@ proc greet {name} {          ;# "2 references" appears above this line
 
 greet "Alice"                 ;# reference 1
 greet "Bob"                   ;# reference 2
+
+oo::class create Factory {
+    method get {} { return 1 }       ;# "1 reference" — the $f get call below
+    classmethod make {} { return [Factory new] }  ;# "1 reference" — Factory make
+}
+set f [Factory new]
+$f get
+Factory make
 ```
 
 The lens updates as you type. If you rename or remove a call, the count adjusts on the next keystroke.
+
+## Failure modes
+
+- A method / classmethod lens above a TclOO member always resolves to a
+  clickable command, the same as a proc or class lens — a lens that shows a
+  count but does nothing when clicked is a bug (issues #724, #956), not
+  expected behaviour.
 
 ## Related
 

--- a/docs/kcs/features/kcs-feature-code-lens.md
+++ b/docs/kcs/features/kcs-feature-code-lens.md
@@ -54,6 +54,10 @@ The lens updates as you type. If you rename or remove a call, the count adjusts 
   clickable command, the same as a proc or class lens — a lens that shows a
   count but does nothing when clicked is a bug (issues #724, #956), not
   expected behaviour.
+- A `method` and a `classmethod` sharing the same name on one class are
+  counted and resolved independently — the method's lens never picks up the
+  classmethod's `ClassName foo` dispatch sites (or vice versa), even though
+  both are legal, separate members.
 
 ## Related
 

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -22,7 +22,7 @@ all-editors, MCP, analyser
 
 Locates all usages of the symbol under the cursor, including definitions, calls, and variable reads/writes. Uses shared proc-reference matching.
 
-TclOO dispatch is followed as well. A method is found through every `$obj method` call on a tracked instance, every intra-class `my method` dispatch, and `next` / `nextto` super-dispatch, whether the call sits at the top level of a body, inside a `[…]` command substitution, or embedded in a quoted or compound word such as `"value: [my get]"`. An expr math function resolves to its backing proc, so a `proc ::tcl::mathfunc::foo` is found from every `foo(...)` written inside an `expr`.
+TclOO dispatch is followed as well. A method is found through every `$obj method` call on a tracked instance, every intra-class `my method` dispatch, and `next` / `nextto` super-dispatch, whether the call sits at the top level of a body, inside a `[…]` command substitution, or embedded in a quoted or compound word such as `"value: [my get]"`. A `classmethod` is dispatched differently — on the class's own command, never on an instance — so its references are every bare `ClassName method` call, including from a subclass's own command when the subclass inherits (does not override) the classmethod. An expr math function resolves to its backing proc, so a `proc ::tcl::mathfunc::foo` is found from every `foo(...)` written inside an `expr`.
 
 A class is found through every use of its name, not only `<Class> new` instantiations: a `superclass`, `mixin`, or `[incr Tcl]` `inherit` argument that names the class is a reference to it, and a `forward` member's delegated command is a reference to that command. These references are resolved by the class's namespace exactly as a call would be, so a fully-qualified `superclass ::ns::Base` in one file is found from `::ns::Base`'s declaration in another, and a same-named class in an unrelated namespace is never cross-linked. Because the same references drive rename, renaming a class rewrites every `superclass` / `mixin` / `inherit` site that names it, keeping the inheritance graph intact.
 
@@ -44,7 +44,8 @@ double-quoted string.
 
 ## File-path anchors
 
-- `rust/tcl-lsp-core/src/references.rs`
+- `rust/tcl-lsp-core/src/references.rs` (`find_obj_method_call_sites` —
+  instance dispatch plus a classmethod's own-class-command dispatch)
 - `rust/tcl-lsp-core/src/definition.rs` (shared namespace-aware resolvers)
 - `rust/tcl-compiler/src/analyser/oo.rs` (`record_member_command_references` —
   `superclass` / `mixin` / `inherit` / `forward` as command references)
@@ -57,6 +58,9 @@ double-quoted string.
 ## Test anchors
 
 - `rust/tcl-lsp-core/tests/references_residual.rs`
+- `rust/tcl-lsp-core/tests/name_resolution.rs` (`classmethod_dispatch`,
+  `obj_method_dispatch` — TP/FP/TN/FN matrix, including issue #956's exact
+  repro)
 - `rust/tcl-lsp-server/tests/e2e/issue923_class_refs.rs` (cross-file)
 
 ## Screenshots

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -22,7 +22,7 @@ all-editors, MCP, analyser
 
 Locates all usages of the symbol under the cursor, including definitions, calls, and variable reads/writes. Uses shared proc-reference matching.
 
-TclOO dispatch is followed as well. A method is found through every `$obj method` call on a tracked instance, every intra-class `my method` dispatch, and `next` / `nextto` super-dispatch, whether the call sits at the top level of a body, inside a `[…]` command substitution, or embedded in a quoted or compound word such as `"value: [my get]"`. A `classmethod` is dispatched differently — on the class's own command, never on an instance — so its references are every bare `ClassName method` call, including from a subclass's own command when the subclass inherits (does not override) the classmethod. An expr math function resolves to its backing proc, so a `proc ::tcl::mathfunc::foo` is found from every `foo(...)` written inside an `expr`.
+TclOO dispatch is followed as well. A method is found through every `$obj method` call on a tracked instance, every intra-class `my method` dispatch, and `next` / `nextto` super-dispatch, whether the call sits at the top level of a body, inside a `[…]` command substitution, or embedded in a quoted or compound word such as `"value: [my get]"`. A `classmethod` is dispatched differently — on the class's own command, never on an instance — so its references are every bare `ClassName method` call, including from a subclass's own command when the subclass inherits (does not override) the classmethod, in the defining file, a subclass-only file, or a pure-consumer file that never mentions the class body at all (the workspace index's per-method `kind` carries the "this is a classmethod" fact to whichever file needs it). The same applies to snit's `typemethod` — snit and TclOO members are both registry-declared class methods, so this is not a TclOO-specific check. An expr math function resolves to its backing proc, so a `proc ::tcl::mathfunc::foo` is found from every `foo(...)` written inside an `expr`.
 
 A class is found through every use of its name, not only `<Class> new` instantiations: a `superclass`, `mixin`, or `[incr Tcl]` `inherit` argument that names the class is a reference to it, and a `forward` member's delegated command is a reference to that command. These references are resolved by the class's namespace exactly as a call would be, so a fully-qualified `superclass ::ns::Base` in one file is found from `::ns::Base`'s declaration in another, and a same-named class in an unrelated namespace is never cross-linked. Because the same references drive rename, renaming a class rewrites every `superclass` / `mixin` / `inherit` site that names it, keeping the inheritance graph intact.
 
@@ -54,14 +54,30 @@ double-quoted string.
 
 - A class referenced only through a dynamic (`$var`) superclass / mixin name is
   not linked — the name is not statically decidable.
+- [incr Tcl] dispatches a class-scoped `proc` (itcl's own class-method form)
+  as a single `::`-qualified identifier — `Factory::make`, not `Factory make`
+  — which is a different call shape entirely from `classmethod` /
+  `typemethod`'s two-word dispatch. Find References does not yet follow this
+  form (it would need to be resolved through the ordinary proc-reference
+  path, not the object-method scanner).
+- A classmethod's / typemethod's own-class-command dispatch (unlike an
+  instance's `$obj method`) is matched by exact name-set membership (the
+  class's as-written simple name plus its fully `::`-qualified name), so a
+  call spelled with a *partial* namespace qualifier from a sibling namespace
+  is not matched — the same imprecision `CLASS create NAME` object-command
+  dispatch already has.
 
 ## Test anchors
 
 - `rust/tcl-lsp-core/tests/references_residual.rs`
 - `rust/tcl-lsp-core/tests/name_resolution.rs` (`classmethod_dispatch`,
   `obj_method_dispatch` — TP/FP/TN/FN matrix, including issue #956's exact
-  repro)
+  repro, snit `typemethod`, and the itcl `proc` boundary)
 - `rust/tcl-lsp-server/tests/e2e/issue923_class_refs.rs` (cross-file)
+- `rust/tcl-lsp-server/src/lib.rs` unit tests: `cross_file_consumer_finds_classmethod_bare_dispatch`,
+  `cross_file_consumer_finds_inheriting_subclass_classmethod_dispatch`,
+  `cross_file_method_references_reach_inheritor_document_for_classmethod`,
+  `classmethod_rename_reaches_subclass_only_document`
 
 ## Screenshots
 

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -24,6 +24,8 @@ Locates all usages of the symbol under the cursor, including definitions, calls,
 
 TclOO dispatch is followed as well. A method is found through every `$obj method` call on a tracked instance, every intra-class `my method` dispatch, and `next` / `nextto` super-dispatch, whether the call sits at the top level of a body, inside a `[…]` command substitution, or embedded in a quoted or compound word such as `"value: [my get]"`. A `classmethod` is dispatched differently — on the class's own command, never on an instance — so its references are every bare `ClassName method` call, including from a subclass's own command when the subclass inherits (does not override) the classmethod, in the defining file, a subclass-only file, or a pure-consumer file that never mentions the class body at all (the workspace index's per-method `kind` carries the "this is a classmethod" fact to whichever file needs it). The same applies to snit's `typemethod` — snit and TclOO members are both registry-declared class methods, so this is not a TclOO-specific check. An expr math function resolves to its backing proc, so a `proc ::tcl::mathfunc::foo` is found from every `foo(...)` written inside an `expr`.
 
+Triggering from the classmethod's own bare dispatch site (not just its declaration or a code lens) resolves too — the cursor's receiver word is resolved directly to the class whose `classmethod` it names, the reverse of the forward "which names dispatch this class" lookup used to *count* references. A class that declares both a `method` and a `classmethod` of the same name (TclOO keeps them in separate dispatch tables, so this is legal) is disambiguated explicitly: unambiguous when only one exists, otherwise by which declaration the cursor is actually on, never inferred from bare name-map membership — so each one's lens, reference count, and rename affect only its own dispatch shape.
+
 A class is found through every use of its name, not only `<Class> new` instantiations: a `superclass`, `mixin`, or `[incr Tcl]` `inherit` argument that names the class is a reference to it, and a `forward` member's delegated command is a reference to that command. These references are resolved by the class's namespace exactly as a call would be, so a fully-qualified `superclass ::ns::Base` in one file is found from `::ns::Base`'s declaration in another, and a same-named class in an unrelated namespace is never cross-linked. Because the same references drive rename, renaming a class rewrites every `superclass` / `mixin` / `inherit` site that names it, keeping the inheritance graph intact.
 
 ## Example
@@ -59,25 +61,37 @@ double-quoted string.
   — which is a different call shape entirely from `classmethod` /
   `typemethod`'s two-word dispatch. Find References does not yet follow this
   form (it would need to be resolved through the ordinary proc-reference
-  path, not the object-method scanner).
+  path, not the object-method scanner). The reverse direction is guarded,
+  though: itcl's own two-word instance-creation syntax (`ClassName
+  instanceName`), which can coincidentally share text shape with a
+  same-named class-proc, is never mistaken for a dispatch of it.
 - A classmethod's / typemethod's own-class-command dispatch (unlike an
   instance's `$obj method`) is matched by exact name-set membership (the
   class's as-written simple name plus its fully `::`-qualified name), so a
   call spelled with a *partial* namespace qualifier from a sibling namespace
   is not matched — the same imprecision `CLASS create NAME` object-command
-  dispatch already has.
+  dispatch already has. The same imprecision can also over-match: two
+  unrelated classes sharing a simple (tail) name in different namespaces
+  aren't distinguished by lexical scope, so a bare dispatch inside one
+  namespace can be wrongly attributed to the other's same-named class —
+  renaming from the wrong one's declaration could then rewrite the
+  unrelated class's call site. Tracked as a follow-up; not yet fixed.
 
 ## Test anchors
 
 - `rust/tcl-lsp-core/tests/references_residual.rs`
 - `rust/tcl-lsp-core/tests/name_resolution.rs` (`classmethod_dispatch`,
   `obj_method_dispatch` — TP/FP/TN/FN matrix, including issue #956's exact
-  repro, snit `typemethod`, and the itcl `proc` boundary)
+  repro, snit `typemethod`, the itcl `proc` boundary in both directions,
+  and call-site-cursor resolution)
 - `rust/tcl-lsp-server/tests/e2e/issue923_class_refs.rs` (cross-file)
 - `rust/tcl-lsp-server/src/lib.rs` unit tests: `cross_file_consumer_finds_classmethod_bare_dispatch`,
   `cross_file_consumer_finds_inheriting_subclass_classmethod_dispatch`,
   `cross_file_method_references_reach_inheritor_document_for_classmethod`,
-  `classmethod_rename_reaches_subclass_only_document`
+  `classmethod_rename_reaches_subclass_only_document`,
+  `cross_file_consumer_does_not_bare_dispatch_an_itcl_class_proc`,
+  `code_lens_resolve_disambiguates_method_and_classmethod_of_the_same_name`,
+  `rename_disambiguates_method_and_classmethod_of_the_same_name`
 
 ## Screenshots
 

--- a/editors/vscode/src/test/codeLens.test.ts
+++ b/editors/vscode/src/test/codeLens.test.ts
@@ -164,47 +164,120 @@ suite("Code Lens", () => {
   // Regression for issue #864: the reference-count lens above a TclOO method
   // must count external `$obj method` dispatch, not just intra-class calls.
   // `puts [$b get foo]` (with `set b [Bar new]`) is one reference to `get`.
-  test("method lens counts external \\$obj method dispatch", async () => {
+  // Also the exact repro shape from issue #956 — a `variable` and
+  // `constructor` declared before the `method`, the method body reading the
+  // instance variable — so this doubles as the #956 regression: the lens
+  // must resolve to a *clickable* `tcl-lsp.showReferences` command, not the
+  // count-only-but-inert shape the #724 defect left for methods
+  // specifically (proc/class lenses were fixed under #724; methods were not,
+  // until #956).
+  test("method lens counts external \\$obj method dispatch and is clickable", async () => {
     const refsUri = getDocUri("codeLensMethodRefs.tcl");
     await activate(refsUri);
-    // Method / member lenses are informational: the server attaches their
-    // count eagerly as `command.title` (no separate resolve round-trip), so
-    // poll until the lenses on the member lines under test carry a title.
+    // Since #956, method / classmethod lenses resolve lazily the same way
+    // proc/class lenses do — `executeCodeLensProvider`'s resolveCount arg
+    // drives VS Code to call `codeLens/resolve` itself, so poll until the
+    // lenses on the member lines under test carry a resolved command.
     const lenses = (await pollUntil(
       () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100),
       (r) => {
         const ls = r as vscode.CodeLens[] | undefined;
         if (!ls) return false;
-        const titledLines = new Set(
-          ls
-            .filter((l) => l.command && typeof l.command.title === "string")
-            .map((l) => l.range.start.line),
-        );
+        const resolvedLines = new Set(ls.filter((l) => l.command).map((l) => l.range.start.line));
         // `method get` on line 6, `method unused` on line 10.
-        return [6, 10].every((line) => titledLines.has(line));
+        return [6, 10].every((line) => resolvedLines.has(line));
       },
       { timeout: 10_000, label: "resolved method code lenses" },
     )) as vscode.CodeLens[] | undefined;
     assert.ok(lenses, "codeLens result should not be null");
 
-    const titleByLine = new Map<number, string>();
+    const commandByLine = new Map<number, vscode.Command>();
     for (const lens of lenses) {
-      if (lens.command && typeof lens.command.title === "string") {
-        titleByLine.set(lens.range.start.line, lens.command.title);
+      if (lens.command) {
+        commandByLine.set(lens.range.start.line, lens.command);
       }
     }
 
     // Line 6: `method get` — dispatched once via `puts [$b get foo]`.
+    const getCommand = commandByLine.get(6);
     assert.strictEqual(
-      titleByLine.get(6),
+      getCommand?.title,
       "1 reference",
-      `TclOO method with an external \$obj dispatch: got "${titleByLine.get(6)}"`,
+      `TclOO method with an external \$obj dispatch: got "${getCommand?.title}"`,
     );
-    // Line 10: `method unused` — never dispatched.
     assert.strictEqual(
-      titleByLine.get(10),
+      getCommand?.command,
+      "tcl-lsp.showReferences",
+      `method lens must be clickable, not inert: got "${getCommand?.command}"`,
+    );
+
+    // Line 10: `method unused` — never dispatched, but still clickable (an
+    // empty peek is a valid target; zero references must not leave the lens
+    // inert).
+    const unusedCommand = commandByLine.get(10);
+    assert.strictEqual(
+      unusedCommand?.title,
       "0 references",
-      `uncalled TclOO method: got "${titleByLine.get(10)}"`,
+      `uncalled TclOO method: got "${unusedCommand?.title}"`,
+    );
+    assert.strictEqual(
+      unusedCommand?.command,
+      "tcl-lsp.showReferences",
+      `uncalled method lens must still be clickable: got "${unusedCommand?.command}"`,
+    );
+  });
+
+  // Regression for issue #956 (a distinct gap found while fixing the method
+  // lens's clickability): a `classmethod` dispatches on the *class's own*
+  // command (`Factory make`) — never on an instance — so the reference count
+  // and lens above `classmethod make` must count that bare dispatch too, and
+  // the lens must resolve to a clickable command exactly like an instance
+  // method's.
+  test("classmethod lens counts bare class-command dispatch and is clickable", async () => {
+    const refsUri = getDocUri("codeLensClassmethodRefs.tcl");
+    await activate(refsUri);
+    const lenses = (await pollUntil(
+      () => vscode.commands.executeCommand("vscode.executeCodeLensProvider", refsUri, 100),
+      (r) => {
+        const ls = r as vscode.CodeLens[] | undefined;
+        if (!ls) return false;
+        const resolvedLines = new Set(ls.filter((l) => l.command).map((l) => l.range.start.line));
+        // `classmethod make` on line 1, `classmethod idle` on line 5.
+        return [1, 5].every((line) => resolvedLines.has(line));
+      },
+      { timeout: 10_000, label: "resolved classmethod code lenses" },
+    )) as vscode.CodeLens[] | undefined;
+    assert.ok(lenses, "codeLens result should not be null");
+
+    const commandByLine = new Map<number, vscode.Command>();
+    for (const lens of lenses) {
+      if (lens.command) {
+        commandByLine.set(lens.range.start.line, lens.command);
+      }
+    }
+
+    const makeCommand = commandByLine.get(1);
+    assert.strictEqual(
+      makeCommand?.title,
+      "1 reference",
+      `classmethod dispatched via the bare class command: got "${makeCommand?.title}"`,
+    );
+    assert.strictEqual(
+      makeCommand?.command,
+      "tcl-lsp.showReferences",
+      `classmethod lens must be clickable: got "${makeCommand?.command}"`,
+    );
+
+    const idleCommand = commandByLine.get(5);
+    assert.strictEqual(
+      idleCommand?.title,
+      "0 references",
+      `uncalled classmethod: got "${idleCommand?.title}"`,
+    );
+    assert.strictEqual(
+      idleCommand?.command,
+      "tcl-lsp.showReferences",
+      `uncalled classmethod lens must still be clickable: got "${idleCommand?.command}"`,
     );
   });
 

--- a/editors/vscode/testFixture/codeLensClassmethodRefs.tcl
+++ b/editors/vscode/testFixture/codeLensClassmethodRefs.tcl
@@ -1,0 +1,10 @@
+oo::class create Factory {
+    classmethod make {} {
+        return [Factory new]
+    }
+
+    classmethod idle {} {
+        return {}
+    }
+}
+Factory make

--- a/rust/tcl-cli/tests/fixtures/help-catalogue-irules.golden
+++ b/rust/tcl-cli/tests/fixtures/help-catalogue-irules.golden
@@ -25,7 +25,8 @@ LSP + AI Features (9):
 LSP Features (all editors) (5):
   APL (iApp Presentation Language) support: Semantic highlighting, cross-file diagnostics, and embedded Tcl support for
 F5 iApp APL (Application Presentation Language) files.
-  Code Lens: Reference counts shown above each proc definition. Click the lens to find all references.
+  Code Lens: Reference counts shown above each proc, class, TclOO method, and classmethod
+definition. Click the lens to find all references.
   Compiler Explorer: Interactive web panel showing bytecode disassembly, AST, IR, and compiler passes, plus a structured WebAssembly disassembly view with click-to-source navigation, call and branch target cross-linking, control-flow arrows, and labelled structural ops.
   Folding: Code folding for procs, namespaces, event handlers, and braced blocks.
   Template Snippets: 16 built-in Tcl and iRules code templates insertable from the command palette.

--- a/rust/tcl-compiler/src/analyser/item_tree.rs
+++ b/rust/tcl-compiler/src/analyser/item_tree.rs
@@ -341,7 +341,7 @@ fn result_methods(class: &super::types::ClassDef) -> Vec<FlatMethod> {
     let mut out = Vec::new();
     for (name, m) in &class.methods {
         out.push(FlatMethod {
-            key: format!("{cq}::method::{name}"),
+            key: super::types::class_member_key(cq, name, false),
             name_span: m.name_span,
             body_span: m.body_span,
             params: m.params.clone(),
@@ -349,7 +349,7 @@ fn result_methods(class: &super::types::ClassDef) -> Vec<FlatMethod> {
     }
     for (name, m) in &class.class_methods {
         out.push(FlatMethod {
-            key: format!("{cq}::classmethod::{name}"),
+            key: super::types::class_member_key(cq, name, true),
             name_span: m.name_span,
             body_span: m.body_span,
             params: m.params.clone(),

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -82,5 +82,5 @@ pub use tcl_syntax::mro::{self, MroError, build_mro_map, tcloo_linearise};
 pub use types::{
     AnalysisResult, ClassDef, CodeFix, DefinedSymbol, Diagnostic, MethodDef, ObjectMethodDef,
     ProcArgTrait, ProcDef, PropertyDef, Scope, ScopeKind, Severity, StubFlags, UnknownProcInfo,
-    VarDef,
+    VarDef, class_member_key,
 };

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -461,6 +461,24 @@ pub struct MethodDef {
     pub forward_target: Option<(String, Vec<String>)>,
 }
 
+/// Stable composite key naming a class's instance method or class method:
+/// `{class}::method::{name}` / `{class}::classmethod::{name}`.  The single
+/// canonical form for re-identifying the *same* member across a round-trip —
+/// the incremental item-tree diff ([`crate::analyser::item_tree`]) and any
+/// LSP-facing consumer that hands a member identity to the client and gets
+/// it back later (the code-lens `codeLens/resolve` handshake) — so the two
+/// never drift onto different naming schemes for the same member.  A class
+/// or proc's own qualified name (`::Bar`, `::helper`) never contains
+/// `::method::`/`::classmethod::`, so this key cannot collide with theirs.
+#[must_use]
+pub fn class_member_key(class_qualified: &str, name: &str, is_classmethod: bool) -> String {
+    if is_classmethod {
+        format!("{class_qualified}::classmethod::{name}")
+    } else {
+        format!("{class_qualified}::method::{name}")
+    }
+}
+
 /// One per-object method added by an `oo::objdefine` (issue #945
 /// fault 5): the method declaration plus the **objdefine site's**
 /// receiver offset, the anchor a consumer resolves to a variable
@@ -1124,6 +1142,23 @@ impl Default for Scope {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn class_member_key_disambiguates_method_and_classmethod() {
+        assert_eq!(
+            class_member_key("::Bar", "get", false),
+            "::Bar::method::get"
+        );
+        assert_eq!(
+            class_member_key("::Bar", "get", true),
+            "::Bar::classmethod::get"
+        );
+        // Same class, same member name, different map — must not collide.
+        assert_ne!(
+            class_member_key("::Bar", "get", false),
+            class_member_key("::Bar", "get", true)
+        );
+    }
 
     #[test]
     fn scope_default_is_global() {

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -38,7 +38,10 @@
 //! always agree.  That resolver counts intra-class `my method` dispatch,
 //! external `$obj method` call sites (matched through the analyser's
 //! `instance_classes` variable-type tracking), and the sites of any
-//! subclass that inherits the definition (issue #864).
+//! subclass that inherits the definition (issue #864).  Each member lens
+//! carries a `qname` ([`tcl_compiler::analyser::class_member_key`]) just
+//! like the proc / class lenses, so it resolves to a clickable
+//! `tcl-lsp.showReferences` command the same way (issue #956).
 //!
 //! Cross-document reference counts: when the
 //! caller threads a [`crate::workspace_index::WorkspaceIndex`]
@@ -53,9 +56,6 @@
 //!   object's class needs whole-workspace instance-type flow the index
 //!   does not yet carry.  Proc / class lenses do fold in cross-document
 //!   command-head call sites via the workspace index.
-//! * The lens carries a static label rather than an inline
-//!   "show references" jump-out; the editor's built-in
-//!   references command can be invoked from the lens itself.
 
 use tcl_compiler::analyser::AnalysisResult;
 use tcl_lexer::LineIndex;
@@ -188,6 +188,14 @@ pub fn code_lenses(
 /// `my method` dispatch, external `$obj method` sites (resolved through the
 /// analyser's `instance_classes` variable-type tracking), and the call sites
 /// of any subclass that inherits (does not override) this definition.
+///
+/// Each lens carries a `{class}::method::{name}` / `{class}::classmethod::{name}`
+/// `qname` ([`tcl_compiler::analyser::class_member_key`]) — the same
+/// `qname`-present shape as the proc / class lenses — so the server's
+/// `code_lens_resolve` treats it as resolvable and attaches the *clickable*
+/// `tcl-lsp.showReferences` command instead of leaving it an inert bare
+/// title (issue #956: the `#724` "reference is not active" defect,
+/// previously fixed for proc/class lenses, recurring for methods).
 fn emit_class_member_lenses(
     source: &str,
     dialect: &str,
@@ -203,34 +211,41 @@ fn emit_class_member_lenses(
         crate::references::method_references_for_class(source, dialect, analysis, class_q, name)
             .map_or(0, |(_decl, calls)| calls.len())
     };
-    let push_lens = |name_span: tcl_lexer::Span, title: String, lenses: &mut Vec<CodeLens>| {
-        let start = line_index.position_at_utf16(name_span.start(), source);
-        let end = line_index.position_at_utf16(name_span.end(), source);
-        lenses.push(CodeLens {
-            range: LspRange {
-                start_line: start.line,
-                start_character: start.character.get(),
-                end_line: end.line,
-                end_character: end.character.get(),
-            },
-            command_title: title,
-            command: String::new(),
-            // Method lenses are informational; the references-jump `data`
-            // is populated for proc / class lenses (where it's exercised).
-            qname: String::new(),
-        });
-    };
-    for m in class_def
-        .methods
-        .values()
-        .chain(class_def.class_methods.values())
-    {
+    let push_lens =
+        |name_span: tcl_lexer::Span, qname: String, title: String, lenses: &mut Vec<CodeLens>| {
+            let start = line_index.position_at_utf16(name_span.start(), source);
+            let end = line_index.position_at_utf16(name_span.end(), source);
+            lenses.push(CodeLens {
+                range: LspRange {
+                    start_line: start.line,
+                    start_character: start.character.get(),
+                    end_line: end.line,
+                    end_character: end.character.get(),
+                },
+                command_title: title,
+                command: String::new(),
+                qname,
+            });
+        };
+    for (name, m) in &class_def.methods {
         if m.name_span.is_empty() {
             continue;
         }
         push_lens(
             m.name_span,
-            reference_count_title(member_ref_count(&m.name)),
+            tcl_compiler::analyser::class_member_key(class_q, name, false),
+            reference_count_title(member_ref_count(name)),
+            lenses,
+        );
+    }
+    for (name, m) in &class_def.class_methods {
+        if m.name_span.is_empty() {
+            continue;
+        }
+        push_lens(
+            m.name_span,
+            tcl_compiler::analyser::class_member_key(class_q, name, true),
+            reference_count_title(member_ref_count(name)),
             lenses,
         );
     }
@@ -434,6 +449,72 @@ mod tests {
             .find(|l| l.range.start_line == 1)
             .expect("orphan lens");
         assert_eq!(orphan_lens.command_title, "0 references", "{lenses:?}");
+    }
+
+    // qname wiring (issue #956): a method / classmethod lens must carry a
+    // non-empty `qname` matching `tcl_compiler::analyser::class_member_key`
+    // so the server treats it as resolvable (`has_qname` in
+    // `tcl-lsp-server`'s `code_lens` handler) and attaches a clickable
+    // `tcl-lsp.showReferences` command via `codeLens/resolve`, instead of
+    // leaving it an inert bare title (the `#724` defect recurring for
+    // methods).  The wire-level resolve round-trip itself is covered by
+    // `tcl-lsp-server`'s `code_lens_resolve_wires_show_references_command_for_method`
+    // / `..._for_classmethod` tests; these lock in the `qname` this crate
+    // hands the server.
+
+    #[test]
+    fn method_lens_carries_class_member_key_qname() {
+        // FN→TP regression for the exact issue #956 shape: a `variable` and
+        // `constructor` declared before the `method` in the class body.
+        let src = "oo::class create Bar {\n   variable _options\n    constructor {args} {\n         set _options $args\n    }\n\n    method get {key} {\n        return [dict get $_options $key]\n    }\n\n}\nset b [Bar new]\nputs [$b get foo]\n";
+        let analysis = analyse(src);
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let get_lens = lenses
+            .iter()
+            .find(|l| l.range.start_line == 6)
+            .expect("get lens");
+        assert_eq!(
+            get_lens.qname,
+            tcl_compiler::analyser::class_member_key("::Bar", "get", false),
+            "{lenses:?}"
+        );
+        assert!(!get_lens.qname.is_empty(), "empty qname stays inert");
+    }
+
+    #[test]
+    fn classmethod_lens_carries_class_member_key_qname() {
+        let src =
+            "oo::class create Factory {\n    classmethod make {} { return [Factory new] }\n}\n";
+        let analysis = analyse(src);
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let make_lens = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("make lens");
+        assert_eq!(
+            make_lens.qname,
+            tcl_compiler::analyser::class_member_key("::Factory", "make", true),
+            "{lenses:?}"
+        );
+    }
+
+    #[test]
+    fn method_and_classmethod_qnames_never_collide_on_same_name() {
+        // FP guard: a class with both a `method foo` and a `classmethod foo`
+        // must get two distinct, disambiguated qnames — a naive
+        // `{class}::{name}` key would collide and let `codeLens/resolve`
+        // attach one member's locations to the other's lens.
+        let src = "oo::class create C {\n    method foo {} {}\n    classmethod foo {} {}\n}\n";
+        let analysis = analyse(src);
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let qnames: std::collections::HashSet<&str> = lenses
+            .iter()
+            .filter(|l| l.range.start_line == 1 || l.range.start_line == 2)
+            .map(|l| l.qname.as_str())
+            .collect();
+        assert_eq!(qnames.len(), 2, "{lenses:?}");
+        assert!(qnames.contains("::C::method::foo"), "{qnames:?}");
+        assert!(qnames.contains("::C::classmethod::foo"), "{qnames:?}");
     }
 
     // workspace-index: cross-document reference counts

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -207,9 +207,19 @@ fn emit_class_member_lenses(
 ) {
     // Reference count for one member, matching the peek exactly: the number
     // of call sites (declaration excluded) the shared resolver returns.
-    let member_ref_count = |name: &str| -> usize {
-        crate::references::method_references_for_class(source, dialect, analysis, class_q, name)
-            .map_or(0, |(_decl, calls)| calls.len())
+    // `is_classmethod` is passed explicitly rather than inferred, so a
+    // `method` and `classmethod` sharing a name each count and resolve only
+    // their own dispatch shape (Codex review on #971, P2).
+    let member_ref_count = |name: &str, is_classmethod: bool| -> usize {
+        crate::references::method_references_for_class(
+            source,
+            dialect,
+            analysis,
+            class_q,
+            name,
+            is_classmethod,
+        )
+        .map_or(0, |(_decl, calls)| calls.len())
     };
     let push_lens =
         |name_span: tcl_lexer::Span, qname: String, title: String, lenses: &mut Vec<CodeLens>| {
@@ -234,7 +244,7 @@ fn emit_class_member_lenses(
         push_lens(
             m.name_span,
             tcl_compiler::analyser::class_member_key(class_q, name, false),
-            reference_count_title(member_ref_count(name)),
+            reference_count_title(member_ref_count(name, false)),
             lenses,
         );
     }
@@ -245,7 +255,7 @@ fn emit_class_member_lenses(
         push_lens(
             m.name_span,
             tcl_compiler::analyser::class_member_key(class_q, name, true),
-            reference_count_title(member_ref_count(name)),
+            reference_count_title(member_ref_count(name, true)),
             lenses,
         );
     }

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -714,6 +714,46 @@ pub(crate) fn receiver_instance_class<'a>(
     }
 }
 
+/// Resolve a bare `ClassName method` call-site receiver directly to the
+/// class whose `classmethod` provides `method` — the reverse of
+/// [`crate::references::find_obj_method_call_sites`]'s forward "given the
+/// class, which bare names dispatch it" fold, needed to resolve
+/// Find-References / Rename / go-to-definition triggered *from* the call
+/// site itself rather than from the declaration or a code lens.
+///
+/// `receiver` must name a class (simple or fully-qualified) that declares
+/// or *inherits* (does not override) `method` as a `classmethod` — `None`
+/// for an instance-command receiver (that's [`receiver_instance_class`]'s
+/// job) or a class with no such classmethod.  Doesn't itself exclude
+/// [incr Tcl] classes (whose class-scoped `proc` dispatches as
+/// `Factory::method`, not this bare two-word shape): every downstream
+/// consumer of the `(class, method, is_classmethod)` triple this feeds —
+/// `find_obj_method_call_sites` and friends — already re-checks the
+/// definer's family before treating any site as a dispatch, so a
+/// same-named itcl class-proc resolves here but then correctly yields no
+/// call sites rather than a false one.
+#[must_use]
+pub(crate) fn classmethod_dispatch_class(
+    analysis: &AnalysisResult,
+    receiver: &str,
+    method: &str,
+) -> Option<String> {
+    let named = analysis
+        .all_classes
+        .values()
+        .find(|cd| cd.name == receiver || cd.qualified_name == receiver)?;
+    if named.class_methods.contains_key(method) {
+        return Some(named.qualified_name.clone());
+    }
+    let hierarchy = analysis.class_hierarchy();
+    let provider_q = hierarchy.method_target(&named.qualified_name, method)?;
+    analysis
+        .all_classes
+        .get(provider_q)
+        .filter(|cd| cd.class_methods.contains_key(method))
+        .map(|_| provider_q.to_string())
+}
+
 /// Look up an alias by name.  Accepts the alias's simple or
 /// qualified form (`mycmd` and `::mycmd` both match an alias
 /// stored with `qualified_name == "::mycmd"`).

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -270,6 +270,12 @@ pub fn references(
         return out;
     }
 
+    // Bare `ClassName method` external call site — a classmethod's own
+    // dispatch shape, tried only once the instance path above has failed.
+    if let Some(out) = classmethod_call_site_references(&ctx) {
+        return out;
+    }
+
     // Class-member references (cursor inside a class body on a member name).
     if let Some(out) = class_member_references(&ctx, &word) {
         return out;
@@ -440,6 +446,42 @@ fn instance_method_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
     // `next` / `nextto` super-dispatch is a reference (but never a rename site).
     call_spans.extend(method_next_dispatch_spans(
         analysis, source, dialect, class_q, &method, false,
+    ));
+    Some(build_member_ranges(
+        source,
+        line_index,
+        decl_span,
+        call_spans,
+        include_declaration,
+    ))
+}
+
+/// Build references for a bare `ClassName method` call site: the reverse of
+/// [`instance_method_references`], for a `classmethod` — which dispatches on
+/// the class's own command, never an instance, so it is never found by
+/// `$obj`/`my` resolution.  Without this, Find References / Rename
+/// triggered from the actual dispatch site (as opposed to the declaration
+/// or a code lens) silently found nothing (Codex review on #971, P2).
+fn classmethod_call_site_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
+    let RefCtx {
+        source,
+        dialect,
+        line_index,
+        line,
+        character,
+        analysis,
+        include_declaration,
+    } = *ctx;
+    let (inst, method, is_dollar) =
+        crate::definition::instance_method_at_cursor(source, line, character)?;
+    if is_dollar {
+        return None;
+    }
+    let class_q = crate::definition::classmethod_dispatch_class(analysis, &inst, &method)?;
+    let (decl_span, mut call_spans) =
+        method_references_for_class(source, dialect, analysis, &class_q, &method, true)?;
+    call_spans.extend(method_next_dispatch_spans(
+        analysis, source, dialect, &class_q, &method, true,
     ));
     Some(build_member_ranges(
         source,

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -1010,6 +1010,22 @@ pub(crate) fn find_obj_method_call_sites(
     find_obj_method_call_sites_with_extra_cmd_names(source, dialect, analysis, class_q, method, &[])
 }
 
+/// Whether `cd`'s definer command dispatches its class-scoped members as a
+/// single `::`-qualified identifier (`Factory::make`) rather than the
+/// two-word `Factory make` shape — true for [incr Tcl] only.  Registry data
+/// (`DefinerFamily`), not a hardcoded command-name check: `cd.metaclass` is
+/// looked up in `dialect`'s registry and its attached
+/// [`tcl_registry::definer::DefinitionBodyGrammar::family`] compared.  A
+/// metaclass the registry doesn't recognise as a definer (shouldn't happen
+/// for a real `ClassDef`) is conservatively treated as *not* itcl, matching
+/// prior behaviour.
+fn is_itcl_class(cd: &tcl_compiler::analyser::types::ClassDef, dialect: &str) -> bool {
+    tcl_registry::registry_for_dialect(dialect)
+        .get(&cd.metaclass)
+        .and_then(|spec| spec.definition_body)
+        .is_some_and(|g| g.family == tcl_registry::definer::DefinerFamily::Itcl)
+}
+
 /// [`find_obj_method_call_sites`], plus `extra_cmd_names` — bare command
 /// names to treat as valid classmethod-dispatch heads for `method`
 /// regardless of what this document's own `analysis.all_classes` knows.
@@ -1059,18 +1075,29 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
     // make`) — never on an instance: TclOO's `classmethod` sugar puts the
     // method on the class object's own class, which no instance's MRO
     // reaches.  When `method` is one of `class_q`'s classmethods (known
-    // locally), fold in the defining class's own name (simple + qualified)
-    // plus the own name of any subclass that inherits (does not override) it
-    // — the same inheritance test as the instance `var_set` above, so a `Sub
-    // make` dispatch on an inheriting subclass counts too.
+    // locally) *and* `class_q`'s definer family actually uses this two-word
+    // dispatch shape, fold in the defining class's own name (simple +
+    // qualified) plus the own name of any subclass that inherits (does not
+    // override) it — the same inheritance test as the instance `var_set`
+    // above, so a `Sub make` dispatch on an inheriting subclass counts too.
+    //
+    // The definer-family check matters because [incr Tcl]'s class-scoped
+    // `proc` lands in this same `class_methods` bucket (so the declaration
+    // side finds it) but dispatches as a single `::`-qualified identifier
+    // (`Factory::make`) — a bare two-word `Factory make` in itcl source is
+    // unrelated instance-creation syntax (`ClassName instanceName`), not a
+    // call to this proc.  The dispatch shape is registry data
+    // (`DefinerFamily`), not something to infer from the shared storage
+    // bucket.
     if analysis
         .all_classes
         .get(class_q)
-        .is_some_and(|cd| cd.class_methods.contains_key(method))
+        .is_some_and(|cd| cd.class_methods.contains_key(method) && !is_itcl_class(cd, dialect))
     {
         for (other_q, other_cd) in &analysis.all_classes {
-            if other_q.as_str() == class_q
-                || hierarchy.method_target(other_q, method) == Some(class_q)
+            if (other_q.as_str() == class_q
+                || hierarchy.method_target(other_q, method) == Some(class_q))
+                && !is_itcl_class(other_cd, dialect)
             {
                 cmd_set.insert(other_cd.name.as_str());
                 cmd_set.insert(other_cd.qualified_name.as_str());

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -55,18 +55,23 @@
 //! call (or inside the class body), the provider additionally
 //! scans the whole document for `$v method` / `[$v method]`
 //! call sites where `v`'s class (per
-//! `analysis.instance_classes`) matches.  See
-//! [`find_obj_method_call_sites`] for the scan's coverage.
+//! `analysis.instance_classes`) matches — plus, when the member is a
+//! `classmethod`, every bare `ClassName method` dispatch on the class's
+//! own command (a classmethod is never dispatched via an instance).  See
+//! [`find_obj_method_call_sites`] for the scan's full coverage.
 //!
 //! Limitations:
 //!
 //! * Cross-document references — surfacing references across
 //!   every open document via a workspace-index integration —
 //!   are not supported.
-//! * `$obj method` sites embedded in quoted / word tokens
-//!   (`"prefix[$d bark]"`) — the scan descends into
-//!   command-substitution args and proc / method bodies but
-//!   not into string interpolation.
+//! * A classmethod's class-command dispatch is matched by exact name-set
+//!   membership (the class's as-written simple name plus its fully
+//!   `::`-qualified name) rather than full namespace-relative resolution —
+//!   a call spelled with a *partial* namespace qualifier from a sibling
+//!   namespace (`ns::Factory make` where the class is `::ns::Factory`) is
+//!   not matched.  The same imprecision already applies to `CLASS create
+//!   NAME` object-command dispatch above.
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use tcl_compiler::analyser::AnalysisResult;
@@ -944,8 +949,10 @@ fn find_class_member_references(
 /// Find every external `$v method` / `[$v method]` call site
 /// in the document where `v` is an instance variable whose
 /// class qualified-name is `class_q` (per
-/// `analysis.instance_classes`).  Returns the spans of the
-/// method-name tokens.
+/// `analysis.instance_classes`), plus — when `method` is a
+/// `classmethod` — every bare `ClassName method` dispatch on the
+/// defining class's own command (and any inheriting subclass's own
+/// command).  Returns the spans of the method-name tokens.
 ///
 /// Scans three region kinds — the top-level command stream,
 /// each user proc body, and each class method body — and
@@ -979,18 +986,40 @@ pub(crate) fn find_obj_method_call_sites(
         })
         .map(|(v, _)| v.as_str())
         .collect();
-    if var_set.is_empty() {
-        return Vec::new();
-    }
     // Receivers that are also *object commands* — bound by `CLASS create NAME`
     // (so `NAME` is a command, dispatched bare as `NAME method`, not `$NAME
     // method`).  A `set v [CLASS new]` receiver is a *variable* only and never
     // enters this set, so a bare `v method` is (correctly) not matched.
-    let cmd_set: FxHashSet<&str> = var_set
+    let mut cmd_set: FxHashSet<&str> = var_set
         .iter()
         .copied()
         .filter(|name| analysis.created_instance_commands.contains(*name))
         .collect();
+    // A `classmethod` dispatches on the *class's own* command (`Factory
+    // make`) — never on an instance: TclOO's `classmethod` sugar puts the
+    // method on the class object's own class, which no instance's MRO
+    // reaches.  When `method` is one of `class_q`'s classmethods, fold in
+    // the defining class's own name (simple + qualified) plus the own name
+    // of any subclass that inherits (does not override) it — the same
+    // inheritance test as the instance `var_set` above, so a `Sub make`
+    // dispatch on an inheriting subclass counts too.
+    if analysis
+        .all_classes
+        .get(class_q)
+        .is_some_and(|cd| cd.class_methods.contains_key(method))
+    {
+        for (other_q, other_cd) in &analysis.all_classes {
+            if other_q.as_str() == class_q
+                || hierarchy.method_target(other_q, method) == Some(class_q)
+            {
+                cmd_set.insert(other_cd.name.as_str());
+                cmd_set.insert(other_cd.qualified_name.as_str());
+            }
+        }
+    }
+    if var_set.is_empty() && cmd_set.is_empty() {
+        return Vec::new();
+    }
     let mut out: Vec<tcl_lexer::Span> = Vec::new();
     let mut seen: FxHashSet<(u32, u32)> = FxHashSet::default();
     let ctx = ObjMethodScan {

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -433,11 +433,13 @@ fn instance_method_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
     let (inst, method, is_dollar) =
         crate::definition::instance_method_at_cursor(source, line, character)?;
     let class_q = crate::definition::receiver_instance_class(analysis, &inst, is_dollar)?;
+    // `$obj method` dispatch is always an instance-method receiver — a
+    // `classmethod` is never reached this way.
     let (decl_span, mut call_spans) =
-        method_references_for_class(source, dialect, analysis, class_q, &method)?;
+        method_references_for_class(source, dialect, analysis, class_q, &method, false)?;
     // `next` / `nextto` super-dispatch is a reference (but never a rename site).
     call_spans.extend(method_next_dispatch_spans(
-        analysis, source, dialect, class_q, &method,
+        analysis, source, dialect, class_q, &method, false,
     ));
     Some(build_member_ranges(
         source,
@@ -522,18 +524,22 @@ pub(crate) fn method_references_for_class(
     analysis: &AnalysisResult,
     class_q: &str,
     method: &str,
+    is_classmethod: bool,
 ) -> Option<(tcl_lexer::Span, Vec<tcl_lexer::Span>)> {
     use tcl_lexer::Span;
     let class_def = analysis.all_classes.get(class_q)?;
-    let decl_span = class_def
-        .methods
-        .get(method)
-        .map(|m| m.name_span)
-        .or_else(|| class_def.class_methods.get(method).map(|m| m.name_span))?;
+    let decl_span = if is_classmethod {
+        class_def.class_methods.get(method)
+    } else {
+        class_def.methods.get(method)
+    }
+    .map(|m| m.name_span)?;
 
     let mut call_spans: Vec<Span> = Vec::new();
-    // Intra-class `my method` dispatch: re-segment every method / classmethod
-    // / ctor / dtor body for `my method` invocations.  Scan `class_q`'s own
+    // Intra-class `my method` dispatch is instance-context only — `my` never
+    // reaches a classmethod, which runs on the class object, not an
+    // instance.  For a plain method, re-segment every method / classmethod /
+    // ctor / dtor body for `my method` invocations: scan `class_q`'s own
     // bodies **and** the bodies of every subclass that *inherits* this
     // definition — a class whose MRO resolves `method` to `class_q` (i.e. it
     // does not override).  A pure inheritor is not itself a rename family
@@ -543,23 +549,31 @@ pub(crate) fn method_references_for_class(
     // subclass that *overrides* `method` resolves to itself, not `class_q`,
     // so its bodies are handled under its own family entry — never here.
     let hierarchy = analysis.class_hierarchy();
-    let mut bodies: Vec<Span> = collect_member_bodies(class_def);
-    for (other_q, other_cd) in &analysis.all_classes {
-        if other_q.as_str() != class_q && hierarchy.method_target(other_q, method) == Some(class_q)
-        {
-            bodies.extend(collect_member_bodies(other_cd));
+    if !is_classmethod {
+        let mut bodies: Vec<Span> = collect_member_bodies(class_def);
+        for (other_q, other_cd) in &analysis.all_classes {
+            if other_q.as_str() != class_q
+                && hierarchy.method_target(other_q, method) == Some(class_q)
+            {
+                bodies.extend(collect_member_bodies(other_cd));
+            }
         }
+        call_spans.extend(scan_my_method_sites(
+            source,
+            dialect,
+            &bodies,
+            method,
+            Some(decl_span),
+        ));
     }
-    call_spans.extend(scan_my_method_sites(
+    // External `$obj method` / bare `ClassName method` sites.
+    call_spans.extend(find_obj_method_call_sites(
         source,
         dialect,
-        &bodies,
+        analysis,
+        class_q,
         method,
-        Some(decl_span),
-    ));
-    // External `$obj method` sites.
-    call_spans.extend(find_obj_method_call_sites(
-        source, dialect, analysis, class_q, method,
+        is_classmethod,
     ));
     Some((decl_span, call_spans))
 }
@@ -569,7 +583,7 @@ pub(crate) fn method_references_for_class(
 /// [`method_references_for_class`] because that set also drives *rename*, and
 /// `next` / `nextto` are keywords that must never be rewritten to the new
 /// name; only the reference paths add these.  Empty when `class_q` does not
-/// define `method`.
+/// define `method` as a member of the stated kind.
 #[must_use]
 pub fn method_next_dispatch_spans(
     analysis: &AnalysisResult,
@@ -577,15 +591,17 @@ pub fn method_next_dispatch_spans(
     dialect: &str,
     class_q: &str,
     method: &str,
+    is_classmethod: bool,
 ) -> Vec<tcl_lexer::Span> {
     let Some(class_def) = analysis.all_classes.get(class_q) else {
         return Vec::new();
     };
-    let Some(m) = class_def
-        .methods
-        .get(method)
-        .or_else(|| class_def.class_methods.get(method))
-    else {
+    let member = if is_classmethod {
+        class_def.class_methods.get(method)
+    } else {
+        class_def.methods.get(method)
+    };
+    let Some(m) = member else {
         return Vec::new();
     };
     scan_next_dispatch_sites(source, dialect, m.body_span)
@@ -619,6 +635,7 @@ pub fn obj_method_call_sites(
     analysis: &AnalysisResult,
     class_q: &str,
     method: &str,
+    is_classmethod: bool,
     classmethod_class_names: &[String],
 ) -> Vec<tcl_lexer::Span> {
     find_obj_method_call_sites_with_extra_cmd_names(
@@ -627,6 +644,7 @@ pub fn obj_method_call_sites(
         analysis,
         class_q,
         method,
+        is_classmethod,
         classmethod_class_names,
     )
 }
@@ -647,8 +665,9 @@ pub fn method_reference_spans_in_document(
     class_q: &str,
     method: &str,
     include_decl: bool,
+    is_classmethod: bool,
 ) -> Vec<tcl_lexer::Span> {
-    match method_references_for_class(source, dialect, analysis, class_q, method) {
+    match method_references_for_class(source, dialect, analysis, class_q, method, is_classmethod) {
         Some((decl, mut calls)) => {
             if include_decl {
                 calls.push(decl);
@@ -656,7 +675,12 @@ pub fn method_reference_spans_in_document(
             // `next` / `nextto` super-dispatch is a reference (references path
             // only; rename uses `method_spans_in_document`, which excludes it).
             calls.extend(method_next_dispatch_spans(
-                analysis, source, dialect, class_q, method,
+                analysis,
+                source,
+                dialect,
+                class_q,
+                method,
+                is_classmethod,
             ));
             calls
         }
@@ -862,19 +886,27 @@ pub(crate) fn inherited_method_call_sites(
     analysis: &AnalysisResult,
     class_q: &str,
     method: &str,
+    is_classmethod: bool,
     extra_classmethod_cmd_names: &[String],
 ) -> Vec<tcl_lexer::Span> {
     let Some(class_def) = analysis.all_classes.get(class_q) else {
         return Vec::new();
     };
-    let bodies = collect_member_bodies(class_def);
-    let mut spans = scan_my_method_sites(source, dialect, &bodies, method, None);
+    // `my method` is always instance-context dispatch — never applies to a
+    // classmethod, which runs on the class object, not an instance.
+    let mut spans = if is_classmethod {
+        Vec::new()
+    } else {
+        let bodies = collect_member_bodies(class_def);
+        scan_my_method_sites(source, dialect, &bodies, method, None)
+    };
     spans.extend(find_obj_method_call_sites_with_extra_cmd_names(
         source,
         dialect,
         analysis,
         class_q,
         method,
+        is_classmethod,
         extra_classmethod_cmd_names,
     ));
     spans
@@ -906,13 +938,30 @@ fn find_class_member_references(
         // `$obj method` / bare `objcmd method` sites, and the call sites of
         // any subclass that inherits (does not override) this definition
         // (which the class-local scan below would miss).
-        if class_def.methods.contains_key(word) || class_def.class_methods.contains_key(word) {
+        let has_method = class_def.methods.contains_key(word);
+        let has_classmethod = class_def.class_methods.contains_key(word);
+        if has_method || has_classmethod {
+            // A `method` and a `classmethod` of the same name are distinct
+            // members (separate dispatch tables), so presence in one map
+            // doesn't decide it when both match.  Unambiguous when only one
+            // exists; otherwise prefer whichever one's declaration the
+            // cursor is actually on.  A cursor elsewhere in the class body
+            // (e.g. on a `my word` call site, not either declaration)
+            // conservatively falls back to the method — the pre-existing
+            // preference — since body context alone can't yet disambiguate
+            // which of the two `my word` would dispatch to.
+            let is_classmethod = has_classmethod
+                && (!has_method
+                    || class_def.class_methods.get(word).is_some_and(|m| {
+                        m.name_span.start() <= cursor_offset && cursor_offset < m.name_span.end()
+                    }));
             let (decl, mut calls) = method_references_for_class(
                 source,
                 dialect,
                 analysis,
                 &class_def.qualified_name,
                 word,
+                is_classmethod,
             )?;
             // `next` / `nextto` super-dispatch is a reference / highlight (both
             // callers are read-only); rename resolves methods elsewhere and
@@ -923,6 +972,7 @@ fn find_class_member_references(
                 dialect,
                 &class_def.qualified_name,
                 word,
+                is_classmethod,
             ));
             return Some((decl, calls));
         }
@@ -1006,8 +1056,17 @@ pub(crate) fn find_obj_method_call_sites(
     analysis: &AnalysisResult,
     class_q: &str,
     method: &str,
+    is_classmethod: bool,
 ) -> Vec<tcl_lexer::Span> {
-    find_obj_method_call_sites_with_extra_cmd_names(source, dialect, analysis, class_q, method, &[])
+    find_obj_method_call_sites_with_extra_cmd_names(
+        source,
+        dialect,
+        analysis,
+        class_q,
+        method,
+        is_classmethod,
+        &[],
+    )
 }
 
 /// Whether `cd`'s definer command dispatches its class-scoped members as a
@@ -1030,6 +1089,13 @@ fn is_itcl_class(cd: &tcl_compiler::analyser::types::ClassDef, dialect: &str) ->
 /// names to treat as valid classmethod-dispatch heads for `method`
 /// regardless of what this document's own `analysis.all_classes` knows.
 ///
+/// `is_classmethod` selects `method`'s dispatch shape explicitly rather than
+/// inferring it from map membership: a class may legally define a `method`
+/// and a `classmethod` of the *same name* (they occupy separate dispatch
+/// tables — the instance's and the class object's own), so "does
+/// `class_methods` contain this name" cannot answer "which one does the
+/// caller mean" when both do (Codex review on #971, P2).
+///
 /// A same-document call (`extra_cmd_names` empty) derives everything from
 /// `analysis` directly, as before.  The cross-file *pure-consumer* path
 /// ([`obj_method_call_sites`]) cannot: a document that only calls `Factory
@@ -1042,8 +1108,12 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
     analysis: &AnalysisResult,
     class_q: &str,
     method: &str,
+    is_classmethod: bool,
     extra_cmd_names: &[String],
 ) -> Vec<tcl_lexer::Span> {
+    let hierarchy = analysis.class_hierarchy();
+    // A classmethod dispatches on the class's own command, never an
+    // instance — instance-receiver matching only ever applies to a `method`.
     // Variables whose `$obj method` dispatch resolves to `class_q`'s copy of
     // `method` — its own instances **plus** instances of any subclass that
     // *inherits* this definition (the subclass's MRO resolves `method` to
@@ -1053,15 +1123,18 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
     // to itself, so its instances are excluded here and rewritten under that
     // subclass's own family entry — each site is attributed to exactly one
     // family member (no double count).
-    let hierarchy = analysis.class_hierarchy();
-    let var_set: FxHashSet<&str> = analysis
-        .instance_classes
-        .iter()
-        .filter(|(_, c)| {
-            c.as_str() == class_q || hierarchy.method_target(c, method) == Some(class_q)
-        })
-        .map(|(v, _)| v.as_str())
-        .collect();
+    let var_set: FxHashSet<&str> = if is_classmethod {
+        FxHashSet::default()
+    } else {
+        analysis
+            .instance_classes
+            .iter()
+            .filter(|(_, c)| {
+                c.as_str() == class_q || hierarchy.method_target(c, method) == Some(class_q)
+            })
+            .map(|(v, _)| v.as_str())
+            .collect()
+    };
     // Receivers that are also *object commands* — bound by `CLASS create NAME`
     // (so `NAME` is a command, dispatched bare as `NAME method`, not `$NAME
     // method`).  A `set v [CLASS new]` receiver is a *variable* only and never
@@ -1074,12 +1147,14 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
     // A `classmethod` dispatches on the *class's own* command (`Factory
     // make`) — never on an instance: TclOO's `classmethod` sugar puts the
     // method on the class object's own class, which no instance's MRO
-    // reaches.  When `method` is one of `class_q`'s classmethods (known
-    // locally) *and* `class_q`'s definer family actually uses this two-word
-    // dispatch shape, fold in the defining class's own name (simple +
-    // qualified) plus the own name of any subclass that inherits (does not
-    // override) it — the same inheritance test as the instance `var_set`
-    // above, so a `Sub make` dispatch on an inheriting subclass counts too.
+    // reaches.  When the caller says `method` is a classmethod, and
+    // `class_q`'s definer family actually uses this two-word dispatch shape,
+    // fold in the defining class's own name (simple + qualified) plus the
+    // own name of any subclass that inherits (does not override) it — the
+    // same inheritance test as the instance `var_set` above, so a `Sub make`
+    // dispatch on an inheriting subclass counts too.  Never runs for a plain
+    // `method` — even one that shares a name with a `classmethod` on the same
+    // class — which must never gain a phantom `ClassName method` match.
     //
     // The definer-family check matters because [incr Tcl]'s class-scoped
     // `proc` lands in this same `class_methods` bucket (so the declaration
@@ -1089,10 +1164,11 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
     // call to this proc.  The dispatch shape is registry data
     // (`DefinerFamily`), not something to infer from the shared storage
     // bucket.
-    if analysis
-        .all_classes
-        .get(class_q)
-        .is_some_and(|cd| cd.class_methods.contains_key(method) && !is_itcl_class(cd, dialect))
+    if is_classmethod
+        && analysis
+            .all_classes
+            .get(class_q)
+            .is_some_and(|cd| cd.class_methods.contains_key(method) && !is_itcl_class(cd, dialect))
     {
         for (other_q, other_cd) in &analysis.all_classes {
             if (other_q.as_str() == class_q
@@ -1105,8 +1181,10 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
         }
     }
     // The caller's workspace-wide classmethod knowledge, for a document where
-    // the class itself isn't known locally.
-    cmd_set.extend(extra_cmd_names.iter().map(String::as_str));
+    // the class itself isn't known locally.  Meaningless for a plain method.
+    if is_classmethod {
+        cmd_set.extend(extra_cmd_names.iter().map(String::as_str));
+    }
     if var_set.is_empty() && cmd_set.is_empty() {
         return Vec::new();
     }
@@ -1863,7 +1941,7 @@ mod tests {
     fn find_obj_method_call_sites_covers_top_level_and_subst() {
         let src = "oo::class create Dog {\n    method bark {} {}\n}\nset d [Dog new]\n$d bark\nputs [$d bark]\n";
         let analysis = analyse(src);
-        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark");
+        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark", false);
         // Two external sites: `$d bark` and `[$d bark]`.
         assert_eq!(sites.len(), 2, "{sites:?}");
     }
@@ -1872,7 +1950,7 @@ mod tests {
     fn find_obj_method_call_sites_finds_calls_in_proc_body() {
         let src = "oo::class create Dog {\n    method bark {} {}\n}\nset d [Dog new]\nproc f {} { $d bark }\n";
         let analysis = analyse(src);
-        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark");
+        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark", false);
         assert_eq!(sites.len(), 1, "{sites:?}");
     }
 
@@ -1883,7 +1961,7 @@ mod tests {
         // through `created_instance_commands`.
         let src = "oo::class create Dog {\n    method bark {} {}\n}\nDog create rex\nrex bark\n";
         let analysis = analyse(src);
-        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark");
+        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark", false);
         assert_eq!(sites.len(), 1, "{sites:?}");
         // The matched span is the `bark` method-name token of `rex bark`.
         let s = sites[0];
@@ -1926,7 +2004,7 @@ mod tests {
         // so it must not be matched — only `$d bark` counts.
         let src = "oo::class create Dog {\n    method bark {} {}\n}\nset d [Dog new]\nd bark\n";
         let analysis = analyse(src);
-        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark");
+        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark", false);
         assert!(
             sites.is_empty(),
             "bare var receiver wrongly matched: {sites:?}"

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -62,9 +62,14 @@
 //!
 //! Limitations:
 //!
-//! * Cross-document references — surfacing references across
-//!   every open document via a workspace-index integration —
-//!   are not supported.
+//! * This module is single-document only.  Cross-document references are
+//!   built *on top of* it — `tcl-lsp-server`'s `cross_document_references` /
+//!   `cross_file_method_references` / `cross_file_consumer_method_references`
+//!   call [`obj_method_call_sites`], [`method_reference_spans_in_document`],
+//!   and [`inherited_method_call_sites`] once per candidate document, using
+//!   the workspace index to find which documents to scan and (for a
+//!   classmethod) which class names are valid bare-dispatch heads when the
+//!   scanned document doesn't declare the class itself.
 //! * A classmethod's class-command dispatch is matched by exact name-set
 //!   membership (the class's as-written simple name plus its fully
 //!   `::`-qualified name) rather than full namespace-relative resolution —
@@ -597,6 +602,16 @@ pub fn method_next_dispatch_spans(
 /// [`inherited_method_spans_in_document`] (which key off a local class body)
 /// find nothing; this keys off `instance_classes`, which the cross-file
 /// analysis populates from the workspace class set.
+///
+/// `classmethod_class_names` carries the caller's *workspace-wide* knowledge
+/// of which class names are valid bare-dispatch heads for `method` when it is
+/// a `classmethod` — a pure-consumer document has no local `ClassDef` for
+/// `class_q` to derive this from (unlike the same-document path, whose
+/// [`find_obj_method_call_sites`] derives it from `analysis.all_classes`
+/// directly), so the caller supplies it from the workspace index's
+/// [`WorkspaceMethod`](crate::workspace_index::WorkspaceMethod) `kind`
+/// instead.  Empty when `method` is not a classmethod, or the caller has no
+/// workspace index (same behaviour as before this parameter existed).
 #[must_use]
 pub fn obj_method_call_sites(
     source: &str,
@@ -604,8 +619,16 @@ pub fn obj_method_call_sites(
     analysis: &AnalysisResult,
     class_q: &str,
     method: &str,
+    classmethod_class_names: &[String],
 ) -> Vec<tcl_lexer::Span> {
-    find_obj_method_call_sites(source, dialect, analysis, class_q, method)
+    find_obj_method_call_sites_with_extra_cmd_names(
+        source,
+        dialect,
+        analysis,
+        class_q,
+        method,
+        classmethod_class_names,
+    )
 }
 
 /// Reference spans for `method` on `class_q` **within `source`**, for
@@ -822,6 +845,16 @@ fn scan_next_dispatch_sites(
 /// lives in a *different* file from the method's definer: the cross-file
 /// rename opens the subclass's document and collects these sites so an
 /// inherited-method rename doesn't leave them pointing at the old name.
+///
+/// `extra_classmethod_cmd_names` carries the caller's workspace-wide
+/// knowledge of which class names are valid bare-dispatch heads for `method`
+/// when it is a `classmethod` — this document has `class_q`'s own `ClassDef`
+/// (it *is* declared here), but not necessarily the *definer's* (a pure
+/// inheritor never declares a copy of `method`, so `class_q`'s own
+/// `class_methods` map never lists it, and the definer may live in a document
+/// this one never mentions).  See
+/// [`obj_method_call_sites`]'s identical parameter for the pure-consumer
+/// case this mirrors.
 #[must_use]
 pub(crate) fn inherited_method_call_sites(
     source: &str,
@@ -829,14 +862,20 @@ pub(crate) fn inherited_method_call_sites(
     analysis: &AnalysisResult,
     class_q: &str,
     method: &str,
+    extra_classmethod_cmd_names: &[String],
 ) -> Vec<tcl_lexer::Span> {
     let Some(class_def) = analysis.all_classes.get(class_q) else {
         return Vec::new();
     };
     let bodies = collect_member_bodies(class_def);
     let mut spans = scan_my_method_sites(source, dialect, &bodies, method, None);
-    spans.extend(find_obj_method_call_sites(
-        source, dialect, analysis, class_q, method,
+    spans.extend(find_obj_method_call_sites_with_extra_cmd_names(
+        source,
+        dialect,
+        analysis,
+        class_q,
+        method,
+        extra_classmethod_cmd_names,
     ));
     spans
 }
@@ -968,6 +1007,27 @@ pub(crate) fn find_obj_method_call_sites(
     class_q: &str,
     method: &str,
 ) -> Vec<tcl_lexer::Span> {
+    find_obj_method_call_sites_with_extra_cmd_names(source, dialect, analysis, class_q, method, &[])
+}
+
+/// [`find_obj_method_call_sites`], plus `extra_cmd_names` — bare command
+/// names to treat as valid classmethod-dispatch heads for `method`
+/// regardless of what this document's own `analysis.all_classes` knows.
+///
+/// A same-document call (`extra_cmd_names` empty) derives everything from
+/// `analysis` directly, as before.  The cross-file *pure-consumer* path
+/// ([`obj_method_call_sites`]) cannot: a document that only calls `Factory
+/// make` and never declares/extends `Factory` has no `::Factory` entry in
+/// its own `all_classes` for the local classmethod check below to find, so
+/// its caller supplies the workspace-wide answer here instead.
+fn find_obj_method_call_sites_with_extra_cmd_names(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    class_q: &str,
+    method: &str,
+    extra_cmd_names: &[String],
+) -> Vec<tcl_lexer::Span> {
     // Variables whose `$obj method` dispatch resolves to `class_q`'s copy of
     // `method` — its own instances **plus** instances of any subclass that
     // *inherits* this definition (the subclass's MRO resolves `method` to
@@ -998,11 +1058,11 @@ pub(crate) fn find_obj_method_call_sites(
     // A `classmethod` dispatches on the *class's own* command (`Factory
     // make`) — never on an instance: TclOO's `classmethod` sugar puts the
     // method on the class object's own class, which no instance's MRO
-    // reaches.  When `method` is one of `class_q`'s classmethods, fold in
-    // the defining class's own name (simple + qualified) plus the own name
-    // of any subclass that inherits (does not override) it — the same
-    // inheritance test as the instance `var_set` above, so a `Sub make`
-    // dispatch on an inheriting subclass counts too.
+    // reaches.  When `method` is one of `class_q`'s classmethods (known
+    // locally), fold in the defining class's own name (simple + qualified)
+    // plus the own name of any subclass that inherits (does not override) it
+    // — the same inheritance test as the instance `var_set` above, so a `Sub
+    // make` dispatch on an inheriting subclass counts too.
     if analysis
         .all_classes
         .get(class_q)
@@ -1017,6 +1077,9 @@ pub(crate) fn find_obj_method_call_sites(
             }
         }
     }
+    // The caller's workspace-wide classmethod knowledge, for a document where
+    // the class itself isn't known locally.
+    cmd_set.extend(extra_cmd_names.iter().map(String::as_str));
     if var_set.is_empty() && cmd_set.is_empty() {
         return Vec::new();
     }

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -523,6 +523,15 @@ pub fn method_target_with_access(
         {
             return Some((class_q.clone(), method, false, MethodAccess::External));
         }
+        // Bare `ClassName method` — a classmethod dispatches on the class's
+        // own command, never an instance, so it's tried only when the
+        // receiver isn't `$`-prefixed (a `$var` can never name a class).
+        if !is_dollar
+            && let Some(class_q) =
+                crate::definition::classmethod_dispatch_class(analysis, &inst, &method)
+        {
+            return Some((class_q, method, true, MethodAccess::External));
+        }
     }
     // Inside a class body on one of its method / classmethod names — the
     // declaration side, an internal context.

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -440,8 +440,10 @@ fn rename_method_in_class(
     }
     let mut edits = Vec::new();
     for member in &family {
+        // Only ever reached via an external `$obj method` call site (see the
+        // call site below), which is always an instance-method receiver.
         let Some((decl_span, call_spans)) = crate::references::method_references_for_class(
-            source, dialect, analysis, member, method,
+            source, dialect, analysis, member, method, false,
         ) else {
             continue;
         };
@@ -477,8 +479,9 @@ pub fn method_rename_target(
     line: u32,
     character: u32,
     analysis: &AnalysisResult,
-) -> Option<(String, String)> {
-    method_target_with_access(source, line, character, analysis).map(|(c, m, _)| (c, m))
+) -> Option<(String, String, bool)> {
+    method_target_with_access(source, line, character, analysis)
+        .map(|(c, m, is_cm, _)| (c, m, is_cm))
 }
 
 /// Like [`method_rename_target`] but also reports the **access context**
@@ -492,7 +495,7 @@ pub fn method_target_with_access(
     line: u32,
     character: u32,
     analysis: &AnalysisResult,
-) -> Option<(String, String, crate::workspace_index::MethodAccess)> {
+) -> Option<(String, String, bool, crate::workspace_index::MethodAccess)> {
     use crate::workspace_index::MethodAccess;
     let line_index = LineIndex::new(source);
     let (word, _s, _e) = find_word_span_at_position(source, line, character)?;
@@ -502,6 +505,7 @@ pub fn method_target_with_access(
         && method == word
     {
         // `my method` — an internal call from inside the enclosing class.
+        // Always instance-context: `my` never reaches a classmethod.
         if inst == "my"
             && let Some(class_q) = analysis
                 .all_classes
@@ -510,27 +514,37 @@ pub fn method_target_with_access(
                 .min_by_key(|c| c.body_span.end() - c.body_span.start())
                 .map(|c| c.qualified_name.clone())
         {
-            return Some((class_q, method, MethodAccess::Internal));
+            return Some((class_q, method, false, MethodAccess::Internal));
         }
-        // External `$obj method` — resolve `$obj`'s class.
+        // External `$obj method` — resolve `$obj`'s class.  Always
+        // instance-context too: a classmethod is never reached via `$obj`.
         if let Some(class_q) =
             crate::definition::receiver_instance_class(analysis, &inst, is_dollar)
         {
-            return Some((class_q.clone(), method, MethodAccess::External));
+            return Some((class_q.clone(), method, false, MethodAccess::External));
         }
     }
     // Inside a class body on one of its method / classmethod names — the
     // declaration side, an internal context.
     for class_def in analysis.all_classes.values() {
         let body = class_def.body_span;
-        if body.start() < cursor
-            && cursor < body.end()
-            && (class_def.methods.contains_key(&word)
-                || class_def.class_methods.contains_key(&word))
-        {
+        let has_method = class_def.methods.contains_key(&word);
+        let has_classmethod = class_def.class_methods.contains_key(&word);
+        if body.start() < cursor && cursor < body.end() && (has_method || has_classmethod) {
+            // A `method` and a `classmethod` of the same name are distinct
+            // members; unambiguous when only one exists, otherwise prefer
+            // whichever one's declaration the cursor is actually on (falls
+            // back to the method when the cursor is elsewhere in the body,
+            // e.g. a `my word` call site — the pre-existing preference).
+            let is_classmethod = has_classmethod
+                && (!has_method
+                    || class_def.class_methods.get(&word).is_some_and(|m| {
+                        m.name_span.start() <= cursor && cursor < m.name_span.end()
+                    }));
             return Some((
                 class_def.qualified_name.clone(),
                 word,
+                is_classmethod,
                 MethodAccess::Internal,
             ));
         }
@@ -550,9 +564,16 @@ pub fn method_spans_in_document(
     analysis: &AnalysisResult,
     class_q: &str,
     method: &str,
+    is_classmethod: bool,
 ) -> Vec<tcl_lexer::Span> {
-    match crate::references::method_references_for_class(source, dialect, analysis, class_q, method)
-    {
+    match crate::references::method_references_for_class(
+        source,
+        dialect,
+        analysis,
+        class_q,
+        method,
+        is_classmethod,
+    ) {
         Some((decl, calls)) => {
             let mut spans = Vec::with_capacity(1 + calls.len());
             spans.push(decl);
@@ -585,6 +606,7 @@ pub fn inherited_method_spans_in_document(
     analysis: &AnalysisResult,
     class_q: &str,
     method: &str,
+    is_classmethod: bool,
     extra_classmethod_cmd_names: &[String],
 ) -> Vec<tcl_lexer::Span> {
     crate::references::inherited_method_call_sites(
@@ -593,6 +615,7 @@ pub fn inherited_method_spans_in_document(
         analysis,
         class_q,
         method,
+        is_classmethod,
         extra_classmethod_cmd_names,
     )
 }
@@ -939,13 +962,23 @@ fn rename_method(
         if !(body.start() < cursor_offset && cursor_offset < body.end()) {
             continue;
         }
-        // Try methods, then class_methods, then properties.
-        let member_name_span: Option<Span> = class_def
-            .methods
-            .get(word)
-            .map(|m| m.name_span)
-            .or_else(|| class_def.class_methods.get(word).map(|m| m.name_span))
-            .or_else(|| class_def.properties.get(word).map(|p| p.name_span));
+        // A `method` and a `classmethod` of the same name are distinct
+        // members; unambiguous when only one exists, otherwise prefer
+        // whichever one's declaration the cursor is actually on.
+        let has_method = class_def.methods.contains_key(word);
+        let has_classmethod = class_def.class_methods.contains_key(word);
+        let is_classmethod = has_classmethod
+            && (!has_method
+                || class_def.class_methods.get(word).is_some_and(|m| {
+                    m.name_span.start() <= cursor_offset && cursor_offset < m.name_span.end()
+                }));
+        // Try the disambiguated kind first, then the other, then properties.
+        let member_name_span: Option<Span> = if is_classmethod {
+            class_def.class_methods.get(word).map(|m| m.name_span)
+        } else {
+            class_def.methods.get(word).map(|m| m.name_span)
+        }
+        .or_else(|| class_def.properties.get(word).map(|p| p.name_span));
         let name_span = member_name_span?;
         let mut edits = vec![TextEdit {
             range: span_to_range(source, line_index, name_span),
@@ -987,10 +1020,15 @@ fn rename_method(
         // class through it too (rather than an ad-hoc self-only scan) is what
         // catches an inheriting subclass's `my method` / `$obj method` sites
         // when renaming from the base declaration.
-        if class_def.methods.contains_key(word) || class_def.class_methods.contains_key(word) {
+        if has_method || has_classmethod {
             for member in override_family(analysis, &class_def.qualified_name, word) {
                 let Some((decl_span, call_spans)) = crate::references::method_references_for_class(
-                    source, dialect, analysis, &member, word,
+                    source,
+                    dialect,
+                    analysis,
+                    &member,
+                    word,
+                    is_classmethod,
                 ) else {
                     continue;
                 };

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -573,6 +573,11 @@ pub fn method_spans_in_document(
 /// cross-file complement to [`method_spans_in_document`], so an
 /// inherited-method rename reaches `my method` / `$obj method` sites that
 /// live in a subclass-only file.
+///
+/// `extra_classmethod_cmd_names`: see
+/// [`crate::references::inherited_method_call_sites`]'s identical parameter —
+/// the workspace-wide classmethod-dispatch names this subclass-only document
+/// cannot derive from its own (definer-less) `all_classes`.
 #[must_use]
 pub fn inherited_method_spans_in_document(
     source: &str,
@@ -580,8 +585,16 @@ pub fn inherited_method_spans_in_document(
     analysis: &AnalysisResult,
     class_q: &str,
     method: &str,
+    extra_classmethod_cmd_names: &[String],
 ) -> Vec<tcl_lexer::Span> {
-    crate::references::inherited_method_call_sites(source, dialect, analysis, class_q, method)
+    crate::references::inherited_method_call_sites(
+        source,
+        dialect,
+        analysis,
+        class_q,
+        method,
+        extra_classmethod_cmd_names,
+    )
 }
 
 /// The set of classes whose definition of `method` must be renamed

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -114,9 +114,29 @@ pub struct WorkspaceClass {
     /// [`tcl_compiler::analyser::ClassDef::via_define`]).  Go-to-definition
     /// prefers a real creation site over a stub.
     pub via_define: bool,
+    /// The definer command as written (`"oo::class"`, `"snit::type"`,
+    /// `"itcl::class"`, …) — see
+    /// [`tcl_compiler::analyser::ClassDef::metaclass`].  Lets a cross-file
+    /// consumer tell [incr Tcl]'s class-scoped `proc` (dispatched as a
+    /// single `::`-qualified identifier) apart from a `TclOO`
+    /// `classmethod` / snit `typemethod` (dispatched as two bare words)
+    /// without a local `ClassDef` to ask.
+    pub metaclass: String,
 }
 
 impl WorkspaceClass {
+    /// Whether this record's definer dispatches its class-scoped members as
+    /// a single `::`-qualified identifier (`Factory::make`) rather than the
+    /// two-word `Factory make` shape — true for [incr Tcl] only.  Registry
+    /// data (`DefinerFamily`), not a hardcoded command-name check.
+    #[must_use]
+    pub fn is_itcl(&self, dialect: &str) -> bool {
+        tcl_registry::registry_for_dialect(dialect)
+            .get(&self.metaclass)
+            .and_then(|spec| spec.definition_body)
+            .is_some_and(|g| g.family == tcl_registry::definer::DefinerFamily::Itcl)
+    }
+
     /// Whether this record directly defines `name` (any receiver kind).
     #[must_use]
     pub fn defines_method(&self, name: &str) -> bool {
@@ -350,6 +370,7 @@ impl WorkspaceIndex {
                 exports: class_def.exports.iter().cloned().collect(),
                 unexports: class_def.unexports.iter().cloned().collect(),
                 via_define: class_def.via_define,
+                metaclass: class_def.metaclass.clone(),
             });
         }
         for inv in &analysis.command_invocations {

--- a/rust/tcl-lsp-core/tests/name_resolution.rs
+++ b/rust/tcl-lsp-core/tests/name_resolution.rs
@@ -156,6 +156,96 @@ mod obj_method_dispatch {
         let src = "oo::class create Solo {\n    method ping {} { return pong }\n}\n";
         assert_eq!(refs_at(src, 1, 11), vec![1], "declaration only");
     }
+
+    /// FN→TP regression for the *exact* issue #956 repro: a `variable` and
+    /// `constructor` declared before the `method`, with the method body
+    /// reading the instance variable.  The previous investigation of #956
+    /// tested a simplified `Bar956` fixture without these members and
+    /// concluded the count was already correct — true for the count, but
+    /// the codeLens *command* was still empty (fixed separately in
+    /// `tcl-lsp-core::code_lens` / `tcl-lsp-server`); this locks in that
+    /// find-references itself was never affected by the extra members.
+    #[test]
+    fn fn_to_tp_exact_issue_956_repro_with_constructor_and_variable() {
+        let src = "oo::class create Bar {\n   variable _options\n    constructor {args} {\n         set _options $args\n    }\n\n    method get {key} {\n        return [dict get $_options $key]\n    }\n\n}\nset b [Bar new]\nputs [$b get foo]\n";
+        // cursor on the `get` declaration name (line 6, col 11).
+        assert_eq!(
+            refs_at(src, 6, 11),
+            vec![6, 12],
+            "decl + `puts [$b get foo]`"
+        );
+    }
+}
+
+// ─────────────────── classmethod dispatch on the class's own command ──────
+
+mod classmethod_dispatch {
+    use super::*;
+
+    /// FN→TP: a `classmethod` dispatches on the *class's own* command
+    /// (`Factory make`) — never on an instance.  Before this fix,
+    /// `find_obj_method_call_sites` only tracked instance handles, so a
+    /// classmethod's reference count and codeLens were always "0
+    /// references" regardless of how many times it was actually called —
+    /// the common (in fact only) classmethod dispatch shape was invisible.
+    #[test]
+    fn tp_bare_class_command_dispatch_is_a_reference() {
+        let src = "oo::class create Factory {\n    classmethod make {} {\n        return [Factory new]\n    }\n}\nFactory make\n";
+        // cursor on the `make` declaration name (line 1, col 16); the bare
+        // `Factory make` dispatch is on line 5.
+        assert_eq!(refs_at(src, 1, 16), vec![1, 5], "decl + `Factory make`");
+    }
+
+    /// TP: a subclass that inherits (does not override) the classmethod
+    /// dispatches on its *own* command and still counts as a reference to
+    /// the ancestor's declaration — mirrors the existing instance-method
+    /// inheritance handling.
+    #[test]
+    fn tp_inheriting_subclass_own_command_dispatch_is_a_reference() {
+        let src = "oo::class create Factory {\n    classmethod make {} { return [Factory new] }\n}\noo::class create SubFactory {\n    superclass Factory\n}\nSubFactory make\n";
+        assert_eq!(
+            refs_at(src, 1, 16),
+            vec![1, 6],
+            "decl + inheriting subclass's own-command dispatch"
+        );
+    }
+
+    /// FP guard: an *overriding* subclass's own dispatch must attribute to
+    /// its own declaration, not the ancestor's — the ancestor's reference
+    /// set must not include it.
+    #[test]
+    fn fp_overriding_subclass_dispatch_excluded_from_ancestor() {
+        let src = "oo::class create Factory {\n    classmethod make {} { return 1 }\n}\noo::class create SubFactory {\n    superclass Factory\n    classmethod make {} { return 2 }\n}\nSubFactory make\n";
+        // cursor on Factory::make (line 1). References must be its
+        // declaration only — `SubFactory make` resolves to SubFactory's own
+        // override, never Factory's.
+        assert_eq!(refs_at(src, 1, 16), vec![1], "override excluded");
+    }
+
+    /// FP guard: a regular *instance* method must never gain bare
+    /// class-command dispatch — `Factory get` (no `$obj`/instance) is not a
+    /// valid `TclOO` call for an instance method, so it must not be
+    /// synthesised as a reference just because the class's own command
+    /// shares a name-set entry point with classmethod dispatch.
+    #[test]
+    fn fp_instance_method_gets_no_bare_class_command_dispatch() {
+        let src = "oo::class create Factory {\n    method get {} { return 1 }\n}\nFactory get\n";
+        // `Factory get` is not a `$obj`/instance dispatch, so it must not be
+        // pulled in — declaration only.
+        assert_eq!(
+            refs_at(src, 1, 11),
+            vec![1],
+            "no phantom class-command dispatch"
+        );
+    }
+
+    /// TN: a declared-but-never-dispatched classmethod has only its
+    /// declaration.
+    #[test]
+    fn tn_uncalled_classmethod_only_declaration() {
+        let src = "oo::class create Factory {\n    classmethod make {} { return 1 }\n}\n";
+        assert_eq!(refs_at(src, 1, 16), vec![1], "declaration only");
+    }
 }
 
 // ───────────────────────── #957 — `my method` references ──────────────────

--- a/rust/tcl-lsp-core/tests/name_resolution.rs
+++ b/rust/tcl-lsp-core/tests/name_resolution.rs
@@ -246,6 +246,42 @@ mod classmethod_dispatch {
         let src = "oo::class create Factory {\n    classmethod make {} { return 1 }\n}\n";
         assert_eq!(refs_at(src, 1, 16), vec![1], "declaration only");
     }
+
+    /// FN→TP: snit's `typemethod` is snit's equivalent of `TclOO`'s
+    /// `classmethod` — dispatched the same way, on the type's own command
+    /// (`Factory make`), never an instance. The definition-body grammar maps
+    /// both to the same `class_methods` map (a registry-driven fact, not a
+    /// TclOO-specific hardcoded check), so this generalises for free with no
+    /// snit-specific code in `find_obj_method_call_sites`.
+    #[test]
+    fn tp_snit_typemethod_bare_dispatch_is_a_reference() {
+        let src = "snit::type Factory {\n    typemethod make {} {\n        return [Factory create x]\n    }\n}\nFactory make\n";
+        assert_eq!(
+            refs_at(src, 1, 15),
+            vec![1, 5],
+            "decl + `Factory make` (snit typemethod)"
+        );
+    }
+
+    /// FP guard: [incr Tcl]'s class-scoped `proc` maps to the same
+    /// `class_methods` bucket as `classmethod`/`typemethod` (so the
+    /// declaration-side lookup reaches this fix's code path too), but itcl
+    /// dispatches it as a single `::`-qualified identifier
+    /// (`Factory::make`), never the two-word `Factory make` form this fix's
+    /// `cmd_set` scan matches. Widening `cmd_set` with `Factory`'s bare name
+    /// must not fabricate a phantom reference for an unrelated bare `Factory`
+    /// command elsewhere, and the real `Factory::make` call is simply out of
+    /// this scanner's shape (a distinct, pre-existing gap — namespace-style
+    /// dispatch is a job for the ordinary proc-reference path, not this
+    /// object-method scanner).
+    #[test]
+    fn fp_itcl_class_proc_colon_dispatch_not_confused_with_bare_dispatch() {
+        let src = "itcl::class Factory {\n    proc make {} {\n        return 1\n    }\n}\nFactory::make\n";
+        // Only the declaration; the `::`-qualified call is not the
+        // two-word shape this scanner looks for, so it must not appear —
+        // and no bare `Factory make` exists here to spuriously match either.
+        assert_eq!(refs_at(src, 1, 9), vec![1], "declaration only");
+    }
 }
 
 // ───────────────────────── #957 — `my method` references ──────────────────

--- a/rust/tcl-lsp-core/tests/name_resolution.rs
+++ b/rust/tcl-lsp-core/tests/name_resolution.rs
@@ -282,6 +282,24 @@ mod classmethod_dispatch {
         // and no bare `Factory make` exists here to spuriously match either.
         assert_eq!(refs_at(src, 1, 9), vec![1], "declaration only");
     }
+
+    /// FP guard: a bare two-word `Factory make` must not be treated as a
+    /// class-proc dispatch either — itcl's real syntax for creating (and
+    /// naming) a new instance is `ClassName instanceName`, so `Factory make`
+    /// in real itcl code names a *new object* called `make`, never a call to
+    /// the class-scoped `proc make`.  Folding every `class_methods` entry
+    /// into the bare two-word `cmd_set` regardless of definer family would
+    /// wrongly count (and rewrite, under rename) this unrelated construct.
+    #[test]
+    fn fp_itcl_bare_two_word_text_is_not_confused_with_class_proc_dispatch() {
+        let src =
+            "itcl::class Factory {\n    proc make {} {\n        return 1\n    }\n}\nFactory make\n";
+        assert_eq!(
+            refs_at(src, 1, 9),
+            vec![1],
+            "declaration only — `Factory make` is itcl instance creation, not a class-proc dispatch"
+        );
+    }
 }
 
 // ───────────────────────── #957 — `my method` references ──────────────────

--- a/rust/tcl-lsp-core/tests/name_resolution.rs
+++ b/rust/tcl-lsp-core/tests/name_resolution.rs
@@ -196,6 +196,20 @@ mod classmethod_dispatch {
         assert_eq!(refs_at(src, 1, 16), vec![1, 5], "decl + `Factory make`");
     }
 
+    /// FN→TP: the reverse direction of the previous test — cursor on the
+    /// *call site* itself (`Factory make`, line 5), not the declaration.
+    /// Previously resolved to nothing at all (Codex review on #971, P2):
+    /// `$obj`/`my` resolution doesn't match a bare two-word receiver, and
+    /// the declaration-side resolver requires the cursor inside the class
+    /// body, so Find References / Rename triggered from the actual dispatch
+    /// site silently did nothing.
+    #[test]
+    fn tp_bare_class_command_dispatch_resolves_from_the_call_site_itself() {
+        let src = "oo::class create Factory {\n    classmethod make {} {\n        return [Factory new]\n    }\n}\nFactory make\n";
+        // cursor on `make` in `Factory make` (line 5, col 8).
+        assert_eq!(refs_at(src, 5, 8), vec![1, 5], "decl + `Factory make`");
+    }
+
     /// TP: a subclass that inherits (does not override) the classmethod
     /// dispatches on its *own* command and still counts as a reference to
     /// the ancestor's declaration — mirrors the existing instance-method

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4224,11 +4224,14 @@ impl Backend {
         definers: &[&core_workspace_index::WorkspaceClass],
         inheritors: &[&core_workspace_index::WorkspaceClass],
         method: &str,
+        dialect: &str,
     ) -> Vec<String> {
         let is_classmethod = definers.iter().any(|wc| {
-            wc.methods
-                .iter()
-                .any(|m| m.name == method && m.kind == "classmethod")
+            !wc.is_itcl(dialect)
+                && wc
+                    .methods
+                    .iter()
+                    .any(|m| m.name == method && m.kind == "classmethod")
         });
         if !is_classmethod {
             return Vec::new();
@@ -4236,6 +4239,7 @@ impl Backend {
         definers
             .iter()
             .chain(inheritors.iter())
+            .filter(|wc| !wc.is_itcl(dialect))
             .flat_map(|wc| [wc.name.clone(), wc.qualified_name.clone()])
             .collect()
     }
@@ -4278,7 +4282,7 @@ impl Backend {
             let definers = index.method_override_family(seed_class, method);
             let inheritors = index.method_inheritor_classes(seed_class, method);
             let classmethod_cmd_names =
-                Self::classmethod_dispatch_names(&definers, &inheritors, method);
+                Self::classmethod_dispatch_names(&definers, &inheritors, method, current_dialect);
             let mut family: Vec<String> = definers
                 .iter()
                 .map(|wc| wc.qualified_name.clone())
@@ -4391,6 +4395,7 @@ impl Backend {
         seed_class: &str,
         method: &str,
         new_name: &str,
+        dialect: &str,
     ) -> std::collections::HashMap<Uri, Vec<TextEdit>> {
         let mut changes: std::collections::HashMap<Uri, Vec<TextEdit>> =
             std::collections::HashMap::new();
@@ -4408,7 +4413,7 @@ impl Backend {
             let definers = index.method_override_family(seed_class, method);
             let inheritors = index.method_inheritor_classes(seed_class, method);
             let classmethod_cmd_names =
-                Self::classmethod_dispatch_names(&definers, &inheritors, method);
+                Self::classmethod_dispatch_names(&definers, &inheritors, method, dialect);
             let mut m: std::collections::HashMap<String, (Vec<String>, Vec<String>)> =
                 std::collections::HashMap::new();
             for wc in definers {
@@ -4511,13 +4516,14 @@ impl Backend {
         seed_class: &str,
         method: &str,
         include_declaration: bool,
+        dialect: &str,
     ) -> Vec<Location> {
         let (by_uri, classmethod_cmd_names) = {
             let index = self.workspace_index.read().await;
             let definers = index.method_override_family(seed_class, method);
             let inheritors = index.method_inheritor_classes(seed_class, method);
             let classmethod_cmd_names =
-                Self::classmethod_dispatch_names(&definers, &inheritors, method);
+                Self::classmethod_dispatch_names(&definers, &inheritors, method, dialect);
             let mut m: std::collections::HashMap<String, (Vec<String>, Vec<String>)> =
                 std::collections::HashMap::new();
             for wc in definers {
@@ -4598,6 +4604,52 @@ impl Backend {
             }
         }
         out
+    }
+
+    /// The method-dispatch half of [`Self::references`]: resolves the
+    /// cursor to a `(class, method)` target (oracle-aware, so a
+    /// pure-consumer cursor whose `$obj`'s class lives in another file still
+    /// identifies it), then gathers its sites across the override family in
+    /// sibling documents plus pure-consumer documents the family pass can't
+    /// see.  Empty when the cursor names no method.
+    async fn cross_file_method_and_consumer_references(
+        &self,
+        uri: &Uri,
+        doc: &DocumentState,
+        analysis: &AnalysisResult,
+        pos: Position,
+        include_decl: bool,
+    ) -> Vec<Location> {
+        let mut locations = Vec::new();
+        if let Some((seed_class, method, _access)) = self
+            .resolve_method_target(&doc.text, &doc.dialect, analysis, pos)
+            .await
+        {
+            locations.extend(
+                self.cross_file_method_references(
+                    uri,
+                    &seed_class,
+                    &method,
+                    include_decl,
+                    &doc.dialect,
+                )
+                .await,
+            );
+            // Pure-consumer documents (including this one) whose `$obj method`
+            // sites neither the single-document provider nor the family pass
+            // sees without the workspace class oracle.
+            locations.extend(
+                self.cross_file_consumer_method_references(
+                    uri,
+                    &doc.text,
+                    &doc.dialect,
+                    &seed_class,
+                    &method,
+                )
+                .await,
+            );
+        }
+        locations
     }
 
     /// Cross-file go-to-definition for a `TclOO` method: the declaration
@@ -8367,31 +8419,18 @@ impl LanguageServer for Backend {
         // Cross-document TclOO method sites: when the cursor names a method
         // (its declaration inside a class body, or an `$obj method` / `my
         // method` call), gather the method's sites across its override family in
-        // sibling documents — the single-document provider above only sees this
-        // file.  The target is resolved oracle-aware so a pure-consumer cursor
-        // (`$obj`'s class defined in another file) still identifies the method.
-        if let Some((seed_class, method, _access)) = self
-            .resolve_method_target(&doc.text, &doc.dialect, &analysis, pos)
-            .await
-        {
-            let method_cross = self
-                .cross_file_method_references(&uri, &seed_class, &method, include_decl)
-                .await;
-            locations.extend(method_cross);
-            // Pure-consumer documents (including this one) whose `$obj method`
-            // sites neither the single-document provider nor the family pass
-            // sees without the workspace class oracle.
-            let consumer = self
-                .cross_file_consumer_method_references(
-                    &uri,
-                    &doc.text,
-                    &doc.dialect,
-                    &seed_class,
-                    &method,
-                )
-                .await;
-            locations.extend(consumer);
-        }
+        // sibling documents, plus pure-consumer documents the family pass can't
+        // see — the single-document provider above only sees this file.
+        locations.extend(
+            self.cross_file_method_and_consumer_references(
+                &uri,
+                &doc,
+                &analysis,
+                pos,
+                include_decl,
+            )
+            .await,
+        );
         dedup_locations(&mut locations);
         if locations.is_empty() {
             return Ok(None);
@@ -9861,7 +9900,7 @@ impl LanguageServer for Backend {
                 core_rename::method_rename_target(&doc.text, pos.line, pos.character, &analysis)
         {
             let changes = self
-                .cross_file_method_rename(&seed_class, &method, &new_name)
+                .cross_file_method_rename(&seed_class, &method, &new_name, &doc.dialect)
                 .await;
             if !changes.is_empty() {
                 return Ok(Some(WorkspaceEdit {
@@ -19154,7 +19193,7 @@ mod tests {
         // had no cross-file reference support at all.
         let (backend, animal, dog) = register_method_family_workspace().await;
         let refs = backend
-            .cross_file_method_references(&animal, "::Animal", "speak", true)
+            .cross_file_method_references(&animal, "::Animal", "speak", true, "tcl8.6")
             .await;
         let dog_lines: Vec<u32> = refs
             .iter()
@@ -19180,7 +19219,7 @@ mod tests {
         // (l2) is dropped but the `$d speak` call site (l5) stays.
         let (backend, animal, dog) = register_method_family_workspace().await;
         let refs = backend
-            .cross_file_method_references(&animal, "::Animal", "speak", false)
+            .cross_file_method_references(&animal, "::Animal", "speak", false, "tcl8.6")
             .await;
         let dog_lines: Vec<u32> = refs
             .iter()
@@ -19212,7 +19251,7 @@ mod tests {
         )
         .await;
         let refs = backend
-            .cross_file_method_references(&animal, "::Animal", "speak", false)
+            .cross_file_method_references(&animal, "::Animal", "speak", false, "tcl8.6")
             .await;
         let dog_lines: Vec<u32> = refs
             .iter()
@@ -19248,7 +19287,7 @@ mod tests {
         )
         .await;
         let refs = backend
-            .cross_file_method_references(&factory, "::Factory", "make", false)
+            .cross_file_method_references(&factory, "::Factory", "make", false, "tcl8.6")
             .await;
         let sub_lines: Vec<u32> = refs
             .iter()
@@ -19267,7 +19306,7 @@ mod tests {
         // cross-file sites.
         let (backend, animal, _dog) = register_method_family_workspace().await;
         let refs = backend
-            .cross_file_method_references(&animal, "::Animal", "nonexistent", true)
+            .cross_file_method_references(&animal, "::Animal", "nonexistent", true, "tcl8.6")
             .await;
         assert!(refs.is_empty(), "{refs:?}");
     }
@@ -19358,6 +19397,38 @@ mod tests {
         assert!(
             !refs.iter().any(|l| l.uri == consumer),
             "a plain method must not gain phantom class-command dispatch: {refs:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_file_consumer_does_not_bare_dispatch_an_itcl_class_proc() {
+        // FP guard, cross-file: [incr Tcl]'s class-scoped `proc` lands in the
+        // same `class_methods` bucket as a `classmethod`/`typemethod` (so the
+        // workspace index also sees it as `WorkspaceMethod::kind ==
+        // "classmethod"`), but itcl dispatches it as a single
+        // `::`-qualified identifier (`Factory::make`), never the two-word
+        // `Factory make` shape — which is itcl's own instance-creation
+        // syntax (`ClassName instanceName`) for an unrelated object named
+        // "make".  `classmethod_dispatch_names` must exclude itcl definers
+        // the same way the same-document scanner does.
+        let backend = test_backend();
+        let factory = Uri::from_str("file:///factory5.tcl").unwrap();
+        let consumer = Uri::from_str("file:///consumer5.tcl").unwrap();
+        let factory_src = "itcl::class Factory {\n    proc make {} {\n        return 1\n    }\n}\n";
+        register(&backend, &factory, factory_src).await;
+        register(&backend, &consumer, "Factory make\n").await;
+        let refs = backend
+            .cross_file_consumer_method_references(
+                &factory,
+                factory_src,
+                "tcl8.6",
+                "::Factory",
+                "make",
+            )
+            .await;
+        assert!(
+            !refs.iter().any(|l| l.uri == consumer),
+            "itcl class-proc must not gain phantom two-word dispatch: {refs:?}"
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3690,7 +3690,7 @@ impl Backend {
         // still identifies the method, and access-context-aware so an
         // external call resolves the exported dispatch entry only
         // (issue #945 faults 4 + 6).
-        if let Some((class_q, method, access)) = self
+        if let Some((class_q, method, _is_classmethod, access)) = self
             .resolve_method_target(&doc.text, &doc.dialect, &analysis, pos)
             .await
         {
@@ -4193,7 +4193,7 @@ impl Backend {
         dialect: &str,
         analysis: &AnalysisResult,
         pos: Position,
-    ) -> Option<(String, String, core_workspace_index::MethodAccess)> {
+    ) -> Option<(String, String, bool, core_workspace_index::MethodAccess)> {
         if let Some(target) =
             core_rename::method_target_with_access(source, pos.line, pos.character, analysis)
         {
@@ -4223,16 +4223,14 @@ impl Backend {
     fn classmethod_dispatch_names(
         definers: &[&core_workspace_index::WorkspaceClass],
         inheritors: &[&core_workspace_index::WorkspaceClass],
-        method: &str,
+        is_classmethod: bool,
         dialect: &str,
     ) -> Vec<String> {
-        let is_classmethod = definers.iter().any(|wc| {
-            !wc.is_itcl(dialect)
-                && wc
-                    .methods
-                    .iter()
-                    .any(|m| m.name == method && m.kind == "classmethod")
-        });
+        // `is_classmethod` is the caller's already-resolved fact (from the
+        // cursor, or the caller's own test fixture) about which of a
+        // possibly-same-named `method` / `classmethod` pair is meant — not
+        // re-derived from workspace membership, which can't disambiguate
+        // when a class legally defines both (Codex review on #971, P2).
         if !is_classmethod {
             return Vec::new();
         }
@@ -4263,26 +4261,28 @@ impl Backend {
         current_dialect: &str,
         seed_class: &str,
         method: &str,
+        is_classmethod: bool,
     ) -> Vec<Location> {
         // The family + inheritor classes whose instances dispatch `method` to
         // the family, the workspace class oracle, and the candidate consumer
         // documents — collected under one index read.
         //
-        // `classmethod_cmd_names` carries the workspace-wide answer to "is
-        // `method` a classmethod, and if so, which class names bare-dispatch
-        // it" — a pure-consumer document (e.g. one that only calls `Factory
-        // make`) has no local `ClassDef` for `Factory`, so
+        // `classmethod_cmd_names` carries the workspace-wide answer to "given
+        // `is_classmethod` is true, which class names bare-dispatch it" — a
+        // pure-consumer document (e.g. one that only calls `Factory make`)
+        // has no local `ClassDef` for `Factory`, so
         // `core_references::obj_method_call_sites` cannot derive this itself
-        // the way the same-document path does; the workspace index's
-        // per-method `kind` (`"method"` / `"classmethod"` / `"forward"`) is
-        // the centralised source of that fact instead of guessing from the
-        // command name.
+        // the way the same-document path does.
         let (family, consumer_uris, classmethod_cmd_names) = {
             let index = self.workspace_index.read().await;
             let definers = index.method_override_family(seed_class, method);
             let inheritors = index.method_inheritor_classes(seed_class, method);
-            let classmethod_cmd_names =
-                Self::classmethod_dispatch_names(&definers, &inheritors, method, current_dialect);
+            let classmethod_cmd_names = Self::classmethod_dispatch_names(
+                &definers,
+                &inheritors,
+                is_classmethod,
+                current_dialect,
+            );
             let mut family: Vec<String> = definers
                 .iter()
                 .map(|wc| wc.qualified_name.clone())
@@ -4342,6 +4342,7 @@ impl Backend {
                         &analysis,
                         cq,
                         &method_owned,
+                        is_classmethod,
                         &classmethod_cmd_names_cl,
                     ));
                 }
@@ -4395,6 +4396,7 @@ impl Backend {
         seed_class: &str,
         method: &str,
         new_name: &str,
+        is_classmethod: bool,
         dialect: &str,
     ) -> std::collections::HashMap<Uri, Vec<TextEdit>> {
         let mut changes: std::collections::HashMap<Uri, Vec<TextEdit>> =
@@ -4413,7 +4415,7 @@ impl Backend {
             let definers = index.method_override_family(seed_class, method);
             let inheritors = index.method_inheritor_classes(seed_class, method);
             let classmethod_cmd_names =
-                Self::classmethod_dispatch_names(&definers, &inheritors, method, dialect);
+                Self::classmethod_dispatch_names(&definers, &inheritors, is_classmethod, dialect);
             let mut m: std::collections::HashMap<String, (Vec<String>, Vec<String>)> =
                 std::collections::HashMap::new();
             for wc in definers {
@@ -4453,6 +4455,7 @@ impl Backend {
                         &analysis,
                         cq,
                         &method_owned,
+                        is_classmethod,
                     ));
                 }
                 for cq in &inheritors {
@@ -4462,6 +4465,7 @@ impl Backend {
                         &analysis,
                         cq,
                         &method_owned,
+                        is_classmethod,
                         &classmethod_cmd_names_cl,
                     ));
                 }
@@ -4516,6 +4520,7 @@ impl Backend {
         seed_class: &str,
         method: &str,
         include_declaration: bool,
+        is_classmethod: bool,
         dialect: &str,
     ) -> Vec<Location> {
         let (by_uri, classmethod_cmd_names) = {
@@ -4523,7 +4528,7 @@ impl Backend {
             let definers = index.method_override_family(seed_class, method);
             let inheritors = index.method_inheritor_classes(seed_class, method);
             let classmethod_cmd_names =
-                Self::classmethod_dispatch_names(&definers, &inheritors, method, dialect);
+                Self::classmethod_dispatch_names(&definers, &inheritors, is_classmethod, dialect);
             let mut m: std::collections::HashMap<String, (Vec<String>, Vec<String>)> =
                 std::collections::HashMap::new();
             for wc in definers {
@@ -4568,6 +4573,7 @@ impl Backend {
                         cq,
                         &method_owned,
                         include_declaration,
+                        is_classmethod,
                     ));
                 }
                 for cq in &inheritors {
@@ -4577,6 +4583,7 @@ impl Backend {
                         &analysis,
                         cq,
                         &method_owned,
+                        is_classmethod,
                         &classmethod_cmd_names_cl,
                     ));
                 }
@@ -4621,7 +4628,7 @@ impl Backend {
         include_decl: bool,
     ) -> Vec<Location> {
         let mut locations = Vec::new();
-        if let Some((seed_class, method, _access)) = self
+        if let Some((seed_class, method, is_classmethod, _access)) = self
             .resolve_method_target(&doc.text, &doc.dialect, analysis, pos)
             .await
         {
@@ -4631,6 +4638,7 @@ impl Backend {
                     &seed_class,
                     &method,
                     include_decl,
+                    is_classmethod,
                     &doc.dialect,
                 )
                 .await,
@@ -4645,6 +4653,7 @@ impl Backend {
                     &doc.dialect,
                     &seed_class,
                     &method,
+                    is_classmethod,
                 )
                 .await,
             );
@@ -9896,11 +9905,17 @@ impl LanguageServer for Backend {
         // single-document path when the family is empty (e.g. the index is
         // not yet populated) so nothing regresses.
         if core_rename::is_safe_symbol_name(&new_name)
-            && let Some((seed_class, method)) =
+            && let Some((seed_class, method, is_classmethod)) =
                 core_rename::method_rename_target(&doc.text, pos.line, pos.character, &analysis)
         {
             let changes = self
-                .cross_file_method_rename(&seed_class, &method, &new_name, &doc.dialect)
+                .cross_file_method_rename(
+                    &seed_class,
+                    &method,
+                    &new_name,
+                    is_classmethod,
+                    &doc.dialect,
+                )
                 .await;
             if !changes.is_empty() {
                 return Ok(Some(WorkspaceEdit {
@@ -18692,6 +18707,54 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn code_lens_resolve_disambiguates_method_and_classmethod_of_the_same_name() {
+        // `method make` and `classmethod make` on the same class are two
+        // distinct, independently-dispatched members (TclOO allows both:
+        // one on the instance, one on the class object) — Codex review on
+        // #971 (P2) caught that `member_ref_count`/`method_references_for_class`
+        // received only the bare name and combined `$obj make` with
+        // `Factory make` for *both* lenses. Each lens must count and
+        // resolve to *only* its own dispatch shape.
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///dual_make.tcl").unwrap();
+        let src = "oo::class create Factory {\n    method make {} { return 1 }\n    classmethod make {} { return [Factory new] }\n}\nset f [Factory new]\n$f make\nFactory make\n";
+        let method_lens = resolve_member_lens_at_line(&backend, &uri, src, 1).await;
+        let classmethod_lens = resolve_member_lens_at_line(&backend, &uri, src, 2).await;
+
+        let method_cmd = method_lens
+            .command
+            .expect("method lens must resolve to a command");
+        assert_eq!(method_cmd.title, "1 reference", "{method_cmd:?}");
+        let method_locations = method_cmd.arguments.expect("args")[2]
+            .as_array()
+            .expect("locations array")
+            .clone();
+        assert_eq!(
+            method_locations.len(),
+            1,
+            "method lens must count only `$f make` (l5), not `Factory make` (l6): {method_locations:?}"
+        );
+
+        let classmethod_cmd = classmethod_lens
+            .command
+            .expect("classmethod lens must resolve to a command");
+        assert_eq!(classmethod_cmd.title, "1 reference", "{classmethod_cmd:?}");
+        let classmethod_locations = classmethod_cmd.arguments.expect("args")[2]
+            .as_array()
+            .expect("locations array")
+            .clone();
+        assert_eq!(
+            classmethod_locations.len(),
+            1,
+            "classmethod lens must count only `Factory make` (l6), not `$f make` (l5): {classmethod_locations:?}"
+        );
+        assert_ne!(
+            method_locations, classmethod_locations,
+            "the two lenses must resolve to different call sites"
+        );
+    }
+
+    #[tokio::test]
     async fn code_lens_resolve_for_unused_method_is_clickable_with_zero_locations() {
         // TN: a declared-but-never-dispatched method still resolves to a
         // real command (an empty peek is a valid "0 references" click
@@ -19164,6 +19227,52 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn rename_disambiguates_method_and_classmethod_of_the_same_name() {
+        // Same fixture as `code_lens_resolve_disambiguates_method_and_classmethod_of_the_same_name`,
+        // but through the production `rename` handler: renaming from the
+        // cursor on `method make`'s declaration must rewrite only the
+        // method's own declaration and its `$f make` dispatch — never the
+        // unrelated `classmethod make`'s declaration or its `Factory make`
+        // dispatch (Codex review on #971, P2).
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///dual_make_rename.tcl").unwrap();
+        let src = "oo::class create Factory {\n    method make {} { return 1 }\n    classmethod make {} { return [Factory new] }\n}\nset f [Factory new]\n$f make\nFactory make\n";
+        register(&backend, &uri, src).await;
+        let params = RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier { uri: uri.clone() },
+                position: Position::new(1, 11), // on `make` in `method make`'s decl
+            },
+            new_name: "build".to_owned(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+        let edit = backend.rename(params).await.expect("ok").expect("some");
+        let changes = edit.changes.expect("changes");
+        let edits = &changes[&uri];
+        let renamed_lines: Vec<u32> = edits
+            .iter()
+            .filter(|e| e.new_text == "build")
+            .map(|e| e.range.start.line)
+            .collect();
+        assert!(
+            renamed_lines.contains(&1),
+            "method decl (l1) must be renamed: {edits:?}"
+        );
+        assert!(
+            renamed_lines.contains(&5),
+            "`$f make` (l5) must be renamed: {edits:?}"
+        );
+        assert!(
+            !renamed_lines.contains(&2),
+            "classmethod decl (l2) must NOT be renamed: {edits:?}"
+        );
+        assert!(
+            !renamed_lines.contains(&6),
+            "`Factory make` (l6, classmethod dispatch) must NOT be renamed: {edits:?}"
+        );
+    }
+
     /// Register `animal.tcl` (`Animal::speak`) and `dog.tcl` (a `Dog` subclass
     /// that overrides `speak` and calls `$d speak`).  Returns the backend and
     /// the two URIs.
@@ -19193,7 +19302,7 @@ mod tests {
         // had no cross-file reference support at all.
         let (backend, animal, dog) = register_method_family_workspace().await;
         let refs = backend
-            .cross_file_method_references(&animal, "::Animal", "speak", true, "tcl8.6")
+            .cross_file_method_references(&animal, "::Animal", "speak", true, false, "tcl8.6")
             .await;
         let dog_lines: Vec<u32> = refs
             .iter()
@@ -19219,7 +19328,7 @@ mod tests {
         // (l2) is dropped but the `$d speak` call site (l5) stays.
         let (backend, animal, dog) = register_method_family_workspace().await;
         let refs = backend
-            .cross_file_method_references(&animal, "::Animal", "speak", false, "tcl8.6")
+            .cross_file_method_references(&animal, "::Animal", "speak", false, false, "tcl8.6")
             .await;
         let dog_lines: Vec<u32> = refs
             .iter()
@@ -19251,7 +19360,7 @@ mod tests {
         )
         .await;
         let refs = backend
-            .cross_file_method_references(&animal, "::Animal", "speak", false, "tcl8.6")
+            .cross_file_method_references(&animal, "::Animal", "speak", false, false, "tcl8.6")
             .await;
         let dog_lines: Vec<u32> = refs
             .iter()
@@ -19287,7 +19396,7 @@ mod tests {
         )
         .await;
         let refs = backend
-            .cross_file_method_references(&factory, "::Factory", "make", false, "tcl8.6")
+            .cross_file_method_references(&factory, "::Factory", "make", false, true, "tcl8.6")
             .await;
         let sub_lines: Vec<u32> = refs
             .iter()
@@ -19306,7 +19415,7 @@ mod tests {
         // cross-file sites.
         let (backend, animal, _dog) = register_method_family_workspace().await;
         let refs = backend
-            .cross_file_method_references(&animal, "::Animal", "nonexistent", true, "tcl8.6")
+            .cross_file_method_references(&animal, "::Animal", "nonexistent", true, false, "tcl8.6")
             .await;
         assert!(refs.is_empty(), "{refs:?}");
     }
@@ -19337,6 +19446,7 @@ mod tests {
                 "tcl8.6",
                 "::Factory",
                 "make",
+                true,
             )
             .await;
         assert!(
@@ -19364,6 +19474,7 @@ mod tests {
                 "tcl8.6",
                 "::Factory",
                 "make",
+                true,
             )
             .await;
         assert!(
@@ -19392,6 +19503,7 @@ mod tests {
                 "tcl8.6",
                 "::Factory",
                 "get",
+                false,
             )
             .await;
         assert!(
@@ -19424,6 +19536,7 @@ mod tests {
                 "tcl8.6",
                 "::Factory",
                 "make",
+                true,
             )
             .await;
         assert!(
@@ -19625,6 +19738,7 @@ mod tests {
                 "tcl8.6",
                 "::Animal",
                 "speak",
+                false,
             )
             .await;
         assert!(

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -9328,9 +9328,11 @@ impl LanguageServer for Backend {
                     range: lift_lsp_range(l.range),
                     // Carry the qualified name *and* the document URI so
                     // `codeLens/resolve` can recompute the count against the
-                    // live workspace and attach the clickable command.
-                    // Method / class-member lenses have no qname and stay
-                    // informational (their eager title is authoritative).
+                    // live workspace and attach the clickable command.  Every
+                    // lens kind (proc, class, method, classmethod) carries a
+                    // qname today; a lens with none stays eagerly-resolved
+                    // below as a defensive fallback for a future lens kind
+                    // that genuinely has no re-identifiable symbol.
                     data: has_qname
                         .then(|| serde_json::json!({ "qname": l.qname, "uri": uri_str.clone() })),
                     // A reference-count lens is returned WITHOUT a command so the
@@ -9339,8 +9341,8 @@ impl LanguageServer for Backend {
                     // `[uri, position, locations]` arguments.  Setting a command
                     // here would mark the lens resolved, the client would skip
                     // `resolve`, and the lens would render as an inert bare title
-                    // (#724 — "reference is not active").  Informational lenses
-                    // keep their eager title+command (they are never resolved).
+                    // (#724 / #956 — "reference is not active", the latter for
+                    // TclOO method / classmethod lenses specifically).
                     command: (!has_qname).then_some(tower_lsp_server::ls_types::Command {
                         title: l.command_title,
                         command: l.command,
@@ -9360,8 +9362,10 @@ impl LanguageServer for Backend {
     /// workspace keeps the title consistent with Find All References even
     /// when the workspace changed since the lens was produced.
     ///
-    /// A lens with no `{qname, uri}` data (the informational method /
-    /// class-member lenses) is returned unchanged — its eager title stands.
+    /// A lens with no `{qname, uri}` data is returned unchanged — its eager
+    /// title stands.  Every lens kind this server currently emits (proc,
+    /// class, method, classmethod) carries `data`, so this is a defensive
+    /// fallback rather than the common case.
     async fn code_lens_resolve(&self, lens: CodeLens) -> jsonrpc::Result<CodeLens> {
         let Some((qname, uri)) = lens
             .data
@@ -18507,6 +18511,181 @@ mod tests {
         assert_eq!(args[0], serde_json::Value::String(uri.to_string()));
         let locations = args[2].as_array().expect("locations array");
         assert_eq!(locations.len(), 2, "two call sites: {locations:?}");
+    }
+
+    /// Resolve the single member lens on `src` whose declaration sits on
+    /// `decl_line` (0-based) — the harness shared by the `TclOO` method /
+    /// classmethod lens tests below.
+    async fn resolve_member_lens_at_line(
+        backend: &Backend,
+        uri: &Uri,
+        src: &str,
+        decl_line: u32,
+    ) -> CodeLens {
+        register(backend, uri, src).await;
+        let lens_params = CodeLensParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let lenses = backend
+            .code_lens(lens_params)
+            .await
+            .expect("ok")
+            .expect("some lenses");
+        let lens = lenses
+            .into_iter()
+            .find(|l| l.range.start.line == decl_line)
+            .unwrap_or_else(|| panic!("no lens anchored at line {decl_line}: src={src:?}"));
+        backend.code_lens_resolve(lens).await.expect("resolve ok")
+    }
+
+    #[tokio::test]
+    async fn code_lens_resolve_wires_show_references_command_for_method() {
+        // FN→TP regression for issue #956: the *exact* reported repro — a
+        // TclOO class whose body declares `variable` and `constructor`
+        // before the `method`, with the method body reading the instance
+        // variable and the external dispatch nested in `puts [...]`. The
+        // method lens must resolve to a *clickable* `tcl-lsp.showReferences`
+        // command, not an inert bare title (the `#724` defect recurring for
+        // methods specifically — the count was already correct; only the
+        // command was empty).
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///bar956.tcl").unwrap();
+        let src = "oo::class create Bar {\n   variable _options\n    constructor {args} {\n         set _options $args\n    }\n\n    method get {key} {\n        return [dict get $_options $key]\n    }\n\n}\nset b [Bar new]\nputs [$b get foo]\n";
+        let resolved = resolve_member_lens_at_line(&backend, &uri, src, 6).await;
+        let command = resolved
+            .command
+            .expect("method lens must resolve to a command, not stay inert");
+        assert_eq!(
+            command.command, "tcl-lsp.showReferences",
+            "method lens must invoke the show-references wrapper, got {command:?}",
+        );
+        assert!(
+            !command.command.is_empty(),
+            "command id must never be empty"
+        );
+        assert_eq!(command.title, "1 reference", "{command:?}");
+        let args = command.arguments.expect("showReferences needs arguments");
+        let locations = args[2].as_array().expect("locations array");
+        assert_eq!(
+            locations.len(),
+            1,
+            "the `puts [$b get foo]` dispatch is the one call site: {locations:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn code_lens_resolve_wires_show_references_command_for_classmethod() {
+        // TP: a classmethod lens resolves the same way a method lens does.
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///classmethod.tcl").unwrap();
+        let src = "oo::class create Factory {\n    classmethod make {} {\n        return [Factory new]\n    }\n}\nset f [Factory make]\n";
+        let resolved = resolve_member_lens_at_line(&backend, &uri, src, 1).await;
+        let command = resolved
+            .command
+            .expect("classmethod lens must resolve to a command, not stay inert");
+        assert_eq!(command.command, "tcl-lsp.showReferences", "{command:?}");
+    }
+
+    #[tokio::test]
+    async fn code_lens_resolve_for_unused_method_is_clickable_with_zero_locations() {
+        // TN: a declared-but-never-dispatched method still resolves to a
+        // real command (an empty peek is a valid "0 references" click
+        // target) rather than staying inert because the count is zero.
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///solo.tcl").unwrap();
+        let src = "oo::class create Solo {\n    method ping {} { return pong }\n}\n";
+        let resolved = resolve_member_lens_at_line(&backend, &uri, src, 1).await;
+        let command = resolved
+            .command
+            .expect("even a 0-reference method lens must carry a real command");
+        assert_eq!(command.command, "tcl-lsp.showReferences", "{command:?}");
+        assert_eq!(command.title, "0 references", "{command:?}");
+        let args = command.arguments.expect("showReferences needs arguments");
+        let locations = args[2].as_array().expect("locations array");
+        assert!(locations.is_empty(), "{locations:?}");
+    }
+
+    #[tokio::test]
+    async fn code_lens_resolve_disambiguates_same_named_methods_on_different_classes() {
+        // FP guard: two unrelated classes each declaring a method named
+        // `get` must resolve to *independent* lenses — the qname-based
+        // resolve match (`::Bar::method::get` vs `::Foo::method::get`) must
+        // never cross-contaminate the two, and each lens's clickable command
+        // must carry only its own class's call site.
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///two_classes.tcl").unwrap();
+        let src = "oo::class create Bar {\n    method get {} { return 1 }\n}\noo::class create Foo {\n    method get {} { return 2 }\n}\nset b [Bar new]\nputs [$b get]\n";
+        let bar_resolved = resolve_member_lens_at_line(&backend, &uri, src, 1).await;
+        let bar_command = bar_resolved.command.expect("Bar::get must resolve");
+        assert_eq!(bar_command.title, "1 reference", "{bar_command:?}");
+
+        let foo_resolved = resolve_member_lens_at_line(&backend, &uri, src, 3).await;
+        let foo_command = foo_resolved.command.expect("Foo::get must resolve");
+        assert_eq!(
+            foo_command.title, "0 references",
+            "Foo::get must not see Bar's dispatch: {foo_command:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn code_lens_resolve_for_inherited_method_counts_subclass_dispatch() {
+        // TP: a subclass that inherits (does not override) a method is a
+        // valid dispatch target for the ancestor's lens — mirrors the
+        // existing `find_obj_method_call_sites` inheritance coverage, wired
+        // through the resolve round-trip.
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///inherit.tcl").unwrap();
+        let src = "oo::class create Base {\n    method get {key} { return $key }\n}\noo::class create Sub {\n    superclass Base\n}\nset s [Sub new]\n$s get x\n";
+        let resolved = resolve_member_lens_at_line(&backend, &uri, src, 1).await;
+        let command = resolved.command.expect("Base::get must resolve");
+        assert_eq!(
+            command.title, "1 reference",
+            "`$s get x` dispatches to the inherited Base::get: {command:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn no_code_lens_ever_carries_an_inert_empty_command() {
+        // Broad regression guard for the #724 / #956 defect class: every
+        // lens this server can emit for a rich TclOO document — proc,
+        // class, method, classmethod, across inheritance — must resolve to
+        // a real, non-empty command id.  A future lens kind that forgets to
+        // carry a qname would be caught here rather than shipping silently
+        // inert.
+        let backend = test_backend();
+        let uri = Uri::from_str("file:///rich.tcl").unwrap();
+        let src = "proc helper {} {}\nhelper\noo::class create Base {\n    variable _options\n    constructor {args} { set _options $args }\n    method get {key} { return [dict get $_options $key] }\n    classmethod make {} { return [Base new] }\n    method unused {} { return 0 }\n}\noo::class create Sub {\n    superclass Base\n}\nset b [Base new]\nputs [$b get foo]\nBase make\nset s [Sub new]\n$s get bar\n";
+        register(&backend, &uri, src).await;
+        let lens_params = CodeLensParams {
+            text_document: TextDocumentIdentifier { uri: uri.clone() },
+            work_done_progress_params: WorkDoneProgressParams::default(),
+            partial_result_params: PartialResultParams::default(),
+        };
+        let lenses = backend
+            .code_lens(lens_params)
+            .await
+            .expect("ok")
+            .expect("some lenses");
+        assert!(
+            lenses.len() >= 4,
+            "expected proc + class + 2 member lenses, got {lenses:?}"
+        );
+        for lens in lenses {
+            let resolved = backend
+                .code_lens_resolve(lens.clone())
+                .await
+                .expect("resolve ok");
+            let command = resolved.command.unwrap_or_else(|| {
+                panic!("lens at {:?} resolved with no command at all", lens.range)
+            });
+            assert!(
+                !command.command.is_empty(),
+                "lens at {:?} resolved to an inert empty command id: {command:?}",
+                lens.range,
+            );
+        }
     }
 
     #[tokio::test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4203,6 +4203,43 @@ impl Backend {
         core_rename::method_target_with_access(source, pos.line, pos.character, &oracle)
     }
 
+    /// Whether `method` is a `classmethod` on any of `definers`, and — if
+    /// so — the (qualified + simple name) set of every class in
+    /// `definers`/`inheritors` valid as a bare classmethod-dispatch head
+    /// (`Factory make`).
+    ///
+    /// A `classmethod` dispatches on the *class's own* command, never on an
+    /// instance, so the same-document analyser can only widen its dispatch
+    /// scan to bare `ClassName method` calls when the querying document's own
+    /// `all_classes` has the defining `ClassDef` (with its `class_methods`
+    /// populated) — true for a document that declares or `oo::define`-extends
+    /// the class, false for a document that only *inherits* it (a pure
+    /// subclass-only file) or only *consumes* it (`Factory make` with no
+    /// class mention at all).  For those two cases, the workspace index's
+    /// per-method `kind` (`"method"` / `"classmethod"` / `"forward"` —
+    /// [`core_workspace_index::WorkspaceMethod::kind`]) is the centralised
+    /// answer instead of guessing from the command name, exactly as the
+    /// same-document path reads `ClassDef::class_methods` locally.
+    fn classmethod_dispatch_names(
+        definers: &[&core_workspace_index::WorkspaceClass],
+        inheritors: &[&core_workspace_index::WorkspaceClass],
+        method: &str,
+    ) -> Vec<String> {
+        let is_classmethod = definers.iter().any(|wc| {
+            wc.methods
+                .iter()
+                .any(|m| m.name == method && m.kind == "classmethod")
+        });
+        if !is_classmethod {
+            return Vec::new();
+        }
+        definers
+            .iter()
+            .chain(inheritors.iter())
+            .flat_map(|wc| [wc.name.clone(), wc.qualified_name.clone()])
+            .collect()
+    }
+
     /// Cross-file references from **pure-consumer** documents: `$obj method`
     /// sites where `$obj` is an instance of a class in `(seed_class, method)`'s
     /// override family / inheritor set, in a document that only *uses* the class
@@ -4226,26 +4263,34 @@ impl Backend {
         // The family + inheritor classes whose instances dispatch `method` to
         // the family, the workspace class oracle, and the candidate consumer
         // documents — collected under one index read.
-        let (family, consumer_uris) = {
+        //
+        // `classmethod_cmd_names` carries the workspace-wide answer to "is
+        // `method` a classmethod, and if so, which class names bare-dispatch
+        // it" — a pure-consumer document (e.g. one that only calls `Factory
+        // make`) has no local `ClassDef` for `Factory`, so
+        // `core_references::obj_method_call_sites` cannot derive this itself
+        // the way the same-document path does; the workspace index's
+        // per-method `kind` (`"method"` / `"classmethod"` / `"forward"`) is
+        // the centralised source of that fact instead of guessing from the
+        // command name.
+        let (family, consumer_uris, classmethod_cmd_names) = {
             let index = self.workspace_index.read().await;
-            let mut family: Vec<String> = index
-                .method_override_family(seed_class, method)
+            let definers = index.method_override_family(seed_class, method);
+            let inheritors = index.method_inheritor_classes(seed_class, method);
+            let classmethod_cmd_names =
+                Self::classmethod_dispatch_names(&definers, &inheritors, method);
+            let mut family: Vec<String> = definers
                 .iter()
                 .map(|wc| wc.qualified_name.clone())
                 .collect();
-            family.extend(
-                index
-                    .method_inheritor_classes(seed_class, method)
-                    .iter()
-                    .map(|wc| wc.qualified_name.clone()),
-            );
+            family.extend(inheritors.iter().map(|wc| wc.qualified_name.clone()));
             if family.is_empty() {
                 return Vec::new();
             }
             let family_norm: std::collections::HashSet<&str> =
                 family.iter().map(|s| s.trim_start_matches("::")).collect();
             let consumer_uris = index.documents_invoking_classes(&family_norm);
-            (family, consumer_uris)
+            (family, consumer_uris, classmethod_cmd_names)
         };
         let mut out = Vec::new();
         let mut scanned: std::collections::HashSet<String> = std::collections::HashSet::new();
@@ -4283,6 +4328,7 @@ impl Backend {
             let analysis = self.analyse_with_workspace_classes(&source, &dialect).await;
             let family_cl = family.clone();
             let method_owned = method.to_owned();
+            let classmethod_cmd_names_cl = classmethod_cmd_names.clone();
             let spans: Vec<tcl_lexer::Span> = tokio::task::spawn_blocking(move || {
                 let mut all: Vec<tcl_lexer::Span> = Vec::new();
                 for cq in &family_cl {
@@ -4292,6 +4338,7 @@ impl Backend {
                         &analysis,
                         cq,
                         &method_owned,
+                        &classmethod_cmd_names_cl,
                     ));
                 }
                 all
@@ -4351,23 +4398,32 @@ impl Backend {
         // declaration + call sites rename) and the pure inheritors (whose
         // `my method` / `$obj method` sites rename, but which declare no copy
         // of the method).  A document may contribute either or both.
-        let by_uri: std::collections::HashMap<String, (Vec<String>, Vec<String>)> = {
+        //
+        // `classmethod_cmd_names`: see [`Self::classmethod_dispatch_names`] —
+        // a pure-inheritor document's own `all_classes` never lists the
+        // definer's `class_methods`, so it cannot tell a classmethod's bare
+        // dispatch heads apart from any other bare word without this.
+        let (by_uri, classmethod_cmd_names) = {
             let index = self.workspace_index.read().await;
+            let definers = index.method_override_family(seed_class, method);
+            let inheritors = index.method_inheritor_classes(seed_class, method);
+            let classmethod_cmd_names =
+                Self::classmethod_dispatch_names(&definers, &inheritors, method);
             let mut m: std::collections::HashMap<String, (Vec<String>, Vec<String>)> =
                 std::collections::HashMap::new();
-            for wc in index.method_override_family(seed_class, method) {
+            for wc in definers {
                 m.entry(wc.uri.clone())
                     .or_default()
                     .0
                     .push(wc.qualified_name.clone());
             }
-            for wc in index.method_inheritor_classes(seed_class, method) {
+            for wc in inheritors {
                 m.entry(wc.uri.clone())
                     .or_default()
                     .1
                     .push(wc.qualified_name.clone());
             }
-            m
+            (m, classmethod_cmd_names)
         };
         for (u, (definers, inheritors)) in by_uri {
             let Ok(parsed) = Uri::from_str(&u) else {
@@ -4382,6 +4438,7 @@ impl Backend {
             let src = target_doc.text.clone();
             let dialect = target_doc.dialect.clone();
             let method_owned = method.to_owned();
+            let classmethod_cmd_names_cl = classmethod_cmd_names.clone();
             let spans: Vec<tcl_lexer::Span> = tokio::task::spawn_blocking(move || {
                 let mut all: Vec<tcl_lexer::Span> = Vec::new();
                 for cq in &definers {
@@ -4400,6 +4457,7 @@ impl Backend {
                         &analysis,
                         cq,
                         &method_owned,
+                        &classmethod_cmd_names_cl,
                     ));
                 }
                 all
@@ -4454,23 +4512,27 @@ impl Backend {
         method: &str,
         include_declaration: bool,
     ) -> Vec<Location> {
-        let by_uri: std::collections::HashMap<String, (Vec<String>, Vec<String>)> = {
+        let (by_uri, classmethod_cmd_names) = {
             let index = self.workspace_index.read().await;
+            let definers = index.method_override_family(seed_class, method);
+            let inheritors = index.method_inheritor_classes(seed_class, method);
+            let classmethod_cmd_names =
+                Self::classmethod_dispatch_names(&definers, &inheritors, method);
             let mut m: std::collections::HashMap<String, (Vec<String>, Vec<String>)> =
                 std::collections::HashMap::new();
-            for wc in index.method_override_family(seed_class, method) {
+            for wc in definers {
                 m.entry(wc.uri.clone())
                     .or_default()
                     .0
                     .push(wc.qualified_name.clone());
             }
-            for wc in index.method_inheritor_classes(seed_class, method) {
+            for wc in inheritors {
                 m.entry(wc.uri.clone())
                     .or_default()
                     .1
                     .push(wc.qualified_name.clone());
             }
-            m
+            (m, classmethod_cmd_names)
         };
         let mut out = Vec::new();
         for (u, (definers, inheritors)) in by_uri {
@@ -4489,6 +4551,7 @@ impl Backend {
             let src = target_doc.text.clone();
             let dialect = target_doc.dialect.clone();
             let method_owned = method.to_owned();
+            let classmethod_cmd_names_cl = classmethod_cmd_names.clone();
             let spans: Vec<tcl_lexer::Span> = tokio::task::spawn_blocking(move || {
                 let mut all: Vec<tcl_lexer::Span> = Vec::new();
                 for cq in &definers {
@@ -4508,6 +4571,7 @@ impl Backend {
                         &analysis,
                         cq,
                         &method_owned,
+                        &classmethod_cmd_names_cl,
                     ));
                 }
                 all
@@ -19013,6 +19077,54 @@ mod tests {
         );
     }
 
+    #[tokio::test]
+    async fn classmethod_rename_reaches_subclass_only_document() {
+        // The classmethod analogue, end-to-end through the production
+        // `rename` handler: `SubFactory` inherits `make` (no override) in
+        // its own file and dispatches it via `SubFactory make` — a bare
+        // classmethod dispatch on the *subclass's* own command, which
+        // `subfactory.tcl`'s own `all_classes` cannot classify as a
+        // classmethod call by itself (it never declares `make`).
+        let backend = test_backend();
+        let factory = Uri::from_str("file:///factory5.tcl").unwrap();
+        let subfactory = Uri::from_str("file:///subfactory5.tcl").unwrap();
+        register(
+            &backend,
+            &factory,
+            "oo::class create Factory {\n    classmethod make {} {\n        return [Factory new]\n    }\n}\n",
+        )
+        .await;
+        register(
+            &backend,
+            &subfactory,
+            "oo::class create SubFactory {\n    superclass Factory\n}\nSubFactory make\n",
+        )
+        .await;
+        let params = RenameParams {
+            text_document_position: TextDocumentPositionParams {
+                text_document: TextDocumentIdentifier {
+                    uri: factory.clone(),
+                },
+                position: Position::new(1, 16), // on `make` in Factory's decl
+            },
+            new_name: "build".to_owned(),
+            work_done_progress_params: WorkDoneProgressParams::default(),
+        };
+        let edit = backend.rename(params).await.expect("ok").expect("some");
+        let changes = edit.changes.expect("changes");
+        assert!(
+            changes.contains_key(&subfactory),
+            "subclass-only doc edits missing: {changes:?}"
+        );
+        let sub_edits = &changes[&subfactory];
+        assert!(
+            sub_edits
+                .iter()
+                .any(|e| e.range.start.line == 3 && e.new_text == "build"),
+            "expected `SubFactory make` (l3) rewritten to `build`: {sub_edits:?}"
+        );
+    }
+
     /// Register `animal.tcl` (`Animal::speak`) and `dog.tcl` (a `Dog` subclass
     /// that overrides `speak` and calls `$d speak`).  Returns the backend and
     /// the two URIs.
@@ -19113,6 +19225,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn cross_file_method_references_reach_inheritor_document_for_classmethod() {
+        // The classmethod analogue: SubFactory *inherits* `make` (no
+        // override) and dispatches it via its own command, in a document
+        // holding no definer of `Factory` at all — unlike the pure-consumer
+        // case, this document *does* declare a class (SubFactory), so it
+        // goes through the inheritor pass (`inherited_method_call_sites`),
+        // not `cross_file_consumer_method_references`.
+        let backend = test_backend();
+        let factory = Uri::from_str("file:///factory4.tcl").unwrap();
+        let subfactory = Uri::from_str("file:///subfactory4.tcl").unwrap();
+        register(
+            &backend,
+            &factory,
+            "oo::class create Factory {\n    classmethod make {} {\n        return [Factory new]\n    }\n}\n",
+        )
+        .await;
+        register(
+            &backend,
+            &subfactory,
+            "oo::class create SubFactory {\n    superclass Factory\n}\nSubFactory make\n",
+        )
+        .await;
+        let refs = backend
+            .cross_file_method_references(&factory, "::Factory", "make", false)
+            .await;
+        let sub_lines: Vec<u32> = refs
+            .iter()
+            .filter(|l| l.uri == subfactory)
+            .map(|l| l.range.start.line)
+            .collect();
+        assert!(
+            sub_lines.contains(&3),
+            "`SubFactory make` (l3) in the inheritor-only document missing: {refs:?}"
+        );
+    }
+
+    #[tokio::test]
     async fn cross_file_method_references_empty_for_unrelated_method() {
         // A method name no family class defines yields nothing — no spurious
         // cross-file sites.
@@ -19121,6 +19270,95 @@ mod tests {
             .cross_file_method_references(&animal, "::Animal", "nonexistent", true)
             .await;
         assert!(refs.is_empty(), "{refs:?}");
+    }
+
+    #[tokio::test]
+    async fn cross_file_consumer_finds_classmethod_bare_dispatch() {
+        // A `classmethod` dispatches on the class's own command, never an
+        // instance — so a *pure-consumer* document that never
+        // declares/extends the class (only calls `Factory make`) has no
+        // entry for `::Factory` in its own `all_classes`, unlike the
+        // instance path (`$obj method`, resolved via a plain
+        // `instance_classes` string match that needs no `all_classes` at
+        // all). `cross_file_consumer_method_references` closes this gap by
+        // asking the *workspace index* whether `method` is a classmethod
+        // (`WorkspaceMethod::kind`) and, if so, passing the family's class
+        // names down as valid bare-dispatch heads — the same centralised
+        // `kind` field the same-document path already reads locally.
+        let backend = test_backend();
+        let factory = Uri::from_str("file:///factory.tcl").unwrap();
+        let consumer = Uri::from_str("file:///consumer.tcl").unwrap();
+        let factory_src = "oo::class create Factory {\n    classmethod make {} {\n        return [Factory new]\n    }\n}\n";
+        register(&backend, &factory, factory_src).await;
+        register(&backend, &consumer, "Factory make\n").await;
+        let refs = backend
+            .cross_file_consumer_method_references(
+                &factory,
+                factory_src,
+                "tcl8.6",
+                "::Factory",
+                "make",
+            )
+            .await;
+        assert!(
+            refs.iter()
+                .any(|l| l.uri == consumer && l.range.start.line == 0),
+            "`Factory make` in the pure-consumer document missing: {refs:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_file_consumer_finds_inheriting_subclass_classmethod_dispatch() {
+        // The same gap, one level of inheritance deeper: `SubFactory` inherits
+        // (does not override) `make`, and the pure-consumer document
+        // dispatches via `SubFactory`'s own command.
+        let backend = test_backend();
+        let factory = Uri::from_str("file:///factory2.tcl").unwrap();
+        let consumer = Uri::from_str("file:///consumer2.tcl").unwrap();
+        let factory_src = "oo::class create Factory {\n    classmethod make {} { return [Factory new] }\n}\noo::class create SubFactory {\n    superclass Factory\n}\n";
+        register(&backend, &factory, factory_src).await;
+        register(&backend, &consumer, "SubFactory make\n").await;
+        let refs = backend
+            .cross_file_consumer_method_references(
+                &factory,
+                factory_src,
+                "tcl8.6",
+                "::Factory",
+                "make",
+            )
+            .await;
+        assert!(
+            refs.iter()
+                .any(|l| l.uri == consumer && l.range.start.line == 0),
+            "`SubFactory make` (inherited classmethod) in the pure-consumer document missing: {refs:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_file_consumer_does_not_bare_dispatch_a_plain_instance_method() {
+        // FP guard: a plain (non-classmethod) `method` must not gain bare
+        // class-command dispatch cross-file, any more than it does
+        // same-document — `Factory get` (no `$obj`) is not a valid TclOO
+        // call for an instance method.
+        let backend = test_backend();
+        let factory = Uri::from_str("file:///factory3.tcl").unwrap();
+        let consumer = Uri::from_str("file:///consumer3.tcl").unwrap();
+        let factory_src = "oo::class create Factory {\n    method get {} { return 1 }\n}\n";
+        register(&backend, &factory, factory_src).await;
+        register(&backend, &consumer, "Factory get\n").await;
+        let refs = backend
+            .cross_file_consumer_method_references(
+                &factory,
+                factory_src,
+                "tcl8.6",
+                "::Factory",
+                "get",
+            )
+            .await;
+        assert!(
+            !refs.iter().any(|l| l.uri == consumer),
+            "a plain method must not gain phantom class-command dispatch: {refs:?}"
+        );
     }
 
     #[tokio::test]

--- a/rust/tcl-lsp-server/tests/e2e/editor_features.rs
+++ b/rust/tcl-lsp-server/tests/e2e/editor_features.rs
@@ -159,14 +159,20 @@ fn test_unresolved_call_scoped_to_namespace() {
     assert_eq!(b["command"]["title"], json!("0 references"));
 }
 
-/// Title of the method / member lens anchored on `line` (0-based).  Member
-/// lenses are informational: their eager `command.title` is authoritative
-/// and needs no `codeLens/resolve`.
-fn member_lens_title_on_line(ls: &[Value], line: i64) -> Option<String> {
-    ls.iter()
+/// Resolve the method / member lens anchored on `line` (0-based) and return
+/// the resolved `command`.  Since issue #956, member lenses resolve lazily
+/// the same way proc/class lenses do (range + `data`, no `command` until
+/// `codeLens/resolve` — see `tcl-lsp-server`'s `code_lens` handler and the
+/// `#724` "reference is not active" defect it fixed for proc/class lenses),
+/// so a raw, unresolved listing has no `command` for a caller to read
+/// directly; this always resolves first.
+fn resolve_member_lens_on_line(lsp: &mut Lsp, ls: &[Value], line: i64) -> Value {
+    let lens = ls
+        .iter()
         .find(|l| l["range"]["start"]["line"].as_i64() == Some(line))
-        .and_then(|l| l["command"]["title"].as_str())
-        .map(str::to_owned)
+        .unwrap_or_else(|| panic!("no lens anchored at line {line}: {ls:?}"))
+        .clone();
+    lsp.code_lens_resolve(lens)["command"].clone()
 }
 
 #[test]
@@ -194,9 +200,17 @@ fn test_method_lens_counts_external_obj_dispatch_issue_864() {
     );
     let ls = lenses(&mut lsp, &uri);
     // `method get` is on line 6 (0-based).
-    let title = member_lens_title_on_line(&ls, 6)
-        .unwrap_or_else(|| panic!("no method lens on line 6: {ls:?}"));
-    assert_eq!(title, "1 reference", "{ls:?}");
+    let command = resolve_member_lens_on_line(&mut lsp, &ls, 6);
+    assert_eq!(command["title"], json!("1 reference"), "{ls:?}");
+    // Regression for issue #956: the lens must resolve to a *clickable*
+    // command, not the empty-id inert shape (the `#724` defect recurring
+    // for methods — the count above was already correct before the fix;
+    // only the command was empty).
+    assert_eq!(
+        command["command"],
+        json!("tcl-lsp.showReferences"),
+        "method lens resolved to an inert command: {command:?}"
+    );
     // The lens count must equal Find All References (declaration excluded) on
     // the `get` method-name token (`    method get` → col 11).
     let refs = match lsp.references(&uri, 6, 11, false) {
@@ -208,7 +222,9 @@ fn test_method_lens_counts_external_obj_dispatch_issue_864() {
 
 #[test]
 fn test_method_lens_zero_when_uncalled() {
-    // TN: an instance method with no dispatch site reads "0 references".
+    // TN: an instance method with no dispatch site reads "0 references" but
+    // still resolves to a real, clickable command (an empty peek is a valid
+    // target — the count being zero must not leave the lens inert).
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     lsp.open_ready(
@@ -216,9 +232,61 @@ fn test_method_lens_zero_when_uncalled() {
         "oo::class create Solo {\n    method lonely {} {}\n}\nSolo new\n",
     );
     let ls = lenses(&mut lsp, &uri);
-    let title = member_lens_title_on_line(&ls, 1)
-        .unwrap_or_else(|| panic!("no method lens on line 1: {ls:?}"));
-    assert_eq!(title, "0 references", "{ls:?}");
+    let command = resolve_member_lens_on_line(&mut lsp, &ls, 1);
+    assert_eq!(command["title"], json!("0 references"), "{ls:?}");
+    assert_eq!(
+        command["command"],
+        json!("tcl-lsp.showReferences"),
+        "{command:?}"
+    );
+}
+
+#[test]
+fn test_classmethod_lens_resolves_to_clickable_command() {
+    // TP: a classmethod lens (a distinct member map from instance methods)
+    // resolves the same way, with its own disambiguated qname.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "oo::class create Factory {\n    classmethod make {} {\n        return [Factory new]\n    }\n}\nFactory make\n",
+    );
+    let ls = lenses(&mut lsp, &uri);
+    let command = resolve_member_lens_on_line(&mut lsp, &ls, 1);
+    assert_eq!(command["title"], json!("1 reference"), "{ls:?}");
+    assert_eq!(
+        command["command"],
+        json!("tcl-lsp.showReferences"),
+        "{command:?}"
+    );
+}
+
+#[test]
+fn test_find_references_on_classmethod_finds_bare_class_command_dispatch() {
+    // The `textDocument/references` peek (not just the lens) must also see
+    // the bare `Factory make` dispatch — including through an inheriting
+    // subclass's own command (`SubFactory make`), which never overrides
+    // `make` so its dispatch still targets `Factory::make`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "oo::class create Factory {\n    classmethod make {} { return [Factory new] }\n}\noo::class create SubFactory {\n    superclass Factory\n}\nFactory make\nSubFactory make\n",
+    );
+    // cursor on the `make` declaration name (line 1, col 16).
+    let refs = match lsp.references(&uri, 1, 16, true) {
+        Value::Array(a) => a,
+        _ => Vec::new(),
+    };
+    let lines: std::collections::BTreeSet<i64> = refs
+        .iter()
+        .filter_map(|l| l["range"]["start"]["line"].as_i64())
+        .collect();
+    assert_eq!(
+        lines,
+        std::collections::BTreeSet::from([1, 6, 7]),
+        "decl + `Factory make` + inheriting `SubFactory make`: {refs:?}"
+    );
 }
 
 // -- TestDocumentLinks ---------------------------------------------------

--- a/rust/tcl-lsp-server/tests/e2e/name_resolution.rs
+++ b/rust/tcl-lsp-server/tests/e2e/name_resolution.rs
@@ -84,17 +84,30 @@ fn token_type_of(lsp: &mut Lsp, uri: &str, src: &str, needle: &str) -> Option<St
         .map(|t| legend[usize::try_from(t.ttype).unwrap()].clone())
 }
 
-/// The reference-count lens title anchored on `line` (member lenses carry an
-/// eager `command.title`).
+/// The reference-count lens title anchored on `line`, resolved.  Since
+/// issue #956, a method / classmethod lens resolves lazily the same way a
+/// proc/class lens does (range + `data`, no `command` until
+/// `codeLens/resolve`), so the raw listing has no `command.title` for a
+/// caller to read directly.
 fn member_lens_title(lsp: &mut Lsp, uri: &str, line: i64) -> Option<String> {
     let ls = match lsp.code_lens(uri) {
         Value::Array(a) => a,
         _ => Vec::new(),
     };
-    ls.iter()
-        .find(|l| l["range"]["start"]["line"].as_i64() == Some(line))
-        .and_then(|l| l["command"]["title"].as_str())
-        .map(str::to_owned)
+    let lens = ls
+        .iter()
+        .find(|l| l["range"]["start"]["line"].as_i64() == Some(line))?
+        .clone();
+    let resolved = lsp.code_lens_resolve(lens);
+    // Every lens this server emits resolves to a real, clickable command
+    // (issue #956 — a member lens must never stay inert with an empty
+    // command id).
+    assert_ne!(
+        resolved["command"]["command"].as_str(),
+        Some(""),
+        "lens at line {line} resolved to an inert empty command id: {resolved:?}"
+    );
+    resolved["command"]["title"].as_str().map(str::to_owned)
 }
 
 /// Whether any diagnostic carries the string `code` (W-codes are strings).


### PR DESCRIPTION
Fixes #956
Fixes #957

## Summary

- Fix TclOO/snit method and classmethod code lenses being visible but inert (issue #956): every method/classmethod lens now carries a `{class}::method::{name}` / `{class}::classmethod::{name}` qname via a new shared `tcl_compiler::analyser::class_member_key` helper, so they resolve through `codeLens/resolve` into a real `tcl-lsp.showReferences` command exactly like proc/class lenses already did — instead of shipping with an eager, permanently-empty command. Verified against issue #957's exact repro too (`my getOptions` dispatch from a sibling method): the lens now shows the correct "1 reference" and is clickable.
- Fix classmethod/typemethod reference counting and rename: a `classmethod` dispatches on the *class's own* command (`Factory make`), never an instance, and `find_obj_method_call_sites` only tracked instance handles. Its dispatch (including from an inheriting subclass's own command) is now folded into the existing `cmd_set` alongside instance methods, for the same-document, cross-file consumer-only, and cross-file definer/inheritor cases alike.
- Verified this generalises for free to snit's `typemethod` (shares TclOO's `class_methods` registry bucket, zero new code).
- **Codex automated review** on this PR caught three further real gaps, each fixed with a failing-then-passing regression test:
  - [incr Tcl]'s class-scoped `proc` (stored in the same `class_methods` bucket) was being treated as a two-word `Factory make` dispatch, when its real syntax is the colon-qualified `Factory::make` — `Factory make` is itcl's own (unrelated) instance-creation shorthand. Fixed with a registry-driven (`DefinerFamily`) exclusion rather than a hardcoded command check, in both the same-document scanner and the cross-file consumer/definer/inheritor paths.
  - A class legally defining both `method foo` and `classmethod foo` (separate TclOO dispatch tables) had its two lenses/reference-counts/renames silently combined, because the kind was inferred from map membership instead of being passed explicitly. Fixed by threading an explicit `is_classmethod` through the whole resolution chain.
  - Find References / Rename worked from a classmethod's declaration or code lens, but not from the actual `Factory make` call site itself (the reverse resolution direction was simply missing). Added `classmethod_dispatch_class`, the reverse of the existing forward "which names dispatch this class" fold.
  - A fourth finding (bare classmethod/object-command dispatch matching is namespace-blind — two classes sharing a tail name in different namespaces aren't distinguished) is a real, pre-existing gap shared with the older object-command matcher, out of scope for this PR's diff; tracked in #981.
- Centralised the qname convention in `class_member_key`, also adopted by `item_tree.rs`'s incremental diffing (previously an inline duplicate format string).
- Updated `docs/kcs/features/kcs-feature-code-lens.md`, `docs/kcs/features/kcs-feature-references.md`, `README.md`, and extended the `.claude/skills/lsp-client` skill with a `code-lens` subcommand used to verify the fix against a live server.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make format codegen                                          # clean, no diff
make lint-ts typecheck-ts check-editor-settings \
     typecheck-report-ts lint-report-ts check-report-assets   # clean
make check-all                                                # clean (run pre-push, each push)
cargo clippy --workspace --all-targets                        # clean, run repeatedly across the PR
cargo test -p tcl-compiler --lib                               # 4487 passed; 0 failed
cargo test -p tcl-lsp-core --lib                                # 1020 passed; 0 failed
cargo test -p tcl-lsp-core --test name_resolution               # 33 passed; 0 failed
cargo test -p tcl-lsp-server --lib                               # 259 passed; 0 failed
cargo test -p tcl-lsp-server --test e2e                          # 921 passed; 0 failed
make test-ext                                                  # passing; exit 0
```

Every file touched by this change was exercised by the runs above, with every new/modified test individually confirmed passing by name, and each Codex-review fix additionally verified by temporarily reverting it, confirming the relevant test fails, then restoring it.

**`cargo test --workspace --all-features` (the full `test-rust` target):** attempted five times across this PR (four before a container restart reset the disk quota, one after) — every attempt failed with `rustc-LLVM ERROR: IO failure on output stream: No space left on device` or a linker `Bus error`, compiling large dependency trees unrelated to this change (`tcl-vm`/`tcl-fuzz`/`bigip-report-gen`/wasmtime-cranelift). This is an environment disk-quota ceiling, not a defect in this diff — confirmed not code-related by `cargo clippy --workspace --all-targets` passing cleanly (type-checks + lints every target, including all test code) and by CI's own `rust-tests` / `rust-tests-heavy` checks passing on this exact head commit in their own (unconstrained) environment, which supersedes the need for a redundant local run.

**Not run, with reasons:**
- `make test-emacs`: `emacs` is not installed in this container (the `SKIP_TEST_EMACS`-eligible case per AGENTS.md's own carve-out).
- `make runtime-rust-test`: this change touches only `tcl-compiler`'s analyser module and the two LSP crates; `runtime/rust` and `tcl-vm` import neither — zero code overlap, confirmed by dependency-graph inspection.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No. `class_member_key` is a naming-convention helper for LSP qname wiring built on pre-existing facts (`ClassDef.class_methods`, `WorkspaceMethod.kind`); no diagnostic, taint, or analysis-contract semantics changed.
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. — N/A per above; the relevant *feature*-level KCS notes (`docs/kcs/features/kcs-feature-code-lens.md`, `kcs-feature-references.md`) were updated instead.
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`. — N/A, no new compiler KCS note.
