### PR TITLE
Gate deletion/rename-aware "known command" checks across W123, arity, and dynamic-dispatch passes

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,6 +331,21 @@ Analysis is file-aware where Tcl semantics demand it: in a `pkgIndex.tcl` the
 treated as already defined, so reading it is not flagged read-before-set
 (`W210`) — while the same read in an ordinary file still is.
 
+A proc, class, `rename` target, or `interp alias` that was renamed or
+deleted away (`rename NAME {}`, an `interp alias {} NAME {}` deletion) with
+no later re-establishment under the same name draws W123 wherever it's
+still called — calling it fails `invalid command name` at runtime just
+like a name that was never defined. The check is call-site and
+conditional-body aware: a call that runs before the deletion, or a
+deletion recorded inside a proc/method body that might never execute,
+does not draw the warning.
+
+```tcl
+proc helper {} { return 1 }
+rename helper {}
+proc caller {} { helper }      ;# W123: helper was deleted, never re-established
+```
+
 ### Completions
 
 Context-aware completions for commands, subcommands, variables, proc names

--- a/docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md
+++ b/docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md
@@ -31,6 +31,21 @@ unknownCmd $arg
 
 The analyser reports **`W123`** on `unknownCmd`.
 
+A proc, class, `rename` target, or `interp alias` that was renamed or
+deleted away, with no later re-establishment under the same name, is also
+unresolved — calling it fails `invalid command name` at runtime just like
+a name that was never defined:
+
+```tcl
+proc helper {} { return 1 }
+rename helper {}
+proc caller {} { helper }
+```
+
+The analyser reports **`W123`** on `helper` inside `caller`. Defining a
+fresh `helper` (or `rename`-ing a different command to that name) after
+the deletion re-establishes it and clears the warning.
+
 ## What does not trigger it
 
 A built-in `expr` math function (`sin`, `max`, `abs`, …) called with

--- a/editors/vscode/src/test/issue945.test.ts
+++ b/editors/vscode/src/test/issue945.test.ts
@@ -78,11 +78,75 @@ suite("Issue #945 resolution model", () => {
       new vscode.Position(0, 5),
     )) as vscode.Location[];
 
-    const lines = (locations ?? []).map((l) => l.range.start.line);
+    // Same-document hits only: a sibling fixture left open by an earlier
+    // test in this suite (`issue945ConstDispatch.tcl`) shares this file's
+    // `target`/`$cmd` shape but without the deletion, and legitimately
+    // surfaces its own live references under cross-document search — those
+    // must not be mistaken for this fixture's dead dispatch.
+    const lines = (locations ?? [])
+      .filter((l) => l.uri.toString() === docUri.toString())
+      .map((l) => l.range.start.line);
     assert.ok(
       !lines.includes(2) && !lines.includes(3),
       `a proc deleted with no re-establishment must draw no reference from ` +
         `the dead $cmd dispatch ("set cmd target" / "$cmd"): ${JSON.stringify(lines)}`,
+    );
+  });
+
+  // Codex PR #1014 review follow-up — two confirmed false positives found
+  // in review after the #1009/#1006/#973 fixes landed. Both confirmed
+  // against tclsh 8.6.14; deep TP/FP/TN coverage lives in the analyser and
+  // native e2e suites (see `fact_live_for_call` / `finalise_invocation_resolutions`
+  // unit tests and `rust/tcl-lsp-server/tests/e2e/issue945.rs`); these
+  // prove the fixes reach a real VS Code session.
+
+  test("body call before a later deletion draws no W123 (Codex review)", async () => {
+    const docUri = getDocUri("issue1009CodexBodyCallBeforeDeletion.tcl");
+    await activate(docUri);
+
+    // `caller`'s own top-level invocation (line 2) runs before `rename
+    // helper {}` (line 3), so the `helper` call inside its body must not
+    // draw W123 — confirmed against tclsh 8.6.14 (the script runs to
+    // completion).
+    const diags = vscode.languages.getDiagnostics(docUri);
+    assert.ok(
+      !diags.some((d) => String(d.code) === "W123"),
+      `a body call before a later deletion must not draw W123: ${JSON.stringify(diags.map((d) => d.code))}`,
+    );
+  });
+
+  test("namespaced local call before a later deletion is a reference to the local definition (Codex review)", async () => {
+    const docUri = getDocUri("issue1009CodexLocalCallBeforeDeletion.tcl");
+    await activate(docUri);
+
+    // `foo::caller`'s own top-level invocation (line 5) runs before
+    // `rename foo::bar {}` (line 6), so the `bar` call inside its body
+    // must reference the local `::foo::bar` (line 2 — `bar` at col 9),
+    // not the global `bar` (line 0 — `bar` at col 5).
+    const localRefs = ((await vscode.commands.executeCommand(
+      "vscode.executeReferenceProvider",
+      docUri,
+      new vscode.Position(2, 9),
+    )) ?? []) as vscode.Location[];
+    const localLines = localRefs
+      .filter((l) => l.uri.toString() === docUri.toString())
+      .map((l) => l.range.start.line);
+    assert.ok(
+      localLines.includes(3),
+      `the call before the deletion must reference the local definition: ${JSON.stringify(localLines)}`,
+    );
+
+    const globalRefs = ((await vscode.commands.executeCommand(
+      "vscode.executeReferenceProvider",
+      docUri,
+      new vscode.Position(0, 5),
+    )) ?? []) as vscode.Location[];
+    const globalLines = globalRefs
+      .filter((l) => l.uri.toString() === docUri.toString())
+      .map((l) => l.range.start.line);
+    assert.ok(
+      !globalLines.includes(3),
+      `the call must not also reference the global definition: ${JSON.stringify(globalLines)}`,
     );
   });
 

--- a/editors/vscode/src/test/issue945.test.ts
+++ b/editors/vscode/src/test/issue945.test.ts
@@ -61,6 +61,31 @@ suite("Issue #945 resolution model", () => {
     );
   });
 
