### PR TITLE
Make a trait bit collision unrepresentable, fixing #1031

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,7 +325,11 @@ nested call, `{*}` expansion, the `package ifneeded name ver [list apply
 {dir {...}} $dir]` deferred-command idiom, and a `namespace ensemble
 create`/`configure -map` redirect to a hidden target — so a hidden
 `source` reached only that way is flagged the same as a direct call, in
-both a one-shot lint and the live editor session.
+both a one-shot lint and the live editor session. The hidden set is the
+one Tcl itself hides — `source`, `load`, `file`, `exec`, `open`, `socket`,
+`cd`, `pwd`, `glob`, `exit`, `fconfigure`, `encoding`, and `unload`;
+control-transfer commands such as `break` and `yield` stay visible and are
+never flagged.
 
 ```tcl
 interp create -safe s
@@ -650,6 +654,15 @@ set x [expr {$x+1}]  ;# O114 → quick-fix: use incr idiom → incr x
 moves into a new `proc` with detected variable parameters; the original
 lines are replaced with a call. The editor places the cursor on the new
 proc name so you can rename it immediately.
+
+**Inline proc** — put the cursor on a call to a single-command proc,
+trigger code actions (`Ctrl+.`), and choose *Inline proc* to replace the
+call with the proc's body. Branchy bodies are declined, as is any call
+whose head is *frame-sensitive* — a command that terminates a block,
+transfers control, creates a scope alias, or creates a barrier (`return`,
+`break`, `continue`, `tailcall`, `yield`, `uplevel`, `upvar`, `global`,
+`variable`, `source`, `exit`, …) — because lifting one of those out of its
+proc frame changes what it returns from, breaks out of, or binds against.
 
 ### Snippets
 

--- a/docs/design/contracts/command-spec-studio.md
+++ b/docs/design/contracts/command-spec-studio.md
@@ -154,15 +154,22 @@ assertion.**
 Procedures are deduplicated by qualified name across files, last definition
 winning, matching what the interpreter would end up with.
 
-## Known registry defect the studio works around
+## Trait names come from the registry
 
-`Traits` is a `u64` with all 64 bits allocated, and `SAFE_INTERP_HIDDEN`
-shares bit 61 with `TRANSFERS_CONTROL` — the two are the same flag at run
-time (issue #1031). `catalogue::trait_keys` therefore deduplicates by bit
-*value*, first catalogue entry winning, so a rendered spec stays bit-identical
-to the one it was seeded from rather than claiming a trait its author never
-set. `catalogue::tests::traits_catalogue_pins_the_known_bit_collision` fails
-once the registry widens `Traits`, which is the cue to remove the workaround.
+`catalogue::trait_keys` renders a spec's traits by asking the registry for
+them (`Traits::iter_names`), and `catalogue::trait_bit` resolves a name
+against `Trait::ALL`. There is no name↔bit table in the studio to drift out of
+step with the registry, and
+`catalogue::tests::traits_catalogue_matches_the_registry_flags` asserts the
+studio's descriptive catalogue covers exactly the registry's declared flags,
+in order.
+
+This previously needed a workaround. `Traits` was a `bitflags` `u64` holding
+65 flags, with `SAFE_INTERP_HIDDEN` and `TRANSFERS_CONTROL` both spelled
+`1 << 61` — the same flag at run time (issue #1031) — so `trait_keys` had to
+deduplicate by bit *value* to avoid rendering a spec that claimed a trait its
+author never set. The registry now derives each bit from an enum discriminant,
+so two flags cannot share one and the deduplication is gone.
 
 ## Publishing
 

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -59,6 +59,11 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   hidden command is reached only through a `[...]` bracket substitution —
   most importantly the `package ifneeded ... [list apply {...} $dir]`
   deferred-command idiom.
+- [kcs-issue-w129-false-positive-on-control-transfer-commands.md](kcs-issue-w129-false-positive-on-control-transfer-commands.md)
+  — W129 wrongly fires on `break`, `continue`, `yield`, `yieldto`, and
+  `tailcall` in a safe-interpreter body, and the *Inline proc* code action
+  is missing on `file`, `exec`, `open`, and seven other commands — two
+  symptoms of one trait-flag bit collision.
 - [kcs-issue-duplicate-diagnostics.md](kcs-issue-duplicate-diagnostics.md)
   — the same finding is reported twice.
 - [kcs-issue-counter-numtests-array-init.md](kcs-issue-counter-numtests-array-init.md)

--- a/docs/kcs/codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md
+++ b/docs/kcs/codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md
@@ -90,3 +90,11 @@ false one. See the
 [contributor-level note on the bracket-indirection fix](../kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md)
 for the full list of indirection shapes this check follows (and the ones it
 deliberately does not).
+
+The hidden set is exactly the list above. Tcl's control-transfer commands
+— `break`, `continue`, `yield`, `yieldto`, and `tailcall` — are **not**
+hidden by `interp create -safe` and must never draw this warning. Builds
+before the trait-flag fix did flag them, because the registry flag for
+"hidden in a safe interpreter" collided with the flag for "transfers
+control"; see
+[the note on that false positive](../kcs-issue-w129-false-positive-on-control-transfer-commands.md).

--- a/docs/kcs/features/kcs-feature-code-actions.md
+++ b/docs/kcs/features/kcs-feature-code-actions.md
@@ -37,6 +37,15 @@ batch-applied. The extract-to-proc refactoring attaches a post-edit command
 new proc name — VS Code handles this automatically; other editors silently
 ignore the command and the user can rename manually.
 
+Inline proc declines a proc whose body is branchy, and any call whose head
+is **frame-sensitive** — a command that terminates a block, transfers
+control, creates a scope alias, or creates a barrier (`return`, `break`,
+`continue`, `tailcall`, `yield`, `uplevel`, `upvar`, `global`, `variable`,
+`source`, `exit`, …). Lifting one of those out of its proc frame changes
+what it returns from, breaks out of, or binds against. The set is registry
+trait data, not a hand-maintained list, so a newly declared command is
+gated automatically.
+
 ## File-path anchors
 
 - `server/features/code_actions.py`
@@ -44,6 +53,12 @@ ignore the command and the user can rename manually.
 ## Failure modes
 
 - Code action produces invalid code.
+- Inline proc is offered on, or withheld from, the wrong command because a
+  registry trait is mis-declared. A flag collision once made every
+  safe-interpreter-hidden command read as frame-sensitive, silently
+  withholding the action from `file`, `exec`, `open`, and seven others —
+  see
+  [the note on that false positive](../kcs-issue-w129-false-positive-on-control-transfer-commands.md).
 - Safe-fix classification incorrect (destructive fix marked as safe).
 
 ## Test anchors

--- a/docs/kcs/kcs-issue-w129-false-positive-on-control-transfer-commands.md
+++ b/docs/kcs/kcs-issue-w129-false-positive-on-control-transfer-commands.md
@@ -1,0 +1,95 @@
+# KCS: W129 fires on `break` / `continue` / `yield`, and inline-proc is missing on `file` / `exec`
+
+> **Audience:** User
+> **Type:** Issue
+
+## Applies to
+
+all-editors, diagnostic, refactoring
+
+## Question
+
+Why does the analyser call `break` "hidden in this safe interpreter", and
+why is *Inline proc* not offered on a call to `file`, `exec`, or `open`?
+
+## Symptoms
+
+- A yellow squiggle under `break`, `continue`, `yield`, `yieldto`, or
+  `tailcall` inside an `interp eval` body for a `-safe` interpreter:
+  "'break' is hidden in this safe interpreter — the call raises
+  `invalid command name` unless it is exposed or invoked via
+  `interp invokehidden`". None of these commands is hidden by
+  `interp create -safe`, so the warning is wrong.
+- Worse than the squiggle: W129 also **skips** the command it flags, so
+  those control-flow commands contributed nothing to analysis inside a
+  safe-interpreter body. Definition, source, and package edges that
+  should have been built there went missing, so go-to-definition and
+  related features could come up empty.
+- Pressing `Ctrl+.` on a call to `file`, `encoding`, `open`, `socket`,
+  `exec`, `cd`, `pwd`, `glob`, `load`, or `unload` never offers
+  *Inline proc*, even where inlining is safe.
+
+## Why
+
+Both symptoms are one bug with one cause, and neither is a rule anyone
+intended.
+
+The command registry describes each command with behavioural trait flags.
+Two of them — the flag for "hidden by `interp create -safe`" and the flag
+for "jumps out of the current frame" — were accidentally given the *same
+bit*, so at run time the two were a single flag. Every safe-hidden command
+therefore read as control-transferring, and every control-transferring
+command read as safe-hidden.
+
+That single collision produced both symptoms, from opposite directions:
+
+- W129's hidden set is registry data, so the control-transfer commands
+  were read straight into it and flagged.
+- *Inline proc* declines any call whose head is **frame-sensitive** —
+  a command that terminates a block, transfers control, creates a scope
+  alias, or creates a barrier — because moving such a command out of its
+  proc frame changes what it returns from, breaks out of, or binds
+  against. The collision pulled the safe-hidden commands into that set,
+  suppressing the action on them.
+
+## Answer
+
+Both are fixed — no configuration change or workaround is needed. Update
+to a build containing the fix: the false warning disappears, and
+*Inline proc* reappears on the ten commands listed above.
+
+To confirm the fix is present:
+
+1. Open a file containing an `interp eval` body for a `-safe` interpreter
+   with a `break` or `continue` in it.
+2. Check the Problems view: no **W129** on the control-flow command. A
+   W129 on a genuinely hidden command such as `source` or `exec` in the
+   same body is correct and still appears — see
+   [the W129 diagnostic note](codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md)
+   for that set.
+3. Put the cursor on a call to a single-command proc whose body is
+   `file …` or `exec …` and press `Ctrl+.`. *Inline proc* is offered.
+
+`source` and `exit` are **still** frame-sensitive and still decline
+*Inline proc*, on their own merits rather than through the collision:
+`source` creates a barrier and `exit` terminates the block. That is
+correct behaviour, not a leftover of this bug.
+
+If the false warning persists after updating, collect the output channel
+log and open an issue.
+
+## Notes
+
+The traits are now declared so that each flag's bit is assigned by the
+compiler rather than written by hand, which makes two flags sharing a bit
+impossible to express rather than merely corrected. See
+[the command-spec-studio contract](../design/contracts/command-spec-studio.md)
+for that arrangement.
+
+## Related
+
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
+- [W129 — command hidden in a safe interpreter](codes/kcs-diagnostic-w129-command-hidden-in-safe-interpreter.md)
+- [W129 via bracket indirection](kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md)
+- [Code actions](features/kcs-feature-code-actions.md)

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1630,6 +1630,69 @@ impl std::fmt::Debug for CommandRegistry {
 
 #[cfg(test)]
 mod tests {
+    /// `SAFE_INTERP_HIDDEN` and `TRANSFERS_CONTROL` were the same bit.
+    ///
+    /// Both were spelled `1 << 61`, so the 65th trait silently aliased the
+    /// 61st. Because `FRAME_SENSITIVE_TRAITS` unions in `TRANSFERS_CONTROL`,
+    /// every safe-interp-hidden command — `file`, `source`, `encoding`,
+    /// `open`, … — read as frame-sensitive and had the inline-proc code
+    /// action suppressed, while `break`/`continue`/`yield`/`yieldto`/
+    /// `tailcall` read as safe-interp-hidden.
+    ///
+    /// The two are now separate enum variants, so the aliasing is
+    /// unrepresentable rather than merely fixed. This pins the *behaviour*
+    /// that was wrong, which a type-level guarantee alone does not cover.
+    #[test]
+    fn safe_interp_hidden_is_not_control_transfer() {
+        let reg = CommandRegistry::build_default();
+        assert_ne!(Traits::TRANSFERS_CONTROL, Traits::SAFE_INTERP_HIDDEN);
+
+        for name in ["break", "continue", "yield", "yieldto", "tailcall"] {
+            let spec = reg.get(name).expect("control-transfer command");
+            assert!(
+                spec.traits.contains(Traits::TRANSFERS_CONTROL),
+                "{name} must transfer control"
+            );
+            assert!(
+                !spec.traits.contains(Traits::SAFE_INTERP_HIDDEN),
+                "{name} is not hidden in a safe interpreter"
+            );
+            assert!(reg.is_frame_sensitive(name), "{name} is frame-sensitive");
+        }
+
+        // Safe-hidden commands carrying no *other* frame-sensitive trait.
+        // These are the ones the alias was wrongly marking: each had the
+        // inline-proc code action suppressed on it.
+        for name in [
+            "file", "encoding", "open", "socket", "exec", "cd", "pwd", "glob", "load", "unload",
+        ] {
+            let spec = reg.get(name).expect("safe-hidden command");
+            assert!(
+                spec.traits.contains(Traits::SAFE_INTERP_HIDDEN),
+                "{name} is hidden in a safe interpreter"
+            );
+            assert!(
+                !spec.traits.contains(Traits::TRANSFERS_CONTROL),
+                "{name} does not transfer control"
+            );
+            assert!(
+                !reg.is_frame_sensitive(name),
+                "{name} must not be frame-sensitive — the alias suppressed the \
+                 inline-proc code action on it"
+            );
+        }
+
+        // The correction must not swing too far: `source` and `exit` are
+        // frame-sensitive on their own merits (a barrier and a block
+        // terminator respectively), and stay so.
+        for name in ["source", "exit"] {
+            assert!(
+                reg.is_frame_sensitive(name),
+                "{name} is frame-sensitive independently of the trait alias"
+            );
+        }
+    }
+
     use super::*;
 
     #[test]

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -18,385 +18,579 @@
 
 //! Behavioural trait flags for commands.
 //!
-//! Each bit replaces one `bool` field from `CommandSpec`.
-//! Consumers query traits via `spec.traits.contains(Traits::CONTROL_FLOW)`
-//! instead of matching on command name strings.
+//! Each flag replaces one `bool` field from `CommandSpec`. Consumers query
+//! traits via `spec.traits.contains(Traits::CONTROL_FLOW)` instead of matching
+//! on command name strings.
+//!
+//! # Why an enum and not `bitflags`
+//!
+//! Every flag is declared **once**, by name, in [`declare_traits!`] below. Its
+//! bit is the enum discriminant the compiler assigns — no bit number is ever
+//! written down, so two flags cannot be given the same one. That is not a
+//! checked invariant; it is an unrepresentable state.
+//!
+//! This matters because it already went wrong. Under `bitflags` these were
+//! spelled `1 << 61` and `1 << 61`:
+//!
+//! ```text
+//! const TRANSFERS_CONTROL  = 1 << 61;
+//! const SAFE_INTERP_HIDDEN = 1 << 61;
+//! ```
+//!
+//! `bitflags` cannot reject that — two constants sharing a value is a
+//! supported feature there, used for composite masks like `const RW = R | W`.
+//! So the `u64` silently held 65 flags in 64 bits and the two names became one
+//! flag: every `SAFE_INTERP_HIDDEN` command (`file`, `source`, `encoding`,
+//! `open`, …) read as control-transferring and therefore as *frame-sensitive*,
+//! suppressing the inline-proc code action on all of them, while `break`,
+//! `continue`, `yield`, `yieldto` and `tailcall` read as safe-interp-hidden.
+//!
+//! The macro also generates [`Trait::name`] as an exhaustive `match`, so a new
+//! flag fails to compile until it is named — the string table cannot drift
+//! from the flags either.
 
