### PR TITLE
Compiler correctness: uplevel #0 context, class-liveness typing, call-graph reachability, scan modes, unknown-handler seeding (#980 #1013 #1015 #1024 #1025 #1044, pins #979)

### DIFF
--- a/docs/design/compiler/fp-audit-todo.md
+++ b/docs/design/compiler/fp-audit-todo.md
@@ -360,8 +360,21 @@ inspected · counts are dialect-aware corpus firings as of the last sweep.
   (non-`package provide`) file `source`d by another that calls its procs
   differently (issue #977); dynamic dispatch (`$cmd args`, issue #976);
   `CommandPrefix`-role indirection (`trace add variable … command cb`,
-  `-command` callback options, issue #978). Still open: `namespace ensemble
-  configure -map` redirection (issue #979).
+  `-command` callback options, issue #978); `uplevel #0` body namespace
+  context (issue #980).
+  **`namespace ensemble … -map` redirection (issue #979)** — investigated
+  and closed as *already sound, bluntly*: the scan has no model of ensemble
+  dispatch, but the registry marks `namespace ensemble` with
+  `Traits::EXPORTS_COMMAND`, which declines whole-module seeding, so a proc
+  reached only through a `-map` target never folds.  tclsh8.6/9.0-confirmed
+  that `namespace ensemble create -command myens -map {go helper}` +
+  `myens go dev` really does reach `helper` with `"dev"`.  Nothing pinned
+  that, so a registry edit narrowing the trait — or a precision follow-up
+  that starts resolving *some* ensemble maps — would silently reopen
+  FP-IPCP-01's exact shape; `ensemble_map_redirected_caller_does_not_fold_issue_979`
+  now guards the mechanism, whatever replaces it.  Resolving ensemble maps
+  precisely (so an *agreeing* mapped caller could still fold) remains an
+  optional precision follow-up, not a soundness gap.
   Traced end-to-end: the same `SccpResult` feeds I230, the optimiser's O101
   fold and O107 dead-code suggestions (all suggestion-only text rewrites,
   never applied to the compiled CFG/IR — confirmed codegen/`tcl-vm`/WASM
@@ -407,31 +420,41 @@ inspected · counts are dialect-aware corpus firings as of the last sweep.
     (top level, every proc/method/body-unit, and every nested control-flow
     body) checking for a resolved `Call`/`Barrier` statement whose command
     is `package` with a literal `provide` first argument.
-  **Newly confirmed (not merely theoretical) by the same review, deliberately
-  left open:** `uplevel #0 { … }` also resolves against global
-  (tclsh8.6-confirmed), and reproduces the identical misattribution +
-  phantom-fold pair as the `TclOO`/namespace-eval cases — but the scan never
-  reaches that body as an `UpFrame` statement at all. `Statement::UpFrame`
-  keeps its body as a nested `Script` that CFG construction does *not*
-  flatten into blocks (re-confirmed during the #976 work, correcting this
-  entry's original "is inlined into CFG blocks" reading), so the walk over
-  `block.statements` skips it and the call is seen only through the
-  enclosing `proc` statement's own `ArgRole::Body` argument, re-segmented in
-  the frame that `proc` statement sits in — the declaring namespace, not
-  global. Fixing it properly needs the registry to say *which* argument of a
-  frame-shifting command is its level (`uplevel`'s level detection is a
-  private spec helper today, and the body-text recursion sees only raw
-  words), so the scan can switch its resolution context to global for an
-  absolute `#0` — a registry extension, not the one-line namespace-context
-  overrides above, so left as a pinned, `#[ignore]`d regression
-  (`uplevel_zero_body_resolves_against_global_not_enclosing_namespace`) for
-  follow-up rather than a rushed fix. `uplevel N` for any relative
-  (non-`#0`) level remains a separate, permanent approximation: the target
-  frame's namespace depends on the live call stack, which is undecidable by
-  a single-file static analysis. Tests: 4 new cases in the same
-  `call_site_param_constants` module (19 passing + 1 pinned `#[ignore]`),
-  plus the `namespace_eval_body_unit_does_not_change_bytecode` regression
-  in `regex_source.rs` updated for the corrected qname format.
+  **Newly confirmed by the same review, since CLOSED (issue #980):**
+  `uplevel #0 { … }` also resolves against global (tclsh8.6/9.0-confirmed),
+  and reproduced the identical misattribution + phantom-fold pair as the
+  `TclOO`/namespace-eval cases, but through two distinct routes. The scan
+  never reached that body as an `UpFrame` statement at all —
+  `Statement::UpFrame` keeps its body as a nested `Script` that CFG
+  construction does *not* flatten into blocks, so the walk over
+  `block.statements` skips it — while the *enclosing* `proc` statement's own
+  `ArgRole::Body` argument was re-segmented in the frame that `proc`
+  statement sits in, inventing a call to a same-named proc in the declaring
+  namespace. Both halves are fixed:
+  - `build_extra_call_site_scan_contexts` now builds a bare CFG for every
+    static `uplevel` body (`upframe_scan_bodies`). `frame_shift == 0`
+    resolves as `"::top"` — the same global-resolving pseudo-qname a method
+    body is forced to — while a relative level keeps the enclosing unit's
+    namespace. Each gets a synthetic occurrence-unique CFG name so its
+    variable-scope facts never clobber another scope's.
+  - The `ArgRole::Body` recursion no longer re-walks a body the registry
+    marks `Traits::DEFINES_PROCEDURE`. A definition body does not run at the
+    definition site, and lowering already registers it as a procedure /
+    method / body unit the scan visits with the right context — the same
+    rule the `namespace eval ::abs { … }` guard beside it already applies,
+    generalised from "absolute `ArgRole::Name`" to the registry's own
+    "this command defines a procedure" fact.
+  `uplevel N` for any relative (non-`#0`) level remains a separate,
+  permanent approximation: the target frame's namespace depends on the live
+  call stack, which is undecidable by a single-file static analysis — now
+  pinned by `uplevel_relative_body_keeps_the_enclosing_units_namespace`
+  rather than left implicit. Tests: the pinned
+  `uplevel_zero_body_resolves_against_global_not_enclosing_namespace` is
+  un-ignored and passes; new
+  `conditionally_defined_proc_body_call_sites_are_still_counted` guards the
+  definition-body skip against losing a real call site; plus the
+  `namespace_eval_body_unit_does_not_change_bytecode` regression in
+  `regex_source.rs` updated for the corrected qname format.
 - [x] **FP-IPCP-02** I230 on a plain library file `source`d by a caller with
   a differing literal — CLOSED (issue #977). FP-IPCP-01's `package
   provide`-in-file guard covered a package file, but not the more common
@@ -666,6 +689,42 @@ inspected · counts are dialect-aware corpus firings as of the last sweep.
   Tests: five in `unit_scope` (own-unit withdrawal; reaches a linked file in
   both directions; leaves an unlinked one alone) and two end-to-end in
   `tcl-lsp-db` over a real two-file project with paths.
+
+- [x] **FP-IPCP-05** I230 on a module's own `unknown` handler — CLOSED
+  (issue #1044).  The last caller class the scan structurally could not
+  enumerate: Tcl dispatches *every* command word that resolves to nothing to
+  the interpreter's unresolved-command handler, passing the word itself
+  followed by that call's own arguments.  A module defining `proc unknown
+  {cmd args}` was therefore seeded from its *direct* callers alone, so
+  `unknown alpha` twice plus a `bogus beta` anywhere in the file bound `cmd`
+  to the constant `"alpha"` and folded `$cmd eq "alpha"` on a condition that
+  genuinely varies.  tclsh8.6/9.0-confirmed before fixing: `bogus beta gamma`
+  runs the handler with `cmd` = `bogus`, `args` = `beta gamma`; and a
+  namespace-local `proc unknown` is *not* consulted for unresolved words in
+  that namespace — `::unknown` handles them regardless of calling namespace,
+  so the lookup is global-scope only.
+  Which command is the handler is registry data, never a literal in the
+  compiler: a new `Traits::UNRESOLVED_COMMAND_HANDLER` (`declare_traits!`
+  bit, room already available after #1031's `u128` widening) is carried by
+  the `unknown` spec, and `unit_scope::unresolved_command_handler` resolves
+  it against the unit's — or, cross-file, the project's — procedure set.
+  When `resolve_target` finds no callee for a literal word that the registry
+  also does not know, `record_unresolved_word_dispatch` records the handler's
+  invocation with `(word, args…)` through the same `record_invocation` path
+  everything else uses, so the evidence union is exactly the values the
+  handler's parameters really see rather than a blanket poison.
+  Deliberately over-inclusive on the residue: a word bound by something the
+  scan does not model (a class command, an ensemble, a coroutine) also reads
+  as unresolved and contributes an extra value, which can only *retract* a
+  fold, never manufacture one — and costs nothing at all in a module with no
+  handler, the common case and the whole regression risk.
+  Tests: six in `unit_scope` (the repro; the word's own arguments following
+  it; no-handler module unaffected; handler with agreeing callers and no
+  unresolved words still seeds; a registry builtin is not an unresolved
+  word; an unenumerable dispatch still poisons rather than naming the
+  handler) plus three end-to-end in
+  `diagnostics::unresolved_word_reaching_the_unknown_handler_does_not_fire_i230`
+  and its TP/TN controls.
 
 ## Confirmed true-positive this audit (sampled, no change needed)
 

--- a/docs/design/compiler/fp-audit-todo.md
+++ b/docs/design/compiler/fp-audit-todo.md
@@ -713,18 +713,140 @@ inspected · counts are dialect-aware corpus firings as of the last sweep.
   invocation with `(word, args…)` through the same `record_invocation` path
   everything else uses, so the evidence union is exactly the values the
   handler's parameters really see rather than a blanket poison.
-  Deliberately over-inclusive on the residue: a word bound by something the
-  scan does not model (a class command, an ensemble, a coroutine) also reads
-  as unresolved and contributes an extra value, which can only *retract* a
-  fold, never manufacture one — and costs nothing at all in a module with no
-  handler, the common case and the whole regression risk.
-  Tests: six in `unit_scope` (the repro; the word's own arguments following
-  it; no-handler module unaffected; handler with agreeing callers and no
-  unresolved words still seeds; a registry builtin is not an unresolved
+  **Superseded in part — see MC-UNKNOWN-SEED below.** This entry originally
+  claimed the invented-dispatch residue "can only *retract* a fold, never
+  manufacture one". That was false while those dispatches were the handler's
+  *only* recorded call sites, and the adversarial review demonstrated the
+  miscompile. The handler is now poisoned unconditionally and the recorded
+  dispatches are extra evidence only, which is what finally makes the claim
+  true.
+  Tests: nine in `unit_scope` (the repro; the word's own arguments following
+  it; no-handler module unaffected; a registry builtin is not an unresolved
   word; an unenumerable dispatch still poisons rather than naming the
-  handler) plus three end-to-end in
+  handler; plus the four listed under MC-UNKNOWN-SEED) and one on the
+  registry's single-carrier invariant, plus three end-to-end in
   `diagnostics::unresolved_word_reaching_the_unknown_handler_does_not_fire_i230`
   and its TP/TN controls.
+
+## Adversarial review of the #1044/#1015/#1013 round — CLOSED
+
+Every item below was confirmed against tclsh8.6 and tclsh9.0 before being
+fixed; the probe scripts are named where they exist.
+
+- [x] **MC-UPLEVEL-ZERO** `uplevel 0` miscompiled as `uplevel #0`.
+  `parse_uplevel_level` folded the absolute `#N` form and the relative `N`
+  form into one `frame_shift`, so `#0` and `0` both reached
+  `Statement::UpFrame` as `0` and `upframe_scan_bodies` resolved both
+  against the global namespace. They are different frames: inside
+  `::foo::runIt`, `uplevel #0 { helper b }` calls `::helper` while `uplevel
+  0 { helper c }` calls `::foo::helper`. Every `uplevel 0` body was therefore
+  resolving its bare command words globally, sending evidence to a proc that
+  is never called and withholding it from the one that is. `UpFrame` now
+  carries an explicit `absolute: bool`; the scan resolves globally only for
+  an absolute shift of 0, and the relative form takes the enclosing-unit
+  branch — which for `uplevel 0` is exact, not an approximation.
+  `inline_uplevel`'s passthrough detector gained the matching guard so
+  `uplevel #1` is not confusable with `uplevel 1`.
+- [x] **MC-UNKNOWN-SEED** The unresolved-command handler's invented
+  dispatches manufactured folds. Naming some of an unenumerable set is not
+  enumerating it, and the recorded words are wrong in *both* directions:
+  `Dog new` after `oo::class create Dog` and `worker` after `coroutine
+  worker body` are recorded yet never reach the handler, while a `bogus
+  beta` written *before* `proc unknown` is handled by the builtin
+  `::unknown` and errors. `scan_cfg_callers` now poisons the handler
+  unconditionally the moment the module defines one, before reading a
+  statement — which, being shared, also closes the cross-file case where
+  one file's dispatch seeded a handler another file defines. The
+  concrete dispatches remain as retracting evidence.
+  `unresolved_command_handler`'s candidate list is sorted (it came off a
+  hash-map walk) and the single-carrier invariant is pinned.
+  Tests: `a_handler_never_seeds_even_when_every_visible_caller_agrees_1044`
+  (which previously asserted the manufactured fold, on the disproved premise
+  that the visible callers were all of them),
+  `a_class_command_never_seeds_the_handler_1044`,
+  `a_coroutine_command_never_seeds_the_handler_1044`,
+  `a_word_written_before_the_handler_never_seeds_it_1044`,
+  `a_cross_file_dispatch_never_seeds_another_files_handler_1044`.
+- [x] **MC-APPLY-NS** `apply {params body ns}` resolved its body globally.
+  `lower_apply` computed the pinned namespace and lowered the body against
+  it, then registered the body unit under the bare `apply` marker, whose
+  qname puts it in the global namespace. tclsh8.6/9.0: inside `::foo::runIt`,
+  `apply {{x} { helper $x } ::foo} b` calls `::foo::helper`, while the
+  two-element form calls `::helper`. Fixed by qualifying the marker exactly
+  as `lower_namespace_eval` does; `join_namespace` normalises the unpinned
+  case back, so the two-element form is untouched.
+- [x] **RE-DEAD-EDGE** `compute_reachable_call_offsets` accepted statically
+  dead proof edges. A call site's presence in a body is not proof the body
+  executes it, but a `proc a {} { if {0} { b } }` edge still handed `b` —
+  and transitively everything `b` calls — `a`'s early offset, which read as
+  "reached before the deletion" and withdrew a correct W123
+  (`review-probes-sound/r1.tcl` really does fail). The precise rule would
+  drop edges in SCCP-proved-unreachable regions, but SCCP runs later over
+  the IR this analyser's own result feeds, so consulting it here is
+  circular. Implemented instead: **a body edge may add a callee offset but
+  never lower a base top-level one**. A callee with its own top-level call
+  site has an offset that is already an observation of real execution; one
+  without keeps the old optimism, which is what #1015's chains need. Still
+  misses a dead edge to a callee never called at top level, and can raise
+  an offset for a live edge whose callee also has a later top-level call —
+  both documented at the function.
+  Also documents the pre-existing **earliest-offset false negative** on
+  `reachable_call_offsets` (`review-probes-sound/r3.tcl`): one offset per
+  name means a proc called both before and after a deletion reads as
+  reached-before for all of its invocations. Widened by #1015, not
+  introduced by it, and unchanged by design.
+- [x] **FP-OBJ-1013R** Class liveness gated at the wrong point, and on two
+  wrong facts.
+  1. `aggregate_object_types` dropped a class's type when the class was dead
+     at *file end*, so a class used before a *later* deletion lost its object
+     typing entirely — the dispatch lost its W308 and drew a spurious W307
+     instead (`review-probes-sound/w308d.tcl`, which really does fail with
+     `unknown method "fly"`). The map is now unfiltered and the gate moved
+     to the emit site, which knows the dispatch offset — the same
+     granularity #1010 used for the constructor sites.
+  2. `rename Dog Cat` was read as a pure deletion of the class. It removes
+     the command *name* but not the class, and objects already built from it
+     still answer their methods. Class liveness now treats a class named as
+     some rename's source as live; the command-name question is separate and
+     untouched, so `Dog new` still draws W123.
+  3. A `rename` inside a control-flow body counted as an unconditional
+     deletion, so `if {0} { rename Dog {} }` flagged `Dog new` with W123 —
+     while the analyser proved that very branch dead in the same run,
+     emitting I230 on it. Only straight-line renames are recorded now,
+     decided by a registry-driven `control_flow_body_depth`
+     (`Traits::CONTROL_FLOW` bodies may run zero times or many;
+     `namespace eval` / `eval` / `uplevel` bodies always run). This is the
+     narrow *syntactic* rule — `if {1} { rename Dog {} }` is equally not
+     recorded — matching the existing "a deletion inside a definition body
+     does not count" rule.
+- [x] **FP-INTERP-CREATE** `interp create`'s flag scan stopped at the path,
+  so `interp create x -safe` recorded `x` as unsafe. C Tcl examines every
+  word and treats a `-` word as a flag until `--`; tclsh8.6/9.0 confirm
+  `interp create n -bogus` errors `bad option`, proving flags are still
+  parsed after the path. The scan now mirrors that loop, and a second path
+  word — the `wrong # args` shape — records no path rather than an arbitrary
+  one. Separately, `interp_create_words_from_value` ended its element scan on
+  a parse error and kept the prefix, so `[interp create {child]` read as a
+  bare `interp create` and bound the variable to a phantom interpreter;
+  a parse error now rejects the whole substitution.
+- [x] **FP-UPFRAME-REWALK** A frame-shifting body nested inside another
+  `ArgRole::Body` was re-attributed. `proc runIt {} { catch { uplevel #0 {
+  helper b } } }` inside `::foo` walks the `catch` body correctly, then
+  walked the `uplevel` body again as `::foo`, inventing `::foo::helper`
+  alongside the correct `::helper` the upframe scan had already recorded.
+  Fixed by a new `Traits::EVALUATES_IN_SHIFTED_FRAME`, stamped on `uplevel`,
+  joining the existing `DEFINES_PROCEDURE` skip — so the walker still names
+  no commands.
+- [x] **VAR-ESCAPE-SCAN-MODE** The three `eval`/`catch` body pre-scans in
+  var_escape used `scan_script`, which honours Tcl's word-splitting and so
+  misses a name mentioned only inside a brace-quoted word. They now use
+  `scan_word`, the over-approximating mode the sites intend. **This is a
+  statement of intent, not a behaviour change:** `is_dynamic_token` already
+  sends any body containing `$` or `[` down the pessimistic path before the
+  scan runs, which is every body the scan could find a reference in, so the
+  mode is unobservable today and the guard carries the soundness. Written
+  the over-approximating way so narrowing that guard later cannot silently
+  reopen the hole.
 
 ## Confirmed true-positive this audit (sampled, no change needed)
 

--- a/docs/kcs/codes/kcs-diagnostic-i230-constant-existence-check.md
+++ b/docs/kcs/codes/kcs-diagnostic-i230-constant-existence-check.md
@@ -62,6 +62,44 @@ the call-site scan see the call, never to special-case the parameter. For
 the full rule, see
 [when a parameter is treated as a constant](../kcs-qa-when-is-a-proc-parameter-treated-as-a-constant.md).
 
+## Where a parameter is never treated as a constant
+
+Some procs have callers no scan can list, so their parameters are never
+seeded and `I230` never fires inside them.
+
+A `proc unknown` is the clearest case. Tcl sends it every command word
+that resolves to nothing at the moment of the call — a name an
+autoloader supplies, a name another sourced file introduces, a name built
+by string arithmetic — and most of those appear nowhere in your source.
+Whatever calls the analyser can see are only some of them, so none of
+them counts as evidence:
+
+```tcl
+proc unknown {cmd args} {
+    if {$cmd eq "alpha"} { return 1 } else { return 2 }
+}
+unknown alpha
+unknown alpha
+```
+
+No `I230` is reported on the condition, even though both visible calls
+pass `alpha`.
+
+The same reasoning applies to a proc reached in a way the scan cannot
+enumerate at all — through a command name it cannot read (`set cmd [gets
+stdin]; $cmd dev`), or through a `namespace import`.
+
+Two shapes that used to lose evidence now keep it, so a fold you saw
+before may correctly have gone away:
+
+- A body pinned to a namespace by `apply {params body ns}`. Its bare
+  command words resolve in that namespace, so `apply {{x} { helper $x }
+  ::foo} b` counts as a call to `::foo::helper`, not to a global
+  `::helper`.
+- A body run by `uplevel 0`. That is the *current* frame, not the global
+  one — only `uplevel #0` is global — so its calls count against the
+  enclosing namespace's procs.
+
 ## Fix
 
 To remember a value across calls, give it real cross-call storage instead of a

--- a/docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md
+++ b/docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md
@@ -48,6 +48,62 @@ the deletion re-establishes it and clears the warning.
 
 ## What does not trigger it
 
+A call the file demonstrably makes *before* the deletion is not a
+problem, even when the call is written inside a proc body. The analyser
+follows the chain of enclosing definitions to decide this: if some
+top-level call reaches the proc before the deletion runs, the nested call
+resolved at the time it ran, and no warning is reported.
+
+```tcl
+proc helper {} { return hi }
+proc inner {} { helper }
+proc outer {} { inner }
+outer
+rename helper {}
+```
+
+Nothing is flagged here. `outer` runs on the fourth line, which runs
+`inner`, which runs `helper` — all before the rename.
+
+The chain only follows call sites that are guaranteed to run. A call
+written inside an `if`, a loop, or a `switch` arm proves nothing about
+whether the enclosing proc really reaches it, so it does not silence a
+warning on a later call:
+
+```tcl
+proc helper {} { return hi }
+proc b {} { helper }
+proc a {} { if {0} { b } }
+a
+rename helper {}
+b
+```
+
+The analyser reports **`W123`** on `helper` inside `b`, and it is right
+to: the last line really does fail with `invalid command name "helper"`.
+
+A `rename` or deletion written inside an `if`, a loop, or a `switch` arm
+is treated the same way, in the other direction. Because it might never
+run, it is not taken as proof that the command is gone:
+
+```tcl
+oo::class create Dog {
+    method bark {} { return woof }
+}
+if {0} { rename Dog {} }
+Dog new
+```
+
+Nothing is flagged on `Dog`. This is a deliberately simple rule about
+where the `rename` is written, not about whether the branch is taken —
+`if {1} { rename Dog {} }` is treated the same way, so a deletion the
+analyser could in principle prove does happen is still not reported.
+
+A command whose name is vacated by a `rename` is still flagged, even
+though the command itself survives under its new name. `rename Dog Cat`
+moves the class to `Cat`; `Dog new` afterwards fails with `invalid
+command name "Dog"`, so the old name is reported.
+
 A built-in `expr` math function (`sin`, `max`, `abs`, …) called with
 function-call syntax inside `expr` resolves to the command it dispatches to
 (`::tcl::mathfunc::<name>`) and never draws `W123`, whether or not it has

--- a/docs/kcs/codes/kcs-diagnostic-w308-unknown-tcloo-method.md
+++ b/docs/kcs/codes/kcs-diagnostic-w308-unknown-tcloo-method.md
@@ -46,6 +46,48 @@ $p distance
 The analyser reports **`W308`** on `$p distance` — `Point` has no `distance`
 method.
 
+## What a deleted class changes
+
+The check asks whether the class is still live **at the dispatch**, not
+whether it survives to the end of the file. A class deleted later in the
+file is fully alive at any dispatch written before the deletion, so those
+dispatches are still checked:
+
+```tcl
+oo::class create Dog { method bark {} { return woof } }
+proc walk {} {
+    set d [Dog new]
+    $d fly
+}
+walk
+rename Dog {}
+```
+
+The analyser reports **`W308`** on `$d fly`. Running this really does
+fail with `unknown method "fly"` — the trailing `rename` happens after
+`walk` has already run.
+
+A class deleted *before* the dispatch is a different matter. There the
+constructor itself fails, so the object is never created and the method
+name is not the real problem. The analyser stays quiet about the method
+and reports the dead class instead, as
+[`W123`](kcs-diagnostic-w123-unresolved-command.md).
+
+`rename Dog Cat` does not delete the class. It moves the class to a new
+name, and every object already built from it keeps answering its
+methods, so those dispatches are still checked:
+
+```tcl
+oo::class create Dog { method bark {} { return woof } }
+set d [Dog new]
+rename Dog Cat
+$d fly
+```
+
+The analyser reports **`W308`** on `$d fly`. The vacated name `Dog` is a
+separate question, and is reported separately as `W123` if anything
+still calls it.
+
 ## Fix
 
 Call a method the class actually defines, or add the method to the class:
@@ -65,4 +107,5 @@ Add `# noqa: W308` at the end of the offending line.
 
 - [KCS codes index](README.md)
 - [Diagnostics feature](../features/kcs-feature-diagnostics.md)
+- [W123 — unresolved command](kcs-diagnostic-w123-unresolved-command.md)
 - Related codes: `W001`, `W307`

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1515,6 +1515,18 @@ impl Analyser {
         if is_conditional {
             self.conditional_depth += 1;
         }
+        // Whether these bodies are guaranteed to run once when the enclosing
+        // script runs. A `Traits::CONTROL_FLOW` command's body may run zero
+        // times (`if {0}`, an empty `foreach` list, an untaken `switch` arm)
+        // or many, so anything inside it is not straight-line. `namespace
+        // eval` / `eval` / `uplevel` bodies carry no such trait and stay
+        // straight-line, which is correct — they always run.
+        let is_control_flow = registry
+            .get(cmd_name)
+            .is_some_and(|s| s.traits.contains(tcl_registry::Traits::CONTROL_FLOW));
+        if is_control_flow {
+            self.control_flow_body_depth += 1;
+        }
         for idx in body_indices {
             if let (Some(body_text), Some(body_tok)) = (args.get(idx), arg_tokens.get(idx).copied())
             {
@@ -1531,6 +1543,9 @@ impl Analyser {
         }
         if is_conditional {
             self.conditional_depth -= 1;
+        }
+        if is_control_flow {
+            self.control_flow_body_depth -= 1;
         }
         if cmd_name == "when" {
             self.current_event = prev_event;

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -1343,10 +1343,12 @@ file; this call falls through to the 'unknown' handler."
             };
 
             // Collect the variable names read by the return value (word
-            // substitutions + nested `[...]`) and any parsed expr.
+            // substitutions + nested `[...]`) and any parsed expr. The
+            // return value is a single already-extracted word, not a
+            // script, so it scans in value-body mode.
             let mut reads: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
             if let Some(v) = value {
-                reads.extend(scanner.scan_script(v, registry));
+                reads.extend(scanner.scan_word(v, registry));
             }
             if let Some(e) = expr {
                 reads.extend(crate::var_refs::vars_in_expr(e));

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -10967,6 +10967,47 @@ fn w123_tp_issue_1015_mutual_recursion_cycle_never_entered_still_flags() {
 }
 
 #[test]
+fn w123_tp_a_dead_body_edge_does_not_lower_a_later_top_level_offset() {
+    // TP guard (Codex review of PR #1045, adversarial soundness review):
+    // `a` runs before the rename, but its only call to `b` sits inside `if
+    // {0} { … }` and never executes. `b`'s real first invocation is the
+    // top-level one *after* the rename, so `b`'s `helper` call fails.
+    //
+    // The unrestricted fixpoint let the dead `a` -> `b` edge lower `b`'s
+    // offset to `a`'s, which read as "reached before the deletion" and
+    // withdrew the warning. A body edge may no longer undercut a callee's
+    // own top-level offset.
+    //
+    // Oracle (tclsh8.6, `review-probes-sound/r1.tcl`): exits 1 with
+    // `invalid command name "helper"` from `b`, invoked at line 6.
+    let src = "proc helper {} { return hi }\nproc b {} { helper }\nproc a {} { if {0} { b } }\na\nrename helper {}\nb\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_string()]);
+}
+
+#[test]
+fn w123_tp_an_empty_enclosing_body_leaves_the_later_top_level_offset() {
+    // The paired FP guard for the test above: same shape with `a`'s body
+    // empty, so there is no `a` -> `b` edge to drop in the first place.
+    // Both must warn, or the fix would be indistinguishable from "the edge
+    // never mattered".
+    //
+    // Oracle (tclsh8.6, `review-probes-sound/r2.tcl`): exits 1, same error.
+    let src = "proc helper {} { return hi }\nproc b {} { helper }\nproc a {} { }\na\nrename helper {}\nb\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_string()]);
+}
+
+#[test]
+fn w123_fp_a_live_body_edge_still_reaches_a_callee_with_no_top_level_call() {
+    // FP guard for the restriction: `b` has no top-level call site of its
+    // own, so the `a` -> `b` edge is the only evidence there is and must
+    // still resolve. This is issue #1015's shape, and the restriction is
+    // written to leave it alone — without it, every #1015 chain would
+    // regress to a false positive.
+    let src = "proc helper {} { return hi }\nproc b {} { helper }\nproc a {} { b }\na\nrename helper {}\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
 fn w123_fp_issue_1015_mutual_recursion_cycle_entered_at_top_level_resolves() {
     // FP guard: the same cycle, but entered by a real top-level call
     // before the deletion — every member is then reachable, so the nested

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -10880,3 +10880,44 @@ fn w123_tp_issue_1009_codex_review_escape_hatch_requires_specific_enclosing_call
     let src = "proc helper {} {}\nproc caller {} { helper }\nproc unrelated {} { return 1 }\nunrelated\nrename helper {}\n";
     assert_eq!(w123_codes(src), vec!["W123".to_string()]);
 }
+
+#[test]
+fn w123_fp_issue_1015_two_level_call_chain_before_later_deletion_resolves() {
+    // FP guard (issue #1015): the escape hatch must follow a *chain* of
+    // enclosing definitions, not one level. `inner` is never invoked at
+    // the top level — only `outer` is — but `outer` calls `inner`, which
+    // calls `helper`, all before the rename. tclsh8.6/9.0 both run this
+    // clean (exit 0, no error).
+    let src = "proc helper {} { return hi }\nproc inner {} { helper }\nproc outer {} { inner }\nouter\nrename helper {}\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_fp_issue_1015_three_level_call_chain_before_later_deletion_resolves() {
+    // FP guard, one level deeper still — the reachability query is a
+    // fixpoint, so depth is not bounded by the number of hops.
+    let src = "proc helper {} { return hi }\nproc l1 {} { helper }\nproc l2 {} { l1 }\nproc l3 {} { l2 }\nl3\nrename helper {}\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_tp_issue_1015_mutual_recursion_cycle_never_entered_still_flags() {
+    // TP guard (issue #1015): `pingCaller`/`pongCaller` call each other and
+    // nothing calls either at the top level, so neither is ever reached —
+    // the cycle must terminate as "unreachable" rather than looping, and
+    // the `helper` call inside must still draw W123. tclsh8.6 loads the
+    // file fine precisely *because* the cycle is never entered; calling
+    // into it after the rename fails `invalid command name "helper"`.
+    let src = "proc helper {} {}\nproc pingCaller {} { helper\n pongCaller }\nproc pongCaller {} { pingCaller }\nrename helper {}\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_string()]);
+}
+
+#[test]
+fn w123_fp_issue_1015_mutual_recursion_cycle_entered_at_top_level_resolves() {
+    // FP guard: the same cycle, but entered by a real top-level call
+    // before the deletion — every member is then reachable, so the nested
+    // `helper` call resolves. Confirms the cycle handling short-circuits
+    // without also poisoning the reachable case.
+    let src = "proc helper {} { return hi }\nproc pingCaller {} { helper }\nproc pongCaller {} { pingCaller }\nproc entry {} { pongCaller }\nentry\nrename helper {}\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5435,6 +5435,97 @@ fn w308_tn_issue_1013_live_class_set_var_constructor_still_flags() {
 }
 
 #[test]
+fn w308_tp_copy_propagated_handle_with_a_trailing_rename_still_flags() {
+    // TP restored by moving the class-liveness gate from file end to the
+    // dispatch site. `foo` runs while `Dog` is alive; the rename is the last
+    // line of the file and cannot affect a call that already happened.
+    //
+    // The file-end gate dropped `x`'s `Object(::Dog)` type outright, so the
+    // dispatch lost its W308 *and* picked up a spurious W307 in its place.
+    //
+    // Oracle (tclsh8.6, `review-probes-sound/w308d.tcl`): exits 1 with
+    // `unknown method "fly": must be bark or destroy`.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nproc foo {} {\n    set y [Dog new]\n    set x $y\n    $x fly\n}\nfoo\nrename Dog {}\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "the class is alive at the dispatch, so the unknown method must flag; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w308_tp_class_renamed_to_a_name_keeps_typing_its_existing_objects() {
+    // `rename Dog Cat` deletes the command *name* `Dog` but not the class —
+    // the object in `d` is still a Dog and still rejects `fly`.
+    //
+    // Oracle (tclsh8.6 and tclsh9.0): after `set d [Dog new]` and `rename
+    // Dog Cat`, `$d bark` returns `woof` while `$d fly` fails with `unknown
+    // method "fly": must be bark or destroy`.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nset d [Dog new]\nrename Dog Cat\n$d fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "a class renamed to a name is re-established, not deleted; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w123_tp_a_class_renamed_away_still_flags_its_old_name() {
+    // The paired guard: making the *class* survive a rename must not make
+    // the vacated *command name* resolve. Oracle (tclsh8.6,
+    // `review-probes/cls1_run.tcl`): after `rename Dog Cat`, `Dog new`
+    // fails with `invalid command name "Dog"`.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog Cat\nDog new\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    let codes: HashSet<String> = r.diagnostics.iter().map(|d| d.code.to_string()).collect();
+    assert!(
+        codes.contains("W123"),
+        "the vacated name must still be unknown; got {codes:?}",
+    );
+}
+
+#[test]
+fn w123_tp_a_rename_in_a_dead_branch_is_not_an_unconditional_deletion() {
+    // A `rename` nested in a control-flow body may never run, so it is not
+    // evidence the command is gone. The analyser proves this very branch
+    // dead in the same run (it emits I230 on it) yet honoured the deletion,
+    // flagging a command that is demonstrably still callable and — through
+    // the shared liveness facts — withdrawing the W308 as well.
+    //
+    // Oracle (tclsh8.6, `review-probes/cls5.tcl`): `Dog new` succeeds and
+    // `$d fly` fails with `unknown method "fly": must be bark or destroy`.
+    let src = "oo::class create Dog {\n    method bark {} { return woof }\n}\nif {0} { rename Dog {} }\nset d [Dog new]\n$d fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    let codes: HashSet<String> = r.diagnostics.iter().map(|d| d.code.to_string()).collect();
+    assert!(
+        !codes.contains("W123"),
+        "the branch never runs, so `Dog` is still bound; got {:?}",
+        r.diagnostics,
+    );
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "and the live class must still validate its methods; got {:?}",
+        r.diagnostics,
+    );
+    assert!(
+        codes.contains("I230"),
+        "the dead branch itself is still reported; got {codes:?}",
+    );
+}
+
+#[test]
 fn w308_fp_issue_1010_reestablished_class_constructor_still_flags_unknown_method() {
     let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog {}\noo::class create Dog { method bark {} { return woof } }\n[Dog new] fly";
     let mut a = Analyser::new();

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5355,13 +5355,12 @@ fn analyse_w308_emitted_for_unknown_method_on_known_class_constructor() {
 // real, primary diagnostic.
 //
 // `harvest_constructor_object_types` (the `set x [Cls new]` variable-
-// assignment sibling of this same check) is fixed the same way, but a
+// assignment sibling of this same check) is fixed the same way. The
 // deeper, independent source in `type_infer.rs`'s `constructor_object_type`
-// still separately types `x` as `Object(Cls)` for that shape via the SSA
-// type lattice, so `$x method` there still draws the same misleading
-// W308 — tracked as a follow-up (that fix needs a call-site offset
-// threaded into a foundational, flow-insensitive type-inference helper,
-// a larger and riskier change than this session's other gate-only fixes).
+// — which types `x` as `Object(Cls)` for that shape via the SSA type
+// lattice — is gated in `aggregate_object_types`, where both sources are
+// unioned and the analyser's own deletion facts are in scope (issue #1013;
+// see the `w308_*_issue_1013_*` cases below).
 
 #[test]
 fn w308_tp_issue_1010_deleted_class_constructor_falls_back_to_w307() {
@@ -5377,6 +5376,61 @@ fn w308_tp_issue_1010_deleted_class_constructor_falls_back_to_w307() {
     assert!(
         codes.contains("W123"),
         "the deleted class itself must draw W123 as the real diagnostic; got {codes:?}"
+    );
+}
+
+#[test]
+fn w308_tp_issue_1013_deleted_class_set_var_constructor_draws_no_w308() {
+    // Issue #1013 primary repro: `type_infer.rs`'s `constructor_object_type`
+    // is a second, independent source of `Object(Dog)` typing for the
+    // `set x [Dog new]` shape, reached through the SSA type lattice rather
+    // than #1010's `harvest_constructor_object_types`. It reads an
+    // unfiltered "known classes" set with no deletion awareness, so this
+    // still drew the misleading "unknown method" W308 after #1010's fix.
+    // tclsh8.6 and 9.0 both fail the constructor first: `invalid command
+    // name "Dog"` — `x` is never assigned an object at all.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog {}\nproc foo {} {\n    set x [Dog new]\n    $x fly\n}\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    let codes: HashSet<String> = r.diagnostics.iter().map(|d| d.code.to_string()).collect();
+    assert!(
+        !codes.contains("W308"),
+        "a deleted class must not draw the misleading 'unknown method' W308; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w308_fp_issue_1013_reestablished_class_set_var_constructor_still_flags() {
+    // FP guard for the same gate: a class deleted and then re-established
+    // under the same name is live again at file end (the fresh definition
+    // postdates the deletion), so `x` must still type as `Object(Dog)` and
+    // the unknown method must still be flagged.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog {}\noo::class create Dog { method bark {} { return woof } }\nproc foo {} {\n    set x [Dog new]\n    $x fly\n}\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "a re-established class must still type its constructor result; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w308_tn_issue_1013_live_class_set_var_constructor_still_flags() {
+    // TN control: with no deletion anywhere, the ordinary `set x [Dog new]`
+    // shape must be entirely unaffected by the gate.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nproc foo {} {\n    set x [Dog new]\n    $x fly\n}\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "a live class must still validate its methods; got {:?}",
+        r.diagnostics,
     );
 }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs
@@ -251,18 +251,24 @@ impl Analyser {
     /// A call *inside* a body carries no execution-order meaning from its
     /// own textual position — it runs whenever the enclosing definition is
     /// invoked, not when its text was written — so a call there falls back
-    /// to a narrower, still-sound question: does [`Self::top_level_call_offsets`]
-    /// record a *top-level* invocation of the innermost enclosing
-    /// definition ([`super::super::types::AnalysisResult::enclosing_definition_qualified_name`])
-    /// that provably ran before the deletion? If so, that invocation's own
+    /// to a narrower, still-sound question: does [`Self::reachable_call_offsets`]
+    /// show the innermost enclosing definition
+    /// ([`super::super::types::AnalysisResult::enclosing_definition_qualified_name`])
+    /// provably *reached* before the deletion? If so, that invocation's own
     /// nested calls already resolved (issue #1009 Codex review: `proc
     /// helper {}`, `proc caller {} { helper }`, `caller`, `rename helper
     /// {}` resolves in real Tcl — confirmed against tclsh 8.6.14 — because
-    /// `caller`'s own top-level call runs before the rename). Absent such
-    /// proof (the enclosing definition is never called at the top level in
-    /// this file, or only after the deletion), the existing conservative
-    /// default holds: an unconditional top-level deletion is in effect for
-    /// every call inside any body.
+    /// `caller`'s own top-level call runs before the rename).
+    ///
+    /// "Reached" is transitive over the whole call graph, not one level
+    /// (issue #1015): `proc helper {}`, `proc inner {} { helper }`, `proc
+    /// outer {} { inner }`, `outer`, `rename helper {}` also runs clean on
+    /// tclsh8.6/9.0, because `outer`'s own top-level call reaches `helper`
+    /// two bodies deep. Absent such proof (the enclosing definition is
+    /// never reached in this file, or only after the deletion — including
+    /// every member of a mutual-recursion cycle no top-level call enters),
+    /// the existing conservative default holds: an unconditional top-level
+    /// deletion is in effect for every call inside any body.
     pub(super) fn fact_live_for_call(&self, qualified: &str, fact_off: u32, call_off: u32) -> bool {
         let Some(&del_off) = self.deleted_commands.get(qualified) else {
             return true;
@@ -278,7 +284,7 @@ impl Analyser {
         }
         self.result
             .enclosing_definition_qualified_name(call_off)
-            .and_then(|qn| self.top_level_call_offsets.get(qn))
+            .and_then(|qn| self.reachable_call_offsets.get(qn))
             .is_some_and(|&t| t < del_off)
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -250,16 +250,20 @@ impl Analyser {
     /// types: var name → the set of `TclType::Object` class qualified names it
     /// can hold, for the W308 method-resolution check.
     ///
-    /// Every class name is gated on [`Self::class_live_at_file_end`] (issue
-    /// #1013): `type_infer.rs`'s `constructor_object_type` types `[Cls new]`
-    /// straight off an unfiltered "known classes" set with no deletion
-    /// awareness, so a `rename Cls {}` left `set x [Cls new]; $x fly`
-    /// drawing a misleading "unknown method" W308 even though tclsh8.6/9.0
-    /// fail the constructor itself with `invalid command name "Cls"`. This
-    /// is the same gate #1010 applied to
-    /// [`Self::harvest_constructor_object_types`], the other source this
-    /// map unions — filtering both here keeps the two in step regardless of
-    /// which one typed the symbol.
+    /// The map itself is **unfiltered**. Deletion awareness (issue #1013 —
+    /// `type_infer.rs`'s `constructor_object_type` types `[Cls new]` straight
+    /// off a "known classes" set that has none) belongs at the *emit* sites,
+    /// which know the dispatch offset and can ask
+    /// [`Self::class_live_for_call`]. Filtering here instead used
+    /// `class_live_at_file_end`, and dropping the type outright cost the
+    /// diagnostic in both directions: a class used before a *later* deletion
+    /// lost its W308 and drew a spurious W307 in its place, even though the
+    /// dispatch happens while the class is still live.
+    ///
+    /// Oracle (tclsh8.6, `review-probes-sound/w308d.tcl`): `proc foo {} {
+    /// set y [Dog new]; set x $y; $x fly }`, `foo`, then `rename Dog {}`
+    /// fails with `unknown method "fly"` — the class is alive at the
+    /// dispatch, and the trailing rename is irrelevant to it.
     fn aggregate_object_types(
         &self,
         cu: &crate::compilation_unit::CompilationUnit,
@@ -280,9 +284,6 @@ impl Analyser {
                     let Some(class_name) = tl.class_name() else {
                         continue;
                     };
-                    if !self.class_live_at_file_end(class_name) {
-                        continue;
-                    }
                     out.entry(fu.ssa.var_name(*sym).to_owned())
                         .or_default()
                         .insert(class_name.to_owned());
@@ -680,33 +681,78 @@ impl Analyser {
             .is_some_and(|c| self.fact_live_for_call(qualified, c.name_span.start(), call_off))
     }
 
-    /// Whether `qualified` names a class still live when the file finishes
-    /// loading — the file-end sibling of [`Self::class_live_for_call`],
-    /// for the SSA type lattice (issue #1013).
+    /// The object classes `site`'s receiver may hold that are still live
+    /// *at this dispatch*, out of everything
+    /// [`Self::aggregate_object_types`] recorded for the variable.
     ///
-    /// File-end, not per-call-site, is the only granularity available here
-    /// and it is the right boundary: `fu.types` is a *flow-insensitive
-    /// per-symbol* lattice with no offset attached to the entry that typed
-    /// the symbol, so there is no call site to gate against. The
-    /// consequence is deliberate and matches
-    /// [`super::unresolved::Analyser::fact_live_at_file_end`]'s own
-    /// contract — a class deleted and then re-established under the same
-    /// name reads as live (the re-establishment postdates the deletion),
-    /// while a class deleted for good does not. A class *used* before a
-    /// later deletion is the one case this is coarser than
-    /// `class_live_for_call`: W308's "unknown method" is a secondary
-    /// diagnostic, and suppressing it there costs only a hint, whereas
-    /// asserting a dead class exists actively misleads.
+    /// A class deleted before the dispatch cannot answer it, so its method
+    /// table says nothing about the call; a class deleted only afterwards is
+    /// fully live here and must still be checked (issue #1013, refined by
+    /// the adversarial review). An empty result means the site has no usable
+    /// object type left, and the caller falls through to the W307 path
+    /// exactly as it did when the type was dropped wholesale.
+    fn live_classes_at_dispatch(
+        &self,
+        all_object_types: &std::collections::HashMap<String, HashSet<String>>,
+        site: &crate::analyser::state::VarCommandSite,
+    ) -> HashSet<String> {
+        let Some(names) = all_object_types.get(&site.var_name) else {
+            return HashSet::new();
+        };
+        names
+            .iter()
+            .filter(|cls| self.class_live_by_name_for_call(cls, site.cmd_span.start()))
+            .cloned()
+            .collect()
+    }
+
+    /// Whether the class `name` is still live at `call_off` — the
+    /// by-written-name wrapper around [`Self::class_live_for_call`], for the
+    /// type-lattice class names [`Self::aggregate_object_types`] collects
+    /// (issue #1013).
+    ///
+    /// Gating at the dispatch offset rather than at file end is what keeps
+    /// a class *used before a later deletion* diagnosable: the dispatch runs
+    /// while the class is alive, so its methods are exactly as checkable as
+    /// if the deletion were not there. `fu.types` is flow-insensitive and
+    /// carries no offset of its own, but the *dispatch site* does
+    /// (`VarCommandSite::cmd_span`), and that is the offset that decides
+    /// whether the call succeeds — the same granularity issue #1010 used
+    /// for the constructor sites.
     ///
     /// A name this file declares no class for (a cross-file or
     /// registry-provided class) has no deletion fact to check and stays
-    /// live, exactly as before.
-    fn class_live_at_file_end(&self, name: &str) -> bool {
+    /// live.
+    ///
+    /// # A rename to a name is re-establishment, not deletion
+    ///
+    /// `rename Dog Cat` records a deletion of `::Dog`, which is right for
+    /// the *command name* — `Dog new` genuinely fails afterwards. It is
+    /// wrong for the *class*, which is alive and well under its new name,
+    /// along with every object already constructed from it.
+    ///
+    /// Oracle (tclsh8.6 and tclsh9.0): after `set d [Dog new]` and `rename
+    /// Dog Cat`, `$d bark` returns `woof` and `$d fly` fails with `unknown
+    /// method "fly"`. Treating the class as dead dropped that W308.
+    ///
+    /// So a class named as some rename's *source* stays live here. The
+    /// command-name question is a different one and keeps using
+    /// [`Self::fact_live_for_call`] directly, which is what still lets
+    /// `Dog new` draw its W123.
+    fn class_live_by_name_for_call(&self, name: &str, call_off: u32) -> bool {
         let qualified = self.canonicalise_class_name(name);
+        if self
+            .result
+            .renamed_commands
+            .values()
+            .any(|old| *old == qualified)
+        {
+            return true;
+        }
         self.result
             .all_classes
             .get(&qualified)
-            .is_none_or(|c| self.fact_live_at_file_end(&qualified, c.name_span.start()))
+            .is_none_or(|c| self.fact_live_for_call(&qualified, c.name_span.start(), call_off))
     }
 
     /// True when `v` resolves to a known, *live* command at `call_off`: a
@@ -1132,10 +1178,12 @@ impl Analyser {
             // **W308 path.**  Variable known to hold an Object — validate the
             // method against the hierarchy and emit W308 when it isn't found.
             // The W307 path never fires for a known-Object var, so `continue`.
-            if let Some(class_names) = all_object_types.get(&site.var_name) {
+            //
+            let live_classes = self.live_classes_at_dispatch(&all_object_types, site);
+            if !live_classes.is_empty() {
                 if let Some(diag) = self.w308_for_object_var(
                     site,
-                    class_names,
+                    &live_classes,
                     hierarchy.as_ref(),
                     &objdefined_vars,
                 ) {

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -249,6 +249,17 @@ impl Analyser {
     /// (top level, procs, *and* method bodies) plus constructor-harvested
     /// types: var name → the set of `TclType::Object` class qualified names it
     /// can hold, for the W308 method-resolution check.
+    ///
+    /// Every class name is gated on [`Self::class_live_at_file_end`] (issue
+    /// #1013): `type_infer.rs`'s `constructor_object_type` types `[Cls new]`
+    /// straight off an unfiltered "known classes" set with no deletion
+    /// awareness, so a `rename Cls {}` left `set x [Cls new]; $x fly`
+    /// drawing a misleading "unknown method" W308 even though tclsh8.6/9.0
+    /// fail the constructor itself with `invalid command name "Cls"`. This
+    /// is the same gate #1010 applied to
+    /// [`Self::harvest_constructor_object_types`], the other source this
+    /// map unions — filtering both here keeps the two in step regardless of
+    /// which one typed the symbol.
     fn aggregate_object_types(
         &self,
         cu: &crate::compilation_unit::CompilationUnit,
@@ -269,6 +280,9 @@ impl Analyser {
                     let Some(class_name) = tl.class_name() else {
                         continue;
                     };
+                    if !self.class_live_at_file_end(class_name) {
+                        continue;
+                    }
                     out.entry(fu.ssa.var_name(*sym).to_owned())
                         .or_default()
                         .insert(class_name.to_owned());
@@ -664,6 +678,35 @@ impl Analyser {
             .all_classes
             .get(qualified)
             .is_some_and(|c| self.fact_live_for_call(qualified, c.name_span.start(), call_off))
+    }
+
+    /// Whether `qualified` names a class still live when the file finishes
+    /// loading — the file-end sibling of [`Self::class_live_for_call`],
+    /// for the SSA type lattice (issue #1013).
+    ///
+    /// File-end, not per-call-site, is the only granularity available here
+    /// and it is the right boundary: `fu.types` is a *flow-insensitive
+    /// per-symbol* lattice with no offset attached to the entry that typed
+    /// the symbol, so there is no call site to gate against. The
+    /// consequence is deliberate and matches
+    /// [`super::unresolved::Analyser::fact_live_at_file_end`]'s own
+    /// contract — a class deleted and then re-established under the same
+    /// name reads as live (the re-establishment postdates the deletion),
+    /// while a class deleted for good does not. A class *used* before a
+    /// later deletion is the one case this is coarser than
+    /// `class_live_for_call`: W308's "unknown method" is a secondary
+    /// diagnostic, and suppressing it there costs only a hint, whereas
+    /// asserting a dead class exists actively misleads.
+    ///
+    /// A name this file declares no class for (a cross-file or
+    /// registry-provided class) has no deletion fact to check and stays
+    /// live, exactly as before.
+    fn class_live_at_file_end(&self, name: &str) -> bool {
+        let qualified = self.canonicalise_class_name(name);
+        self.result
+            .all_classes
+            .get(&qualified)
+            .is_none_or(|c| self.fact_live_at_file_end(&qualified, c.name_span.start()))
     }
 
     /// True when `v` resolves to a known, *live* command at `call_off`: a

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -120,7 +120,21 @@ fn parse_interp_create_words<'a>(words: &[&'a str]) -> (bool, Option<&'a str>) {
 /// [`parse_interp_create_words`] (issue #923 idx 9).
 fn interp_create_words_from_value(text: &str) -> Option<Vec<&str>> {
     let inner = text.strip_prefix('[')?.strip_suffix(']')?;
-    let mut words = inner.split_whitespace();
+    // Tcl-list parse, not `split_whitespace` (issue #1025): the direct
+    // `interp create` handler sees segmenter-decoded words, so a braced
+    // path word (`{child}`, `{parent child}`) reaches it already stripped.
+    // Whitespace-splitting the raw substitution text instead keeps the
+    // braces and can even split one word in two (`{parent child}` →
+    // `"{parent"`, `"child}"`), binding the variable to a key the direct
+    // handler never records — later `$i eval` / `interp alias $i …` then
+    // resolve against a phantom interpreter.
+    let mut words = Vec::new();
+    let mut pos = 0usize;
+    while let Ok(Some(el)) = find_element(inner, pos) {
+        words.push(inner.get(el.value.clone())?);
+        pos = el.next;
+    }
+    let mut words = words.into_iter();
     if words.next()? != "interp" || words.next()? != "create" {
         return None;
     }
@@ -4533,6 +4547,61 @@ mod tests {
 
     fn span(start: u32, end: u32) -> Span {
         Span::new(start, end)
+    }
+
+    // interp_create_words_from_value — issue #1025
+
+    #[test]
+    fn interp_create_value_words_strip_a_single_braced_path_issue_1025() {
+        // TP — `{child}` is one Tcl word naming interpreter `child`; the
+        // direct handler sees it segmenter-decoded, so the value-flow path
+        // must strip the braces too rather than binding to `"{child}"`.
+        assert_eq!(
+            interp_create_words_from_value("[interp create {child}]"),
+            Some(vec!["child"])
+        );
+    }
+
+    #[test]
+    fn interp_create_value_words_keep_a_nested_path_as_one_word_issue_1025() {
+        // TP — `{parent child}` is one word (a descent path), not two.
+        // `split_whitespace` used to yield `["{parent", "child}"]`, whose
+        // first fragment became the bound key.
+        assert_eq!(
+            interp_create_words_from_value("[interp create {parent child}]"),
+            Some(vec!["parent child"])
+        );
+    }
+
+    #[test]
+    fn interp_create_value_words_unchanged_for_bare_and_flagged_forms_issue_1025() {
+        // TN — the shapes that already worked must be byte-for-byte
+        // unchanged by the switch to list parsing.
+        assert_eq!(
+            interp_create_words_from_value("[interp create -safe]"),
+            Some(vec!["-safe"])
+        );
+        assert_eq!(
+            interp_create_words_from_value("[interp create -safe -- name]"),
+            Some(vec!["-safe", "--", "name"])
+        );
+        assert_eq!(
+            interp_create_words_from_value("[interp create]"),
+            Some(vec![])
+        );
+        assert_eq!(interp_create_words_from_value("[set x 1]"), None);
+        assert_eq!(interp_create_words_from_value("interp create child"), None);
+    }
+
+    #[test]
+    fn interp_create_value_words_abstain_on_an_unmatched_brace_issue_1025() {
+        // FN guard — a malformed (mid-edit) path stops the element scan, so
+        // the words seen are only those parsed before the break; nothing
+        // may be silently mis-split into fragments.
+        assert_eq!(
+            interp_create_words_from_value("[interp create {child]"),
+            Some(vec![])
+        );
     }
 
     // handle_set_command

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -3436,6 +3436,33 @@ impl Analyser {
                 self.interpreters.insert(new_interp_key, state);
             }
         }
+        // A rename nested inside a control-flow body may not run at all, so it
+        // is not evidence that `OLD` is gone. Recording it anyway produced a
+        // W123 on a command that is demonstrably still callable, and — once
+        // class liveness started consulting the same facts — withdrew the
+        // W308 on objects of that class too.
+        //
+        // Oracle (tclsh8.6, `review-probes/cls5.tcl`): with `if {0} { rename
+        // Dog {} }`, `Dog new` succeeds and `$d fly` fails with `unknown
+        // method "fly"`. The analyser proves the same branch dead in the same
+        // run — it emits I230 on it — yet honoured the deletion.
+        //
+        // Only straight-line deletions count. This is the *syntactic* rule:
+        // `if {1} { rename Dog {} }` is equally not recorded, even though it
+        // does run. Reading the branch's real value needs SCCP, which runs
+        // later over the IR this walk feeds, so it is not available here. The
+        // narrower rule errs towards treating commands as live, matching the
+        // existing "a deletion inside a definition body does not count"
+        // rule in `fact_live_for_call` (issue #973).
+        if self.control_flow_body_depth > 0 {
+            if !new.is_empty() {
+                self.renamed_commands.insert(new.clone(), old.clone());
+                self.rename_offsets.insert(new.clone(), offset);
+                self.result.rename_offsets.insert(new.clone(), offset);
+                self.result.renamed_commands.insert(new, old);
+            }
+            return false;
+        }
         if new.is_empty() {
             self.deleted_commands.insert(old, deletion_offset);
             return false;

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -87,28 +87,53 @@ pub(super) fn interp_path_key(path: &str) -> String {
     path.split_whitespace().collect::<Vec<_>>().join(" ")
 }
 
-/// Parse `interp create`'s `?-safe? ?--? ?path?` leading words (issue
-/// #923 idx 9): returns `(safe, path)`, where `path` is the first
-/// non-flag word (or `None` for a bare, uncaptured `interp create
-/// -safe`). Shared by `Analyser::handle_interp_create_command` and the
-/// `set VAR [interp create ...]` value-flow detector in
-/// `Analyser::handle_set_command`, so both parse the flag/path shape
-/// identically.
+/// Parse `interp create`'s `?-safe? ?--? ?path?` words (issue #923 idx 9):
+/// returns `(safe, path)`, where `path` is the sole non-flag word (or
+/// `None` for a bare, uncaptured `interp create -safe`). Shared by
+/// `Analyser::handle_interp_create_command` and the `set VAR [interp
+/// create ...]` value-flow detector in `Analyser::handle_set_command`, so
+/// both parse the flag/path shape identically.
+///
+/// Mirrors C Tcl's own loop (`Tcl_InterpObjCmd`, the `create` arm): every
+/// word is examined, and a `-`-prefixed word is a *flag* until `--` is
+/// seen, whether or not the path has already been read. The scan does not
+/// stop at the path.
+///
+/// Oracle (tclsh8.6 and tclsh9.0):
+///
+/// * `interp create x -safe` — path `x`, and it **is** safe.
+/// * `interp create -safe -- z` — path `z`, safe.
+/// * `interp create -- -safe` — path is the literal `-safe`, not safe.
+/// * `interp create n -bogus` — `bad option "-bogus"`, so flags really are
+///   still being parsed after the path.
+/// * `interp create a b` — `wrong # args`; a second path word is an error
+///   shape, not a rebinding, so no path is reported rather than the wrong
+///   one.
 fn parse_interp_create_words<'a>(words: &[&'a str]) -> (bool, Option<&'a str>) {
     let mut safe = false;
     let mut path: Option<&str> = None;
     let mut past_flags = false;
+    let mut too_many_paths = false;
     for &word in words {
-        if !past_flags && word == "-safe" {
-            safe = true;
+        if !past_flags && word.starts_with('-') {
+            if word == "--" {
+                past_flags = true;
+            } else if word == "-safe" {
+                safe = true;
+            }
+            // Any other `-` word is a bad option in real Tcl. Skipping it
+            // keeps the path reading unaffected, which is the conservative
+            // choice for a command that will fail anyway.
             continue;
         }
-        if !past_flags && word == "--" {
-            past_flags = true;
-            continue;
+        if path.is_none() {
+            path = Some(word);
+        } else {
+            too_many_paths = true;
         }
-        path = Some(word);
-        break;
+    }
+    if too_many_paths {
+        return (safe, None);
     }
     (safe, path)
 }
@@ -128,11 +153,23 @@ fn interp_create_words_from_value(text: &str) -> Option<Vec<&str>> {
     // `"{parent"`, `"child}"`), binding the variable to a key the direct
     // handler never records — later `$i eval` / `interp alias $i …` then
     // resolve against a phantom interpreter.
+    // A parse error means `inner` is not a well-formed Tcl list at all
+    // (`interp create {child]`), so there is no interpreter here to record.
+    // Keeping the words parsed so far would bind the variable to a path
+    // real Tcl never creates — a phantom interpreter that later `$i eval` /
+    // `interp alias $i …` sites then resolve against, which is exactly what
+    // an incomplete edit looks like mid-keystroke.
     let mut words = Vec::new();
     let mut pos = 0usize;
-    while let Ok(Some(el)) = find_element(inner, pos) {
-        words.push(inner.get(el.value.clone())?);
-        pos = el.next;
+    loop {
+        match find_element(inner, pos) {
+            Ok(Some(el)) => {
+                words.push(inner.get(el.value.clone())?);
+                pos = el.next;
+            }
+            Ok(None) => break,
+            Err(_) => return None,
+        }
     }
     let mut words = words.into_iter();
     if words.next()? != "interp" || words.next()? != "create" {
@@ -4621,13 +4658,81 @@ mod tests {
     }
 
     #[test]
-    fn interp_create_value_words_abstain_on_an_unmatched_brace_issue_1025() {
-        // FN guard — a malformed (mid-edit) path stops the element scan, so
-        // the words seen are only those parsed before the break; nothing
-        // may be silently mis-split into fragments.
+    fn interp_create_value_words_reject_an_unmatched_brace_issue_1025() {
+        // A malformed (mid-edit) path is not a list at all, so the whole
+        // substitution is rejected. Returning the prefix parsed before the
+        // error instead — `Some(vec![])` here — read as a bare `interp
+        // create`, binding the variable to an auto-named interpreter real
+        // Tcl never creates. Later `$i eval` / `interp alias $i …` sites
+        // then resolved against that phantom (Codex review, PR #1045).
         assert_eq!(
             interp_create_words_from_value("[interp create {child]"),
-            Some(vec![])
+            None
+        );
+        assert_eq!(
+            interp_create_words_from_value("[interp create good {child]"),
+            None,
+            "a valid prefix does not rescue a malformed tail",
+        );
+    }
+
+    // parse_interp_create_words — full flag scan, mirroring tclInterp.c
+
+    #[test]
+    fn interp_create_flags_are_still_scanned_after_the_path() {
+        // C Tcl examines every word and treats a `-` word as a flag until
+        // `--`, whether or not the path has been read. tclsh8.6/9.0:
+        // `interp create x -safe` yields `interp issafe x` == 1, and
+        // `interp create n -bogus` errors `bad option "-bogus"` — proof the
+        // scan does not stop at the path. Stopping at the path recorded `x`
+        // as an *unsafe* interpreter.
+        assert_eq!(
+            parse_interp_create_words(&["x", "-safe"]),
+            (true, Some("x"))
+        );
+        assert_eq!(
+            parse_interp_create_words(&["-safe", "y"]),
+            (true, Some("y"))
+        );
+    }
+
+    #[test]
+    fn interp_create_double_dash_ends_flag_parsing() {
+        // tclsh8.6/9.0: `interp create -safe -- z` creates a safe `z`, and
+        // `interp create -- -safe` creates an *unsafe* interpreter whose
+        // path is the literal `-safe`.
+        assert_eq!(
+            parse_interp_create_words(&["-safe", "--", "z"]),
+            (true, Some("z"))
+        );
+        assert_eq!(
+            parse_interp_create_words(&["--", "-safe"]),
+            (false, Some("-safe"))
+        );
+    }
+
+    #[test]
+    fn interp_create_two_path_words_record_no_path() {
+        // tclsh8.6/9.0: `interp create a b` is `wrong # args`. No
+        // interpreter is created, so recording either word would bind a
+        // name that does not exist. A `-safe` seen alongside is still
+        // reported — it costs nothing and the command creates nothing.
+        assert_eq!(parse_interp_create_words(&["a", "b"]), (false, None));
+        assert_eq!(
+            parse_interp_create_words(&["--", "x", "-safe"]),
+            (false, None),
+            "after `--` a second `-` word is a path word, so this is the error shape too",
+        );
+    }
+
+    #[test]
+    fn interp_create_bare_and_flag_only_forms_are_unchanged() {
+        // TN control for the rewritten scan.
+        assert_eq!(parse_interp_create_words(&[]), (false, None));
+        assert_eq!(parse_interp_create_words(&["-safe"]), (true, None));
+        assert_eq!(
+            parse_interp_create_words(&["child"]),
+            (false, Some("child"))
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -296,7 +296,7 @@ struct KnownPredicateCtx<'a, A> {
     alias_offsets: &'a HashMap<String, u32>,
     rename_offsets: &'a HashMap<String, u32>,
     deleted_commands: &'a HashMap<String, u32>,
-    top_level_call_offsets: &'a HashMap<String, u32>,
+    reachable_call_offsets: &'a HashMap<String, u32>,
 }
 
 impl<A> KnownPredicateCtx<'_, A> {
@@ -361,6 +361,12 @@ impl<A> KnownPredicateCtx<'_, A> {
     /// global `::bar` — confirmed against tclsh 8.6.14 — because
     /// `foo::caller`'s own top-level invocation already ran before the
     /// rename.
+    ///
+    /// The enclosing definition need not be called at the top level
+    /// *itself* — [`Analyser::reachable_call_offsets`] answers the
+    /// transitive question (issue #1015), so an arbitrarily deep chain of
+    /// enclosing definitions bottoming out at a real top-level call counts,
+    /// while a mutual-recursion cycle no top-level call enters does not.
     fn live_for_call(&self, qualified: &str, fact_off: u32, call_off: u32) -> bool {
         let Some(&del_off) = self.deleted_commands.get(qualified) else {
             return true;
@@ -375,7 +381,7 @@ impl<A> KnownPredicateCtx<'_, A> {
             return call_off <= del_off;
         }
         self.enclosing_definition(call_off)
-            .and_then(|qn| self.top_level_call_offsets.get(qn))
+            .and_then(|qn| self.reachable_call_offsets.get(qn))
             .is_some_and(|&t| t < del_off)
     }
 
@@ -683,29 +689,73 @@ impl Analyser {
             .collect()
     }
 
-    /// Build [`Analyser::top_level_call_offsets`]: the earliest offset,
-    /// among the walk's recorded invocations, of a call whose own site is
-    /// *not* inside any proc/class body — grouped by resolved qualified
-    /// name.  Read by [`Self::finalise_invocation_resolutions`]'s
-    /// `live_for_call` and by [`Self::fact_live_for_call`] as the "was the
-    /// enclosing definition itself invoked before the deletion" escape
-    /// hatch for a call nested inside a body (issue #1009 Codex review).
-    fn compute_top_level_call_offsets(&self) -> HashMap<String, u32> {
-        let mut offsets: HashMap<String, u32> = HashMap::new();
+    /// Build [`Analyser::reachable_call_offsets`]: the earliest offset at
+    /// which each resolved qualified name is *provably reached* by the
+    /// file's own top-level execution.
+    ///
+    /// The base case is a call whose own site is not inside any proc/class
+    /// body — that call runs where it is written. The recursive case is a
+    /// call inside some definition `E`'s body: it runs whenever `E` runs, so
+    /// it inherits `E`'s own earliest reachable offset (issue #1015:
+    /// `proc helper {}`, `proc inner {} { helper }`, `proc outer {} { inner
+    /// }`, `outer`, `rename helper {}` — tclsh8.6/9.0 run this clean,
+    /// because `outer`'s top-level call reaches `helper` two bodies deep,
+    /// before the rename).
+    ///
+    /// Computed as a monotone least-fixpoint over the call graph rather
+    /// than a memoised recursion: offsets only ever decrease, so the loop
+    /// terminates, and a mutual-recursion cycle with no top-level entry
+    /// simply never acquires a value (`None` — unreachable) instead of
+    /// recursing forever.
+    ///
+    /// Read by [`Self::finalise_invocation_resolutions`]'s `live_for_call`
+    /// and by [`Self::fact_live_for_call`] as the "was this call's enclosing
+    /// definition itself reached before the deletion" escape hatch (issue
+    /// #1009 Codex review, generalised by #1015).
+    fn compute_reachable_call_offsets(&self) -> HashMap<String, u32> {
+        let mut reachable: HashMap<String, u32> = HashMap::new();
+        // Call-graph edges: `enclosing definition -> callee`, for every
+        // invocation whose own site sits inside a body.
+        let mut body_edges: Vec<(&str, &str)> = Vec::new();
         for inv in &self.result.command_invocations {
             let Some(qualified) = inv.resolved_qualified_name.as_deref() else {
                 continue;
             };
             let call_off = inv.range.start();
-            if self.result.offset_is_inside_any_definition_body(call_off) {
+            if !self.result.offset_is_inside_any_definition_body(call_off) {
+                reachable
+                    .entry(qualified.to_string())
+                    .and_modify(|off| *off = (*off).min(call_off))
+                    .or_insert(call_off);
                 continue;
             }
-            offsets
-                .entry(qualified.to_string())
-                .and_modify(|off| *off = (*off).min(call_off))
-                .or_insert(call_off);
+            if let Some(enclosing) = self.result.enclosing_definition_qualified_name(call_off) {
+                body_edges.push((enclosing, qualified));
+            }
         }
-        offsets
+        loop {
+            let mut changed = false;
+            for &(enclosing, callee) in &body_edges {
+                let Some(&reached) = reachable.get(enclosing) else {
+                    continue;
+                };
+                match reachable.get_mut(callee) {
+                    Some(off) if *off <= reached => {}
+                    Some(off) => {
+                        *off = reached;
+                        changed = true;
+                    }
+                    None => {
+                        reachable.insert(callee.to_string(), reached);
+                        changed = true;
+                    }
+                }
+            }
+            if !changed {
+                break;
+            }
+        }
+        reachable
     }
 
     pub(super) fn finalise_invocation_resolutions(&mut self) {
@@ -739,11 +789,11 @@ impl Analyser {
         // review) can consult it, and cached on `self` so the later W123 /
         // const-dispatch / variable-command passes' `Self::fact_live_for_call`
         // calls reuse the same map instead of rebuilding it.
-        self.top_level_call_offsets = self.compute_top_level_call_offsets();
+        self.reachable_call_offsets = self.compute_reachable_call_offsets();
         let renamed_away = self.renamed_away_builtin_names();
         let deleted_commands = &self.deleted_commands;
         let rename_offsets = &self.rename_offsets;
-        let top_level_call_offsets = &self.top_level_call_offsets;
+        let reachable_call_offsets = &self.reachable_call_offsets;
         let result = &mut self.result;
         let (procs, classes, aliases, renames) = (
             &result.all_procs,
@@ -766,7 +816,7 @@ impl Analyser {
             alias_offsets,
             rename_offsets,
             deleted_commands,
-            top_level_call_offsets,
+            reachable_call_offsets,
         };
         for inv in &mut result.command_invocations {
             // Absolute names are exact — the sole candidate is the name itself.
@@ -2425,6 +2475,48 @@ mod tests {
             bar_call.resolved_qualified_name.as_deref(),
             Some("::bar"),
             "foo::caller is never invoked, so the escape hatch must not apply"
+        );
+    }
+
+    #[test]
+    fn escape_hatch_follows_a_chain_of_enclosing_definitions_issue_1015() {
+        // FP guard (issue #1015): `foo::caller` is never invoked at the top
+        // level — only `foo::entry` is — but `entry` calls `caller`, which
+        // calls `bar`, all before the rename, so the local `::foo::bar`
+        // stays the resolution. tclsh8.6/9.0 confirm the chain runs clean.
+        let mut a = Analyser::new();
+        let src = "proc bar {} { return global }\nnamespace eval foo {\n    proc bar {} { return local }\n    proc caller {} { return [bar] }\n    proc entry {} { return [caller] }\n}\nfoo::entry\nrename foo::bar {}\n";
+        let r = a.analyse(src, "tcl8.6");
+        let bar_call = r
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "bar" && !i.indirect)
+            .expect("bar call recorded");
+        assert_eq!(
+            bar_call.resolved_qualified_name.as_deref(),
+            Some("::foo::bar"),
+            "foo::entry reaches foo::caller, which reaches bar, before the rename"
+        );
+    }
+
+    #[test]
+    fn escape_hatch_terminates_on_a_never_entered_mutual_recursion_cycle_issue_1015() {
+        // TP guard (issue #1015): `foo::ping` and `foo::pong` call each
+        // other and nothing calls either, so neither is ever reached — the
+        // reachability fixpoint must terminate and leave the escape hatch
+        // shut, falling the `bar` call back to the global `::bar`.
+        let mut a = Analyser::new();
+        let src = "proc bar {} { return global }\nnamespace eval foo {\n    proc bar {} { return local }\n    proc ping {} { pong\n        return [bar] }\n    proc pong {} { return [ping] }\n}\nrename foo::bar {}\n";
+        let r = a.analyse(src, "tcl8.6");
+        let bar_call = r
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "bar" && !i.indirect)
+            .expect("bar call recorded");
+        assert_eq!(
+            bar_call.resolved_qualified_name.as_deref(),
+            Some("::bar"),
+            "neither cycle member is ever reached, so the escape hatch must not apply"
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -712,8 +712,47 @@ impl Analyser {
     /// and by [`Self::fact_live_for_call`] as the "was this call's enclosing
     /// definition itself reached before the deletion" escape hatch (issue
     /// #1009 Codex review, generalised by #1015).
+    ///
+    /// # A body edge may raise a callee's offset but never lower a base one
+    ///
+    /// A call site's *presence* in a body is not proof that the body reaches
+    /// it. `proc a {} { if {0} { b } }` never calls `b`, so `a`'s own
+    /// earliest offset says nothing about when `b` first runs — yet the
+    /// unrestricted fixpoint handed `b` (and everything `b` calls) `a`'s
+    /// early offset, which then read as "reached before the deletion" and
+    /// silently withdrew a correct W123.
+    ///
+    /// Oracle (tclsh8.6, `review-probes-sound/r1.tcl`): with `proc b {}
+    /// { helper }`, `proc a {} { if {0} { b } }`, `a`, `rename helper {}`,
+    /// `b` — the final `b` really does fail with `invalid command name
+    /// "helper"`.
+    ///
+    /// The precise rule would drop edges inside regions a constant-branch
+    /// analysis proves unreachable, but those facts do not exist yet here:
+    /// SCCP runs later, over the IR this analyser's result feeds, so
+    /// consulting it at edge-collection time would be circular. What is
+    /// available is the base case itself, so the fixpoint keeps the
+    /// **weaker, non-circular** rule the review offered as its alternative:
+    ///
+    /// > a body edge may only ever *add* a callee offset, never *lower* a
+    /// > base top-level one.
+    ///
+    /// A callee with its own top-level call site has an offset that is
+    /// already a fact about real execution; a speculative path through some
+    /// body may not undercut it. A callee with no top-level call site keeps
+    /// the old optimism — the chain is the only evidence there is, and
+    /// dropping it would reopen issue #1015.
+    ///
+    /// This is deliberately approximate in the sound direction for the
+    /// review's repros and deliberately optimistic elsewhere. It does not
+    /// catch a dead edge to a callee that is never called at top level at
+    /// all, and it can raise an offset for a *live* body edge whose callee
+    /// also has a later top-level call.
     fn compute_reachable_call_offsets(&self) -> HashMap<String, u32> {
         let mut reachable: HashMap<String, u32> = HashMap::new();
+        // Callees with a top-level (non-body) call site. Their offsets are
+        // observations of real execution, so body edges may not lower them.
+        let mut has_base_offset: HashSet<&str> = HashSet::new();
         // Call-graph edges: `enclosing definition -> callee`, for every
         // invocation whose own site sits inside a body.
         let mut body_edges: Vec<(&str, &str)> = Vec::new();
@@ -723,6 +762,7 @@ impl Analyser {
             };
             let call_off = inv.range.start();
             if !self.result.offset_is_inside_any_definition_body(call_off) {
+                has_base_offset.insert(qualified);
                 reachable
                     .entry(qualified.to_string())
                     .and_modify(|off| *off = (*off).min(call_off))
@@ -741,6 +781,7 @@ impl Analyser {
                 };
                 match reachable.get_mut(callee) {
                     Some(off) if *off <= reached => {}
+                    Some(_) if has_base_offset.contains(callee) => {}
                     Some(off) => {
                         *off = reached;
                         changed = true;

--- a/rust/tcl-compiler/src/analyser/snapshot.rs
+++ b/rust/tcl-compiler/src/analyser/snapshot.rs
@@ -51,6 +51,9 @@ use super::types::AnalysisResult;
 /// - ``conditional_depth`` — depth of the ``if`` / ``catch`` /
 ///   ``try`` nesting; used to mark ``package require`` records as
 ///   ``conditional=true``.
+/// - ``control_flow_body_depth`` — depth of nesting inside any
+///   ``Traits::CONTROL_FLOW`` command's body; used to tell a
+///   straight-line `rename` from one that may never run.
 /// - ``command_aliases`` — `interp alias` table.
 /// - ``renamed_commands`` — static `rename` table.
 /// - ``const_strings`` / ``regex_vars`` — per-scope const-string
@@ -70,6 +73,8 @@ pub struct AnalyserSnapshot {
     pub current_event: Option<String>,
     /// Conditional-nesting depth.
     pub conditional_depth: u32,
+    /// Nesting depth inside a `Traits::CONTROL_FLOW` command's body.
+    pub control_flow_body_depth: u32,
     /// Command aliases: ``name -> (target, prepended_args)``.
     pub command_aliases: HashMap<String, (String, Vec<String>)>,
     /// Static renames: ``new_qname -> old_qname``.
@@ -123,6 +128,7 @@ impl Analyser {
             last_comment: self.last_comment.clone(),
             current_event: self.current_event.clone(),
             conditional_depth: self.conditional_depth,
+            control_flow_body_depth: self.control_flow_body_depth,
             command_aliases: self.command_aliases.clone(),
             renamed_commands: self.renamed_commands.clone(),
             const_strings: self.const_strings.clone(),
@@ -157,6 +163,7 @@ impl Analyser {
         self.last_comment = snap.last_comment;
         self.current_event = snap.current_event;
         self.conditional_depth = snap.conditional_depth;
+        self.control_flow_body_depth = snap.control_flow_body_depth;
         self.command_aliases = snap.command_aliases;
         self.renamed_commands = snap.renamed_commands;
         self.const_strings = snap.const_strings;

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -335,20 +335,28 @@ pub struct Analyser {
     /// [`Self::rename_offsets`]), instead of still validating it against
     /// a definition that's no longer callable under that name.
     pub deleted_commands: HashMap<String, u32>,
-    /// Earliest source offset, among this file's recorded command
-    /// invocations, of a *top-level* (not inside any proc/class body) call
-    /// resolving to each qualified name — keyed by `resolved_qualified_name`.
+    /// Earliest source offset at which this file's own top-level execution
+    /// provably *reaches* each qualified name — keyed by
+    /// `resolved_qualified_name`. A top-level (not inside any proc/class
+    /// body) call contributes its own offset; a call inside definition
+    /// `E`'s body contributes `E`'s own reachable offset, transitively
+    /// through the whole call graph (issue #1015).
+    ///
     /// Populated once by [`Self::finalise_invocation_resolutions`] from the
     /// already-settled `command_invocations`, and consulted by
     /// [`Self::fact_live_for_call`] when the call site under test is itself
-    /// nested inside a body: a proven top-level invocation of the
-    /// *enclosing* definition that ran before a later unconditional
-    /// deletion means that invocation's own nested calls already resolved
-    /// (issue #1009 Codex review: `proc helper {}`, `proc caller {} {
-    /// helper }`, `caller`, `rename helper {}` resolves in real Tcl —
-    /// confirmed against tclsh 8.6.14 — because `caller`'s own top-level
-    /// invocation runs before the rename).
-    pub(super) top_level_call_offsets: HashMap<String, u32>,
+    /// nested inside a body: a proven invocation of the *enclosing*
+    /// definition that ran before a later unconditional deletion means that
+    /// invocation's own nested calls already resolved (issue #1009 Codex
+    /// review: `proc helper {}`, `proc caller {} { helper }`, `caller`,
+    /// `rename helper {}` resolves in real Tcl — confirmed against tclsh
+    /// 8.6.14 — because `caller`'s own top-level invocation runs before the
+    /// rename; issue #1015 extends that through an arbitrary chain of
+    /// enclosing definitions).
+    ///
+    /// A name with no entry is one this file never reaches — including
+    /// every member of a mutual-recursion cycle no top-level call enters.
+    pub(super) reachable_call_offsets: HashMap<String, u32>,
     /// Static `namespace path {…}` declarations: ``declaring namespace →
     /// raw path entries`` (each declaration replaces the whole path, as in
     /// C Tcl, so the lexically-last one wins). Entries are stored as
@@ -848,7 +856,7 @@ impl Analyser {
             alias_offsets: HashMap::new(),
             rename_offsets: HashMap::new(),
             deleted_commands: HashMap::new(),
-            top_level_call_offsets: HashMap::new(),
+            reachable_call_offsets: HashMap::new(),
             namespace_paths: HashMap::new(),
             var_command_sites: Vec::new(),
             pending_const_dispatches: Vec::new(),

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -277,6 +277,23 @@ pub struct Analyser {
     /// `if` / `catch` / `try` arms, used to mark
     /// ``package require`` records as ``conditional=true``.
     pub conditional_depth: u32,
+    /// Nesting depth inside the body of a [`tcl_registry::Traits::CONTROL_FLOW`]
+    /// command — `if`, `while`, `for`, `foreach`, `lmap`, `switch`, `try`,
+    /// `catch` and their dialect siblings.
+    ///
+    /// A body at depth 0 is *straight-line*: it runs exactly once when its
+    /// enclosing script runs. Depth above 0 means the walker cannot say
+    /// whether the command runs at all, which is what
+    /// [`Self::handle_rename`] needs before recording a command deletion as
+    /// unconditional. Deliberately distinct from `conditional_depth`, which
+    /// covers only `if`/`try` and drives the `package require` conditional
+    /// flag.
+    ///
+    /// Registry-driven: the trait decides, so no command name appears in the
+    /// walker. `namespace eval`, `eval`, and `uplevel` bodies do *not* count
+    /// — they run unconditionally, so a deletion inside one is still
+    /// straight-line.
+    pub control_flow_body_depth: u32,
     /// Body-nesting depth — incremented on entry to a braced
     /// body. Used for top-level-only command checks.
     pub body_depth: u32,
@@ -866,6 +883,7 @@ impl Analyser {
             builtin_names: None,
             builtin_dialect: None,
             conditional_depth: 0,
+            control_flow_body_depth: 0,
             body_depth: 0,
             e207_emitted: false,
             body_scope_stack: Vec::new(),

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -356,6 +356,24 @@ pub struct Analyser {
     ///
     /// A name with no entry is one this file never reaches — including
     /// every member of a mutual-recursion cycle no top-level call enters.
+    ///
+    /// # Known false negative: only the *earliest* reach is recorded
+    ///
+    /// The map holds one offset per name — the earliest — so a definition
+    /// called both before and after a deletion looks reached-before, and the
+    /// deletion diagnostic on its body is withdrawn for *all* of its
+    /// invocations rather than just the early ones.
+    ///
+    /// Oracle (tclsh8.6, `review-probes-sound/r3.tcl`): `proc a {} {
+    /// helper }`, `a`, `rename helper {}`, `a` — the second `a` really does
+    /// fail with `invalid command name "helper"`, and no W123 is reported.
+    ///
+    /// This is unchanged by design: reporting it needs a per-invocation
+    /// reachability interval rather than a single floor, and the escape
+    /// hatch exists precisely to stop the far commoner call-before-deletion
+    /// shape being flagged. Issue #1015 widened the false negative — a
+    /// transitive chain now reaches through arbitrarily many bodies — but
+    /// did not introduce it.
     pub(super) reachable_call_offsets: HashMap<String, u32>,
     /// Static `namespace path {…}` declarations: ``declaring namespace →
     /// raw path entries`` (each declaration replaces the whole path, as in

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -2243,8 +2243,8 @@ mod tests {
         /// caller's `"a"` folded the condition.
         ///
         /// `build_extra_call_site_scan_contexts` now builds a bare CFG for
-        /// every `frame_shift == 0` `UpFrame` body, resolved as `"::top"` —
-        /// mirroring how a `TclOO` method body is forced global.
+        /// every *absolute* shift-`0` `UpFrame` body, resolved as `"::top"`
+        /// — mirroring how a `TclOO` method body is forced global.
         ///
         /// `uplevel N` for any relative (non-`#0`) level stays out of scope:
         /// the target frame's namespace depends on the live call stack,
@@ -2284,6 +2284,44 @@ mod tests {
                 !folds_condition_mentioning(ns_helper, "mode"),
                 "::foo::helper is never actually called by real Tcl semantics: {:?}",
                 ns_helper.sccp.constant_branches,
+            );
+        }
+
+        /// MISCOMPILE regression (adversarial review): `uplevel 0 { … }` is
+        /// the *relative* current-frame form and must NOT be treated as the
+        /// absolute global form. Lowering encoded `#0` and `0` as the same
+        /// `frame_shift == 0`, so this body was resolved against `"::top"`
+        /// and `::foo::helper` lost its only varying call site — folding a
+        /// branch that real Tcl reaches both ways.
+        ///
+        /// Oracle (tclsh8.6 and tclsh9.0, `review-probes/up1.tcl`): inside
+        /// `::foo::runIt`, `uplevel #0 { helper b }` prints `GLOBAL helper`
+        /// while `uplevel 0 { helper c }` prints `FOO helper`.
+        #[test]
+        fn uplevel_bare_zero_body_resolves_against_the_enclosing_namespace() {
+            let reg = registry();
+            let src = "
+                namespace eval ::foo {
+                    proc helper {mode} {
+                        if {$mode eq \"a\"} { set r 1 } else { set r 2 }
+                    }
+                    proc runIt {} {
+                        uplevel 0 { helper b }
+                    }
+                }
+                ::foo::helper a
+                ::foo::runIt
+            ";
+            let cu = CompilationUnit::build_for(src, &reg, false);
+            let helper = cu
+                .procedures
+                .get("::foo::helper")
+                .expect("::foo::helper analysed");
+            assert!(
+                !folds_condition_mentioning(helper, "mode"),
+                "`uplevel 0` runs in the current frame, so ::foo::helper sees both \
+                 \"a\" (direct) and \"b\" (the uplevel body): {:?}",
+                helper.sccp.constant_branches,
             );
         }
 

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -1040,10 +1040,11 @@ impl CompilationUnit {
         // memoised request, the methods/body-units below, and the call-site
         // scan's extra caller contexts, so the offset-0 CFG the memo rebuilds
         // is identical to this whole-module build's.  Only needed on the
-        // memoised path or when methods/body units are present.
-        let cfg_context =
-            (cache.is_some() || !ir_module.methods.is_empty() || !ir_module.body_units.is_empty())
-                .then(|| crate::cfg_builder::prepare_cfg_context(&ir_module));
+        // memoised path or when the call-site scan has extra caller contexts
+        // to build (methods, body units, `uplevel #0` bodies).
+        let cfg_context = (cache.is_some()
+            || crate::unit_scope::needs_extra_call_site_scan_contexts(&ir_module))
+        .then(|| crate::cfg_builder::prepare_cfg_context(&ir_module));
         let (call_site_constants, command_mutations, linkage) =
             resolve_unit_scope(&ir_module, &cfg_module, cfg_context.as_ref(), options);
         let caller_view = crate::unit_scope::UnitCallerView {
@@ -2187,31 +2188,26 @@ mod tests {
             );
         }
 
-        /// KNOWN RESIDUAL GAP (Codex review, PR #970) — confirmed, not yet
-        /// fixed: `uplevel #0 { … }`'s body resolves bare commands against
-        /// the GLOBAL namespace (tclsh8.6-confirmed live,
-        /// `/tmp/uplevel0_probe.tcl`: `uplevel #0 { helper }` inside
-        /// `::foo::runIt` calls `::helper`, never `::foo::helper`), but
-        /// `Statement::UpFrame`'s body is inlined into the enclosing
-        /// function's own CFG blocks *before* `collect_call_site_constants`
-        /// ever sees it — `frame_shift` (the field that would tell us "this
-        /// call originated inside an absolute-frame `uplevel #0`, force
-        /// global") is consumed by CFG construction and isn't visible at the
-        /// point this scan walks `block.statements`. Confirmed live: this
-        /// call is misattributed to `::foo::helper` (which real Tcl never
-        /// actually invokes this way — a phantom fold) while the real target
-        /// `::helper` is *also* wrong, not merely under-evidenced. Properly
-        /// fixing this needs `frame_shift == 0` preserved through CFG
-        /// construction (or a pre-CFG scan of `Statement::UpFrame`, mirroring
-        /// `build_extra_call_site_scan_contexts`'s method/body-unit
-        /// approach) — larger than a one-line namespace-context override, so
-        /// deliberately left for follow-up rather than a rushed fix.
-        /// `uplevel N` for any relative (non-`#0`) level is separately
-        /// undecidable by a single-file static analysis (the target frame's
-        /// namespace depends on the live call stack) and stays a documented,
+        /// FN regression (issue #980, Codex review of PR #970): `uplevel #0
+        /// { … }`'s body resolves bare commands against the GLOBAL
+        /// namespace — tclsh8.6/9.0-confirmed live: `uplevel #0 { helper b
+        /// }` inside `::foo::runIt` prints `GLOBAL helper mode=b`, never the
+        /// `::foo::helper` sitting in the enclosing namespace.
+        /// `Statement::UpFrame`'s body survives CFG construction as a block
+        /// *statement*, which `scan_cfg_callers` (walking only
+        /// `Call`/`Barrier`) skips entirely, so this real, differing call
+        /// site vanished from `::helper`'s evidence and its one remaining
+        /// caller's `"a"` folded the condition.
+        ///
+        /// `build_extra_call_site_scan_contexts` now builds a bare CFG for
+        /// every `frame_shift == 0` `UpFrame` body, resolved as `"::top"` —
+        /// mirroring how a `TclOO` method body is forced global.
+        ///
+        /// `uplevel N` for any relative (non-`#0`) level stays out of scope:
+        /// the target frame's namespace depends on the live call stack,
+        /// which single-file static analysis cannot decide — a documented,
         /// permanent approximation.
         #[test]
-        #[ignore = "confirmed residual gap, PR #970 review: uplevel #0 body namespace context; see doc comment"]
         fn uplevel_zero_body_resolves_against_global_not_enclosing_namespace() {
             let reg = registry();
             let src = "
@@ -2245,6 +2241,69 @@ mod tests {
                 !folds_condition_mentioning(ns_helper, "mode"),
                 "::foo::helper is never actually called by real Tcl semantics: {:?}",
                 ns_helper.sccp.constant_branches,
+            );
+        }
+
+        /// Approximation pin (issue #980): a *relative* `uplevel N { … }`
+        /// keeps resolving against the enclosing unit's own namespace. The
+        /// target frame's namespace depends on the live call stack, so this
+        /// is a deliberate, permanent approximation — but it must stay an
+        /// approximation that still *counts* the call site, not one that
+        /// drops it. `::foo::helper` here sees both `"a"` and `"b"`.
+        #[test]
+        fn uplevel_relative_body_keeps_the_enclosing_units_namespace() {
+            let reg = registry();
+            let src = "
+                namespace eval ::foo {
+                    proc helper {mode} {
+                        if {$mode eq \"a\"} { set r 1 } else { set r 2 }
+                    }
+                    proc runIt {} {
+                        uplevel 1 { helper b }
+                    }
+                }
+                ::foo::helper a
+                ::foo::runIt
+            ";
+            let cu = CompilationUnit::build_for(src, &reg, false);
+            let helper = cu
+                .procedures
+                .get("::foo::helper")
+                .expect("::foo::helper analysed");
+            assert!(
+                !folds_condition_mentioning(helper, "mode"),
+                "::foo::helper sees both \"a\" (direct) and \"b\" (the relative uplevel \
+                 body, approximated to the enclosing namespace): {:?}",
+                helper.sccp.constant_branches,
+            );
+        }
+
+        /// FN guard for the `Traits::DEFINES_PROCEDURE` body-recursion skip
+        /// (issue #980): a definition body is no longer re-walked from the
+        /// definition site, so its call sites must still arrive through the
+        /// defined procedure's *own* CFG. A conditionally-defined proc is
+        /// the shape most at risk — its `proc` call is not a plain top-level
+        /// statement.
+        #[test]
+        fn conditionally_defined_proc_body_call_sites_are_still_counted() {
+            let reg = registry();
+            let src = "
+                proc helper {mode} {
+                    if {$mode eq \"a\"} { set r 1 } else { set r 2 }
+                }
+                if {[info exists ::env(X)]} {
+                    proc runIt {} { helper b }
+                }
+                helper a
+                runIt
+            ";
+            let cu = CompilationUnit::build_for(src, &reg, false);
+            let helper = cu.procedures.get("::helper").expect("::helper analysed");
+            assert!(
+                !folds_condition_mentioning(helper, "mode"),
+                "::helper is called with both \"a\" and \"b\" (the conditionally-defined \
+                 runIt's body): {:?}",
+                helper.sccp.constant_branches,
             );
         }
 

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -2427,6 +2427,80 @@ mod tests {
             );
         }
 
+        /// MISCOMPILE regression (adversarial review): `apply {params body
+        /// ns}`'s third element names the namespace the body runs in, so a
+        /// bare command word inside it resolves against *that* namespace.
+        /// `lower_apply` computed the right `body_ns` and lowered the body
+        /// against it, then registered the body unit under the bare `apply`
+        /// marker — whose qname puts it in the global namespace. The call
+        /// site was attributed to a `::helper` that does not exist and
+        /// vanished from `::foo::helper`'s evidence, folding a branch real
+        /// Tcl reaches both ways.
+        ///
+        /// Oracle (tclsh8.6 and tclsh9.0, `review-probes/ap3_run.tcl`):
+        /// inside `::foo::runIt`, `apply {{x} { helper $x } ::foo} b`
+        /// returns 2 — the `else` arm of `::foo::helper` — while the direct
+        /// `::foo::helper a` returns 1.
+        #[test]
+        fn apply_with_a_namespace_element_resolves_the_body_against_it() {
+            let reg = registry();
+            let src = "
+                namespace eval ::foo {
+                    proc helper {mode} {
+                        if {$mode eq \"a\"} { set r 1 } else { set r 2 }
+                    }
+                    proc runIt {} {
+                        apply {{x} { helper $x } ::foo} b
+                    }
+                }
+                ::foo::helper a
+                ::foo::runIt
+            ";
+            let cu = CompilationUnit::build_for(src, &reg, false);
+            let helper = cu
+                .procedures
+                .get("::foo::helper")
+                .expect("::foo::helper analysed");
+            assert!(
+                !folds_condition_mentioning(helper, "mode"),
+                "::foo::helper is called with both \"a\" (direct) and \"b\" (through the \
+                 ::foo-pinned lambda): {:?}",
+                helper.sccp.constant_branches,
+            );
+        }
+
+        /// The two-element form is unchanged: with no namespace element,
+        /// `apply` runs the body in the *global* namespace, not the caller's
+        /// (Tcl `apply` manual). So the enclosing namespace's `helper` is
+        /// genuinely never called from the lambda and keeps its fold.
+        #[test]
+        fn apply_without_a_namespace_element_still_resolves_globally() {
+            let reg = registry();
+            let src = "
+                namespace eval ::foo {
+                    proc helper {mode} {
+                        if {$mode eq \"a\"} { set r 1 } else { set r 2 }
+                    }
+                    proc runIt {} {
+                        apply {{x} { helper $x }} b
+                    }
+                }
+                ::foo::helper a
+                ::foo::runIt
+            ";
+            let cu = CompilationUnit::build_for(src, &reg, false);
+            let helper = cu
+                .procedures
+                .get("::foo::helper")
+                .expect("::foo::helper analysed");
+            assert!(
+                folds_condition_mentioning(helper, "mode"),
+                "an unpinned lambda body resolves globally, so ::foo::helper only ever \
+                 sees the direct \"a\": {:?}",
+                helper.sccp.constant_branches,
+            );
+        }
+
         /// True if any constant-branch condition recorded for `fu` mentions
         /// `needle` (a variable name) — the ambient SCCP-fold check the I230
         /// diagnostic, and the O101/O107 optimiser suggestions, all key off.

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -2135,6 +2135,49 @@ mod tests {
             }
         }
 
+        /// Pinning test for issue #979: a proc reached only through a
+        /// `namespace ensemble` `-map` redirection is a real caller the
+        /// call-site scan cannot resolve — it has no model of ensemble
+        /// dispatch. tclsh8.6/9.0-confirmed: with `namespace ensemble
+        /// create -command myens -map {go helper}`, `myens go dev` prints
+        /// `helper mode=dev`, so `mode` genuinely varies and must not fold.
+        ///
+        /// Nothing pinned that today. What makes it safe is *indirect*: the
+        /// registry marks `namespace ensemble` with `Traits::EXPORTS_COMMAND`,
+        /// which `params_constants_from_call_sites` treats as a boundary
+        /// publishing the file's commands to callers it cannot enumerate, so
+        /// the whole module declines seeding. Sound but blunt — and a future
+        /// registry edit narrowing that trait (or a precision follow-up that
+        /// starts resolving *some* ensemble maps) would silently reopen
+        /// issue #969's exact false-fold shape here. This test guards that
+        /// mechanism, whatever replaces it: the fold must stay off unless a
+        /// real ensemble-map resolution lands.
+        #[test]
+        fn ensemble_map_redirected_caller_does_not_fold_issue_979() {
+            let reg = registry();
+            let src = "
+                proc helper {mode} {
+                    if {$mode eq \"prod\"} { set r 1 } else { set r 2 }
+                }
+                helper prod
+                helper prod
+                namespace ensemble create -command myens -map {go helper}
+                myens go dev
+            ";
+            for cu in [
+                CompilationUnit::build_for(src, &reg, false),
+                build_closed_world(src, &reg),
+            ] {
+                let f = cu.procedures.get("::helper").expect("helper analysed");
+                assert!(
+                    !folds_condition_mentioning(f, "mode"),
+                    "`myens go dev` reaches helper with \"dev\" (tclsh8.6/9.0-confirmed), \
+                     so mode is not caller-invariant: {:?}",
+                    f.sccp.constant_branches,
+                );
+            }
+        }
+
         /// FP guard (Codex review, PR #970): a `TclOO` method body resolves
         /// bare commands against the GLOBAL namespace, never the class's own
         /// namespace — tclsh8.6-confirmed live: `[::foo::Widget new] go`

--- a/rust/tcl-compiler/src/inline_uplevel.rs
+++ b/rust/tcl-compiler/src/inline_uplevel.rs
@@ -19,8 +19,8 @@
 //! Whole-callee uplevel-passthrough inlining.
 //!
 //! Detects procs whose entire body is a single
-//! [`Statement::UpFrame`] with `frame_shift == 1` (the canonical
-//! "shift to caller's frame, evaluate body, restore frame" idiom)
+//! [`Statement::UpFrame`] with a *relative* `frame_shift == 1` (the
+//! canonical "shift to caller's frame, evaluate body, restore frame" idiom)
 //! and rewrites every callsite to splice the body inline.
 
 use std::collections::HashMap;
@@ -33,8 +33,8 @@ use tcl_registry::CommandRegistry;
 #[derive(Debug, Clone)]
 pub enum PassthroughShape {
     /// Zero-param proc whose body is exactly one
-    /// `Statement::UpFrame { frame_shift: 1, body, .. }` — splice
-    /// `body` directly at every callsite.
+    /// `Statement::UpFrame { frame_shift: 1, absolute: false, body, .. }`
+    /// — splice `body` directly at every callsite.
     Static {
         /// Pre-lowered body to inline at every callsite.
         body: Script,
@@ -92,9 +92,11 @@ fn classify_passthrough(proc: &Procedure) -> Option<PassthroughShape> {
 }
 
 /// Return the inner body if *proc* is a zero-param `uplevel 1`
-/// passthrough — body is exactly one [`Statement::UpFrame`] with
-/// `frame_shift == 1` and contains no nested frame-reaching
-/// commands.
+/// passthrough — body is exactly one [`Statement::UpFrame`] with a
+/// *relative* `frame_shift == 1` and no nested frame-reaching
+/// commands. The absolute `uplevel #1` names a frame counted down
+/// from the global one, so it is not the same-frame idiom and is
+/// rejected alongside `#0`.
 fn static_passthrough_body(proc: &Procedure) -> Option<Script> {
     if !proc.params.is_empty() {
         return None;
@@ -104,8 +106,11 @@ fn static_passthrough_body(proc: &Procedure) -> Option<Script> {
     }
     match &proc.body.statements[0] {
         Statement::UpFrame {
-            frame_shift, body, ..
-        } if *frame_shift == 1 => {
+            frame_shift,
+            absolute,
+            body,
+            ..
+        } if !*absolute && *frame_shift == 1 => {
             if body_has_frame_reach(body) || body_has_completion_escape(body) {
                 None
             } else {
@@ -624,6 +629,20 @@ mod tests {
         // expressed as a same-frame inline.
         let m = lower_to_ir("proc reset {} { uplevel #0 {set counter 0} }", &reg());
         assert!(detect_static_passthrough(&m).is_empty());
+    }
+
+    #[test]
+    fn absolute_level_one_is_not_static_passthrough() {
+        // `uplevel #1` counts *down* from the global frame, so it is not the
+        // caller's-frame idiom `uplevel 1` denotes. Both carry the magnitude
+        // 1; only the `absolute` flag separates them.
+        let m = lower_to_ir("proc reset {} { uplevel #1 {set counter 0} }", &reg());
+        assert!(detect_static_passthrough(&m).is_empty());
+        let relative = lower_to_ir("proc reset {} { uplevel 1 {set counter 0} }", &reg());
+        assert!(
+            !detect_static_passthrough(&relative).is_empty(),
+            "the relative form is still recognised",
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/inlining/mod.rs
+++ b/rust/tcl-compiler/src/inlining/mod.rs
@@ -1051,6 +1051,7 @@ fn rewrite_single_body_stmt(
         Statement::UpFrame {
             span,
             frame_shift,
+            absolute,
             body,
             tokens,
         } => {
@@ -1060,6 +1061,7 @@ fn rewrite_single_body_stmt(
                 vec![Statement::UpFrame {
                     span: *span,
                     frame_shift: *frame_shift,
+                    absolute: *absolute,
                     body: new_body,
                     tokens: tokens.clone(),
                 }]

--- a/rust/tcl-compiler/src/inlining/rename.rs
+++ b/rust/tcl-compiler/src/inlining/rename.rs
@@ -257,11 +257,13 @@ fn rewrite_block_like(stmt: &Statement, rename: &HashMap<String, String>) -> Sta
         Statement::UpFrame {
             span,
             frame_shift,
+            absolute,
             body,
             tokens,
         } => Statement::UpFrame {
             span: *span,
             frame_shift: *frame_shift,
+            absolute: *absolute,
             body: rewrite_script(body, rename),
             tokens: tokens.clone(),
         },

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -459,11 +459,26 @@ pub enum Statement {
     UpFrame {
         /// Source span of the original `uplevel` call.
         span: Span,
-        /// Frame shift in caller-relative levels — `1` for `uplevel
-        /// 1 {body}` (the canonical form), `0` for the rare `uplevel
-        /// #0 {body}` global form. Sign matches the C Tcl level
-        /// argument: positive = move up the stack, `0` = absolute.
+        /// The level argument's magnitude — `1` for `uplevel 1
+        /// {body}` (the canonical form) and for a bare `uplevel
+        /// {body}`, `0` for `uplevel #0 {body}` or `uplevel 0
+        /// {body}`. Read it together with [`Self::UpFrame::absolute`]:
+        /// the same magnitude means two different frames depending on
+        /// that flag.
         frame_shift: i32,
+        /// `true` when the level was written in the `#N` *absolute*
+        /// form, counting down from the global frame (`uplevel #0`
+        /// evaluates the body in the global frame). `false` for the
+        /// *relative* form, counting up from the current frame
+        /// (`uplevel 0` evaluates the body in the current frame,
+        /// `uplevel 1` in the caller's).
+        ///
+        /// The distinction is load-bearing, not cosmetic: `uplevel #0`
+        /// and `uplevel 0` are different frames whenever the current
+        /// frame is not the global one, so bare command words in the
+        /// body resolve against different namespaces
+        /// (tclsh8.6/9.0-confirmed).
+        absolute: bool,
         /// The pre-lowered body, evaluated at the shifted frame.
         body: Script,
         /// Original command tokens for downstream analysis.
@@ -1073,6 +1088,7 @@ mod tests {
         let upframe = Statement::UpFrame {
             span: Span::new(0, 0),
             frame_shift: 0,
+            absolute: true,
             body: Script::from_statements(vec![inner]),
             tokens: None,
         };

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -285,20 +285,40 @@ pub(crate) fn static_bool(expr_text: &str) -> Option<bool> {
     }
 }
 
-/// Parse the level argument of an `uplevel` call into a frame
-/// shift. Accepts the canonical positive-integer form (`uplevel 1
-/// body`, `uplevel 3 body`) and the global form (`#0` / `#N`),
-/// returning `None` when the argument is dynamic (`$lvl`, `[expr
-/// {...}]`) or otherwise unparseable.
+/// An `uplevel` level argument, parsed.
 ///
-/// The returned shift is normalised so callers can decide whether to
-/// route the call through [`Statement::UpFrame`] (positive shifts)
-/// or fall back to a barrier.
-fn parse_uplevel_level(text: &str) -> Option<i32> {
+/// The two forms address different frames and must not be conflated:
+/// `#N` counts *down* from the global frame, `N` counts *up* from the
+/// current one. They coincide only when the current frame is the
+/// global frame, which static analysis cannot assume.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct UplevelLevel {
+    /// The level number as written, without the `#`.
+    shift: i32,
+    /// `true` for the `#N` absolute form, `false` for the relative form.
+    absolute: bool,
+}
+
+/// Parse the level argument of an `uplevel` call. Accepts the
+/// canonical relative form (`uplevel 1 body`, `uplevel 3 body`) and
+/// the absolute form (`#0` / `#N`), returning `None` when the argument
+/// is dynamic (`$lvl`, `[expr {...}]`) or otherwise unparseable.
+///
+/// `#0` and `0` both yield a `shift` of `0` and are told apart by
+/// `absolute` — `uplevel #0 {…}` runs the body in the global frame
+/// while `uplevel 0 {…}` runs it in the current one
+/// (tclsh8.6/9.0-confirmed).
+fn parse_uplevel_level(text: &str) -> Option<UplevelLevel> {
     if let Some(rest) = text.strip_prefix('#') {
-        return rest.parse::<i32>().ok().map(|n| -n);
+        return rest.parse::<i32>().ok().map(|shift| UplevelLevel {
+            shift,
+            absolute: true,
+        });
     }
-    text.parse::<i32>().ok()
+    text.parse::<i32>().ok().map(|shift| UplevelLevel {
+        shift,
+        absolute: false,
+    })
 }
 
 /// Return `(name, literal)` when *seg* is `set name {literal}`.
@@ -1649,8 +1669,15 @@ impl<'r> Lowerer<'r> {
         // activation) is an opt-in optimiser pass, not wired into codegen.
         let args = seg.args();
         let arg_tokens = seg.arg_tokens();
-        let (frame_shift, body_tok_idx) = match args.len() {
-            1 => (1_i32, 0),
+        let (level, body_tok_idx) = match args.len() {
+            // A bare `uplevel {body}` means relative level 1.
+            1 => (
+                UplevelLevel {
+                    shift: 1,
+                    absolute: false,
+                },
+                0,
+            ),
             2 => (parse_uplevel_level(&args[0])?, 1),
             _ => return None,
         };
@@ -1679,7 +1706,8 @@ impl<'r> Lowerer<'r> {
         };
         Some(Statement::UpFrame {
             span: seg.span,
-            frame_shift,
+            frame_shift: level.shift,
+            absolute: level.absolute,
             body,
             tokens: Some(Self::cmd_tokens(seg)),
         })
@@ -3424,15 +3452,41 @@ mod tests {
 
     #[test]
     fn parse_uplevel_level_decimal() {
-        assert_eq!(parse_uplevel_level("1"), Some(1));
-        assert_eq!(parse_uplevel_level("3"), Some(3));
-        assert_eq!(parse_uplevel_level("0"), Some(0));
+        let relative = |shift| {
+            Some(UplevelLevel {
+                shift,
+                absolute: false,
+            })
+        };
+        assert_eq!(parse_uplevel_level("1"), relative(1));
+        assert_eq!(parse_uplevel_level("3"), relative(3));
+        assert_eq!(parse_uplevel_level("0"), relative(0));
     }
 
     #[test]
     fn parse_uplevel_level_hash_form() {
-        assert_eq!(parse_uplevel_level("#0"), Some(0));
-        assert_eq!(parse_uplevel_level("#3"), Some(-3));
+        let absolute = |shift| {
+            Some(UplevelLevel {
+                shift,
+                absolute: true,
+            })
+        };
+        assert_eq!(parse_uplevel_level("#0"), absolute(0));
+        assert_eq!(parse_uplevel_level("#3"), absolute(3));
+    }
+
+    #[test]
+    fn parse_uplevel_level_zero_keeps_absolute_and_relative_apart() {
+        // `uplevel #0` runs the body in the global frame; `uplevel 0` runs it
+        // in the current frame. Both carry the magnitude 0, so only the
+        // `absolute` flag tells them apart — conflating them miscompiled the
+        // command-word namespace of every `uplevel 0` body.
+        let hash_zero = parse_uplevel_level("#0").expect("#0 parses");
+        let bare_zero = parse_uplevel_level("0").expect("0 parses");
+        assert_eq!(hash_zero.shift, bare_zero.shift);
+        assert!(hash_zero.absolute);
+        assert!(!bare_zero.absolute);
+        assert_ne!(hash_zero, bare_zero);
     }
 
     #[test]
@@ -3461,7 +3515,14 @@ mod tests {
     fn uplevel_static_body_with_level_one() {
         let m = lower_to_ir("uplevel 1 {set x 1}", &reg());
         match &m.top_level.statements[0] {
-            Statement::UpFrame { frame_shift, .. } => assert_eq!(*frame_shift, 1),
+            Statement::UpFrame {
+                frame_shift,
+                absolute,
+                ..
+            } => {
+                assert_eq!(*frame_shift, 1);
+                assert!(!*absolute, "`uplevel 1` is the relative form");
+            }
             other => panic!("expected UpFrame, got {other:?}"),
         }
     }
@@ -3470,8 +3531,34 @@ mod tests {
     fn uplevel_static_body_with_hash_zero() {
         let m = lower_to_ir("uplevel #0 {set x 1}", &reg());
         match &m.top_level.statements[0] {
-            Statement::UpFrame { frame_shift, .. } => assert_eq!(*frame_shift, 0),
+            Statement::UpFrame {
+                frame_shift,
+                absolute,
+                ..
+            } => {
+                assert_eq!(*frame_shift, 0);
+                assert!(*absolute, "`uplevel #0` is the absolute global form");
+            }
             other => panic!("expected UpFrame for #0, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn uplevel_static_body_with_bare_zero_is_relative() {
+        // `uplevel 0 {body}` evaluates the body in the *current* frame, not
+        // the global one. It shares the magnitude 0 with `#0` and is told
+        // apart only by `absolute`.
+        let m = lower_to_ir("uplevel 0 {set x 1}", &reg());
+        match &m.top_level.statements[0] {
+            Statement::UpFrame {
+                frame_shift,
+                absolute,
+                ..
+            } => {
+                assert_eq!(*frame_shift, 0);
+                assert!(!*absolute, "`uplevel 0` is the relative current-frame form");
+            }
+            other => panic!("expected UpFrame for bare 0, got {other:?}"),
         }
     }
 

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -1980,7 +1980,16 @@ impl<'r> Lowerer<'r> {
                 body_offset,
                 body_offset + u32::try_from(body_text.len()).unwrap_or(u32::MAX),
             );
-            self.register_body_unit("apply", params, span, body);
+            // Prefix the body unit's qualified name with the namespace the
+            // lambda actually runs in, exactly as `lower_namespace_eval` does
+            // — a bare command word inside the body resolves against
+            // `body_ns`, never the caller's own namespace, and
+            // `interprocedural::resolve_internal_call` reads that off the
+            // qname. `join_namespace` normalises the global case back to the
+            // plain `apply` marker. tclsh8.6/9.0-confirmed: inside
+            // `::foo::runIt`, `apply {{x} { helper $x } ::foo} b` calls
+            // `::foo::helper`, not `::helper`.
+            self.register_body_unit(&join_namespace(&body_ns, "apply"), params, span, body);
         }
 
         Statement::Barrier {

--- a/rust/tcl-compiler/src/memory_ssa.rs
+++ b/rust/tcl-compiler/src/memory_ssa.rs
@@ -1036,6 +1036,7 @@ mod tests {
         let upframe = Statement::UpFrame {
             span: tcl_lexer::Span::new(0, 0),
             frame_shift: 1,
+            absolute: false,
             body: crate::ir::Script::new(),
             tokens: None,
         };

--- a/rust/tcl-compiler/src/type_infer.rs
+++ b/rust/tcl-compiler/src/type_infer.rs
@@ -188,6 +188,18 @@ fn function_namespace(qname: &str) -> String {
 /// to a known class, else `OVERDEFINED`.  The relative head is resolved as-is,
 /// `::`-prefixed, and against the call-site `namespace` (so `[Foo new]` inside
 /// `namespace eval ns` types as `OBJECT(::ns::Foo)`).
+///
+/// `known_classes` carries **no deletion or lifetime information** — it is
+/// the raw signature-scan class set, and this module (a flow-insensitive
+/// per-symbol type inference reached from three internal sites, none of
+/// which has a call-site offset to hand) has nowhere to put one. A class
+/// this file later `rename`s away therefore still types its constructor
+/// result here. Consumers that turn an `OBJECT(class)` into a *diagnostic*
+/// must apply the liveness gate themselves — `var_command.rs`'s
+/// `aggregate_object_types` does, at file-end granularity, for W308 (issue
+/// #1013). Consumers that only use the type internally (SCCP shape
+/// selection, codegen hints) are unaffected: a dead class's constructor
+/// raises at runtime, so no correct program reaches them.
 fn constructor_object_type<S: std::hash::BuildHasher>(
     command: &str,
     args: &[&str],

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -860,17 +860,23 @@ fn record_invocation(
 /// lookup is global-scope only: a namespace-local `proc unknown` is *not*
 /// consulted for unresolved words in that namespace — tclsh8.6/9.0 both
 /// dispatch to `::unknown` regardless of the calling namespace.
+///
+/// [`CommandRegistry::commands_with_trait`] iterates a hash map, so the
+/// candidates are sorted before the first match is taken. Exactly one
+/// command carries the trait today (pinned by
+/// `only_one_command_carries_the_unresolved_handler_trait`), but an
+/// order-dependent answer would be a silent source of build-to-build drift
+/// the day a dialect adds a second carrier.
 fn unresolved_command_handler<'a, S: std::hash::BuildHasher>(
     registry: &CommandRegistry,
     known: &'a HashSet<String, S>,
 ) -> Option<&'a str> {
-    registry
-        .commands_with_trait(Traits::UNRESOLVED_COMMAND_HANDLER)
-        .into_iter()
-        .find_map(|name| {
-            let qualified = crate::naming::qualify("::", name);
-            known.get(&qualified).map(String::as_str)
-        })
+    let mut candidates = registry.commands_with_trait(Traits::UNRESOLVED_COMMAND_HANDLER);
+    candidates.sort_unstable();
+    candidates.into_iter().find_map(|name| {
+        let qualified = crate::naming::qualify("::", name);
+        known.get(&qualified).map(String::as_str)
+    })
 }
 
 /// Record the unresolved-command handler's own invocation for a literal
@@ -879,14 +885,25 @@ fn unresolved_command_handler<'a, S: std::hash::BuildHasher>(
 /// Only fires when the module defines a handler, and only for a word the
 /// registry does not know either — everything else either resolves or is a
 /// builtin. The word becomes the handler's first argument and the call's
-/// own arguments follow, exactly as Tcl passes them, so the evidence union
-/// is the precise set of values the handler's parameters really see.
+/// own arguments follow, exactly as Tcl passes them.
 ///
-/// Deliberately over-inclusive on the residue: a word bound by something
-/// this scan does not model (a class command, an ensemble, a coroutine)
-/// also reads as unresolved and contributes an extra value. That can only
-/// *retract* a fold, never manufacture one, and it costs nothing in a
-/// module with no handler.
+/// **This is additional evidence, never a complete caller set.** The
+/// handler is poisoned unconditionally in [`scan_cfg_callers`] the moment
+/// the module defines one, so nothing recorded here can seed a fold. It can
+/// only widen an already-unfoldable value set, which is what makes the two
+/// known imprecisions harmless:
+///
+/// * *Over-inclusive.* A word bound by something this scan does not model —
+///   a `TclOO` class command, an ensemble, a coroutine — also reads as
+///   unresolved and contributes a value real Tcl never passes the handler.
+/// * *Under-inclusive.* Most of the handler's real callers are words that
+///   exist nowhere in the source at all, so no scan can name them.
+///
+/// An earlier revision claimed the residue "can only retract a fold, never
+/// manufacture one". That was false while these dispatches were the
+/// handler's *only* recorded call sites: with no other evidence, a
+/// coincidentally-uniform set of invented words *was* a fold. The
+/// unconditional poison is what makes the claim true.
 fn record_unresolved_word_dispatch(
     out: &mut CallSiteEvidence,
     ctx: &CallSiteScanCtx<'_, impl std::hash::BuildHasher>,
@@ -1358,6 +1375,22 @@ fn scan_cfg_callers<'a>(
     ctx: &CallSiteScanCtx<'_, impl std::hash::BuildHasher>,
     funcs: impl Iterator<Item = (&'a str, &'a CfgFunction)>,
 ) {
+    // The unresolved-command handler's caller set is *never* enumerable, so
+    // it is poisoned before a single statement is read (issue #1044, and the
+    // adversarial review that followed).
+    //
+    // Tcl routes to it every command word that resolves to nothing at the
+    // moment of the call — a name typed at a prompt, a name a package
+    // autoloads, a name another file introduces, a name produced by string
+    // arithmetic. `record_unresolved_word_dispatch` can name *some* of those
+    // words, but naming some of a set is not enumerating it: treating those
+    // as the complete caller set let a coincidentally-uniform handful seed
+    // the handler's parameters and fold its body against values real Tcl
+    // never passes. The concrete dispatches stay, purely as extra retracting
+    // evidence.
+    if let Some(handler) = ctx.unresolved_handler {
+        out.record_opaque_caller(handler);
+    }
     for (resolve_as, func) in funcs {
         // The CFG function's own name is the *variable-scope* identity, which
         // differs from `resolve_as` for a `TclOO` method (global command
@@ -2148,17 +2181,79 @@ mod tests {
     }
 
     #[test]
-    fn a_handler_with_agreeing_callers_and_no_unresolved_words_still_seeds_1044() {
-        // TN: the gate must not blanket-disable seeding for any module that
-        // happens to define a handler — with every caller agreeing and no
-        // unresolved word anywhere, the seed still stands.
+    fn a_handler_never_seeds_even_when_every_visible_caller_agrees_1044() {
+        // The handler's caller set is unenumerable *by construction*, so
+        // agreement among the callers a scan can see proves nothing.
+        //
+        // This test previously asserted the opposite — that with no
+        // unresolved word in the file "the direct callers really are all of
+        // them" — and that premise is false. Real Tcl routes to the handler
+        // every word that resolves to nothing at the instant of the call:
+        // an auto-loaded name, a name another sourced file introduces, a
+        // name built by string arithmetic, a name typed at a prompt. None of
+        // those appear in the source for any scan to find.
+        //
+        // Oracle (tclsh8.6, `review-probes-sound/`): the seeded words are
+        // wrong in *both* directions. `Dog new` after `oo::class create Dog`
+        // and `worker` after `coroutine worker body` are recorded as
+        // dispatches, yet neither ever reaches the handler. And a `bogus
+        // beta` written *before* `proc unknown` is handled by the builtin
+        // `::unknown` — it errors — so it is not a call site of this
+        // handler either.
         let ev = evidence(
             "proc unknown {cmd args} { return $cmd }\nunknown alpha\nunknown alpha\nputs hi\n",
         );
         assert_eq!(
-            uniform(&ev, "::unknown", 0).as_deref(),
-            Some("alpha"),
-            "no unresolved word exists, so the direct callers really are all of them",
+            uniform(&ev, "::unknown", 0),
+            None,
+            "defining the handler is itself the unenumerable caller: {ev:?}",
+        );
+    }
+
+    #[test]
+    fn a_class_command_never_seeds_the_handler_1044() {
+        // Oracle (tclsh8.6): `oo::class create Dog` binds `Dog`, so `Dog
+        // new` dispatches to the class command and the handler is never
+        // called. The scan cannot resolve `Dog` and records it as an
+        // unresolved-word dispatch anyway; the unconditional poison is what
+        // stops that invented evidence becoming a fold.
+        let ev = evidence(
+            "proc unknown {cmd args} { if {$cmd eq \"Dog\"} { return 1 } else { return 2 } }\noo::class create Dog {\n    method bark {} { return woof }\n}\nDog new\n",
+        );
+        assert_eq!(
+            uniform(&ev, "::unknown", 0),
+            None,
+            "a class command is not a handler call site: {ev:?}",
+        );
+    }
+
+    #[test]
+    fn a_coroutine_command_never_seeds_the_handler_1044() {
+        // Oracle (tclsh8.6): `coroutine worker body` binds `worker`, so
+        // calling it resumes the coroutine and the handler is never called.
+        let ev = evidence(
+            "proc unknown {cmd args} { if {$cmd eq \"worker\"} { return 1 } else { return 2 } }\nproc body {} { yield ; return done }\ncoroutine worker body\nworker\n",
+        );
+        assert_eq!(
+            uniform(&ev, "::unknown", 0),
+            None,
+            "a coroutine command is not a handler call site: {ev:?}",
+        );
+    }
+
+    #[test]
+    fn a_word_written_before_the_handler_never_seeds_it_1044() {
+        // Oracle (tclsh8.6): `bogus beta` on line 1, with `proc unknown`
+        // defined only afterwards, is handled by the *builtin* `::unknown`
+        // and errors with `invalid command name "bogus"`. The scan is
+        // definition-order-insensitive, so it records the dispatch anyway.
+        let ev = evidence(
+            "bogus beta\nproc unknown {cmd args} { if {$cmd eq \"bogus\"} { return 1 } else { return 2 } }\n",
+        );
+        assert_eq!(
+            uniform(&ev, "::unknown", 0),
+            None,
+            "an order-insensitive scan may not seed an order-sensitive dispatch: {ev:?}",
         );
     }
 
@@ -2188,6 +2283,49 @@ mod tests {
             uniform(&ev, "::unknown", 0),
             None,
             "an unreadable dispatch may name anything, handler included: {ev:?}",
+        );
+    }
+
+    #[test]
+    fn a_cross_file_dispatch_never_seeds_another_files_handler_1044() {
+        // The cross-file scan resolves against the *project's* names, so a
+        // file that defines no handler still attributes its unresolved words
+        // to one another file defines. That path needs the same poison, or
+        // the miscompile simply moves across the file boundary.
+        //
+        // Shape: `h.tcl` holds `proc unknown`, `c.tcl` holds
+        // `oo::class create Dog` + `Dog new`. The `Dog` dispatch is invented
+        // (tclsh8.6: the class command answers, the handler is never called),
+        // and it would be the handler's only recorded call site.
+        let reg = registry();
+        let evidence = scan_source_call_sites(
+            "oo::class create Dog { method bark {} { return woof } }\nDog new\n",
+            &reg,
+            "",
+            &known(&["::unknown"]),
+            &[],
+        );
+        assert_eq!(
+            evidence
+                .get("::unknown")
+                .and_then(|e| e.uniform_literal_at(0)),
+            None,
+            "a sibling file's dispatch may not seed the project's handler: {evidence:?}",
+        );
+    }
+
+    #[test]
+    fn only_one_command_carries_the_unresolved_handler_trait() {
+        // `unresolved_command_handler` takes the first match from a hash-map
+        // walk, so more than one carrier would make the answer depend on
+        // iteration order. Sorting makes it deterministic; this pins the
+        // stronger property that there is nothing to choose between.
+        let reg = registry();
+        let carriers = reg.commands_with_trait(Traits::UNRESOLVED_COMMAND_HANDLER);
+        assert_eq!(
+            carriers.len(),
+            1,
+            "a second carrier needs a resolution rule, not an arbitrary pick: {carriers:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -768,6 +768,7 @@ fn record_call_site_evidence(
         // ::foo { proc runIt {} { uplevel #0 { helper b } } }` invented a
         // call to `::foo::helper` — a proc tclsh8.6/9.0 confirm real Tcl
         // never reaches this way.
+        //
         // And the same rule again for a body that runs in another *frame*
         // (`Traits::EVALUATES_IN_SHIFTED_FRAME` — `uplevel`). The frame the
         // level argument selects decides which namespace the body's bare

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -1558,8 +1558,9 @@ fn walk_statement<'a>(
 ) {
     use crate::ir::Statement;
     visit(stmt);
+    // Only the body-bearing arms have anything left to do — everything else
+    // is a leaf the visit above has already seen.
     match stmt {
-        Statement::Call { .. } | Statement::Barrier { .. } => {}
         Statement::Block { body, .. }
         | Statement::UpFrame { body, .. }
         | Statement::While { body, .. }
@@ -1608,7 +1609,9 @@ fn walk_statement<'a>(
                 walk_script(body, visit);
             }
         }
-        Statement::AssignConst { .. }
+        Statement::Call { .. }
+        | Statement::Barrier { .. }
+        | Statement::AssignConst { .. }
         | Statement::AssignExpr { .. }
         | Statement::AssignValue { .. }
         | Statement::Incr { .. }

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -755,6 +755,23 @@ fn record_call_site_evidence(
         {
             continue;
         }
+        // The same rule for a *definition* body (`Traits::DEFINES_PROCEDURE`
+        // — `proc`, `oo::class create`, …): it does not run at the
+        // definition site at all, and when it runs it resolves in the
+        // defined procedure's own namespace and frame. Lowering has already
+        // registered it as a procedure / method / body unit, all of which
+        // this scan visits with the right context, so recursing here would
+        // only re-walk it under the definer's. Issue #980: `namespace eval
+        // ::foo { proc runIt {} { uplevel #0 { helper b } } }` invented a
+        // call to `::foo::helper` — a proc tclsh8.6/9.0 confirm real Tcl
+        // never reaches this way.
+        if ctx
+            .registry
+            .get(command.strip_prefix("::").unwrap_or(command))
+            .is_some_and(|spec| spec.traits.contains(Traits::DEFINES_PROCEDURE))
+        {
+            continue;
+        }
         let nested = crate::segmenter::segment_commands_with_offset_and_config(
             body_text,
             0,
@@ -924,9 +941,99 @@ fn record_indirect_callers(
     }
 }
 
-/// Build bare CFGs (no further per-function analysis) for every `TclOO` method
-/// and synthetic body unit (`apply` lambda, `namespace eval` body), so
-/// [`collect_call_site_constants`] can walk them as *callers* too.
+/// Whether [`build_extra_call_site_scan_contexts`] has anything to build for
+/// this module — and therefore whether its
+/// [`crate::cfg_builder::prepare_cfg_context`] must be computed.
+///
+/// A single predicate so the two builders that gate on it
+/// ([`crate::compilation_unit::CompilationUnit`]'s build and
+/// [`scan_source_call_sites`]) cannot drift from what the context builder
+/// actually consumes.
+pub(crate) fn needs_extra_call_site_scan_contexts(ir_module: &IrModule) -> bool {
+    !ir_module.methods.is_empty()
+        || !ir_module.body_units.is_empty()
+        || !upframe_scan_bodies(ir_module).is_empty()
+}
+
+/// The synthetic caller name prefix an `uplevel` body's bare CFG carries:
+/// unique per occurrence, so its own variable-scope facts never clobber
+/// another scope's (issue #980).
+const UPFRAME_SCOPE_PREFIX: &str = "@upframe@";
+
+/// One `uplevel ?level? { … }` body the call-site scan visits as a caller.
+struct UpFrameCaller<'a> {
+    /// Qualified-name context the body's bare command words resolve against.
+    resolve_as: String,
+    /// Synthetic, occurrence-unique variable-scope identity for its CFG.
+    scope: String,
+    /// The lowered body.
+    body: &'a crate::ir::Script,
+}
+
+/// Every static-body `uplevel` in the module, paired with the namespace
+/// context its body's bare command words resolve against.
+///
+/// `uplevel #0` (`frame_shift == 0`) is the *absolute* frame form: its body
+/// runs in the global frame, so bare command words resolve against the
+/// global namespace, not the enclosing proc's — tclsh8.6/9.0-confirmed,
+/// `uplevel #0 { helper b }` inside `::foo::runIt` calls `::helper`, never
+/// `::foo::helper` (issue #980).
+///
+/// Any *relative* level (`uplevel 1`, `uplevel 2`, …) targets a frame whose
+/// namespace depends on the live call stack, which single-file static
+/// analysis cannot decide. Those keep the enclosing unit's own namespace —
+/// the documented, permanent approximation this scan has always used for
+/// them, now expressed here rather than falling out of a text re-walk of
+/// the enclosing definition's body.
+fn upframe_scan_bodies(ir_module: &IrModule) -> Vec<UpFrameCaller<'_>> {
+    let mut out = Vec::new();
+    collect_upframes("::top", &ir_module.top_level, &mut out);
+    for (qname, proc) in &ir_module.procedures {
+        collect_upframes(qname, &proc.body, &mut out);
+    }
+    // A `TclOO` method body resolves bare words against the global namespace
+    // (see `build_extra_call_site_scan_contexts`), so an `uplevel` inside one
+    // inherits `"::top"` for the relative case too.
+    for method in ir_module.methods.values() {
+        collect_upframes("::top", &method.body, &mut out);
+    }
+    for (qname, unit) in &ir_module.body_units {
+        collect_upframes(qname, &unit.body, &mut out);
+    }
+    out
+}
+
+/// The [`upframe_scan_bodies`] half that walks one enclosing unit's script.
+fn collect_upframes<'a>(
+    enclosing: &str,
+    script: &'a crate::ir::Script,
+    out: &mut Vec<UpFrameCaller<'a>>,
+) {
+    walk_script(script, &mut |stmt| {
+        if let crate::ir::Statement::UpFrame {
+            frame_shift,
+            body,
+            span,
+            ..
+        } = stmt
+        {
+            out.push(UpFrameCaller {
+                resolve_as: if *frame_shift == 0 {
+                    "::top".to_owned()
+                } else {
+                    enclosing.to_owned()
+                },
+                scope: format!("{UPFRAME_SCOPE_PREFIX}{}", span.start()),
+                body,
+            });
+        }
+    });
+}
+
+/// Build bare CFGs (no further per-function analysis) for every `TclOO` method,
+/// synthetic body unit (`apply` lambda, `namespace eval` body), and static
+/// `uplevel` body, so [`collect_call_site_constants`] can walk them as
+/// *callers* too.
 ///
 /// Neither is itself ever seeded with `param_constants`
 /// (`build_method_units` / `build_body_units` always pass `None` for their
@@ -939,16 +1046,17 @@ fn record_indirect_callers(
 /// caller agrees" evidence), reached through a method/lambda body instead
 /// of namespace-blind recursion or a `catch`/`uplevel` body.
 ///
-/// Returns an empty `Vec` (no cost beyond the emptiness checks) when the
-/// module has neither methods nor body units — the overwhelmingly common
-/// case — or when `cfg_context` is `None` (methods/body units require it;
-/// [`crate::compilation_unit::CompilationUnit`]'s builder only omits it when
-/// both are empty).
+/// Returns an empty `Vec` (no cost beyond
+/// [`needs_extra_call_site_scan_contexts`]) when the module has none of the
+/// three — the overwhelmingly common case — or when `cfg_context` is `None`
+/// (all three require it; the builders compute it exactly when
+/// [`needs_extra_call_site_scan_contexts`] says so).
 pub(crate) fn build_extra_call_site_scan_contexts(
     ir_module: &IrModule,
     cfg_context: Option<&crate::cfg_builder::CfgContext>,
 ) -> Vec<(String, CfgFunction)> {
-    if ir_module.methods.is_empty() && ir_module.body_units.is_empty() {
+    let upframes = upframe_scan_bodies(ir_module);
+    if ir_module.methods.is_empty() && ir_module.body_units.is_empty() && upframes.is_empty() {
         return Vec::new();
     }
     let Some((upvar_procs, proc_params, global_write_procs)) = cfg_context else {
@@ -987,6 +1095,16 @@ pub(crate) fn build_extra_call_site_scan_contexts(
                 .iter()
                 .map(|(qname, unit)| (qname.clone(), build(qname, &unit.body))),
         )
+        .chain(upframes.into_iter().map(|up| {
+            // Same shape as the method case: the caller context bare command
+            // words resolve against is chosen by the frame the body runs in
+            // (see [`upframe_scan_bodies`]), while the CFG keeps a distinct
+            // identity of its own. Here that identity must be *synthetic* —
+            // the CFG's name is this scan's variable-scope key, and reusing
+            // the resolution context would overwrite that scope's real
+            // variable facts in `collect_module_scope_var_facts`.
+            (up.resolve_as, build(&up.scope, up.body))
+        }))
         .collect()
 }
 
@@ -1210,7 +1328,7 @@ pub fn scan_source_call_sites<S: std::hash::BuildHasher>(
     crate::specialise_factories::specialise_factories(&mut ir_module, registry);
     crate::inline_uplevel::inline_uplevel_passthrough(&mut ir_module, registry);
     let cfg_module = crate::cfg_builder::build_cfg(&ir_module, false);
-    let cfg_context = (!ir_module.methods.is_empty() || !ir_module.body_units.is_empty())
+    let cfg_context = needs_extra_call_site_scan_contexts(&ir_module)
         .then(|| crate::cfg_builder::prepare_cfg_context(&ir_module));
     let extra = build_extra_call_site_scan_contexts(&ir_module, cfg_context.as_ref());
     // The cross-file scan resolves a dispatch word exactly as the in-unit one
@@ -1301,40 +1419,59 @@ pub fn scan_unit_linkage(
         tcl_dialect::DialectSet::parse(dialect).unwrap_or_else(tcl_dialect::DialectSet::empty);
     let mut found = Traits::empty();
 
-    let mut visit = |command: &str, args: &[String]| {
-        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
-        found |= registry.unit_linkage(command, &arg_strs, dialect_set);
+    let mut visit = |stmt: &crate::ir::Statement| {
+        if let crate::ir::Statement::Call { command, args, .. }
+        | crate::ir::Statement::Barrier { command, args, .. } = stmt
+        {
+            let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+            found |= registry.unit_linkage(command, &arg_strs, dialect_set);
+        }
     };
-    walk_script(&ir_module.top_level, &mut visit);
-    for proc in ir_module.procedures.values() {
-        walk_script(&proc.body, &mut visit);
-    }
-    for method in ir_module.methods.values() {
-        walk_script(&method.body, &mut visit);
-    }
-    for unit in ir_module.body_units.values() {
-        walk_script(&unit.body, &mut visit);
-    }
+    walk_module_scripts(ir_module, &mut visit);
     found
 }
 
-/// Visit every `Call` / `Barrier` statement in `script`, descending into every
-/// nested control-flow body.  Written as a module-level pair with
-/// [`walk_statement`] rather than nested inside [`scan_unit_linkage`] so the
+/// Visit every statement of every script the module owns — top level,
+/// procedures, `TclOO` methods, and synthetic body units — descending into
+/// nested control-flow bodies.
+fn walk_module_scripts<'a>(
+    ir_module: &'a IrModule,
+    visit: &mut impl FnMut(&'a crate::ir::Statement),
+) {
+    walk_script(&ir_module.top_level, visit);
+    for proc in ir_module.procedures.values() {
+        walk_script(&proc.body, visit);
+    }
+    for method in ir_module.methods.values() {
+        walk_script(&method.body, visit);
+    }
+    for unit in ir_module.body_units.values() {
+        walk_script(&unit.body, visit);
+    }
+}
+
+/// Visit every statement in `script`, descending into every nested
+/// control-flow body.  Written as a module-level pair with
+/// [`walk_statement`] rather than nested inside its callers so the
 /// mutual recursion reads as two ordinary functions.
-fn walk_script(script: &crate::ir::Script, visit: &mut impl FnMut(&str, &[String])) {
+fn walk_script<'a>(
+    script: &'a crate::ir::Script,
+    visit: &mut impl FnMut(&'a crate::ir::Statement),
+) {
     for stmt in &script.statements {
         walk_statement(stmt, visit);
     }
 }
 
 /// The [`walk_script`] half that dispatches one statement.
-fn walk_statement(stmt: &crate::ir::Statement, visit: &mut impl FnMut(&str, &[String])) {
+fn walk_statement<'a>(
+    stmt: &'a crate::ir::Statement,
+    visit: &mut impl FnMut(&'a crate::ir::Statement),
+) {
     use crate::ir::Statement;
+    visit(stmt);
     match stmt {
-        Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. } => {
-            visit(command, args);
-        }
+        Statement::Call { .. } | Statement::Barrier { .. } => {}
         Statement::Block { body, .. }
         | Statement::UpFrame { body, .. }
         | Statement::While { body, .. }

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -768,10 +768,27 @@ fn record_call_site_evidence(
         // ::foo { proc runIt {} { uplevel #0 { helper b } } }` invented a
         // call to `::foo::helper` — a proc tclsh8.6/9.0 confirm real Tcl
         // never reaches this way.
+        // And the same rule again for a body that runs in another *frame*
+        // (`Traits::EVALUATES_IN_SHIFTED_FRAME` — `uplevel`). The frame the
+        // level argument selects decides which namespace the body's bare
+        // command words resolve against, and the enclosing unit is not it.
+        // `upframe_scan_bodies` visits every such body with the frame it
+        // actually targets, so recursing here would scan it a second time
+        // under the wrong one.
+        //
+        // Sound-7: `proc runIt {} { catch { uplevel #0 { helper b } } }`
+        // inside `::foo`. The `catch` body is walked correctly (catch does
+        // not shift anything), and the `uplevel` body inside it was then
+        // re-walked as `::foo`, inventing a call to `::foo::helper` on top
+        // of the correct `::helper` the upframe scan had already recorded.
+        // tclsh8.6/9.0 confirm only `::helper` runs.
         if ctx
             .registry
             .get(command.strip_prefix("::").unwrap_or(command))
-            .is_some_and(|spec| spec.traits.contains(Traits::DEFINES_PROCEDURE))
+            .is_some_and(|spec| {
+                spec.traits
+                    .intersects(Traits::DEFINES_PROCEDURE | Traits::EVALUATES_IN_SHIFTED_FRAME)
+            })
         {
             continue;
         }
@@ -2043,6 +2060,39 @@ mod tests {
         assert_eq!(
             cu.caller_scope.call_sites.callees().collect::<Vec<_>>(),
             vec!["::a::helper"],
+        );
+    }
+
+    /// An `uplevel` body nested inside another `ArgRole::Body` must not be
+    /// re-walked with the enclosing unit's namespace.
+    ///
+    /// The `catch` body is walked correctly — `catch` shifts nothing — and
+    /// the `uplevel #0` body inside it was then walked again as `::foo`,
+    /// inventing a call to `::foo::helper` alongside the correct `::helper`
+    /// that `upframe_scan_bodies` had already recorded with the right
+    /// frame. Both the phantom callee and the double attribution are wrong:
+    /// tclsh8.6/9.0 confirm `uplevel #0 { helper b }` inside `::foo::runIt`
+    /// calls `::helper` and nothing else.
+    ///
+    /// The `Traits::EVALUATES_IN_SHIFTED_FRAME` skip is what stops it, so
+    /// no command name appears in the walker.
+    #[test]
+    fn an_uplevel_body_inside_a_catch_body_is_not_reattributed() {
+        let reg = registry();
+        let src = "namespace eval ::foo {\n    proc helper {mode} { return $mode }\n    proc runIt {} { catch { uplevel #0 { helper b } } }\n}\n";
+        let evidence = scan_source_call_sites(
+            src,
+            &reg,
+            "tcl8.6",
+            &known(&["::foo::helper", "::foo::runIt", "::helper"]),
+            &[],
+        );
+        let mut callees: Vec<&str> = evidence.callees().collect();
+        callees.sort_unstable();
+        assert_eq!(
+            callees,
+            vec!["::helper"],
+            "the global helper takes the evidence and ::foo::helper gets no phantom call",
         );
     }
 

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -1023,9 +1023,17 @@ fn record_indirect_callers(
 /// [`scan_source_call_sites`]) cannot drift from what the context builder
 /// actually consumes.
 pub(crate) fn needs_extra_call_site_scan_contexts(ir_module: &IrModule) -> bool {
-    !ir_module.methods.is_empty()
-        || !ir_module.body_units.is_empty()
-        || !upframe_scan_bodies(ir_module).is_empty()
+    if !ir_module.methods.is_empty() || !ir_module.body_units.is_empty() {
+        return true;
+    }
+    // Only a module with neither pays for the statement walk, and it costs
+    // no allocation — a bare `uplevel {…}` is rare enough that building the
+    // caller list here just to test it for emptiness would be wasteful.
+    let mut found = false;
+    walk_module_scripts(ir_module, &mut |stmt| {
+        found |= matches!(stmt, crate::ir::Statement::UpFrame { .. });
+    });
+    found
 }
 
 /// The synthetic caller name prefix an `uplevel` body's bare CFG carries:

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -308,6 +308,9 @@ struct CallSiteScanCtx<'a, S> {
     /// [`unenumerable_reach`] and
     /// [`CallSiteEvidence::record_unenumerable_caller`].
     unenumerable_reach: &'a [String],
+    /// The qualified name of the module's own unresolved-command handler,
+    /// when it defines one — see [`unresolved_command_handler`].
+    unresolved_handler: Option<&'a str>,
 }
 
 /// One body the scan walks as a *caller*.
@@ -832,12 +835,82 @@ fn record_invocation(
     };
     for name in &values {
         let Some(target) = resolve_target(ctx, caller.resolve_as, name) else {
+            record_unresolved_word_dispatch(out, ctx, name, args);
             continue;
         };
         match args {
             IndirectArgs::Words(words) => out.record_call(target, words),
             IndirectArgs::Unknowable => out.record_opaque_caller(&target),
         }
+    }
+}
+
+/// The qualified name of the unresolved-command handler this unit defines,
+/// or `None` when it defines none — the overwhelmingly common case.
+///
+/// Tcl routes every command word that resolves to nothing to a single
+/// global handler, passing the word itself followed by that call's own
+/// arguments (tclsh8.6/9.0-confirmed). A module that defines one therefore
+/// has callers no scan of its *direct* call sites can enumerate, and a
+/// coincidentally-uniform set of those direct calls would fold a parameter
+/// the unresolved words genuinely vary (issue #1044).
+///
+/// Which command is the handler comes from
+/// [`Traits::UNRESOLVED_COMMAND_HANDLER`], never a literal name here. The
+/// lookup is global-scope only: a namespace-local `proc unknown` is *not*
+/// consulted for unresolved words in that namespace — tclsh8.6/9.0 both
+/// dispatch to `::unknown` regardless of the calling namespace.
+fn unresolved_command_handler<'a, S: std::hash::BuildHasher>(
+    registry: &CommandRegistry,
+    known: &'a HashSet<String, S>,
+) -> Option<&'a str> {
+    registry
+        .commands_with_trait(Traits::UNRESOLVED_COMMAND_HANDLER)
+        .into_iter()
+        .find_map(|name| {
+            let qualified = crate::naming::qualify("::", name);
+            known.get(&qualified).map(String::as_str)
+        })
+}
+
+/// Record the unresolved-command handler's own invocation for a literal
+/// command word this scan could not resolve (issue #1044).
+///
+/// Only fires when the module defines a handler, and only for a word the
+/// registry does not know either — everything else either resolves or is a
+/// builtin. The word becomes the handler's first argument and the call's
+/// own arguments follow, exactly as Tcl passes them, so the evidence union
+/// is the precise set of values the handler's parameters really see.
+///
+/// Deliberately over-inclusive on the residue: a word bound by something
+/// this scan does not model (a class command, an ensemble, a coroutine)
+/// also reads as unresolved and contributes an extra value. That can only
+/// *retract* a fold, never manufacture one, and it costs nothing in a
+/// module with no handler.
+fn record_unresolved_word_dispatch(
+    out: &mut CallSiteEvidence,
+    ctx: &CallSiteScanCtx<'_, impl std::hash::BuildHasher>,
+    word: &str,
+    args: IndirectArgs<'_>,
+) {
+    let Some(handler) = ctx.unresolved_handler else {
+        return;
+    };
+    if ctx
+        .registry
+        .get(word.strip_prefix("::").unwrap_or(word))
+        .is_some()
+    {
+        return;
+    }
+    match args {
+        IndirectArgs::Words(words) => {
+            let mut dispatched = Vec::with_capacity(words.len() + 1);
+            dispatched.push(word.to_owned());
+            dispatched.extend_from_slice(words);
+            out.record_call(handler.to_owned(), &dispatched);
+        }
+        IndirectArgs::Unknowable => out.record_opaque_caller(handler),
     }
 }
 
@@ -1150,6 +1223,7 @@ pub(crate) fn collect_call_site_constants(
     // identical to the module-wide rule it replaces, but expressed per callee
     // so it merges and slices correctly across files.
     let reach = unenumerable_reach(procedures, Traits::empty(), &known);
+    let unresolved_handler = unresolved_command_handler(registry, &known);
     // The top level has no qualified name of its own; `"::top"` (the same
     // pseudo-qname `FunctionUnit::build_full` uses for it) resolves to the
     // global namespace via `resolve_internal_call`'s "drop the last
@@ -1165,6 +1239,7 @@ pub(crate) fn collect_call_site_constants(
             previous,
             procedures,
             unenumerable_reach: &reach,
+            unresolved_handler,
         };
         let funcs = std::iter::once(("::top", &cfg_module.top_level))
             .chain(cfg_module.procedures.iter().map(|(q, f)| (q.as_str(), f)))
@@ -1350,6 +1425,10 @@ pub fn scan_source_call_sites<S: std::hash::BuildHasher>(
     } else {
         dispatch_reach.to_vec()
     };
+    // `known` here is the *project*-wide procedure set, so a handler defined
+    // in any scanned file is visible — matching Tcl, where `::unknown` is one
+    // command shared by the whole interpreter, not a per-file one.
+    let unresolved_handler = unresolved_command_handler(registry, known);
     out = run_to_fixpoint(&reach, |previous| {
         let ctx = CallSiteScanCtx {
             known,
@@ -1360,6 +1439,7 @@ pub fn scan_source_call_sites<S: std::hash::BuildHasher>(
             previous,
             procedures: &ir_module.procedures,
             unenumerable_reach: &reach,
+            unresolved_handler,
         };
         let funcs = std::iter::once(("::top", &cfg_module.top_level))
             .chain(cfg_module.procedures.iter().map(|(q, f)| (q.as_str(), f)))
@@ -1998,6 +2078,97 @@ mod tests {
         // Two disagreeing literals, so no uniform value — but the position is
         // *bound* by every recorded call, which a withdrawal would undo.
         assert!(ev.get("::helper").unwrap().binds_position(0));
+    }
+
+    // Issue #1044 — a module's own `unknown` handler. Tcl dispatches every
+    // unresolved command word to it, so its direct callers are never its
+    // complete caller set. tclsh8.6/9.0-confirmed: with `proc unknown {cmd
+    // args}` in scope, `bogus beta gamma` runs the handler with
+    // `cmd` = `bogus`, `args` = `beta gamma`.
+
+    #[test]
+    fn an_unresolved_word_is_a_call_site_of_the_modules_unknown_handler_1044() {
+        // TP, the issue's repro: `bogus` names nothing, so real Tcl calls
+        // the handler with `bogus`. Seeing only the two `unknown alpha`
+        // calls, the scan bound `cmd` to the constant `"alpha"` and folded
+        // `$cmd eq "alpha"` on a genuinely runtime-varying condition.
+        let ev = evidence(
+            "proc unknown {cmd args} { if {$cmd eq \"alpha\"} { return 1 } else { return 2 } }\nunknown alpha\nunknown alpha\nbogus beta\n",
+        );
+        assert_eq!(
+            slot(&ev, "::unknown", 0),
+            (vec!["alpha".into(), "bogus".into()], false),
+            "the unresolved word itself is the handler's first argument",
+        );
+        assert_eq!(uniform(&ev, "::unknown", 0), None, "must not fold");
+    }
+
+    #[test]
+    fn the_unresolved_words_own_arguments_follow_it_into_the_handler_1044() {
+        // TP: Tcl passes the failed call's arguments after the word, so
+        // `args`' positions carry them — evidence the scan really can see,
+        // recorded in full rather than merely poisoned.
+        let ev = evidence("proc unknown {cmd args} { return $cmd }\nbogus beta gamma\n");
+        assert_eq!(slot(&ev, "::unknown", 0), (vec!["bogus".into()], false));
+        assert_eq!(slot(&ev, "::unknown", 1), (vec!["beta".into()], false));
+        assert_eq!(slot(&ev, "::unknown", 2), (vec!["gamma".into()], false));
+    }
+
+    #[test]
+    fn a_module_with_no_unknown_handler_is_unaffected_1044() {
+        // TN, the common case and the whole regression risk: an unresolved
+        // word in a module that defines no handler must change nothing.
+        let ev = evidence("proc helper {mode} { return $mode }\nhelper a\nbogus beta\n");
+        assert_eq!(slot(&ev, "::helper", 0), (vec!["a".into()], false));
+        assert_eq!(uniform(&ev, "::helper", 0).as_deref(), Some("a"));
+        assert!(
+            ev.get("::unknown").is_none(),
+            "no handler defined, so nothing may be attributed to one: {ev:?}",
+        );
+    }
+
+    #[test]
+    fn a_handler_with_agreeing_callers_and_no_unresolved_words_still_seeds_1044() {
+        // TN: the gate must not blanket-disable seeding for any module that
+        // happens to define a handler — with every caller agreeing and no
+        // unresolved word anywhere, the seed still stands.
+        let ev = evidence(
+            "proc unknown {cmd args} { return $cmd }\nunknown alpha\nunknown alpha\nputs hi\n",
+        );
+        assert_eq!(
+            uniform(&ev, "::unknown", 0).as_deref(),
+            Some("alpha"),
+            "no unresolved word exists, so the direct callers really are all of them",
+        );
+    }
+
+    #[test]
+    fn a_registry_builtin_is_not_an_unresolved_word_1044() {
+        // FP guard: a builtin resolves to no *user proc*, but it is not an
+        // unresolved word — Tcl never routes `puts`/`set` to the handler.
+        let ev = evidence(
+            "proc unknown {cmd args} { return $cmd }\nunknown alpha\nunknown alpha\nputs hi\nset x 1\nincr x\n",
+        );
+        assert_eq!(
+            slot(&ev, "::unknown", 0),
+            (vec!["alpha".into()], false),
+            "builtins must not appear as handler arguments: {ev:?}",
+        );
+    }
+
+    #[test]
+    fn an_unenumerable_dispatch_word_still_poisons_rather_than_naming_the_handler_1044() {
+        // FN guard: a dynamic word whose value set is unreadable is not an
+        // *unresolved* word — the scan cannot say it resolves to nothing —
+        // so it keeps withdrawing every seed, the handler's included.
+        let ev = evidence(
+            "proc unknown {cmd args} { return $cmd }\nunknown alpha\nunknown alpha\nset c [gets stdin]\n$c beta\n",
+        );
+        assert_eq!(
+            uniform(&ev, "::unknown", 0),
+            None,
+            "an unreadable dispatch may name anything, handler included: {ev:?}",
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -1054,18 +1054,26 @@ struct UpFrameCaller<'a> {
 /// Every static-body `uplevel` in the module, paired with the namespace
 /// context its body's bare command words resolve against.
 ///
-/// `uplevel #0` (`frame_shift == 0`) is the *absolute* frame form: its body
-/// runs in the global frame, so bare command words resolve against the
+/// `uplevel #0` (`absolute`, shift `0`) is the *absolute* frame form: its
+/// body runs in the global frame, so bare command words resolve against the
 /// global namespace, not the enclosing proc's — tclsh8.6/9.0-confirmed,
 /// `uplevel #0 { helper b }` inside `::foo::runIt` calls `::helper`, never
 /// `::foo::helper` (issue #980).
 ///
-/// Any *relative* level (`uplevel 1`, `uplevel 2`, …) targets a frame whose
-/// namespace depends on the live call stack, which single-file static
-/// analysis cannot decide. Those keep the enclosing unit's own namespace —
-/// the documented, permanent approximation this scan has always used for
-/// them, now expressed here rather than falling out of a text re-walk of
-/// the enclosing definition's body.
+/// Every other level keeps the enclosing unit's own namespace:
+///
+/// * `uplevel 0` is the *relative* current-frame form. Despite sharing the
+///   magnitude `0` with `#0` it is the opposite case — tclsh8.6/9.0 confirm
+///   `uplevel 0 { helper c }` inside `::foo::runIt` calls `::foo::helper`.
+///   Resolving it against the enclosing unit is exact, not an approximation.
+/// * Any other relative level (`uplevel 1`, `uplevel 2`, …) targets a frame
+///   whose namespace depends on the live call stack, which single-file
+///   static analysis cannot decide. Those keep the enclosing unit's
+///   namespace as the documented, permanent approximation this scan has
+///   always used for them.
+/// * An absolute `#N` for `N > 0` names a frame counted down from the
+///   global one, equally undecidable statically, so it takes the same
+///   approximation.
 fn upframe_scan_bodies(ir_module: &IrModule) -> Vec<UpFrameCaller<'_>> {
     let mut out = Vec::new();
     collect_upframes("::top", &ir_module.top_level, &mut out);
@@ -1093,13 +1101,14 @@ fn collect_upframes<'a>(
     walk_script(script, &mut |stmt| {
         if let crate::ir::Statement::UpFrame {
             frame_shift,
+            absolute,
             body,
             span,
             ..
         } = stmt
         {
             out.push(UpFrameCaller {
-                resolve_as: if *frame_shift == 0 {
+                resolve_as: if *absolute && *frame_shift == 0 {
                     "::top".to_owned()
                 } else {
                     enclosing.to_owned()

--- a/rust/tcl-compiler/src/var_escape/cfg_propagation/walker.rs
+++ b/rust/tcl-compiler/src/var_escape/cfg_propagation/walker.rs
@@ -179,10 +179,15 @@ fn handle_eval(args: &[String], state: &mut CfgState, defs: &HashMap<String, Ver
         state.mark_pessimistic();
         return;
     }
+    // [`scan_word`], not `scan_script`: this scan over-approximates on
+    // purpose — every name the body text mentions escapes, whether or not
+    // Tcl substitutes it at *this* level. A brace-quoted word (`eval {if
+    // {$x > 1} {...}}`) is re-parsed and substituted when the inner command
+    // runs, so its names escape too. See `var_escape::walker::handle_eval`.
     let registry = tcl_registry::CommandRegistry::build_default();
     let mut scanner =
         crate::var_refs::VarReferenceScanner::new(crate::var_refs::VarScanOptions::default());
-    for ref_ in scanner.scan_script(&body, &registry) {
+    for ref_ in scanner.scan_word(&body, &registry) {
         state.escape(&ref_, defs);
     }
     let sub_module = crate::lowering::lower_to_ir(&body, &registry);
@@ -203,10 +208,12 @@ fn handle_catch(args: &[String], state: &mut CfgState, defs: &HashMap<String, Ve
     if is_dynamic_token(body) {
         return;
     }
+    // [`scan_word`] for the same over-approximation reason as `handle_eval`:
+    // a brace-quoted word inside the caught body still escapes its names.
     let registry = tcl_registry::CommandRegistry::build_default();
     let mut scanner =
         crate::var_refs::VarReferenceScanner::new(crate::var_refs::VarScanOptions::default());
-    for ref_ in scanner.scan_script(body, &registry) {
+    for ref_ in scanner.scan_word(body, &registry) {
         state.escape(&ref_, defs);
     }
     let sub_module = crate::lowering::lower_to_ir(body, &registry);
@@ -772,6 +779,43 @@ mod tests {
         let r = analyse("set x 1");
         assert!(!r.dynamic_barrier());
         assert!(r.name_tags.is_empty());
+    }
+
+    /// An `eval` body that mentions any variable takes the pessimistic
+    /// path, which is what accounts for names Tcl does not substitute at
+    /// this level — a brace-quoted `if` condition among them.
+    ///
+    /// Driven through the handler directly because lowering relaxes a
+    /// static-body `eval` into structured IR, so no opaque call reaches it
+    /// from [`analyse`]. This is the fallback for every body lowering
+    /// declines to relax.
+    ///
+    /// The pre-scan below the guard uses the over-approximating `scan_word`
+    /// mode, but `is_dynamic_token` fires on any `$` or `[` — which is every
+    /// body the scan could find a reference in — so the mode is unobservable
+    /// here today and the guard carries the soundness. It is written the
+    /// over-approximating way so that narrowing the guard cannot silently
+    /// open a hole; the mode contract itself is pinned by `var_refs`'
+    /// `scan_word_finds_a_var_inside_braces_within_a_value_body`.
+    ///
+    /// `handle_catch`'s dynamic branch deliberately records nothing here —
+    /// its doc states the caller's own call-fallback covers a non-literal
+    /// body — so its contract does not hold at this level and is not
+    /// asserted.
+    #[test]
+    fn an_eval_body_mentioning_a_variable_is_pessimistic() {
+        let mut state = CfgState::new(std::iter::empty::<String>());
+        handle_eval(
+            &["if {$x > 1} { set y 2 }".to_string()],
+            &mut state,
+            &HashMap::new(),
+        );
+        assert!(
+            state
+                .flags
+                .contains(crate::var_escape::types::EscapeFlags::DYNAMIC_BARRIER),
+            "a substitution-bearing eval body is pessimistic, which covers every name",
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/var_escape/walker.rs
+++ b/rust/tcl-compiler/src/var_escape/walker.rs
@@ -197,10 +197,25 @@ fn handle_eval(args: &[String], state: &mut EscapeState) {
         return;
     }
     // Cheap scan first — any ``$var`` reference escapes that name.
+    //
+    // Deliberately ``scan_word``, not ``scan_script``: escape analysis wants
+    // *every name the text mentions*, not the names Tcl's own word-splitting
+    // says are substituted at this level. A brace-quoted word inside the body
+    // (`eval {if {$x > 1} {...}}` — the expression is braced) suppresses
+    // substitution here but is re-parsed and substituted when the inner
+    // command runs, so the name really does escape. Missing it would be
+    // unsound in the direction that matters: a variable wrongly believed
+    // frame-local is one the optimiser may keep in a register.
+    //
+    // Note the ``is_dynamic_token`` guard above already takes the pessimistic
+    // path for *any* body containing ``$`` or ``[``, which is every body this
+    // scan could find a reference in — so today the mode is unobservable and
+    // the guard is what carries the soundness. It is written as ``scan_word``
+    // so that narrowing that guard cannot silently reintroduce the hole.
     let registry = tcl_registry::CommandRegistry::build_default();
     let mut scanner =
         crate::var_refs::VarReferenceScanner::new(crate::var_refs::VarScanOptions::default());
-    for ref_ in scanner.scan_script(&body, &registry) {
+    for ref_ in scanner.scan_word(&body, &registry) {
         state.escape_with_reason(
             &ref_,
             EscapeReason::with_detail(
@@ -826,6 +841,36 @@ mod tests {
     fn descends_into_if_body() {
         let s = analyse("if {1} { upvar 1 caller_x x }");
         assert!(s.is_frame("x"));
+    }
+
+    /// A name mentioned only inside a *brace-quoted* word of an `eval` body
+    /// must still escape.
+    ///
+    /// `if`'s condition is brace-quoted, so Tcl's own word-splitting
+    /// suppresses substitution at this level — but the expression is
+    /// re-parsed and `$x` substituted when the inner `if` runs, so `x` is
+    /// genuinely reachable from another frame. Believing it frame-local is
+    /// unsound in the direction that matters: the optimiser may keep such a
+    /// variable in a register.
+    ///
+    /// Today this holds because `is_dynamic_token` sends *any* body
+    /// containing `$` or `[` down the pessimistic barrier path before the
+    /// pre-scan runs — which is why the assertion below is on the barrier as
+    /// well as the name. The pre-scan's own mode (`scan_word`, the
+    /// over-approximating one) is the second line of defence should that
+    /// guard ever be narrowed; the mode contract itself is pinned by
+    /// `var_refs`' `scan_word_finds_a_var_inside_braces_within_a_value_body`.
+    #[test]
+    fn eval_body_escapes_a_name_inside_a_brace_quoted_word() {
+        let s = analyse("eval {if {$x > 1} { set y 2 }}");
+        assert!(
+            s.is_frame("x"),
+            "a brace-quoted expression inside an eval body still escapes its names",
+        );
+        assert!(
+            s.dynamic_barrier(),
+            "and the substitution-bearing body is what makes it pessimistic today",
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/var_refs.rs
+++ b/rust/tcl-compiler/src/var_refs.rs
@@ -22,9 +22,11 @@
 //! variable names.  It tokenises the input with the Rust lexer, collects
 //! `VAR` tokens, and optionally recurses into command substitutions.
 //!
-//! Results are cached in a bounded LRU keyed by source text — the same
-//! word/script strings are scanned repeatedly across SSA, GVN, and
-//! interprocedural passes.
+//! Results are cached in a bounded LRU keyed by source text *and* scan
+//! mode — the same word/script strings are scanned repeatedly across SSA,
+//! GVN, and interprocedural passes, and the two modes ([`
+//! VarReferenceScanner::scan_word`] vs [`VarReferenceScanner::scan_script`])
+//! can legitimately disagree about the same text.
 
 use std::collections::{BTreeSet, HashMap, VecDeque};
 
@@ -72,17 +74,24 @@ const DEFAULT_CACHE_SIZE: usize = 512;
 
 /// Scan Tcl words/scripts for referenced variable names.
 ///
-/// Results are cached in a bounded LRU keyed by source text.
-/// The same word/script strings are scanned repeatedly across SSA,
+/// Results are cached in a bounded LRU keyed by source text **and** scan
+/// mode. The same word/script strings are scanned repeatedly across SSA,
 /// GVN, and interprocedural passes, so caching avoids redundant
-/// lexer creation and tokenisation.
+/// lexer creation and tokenisation. The mode is part of the key because
+/// value-body and script-body scans of identical text give different
+/// answers (`set literal {$x}` reads `x` as a value word, nothing as a
+/// script) — issue #1024.
 pub struct VarReferenceScanner {
     options: VarScanOptions,
     /// Bounded LRU: `order` tracks access recency, `cache` stores results.
-    cache: HashMap<String, BTreeSet<String>>,
-    order: VecDeque<String>,
+    cache: HashMap<CacheKey, BTreeSet<String>>,
+    order: VecDeque<CacheKey>,
     cache_size: usize,
 }
+
+/// LRU key: the scanned text plus the mode it was scanned in
+/// (`quoted_body` — see [`scan_tokens`]).
+type CacheKey = (String, bool);
 
 impl VarReferenceScanner {
     /// Create a new scanner with the given options and default cache size.
@@ -125,26 +134,46 @@ impl VarReferenceScanner {
         }
     }
 
-    /// Scan one Tcl word for variable references.
+    /// Scan one Tcl word for variable references (LRU-cached).
+    ///
+    /// `text` is already-extracted word/value text whose own enclosing
+    /// quotes or braces were stripped by whatever produced it, so it is
+    /// scanned in *value body* mode — see [`scan_tokens`].
     pub fn scan_word(&mut self, text: &str, registry: &CommandRegistry) -> BTreeSet<String> {
-        self.scan_script(text, registry)
+        self.scan_cached(text, registry, true)
     }
 
     /// Scan a Tcl script for variable references (LRU-cached).
+    ///
+    /// `source` is a genuine script body (an `eval`/`catch`/`uplevel` body,
+    /// a proc body), so ordinary top-level Tcl word-splitting and
+    /// brace-quoting apply: a `{…}` word inside it really does suppress
+    /// substitution (issue #1024). Use [`Self::scan_word`] for a value word.
     pub fn scan_script(&mut self, source: &str, registry: &CommandRegistry) -> BTreeSet<String> {
+        self.scan_cached(source, registry, false)
+    }
+
+    /// Shared cache lookup/insert for both scan modes.
+    fn scan_cached(
+        &mut self,
+        source: &str,
+        registry: &CommandRegistry,
+        quoted_body: bool,
+    ) -> BTreeSet<String> {
+        let key: CacheKey = (source.to_owned(), quoted_body);
+
         // Check cache.
-        if let Some(cached) = self.cache.get(source) {
+        if let Some(cached) = self.cache.get(&key) {
             let result = cached.clone();
             // Move to end of LRU order.
-            self.order.retain(|k| k != source);
-            self.order.push_back(source.to_owned());
+            self.order.retain(|k| k != &key);
+            self.order.push_back(key);
             return result;
         }
 
-        let result = self.scan_script_uncached(source, registry);
+        let result = scan_tokens(source, registry, self.options, quoted_body);
 
         // Insert into cache.
-        let key = source.to_owned();
         self.cache.insert(key.clone(), result.clone());
         self.order.push_back(key);
 
@@ -164,18 +193,6 @@ impl VarReferenceScanner {
         self.order.clear();
     }
 
-    /// Scan without cache — called on cache miss. The outermost scan is
-    /// always over *value body* text (see [`scan_tokens`]): whatever
-    /// produced `source` (a `set` value, a proc-arg default, …) already
-    /// stripped its own enclosing quotes/braces, so any `{`/`}` surviving
-    /// in `source` is literal content, never a fresh word boundary.
-    fn scan_script_uncached(
-        &mut self,
-        source: &str,
-        registry: &CommandRegistry,
-    ) -> BTreeSet<String> {
-        scan_tokens(source, registry, self.options, true)
-    }
 }
 
 /// The variable name a `TokenType::Var` token contributes, per
@@ -578,6 +595,62 @@ mod tests {
     }
 
     #[test]
+    fn scan_script_keeps_brace_quoting_in_a_genuine_script_body_issue_1024() {
+        // TN twin of `scan_word_finds_a_var_inside_braces_within_a_value_body`
+        // — same `{$x}` text, opposite answer, because a *script* body is
+        // ordinary Tcl: its `{…}` is real brace-quoting, not literal text
+        // that survived from an enclosing quoted word. tclsh8.6/9.0: `set x
+        // GLOBALX; eval {set literal {$x}}; puts [set literal]` prints `$x`
+        // — unsubstituted.
+        let reg = default_registry();
+        let mut scanner = VarReferenceScanner::new(VarScanOptions::default());
+        let vars = scanner.scan_script("set literal {$x}", &reg);
+        assert!(
+            !vars.contains("x"),
+            "a script body's brace-quoted {{$x}} must stay literal; got {vars:?}"
+        );
+    }
+
+    #[test]
+    fn scan_script_still_finds_a_bare_substitution_in_a_script_body_issue_1024() {
+        // TP guard for the same fix: dropping quoted-body mode must not
+        // stop `scan_script` seeing ordinary substitutions.
+        let reg = default_registry();
+        let mut scanner = VarReferenceScanner::new(VarScanOptions::default());
+        let vars = scanner.scan_script("set copy $x\nputs [foo $y]", &reg);
+        assert!(vars.contains("x"), "should find bare $x; got {vars:?}");
+        assert!(
+            vars.contains("y"),
+            "should recurse into [foo $y]; got {vars:?}"
+        );
+    }
+
+    #[test]
+    fn scan_word_and_scan_script_cache_the_same_text_separately_issue_1024() {
+        // The LRU key must carry the mode: the same source text has two
+        // legitimate answers, and whichever ran first must not poison the
+        // other.
+        let reg = default_registry();
+        let mut scanner = VarReferenceScanner::new(VarScanOptions::default());
+        let as_word = scanner.scan_word("set literal {$x}", &reg);
+        let as_script = scanner.scan_script("set literal {$x}", &reg);
+        assert!(
+            as_word.contains("x"),
+            "value-body mode substitutes {{$x}}; got {as_word:?}"
+        );
+        assert!(
+            !as_script.contains("x"),
+            "script mode must not inherit the cached value-body answer; got {as_script:?}"
+        );
+        // And the reverse order, on a fresh scanner.
+        let mut scanner = VarReferenceScanner::new(VarScanOptions::default());
+        let as_script = scanner.scan_script("set literal {$x}", &reg);
+        let as_word = scanner.scan_word("set literal {$x}", &reg);
+        assert!(!as_script.contains("x"), "got {as_script:?}");
+        assert!(as_word.contains("x"), "got {as_word:?}");
+    }
+
+    #[test]
     fn scan_no_recurse() {
         let reg = default_registry();
         let mut scanner = VarReferenceScanner::new(VarScanOptions {
@@ -629,7 +702,7 @@ mod tests {
         scanner.scan_word("$c", &reg); // should evict $a
         assert_eq!(scanner.cache.len(), 2);
         assert!(
-            !scanner.cache.contains_key("$a"),
+            !scanner.cache.contains_key(&("$a".to_owned(), true)),
             "oldest entry should be evicted"
         );
     }

--- a/rust/tcl-compiler/src/var_refs.rs
+++ b/rust/tcl-compiler/src/var_refs.rs
@@ -192,7 +192,6 @@ impl VarReferenceScanner {
         self.cache.clear();
         self.order.clear();
     }
-
 }
 
 /// The variable name a `TokenType::Var` token contributes, per

--- a/rust/tcl-compiler/src/var_refs.rs
+++ b/rust/tcl-compiler/src/var_refs.rs
@@ -24,9 +24,10 @@
 //!
 //! Results are cached in a bounded LRU keyed by source text *and* scan
 //! mode — the same word/script strings are scanned repeatedly across SSA,
-//! GVN, and interprocedural passes, and the two modes ([`
-//! VarReferenceScanner::scan_word`] vs [`VarReferenceScanner::scan_script`])
-//! can legitimately disagree about the same text.
+//! GVN, and interprocedural passes, and the two modes
+//! ([`VarReferenceScanner::scan_word`] vs
+//! [`VarReferenceScanner::scan_script`]) can legitimately disagree about
+//! the same text.
 
 use std::collections::{BTreeSet, HashMap, VecDeque};
 

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -1826,6 +1826,65 @@ mod interp_value_flow {
         assert!(codes(src, D).is_empty(), "{:?}", codes(src, D));
     }
 
+    /// The `@interp@<key>` synthetic namespaces a source's definitions
+    /// land in — the observable projection of the interpreter-domain key.
+    fn interp_domains(src: &str) -> Vec<String> {
+        let mut keys: Vec<String> = Analyser::new()
+            .analyse(src, D)
+            .all_procs
+            .keys()
+            .filter_map(|k| k.split("::").find(|s| s.starts_with("@interp@")))
+            .map(str::to_owned)
+            .collect();
+        keys.sort();
+        keys.dedup();
+        keys
+    }
+
+    #[test]
+    fn braced_path_value_flow_key_matches_the_direct_handler_issue_1025() {
+        // TP — `interp create {child}` names interpreter `child`
+        // (tclsh8.6/9.0: `interp exists child` → 1, `interp slaves` →
+        // `child`). The value-flow path used to `split_whitespace` the raw
+        // substitution text and bind `$i` to `"{child}"`, a domain the
+        // direct handler never records.
+        let via_value = "set i [interp create {child}]\n$i eval { proc helper {} {} }\n";
+        let direct = "interp create {child}\ninterp eval child { proc helper {} {} }\n";
+        assert_eq!(
+            interp_domains(via_value),
+            interp_domains(direct),
+            "value-flow and direct keys must agree"
+        );
+        assert_eq!(interp_domains(via_value), vec!["@interp@child".to_string()]);
+    }
+
+    #[test]
+    fn nested_path_value_flow_key_matches_the_direct_handler_issue_1025() {
+        // TP — `{parent child}` is one word: a descent path (tclsh8.6/9.0:
+        // `interp create {parent child}` returns `parent child` and
+        // `interp slaves parent` → `child`). `split_whitespace` used to
+        // split it into `"{parent"` + `"child}"` and bind the first
+        // fragment.
+        let via_value = "interp create parent\nset i [interp create {parent child}]\n$i eval { proc helper {} {} }\n";
+        let direct = "interp create parent\ninterp create {parent child}\ninterp eval {parent child} { proc helper {} {} }\n";
+        assert_eq!(interp_domains(via_value), interp_domains(direct));
+        assert!(
+            interp_domains(via_value).contains(&"@interp@parent child".to_string()),
+            "{:?}",
+            interp_domains(via_value)
+        );
+    }
+
+    #[test]
+    fn braced_path_binding_links_a_later_literal_eval_issue_1025() {
+        // TP — the linkage the diverging key broke: a proc defined through
+        // the tracked `$i eval` handle must resolve for a later literal
+        // `interp eval child` call, with no W123.
+        let src = "set i [interp create {child}]\n$i eval { proc helper {} { return 1 } }\ninterp eval child { helper }\n";
+        assert!(!fires(src, D, "W123"), "{:?}", codes(src, D));
+        assert!(!fires(src, D, "W140"), "{:?}", codes(src, D));
+    }
+
     #[test]
     fn synthetic_autoname_key_used_for_pathless_interp_create() {
         // TP — pins the synthetic per-call-site key convention (mirrors

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -2011,19 +2011,32 @@ fn unresolved_word_reaching_the_unknown_handler_does_not_fire_i230() {
     );
 }
 
-/// TP control: a module that defines a handler but has no unresolved word
-/// anywhere really does see every caller, so an agreeing set still folds —
-/// the fix must not blanket-disable seeding for any file containing an
-/// `unknown` proc.
+/// End-to-end pair for the unit-level
+/// `a_handler_never_seeds_even_when_every_visible_caller_agrees_1044`:
+/// defining the handler is itself the unenumerable caller, so agreement
+/// among the callers the scan can see proves nothing and no fold happens.
+///
+/// This previously asserted the opposite, on the premise that with no
+/// unresolved word in the file "the direct callers are all of them". That
+/// premise is false — Tcl routes to the handler every word that resolves to
+/// nothing at the instant of the call, and most of those (an autoloaded
+/// name, a name another sourced file introduces, a name built by string
+/// arithmetic) appear nowhere in the source for any scan to find.
+///
+/// tclsh8.6 confirms the seeded words are wrong in both directions: `Dog
+/// new` after `oo::class create Dog` and `worker` after `coroutine worker
+/// body` are recorded as dispatches yet never reach the handler, while a
+/// `bogus beta` written before `proc unknown` is handled by the builtin
+/// `::unknown` and errors.
 #[test]
-fn unknown_handler_with_no_unresolved_words_still_fires_i230() {
+fn unknown_handler_never_fires_i230_even_with_agreeing_callers() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
     let src = "proc unknown {cmd args} {\n    if {$cmd eq \"alpha\"} { return 1 } else { return 2 }\n}\nunknown alpha\nunknown alpha\nputs hi\n";
     let diags = lsp.open_ready(&uri, src);
     assert!(
-        has_code(&diags, "I230"),
-        "no unresolved word exists, so the direct callers are all of them: {:?}",
+        !has_code(&diags, "I230"),
+        "the handler's caller set is unenumerable, so it never seeds: {:?}",
         codes(&diags)
     );
 }

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -2297,6 +2297,42 @@ fn defstyle_body_typo_still_w123() {
 }
 
 #[test]
+fn w123_call_chain_reaching_a_command_before_its_deletion_issue_1015() {
+    // Issue #1015, end-to-end: `inner` is never invoked at the top level —
+    // only `outer` is — but `outer` calls `inner`, which calls `helper`,
+    // all before the `rename helper {}`. tclsh8.6/9.0 both run this clean
+    // (exit 0, no error), so the analyser must not draw W123 on `helper`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc helper {} { return hi }\nproc inner {} { helper }\nproc outer {} { inner }\nouter\nrename helper {}\n",
+    );
+    assert!(
+        !has_code(&diags, "W123"),
+        "outer's top-level call reaches helper two bodies deep, before the rename: {diags:?}"
+    );
+}
+
+#[test]
+fn w123_unreached_mutual_recursion_cycle_still_flags_issue_1015() {
+    // TP control for the same fix: neither cycle member is ever called, so
+    // `helper` is genuinely unreachable before the rename and the call must
+    // still be flagged — the reachability query must terminate on the
+    // cycle, not treat it as proof of reachability.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "proc helper {} {}\nproc pingCaller {} { helper\n pongCaller }\nproc pongCaller {} { pingCaller }\nrename helper {}\n",
+    );
+    assert!(
+        has_code(&diags, "W123"),
+        "an unreached cycle proves nothing; helper is deleted: {diags:?}"
+    );
+}
+
+#[test]
 fn defstyle_bad_operation_is_w001() {
     // `top bogus` — unknown ensemble operation of a scoped command.
     let mut lsp = Lsp::tcl();

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -1989,6 +1989,60 @@ fn command_prefix_callback_target_does_not_fire_i230() {
     );
 }
 
+// Issue #1044: Tcl dispatches every unresolved command word to the module's
+// own `unknown` handler, passing the word and that call's arguments — so the
+// handler's *direct* callers are never its complete caller set, and a
+// coincidentally-uniform set of them folded a condition that varies at
+// runtime. tclsh8.6/9.0-confirmed: with `proc unknown {cmd args}` in scope,
+// `bogus beta` runs the handler with `cmd` = `bogus`. The registry marks the
+// handler with `Traits::UNRESOLVED_COMMAND_HANDLER`, so no compiler code
+// spells the name.
+
+#[test]
+fn unresolved_word_reaching_the_unknown_handler_does_not_fire_i230() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc unknown {cmd args} {\n    if {$cmd eq \"alpha\"} { return 1 } else { return 2 }\n}\nunknown alpha\nunknown alpha\nbogus beta\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        !has_code(&diags, "I230"),
+        "`bogus beta` also reaches unknown, with cmd = \"bogus\": {:?}",
+        codes(&diags)
+    );
+}
+
+/// TP control: a module that defines a handler but has no unresolved word
+/// anywhere really does see every caller, so an agreeing set still folds —
+/// the fix must not blanket-disable seeding for any file containing an
+/// `unknown` proc.
+#[test]
+fn unknown_handler_with_no_unresolved_words_still_fires_i230() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc unknown {cmd args} {\n    if {$cmd eq \"alpha\"} { return 1 } else { return 2 }\n}\nunknown alpha\nunknown alpha\nputs hi\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        has_code(&diags, "I230"),
+        "no unresolved word exists, so the direct callers are all of them: {:?}",
+        codes(&diags)
+    );
+}
+
+/// TN control and the regression risk: a module with **no** handler is the
+/// common case and must be entirely unaffected by the unresolved-word path.
+#[test]
+fn unresolved_word_without_an_unknown_handler_still_fires_i230() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc helper {mode} {\n    if {$mode eq \"prod\"} { set r 1 } else { set r 2 }\n}\nproc caller1 {} { helper prod }\nproc caller2 {} { helper prod }\nbogus beta\n";
+    let diags = lsp.open_ready(&uri, src);
+    assert!(
+        has_code(&diags, "I230"),
+        "with no handler defined, an unresolved word reaches nothing: {:?}",
+        codes(&diags)
+    );
+}
+
 // Issue #977: PR #970's `package provide` guard did not cover the more common
 // shape — a plain library file with NO `package provide`, `source`d by another
 // file that calls its procs with a different literal. `lib.tcl` analysed alone

--- a/rust/tcl-lsp-server/tests/e2e/precision_review.rs
+++ b/rust/tcl-lsp-server/tests/e2e/precision_review.rs
@@ -214,6 +214,42 @@ fn constructor_of_a_deleted_class_does_not_draw_misleading_w308() {
     );
 }
 
+/// TP (issue #1013): the `set x [Cls new]` shape reaches the same
+/// misleading W308 through the SSA type lattice rather than the direct
+/// constructor recognition, so it needs its own end-to-end guard.
+/// tclsh8.6/9.0 fail the constructor itself with `invalid command name
+/// "Dog"`, so `x` never holds an object.
+#[test]
+fn set_var_constructor_of_a_deleted_class_does_not_draw_misleading_w308() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "oo::class create Dog { method bark {} { return woof } }\nrename Dog {}\nproc foo {} {\n    set x [Dog new]\n    $x fly\n}\n",
+    );
+    let cs = codes(&diags);
+    assert!(
+        !cs.iter().any(|c| c == "W308"),
+        "a deleted class must not draw the misleading unknown-method W308: {diags:?}"
+    );
+}
+
+/// FP control for the same gate: a class re-established after its deletion
+/// is live again, so the unknown method must still be flagged.
+#[test]
+fn set_var_constructor_of_a_reestablished_class_still_draws_w308() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "oo::class create Dog { method bark {} { return woof } }\nrename Dog {}\noo::class create Dog { method bark {} { return woof } }\nproc foo {} {\n    set x [Dog new]\n    $x fly\n}\n",
+    );
+    assert!(
+        codes(&diags).iter().any(|c| c == "W308"),
+        "a re-established class must still validate its methods: {diags:?}"
+    );
+}
+
 /// FP guard: `coroutine NAME cmd` binds NAME as a command — calling it is
 /// not unknown.  TP control: a typo'd coroutine name still fires.
 #[test]

--- a/rust/tcl-registry/src/commands/tcl/unknown.rs
+++ b/rust/tcl-registry/src/commands/tcl/unknown.rs
@@ -165,7 +165,12 @@ pub fn spec() -> CommandSpec {
             // already covers for `eval`/`source`/`rename`, so the
             // minifier must not rewrite a call to it through a `$var`
             // alias.
-            | Traits::BYTE_COMPILED,
+            | Traits::BYTE_COMPILED
+            // The interpreter routes every unresolved command word here,
+            // so a module that defines its own `unknown` has callers the
+            // interprocedural seed must enumerate from those words rather
+            // than from direct calls alone (issue #1044).
+            | Traits::UNRESOLVED_COMMAND_HANDLER,
         // `cmdName ?arg arg ...?` — at least 1 argument, unbounded
         // above. Identical in every fetched manpage, Tcl 8.4 through
         // 9.1.

--- a/rust/tcl-registry/src/commands/tcl/uplevel_.rs
+++ b/rust/tcl-registry/src/commands/tcl/uplevel_.rs
@@ -175,7 +175,8 @@ pub fn spec() -> CommandSpec {
             | Traits::TAINT_SINK
             | Traits::UNSAFE
             | Traits::CREATES_DYNAMIC_BARRIER
-            | Traits::DYNAMIC_EVAL_BODY,
+            | Traits::DYNAMIC_EVAL_BODY
+            | Traits::EVALUATES_IN_SHIFTED_FRAME,
         arity: Arity::at_least(1),
         // The body runs in another stack frame (the `level`), not the
         // caller's, so its variable references belong to that frame — mark

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -645,6 +645,31 @@ declare_traits! {
     /// path is already modelled by its handler argument's
     /// [`crate::arg_role::ArgRole::CommandPrefix`] role.)
     UnresolvedCommandHandler => UNRESOLVED_COMMAND_HANDLER;
+
+    /// Evaluates its script argument in a **different stack frame** than
+    /// the one the call is written in — `uplevel`, whose body runs in the
+    /// frame the level argument selects (`Tcl_UplevelObjCmd`,
+    /// `generic/tclProc.c`).
+    ///
+    /// Distinct from [`Traits::EVALUATES_CODE`], which every `eval`-family
+    /// command carries: `eval`, `catch`, and `namespace inscope` bodies all
+    /// run somewhere, but only this one runs somewhere the *writing* frame
+    /// does not describe. And distinct from
+    /// [`crate::arg_role::ArgRole::Name`]-qualified commands like
+    /// `namespace eval`, which shift *namespace* while staying in the same
+    /// frame.
+    ///
+    /// A consumer that walks `ArgRole::Body` arguments with the enclosing
+    /// unit's own context must skip these bodies: the context is wrong, so
+    /// every bare command word in the body resolves against the wrong
+    /// namespace. `tcl_compiler::unit_scope` has a dedicated scan
+    /// (`upframe_scan_bodies`) that visits them with the frame the level
+    /// argument actually selects.
+    ///
+    /// tclsh8.6/9.0-confirmed: inside `::foo::runIt`, `uplevel #0 { helper
+    /// b }` calls `::helper`, never the `::foo::helper` sitting in the
+    /// enclosing namespace.
+    EvaluatesInShiftedFrame => EVALUATES_IN_SHIFTED_FRAME;
 }
 
 /// Every trait that widens a file's caller set beyond the file itself — the

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -623,6 +623,28 @@ declare_traits! {
     /// commands as an API surface whose callers the file does not contain
     /// and no enumeration bounds (issue #977).
     ExportsCommand => EXPORTS_COMMAND;
+
+    /// The interpreter's fallback for a command word that resolves to
+    /// nothing — `unknown`.  Tcl dispatches *every* unresolved command
+    /// word to it, passing the word itself followed by that call's
+    /// arguments (tclsh8.6/9.0-confirmed: `bogus beta gamma` with a
+    /// user-defined `proc unknown {cmd args}` in scope runs the handler
+    /// with `cmd` = `bogus`, `args` = `beta gamma`).
+    ///
+    /// The interprocedural call-site seed (`tcl_compiler::unit_scope`)
+    /// consults this trait so it can enumerate those dispatches as real
+    /// call sites of a module's own handler instead of seeing only its
+    /// direct callers — a coincidentally-uniform set of which would
+    /// otherwise fold a genuinely runtime-varying parameter (issue #1044).
+    /// Carried by the spec so no consumer spells the name `unknown`.
+    ///
+    /// Global only: a namespace-local `proc unknown` is *not* the handler
+    /// for unresolved words in that namespace — tclsh8.6/9.0 dispatch to
+    /// `::unknown` regardless of the calling namespace. (`namespace
+    /// unknown NAME` registers a per-namespace handler explicitly; that
+    /// path is already modelled by its handler argument's
+    /// [`crate::arg_role::ArgRole::CommandPrefix`] role.)
+    UnresolvedCommandHandler => UNRESOLVED_COMMAND_HANDLER;
 }
 
 /// Every trait that widens a file's caller set beyond the file itself — the

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -458,6 +458,10 @@ pub const TRAITS: &[Variant] = &[
         "UNRESOLVED_COMMAND_HANDLER",
         "handles the dialect's unresolved command words",
     ),
+    v(
+        "EVALUATES_IN_SHIFTED_FRAME",
+        "runs its body script in another stack frame",
+    ),
 ];
 
 /// [`TaintColour`] bits.

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -454,6 +454,10 @@ pub const TRAITS: &[Variant] = &[
         "EXPORTS_COMMAND",
         "publishes a command name for another unit",
     ),
+    v(
+        "UNRESOLVED_COMMAND_HANDLER",
+        "handles the dialect's unresolved command words",
+    ),
 ];
 
 /// [`TaintColour`] bits.


### PR DESCRIPTION
## Summary

Seven verified compiler-correctness fixes, each oracle-confirmed against tclsh8.6 **and** tclsh9.0 before any code was written, each with failing-then-passing regression tests:

- **#980** — `uplevel #0 { … }` bodies now resolve against the global namespace in interprocedural call-site seeding. Two halves: a pre-CFG scan builds bare CFG contexts for static `uplevel` bodies (`frame_shift == 0` → global; relative levels keep the enclosing unit's namespace as the documented approximation), and the `ArgRole::Body` text re-walk no longer descends into `Traits::DEFINES_PROCEDURE` bodies (the phantom-fold half). The pinned `#[ignore]` test is un-ignored and passes.
- **#1013** — the SSA type lattice's constructor typing (`constructor_object_type`) is now gated on class liveness at `aggregate_object_types`, where the analyser's deletion facts are in scope — `rename Dog {}` no longer leaves `[Dog new]` typed as `Object(::Dog)`, killing the false W308. Gating there (rather than pre-filtering in `CompilationUnit`, which has no analyser) also covers the LSP's incremental path.
- **#1015** — the deletion escape hatch follows the whole call graph: `top_level_call_offsets` generalised to `reachable_call_offsets`, a monotone least-fixpoint, so `outer → inner → helper` chains resolve and mutual-recursion cycles terminate. All five prior regression tests preserved.
- **#1024** — `scan_script` regains genuine Tcl script-body semantics (`quoted_body=false`); `scan_word` keeps value-body mode; the scan cache is keyed by `(source, quoted_body)` so the modes can't collide. One caller (`dataflow.rs`, scanning a `return` value word) moved to `scan_word` to keep its semantics.
- **#1025** — `interp create`'s value-flow path parses the interpreter path with the Tcl list parser instead of `split_whitespace`, so `set i [interp create {parent child}]` binds `$i` to the same domain key as the direct handler.
- **#1044** — a module's own `unknown` handler is now seeded from every unresolved literal command word (word + args recorded as real invocations), via a new registry trait `UNRESOLVED_COMMAND_HANDLER` on the `unknown` spec — no consumer spells the command name. Oracle-confirmed that only `::unknown` (global) is the handler, and that namespace-local `proc unknown` is not consulted.
- **#979** — pinned: a regression test guards the `EXPORTS_COMMAND`-declines-seeding mechanism that (soundly, if bluntly) protects ensemble `-map` redirection, so a future registry edit can't silently reopen it.

Also updates `docs/design/compiler/fp-audit-todo.md` (FP-IPCP-01 residual closed, new FP-IPCC-05 entry for #1044) and catalogues the new trait in the spec studio.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Run on the integration of this PR with the two sibling PRs (branch-identical files; merges are conflict-free):

- `make rust-check` — fmt + clippy (`-D warnings`, zero new allows) + all xtask drift gates: pass
- `make check-all` — pass
- `make prep-pr` — full workspace suite (306 test targets incl. native lsp_e2e): pass, 0 failures
- `make test-ext` — VS Code extension: 710 passing
- `make test-emacs` — pass
- `make runtime-rust-test` — 400 passed
- Per-fix: failing-then-passing verified for every fix (details in the per-commit messages); oracle transcripts against tclsh8.6/9.0 for #980/#1013/#1015/#1024/#1025/#1044/#979

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? (call-site seeding evidence, SSA constructor typing, scan modes)
- [x] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. (`docs/design/compiler/fp-audit-todo.md` audit trail updated; no `docs/kcs/compiler/` note's contract changed — the seeding/typing notes' documented behaviour is what these fixes now actually implement)
- [ ] If I added a new compiler KCS note, I linked it from both:
  - `docs/kcs/compiler/README.md`
  - `docs/kcs/README.md`

(no new KCS note added)

**Merge order note:** this PR, the registry PR, and the oonav PR are mutually conflict-free (verified by merging all three); merge this one first, the others in any order after.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178kD1P7t6ne1shFtWwkK54

---
_Generated by [Claude Code](https://claude.ai/code/session_0178kD1P7t6ne1shFtWwkK54)_