### PR TITLE
Fix apply lambda highlighting through [list ...] quoting

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,14 @@ Script-body arguments are highlighted as scripts, not opaque strings. The body
 of an `apply {argList body}` lambda literal has its commands, variables, and
 strings tokenised like any other body, and the argument list names — a braced
 `{a b}` list or a bare single name (`apply {dir { … }}`) — are painted as
-parameter declarations.
+parameter declarations. This reaches `apply` reached indirectly through
+`[list apply {argList body} $val]` too — the idiomatic way to build a
+deferred command around a dynamic value, most commonly a pkgIndex.tcl entry:
+`package ifneeded myPackage 1.0 [list apply {dir { source [file join $dir
+init.tcl] }} $dir]` highlights `source`/`file`/`join` inside the lambda body
+correctly, not as one opaque string. `package ifneeded`'s deferred script
+argument is recognised as a script body in its own right too, whether
+literal or list-quoted.
 
 ### Diagnostics
 

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -325,6 +325,18 @@ invocation falls outside bounds.  Each `SubCommand` has its own arity.
 | `OPTION_TERMINATOR` | The `--` terminator |
 | `CHANNEL` | Channel identifier |
 | `INDEX` | List/string index expression |
+| `COMMAND_PREFIX` | A callback command reference (`lsort -command cb`) whose first word is invoked at runtime with further arguments appended; recognises a literal bareword, a braced `{cmd extra}` multi-word prefix, and a `[list cmd extra]`-quoted prefix (gated on the `BUILDS_COMMAND_PREFIX` trait, below) -- distinct from `BODY` since the word is a reference, not code |
+| `LAMBDA_LITERAL` | A `{argList body ?namespace?}` anonymous-lambda literal (`apply`'s argument shape) -- a *list*, not a script directly; element 0 is a parameter list, element 1 is the body to recurse into |
+
+`Traits.BUILDS_COMMAND_PREFIX` (set on `list` only, not `concat`) marks a
+command whose result, when its own first argument is a literal command name,
+is a valid command reference the remaining arguments append to -- the
+`[list cmd extra]` idiom for building a callback or deferred command around a
+dynamic value (`-command [list doSomething $x]`,
+`package ifneeded name ver [list apply {argList body} $dir]`). Consulted
+generically wherever a `COMMAND_PREFIX`/`BODY`/`LAMBDA_LITERAL` argument
+position needs to see through the quoting -- never by comparing a command
+head to the literal string `"list"`.
 
 ### Resolution priority
 

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -49,6 +49,11 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-issue-subcommand-script-body-not-highlighted.md](kcs-issue-subcommand-script-body-not-highlighted.md)
   — a subcommand's script argument (`console eval { ... }`) stays one opaque
   string instead of recursing into keyword/variable/comment highlighting.
+- [kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md](kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md)
+  — commands inside an `apply {argList body}` lambda stay one opaque string
+  when `apply` is reached indirectly through `[list apply {...} $x]`
+  (the pkgIndex.tcl `package ifneeded ... [list apply {dir {...}} $dir]`
+  idiom), even though a direct `apply {...}` call highlights fine.
 - [kcs-issue-duplicate-diagnostics.md](kcs-issue-duplicate-diagnostics.md)
   — the same finding is reported twice.
 - [kcs-issue-counter-numtests-array-init.md](kcs-issue-counter-numtests-array-init.md)

--- a/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
+++ b/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
@@ -155,6 +155,71 @@ needed).
 - `rust/tcl-irules/src/walker.rs` — the iRules object-reference walker's
   branch (feeds `bigip-cleanup` liveness)
 
