### PR TITLE
Spec studio: typed-in option-arity hooks; and mark the mathop operators PURE

### DIFF
--- a/docs/design/contracts/command-spec-studio.md
+++ b/docs/design/contracts/command-spec-studio.md
@@ -82,6 +82,18 @@ Those fields use `FieldKind::RustExpr`: the value is a string emitted
 verbatim, so it carries its own `Some(…)` and type path. The schema's `hint`
 shows the exact expression shape expected.
 
+One unrecoverable expression is not a top-level field. `OptionArity::Hook`
+holds a function pointer inside an *option row*, so it gets a `hook fn` text
+box in that row rather than an entry under Advanced, and its
+`__unrenderable` key is `draft::OPTION_HOOK_KEY` (`options.arity_hook`)
+instead of a field name. Both the form's warning list and the renderer's
+`TODO` resolve that key against the `options` array, so they name the exact
+options still missing a hook — `return`'s `-errorstack` is the registry's
+live example — and both clear once every hook holds an expression. Before
+this, the whole `options` field was reported unreadable even though only one
+option's arity was, and the note could never clear because the filled-in
+check only understood string-valued fields.
+
 ## Renderer contract
 
 `render_rs::render` produces a complete `tcl-registry/src/commands/<pack>/`

--- a/editors/zed/src/generated/tcl_commands.json
+++ b/editors/zed/src/generated/tcl_commands.json
@@ -3,39 +3,48 @@
   "commands": [
     {
       "name": "!",
-      "summary": "logical NOT"
+      "summary": "logical NOT",
+      "pure": true
     },
     {
       "name": "!=",
-      "summary": "numeric inequality"
+      "summary": "numeric inequality",
+      "pure": true
     },
     {
       "name": "%",
-      "summary": "modulo"
+      "summary": "modulo",
+      "pure": true
     },
     {
       "name": "&",
-      "summary": "bitwise AND"
+      "summary": "bitwise AND",
+      "pure": true
     },
     {
       "name": "*",
-      "summary": "multiplication"
+      "summary": "multiplication",
+      "pure": true
     },
     {
       "name": "**",
-      "summary": "exponentiation"
+      "summary": "exponentiation",
+      "pure": true
     },
     {
       "name": "+",
-      "summary": "arithmetic identity"
+      "summary": "arithmetic identity",
+      "pure": true
     },
     {
       "name": "-",
-      "summary": "arithmetic negation"
+      "summary": "arithmetic negation",
+      "pure": true
     },
     {
       "name": "/",
-      "summary": "division"
+      "summary": "division",
+      "pure": true
     },
     {
       "name": "::tcl::dict::append",
@@ -439,111 +448,138 @@
     },
     {
       "name": "::tcl::mathop::!",
-      "summary": "logical NOT"
+      "summary": "logical NOT",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::!=",
-      "summary": "numeric inequality"
+      "summary": "numeric inequality",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::%",
-      "summary": "modulo"
+      "summary": "modulo",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::&",
-      "summary": "bitwise AND"
+      "summary": "bitwise AND",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::*",
-      "summary": "multiplication"
+      "summary": "multiplication",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::**",
-      "summary": "exponentiation"
+      "summary": "exponentiation",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::+",
-      "summary": "arithmetic identity"
+      "summary": "arithmetic identity",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::-",
-      "summary": "arithmetic negation"
+      "summary": "arithmetic negation",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::/",
-      "summary": "division"
+      "summary": "division",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::<",
-      "summary": "numeric less-than"
+      "summary": "numeric less-than",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::<<",
-      "summary": "left shift"
+      "summary": "left shift",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::<=",
-      "summary": "numeric less-or-equal"
+      "summary": "numeric less-or-equal",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::==",
-      "summary": "numeric equality"
+      "summary": "numeric equality",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::>",
-      "summary": "numeric greater-than"
+      "summary": "numeric greater-than",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::>=",
-      "summary": "numeric greater-or-equal"
+      "summary": "numeric greater-or-equal",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::>>",
-      "summary": "right shift"
+      "summary": "right shift",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::^",
-      "summary": "bitwise XOR"
+      "summary": "bitwise XOR",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::eq",
-      "summary": "string equality"
+      "summary": "string equality",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::ge",
-      "summary": "string greater-or-equal"
+      "summary": "string greater-or-equal",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::gt",
-      "summary": "string greater-than"
+      "summary": "string greater-than",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::in",
-      "summary": "list membership"
+      "summary": "list membership",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::le",
-      "summary": "string less-or-equal"
+      "summary": "string less-or-equal",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::lt",
-      "summary": "string less-than"
+      "summary": "string less-than",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::ne",
-      "summary": "string inequality"
+      "summary": "string inequality",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::ni",
-      "summary": "list non-membership"
+      "summary": "list non-membership",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::|",
-      "summary": "bitwise OR"
+      "summary": "bitwise OR",
+      "pure": true
     },
     {
       "name": "::tcl::mathop::~",
-      "summary": "bitwise complement"
+      "summary": "bitwise complement",
+      "pure": true
     },
     {
       "name": "::tcl::process",
@@ -581,31 +617,38 @@
     },
     {
       "name": "<",
-      "summary": "numeric less-than"
+      "summary": "numeric less-than",
+      "pure": true
     },
     {
       "name": "<<",
-      "summary": "left shift"
+      "summary": "left shift",
+      "pure": true
     },
     {
       "name": "<=",
-      "summary": "numeric less-or-equal"
+      "summary": "numeric less-or-equal",
+      "pure": true
     },
     {
       "name": "==",
-      "summary": "numeric equality"
+      "summary": "numeric equality",
+      "pure": true
     },
     {
       "name": ">",
-      "summary": "numeric greater-than"
+      "summary": "numeric greater-than",
+      "pure": true
     },
     {
       "name": ">=",
-      "summary": "numeric greater-or-equal"
+      "summary": "numeric greater-or-equal",
+      "pure": true
     },
     {
       "name": ">>",
-      "summary": "right shift"
+      "summary": "right shift",
+      "pure": true
     },
     {
       "name": "DES::Decrypt",
@@ -681,7 +724,8 @@
     },
     {
       "name": "^",
-      "summary": "bitwise XOR"
+      "summary": "bitwise XOR",
+      "pure": true
     },
     {
       "name": "aes::Decrypt",
@@ -1934,7 +1978,8 @@
     },
     {
       "name": "eq",
-      "summary": "string equality"
+      "summary": "string equality",
+      "pure": true
     },
     {
       "name": "error",
@@ -2345,7 +2390,8 @@
     },
     {
       "name": "ge",
-      "summary": "string greater-or-equal"
+      "summary": "string greater-or-equal",
+      "pure": true
     },
     {
       "name": "generator",
@@ -2665,7 +2711,8 @@
     },
     {
       "name": "gt",
-      "summary": "string greater-than"
+      "summary": "string greater-than",
+      "pure": true
     },
     {
       "name": "history",
@@ -3264,7 +3311,8 @@
     },
     {
       "name": "in",
-      "summary": "list membership"
+      "summary": "list membership",
+      "pure": true
     },
     {
       "name": "incr",
@@ -3758,7 +3806,8 @@
     },
     {
       "name": "le",
-      "summary": "string less-or-equal"
+      "summary": "string less-or-equal",
+      "pure": true
     },
     {
       "name": "ledit",
@@ -4019,7 +4068,8 @@
     },
     {
       "name": "lt",
-      "summary": "string less-than"
+      "summary": "string less-than",
+      "pure": true
     },
     {
       "name": "map",
@@ -6564,7 +6614,8 @@
     },
     {
       "name": "ne",
-      "summary": "string inequality"
+      "summary": "string inequality",
+      "pure": true
     },
     {
       "name": "nettool::allocate_port",
@@ -6608,7 +6659,8 @@
     },
     {
       "name": "ni",
-      "summary": "list non-membership"
+      "summary": "list non-membership",
+      "pure": true
     },
     {
       "name": "nmea::checksum",
@@ -8447,111 +8499,138 @@
     },
     {
       "name": "tcl::mathop::!",
-      "summary": "logical NOT"
+      "summary": "logical NOT",
+      "pure": true
     },
     {
       "name": "tcl::mathop::!=",
-      "summary": "numeric inequality"
+      "summary": "numeric inequality",
+      "pure": true
     },
     {
       "name": "tcl::mathop::%",
-      "summary": "modulo"
+      "summary": "modulo",
+      "pure": true
     },
     {
       "name": "tcl::mathop::&",
-      "summary": "bitwise AND"
+      "summary": "bitwise AND",
+      "pure": true
     },
     {
       "name": "tcl::mathop::*",
-      "summary": "multiplication"
+      "summary": "multiplication",
+      "pure": true
     },
     {
       "name": "tcl::mathop::**",
-      "summary": "exponentiation"
+      "summary": "exponentiation",
+      "pure": true
     },
     {
       "name": "tcl::mathop::+",
-      "summary": "arithmetic identity"
+      "summary": "arithmetic identity",
+      "pure": true
     },
     {
       "name": "tcl::mathop::-",
-      "summary": "arithmetic negation"
+      "summary": "arithmetic negation",
+      "pure": true
     },
     {
       "name": "tcl::mathop::/",
-      "summary": "division"
+      "summary": "division",
+      "pure": true
     },
     {
       "name": "tcl::mathop::<",
-      "summary": "numeric less-than"
+      "summary": "numeric less-than",
+      "pure": true
     },
     {
       "name": "tcl::mathop::<<",
-      "summary": "left shift"
+      "summary": "left shift",
+      "pure": true
     },
     {
       "name": "tcl::mathop::<=",
-      "summary": "numeric less-or-equal"
+      "summary": "numeric less-or-equal",
+      "pure": true
     },
     {
       "name": "tcl::mathop::==",
-      "summary": "numeric equality"
+      "summary": "numeric equality",
+      "pure": true
     },
     {
       "name": "tcl::mathop::>",
-      "summary": "numeric greater-than"
+      "summary": "numeric greater-than",
+      "pure": true
     },
     {
       "name": "tcl::mathop::>=",
-      "summary": "numeric greater-or-equal"
+      "summary": "numeric greater-or-equal",
+      "pure": true
     },
     {
       "name": "tcl::mathop::>>",
-      "summary": "right shift"
+      "summary": "right shift",
+      "pure": true
     },
     {
       "name": "tcl::mathop::^",
-      "summary": "bitwise XOR"
+      "summary": "bitwise XOR",
+      "pure": true
     },
     {
       "name": "tcl::mathop::eq",
-      "summary": "string equality"
+      "summary": "string equality",
+      "pure": true
     },
     {
       "name": "tcl::mathop::ge",
-      "summary": "string greater-or-equal"
+      "summary": "string greater-or-equal",
+      "pure": true
     },
     {
       "name": "tcl::mathop::gt",
-      "summary": "string greater-than"
+      "summary": "string greater-than",
+      "pure": true
     },
     {
       "name": "tcl::mathop::in",
-      "summary": "list membership"
+      "summary": "list membership",
+      "pure": true
     },
     {
       "name": "tcl::mathop::le",
-      "summary": "string less-or-equal"
+      "summary": "string less-or-equal",
+      "pure": true
     },
     {
       "name": "tcl::mathop::lt",
-      "summary": "string less-than"
+      "summary": "string less-than",
+      "pure": true
     },
     {
       "name": "tcl::mathop::ne",
-      "summary": "string inequality"
+      "summary": "string inequality",
+      "pure": true
     },
     {
       "name": "tcl::mathop::ni",
-      "summary": "list non-membership"
+      "summary": "list non-membership",
+      "pure": true
     },
     {
       "name": "tcl::mathop::|",
-      "summary": "bitwise OR"
+      "summary": "bitwise OR",
+      "pure": true
     },
     {
       "name": "tcl::mathop::~",
-      "summary": "bitwise complement"
+      "summary": "bitwise complement",
+      "pure": true
     },
     {
       "name": "tcl::prefix",
@@ -10655,11 +10734,13 @@
     },
     {
       "name": "|",
-      "summary": "bitwise OR"
+      "summary": "bitwise OR",
+      "pure": true
     },
     {
       "name": "~",
-      "summary": "bitwise complement"
+      "summary": "bitwise complement",
+      "pure": true
     }
   ]
 }

