### PR TITLE
Fix W123 and namespace-relative resolution for expr math-function calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -2022,7 +2022,7 @@ In a project with an "entry" file that runs the `package require`s and then
 | W120 | Package-gated command used without `package require` | Insert `package require` |
 | W121 | Subnet mask has non-contiguous bits | Replace with nearest valid mask |
 | W122 | Mistyped IPv4 address (octet > 255 or leading zero) | |
-| W123 | Unknown command — not found in registry, user procs, or `unknown` handler | Replace with suggestion |
+| W123 | Unknown command — not found in registry, user procs, built-in `expr` math functions, or `unknown` handler | Replace with suggestion |
 | W124 | Invalid IP address literal | |
 | W125 | Orphaned control-flow keyword used as a standalone command | |
 | W126 | Non-channel value in channel argument position | |

--- a/docs/design/tricky-name-resolution-surfaces.md
+++ b/docs/design/tricky-name-resolution-surfaces.md
@@ -352,6 +352,27 @@ the ensemble configuration string. Same fix location, same milestone.
   unmodified throughout, so nothing regressed, but no test in this effort
   specifically targets a mathfunc call through any of them.
 
+  **Review follow-up:** the W123 shortcut (`w123_invocation_resolves`,
+  `unresolved.rs`) checked only the settled qualified name against
+  `expr_mathfunc_name_known`, with no regard for *how* the invocation was
+  recorded. An *ordinary* call made from inside the real `::tcl::mathfunc`
+  namespace (or targeting a custom function's own body) can settle to the
+  identical `::tcl::mathfunc::<name>` shape a genuine `expr` function-call
+  site does, and TIP 232's command wrappers — the mechanism that makes such
+  a bareword call valid *at all* — only exist from Tcl 8.5 onward,
+  independent of any individual function's own earlier expr-grammar
+  availability (`sin` is a valid 8.4 expr function with no 8.4 command
+  form). The shortcut now also checks `is_mathfunc_call`: a genuine `expr`
+  function-call site keeps the existing per-function expr-grammar check
+  unchanged, while any other invocation additionally requires
+  `tcl_expr_eval::mathfunc_command_wrappers_available_in_dialect` — a
+  coarser, single fact (available from 8.5 onward, regardless of which
+  function) rather than the per-function ceiling. Covered by
+  `tests.rs`'s `w123_tp_ordinary_call_shaped_like_mathfunc_fires_under_84`
+  / `w123_fp_ordinary_call_shaped_like_mathfunc_resolves_under_86` /
+  `w123_tp_custom_mathfunc_body_bareword_call_fires_under_84` /
+  `w123_fp_expr_function_call_unaffected_by_wrapper_availability_under_84`.
+
 ### 1.7 Literal command names in dispatch tables — **CONFIRMED** (medium)
 
 - **Real Tcl:** a literal extracted from a dict/array/string-map value becomes the

--- a/docs/design/tricky-name-resolution-surfaces.md
+++ b/docs/design/tricky-name-resolution-surfaces.md
@@ -258,8 +258,9 @@ the ensemble configuration string. Same fix location, same milestone.
   `tcl_syntax::expr::mathfunc` name/version table). **Still open:** the
   settled qualified name is always the *global* `::tcl::mathfunc::f`, never
   accounting for a namespace-local override (`::ns::tcl::mathfunc::f`
-  shadowing inside `::ns` — real per TIP 232 / verified by the WASM
-  runtime's `namespace_local_mathfunc_shadows_in_expr` test) — a narrower,
+  shadowing inside `::ns` — real per TIP 232 / verified by the VM's
+  `namespace_local_mathfunc_shadows_global_in_expr` test in
+  `tcl-vm/tests/tricky_resolution_e2e.rs`) — a narrower,
   separate follow-up.
 
 ### 1.7 Literal command names in dispatch tables — **CONFIRMED** (medium)

--- a/docs/design/tricky-name-resolution-surfaces.md
+++ b/docs/design/tricky-name-resolution-surfaces.md
@@ -277,19 +277,46 @@ the ensemble configuration string. Same fix location, same milestone.
   `proc_tail_names` fallback happened to still suppress it either way), but
   go-to-definition, references, rename, call-hierarchy, minify, and
   completion all read `resolved_qualified_name` directly and would have
-  inherited the wrong target. Fixed by giving mathfunc invocations their own
-  two-candidate settlement rule (caller's `tcl::mathfunc`, else the global
-  one — `bareword_resolution_candidates` against the relative name
-  `tcl::mathfunc::f`, not the generic suffix-strip) in
-  `finalise_invocation_resolutions` (`scope.rs`), keyed off the shared
-  `tcl_expr_eval::is_known_mathfunc_in_dialect` free function so the
-  existence check and W123's own agree by construction. Covered by
-  `commands.rs`'s `expr_function_call_ignores_unrelated_same_named_global_proc`
-  / `expr_function_call_resolves_namespace_local_mathfunc_override` /
-  `expr_function_call_falls_back_to_global_user_override_from_a_namespace`
-  / `expr_function_call_resolves_builtin_from_inside_a_namespace`, and
-  `definition.rs`'s `no_definition_for_mathfunc_call_despite_unrelated_same_named_proc`
-  / `mathfunc_call_jumps_to_namespace_local_override`.
+  inherited the wrong target.
+
+  First pass fixed this with a *structural* branch in
+  `finalise_invocation_resolutions`: detect the mathfunc shape by checking
+  whether `resolved` ends with `::tcl::mathfunc::{name}`, then settle via a
+  dedicated two-candidate rule. Re-reviewing that fix surfaced two more
+  things worth doing properly rather than declaring done: (1) shape-sniffing
+  a string is exactly the kind of guess this whole bug started from — a
+  contrived namespace literally named `…::tcl::mathfunc` holding unrelated
+  ordinary commands could still fool it — and every *other*
+  `push_command_reference` caller in the analyser (`oo.rs`, both ensemble
+  paths in `handlers.rs`, the existence-probe path in `commands.rs`) was
+  audited to confirm mathfunc really is the only "fixed dispatch prefix,
+  not the calling namespace" case among them, so a one-off flag beats a
+  speculative general mechanism; and (2) the branch used
+  `bareword_resolution_candidates` (no `namespace path`), while math
+  functions are ordinary commands under TIP 232 and the VM's own
+  `resolve_command_fqn` routes every lookup — mathfunc calls included —
+  through the same `namespace path`-aware resolver
+  (`tcl-vm/src/interp.rs`), so the analyser was silently narrower than the
+  runtime it describes.
+
+  Landed properly instead:
+  [`SignatureCommandInvocation::is_mathfunc_call`](../../rust/tcl-compiler/src/signature_scan/types.rs)
+  is set once, at record time, by the one caller that needs it
+  (`push_mathfunc_command_reference`) — no shape-guessing at settlement
+  time. `finalise_invocation_resolutions` (`scope.rs`) branches on the flag
+  and settles via `command_resolution_candidates(&ns, path, "tcl::mathfunc::f")`
+  (the same `path`-aware builder the generic case already uses, not the
+  `path`-free specialisation), `known()` plus — for the global candidate
+  only — the shared `tcl_expr_eval::is_known_mathfunc_in_dialect` free
+  function, so the existence check and W123's own agree by construction.
+  Covered by `commands.rs`'s
+  `expr_function_call_ignores_unrelated_same_named_global_proc` /
+  `expr_function_call_resolves_namespace_local_mathfunc_override` /
+  `expr_function_call_falls_back_to_global_user_override_from_a_namespace` /
+  `expr_function_call_resolves_builtin_from_inside_a_namespace` /
+  `expr_function_call_honours_namespace_path`, and `definition.rs`'s
+  `no_definition_for_mathfunc_call_despite_unrelated_same_named_proc` /
+  `mathfunc_call_jumps_to_namespace_local_override`.
 
 ### 1.7 Literal command names in dispatch tables — **CONFIRMED** (medium)
 

--- a/docs/design/tricky-name-resolution-surfaces.md
+++ b/docs/design/tricky-name-resolution-surfaces.md
@@ -255,13 +255,41 @@ the ensemble configuration string. Same fix location, same milestone.
   override drew a spurious "unknown command" hint, since only the
   user-proc path resolved (`w123_invocation_resolves`'s
   `expr_mathfunc_name_known`, `unresolved.rs`, consulting the shared
-  `tcl_syntax::expr::mathfunc` name/version table). **Still open:** the
-  settled qualified name is always the *global* `::tcl::mathfunc::f`, never
-  accounting for a namespace-local override (`::ns::tcl::mathfunc::f`
+  `tcl_syntax::expr::mathfunc` name/version table). **Follow-up closed:**
+  the settled qualified name was always the *global* `::tcl::mathfunc::f`,
+  never accounting for a namespace-local override (`::ns::tcl::mathfunc::f`
   shadowing inside `::ns` — real per TIP 232 / verified by the VM's
   `namespace_local_mathfunc_shadows_global_in_expr` test in
-  `tcl-vm/tests/tricky_resolution_e2e.rs`) — a narrower,
-  separate follow-up.
+  `tcl-vm/tests/tricky_resolution_e2e.rs`). Digging into that gap surfaced a
+  sharper, more common bug in the same code path: `record_expr_function_invocations`'s
+  walk-time guess and `finalise_invocation_resolutions`'s generic one-hop
+  `{ns}::{name}` suffix-strip both assumed a mathfunc invocation's resolved
+  name has the *ordinary* `{callingNamespace}::{tail}` shape — false for a
+  mathfunc call, whose resolved name always carries the fixed
+  `tcl::mathfunc` dispatch segment regardless of the caller's own namespace.
+  The generic settling pass would then strip the wrong suffix (recovering
+  `::tcl::mathfunc` as a bogus "calling namespace"), and — whenever an
+  *unrelated* ordinary command/proc/class/alias/rename-target anywhere in
+  the file happened to share the bare tail name (`proc sin {…}`, `proc abs
+  {…}`, `proc max {…}` — all plausible user proc names) — silently
+  mis-resolve `expr {sin(...)}` to that unrelated global command instead of
+  `::tcl::mathfunc::sin`. W123 itself never regressed (the coarse
+  `proc_tail_names` fallback happened to still suppress it either way), but
+  go-to-definition, references, rename, call-hierarchy, minify, and
+  completion all read `resolved_qualified_name` directly and would have
+  inherited the wrong target. Fixed by giving mathfunc invocations their own
+  two-candidate settlement rule (caller's `tcl::mathfunc`, else the global
+  one — `bareword_resolution_candidates` against the relative name
+  `tcl::mathfunc::f`, not the generic suffix-strip) in
+  `finalise_invocation_resolutions` (`scope.rs`), keyed off the shared
+  `tcl_expr_eval::is_known_mathfunc_in_dialect` free function so the
+  existence check and W123's own agree by construction. Covered by
+  `commands.rs`'s `expr_function_call_ignores_unrelated_same_named_global_proc`
+  / `expr_function_call_resolves_namespace_local_mathfunc_override` /
+  `expr_function_call_falls_back_to_global_user_override_from_a_namespace`
+  / `expr_function_call_resolves_builtin_from_inside_a_namespace`, and
+  `definition.rs`'s `no_definition_for_mathfunc_call_despite_unrelated_same_named_proc`
+  / `mathfunc_call_jumps_to_namespace_local_override`.
 
 ### 1.7 Literal command names in dispatch tables — **CONFIRMED** (medium)
 