+## Follow-up: codex review of the initial fix
+
+The first pass at this fix (the sections above) shipped four gaps a codex
+review of the PR caught — each a case where a *consumer* of the shared
+`LambdaLiteral` split treated the lambda's fresh call frame as if it were
+the same frame as its surroundings:
+
+1. **List-quoted detection wasn't actually gated on the enclosing role**
+   (decision rule 3 above describes the *intended* bound, but the shipped
+   `insert_lambda_literal_overrides` recognised `[list apply {…} $x]`
+   whenever `list`'s own first argument resolved to a `LambdaLiteral`-bearing
+   spec, with no check on what argument slot the whole `[list …]`
+   substitution itself occupied). `set data [list apply {x {puts $x}}
+   value]` — `list` here only ever returns a value; nothing invokes
+   `apply` — painted `x` as a `Parameter`, `puts` as a `Function`, and
+   `apply` as a call-site reference, exactly the "over-broad" failure mode
+   already called out below. Fixed by threading a `deferred_role` flag from
+   [`collect_script`] through to [`insert_lambda_literal_overrides`]:
+   `true` only when the `[…]` substitution being recursed into is itself the
+   whole value of an argument slot the registry marks `Body` /
+   `LambdaLiteral` / `CommandPrefix` (computed per-command by
+   `deferred_role_arg_starts`, never inherited across recursion levels — a
+   bare `list apply {…} $x` statement inside a real, executing body is
+   exactly as inert as one at the top level).
+2. **Call-graph resolution used the wrong namespace.** `interprocedural.rs`'s
+   `scan_source_for_calls` recursed into a lambda body with `ctx` unchanged,
+   so a bare call inside `apply {{} {helper}}` resolved relative to the
+   *enclosing* proc's namespace instead of the lambda's own (the global
+   namespace by default, or its optional third element) — Tcl always
+   evaluates a two/three-element `apply` lambda in `::` or the given
+   namespace, never the caller's. Fixed by building a synthetic caller qname
+   from `elems.namespace` (or `"::"` when absent) for that one recursive call.
+3. **Minify/format reprocessed a lambda element's raw, undecoded spelling.**
+   `apply {{} puts\ hi}`'s real body (after Tcl's list-element decode) is
+   `puts hi` — two words — but `minify.rs`/`formatting/engine.rs` fed the
+   *raw* source span (`puts\ hi`, backslash intact) straight to the
+   script minifier/formatter, which re-parses a bare `\ ` as an
+   escaped-space-within-one-word, silently changing what would execute.
+   Fixed with `split_lambda_literal_decoded` (a `lambda_literal.rs` sibling
+   of `split_lambda_literal` that also collapses a non-literal element's
+   backslashes, mirroring `tcl_syntax::list::split_list`), and re-quoting a
+   reconstructed lambda literal's elements with
+   `tcl_syntax::list::list_element` rather than an unconditional bare `{}`
+   wrap — which also fixes a related bug where a multi-word parameter list
+   (`apply {{x y} …}`) lost the braces grouping it into one list element on
+   reassembly.
+4. **`param_traits.rs` and `declaration.rs` treated the lambda's fresh frame
+   as the enclosing frame.** `scan_deep` recursed into a lambda body with the
+   *enclosing* proc's own `param_set`/`traits`, so `proc f {body} { apply {x
+   {eval $body}} 1 }` wrongly marked `f`'s unrelated `body` param as
+   evaluated (name collision only, the lambda's own param is `x`), while the
+   real forwarding case (`apply {x {eval $x}} $body`) was missed. Fixed by
+   inferring the lambda's own traits in isolation
+   (`infer_param_traits_deep_with_config` against just the lambda's own
+   param list and body) and propagating a lambda param's trait back to an
+   enclosing param only when the actual argument at that position is a bare
+   reference to it. Symmetrically, `declaration.rs`'s
+   `collect_declarations_in_region` recursed into a lambda's body
+   unconditionally whenever it fell inside the *current scan region*, so a
+   `global x` declared inside a lambda was "visible" (by pure lexical/`Span`
+   containment) to a cursor on an unrelated `$x` elsewhere in the enclosing
+   proc. The analyser's scope tree has no `apply`-body scope kind for
+   `scan.visible` to reflect this with, so the fix checks the cursor's raw
+   byte offset against the lambda's own body span directly before recursing.
+
 ## Failure modes
 
 - Tagging a lambda-literal-shaped argument `ArgRole::Body` instead of
@@ -198,10 +263,15 @@ needed).
 
 - `rust/tcl-lsp-core/src/semantic_tokens.rs` —
   `list_quoted_apply_lambda_body_recurses`,
-  `list_quoted_apply_lambda_false_positive_guards`,
+  `list_quoted_apply_lambda_false_positive_guards` (includes the
+  enclosing-role gate: `set data [list apply {…} value]` must not paint the
+  lambda as executable),
   `package_ifneeded_literal_script_recurses_as_body`
 - `rust/tcl-compiler/src/lambda_literal.rs` — `split_lambda_literal`'s own
-  unit tests (params/body/namespace splitting, dynamic-lambda guard)
+  unit tests (params/body/namespace splitting, dynamic-lambda guard) and
+  `split_lambda_literal_decoded`'s (`decodes_bare_body_backslash_escape`,
+  `braced_elements_are_not_decoded`, `decodes_bare_namespace_backslash_escape`,
+  `decoded_dynamic_lambda_is_not_split`)
 - `rust/tcl-lsp-core/tests/command_prefix_integration.rs` —
   `list_quoted_prefix_records_head_span_and_baked_count`,
   `list_quoted_prefix_dynamic_head_is_not_recorded`,
@@ -210,14 +280,21 @@ needed).
   `apply_lambda_body_folds_and_recurses_into_nested_blocks`
 - `rust/tcl-lsp-core/src/formatting/engine.rs` —
   `apply_lambda_body_indents_and_params_normalise`,
-  `apply_lambda_namespace_element_preserved`
-- `rust/tcl-lsp-core/src/minify.rs` — `apply_lambda_body_minifies`
+  `apply_lambda_namespace_element_preserved`,
+  `apply_lambda_body_with_backslash_escape_decodes`
+- `rust/tcl-lsp-core/src/minify.rs` — `apply_lambda_body_minifies`,
+  `apply_lambda_body_with_backslash_escape_decodes`,
+  `apply_lambda_multi_word_param_list_keeps_its_braces`
 - `rust/tcl-lsp-core/src/declaration.rs` —
-  `global_declared_inside_apply_lambda_body_is_found`
+  `global_declared_inside_apply_lambda_body_is_found`,
+  `global_declared_inside_apply_lambda_body_is_not_visible_outside_it`
 - `rust/tcl-compiler/src/interprocedural.rs` —
-  `call_inside_apply_lambda_body_is_a_direct_call`
+  `call_inside_apply_lambda_body_is_a_direct_call`,
+  `call_inside_apply_lambda_body_resolves_in_lambda_namespace`,
+  `call_inside_apply_lambda_body_resolves_in_explicit_namespace`
 - `rust/tcl-compiler/src/analyser/param_traits.rs` —
-  `eval_param_inside_apply_lambda_body_records_eval_trait`
+  `eval_inside_apply_lambda_body_does_not_leak_to_unrelated_enclosing_param`,
+  `eval_param_forwarded_into_apply_lambda_records_eval_trait`
 - `rust/tcl-irules/tests/script_bearing_args.rs` —
   `a_pool_used_only_inside_an_apply_lambda_body_is_referenced`,
   `the_walker_descends_into_every_script_bearing_role`

--- a/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
+++ b/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
@@ -270,7 +270,34 @@ no instances of its own:
    as genuinely isolated (fresh scope rooted at the lambda's own namespace,
    params bound only from the lambda's own element 0, no enclosing-proc state
    threaded in) — this line of the codebase predates the recent fixes and
-   was already correct.
+   was already correct. Unlike the highlighting/analysis-text consumers
+   above (which recurse by re-segmenting a body-text slice and so had to be
+   *taught* isolation one file at a time), this layer gets it for free
+   structurally: `lower_apply` builds each lambda body as its own
+   `FunctionUnit` with its own `CfgFunction`/SSA graph — a bare `$var` inside
+   the lambda has no shared symbol table to wrongly resolve against, and
+   `taint_interproc.rs` seeds its proc-name set from
+   `cu.ir_module.procedures.keys()` only, so a body unit's taint always falls
+   back to its own bare facts rather than an inherited merge. `var_escape` /
+   `memory_ssa` / `shimmer` don't visit body units at all (they iterate
+   `analysable_functions()`, procedures only) — a coverage gap, not a leak,
+   since every `apply` call site is already a `Statement::Barrier` those
+   passes treat as clobber-everything regardless.
+
+   One latent, currently-unreachable landmine for the same bug class: like
+   `var_escape`/`memory_ssa`/`shimmer`, `class_lattice.rs`'s
+   `collect_assign_kinds` / `build_class_values` iterate `top_level +
+   procedures + methods`, excluding body units — so its `NsContext::enclosing`
+   (a pure lexical-span lookup against `namespace eval` ranges, with no
+   `apply`-frame awareness at all) never runs on an apply-lambda body's
+   statements today. If a future change ever widens that iteration to cover
+   body units (mirroring how taint's `analysable_body_function_units()` was
+   added), a bare class name inside an `apply {…}` lexically nested in a
+   `namespace eval NS {…}` block would resolve via the lexically-enclosing
+   `NS` instead of Tcl's actual default (`::`, or the lambda's own third
+   element) — the exact bug class fixed above, just for class-value
+   inference. Not a fix here since there's nothing live to fix; a flag for
+   whoever touches that iterator next.
 
 ## Failure modes
 

--- a/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
+++ b/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
@@ -1,0 +1,235 @@
+# KCS: `apply`'s lambda body is not highlighted when reached through `[list ...]`
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+all-editors
+
+## Symptom
+
+Commands inside an `apply {argList body}` lambda render as one opaque,
+unhighlighted string when `apply` is not the literal head of the call — most
+commonly a pkgIndex.tcl-style entry:
+
+```tcl
+package ifneeded myPackage 1.0.0 [list apply {dir {
+    source [file join $dir src font.tcl]
+    source [file join $dir src utils.tcl]
+}} $dir]
+```
+
+`package`, `ifneeded`, and `list` highlight normally; `source`, `file`,
+`join`, and the `dir` parameter inside the lambda do not — the whole
+`{dir {...}}` blob paints as a plain string. A *direct* `apply {dir {...}}
+$val` call (no `[list ...]` wrapper) highlights correctly.
+
+Reported as issue #954. A first fix (merged as `cb10e7c90`, shipped in
+v2.1.11) corrected a narrower, related bug — a bare (unbraced) single-name
+argument list (`apply {dir {...}}`, where `dir` has no braces of its own)
+painting as a string instead of a `Parameter` — but the issue was reopened:
+the reporter's actual repro was the `[list apply {...} $dir]` shape above,
+which the first fix never touched.
+
+## Operational context
+
+`apply`'s first argument is a 2- or 3-element Tcl list — `{argList body
+?namespace?}` — not a script directly. Highlighting it correctly requires
+two separate things to work:
+
+1. Recognising that the argument *is* this lambda-literal shape (as opposed
+   to a plain `ArgRole::Body` script), so the highlighter splits it — element
+   0 is a parameter list, element 1 is the body to recurse into as a script —
+   rather than re-segmenting the whole `{argList} {body}` blob as one script.
+   The pre-fix code did exactly that: it re-parsed `"dir {puts $dir}"` as a
+   *script*, reading `dir` as a command name and `{puts $dir}` as `dir`'s one
+   argument. Since `dir` never resolves to a registered command, recursion
+   stopped there and the real body was never reached.
+2. Recognising `apply` as the callee *at all* when it is not the literal head
+   of the current statement. `[list apply {…} $dir]` is the idiomatic way to
+   build a deferred command around a dynamic value — `list` quotes each
+   argument so the result, evaluated later, invokes `apply` with exactly
+   those words — precisely because a literal `apply {…} $dir` can't be
+   written when `$dir`'s value must be captured at index-time rather than
+   substituted textually. The same idiom shows up for any deferred callback
+   (`button .b -command [list doSomething $x]`, `after idle [list apply
+   {…} $x]`), not just pkgIndex.tcl.
+
+Both are registry-driven, with **no command name compared anywhere in the
+consumer**:
+
+- [`ArgRole::LambdaLiteral`](../../rust/tcl-registry/src/arg_role.rs) is a
+  role distinct from `ArgRole::Body` for exactly this shape. `apply`'s spec
+  declares `arg_roles: &[(0, ArgRole::LambdaLiteral)]`
+  ([`rust/tcl-registry/src/commands/tcl/apply.rs`](../../rust/tcl-registry/src/commands/tcl/apply.rs)).
+  A generic `ArgRole::Body` walker (the semantic-token highlighter's default
+  body recursion, folding, formatting, minification, declaration-scanning,
+  the interprocedural call-graph scanner, the iRules object-reference
+  walker) never touches a `LambdaLiteral`-tagged argument, so none of them
+  mis-parses the parameter word as a command; each was given its own small
+  `LambdaLiteral`-aware branch that splits the list first (via the shared
+  [`tcl_compiler::lambda_literal::split_lambda_literal`](../../rust/tcl-compiler/src/lambda_literal.rs))
+  and recurses only into the real body element.
+- `Traits::BUILDS_COMMAND_PREFIX` is set on `list`'s own spec
+  ([`rust/tcl-registry/src/commands/tcl/list_.rs`](../../rust/tcl-registry/src/commands/tcl/list_.rs)):
+  "when this command's first argument is a literal command name, the result
+  invokes that command with the remaining arguments appended verbatim." It is
+  **not** set on `concat` — `concat`'s plain string-join doesn't give the same
+  per-word quoting guarantee for a dynamic value, so recognising it the same
+  way would be unsound. `insert_lambda_literal_overrides`
+  ([`rust/tcl-lsp-core/src/semantic_tokens.rs`](../../rust/tcl-lsp-core/src/semantic_tokens.rs))
+  checks this trait to decide whether a segmented command's own head (`list`)
+  is quoting a further command, then resolves *that* command's own literal
+  first argument against `ArgRole::LambdaLiteral` the same way the direct
+  case does — recursively, so it generalises to any future command sharing
+  the lambda-literal shape, not just `apply`.
+- The same trait feeds
+  [`extract_list_quoted_prefix_head`](../../rust/tcl-compiler/src/signature_scan/command_prefix.rs),
+  a third shape alongside the existing bareword and braced-multi-word
+  `ArgRole::CommandPrefix` recognisers — so `-command [list doSomething $x]`
+  callbacks feed find-references / call-hierarchy / arity-checking / W123
+  exactly like a literal `-command doSomething` would.
+
+`package ifneeded`'s own `script` argument carried **no role at all** before
+this fix — a *literal* `package ifneeded name ver {script}` (no `[list ...]`
+wrapper) was equally unhighlighted. It is now `arg_roles: &[(2,
+ArgRole::Body)]` with `body_kind: BodyKind::Structural` (the script runs
+later, in the global namespace via `uplevel #0`, never the definer's frame —
+mirrors `timer in`/`timer idle`'s precedent, no dedicated lowering hook
+needed).
+
+## Decision rules / contracts
+
+1. A command whose argument is a `{paramList body ?ns?}` list (not a plain
+   script) declares `ArgRole::LambdaLiteral`, never `ArgRole::Body` — tagging
+   it `Body` makes generic Body-role walkers (SSA's caller-scope scan
+   included) try to read the list as a script and misattribute or corrupt
+   whatever they find.
+2. The `[list head arg1 arg2 …]` command-quoting idiom is recognised via a
+   registry trait (`Traits::BUILDS_COMMAND_PREFIX`) on `list` itself, checked
+   generically wherever a Body/LambdaLiteral/CommandPrefix argument position
+   needs to see through it — never by comparing a segmented command's head
+   text to the literal string `"list"`.
+3. Recognising the quoting idiom is bounded to positions the registry already
+   marks as carrying a script/callback (`ArgRole::Body`,
+   `ArgRole::LambdaLiteral`, `ArgRole::CommandPrefix`) — not universally for
+   every bare `[list ...]` anywhere in the source. This matches the existing
+   precision posture of the braced-multi-word `CommandPrefix` shape (also a
+   heuristic, also scoped to declared role positions) and avoids false
+   positives on `[list ...]` used purely to build ordinary data.
+4. A shape recogniser that is safe to be more permissive as a *highlighting*
+   heuristic (worst case: a cosmetic misclassification) is not automatically
+   safe to reuse unchanged as an *analyser/diagnostic* fact (worst case: a
+   spurious diagnostic on data that was never actually invoked as a command).
+   The semantic-token layer, folding, formatting, minification, and
+   declaration-scanning all recurse into a `LambdaLiteral` body
+   unconditionally; the deeper SSA/CFG-based analyser (`register_body_unit`,
+   `LoweringHookId::Apply`) stays scoped to the *direct* literal-call shape
+   only — it does not follow the `[list ...]` indirection, by design.
+5. This class of bug lives entirely in registry data plus one generic,
+   reusable split primitive
+   ([`split_lambda_literal`](../../rust/tcl-compiler/src/lambda_literal.rs)).
+   Do not special-case `"apply"` (or any other command name) in a walker to
+   work around a missing registry role.
+
+## File-path anchors
+
+- `rust/tcl-registry/src/arg_role.rs` — `ArgRole::LambdaLiteral`
+- `rust/tcl-registry/src/commands/tcl/apply.rs` — `apply`'s spec
+- `rust/tcl-registry/src/commands/tcl/list_.rs` — `Traits::BUILDS_COMMAND_PREFIX`
+- `rust/tcl-registry/src/commands/tcl/package_.rs` — `ifneeded`'s `Body` +
+  `BodyKind::Structural`
+- `rust/tcl-registry/src/traits.rs` — the trait bit and its doc
+- `rust/tcl-compiler/src/lambda_literal.rs` — `split_lambda_literal`, the
+  shared list-element splitter
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` —
+  `insert_lambda_literal_overrides`, `collect_lambda_literal`
+- `rust/tcl-lsp-core/src/folding.rs`, `formatting/engine.rs`, `minify.rs`,
+  `declaration.rs` — each command's own `LambdaLiteral`-aware branch
+- `rust/tcl-compiler/src/signature_scan/command_prefix.rs` —
+  `extract_list_quoted_prefix_head`
+- `rust/tcl-compiler/src/interprocedural.rs`,
+  `rust/tcl-compiler/src/analyser/param_traits.rs` — the same split applied
+  to the (best-effort, text-based) call-graph / param-trait scanners
+- `rust/tcl-irules/src/walker.rs` — the iRules object-reference walker's
+  branch (feeds `bigip-cleanup` liveness)
+
+## Failure modes
+
+- Tagging a lambda-literal-shaped argument `ArgRole::Body` instead of
+  `ArgRole::LambdaLiteral` makes every generic Body-role walker treat the
+  parameter word as if it might be a command name — usually harmless (the
+  parameter name rarely collides with a real command), but silently wrong,
+  and a genuine collision (a parameter literally named `global` inside a
+  declaration-scanning walker, say) produces a bogus result.
+- Recognising `[list cmd ...]` unconditionally (not gated on the registry
+  role of the *enclosing* argument position) would make `[list puts
+  $x]`-as-plain-data read as if it invoked `puts` — over-broad.
+- Extending `Traits::BUILDS_COMMAND_PREFIX` to `concat` (which also carries
+  `Traits::PRODUCES_CANONICAL_LIST`, a *different*, more permissive
+  const-folding trait) would be unsound: `concat`'s plain-join semantics
+  don't guarantee a dynamic trailing argument stays a distinct word the way
+  `list`'s per-element quoting does.
+- Assuming the analyser's deep SSA/CFG modelling of `apply` bodies
+  (`register_body_unit`) also follows `[list apply ...]` indirection
+  overclaims the fix — it deliberately does not, to keep the
+  correctness-sensitive analyser conservative (see decision rule 4).
+
+## Triage checklist
+
+1. Decode the semantic tokens for a minimal repro (`apply {p {body}} arg`
+   and the same wrapped in `[list apply {p {body}} arg]`) and confirm the
+   body's inner tokens (a builtin, a variable) appear as their own token
+   kinds in *both* forms, not just the direct one.
+2. Check whether the command carries `ArgRole::LambdaLiteral` (not `Body`) at
+   the right index — `registry.arg_indices_for_role(head, args,
+   ArgRole::LambdaLiteral)`.
+3. For the list-quoted form, confirm `list` carries
+   `Traits::BUILDS_COMMAND_PREFIX` and that the resolved inner head (`list`'s
+   own first argument) itself carries `ArgRole::LambdaLiteral`.
+4. If a *different* consumer (folding, formatting, minify, declaration,
+   call-graph, iRules object references) also queries `ArgRole::Body`
+   generically, confirm it has its own `LambdaLiteral`-aware branch — the
+   role change silently stops the generic walker from seeing the argument at
+   all otherwise.
+
+## Test anchors
+
+- `rust/tcl-lsp-core/src/semantic_tokens.rs` —
+  `list_quoted_apply_lambda_body_recurses`,
+  `list_quoted_apply_lambda_false_positive_guards`,
+  `package_ifneeded_literal_script_recurses_as_body`
+- `rust/tcl-compiler/src/lambda_literal.rs` — `split_lambda_literal`'s own
+  unit tests (params/body/namespace splitting, dynamic-lambda guard)
+- `rust/tcl-lsp-core/tests/command_prefix_integration.rs` —
+  `list_quoted_prefix_records_head_span_and_baked_count`,
+  `list_quoted_prefix_dynamic_head_is_not_recorded`,
+  `cmd_substitution_with_non_list_head_is_not_recorded_as_prefix`
+- `rust/tcl-lsp-core/src/folding.rs` —
+  `apply_lambda_body_folds_and_recurses_into_nested_blocks`
+- `rust/tcl-lsp-core/src/formatting/engine.rs` —
+  `apply_lambda_body_indents_and_params_normalise`,
+  `apply_lambda_namespace_element_preserved`
+- `rust/tcl-lsp-core/src/minify.rs` — `apply_lambda_body_minifies`
+- `rust/tcl-lsp-core/src/declaration.rs` —
+  `global_declared_inside_apply_lambda_body_is_found`
+- `rust/tcl-compiler/src/interprocedural.rs` —
+  `call_inside_apply_lambda_body_is_a_direct_call`
+- `rust/tcl-compiler/src/analyser/param_traits.rs` —
+  `eval_param_inside_apply_lambda_body_records_eval_trait`
+- `rust/tcl-irules/tests/script_bearing_args.rs` —
+  `a_pool_used_only_inside_an_apply_lambda_body_is_referenced`,
+  `the_walker_descends_into_every_script_bearing_role`
+- `rust/tcl-lsp-server/tests/e2e/issue954_followup.rs` — full end-to-end
+  coverage against the packaged native server
+- `editors/vscode/src/test/issue954Followup.test.ts` — VS Code semantic
+  tokens provider coverage
+
+## Related
+
+- [KCS index](README.md)
+- [subcommand script body not highlighted](kcs-issue-subcommand-script-body-not-highlighted.md)
+- [Command registry design doc](../design/compiler/command-registry.md)
+- [Semantic Tokens feature](features/kcs-feature-semantic-tokens.md)
+- [Glossary](../GLOSSARY.md)

--- a/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
+++ b/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
@@ -220,6 +220,26 @@ the same frame as its surroundings:
    `scan.visible` to reflect this with, so the fix checks the cursor's raw
    byte offset against the lambda's own body span directly before recursing.
 
+A subsequent self-review for the same bug class, prompted by the codex
+findings above, found a fifth instance the review itself hadn't flagged
+(likely out of its sampled scope, not a different root cause):
+
+5. **The iRules object-reference walker inherited the caller's `set`-bound
+   constants into the lambda frame.** `tcl-irules/src/walker.rs` tracks
+   `set var literal` bindings in a `BindingScope`, propagated into nested
+   bodies via `scope.child()` (a full clone) — correct for `if`/`foreach`/
+   `switch`, which share the enclosing frame, but the `apply` lambda
+   recursion used the identical `scope.child()`, so `set poolName /Common/x;
+   apply {{} { pool $poolName }}` resolved `$poolName` inside a *zero-param*
+   lambda from the enclosing binding, even though that variable is genuinely
+   undefined inside the lambda's fresh frame at runtime. A false positive
+   here means `bigip-cleanup` treats an actually-dead pool as still
+   referenced. Fixed with `lambda_frame_scope`: an empty `BindingScope`, with
+   only the lambda's own params bound from their actual arguments (resolved
+   against the *enclosing* scope via the same `resolve_arg_value` ordinary
+   references use) — mirrors the `param_traits.rs` fix in (4) exactly, one
+   layer down (constant propagation instead of trait inference).
+
 ## Failure modes
 
 - Tagging a lambda-literal-shaped argument `ArgRole::Body` instead of
@@ -297,7 +317,9 @@ the same frame as its surroundings:
   `eval_param_forwarded_into_apply_lambda_records_eval_trait`
 - `rust/tcl-irules/tests/script_bearing_args.rs` —
   `a_pool_used_only_inside_an_apply_lambda_body_is_referenced`,
-  `the_walker_descends_into_every_script_bearing_role`
+  `the_walker_descends_into_every_script_bearing_role`,
+  `apply_lambda_does_not_inherit_enclosing_set_bindings`,
+  `apply_lambda_param_resolves_via_forwarded_actual_argument`
 - `rust/tcl-lsp-server/tests/e2e/issue954_followup.rs` — full end-to-end
   coverage against the packaged native server
 - `editors/vscode/src/test/issue954Followup.test.ts` — VS Code semantic

--- a/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
+++ b/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
@@ -240,6 +240,38 @@ findings above, found a fifth instance the review itself hadn't flagged
    references use) — mirrors the `param_traits.rs` fix in (4) exactly, one
    layer down (constant propagation instead of trait inference).
 
+A deeper follow-up search for the same bug class (this time deliberately
+broad rather than reactive to a specific review) found a sixth instance,
+this time in a dimension none of the above touch — TclOO self-dispatch —
+and, separately, positively confirmed the deep SSA/CFG/taint analyser has
+no instances of its own:
+
+6. **`my`/`$self`/`$this` dispatch resolved *through* an apply lambda's fresh
+   frame.** `semantic_tokens.rs`'s `collect_lambda_literal` recursed into the
+   body with the *enclosing* `ScriptCtx` unchanged, so `enclosing_class`
+   (which correctly persists into an `if`/`foreach` body — those share the
+   calling method's frame) also persisted into an `apply` lambda's body,
+   which does not: `oo::class create C { method helper {} {} method run {} {
+   apply {{} {my helper}} } }` painted `my helper` inside the lambda as a
+   resolved call to `C`'s `helper` method, even though a bare (namespace-less)
+   `apply` lambda runs in `::`, where `my` isn't defined — that call would
+   actually raise "invalid command name my" at runtime. Fixed by clearing
+   `oo_grammar` / `enclosing_class` / `scoped_env` before recursing into the
+   lambda body, mirroring `folding.rs`'s pre-existing `None` reset for the
+   same recursion (which this search re-confirmed is correct and was the
+   template for the fix, not a new finding).
+7. **The deep SSA/CFG/taint analyser: searched, no instances found.** Despite
+   the doc's decision rule 4 above describing its `apply` handling as
+   deliberately narrow (direct-call-shape only), a targeted search of
+   `handlers.rs`'s `handle_apply_command`, `lowering/mod.rs`'s `lower_apply`,
+   `per_item.rs`'s deferred-body machinery, `diagnostics/validity.rs`'s arity
+   check, `bounds_checks.rs`'s scope-boundary scan, and `var_escape`'s
+   conservative bail-out set confirmed each already treats the lambda's frame
+   as genuinely isolated (fresh scope rooted at the lambda's own namespace,
+   params bound only from the lambda's own element 0, no enclosing-proc state
+   threaded in) — this line of the codebase predates the recent fixes and
+   was already correct.
+
 ## Failure modes
 
 - Tagging a lambda-literal-shaped argument `ArgRole::Body` instead of
@@ -286,7 +318,8 @@ findings above, found a fifth instance the review itself hadn't flagged
   `list_quoted_apply_lambda_false_positive_guards` (includes the
   enclosing-role gate: `set data [list apply {…} value]` must not paint the
   lambda as executable),
-  `package_ifneeded_literal_script_recurses_as_body`
+  `package_ifneeded_literal_script_recurses_as_body`,
+  `my_call_inside_apply_lambda_body_does_not_resolve`
 - `rust/tcl-compiler/src/lambda_literal.rs` — `split_lambda_literal`'s own
   unit tests (params/body/namespace splitting, dynamic-lambda guard) and
   `split_lambda_literal_decoded`'s (`decodes_bare_body_backslash_escape`,

--- a/editors/vscode/src/test/issue954Followup.test.ts
+++ b/editors/vscode/src/test/issue954Followup.test.ts
@@ -1,0 +1,194 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, setTestContent } from "./helper";
+
+// Issue #954 follow-up: the original fix (a bare-unbraced-parameter-list
+// highlighting bug in `apply {dir {...}}`) shipped in v2.1.11, but the
+// reporter's actual screenshot -- a pkgIndex.tcl-style
+// `package ifneeded name ver [list apply {dir {...}} $dir]` entry -- reaches
+// `apply` *indirectly* through the `[list ...]` command-quoting idiom, a
+// shape the first fix never touched. These tests drive the real repro (and
+// the closely related shapes the general, registry-driven fix now also
+// covers) through VS Code's semantic-tokens provider.
+
+interface DecodedToken {
+  line: number;
+  char: number;
+  length: number;
+  type: string;
+}
+
+function decodeTokens(
+  tokens: vscode.SemanticTokens,
+  legend: vscode.SemanticTokensLegend,
+): DecodedToken[] {
+  const out: DecodedToken[] = [];
+  let line = 0;
+  let char = 0;
+  for (let i = 0; i < tokens.data.length; i += 5) {
+    const [dLine, dChar, length, typeIdx] = tokens.data.slice(i, i + 5);
+    if (dLine) {
+      line += dLine;
+      char = dChar;
+    } else {
+      char += dChar;
+    }
+    out.push({ line, char, length, type: legend.tokenTypes[typeIdx] });
+  }
+  return out;
+}
+
+suite("Issue #954 follow-up: apply reached through [list ...]", () => {
+  const docUri = getDocUri("issue954Followup.tcl");
+
+  async function tokensFor(
+    editor: vscode.TextEditor,
+    content: string,
+  ): Promise<{ toks: DecodedToken[]; lines: string[] }> {
+    await setTestContent(editor, content);
+    const legend = (await vscode.commands.executeCommand(
+      "vscode.provideDocumentSemanticTokensLegend",
+      docUri,
+    )) as vscode.SemanticTokensLegend;
+    const tokens = (await vscode.commands.executeCommand(
+      "vscode.provideDocumentSemanticTokens",
+      docUri,
+    )) as vscode.SemanticTokens;
+    return { toks: decodeTokens(tokens, legend), lines: content.split("\n") };
+  }
+
+  function covered(lines: string[], t: DecodedToken): string {
+    return lines[t.line]?.slice(t.char, t.char + t.length) ?? "";
+  }
+
+  function hasTyped(toks: DecodedToken[], lines: string[], text: string, type: string): boolean {
+    return toks.some((t) => t.type === type && covered(lines, t) === text);
+  }
+
+  test("the reported pkgIndex.tcl repro: [list apply {dir {...}} $dir] body highlights", async () => {
+    const doc = await activate(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+    const original = doc.getText();
+    try {
+      const src =
+        "package ifneeded myPackage 1.0.0 [list apply {dir {\n" +
+        "\n" +
+        "    source [file join $dir src font.tcl]\n" +
+        "    source [file join $dir src utils.tcl]\n" +
+        "\n" +
+        "}} $dir]\n";
+      const { toks, lines } = await tokensFor(editor, src);
+      assert.ok(
+        hasTyped(toks, lines, "source", "keyword"),
+        `expected \`source\` to tokenise inside the list-quoted apply body; got ${JSON.stringify(
+          toks.map((t) => [t.line, t.char, covered(lines, t), t.type]),
+        )}`,
+      );
+      assert.ok(hasTyped(toks, lines, "file", "function"), "expected `file` to tokenise");
+      assert.ok(
+        hasTyped(toks, lines, "dir", "parameter"),
+        "expected the bare `dir` param to be a Parameter declaration",
+      );
+    } finally {
+      await setTestContent(editor, original);
+    }
+  });
+
+  test("a qualified ::apply inside [list ...] resolves the same way", async () => {
+    const doc = await activate(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+    const original = doc.getText();
+    try {
+      const src = "package ifneeded p 1.0 [list ::apply {dir {puts $dir}} $dir]\n";
+      const { toks, lines } = await tokensFor(editor, src);
+      assert.ok(
+        hasTyped(toks, lines, "puts", "function"),
+        `expected \`puts\` to tokenise inside the qualified ::apply body; got ${JSON.stringify(
+          toks.map((t) => [t.line, t.char, covered(lines, t), t.type]),
+        )}`,
+      );
+    } finally {
+      await setTestContent(editor, original);
+    }
+  });
+
+  test("the same idiom under a different Body-role command (after idle) also highlights", async () => {
+    const doc = await activate(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+    const original = doc.getText();
+    try {
+      const src = "after idle [list apply {{x} {puts $x}} 5]\n";
+      const { toks, lines } = await tokensFor(editor, src);
+      assert.ok(hasTyped(toks, lines, "puts", "function"));
+      assert.ok(hasTyped(toks, lines, "x", "parameter"));
+    } finally {
+      await setTestContent(editor, original);
+    }
+  });
+
+  test("package ifneeded's literal (non-list-quoted) script also highlights", async () => {
+    const doc = await activate(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+    const original = doc.getText();
+    try {
+      const src = "package ifneeded myPackage 1.0.0 {\n    source [file join $dir x.tcl]\n}\n";
+      const { toks, lines } = await tokensFor(editor, src);
+      assert.ok(
+        hasTyped(toks, lines, "source", "keyword"),
+        "expected `source` to tokenise inside package ifneeded's literal script body",
+      );
+    } finally {
+      await setTestContent(editor, original);
+    }
+  });
+
+  test("FP guard: a plain data list is never split as a lambda literal", async () => {
+    const doc = await activate(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+    const original = doc.getText();
+    try {
+      const src = "set data [list puts hello world]\n";
+      const { toks, lines } = await tokensFor(editor, src);
+      assert.ok(
+        !hasTyped(toks, lines, "hello", "parameter"),
+        `a plain data list must never be split as a lambda literal; got ${JSON.stringify(
+          toks.map((t) => [t.line, t.char, covered(lines, t), t.type]),
+        )}`,
+      );
+    } finally {
+      await setTestContent(editor, original);
+    }
+  });
+
+  test("regression: direct apply with a bare unbraced param list still highlights", async () => {
+    const doc = await activate(docUri);
+    const editor = await vscode.window.showTextDocument(doc);
+    const original = doc.getText();
+    try {
+      const src = "apply {dir {\n    puts $dir\n}} /tmp\n";
+      const { toks, lines } = await tokensFor(editor, src);
+      assert.ok(hasTyped(toks, lines, "dir", "parameter"));
+      assert.ok(hasTyped(toks, lines, "puts", "function"));
+    } finally {
+      await setTestContent(editor, original);
+    }
+  });
+});

--- a/editors/vscode/testFixture/issue954Followup.tcl
+++ b/editors/vscode/testFixture/issue954Followup.tcl
@@ -1,0 +1,7 @@
+# Issue #954 follow-up: placeholder fixture. `issue954Followup.test.ts`
+# replaces this content at runtime (via setTestContent) with each specific
+# repro/regression snippet -- checking in one file per tiny snippet would
+# bloat the repo for no benefit.
+proc placeholder {} {
+    return 1
+}

--- a/rust/tcl-cli/tests/fixtures/registry-dump.tcl8.6-subset.golden
+++ b/rust/tcl-cli/tests/fixtures/registry-dump.tcl8.6-subset.golden
@@ -43,6 +43,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -287,6 +288,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -376,6 +378,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -465,6 +468,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -554,6 +558,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -643,6 +648,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -732,6 +738,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": true,
@@ -822,6 +829,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -911,6 +919,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -1000,6 +1009,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": true,
@@ -1089,6 +1099,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -1543,6 +1554,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -1632,6 +1644,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": false,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -1721,6 +1734,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -1815,6 +1829,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": false,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -1904,6 +1919,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -1993,6 +2009,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -2082,6 +2099,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -2171,6 +2189,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -2296,6 +2315,7 @@
     ],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -2414,6 +2434,7 @@
     ],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -2503,6 +2524,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -2592,6 +2614,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -2681,6 +2704,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": false,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -2795,6 +2819,7 @@
     ],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -2888,6 +2913,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -2981,6 +3007,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -3079,6 +3106,7 @@
     ],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,
@@ -3168,6 +3196,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": true,
@@ -3258,6 +3287,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": true,
@@ -3349,6 +3379,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": true,
@@ -3438,6 +3469,7 @@
     "switches": [],
     "traits": {
       "allow_unknown_subcommands": false,
+      "builds_command_prefix": false,
       "byte_compiled": true,
       "configures_channel": false,
       "creates_dynamic_barrier": false,

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -428,6 +428,38 @@ fn scan_deep<'p>(
             }
             scan_deep(body_text, ctx, traits, aliases, depth + 1);
         }
+
+        // `apply {argList body ?ns?} …` — the lambda-literal argument is a
+        // 2-element list, not a script, so scanning the whole word as a
+        // `Body` (like the loop above) would misread the parameter word as
+        // a command and never reach the real body's own calls. Split it and
+        // recurse only into the body element (issue #954's param-trait
+        // sibling gap).
+        for idx in ctx
+            .registry
+            .arg_indices_for_role(cmd_name, &cmd_args, ArgRole::LambdaLiteral)
+        {
+            let Some(&tok) = seg.argv.get(idx + 1) else {
+                continue;
+            };
+            if tok.kind != tcl_lexer::TokenType::Str {
+                continue;
+            }
+            let Some(elems) = crate::lambda_literal::split_lambda_literal(source, tok) else {
+                continue;
+            };
+            let Some(body_span) = elems.body else {
+                continue;
+            };
+            let Some(body_text) = source.get(body_span.start() as usize..body_span.end() as usize)
+            else {
+                continue;
+            };
+            if body_text.trim().is_empty() {
+                continue;
+            }
+            scan_deep(body_text, ctx, traits, aliases, depth + 1);
+        }
     }
 }
 
