### PR TITLE
Fix W129 missing safe-interp hidden commands via bracket-substitution indirection (#1001)

### DIFF
--- a/README.md
+++ b/README.md
@@ -318,7 +318,13 @@ catch { error "oops" }       ;# W302: catch without a result variable
 Child interpreters are modelled too: a command hidden in a safe
 interpreter (`interp create -safe`) is flagged where it can never run
 (W129), and an `interp eval` into an interpreter the file never creates
-is flagged before it fails at run time (W140).
+is flagged before it fails at run time (W140). W129 follows the hidden
+command through `[...]` bracket-substitution indirection too — a direct
+nested call, `{*}` expansion, the `package ifneeded name ver [list apply
+{dir {...}} $dir]` deferred-command idiom, and a `namespace ensemble
+create`/`configure -map` redirect to a hidden target — so a hidden
+`source` reached only that way is flagged the same as a direct call, in
+both a one-shot lint and the live editor session.
 
 ```tcl
 interp create -safe s

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -54,6 +54,11 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   when `apply` is reached indirectly through `[list apply {...} $x]`
   (the pkgIndex.tcl `package ifneeded ... [list apply {dir {...}} $dir]`
   idiom), even though a direct `apply {...}` call highlights fine.
+- [kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md](kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md)
+  — W129 (a command hidden in a safe interpreter) does not warn when the
+  hidden command is reached only through a `[...]` bracket substitution —
+  most importantly the `package ifneeded ... [list apply {...} $dir]`
+  deferred-command idiom.
 - [kcs-issue-duplicate-diagnostics.md](kcs-issue-duplicate-diagnostics.md)
   — the same finding is reported twice.
 - [kcs-issue-counter-numtests-array-init.md](kcs-issue-counter-numtests-array-init.md)

--- a/docs/kcs/codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md
+++ b/docs/kcs/codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md
@@ -30,14 +30,18 @@ because C Tcl never runs it.
 
 The check also follows a hidden command through `[...]` bracket-substitution
 indirection — a direct nested call (`set x [source b.tcl]`), `{*}` expansion
-of a built command, and the pervasive `package ifneeded name ver [list apply
+of a built command, the pervasive `package ifneeded name ver [list apply
 {dir {...}} $dir]` deferred-command idiom (also seen as `-command [list
 apply {...} $x]`, `after idle [list apply {...} $x]`, `trace add ...
-command [list apply {...} $x]`) — so a hidden `source` nested inside such a
-lambda body is flagged the same way a direct `source` call would be.  The
-underlying runtime already refuses every one of these shapes at execution
-time regardless of whether this diagnostic catches it ahead of time — this
-check is early, editor-time feedback, not the enforcement mechanism itself.
+command [list apply {...} $x]`), and a `namespace ensemble create`/`configure
+-map` redirection to a hidden target — so a hidden `source` nested inside
+such a lambda body, or reached by calling an ensemble subcommand mapped to
+it, is flagged the same way a direct `source` call would be.  This applies
+equally whether the code is analysed as a whole file or incrementally by
+the running editor session.  The underlying runtime already refuses every
+one of these shapes at execution time regardless of whether this diagnostic
+catches it ahead of time — this check is early, editor-time feedback, not
+the enforcement mechanism itself.
 
 ## Symptoms
 

--- a/docs/kcs/codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md
+++ b/docs/kcs/codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md
@@ -28,6 +28,17 @@ interpreter's visible command set (safe state plus any explicit
 [source](../../GLOSSARY.md#source-edge) or definition facts from it,
 because C Tcl never runs it.
 
+The check also follows a hidden command through `[...]` bracket-substitution
+indirection — a direct nested call (`set x [source b.tcl]`), `{*}` expansion
+of a built command, and the pervasive `package ifneeded name ver [list apply
+{dir {...}} $dir]` deferred-command idiom (also seen as `-command [list
+apply {...} $x]`, `after idle [list apply {...} $x]`, `trace add ...
+command [list apply {...} $x]`) — so a hidden `source` nested inside such a
+lambda body is flagged the same way a direct `source` call would be.  The
+underlying runtime already refuses every one of these shapes at execution
+time regardless of whether this diagnostic catches it ahead of time — this
+check is early, editor-time feedback, not the enforcement mechanism itself.
+
 ## Symptoms
 
 - A yellow squiggle appears under a command inside an
@@ -67,3 +78,11 @@ An `interp hide` in a **normal** interpreter draws the same warning for
 the hidden name, and a dynamic `interp hide` / `interp expose` operand
 makes the visible set unknowable, so the analyser abstains entirely for
 that interpreter.
+
+A command reached only through an unresolvable dynamic value (`{*}$cmdList`,
+or `set cmd source; $cmd b.tcl`) is not flagged — its identity cannot be
+proven statically, and this diagnostic prefers a missed warning over a
+false one. See the
+[contributor-level note on the bracket-indirection fix](../kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md)
+for the full list of indirection shapes this check follows (and the ones it
+deliberately does not).

--- a/docs/kcs/kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md
+++ b/docs/kcs/kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md
@@ -307,7 +307,10 @@ its own tracked issue.
 
 - `rust/tcl-compiler/src/analyser/handlers.rs` (suffixed `_1001`) —
   `safe_interp_w129_list_quoted_apply_lambda_body_reports_hidden_source_1001`
-  (the reported repro), `safe_interp_w129_list_quoted_apply_in_command_prefix_position_1001`,
+  (the reported repro), `safe_interp_w129_expand_list_quoted_apply_lambda_body_1001`
+  and `safe_interp_w129_list_quoted_apply_package_ifneeded_then_require_1001`
+  (issue #1001's own second and third repro cases, pinned verbatim),
+  `safe_interp_w129_list_quoted_apply_in_command_prefix_position_1001`,
   `safe_interp_w129_list_quoted_apply_after_idle_1001`,
   `safe_interp_w129_list_quoted_hidden_command_directly_1001` (no `apply`),
   `safe_interp_w129_list_quoted_apply_in_plain_data_is_not_flagged_1001` (FP

--- a/docs/kcs/kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md
+++ b/docs/kcs/kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md
@@ -197,21 +197,34 @@ source; $cmd $file`) are **not** flagged — see decision rule 3.
    indirection shape specifically. Worth a follow-up test-only PR; not
    folded into this fix since it changes no runtime behaviour.
 7. **`namespace ensemble configure -map` redirection to a hidden command is
-   an explicitly scoped-out, pre-existing gap, not fixed here.** Only
-   `namespace ensemble create ... -map {...}` is handled by
-   `handle_namespace_ensemble` at all (`configure` is silently ignored —
-   `if args[1] != "create" { return; }`); even for `create`, a `-map` target
-   is recorded only as a *reference* (`push_command_reference`, for
-   find-references/rename), never resolved at the ensemble's own *call
-   sites* — `myEnsemble sub ...` is analysed as an ordinary call to
-   `myEnsemble` (not hidden), never as a call to the mapped target. Making
-   W129 see through ensemble-map redirection would require building
-   generic ensemble-dispatch-aware call-site resolution that does not exist
-   for *any* diagnostic today — the same theme as issue #979's
-   interprocedural call-site gap. Fixing that is a distinct, larger,
-   pre-existing architectural gap shared with #979, not specific to
-   bracket-substitution indirection; tracked separately rather than folded
-   into this fix.
+   now resolved at the ensemble's own call sites.** `handle_namespace_ensemble`
+   now accepts both `create` and `configure` (previously `configure` was
+   silently ignored — `if args[1] != "create" { return; }`); for both forms,
+   `record_ensemble_map_targets` records each `-map` target's *raw, written
+   text* (not a namespace-resolved qualified name) into a new
+   `self.ensemble_command_maps: HashMap<String, HashMap<String, String>>`,
+   keyed by the ensemble's own name (the enclosing namespace for a bare
+   `create`, or the `-command` value when given — `-command` *replaces* the
+   default naming, it does not add an alias, confirmed against real
+   `tclsh8.6` — or the resolved `NAME` argument for `configure`). A new
+   `Analyser::check_ensemble_redirect_hiding` call (from both
+   `check_indirect_hiding` and `dispatch_nested_segment`) looks up the
+   called command's first argument (the ensemble subcommand) in this map
+   and, on a hit, runs `safe_interp_visibility_gate` against the mapped
+   target exactly as if it had been called directly. Storing the *raw*
+   target text (rather than resolving it through
+   `resolve_command_qualified_name`) is deliberate: real Tcl resolves a
+   `-map` target relative to the *ensemble's own* namespace, not the
+   caller's, and a resolved qualified name would frequently be a
+   synthetic, interp-domain-prefixed name (e.g. `::@interp@s::source`)
+   that the registry lookup (bare names only) could never match — using
+   the written text, unresolved, is a deliberate, permissive-leaning
+   precision tradeoff, consistent with this fix's "prefer a false positive
+   over a missed real violation" stance for a security diagnostic (decision
+   rule 2). This closes the gap previously described here as scoped out;
+   the remaining, distinct architectural gap from issue #979 (generic
+   interprocedural call-site resolution for diagnostics other than W129) is
+   untouched and still tracked separately.
 8. **`rename` / `interp alias` do not defeat this gate, and needed no new
    handling.** `safe_interp_visibility_gate` checks the *literal, written*
    command name against the registry — it does not resolve through
@@ -231,40 +244,81 @@ source; $cmd $file`) are **not** flagged — see decision rule 3.
    lookups not resolving through renames *generally*, for other
    diagnostics); it does not apply to W129's hidden-command check.
 
-## Known, separate gap found during this investigation (not fixed here)
+## The live server's incremental path (`analyse_per_item`) — fixed
 
 `analyse_per_item` — the incremental shell/body-pass split the *live* LSP
 server always uses for diagnostics (`tcl-lsp-db`) — defers **every**
-proc/method body (via `DeferredBody`, filled by
-`analyse_proc_body_isolated` in a second, isolated pass) regardless of
-whether it is nested inside a tracked `interp eval` safe-interpreter body.
-`DeferredBody` carries no `safe_interp_stack` snapshot at all, so **W129
-never fires for a hidden call inside any proc (or, by the same mechanism,
-`apply`-lambda) body nested in a safe interpreter when analysed
-incrementally** — including a *directly-written* call with no
-bracket-substitution indirection whatsoever:
+proc/method/`apply` body (via `DeferredBody`, filled by
+`analyse_proc_body_isolated` in a second, isolated pass). `DeferredBody`
+previously carried no safe-interpreter visibility information at all, so
+W129 never fired for a hidden call inside any such body nested in a safe
+interpreter when analysed incrementally — including a *directly-written*
+call with no bracket-substitution indirection whatsoever:
 
 ```tcl
 interp create -safe s
 interp eval s { proc f {} { source foo }; f }
 ```
 
-draws no W129 through the live server's diagnostics path, even though
+drew no W129 through the live server's diagnostics path, even though
 `Analyser::analyse` (the whole-file walk — used by the `tcl diag`/`lint`
-CLIs and every existing W129 unit test) correctly flags it. This is a
-pre-existing gap, not introduced or worsened by this fix (this fix's own
-`handle_apply_command` recursion inherits the exact same limitation for the
-indirect case, symmetrically with the direct one) and it is **not specific
-to bracket-substitution indirection** — issue #1001's actual subject — so it
-is out of scope here. It is pinned by a dedicated, currently-still-red-by-
-design unit test
-(`safe_interp_w129_lost_across_per_item_deferred_proc_body_1001` in
-`tcl-compiler`'s `analyser::handlers::tests`) so a future fix threading
-`safe_interp_stack` (or an equivalent snapshot) through `DeferredBody` /
-`analyse_proc_body_isolated` has a red test to turn green. Given its
-real-world impact (it affects the live server's diagnostics for *any*
-proc/apply body in a safe interpreter, not just this idiom), it is worth
-its own tracked issue.
+CLIs and every existing W129 unit test) correctly flagged it. This was a
+pre-existing gap, not introduced by this fix, but with real-world impact
+broad enough (it affects the live server's diagnostics for *any*
+proc/apply/method body in a safe interpreter, not just this issue's
+bracket-substitution idiom) that it was folded into this same change
+rather than left to a separate issue.
+
+Fixed by threading a flattened visibility snapshot through `DeferredBody`
+and the `tcl-lsp-db` salsa cache: `Analyser::safe_interp_ctx_snapshot`
+converts the top of `self.safe_interp_stack` (a `SafeInterpCtx` whose
+`hidden_extra`/`exposed` fields are `HashSet<String>`) into a
+`(bool, Vec<String>, Vec<String>)` — sorted `Vec`s, not `HashSet`s, because
+this snapshot must round-trip through `tcl-lsp-db`'s
+`#[salsa::interned] ItemBodyKey`, whose fields must be `Eq + Hash + Clone`,
+which `HashSet` does not implement. Both `handle_proc_command`,
+`handle_apply_command`, and the TclOO method-body push site in `oo.rs` now
+capture this snapshot into `DeferredBody::safe_interp_ctx` at defer time;
+`analyse_proc_body_isolated` pushes it back onto a fresh `Analyser`'s
+`safe_interp_stack` before analysing the deferred body, so the isolated
+second pass sees the same visibility state the shell pass had. `tcl-lsp-db`
+carries the same field through `ItemBodyKey` end to end (both the
+`ItemBodyKey::new(...)` construction site and the `DeferredBody`
+reconstruction in `item_body_analysis`) so the production incremental path
+gets identical coverage to `Analyser::analyse`, not just the test-only
+`analyse_per_item` entry point.
+
+One narrower limitation remains, deliberately not fixed, because it would
+require threading interpreter *identity* (`interp_path_stack` /
+`self.interpreters`), not just a visibility snapshot, through
+`DeferredBody` — a larger, separate change: a `proc` that locally
+*redefines* a hidden name **nested inside** a deferred body does not
+suppress W129 for a later call to that redefined name within the *same*
+body, under incremental analysis only (`Analyser::analyse`'s whole-file
+walk is unaffected, since it never loses interpreter identity in the first
+place). Concretely:
+
+```tcl
+interp create -safe s
+interp eval s {
+    proc f {} {
+        proc source {args} { return ok }
+        source foo
+    }
+    f
+}
+```
+
+still draws W129 on the inner `source foo` call under `analyse_per_item`,
+even though the local redefinition makes it a false positive (the call
+truly is safe at run time). This can only ever produce a spurious
+diagnostic, never miss a real violation, so it stays on the acceptable
+side of this fix's "prefer a false positive over a missed real violation"
+stance (decision rule 2) — unlike the gap this whole fix closes, which
+could miss a real violation. Pinned by
+`safe_interp_w129_nested_redefinition_inside_deferred_body_still_flagged_1001`,
+which documents and asserts the current (over-flagging) behaviour rather
+than silently regressing it in either direction.
 
 ## Failure modes
 
@@ -275,14 +329,18 @@ its own tracked issue.
   would widen this walker's general scope (every other diagnostic starting
   to fire inside `[list apply ...]` bodies everywhere) — guarded against by
   gating every new call site on `!self.safe_interp_stack.is_empty()`.
-- Assuming `rust/tcl-vm`'s `UNSAFE`-command list is authoritative for the
-  static registry's `Traits::SAFE_INTERP_HIDDEN` set: `tcl-vm` additionally
-  hides `after`/`vwait`, which the registry does not currently mark
-  `SAFE_INTERP_HIDDEN` (only the 13 commands this note's companion
-  diagnostic page lists are marked). This discrepancy is unrelated to
-  bracket-substitution indirection and is not addressed by this fix —
-  noted here so a future contributor does not assume the two sets are
-  already reconciled.
+- `rust/tcl-vm`'s `UNSAFE`-command list previously over-hid `after` and
+  `vwait`, disagreeing with the static registry's `Traits::SAFE_INTERP_HIDDEN`
+  set (only the 13 commands this note's companion diagnostic page lists are
+  marked, and real `tclsh8.6` confirms neither `after` nor `vwait` is hidden
+  by `-safe`). Fixed by removing both from `UNSAFE` in both
+  `rust/tcl-vm/src/interp.rs` and the WASM runtime's `runtime/rust/src/interp.rs`
+  equivalent, with a pinning comment; verified with
+  `after_and_vwait_remain_callable_in_a_safe_interp` (see test anchors).
+  This discrepancy was unrelated to bracket-substitution indirection but,
+  like the per-item gap above, was folded into this same change given its
+  direct relevance to this issue's runtime-severity investigation
+  (decision rule 6).
 
 ## Triage checklist
 
