### PR TITLE
fix(lsp): TclOO property/constructor/destructor code lenses (issue #992)

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,9 +396,22 @@ dispatch, and `next` / `nextto` super-dispatch — including calls nested in a
 (any combination, arbitrarily deep). A `classmethod` dispatches on the
 class's own command rather than an instance, so it is found through every
 bare `ClassName method` call, including from a subclass's own command when
-the subclass inherits (does not override) the classmethod. Expr math
-functions resolve to their backing proc, so a `proc ::tcl::mathfunc::foo` is
-found (and renamed) from every `foo(...)` used inside `expr`.
+the subclass inherits (does not override) the classmethod. A `property`
+(`oo::configurable`'s `property name -get {...} -set {...}` form) is found
+through every `my <property>` dispatch inside the class body — properties
+have no `$obj property` dispatch shape or inheritance model, so this is a
+class-local scan. Expr math functions resolve to their backing proc, so a
+`proc ::tcl::mathfunc::foo` is found (and renamed) from every `foo(...)`
+used inside `expr`.
+
+A `constructor` or `destructor` is invoked positionally
+(`ClassName new`/`create`/`destroy`), never dispatched by name, so it has no
+general reference story the way a method does — but an overriding
+subclass's own constructor/destructor chaining up to it via `next` /
+`nextto` is still a name-independent reference, and code lens / find
+references surface it, resolved through the full class hierarchy (skipping
+an intermediate ancestor that declares no constructor/destructor of its
+own).
 
 A class is found through every use of its name, not only `<Class> new`. A
 `superclass`, `mixin`, or `[incr Tcl]` `inherit` argument that names the class

--- a/docs/kcs/features/kcs-feature-code-lens.md
+++ b/docs/kcs/features/kcs-feature-code-lens.md
@@ -5,8 +5,8 @@
 
 ## Summary
 
-Reference counts shown above each proc, class, TclOO method, and classmethod
-definition. Click the lens to find all references.
+Reference counts shown above each proc, class, TclOO method, classmethod,
+and property definition. Click the lens to find all references.
 
 ## Applies to
 
@@ -14,16 +14,21 @@ all-editors, analyser
 
 ## Question
 
-What are the numbers that appear above my proc, class, and method definitions?
+What are the numbers that appear above my proc, class, method, and property definitions?
 
 ## How to use
 
 Code lenses appear automatically above every `proc` definition, every
-`oo::class create` declaration, and every TclOO `method` / `classmethod`
-inside a class body, in a Tcl or iRules file. Each lens shows how many
-references exist to that symbol across the current file (and the workspace,
-for procs and classes, if indexing is enabled). Click the lens to open the
-Find References panel.
+`oo::class create` declaration, every TclOO `method` / `classmethod` inside a
+class body, and every `property` declaration (`oo::configurable`'s `property
+name -get {...} -set {...}` form), in a Tcl or iRules file. Each lens shows
+how many references exist to that symbol across the current file (and the
+workspace, for procs and classes, if indexing is enabled). Click the lens to
+open the Find References panel.
+
+A property's count comes from a class-local scan of `my <property>` sites —
+properties have no `$obj property` dispatch shape and no inheritance model,
+unlike methods and classmethods.
 
 No configuration is needed. The feature can be toggled with `tclLsp.features.codeLens`.
 
@@ -40,6 +45,8 @@ greet "Bob"                   ;# reference 2
 oo::class create Factory {
     method get {} { return 1 }       ;# "1 reference" — the $f get call below
     classmethod make {} { return [Factory new] }  ;# "1 reference" — Factory make
+    property size -get {return $mySize} -set {set mySize $value}  ;# "1 reference" — my size below
+    method resize {} { my size }
 }
 set f [Factory new]
 $f get
@@ -50,14 +57,19 @@ The lens updates as you type. If you rename or remove a call, the count adjusts 
 
 ## Failure modes
 
-- A method / classmethod lens above a TclOO member always resolves to a
-  clickable command, the same as a proc or class lens — a lens that shows a
-  count but does nothing when clicked is a bug (issues #724, #956), not
-  expected behaviour.
+- A method / classmethod / property lens above a TclOO member always
+  resolves to a clickable command, the same as a proc or class lens — a lens
+  that shows a count but does nothing when clicked is a bug (issues #724,
+  #956, #992), not expected behaviour.
 - A `method` and a `classmethod` sharing the same name on one class are
   counted and resolved independently — the method's lens never picks up the
   classmethod's `ClassName foo` dispatch sites (or vice versa), even though
-  both are legal, separate members.
+  both are legal, separate members. The same independence holds for a
+  `property` sharing a name with a `method` or `classmethod`.
+- A class's `constructor` and `destructor` do not get a lens: both are
+  invoked positionally (`ClassName new`/`create`), never dispatched by name,
+  so a conventional "N references" count has no obvious meaning for them the
+  way it does for a `method`/`classmethod`/`property`.
 
 ## Related
 

--- a/docs/kcs/features/kcs-feature-code-lens.md
+++ b/docs/kcs/features/kcs-feature-code-lens.md
@@ -6,7 +6,8 @@
 ## Summary
 
 Reference counts shown above each proc, class, TclOO method, classmethod,
-and property definition. Click the lens to find all references.
+property, constructor, and destructor definition. Click the lens to find
+all references.
 
 ## Applies to
 
@@ -14,21 +15,32 @@ all-editors, analyser
 
 ## Question
 
-What are the numbers that appear above my proc, class, method, and property definitions?
+What are the numbers that appear above my proc, class, method, property, and constructor/destructor definitions?
 
 ## How to use
 
 Code lenses appear automatically above every `proc` definition, every
 `oo::class create` declaration, every TclOO `method` / `classmethod` inside a
-class body, and every `property` declaration (`oo::configurable`'s `property
-name -get {...} -set {...}` form), in a Tcl or iRules file. Each lens shows
-how many references exist to that symbol across the current file (and the
-workspace, for procs and classes, if indexing is enabled). Click the lens to
-open the Find References panel.
+class body, every `property` declaration (`oo::configurable`'s `property
+name -get {...} -set {...}` form), and every explicit `constructor` /
+`destructor`, in a Tcl or iRules file. Each lens shows how many references
+exist to that symbol across the current file (and the workspace, for procs
+and classes, if indexing is enabled). Click the lens to open the Find
+References panel.
 
 A property's count comes from a class-local scan of `my <property>` sites —
 properties have no `$obj property` dispatch shape and no inheritance model,
 unlike methods and classmethods.
+
+A constructor or destructor is invoked positionally (`ClassName
+new`/`create`/`destroy`), never dispatched by name, so a conventional "N
+references" count has no general meaning for it the way it does for a
+`method`/`classmethod`/`property`. Its lens is scoped to one specific,
+name-independent relationship instead: an overriding subclass's own
+constructor/destructor chaining up to this one via `next` / `nextto`. The
+count resolves that chain through the full class hierarchy (skipping past
+an intermediate ancestor that declares no constructor/destructor of its
+own), not just the immediate superclass.
 
 No configuration is needed. The feature can be toggled with `tclLsp.features.codeLens`.
 
@@ -42,7 +54,12 @@ proc greet {name} {          ;# "2 references" appears above this line
 greet "Alice"                 ;# reference 1
 greet "Bob"                   ;# reference 2
 
+oo::class create Base {
+    constructor {} { }         ;# "1 reference" — Sub's `next` below chains to this one
+}
 oo::class create Factory {
+    superclass Base
+    constructor {} { next }     ;# "0 references" — nothing chains into Factory's own
     method get {} { return 1 }       ;# "1 reference" — the $f get call below
     classmethod make {} { return [Factory new] }  ;# "1 reference" — Factory make
     property size -get {return $mySize} -set {set mySize $value}  ;# "1 reference" — my size below
@@ -57,19 +74,23 @@ The lens updates as you type. If you rename or remove a call, the count adjusts 
 
 ## Failure modes
 
-- A method / classmethod / property lens above a TclOO member always
-  resolves to a clickable command, the same as a proc or class lens — a lens
-  that shows a count but does nothing when clicked is a bug (issues #724,
-  #956, #992), not expected behaviour.
+- A method / classmethod / property / constructor / destructor lens above a
+  TclOO member always resolves to a clickable command, the same as a proc or
+  class lens — a lens that shows a count but does nothing when clicked is a
+  bug (issues #724, #956, #992), not expected behaviour.
 - A `method` and a `classmethod` sharing the same name on one class are
   counted and resolved independently — the method's lens never picks up the
   classmethod's `ClassName foo` dispatch sites (or vice versa), even though
   both are legal, separate members. The same independence holds for a
   `property` sharing a name with a `method` or `classmethod`.
-- A class's `constructor` and `destructor` do not get a lens: both are
-  invoked positionally (`ClassName new`/`create`), never dispatched by name,
-  so a conventional "N references" count has no obvious meaning for them the
-  way it does for a `method`/`classmethod`/`property`.
+- `oo::configurable` allows several `constructor` declarations on one class;
+  only the last is ever effective. An earlier, shadowed `constructor` gets no
+  lens — there is no reference story worth surfacing for a declaration that
+  can never run.
+- A `nextto SomeClass` inside a subclass's constructor/destructor is
+  resolved to the class it actually names, not assumed to target the
+  immediate superclass — a `nextto` that skips past a closer ancestor to an
+  explicit target further up the chain counts only for that named target.
 
 ## Related
 

--- a/rust/tcl-cli/tests/fixtures/help-catalogue-irules.golden
+++ b/rust/tcl-cli/tests/fixtures/help-catalogue-irules.golden
@@ -26,7 +26,8 @@ LSP Features (all editors) (5):
   APL (iApp Presentation Language) support: Semantic highlighting, cross-file diagnostics, and embedded Tcl support for
 F5 iApp APL (Application Presentation Language) files.
   Code Lens: Reference counts shown above each proc, class, TclOO method, classmethod,
-and property definition. Click the lens to find all references.
+property, constructor, and destructor definition. Click the lens to find
+all references.
   Compiler Explorer: Interactive web panel showing bytecode disassembly, AST, IR, and compiler passes, plus a structured WebAssembly disassembly view with click-to-source navigation, call and branch target cross-linking, control-flow arrows, and labelled structural ops.
   Folding: Code folding for procs, namespaces, event handlers, and braced blocks.
   Template Snippets: 16 built-in Tcl and iRules code templates insertable from the command palette.

--- a/rust/tcl-cli/tests/fixtures/help-catalogue-irules.golden
+++ b/rust/tcl-cli/tests/fixtures/help-catalogue-irules.golden
@@ -25,8 +25,8 @@ LSP + AI Features (9):
 LSP Features (all editors) (5):
   APL (iApp Presentation Language) support: Semantic highlighting, cross-file diagnostics, and embedded Tcl support for
 F5 iApp APL (Application Presentation Language) files.
-  Code Lens: Reference counts shown above each proc, class, TclOO method, and classmethod
-definition. Click the lens to find all references.
+  Code Lens: Reference counts shown above each proc, class, TclOO method, classmethod,
+and property definition. Click the lens to find all references.
   Compiler Explorer: Interactive web panel showing bytecode disassembly, AST, IR, and compiler passes, plus a structured WebAssembly disassembly view with click-to-source navigation, call and branch target cross-linking, control-flow arrows, and labelled structural ops.
   Folding: Code folding for procs, namespaces, event handlers, and braced blocks.
   Template Snippets: 16 built-in Tcl and iRules code templates insertable from the command palette.

--- a/rust/tcl-compiler/src/analyser/class_hierarchy.rs
+++ b/rust/tcl-compiler/src/analyser/class_hierarchy.rs
@@ -148,6 +148,77 @@ impl ClassHierarchy {
         })
     }
 
+    /// Resolve `TclOO` `next` / `nextto` from *within* `class`'s own
+    /// constructor: the class after `class` in its MRO that provides an
+    /// *effective* constructor (mirrors [`Self::next_provider`], but for the
+    /// unnamed constructor slot rather than a named method — "effective"
+    /// carries the same empty-body caveat as [`Self::constructor_provider`],
+    /// whose doc explains it).
+    ///
+    /// For plain `next`, pass `start_from = None`; the search begins one
+    /// past `class` itself. For `nextto SomeClass`, pass `start_from =
+    /// Some("::SomeClass")`; the search begins *at* that class. `source` is
+    /// the document text `body_span`s index into. Returns `None` when the
+    /// chain is exhausted or `class` is unknown.
+    #[must_use]
+    pub fn constructor_next_provider(
+        &self,
+        class: &str,
+        start_from: Option<&str>,
+        source: &str,
+    ) -> Option<&str> {
+        let mro = self.mro_map.get(class)?;
+        let anchor = start_from.unwrap_or(class);
+        let anchor_pos = mro.iter().position(|c| c == anchor)?;
+        let scan_from = if start_from.is_some() {
+            anchor_pos
+        } else {
+            anchor_pos + 1
+        };
+        mro.iter().skip(scan_from).find_map(|c| {
+            self.classes
+                .get(c)
+                .filter(|cd| {
+                    cd.constructors
+                        .last()
+                        .is_some_and(|ctor| !is_empty_method_body(source, ctor.body_span))
+                })
+                .map(|_| c.as_str())
+        })
+    }
+
+    /// Resolve `TclOO` `next` / `nextto` from *within* `class`'s own
+    /// destructor: the class after `class` in its MRO that declares a
+    /// destructor.
+    ///
+    /// Unlike [`Self::constructor_next_provider`], a destructor's
+    /// "effective" test is plain existence (`ClassDef::destructor.is_some()`)
+    /// — `TclOO`'s empty-body-elides-the-constructor quirk is verified
+    /// (against tclsh 9.0.4) for constructors specifically; no equivalent
+    /// claim has been checked for destructors, so an explicitly empty
+    /// destructor body is conservatively still treated as a real override
+    /// here rather than assumed to share the constructor's special case.
+    ///
+    /// Same `start_from` convention as [`Self::constructor_next_provider`].
+    /// Returns `None` when the chain is exhausted or `class` is unknown.
+    #[must_use]
+    pub fn destructor_next_provider(&self, class: &str, start_from: Option<&str>) -> Option<&str> {
+        let mro = self.mro_map.get(class)?;
+        let anchor = start_from.unwrap_or(class);
+        let anchor_pos = mro.iter().position(|c| c == anchor)?;
+        let scan_from = if start_from.is_some() {
+            anchor_pos
+        } else {
+            anchor_pos + 1
+        };
+        mro.iter().skip(scan_from).find_map(|c| {
+            self.classes
+                .get(c)
+                .filter(|cd| cd.destructor.is_some())
+                .map(|_| c.as_str())
+        })
+    }
+
     /// Return all `(class, defining_class)` pairs that
     /// implement `method_name`.  Order matches the iteration
     /// order of `method_providers` (`HashMap` — non-deterministic
@@ -831,6 +902,133 @@ mod tests {
         assert!(is_empty_method_body("\"\"", Span::new(0, 2)));
         // Out-of-range span — must not panic, must not report empty.
         assert!(!is_empty_method_body("{}", Span::new(0, 5)));
+    }
+
+    // `constructor_next_provider` / `destructor_next_provider` — issue #992's
+    // constructor/destructor next-chain lens support.
+
+    #[test]
+    fn constructor_next_provider_none_when_class_unknown() {
+        let classes = map(vec![cls_with_ctor("::A", &[])]);
+        let h = build_class_hierarchy(classes);
+        assert_eq!(h.constructor_next_provider("::Nope", None, CTOR_SRC), None);
+    }
+
+    #[test]
+    fn constructor_next_provider_direct_superclass() {
+        // `Sub`'s own `next` (no explicit target) resolves one past `Sub`
+        // itself in `Sub`'s own MRO — its direct superclass `Base`.
+        let classes = map(vec![
+            cls_with_ctor("::Base", &[]),
+            cls_with_ctor("::Sub", &["::Base"]),
+        ]);
+        let h = build_class_hierarchy(classes);
+        assert_eq!(
+            h.constructor_next_provider("::Sub", None, CTOR_SRC),
+            Some("::Base")
+        );
+    }
+
+    #[test]
+    fn constructor_next_provider_skips_ancestor_with_no_effective_constructor() {
+        // `Mid` declares no constructor of its own (a pure pass-through), so
+        // `Sub`'s `next` must skip past it and reach `Base`'s — the same
+        // "effective provider" skip `constructor_provider` already performs,
+        // just starting one class later.
+        let classes = map(vec![
+            cls_with_ctor("::Base", &[]),
+            cls("::Mid", &["::Base"], &[], &[]),
+            cls_with_ctor("::Sub", &["::Mid"]),
+        ]);
+        let h = build_class_hierarchy(classes);
+        assert_eq!(
+            h.constructor_next_provider("::Sub", None, CTOR_SRC),
+            Some("::Base")
+        );
+    }
+
+    #[test]
+    fn constructor_next_provider_skips_ancestor_with_empty_bodied_constructor() {
+        // `Mid` declares an explicit but empty-bodied constructor — `TclOO`
+        // treats that as "no constructor", so `next` from `Sub` must skip
+        // past it too, exactly like `constructor_provider` does.
+        let classes = map(vec![
+            cls_with_ctor("::Base", &[]),
+            cls_with_ctor_body("::Mid", &["::Base"], EMPTY_BODY),
+            cls_with_ctor("::Sub", &["::Mid"]),
+        ]);
+        let h = build_class_hierarchy(classes);
+        assert_eq!(
+            h.constructor_next_provider("::Sub", None, CTOR_SRC),
+            Some("::Base")
+        );
+    }
+
+    #[test]
+    fn constructor_next_provider_none_when_chain_exhausted() {
+        let classes = map(vec![cls_with_ctor("::Sub", &[])]);
+        let h = build_class_hierarchy(classes);
+        assert_eq!(h.constructor_next_provider("::Sub", None, CTOR_SRC), None);
+    }
+
+    #[test]
+    fn constructor_next_provider_nextto_explicit_target() {
+        // `nextto Grandparent` jumps straight to the named class, skipping
+        // `Base` even though `Base` also has an effective constructor.
+        let classes = map(vec![
+            cls_with_ctor("::Grandparent", &[]),
+            cls_with_ctor("::Base", &["::Grandparent"]),
+            cls_with_ctor("::Sub", &["::Base"]),
+        ]);
+        let h = build_class_hierarchy(classes);
+        assert_eq!(
+            h.constructor_next_provider("::Sub", Some("::Grandparent"), CTOR_SRC),
+            Some("::Grandparent")
+        );
+    }
+
+    /// A class with a real (non-empty) destructor.
+    fn cls_with_dtor(qname: &str, supers: &[&str]) -> ClassDef {
+        let mut cd = cls(qname, supers, &[], &[]);
+        cd.destructor = Some(MethodDef {
+            name: "<destructor>".to_string(),
+            params: Vec::new(),
+            name_span: span(),
+            body_span: NON_EMPTY_BODY,
+            kind: "destructor".to_string(),
+            visibility: "public".to_string(),
+            doc: String::new(),
+            forward_target: None,
+        });
+        cd
+    }
+
+    #[test]
+    fn destructor_next_provider_direct_superclass() {
+        let classes = map(vec![
+            cls_with_dtor("::Base", &[]),
+            cls_with_dtor("::Sub", &["::Base"]),
+        ]);
+        let h = build_class_hierarchy(classes);
+        assert_eq!(h.destructor_next_provider("::Sub", None), Some("::Base"));
+    }
+
+    #[test]
+    fn destructor_next_provider_skips_ancestor_with_no_destructor() {
+        let classes = map(vec![
+            cls_with_dtor("::Base", &[]),
+            cls("::Mid", &["::Base"], &[], &[]),
+            cls_with_dtor("::Sub", &["::Mid"]),
+        ]);
+        let h = build_class_hierarchy(classes);
+        assert_eq!(h.destructor_next_provider("::Sub", None), Some("::Base"));
+    }
+
+    #[test]
+    fn destructor_next_provider_none_when_chain_exhausted() {
+        let classes = map(vec![cls_with_dtor("::Sub", &[])]);
+        let h = build_class_hierarchy(classes);
+        assert_eq!(h.destructor_next_provider("::Sub", None), None);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -82,5 +82,5 @@ pub use tcl_syntax::mro::{self, MroError, build_mro_map, tcloo_linearise};
 pub use types::{
     AnalysisResult, ClassDef, CodeFix, DefinedSymbol, Diagnostic, MethodDef, ObjectMethodDef,
     ProcArgTrait, ProcDef, PropertyDef, Scope, ScopeKind, Severity, StubFlags, UnknownProcInfo,
-    VarDef, class_member_key, class_property_key,
+    VarDef, class_constructor_key, class_destructor_key, class_member_key, class_property_key,
 };

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -82,5 +82,5 @@ pub use tcl_syntax::mro::{self, MroError, build_mro_map, tcloo_linearise};
 pub use types::{
     AnalysisResult, ClassDef, CodeFix, DefinedSymbol, Diagnostic, MethodDef, ObjectMethodDef,
     ProcArgTrait, ProcDef, PropertyDef, Scope, ScopeKind, Severity, StubFlags, UnknownProcInfo,
-    VarDef, class_member_key,
+    VarDef, class_member_key, class_property_key,
 };

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -488,6 +488,25 @@ pub fn class_property_key(class_qualified: &str, name: &str) -> String {
     format!("{class_qualified}::property::{name}")
 }
 
+/// Stable composite key naming a class's own effective `constructor`:
+/// `{class}::constructor`.  Unlike a method or property there is exactly one
+/// dispatch-reachable constructor per class (`oo::configurable` allows
+/// several to be *declared*, but only the last is ever effective — see
+/// [`crate::analyser::class_hierarchy::ClassHierarchy::constructor_provider`]),
+/// so this carries no `{name}` suffix; same round-trip rationale as
+/// [`class_member_key`] / [`class_property_key`].
+#[must_use]
+pub fn class_constructor_key(class_qualified: &str) -> String {
+    format!("{class_qualified}::constructor")
+}
+
+/// The `destructor` counterpart of [`class_constructor_key`]:
+/// `{class}::destructor`.
+#[must_use]
+pub fn class_destructor_key(class_qualified: &str) -> String {
+    format!("{class_qualified}::destructor")
+}
+
 /// One per-object method added by an `oo::objdefine` (issue #945
 /// fault 5): the method declaration plus the **objdefine site's**
 /// receiver offset, the anchor a consumer resolves to a variable

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -479,6 +479,15 @@ pub fn class_member_key(class_qualified: &str, name: &str, is_classmethod: bool)
     }
 }
 
+/// Stable composite key naming a class's `property`: `{class}::property::{name}`.
+/// Properties are a third, independent member table — never a `method` or
+/// `classmethod` — so this never collides with [`class_member_key`]'s output;
+/// same round-trip rationale (item-tree diff, code-lens `codeLens/resolve`).
+#[must_use]
+pub fn class_property_key(class_qualified: &str, name: &str) -> String {
+    format!("{class_qualified}::property::{name}")
+}
+
 /// One per-object method added by an `oo::objdefine` (issue #945
 /// fault 5): the method declaration plus the **objdefine site's**
 /// receiver offset, the anchor a consumer resolves to a variable

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -638,6 +638,28 @@ mod tests {
         assert!(qnames.contains("::C::method::color"), "{qnames:?}");
     }
 
+    #[test]
+    fn lens_counts_each_name_independently_in_a_multi_name_property_declaration() {
+        // `property x y` declares two independent properties from one command
+        // (verified structurally by `extract_property_defs`'s own
+        // `property_subcommand_records_multiple_names` test) — each name must
+        // get its own lens with its own independently-counted `my <name>`
+        // dispatch sites, not a shared or merged count.
+        let src = "oo::class create Widget {\n    property x y\n    method bump {} { my x ; my y ; my y }\n}\n";
+        let analysis = analyse90(src);
+        let lenses = code_lenses(src, "tcl9.0", Some(&analysis), None, "");
+        let x_lens = lenses
+            .iter()
+            .find(|l| l.qname == "::Widget::property::x")
+            .expect("x lens");
+        let y_lens = lenses
+            .iter()
+            .find(|l| l.qname == "::Widget::property::y")
+            .expect("y lens");
+        assert_eq!(x_lens.command_title, "1 reference", "{lenses:?}");
+        assert_eq!(y_lens.command_title, "2 references", "{lenses:?}");
+    }
+
     // workspace-index: cross-document reference counts
 
     #[test]

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -52,6 +52,23 @@
 //! ([`tcl_compiler::analyser::class_property_key`]) so it resolves through
 //! the same click-to-references flow (issue #992).
 //!
+//! Constructor / destructor next-chain lenses: a class's own explicit
+//! `constructor` / `destructor` also gets a lens, but a conventional
+//! dispatch-count has no general meaning for either (both are invoked
+//! positionally — `ClassName new`/`create`/`destroy` — never by name). The
+//! one name-independent relationship that *is* meaningful: an overriding
+//! subclass's own constructor/destructor chaining up to this one via
+//! `next` / `nextto`. Sourced from
+//! [`crate::references::constructor_next_chain_references`] /
+//! [`crate::references::destructor_next_chain_references`], which resolve
+//! the chain through the full class hierarchy (via
+//! [`tcl_compiler::analyser::class_hierarchy::ClassHierarchy::constructor_next_provider`]
+//! / `destructor_next_provider`), not just the immediate superclass.
+//! Carries a `{class}::constructor` / `{class}::destructor` qname
+//! ([`tcl_compiler::analyser::class_constructor_key`] /
+//! `class_destructor_key`) for the same click-to-references flow (issue
+//! #992).
+//!
 //! Cross-document reference counts: when the
 //! caller threads a [`crate::workspace_index::WorkspaceIndex`]
 //! and the document's URI, the proc / class lens count
@@ -65,6 +82,9 @@
 //!   object's class needs whole-workspace instance-type flow the index
 //!   does not yet carry.  Proc / class lenses do fold in cross-document
 //!   command-head call sites via the workspace index.
+//! * Constructor / destructor next-chain counts are current-document only
+//!   too, for the same reason: a subclass declared in a sibling document
+//!   that `next`-chains to a superclass defined here is not counted.
 
 use tcl_compiler::analyser::AnalysisResult;
 use tcl_lexer::LineIndex;
@@ -286,6 +306,41 @@ fn emit_class_member_lenses(
         push_lens(
             p.name_span,
             tcl_compiler::analyser::class_property_key(class_q, name),
+            reference_count_title(count),
+            lenses,
+        );
+    }
+    // Constructor / destructor next-chain lenses (issue #992): unlike a
+    // method/classmethod/property, neither has a name to dispatch on, so a
+    // conventional reference count has no general meaning — the one
+    // meaningful, name-independent relationship is an overriding subclass's
+    // own constructor/destructor chaining up to this one via `next`/`nextto`.
+    // Only a class that declares its own effective constructor/destructor
+    // gets one of these lenses, same "declared members only" rule as every
+    // other lens kind.
+    if let Some(ctor) = class_def.constructors.last()
+        && !ctor.name_span.is_empty()
+    {
+        let count = crate::references::constructor_next_chain_references(
+            source, dialect, analysis, class_q,
+        )
+        .map_or(0, |(_decl, calls)| calls.len());
+        push_lens(
+            ctor.name_span,
+            tcl_compiler::analyser::class_constructor_key(class_q),
+            reference_count_title(count),
+            lenses,
+        );
+    }
+    if let Some(dtor) = &class_def.destructor
+        && !dtor.name_span.is_empty()
+    {
+        let count =
+            crate::references::destructor_next_chain_references(source, dialect, analysis, class_q)
+                .map_or(0, |(_decl, calls)| calls.len());
+        push_lens(
+            dtor.name_span,
+            tcl_compiler::analyser::class_destructor_key(class_q),
             reference_count_title(count),
             lenses,
         );
@@ -658,6 +713,80 @@ mod tests {
             .expect("y lens");
         assert_eq!(x_lens.command_title, "1 reference", "{lenses:?}");
         assert_eq!(y_lens.command_title, "2 references", "{lenses:?}");
+    }
+
+    // constructor / destructor next-chain lenses (issue #992)
+
+    #[test]
+    fn constructor_lens_counts_subclass_next_chain() {
+        let src = "oo::class create Base {\n    constructor {} { }\n}\noo::class create Sub {\n    superclass Base\n    constructor {} { next }\n}\n";
+        let analysis = analyse(src);
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let base_ctor_lens = lenses
+            .iter()
+            .find(|l| l.qname == "::Base::constructor")
+            .expect("Base constructor lens");
+        assert_eq!(base_ctor_lens.command_title, "1 reference", "{lenses:?}");
+        // `Sub` also declares its own constructor, so it gets a lens too —
+        // nothing chains *into* Sub's, so it reads zero.
+        let sub_ctor_lens = lenses
+            .iter()
+            .find(|l| l.qname == "::Sub::constructor")
+            .expect("Sub constructor lens");
+        assert_eq!(sub_ctor_lens.command_title, "0 references", "{lenses:?}");
+    }
+
+    #[test]
+    fn destructor_lens_counts_subclass_next_chain() {
+        let src = "oo::class create Base {\n    destructor { }\n}\noo::class create Sub {\n    superclass Base\n    destructor { next }\n}\n";
+        let analysis = analyse(src);
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let base_dtor_lens = lenses
+            .iter()
+            .find(|l| l.qname == "::Base::destructor")
+            .expect("Base destructor lens");
+        assert_eq!(base_dtor_lens.command_title, "1 reference", "{lenses:?}");
+    }
+
+    #[test]
+    fn constructor_lens_reports_zero_when_no_subclass_chains() {
+        let src = "oo::class create Base {\n    constructor {} { }\n}\n";
+        let analysis = analyse(src);
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let ctor_lens = lenses
+            .iter()
+            .find(|l| l.qname == "::Base::constructor")
+            .expect("constructor lens");
+        assert_eq!(ctor_lens.command_title, "0 references", "{lenses:?}");
+    }
+
+    #[test]
+    fn class_with_no_explicit_constructor_or_destructor_gets_neither_lens() {
+        let src = "oo::class create Plain {\n    method use {} {}\n}\n";
+        let analysis = analyse(src);
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        assert!(
+            lenses
+                .iter()
+                .all(|l| !l.qname.ends_with("::constructor") && !l.qname.ends_with("::destructor")),
+            "{lenses:?}"
+        );
+    }
+
+    #[test]
+    fn constructor_lens_carries_class_constructor_key_qname() {
+        let src = "oo::class create Bar {\n    constructor {} { }\n}\n";
+        let analysis = analyse(src);
+        let lenses = code_lenses(src, "tcl", Some(&analysis), None, "");
+        let ctor_lens = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("constructor lens");
+        assert_eq!(
+            ctor_lens.qname,
+            tcl_compiler::analyser::class_constructor_key("::Bar"),
+            "{lenses:?}"
+        );
     }
 
     // workspace-index: cross-document reference counts

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -43,6 +43,15 @@
 //! like the proc / class lenses, so it resolves to a clickable
 //! `tcl-lsp.showReferences` command the same way (issue #956).
 //!
+//! Per-property reference-count lenses: each `property` declaration gets
+//! the same treatment, sourced from
+//! [`crate::references::property_references_for_class`] instead — a
+//! class-local `my <property>` scan, since properties have no `$obj
+//! property` dispatch shape and no inheritance model. Carries a
+//! `{class}::property::{name}` qname
+//! ([`tcl_compiler::analyser::class_property_key`]) so it resolves through
+//! the same click-to-references flow (issue #992).
+//!
 //! Cross-document reference counts: when the
 //! caller threads a [`crate::workspace_index::WorkspaceIndex`]
 //! and the document's URI, the proc / class lens count
@@ -180,22 +189,29 @@ pub fn code_lenses(
     lenses
 }
 
-/// Emit per-member reference-count lenses for every method and classmethod
-/// in `class_def`.  The count for each member is the number of call sites
-/// [`references::method_references_for_class`] resolves — the single source
-/// of truth also used by Find All References and rename — so the lens title
-/// and the peek can never drift.  That resolver covers intra-class
-/// `my method` dispatch, external `$obj method` sites (resolved through the
-/// analyser's `instance_classes` variable-type tracking), and the call sites
-/// of any subclass that inherits (does not override) this definition.
+/// Emit per-member reference-count lenses for every method, classmethod, and
+/// property in `class_def`.  The count for a method / classmethod is the
+/// number of call sites [`references::method_references_for_class`]
+/// resolves; for a property it's [`references::property_references_for_class`]
+/// instead (a class-local `my <property>` scan — properties have no `$obj
+/// property` dispatch shape and no inheritance model).  Both are the same
+/// single source of truth also used by Find All References and rename, so
+/// the lens title and the peek can never drift.  The method/classmethod
+/// resolver covers intra-class `my method` dispatch, external `$obj method`
+/// sites (resolved through the analyser's `instance_classes` variable-type
+/// tracking), and the call sites of any subclass that inherits (does not
+/// override) this definition.
 ///
 /// Each lens carries a `{class}::method::{name}` / `{class}::classmethod::{name}`
-/// `qname` ([`tcl_compiler::analyser::class_member_key`]) — the same
+/// / `{class}::property::{name}` `qname`
+/// ([`tcl_compiler::analyser::class_member_key`] /
+/// [`tcl_compiler::analyser::class_property_key`]) — the same
 /// `qname`-present shape as the proc / class lenses — so the server's
 /// `code_lens_resolve` treats it as resolvable and attaches the *clickable*
 /// `tcl-lsp.showReferences` command instead of leaving it an inert bare
 /// title (issue #956: the `#724` "reference is not active" defect,
-/// previously fixed for proc/class lenses, recurring for methods).
+/// previously fixed for proc/class lenses, recurring for methods; issue
+/// #992 extends the same treatment to properties).
 fn emit_class_member_lenses(
     source: &str,
     dialect: &str,
@@ -256,6 +272,21 @@ fn emit_class_member_lenses(
             m.name_span,
             tcl_compiler::analyser::class_member_key(class_q, name, true),
             reference_count_title(member_ref_count(name, true)),
+            lenses,
+        );
+    }
+    for (name, p) in &class_def.properties {
+        if p.name_span.is_empty() {
+            continue;
+        }
+        let count = crate::references::property_references_for_class(
+            source, dialect, analysis, class_q, name,
+        )
+        .map_or(0, |(_decl, calls)| calls.len());
+        push_lens(
+            p.name_span,
+            tcl_compiler::analyser::class_property_key(class_q, name),
+            reference_count_title(count),
             lenses,
         );
     }
@@ -525,6 +556,86 @@ mod tests {
         assert_eq!(qnames.len(), 2, "{lenses:?}");
         assert!(qnames.contains("::C::method::foo"), "{qnames:?}");
         assert!(qnames.contains("::C::classmethod::foo"), "{qnames:?}");
+    }
+
+    // property-member lenses (issue #992)
+
+    /// `property` is Tcl 9.0+ — the shared `analyse()` helper above fixes the
+    /// dialect at 8.6, so these tests analyse at 9.0 directly (mirrors
+    /// `rename.rs`'s property-rename tests).
+    fn analyse90(source: &str) -> AnalysisResult {
+        let mut a = Analyser::new();
+        a.analyse(source, "tcl9.0").clone()
+    }
+
+    #[test]
+    fn lens_counts_property_my_dispatch_within_class_body() {
+        // A property's auto-generated accessor dispatches through `my
+        // <property>`, exactly like a method — `bump` reads/writes `size`
+        // twice, so its lens must read "2 references" the same way a
+        // twice-dispatched method would (`lens_counts_method_calls_within_class_body`).
+        let src = "oo::class create Widget {\n    property size -get {return $mySize} -set {set mySize $value}\n    method bump {} { my size ; my size }\n}\n";
+        let analysis = analyse90(src);
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        let lenses = code_lenses(src, "tcl9.0", Some(&analysis), None, "");
+        let size_lens = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("size lens");
+        assert_eq!(size_lens.command_title, "2 references", "{lenses:?}");
+    }
+
+    #[test]
+    fn lens_reports_zero_for_unused_property() {
+        let src = "oo::class create Widget {\n    property size\n}\n";
+        let analysis = analyse90(src);
+        if analysis.all_classes.is_empty() {
+            return;
+        }
+        let lenses = code_lenses(src, "tcl9.0", Some(&analysis), None, "");
+        let size_lens = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("size lens");
+        assert_eq!(size_lens.command_title, "0 references", "{lenses:?}");
+    }
+
+    #[test]
+    fn property_lens_carries_class_property_key_qname() {
+        let src = "oo::class create Widget {\n    property size\n}\n";
+        let analysis = analyse90(src);
+        let lenses = code_lenses(src, "tcl9.0", Some(&analysis), None, "");
+        let size_lens = lenses
+            .iter()
+            .find(|l| l.range.start_line == 1)
+            .expect("size lens");
+        assert_eq!(
+            size_lens.qname,
+            tcl_compiler::analyser::class_property_key("::Widget", "size"),
+            "{lenses:?}"
+        );
+        assert!(!size_lens.qname.is_empty(), "empty qname stays inert");
+    }
+
+    #[test]
+    fn property_qname_never_collides_with_a_same_named_method() {
+        // FP guard mirroring `method_and_classmethod_qnames_never_collide_on_same_name`:
+        // methods and properties are independent tables, so a `property
+        // color` and a `method color` on the same class must still get two
+        // distinct, disambiguated lenses.
+        let src = "oo::class create C {\n    property color\n    method color {} {}\n}\n";
+        let analysis = analyse90(src);
+        let lenses = code_lenses(src, "tcl9.0", Some(&analysis), None, "");
+        let qnames: std::collections::HashSet<&str> = lenses
+            .iter()
+            .filter(|l| l.range.start_line == 1 || l.range.start_line == 2)
+            .map(|l| l.qname.as_str())
+            .collect();
+        assert_eq!(qnames.len(), 2, "{lenses:?}");
+        assert!(qnames.contains("::C::property::color"), "{qnames:?}");
+        assert!(qnames.contains("::C::method::color"), "{qnames:?}");
     }
 
     // workspace-index: cross-document reference counts

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -314,7 +314,64 @@ pub fn references(
         return out;
     }
 
+    // `constructor` / `destructor` keyword — the next-chain reference story
+    // (issue #992); neither has a name to dispatch on, so no `my`/`$obj`
+    // call-site scan applies the way it does for a method.
+    if let Some(out) = constructor_or_destructor_references(&ctx, &word) {
+        return out;
+    }
+
     Vec::new()
+}
+
+/// Build references for a `constructor` / `destructor` keyword: when the
+/// cursor sits inside a class body on the keyword token of that class's own
+/// *effective* declaration (the last `constructor`, or the single
+/// `destructor`), surface its declaration plus every `next`/`nextto` site —
+/// in *any* class — whose MRO target resolves to it
+/// ([`constructor_next_chain_references`] / [`destructor_next_chain_references`]).
+///
+/// A cursor on a shadowed (non-last) `constructor` declaration resolves to
+/// nothing here — `oo::configurable` allows several, but only the last is
+/// ever reachable, so an earlier one has no reference story worth surfacing.
+fn constructor_or_destructor_references(ctx: &RefCtx<'_>, word: &str) -> Option<Vec<LspRange>> {
+    let RefCtx {
+        source,
+        dialect,
+        line_index,
+        line,
+        character,
+        analysis,
+        include_declaration,
+    } = *ctx;
+    if word != "constructor" && word != "destructor" {
+        return None;
+    }
+    let cursor_offset = crate::definition::byte_offset_at(line_index, source, line, character);
+    let class_def = analysis
+        .all_classes
+        .values()
+        .find(|cd| cd.body_span.start() < cursor_offset && cursor_offset < cd.body_span.end())?;
+    let name_span = if word == "constructor" {
+        class_def.constructors.last().map(|c| c.name_span)
+    } else {
+        class_def.destructor.as_ref().map(|d| d.name_span)
+    }?;
+    if !(name_span.start() <= cursor_offset && cursor_offset <= name_span.end()) {
+        return None;
+    }
+    let (decl_span, call_spans) = if word == "constructor" {
+        constructor_next_chain_references(source, dialect, analysis, &class_def.qualified_name)
+    } else {
+        destructor_next_chain_references(source, dialect, analysis, &class_def.qualified_name)
+    }?;
+    Some(build_member_ranges(
+        source,
+        line_index,
+        decl_span,
+        call_spans,
+        include_declaration,
+    ))
 }
 
 /// Shared immutable inputs for the per-kind reference resolvers, so each
@@ -815,6 +872,95 @@ pub fn method_next_dispatch_spans(
     scan_next_dispatch_sites(source, dialect, m.body_span)
 }
 
+/// Canonicalise a written class name (`nextto`'s argument) to the qualified
+/// form keyed in `analysis.all_classes`, owner-aware — the same resolution
+/// `definition.rs`'s go-to-definition `next`/`nextto` handling uses (kept as
+/// a separate copy rather than shared: it is a two-line wrapper around the
+/// registry's own `resolve_class_name`, so a cross-module `pub(crate)`
+/// promotion would cost more than it saves). Falls back to the written name
+/// when nothing resolves, so the caller's MRO lookup simply finds no match.
+fn canonicalise_class_name(analysis: &AnalysisResult, owner: &str, name: &str) -> String {
+    let tail_index =
+        tcl_compiler::analyser::class_hierarchy::build_tail_index(analysis.all_classes.keys());
+    tcl_compiler::analyser::class_hierarchy::resolve_class_name(
+        name,
+        owner,
+        |n| analysis.all_classes.contains_key(n),
+        &tail_index,
+    )
+    .unwrap_or_else(|| name.to_owned())
+}
+
+/// Every `next` / `nextto` call site — across every other class in this
+/// document — whose target resolves (via the class hierarchy's MRO) to
+/// `class_q`'s own effective constructor: a subclass constructor chaining
+/// up to its superclass's is a name-independent but still meaningful
+/// "referenced by an overriding subclass" relationship (issue #992), the
+/// constructor counterpart of [`method_next_dispatch_spans`]. Constructors
+/// have no name-based dispatch, so this next-chain scan is the *whole*
+/// reference story for one — no `my`/`$obj` call-site scan applies, unlike
+/// [`method_references_for_class`]. Returns `None` when `class_q` declares
+/// no explicit constructor.
+pub(crate) fn constructor_next_chain_references(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    class_q: &str,
+) -> Option<(tcl_lexer::Span, Vec<tcl_lexer::Span>)> {
+    let class_def = analysis.all_classes.get(class_q)?;
+    let decl_span = class_def.constructors.last()?.name_span;
+    let hierarchy = analysis.class_hierarchy();
+    let mut call_spans = Vec::new();
+    for (other_q, other_cd) in &analysis.all_classes {
+        if other_q == class_q {
+            continue;
+        }
+        let Some(ctor) = other_cd.constructors.last() else {
+            continue;
+        };
+        for (span, target) in scan_next_dispatch_sites_with_target(source, dialect, ctor.body_span)
+        {
+            let start_from = target.map(|t| canonicalise_class_name(analysis, other_q, &t));
+            if hierarchy.constructor_next_provider(other_q, start_from.as_deref(), source)
+                == Some(class_q)
+            {
+                call_spans.push(span);
+            }
+        }
+    }
+    Some((decl_span, call_spans))
+}
+
+/// The destructor counterpart of [`constructor_next_chain_references`].
+/// Returns `None` when `class_q` declares no explicit destructor.
+pub(crate) fn destructor_next_chain_references(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    class_q: &str,
+) -> Option<(tcl_lexer::Span, Vec<tcl_lexer::Span>)> {
+    let class_def = analysis.all_classes.get(class_q)?;
+    let decl_span = class_def.destructor.as_ref()?.name_span;
+    let hierarchy = analysis.class_hierarchy();
+    let mut call_spans = Vec::new();
+    for (other_q, other_cd) in &analysis.all_classes {
+        if other_q == class_q {
+            continue;
+        }
+        let Some(dtor) = &other_cd.destructor else {
+            continue;
+        };
+        for (span, target) in scan_next_dispatch_sites_with_target(source, dialect, dtor.body_span)
+        {
+            let start_from = target.map(|t| canonicalise_class_name(analysis, other_q, &t));
+            if hierarchy.destructor_next_provider(other_q, start_from.as_deref()) == Some(class_q) {
+                call_spans.push(span);
+            }
+        }
+    }
+    Some((decl_span, call_spans))
+}
+
 /// The external `$obj method` / bare `objcmd method` call sites for `method`
 /// on instances of `class_q` **within `source`**, independent of whether
 /// `class_q` is *defined* in this document.
@@ -1027,33 +1173,57 @@ fn scan_my_method_region(
 /// exactly like [`scan_my_method_region`] / [`scan_obj_method_region`] — a
 /// `next` inside an `if` / `while` / `foreach` / `switch` / `try` / `catch`
 /// body is found too (issue #957's general form).
+///
+/// Thin wrapper over [`scan_next_dispatch_sites_with_target`] that drops the
+/// `nextto` target argument — a method's `next`/`nextto` is flagged as a
+/// reference purely by presence, never MRO-resolved, so the target is
+/// irrelevant here (unlike the constructor/destructor next-chain resolvers,
+/// which need it to disambiguate `nextto`).
 fn scan_next_dispatch_sites(
     source: &str,
     dialect: &str,
     body: tcl_lexer::Span,
 ) -> Vec<tcl_lexer::Span> {
-    let mut out: Vec<tcl_lexer::Span> = Vec::new();
+    scan_next_dispatch_sites_with_target(source, dialect, body)
+        .into_iter()
+        .map(|(span, _target)| span)
+        .collect()
+}
+
+/// [`scan_next_dispatch_sites`], but paired with `nextto`'s target-class
+/// argument as written (`None` for plain `next`, which takes no argument, or
+/// for a malformed `nextto` with no argument token). Feeds the
+/// constructor/destructor next-chain resolvers
+/// ([`constructor_next_chain_references`] / [`destructor_next_chain_references`]),
+/// which must know *which* class a `nextto` names to decide whether it
+/// chains to the class under a given lens.
+fn scan_next_dispatch_sites_with_target(
+    source: &str,
+    dialect: &str,
+    body: tcl_lexer::Span,
+) -> Vec<(tcl_lexer::Span, Option<String>)> {
+    let mut out = Vec::new();
     if body.is_empty() {
         return out;
     }
     let (start, end) = strip_outer_braces(source, body);
     if start < end {
-        scan_next_dispatch_region(source, dialect, start, end, 0, &mut out);
+        scan_next_dispatch_region_with_target(source, dialect, start, end, 0, &mut out);
     }
     out
 }
 
-/// Segment `source[start..end]` and append the head-token span of every
-/// `next` / `nextto` command, recursing per [`nested_dispatch_regions`].
-/// `depth` guards against runaway recursion — see
-/// [`MAX_DISPATCH_SCAN_DEPTH`].
-fn scan_next_dispatch_region(
+/// Segment `source[start..end]` and append the head-token span (plus
+/// `nextto`'s target argument, when present) of every `next` / `nextto`
+/// command, recursing per [`nested_dispatch_regions`]. `depth` guards
+/// against runaway recursion — see [`MAX_DISPATCH_SCAN_DEPTH`].
+fn scan_next_dispatch_region_with_target(
     source: &str,
     dialect: &str,
     start: usize,
     end: usize,
     depth: u32,
-    out: &mut Vec<tcl_lexer::Span>,
+    out: &mut Vec<(tcl_lexer::Span, Option<String>)>,
 ) {
     use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
     if start >= end || end > source.len() || depth > MAX_DISPATCH_SCAN_DEPTH {
@@ -1071,12 +1241,29 @@ fn scan_next_dispatch_region(
             if h_end <= source.len() && h_start < h_end {
                 let h = &source[h_start..h_end];
                 if h == "next" || h == "nextto" {
-                    out.push(head.span);
+                    let target =
+                        (h == "nextto")
+                            .then(|| cmd.argv.get(1))
+                            .flatten()
+                            .and_then(|tok| {
+                                let (a_start, a_end) =
+                                    (tok.span.start() as usize, tok.span.end() as usize);
+                                (a_end <= source.len() && a_start < a_end)
+                                    .then(|| source[a_start..a_end].to_owned())
+                            });
+                    out.push((head.span, target));
                 }
             }
         }
         for (inner_start, inner_end) in nested_dispatch_regions(source, dialect, cmd) {
-            scan_next_dispatch_region(source, dialect, inner_start, inner_end, depth + 1, out);
+            scan_next_dispatch_region_with_target(
+                source,
+                dialect,
+                inner_start,
+                inner_end,
+                depth + 1,
+                out,
+            );
         }
     }
 }
@@ -2004,6 +2191,87 @@ mod tests {
                 .any(|r| r.start_line == 5 && r.start_character > 15),
             "expected the `next` dispatch among refs: {refs:?}",
         );
+    }
+
+    // Constructor / destructor next-chain references (issue #992).
+
+    #[test]
+    fn constructor_next_chain_reference_from_direct_subclass() {
+        // `Sub`'s constructor calls plain `next`, chaining to `Base`'s —
+        // cursor on `Base`'s own `constructor` keyword must surface that
+        // chain as a reference.
+        let src = "oo::class create Base {\n    constructor {} { }\n}\noo::class create Sub {\n    superclass Base\n    constructor {} { next }\n}\n";
+        let analysis = analyse(src);
+        // `constructor` keyword on line 1, col 4.
+        let refs = references(src, "tcl", 1, 6, &analysis, true);
+        // decl (line 1) + the `next` call site (line 5).
+        assert_eq!(refs.len(), 2, "{refs:?}");
+        assert!(refs.iter().any(|r| r.start_line == 5), "{refs:?}");
+    }
+
+    #[test]
+    fn constructor_next_chain_reference_skips_non_overriding_subclass() {
+        // `Sub` inherits `Base`'s constructor outright (declares none of its
+        // own) — nothing to chain, so `Base`'s constructor stays unreferenced.
+        let src = "oo::class create Base {\n    constructor {} { }\n}\noo::class create Sub {\n    superclass Base\n}\n";
+        let analysis = analyse(src);
+        let refs = references(src, "tcl", 1, 6, &analysis, false);
+        assert!(refs.is_empty(), "{refs:?}");
+    }
+
+    #[test]
+    fn constructor_next_chain_reference_not_counted_without_next() {
+        // `Sub` declares its own constructor but never calls `next` — a
+        // legitimate full override, not a chain.
+        let src = "oo::class create Base {\n    constructor {} { }\n}\noo::class create Sub {\n    superclass Base\n    constructor {} { set x 1 }\n}\n";
+        let analysis = analyse(src);
+        let refs = references(src, "tcl", 1, 6, &analysis, false);
+        assert!(refs.is_empty(), "{refs:?}");
+    }
+
+    #[test]
+    fn constructor_next_chain_reference_skips_ancestor_with_no_own_constructor() {
+        // `Mid` declares no constructor of its own; `Sub`'s `next` must
+        // still reach `Base` (the actual MRO-effective provider), not `Mid`.
+        let src = "oo::class create Base {\n    constructor {} { }\n}\noo::class create Mid {\n    superclass Base\n}\noo::class create Sub {\n    superclass Mid\n    constructor {} { next }\n}\n";
+        let analysis = analyse(src);
+        // `Base`'s constructor (line 1) picks up the chain.
+        let base_refs = references(src, "tcl", 1, 6, &analysis, false);
+        assert_eq!(base_refs.len(), 1, "{base_refs:?}");
+        assert_eq!(base_refs[0].start_line, 8, "{base_refs:?}");
+    }
+
+    #[test]
+    fn constructor_next_chain_reference_via_nextto_explicit_target() {
+        // `nextto Grandparent` jumps past `Base` even though `Base` also has
+        // an effective constructor — only `Grandparent` picks up a reference.
+        let src = "oo::class create Grandparent {\n    constructor {} { }\n}\noo::class create Base {\n    superclass Grandparent\n    constructor {} { }\n}\noo::class create Sub {\n    superclass Base\n    constructor {} { nextto Grandparent }\n}\n";
+        let analysis = analyse(src);
+        let grandparent_refs = references(src, "tcl", 1, 6, &analysis, false);
+        assert_eq!(grandparent_refs.len(), 1, "{grandparent_refs:?}");
+        let base_refs = references(src, "tcl", 4, 6, &analysis, false);
+        assert!(base_refs.is_empty(), "{base_refs:?}");
+    }
+
+    #[test]
+    fn destructor_next_chain_reference_from_direct_subclass() {
+        let src = "oo::class create Base {\n    destructor { }\n}\noo::class create Sub {\n    superclass Base\n    destructor { next }\n}\n";
+        let analysis = analyse(src);
+        // `destructor` keyword on line 1, col 4.
+        let refs = references(src, "tcl", 1, 5, &analysis, true);
+        assert_eq!(refs.len(), 2, "{refs:?}");
+        assert!(refs.iter().any(|r| r.start_line == 5), "{refs:?}");
+    }
+
+    #[test]
+    fn constructor_shadowed_by_a_later_redeclaration_has_no_references() {
+        // `oo::configurable` allows several constructors; only the last is
+        // ever effective. A cursor on the shadowed first one resolves to
+        // nothing (it has no reference story worth surfacing).
+        let src = "oo::class create C {\n    constructor {} { }\n    constructor {} { }\n}\n";
+        let analysis = analyse(src);
+        let refs = references(src, "tcl", 1, 6, &analysis, true);
+        assert!(refs.is_empty(), "{refs:?}");
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -309,15 +309,24 @@ pub fn references(
         return out;
     }
 
-    // Class-member references (cursor inside a class body on a member name).
-    if let Some(out) = class_member_references(&ctx, &word) {
+    // `constructor` / `destructor` keyword — the next-chain reference story
+    // (issue #992); neither has a name to dispatch on, so no `my`/`$obj`
+    // call-site scan applies the way it does for a method. Tried *before*
+    // the ordinary class-member lookup below: a class may legally also
+    // declare a `method`/`property` literally named `constructor` or
+    // `destructor` (the keyword form and a same-named ordinary member are
+    // independent), and `class_member_references`'s cursor-outside-any-span
+    // fallback (see `resolve_member_span`) would otherwise claim a cursor
+    // sitting on the special keyword token for that unrelated same-named
+    // member instead (Codex review on #1011, P2). This resolver only ever
+    // matches when the cursor sits strictly on the keyword's own name span,
+    // so trying it first never steals a real member reference.
+    if let Some(out) = constructor_or_destructor_references(&ctx, &word) {
         return out;
     }
 
-    // `constructor` / `destructor` keyword — the next-chain reference story
-    // (issue #992); neither has a name to dispatch on, so no `my`/`$obj`
-    // call-site scan applies the way it does for a method.
-    if let Some(out) = constructor_or_destructor_references(&ctx, &word) {
+    // Class-member references (cursor inside a class body on a member name).
+    if let Some(out) = class_member_references(&ctx, &word) {
         return out;
     }
 
@@ -901,6 +910,20 @@ fn canonicalise_class_name(analysis: &AnalysisResult, owner: &str, name: &str) -
 /// reference story for one — no `my`/`$obj` call-site scan applies, unlike
 /// [`method_references_for_class`]. Returns `None` when `class_q` declares
 /// no explicit constructor.
+///
+/// Not gated by `DefinerFamily` (Codex review on #1011, P1): `next` /
+/// `nextto` and the MRO this walks (`ClassHierarchy::mro_map`, built by
+/// `tcloo_linearise` for every `ClassDef` alike) are `TclOO`-specific —
+/// Snit / [incr Tcl] classes have different chaining models the registry
+/// doesn't even register a `next`/`nextto` command for. This is not a new
+/// gap: [`method_next_dispatch_spans`] / [`ClassHierarchy::next_provider`]
+/// have run unconditionally across every definer family since they were
+/// introduced, with no existing itcl/Snit exclusion (unlike
+/// `find_obj_method_call_sites`'s classmethod dispatch-shape check, which
+/// *does* consult `is_itcl_class` for an unrelated concern). Gating only
+/// the constructor/destructor path here would be an inconsistent partial
+/// fix, not a real one — a proper fix scopes the whole next/nextto
+/// reference system by family, out of scope for this change.
 pub(crate) fn constructor_next_chain_references(
     source: &str,
     dialect: &str,
@@ -1241,16 +1264,18 @@ fn scan_next_dispatch_region_with_target(
             if h_end <= source.len() && h_start < h_end {
                 let h = &source[h_start..h_end];
                 if h == "next" || h == "nextto" {
-                    let target =
-                        (h == "nextto")
-                            .then(|| cmd.argv.get(1))
-                            .flatten()
-                            .and_then(|tok| {
-                                let (a_start, a_end) =
-                                    (tok.span.start() as usize, tok.span.end() as usize);
-                                (a_end <= source.len() && a_start < a_end)
-                                    .then(|| source[a_start..a_end].to_owned())
-                            });
+                    // `texts` is the segmenter's already-*decoded* per-word
+                    // reconstruction — unlike `argv`'s token span (which
+                    // covers a braced/quoted word's raw delimiters per this
+                    // codebase's body-span convention, e.g. `{Grandparent`
+                    // for `nextto {Grandparent}`, dropping only the closer),
+                    // `texts[1]` is plain `"Grandparent"` regardless of
+                    // whether the target was written bare, braced, or
+                    // quoted. Slicing the raw span instead left a literal
+                    // `{`/`"` in the target text, which
+                    // `canonicalise_class_name` could never resolve to a
+                    // real class (Codex review on #1011, P2).
+                    let target = (h == "nextto").then(|| cmd.texts.get(1).cloned()).flatten();
                     out.push((head.span, target));
                 }
             }
@@ -2254,6 +2279,21 @@ mod tests {
     }
 
     #[test]
+    fn constructor_next_chain_reference_via_braced_nextto_target() {
+        // Regression (Codex review on #1011, P2): `nextto {Grandparent}` (a
+        // braced target, functionally identical to the bare form) must
+        // resolve exactly like `constructor_next_chain_reference_via_nextto_explicit_target`'s
+        // bare `nextto Grandparent` — the decoded word, not the raw
+        // delimited span, is what gets resolved against the class map.
+        let src = "oo::class create Grandparent {\n    constructor {} { }\n}\noo::class create Base {\n    superclass Grandparent\n    constructor {} { }\n}\noo::class create Sub {\n    superclass Base\n    constructor {} { nextto {Grandparent} }\n}\n";
+        let analysis = analyse(src);
+        let grandparent_refs = references(src, "tcl", 1, 6, &analysis, false);
+        assert_eq!(grandparent_refs.len(), 1, "{grandparent_refs:?}");
+        let base_refs = references(src, "tcl", 4, 6, &analysis, false);
+        assert!(base_refs.is_empty(), "{base_refs:?}");
+    }
+
+    #[test]
     fn destructor_next_chain_reference_from_direct_subclass() {
         let src = "oo::class create Base {\n    destructor { }\n}\noo::class create Sub {\n    superclass Base\n    destructor { next }\n}\n";
         let analysis = analyse(src);
@@ -2272,6 +2312,26 @@ mod tests {
         let analysis = analyse(src);
         let refs = references(src, "tcl", 1, 6, &analysis, true);
         assert!(refs.is_empty(), "{refs:?}");
+    }
+
+    #[test]
+    fn constructor_keyword_resolves_its_own_next_chain_even_with_a_same_named_method() {
+        // Regression (Codex review on #1011, P2): a class can also declare a
+        // `method` literally named `constructor` — an independent, ordinary
+        // member sharing a name with the special keyword form. A cursor on
+        // the special `constructor` keyword must still resolve its own
+        // next-chain story, not fall through to the unrelated same-named
+        // method's (ordinary) references.
+        let src = "oo::class create Base {\n    constructor {} { }\n}\noo::class create Sub {\n    superclass Base\n    constructor {} { next }\n    method constructor {} { }\n}\n";
+        let analysis = analyse(src);
+        // `Base`'s `constructor` keyword, line 1.
+        let refs = references(src, "tcl", 1, 6, &analysis, false);
+        assert_eq!(
+            refs.len(),
+            1,
+            "must resolve the next-chain, not the unrelated same-named method: {refs:?}"
+        );
+        assert_eq!(refs[0].start_line, 5, "{refs:?}");
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -757,6 +757,35 @@ pub(crate) fn method_references_for_class(
     Some((decl_span, call_spans))
 }
 
+/// Resolve a property's declaration span plus every `my <property>` call
+/// site — the property counterpart of [`method_references_for_class`], and
+/// the single source of truth the code lens and the reference peek both
+/// defer to so their counts can never drift.  Properties have no `$obj
+/// property` dispatch shape and no inheritance model (confirmed against
+/// tclsh 9.0.4), so a class-local `my <name>` scan — the same matcher
+/// [`scan_my_method_sites`] uses for methods — is the whole story; a
+/// property's own `property <name>` declaration is never itself a `my
+/// <name>` call site, so there's no declaration span to skip. Returns
+/// `None` when `class_q` has no property named `property`.
+pub(crate) fn property_references_for_class(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    class_q: &str,
+    property: &str,
+) -> Option<(tcl_lexer::Span, Vec<tcl_lexer::Span>)> {
+    let class_def = analysis.all_classes.get(class_q)?;
+    let decl_span = class_def.properties.get(property)?.name_span;
+    let call_spans = scan_my_method_sites(
+        source,
+        dialect,
+        &collect_member_bodies(class_def),
+        property,
+        None,
+    );
+    Some((decl_span, call_spans))
+}
+
 /// The `next` / `nextto` super-dispatch spans inside `class_q`'s own `method`
 /// body — polymorphic **references** to `method`.  Kept out of
 /// [`method_references_for_class`] because that set also drives *rename*, and
@@ -1125,7 +1154,7 @@ fn find_class_member_references(
         // merges them) disambiguates by which declaration's own span the
         // cursor sits on rather than a fixed priority — see
         // `resolve_member_span`.
-        let (kind, member_span) = resolve_member_span(class_def, word, cursor_offset)?;
+        let (kind, _) = resolve_member_span(class_def, word, cursor_offset)?;
         if matches!(kind, MemberSel::Method | MemberSel::ClassMethod) {
             let is_classmethod = kind == MemberSel::ClassMethod;
             // Methods / classmethods: defer to the shared resolver — the *same*
@@ -1155,21 +1184,16 @@ fn find_class_member_references(
             ));
             return Some((decl, calls));
         }
-        // Properties: no `$obj prop` dispatch and no inheritance model, so a
-        // class-local `my <prop>` scan is the whole story — the same
-        // intra-class `my <name>` matcher [`scan_my_method_sites`] uses for
-        // methods (recursing into `[...]` substitutions and same-frame
-        // control-flow / `eval` bodies), just with no declaration span to
-        // skip: a property's declaration is `property <name>` in the
-        // definer body, never itself a `my <name>` call site.
-        let call_spans = scan_my_method_sites(
+        // Properties: defer to the shared resolver — the *same* one the code
+        // lens counts with — so the peek and the lens can never drift, just
+        // like the method / classmethod branch above.
+        return property_references_for_class(
             source,
             dialect,
-            &collect_member_bodies(class_def),
+            analysis,
+            &class_def.qualified_name,
             word,
-            None,
         );
-        return Some((member_span, call_spans));
     }
     None
 }

--- a/rust/tcl-lsp-server/tests/e2e/editor_features.rs
+++ b/rust/tcl-lsp-server/tests/e2e/editor_features.rs
@@ -289,6 +289,97 @@ fn test_find_references_on_classmethod_finds_bare_class_command_dispatch() {
     );
 }
 
+#[test]
+fn test_property_lens_counts_my_dispatch_and_resolves_clickable() {
+    // TP mirroring `test_method_lens_counts_external_obj_dispatch_issue_864`:
+    // a `property`'s auto-generated accessor is dispatched via `my <name>`,
+    // just like a method, so its lens must count those sites and resolve to
+    // a clickable command the same way (issue #992).
+    // `property` is Tcl 9.0+, so pin the dialect via the in-source directive
+    // (shifts every line below down by one).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "# tcl-dialect: tcl9.0\noo::class create Widget {\n    property size -get {return $mySize} -set {set mySize $value}\n    method bump {} { my size ; my size }\n}\n",
+    );
+    let ls = lenses(&mut lsp, &uri);
+    // `property size` is on line 2 (0-based).
+    let command = resolve_member_lens_on_line(&mut lsp, &ls, 2);
+    assert_eq!(command["title"], json!("2 references"), "{ls:?}");
+    assert_eq!(
+        command["command"],
+        json!("tcl-lsp.showReferences"),
+        "property lens resolved to an inert command: {command:?}"
+    );
+    // The lens count must equal Find All References (declaration excluded) on
+    // the `size` property-name token (`    property size` → col 13).
+    let refs = match lsp.references(&uri, 2, 13, false) {
+        Value::Array(a) => a,
+        _ => Vec::new(),
+    };
+    assert_eq!(refs.len(), 2, "peek disagrees with lens: {refs:?}");
+}
+
+#[test]
+fn test_property_lens_zero_when_unused() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "# tcl-dialect: tcl9.0\noo::class create Widget {\n    property size\n}\n",
+    );
+    let ls = lenses(&mut lsp, &uri);
+    let command = resolve_member_lens_on_line(&mut lsp, &ls, 2);
+    assert_eq!(command["title"], json!("0 references"), "{ls:?}");
+    assert_eq!(
+        command["command"],
+        json!("tcl-lsp.showReferences"),
+        "{command:?}"
+    );
+}
+
+#[test]
+fn test_property_method_and_class_all_get_lenses_constructor_does_not_issue_992() {
+    // Repro from issue #992: a class with a `property`, a `constructor`, and
+    // a `method` gets exactly three lenses — the class itself, the property,
+    // and the method — with the constructor intentionally excluded (a
+    // constructor is invoked positionally, `Widget new`/`create`, never
+    // dispatched by name, so "N references" has no obvious meaning for it;
+    // out of scope for this fix per the issue's own "Constructors /
+    // destructors" discussion).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "# tcl-dialect: tcl9.0\noo::class create Widget {\n    property size -get {return $mySize} -set {set mySize $value}\n    constructor {} { set mySize 10 }\n    method use {} { return 1 }\n}\nset w [Widget new]\n$w use\n",
+    );
+    let ls = lenses(&mut lsp, &uri);
+    assert_eq!(
+        ls.len(),
+        3,
+        "class + property + method, no constructor: {ls:?}"
+    );
+
+    let class_lens = resolve_member_lens_on_line(&mut lsp, &ls, 1);
+    assert_eq!(class_lens["title"], json!("1 reference"), "{ls:?}");
+
+    let property_lens = resolve_member_lens_on_line(&mut lsp, &ls, 2);
+    assert_eq!(property_lens["title"], json!("0 references"), "{ls:?}");
+    assert_eq!(property_lens["command"], json!("tcl-lsp.showReferences"));
+
+    // No lens anchored on line 3 — the `constructor` declaration.
+    assert!(
+        !ls.iter()
+            .any(|l| l["range"]["start"]["line"].as_i64() == Some(3)),
+        "constructor must not get a lens: {ls:?}"
+    );
+
+    let method_lens = resolve_member_lens_on_line(&mut lsp, &ls, 4);
+    assert_eq!(method_lens["title"], json!("1 reference"), "{ls:?}");
+    assert_eq!(method_lens["command"], json!("tcl-lsp.showReferences"));
+}
+
 // -- TestDocumentLinks ---------------------------------------------------
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/editor_features.rs
+++ b/rust/tcl-lsp-server/tests/e2e/editor_features.rs
@@ -340,14 +340,13 @@ fn test_property_lens_zero_when_unused() {
 }
 
 #[test]
-fn test_property_method_and_class_all_get_lenses_constructor_does_not_issue_992() {
+fn test_property_method_constructor_and_class_all_get_lenses_issue_992() {
     // Repro from issue #992: a class with a `property`, a `constructor`, and
-    // a `method` gets exactly three lenses — the class itself, the property,
-    // and the method — with the constructor intentionally excluded (a
-    // constructor is invoked positionally, `Widget new`/`create`, never
-    // dispatched by name, so "N references" has no obvious meaning for it;
-    // out of scope for this fix per the issue's own "Constructors /
-    // destructors" discussion).
+    // a `method` gets a lens for every one of them — the class itself, the
+    // property, the constructor, and the method. The constructor's lens is
+    // scoped to the next-chain relationship (issue #992's own "Constructors
+    // / destructors" follow-up), not a general dispatch count, so it reads
+    // "0 references" here (nothing chains into it).
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     lsp.open_ready(
@@ -357,8 +356,8 @@ fn test_property_method_and_class_all_get_lenses_constructor_does_not_issue_992(
     let ls = lenses(&mut lsp, &uri);
     assert_eq!(
         ls.len(),
-        3,
-        "class + property + method, no constructor: {ls:?}"
+        4,
+        "class + property + constructor + method: {ls:?}"
     );
 
     let class_lens = resolve_member_lens_on_line(&mut lsp, &ls, 1);
@@ -368,16 +367,44 @@ fn test_property_method_and_class_all_get_lenses_constructor_does_not_issue_992(
     assert_eq!(property_lens["title"], json!("0 references"), "{ls:?}");
     assert_eq!(property_lens["command"], json!("tcl-lsp.showReferences"));
 
-    // No lens anchored on line 3 — the `constructor` declaration.
-    assert!(
-        !ls.iter()
-            .any(|l| l["range"]["start"]["line"].as_i64() == Some(3)),
-        "constructor must not get a lens: {ls:?}"
-    );
+    let constructor_lens = resolve_member_lens_on_line(&mut lsp, &ls, 3);
+    assert_eq!(constructor_lens["title"], json!("0 references"), "{ls:?}");
+    assert_eq!(constructor_lens["command"], json!("tcl-lsp.showReferences"));
 
     let method_lens = resolve_member_lens_on_line(&mut lsp, &ls, 4);
     assert_eq!(method_lens["title"], json!("1 reference"), "{ls:?}");
     assert_eq!(method_lens["command"], json!("tcl-lsp.showReferences"));
+}
+
+#[test]
+fn test_constructor_lens_counts_and_resolves_subclass_next_chain() {
+    // TP for issue #992's own follow-up: a subclass constructor chaining to
+    // its superclass's via `next` is a name-independent but still
+    // meaningful reference — the superclass constructor's lens must count
+    // it and resolve to a clickable command, the same as every other lens
+    // kind.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "oo::class create Base {\n    constructor {} { }\n}\noo::class create Sub {\n    superclass Base\n    constructor {} { next }\n}\n",
+    );
+    let ls = lenses(&mut lsp, &uri);
+    // `Base`'s constructor is on line 1.
+    let command = resolve_member_lens_on_line(&mut lsp, &ls, 1);
+    assert_eq!(command["title"], json!("1 reference"), "{ls:?}");
+    assert_eq!(
+        command["command"],
+        json!("tcl-lsp.showReferences"),
+        "constructor lens resolved to an inert command: {command:?}"
+    );
+    // The lens count must equal Find All References (declaration excluded)
+    // on the `constructor` keyword (`    constructor` → col 4).
+    let refs = match lsp.references(&uri, 1, 4, false) {
+        Value::Array(a) => a,
+        _ => Vec::new(),
+    };
+    assert_eq!(refs.len(), 1, "peek disagrees with lens: {refs:?}");
 }
 
 // -- TestDocumentLinks ---------------------------------------------------


### PR DESCRIPTION
## Summary

- `emit_class_member_lenses` only looped over `class_def.methods` and `class_def.class_methods` — a TclOO `property` member (`oo::configurable`'s `property name -get {...} -set {...}` form) got no code lens at all, even though `find_class_member_references` already resolved a cursor on a property name to its declaration plus every `my <property>` call site. Added a loop over `class_def.properties`, reusing that existing reference-counting machinery via a new `property_references_for_class`, with a stable `{class}::property::{name}` qname so it resolves through the same click-to-references flow as methods/classmethods (issue #956's fix, applied to properties).
- Follow-up (issue #992's own "Constructors / destructors" discussion): a class's own explicit `constructor`/`destructor` now also gets a lens. A conventional dispatch-based reference count has no general meaning for either (both are invoked positionally — `ClassName new`/`create`/`destroy` — never by name), so the count is scoped to the one name-independent relationship that is meaningful: an overriding subclass's own constructor/destructor chaining up to this one via `next` / `nextto`. `ClassHierarchy` gained `constructor_next_provider`/`destructor_next_provider` (MRO-aware, mirroring the existing `next_provider`/`constructor_provider`, correctly skipping an intermediate ancestor with no constructor/destructor of its own), and `references.rs` gained the matching `constructor_next_chain_references`/`destructor_next_chain_references`, wired into both the lens and a new `references()` branch so the lens and Find-All-References can never drift apart. `nextto SomeClass`'s explicit target is resolved rather than assumed to be the immediate superclass.
- Updated `docs/kcs/features/kcs-feature-code-lens.md` to document both additions.

## Validation

- `cargo fmt --check`
- `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- `cargo test --workspace --all-features` (clean end-to-end; two KCS help-catalogue golden-fixture regenerations included, since the catalogue embeds the doc summary text verbatim)

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? No new diagnostics or analysis-result fields — this only adds lens/reference-resolution consumers over existing `ClassDef` data (`properties`, `constructors`, `destructor`) and a new pure MRO query (`constructor_next_provider`/`destructor_next_provider`) alongside the existing `next_provider`/`constructor_provider`.
- [x] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. N/A — this is an LSP-facing feature note (`docs/kcs/features/kcs-feature-code-lens.md`), updated.
- [ ] If I added a new compiler KCS note, I linked it from both `docs/kcs/compiler/README.md` and `docs/kcs/README.md`. N/A — no new compiler KCS note.

Closes #992.


---
_Generated by [Claude Code](https://claude.ai/code/session_019c5gfMkmB1pRLfvrag36Qd)_