### PR TITLE
Fix issue #977: cross-file call-site evidence for interprocedural seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -921,6 +921,13 @@ labelled `block` / `loop` / `if` for each Tcl construct (`foreach`,
 above every instruction group, and orthogonal control-flow arrows in the
 left gutter.
 
+The **Interproc** tab opens with a *unit scope* card: which registry-declared
+boundaries the file crosses (`package provide`, `source`, `namespace export`,
+…), whether the analysis had a cross-file view of the workspace, and the
+per-argument verdict behind every interprocedural constant fold.  It is the
+first place to look when a constant fold — or its absence — is a surprise;
+the same data is the `unitScope` view in the `tcl explore` CLI and TUI.
+
 The IR, CFG, SSA, bytecode, and WASM tabs each carry an **optimiser lens**
 (`off` / `on` / `diff`).  The `diff` mode compares the relevant node — IR
 statement, CFG block, or bytecode instruction — rather than raw text, so

--- a/docs/GLOSSARY.md
+++ b/docs/GLOSSARY.md
@@ -737,6 +737,29 @@ safe interpreter) contributes no edge.
 
 ## Phase 7 — Interprocedural analysis and specialised passes
 
+### Unit linkage
+
+The registry-declared fact that a file is part of a **bigger program**, and
+so has callers its own compilation unit cannot enumerate. Carried as `Traits`
+bits on the command specs — `PROVIDES_PACKAGE` (`package provide`),
+`EXPORTS_COMMAND` (`namespace export`), `LOADS_EXTERNAL_UNIT` (`source`,
+`load`, `package require`) — and read generically via
+`CommandRegistry::unit_linkage`, so no command name appears in the compiler.
+The interprocedural constant seed refuses to treat a file's visible call
+sites as the complete caller set once a linkage trait is present, unless the
+host supplied cross-file call-site evidence. See
+[compilation-unit-scope.md](design/compiler/compilation-unit-scope.md).
+
+### Call-site evidence
+
+The per-callee, per-argument-position record of what every resolvable call
+passes — `CallSiteEvidence` in `tcl_compiler::unit_scope`. Merging evidence
+from another file is *monotone*: it adds values, unknowns, and observed
+argument counts, so a second file can retract a constant fold but never
+manufacture one. An **opaque caller** (a deferred `-command` prefix, a
+`rename`, an import binding a new name) is recorded as "a call site exists
+whose arguments are unknown" rather than being left out.
+
 ### IPA
 
 Interprocedural Analysis — walks every proc in the compilation unit

--- a/docs/design/compiler/README.md
+++ b/docs/design/compiler/README.md
@@ -146,6 +146,10 @@ User-facing compiler troubleshooting and how-tos live in
   command-substitution intent facts used by the optimiser and shimmer.
 - [compilation-unit-contracts.md](compilation-unit-contracts.md) —
   compilation unit orchestration and incremental cache expectations.
+- [compilation-unit-scope.md](compilation-unit-scope.md) — when a fact
+  derived from one file's call sites may be trusted as a fact about every
+  caller: cross-file evidence, registry-declared unit boundaries, and the
+  interprocedural constant seed's gate.
 
 ## Optimisation passes
 

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -338,6 +338,34 @@ generically wherever a `COMMAND_PREFIX`/`BODY`/`LAMBDA_LITERAL` argument
 position needs to see through the quoting -- never by comparing a command
 head to the literal string `"list"`.
 
+### Unit-linkage traits
+
+Three traits record that a command makes the file it appears in part of a
+**bigger program** — the fact `tcl_compiler::unit_scope` needs to decide
+whether one file's call sites can be trusted as every call site (issue #977):
+
+| Trait | Set on | Means |
+|---|---|---|
+| `PROVIDES_PACKAGE` | `package provide`, `package ifneeded` | the file is a loadable package; its commands are public API |
+| `EXPORTS_COMMAND` | `namespace export`, `namespace ensemble` | the file publishes command names for another unit to import or dispatch through |
+| `LOADS_EXTERNAL_UNIT` | `source`, `load`, `package require`, `auto_load`, `auto_import` | another unit's script runs in this interpreter and can call back in |
+
+`CommandRegistry::unit_linkage(name, args, dialect)` resolves an invocation
+through `resolve_call` and returns the union of `spec.traits | sub.traits`
+masked to `UNIT_LINKAGE_TRAITS`, so the answer is subcommand-precise:
+`package provide` is a boundary, `package names` is not. Adding a new
+boundary command is a spec edit — the compiler never names one.
+
+The first two traits publish the file's commands to consumers no project
+enumeration can bound, so they decline the interprocedural seed
+unconditionally; `LOADS_EXTERNAL_UNIT` names a caller a workspace normally
+contains, so it defers to host-supplied cross-file evidence. See
+[compilation-unit-scope.md](compilation-unit-scope.md).
+
+`namespace import` is deliberately excluded: it is as often an intra-file
+convenience over a namespace the same file defines, and `unit_scope`'s
+evidence scan already models the import as a real caller path.
+
 ### Resolution priority
 
 Three mechanisms assign roles to command arguments. They are evaluated in

--- a/docs/design/compiler/compilation-unit-scope.md
+++ b/docs/design/compiler/compilation-unit-scope.md
@@ -1,0 +1,171 @@
+# Compilation-unit scope — who can call this file's procedures?
+
+> One contract: when may an interprocedural fact derived from the call sites
+> a single file contains be trusted as a fact about *every* caller?
+
+Source: [`rust/tcl-compiler/src/unit_scope.rs`](../../../rust/tcl-compiler/src/unit_scope.rs).
+
+## The problem
+
+`CompilationUnit::build_for` is single-source-text by construction, but Tcl
+has no `static`: every `proc` lands in a global command table that any file
+sharing the interpreter can reach. The interprocedural SCCP seed
+(`params_constants_from_call_sites`) binds a parameter to a compile-time
+literal only when **every** caller passes that literal — so the seed is
+exactly as sound as the claim *"the call sites I found are all of them"*.
+
+Issue #977 is that claim failing in its most ordinary form:
+
+```tcl
+# lib.tcl — no package provide
+proc helper {mode} {
+    if {$mode eq "prod"} { … } else { … }
+}
+helper prod
+helper prod
+```
+
+```tcl
+# main.tcl
+source lib.tcl
+helper dev        ;# a real caller lib.tcl's compilation unit can never see
+```
+
+Analysed on its own, `lib.tcl`'s only visible callers agree, so `mode` is
+seeded as `"prod"` and the condition folds — producing an I230 "condition is
+always true" that is simply wrong.
+
+## The three layers
+
+`unit_scope` owns the completeness claim in three layers. Each is
+*monotone*: it can only ever remove a fold, never add one.
+
+### 1. In-unit evidence
+
+`collect_call_site_constants` walks the module's own CFGs — the top level,
+every procedure, plus the `TclOO` method and `apply` / `namespace eval` body
+units `build_extra_call_site_scan_contexts` supplies — and records each
+resolvable call's literal arguments into a `CallSiteEvidence`.
+
+Resolution goes through `interprocedural::resolve_internal_call` (Tcl's real
+existence-checked, namespace-relative order, evaluated in the *calling*
+function's namespace) with a `namespace import` fallback, and recurses into
+`ArgRole::Body` arguments so a call inside `catch { … }` or a literal
+`uplevel { … }` still counts. See FP-IPCP-01 in
+[`fp-audit-todo.md`](fp-audit-todo.md) for why each of those matters.
+
+### 2. Cross-unit evidence
+
+`scan_source_call_sites` runs the *identical* lowering → CFG →
+`record_call_site_evidence` walk over **another** file's source text,
+resolving each call against the whole project's procedure names, so a host
+with a workspace view can hand this unit the call sites it could never see
+itself. `CallSiteEvidence::merge_from` folds them in before seeding.
+
+| Producer | How it enumerates the project |
+|---|---|
+| LSP | `tcl_lsp_db::file_call_site_evidence` → `project_call_site_evidence` → `file_external_call_sites` (sliced to the file's own declarations), compare-then-set onto `SourceFile::external_call_sites` by the server's `sync_cross_file_evidence` |
+| `tcl` CLI | `cross_file_call_site_evidence` across a multi-input `diag` / `validate` invocation |
+| Standalone (tests, a library call) | `UnitBuildOptions::external_call_sites: None` — no view |
+
+Slicing the merged table to the file's own declarations is what keeps
+invalidation precise: a call-site edit in `main.tcl` re-sets only the file
+that *defines* the callee.
+
+`None` and `Some(empty)` are **different claims**. `None` means "no
+cross-file view available", which is not the same as "no cross-file callers".
+`Some` — even of an empty table — is the host asserting it enumerated the
+project, so the merged evidence is the whole picture.
+
+### 3. Registry-declared unit boundaries
+
+`scan_unit_linkage` asks the registry whether the file itself admits to being
+part of a bigger program, via `CommandRegistry::unit_linkage` (which resolves
+the subcommand word, so `package provide` is a boundary and `package names`
+is not). **No command name appears in the compiler** — the facts are
+`Traits` bits on the specs:
+
+| Trait | Set on | Means |
+|---|---|---|
+| `PROVIDES_PACKAGE` | `package provide`, `package ifneeded` | the file is a loadable package; its commands are public API |
+| `EXPORTS_COMMAND` | `namespace export`, `namespace ensemble` | the file publishes command names for another unit |
+| `LOADS_EXTERNAL_UNIT` | `source`, `load`, `package require`, `auto_load`, `auto_import` | another unit's script runs in this interpreter and can call back in |
+
+`namespace import` is deliberately **not** a boundary: it is as often an
+intra-file convenience over a namespace the same file defines, and layer 1
+already models the import as a real caller path.
+
+## The gate
+
+`params_constants_from_call_sites` binds `(param, 0)` to a literal only when
+all of the following hold:
+
+1. Every recorded call site passes the same single literal at that position,
+   and every one of them actually *supplied* an argument there
+   (`CalleeEvidence::binds_position` — an omitted argument takes the
+   parameter's default, an unknown value).
+2. The parameter is not at or past a **trailing** `args`. Only a trailing
+   `args` is Tcl's variadic catch-all (`TclCreateProc`,
+   `generic/tclProc.c`) — in `proc f {args x}` the first word is an ordinary
+   parameter.
+3. `command_mutations.trusts_proc_binding(qname)` — the callee's binding was
+   not perturbed by a `rename` / `interp alias` / dynamic redefinition
+   anywhere in *this* module (the optimiser's own O103 trust lattice, reused
+   rather than duplicated).
+4. The file crosses no registry-declared boundary the evidence cannot
+   cover. The two kinds differ, because a host's enumeration can only bound
+   one of them:
+   - `PROVIDES_PACKAGE` / `EXPORTS_COMMAND` publish this file's commands as
+     an API surface, whose consumers need not be in the project at all —
+     another checkout can `package require` it. **Declines
+     unconditionally**, workspace view or not.
+   - `LOADS_EXTERNAL_UNIT` names a caller the project normally *does*
+     contain, so it declines only when the host supplied no cross-file
+     view.
+
+## Opaque callers
+
+Some callers exist but cannot be attributed argument by argument.
+`record_indirect_callers` records those as *opaque* — "a call site exists
+whose arguments I do not know" — which poisons every position rather than
+leaving the callee looking uncontradicted:
+
+- an `ArgRole::CommandPrefix` argument naming a known command (`after 0
+  helper`, `trace add variable v write helper`, `-command helper`): the
+  runtime appends words to the prefix;
+- a `CommandTableEffect::RenamesCommands` / `CreatesAliases` word naming a
+  known command, which is how a cross-file `rename` reaches a callee the
+  single-file trust lattice in (3) above cannot see;
+- a `namespace import` in another file that binds one of this file's
+  commands under a new bare name.
+
+## Accepted residual
+
+**The workspace is the trust boundary.** A caller outside it — a `source`
+target that is not a project file, another project `package require`ing this
+one — is still unenumerable. That is precisely why `PROVIDES_PACKAGE` and
+`EXPORTS_COMMAND` decline the seed outright rather than trusting an
+enumeration that cannot cover them.
+
+`namespace ensemble configure -map` redirection, and `uplevel #0`'s
+global-resolving body (pinned by an `#[ignore]`d regression), remain open —
+see FP-IPCP-01/02 in [`fp-audit-todo.md`](fp-audit-todo.md).
+
+## Seeing it
+
+The compiler explorer's **Unit Scope** view (`unitScope`, rendered at the top
+of the Interproc pane in both GUIs) shows the boundaries crossed, whether a
+cross-file view was supplied, and the per-position seed verdict for every
+callee — so a surprising, or surprisingly absent, constant fold can be traced
+straight back to the evidence that produced it.
+
+```
+tcl explore --show unitScope --text lib.tcl
+```
+
+## Related docs
+
+- [fp-audit-todo.md](fp-audit-todo.md) — FP-IPCP-01 / FP-IPCP-02.
+- [command-registry.md](command-registry.md) — `CommandSpec` field reference.
+- [interprocedural-analysis.md](interprocedural-analysis.md) — `ProcSummary`
+  construction (a separate interprocedural product from this seed).

--- a/docs/design/compiler/fp-audit-todo.md
+++ b/docs/design/compiler/fp-audit-todo.md
@@ -356,15 +356,12 @@ inspected · counts are dialect-aware corpus firings as of the last sweep.
   statically enumerated at all) that pre-dates this fix and is orthogonal to
   what #969 actually reported — documented as a known limitation rather than
   papered over with disproportionate collateral damage.