@@ -294,14 +352,21 @@ its own tracked issue.
    actually carries `ArgRole::Body` / `LambdaLiteral` / `CommandPrefix` for
    the command it sits in (`registry.arg_indices_for_role`) — if not, the
    gate is correctly silent (decision rule 4).
-3. For an `apply`-lambda-body case specifically, check whether the call is
-   reached via `Analyser::analyse` (works) or `analyse_per_item` (currently
-   does not, for *any* proc/apply body in a safe interpreter — the separate
-   gap above, not this fix's concern).
-4. If a hidden command is reached via `namespace ensemble configure -map`
-   or an ensemble's call site generally, that is the pre-existing,
-   documented-separate gap in decision rule 7 — not a regression in this
-   fix.
+3. For an `apply`/proc/method-body case, both `Analyser::analyse` (the
+   whole-file walk) and `analyse_per_item` (the live server's incremental
+   path) now carry safe-interpreter visibility into deferred bodies; if
+   only one of the two flags a case, that is a real regression, not the
+   old known gap (which is fixed — see the section above).
+4. If a hidden command is reached via `namespace ensemble create` or
+   `configure -map`, `check_ensemble_redirect_hiding` should catch it
+   (decision rule 7) — if it doesn't, check whether the `-map` target text
+   or the ensemble key (bare vs. explicit `-command`) actually matches what
+   `record_ensemble_map_targets` stored, before assuming a new gap.
+5. A local redefinition of a hidden command's name **nested inside** a
+   deferred body (proc/apply/method) not suppressing a later same-body call
+   under `analyse_per_item` is the one remaining, deliberately-accepted,
+   over-flagging-only limitation — see the end of the per-item section
+   above, not a bug to chase.
 
 ## Test anchors
 
@@ -326,18 +391,43 @@ its own tracked issue.
   `safe_interp_w129_list_quoted_apply_safe_command_not_flagged_1001` (TN),
   `safe_interp_w129_redefined_command_not_flagged_through_indirection_1001`,
   `safe_interp_w129_alias_bridged_command_not_flagged_through_indirection_1001`,
-  `safe_interp_w129_lost_across_per_item_deferred_proc_body_1001` (pins the
-  separate, out-of-scope per-item gap above).
+  `safe_interp_w129_ensemble_create_map_redirect_to_hidden_command_1001`,
+  `safe_interp_w129_ensemble_configure_map_redirect_to_hidden_command_1001`,
+  `safe_interp_w129_ensemble_default_name_map_redirect_to_hidden_command_1001`,
+  `safe_interp_w129_ensemble_map_redirect_to_safe_command_not_flagged_1001`
+  (TN), `ensemble_map_redirect_outside_any_safe_interp_is_untouched_1001`
+  (no scope-creep guard),
+  `safe_interp_w129_reaches_deferred_proc_body_under_per_item_1001`,
+  `safe_interp_w129_reaches_deferred_apply_body_under_per_item_1001`,
+  `safe_interp_w129_reaches_deferred_method_body_under_per_item_1001`,
+  `deferred_proc_body_outside_any_safe_interp_is_untouched_under_per_item_1001`
+  (no scope-creep guard),
+  `safe_interp_w129_nested_redefinition_inside_deferred_body_still_flagged_1001`
+  (pins the narrower, accepted, over-flagging-only limitation described
+  above).
 - `rust/tcl-compiler/src/signature_scan/command_prefix.rs` —
   `list_quoted_command_segment` (new shared primitive); existing
   `extract_list_quoted_prefix_head` tests continue to pass against it
   unchanged.
 - `rust/tcl-lsp-server/tests/e2e/issue1001.rs` — full end-to-end coverage
   against the real, packaged native server for every path that does not
-  depend on the separate per-item/`DeferredBody` gap above (list-quoted
-  direct hidden command in both `Body` and `CommandPrefix` positions, the
-  plain-data FP guard, direct nested substitution, `{*}`-expanded
-  list-quoted head, the safe-command FP guard through list-quoted `apply`).
+  depend on the (now-fixed, but deliberately not re-exercised at the e2e
+  layer) per-item/`DeferredBody` case (list-quoted direct hidden command in
+  both `Body` and `CommandPrefix` positions, the plain-data FP guard, direct
+  nested substitution, `{*}`-expanded list-quoted head, the safe-command FP
+  guard through list-quoted `apply`).
+- `rust/tcl-vm/tests/safe_interp_e2e.rs` (new) — runtime-severity coverage
+  confirming `tcl-vm`'s bytecode VM already enforces hidden-command
+  rejection at execution time, independent of the static lint, for every
+  indirection shape this note enumerates:
+  `hidden_command_direct_call_raises_invalid_command_name`,
+  `hidden_command_via_expand_list_quoting_raises_invalid_command_name`,
+  `hidden_command_via_eval_of_built_string_raises_invalid_command_name`,
+  `hidden_command_via_ensemble_map_redirect_raises_invalid_command_name`,
+  `rename_cannot_resurrect_a_hidden_command`,
+  `after_and_vwait_remain_callable_in_a_safe_interp` (pins the
+  `UNSAFE`-list fix above),
+  `safe_interp_hides_every_implemented_command_in_the_registry_set`.
 
 ## Related
 

--- a/docs/kcs/kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md
+++ b/docs/kcs/kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md
@@ -1,0 +1,353 @@
+# KCS: W129 misses a hidden command reached through `[...]` bracket-substitution indirection
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+all-editors
+
+## Symptom
+
+**W129** (the Safe Base diagnostic — see
+[its own diagnostic-code note](codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md)
+for the user-facing picture) fires correctly when a command hidden from a
+`-safe` interpreter is the *literal, written head* of a call inside that
+interpreter's `interp eval` body:
+
+```tcl
+interp create -safe s
+interp eval s { source b.tcl }
+```
+
+but silently misses the identical violation the moment it is reached only
+through a `[...]` bracket substitution — most importantly the pervasive
+`[list apply {...} $x]` deferred-command idiom:
+
+```tcl
+interp create -safe s
+interp eval s {
+    package ifneeded myPackage 1.0.0 [list apply {dir {
+        source [file join $dir src font.tcl]
+    }} $dir]
+}
+```
+
+No warning appears anywhere in this snippet, even though `source` is exactly
+as hidden and exactly as doomed to raise `invalid command name` at run time
+as the first example. Unlike a missed style warning, a silently-missing
+safety diagnostic is actively worse than not having the check at all — it
+creates false confidence that the code has been vetted for safe-interpreter
+compatibility when it has not.
+
+Reported as issue #1001.
+
+## Operational context
+
+The entire W129 implementation is one gate,
+[`safe_interp_visibility_gate`](../../rust/tcl-compiler/src/analyser/commands.rs)
+(issue #945 fault 7), called from exactly one place: the top of
+`process_command`. It takes a literal command-name string and a token, and
+checks that name against the interpreter-domain state
+(`self.safe_interp_stack`) built by the `InterpCreate` / `InterpHide` /
+`InterpExpose` / `InterpEval` hooks. The *direct* case in the symptom above
+works because a literal `apply {argList body} $x` head is recognised via
+head-text dispatch (`AnalyserHookId::Apply` → `handle_apply_command`), which
+walks into the lambda body via `analyse_body`, re-entering `process_command`
+for each inner command and correctly inheriting `self.safe_interp_stack` —
+so the nested `source` call hits the same gate a top-level call would.
+
+Anything reached only through a bracket substitution never reached
+`process_command` in a form the gate recognised, for three distinct
+reasons, each now fixed by its own mechanism:
+
+1. **`[list apply {...} $x]` (and any other command) sitting in one of the
+   *enclosing* command's own `Body` / `LambdaLiteral` / `CommandPrefix`-role
+   argument positions** (`package ifneeded`'s script argument, a `-command`
+   option, `trace add ... command`, `after`/`after idle`, `eval`, `uplevel`)
+   — `list`'s own arguments are never re-walked as a nested call at all; the
+   main walk treats the whole `[...]` value as opaque data. Fixed by
+   [`Analyser::check_deferred_call_safe_interp_hiding`]: for each such
+   argument position, resolve a `[list HEAD ...]` shape via
+   [`list_quoted_command_segment`] (in `tcl-compiler`'s
+   `signature_scan::command_prefix`, shared with
+   [`extract_list_quoted_prefix_head`] — see decision rule 1 below), gate
+   `HEAD` directly, and — when `HEAD` resolves to the `Apply` hook — recurse
+   into [`Analyser::handle_apply_command`] with the segment's remaining
+   words as if they were a literal `apply {...} $x` call. Reusing that exact
+   handler means the lambda body is walked by the same `analyse_body` →
+   `process_command` recursion the direct case already uses, so a hidden
+   call nested *inside* the lambda body (the reported repro's `source`) hits
+   the unmodified gate with `self.safe_interp_stack` still live — no new
+   logic was needed inside the gate itself, only getting the walk to reach
+   the lambda body at all.
+2. **A direct nested `[...]` substitution, with no `list`-quoting at all**
+   (`set x [source b.tcl]`, `if {[exec ls] ne ""} ...`) — a bracket
+   substitution always evaluates its content immediately, wherever it
+   appears, so this is not a "deferred call" question at all; the existing
+   nested-substitution walker
+   (`record_nested_invocations_from_args` /
+   `run_nested_command_diagnostics` → `dispatch_nested_segment`) already
+   discovers every such nested command at arbitrary depth for *other*
+   per-command diagnostics (arity, W100/W110/W216, ...) but never checked
+   the safe-interpreter gate. Fixed by adding the same
+   `safe_interp_visibility_gate` call to the top of `dispatch_nested_segment`
+   — free arbitrary-depth coverage, since the discovery machinery already
+   existed.
+3. **`{*}[list HEAD ...]` as a command's own (expand-marked) head** — `{*}`
+   expansion splices `list`'s result into the statement's own argv, so the
+   command's *effective* head becomes `HEAD`, while the literal head word
+   `process_command` sees is the substitution text (never a registry name).
+   Fixed by [`Analyser::check_indirect_hiding`] resolving the same
+   `[list HEAD ...]` shape when the head word is expand-marked, gating the
+   *effective* head instead of the unresolvable literal one.
+
+`{*}$cmdList` (an opaque variable) and a bare dynamic dispatch (`set cmd
+source; $cmd $file`) are **not** flagged — see decision rule 3.
+
+## Decision rules / contracts
+
+1. **The list-quoted-command shape is resolved through the exact same
+   primitive the highlighting/call-graph consumers use, generalised to
+   return the whole segmented command, not just a head+span.**
+   [`extract_list_quoted_prefix_head`] (used by `ArgRole::CommandPrefix`
+   consumers: find-references, call-hierarchy, callback-arity) and W129's
+   new [`list_quoted_command_segment`] both live in
+   `tcl-compiler/src/signature_scan/command_prefix.rs` and share one
+   resolution: the token's sole inner command must be a call to a
+   `Traits::BUILDS_COMMAND_PREFIX` command (`list`) whose own first argument
+   is a literal, resolvable bareword. W129 additionally needs the
+   *remaining* words (to recurse into `handle_apply_command` with them),
+   which the shared function now returns as the full `SegmentedCommand`;
+   `extract_list_quoted_prefix_head` reduces to reading its head/span/baked
+   count from that same segment. No second parsing mechanism was
+   introduced.
+2. **A false negative (missed real violation) is the worse failure mode for
+   W129, unlike the general analyser and the highlighting consumers.** The
+   [apply-lambda-highlighting KCS
+   note](kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md)'s
+   decision rule 4 documents that the deep SSA/CFG-based analyser
+   deliberately does **not** follow `[list ...]` indirection, to stay
+   conservative (a false positive there is a spurious diagnostic on inert
+   data). That deep analyser is a different component from the one this fix
+   touches (`tcl-compiler/src/analyser/commands.rs`'s diagnostic-producing
+   walker, not the IR/CFG/SSA optimiser pipeline) — see that note's §7 for
+   the explicit confirmation the SSA/CFG layer has no instances of this bug
+   class and stays out of scope here. This fix's gating is still
+   precision-scoped (rule 1's `deferred_role`-equivalent check — decision
+   rule 4 below), it is simply on the *permissive* side of the tradeoff
+   that specific check makes, appropriate for a security diagnostic rather
+   than a cosmetic one.
+3. **`{*}$var` and `$cmd args` (dynamic dispatch via an opaque variable) are
+   deliberately left unflagged.** This matches the existing, established
+   precedent elsewhere in this codebase for "prefer a miss over a false
+   positive" on dynamic command dispatch (W123's unresolved-command
+   handling, the command-prefix bareword-only guard in
+   `command_prefix.rs`'s module docs: "A dynamic head (`$var`/`[cmd]`, in
+   any shape) can't be resolved to a proc and recording it would false-fire
+   W123, so it stays unrecorded"). No new precedent was invented for this
+   fix; `check_indirect_hiding`'s `{*}`-head resolution only engages when
+   the head word is a `Cmd`-kind (`[...]`) token, which a bare `$var` never
+   is, so the guard falls out of the existing token-kind check rather than
+   a new explicit branch.
+4. **The new deferred-call resolution is gated on the exact `deferred_role`
+   precision the highlighting consumers use — never a blanket "any `[list
+   apply ...]` anywhere is a call".** `check_deferred_call_safe_interp_hiding`
+   only inspects argument indices the registry marks `Body` / `LambdaLiteral`
+   / `CommandPrefix` for the *enclosing* command (mirrors
+   `deferred_role_arg_starts` in `tcl-lsp-core`'s `semantic_tokens.rs`, from
+   the codex-review follow-up to #954) — a `[list apply {...} value]` sitting
+   in ordinary `set` data is never treated as invoked, even though its lambda
+   body contains a hidden command (see the FP-guard test anchors below).
+5. **This entire fix is additive and gated on `!self.safe_interp_stack.is_empty()`
+   at every new call site.** Outside a tracked safe interpreter — the
+   overwhelming common case — none of the three new mechanisms run at all:
+   no new scope is created, no new diagnostic of any kind appears, and
+   `[list apply {...} $x]` used anywhere in ordinary (non-safe-interpreter)
+   code stays exactly as un-analysed as it was before this fix. This was a
+   deliberate choice over unconditionally following the indirection for
+   *every* consumer of this analyser: doing so would have widened this
+   walker's scope far beyond W129 (every other diagnostic that already
+   fires inside a directly-written `apply {...}` body would newly start
+   firing inside a `[list apply {...} $x]` body too, everywhere in the
+   codebase, not just inside safe interpreters) — a much larger, differently
+   -reviewed change than "fix W129's recall."
+6. **Runtime severity finding (required investigation before treating this
+   as purely an analyser-precision issue):** both `rust/tcl-vm` and the WASM
+   backend (`runtime/rust`) enforce safe-interpreter command hiding at a
+   single, universal command-resolution choke point
+   (`InterpState::lookup_command` / the WASM runtime's equivalent
+   `dispatch_inner`/namespace-resolve path) that only ever consults the
+   *visible* command table — a hidden command is not merely flagged, it is
+   physically absent from the table every invocation path (direct call,
+   `{*}` expansion, `eval`/`uplevel` of a dynamically-built string, a
+   namespace-ensemble `-map` redirect, an alias) resolves through. `rename`
+   cannot resurrect a hidden command's callability either: it only
+   operates on the same visible table, so it can neither find nor move a
+   name that was already hidden. **This means the runtime already correctly
+   rejects every indirection shape enumerated in this note at execution
+   time, independent of what the static lint catches — this fix is purely
+   about improving the *static diagnostic's* recall (better, earlier editor
+   feedback), not closing an executable security hole.** The one adjacent,
+   separately-actionable finding from that investigation: `rust/tcl-vm` has
+   no test at all asserting a hidden command raises `invalid command name`
+   inside a `-safe` interpreter (its only "safe child" e2e vector tests the
+   opposite direction — an explicitly-wired alias still working), and
+   neither `tcl-vm` nor the WASM runtime has a test exercising any
+   indirection shape specifically. Worth a follow-up test-only PR; not
+   folded into this fix since it changes no runtime behaviour.
+7. **`namespace ensemble configure -map` redirection to a hidden command is
+   an explicitly scoped-out, pre-existing gap, not fixed here.** Only
+   `namespace ensemble create ... -map {...}` is handled by
+   `handle_namespace_ensemble` at all (`configure` is silently ignored —
+   `if args[1] != "create" { return; }`); even for `create`, a `-map` target
+   is recorded only as a *reference* (`push_command_reference`, for
+   find-references/rename), never resolved at the ensemble's own *call
+   sites* — `myEnsemble sub ...` is analysed as an ordinary call to
+   `myEnsemble` (not hidden), never as a call to the mapped target. Making
+   W129 see through ensemble-map redirection would require building
+   generic ensemble-dispatch-aware call-site resolution that does not exist
+   for *any* diagnostic today — the same theme as issue #979's
+   interprocedural call-site gap. Fixing that is a distinct, larger,
+   pre-existing architectural gap shared with #979, not specific to
+   bracket-substitution indirection; tracked separately rather than folded
+   into this fix.
+8. **`rename` / `interp alias` do not defeat this gate, and needed no new
+   handling.** `safe_interp_visibility_gate` checks the *literal, written*
+   command name against the registry — it does not resolve through
+   `self.renamed_commands` or `self.command_aliases` at all, and this is
+   correct as-is: real Tcl's `rename` can only rename a command already in
+   the *visible* command table (confirmed by the runtime finding in rule 6
+   above), so a hidden command's name is never a valid `rename` source —
+   attempting `rename source mySource` inside a safe interpreter fails at
+   run time with "command doesn't exist" before this diagnostic's concern
+   even arises. The standard safe-interpreter delegation pattern — the
+   trusted parent bridging in a capability with `interp alias s foo {}
+   source` (aliasing to the *parent's own*, non-hidden `source`) — correctly
+   draws no W129 for a later `foo` call inside the child, simply because
+   `foo` is never itself a `SAFE_INTERP_HIDDEN` registry name; no special
+   -casing was added or needed (see the alias-bridging test anchor below).
+   This is issue #1002's concern about a different bug class (registry
+   lookups not resolving through renames *generally*, for other
+   diagnostics); it does not apply to W129's hidden-command check.
+
+## Known, separate gap found during this investigation (not fixed here)
+
+`analyse_per_item` — the incremental shell/body-pass split the *live* LSP
+server always uses for diagnostics (`tcl-lsp-db`) — defers **every**
+proc/method body (via `DeferredBody`, filled by
+`analyse_proc_body_isolated` in a second, isolated pass) regardless of
+whether it is nested inside a tracked `interp eval` safe-interpreter body.
+`DeferredBody` carries no `safe_interp_stack` snapshot at all, so **W129
+never fires for a hidden call inside any proc (or, by the same mechanism,
+`apply`-lambda) body nested in a safe interpreter when analysed
+incrementally** — including a *directly-written* call with no
+bracket-substitution indirection whatsoever:
+
+```tcl
+interp create -safe s
+interp eval s { proc f {} { source foo }; f }
+```
+
+draws no W129 through the live server's diagnostics path, even though
+`Analyser::analyse` (the whole-file walk — used by the `tcl diag`/`lint`
+CLIs and every existing W129 unit test) correctly flags it. This is a
+pre-existing gap, not introduced or worsened by this fix (this fix's own
+`handle_apply_command` recursion inherits the exact same limitation for the
+indirect case, symmetrically with the direct one) and it is **not specific
+to bracket-substitution indirection** — issue #1001's actual subject — so it
+is out of scope here. It is pinned by a dedicated, currently-still-red-by-
+design unit test
+(`safe_interp_w129_lost_across_per_item_deferred_proc_body_1001` in
+`tcl-compiler`'s `analyser::handlers::tests`) so a future fix threading
+`safe_interp_stack` (or an equivalent snapshot) through `DeferredBody` /
+`analyse_proc_body_isolated` has a red test to turn green. Given its
+real-world impact (it affects the live server's diagnostics for *any*
+proc/apply body in a safe interpreter, not just this idiom), it is worth
+its own tracked issue.
+
+## Failure modes
+
+- Checking `[list apply ...]` unconditionally (not gated on the enclosing
+  argument's registry role) would make `set data [list apply {...} value]`
+  — never invoked — warn, an over-broad false positive on inert data.
+- Recursing into `handle_apply_command` outside a tracked safe interpreter
+  would widen this walker's general scope (every other diagnostic starting
+  to fire inside `[list apply ...]` bodies everywhere) — guarded against by
+  gating every new call site on `!self.safe_interp_stack.is_empty()`.
+- Assuming `rust/tcl-vm`'s `UNSAFE`-command list is authoritative for the
+  static registry's `Traits::SAFE_INTERP_HIDDEN` set: `tcl-vm` additionally
+  hides `after`/`vwait`, which the registry does not currently mark
+  `SAFE_INTERP_HIDDEN` (only the 13 commands this note's companion
+  diagnostic page lists are marked). This discrepancy is unrelated to
+  bracket-substitution indirection and is not addressed by this fix —
+  noted here so a future contributor does not assume the two sets are
+  already reconciled.
+
+## Triage checklist
+
+1. Confirm the call site is genuinely reached through one of the three
+   mechanisms above (list-quoted deferred call, direct nested substitution,
+   `{*}`-expanded list-quoted head) — a bare dynamic dispatch
+   (`{*}$var`/`$cmd args`) is out of scope by design (decision rule 3).
+2. For a list-quoted deferred call, check the *enclosing* argument position
+   actually carries `ArgRole::Body` / `LambdaLiteral` / `CommandPrefix` for
+   the command it sits in (`registry.arg_indices_for_role`) — if not, the
+   gate is correctly silent (decision rule 4).
+3. For an `apply`-lambda-body case specifically, check whether the call is
+   reached via `Analyser::analyse` (works) or `analyse_per_item` (currently
+   does not, for *any* proc/apply body in a safe interpreter — the separate
+   gap above, not this fix's concern).
+4. If a hidden command is reached via `namespace ensemble configure -map`
+   or an ensemble's call site generally, that is the pre-existing,
+   documented-separate gap in decision rule 7 — not a regression in this
+   fix.
+
+## Test anchors
+
+- `rust/tcl-compiler/src/analyser/handlers.rs` (suffixed `_1001`) —
+  `safe_interp_w129_list_quoted_apply_lambda_body_reports_hidden_source_1001`
+  (the reported repro), `safe_interp_w129_list_quoted_apply_in_command_prefix_position_1001`,
+  `safe_interp_w129_list_quoted_apply_after_idle_1001`,
+  `safe_interp_w129_list_quoted_hidden_command_directly_1001` (no `apply`),
+  `safe_interp_w129_list_quoted_apply_in_plain_data_is_not_flagged_1001` (FP
+  guard, mirrors #954's non-invocation guard),
+  `list_quoted_apply_lambda_outside_any_safe_interp_is_untouched_1001` (no
+  scope-creep guard), `safe_interp_w129_direct_nested_bracket_substitution_1001`,
+  `safe_interp_w129_direct_nested_bracket_substitution_deep_1001`,
+  `safe_interp_w129_expand_list_quoted_head_1001`,
+  `safe_interp_w129_expand_dynamic_var_head_not_flagged_1001` (TN),
+  `safe_interp_w129_dynamic_variable_dispatch_not_flagged_1001` (TN),
+  `safe_interp_w129_eval_list_quoted_hidden_command_1001`,
+  `safe_interp_w129_uplevel_list_quoted_hidden_command_1001`,
+  `safe_interp_w129_list_quoted_apply_safe_command_not_flagged_1001` (TN),
+  `safe_interp_w129_redefined_command_not_flagged_through_indirection_1001`,
+  `safe_interp_w129_alias_bridged_command_not_flagged_through_indirection_1001`,
+  `safe_interp_w129_lost_across_per_item_deferred_proc_body_1001` (pins the
+  separate, out-of-scope per-item gap above).
+- `rust/tcl-compiler/src/signature_scan/command_prefix.rs` —
+  `list_quoted_command_segment` (new shared primitive); existing
+  `extract_list_quoted_prefix_head` tests continue to pass against it
+  unchanged.
+- `rust/tcl-lsp-server/tests/e2e/issue1001.rs` — full end-to-end coverage
+  against the real, packaged native server for every path that does not
+  depend on the separate per-item/`DeferredBody` gap above (list-quoted
+  direct hidden command in both `Body` and `CommandPrefix` positions, the
+  plain-data FP guard, direct nested substitution, `{*}`-expanded
+  list-quoted head, the safe-command FP guard through list-quoted `apply`).
+
+## Related
+
+- [KCS index](README.md)
+- [W129 diagnostic-code note](codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md)
+- [apply lambda body not highlighted via list quoting](kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md)
+  — the prior fix (#954/#999) that built the `Traits::BUILDS_COMMAND_PREFIX`
+  / `ArgRole::LambdaLiteral` / `deferred_role` infrastructure this fix reuses
+- [Glossary](../GLOSSARY.md)
+
+[`safe_interp_visibility_gate`]: ../../rust/tcl-compiler/src/analyser/commands.rs
+[`extract_list_quoted_prefix_head`]: ../../rust/tcl-compiler/src/signature_scan/command_prefix.rs
+[`list_quoted_command_segment`]: ../../rust/tcl-compiler/src/signature_scan/command_prefix.rs
+[`Analyser::check_deferred_call_safe_interp_hiding`]: ../../rust/tcl-compiler/src/analyser/commands.rs
+[`Analyser::check_indirect_hiding`]: ../../rust/tcl-compiler/src/analyser/commands.rs
+[`Analyser::handle_apply_command`]: ../../rust/tcl-compiler/src/analyser/handlers.rs

--- a/runtime/rust/src/interp.rs
+++ b/runtime/rust/src/interp.rs
@@ -4957,6 +4957,12 @@ impl Interp {
     /// `interp create -safe`. The Safe Base's re-aliasing of `source`/`load`/
     /// `file` is a follow-up (needs cross-interp aliases).
     pub(crate) fn make_safe(&mut self) {
+        // Pinned against real tclsh 8.6.14 (`interp create -safe s; s hidden`):
+        // `after` / `vwait` are deliberately NOT on this list — confirmed
+        // present and callable inside a real safe child (`s eval {info
+        // commands after}` returns `after`). An earlier version of this list
+        // incorrectly hid them, which would have broken legitimate
+        // safe-interp code using `after idle`/`after cancel`.
         const UNSAFE: &[&[u8]] = &[
             b"exec",
             b"exit",
@@ -4970,8 +4976,6 @@ impl Interp {
             b"file",
             b"fconfigure",
             b"encoding",
-            b"after",
-            b"vwait",
         ];
         for &c in UNSAFE {
             self.hide_command(c);

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -277,6 +277,168 @@ impl Analyser {
         true
     }
 
+    /// Issue #1001's two `process_command`-level extensions to
+    /// [`Self::safe_interp_visibility_gate`], combined into one call so
+    /// `process_command` stays within its line budget:
+    ///
+    /// 1. `{*}[list HEAD arg …]` as this command's own (expand-marked)
+    ///    head: Tcl expands the list `list` builds into this statement's
+    ///    own argv, so the command's *effective* head is `HEAD`, not the
+    ///    substitution text `cmd_name` holds — which never matches a
+    ///    registry name, so the literal-head gate silently no-ops for this
+    ///    shape. Resolved through the same `[list …]` command-quoting idiom
+    ///    [`Self::check_list_quoted_deferred_head`] uses; stops exactly as
+    ///    the literal-head gate does when the effective head is hidden.
+    /// 2. [`Self::check_deferred_call_safe_interp_hiding`] for this
+    ///    command's own `Body` / `LambdaLiteral` / `CommandPrefix`-role
+    ///    argument positions (the pervasive `[list apply …]`
+    ///    deferred-command idiom) — never itself a reason to stop
+    ///    processing *this* command, since each such argument is an
+    ///    independent deferred call, not this command's own head.
+    ///
+    /// Returns `true` when the caller must stop (this command's own
+    /// effective head was hidden), mirroring
+    /// `safe_interp_visibility_gate`'s contract. A no-op outside a tracked
+    /// safe-interpreter context.
+    fn check_indirect_hiding(
+        &mut self,
+        argv_texts: &[String],
+        arg_tokens_in: &[Token],
+        arg_expand_in: &[bool],
+        scope_path: &[usize],
+    ) -> bool {
+        if self.safe_interp_stack.is_empty() {
+            return false;
+        }
+        let cmd_name = argv_texts[0].as_str();
+        let head_tok = arg_tokens_in[0];
+        if arg_expand_in.first().copied().unwrap_or(false)
+            && head_tok.kind == TokenType::Cmd
+            && self.check_list_quoted_deferred_head(head_tok, cmd_name, scope_path)
+        {
+            return true;
+        }
+        let args = argv_texts.get(1..).unwrap_or(&[]);
+        let arg_tokens = arg_tokens_in.get(1..).unwrap_or(&[]);
+        self.check_deferred_call_safe_interp_hiding(cmd_name, args, arg_tokens, scope_path);
+        false
+    }
+
+    /// Extend [`Self::safe_interp_visibility_gate`] through the `[list HEAD
+    /// …]` command-quoting idiom (issue #1001): the literal-head gate above
+    /// only ever sees a command whose head is written directly, so the
+    /// pervasive deferred-command idiom (`package ifneeded … [list apply
+    /// {…} $dir]`, `-command [list apply {…} $x]`, `after idle [list apply
+    /// {…} $x]`, `trace add … command [list apply {…} $x]`) — building a
+    /// callback around a dynamic value with `list` rather than writing a
+    /// literal `apply {…} $dir` — is entirely invisible to it.
+    ///
+    /// Checked only for this command's own `Body` / `LambdaLiteral` /
+    /// `CommandPrefix`-role argument positions — the exact `deferred_role`
+    /// gate the semantic-token highlighter's list-quoted-lambda recognition
+    /// uses (`deferred_role_arg_starts` in `tcl-lsp-core`'s
+    /// `semantic_tokens.rs`, from the codex-review follow-up to #954) — so a
+    /// `[list apply {…} value]` sitting in ordinary data (`set data [list
+    /// apply {…} value]`, no role at that position) is never treated as a
+    /// call; only a position the registry already marks as later
+    /// invoked/sourced is. See
+    /// `docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md`
+    /// decision rule 4 for why that highlighting-only precision is
+    /// deliberately widened here rather than reused unchanged: a missed
+    /// W129 (false negative) is the worse failure mode for a security
+    /// diagnostic, unlike a spurious highlight.
+    ///
+    /// A no-op outside a tracked safe-interpreter context (the overwhelming
+    /// common case) — this never runs, and never has any side effect (no
+    /// new scope, no new diagnostic of any other kind), for ordinary code.
+    fn check_deferred_call_safe_interp_hiding(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        scope_path: &[usize],
+    ) {
+        if self.safe_interp_stack.is_empty() {
+            return;
+        }
+        let Some(registry) = self.registry else {
+            return;
+        };
+        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let mut indices: Vec<usize> = [
+            ArgRole::Body,
+            ArgRole::LambdaLiteral,
+            ArgRole::CommandPrefix,
+        ]
+        .into_iter()
+        .flat_map(|role| registry.arg_indices_for_role(cmd_name, &arg_strs, role))
+        .collect();
+        indices.sort_unstable();
+        indices.dedup();
+        for idx in indices {
+            let (Some(tok), Some(text)) = (arg_tokens.get(idx), args.get(idx)) else {
+                continue;
+            };
+            // A whole-argument `[…]` substitution is the only shape `list`
+            // command-quoting can take here — a braced or bareword value at
+            // a deferred-call position is either a literal script (handled
+            // by the ordinary `Body`-role `analyse_body` walk) or a plain
+            // `CommandPrefix` head already resolved by
+            // `record_command_prefix_invocations`, neither of which needs
+            // this resolution.
+            if tok.kind != TokenType::Cmd {
+                continue;
+            }
+            self.check_list_quoted_deferred_head(*tok, text, scope_path);
+        }
+    }
+
+    /// Resolve one `[list HEAD arg1 arg2 …]`-shaped deferred-call argument:
+    /// gate `HEAD` for safe-interpreter visibility (issue #1001), recursing
+    /// into an `apply` lambda body via [`Self::handle_apply_command`] — the
+    /// SAME handler a literal `apply {…} $x` call dispatches to — when
+    /// `HEAD` resolves to it, so a hidden command nested inside the lambda
+    /// (the reported repro's `source` call) is caught by the ordinary,
+    /// unmodified gate the recursion's own `process_command` calls hit.
+    /// `self.safe_interp_stack` is untouched by this recursion (only
+    /// `interp eval` pushes/pops it), so the enclosing safe interpreter's
+    /// visibility context is inherited automatically — exactly as it is for
+    /// a directly-written `apply {…} $x` call already inside the same body.
+    ///
+    /// Returns `true` when `HEAD` itself was hidden (a W129 was already
+    /// pushed) so a caller checking its *own* effective head (the `{*}[list
+    /// HEAD …]` argv-expansion shape) can stop further processing the same
+    /// way the literal-head gate does.
+    fn check_list_quoted_deferred_head(
+        &mut self,
+        tok: Token,
+        text: &str,
+        scope_path: &[usize],
+    ) -> bool {
+        let Some(registry) = self.registry else {
+            return false;
+        };
+        let Some(seg) =
+            crate::signature_scan::command_prefix::list_quoted_command_segment(registry, tok, text)
+        else {
+            return false;
+        };
+        let head = seg.texts[1].clone();
+        let head_tok = seg.argv[1];
+        if self.safe_interp_visibility_gate(&head, head_tok) {
+            return true;
+        }
+        let rest_args = seg.texts.get(2..).unwrap_or(&[]);
+        if matches!(
+            self.resolve_analyser_hook(&head, rest_args),
+            Some(tcl_registry::hooks::AnalyserHookId::Apply)
+        ) {
+            let rest_tokens = seg.argv.get(2..).unwrap_or(&[]);
+            self.handle_apply_command(rest_args, rest_tokens, scope_path);
+        }
+        false
+    }
+
     /// Process a single segmented command.
     ///
     /// Walks `args` against every handler and stops at the first
@@ -328,7 +490,11 @@ impl Analyser {
         } else {
             &[]
         };
-
+        // Bracket-substitution indirection (issue #1001) invisible to the
+        // gate above — see `check_indirect_hiding`'s doc.
+        if self.check_indirect_hiding(argv_texts, arg_tokens_in, arg_expand_in, scope_path) {
+            return;
+        }
         // Record this invocation so the post-walk
         // ``emit_unresolved_command_diagnostics`` (W123) can iterate
         // every command head the analyser visited.  ``inv.range``
@@ -1694,6 +1860,18 @@ impl Analyser {
         }
         let cmd_name = seg.texts[0].clone();
         let cmd_tok = seg.argv[0];
+        // Safe-interpreter visibility gate (issue #1001): a `[…]` bracket
+        // substitution always invokes its head immediately, wherever it
+        // appears — `set x [source b.tcl]`, `if {[exec ls] ne ""} …` — so a
+        // command nested this way must pass the same gate a top-level
+        // command does (`Self::safe_interp_visibility_gate`'s doc). Every
+        // nesting depth this walker's caller
+        // (`collect_substitution_segments` / `collect_segment_recursive`)
+        // already discovers is covered for free; a no-op outside a tracked
+        // safe interpreter.
+        if self.safe_interp_visibility_gate(&cmd_name, cmd_tok) {
+            return;
+        }
         let args = seg.texts.get(1..).unwrap_or(&[]);
         let arg_tokens = seg.argv.get(1..).unwrap_or(&[]);
         let arg_single = seg.single_token_word.get(1..).unwrap_or(&[]);

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -320,8 +320,52 @@ impl Analyser {
         }
         let args = argv_texts.get(1..).unwrap_or(&[]);
         let arg_tokens = arg_tokens_in.get(1..).unwrap_or(&[]);
+        if self.check_ensemble_redirect_hiding(cmd_name, args, arg_tokens, scope_path) {
+            return true;
+        }
         self.check_deferred_call_safe_interp_hiding(cmd_name, args, arg_tokens, scope_path);
         false
+    }
+
+    /// Resolve a call through a tracked `namespace ensemble create|configure
+    /// ... -map {sub target ...}` redirect (issue #1001 follow-up — the same
+    /// theme as issue #979's interprocedural call-site gap, but for W129
+    /// rather than constant-propagation seeding, and confirmed via a
+    /// dedicated investigation to be a genuinely distinct, previously
+    /// untracked gap): `cmd_name` isn't itself a hidden registry name — it's
+    /// the ensemble's own command name (`myens`) — but if it resolves to a
+    /// tracked ensemble (`self.ensemble_command_maps`, populated by
+    /// [`Self::handle_namespace_ensemble`]) and `args[0]` (the subcommand) is
+    /// one of its mapped entries, the call's *effective* target is whatever
+    /// that entry names, which might be hidden.
+    ///
+    /// Returns `true` when the resolved target was hidden (a W129 was
+    /// already pushed), mirroring `safe_interp_visibility_gate`'s contract.
+    /// A no-op outside a tracked safe interpreter, when `cmd_name` doesn't
+    /// resolve to a tracked ensemble, or when `args[0]` isn't one of its
+    /// mapped subcommands.
+    fn check_ensemble_redirect_hiding(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        scope_path: &[usize],
+    ) -> bool {
+        if self.safe_interp_stack.is_empty() {
+            return false;
+        }
+        let Some(sub) = args.first() else {
+            return false;
+        };
+        let resolved = self.resolve_command_qualified_name(cmd_name, scope_path);
+        let target = self
+            .ensemble_command_maps
+            .get(&resolved)
+            .and_then(|m| m.get(sub).cloned());
+        let (Some(target), Some(tok)) = (target, arg_tokens.first().copied()) else {
+            return false;
+        };
+        self.safe_interp_visibility_gate(&target, tok)
     }
 
     /// Extend [`Self::safe_interp_visibility_gate`] through the `[list HEAD
@@ -1874,6 +1918,13 @@ impl Analyser {
         }
         let args = seg.texts.get(1..).unwrap_or(&[]);
         let arg_tokens = seg.argv.get(1..).unwrap_or(&[]);
+        // A tracked `namespace ensemble ... -map` redirect to a hidden
+        // command (issue #1001 follow-up): `cmd_name` isn't itself a hidden
+        // registry name, but its resolved dispatch target might be — see
+        // `check_ensemble_redirect_hiding`'s doc.
+        if self.check_ensemble_redirect_hiding(&cmd_name, args, arg_tokens, scope_path) {
+            return;
+        }
         let arg_single = seg.single_token_word.get(1..).unwrap_or(&[]);
         // `emit_arity_diagnostics` expects the expand array parallel to
         // the *full* argv (head at index 0), matching `process_command`.

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -277,6 +277,21 @@ impl Analyser {
         true
     }
 
+    /// A flattened snapshot of `self.safe_interp_stack`'s *top* entry, for
+    /// [`super::per_item::DeferredBody::safe_interp_ctx`] (issue #1001
+    /// follow-up) — see that field's doc for the full rationale. Called
+    /// wherever a proc/method/apply body is deferred for `analyse_per_item`'s
+    /// isolated second pass, so the visibility context is available for
+    /// [`super::per_item::analyse_proc_body_isolated`] to restore.
+    pub(super) fn safe_interp_ctx_snapshot(&self) -> Option<(bool, Vec<String>, Vec<String>)> {
+        let ctx = self.safe_interp_stack.last()?;
+        let mut hidden_extra: Vec<String> = ctx.hidden_extra.iter().cloned().collect();
+        hidden_extra.sort_unstable();
+        let mut exposed: Vec<String> = ctx.exposed.iter().cloned().collect();
+        exposed.sort_unstable();
+        Some((ctx.base_hidden, hidden_extra, exposed))
+    }
+
     /// Issue #1001's two `process_command`-level extensions to
     /// [`Self::safe_interp_visibility_gate`], combined into one call so
     /// `process_command` stays within its line budget:

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -771,6 +771,7 @@ impl Analyser {
             // created with params; a second pass fills it in place).
             let body_text = args[2].clone();
             if self.defer_proc_bodies {
+                let safe_interp_ctx = self.safe_interp_ctx_snapshot();
                 self.deferred_bodies.push(super::per_item::DeferredBody {
                     body_text,
                     body_tok,
@@ -781,6 +782,7 @@ impl Analyser {
                     scope_name: raw_name.clone(),
                     params: params.clone(),
                     class_variables: Vec::new(),
+                    safe_interp_ctx,
                 });
             } else {
                 self.analyse_body(&body_text, body_tok, &child_path);
@@ -952,6 +954,7 @@ impl Analyser {
         // doc-comment inside the lambda body doesn't bleed to what follows.
         let saved_comment = std::mem::take(&mut self.last_comment);
         if self.defer_proc_bodies {
+            let safe_interp_ctx = self.safe_interp_ctx_snapshot();
             self.deferred_bodies.push(super::per_item::DeferredBody {
                 body_text,
                 body_tok,
@@ -962,6 +965,7 @@ impl Analyser {
                 scope_name,
                 params,
                 class_variables: Vec::new(),
+                safe_interp_ctx,
             });
         } else {
             self.analyse_body(&body_text, body_tok, &child_path);
@@ -6938,41 +6942,138 @@ proc runs {body} {\n\
         );
     }
 
-    /// Pre-existing, **separate** gap found while investigating issue #1001
-    /// (tracked distinctly, not folded into this fix — see the issue's KCS
-    /// doc): `analyse_per_item`'s shell/body-pass split (`per_item.rs`)
+    // -- issue #1001 follow-up: safe-interp visibility survives `analyse_per_item` --
+
+    /// A **separate** gap found while investigating issue #1001, now fixed
+    /// alongside it: `analyse_per_item`'s shell/body-pass split (`per_item.rs`)
     /// defers *every* proc/method body — including one nested inside a
     /// tracked `interp eval` safe-interpreter body — to an isolated second
-    /// pass (`DeferredBody` / `analyse_proc_body_isolated`) that carries no
-    /// `safe_interp_stack` snapshot at all, so W129 never fires for a hidden
-    /// call inside *any* proc body nested in a safe interpreter when
-    /// analysed incrementally (the live LSP server's diagnostics path always
-    /// uses `analyse_per_item`) — even a directly-written call, with no
-    /// bracket-substitution indirection whatsoever. `Analyser::analyse`
-    /// (the whole-file walk; also what every existing W129/#945 unit test
-    /// above uses) is unaffected, since it never defers a body at all. This
-    /// pins the gap so a future fix has a red test to turn green; it is
-    /// out of scope here because it is not specific to bracket-substitution
-    /// indirection (issue #1001's actual subject) and touches the
-    /// differential-fuzzer-gated incremental-analysis core rather than the
-    /// W129 gate itself.
+    /// pass (`DeferredBody` / `analyse_proc_body_isolated`). Before this fix
+    /// that pass carried no `safe_interp_stack` snapshot at all, so W129
+    /// never fired for a hidden call inside *any* proc body nested in a safe
+    /// interpreter when analysed incrementally (the live LSP server's
+    /// diagnostics path always uses `analyse_per_item`) — even a
+    /// directly-written call, with no bracket-substitution indirection
+    /// whatsoever. `DeferredBody::safe_interp_ctx` (a flattened snapshot of
+    /// the stack's top entry, captured when the body is deferred and
+    /// restored in `analyse_proc_body_isolated`) closes this.
     #[test]
-    fn safe_interp_w129_lost_across_per_item_deferred_proc_body_1001() {
+    fn safe_interp_w129_reaches_deferred_proc_body_under_per_item_1001() {
         let mut a = Analyser::new();
         let r = a.analyse_per_item(
             "interp create -safe s\ninterp eval s { proc f {} { source foo }; f }\n",
             "tcl8.6",
         );
         assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "a hidden call inside a deferred proc body warns under \
+             incremental (per-item) analysis, matching `Analyser::analyse`: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// The same fix for a directly-written `apply` lambda body (also
+    /// deferred by the shell pass) rather than a `proc` body.
+    #[test]
+    fn safe_interp_w129_reaches_deferred_apply_body_under_per_item_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse_per_item(
+            "interp create -safe s\ninterp eval s { apply {{} { source foo }} }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "a hidden call inside a deferred apply-lambda body warns under \
+             incremental (per-item) analysis: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// The same fix for a `TclOO` method body (also deferred by the shell pass
+    /// via a distinct push site in `oo.rs`).
+    #[test]
+    fn safe_interp_w129_reaches_deferred_method_body_under_per_item_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse_per_item(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 oo::class create C { method m {} { source foo } }\n\
+                 [C new] m\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "a hidden call inside a deferred TclOO method body warns under \
+             incremental (per-item) analysis: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// FP guard: a deferred proc body outside any safe interpreter must not
+    /// warn — the new `safe_interp_ctx` snapshot must stay `None` and inert
+    /// for the overwhelming common case.
+    #[test]
+    fn deferred_proc_body_outside_any_safe_interp_is_untouched_under_per_item_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse_per_item("proc f {} { source foo }\nf\n", "tcl8.6");
+        assert!(
             !r.diagnostics
                 .iter()
                 .any(|d| d.code == tcl_core_types::DiagCode::W129),
-            "known gap (separate from #1001): per-item analysis currently \
-             loses the hidden `source` call inside `f`'s deferred body — \
-             `Analyser::analyse` (non-per-item) correctly flags it \
-             (`safe_interp_hides_unsafe_commands_and_expose_restores_945`); \
-             flip this assertion once a future fix threads \
-             `safe_interp_stack` through `DeferredBody`: {:?}",
+            "no safe interpreter is involved, so no W129 can ever fire: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// A narrower, separate limitation the `safe_interp_ctx` fix above does
+    /// **not** cover, found while adding it: a *nested* local redefinition —
+    /// `proc source {…}` written **inside** a proc body that is itself
+    /// deferred, redefining a name a *later statement in the same body* then
+    /// calls — does not suppress W129 the way an identical redefinition at
+    /// the top level of a tracked `interp eval` body already does (see
+    /// `safe_interp_w129_redefined_command_not_flagged_through_indirection_1001`,
+    /// which is unaffected — it never defers a body at all). Root cause:
+    /// `mark_locally_defined_in_enclosing_interp` also requires
+    /// `self.interp_path_stack` / `self.interpreters` to recognise the
+    /// current interpreter, and `safe_interp_ctx` only snapshots
+    /// `safe_interp_stack` (sufficient for the gate check itself, per that
+    /// field's doc) — not those two, which `analyse_proc_body_isolated`'s
+    /// fresh `Analyser` never seeds. Fixing this fully would mean threading
+    /// the interpreter identity (not just its visibility snapshot) through
+    /// `DeferredBody` too; out of scope here since the primary miss (a
+    /// hidden call inside a deferred body not warning *at all*) is what this
+    /// fix targets, and this narrower shadowing case is `SAFE_INTERP_HIDDEN`-
+    /// specific low-severity — it only means an occasional cosmetic false
+    /// positive on a rare pattern (redefining a hidden builtin's name
+    /// *inside* the very body that also calls it), never a missed real
+    /// violation. Pinned so a future contributor extending
+    /// `DeferredBody` has a red test.
+    #[test]
+    fn safe_interp_w129_nested_redefinition_inside_deferred_body_still_flagged_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse_per_item(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 proc f {} { proc source {} { return ok }; source }\n\
+                 f\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "known narrower gap: a redefinition nested inside a deferred \
+             body doesn't suppress W129 for a later call in the same body, \
+             under per-item analysis specifically; flip this assertion if a \
+             future fix threads interpreter identity through `DeferredBody`: {:?}",
             r.diagnostics
         );
     }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -6881,4 +6881,55 @@ proc runs {body} {\n\
             r.diagnostics
         );
     }
+
+    /// Pins issue #1001's own second reported repro case verbatim:
+    /// `{*}[list apply {...} $x]` combines *two* indirection mechanisms at
+    /// once — `{*}`-expansion of this command's own effective head
+    /// (`check_indirect_hiding`'s `{*}[list HEAD ...]` resolution) *and*
+    /// the resolved head being `apply` (triggering the lambda-body
+    /// recursion into `handle_apply_command`), so the hidden `source`
+    /// nested inside the lambda body must still draw W129.
+    #[test]
+    fn safe_interp_w129_expand_list_quoted_apply_lambda_body_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s { {*}[list apply {dir {source $dir/evil.tcl}} $env(HOME)] }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "hidden `source` nested inside a `{{*}}[list apply ...]`-invoked \
+             lambda body warns: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// Pins issue #1001's third reported repro case verbatim: the
+    /// `package ifneeded` deferred script followed by the actual
+    /// `package require` that triggers it — confirms the fix holds when the
+    /// deferred script is later invoked, not just when it is merely
+    /// declared.
+    #[test]
+    fn safe_interp_w129_list_quoted_apply_package_ifneeded_then_require_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 package ifneeded evil 1.0 [list apply {dir {source $dir/evil.tcl}} $env(HOME)]\n\
+                 package require evil\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "the deferred script's hidden `source` warns once `package \
+             require` is present too: {:?}",
+            r.diagnostics
+        );
+    }
 }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -33,6 +33,7 @@
 
 use tcl_core_types::DiagCode;
 use tcl_lexer::{Span, Token, TokenType};
+use tcl_syntax::list::find_element;
 
 use crate::alias::{detect_interp_alias, resolve_alias};
 use crate::signature_scan::types::SignatureCommandAlias;
@@ -1690,25 +1691,59 @@ impl Analyser {
         }
     }
 
-    /// The `(element, span)` pairs of a whitespace-separated list word, with
-    /// each element's span located inside the token's content (`content_offset`
-    /// skips the opening delimiter).  Shared by the ensemble `-map` /
-    /// `-subcommands` extraction; a dynamic element is left for the caller to
-    /// skip.
+    /// The `(element, span)` pairs of a list word's *top-level* Tcl-list
+    /// elements — proper brace/quote-aware splitting
+    /// ([`find_element`]), not naive whitespace splitting, so a braced
+    /// multi-word element (`{source b.tcl}`, the shape a `-map` *target*
+    /// commonly takes — see [`Self::record_ensemble_map_targets`]) comes
+    /// back as one element instead of being shredded into stray fragments
+    /// that no longer line up in pairs (codex review, #1001 follow-up: a
+    /// naive `split_whitespace` turned `-map {go {source b.tcl}}` into
+    /// `["go", "{source", "b.tcl}"]`, an unmatched three-way split that
+    /// silently dropped the pairing entirely). Each element's span is
+    /// located inside the token's content (`content_offset` skips the
+    /// opening delimiter). A malformed trailing element (unmatched
+    /// brace/quote, typically mid-edit) simply stops the scan early,
+    /// matching this codebase's established lenient-list-parsing
+    /// convention (`tcl_syntax::list::split_list_lenient`) rather than
+    /// discarding everything already parsed. Shared by the ensemble
+    /// `-map` / `-subcommands` extraction; a dynamic element is left for
+    /// the caller to skip.
     fn list_word_elements(list_text: &str, tok: Token) -> Vec<(String, Span)> {
         let content_start = tok.span.start() + u32::from(tok.content_offset);
         let mut out = Vec::new();
-        let mut search_start = 0usize;
-        for elem in list_text.split_whitespace() {
-            if let Some(rel) = list_text[search_start..].find(elem) {
-                let idx = search_start + rel;
-                let start = content_start + u32::try_from(idx).unwrap_or(0);
-                let end = start + u32::try_from(elem.len()).unwrap_or(0);
-                out.push((elem.to_owned(), Span::new(start, end)));
-                search_start = idx + elem.len();
+        let mut pos = 0usize;
+        while let Ok(Some(el)) = find_element(list_text, pos) {
+            if let Some(text) = list_text.get(el.value.clone()) {
+                let start = content_start + u32::try_from(el.value.start).unwrap_or(0);
+                let end = content_start + u32::try_from(el.value.end).unwrap_or(0);
+                out.push((text.to_string(), Span::new(start, end)));
             }
+            pos = el.next;
         }
         out
+    }
+
+    /// The head word `(text, span)` of a command-prefix string — Tcl-list
+    /// parses `text` and returns just its first element, the command
+    /// actually invoked once the prefix's trailing words and the caller's
+    /// own arguments are appended (mirrors
+    /// `signature_scan::command_prefix::extract_prefix_head`'s
+    /// braced-multi-word case, applied to a string with no lexer token of
+    /// its own — a `-map` target sits *inside* another list element, not
+    /// as a distinct token). `base_start` is `text`'s own absolute start
+    /// offset in the source, so the returned span locates the head word
+    /// there, not merely within `text`. `None` for an empty or malformed
+    /// (unmatched brace/quote) prefix.
+    fn command_prefix_head(text: &str, base_start: u32) -> Option<(String, Span)> {
+        let head_el = find_element(text, 0).ok().flatten()?;
+        let head = text.get(head_el.value.clone())?;
+        if head.is_empty() {
+            return None;
+        }
+        let start = base_start + u32::try_from(head_el.value.start).ok()?;
+        let end = base_start + u32::try_from(head_el.value.end).ok()?;
+        Some((head.to_string(), Span::new(start, end)))
     }
 
     /// Record every `-map` target (the odd elements of the `sub target …`
@@ -1722,7 +1757,32 @@ impl Analyser {
     /// couldn't be resolved statically, matching every other guard in this
     /// handler).
     ///
-    /// The map stores the *raw written* target text (`"source"`), not
+    /// A `-map` target is a command name **or a command prefix** in real
+    /// Tcl (tclsh 8.6.14-verified: `-map {go {string length}}` dispatches
+    /// `myens go hello` to `string length hello`) — the command actually
+    /// invoked is the prefix's *head*; the rest are baked-in arguments, not
+    /// part of the command's identity. [`Self::command_prefix_head`]
+    /// extracts just that head (codex review, #1001 follow-up: recording
+    /// the whole multi-word target text verbatim, or worse, splitting it
+    /// on whitespace before pairing it with its subcommand at all, means
+    /// a target like `{source b.tcl}` never matches the registry's bare
+    /// `source` and W129 stays silently missed for this valid indirection
+    /// shape) — both the reference recorded below and the map entry use
+    /// only the head.
+    ///
+    /// Every `-map` value **replaces** the ensemble's entire subcommand
+    /// table in real Tcl, whether given at `create` or a later
+    /// `configure` (tclsh 8.6.14-verified: `configure myens -map {ok
+    /// puts}` after `create ... -map {bad source ok puts}` turns `myens
+    /// bad` into an "unknown or ambiguous subcommand" error, not a
+    /// leftover redirect to `source`) — codex review, #1001 follow-up:
+    /// merging new pairs into the existing cached map instead of
+    /// replacing it would leave a subcommand a later `-map` dropped still
+    /// resolving to its stale target, a false-positive risk. The cached
+    /// map for `ensemble_key` is cleared before any of its new pairs are
+    /// inserted.
+    ///
+    /// The map stores the *raw written* head text (`"source"`), not
     /// `resolved` (the namespace-qualified form used for the reference
     /// below) — [`Self::check_ensemble_redirect_hiding`] hands it straight
     /// to [`Self::safe_interp_visibility_gate`], which — like the direct
@@ -1753,6 +1813,12 @@ impl Analyser {
         scope_path: &[usize],
         ensemble_key: Option<&str>,
     ) {
+        if let Some(key) = ensemble_key {
+            self.ensemble_command_maps
+                .entry(key.to_string())
+                .or_default()
+                .clear();
+        }
         for pair in Self::list_word_elements(list_text, tok).chunks(2) {
             let [(sub, _), (target, span)] = pair else {
                 continue;
@@ -1760,14 +1826,17 @@ impl Analyser {
             if crate::naming::is_dynamic_word(target) {
                 continue;
             }
+            let Some((head, head_span)) = Self::command_prefix_head(target, span.start()) else {
+                continue;
+            };
             if let Some(key) = ensemble_key {
                 self.ensemble_command_maps
                     .entry(key.to_string())
                     .or_default()
-                    .insert(sub.clone(), target.clone());
+                    .insert(sub.clone(), head.clone());
             }
-            let resolved = self.resolve_command_qualified_name(target, scope_path);
-            self.push_command_reference(target.clone(), *span, resolved, None);
+            let resolved = self.resolve_command_qualified_name(&head, scope_path);
+            self.push_command_reference(head, head_span, resolved, None);
         }
     }
 
@@ -7240,6 +7309,64 @@ proc runs {body} {\n\
                 .iter()
                 .any(|d| d.code == tcl_core_types::DiagCode::W129),
             "no safe interpreter is involved, so no W129 can ever fire: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP: a `-map` target that is itself a multi-word command prefix
+    /// (`{source b.tcl}`, real and valid Tcl — tclsh 8.6.14-verified:
+    /// `-map {go {string length}}` dispatches `myens go x` to `string
+    /// length x`) must still resolve to its *head* command for W129,
+    /// not be dropped entirely by a naive whitespace split across the
+    /// pair boundary (codex review, #1001 follow-up).
+    #[test]
+    fn safe_interp_w129_ensemble_map_redirect_multiword_target_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 namespace ensemble create -command myens -map {go {source b.tcl}}\n\
+                 myens go\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "an ensemble -map redirect to a multi-word hidden-command \
+             prefix warns: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP/FN guard: `configure -map` *replaces* the ensemble's whole
+    /// subcommand table in real Tcl (tclsh 8.6.14-verified: a subcommand
+    /// dropped from a later `-map` becomes "unknown or ambiguous
+    /// subcommand", not a leftover redirect) — a subcommand a later
+    /// `-map` omits must stop resolving to its stale, no-longer-mapped
+    /// target instead of still drawing W129 (codex review, #1001
+    /// follow-up: merging into the cached map instead of replacing it
+    /// left the stale entry behind).
+    #[test]
+    fn safe_interp_w129_ensemble_configure_map_replaces_not_merges_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 namespace ensemble create -command myens \
+                     -map {bad source ok puts}\n\
+                 namespace ensemble configure myens -map {ok puts}\n\
+                 myens bad\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "a subcommand dropped by a later `-map` must not keep warning \
+             through its stale mapping: {:?}",
             r.diagnostics
         );
     }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -4565,6 +4565,386 @@ mod tests {
         );
     }
 
+    // -- issue #1001: W129 through `[...]` bracket-substitution indirection --
+
+    /// TP (the reported repro): `package ifneeded`'s script argument is
+    /// `ArgRole::Body`-tagged (`Structural` — runs later, via `uplevel #0`,
+    /// never the definer's frame), so a `[list apply {…} $dir]`
+    /// deferred-command idiom sitting there is genuinely invoked later —
+    /// a hidden `source` nested inside the lambda body must draw W129, the
+    /// same way it would if `apply {dir {source …}} $dir` were written
+    /// directly (no `[list …]` wrapper).
+    #[test]
+    fn safe_interp_w129_list_quoted_apply_lambda_body_reports_hidden_source_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 package ifneeded myPackage 1.0 [list apply {dir {\n\
+                     source [file join $dir font.tcl]\n\
+                 }} $dir]\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "hidden `source` nested inside a list-quoted apply lambda body \
+             (reached only via `package ifneeded`'s deferred script) warns: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP: the same `[list apply {…} $x]` idiom in an `ArgRole::CommandPrefix`
+    /// position (`trace add variable … command CALLBACK`) — a different
+    /// registry role than `package ifneeded`'s `Body`, exercising the same
+    /// deferred-call resolution through a different gate.
+    #[test]
+    fn safe_interp_w129_list_quoted_apply_in_command_prefix_position_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 trace add variable x write [list apply {{a b c} {\n\
+                     exec ls\n\
+                 }} $x]\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "hidden `exec` nested inside a list-quoted apply lambda body \
+             reached via a CommandPrefix (`trace add … command`) position warns: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP: `after idle [list apply {…} $x]` — the `after`/`after idle`
+    /// deferred-callback idiom the issue calls out by name.
+    #[test]
+    fn safe_interp_w129_list_quoted_apply_after_idle_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 after idle [list apply {x {\n\
+                     file delete $x\n\
+                 }} val]\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "hidden `file` nested inside a list-quoted apply lambda body \
+             reached via `after idle` warns: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP: `[list source $file]` / `[list exec …]` directly — no `apply` at
+    /// all, `list` command-quoting a hidden command straight.
+    #[test]
+    fn safe_interp_w129_list_quoted_hidden_command_directly_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s { after idle [list source b.tcl] }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "a bare `[list source …]` in a deferred-call position warns \
+             directly, with no `apply` indirection needed: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// FP guard (mirrors #954's `set data [list apply {…} value]`
+    /// non-invocation case, adapted to W129): `[list apply {…} value]`
+    /// sitting in ordinary `set` data — not a `Body` / `LambdaLiteral` /
+    /// `CommandPrefix` argument position — is never invoked, so it must
+    /// never draw W129 even though its lambda body contains a hidden
+    /// command.
+    #[test]
+    fn safe_interp_w129_list_quoted_apply_in_plain_data_is_not_flagged_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 set data [list apply {x { source $x }} value]\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "a `[list apply …]` value that is only ever stored, never \
+             invoked, must not warn: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// FP guard: the exact same list-quoted-apply-with-a-hidden-command
+    /// shape, but with **no** enclosing safe interpreter at all, must not
+    /// warn — and, since this fix's whole mechanism is gated on a
+    /// non-empty `safe_interp_stack`, must not create any new scope either
+    /// (no `apply@…` proc scope, no collateral diagnostics of any other
+    /// kind) — this stays exactly as un-analysed as it was before #1001.
+    #[test]
+    fn list_quoted_apply_lambda_outside_any_safe_interp_is_untouched_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "package ifneeded myPackage 1.0 [list apply {dir {source [file join $dir x]}} $dir]\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "no safe interpreter is involved, so no W129 can ever fire: {:?}",
+            r.diagnostics
+        );
+        assert!(
+            r.all_procs.is_empty(),
+            "this fix must not widen the general analyser's scope — \
+             the list-quoted lambda body stays un-analysed outside a \
+             safe-interpreter context, exactly as before #1001: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// TP: a direct nested `[…]` bracket substitution (no `list`-quoting at
+    /// all) — `set x [source b.tcl]` — is an *immediate* invocation
+    /// (bracket substitution always evaluates its content right away,
+    /// wherever it appears), so it must warn exactly like a bare top-level
+    /// `source b.tcl` statement would.
+    #[test]
+    fn safe_interp_w129_direct_nested_bracket_substitution_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\ninterp eval s { set x [source b.tcl] }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "a directly nested `[source …]` substitution warns: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP: the same direct-nested shape, reached through a deeper `[…]` /
+    /// braced-body combination (`if {$c} { [exec ls] }` inside another
+    /// substitution) — pins that the fix covers arbitrary nesting depth,
+    /// not just one level.
+    #[test]
+    fn safe_interp_w129_direct_nested_bracket_substitution_deep_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s { if {[catch {set y [exec ls]} err]} { puts $err } }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "a deeply nested `[exec …]` substitution still warns: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP: `{*}[list source $file]` as the *whole* statement — `{*}`
+    /// expansion splices `list`'s result into this statement's own argv, so
+    /// the command's effective head becomes `source`, even though the
+    /// literal head word is the substitution text (never itself a
+    /// registry name).
+    #[test]
+    fn safe_interp_w129_expand_list_quoted_head_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\ninterp eval s { {*}[list source b.tcl] }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "`{{*}}[list source …]` used as the whole statement warns \
+             on the effective (expanded) head: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TN: `{*}$cmdList` — an opaque variable expansion. Unlike
+    /// `{*}[list source $file]`, the value isn't statically known, so this
+    /// must NOT warn (matches this codebase's "prefer a miss over a false
+    /// positive" stance for dynamic dispatch — the same policy `$cmd $file`
+    /// direct dynamic dispatch already gets).
+    #[test]
+    fn safe_interp_w129_expand_dynamic_var_head_not_flagged_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s { set cmdList [list source b.tcl]; {*}$cmdList }\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "an opaque `{{*}}$var` expansion is not statically resolvable \
+             and must not warn: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TN: a bare dynamic dispatch via a variable (`set cmd source; $cmd
+    /// $file`) is not statically provable and must stay unflagged, matching
+    /// this codebase's existing precedent for dynamic command dispatch.
+    #[test]
+    fn safe_interp_w129_dynamic_variable_dispatch_not_flagged_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s { set cmd source; $cmd b.tcl }\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "dynamic dispatch through a variable is not statically \
+             resolvable and must not warn: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP: `eval [list source $file]` — combining `eval` (a `Body`-role
+    /// command) with list-quoting; `eval` evaluates the built string as a
+    /// script, immediately invoking `source`.
+    #[test]
+    fn safe_interp_w129_eval_list_quoted_hidden_command_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\ninterp eval s { eval [list source b.tcl] }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "`eval [list source …]` warns on the resolved head: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP: `uplevel [list source $file]` — the same combination via
+    /// `uplevel` instead of `eval`.
+    #[test]
+    fn safe_interp_w129_uplevel_list_quoted_hidden_command_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\ninterp eval s { uplevel [list source b.tcl] }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "`uplevel [list source …]` warns on the resolved head: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TN: a *safe* command wrapped the same list-quoted-apply way must not
+    /// warn — this fix widens W129's recall, it must not start flagging
+    /// ordinary, allowed calls just because they are reached via `[list
+    /// apply …]`.
+    #[test]
+    fn safe_interp_w129_list_quoted_apply_safe_command_not_flagged_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s { after idle [list apply {x { puts $x }} val] }\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "a safe command (`puts`) reached via list-quoted apply must \
+             not warn: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// A locally-redefined hidden-builtin name (issue #945 fault 7 follow-up
+    /// — see `safe_interp_child_redefinition_of_a_hidden_builtin_is_callable_945`)
+    /// stays callable through this fix's new indirection paths too: once
+    /// `proc source {} {…}` has run earlier in the same interpreter body,
+    /// `source` is a real, locally-defined command — independent of the
+    /// hidden-command table — so a later `[list apply {…} $x]`-nested call
+    /// to it must not warn.
+    #[test]
+    fn safe_interp_w129_redefined_command_not_flagged_through_indirection_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 proc source {} { return ok }\n\
+                 after idle [list apply {{} { source }}]\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "a locally-redefined name reached via list-quoted apply is \
+             callable, not hidden: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// The standard safe-interpreter delegation pattern — the trusted
+    /// parent creates `interp alias s foo {} source`, bridging its *own*
+    /// (non-hidden) `source` into the child under a new name — must not
+    /// warn when `foo` is called inside the child, including through this
+    /// fix's new indirection paths: `foo` is never itself a
+    /// `SAFE_INTERP_HIDDEN` registry name, so the gate correctly leaves it
+    /// alone (rename/`interp alias` cannot resurrect a *hidden* command's
+    /// callability from within the child — confirmed against the `tcl-vm`
+    /// runtime, which resolves both only through the ordinary, hidden-
+    /// command-free lookup table).
+    #[test]
+    fn safe_interp_w129_alias_bridged_command_not_flagged_through_indirection_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp alias s foo {} source\n\
+             interp eval s { after idle [list apply {{} { foo }}] }\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "an alias bridging a capability in from the trusted parent is \
+             not itself a hidden registry name, so it must not warn: {:?}",
+            r.diagnostics
+        );
+    }
+
     /// `namespace inscope ::x { proc foo }` runs the body in `::x`, so `foo`
     /// homes to `::x::foo` — the same namespace frame as `namespace eval`, not
     /// the caller's scope.
@@ -6460,6 +6840,45 @@ proc runs {body} {\n\
                 .is_some_and(|s| s.contains(&crate::analyser::ProcArgTrait::Body)),
             "expected NO Body trait without stub directive, got {:?}",
             proc.param_traits.get("body"),
+        );
+    }
+
+    /// Pre-existing, **separate** gap found while investigating issue #1001
+    /// (tracked distinctly, not folded into this fix — see the issue's KCS
+    /// doc): `analyse_per_item`'s shell/body-pass split (`per_item.rs`)
+    /// defers *every* proc/method body — including one nested inside a
+    /// tracked `interp eval` safe-interpreter body — to an isolated second
+    /// pass (`DeferredBody` / `analyse_proc_body_isolated`) that carries no
+    /// `safe_interp_stack` snapshot at all, so W129 never fires for a hidden
+    /// call inside *any* proc body nested in a safe interpreter when
+    /// analysed incrementally (the live LSP server's diagnostics path always
+    /// uses `analyse_per_item`) — even a directly-written call, with no
+    /// bracket-substitution indirection whatsoever. `Analyser::analyse`
+    /// (the whole-file walk; also what every existing W129/#945 unit test
+    /// above uses) is unaffected, since it never defers a body at all. This
+    /// pins the gap so a future fix has a red test to turn green; it is
+    /// out of scope here because it is not specific to bracket-substitution
+    /// indirection (issue #1001's actual subject) and touches the
+    /// differential-fuzzer-gated incremental-analysis core rather than the
+    /// W129 gate itself.
+    #[test]
+    fn safe_interp_w129_lost_across_per_item_deferred_proc_body_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse_per_item(
+            "interp create -safe s\ninterp eval s { proc f {} { source foo }; f }\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "known gap (separate from #1001): per-item analysis currently \
+             loses the hidden `source` call inside `f`'s deferred body — \
+             `Analyser::analyse` (non-per-item) correctly flags it \
+             (`safe_interp_hides_unsafe_commands_and_expose_restores_945`); \
+             flip this assertion once a future fix threads \
+             `safe_interp_stack` through `DeferredBody`: {:?}",
+            r.diagnostics
         );
     }
 }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1574,14 +1574,57 @@ impl Analyser {
         if args.len() < 2 {
             return;
         }
-        if args[1] != "create" {
+        // `create` operates on the *current* namespace, with no explicit name
+        // argument; `configure NAME ...` (issue #1001 follow-up — the ensemble
+        // side of the `namespace ensemble configure -map` gap, previously
+        // silently ignored here entirely) names an *existing* ensemble
+        // command explicitly, resolved like any other command reference.
+        // Both share the same `-command`/`-map`/`-subcommands` option set.
+        let is_create = args[1] == "create";
+        let is_configure = args[1] == "configure";
+        if !is_create && !is_configure {
             return;
         }
         let ns = self.namespace_from_scope_path(scope_path);
-        if !ns.is_empty() && ns != "::" {
-            self.ensemble_namespaces.insert(ns.clone());
-        }
         let ns_prefix = ns.trim_start_matches(':').to_owned();
+
+        let (opts, opt_tokens, configure_target) = if is_create {
+            if !ns.is_empty() && ns != "::" {
+                self.ensemble_namespaces.insert(ns.clone());
+            }
+            (&args[2..], arg_tokens.get(2..).unwrap_or(&[]), None)
+        } else {
+            let Some(name) = args.get(2) else { return };
+            if crate::naming::is_dynamic_word(name) {
+                return;
+            }
+            let target = self.resolve_command_qualified_name(name, scope_path);
+            (
+                args.get(3..).unwrap_or(&[]),
+                arg_tokens.get(3..).unwrap_or(&[]),
+                Some(target),
+            )
+        };
+
+        // The ensemble's own resolved command name (issue #1001 follow-up):
+        // `-command NAME`, when present, *replaces* the default naming
+        // entirely (tclsh 8.6.14-verified: `namespace ensemble create
+        // -command ::alt` creates only `::alt`, never the enclosing
+        // namespace's own name too) — so scan for it before recording any
+        // `-map`, rather than defaulting eagerly the way `ensemble_namespaces`
+        // (a broader, over-inclusive "valid command name" recovery set) does.
+        let explicit_command = is_create
+            .then(|| {
+                opts.iter()
+                    .enumerate()
+                    .find_map(|(i, o)| (o == "-command").then(|| opts.get(i + 1)).flatten())
+            })
+            .flatten()
+            .filter(|v| !v.is_empty() && !crate::naming::is_dynamic_word(v))
+            .map(|v| qualify(&ns_prefix, v));
+        let ensemble_key = configure_target
+            .or(explicit_command)
+            .or_else(|| (is_create && !ns.is_empty() && ns != "::").then(|| ns.clone()));
 
         let option_specs: Vec<&tcl_registry::hover::OptionSpec> = self
             .registry
@@ -1593,8 +1636,6 @@ impl Analyser {
             })
             .unwrap_or_default();
 
-        let opts = &args[2..];
-        let opt_tokens = arg_tokens.get(2..).unwrap_or(&[]);
         let mut i = 0usize;
         while i < opts.len() {
             let Some(spec) = option_specs.iter().find(|o| o.matches(opts[i].as_str())) else {
@@ -1618,10 +1659,18 @@ impl Analyser {
                 }
                 // `-map {sub target sub target …}` — every *target* (an
                 // odd-indexed element) is a command the ensemble dispatches to,
-                // recorded so it is reached by references / definition / rename.
+                // recorded so it is reached by references / definition / rename
+                // — and, keyed by the ensemble's own resolved command name, so
+                // the W129 safe-interpreter gate can resolve a call through
+                // this redirect to the target (issue #1001 follow-up).
                 "-map" => {
                     if let (Some(value), Some(tok)) = (value, value_tok) {
-                        self.record_ensemble_map_targets(value, tok, scope_path);
+                        self.record_ensemble_map_targets(
+                            value,
+                            tok,
+                            scope_path,
+                            ensemble_key.as_deref(),
+                        );
                     }
                 }
                 // `-subcommands {a b c}` — each subcommand `a` dispatches to
@@ -1659,16 +1708,62 @@ impl Analyser {
     }
 
     /// Record every `-map` target (the odd elements of the `sub target …`
-    /// list) as a command reference resolved in the caller's namespace.
-    fn record_ensemble_map_targets(&mut self, list_text: &str, tok: Token, scope_path: &[usize]) {
-        for (idx, (elem, span)) in Self::list_word_elements(list_text, tok)
-            .into_iter()
-            .enumerate()
-        {
-            if idx % 2 == 1 && !crate::naming::is_dynamic_word(&elem) {
-                let resolved = self.resolve_command_qualified_name(&elem, scope_path);
-                self.push_command_reference(elem, span, resolved, None);
+    /// list) as a command reference resolved in the caller's namespace, and
+    /// — when `ensemble_key` is `Some` (the ensemble's own resolved
+    /// qualified command name, computed by [`Self::handle_namespace_ensemble`])
+    /// — also record each `sub -> target` pair into
+    /// `self.ensemble_command_maps`, so the W129 safe-interpreter gate can
+    /// resolve a call reaching a hidden command only through this ensemble's
+    /// redirect (issue #1001 follow-up; `None` when the ensemble's own name
+    /// couldn't be resolved statically, matching every other guard in this
+    /// handler).
+    ///
+    /// The map stores the *raw written* target text (`"source"`), not
+    /// `resolved` (the namespace-qualified form used for the reference
+    /// below) — [`Self::check_ensemble_redirect_hiding`] hands it straight
+    /// to [`Self::safe_interp_visibility_gate`], which — like the direct
+    /// literal-head case and every other indirection path this fix adds —
+    /// checks the bare written spelling against the registry, not a
+    /// namespace-qualified path. This matters concretely: a `-map` target is
+    /// namespace-qualified relative to the ensemble's own (possibly
+    /// synthetic, interp-domain-rooted) home namespace by real Tcl's own
+    /// rule (tclsh 8.6.14-verified: `-map {go source}` inside `namespace
+    /// eval myns {…}` really dispatches `go` to `::myns::source`, not the
+    /// global builtin, and raises its own unrelated `invalid command name
+    /// ::myns::source` in every interpreter, safe or not, when no such proc
+    /// exists) — using the qualified form here would make the check depend
+    /// on the interp-domain namespace model lining up with the registry's
+    /// flat, unqualified command-name keying, which it structurally can't.
+    /// The raw-text check this uses instead only fires for a target that is
+    /// unqualified or explicitly `::`-rooted, matching the shape a
+    /// `SAFE_INTERP_HIDDEN` registry command's name actually takes; a
+    /// locally shadowing `proc` by the same bare name, anywhere in the
+    /// tracked safe interpreter body, still suppresses it via the *existing*
+    /// `ctx.exposed` check inside `safe_interp_visibility_gate` (populated
+    /// by `mark_locally_defined_in_enclosing_interp`, which is namespace-
+    /// blind in exactly the same way already, for the direct-call case).
+    fn record_ensemble_map_targets(
+        &mut self,
+        list_text: &str,
+        tok: Token,
+        scope_path: &[usize],
+        ensemble_key: Option<&str>,
+    ) {
+        for pair in Self::list_word_elements(list_text, tok).chunks(2) {
+            let [(sub, _), (target, span)] = pair else {
+                continue;
+            };
+            if crate::naming::is_dynamic_word(target) {
+                continue;
             }
+            if let Some(key) = ensemble_key {
+                self.ensemble_command_maps
+                    .entry(key.to_string())
+                    .or_default()
+                    .insert(sub.clone(), target.clone());
+            }
+            let resolved = self.resolve_command_qualified_name(target, scope_path);
+            self.push_command_reference(target.clone(), *span, resolved, None);
         }
     }
 
@@ -6929,6 +7024,121 @@ proc runs {body} {\n\
                 .any(|d| d.code == tcl_core_types::DiagCode::W129),
             "the deferred script's hidden `source` warns once `package \
              require` is present too: {:?}",
+            r.diagnostics
+        );
+    }
+
+    // -- issue #1001 follow-up: namespace ensemble -map redirection --------
+
+    /// TP: `namespace ensemble create -command myens -map {go source}` then
+    /// `myens go ...` — the ensemble redirects `go` to the hidden `source`,
+    /// so the call must warn exactly like a direct `source` call would, even
+    /// though `myens` itself is never a registry name.
+    #[test]
+    fn safe_interp_w129_ensemble_create_map_redirect_to_hidden_command_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 namespace ensemble create -command myens -map {go source}\n\
+                 myens go pkg.tcl\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "an ensemble -map redirect to a hidden command warns: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP: the same redirect declared via `namespace ensemble configure NAME
+    /// -map {...}` (previously silently ignored entirely — only `create`
+    /// was handled) rather than at `create` time.
+    #[test]
+    fn safe_interp_w129_ensemble_configure_map_redirect_to_hidden_command_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 namespace ensemble create -command myens\n\
+                 namespace ensemble configure myens -map {go source}\n\
+                 myens go pkg.tcl\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "an ensemble -map redirect declared via `configure` warns: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// TP: the ensemble's default naming (no `-command`, so the command is
+    /// the enclosing namespace's own name) also resolves the redirect.
+    #[test]
+    fn safe_interp_w129_ensemble_default_name_map_redirect_to_hidden_command_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 namespace eval myns { namespace ensemble create -map {go source} }\n\
+                 myns go pkg.tcl\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "an ensemble redirect under its default (namespace) name warns: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// FP guard: an ensemble `-map` redirect to a *safe* command must not
+    /// warn — this fix widens W129's recall, it must not start flagging
+    /// ordinary ensemble dispatch.
+    #[test]
+    fn safe_interp_w129_ensemble_map_redirect_to_safe_command_not_flagged_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "interp create -safe s\n\
+             interp eval s {\n\
+                 namespace ensemble create -command myens -map {go puts}\n\
+                 myens go hi\n\
+             }\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "an ensemble redirect to a safe command must not warn: {:?}",
+            r.diagnostics
+        );
+    }
+
+    /// FP guard: the exact same ensemble-redirect shape outside any safe
+    /// interpreter must not warn (and, since the whole mechanism is gated on
+    /// a non-empty `safe_interp_stack`, must not do anything at all).
+    #[test]
+    fn ensemble_map_redirect_outside_any_safe_interp_is_untouched_1001() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "namespace ensemble create -command myens -map {go source}\n\
+             myens go pkg.tcl\n",
+            "tcl8.6",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W129),
+            "no safe interpreter is involved, so no W129 can ever fire: {:?}",
             r.diagnostics
         );
     }

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -535,6 +535,7 @@ impl Analyser {
         // params, and the class instance variables (pre-bound in every method).
         if self.defer_proc_bodies {
             let namespace = self.namespace_from_scope_path(scope_path);
+            let safe_interp_ctx = self.safe_interp_ctx_snapshot();
             self.deferred_bodies.push(super::per_item::DeferredBody {
                 body_text: mb.body_text.clone(),
                 body_tok: mb.body_tok,
@@ -548,6 +549,7 @@ impl Analyser {
                 // declaration spans; the graft keeps the shell's span, so
                 // the deferred body pass only needs the names.
                 class_variables: class_variables.to_vec(),
+                safe_interp_ctx,
             });
         } else {
             self.analyse_body(&mb.body_text, mb.body_tok, &method_path);

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -94,6 +94,26 @@ pub struct DeferredBody {
     /// pass below only needs the names, so this stays `Vec<String>` (and salsa
     /// -interning-friendly — see `tcl-lsp-db`'s `ItemBodyKey`).
     pub class_variables: Vec<String>,
+    /// A flattened snapshot of `self.safe_interp_stack`'s *top* entry (issue
+    /// #1001 follow-up) at the moment this body was deferred — `(base_hidden,
+    /// hidden_extra, exposed)`, sorted `Vec<String>`s rather than the live
+    /// `HashSet`-based `SafeInterpCtx` (which isn't `Hash`, so can't key
+    /// `tcl-lsp-db`'s `ItemBodyKey` directly) so this stays deterministic and
+    /// salsa-interning-friendly, matching `class_variables` above.
+    /// `None` outside any tracked safe interpreter (the overwhelming common
+    /// case — no new work, no behaviour change from before this field
+    /// existed). Every safe-interp check only ever consults the *top* of the
+    /// stack (`safe_interp_visibility_gate`'s `.last()`), never an older
+    /// entry, so this single flattened snapshot is sufficient — a proc/apply
+    /// body nested several `interp eval`s deep still only needs the
+    /// innermost one. [`analyse_proc_body_isolated`] seeds the isolated
+    /// `Analyser`'s own `safe_interp_stack` from this before walking the
+    /// body, so a hidden call inside the body hits the same, unmodified gate
+    /// a directly-written call already does — without this, W129 silently
+    /// missed *any* hidden call inside *any* proc/apply body nested in a
+    /// safe interpreter under incremental (`analyse_per_item`) analysis,
+    /// which is what the live LSP server always uses for diagnostics.
+    pub safe_interp_ctx: Option<(bool, Vec<String>, Vec<String>)>,
 }
 
 impl Analyser {
@@ -671,6 +691,20 @@ pub fn analyse_proc_body_isolated<S: std::hash::BuildHasher>(
         a.define_var(base, dummy, &proc_path, false, Some(placeholder));
     }
     a.suppress_w215 = false;
+    // Restore the enclosing safe-interpreter visibility context (issue #1001
+    // follow-up) so a hidden call inside this body — reached only via
+    // incremental analysis's isolated second pass — still hits
+    // `safe_interp_visibility_gate` the same way it would in a directly-
+    // written body under the whole-file `analyse` path. `None` (the
+    // overwhelming common case) leaves the fresh analyser's stack empty,
+    // exactly as before this field existed.
+    if let Some((base_hidden, hidden_extra, exposed)) = &db.safe_interp_ctx {
+        a.safe_interp_stack.push(super::state::SafeInterpCtx {
+            base_hidden: *base_hidden,
+            hidden_extra: hidden_extra.iter().cloned().collect(),
+            exposed: exposed.iter().cloned().collect(),
+        });
+    }
     a.analyse_body(&db.body_text, body_tok, &proc_path);
     let proc_scope = super::scope::scope_at_mut(&mut a.result.global_scope, &proc_path)
         .expect("reconstructed proc scope")

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -341,6 +341,16 @@ pub struct Analyser {
     /// Namespaces where ``namespace ensemble create`` was seen —
     /// their tail names become valid commands.
     pub ensemble_namespaces: HashSet<String>,
+    /// `namespace ensemble create|configure ... -map {sub target ...}`
+    /// subcommand-to-target maps, keyed by the ensemble's own qualified
+    /// command name (`-command NAME`, or the enclosing namespace's own
+    /// qualified name when `-command` is absent — Tcl's default). Consulted
+    /// by the W129 safe-interpreter gate (issue #1001 follow-up, tracked
+    /// separately from #979's interprocedural call-site concern) so a
+    /// hidden command reached only through an ensemble redirect (`myens sub
+    /// ...` → target) is still flagged, mirroring a literal call to the
+    /// target.
+    pub ensemble_command_maps: HashMap<String, HashMap<String, String>>,
     /// Vars where ``oo::objdefine`` was applied — the per-instance
     /// method table may extend the class definition.
     pub objdefined_vars: HashSet<String>,
@@ -697,6 +707,7 @@ impl Analyser {
             cmd_command_sites: Vec::new(),
             ns_cache: HashMap::new(),
             ensemble_namespaces: HashSet::new(),
+            ensemble_command_maps: HashMap::new(),
             objdefined_vars: HashSet::new(),
             interpreters: HashMap::new(),
             dynamic_interp_ops: false,

--- a/rust/tcl-compiler/src/signature_scan/command_prefix.rs
+++ b/rust/tcl-compiler/src/signature_scan/command_prefix.rs
@@ -57,7 +57,7 @@ use tcl_lexer::{Span, Token, TokenType};
 use tcl_registry::{AppendedArity, CommandRegistry};
 use tcl_syntax::list::find_element;
 
-use crate::segmenter::segment_commands_with_offset;
+use crate::segmenter::{SegmentedCommand, segment_commands_with_offset};
 
 /// A command-prefix callback head extracted from a call site.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -254,6 +254,29 @@ fn extract_list_quoted_prefix_head(
     tok: Token,
     text: &str,
 ) -> Option<(String, Span, usize)> {
+    let seg = list_quoted_command_segment(registry, tok, text)?;
+    let head_tok = seg.argv[1];
+    let baked = seg.texts.len().saturating_sub(2);
+    Some((seg.texts[1].clone(), head_tok.span, baked))
+}
+
+/// Extract the full segmented `list HEAD arg1 arg2 …` command from a
+/// `[list …]` `Cmd` token: `Some` when the token's sole inner command is a
+/// call to a [`tcl_registry::Traits::BUILDS_COMMAND_PREFIX`] command
+/// (`list`) whose own first argument is a literal, resolvable bareword.
+///
+/// `seg.texts[1]` / `seg.argv[1]` is the resolved head; `seg.texts[2..]` /
+/// `seg.argv[2..]` are the words `list` appends after it when the value is
+/// later invoked as a command. Shared by [`extract_list_quoted_prefix_head`]
+/// (which only needs the head/span/baked-count) and the W129 safe-interpreter
+/// gate's deferred-call resolution (`analyser::commands`), which also needs
+/// the full remaining words to recurse into an `apply` lambda body the same
+/// way a direct `apply {…} $x` call would.
+pub(crate) fn list_quoted_command_segment(
+    registry: &CommandRegistry,
+    tok: Token,
+    text: &str,
+) -> Option<SegmentedCommand> {
     let inner = text.strip_prefix('[')?.strip_suffix(']')?;
     let content_start = tok.span.start() + u32::from(tok.content_offset);
     let mut segs = segment_commands_with_offset(inner, content_start);
@@ -261,6 +284,9 @@ fn extract_list_quoted_prefix_head(
         return None;
     }
     let seg = segs.pop()?;
+    if seg.texts.len() < 2 {
+        return None;
+    }
     if !registry.get(&seg.texts[0]).is_some_and(|s| {
         s.traits
             .contains(tcl_registry::Traits::BUILDS_COMMAND_PREFIX)
@@ -274,10 +300,8 @@ fn extract_list_quoted_prefix_head(
     {
         return None;
     }
-    let head = seg.texts.get(1)?.as_str();
-    if looks_unresolvable(head) {
+    if looks_unresolvable(seg.texts.get(1)?) {
         return None;
     }
-    let baked = seg.texts.len().saturating_sub(2);
-    Some((head.to_string(), head_tok.span, baked))
+    Some(seg)
 }

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -666,6 +666,15 @@ pub struct ItemBodyKey<'db> {
     /// Class instance variables pre-bound in a method body (empty for procs).
     #[returns(ref)]
     pub class_variables: Vec<String>,
+    /// Snapshot of the enclosing safe-interpreter visibility context (issue
+    /// #1001 follow-up) — mirrors [`tcl_compiler::analyser::per_item::DeferredBody::safe_interp_ctx`]
+    /// exactly (same flattened, sorted-`Vec` shape, for the same reason: a
+    /// live `HashSet`-based `SafeInterpCtx` isn't `Hash` and can't key an
+    /// interned salsa struct). Part of the cache key so a proc/apply body
+    /// that moves in or out of a tracked safe interpreter between edits gets
+    /// re-analysed rather than serving a stale cached `W129` verdict.
+    #[returns(ref)]
+    pub safe_interp_ctx: Option<(bool, Vec<String>, Vec<String>)>,
     #[returns(ref)]
     pub dialect: String,
     #[returns(ref)]
@@ -691,6 +700,7 @@ pub fn item_body_analysis<'db>(db: &'db dyn TclDb, key: ItemBodyKey<'db>) -> Arc
         scope_name: key.scope_name(db).clone(),
         params: key.params(db).clone(),
         class_variables: key.class_variables(db).clone(),
+        safe_interp_ctx: key.safe_interp_ctx(db).clone(),
     };
     let disabled: HashSet<String> = key.disabled(db).iter().cloned().collect();
     let overlay = tcl_compiler::analyser::types::build_stub_overlay(&[]);
@@ -2112,6 +2122,7 @@ pub fn file_analysis_incremental(
             body.is_method,
             body.oo_global_resolution,
             body.class_variables.clone(),
+            body.safe_interp_ctx.clone(),
             dialect.clone(),
             disabled_vec.clone(),
             non_ascii,

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -55,6 +55,8 @@ mod hover;
 mod invariants;
 #[path = "e2e/irules.rs"]
 mod irules;
+#[path = "e2e/issue1001.rs"]
+mod issue1001;
 #[path = "e2e/issue923_class_refs.rs"]
 mod issue923_class_refs;
 #[path = "e2e/issue945.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/issue1001.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1001.rs
@@ -1,0 +1,156 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! End-to-end coverage for issue #1001, against the real, packaged native
+//! server: W129 (the Safe Base diagnostic) missing a hidden command reached
+//! only through `[...]` bracket-substitution indirection.
+//!
+//! The unit tests in `tcl-compiler`'s `analyser::handlers::tests` module
+//! (suffixed `_1001`) exercise every indirection path exhaustively —
+//! including the pervasive `[list apply {...} $x]` deferred-command idiom
+//! (`package ifneeded ... [list apply {...} $dir]`) — via `Analyser::analyse`
+//! (the whole-file walk). This file confirms the fix reaches real clients
+//! through the full, *incremental* LSP diagnostics pipeline
+//! (`analyse_per_item`, what the live server actually uses), for every
+//! indirection path **except** one reached through an `apply` (or any
+//! other proc/method) body: `analyse_per_item`'s shell/body-pass split
+//! defers every such body to an isolated second pass that carries no
+//! `safe_interp_stack` snapshot at all — a pre-existing gap unrelated to
+//! bracket-substitution (it loses a *directly-written* hidden call the
+//! same way), pinned separately by
+//! `safe_interp_w129_lost_across_per_item_deferred_proc_body_1001` in
+//! `tcl-compiler`, not fixed here (see that test's doc for why).
+
+use serde_json::Value;
+
+use crate::common::{Lsp, unique_uri};
+
+fn diagnostic_codes(lsp: &mut Lsp, uri: &str) -> Vec<String> {
+    lsp.await_diagnostics(uri)
+        .iter()
+        .filter_map(|d| d.get("code").and_then(Value::as_str).map(str::to_owned))
+        .collect()
+}
+
+/// `package ifneeded`'s deferred script built with `[list source $file]`
+/// directly (no `apply` / no proc body involved, so this reaches the real
+/// server's incremental pipeline in full) — the reported issue's second
+/// bullet: `list` command-quoting a hidden command straight.
+#[test]
+fn safe_interp_w129_reaches_list_quoted_hidden_command_in_package_ifneeded_1001() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "interp create -safe s\n\
+               interp eval s {\n\
+                   package ifneeded myPackage 1.0 [list source pkg.tcl]\n\
+               }\n";
+    lsp.open_ready(&uri, src);
+    let codes = diagnostic_codes(&mut lsp, &uri);
+    assert!(
+        codes.iter().any(|c| c == "W129"),
+        "a `[list source ...]` deferred script in `package ifneeded` warns: {codes:?}"
+    );
+}
+
+/// The same idiom in an `ArgRole::CommandPrefix` position (`trace add
+/// variable ... command`) rather than `package ifneeded`'s `Body` position —
+/// a different registry role reaching the same resolution.
+#[test]
+fn safe_interp_w129_reaches_list_quoted_hidden_command_in_command_prefix_1001() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "interp create -safe s\n\
+               interp eval s { trace add variable x write [list source pkg.tcl] }\n";
+    lsp.open_ready(&uri, src);
+    let codes = diagnostic_codes(&mut lsp, &uri);
+    assert!(
+        codes.iter().any(|c| c == "W129"),
+        "a `[list source ...]` trace command-prefix warns: {codes:?}"
+    );
+}
+
+/// FP guard (mirrors #954's `set data [list apply {...} value]`
+/// non-invocation case): the same list-quoting shape sitting in ordinary
+/// `set` data (never a `Body`/`LambdaLiteral`/`CommandPrefix` argument
+/// position) must not draw W129.
+#[test]
+fn safe_interp_w129_does_not_flag_list_quoted_hidden_command_in_plain_data_1001() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "interp create -safe s\n\
+               interp eval s {\n\
+                   set data [list source pkg.tcl]\n\
+               }\n";
+    lsp.open_ready(&uri, src);
+    let codes = diagnostic_codes(&mut lsp, &uri);
+    assert!(
+        !codes.iter().any(|c| c == "W129"),
+        "a `[list source ...]` value that is only ever stored must not warn: {codes:?}"
+    );
+}
+
+/// A direct nested `[...]` bracket substitution (no `list`-quoting at all)
+/// is an *immediate* invocation, wherever it appears — `set x [source
+/// b.tcl]` inside a safe interpreter must warn exactly like a bare
+/// top-level `source b.tcl` statement would.
+#[test]
+fn safe_interp_w129_reaches_direct_nested_bracket_substitution_1001() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "interp create -safe s\ninterp eval s { set x [source b.tcl] }\n";
+    lsp.open_ready(&uri, src);
+    let codes = diagnostic_codes(&mut lsp, &uri);
+    assert!(
+        codes.iter().any(|c| c == "W129"),
+        "a directly nested `[source ...]` substitution warns: {codes:?}"
+    );
+}
+
+/// `{*}[list source $file]` as the whole statement: `{*}` expansion splices
+/// `list`'s result into this statement's own argv, so the command's
+/// effective head becomes `source`.
+#[test]
+fn safe_interp_w129_reaches_expand_list_quoted_head_1001() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "interp create -safe s\ninterp eval s { {*}[list source b.tcl] }\n";
+    lsp.open_ready(&uri, src);
+    let codes = diagnostic_codes(&mut lsp, &uri);
+    assert!(
+        codes.iter().any(|c| c == "W129"),
+        "`{{*}}[list source ...]` used as the whole statement warns on the \
+         effective (expanded) head: {codes:?}"
+    );
+}
+
+/// A safe command wrapped the same list-quoted-apply way must not warn —
+/// this fix widens W129's recall, it must not start flagging ordinary,
+/// allowed calls just because they are reached via `[list apply ...]`.
+#[test]
+fn safe_interp_w129_does_not_flag_safe_command_via_list_quoted_apply_1001() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "interp create -safe s\n\
+               interp eval s { after idle [list apply {x { puts $x }} val] }\n";
+    lsp.open_ready(&uri, src);
+    let codes = diagnostic_codes(&mut lsp, &uri);
+    assert!(
+        !codes.iter().any(|c| c == "W129"),
+        "a safe command (`puts`) reached via list-quoted apply must not warn: {codes:?}"
+    );
+}

--- a/rust/tcl-vm/src/interp.rs
+++ b/rust/tcl-vm/src/interp.rs
@@ -1927,6 +1927,12 @@ impl Vm {
     /// Hidden commands move to `hidden_commands`, invocable via
     /// `interp invokehidden` and restorable with `interp expose`.
     fn make_safe(&mut self) {
+        // Pinned against real tclsh 8.6.14 (`interp create -safe s; s hidden`):
+        // `after` / `vwait` are deliberately NOT on this list — confirmed
+        // present and callable inside a real safe child (`s eval {info
+        // commands after}` returns `after`). An earlier version of this list
+        // incorrectly hid them, which would have broken legitimate
+        // safe-interp code using `after idle`/`after cancel`.
         const UNSAFE: &[&str] = &[
             "exec",
             "exit",
@@ -1940,8 +1946,6 @@ impl Vm {
             "file",
             "fconfigure",
             "encoding",
-            "after",
-            "vwait",
         ];
         // The host-revealing `tcl_platform` elements (C's `Tcl_MakeSafe` unsets
         // os/osVersion/machine/user) plus our backend-introspection keys, so a

--- a/rust/tcl-vm/tests/safe_interp_e2e.rs
+++ b/rust/tcl-vm/tests/safe_interp_e2e.rs
@@ -1,0 +1,233 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Runtime enforcement of `interp create -safe` command hiding, for every
+//! indirection shape the W129 static-lint fix (issue #1001) statically
+//! flags — and a couple it deliberately does not (dynamic dispatch), which
+//! must still be rejected here since the runtime is the actual enforcement
+//! mechanism regardless of what the static lint catches.
+//!
+//! Before this file, `rust/tcl-vm` had no test at all asserting a hidden
+//! command raises `invalid command name` inside a `-safe` interpreter — its
+//! only "safe child" vector (`cross_interp_reentry_e2e.rs`,
+//! `"TP: a safe child can still call a parent-target alias"`) tests the
+//! opposite direction (an explicitly-wired alias still working). This file
+//! closes that gap.
+//!
+//! Also pins the `after`/`vwait` fix: confirmed against real tclsh 8.6.14
+//! (`interp create -safe s; s hidden` does not list either; `s eval {info
+//! commands after}` returns `after`) that a prior version of `make_safe`'s
+//! `UNSAFE` list incorrectly hid both, which would have broken legitimate
+//! safe-interp code using `after idle`/`after cancel`.
+
+use std::cell::RefCell;
+use std::io::Write;
+use std::rc::Rc;
+
+use tcl_compiler::cfg_builder::build_cfg_codegen;
+use tcl_compiler::codegen::codegen_module;
+use tcl_compiler::lowering::lower_to_ir;
+use tcl_registry::CommandRegistry;
+use tcl_vm::{CompileError, CompileService, Vm};
+
+struct CompilerSvc {
+    registry: CommandRegistry,
+}
+
+impl CompileService for CompilerSvc {
+    type Module = tcl_bytecode::ModuleAsm;
+
+    fn compile(&self, src: &str) -> Result<tcl_bytecode::ModuleAsm, CompileError> {
+        let ir = lower_to_ir(src, &self.registry);
+        let cfg = build_cfg_codegen(&ir, false);
+        Ok(codegen_module(&cfg, &ir, &self.registry))
+    }
+}
+
+#[derive(Clone, Default)]
+struct Capture(Rc<RefCell<Vec<u8>>>);
+
+impl Write for Capture {
+    fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+        self.0.borrow_mut().extend_from_slice(buf);
+        Ok(buf.len())
+    }
+    fn flush(&mut self) -> std::io::Result<()> {
+        Ok(())
+    }
+}
+
+/// Compile + run `src`; return `(ok, stdout)`, mirroring
+/// `command_resolution_conformance.rs`'s helper of the same shape.
+fn run(src: &str) -> (bool, String) {
+    let registry = CommandRegistry::build_default();
+    let ir = lower_to_ir(src, &registry);
+    let cfg = build_cfg_codegen(&ir, false);
+    let asm = codegen_module(&cfg, &ir, &registry);
+    let cap = Capture::default();
+    let mut vm = Vm::with_output(Box::new(cap.clone()));
+    vm.set_compiler(Box::new(CompilerSvc {
+        registry: CommandRegistry::build_default(),
+    }));
+    let c = vm.run_module(&asm);
+    let out = String::from_utf8_lossy(&cap.0.borrow()).trim().to_string();
+    (c.code.is_ok(), out)
+}
+
+/// TP: a hidden command called directly inside a safe child's `interp eval`
+/// body raises `invalid command name` — the direct case (no indirection).
+#[test]
+fn hidden_command_direct_call_raises_invalid_command_name() {
+    let (ok, out) = run("interp create -safe s\n\
+         set rc [catch {interp eval s { source b.tcl }} err]\n\
+         puts \"$rc $err\"\n");
+    assert!(ok, "the catch itself must not error: {out}");
+    assert!(out.starts_with("1 "), "source must fail: {out}");
+    assert!(
+        out.contains("invalid command name"),
+        "expected the C-Tcl-faithful error text: {out}"
+    );
+}
+
+/// TP: the same hidden command reached via `{*}[list source ...]` — the
+/// runtime must reject this exactly like the direct call, independent of
+/// whether the static W129 lint catches the shape.
+#[test]
+fn hidden_command_via_expand_list_quoting_raises_invalid_command_name() {
+    let (ok, out) = run("interp create -safe s\n\
+         set rc [catch {interp eval s { {*}[list source b.tcl] }} err]\n\
+         puts \"$rc $err\"\n");
+    assert!(ok, "the catch itself must not error: {out}");
+    assert!(out.starts_with("1 "), "source must fail: {out}");
+    assert!(
+        out.contains("invalid command name"),
+        "expected the C-Tcl-faithful error text: {out}"
+    );
+}
+
+/// TP: `eval` of a dynamically-built string naming a hidden command — the
+/// runtime resolves the evaluated script's command the same way it would
+/// resolve any other, so this must fail too.
+#[test]
+fn hidden_command_via_eval_of_built_string_raises_invalid_command_name() {
+    let (ok, out) = run("interp create -safe s\n\
+         set rc [catch {interp eval s { eval [list source b.tcl] }} err]\n\
+         puts \"$rc $err\"\n");
+    assert!(ok, "the catch itself must not error: {out}");
+    assert!(out.starts_with("1 "), "source must fail: {out}");
+    assert!(
+        out.contains("invalid command name"),
+        "expected the C-Tcl-faithful error text: {out}"
+    );
+}
+
+/// TP: a `namespace ensemble` `-map` redirect to a hidden command still
+/// dispatches through the same visible-table-only lookup, so it must fail
+/// too — the runtime has no ensemble-specific bypass.
+#[test]
+fn hidden_command_via_ensemble_map_redirect_raises_invalid_command_name() {
+    let (ok, out) = run("interp create -safe s\n\
+         set rc [catch {interp eval s {\n\
+             namespace eval myns { namespace ensemble create -command myens -map {go source} }\n\
+             myns::myens go b.tcl\n\
+         }} err]\n\
+         puts \"$rc $err\"\n");
+    assert!(ok, "the catch itself must not error: {out}");
+    assert!(
+        out.starts_with("1 "),
+        "the ensemble redirect must fail: {out}"
+    );
+    assert!(
+        out.contains("invalid command name"),
+        "expected the C-Tcl-faithful error text: {out}"
+    );
+}
+
+/// TN (runtime side of the rename/alias investigation from issue #1001's
+/// KCS doc): `rename` can only rename a command already in the *visible*
+/// table, so it cannot resurrect a hidden command's callability — attempting
+/// to rename an already-hidden `source` fails ("doesn't exist"), it does not
+/// silently succeed and leave the renamed target callable.
+#[test]
+fn rename_cannot_resurrect_a_hidden_command() {
+    let (ok, out) = run("interp create -safe s\n\
+         set rc [catch {interp eval s { rename source mySource }} err]\n\
+         puts \"$rc $err\"\n");
+    assert!(ok, "the catch itself must not error: {out}");
+    assert!(
+        out.starts_with("1 "),
+        "renaming an already-hidden command must fail: {out}"
+    );
+}
+
+/// Regression guard for the `after`/`vwait` fix: both stay present and
+/// callable inside a safe interpreter (confirmed against real tclsh
+/// 8.6.14 — see this file's module doc) — a prior version of `make_safe`
+/// incorrectly hid them.
+#[test]
+fn after_and_vwait_remain_callable_in_a_safe_interp() {
+    let (ok, out) = run("interp create -safe s\n\
+         set rc [catch {interp eval s { after idle {} }} err]\n\
+         puts \"$rc $err\"\n\
+         puts [interp eval s { info commands after }]\n\
+         puts [interp eval s { info commands vwait }]\n\
+         puts [expr {[lsearch [interp hidden s] after] < 0}]\n\
+         puts [expr {[lsearch [interp hidden s] vwait] < 0}]\n");
+    assert!(ok, "must not error: {out}");
+    let lines: Vec<&str> = out.lines().collect();
+    assert!(
+        lines.first().is_some_and(|l| l.starts_with("0 ")),
+        "`after idle {{}}` must succeed inside a safe interp: {out}"
+    );
+    assert_eq!(lines.get(1), Some(&"after"), "after must be visible: {out}");
+    assert_eq!(lines.get(2), Some(&"vwait"), "vwait must be visible: {out}");
+    assert_eq!(
+        lines.get(3),
+        Some(&"1"),
+        "after must not be in the hidden set: {out}"
+    );
+    assert_eq!(
+        lines.get(4),
+        Some(&"1"),
+        "vwait must not be in the hidden set: {out}"
+    );
+}
+
+/// The registry's `Traits::SAFE_INTERP_HIDDEN` set is 13 commands (`source`,
+/// `load`, `file`, `exec`, `open`, `socket`, `cd`, `pwd`, `glob`, `exit`,
+/// `fconfigure`, `encoding`, `unload` — pinned against real tclsh 8.6.14,
+/// `interp create -safe s; s hidden`). `tcl-vm` does not implement `load` /
+/// `unload` / `socket` as real commands at all (nothing to hide — calling
+/// any of the three already fails with "invalid command name" regardless of
+/// safe-interp state, for an unrelated reason — confirmed via `info
+/// commands` returning empty for each in a plain, non-safe interpreter), so
+/// only the 10 it does implement are checked here.
+#[test]
+fn safe_interp_hides_every_implemented_command_in_the_registry_set() {
+    let (ok, out) = run("interp create -safe s\n\
+         foreach c {source file exec open cd pwd glob exit fconfigure encoding} {\n\
+             puts \"$c [expr {[lsearch [interp hidden s] $c] >= 0}]\"\n\
+         }\n");
+    assert!(ok, "must not error: {out}");
+    for line in out.lines() {
+        assert!(
+            line.ends_with(" 1"),
+            "expected every listed command hidden, got: {line:?} (full: {out:?})"
+        );
+    }
+}


### PR DESCRIPTION
## Summary

- Fixes issue #1001: W129 (the Safe Base diagnostic) missed a hidden command reached through `[...]` bracket-substitution indirection — most importantly the pervasive `[list apply {...} $x]` deferred-command idiom (`package ifneeded`, `-command`, `trace add ... command`, `after idle`, `eval`, `uplevel`), a direct nested `[...]` substitution with no list-quoting, and `{*}[list HEAD ...]` as an expand-marked head. All three are now caught by `Analyser::check_indirect_hiding` and friends in `rust/tcl-compiler/src/analyser/commands.rs`, reusing the existing `Traits::BUILDS_COMMAND_PREFIX` / `ArgRole::LambdaLiteral` / `deferred_role` infrastructure from #954/#998 rather than reinventing it.
- Fixes the live LSP server's incremental analysis path (`analyse_per_item`/`DeferredBody`, backing `tcl-lsp-db`'s production query cache), which previously lost W129 entirely for any proc/apply/method body nested inside a safe interpreter — including a directly-written hidden call with no bracket indirection at all. Fixed by threading a flattened, salsa-hashable visibility snapshot (`Analyser::safe_interp_ctx_snapshot`) through `DeferredBody` and `tcl-lsp-db`'s `ItemBodyKey`.
- Fixes `namespace ensemble create`/`configure -map` redirection to a hidden command, which previously escaped W129 entirely (`configure` was silently ignored, and even `create`'s `-map` targets were never resolved at the ensemble's own call sites).
- Fixes `rust/tcl-vm` and the WASM runtime (`runtime/rust`) incorrectly hiding `after`/`vwait` in `-safe` interpreters — confirmed against real `tclsh8.6` that neither is actually hidden — and adds the first `tcl-vm` test coverage asserting hidden commands raise `invalid command name` at runtime for every indirection shape this issue enumerates (the runtime already enforced this correctly; it just had zero tests proving it).

These four gaps were surfaced during the original #1001 investigation, confirmed not already tracked as separate open issues, and folded into this same fix rather than split out, given their direct relevance to this issue's runtime-severity investigation and shared root cause.

See `docs/kcs/kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md` for the full contributor-level writeup (decision rules, failure modes, triage checklist, test anchors) and `docs/kcs/codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md` for the user-facing diagnostic note.

## Validation

- [x] `cargo fmt --all --check` — clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean, zero new `#[allow]`s
- [x] `cargo test --workspace --all-features` — all green (verified with an explicit, non-piped exit code)
- [x] `cd runtime/rust && cargo test --lib` — all green except one pre-existing, unrelated failure (`cmd_namespace::tests::dispatch_matches_every_conformance_vector`), confirmed via diff against `origin/rust` to predate and be untouched by this branch
- [x] `make xtask-check` (KCS index links, diag-tables, editor catalogs, Zed/TextMate/VS Code/JetBrains/AI generated-file drift, resolution-drift) — clean

## Compiler/KCS checklist

- [x] Did this change alter a compiler fact contract? No new diagnostic messages or severities changed — this improves W129's *recall* (it already existed), and fixes two runtime `UNSAFE`-list bugs and one LSP incremental-analysis gap.
- [x] Updated the relevant KCS notes: `docs/kcs/kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md` (contributor) and `docs/kcs/codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md` (user-facing), both linked from `docs/kcs/README.md`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Gk2bHLNa6XjFofCLUCSmsa)_