-use bitflags::bitflags;
+use std::fmt;
+use std::ops::{BitOr, BitOrAssign};
 
-bitflags! {
-    /// Declarative behavioural traits for a command.
-    ///
-    /// Packed into a single `u64` — compact storage, fast intersection
-    /// and containment queries on a single spec. Whole-registry
-    /// trait-membership queries
-    /// ([`crate::registry::CommandRegistry::commands_with_trait`])
-    /// scan the spec table in O(N) today; a precomputed trait index
-    /// is a future optimisation.
-    #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
-    pub struct Traits: u64 {
-        // Control flow
-        /// Command is a control-flow construct (`if`, `for`, `while`, `switch`).
-        const CONTROL_FLOW              = 1 << 0;
-        /// Language keyword for semantic token classification.
-        const LANGUAGE_KEYWORD          = 1 << 1;
-        /// First expression argument is in boolean context (`if`, `while`, `for`).
-        const HAS_BOOLEAN_COND          = 1 << 2;
-        /// Unconditionally terminates the current block (`error`, `return`, `exit`).
-        const TERMINATES_BLOCK          = 1 << 3;
+/// Declare every behavioural trait exactly once.
+///
+/// `Variant => CONST_NAME;` generates the [`Trait`] variant, the [`Traits`]
+/// single-flag constant, and the arm of [`Trait::name`]. Bits come from the
+/// discriminants the compiler assigns, so ordering is free and duplication is
+/// impossible.
+macro_rules! declare_traits {
+    ($( $(#[$meta:meta])* $variant:ident => $konst:ident );* $(;)?) => {
+        /// The identity of a single behavioural trait.
+        ///
+        /// One variant per flag. Its bit is its discriminant — see the module
+        /// docs for why no bit is written by hand.
+        #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+        #[repr(u8)]
+        #[allow(missing_docs)] // Documented on the matching `Traits` constant.
+        pub enum Trait {
+            $( $(#[$meta])* $variant ),*
+        }
 
-        // Loop/body structure
-        /// Contains a loop body (`for`, `while`, `foreach`).
-        const HAS_LOOP_BODY             = 1 << 4;
-        /// Forbid inlining body arguments.
-        const NEVER_INLINE_BODY         = 1 << 5;
-        /// CFG header with list-expression args evaluated once (`foreach`, `lmap`).
-        const LOOP_LIST_HEADER          = 1 << 6;
+        impl Trait {
+            /// Every declared trait, in declaration order.
+            pub const ALL: &'static [Trait] = &[ $( Trait::$variant ),* ];
 
-        // Purity and optimisation
-        /// Side-effect-free command.
-        const PURE                      = 1 << 7;
-        /// Candidate for common subexpression elimination.
-        const CSE_CANDIDATE             = 1 << 8;
-        /// Pure evaluation (`expr` — side-effect-free when braced).
-        const PURE_EVALUATION           = 1 << 9;
+            /// The trait's screaming-snake name, as written in a spec literal.
+            ///
+            /// Exhaustive by construction: adding a variant without a name
+            /// here is a compile error.
+            #[must_use]
+            pub const fn name(self) -> &'static str {
+                match self { $( Trait::$variant => stringify!($konst) ),* }
+            }
+        }
 
-        // Variable semantics
-        /// Defines a procedure (`proc`).
-        const DEFINES_PROCEDURE         = 1 << 10;
-        /// Destroys/removes a variable (`unset`).
-        const DESTROYS_VARIABLE         = 1 << 11;
-        /// Reads the target variable before writing (`incr`, `append`, `lappend`).
-        const READS_BEFORE_WRITE        = 1 << 12;
-        /// Creates a scope alias — upvar-like binding (`upvar`, `global`, `variable`).
-        const CREATES_SCOPE_ALIAS       = 1 << 13;
-        /// Creates a runtime control-flow barrier (`eval`, `uplevel`, `upvar`).
-        const CREATES_BARRIER           = 1 << 14;
+        impl Traits {
+            $( $(#[$meta])* pub const $konst: Self = Self::of(&[Trait::$variant]); )*
+        }
+    };
+}
 
-        // Analysis check dispatch
-        /// Evaluates code dynamically (`eval`, `uplevel`).
-        const EVALUATES_CODE            = 1 << 15;
-        /// Performs backslash/variable substitution (`subst`).
-        const PERFORMS_SUBSTITUTION      = 1 << 16;
-        /// Opens a channel (`open`).
-        const OPENS_CHANNEL             = 1 << 17;
-        /// Sources a file (`source`).
-        const SOURCES_FILE              = 1 << 18;
-        /// Has a switch body (`switch`).
-        const HAS_SWITCH_BODY           = 1 << 19;
-        /// String/list confusion risk (`append`).
-        const STRING_LIST_CONFUSION     = 1 << 20;
-        /// Configures a channel (`fconfigure`, `chan configure`).
-        const CONFIGURES_CHANNEL        = 1 << 21;
-        /// Has `interp eval` subcommand.
-        const HAS_INTERP_EVAL           = 1 << 22;
-        /// Has destructive operations (`file delete`, `namespace delete`).
-        const HAS_DESTRUCTIVE_OPS       = 1 << 23;
-        /// iRules event handler (`when`).
-        const IS_EVENT_HANDLER          = 1 << 24;
-        /// Returns unnormalised HTTP path/URI/query.
-        const UNNORMALISED_HTTP_GETTER  = 1 << 25;
+/// A set of behavioural traits.
+///
+/// A `u128` bitset over [`Trait`]. The only way to set a bit is to name a
+/// `Trait`, so the set cannot contain a flag that was never declared.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Default)]
+pub struct Traits(u128);
 
-        // Output/value traits
-        /// Returns a filesystem path (`pwd`, `file join`).
-        const RETURNS_PATH              = 1 << 26;
-        /// Performs unescaping/decoding (`subst`, `URI::decode`).
-        const IS_UNESCAPE              = 1 << 27;
-        /// Produces a canonical Tcl list (`list`, `concat`).
-        const PRODUCES_CANONICAL_LIST   = 1 << 28;
-
-        /// Quotes its arguments into a well-formed command reference: when
-        /// the first argument is a literal command name, evaluating the
-        /// result invokes that command with the remaining arguments
-        /// appended verbatim (`list cmd $a $b` → `cmd $a $b`, each word
-        /// preserved regardless of its runtime value). Set on `list` only —
-        /// **not** `concat`, whose plain string-join does not give the same
-        /// per-word quoting guarantee for a dynamic value, so it is unsafe
-        /// to reinterpret the same way. The idiomatic way to build a
-        /// deferred callback / command prefix around a dynamic value
-        /// (`package ifneeded name ver [list apply {params} {body} $dir]`,
-        /// `button .b -command [list doSomething $x]`) rather than a
-        /// literal braced prefix. Consulted wherever a
-        /// [`crate::arg_role::ArgRole::CommandPrefix`] /
-        /// [`crate::arg_role::ArgRole::Body`] /
-        /// [`crate::arg_role::ArgRole::LambdaLiteral`] argument position
-        /// needs to recognise this quoting shape generically — no command
-        /// name appears in the consumer.
-        const BUILDS_COMMAND_PREFIX     = 1 << 30;
-
-        // Safety
-        /// Inherently dangerous command.
-        const UNSAFE                    = 1 << 29;
-        /// Password option command.
-        const PASSWORD_OPTION           = 1 << 31;
-
-        // iRules-specific
-        /// Side-switching command (`clientside`/`serverside`).
-        const IS_SIDE_SWITCH            = 1 << 32;
-        /// Must appear at iRules top level (`proc`, `when`, `timing`).
-        const IRULES_TOP_LEVEL_ONLY     = 1 << 33;
-        /// TclOO metaclass (`oo::class`, `oo::abstract`).
-        const IS_OO_METACLASS           = 1 << 34;
-
-        // Codegen/diagram
-        /// Included in diagram extraction.
-        const DIAGRAM_ACTION            = 1 << 35;
-        /// Needs `startCommand` bytecode instruction.
-        const NEEDS_START_CMD           = 1 << 36;
-
-        // Taint
-        /// Command is a taint sink (absorbs tainted data).
-        const TAINT_SINK                = 1 << 37;
-        /// Command returns attacker-controlled data
-        /// (`gets`, `read`, `exec`, `socket`, …).
-        const TAINT_SOURCE              = 1 << 38;
-        /// Command operates on attacker-controlled iRules data
-        /// (any reachable form of `HTTP::*` / `URI::*` / `IP::*` /
-        /// `TCP::*` / `UDP::*` / `SSL::*` / `STREAM::*`).
-        const IRULES_DATA_GETTER        = 1 << 39;
-
-        /// Creates a runtime scope-alias barrier whose VarWrite
-        /// args are vararg lists (`global x y z`, `variable a b c`,
-        /// `upvar 1 a b 1 c d`).  The analyser's `var_scoping` pass
-        /// handles the per-arg list; SSA must not produce partial
-        /// defs from `arg_roles[0]`.
-        const CREATES_DYNAMIC_BARRIER   = 1 << 40;
-
-        /// Command invokes a user-defined Tcl procedure named by
-        /// its first argument.  Set on the iRules `call` command
-        /// (`call PROC_NAME ?ARGS?`).  Used by the LSP completion
-        /// provider to surface user-proc names — and only those,
-        /// not built-in commands — at word-index 1.
-        const INVOKES_USER_PROC         = 1 << 41;
-
-        /// Core Tcl built-in that the bytecode compiler special-cases
-        /// (or that is otherwise load-bearing as a literal command
-        /// word).  Re-invoking such a command through a `$var`
-        /// command alias would defeat byte-compilation or change
-        /// semantics, so the minifier never rewrites these heads to
-        /// `$alias`.  Single source of truth for the minifier's
-        /// former `_BUILTIN_SKIP` list; query via
-        /// [`crate::registry::CommandRegistry::is_byte_compiled`].
-        const BYTE_COMPILED             = 1 << 42;
-
-        /// Command head incidentally matches the
-        /// `HEAD NAME BRACED BRACED` four-token shape but is **not** a
-        /// proc-factory wrapper, so the signature scanner must not
-        /// treat it as one.  Single source of truth for the analyser's
-        /// former `_FACTORY_SKIP_HEADS` list (registered heads only;
-        /// non-command heads like `method` / `itcl::class` are handled
-        /// by a small residual set in the scanner).
-        const NOT_PROC_FACTORY          = 1 << 43;
-
-        /// Command whose codegen always lowers to a dedicated runtime
-        /// helper (or to a structured IR node) and never falls back to
-        /// the interpreter — so a call to it needs no runtime frame in
-        /// the callee.  The var-escape analysis treats only these as
-        /// frame-free.  Single source of truth for the former
-        /// `_FRAMELESS_RUNTIME_COMMANDS` allow-list.  Keep audited:
-        /// stamping a command that secretly eval-falls-back would
-        /// break eval-inside-proc semantics in escape-free procs.
-        const FRAMELESS_RUNTIME         = 1 << 44;
-
-        /// First argument is a variable *name* (read / write / modify),
-        /// not a value — `set` / `incr` / `append` / `lappend` / `unset`.
-        /// The var-escape analysis uses this to detect dynamic-name forms
-        /// (`set $n value`). Single source of truth for the former
-        /// `NAME_FIRST_COMMANDS` allow-list.
-        const FIRST_ARG_VARNAME         = 1 << 45;
-
-        /// A `VarRead`-role argument names the *whole* array, not a single
-        /// element (`array` / `parray`), so a write to any element is
-        /// observed by the read. Single source of truth for the former
-        /// `WHOLE_ARRAY_COMMANDS` allow-list.
-        const WHOLE_ARRAY_ARG           = 1 << 46;
-
-        /// Executes a body through the interpreter, opening a
-        /// name-resolution channel back into the local frame — `eval` /
-        /// `uplevel` / `apply` / `source` / `namespace` / `interp`. The
-        /// var-escape slot resolver treats a frame reached this way as
-        /// hash-backed. Single source of truth for the former
-        /// `DYNAMIC_EVAL_COMMANDS` allow-list. (Distinct from
-        /// `HAS_INTERP_EVAL` / `CREATES_DYNAMIC_BARRIER`, which only some
-        /// of these carry.)
-        const DYNAMIC_EVAL_BODY         = 1 << 47;
-
-        /// (Subcommand) introspects program state by variable *name* —
-        /// `info exists|vars|locals|args|default`. The var-escape slot
-        /// resolver treats the named variable as ineligible for a slot.
-        /// Single source of truth for the former
-        /// `INFO_INTROSPECTING_SUBCMDS` list.
-        const INTROSPECTS_BY_NAME       = 1 << 48;
-
-        /// (Subcommand) targets a variable by *name* —
-        /// `trace add|remove|info|variable|vdelete|vinfo`. Used by the
-        /// var-escape slot resolver. Single source of truth for the former
-        /// `TRACE_NAME_TARGETING` list.
-        const TARGETS_VARIABLE_BY_NAME  = 1 << 49;
-
-        /// Aliases / reads / writes variables through the frame's *hash
-        /// bucket* by name (`upvar` / `global` / `variable` / `lassign` /
-        /// `lset` / `regexp` / `regsub` / `scan` / `binary` / `vwait` /
-        /// `tkwait`), so a named variable it touches cannot live in an
-        /// indexed slot. Single source of truth for the former
-        /// `FRAME_HASH_BUILTINS` list.
-        const FRAME_HASH_BUILTIN        = 1 << 50;
-
-        /// A Tcl auto-loading / library proc that user code is expected to
-        /// redefine (`unknown`, `auto_*`, `pkg_*`, `tclLog`,
-        /// `tcl_findLibrary`, the `tcl_*Word*` helpers, …), so redefining
-        /// it must not fire the W113 "overrides a built-in" warning.
-        /// Single source of truth for the former
-        /// `OVERRIDABLE_LIBRARY_PROCS` list.
-        const OVERRIDABLE_LIBRARY_PROC  = 1 << 51;
-
-        /// The WASM backend lowers this command to a structural construct
-        /// that imports / emits no runtime helper of its own (`foreach`,
-        /// `namespace`, `package`, `proc`).  Consulted by the WASM import
-        /// collector.
-        const WASM_EMITS_NOTHING        = 1 << 52;
-
-        /// The registry's simple `min..=max` [`crate::Arity`] is a coarse
-        /// floor/ceiling only — this command's real grammar is a clause
-        /// chain validated by [`crate::spec::CommandSpec::clause_shape_check`]
-        /// (`if`'s `elseif`/`else` chain). The generic arity floor/ceiling
-        /// diagnostic (E002/E003) skips a command carrying this trait so its
-        /// dedicated structural diagnostic owns arity together with clause
-        /// shape — one precise diagnostic per malformed call instead of a
-        /// redundant generic one alongside it.
-        const STRUCTURALLY_CHECKED_ARITY = 1 << 54;
-
-        /// The command concatenates its *entire* argument list into a single
-        /// expression (`expr` — `expr $a + $b` evaluates the one expression
-        /// `$a + $b`). This differs from commands whose expression is a single
-        /// bounded argument (`if` / `while` / `for` conditions,
-        /// `control::assert`'s first arg), which mark only that arg
-        /// [`crate::arg_role::ArgRole::Expr`]. Consulted by the formatter's
-        /// `enforceBracedExpr` pass to decide whether to brace the whole tail
-        /// (`expr {$a + $b}`) or just the marked argument. Kept separate from
-        /// the `Expr` arg-role so widening it does not perturb the analyser
-        /// passes (expr re-lexing, W110) that consume the role.
-        const EXPR_CONCATENATES_ARGS    = 1 << 53;
-
-        /// (Subcommand) installs or removes an active variable trace on a
-        /// named target — `trace add|remove|variable|vdelete` (not
-        /// `info`/`vinfo`, which only *query* trace state). A variable
-        /// carrying an active trace can run arbitrary handler code on
-        /// read/write/unset, and a write handler can rewrite the value
-        /// being stored — so no compiler pass may treat a read of this
-        /// variable as equivalent to its last literal assignment, or elide
-        /// an assignment to it as dead. Single source of truth for the
-        /// module-wide traced-variable fact consumed by the propagation
-        /// optimiser (`O102` load-forwarding) and dead-store elimination.
-        const ESTABLISHES_VARIABLE_TRACE = 1 << 56;
-
-        /// Transfers control relative to the enclosing loop, frame, or
-        /// coroutine instead of falling through to the next statement —
-        /// `break` / `continue` (loop exit / re-entry), `tailcall` (frame
-        /// replacement), `yield` / `yieldto` (coroutine suspension).
-        /// Deliberately distinct from [`Traits::TERMINATES_BLOCK`], which
-        /// marks commands that *unwind* the enclosing block/proc
-        /// (`return` / `error` / `exit` / `throw`) — a `break` leaves only
-        /// the loop and a `yield` resumes in place, so stamping them
-        /// `TERMINATES_BLOCK` would corrupt the dead-end analyses (W241,
-        /// taint guard propagation) that consume that trait.  Together the
-        /// two traits give consumers the full "diverts control flow" set;
-        /// the inline-proc code action and the inliner's splice-safety
-        /// query are the current consumers.
-        const TRANSFERS_CONTROL          = 1 << 61;
-
-        /// Teardown/removal command (or subcommand) for which a bare
-        /// `catch {…}` with no result variable is the documented
-        /// fire-and-forget idiom: the operation errors when its target is
-        /// already gone, and ignoring that failure is intentional —
-        /// `close` / `unset` / `rename foo {}`, `after cancel`,
-        /// `chan close`, `array unset`, `dict unset`, `interp delete`,
-        /// `file delete`, `namespace delete|forget`.  Single source of
-        /// truth for W302's suppression set.  Narrower than
-        /// [`crate::spec::SubCommand::destructive`] (`file rename` /
-        /// `file mkdir` are destructive but their failures are real
-        /// errors, not expected teardown noise).
-        const FIRE_AND_FORGET_TEARDOWN   = 1 << 62;
-
-        /// Command is a math-operator head (`+`, `eq`, `ne`, `in`, `ni`,
-        /// and the `tcl::mathop::*` spellings): a real callable command in
-        /// every dialect whose profile has `operators_as_commands`, but
-        /// *never* a command head where operators live only inside `expr`
-        /// (F5 iRules; `tk` when modelled). Replaces the retired
-        /// `NON_IRULES_OPERATORS` membership tag as the operator-head
-        /// marker (dialect-profile-model.md §9, Milestone 5).
-        const OPERATOR_COMMAND           = 1 << 63;
-
-        /// `TclOO` `next` / `nextto` — invokes the next implementation of the
-        /// *currently executing* method along the receiver's MRO. Its
-        /// callee's arity is resolvable only from the enclosing method's
-        /// call-site context (which class/method body the call textually
-        /// sits in), never from a fixed registry range, so both commands
-        /// keep [`crate::Arity::any`] / [`crate::Arity::at_least`] and the
-        /// analyser queues a context-aware candidate for any command
-        /// carrying this trait instead
-        /// (`Analyser::queue_next_arity_candidate`). Set on `next` and
-        /// `nextto`; `nextto`'s explicit target-class first word is
-        /// distinguished structurally via an [`crate::arg_role::ArgRole::Name`]
-        /// at argument index 0, not by command name.
-        const TCLOO_NEXT_CHAIN           = 1 << 55;
-
-        /// Raises a *catchable* exception — completes `TCL_ERROR`, which
-        /// `catch` / `try` intercept: `error` (`Tcl_ErrorObjCmd`,
-        /// `generic/tclCmdAH.c`) and `throw` (`TclNRThrowObjCmd`,
-        /// `generic/tclBasic.c`, 8.6+). The strict subset of
-        /// [`Self::TERMINATES_BLOCK`] that sources an enclosing `try`'s
-        /// on-error edge: `exit` (`Tcl_ExitObjCmd`) terminates the
-        /// process rather than unwinding through exception ranges, and
-        /// `return` pops the frame with `TCL_RETURN`, so neither is a
-        /// throw point. Consumed by the CFG builder's throw-block
-        /// recording.
-        const CATCHABLE_THROW           = 1 << 57;
-
-        /// Jumps to the innermost enclosing loop's *post-loop* target —
-        /// `break`, which completes `TCL_BREAK` (`Tcl_BreakObjCmd`,
-        /// `generic/tclCmdAH.c`); inside a compiled loop the bytecode
-        /// compiler rewrites it into a jump to the loop's break fixup
-        /// site (`TclCompileBreakCmd`, `generic/tclCompCmds.c`).
-        /// Loop-jump classification for the CFG builder's
-        /// `break`/`continue` edge lowering and the inline emitters'
-        /// straight-line-body gate; paired with
-        /// [`Self::CONTINUES_LOOP`].
-        const BREAKS_LOOP               = 1 << 58;
-
-        /// Jumps to the innermost enclosing loop's *next-iteration*
-        /// target — `continue`, which completes `TCL_CONTINUE`
-        /// (`Tcl_ContinueObjCmd`, `generic/tclCmdAH.c`;
-        /// `TclCompileContinueCmd`, `generic/tclCompCmds.c`). The
-        /// other half of the loop-jump classification — see
-        /// [`Self::BREAKS_LOOP`].
-        const CONTINUES_LOOP            = 1 << 59;
-
-        /// Replaces the current procedure's frame — `tailcall`
-        /// (`TclNRTailcallObjCmd`, `generic/tclBasic.c`, 8.6+), which
-        /// schedules its command to run after the frame pops and always
-        /// completes `TCL_RETURN`, so control never resumes in the
-        /// calling body. Deliberately *not* [`Self::TERMINATES_BLOCK`]:
-        /// the analysis CFG promotes it to a proc-exit terminator, but
-        /// codegen must keep the plain fall-through call shape so the
-        /// emitted bytecode matches C Tcl's.
-        const REPLACES_FRAME            = 1 << 60;
-
-        /// Hidden when an interpreter is made **safe** — the command is
-        /// *not* part of C Tcl's safe-interpreter command set (its
-        /// `CmdInfo` row lacks `CMD_IS_SAFE`, or it is a whole-command
-        /// row of `unsafeEnsembleCommands` — `tclBasic.c`, 9.0.4:
-        /// `cd`, `encoding`, `exec`, `exit`, `fconfigure`, `file`,
-        /// `glob`, `load`, `open`, `pwd`, `socket`, `source`,
-        /// `unload`).  A call inside a safe interpreter's evaluation
-        /// context errors `invalid command name` unless the command was
-        /// re-exposed (`interp expose`) or reached via
-        /// `interp invokehidden`; the analyser's safe-context walk
-        /// consults this flag generically — no command name appears in
-        /// the consumer (issue #945 fault 7).
-        const SAFE_INTERP_HIDDEN        = 1 << 61;
+impl Trait {
+    /// This trait's bit. The discriminant *is* the bit index.
+    const fn bit(self) -> u128 {
+        1u128 << (self as u8)
     }
 }
+
+impl Traits {
+    /// The empty set.
+    #[must_use]
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Build a set from a slice of traits, usable in `const` context.
+    #[must_use]
+    pub const fn of(list: &[Trait]) -> Self {
+        let (mut acc, mut i) = (0u128, 0);
+        while i < list.len() {
+            acc |= list[i].bit();
+            i += 1;
+        }
+        Self(acc)
+    }
+
+    /// Whether no trait is set.
+    #[must_use]
+    pub const fn is_empty(self) -> bool {
+        self.0 == 0
+    }
+
+    /// Whether every trait in `other` is set here.
+    #[must_use]
+    pub const fn contains(self, other: Self) -> bool {
+        self.0 & other.0 == other.0
+    }
+
+    /// Whether any trait is set in both.
+    #[must_use]
+    pub const fn intersects(self, other: Self) -> bool {
+        self.0 & other.0 != 0
+    }
+
+    /// Set union, usable in `const` context (`BitOr` cannot be).
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self(self.0 | other.0)
+    }
+
+    /// Add every trait in `other`.
+    pub const fn insert(&mut self, other: Self) {
+        self.0 |= other.0;
+    }
+
+    /// Remove every trait in `other`.
+    pub const fn remove(&mut self, other: Self) {
+        self.0 &= !other.0;
+    }
+
+    /// How many traits are set.
+    #[must_use]
+    pub const fn len(self) -> u32 {
+        self.0.count_ones()
+    }
+
+    /// The traits set here, in declaration order.
+    ///
+    /// Replaces `bitflags`' `iter_names`, and is the single source for every
+    /// consumer that needs to render a trait set as names.
+    pub fn iter(self) -> impl Iterator<Item = Trait> {
+        Trait::ALL
+            .iter()
+            .copied()
+            .filter(move |t| self.0 & t.bit() != 0)
+    }
+
+    /// The names of the traits set here, in declaration order.
+    pub fn iter_names(self) -> impl Iterator<Item = &'static str> {
+        self.iter().map(Trait::name)
+    }
+}
+
+impl BitOr for Traits {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl BitOrAssign for Traits {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+impl FromIterator<Trait> for Traits {
+    fn from_iter<I: IntoIterator<Item = Trait>>(iter: I) -> Self {
+        let mut out = Self::empty();
+        for t in iter {
+            out.0 |= t.bit();
+        }
+        out
+    }
+}
+
+impl fmt::Display for Traits {
+    /// `A | B | C`, or `(empty)`.
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if self.is_empty() {
+            return f.write_str("(empty)");
+        }
+        let mut first = true;
+        for name in self.iter_names() {
+            if !first {
+                f.write_str(" | ")?;
+            }
+            f.write_str(name)?;
+            first = false;
+        }
+        Ok(())
+    }
+}
+
+declare_traits! {
+    // Control flow
+    /// Command is a control-flow construct (`if`, `for`, `while`, `switch`).
+    ControlFlow => CONTROL_FLOW;
+    /// Language keyword for semantic token classification.
+    LanguageKeyword => LANGUAGE_KEYWORD;
+    /// First expression argument is in boolean context (`if`, `while`, `for`).
+    HasBooleanCond => HAS_BOOLEAN_COND;
+    /// Unconditionally terminates the current block (`error`, `return`, `exit`).
+    TerminatesBlock => TERMINATES_BLOCK;
+
+    // Loop/body structure
+    /// Contains a loop body (`for`, `while`, `foreach`).
+    HasLoopBody => HAS_LOOP_BODY;
+    /// Forbid inlining body arguments.
+    NeverInlineBody => NEVER_INLINE_BODY;
+    /// CFG header with list-expression args evaluated once (`foreach`, `lmap`).
+    LoopListHeader => LOOP_LIST_HEADER;
+
+    // Purity and optimisation
+    /// Side-effect-free command.
+    Pure => PURE;
+    /// Candidate for common subexpression elimination.
+    CseCandidate => CSE_CANDIDATE;
+    /// Pure evaluation (`expr` — side-effect-free when braced).
+    PureEvaluation => PURE_EVALUATION;
+
+    // Variable semantics
+    /// Defines a procedure (`proc`).
+    DefinesProcedure => DEFINES_PROCEDURE;
+    /// Destroys/removes a variable (`unset`).
+    DestroysVariable => DESTROYS_VARIABLE;
+    /// Reads the target variable before writing (`incr`, `append`, `lappend`).
+    ReadsBeforeWrite => READS_BEFORE_WRITE;
+    /// Creates a scope alias — upvar-like binding (`upvar`, `global`, `variable`).
+    CreatesScopeAlias => CREATES_SCOPE_ALIAS;
+    /// Creates a runtime control-flow barrier (`eval`, `uplevel`, `upvar`).
+    CreatesBarrier => CREATES_BARRIER;
+
+    // Analysis check dispatch
+    /// Evaluates code dynamically (`eval`, `uplevel`).
+    EvaluatesCode => EVALUATES_CODE;
+    /// Performs backslash/variable substitution (`subst`).
+    PerformsSubstitution => PERFORMS_SUBSTITUTION;
+    /// Opens a channel (`open`).
+    OpensChannel => OPENS_CHANNEL;
+    /// Sources a file (`source`).
+    SourcesFile => SOURCES_FILE;
+    /// Has a switch body (`switch`).
+    HasSwitchBody => HAS_SWITCH_BODY;
+    /// String/list confusion risk (`append`).
+    StringListConfusion => STRING_LIST_CONFUSION;
+    /// Configures a channel (`fconfigure`, `chan configure`).
+    ConfiguresChannel => CONFIGURES_CHANNEL;
+    /// Has `interp eval` subcommand.
+    HasInterpEval => HAS_INTERP_EVAL;
+    /// Has destructive operations (`file delete`, `namespace delete`).
+    HasDestructiveOps => HAS_DESTRUCTIVE_OPS;
+    /// iRules event handler (`when`).
+    IsEventHandler => IS_EVENT_HANDLER;
+    /// Returns unnormalised HTTP path/URI/query.
+    UnnormalisedHttpGetter => UNNORMALISED_HTTP_GETTER;
+
+    // Output/value traits
+    /// Returns a filesystem path (`pwd`, `file join`).
+    ReturnsPath => RETURNS_PATH;
+    /// Performs unescaping/decoding (`subst`, `URI::decode`).
+    IsUnescape => IS_UNESCAPE;
+    /// Produces a canonical Tcl list (`list`, `concat`).
+    ProducesCanonicalList => PRODUCES_CANONICAL_LIST;
+
+    /// Quotes its arguments into a well-formed command reference: when
+    /// the first argument is a literal command name, evaluating the
+    /// result invokes that command with the remaining arguments
+    /// appended verbatim (`list cmd $a $b` → `cmd $a $b`, each word
+    /// preserved regardless of its runtime value). Set on `list` only —
+    /// **not** `concat`, whose plain string-join does not give the same
+    /// per-word quoting guarantee for a dynamic value, so it is unsafe
+    /// to reinterpret the same way. The idiomatic way to build a
+    /// deferred callback / command prefix around a dynamic value
+    /// (`package ifneeded name ver [list apply {params} {body} $dir]`,
+    /// `button .b -command [list doSomething $x]`) rather than a
+    /// literal braced prefix. Consulted wherever a
+    /// [`crate::arg_role::ArgRole::CommandPrefix`] /
+    /// [`crate::arg_role::ArgRole::Body`] /
+    /// [`crate::arg_role::ArgRole::LambdaLiteral`] argument position
+    /// needs to recognise this quoting shape generically — no command
+    /// name appears in the consumer.
+    BuildsCommandPrefix => BUILDS_COMMAND_PREFIX;
+
+    // Safety
+    /// Inherently dangerous command.
+    Unsafe => UNSAFE;
+    /// Password option command.
+    PasswordOption => PASSWORD_OPTION;
+
+    // iRules-specific
+    /// Side-switching command (`clientside`/`serverside`).
+    IsSideSwitch => IS_SIDE_SWITCH;
+    /// Must appear at iRules top level (`proc`, `when`, `timing`).
+    IrulesTopLevelOnly => IRULES_TOP_LEVEL_ONLY;
+    /// `TclOO` metaclass (`oo::class`, `oo::abstract`).
+    IsOoMetaclass => IS_OO_METACLASS;
+
+    // Codegen/diagram
+    /// Included in diagram extraction.
+    DiagramAction => DIAGRAM_ACTION;
+    /// Needs `startCommand` bytecode instruction.
+    NeedsStartCmd => NEEDS_START_CMD;
+
+    // Taint
+    /// Command is a taint sink (absorbs tainted data).
+    TaintSink => TAINT_SINK;
+    /// Command returns attacker-controlled data
+    /// (`gets`, `read`, `exec`, `socket`, …).
+    TaintSource => TAINT_SOURCE;
+    /// Command operates on attacker-controlled iRules data
+    /// (any reachable form of `HTTP::*` / `URI::*` / `IP::*` /
+    /// `TCP::*` / `UDP::*` / `SSL::*` / `STREAM::*`).
+    IrulesDataGetter => IRULES_DATA_GETTER;
+
+    /// Creates a runtime scope-alias barrier whose `VarWrite`
+    /// args are vararg lists (`global x y z`, `variable a b c`,
+    /// `upvar 1 a b 1 c d`).  The analyser's `var_scoping` pass
+    /// handles the per-arg list; SSA must not produce partial
+    /// defs from `arg_roles[0]`.
+    CreatesDynamicBarrier => CREATES_DYNAMIC_BARRIER;
+
+    /// Command invokes a user-defined Tcl procedure named by
+    /// its first argument.  Set on the iRules `call` command
+    /// (`call PROC_NAME ?ARGS?`).  Used by the LSP completion
+    /// provider to surface user-proc names — and only those,
+    /// not built-in commands — at word-index 1.
+    InvokesUserProc => INVOKES_USER_PROC;
+
+    /// Core Tcl built-in that the bytecode compiler special-cases
+    /// (or that is otherwise load-bearing as a literal command
+    /// word).  Re-invoking such a command through a `$var`
+    /// command alias would defeat byte-compilation or change
+    /// semantics, so the minifier never rewrites these heads to
+    /// `$alias`.  Single source of truth for the minifier's
+    /// former `_BUILTIN_SKIP` list; query via
+    /// [`crate::registry::CommandRegistry::is_byte_compiled`].
+    ByteCompiled => BYTE_COMPILED;
+
+    /// Command head incidentally matches the
+    /// `HEAD NAME BRACED BRACED` four-token shape but is **not** a
+    /// proc-factory wrapper, so the signature scanner must not
+    /// treat it as one.  Single source of truth for the analyser's
+    /// former `_FACTORY_SKIP_HEADS` list (registered heads only;
+    /// non-command heads like `method` / `itcl::class` are handled
+    /// by a small residual set in the scanner).
+    NotProcFactory => NOT_PROC_FACTORY;
+
+    /// Command whose codegen always lowers to a dedicated runtime
+    /// helper (or to a structured IR node) and never falls back to
+    /// the interpreter — so a call to it needs no runtime frame in
+    /// the callee.  The var-escape analysis treats only these as
+    /// frame-free.  Single source of truth for the former
+    /// `_FRAMELESS_RUNTIME_COMMANDS` allow-list.  Keep audited:
+    /// stamping a command that secretly eval-falls-back would
+    /// break eval-inside-proc semantics in escape-free procs.
+    FramelessRuntime => FRAMELESS_RUNTIME;
+
+    /// First argument is a variable *name* (read / write / modify),
+    /// not a value — `set` / `incr` / `append` / `lappend` / `unset`.
+    /// The var-escape analysis uses this to detect dynamic-name forms
+    /// (`set $n value`). Single source of truth for the former
+    /// `NAME_FIRST_COMMANDS` allow-list.
+    FirstArgVarname => FIRST_ARG_VARNAME;
+
+    /// A `VarRead`-role argument names the *whole* array, not a single
+    /// element (`array` / `parray`), so a write to any element is
+    /// observed by the read. Single source of truth for the former
+    /// `WHOLE_ARRAY_COMMANDS` allow-list.
+    WholeArrayArg => WHOLE_ARRAY_ARG;
+
+    /// Executes a body through the interpreter, opening a
+    /// name-resolution channel back into the local frame — `eval` /
+    /// `uplevel` / `apply` / `source` / `namespace` / `interp`. The
+    /// var-escape slot resolver treats a frame reached this way as
+    /// hash-backed. Single source of truth for the former
+    /// `DYNAMIC_EVAL_COMMANDS` allow-list. (Distinct from
+    /// `HAS_INTERP_EVAL` / `CREATES_DYNAMIC_BARRIER`, which only some
+    /// of these carry.)
+    DynamicEvalBody => DYNAMIC_EVAL_BODY;
+
+    /// (Subcommand) introspects program state by variable *name* —
+    /// `info exists|vars|locals|args|default`. The var-escape slot
+    /// resolver treats the named variable as ineligible for a slot.
+    /// Single source of truth for the former
+    /// `INFO_INTROSPECTING_SUBCMDS` list.
+    IntrospectsByName => INTROSPECTS_BY_NAME;
+
+    /// (Subcommand) targets a variable by *name* —
+    /// `trace add|remove|info|variable|vdelete|vinfo`. Used by the
+    /// var-escape slot resolver. Single source of truth for the former
+    /// `TRACE_NAME_TARGETING` list.
+    TargetsVariableByName => TARGETS_VARIABLE_BY_NAME;
+
+    /// Aliases / reads / writes variables through the frame's *hash
+    /// bucket* by name (`upvar` / `global` / `variable` / `lassign` /
+    /// `lset` / `regexp` / `regsub` / `scan` / `binary` / `vwait` /
+    /// `tkwait`), so a named variable it touches cannot live in an
+    /// indexed slot. Single source of truth for the former
+    /// `FRAME_HASH_BUILTINS` list.
+    FrameHashBuiltin => FRAME_HASH_BUILTIN;
+
+    /// A Tcl auto-loading / library proc that user code is expected to
+    /// redefine (`unknown`, `auto_*`, `pkg_*`, `tclLog`,
+    /// `tcl_findLibrary`, the `tcl_*Word*` helpers, …), so redefining
+    /// it must not fire the W113 "overrides a built-in" warning.
+    /// Single source of truth for the former
+    /// `OVERRIDABLE_LIBRARY_PROCS` list.
+    OverridableLibraryProc => OVERRIDABLE_LIBRARY_PROC;
+
+    /// The WASM backend lowers this command to a structural construct
+    /// that imports / emits no runtime helper of its own (`foreach`,
+    /// `namespace`, `package`, `proc`).  Consulted by the WASM import
+    /// collector.
+    WasmEmitsNothing => WASM_EMITS_NOTHING;
+
+    /// The registry's simple `min..=max` [`crate::Arity`] is a coarse
+    /// floor/ceiling only — this command's real grammar is a clause
+    /// chain validated by [`crate::spec::CommandSpec::clause_shape_check`]
+    /// (`if`'s `elseif`/`else` chain). The generic arity floor/ceiling
+    /// diagnostic (E002/E003) skips a command carrying this trait so its
+    /// dedicated structural diagnostic owns arity together with clause
+    /// shape — one precise diagnostic per malformed call instead of a
+    /// redundant generic one alongside it.
+    StructurallyCheckedArity => STRUCTURALLY_CHECKED_ARITY;
+
+    /// The command concatenates its *entire* argument list into a single
+    /// expression (`expr` — `expr $a + $b` evaluates the one expression
+    /// `$a + $b`). This differs from commands whose expression is a single
+    /// bounded argument (`if` / `while` / `for` conditions,
+    /// `control::assert`'s first arg), which mark only that arg
+    /// [`crate::arg_role::ArgRole::Expr`]. Consulted by the formatter's
+    /// `enforceBracedExpr` pass to decide whether to brace the whole tail
+    /// (`expr {$a + $b}`) or just the marked argument. Kept separate from
+    /// the `Expr` arg-role so widening it does not perturb the analyser
+    /// passes (expr re-lexing, W110) that consume the role.
+    ExprConcatenatesArgs => EXPR_CONCATENATES_ARGS;
+
+    /// (Subcommand) installs or removes an active variable trace on a
+    /// named target — `trace add|remove|variable|vdelete` (not
+    /// `info`/`vinfo`, which only *query* trace state). A variable
+    /// carrying an active trace can run arbitrary handler code on
+    /// read/write/unset, and a write handler can rewrite the value
+    /// being stored — so no compiler pass may treat a read of this
+    /// variable as equivalent to its last literal assignment, or elide
+    /// an assignment to it as dead. Single source of truth for the
+    /// module-wide traced-variable fact consumed by the propagation
+    /// optimiser (`O102` load-forwarding) and dead-store elimination.
+    EstablishesVariableTrace => ESTABLISHES_VARIABLE_TRACE;
+
+    /// Transfers control relative to the enclosing loop, frame, or
+    /// coroutine instead of falling through to the next statement —
+    /// `break` / `continue` (loop exit / re-entry), `tailcall` (frame
+    /// replacement), `yield` / `yieldto` (coroutine suspension).
+    /// Deliberately distinct from [`Traits::TERMINATES_BLOCK`], which
+    /// marks commands that *unwind* the enclosing block/proc
+    /// (`return` / `error` / `exit` / `throw`) — a `break` leaves only
+    /// the loop and a `yield` resumes in place, so stamping them
+    /// `TERMINATES_BLOCK` would corrupt the dead-end analyses (W241,
+    /// taint guard propagation) that consume that trait.  Together the
+    /// two traits give consumers the full "diverts control flow" set;
+    /// the inline-proc code action and the inliner's splice-safety
+    /// query are the current consumers.
+    TransfersControl => TRANSFERS_CONTROL;
+
+    /// Teardown/removal command (or subcommand) for which a bare
+    /// `catch {…}` with no result variable is the documented
+    /// fire-and-forget idiom: the operation errors when its target is
+    /// already gone, and ignoring that failure is intentional —
+    /// `close` / `unset` / `rename foo {}`, `after cancel`,
+    /// `chan close`, `array unset`, `dict unset`, `interp delete`,
+    /// `file delete`, `namespace delete|forget`.  Single source of
+    /// truth for W302's suppression set.  Narrower than
+    /// [`crate::spec::SubCommand::destructive`] (`file rename` /
+    /// `file mkdir` are destructive but their failures are real
+    /// errors, not expected teardown noise).
+    FireAndForgetTeardown => FIRE_AND_FORGET_TEARDOWN;
+
+    /// Command is a math-operator head (`+`, `eq`, `ne`, `in`, `ni`,
+    /// and the `tcl::mathop::*` spellings): a real callable command in
+    /// every dialect whose profile has `operators_as_commands`, but
+    /// *never* a command head where operators live only inside `expr`
+    /// (F5 iRules; `tk` when modelled). Replaces the retired
+    /// `NON_IRULES_OPERATORS` membership tag as the operator-head
+    /// marker (dialect-profile-model.md §9, Milestone 5).
+    OperatorCommand => OPERATOR_COMMAND;
+
+    /// `TclOO` `next` / `nextto` — invokes the next implementation of the
+    /// *currently executing* method along the receiver's MRO. Its
+    /// callee's arity is resolvable only from the enclosing method's
+    /// call-site context (which class/method body the call textually
+    /// sits in), never from a fixed registry range, so both commands
+    /// keep [`crate::Arity::any`] / [`crate::Arity::at_least`] and the
+    /// analyser queues a context-aware candidate for any command
+    /// carrying this trait instead
+    /// (`Analyser::queue_next_arity_candidate`). Set on `next` and
+    /// `nextto`; `nextto`'s explicit target-class first word is
+    /// distinguished structurally via an [`crate::arg_role::ArgRole::Name`]
+    /// at argument index 0, not by command name.
+    TclooNextChain => TCLOO_NEXT_CHAIN;
+
+    /// Raises a *catchable* exception — completes `TCL_ERROR`, which
+    /// `catch` / `try` intercept: `error` (`Tcl_ErrorObjCmd`,
+    /// `generic/tclCmdAH.c`) and `throw` (`TclNRThrowObjCmd`,
+    /// `generic/tclBasic.c`, 8.6+). The strict subset of
+    /// [`Self::TERMINATES_BLOCK`] that sources an enclosing `try`'s
+    /// on-error edge: `exit` (`Tcl_ExitObjCmd`) terminates the
+    /// process rather than unwinding through exception ranges, and
+    /// `return` pops the frame with `TCL_RETURN`, so neither is a
+    /// throw point. Consumed by the CFG builder's throw-block
+    /// recording.
+    CatchableThrow => CATCHABLE_THROW;
+
+    /// Jumps to the innermost enclosing loop's *post-loop* target —
+    /// `break`, which completes `TCL_BREAK` (`Tcl_BreakObjCmd`,
+    /// `generic/tclCmdAH.c`); inside a compiled loop the bytecode
+    /// compiler rewrites it into a jump to the loop's break fixup
+    /// site (`TclCompileBreakCmd`, `generic/tclCompCmds.c`).
+    /// Loop-jump classification for the CFG builder's
+    /// `break`/`continue` edge lowering and the inline emitters'
+    /// straight-line-body gate; paired with
+    /// [`Self::CONTINUES_LOOP`].
+    BreaksLoop => BREAKS_LOOP;
+
+    /// Jumps to the innermost enclosing loop's *next-iteration*
+    /// target — `continue`, which completes `TCL_CONTINUE`
+    /// (`Tcl_ContinueObjCmd`, `generic/tclCmdAH.c`;
+    /// `TclCompileContinueCmd`, `generic/tclCompCmds.c`). The
+    /// other half of the loop-jump classification — see
+    /// [`Self::BREAKS_LOOP`].
+    ContinuesLoop => CONTINUES_LOOP;
+
+    /// Replaces the current procedure's frame — `tailcall`
+    /// (`TclNRTailcallObjCmd`, `generic/tclBasic.c`, 8.6+), which
+    /// schedules its command to run after the frame pops and always
+    /// completes `TCL_RETURN`, so control never resumes in the
+    /// calling body. Deliberately *not* [`Self::TERMINATES_BLOCK`]:
+    /// the analysis CFG promotes it to a proc-exit terminator, but
+    /// codegen must keep the plain fall-through call shape so the
+    /// emitted bytecode matches C Tcl's.
+    ReplacesFrame => REPLACES_FRAME;
+
+    /// Hidden when an interpreter is made **safe** — the command is
+    /// *not* part of C Tcl's safe-interpreter command set (its
+    /// `CmdInfo` row lacks `CMD_IS_SAFE`, or it is a whole-command
+    /// row of `unsafeEnsembleCommands` — `tclBasic.c`, 9.0.4:
+    /// `cd`, `encoding`, `exec`, `exit`, `fconfigure`, `file`,
+    /// `glob`, `load`, `open`, `pwd`, `socket`, `source`,
+    /// `unload`).  A call inside a safe interpreter's evaluation
+    /// context errors `invalid command name` unless the command was
+    /// re-exposed (`interp expose`) or reached via
+    /// `interp invokehidden`; the analyser's safe-context walk
+    /// consults this flag generically — no command name appears in
+    /// the consumer (issue #945 fault 7).
+    SafeInterpHidden => SAFE_INTERP_HIDDEN;
+}
+
+/// A `Trait`'s bit is `1 << discriminant`, so the set must fit the `u128`.
+/// Unlike a collision — which the enum makes unrepresentable — running out of
+/// width is a real limit worth failing the build over.
+const _: () = assert!(
+    Trait::ALL.len() <= 128,
+    "more traits than a u128 bitset can hold — widen `Traits` to [u64; N] via a custom bit type"
+);
 
 /// Clause/block words that behave as [`Traits::LANGUAGE_KEYWORD`] tokens but
 /// have no standalone `CommandSpec` — they are never independently invocable

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -24,7 +24,7 @@
 //!
 //! # Why an enum and not `bitflags`
 //!
-//! Every flag is declared **once**, by name, in [`declare_traits!`] below. Its
+//! Every flag is declared **once**, by name, in `declare_traits!` below. Its
 //! bit is the enum discriminant the compiler assigns — no bit number is ever
 //! written down, so two flags cannot be given the same one. That is not a
 //! checked invariant; it is an unrepresentable state.
@@ -58,6 +58,10 @@ use std::ops::{BitOr, BitOrAssign};
 /// single-flag constant, and the arm of [`Trait::name`]. Bits come from the
 /// discriminants the compiler assigns, so ordering is free and duplication is
 /// impossible.
+///
+/// Each doc comment is copied onto *both* generated items, so `Self` in an
+/// intra-doc link would resolve to `Trait` on the variant and `Traits` on the
+/// constant. Spell such links against `Traits` explicitly, never `Self`.
 macro_rules! declare_traits {
     ($( $(#[$meta:meta])* $variant:ident => $konst:ident );* $(;)?) => {
         /// The identity of a single behavioural trait.
@@ -532,7 +536,7 @@ declare_traits! {
     /// `catch` / `try` intercept: `error` (`Tcl_ErrorObjCmd`,
     /// `generic/tclCmdAH.c`) and `throw` (`TclNRThrowObjCmd`,
     /// `generic/tclBasic.c`, 8.6+). The strict subset of
-    /// [`Self::TERMINATES_BLOCK`] that sources an enclosing `try`'s
+    /// [`Traits::TERMINATES_BLOCK`] that sources an enclosing `try`'s
     /// on-error edge: `exit` (`Tcl_ExitObjCmd`) terminates the
     /// process rather than unwinding through exception ranges, and
     /// `return` pops the frame with `TCL_RETURN`, so neither is a
@@ -548,7 +552,7 @@ declare_traits! {
     /// Loop-jump classification for the CFG builder's
     /// `break`/`continue` edge lowering and the inline emitters'
     /// straight-line-body gate; paired with
-    /// [`Self::CONTINUES_LOOP`].
+    /// [`Traits::CONTINUES_LOOP`].
     BreaksLoop => BREAKS_LOOP;
 
     /// Jumps to the innermost enclosing loop's *next-iteration*
@@ -556,14 +560,14 @@ declare_traits! {
     /// (`Tcl_ContinueObjCmd`, `generic/tclCmdAH.c`;
     /// `TclCompileContinueCmd`, `generic/tclCompCmds.c`). The
     /// other half of the loop-jump classification — see
-    /// [`Self::BREAKS_LOOP`].
+    /// [`Traits::BREAKS_LOOP`].
     ContinuesLoop => CONTINUES_LOOP;
 
     /// Replaces the current procedure's frame — `tailcall`
     /// (`TclNRTailcallObjCmd`, `generic/tclBasic.c`, 8.6+), which
     /// schedules its command to run after the frame pops and always
     /// completes `TCL_RETURN`, so control never resumes in the
-    /// calling body. Deliberately *not* [`Self::TERMINATES_BLOCK`]:
+    /// calling body. Deliberately *not* [`Traits::TERMINATES_BLOCK`]:
     /// the analysis CFG promotes it to a proc-exit terminator, but
     /// codegen must keep the plain fall-through call shape so the
     /// emitted bytecode matches C Tcl's.

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -33,7 +33,7 @@
 
 use tcl_dialect::DialectSet;
 use tcl_registry::taint::TaintColour;
-use tcl_registry::traits::Traits;
+use tcl_registry::traits::{Trait, Traits};
 
 /// One selectable value in a picker — the Rust spelling plus a one-line
 /// description.
@@ -513,110 +513,30 @@ pub fn dialect_bit(name: &str) -> Option<DialectSet> {
 }
 
 /// The [`Traits`] bit for a catalogue key from [`TRAITS`].
+///
+/// Resolved against the registry's own flag list, so there is no second table
+/// here to drift out of step with it.
 #[must_use]
 pub fn trait_bit(key: &str) -> Option<Traits> {
-    TRAIT_BITS.iter().find(|(n, _)| *n == key).map(|(_, b)| *b)
+    Trait::ALL
+        .iter()
+        .find(|t| t.name() == key)
+        .map(|t| Traits::of(&[*t]))
 }
 
-/// The catalogue key for each [`Traits`] bit the spec carries, in
-/// [`TRAITS`] order.
+/// The catalogue key for each [`Traits`] flag the spec carries, in
+/// declaration order.
 ///
-/// Deduplicated by bit *value*, not by name. `Traits` is a `u64` with all 64
-/// bits allocated, and `SAFE_INTERP_HIDDEN` currently shares bit 61 with
-/// `TRANSFERS_CONTROL` (see `traits_catalogue_pins_the_known_bit_collision`).
-/// Two names for one bit are indistinguishable at run time, so reporting both
-/// would render a spec that claims a trait its author never set. The first
-/// catalogue entry for a bit wins, which keeps the rendered `.rs`
-/// bit-identical to the spec it came from.
+/// Each flag is a distinct enum variant, so a name maps to exactly one bit and
+/// a bit to exactly one name. This previously had to deduplicate by bit value:
+/// `Traits` was a `u64` holding 65 flags, and `SAFE_INTERP_HIDDEN` shared bit
+/// 61 with `TRANSFERS_CONTROL`, so reporting both would have rendered a spec
+/// claiming a trait its author never set. The registry now derives each bit
+/// from an enum discriminant, which makes that collision unrepresentable.
 #[must_use]
 pub fn trait_keys(traits: Traits) -> Vec<&'static str> {
-    let mut seen = Traits::empty();
-    let mut out = Vec::new();
-    for (name, bit) in TRAIT_BITS {
-        if traits.contains(*bit) && !seen.contains(*bit) {
-            seen |= *bit;
-            out.push(*name);
-        }
-    }
-    out
+    traits.iter_names().collect()
 }
-
-/// Key ↔ bit table backing [`trait_bit`] / [`trait_keys`]. Kept in
-/// [`TRAITS`] order; the `traits_catalogue_matches_bits` test asserts the two
-/// stay in step.
-const TRAIT_BITS: &[(&str, Traits)] = &[
-    ("CONTROL_FLOW", Traits::CONTROL_FLOW),
-    ("LANGUAGE_KEYWORD", Traits::LANGUAGE_KEYWORD),
-    ("HAS_BOOLEAN_COND", Traits::HAS_BOOLEAN_COND),
-    ("TERMINATES_BLOCK", Traits::TERMINATES_BLOCK),
-    ("HAS_LOOP_BODY", Traits::HAS_LOOP_BODY),
-    ("NEVER_INLINE_BODY", Traits::NEVER_INLINE_BODY),
-    ("LOOP_LIST_HEADER", Traits::LOOP_LIST_HEADER),
-    ("PURE", Traits::PURE),
-    ("CSE_CANDIDATE", Traits::CSE_CANDIDATE),
-    ("PURE_EVALUATION", Traits::PURE_EVALUATION),
-    ("DEFINES_PROCEDURE", Traits::DEFINES_PROCEDURE),
-    ("DESTROYS_VARIABLE", Traits::DESTROYS_VARIABLE),
-    ("READS_BEFORE_WRITE", Traits::READS_BEFORE_WRITE),
-    ("CREATES_SCOPE_ALIAS", Traits::CREATES_SCOPE_ALIAS),
-    ("CREATES_BARRIER", Traits::CREATES_BARRIER),
-    ("EVALUATES_CODE", Traits::EVALUATES_CODE),
-    ("PERFORMS_SUBSTITUTION", Traits::PERFORMS_SUBSTITUTION),
-    ("OPENS_CHANNEL", Traits::OPENS_CHANNEL),
-    ("SOURCES_FILE", Traits::SOURCES_FILE),
-    ("HAS_SWITCH_BODY", Traits::HAS_SWITCH_BODY),
-    ("STRING_LIST_CONFUSION", Traits::STRING_LIST_CONFUSION),
-    ("CONFIGURES_CHANNEL", Traits::CONFIGURES_CHANNEL),
-    ("HAS_INTERP_EVAL", Traits::HAS_INTERP_EVAL),
-    ("HAS_DESTRUCTIVE_OPS", Traits::HAS_DESTRUCTIVE_OPS),
-    ("IS_EVENT_HANDLER", Traits::IS_EVENT_HANDLER),
-    ("UNNORMALISED_HTTP_GETTER", Traits::UNNORMALISED_HTTP_GETTER),
-    ("RETURNS_PATH", Traits::RETURNS_PATH),
-    ("IS_UNESCAPE", Traits::IS_UNESCAPE),
-    ("PRODUCES_CANONICAL_LIST", Traits::PRODUCES_CANONICAL_LIST),
-    ("BUILDS_COMMAND_PREFIX", Traits::BUILDS_COMMAND_PREFIX),
-    ("UNSAFE", Traits::UNSAFE),
-    ("PASSWORD_OPTION", Traits::PASSWORD_OPTION),
-    ("IS_SIDE_SWITCH", Traits::IS_SIDE_SWITCH),
-    ("IRULES_TOP_LEVEL_ONLY", Traits::IRULES_TOP_LEVEL_ONLY),
-    ("IS_OO_METACLASS", Traits::IS_OO_METACLASS),
-    ("DIAGRAM_ACTION", Traits::DIAGRAM_ACTION),
-    ("NEEDS_START_CMD", Traits::NEEDS_START_CMD),
-    ("TAINT_SINK", Traits::TAINT_SINK),
-    ("TAINT_SOURCE", Traits::TAINT_SOURCE),
-    ("IRULES_DATA_GETTER", Traits::IRULES_DATA_GETTER),
-    ("CREATES_DYNAMIC_BARRIER", Traits::CREATES_DYNAMIC_BARRIER),
-    ("INVOKES_USER_PROC", Traits::INVOKES_USER_PROC),
-    ("BYTE_COMPILED", Traits::BYTE_COMPILED),
-    ("NOT_PROC_FACTORY", Traits::NOT_PROC_FACTORY),
-    ("FRAMELESS_RUNTIME", Traits::FRAMELESS_RUNTIME),
-    ("FIRST_ARG_VARNAME", Traits::FIRST_ARG_VARNAME),
-    ("WHOLE_ARRAY_ARG", Traits::WHOLE_ARRAY_ARG),
-    ("DYNAMIC_EVAL_BODY", Traits::DYNAMIC_EVAL_BODY),
-    ("INTROSPECTS_BY_NAME", Traits::INTROSPECTS_BY_NAME),
-    ("TARGETS_VARIABLE_BY_NAME", Traits::TARGETS_VARIABLE_BY_NAME),
-    ("FRAME_HASH_BUILTIN", Traits::FRAME_HASH_BUILTIN),
-    ("OVERRIDABLE_LIBRARY_PROC", Traits::OVERRIDABLE_LIBRARY_PROC),
-    ("WASM_EMITS_NOTHING", Traits::WASM_EMITS_NOTHING),
-    (
-        "STRUCTURALLY_CHECKED_ARITY",
-        Traits::STRUCTURALLY_CHECKED_ARITY,
-    ),
-    ("EXPR_CONCATENATES_ARGS", Traits::EXPR_CONCATENATES_ARGS),
-    (
-        "ESTABLISHES_VARIABLE_TRACE",
-        Traits::ESTABLISHES_VARIABLE_TRACE,
-    ),
-    ("TRANSFERS_CONTROL", Traits::TRANSFERS_CONTROL),
-    ("FIRE_AND_FORGET_TEARDOWN", Traits::FIRE_AND_FORGET_TEARDOWN),
-    ("OPERATOR_COMMAND", Traits::OPERATOR_COMMAND),
-    ("TCLOO_NEXT_CHAIN", Traits::TCLOO_NEXT_CHAIN),
-    ("CATCHABLE_THROW", Traits::CATCHABLE_THROW),
-    ("BREAKS_LOOP", Traits::BREAKS_LOOP),
-    ("CONTINUES_LOOP", Traits::CONTINUES_LOOP),
-    ("REPLACES_FRAME", Traits::REPLACES_FRAME),
-    ("SAFE_INTERP_HIDDEN", Traits::SAFE_INTERP_HIDDEN),
-];
 
 /// The [`TaintColour`] bit for a catalogue key from [`TAINT_COLOURS`].
 #[must_use]
@@ -1062,36 +982,38 @@ mod tests {
     }
 
     #[test]
-    fn traits_catalogue_matches_bits() {
+    fn traits_catalogue_matches_the_registry_flags() {
+        // The catalogue's keys must be exactly the registry's declared flags,
+        // in the same order — a new trait shows up in the studio without a
+        // hand-maintained table to update.
         let cat: Vec<&str> = TRAITS.iter().map(|v| v.key).collect();
-        let bits: Vec<&str> = TRAIT_BITS.iter().map(|(n, _)| *n).collect();
-        assert_eq!(cat, bits, "TRAITS and TRAIT_BITS must stay in step");
-        for (name, bit) in TRAIT_BITS {
-            assert_eq!(trait_bit(name), Some(*bit));
-            let keys = trait_keys(*bit);
-            assert_eq!(keys.len(), 1, "one bit must report one key, got {keys:?}");
+        let declared: Vec<&str> = Trait::ALL.iter().map(|t| t.name()).collect();
+        assert_eq!(cat, declared, "TRAITS must match the registry's flags");
+        for t in Trait::ALL {
+            let bit = Traits::of(&[*t]);
+            assert_eq!(trait_bit(t.name()), Some(bit));
+            assert_eq!(trait_keys(bit), vec![t.name()], "one flag, one name");
         }
     }
 
-    /// `Traits` is a `u64` with every bit allocated, and `SAFE_INTERP_HIDDEN`
-    /// was added on top of `TRANSFERS_CONTROL`'s bit 61 — so the two are the
-    /// same flag at run time (issue #1031). This test pins that reality
-    /// rather than hiding
-    /// it: `trait_keys` reports the first name so a rendered spec stays
-    /// bit-identical to its source, and when the registry widens `Traits` and
-    /// gives `SAFE_INTERP_HIDDEN` its own bit, this test fails and the
-    /// catalogue can stop deduplicating.
+    /// Every flag owns a distinct bit.
+    ///
+    /// `SAFE_INTERP_HIDDEN` and `TRANSFERS_CONTROL` were both `1 << 61` under
+    /// `bitflags`, which cannot reject a duplicate value — aliasing is a
+    /// supported feature there. The registry now assigns bits from enum
+    /// discriminants, so this is a property of the type rather than something
+    /// a test can meaningfully defend; the assertion below documents the fixed
+    /// bug for anyone who finds issue #1031.
     #[test]
-    fn traits_catalogue_pins_the_known_bit_collision() {
-        assert_eq!(
-            Traits::TRANSFERS_CONTROL,
-            Traits::SAFE_INTERP_HIDDEN,
-            "bit 61 is shared; if this now differs the registry has been widened"
-        );
-        assert_eq!(
-            trait_keys(Traits::SAFE_INTERP_HIDDEN),
-            vec!["TRANSFERS_CONTROL"]
-        );
+    fn every_trait_has_its_own_bit() {
+        assert_ne!(Traits::TRANSFERS_CONTROL, Traits::SAFE_INTERP_HIDDEN);
+        let mut seen = Traits::empty();
+        for t in Trait::ALL {
+            let bit = Traits::of(&[*t]);
+            assert!(!seen.intersects(bit), "{} reuses a bit", t.name());
+            seen |= bit;
+        }
+        assert_eq!(seen.len() as usize, Trait::ALL.len());
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Fixes #1031. `Traits` was a `bitflags` `u64` holding **65 flags in 64 bits** — `SAFE_INTERP_HIDDEN` and `TRANSFERS_CONTROL` were both spelled `1 << 61`, so the two names were one flag at run time.

**`bitflags` cannot reject that.** Two constants sharing a value is a supported feature there, used for composite masks like `const RW = R | W`, so the library has no way to tell a deliberate alias from an accident. No amount of care in that shape would have caught it, and a const assertion would only have caught it after the fact.

So this stops writing bit numbers. Every flag is declared once:

```rust
declare_traits! {
    /// Command is a control-flow construct (`if`, `for`, `while`, `switch`).
    ControlFlow => CONTROL_FLOW;
    …
}
```

The macro generates the `Trait` enum variant, the `Traits` constant, and the `Trait::name` arm from that one line. Bits are the discriminants the compiler assigns, so **there is no number to duplicate**. Reintroducing the bug is a compile error either way it can be attempted — verified in this tree, not assumed:

| attempt | result |
|---|---|
| reuse a constant name (`SafeInterpHidden => TRANSFERS_CONTROL`) | `error[E0592]: duplicate definitions with name TRANSFERS_CONTROL` |
| reuse a variant name (`TransfersControl => SAFE_INTERP_HIDDEN`) | `error[E0428]: the name TransfersControl is defined multiple times` |

`Traits` becomes a `u128` newtype over those bits, leaving room for 63 more flags. A `const` assert guards the *width* — unlike a collision, running out of room is a real limit worth failing the build over.

### Call sites are untouched

`Traits::A | Traits::B` still works via `BitOr`, and `contains` / `intersects` / `union` remain `const fn`s with the same signatures. **None of the 383 command files needed editing** — the whole change is four files.

## What the aliasing was actually doing

`FRAME_SENSITIVE_TRAITS` unions in `TRANSFERS_CONTROL`, so every safe-interp-hidden command read as frame-sensitive and had the inline-proc code action suppressed, while `break` / `continue` / `yield` / `yieldto` / `tailcall` read as safe-interp-hidden and drew a false W129.

Ten commands were frame-sensitive *purely* through the alias and no longer are: `file`, `encoding`, `open`, `socket`, `exec`, `cd`, `pwd`, `glob`, `load`, `unload`.

`source` and `exit` **stay** frame-sensitive — they carry `CREATES_BARRIER` / `TERMINATES_BLOCK` on their own merits. My first version of the regression test asserted all safe-hidden commands become non-frame-sensitive and failed on `source`; I measured which ones actually changed and wrote the test against that, including an assertion that `source`/`exit` remain frame-sensitive so the correction cannot swing too far.

Auditing all 36 declaring files found **no mis-declarations**: the 5 are exactly Tcl's control-transfer commands and the 31 its `interp create -safe` hidden set, so separating the bits fixes the behaviour with no spec changes.

## Spec studio

`Trait::name` is exhaustive by construction, so the studio drops its **80-entry hand-maintained name table** for `Traits::iter_names()` — and with it the workaround that deduplicated trait names by bit value to avoid rendering a spec claiming a trait its author never set. `traits_catalogue_matches_the_registry_flags` now asserts the studio's descriptive catalogue covers exactly the registry's declared flags, in order, so a new trait reaches the UI with no table to update.

The design contract is rewritten to describe the new arrangement rather than the workaround.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make check-all                          # PASSED
make xtask-check                        # PASSED
make xtask-kcs-index-links              # PASSED
cargo test -p tcl-registry --lib        # 340 passed (339 + the new regression test)
cargo test -p tcl-spec-studio           # 60 passed, incl. the 345-command render sweep
cargo clippy -p tcl-registry -p tcl-spec-studio --all-targets   # 0 findings
cargo check -p tcl-registry --examples  # the three registry examples still build
```

`make test-rust` is re-running against this rebased branch as I open this; **I will report the result in a comment.** An earlier full run on the same content gave 14,500 passed / 0 failed, but that tree differed by later comment-only edits and by the rebase, so I am not claiming it for this commit.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? — **Yes, by correcting one.** No contract's *definition* changed; two traits that were accidentally the same flag are now distinct, which is the documented intent of both. The behavioural consequences are enumerated above and pinned by `registry::tests::safe_interp_hidden_is_not_control_transfer`.
- [x] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/` — the affected note is a design contract rather than a compiler KCS note: `docs/design/contracts/command-spec-studio.md`, updated. The W129 KCS note documents a different gap (bracket indirection) and describes intended behaviour that was never changed, so it needs no edit.
- [x] If I added a new compiler KCS note, I linked it from both indexes — n/a; no new KCS notes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHqVbgdKbCFvfqapwyCJn1

---
_Generated by [Claude Code](https://claude.ai/code/session_01QHqVbgdKbCFvfqapwyCJn1)_