### PR TITLE
Fix issue #1035: memory leaks and nondeterminism in per-keystroke analysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -2558,6 +2558,37 @@ The explorer renders:
 - optimiser rewrites
 - source callouts with caret markers and `+-->` arrows for salient spans
 
+### Per-keystroke cost and memory profiling
+
+Two examples measure what an editing session actually costs, rather than what a
+cold run costs. Both read a corpus from `tmp/` (see the `fetch-tcl-source`
+skill, or any directory of `.tcl` files).
+
+```sh
+# Which incremental-analysis guard forces a whole-file re-walk, and what it costs.
+# Weighted by document, by source line, and by measured milliseconds.
+cargo run --release -p tcl-compiler --example per_item_fallbacks
+
+# ROOT=<dir>    sweep a different corpus
+# COMPARE=1     also time the whole-file walk, per document, and show the ratio
+# TK_AUDIT=1    audit the Tk guard: how many documents trip it vs really need it
+
+# Resident memory across a simulated typing session — a fresh, constant-length
+# buffer on every keystroke, with per-subsystem attribution.
+cargo run --release -p tcl-lsp-db --example edit_memory -- 400 both
+```
+
+`edit_memory`'s mode argument bisects growth onto a subsystem: `both`
+(production), `fa` / `cc` (one diagnostic query each), `set` (input writes only,
+no analysis) and `nosalsa` (the analyser with no query database at all). That
+last pair is how [issue #1035](https://github.com/bitwisecook/tcl-lsp/issues/1035)
+was localised — `set` stayed flat while `nosalsa` leaked just as steadily,
+placing the bug in the compiler rather than in the incremental layer. See
+[`docs/kcs/kcs-issue-memory-grows-while-editing.md`](docs/kcs/kcs-issue-memory-grows-while-editing.md)
+for the user-facing symptoms and
+[`docs/design/rust/incremental-analysis.md`](docs/design/rust/incremental-analysis.md)
+for the fallback taxonomy.
+
 ### Developing the extension client
 
 ```sh

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -173,6 +173,68 @@ current whole-file walk. Guards, in order:
 When incremental can't prove equivalence (error recovery, stub overlays — the
 existing `analyse_incremental` guard), fall back to a full walk.
 
+### Fallback telemetry: which guard fired
+
+A fallback is correct but not free — it re-walks the whole document on **every
+keystroke**, so the per-body memoisation above it is dead weight for that file.
+`Analyser::took_fast_path` answers "did we pay for a whole-file walk?", which is
+the latency question; `Analyser::per_item_fallback` answers "why?", which is the
+only actionable one. It is `None` on the fast path, otherwise one of
+[`PerItemFallback`](../../../rust/tcl-compiler/src/analyser/per_item.rs)'s
+variants, ordered by where the guard sits in the pass:
+
+| Variant | Guard |
+| --- | --- |
+| `IncompleteScript` | unbalanced braces/quotes — the transient mid-typing state |
+| `StubDirective` | an inline `tcl-lsp: stub` overlay |
+| `TkActive` | Tk checks accumulate whole-file widget/geometry state |
+| `GhostRecovery` | ghost-token error recovery engaged |
+| `PartialCommand` | an unterminated command survived segmentation |
+| `ErrorDiagnostic` | an `E…` code — `analyse` ran recovery machinery |
+| `DuplicateMethod` | one method qualified name defined twice |
+| `EnclosingContext` | a body links a qualified sub-namespace variable, or `namespace import`/`export`s from inside a body |
+| `DuplicateProcInBody` | a body defines an already-defined proc |
+| `ClassFactsCollide` | a body extends a class whose facts already exist |
+| `MethodInstanceReplay` | a method body's object-instance tracking cannot be replayed |
+
+`rust/tcl-compiler/examples/per_item_fallbacks.rs` sweeps a corpus (`tmp/`, or
+`ROOT=<dir>`) and reports the distribution weighted three ways — by document, by
+source line, and by measured milliseconds. They rank the guards differently: a
+guard that fires on a few very large documents is rare by count and dominant by
+time, and time is what the user feels. `COMPARE=1` additionally times both paths
+per document, and `TK_AUDIT=1` audits the `TkActive` guard specifically.
+
+Measured over tcllib + Tk (1026 documents, 512k lines): **20.5% of documents
+fall back, accounting for 46.8% of source lines and 52.3% of analysis time**;
+mean 19.1 ms per document on the fast path against 81.4 ms on the fallback. The
+three dominant guards by time are `TkActive` (25.4%), `ErrorDiagnostic` (13.4%)
+and `EnclosingContext` (11.1%). Note that `IncompleteScript` never fires on
+documents at rest but fires constantly *while typing*, so the live rate is worse
+than this at-rest figure.
+
+Two findings from that sweep are open, and both argue against widening the fast
+path before the cost model is understood:
+
+- **`TkActive` is ~78% false positives.** The guard is three *independent*
+  substring tests (`package`, `require`, `Tk`, anywhere, comments included). 64
+  documents trip it, 14 genuinely `package require Tk`, and the other 50 emit no
+  Tk diagnostic at all — so tightening it to an adjacent `package require Tk` is
+  behaviour-preserving on this corpus.
+- **…but tightening it exposes a scaling cliff.** On `fumagic/filetypes.tcl`
+  (85k generated lines, one 71k-line body) the incremental path costs 139,010 ms
+  against 5,312 ms for the plain whole-file walk — 26x slower, per keystroke.
+  The decomposition is not the cause: the same body extracted and analysed as a
+  standalone script takes 36,634 ms against 5,312 ms for the whole document
+  containing it, so isolated analysis of a large body is ~7x more expensive than
+  the identical content analysed in place.
+
+More broadly, the decomposition alone is close to break-even — over 210 sampled
+fast-path documents `analyse_per_item` is *slower* than `analyse` on 23% of
+them, mean ratio 1.08. Its value is the memoisation layered on top (a warm
+one-character body edit rebuilds 1 procedure of 40), so the cold-path overhead
+is the price of that option, and a document where the memo cannot pay off should
+not take the path at all.
+
 ## Staging (each slice behaviour-preserving, differential-guarded)
 
 1. **`item_tree` + `item_sig` + `file_decls`** as salsa queries — additive,

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -35,6 +35,9 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   you want to know whether the Tcl Language Server started at all.
 - [kcs-issue-stale-compiler-cache.md](kcs-issue-stale-compiler-cache.md)
   — stale incremental cache produces wrong diagnostics.
+- [kcs-issue-memory-grows-while-editing.md](kcs-issue-memory-grows-while-editing.md)
+  — the language server's memory use climbs with every keystroke and never
+  comes back down.
 - [kcs-issue-problems-not-retained-after-closing-files.md](kcs-issue-problems-not-retained-after-closing-files.md)
   — a file's problems and File Explorer badge vanish after its editor
   tab is closed.

--- a/docs/kcs/kcs-issue-memory-grows-while-editing.md
+++ b/docs/kcs/kcs-issue-memory-grows-while-editing.md
@@ -59,8 +59,8 @@ steady climb rather than a spike on a particular file.
 
 ## Related
 
-- [KCS index](../README.md)
-- [Glossary](../../GLOSSARY.md)
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
 - [kcs-issue-stale-compiler-cache.md](kcs-issue-stale-compiler-cache.md) —
   a different cache problem, where results rather than memory go wrong.
 - [kcs-qa-when-to-restart-server.md](kcs-qa-when-to-restart-server.md) —

--- a/docs/kcs/kcs-issue-memory-grows-while-editing.md
+++ b/docs/kcs/kcs-issue-memory-grows-while-editing.md
@@ -1,0 +1,69 @@
+# KCS: memory use climbs steadily while you edit
+
+> **Audience:** User
+> **Type:** Issue
+
+## Applies to
+
+all-editors
+
+## Question
+
+The Tcl Language Server's memory use keeps rising the longer I edit a file,
+and never comes back down — how do I tell whether I am hitting the known
+leak, and what fixes it?
+
+## Symptoms
+
+- The language-server process grows by hundreds of megabytes over a single
+  editing session, and keeps growing the longer you type.
+- Memory never falls back after you stop typing, close the file, or close
+  the whole workspace — only restarting the server recovers it.
+- Growth tracks *keystrokes*, not file size: a small file edited for a few
+  minutes grows as much as a large one opened and left alone.
+- Reported in [issue #1035](https://github.com/bitwisecook/tcl-lsp/issues/1035).
+
+## Answer
+
+Upgrade to a release containing the fix, then restart the language server.
+
+1. Check your installed version — in VS Code, run **Tcl: Show Version** from
+   the command palette; elsewhere, read the version from the server's output
+   channel at startup.
+2. If it is **v2.1.14 or earlier**, upgrade to the next release. Versions
+   v2.1.9 through v2.1.14 leaked roughly half a megabyte per keystroke.
+3. Restart the language server (**Tcl: Restart Server**, or reload the
+   editor window). The leaked memory is only reclaimed by restarting the
+   process.
+4. Success signal: with the same file open, type for a minute and watch the
+   server process in your OS task manager. Memory should rise to a plateau
+   and stay there, rather than climbing without limit.
+
+If memory still grows without a plateau on a current release, collect the
+output channel log and open an issue with the file that reproduces it.
+
+### What was actually wrong
+
+Two of the generated command tables — the `tcl::mathop` operator ensemble and
+the `tcl::mathfunc` math-function ensemble — build their command specifications
+by leaking small strings, on the assumption that a `CommandRegistry` is
+constructed once per process. It is not: the CFG builder constructed a fresh
+default registry on *every* control-flow-graph build, which is several times
+per keystroke, so every edit permanently leaked the whole ensemble. The
+specifications are now built once and shared, and the hot paths take a cached
+registry instead of constructing one.
+
+Nothing about your configuration, workspace size, or dialect affects this —
+the leak is per-edit and unconditional, which is why it looks like a slow,
+steady climb rather than a spike on a particular file.
+
+## Related
+
+- [KCS index](../README.md)
+- [Glossary](../../GLOSSARY.md)
+- [kcs-issue-stale-compiler-cache.md](kcs-issue-stale-compiler-cache.md) —
+  a different cache problem, where results rather than memory go wrong.
+- [kcs-qa-when-to-restart-server.md](kcs-qa-when-to-restart-server.md) —
+  when restarting the server is the right remedy.
+- [Incremental analysis design](../design/rust/incremental-analysis.md) —
+  the per-keystroke analysis path and its fallback telemetry.

--- a/rust/tcl-compiler/examples/per_item_fallbacks.rs
+++ b/rust/tcl-compiler/examples/per_item_fallbacks.rs
@@ -64,10 +64,17 @@ struct Row {
     reason: Option<PerItemFallback>,
     lines: usize,
     ms: f64,
+    path: PathBuf,
 }
 
+#[allow(clippy::too_many_lines)] // a linear reporting script; splitting it hurts readability
 fn main() {
-    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp");
+    // `ROOT` points the sweep at a different corpus (e.g. a directory of
+    // size-truncated copies, to check how cost scales with document length).
+    let root = std::env::var("ROOT").map_or_else(
+        |_| PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp"),
+        PathBuf::from,
+    );
     let dialect = "tcl8.6";
     let cap: usize = std::env::var("CAP")
         .ok()
@@ -84,6 +91,26 @@ fn main() {
         if src.trim().is_empty() {
             continue;
         }
+        // `COMPARE=1` also times the whole-file walk, so a document where the
+        // incremental path is *slower* than the thing it replaces stands out.
+        if std::env::var("COMPARE").is_ok() {
+            let t0 = Instant::now();
+            let _ = Analyser::new().analyse(&src, dialect);
+            let full = t0.elapsed().as_secs_f64() * 1000.0;
+            let t1 = Instant::now();
+            let mut probe = Analyser::new();
+            let _ = probe.analyse_per_item(&src, dialect);
+            let incr = t1.elapsed().as_secs_f64() * 1000.0;
+            println!(
+                "  {:>6} lines  analyse {full:>9.0} ms  per_item {incr:>9.0} ms  x{:>6.1}  {:<20} {}",
+                src.lines().count(),
+                if full > 0.0 { incr / full } else { 0.0 },
+                probe
+                    .per_item_fallback
+                    .map_or("FAST PATH", PerItemFallback::as_str),
+                path.file_name().unwrap_or_default().to_string_lossy(),
+            );
+        }
         let mut a = Analyser::new();
         let start = Instant::now();
         let _ = a.analyse_per_item(&src, dialect);
@@ -91,6 +118,7 @@ fn main() {
             reason: a.per_item_fallback,
             lines: src.lines().count(),
             ms: start.elapsed().as_secs_f64() * 1000.0,
+            path: path.clone(),
         });
     }
 
@@ -176,4 +204,87 @@ fn main() {
         mean(&fast),
         mean(&slow),
     );
+
+    // The tail is what a user actually feels: one pathological document costs
+    // more per keystroke than a thousand ordinary ones.
+    let mut slowest: Vec<&Row> = rows.iter().collect();
+    slowest.sort_by(|a, b| b.ms.partial_cmp(&a.ms).unwrap_or(std::cmp::Ordering::Equal));
+    println!("\n  slowest documents (per-keystroke cost):");
+    for r in slowest.iter().take(8) {
+        println!(
+            "    {:>9.0} ms  {:>6} lines  {:<22} {}",
+            r.ms,
+            r.lines,
+            r.reason.map_or("FAST PATH", PerItemFallback::as_str),
+            r.path.file_name().unwrap_or_default().to_string_lossy(),
+        );
+    }
+
+    if std::env::var("TK_AUDIT").is_ok() {
+        tk_audit(&files, dialect);
+    }
+}
+
+/// Audit the `tk-active` gate — the single most expensive fallback reason.
+///
+/// `tk_possibly_active` is three *independent* substring searches (`package`,
+/// `require`, `Tk`, anywhere, in any order, comments included), and it does
+/// double duty: it gates the per-item fallback *and* whether Tk diagnostics
+/// accumulate at all.  Narrowing it is only safe if the files it currently
+/// catches spuriously emit no Tk diagnostics — otherwise tightening the gate
+/// silences real warnings.  This measures exactly that.
+fn tk_audit(files: &[PathBuf], dialect: &str) {
+    let (mut tripped, mut real_require, mut spurious_with_tk_diags) = (0usize, 0usize, 0usize);
+    let mut genuine_tk_diags = 0usize;
+    let mut spurious_examples: Vec<String> = Vec::new();
+    for path in files {
+        let Ok(src) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        // Mirrors `tk_checks::tk_possibly_active` (which is crate-private).
+        let heuristic = src.contains("package") && src.contains("require") && src.contains("Tk");
+        if !heuristic {
+            continue;
+        }
+        tripped += 1;
+        // What the gate is trying to detect: an actual `package require Tk`.
+        let genuine = src.split("package").skip(1).any(|rest| {
+            let rest = rest.trim_start();
+            rest.strip_prefix("require").is_some_and(|r| {
+                let r = r.trim_start();
+                let r = r.strip_prefix("-exact").map_or(r, |x| x.trim_start());
+                r.starts_with("Tk")
+            })
+        });
+        let tk_diags = Analyser::new()
+            .analyse(&src, dialect)
+            .diagnostics
+            .iter()
+            .filter(|d| d.code.as_str().starts_with("TK"))
+            .count();
+        if genuine {
+            real_require += 1;
+            genuine_tk_diags += tk_diags;
+            continue;
+        }
+        if tk_diags > 0 {
+            spurious_with_tk_diags += 1;
+            if spurious_examples.len() < 5 {
+                spurious_examples.push(format!("{} ({tk_diags} TK diags)", path.display()));
+            }
+        }
+    }
+    println!("\n== tk-active gate audit ==");
+    println!("  files tripping the 3-substring heuristic:      {tripped}");
+    println!(
+        "  ... with a genuine `package require Tk`:       {real_require} \
+         (emitting {genuine_tk_diags} TK diagnostics in total)"
+    );
+    println!(
+        "  ... spurious (no require) BUT emitting TK diags: {spurious_with_tk_diags}  \
+         <- tightening the gate would change these"
+    );
+    for e in &spurious_examples {
+        println!("      {e}");
+    }
 }

--- a/rust/tcl-compiler/examples/per_item_fallbacks.rs
+++ b/rust/tcl-compiler/examples/per_item_fallbacks.rs
@@ -1,0 +1,179 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! How often does incremental analysis give up, and what does that cost?
+//!
+//! `per_item_divergence` asks whether the fast path is *correct*. This asks
+//! whether it is *taken* — a different question with a different answer, and
+//! the one that decides per-keystroke latency: every fallback re-walks the
+//! whole document on every edit, making the per-body memoisation above it dead
+//! weight for that file.
+//!
+//! Reports the [`PerItemFallback`] histogram over a corpus, weighted three ways
+//! — by file, by source line, and by measured milliseconds — because they rank
+//! the gates differently: a gate that fires on a few very large files can be
+//! rare by count and dominant by time, and time is what the user feels.
+//!
+//! Usage: `cargo run --release --example per_item_fallbacks` (corpus: `tmp/`).
+
+use std::collections::BTreeMap;
+use std::path::{Path, PathBuf};
+use std::time::Instant;
+
+use tcl_compiler::analyser::Analyser;
+use tcl_compiler::analyser::per_item::PerItemFallback;
+
+fn gather_tcl(dir: &Path, out: &mut Vec<PathBuf>, cap: usize) {
+    if out.len() >= cap {
+        return;
+    }
+    let Ok(entries) = std::fs::read_dir(dir) else {
+        return;
+    };
+    let mut entries: Vec<_> = entries.filter_map(Result::ok).map(|e| e.path()).collect();
+    entries.sort();
+    for path in entries {
+        if out.len() >= cap {
+            return;
+        }
+        if path.is_dir() {
+            gather_tcl(&path, out, cap);
+        } else if path.extension().is_some_and(|e| e == "tcl") {
+            out.push(path);
+        }
+    }
+}
+
+/// One corpus file's verdict.
+struct Row {
+    reason: Option<PerItemFallback>,
+    lines: usize,
+    ms: f64,
+}
+
+fn main() {
+    let root = PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("../../tmp");
+    let dialect = "tcl8.6";
+    let cap: usize = std::env::var("CAP")
+        .ok()
+        .and_then(|s| s.parse().ok())
+        .unwrap_or(4000);
+    let mut files = Vec::new();
+    gather_tcl(&root, &mut files, cap);
+
+    let mut rows = Vec::new();
+    for path in &files {
+        let Ok(src) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if src.trim().is_empty() {
+            continue;
+        }
+        let mut a = Analyser::new();
+        let start = Instant::now();
+        let _ = a.analyse_per_item(&src, dialect);
+        rows.push(Row {
+            reason: a.per_item_fallback,
+            lines: src.lines().count(),
+            ms: start.elapsed().as_secs_f64() * 1000.0,
+        });
+    }
+
+    let files_n = rows.len();
+    let lines_n: usize = rows.iter().map(|r| r.lines).sum();
+    let ms_n: f64 = rows.iter().map(|r| r.ms).sum();
+    let fast: Vec<&Row> = rows.iter().filter(|r| r.reason.is_none()).collect();
+    println!("corpus: {files_n} files, {lines_n} lines, {ms_n:.0} ms total (dialect {dialect})\n");
+
+    println!(
+        "  {:<24} {:>7} {:>7}   {:>9} {:>7}   {:>9} {:>7}",
+        "outcome", "files", "%", "lines", "%", "ms", "%"
+    );
+    // Counts are file/line tallies, far below `f64`'s exact-integer range, so the
+    // narrowing through `u32` is lossless here and keeps the cast lints quiet.
+    let ratio = |part: usize, whole: usize| -> f64 {
+        if whole == 0 {
+            return 0.0;
+        }
+        f64::from(u32::try_from(part).unwrap_or(u32::MAX))
+            / f64::from(u32::try_from(whole).unwrap_or(u32::MAX))
+            * 100.0
+    };
+    let pct = |part: f64, whole: f64| {
+        if whole > 0.0 {
+            part / whole * 100.0
+        } else {
+            0.0
+        }
+    };
+    let report = |label: &str, sel: &dyn Fn(&Row) -> bool| {
+        let f = rows.iter().filter(|r| sel(r)).count();
+        if f == 0 {
+            return;
+        }
+        let l: usize = rows.iter().filter(|r| sel(r)).map(|r| r.lines).sum();
+        let m: f64 = rows.iter().filter(|r| sel(r)).map(|r| r.ms).sum();
+        println!(
+            "  {label:<24} {f:>7} {:>6.1}% {l:>9} {:>6.1}% {m:>9.0} {:>6.1}%",
+            ratio(f, files_n),
+            ratio(l, lines_n),
+            pct(m, ms_n),
+        );
+    };
+    report("FAST PATH", &|r: &Row| r.reason.is_none());
+    report("fell back (all)", &|r: &Row| r.reason.is_some());
+    println!();
+
+    // Per-gate breakdown, ordered by the cost that actually matters: time.
+    let mut by_reason: BTreeMap<&'static str, (usize, usize, f64)> = BTreeMap::new();
+    for r in rows.iter().filter_map(|r| r.reason.map(|x| (x, r))) {
+        let e = by_reason.entry(r.0.as_str()).or_default();
+        e.0 += 1;
+        e.1 += r.1.lines;
+        e.2 += r.1.ms;
+    }
+    let mut ordered: Vec<_> = by_reason.into_iter().collect();
+    ordered.sort_by(|a, b| {
+        b.1.2
+            .partial_cmp(&a.1.2)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    for (name, (f, l, m)) in ordered {
+        println!(
+            "  {name:<24} {f:>7} {:>6.1}% {l:>9} {:>6.1}% {m:>9.0} {:>6.1}%",
+            ratio(f, files_n),
+            ratio(l, lines_n),
+            pct(m, ms_n),
+        );
+    }
+
+    // Mean cost per file on each side — the per-keystroke number.
+    let mean = |v: &[&Row]| -> f64 {
+        if v.is_empty() {
+            0.0
+        } else {
+            v.iter().map(|r| r.ms).sum::<f64>() / f64::from(u32::try_from(v.len()).unwrap_or(1))
+        }
+    };
+    let slow: Vec<&Row> = rows.iter().filter(|r| r.reason.is_some()).collect();
+    println!(
+        "\n  mean per file: fast {:.1} ms  |  fell back {:.1} ms",
+        mean(&fast),
+        mean(&slow),
+    );
+}

--- a/rust/tcl-compiler/examples/per_item_fallbacks.rs
+++ b/rust/tcl-compiler/examples/per_item_fallbacks.rs
@@ -67,7 +67,173 @@ struct Row {
     path: PathBuf,
 }
 
-#[allow(clippy::too_many_lines)] // a linear reporting script; splitting it hurts readability
+/// Totals a set of rows contributes, for the three weightings the report
+/// compares: documents, source lines, and measured milliseconds.
+#[derive(Default, Clone, Copy)]
+struct Totals {
+    files: usize,
+    lines: usize,
+    ms: f64,
+}
+
+impl Totals {
+    fn add(&mut self, row: &Row) {
+        self.files += 1;
+        self.lines += row.lines;
+        self.ms += row.ms;
+    }
+
+    fn of<'a>(rows: impl IntoIterator<Item = &'a Row>) -> Self {
+        let mut t = Self::default();
+        for r in rows {
+            t.add(r);
+        }
+        t
+    }
+}
+
+/// Percentage of `whole`, via `u32` so the cast is provably lossless for
+/// tallies of this size (and the pedantic cast lints stay quiet).
+fn share(part: usize, whole: usize) -> f64 {
+    if whole == 0 {
+        return 0.0;
+    }
+    f64::from(u32::try_from(part).unwrap_or(u32::MAX))
+        / f64::from(u32::try_from(whole).unwrap_or(u32::MAX))
+        * 100.0
+}
+
+/// Percentage of a `f64` total (milliseconds), which has no integer form.
+fn share_ms(part: f64, whole: f64) -> f64 {
+    if whole > 0.0 {
+        part / whole * 100.0
+    } else {
+        0.0
+    }
+}
+
+/// Mean milliseconds across `rows`; `0.0` for an empty set.
+fn mean_ms(rows: &[&Row]) -> f64 {
+    if rows.is_empty() {
+        return 0.0;
+    }
+    rows.iter().map(|r| r.ms).sum::<f64>() / f64::from(u32::try_from(rows.len()).unwrap_or(1))
+}
+
+/// Analyse every corpus document once, recording which gate (if any) forced it
+/// off the incremental path and what that cost.
+fn collect_rows(files: &[PathBuf], dialect: &str, compare: bool) -> Vec<Row> {
+    let mut rows = Vec::new();
+    for path in files {
+        let Ok(src) = std::fs::read_to_string(path) else {
+            continue;
+        };
+        if src.trim().is_empty() {
+            continue;
+        }
+        if compare {
+            compare_paths(&src, dialect, path);
+        }
+        let mut a = Analyser::new();
+        let start = Instant::now();
+        let _ = a.analyse_per_item(&src, dialect);
+        rows.push(Row {
+            reason: a.per_item_fallback,
+            lines: src.lines().count(),
+            ms: start.elapsed().as_secs_f64() * 1000.0,
+            path: path.clone(),
+        });
+    }
+    rows
+}
+
+/// Time both paths for one document, so a case where the *incremental* path is
+/// slower than the whole-file walk it replaces stands out per file.
+fn compare_paths(src: &str, dialect: &str, path: &Path) {
+    let t0 = Instant::now();
+    let _ = Analyser::new().analyse(src, dialect);
+    let full = t0.elapsed().as_secs_f64() * 1000.0;
+    let t1 = Instant::now();
+    let mut probe = Analyser::new();
+    let _ = probe.analyse_per_item(src, dialect);
+    let incr = t1.elapsed().as_secs_f64() * 1000.0;
+    println!(
+        "  {:>6} lines  analyse {full:>9.0} ms  per_item {incr:>9.0} ms  x{:>6.1}  {:<20} {}",
+        src.lines().count(),
+        if full > 0.0 { incr / full } else { 0.0 },
+        probe
+            .per_item_fallback
+            .map_or("FAST PATH", PerItemFallback::as_str),
+        path.file_name().unwrap_or_default().to_string_lossy(),
+    );
+}
+
+/// One table row: absolute tallies plus each one's share of the corpus.
+fn print_row(label: &str, part: Totals, whole: Totals) {
+    println!(
+        "  {label:<24} {:>7} {:>6.1}% {:>9} {:>6.1}% {:>9.0} {:>6.1}%",
+        part.files,
+        share(part.files, whole.files),
+        part.lines,
+        share(part.lines, whole.lines),
+        part.ms,
+        share_ms(part.ms, whole.ms),
+    );
+}
+
+/// The fast-path/fallback split and the per-gate breakdown, each weighted three
+/// ways — they rank the gates differently, and time is what a user feels.
+fn print_breakdown(rows: &[Row], whole: Totals) {
+    println!(
+        "  {:<24} {:>7} {:>7}   {:>9} {:>7}   {:>9} {:>7}",
+        "outcome", "files", "%", "lines", "%", "ms", "%"
+    );
+    print_row(
+        "FAST PATH",
+        Totals::of(rows.iter().filter(|r| r.reason.is_none())),
+        whole,
+    );
+    print_row(
+        "fell back (all)",
+        Totals::of(rows.iter().filter(|r| r.reason.is_some())),
+        whole,
+    );
+    println!();
+
+    let mut by_reason: BTreeMap<&'static str, Totals> = BTreeMap::new();
+    for row in rows {
+        if let Some(reason) = row.reason {
+            by_reason.entry(reason.as_str()).or_default().add(row);
+        }
+    }
+    let mut ordered: Vec<_> = by_reason.into_iter().collect();
+    ordered.sort_by(|a, b| {
+        b.1.ms
+            .partial_cmp(&a.1.ms)
+            .unwrap_or(std::cmp::Ordering::Equal)
+    });
+    for (name, totals) in ordered {
+        print_row(name, totals, whole);
+    }
+}
+
+/// The slowest documents: the tail is what a user actually feels, since one
+/// pathological document costs more per keystroke than a thousand ordinary ones.
+fn print_slowest(rows: &[Row]) {
+    let mut slowest: Vec<&Row> = rows.iter().collect();
+    slowest.sort_by(|a, b| b.ms.partial_cmp(&a.ms).unwrap_or(std::cmp::Ordering::Equal));
+    println!("\n  slowest documents (per-keystroke cost):");
+    for r in slowest.iter().take(8) {
+        println!(
+            "    {:>9.0} ms  {:>6} lines  {:<22} {}",
+            r.ms,
+            r.lines,
+            r.reason.map_or("FAST PATH", PerItemFallback::as_str),
+            r.path.file_name().unwrap_or_default().to_string_lossy(),
+        );
+    }
+}
+
 fn main() {
     // `ROOT` points the sweep at a different corpus (e.g. a directory of
     // size-truncated copies, to check how cost scales with document length).
@@ -83,142 +249,24 @@ fn main() {
     let mut files = Vec::new();
     gather_tcl(&root, &mut files, cap);
 
-    let mut rows = Vec::new();
-    for path in &files {
-        let Ok(src) = std::fs::read_to_string(path) else {
-            continue;
-        };
-        if src.trim().is_empty() {
-            continue;
-        }
-        // `COMPARE=1` also times the whole-file walk, so a document where the
-        // incremental path is *slower* than the thing it replaces stands out.
-        if std::env::var("COMPARE").is_ok() {
-            let t0 = Instant::now();
-            let _ = Analyser::new().analyse(&src, dialect);
-            let full = t0.elapsed().as_secs_f64() * 1000.0;
-            let t1 = Instant::now();
-            let mut probe = Analyser::new();
-            let _ = probe.analyse_per_item(&src, dialect);
-            let incr = t1.elapsed().as_secs_f64() * 1000.0;
-            println!(
-                "  {:>6} lines  analyse {full:>9.0} ms  per_item {incr:>9.0} ms  x{:>6.1}  {:<20} {}",
-                src.lines().count(),
-                if full > 0.0 { incr / full } else { 0.0 },
-                probe
-                    .per_item_fallback
-                    .map_or("FAST PATH", PerItemFallback::as_str),
-                path.file_name().unwrap_or_default().to_string_lossy(),
-            );
-        }
-        let mut a = Analyser::new();
-        let start = Instant::now();
-        let _ = a.analyse_per_item(&src, dialect);
-        rows.push(Row {
-            reason: a.per_item_fallback,
-            lines: src.lines().count(),
-            ms: start.elapsed().as_secs_f64() * 1000.0,
-            path: path.clone(),
-        });
-    }
-
-    let files_n = rows.len();
-    let lines_n: usize = rows.iter().map(|r| r.lines).sum();
-    let ms_n: f64 = rows.iter().map(|r| r.ms).sum();
-    let fast: Vec<&Row> = rows.iter().filter(|r| r.reason.is_none()).collect();
-    println!("corpus: {files_n} files, {lines_n} lines, {ms_n:.0} ms total (dialect {dialect})\n");
-
+    let rows = collect_rows(&files, dialect, std::env::var("COMPARE").is_ok());
+    let whole = Totals::of(&rows);
     println!(
-        "  {:<24} {:>7} {:>7}   {:>9} {:>7}   {:>9} {:>7}",
-        "outcome", "files", "%", "lines", "%", "ms", "%"
+        "corpus: {} files, {} lines, {:.0} ms total (dialect {dialect})\n",
+        whole.files, whole.lines, whole.ms
     );
-    // Counts are file/line tallies, far below `f64`'s exact-integer range, so the
-    // narrowing through `u32` is lossless here and keeps the cast lints quiet.
-    let ratio = |part: usize, whole: usize| -> f64 {
-        if whole == 0 {
-            return 0.0;
-        }
-        f64::from(u32::try_from(part).unwrap_or(u32::MAX))
-            / f64::from(u32::try_from(whole).unwrap_or(u32::MAX))
-            * 100.0
-    };
-    let pct = |part: f64, whole: f64| {
-        if whole > 0.0 {
-            part / whole * 100.0
-        } else {
-            0.0
-        }
-    };
-    let report = |label: &str, sel: &dyn Fn(&Row) -> bool| {
-        let f = rows.iter().filter(|r| sel(r)).count();
-        if f == 0 {
-            return;
-        }
-        let l: usize = rows.iter().filter(|r| sel(r)).map(|r| r.lines).sum();
-        let m: f64 = rows.iter().filter(|r| sel(r)).map(|r| r.ms).sum();
-        println!(
-            "  {label:<24} {f:>7} {:>6.1}% {l:>9} {:>6.1}% {m:>9.0} {:>6.1}%",
-            ratio(f, files_n),
-            ratio(l, lines_n),
-            pct(m, ms_n),
-        );
-    };
-    report("FAST PATH", &|r: &Row| r.reason.is_none());
-    report("fell back (all)", &|r: &Row| r.reason.is_some());
-    println!();
 
-    // Per-gate breakdown, ordered by the cost that actually matters: time.
-    let mut by_reason: BTreeMap<&'static str, (usize, usize, f64)> = BTreeMap::new();
-    for r in rows.iter().filter_map(|r| r.reason.map(|x| (x, r))) {
-        let e = by_reason.entry(r.0.as_str()).or_default();
-        e.0 += 1;
-        e.1 += r.1.lines;
-        e.2 += r.1.ms;
-    }
-    let mut ordered: Vec<_> = by_reason.into_iter().collect();
-    ordered.sort_by(|a, b| {
-        b.1.2
-            .partial_cmp(&a.1.2)
-            .unwrap_or(std::cmp::Ordering::Equal)
-    });
-    for (name, (f, l, m)) in ordered {
-        println!(
-            "  {name:<24} {f:>7} {:>6.1}% {l:>9} {:>6.1}% {m:>9.0} {:>6.1}%",
-            ratio(f, files_n),
-            ratio(l, lines_n),
-            pct(m, ms_n),
-        );
-    }
+    print_breakdown(&rows, whole);
 
-    // Mean cost per file on each side — the per-keystroke number.
-    let mean = |v: &[&Row]| -> f64 {
-        if v.is_empty() {
-            0.0
-        } else {
-            v.iter().map(|r| r.ms).sum::<f64>() / f64::from(u32::try_from(v.len()).unwrap_or(1))
-        }
-    };
+    let fast: Vec<&Row> = rows.iter().filter(|r| r.reason.is_none()).collect();
     let slow: Vec<&Row> = rows.iter().filter(|r| r.reason.is_some()).collect();
     println!(
         "\n  mean per file: fast {:.1} ms  |  fell back {:.1} ms",
-        mean(&fast),
-        mean(&slow),
+        mean_ms(&fast),
+        mean_ms(&slow),
     );
 
-    // The tail is what a user actually feels: one pathological document costs
-    // more per keystroke than a thousand ordinary ones.
-    let mut slowest: Vec<&Row> = rows.iter().collect();
-    slowest.sort_by(|a, b| b.ms.partial_cmp(&a.ms).unwrap_or(std::cmp::Ordering::Equal));
-    println!("\n  slowest documents (per-keystroke cost):");
-    for r in slowest.iter().take(8) {
-        println!(
-            "    {:>9.0} ms  {:>6} lines  {:<22} {}",
-            r.ms,
-            r.lines,
-            r.reason.map_or("FAST PATH", PerItemFallback::as_str),
-            r.path.file_name().unwrap_or_default().to_string_lossy(),
-        );
-    }
+    print_slowest(&rows);
 
     if std::env::var("TK_AUDIT").is_ok() {
         tk_audit(&files, dialect);

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -54,6 +54,66 @@ use tcl_lexer::Token;
 use super::state::Analyser;
 use super::types::AnalysisResult;
 
+/// Why [`Analyser::analyse_per_item_with`] abandoned the incremental path and
+/// paid for a full whole-file walk.
+///
+/// Every fallback costs a complete re-analysis of the document on **every
+/// keystroke** — the per-body memoisation above it is dead weight for a file
+/// that trips one of these. Knowing the rate is a perf question; knowing the
+/// *distribution* is what says which gate is worth engineering away, so the
+/// variants are ordered by where they fire in the pass.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, PartialOrd, Ord)]
+pub enum PerItemFallback {
+    /// Source is not a complete script (unbalanced braces / quotes) — mid-edit
+    /// state, so this one is expected to fire transiently while typing.
+    IncompleteScript,
+    /// An inline `tcl-lsp: stub` directive; stub overlays are modelled only on
+    /// the full path.
+    StubDirective,
+    /// Tk checks are live, and their whole-file state (created widgets,
+    /// per-parent geometry) is not visible to an isolated body.
+    TkActive,
+    /// Ghost-token error recovery engaged.
+    GhostRecovery,
+    /// A partial (unterminated) command survived segmentation.
+    PartialCommand,
+    /// An `E…` diagnostic was emitted — `analyse` would have run recovery
+    /// machinery the per-item walk only partially reproduces.
+    ErrorDiagnostic,
+    /// The same method qualified name is defined more than once.
+    DuplicateMethod,
+    /// A body declares a link to a qualified sub-namespace variable, or
+    /// `namespace import`/`export`s from inside a body
+    /// ([`body_needs_enclosing_context`]).
+    EnclosingContext,
+    /// A body defines a proc whose name is already defined elsewhere.
+    DuplicateProcInBody,
+    /// A body defines/extends a class whose facts collide with existing ones.
+    ClassFactsCollide,
+    /// A method body's object-instance tracking could not be replayed.
+    MethodInstanceReplay,
+}
+
+impl PerItemFallback {
+    /// Stable short name for histograms / logs.
+    #[must_use]
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::IncompleteScript => "incomplete-script",
+            Self::StubDirective => "stub-directive",
+            Self::TkActive => "tk-active",
+            Self::GhostRecovery => "ghost-recovery",
+            Self::PartialCommand => "partial-command",
+            Self::ErrorDiagnostic => "error-diagnostic",
+            Self::DuplicateMethod => "duplicate-method",
+            Self::EnclosingContext => "enclosing-context",
+            Self::DuplicateProcInBody => "duplicate-proc-in-body",
+            Self::ClassFactsCollide => "class-facts-collide",
+            Self::MethodInstanceReplay => "method-instance-replay",
+        }
+    }
+}
+
 /// A proc / method body deferred by the shell pass for a second analysis pass.
 /// Its scope already exists at `scope_path` (params + instance vars defined);
 /// the body pass fills it via an **isolated** analysis (memoisable) and grafts
@@ -148,6 +208,7 @@ impl Analyser {
         body_fn: &mut dyn FnMut(&DeferredBody) -> BodyFragment,
     ) -> AnalysisResult {
         self.took_fast_path = false;
+        self.per_item_fallback = None;
         // Recovery / stub overlays are only modelled on the full `analyse`
         // path; fall back so the per-item result can never diverge.  Tk's
         // TK100x checks accumulate whole-file state (created widgets, per-parent
@@ -155,10 +216,23 @@ impl Analyser {
         // also falls back to full analysis rather than diverge (a parent
         // created outside a proc would otherwise look missing inside it, and a
         // `pack`/`grid` conflict spanning a proc body would never flush).
-        if !tcl_lexer::script_is_complete(source)
-            || source.contains("tcl-lsp: stub")
-            || super::tk_checks::tk_possibly_active(source, dialect)
-        {
+        //
+        // Evaluated one gate at a time (rather than as one `||` chain) so the
+        // telemetry can name which fired — these are checked in cheapest-first
+        // order, so the split costs nothing.
+        let entry_gate = if tcl_lexer::script_is_complete(source) {
+            if source.contains("tcl-lsp: stub") {
+                Some(PerItemFallback::StubDirective)
+            } else if super::tk_checks::tk_possibly_active(source, dialect) {
+                Some(PerItemFallback::TkActive)
+            } else {
+                None
+            }
+        } else {
+            Some(PerItemFallback::IncompleteScript)
+        };
+        if let Some(reason) = entry_gate {
+            self.per_item_fallback = Some(reason);
             return self.analyse(source, dialect);
         }
 
@@ -170,6 +244,11 @@ impl Analyser {
         // partial-command handling is not reproduced on the per-item path).
         let ghost = self.apply_ghost_recovery(source, &mut commands);
         if ghost || commands.iter().any(|c| c.is_partial) {
+            self.per_item_fallback = Some(if ghost {
+                PerItemFallback::GhostRecovery
+            } else {
+                PerItemFallback::PartialCommand
+            });
             return self.fresh_full_analyse(source, dialect);
         }
 
@@ -204,6 +283,7 @@ impl Analyser {
         // from-scratch `analyse`.  Well-formed edits (the common case) carry no
         // E-codes and stay on the fast path.
         if self.result.diagnostics.iter().any(|d| d.code.is_error()) {
+            self.per_item_fallback = Some(PerItemFallback::ErrorDiagnostic);
             return self.fresh_full_analyse(source, dialect);
         }
 
@@ -316,6 +396,11 @@ impl Analyser {
                 .iter()
                 .any(|db| !db.is_method && body_needs_enclosing_context(&db.body_text));
         if duplicate_method || enclosing_fallback {
+            self.per_item_fallback = Some(if duplicate_method {
+                PerItemFallback::DuplicateMethod
+            } else {
+                PerItemFallback::EnclosingContext
+            });
             return Err(Box::new(self.fresh_full_analyse(source, dialect)));
         }
         // **Proc duplicates take the fast path.**  A whole-file walk's
@@ -349,6 +434,7 @@ impl Analyser {
                 .keys()
                 .any(|name| !defined_procs.insert(name.clone()))
             {
+                self.per_item_fallback = Some(PerItemFallback::DuplicateProcInBody);
                 return Err(Box::new(self.fresh_full_analyse(source, dialect)));
             }
             // A body that defines/extends a class whose `all_classes` entry
@@ -357,6 +443,7 @@ impl Analyser {
             // *accumulates* there (`oo::define` adds methods to the existing
             // class).  A fresh (non-colliding) class definition stays fast.
             if class_facts_collide(&self.result, &frag.result) {
+                self.per_item_fallback = Some(PerItemFallback::ClassFactsCollide);
                 return Err(Box::new(self.fresh_full_analyse(source, dialect)));
             }
             // Object-instance tracking (W308) resolves the class at the walk
@@ -374,6 +461,7 @@ impl Analyser {
             if let Some(before) = inst_snapshot
                 && self.result.instance_classes != before
             {
+                self.per_item_fallback = Some(PerItemFallback::MethodInstanceReplay);
                 return Err(Box::new(self.fresh_full_analyse(source, dialect)));
             }
         }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -692,7 +692,17 @@ pub struct Analyser {
     /// when the run completed on the incremental per-item path and `false` when
     /// it fell back to a full rebuild.  Read by perf/coverage probes; ignored by
     /// production callers (which only consume the returned `AnalysisResult`).
+    ///
+    /// Equivalent to `per_item_fallback.is_none()` — read that instead when you
+    /// need to know *which* gate fired.
     pub took_fast_path: bool,
+    /// **Probe telemetry.**  `None` when the run stayed on the incremental
+    /// per-item path; otherwise the gate that forced the full rebuild.
+    ///
+    /// `took_fast_path` answers "did we pay for a whole-file walk?", which is
+    /// the latency question; this answers "why?", which is the only actionable
+    /// one.  The two are always set together.
+    pub per_item_fallback: Option<super::per_item::PerItemFallback>,
     /// iRules file-profile cache for IRULE1001's informational profile hint:
     /// the sorted, fully-expanded profile stack derived from any
     /// `# profiles:` directive plus the profiles implied by the file's
@@ -883,6 +893,7 @@ impl Analyser {
             probe_skip_enclosing_fallback: false,
             probe_skip_duplicate_fallback: false,
             took_fast_path: false,
+            per_item_fallback: None,
             irules_file_profiles: None,
         }
     }