+  // Issue #1009: the const-`$cmd` dispatch settlement resolved through a
+  // proc renamed/deleted away with no later re-establishment, the same
+  // root cause #973/#1006/#1007 fixed for bareword calls. Deep TP/FP/TN
+  // coverage lives in the analyser and native e2e suites (see
+  // rust/tcl-lsp-server/tests/e2e/issue945.rs); this proves the fix
+  // reaches a real VS Code session.
+  test("const-dispatch draws no reference to a proc deleted with no re-establishment", async () => {
+    const docUri = getDocUri("issue1009ConstDispatchDeleted.tcl");
+    await activate(docUri);
+
+    // `target` declaration name at line 0, col 5.
+    const locations = (await vscode.commands.executeCommand(
+      "vscode.executeReferenceProvider",
+      docUri,
+      new vscode.Position(0, 5),
+    )) as vscode.Location[];
+
+    const lines = (locations ?? []).map((l) => l.range.start.line);
+    assert.ok(
+      !lines.includes(2) && !lines.includes(3),
+      `a proc deleted with no re-establishment must draw no reference from ` +
+        `the dead $cmd dispatch ("set cmd target" / "$cmd"): ${JSON.stringify(lines)}`,
+    );
+  });
+
   test("externally unexported TclOO method does not resolve; dispatch entry does", async () => {
     const docUri = getDocUri("issue945Tcloo.tcl");
     await activate(docUri);

--- a/editors/vscode/src/test/precisionReview.test.ts
+++ b/editors/vscode/src/test/precisionReview.test.ts
@@ -48,19 +48,27 @@ function withCode(diags: vscode.Diagnostic[], code: string): vscode.Diagnostic[]
 suite("Diagnostics precision review", () => {
   const docUri = getDocUri("precisionReview.tcl");
 
-  test("rename target is known; vacated name draws W128", async () => {
+  test("rename target is known; vacated name draws both W128 and W123", async () => {
     await activate(docUri);
     const diags = await waitForDiagnostics(docUri, {
       predicate: (d) => d.some((x) => codeOf(x) === "W128"),
     });
-    assert.strictEqual(
-      withCode(diags, "W123").length,
-      0,
+    // `ua2` (line 5) is the rename target — must not be an unknown command.
+    assert.ok(
+      !withCode(diags, "W123").some((d) => d.range.start.line === 5),
       "the rename target `ua2` must not be an unknown command",
     );
+    // `user_args` (line 6) is the vacated source name — issue #973 (confirmed
+    // against tclsh 8.6.14): it fails "invalid command name" just like any
+    // other unresolved command, so it draws the generic W123 alongside the
+    // specific "renamed or deleted" W128 hint.
     const w128 = withCode(diags, "W128");
     assert.strictEqual(w128.length, 1, "the vacated `user_args` draws exactly one W128");
     assert.strictEqual(w128[0].range.start.line, 6);
+    assert.ok(
+      withCode(diags, "W123").some((d) => d.range.start.line === 6),
+      "the vacated `user_args` now also draws W123 (issue #973)",
+    );
   });
 
   test("W210 range is tight on the nested $missing read", async () => {

--- a/editors/vscode/testFixture/issue1009CodexBodyCallBeforeDeletion.tcl
+++ b/editors/vscode/testFixture/issue1009CodexBodyCallBeforeDeletion.tcl
@@ -1,0 +1,4 @@
+proc helper {} {}
+proc caller {} { helper }
+caller
+rename helper {}

--- a/editors/vscode/testFixture/issue1009CodexLocalCallBeforeDeletion.tcl
+++ b/editors/vscode/testFixture/issue1009CodexLocalCallBeforeDeletion.tcl
@@ -1,0 +1,7 @@
+proc bar {} { return global }
+namespace eval foo {
+    proc bar {} { return local }
+    proc caller {} { return [bar] }
+}
+foo::caller
+rename foo::bar {}

--- a/editors/vscode/testFixture/issue1009ConstDispatchDeleted.tcl
+++ b/editors/vscode/testFixture/issue1009ConstDispatchDeleted.tcl
@@ -1,0 +1,4 @@
+proc target {} { return hi }
+rename target {}
+set cmd target
+$cmd

--- a/rust/tcl-compiler/src/analyser/diagnostics/const_dispatch.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/const_dispatch.rs
@@ -49,7 +49,6 @@ use std::collections::HashMap;
 use std::collections::HashSet;
 
 use crate::analyser::state::{Analyser, ConstDispatchSite};
-use crate::analyser::types::AnalysisResult;
 use crate::signature_scan::types::SignatureCommandInvocation;
 use crate::value_provenance::{ValueContributor, const_contributors};
 
@@ -90,7 +89,7 @@ fn command_component(c: &ValueContributor, head_expanded: bool) -> Option<ValueC
 fn settle_one_site(
     cu: &crate::compilation_unit::CompilationUnit,
     site: &ConstDispatchSite,
-    result: &AnalysisResult,
+    analyser: &Analyser,
     builtins: &HashSet<String>,
     renamed_away: &HashSet<&String>,
     settled: &mut Vec<SignatureCommandInvocation>,
@@ -108,19 +107,36 @@ fn settle_one_site(
     let Some(contributors) = const_contributors(fu, site.span.start(), &site.var_name) else {
         return;
     };
+    let result = &analyser.result;
+    let call_off = site.span.start();
+    // A candidate qualified name is "user-defined" only when its own fact
+    // — the proc/class definition, or the establishing `interp alias` /
+    // `rename` — is still live at this dispatch site: renamed away or
+    // deleted with no later re-establishment no longer denotes a real
+    // command (issue #1009, the same question `unresolved.rs`'s W123
+    // pass already answers for ordinary bareword calls via
+    // `fact_live_for_call`, reused here rather than reimplemented).
+    let user_defined =
+        |qualified: &str| {
+            result.all_procs.get(qualified).is_some_and(|p| {
+                analyser.fact_live_for_call(qualified, p.name_span.start(), call_off)
+            }) || result.all_classes.get(qualified).is_some_and(|c| {
+                analyser.fact_live_for_call(qualified, c.name_span.start(), call_off)
+            }) || (result.command_aliases.contains_key(qualified)
+                && analyser
+                    .alias_offsets
+                    .get(qualified)
+                    .is_some_and(|&off| analyser.fact_live_for_call(qualified, off, call_off)))
+                || (analyser.renamed_commands.contains_key(qualified)
+                    && analyser
+                        .rename_offsets
+                        .get(qualified)
+                        .is_some_and(|&off| analyser.fact_live_for_call(qualified, off, call_off)))
+        };
     let known = |qualified: &str| {
-        result.all_procs.contains_key(qualified)
-            || result.all_classes.contains_key(qualified)
-            || result.command_aliases.contains_key(qualified)
-            || result.renamed_commands.contains_key(qualified)
+        user_defined(qualified)
             || (builtins.contains(qualified.trim_start_matches(':'))
                 && !renamed_away.contains(&qualified.to_string()))
-    };
-    let user_defined = |qualified: &str| {
-        result.all_procs.contains_key(qualified)
-            || result.all_classes.contains_key(qualified)
-            || result.command_aliases.contains_key(qualified)
-            || result.renamed_commands.contains_key(qualified)
     };
     let path: &[String] = result
         .namespace_paths
@@ -228,14 +244,7 @@ impl Analyser {
 
         let mut settled: Vec<SignatureCommandInvocation> = Vec::new();
         for site in &sites {
-            settle_one_site(
-                cu,
-                site,
-                &self.result,
-                builtins,
-                &renamed_away,
-                &mut settled,
-            );
+            settle_one_site(cu, site, self, builtins, &renamed_away, &mut settled);
         }
         // A literal feeding several dispatch sites (or several sites
         // resolving the same head) settles once per distinct

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -10554,3 +10554,63 @@ fn w123_fp_issue_1006_rename_target_deletion_inside_never_triggered_body_resolve
     let src = "proc helper {} { return 1 }\nrename helper ha2\nproc maybeDelete {} { rename ha2 {} }\nproc caller {} { ha2 }\n";
     assert_eq!(w123_codes(src), Vec::<String>::new());
 }
+
+// `fact_live_for_call`'s body-call escape hatch, Codex PR #1014 review
+// comment #2 (`unresolved.rs:260`): a call *inside* a proc/class body
+// carries no execution-order meaning from its own textual position — it
+// was wrongly treated as automatically after every top-level deletion, so
+// a body call whose enclosing definition demonstrably ran before a later
+// deletion still drew a spurious W123. Confirmed against tclsh 8.6.14
+// throughout.
+
+#[test]
+fn w123_fp_issue_1009_codex_review_body_call_before_later_deletion_resolves() {
+    // FP guard (the confirmed regression): `caller`'s own top-level
+    // invocation runs before `rename helper {}`, so the `helper` call
+    // inside its body must still resolve — confirmed against tclsh 8.6.14
+    // (the script prints "ok" and exits 0).
+    let src = "proc helper {} {}\nproc caller {} { helper }\ncaller\nrename helper {}\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_tp_issue_1009_codex_review_deleted_before_definition_still_flags() {
+    // TP regression: `helper` is deleted *before* `caller` is even
+    // defined, with no re-establishment — the body call must still draw
+    // W123 (confirmed against tclsh 8.6.14: `invalid command name
+    // "helper"`).
+    let src = "proc helper {} {}\nrename helper {}\nproc caller {} { helper }\ncaller\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_string()]);
+}
+
+#[test]
+fn w123_tp_issue_1009_codex_review_deleted_between_definition_and_call_still_flags() {
+    // TP regression: `helper` is deleted *after* `caller` is defined but
+    // *before* `caller` is ever invoked — the body call must still draw
+    // W123 (confirmed against tclsh 8.6.14: `invalid command name
+    // "helper"`, even though `caller`'s own definition predates the
+    // deletion).
+    let src = "proc helper {} {}\nproc caller {} { helper }\nrename helper {}\ncaller\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_string()]);
+}
+
+#[test]
+fn w123_fp_issue_1009_codex_review_method_body_call_before_later_deletion_resolves() {
+    // FP guard, TclOO variant: a method body call before a later
+    // unconditional deletion of the command it calls must also resolve —
+    // confirmed against tclsh 8.6.14 (the script prints "ok" and exits 0).
+    let src = "proc helper {} { return hi }\noo::class create Widget {\n    method run {} { helper }\n}\nWidget create w1\nw1 run\nrename helper {}\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_tp_issue_1009_codex_review_escape_hatch_requires_specific_enclosing_call() {
+    // FN guard: an unrelated proc's top-level invocation must not "lend"
+    // liveness to a different, never-invoked enclosing definition — only
+    // `unrelated` is called at the top level before the deletion, `caller`
+    // itself never is, so the `helper` call inside `caller`'s body must
+    // still draw W123 (the same base shape the original #973 fix already
+    // covers when there is no competing top-level call at all).
+    let src = "proc helper {} {}\nproc caller {} { helper }\nproc unrelated {} { return 1 }\nunrelated\nrename helper {}\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_string()]);
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -10268,3 +10268,37 @@ fn vendor_command_inherited_options_resolve_cleanly() {
         "inherited expect options must resolve under expect, got {codes:?}"
     );
 }
+
+// Issue #1006 — the W123 alias / rename-target checks used file-end-only
+// gating (`fact_live_at_file_end`, no call site or conditional-body
+// awareness), unlike the proc/class checks #973 already made call-site-
+// and conditional-aware (`fact_live_for_call`). Fixed by replacing the
+// plain `alias_names` / `rename_target_names` tail `HashSet`s'
+// contribution to resolution with `alias_defs_by_tail` /
+// `rename_defs_by_tail` (mirroring `proc_defs_by_tail` /
+// `class_defs_by_tail`), checked per call site the same way. All cases
+// confirmed against tclsh 8.6.14.
+
+#[test]
+fn w123_fp_issue_1006_alias_call_before_later_deletion_resolves() {
+    let src = "proc target {} { return 1 }\ninterp alias {} short {} target\nshort\ninterp alias {} short {}\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_fp_issue_1006_alias_deletion_inside_never_triggered_body_resolves() {
+    let src = "proc target {} { return 1 }\ninterp alias {} short {} target\nproc maybeDelete {} { interp alias {} short {} }\nproc caller {} { short }\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_fp_issue_1006_rename_target_call_before_later_deletion_resolves() {
+    let src = "proc helper {} { return 1 }\nrename helper ha2\nha2\nrename ha2 {}\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_fp_issue_1006_rename_target_deletion_inside_never_triggered_body_resolves() {
+    let src = "proc helper {} { return 1 }\nrename helper ha2\nproc maybeDelete {} { rename ha2 {} }\nproc caller {} { ha2 }\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5189,6 +5189,56 @@ fn analyse_w308_emitted_for_unknown_method_on_known_class_constructor() {
     );
 }
 
+// Issue #1010 (site 4) — `emit_cmd_command_diagnostics`'s constructor
+// recognition (`[Cls new] method`) typed the result as `Object(Cls)`
+// even when `Cls` was renamed or deleted away with no later
+// re-establishment, producing a misleading "unknown method" W308 that
+// implies `Cls` exists. Confirmed against tclsh 8.6.14 that the
+// constructor call itself fails "invalid command name" first — fixed so
+// the dispatch instead falls back to the conservative "non-literal,
+// cannot statically analyze" (W307), with W123 on `Cls` itself as the
+// real, primary diagnostic.
+//
+// `harvest_constructor_object_types` (the `set x [Cls new]` variable-
+// assignment sibling of this same check) is fixed the same way, but a
+// deeper, independent source in `type_infer.rs`'s `constructor_object_type`
+// still separately types `x` as `Object(Cls)` for that shape via the SSA
+// type lattice, so `$x method` there still draws the same misleading
+// W308 — tracked as a follow-up (that fix needs a call-site offset
+// threaded into a foundational, flow-insensitive type-inference helper,
+// a larger and riskier change than this session's other gate-only fixes).
+
+#[test]
+fn w308_tp_issue_1010_deleted_class_constructor_falls_back_to_w307() {
+    let src =
+        "oo::class create Dog { method bark {} { return woof } }\nrename Dog {}\n[Dog new] fly";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    let codes: HashSet<String> = r.diagnostics.iter().map(|d| d.code.to_string()).collect();
+    assert!(
+        !codes.contains("W308"),
+        "a deleted class must not draw the misleading 'unknown method' W308; got {codes:?}"
+    );
+    assert!(
+        codes.contains("W123"),
+        "the deleted class itself must draw W123 as the real diagnostic; got {codes:?}"
+    );
+}
+
+#[test]
+fn w308_fp_issue_1010_reestablished_class_constructor_still_flags_unknown_method() {
+    let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog {}\noo::class create Dog { method bark {} { return woof } }\n[Dog new] fly";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "a class re-established after deletion must still resolve its constructor normally; got {:?}",
+        r.diagnostics,
+    );
+}
+
 /// Object-`of` constructor typing — the W307/W308 item.  Each
 /// case asserts the exact set of expected diagnostic codes.
 fn w30x_codes(src: &str) -> Vec<String> {
@@ -6190,6 +6240,37 @@ foo$suffix
     assert!(
         !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
         "W123 should be suppressed when partial interpolation resolves to a known proc; got {:?}",
+        r.diagnostics,
+    );
+}
+
+// Issue #1010 (site 1) — `resolve_interpolated_w123_diagnostics` deleted an
+// already-correct W123 for an interpolated command head (`foo$suffix`)
+// once SCCP folded it to a known-but-dead proc name, with no deletion
+// gate at all. Fixed by reusing `fact_live_for_call` per candidate.
+// Confirmed against tclsh 8.6.14.
+
+#[test]
+fn w123_tp_issue_1010_interpolated_head_folds_to_deleted_proc_stays_flagged() {
+    let src = "proc foo_hi {} {}\nrename foo_hi {}\nset suffix _hi\nfoo$suffix\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "an interpolated head folding to a deleted proc must still draw W123; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_fp_issue_1010_interpolated_head_folds_to_reestablished_proc_resolves() {
+    let src =
+        "proc foo_hi {} {}\nrename foo_hi {}\nproc foo_hi {} {}\nset suffix _hi\nfoo$suffix\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W123),
+        "a proc re-established after deletion must still resolve; got {:?}",
         r.diagnostics,
     );
 }
@@ -7432,6 +7513,38 @@ fn analyse_no_w307_for_static_known_command() {
     assert!(
         w307s.is_empty(),
         "W307 must be suppressed when var holds known command name; got {:?}",
+        r.diagnostics,
+    );
+}
+
+// Issue #1010 (site 2) — `is_known_command` (used by `w307_site_suppressed`)
+// suppressed W307 whenever SCCP proved a dynamic-dispatch value equalled
+// a proc/class name, with no deletion gate — so a variable holding a
+// renamed-or-deleted-away command (no later re-establishment) still
+// silenced the real "invalid command name" hazard. Fixed by threading
+// the dispatch site's own offset through and reusing `fact_live_for_call`.
+// Confirmed against tclsh 8.6.14.
+
+#[test]
+fn w307_tp_issue_1010_dispatch_value_is_deleted_proc_stays_flagged() {
+    let src = "proc target {} {}\nrename target {}\nproc foo {} { set cmd target\n$cmd hello }";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics.iter().any(|d| d.code == DiagCode::W307),
+        "a dispatch value equalling a deleted proc must still draw W307; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w307_fp_issue_1010_dispatch_value_is_reestablished_proc_resolves() {
+    let src = "proc target {} {}\nrename target {}\nproc target {} {}\nproc foo {} { set cmd target\n$cmd hello }";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W307),
+        "a proc re-established after deletion must still suppress W307; got {:?}",
         r.diagnostics,
     );
 }
@@ -9706,6 +9819,45 @@ fn dispatch_table_value_abstains_when_the_table_is_not_consumed_m7() {
     assert!(
         !r.command_invocations.iter().any(|i| i.name == "do_add"),
         "{:?}",
+        r.command_invocations
+            .iter()
+            .map(|i| (&i.name, i.range.start()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+// Issue #1010 (site 3) — `emit_dispatch_table_command_references`'s
+// `known` closure synthesized a "live reference" for a dispatch-table
+// literal even when the proc/class it named was renamed or deleted away
+// with no later re-establishment. Fixed by reusing `fact_live_for_call`
+// with the table entry's own position as the call site. Confirmed
+// against tclsh 8.6.14.
+
+#[test]
+fn dispatch_table_tp_issue_1010_deleted_proc_draws_no_reference() {
+    let src = "proc do_add {a b} {}\nrename do_add {}\narray set ops {add do_add}\nset k add\n$ops($k) 1 2\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        !r.command_invocations.iter().any(|i| i.name == "do_add"),
+        "a deleted proc with no re-establishment must draw no reference: {:?}",
+        r.command_invocations
+            .iter()
+            .map(|i| (&i.name, i.range.start()))
+            .collect::<Vec<_>>(),
+    );
+}
+
+#[test]
+fn dispatch_table_fp_issue_1010_reestablished_proc_still_references() {
+    let src = "proc do_add {a b} {}\nrename do_add {}\nproc do_add {a b} {}\narray set ops {add do_add}\nset k add\n$ops($k) 1 2\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.command_invocations
+            .iter()
+            .any(|i| i.name == "do_add" && i.resolved_qualified_name.as_deref() == Some("::do_add")),
+        "a proc re-established after deletion must still be referenced: {:?}",
         r.command_invocations
             .iter()
             .map(|i| (&i.name, i.range.start()))

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -9248,6 +9248,106 @@ fn colon_named_proc_resolves_from_bare_calls_not_written_runs() {
 
 // -- M7: command names carried in variables / dispatch tables ------------
 
+// Issue #1009 — the constant-`$cmd` dispatch settlement's `known` /
+// `user_defined` closures resolved through a proc/class/alias/rename
+// target that was renamed or deleted away, with no later
+// re-establishment, exactly like the pre-#973 bug in `scope.rs`. Fixed
+// by reusing `fact_live_for_call` (widened to `pub(super)` so this
+// sibling pass can call it) with the dispatch site's own offset as the
+// call site. Confirmed this never caused a W123 false negative (the
+// pass runs after W123 already fired), but did poison the
+// `resolved_qualified_name` these invocations carry for hover /
+// go-to-definition / find-references / rename-tracking. All cases
+// confirmed against tclsh 8.6.14 (deletion semantics are identical
+// whether a command is invoked literally or via a variable).
+
+fn const_dispatch_target(src: &str) -> Option<(String, Option<String>)> {
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    let dispatch = u32::try_from(src.rfind("$cmd").unwrap()).unwrap();
+    r.command_invocations
+        .into_iter()
+        .find(|i| i.range.start() == dispatch && i.indirect)
+        .map(|i| (i.name, i.resolved_qualified_name))
+}
+
+#[test]
+fn const_dispatch_tp_issue_1009_proc_deleted_no_reestablishment_does_not_resolve() {
+    let src = "proc target {} {}\nrename target {}\nset cmd target\n$cmd\n";
+    assert_eq!(
+        const_dispatch_target(src),
+        None,
+        "a $cmd dispatch to a deleted proc with no re-establishment must not resolve"
+    );
+}
+
+#[test]
+fn const_dispatch_fp_issue_1009_proc_reestablished_after_deletion_resolves() {
+    let src = "proc target {} {}\nrename target {}\nproc target {} {}\nset cmd target\n$cmd\n";
+    assert_eq!(
+        const_dispatch_target(src),
+        Some(("target".to_owned(), Some("::target".to_owned())))
+    );
+}
+
+#[test]
+fn const_dispatch_tn_issue_1009_proc_no_deletion_still_resolves() {
+    let src = "proc target {} {}\nset cmd target\n$cmd\n";
+    assert_eq!(
+        const_dispatch_target(src),
+        Some(("target".to_owned(), Some("::target".to_owned())))
+    );
+}
+
+#[test]
+fn const_dispatch_tp_issue_1009_class_deleted_no_reestablishment_does_not_resolve() {
+    let src = "oo::class create Target\nrename Target {}\nset cmd Target\n$cmd\n";
+    assert_eq!(const_dispatch_target(src), None);
+}
+
+#[test]
+fn const_dispatch_tp_issue_1009_rename_target_deleted_no_reestablishment_does_not_resolve() {
+    let src = "proc helper {} {}\nrename helper ha2\nrename ha2 {}\nset cmd ha2\n$cmd\n";
+    assert_eq!(const_dispatch_target(src), None);
+}
+
+#[test]
+fn const_dispatch_fp_issue_1009_rename_target_no_deletion_still_resolves() {
+    let src = "proc helper {} {}\nrename helper ha2\nset cmd ha2\n$cmd\n";
+    assert_eq!(
+        const_dispatch_target(src),
+        Some(("ha2".to_owned(), Some("::ha2".to_owned())))
+    );
+}
+
+#[test]
+fn const_dispatch_tp_issue_1009_alias_deleted_no_reestablishment_does_not_resolve() {
+    let src = "proc target {} {}\ninterp alias {} short {} target\ninterp alias {} short {}\nset cmd short\n$cmd\n";
+    assert_eq!(const_dispatch_target(src), None);
+}
+
+#[test]
+fn const_dispatch_fp_issue_1009_alias_no_deletion_still_resolves() {
+    let src = "proc target {} {}\ninterp alias {} short {} target\nset cmd short\n$cmd\n";
+    assert_eq!(
+        const_dispatch_target(src),
+        Some(("short".to_owned(), Some("::short".to_owned())))
+    );
+}
+
+#[test]
+fn const_dispatch_fp_issue_1009_deletion_inside_never_triggered_body_still_resolves() {
+    // Same conditional-body guard #1006/#1007 already apply — a deletion
+    // recorded inside a proc that's never called must not disqualify the
+    // dispatch (tclsh: calling nothing that invokes `maybeDelete` leaves
+    // `target` live).
+    let src = "proc target {} {}\nproc maybeDelete {} { rename target {} }\nset cmd target\n$cmd\n";
+    assert_eq!(
+        const_dispatch_target(src),
+        Some(("target".to_owned(), Some("::target".to_owned())))
+    );
+}
+
 #[test]
 fn const_cmd_head_records_a_reference_to_the_dispatched_proc_m7() {
     let mut a = Analyser::new();

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -10081,6 +10081,131 @@ fn w004_later_version_options_never_leak_into_supersets() {
     }
 }
 
+// Issue #973 — a proc / class / rename / alias target that was renamed or
+// deleted away, with no later re-establishment under the same name, must
+// not still read as "known" for W123: calling it fails "invalid command
+// name" in real Tcl. `finalise_invocation_resolutions`'s `known` predicate
+// (scope.rs) and `build_w123_known_names` (unresolved.rs — the pass that
+// actually decides W123) both gated deletion only for registry builtins /
+// aliases / rename targets, never for user procs or classes themselves.
+//
+// Fixed by extending the same "was this fact re-established after its
+// last deletion" question the arity resolver's `fact_superseded_by_deletion`
+// already answers for E002/E003 (see
+// `same_file_rename_reestablished_after_deletion_checks_new_arity` above)
+// to the proc/class checks here — `fact_live_for_call` in unresolved.rs —
+// with the same call-site + conditional-body awareness
+// `qualified_name_deleted_before` already gives registry builtins: a
+// deletion recorded inside a proc/class/method body is conditional (it
+// executes only if that body is ever invoked) and a top-level call
+// textually before a later deletion still resolves. All cases below
+// confirmed against tclsh 8.6.14.
+fn w123_codes(src: &str) -> Vec<String> {
+    let mut a = Analyser::new();
+    a.analyse(src, "tcl8.6")
+        .diagnostics
+        .into_iter()
+        .filter(|d| d.code == DiagCode::W123)
+        .map(|d| d.code.to_string())
+        .collect()
+}
+
+#[test]
+fn w123_fp_issue_973_proc_call_before_rename_resolves() {
+    let src = "proc helper {} { return 1 }\nproc caller {} { helper }\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_tp_issue_973_proc_deleted_via_rename_no_reestablishment() {
+    // The exact shape from issue #973's repro.
+    let src = "\
+namespace eval ::a {
+    proc helper {} { return 1 }
+}
+rename ::a::helper {}
+namespace eval ::a {
+    proc caller {} { helper }
+}
+";
+    assert_eq!(w123_codes(src), vec!["W123".to_owned()]);
+}
+
+#[test]
+fn w123_fp_issue_973_proc_reestablished_after_deletion_resolves() {
+    let src = "proc helper {} { return 1 }\nrename helper {}\nproc helper {} { return 2 }\nproc caller {} { helper }\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_tp_issue_973_class_deleted_via_rename_no_reestablishment() {
+    let src = "oo::class create Helper\nrename Helper {}\nproc caller {} { Helper new }\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_owned()]);
+}
+
+#[test]
+fn w123_fp_issue_973_class_call_before_rename_resolves() {
+    let src = "oo::class create Helper\nproc caller {} { Helper new }\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_fp_issue_973_class_reestablished_after_deletion_resolves() {
+    let src = "oo::class create Helper\nrename Helper {}\noo::class create Helper\nproc caller {} { Helper new }\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_tp_issue_973_interp_alias_deleted_no_reestablishment() {
+    let src = "proc target {} {}\ninterp alias {} short {} target\ninterp alias {} short {}\nproc caller {} { short }\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_owned()]);
+}
+
+#[test]
+fn w123_fp_issue_973_interp_alias_call_before_deletion_resolves() {
+    let src = "proc target {} {}\ninterp alias {} short {} target\nproc caller {} { short }\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_fp_issue_973_interp_alias_reestablished_after_deletion_resolves() {
+    let src = "\
+proc target {} {}
+proc target2 {} {}
+interp alias {} short {} target
+interp alias {} short {}
+interp alias {} short {} target2
+proc caller {} { short }
+";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_tp_issue_973_rename_to_new_name_call_to_old_name_stays_unknown() {
+    // A rename that *moves* the name (not a deletion) leaves the old name
+    // permanently gone — must stay unknown, same as before this fix.
+    let src = "proc helper {} { return 1 }\nrename helper newhelper\nproc caller {} { helper }\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_owned()]);
+}
+
+#[test]
+fn w123_fp_issue_973_top_level_call_before_later_proc_deletion_resolves() {
+    // A top-level call textually before a *later* same-file deletion still
+    // resolves — order matters at top level (tclsh: `proc helper {} {};
+    // helper; rename helper {}` succeeds).
+    let src = "proc helper {} { return 1 }\nhelper\nrename helper {}\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_fp_issue_973_deletion_inside_never_triggered_proc_body_resolves() {
+    // A `rename` recorded inside a proc body that's never called is
+    // conditional — it never executes, so the name stays live (tclsh:
+    // calling `caller` without ever calling `maybeDelete` succeeds).
+    let src = "proc helper {} { return 1 }\nproc maybeDelete {} { rename helper {} }\nproc caller {} { helper }\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
 #[test]
 fn vendor_command_inherited_options_resolve_cleanly() {
     // expect_after's options inherit the command's EXPECT gate — under the

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -2238,6 +2238,57 @@ fn same_file_rename_reestablished_after_deletion_checks_new_arity() {
     );
 }
 
+// Issue #1007 — a `rename` / `interp alias` deletion recorded *inside* a
+// proc body that's never called is conditional: it may never execute, so
+// it must not supersede a fact established outside that body.
+// `fact_superseded_by_deletion` previously reused `fact_in_effect`
+// (call-site order-gating) to also decide whether the *deletion itself*
+// was in effect, which only asks whether the call is order-gated against
+// its own top-level/body status — never whether the deletion's own
+// offset sits inside a different, possibly-never-invoked body. Fixed by
+// adding the same `offset_is_inside_any_definition_body` guard the W123
+// pass's `fact_live_for_call` already applies for the identical question
+// (issue #973). All cases confirmed against tclsh 8.6.14.
+
+#[test]
+fn e003_fp_issue_1007_conditional_deletion_never_triggered_proc_stays_live() {
+    let src = "proc target {a b} {}\nproc maybeDelete {} { rename target {} }\ntarget 1 2\n";
+    assert_eq!(arity_codes(src, "tcl8.6"), Vec::<String>::new());
+}
+
+#[test]
+fn e003_tp_issue_1007_conditional_deletion_never_triggered_still_checks_arity() {
+    // `maybeDelete` is never called, so `target` keeps its original 2-arg
+    // signature — an over-applied call must still fire E003, not
+    // silently abstain as if the name were permanently gone.
+    let src = "proc target {a b} {}\nproc maybeDelete {} { rename target {} }\ntarget 1 2 3\n";
+    assert_eq!(arity_codes(src, "tcl8.6"), vec!["E003".to_owned()]);
+}
+
+#[test]
+fn e003_tn_issue_1007_unconditional_deletion_before_call_stays_dead() {
+    // Regression guard: an *unconditional* (top-level) deletion must
+    // still permanently kill the name — the fix only exempts deletions
+    // recorded inside a body.
+    let src = "proc target {a b} {}\nrename target {}\ntarget 1 2\n";
+    assert_eq!(arity_codes(src, "tcl8.6"), Vec::<String>::new());
+}
+
+#[test]
+fn e003_tp_issue_1007_call_before_later_unconditional_deletion_still_checked() {
+    // Regression guard: the already-correct call-site order gating for a
+    // top-level, unconditional deletion is untouched by this fix.
+    let src = "proc target {a b} {}\ntarget 1 2 3\nrename target {}\n";
+    assert_eq!(arity_codes(src, "tcl8.6"), vec!["E003".to_owned()]);
+}
+
+#[test]
+fn e003_tp_issue_1007_alias_conditional_deletion_never_triggered_still_checks_arity() {
+    // Same fix, `interp alias` deletion form.
+    let src = "proc target {a b} {}\ninterp alias {} short {} target\nproc maybeDelete {} { interp alias {} short {} }\nshort 1 2 3\n";
+    assert_eq!(arity_codes(src, "tcl8.6"), vec!["E003".to_owned()]);
+}
+
 #[test]
 fn same_file_rename_target_reestablished_after_further_rename_checks_new_arity() {
     // `rename target target_orig` moves `target`'s identity onward (like

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -50,8 +50,13 @@ struct W123KnownNames {
     proc_defs_by_tail: HashMap<String, Vec<(String, u32)>>,
     /// [`Self::proc_defs_by_tail`]'s twin for classes.
     class_defs_by_tail: HashMap<String, Vec<(String, u32)>>,
-    alias_names: HashSet<String>,
-    rename_target_names: HashSet<String>,
+    /// [`Self::proc_defs_by_tail`]'s twin for `interp alias` targets
+    /// (issue #1006 — previously a plain tail `HashSet`, checked only at
+    /// file-end granularity via `fact_live_at_file_end`).
+    alias_defs_by_tail: HashMap<String, Vec<(String, u32)>>,
+    /// [`Self::proc_defs_by_tail`]'s twin for static `rename OLD NEW`
+    /// targets (issue #1006, same history as `alias_defs_by_tail`).
+    rename_defs_by_tail: HashMap<String, Vec<(String, u32)>>,
     ensemble_cmds: HashSet<String>,
     stub_names: HashSet<String>,
     /// Final `::`-segment of each literal (non-conjectured) `namespace
@@ -339,26 +344,33 @@ impl Analyser {
                 .iter()
                 .map(|(qn, def)| (qn, def.name_span.start())),
         );
-        // An alias whose most recent action (by offset) in the file is a
-        // deletion (`interp alias {} name {}`) is no longer a callable
-        // command — `command_aliases` itself is never pruned on deletion
-        // (a later re-declaration of the same name must still win, and this
-        // whole-file set has no per-call-site position to gate against), so
-        // `live_tail_names` checks `deleted_commands` directly. This
-        // mirrors the same-file arity resolver's `fact_in_effect`
-        // convention for deleted aliases, just at file-end granularity
-        // rather than per call site.
+        // These two tail sets feed only the "did you mean…?" candidate list
+        // below (same convention as `proc_tail_names` / `class_tail_names`
+        // above) — resolution itself uses `alias_defs_by_tail` /
+        // `rename_defs_by_tail` (built further down), issue #1006.
         let alias_names =
             self.live_tail_names(self.result.command_aliases.keys(), &self.alias_offsets);
-        // A static `rename OLD NEW` binds `NEW` to whatever `OLD` denoted —
-        // `NEW` is a callable command from the rename onward, so calls to it
-        // must not draw W123 (the same-file arity resolver already validates
-        // them against `OLD`'s signature via `renamed_commands`). Deletion is
-        // order-gated exactly like `alias_names` above: a `NEW` whose most
-        // recent action in the file is a deletion (`rename NEW {}`, or `NEW`
-        // renamed away again) is no longer callable at file end.
         let rename_target_names =
             self.live_tail_names(self.renamed_commands.keys(), &self.rename_offsets);
+        // Grouped by tail, unfiltered by deletion — same per-call live
+        // check as `proc_defs_by_tail` / `class_defs_by_tail` (issue
+        // #1006: an alias/rename-target call textually before a later
+        // deletion, or a deletion recorded inside a never-triggered
+        // proc/class body, must still resolve; previously these two were
+        // plain tail `HashSet`s checked only via `fact_live_at_file_end`
+        // — file-end granularity, no call site or conditional-body
+        // awareness).
+        let alias_defs_by_tail = group_defs_by_tail(
+            self.result
+                .command_aliases
+                .keys()
+                .filter_map(|qn| self.alias_offsets.get(qn).map(|&off| (qn, off))),
+        );
+        let rename_defs_by_tail = group_defs_by_tail(
+            self.renamed_commands
+                .keys()
+                .filter_map(|qn| self.rename_offsets.get(qn).map(|&off| (qn, off))),
+        );
         let ensemble_cmds: HashSet<String> = self
             .ensemble_namespaces
             .iter()
@@ -412,8 +424,8 @@ impl Analyser {
             registry_names,
             proc_defs_by_tail,
             class_defs_by_tail,
-            alias_names,
-            rename_target_names,
+            alias_defs_by_tail,
+            rename_defs_by_tail,
             ensemble_cmds,
             stub_names,
             import_pattern_tails,
@@ -572,11 +584,12 @@ impl Analyser {
         }
         // A tail may match several qualified names (the same simple name
         // in different namespaces) — resolve if *any* of them has a fact
-        // still live for this specific call (issue #973: a proc/class
-        // renamed or deleted away, with no later re-establishment, must
-        // not resolve here; `fact_live_for_call` also keeps a top-level
-        // call textually before a later deletion, and a deletion recorded
-        // inside a never-triggered proc/class body, correctly resolving).
+        // still live for this specific call (issue #973 for procs/classes,
+        // issue #1006 for aliases/rename targets: a name renamed or
+        // deleted away, with no later re-establishment, must not resolve
+        // here; `fact_live_for_call` also keeps a top-level call textually
+        // before a later deletion, and a deletion recorded inside a
+        // never-triggered proc/class body, correctly resolving).
         let tail_has_live_def = |defs_by_tail: &HashMap<String, Vec<(String, u32)>>| {
             defs_by_tail.get(name).is_some_and(|defs| {
                 defs.iter().any(|(qualified, fact_off)| {
@@ -586,8 +599,8 @@ impl Analyser {
         };
         if tail_has_live_def(&known.proc_defs_by_tail)
             || tail_has_live_def(&known.class_defs_by_tail)
-            || known.alias_names.contains(name)
-            || known.rename_target_names.contains(name)
+            || tail_has_live_def(&known.alias_defs_by_tail)
+            || tail_has_live_def(&known.rename_defs_by_tail)
             || known.ensemble_cmds.contains(name)
             || known.stub_names.contains(name)
         {

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -232,7 +232,12 @@ impl Analyser {
     ///   running every top-level statement, including the deletion —
     ///   before any body ever runs) and, for a top-level call, only once
     ///   the call's own textual position is after it.
-    fn fact_live_for_call(&self, qualified: &str, fact_off: u32, call_off: u32) -> bool {
+    ///
+    /// `pub(super)` (not private) so sibling passes over the same
+    /// `command_invocations` question — `const_dispatch.rs`'s constant-
+    /// `$cmd` settlement (issue #1009) — reuse this rather than
+    /// reimplementing it.
+    pub(super) fn fact_live_for_call(&self, qualified: &str, fact_off: u32, call_off: u32) -> bool {
         let Some(&del_off) = self.deleted_commands.get(qualified) else {
             return true;
         };

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -247,6 +247,22 @@ impl Analyser {
     /// `command_invocations` question — `const_dispatch.rs`'s constant-
     /// `$cmd` settlement (issue #1009) — reuse this rather than
     /// reimplementing it.
+    ///
+    /// A call *inside* a body carries no execution-order meaning from its
+    /// own textual position — it runs whenever the enclosing definition is
+    /// invoked, not when its text was written — so a call there falls back
+    /// to a narrower, still-sound question: does [`Self::top_level_call_offsets`]
+    /// record a *top-level* invocation of the innermost enclosing
+    /// definition ([`super::super::types::AnalysisResult::enclosing_definition_qualified_name`])
+    /// that provably ran before the deletion? If so, that invocation's own
+    /// nested calls already resolved (issue #1009 Codex review: `proc
+    /// helper {}`, `proc caller {} { helper }`, `caller`, `rename helper
+    /// {}` resolves in real Tcl — confirmed against tclsh 8.6.14 — because
+    /// `caller`'s own top-level call runs before the rename). Absent such
+    /// proof (the enclosing definition is never called at the top level in
+    /// this file, or only after the deletion), the existing conservative
+    /// default holds: an unconditional top-level deletion is in effect for
+    /// every call inside any body.
     pub(super) fn fact_live_for_call(&self, qualified: &str, fact_off: u32, call_off: u32) -> bool {
         let Some(&del_off) = self.deleted_commands.get(qualified) else {
             return true;
@@ -257,7 +273,13 @@ impl Analyser {
         if self.offset_is_inside_definition_body(del_off) {
             return true;
         }
-        !self.offset_is_inside_definition_body(call_off) && call_off <= del_off
+        if !self.offset_is_inside_definition_body(call_off) {
+            return call_off <= del_off;
+        }
+        self.result
+            .enclosing_definition_qualified_name(call_off)
+            .and_then(|qn| self.top_level_call_offsets.get(qn))
+            .is_some_and(|&t| t < del_off)
     }
 
     /// The tail set for a "known command" map whose own fact is still

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -69,11 +69,15 @@ struct W123KnownNames {
 
 /// Group `(qualified_name, establishing_offset)` pairs by their
 /// `::`-tail — shared by the proc and class def maps in
-/// [`Analyser::build_w123_known_names`] (issue #973): a tail may match
-/// several qualified names (the same simple name in different
-/// namespaces), each kept with its own offset for a later per-call live
-/// check ([`Analyser::fact_live_for_call`]).
-fn group_defs_by_tail<'a>(
+/// [`Analyser::build_w123_known_names`] (issue #973) and its siblings
+/// (`var_command.rs`'s `build_w307_known_names` / interpolated-W123
+/// resolution, issue #1010): a tail may match several qualified names
+/// (the same simple name in different namespaces), each kept with its
+/// own offset for a later per-call live check
+/// ([`Analyser::fact_live_for_call`]). `pub(super)` (not private) so
+/// those sibling passes reuse it rather than reimplementing the same
+/// grouping loop.
+pub(super) fn group_defs_by_tail<'a>(
     entries: impl Iterator<Item = (&'a String, u32)>,
 ) -> HashMap<String, Vec<(String, u32)>> {
     let mut map: HashMap<String, Vec<(String, u32)>> = HashMap::new();
@@ -203,7 +207,13 @@ impl Analyser {
     /// statements in source order — is always the most recent one, so a
     /// name re-established after its deletion (a fresh `rename` or
     /// `interp alias` under the same name) reads as live again.
-    fn fact_live_at_file_end(&self, qualified: &str, fact_off: u32) -> bool {
+    ///
+    /// `pub(super)`: also reused by `var_command.rs`'s
+    /// `compute_factory_object_ranges` (issue #1010), whose
+    /// `is_object_returning_head` predicate classifies a bare command
+    /// head with no specific call site in hand — the same file-end
+    /// question, not [`Self::fact_live_for_call`]'s per-call one.
+    pub(super) fn fact_live_at_file_end(&self, qualified: &str, fact_off: u32) -> bool {
         self.deleted_commands
             .get(qualified)
             .is_none_or(|&del_off| fact_off > del_off)

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -42,8 +42,14 @@ use crate::analyser::types::Severity;
 /// the deduplicated candidate list for "did you mean…?" suggestions.
 struct W123KnownNames {
     registry_names: HashSet<String>,
-    proc_tail_names: HashSet<String>,
-    class_tail_names: HashSet<String>,
+    /// Per-tail proc definitions (qualified name, establishing offset) —
+    /// a tail may match several qualified names (same simple name in
+    /// different namespaces), each with its own deletion history, so
+    /// resolution checks every one for a call-site-specific live match
+    /// (issue #973) rather than a plain tail-membership test.
+    proc_defs_by_tail: HashMap<String, Vec<(String, u32)>>,
+    /// [`Self::proc_defs_by_tail`]'s twin for classes.
+    class_defs_by_tail: HashMap<String, Vec<(String, u32)>>,
     alias_names: HashSet<String>,
     rename_target_names: HashSet<String>,
     ensemble_cmds: HashSet<String>,
@@ -54,6 +60,28 @@ struct W123KnownNames {
     /// call matching one of these resolves to the imported command.
     import_pattern_tails: Vec<String>,
     candidates: Vec<String>,
+}
+
+/// Group `(qualified_name, establishing_offset)` pairs by their
+/// `::`-tail — shared by the proc and class def maps in
+/// [`Analyser::build_w123_known_names`] (issue #973): a tail may match
+/// several qualified names (the same simple name in different
+/// namespaces), each kept with its own offset for a later per-call live
+/// check ([`Analyser::fact_live_for_call`]).
+fn group_defs_by_tail<'a>(
+    entries: impl Iterator<Item = (&'a String, u32)>,
+) -> HashMap<String, Vec<(String, u32)>> {
+    let mut map: HashMap<String, Vec<(String, u32)>> = HashMap::new();
+    for (qn, off) in entries {
+        if let Some((_, tail)) = qn.rsplit_once("::")
+            && !tail.is_empty()
+        {
+            map.entry(tail.to_string())
+                .or_default()
+                .push((qn.clone(), off));
+        }
+    }
+    map
 }
 
 impl Analyser {
@@ -150,6 +178,89 @@ impl Analyser {
         self.emit_w123_for_invocations(&known, emit_w123);
     }
 
+    /// Whether `qualified`'s establishing fact — an `interp alias`
+    /// (`alias_offsets`) or a `rename` target (`rename_offsets`), recorded
+    /// at `fact_off` — is still live at file end: no `rename NAME {}` /
+    /// `interp alias {} NAME {}` deletion of `qualified` itself has a
+    /// *later* offset recorded in `deleted_commands` (issue #973: a
+    /// rename/alias target that was later renamed away must not still
+    /// count as known — calling it fails "invalid command name" in real
+    /// Tcl, confirmed against tclsh 8.6.14).
+    ///
+    /// File-end granularity, not per-call-site — the alias / rename
+    /// candidate sets this feeds have no call site to gate against, unlike
+    /// [`Self::qualified_name_deleted_before`] (registry builtins) or
+    /// [`Self::fact_live_for_call`] (procs / classes, which — unlike an
+    /// alias or rename target — can have namesakes across namespaces, so
+    /// resolution needs the specific qualified name each call resolves
+    /// against, not just a bare tail). `deleted_commands` holds only the
+    /// last-seen deletion offset per name, which — since the walk visits
+    /// statements in source order — is always the most recent one, so a
+    /// name re-established after its deletion (a fresh `rename` or
+    /// `interp alias` under the same name) reads as live again.
+    fn fact_live_at_file_end(&self, qualified: &str, fact_off: u32) -> bool {
+        self.deleted_commands
+            .get(qualified)
+            .is_none_or(|&del_off| fact_off > del_off)
+    }
+
+    /// Whether `qualified`'s establishing fact — recorded at `fact_off` —
+    /// is still in effect for a call at `call_off`. Unlike
+    /// [`Self::fact_live_at_file_end`] (used for aliases / rename targets,
+    /// whose candidate sets have no call site to gate against), a proc or
+    /// class *definition* has one real fact per qualified name that a
+    /// specific call resolves against, so this additionally applies the
+    /// same call-site + conditional-body awareness
+    /// [`Self::qualified_name_deleted_before`] already gives registry
+    /// builtins (issue #973's "conditional deletion never triggered" and
+    /// "call textually before a later deletion" cases — confirmed against
+    /// tclsh 8.6.14 that both still resolve):
+    ///
+    /// - No recorded deletion, or the fact was re-established *after* the
+    ///   last one (`fact_off` postdates `del_off`) — live.
+    /// - A deletion recorded inside a proc/class/method body is
+    ///   conditional — it executes only if that body is ever invoked,
+    ///   which the textual load-order gate can't know — so it never
+    ///   disqualifies.
+    /// - Otherwise the deletion is unconditional (top level) and in
+    ///   effect for every call inside *any* body (the whole file loads —
+    ///   running every top-level statement, including the deletion —
+    ///   before any body ever runs) and, for a top-level call, only once
+    ///   the call's own textual position is after it.
+    fn fact_live_for_call(&self, qualified: &str, fact_off: u32, call_off: u32) -> bool {
+        let Some(&del_off) = self.deleted_commands.get(qualified) else {
+            return true;
+        };
+        if del_off <= fact_off {
+            return true;
+        }
+        if self.offset_is_inside_definition_body(del_off) {
+            return true;
+        }
+        !self.offset_is_inside_definition_body(call_off) && call_off <= del_off
+    }
+
+    /// The tail set for a "known command" map whose own fact is still
+    /// live at file end — shared by `alias_names` and
+    /// `rename_target_names` in [`Self::build_w123_known_names`] (both
+    /// ask the identical [`Self::fact_live_at_file_end`] question, just
+    /// against a different qualified-name / establishing-offset map).
+    fn live_tail_names<'a>(
+        &self,
+        names: impl Iterator<Item = &'a String>,
+        offsets: &HashMap<String, u32>,
+    ) -> HashSet<String> {
+        names
+            .filter(|qn| {
+                offsets
+                    .get(qn.as_str())
+                    .is_some_and(|&off| self.fact_live_at_file_end(qn, off))
+            })
+            .filter_map(|qn| qn.rsplit_once("::").map(|(_, t)| t.to_string()))
+            .filter(|s| !s.is_empty())
+            .collect()
+    }
+
     /// Build the [`W123KnownNames`] sets consulted by the unresolved-command
     /// pass: registry names enabled in the active dialect, user proc / class /
     /// alias / ensemble simple-name tails, inline-stub names, and the
@@ -185,40 +296,60 @@ impl Analyser {
         // suppression set so users who declared a stub for a
         // command don't get spurious W123s.
         let stub_names: HashSet<String> = super::utils::scan_stub_command_names(&self.source);
+        // These two tail sets feed only the "did you mean…?" candidate
+        // list below — resolution itself uses `proc_defs_by_tail` /
+        // `class_defs_by_tail` (built further down), which check each
+        // matching qualified name's own deletion history per call site
+        // (`fact_live_for_call`). Filtering by `fact_live_at_file_end`
+        // here keeps a proc/class with no live definition anywhere in the
+        // file (deleted, never re-established) from being suggested as a
+        // fix for an unrelated typo.
         let proc_tail_names: HashSet<String> = self
             .result
             .all_procs
-            .keys()
-            .filter_map(|qn| qn.rsplit_once("::").map(|(_, t)| t.to_string()))
+            .iter()
+            .filter(|(qn, def)| self.fact_live_at_file_end(qn, def.name_span.start()))
+            .filter_map(|(qn, _)| qn.rsplit_once("::").map(|(_, t)| t.to_string()))
             .filter(|s| !s.is_empty())
             .collect();
         let class_tail_names: HashSet<String> = self
             .result
             .all_classes
-            .keys()
-            .filter_map(|qn| qn.rsplit_once("::").map(|(_, t)| t.to_string()))
+            .iter()
+            .filter(|(qn, def)| self.fact_live_at_file_end(qn, def.name_span.start()))
+            .filter_map(|(qn, _)| qn.rsplit_once("::").map(|(_, t)| t.to_string()))
             .filter(|s| !s.is_empty())
             .collect();
+        // Grouped by tail (unfiltered by deletion — the per-call live check
+        // in `w123_invocation_resolves` does that, since a top-level call
+        // textually before a later deletion, or a deletion recorded inside
+        // a never-triggered proc/class body, must still resolve; see
+        // `fact_live_for_call`). A tail may match several qualified names
+        // (the same simple name in different namespaces), each tracked
+        // with its own establishing offset.
+        let proc_defs_by_tail = group_defs_by_tail(
+            self.result
+                .all_procs
+                .iter()
+                .map(|(qn, def)| (qn, def.name_span.start())),
+        );
+        let class_defs_by_tail = group_defs_by_tail(
+            self.result
+                .all_classes
+                .iter()
+                .map(|(qn, def)| (qn, def.name_span.start())),
+        );
         // An alias whose most recent action (by offset) in the file is a
         // deletion (`interp alias {} name {}`) is no longer a callable
         // command — `command_aliases` itself is never pruned on deletion
         // (a later re-declaration of the same name must still win, and this
         // whole-file set has no per-call-site position to gate against), so
-        // check `deleted_commands` here directly. This mirrors the same-file
-        // arity resolver's `fact_in_effect` convention for deleted aliases,
-        // just at file-end granularity rather than per call site.
-        let alias_names: HashSet<String> = self
-            .result
-            .command_aliases
-            .keys()
-            .filter(|qn| {
-                self.deleted_commands
-                    .get(qn.as_str())
-                    .is_none_or(|&del_off| self.alias_offsets.get(qn.as_str()) > Some(&del_off))
-            })
-            .filter_map(|qn| qn.rsplit_once("::").map(|(_, t)| t.to_string()))
-            .filter(|s| !s.is_empty())
-            .collect();
+        // `live_tail_names` checks `deleted_commands` directly. This
+        // mirrors the same-file arity resolver's `fact_in_effect`
+        // convention for deleted aliases, just at file-end granularity
+        // rather than per call site.
+        let alias_names =
+            self.live_tail_names(self.result.command_aliases.keys(), &self.alias_offsets);
         // A static `rename OLD NEW` binds `NEW` to whatever `OLD` denoted —
         // `NEW` is a callable command from the rename onward, so calls to it
         // must not draw W123 (the same-file arity resolver already validates
@@ -226,17 +357,8 @@ impl Analyser {
         // order-gated exactly like `alias_names` above: a `NEW` whose most
         // recent action in the file is a deletion (`rename NEW {}`, or `NEW`
         // renamed away again) is no longer callable at file end.
-        let rename_target_names: HashSet<String> = self
-            .renamed_commands
-            .keys()
-            .filter(|qn| {
-                self.deleted_commands
-                    .get(qn.as_str())
-                    .is_none_or(|&del_off| self.rename_offsets.get(qn.as_str()) > Some(&del_off))
-            })
-            .filter_map(|qn| qn.rsplit_once("::").map(|(_, t)| t.to_string()))
-            .filter(|s| !s.is_empty())
-            .collect();
+        let rename_target_names =
+            self.live_tail_names(self.renamed_commands.keys(), &self.rename_offsets);
         let ensemble_cmds: HashSet<String> = self
             .ensemble_namespaces
             .iter()
@@ -288,8 +410,8 @@ impl Analyser {
 
         W123KnownNames {
             registry_names,
-            proc_tail_names,
-            class_tail_names,
+            proc_defs_by_tail,
+            class_defs_by_tail,
             alias_names,
             rename_target_names,
             ensemble_cmds,
@@ -448,8 +570,22 @@ impl Analyser {
         if name.contains("::") || name.starts_with('$') || name.starts_with('[') {
             return true;
         }
-        if known.proc_tail_names.contains(name)
-            || known.class_tail_names.contains(name)
+        // A tail may match several qualified names (the same simple name
+        // in different namespaces) — resolve if *any* of them has a fact
+        // still live for this specific call (issue #973: a proc/class
+        // renamed or deleted away, with no later re-establishment, must
+        // not resolve here; `fact_live_for_call` also keeps a top-level
+        // call textually before a later deletion, and a deletion recorded
+        // inside a never-triggered proc/class body, correctly resolving).
+        let tail_has_live_def = |defs_by_tail: &HashMap<String, Vec<(String, u32)>>| {
+            defs_by_tail.get(name).is_some_and(|defs| {
+                defs.iter().any(|(qualified, fact_off)| {
+                    self.fact_live_for_call(qualified, *fact_off, range.start())
+                })
+            })
+        };
+        if tail_has_live_def(&known.proc_defs_by_tail)
+            || tail_has_live_def(&known.class_defs_by_tail)
             || known.alias_names.contains(name)
             || known.rename_target_names.contains(name)
             || known.ensemble_cmds.contains(name)
@@ -479,10 +615,16 @@ impl Analyser {
             return true;
         }
         // Absolute-form fallback — ``cmd`` may be defined as ``::cmd`` in
-        // the global namespace.
-        if self.result.all_procs.contains_key(&format!("::{name}"))
-            || self.result.all_classes.contains_key(&format!("::{name}"))
-        {
+        // the global namespace. Same per-call deletion gate as the
+        // proc/class tail check above (issue #973): a `::cmd` renamed or
+        // deleted away, with no later re-establishment, must not resolve
+        // here either.
+        let absolute = format!("::{name}");
+        if self.result.all_procs.get(&absolute).is_some_and(|def| {
+            self.fact_live_for_call(&absolute, def.name_span.start(), range.start())
+        }) || self.result.all_classes.get(&absolute).is_some_and(|def| {
+            self.fact_live_for_call(&absolute, def.name_span.start(), range.start())
+        }) {
             return true;
         }
         // A command bound by `CLASS create NAME` (or a registry

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -1840,15 +1840,28 @@ impl Analyser {
     /// (confirmed against tclsh 9.0.4: `proc p {} {}`, `rename p {}`,
     /// `proc p {a b} {}`, `p 1 2` succeeds — the second `proc` overrides
     /// the deletion).
+    ///
+    /// A deletion recorded *inside* a proc/class/method body is itself
+    /// conditional — it executes only if and when that body is ever
+    /// invoked, which the textual load-order gate can't know — so it
+    /// never supersedes anything (issue #1007: confirmed against tclsh
+    /// 8.6.14 that `proc p {a b} {}`, `proc maybeDelete {} { rename p {}
+    /// }`, `p 1 2 3` still fails "wrong # args" against `p`'s original
+    /// 2-arg signature, since `maybeDelete` is never called and the
+    /// `rename` never runs). Mirrors the equivalent guard
+    /// [`Self::fact_live_for_call`] applies for the same question in the
+    /// W123 pass (see issue #973).
     fn fact_superseded_by_deletion(
         &self,
         name: &str,
         fact_off: u32,
         cand: &PendingUserCallArity,
     ) -> bool {
-        self.deleted_commands
-            .get(name)
-            .is_some_and(|&del_off| del_off > fact_off && Self::fact_in_effect(cand, del_off))
+        self.deleted_commands.get(name).is_some_and(|&del_off| {
+            del_off > fact_off
+                && !self.result.offset_is_inside_any_definition_body(del_off)
+                && Self::fact_in_effect(cand, del_off)
+        })
     }
 
     /// Chase `cand.cmd_name` (as it resolves at `cand.ns`) through

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -45,9 +45,16 @@ use crate::analyser::types::Severity;
 /// and class simple-name tails.
 struct W307KnownNames {
     cmds: HashSet<String>,
-    procs: HashSet<String>,
-    proc_bare: HashSet<String>,
-    class_tails: HashSet<String>,
+    /// Qualified proc name → establishing offset (issue #1010: was a
+    /// plain `HashSet`; the offset lets `is_known_command` check each
+    /// candidate is still live — not renamed/deleted away with no later
+    /// re-establishment — at the dispatch site via `fact_live_for_call`).
+    procs: HashMap<String, u32>,
+    /// Bare tail → `(qualified_name, establishing_offset)` pairs — a tail
+    /// may match several qualified procs across namespaces.
+    proc_by_tail: HashMap<String, Vec<(String, u32)>>,
+    /// [`Self::proc_by_tail`]'s twin for classes.
+    class_by_tail: HashMap<String, Vec<(String, u32)>>,
 }
 
 /// All the borrowed analysis data the W307 per-site suppression decision
@@ -130,7 +137,10 @@ impl Analyser {
         for fu in units {
             for block in fu.cfg.blocks.values() {
                 for stmt in &block.statements {
-                    let Statement::AssignValue { name, value, .. } = stmt else {
+                    let Statement::AssignValue {
+                        name, value, span, ..
+                    } = stmt
+                    else {
                         continue;
                     };
                     let Some((head, args)) =
@@ -141,9 +151,13 @@ impl Analyser {
                     if !args.first().is_some_and(|s| s == "new" || s == "create") {
                         continue;
                     }
+                    // The constructor call must still be live at this
+                    // assignment — a dead class fails the call, so `x`
+                    // is never assigned an object (issue #1010).
                     let class_qn = self.canonicalise_class_name(&head);
-                    if self.result.all_classes.contains_key(&class_qn)
-                        || self.result.all_classes.contains_key(&head)
+                    let off = span.start();
+                    if self.class_live_for_call(&class_qn, off)
+                        || self.class_live_for_call(&head, off)
                     {
                         out.entry(name.clone()).or_default().insert(class_qn);
                     }
@@ -546,36 +560,70 @@ impl Analyser {
     /// qualified names + their simple-name tails, and class simple-name tails.
     fn build_w307_known_names(&self, registry: &tcl_registry::CommandRegistry) -> W307KnownNames {
         let cmds: HashSet<String> = registry.command_names().map(str::to_string).collect();
-        let procs: HashSet<String> = self.result.all_procs.keys().cloned().collect();
-        let proc_bare: HashSet<String> = procs
-            .iter()
-            .filter_map(|qn| qn.rsplit_once("::").map(|(_, tail)| tail.to_string()))
-            .filter(|s| !s.is_empty())
-            .collect();
-        let class_tails: HashSet<String> = self
+        let procs: HashMap<String, u32> = self
             .result
-            .all_classes
-            .keys()
-            .filter_map(|qn| qn.rsplit_once("::").map(|(_, tail)| tail.to_string()))
-            .filter(|s| !s.is_empty())
+            .all_procs
+            .iter()
+            .map(|(qn, def)| (qn.clone(), def.name_span.start()))
             .collect();
+        let proc_by_tail = super::unresolved::group_defs_by_tail(
+            self.result
+                .all_procs
+                .iter()
+                .map(|(qn, def)| (qn, def.name_span.start())),
+        );
+        let class_by_tail = super::unresolved::group_defs_by_tail(
+            self.result
+                .all_classes
+                .iter()
+                .map(|(qn, def)| (qn, def.name_span.start())),
+        );
         W307KnownNames {
             cmds,
             procs,
-            proc_bare,
-            class_tails,
+            proc_by_tail,
+            class_by_tail,
         }
     }
 
-    /// True when `v` resolves to a known command: a registry name, a user proc
-    /// (bare / `::`-qualified / tail), or a class command.
-    fn is_known_command(&self, known: &W307KnownNames, v: &str) -> bool {
+    /// Whether `qualified` names a class that is still live at `call_off`
+    /// — shared by the constructor-recognition sites (`[Cls new]` direct
+    /// calls and `set x [Cls new]` variable assignments alike), which
+    /// otherwise duplicate the identical `all_classes.get(...).is_some_and(...)`
+    /// call three times over (issue #1010).
+    fn class_live_for_call(&self, qualified: &str, call_off: u32) -> bool {
+        self.result
+            .all_classes
+            .get(qualified)
+            .is_some_and(|c| self.fact_live_for_call(qualified, c.name_span.start(), call_off))
+    }
+
+    /// True when `v` resolves to a known, *live* command at `call_off`: a
+    /// registry name, a user proc (bare / `::`-qualified / tail), or a
+    /// class command. A proc/class renamed or deleted away with no later
+    /// re-establishment does not count (issue #1010: this used to
+    /// wrongly suppress W307 on a dead dynamic-dispatch value —
+    /// confirmed against tclsh 8.6.14 that calling it still fails
+    /// "invalid command name" — reusing `fact_live_for_call` rather than
+    /// a third re-derivation of the same question).
+    fn is_known_command(&self, known: &W307KnownNames, v: &str, call_off: u32) -> bool {
+        let live_at = |qualified: &str, off: u32| self.fact_live_for_call(qualified, off, call_off);
+        let by_tail_live = |defs_by_tail: &HashMap<String, Vec<(String, u32)>>| {
+            defs_by_tail
+                .get(v)
+                .is_some_and(|defs| defs.iter().any(|(qn, off)| live_at(qn, *off)))
+        };
+        let global = format!("::{v}");
         known.cmds.contains(v)
-            || known.procs.contains(v)
-            || known.proc_bare.contains(v)
-            || known.procs.contains(&format!("::{v}"))
-            || known.class_tails.contains(v)
-            || self.result.all_classes.contains_key(&format!("::{v}"))
+            || known.procs.get(v).is_some_and(|&off| live_at(v, off))
+            || by_tail_live(&known.proc_by_tail)
+            || known.procs.get(&global).is_some_and(|&off| live_at(&global, off))
+            || by_tail_live(&known.class_by_tail)
+            || self
+                .result
+                .all_classes
+                .get(&global)
+                .is_some_and(|c| live_at(&global, c.name_span.start()))
             // A command bound by `CLASS create NAME` (issue #777).
             || self.result.created_instance_commands.contains(v)
     }
@@ -606,10 +654,13 @@ impl Analyser {
         let effective = precise
             .as_ref()
             .or_else(|| ctx.all_constsets.get(&site.var_name));
+        let call_off = site.cmd_span.start();
         // SCCP concrete evidence the value IS a known command — suppress.
-        if effective
-            .is_some_and(|v| !v.is_empty() && v.iter().all(|x| self.is_known_command(ctx.known, x)))
-        {
+        if effective.is_some_and(|v| {
+            !v.is_empty()
+                && v.iter()
+                    .all(|x| self.is_known_command(ctx.known, x, call_off))
+        }) {
             return true;
         }
         // SCCP concrete evidence the value is NOT a command: every feasible
@@ -618,7 +669,9 @@ impl Analyser {
         // proc-param / multi-dispatch) must not silence the real "invalid
         // command name" hazard (FP-OBJ-09 / FP-OBJ-D4-F5).
         let sccp_not_command = effective.is_some_and(|v| {
-            !v.is_empty() && v.iter().all(|x| !self.is_known_command(ctx.known, x))
+            !v.is_empty()
+                && v.iter()
+                    .all(|x| !self.is_known_command(ctx.known, x, call_off))
         });
         // ``in_method`` short-circuits W307 because OO methods routinely use
         // ``$obj method`` patterns — unless SCCP proves a non-command value.
@@ -656,17 +709,16 @@ impl Analyser {
             && !values.is_empty()
             && values
                 .iter()
-                .all(|v| self.is_known_command(ctx.known, &format!("{v}::{tail}")))
+                .all(|v| self.is_known_command(ctx.known, &format!("{v}::{tail}"), call_off))
         {
             return true;
         }
         // Object-factory provenance: `$var` holds a factory result in this scope
         // — a designed object handle, so the dispatch is not a static error.
-        let off = site.cmd_span.start();
         if ctx
             .factory_object_ranges
             .iter()
-            .any(|(s, e, names)| *s <= off && off <= *e && names.contains(&site.var_name))
+            .any(|(s, e, names)| *s <= call_off && call_off <= *e && names.contains(&site.var_name))
         {
             return true;
         }
@@ -675,7 +727,7 @@ impl Analyser {
         if ctx
             .snit_var_ranges
             .iter()
-            .any(|(s, e, vars)| *s <= off && off <= *e && vars.contains(&site.var_name))
+            .any(|(s, e, vars)| *s <= call_off && call_off <= *e && vars.contains(&site.var_name))
         {
             return true;
         }
@@ -697,12 +749,21 @@ impl Analyser {
         cu: &crate::compilation_unit::CompilationUnit,
         registry: &tcl_registry::CommandRegistry,
     ) -> Vec<(u32, u32, HashSet<String>)> {
-        let class_qnames: HashSet<&String> = self.result.all_classes.keys().collect();
-        let class_tails: HashSet<&str> = class_qnames
-            .iter()
-            .filter_map(|qn| qn.rsplit_once("::").map(|(_, t)| t))
-            .filter(|t| !t.is_empty())
-            .collect();
+        // Grouped by tail (unfiltered by deletion — `is_object_returning_head`
+        // below does that, file-end granularity: this predicate classifies
+        // a bare head with no specific call site in hand, unlike
+        // `w307_site_suppressed`'s per-site checks). A class renamed or
+        // deleted away with no later re-establishment can't actually
+        // produce an object, so a `set x [ClassName new]` where
+        // `ClassName` is dead must not mark `x` a factory local (issue
+        // #1010, confirmed against tclsh 8.6.14 that the constructor call
+        // itself fails "invalid command name" first).
+        let class_by_tail = super::unresolved::group_defs_by_tail(
+            self.result
+                .all_classes
+                .iter()
+                .map(|(qn, def)| (qn, def.name_span.start())),
+        );
         let is_user_proc = |head: &str| {
             self.result.all_procs.contains_key(head)
                 || self.result.all_procs.contains_key(&format!("::{head}"))
@@ -710,7 +771,19 @@ impl Analyser {
         // A command head whose value-returning invocation yields an object
         // handle (excluding user procs, which the fixpoint classifies).
         let is_object_returning_head = |head: &str| -> bool {
-            if class_tails.contains(head) || class_qnames.contains(&format!("::{head}")) {
+            if class_by_tail.get(head).is_some_and(|defs| {
+                defs.iter()
+                    .any(|(qn, off)| self.fact_live_at_file_end(qn, *off))
+            }) {
+                return true;
+            }
+            let global = format!("::{head}");
+            if self
+                .result
+                .all_classes
+                .get(&global)
+                .is_some_and(|c| self.fact_live_at_file_end(&global, c.name_span.start()))
+            {
                 return true;
             }
             if head.contains("::") {
@@ -1067,8 +1140,10 @@ impl Analyser {
             // explicitly here — ``known_class new/create`` maps to
             // ``TclType.OBJECT`` with the class name attached.
             let class_qn = self.canonicalise_class_name(head);
-            let head_is_known_class = self.result.all_classes.contains_key(&class_qn)
-                || self.result.all_classes.contains_key(head);
+            // Renamed/deleted with no re-establishment fails the call (issue #1010).
+            let off = site.cmd_span.start();
+            let head_is_known_class =
+                self.class_live_for_call(&class_qn, off) || self.class_live_for_call(head, off);
             let is_constructor_call = head_is_known_class
                 && arg_strs
                     .first()
@@ -1263,10 +1338,6 @@ impl Analyser {
         if harvested.is_empty() {
             return;
         }
-        let known = |qualified: &str| {
-            self.result.all_procs.contains_key(qualified)
-                || self.result.all_classes.contains_key(qualified)
-        };
         let mut seen_spans: HashSet<(u32, u32)> = self
             .result
             .command_invocations
@@ -1285,6 +1356,19 @@ impl Analyser {
                 &self.result.global_scope,
                 span.start(),
             );
+            // A candidate must still be *live* at this dispatch-table
+            // entry's own position — renamed or deleted away with no
+            // later re-establishment must not synthesize a phantom
+            // reference (issue #1010, same question `unresolved.rs`'s
+            // W123 pass already answers via `fact_live_for_call`, reused
+            // here rather than reimplemented).
+            let known = |qualified: &str| {
+                self.result.all_procs.get(qualified).is_some_and(|p| {
+                    self.fact_live_for_call(qualified, p.name_span.start(), span.start())
+                }) || self.result.all_classes.get(qualified).is_some_and(|c| {
+                    self.fact_live_for_call(qualified, c.name_span.start(), span.start())
+                })
+            };
             let Some(winner) =
                 crate::naming::resolve_command_with::<&str, _>(&ns, &[], &value, known)
             else {
@@ -1441,13 +1525,25 @@ impl Analyser {
         // emitter used to skip suggestions in the first pass.
         let registry = tcl_registry::CommandRegistry::build_default();
         let known_cmds: HashSet<String> = registry.command_names().map(str::to_string).collect();
-        let known_proc_tails: HashSet<String> = self
-            .result
-            .all_procs
-            .keys()
-            .filter_map(|qn| qn.rsplit_once("::").map(|(_, t)| t.to_string()))
-            .filter(|s| !s.is_empty())
-            .collect();
+        // Grouped by tail (unfiltered by deletion — the per-diagnostic live
+        // check below does that): a tail may match several qualified
+        // procs, each tracked with its own establishing offset so a
+        // renamed-or-deleted-away one (with no later re-establishment)
+        // doesn't count as resolving this interpolated head (issue #1010,
+        // the same question `unresolved.rs`'s `proc_defs_by_tail` already
+        // answers for ordinary bareword W123, reused here via
+        // `fact_live_for_call` rather than reimplemented).
+        let mut proc_defs_by_tail: HashMap<String, Vec<(String, u32)>> = HashMap::new();
+        for (qn, def) in &self.result.all_procs {
+            if let Some((_, tail)) = qn.rsplit_once("::")
+                && !tail.is_empty()
+            {
+                proc_defs_by_tail
+                    .entry(tail.to_string())
+                    .or_default()
+                    .push((qn.clone(), def.name_span.start()));
+            }
+        }
 
         // Walk W123 diagnostics and remove those whose
         // interpolated command name resolves cleanly.
@@ -1471,12 +1567,30 @@ impl Analyser {
                 kept.push(d);
                 continue;
             };
-            // All resolved candidates must be known commands.
+            // All resolved candidates must be known commands — live ones,
+            // not a proc renamed or deleted away with no later
+            // re-establishment (issue #1010: this closure used to delete
+            // an already-correct W123 for e.g. `do${suffix}` folding to
+            // `doThing` after `rename doThing {}`, confirmed against
+            // tclsh 8.6.14 that the call still fails "invalid command
+            // name").
+            let call_off = d.span.start();
+            let proc_tail_live = |name: &str| {
+                proc_defs_by_tail.get(name).is_some_and(|defs| {
+                    defs.iter()
+                        .any(|(qn, off)| self.fact_live_for_call(qn, *off, call_off))
+                })
+            };
+            let proc_qualified_live = |qualified: &str| {
+                self.result.all_procs.get(qualified).is_some_and(|p| {
+                    self.fact_live_for_call(qualified, p.name_span.start(), call_off)
+                })
+            };
             let all_known = resolved.iter().all(|name| {
                 known_cmds.contains(name)
-                    || known_proc_tails.contains(name)
-                    || self.result.all_procs.contains_key(&format!("::{name}"))
-                    || self.result.all_procs.contains_key(name)
+                    || proc_tail_live(name)
+                    || proc_qualified_live(&format!("::{name}"))
+                    || proc_qualified_live(name)
             });
             if all_known {
                 // Suppress this W123 — the interpolated head

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -33,13 +33,15 @@
 //! tracking maps (``const_strings``, ``regex_vars``, ``ns_cache``,
 //! ``result.regex_patterns``).
 
+use std::collections::{HashMap, HashSet};
+
 use tcl_core_types::DiagCode;
 use tcl_lexer::{Span, Token, TokenType};
 
 use crate::naming::{normalise_qualified_name, normalise_var_name, split_array_name};
 
 use super::state::Analyser;
-use super::types::{Scope, ScopeKind, VarDef};
+use super::types::{ClassDef, ProcDef, Scope, ScopeKind, VarDef};
 
 /// Ancestor path enumerator: yields the active scope's path and
 /// each of its proper ancestors back to the root, longest first.
@@ -232,6 +234,129 @@ pub fn lookup_var_in_namespace<'a>(
     walk("::", root, target_ns, base_name)
 }
 
+/// Bundles the field-disjoint borrows [`Analyser::finalise_invocation_resolutions`]'s
+/// call-site "is `qualified` known, for a call at `call_off`?" predicate
+/// needs, and the small body/enclosing-definition/liveness helpers it's
+/// built from — extracted so the loop that builds and consults it doesn't
+/// blow that function's line budget. `A` is left generic over the
+/// alias-map value type (only `contains_key` is used) so this doesn't need
+/// to name `command_aliases`'s value type explicitly.
+struct KnownPredicateCtx<'a, A> {
+    builtins: &'a HashSet<String>,
+    renamed_away: &'a HashSet<String>,
+    procs: &'a HashMap<String, ProcDef>,
+    classes: &'a HashMap<String, ClassDef>,
+    aliases: &'a HashMap<String, A>,
+    renames: &'a HashMap<String, String>,
+    alias_offsets: &'a HashMap<String, u32>,
+    rename_offsets: &'a HashMap<String, u32>,
+    deleted_commands: &'a HashMap<String, u32>,
+    top_level_call_offsets: &'a HashMap<String, u32>,
+}
+
+impl<A> KnownPredicateCtx<'_, A> {
+    /// Whether byte offset `off` falls inside any proc/class body recorded
+    /// so far — a local restatement of
+    /// `AnalysisResult::offset_is_inside_any_definition_body` over the
+    /// field-disjoint borrows above, since a method call on `result` (the
+    /// whole struct) would conflict with the `&mut
+    /// result.command_invocations` borrow the caller's loop holds.
+    fn offset_inside_any_body(&self, off: u32) -> bool {
+        self.procs
+            .values()
+            .any(|p| p.body_span.start() <= off && off < p.body_span.end())
+            || self
+                .classes
+                .values()
+                .any(|c| c.body_span.start() <= off && off < c.body_span.end())
+    }
+
+    /// The qualified name of the innermost proc/class body containing
+    /// `off`, mirroring `AnalysisResult::enclosing_definition_qualified_name`
+    /// for the same borrow-splitting reason as `offset_inside_any_body`.
+    fn enclosing_definition(&self, off: u32) -> Option<&str> {
+        self.procs
+            .values()
+            .map(|p| (p.qualified_name.as_str(), p.body_span))
+            .chain(
+                self.classes
+                    .values()
+                    .map(|c| (c.qualified_name.as_str(), c.body_span)),
+            )
+            .filter(|(_, span)| span.start() <= off && off < span.end())
+            .min_by_key(|(_, span)| span.end() - span.start())
+            .map(|(qn, _)| qn)
+    }
+
+    /// Whether `qualified`'s fact — a proc/class definition, a `rename`
+    /// target, or an `interp alias` target, established at `fact_off` — is
+    /// still live *for a call at `call_off`*: no `rename NAME {}` / `interp
+    /// alias {} NAME {}` deletion of `qualified` itself has been recorded
+    /// *after* that offset (issue #973: a proc/class/rename/alias target
+    /// that was later renamed away must not still count as known —
+    /// calling it fails "invalid command name" in real Tcl, confirmed
+    /// against tclsh 8.6.14). Mirrors `fact_superseded_by_deletion` in
+    /// `diagnostics/validity.rs` (the arity resolver's answer to the same
+    /// "most recent fact: live definition or deletion?" question) rather
+    /// than re-deriving it: a name deleted and then re-established under
+    /// the same name (a fresh `proc`, `rename`, or `interp alias`) is live
+    /// again, so only a deletion that postdates this specific fact's own
+    /// establishing offset disqualifies it. `deleted_commands` stores only
+    /// the last-seen deletion offset per name, which — since the walk
+    /// visits statements in source order — is always the most recent one.
+    ///
+    /// Call-site and conditional-body aware the same way
+    /// [`Analyser::fact_live_for_call`] is (the W123 pass's answer to the
+    /// identical question) — a namespaced local candidate must not lose to
+    /// the global one just because *some later* deletion exists, when this
+    /// specific call runs before it; issue #1009 Codex review: `proc bar
+    /// {}`, `namespace eval foo { proc bar {}; proc caller {} { bar } }`,
+    /// `foo::caller`, `rename foo::bar {}` still resolves `bar` (called
+    /// from `foo::caller`, before the rename) to `::foo::bar`, not the
+    /// global `::bar` — confirmed against tclsh 8.6.14 — because
+    /// `foo::caller`'s own top-level invocation already ran before the
+    /// rename.
+    fn live_for_call(&self, qualified: &str, fact_off: u32, call_off: u32) -> bool {
+        let Some(&del_off) = self.deleted_commands.get(qualified) else {
+            return true;
+        };
+        if del_off <= fact_off {
+            return true;
+        }
+        if self.offset_inside_any_body(del_off) {
+            return true;
+        }
+        if !self.offset_inside_any_body(call_off) {
+            return call_off <= del_off;
+        }
+        self.enclosing_definition(call_off)
+            .and_then(|qn| self.top_level_call_offsets.get(qn))
+            .is_some_and(|&t| t < del_off)
+    }
+
+    fn known(&self, qualified: &str, call_off: u32) -> bool {
+        self.procs
+            .get(qualified)
+            .is_some_and(|p| self.live_for_call(qualified, p.name_span.start(), call_off))
+            || self
+                .classes
+                .get(qualified)
+                .is_some_and(|c| self.live_for_call(qualified, c.name_span.start(), call_off))
+            || (self.aliases.contains_key(qualified)
+                && self
+                    .alias_offsets
+                    .get(qualified)
+                    .is_none_or(|&off| self.live_for_call(qualified, off, call_off)))
+            || (self.renames.contains_key(qualified)
+                && self
+                    .rename_offsets
+                    .get(qualified)
+                    .is_none_or(|&off| self.live_for_call(qualified, off, call_off)))
+            || (self.builtins.contains(qualified.trim_start_matches(':'))
+                && !self.renamed_away.contains(qualified))
+    }
+}
+
 impl Analyser {
     /// Resolve the current scope path to a borrow of the active
     /// [`Scope`] inside [`Self::result`]. Convenience wrapper
@@ -405,6 +530,31 @@ impl Analyser {
             .collect()
     }
 
+    /// Build [`Analyser::top_level_call_offsets`]: the earliest offset,
+    /// among the walk's recorded invocations, of a call whose own site is
+    /// *not* inside any proc/class body — grouped by resolved qualified
+    /// name.  Read by [`Self::finalise_invocation_resolutions`]'s
+    /// `live_for_call` and by [`Self::fact_live_for_call`] as the "was the
+    /// enclosing definition itself invoked before the deletion" escape
+    /// hatch for a call nested inside a body (issue #1009 Codex review).
+    fn compute_top_level_call_offsets(&self) -> HashMap<String, u32> {
+        let mut offsets: HashMap<String, u32> = HashMap::new();
+        for inv in &self.result.command_invocations {
+            let Some(qualified) = inv.resolved_qualified_name.as_deref() else {
+                continue;
+            };
+            let call_off = inv.range.start();
+            if self.result.offset_is_inside_any_definition_body(call_off) {
+                continue;
+            }
+            offsets
+                .entry(qualified.to_string())
+                .and_modify(|off| *off = (*off).min(call_off))
+                .or_insert(call_off);
+        }
+        offsets
+    }
+
     pub(super) fn finalise_invocation_resolutions(&mut self) {
         // Populate the per-dialect builtin-name cache before splitting field
         // borrows below (`builtin_command_names` needs `&mut self`).
@@ -429,9 +579,18 @@ impl Analyser {
         // consumers (definition / hover / signature help) can honour a
         // `namespace path` the same way call-site settling does.
         self.result.namespace_paths.clone_from(&paths);
+        // Earliest top-level (non-body) call-site offset per resolved
+        // qualified name, from the invocations the walk has already
+        // recorded — computed before the mutable loop below so
+        // `live_for_call`'s body-call escape hatch (issue #1009 Codex
+        // review) can consult it, and cached on `self` so the later W123 /
+        // const-dispatch / variable-command passes' `Self::fact_live_for_call`
+        // calls reuse the same map instead of rebuilding it.
+        self.top_level_call_offsets = self.compute_top_level_call_offsets();
         let renamed_away = self.renamed_away_builtin_names();
         let deleted_commands = &self.deleted_commands;
         let rename_offsets = &self.rename_offsets;
+        let top_level_call_offsets = &self.top_level_call_offsets;
         let result = &mut self.result;
         let (procs, classes, aliases, renames) = (
             &result.all_procs,
@@ -440,45 +599,21 @@ impl Analyser {
             &result.renamed_commands,
         );
         let alias_offsets = &result.alias_offsets;
-        // Whether `qualified`'s fact — a proc/class definition, a `rename`
-        // target, or an `interp alias` target, established at `fact_off` —
-        // is still live: no `rename NAME {}` / `interp alias {} NAME {}`
-        // deletion of `qualified` itself has been recorded *after* that
-        // offset (issue #973: a proc/class/rename/alias target that was
-        // later renamed away must not still count as known — calling it
-        // fails "invalid command name" in real Tcl, confirmed against
-        // tclsh 8.6.14). Mirrors `fact_superseded_by_deletion` in
-        // `diagnostics/validity.rs` (the arity resolver's answer to the
-        // same "most recent fact: live definition or deletion?" question)
-        // rather than re-deriving it: a name deleted and then
-        // re-established under the same name (a fresh `proc`, `rename`, or
-        // `interp alias`) is live again, so only a deletion that postdates
-        // this specific fact's own establishing offset disqualifies it.
-        // `deleted_commands` stores only the last-seen deletion offset per
-        // name, which — since the walk visits statements in source order —
-        // is always the most recent one.
-        let live = |qualified: &str, fact_off: u32| {
-            deleted_commands
-                .get(qualified)
-                .is_none_or(|&del_off| del_off <= fact_off)
-        };
-        let known = |qualified: &str| {
-            procs
-                .get(qualified)
-                .is_some_and(|p| live(qualified, p.name_span.start()))
-                || classes
-                    .get(qualified)
-                    .is_some_and(|c| live(qualified, c.name_span.start()))
-                || (aliases.contains_key(qualified)
-                    && alias_offsets
-                        .get(qualified)
-                        .is_none_or(|&off| live(qualified, off)))
-                || (renames.contains_key(qualified)
-                    && rename_offsets
-                        .get(qualified)
-                        .is_none_or(|&off| live(qualified, off)))
-                || (builtins.contains(qualified.trim_start_matches(':'))
-                    && !renamed_away.contains(qualified))
+        // See `KnownPredicateCtx` (module level, above `impl Analyser`) for
+        // the call-site + conditional-body-aware "is `qualified` known?"
+        // predicate this builds — extracted out of this function to stay
+        // within the line budget.
+        let known_ctx = KnownPredicateCtx {
+            builtins,
+            renamed_away: &renamed_away,
+            procs,
+            classes,
+            aliases,
+            renames,
+            alias_offsets,
+            rename_offsets,
+            deleted_commands,
+            top_level_call_offsets,
         };
         for inv in &mut result.command_invocations {
             // Absolute names are exact — the sole candidate is the name itself.
@@ -527,8 +662,9 @@ impl Analyser {
                 let candidates = crate::naming::command_resolution_candidates(&ns, path, &rel);
                 inv.resolution_candidates.clone_from(&candidates);
                 let global = format!("::tcl::mathfunc::{}", inv.name);
+                let call_off = inv.range.start();
                 let winner = candidates.into_iter().find(|c| {
-                    known(c)
+                    known_ctx.known(c, call_off)
                         || (*c == global
                             && crate::tcl_expr_eval::is_known_mathfunc_in_dialect(
                                 &inv.name, dialect,
@@ -568,7 +704,10 @@ impl Analyser {
             // defined in another file cannot settle correctly here.
             inv.resolution_candidates =
                 crate::naming::command_resolution_candidates(&ns, path, &inv.name);
-            if let Some(winner) = crate::naming::resolve_command_with(&ns, path, &inv.name, &known)
+            let call_off = inv.range.start();
+            let known_here = |c: &str| known_ctx.known(c, call_off);
+            if let Some(winner) =
+                crate::naming::resolve_command_with(&ns, path, &inv.name, &known_here)
                 && winner != resolved
             {
                 inv.resolved_qualified_name = Some(winner);
@@ -1834,6 +1973,82 @@ mod tests {
         assert_eq!(
             lookup_var_in_namespace(&root, "::", "v").map(|v| v.definition_span),
             Some(span(0, 1))
+        );
+    }
+
+    // `finalise_invocation_resolutions`'s local-vs-global candidate choice,
+    // Codex PR #1014 review comment #1 (`scope.rs:463`): the "known"
+    // predicate compared only the final deletion offset against the
+    // candidate's own establishing offset, never the call site, so a
+    // namespaced local call textually *before* a later unconditional
+    // deletion wrongly lost to the global candidate. Confirmed against
+    // tclsh 8.6.14 throughout.
+
+    #[test]
+    fn local_call_before_later_deletion_resolves_local_not_global_codex_1009() {
+        // TP (the confirmed regression): `foo::caller`'s own top-level
+        // invocation runs before `rename foo::bar {}`, so its `bar` call
+        // must still resolve to the local `::foo::bar`, not the global
+        // `::bar` — confirmed against tclsh 8.6.14 (prints "local").
+        let mut a = Analyser::new();
+        let src = "proc bar {} { return global }\nnamespace eval foo {\n    proc bar {} { return local }\n    proc caller {} { return [bar] }\n}\nfoo::caller\nrename foo::bar {}\n";
+        let r = a.analyse(src, "tcl8.6");
+        let bar_call = r
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "bar" && !i.indirect)
+            .expect("bar call recorded");
+        assert_eq!(
+            bar_call.resolved_qualified_name.as_deref(),
+            Some("::foo::bar"),
+            "a call before the deletion must still resolve to the local candidate"
+        );
+    }
+
+    #[test]
+    fn local_call_after_deletion_still_falls_back_to_global_issue_973() {
+        // FN guard / regression: unlike the case above, `foo::caller` is
+        // only ever invoked (at the top level) *after* `rename foo::bar
+        // {}` runs, so the local `bar` is genuinely gone by the time the
+        // call executes — it must still fall back to the global `::bar`
+        // (issue #973's original fix must not regress).
+        let mut a = Analyser::new();
+        let src = "proc bar {} { return global }\nnamespace eval foo {\n    proc bar {} { return local }\n    rename foo::bar {}\n    proc caller {} { return [bar] }\n}\nfoo::caller\n";
+        let r = a.analyse(src, "tcl8.6");
+        let bar_call = r
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "bar" && !i.indirect)
+            .expect("bar call recorded");
+        assert_eq!(
+            bar_call.resolved_qualified_name.as_deref(),
+            Some("::bar"),
+            "a call genuinely after the deletion must fall back to the global candidate"
+        );
+    }
+
+    #[test]
+    fn escape_hatch_requires_the_specific_enclosing_definitions_own_top_level_call() {
+        // FN guard: an unrelated proc's top-level invocation elsewhere in
+        // the file must not "lend" liveness to a different enclosing
+        // definition that is itself never invoked — the escape hatch must
+        // key off the *specific* body's own top-level call, not just
+        // "some call happened somewhere before the deletion". `foo::bar`
+        // is deleted, and `foo::caller` (the only body that calls it) is
+        // never invoked anywhere — only the unrelated `baz::unrelated` is
+        // — so the `bar` call must fall back to the global `::bar`.
+        let mut a = Analyser::new();
+        let src = "proc bar {} { return global }\nnamespace eval foo {\n    proc bar {} { return local }\n    proc caller {} { return [bar] }\n}\nnamespace eval baz {\n    proc unrelated {} { return 1 }\n}\nbaz::unrelated\nrename foo::bar {}\n";
+        let r = a.analyse(src, "tcl8.6");
+        let bar_call = r
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "bar" && !i.indirect)
+            .expect("bar call recorded");
+        assert_eq!(
+            bar_call.resolved_qualified_name.as_deref(),
+            Some("::bar"),
+            "foo::caller is never invoked, so the escape hatch must not apply"
         );
     }
 }

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -388,6 +388,23 @@ impl Analyser {
     /// (`graphs`, `minify`) find no same-file definition either way, and
     /// the cross-file reference matchers treat the field as a candidate,
     /// not ground truth.
+    /// Registry builtin names renamed away (`rename puts ::a::p`) or
+    /// deleted (`rename puts ""` / an `interp alias` deletion) anywhere in
+    /// the file — no longer callable under their original name (C raises
+    /// `invalid command name`), so the registry name must not count as
+    /// existing. Gates only [`Self::finalise_invocation_resolutions`]'s
+    /// registry-builtin clause; user procs/classes keep that function's
+    /// whole-file semantics (a proc/class's own deletion is instead gated
+    /// per qualified name, via `deleted_commands` directly).
+    fn renamed_away_builtin_names(&self) -> std::collections::HashSet<String> {
+        self.result
+            .renamed_commands
+            .values()
+            .cloned()
+            .chain(self.deleted_commands.keys().cloned())
+            .collect()
+    }
+
     pub(super) fn finalise_invocation_resolutions(&mut self) {
         // Populate the per-dialect builtin-name cache before splitting field
         // borrows below (`builtin_command_names` needs `&mut self`).
@@ -412,19 +429,9 @@ impl Analyser {
         // consumers (definition / hover / signature help) can honour a
         // `namespace path` the same way call-site settling does.
         self.result.namespace_paths.clone_from(&paths);
-        // A builtin renamed away (`rename puts ::a::p`) or deleted
-        // (`rename puts ""` / alias deletion) is no longer callable under
-        // its original name — C raises `invalid command name` — so the
-        // registry name must not count as existing. (User procs keep the
-        // whole-file semantics documented above; this gates only the
-        // builtin clause.)
-        let renamed_away: std::collections::HashSet<String> = self
-            .result
-            .renamed_commands
-            .values()
-            .cloned()
-            .chain(self.deleted_commands.keys().cloned())
-            .collect();
+        let renamed_away = self.renamed_away_builtin_names();
+        let deleted_commands = &self.deleted_commands;
+        let rename_offsets = &self.rename_offsets;
         let result = &mut self.result;
         let (procs, classes, aliases, renames) = (
             &result.all_procs,
@@ -432,11 +439,44 @@ impl Analyser {
             &result.command_aliases,
             &result.renamed_commands,
         );
+        let alias_offsets = &result.alias_offsets;
+        // Whether `qualified`'s fact — a proc/class definition, a `rename`
+        // target, or an `interp alias` target, established at `fact_off` —
+        // is still live: no `rename NAME {}` / `interp alias {} NAME {}`
+        // deletion of `qualified` itself has been recorded *after* that
+        // offset (issue #973: a proc/class/rename/alias target that was
+        // later renamed away must not still count as known — calling it
+        // fails "invalid command name" in real Tcl, confirmed against
+        // tclsh 8.6.14). Mirrors `fact_superseded_by_deletion` in
+        // `diagnostics/validity.rs` (the arity resolver's answer to the
+        // same "most recent fact: live definition or deletion?" question)
+        // rather than re-deriving it: a name deleted and then
+        // re-established under the same name (a fresh `proc`, `rename`, or
+        // `interp alias`) is live again, so only a deletion that postdates
+        // this specific fact's own establishing offset disqualifies it.
+        // `deleted_commands` stores only the last-seen deletion offset per
+        // name, which — since the walk visits statements in source order —
+        // is always the most recent one.
+        let live = |qualified: &str, fact_off: u32| {
+            deleted_commands
+                .get(qualified)
+                .is_none_or(|&del_off| del_off <= fact_off)
+        };
         let known = |qualified: &str| {
-            procs.contains_key(qualified)
-                || classes.contains_key(qualified)
-                || aliases.contains_key(qualified)
-                || renames.contains_key(qualified)
+            procs
+                .get(qualified)
+                .is_some_and(|p| live(qualified, p.name_span.start()))
+                || classes
+                    .get(qualified)
+                    .is_some_and(|c| live(qualified, c.name_span.start()))
+                || (aliases.contains_key(qualified)
+                    && alias_offsets
+                        .get(qualified)
+                        .is_none_or(|&off| live(qualified, off)))
+                || (renames.contains_key(qualified)
+                    && rename_offsets
+                        .get(qualified)
+                        .is_none_or(|&off| live(qualified, off)))
                 || (builtins.contains(qualified.trim_start_matches(':'))
                     && !renamed_away.contains(qualified))
         };

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -293,6 +293,20 @@ pub struct Analyser {
     /// [`Self::rename_offsets`]), instead of still validating it against
     /// a definition that's no longer callable under that name.
     pub deleted_commands: HashMap<String, u32>,
+    /// Earliest source offset, among this file's recorded command
+    /// invocations, of a *top-level* (not inside any proc/class body) call
+    /// resolving to each qualified name — keyed by `resolved_qualified_name`.
+    /// Populated once by [`Self::finalise_invocation_resolutions`] from the
+    /// already-settled `command_invocations`, and consulted by
+    /// [`Self::fact_live_for_call`] when the call site under test is itself
+    /// nested inside a body: a proven top-level invocation of the
+    /// *enclosing* definition that ran before a later unconditional
+    /// deletion means that invocation's own nested calls already resolved
+    /// (issue #1009 Codex review: `proc helper {}`, `proc caller {} {
+    /// helper }`, `caller`, `rename helper {}` resolves in real Tcl —
+    /// confirmed against tclsh 8.6.14 — because `caller`'s own top-level
+    /// invocation runs before the rename).
+    pub(super) top_level_call_offsets: HashMap<String, u32>,
     /// Static `namespace path {…}` declarations: ``declaring namespace →
     /// raw path entries`` (each declaration replaces the whole path, as in
     /// C Tcl, so the lexically-last one wins). Entries are stored as
@@ -688,6 +702,7 @@ impl Analyser {
             alias_offsets: HashMap::new(),
             rename_offsets: HashMap::new(),
             deleted_commands: HashMap::new(),
+            top_level_call_offsets: HashMap::new(),
             namespace_paths: HashMap::new(),
             var_command_sites: Vec::new(),
             pending_const_dispatches: Vec::new(),

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -982,6 +982,28 @@ impl AnalysisResult {
             .chain(self.all_classes.values().map(|c| c.body_span))
             .any(|span| span.start() <= off && off < span.end())
     }
+
+    /// The qualified name of the *innermost* recorded proc or class
+    /// definition whose body contains offset `off`, or `None` when `off`
+    /// isn't inside any recorded definition body.  Bodies can nest (a
+    /// `proc` written inside another proc's or a class's body), so this
+    /// picks the smallest enclosing span rather than an arbitrary match —
+    /// the definition whose body most tightly wraps `off` is the one that
+    /// actually runs when the call at `off` executes.
+    #[must_use]
+    pub fn enclosing_definition_qualified_name(&self, off: u32) -> Option<&str> {
+        self.all_procs
+            .values()
+            .map(|p| (p.qualified_name.as_str(), p.body_span))
+            .chain(
+                self.all_classes
+                    .values()
+                    .map(|c| (c.qualified_name.as_str(), c.body_span)),
+            )
+            .filter(|(_, span)| span.start() <= off && off < span.end())
+            .min_by_key(|(_, span)| span.end() - span.start())
+            .map(|(qn, _)| qn)
+    }
 }
 
 /// `package provide NAME ?VERSION?` record.

--- a/rust/tcl-lsp-server/tests/e2e/issue945.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue945.rs
@@ -167,6 +167,113 @@ fn const_dispatch_still_references_a_proc_reestablished_after_deletion_1009() {
     );
 }
 
+// Issue #1009, Codex PR #1014 review follow-up — two confirmed false
+// positives found in review after the original #1009/#1006/#973 fixes
+// landed:
+//
+// 1. `scope.rs`'s `finalise_invocation_resolutions` picked between a local
+//    and a global candidate using a *file-end-only* deletion check, so a
+//    namespaced local call textually before a later unconditional
+//    deletion wrongly lost to the global candidate.
+// 2. `fact_live_for_call` treated *any* call inside a proc/class body as
+//    automatically after every top-level deletion, drawing a spurious
+//    W123 even when the enclosing definition's own top-level invocation
+//    demonstrably ran before that deletion.
+//
+// Both confirmed against tclsh 8.6.14 (see the unit tests alongside
+// `finalise_invocation_resolutions` and `fact_live_for_call` for the exact
+// repros run under a real interpreter).
+
+// These two use `references` rather than `definition`: go-to-definition's
+// own call-site resolver (`tcl-lsp-core::definition::resolve_called_proc`)
+// is a namespace-visibility check with no deletion tracking of its own, so
+// it always prefers a namespace-visible local proc regardless of a later
+// `rename` — it does not exercise `finalise_invocation_resolutions`'s fix.
+// `references` does: it matches a call site against a definition via
+// `resolved_qualified_name` (`tcl-lsp-core::references`), the exact field
+// this fix corrects.
+
+#[test]
+fn local_call_before_later_deletion_is_a_reference_to_the_local_definition_codex_1009() {
+    // TP: `foo::caller`'s own top-level invocation (line 5) runs before
+    // `rename foo::bar {}` (line 6), so the `bar` call inside its body
+    // must be a reference to the *local* `::foo::bar` (line 2), not the
+    // global `bar` (line 0).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc bar {} { return global }\nnamespace eval foo {\n    proc bar {} { return local }\n    proc caller {} { return [bar] }\n}\nfoo::caller\nrename foo::bar {}\n";
+    lsp.open_ready(&uri, src);
+    let local_refs = start_lines(&lsp.references(&uri, 2, 9, false));
+    assert!(
+        local_refs.contains(&3),
+        "the call before the deletion must reference the local definition: {local_refs:?}"
+    );
+    let global_refs = start_lines(&lsp.references(&uri, 0, 5, false));
+    assert!(
+        !global_refs.contains(&3),
+        "the call must not also reference the global definition: {global_refs:?}"
+    );
+}
+
+#[test]
+fn local_call_after_deletion_is_a_reference_to_the_global_definition_issue_973() {
+    // FN guard / regression: `foo::caller` is only ever invoked (line 6,
+    // after `rename foo::bar {}` on line 3) — the local `bar` is genuinely
+    // gone by the time the call executes, so it must be a reference to
+    // the global `bar` (line 0), not the local one (line 2). Guards
+    // against #973's original fix regressing.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc bar {} { return global }\nnamespace eval foo {\n    proc bar {} { return local }\n    rename foo::bar {}\n    proc caller {} { return [bar] }\n}\nfoo::caller\n";
+    lsp.open_ready(&uri, src);
+    // Driven by `resolved_qualified_name` resolving to the global `::bar`:
+    // before this fix it stayed `::foo::bar`, and `invocation_references_named`
+    // would not have matched this query at all (`call_ns` ("foo") differs
+    // from the global definition's own namespace ("")).
+    let global_refs = start_lines(&lsp.references(&uri, 0, 5, false));
+    assert!(
+        global_refs.contains(&4),
+        "a call genuinely after the deletion must reference the global definition: {global_refs:?}"
+    );
+}
+
+#[test]
+fn body_call_before_later_deletion_draws_no_w123_codex_1009() {
+    // FP guard (the confirmed regression): `caller`'s own top-level
+    // invocation runs before `rename helper {}`, so the `helper` call
+    // inside its body must draw no W123 — confirmed against tclsh 8.6.14
+    // (the script runs to completion).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc helper {} {}\nproc caller {} { helper }\ncaller\nrename helper {}\n";
+    lsp.open_ready(&uri, src);
+    let diags = lsp.await_diagnostics(&uri);
+    assert!(
+        !diags
+            .iter()
+            .any(|d| d.get("code").and_then(Value::as_str) == Some("W123")),
+        "a body call before a later deletion must not draw W123: {diags:?}"
+    );
+}
+
+#[test]
+fn body_call_deleted_before_definition_still_draws_w123_issue_973() {
+    // TP regression: `helper` is deleted before `caller` is even defined,
+    // with no re-establishment — the body call must still draw W123
+    // (confirmed against tclsh 8.6.14: `invalid command name "helper"`).
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc helper {} {}\nrename helper {}\nproc caller {} { helper }\ncaller\n";
+    lsp.open_ready(&uri, src);
+    let diags = lsp.await_diagnostics(&uri);
+    assert!(
+        diags
+            .iter()
+            .any(|d| d.get("code").and_then(Value::as_str) == Some("W123")),
+        "helper was deleted before caller was even defined: {diags:?}"
+    );
+}
+
 #[test]
 fn branch_joined_dispatch_definition_offers_both_targets_945() {
     let mut lsp = Lsp::tcl();

--- a/rust/tcl-lsp-server/tests/e2e/issue945.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue945.rs
@@ -131,6 +131,42 @@ fn const_dispatch_rename_rewrites_the_defining_literal_and_executes_945() {
     }
 }
 
+// Issue #1009 — the constant-`$cmd` dispatch settlement resolved through a
+// proc/class/alias/rename target renamed or deleted away with no later
+// re-establishment, the same root cause #973/#1006/#1007 fixed for the
+// bareword-call paths. Confirmed against tclsh 8.6.14 that a deleted
+// proc's dispatch fails "invalid command name" — the LSP must not still
+// treat the dead name as a live reference.
+
+#[test]
+fn const_dispatch_draws_no_reference_to_a_deleted_proc_1009() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc target {} { return hi }\nrename target {}\nset cmd target\n$cmd\n";
+    lsp.open_ready(&uri, src);
+    let refs = start_lines(&lsp.references(&uri, 0, 6, true));
+    assert!(
+        !refs.contains(&2) && !refs.contains(&3),
+        "a proc deleted with no re-establishment must draw no reference from \
+         the dead $cmd dispatch (`set cmd target` / `$cmd`): {refs:?}"
+    );
+}
+
+#[test]
+fn const_dispatch_still_references_a_proc_reestablished_after_deletion_1009() {
+    // FP guard: a fresh `proc target` after the deletion re-establishes the
+    // name — the dispatch must still resolve and reference it normally.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc target {} { return hi }\nrename target {}\nproc target {} { return bye }\nset cmd target\n$cmd\n";
+    lsp.open_ready(&uri, src);
+    let refs = start_lines(&lsp.references(&uri, 2, 6, true));
+    assert!(
+        refs.contains(&3),
+        "the re-established proc must still be referenced by the dispatch: {refs:?}"
+    );
+}
+
 #[test]
 fn branch_joined_dispatch_definition_offers_both_targets_945() {
     let mut lsp = Lsp::tcl();

--- a/rust/tcl-lsp-server/tests/e2e/precision_review.rs
+++ b/rust/tcl-lsp-server/tests/e2e/precision_review.rs
@@ -58,7 +58,11 @@ fn message_of(d: &Value) -> String {
 // -- W123 / rename resolution ---------------------------------------------
 
 /// FP guard: `rename OLD NEW` binds NEW — calling the renamed name is not an
-/// unknown command.  TP control: the vacated OLD name still draws W128.
+/// unknown command. TP control: the vacated OLD name draws both W128 (the
+/// specific "renamed or deleted" hint) and W123 (the generic "unknown
+/// command" — issue #973: confirmed against tclsh 8.6.14 that `rename
+/// user_args ua2` really does make a later `user_args` call fail "invalid
+/// command name", the same as any other unresolved command).
 #[test]
 fn rename_target_is_known_and_old_name_flags_w128() {
     let mut lsp = Lsp::tcl();
@@ -67,13 +71,23 @@ fn rename_target_is_known_and_old_name_flags_w128() {
         &uri,
         "proc user_args {args} { puts [llength $args] }\nrename user_args ua2\nua2 1 2\nuser_args 9\n",
     );
+    // `ua2 1 2` is line 2 — the rename target must not draw W123 there.
     assert!(
-        !codes(&diags).iter().any(|c| c == "W123"),
+        !diags
+            .iter()
+            .any(|d| code_str(d) == "W123" && range_of(d).0 == 2),
         "the rename target must be a known command: {diags:?}"
     );
+    // `user_args 9` is line 3 — the vacated source name.
     assert!(
         codes(&diags).iter().any(|c| c == "W128"),
         "the vacated source name still draws W128: {diags:?}"
+    );
+    assert!(
+        diags
+            .iter()
+            .any(|d| code_str(d) == "W123" && range_of(d).0 == 3),
+        "the vacated source name now also draws W123 (issue #973): {diags:?}"
     );
 }
 

--- a/rust/tcl-lsp-server/tests/e2e/precision_review.rs
+++ b/rust/tcl-lsp-server/tests/e2e/precision_review.rs
@@ -130,6 +130,90 @@ fn renamed_away_builtin_fires_w123_only_after_the_rename() {
     );
 }
 
+// -- Issue #1010: known-command checks gated on deletion -------------------
+//
+// Four `var_command.rs` "is this a known command" checks had no deletion
+// gate at all (the pre-#973 shape): interpolated-W123 resolution, W307
+// dynamic-dispatch suppression, dispatch-table reference synthesis, and
+// constructor object-typing. Each is confirmed against tclsh 8.6.14.
+
+/// TP: an interpolated command head (`do${suffix}`) folding to a proc
+/// renamed away with no re-establishment must keep its W123 — this
+/// closure used to delete an already-correct W123 outright.
+#[test]
+fn interpolated_head_folding_to_a_deleted_proc_keeps_w123() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc doThing {} {}\nrename doThing {}\nset suffix Thing\ndo$suffix\n",
+    );
+    assert!(
+        codes(&diags).iter().any(|c| c == "W123"),
+        "the interpolated head must still draw W123 once its target is deleted: {diags:?}"
+    );
+}
+
+/// TP: a dynamic-dispatch value (`$cmd hello`) proven by SCCP to equal a
+/// deleted proc name must not have its W307 silenced.
+#[test]
+fn dynamic_dispatch_value_equal_to_a_deleted_proc_keeps_w307() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc target {} {}\nrename target {}\nproc foo {} { set cmd target\n$cmd hello }\n",
+    );
+    assert!(
+        codes(&diags).iter().any(|c| c == "W307"),
+        "a dispatch value equalling a deleted proc must still draw W307: {diags:?}"
+    );
+}
+
+/// TP: a dispatch-table literal (`array set ops {add do_add}`) naming a
+/// deleted proc must draw no reference (checked via find-references,
+/// since this feeds rename-tracking rather than a diagnostic directly).
+#[test]
+fn dispatch_table_entry_naming_a_deleted_proc_draws_no_reference() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc do_add {a b} {}\nrename do_add {}\narray set ops {add do_add}\nset k add\n$ops($k) 1 2\n";
+    lsp.open_ready(&uri, src);
+    // `do_add` proc declaration name at line 0, col 5.
+    let refs = lsp.references(&uri, 0, 5, true);
+    let refs = refs.as_array().cloned().unwrap_or_default();
+    let lines: Vec<i64> = refs
+        .iter()
+        .map(|r| r["range"]["start"]["line"].as_i64().unwrap())
+        .collect();
+    assert!(
+        !lines.contains(&2),
+        "a deleted proc must draw no reference from the dead dispatch-table entry: {lines:?}"
+    );
+}
+
+/// TP: `[Cls new] method` where `Cls` was renamed away with no
+/// re-establishment must not draw the misleading "unknown method" W308
+/// (which implies `Cls` exists) — `Cls` itself draws W123 instead.
+#[test]
+fn constructor_of_a_deleted_class_does_not_draw_misleading_w308() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "oo::class create Dog { method bark {} { return woof } }\nrename Dog {}\n[Dog new] fly\n",
+    );
+    let cs = codes(&diags);
+    assert!(
+        !cs.iter().any(|c| c == "W308"),
+        "a deleted class must not draw the misleading unknown-method W308: {diags:?}"
+    );
+    assert!(
+        cs.iter().any(|c| c == "W123"),
+        "the deleted class itself must draw W123: {diags:?}"
+    );
+}
+
 /// FP guard: `coroutine NAME cmd` binds NAME as a command — calling it is
 /// not unknown.  TP control: a typo'd coroutine name still fires.
 #[test]


### PR DESCRIPTION
## Summary

- Fixes #973: `finalise_invocation_resolutions`'s `known` predicate (`scope.rs`) and the real W123-firing logic (`unresolved.rs`) never gated proc/class/alias/rename-target resolution on `rename NAME {}` / `interp alias {} NAME {}` deletion — a deleted-with-no-re-establishment name still resolved as callable.
- Fixes #1006: extends the same fix to `unresolved.rs`'s alias/rename-target checks, making them call-site- and conditional-body-aware (matching the sophistication already used for registry builtins) instead of file-end-only.
- Fixes #1007: the arity checker's (`validity.rs`) `fact_superseded_by_deletion` reused a call-site-order helper to also decide whether a *deletion* was in effect, with no way to know the deletion sat inside a never-triggered proc body — so any `rename`/`interp alias` deletion anywhere in the file permanently (and wrongly) silenced E002/E003 for later calls.
- Fixes #1009: constant-`$cmd` dispatch settlement (`const_dispatch.rs`) resolved through a renamed/deleted command with no gate at all, poisoning hover/go-to-definition/references/rename-tracking for indirect dispatch sites (confirmed this never caused a W123 false negative, since that pass runs after W123 already fires).
- Fixes #1010: four more ungated checks in `var_command.rs` — interpolated-W123 resolution (was actively **deleting** an already-correct W123), W307 dynamic-dispatch suppression, dispatch-table reference synthesis, and TclOO constructor object-typing (was producing a misleading secondary W308 instead of the real W123 + a conservative W307 fallback).
- Fixes two false positives found in Codex review of this PR (both confirmed against tclsh 8.6.14):
  - `finalise_invocation_resolutions` picked between a local and a global candidate using a file-end-only deletion check, so a namespaced local call textually before a later unconditional deletion wrongly lost to the global candidate.
  - `fact_live_for_call` treated any call inside a proc/class body as automatically after every top-level deletion, drawing a spurious W123 even when the enclosing definition's own top-level invocation demonstrably ran before that deletion.

  Both fixed via a shared escape hatch: track the earliest top-level (non-body) call-site offset per resolved qualified name, and when a call is nested inside a body, check whether its innermost enclosing definition has a provable top-level invocation before the deletion.
- Also fixes a VS Code extension test that started failing in CI: it compared reference results without filtering by document URI, so a sibling fixture left open by an earlier test in the same suite (same proc name, minus the deletion) was leaking legitimate cross-document references into the assertion.

All fixes reuse a single mechanism (`fact_live_for_call` / `fact_live_at_file_end` / `group_defs_by_tail`, widened to `pub(super)` so sibling passes share one implementation) rather than re-deriving the same "is this name's most recent fact a live definition or a deletion" question five different ways. Every case — TP (deleted, no re-establishment), FP guard (re-established after deletion), TN (never deleted), and the call-site/conditional-body edge cases — was verified against a real tclsh 8.6.14 before being encoded as a test, not assumed.

Two residuals, deliberately **not** folded into this PR:
- `set x [Cls new]` (the variable-assignment constructor shape) still has an independent, ungated source in `type_infer.rs`'s SSA type-lattice construction — a foundational, flow-insensitive module with no call-site offset available today. Tracked separately as #1013.
- The body-call escape hatch added in response to Codex review only checks one level of enclosing-definition indirection (`proc outer {} { inner }` calling `proc inner {} { helper }` where only `outer` has a top-level call site) — a fully correct fix needs call-graph reachability with cycle handling, a bigger and riskier change than the two confirmed findings warranted rushing in. Tracked separately as #1015.

## Validation

- `cargo test --workspace --all-features` — full workspace, including the native `lsp-e2e` suite (`rust/tcl-lsp-server/tests/e2e/`).
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-features -- -D warnings` (no new allows; several functions needed line-count-driven helper extraction to stay compliant)
- `cargo xtask resolution-drift` (the namespace-blind `.name ==` scan gate — relevant since this PR adds new `all_procs`/`all_classes` scans)
- VS Code extension tests added/fixed (`editors/vscode/src/test/issue945.test.ts`, `precisionReview.test.ts`) — run for real against the actual Electron-hosted test host (not just type-checked), confirming both new tests and the previously-failing CI test now pass.
- Found and fixed two genuine pre-existing regression risks along the way: a VS Code test (`precisionReview.test.ts`) and a native e2e test (`precision_review.rs`) both asserted "zero W123 anywhere in this fixture," an assumption that only held because of #973's bug — both updated to assert the correct, scoped behavior; and a VS Code reference-provider test that leaked cross-document results from a sibling fixture left open by an earlier test in the same suite.

## Compiler/KCS checklist

- [x] Did this change alter a compiler fact contract? Yes — W123/E002/E003 now fire in more cases (previously silent false negatives), and resolve correctly in more cases (previously silent false positives from the Codex review round).
- [x] Updated `docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md` with the newly-covered shape (a renamed/deleted-away command with no re-establishment).
- [x] Updated `README.md`'s Diagnostics section with the renamed/deleted-command W123 behaviour, per AGENTS.md's documentation requirement (flagged in Codex review).

## Follow-ups tracked separately

- #1013 — the deeper `type_infer.rs` gap noted above.
- #1015 — the one-level-only body-call escape hatch noted above.