--- a/docs/design/tricky-name-resolution-surfaces.md
+++ b/docs/design/tricky-name-resolution-surfaces.md
@@ -245,6 +245,22 @@ the ensemble configuration string. Same fix location, same milestone.
 - **Repro:** `proc ::tcl::mathfunc::dbl {x} {expr {$x*2}}; set y [expr {dbl(3)}]`.
 - **Milestone:** none. **NEW** — expr-body function-name resolution; slot into
   **M7** (or a small standalone). Niche (requires custom mathfuncs).
+- **Status (M7, shipped):** `record_expr_function_invocations`
+  (`commands.rs`) now harvests every `f(...)` bareword inside an `expr`
+  (via `expr_function_calls`, the const-folder's expr parse) as a command
+  invocation resolved to `::tcl::mathfunc::f` — closing the go-to-def /
+  references / rename gap above for a *user*-defined
+  `proc ::tcl::mathfunc::f`. Issue #968 closed the companion W123 gap this
+  left open: a *built-in* function name (`sin`, `max`, …) with no user
+  override drew a spurious "unknown command" hint, since only the
+  user-proc path resolved (`w123_invocation_resolves`'s
+  `expr_mathfunc_name_known`, `unresolved.rs`, consulting the shared
+  `tcl_syntax::expr::mathfunc` name/version table). **Still open:** the
+  settled qualified name is always the *global* `::tcl::mathfunc::f`, never
+  accounting for a namespace-local override (`::ns::tcl::mathfunc::f`
+  shadowing inside `::ns` — real per TIP 232 / verified by the WASM
+  runtime's `namespace_local_mathfunc_shadows_in_expr` test) — a narrower,
+  separate follow-up.
 
 ### 1.7 Literal command names in dispatch tables — **CONFIRMED** (medium)
 

--- a/docs/design/tricky-name-resolution-surfaces.md
+++ b/docs/design/tricky-name-resolution-surfaces.md
@@ -314,9 +314,43 @@ the ensemble configuration string. Same fix location, same milestone.
   `expr_function_call_resolves_namespace_local_mathfunc_override` /
   `expr_function_call_falls_back_to_global_user_override_from_a_namespace` /
   `expr_function_call_resolves_builtin_from_inside_a_namespace` /
-  `expr_function_call_honours_namespace_path`, and `definition.rs`'s
+  `expr_function_call_honours_namespace_path`, `definition.rs`'s
   `no_definition_for_mathfunc_call_despite_unrelated_same_named_proc` /
-  `mathfunc_call_jumps_to_namespace_local_override`.
+  `mathfunc_call_jumps_to_namespace_local_override`, `references.rs`'s
+  `references_do_not_cross_between_unrelated_proc_and_mathfunc_override`,
+  and `rename.rs`'s
+  `rename_mathfunc_override_updates_call_site_and_skips_unrelated_proc` —
+  the last two close out the two consumers (go-to-def already had direct
+  coverage) this section's own "Gap" line named as broken: references and
+  rename now have direct e2e coverage, not just an inference from the
+  analyser-level `resolved_qualified_name` being correct.
+
+  **Known residual gap, confirmed pre-existing and generic — not fixed
+  here:** `finalise_invocation_resolutions`'s `known()` predicate checks
+  `all_procs.contains_key(qualified)` with no deletion gating at all (unlike
+  its registry-builtin clause, which explicitly excludes a renamed-away
+  name via `renamed_away`). A namespace-local mathfunc override that is
+  declared and then `rename`d away before a later call resolves — and
+  therefore fails to draw W123 — is one instance of this, but the identical
+  probe against an ordinary same-shape case (`namespace eval ::a { proc
+  helper {} {...} }; rename ::a::helper {}; namespace eval ::a { proc
+  caller {} { helper } }`) shows the same non-detection, proving this
+  predates every change in this section and is not mathfunc-specific. Given
+  W123's own documented design bias (prefer a missed warning over a false
+  positive — see `build_w123_known_names`'s profile-filter reasoning
+  above), leaving it be is consistent with that stance; fixing it for real
+  would mean threading `deleted_commands` through `known()` for every
+  invocation kind, a separate, broader change out of scope here.
+
+  **Consumers verified only indirectly, via the shared
+  `resolved_qualified_name`/`resolution_candidates` fields being correct at
+  the source, not by a dedicated end-to-end test:** hover, completion, call
+  hierarchy, minify, and the dependency graphs (`tcl-lsp-core`'s
+  `references.rs`, `linked_editing_range.rs`, `minify.rs`, `graphs.rs`,
+  `call_hierarchy.rs`, `completion.rs` all read these same fields). Their
+  own test suites (1017+ tests across `tcl-lsp-core`/`tcl-lsp-db`) passed
+  unmodified throughout, so nothing regressed, but no test in this effort
+  specifically targets a mathfunc call through any of them.
 
 ### 1.7 Literal command names in dispatch tables — **CONFIRMED** (medium)
 

--- a/docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md
+++ b/docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md
@@ -31,6 +31,17 @@ unknownCmd $arg
 
 The analyser reports **`W123`** on `unknownCmd`.
 
+## What does not trigger it
+
+A built-in `expr` math function (`sin`, `max`, `abs`, …) called with
+function-call syntax inside `expr` resolves to the command it dispatches to
+(`::tcl::mathfunc::<name>`) and never draws `W123`, whether or not it has
+also been overridden by a `proc ::tcl::mathfunc::<name>` in the file:
+
+```tcl
+set x [expr {sin(1.0) + max(1, 2, 3)}]
+```
+
 ## Fix
 
 ```tcl

--- a/editors/vscode/src/test/issue968.test.ts
+++ b/editors/vscode/src/test/issue968.test.ts
@@ -1,0 +1,73 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Issue #968: every built-in `expr` math function (`sin(...)`, `max(...)`,
+// ...) drew a spurious W123 "unknown command" hint — the analyser only ever
+// recognised a same-named user `proc ::tcl::mathfunc::<name>` override, never
+// the built-in function table itself. The deep TP/FP/TN/FN coverage lives in
+// the analyser and native lsp_e2e suites; this proves the same fix arrives
+// through a real VS Code session.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, waitForDiagnostics } from "./helper";
+
+function codeOf(d: vscode.Diagnostic): string | undefined {
+  return typeof d.code === "object" ? String(d.code.value) : (d.code as string | undefined);
+}
+
+suite("Issue #968: expr math functions", () => {
+  test("built-in expr math functions draw no W123, unknown function still does", async () => {
+    const docUri = getDocUri("issue968.tcl");
+    await activate(docUri);
+
+    // Wait for the deep pass to settle: the unknown `frobnicate` call on
+    // line 12 must eventually surface its W123 — once it has, the earlier
+    // (fixed) lines are guaranteed to have been analysed too.
+    const diagnostics = await waitForDiagnostics(docUri, {
+      predicate: (diags) => diags.some((d) => codeOf(d) === "W123" && d.range.start.line === 12),
+      timeout: 15_000,
+    });
+
+    const w123Lines = diagnostics
+      .filter((d) => codeOf(d) === "W123")
+      .map((d) => d.range.start.line);
+
+    // Line 5: `set builtin [expr {sin(1.0) + max(1, 2, 3)}]`.
+    assert.ok(
+      !w123Lines.includes(5),
+      `built-in sin()/max() must not draw W123, got W123 on lines [${w123Lines}]`,
+    );
+    // Line 8: `set nested [expr {sqrt(abs($builtin))}]` — both the outer and
+    // inner function calls must resolve.
+    assert.ok(
+      !w123Lines.includes(8),
+      `nested built-in sqrt(abs(...)) must not draw W123, got W123 on lines [${w123Lines}]`,
+    );
+    // Line 12 (control): a genuinely unknown function name is still flagged.
+    assert.ok(
+      w123Lines.includes(12),
+      `an unknown expr function must still draw W123, got W123 on lines [${w123Lines}]`,
+    );
+    const frobnicate = diagnostics.find((d) => codeOf(d) === "W123" && d.range.start.line === 12);
+    assert.ok(
+      frobnicate?.message.includes("frobnicate"),
+      `W123 message should name the unknown function: ${frobnicate?.message}`,
+    );
+  });
+});

--- a/editors/vscode/testFixture/issue968.tcl
+++ b/editors/vscode/testFixture/issue968.tcl
@@ -1,0 +1,14 @@
+# Issue #968: the analyser never recognised a built-in `expr` math function
+# (`sin`, `max`, ...) as a resolvable command — only a same-named user
+# `proc ::tcl::mathfunc::<name>` override resolved. Every stock math function
+# call inside `expr` drew a spurious W123 "unknown command" hint.
+
+set builtin [expr {sin(1.0) + max(1, 2, 3)}]
+puts $builtin
+
+set nested [expr {sqrt(abs($builtin))}]
+puts $nested
+
+# Control: a genuinely unknown function name must still be flagged.
+set bogus [expr {frobnicate(1)}]
+puts $bogus

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1496,7 +1496,7 @@ impl Analyser {
         // to `::tcl::mathfunc::<fn>` — recorded here (with `&mut self`) because
         // the free-function collection can't resolve that namespace.
         for expr_tok in expr_toks {
-            self.record_expr_function_invocations(expr_tok);
+            self.record_expr_function_invocations(expr_tok, scope_path);
         }
     }
 
@@ -1845,9 +1845,9 @@ impl Analyser {
         self.push_collected_heads(heads, scope_path);
         // This expr's own math functions, plus any nested inside a `[expr {…}]`
         // substitution the collection surfaced (`if {[expr {Pi()}]}`).
-        self.record_expr_function_invocations(expr_tok);
+        self.record_expr_function_invocations(expr_tok, scope_path);
         for nested in expr_toks {
-            self.record_expr_function_invocations(nested);
+            self.record_expr_function_invocations(nested, scope_path);
         }
     }
 
@@ -1891,18 +1891,27 @@ impl Analyser {
 
     /// Record each math-function application (`sin($x)`, `max($a, $b)`) as an
     /// invocation of the command it dispatches to, `::tcl::mathfunc::<name>`.
-    /// A user who defines `proc ::tcl::mathfunc::myfunc { … }` then gets
-    /// go-to-definition, references, rename, and arity checking on
-    /// `myfunc(...)` calls, and the function is no longer reported unused.
+    /// A user who defines `proc ::tcl::mathfunc::myfunc { … }` — or, per TIP
+    /// 232, a namespace-local `proc ::ns::tcl::mathfunc::myfunc` that shadows
+    /// it inside `::ns` — then gets go-to-definition, references, rename, and
+    /// arity checking on `myfunc(...)` calls, and the function is no longer
+    /// reported unused.
     ///
-    /// The written head is the bare function word (`sin`) and the resolved
-    /// name is `::tcl::mathfunc::sin`; [`Self::finalise_invocation_resolutions`]
-    /// recovers the `::tcl::mathfunc` namespace from that pair and settles the
-    /// candidate list the same way it does an ordinary namespaced call, so a
-    /// rename rewrites only the tail token in the expression.
-    fn record_expr_function_invocations(&mut self, expr_tok: Token) {
+    /// The written head is the bare function word (`sin`); the resolved name
+    /// is the *local-first* candidate `{ns}::tcl::mathfunc::sin` for the
+    /// call's own namespace, computed the same way an ordinary bareword
+    /// command's walk-time guess is ([`Self::resolve_command_qualified_name`])
+    /// so a rename rewrites only the tail token in the expression.
+    /// [`Self::finalise_invocation_resolutions`] settles it against the real
+    /// two-candidate rule (the caller's `tcl::mathfunc`, else the global
+    /// one) — never the generic one-hop `{ns}::{name}` suffix-strip it uses
+    /// for an ordinary call, which would misparse the fixed `tcl::mathfunc`
+    /// dispatch segment as if it were the calling namespace and could
+    /// mis-resolve to an unrelated global command sharing the bare tail name.
+    fn record_expr_function_invocations(&mut self, expr_tok: Token, scope_path: &[usize]) {
         for (name, span, argc) in self.expr_function_calls(expr_tok) {
-            let resolved = format!("::tcl::mathfunc::{name}");
+            let resolved =
+                self.resolve_command_qualified_name(&format!("tcl::mathfunc::{name}"), scope_path);
             self.push_command_reference(name, span, resolved, Some(argc));
         }
     }
@@ -3506,5 +3515,111 @@ mod tests {
                     .collect::<Vec<_>>(),
             );
         }
+    }
+
+    /// An unrelated ordinary `proc sin` sharing a math function's bare tail
+    /// name must never hijack `expr {sin(...)}` — the two live in entirely
+    /// separate command tables in real Tcl (confirmed by the VM's own
+    /// `tcl::mathfunc::*` dispatch, which never consults an ordinary
+    /// top-level command). Before the two-candidate resettlement rule
+    /// below, `finalise_invocation_resolutions`'s generic one-hop
+    /// `{ns}::{name}` suffix-strip misparsed the mathfunc-qualified
+    /// `::tcl::mathfunc::sin` as if `::tcl::mathfunc` were the *calling*
+    /// namespace, and — once `sin` was `known` only as the unrelated
+    /// global proc — silently rewrote the resolved name to `::sin`.
+    #[test]
+    fn expr_function_call_ignores_unrelated_same_named_global_proc() {
+        let src = "proc sin {x} { return bogus }\nset y [expr {sin(1.0)}]\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        let inv = r
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "sin" && i.argc == Some(1))
+            .expect("mathfunc invocation recorded");
+        assert_eq!(
+            inv.resolved_qualified_name.as_deref(),
+            Some("::tcl::mathfunc::sin"),
+            "the unrelated proc sin must not hijack expr's sin(...): {inv:?}",
+        );
+    }
+
+    /// TIP 232: a namespace-local `proc ::ns::tcl::mathfunc::f` shadows the
+    /// global `::tcl::mathfunc::f` for a call made from inside `::ns` —
+    /// confirmed real Tcl behaviour by the VM's
+    /// `namespace_local_mathfunc_shadows_global_in_expr`
+    /// (`tcl-vm/tests/tricky_resolution_e2e.rs`). The analyser must settle
+    /// the call to the local override, not the fixed global form.
+    #[test]
+    fn expr_function_call_resolves_namespace_local_mathfunc_override() {
+        let src = "namespace eval ::nsa::tcl::mathfunc {}\n\
+                    proc ::nsa::tcl::mathfunc::pf {x} { return 20 }\n\
+                    namespace eval ::nsa {\n    proc caller {} { return [expr {pf(1)}] }\n}\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        let inv = r
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "pf")
+            .expect("mathfunc invocation recorded");
+        assert_eq!(
+            inv.resolved_qualified_name.as_deref(),
+            Some("::nsa::tcl::mathfunc::pf"),
+            "pf(1) inside ::nsa must resolve to the local override: {inv:?}",
+        );
+        assert_eq!(
+            inv.resolution_candidates,
+            vec!["::nsa::tcl::mathfunc::pf", "::tcl::mathfunc::pf"],
+            "local-first, then global, matching the VM's own search order",
+        );
+    }
+
+    /// The companion of the override case above: no local override exists at
+    /// `::nsa::tcl::mathfunc::pf`, only a *global* user-defined one — the
+    /// call still finds it via the two-candidate rule's fallback step.
+    #[test]
+    fn expr_function_call_falls_back_to_global_user_override_from_a_namespace() {
+        let src = "proc ::tcl::mathfunc::pf {x} { return 10 }\n\
+                    namespace eval ::nsa {\n    proc caller {} { return [expr {pf(1)}] }\n}\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        let inv = r
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "pf")
+            .expect("mathfunc invocation recorded");
+        assert_eq!(
+            inv.resolved_qualified_name.as_deref(),
+            Some("::tcl::mathfunc::pf"),
+            "no local override at ::nsa -- must fall back to the global proc: {inv:?}",
+        );
+    }
+
+    /// The everyday case exercised via the new namespace-aware resolution
+    /// path: a built-in (`sin`), called from inside a namespace with no
+    /// override anywhere, must still settle to the global built-in slot —
+    /// the fix to the collision/shadowing bugs above must not regress the
+    /// common no-namespace, no-override call this project's issue #968
+    /// fix already covers at the diagnostic layer.
+    #[test]
+    fn expr_function_call_resolves_builtin_from_inside_a_namespace() {
+        let src = "namespace eval ::nsa {\n    proc caller {} { return [expr {sin(1.0)}] }\n}\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        let inv = r
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "sin")
+            .expect("mathfunc invocation recorded");
+        assert_eq!(
+            inv.resolved_qualified_name.as_deref(),
+            Some("::tcl::mathfunc::sin"),
+            "a built-in with no override anywhere must settle globally: {inv:?}",
+        );
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+            "must still draw no W123: {:?}",
+            r.diagnostics,
+        );
     }
 }

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -364,6 +364,7 @@ impl Analyser {
                     indirect: false,
                     rename_safe: true,
                     existence_probe: false,
+                    is_mathfunc_call: false,
                 },
             );
 
@@ -391,6 +392,7 @@ impl Analyser {
                         indirect: false,
                         rename_safe: true,
                         existence_probe: false,
+                        is_mathfunc_call: false,
                     },
                 );
             }
@@ -1286,6 +1288,7 @@ impl Analyser {
                     indirect: false,
                     rename_safe: true,
                     existence_probe: false,
+                    is_mathfunc_call: false,
                 },
             );
         }
@@ -1334,6 +1337,38 @@ impl Analyser {
                 indirect: false,
                 rename_safe: true,
                 existence_probe,
+                is_mathfunc_call: false,
+            },
+        );
+    }
+
+    /// [`Self::push_command_reference`] for an `expr` math-function call —
+    /// see
+    /// [`crate::signature_scan::types::SignatureCommandInvocation::is_mathfunc_call`].
+    /// A dedicated method rather than another positional bool on
+    /// [`Self::push_command_reference_with_policy`]: it has exactly one
+    /// caller, and a same-typed `existence_probe, is_mathfunc_call` pair
+    /// invites a silently-transposed call.
+    pub(in crate::analyser) fn push_mathfunc_command_reference(
+        &mut self,
+        written: String,
+        span: Span,
+        resolved: String,
+        argc: Option<usize>,
+    ) {
+        self.result.command_invocations.push(
+            crate::signature_scan::types::SignatureCommandInvocation {
+                name: written,
+                range: span,
+                resolved_qualified_name: Some(resolved),
+                resolution_candidates: Vec::new(),
+                argc,
+                callback_arity: None,
+                callback_baked_args: 0,
+                indirect: false,
+                rename_safe: true,
+                existence_probe: false,
+                is_mathfunc_call: true,
             },
         );
     }
@@ -1912,7 +1947,7 @@ impl Analyser {
         for (name, span, argc) in self.expr_function_calls(expr_tok) {
             let resolved =
                 self.resolve_command_qualified_name(&format!("tcl::mathfunc::{name}"), scope_path);
-            self.push_command_reference(name, span, resolved, Some(argc));
+            self.push_mathfunc_command_reference(name, span, resolved, Some(argc));
         }
     }
 
@@ -1936,6 +1971,7 @@ impl Analyser {
                     indirect: false,
                     rename_safe: true,
                     existence_probe: false,
+                    is_mathfunc_call: false,
                 },
             );
         }
@@ -1986,6 +2022,7 @@ impl Analyser {
                     indirect: false,
                     rename_safe: true,
                     existence_probe: false,
+                    is_mathfunc_call: false,
                 },
             );
         }
@@ -3619,6 +3656,48 @@ mod tests {
         assert!(
             !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
             "must still draw no W123: {:?}",
+            r.diagnostics,
+        );
+    }
+
+    /// TIP 232 math functions are ordinary commands, so `namespace path`
+    /// applies to their resolution exactly as it does to any other command —
+    /// confirmed against the VM's own `resolve_command_fqn`, which routes
+    /// every lookup (mathfunc calls included) through the same `ns_paths`-
+    /// aware resolver. Neither the caller's own namespace nor the global
+    /// slot defines `triple`; only the `namespace path` entry does.
+    #[test]
+    fn expr_function_call_honours_namespace_path() {
+        let src = "namespace eval ::libns::tcl::mathfunc {}\n\
+                    proc ::libns::tcl::mathfunc::triple {x} { return [expr {$x * 3}] }\n\
+                    namespace eval ::consumer {\n    \
+                        namespace path ::libns\n    \
+                        proc caller {} { return [expr {triple(2)}] }\n\
+                    }\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl8.6");
+        let inv = r
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "triple")
+            .expect("mathfunc invocation recorded");
+        assert_eq!(
+            inv.resolved_qualified_name.as_deref(),
+            Some("::libns::tcl::mathfunc::triple"),
+            "must settle via the namespace path entry: {inv:?}",
+        );
+        assert_eq!(
+            inv.resolution_candidates,
+            vec![
+                "::consumer::tcl::mathfunc::triple",
+                "::libns::tcl::mathfunc::triple",
+                "::tcl::mathfunc::triple",
+            ],
+            "current namespace, then the path entry, then global",
+        );
+        assert!(
+            !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+            "must draw no W123: {:?}",
             r.diagnostics,
         );
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/const_dispatch.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/const_dispatch.rs
@@ -174,6 +174,7 @@ fn settle_one_site(
             indirect: true,
             rename_safe,
             existence_probe: false,
+            is_mathfunc_call: false,
         });
         for c in group {
             let Some(span) = c.literal_span else { continue };
@@ -190,6 +191,7 @@ fn settle_one_site(
                 indirect: false,
                 rename_safe: true,
                 existence_probe: false,
+                is_mathfunc_call: false,
             });
         }
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -6209,6 +6209,196 @@ foo$suffix
     );
 }
 
+// Issue #968 — W123 false-positived on every built-in `expr` math function
+// (`sin(...)`, `max(...)`, ...): `record_expr_function_invocations` already
+// resolved a math-function call to `::tcl::mathfunc::<name>`, but the W123
+// pass only recognised that qualified name via a *user-defined*
+// `proc ::tcl::mathfunc::<name>` (`proc_tail_names`) — never the built-in
+// function table itself, so every stock call read as unresolved.
+
+#[test]
+fn w123_tp_unknown_function_name_inside_expr_still_fires() {
+    // FP fix must not swallow a genuinely unknown function — `frobnicate` is
+    // not a real `::tcl::mathfunc` name in any Tcl release.
+    let src = "set x [expr {frobnicate(1)}]\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "an unknown expr function must still draw W123; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_tp_math_function_before_its_release_dual_fires_with_w002() {
+    // `min`/`max` are TIP 232 (8.5+); under 8.4 the name is not a real
+    // `::tcl::mathfunc` command in *this* dialect — the same "known
+    // elsewhere, disabled here" split the registry-builtin path draws for
+    // e.g. `dict` under `tcl8.4` (both W002 *and* W123 fire — see
+    // `build_w123_known_names`'s profile-filter comment; verified live
+    // against `exec` under `f5-irules`).
+    let src = "set x [expr {min(1, 2)}]\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.4");
+    assert!(
+        r.diagnostics.iter().any(|d| d.code == DiagCode::W002),
+        "min() under tcl8.4 must draw W002 (disabled in dialect); got {:?}",
+        r.diagnostics,
+    );
+    assert!(
+        r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "min() under tcl8.4 must also draw W123 (unresolved in this dialect); got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_tp_expr_function_after_rename_away_is_unresolved() {
+    // `rename ::tcl::mathfunc::sin {}` really does break `expr {sin(...)}}`
+    // in C Tcl (`invalid command name "tcl::mathfunc::sin"` — see the WASM
+    // runtime's `expr_routes_through_the_command_table` test) — a call after
+    // the deletion must not silently resolve.
+    let src = "rename ::tcl::mathfunc::sin {}\nset x [expr {sin(1.0)}]\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "a call through a renamed-away mathfunc must be flagged unresolved; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_tp_bareword_call_to_a_mathfunc_shaped_name_is_still_unresolved() {
+    // `sin` is only ever callable via `::tcl::mathfunc::sin` or the `expr`
+    // function-call grammar — a bare top-level command call to `sin` (no
+    // user `proc sin`, not inside `expr`) is `invalid command name` in real
+    // Tcl, and the fix must not leak resolution into ordinary bareword
+    // command dispatch.
+    let src = "sin 1.0\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "a bareword call to a mathfunc-shaped name must still be unresolved; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_fp_original_issue_968_repro_is_silent() {
+    // The exact shape reported in issue #968: built-in `expr` math
+    // functions must resolve with no diagnostic at all.
+    let src = "set x [expr {sin(1.0) + max(1, 2, 3)}]\nputs $x\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "issue #968: built-in expr math functions must not draw W123; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_fp_nested_function_calls_both_resolve() {
+    // `sqrt(abs($x))` records both the outer and the inner function as
+    // separate mathfunc invocations (`expr_nested_function_calls_are_both_recorded`
+    // in commands.rs) — both must resolve.
+    let src = "set x [expr {sqrt(abs($y))}]\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "nested built-in expr math functions must not draw W123; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_fp_version_gated_function_resolves_at_its_introducing_release() {
+    // `isnan` is TIP 521 (9.0+) — available (and silent) exactly at tcl9.0,
+    // unlike the tcl8.4 case above.
+    let src = "set x [expr {isnan(1.0)}]\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl9.0");
+    assert!(
+        !r.diagnostics
+            .iter()
+            .any(|d| matches!(d.code, DiagCode::W002 | DiagCode::W123)),
+        "isnan() under tcl9.0 must draw neither W002 nor W123; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_fp_expr_function_resolves_inside_if_condition() {
+    // The `expr`-function resolution path is driven by the registry's
+    // `ArgRole::Expr` role, so it fires for *any* EXPR-role argument —
+    // `if`'s condition, not only a literal `expr` command.
+    let src = "if {sin($y) > 0} {\n    puts hi\n}\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "a math function inside an `if` condition must not draw W123; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_fp_expr_function_resolves_inside_namespace_and_proc_body() {
+    // Interprocedural context (a namespace-scoped proc body) must not
+    // change resolution — the function dispatches through the global
+    // `::tcl::mathfunc` namespace regardless of the caller's own scope.
+    let src = "\
+namespace eval ::acme {
+    proc calc {y} {
+        return [expr {sin($y) + cos($y)}]
+    }
+}
+";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "a math function inside a namespaced proc body must not draw W123; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_tn_user_defined_mathfunc_override_still_resolves() {
+    // Pre-existing behaviour (`expr_function_call_records_a_mathfunc_invocation`
+    // in commands.rs), unaffected by the built-in-name fix: a user override
+    // resolves via `proc_tail_names` exactly as before.
+    let src = "proc ::tcl::mathfunc::myfunc {x} { return $x }\nset r [expr {myfunc(1)}]\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "a user-defined mathfunc override must resolve; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_tn_unrelated_proc_sharing_a_mathfunc_name_is_unaffected() {
+    // `proc abs {x} {...}` is an ordinary, unrelated command — the fix is
+    // scoped to `expr` function-call invocations only (via the settled
+    // `::tcl::mathfunc::<name>` qualified name), so a same-named regular
+    // proc and its ordinary bareword call sites must resolve exactly as
+    // they did before this fix, via the normal proc-tail path.
+    let src = "proc abs {x} {\n    if {$x < 0} { return [expr {-$x}] }\n    return $x\n}\nputs [abs -5]\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "an unrelated proc sharing a mathfunc name must resolve normally; got {:?}",
+        r.diagnostics,
+    );
+}
+
 #[test]
 fn analyse_static_rename_does_not_set_has_dynamic_providers() {
     // A fully static `rename OLD NEW` is now recorded precisely

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -6399,6 +6399,77 @@ fn w123_tn_unrelated_proc_sharing_a_mathfunc_name_is_unaffected() {
     );
 }
 
+// The `expr`-function shortcut above is keyed on `is_mathfunc_call`, not
+// merely on the settled qualified name matching `::tcl::mathfunc::<name>` —
+// an *ordinary* call can resolve to that same shape by being made from
+// inside the real `::tcl::mathfunc` namespace, and TIP 232's command
+// wrappers (the mechanism that makes such a bareword call valid at all)
+// only exist from Tcl 8.5 onward, independent of any individual function's
+// own, earlier expr-grammar availability.
+
+#[test]
+fn w123_tp_ordinary_call_shaped_like_mathfunc_fires_under_84() {
+    // `sin` is a valid *expr* function since 8.4, but the `::tcl::mathfunc`
+    // *command* namespace TIP 232 introduced does not exist until 8.5 — an
+    // ordinary bareword call to `sin` from inside that namespace is not a
+    // real command under an 8.4-based dialect.
+    let src = "namespace eval ::tcl::mathfunc {\n    sin 1\n}\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.4");
+    assert!(
+        r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "an ordinary call shaped like a mathfunc dispatch must still draw \
+         W123 under an 8.4-based dialect; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_fp_ordinary_call_shaped_like_mathfunc_resolves_under_86() {
+    // The same call is genuinely valid Tcl from 8.5 onward: `::tcl::mathfunc::sin`
+    // really is a callable command there, so the bareword call must resolve.
+    let src = "namespace eval ::tcl::mathfunc {\n    sin 1\n}\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.6");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "the command wrapper genuinely exists under tcl8.6; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_tp_custom_mathfunc_body_bareword_call_fires_under_84() {
+    // The more realistic trigger: a custom math function's own body calling
+    // a built-in bareword (not through `expr`'s function-call syntax) —
+    // still invalid under an 8.4-based dialect for the same reason.
+    let src = "proc ::tcl::mathfunc::myfunc {x} { return [sin $x] }\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.4");
+    assert!(
+        r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "a bareword call to a builtin from inside a custom mathfunc body \
+         must still draw W123 under an 8.4-based dialect; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_fp_expr_function_call_unaffected_by_wrapper_availability_under_84() {
+    // Regression guard: the wrapper-availability gate must apply only to
+    // ordinary calls, never to a genuine `expr` function-call site — issue
+    // #968's original fix must not regress under an 8.4-based dialect.
+    let src = "set x [expr {sin(1.0)}]\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl8.4");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "expr {{sin(1.0)}} is valid under tcl8.4 regardless of TIP 232's \
+         command-wrapper availability; got {:?}",
+        r.diagnostics,
+    );
+}
+
 #[test]
 fn analyse_static_rename_does_not_set_has_dynamic_providers() {
     // A fully static `rename OLD NEW` is now recorded precisely

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -7203,6 +7203,7 @@ fn analyse_w123_package_require_gate_suppresses_when_recorded() {
             indirect: false,
             rename_safe: true,
             existence_probe: false,
+            is_mathfunc_call: false,
         });
     let registry = tcl_registry::CommandRegistry::build_default();
     a.emit_unresolved_command_diagnostics(&registry);

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -364,6 +364,14 @@ impl Analyser {
         crate::tcl_expr_eval::is_known_mathfunc_in_dialect(name, self.dialect())
     }
 
+    /// Whether this dialect exposes `::tcl::mathfunc::*` as literal,
+    /// bareword-callable commands (TIP 232, Tcl 8.5+) — see
+    /// [`crate::tcl_expr_eval::mathfunc_command_wrappers_available_in_dialect`].
+    #[must_use]
+    fn mathfunc_command_wrappers_available(&self) -> bool {
+        crate::tcl_expr_eval::mathfunc_command_wrappers_available_in_dialect(self.dialect())
+    }
+
     /// Whether byte offset `off` falls inside any recorded proc or class
     /// definition body — code there runs at *call* time, not load time.
     fn offset_is_inside_definition_body(&self, off: u32) -> bool {
@@ -381,6 +389,7 @@ impl Analyser {
         name: &str,
         range: tcl_lexer::Span,
         resolved_qualified_name: Option<&str>,
+        is_mathfunc_call: bool,
     ) -> bool {
         // A built-in renamed away / deleted at an earlier offset no longer
         // resolves here — fall through to the user-defined paths below,
@@ -410,10 +419,24 @@ impl Analyser {
         // {}` breaks `expr {sin(…)}` in C Tcl (confirmed by the WASM
         // runtime's `expr_routes_through_the_command_table` test), so a call
         // after that point falls through to the user-defined paths below.
+        //
+        // `is_mathfunc_call` gates which of two distinct facts applies. A
+        // genuine `expr` function-call site is governed by expr-grammar
+        // per-function availability alone (`expr_mathfunc_name_known`) —
+        // `expr {sin(1)}` is valid under an 8.4-based dialect even though
+        // TIP 232 (and the `::tcl::mathfunc` *command* namespace it
+        // introduced) did not land until 8.5. An *ordinary* call that
+        // merely happens to resolve to the same qualified shape (a bareword
+        // `sin` invoked from inside a real `::tcl::mathfunc` namespace) has
+        // no such exemption — it can only be that literal command, which
+        // exists only where the wrapper mechanism itself does
+        // (`mathfunc_command_wrappers_available_in_dialect`). Without this
+        // split, an 8.4-based dialect would wrongly resolve the latter.
         if let Some(resolved) = resolved_qualified_name {
             let mathfunc_qualified = format!("::tcl::mathfunc::{name}");
             if resolved == mathfunc_qualified
                 && self.expr_mathfunc_name_known(name)
+                && (is_mathfunc_call || self.mathfunc_command_wrappers_available())
                 && !self.qualified_name_deleted_before(&mathfunc_qualified, range.start())
             {
                 return true;
@@ -515,6 +538,7 @@ impl Analyser {
                 name,
                 inv.range,
                 inv.resolved_qualified_name.as_deref(),
+                inv.is_mathfunc_call,
             ) {
                 continue;
             }

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -361,11 +361,7 @@ impl Analyser {
     /// matching W002's own "don't restrict" rule for that case.
     #[must_use]
     fn expr_mathfunc_name_known(&self, name: &str) -> bool {
-        let Some(since) = tcl_syntax::expr::mathfunc::added_in(name) else {
-            return false;
-        };
-        crate::tcl_expr_eval::math_func_ceiling_for_dialect(self.dialect())
-            .is_none_or(|ceiling| since <= ceiling)
+        crate::tcl_expr_eval::is_known_mathfunc_in_dialect(name, self.dialect())
     }
 
     /// Whether byte offset `off` falls inside any recorded proc or class

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -68,6 +68,10 @@ impl Analyser {
     ///
     /// - `cmd_name in registry_names` (built-in command), unless the
     ///   built-in was renamed away / deleted earlier in the file.
+    /// - The call is an `expr` math-function application (`sin($x)`,
+    ///   `max($a, $b)`) whose name is a genuine built-in `::tcl::mathfunc`
+    ///   function available under the dialect's `expr` grammar version,
+    ///   unless that qualified name was renamed away / deleted earlier.
     /// - `cmd_name` contains `::` (qualified — defer to
     ///   per-namespace logic, conservative skip).
     /// - `cmd_name` starts with `$` / `[` (interpolated /
@@ -312,7 +316,17 @@ impl Analyser {
     fn registry_name_deleted_before(&self, name: &str, call_off: u32) -> bool {
         // `handle_rename` / `handle_interp_alias` record deletions under the
         // normalised qualified name; an unqualified built-in lives at `::`.
-        let Some(&del_off) = self.deleted_commands.get(&format!("::{name}")) else {
+        self.qualified_name_deleted_before(&format!("::{name}"), call_off)
+    }
+
+    /// [`Self::registry_name_deleted_before`] for a name that is already
+    /// fully qualified (`::tcl::mathfunc::sin`) rather than an unqualified
+    /// built-in living at the global `::`. Shared so the deletion-gating
+    /// rule — a deletion recorded inside a proc/method/class body is
+    /// conditional and never disqualifies — cannot drift between the two
+    /// callers.
+    fn qualified_name_deleted_before(&self, qualified: &str, call_off: u32) -> bool {
+        let Some(&del_off) = self.deleted_commands.get(qualified) else {
             return false;
         };
         if del_off >= call_off {
@@ -325,6 +339,33 @@ impl Analyser {
         // path byte-identical: an isolated body's analyser state, including
         // its deletions, is not grafted back into the shell.)
         !self.offset_is_inside_definition_body(del_off)
+    }
+
+    /// Whether `name` is a genuine built-in `expr` math function (`sin`,
+    /// `max`, …) for W123 purposes — i.e. a real name in
+    /// [`tcl_syntax::expr::mathfunc`], the single shared function/version
+    /// table the const-folder, the runtime, and
+    /// [`Self::emit_expr_function_dialect_diagnostics`] (W002) already
+    /// consult.
+    ///
+    /// Deliberately does **not** gate on the dialect's `expr`-grammar
+    /// version ceiling the way W002 does: a function that predates the
+    /// active dialect (`min(…)` under `tcl8.4`) is still a *real* name, just
+    /// disabled here — exactly the same "known but disabled" split the
+    /// generic registry-builtin path draws for a dialect-gated command like
+    /// `dict` under `tcl8.4` (`build_w123_known_names`'s profile filter): W002
+    /// explains why the call is disabled, and W123 fires alongside it since
+    /// the name still doesn't dispatch to anything in *this* dialect. A
+    /// dialect with no `expr` grammar base at all
+    /// (`math_func_ceiling_for_dialect` returns `None`) applies no ceiling,
+    /// matching W002's own "don't restrict" rule for that case.
+    #[must_use]
+    fn expr_mathfunc_name_known(&self, name: &str) -> bool {
+        let Some(since) = tcl_syntax::expr::mathfunc::added_in(name) else {
+            return false;
+        };
+        crate::tcl_expr_eval::math_func_ceiling_for_dialect(self.dialect())
+            .is_none_or(|ceiling| since <= ceiling)
     }
 
     /// Whether byte offset `off` falls inside any recorded proc or class
@@ -343,6 +384,7 @@ impl Analyser {
         known: &W123KnownNames,
         name: &str,
         range: tcl_lexer::Span,
+        resolved_qualified_name: Option<&str>,
     ) -> bool {
         // A built-in renamed away / deleted at an earlier offset no longer
         // resolves here — fall through to the user-defined paths below,
@@ -353,6 +395,33 @@ impl Analyser {
             && !self.registry_name_deleted_before(name, range.start())
         {
             return true;
+        }
+        // An `expr` math-function application (`sin($x)`, `max($a, $b)`) is
+        // recorded by `record_expr_function_invocations` with the *bare*
+        // function word as `name` and `::tcl::mathfunc::<name>` as the
+        // settled qualified name — never a bareword registry entry, unlike
+        // `tcl::mathop`'s `+`/`!`. A bare `sin`/`abs`/`round`/`bool`
+        // registration would misdirect *every other* consumer of the bare
+        // registry-name set (an unrelated `proc abs {x} {…}` would misread
+        // as "renaming a builtin") — precisely the defect `tcl::mathop`
+        // deliberately avoids by leaving `max`/`min` unregistered bare (see
+        // `mathop_generated.rs`). So this checks the settled qualified name
+        // directly against the single shared math-function name/version
+        // table (`tcl_syntax::expr::mathfunc`) — the same table
+        // `emit_expr_function_dialect_diagnostics` (W002) already consults —
+        // rather than the registry's bare-name set, and is gated by the same
+        // deletion rule as a registry builtin: `rename ::tcl::mathfunc::sin
+        // {}` breaks `expr {sin(…)}` in C Tcl (confirmed by the WASM
+        // runtime's `expr_routes_through_the_command_table` test), so a call
+        // after that point falls through to the user-defined paths below.
+        if let Some(resolved) = resolved_qualified_name {
+            let mathfunc_qualified = format!("::tcl::mathfunc::{name}");
+            if resolved == mathfunc_qualified
+                && self.expr_mathfunc_name_known(name)
+                && !self.qualified_name_deleted_before(&mathfunc_qualified, range.start())
+            {
+                return true;
+            }
         }
         // Qualified names defer to per-namespace logic (conservative skip);
         // `$`-interpolated / `[…]`-substituted heads are W307 / W308's
@@ -445,7 +514,12 @@ impl Analyser {
             if inv.existence_probe {
                 continue;
             }
-            if self.w123_invocation_resolves(known, name, inv.range) {
+            if self.w123_invocation_resolves(
+                known,
+                name,
+                inv.range,
+                inv.resolved_qualified_name.as_deref(),
+            ) {
                 continue;
             }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -1301,6 +1301,7 @@ impl Analyser {
                 indirect: false,
                 rename_safe: true,
                 existence_probe: false,
+                is_mathfunc_call: false,
             });
         }
         self.result.command_invocations.extend(new_invocations);

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -453,27 +453,38 @@ impl Analyser {
             };
             // A math-function invocation's resolved name carries the fixed
             // `tcl::mathfunc` dispatch segment, never the calling namespace —
-            // the generic one-hop `{ns}::{name}` strip just below would
-            // misparse `::tcl::mathfunc::sin` (minus `::sin`) as the nonsense
-            // namespace `::tcl::mathfunc`, silently mis-resolving to an
-            // unrelated global command that happens to share the bare tail
-            // name (a same-file `proc sin {…}` would hijack `expr {sin(x)}`).
-            // Settle these against the real two-candidate rule instead: the
-            // caller's own `tcl::mathfunc` (a TIP 232 namespace-local
-            // override), else the global one — `known` plus, for the global
-            // candidate only, genuine built-in membership (a local slot is
-            // never a built-in; only the true global one ever is).
-            let mathfunc_suffix = format!("::tcl::mathfunc::{}", inv.name);
-            if let Some(stripped) = resolved.strip_suffix(mathfunc_suffix.as_str()) {
-                let ns: String = if stripped.is_empty() {
-                    "::".to_owned()
-                } else {
-                    stripped.to_owned()
+            // the generic one-hop `{ns}::{name}` strip just below assumes
+            // `resolved` is exactly `{callingNamespace}::{name}`, which is
+            // false here (it would misparse `::tcl::mathfunc::sin` as if
+            // `::tcl::mathfunc` were the calling namespace, silently
+            // mis-resolving to an unrelated global command that happens to
+            // share the bare tail name — a same-file `proc sin {…}` would
+            // hijack `expr {sin(x)}`). `is_mathfunc_call` — set once, at
+            // record time, never re-derived by guessing at the resolved
+            // string's shape — routes these through the real two-candidate
+            // rule instead: the caller's own `tcl::mathfunc` (honouring its
+            // `namespace path`, exactly like the VM's own
+            // `resolve_command_fqn` does for every command lookup, math
+            // functions included), else the global one — `known` plus, for
+            // the global candidate only, genuine built-in membership (a
+            // local slot is never a built-in; only the true global one
+            // ever is).
+            if inv.is_mathfunc_call {
+                let mathfunc_suffix = format!("::tcl::mathfunc::{}", inv.name);
+                let ns: String = match resolved.strip_suffix(mathfunc_suffix.as_str()) {
+                    Some("") => "::".to_owned(),
+                    Some(prefix) => prefix.to_owned(),
+                    // The walk always produces this shape for a mathfunc
+                    // invocation; treat an unrecognised one conservatively,
+                    // matching the generic path's own fallback below.
+                    None => {
+                        inv.resolution_candidates = vec![resolved];
+                        continue;
+                    }
                 };
-                let candidates = crate::naming::bareword_resolution_candidates(
-                    &ns,
-                    &format!("tcl::mathfunc::{}", inv.name),
-                );
+                let path: &[String] = paths.get(&ns).map_or(&[], Vec::as_slice);
+                let rel = format!("tcl::mathfunc::{}", inv.name);
+                let candidates = crate::naming::command_resolution_candidates(&ns, path, &rel);
                 inv.resolution_candidates.clone_from(&candidates);
                 let global = format!("::tcl::mathfunc::{}", inv.name);
                 let winner = candidates.into_iter().find(|c| {

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -395,6 +395,12 @@ impl Analyser {
         let Some(builtins) = self.builtin_names.as_ref() else {
             return;
         };
+        // `&'static str`, not a borrow of `self` — safe to read after the
+        // field-splitting `result` borrow below, unlike an `&self` method
+        // call (which is why the math-function existence check the
+        // mathfunc branch uses is a free function, not `Analyser::dialect`
+        // plus an instance method).
+        let dialect = self.dialect();
         // Recorded `namespace path` declarations, cloned before borrowing
         // `result` mutably. Entries are passed as written — the shared
         // candidate builder roots a relative entry against the declaring
@@ -445,6 +451,45 @@ impl Analyser {
             let Some(resolved) = inv.resolved_qualified_name.clone() else {
                 continue;
             };
+            // A math-function invocation's resolved name carries the fixed
+            // `tcl::mathfunc` dispatch segment, never the calling namespace —
+            // the generic one-hop `{ns}::{name}` strip just below would
+            // misparse `::tcl::mathfunc::sin` (minus `::sin`) as the nonsense
+            // namespace `::tcl::mathfunc`, silently mis-resolving to an
+            // unrelated global command that happens to share the bare tail
+            // name (a same-file `proc sin {…}` would hijack `expr {sin(x)}`).
+            // Settle these against the real two-candidate rule instead: the
+            // caller's own `tcl::mathfunc` (a TIP 232 namespace-local
+            // override), else the global one — `known` plus, for the global
+            // candidate only, genuine built-in membership (a local slot is
+            // never a built-in; only the true global one ever is).
+            let mathfunc_suffix = format!("::tcl::mathfunc::{}", inv.name);
+            if let Some(stripped) = resolved.strip_suffix(mathfunc_suffix.as_str()) {
+                let ns: String = if stripped.is_empty() {
+                    "::".to_owned()
+                } else {
+                    stripped.to_owned()
+                };
+                let candidates = crate::naming::bareword_resolution_candidates(
+                    &ns,
+                    &format!("tcl::mathfunc::{}", inv.name),
+                );
+                inv.resolution_candidates.clone_from(&candidates);
+                let global = format!("::tcl::mathfunc::{}", inv.name);
+                let winner = candidates.into_iter().find(|c| {
+                    known(c)
+                        || (*c == global
+                            && crate::tcl_expr_eval::is_known_mathfunc_in_dialect(
+                                &inv.name, dialect,
+                            ))
+                });
+                if let Some(w) = winner
+                    && w != resolved
+                {
+                    inv.resolved_qualified_name = Some(w);
+                }
+                continue;
+            }
             // The walk stored the local-first candidate (`{ns}::{name}`);
             // recover the call namespace and re-run the *shared* resolver
             // (`resolve_command_with`, the same rule the optimiser, the

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -206,6 +206,7 @@ pub struct SignatureAutoPathEntry {
 /// sites against a proc's qualified name even when the call
 /// site uses a relative form.
 #[derive(Debug, Clone, PartialEq, Eq)]
+#[allow(clippy::struct_excessive_bools)] // independent per-call-site flags, not a state machine
 pub struct SignatureCommandInvocation {
     /// Command head as written at the call site (no namespace
     /// resolution performed).
@@ -275,6 +276,20 @@ pub struct SignatureCommandInvocation {
     /// are orthogonal (issue #945 fault 9).  Navigation and rename treat
     /// the record exactly like any other direct reference.
     pub existence_probe: bool,
+    /// `true` for an `expr` math-function call (`sin($x)`, `max($a, $b)`,
+    /// recorded by `record_expr_function_invocations`). `name` is the bare
+    /// function word and `resolved_qualified_name` is the *local-first*
+    /// `{ns}::tcl::mathfunc::name` candidate for the call's own namespace —
+    /// unlike every other invocation, whose resolved name has the ordinary
+    /// `{ns}::{name}` shape (`ns` a single hop from `name`), a mathfunc
+    /// invocation always carries the fixed two-segment `tcl::mathfunc`
+    /// dispatch prefix between them. This flag — not a shape guess re-derived
+    /// from the resolved string — is what tells
+    /// [`crate::analyser::Analyser::finalise_invocation_resolutions`] to
+    /// settle it against the dedicated two-candidate mathfunc rule instead of
+    /// the generic one-hop suffix-strip, which would otherwise misparse
+    /// `tcl::mathfunc` as if it were the calling namespace.
+    pub is_mathfunc_call: bool,
 }
 
 /// The full result returned by `extract_signatures`.

--- a/rust/tcl-compiler/src/signature_scan/walker.rs
+++ b/rust/tcl-compiler/src/signature_scan/walker.rs
@@ -120,6 +120,7 @@ pub(super) fn scan(
                 indirect: false,
                 rename_safe: true,
                 existence_probe: false,
+                is_mathfunc_call: false,
             });
         // Record command-prefix callback heads (`lsort -command cb`, `trace
         // add … cb`, …) as their own invocations so background-scanned files
@@ -264,6 +265,7 @@ fn record_command_prefix_invocations(cmd: &SegmentedCommand, head: &str, ctx: &m
                 indirect: false,
                 rename_safe: true,
                 existence_probe: false,
+                is_mathfunc_call: false,
             });
     }
 }

--- a/rust/tcl-compiler/src/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/src/tcl_expr_eval.rs
@@ -232,6 +232,26 @@ pub fn is_known_mathfunc_in_dialect(name: &str, dialect: &str) -> bool {
     math_func_ceiling_for_dialect(dialect).is_none_or(|ceiling| since <= ceiling)
 }
 
+/// Whether `dialect` exposes math functions as literal `::tcl::mathfunc::*`
+/// **commands** — TIP 232's own wrapper mechanism, landed in 8.5 alongside
+/// `bool`/`entier`/`isqrt`/`min`/`max` (see
+/// [`tcl_syntax::expr::mathfunc::MathFuncSince::Tcl85`]'s doc comment). This
+/// is a coarser, single fact than [`is_known_mathfunc_in_dialect`]: it does
+/// not vary per function name, because every wrapper command — even one
+/// backing an 8.4-vintage function like `sin` — only exists from 8.5
+/// onward. An 8.4-based dialect supports `expr {sin(1)}` (the internal
+/// expr-grammar dispatch predates TIP 232) but not a bareword
+/// `::tcl::mathfunc::sin 1` call (the command itself does not exist there) —
+/// [`crate::analyser::diagnostics::unresolved`]'s W123 check uses this to
+/// keep an *ordinary* call that happens to resolve to a `tcl::mathfunc`-
+/// shaped qualified name from being waved through by the `expr`
+/// function-call shortcut, which only reflects the first, narrower fact.
+#[must_use]
+pub fn mathfunc_command_wrappers_available_in_dialect(dialect: &str) -> bool {
+    use tcl_syntax::expr::mathfunc::MathFuncSince;
+    math_func_ceiling_for_dialect(dialect).is_none_or(|ceiling| ceiling >= MathFuncSince::Tcl85)
+}
+
 fn eval_with_config(
     node: &ExprNode,
     env: &Env,

--- a/rust/tcl-compiler/src/tcl_expr_eval.rs
+++ b/rust/tcl-compiler/src/tcl_expr_eval.rs
@@ -215,6 +215,23 @@ pub fn math_func_ceiling_for_dialect(
     })
 }
 
+/// Whether `name` is a genuine built-in `expr` math function (`sin`, `max`,
+/// …) available under `dialect` — a real name in
+/// [`tcl_syntax::expr::mathfunc`] whose introducing release is at or before
+/// [`math_func_ceiling_for_dialect`]'s ceiling for this dialect.  Free
+/// function (rather than an `Analyser` method) so both the W123
+/// unresolved-command check and the cross-namespace invocation resettlement
+/// (`finalise_invocation_resolutions`, which runs after `self.result` is
+/// borrowed mutably and so cannot call back through `&self`) share one
+/// answer without either duplicating the other's logic.
+#[must_use]
+pub fn is_known_mathfunc_in_dialect(name: &str, dialect: &str) -> bool {
+    let Some(since) = tcl_syntax::expr::mathfunc::added_in(name) else {
+        return false;
+    };
+    math_func_ceiling_for_dialect(dialect).is_none_or(|ceiling| since <= ceiling)
+}
+
 fn eval_with_config(
     node: &ExprNode,
     env: &Env,

--- a/rust/tcl-lsp-server/tests/e2e/definition.rs
+++ b/rust/tcl-lsp-server/tests/e2e/definition.rs
@@ -184,6 +184,53 @@ fn global_call_fallback_is_deterministic_across_repeats() {
     }
 }
 
+// -- TestMathFunctionDefinition -------------------------------------------
+// `expr` math-function calls (`sin(...)`) dispatch through the fixed
+// `::tcl::mathfunc` sub-namespace, never the calling namespace — a generic
+// one-hop resolver that (mis)treated the qualified dispatch name as
+// `{callingNamespace}::{name}` could mis-jump to an unrelated same-named
+// top-level proc. These pin the fix at the go-to-definition layer, not just
+// the underlying resolved-name data.
+
+#[test]
+fn no_definition_for_mathfunc_call_despite_unrelated_same_named_proc() {
+    // `proc sin` is an ordinary, unrelated top-level command — it has zero
+    // effect on `expr {sin(...)}`, which only ever dispatches through
+    // `::tcl::mathfunc::sin` (a real Tcl builtin with no source location).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc sin {x} { return bogus }\nset y [expr {sin(1.0)}]\n";
+    lsp.open_ready(&uri, src);
+    let result = lsp.definition(&uri, 1, 14);
+    assert!(
+        locations(&result).is_empty(),
+        "must not jump to the unrelated proc sin: {result:?}"
+    );
+}
+
+#[test]
+fn mathfunc_call_jumps_to_namespace_local_override() {
+    // TIP 232: a namespace-local `proc ::nsa::tcl::mathfunc::pf` shadows the
+    // global `::tcl::mathfunc::pf` for a call made from inside `::nsa` (real
+    // Tcl behaviour — see the VM's
+    // `namespace_local_mathfunc_shadows_global_in_expr`). Go-to-definition
+    // on the call must land on the local override, not report nothing.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "namespace eval ::nsa::tcl::mathfunc {}\n\
+               proc ::nsa::tcl::mathfunc::pf {x} { return 20 }\n\
+               namespace eval ::nsa {\n    proc caller {} { return [expr {pf(1)}] }\n}\n";
+    lsp.open_ready(&uri, src);
+    let result = lsp.definition(&uri, 3, 36);
+    let locs = locations(&result);
+    assert!(!locs.is_empty(), "{result:?}");
+    assert_eq!(
+        start_line(&locs[0]),
+        1,
+        "must resolve to the local override"
+    );
+}
+
 // -- TestVariableDefinition ----------------------------------------------
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -3234,3 +3234,106 @@ fn irules_subcommands_named_like_banned_commands_are_clean_end_to_end() {
         codes(&diags)
     );
 }
+
+// -- Issue #968: W123 false-positived on every built-in `expr` math
+// function (`sin(...)`, `max(...)`, ...) — `expr_function_call_records_a_
+// mathfunc_invocation` (commands.rs) already resolved the call to
+// `::tcl::mathfunc::<name>`, but the W123 pass never recognised that
+// qualified name unless a same-named user proc happened to shadow it.
+
+#[test]
+fn issue_968_builtin_expr_math_functions_are_clean_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set x [expr {sin(1.0) + max(1, 2, 3)}]\nputs $x\n");
+    assert!(
+        !has_code(&diags, "W123"),
+        "issue #968: built-in expr math functions must not draw W123: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn issue_968_nested_expr_math_functions_are_clean_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set x [expr {sqrt(abs($y))}]\n");
+    assert!(
+        !has_code(&diags, "W123"),
+        "nested built-in expr math functions must not draw W123: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn issue_968_unknown_expr_function_still_w123_end_to_end() {
+    // Control: the fix must not swallow a genuinely unknown function name.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "set x [expr {frobnicate(1)}]\n");
+    assert!(
+        has_code(&diags, "W123"),
+        "an unknown expr function must still draw W123: {:?}",
+        codes(&diags)
+    );
+    assert!(
+        diags.iter().any(|d| message(d).contains("frobnicate")),
+        "message names the unknown function: {diags:?}",
+    );
+}
+
+#[test]
+fn issue_968_version_gated_math_function_dual_fires_end_to_end() {
+    // `min`/`max` are TIP 232 (Tcl 8.5+) — under an 8.4 document the name
+    // is a real function elsewhere but disabled here, so both the
+    // dialect-availability diagnostic (W002) and the unresolved-command
+    // diagnostic (W123) fire, matching the established dual-fire precedent
+    // for a dialect-disabled registry builtin (e.g. `lmap` under an 8.5
+    // host, exercised by `iapps_86_core_still_draws_w123_end_to_end` above).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl84");
+    let diags = lsp.open_ready_lang(&uri, "set x [expr {min(1, 2)}]\n", "tcl8.4");
+    assert!(
+        has_code(&diags, "W002") && has_code(&diags, "W123"),
+        "min() under tcl8.4 must draw both W002 and W123: {:?}",
+        codes(&diags)
+    );
+
+    let uri2 = unique_uri("tcl86");
+    let diags2 = lsp.open_ready_lang(&uri2, "set x [expr {min(1, 2)}]\n", "tcl8.6");
+    assert!(
+        !has_code(&diags2, "W002") && !has_code(&diags2, "W123"),
+        "min() under tcl8.6 must be clean: {:?}",
+        codes(&diags2)
+    );
+}
+
+#[test]
+fn issue_968_expr_function_after_rename_away_still_w123_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "rename ::tcl::mathfunc::sin {}\nset x [expr {sin(1.0)}]\n",
+    );
+    assert!(
+        has_code(&diags, "W123"),
+        "a call through a renamed-away mathfunc must be unresolved: {:?}",
+        codes(&diags)
+    );
+}
+
+#[test]
+fn issue_968_user_defined_mathfunc_override_still_resolves_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc ::tcl::mathfunc::myfunc {x} { return $x }\nset r [expr {myfunc(1)}]\n",
+    );
+    assert!(
+        !has_code(&diags, "W123"),
+        "a user-defined mathfunc override must resolve end-to-end: {:?}",
+        codes(&diags)
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/references.rs
+++ b/rust/tcl-lsp-server/tests/e2e/references.rs
@@ -297,3 +297,42 @@ fn references_namespace_variable_unify_across_procs() {
     assert!(lines.contains(&2), "bump alias+use (line 2): {lines:?}");
     assert!(lines.contains(&3), "get alias+use (line 3): {lines:?}");
 }
+
+/// End-to-end (real server): an unrelated ordinary `proc pf` sharing an
+/// `expr` math-function's bare tail name must not leak into either symbol's
+/// references — the two live in entirely separate command tables in real
+/// Tcl. Pins the same fix `definition.rs`'s
+/// `no_definition_for_mathfunc_call_despite_unrelated_same_named_proc`
+/// covers, at the find-references layer.
+#[test]
+fn references_do_not_cross_between_unrelated_proc_and_mathfunc_override() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc pf {y} { return bogus }\n\
+               namespace eval ::nsa::tcl::mathfunc {}\n\
+               proc ::nsa::tcl::mathfunc::pf {x} { return 20 }\n\
+               namespace eval ::nsa {\n    proc caller {} { return [expr {pf(1)}] }\n}\n";
+    lsp.open_ready(&uri, src);
+
+    // References on the mathfunc override's declaration (line 2) must reach
+    // the expr call site (line 4), never the unrelated proc (line 0).
+    let override_col = src.lines().nth(2).unwrap().rfind("pf").unwrap() as u32;
+    let override_lines = start_lines(&lsp.references(&uri, 2, override_col, true));
+    assert!(
+        override_lines.contains(&4),
+        "override references must reach the expr call site: {override_lines:?}"
+    );
+    assert!(
+        !override_lines.contains(&0),
+        "override references must not include the unrelated proc: {override_lines:?}"
+    );
+
+    // References on the unrelated proc's declaration (line 0) must not
+    // include the expr call site, which never dispatches to it.
+    let unrelated_col = src.lines().next().unwrap().find("pf").unwrap() as u32;
+    let unrelated_lines = start_lines(&lsp.references(&uri, 0, unrelated_col, true));
+    assert!(
+        !unrelated_lines.contains(&4),
+        "unrelated proc's references must not include the expr call site: {unrelated_lines:?}"
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/rename.rs
+++ b/rust/tcl-lsp-server/tests/e2e/rename.rs
@@ -396,3 +396,51 @@ fn rename_from_callsite_does_not_touch_same_named_proc_in_other_namespace() {
         "must NOT rename ::b::helper (line 5): {for_uri:?}"
     );
 }
+
+/// End-to-end: renaming an `expr` math-function override renames both its
+/// declaration and the call site's bare tail token (`pf(1)` ->
+/// `pfRenamed(1)`), and never touches an unrelated same-named ordinary proc.
+#[test]
+fn rename_mathfunc_override_updates_call_site_and_skips_unrelated_proc() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    // line 0: unrelated proc pf; line 2: the override decl; line 4: the expr call
+    let src = "proc pf {y} { return bogus }\n\
+               namespace eval ::nsa::tcl::mathfunc {}\n\
+               proc ::nsa::tcl::mathfunc::pf {x} { return 20 }\n\
+               namespace eval ::nsa {\n    proc caller {} { return [expr {pf(1)}] }\n}\n";
+    lsp.open_ready(&uri, src);
+    let col = src.lines().nth(2).unwrap().rfind("pf").unwrap() as u32;
+    let result = lsp.rename(&uri, 2, col, "pfRenamed");
+    let edits = rename_edits(&result);
+    let for_uri = edits.get(&uri).cloned().unwrap_or_default();
+    let lines: Vec<u64> = for_uri
+        .iter()
+        .filter_map(|e| e["range"]["start"]["line"].as_u64())
+        .collect();
+    assert!(
+        lines.contains(&2),
+        "the override decl (line 2) must rename: {for_uri:?}"
+    );
+    assert!(
+        lines.contains(&4),
+        "the expr call site (line 4) must rename: {for_uri:?}"
+    );
+    assert!(
+        !lines.contains(&0),
+        "must NOT rename the unrelated proc pf (line 0): {for_uri:?}"
+    );
+    // The declaration's own name token is written in source as the full
+    // qualified name (`proc ::nsa::tcl::mathfunc::pf {...}`), so its edit
+    // rewrites the whole qualified string; the `expr` call site only ever
+    // has the bare tail written (`pf(1)`), so its edit rewrites just that.
+    let new_texts: std::collections::BTreeSet<&str> = for_uri
+        .iter()
+        .filter_map(|e| e["newText"].as_str())
+        .collect();
+    assert_eq!(
+        new_texts,
+        std::collections::BTreeSet::from(["::nsa::tcl::mathfunc::pfRenamed", "pfRenamed"]),
+        "decl rewrites the qualified name, the call site rewrites only the tail: {for_uri:?}"
+    );
+}


### PR DESCRIPTION
## Summary

- Fixes #968: `expr` math-function calls (`sin(...)`, `max(...)`, ...) drew a spurious W123 "unknown command" hint for every built-in function — the analyser only ever recognised the qualified name `::tcl::mathfunc::<name>` via a user-defined `proc` override, never the built-in function table itself.
- Fixes the namespace-relative resolution of those same calls: a TIP 232 namespace-local override (`::ns::tcl::mathfunc::f` shadowing the global builtin inside `::ns`) previously never resolved, and — more importantly — an unrelated ordinary proc/class/alias/rename target sharing a math function's bare tail name (e.g. `proc sin {x} {...}`) could silently hijack the call's `resolved_qualified_name`, corrupting go-to-definition, find-references, rename, call-hierarchy, minify, and completion for that call site. `namespace path` is now also honoured for math-function resolution, matching how the VM's own `resolve_command_fqn` already treats math functions as ordinary commands under TIP 232.
- `SignatureCommandInvocation` gains an explicit `is_mathfunc_call` flag, set once at record time by a dedicated `push_mathfunc_command_reference`, so `finalise_invocation_resolutions` settles these invocations from a real recorded fact instead of guessing from the resolved string's shape — the same class of mistake this whole fix addresses.
- Every other `push_command_reference` call site in the analyser (TclOO in `oo.rs`, both ensemble paths in `handlers.rs`, the existence-probe path in `commands.rs`) was audited to confirm math functions are genuinely the only "fixed dispatch prefix, not the calling namespace" case among them.
- A review pass flagged that the W123 shortcut also applied to an *ordinary* call shaped like a mathfunc dispatch (e.g. a bareword call from inside the real `::tcl::mathfunc` namespace), incorrectly resolving it under an 8.4-based dialect where TIP 232's command wrappers don't exist yet. Fixed by threading `is_mathfunc_call` into that check and adding a `mathfunc_command_wrappers_available_in_dialect` fact, plus the missing README.md row update.
- Opens #973 (a confirmed pre-existing, non-mathfunc-specific gap found while auditing this code: `known()` never gates proc/class/alias/rename existence on deletion, only registry builtins) and #974 (test-coverage follow-up for the hover/completion/call-hierarchy/minify/graph consumers of the same fields) as tracked, separate follow-ups rather than folding them into this change.

Full writeup, including the two prior (superseded) attempts at this fix and why each fell short: `docs/design/tricky-name-resolution-surfaces.md` §1.6.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```sh
cargo test -p tcl-compiler --lib                    # 4506 passed
cargo test -p tcl-lsp-server --test e2e             # 929 passed
cargo test -p tcl-lsp-core -p tcl-lsp-db            # 1017+ passed, 0 failed
cargo fmt --check -p tcl-compiler -p tcl-lsp-server
cargo clippy -p tcl-compiler -p tcl-lsp-server --all-targets
make rust-check
make check-all
```

All zero failures / clean on the pushed tree.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract?
  - An analyser resolution contract (`SignatureCommandInvocation::resolved_qualified_name`/`resolution_candidates` for `expr` math-function calls), not a codegen/bytecode/VM fact — codegen and the VM were audited and confirmed already correct and unaffected (§1.6 of the design doc above).
- [x] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`.
  - `docs/kcs/compiler/` doesn't exist in this tree; the relevant note lives at `docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md` (updated) per this repo's established per-diagnostic-code KCS convention, alongside the deep resolution-model writeup in `docs/design/tricky-name-resolution-surfaces.md` §1.6.
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`.
  - N/A — no new compiler KCS note added; the design doc and the existing per-code KCS note were extended instead.