--- a/rust/tcl-registry/src/commands/tcl/mathop_generated.rs
+++ b/rust/tcl-registry/src/commands/tcl/mathop_generated.rs
@@ -85,7 +85,21 @@ fn push_spellings(out: &mut Vec<CommandSpec>, spec: OperatorSpec) {
             // operator with its own tighter gate (a 9.0-only op → `TCL90_PLUS`)
             // keeps it.
             dialects: spec.dialects.or(Some(DialectSet::TCL85_PLUS)),
-            traits: Traits::OPERATOR_COMMAND,
+            // Every operator command is a pure value computation: it reads
+            // its operands and returns a result, touching no variable,
+            // channel, or interpreter state. That holds for all 27 —
+            // arithmetic, bitwise, numeric and string comparison, list
+            // membership (`in`/`ni`), and `!`. A bad operand (divide by zero,
+            // non-numeric) raises an error, which the registry models as
+            // control flow rather than as a side effect.
+            //
+            // The namespace spec (`mathop.rs`) already carried `PURE`; the
+            // commands generated under it did not, so `classify_side_effects`
+            // treated `[+ $a $b]` as impure and the GVN pass would not hoist
+            // or CSE it. Deliberately *not* `CSE_CANDIDATE` — that trait asks
+            // for a redundancy *diagnostic*, which is a policy call about
+            // user-visible noise rather than a fact about the command.
+            traits: Traits::OPERATOR_COMMAND.union(Traits::PURE),
             arity,
             hover: Some(HoverSnippet {
                 summary: spec.summary,

--- a/rust/tcl-registry/tests/registry_commands.rs
+++ b/rust/tcl-registry/tests/registry_commands.rs
@@ -378,6 +378,49 @@ fn splice_safe_membership() {
 /// registry-metadata: frame-sensitivity is our classification (the
 /// `TERMINATES_BLOCK` | `TRANSFERS_CONTROL` | `CREATES_SCOPE_ALIAS` |
 /// `CREATES_BARRIER` trait union).
+/// Every `::tcl::mathop` operator command is `PURE`.
+///
+/// The namespace spec carried `PURE` but the commands generated under it did
+/// not, so `classify_side_effects` treated `[+ $a $b]` as impure and the GVN
+/// pass would neither hoist nor CSE it. Found by scanning all specs for trait
+/// pairs that never co-occur: `OPERATOR_COMMAND` (87 specs) and `PURE` (379)
+/// had no overlap at all, which for arithmetic is not a plausible fact.
+///
+/// Purity here is a statement about the command, not a policy: an operator
+/// reads its operands and returns a result, touching no variable, channel, or
+/// interpreter state. A bad operand raises an error, which the registry
+/// models as control flow rather than a side effect.
+#[test]
+fn operator_commands_are_pure() {
+    let reg = CommandRegistry::build_default();
+    let ops = [
+        "!", "!=", "%", "&", "*", "**", "+", "-", "/", "<", "<<", "<=", "==", ">", ">=", ">>", "^",
+        "eq", "ge", "gt", "in", "le", "lt", "ne", "ni", "|", "~",
+    ];
+    for op in ops {
+        let spec = reg
+            .get(op)
+            .unwrap_or_else(|| panic!("{op} is a registered operator"));
+        assert!(
+            spec.traits.contains(Traits::OPERATOR_COMMAND),
+            "{op} is an operator command"
+        );
+        assert!(
+            spec.traits.contains(Traits::PURE),
+            "{op} computes a value with no side effect and must be PURE, or \
+             the optimiser cannot hoist or CSE it"
+        );
+    }
+    // The qualified spellings carry the traits too — the optimiser sees
+    // whichever spelling the source used.
+    for name in ["::tcl::mathop::+", "tcl::mathop::eq"] {
+        let spec = reg
+            .get(name)
+            .unwrap_or_else(|| panic!("{name} is registered"));
+        assert!(spec.traits.contains(Traits::PURE), "{name} must be PURE");
+    }
+}
+
 #[test]
 fn frame_sensitive_membership() {
     let (reg, _) = reg_and_set("tcl8.6");

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -55,6 +55,13 @@ use crate::catalogue;
 /// round-tripped.
 pub const UNRENDERABLE_KEY: &str = "__unrenderable";
 
+/// Draft key naming the option-arity hooks that need supplying.
+///
+/// Distinct from a plain field key because the thing to fill in is nested in
+/// an option row, not a top-level field: the renderer resolves it against the
+/// `options` array so the note clears once every hook holds an expression.
+pub const OPTION_HOOK_KEY: &str = "options.arity_hook";
+
 /// Draft key holding the dialect the draft was seeded from, when it came from
 /// the live registry.
 pub const SOURCE_DIALECT_KEY: &str = "__sourceDialect";
@@ -200,9 +207,11 @@ fn option_arity(value: OptionArity) -> (Value, bool) {
     match value {
         OptionArity::One => (json!({ "kind": "One" }), true),
         OptionArity::Fixed(n) => (json!({ "kind": "Fixed", "n": n }), true),
-        // The hook is a function pointer; the shape is recorded but the
-        // expression that produced it is not recoverable.
-        OptionArity::Hook(_) => (json!({ "kind": "Hook" }), false),
+        // The hook is a function pointer: the *shape* round-trips, but the
+        // expression that produced it does not. `hook` is the slot the author
+        // fills in under the option's editor; it seeds empty, and the option
+        // is complete once it holds an expression.
+        OptionArity::Hook(_) => (json!({ "kind": "Hook", "hook": Value::Null }), false),
     }
 }
 
@@ -483,7 +492,7 @@ fn subcommand_rest(d: &mut Draft, sub: &SubCommand, lost: &mut Unrecovered) {
     for opt in sub.options {
         let (json_value, complete) = option_spec(opt);
         if !complete {
-            lost.note("options");
+            lost.note(OPTION_HOOK_KEY);
         }
         options.push(json_value);
     }
@@ -726,7 +735,7 @@ fn command_options(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
     for opt in spec.options {
         let (json_value, complete) = option_spec(opt);
         if !complete {
-            lost.note("options");
+            lost.note(OPTION_HOOK_KEY);
         }
         options.push(json_value);
     }

--- a/rust/tcl-spec-studio/src/render_rs.rs
+++ b/rust/tcl-spec-studio/src/render_rs.rs
@@ -335,6 +335,27 @@ fn integer_domain_expr(value: &Value) -> Option<String> {
     }
 }
 
+/// The Rust expression supplied for a `Hook` arity, if the author filled it in.
+fn hook_expr(arity: &Value) -> Option<&str> {
+    arity
+        .get("hook")
+        .and_then(Value::as_str)
+        .map(str::trim)
+        .filter(|h| !h.is_empty())
+}
+
+/// Every option row still missing its arity hook, by option name.
+fn unfilled_option_hooks(draft: &Value) -> Vec<&str> {
+    as_array(draft.get("options").unwrap_or(&Value::Null))
+        .iter()
+        .filter(|opt| {
+            let arity = &opt["value"]["arity"];
+            as_str(&arity["kind"]) == "Hook" && hook_expr(arity).is_none()
+        })
+        .map(|opt| as_str(&opt["name"]))
+        .collect()
+}
+
 fn option_expr(entry: &Value, indent: &str) -> String {
     let inner = format!("{indent}    ");
     let mut parts = vec![format!(
@@ -349,7 +370,10 @@ fn option_expr(entry: &Value, indent: &str) -> String {
         let arity = &value["arity"];
         let arity_expr = match as_str(&arity["kind"]) {
             "Fixed" => Some(format!("OptionArity::Fixed({})", as_u64(&arity["n"]))),
-            "Hook" => None,
+            // The hook is a function pointer, so seeding cannot recover it —
+            // but the author can type it, and then it renders like any other
+            // arity. Empty still falls through to the TODO below.
+            "Hook" => hook_expr(arity).map(|h| format!("OptionArity::Hook({h})")),
             _ => Some("OptionArity::One".to_owned()),
         };
         match arity_expr {
@@ -651,6 +675,24 @@ fn unrenderable_notes(draft: &Value, indent: &str) -> Vec<String> {
         .iter()
         .filter_map(|key| {
             let key = key.as_str()?;
+            // Option-arity hooks live in an option row, not a top-level field,
+            // so they resolve against `options` and name the exact options
+            // still outstanding. Filling every one clears the note.
+            if key == crate::draft::OPTION_HOOK_KEY {
+                let pending = unfilled_option_hooks(draft);
+                if pending.is_empty() {
+                    return None;
+                }
+                return Some(format!(
+                    "{indent}// TODO: {} consumes a computed number of words \
+                     (OptionArity::Hook); supply the hook under that option.",
+                    pending
+                        .iter()
+                        .map(|n| format!("`{n}`"))
+                        .collect::<Vec<_>>()
+                        .join(", "),
+                ));
+            }
             // Only note a field the author has not since filled in.
             let filled = draft
                 .get(key)
@@ -848,6 +890,62 @@ pub fn suggested_path(name: &str, pack: &str) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// `return`'s `-errorstack` is the registry's real `OptionArity::Hook`.
+    ///
+    /// Seeding cannot recover `errorstack_value` from a function pointer, so
+    /// the arity seeds with an empty `hook` slot, the note names that one
+    /// option rather than the whole `options` field, and supplying the
+    /// expression both renders it and clears the note.
+    #[test]
+    fn option_arity_hook_round_trips_once_supplied() {
+        let reg = tcl_registry::registry::CommandRegistry::build_default();
+        let spec = reg.get("return").expect("return is a core command");
+        let mut d = draft::from_command_spec(spec);
+
+        // Seeded: the hook slot exists and is empty.
+        let opts = d["options"].as_array().expect("options array").clone();
+        let hooked: Vec<&str> = opts
+            .iter()
+            .filter(|o| as_str(&o["value"]["arity"]["kind"]) == "Hook")
+            .map(|o| as_str(&o["name"]))
+            .collect();
+        assert_eq!(
+            hooked,
+            vec!["-errorstack"],
+            "one option consumes via a hook"
+        );
+
+        // Unfilled: the TODO names the option, not the whole field.
+        let out = render(&d);
+        assert!(
+            out.contains("`-errorstack` consumes a computed number of words"),
+            "note must name the option, got:\n{out}"
+        );
+        assert!(
+            !out.contains("`options` is set on the source command"),
+            "the whole options field must not be reported unreadable:\n{out}"
+        );
+
+        // Supplied: it renders as a real arity and the note is gone.
+        let mut filled = opts;
+        for opt in &mut filled {
+            if as_str(&opt["value"]["arity"]["kind"]) == "Hook" {
+                opt["value"]["arity"]["hook"] = json!("errorstack_value");
+            }
+        }
+        d.insert("options".into(), Value::Array(filled));
+        let out = render(&d);
+        assert!(
+            out.contains("arity: OptionArity::Hook(errorstack_value),"),
+            "supplied hook must render:\n{out}"
+        );
+        assert!(
+            !out.contains("consumes a computed number of words"),
+            "note must clear once supplied:\n{out}"
+        );
+    }
+
     use serde_json::json;
     use tcl_registry::arg_role::ArgRole;
     use tcl_registry::arity::Arity;

--- a/rust/tcl-spec-studio/tests/option_row_editing.rs
+++ b/rust/tcl-spec-studio/tests/option_row_editing.rs
@@ -1,0 +1,110 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Pins the rule that lets an option row's text inputs be typed into.
+//!
+//! `options` is a `STRUCTURAL_KINDS` member, so every change to it used to
+//! rebuild the whole field — `clear(ctl)` and recreate the DOM. That is right
+//! for adding or removing a row, but wrong for a plain text edit: the input
+//! the user is typing into is destroyed on the first keystroke, focus is lost,
+//! and only one character lands. `STRUCTURAL_KINDS`' own doc comment warns
+//! about exactly this ("a plain text or number input must not be [rebuilt], or
+//! the caret jumps to the end mid-word"); composite kinds hold both sorts of
+//! control, so the kind-level flag could not express it.
+//!
+//! Measured in Chromium, driving the real `options` editor and typing
+//! `errorstack_value` one character at a time into the arity-hook box:
+//!
+//! ```text
+//! rebuild on every change (old) : typed "e"                 — focus lost
+//! rebuild only when structural  : typed "errorstack_value"  — focus held
+//! ```
+//!
+//! The fix is a `structural` flag on `Setter`, defaulting to `true` so every
+//! editor keeps its old behaviour. The option row passes `false` for scalar
+//! edits and leaves it defaulted where a control appears or disappears.
+
+const EDITORS_TS: &str = include_str!("../web/src/editors.ts");
+const STUDIO_TS: &str = include_str!("../web/src/studio.ts");
+
+/// Strip whitespace so an assertion survives reformatting.
+fn squashed(text: &str) -> String {
+    text.chars().filter(|c| !c.is_whitespace()).collect()
+}
+
+#[test]
+fn the_setter_can_report_a_change_as_non_structural() {
+    assert!(
+        squashed(EDITORS_TS).contains("exporttypeSetter=(next:Json,structural?:boolean)=>void;"),
+        "`Setter` must carry the optional `structural` flag — without it a \
+         composite editor has no way to say that a text edit did not change \
+         the editor's shape"
+    );
+}
+
+#[test]
+fn a_rebuild_only_happens_for_a_structural_change() {
+    // The gate itself. `structural` defaults to true at the call site, so an
+    // editor that never passes it behaves exactly as before.
+    assert!(
+        squashed(STUDIO_TS)
+            .contains("if(structural&&STRUCTURAL_KINDS.has(field.kind.tag))rebuild();"),
+        "the field rebuild must be gated on `structural`, or every keystroke \
+         in an option row tears down the focused input"
+    );
+}
+
+#[test]
+fn option_row_text_edits_are_marked_non_structural() {
+    let src = squashed(EDITORS_TS);
+    // The option's own name and detail, the value's hint, and the arity hook —
+    // every free-text box in the row.
+    for (what, needle) in [
+        ("option name", "patch({name:t},false)"),
+        ("option detail", "patch({detail:t},false)"),
+        ("value hint", "patchValue({hint:t},false)"),
+    ] {
+        assert!(
+            src.contains(needle),
+            "the {what} input must patch non-structurally ({needle} missing) \
+             or it cannot be typed into continuously"
+        );
+    }
+    assert!(
+        src.contains(
+            "patchValue({arity:{kind:\"Hook\",hook:t.trim()===\"\"?null:t.trim()}},false,)"
+        ),
+        "the arity-hook input must patch non-structurally too, or the hook \
+         expression cannot be typed continuously"
+    );
+}
+
+#[test]
+fn switching_the_arity_kind_still_rebuilds() {
+    // Toggling One/Fixed/Hook shows and hides the `n` and `hook fn` inputs, so
+    // that one *must* rebuild — the flag is left defaulted.
+    let src = squashed(EDITORS_TS);
+    assert!(
+        src.contains("patchValue({arity:{kind:\"Fixed\",n:asNumber(arity.n)??2}});"),
+        "switching to a fixed count must rebuild so the `n` input appears"
+    );
+    assert!(
+        src.contains("patchValue({arity:{kind:\"Hook\",hook:arity.hook??null}});"),
+        "switching to a hook must rebuild so the `hook fn` input appears"
+    );
+}

--- a/rust/tcl-spec-studio/web/src/editors.ts
+++ b/rust/tcl-spec-studio/web/src/editors.ts
@@ -72,7 +72,7 @@ export interface EditorContext {
 /* Value coercions. A draft arrives from `JSON.parse`, so every read has to
    narrow before use rather than trusting the declared shape. */
 
-function asRecord(value: Json): Record<string, Json> {
+export function asRecord(value: Json): Record<string, Json> {
   return value !== null && typeof value === "object" && !Array.isArray(value)
     ? (value as Record<string, Json>)
     : {};
@@ -82,7 +82,7 @@ function asArray(value: Json): Json[] {
   return Array.isArray(value) ? value : [];
 }
 
-function asString(value: Json | undefined): string {
+export function asString(value: Json | undefined): string {
   return typeof value === "string" ? value : "";
 }
 
@@ -377,16 +377,20 @@ export function makeEditors(ctx: EditorContext): Record<string, Editor> {
       const words = el("select", {}, [
         el("option", { value: "One", text: "one" }),
         el("option", { value: "Fixed", text: "fixed count" }),
+        el("option", { value: "Hook", text: "computed (hook)" }),
       ]);
-      words.value = asString(arity.kind) === "Fixed" ? "Fixed" : "One";
-      words.addEventListener("change", () =>
-        patchValue({
-          arity:
-            words.value === "Fixed"
-              ? { kind: "Fixed", n: asNumber(arity.n) ?? 2 }
-              : { kind: "One" },
-        }),
-      );
+      const arityKind = asString(arity.kind);
+      words.value = arityKind === "Fixed" || arityKind === "Hook" ? arityKind : "One";
+      words.addEventListener("change", () => {
+        if (words.value === "Fixed") {
+          patchValue({ arity: { kind: "Fixed", n: asNumber(arity.n) ?? 2 } });
+        } else if (words.value === "Hook") {
+          // Preserve any expression already typed when toggling back and forth.
+          patchValue({ arity: { kind: "Hook", hook: arity.hook ?? null } });
+        } else {
+          patchValue({ arity: { kind: "One" } });
+        }
+      });
 
       rows.push(
         el("div", { class: "ctl" }, [
@@ -397,11 +401,26 @@ export function makeEditors(ctx: EditorContext): Record<string, Editor> {
             ),
           ),
           labelled("words", words),
-          asString(arity.kind) === "Fixed"
+          arityKind === "Fixed"
             ? labelled(
                 "n",
                 numberInput(asNumber(arity.n), (n) =>
                   patchValue({ arity: { kind: "Fixed", n: n ?? 1 } }),
+                ),
+              )
+            : null,
+          // A function pointer the studio cannot recover by seeding — the
+          // author types the expression and it renders like any other arity.
+          arityKind === "Hook"
+            ? labelled(
+                "hook fn",
+                textInput(
+                  asString(arity.hook),
+                  (t) =>
+                    patchValue({
+                      arity: { kind: "Hook", hook: t.trim() === "" ? null : t.trim() },
+                    }),
+                  { size: 16, placeholder: "errorstack_value" },
                 ),
               )
             : null,

--- a/rust/tcl-spec-studio/web/src/editors.ts
+++ b/rust/tcl-spec-studio/web/src/editors.ts
@@ -26,8 +26,16 @@
 import { clone, el, type Child } from "./dom.js";
 import type { Catalogues, FieldKind, Json, Variant } from "./types.js";
 
-/** Callback an editor uses to replace the field's whole value. */
-export type Setter = (next: Json) => void;
+/**
+ * Callback an editor uses to replace the field's whole value.
+ *
+ * `structural` says whether the change alters the editor's *shape* — a row
+ * added or removed, a discriminant switched, a toggle revealing further
+ * controls. It defaults to `true`, which is the safe answer: the field is
+ * rebuilt. A composite editor passes `false` for a plain text or number edit
+ * inside a row, so the input the user is typing into survives the keystroke.
+ */
+export type Setter = (next: Json, structural?: boolean) => void;
 
 /** Builds the editor DOM for one field kind. */
 export type Editor = (kind: FieldKind, value: Json, set: Setter) => HTMLElement;
@@ -162,22 +170,27 @@ function removeButton(onRemove: () => void): HTMLButtonElement {
 function rowList<T extends Json>(
   items: T[],
   blank: () => T,
-  make: (item: T, index: number, update: (next: T) => void, remove: () => void) => HTMLElement,
-  onChange: (next: T[]) => void,
+  make: (
+    item: T,
+    index: number,
+    update: (next: T, structural?: boolean) => void,
+    remove: () => void,
+  ) => HTMLElement,
+  onChange: (next: T[], structural?: boolean) => void,
   addLabel: string,
 ): HTMLElement {
   const list = items.slice();
   const wrap = el("div", { class: "rows" });
-  const commit = (): void => onChange(list.slice());
+  const commit = (structural = true): void => onChange(list.slice(), structural);
 
   list.forEach((item, i) => {
     wrap.appendChild(
       make(
         item,
         i,
-        (next) => {
+        (next, structural) => {
           list[i] = next;
-          commit();
+          commit(structural);
         },
         () => {
           list.splice(i, 1);
@@ -326,12 +339,16 @@ export function makeEditors(ctx: EditorContext): Record<string, Editor> {
   function optionRow(
     item: Json,
     _index: number,
-    update: (next: Json) => void,
+    update: (next: Json, structural?: boolean) => void,
     remove: () => void,
   ): HTMLElement {
     const opt = asRecord(item);
-    const patch = (next: Record<string, Json>): void => {
-      update({ ...clone(opt), ...next });
+    // `structural: false` for a plain text edit — the row keeps its DOM, so
+    // the input being typed into is not torn down mid-word. Anything that
+    // shows or hides a control (toggling "takes a value", switching the arity
+    // kind) leaves it defaulted so the row rebuilds.
+    const patch = (next: Record<string, Json>, structural = true): void => {
+      update({ ...clone(opt), ...next }, structural);
     };
     const takesValue = opt.value !== null && opt.value !== undefined;
 
@@ -339,7 +356,7 @@ export function makeEditors(ctx: EditorContext): Record<string, Editor> {
       el("div", { class: "ctl" }, [
         labelled(
           "flag",
-          textInput(asString(opt.name), (t) => patch({ name: t }), { size: 14 }),
+          textInput(asString(opt.name), (t) => patch({ name: t }, false), { size: 14 }),
         ),
         checkbox(
           takesValue,
@@ -363,7 +380,7 @@ export function makeEditors(ctx: EditorContext): Record<string, Editor> {
         ),
         removeButton(remove),
       ]),
-      textInput(asString(opt.detail), (t) => patch({ detail: t }), {
+      textInput(asString(opt.detail), (t) => patch({ detail: t }, false), {
         placeholder: "what the option does",
       }),
     ];
@@ -371,8 +388,8 @@ export function makeEditors(ctx: EditorContext): Record<string, Editor> {
     if (takesValue) {
       const value = asRecord(opt.value);
       const arity = asRecord(value.arity);
-      const patchValue = (next: Record<string, Json>): void => {
-        patch({ value: { ...clone(value), ...next } });
+      const patchValue = (next: Record<string, Json>, structural = true): void => {
+        patch({ value: { ...clone(value), ...next } }, structural);
       };
       const words = el("select", {}, [
         el("option", { value: "One", text: "one" }),
@@ -417,16 +434,17 @@ export function makeEditors(ctx: EditorContext): Record<string, Editor> {
                 textInput(
                   asString(arity.hook),
                   (t) =>
-                    patchValue({
-                      arity: { kind: "Hook", hook: t.trim() === "" ? null : t.trim() },
-                    }),
+                    patchValue(
+                      { arity: { kind: "Hook", hook: t.trim() === "" ? null : t.trim() } },
+                      false,
+                    ),
                   { size: 16, placeholder: "errorstack_value" },
                 ),
               )
             : null,
           labelled(
             "hint",
-            textInput(asString(value.hint), (t) => patchValue({ hint: t }), { size: 10 }),
+            textInput(asString(value.hint), (t) => patchValue({ hint: t }, false), { size: 10 }),
           ),
           checkbox(asBool(value.closed), (on) => patchValue({ closed: on }), "closed set"),
         ]),

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -153,10 +153,13 @@ function buildField(
       return;
     }
     ctl.appendChild(
-      editor(field.kind, draft[field.key] ?? null, (next: Json) => {
+      editor(field.kind, draft[field.key] ?? null, (next: Json, structural = true) => {
         draft[field.key] = next;
         markSet();
-        if (STRUCTURAL_KINDS.has(field.kind.tag)) rebuild();
+        // A composite editor reports a plain text edit inside a row as
+        // non-structural; rebuilding there would tear down the input the user
+        // is typing into.
+        if (structural && STRUCTURAL_KINDS.has(field.kind.tag)) rebuild();
         onChange();
       }),
     );
@@ -245,34 +248,66 @@ function loadDraft(draft: Draft, origin: string): void {
   state.draft = draft;
   byId("editorSource").textContent = origin;
 
-  const lost = Array.isArray(draft.__unrenderable) ? draft.__unrenderable : [];
-  const warn = byId("unrenderable");
-  if (lost.length) {
-    warn.hidden = false;
-    clear(warn);
-    warn.appendChild(
-      el("b", {
-        text: `This command sets ${lost.length} field${lost.length === 1 ? "" : "s"} the studio cannot read back.`,
-      }),
-    );
-    warn.appendChild(
-      document.createTextNode(
-        " Rust can tell the field is set but not recover the expression that set it — a function pointer or a reference to a static descriptor. Each is listed below and in the rendered file as a TODO; fill it in where it appears in the form (most sit under Advanced) to emit it.",
-      ),
-    );
-    const ul = el("ul", {});
-    for (const key of lost)
-      ul.appendChild(el("li", {}, [el("code", { text: lostLabel(draft, key) })]));
-    warn.appendChild(ul);
-  } else {
-    warn.hidden = true;
-  }
+  renderUnrenderableWarning(draft);
 
   const form = byId("form");
   clear(form);
   buildForm(form, state.schema.command, draft, "command", onDraftChanged);
   renderList();
   onDraftChanged();
+}
+
+/// Render the "cannot read back" panel for `draft`.
+///
+/// Recomputed on every draft change, not just on load: the option-arity hook
+/// entry names the options still missing a hook, so supplying one has to clear
+/// it. Field entries are static, but running them through the same path keeps
+/// one code path rather than two.
+function renderUnrenderableWarning(draft: Record<string, Json>): void {
+  const lost = Array.isArray(draft.__unrenderable) ? draft.__unrenderable : [];
+  const pending = lost.filter((key) => !isLostResolved(draft, key));
+  const warn = byId("unrenderable");
+  if (!pending.length) {
+    warn.hidden = true;
+    return;
+  }
+  warn.hidden = false;
+  clear(warn);
+  warn.appendChild(
+    el("b", {
+      text: `This command sets ${pending.length} field${pending.length === 1 ? "" : "s"} the studio cannot read back.`,
+    }),
+  );
+  warn.appendChild(
+    document.createTextNode(
+      " Rust can tell the field is set but not recover the expression that set it — a function pointer or a reference to a static descriptor. Each is listed below and in the rendered file as a TODO; fill it in where it appears in the form (most sit under Advanced) to emit it.",
+    ),
+  );
+  const ul = el("ul", {});
+  for (const key of pending)
+    ul.appendChild(el("li", {}, [el("code", { text: lostLabel(draft, key) })]));
+  warn.appendChild(ul);
+}
+
+/// Whether the author has since supplied what `key` was missing.
+///
+/// Mirrors the renderer's own test, so the panel and the emitted `TODO` agree.
+function isLostResolved(draft: Record<string, Json>, key: unknown): boolean {
+  if (String(key) === "options.arity_hook") return unfilledHooks(draft).length === 0;
+  const value = draft[String(key)];
+  return typeof value === "string" && value.trim() !== "";
+}
+
+/// Option names whose arity is a hook with no expression supplied yet.
+function unfilledHooks(draft: Record<string, Json>): string[] {
+  const opts = Array.isArray(draft.options) ? draft.options : [];
+  return opts
+    .filter((o) => {
+      const arity = asRecord(asRecord(asRecord(o).value).arity);
+      return asString(arity.kind) === "Hook" && !asString(arity.hook).trim();
+    })
+    .map((o) => asString(asRecord(o).name))
+    .filter(Boolean);
 }
 
 /// Display text for one `__unrenderable` entry.
@@ -283,14 +318,7 @@ function loadDraft(draft: Draft, origin: string): void {
 function lostLabel(draft: Record<string, Json>, key: unknown): string {
   const name = String(key);
   if (name !== "options.arity_hook") return name;
-  const opts = Array.isArray(draft.options) ? draft.options : [];
-  const pending = opts
-    .filter((o) => {
-      const arity = asRecord(asRecord(asRecord(o).value).arity);
-      return asString(arity.kind) === "Hook" && !asString(arity.hook).trim();
-    })
-    .map((o) => asString(asRecord(o).name))
-    .filter(Boolean);
+  const pending = unfilledHooks(draft);
   return pending.length ? `options → ${pending.join(", ")} (arity hook)` : name;
 }
 
@@ -353,6 +381,7 @@ function onDraftChanged(): void {
 
 function renderOutputs(): void {
   if (!state.draft) return;
+  renderUnrenderableWarning(state.draft);
   try {
     const pack = byId<HTMLInputElement>("rsPack").value || "tcl";
     const rs = JSON.parse(wasm.render_rs(JSON.stringify(state.draft), pack)) as Rendered;

--- a/rust/tcl-spec-studio/web/src/studio.ts
+++ b/rust/tcl-spec-studio/web/src/studio.ts
@@ -25,7 +25,7 @@
 // importer.
 
 import { byId, clear, clone, copyText, deepEqual, download, el, setStatus } from "./dom.js";
-import { makeEditors, STRUCTURAL_KINDS, type Editor } from "./editors.js";
+import { asRecord, asString, makeEditors, STRUCTURAL_KINDS, type Editor } from "./editors.js";
 import type {
   CommandIndex,
   DialectEntry,
@@ -257,11 +257,12 @@ function loadDraft(draft: Draft, origin: string): void {
     );
     warn.appendChild(
       document.createTextNode(
-        " Rust can tell the field is set but not recover the expression that set it — a function pointer or a reference to a static descriptor. Each is listed below and in the rendered file as a TODO; fill it in under Advanced to emit it.",
+        " Rust can tell the field is set but not recover the expression that set it — a function pointer or a reference to a static descriptor. Each is listed below and in the rendered file as a TODO; fill it in where it appears in the form (most sit under Advanced) to emit it.",
       ),
     );
     const ul = el("ul", {});
-    for (const key of lost) ul.appendChild(el("li", {}, [el("code", { text: String(key) })]));
+    for (const key of lost)
+      ul.appendChild(el("li", {}, [el("code", { text: lostLabel(draft, key) })]));
     warn.appendChild(ul);
   } else {
     warn.hidden = true;
@@ -272,6 +273,25 @@ function loadDraft(draft: Draft, origin: string): void {
   buildForm(form, state.schema.command, draft, "command", onDraftChanged);
   renderList();
   onDraftChanged();
+}
+
+/// Display text for one `__unrenderable` entry.
+///
+/// Most entries are a spec field name and read fine as-is. Option-arity hooks
+/// are not a top-level field — they sit in an option row — so name the options
+/// that still need one, which is where the author has to go.
+function lostLabel(draft: Record<string, Json>, key: unknown): string {
+  const name = String(key);
+  if (name !== "options.arity_hook") return name;
+  const opts = Array.isArray(draft.options) ? draft.options : [];
+  const pending = opts
+    .filter((o) => {
+      const arity = asRecord(asRecord(asRecord(o).value).arity);
+      return asString(arity.kind) === "Hook" && !asString(arity.hook).trim();
+    })
+    .map((o) => asString(asRecord(o).name))
+    .filter(Boolean);
+  return pending.length ? `options → ${pending.join(", ")} (arity hook)` : name;
 }
 
 /// Load whatever the filter box currently names.


### PR DESCRIPTION
Two changes. The second is a registry/compiler semantics fix and is **unrelated to the first** — it is here because it came out of the same investigation, and is called out separately below so it gets its own scrutiny.

---

# 1. Option-arity hooks can be typed in (spec studio)

`OptionArity::Hook` holds a function pointer, so seeding a draft cannot recover it. The studio recorded the shape and marked the whole `options` field unreadable.

`return` shows how coarse that was: **five of its six options round-trip perfectly**, and of the sixth (`-errorstack`) only `arity` is lost. A user reading *"options — cannot read back"* would reasonably conclude all six were gone.

`option_arity` now seeds `{kind: "Hook", hook: null}`, the option row grows a `hook fn` text box, and the renderer emits `OptionArity::Hook(<expr>)` once filled — the same verbatim-expression contract the 26 `FieldKind::RustExpr` fields already use, reachable where it belongs rather than under Advanced.

The note is precise and now actually clears. Its key is `draft::OPTION_HOOK_KEY` (`options.arity_hook`), resolved against the option rows by both the warning list and the rendered `TODO`. That fixed a latent bug: `unrenderable_notes` tested "already filled in" with `draft.get(key).as_str()`, which is `None` for an array, so **the options note could never clear**. Nothing exercised it before because nothing could fill it in.

### Review fixes (81d47d9)

**The hook input could not be typed into.** Reproduced in Chromium against the real editor, typing `errorstack_value` one character at a time:

```
rebuild on every change (old) : typed "e"                 — focus lost
rebuild only when structural  : typed "errorstack_value"  — focus held
```

This predates the PR — the option's `name`, `detail` and `hint` boxes have it too, since `options` is a `STRUCTURAL_KINDS` member so any change rebuilds the field and destroys the focused input. `STRUCTURAL_KINDS`' own doc warns about exactly this; the flag is per-*kind*, and a composite kind holds both sorts of control. `Setter` now takes an optional `structural` flag defaulting to `true`, so untouched editors are unaffected; the option row passes `false` for scalar edits and leaves it defaulted where a control appears or disappears.

**The warning went stale** — my bug: the label depends on live draft state but was rendered only from `loadDraft`. Now recomputed on every draft change, using the same resolved-test the renderer applies so the panel and the `TODO` cannot disagree.

---

# 2. The `::tcl::mathop` operator commands are `PURE`

**This is a compiler-behaviour change, not a studio change.**

The `::tcl::mathop` *namespace* spec carried `Traits::PURE`, but every operator command generated under it carried only `OPERATOR_COMMAND`. The compiler therefore treated `[+ $a $b]` as impure — `classify_side_effects` returned `pure=false`, so the GVN pass would neither hoist it out of a loop nor CSE it.

Found by scanning all 2354 specs for trait pairs that never co-occur: `OPERATOR_COMMAND` (87 specs) and `PURE` (379) had **no overlap at all**, which for arithmetic is not a plausible fact about the language. The mechanical cause is that `push_spellings` assigns one flat trait literal, so purity was never expressible per operator.

All 27 operators — `! != % & * ** + - / < << <= == > >= >> ^ eq ge gt in le lt ne ni | ~` — are pure value computations. None reads or writes a variable, channel, or interpreter state. A bad operand raises an error, which the registry models as control flow, not a side effect.

Measured before and after, via `gvn::is_pure_command`:

```
before : +  eq  in  ::tcl::mathop::+   →  all false
after  : +  eq  in  ::tcl::mathop::+   →  all true
```

**Only `PURE` is added, deliberately.** `CSE_CANDIDATE` asks for a redundancy *diagnostic* — a policy call about user-visible noise, not a fact about the command. `BYTE_COMPILED` is a claim about Tcl's own compilation governing whether the minifier may rewrite the head, and getting it wrong would permit an invalid rewrite. Neither is established by this evidence.

The zed editor catalog embeds the flag and is regenerated: 81 entries flip to `"pure": true`, exactly the 27 operators in their three spellings.

---

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

```
make check-all                    # PASSED
make xtask-check                  # PASSED (caught the stale zed catalog before push)
make lint-spec-studio-ts          # PASSED (eslint + prettier)
make typecheck-spec-studio-ts     # PASSED (tsc)
cargo test -p tcl-registry        # 511 passed
cargo test -p tcl-compiler        # 7302 passed, 0 failed
cargo test -p tcl-spec-studio     # 65 passed
cargo clippy -p tcl-registry -p tcl-spec-studio --all-targets   # 0 findings
```

`test-ext` is red here and on #1040 (unrelated code, every other job green): two capability assertions time out at 60s and the VS Code runner then hangs until killed. Infrastructure, not either diff.

## Compiler/KCS checklist

- [x] Did this change alter a compiler fact contract? — **Yes, part 2 does.** Operator commands are now `PURE`, so side-effect classification and GVN see them as pure. No contract's *definition* changed; a fact that was always true is now declared. Pinned by `registry_commands::operator_commands_are_pure`.
- [x] If yes, I updated at least one relevant KCS note — part 1's contract, `docs/design/contracts/command-spec-studio.md`, is updated. **Part 2 has no KCS note yet** — say the word and I will add one covering operator purity and what it unlocks.
- [x] If I added a new compiler KCS note, I linked it from both indexes — n/a.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QHqVbgdKbCFvfqapwyCJn1