@@ -1061,6 +1093,22 @@ mod tests {
     #[test]
     fn eval_param_records_eval_trait() {
         let traits = infer(&["body"], "eval $body");
+        assert_trait(&traits, "body", ProcArgTrait::Eval);
+    }
+
+    /// Issue #954's param-trait sibling gap: the *deep* pass
+    /// (`infer_param_traits_deep`, which alone recurses into braced body
+    /// arguments) must reach real commands *inside* an `apply` lambda body,
+    /// not misread the whole `{argList} {body}` blob as one script (which
+    /// would treat the parameter word as a command name and never find the
+    /// `eval` at all) — mirrors `overlay_deep_recurses_through_stub_body_args`,
+    /// swapping the registry-known `apply`/`LambdaLiteral` shape in for a
+    /// stub-declared `Body` shape.
+    #[test]
+    fn eval_param_inside_apply_lambda_body_records_eval_trait() {
+        let registry = CommandRegistry::build_default();
+        let traits =
+            infer_param_traits_deep(&["body"], "apply {x {eval $body}} 1", &registry, None);
         assert_trait(&traits, "body", ProcArgTrait::Eval);
     }
 

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -429,12 +429,20 @@ fn scan_deep<'p>(
             scan_deep(body_text, ctx, traits, aliases, depth + 1);
         }
 
-        // `apply {argList body ?ns?} …` — the lambda-literal argument is a
-        // 2-element list, not a script, so scanning the whole word as a
-        // `Body` (like the loop above) would misread the parameter word as
-        // a command and never reach the real body's own calls. Split it and
-        // recurse only into the body element (issue #954's param-trait
-        // sibling gap).
+        // `apply {argList body ?ns?} …` — an apply body runs in a *fresh*
+        // call frame with its own parameters; recursing into it with the
+        // enclosing proc's own `ctx`/`traits` (as a plain `Body` arg would)
+        // conflates the two frames. A lambda-local variable that happens to
+        // share a name with an enclosing param (`proc f {body} { apply {x
+        // {eval $body}} 1 }`) would wrongly mark `f`'s `body` param as
+        // evaluated, while the real forwarding case (`apply {x {eval $x}}
+        // $body`) would be missed entirely (codex review of #954's
+        // follow-up). Instead: infer the lambda's own traits in complete
+        // isolation — as if it were its own tiny proc — then propagate a
+        // lambda param's trait back onto an enclosing param only when the
+        // corresponding actual argument is a bare, unadorned reference to
+        // that enclosing param, i.e. only when the value genuinely flows
+        // from the caller's frame into the lambda's.
         for idx in ctx
             .registry
             .arg_indices_for_role(cmd_name, &cmd_args, ArgRole::LambdaLiteral)
@@ -458,7 +466,44 @@ fn scan_deep<'p>(
             if body_text.trim().is_empty() {
                 continue;
             }
-            scan_deep(body_text, ctx, traits, aliases, depth + 1);
+            let Some(params_text) =
+                source.get(elems.params.start() as usize..elems.params.end() as usize)
+            else {
+                continue;
+            };
+            let lambda_param_defs = crate::signature_scan::params::parse_param_list(params_text);
+            let lambda_param_names: Vec<&str> =
+                lambda_param_defs.iter().map(|p| p.name.as_str()).collect();
+            if lambda_param_names.is_empty() {
+                continue;
+            }
+            let lambda_traits = infer_param_traits_deep_with_config(
+                &lambda_param_names,
+                body_text,
+                ctx.registry,
+                ctx.stub_overlay,
+                ctx.config,
+            );
+            if lambda_traits.is_empty() {
+                continue;
+            }
+            // Positional actual arguments following the lambda literal bind
+            // to `argList`'s names in order (`apply {argList body} a1 a2 …`).
+            for (param_name, actual) in lambda_param_names.iter().copied().zip(&cmd_args[idx + 1..])
+            {
+                let Some(outer_name) = extract_var_name(actual) else {
+                    continue;
+                };
+                let Some(outer_param) = ctx.param_set.get(outer_name).copied() else {
+                    continue;
+                };
+                if let Some(lambda_param_traits) = lambda_traits.get(param_name) {
+                    traits
+                        .entry(outer_param)
+                        .or_default()
+                        .extend(lambda_param_traits.iter().copied());
+                }
+            }
         }
     }
 }