--- a/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
@@ -100,7 +100,19 @@ pub fn detect_global_write_procs(module: &Module) -> HashMap<String, GlobalWrite
     let registry = tcl_registry::cache::default_registry();
     let mut own: HashMap<String, GlobalWriteInfo> = HashMap::new();
     let mut direct_calls: HashMap<String, BTreeSet<String>> = HashMap::new();
-    for (qname, proc) in &module.procedures {
+    // Iterate procedures in a deterministic (qualified-name) order, for the same
+    // reason [`super::prepare_cfg_context`] does it for `proc_params`: every proc
+    // registers its *short* name as well as its qualified one, so procedures
+    // sharing a short name (`::a::run` and `::b::run`) both write the `run` key
+    // and the last writer wins.  Off a `HashMap`, "last" is the random per-process
+    // hash seed — and this map is part of the `CfgContext` folded into *every*
+    // procedure's `function_lattice` memo key, so a nondeterministic winner makes
+    // the whole file's per-procedure cache hit or miss by luck of the process
+    // start (issue #1035 follow-up: measured flipping a one-keystroke edit between
+    // rebuilding 1 procedure and rebuilding all 40, run to run, on the same file).
+    let mut entries: Vec<(&String, &crate::ir::Procedure)> = module.procedures.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    for (qname, proc) in entries {
         let info = own_body_global_writes(&proc.body, registry);
         let calls = direct_call_targets(&proc.body);
         for key in registered_keys(qname) {
@@ -112,17 +124,26 @@ pub fn detect_global_write_procs(module: &Module) -> HashMap<String, GlobalWrite
     // Transitive closure: monotonic union over direct-callee summaries.
     // Bounded by the number of registered names, so an adversarial call
     // graph still terminates.
+    //
+    // Walk the callers in sorted order too: the union itself is order-independent,
+    // but the `guard` bound can cut the fixpoint short on an adversarial graph, and
+    // a truncated result must at least be the *same* truncated result every run.
+    let mut callers: Vec<String> = direct_calls.keys().cloned().collect();
+    callers.sort();
     let mut changed = true;
     let mut guard = 0usize;
     while changed && guard <= own.len() {
         changed = false;
         guard += 1;
         let snapshot = own.clone();
-        for (caller, callees) in &direct_calls {
+        for caller in &callers {
+            let Some(callee_names) = direct_calls.get(caller) else {
+                continue;
+            };
             let Some(target_summary) = own.get_mut(caller) else {
                 continue;
             };
-            for callee in callees {
+            for callee in callee_names {
                 let Some(source_summary) = snapshot.get(callee) else {
                     continue;
                 };
@@ -342,6 +363,37 @@ mod tests {
     fn empty_module_has_no_writes() {
         let m = module("");
         assert!(detect_global_write_procs(&m).is_empty());
+    }
+
+    /// Procedures sharing a *short* name both write the short key, so the
+    /// tie-break must be a property of the source, not of `HashMap` iteration
+    /// order — this map is folded into the `CfgContext` that keys **every**
+    /// procedure's `function_lattice` memo, so a seed-dependent winner makes the
+    /// whole file's per-procedure cache hit or miss by luck of the process start.
+    ///
+    /// Measured before the fix, on a 540-line file with six `run` procedures: the
+    /// same one-character edit rebuilt 1 procedure on some runs and all 40 on
+    /// others, and the cold build swung between 39 and 78 lattices.
+    ///
+    /// Asserting *which* definition wins (last in qualified-name order) is what
+    /// makes this a real guard — a same-process "run it twice" check would pass
+    /// even with the bug, since the order only varies between processes.
+    #[test]
+    fn short_name_collision_resolves_in_qualified_name_order() {
+        let m = module(
+            "proc ::b::run {} { global bbb; set bbb 1 }\n\
+             proc ::a::run {} { global aaa; set aaa 1 }\n",
+        );
+        let info = detect_global_write_procs(&m);
+        // Sorted qualified order is ::a::run then ::b::run, so ::b::run writes last.
+        assert_eq!(
+            info.get("run").expect("short key registered").names,
+            info.get("::b::run").expect("::b::run registered").names,
+            "the short `run` key must resolve to the last definition in \
+             qualified-name order, independent of hash-map iteration order",
+        );
+        assert!(info["run"].names.contains("bbb"));
+        assert!(!info["run"].names.contains("aaa"));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
@@ -91,11 +91,17 @@ pub fn detect_global_write_procs(module: &Module) -> HashMap<String, GlobalWrite
     // bit, never `is_traced()` — so a dialect-specific registry is
     // unnecessary here; the default registry resolves `global`/`variable`/
     // `upvar` identically across every dialect.
-    let registry = tcl_registry::CommandRegistry::build_default();
+    //
+    // Needing no *dialect* is not a reason to build one: this runs once per CFG
+    // build, i.e. several times per keystroke, so take the cached default rather
+    // than reconstructing a few hundred `CommandSpec`s each time (issue #1035,
+    // where `build_default()` here also leaked the generated mathop/mathfunc
+    // ensembles on every call).
+    let registry = tcl_registry::cache::default_registry();
     let mut own: HashMap<String, GlobalWriteInfo> = HashMap::new();
     let mut direct_calls: HashMap<String, BTreeSet<String>> = HashMap::new();
     for (qname, proc) in &module.procedures {
-        let info = own_body_global_writes(&proc.body, &registry);
+        let info = own_body_global_writes(&proc.body, registry);
         let calls = direct_call_targets(&proc.body);
         for key in registered_keys(qname) {
             own.insert(key.clone(), info.clone());

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -1260,7 +1260,16 @@ impl CfgBuilder {
 #[must_use]
 pub fn detect_upvar_procs(module: &Module) -> HashMap<String, UpvarInfo> {
     let mut result: HashMap<String, UpvarInfo> = HashMap::new();
-    for (qname, proc) in &module.procedures {
+    // Deterministic (qualified-name) iteration order, for the same reason
+    // [`prepare_cfg_context`] does it for `proc_params`: the *short* key below is
+    // written by every procedure sharing that short name, so last-write-wins must
+    // not be decided by the `HashMap`'s random per-process seed — this map is part
+    // of the `CfgContext` folded into every procedure's `function_lattice` memo
+    // key, and a nondeterministic winner makes the per-procedure cache hit or miss
+    // by luck of the process start (issue #1035 follow-up).
+    let mut entries: Vec<(&String, &crate::ir::Procedure)> = module.procedures.iter().collect();
+    entries.sort_by(|a, b| a.0.cmp(b.0));
+    for (qname, proc) in entries {
         let info = collect_upvar_targets(&proc.body, &proc.params);
         if info.is_empty() {
             continue;

--- a/rust/tcl-compiler/src/lattice_rebase.rs
+++ b/rust/tcl-compiler/src/lattice_rebase.rs
@@ -357,4 +357,43 @@ mod tests {
             assert_eq!(a.end(), b.end() + 100);
         }
     }
+
+    /// The load-bearing invariant behind the per-procedure lattice memo: a
+    /// procedure's body, normalised to offset 0, must be **byte-identical**
+    /// whether the procedure sits at offset X or at X+delta.
+    ///
+    /// `compilation_unit::build_for_memoized` normalises with exactly this call
+    /// before interning `FnLatticeKey`, so if this does not hold then inserting
+    /// a line anywhere above a procedure re-keys it and rebuilds its lattice,
+    /// its checks, and its taint cascade — the whole point of the memo is that
+    /// a *shift* is free and only a *content* change costs.
+    #[test]
+    fn offset_zero_body_is_identical_under_a_pure_shift() {
+        let reg = CommandRegistry::build_default();
+        let src = "proc a {x} {\n    set y $x\n    if {$y > 1} { puts hi } else { puts lo }\n    \
+                   foreach i {1 2 3} { incr y $i }\n    return $y\n}\n\
+                   proc b {} {\n    set z [expr {1 + 2}]\n    return $z\n}\n";
+        let shifted = format!("# a comment line that shifts everything below it\n{src}");
+        let base = CompilationUnit::build_for(src, &reg, false);
+        let moved = CompilationUnit::build_for(&shifted, &reg, false);
+
+        let at_zero = |cu: &CompilationUnit, qname: &str| {
+            let p = cu
+                .ir_module
+                .procedures
+                .get(qname)
+                .unwrap_or_else(|| panic!("{qname} lowered"));
+            let mut body = p.body.clone();
+            rebase_script(&mut body, -i64::from(p.span.start()));
+            body
+        };
+        for qname in ["::a", "::b"] {
+            assert_eq!(
+                at_zero(&base, qname),
+                at_zero(&moved, qname),
+                "offset-0 body for {qname} changed under a pure shift — every \
+                 procedure below an edit will miss its lattice memo",
+            );
+        }
+    }
 }

--- a/rust/tcl-compiler/src/optimiser/chain_fold.rs
+++ b/rust/tcl-compiler/src/optimiser/chain_fold.rs
@@ -77,13 +77,9 @@ pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
     // `None`, so fall back to a default-dialect registry rather than
     // panic — `trace`'s `ESTABLISHES_VARIABLE_TRACE` grammar is core Tcl,
     // present in every dialect's registry.
-    let default_registry;
-    let registry: &CommandRegistry = if let Some(r) = ctx.registry {
-        r
-    } else {
-        default_registry = CommandRegistry::build_default();
-        &default_registry
-    };
+    let registry: &CommandRegistry = ctx
+        .registry
+        .unwrap_or_else(|| tcl_registry::cache::default_registry());
     let top_protected = protected_vars(&cu.top_level, &cross, registry);
     fold_script(ctx, &cu.ir_module.top_level, &top_protected, 0);
     for (qname, proc) in &cu.ir_module.procedures {

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -1045,13 +1045,9 @@ fn evaluate_proc_with_constants(
     octal: Option<bool>,
 ) -> Option<ConstValue> {
     let seed = seed_params_from_args(params, args)?;
-    let default_registry;
-    let registry: &CommandRegistry = if let Some(r) = ctx.registry {
-        r
-    } else {
-        default_registry = CommandRegistry::build_default();
-        &default_registry
-    };
+    let registry: &CommandRegistry = ctx
+        .registry
+        .unwrap_or_else(|| tcl_registry::cache::default_registry());
     let empty_traced = std::collections::BTreeSet::new();
     let (traced_variables, has_dynamic_variable_trace) = match ctx.ir_module {
         Some(m) => (&m.traced_variables, m.has_dynamic_variable_trace),

--- a/rust/tcl-lsp-db/Cargo.toml
+++ b/rust/tcl-lsp-db/Cargo.toml
@@ -39,3 +39,7 @@ tcl-lsp-core = { path = "../tcl-lsp-core" }
 
 [dev-dependencies]
 rayon = "1"
+# `salsa_unstable` exposes `<dyn salsa::Database>::memory_usage()` — per-ingredient
+# slot counts and memo sizes. Used by the `edit_memory` example to attribute
+# per-edit growth to a specific interned key / tracked query (issue #1035).
+salsa = { version = "0.27", features = ["salsa_unstable"] }

--- a/rust/tcl-lsp-db/examples/edit_memory.rs
+++ b/rust/tcl-lsp-db/examples/edit_memory.rs
@@ -70,13 +70,24 @@ fn main() {
     let src = std::fs::read_to_string(&path).expect("read source file");
     let dialect = "tcl8.6";
 
-    // Type inside a procedure body, so the body-keyed interned structs
+    // Type inside a procedure *body*, so the body-keyed interned structs
     // (`ProcBodyKey` / `ItemBodyKey` / `FnLatticeKey` / `OptDepsKey`) see a new
     // key on every keystroke — exactly what editing does.
-    let edit_pos = src
-        .find("\nproc ")
-        .and_then(|p| src[p..].find('{').map(|b| p + b + 1))
-        .unwrap_or(src.len() / 2);
+    //
+    // Ask the analyser for `body_span` rather than scanning for a brace: in
+    // `proc name {args} {body}` the first `{` after `proc` opens the *parameter
+    // list*, so a naive scan types into the parameters instead. That still
+    // parses, so nothing fails loudly — it just measures the wrong thing, and a
+    // parameter edit additionally re-keys every procedure's lattice through the
+    // module-wide `proc_params` context rather than isolating one body.
+    let edit_pos = Analyser::new()
+        .analyse(&src, dialect)
+        .all_procs
+        .values()
+        .map(|p| p.body_span)
+        .filter(|s| s.end() > s.start())
+        .max_by_key(|s| s.end() - s.start())
+        .map_or(src.len() / 2, |s| s.start() as usize);
 
     let mut db = TclDatabase::default();
     let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);

--- a/rust/tcl-lsp-db/examples/edit_memory.rs
+++ b/rust/tcl-lsp-db/examples/edit_memory.rs
@@ -1,0 +1,208 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Resident-memory growth across a *typing session* (issue #1035).
+//!
+//! `tail_profile` alternates between two fixed texts, so the content-keyed
+//! interned structs only ever see two distinct bodies and nothing accumulates —
+//! which is why it measured the incremental path as healthy while real editing
+//! grew without bound.  This drives the buffer the way an editor does instead:
+//! every keystroke produces a **fresh, never-seen-before** text (of constant
+//! length, so growth can never be blamed on a bigger input), and every keystroke
+//! runs the production diagnostic queries.
+//!
+//! The `mode` argument bisects the growth onto a subsystem, which is how #1035
+//! was localised: `set` (input write only) stayed flat, while `nosalsa` — the
+//! analyser called with no query database at all — leaked just as steadily,
+//! placing the bug in the compiler rather than the incremental layer.
+//!
+//! Usage: `cargo run --release --example edit_memory -- [edits] [mode] [file]`
+//! where `mode` is `both` (default), `fa`, `cc`, `set`, or `nosalsa`.
+
+use salsa::Setter as _;
+use tcl_compiler::analyser::{Analyser, NonAsciiMode};
+use tcl_lsp_db::{
+    AnalyserConfig, SourceFile, TclDatabase, compiler_check_diagnostics, file_analysis_incremental,
+};
+
+/// Resident set size in KiB, read from `/proc/self/statm` (pages) — no
+/// allocator introspection, so it also catches arena/`mmap` growth.
+fn rss_kib() -> u64 {
+    let statm = std::fs::read_to_string("/proc/self/statm").expect("read /proc/self/statm");
+    let pages: u64 = statm
+        .split_whitespace()
+        .nth(1)
+        .expect("resident field")
+        .parse()
+        .expect("resident pages");
+    pages * 4
+}
+
+fn main() {
+    let mut args = std::env::args().skip(1);
+    let edits: u32 = args.next().and_then(|a| a.parse().ok()).unwrap_or(200);
+    // Which work each keystroke drives, so the growth can be bisected onto a
+    // subsystem: `both` (production), `fa` / `cc` (one query each), `set` (input
+    // write only — no analysis), `nosalsa` (the analyser called directly, with
+    // no query database in the picture at all).
+    let mode = args.next().unwrap_or_else(|| "both".to_owned());
+    let rel = args
+        .next()
+        .unwrap_or_else(|| "samples/tcl/09_long_code.tcl".to_owned());
+    let path = std::path::PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .join("../..")
+        .join(&rel);
+    let src = std::fs::read_to_string(&path).expect("read source file");
+    let dialect = "tcl8.6";
+
+    // Type inside a procedure body, so the body-keyed interned structs
+    // (`ProcBodyKey` / `ItemBodyKey` / `FnLatticeKey` / `OptDepsKey`) see a new
+    // key on every keystroke — exactly what editing does.
+    let edit_pos = src
+        .find("\nproc ")
+        .and_then(|p| src[p..].find('{').map(|b| p + b + 1))
+        .unwrap_or(src.len() / 2);
+
+    let mut db = TclDatabase::default();
+    let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
+    let config = AnalyserConfig::new(
+        &db,
+        Vec::new(),
+        NonAsciiMode::Default,
+        Vec::new(),
+        None,
+        None,
+    );
+
+    println!(
+        "== {rel} ({} lines, {} bytes) — {edits} keystrokes, mode={mode} ==",
+        src.lines().count(),
+        src.len()
+    );
+
+    // Cold build first, so the baseline excludes one-time registry/parse cost.
+    let _ = file_analysis_incremental(&db, file, config);
+    let _ = compiler_check_diagnostics(&db, file, config);
+    let base = rss_kib();
+    println!("  after cold build:        {base:>8} KiB RSS");
+
+    for i in 1..=edits {
+        // A distinct, **constant-length** body on every edit: the buffer never
+        // repeats (an editor never replays an old text) but it also never grows,
+        // so per-edit growth cannot be blamed on a bigger input. `{i:08}` keeps
+        // the inserted statement byte-identical in length across the whole run.
+        let mut text = src.clone();
+        text.insert_str(edit_pos, &format!("\n    set probe_v {i:08}"));
+
+        if mode == "nosalsa" {
+            // No database at all: just the analyser, on a fresh text each time.
+            std::hint::black_box(Analyser::new().analyse(&text, dialect));
+        } else {
+            file.set_text(&mut db).to(text);
+            if mode == "both" || mode == "fa" {
+                let _ = file_analysis_incremental(&db, file, config);
+            }
+            if mode == "both" || mode == "cc" {
+                let _ = compiler_check_diagnostics(&db, file, config);
+            }
+        }
+
+        if i % 20 == 0 || i == 1 {
+            let now = rss_kib();
+            println!(
+                "  after {i:>4} edits:        {now:>8} KiB RSS   (+{} KiB, {:.1} KiB/edit)",
+                now.saturating_sub(base),
+                f64::from(u32::try_from(now.saturating_sub(base)).unwrap_or(u32::MAX))
+                    / f64::from(i),
+            );
+        }
+    }
+
+    report_ingredients(&db, edits);
+
+    // Is the query graph holding it?  Drop the database and re-measure: salsa's
+    // interned garbage collector recycles slots (the counts above plateau), so a
+    // resident set that does not fall here is not being held by anything salsa
+    // still owns.
+    let before_drop = rss_kib();
+    drop(db);
+    println!("\n== where the resident memory lives ==");
+    println!("  peak (db alive):         {before_drop:>8} KiB RSS");
+    println!("  after drop(db):          {:>8} KiB RSS", rss_kib());
+}
+
+/// Per-interned-struct slot counts and per-query memo counts, to decide whether
+/// the query graph is the one growing.  A count that tracks the edit number is a
+/// key salsa's interned garbage collector never reclaimed; counts that plateau
+/// while RSS climbs mean the memory is *not* salsa's, and the next step is to
+/// bisect with `mode` rather than to keep tuning the query keys.
+///
+/// (The `bytes` column is stack size only — these ingredients define no
+/// `heap_size`, so the `Arc` payloads behind them are not counted. Read it as a
+/// relative signal, never as a memory total.)
+fn report_ingredients(db: &TclDatabase, edits: u32) {
+    let usage = <dyn salsa::Database>::memory_usage(db);
+
+    let mut structs: Vec<_> = usage
+        .structs
+        .iter()
+        .filter(|s| s.count() > 0)
+        .map(|s| {
+            (
+                s.debug_name(),
+                s.count(),
+                s.size_of_fields(),
+                s.heap_size_of_fields(),
+            )
+        })
+        .collect();
+    structs.sort_by_key(|&(_, count, ..)| std::cmp::Reverse(count));
+
+    println!("\n== interned / input slots after {edits} edits ==");
+    println!("  {:<28} {:>8}  {:>12}", "ingredient", "slots", "bytes");
+    for (name, count, fields, heap) in structs.iter().take(12) {
+        println!(
+            "  {name:<28} {count:>8}  {:>12}",
+            fields + heap.unwrap_or(0)
+        );
+    }
+
+    let mut queries: Vec<_> = usage
+        .queries
+        .values()
+        .filter(|q| q.count() > 0)
+        .map(|q| {
+            (
+                q.debug_name(),
+                q.count(),
+                q.size_of_fields(),
+                q.heap_size_of_fields(),
+            )
+        })
+        .collect();
+    queries.sort_by_key(|&(_, count, ..)| std::cmp::Reverse(count));
+
+    println!("\n== memoised query results after {edits} edits ==");
+    println!("  {:<28} {:>8}  {:>12}", "query output", "memos", "bytes");
+    for (name, count, fields, heap) in queries.iter().take(12) {
+        println!(
+            "  {name:<28} {count:>8}  {:>12}",
+            fields + heap.unwrap_or(0)
+        );
+    }
+}

--- a/rust/tcl-lsp-db/examples/tail_profile.rs
+++ b/rust/tcl-lsp-db/examples/tail_profile.rs
@@ -63,18 +63,33 @@ fn main() {
     let t_analyse = time("analyse (full whole-file walk)", 3, || {
         Analyser::new().analyse(&src, dialect)
     });
-    let t_per_item = time("analyse_per_item (no memo)", 3, || {
+    time("analyse_per_item (no memo)", 3, || {
         Analyser::new().analyse_per_item(&src, dialect)
     });
     let t_structure = time("structure_only().analyse (no diagnostics)", 3, || {
         Analyser::new().structure_only().analyse(&src, dialect)
     });
+    // Ask the analyser, don't infer it from the clock.  This used to compare
+    // `t_per_item` against `t_analyse` with a 15% band and call them equal,
+    // which made the verdict a function of whatever else happened to be slow:
+    // removing the per-CFG-build `CommandRegistry::build_default()` (issue
+    // #1035) moved the two timings apart and flipped `09_long_code.tcl` from
+    // "fallback" to "fast path" — while the analyser's behaviour was unchanged,
+    // and *falling back* is the true answer for that file either way.  Two
+    // paths costing about the same never implied they were the same path.
+    //
+    // `took_fast_path` is set by `analyse_per_item_with` itself: `true` only
+    // when the run completed on the incremental path, `false` on every fallback
+    // (incomplete script, stub overlay, Tk, ghost recovery, a partial command,
+    // an E-code).  Costs stay measured; the structural claim gets asked.
+    let mut probe = Analyser::new();
+    let _ = probe.analyse_per_item(&src, dialect);
     println!(
         "  -> fallback to full walk? {}  (diagnostic-emit cost ~= {:.0} ms)",
-        if (t_per_item - t_analyse).abs() < t_analyse * 0.15 {
-            "YES (per_item ~= analyse)"
-        } else {
+        if probe.took_fast_path {
             "NO (fast path)"
+        } else {
+            "YES (analyse_per_item fell back)"
         },
         t_analyse - t_structure,
     );

--- a/rust/tcl-lsp-db/examples/tail_profile.rs
+++ b/rust/tcl-lsp-db/examples/tail_profile.rs
@@ -215,13 +215,9 @@ fn main() {
     rerun_breadth(&src, dialect, edit_pos, cu.functions().count());
 }
 
-/// Count salsa `WillExecute` events per query across one single-procedure body
-/// edit.  Proves the per-proc memo rebuilds ONE procedure (`function_lattice` /
-/// `item_body_analysis` / `taint_cascade`) while `compiler_check_diagnostics`
-/// re-executes wholesale — so `run_all_checks`, which runs inside it and is not
-/// itself a salsa query, re-checks every function every edit.
-fn rerun_breadth(src: &str, dialect: &str, fallback_pos: usize, n_functions: usize) {
-    println!("\n== salsa re-execution breadth (one body edit, warm db) ==");
+/// Count salsa `WillExecute` events per query for one edit, against a db already
+/// warm on `src`.  Returns `(cold, warm)` event logs.
+fn breadth_for_edit(src: &str, dialect: &str, edited: &str) -> (Vec<String>, Vec<String>) {
     let log: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
     let sink = Arc::clone(&log);
     let mut db = TclDatabase::with_event_logger(move |k| sink.lock().unwrap().push(k));
@@ -237,6 +233,26 @@ fn rerun_breadth(src: &str, dialect: &str, fallback_pos: usize, n_functions: usi
     let _ = file_analysis_incremental(&db, file, cfg);
     let _ = compiler_check_diagnostics(&db, file, cfg);
     let cold: Vec<String> = std::mem::take(&mut *log.lock().unwrap());
+    file.set_text(&mut db).to(edited.to_owned());
+    let _ = file_analysis_incremental(&db, file, cfg);
+    let _ = compiler_check_diagnostics(&db, file, cfg);
+    let warm: Vec<String> = std::mem::take(&mut *log.lock().unwrap());
+    (cold, warm)
+}
+
+/// Count salsa `WillExecute` events per query across several *kinds* of
+/// single-character edit, on a warm db.
+///
+/// The interesting comparison is between an edit that changes a body's content
+/// and one that changes only where every body *sits*.  The per-proc memo keys
+/// (`ProcBodyKey` / `FnLatticeKey` / `ItemBodyKey`) are offset-normalised — they
+/// hold the body's text and context but not its position — so a pure shift
+/// should re-intern to the same keys and hit every memo, while a content edit
+/// should rebuild exactly one procedure.  Anything that re-executes on the shift
+/// row is work the offset-invariance was supposed to have removed, i.e. rework
+/// caused by a position that failed to be inherited rather than stored.
+fn rerun_breadth(src: &str, dialect: &str, fallback_pos: usize, n_functions: usize) {
+    println!("\n== salsa re-execution breadth (one edit, warm db) ==");
     // A single-character body edit that changes a *token* (a letter inserted after
     // the first alphanumeric character of the largest proc body) — not whitespace,
     // which the offset-invariant key normalises away.  Exactly one procedure's body
@@ -255,25 +271,45 @@ fn rerun_breadth(src: &str, dialect: &str, fallback_pos: usize, n_functions: usi
                 .map(|off| lo + off + 1)
         })
         .unwrap_or(fallback_pos);
-    let mut edited_tok = src.to_owned();
-    edited_tok.insert(body_pos, 'Z');
-    file.set_text(&mut db).to(edited_tok);
-    let _ = file_analysis_incremental(&db, file, cfg);
-    let _ = compiler_check_diagnostics(&db, file, cfg);
-    let warm: Vec<String> = std::mem::take(&mut *log.lock().unwrap());
+
+    let mut body_edit = src.to_owned();
+    body_edit.insert(body_pos, 'Z');
+    // Pure shift: a fresh comment line at the very top. Not one byte of any
+    // procedure's text changes — every body just moves down by 8 bytes.
+    let shift_edit = format!("# shift\n{src}");
+
+    let scenarios = [
+        ("body token edit", body_edit),
+        ("prepend line (pure shift)", shift_edit),
+    ];
+    let mut cold_once: Option<Vec<String>> = None;
+    let mut warms: Vec<(&str, Vec<String>)> = Vec::new();
+    for (label, edited) in &scenarios {
+        let (cold, warm) = breadth_for_edit(src, dialect, edited);
+        cold_once.get_or_insert(cold);
+        warms.push((label, warm));
+    }
+    let cold = cold_once.unwrap_or_default();
+
+    println!(
+        "  {:<34} {:>6}  {:>16}  {:>16}",
+        "query", "cold", scenarios[0].0, scenarios[1].0
+    );
     let row = |q: &str| {
         let c = cold.iter().filter(|s| s.contains(q)).count();
-        let w = warm.iter().filter(|s| s.contains(q)).count();
-        println!("  {q:<34} cold {c:>5}   1-edit {w:>5}");
+        let a = warms[0].1.iter().filter(|s| s.contains(q)).count();
+        let b = warms[1].1.iter().filter(|s| s.contains(q)).count();
+        println!("  {q:<34} {c:>6}  {a:>16}  {b:>16}");
     };
-    println!("  per-proc memoised (rebuild only the edited procedure):");
+    println!("  per-proc memoised (should rebuild only the edited procedure):");
     row("item_body_analysis");
     row("function_lattice");
     row("taint_cascade");
     println!("  whole-file (re-run in full regardless of which procedure changed):");
     row("compilation_unit");
     row("compiler_check_diagnostics");
-    let cc = warm
+    let cc = warms[0]
+        .1
         .iter()
         .filter(|s| s.contains("compiler_check_diagnostics"))
         .count();

--- a/rust/tcl-registry/src/cache.rs
+++ b/rust/tcl-registry/src/cache.rs
@@ -34,6 +34,25 @@ use tcl_dialect::DialectProfile;
 
 use crate::registry::CommandRegistry;
 
+/// The process-wide **plain default** registry — exactly what
+/// [`CommandRegistry::build_default`] produces, built once.
+///
+/// For callers that genuinely need no dialect layering and reached for
+/// `build_default()` to say so.  `build_default()` is a *constructor*, not an
+/// accessor: it rebuilds several hundred `CommandSpec`s (and, before issue
+/// #1035, leaked the generated `tcl::mathop` / `tcl::mathfunc` ensembles) on
+/// every call.  Hot paths that run per CFG build — so, per keystroke — were
+/// calling it directly; they want this.
+///
+/// Deliberately *not* routed through [`registry_for_profile`]: that would
+/// attach the `PLAIN_TCL` profile and its (currently empty) base layers, which
+/// is a behavioural claim this accessor does not need to make.  Same
+/// constructor, same bytes, once.
+pub fn default_registry() -> &'static CommandRegistry {
+    static DEFAULT: OnceLock<CommandRegistry> = OnceLock::new();
+    DEFAULT.get_or_init(CommandRegistry::build_default)
+}
+
 /// Return the cached registry for `profile`, building it on first use.
 ///
 /// The registry is the default build plus the profile's

--- a/rust/tcl-registry/src/commands/tcl/mathfunc_generated.rs
+++ b/rust/tcl-registry/src/commands/tcl/mathfunc_generated.rs
@@ -42,18 +42,29 @@
 //! tracks the `expr` grammar, not the command table) only became callable
 //! as `::tcl::mathfunc::abs` from 8.5 on. A function introduced later
 //! (`isnan` in 9.0, `gamma` in 9.1, …) keeps its own, tighter gate.
+use std::sync::OnceLock;
+
 use crate::prelude::*;
 use tcl_syntax::expr::mathfunc::{self, MathFuncSince};
 
 /// All `tcl::mathfunc` math-function command specs (both qualified
 /// spellings).
+///
+/// Built **once per process** and cloned per call — see
+/// `mathop_generated::specs` for why memoising here is what bounds [`leak`]
+/// (issue #1035).
 #[must_use]
 pub fn specs() -> Vec<CommandSpec> {
-    let mut out = Vec::new();
-    for spec in mathfunc::all() {
-        push_spellings(&mut out, &spec);
-    }
-    out
+    static SPECS: OnceLock<Vec<CommandSpec>> = OnceLock::new();
+    SPECS
+        .get_or_init(|| {
+            let mut out = Vec::new();
+            for spec in mathfunc::all() {
+                push_spellings(&mut out, &spec);
+            }
+            out
+        })
+        .clone()
 }
 
 /// The two spellings a math function is invocable under as a command (see
@@ -125,9 +136,12 @@ fn to_registry_arity(a: tcl_syntax::expr::operators::CommandArity) -> Arity {
     Arity::new(min, max)
 }
 
-/// Leak an owned `String` to a `'static` `&str` — safe and cheap here: every
-/// mathfunc `CommandSpec` is built exactly once, at registry-construction
-/// time, from a small fixed set (2 spellings x ~56 functions).
+/// Leak an owned `String` to a `'static` `&str`.
+///
+/// Bounded **only** because [`specs`] memoises its result: this runs once per
+/// process, over a small fixed set (2 spellings x ~56 functions).  Registry
+/// construction itself is *not* a one-off (issue #1035), so any new caller must
+/// go through [`specs`].
 fn leak(s: String) -> &'static str {
     &*s.leak()
 }
@@ -141,6 +155,24 @@ fn leak_slice<T>(v: Vec<T>) -> &'static [T] {
 mod tests {
     use super::specs;
     use crate::prelude::DialectSet;
+
+    /// Issue #1035, mathfunc half — see `mathop_generated`'s twin for the full
+    /// rationale.  `specs()` leaks `&'static` strings, so it must memoise:
+    /// pointer identity across two calls is what proves it did.
+    #[test]
+    fn specs_are_built_once_and_never_releaked() {
+        let first = specs();
+        let second = specs();
+        assert!(!first.is_empty(), "the mathfunc ensemble must not be empty");
+        assert_eq!(first.len(), second.len());
+        for (a, b) in first.iter().zip(second.iter()) {
+            assert!(
+                std::ptr::eq(a.name, b.name),
+                "`{}` was re-leaked: specs() must memoise, not rebuild",
+                a.name
+            );
+        }
+    }
 
     /// Adversarial-review finding: this file's own translation from
     /// `MathFuncSpec` to `CommandSpec` (`push_spellings`/`since_to_dialects`/

--- a/rust/tcl-registry/src/commands/tcl/mathop_generated.rs
+++ b/rust/tcl-registry/src/commands/tcl/mathop_generated.rs
@@ -41,19 +41,33 @@
 //! fold. `&&`/`||` are absent for a different, structural reason: `BinOp::And`/
 //! `BinOp::Or`'s `spec().mathop_shape` is `None` (TIP 174 excludes them —
 //! a command can't short-circuit its own already-evaluated arguments).
+use std::sync::OnceLock;
+
 use crate::prelude::*;
 use tcl_syntax::expr::operators::{ALL_BIN_OPS, ALL_UNARY_OPS, CommandArity, OperatorSpec};
 
 /// All `tcl::mathop` operator-command specs (every spelling).
+///
+/// Built **once per process** and cloned per call.  The spec fields are
+/// `&'static` (see [`leak`]), so the clone is a shallow copy of pointers, and
+/// memoising here is what makes those leaks a one-off: `build_default()` is not
+/// a once-per-process call — the CFG builder and the optimiser's fold paths
+/// rebuild a registry per invocation — so building the specs afresh each time
+/// leaked the whole ensemble on every rebuild (issue #1035).
 pub fn specs() -> Vec<CommandSpec> {
-    let mut out = Vec::new();
-    for &op in ALL_BIN_OPS {
-        push_spellings(&mut out, op.spec());
-    }
-    for &op in ALL_UNARY_OPS {
-        push_spellings(&mut out, op.spec());
-    }
-    out
+    static SPECS: OnceLock<Vec<CommandSpec>> = OnceLock::new();
+    SPECS
+        .get_or_init(|| {
+            let mut out = Vec::new();
+            for &op in ALL_BIN_OPS {
+                push_spellings(&mut out, op.spec());
+            }
+            for &op in ALL_UNARY_OPS {
+                push_spellings(&mut out, op.spec());
+            }
+            out
+        })
+        .clone()
 }
 
 /// The three spellings a mathop operator command is invocable under.
@@ -116,10 +130,13 @@ fn to_registry_arity(a: CommandArity) -> Arity {
     Arity::new(min, max)
 }
 
-/// Leak an owned `String` to a `'static` `&str` — safe and cheap here: every
-/// mathop `CommandSpec` is built exactly once, at registry-construction
-/// time, from a small fixed set (3 spellings x ~30 gated operators), not
-/// per-lookup.
+/// Leak an owned `String` to a `'static` `&str`.
+///
+/// Bounded **only** because [`specs`] memoises its result: this runs once per
+/// process, over a small fixed set (3 spellings x ~30 gated operators).  It is
+/// *not* bounded by registry construction being a one-off — it isn't (issue
+/// #1035: a per-CFG-build `CommandRegistry::build_default()` leaked the whole
+/// ensemble on every keystroke).  Any new caller must go through [`specs`].
 fn leak(s: String) -> &'static str {
     &*s.leak()
 }
@@ -133,6 +150,32 @@ fn leak_slice<T>(v: Vec<T>) -> &'static [T] {
 mod tests {
     use super::specs;
     use crate::prelude::DialectSet;
+
+    /// Issue #1035: `specs()` `Box::leak`s its `&'static` name / synopsis /
+    /// snippet strings, so it must build them **once per process** — every
+    /// later call has to hand back the same allocations.  `CommandRegistry`
+    /// construction is not a one-off (the CFG builder and the optimiser's fold
+    /// paths each rebuilt one per invocation), so an un-memoised `specs()`
+    /// leaked the whole ensemble on every keystroke: ~500 KiB per edit,
+    /// unbounded, and invisible to the query database that appeared to own it.
+    ///
+    /// Pointer identity is the assertion that actually catches a regression —
+    /// equal-but-freshly-leaked strings would pass a `==` comparison while
+    /// leaking exactly as before.
+    #[test]
+    fn specs_are_built_once_and_never_releaked() {
+        let first = specs();
+        let second = specs();
+        assert!(!first.is_empty(), "the mathop ensemble must not be empty");
+        assert_eq!(first.len(), second.len());
+        for (a, b) in first.iter().zip(second.iter()) {
+            assert!(
+                std::ptr::eq(a.name, b.name),
+                "`{}` was re-leaked: specs() must memoise, not rebuild",
+                a.name
+            );
+        }
+    }
 
     /// Adversarial-review finding: `specs()`'s translation from
     /// `OperatorSpec` to `CommandSpec` (`push_spellings`/`to_registry_arity`)


### PR DESCRIPTION
## Summary

This PR addresses issue #1035, which manifested as unbounded memory growth during editing sessions and nondeterministic per-keystroke performance. The root causes were:

1. **Memory leak in mathop/mathfunc specs**: `CommandRegistry::build_default()` was called per CFG build (multiple times per keystroke), leaking ~500 KiB per edit via `Box::leak` in the generated operator/function specs. Fixed by memoising `specs()` with `OnceLock`.

2. **Nondeterministic procedure iteration**: HashMap iteration over procedures in `detect_global_write_procs` and `detect_upvar_procs` produced non-deterministic results when multiple procedures shared a short name. This caused the same file to either rebuild 1 procedure or all 40 on a single keystroke, depending on process startup hash seed. Fixed by sorting entries before iteration.

3. **Registry construction overhead**: Unnecessary `CommandRegistry::build_default()` calls in hot paths (CFG builder, optimiser fold/propagation). Replaced with cached `default_registry()` accessor.

4. **Telemetry gap**: The incremental analysis path had no way to report *why* it fell back to full analysis. Added `PerItemFallback` enum to track which gate fired (incomplete script, stub directive, Tk checks, ghost recovery, etc.), enabling performance analysis.

5. **Offset-invariance verification**: Added test to verify that procedure bodies remain byte-identical under pure position shifts, validating the load-bearing invariant of the per-procedure lattice memo.

## Changes

- **tcl-compiler/src/analyser/per_item.rs**: Added `PerItemFallback` enum with 11 variants tracking fallback reasons. Modified `analyse_per_item_with` to record which gate fired instead of a simple boolean.

- **tcl-compiler/src/analyser/state.rs**: Added `per_item_fallback: Option<PerItemFallback>` field to `Analyser` for telemetry.

- **tcl-registry/src/commands/tcl/mathop_generated.rs** and **mathfunc_generated.rs**: Wrapped `specs()` with `OnceLock` to build once per process. Added tests verifying pointer identity across calls.

- **tcl-registry/src/cache.rs**: Added `default_registry()` accessor for callers that need the plain default without dialect layering.

- **tcl-compiler/src/cfg_builder/global_write_info.rs**: Sorted procedure iteration by qualified name; replaced `build_default()` with cached accessor.

- **tcl-compiler/src/cfg_builder/mod.rs** and **optimiser/chain_fold.rs**, **propagation.rs**: Replaced `build_default()` calls with cached accessor.

- **tcl-compiler/src/lattice_rebase.rs**: Added test verifying offset-zero body invariant under pure shifts.

- **tcl-lsp-db/examples/tail_profile.rs**: Updated to use `took_fast_path` and `per_item_fallback` fields instead of timing heuristics for fallback detection.

- **New examples**: 
  - `tcl-compiler/examples/per_item_fallbacks.rs`: Corpus analysis tool reporting fallback rates weighted by file count, source lines, and milliseconds. Includes Tk gate audit.
  - `tcl-lsp-db/examples/edit_memory.rs`: Simulates typing sessions with fresh text on every keystroke to measure resident memory growth and identify which subsystem leaks.

## Validation

- Existing unit tests pass (offset-invariance, mathop/mathfunc memoisation).
- New examples enable corpus-level performance analysis and memory profiling.
- The `per_item_fallback` telemetry allows identifying which gates fire most frequently and expensively.

https://claude.ai/code/session_01AYaLHLpBihuDJ97ALkpM7c