-  **Known, deliberately out-of-scope residual gaps** (none reproduce the
-  reported shape; listed so they aren't mistaken for silently-missed):
-  cross-file soundness for a plain (non-`package provide`) file `source`d
-  by another that calls its procs differently; `CommandPrefix`-role
+  **Residual gaps at the time** (since closed by FP-IPCP-02 below, except
+  the last): cross-file soundness for a plain (non-`package provide`) file
+  `source`d by another that calls its procs differently; `CommandPrefix`-role
   indirection (`trace add variable … command cb`, `-command` callback
-  options) — neither this scan nor the pre-existing
-  `interprocedural::scan_source_for_calls` call-graph walk follows a
-  `CommandPrefix` argument, so this is a shared, pre-existing limitation,
-  not a regression; and `namespace ensemble configure -map` redirection.
+  options); and `namespace ensemble configure -map` redirection, which
+  remains open.
   Traced end-to-end: the same `SccpResult` feeds I230, the optimiser's O101
   fold and O107 dead-code suggestions (all suggestion-only text rewrites,
   never applied to the compiled CFG/IR — confirmed codegen/`tcl-vm`/WASM
@@ -431,6 +428,76 @@ inspected · counts are dialect-aware corpus firings as of the last sweep.
   `call_site_param_constants` module (19 passing + 1 pinned `#[ignore]`),
   plus the `namespace_eval_body_unit_does_not_change_bytecode` regression
   in `regex_source.rs` updated for the corrected qname format.
+- [x] **FP-IPCP-02** I230 on a plain library file `source`d by a caller with
+  a differing literal — CLOSED (issue #977). FP-IPCP-01's `package
+  provide`-in-file guard covered a package file, but not the more common
+  shape the issue reported: `lib.tcl` with **no** `package provide`, whose
+  two visible callers both pass `"prod"`, `source`d by `main.tcl` which calls
+  `helper dev`. `CompilationUnit::build_for` is single-source-text by
+  construction, so that caller is invisible and `mode` folded. Closed on
+  three fronts, all in the new `tcl-compiler/src/unit_scope.rs` (which also
+  lifts `ArgConsts` / `collect_call_site_constants` /
+  `params_constants_from_call_sites` / `build_extra_call_site_scan_contexts`
+  out of the 2 900-line `compilation_unit.rs`):
+  1. **Cross-file evidence.** `unit_scope::scan_source_call_sites` runs the
+     *identical* lowering → CFG → `record_call_site_evidence` walk over
+     another file's source, resolving each call against the whole project's
+     proc names, and `CallSiteEvidence::merge_from` folds the result into the
+     unit's own evidence before seeding. Merging is monotone (more values,
+     more unknowns, more observed argument counts), so extra evidence can
+     only ever *retract* a fold — never manufacture one. Plumbed through
+     `UnitBuildOptions::external_call_sites`; salsa-side by
+     `tcl_lsp_db::file_call_site_evidence` → `project_call_site_evidence` →
+     `file_external_call_sites` (sliced to the file's own declarations, so a
+     call-site edit in one file re-sets only the file that *defines* the
+     callee) onto `SourceFile::external_call_sites`, which the server
+     compare-then-sets in `sync_cross_file_evidence`. The `tcl` CLI does the
+     same across a multi-file `diag` / `validate` invocation.
+  2. **Registry-declared unit boundaries.** `has_package_provide_statement`
+     knew one command pair by name; `unit_scope::scan_unit_linkage` asks the
+     registry instead (`CommandRegistry::unit_linkage`, resolving the
+     subcommand word so `package provide` is a boundary and `package names`
+     is not). Three new `Traits` bits carry the fact as spec data:
+     `PROVIDES_PACKAGE` (`package provide` / `ifneeded`), `EXPORTS_COMMAND`
+     (`namespace export`, `namespace ensemble`), and `LOADS_EXTERNAL_UNIT`
+     (`source`, `load`, `package require`, `auto_load`, `auto_import`).
+     The two kinds are gated differently, because a host's enumeration can
+     only bound one of them: `PROVIDES_PACKAGE` / `EXPORTS_COMMAND` publish
+     this file's commands to consumers that need not be in the project at
+     all (another checkout can `package require` it), so they decline the
+     seed **unconditionally**; `LOADS_EXTERNAL_UNIT` names a caller the
+     project normally does contain, so it declines only without a
+     cross-file view. `namespace import` is
+     deliberately *not* a boundary — it is as often an intra-file convenience
+     over a namespace the same file defines, and the evidence scan already
+     models the import as a real caller path.
+  3. **Indirect callers.** `record_indirect_callers` records an *opaque
+     caller* — "a call site exists whose arguments I do not know" — for a
+     deferred command prefix (`ArgRole::CommandPrefix`: `after 0 helper`,
+     `trace add variable … helper`, `-command helper`) and for a
+     `CommandTableEffect::RenamesCommands` / `CreatesAliases` word naming a
+     known command. That closes FP-IPCP-01's documented `CommandPrefix`
+     limitation for both scans at once, and gives cross-file `rename` the
+     coverage `command_binding`'s single-file trust lattice cannot have.
+  Also fixed here: only a **trailing** `args` is Tcl's variadic catch-all
+  (`TclCreateProc`, `generic/tclProc.c`), so `proc f {args x}`'s `x` is no
+  longer skipped. The three traits above are declared through the
+  `declare_traits!` macro PR #1034 introduced (issue #1031), so they carry no
+  hand-written bit number and `Traits::iter_names` renders them in the
+  explorer with no second name table to maintain. **Accepted residual:** the workspace *is* the
+  trust boundary — a caller outside it (a `source` target not in the project,
+  another project `package require`ing this one) is still unenumerable, which
+  is why `PROVIDES_PACKAGE` / `EXPORTS_COMMAND` decline the seed regardless
+  of what evidence a host supplies. Visible in the compiler explorer's new **Unit Scope**
+  view (`unitScope`), which shows the boundaries crossed, whether a
+  cross-file view was supplied, and the per-position seed verdict. Tests: the
+  `call_site_param_constants::cross_file` module (8 TP/FP/TN/FN cases) plus
+  `exported_namespace_declines_the_seed_even_with_a_workspace_view`,
+  `unit_scope`'s own 8-case suite over the evidence primitives and the gate,
+  `tcl-lsp-db`'s `cross_file_call_sites` module (4, including a backdating
+  guard), four native e2e cases in `diagnostics.rs`,
+  `cli::diag_shares_call_sites_across_inputs`, two explorer serialisation
+  tests, and the VS Code `issue977.test.ts` suite.
 
 ## Confirmed true-positive this audit (sampled, no change needed)
 

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -67,6 +67,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   `tailcall` in a safe-interpreter body, and the *Inline proc* code action
   is missing on `file`, `exec`, `open`, and seven other commands — two
   symptoms of one trait-flag bit collision.
+- [kcs-issue-always-true-condition-in-a-sourced-library-file.md](kcs-issue-always-true-condition-in-a-sourced-library-file.md)
+  — I230 says a condition is always true in a library file whose procedure
+  is really called with different values from another file.
 - [kcs-issue-duplicate-diagnostics.md](kcs-issue-duplicate-diagnostics.md)
   — the same finding is reported twice.
 - [kcs-issue-counter-numtests-array-init.md](kcs-issue-counter-numtests-array-init.md)

--- a/docs/kcs/kcs-issue-always-true-condition-in-a-sourced-library-file.md
+++ b/docs/kcs/kcs-issue-always-true-condition-in-a-sourced-library-file.md
@@ -1,0 +1,88 @@
+# KCS: A condition in my library file is reported as always true
+
+> **Audience:** User
+> **Type:** Issue
+
+## Applies to
+
+all-editors, tcl-lsp-cli
+
+## Question
+
+Why does the editor say a condition in my library file is always true or
+always false, when the file's procedure is clearly called with different
+values from somewhere else?
+
+## Symptoms
+
+- An `I230` hint on an `if` in a library file: `Condition '$mode eq "prod"'
+  is always true`.
+- The procedure the condition lives in really is called with more than one
+  value — just not from the file the hint appears in.
+- Opening the calling file makes the hint disappear.
+
+## Answer
+
+The compiler works out a parameter's value from the calls it can see. If
+every call agrees on one literal, the parameter is treated as a constant and
+conditions on it fold. That reasoning is only correct when the calls it can
+see are *all* the calls.
+
+A library file that is loaded by another file has callers the file itself
+does not contain:
+
+```tcl
+# lib.tcl
+proc helper {mode} {
+    if {$mode eq "prod"} { ... } else { ... }
+}
+helper prod
+helper prod
+```
+
+```tcl
+# main.tcl
+source lib.tcl
+helper dev
+```
+
+The server reads the whole workspace, so with both files in the project it
+sees `helper dev` and does not fold. If you see the hint anyway, one of these
+is usually why:
+
+1. **The calling file is not in the workspace.** Open the folder that
+   contains both files (**File → Open Folder**), not just the single file.
+   Verify with **Tcl: Show Workspace Index** that the calling file is listed.
+2. **The calling file is outside the workspace entirely** — a vendored
+   script, or a separate project that `package require`s this one. The
+   server cannot enumerate callers it has never been shown. Add a
+   `package provide` line to the library: a file that declares itself a
+   package is never seeded from its own call sites, because its procedures
+   are public API by definition.
+3. **You are running the command line on one file.** `tcl diag lib.tcl` has
+   no project to consult. Pass every file — `tcl diag lib.tcl main.tcl`, or a
+   directory — and the calls are shared across them.
+
+If none of those apply, the hint is telling you something true: within
+everything the server can see, that parameter really does only ever take one
+value.
+
+To see exactly what the compiler decided and why, run:
+
+```
+tcl explore --show unitScope --text lib.tcl
+```
+
+It lists the boundaries the file crosses (`package provide`, `source`,
+`namespace export`, …), whether a cross-file view was available, and the
+verdict for each argument position.
+
+If the calling file *is* in the workspace and the hint still appears, collect
+the output channel log and open an issue.
+
+## Related
+
+- [I230 — constant existence check](codes/kcs-diagnostic-i230-constant-existence-check.md)
+- [Compilation-unit scope](../design/compiler/compilation-unit-scope.md) —
+  the contract behind this behaviour.
+- [How to suppress diagnostics](kcs-howto-suppress-diagnostics.md)

--- a/editors/vscode/src/test/issue977.test.ts
+++ b/editors/vscode/src/test/issue977.test.ts
@@ -1,0 +1,68 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+// Issue #977: the interprocedural call-site seed was unsound for a plain
+// library file — no `package provide`, so PR #970's guard never fired —
+// `source`d by another file that calls its procs with a different literal.
+// The deep TP/FP/TN/FN coverage lives in `tcl-compiler`'s `unit_scope` /
+// `call_site_param_constants` unit tests, `tcl-lsp-db`'s
+// `cross_file_call_sites` module, and the native `e2e` suite; these prove the
+// same behaviour arrives through a real VS Code session, where the workspace
+// (not a single buffer) is the compilation scope.
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, waitForDiagnostics } from "./helper";
+
+function codeOf(d: vscode.Diagnostic): string {
+  return typeof d.code === "object" && d.code !== null ? String(d.code.value) : String(d.code);
+}
+
+suite("Issue #977 cross-file interprocedural seeding", () => {
+  test("a caller in a sourcing file with a differing literal clears I230", async () => {
+    // Open the caller first so it is already in the project when the library
+    // is analysed — the ordering a workspace scan produces.
+    await activate(getDocUri("issue977Main.tcl"));
+    const libUri = getDocUri("issue977Lib.tcl");
+    await activate(libUri);
+
+    const diags = vscode.languages.getDiagnostics(libUri);
+    assert.ok(
+      !diags.some((d) => codeOf(d) === "I230"),
+      `issue977Main.tcl calls helper with "dev"; the library must not fold on "prod": ${JSON.stringify(
+        diags.map((d) => codeOf(d)),
+      )}`,
+    );
+  });
+
+  test("TP control: every project caller agreeing on the literal still fires I230", async () => {
+    await activate(getDocUri("issue977AgreeingMain.tcl"));
+    const libUri = getDocUri("issue977AgreeingLib.tcl");
+    await activate(libUri);
+
+    const diags = await waitForDiagnostics(libUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "I230"),
+    });
+    assert.ok(
+      diags.some((d) => codeOf(d) === "I230"),
+      `every caller in the project passes "prod", so the seed is sound: ${JSON.stringify(
+        diags.map((d) => codeOf(d)),
+      )}`,
+    );
+  });
+});

--- a/editors/vscode/testFixture/issue977AgreeingLib.tcl
+++ b/editors/vscode/testFixture/issue977AgreeingLib.tcl
@@ -1,0 +1,13 @@
+# Issue #977 TP control — the same library shape whose project-wide callers
+# all agree on the literal, so the interprocedural seed is sound and I230
+# must still fire.
+proc agreeing_helper {mode} {
+    if {$mode eq "prod"} {
+        set r 1
+    } else {
+        set r 2
+    }
+    return $r
+}
+agreeing_helper prod
+agreeing_helper prod

--- a/editors/vscode/testFixture/issue977AgreeingMain.tcl
+++ b/editors/vscode/testFixture/issue977AgreeingMain.tcl
@@ -1,0 +1,3 @@
+# Issue #977 TP control — every project caller passes the same literal.
+source issue977AgreeingLib.tcl
+agreeing_helper prod

--- a/editors/vscode/testFixture/issue977Lib.tcl
+++ b/editors/vscode/testFixture/issue977Lib.tcl
@@ -1,0 +1,14 @@
+# Issue #977 — a plain library file with NO `package provide`.  Both callers
+# visible in this file pass "prod", so a single-file compilation unit seeds
+# `mode` as that literal and folds the condition — even though
+# issue977Main.tcl calls `helper dev`.
+proc helper {mode} {
+    if {$mode eq "prod"} {
+        set r 1
+    } else {
+        set r 2
+    }
+    return $r
+}
+helper prod
+helper prod

--- a/editors/vscode/testFixture/issue977Lib.tcl
+++ b/editors/vscode/testFixture/issue977Lib.tcl
@@ -1,8 +1,8 @@
 # Issue #977 — a plain library file with NO `package provide`.  Both callers
 # visible in this file pass "prod", so a single-file compilation unit seeds
 # `mode` as that literal and folds the condition — even though
-# issue977Main.tcl calls `helper dev`.
-proc helper {mode} {
+# issue977Main.tcl calls `issue977_helper dev`.
+proc issue977_helper {mode} {
     if {$mode eq "prod"} {
         set r 1
     } else {
@@ -10,5 +10,5 @@ proc helper {mode} {
     }
     return $r
 }
-helper prod
-helper prod
+issue977_helper prod
+issue977_helper prod

--- a/editors/vscode/testFixture/issue977Main.tcl
+++ b/editors/vscode/testFixture/issue977Main.tcl
@@ -1,4 +1,4 @@
 # Issue #977 — the sourcing file the library's own compilation unit can never
-# see.  Its `helper dev` is the caller that makes the fold unsound.
+# see.  Its `issue977_helper dev` is the caller that makes the fold unsound.
 source issue977Lib.tcl
-helper dev
+issue977_helper dev

--- a/editors/vscode/testFixture/issue977Main.tcl
+++ b/editors/vscode/testFixture/issue977Main.tcl
@@ -1,0 +1,4 @@
+# Issue #977 — the sourcing file the library's own compilation unit can never
+# see.  Its `helper dev` is the caller that makes the fold unsound.
+source issue977Lib.tcl
+helper dev

--- a/rust/tcl-cli/gui/explorer-core.js
+++ b/rust/tcl-cli/gui/explorer-core.js
@@ -263,11 +263,42 @@ function renderCfgPost() {
   requestAnimationFrame(function() { drawAllCfgEdges(pane, funcs); });
 }
 
+// Unit scope: who else can call this file's procedures (issue #977).
+// Rendered at the top of the Interproc pane because it is the precondition
+// for every interprocedural constant seed below it — the `seeding` line says
+// whether the seeds were allowed, and which boundary declined them.
+function renderUnitScope() {
+  var scope = data.unitScope;
+  if (!scope) return '';
+  var boundaries = (scope.boundaries && scope.boundaries.length)
+    ? esc(scope.boundaries.join(', '))
+    : 'none';
+  var html = '<div class="proc-card">';
+  html += '<div class="proc-name">unit scope';
+  html += '<span class="pure-badge ' + (scope.hasCrossFileEvidence ? 'pure-yes' : 'pure-no') + '">'
+    + (scope.hasCrossFileEvidence ? 'cross-file view' : 'single file') + '</span>';
+  html += '</div>';
+  html += '<div class="proc-detail">registry boundaries: <span class="val">' + boundaries + '</span></div>';
+  html += '<div class="proc-detail">seeding: <span class="val">' + esc(scope.seeding || '') + '</span></div>';
+  for (var c of (scope.callees || [])) {
+    var parts = [];
+    for (var pos of (c.positions || [])) parts.push('arg ' + esc(pos.index) + ': ' + esc(pos.verdict));
+    html += '<div class="proc-detail">' + esc(c.name) + ': <span class="val">'
+      + (parts.length ? parts.join('; ') : '\u2014') + '</span></div>';
+  }
+  html += '</div>';
+  return html;
+}
+
 // Interprocedural
 function renderInterproc() {
   var pane = $('#pane-interproc');
-  if (!data.interprocedural.length) { pane.innerHTML = '<div class="empty-state">No procedures to analyse</div>'; return; }
-  var html = '';
+  var scopeHtml = renderUnitScope();
+  if (!data.interprocedural.length) {
+    pane.innerHTML = scopeHtml + '<div class="empty-state">No procedures to analyse</div>';
+    return;
+  }
+  var html = scopeHtml;
   for (var p of data.interprocedural) {
     // TclOO method summaries carry a different shape than proc summaries
     // (no arity/foldable/returnShape; instead methodKind + instance-var

--- a/rust/tcl-cli/src/commands/diag.rs
+++ b/rust/tcl-cli/src/commands/diag.rs
@@ -29,8 +29,9 @@ use tcl_cli_support::{
     InputDocument, OutputTarget, read_input_documents, registry_for_dialect, write_text_output,
 };
 use tcl_compiler::analyser::{Analyser, Severity};
-use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_compiler::compilation_unit::{CompilationUnit, UnitBuildOptions};
 use tcl_compiler::compiler_checks::run_all_checks;
+use tcl_compiler::unit_scope::CallSiteEvidence;
 use tcl_lexer::LineIndex;
 
 use crate::cli::{DiagArgs, InputArgs};
@@ -134,6 +135,51 @@ struct Row {
     message: String,
 }
 
+/// Cross-file call-site evidence across every input document, plus the
+/// project-wide procedure-name set the scan resolved against (issue #977).
+///
+/// `tcl diag a.tcl b.tcl` is a multi-file compilation just as much as the
+/// editor's workspace is: without this, `a.tcl` would fold a parameter that
+/// `b.tcl` calls with a different literal.  `None` for a single input — one
+/// file is not a project, and asserting a closed world from it would be the
+/// very claim issue #977 is about.
+fn cross_file_call_site_evidence(
+    documents: &[InputDocument],
+    dialect_override: Option<&str>,
+) -> Option<CallSiteEvidence> {
+    if documents.len() < 2 {
+        return None;
+    }
+    let mut known: HashSet<String> = HashSet::new();
+    for document in documents {
+        let dialect = document.effective_dialect(dialect_override);
+        known.extend(document_proc_names(document, &dialect));
+    }
+    let mut merged = CallSiteEvidence::default();
+    for document in documents {
+        let dialect = document.effective_dialect(dialect_override);
+        merged.merge_from(&tcl_compiler::unit_scope::scan_source_call_sites(
+            &document.source,
+            registry_for_dialect(&dialect),
+            &dialect,
+            &known,
+        ));
+    }
+    Some(merged)
+}
+
+/// The qualified names of every procedure `document` declares, from the same
+/// [`tcl_compiler::signature_scan`] the analyser and the LSP index use.
+fn document_proc_names(document: &InputDocument, dialect: &str) -> Vec<String> {
+    tcl_compiler::signature_scan::extract_signatures(
+        &document.source,
+        registry_for_dialect(dialect),
+    )
+    .procs
+    .into_keys()
+    .collect()
+}
+
 /// Collect every diagnostic the editor surfaces for one document: the analyser's
 /// syntactic / semantic checks plus the compiler-checks pass (shimmer `S1xx`,
 /// taint `T1xx` / `W2xx`, iRules data-flow). Mirrors the server's
@@ -142,15 +188,39 @@ struct Row {
 /// domain of the `optimise` verb, so they are dropped here — the same split the
 /// server draws with its optimiser toggle. Rows come back in a deterministic
 /// `(line, column, code)` order; `disabled` removes `--disable`d codes.
-fn collect_rows(document: &InputDocument, dialect: &str, disabled: &HashSet<String>) -> Vec<Row> {
+fn collect_rows(
+    document: &InputDocument,
+    dialect: &str,
+    disabled: &HashSet<String>,
+    external_call_sites: Option<&CallSiteEvidence>,
+) -> Vec<Row> {
     let source = document.source.as_str();
     let line_index = LineIndex::new(source);
     let mut rows: Vec<Row> = Vec::new();
 
+    // One compilation unit for both consumers, built with whatever cross-file
+    // call-site evidence the caller gathered (issue #977).  The analyser's
+    // CFG/SSA tail would otherwise build its **own** unit — with no evidence —
+    // and its I230 / I231 constant-branch findings would disagree with the
+    // compiler-checks pass below.  `LexerConfig::default()` matches what
+    // `emit_cfg_ssa_diagnostics` builds for itself, mirroring the server's
+    // `set_cu_override` seam in `tcl_lsp_db::file_analysis_incremental`.
+    let registry = registry_for_dialect(dialect);
+    let analysis_cu = std::sync::Arc::new(CompilationUnit::build_with_options(
+        source,
+        UnitBuildOptions {
+            registry,
+            defer_top_level: false,
+            config: tcl_lexer::LexerConfig::default(),
+            dialect,
+            external_call_sites,
+        },
+    ));
+
     let file_path = document.path.as_deref().map(|p| p.display().to_string());
-    let result = Analyser::new()
-        .with_file_path(file_path)
-        .analyse(source, dialect);
+    let mut analyser = Analyser::new().with_file_path(file_path);
+    analyser.set_cu_override(std::sync::Arc::clone(&analysis_cu));
+    let result = analyser.analyse(source, dialect);
     for d in &result.diagnostics {
         if disabled.contains(d.code.as_str()) {
             continue;
@@ -168,10 +238,28 @@ fn collect_rows(document: &InputDocument, dialect: &str, disabled: &HashSet<Stri
     // Compiler-checks pass — the same `run_all_checks` set the server lifts via
     // `compiler_check_diagnostics`. Built once per document; `diag` is a batch
     // verb, not latency-sensitive.
-    let registry = registry_for_dialect(dialect);
-    let cu = CompilationUnit::build_for(source, registry, false);
+    // The checks pass lowers under the document's own dialect config (`{*}` /
+    // iRules braces), which coincides with the analyser tail's default for
+    // every dialect but `tcl8.4` / `f5-irules` — reuse the unit above when it
+    // does, exactly as the server's shared `compilation_unit` query does.
+    let checks_config = tcl_lexer::LexerConfig::for_dialect(dialect);
+    let checks_cu = if checks_config == tcl_lexer::LexerConfig::default() {
+        std::sync::Arc::clone(&analysis_cu)
+    } else {
+        std::sync::Arc::new(CompilationUnit::build_with_options(
+            source,
+            UnitBuildOptions {
+                registry,
+                defer_top_level: false,
+                config: checks_config,
+                dialect,
+                external_call_sites,
+            },
+        ))
+    };
+    let cu = checks_cu.as_ref();
     let dialect_opt = (!dialect.is_empty()).then_some(dialect);
-    for d in run_all_checks(&cu, registry, dialect_opt) {
+    for d in run_all_checks(cu, registry, dialect_opt) {
         if d.code.is_optimisation() || disabled.contains(d.code.as_str()) {
             continue;
         }
@@ -200,9 +288,14 @@ pub fn run_diag(input: &InputArgs, diag: &DiagArgs) -> anyhow::Result<u8> {
     let mut problem_count = 0usize;
     let mut diagnostic_count = 0usize;
 
+    let evidence = cross_file_call_site_evidence(&documents, input.dialect.as_deref());
     for document in &documents {
         let dialect = document.effective_dialect(input.dialect.as_deref());
-        let rows = collect_rows(document, &dialect, &disabled);
+        let declared = document_proc_names(document, &dialect);
+        let slice = evidence
+            .as_ref()
+            .map(|all| all.slice_for(declared.iter().map(String::as_str)));
+        let rows = collect_rows(document, &dialect, &disabled, slice.as_ref());
         let mut items = Vec::with_capacity(rows.len());
         for r in rows {
             diagnostic_count += 1;
@@ -257,9 +350,14 @@ pub fn run_validate(input: &InputArgs, diag: &DiagArgs) -> anyhow::Result<u8> {
     let disabled = resolve_disabled(&diag.disable, &diag.enable);
 
     let mut errors: Vec<ValidateError> = Vec::new();
+    let evidence = cross_file_call_site_evidence(&documents, input.dialect.as_deref());
     for document in &documents {
         let dialect = document.effective_dialect(input.dialect.as_deref());
-        for r in collect_rows(document, &dialect, &disabled) {
+        let declared = document_proc_names(document, &dialect);
+        let slice = evidence
+            .as_ref()
+            .map(|all| all.slice_for(declared.iter().map(String::as_str)));
+        for r in collect_rows(document, &dialect, &disabled, slice.as_ref()) {
             if r.severity == Severity::Error {
                 errors.push(ValidateError {
                     file: document.label.clone(),

--- a/rust/tcl-cli/tests/cli.rs
+++ b/rust/tcl-cli/tests/cli.rs
@@ -177,3 +177,40 @@ fn minify_symbol_map_written_for_plain_minify() {
     );
     let _ = std::fs::remove_file(&tmp);
 }
+
+/// Issue #977: `tcl diag` over several inputs is a multi-file compilation, so
+/// a call in one file must be visible to another file's interprocedural
+/// constant seed.  On its own, the library's two agreeing callers make
+/// `$mode eq "prod"` fold (I230); adding the file that calls it with `dev`
+/// must retract that.
+#[test]
+fn diag_shares_call_sites_across_inputs() {
+    let lib = fixtures_dir().join("issue977Lib.tcl");
+    let main = fixtures_dir().join("issue977Main.tcl");
+    let alone = String::from_utf8(run_tcl_allow_failure(&["diag", lib.to_str().unwrap()]))
+        .expect("utf-8 output");
+    assert!(
+        alone.contains("I230"),
+        "the library alone has only agreeing callers, so the fold is expected: {alone}"
+    );
+    let together = String::from_utf8(run_tcl_allow_failure(&[
+        "diag",
+        lib.to_str().unwrap(),
+        main.to_str().unwrap(),
+    ]))
+    .expect("utf-8 output");
+    assert!(
+        !together.contains("I230"),
+        "issue977Main.tcl calls the helper with \"dev\": {together}"
+    );
+}
+
+/// Like [`run_tcl`] but tolerates a non-zero exit — `diag` returns 1 whenever
+/// it reports a problem-severity finding, which is not a harness failure.
+fn run_tcl_allow_failure(args: &[&str]) -> Vec<u8> {
+    Command::new(env!("CARGO_BIN_EXE_tcl"))
+        .args(args)
+        .output()
+        .expect("failed to spawn tcl binary")
+        .stdout
+}

--- a/rust/tcl-cli/tests/fixtures/issue977Lib.tcl
+++ b/rust/tcl-cli/tests/fixtures/issue977Lib.tcl
@@ -1,0 +1,8 @@
+# Issue #977 — a plain library file with no `package provide`.  Both callers
+# visible here pass "prod", so a single-file compilation folds the condition.
+proc issue977_helper {mode} {
+    if {$mode eq "prod"} { set r 1 } else { set r 2 }
+    return $r
+}
+issue977_helper prod
+issue977_helper prod

--- a/rust/tcl-cli/tests/fixtures/issue977Main.tcl
+++ b/rust/tcl-cli/tests/fixtures/issue977Main.tcl
@@ -1,0 +1,4 @@
+# Issue #977 — the sourcing file whose `dev` call the library alone can never
+# see.
+source issue977Lib.tcl
+issue977_helper dev

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -3503,10 +3503,13 @@ fn memoized_compilation_unit_diagnostics_match_whole_file() {
         let build_cu = |cache: &mut HashMap<String, FunctionUnit>| {
             CompilationUnit::build_for_memoized(
                 src,
-                &registry,
-                false,
-                tcl_lexer::LexerConfig::default(),
-                "tcl",
+                crate::compilation_unit::UnitBuildOptions {
+                    registry: &registry,
+                    defer_top_level: false,
+                    config: tcl_lexer::LexerConfig::default(),
+                    dialect: "tcl",
+                    external_call_sites: None,
+                },
                 &mut |req: &crate::compilation_unit::LatticeRequest<'_>| -> FunctionUnit {
                     // Key + build mirror the db's `function_lattice` query,
                     // including the whole-unit `known_classes` /
@@ -3611,10 +3614,13 @@ fn memoized_compilation_unit_shift_correctness() {
     let build = |s: &str, cache: &mut HashMap<String, FunctionUnit>| {
         let cu = CompilationUnit::build_for_memoized(
             s,
-            &registry,
-            false,
-            tcl_lexer::LexerConfig::default(),
-            "tcl",
+            crate::compilation_unit::UnitBuildOptions {
+                registry: &registry,
+                defer_top_level: false,
+                config: tcl_lexer::LexerConfig::default(),
+                dialect: "tcl",
+                external_call_sites: None,
+            },
             // Position-independent key: the body is normalised to offset 0
             // before the callback sees it, so a shifted-but-unedited proc
             // hits and the builder rebases the cached offset-0 unit.

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -45,6 +45,10 @@ use crate::ssa::{SsaFunction, ValueKey, build_ssa};
 use crate::taint::{TaintLattice, propagate_taints};
 use crate::type_infer::propagate_types;
 use crate::types::TypeLattice;
+use crate::unit_scope::{
+    build_extra_call_site_scan_contexts, collect_call_site_constants,
+    params_constants_from_call_sites,
+};
 
 /// Module-wide CFG-determining context (upvar summaries + proc params +
 /// global-write summaries) shared by every procedure/method build so each
@@ -128,6 +132,44 @@ pub struct LatticeRequest<'a> {
 /// redundant lattice recompute for an unchanged procedure body is skipped.  The
 /// caller owns the backing store and its eviction policy.
 pub type ProcLatticeCache<'a> = dyn FnMut(&LatticeRequest<'_>) -> FunctionUnit + 'a;
+
+/// Memoised per-procedure **body-lowering** callback (SRV-INCREMENTAL Task 3):
+/// `(qualified name, body source) -> lowered body`.  Named so the build entry
+/// points that thread it stay readable (and clippy's `type_complexity` has
+/// nothing to complain about).
+pub type BodyLoweringCache<'a> = dyn Fn(&str, &str) -> crate::ir::Script + 'a;
+
+/// The non-callback inputs to a [`CompilationUnit`] build.
+///
+/// Grouped into one struct rather than threaded as five positional
+/// parameters: `build_with` already takes two callbacks, and every entry
+/// point below funnels into it.  `Copy`, so passing it on costs nothing.
+#[derive(Clone, Copy)]
+pub struct UnitBuildOptions<'a> {
+    /// Command registry the whole build resolves against.
+    pub registry: &'a CommandRegistry,
+    /// `false` gives analyses the fully-inlined top-level CFG; `true`
+    /// matches codegen, where top-level `foreach` / `catch` / `try` compile
+    /// as opaque calls.
+    pub defer_top_level: bool,
+    /// Lexer configuration (dialect `{*}` / `}{` tokenisation).
+    pub config: tcl_lexer::LexerConfig,
+    /// Analysis dialect key; `""` for plain Tcl.
+    pub dialect: &'a str,
+    /// Call sites in **other** files that reach this unit's procedures, from
+    /// a host with a workspace view (see
+    /// [`crate::unit_scope::scan_source_call_sites`]).
+    ///
+    /// `None` means "no cross-file view available", which is not the same as
+    /// "no cross-file callers": the unit is then on its own, and any
+    /// registry-declared boundary
+    /// ([`crate::unit_scope::scan_unit_linkage`]) disables the
+    /// interprocedural seed rather than trusting an unprovable "every caller
+    /// is in this file".  `Some` — even `Some(&empty)` — is the host
+    /// asserting it enumerated the project, so the merged evidence is the
+    /// whole picture.
+    pub external_call_sites: Option<&'a crate::unit_scope::CallSiteEvidence>,
+}
 
 /// Callback type for [`CompilationUnit::with_interprocedural_memoized`].
 ///
@@ -598,6 +640,268 @@ pub struct CompilationUnit {
     /// in [`Self::procedures`]; ``None`` for non-iRules sources or any
     /// source with no ``when`` blocks.
     pub connection_scope: Option<crate::connection_scope::ConnectionScope>,
+    /// Who else can call this unit's procedures — the inputs the
+    /// interprocedural constant seed was (or was not) allowed to trust.
+    /// Surfaced by the compiler explorer's **Unit Scope** view; see
+    /// [`crate::unit_scope`].
+    pub caller_scope: UnitCallerScope,
+}
+
+/// The unit-scope facts a build resolved, kept on the finished
+/// [`CompilationUnit`] so the explorer — and anyone debugging a missing or
+/// unexpected fold — can see exactly why the interprocedural seed fired or
+/// declined.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct UnitCallerScope {
+    /// Registry-declared unit boundaries this file crosses
+    /// ([`crate::unit_scope::scan_unit_linkage`]).
+    pub linkage: tcl_registry::Traits,
+    /// Whether the host supplied a cross-file view
+    /// ([`UnitBuildOptions::external_call_sites`]).
+    pub has_cross_file_evidence: bool,
+    /// The merged (in-unit + cross-file) call-site evidence the seed read.
+    pub call_sites: crate::unit_scope::CallSiteEvidence,
+}
+
+/// Whole-module facts every per-function build in a [`CompilationUnit`] build
+/// consumes, gathered once.
+struct ModuleWideFacts {
+    /// Fully-qualified names of every class defined in the unit.
+    known_class_set: HashSet<String>,
+    /// [`Self::known_class_set`], sorted — the form each `LatticeRequest`
+    /// carries into its memo key, so a class-set change invalidates the
+    /// per-procedure lattices.
+    known_classes: Vec<String>,
+    /// Every name any procedure/method declares via `global NAME`.
+    top_level_extra_escaping: HashSet<String>,
+    /// [`crate::ir::Module::traced_variables`] as a sorted `Vec` (a `BTreeSet`
+    /// iterates in order), mirroring `known_classes`.
+    traced_variable_names: Vec<String>,
+}
+
+impl ModuleWideFacts {
+    fn collect(source: &str, ir_module: &IrModule, registry: &CommandRegistry) -> Self {
+        // Classes come from the signature scanner so this build and the
+        // incremental/db build derive an identical set (⇒ identical
+        // OBJECT-constructor typing on both paths).
+        let known_class_set = collect_known_classes(source, registry);
+        let mut known_classes: Vec<String> = known_class_set.iter().cloned().collect();
+        known_classes.sort_unstable();
+        Self {
+            known_class_set,
+            known_classes,
+            // A top-level bare name already lives in the global frame, so a
+            // call to a procedure that declares it `global` can reassign it
+            // mid-run even though the top-level body never says `global`
+            // itself. See `crate::var_observability::scan_module_global_names`.
+            top_level_extra_escaping: crate::var_observability::scan_module_global_names(ir_module),
+            traced_variable_names: ir_module.traced_variables.iter().cloned().collect(),
+        }
+    }
+}
+
+/// Lower `source` to IR, run the module-level pre-CFG passes, and build the
+/// module CFG — the front half of a [`CompilationUnit`] build, shared by every
+/// entry point.
+fn lower_and_build_cfg(
+    source: &str,
+    options: UnitBuildOptions<'_>,
+    body_cache: Option<&BodyLoweringCache<'_>>,
+) -> (IrModule, CfgModule) {
+    let registry = options.registry;
+    let mut ir_module = match body_cache {
+        Some(bc) => {
+            crate::lowering::lower_to_ir_with_body_cache(source, registry, options.config, bc)
+        }
+        None => lower_to_ir_with_config(source, registry, options.config),
+    };
+    // Specialise Option-shape factories before any other
+    // module-level passes so the synthesised child procs
+    // appear in module.procedures for the inline_uplevel pass
+    // and CFG construction.
+    crate::specialise_factories::specialise_factories(&mut ir_module, registry);
+    // Run the inline_uplevel pass before CFG construction so
+    // every passthrough callsite is replaced with a Statement::Block
+    // that splices the body inline.
+    crate::inline_uplevel::inline_uplevel_passthrough(&mut ir_module, registry);
+    let cfg_module = build_cfg(&ir_module, options.defer_top_level);
+    (ir_module, cfg_module)
+}
+
+/// Resolve everything the interprocedural constant seed needs to know about
+/// *who can call this unit's procedures* (see [`crate::unit_scope`]):
+/// the merged call-site evidence, the whole-module command-binding trust
+/// lattice, and the registry-declared unit boundaries the file crosses.
+///
+/// Returned as a tuple rather than a ready-made
+/// [`crate::unit_scope::UnitCallerView`] because that view *borrows* the
+/// mutations lattice, which is produced here — the caller owns both and pairs
+/// them up.
+fn resolve_unit_scope(
+    ir_module: &IrModule,
+    cfg_module: &CfgModule,
+    cfg_context: Option<&CfgContext>,
+    options: UnitBuildOptions<'_>,
+) -> (
+    crate::unit_scope::CallSiteEvidence,
+    crate::command_binding::ModuleCommandMutations,
+    tcl_registry::Traits,
+) {
+    let registry = options.registry;
+    // Bare CFGs for every TclOO method and synthetic body unit (`apply`
+    // lambda, `namespace eval` body) — the call-site scan must walk these as
+    // *callers* too, even though neither is itself seeded with
+    // `param_constants` (`build_method_units`/`build_body_units` always pass
+    // `None`): a call from inside one of these bodies to an ordinary user proc
+    // is a real call site whose argument can vary between call sites, exactly
+    // like a bare top-level/proc-body call.
+    let extra_callers = build_extra_call_site_scan_contexts(ir_module, cfg_context);
+    // Collect call-site literal arg values per user proc so each callee's SCCP
+    // can fold a param every caller passes the same literal for
+    // (interprocedural constant propagation).
+    let mut call_sites = collect_call_site_constants(
+        cfg_module,
+        &extra_callers,
+        &ir_module.procedures,
+        &ir_module.namespace_imports,
+        registry,
+        options.dialect,
+    );
+    // Fold in the call sites a host with a cross-file view supplied — callers
+    // in *other* files, which this single-source unit can never see for itself
+    // (issue #977). Merging is monotone: extra evidence can retract a fold,
+    // never manufacture one.
+    if let Some(external) = options.external_call_sites {
+        call_sites.merge_from(external);
+    }
+    // Whole-module `rename` / `interp alias` / dynamic-redefinition trust
+    // fact — reused (not duplicated) from the optimiser's identical O103
+    // proc-call-fold trust gate, so the interprocedural param-constant seed
+    // never trusts a callee whose binding could have moved.
+    let command_mutations =
+        crate::command_binding::scan_module_command_mutations(ir_module, registry);
+    // Which registry-declared unit boundaries this file crosses — the generic
+    // replacement for the old hardcoded `package provide` check.
+    let linkage = crate::unit_scope::scan_unit_linkage(ir_module, registry, options.dialect);
+    (call_sites, command_mutations, linkage)
+}
+
+/// Module-wide, read-only inputs [`build_procedure_units`] shares across
+/// every procedure in the loop.  Grouped into one struct so the extracted
+/// helper takes two parameters instead of a dozen.
+struct ProcedureBuildContext<'a> {
+    ir_module: &'a IrModule,
+    cfg_module: &'a CfgModule,
+    cfg_context: Option<&'a CfgContext>,
+    registry: &'a CommandRegistry,
+    dialect: &'a str,
+    /// Merged in-unit + cross-file call-site evidence
+    /// ([`crate::unit_scope::CallSiteEvidence`]).
+    call_sites: &'a crate::unit_scope::CallSiteEvidence,
+    /// Who else can call these procedures
+    /// ([`crate::unit_scope::UnitCallerView`]).
+    caller_view: &'a crate::unit_scope::UnitCallerView<'a>,
+    known_class_set: &'a HashSet<String>,
+    known_classes: &'a [String],
+    traced_variable_names: &'a [String],
+    trace_facts: ModuleTraceFacts<'a>,
+}
+
+/// Build one [`FunctionUnit`] per procedure: seed its SCCP with the
+/// caller-uniform literals [`crate::unit_scope`] proved, route the build
+/// through the per-procedure lattice memo when one is available, and skip
+/// both for an oversized body.
+fn build_procedure_units(
+    ctx: &ProcedureBuildContext<'_>,
+    mut cache: Option<&mut ProcLatticeCache<'_>>,
+) -> HashMap<String, FunctionUnit> {
+    let mut procedures: HashMap<String, FunctionUnit> = HashMap::new();
+    for (qname, cfg) in &ctx.cfg_module.procedures {
+        let params = ctx
+            .ir_module
+            .procedures
+            .get(qname)
+            .map_or(&[][..], |p| p.params.as_slice());
+        let param_constants =
+            params_constants_from_call_sites(params, ctx.call_sites, qname, ctx.caller_view);
+        let proc = ctx.ir_module.procedures.get(qname);
+        // Complexity guard (block-count or body-byte half): skip both the
+        // memo and the deep analysis for an oversized body. A flat
+        // generated proc is block-light yet byte-huge, so the byte test is
+        // what catches it.
+        let body_bytes = proc.map_or(0usize, |p| {
+            p.span.end().saturating_sub(p.span.start()) as usize
+        });
+        if body_bytes > crate::ssa::DEEP_ANALYSIS_BODY_BYTES
+            || crate::ssa::is_complexity_guarded(cfg)
+        {
+            procedures.insert(
+                qname.clone(),
+                FunctionUnit::trivial_guarded(qname, cfg.clone()),
+            );
+            continue;
+        }
+        let body_offset = proc.map_or(0, |p| p.span.start());
+        // Encode the interprocedural seeds into the hashable form the memo
+        // key carries.  The interproc `param_constants` are folded *into*
+        // the key (not a fresh-build escape hatch as before), so a procedure
+        // with caller-uniform literals still engages the memo — its key
+        // simply also distinguishes the seeds, so it rebuilds iff a caller's
+        // literal at that position changes.  `None` means a seed shape we
+        // can't intern (defensive; the current producer only emits string
+        // consts) → build fresh.
+        let encoded_pc = encode_param_constants(param_constants.as_ref());
+        // Route through the memo only when (a) a cache is present, (b) the
+        // procedure has a real body, (c) the module context is available,
+        // and (d) the seeds encode into the hashable key form.
+        let memoised = match (cache.as_mut(), proc, ctx.cfg_context, encoded_pc) {
+            (
+                Some(memo),
+                Some(proc),
+                Some((upvar_procs, proc_params, global_write_procs)),
+                Some(encoded_pc),
+            ) => {
+                // Normalise the body to offset 0 so a shifted-but-unchanged
+                // procedure produces an identical request (memo hit).
+                let mut body = proc.body.clone();
+                crate::lattice_rebase::rebase_script(&mut body, -i64::from(body_offset));
+                let mut fu = memo(&LatticeRequest {
+                    qname,
+                    body: &body,
+                    params,
+                    upvar_procs,
+                    proc_params,
+                    global_write_procs,
+                    dialect: ctx.dialect,
+                    param_constants: &encoded_pc,
+                    known_classes: ctx.known_classes,
+                    traced_variables: ctx.traced_variable_names,
+                    has_dynamic_variable_trace: ctx.ir_module.has_dynamic_variable_trace,
+                });
+                // Rebase the offset-0 memo result to the procedure's real
+                // position so every consumer sees **absolute** spans without
+                // needing offset-awareness — robust against new/upstream
+                // diagnostic & optimiser passes that read `fu.cfg` spans
+                // directly (`base_offset` stays 0; `abs_span` is identity).
+                crate::lattice_rebase::rebase_function_unit(&mut fu, i64::from(body_offset));
+                Some(fu)
+            }
+            _ => None,
+        };
+        let fu = memoised.unwrap_or_else(|| {
+            FunctionUnit::build_with_param_constants_and_classes(
+                qname,
+                cfg.clone(),
+                params,
+                ctx.registry,
+                param_constants.as_ref(),
+                ctx.known_class_set,
+                ctx.trace_facts,
+            )
+        });
+        procedures.insert(qname.clone(), fu);
+    }
+    procedures
 }
 
 impl CompilationUnit {
@@ -632,7 +936,26 @@ impl CompilationUnit {
         defer_top_level: bool,
         config: tcl_lexer::LexerConfig,
     ) -> Self {
-        Self::build_for_inner(source, registry, defer_top_level, config, "", None, None)
+        Self::build_with(
+            source,
+            UnitBuildOptions {
+                registry,
+                defer_top_level,
+                config,
+                dialect: "",
+                external_call_sites: None,
+            },
+            None,
+            None,
+        )
+    }
+
+    /// Build under an explicit [`UnitBuildOptions`] — the entry point a host
+    /// with a cross-file view uses to supply
+    /// [`UnitBuildOptions::external_call_sites`].
+    #[must_use]
+    pub fn build_with_options(source: &str, options: UnitBuildOptions<'_>) -> Self {
+        Self::build_with(source, options, None, None)
     }
 
     /// Like [`Self::build_for_with_config`] but routes each procedure's
@@ -654,21 +977,10 @@ impl CompilationUnit {
     /// [`Self::with_interprocedural`].
     pub fn build_for_memoized(
         source: &str,
-        registry: &CommandRegistry,
-        defer_top_level: bool,
-        config: tcl_lexer::LexerConfig,
-        dialect: &str,
+        options: UnitBuildOptions<'_>,
         cache: &mut ProcLatticeCache<'_>,
     ) -> Self {
-        Self::build_for_inner(
-            source,
-            registry,
-            defer_top_level,
-            config,
-            dialect,
-            Some(cache),
-            None,
-        )
+        Self::build_with(source, options, Some(cache), None)
     }
 
     /// Like [`Self::build_for_memoized`] but also threads a memoised per-procedure
@@ -678,52 +990,26 @@ impl CompilationUnit {
     /// `body_cache`); byte-identity is guarded by the corpus differential gates.
     pub fn build_for_memoized_with_body_cache(
         source: &str,
-        registry: &CommandRegistry,
-        defer_top_level: bool,
-        config: tcl_lexer::LexerConfig,
-        dialect: &str,
+        options: UnitBuildOptions<'_>,
         cache: &mut ProcLatticeCache<'_>,
-        body_cache: &dyn Fn(&str, &str) -> crate::ir::Script,
+        body_cache: &BodyLoweringCache<'_>,
     ) -> Self {
-        Self::build_for_inner(
-            source,
-            registry,
-            defer_top_level,
-            config,
-            dialect,
-            Some(cache),
-            Some(body_cache),
-        )
+        Self::build_with(source, options, Some(cache), Some(body_cache))
     }
 
-    #[allow(
-        clippy::too_many_lines,
-        clippy::too_many_arguments,
-        clippy::type_complexity
-    )]
-    fn build_for_inner(
+    fn build_with(
         source: &str,
-        registry: &CommandRegistry,
-        defer_top_level: bool,
-        config: tcl_lexer::LexerConfig,
-        dialect: &str,
-        mut cache: Option<&mut ProcLatticeCache<'_>>,
-        body_cache: Option<&dyn Fn(&str, &str) -> crate::ir::Script>,
+        options: UnitBuildOptions<'_>,
+        cache: Option<&mut ProcLatticeCache<'_>>,
+        body_cache: Option<&BodyLoweringCache<'_>>,
     ) -> Self {
-        let mut ir_module = match body_cache {
-            Some(bc) => crate::lowering::lower_to_ir_with_body_cache(source, registry, config, bc),
-            None => lower_to_ir_with_config(source, registry, config),
-        };
-        // Specialise Option-shape factories before any other
-        // module-level passes so the synthesised child procs
-        // appear in module.procedures for the inline_uplevel pass
-        // and CFG construction.
-        crate::specialise_factories::specialise_factories(&mut ir_module, registry);
-        // Run the inline_uplevel pass before CFG construction so
-        // every passthrough callsite is replaced with a Statement::Block
-        // that splices the body inline.
-        crate::inline_uplevel::inline_uplevel_passthrough(&mut ir_module, registry);
-        let cfg_module = build_cfg(&ir_module, defer_top_level);
+        let UnitBuildOptions {
+            registry,
+            dialect,
+            external_call_sites,
+            ..
+        } = options;
+        let (ir_module, cfg_module) = lower_and_build_cfg(source, options, body_cache);
         // Module-wide upvar/param context — the CFG-determining context a
         // procedure body is rebuilt under.  Computed once and shared by every
         // memoised request, the methods/body-units below, and the call-site
@@ -733,66 +1019,26 @@ impl CompilationUnit {
         let cfg_context =
             (cache.is_some() || !ir_module.methods.is_empty() || !ir_module.body_units.is_empty())
                 .then(|| crate::cfg_builder::prepare_cfg_context(&ir_module));
-        // Bare CFGs for every TclOO method and synthetic body unit (`apply`
-        // lambda, `namespace eval` body) — the call-site scan below must
-        // walk these as *callers* too, even though neither is itself seeded
-        // with `param_constants` (`build_method_units`/`build_body_units`
-        // always pass `None`): a call from inside one of these bodies to an
-        // ordinary user proc is a real call site whose argument can vary
-        // between call sites, exactly like a bare top-level/proc-body call.
-        let extra_call_site_scan_contexts =
-            build_extra_call_site_scan_contexts(&ir_module, cfg_context.as_ref());
-        // Collect call-site literal arg values per user proc so each
-        // callee's SCCP can fold a param every caller passes the same literal
-        // for (interprocedural constant propagation).
-        let call_site_constants = collect_call_site_constants(
-            &cfg_module,
-            &extra_call_site_scan_contexts,
-            &ir_module.procedures,
-            &ir_module.namespace_imports,
-            registry,
-            dialect,
-        );
-        // Whole-module `rename` / `interp alias` / dynamic-redefinition trust
-        // fact — reused (not duplicated) from the optimiser's identical O103
-        // proc-call-fold trust gate, so the interprocedural param-constant
-        // seed below never trusts a callee whose binding could have moved.
-        let command_mutations =
-            crate::command_binding::scan_module_command_mutations(&ir_module, registry);
-        // A file that declares `package provide` may export procs other
-        // files call (with call sites this single-file compilation unit can
-        // never see) — see `params_constants_from_call_sites`'s doc.
-        let has_package_provide = has_package_provide_statement(&ir_module);
-        // Fully-qualified names of every class defined in the unit, sourced from
-        // the signature scanner so this build and the incremental/db build
-        // derive an identical set (⇒ identical OBJECT-constructor typing on both
-        // paths).  `known_classes` (sorted) is also what each `LatticeRequest`
-        // carries into the memo key, so a class-set change invalidates the
-        // per-procedure lattices.
-        let known_class_set = collect_known_classes(source, registry);
-        let known_classes: Vec<String> = {
-            let mut v: Vec<String> = known_class_set.iter().cloned().collect();
-            v.sort_unstable();
-            v
+        let (call_site_constants, command_mutations, linkage) =
+            resolve_unit_scope(&ir_module, &cfg_module, cfg_context.as_ref(), options);
+        let caller_view = crate::unit_scope::UnitCallerView {
+            linkage,
+            has_cross_file_evidence: external_call_sites.is_some(),
+            command_mutations: &command_mutations,
         };
-        // Every name any procedure/method declares via `global NAME` —
-        // top-level bare names already live in the global frame, so a call
-        // to such a procedure can reassign one mid-run even though the
-        // top-level body never mentions it via `global` itself. See
-        // `crate::var_observability::scan_module_global_names`.
-        let top_level_extra_escaping =
-            crate::var_observability::scan_module_global_names(&ir_module);
+        let ModuleWideFacts {
+            known_class_set,
+            known_classes,
+            top_level_extra_escaping,
+            traced_variable_names,
+        } = ModuleWideFacts::collect(source, &ir_module, registry);
         // Whole-module variable-trace fact — computed once by lowering
         // and stored on `ir_module`, so every per-function build below is a
-        // cheap reference pass-through, not a recomputation. `traced_variable_names`
-        // is the `Vec` form (already sorted — `BTreeSet` iterates in order)
-        // `LatticeRequest`'s memo key carries, mirroring `known_classes`.
+        // cheap reference pass-through, not a recomputation.
         let trace_facts = ModuleTraceFacts {
             traced_variables: &ir_module.traced_variables,
             has_dynamic_variable_trace: ir_module.has_dynamic_variable_trace,
         };
-        let traced_variable_names: Vec<String> =
-            ir_module.traced_variables.iter().cloned().collect();
         let top_level = FunctionUnit::build_full(
             "::top",
             cfg_module.top_level.clone(),
@@ -805,96 +1051,22 @@ impl CompilationUnit {
                 trace_facts,
             },
         );
-        let mut procedures: HashMap<String, FunctionUnit> = HashMap::new();
-        for (qname, cfg) in &cfg_module.procedures {
-            let params = ir_module
-                .procedures
-                .get(qname)
-                .map_or(&[][..], |p| p.params.as_slice());
-            let param_constants = params_constants_from_call_sites(
-                params,
-                &call_site_constants,
-                qname,
-                &command_mutations,
-                has_package_provide,
-            );
-            let proc = ir_module.procedures.get(qname);
-            // Complexity guard (block-count or body-byte half): skip both the
-            // memo and the deep analysis for an oversized body. A flat
-            // generated proc is block-light yet byte-huge, so the byte test is
-            // what catches it.
-            let body_bytes = proc.map_or(0usize, |p| {
-                p.span.end().saturating_sub(p.span.start()) as usize
-            });
-            if body_bytes > crate::ssa::DEEP_ANALYSIS_BODY_BYTES
-                || crate::ssa::is_complexity_guarded(cfg)
-            {
-                procedures.insert(
-                    qname.clone(),
-                    FunctionUnit::trivial_guarded(qname, cfg.clone()),
-                );
-                continue;
-            }
-            let body_offset = proc.map_or(0, |p| p.span.start());
-            // Encode the interprocedural seeds into the hashable form the memo
-            // key carries.  The interproc `param_constants` are folded *into*
-            // the key (not a fresh-build escape hatch as before), so a procedure
-            // with caller-uniform literals still engages the memo — its key
-            // simply also distinguishes the seeds, so it rebuilds iff a caller's
-            // literal at that position changes.  `None` means a seed shape we
-            // can't intern (defensive; the current producer only emits string
-            // consts) → build fresh.
-            let encoded_pc = encode_param_constants(param_constants.as_ref());
-            // Route through the memo only when (a) a cache is present, (b) the
-            // procedure has a real body, (c) the module context is available,
-            // and (d) the seeds encode into the hashable key form.
-            let memoised = match (cache.as_mut(), proc, cfg_context.as_ref(), encoded_pc) {
-                (
-                    Some(memo),
-                    Some(proc),
-                    Some((upvar_procs, proc_params, global_write_procs)),
-                    Some(encoded_pc),
-                ) => {
-                    // Normalise the body to offset 0 so a shifted-but-unchanged
-                    // procedure produces an identical request (memo hit).
-                    let mut body = proc.body.clone();
-                    crate::lattice_rebase::rebase_script(&mut body, -i64::from(body_offset));
-                    let mut fu = memo(&LatticeRequest {
-                        qname,
-                        body: &body,
-                        params,
-                        upvar_procs,
-                        proc_params,
-                        global_write_procs,
-                        dialect,
-                        param_constants: &encoded_pc,
-                        known_classes: &known_classes,
-                        traced_variables: &traced_variable_names,
-                        has_dynamic_variable_trace: ir_module.has_dynamic_variable_trace,
-                    });
-                    // Rebase the offset-0 memo result to the procedure's real
-                    // position so every consumer sees **absolute** spans without
-                    // needing offset-awareness — robust against new/upstream
-                    // diagnostic & optimiser passes that read `fu.cfg` spans
-                    // directly (`base_offset` stays 0; `abs_span` is identity).
-                    crate::lattice_rebase::rebase_function_unit(&mut fu, i64::from(body_offset));
-                    Some(fu)
-                }
-                _ => None,
-            };
-            let fu = memoised.unwrap_or_else(|| {
-                FunctionUnit::build_with_param_constants_and_classes(
-                    qname,
-                    cfg.clone(),
-                    params,
-                    registry,
-                    param_constants.as_ref(),
-                    &known_class_set,
-                    trace_facts,
-                )
-            });
-            procedures.insert(qname.clone(), fu);
-        }
+        let mut procedures = build_procedure_units(
+            &ProcedureBuildContext {
+                ir_module: &ir_module,
+                cfg_module: &cfg_module,
+                cfg_context: cfg_context.as_ref(),
+                registry,
+                dialect,
+                call_sites: &call_site_constants,
+                caller_view: &caller_view,
+                known_class_set: &known_class_set,
+                known_classes: &known_classes,
+                traced_variable_names: &traced_variable_names,
+                trace_facts,
+            },
+            cache,
+        );
         let methods = Self::build_method_units(
             &ir_module,
             cfg_context.as_ref(),
@@ -936,6 +1108,11 @@ impl CompilationUnit {
             body_units,
             interproc: None,
             connection_scope,
+            caller_scope: UnitCallerScope {
+                linkage: caller_view.linkage,
+                has_cross_file_evidence: caller_view.has_cross_file_evidence,
+                call_sites: call_site_constants,
+            },
         }
     }
 
@@ -1374,15 +1551,6 @@ impl CompilationUnit {
     }
 }
 
-/// Per-arg-position call-site literal evidence for one callee.
-#[derive(Default)]
-struct ArgConsts {
-    /// At least one call passed a non-literal (`$`/`[`) value here.
-    unknown: bool,
-    /// Distinct literal values seen at this position.
-    values: std::collections::HashSet<String>,
-}
-
 /// Fully-qualified names of every class defined in `source`.
 ///
 /// Sourced from [`crate::signature_scan`] (which records `oo::class create` and
@@ -1409,442 +1577,6 @@ fn collect_known_classes(source: &str, registry: &CommandRegistry) -> HashSet<St
         .classes
         .into_keys()
         .collect()
-}
-
-/// Recursion cap for [`record_call_site_evidence`]'s descent into nested
-/// `ArgRole::Body` arguments (`catch { catch { catch { … } } }` and similar) —
-/// defensive against a pathological or generated nesting depth; real code
-/// never approaches it.
-const MAX_CALL_SITE_BODY_DEPTH: tcl_core_types::RecursionLimit = tcl_core_types::RecursionLimit(16);
-
-/// Invariant context [`record_call_site_evidence`] threads unchanged through
-/// its recursion into nested `ArgRole::Body` arguments — grouped into one
-/// struct (rather than passed as five separate parameters) purely to keep
-/// the recursive function's own argument count down to the two things that
-/// actually change per call (`caller_qname` stays fixed across one top-level
-/// statement's recursion, `command`/`args`/`depth` do not).
-struct CallSiteScanCtx<'a> {
-    procedures: &'a HashMap<String, crate::ir::Procedure>,
-    known: &'a HashSet<String>,
-    registry: &'a CommandRegistry,
-    dialect: &'a str,
-    /// `namespace import` directives (`(importing_namespace, absolute_pattern)`
-    /// pairs), from [`crate::ir::Module::namespace_imports`] — see
-    /// [`resolve_via_namespace_import`].
-    namespace_imports: &'a [(String, String)],
-}
-
-/// Resolve `command` to a qualified proc name via a `namespace import`
-/// directive active in `caller_qname`'s own namespace, when
-/// [`crate::interprocedural::resolve_internal_call`] found no direct match.
-///
-/// `namespace import ::lib::helper` binds the bare name `helper` in the
-/// importing namespace to `::lib::helper` — a real command-resolution path
-/// distinct from (and checked *after*) plain namespace-relative lookup, so a
-/// call site reached only this way was invisible to the collector before
-/// this: `::lib::helper`'s only *visible* caller was some unrelated external
-/// call, while every importing-namespace caller's (potentially differing)
-/// argument silently vanished from the evidence, exactly like the
-/// namespace-blind recursion and `ArgRole::Body` gaps above.
-///
-/// `::foo::*` (wildcard) imports resolve `command` under `::foo`; an exact
-/// pattern (`::foo::bar`) binds only its own leaf name — `namespace_imports`
-/// already only ever records absolute patterns (relative ones need runtime
-/// namespace-path walking this compile-time pass does not model, per
-/// [`crate::ir::Module::namespace_imports`]'s own doc).
-fn resolve_via_namespace_import<S: std::hash::BuildHasher>(
-    command: &str,
-    caller_qname: &str,
-    namespace_imports: &[(String, String)],
-    known: &HashSet<String, S>,
-) -> Option<String> {
-    if namespace_imports.is_empty() {
-        return None;
-    }
-    let ns_parts = crate::interprocedural::namespace_parts_from_proc(caller_qname);
-    let caller_ns = if ns_parts.is_empty() {
-        "::".to_owned()
-    } else {
-        format!("::{}", ns_parts.join("::"))
-    };
-    for (import_ns, pattern) in namespace_imports {
-        if *import_ns != caller_ns {
-            continue;
-        }
-        if let Some(ns_prefix) = pattern.strip_suffix("::*") {
-            let candidate = format!("{ns_prefix}::{command}");
-            if known.contains(&candidate) {
-                return Some(candidate);
-            }
-        } else if pattern.rsplit("::").next().unwrap_or(pattern.as_str()) == command
-            && known.contains(pattern)
-        {
-            return Some(pattern.clone());
-        }
-    }
-    None
-}
-
-/// Record one call site's literal-argument evidence into `out`, then recurse
-/// into any `ArgRole::Body` argument of `command` (regardless of whether
-/// `command` itself is a user proc) — a nested script embedded in a nested
-/// script embedded in a nested script, and so on, up to
-/// [`MAX_CALL_SITE_BODY_DEPTH`].
-///
-/// This is the fix for the residual gap issue #969's own root cause left
-/// open: `catch { isEven 4 }`, a non-exact `switch` arm, a literal `uplevel
-/// {…}` / `apply {{…} {…}}` body, and friends all carry their nested script
-/// as one opaque *argument string* to a builtin (`catch`, `switch`,
-/// `uplevel`, `apply`) that is never itself a user proc — so a flat,
-/// one-level `Statement::Call`/`Statement::Barrier` walk resolves `catch`
-/// (finds no matching proc, moves on) and never notices `isEven 4` sitting
-/// inside its body argument at all. That's a *second* proc call this scan
-/// cannot see, exactly like the namespace-resolution gap: an invisible call
-/// site with a differing argument silently vanishes from
-/// [`params_constants_from_call_sites`]'s "every caller agrees" evidence.
-///
-/// The registry already knows which argument position of which command is a
-/// script body (`ArgRole::Body`, driving the identical recursive call-graph
-/// walk in [`crate::interprocedural::scan_source_for_calls`] and the
-/// `BODY`-role scans in `ir_helpers.rs` / `place_bridge.rs` / `ssa.rs`) — so
-/// this reuses that one fact via [`tcl_registry::CommandRegistry::arg_indices_for_role`]
-/// and the shared [`crate::segmenter`] rather than hand-rolling a second
-/// "which commands embed scripts" list here.
-fn record_call_site_evidence(
-    out: &mut HashMap<String, HashMap<usize, ArgConsts>>,
-    ctx: &CallSiteScanCtx<'_>,
-    caller_qname: &str,
-    command: &str,
-    args: &[String],
-    depth: u32,
-) {
-    // A dynamically-dispatched command word (`$cmd args`) can't be resolved
-    // to any specific callee, so it never counts as a call site — but nor
-    // does it disqualify anyone else's: this scan has never claimed to
-    // enumerate every indirect dispatch, only every statically-resolvable
-    // one (including, now, one level of script-body nesting at a time).
-    if !command.contains(['$', '['])
-        && let Some(target) = crate::interprocedural::resolve_internal_call(
-            command,
-            caller_qname,
-            ctx.known,
-        )
-        .or_else(|| {
-            resolve_via_namespace_import(command, caller_qname, ctx.namespace_imports, ctx.known)
-        })
-    {
-        // A call that omits a (defaulted) parameter uses its default, an
-        // unknown value at that slot — poison every param position this
-        // call doesn't provide so a single literal at another call site
-        // can't bind it (omitted args are treated as unknown).
-        let nparams = ctx.procedures.get(&target).map_or(0, |p| p.params.len());
-        let by_idx = out.entry(target).or_default();
-        for (i, arg) in args.iter().enumerate() {
-            let slot = by_idx.entry(i).or_default();
-            if arg.contains(['$', '[']) {
-                slot.unknown = true;
-            } else {
-                slot.values.insert(arg.clone());
-            }
-        }
-        for i in args.len()..nparams {
-            by_idx.entry(i).or_default().unknown = true;
-        }
-    }
-    if MAX_CALL_SITE_BODY_DEPTH.exceeded(depth + 1) {
-        return;
-    }
-    let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
-    for idx in ctx
-        .registry
-        .arg_indices_for_role(command, &arg_strs, tcl_registry::ArgRole::Body)
-    {
-        let Some(body_text) = args.get(idx) else {
-            continue;
-        };
-        let nested = crate::segmenter::segment_commands_with_offset_and_config(
-            body_text,
-            0,
-            tcl_lexer::LexerConfig::for_dialect(ctx.dialect),
-        );
-        for cmd in &nested {
-            let name = cmd.name();
-            if name.is_empty() {
-                continue;
-            }
-            record_call_site_evidence(out, ctx, caller_qname, name, cmd.args(), depth + 1);
-        }
-    }
-}
-
-/// Build bare CFGs (no further per-function analysis) for every `TclOO` method
-/// and synthetic body unit (`apply` lambda, `namespace eval` body), so
-/// [`collect_call_site_constants`] can walk them as *callers* too.
-///
-/// Neither is itself ever seeded with `param_constants`
-/// (`build_method_units` / `build_body_units` always pass `None` for their
-/// own analysis), but a call *from* one of their bodies *to* an ordinary
-/// user proc is a real call site whose argument can vary between call
-/// sites, exactly like a bare top-level or proc-body call — invisible to
-/// the collector before this, which walked only `cfg_module.top_level` and
-/// `cfg_module.procedures`. The same class of bug as issue #969's own root
-/// cause (a real, varying call site silently missing from the "every
-/// caller agrees" evidence), reached through a method/lambda body instead
-/// of namespace-blind recursion or a `catch`/`uplevel` body.
-///
-/// Returns an empty `Vec` (no cost beyond the emptiness checks) when the
-/// module has neither methods nor body units — the overwhelmingly common
-/// case — or when `cfg_context` is `None` (methods/body units require it;
-/// [`CompilationUnit::build_for_inner`] only omits it when both are empty).
-fn build_extra_call_site_scan_contexts(
-    ir_module: &IrModule,
-    cfg_context: Option<&CfgContext>,
-) -> Vec<(String, CfgFunction)> {
-    if ir_module.methods.is_empty() && ir_module.body_units.is_empty() {
-        return Vec::new();
-    }
-    let Some((upvar_procs, proc_params, global_write_procs)) = cfg_context else {
-        return Vec::new();
-    };
-    let build = |qname: &str, body: &crate::ir::Script| {
-        crate::cfg_builder::build_cfg_function_with_upvars(
-            qname,
-            body,
-            true,
-            upvar_procs.clone(),
-            proc_params.clone(),
-            global_write_procs.clone(),
-        )
-    };
-    ir_module
-        .methods
-        .iter()
-        .map(|(mqname, method)| {
-            // tclsh8.6-confirmed (live): a bare command inside a `TclOO`
-            // method body resolves against the GLOBAL namespace, never the
-            // class's own declaring namespace — `method go {} { helper }`
-            // calls `::helper` even when a proc of the same name sits in
-            // the class's own namespace. `mqname`'s own namespace (e.g.
-            // `::foo::Widget` for method `::foo::Widget::go`) would be
-            // wrong here, so the caller-context string this scan resolves
-            // against is forced to global — reusing `"::top"`, the same
-            // pseudo-qname the top-level script already uses to mean
-            // exactly that. The CFG's own identity still uses the real
-            // `mqname` (unrelated to this scan's namespace concern).
-            ("::top".to_owned(), build(mqname, &method.body))
-        })
-        .chain(
-            ir_module
-                .body_units
-                .iter()
-                .map(|(qname, unit)| (qname.clone(), build(qname, &unit.body))),
-        )
-        .collect()
-}
-
-/// True when `ir_module` contains a resolved `package provide` invocation
-/// anywhere — top level, any proc/method/body-unit, or nested inside control
-/// flow. A registry/IR-level check (Codex review, PR #970) rather than the
-/// raw-text substring scan it replaces: that scan both over-triggered (any
-/// script merely *mentioning* the phrase in a comment, string, or embedded
-/// example disabled every interprocedural seed in the file) and
-/// under-triggered (a real invocation spelled `package\tprovide` or
-/// `::package provide` didn't match the literal substring, silently
-/// re-opening the exact cross-file soundness gap this guard exists to close).
-fn has_package_provide_statement(ir_module: &IrModule) -> bool {
-    use crate::ir::Statement;
-
-    fn is_package_provide(command: &str, args: &[String]) -> bool {
-        command.trim_start_matches("::") == "package"
-            && args.first().map(String::as_str) == Some("provide")
-    }
-
-    fn walk_script(script: &crate::ir::Script) -> bool {
-        script.statements.iter().any(walk_statement)
-    }
-
-    fn walk_statement(stmt: &Statement) -> bool {
-        match stmt {
-            Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. } => {
-                is_package_provide(command, args)
-            }
-            Statement::Block { body, .. }
-            | Statement::UpFrame { body, .. }
-            | Statement::While { body, .. }
-            | Statement::Foreach { body, .. }
-            | Statement::Catch { body, .. } => walk_script(body),
-            Statement::If {
-                clauses, else_body, ..
-            } => {
-                clauses.iter().any(|c| walk_script(&c.body))
-                    || else_body.as_ref().is_some_and(walk_script)
-            }
-            Statement::For {
-                init, next, body, ..
-            } => walk_script(init) || walk_script(next) || walk_script(body),
-            Statement::Try {
-                body,
-                handlers,
-                finally_body,
-                ..
-            } => {
-                walk_script(body)
-                    || handlers.iter().any(|h| walk_script(&h.body))
-                    || finally_body.as_ref().is_some_and(walk_script)
-            }
-            Statement::Switch {
-                arms, default_body, ..
-            } => {
-                arms.iter()
-                    .any(|a| a.body.as_ref().is_some_and(walk_script))
-                    || default_body.as_ref().is_some_and(walk_script)
-            }
-            Statement::AssignConst { .. }
-            | Statement::AssignExpr { .. }
-            | Statement::AssignValue { .. }
-            | Statement::Incr { .. }
-            | Statement::ExprEval { .. }
-            | Statement::Return { .. } => false,
-        }
-    }
-
-    walk_script(&ir_module.top_level)
-        || ir_module.procedures.values().any(|p| walk_script(&p.body))
-        || ir_module.methods.values().any(|m| walk_script(&m.body))
-        || ir_module.body_units.values().any(|b| walk_script(&b.body))
-}
-
-/// Collect literal arg values per user-proc call site across the whole
-/// module's CFGs (top-level + every proc/method/body-unit, statements
-/// already flattened), including calls nested inside `ArgRole::Body`
-/// arguments (`catch { … }`, a literal `uplevel { … }`, `apply {{…} {…}}`, a
-/// non-exact `switch` arm, …) via [`record_call_site_evidence`].
-///
-/// Each call site is resolved to its callee via
-/// [`crate::interprocedural::resolve_internal_call`] — Tcl's real,
-/// existence-checked, namespace-relative resolution order, evaluated in the
-/// *calling* function's own namespace, not the global one. This is the same
-/// resolver the analyser and optimiser use for identical same-file call
-/// resolution; a bespoke or partial resolver here could disagree with them
-/// on which callee a bare name reaches.
-///
-/// The namespace context matters because a call site this scan fails to
-/// resolve doesn't just go uncounted — it *vanishes* from
-/// [`params_constants_from_call_sites`]'s "every caller passes the same
-/// literal" evidence, which can flip an absence of contradicting evidence
-/// into a false positive. Issue #969: a proc declared inside a `namespace
-/// eval` block recursed into itself by its bare (unqualified) name; the old
-/// resolver only ever tried global-qualified spellings of the command word,
-/// so it could never match the proc's namespaced qualified name, and the
-/// recursive self-call — whose argument necessarily varies call to call —
-/// was silently dropped. Only the one external, fully-qualified caller's
-/// literal remained, so the loop/recursion-varying parameter was seeded as
-/// that one constant and folded a genuinely alternating condition (`$count &
-/// 1`) to a fixed boolean.
-fn collect_call_site_constants(
-    cfg_module: &CfgModule,
-    extra_callers: &[(String, CfgFunction)],
-    procedures: &HashMap<String, crate::ir::Procedure>,
-    namespace_imports: &[(String, String)],
-    registry: &CommandRegistry,
-    dialect: &str,
-) -> HashMap<String, HashMap<usize, ArgConsts>> {
-    use crate::ir::Statement;
-    let mut out: HashMap<String, HashMap<usize, ArgConsts>> = HashMap::new();
-    let known: HashSet<String> = procedures.keys().cloned().collect();
-    let ctx = CallSiteScanCtx {
-        procedures,
-        known: &known,
-        registry,
-        dialect,
-        namespace_imports,
-    };
-    // The top level has no qualified name of its own; `"::top"` (the same
-    // pseudo-qname `FunctionUnit::build_full` uses for it) resolves to the
-    // global namespace via `resolve_internal_call`'s "drop the last
-    // segment" rule, matching a bare top-level call's real resolution
-    // scope.
-    let funcs = std::iter::once(("::top", &cfg_module.top_level))
-        .chain(cfg_module.procedures.iter().map(|(q, f)| (q.as_str(), f)))
-        .chain(extra_callers.iter().map(|(q, f)| (q.as_str(), f)));
-    for (caller_qname, func) in funcs {
-        for block in func.blocks.values() {
-            for stmt in &block.statements {
-                let (Statement::Call { command, args, .. }
-                | Statement::Barrier { command, args, .. }) = stmt
-                else {
-                    continue;
-                };
-                record_call_site_evidence(&mut out, &ctx, caller_qname, command, args, 0);
-            }
-        }
-    }
-    out
-}
-
-/// Build the SCCP `param_constants` seed for `qname` from collected call-site
-/// literals: bind `(param, 0)` only when every caller passes the same single
-/// literal at that position.
-///
-/// Beyond the per-slot literal-uniformity test, two whole-module gates must
-/// also hold — each closes a way the call sites
-/// [`collect_call_site_constants`] resolved could be an incomplete picture
-/// of every real caller (an unproven "every caller I found agrees" says
-/// nothing about callers that scan couldn't see):
-///
-/// - `!command_mutations.trusts_proc_binding(qname)` — `qname`'s own
-///   binding may have been perturbed by `rename` / `interp alias` / a
-///   dynamic proc redefinition anywhere in the module, so a call reaching
-///   it at runtime need not be one this scan attributed to it (and vice
-///   versa).
-/// - `has_package_provide` — the file declares `package provide`, so
-///   `qname` may be public package API that a caller in some OTHER file
-///   invokes with a different literal; [`collect_call_site_constants`] only
-///   ever sees the current file's call sites (this compilation unit is
-///   single-file, so it cannot rule out cross-file callers by itself).
-///
-/// A call site dispatched through a non-literal command word (`$cmd args`)
-/// is deliberately NOT treated as a module-wide wildcard here: it can't be
-/// resolved to any specific callee, so `collect_call_site_constants` already
-/// never counts it as evidence for (or against) any particular proc's
-/// params, the same way it has always treated any other unresolvable call.
-fn params_constants_from_call_sites(
-    params: &[String],
-    call_site_constants: &HashMap<String, HashMap<usize, ArgConsts>>,
-    qname: &str,
-    command_mutations: &crate::command_binding::ModuleCommandMutations,
-    has_package_provide: bool,
-) -> Option<HashMap<(String, crate::ssa::Version), crate::analyses::LatticeValue>> {
-    use crate::analyses::{ConstValue, LatticeValue};
-    if has_package_provide {
-        return None;
-    }
-    if !command_mutations.trusts_proc_binding(qname) {
-        return None;
-    }
-    let by_idx = call_site_constants.get(qname)?;
-    let mut consts: HashMap<(String, crate::ssa::Version), LatticeValue> = HashMap::new();
-    for (i, pname) in params.iter().enumerate() {
-        if pname == "args" {
-            break;
-        }
-        let Some(slot) = by_idx.get(&i) else {
-            continue;
-        };
-        if slot.unknown || slot.values.len() != 1 {
-            continue;
-        }
-        let val = slot.values.iter().next().unwrap().clone();
-        consts.insert(
-            (pname.clone(), 0),
-            LatticeValue::Const(ConstValue::String(val)),
-        );
-    }
-    if consts.is_empty() {
-        None
-    } else {
-        Some(consts)
-    }
 }
 
 /// Encode interprocedural `param_constants` (caller-uniform-literal SCCP seeds)
@@ -2313,6 +2045,26 @@ mod tests {
             );
         }
 
+        /// `::lib::helper` has two resolvable callers — one direct, one
+        /// through a `namespace import ::lib::*` wildcard alias — and both
+        /// pass `"prod"`.  Carries no `namespace export`: the scan resolves
+        /// the import from the recorded directive (export *enforcement* is
+        /// not modelled), and an export would cross the `EXPORTS_COMMAND`
+        /// boundary the sibling test below exercises deliberately.
+        const WILDCARD_IMPORT_SRC: &str = "
+            namespace eval ::lib {
+                proc helper {mode} {
+                    if {$mode eq \"prod\"} { set r 1 } else { set r 2 }
+                }
+            }
+            namespace eval ::app {
+                namespace import ::lib::*
+                proc go {} { helper prod }
+            }
+            ::lib::helper prod
+            ::app::go
+        ";
+
         /// TP control: a wildcard `namespace import ::lib::*` alias must
         /// still resolve correctly (not just exact-name imports), and the
         /// mechanism must still fold when every resolved caller — direct and
@@ -2320,27 +2072,39 @@ mod tests {
         #[test]
         fn wildcard_namespace_import_alias_resolves_and_still_folds_when_uniform() {
             let reg = registry();
-            let src = "
-                namespace eval ::lib {
-                    namespace export *
-                    proc helper {mode} {
-                        if {$mode eq \"prod\"} { set r 1 } else { set r 2 }
-                    }
-                }
-                namespace eval ::app {
-                    namespace import ::lib::*
-                    proc go {} { helper prod }
-                }
-                ::lib::helper prod
-                ::app::go
-            ";
-            let cu = CompilationUnit::build_for(src, &reg, false);
+            let cu = CompilationUnit::build_for(WILDCARD_IMPORT_SRC, &reg, false);
             let f = cu.procedures.get("::lib::helper").expect("helper analysed");
             assert!(
                 folds_condition_mentioning(f, "mode"),
                 "both the direct and the wildcard-imported caller pass \"prod\": {:?}",
                 f.sccp.constant_branches,
             );
+        }
+
+        /// FP guard (issue #977): adding `namespace export *` to the very
+        /// same source must stop the fold — and, unlike a `source` boundary,
+        /// must keep stopping it even when a host supplies a workspace view.
+        /// An export publishes `::lib::helper` for *any* other unit to import
+        /// and call with a different literal, including one in a different
+        /// checkout that no project enumeration can reach.
+        #[test]
+        fn exported_namespace_declines_the_seed_even_with_a_workspace_view() {
+            let reg = registry();
+            let exported = WILDCARD_IMPORT_SRC.replace(
+                "namespace eval ::lib {",
+                "namespace eval ::lib {\n                namespace export *",
+            );
+            for cu in [
+                CompilationUnit::build_for(&exported, &reg, false),
+                build_closed_world(&exported, &reg),
+            ] {
+                let f = cu.procedures.get("::lib::helper").expect("helper analysed");
+                assert!(
+                    !folds_condition_mentioning(f, "mode"),
+                    "`namespace export *` publishes helper beyond any enumerable project: {:?}",
+                    f.sccp.constant_branches,
+                );
+            }
         }
 
         /// FP guard (Codex review, PR #970): a `TclOO` method body resolves
@@ -2499,6 +2263,24 @@ mod tests {
         /// True if any constant-branch condition recorded for `fu` mentions
         /// `needle` (a variable name) — the ambient SCCP-fold check the I230
         /// diagnostic, and the O101/O107 optimiser suggestions, all key off.
+        /// Build `src` under a **closed world**: an empty cross-file evidence
+        /// set, which is the host asserting "I enumerated the project and no
+        /// other file calls into this one".  The pre-issue-#977 semantics for
+        /// a file that is genuinely the whole program.
+        fn build_closed_world(src: &str, reg: &CommandRegistry) -> CompilationUnit {
+            let empty = crate::unit_scope::CallSiteEvidence::default();
+            CompilationUnit::build_with_options(
+                src,
+                UnitBuildOptions {
+                    registry: reg,
+                    defer_top_level: false,
+                    config: tcl_lexer::LexerConfig::default(),
+                    dialect: "",
+                    external_call_sites: Some(&empty),
+                },
+            )
+        }
+
         fn folds_condition_mentioning(fu: &FunctionUnit, needle: &str) -> bool {
             fu.sccp
                 .constant_branches
@@ -2870,6 +2652,200 @@ mod tests {
                 "a real (if oddly-spelled) package provide must still disqualify: {:?}",
                 helper.sccp.constant_branches,
             );
+        }
+
+        /// Issue #977 (the two-file repro, verbatim): `lib.tcl` has **no**
+        /// `package provide`, so PR #970's guard never fires; its only two
+        /// visible callers both pass `"prod"`, so `mode` was seeded as that
+        /// constant and the condition folded — even though `main.tcl`
+        /// `source`s it and calls `helper dev`.
+        mod cross_file {
+            use super::*;
+            use crate::unit_scope::CallSiteEvidence;
+
+            /// `lib.tcl` from the issue: a plain library file, no `package
+            /// provide`, whose in-file callers agree.
+            const LIB: &str = "
+                proc helper {mode} {
+                    if {$mode eq \"prod\"} { set r 1 } else { set r 2 }
+                }
+                helper prod
+                helper prod
+            ";
+
+            /// `main.tcl` from the issue: sources the library and calls its
+            /// proc with a literal `lib.tcl` never sees.
+            const MAIN: &str = "
+                source lib.tcl
+                helper dev
+            ";
+
+            /// Cross-file evidence a host builds from `other`, resolved
+            /// against the procedures `LIB` declares.
+            fn evidence_from(other: &str, reg: &CommandRegistry) -> CallSiteEvidence {
+                let known: HashSet<String> = ["::helper".to_owned()].into_iter().collect();
+                crate::unit_scope::scan_source_call_sites(other, reg, "", &known)
+            }
+
+            fn build_with_evidence(
+                src: &str,
+                reg: &CommandRegistry,
+                evidence: &CallSiteEvidence,
+            ) -> CompilationUnit {
+                CompilationUnit::build_with_options(
+                    src,
+                    UnitBuildOptions {
+                        registry: reg,
+                        defer_top_level: false,
+                        config: tcl_lexer::LexerConfig::default(),
+                        dialect: "",
+                        external_call_sites: Some(evidence),
+                    },
+                )
+            }
+
+            /// FP guard — the reported bug. With `main.tcl`'s `helper dev`
+            /// merged in, `mode` has two distinct literals and must not fold.
+            #[test]
+            fn sourcing_file_with_a_differing_literal_retracts_the_fold() {
+                let reg = registry();
+                let evidence = evidence_from(MAIN, &reg);
+                let cu = build_with_evidence(LIB, &reg, &evidence);
+                let helper = cu.procedures.get("::helper").expect("helper analysed");
+                assert!(
+                    !folds_condition_mentioning(helper, "mode"),
+                    "main.tcl calls helper with \"dev\"; lib.tcl must not fold on \"prod\": {:?}",
+                    helper.sccp.constant_branches,
+                );
+            }
+
+            /// The evidence itself, before any lattice: the cross-file scan
+            /// must attribute `helper dev` to `::helper` at position 0.
+            #[test]
+            fn cross_file_scan_attributes_the_call_to_the_library_proc() {
+                let reg = registry();
+                let evidence = evidence_from(MAIN, &reg);
+                let helper = evidence.get("::helper").expect("helper call recorded");
+                assert_eq!(helper.uniform_literal_at(0), Some("dev"));
+            }
+
+            /// TP control — the mechanism must still fold when the other file
+            /// agrees. `main.tcl` passing `prod` too leaves one literal
+            /// across the whole project, so the seed is sound and fires.
+            #[test]
+            fn sourcing_file_agreeing_on_the_literal_still_folds() {
+                let reg = registry();
+                let evidence = evidence_from("source lib.tcl\nhelper prod\n", &reg);
+                let cu = build_with_evidence(LIB, &reg, &evidence);
+                let helper = cu.procedures.get("::helper").expect("helper analysed");
+                assert!(
+                    folds_condition_mentioning(helper, "mode"),
+                    "every caller in the project passes \"prod\"; the seed is sound: {:?}",
+                    helper.sccp.constant_branches,
+                );
+            }
+
+            /// TN control — a workspace file that never mentions `helper`
+            /// contributes no evidence and must not disturb the fold.
+            #[test]
+            fn unrelated_workspace_file_contributes_nothing() {
+                let reg = registry();
+                let evidence = evidence_from("proc other {x} { return $x }\nother 1\n", &reg);
+                assert!(evidence.is_empty(), "no call to ::helper was written");
+                let cu = build_with_evidence(LIB, &reg, &evidence);
+                let helper = cu.procedures.get("::helper").expect("helper analysed");
+                assert!(
+                    folds_condition_mentioning(helper, "mode"),
+                    "an unrelated file must not retract a sound fold: {:?}",
+                    helper.sccp.constant_branches,
+                );
+            }
+
+            /// FN guard — a cross-file caller reached through a *dynamic*
+            /// argument is still a caller. `helper $mode` in `main.tcl`
+            /// poisons position 0, so the fold is retracted even though no
+            /// second literal was ever written.
+            #[test]
+            fn cross_file_dynamic_argument_poisons_the_position() {
+                let reg = registry();
+                let evidence = evidence_from("set m dev\nhelper $m\n", &reg);
+                let cu = build_with_evidence(LIB, &reg, &evidence);
+                let helper = cu.procedures.get("::helper").expect("helper analysed");
+                assert!(
+                    !folds_condition_mentioning(helper, "mode"),
+                    "a cross-file caller with a non-literal argument must retract the fold: {:?}",
+                    helper.sccp.constant_branches,
+                );
+            }
+
+            /// FN guard — a cross-file *deferred* caller (`after 0 helper`,
+            /// a `-command` callback, `trace add variable`) invokes the proc
+            /// with words appended at runtime, so no position is uniform.
+            /// The callback slot comes from `ArgRole::CommandPrefix`, not a
+            /// command-name list in the compiler.
+            #[test]
+            fn cross_file_command_prefix_callback_poisons_every_position() {
+                let reg = registry();
+                let evidence = evidence_from("after 0 helper\n", &reg);
+                let cu = build_with_evidence(LIB, &reg, &evidence);
+                let helper = cu.procedures.get("::helper").expect("helper analysed");
+                assert!(
+                    !folds_condition_mentioning(helper, "mode"),
+                    "a deferred cross-file callback appends unknown words: {:?}",
+                    helper.sccp.constant_branches,
+                );
+            }
+
+            /// FN guard — a cross-file `rename` moves `helper`'s binding, so
+            /// a call reaching it need not be one any scan attributed to it.
+            /// `command_mutations` only sees the file being compiled, so
+            /// without this the rebinding was invisible across files.
+            #[test]
+            fn cross_file_rename_poisons_the_callee() {
+                let reg = registry();
+                let evidence = evidence_from("rename helper legacy_helper\n", &reg);
+                let cu = build_with_evidence(LIB, &reg, &evidence);
+                let helper = cu.procedures.get("::helper").expect("helper analysed");
+                assert!(
+                    !folds_condition_mentioning(helper, "mode"),
+                    "another file renamed helper; its binding has moved: {:?}",
+                    helper.sccp.constant_branches,
+                );
+            }
+
+            /// A `source`ing file is itself a boundary: `lib.tcl` on its own
+            /// (no workspace view) has no boundary at all and still folds —
+            /// the documented, accepted limit of a standalone single-file
+            /// build — but the *sourcing* file's own procs do not, because
+            /// `source` declares `LOADS_EXTERNAL_UNIT`.
+            #[test]
+            fn a_file_that_sources_another_declines_the_seed_on_its_own() {
+                let reg = registry();
+                let src = "
+                    source lib.tcl
+                    proc local {mode} {
+                        if {$mode eq \"prod\"} { set r 1 } else { set r 2 }
+                    }
+                    local prod
+                    local prod
+                ";
+                let cu = CompilationUnit::build_for(src, &reg, false);
+                let f = cu.procedures.get("::local").expect("local analysed");
+                assert!(
+                    !folds_condition_mentioning(f, "mode"),
+                    "the sourced file's script can call ::local with anything: {:?}",
+                    f.sccp.constant_branches,
+                );
+                // …and with a workspace view that says otherwise, it folds.
+                let empty = CallSiteEvidence::default();
+                let closed = build_with_evidence(src, &reg, &empty);
+                let f = closed.procedures.get("::local").expect("local analysed");
+                assert!(
+                    folds_condition_mentioning(f, "mode"),
+                    "with the project enumerated, the boundary is no longer a blind spot: {:?}",
+                    f.sccp.constant_branches,
+                );
+            }
         }
 
         /// FN regression pinned at the `LatticeValue` level (not just

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -154,6 +154,7 @@ pub mod tcl_expr_eval;
 pub mod text;
 pub mod type_infer;
 pub mod types;
+pub mod unit_scope;
 pub mod uri_split;
 pub mod value_provenance;
 pub mod value_shapes;

--- a/rust/tcl-compiler/src/optimiser/branch_folding.rs
+++ b/rust/tcl-compiler/src/optimiser/branch_folding.rs
@@ -509,6 +509,7 @@ mod tests {
             body_units: HashMap::new(),
             interproc: None,
             connection_scope: None,
+            caller_scope: crate::compilation_unit::UnitCallerScope::default(),
         }
     }
 

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -1,0 +1,1112 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Who can call this compilation unit's procedures?
+//!
+//! [`CompilationUnit`](crate::compilation_unit::CompilationUnit) is
+//! single-source-text by construction, but Tcl has no `static`: every `proc`
+//! lands in a global command table any file sharing the interpreter can
+//! reach.  The interprocedural SCCP seed
+//! ([`params_constants_from_call_sites`]) binds a parameter to a compile-time
+//! literal only when **every** caller passes that literal — so the seed is
+//! only as sound as the claim "the call sites I found are all of them".
+//!
+//! This module owns that claim, in three layers:
+//!
+//! 1. **In-unit evidence** — [`collect_call_site_constants`] walks the
+//!    module's own CFGs (top level, every proc, plus the `TclOO` method and
+//!    `apply` / `namespace eval` body units [`build_extra_call_site_scan_contexts`]
+//!    supplies) and records each resolvable call's literal arguments.
+//! 2. **Cross-unit evidence** — [`scan_source_call_sites`] runs the identical
+//!    registry-driven walk over *another* file's source text, resolving each
+//!    call against the whole project's proc names, so a host with a workspace
+//!    view can hand this unit the call sites it could never see itself
+//!    ([`CallSiteEvidence::merge_from`]).  Issue #977: a plain library file
+//!    with no `package provide`, `source`d by a file that calls its procs
+//!    with a different literal, folded a genuinely varying parameter.
+//! 3. **Registry-declared boundaries** — [`scan_unit_linkage`] asks the
+//!    registry ([`CommandRegistry::unit_linkage`]) whether the file itself
+//!    admits to being part of a bigger program: `package provide` /
+//!    `ifneeded` publish it as a package, `namespace export` / `ensemble`
+//!    publish command names, and `source` / `load` / `package require` /
+//!    `auto_load` / `auto_import` pull another unit into the same
+//!    interpreter.  The first two admit callers *no* enumeration bounds, so
+//!    they decline the seed outright; the last defers to layer 2's evidence
+//!    when a host supplied any.  No command name appears here — the traits
+//!    are registry data ([`tcl_registry::UNIT_LINKAGE_TRAITS`]).
+//!
+//! The gate [`params_constants_from_call_sites`] applies is stated in full on
+//! that function.
+
+use std::collections::{BTreeMap, BTreeSet, HashMap, HashSet};
+
+use tcl_registry::{CommandRegistry, Traits};
+
+use crate::cfg::{CfgModule, Function as CfgFunction};
+use crate::ir::Module as IrModule;
+
+/// Recursion cap for [`record_call_site_evidence`]'s descent into nested
+/// `ArgRole::Body` arguments (`catch { catch { catch { … } } }` and similar) —
+/// defensive against a pathological or generated nesting depth; real code
+/// never approaches it.
+const MAX_CALL_SITE_BODY_DEPTH: tcl_core_types::RecursionLimit = tcl_core_types::RecursionLimit(16);
+
+/// Per-arg-position call-site literal evidence for one callee.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct ArgConsts {
+    /// At least one call passed a non-literal (`$`/`[`) value here.
+    pub unknown: bool,
+    /// Distinct literal values seen at this position.  Ordered so the
+    /// evidence — and therefore every seed derived from it and every memo key
+    /// that interns one — is independent of scan order.
+    pub values: BTreeSet<String>,
+}
+
+/// Every call site the scans could attribute to one callee.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CalleeEvidence {
+    /// Argument counts observed across the recorded call sites.  A call that
+    /// supplies fewer arguments than the callee has parameters leaves the
+    /// remaining parameters bound to their **defaults**, an unknown value at
+    /// those positions — so a parameter is only literal-uniform when every
+    /// observed call actually reached it (see [`Self::binds_position`]).
+    pub arg_counts: BTreeSet<usize>,
+    /// Literal evidence per 0-based argument position.
+    pub slots: BTreeMap<usize, ArgConsts>,
+}
+
+impl CalleeEvidence {
+    /// Whether every recorded call site supplied an argument at `index`.
+    #[must_use]
+    pub fn binds_position(&self, index: usize) -> bool {
+        self.arg_counts.iter().all(|&n| n > index)
+    }
+
+    /// The single literal every recorded call passes at `index`, or `None`
+    /// when the position is unknown, absent, omitted by some call, or
+    /// disagreed on.
+    #[must_use]
+    pub fn uniform_literal_at(&self, index: usize) -> Option<&str> {
+        let slot = self.slots.get(&index)?;
+        if slot.unknown || slot.values.len() != 1 || !self.binds_position(index) {
+            return None;
+        }
+        slot.values.first().map(String::as_str)
+    }
+
+    /// Mark every recorded position — and every position a future merge adds
+    /// — as carrying an unknown value.  Used when a caller exists that the
+    /// scan cannot attribute argument-by-argument (an alias, an imported
+    /// name, a `CommandPrefix` callback), where the honest record is "this
+    /// callee has a call site whose arguments I do not know".
+    pub fn poison(&mut self) {
+        self.arg_counts.insert(0);
+        for slot in self.slots.values_mut() {
+            slot.unknown = true;
+        }
+    }
+
+    /// Fold `other`'s call sites into this one.  Merging only ever widens
+    /// (more values, more unknowns, more argument counts), so evidence from a
+    /// second file can retract a fold but never manufacture one.
+    fn merge_from(&mut self, other: &Self) {
+        self.arg_counts.extend(other.arg_counts.iter().copied());
+        for (index, slot) in &other.slots {
+            let mine = self.slots.entry(*index).or_default();
+            mine.unknown |= slot.unknown;
+            mine.values.extend(slot.values.iter().cloned());
+        }
+    }
+}
+
+/// Call-site literal evidence for a set of callees, keyed by resolved
+/// qualified name.
+///
+/// The same shape backs the in-unit scan and the cross-unit one, so a host
+/// supplying workspace evidence is feeding the seed exactly what the unit
+/// would have collected had the other file been part of it.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct CallSiteEvidence {
+    by_callee: BTreeMap<String, CalleeEvidence>,
+}
+
+impl CallSiteEvidence {
+    /// Whether no call site at all was recorded.
+    #[must_use]
+    pub fn is_empty(&self) -> bool {
+        self.by_callee.is_empty()
+    }
+
+    /// The evidence recorded for `qname`, if any.
+    #[must_use]
+    pub fn get(&self, qname: &str) -> Option<&CalleeEvidence> {
+        self.by_callee.get(qname)
+    }
+
+    /// Every callee name evidence was recorded for.
+    pub fn callees(&self) -> impl Iterator<Item = &str> {
+        self.by_callee.keys().map(String::as_str)
+    }
+
+    /// Fold `other`'s call sites in.  See [`CalleeEvidence::merge_from`] —
+    /// merging is monotone, so it can only ever retract a fold.
+    pub fn merge_from(&mut self, other: &Self) {
+        for (qname, evidence) in &other.by_callee {
+            self.by_callee
+                .entry(qname.clone())
+                .or_default()
+                .merge_from(evidence);
+        }
+    }
+
+    /// The sub-table covering just `callees` — what a host hands one file's
+    /// build after merging the whole project's evidence.
+    ///
+    /// Narrowing to the procedures a file actually declares is what keeps
+    /// invalidation precise: a call site edited in one file changes only the
+    /// slice of the file that *defines* the callee.  Driven by `callees`
+    /// (the file's own declarations) rather than by filtering the merged
+    /// table, so the cost is the file's procedure count, not the project's.
+    #[must_use]
+    pub fn slice_for<'n>(&self, callees: impl Iterator<Item = &'n str>) -> Self {
+        let mut out = Self::default();
+        for qname in callees {
+            if let Some(evidence) = self.by_callee.get(qname) {
+                out.by_callee.insert(qname.to_owned(), evidence.clone());
+            }
+        }
+        out
+    }
+
+    /// Record one call: `args` as written, at `arg_count` words.
+    fn record_call(&mut self, qname: String, args: &[String]) {
+        let evidence = self.by_callee.entry(qname).or_default();
+        evidence.arg_counts.insert(args.len());
+        for (index, arg) in args.iter().enumerate() {
+            let slot = evidence.slots.entry(index).or_default();
+            if arg.contains(['$', '[']) {
+                slot.unknown = true;
+            } else {
+                slot.values.insert(arg.clone());
+            }
+        }
+    }
+
+    /// Record that `qname` has a caller whose arguments are unattributable.
+    pub fn record_opaque_caller(&mut self, qname: &str) {
+        self.by_callee.entry(qname.to_owned()).or_default().poison();
+    }
+}
+
+/// Invariant context [`record_call_site_evidence`] threads unchanged through
+/// its recursion into nested `ArgRole::Body` arguments — grouped into one
+/// struct (rather than passed as separate parameters) purely to keep the
+/// recursive function's own argument count down to the things that actually
+/// change per call (`caller_qname` stays fixed across one top-level
+/// statement's recursion, `command`/`args`/`depth` do not).
+struct CallSiteScanCtx<'a, S> {
+    /// The qualified names a call may resolve to.  For the in-unit scan this
+    /// is the unit's own procedures; for [`scan_source_call_sites`] it is the
+    /// whole project's, so a cross-file call resolves to the file that
+    /// actually defines the callee.
+    known: &'a HashSet<String, S>,
+    registry: &'a CommandRegistry,
+    dialect: &'a str,
+    /// `namespace import` directives (`(importing_namespace, absolute_pattern)`
+    /// pairs), from [`crate::ir::Module::namespace_imports`] — see
+    /// [`resolve_via_namespace_import`].
+    namespace_imports: &'a [(String, String)],
+}
+
+/// Resolve `command` to a qualified proc name via a `namespace import`
+/// directive active in `caller_qname`'s own namespace, when
+/// [`crate::interprocedural::resolve_internal_call`] found no direct match.
+///
+/// `namespace import ::lib::helper` binds the bare name `helper` in the
+/// importing namespace to `::lib::helper` — a real command-resolution path
+/// distinct from (and checked *after*) plain namespace-relative lookup, so a
+/// call site reached only this way was invisible to the collector before
+/// this: `::lib::helper`'s only *visible* caller was some unrelated external
+/// call, while every importing-namespace caller's (potentially differing)
+/// argument silently vanished from the evidence, exactly like the
+/// namespace-blind recursion and `ArgRole::Body` gaps.
+///
+/// `::foo::*` (wildcard) imports resolve `command` under `::foo`; an exact
+/// pattern (`::foo::bar`) binds only its own leaf name — `namespace_imports`
+/// already only ever records absolute patterns (relative ones need runtime
+/// namespace-path walking this compile-time pass does not model, per
+/// [`crate::ir::Module::namespace_imports`]'s own doc).
+fn resolve_via_namespace_import<S: std::hash::BuildHasher>(
+    command: &str,
+    caller_qname: &str,
+    namespace_imports: &[(String, String)],
+    known: &HashSet<String, S>,
+) -> Option<String> {
+    if namespace_imports.is_empty() {
+        return None;
+    }
+    let ns_parts = crate::interprocedural::namespace_parts_from_proc(caller_qname);
+    let caller_ns = if ns_parts.is_empty() {
+        "::".to_owned()
+    } else {
+        format!("::{}", ns_parts.join("::"))
+    };
+    for (import_ns, pattern) in namespace_imports {
+        if *import_ns != caller_ns {
+            continue;
+        }
+        if let Some(ns_prefix) = pattern.strip_suffix("::*") {
+            let candidate = format!("{ns_prefix}::{command}");
+            if known.contains(&candidate) {
+                return Some(candidate);
+            }
+        } else if pattern.rsplit("::").next().unwrap_or(pattern.as_str()) == command
+            && known.contains(pattern)
+        {
+            return Some(pattern.clone());
+        }
+    }
+    None
+}
+
+/// Record one call site's literal-argument evidence into `out`, then recurse
+/// into any `ArgRole::Body` argument of `command` (regardless of whether
+/// `command` itself is a user proc) — a nested script embedded in a nested
+/// script embedded in a nested script, and so on, up to
+/// [`MAX_CALL_SITE_BODY_DEPTH`].
+///
+/// This is the fix for the residual gap issue #969's own root cause left
+/// open: `catch { isEven 4 }`, a non-exact `switch` arm, a literal `uplevel
+/// {…}` / `apply {{…} {…}}` body, and friends all carry their nested script
+/// as one opaque *argument string* to a builtin (`catch`, `switch`,
+/// `uplevel`, `apply`) that is never itself a user proc — so a flat,
+/// one-level `Statement::Call`/`Statement::Barrier` walk resolves `catch`
+/// (finds no matching proc, moves on) and never notices `isEven 4` sitting
+/// inside its body argument at all. That's a *second* proc call this scan
+/// cannot see, exactly like the namespace-resolution gap: an invisible call
+/// site with a differing argument silently vanishes from
+/// [`params_constants_from_call_sites`]'s "every caller agrees" evidence.
+///
+/// The registry already knows which argument position of which command is a
+/// script body (`ArgRole::Body`, driving the identical recursive call-graph
+/// walk in [`crate::interprocedural`] and the `BODY`-role scans in
+/// `ir_helpers.rs` / `place_bridge.rs` / `ssa.rs`) — so this reuses that one
+/// fact via [`tcl_registry::CommandRegistry::arg_indices_for_role`] and the
+/// shared [`crate::segmenter`] rather than hand-rolling a second "which
+/// commands embed scripts" list here.
+fn record_call_site_evidence(
+    out: &mut CallSiteEvidence,
+    ctx: &CallSiteScanCtx<'_, impl std::hash::BuildHasher>,
+    caller_qname: &str,
+    command: &str,
+    args: &[String],
+    depth: u32,
+) {
+    // A dynamically-dispatched command word (`$cmd args`) can't be resolved
+    // to any specific callee, so it never counts as a call site — but nor
+    // does it disqualify anyone else's: this scan has never claimed to
+    // enumerate every indirect dispatch, only every statically-resolvable
+    // one (including one level of script-body nesting at a time).
+    if !command.contains(['$', '['])
+        && let Some(target) = crate::interprocedural::resolve_internal_call(
+            command,
+            caller_qname,
+            ctx.known,
+        )
+        .or_else(|| {
+            resolve_via_namespace_import(command, caller_qname, ctx.namespace_imports, ctx.known)
+        })
+    {
+        out.record_call(target, args);
+    }
+    record_indirect_callers(out, ctx, caller_qname, command, args);
+    if MAX_CALL_SITE_BODY_DEPTH.exceeded(depth + 1) {
+        return;
+    }
+    let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+    for idx in ctx
+        .registry
+        .arg_indices_for_role(command, &arg_strs, tcl_registry::ArgRole::Body)
+    {
+        let Some(body_text) = args.get(idx) else {
+            continue;
+        };
+        let nested = crate::segmenter::segment_commands_with_offset_and_config(
+            body_text,
+            0,
+            tcl_lexer::LexerConfig::for_dialect(ctx.dialect),
+        );
+        for cmd in &nested {
+            let name = cmd.name();
+            if name.is_empty() {
+                continue;
+            }
+            record_call_site_evidence(out, ctx, caller_qname, name, cmd.args(), depth + 1);
+        }
+    }
+}
+
+/// Record the callers a statement creates *without* naming their arguments:
+/// a deferred command prefix, and a rebinding of a known command's name.
+///
+/// Both are real call paths whose argument list this scan can never see —
+/// `after 0 helper`, `trace add variable v write helper`, `-command helper`
+/// all invoke `helper` with runtime-supplied words appended, and `rename
+/// helper other` / `interp alias {} h {} helper` let a call reach `helper`
+/// under a name no scan attributed to it. Before this they were simply
+/// *absent* from the evidence, which reads to
+/// [`params_constants_from_call_sites`] as "no caller disagrees" — the exact
+/// shape issue #969 reported, reached through a callback instead of a missed
+/// call site. Recording them as opaque callers states the truth instead: a
+/// call site exists whose arguments are unknown.
+///
+/// Registry-driven throughout — the callback positions come from
+/// [`tcl_registry::ArgRole::CommandPrefix`]
+/// ([`CommandRegistry::arg_indices_for_role`]) and the rebinding forms from
+/// [`CommandRegistry::command_table_effect`], so no command name appears
+/// here.  Closes, for both the in-unit and the cross-unit scan, the
+/// `CommandPrefix` limitation PR #970 documented as shared and pre-existing.
+fn record_indirect_callers(
+    out: &mut CallSiteEvidence,
+    ctx: &CallSiteScanCtx<'_, impl std::hash::BuildHasher>,
+    caller_qname: &str,
+    command: &str,
+    args: &[String],
+) {
+    let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let mut poison = |word: &str| {
+        if word.is_empty() || word.contains(['$', '[']) {
+            return;
+        }
+        if let Some(target) =
+            crate::interprocedural::resolve_internal_call(word, caller_qname, ctx.known)
+        {
+            out.record_opaque_caller(&target);
+        }
+    };
+    for idx in
+        ctx.registry
+            .arg_indices_for_role(command, &arg_strs, tcl_registry::ArgRole::CommandPrefix)
+    {
+        // A command prefix is a list whose first word is the command; the
+        // rest are leading arguments the runtime appends to. Only the head
+        // names a callee.
+        if let Some(head) = args.get(idx).and_then(|p| p.split_whitespace().next()) {
+            poison(head);
+        }
+    }
+    if ctx
+        .registry
+        .command_table_effect(command, arg_strs.first().copied())
+        .is_some_and(|effect| {
+            matches!(
+                effect,
+                tcl_registry::CommandTableEffect::RenamesCommands
+                    | tcl_registry::CommandTableEffect::CreatesAliases
+            )
+        })
+    {
+        // Every word of a rebinding call that names a known command is a
+        // name whose binding has moved — `rename OLD NEW` in either
+        // direction, `interp alias {} NEW {} TARGET` in either.
+        for word in &arg_strs {
+            poison(word);
+        }
+    }
+}
+
+/// Build bare CFGs (no further per-function analysis) for every `TclOO` method
+/// and synthetic body unit (`apply` lambda, `namespace eval` body), so
+/// [`collect_call_site_constants`] can walk them as *callers* too.
+///
+/// Neither is itself ever seeded with `param_constants`
+/// (`build_method_units` / `build_body_units` always pass `None` for their
+/// own analysis), but a call *from* one of their bodies *to* an ordinary
+/// user proc is a real call site whose argument can vary between call
+/// sites, exactly like a bare top-level or proc-body call — invisible to
+/// the collector before this, which walked only `cfg_module.top_level` and
+/// `cfg_module.procedures`. The same class of bug as issue #969's own root
+/// cause (a real, varying call site silently missing from the "every
+/// caller agrees" evidence), reached through a method/lambda body instead
+/// of namespace-blind recursion or a `catch`/`uplevel` body.
+///
+/// Returns an empty `Vec` (no cost beyond the emptiness checks) when the
+/// module has neither methods nor body units — the overwhelmingly common
+/// case — or when `cfg_context` is `None` (methods/body units require it;
+/// [`crate::compilation_unit::CompilationUnit`]'s builder only omits it when
+/// both are empty).
+pub(crate) fn build_extra_call_site_scan_contexts(
+    ir_module: &IrModule,
+    cfg_context: Option<&crate::cfg_builder::CfgContext>,
+) -> Vec<(String, CfgFunction)> {
+    if ir_module.methods.is_empty() && ir_module.body_units.is_empty() {
+        return Vec::new();
+    }
+    let Some((upvar_procs, proc_params, global_write_procs)) = cfg_context else {
+        return Vec::new();
+    };
+    let build = |qname: &str, body: &crate::ir::Script| {
+        crate::cfg_builder::build_cfg_function_with_upvars(
+            qname,
+            body,
+            true,
+            upvar_procs.clone(),
+            proc_params.clone(),
+            global_write_procs.clone(),
+        )
+    };
+    ir_module
+        .methods
+        .iter()
+        .map(|(mqname, method)| {
+            // tclsh8.6-confirmed (live): a bare command inside a `TclOO`
+            // method body resolves against the GLOBAL namespace, never the
+            // class's own declaring namespace — `method go {} { helper }`
+            // calls `::helper` even when a proc of the same name sits in
+            // the class's own namespace. `mqname`'s own namespace (e.g.
+            // `::foo::Widget` for method `::foo::Widget::go`) would be
+            // wrong here, so the caller-context string this scan resolves
+            // against is forced to global — reusing `"::top"`, the same
+            // pseudo-qname the top-level script already uses to mean
+            // exactly that. The CFG's own identity still uses the real
+            // `mqname` (unrelated to this scan's namespace concern).
+            ("::top".to_owned(), build(mqname, &method.body))
+        })
+        .chain(
+            ir_module
+                .body_units
+                .iter()
+                .map(|(qname, unit)| (qname.clone(), build(qname, &unit.body))),
+        )
+        .collect()
+}
+
+/// Collect literal arg values per user-proc call site across the whole
+/// module's CFGs (top-level + every proc/method/body-unit, statements
+/// already flattened), including calls nested inside `ArgRole::Body`
+/// arguments (`catch { … }`, a literal `uplevel { … }`, `apply {{…} {…}}`, a
+/// non-exact `switch` arm, …) via [`record_call_site_evidence`].
+///
+/// Each call site is resolved to its callee via
+/// [`crate::interprocedural::resolve_internal_call`] — Tcl's real,
+/// existence-checked, namespace-relative resolution order, evaluated in the
+/// *calling* function's own namespace, not the global one. This is the same
+/// resolver the analyser and optimiser use for identical same-file call
+/// resolution; a bespoke or partial resolver here could disagree with them
+/// on which callee a bare name reaches.
+///
+/// The namespace context matters because a call site this scan fails to
+/// resolve doesn't just go uncounted — it *vanishes* from
+/// [`params_constants_from_call_sites`]'s "every caller passes the same
+/// literal" evidence, which can flip an absence of contradicting evidence
+/// into a false positive. Issue #969: a proc declared inside a `namespace
+/// eval` block recursed into itself by its bare (unqualified) name; the old
+/// resolver only ever tried global-qualified spellings of the command word,
+/// so it could never match the proc's namespaced qualified name, and the
+/// recursive self-call — whose argument necessarily varies call to call —
+/// was silently dropped. Only the one external, fully-qualified caller's
+/// literal remained, so the loop/recursion-varying parameter was seeded as
+/// that one constant and folded a genuinely alternating condition (`$count &
+/// 1`) to a fixed boolean.
+pub(crate) fn collect_call_site_constants(
+    cfg_module: &CfgModule,
+    extra_callers: &[(String, CfgFunction)],
+    procedures: &HashMap<String, crate::ir::Procedure>,
+    namespace_imports: &[(String, String)],
+    registry: &CommandRegistry,
+    dialect: &str,
+) -> CallSiteEvidence {
+    let known: HashSet<String> = procedures.keys().cloned().collect();
+    let ctx = CallSiteScanCtx {
+        known: &known,
+        registry,
+        dialect,
+        namespace_imports,
+    };
+    // The top level has no qualified name of its own; `"::top"` (the same
+    // pseudo-qname `FunctionUnit::build_full` uses for it) resolves to the
+    // global namespace via `resolve_internal_call`'s "drop the last
+    // segment" rule, matching a bare top-level call's real resolution
+    // scope.
+    let funcs = std::iter::once(("::top", &cfg_module.top_level))
+        .chain(cfg_module.procedures.iter().map(|(q, f)| (q.as_str(), f)))
+        .chain(extra_callers.iter().map(|(q, f)| (q.as_str(), f)));
+    let mut out = CallSiteEvidence::default();
+    scan_cfg_callers(&mut out, &ctx, funcs);
+    out
+}
+
+/// Walk each `(caller qname, CFG)` pair's flattened statements, recording
+/// every `Call`/`Barrier` as a call site.  Shared by the in-unit scan and
+/// [`scan_source_call_sites`] so the two can never diverge on what counts.
+fn scan_cfg_callers<'a>(
+    out: &mut CallSiteEvidence,
+    ctx: &CallSiteScanCtx<'_, impl std::hash::BuildHasher>,
+    funcs: impl Iterator<Item = (&'a str, &'a CfgFunction)>,
+) {
+    use crate::ir::Statement;
+    for (caller_qname, func) in funcs {
+        for block in func.blocks.values() {
+            for stmt in &block.statements {
+                let (Statement::Call { command, args, .. }
+                | Statement::Barrier { command, args, .. }) = stmt
+                else {
+                    continue;
+                };
+                record_call_site_evidence(out, ctx, caller_qname, command, args, 0);
+            }
+        }
+    }
+}
+
+/// Collect the call sites **another** file contributes, resolved against the
+/// whole project's procedure names.
+///
+/// This is the cross-file half of issue #977: a plain library file with no
+/// `package provide` is `source`d by a file that calls its procs with a
+/// different literal, and the library's own compilation unit — single-source
+/// by construction — can never see that caller.  A host with a workspace view
+/// (the LSP; the `tcl` CLI when given several files) runs this over every
+/// other file and hands the result to
+/// [`crate::compilation_unit::CompilationUnit`]'s build, which merges it into
+/// the in-unit evidence before seeding.
+///
+/// `known` must be the **project-wide** set of procedure qualified names, so
+/// a bare call in the scanned file resolves to the file that really defines
+/// it rather than resolving to nothing.  The scan is deliberately the same
+/// lowering → CFG → [`record_call_site_evidence`] path the in-unit scan takes
+/// (including its `TclOO` method / `apply` / `namespace eval` body-unit
+/// callers and its `ArgRole::Body` recursion), so cross-file evidence is
+/// exactly what this unit would have collected had the two files been one.
+#[must_use]
+pub fn scan_source_call_sites<S: std::hash::BuildHasher>(
+    source: &str,
+    registry: &CommandRegistry,
+    dialect: &str,
+    known: &HashSet<String, S>,
+) -> CallSiteEvidence {
+    let mut out = CallSiteEvidence::default();
+    if known.is_empty() {
+        return out;
+    }
+    let config = tcl_lexer::LexerConfig::for_dialect(dialect);
+    let mut ir_module = crate::lowering::lower_to_ir_with_config(source, registry, config);
+    crate::specialise_factories::specialise_factories(&mut ir_module, registry);
+    crate::inline_uplevel::inline_uplevel_passthrough(&mut ir_module, registry);
+    let cfg_module = crate::cfg_builder::build_cfg(&ir_module, false);
+    let cfg_context = (!ir_module.methods.is_empty() || !ir_module.body_units.is_empty())
+        .then(|| crate::cfg_builder::prepare_cfg_context(&ir_module));
+    let extra = build_extra_call_site_scan_contexts(&ir_module, cfg_context.as_ref());
+    let ctx = CallSiteScanCtx {
+        known,
+        registry,
+        dialect,
+        namespace_imports: &ir_module.namespace_imports,
+    };
+    let funcs = std::iter::once(("::top", &cfg_module.top_level))
+        .chain(cfg_module.procedures.iter().map(|(q, f)| (q.as_str(), f)))
+        .chain(extra.iter().map(|(q, f)| (q.as_str(), f)));
+    scan_cfg_callers(&mut out, &ctx, funcs);
+    // A `namespace import` in the scanned file binds one of `known`'s
+    // commands under a *new* bare name, so a call through that name never
+    // reaches `record_call_site_evidence`'s resolver at all. Record it as an
+    // opaque caller: a real call path whose arguments are unknown. (Renames
+    // and aliases are already covered per-statement by
+    // `record_indirect_callers`.)
+    for (_, pattern) in &ir_module.namespace_imports {
+        if let Some(ns_prefix) = pattern.strip_suffix("::*") {
+            let prefix = format!("{ns_prefix}::");
+            let imported: Vec<String> = known
+                .iter()
+                .filter(|q| q.starts_with(&prefix) && q[prefix.len()..].find("::").is_none())
+                .cloned()
+                .collect();
+            for target in imported {
+                out.record_opaque_caller(&target);
+            }
+        } else if known.contains(pattern) {
+            out.record_opaque_caller(pattern);
+        }
+    }
+    out
+}
+
+/// Which registry-declared unit boundaries this module crosses.
+///
+/// A pure union of [`CommandRegistry::unit_linkage`] over every resolved
+/// `Call`/`Barrier` statement in the module — top level, every
+/// proc/method/body-unit, and every nested control-flow body.  No command
+/// name appears here: `package provide`, `source`, `namespace export` and
+/// friends are recognised only through the traits their specs carry, so
+/// teaching the compiler about a new boundary command is a registry edit
+/// (see [`tcl_registry::traits::UNIT_LINKAGE_TRAITS`]).
+///
+/// Replaces the raw-text `package provide` substring scan (PR #970) and then
+/// the IR walk that hardcoded the `package`/`provide` word pair: the former
+/// both over-triggered (any script merely *mentioning* the phrase in a
+/// comment or string disabled every interprocedural seed in the file) and
+/// under-triggered (`package\tprovide`, `::package provide`); the latter was
+/// correct but knew a command by name, and missed every other way a file
+/// admits to being part of a larger program.
+#[must_use]
+pub fn scan_unit_linkage(
+    ir_module: &IrModule,
+    registry: &CommandRegistry,
+    dialect: &str,
+) -> Traits {
+    let dialect_set =
+        tcl_dialect::DialectSet::parse(dialect).unwrap_or_else(tcl_dialect::DialectSet::empty);
+    let mut found = Traits::empty();
+
+    let mut visit = |command: &str, args: &[String]| {
+        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+        found |= registry.unit_linkage(command, &arg_strs, dialect_set);
+    };
+    walk_script(&ir_module.top_level, &mut visit);
+    for proc in ir_module.procedures.values() {
+        walk_script(&proc.body, &mut visit);
+    }
+    for method in ir_module.methods.values() {
+        walk_script(&method.body, &mut visit);
+    }
+    for unit in ir_module.body_units.values() {
+        walk_script(&unit.body, &mut visit);
+    }
+    found
+}
+
+/// Visit every `Call` / `Barrier` statement in `script`, descending into every
+/// nested control-flow body.  Written as a module-level pair with
+/// [`walk_statement`] rather than nested inside [`scan_unit_linkage`] so the
+/// mutual recursion reads as two ordinary functions.
+fn walk_script(script: &crate::ir::Script, visit: &mut impl FnMut(&str, &[String])) {
+    for stmt in &script.statements {
+        walk_statement(stmt, visit);
+    }
+}
+
+/// The [`walk_script`] half that dispatches one statement.
+fn walk_statement(stmt: &crate::ir::Statement, visit: &mut impl FnMut(&str, &[String])) {
+    use crate::ir::Statement;
+    match stmt {
+        Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. } => {
+            visit(command, args);
+        }
+        Statement::Block { body, .. }
+        | Statement::UpFrame { body, .. }
+        | Statement::While { body, .. }
+        | Statement::Foreach { body, .. }
+        | Statement::Catch { body, .. } => walk_script(body, visit),
+        Statement::If {
+            clauses, else_body, ..
+        } => {
+            for clause in clauses {
+                walk_script(&clause.body, visit);
+            }
+            if let Some(body) = else_body {
+                walk_script(body, visit);
+            }
+        }
+        Statement::For {
+            init, next, body, ..
+        } => {
+            walk_script(init, visit);
+            walk_script(next, visit);
+            walk_script(body, visit);
+        }
+        Statement::Try {
+            body,
+            handlers,
+            finally_body,
+            ..
+        } => {
+            walk_script(body, visit);
+            for handler in handlers {
+                walk_script(&handler.body, visit);
+            }
+            if let Some(body) = finally_body {
+                walk_script(body, visit);
+            }
+        }
+        Statement::Switch {
+            arms, default_body, ..
+        } => {
+            for arm in arms {
+                if let Some(body) = &arm.body {
+                    walk_script(body, visit);
+                }
+            }
+            if let Some(body) = default_body {
+                walk_script(body, visit);
+            }
+        }
+        Statement::AssignConst { .. }
+        | Statement::AssignExpr { .. }
+        | Statement::AssignValue { .. }
+        | Statement::Incr { .. }
+        | Statement::ExprEval { .. }
+        | Statement::Return { .. } => {}
+    }
+}
+
+/// Everything the interprocedural seed needs to know about *who else* can
+/// call this unit's procedures.
+pub(crate) struct UnitCallerView<'a> {
+    /// Registry-declared boundaries the file itself crosses
+    /// ([`scan_unit_linkage`]).
+    pub linkage: Traits,
+    /// Whether a host supplied cross-file call-site evidence for this unit.
+    /// With evidence, `merged` is the whole project's view and a
+    /// registry-declared boundary no longer has to be treated as an unknown
+    /// caller; without it, the unit is on its own and any boundary sinks the
+    /// seed.
+    pub has_cross_file_evidence: bool,
+    /// Whole-module `rename` / `interp alias` / dynamic-redefinition trust
+    /// lattice.
+    pub command_mutations: &'a crate::command_binding::ModuleCommandMutations,
+}
+
+/// Boundaries that publish this file's commands to callers **no** host
+/// enumeration can bound — another checkout can `package require` this one,
+/// or `namespace import` from it.  Distinct from `LOADS_EXTERNAL_UNIT`, whose
+/// implied caller is normally a project file the host has already scanned.
+const UNBOUNDABLE_BOUNDARIES: Traits = Traits::PROVIDES_PACKAGE.union(Traits::EXPORTS_COMMAND);
+
+impl UnitCallerView<'_> {
+    /// Whether a registry-declared boundary rules out seeding outright — see
+    /// [`params_constants_from_call_sites`]'s gate for the full rule.
+    fn declines_seeding(&self) -> bool {
+        if self.linkage.intersects(UNBOUNDABLE_BOUNDARIES) {
+            return true;
+        }
+        !self.has_cross_file_evidence && self.linkage.intersects(Traits::LOADS_EXTERNAL_UNIT)
+    }
+}
+
+/// Build the SCCP `param_constants` seed for `qname` from collected call-site
+/// literals: bind `(param, 0)` only when every caller passes the same single
+/// literal at that position.
+///
+/// Beyond the per-slot literal-uniformity test
+/// ([`CalleeEvidence::uniform_literal_at`]), two whole-module gates must also
+/// hold — each closes a way the recorded call sites could be an incomplete
+/// picture of every real caller (an unproven "every caller I found agrees"
+/// says nothing about callers no scan could see):
+///
+/// - `!command_mutations.trusts_proc_binding(qname)` — `qname`'s own
+///   binding may have been perturbed by `rename` / `interp alias` / a
+///   dynamic proc redefinition anywhere in the module, so a call reaching
+///   it at runtime need not be one this scan attributed to it (and vice
+///   versa).
+/// - **No registry-declared unit boundary the evidence cannot cover.** The
+///   two kinds are treated differently, because a host's enumeration can only
+///   ever bound one of them:
+///   - `PROVIDES_PACKAGE` (`package provide` / `ifneeded`) and
+///     `EXPORTS_COMMAND` (`namespace export`, `namespace ensemble`) publish
+///     this file's commands as an API surface. Their consumers need not be in
+///     the host's project at all — another checkout can `package require`
+///     this one — so no enumeration bounds them and the seed is declined
+///     **unconditionally**.
+///   - `LOADS_EXTERNAL_UNIT` (`source`, `load`, `package require`,
+///     `auto_load`, `auto_import`) says another unit's script runs here and
+///     can call back in. That unit is normally a project file, so a host that
+///     supplied cross-file evidence
+///     ([`UnitCallerView::has_cross_file_evidence`]) has already contributed
+///     its call sites and the seed proceeds on the union; with no host view
+///     it is a blind spot and the seed is declined.
+///
+/// A call site dispatched through a non-literal command word (`$cmd args`)
+/// is deliberately NOT treated as a module-wide wildcard here: it can't be
+/// resolved to any specific callee, so the scans already never count it as
+/// evidence for (or against) any particular proc's params, the same way they
+/// have always treated any other unresolvable call.
+pub(crate) fn params_constants_from_call_sites(
+    params: &[String],
+    evidence: &CallSiteEvidence,
+    qname: &str,
+    view: &UnitCallerView<'_>,
+) -> Option<HashMap<(String, crate::ssa::Version), crate::analyses::LatticeValue>> {
+    use crate::analyses::{ConstValue, LatticeValue};
+    if view.declines_seeding() {
+        return None;
+    }
+    if !view.command_mutations.trusts_proc_binding(qname) {
+        return None;
+    }
+    let callee = evidence.get(qname)?;
+    let mut consts: HashMap<(String, crate::ssa::Version), LatticeValue> = HashMap::new();
+    for (index, pname) in params.iter().enumerate() {
+        // Only a *trailing* `args` is Tcl's variadic catch-all
+        // (`TclCreateProc`, `generic/tclProc.c`): in `proc f {args x}` the
+        // first word is an ordinary parameter and `x` is required.  Every
+        // position from a trailing `args` on absorbs an unbounded, per-call
+        // word list, so no single position beyond it can be literal-uniform.
+        if pname == "args" && index + 1 == params.len() {
+            break;
+        }
+        if let Some(value) = callee.uniform_literal_at(index) {
+            consts.insert(
+                (pname.clone(), 0),
+                LatticeValue::Const(ConstValue::String(value.to_owned())),
+            );
+        }
+    }
+    if consts.is_empty() {
+        None
+    } else {
+        Some(consts)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn registry() -> CommandRegistry {
+        CommandRegistry::build_default()
+    }
+
+    fn known(names: &[&str]) -> HashSet<String> {
+        names.iter().map(|n| (*n).to_owned()).collect()
+    }
+
+    fn params(names: &[&str]) -> Vec<String> {
+        names.iter().map(|n| (*n).to_owned()).collect()
+    }
+
+    fn seed(
+        params: &[String],
+        evidence: &CallSiteEvidence,
+        qname: &str,
+        linkage: Traits,
+        has_cross_file_evidence: bool,
+    ) -> Option<HashMap<(String, crate::ssa::Version), crate::analyses::LatticeValue>> {
+        let mutations = crate::command_binding::ModuleCommandMutations::default();
+        params_constants_from_call_sites(
+            params,
+            evidence,
+            qname,
+            &UnitCallerView {
+                linkage,
+                has_cross_file_evidence,
+                command_mutations: &mutations,
+            },
+        )
+    }
+
+    /// A call that omits a defaulted parameter binds it to its **default**, an
+    /// unknown value — so a literal at another call site cannot claim the
+    /// position. `binds_position` is what encodes that.
+    #[test]
+    fn an_omitted_argument_stops_a_position_being_uniform() {
+        let reg = registry();
+        let evidence = scan_source_call_sites(
+            "proc helper {a {b x}} { return $a }\nhelper 1 two\nhelper 1\n",
+            &reg,
+            "",
+            &known(&["::helper"]),
+        );
+        let helper = evidence.get("::helper").expect("calls recorded");
+        assert_eq!(helper.uniform_literal_at(0), Some("1"));
+        assert_eq!(helper.arg_counts, [1, 2].into_iter().collect());
+        assert!(!helper.binds_position(1));
+        assert_eq!(helper.uniform_literal_at(1), None);
+    }
+
+    /// Merging is monotone: extra evidence widens the value set and the
+    /// observed argument counts, so a second file can retract a fold but
+    /// never manufacture one.
+    #[test]
+    fn merging_only_ever_widens() {
+        let reg = registry();
+        let src = "proc helper {mode} { return $mode }\n";
+        let mut a = scan_source_call_sites(
+            &format!("{src}helper prod\n"),
+            &reg,
+            "",
+            &known(&["::helper"]),
+        );
+        assert_eq!(
+            a.get("::helper").unwrap().uniform_literal_at(0),
+            Some("prod")
+        );
+        let b = scan_source_call_sites(
+            &format!("{src}helper dev\n"),
+            &reg,
+            "",
+            &known(&["::helper"]),
+        );
+        a.merge_from(&b);
+        assert_eq!(a.get("::helper").unwrap().uniform_literal_at(0), None);
+    }
+
+    /// A deferred command prefix (`ArgRole::CommandPrefix`) invokes the proc
+    /// with runtime-supplied words appended, so no position stays uniform.
+    /// The callback slot comes from the registry, not a command-name list.
+    #[test]
+    fn a_command_prefix_callback_is_recorded_as_an_opaque_caller() {
+        let reg = registry();
+        let evidence = scan_source_call_sites(
+            "helper prod\nafter 0 helper\n",
+            &reg,
+            "",
+            &known(&["::helper"]),
+        );
+        let helper = evidence.get("::helper").expect("calls recorded");
+        assert!(helper.arg_counts.contains(&0), "{helper:?}");
+        assert_eq!(helper.uniform_literal_at(0), None);
+    }
+
+    /// A `rename` / `interp alias` naming a known command moves its binding,
+    /// so a call can reach it under a name no scan attributed to it.
+    #[test]
+    fn a_rebinding_call_is_recorded_as_an_opaque_caller() {
+        let reg = registry();
+        for src in [
+            "helper prod\nrename helper legacy\n",
+            "helper prod\ninterp alias {} h {} helper\n",
+        ] {
+            let evidence = scan_source_call_sites(src, &reg, "", &known(&["::helper"]));
+            let helper = evidence.get("::helper").expect("calls recorded");
+            assert_eq!(helper.uniform_literal_at(0), None, "{src}");
+        }
+    }
+
+    /// Only a **trailing** `args` is Tcl's variadic catch-all
+    /// (`TclCreateProc`, `generic/tclProc.c`) — in `proc f {args x}` the
+    /// first word is an ordinary parameter and both positions may be seeded.
+    #[test]
+    fn only_a_trailing_args_stops_the_seed() {
+        let reg = registry();
+        let evidence = scan_source_call_sites(
+            "helper one two\nhelper one two\n",
+            &reg,
+            "",
+            &known(&["::helper"]),
+        );
+        let leading = seed(
+            &params(&["args", "x"]),
+            &evidence,
+            "::helper",
+            Traits::empty(),
+            false,
+        )
+        .expect("both positions seeded");
+        assert_eq!(leading.len(), 2);
+        let trailing = seed(
+            &params(&["x", "args"]),
+            &evidence,
+            "::helper",
+            Traits::empty(),
+            false,
+        )
+        .expect("the leading parameter is still seeded");
+        assert_eq!(trailing.len(), 1);
+        assert!(trailing.contains_key(&("x".to_owned(), 0)));
+    }
+
+    /// A registry-declared boundary declines the seed on its own, and a
+    /// host-supplied cross-file view re-enables it — but only for the kind of
+    /// boundary that view can actually bound.
+    ///
+    /// Publishing this file's commands as an API surface (`PROVIDES_PACKAGE`
+    /// / `EXPORTS_COMMAND`) admits callers no project scan covers — another
+    /// checkout can `package require` this one — so it declines outright.
+    /// Pulling another unit in (`LOADS_EXTERNAL_UNIT`) names a caller the
+    /// host's project normally *does* contain, so it defers to the evidence.
+    #[test]
+    fn boundary_gating_distinguishes_publishing_from_loading() {
+        let reg = registry();
+        let evidence = scan_source_call_sites(
+            "helper prod\nhelper prod\n",
+            &reg,
+            "",
+            &known(&["::helper"]),
+        );
+        let p = params(&["mode"]);
+        assert!(
+            seed(&p, &evidence, "::helper", Traits::empty(), false).is_some(),
+            "no boundary at all: the visible callers are the whole story"
+        );
+        for boundary in [Traits::PROVIDES_PACKAGE, Traits::EXPORTS_COMMAND] {
+            for has_view in [false, true] {
+                assert!(
+                    seed(&p, &evidence, "::helper", boundary, has_view).is_none(),
+                    "{boundary:?} publishes to callers no enumeration bounds \
+                     (cross-file view: {has_view})"
+                );
+            }
+        }
+        assert!(
+            seed(
+                &p,
+                &evidence,
+                "::helper",
+                Traits::LOADS_EXTERNAL_UNIT,
+                false
+            )
+            .is_none(),
+            "a loaded unit is an unenumerated caller without a host view"
+        );
+        assert!(
+            seed(&p, &evidence, "::helper", Traits::LOADS_EXTERNAL_UNIT, true).is_some(),
+            "with the project enumerated, the loaded unit's callers are in the evidence"
+        );
+    }
+
+    /// `scan_unit_linkage` reads the registry, so it recognises a boundary
+    /// however it is spelled — and never fires on a mere mention.
+    #[test]
+    fn unit_linkage_is_scanned_from_the_lowered_ir_not_the_raw_text() {
+        let reg = registry();
+        let cases = [
+            ("package provide mylib 1.0\n", Traits::PROVIDES_PACKAGE),
+            ("::package\tprovide mylib 1.0\n", Traits::PROVIDES_PACKAGE),
+            ("if {1} { source other.tcl }\n", Traits::LOADS_EXTERNAL_UNIT),
+            (
+                "namespace eval ::a { namespace export * }\n",
+                Traits::EXPORTS_COMMAND,
+            ),
+            (
+                "# this file does not package provide anything\n",
+                Traits::empty(),
+            ),
+            ("set msg \"package provide\"\n", Traits::empty()),
+            ("namespace import ::lib::helper\n", Traits::empty()),
+        ];
+        for (src, want) in cases {
+            let module = crate::lowering::lower_to_ir_with_config(
+                src,
+                &reg,
+                tcl_lexer::LexerConfig::default(),
+            );
+            assert_eq!(scan_unit_linkage(&module, &reg, ""), want, "{src:?}");
+        }
+    }
+
+    /// `slice_for` is driven by the *callee* names a file declares, so its
+    /// cost is that file's procedure count rather than the project's.
+    #[test]
+    fn slice_for_keeps_only_the_named_callees() {
+        let reg = registry();
+        let evidence = scan_source_call_sites("a 1\nb 2\n", &reg, "", &known(&["::a", "::b"]));
+        let sliced = evidence.slice_for(["::a"].into_iter());
+        assert_eq!(sliced.callees().collect::<Vec<_>>(), vec!["::a"]);
+        assert!(evidence.slice_for(["::zzz"].into_iter()).is_empty());
+    }
+}

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -346,6 +346,28 @@ fn record_call_site_evidence(
         let Some(body_text) = args.get(idx) else {
             continue;
         };
+        // A body whose resolution namespace differs from the caller's must not
+        // be walked with the caller's namespace: `namespace eval ::a { helper }`
+        // calls `::a::helper`, never the caller's own `helper`
+        // (tclsh8.6-confirmed; see `lowering`'s `register_body_unit` call for
+        // the same reasoning). Such a command carries an absolute `ArgRole::Name`
+        // naming that namespace, and lowering has already registered its body as
+        // a body unit whose qname encodes it — which
+        // `build_extra_call_site_scan_contexts` scans with the *correct*
+        // namespace. Recursing here as well would scan it a second time under
+        // the wrong one, inventing a call to a same-named proc in the caller's
+        // namespace. Cross-file that is a false edge into another file's
+        // procedure; in-unit it was merely invisible, because a bare global
+        // `::helper` is rarely in a single file's own `known` set (issue #977).
+        if ctx
+            .registry
+            .arg_indices_for_role(command, &arg_strs, tcl_registry::ArgRole::Name)
+            .into_iter()
+            .filter_map(|i| args.get(i))
+            .any(|name| name.starts_with("::"))
+        {
+            continue;
+        }
         let nested = crate::segmenter::segment_commands_with_offset_and_config(
             body_text,
             0,
@@ -1097,6 +1119,62 @@ mod tests {
             );
             assert_eq!(scan_unit_linkage(&module, &reg, ""), want, "{src:?}");
         }
+    }
+
+    /// A `namespace eval ::a { helper }` body calls `::a::helper`, never a
+    /// same-named proc in the *caller's* namespace (tclsh8.6-confirmed).
+    ///
+    /// The body is scanned once, as the properly-namespaced body unit lowering
+    /// registers for it. Walking it a second time through the enclosing
+    /// statement's `ArgRole::Body` — with the caller's namespace — invents a
+    /// call to whatever `::helper` happens to exist. Within one file that was
+    /// invisible (a bare global `::helper` is rarely in a single file's own
+    /// `known` set); across a project it is a false edge into *another file's*
+    /// procedure, which is how it surfaced (issue #977).
+    #[test]
+    fn a_namespace_eval_body_resolves_against_its_own_namespace() {
+        let reg = registry();
+        let src = "namespace eval ::a {\n    proc helper {} { return 1 }\n    proc run {} { helper }\n}\n";
+        // `::helper` is in scope project-wide, as a global proc in some other
+        // file would be — the call inside `::a` must not reach it.
+        let evidence = scan_source_call_sites(
+            src,
+            &reg,
+            "tcl8.6",
+            &known(&["::a::helper", "::a::run", "::helper"]),
+        );
+        assert_eq!(
+            evidence.callees().collect::<Vec<_>>(),
+            vec!["::a::helper"],
+            "the call binds to ::a::helper only"
+        );
+        // The in-unit scan is the reference: cross-file must not see more.
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, &reg, false);
+        assert_eq!(
+            cu.caller_scope.call_sites.callees().collect::<Vec<_>>(),
+            vec!["::a::helper"],
+        );
+    }
+
+    /// `catch { … }` does *not* shift namespace, so its body must still be
+    /// walked with the caller's — the guard above keys on an absolute
+    /// `ArgRole::Name`, which `catch` has none of.
+    #[test]
+    fn a_catch_body_is_still_walked_with_the_callers_namespace() {
+        let reg = registry();
+        let evidence = scan_source_call_sites(
+            "proc helper {mode} { return $mode }\ncatch { helper prod }\n",
+            &reg,
+            "tcl8.6",
+            &known(&["::helper"]),
+        );
+        assert_eq!(
+            evidence
+                .get("::helper")
+                .and_then(|e| e.uniform_literal_at(0)),
+            Some("prod"),
+            "the call inside catch is still evidence"
+        );
     }
 
     /// `slice_for` is driven by the *callee* names a file declares, so its