@@ -1103,12 +1148,35 @@ mod tests {
     /// would treat the parameter word as a command name and never find the
     /// `eval` at all) — mirrors `overlay_deep_recurses_through_stub_body_args`,
     /// swapping the registry-known `apply`/`LambdaLiteral` shape in for a
-    /// stub-declared `Body` shape.
+    /// stub-declared `Body` shape. The lambda's own param is `x`, bound to
+    /// the literal `1` — an enclosing `body` param is neither the lambda's
+    /// param nor forwarded into the call, so it must record nothing (codex
+    /// review of #954's follow-up: a lambda body runs in a fresh frame, and
+    /// a same-named enclosing param is not implicitly in scope there).
     #[test]
-    fn eval_param_inside_apply_lambda_body_records_eval_trait() {
+    fn eval_inside_apply_lambda_body_does_not_leak_to_unrelated_enclosing_param() {
         let registry = CommandRegistry::build_default();
         let traits =
             infer_param_traits_deep(&["body"], "apply {x {eval $body}} 1", &registry, None);
+        assert!(
+            !traits
+                .get("body")
+                .is_some_and(|s| s.contains(&ProcArgTrait::Eval)),
+            "an apply lambda's fresh frame must not leak a same-named \
+             enclosing param's trait when that param is never forwarded \
+             into the call; got {traits:?}"
+        );
+    }
+
+    /// The real forwarding case: the lambda's own param `x` is `eval`'d
+    /// inside its body, and the enclosing `body` param is passed as the
+    /// actual argument that binds to `x` — so `body`'s value genuinely does
+    /// flow into an `eval`, and the trait must propagate back to it.
+    #[test]
+    fn eval_param_forwarded_into_apply_lambda_records_eval_trait() {
+        let registry = CommandRegistry::build_default();
+        let traits =
+            infer_param_traits_deep(&["body"], "apply {x {eval $x}} $body", &registry, None);
         assert_trait(&traits, "body", ProcArgTrait::Eval);
     }
 

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -1702,7 +1702,29 @@ fn scan_source_for_calls(source: &str, ctx: ScanCtx<'_>, facts: &mut LocalFacts)
                 && let Some(body_text) =
                     source.get(body_span.start() as usize..body_span.end() as usize)
             {
-                scan_source_for_calls(body_text, ctx, facts);
+                // A lambda body runs in a fresh call frame whose current
+                // namespace is the lambda's own (optional) third element, or
+                // the global namespace when omitted — never the enclosing
+                // procedure's namespace. Build a synthetic "caller" qname
+                // carrying that namespace so `resolve_internal_call` (which
+                // derives its search namespace from the caller qname's own
+                // namespace prefix) resolves bare calls inside the lambda the
+                // same way Tcl itself would, instead of relative to
+                // `ctx.caller`'s enclosing namespace (codex review of #954's
+                // follow-up: an `apply {{} {helper}}` inside `::ns::f` calls
+                // `::helper`, not `::ns::helper`).
+                let lambda_caller = match elems
+                    .namespace
+                    .and_then(|ns| source.get(ns.start() as usize..ns.end() as usize))
+                {
+                    Some(ns) => format!("{ns}::<apply>"),
+                    None => "<apply>".to_owned(),
+                };
+                let lambda_ctx = ScanCtx {
+                    caller: &lambda_caller,
+                    ..ctx
+                };
+                scan_source_for_calls(body_text, lambda_ctx, facts);
             }
         }
         // Recurse into EXPR-role args. `expr {…}` (and the registry's other
@@ -2293,6 +2315,64 @@ mod tests {
         assert!(
             s.direct_calls.iter().any(|c| c == "::helper"),
             "expected a direct_calls edge to ::helper via the apply lambda body; got {:?}",
+            s.direct_calls
+        );
+    }
+
+    /// Codex review of #954's follow-up: a lambda body's bare calls must
+    /// resolve in the lambda's own namespace (the optional third `apply`
+    /// element, or global when omitted) — never the enclosing procedure's
+    /// namespace. `::ns::f`'s `apply {{} {helper}}` must resolve `helper` to
+    /// `::helper` (the two-element form runs in `::`), not `::ns::helper`,
+    /// even though `::ns::helper` also exists and would otherwise look like
+    /// the "closer" match.
+    #[test]
+    fn call_inside_apply_lambda_body_resolves_in_lambda_namespace() {
+        let ia = build(
+            "namespace eval ::ns {\n\
+                 proc helper {} { return 1 }\n\
+             }\n\
+             proc ::helper {} { return 2 }\n\
+             proc ::ns::f {} { set y [apply {{} {helper}}]; return $y }\n",
+        );
+        let s = ia.procedures.get("::ns::f").expect("::ns::f summary");
+        assert!(
+            s.direct_calls.iter().any(|c| c == "::helper"),
+            "expected the apply lambda body's bare `helper` call to resolve \
+             in the global namespace (Tcl evaluates a two-element apply \
+             lambda in `::`); got {:?}",
+            s.direct_calls
+        );
+        assert!(
+            !s.direct_calls.iter().any(|c| c == "::ns::helper"),
+            "the apply lambda body must not resolve `helper` against the \
+             enclosing proc's `::ns` namespace; got {:?}",
+            s.direct_calls
+        );
+    }
+
+    /// The lambda's explicit third-element namespace overrides both the
+    /// enclosing procedure's namespace and the global default.
+    #[test]
+    fn call_inside_apply_lambda_body_resolves_in_explicit_namespace() {
+        let ia = build(
+            "namespace eval ::other {\n\
+                 proc helper {} { return 1 }\n\
+             }\n\
+             proc ::helper {} { return 2 }\n\
+             proc ::ns::f {} { set y [apply {{} {helper} ::other}]; return $y }\n",
+        );
+        let s = ia.procedures.get("::ns::f").expect("::ns::f summary");
+        assert!(
+            s.direct_calls.iter().any(|c| c == "::other::helper"),
+            "expected the apply lambda's explicit `::other` namespace \
+             element to resolve `helper` there; got {:?}",
+            s.direct_calls
+        );
+        assert!(
+            !s.direct_calls.iter().any(|c| c == "::helper"),
+            "the explicit lambda namespace must not fall back to global; \
+             got {:?}",
             s.direct_calls
         );
     }

--- a/rust/tcl-compiler/src/interprocedural.rs
+++ b/rust/tcl-compiler/src/interprocedural.rs
@@ -1683,6 +1683,28 @@ fn scan_source_for_calls(source: &str, ctx: ScanCtx<'_>, facts: &mut LocalFacts)
                 scan_source_for_calls(body_text, ctx, facts);
             }
         }
+        // Recurse into an `ArgRole::LambdaLiteral` argument's real body
+        // element (`apply {argList body ?ns?} …`) — the whole lambda literal
+        // is a 2-element list, not a script, so scanning it as one (like a
+        // plain `Body` arg) would misread the parameter word as a call-graph
+        // edge to a non-existent proc and never reach the real body's own
+        // calls at all (issue #954's call-graph sibling gap).
+        let lambda_indices = registry.arg_indices_for_role(
+            name,
+            &arg_strs,
+            tcl_registry::arg_role::ArgRole::LambdaLiteral,
+        );
+        for idx in lambda_indices {
+            if let Some(&tok) = cmd.argv.get(idx + 1)
+                && tok.kind == tcl_lexer::TokenType::Str
+                && let Some(elems) = crate::lambda_literal::split_lambda_literal(source, tok)
+                && let Some(body_span) = elems.body
+                && let Some(body_text) =
+                    source.get(body_span.start() as usize..body_span.end() as usize)
+            {
+                scan_source_for_calls(body_text, ctx, facts);
+            }
+        }
         // Recurse into EXPR-role args. `expr {…}` (and the registry's other
         // expression operands) re-parse and evaluate their argument, so a
         // `[cmd]` substitution inside it is a real call edge even when the
@@ -2250,6 +2272,29 @@ mod tests {
     fn empty_module_has_no_summaries() {
         let ia = build("");
         assert!(ia.procedures.is_empty());
+    }
+
+    /// Issue #954's call-graph sibling gap: a proc called *inside* an
+    /// `apply` lambda body reached through a `[…]` command substitution
+    /// (`set y [apply {p {…}} $x]`) must still register as a call-graph
+    /// edge. `apply`'s lambda-literal argument is `ArgRole::LambdaLiteral`,
+    /// not `Body` — scanning the whole `{argList} {body}` blob as one script
+    /// (the old generic-`Body` path) misread the parameter word as a
+    /// command name and never reached the real body's own calls, which
+    /// would have made `helper` look like dead code (O124) despite being
+    /// reachable only from inside the lambda.
+    #[test]
+    fn call_inside_apply_lambda_body_is_a_direct_call() {
+        let ia = build(
+            "proc ::helper {x} { return $x }\n\
+             proc ::f {} { set y [apply {p {helper $p}} 1]; return $y }\n",
+        );
+        let s = ia.procedures.get("::f").expect("::f summary");
+        assert!(
+            s.direct_calls.iter().any(|c| c == "::helper"),
+            "expected a direct_calls edge to ::helper via the apply lambda body; got {:?}",
+            s.direct_calls
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/lambda_literal.rs
+++ b/rust/tcl-compiler/src/lambda_literal.rs
@@ -33,8 +33,10 @@
 //! parameter list, element 1 is the body script — lets each consumer recurse
 //! into the real body directly.
 
+use std::borrow::Cow;
+
 use tcl_lexer::{Span, Token, TokenType};
-use tcl_syntax::list::find_element;
+use tcl_syntax::list::{Element, find_element};
 
 /// The list elements of a lambda literal, as absolute byte spans into the
 /// original source.
@@ -65,6 +67,31 @@ pub struct LambdaLiteralElements {
 /// at all (an unmatched brace/quote in the parameter-list element).
 #[must_use]
 pub fn split_lambda_literal(source: &str, tok: Token) -> Option<LambdaLiteralElements> {
+    let (content_start, params_el, body_el, namespace_el) = locate_elements(source, tok)?;
+    let to_span = |el: &Element| -> Option<Span> {
+        Some(Span::new(
+            content_start + u32::try_from(el.value.start).ok()?,
+            content_start + u32::try_from(el.value.end).ok()?,
+        ))
+    };
+    Some(LambdaLiteralElements {
+        params: to_span(&params_el)?,
+        body: body_el.as_ref().and_then(to_span),
+        namespace: namespace_el.as_ref().and_then(to_span),
+    })
+}
+
+/// Shared element-location logic for [`split_lambda_literal`] and
+/// [`split_lambda_literal_decoded`]: locate the (params, ?body?, ?namespace?)
+/// list elements of a lambda literal, keeping each [`Element`]'s `literal`
+/// flag — whether it was `{brace}`-delimited (verbatim) vs bare/quoted
+/// (backslash escapes need collapsing) — that a `Span`-only result would
+/// discard. Returns the absolute byte offset the elements' (source-relative)
+/// spans are anchored to, alongside the elements themselves.
+fn locate_elements(
+    source: &str,
+    tok: Token,
+) -> Option<(u32, Element, Option<Element>, Option<Element>)> {
     if tok.kind != TokenType::Str {
         return None;
     }
@@ -78,26 +105,58 @@ pub fn split_lambda_literal(source: &str, tok: Token) -> Option<LambdaLiteralEle
     }
     let text = source.get(content_start as usize..content_end as usize)?;
 
-    let to_span = |el: &tcl_syntax::list::Element| -> Option<Span> {
-        Some(Span::new(
-            content_start + u32::try_from(el.value.start).ok()?,
-            content_start + u32::try_from(el.value.end).ok()?,
-        ))
-    };
-
     let params_el = find_element(text, 0).ok().flatten()?;
-    let params = to_span(&params_el)?;
-
     let body_el = find_element(text, params_el.next).ok().flatten();
-    let body = body_el.as_ref().and_then(to_span);
-    let namespace = body_el
-        .and_then(|el| find_element(text, el.next).ok().flatten())
-        .and_then(|el| to_span(&el));
+    let namespace_el = body_el
+        .as_ref()
+        .and_then(|el| find_element(text, el.next).ok().flatten());
 
-    Some(LambdaLiteralElements {
-        params,
-        body,
-        namespace,
+    Some((content_start, params_el, body_el, namespace_el))
+}
+
+/// A lambda literal's list elements, decoded to the actual value Tcl's list
+/// parser produces — a `{braced}` element verbatim, a bare/quoted element
+/// with its backslash escapes collapsed ([`tcl_lexer::backslash_subst`]).
+///
+/// Reconstruction consumers (minification, formatting) that rewrite an
+/// element and reassemble the literal need this rather than
+/// [`LambdaLiteralElements`]'s raw spans: reprocessing a non-literal
+/// element's still-escaped source spelling directly as list/script text
+/// silently changes what it means (codex review of #954's follow-up —
+/// `apply {{} puts\ hi}`'s real body is `puts hi`, not the literal text
+/// `puts\ hi`, since list-element decoding collapses the `\ ` into a space
+/// *before* the result is ever parsed as a script).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DecodedLambdaLiteral<'a> {
+    /// Element 0's decoded value (the parameter list).
+    pub params: Cow<'a, str>,
+    /// Element 1's decoded value (the body script), when present.
+    pub body: Option<Cow<'a, str>>,
+    /// Element 2's decoded value (the namespace), when present.
+    pub namespace: Option<Cow<'a, str>>,
+}
+
+/// Decoded counterpart of [`split_lambda_literal`] — see
+/// [`DecodedLambdaLiteral`]. Returns `None` under the same conditions as
+/// [`split_lambda_literal`] (a `$var`/`[cmd]`-computed lambda, or content
+/// that isn't parseable as a Tcl list).
+#[must_use]
+pub fn split_lambda_literal_decoded(source: &str, tok: Token) -> Option<DecodedLambdaLiteral<'_>> {
+    let (content_start, params_el, body_el, namespace_el) = locate_elements(source, tok)?;
+    let decode = |el: &Element| -> Option<Cow<'_, str>> {
+        let start = content_start as usize + el.value.start;
+        let end = content_start as usize + el.value.end;
+        let raw = source.get(start..end)?;
+        Some(if el.literal {
+            Cow::Borrowed(raw)
+        } else {
+            tcl_lexer::backslash_subst(raw)
+        })
+    };
+    Some(DecodedLambdaLiteral {
+        params: decode(&params_el)?,
+        body: body_el.as_ref().and_then(decode),
+        namespace: namespace_el.as_ref().and_then(decode),
     })
 }
 
@@ -165,5 +224,42 @@ mod tests {
         let cmds = segment_commands(src);
         let tok = cmds[0].argv[1];
         assert!(split_lambda_literal(src, tok).is_none());
+    }
+
+    /// Codex review of #954's follow-up: a bare body element's backslash
+    /// escapes must be collapsed to get the value Tcl's list parser (and
+    /// then `apply`'s script evaluator) actually sees — `puts\ hi`'s real
+    /// runtime body is `puts hi` (a two-word command), not the literal
+    /// source text `puts\ hi` (which would parse as one word if re-lexed
+    /// verbatim as script source).
+    #[test]
+    fn decodes_bare_body_backslash_escape() {
+        let src = r"apply {{} puts\ hi}";
+        let decoded = split_lambda_literal_decoded(src, lambda_tok(src)).unwrap();
+        assert_eq!(decoded.params, "");
+        assert_eq!(decoded.body.as_deref(), Some("puts hi"));
+    }
+
+    #[test]
+    fn braced_elements_are_not_decoded() {
+        let src = "apply {dir {puts $dir}} /tmp";
+        let decoded = split_lambda_literal_decoded(src, lambda_tok(src)).unwrap();
+        assert_eq!(decoded.params, "dir");
+        assert_eq!(decoded.body.as_deref(), Some("puts $dir"));
+    }
+
+    #[test]
+    fn decodes_bare_namespace_backslash_escape() {
+        let src = r"apply {dir {puts $dir} ::ns\ x} /tmp";
+        let decoded = split_lambda_literal_decoded(src, lambda_tok(src)).unwrap();
+        assert_eq!(decoded.namespace.as_deref(), Some("::ns x"));
+    }
+
+    #[test]
+    fn decoded_dynamic_lambda_is_not_split() {
+        let src = "apply $lambda /tmp";
+        let cmds = segment_commands(src);
+        let tok = cmds[0].argv[1];
+        assert!(split_lambda_literal_decoded(src, tok).is_none());
     }
 }

--- a/rust/tcl-compiler/src/lambda_literal.rs
+++ b/rust/tcl-compiler/src/lambda_literal.rs
@@ -1,0 +1,169 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Shared splitting of an [`tcl_registry::ArgRole::LambdaLiteral`] argument
+//! (`apply`'s `{argList body ?namespace?}` shape) into its list elements'
+//! absolute spans, so every consumer that walks such an argument — folding,
+//! formatting, minification, declaration-scanning, the iRules object-
+//! reference walker, the semantic-token highlighter — splits it the same
+//! way instead of mis-reading the whole literal as if it were script source.
+//!
+//! Before this shape had its own role, several generic `ArgRole::Body`
+//! walkers re-segmented the *entire* `{argList body}` blob as a script:
+//! `apply {dir { puts $dir }} …` was read as one statement whose command
+//! name is `dir` and whose one argument is `{puts $dir}` — the parameter
+//! word masquerading as a command head. Since `dir` never resolves to a
+//! registered command, recursion stopped there and the real body was never
+//! reached (issue #954). Splitting the list here — element 0 is the
+//! parameter list, element 1 is the body script — lets each consumer recurse
+//! into the real body directly.
+
+use tcl_lexer::{Span, Token, TokenType};
+use tcl_syntax::list::find_element;
+
+/// The list elements of a lambda literal, as absolute byte spans into the
+/// original source.
+///
+/// `params` is present whenever the literal parses as a list at all.
+/// `body` / `namespace` are `None` when the list has fewer elements — a
+/// malformed lambda that would itself error under `apply` at runtime, or a
+/// list truncated mid-edit — so callers that need "is this a usable 2-or-3
+/// element lambda" should check `body.is_some()` rather than assuming it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LambdaLiteralElements {
+    /// Element 0 — the parameter list (not code: a plain word or a braced
+    /// `{name ?default...?}` list, never recursed as script).
+    pub params: Span,
+    /// Element 1 — the body script, when present.
+    pub body: Option<Span>,
+    /// Element 2 — the namespace the body runs in, when present.
+    pub namespace: Option<Span>,
+}
+
+/// Split a lambda-literal token into its list elements' absolute spans.
+///
+/// `tok` must be the braced literal argument itself (a `Str` token) — a
+/// `$var` / `[cmd]`-computed lambda can't be split statically, and this
+/// returns `None` for that case, matching the guard every
+/// `ArgRole::LambdaLiteral` consumer applies before calling this. Also
+/// returns `None` when the literal's content isn't parseable as a Tcl list
+/// at all (an unmatched brace/quote in the parameter-list element).
+#[must_use]
+pub fn split_lambda_literal(source: &str, tok: Token) -> Option<LambdaLiteralElements> {
+    if tok.kind != TokenType::Str {
+        return None;
+    }
+    let content_start = tok.span.start() + u32::from(tok.content_offset);
+    let content_end = tok
+        .span
+        .end()
+        .min(u32::try_from(source.len()).unwrap_or(u32::MAX));
+    if content_end < content_start {
+        return None;
+    }
+    let text = source.get(content_start as usize..content_end as usize)?;
+
+    let to_span = |el: &tcl_syntax::list::Element| -> Option<Span> {
+        Some(Span::new(
+            content_start + u32::try_from(el.value.start).ok()?,
+            content_start + u32::try_from(el.value.end).ok()?,
+        ))
+    };
+
+    let params_el = find_element(text, 0).ok().flatten()?;
+    let params = to_span(&params_el)?;
+
+    let body_el = find_element(text, params_el.next).ok().flatten();
+    let body = body_el.as_ref().and_then(to_span);
+    let namespace = body_el
+        .and_then(|el| find_element(text, el.next).ok().flatten())
+        .and_then(|el| to_span(&el));
+
+    Some(LambdaLiteralElements {
+        params,
+        body,
+        namespace,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::segmenter::segment_commands;
+
+    fn lambda_tok(src: &str) -> Token {
+        // `apply <lambda> …` — the lambda literal is argv[1].
+        let cmds = segment_commands(src);
+        cmds[0].argv[1]
+    }
+
+    #[test]
+    fn splits_params_and_body() {
+        let src = "apply {dir {puts $dir}} /tmp";
+        let elems = split_lambda_literal(src, lambda_tok(src)).unwrap();
+        assert_eq!(
+            &src[elems.params.start() as usize..elems.params.end() as usize],
+            "dir"
+        );
+        let body = elems.body.unwrap();
+        assert_eq!(
+            &src[body.start() as usize..body.end() as usize],
+            "puts $dir"
+        );
+        assert!(elems.namespace.is_none());
+    }
+
+    #[test]
+    fn splits_braced_multi_param_list() {
+        let src = "apply {{x y} {return [expr {$x+$y}]}} 1 2";
+        let elems = split_lambda_literal(src, lambda_tok(src)).unwrap();
+        assert_eq!(
+            &src[elems.params.start() as usize..elems.params.end() as usize],
+            "x y"
+        );
+        let body = elems.body.unwrap();
+        assert_eq!(
+            &src[body.start() as usize..body.end() as usize],
+            "return [expr {$x+$y}]"
+        );
+    }
+
+    #[test]
+    fn splits_namespace_element() {
+        let src = "apply {dir {puts $dir} ::foo} /tmp";
+        let elems = split_lambda_literal(src, lambda_tok(src)).unwrap();
+        let ns = elems.namespace.unwrap();
+        assert_eq!(&src[ns.start() as usize..ns.end() as usize], "::foo");
+    }
+
+    #[test]
+    fn params_only_has_no_body() {
+        let src = "apply {dir}";
+        let elems = split_lambda_literal(src, lambda_tok(src)).unwrap();
+        assert!(elems.body.is_none());
+        assert!(elems.namespace.is_none());
+    }
+
+    #[test]
+    fn dynamic_lambda_is_not_split() {
+        let src = "apply $lambda /tmp";
+        let cmds = segment_commands(src);
+        let tok = cmds[0].argv[1];
+        assert!(split_lambda_literal(src, tok).is_none());
+    }
+}

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -118,6 +118,7 @@ pub mod intervals;
 pub mod ir;
 pub mod ir_helpers;
 pub mod irules_checks;
+pub mod lambda_literal;
 mod lattice_rebase;
 pub use lattice_rebase::rebase_script;
 pub mod loops;

--- a/rust/tcl-compiler/src/signature_scan/command_prefix.rs
+++ b/rust/tcl-compiler/src/signature_scan/command_prefix.rs
@@ -27,7 +27,7 @@
 //! feeding find-references, call-hierarchy, call-graph, code-lens, W123, and
 //! the callback-arity check off one substrate.
 //!
-//! Two prefix shapes are recognised:
+//! Three prefix shapes are recognised:
 //!
 //! - A **literal bareword** head (a single `Esc` token, not quoted, not a
 //!   `$var`/`[cmd]` substitution) — mirroring the highlight guard in
@@ -39,8 +39,16 @@
 //!   the callback head and every further element is a *baked* argument the
 //!   callback-arity check (`tcl_lsp_db::apply_callback_arity`) adds to the
 //!   command's own appended count.
+//! - A **list-quoted prefix** (`[list cmd extra1 extra2]`, a single `Cmd`
+//!   token whose sole content is a call to a `Traits::BUILDS_COMMAND_PREFIX`
+//!   command — `list` — with a literal bareword as its own first argument):
+//!   the idiomatic way to build a callback around a dynamic value
+//!   (`-command [list doSomething $x]`) rather than a fixed literal prefix.
+//!   Same head/baked-count semantics as the braced shape, just constructed
+//!   dynamically; the *value* of the trailing arguments isn't needed, only
+//!   their count.
 //!
-//! A dynamic head (`$var`/`[cmd]`, in either shape) can't be resolved to a
+//! A dynamic head (`$var`/`[cmd]`, in any shape) can't be resolved to a
 //! proc and recording it would false-fire W123, so it stays unrecorded.
 //!
 //! [`ArgRole::CommandPrefix`]: tcl_registry::arg_role::ArgRole::CommandPrefix
@@ -48,6 +56,8 @@
 use tcl_lexer::{Span, Token, TokenType};
 use tcl_registry::{AppendedArity, CommandRegistry};
 use tcl_syntax::list::find_element;
+
+use crate::segmenter::segment_commands_with_offset;
 
 /// A command-prefix callback head extracted from a call site.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -83,9 +93,12 @@ pub(crate) fn command_prefix_invocations(
         let (Some(&tok), Some(text)) = (arg_tokens.get(idx), arg_texts.get(idx)) else {
             continue;
         };
-        if let Some((head, span, baked)) =
-            extract_prefix_head(tok, text, arg_single.get(idx).copied().unwrap_or(false))
-        {
+        if let Some((head, span, baked)) = extract_prefix_head(
+            registry,
+            tok,
+            text,
+            arg_single.get(idx).copied().unwrap_or(false),
+        ) {
             out.push(CommandPrefixInvocation {
                 head,
                 span,
@@ -124,6 +137,7 @@ pub(crate) fn instance_method_command_prefix_invocations(
             continue;
         };
         if let Some((head, span, baked)) = extract_prefix_head(
+            registry,
             tok,
             text,
             method_arg_single.get(idx).copied().unwrap_or(false),
@@ -159,16 +173,19 @@ fn looks_unresolvable(text: &str) -> bool {
 /// argument, or `None` when it isn't a literal, resolvable command
 /// reference.
 ///
-/// Two shapes are recognised (see the module docs): a literal bareword head
-/// — a single `Esc` token, unquoted, with no leading `$`/`[` substitution
-/// and not a widget path, mirroring the highlight retag guard so recording
-/// and highlighting agree exactly — bakes 0; a braced multi-word prefix —
-/// a single `Str` token — is list-parsed via [`find_element`], with the
-/// first element as the head (subject to the same guard) and every further
-/// element counted as a baked argument. A malformed list (unmatched
+/// Three shapes are recognised (see the module docs): a literal bareword
+/// head — a single `Esc` token, unquoted, with no leading `$`/`[`
+/// substitution and not a widget path, mirroring the highlight retag guard
+/// so recording and highlighting agree exactly — bakes 0; a braced
+/// multi-word prefix — a single `Str` token — is list-parsed via
+/// [`find_element`], with the first element as the head (subject to the
+/// same guard) and every further element counted as a baked argument; a
+/// list-quoted prefix — a single `Cmd` token — delegates to
+/// [`extract_list_quoted_prefix_head`]. A malformed list (unmatched
 /// brace/quote, typically mid-edit) or an empty list abstains rather than
 /// guessing.
 fn extract_prefix_head(
+    registry: &CommandRegistry,
     tok: Token,
     text: &str,
     single_token: bool,
@@ -212,5 +229,55 @@ fn extract_prefix_head(
         }
         return Some((head.to_string(), head_span, baked));
     }
+    if tok.kind == TokenType::Cmd {
+        return extract_list_quoted_prefix_head(registry, tok, text);
+    }
     None
+}
+
+/// Extract `(head, head_span, baked_arg_count)` from a `[list cmd a b]`
+/// command-prefix argument.
+///
+/// `text` is the reconstructed word text for a `Cmd` token, which — unlike
+/// the `Str` shape above — keeps its surrounding `[`/`]` (the segmenter's
+/// convention for command-substitution words); strip them to reach the
+/// inner script. That script must be exactly one call to a
+/// `Traits::BUILDS_COMMAND_PREFIX` command (`list`; resolved via
+/// `registry.get`, which strips a leading `::`) whose own first argument is
+/// a literal, resolvable bareword — the same guard as the bareword shape,
+/// applied one level in. The baked count is simply the remaining word
+/// count: unlike the braced-list shape, the trailing words don't need
+/// list-parsing, since `list`'s own arguments are already individually
+/// segmented words, not list elements packed into one.
+fn extract_list_quoted_prefix_head(
+    registry: &CommandRegistry,
+    tok: Token,
+    text: &str,
+) -> Option<(String, Span, usize)> {
+    let inner = text.strip_prefix('[')?.strip_suffix(']')?;
+    let content_start = tok.span.start() + u32::from(tok.content_offset);
+    let mut segs = segment_commands_with_offset(inner, content_start);
+    if segs.len() != 1 {
+        return None;
+    }
+    let seg = segs.pop()?;
+    if !registry.get(&seg.texts[0]).is_some_and(|s| {
+        s.traits
+            .contains(tcl_registry::Traits::BUILDS_COMMAND_PREFIX)
+    }) {
+        return None;
+    }
+    let head_tok = *seg.argv.get(1)?;
+    if head_tok.kind != TokenType::Esc
+        || head_tok.in_quote
+        || seg.single_token_word.get(1) != Some(&true)
+    {
+        return None;
+    }
+    let head = seg.texts.get(1)?.as_str();
+    if looks_unresolvable(head) {
+        return None;
+    }
+    let baked = seg.texts.len().saturating_sub(2);
+    Some((head.to_string(), head_tok.span, baked))
 }

--- a/rust/tcl-irules/src/walker.rs
+++ b/rust/tcl-irules/src/walker.rs
@@ -25,6 +25,7 @@
 
 use std::collections::{HashMap, HashSet};
 
+use tcl_compiler::lambda_literal::split_lambda_literal;
 use tcl_compiler::segmenter::{SegmentedCommand, segment_commands_with_offset_and_config};
 use tcl_lexer::LexerConfig;
 use tcl_lexer::{Span, Token, TokenType};
@@ -177,6 +178,38 @@ fn walk(
             {
                 let mut child = scope.child();
                 recurse_token(full, tok, rule_module, registry, &mut child, out);
+            }
+        }
+
+        // `apply {argList body ?ns?} …` (and any future command sharing the
+        // shape) — recurse into the real body *element*, not the whole
+        // lambda literal (issue #954): re-segmenting the whole `{argList}
+        // {body}` blob as a script previously misread the parameter word as
+        // a command name, so an object referenced only inside an apply
+        // lambda body embedded in an iRule event handler was invisible to
+        // this walker — and thus, per `bigip-cleanup`, looked unreferenced.
+        for lambda_idx in registry.arg_indices_for_role(cmd.name(), &args, ArgRole::LambdaLiteral) {
+            let word_index = lambda_idx + 1;
+            if let Some(tok) = cmd.argv.get(word_index)
+                && matches!(tok.kind, TokenType::Str)
+                && let Some(elems) = split_lambda_literal(full, *tok)
+                && let Some(body_span) = elems.body
+            {
+                let (bstart, bend) = (body_span.start() as usize, body_span.end() as usize);
+                if let Some(inner) = full.get(bstart..bend)
+                    && !inner.trim().is_empty()
+                {
+                    let mut child = scope.child();
+                    walk(
+                        full,
+                        inner,
+                        body_span.start(),
+                        rule_module,
+                        registry,
+                        &mut child,
+                        out,
+                    );
+                }
             }
         }
 

--- a/rust/tcl-irules/src/walker.rs
+++ b/rust/tcl-irules/src/walker.rs
@@ -25,7 +25,7 @@
 
 use std::collections::{HashMap, HashSet};
 
-use tcl_compiler::lambda_literal::split_lambda_literal;
+use tcl_compiler::lambda_literal::{LambdaLiteralElements, split_lambda_literal};
 use tcl_compiler::segmenter::{SegmentedCommand, segment_commands_with_offset_and_config};
 use tcl_lexer::LexerConfig;
 use tcl_lexer::{Span, Token, TokenType};
@@ -188,6 +188,12 @@ fn walk(
         // a command name, so an object referenced only inside an apply
         // lambda body embedded in an iRule event handler was invisible to
         // this walker — and thus, per `bigip-cleanup`, looked unreferenced.
+        //
+        // Unlike an `if`/`foreach`/`switch` body (which shares the enclosing
+        // frame — `scope.child()` is correct there), an `apply` body runs in
+        // a *fresh* call frame: it does not inherit the caller's `set`-bound
+        // constants, only whatever its own actual arguments bind to its own
+        // params (`lambda_frame_scope` builds exactly that).
         for lambda_idx in registry.arg_indices_for_role(cmd.name(), &args, ArgRole::LambdaLiteral) {
             let word_index = lambda_idx + 1;
             if let Some(tok) = cmd.argv.get(word_index)
@@ -199,7 +205,7 @@ fn walk(
                 if let Some(inner) = full.get(bstart..bend)
                     && !inner.trim().is_empty()
                 {
-                    let mut child = scope.child();
+                    let mut child = lambda_frame_scope(full, &cmd, lambda_idx, elems, scope);
                     walk(
                         full,
                         inner,
@@ -246,6 +252,41 @@ fn walk(
             recurse_token(full, tok, rule_module, registry, &mut child, out);
         }
     }
+}
+
+/// Build the fresh binding scope an `apply` lambda body runs in: empty
+/// (unlike `scope.child()`'s full clone, this inherits none of the
+/// enclosing frame's `set`-bound constants), with the lambda's own params
+/// bound to whatever their corresponding actual argument resolves to.
+///
+/// Inheriting the full scope would let an unrelated enclosing binding that
+/// happens to share a lambda-local variable's name (or, in the case of a
+/// zero-param lambda, *any* enclosing binding at all) misattribute an
+/// object reference to the wrong constant — a lambda body does not close
+/// over the caller's locals. `lambda_idx` is the lambda-literal argument's
+/// own 0-based (head-excluded) index in `cmd`, so its actual arguments run
+/// from `lambda_idx + 1`; each is resolved via the same literal /
+/// `$var`-propagation [`resolve_arg_value`] already uses for ordinary
+/// references, against the *enclosing* `scope`.
+fn lambda_frame_scope(
+    full: &str,
+    cmd: &SegmentedCommand,
+    lambda_idx: usize,
+    elems: LambdaLiteralElements,
+    scope: &BindingScope,
+) -> BindingScope {
+    let mut child = BindingScope::default();
+    let Some(params_text) = full.get(elems.params.start() as usize..elems.params.end() as usize)
+    else {
+        return child;
+    };
+    let lambda_params = tcl_compiler::signature_scan::params::parse_param_list(params_text);
+    for (k, param) in lambda_params.iter().enumerate() {
+        if let Some((value, _span)) = resolve_arg_value(full, cmd, lambda_idx + 1 + k, scope) {
+            child.set_const(&param.name, value);
+        }
+    }
+    child
 }
 
 /// The clause-list word of `cmd` (`switch … {pat body …}`), per the registry's

--- a/rust/tcl-irules/tests/script_bearing_args.rs
+++ b/rust/tcl-irules/tests/script_bearing_args.rs
@@ -206,6 +206,41 @@ fn a_pool_used_only_inside_an_apply_lambda_body_is_referenced() {
     );
 }
 
+/// An `apply` body runs in a *fresh* call frame — unlike an `if`/`foreach`/
+/// `switch` body (which shares the enclosing frame), it does not inherit the
+/// caller's `set`-bound constants. A zero-param lambda referencing a
+/// same-named enclosing variable must not resolve it: at runtime `$poolName`
+/// inside this lambda is simply undefined, so a reference here would be a
+/// false positive that could make `bigip-cleanup` treat an actually-dead
+/// pool as still live.
+#[test]
+fn apply_lambda_does_not_inherit_enclosing_set_bindings() {
+    let registry = irules_registry();
+    let source = "when HTTP_REQUEST {\n    set poolName PROBE_PLACEHOLDER\n    apply {{} { pool $poolName }}\n}\n"
+        .replace("PROBE_PLACEHOLDER", PROBE);
+    assert!(
+        !finds_probe(&source, &registry),
+        "a zero-param apply lambda must not inherit the enclosing scope's \
+         `set`-bound constants — `$poolName` is undefined inside its fresh \
+         frame, so it must not resolve to the enclosing binding"
+    );
+}
+
+/// The forwarding half of the same fix: when the enclosing binding *is*
+/// passed as the lambda's actual argument, its value correctly flows into
+/// the lambda's own parameter.
+#[test]
+fn apply_lambda_param_resolves_via_forwarded_actual_argument() {
+    let registry = irules_registry();
+    let source = "when HTTP_REQUEST {\n    set poolName PROBE_PLACEHOLDER\n    apply {{p} { pool $p }} $poolName\n}\n"
+        .replace("PROBE_PLACEHOLDER", PROBE);
+    assert!(
+        finds_probe(&source, &registry),
+        "the lambda's own param `p`, bound from the forwarded `$poolName` \
+         actual argument, must resolve `pool $p` to the propagated constant"
+    );
+}
+
 /// The regression itself, spelled out — the exact iRule that `bigip-cleanup`
 /// would have deleted a live pool from.
 #[test]

--- a/rust/tcl-irules/tests/script_bearing_args.rs
+++ b/rust/tcl-irules/tests/script_bearing_args.rs
@@ -62,7 +62,7 @@ fn finds_probe(source: &str, registry: &CommandRegistry) -> bool {
 ///
 /// Kept beside the walker's behaviour rather than inferred from it, so that a
 /// role which *starts* carrying a script has to be added here consciously.
-const WALKED_ROLES: &[ArgRole] = &[ArgRole::Body, ArgRole::Expr];
+const WALKED_ROLES: &[ArgRole] = &[ArgRole::Body, ArgRole::Expr, ArgRole::LambdaLiteral];
 
 /// The walker must descend into every role the registry says holds code.
 ///
@@ -178,6 +178,31 @@ fn every_clause_list_body_is_walked() {
         gaps.is_empty(),
         "these commands carry a clause list whose bodies are not walked: {}",
         gaps.join(", ")
+    );
+}
+
+/// A pool used only inside an `apply` lambda body — issue #954's sibling gap.
+///
+/// `apply`'s lambda-literal argument is `ArgRole::LambdaLiteral`, not
+/// `ArgRole::Body` — the whole `{argList} {body}` word is a 2-element list,
+/// not a script, so recursing it as one misreads the parameter word as a
+/// command name and never reaches the real body at all. A pool referenced
+/// only inside such a body was invisible to the reference graph until the
+/// walker learned to split the lambda literal and descend into its body
+/// element specifically.
+#[test]
+fn a_pool_used_only_inside_an_apply_lambda_body_is_referenced() {
+    let registry = irules_registry();
+    let source =
+        format!("when HTTP_REQUEST {{\n    apply {{dir {{ pool {PROBE} }}}} /Common\n}}\n");
+    let names: Vec<String> = extract_irules_object_references(&source, None, &registry)
+        .into_iter()
+        .map(|r| r.name)
+        .collect();
+    assert!(
+        names.iter().any(|n| n == PROBE),
+        "a pool referenced only inside an apply lambda body is invisible to the \
+         reference graph; got {names:?}"
     );
 }
 

--- a/rust/tcl-lsp-core/src/declaration.rs
+++ b/rust/tcl-lsp-core/src/declaration.rs
@@ -34,9 +34,10 @@
 //! empty set means the whole file is visible (cursor at global scope).
 
 use tcl_compiler::analyser::AnalysisResult;
+use tcl_compiler::lambda_literal::split_lambda_literal;
 use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
 use tcl_compiler::var_scoping::scope_alias_declaration_indices;
-use tcl_lexer::{LexerConfig, LineIndex, Span};
+use tcl_lexer::{LexerConfig, LineIndex, Span, TokenType};
 use tcl_registry::CommandRegistry;
 use tcl_registry::arg_role::ArgRole;
 
@@ -200,6 +201,31 @@ fn collect_declarations_in_region(
                 collect_declarations_in_region(scan, body_tok.span, depth + 1, found);
             }
         }
+
+        // `apply {argList body ?ns?} …` (and any future command sharing the
+        // shape) — recurse into the real body *element*, not the whole
+        // lambda literal (issue #954): re-segmenting the whole `{argList}
+        // {body}` blob as a script misread the parameter word as a command
+        // name, so a `global` / `variable` / `upvar` genuinely inside the
+        // body was never reached (and, worse, a parameter that happened to
+        // be *named* `global`/`variable`/`upvar` could misfire as a bogus
+        // declaration). `split_lambda_literal`'s span is already
+        // delimiter-stripped, so it can be handed to
+        // `collect_declarations_in_region` directly — its own peel step is a
+        // no-op on a region that has nothing left to peel.
+        for lambda_idx in registry.arg_indices_for_role(head, &arg_refs, ArgRole::LambdaLiteral) {
+            let Some(&lambda_tok) = arg_tokens.get(lambda_idx) else {
+                continue;
+            };
+            if lambda_tok.kind != TokenType::Str {
+                continue;
+            }
+            if let Some(elems) = split_lambda_literal(source, lambda_tok)
+                && let Some(body_span) = elems.body
+            {
+                collect_declarations_in_region(scan, body_span, depth + 1, found);
+            }
+        }
     }
 }
 
@@ -353,6 +379,25 @@ mod tests {
         let locs = declaration(src, l, c + 1, "tcl8.6", &analysis, &reg());
         assert_eq!(locs.len(), 1, "{locs:?}");
         // `global x` is on line 1 (the `if` line).
+        assert_eq!(locs[0].start_line, 1);
+    }
+
+    #[test]
+    fn global_declared_inside_apply_lambda_body_is_found() {
+        // Issue #954: `apply`'s lambda-literal argument is
+        // `ArgRole::LambdaLiteral`, not `Body` — recursing the whole
+        // `{argList} {body}` blob as a script (the old generic-`Body` path)
+        // misread the parameter word as a command name, so a `global`
+        // declared *inside* the real body was never reached at all.
+        let src = "apply {dir {\n\
+                   global x\n\
+                   puts $x\n\
+                   }} /tmp\n";
+        let analysis = analyse(src);
+        let (l, c) = pos_of(src, "$x", 1);
+        let locs = declaration(src, l, c + 1, "tcl8.6", &analysis, &reg());
+        assert_eq!(locs.len(), 1, "{locs:?}");
+        // `global x` is on line 1 (inside the lambda body).
         assert_eq!(locs[0].start_line, 1);
     }
 

--- a/rust/tcl-lsp-core/src/declaration.rs
+++ b/rust/tcl-lsp-core/src/declaration.rs
@@ -85,6 +85,7 @@ pub fn declaration(
         target,
         visible: &visible,
         registry,
+        cursor,
     };
     let mut found = DeclSpans::default();
     for region in &regions {
@@ -127,6 +128,13 @@ struct DeclScan<'a> {
     target: &'a str,
     visible: &'a [Span],
     registry: &'a CommandRegistry,
+    /// The cursor's byte offset. The analyser's scope tree does not model an
+    /// `apply` lambda body as its own scope (it has no `proc`/`namespace
+    /// eval`-style boundary), so `visible` never reflects it; recursing into
+    /// a lambda's body is instead gated directly on whether the cursor sits
+    /// inside that specific lambda's span (see the `LambdaLiteral` arm of
+    /// [`collect_declarations_in_region`]).
+    cursor: u32,
 }
 
 /// Scan the commands of `region` for `global` / `variable` / `upvar` /
@@ -213,6 +221,19 @@ fn collect_declarations_in_region(
         // delimiter-stripped, so it can be handed to
         // `collect_declarations_in_region` directly — its own peel step is a
         // no-op on a region that has nothing left to peel.
+        //
+        // Unlike an `if`/`foreach`/`catch` body, an `apply` body runs in a
+        // *fresh* call frame — a `global`/`variable`/`upvar` declared inside
+        // it is scoped to that frame alone, never to the frame containing
+        // this `apply` call. Descending unconditionally would make such a
+        // declaration "visible" to a cursor sitting *outside* the lambda too
+        // (codex review of #954's follow-up: `apply {{} {global x}}` inside a
+        // proc, followed by an unrelated `puts $x` in the same proc, must
+        // not resolve `$x`'s declaration into the lambda). So recurse only
+        // when the cursor itself is positioned inside this specific lambda's
+        // body — the analyser's scope tree has no `apply`-body scope kind for
+        // `scan.visible` to reflect, so the direct span/offset containment
+        // check stands in for "the cursor's scope chain includes this frame".
         for lambda_idx in registry.arg_indices_for_role(head, &arg_refs, ArgRole::LambdaLiteral) {
             let Some(&lambda_tok) = arg_tokens.get(lambda_idx) else {
                 continue;
@@ -222,6 +243,8 @@ fn collect_declarations_in_region(
             }
             if let Some(elems) = split_lambda_literal(source, lambda_tok)
                 && let Some(body_span) = elems.body
+                && body_span.start() <= scan.cursor
+                && scan.cursor <= body_span.end()
             {
                 collect_declarations_in_region(scan, body_span, depth + 1, found);
             }
@@ -399,6 +422,26 @@ mod tests {
         assert_eq!(locs.len(), 1, "{locs:?}");
         // `global x` is on line 1 (inside the lambda body).
         assert_eq!(locs[0].start_line, 1);
+    }
+
+    /// Codex review of #954's follow-up: an `apply` body runs in a *fresh*
+    /// call frame, so a `global x` declared inside it must not leak out as a
+    /// visible declaration for an unrelated `$x` reference sitting outside
+    /// the lambda in the enclosing proc.
+    #[test]
+    fn global_declared_inside_apply_lambda_body_is_not_visible_outside_it() {
+        let src = "proc p {} {\n\
+                   apply {{} {global x}}\n\
+                   puts $x\n\
+                   }\n";
+        let analysis = analyse(src);
+        let (l, c) = pos_of(src, "$x", 1);
+        let locs = declaration(src, l, c + 1, "tcl8.6", &analysis, &reg());
+        assert!(
+            !locs.iter().any(|loc| loc.start_line == 1),
+            "the lambda's `global x` (line 1) must not resolve as `p`'s own \
+             declaration site for the unrelated `$x` on line 2; got {locs:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/folding.rs
+++ b/rust/tcl-lsp-core/src/folding.rs
@@ -39,6 +39,7 @@ use std::collections::BTreeSet;
 use rustc_hash::FxHashSet;
 
 use tcl_compiler::analyser::{Analyser, Scope, ScopeKind};
+use tcl_compiler::lambda_literal::split_lambda_literal;
 use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
 use tcl_lexer::{Lexer, LineIndex, TokenType};
 use tcl_registry::{ArgRole, CommandRegistry};
@@ -434,6 +435,49 @@ fn collect_body_folds(
                 ctx,
             );
         }
+
+        // `apply {argList body ?ns?} …` (and any future command sharing the
+        // shape) — fold the whole lambda literal as one region, but recurse
+        // only into the real body element (`split_lambda_literal`, issue
+        // #954): the argument-list element is a plain word/list, not code,
+        // so re-segmenting the whole literal as a script previously mis-read
+        // the params word as a command name and never found the real body's
+        // own nested folds.
+        for idx in
+            ctx.registry
+                .arg_indices_for_role(cmd.name(), &args_borrow, ArgRole::LambdaLiteral)
+        {
+            let arg_tokens = cmd.arg_tokens();
+            let Some(&lambda_tok) = arg_tokens.get(idx) else {
+                continue;
+            };
+            if !matches!(lambda_tok.kind, TokenType::Str) {
+                continue;
+            }
+            emit_body_span_fold(
+                lambda_tok.span,
+                ctx.original_source,
+                ctx.line_index,
+                ctx.seen,
+                ctx.ranges,
+            );
+            let Some(elems) = split_lambda_literal(ctx.original_source, lambda_tok) else {
+                continue;
+            };
+            let Some(body_span) = elems.body else {
+                continue;
+            };
+            let (bstart, bend) = (body_span.start() as usize, body_span.end() as usize);
+            if bend <= bstart {
+                continue;
+            }
+            let Some(inner) = ctx.original_source.get(bstart..bend) else {
+                continue;
+            };
+            // The body runs in a fresh, non-OO frame (`apply`'s own scope),
+            // never the enclosing definer's grammar.
+            collect_body_folds(inner, body_span.start(), depth + 1, None, ctx);
+        }
     }
 }
 
@@ -701,6 +745,30 @@ mod tests {
         let source = "while {1} {\n    puts \"loop\"\n    puts \"again\"\n}\n";
         let ranges = folding_ranges_default(source, "tcl8.6");
         assert!(!fold_lines(&ranges, FoldKind::Region).is_empty());
+    }
+
+    /// Issue #954: `apply`'s lambda-literal argument is
+    /// `ArgRole::LambdaLiteral`, not `Body` — re-segmenting the whole
+    /// `{argList} {body}` blob as a script (the old generic-`Body` path)
+    /// misread the parameter word as a command name, so a nested foldable
+    /// region *inside* the real body (here, the `if`) was never found. A
+    /// fold must cover the whole lambda literal (line 0) and the walk must
+    /// also recurse far enough to find the `if` block's own nested fold.
+    #[test]
+    fn apply_lambda_body_folds_and_recurses_into_nested_blocks() {
+        let source = "apply {dir {\n    if {1} {\n        puts \"yes\"\n        puts \"again\"\n    }\n}} /tmp\n";
+        let ranges = folding_ranges_default(source, "tcl8.6");
+        let regions = fold_lines(&ranges, FoldKind::Region);
+        assert!(
+            regions.iter().any(|&(s, _)| s == 0),
+            "expected a region fold for the whole lambda literal at line 0, got {regions:?}"
+        );
+        assert!(
+            regions.iter().any(|&(s, _)| s == 1),
+            "expected the `if` block nested inside the real body to fold too \
+             (proves recursion reached the actual body, not a params-as-head \
+             misparse), got {regions:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/formatting/engine.rs
+++ b/rust/tcl-lsp-core/src/formatting/engine.rs
@@ -27,6 +27,7 @@
 //! The entry point is [`format_tcl`]; everything else is the
 //! private machinery [`format_tcl`] drives.
 
+use tcl_compiler::lambda_literal::split_lambda_literal;
 use tcl_lexer::{Lexer, SourceMap, Token, TokenType};
 use tcl_registry::{ArgRole, CommandRegistry, Traits};
 
@@ -44,6 +45,12 @@ enum ArgKind {
     Keyword,
     /// Parameter list — normalise internal whitespace.
     ParamList,
+    /// `ArgRole::LambdaLiteral` argument (`apply`'s `{argList body ?ns?}`
+    /// shape) — the parameter-list element is normalised and the body
+    /// element recursively formatted, then reassembled; never fed to
+    /// `format_body` as a whole (that would misread the parameter word as a
+    /// command name — issue #954).
+    LambdaLiteral,
 }
 
 /// A single argument to a command.
@@ -56,6 +63,10 @@ struct CommandArg {
     is_braced: bool,
     /// The argument was `"`-quoted.
     is_quoted: bool,
+    /// The recursively reformatted script content of a `Body` argument, or
+    /// (for `LambdaLiteral`) of just its body *element* — the parameter-list
+    /// element is never fed here, only normalised at reconstruction time
+    /// (`render_lambda_literal_arg`).
     formatted_body: Option<String>,
 }
 
@@ -347,10 +358,17 @@ fn identify_body_args(cmd: &mut ParsedCommand, registry: &CommandRegistry) {
     let refs: Vec<&str> = arg_texts.iter().map(String::as_str).collect();
     let body_indices = registry.arg_indices_for_role(&name, &refs, ArgRole::Body);
     let param_indices = registry.arg_indices_for_role(&name, &refs, ArgRole::ParamList);
+    let lambda_indices = registry.arg_indices_for_role(&name, &refs, ArgRole::LambdaLiteral);
     for idx in body_indices {
         let actual = idx + 1; // +1 for the command-name slot.
         if actual < cmd.args.len() && cmd.args[actual].is_braced {
             cmd.args[actual].kind = ArgKind::Body;
+        }
+    }
+    for idx in lambda_indices {
+        let actual = idx + 1; // +1 for the command-name slot.
+        if actual < cmd.args.len() && cmd.args[actual].is_braced {
+            cmd.args[actual].kind = ArgKind::LambdaLiteral;
         }
     }
 
@@ -997,6 +1015,56 @@ fn append_body_no_space(
     }
 }
 
+/// Reassemble an `ArgKind::LambdaLiteral` argument: its parameter-list
+/// element (normalised, not code) and its body element (`arg.formatted_body`
+/// — already recursively formatted by the caller from just the body span,
+/// never the whole lambda literal, so the parameter word is never misread as
+/// a command name), plus an optional namespace element, wrapped back in the
+/// outer `{}`. Falls back to the original literal verbatim if the source
+/// can no longer be split (should not happen once `identify_body_args` and
+/// this function agree, but a stale token must not panic).
+fn render_lambda_literal_arg(
+    sm: &SourceMap,
+    arg: &CommandArg,
+    config: &FormatterConfig,
+    indent: &str,
+    current_line_len: usize,
+    never_inline: bool,
+) -> String {
+    let source = sm.source();
+    let fallback = || format!("{{{}}}", arg.text);
+    let Some(&tok) = arg.tokens.first() else {
+        return fallback();
+    };
+    let Some(elems) = split_lambda_literal(source, tok) else {
+        return fallback();
+    };
+    let Some(formatted_body) = arg.formatted_body.as_deref() else {
+        return fallback();
+    };
+    let params_text = source
+        .get(elems.params.start() as usize..elems.params.end() as usize)
+        .unwrap_or_default();
+    let mut body_parts: Vec<String> = Vec::new();
+    append_body_no_space(
+        &mut body_parts,
+        formatted_body,
+        config,
+        indent,
+        current_line_len,
+        never_inline,
+    );
+    let params_rendered = normalise_param_list(params_text);
+    let body_rendered = body_parts.concat();
+    match elems
+        .namespace
+        .and_then(|ns| source.get(ns.start() as usize..ns.end() as usize))
+    {
+        Some(ns) => format!("{{{params_rendered} {body_rendered} {ns}}}"),
+        None => format!("{{{params_rendered} {body_rendered}}}"),
+    }
+}
+
 /// Append a plain word argument (with optional expression
 /// wrapping).  Returns `false` when nothing was emitted (an
 /// all-continuation artifact), so the caller leaves the brace
@@ -1110,6 +1178,19 @@ fn reconstruct_command(
                     current_line_len,
                     never_inline,
                 );
+                in_brace_chain = true;
+            }
+            ArgKind::LambdaLiteral if arg.formatted_body.is_some() => {
+                let current_line_len = indent.len() + parts.concat().len();
+                maybe_space(&mut parts, in_brace_chain, config.space_between_braces);
+                parts.push(render_lambda_literal_arg(
+                    sm,
+                    arg,
+                    config,
+                    indent,
+                    current_line_len,
+                    never_inline,
+                ));
                 in_brace_chain = true;
             }
             ArgKind::ParamList => {
@@ -1296,6 +1377,21 @@ pub(crate) fn format_body(
                 } else {
                     format_body(&body_text, config, registry, inner_level)
                 };
+                commands[i].args[a].formatted_body = Some(formatted);
+            } else if commands[i].args[a].kind == ArgKind::LambdaLiteral
+                && commands[i].args[a].is_braced
+                && let Some(&tok) = commands[i].args[a].tokens.first()
+                && let Some(elems) = split_lambda_literal(source, tok)
+                && let Some(body_span) = elems.body
+            {
+                // Format only the real body element — `render_lambda_literal_arg`
+                // re-derives the parameter list / namespace elements from the
+                // original source at reconstruction time and reassembles them.
+                let body_text = source
+                    .get(body_span.start() as usize..body_span.end() as usize)
+                    .unwrap_or_default()
+                    .to_owned();
+                let formatted = format_body(&body_text, config, registry, inner_level);
                 commands[i].args[a].formatted_body = Some(formatted);
             }
         }
@@ -1781,6 +1877,32 @@ mod tests {
     #[test]
     fn quoted_string_preserved() {
         check("puts \"hello $name\"\n", "puts \"hello $name\"\n");
+    }
+
+    /// Issue #954: `apply`'s lambda-literal argument (`ArgRole::LambdaLiteral`,
+    /// not `Body`) must have its real body element reformatted — not the
+    /// whole `{argList} {body}` blob re-segmented as one script (which
+    /// misreads the parameter word as a command name and never reaches the
+    /// real body). The parameter list is normalised the same way a `proc`'s
+    /// is (bare `dir` → braced `{dir}`), matching `param_list_normalised`.
+    #[test]
+    fn apply_lambda_body_indents_and_params_normalise() {
+        check(
+            "apply {dir {\nputs    $dir\nset x 1\n}} /tmp\n",
+            "apply {{dir} {\n    puts $dir\n    set x 1\n}} /tmp\n",
+        );
+    }
+
+    /// The optional namespace element (lambda literal position 2) survives
+    /// reassembly untouched. A short single-command body inlines (matching
+    /// ordinary body formatting), so this also confirms the inline path
+    /// reassembles the namespace element correctly.
+    #[test]
+    fn apply_lambda_namespace_element_preserved() {
+        check(
+            "apply {dir {\nputs    $dir\n} ::foo} /tmp\n",
+            "apply {{dir} { puts $dir } ::foo} /tmp\n",
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/formatting/engine.rs
+++ b/rust/tcl-lsp-core/src/formatting/engine.rs
@@ -27,7 +27,7 @@
 //! The entry point is [`format_tcl`]; everything else is the
 //! private machinery [`format_tcl`] drives.
 
-use tcl_compiler::lambda_literal::split_lambda_literal;
+use tcl_compiler::lambda_literal::split_lambda_literal_decoded;
 use tcl_lexer::{Lexer, SourceMap, Token, TokenType};
 use tcl_registry::{ArgRole, CommandRegistry, Traits};
 
@@ -1017,12 +1017,23 @@ fn append_body_no_space(
 
 /// Reassemble an `ArgKind::LambdaLiteral` argument: its parameter-list
 /// element (normalised, not code) and its body element (`arg.formatted_body`
-/// — already recursively formatted by the caller from just the body span,
-/// never the whole lambda literal, so the parameter word is never misread as
-/// a command name), plus an optional namespace element, wrapped back in the
-/// outer `{}`. Falls back to the original literal verbatim if the source
-/// can no longer be split (should not happen once `identify_body_args` and
-/// this function agree, but a stale token must not panic).
+/// — already recursively formatted by the caller from just the *decoded*
+/// body span, never the whole lambda literal, so the parameter word is
+/// never misread as a command name), plus an optional namespace element,
+/// wrapped back in the outer `{}`. Falls back to the original literal
+/// verbatim if the source can no longer be split (should not happen once
+/// `identify_body_args` and this function agree, but a stale token must not
+/// panic).
+///
+/// The parameter-list and namespace elements are decoded (backslash escapes
+/// collapsed for a bare/quoted element — [`split_lambda_literal_decoded`])
+/// before use, not pasted through as raw source spelling: a non-literal
+/// element's escapes would otherwise survive reformatting and change what it
+/// means (codex review of #954's follow-up). The namespace is re-quoted with
+/// [`tcl_syntax::list::list_element`] on reassembly rather than always left
+/// bare, so an element that needs quoting (e.g. an escaped space) still
+/// round-trips safely; `normalise_param_list` already unconditionally
+/// brace-wraps the parameter list, so no further quoting is needed there.
 fn render_lambda_literal_arg(
     sm: &SourceMap,
     arg: &CommandArg,
@@ -1036,15 +1047,12 @@ fn render_lambda_literal_arg(
     let Some(&tok) = arg.tokens.first() else {
         return fallback();
     };
-    let Some(elems) = split_lambda_literal(source, tok) else {
+    let Some(elems) = split_lambda_literal_decoded(source, tok) else {
         return fallback();
     };
     let Some(formatted_body) = arg.formatted_body.as_deref() else {
         return fallback();
     };
-    let params_text = source
-        .get(elems.params.start() as usize..elems.params.end() as usize)
-        .unwrap_or_default();
     let mut body_parts: Vec<String> = Vec::new();
     append_body_no_space(
         &mut body_parts,
@@ -1054,13 +1062,13 @@ fn render_lambda_literal_arg(
         current_line_len,
         never_inline,
     );
-    let params_rendered = normalise_param_list(params_text);
+    let params_rendered = normalise_param_list(&elems.params);
     let body_rendered = body_parts.concat();
-    match elems
-        .namespace
-        .and_then(|ns| source.get(ns.start() as usize..ns.end() as usize))
-    {
-        Some(ns) => format!("{{{params_rendered} {body_rendered} {ns}}}"),
+    match elems.namespace.as_deref() {
+        Some(ns) => {
+            let ns_rendered = tcl_syntax::list::list_element(ns);
+            format!("{{{params_rendered} {body_rendered} {ns_rendered}}}")
+        }
         None => format!("{{{params_rendered} {body_rendered}}}"),
     }
 }
@@ -1381,16 +1389,18 @@ pub(crate) fn format_body(
             } else if commands[i].args[a].kind == ArgKind::LambdaLiteral
                 && commands[i].args[a].is_braced
                 && let Some(&tok) = commands[i].args[a].tokens.first()
-                && let Some(elems) = split_lambda_literal(source, tok)
-                && let Some(body_span) = elems.body
+                && let Some(elems) = split_lambda_literal_decoded(source, tok)
+                && let Some(body_text) = elems.body
             {
-                // Format only the real body element — `render_lambda_literal_arg`
-                // re-derives the parameter list / namespace elements from the
-                // original source at reconstruction time and reassembles them.
-                let body_text = source
-                    .get(body_span.start() as usize..body_span.end() as usize)
-                    .unwrap_or_default()
-                    .to_owned();
+                // Format only the real, *decoded* body element —
+                // `render_lambda_literal_arg` re-derives the parameter list /
+                // namespace elements from the original source at
+                // reconstruction time and reassembles them. Decoding first
+                // (rather than reformatting the raw source spelling) matters
+                // for a non-literal (bare/quoted) body: its backslash escapes
+                // must be collapsed before the result is parsed as a script,
+                // exactly as Tcl's own list-then-script evaluation would
+                // (codex review of #954's follow-up).
                 let formatted = format_body(&body_text, config, registry, inner_level);
                 commands[i].args[a].formatted_body = Some(formatted);
             }
@@ -1903,6 +1913,15 @@ mod tests {
             "apply {dir {\nputs    $dir\n} ::foo} /tmp\n",
             "apply {{dir} { puts $dir } ::foo} /tmp\n",
         );
+    }
+
+    /// Codex review of #954's follow-up: a bare body element's backslash
+    /// escape must be decoded before reformatting, not reformatted from its
+    /// raw source spelling — `puts\ hi`'s real runtime body is the two-word
+    /// command `puts hi`, not one word containing a literal backslash.
+    #[test]
+    fn apply_lambda_body_with_backslash_escape_decodes() {
+        check(r"apply {{} puts\ hi}", "apply {{} { puts hi }}\n");
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/minify.rs
+++ b/rust/tcl-lsp-core/src/minify.rs
@@ -92,6 +92,7 @@ use tcl_compiler::analyses::{ConstValue, LatticeValue};
 use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
 use tcl_compiler::expr_ast::render_expr;
 use tcl_compiler::ir::Statement;
+use tcl_compiler::lambda_literal::split_lambda_literal;
 use tcl_compiler::ssa::Version;
 use tcl_compiler::taint::{TaintColour, TaintLattice};
 use tcl_compiler::{BinOp, ExprNode, UnaryOp, parse_expr};
@@ -2425,6 +2426,7 @@ fn render_command(
     let post_refs: Vec<&str> = post.iter().map(String::as_str).collect();
 
     let body_indices = role_indices(registry, &cmd_name, &post_refs, ArgRole::Body);
+    let lambda_indices = role_indices(registry, &cmd_name, &post_refs, ArgRole::LambdaLiteral);
     let expr_indices = role_indices(registry, &cmd_name, &post_refs, ArgRole::Expr);
     let is_case_list = cmd_name == "switch" && is_switch_case_list_form(&post_refs);
 
@@ -2439,6 +2441,8 @@ fn render_command(
                 minify_body(inner, dialect, registry)
             };
             out.push(format!("{{{minified}}}"));
+        } else if lambda_indices.contains(&i) && single_braced {
+            out.push(minify_lambda_literal(sm, arg.tokens[0], dialect, registry));
         } else if expr_indices.contains(&i) && single_braced {
             let inner = sm.token_text(arg.tokens[0]);
             out.push(format!("{{{}}}", compress_expr(inner, dialect, registry)));
@@ -2447,6 +2451,46 @@ fn render_command(
         }
     }
     out
+}
+
+/// Minify an `ArgRole::LambdaLiteral` argument (`apply`'s `{argList body
+/// ?ns?}` shape): only the body element is recursively minified as a
+/// script; the parameter list and optional namespace elements are copied
+/// verbatim, exactly as `render_command` already leaves a plain `proc`
+/// parameter list untouched (`ArgRole::ParamList` isn't itself minified
+/// anywhere in this file — issue #954 only needs the body reached
+/// correctly, not new parameter-list compaction). Re-segmenting the whole
+/// literal as a script (the pre-`LambdaLiteral`-role behaviour) misread the
+/// parameter word as a command name and never reached the real body at all.
+fn minify_lambda_literal(
+    sm: &SourceMap,
+    tok: Token,
+    dialect: &str,
+    registry: &CommandRegistry,
+) -> String {
+    let source = sm.source();
+    let fallback = || format!("{{{}}}", sm.token_text(tok));
+    let Some(elems) = split_lambda_literal(source, tok) else {
+        return fallback();
+    };
+    let Some(params_text) = source.get(elems.params.start() as usize..elems.params.end() as usize)
+    else {
+        return fallback();
+    };
+    let Some(body_span) = elems.body else {
+        return fallback();
+    };
+    let Some(body_text) = source.get(body_span.start() as usize..body_span.end() as usize) else {
+        return fallback();
+    };
+    let minified_body = minify_body(body_text, dialect, registry);
+    match elems
+        .namespace
+        .and_then(|ns| source.get(ns.start() as usize..ns.end() as usize))
+    {
+        Some(ns) => format!("{{{params_text} {{{minified_body}}} {ns}}}"),
+        None => format!("{{{params_text} {{{minified_body}}}}}"),
+    }
 }
 
 /// Registry role indices, offset by 1 for the command-name slot.
@@ -3570,5 +3614,20 @@ mod tests {
     #[test]
     fn empty_source_minifies_to_empty() {
         check("\n\n# only a comment\n", "");
+    }
+
+    /// Issue #954: `apply`'s lambda-literal argument (`ArgRole::LambdaLiteral`,
+    /// not `Body`) must have its real body element minified — not the whole
+    /// `{argList} {body}` blob re-segmented as one script (which misreads
+    /// the parameter word as a command name and never reaches the real
+    /// body, leaving comments / extra whitespace inside it untouched). The
+    /// parameter-list element itself stays verbatim, matching how a plain
+    /// `proc` parameter list is never specially minified either.
+    #[test]
+    fn apply_lambda_body_minifies() {
+        check(
+            "apply {dir {\n    # a comment\n    puts    $dir\n}} /tmp\n",
+            "apply {dir {puts $dir}} /tmp",
+        );
     }
 }

--- a/rust/tcl-lsp-core/src/minify.rs
+++ b/rust/tcl-lsp-core/src/minify.rs
@@ -92,7 +92,7 @@ use tcl_compiler::analyses::{ConstValue, LatticeValue};
 use tcl_compiler::compilation_unit::{CompilationUnit, FunctionUnit};
 use tcl_compiler::expr_ast::render_expr;
 use tcl_compiler::ir::Statement;
-use tcl_compiler::lambda_literal::split_lambda_literal;
+use tcl_compiler::lambda_literal::split_lambda_literal_decoded;
 use tcl_compiler::ssa::Version;
 use tcl_compiler::taint::{TaintColour, TaintLattice};
 use tcl_compiler::{BinOp, ExprNode, UnaryOp, parse_expr};
@@ -2456,12 +2456,21 @@ fn render_command(
 /// Minify an `ArgRole::LambdaLiteral` argument (`apply`'s `{argList body
 /// ?ns?}` shape): only the body element is recursively minified as a
 /// script; the parameter list and optional namespace elements are copied
-/// verbatim, exactly as `render_command` already leaves a plain `proc`
-/// parameter list untouched (`ArgRole::ParamList` isn't itself minified
-/// anywhere in this file — issue #954 only needs the body reached
-/// correctly, not new parameter-list compaction). Re-segmenting the whole
-/// literal as a script (the pre-`LambdaLiteral`-role behaviour) misread the
-/// parameter word as a command name and never reached the real body at all.
+/// through untouched (`ArgRole::ParamList` isn't itself minified anywhere in
+/// this file — issue #954 only needs the body reached correctly, not new
+/// parameter-list compaction). Re-segmenting the whole literal as a script
+/// (the pre-`LambdaLiteral`-role behaviour) misread the parameter word as a
+/// command name and never reached the real body at all.
+///
+/// Each element is decoded (backslash escapes collapsed for a bare/quoted
+/// element — [`split_lambda_literal_decoded`]) before use and re-quoted with
+/// [`tcl_syntax::list::list_element`] on reassembly, rather than pasted back
+/// as raw source spelling wrapped in a bare `{}`: a non-literal body's
+/// backslash escapes would otherwise survive into the "minified" text and
+/// change what it runs (codex review of #954's follow-up — `apply {{}
+/// puts\ hi}`'s real body is `puts hi`, not `puts\ hi`), and a multi-word
+/// parameter list (`apply {{x y} …}`) would otherwise lose the braces that
+/// group it into one list element.
 fn minify_lambda_literal(
     sm: &SourceMap,
     tok: Token,
@@ -2470,27 +2479,21 @@ fn minify_lambda_literal(
 ) -> String {
     let source = sm.source();
     let fallback = || format!("{{{}}}", sm.token_text(tok));
-    let Some(elems) = split_lambda_literal(source, tok) else {
+    let Some(elems) = split_lambda_literal_decoded(source, tok) else {
         return fallback();
     };
-    let Some(params_text) = source.get(elems.params.start() as usize..elems.params.end() as usize)
-    else {
+    let Some(body) = elems.body.as_deref() else {
         return fallback();
     };
-    let Some(body_span) = elems.body else {
-        return fallback();
-    };
-    let Some(body_text) = source.get(body_span.start() as usize..body_span.end() as usize) else {
-        return fallback();
-    };
-    let minified_body = minify_body(body_text, dialect, registry);
-    match elems
-        .namespace
-        .and_then(|ns| source.get(ns.start() as usize..ns.end() as usize))
-    {
-        Some(ns) => format!("{{{params_text} {{{minified_body}}} {ns}}}"),
-        None => format!("{{{params_text} {{{minified_body}}}}}"),
+    let minified_body = minify_body(body, dialect, registry);
+    let mut parts = vec![
+        tcl_syntax::list::list_element(&elems.params),
+        tcl_syntax::list::list_element(&minified_body),
+    ];
+    if let Some(ns) = elems.namespace.as_deref() {
+        parts.push(tcl_syntax::list::list_element(ns));
     }
+    format!("{{{}}}", parts.join(" "))
 }
 
 /// Registry role indices, offset by 1 for the command-name slot.
@@ -3628,6 +3631,27 @@ mod tests {
         check(
             "apply {dir {\n    # a comment\n    puts    $dir\n}} /tmp\n",
             "apply {dir {puts $dir}} /tmp",
+        );
+    }
+
+    /// Codex review of #954's follow-up: a bare body element's backslash
+    /// escape must be decoded before minification, not pasted through raw —
+    /// `puts\ hi`'s real runtime body is the two-word command `puts hi`, and
+    /// the minified output must preserve that (not keep the backslash, which
+    /// would change what `apply` actually runs).
+    #[test]
+    fn apply_lambda_body_with_backslash_escape_decodes() {
+        check(r"apply {{} puts\ hi}", "apply {{} {puts hi}}");
+    }
+
+    /// A multi-word parameter list is itself a *nested* list element
+    /// (`{x y}`) — reassembling it without its own braces would collapse it
+    /// into separate top-level elements and corrupt the lambda's arity.
+    #[test]
+    fn apply_lambda_multi_word_param_list_keeps_its_braces() {
+        check(
+            "apply {{x y} {\n    return [expr {$x + $y}]\n}} 1 2",
+            "apply {{x y} {return [expr {$x+$y}]}} 1 2",
         );
     }
 }

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1303,6 +1303,7 @@ fn special_arg_kinds(
     extra_var_write: &FxHashMap<String, Vec<u32>>,
     extra_var_read: &FxHashMap<String, Vec<u32>>,
     extra_command: &FxHashMap<String, Vec<u32>>,
+    deferred_role: bool,
 ) -> FxHashMap<u32, ArgOverride> {
     let mut overrides = FxHashMap::default();
 
@@ -1362,7 +1363,7 @@ fn special_arg_kinds(
     insert_enum_value_overrides(seg, registry, head, dialect, &mut overrides);
     insert_oo_define_keyword_overrides(seg, registry, &mut overrides);
     insert_definer_class_name_override(seg, registry, &mut overrides);
-    insert_lambda_literal_overrides(seg, registry, head, &mut overrides);
+    insert_lambda_literal_overrides(seg, registry, head, deferred_role, &mut overrides);
     insert_case_list_override(seg, registry, &mut overrides);
     insert_role_overrides(seg, registry, head, arg_texts, &mut overrides);
     insert_oo_body_overrides(seg, oo_grammar, arg_texts, &mut overrides);
@@ -2810,10 +2811,23 @@ fn insert_oo_define_keyword_overrides(
 ///   spec, the token at `argv[K + 2]` (shifted by one for `list` itself) is
 ///   the lambda literal. A dynamic `list` argument (`$var`, `[cmd]`) can't be
 ///   resolved statically and is left alone.
+///
+/// The list-quoted case is additionally gated on `deferred_role`: `list`
+/// itself never invokes anything — it only ever returns a value — so
+/// `[list apply {…} $x]` builds a real deferred invocation only when
+/// *its own* enclosing argument slot is one that's later invoked/sourced
+/// (`Body` / `LambdaLiteral` / `CommandPrefix`), e.g. `package ifneeded`'s
+/// script argument. Plain data such as `set data [list apply {x {puts $x}}
+/// value]` must not paint `x`/`puts`/`apply` as executable (codex review of
+/// #954's follow-up) — `deferred_role` carries that enclosing-role check in
+/// from [`collect_script`], computed once per `[…]` substitution. The direct
+/// case needs no such gate: writing `apply {…}` literally *always* invokes
+/// `apply` when reached, regardless of what its caller does with the result.
 fn insert_lambda_literal_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
     registry: &CommandRegistry,
     head: &str,
+    deferred_role: bool,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
     let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
@@ -2833,6 +2847,10 @@ fn insert_lambda_literal_overrides(
         for idx in direct {
             mark(idx, overrides);
         }
+        return;
+    }
+
+    if !deferred_role {
         return;
     }
 
@@ -4092,6 +4110,7 @@ fn collect_case_list(
                     u32::try_from(bstart).unwrap_or(0),
                     entries,
                     depth + 1,
+                    false,
                 );
             } else if let Some(kind) = classify_arg_token(btok, full_source) {
                 push_token(line_index, full_source, btok, kind, 0, entries);
@@ -4149,6 +4168,7 @@ fn collect_lambda_literal(ctx: ScriptCtx<'_>, tok: Token, entries: &mut Vec<Entr
                 u32::try_from(bstart).unwrap_or(0),
                 entries,
                 depth + 1,
+                false,
             );
         } else if let Some(kind) = classify_arg_token(*word_tok, full_source) {
             push_token(line_index, full_source, *word_tok, kind, 0, entries);
@@ -4438,12 +4458,25 @@ fn emit_command_head(
 /// (`ArgRole::Expr`), and `[…]` command substitutions.  Token spans are
 /// already absolute (the segmenter shifts them by `base_offset`), so positions
 /// and text are resolved against `full_source` + `line_index`.
+///
+/// `deferred_role` is `true` only when this call's *entire* `text` is the
+/// content of a `[…]` substitution whose own enclosing argument slot (in the
+/// command containing it) carries `Body` / `LambdaLiteral` / `CommandPrefix`
+/// — i.e. a position whose value is later invoked or sourced, not merely
+/// computed. It gates [`insert_lambda_literal_overrides`]'s list-quoted-lambda
+/// recognition (codex review of #954's follow-up) and is otherwise `false`:
+/// every other recursion (the top-level script, a body, a lambda body, a
+/// case-list clause, an expression) processes source that is *itself*
+/// executed code, not a value that might or might not be invoked later, so
+/// list-quoted detection inside it is decided fresh at the next `[…]` hop
+/// rather than inherited.
 fn collect_script(
     ctx: ScriptCtx<'_>,
     text: &str,
     base_offset: u32,
     entries: &mut Vec<Entry>,
     depth: u32,
+    deferred_role: bool,
 ) {
     if depth > MAX_TOKEN_RECURSION {
         return;
@@ -4524,6 +4557,7 @@ fn collect_script(
             ctx.extra_var_write,
             ctx.extra_var_read,
             ctx.extra_command,
+            deferred_role,
         );
         // `my method …` inside a class body resolves against the enclosing
         // class's MRO (the most common `TclOO` dispatch form).
@@ -4569,6 +4603,9 @@ fn collect_script(
             ..ctx
         };
 
+        let deferred_role_starts =
+            deferred_role_arg_starts(&seg, registry, resolved_head, &arg_texts);
+
         for tok in &seg.all_tokens {
             // Skip every token that falls inside a *static* head word — not
             // just the exact head token.  Such a head is one word that
@@ -4593,11 +4630,39 @@ fn collect_script(
                 body_ctx,
                 *tok,
                 overrides.get(&tok.span.start()),
+                deferred_role_starts.contains(&tok.span.start()),
                 entries,
                 depth,
             );
         }
     }
+}
+
+/// This command's own argument slots whose registry role means "the value
+/// here is later invoked/sourced as a command" — `Body` / `LambdaLiteral` /
+/// `CommandPrefix` — as the set of their representative tokens' start
+/// offsets. A `[…]` substitution occupying one of these slots recurses with
+/// `deferred_role = true` (see [`collect_script`]) so list-quoted-lambda
+/// detection ([`insert_lambda_literal_overrides`]) only fires for a
+/// genuinely deferred invocation (`package ifneeded … [list apply {…}
+/// $dir]`), never for inert data (`set x [list apply {…} value]`) — codex
+/// review of #954's follow-up.
+fn deferred_role_arg_starts(
+    seg: &tcl_compiler::segmenter::SegmentedCommand,
+    registry: &CommandRegistry,
+    head: &str,
+    arg_texts: &[&str],
+) -> FxHashSet<u32> {
+    [
+        tcl_registry::ArgRole::Body,
+        tcl_registry::ArgRole::LambdaLiteral,
+        tcl_registry::ArgRole::CommandPrefix,
+    ]
+    .into_iter()
+    .flat_map(|role| registry.arg_indices_for_role(head, arg_texts, role))
+    .filter_map(|i| seg.argv.get(i + 1))
+    .map(|t| t.span.start())
+    .collect()
 }
 
 /// Emit semantic-token entries for a single non-head argument token,
@@ -4637,6 +4702,7 @@ fn emit_arg_token(
     body_ctx: ScriptCtx<'_>,
     tok: Token,
     override_kind: Option<&ArgOverride>,
+    deferred_role: bool,
     entries: &mut Vec<Entry>,
     depth: u32,
 ) {
@@ -4709,6 +4775,7 @@ fn emit_arg_token(
                     u32::try_from(cstart).unwrap_or(0),
                     entries,
                     depth + 1,
+                    false,
                 );
             } else if let Some(kind) = classify_arg_token(*tok, full_source) {
                 push_token(line_index, full_source, *tok, kind, 0, entries);
@@ -4735,14 +4802,24 @@ fn emit_arg_token(
             | ArgOverride::ClassNameDef
             | ArgOverride::ClassNameRef,
         ) => {}
-        None => emit_default_arg_token(plain_ctx, *tok, entries, depth),
+        None => emit_default_arg_token(plain_ctx, *tok, entries, depth, deferred_role),
     }
 }
 
 /// Handle an argument token with no [`ArgOverride`]: recurse into a `[…]`
 /// command substitution, or classify a plain word (splitting backslash
 /// escapes out of string literals).  Extracted from [`emit_arg_token`].
-fn emit_default_arg_token(ctx: ScriptCtx<'_>, tok: Token, entries: &mut Vec<Entry>, depth: u32) {
+///
+/// `deferred_role` is `tok`'s own [`collect_script`]-computed deferred-role
+/// flag (see there) — threaded through unchanged so the `[…]` recursion below
+/// carries it into the substitution's content.
+fn emit_default_arg_token(
+    ctx: ScriptCtx<'_>,
+    tok: Token,
+    entries: &mut Vec<Entry>,
+    depth: u32,
+    deferred_role: bool,
+) {
     let full_source = ctx.full_source;
     let line_index = ctx.line_index;
     if matches!(tok.kind, TokenType::Cmd) {
@@ -4759,6 +4836,7 @@ fn emit_default_arg_token(ctx: ScriptCtx<'_>, tok: Token, entries: &mut Vec<Entr
                 u32::try_from(cstart).unwrap_or(0),
                 entries,
                 depth + 1,
+                deferred_role,
             );
         }
     } else if let Some(kind) = classify_arg_token(tok, full_source) {
@@ -4802,6 +4880,7 @@ fn collect_expr(ctx: ScriptCtx<'_>, tok: Token, entries: &mut Vec<Entry>, depth:
                     u32::try_from(abs_start + usize::from(has_open)).unwrap_or(0),
                     entries,
                     depth + 1,
+                    false,
                 );
             }
             E::Number => {
@@ -5346,7 +5425,7 @@ fn collect_entries(
         extra_var_read: &extra_var_read,
         extra_command: &extra_command,
     };
-    collect_script(ctx, source, 0, &mut entries, 0);
+    collect_script(ctx, source, 0, &mut entries, 0, false);
 
     // Comments aren't in the segmenter's command stream
     // (it strips them).  Scan the source for `#` comments
@@ -8112,6 +8191,31 @@ mod tests {
                 TokenKind::Parameter
             ),
             "llength must never be treated as a command-quoting construct"
+        );
+
+        // Codex review of #954's follow-up: a well-formed `[list apply …]`
+        // shape sitting in an *inert* argument slot (here `set`'s value,
+        // which carries no `Body` / `LambdaLiteral` / `CommandPrefix` role)
+        // must not be treated as a deferred invocation — `list` only ever
+        // returns a value here; nothing ever invokes `apply`.
+        let inert_data = "set data [list apply {x {puts $x}} value]\n";
+        assert!(
+            !has_token_kind(inert_data, "tcl", &registry, "x", TokenKind::Parameter),
+            "an inert `[list apply …]` value must not paint its param as a \
+             Parameter; got {:?}",
+            decode_full(inert_data, "tcl", &registry)
+        );
+        assert!(
+            !has_token_kind(inert_data, "tcl", &registry, "puts", TokenKind::Function),
+            "an inert `[list apply …]` value must not recurse into its body \
+             as executable code; got {:?}",
+            decode_full(inert_data, "tcl", &registry)
+        );
+        assert!(
+            !has_token_kind(inert_data, "tcl", &registry, "apply", TokenKind::Function),
+            "an inert `[list apply …]` value's `apply` word must not read as \
+             a call-site reference; got {:?}",
+            decode_full(inert_data, "tcl", &registry)
         );
     }
 

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -1098,9 +1098,13 @@ enum ArgOverride {
     /// parameter the analyser inferred to be a `Command`) → `Function`: the
     /// literal names a command the callee invokes.
     CommandRef,
-    /// The `{params body ?ns?}` lambda literal argument of `apply` — its
-    /// second list element (the body) is re-segmented as a script.
-    ApplyLambda,
+    /// The `{params body ?ns?}` lambda literal argument of a command
+    /// carrying `ArgRole::LambdaLiteral` (`apply` today) — its second list
+    /// element (the body) is re-segmented as a script.  Reached either as
+    /// the call's own argument or, indirectly, through the `[list apply
+    /// {…} $x]` deferred-command idiom — see
+    /// [`insert_lambda_literal_overrides`].
+    LambdaLiteral,
     /// A known subcommand word (arg index 1) → `Keyword` + `defaultLibrary`.
     SubcommandKeyword,
     /// The name argument of a `proc` definition → `Function` + `definition`.
@@ -1358,7 +1362,7 @@ fn special_arg_kinds(
     insert_enum_value_overrides(seg, registry, head, dialect, &mut overrides);
     insert_oo_define_keyword_overrides(seg, registry, &mut overrides);
     insert_definer_class_name_override(seg, registry, &mut overrides);
-    insert_apply_lambda_override(seg, &mut overrides);
+    insert_lambda_literal_overrides(seg, registry, head, &mut overrides);
     insert_case_list_override(seg, registry, &mut overrides);
     insert_role_overrides(seg, registry, head, arg_texts, &mut overrides);
     insert_oo_body_overrides(seg, oo_grammar, arg_texts, &mut overrides);
@@ -2783,25 +2787,99 @@ fn insert_oo_define_keyword_overrides(
     insert_oo_member_overrides(seg, grammar, &first, &member_args, 2, overrides);
 }
 
-/// `apply {params body ?ns?} …` — mark the braced lambda literal so its body
-/// (the second list element) is re-segmented as a script.  Only a braced
-/// literal first argument qualifies; `apply $lambda …` (a variable) is left
-/// alone.  Matches C Tcl, where `apply`'s first argument is a 2- or 3-element
-/// list `{argList body ?namespace?}`.
-fn insert_apply_lambda_override(
+/// `apply {params body ?ns?} …` — mark the braced lambda-literal argument
+/// (`ArgRole::LambdaLiteral`) so its body (the second list element) is
+/// re-segmented as a script.  Only a braced literal argument qualifies;
+/// `apply $lambda …` (a variable) is left alone.  Matches C Tcl, where
+/// `apply`'s first argument is a 2- or 3-element list `{argList body
+/// ?namespace?}`.
+///
+/// Two shapes are recognised, both registry-driven — no command name is
+/// compared anywhere in this function:
+///
+/// - **Direct**: `head` (this segmented command's own, already-resolved
+///   head) carries `ArgRole::LambdaLiteral` at some argument index `K` — the
+///   token at `argv[K + 1]` is the lambda literal.
+/// - **List-quoted**: `head` instead carries `Traits::BUILDS_COMMAND_PREFIX`
+///   (`list`) — the idiomatic way to build a deferred command around a
+///   dynamic value, e.g. a pkgIndex.tcl entry capturing the install
+///   directory: `package ifneeded name ver [list apply {dir {…}} $dir]`
+///   (issue #954). `list`'s own first *argument*, if a literal bareword, is
+///   resolved the same way any other command head is (registry `get`, which
+///   strips a leading `::`); if that resolves to a `LambdaLiteral`-bearing
+///   spec, the token at `argv[K + 2]` (shifted by one for `list` itself) is
+///   the lambda literal. A dynamic `list` argument (`$var`, `[cmd]`) can't be
+///   resolved statically and is left alone.
+fn insert_lambda_literal_overrides(
     seg: &tcl_compiler::segmenter::SegmentedCommand,
+    registry: &CommandRegistry,
+    head: &str,
     overrides: &mut FxHashMap<u32, ArgOverride>,
 ) {
-    if seg.texts[0] != "apply" {
+    let arg_texts: Vec<&str> = seg.texts[1..].iter().map(String::as_str).collect();
+    let mark = |idx: usize, overrides: &mut FxHashMap<u32, ArgOverride>| {
+        if let Some(tok) = seg.argv.get(idx + 1)
+            && matches!(tok.kind, TokenType::Str)
+        {
+            overrides
+                .entry(tok.span.start())
+                .or_insert(ArgOverride::LambdaLiteral);
+        }
+    };
+
+    let direct =
+        registry.arg_indices_for_role(head, &arg_texts, tcl_registry::ArgRole::LambdaLiteral);
+    if !direct.is_empty() {
+        for idx in direct {
+            mark(idx, overrides);
+        }
         return;
     }
-    if let Some(tok) = seg.argv.get(1)
-        && matches!(tok.kind, TokenType::Str)
-    {
-        overrides
-            .entry(tok.span.start())
-            .or_insert(ArgOverride::ApplyLambda);
+
+    if !registry.get(head).is_some_and(|s| {
+        s.traits
+            .contains(tcl_registry::Traits::BUILDS_COMMAND_PREFIX)
+    }) {
+        return;
     }
+    // `list`'s own arg 0 must be a literal, unquoted, single-token bareword
+    // to resolve statically — mirrors the bareword guard
+    // `command_prefix::extract_prefix_head` uses for the same reason.
+    let Some(inner_head_tok) = seg.argv.get(1) else {
+        return;
+    };
+    if !matches!(inner_head_tok.kind, TokenType::Esc)
+        || inner_head_tok.in_quote
+        || seg.single_token_word.get(1) != Some(&true)
+    {
+        return;
+    }
+    let inner_head = seg.texts[1].as_str();
+    let inner_arg_texts: Vec<&str> = seg.texts[2..].iter().map(String::as_str).collect();
+    let inner_roles = registry.arg_indices_for_role(
+        inner_head,
+        &inner_arg_texts,
+        tcl_registry::ArgRole::LambdaLiteral,
+    );
+    if inner_roles.is_empty() {
+        return;
+    }
+    for idx in inner_roles {
+        if let Some(tok) = seg.argv.get(idx + 2)
+            && matches!(tok.kind, TokenType::Str)
+        {
+            overrides
+                .entry(tok.span.start())
+                .or_insert(ArgOverride::LambdaLiteral);
+        }
+    }
+    // The resolved command-name word itself (`apply` / `::apply`) is a real
+    // call-site reference, same as a `CommandPrefix` bareword head — paint it
+    // `Function` rather than leaving it to fall through to a plain string /
+    // namespace-word guess.
+    overrides
+        .entry(inner_head_tok.span.start())
+        .or_insert(ArgOverride::CommandRef);
 }
 
 /// Variable names a command declares / writes (`ArgRole::VarWrite`) →
@@ -4022,14 +4100,16 @@ fn collect_case_list(
     }
 }
 
-/// Recurse the body of an `apply {params body ?ns?}` lambda literal.
+/// Recurse the body of an `ArgRole::LambdaLiteral` `{params body ?ns?}`
+/// lambda literal (`apply`'s shape, reached directly or list-quoted — see
+/// [`insert_lambda_literal_overrides`]).
 ///
 /// The braced lambda is a Tcl list; its second element is the body script
 /// and is re-segmented so its commands / vars / strings tokenise like any
 /// other body.  The first element (the argument list) and an optional third
 /// (the namespace) are emitted with their default classification, so no part
 /// of the lambda is dropped.  Mirrors C Tcl's `apply` lambda shape.
-fn collect_apply_lambda(ctx: ScriptCtx<'_>, tok: Token, entries: &mut Vec<Entry>, depth: u32) {
+fn collect_lambda_literal(ctx: ScriptCtx<'_>, tok: Token, entries: &mut Vec<Entry>, depth: u32) {
     if depth > MAX_TOKEN_RECURSION {
         return;
     }
@@ -4597,8 +4677,8 @@ fn emit_arg_token(
             let emitted = push_regsub_subtokens(line_index, full_source, *tok, entries);
             classify_and_push_if(!emitted, ctx, *tok, entries);
         }
-        Some(ArgOverride::ApplyLambda) => {
-            collect_apply_lambda(ctx, *tok, entries, depth + 1);
+        Some(ArgOverride::LambdaLiteral) => {
+            collect_lambda_literal(ctx, *tok, entries, depth + 1);
         }
         Some(ArgOverride::LoopVarList) => {
             collect_loop_var_list(ctx, *tok, entries);
@@ -7918,6 +7998,135 @@ mod tests {
                 TokenKind::Parameter
             ),
             "a computed arg list must not be a parameter declaration"
+        );
+    }
+
+    /// Issue #954, the reopened follow-up: `apply`'s lambda body is
+    /// reachable indirectly through `[list apply {…} $x]`, the idiomatic way
+    /// to build a deferred command around a dynamic value — most commonly a
+    /// pkgIndex.tcl `package ifneeded name ver [list apply {dir {…}} $dir]`
+    /// entry. TP cases: the reported repro, a namespace-qualified `::apply`,
+    /// and the same idiom under a *different* enclosing Body-role command
+    /// (`after idle`) to prove the fix is registry-driven (any Body-role
+    /// position), not special-cased to `package ifneeded`.
+    #[test]
+    fn list_quoted_apply_lambda_body_recurses() {
+        let registry = reg();
+
+        // The exact reported repro: a pkgIndex.tcl-style entry.
+        let pkgindex = "package ifneeded myPackage 1.0.0 [list apply {dir {\n    source [file join $dir x.tcl]\n}} $dir]\n";
+        assert!(
+            has_token_kind(pkgindex, "tcl", &registry, "source", TokenKind::Keyword),
+            "pkgIndex-style list-quoted apply body: `source` must tokenise; got {:?}",
+            decode_full(pkgindex, "tcl", &registry)
+        );
+        assert!(
+            has_token_kind(pkgindex, "tcl", &registry, "dir", TokenKind::Parameter),
+            "pkgIndex-style list-quoted apply: `dir` param must be a Parameter; got {:?}",
+            decode_full(pkgindex, "tcl", &registry)
+        );
+        // The reconstructed command-name word itself reads as a call-site
+        // reference, same as a literal head — not a plain string.
+        assert!(
+            has_token_kind(pkgindex, "tcl", &registry, "apply", TokenKind::Function),
+            "the list-quoted `apply` word must read as a Function reference; got {:?}",
+            decode_full(pkgindex, "tcl", &registry)
+        );
+
+        // A `::`-qualified spelling resolves the same way (registry `get`
+        // strips a leading `::`, exactly like a direct `::apply {…}` call).
+        let qualified = "package ifneeded p 1.0 [list ::apply {dir {puts $dir}} $dir]\n";
+        assert!(
+            has_token_kind(qualified, "tcl", &registry, "puts", TokenKind::Function),
+            "qualified `::apply` list-quoted body: `puts` must tokenise; got {:?}",
+            decode_full(qualified, "tcl", &registry)
+        );
+
+        // A *different* Body-role enclosing command (`after idle`) proves
+        // the fix isn't specific to `package ifneeded`.
+        let after_idle = "after idle [list apply {{x} {puts $x}} 5]\n";
+        assert!(
+            has_token_kind(after_idle, "tcl", &registry, "puts", TokenKind::Function),
+            "after-idle list-quoted apply body: `puts` must tokenise; got {:?}",
+            decode_full(after_idle, "tcl", &registry)
+        );
+        assert!(
+            has_token_kind(after_idle, "tcl", &registry, "x", TokenKind::Parameter),
+            "after-idle list-quoted apply: `x` param must be a Parameter; got {:?}",
+            decode_full(after_idle, "tcl", &registry)
+        );
+    }
+
+    /// FP guards for the `[list …]`-quoted lambda recognition: a plain data
+    /// list, a list naming an unregistered head, and a dynamic `list` head
+    /// must never be split as if they were an apply lambda.
+    #[test]
+    fn list_quoted_apply_lambda_false_positive_guards() {
+        let registry = reg();
+
+        // Ordinary data list: `list`'s own args stay whatever the default
+        // classifier gives them — none of them becomes a `Parameter`
+        // declaration (which only a recognised lambda-literal split emits).
+        let data_list = "set data [list puts hello world]\n";
+        assert!(
+            !has_token_kind(data_list, "tcl", &registry, "hello", TokenKind::Parameter),
+            "a plain data list must not be split as a lambda literal"
+        );
+
+        // `list`'s first argument names a command that does not carry
+        // `ArgRole::LambdaLiteral` (`puts` is an ordinary command) — its
+        // second argument must not be treated as a lambda body either.
+        assert!(
+            !has_token_kind(
+                "set cb [list puts hello]\n",
+                "tcl",
+                &registry,
+                "hello",
+                TokenKind::Parameter
+            ),
+            "list-quoting a non-lambda-literal command must not split its trailing arg"
+        );
+
+        // An unregistered head: no crash, no spurious split.
+        let unknown = "set cb [list notARealCommand {dir {source x.tcl}} $dir]\n";
+        assert!(
+            !has_token_kind(unknown, "tcl", &registry, "dir", TokenKind::Parameter),
+            "an unresolvable list-quoted head must not be split as a lambda literal"
+        );
+
+        // A dynamic `list` head (`$cmd`) can't be resolved statically.
+        let dynamic_head = "set cb [list $cmd {dir {source x.tcl}} $dir]\n";
+        assert!(
+            !has_token_kind(dynamic_head, "tcl", &registry, "dir", TokenKind::Parameter),
+            "a dynamic list head must not be split as a lambda literal"
+        );
+
+        // `[llength $x]` — a `Cmd` substitution whose head is `llength`, not
+        // `list` (no `BUILDS_COMMAND_PREFIX` trait) — must not be misread.
+        assert!(
+            !has_token_kind(
+                "set n [llength $items]\n",
+                "tcl",
+                &registry,
+                "items",
+                TokenKind::Parameter
+            ),
+            "llength must never be treated as a command-quoting construct"
+        );
+    }
+
+    /// TN regression: `package ifneeded`'s script argument, when a literal
+    /// braced script (no `[list …]` wrapper), is now itself recognised
+    /// generically as `ArgRole::Body` — the sibling half of issue #954 (the
+    /// package.ifneeded script argument carried no role at all before).
+    #[test]
+    fn package_ifneeded_literal_script_recurses_as_body() {
+        let registry = reg();
+        let src = "package ifneeded myPackage 1.0.0 {\n    source [file join $dir x.tcl]\n}\n";
+        assert!(
+            has_token_kind(src, "tcl", &registry, "source", TokenKind::Keyword),
+            "package ifneeded literal script: `source` must tokenise; got {:?}",
+            decode_full(src, "tcl", &registry)
         );
     }
 

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -4128,6 +4128,18 @@ fn collect_case_list(
 /// other body.  The first element (the argument list) and an optional third
 /// (the namespace) are emitted with their default classification, so no part
 /// of the lambda is dropped.  Mirrors C Tcl's `apply` lambda shape.
+///
+/// The body recurses in a *fresh* context (`oo_grammar` / `enclosing_class` /
+/// `scoped_env` all cleared), never the enclosing command's: `apply`'s body
+/// runs in a new call frame in the global namespace by default (or the
+/// lambda's own optional third element, never inherited), so `my foo` inside
+/// a bare `apply {{} {my foo}}` called from a method body is not actually a
+/// call to that method at runtime — `my` isn't defined in `::`. Leaving the
+/// enclosing class/grammar/scoped-env active here would resolve such a call
+/// anyway, painting it as live when it would error (mirrors `folding.rs`'s
+/// `None` reset for the same recursion, and the same fresh-frame reasoning
+/// as the interprocedural/param-trait/declaration fixes for issue #954's
+/// follow-up).
 fn collect_lambda_literal(ctx: ScriptCtx<'_>, tok: Token, entries: &mut Vec<Entry>, depth: u32) {
     if depth > MAX_TOKEN_RECURSION {
         return;
@@ -4141,6 +4153,12 @@ fn collect_lambda_literal(ctx: ScriptCtx<'_>, tok: Token, entries: &mut Vec<Entr
             push_token(line_index, full_source, tok, kind, 0, entries);
         }
         return;
+    };
+    let lambda_ctx = ScriptCtx {
+        oo_grammar: None,
+        enclosing_class: None,
+        scoped_env: None,
+        ..ctx
     };
     // Flatten the lambda's list elements (params, body, ?ns?).
     let mut words: Vec<Token> = Vec::new();
@@ -4163,7 +4181,7 @@ fn collect_lambda_literal(ctx: ScriptCtx<'_>, tok: Token, entries: &mut Vec<Entr
         {
             // Element 1 is the body — recurse it as a script when braced.
             collect_script(
-                ctx,
+                lambda_ctx,
                 body,
                 u32::try_from(bstart).unwrap_or(0),
                 entries,
@@ -7266,6 +7284,44 @@ mod tests {
             toks.iter()
                 .any(|&(l, _, _, k, m)| l == 2 && k == TokenKind::Method as u32 && m == 0),
             "expected `my helper` to resolve; got {toks:?}"
+        );
+    }
+
+    /// A bare (namespace-less) `apply {{} {...}}` runs its body in a *fresh*
+    /// call frame in the global namespace by default — never the enclosing
+    /// method's object namespace — so `my helper` inside it is not actually a
+    /// call to the enclosing class's method at runtime (`my` isn't defined in
+    /// `::`); a class-definition-body scan would raise "invalid command name
+    /// my" here. The `enclosing_class` context must not leak into an
+    /// `apply`-lambda body the way it correctly persists into an ordinary
+    /// nested `if`/`foreach` body, or this gets painted as a resolved,
+    /// legitimate method call anyway (codex-review-adjacent follow-up to
+    /// issue #954: the same fresh-frame class of bug already fixed for
+    /// call-graph namespace resolution, param traits, and declarations).
+    #[test]
+    fn my_call_inside_apply_lambda_body_does_not_resolve() {
+        use tcl_compiler::analyser::Analyser;
+        use tcl_compiler::compilation_unit::CompilationUnit;
+        let registry = reg();
+        let src = "oo::class create C {\n\
+                   \x20   method helper {} {}\n\
+                   \x20   method run {} { apply {{} {my helper}} }\n\
+                   }\n";
+        let cu = CompilationUnit::build_for(src, &registry, false);
+        let analysis = Analyser::new().analyse(src, "tcl9.0");
+        let toks = decode_semantic(&full_with_cu_and_analysis(
+            src,
+            "tcl9.0",
+            &registry,
+            Some(&cu),
+            Some(&analysis),
+        ));
+        assert!(
+            !toks
+                .iter()
+                .any(|&(l, _, _, k, m)| l == 2 && k == TokenKind::Method as u32 && m == 0),
+            "a bare apply lambda's `my helper` must not resolve as the \
+             enclosing class's method — it isn't one at runtime; got {toks:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/tests/command_prefix_integration.rs
+++ b/rust/tcl-lsp-core/tests/command_prefix_integration.rs
@@ -159,6 +159,68 @@ fn braced_multi_word_prefix_dynamic_head_is_not_recorded() {
     );
 }
 
+/// A `[list cmd extra]` command-prefix — the idiomatic way to build a
+/// callback around a dynamic value (`-command [list doSomething $x]`) rather
+/// than a fixed literal prefix — is recorded exactly like the braced-list
+/// shape: head span covers just the head word, and every further `list`
+/// argument (whatever its own runtime value) is a baked argument.
+#[test]
+fn list_quoted_prefix_records_head_span_and_baked_count() {
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let src = "proc myCompare {a b extra} { expr {$a - $b} }\nset extra 99\nlsort -command [list myCompare $extra] $items\n";
+    let r = a.analyse(src, "tcl9.0");
+    let inv = r
+        .command_invocations
+        .iter()
+        .find(|i| i.name == "myCompare" && i.callback_arity.is_some())
+        .expect("a list-quoted prefix must record its head as an invocation");
+    assert_eq!(
+        inv.callback_baked_args, 1,
+        "the `$extra` word after the head must be counted as one baked argument"
+    );
+    let head_text = &src[inv.range.start() as usize..inv.range.end() as usize];
+    assert_eq!(
+        head_text, "myCompare",
+        "the recorded span must cover exactly the head word, got {head_text:?}"
+    );
+}
+
+/// FP guard: `[list $cb 99]` — a dynamic head as `list`'s own first argument
+/// — is not a literal command reference and must not be recorded, mirroring
+/// the braced-shape guard.
+#[test]
+fn list_quoted_prefix_dynamic_head_is_not_recorded() {
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let r = a.analyse(
+        "proc f {cb l} { return [lsort -command [list $cb 99] $l] }\n",
+        "tcl9.0",
+    );
+    assert!(
+        !r.command_invocations
+            .iter()
+            .any(|i| i.callback_arity.is_some()),
+        "a dynamic list-quoted-prefix head must not be recorded as a command-prefix invocation"
+    );
+}
+
+/// FP guard: `[llength $x]` — a `Cmd` substitution whose head is *not*
+/// `list` (doesn't carry `Traits::BUILDS_COMMAND_PREFIX`) — must not be
+/// misread as constructing a deferred command, however similarly shaped.
+#[test]
+fn cmd_substitution_with_non_list_head_is_not_recorded_as_prefix() {
+    let mut a = tcl_compiler::analyser::Analyser::new();
+    let r = a.analyse(
+        "proc f {items} { return [lsort -command [llength $items] $items] }\n",
+        "tcl9.0",
+    );
+    assert!(
+        !r.command_invocations
+            .iter()
+            .any(|i| i.callback_arity.is_some()),
+        "an [llength ...] substitution must not be recorded as a command-prefix invocation"
+    );
+}
+
 /// The deferred core-Tcl callback surfaces are wired through the same generic
 /// substrate — no per-command code — so a registry-declared prefix on
 /// `namespace unknown` / `package unknown` / `regsub -command` /

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -59,6 +59,8 @@ mod irules;
 mod issue923_class_refs;
 #[path = "e2e/issue945.rs"]
 mod issue945;
+#[path = "e2e/issue954_followup.rs"]
+mod issue954_followup;
 #[path = "e2e/name_resolution.rs"]
 mod name_resolution;
 #[path = "e2e/navigation.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/issue954_followup.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue954_followup.rs
@@ -1,0 +1,202 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! End-to-end coverage for the issue #954 follow-up, against the real,
+//! packaged native server.
+//!
+//! The original #954 fix (merged as part of v2.1.11, `cb10e7c90`) corrected
+//! a bare-unbraced-parameter-list highlighting bug in `apply {dir {…}}`, but
+//! the issue was reopened: the reporter's actual screenshot was a
+//! pkgIndex.tcl-style `package ifneeded name ver [list apply {dir {…}} $dir]`
+//! entry — `apply` reached *indirectly* through the `[list …]`
+//! command-quoting idiom, a case the first fix never touched. This file
+//! exercises the real reported repro end-to-end, plus the closely related
+//! shapes the general (registry-driven) fix now also covers.
+
+use crate::common::helpers::*;
+use crate::common::{Lsp, unique_uri};
+
+fn legend(lsp: &Lsp) -> Vec<String> {
+    lsp.initialize_result()["capabilities"]["semanticTokensProvider"]["legend"]["tokenTypes"]
+        .as_array()
+        .expect("tokenTypes legend")
+        .iter()
+        .map(|v| v.as_str().unwrap_or("").to_owned())
+        .collect()
+}
+
+struct TypedToken {
+    line: i64,
+    char: i64,
+    length: i64,
+    ttype: String,
+}
+
+fn typed(lsp: &mut Lsp, legend: &[String], uri: &str) -> Vec<TypedToken> {
+    let raw = lsp.semantic_tokens(uri);
+    decode_semantic_tokens(&raw)
+        .into_iter()
+        .map(|t| TypedToken {
+            line: t.line,
+            char: t.char,
+            length: t.length,
+            ttype: legend[usize::try_from(t.ttype).unwrap()].clone(),
+        })
+        .collect()
+}
+
+fn open_doc(lsp: &mut Lsp, source: &str) -> String {
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, source);
+    uri
+}
+
+/// The source text a decoded token covers (single-line tokens only).
+fn covered<'a>(source: &'a str, tok: &TypedToken) -> &'a str {
+    let line = source
+        .split('\n')
+        .nth(usize::try_from(tok.line).unwrap())
+        .unwrap_or("");
+    let start = usize::try_from(tok.char).unwrap();
+    let end = start + usize::try_from(tok.length).unwrap();
+    line.get(start..end).unwrap_or("")
+}
+
+fn has_typed(toks: &[TypedToken], source: &str, text: &str, ttype: &str) -> bool {
+    toks.iter()
+        .any(|t| t.ttype == ttype && covered(source, t) == text)
+}
+
+/// The exact reported repro: a pkgIndex.tcl-style `package ifneeded` entry
+/// whose deferred script is built with `[list apply {dir {…}} $dir]` to
+/// capture the install directory safely. Every command inside the real
+/// apply body must tokenise — not sit inside one opaque string, which is
+/// what the reporter's screenshot showed.
+#[test]
+fn test_pkgindex_list_quoted_apply_body_highlights() {
+    let mut lsp = Lsp::tcl();
+    let legend_names = legend(&lsp);
+    let source = "package ifneeded myPackage 1.0.0 [list apply {dir {\n\
+                  \n\
+                  \x20   source [file join $dir src font.tcl]\n\
+                  \x20   source [file join $dir src utils.tcl]\n\
+                  \n\
+                  }} $dir]\n";
+    let uri = open_doc(&mut lsp, source);
+    let toks = typed(&mut lsp, &legend_names, &uri);
+    assert!(
+        has_typed(&toks, source, "source", "keyword"),
+        "expected `source` to tokenise inside the list-quoted apply body; got {:?}",
+        toks.iter()
+            .map(|t| (t.line, t.char, covered(source, t), t.ttype.as_str()))
+            .collect::<Vec<_>>()
+    );
+    assert!(
+        has_typed(&toks, source, "file", "function"),
+        "expected `file` to tokenise inside the list-quoted apply body"
+    );
+    assert!(
+        has_typed(&toks, source, "dir", "parameter"),
+        "expected the bare `dir` param to be a Parameter declaration"
+    );
+}
+
+/// A `::`-qualified `::apply` inside the `[list …]` wrapper resolves the
+/// same way (registry `get` strips a leading `::`).
+#[test]
+fn test_qualified_apply_list_quoted_body_highlights() {
+    let mut lsp = Lsp::tcl();
+    let legend_names = legend(&lsp);
+    let source = "package ifneeded p 1.0 [list ::apply {dir {puts $dir}} $dir]\n";
+    let uri = open_doc(&mut lsp, source);
+    let toks = typed(&mut lsp, &legend_names, &uri);
+    assert!(
+        has_typed(&toks, source, "puts", "function"),
+        "expected `puts` to tokenise inside the qualified `::apply` body; got {:?}",
+        toks.iter()
+            .map(|t| (t.line, t.char, covered(source, t), t.ttype.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// The same `[list apply {…} $x]` idiom under a different Body-role
+/// enclosing command (`after idle`) — proves the fix is registry-driven
+/// (any Body-role position), not special-cased to `package ifneeded`.
+#[test]
+fn test_after_idle_list_quoted_apply_body_highlights() {
+    let mut lsp = Lsp::tcl();
+    let legend_names = legend(&lsp);
+    let source = "after idle [list apply {{x} {puts $x}} 5]\n";
+    let uri = open_doc(&mut lsp, source);
+    let toks = typed(&mut lsp, &legend_names, &uri);
+    assert!(
+        has_typed(&toks, source, "puts", "function"),
+        "expected `puts` to tokenise inside the after-idle list-quoted apply body"
+    );
+    assert!(
+        has_typed(&toks, source, "x", "parameter"),
+        "expected the `x` param to be a Parameter declaration"
+    );
+}
+
+/// `package ifneeded`'s script argument, as a *literal* braced script (no
+/// `[list …]` wrapper), must also recurse — the sibling half of the fix
+/// (the argument previously carried no `ArgRole` at all).
+#[test]
+fn test_pkgindex_literal_script_highlights() {
+    let mut lsp = Lsp::tcl();
+    let legend_names = legend(&lsp);
+    let source = "package ifneeded myPackage 1.0.0 {\n\x20   source [file join $dir x.tcl]\n}\n";
+    let uri = open_doc(&mut lsp, source);
+    let toks = typed(&mut lsp, &legend_names, &uri);
+    assert!(
+        has_typed(&toks, source, "source", "keyword"),
+        "expected `source` to tokenise inside package ifneeded's literal script body"
+    );
+}
+
+/// FP guard: an ordinary data list must not be split as if it were a
+/// deferred `apply` command construction.
+#[test]
+fn test_plain_data_list_is_not_split_as_lambda() {
+    let mut lsp = Lsp::tcl();
+    let legend_names = legend(&lsp);
+    let source = "set data [list puts hello world]\n";
+    let uri = open_doc(&mut lsp, source);
+    let toks = typed(&mut lsp, &legend_names, &uri);
+    assert!(
+        !has_typed(&toks, source, "hello", "parameter"),
+        "a plain data list must never be split as a lambda literal; got {:?}",
+        toks.iter()
+            .map(|t| (t.line, t.char, covered(source, t), t.ttype.as_str()))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Direct (non-list-quoted) `apply` regression check — the original #954
+/// fix (bare unbraced param list) must still hold.
+#[test]
+fn test_direct_apply_bare_param_still_highlights() {
+    let mut lsp = Lsp::tcl();
+    let legend_names = legend(&lsp);
+    let source = "apply {dir {\n\x20   puts $dir\n}} /tmp\n";
+    let uri = open_doc(&mut lsp, source);
+    let toks = typed(&mut lsp, &legend_names, &uri);
+    assert!(has_typed(&toks, source, "dir", "parameter"));
+    assert!(has_typed(&toks, source, "puts", "function"));
+}

--- a/rust/tcl-registry/examples/dump_specs.rs
+++ b/rust/tcl-registry/examples/dump_specs.rs
@@ -154,6 +154,7 @@ const BOOL_TRAITS: &[(&str, Traits)] = &[
     ("destroys_variable", Traits::DESTROYS_VARIABLE),
     ("is_language_keyword", Traits::LANGUAGE_KEYWORD),
     ("produces_canonical_list", Traits::PRODUCES_CANONICAL_LIST),
+    ("builds_command_prefix", Traits::BUILDS_COMMAND_PREFIX),
     ("is_side_switch", Traits::IS_SIDE_SWITCH),
     ("defines_procedure", Traits::DEFINES_PROCEDURE),
     ("unsafe", Traits::UNSAFE),

--- a/rust/tcl-registry/src/arg_role.rs
+++ b/rust/tcl-registry/src/arg_role.rs
@@ -110,6 +110,27 @@ pub enum ArgRole {
     /// (issue #945 fault 9: reference identity and existence assertion are
     /// orthogonal, and a probe asserts nothing).
     CommandNameProbe,
+    /// An anonymous-lambda **literal** — Tcl's `apply` argument shape, a
+    /// `{argList body ?namespace?}` list rather than a plain script.
+    ///
+    /// Distinct from [`Self::Body`]: a `Body`-role argument *is* the script
+    /// directly, walked by re-segmenting its own text. A `LambdaLiteral`
+    /// argument is one level removed — it is a 2- or 3-element Tcl **list**
+    /// whose element 0 is a parameter list ([`Self::ParamList`] shape, not
+    /// code) and element 1 is the actual body script; an optional element 2
+    /// names the namespace the body runs in. A consumer that recurses
+    /// [`Self::Body`] arguments directly would mis-segment the whole
+    /// `{argList} {body}` pair as if it were script source. Every command
+    /// declaring this role is dispatched identically by
+    /// [`Self::carries_script`] callers: split the list, walk element 0 as a
+    /// parameter list and element 1 as a body, leave the rest verbatim.
+    ///
+    /// `apply` is the only built-in with this shape today, but the role is
+    /// named for the *shape*, not the command — a future command sharing it
+    /// (or `apply` reached indirectly, e.g. quoted through `[list apply
+    /// {…} $x]`) is recognised the same way, with no command-name check in
+    /// the consumer.
+    LambdaLiteral,
 }
 
 impl ArgRole {
@@ -134,6 +155,7 @@ impl ArgRole {
         Self::CommandPrefix,
         Self::CommandName,
         Self::CommandNameProbe,
+        Self::LambdaLiteral,
     ];
 
     /// Whether an argument in this role carries **executable Tcl** that a
@@ -163,7 +185,7 @@ impl ArgRole {
     #[must_use]
     pub const fn carries_script(self) -> bool {
         match self {
-            Self::Body | Self::Expr => true,
+            Self::Body | Self::Expr | Self::LambdaLiteral => true,
             Self::CommandPrefix
             | Self::CommandName
             | Self::CommandNameProbe

--- a/rust/tcl-registry/src/command_snapshot.rs
+++ b/rust/tcl-registry/src/command_snapshot.rs
@@ -89,6 +89,7 @@ const TRAIT_FLAGS: &[(&str, Traits)] = &[
     ("password_option_command", Traits::PASSWORD_OPTION),
     ("performs_substitution", Traits::PERFORMS_SUBSTITUTION),
     ("produces_canonical_list", Traits::PRODUCES_CANONICAL_LIST),
+    ("builds_command_prefix", Traits::BUILDS_COMMAND_PREFIX),
     ("pure", Traits::PURE),
     ("pure_evaluation", Traits::PURE_EVALUATION),
     ("reads_variable_before_write", Traits::READS_BEFORE_WRITE),

--- a/rust/tcl-registry/src/commands/tcl/apply.rs
+++ b/rust/tcl-registry/src/commands/tcl/apply.rs
@@ -40,7 +40,14 @@ pub fn spec() -> CommandSpec {
         // Added in Tcl 8.5 (TIP 194).
         dialects: Some(DialectSet::TCL85_PLUS),
         arity: Arity::at_least(1),
-        arg_roles: &[(0, ArgRole::Body)],
+        // The lambda literal is a `{argList body ?ns?}` list, not a plain
+        // script — `ArgRole::LambdaLiteral` (not `Body`) says so, so generic
+        // Body-role walkers (SSA's caller-scope scan, the semantic-token
+        // highlighter's default body recursion) never try to re-segment the
+        // list itself as script source. The real body (element 1) is walked
+        // by the dedicated `LoweringHookId::Apply` / `AnalyserHookId::Apply`
+        // hooks below, which already split the list correctly.
+        arg_roles: &[(0, ArgRole::LambdaLiteral)],
         lowering_hook: Some(crate::hooks::LoweringHookId::Apply),
         return_type: Some(TclType::String),
         hover: Some(HoverSnippet {

--- a/rust/tcl-registry/src/commands/tcl/list_.rs
+++ b/rust/tcl-registry/src/commands/tcl/list_.rs
@@ -32,7 +32,8 @@ pub fn spec() -> CommandSpec {
             | Traits::NOT_PROC_FACTORY
             | Traits::BYTE_COMPILED
             | Traits::PURE
-            | Traits::PRODUCES_CANONICAL_LIST,
+            | Traits::PRODUCES_CANONICAL_LIST
+            | Traits::BUILDS_COMMAND_PREFIX,
         arity: Arity::any(),
         return_type: Some(TclType::List),
         return_elements: Some(ReturnElements::ListOfArgs { from: 0 }),

--- a/rust/tcl-registry/src/commands/tcl/package_.rs
+++ b/rust/tcl-registry/src/commands/tcl/package_.rs
@@ -50,6 +50,14 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Set up or query the package ifneeded script.",
         synopsis: "package ifneeded package version ?script?",
         return_type: Some(TclType::String),
+        // The optional script (index 2 after `ifneeded`) is stored and run
+        // later — `uplevel #0 $script` inside `package require`, in the
+        // *global* namespace, never the definer's frame — so it is a
+        // structural body like `bind`'s/`after`'s deferred scripts, not a
+        // caller-frame one: `body_kind: Structural` keeps SSA from scanning
+        // it as part of the enclosing `package ifneeded` call's own scope.
+        arg_roles: &[(2, ArgRole::Body)],
+        body_kind: BodyKind::Structural,
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -105,6 +105,25 @@ bitflags! {
         /// Produces a canonical Tcl list (`list`, `concat`).
         const PRODUCES_CANONICAL_LIST   = 1 << 28;
 
+        /// Quotes its arguments into a well-formed command reference: when
+        /// the first argument is a literal command name, evaluating the
+        /// result invokes that command with the remaining arguments
+        /// appended verbatim (`list cmd $a $b` → `cmd $a $b`, each word
+        /// preserved regardless of its runtime value). Set on `list` only —
+        /// **not** `concat`, whose plain string-join does not give the same
+        /// per-word quoting guarantee for a dynamic value, so it is unsafe
+        /// to reinterpret the same way. The idiomatic way to build a
+        /// deferred callback / command prefix around a dynamic value
+        /// (`package ifneeded name ver [list apply {params} {body} $dir]`,
+        /// `button .b -command [list doSomething $x]`) rather than a
+        /// literal braced prefix. Consulted wherever a
+        /// [`crate::arg_role::ArgRole::CommandPrefix`] /
+        /// [`crate::arg_role::ArgRole::Body`] /
+        /// [`crate::arg_role::ArgRole::LambdaLiteral`] argument position
+        /// needs to recognise this quoting shape generically — no command
+        /// name appears in the consumer.
+        const BUILDS_COMMAND_PREFIX     = 1 << 30;
+
         // Safety
         /// Inherently dangerous command.
         const UNSAFE                    = 1 << 29;

--- a/rust/tcl-registry/tests/registry_sweep.rs
+++ b/rust/tcl-registry/tests/registry_sweep.rs
@@ -123,6 +123,7 @@ const ALL_TRAITS: &[Traits] = &[
     Traits::RETURNS_PATH,
     Traits::IS_UNESCAPE,
     Traits::PRODUCES_CANONICAL_LIST,
+    Traits::BUILDS_COMMAND_PREFIX,
     Traits::UNSAFE,
     Traits::PASSWORD_OPTION,
     Traits::IS_SIDE_SWITCH,


### PR DESCRIPTION
## Summary

Fixes issue #954 follow-up: `apply` lambda bodies were not highlighted when reached indirectly through the `[list apply {…} $x]` command-quoting idiom (common in pkgIndex.tcl entries), even though direct `apply {…} $x` calls worked correctly.

The root cause was that the semantic-token highlighter only recognized `apply` as the literal head of a command. The idiomatic `[list apply {…} $x]` pattern — used to build deferred callbacks around dynamic values — was invisible to the highlighter because `list` was the actual head.

This fix introduces:

1. **New `ArgRole::LambdaLiteral`** — distinct from `Body`, marking arguments that are `{paramList body ?namespace?}` lists (not plain scripts). Prevents generic body walkers from mis-parsing the parameter word as a command name (issue #954's root cause).

2. **New `Traits::BUILDS_COMMAND_PREFIX`** on `list` — declares that when `list`'s first argument is a literal command name, the result invokes that command with remaining arguments appended. Enables static resolution of list-quoted command prefixes.

3. **Shared `split_lambda_literal` utility** — splits a lambda-literal token into its list elements' absolute spans, used by all consumers (semantic tokens, folding, formatting, minification, declaration scanning, call-graph analysis, iRules walker) to avoid mis-parsing.

4. **Enhanced `insert_lambda_literal_overrides`** — now handles both direct (`apply {…}`) and list-quoted (`[list apply {…} $x]`) shapes via registry-driven resolution, with no command-name string comparisons.

5. **Updated `apply` and `package ifneeded` specs** — `apply` now declares `ArgRole::LambdaLiteral` instead of `Body`; `package ifneeded`'s script argument is now `ArgRole::Body` (was untagged).

All body-role consumers (folding, formatting, minification, declaration scanning, call-graph analysis, iRules walker, param-trait scanning) have been updated to recognize and correctly handle `LambdaLiteral` arguments by splitting the list first.

## Validation

- Added end-to-end tests covering the reported pkgIndex.tcl repro and related shapes (Rust and VS Code)
- Updated existing command-prefix integration tests to cover list-quoted prefixes
- All existing tests pass; new tests validate both direct and list-quoted lambda highlighting

## Compiler/KCS checklist

- [x] This change alters compiler fact contracts (`ArgRole::LambdaLiteral`, `Traits::BUILDS_COMMAND_PREFIX`)
- [x] Updated KCS note: `docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md` (new)
- [x] Linked from `docs/kcs/README.md`

https://claude.ai/code/session_019a7wfz3oaBpWgVkUwwDv8R