--- a/rust/tcl-compiler/tests/compiler_analysis_residual.rs
+++ b/rust/tcl-compiler/tests/compiler_analysis_residual.rs
@@ -931,10 +931,13 @@ fn rebased_units(base: &str, shifted: &str) -> (CompilationUnit, CompilationUnit
     let build = |s: &str, cache: &mut HashMap<String, FunctionUnit>| -> CompilationUnit {
         CompilationUnit::build_for_memoized(
             s,
-            &registry,
-            false,
-            tcl_lexer::LexerConfig::default(),
-            D,
+            tcl_compiler::compilation_unit::UnitBuildOptions {
+                registry: &registry,
+                defer_top_level: false,
+                config: tcl_lexer::LexerConfig::default(),
+                dialect: D,
+                external_call_sites: None,
+            },
             &mut |req: &tcl_compiler::compilation_unit::LatticeRequest<'_>| -> FunctionUnit {
                 let key = format!(
                     "{}\u{0}{:?}\u{0}{:?}\u{0}{:?}",

--- a/rust/tcl-explorer/src/serialise.rs
+++ b/rust/tcl-explorer/src/serialise.rs
@@ -1108,6 +1108,73 @@ pub fn serialise_bounds(result: &ExplorerResult) -> Value {
     Value::Array(funcs)
 }
 
+/// Serialise the `unitScope` view: who else can call this file's procedures.
+///
+/// Shows the registry-declared unit boundaries the file crosses
+/// (`package provide`, `source`, `namespace export`, …), whether the host
+/// supplied a cross-file view, and the merged call-site evidence per callee
+/// with the seed verdict at each argument position — the inputs
+/// `tcl_compiler::unit_scope::params_constants_from_call_sites` reads, so a
+/// surprising (or surprisingly absent) constant fold can be traced to the
+/// evidence that produced it (issue #977).
+#[must_use]
+pub fn serialise_unit_scope(result: &ExplorerResult) -> Value {
+    let scope = &result.unit.caller_scope;
+    // `scan_unit_linkage` already masks to `UNIT_LINKAGE_TRAITS`, so every
+    // name here is a boundary — and `iter_names` is generated from the trait
+    // declarations, so this cannot drift from them (#1034).
+    let boundaries: Vec<Value> = scope
+        .linkage
+        .iter_names()
+        .map(|k| Value::String(k.to_owned()))
+        .collect();
+    let callees: Vec<Value> = scope
+        .call_sites
+        .callees()
+        .map(|name| {
+            let evidence = scope
+                .call_sites
+                .get(name)
+                .expect("callee listed by the evidence table");
+            let max_index = evidence.slots.keys().copied().max().map_or(0, |m| m + 1);
+            let positions: Vec<Value> = (0..max_index)
+                .map(|index| {
+                    json!({
+                        "index": index.to_string(),
+                        "verdict": match evidence.uniform_literal_at(index) {
+                            Some(literal) => format!("uniform literal {literal:?}"),
+                            None => "not uniform".to_owned(),
+                        },
+                    })
+                })
+                .collect();
+            let arg_counts: Vec<Value> = evidence
+                .arg_counts
+                .iter()
+                .map(|n| Value::String(n.to_string()))
+                .collect();
+            json!({ "name": name, "positions": positions, "argCounts": arg_counts })
+        })
+        .collect();
+    json!({
+        "boundaries": boundaries,
+        "hasCrossFileEvidence": scope.has_cross_file_evidence,
+        "seeding": if scope
+            .linkage
+            .intersects(tcl_registry::Traits::PROVIDES_PACKAGE | tcl_registry::Traits::EXPORTS_COMMAND)
+        {
+            "declined — the file publishes commands beyond any enumerable project"
+        } else if !scope.has_cross_file_evidence
+            && scope.linkage.intersects(tcl_registry::Traits::LOADS_EXTERNAL_UNIT)
+        {
+            "declined — another unit is loaded here and no cross-file view was supplied"
+        } else {
+            "allowed — evidence is treated as the complete caller set"
+        },
+        "callees": callees,
+    })
+}
+
 /// Serialise the `interprocedural` view: per-procedure summaries followed
 /// by `TclOO` method summaries.
 #[must_use]
@@ -1758,6 +1825,7 @@ pub fn serialise_result(result: &ExplorerResult) -> Value {
     if let Some(interproc) = &result.unit.interproc {
         out.insert("interprocedural".to_owned(), serialise_interproc(interproc));
     }
+    out.insert("unitScope".to_owned(), serialise_unit_scope(result));
     out.insert("types".to_owned(), serialise_types(result));
     // Honour the document's dialect so the CST and segment views tokenise
     // `{*}` / iRules braces the same way the rest of the pipeline does.
@@ -1883,10 +1951,11 @@ mod tests {
         let meta = serialise_meta();
         // 16 dialects: the prior 15 + `tcl9.1` (the Tcl 9.1 sync).
         assert_eq!(meta["dialects"].as_array().unwrap().len(), 16);
-        // 26 views: the base 24 minus the dropped `greentree` tab (Rust has a
+        // 27 views: the base 24 minus the dropped `greentree` tab (Rust has a
         // single red-green CST) plus the Rust-native `structuralIndex`,
-        // `sourceMap`, and `optimiserPasses` views.
-        assert_eq!(meta["views"].as_array().unwrap().len(), 26);
+        // `sourceMap`, and `optimiserPasses` views, plus `unitScope`
+        // (issue #977's cross-file caller evidence).
+        assert_eq!(meta["views"].as_array().unwrap().len(), 27);
         assert_eq!(meta["severities"], json!(["error", "warning", "info"]));
         // The parse-tree tab is the CST; there is no `greentree` entry.
         assert_eq!(
@@ -2460,6 +2529,53 @@ mod tests {
         assert_eq!(add["returnShape"], "passthrough(x)");
         assert!(add["pure"].is_boolean());
         assert!(add["calls"].is_array());
+    }
+
+    /// The Unit Scope view must show *why* the interprocedural seed fired:
+    /// the registry-declared boundaries the file crosses, whether a
+    /// cross-file view was supplied, and the per-position verdict (#977).
+    #[test]
+    fn unit_scope_reports_uniform_literals_and_no_boundary() {
+        let result = run_pipeline(
+            "proc helper {mode} { if {$mode eq \"prod\"} { set r 1 } }\nhelper prod\nhelper prod\n",
+            "tcl8.6",
+        );
+        let scope = serialise_result(&result)["unitScope"].clone();
+        assert_eq!(scope["boundaries"].as_array().unwrap().len(), 0);
+        assert_eq!(scope["hasCrossFileEvidence"], false);
+        assert!(
+            scope["seeding"].as_str().unwrap().starts_with("allowed"),
+            "{scope:?}"
+        );
+        let helper = scope["callees"]
+            .as_array()
+            .unwrap()
+            .iter()
+            .find(|c| c["name"] == "::helper")
+            .expect("::helper evidence present");
+        assert_eq!(
+            helper["positions"][0]["verdict"],
+            "uniform literal \"prod\""
+        );
+    }
+
+    /// The same file with a `package provide` crosses a registry-declared
+    /// boundary, so the view must report the boundary and the declined seed.
+    #[test]
+    fn unit_scope_reports_a_registry_declared_boundary() {
+        let result = run_pipeline(
+            "package provide mylib 1.0\nproc helper {mode} { if {$mode eq \"prod\"} { set r 1 } }\nhelper prod\n",
+            "tcl8.6",
+        );
+        let scope = serialise_result(&result)["unitScope"].clone();
+        assert_eq!(
+            scope["boundaries"].as_array().unwrap(),
+            &vec![Value::String("PROVIDES_PACKAGE".to_owned())]
+        );
+        assert!(
+            scope["seeding"].as_str().unwrap().starts_with("declined"),
+            "{scope:?}"
+        );
     }
 
     #[test]

--- a/rust/tcl-explorer/src/view_tree.rs
+++ b/rust/tcl-explorer/src/view_tree.rs
@@ -732,6 +732,46 @@ fn build_interproc(d: &Value) -> Vec<ViewNode> {
     }
 }
 
+/// Why the interprocedural constant seed fired (or declined) for each
+/// procedure: the registry-declared unit boundaries the file crosses, whether
+/// the host supplied a cross-file view, and the merged call-site evidence
+/// per callee (issue #977).
+fn build_unit_scope(d: &Value) -> Vec<ViewNode> {
+    let scope = &d["unitScope"];
+    let boundaries = join_str_array(&scope["boundaries"]);
+    let mut out = vec![ViewNode::leaf(
+        "unit".to_owned(),
+        vec![
+            det(
+                "registry boundaries",
+                if boundaries.is_empty() {
+                    "none".to_owned()
+                } else {
+                    boundaries
+                },
+            ),
+            det("cross-file view", yn(&scope["hasCrossFileEvidence"])),
+            det("seeding", s(scope, "seeding")),
+        ],
+        Some("cyan"),
+    )];
+    for callee in arr(scope, "callees") {
+        let detail = arr(callee, "positions")
+            .iter()
+            .map(|p| det("arg", format!("{}: {}", s(p, "index"), s(p, "verdict"))))
+            .chain(std::iter::once(det(
+                "argument counts",
+                join_str_array(&callee["argCounts"]),
+            )))
+            .collect();
+        out.push(ViewNode::leaf(s(callee, "name"), detail, Some("green")));
+    }
+    if out.len() == 1 {
+        out.push(ViewNode::note("(no resolvable call sites)", "dim"));
+    }
+    out
+}
+
 // --- Optimiser / GVN / shimmer / taint / iRules / callouts ---
 
 fn build_opt(d: &Value) -> Vec<ViewNode> {
@@ -1154,6 +1194,7 @@ pub const TREE_VIEWS: &[&str] = &[
     "bounds",
     "dataflow",
     "interproc",
+    "unitScope",
     "rendered",
     "opt",
     "optimiserPasses",
@@ -1179,6 +1220,7 @@ pub fn build_view(view: &str, data: &Value) -> Vec<ViewNode> {
         "bounds" => build_bounds(data),
         "dataflow" => build_dataflow(data),
         "interproc" => build_interproc(data),
+        "unitScope" => build_unit_scope(data),
         "rendered" => build_rendered(data),
         "structuralIndex" => build_structural_index(data),
         "sourceMap" => build_source_map(data),

--- a/rust/tcl-explorer/src/views.rs
+++ b/rust/tcl-explorer/src/views.rs
@@ -44,6 +44,7 @@ pub const VIEW_META: &[ViewMeta] = &[
     ("bounds", "Bounds", "compiler"),
     ("dataflow", "Data Flow", "compiler"),
     ("interproc", "Interprocedural", "compiler"),
+    ("unitScope", "Unit Scope", "compiler"),
     ("rendered", "Rendered Props", "compiler"),
     ("opt", "Optimisations", "optimiser"),
     ("optimiserPasses", "Pass Pipeline", "optimiser"),

--- a/rust/tcl-lsp-db/examples/cc_diff.rs
+++ b/rust/tcl-lsp-db/examples/cc_diff.rs
@@ -49,7 +49,7 @@ fn main() {
     );
     let memo = compiler_check_diagnostics(&db, file, cfg);
     let reg = db.registry(&dialect);
-    let fresh = compiler_check_diagnostics_uncached(&src, &reg, &dialect, None);
+    let fresh = compiler_check_diagnostics_uncached(&src, &reg, &dialect, None, None);
 
     let ck = |d: &tcl_compiler::compiler_checks::Diagnostic| (d.span.start(), d.span.end(), d.code);
     let ms: BTreeSet<_> = memo.checks.iter().map(ck).collect();

--- a/rust/tcl-lsp-db/examples/tail_profile.rs
+++ b/rust/tcl-lsp-db/examples/tail_profile.rs
@@ -188,7 +188,6 @@ fn main() {
     // must pay against its ~120 ms summary-floor saving.
     println!("\n== 2b gate: warm duplicate-build cost (function_lattice cache hot) ==");
     {
-        let dialect_opt = Some(dialect);
         let cfg_d = tcl_lexer::LexerConfig::for_dialect(dialect);
         // Warm the shared build (populates function_lattice / taint_cascade) on the
         // *edited* text, mirroring the per-edit state proc_taint_solve runs in.
@@ -198,10 +197,13 @@ fn main() {
             tcl_lsp_db::memoised_compilation_unit(
                 &db,
                 &edited,
-                &registry,
-                false,
-                cfg_d,
-                dialect_opt,
+                tcl_compiler::compilation_unit::UnitBuildOptions {
+                    registry: &registry,
+                    defer_top_level: false,
+                    config: cfg_d,
+                    dialect,
+                    external_call_sites: None,
+                },
             )
         });
         println!(

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -348,12 +348,31 @@ pub fn file_call_site_evidence(
     let registry = db.registry(&dialect);
     let known: std::collections::HashSet<String> =
         project_proc_names(db, project).iter().cloned().collect();
-    Arc::new(tcl_compiler::unit_scope::scan_source_call_sites(
+    let scanned = tcl_compiler::unit_scope::scan_source_call_sites(
         file.text(db),
         &registry,
         &dialect,
         &known,
-    ))
+    );
+    // Drop the callees *this* file declares. A call to a name the file also
+    // defines binds to its own definition, so it is in-unit evidence (already
+    // collected during the build) — not evidence about a same-named proc in
+    // some other file.
+    //
+    // Without this, any two unrelated workspace files that happen to reuse a
+    // common helper name (`helper`, `init`, `run` — pervasive in Tcl) pool
+    // their call sites: differing arities make `binds_position` fail and
+    // differing literals contradict each other, so *both* files lose folds
+    // they are individually entitled to, and editing one changes diagnostics
+    // in the other. Excluding self-declared callees keeps the merge to what
+    // the query name promises — the call sites a file contributes to *other*
+    // files' procedures.
+    let declared = file_decls(db, file);
+    let external: Vec<&str> = scanned
+        .callees()
+        .filter(|qname| !declared.procs.contains(*qname))
+        .collect();
+    Arc::new(scanned.slice_for(external.into_iter()))
 }
 
 /// The project-wide merge of every file's [`file_call_site_evidence`].
@@ -2800,11 +2819,16 @@ mod tests {
             );
         }
 
-        /// The per-file slice is keyed on the file's own declarations, so a
-        /// file that declares nothing the project calls gets an empty slice —
-        /// which is still the meaningful "the project was enumerated" claim.
+        /// The per-file slice is keyed on the file's own declarations *and*
+        /// carries only calls from **other** files.
+        ///
+        /// `main` both declares and calls `::other`, so that call is in-unit
+        /// evidence for `main` and never reaches its external slice — leaving
+        /// it empty, which is still the meaningful "the project was
+        /// enumerated, nobody else calls in" claim. `lib`'s slice does carry
+        /// `::helper`, because `main` calls it without declaring it.
         #[test]
-        fn slice_is_narrowed_to_the_files_own_declarations() {
+        fn slice_carries_only_other_files_calls_to_this_files_procs() {
             let db = TclDatabase::default();
             let lib = SourceFile::new(&db, LIB.to_owned(), "tcl8.6".to_owned(), None);
             let main = SourceFile::new(
@@ -2817,7 +2841,58 @@ mod tests {
             let lib_slice = file_external_call_sites(&db, lib, project);
             assert_eq!(lib_slice.callees().collect::<Vec<_>>(), vec!["::helper"]);
             let main_slice = file_external_call_sites(&db, main, project);
-            assert_eq!(main_slice.callees().collect::<Vec<_>>(), vec!["::other"]);
+            assert!(
+                main_slice.is_empty(),
+                "main's call to its own `other` is in-unit evidence: {main_slice:?}"
+            );
+        }
+
+        /// A workspace pools every file into one project, so two *unrelated*
+        /// files reusing a common helper name (`helper`, `init`, `run` — endemic
+        /// in Tcl) must not pool their call sites.  Here the second file declares
+        /// its own zero-arity `::helper`; without the self-declared-callee
+        /// exclusion its call contributes `arg_counts {0}`, `binds_position(0)`
+        /// fails, and the first file loses a fold it is entitled to — and would
+        /// regain only when the unrelated file changed.
+        ///
+        /// Caught by the VS Code suite, where ~200 fixtures share one workspace
+        /// folder: this exact collision broke issue #969's TP control.
+        #[test]
+        fn an_unrelated_file_reusing_a_proc_name_does_not_poison_the_seed() {
+            use salsa::Setter as _;
+            let mut db = TclDatabase::default();
+            let ctl = SourceFile::new(
+                &db,
+                "proc helper {mode} {\n if {$mode eq \"prod\"} { set r 1 } else { set r 2 }\n}\n\
+             proc c1 {} { helper prod }\nproc c2 {} { helper prod }\n"
+                    .to_owned(),
+                "tcl8.6".to_owned(),
+                None,
+            );
+            let unrelated = SourceFile::new(
+                &db,
+                "proc helper {} {}\nproc caller {} { helper }\n".to_owned(),
+                "tcl8.6".to_owned(),
+                None,
+            );
+            let project = Project::new(&db, vec![ctl, unrelated]);
+            let evidence = file_external_call_sites(&db, ctl, project);
+            assert!(
+                evidence.get("::helper").is_none(),
+                "the unrelated file's own `helper` is in-unit evidence there, not \
+             evidence about this file's proc: {evidence:?}"
+            );
+            ctl.set_external_call_sites(&mut db).to(Some(evidence));
+            let cu = document_compilation_unit(&db, ctl);
+            assert!(
+                !cu.procedures
+                    .get("::helper")
+                    .expect("helper analysed")
+                    .sccp
+                    .constant_branches
+                    .is_empty(),
+                "every caller that can actually reach this proc passes \"prod\""
+            );
         }
 
         /// A body edit that moves no call-site literal must leave

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -40,7 +40,7 @@ use tcl_compiler::cfg_builder::build_cfg_function_with_upvars;
 use tcl_compiler::cfg_builder::global_write_info::GlobalWriteInfo;
 use tcl_compiler::cfg_builder::upvar_info::UpvarInfo;
 use tcl_compiler::compilation_unit::{
-    CompilationUnit, FunctionUnit, LatticeRequest, ModuleTraceFacts,
+    CompilationUnit, FunctionUnit, LatticeRequest, ModuleTraceFacts, UnitBuildOptions,
 };
 use tcl_compiler::compiler_checks::{DiagCode, Diagnostic as CompilerCheck};
 use tcl_compiler::interprocedural::{InterproceduralAnalysis, ProcSummary};
@@ -48,6 +48,7 @@ use tcl_compiler::ir::Script;
 use tcl_compiler::optimiser::Optimisation;
 use tcl_compiler::ssa::ValueKey;
 use tcl_compiler::taint::TaintLattice;
+use tcl_compiler::unit_scope::CallSiteEvidence;
 // The compiler's per-proc return-taint summary (the colour-aware transfer
 // function the interprocedural fixpoint converges) — aliased to avoid clashing
 // with this crate's `ProcTaintSummary` (the *interproc-analysis* projection in
@@ -137,7 +138,7 @@ impl TclDb for TclDatabase {
 ///
 /// `set_text` (generated) is the single write on an edit — salsa cascades
 /// invalidation to every query that read it.
-#[salsa::input]
+#[salsa::input(constructor = with_call_site_evidence)]
 pub struct SourceFile {
     #[returns(ref)]
     pub text: String,
@@ -150,6 +151,42 @@ pub struct SourceFile {
     /// manifests) is analysed with that environment ambient.
     #[returns(ref)]
     pub path: Option<String>,
+    /// Call sites in **other** project files that reach the procedures this
+    /// file defines — the cross-file half of the interprocedural constant
+    /// seed (issue #977).
+    ///
+    /// `None` means "no workspace view": the compilation unit is then on its
+    /// own, and any registry-declared unit boundary in the file — including
+    /// `source` / `package require`, whose loaded unit a workspace normally
+    /// *does* contain — disables the seed rather than trusting an unprovable
+    /// "every caller is in this file".  `Some` is the host asserting it
+    /// enumerated the project, so the merged evidence is the whole picture;
+    /// `Some` of an *empty* evidence set is the meaningful statement "no
+    /// other file calls into this one".  A file that *publishes* commands
+    /// (`package provide`, `namespace export`) declines either way — no
+    /// project enumeration bounds another checkout's `package require`.
+    ///
+    /// Set by the server from [`project_call_site_evidence`] whenever the
+    /// slice relevant to *this* file changes (compare-then-set), so a
+    /// keystroke in an unrelated file leaves it — and every query reading it
+    /// — untouched.
+    #[returns(ref)]
+    pub external_call_sites: Option<Arc<CallSiteEvidence>>,
+}
+
+impl SourceFile {
+    /// Create a source file with **no** cross-file view (`external_call_sites
+    /// = None`) — the shape every standalone consumer (tests, examples, the
+    /// CLI's single-file paths) wants.  Hosts with a workspace call
+    /// [`Self::with_call_site_evidence`] instead, or set the field later.
+    pub fn new(
+        db: &dyn salsa::Database,
+        text: String,
+        dialect: String,
+        path: Option<String>,
+    ) -> Self {
+        Self::with_call_site_evidence(db, text, dialect, path, None)
+    }
 }
 
 /// Analyser configuration mirrored from the editor (the former
@@ -187,6 +224,14 @@ pub struct AnalyserConfig {
 /// concurrent edit's `set_text` until the whole walk finishes). `file_analysis`
 /// itself stays live as the differential-fuzzer / corpus-gate ground truth
 /// [`file_analysis_incremental`] is proven byte-identical against.
+///
+/// One deliberate asymmetry: this query lets the analyser build its **own**
+/// compilation unit, so it never sees [`SourceFile::external_call_sites`],
+/// while [`file_analysis_incremental`] feeds it the shared
+/// [`compilation_unit`] (which does). The two therefore agree exactly when
+/// the file has no cross-file view — which is every gate and fuzzer input,
+/// since [`SourceFile::new`] leaves the field `None`. Production reads only
+/// the incremental query.
 #[salsa::tracked]
 pub fn file_analysis(
     db: &dyn salsa::Database,
@@ -276,6 +321,72 @@ pub fn project_proc_names(db: &dyn salsa::Database, project: Project) -> Arc<BTr
         names.extend(file_decls(db, file).procs.iter().cloned());
     }
     Arc::new(names)
+}
+
+/// Every call site **this** file contributes, resolved against the whole
+/// project's procedure names.
+///
+/// The per-file half of the cross-file interprocedural seed (issue #977):
+/// `lib.tcl`'s own compilation unit can never see `main.tcl`'s `helper dev`,
+/// so each file publishes its call sites here and
+/// [`project_call_site_evidence`] merges them.
+///
+/// Depends on the file's text **and** on [`project_proc_names`] — the
+/// signature firewall — so a body edit anywhere else in the project leaves
+/// this query's inputs unchanged and it is not re-run.  Its own result
+/// early-cutoffs too: an edit that does not move a call site's literal
+/// arguments produces an equal `CallSiteEvidence` and backdates, so
+/// [`project_call_site_evidence`] (and every compilation unit downstream of
+/// it) is left alone.
+#[salsa::tracked]
+pub fn file_call_site_evidence(
+    db: &dyn TclDb,
+    file: SourceFile,
+    project: Project,
+) -> Arc<CallSiteEvidence> {
+    let dialect = file.dialect(db).clone();
+    let registry = db.registry(&dialect);
+    let known: std::collections::HashSet<String> =
+        project_proc_names(db, project).iter().cloned().collect();
+    Arc::new(tcl_compiler::unit_scope::scan_source_call_sites(
+        file.text(db),
+        &registry,
+        &dialect,
+        &known,
+    ))
+}
+
+/// The project-wide merge of every file's [`file_call_site_evidence`].
+///
+/// One table serves every file: a unit's own call sites are already in it, and
+/// merging is monotone, so handing a file the whole project's view is exactly
+/// what it would have collected had the project been one source text.
+#[salsa::tracked]
+pub fn project_call_site_evidence(db: &dyn TclDb, project: Project) -> Arc<CallSiteEvidence> {
+    let mut merged = CallSiteEvidence::default();
+    for &file in project.files(db) {
+        merged.merge_from(&file_call_site_evidence(db, file, project));
+    }
+    Arc::new(merged)
+}
+
+/// The slice of [`project_call_site_evidence`] that concerns the procedures
+/// `file` itself declares — what a host sets on
+/// [`SourceFile::external_call_sites`].
+///
+/// Narrowing to the file's own declarations is what keeps invalidation
+/// precise: editing a call site in `main.tcl` changes only the evidence of the
+/// file that *defines* the callee, so only that file's compilation unit is
+/// rebuilt.
+#[salsa::tracked]
+pub fn file_external_call_sites(
+    db: &dyn TclDb,
+    file: SourceFile,
+    project: Project,
+) -> Arc<CallSiteEvidence> {
+    let declared = file_decls(db, file);
+    let all = project_call_site_evidence(db, project);
+    Arc::new(all.slice_for(declared.procs.iter().map(String::as_str)))
 }
 
 /// Extract the unknown-command name from a W123 message
@@ -900,12 +1011,9 @@ pub fn lower_proc_body<'db>(db: &'db dyn TclDb, key: ProcBodyKey<'db>) -> Arc<Sc
 pub fn memoised_compilation_unit(
     db: &dyn TclDb,
     source: &str,
-    registry: &CommandRegistry,
-    defer_top_level: bool,
-    config: tcl_lexer::LexerConfig,
-    dialect_opt: Option<&str>,
+    options: UnitBuildOptions<'_>,
 ) -> CompilationUnit {
-    build_unit_with_keys(db, source, registry, defer_top_level, config, dialect_opt).0
+    build_unit_with_keys(db, source, options).0
 }
 
 /// [`memoised_compilation_unit`] that also returns the per-procedure
@@ -924,12 +1032,13 @@ pub fn memoised_compilation_unit(
 fn build_unit_with_keys<'db>(
     db: &'db dyn TclDb,
     source: &str,
-    registry: &CommandRegistry,
-    defer_top_level: bool,
-    config: tcl_lexer::LexerConfig,
-    dialect_opt: Option<&str>,
+    options: UnitBuildOptions<'_>,
 ) -> (CompilationUnit, HashMap<String, FnLatticeKey<'db>>) {
-    let dialect = dialect_opt.unwrap_or("");
+    let UnitBuildOptions {
+        registry, config, ..
+    } = options;
+    let dialect = options.dialect;
+    let dialect_opt = (!dialect.is_empty()).then_some(dialect);
     // The module CFG context is the same for every procedure in this build;
     // intern it once on the first request and reuse the id (O(procs), not
     // O(procs²)).
@@ -989,14 +1098,7 @@ fn build_unit_with_keys<'db>(
     // empty table — so a file that may establish aliases forgoes the cache
     // entirely (the per-body scan cannot see a top-level alias).
     let cu = if tcl_compiler::lowering::source_may_alias_commands(source) {
-        CompilationUnit::build_for_memoized(
-            source,
-            registry,
-            defer_top_level,
-            config,
-            dialect,
-            &mut lattice_memo,
-        )
+        CompilationUnit::build_for_memoized(source, options, &mut lattice_memo)
     } else {
         let body_memo = |body_text: &str, namespace: &str| -> Script {
             let key = ProcBodyKey::new(
@@ -1011,10 +1113,7 @@ fn build_unit_with_keys<'db>(
         };
         CompilationUnit::build_for_memoized_with_body_cache(
             source,
-            registry,
-            defer_top_level,
-            config,
-            dialect,
+            options,
             &mut lattice_memo,
             &body_memo,
         )
@@ -1447,13 +1546,17 @@ pub fn proc_taint_solve<'db>(
     let dialect = file.dialect(db).clone();
     let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
     let registry = db.registry(&dialect);
+    let external = file.external_call_sites(db).clone();
     let (cu, lattice_keys) = build_unit_with_keys(
         db,
         file.text(db),
-        &registry,
-        false,
-        cfg.to_config(db),
-        dialect_opt,
+        UnitBuildOptions {
+            registry: &registry,
+            defer_top_level: false,
+            config: cfg.to_config(db),
+            dialect: &dialect,
+            external_call_sites: external.as_deref(),
+        },
     );
     let interproc = cu.interproc.as_ref();
 
@@ -1831,6 +1934,9 @@ pub fn function_optimisations<'db>(
         body_units: HashMap::new(),
         interproc: Some(ia),
         connection_scope: None,
+        // A synthetic single-procedure unit: no source text of its own to
+        // scan for boundaries, and no cross-file view to inherit.
+        caller_scope: tcl_compiler::compilation_unit::UnitCallerScope::default(),
     };
     Arc::new(tcl_compiler::optimiser::optimise_unit_raw(
         &cu,
@@ -2004,6 +2110,10 @@ fn solve_optimisations<'db>(
         body_units: HashMap::new(),
         interproc: cu.interproc.clone(),
         connection_scope: None,
+        // Carried from the real unit: the top-level's own O103 folds must
+        // read the same boundary / cross-file facts the whole-module build
+        // resolved, not a fresh empty scope.
+        caller_scope: cu.caller_scope.clone(),
     };
     for mut opt in tcl_compiler::optimiser::optimise_unit_raw(&top_unit, registry, dialect_opt) {
         if let Some(g) = opt.group {
@@ -2063,15 +2173,18 @@ pub fn compilation_unit<'db>(
     cfg: LexerCfgKey<'db>,
 ) -> Arc<CompilationUnit> {
     let dialect = file.dialect(db).clone();
-    let dialect_opt = (!dialect.is_empty()).then_some(dialect.as_str());
     let registry = db.registry(&dialect);
+    let external = file.external_call_sites(db).clone();
     Arc::new(memoised_compilation_unit(
         db,
         file.text(db),
-        &registry,
-        false,
-        cfg.to_config(db),
-        dialect_opt,
+        UnitBuildOptions {
+            registry: &registry,
+            defer_top_level: false,
+            config: cfg.to_config(db),
+            dialect: &dialect,
+            external_call_sites: external.as_deref(),
+        },
     ))
 }
 
@@ -2630,6 +2743,104 @@ mod tests {
             "a single-body edit must recompute exactly one item via the token \
              path: {after_edit:?}"
         );
+    }
+
+    /// Issue #977, end-to-end through the query graph: `lib.tcl` has no
+    /// `package provide`, its two in-file callers agree on `"prod"`, and
+    /// `main.tcl` — which the single-file compilation unit can never see —
+    /// calls `helper dev`.  With the project's evidence set on the file, the
+    /// I230 "condition is always true/false" fold must not happen.
+    mod cross_file_call_sites {
+        use super::*;
+
+        const LIB: &str = "proc helper {mode} {\n\
+                           if {$mode eq \"prod\"} { set r 1 } else { set r 2 }\n\
+                           }\n\
+                           helper prod\n\
+                           helper prod\n";
+
+        /// Build a two-file project and return `lib`'s compilation unit with
+        /// the project evidence applied, exactly as the server's
+        /// `sync_cross_file_evidence` does.
+        fn lib_unit_with_project(main_src: &str) -> Arc<CompilationUnit> {
+            use salsa::Setter as _;
+            let mut db = TclDatabase::default();
+            let lib = SourceFile::new(&db, LIB.to_owned(), "tcl8.6".to_owned(), None);
+            let main = SourceFile::new(&db, main_src.to_owned(), "tcl8.6".to_owned(), None);
+            let project = Project::new(&db, vec![lib, main]);
+            let evidence = file_external_call_sites(&db, lib, project);
+            lib.set_external_call_sites(&mut db).to(Some(evidence));
+            document_compilation_unit(&db, lib)
+        }
+
+        fn folds_mode(cu: &CompilationUnit) -> bool {
+            !cu.procedures
+                .get("::helper")
+                .expect("helper analysed")
+                .sccp
+                .constant_branches
+                .is_empty()
+        }
+
+        #[test]
+        fn caller_in_another_file_with_a_differing_literal_retracts_the_fold() {
+            let cu = lib_unit_with_project("source lib.tcl\nhelper dev\n");
+            assert!(
+                !folds_mode(&cu),
+                "main.tcl calls helper with \"dev\"; the seed is unsound"
+            );
+        }
+
+        #[test]
+        fn caller_in_another_file_agreeing_still_folds() {
+            let cu = lib_unit_with_project("source lib.tcl\nhelper prod\n");
+            assert!(
+                folds_mode(&cu),
+                "every caller in the project passes \"prod\""
+            );
+        }
+
+        /// The per-file slice is keyed on the file's own declarations, so a
+        /// file that declares nothing the project calls gets an empty slice —
+        /// which is still the meaningful "the project was enumerated" claim.
+        #[test]
+        fn slice_is_narrowed_to_the_files_own_declarations() {
+            let db = TclDatabase::default();
+            let lib = SourceFile::new(&db, LIB.to_owned(), "tcl8.6".to_owned(), None);
+            let main = SourceFile::new(
+                &db,
+                "proc other {x} { return $x }\nother 1\nhelper dev\n".to_owned(),
+                "tcl8.6".to_owned(),
+                None,
+            );
+            let project = Project::new(&db, vec![lib, main]);
+            let lib_slice = file_external_call_sites(&db, lib, project);
+            assert_eq!(lib_slice.callees().collect::<Vec<_>>(), vec!["::helper"]);
+            let main_slice = file_external_call_sites(&db, main, project);
+            assert_eq!(main_slice.callees().collect::<Vec<_>>(), vec!["::other"]);
+        }
+
+        /// A body edit that moves no call-site literal must leave
+        /// `project_call_site_evidence` equal, so it backdates and no
+        /// compilation unit downstream of it is invalidated.
+        #[test]
+        fn evidence_backdates_across_an_unrelated_body_edit() {
+            use salsa::Setter as _;
+            let mut db = TclDatabase::default();
+            let lib = SourceFile::new(&db, LIB.to_owned(), "tcl8.6".to_owned(), None);
+            let main = SourceFile::new(
+                &db,
+                "source lib.tcl\nhelper dev\n".to_owned(),
+                "tcl8.6".to_owned(),
+                None,
+            );
+            let project = Project::new(&db, vec![lib, main]);
+            let before = file_external_call_sites(&db, lib, project);
+            main.set_text(&mut db)
+                .to("source lib.tcl\nset unrelated 1\nhelper dev\n".to_owned());
+            let after = file_external_call_sites(&db, lib, project);
+            assert_eq!(*before, *after, "an unrelated edit must not move evidence");
+        }
     }
 
     /// [`project_class_index`] and [`project_proc_var_index`] must likewise

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -2357,13 +2357,18 @@ pub fn compiler_check_diagnostics_uncached(
     registry: &CommandRegistry,
     dialect: &str,
     generic_patterns: Option<&[String]>,
+    external_call_sites: Option<&CallSiteEvidence>,
 ) -> CompilerDiagnostics {
     let dialect_opt = (!dialect.is_empty()).then_some(dialect);
-    let cu = CompilationUnit::build_for_with_config(
+    let cu = CompilationUnit::build_with_options(
         text,
-        registry,
-        false,
-        tcl_lexer::LexerConfig::for_dialect(dialect),
+        UnitBuildOptions {
+            registry,
+            defer_top_level: false,
+            config: tcl_lexer::LexerConfig::for_dialect(dialect),
+            dialect,
+            external_call_sites,
+        },
     )
     .with_interprocedural(registry, dialect_opt);
     compiler_diagnostics_from_unit(&cu, registry, dialect_opt, generic_patterns)
@@ -2595,7 +2600,7 @@ mod tests {
         let registry = db.registry(dialect);
         let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned(), None);
         let got = compiler_check_diagnostics(&db, file, cfg(&db));
-        let want = compiler_check_diagnostics_uncached(src, &registry, dialect, None);
+        let want = compiler_check_diagnostics_uncached(src, &registry, dialect, None, None);
         assert!(
             got.optimisations.iter().any(|o| o.code == DiagCode::O122),
             "expected O122 to fire on the tail-recursive proc"
@@ -3352,7 +3357,7 @@ mod tests {
                 ),
             );
             let registry = db.registry(dialect);
-            let want = compiler_check_diagnostics_uncached(src, &registry, dialect, None);
+            let want = compiler_check_diagnostics_uncached(src, &registry, dialect, None, None);
             assert_eq!(
                 got.checks, want.checks,
                 "checks differ for ({dialect}):\n{src}"
@@ -3416,7 +3421,7 @@ mod tests {
                     None,
                 ),
             );
-            let want = compiler_check_diagnostics_uncached(src, &registry, dialect, None);
+            let want = compiler_check_diagnostics_uncached(src, &registry, dialect, None, None);
             assert_eq!(
                 got.checks, want.checks,
                 "cascade checks diverge after edit to:\n{src}"
@@ -3509,7 +3514,7 @@ mod tests {
             file.set_text(&mut db).to(src.clone());
 
             let got = compiler_check_diagnostics(&db, file, cfg(&db));
-            let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None);
+            let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None, None);
             assert_eq!(
                 got.checks, want.checks,
                 "iter {iter}: checks diverge from fresh build for state {state:?}:\n{src}"

--- a/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
+++ b/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
@@ -99,7 +99,7 @@ fn compiler_check_memo_matches_uncached_graphops() {
     let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
     let got = compiler_check_diagnostics(&db, file, default_config(&db));
     let registry = db.registry(dialect);
-    let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None);
+    let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None, None);
     assert_eq!(
         got.checks, want.checks,
         "graphops checks diverge (memo vs uncached)"
@@ -129,7 +129,7 @@ fn compiler_check_memo_matches_uncached_init() {
     let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
     let got = compiler_check_diagnostics(&db, file, default_config(&db));
     let registry = db.registry(dialect);
-    let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None);
+    let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None, None);
     assert_eq!(
         got.checks, want.checks,
         "init.tcl checks diverge (memo vs uncached)"
@@ -171,7 +171,7 @@ fn compiler_check_memo_matches_uncached_over_corpus() {
         let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
         let got = compiler_check_diagnostics(&db, file, default_config(&db));
         let registry = db.registry(dialect);
-        let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None);
+        let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None, None);
         checked += 1;
         if got.checks != want.checks || got.optimisations != want.optimisations {
             let detail = format!(
@@ -270,7 +270,7 @@ fn compiler_check_memo_matches_uncached_under_corpus_edits() {
             file.set_text(&mut db).to(src.clone());
 
             let got = compiler_check_diagnostics(&db, file, default_config(&db));
-            let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None);
+            let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None, None);
             checked += 1;
             if got.checks != want.checks || got.optimisations != want.optimisations {
                 let detail = format!(

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2454,6 +2454,8 @@ impl Backend {
             // untouched (a body edit then backdates `project_proc_names`).
             file.set_text(&mut *db).to(text);
             file.set_dialect(&mut *db).to(dialect);
+            let project = self.db_project.lock().await;
+            Self::sync_cross_file_evidence(&mut db, &files, project.as_ref());
         } else {
             let path = uri.to_file_path().map(|p| p.display().to_string());
             let file = tcl_lsp_db::SourceFile::new(&*db, text, dialect, path);
@@ -2461,6 +2463,7 @@ impl Backend {
             // Membership changed — re-set the `Project` file set.
             let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
+            Self::sync_cross_file_evidence(&mut db, &files, project.as_ref());
         }
     }
 
@@ -2472,6 +2475,7 @@ impl Backend {
         if files.remove(uri).is_some() {
             let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
+            Self::sync_cross_file_evidence(&mut db, &files, project.as_ref());
         }
     }
 
@@ -2500,10 +2504,11 @@ impl Backend {
                 membership_changed = true;
             }
         }
+        let mut project = self.db_project.lock().await;
         if membership_changed {
-            let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
         }
+        Self::sync_cross_file_evidence(&mut db, &files, project.as_ref());
     }
 
     /// Drop many salsa `SourceFile` inputs at once (files under a removed workspace
@@ -2524,6 +2529,7 @@ impl Backend {
         if membership_changed {
             let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
+            Self::sync_cross_file_evidence(&mut db, &files, project.as_ref());
         }
     }
 
@@ -2547,6 +2553,71 @@ impl Backend {
                 p.set_files(db).to(sources);
             }
             None => *project = Some(tcl_lsp_db::Project::new(&*db, sources)),
+        }
+    }
+
+    /// Refresh every file's [`tcl_lsp_db::SourceFile::external_call_sites`] —
+    /// the call sites in *other* project files that reach the procedures it
+    /// declares (issue #977).
+    ///
+    /// Without this, a compilation unit only ever sees its own file's callers
+    /// and can seed a proc parameter as a compile-time literal that a caller
+    /// in another file contradicts.  Setting the evidence turns the unit's
+    /// "every caller I found agrees" into a claim about the whole project —
+    /// and `Some` of an *empty* slice is itself meaningful: it says the
+    /// server enumerated the project and found no external caller, which is
+    /// what lets a file carrying a registry-declared boundary
+    /// (`package provide`, `source`, `namespace export`) keep folding.
+    ///
+    /// **Compare-then-set**, so an edit that moves no call-site literal
+    /// writes no input and invalidates nothing.  The per-file slice is keyed
+    /// on the file's own declarations, so a call site edited in `main.tcl`
+    /// re-sets only the file that *defines* the callee — not the whole
+    /// project.  Cost per call is one memoised
+    /// [`tcl_lsp_db::project_call_site_evidence`] demand (which backdates
+    /// unless a literal actually moved) plus an O(procs-in-file) slice each.
+    ///
+    /// Runs unconditionally, including when the project drops back to a single
+    /// file: the claim is always "these are the files the server knows about",
+    /// so a file left behind by a `didClose` must have the departed file's
+    /// call sites *removed* from its evidence, not kept.
+    ///
+    /// The workspace is the trust boundary. A caller outside it — a `source`
+    /// target that was never scanned, another project `package require`ing
+    /// this one — is still unenumerable, which is why the registry's
+    /// `PROVIDES_PACKAGE` / `EXPORTS_COMMAND` boundaries decline the seed
+    /// outright rather than trusting an enumeration that cannot cover them.
+    ///
+    /// Salsa cancellation is caught and treated as "leave the evidence
+    /// alone": the edit that cancelled this pass drives its own refresh.
+    fn sync_cross_file_evidence(
+        db: &mut tcl_lsp_db::TclDatabase,
+        files: &HashMap<Uri, tcl_lsp_db::SourceFile>,
+        project: Option<&tcl_lsp_db::Project>,
+    ) {
+        use salsa::Setter as _;
+        let Some(&project) = project else {
+            return;
+        };
+        let snapshot: Vec<tcl_lsp_db::SourceFile> = files.values().copied().collect();
+        let pending = salsa::Cancelled::catch(|| {
+            snapshot
+                .iter()
+                .filter_map(|&file| {
+                    let want = tcl_lsp_db::file_external_call_sites(&*db, file, project);
+                    let unchanged = file
+                        .external_call_sites(&*db)
+                        .as_ref()
+                        .is_some_and(|have| **have == *want);
+                    (!unchanged).then_some((file, want))
+                })
+                .collect::<Vec<_>>()
+        });
+        let Ok(pending) = pending else {
+            return;
+        };
+        for (file, want) in pending {
+            file.set_external_call_sites(db).to(Some(want));
         }
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1201,6 +1201,10 @@ async fn compute_compiler_diags(
                     &c_registry,
                     &c_dialect,
                     c_generic.as_deref(),
+                    // The no-salsa-input fallback: this document is not in the
+                    // db, so there is genuinely no workspace view to pass —
+                    // `None` is the honest answer, not a missed wiring.
+                    None,
                 ))
             })
             .await
@@ -1212,6 +1216,244 @@ async fn compute_compiler_diags(
             }),
         )
     }
+}
+
+/// The debounced, detached diagnostics worker for one document.
+///
+/// A free function rather than an inline `tokio::spawn` body so it can
+/// **respawn itself for a peer document**: refreshing cross-file call-site
+/// evidence here can invalidate another file's diagnostics, and that file's
+/// own worker has to be (re)started to republish them.
+fn spawn_diagnostics_worker(slots: Arc<Mutex<HashMap<Uri, DiagSlot>>>, uri: Uri) {
+    tokio::spawn(async move {
+        loop {
+            // Debounce, then claim the dirty flag *and* the freshest inputs.
+            // A burst collapses to one run; with nothing dirty we retire the
+            // worker (under the lock, so a concurrent edit either sees
+            // `running` and skips the spawn while we run, or sees
+            // `!running` and starts a fresh one).
+            tokio::time::sleep(DIAGNOSTICS_DEBOUNCE).await;
+            let inputs = {
+                let mut guard = slots.lock().await;
+                let Some(slot) = guard.get_mut(&uri) else {
+                    return;
+                };
+                if slot.dirty {
+                    slot.dirty = false;
+                    slot.latest_inputs.clone()
+                } else {
+                    slot.running = false;
+                    return;
+                }
+            };
+            // `latest_inputs` is set alongside `dirty`, so this is `Some`;
+            // guard defensively and retire if it is somehow absent.
+            let Some(inputs) = inputs else {
+                if let Some(slot) = slots.lock().await.get_mut(&uri) {
+                    slot.running = false;
+                }
+                return;
+            };
+            // Refresh the project's cross-file call-site evidence *here* —
+            // debounced and off the message loop — rather than on the edit
+            // handler (issue #977). Any peer whose evidence moved has stale
+            // published diagnostics, so reschedule it below.
+            let stale_peers = sync_cross_file_evidence(
+                &inputs.db,
+                &inputs.db_files,
+                &inputs.db_project,
+                &inputs.workspace_index,
+            )
+            .await;
+            // Capture + analyse the document's current state.  If it is gone
+            // (closed) there is nothing to publish — retire.
+            let Some(job) = inputs.capture_job(&uri).await else {
+                let mut guard = slots.lock().await;
+                if let Some(slot) = guard.get_mut(&uri) {
+                    slot.running = false;
+                }
+                return;
+            };
+            let settled = run_diagnostics_core(inputs, &uri, job).await;
+            if !settled {
+                // Cancelled mid-flight — re-mark dirty so we retry the latest
+                // state next loop.
+                if let Some(slot) = slots.lock().await.get_mut(&uri) {
+                    slot.dirty = true;
+                }
+            }
+            // Republish every peer this run's evidence refresh invalidated.
+            // Only documents that already have resolved inputs are eligible:
+            // a file nobody has analysed has no published diagnostics to go
+            // stale, and its inputs cannot be resolved from here anyway. This
+            // converges — the peer's own run re-syncs, finds nothing changed
+            // (compare-then-set), and reschedules nobody.
+            reschedule_peers(&slots, &uri, stale_peers).await;
+        }
+    });
+}
+
+/// Mark each peer dirty and start its worker if one is not already draining
+/// it. See [`spawn_diagnostics_worker`] for why this exists.
+async fn reschedule_peers(
+    slots: &Arc<Mutex<HashMap<Uri, DiagSlot>>>,
+    self_uri: &Uri,
+    peers: Vec<Uri>,
+) {
+    let mut to_spawn = Vec::new();
+    {
+        let mut guard = slots.lock().await;
+        for peer in peers {
+            if &peer == self_uri {
+                continue;
+            }
+            let Some(slot) = guard.get_mut(&peer) else {
+                continue;
+            };
+            if slot.latest_inputs.is_none() {
+                continue;
+            }
+            slot.dirty = true;
+            if !slot.running {
+                slot.running = true;
+                to_spawn.push(peer);
+            }
+        }
+    }
+    for peer in to_spawn {
+        spawn_diagnostics_worker(Arc::clone(slots), peer);
+    }
+}
+
+/// Refresh every project file's [`tcl_lsp_db::SourceFile::external_call_sites`]
+/// — the call sites in *other* files that reach the procedures it declares
+/// (issue #977) — and report the URIs whose evidence actually moved.
+///
+/// **Runs on the debounced diagnostics worker, never on the edit handler.**
+/// The cold path lowers and builds a CFG for every project file
+/// (`file_call_site_evidence`), which measured ~7s for a 500-file workspace;
+/// doing that inside `did_change` while the `documents` and `db` locks are
+/// held would block the LSP message loop on every keystroke. On the worker it
+/// is already off the message loop, already debounced, and already the place
+/// that pays for analysis.
+///
+/// **Compare-then-set**, so an edit that moves no call-site literal writes no
+/// input and invalidates nothing. The returned URIs are the files whose
+/// published diagnostics are now stale — editing `main.tcl` can change what
+/// `lib.tcl` folds, and `did_change` only ever schedules the edited document,
+/// so the caller must reschedule them or `lib.tcl` keeps showing a diagnostic
+/// the project no longer supports.
+///
+/// Salsa cancellation is caught and reported as "nothing changed": the edit
+/// that cancelled this pass drives its own refresh.
+async fn sync_cross_file_evidence(
+    db: &Mutex<tcl_lsp_db::TclDatabase>,
+    db_files: &Mutex<HashMap<Uri, tcl_lsp_db::SourceFile>>,
+    db_project: &Mutex<Option<tcl_lsp_db::Project>>,
+    workspace_index: &RwLock<core_workspace_index::WorkspaceIndex>,
+) -> Vec<Uri> {
+    use salsa::Setter as _;
+    // Which files the host can honestly claim a closed world for, resolved
+    // before taking the db locks (the index has its own).
+    let covered = files_with_covered_load_targets(db_files, workspace_index).await;
+    let mut db = db.lock().await;
+    let files = db_files.lock().await;
+    let project = db_project.lock().await;
+    let Some(&project) = project.as_ref() else {
+        return Vec::new();
+    };
+    let snapshot: Vec<(Uri, tcl_lsp_db::SourceFile)> =
+        files.iter().map(|(u, &f)| (u.clone(), f)).collect();
+    // `AssertUnwindSafe`: the closure only *reads* the database, and a
+    // cancellation unwind discards the whole `pending` list without applying
+    // anything, so no torn state can be observed afterwards.
+    let pending = salsa::Cancelled::catch(std::panic::AssertUnwindSafe(|| {
+        snapshot
+            .iter()
+            .filter_map(|(uri, file)| {
+                // A file whose `source` target the host never indexed has a
+                // caller the project cannot enumerate, so it gets **no**
+                // evidence: `None` keeps its `LOADS_EXTERNAL_UNIT` boundary
+                // closed rather than letting `Some(empty)` assert a closed
+                // world the scan cannot back (issue #977).
+                let want = covered
+                    .contains(uri)
+                    .then(|| tcl_lsp_db::file_external_call_sites(&*db, *file, project));
+                let unchanged = match (&want, file.external_call_sites(&*db)) {
+                    (Some(want), Some(have)) => **have == **want,
+                    (None, None) => true,
+                    _ => false,
+                };
+                (!unchanged).then(|| (uri.clone(), *file, want))
+            })
+            .collect::<Vec<_>>()
+    }));
+    let Ok(pending) = pending else {
+        return Vec::new();
+    };
+    let mut changed = Vec::with_capacity(pending.len());
+    for (uri, file, want) in pending {
+        file.set_external_call_sites(&mut *db).to(want);
+        changed.push(uri);
+    }
+    changed
+}
+
+/// The project files whose unit-loading boundaries the host can actually
+/// account for — the precondition for claiming a closed world over their
+/// callers (issue #977).
+///
+/// `has_cross_file_evidence` only ever proved that the server enumerated *its
+/// configured project*; it never proved the thing a `source` boundary
+/// actually implies, namely that the loaded unit was among them. A
+/// `source ../shared.tcl` pointing outside the workspace runs a script that
+/// can call this file's procedures with anything, so handing that file
+/// `Some(empty)` would re-open exactly the unsound fold this change closes.
+///
+/// A file is covered when **every** `source` site it contains is a literal
+/// path resolving to a document the project holds. A non-literal path
+/// (`source [file join $dir x.tcl]`) is never covered — the target is a
+/// runtime value.
+///
+/// `package require` / `load` are deliberately not consulted: the required
+/// unit is third-party code written without knowledge of this file, so it
+/// cannot name its procedures. The one way it *can* re-enter — a callback
+/// this file registers — is already recorded as an opaque caller by
+/// `tcl_compiler::unit_scope::record_indirect_callers`.
+async fn files_with_covered_load_targets(
+    db_files: &Mutex<HashMap<Uri, tcl_lsp_db::SourceFile>>,
+    workspace_index: &RwLock<core_workspace_index::WorkspaceIndex>,
+) -> HashSet<Uri> {
+    let files = db_files.lock().await;
+    let known_paths: HashSet<std::path::PathBuf> = files
+        .keys()
+        .filter_map(|u| u.to_file_path().map(|p| p.to_path_buf()))
+        .collect();
+    let mut uncovered: HashSet<&str> = HashSet::new();
+    let index = workspace_index.read().await;
+    for site in index.sources() {
+        if uncovered.contains(site.uri.as_str()) {
+            continue;
+        }
+        let covered = site.is_literal
+            && Uri::from_str(&site.uri)
+                .ok()
+                .and_then(|u| u.to_file_path().map(|p| p.to_path_buf()))
+                .is_some_and(|parent| {
+                    known_paths.contains(&tcl_lsp_core::source_graph::resolve_source_target(
+                        &parent,
+                        &site.raw_path,
+                    ))
+                });
+        if !covered {
+            uncovered.insert(site.uri.as_str());
+        }
+    }
+    files
+        .keys()
+        .filter(|u| !uncovered.contains(u.as_str()))
+        .cloned()
+        .collect()
 }
 
 async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bool {
@@ -2454,8 +2696,6 @@ impl Backend {
             // untouched (a body edit then backdates `project_proc_names`).
             file.set_text(&mut *db).to(text);
             file.set_dialect(&mut *db).to(dialect);
-            let project = self.db_project.lock().await;
-            Self::sync_cross_file_evidence(&mut db, &files, project.as_ref());
         } else {
             let path = uri.to_file_path().map(|p| p.display().to_string());
             let file = tcl_lsp_db::SourceFile::new(&*db, text, dialect, path);
@@ -2463,7 +2703,6 @@ impl Backend {
             // Membership changed — re-set the `Project` file set.
             let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
-            Self::sync_cross_file_evidence(&mut db, &files, project.as_ref());
         }
     }
 
@@ -2475,7 +2714,6 @@ impl Backend {
         if files.remove(uri).is_some() {
             let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
-            Self::sync_cross_file_evidence(&mut db, &files, project.as_ref());
         }
     }
 
@@ -2504,11 +2742,10 @@ impl Backend {
                 membership_changed = true;
             }
         }
-        let mut project = self.db_project.lock().await;
         if membership_changed {
+            let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
         }
-        Self::sync_cross_file_evidence(&mut db, &files, project.as_ref());
     }
 
     /// Drop many salsa `SourceFile` inputs at once (files under a removed workspace
@@ -2529,8 +2766,29 @@ impl Backend {
         if membership_changed {
             let mut project = self.db_project.lock().await;
             Self::sync_db_project(&mut db, &files, &mut project);
-            Self::sync_cross_file_evidence(&mut db, &files, project.as_ref());
         }
+    }
+
+    /// This document's cross-file call-site evidence, cloned out of the salsa
+    /// db so a `spawn_blocking` build can carry it (issue #977).
+    ///
+    /// The tracked `compilation_unit` query reads
+    /// [`tcl_lsp_db::SourceFile::external_call_sites`] itself, but every
+    /// **uncached** build — the pull-diagnostics path and code actions — makes
+    /// a standalone unit that cannot. Without this a pull-mode client would
+    /// get a correct analyser I230 alongside an unsound optimiser O101 for the
+    /// very shape this change exists to fix.
+    ///
+    /// `None` when the document is not in the salsa db (no workspace view to
+    /// speak of), which is the honest answer rather than a claim of one.
+    /// Lock order is `db` → `db_files`, matching [`Self::db_set_source`].
+    async fn cross_file_evidence_for(
+        &self,
+        uri: &Uri,
+    ) -> Option<Arc<tcl_compiler::unit_scope::CallSiteEvidence>> {
+        let db = self.db.lock().await;
+        let files = self.db_files.lock().await;
+        files.get(uri)?.external_call_sites(&*db).clone()
     }
 
     /// Re-set the salsa [`tcl_lsp_db::Project`] input to the current `db_files`
@@ -2553,71 +2811,6 @@ impl Backend {
                 p.set_files(db).to(sources);
             }
             None => *project = Some(tcl_lsp_db::Project::new(&*db, sources)),
-        }
-    }
-
-    /// Refresh every file's [`tcl_lsp_db::SourceFile::external_call_sites`] —
-    /// the call sites in *other* project files that reach the procedures it
-    /// declares (issue #977).
-    ///
-    /// Without this, a compilation unit only ever sees its own file's callers
-    /// and can seed a proc parameter as a compile-time literal that a caller
-    /// in another file contradicts.  Setting the evidence turns the unit's
-    /// "every caller I found agrees" into a claim about the whole project —
-    /// and `Some` of an *empty* slice is itself meaningful: it says the
-    /// server enumerated the project and found no external caller, which is
-    /// what lets a file carrying a registry-declared boundary
-    /// (`package provide`, `source`, `namespace export`) keep folding.
-    ///
-    /// **Compare-then-set**, so an edit that moves no call-site literal
-    /// writes no input and invalidates nothing.  The per-file slice is keyed
-    /// on the file's own declarations, so a call site edited in `main.tcl`
-    /// re-sets only the file that *defines* the callee — not the whole
-    /// project.  Cost per call is one memoised
-    /// [`tcl_lsp_db::project_call_site_evidence`] demand (which backdates
-    /// unless a literal actually moved) plus an O(procs-in-file) slice each.
-    ///
-    /// Runs unconditionally, including when the project drops back to a single
-    /// file: the claim is always "these are the files the server knows about",
-    /// so a file left behind by a `didClose` must have the departed file's
-    /// call sites *removed* from its evidence, not kept.
-    ///
-    /// The workspace is the trust boundary. A caller outside it — a `source`
-    /// target that was never scanned, another project `package require`ing
-    /// this one — is still unenumerable, which is why the registry's
-    /// `PROVIDES_PACKAGE` / `EXPORTS_COMMAND` boundaries decline the seed
-    /// outright rather than trusting an enumeration that cannot cover them.
-    ///
-    /// Salsa cancellation is caught and treated as "leave the evidence
-    /// alone": the edit that cancelled this pass drives its own refresh.
-    fn sync_cross_file_evidence(
-        db: &mut tcl_lsp_db::TclDatabase,
-        files: &HashMap<Uri, tcl_lsp_db::SourceFile>,
-        project: Option<&tcl_lsp_db::Project>,
-    ) {
-        use salsa::Setter as _;
-        let Some(&project) = project else {
-            return;
-        };
-        let snapshot: Vec<tcl_lsp_db::SourceFile> = files.values().copied().collect();
-        let pending = salsa::Cancelled::catch(|| {
-            snapshot
-                .iter()
-                .filter_map(|&file| {
-                    let want = tcl_lsp_db::file_external_call_sites(&*db, file, project);
-                    let unchanged = file
-                        .external_call_sites(&*db)
-                        .as_ref()
-                        .is_some_and(|have| **have == *want);
-                    (!unchanged).then_some((file, want))
-                })
-                .collect::<Vec<_>>()
-        });
-        let Ok(pending) = pending else {
-            return;
-        };
-        for (file, want) in pending {
-            file.set_external_call_sites(db).to(Some(want));
         }
     }
 
@@ -6719,12 +6912,17 @@ impl Backend {
         // path's `resolved_generic_variable_patterns(uri)` so IRULE4002
         // honours a folder's `diagnostics.genericVariablePatterns` override.
         let c_generic = self.resolved_generic_variable_patterns(uri).await;
+        // The pull path builds a standalone unit, so it must be handed the
+        // project's call-site evidence explicitly — the tracked query's own
+        // read of `SourceFile::external_call_sites` never reaches here.
+        let c_evidence = self.cross_file_evidence_for(uri).await;
         tokio::task::spawn_blocking(move || {
             tcl_lsp_db::compiler_check_diagnostics_uncached(
                 &c_text,
                 &c_registry,
                 &c_dialect,
                 c_generic.as_deref(),
+                c_evidence.as_deref(),
             )
         })
         .await
@@ -6959,54 +7157,7 @@ impl Backend {
             return;
         }
         let slots = Arc::clone(&self.diag_slots);
-        tokio::spawn(async move {
-            loop {
-                // Debounce, then claim the dirty flag *and* the freshest inputs.
-                // A burst collapses to one run; with nothing dirty we retire the
-                // worker (under the lock, so a concurrent edit either sees
-                // `running` and skips the spawn while we run, or sees
-                // `!running` and starts a fresh one).
-                tokio::time::sleep(DIAGNOSTICS_DEBOUNCE).await;
-                let inputs = {
-                    let mut guard = slots.lock().await;
-                    let Some(slot) = guard.get_mut(&uri) else {
-                        return;
-                    };
-                    if slot.dirty {
-                        slot.dirty = false;
-                        slot.latest_inputs.clone()
-                    } else {
-                        slot.running = false;
-                        return;
-                    }
-                };
-                // `latest_inputs` is set alongside `dirty`, so this is `Some`;
-                // guard defensively and retire if it is somehow absent.
-                let Some(inputs) = inputs else {
-                    if let Some(slot) = slots.lock().await.get_mut(&uri) {
-                        slot.running = false;
-                    }
-                    return;
-                };
-                // Capture + analyse the document's current state.  If it is gone
-                // (closed) there is nothing to publish — retire.
-                let Some(job) = inputs.capture_job(&uri).await else {
-                    let mut guard = slots.lock().await;
-                    if let Some(slot) = guard.get_mut(&uri) {
-                        slot.running = false;
-                    }
-                    return;
-                };
-                let settled = run_diagnostics_core(inputs, &uri, job).await;
-                if !settled {
-                    // Cancelled mid-flight — re-mark dirty so we retry the latest
-                    // state next loop.
-                    if let Some(slot) = slots.lock().await.get_mut(&uri) {
-                        slot.dirty = true;
-                    }
-                }
-            }
-        });
+        spawn_diagnostics_worker(slots, uri);
     }
 
     /// Best-effort dynamic registration of
@@ -9829,6 +9980,10 @@ impl LanguageServer for Backend {
         // IRULE4002 generic-name patterns for the iRules-only compiler-checks
         // code-action lowering below (uncached, off the salsa path).
         let generic_patterns = self.generic_variable_patterns.lock().await.clone();
+        // Same standalone-unit caveat as the pull-diagnostics path: without
+        // the project's evidence a quick-fix could offer to delete a branch
+        // the project proves reachable (issue #977).
+        let evidence = self.cross_file_evidence_for(&uri).await;
         let actions = tokio::task::spawn_blocking(move || {
             let mut actions = core_code_actions::code_actions(&doc.text, range, Some(&analysis));
             actions.extend(core_code_actions::package_require_actions(
@@ -9864,6 +10019,7 @@ impl LanguageServer for Backend {
                 &registry,
                 &dialect,
                 generic_patterns.as_deref(),
+                evidence.as_deref(),
             );
             actions.extend(core_code_actions::check_diagnostic_actions(
                 &doc.text,
@@ -13525,7 +13681,7 @@ mod tests {
         let src = "if {1} { set x 1 } else { set y 2 }\n";
         let diags = lift_compiler_diagnostics(
             src,
-            &tcl_lsp_db::compiler_check_diagnostics_uncached(src, &registry, "", None),
+            &tcl_lsp_db::compiler_check_diagnostics_uncached(src, &registry, "", None, None),
             true,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
@@ -13551,7 +13707,7 @@ mod tests {
         // Master switch off: no optimiser O-codes at all (compiler checks still run).
         let off = lift_compiler_diagnostics(
             src,
-            &tcl_lsp_db::compiler_check_diagnostics_uncached(src, &registry, "", None),
+            &tcl_lsp_db::compiler_check_diagnostics_uncached(src, &registry, "", None, None),
             false,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
@@ -13567,7 +13723,7 @@ mod tests {
         disabled.insert("O100".to_string());
         let per_code = lift_compiler_diagnostics(
             src,
-            &tcl_lsp_db::compiler_check_diagnostics_uncached(src, &registry, "", None),
+            &tcl_lsp_db::compiler_check_diagnostics_uncached(src, &registry, "", None, None),
             true,
             &disabled,
             &std::collections::HashSet::new(),
@@ -13588,7 +13744,7 @@ mod tests {
         let registry = tcl_registry::registry_for_profile(tcl_dialect::DialectProfile::irules());
         let src = "set u [HTTP::uri]\nHTTP::respond 200 content $u\n";
         let cdiags =
-            tcl_lsp_db::compiler_check_diagnostics_uncached(src, registry, "f5-irules", None);
+            tcl_lsp_db::compiler_check_diagnostics_uncached(src, registry, "f5-irules", None, None);
         let diags = lift_compiler_diagnostics(
             src,
             &cdiags,
@@ -13617,7 +13773,7 @@ mod tests {
         let registry = tcl_registry::registry_for_profile(tcl_dialect::DialectProfile::irules());
         let src = "set u [HTTP::uri]\nHTTP::respond 200 content $u\n";
         let cdiags =
-            tcl_lsp_db::compiler_check_diagnostics_uncached(src, registry, "f5-irules", None);
+            tcl_lsp_db::compiler_check_diagnostics_uncached(src, registry, "f5-irules", None, None);
         let is_irule3001 = |d: &tower_lsp_server::ls_types::Diagnostic| matches!(&d.code, Some(tower_lsp_server::ls_types::NumberOrString::String(c)) if c == "IRULE3001");
         // Baseline: IRULE3001 is present with no disabled codes.
         let baseline = lift_compiler_diagnostics(
@@ -13664,7 +13820,7 @@ mod tests {
         // Baseline: S100 fires with no suppression.
         let baseline = lift_compiler_diagnostics(
             src,
-            &tcl_lsp_db::compiler_check_diagnostics_uncached(src, &registry, "", None),
+            &tcl_lsp_db::compiler_check_diagnostics_uncached(src, &registry, "", None, None),
             true,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
@@ -13680,7 +13836,13 @@ mod tests {
             .clone();
         let filtered = lift_compiler_diagnostics(
             suppressed_src,
-            &tcl_lsp_db::compiler_check_diagnostics_uncached(suppressed_src, &registry, "", None),
+            &tcl_lsp_db::compiler_check_diagnostics_uncached(
+                suppressed_src,
+                &registry,
+                "",
+                None,
+                None,
+            ),
             true,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),
@@ -13701,7 +13863,13 @@ mod tests {
             .clone();
         let unfiltered = lift_compiler_diagnostics(
             unrelated_src,
-            &tcl_lsp_db::compiler_check_diagnostics_uncached(unrelated_src, &registry, "", None),
+            &tcl_lsp_db::compiler_check_diagnostics_uncached(
+                unrelated_src,
+                &registry,
+                "",
+                None,
+                None,
+            ),
             true,
             &std::collections::HashSet::new(),
             &std::collections::HashSet::new(),

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1254,17 +1254,22 @@ fn spawn_diagnostics_worker(slots: Arc<Mutex<HashMap<Uri, DiagSlot>>>, uri: Uri)
                 }
                 return;
             };
-            // Refresh the project's cross-file call-site evidence *here* —
-            // debounced and off the message loop — rather than on the edit
-            // handler (issue #977). Any peer whose evidence moved has stale
-            // published diagnostics, so reschedule it below.
-            let stale_peers = sync_cross_file_evidence(
-                &inputs.db,
-                &inputs.db_files,
-                &inputs.db_project,
-                &inputs.workspace_index,
-            )
-            .await;
+            // A document that has never had cross-file evidence set gets it
+            // *before* its first analysis, so its first published diagnostics
+            // are already correct — publishing an "always true" fold and
+            // retracting it a moment later is precisely the flicker issue #977
+            // is about. Subsequent passes skip this and refresh after
+            // publishing instead, keeping the project-wide scan off the
+            // critical path for every later edit (and out from in front of the
+            // semantic-token enrichment tier on a large document).
+            // Handles for the post-publish evidence refresh below
+            // (`run_diagnostics_core` consumes `inputs`).
+            let evidence_handles = (
+                Arc::clone(&inputs.db),
+                Arc::clone(&inputs.db_files),
+                Arc::clone(&inputs.db_project),
+                Arc::clone(&inputs.workspace_index),
+            );
             // Capture + analyse the document's current state.  If it is gone
             // (closed) there is nothing to publish — retire.
             let Some(job) = inputs.capture_job(&uri).await else {
@@ -1282,13 +1287,46 @@ fn spawn_diagnostics_worker(slots: Arc<Mutex<HashMap<Uri, DiagSlot>>>, uri: Uri)
                     slot.dirty = true;
                 }
             }
-            // Republish every peer this run's evidence refresh invalidated.
-            // Only documents that already have resolved inputs are eligible:
-            // a file nobody has analysed has no published diagnostics to go
-            // stale, and its inputs cannot be resolved from here anyway. This
-            // converges — the peer's own run re-syncs, finds nothing changed
+            // Refresh the project's cross-file call-site evidence *after*
+            // publishing (issue #977). Off the edit handler, as it must be —
+            // but also behind this document's own result rather than in front
+            // of it: the cold path lowers every project file, and on a large
+            // document that delayed both the diagnostics and the semantic-token
+            // enrichment tier gated behind them.
+            //
+            // The cost of publishing first is that a file's *first* run uses
+            // whatever evidence it already had. When the refresh then changes
+            // this file's own evidence we re-mark it dirty, so the loop
+            // immediately re-analyses under the corrected view — the same
+            // publish-then-enrich shape the semantic-token tiers use. Salsa
+            // memoisation makes the second pass cheap apart from what the
+            // evidence genuinely invalidated.
+            let (db, db_files, db_project, workspace_index) = evidence_handles;
+            let changed =
+                sync_cross_file_evidence(&db, &db_files, &db_project, &workspace_index).await;
+            // Re-analyse *this* document only when the refresh gave it evidence
+            // that can actually change its result: a non-empty table means some
+            // other file calls into it, which is what retracts a fold. Going
+            // from "no view" to an *empty* view leaves the merged evidence
+            // identical, so re-running would publish a byte-identical second
+            // result — and one publish per version is a contract
+            // (`diagnostics_delivery_smoke`, and the duplicate-diagnostics KCS
+            // note). Residual: an empty view also lifts a `LOADS_EXTERNAL_UNIT`
+            // decline, which can *add* a fold; not republishing leaves that as
+            // a missing hint until the next edit, the safe direction.
+            if changed.contains(&uri)
+                && has_external_callers(&db, &db_files, &uri).await
+                && let Some(slot) = slots.lock().await.get_mut(&uri)
+            {
+                slot.dirty = true;
+            }
+            // Republish every peer the refresh invalidated. Only documents
+            // that already have resolved inputs are eligible: a file nobody
+            // has analysed has no published diagnostics to go stale, and its
+            // inputs cannot be resolved from here anyway. This converges — the
+            // peer's own run re-syncs, finds nothing changed
             // (compare-then-set), and reschedules nobody.
-            reschedule_peers(&slots, &uri, stale_peers).await;
+            reschedule_peers(&slots, &uri, changed).await;
         }
     });
 }
@@ -1323,6 +1361,26 @@ async fn reschedule_peers(
     for peer in to_spawn {
         spawn_diagnostics_worker(Arc::clone(slots), peer);
     }
+}
+
+/// Whether `uri`'s cross-file evidence actually names a caller.
+///
+/// Distinguishes "the project has something to say about this file's
+/// procedures" from "the project was enumerated and had nothing to add" — the
+/// latter cannot change what the file folds, so it must not trigger a second,
+/// identical publish. Lock order is `db` → `db_files`.
+async fn has_external_callers(
+    db: &Mutex<tcl_lsp_db::TclDatabase>,
+    db_files: &Mutex<HashMap<Uri, tcl_lsp_db::SourceFile>>,
+    uri: &Uri,
+) -> bool {
+    let db = db.lock().await;
+    let files = db_files.lock().await;
+    files.get(uri).is_some_and(|f| {
+        f.external_call_sites(&*db)
+            .as_ref()
+            .is_some_and(|e| !e.is_empty())
+    })
 }
 
 /// Refresh every project file's [`tcl_lsp_db::SourceFile::external_call_sites`]

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -580,6 +580,66 @@ impl Lsp {
         self.await_diagnostics_version(uri, None, DEFAULT_TIMEOUT)
     }
 
+    /// Block until the most recent `publishDiagnostics` for `uri` satisfies
+    /// `settled`, returning it.
+    ///
+    /// For facts the server publishes **progressively**: a cross-file
+    /// correction (issue #977) lands on a later publish than the document's
+    /// own first result, because the project-wide call-site evidence is
+    /// refreshed after publishing rather than in front of it — putting it in
+    /// front delayed the semantic-token enrichment tier on a large document.
+    /// [`Self::open_ready`] returns the *first* publish, so a test asserting a
+    /// cross-file outcome has to wait for the converged one instead.
+    pub fn await_diagnostics_settled(
+        &self,
+        uri: &str,
+        timeout: Duration,
+        settled: impl Fn(&[Value]) -> bool,
+    ) -> Vec<Value> {
+        let deadline = Instant::now() + timeout;
+        let mut notes = self.shared.notifications.lock().unwrap();
+        loop {
+            let mut latest: Option<Vec<Value>> = None;
+            for note in notes.iter() {
+                if note.get("method").and_then(Value::as_str)
+                    != Some("textDocument/publishDiagnostics")
+                {
+                    continue;
+                }
+                let params = note.get("params").cloned().unwrap_or(Value::Null);
+                if params.get("uri").and_then(Value::as_str) != Some(uri) {
+                    continue;
+                }
+                latest = Some(
+                    params
+                        .get("diagnostics")
+                        .and_then(Value::as_array)
+                        .cloned()
+                        .unwrap_or_default(),
+                );
+            }
+            if let Some(diags) = &latest
+                && settled(diags)
+            {
+                return latest.unwrap_or_default();
+            }
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                drop(notes);
+                panic!(
+                    "diagnostics for {uri:?} never settled within {timeout:?}{}",
+                    latency_barrier_timeout_note()
+                );
+            }
+            let (guard, _) = self
+                .shared
+                .notify_cv
+                .wait_timeout(notes, remaining)
+                .unwrap();
+            notes = guard;
+        }
+    }
+
     /// Block until a `publishDiagnostics` for `uri` (optionally carrying exactly
     /// `version`) arrives; return the latest matching diagnostics array.
     pub fn await_diagnostics_version(

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -1990,6 +1990,28 @@ fn callback_from_a_sourced_file_clears_i230_in_the_sourcing_file() {
     );
 }
 
+/// A workspace pools every file into one project, so an unrelated file that
+/// happens to reuse a common proc name must not drag its call sites into
+/// this one's evidence.  Regression for the VS Code suite, where ~200
+/// fixtures share a workspace folder and a second global `helper` (zero
+/// arity) silently killed issue #969's TP control.
+#[test]
+fn an_unrelated_file_reusing_a_proc_name_does_not_clear_i230() {
+    let mut lsp = Lsp::tcl();
+    let unrelated_uri = unique_uri("tcl");
+    let ctl_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &unrelated_uri,
+        "proc helper {} {}\nproc caller {} { helper }\n",
+    );
+    let diags = lsp.open_ready(&ctl_uri, CROSS_FILE_LIB);
+    assert!(
+        has_code(&diags, "I230"),
+        "the unrelated file's own `helper` binds to its own definition: {:?}",
+        codes(&diags)
+    );
+}
+
 // -- TestDiagnosticsTrackEdits -------------------------------------------
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -1910,6 +1910,86 @@ fn two_callers_with_uniform_literal_still_fires_i230() {
     );
 }
 
+// -- TestI230CrossFileCallSiteSeedingE2E ---------------------------------
+// Issue #977: PR #970's `package provide` guard did not cover the more common
+// shape — a plain library file with NO `package provide`, `source`d by another
+// file that calls its procs with a different literal. `lib.tcl` analysed alone
+// sees only its own two `helper prod` callers, seeds `mode` as `"prod"`, and
+// folds. The fix threads the project's call sites into the compilation unit
+// (`tcl_lsp_db::project_call_site_evidence` → `SourceFile::external_call_sites`
+// → `tcl_compiler::unit_scope`), so `main.tcl`'s `helper dev` retracts it.
+
+/// The library file from the issue: no `package provide`, two agreeing
+/// in-file callers.
+const CROSS_FILE_LIB: &str = "proc helper {mode} {\n    if {$mode eq \"prod\"} { set r 1 } else { set r 2 }\n}\nhelper prod\nhelper prod\n";
+
+#[test]
+fn caller_in_a_sourcing_file_with_a_differing_literal_clears_i230() {
+    let mut lsp = Lsp::tcl();
+    let main_uri = unique_uri("tcl");
+    let lib_uri = unique_uri("tcl");
+    // Open the caller first so it is already in the project when the library
+    // is analysed — the same ordering a workspace scan produces.
+    lsp.open_ready(&main_uri, "source lib.tcl\nhelper dev\n");
+    let diags = lsp.open_ready(&lib_uri, CROSS_FILE_LIB);
+    assert!(
+        !has_code(&diags, "I230"),
+        "helper is called with \"dev\" from the sourcing file; must not fold: {:?}",
+        codes(&diags)
+    );
+}
+
+/// TP control: with every project caller agreeing on the literal the seed is
+/// sound and I230 still fires — the fix must not disable the mechanism.
+#[test]
+fn caller_in_another_file_agreeing_on_the_literal_still_fires_i230() {
+    let mut lsp = Lsp::tcl();
+    let main_uri = unique_uri("tcl");
+    let lib_uri = unique_uri("tcl");
+    lsp.open_ready(&main_uri, "source lib.tcl\nhelper prod\n");
+    let diags = lsp.open_ready(&lib_uri, CROSS_FILE_LIB);
+    assert!(
+        has_code(&diags, "I230"),
+        "every caller in the project passes \"prod\": {:?}",
+        codes(&diags)
+    );
+}
+
+/// TN control: a project file that never calls into the library contributes
+/// no evidence and must not disturb a sound fold.
+#[test]
+fn unrelated_project_file_does_not_clear_i230() {
+    let mut lsp = Lsp::tcl();
+    let other_uri = unique_uri("tcl");
+    let lib_uri = unique_uri("tcl");
+    lsp.open_ready(&other_uri, "proc other {x} { return $x }\nother 1\n");
+    let diags = lsp.open_ready(&lib_uri, CROSS_FILE_LIB);
+    assert!(
+        has_code(&diags, "I230"),
+        "an unrelated file must not retract a sound fold: {:?}",
+        codes(&diags)
+    );
+}
+
+/// The other direction: the *sourcing* file's own proc is called back from
+/// the file it sources. `main.tcl`'s two visible callers agree on `"prod"`,
+/// but `lib.tcl` — whose script runs in the same interpreter — calls
+/// `local dev`, so the fold must be retracted there too.
+#[test]
+fn callback_from_a_sourced_file_clears_i230_in_the_sourcing_file() {
+    let mut lsp = Lsp::tcl();
+    let lib_uri = unique_uri("tcl");
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(&lib_uri, "local dev\n");
+    let src = "source lib.tcl\nproc local {mode} {\n    if {$mode eq \"prod\"} { set r 1 } else { set r 2 }\n}\nlocal prod\nlocal prod\n";
+    let diags = lsp.open_ready(&main_uri, src);
+    assert!(
+        !has_code(&diags, "I230"),
+        "the sourced script calls ::local with \"dev\": {:?}",
+        codes(&diags)
+    );
+}
+
 // -- TestDiagnosticsTrackEdits -------------------------------------------
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -1931,7 +1931,15 @@ fn caller_in_a_sourcing_file_with_a_differing_literal_clears_i230() {
     // Open the caller first so it is already in the project when the library
     // is analysed — the same ordering a workspace scan produces.
     lsp.open_ready(&main_uri, "source lib.tcl\nhelper dev\n");
-    let diags = lsp.open_ready(&lib_uri, CROSS_FILE_LIB);
+    lsp.open_document(&lib_uri, CROSS_FILE_LIB);
+    // The cross-file retraction lands on a *later* publish than the library's
+    // own first result: the project's call-site evidence is refreshed after
+    // publishing, not in front of it (putting it in front delayed the
+    // semantic-token enrichment tier on a large document). Wait for the
+    // converged state rather than the first publish.
+    let diags = lsp.await_diagnostics_settled(&lib_uri, Duration::from_secs(20), |d| {
+        !d.is_empty() && !has_code(d, "I230")
+    });
     assert!(
         !has_code(&diags, "I230"),
         "helper is called with \"dev\" from the sourcing file; must not fold: {:?}",
@@ -1982,7 +1990,10 @@ fn callback_from_a_sourced_file_clears_i230_in_the_sourcing_file() {
     let main_uri = unique_uri("tcl");
     lsp.open_ready(&lib_uri, "local dev\n");
     let src = "source lib.tcl\nproc local {mode} {\n    if {$mode eq \"prod\"} { set r 1 } else { set r 2 }\n}\nlocal prod\nlocal prod\n";
-    let diags = lsp.open_ready(&main_uri, src);
+    lsp.open_document(&main_uri, src);
+    let diags = lsp.await_diagnostics_settled(&main_uri, Duration::from_secs(20), |d| {
+        !d.is_empty() && !has_code(d, "I230")
+    });
     assert!(
         !has_code(&diags, "I230"),
         "the sourced script calls ::local with \"dev\": {:?}",

--- a/rust/tcl-registry/src/commands/tcl/auto_import.rs
+++ b/rust/tcl-registry/src/commands/tcl/auto_import.rs
@@ -49,7 +49,11 @@ pub fn spec() -> CommandSpec {
         // `CmdInfo` row and is absent from the exact C Tcl
         // safe-interpreter hidden-command table documented on
         // `Traits::SAFE_INTERP_HIDDEN` — that trait does not apply here.
-        traits: Traits::OVERRIDABLE_LIBRARY_PROC,
+        traits: Traits::OVERRIDABLE_LIBRARY_PROC
+            // Auto-loads (and imports) the commands matching `pattern`
+            // from whichever unit the auto-index names, so another unit's
+            // script runs in this interpreter.
+            | Traits::LOADS_EXTERNAL_UNIT,
         // `auto_import pattern` — exactly one argument, unchanged across
         // every documented release, Tcl library.n 8.4 through 9.1.
         arity: Arity::exact(1),

--- a/rust/tcl-registry/src/commands/tcl/auto_load.rs
+++ b/rust/tcl-registry/src/commands/tcl/auto_load.rs
@@ -49,7 +49,11 @@ pub fn spec() -> CommandSpec {
         // `CmdInfo` row and is absent from the exact C Tcl
         // safe-interpreter hidden-command table documented on
         // `Traits::SAFE_INTERP_HIDDEN` — that trait does not apply here.
-        traits: Traits::OVERRIDABLE_LIBRARY_PROC,
+        traits: Traits::OVERRIDABLE_LIBRARY_PROC
+            // Sources the auto-index-named file that defines `cmdName`
+            // into this interpreter, so that file's script can call back
+            // into whatever this one has defined.
+            | Traits::LOADS_EXTERNAL_UNIT,
         // `auto_load cmd ?namespace?`: library.n (8.4 through 9.1) only
         // documents `cmd`, but every shipped `library/init.tcl` defines
         // `proc auto_load {cmd {namespace {}}} …` — confirmed against the

--- a/rust/tcl-registry/src/commands/tcl/load.rs
+++ b/rust/tcl-registry/src/commands/tcl/load.rs
@@ -82,7 +82,14 @@ pub fn spec() -> CommandSpec {
         // execution in the process, at least as severe as `exec`'s argv
         // hazard or `open`'s pipe-form hazard (both already modelled as
         // sinks the same way).
-        traits: Traits::BYTE_COMPILED | Traits::SAFE_INTERP_HIDDEN | Traits::TAINT_SINK,
+        traits: Traits::BYTE_COMPILED
+            | Traits::SAFE_INTERP_HIDDEN
+            | Traits::TAINT_SINK
+            // Binds a shared library's commands into this interpreter: the
+            // loaded package's own initialisation script can call straight
+            // back into whatever this file has defined, so this file's
+            // visible call sites are no longer the complete caller set.
+            | Traits::LOADS_EXTERNAL_UNIT,
         // Positional-argument count only: 1 (fileName alone) to 3
         // (fileName + prefix/packageName + interp) in every version.
         // `check_simple_arity` (tcl-compiler) skips leading words that

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -269,6 +269,11 @@ static SUBCOMMANDS: &[SubCommand] = &[
         closed_value_args: &[0],
         arg_values_accept_prefix: true,
         analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceEnsemble),
+        // An ensemble publishes its namespace's commands under a single
+        // dispatching command name (and `-map` can redirect a subcommand
+        // to an arbitrary prefix), so the mapped commands acquire callers
+        // that need not appear in this file at all.
+        traits: Traits::EXPORTS_COMMAND,
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -308,6 +313,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         return_type: Some(TclType::List),
         options: EXPORT_OPTIONS,
         analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceExport),
+        // Publishes this namespace's commands for another unit to
+        // `namespace import`, so the exported names have callers this file
+        // does not contain.
+        traits: Traits::EXPORTS_COMMAND,
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -342,6 +351,14 @@ static SUBCOMMANDS: &[SubCommand] = &[
         return_type: Some(TclType::List),
         options: IMPORT_OPTIONS,
         analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceImport),
+        // Deliberately NOT `LOADS_EXTERNAL_UNIT`: `namespace import
+        // ::lib::*` is just as often an intra-file convenience over a
+        // namespace the same file defines, which proves nothing about
+        // other units. The import *is* a real caller path, but
+        // `unit_scope`'s evidence scan already models it precisely (it
+        // resolves calls through the import, and records an opaque caller
+        // when it cannot), so nothing is lost by leaving the coarse
+        // boundary flag off.
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcl/package_.rs
+++ b/rust/tcl-registry/src/commands/tcl/package_.rs
@@ -111,6 +111,11 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // it as part of the enclosing `package ifneeded` call's own scope.
         arg_roles: &[(2, ArgRole::Body)],
         body_kind: BodyKind::Structural,
+        // Registering a load script names *this* file as the thing that
+        // supplies `package`, so the commands it defines are public API a
+        // `package require` in some other file reaches — the same
+        // caller-set widening `provide` declares, one step earlier.
+        traits: Traits::PROVIDES_PACKAGE,
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -167,6 +172,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "package provide package ?version?",
         return_type: Some(TclType::String),
         analyser_hook: Some(crate::hooks::AnalyserHookId::PackageProvide),
+        // Declares the file a loadable package: every command it defines
+        // is reachable from any file that `package require`s it, so a
+        // single-file view of the call sites is never the whole picture.
+        traits: Traits::PROVIDES_PACKAGE,
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -186,6 +195,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
             }]
         },
         analyser_hook: Some(crate::hooks::AnalyserHookId::PackageRequire),
+        // Evaluates another unit's `ifneeded` script in this interpreter,
+        // so that unit's top level can call straight back into whatever
+        // this file has already defined.
+        traits: Traits::LOADS_EXTERNAL_UNIT,
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcl/source_.rs
+++ b/rust/tcl-registry/src/commands/tcl/source_.rs
@@ -138,6 +138,12 @@ pub fn spec() -> CommandSpec {
             | Traits::BYTE_COMPILED
             | Traits::LANGUAGE_KEYWORD
             | Traits::SOURCES_FILE
+            // Evaluates another file's script in this interpreter, so that
+            // file's commands can call back into whatever this one defines
+            // — the signal `tcl_compiler::unit_scope` needs to stop
+            // treating this file's own call sites as the complete caller
+            // set (issue #977).
+            | Traits::LOADS_EXTERNAL_UNIT
             | Traits::DYNAMIC_EVAL_BODY
             | Traits::SAFE_INTERP_HIDDEN
             // fileName is unconditionally read and evaluated as Tcl code:

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -153,7 +153,7 @@ pub use special_vars::{
 };
 pub use symbol_def::{DefinedSymbolKind, SymbolDef};
 pub use taint::{SetterConstraint, TaintColour};
-pub use traits::Traits;
+pub use traits::{Traits, UNIT_LINKAGE_TRAITS};
 pub use types::{ReturnElements, TclType, VarElementsEffect, VarWriteTyping};
 
 /// Crate version string.

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -950,6 +950,35 @@ impl CommandRegistry {
             .is_some_and(|specs| specs.iter().any(|s| s.unsafe_command))
     }
 
+    /// The [`crate::traits::UNIT_LINKAGE_TRAITS`] this concrete invocation
+    /// carries — the registry's answer to "does this command widen the set
+    /// of callers beyond the file it appears in?".
+    ///
+    /// `PROVIDES_PACKAGE` (`package provide` / `ifneeded`) and
+    /// `EXPORTS_COMMAND` (`namespace export`, `namespace ensemble`) say the
+    /// file publishes an API surface; `LOADS_EXTERNAL_UNIT` (`source`,
+    /// `load`, `package require`, `auto_load`, `auto_import`, `namespace
+    /// import`) says another unit's script runs in this interpreter and can
+    /// call back in.  Any of the three sinks the "every caller of this
+    /// file's procs is in this file" assumption that
+    /// `tcl_compiler::unit_scope`'s interprocedural call-site seed rests on
+    /// (issue #977).
+    ///
+    /// Resolved through [`Self::resolve_call`], so the subcommand word is
+    /// honoured (`package provide` is a boundary, `package names` is not)
+    /// and `spec.traits | sub.traits` composes exactly as
+    /// [`crate::spec::SubCommand::traits`] documents. An unknown command
+    /// carries no linkage — a user proc named `source` is a user proc.
+    #[must_use]
+    pub fn unit_linkage(&self, name: &str, args: &[&str], dialect: DialectSet) -> Traits {
+        let Some(resolved) = self.resolve_call(name, args, dialect) else {
+            return Traits::empty();
+        };
+        let traits =
+            resolved.spec.traits | resolved.sub.map_or_else(Traits::empty, |sub| sub.traits);
+        traits.intersection(crate::traits::UNIT_LINKAGE_TRAITS)
+    }
+
     /// Whether `name` is valid only at the top level of an iRule script
     /// (`when`, `proc`, `priority`, `timing`).  Drives the IRULE5006 /
     /// IRULE5007 placement checks ([`Traits::IRULES_TOP_LEVEL_ONLY`]).
@@ -3935,5 +3964,96 @@ mod tests {
         // An unknown command name is safely neither.
         assert!(!reg.is_xc_never_translatable("no_such_command_xyz"));
         assert!(!reg.is_xc_translatable_override("no_such_command_xyz"));
+    }
+
+    /// `unit_linkage` composes `spec.traits | sub.traits` and filters to the
+    /// linkage union, so the answer is subcommand-precise: `package provide`
+    /// publishes an API surface, `package require` pulls another unit in, and
+    /// `package names` does neither (issue #977).
+    #[test]
+    fn unit_linkage_is_subcommand_precise() {
+        let reg = CommandRegistry::build_default();
+        let empty = DialectSet::empty();
+        assert_eq!(
+            reg.unit_linkage("package", &["provide", "mylib", "1.0"], empty),
+            Traits::PROVIDES_PACKAGE
+        );
+        assert_eq!(
+            reg.unit_linkage("package", &["ifneeded", "mylib", "1.0", "body"], empty),
+            Traits::PROVIDES_PACKAGE
+        );
+        assert_eq!(
+            reg.unit_linkage("package", &["require", "mylib"], empty),
+            Traits::LOADS_EXTERNAL_UNIT
+        );
+        assert_eq!(
+            reg.unit_linkage("package", &["names"], empty),
+            Traits::empty()
+        );
+    }
+
+    /// The whole registry-declared boundary surface, resolved by name: every
+    /// command that widens a file's caller set reports its kind, a
+    /// `::`-qualified spelling resolves the same, and a command that does
+    /// neither reports nothing.
+    #[test]
+    fn unit_linkage_covers_every_declared_boundary_command() {
+        let reg = CommandRegistry::build_default();
+        let empty = DialectSet::empty();
+        for (name, args, want) in [
+            ("source", &["lib.tcl"][..], Traits::LOADS_EXTERNAL_UNIT),
+            ("::source", &["lib.tcl"][..], Traits::LOADS_EXTERNAL_UNIT),
+            ("load", &["libx.so"][..], Traits::LOADS_EXTERNAL_UNIT),
+            ("auto_load", &["helper"][..], Traits::LOADS_EXTERNAL_UNIT),
+            (
+                "auto_import",
+                &["::lib::*"][..],
+                Traits::LOADS_EXTERNAL_UNIT,
+            ),
+            // `namespace import` is deliberately not a boundary — see its
+            // own spec comment.
+            (
+                "namespace",
+                &["import", "::lib::helper"][..],
+                Traits::empty(),
+            ),
+            (
+                "namespace",
+                &["export", "helper"][..],
+                Traits::EXPORTS_COMMAND,
+            ),
+            (
+                "namespace",
+                &["ensemble", "create"][..],
+                Traits::EXPORTS_COMMAND,
+            ),
+            ("namespace", &["eval", "::ns", "{}"][..], Traits::empty()),
+            ("set", &["x", "1"][..], Traits::empty()),
+            ("no_such_command_xyz", &["source"][..], Traits::empty()),
+        ] {
+            assert_eq!(
+                reg.unit_linkage(name, args, empty),
+                want,
+                "unit_linkage({name}, {args:?})"
+            );
+        }
+    }
+
+    /// Widening `Traits` to `u128` gave `SAFE_INTERP_HIDDEN` a bit of its own
+    /// (issue #1031): while it aliased `TRANSFERS_CONTROL` at bit 61, every
+    /// `break`/`continue`/`tailcall`/`yield` read as safe-interp-hidden and
+    /// every `cd`/`exec`/`glob`/… read as control-transferring, which
+    /// `FRAME_SENSITIVE_TRAITS` consumes directly.
+    #[test]
+    fn safe_interp_hidden_no_longer_aliases_transfers_control() {
+        let reg = CommandRegistry::build_default();
+        assert_ne!(Traits::TRANSFERS_CONTROL, Traits::SAFE_INTERP_HIDDEN);
+        let cd = reg.get("cd").expect("cd is registered");
+        assert!(cd.traits.contains(Traits::SAFE_INTERP_HIDDEN));
+        assert!(!cd.traits.contains(Traits::TRANSFERS_CONTROL));
+        assert!(!reg.is_frame_sensitive("cd"));
+        let brk = reg.get("break").expect("break is registered");
+        assert!(brk.traits.contains(Traits::TRANSFERS_CONTROL));
+        assert!(!brk.traits.contains(Traits::SAFE_INTERP_HIDDEN));
     }
 }

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -151,6 +151,19 @@ impl Traits {
         Self(self.0 | other.0)
     }
 
+    /// Set intersection — the traits set in both.
+    ///
+    /// The counterpart to [`Self::union`], for a consumer that wants to
+    /// *narrow* a set to a mask rather than test it
+    /// ([`Self::contains`] / [`Self::intersects`] answer a question; this
+    /// returns the overlap). Used by
+    /// [`crate::registry::CommandRegistry::unit_linkage`] to report only the
+    /// [`crate::UNIT_LINKAGE_TRAITS`] a command carries.
+    #[must_use]
+    pub const fn intersection(self, other: Self) -> Self {
+        Self(self.0 & other.0)
+    }
+
     /// Add every trait in `other`.
     pub const fn insert(&mut self, other: Self) {
         self.0 |= other.0;
@@ -586,7 +599,41 @@ declare_traits! {
     /// consults this flag generically — no command name appears in
     /// the consumer (issue #945 fault 7).
     SafeInterpHidden => SAFE_INTERP_HIDDEN;
+
+    /// Declares the enclosing file to be a loadable **package**, so the
+    /// commands it defines are public API that files this compilation unit
+    /// cannot see may call — `package provide`, `package ifneeded`.  The
+    /// interprocedural call-site seed (`tcl_compiler::unit_scope`) refuses
+    /// to treat a file's visible call sites as the complete caller set once
+    /// this appears, because no project enumeration bounds a consumer in
+    /// another checkout (issue #977).
+    ProvidesPackage => PROVIDES_PACKAGE;
+
+    /// Pulls another compilation unit's script into *this* interpreter, so
+    /// that unit's code can call back into the commands this file defines —
+    /// `source`, `load`, `package require`, `auto_load`, `auto_import`.  A
+    /// weaker signal than [`Traits::PROVIDES_PACKAGE`]: the loaded unit is
+    /// normally a file the host's project already contains, so real
+    /// cross-file evidence can cover it (issue #977).
+    LoadsExternalUnit => LOADS_EXTERNAL_UNIT;
+
+    /// Publishes a command name for another unit to import or dispatch
+    /// through — `namespace export`, `namespace ensemble create` /
+    /// `configure`.  Like [`Traits::PROVIDES_PACKAGE`], it marks the file's
+    /// commands as an API surface whose callers the file does not contain
+    /// and no enumeration bounds (issue #977).
+    ExportsCommand => EXPORTS_COMMAND;
 }
+
+/// Every trait that widens a file's caller set beyond the file itself — the
+/// union [`crate::registry::CommandRegistry::unit_linkage`] reports, and that
+/// `tcl_compiler::unit_scope` gates the interprocedural call-site seed on.
+///
+/// Kept beside the declarations so a newly-stamped linkage trait joins the
+/// union here rather than needing a second edit in the consumer.
+pub const UNIT_LINKAGE_TRAITS: Traits = Traits::PROVIDES_PACKAGE
+    .union(Traits::LOADS_EXTERNAL_UNIT)
+    .union(Traits::EXPORTS_COMMAND);
 
 /// A `Trait`'s bit is `1 << discriminant`, so the set must fit the `u128`.
 /// Unlike a collision — which the enum makes unrepresentable — running out of

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -445,6 +445,15 @@ pub const TRAITS: &[Variant] = &[
     v("CONTINUES_LOOP", "continues a loop"),
     v("REPLACES_FRAME", "replaces the current call frame"),
     v("SAFE_INTERP_HIDDEN", "hidden in a safe interpreter"),
+    v("PROVIDES_PACKAGE", "declares this file a loadable package"),
+    v(
+        "LOADS_EXTERNAL_UNIT",
+        "runs another unit's script in this interpreter",
+    ),
+    v(
+        "EXPORTS_COMMAND",
+        "publishes a command name for another unit",
+    ),
 ];
 
 /// [`TaintColour`] bits.


### PR DESCRIPTION
## Summary

Fixes #977. A plain library file — **no `package provide`** — whose procedures are called uniformly within itself but differently from another file had its parameters seeded as compile-time constants, folding conditions that should stay open and emitting a false I230.

```tcl
# lib.tcl — no package provide
proc helper {mode} {
    if {$mode eq "prod"} { ... } else { ... }   ;# folded: "always true"
}
helper prod
helper prod
```
```tcl
# main.tcl
source lib.tcl
helper dev        ;# a real caller lib.tcl's compilation unit can never see
```

`CompilationUnit::build_for` is single-source-text by construction, but Tcl has no `static`: every `proc` lands in a global command table any file sharing the interpreter can reach. PR #970's guard covered a `package provide` file; this covers the ordinary case.

Rebased onto `ac6b942` (#1042). Builds on #1034 — see *Relationship to #1034*.

## The fix

A new `rust/tcl-compiler/src/unit_scope.rs` owns the claim *"the call sites I found are all of them"* in three layers. Each is **monotone**: it can only ever retract a fold, never manufacture one.

1. **In-unit evidence** — `collect_call_site_constants` walks the module's own CFGs (top level, every proc, plus `TclOO` method and `apply`/`namespace eval` body units).
2. **Cross-file evidence** — `scan_source_call_sites` runs the *identical* lowering → CFG → record walk over another file's source, resolved against the whole project's proc names; `CallSiteEvidence::merge_from` folds it in before seeding.
3. **Registry-declared boundaries** — `scan_unit_linkage` asks the registry whether the file admits to being part of a bigger program. No command name appears in the compiler.

`None` and `Some(empty)` are different claims: `None` means "no workspace view", `Some` — even empty — is the host asserting it enumerated the project.

### The boundary gate

| Trait | Set on | Gate |
|---|---|---|
| `PROVIDES_PACKAGE` | `package provide`, `package ifneeded` | declines **unconditionally** — another checkout can `package require` this one |
| `EXPORTS_COMMAND` | `namespace export`, `namespace ensemble` | declines **unconditionally** — same reason |
| `LOADS_EXTERNAL_UNIT` | `source`, `load`, `package require`, `auto_load`, `auto_import` | declines unless the host proves every `source` target resolves into the project |

`namespace import` is deliberately **not** a boundary — it is as often an intra-file convenience over a namespace the same file defines, and layer 1 already models the import as a real caller path.

## What review and CI found (and it was a lot)

Five defects surfaced after the first push. Each is worth naming, because the pattern is consistent: **every one was found by a second reader or a wider test, not by my own design reasoning.**

1. **A `namespace eval` body resolved against the wrong namespace.** `namespace eval ::a { proc run {} { helper } }` calls `::a::helper`, but the body was scanned *twice* — once as the body unit lowering registers (correct namespace), once through the enclosing statement's `ArgRole::Body` recursion (caller's namespace), contradicting `lowering`'s own tclsh8.6-confirmed comment. Invisible within one file; project-wide it became a **false edge into another file's procedure**. Fixed by skipping the recursion when the command carries an absolute `ArgRole::Name` — registry-driven; `catch` still recurses.

2. **Unrelated files pooled their call sites.** The startup scan puts *every* workspace file in one project, so two files reusing a common helper name (`helper`, `init`, `run` — endemic in Tcl) merged evidence: differing arities made `binds_position` fail and both lost folds they were entitled to. A file's calls to a name it *also declares* bind to its own definition — that's in-unit evidence, never cross-file.

3. **Evidence was computed on the edit handler.** Measured before changing anything: **7.1s** for a 500-file cold sync, synchronously under the `db` lock, plus 10–17ms per keystroke. Moved to the debounced diagnostics worker.

4. **Peers were never rescheduled.** Editing `main.tcl` changes what `lib.tcl` folds, but `did_change` only schedules the edited document. The sync now reports which files moved; `reschedule_peers` restarts them. Converges via compare-then-set.

5. **Uncached builds ignored the evidence.** Pull diagnostics and code actions both build standalone units — a pull-mode client got a correct analyser I230 beside an unsound optimiser O101, and a quick-fix would have offered to delete a branch the project proves reachable. Same bug I'd already fixed in the CLI and failed to look for elsewhere.

## The publish-ordering trade-off

Refreshing evidence **before** analysis makes a file's first diagnostics correct, but delayed the enriched semantic-token tier past `converges_via_refresh`. Refreshing **after** and always re-running produced a duplicate publish, violating one-publish-per-version (`diagnostics_delivery_smoke`, and the duplicate-diagnostics KCS note).

Settled on: refresh after publishing, and re-analyse only when the refresh produced **non-empty** evidence — an empty view cannot change what a file folds, so re-publishing would be byte-identical.

**Residual I introduced, and would welcome a second opinion on:** an empty view *also* lifts a `LOADS_EXTERNAL_UNIT` decline, which can legitimately *add* a fold. Not re-running leaves that hint missing until the next edit. I took the false-negative direction to keep the publish contract, but it is a gap accepted to satisfy a test rather than because it is obviously right.

**Underlying cause, worth considering separately:** evidence is a salsa *input* on `SourceFile`, which is why there is an ordering question at all. `file_external_call_sites` is already a tracked query over `Project`; if `compilation_unit` took the project in its key and read it directly, there would be no input write, no sync pass, and none of this tension. That is a db-layer refactor I did not start unprompted.

## Plumbing

| Layer | Change |
|---|---|
| `tcl-registry` | 3 traits via #1034's `declare_traits!`; `CommandRegistry::unit_linkage()`; `Traits::intersection()` |
| `tcl-compiler` | new `unit_scope` module (lifts ~400 lines out of the 2,900-line `compilation_unit.rs`); `UnitBuildOptions`; `UnitCallerScope` |
| `tcl-lsp-db` | `file_call_site_evidence` → `project_call_site_evidence` → `file_external_call_sites`; `SourceFile::external_call_sites` |
| `tcl-lsp-server` | `sync_cross_file_evidence` on the debounced worker; `reschedule_peers`; `cross_file_evidence_for` |
| `tcl-cli` | `cross_file_call_site_evidence` across a multi-input `diag` / `validate` |
| `tcl-explorer` | new **Unit Scope** view (`unitScope`) |

`tcl diag`'s analyser also built its **own** compilation unit, so it computed cross-file evidence and then ignored it. Both halves now share one unit via `set_cu_override`.

## Relationship to #1034

This branch originally carried its own fix for the `Traits` bit-61 collision (#1031) — a hand-widening with hand-assigned bits, i.e. what the issue *suggested*. #1034 makes the collision unrepresentable, so that work is **dropped entirely**:

- `traits.rs` is **+47, zero deletions** — three `declare_traits!` lines, no bit numbers.
- A hand-maintained trait-name table for the explorer is deleted for `Traits::iter_names()`.
- `Default for UnitCallerScope` is now a `#[derive]`.
- #1034's new `traits_catalogue_matches_the_registry_flags` caught three missing catalogue descriptions immediately.

One addition to #1034's file: `Traits::intersection()`, the const-fn counterpart to `union`. Happy to mask differently if preferred.

## Not closed by this PR

- **#978** — `collect_call_site_constants` is addressed; `interprocedural::scan_source_for_calls` is **not**. The issue asks for a recorded decision on sharing a primitive: they shouldn't, because seeding wants an *opaque* caller (trailing args appended at runtime) while the call graph wants a real edge.
- **#979** — reduced, not fixed: `EXPORTS_COMMAND` on `namespace ensemble` removes the FP risk here without resolving `-map`.
- **#976** / **#980** — untouched; #980's `#[ignore]`d regression still pinned.

## Tests

- `unit_scope::tests` — 10 cases (evidence primitives, the gate, namespace resolution, `catch` control)
- `call_site_param_constants::cross_file` — 8 TP/FP/TN/FN, plus `exported_namespace_declines_the_seed_even_with_a_workspace_view`
- `tcl-lsp-db::cross_file_call_sites` — 5, including a salsa backdating guard and the name-collision regression
- native `e2e` — 5 in `diagnostics.rs`; `cli::diag_shares_call_sites_across_inputs`; 2 explorer tests; VS Code `issue977.test.ts`

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

All on this head (`6d785b1`, rebased onto `ac6b942`):

```
cargo fmt --all --check                                  # PASSED
cargo clippy --workspace --all-targets -- -D warnings    # PASSED, 0 findings
cargo test --workspace --all-features --no-fail-fast     # 305 suites, 0 failed
make test-ext                                            # 706 passing, 0 failing
cargo xtask kcs-index-links / workflow-sync / resolution-drift / diag-tables / command-backing   # no drift
npx tsc --noEmit -p .  +  npx eslint src/                # PASSED (after `make copy-canonical`)
```

**Three pre-existing clippy allows removed** (`too_many_lines`, `too_many_arguments`, `type_complexity`); none added.

**Not run:** `make test-emacs` — emacs is not installed in my environment. `make runtime-rust-test` does not apply: this diff touches nothing under `runtime/rust`.

## Compiler/KCS checklist

- [x] Did this change alter a compiler fact contract? — **Yes.** The interprocedural param-constant seed now depends on host-supplied cross-file evidence and registry-declared unit linkage, written up in the new `docs/design/compiler/compilation-unit-scope.md`.
- [x] If yes, I updated at least one relevant KCS note — new user-facing `docs/kcs/kcs-issue-always-true-condition-in-a-sourced-library-file.md`; `fp-audit-todo.md` gains `FP-IPCP-02`; `command-registry.md` and `GLOSSARY.md` updated.
- [x] If I added a new compiler KCS note, I linked it from both indexes — `docs/kcs/README.md` and `docs/design/compiler/README.md`.