### PR TITLE
TclOO navigation: consumer-doc rename, deterministic definition link gate, lens/references parity, classmethod call hierarchy, apply-lambda refactors (#993 #1028 #991 #995 #1000)

### DIFF
--- a/docs/kcs/features/kcs-feature-call-hierarchy.md
+++ b/docs/kcs/features/kcs-feature-call-hierarchy.md
@@ -33,19 +33,31 @@ proc-to-proc edge. External `$obj method` dispatch (a different class or
 document calling in) is not part of the method call graph — it is a Find
 References concern instead.
 
+A `classmethod` is different: it is dispatched on the class's own command,
+`ClassName <method>`, so that shape is a call edge too. A class command is
+an ordinary global command, so the edge fires wherever the call is written
+— inside another classmethod, inside an instance method, inside a plain
+proc, or at the top level (the caller is then shown as `<top-level>`).
+Because it is a real command call, `Factory make` where `Factory` happens
+to be an ordinary proc is a call to *that proc*, not to any class's
+same-named classmethod, and no method edge is created for it.
+
 An instance `method` and a `classmethod` sharing a name (rare, but `TclOO`
 keeps them in independent tables, so it's legal) never cross-link: `my
 <word>` dispatch scope depends on which table the *caller's own body*
 belongs to (`self` is the class object inside a `classmethod`'s body, the
-instance everywhere else), so an edge only ever connects two members of the
-same kind.
+instance everywhere else), so a `my` edge only ever connects two members of
+the same kind. The `ClassName <method>` shape reaches only the class
+object's own table, so it never edges to a same-named instance method.
 
 ## File-path anchors
 
 - `rust/tcl-lsp-core/src/call_hierarchy.rs`
 - `rust/tcl-lsp-core/src/references.rs` (`scan_my_method_sites` — the
   shared `my`-dispatch matcher call hierarchy, Find References, rename,
-  and the code lens all resolve through)
+  and the code lens all resolve through — and
+  `find_obj_method_call_sites`, the shared bare `ClassName <method>`
+  classmethod-dispatch scanner)
 
 ## Failure modes
 
@@ -64,7 +76,9 @@ same kind.
   and `prepare_resolves_classmethod_over_same_named_method_by_cursor`)
 - `rust/tcl-lsp-server/tests/e2e/navigation_extras.rs`
   (`method_incoming_and_outgoing_calls_match_my_dispatch`,
-  `method_outgoing_calls_nested_in_control_flow`)
+  `method_outgoing_calls_nested_in_control_flow`,
+  `classmethod_incoming_and_outgoing_calls_match_bare_class_dispatch`,
+  `bare_dispatch_on_a_same_named_proc_is_not_a_classmethod_edge`)
 
 ## Example
 

--- a/docs/kcs/features/kcs-feature-call-hierarchy.md
+++ b/docs/kcs/features/kcs-feature-call-hierarchy.md
@@ -37,7 +37,11 @@ A `classmethod` is different: it is dispatched on the class's own command,
 `ClassName <method>`, so that shape is a call edge too. A class command is
 an ordinary global command, so the edge fires wherever the call is written
 — inside another classmethod, inside an instance method, inside a plain
-proc, or at the top level (the caller is then shown as `<top-level>`).
+proc, or at the top level (the caller is then shown as `<top-level>`) — and
+that includes bodies that shift frame, such as a `namespace eval` body or an
+`apply` lambda body, where a `$obj method` dispatch would *not* count. The
+edge is symmetric in both directions: the classmethod's Incoming Calls lists
+the calling proc, and the proc's Outgoing Calls lists the classmethod.
 Because it is a real command call, `Factory make` where `Factory` happens
 to be an ordinary proc is a call to *that proc*, not to any class's
 same-named classmethod, and no method edge is created for it.
@@ -48,7 +52,14 @@ keeps them in independent tables, so it's legal) never cross-link: `my
 belongs to (`self` is the class object inside a `classmethod`'s body, the
 instance everywhere else), so a `my` edge only ever connects two members of
 the same kind. The `ClassName <method>` shape reaches only the class
-object's own table, so it never edges to a same-named instance method.
+object's own table, so it never edges to a same-named instance method. A
+caller that dispatches both — `my make` and `C make` in one body — gets two
+separate callee entries, each pointing at its own declaration, because
+edges are grouped by declaration identity rather than by display name.
+
+The callers of a classmethod are listed by their qualified names —
+`::util::helper` for a proc, `::Factory::build` for a method — so the two
+kinds read consistently in the same list.
 
 ## File-path anchors
 
@@ -72,7 +83,11 @@ object's own table, so it never edges to a same-named instance method.
 ## Test anchors
 
 - `rust/tcl-lsp-core/src/call_hierarchy.rs` (`mod tests`, including
-  `outgoing_calls_does_not_conflate_method_and_classmethod_sharing_a_name`
+  `outgoing_calls_does_not_conflate_method_and_classmethod_sharing_a_name`,
+  `outgoing_calls_separate_same_named_instance_method_and_classmethod`,
+  `outgoing_calls_from_proc_reach_bare_class_dispatch`,
+  `classmethod_incoming_covers_lambda_and_namespace_eval_bodies`,
+  `classmethod_incoming_names_proc_callers_qualified`,
   and `prepare_resolves_classmethod_over_same_named_method_by_cursor`)
 - `rust/tcl-lsp-server/tests/e2e/navigation_extras.rs`
   (`method_incoming_and_outgoing_calls_match_my_dispatch`,

--- a/docs/kcs/features/kcs-feature-code-actions.md
+++ b/docs/kcs/features/kcs-feature-code-actions.md
@@ -37,6 +37,15 @@ batch-applied. The extract-to-proc refactoring attaches a post-edit command
 new proc name — VS Code handles this automatically; other editors silently
 ignore the command and the user can rename manually.
 
+The refactoring actions that work on the command under the cursor —
+if-to-switch, switch-to-dict, brace-expr, inline-variable, and
+extract-to-datagroup — descend into every script-bearing argument the
+registry declares, so they are offered inside a `proc` body, a control-flow
+body, and an `apply` lambda's body alike. An `apply` lambda's *argument
+list* is a plain word list rather than code, so it is never walked as a
+script: a parameter that happens to be spelled like a command does not
+offer a control-flow refactor.
+
 Inline proc declines a proc whose body is branchy, and any call whose head
 is **frame-sensitive** — a command that terminates a block, transfers
 control, creates a scope alias, or creates a barrier (`return`, `break`,

--- a/docs/kcs/features/kcs-feature-code-lens.md
+++ b/docs/kcs/features/kcs-feature-code-lens.md
@@ -24,9 +24,15 @@ Code lenses appear automatically above every `proc` definition, every
 class body, every `property` declaration (`oo::configurable`'s `property
 name -get {...} -set {...}` form), and every explicit `constructor` /
 `destructor`, in a Tcl or iRules file. Each lens shows how many references
-exist to that symbol across the current file (and the workspace, for procs
-and classes, if indexing is enabled). Click the lens to open the Find
+exist to that symbol across the workspace. Click the lens to open the Find
 References panel.
+
+The number shown is exactly the number of locations the click opens, and
+both match **Find All References** on the same declaration. That holds for a
+TclOO method or classmethod whose callers live in other files — an override
+in a sibling document, an inheriting subclass's own dispatch, or a
+pure-consumer file that only calls `$obj method` / `Class method` — which
+earlier releases counted and opened from the current file alone.
 
 A property's count comes from a class-local scan of `my <property>` sites —
 properties have no `$obj property` dispatch shape and no inheritance model,

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -26,6 +26,13 @@ Resolves proc calls, variable references, namespace-qualified names, and BIG-IP 
 - `server/features/definition.py`
 - `analyser/proc_lookup.py`
 
+A `TclOO` member name written as a bare word inside a class body is only a
+jump target when it really is one: the cursor must sit on the member's own
+declaration, or on a bare word that `link` (Tcl 9.0's `oo::Helpers::link`)
+actually made callable. An un-linked bare sibling call raises `invalid
+command name` in real Tcl, so Go to Definition abstains on it — in the
+current file and across the workspace alike.
+
 ## Failure modes
 
 - Definition not found after proc lookup or namespace resolution changes.

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -22,7 +22,7 @@ all-editors, MCP, analyser
 
 Locates all usages of the symbol under the cursor, including definitions, calls, and variable reads/writes. Uses shared proc-reference matching.
 
-TclOO dispatch is followed as well. A method is found through every `$obj method` call on a tracked instance, every intra-class `my method` dispatch, and `next` / `nextto` super-dispatch, whether the call sits at the top level of a body, inside a `[…]` command substitution, embedded in a quoted or compound word such as `"value: [my get]"`, or nested inside `if` / `while` / `foreach` / `switch` (either the inline or single-braced-clause-list form) / `try` / `catch` / `eval` / `dict for` — any combination of these, arbitrarily deep. A property is found the same way through every `my <property>` read (a property has no `$obj` dispatch or inheritance model). A `classmethod` is dispatched differently — on the class's own command, never on an instance — so its references are every bare `ClassName method` call, including from a subclass's own command when the subclass inherits (does not override) the classmethod, in the defining file, a subclass-only file, or a pure-consumer file that never mentions the class body at all (the workspace index's per-method `kind` carries the "this is a classmethod" fact to whichever file needs it). The same applies to snit's `typemethod` — snit and TclOO members are both registry-declared class methods, so this is not a TclOO-specific check. An expr math function resolves to its backing proc, so a `proc ::tcl::mathfunc::foo` is found from every `foo(...)` written inside an `expr`.
+TclOO dispatch is followed as well. A method is found through every `$obj method` call on a tracked instance, every intra-class `my method` dispatch, and `next` / `nextto` super-dispatch, whether the call sits at the top level of a body, inside a `[…]` command substitution, embedded in a quoted or compound word such as `"value: [my get]"`, or nested inside `if` / `while` / `foreach` / `switch` (either the inline or single-braced-clause-list form) / `try` / `catch` / `eval` / `dict for` — any combination of these, arbitrarily deep. A property is found the same way through every `my <property>` read (a property has no `$obj` dispatch or inheritance model). A `classmethod` is dispatched differently — on the class's own command, never on an instance — so its references are every bare `ClassName method` call, including from a subclass's own command when the subclass inherits (does not override) the classmethod, in the defining file, a subclass-only file, or a pure-consumer file that never mentions the class body at all (the workspace index's per-method `kind` carries the "this is a classmethod" fact to whichever file needs it). Because a class command is an ordinary command rather than a frame-bound receiver, a bare classmethod dispatch is also found inside a `namespace eval` body or an `apply` lambda body — the two places an instance's `$obj method` dispatch is deliberately *not* followed, since `$obj` names something different there. The same applies to snit's `typemethod` — snit and TclOO members are both registry-declared class methods, so this is not a TclOO-specific check. A stock-TclOO `self method`, however, is not inherited: a subclass's own class command never reaches it, so `Subclass method` is not a reference to a parent's `self method` (only `ooutil`'s `classmethod` keyword propagates that way). An expr math function resolves to its backing proc, so a `proc ::tcl::mathfunc::foo` is found from every `foo(...)` written inside an `expr`.
 
 A method, a classmethod, and a property can share one name within the same
 class (rare, but each lives in its own independent table, so it's legal);
@@ -62,12 +62,21 @@ double-quoted string.
 
 - A class referenced only through a dynamic (`$var`) superclass / mixin name is
   not linked — the name is not statically decidable.
-- A `my` / `next` / `$obj method` dispatch written inside `uplevel` or a bare
-  `apply` lambda is not found: `uplevel`'s body may run in a different call
-  frame (only level `0` is truly the same frame, and that can't be told apart
-  from `uplevel 1`+ statically), and an `apply` lambda's body runs in its own
-  frame that has no route back to the enclosing object's `my` unless the
-  lambda is explicitly constructed with the object's namespace.
+- A `my` / `next` / `$obj method` dispatch written inside `uplevel`, a
+  `namespace eval` body, or an `apply` lambda is not found: `uplevel`'s body
+  may run in a different call frame (only level `0` is truly the same frame,
+  and that can't be told apart from `uplevel 1`+ statically), a `namespace
+  eval` body resolves `$obj` against that namespace's own variables, and an
+  `apply` lambda's body runs in its own frame that has no route back to the
+  enclosing object's `my` unless the lambda is explicitly constructed with
+  the object's namespace. A bare `ClassName classmethod` dispatch (and a
+  `CLASS create NAME` object command's `NAME method`) **is** found in all of
+  those bodies — a class command is an ordinary command and resolves from any
+  frame.
+- Inside an `apply` lambda, only a `{braced}` body element is searched. A
+  body written as a bare or double-quoted list element is backslash-decoded
+  before `apply` evaluates it, so its source text is not the script that runs
+  and a call site found in it would point at the wrong bytes.
 - Expect's `expect { -re pattern body … }` clause list is not descended (only
   a plain `{pattern body …}` clause list, `switch`'s shape, is).
 - [incr Tcl] dispatches a class-scoped `proc` (itcl's own class-method form)

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -105,6 +105,8 @@ double-quoted string.
   `dispatch_scan_depth_guard_stops_runaway_nesting`,
   `tn_expect_clause_flags_not_decomposed`)
 - `rust/tcl-lsp-server/tests/e2e/issue923_class_refs.rs` (cross-file)
+- `rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs` (rename / references /
+  code-lens agreement on the same `TclOO` member — issues #991, #993)
 - `rust/tcl-lsp-server/tests/e2e/name_resolution.rs`
   (`my_method_dispatch::tp_my_dispatch_nested_in_control_flow_reference_and_lens`)
 - `rust/tcl-lsp-server/src/lib.rs` unit tests: `cross_file_consumer_finds_classmethod_bare_dispatch`,

--- a/docs/kcs/features/kcs-feature-rename.md
+++ b/docs/kcs/features/kcs-feature-rename.md
@@ -60,7 +60,12 @@ dispatch site (however deeply nested in `[…]` substitutions or same-frame
 control-flow / `eval` bodies — see [Find References](kcs-feature-references.md)),
 every external `$obj method` site, and every override-family member (a
 superclass or subclass that (re)defines the same method) — all as one
-rename. Renaming a property rewrites the declaration plus every `my
+rename. A **pure-consumer** file — one that only calls the method (`set f
+[Factory new]; $f make`, or a bare `Factory make` classmethod dispatch) and
+declares no part of the class — is rewritten too: rename and **Find
+References** resolve those call sites through one shared resolver, so a
+consumer file can never be left calling a name the rename has already taken
+away. Renaming a property rewrites the declaration plus every `my
 <property>` read; a property has no `$obj` dispatch or inheritance model,
 so those are out of scope by design, not a gap. Because a method is never a
 bare-callable command (only `my method` dispatches it), a method / property

--- a/docs/kcs/features/kcs-feature-rename.md
+++ b/docs/kcs/features/kcs-feature-rename.md
@@ -65,7 +65,13 @@ rename. A **pure-consumer** file — one that only calls the method (`set f
 declares no part of the class — is rewritten too: rename and **Find
 References** resolve those call sites through one shared resolver, so a
 consumer file can never be left calling a name the rename has already taken
-away. Renaming a property rewrites the declaration plus every `my
+away. A bare classmethod dispatch is rewritten wherever it is written,
+including inside a `namespace eval` body or an `apply` lambda body — a class
+command is an ordinary command and resolves from any frame, unlike a `$obj`
+receiver. A subclass's own `Subclass method` dispatch renames with the
+parent's `classmethod`, but **not** with a stock-TclOO `self method`, which
+is not inherited and so was never calling the renamed member. Renaming a
+property rewrites the declaration plus every `my
 <property>` read; a property has no `$obj` dispatch or inheritance model,
 so those are out of scope by design, not a gap. Because a method is never a
 bare-callable command (only `my method` dispatches it), a method / property

--- a/rust/tcl-compiler/src/lambda_literal.rs
+++ b/rust/tcl-compiler/src/lambda_literal.rs
@@ -53,8 +53,33 @@ pub struct LambdaLiteralElements {
     pub params: Span,
     /// Element 1 — the body script, when present.
     pub body: Option<Span>,
+    /// `true` when [`Self::body`] was written as a `{braced}` list element.
+    /// See [`Self::braced_body`].
+    pub body_braced: bool,
     /// Element 2 — the namespace the body runs in, when present.
     pub namespace: Option<Span>,
+}
+
+impl LambdaLiteralElements {
+    /// [`Self::body`], but only for a `{braced}` body element — the one
+    /// shape whose script text is the source text verbatim at exactly this
+    /// span's offsets.
+    ///
+    /// A bare or double-quoted body element goes through list-element
+    /// decoding before `apply` ever evaluates it, so its backslash escapes
+    /// collapse first: `apply {{} if\ \{$x\}\ \{puts a\}}`'s real body is
+    /// `if {$x} {puts a}`, three words, while its *source* slice is a single
+    /// escaped word. A consumer that re-parses the slice in place and reports
+    /// source spans back — the refactor code-action descent, the dispatch
+    /// call-site scan — would be reading a script that does not exist. Those
+    /// consumers take this accessor and skip the element instead; consumers
+    /// that want the real value regardless of shape take
+    /// [`split_lambda_literal_decoded`], which has no spans to get wrong
+    /// (Codex review on #1047).
+    #[must_use]
+    pub fn braced_body(&self) -> Option<Span> {
+        self.body.filter(|_| self.body_braced)
+    }
 }
 
 /// Split a lambda-literal token into its list elements' absolute spans.
@@ -77,6 +102,7 @@ pub fn split_lambda_literal(source: &str, tok: Token) -> Option<LambdaLiteralEle
     Some(LambdaLiteralElements {
         params: to_span(&params_el)?,
         body: body_el.as_ref().and_then(to_span),
+        body_braced: body_el.as_ref().is_some_and(|el| el.braced),
         namespace: namespace_el.as_ref().and_then(to_span),
     })
 }
@@ -216,6 +242,42 @@ mod tests {
         let elems = split_lambda_literal(src, lambda_tok(src)).unwrap();
         assert!(elems.body.is_none());
         assert!(elems.namespace.is_none());
+    }
+
+    #[test]
+    fn braced_body_is_offered_for_in_place_reparse() {
+        let src = "apply {{} {Factory make}}";
+        let elems = split_lambda_literal(src, lambda_tok(src)).unwrap();
+        assert!(elems.body_braced);
+        let body = elems.braced_body().unwrap();
+        assert_eq!(
+            &src[body.start() as usize..body.end() as usize],
+            "Factory make"
+        );
+    }
+
+    /// Codex review on #1047: a bare body element with backslash escapes is
+    /// decoded by the list parser before `apply` evaluates it, so its source
+    /// slice is not the script that runs — an in-place re-parse would read
+    /// `if\ \{$x\}\ \{puts\ a\}` as one word.  `braced_body` withholds it.
+    #[test]
+    fn escaped_bare_body_is_withheld_from_in_place_reparse() {
+        let src = r"apply {{} if\ \{$x\}\ \{puts\ a\}}";
+        let elems = split_lambda_literal(src, lambda_tok(src)).unwrap();
+        assert!(elems.body.is_some());
+        assert!(!elems.body_braced);
+        assert!(elems.braced_body().is_none());
+    }
+
+    /// A double-quoted body element is likewise not brace-delimited: it is
+    /// decoded before evaluation, so it is withheld too.
+    #[test]
+    fn quoted_body_is_withheld_from_in_place_reparse() {
+        let src = r#"apply {{} "Factory make"}"#;
+        let elems = split_lambda_literal(src, lambda_tok(src)).unwrap();
+        assert!(elems.body.is_some());
+        assert!(!elems.body_braced);
+        assert!(elems.braced_body().is_none());
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/call_hierarchy.rs
+++ b/rust/tcl-lsp-core/src/call_hierarchy.rs
@@ -142,6 +142,59 @@ fn method_item_name(class_def: &ClassDef, method: &MethodDef) -> String {
     format!("{}::{}", class_def.qualified_name, method.name)
 }
 
+/// Grouping identity for one end of a call-hierarchy edge — the caller
+/// bucket of an incoming list, the callee bucket of an outgoing one.
+///
+/// The display name alone is **not** an identity.  A `TclOO` class may
+/// define an instance `method make` and a `classmethod make` at the same
+/// time: the two live in independent method tables, and tclsh 9.0.4 sends
+/// `my make` to the instance copy and `C make` to the class copy.  Both
+/// render as `::C::make`, so keying the grouping on the name text merged
+/// them into a single item whose ranges spanned both call sites and whose
+/// declaration range was whichever entry happened to be inserted first
+/// (Codex review on #1047).  Pairing the name with the declaration's own
+/// name-token span separates them while keeping the emitted order
+/// name-first, hence reproducible.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CallItemKey {
+    /// Qualified display name — the primary sort key.
+    name: String,
+    /// The declaration's name-token span, as `(start, end)`.  `(0, 0)` for
+    /// the synthetic top-level item, which declares nothing.
+    decl: (u32, u32),
+}
+
+impl CallItemKey {
+    fn for_method(class_def: &ClassDef, method: &MethodDef) -> Self {
+        Self {
+            name: method_item_name(class_def, method),
+            decl: (method.name_span.start(), method.name_span.end()),
+        }
+    }
+
+    fn for_proc(qname: &str, proc_def: &ProcDef) -> Self {
+        Self {
+            name: qname.to_owned(),
+            decl: (proc_def.name_span.start(), proc_def.name_span.end()),
+        }
+    }
+
+    fn top_level() -> Self {
+        Self {
+            name: TOP_LEVEL_NAME.to_owned(),
+            decl: (0, 0),
+        }
+    }
+}
+
+/// Display name of the synthetic item standing for a document's top-level
+/// command stream.
+const TOP_LEVEL_NAME: &str = "<top-level>";
+
+/// Per-edge accumulator: the far end's item plus every call-site range
+/// attributed to it, keyed by [`CallItemKey`].
+type EdgeBuckets = std::collections::BTreeMap<CallItemKey, (CallHierarchyItem, Vec<LspRange>)>;
+
 /// Find the proc a call-hierarchy item refers to.
 ///
 /// Items carry only the *short* display name (`helper`), which is ambiguous
@@ -654,9 +707,9 @@ pub fn incoming_calls_for_target(
         }
         let inv_range = span_to_range(source, &line_index, inv.range);
         let caller_key = enclosing_proc(analysis, inv.range)
-            .map_or_else(|| "<top-level>".to_owned(), |(qn, _)| qn.to_owned());
+            .map_or_else(|| TOP_LEVEL_NAME.to_owned(), |(qn, _)| qn.to_owned());
         let entry = by_caller.entry(caller_key.clone()).or_insert_with(|| {
-            let caller_item = if caller_key == "<top-level>" {
+            let caller_item = if caller_key == TOP_LEVEL_NAME {
                 top_level_item()
             } else {
                 let proc = &analysis.all_procs[&caller_key];
@@ -675,10 +728,17 @@ pub fn incoming_calls_for_target(
 /// Enumerate outgoing calls from the proc identified by
 /// `item.name`.  Walks every command invocation whose span
 /// sits inside the proc's body span, then resolves each to its
-/// target proc (when the invocation names a user proc).  Calls
+/// target proc (when the invocation names a user proc), and adds every bare
+/// `ClassName <classmethod>` dispatch in the same body.  Calls
 /// to built-in commands are dropped (they have no
 /// [`CallHierarchyItem`] to point to).  Multiple call sites to
 /// the same target group together.
+///
+/// The classmethod half matters for symmetry: a class command is an
+/// ordinary global command, so a proc body may dispatch one, and
+/// [`add_classmethod_incoming`] already lists that proc under the
+/// classmethod's Incoming Calls.  Without the matching collection here the
+/// edge existed in one direction only (Codex review on #1047).
 #[must_use]
 pub fn outgoing_calls(
     source: &str,
@@ -691,9 +751,7 @@ pub fn outgoing_calls(
         // Not a proc — try a class method.
         return method_outgoing_calls(source, dialect, item, analysis, &line_index);
     };
-    // Map target qname → (target item, list of ranges).
-    let mut by_target: std::collections::BTreeMap<String, (CallHierarchyItem, Vec<LspRange>)> =
-        std::collections::BTreeMap::new();
+    let mut by_target: EdgeBuckets = EdgeBuckets::new();
     for inv in &analysis.command_invocations {
         if !span_contains(source_proc.body_span, inv.range) {
             continue;
@@ -702,17 +760,27 @@ pub fn outgoing_calls(
         for (qname, proc_def) in &analysis.all_procs {
             if invocation_targets(analysis, inv, proc_def, qname) {
                 let inv_range = span_to_range(source, &line_index, inv.range);
-                let entry = by_target.entry(qname.clone()).or_insert_with(|| {
-                    (
-                        item_for_proc(source, proc_def, qname, &line_index),
-                        Vec::new(),
-                    )
-                });
+                let entry = by_target
+                    .entry(CallItemKey::for_proc(qname, proc_def))
+                    .or_insert_with(|| {
+                        (
+                            item_for_proc(source, proc_def, qname, &line_index),
+                            Vec::new(),
+                        )
+                    });
                 entry.1.push(inv_range);
                 break;
             }
         }
     }
+    add_classmethod_outgoing(
+        source,
+        dialect,
+        analysis,
+        source_proc.body_span,
+        &line_index,
+        &mut by_target,
+    );
     by_target
         .into_values()
         .map(|(to, from_ranges)| OutgoingCall { to, from_ranges })
@@ -741,8 +809,7 @@ fn method_incoming_calls(
     else {
         return Vec::new();
     };
-    let mut by_caller: std::collections::BTreeMap<String, (CallHierarchyItem, Vec<LspRange>)> =
-        std::collections::BTreeMap::new();
+    let mut by_caller: EdgeBuckets = EdgeBuckets::new();
     for caller in class_methods_iter(class_def) {
         if !dispatch_reaches(&caller.kind, &target_method.kind) {
             continue;
@@ -757,13 +824,14 @@ fn method_incoming_calls(
         if spans.is_empty() {
             continue;
         }
-        let key = method_item_name(class_def, caller);
-        let entry = by_caller.entry(key).or_insert_with(|| {
-            (
-                item_for_method(source, class_def, caller, line_index),
-                Vec::new(),
-            )
-        });
+        let entry = by_caller
+            .entry(CallItemKey::for_method(class_def, caller))
+            .or_insert_with(|| {
+                (
+                    item_for_method(source, class_def, caller, line_index),
+                    Vec::new(),
+                )
+            });
         entry.1.extend(
             spans
                 .into_iter()
@@ -808,7 +876,7 @@ fn add_classmethod_incoming(
     class_def: &ClassDef,
     target_method: &MethodDef,
     line_index: &LineIndex,
-    by_caller: &mut std::collections::BTreeMap<String, (CallHierarchyItem, Vec<LspRange>)>,
+    by_caller: &mut EdgeBuckets,
 ) {
     if target_method.kind != "classmethod" {
         return;
@@ -835,16 +903,24 @@ fn add_classmethod_incoming(
 /// The caller a bare class-command dispatch site is attributed to: the
 /// innermost class-member body containing it, else the innermost proc body,
 /// else the top level.
+///
+/// This one list mixes both kinds of caller, and a method caller has no
+/// short name that could ever be unambiguous — `::C::make` is the only
+/// thing to call it.  So the proc callers alongside it are named by their
+/// qualified name too (`::util::helper`, not `helper`), rather than reading
+/// as a different kind of label in the same list (adversarial review of
+/// #1047, item 11).  Elsewhere a proc item keeps the short display name the
+/// editor's call-hierarchy UI expects.
 fn enclosing_dispatch_caller(
     source: &str,
     analysis: &AnalysisResult,
     span: tcl_lexer::Span,
     line_index: &LineIndex,
-) -> (String, CallHierarchyItem) {
-    // Keyed by (body length, body start) so the innermost body wins and ties
+) -> (CallItemKey, CallHierarchyItem) {
+    // Ranked by (body length, body start) so the innermost body wins and ties
     // never depend on `all_classes`' hash iteration order.
-    let mut best: Option<((u32, u32), String, CallHierarchyItem)> = None;
-    let mut consider = |body: tcl_lexer::Span, key: String, item: CallHierarchyItem| {
+    let mut best: Option<((u32, u32), CallItemKey, CallHierarchyItem)> = None;
+    let mut consider = |body: tcl_lexer::Span, key: CallItemKey, item: CallHierarchyItem| {
         if !span_contains(body, span) {
             return;
         }
@@ -860,20 +936,22 @@ fn enclosing_dispatch_caller(
         for member in class_methods_iter(class_def) {
             consider(
                 member.body_span,
-                method_item_name(class_def, member),
+                CallItemKey::for_method(class_def, member),
                 item_for_method(source, class_def, member, line_index),
             );
         }
     }
     for (qname, proc_def) in &analysis.all_procs {
+        let mut item = item_for_proc(source, proc_def, qname, line_index);
+        item.name.clone_from(qname);
         consider(
             proc_def.body_span,
-            qname.clone(),
-            item_for_proc(source, proc_def, qname, line_index),
+            CallItemKey::for_proc(qname, proc_def),
+            item,
         );
     }
     best.map_or_else(
-        || ("<top-level>".to_owned(), top_level_item()),
+        || (CallItemKey::top_level(), top_level_item()),
         |(_, key, item)| (key, item),
     )
 }
@@ -887,7 +965,7 @@ fn top_level_item() -> CallHierarchyItem {
         end_character: 0,
     };
     CallHierarchyItem {
-        name: "<top-level>".to_owned(),
+        name: TOP_LEVEL_NAME.to_owned(),
         detail: None,
         range: origin,
         selection_range: origin,
@@ -920,8 +998,7 @@ fn method_outgoing_calls(
     else {
         return Vec::new();
     };
-    let mut by_target: std::collections::BTreeMap<String, (CallHierarchyItem, Vec<LspRange>)> =
-        std::collections::BTreeMap::new();
+    let mut by_target: EdgeBuckets = EdgeBuckets::new();
     for callee in class_methods_iter(class_def) {
         if !dispatch_reaches(&source_method.kind, &callee.kind) {
             continue;
@@ -936,13 +1013,14 @@ fn method_outgoing_calls(
         if spans.is_empty() {
             continue;
         }
-        let key = method_item_name(class_def, callee);
-        let entry = by_target.entry(key).or_insert_with(|| {
-            (
-                item_for_method(source, class_def, callee, line_index),
-                Vec::new(),
-            )
-        });
+        let entry = by_target
+            .entry(CallItemKey::for_method(class_def, callee))
+            .or_insert_with(|| {
+                (
+                    item_for_method(source, class_def, callee, line_index),
+                    Vec::new(),
+                )
+            });
         entry.1.extend(
             spans
                 .into_iter()
@@ -971,12 +1049,14 @@ fn method_outgoing_calls(
             crate::definition::resolve_called_proc(analysis, source, class_ns, &head, None)
         {
             let qname = &proc_def.qualified_name;
-            let entry = by_target.entry(qname.clone()).or_insert_with(|| {
-                (
-                    item_for_proc(source, proc_def, qname, line_index),
-                    Vec::new(),
-                )
-            });
+            let entry = by_target
+                .entry(CallItemKey::for_proc(qname, proc_def))
+                .or_insert_with(|| {
+                    (
+                        item_for_proc(source, proc_def, qname, line_index),
+                        Vec::new(),
+                    )
+                });
             entry.1.push(span_to_range(source, line_index, span));
         }
     }
@@ -1003,7 +1083,7 @@ fn add_classmethod_outgoing(
     analysis: &AnalysisResult,
     body: tcl_lexer::Span,
     line_index: &LineIndex,
-    by_target: &mut std::collections::BTreeMap<String, (CallHierarchyItem, Vec<LspRange>)>,
+    by_target: &mut EdgeBuckets,
 ) {
     for class_def in analysis.all_classes.values() {
         for callee in class_def.class_methods.values() {
@@ -1021,13 +1101,14 @@ fn add_classmethod_outgoing(
             if spans.is_empty() {
                 continue;
             }
-            let key = method_item_name(class_def, callee);
-            let entry = by_target.entry(key).or_insert_with(|| {
-                (
-                    item_for_method(source, class_def, callee, line_index),
-                    Vec::new(),
-                )
-            });
+            let entry = by_target
+                .entry(CallItemKey::for_method(class_def, callee))
+                .or_insert_with(|| {
+                    (
+                        item_for_method(source, class_def, callee, line_index),
+                        Vec::new(),
+                    )
+                });
             entry.1.extend(
                 spans
                     .into_iter()
@@ -1542,6 +1623,101 @@ mod tests {
         let incoming = incoming_calls(src, "tcl9.0", &items[0], &analysis);
         let callers: Vec<&str> = incoming.iter().map(|c| c.from.name.as_str()).collect();
         assert_eq!(callers, vec!["::Factory::viaInstance"], "{incoming:?}");
+    }
+
+    /// FN→TP (Codex review on #1047): a **proc** body dispatching a bare
+    /// class command must list the classmethod under its Outgoing Calls.
+    /// The classmethod's Incoming Calls already listed the proc, so the
+    /// edge used to exist in one direction only.
+    #[test]
+    fn outgoing_calls_from_proc_reach_bare_class_dispatch() {
+        let src = "oo::class create Factory {\n    classmethod make {} { return 1 }\n}\nproc build {} { Factory make }\n";
+        let analysis = analyse_tcl9(src);
+        // Cursor on `build`'s declaration name (line 3, col 6).
+        let items = prepare(src, 3, 6, &analysis);
+        assert_eq!(items[0].name, "build", "{items:?}");
+        let outgoing = outgoing_calls(src, "tcl9.0", &items[0], &analysis);
+        let callees: Vec<&str> = outgoing.iter().map(|c| c.to.name.as_str()).collect();
+        assert_eq!(callees, vec!["::Factory::make"], "{outgoing:?}");
+        assert_eq!(outgoing[0].from_ranges.len(), 1, "{outgoing:?}");
+        // Symmetric with the incoming direction from the same fixture.
+        let make = prepare(src, 1, 16, &analysis);
+        let incoming = incoming_calls(src, "tcl9.0", &make[0], &analysis);
+        let calling_procs: Vec<&str> = incoming.iter().map(|c| c.from.name.as_str()).collect();
+        assert_eq!(calling_procs, vec!["::build"], "{incoming:?}");
+    }
+
+    /// Codex review on #1047: an instance `method make` and a `classmethod
+    /// make` on the same class are two distinct declarations (tclsh 9.0.4:
+    /// `my make` returns `inst-make`, `C make` returns `class-make`), so a
+    /// caller that dispatches both must show two callee items with their own
+    /// declaration ranges — not one merged item keyed on the shared display
+    /// name `::C::make`.
+    #[test]
+    fn outgoing_calls_separate_same_named_instance_method_and_classmethod() {
+        let src = "oo::class create C {\n\
+                   \x20   classmethod make {} { return 1 }\n\
+                   \x20   method make {} { return 2 }\n\
+                   \x20   method caller {} { my make ; C make }\n\
+                   }\n";
+        let analysis = analyse_tcl9(src);
+        // Cursor on `caller`'s declaration name (line 3, col 11).
+        let items = prepare(src, 3, 11, &analysis);
+        assert_eq!(items[0].name, "::C::caller", "{items:?}");
+        let outgoing = outgoing_calls(src, "tcl9.0", &items[0], &analysis);
+        assert_eq!(outgoing.len(), 2, "{outgoing:?}");
+        for call in &outgoing {
+            assert_eq!(call.to.name, "::C::make", "{outgoing:?}");
+            assert_eq!(call.from_ranges.len(), 1, "{outgoing:?}");
+        }
+        // One item points at the classmethod's declaration (line 1), the
+        // other at the instance method's (line 2).
+        let mut decl_lines: Vec<u32> = outgoing
+            .iter()
+            .map(|c| c.to.selection_range.start_line)
+            .collect();
+        decl_lines.sort_unstable();
+        assert_eq!(decl_lines, vec![1, 2], "{outgoing:?}");
+    }
+
+    /// Adversarial review of #1047, item 11: a proc caller listed beside a
+    /// method caller is named the same way — qualified — rather than by its
+    /// short name.
+    #[test]
+    fn classmethod_incoming_names_proc_callers_qualified() {
+        let src = "oo::class create Factory {\n    classmethod make {} { return 1 }\n    method viaInstance {} { Factory make }\n}\nnamespace eval ::util {\n    proc helper {} { Factory make }\n}\n";
+        let analysis = analyse_tcl9(src);
+        let items = prepare(src, 1, 16, &analysis);
+        let incoming = incoming_calls(src, "tcl9.0", &items[0], &analysis);
+        let callers: Vec<&str> = incoming.iter().map(|c| c.from.name.as_str()).collect();
+        assert_eq!(
+            callers,
+            vec!["::Factory::viaInstance", "::util::helper"],
+            "{incoming:?}"
+        );
+    }
+
+    /// FN→TP (adversarial review of #1047, item 2): a bare class dispatch
+    /// inside an `apply` lambda body or a `namespace eval` body is a real
+    /// call site, so the call hierarchy must attribute it to the body it
+    /// sits in.  tclsh 9.0.4 runs all three of these dispatches.
+    #[test]
+    fn classmethod_incoming_covers_lambda_and_namespace_eval_bodies() {
+        let src = "oo::class create Factory {\n\
+                   \x20   classmethod make {} { return 1 }\n\
+                   \x20   method inst {} { apply {{} { Factory make }} }\n\
+                   \x20   method nsev {} { namespace eval ::zz { Factory make } }\n\
+                   }\n\
+                   namespace eval ::top2 { Factory make }\n";
+        let analysis = analyse_tcl9(src);
+        let items = prepare(src, 1, 16, &analysis);
+        let incoming = incoming_calls(src, "tcl9.0", &items[0], &analysis);
+        let callers: Vec<&str> = incoming.iter().map(|c| c.from.name.as_str()).collect();
+        assert_eq!(
+            callers,
+            vec!["::Factory::inst", "::Factory::nsev", "<top-level>"],
+            "{incoming:?}"
+        );
     }
 
     /// FP guard: `Factory make` where `Factory` is an ordinary proc calls

--- a/rust/tcl-lsp-core/src/call_hierarchy.rs
+++ b/rust/tcl-lsp-core/src/call_hierarchy.rs
@@ -55,14 +55,24 @@
 //! [`incoming_calls_for_target`] over each other document to find
 //! sibling-file call sites.
 //!
-//! Scope: method edges are intra-class `my <method>` dispatch only. A
-//! `next` / `nextto` super-dispatch is not a call-hierarchy edge (it *is*
-//! a reference — see [`crate::references::method_next_dispatch_spans`] —
-//! but attributing it a call-graph direction is a distinct question this
-//! provider doesn't yet answer). An external `$obj method` site (a
-//! different class or document dispatching in) is likewise not an
-//! incoming edge here — that is [`crate::references::references`]'s
-//! concern, not this provider's.
+//! Scope: method edges are the two dispatch shapes that name the member
+//! without a receiver variable — intra-class `my <method>`, and a
+//! `classmethod`'s bare `ClassName <method>` on the class's own command
+//! (issue #995).  The latter comes from
+//! [`crate::references::find_obj_method_call_sites`], the same scanner
+//! Find-References / rename / the code lens use, and is attributed to
+//! whichever body it sits in: a classmethod body, an instance-method body,
+//! a proc, or the top level — a class command is an ordinary global
+//! command, so all four really do dispatch it (tclsh9.0-verified), and the
+//! `my`-scope rule ([`dispatch_reaches`]) does not gate this shape.
+//!
+//! Still out of scope: a `next` / `nextto` super-dispatch is not a
+//! call-hierarchy edge (it *is* a reference — see
+//! [`crate::references::method_next_dispatch_spans`] — but attributing it a
+//! call-graph direction is a distinct question this provider doesn't yet
+//! answer). An external `$obj method` site (dispatch through an instance
+//! variable) is likewise not an incoming edge here — that is
+//! [`crate::references::references`]'s concern, not this provider's.
 //!
 //! A `method` and a `classmethod` sharing a name (rare, but `TclOO` keeps
 //! them in independent tables, so it's legal) never collide: `my <word>`
@@ -647,22 +657,7 @@ pub fn incoming_calls_for_target(
             .map_or_else(|| "<top-level>".to_owned(), |(qn, _)| qn.to_owned());
         let entry = by_caller.entry(caller_key.clone()).or_insert_with(|| {
             let caller_item = if caller_key == "<top-level>" {
-                CallHierarchyItem {
-                    name: caller_key.clone(),
-                    detail: None,
-                    range: LspRange {
-                        start_line: 0,
-                        start_character: 0,
-                        end_line: 0,
-                        end_character: 0,
-                    },
-                    selection_range: LspRange {
-                        start_line: 0,
-                        start_character: 0,
-                        end_line: 0,
-                        end_character: 0,
-                    },
-                }
+                top_level_item()
             } else {
                 let proc = &analysis.all_procs[&caller_key];
                 item_for_proc(source, proc, &caller_key, &line_index)
@@ -725,7 +720,9 @@ pub fn outgoing_calls(
 }
 
 /// Incoming calls for a class method — every `my <method>` dispatch site
-/// inside any sibling method body, grouped by the enclosing method.
+/// inside any sibling method body, grouped by the enclosing method, plus
+/// (for a `classmethod`) every bare `ClassName <method>` dispatch anywhere
+/// in the document, grouped by whichever body it sits in.
 ///
 /// Intra-class dispatch of a `TclOO` method is `my <method>`, never a bare
 /// `<method>` call (a method is not a command in the body's namespace — a
@@ -773,15 +770,135 @@ fn method_incoming_calls(
                 .map(|s| span_to_range(source, line_index, s)),
         );
     }
+    add_classmethod_incoming(
+        source,
+        dialect,
+        analysis,
+        class_def,
+        target_method,
+        line_index,
+        &mut by_caller,
+    );
     by_caller
         .into_values()
         .map(|(from, from_ranges)| IncomingCall { from, from_ranges })
         .collect()
 }
 
+/// Add the bare `ClassName <classmethod>` dispatch sites of `target_method`
+/// to `by_caller`, each attributed to the innermost body it sits in (issue
+/// #995).  A no-op unless `target_method` really is a `classmethod`.
+///
+/// The sites come from [`crate::references::find_obj_method_call_sites`] —
+/// the same scanner Find-References / rename / the code lens use, which also
+/// carries the registry-driven definer-family rule that keeps [incr Tcl]'s
+/// `Factory::make` class-proc shape (and its unrelated two-word
+/// instance-creation syntax) out of this — rather than a head-word compare
+/// re-derived here.
+///
+/// No [`dispatch_reaches`] gate: that rule is about `my`, whose scope
+/// depends on the calling body.  A class command is an ordinary global
+/// command, so `Factory make` reaches the classmethod from a classmethod
+/// body, an instance-method body, a proc, or the top level alike
+/// (tclsh9.0-verified).
+fn add_classmethod_incoming(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    class_def: &ClassDef,
+    target_method: &MethodDef,
+    line_index: &LineIndex,
+    by_caller: &mut std::collections::BTreeMap<String, (CallHierarchyItem, Vec<LspRange>)>,
+) {
+    if target_method.kind != "classmethod" {
+        return;
+    }
+    for span in crate::references::find_obj_method_call_sites(
+        source,
+        dialect,
+        analysis,
+        &class_def.qualified_name,
+        &target_method.name,
+        true,
+    ) {
+        if span_contains(target_method.name_span, span) {
+            continue;
+        }
+        let (key, caller_item) = enclosing_dispatch_caller(source, analysis, span, line_index);
+        let entry = by_caller
+            .entry(key)
+            .or_insert_with(|| (caller_item, Vec::new()));
+        entry.1.push(span_to_range(source, line_index, span));
+    }
+}
+
+/// The caller a bare class-command dispatch site is attributed to: the
+/// innermost class-member body containing it, else the innermost proc body,
+/// else the top level.
+fn enclosing_dispatch_caller(
+    source: &str,
+    analysis: &AnalysisResult,
+    span: tcl_lexer::Span,
+    line_index: &LineIndex,
+) -> (String, CallHierarchyItem) {
+    // Keyed by (body length, body start) so the innermost body wins and ties
+    // never depend on `all_classes`' hash iteration order.
+    let mut best: Option<((u32, u32), String, CallHierarchyItem)> = None;
+    let mut consider = |body: tcl_lexer::Span, key: String, item: CallHierarchyItem| {
+        if !span_contains(body, span) {
+            return;
+        }
+        let rank = (body.end() - body.start(), body.start());
+        if best
+            .as_ref()
+            .is_none_or(|(best_rank, _, _)| rank < *best_rank)
+        {
+            best = Some((rank, key, item));
+        }
+    };
+    for class_def in analysis.all_classes.values() {
+        for member in class_methods_iter(class_def) {
+            consider(
+                member.body_span,
+                method_item_name(class_def, member),
+                item_for_method(source, class_def, member, line_index),
+            );
+        }
+    }
+    for (qname, proc_def) in &analysis.all_procs {
+        consider(
+            proc_def.body_span,
+            qname.clone(),
+            item_for_proc(source, proc_def, qname, line_index),
+        );
+    }
+    best.map_or_else(
+        || ("<top-level>".to_owned(), top_level_item()),
+        |(_, key, item)| (key, item),
+    )
+}
+
+/// The synthetic item standing for the document's top-level command stream.
+fn top_level_item() -> CallHierarchyItem {
+    let origin = LspRange {
+        start_line: 0,
+        start_character: 0,
+        end_line: 0,
+        end_character: 0,
+    };
+    CallHierarchyItem {
+        name: "<top-level>".to_owned(),
+        detail: None,
+        range: origin,
+        selection_range: origin,
+    }
+}
+
 /// Outgoing calls from a class method — every `my <method>` dispatch site
 /// inside the method's body that names a sibling method (→ method item),
-/// plus every bare-headed call to a top-level user proc (→ proc item).
+/// every bare `ClassName <classmethod>` dispatch in it (→ that
+/// classmethod's item, issue #995), and every bare-headed call to a
+/// top-level user proc (→ proc item).
 ///
 /// The sibling-method half matches through
 /// [`crate::references::scan_my_method_sites`] (the same matcher
@@ -832,6 +949,14 @@ fn method_outgoing_calls(
                 .map(|s| span_to_range(source, line_index, s)),
         );
     }
+    add_classmethod_outgoing(
+        source,
+        dialect,
+        analysis,
+        source_method.body_span,
+        line_index,
+        &mut by_target,
+    );
     let class_ns = tcl_syntax::naming::key_holder_and_tail(&class_def.qualified_name).0;
     for (head, span) in segment_body_calls(source, dialect, source_method.body_span) {
         if matches!(head.as_str(), "my" | "next" | "nextto") {
@@ -859,6 +984,57 @@ fn method_outgoing_calls(
         .into_values()
         .map(|(to, from_ranges)| OutgoingCall { to, from_ranges })
         .collect()
+}
+
+/// Add every bare `ClassName <classmethod>` dispatch inside `body` to
+/// `by_target`, keyed by the classmethod it names (issue #995).
+///
+/// Every class the document declares is a candidate, not just the calling
+/// method's own: a class command is global, so an instance method of one
+/// class may perfectly well dispatch another class's classmethod
+/// (tclsh9.0-verified).  Sites come from
+/// [`crate::references::find_obj_method_call_sites`], the shared scanner —
+/// so the [incr Tcl] definer-family exclusion and the inheriting-subclass
+/// dispatch heads it already knows about apply here too — filtered to the
+/// calling body's span.
+fn add_classmethod_outgoing(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    body: tcl_lexer::Span,
+    line_index: &LineIndex,
+    by_target: &mut std::collections::BTreeMap<String, (CallHierarchyItem, Vec<LspRange>)>,
+) {
+    for class_def in analysis.all_classes.values() {
+        for callee in class_def.class_methods.values() {
+            let spans: Vec<tcl_lexer::Span> = crate::references::find_obj_method_call_sites(
+                source,
+                dialect,
+                analysis,
+                &class_def.qualified_name,
+                &callee.name,
+                true,
+            )
+            .into_iter()
+            .filter(|span| span_contains(body, *span))
+            .collect();
+            if spans.is_empty() {
+                continue;
+            }
+            let key = method_item_name(class_def, callee);
+            let entry = by_target.entry(key).or_insert_with(|| {
+                (
+                    item_for_method(source, class_def, callee, line_index),
+                    Vec::new(),
+                )
+            });
+            entry.1.extend(
+                spans
+                    .into_iter()
+                    .map(|s| span_to_range(source, line_index, s)),
+            );
+        }
+    }
 }
 
 /// Iterate every method + classmethod of a class (the bodies
@@ -1303,5 +1479,99 @@ mod tests {
         let incoming_cd = incoming_calls(src, "tcl", &items_cd[0], &analysis);
         assert_eq!(incoming_cd.len(), 1, "{incoming_cd:?}");
         assert_eq!(incoming_cd[0].from.name, "caller");
+    }
+
+    // Bare `ClassName <classmethod>` dispatch (issue #995).  `classmethod`
+    // is Tcl 9.0+, so these analyse at 9.0.
+
+    fn analyse_tcl9(source: &str) -> AnalysisResult {
+        let mut a = Analyser::new();
+        a.analyse(source, "tcl9.0").clone()
+    }
+
+    /// FN→TP (issue #995's own repro): a `classmethod` dispatches on the
+    /// class's own command (`Factory make`), so its callers are the
+    /// top-level statement *and* the sibling classmethod's body — neither
+    /// of which has the member's own name as its head word, which is why
+    /// the head-word comparison found nothing.  tclsh9.0-verified: both
+    /// `Factory build` and the bare `Factory make` really do enter `make`.
+    #[test]
+    fn incoming_calls_for_classmethod_find_bare_class_dispatch() {
+        let src = "oo::class create Factory {\n    classmethod make {} { return 1 }\n    classmethod build {} { Factory make }\n}\nFactory make\n";
+        let analysis = analyse_tcl9(src);
+        // Cursor on `make`'s declaration name (line 1, col 16).
+        let items = prepare(src, 1, 16, &analysis);
+        assert_eq!(items[0].name, "::Factory::make", "{items:?}");
+        let incoming = incoming_calls(src, "tcl9.0", &items[0], &analysis);
+        let callers: Vec<&str> = incoming.iter().map(|c| c.from.name.as_str()).collect();
+        assert_eq!(
+            callers,
+            vec!["::Factory::build", "<top-level>"],
+            "{incoming:?}"
+        );
+        assert!(
+            incoming.iter().all(|c| c.from_ranges.len() == 1),
+            "one call site each: {incoming:?}"
+        );
+    }
+
+    /// FN→TP: the outgoing direction of the same repro — `build`'s body
+    /// dispatches `Factory make`, so `make` is its callee.
+    #[test]
+    fn outgoing_calls_from_classmethod_reach_bare_class_dispatch() {
+        let src = "oo::class create Factory {\n    classmethod make {} { return 1 }\n    classmethod build {} { Factory make }\n}\nFactory make\n";
+        let analysis = analyse_tcl9(src);
+        // Cursor on `build`'s declaration name (line 2, col 16).
+        let items = prepare(src, 2, 16, &analysis);
+        assert_eq!(items[0].name, "::Factory::build", "{items:?}");
+        let outgoing = outgoing_calls(src, "tcl9.0", &items[0], &analysis);
+        let callees: Vec<&str> = outgoing.iter().map(|c| c.to.name.as_str()).collect();
+        assert_eq!(callees, vec!["::Factory::make"], "{outgoing:?}");
+        assert_eq!(outgoing[0].from_ranges.len(), 1, "{outgoing:?}");
+    }
+
+    /// TP: a class command is an ordinary global command, so an *instance*
+    /// method's body dispatching `Factory make` is an incoming edge too
+    /// (tclsh9.0-verified) — the `my`-scope rule that keeps instance and
+    /// class method tables apart does not apply to this shape.
+    #[test]
+    fn incoming_calls_for_classmethod_include_an_instance_method_caller() {
+        let src = "oo::class create Factory {\n    classmethod make {} { return 1 }\n    method viaInstance {} { Factory make }\n}\n";
+        let analysis = analyse_tcl9(src);
+        let items = prepare(src, 1, 16, &analysis);
+        let incoming = incoming_calls(src, "tcl9.0", &items[0], &analysis);
+        let callers: Vec<&str> = incoming.iter().map(|c| c.from.name.as_str()).collect();
+        assert_eq!(callers, vec!["::Factory::viaInstance"], "{incoming:?}");
+    }
+
+    /// FP guard: `Factory make` where `Factory` is an ordinary proc calls
+    /// *that proc* with the literal argument `make` (tclsh8.6/9.0-verified:
+    /// it prints `proc Factory: make`), so it is no edge at all to an
+    /// unrelated class's same-named classmethod.
+    #[test]
+    fn bare_dispatch_on_a_same_named_proc_is_not_a_classmethod_edge() {
+        let src = "oo::class create Widget {\n    classmethod make {} { return 1 }\n}\nproc Factory {args} { return $args }\nFactory make\n";
+        let analysis = analyse_tcl9(src);
+        let items = prepare(src, 1, 16, &analysis);
+        assert_eq!(items[0].name, "::Widget::make", "{items:?}");
+        assert!(
+            incoming_calls(src, "tcl9.0", &items[0], &analysis).is_empty(),
+            "a proc call spelled `Factory make` is not a dispatch of Widget's classmethod"
+        );
+    }
+
+    /// FP guard: an instance `method` is *not* bare-dispatchable on the
+    /// class command (`Factory make` reaches only the class object's own
+    /// method table), so the classmethod leg must not fire for one.
+    #[test]
+    fn bare_class_dispatch_is_not_an_edge_to_a_same_named_instance_method() {
+        let src = "oo::class create Factory {\n    method make {} { return 1 }\n}\nFactory make\n";
+        let analysis = analyse_tcl9(src);
+        let items = prepare(src, 1, 11, &analysis);
+        assert_eq!(items[0].name, "::Factory::make", "{items:?}");
+        assert!(
+            incoming_calls(src, "tcl9.0", &items[0], &analysis).is_empty(),
+            "an instance method has no bare class-command dispatch"
+        );
     }
 }

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -2795,6 +2795,32 @@ mod tests {
         );
     }
 
+    /// Issue #1000: the refactor code actions reach control flow inside an
+    /// `apply` lambda body too.  `apply`'s literal is
+    /// `ArgRole::LambdaLiteral`, so the descent has to split it rather than
+    /// re-segment the whole `{argList body}` blob — which read `{m}` as a
+    /// command name and left every `body_words`-backed action silently
+    /// unavailable in there.
+    #[test]
+    fn if_to_switch_surfaces_inside_an_apply_lambda_body() {
+        let src = "proc handler {} {\n    apply {{m} {\n        if {$m eq \"GET\"} {\n            puts get\n        } elseif {$m eq \"POST\"} {\n            puts post\n        }\n    }} $x\n}\n";
+        let analysis = analyse(src);
+        // Cursor on the `if` inside the lambda body (line 2, col 8).
+        let cursor = LspRange {
+            start_line: 2,
+            start_character: 8,
+            end_line: 2,
+            end_character: 8,
+        };
+        let actions = code_actions(src, cursor, Some(&analysis));
+        assert!(
+            actions
+                .iter()
+                .any(|a| a.title.to_lowercase().contains("switch")),
+            "{actions:?}",
+        );
+    }
+
     #[test]
     fn extract_datagroup_surfaces_and_carries_definition() {
         let src = "if {$host eq \"a.com\"} {\n    pool web_pool\n} elseif {$host eq \"b.com\"} {\n    pool web_pool\n} elseif {$host eq \"c.com\"} {\n    pool web_pool\n}";

--- a/rust/tcl-lsp-core/src/code_lens.rs
+++ b/rust/tcl-lsp-core/src/code_lens.rs
@@ -74,17 +74,24 @@
 //! and the document's URI, the proc / class lens count
 //! includes call sites in sibling documents.
 //!
-//! Limitations:
+//! Scope of the counts this module computes:
 //!
-//! * Method lens counts are current-document only (matching the method
-//!   peek, which is also single-document): an `$obj method` site in a
-//!   *sibling* document is not counted, because resolving a cross-file
-//!   object's class needs whole-workspace instance-type flow the index
-//!   does not yet carry.  Proc / class lenses do fold in cross-document
-//!   command-head call sites via the workspace index.
-//! * Constructor / destructor next-chain counts are current-document only
-//!   too, for the same reason: a subclass declared in a sibling document
-//!   that `next`-chains to a superclass defined here is not counted.
+//! * Class-member counts (method / classmethod / property, and the
+//!   constructor / destructor next-chain) are **current-document only**.
+//!   Resolving a cross-file `$obj method` site needs each sibling
+//!   document's own analysis, which this pure, single-document provider
+//!   has no way to obtain.  Proc / class counts do fold in cross-document
+//!   command-head call sites, since the workspace index carries those
+//!   directly.
+//! * That is not what the editor ends up showing for a member lens.  Every
+//!   lens carrying a `qname` is returned to the client *without* a command,
+//!   so the client must call `codeLens/resolve` before rendering it — and
+//!   the server relabels it there from the workspace-wide site set it
+//!   resolves for the click, via [`reference_count_title`].  The number
+//!   shown and the locations the click opens are therefore one and the same
+//!   set, and both match Find All References on the declaration (issue
+//!   #991).  The counts here are the single-document floor under that, and
+//!   what a caller with no server gets.
 
 use tcl_compiler::analyser::AnalysisResult;
 use tcl_lexer::LineIndex;
@@ -347,7 +354,15 @@ fn emit_class_member_lenses(
     }
 }
 
-fn reference_count_title(count: usize) -> String {
+/// The lens label for `count` call sites — `"0 references"` /
+/// `"1 reference"` / `"N references"`.
+///
+/// Public so the server can relabel a lens at `codeLens/resolve` time from
+/// the workspace-wide site set it resolves there (issue #991): the count
+/// shown and the locations the click opens are then one number by
+/// construction, not two independently-derived ones.
+#[must_use]
+pub fn reference_count_title(count: usize) -> String {
     match count {
         0 => "0 references".to_string(),
         1 => "1 reference".to_string(),

--- a/rust/tcl-lsp-core/src/refactor/if_to_switch.rs
+++ b/rust/tcl-lsp-core/src/refactor/if_to_switch.rs
@@ -354,4 +354,24 @@ mod tests {
         let r = run(source, cursor).expect("nested result");
         assert!(r.title.to_lowercase().contains("switch"));
     }
+
+    /// Issue #1000: the same conversion must fire inside an `apply` lambda
+    /// body.  `apply`'s literal is `ArgRole::LambdaLiteral`, so
+    /// `find_command_at` has to split it and descend into element 1 —
+    /// before that it read the `{m}` argument list as a command name and
+    /// found no `if` at all, silently disabling this and the four other
+    /// `body_words`-backed code actions there.
+    #[test]
+    fn inside_apply_lambda_body() {
+        let source = "proc handler {} {\n    apply {{m} {\n        if {$m eq \"GET\"} {\n            handle_get\n        } elseif {$m eq \"POST\"} {\n            handle_post\n        } elseif {$m eq \"PUT\"} {\n            handle_put\n        }\n    }} $x\n}\n";
+        let cursor = u32::try_from(source.find("if {$m").unwrap()).unwrap();
+        let r = run(source, cursor).expect("result inside the apply lambda");
+        assert!(r.title.to_lowercase().contains("switch"));
+        let applied = r.apply(source);
+        assert!(applied.contains("switch -exact -- $m"), "{applied:?}");
+        // The rewrite lands inside the lambda body, leaving `apply`'s own
+        // argument list and the enclosing proc intact.
+        assert!(applied.contains("apply {{m} {"), "{applied:?}");
+        assert!(applied.starts_with("proc handler {} {\n"), "{applied:?}");
+    }
 }

--- a/rust/tcl-lsp-core/src/refactor/mod.rs
+++ b/rust/tcl-lsp-core/src/refactor/mod.rs
@@ -339,7 +339,13 @@ struct BodyWord {
 ///   splitter every other migrated consumer uses (issue #1000).  Treating
 ///   the whole literal as one body instead reads `argList` as a command
 ///   name and swallows the real body, which is why no refactor code action
-///   fired inside an `apply` lambda.
+///   fired inside an `apply` lambda.  Only a `{braced}` body element is
+///   descended
+///   ([`LambdaLiteralElements::braced_body`](tcl_compiler::lambda_literal::LambdaLiteralElements::braced_body)):
+///   a bare / double-quoted one is backslash-decoded before `apply`
+///   evaluates it, so its source slice is not the script that runs and the
+///   spans a code action derived from it would edit the wrong bytes (Codex
+///   review on #1047).
 fn body_words(source: &str, cmd: &SegmentedCommand, registry: &CommandRegistry) -> Vec<BodyWord> {
     let name = cmd.name();
     if name.is_empty() {
@@ -373,7 +379,7 @@ fn body_words(source: &str, cmd: &SegmentedCommand, registry: &CommandRegistry) 
             continue;
         }
         let Some(body) = tcl_compiler::lambda_literal::split_lambda_literal(source, tok)
-            .and_then(|elems| elems.body)
+            .and_then(|elems| elems.braced_body())
         else {
             continue;
         };

--- a/rust/tcl-lsp-core/src/refactor/mod.rs
+++ b/rust/tcl-lsp-core/src/refactor/mod.rs
@@ -256,7 +256,9 @@ fn walk_commands_inner(
     for cmd in segment_commands_with_offset(slice, offset) {
         let pos = line_index.position_at_utf16(cmd.span.start(), full);
         out.push((cmd.texts.clone(), pos.line, pos.character.get()));
-        for body in body_words(&cmd, registry) {
+        // Spans here are absolute into `full` (the segmenter was given
+        // `offset`), so the lambda splitter reads from `full` too.
+        for body in body_words(full, &cmd, registry) {
             let Some(body_slice) = full.get(body.inner_start as usize..body.inner_end as usize)
             else {
                 continue;
@@ -297,7 +299,7 @@ fn find_command_at_inner(
             continue;
         }
         // Recurse into body arguments first — the innermost match wins.
-        for body in body_words(&cmd, registry) {
+        for body in body_words(source, &cmd, registry) {
             if let Some(inner) = find_command_at_inner(
                 &source[body.inner_start as usize..body.inner_end as usize],
                 cursor.saturating_sub(body.inner_start),
@@ -323,10 +325,22 @@ struct BodyWord {
     inner_end: u32,
 }
 
-/// Yield the registry-resolved `ArgRole::Body` words of `cmd` whose
-/// value is a non-empty braced (`STR`) word, with the interior byte
-/// range (one past the opening `{` to the closing `}`).
-fn body_words(cmd: &SegmentedCommand, registry: &CommandRegistry) -> Vec<BodyWord> {
+/// Yield the script-bearing words of `cmd` that [`find_command_at_inner`]
+/// may descend into, as interior byte ranges (delimiters excluded) in the
+/// outer source buffer.
+///
+/// Two registry roles qualify, both resolved from the spec — never from a
+/// command name:
+///
+/// * [`ArgRole::Body`] — a plain braced script; the whole interior is code.
+/// * [`ArgRole::LambdaLiteral`] — `apply`'s `{argList body ?ns?}` two- or
+///   three-element list, where only element 1 is code.  It is split with
+///   [`tcl_compiler::lambda_literal::split_lambda_literal`], the same
+///   splitter every other migrated consumer uses (issue #1000).  Treating
+///   the whole literal as one body instead reads `argList` as a command
+///   name and swallows the real body, which is why no refactor code action
+///   fired inside an `apply` lambda.
+fn body_words(source: &str, cmd: &SegmentedCommand, registry: &CommandRegistry) -> Vec<BodyWord> {
     let name = cmd.name();
     if name.is_empty() {
         return Vec::new();
@@ -347,15 +361,36 @@ fn body_words(cmd: &SegmentedCommand, registry: &CommandRegistry) -> Vec<BodyWor
         // is one byte past the `{` up to the span end.
         let inner_start = tok.span.start() + u32::from(tok.content_offset);
         let inner_end = tok.span.end();
-        if inner_end <= inner_start {
-            continue; // empty body — nothing to descend
+        push_body_word(&mut out, inner_start, inner_end);
+    }
+    for idx in registry.arg_indices_for_role(name, &args, ArgRole::LambdaLiteral) {
+        let Some(&tok) = cmd.argv.get(idx + 1) else {
+            continue;
+        };
+        // A `$var` / `[cmd]`-computed lambda can't be split statically —
+        // the guard every `LambdaLiteral` consumer applies.
+        if tok.kind != TokenType::Str {
+            continue;
         }
+        let Some(body) = tcl_compiler::lambda_literal::split_lambda_literal(source, tok)
+            .and_then(|elems| elems.body)
+        else {
+            continue;
+        };
+        push_body_word(&mut out, body.start(), body.end());
+    }
+    out
+}
+
+/// Record a descendable interior range, skipping an empty one (nothing to
+/// descend into).
+fn push_body_word(out: &mut Vec<BodyWord>, inner_start: u32, inner_end: u32) {
+    if inner_end > inner_start {
         out.push(BodyWord {
             inner_start,
             inner_end,
         });
     }
-    out
 }
 
 /// Parse a `switch` command's flags + subject + pattern/body pairs.
@@ -498,6 +533,46 @@ mod tests {
         // The returned span is in the outer buffer's offsets.
         let (s, _e) = command_span_offsets(src, &cmd);
         assert!(src[s as usize..].starts_with("if {$m"));
+    }
+
+    /// Parity with [`find_command_descends_into_proc_body`] for `apply`'s
+    /// lambda literal (issue #1000).  `apply`'s first argument is
+    /// `ArgRole::LambdaLiteral`, not `Body`: the whole `{argList body}`
+    /// blob is not a script, so descending into it verbatim reads
+    /// `argList` as a command name and swallows the real body.  Splitting
+    /// it reaches the body element, and the `if` inside is found exactly
+    /// as it is inside a `proc`.  tclsh8.6/9.0-verified that this lambda
+    /// really does run that `if` (`get` / `post` / `other`).
+    #[test]
+    fn find_command_descends_into_apply_lambda_body() {
+        let reg = test_registry();
+        let src = "proc handler {} {\n    apply {{m} {\n        if {$m eq \"GET\"} {\n            puts get\n        } elseif {$m eq \"POST\"} {\n            puts post\n        } else {\n            puts other\n        }\n    }} $x\n}\n";
+        // Cursor on the `if` inside the lambda body.
+        let cursor = u32::try_from(src.find("if {$m").unwrap()).unwrap() + 1;
+        let cmd = find_command_at(src, cursor, Some("if"), &reg).expect("if inside apply lambda");
+        assert_eq!(cmd.name(), "if");
+        // The returned span is in the outer buffer's offsets.
+        let (start, _end) = command_span_offsets(src, &cmd);
+        assert!(
+            src[start as usize..].starts_with("if {$m"),
+            "span must relocate back into the outer buffer: {:?}",
+            &src[start as usize..]
+        );
+    }
+
+    /// TN: the lambda's *argument-list* element is a plain word list, not
+    /// code.  A cursor on it must not produce a command match — descending
+    /// into it is exactly the mis-read the split avoids.
+    #[test]
+    fn find_command_does_not_match_inside_the_lambda_arg_list() {
+        let reg = test_registry();
+        let src = "apply {{if} {\n    puts $if\n}} 1\n";
+        // Cursor on the `if` *parameter name* in the argument list.
+        let cursor = u32::try_from(src.find("{if}").unwrap()).unwrap() + 1;
+        assert!(
+            find_command_at(src, cursor, Some("if"), &reg).is_none(),
+            "a parameter word named `if` is not an `if` command"
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -110,6 +110,16 @@
 //! ([`tcl_registry::CommandRegistry::plain_body_arg_indices`],
 //! [`tcl_registry::CaseListSpec`]); no command name is hardcoded in the
 //! walkers themselves (issue #957's general form).
+//!
+//! The `$obj`-dispatch scan goes one step further for its *command*-receiver
+//! half — a class command (`Factory make`) or an object command bound by
+//! `CLASS create NAME` (`rex bark`).  Those are ordinary commands, resolvable
+//! from any frame, so that half also descends the **frame-shifting** regions
+//! ([`frame_shifted_dispatch_regions`]): `Structural`-`BodyKind` bodies
+//! (`namespace eval`, `uplevel`, `oo::define`, …) and `apply` lambda bodies.
+//! The `$var`-receiver half stops at those boundaries, because a `$f` inside
+//! a `namespace eval` body names that namespace's own `f` and inside an
+//! `apply` lambda a fresh local (tclsh 9.0.4-verified).
 
 use rustc_hash::{FxHashMap, FxHashSet};
 use tcl_compiler::analyser::AnalysisResult;
@@ -1764,6 +1774,7 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
         var_set: &var_set,
         cmd_set: &cmd_set,
         method,
+        var_receivers_in_scope: true,
     };
 
     // Region 1: the whole document.
@@ -1813,6 +1824,28 @@ struct ObjMethodScan<'a> {
     var_set: &'a FxHashSet<&'a str>,
     cmd_set: &'a FxHashSet<&'a str>,
     method: &'a str,
+    /// `false` once the scan has descended through a frame-shifting region
+    /// ([`frame_shifted_dispatch_regions`]), where a `$var` receiver's bare
+    /// name no longer names the enclosing frame's variable — so `var_set`
+    /// stops matching while `cmd_set` (an ordinary command, resolvable from
+    /// any frame) keeps going.
+    var_receivers_in_scope: bool,
+}
+
+impl ObjMethodScan<'_> {
+    /// This context as it applies inside a frame-shifting region.
+    fn frame_shifted(self) -> Self {
+        Self {
+            var_receivers_in_scope: false,
+            ..self
+        }
+    }
+
+    /// Whether this context can still match anything — a frame-shifted scan
+    /// with no command receivers to look for has nothing left to do.
+    fn has_receivers(&self) -> bool {
+        !self.cmd_set.is_empty() || (self.var_receivers_in_scope && !self.var_set.is_empty())
+    }
 }
 
 /// Mutable sink for matched call-site spans plus the dedup set, threaded
@@ -1877,7 +1910,8 @@ fn scan_obj_method_region(
             if h_start < source.len() && h_end <= source.len() {
                 let raw = &source[h_start..h_end];
                 let receiver_matches = if head.kind == TokenType::Var {
-                    strip_var_decoration(raw).is_some_and(|name| ctx.var_set.contains(name))
+                    ctx.var_receivers_in_scope
+                        && strip_var_decoration(raw).is_some_and(|name| ctx.var_set.contains(name))
                 } else {
                     // A bare-word object command (`rex bark`).  `cmd_set` holds
                     // only plain names, and a braced / bracketed / substituted
@@ -1902,6 +1936,13 @@ fn scan_obj_method_region(
         }
         for (inner_start, inner_end) in nested_dispatch_regions(source, ctx.dialect, cmd) {
             scan_obj_method_region(ctx, inner_start, inner_end, depth + 1, sink);
+        }
+        let shifted = ctx.frame_shifted();
+        if shifted.has_receivers() {
+            for (inner_start, inner_end) in frame_shifted_dispatch_regions(source, ctx.dialect, cmd)
+            {
+                scan_obj_method_region(shifted, inner_start, inner_end, depth + 1, sink);
+            }
         }
     }
 }
@@ -1991,6 +2032,87 @@ fn nested_dispatch_regions(
             if start < end {
                 regions.push((start, end));
             }
+        }
+    }
+    regions
+}
+
+/// Every nested script region reachable from one segmented command whose body
+/// runs in a **different frame** from the enclosing one, as `(start, end)`
+/// byte offsets into `source`:
+///
+/// * an argument the registry marks [`tcl_registry::ArgRole::Body`] with a
+///   `Structural` [`tcl_registry::BodyKind`] — `namespace eval`, `uplevel`,
+///   `oo::define`, `interp eval`, `proc`, … (the complement of
+///   [`nested_dispatch_regions`]'s `Plain` set); and
+/// * the body element of an [`tcl_registry::ArgRole::LambdaLiteral`]
+///   argument — `apply`'s `{argList body ?ns?}` — split by the shared
+///   [`tcl_compiler::lambda_literal`] splitter, and only when that element is
+///   `{braced}` (a bare / quoted one is backslash-decoded before `apply`
+///   evaluates it, so its source slice is not the script that runs).
+///
+/// These carry the *command*-receiver half of the `$obj method` scan only.
+/// A class command (`Factory make`) or a `CLASS create NAME` object command
+/// (`rex bark`) is an ordinary command and resolves the same from a
+/// `namespace eval` body, an `apply` lambda, or the top level, so a dispatch
+/// written in one of them is a real reference to the method — Find All
+/// References, rename, the code lens, and the call hierarchy all missed those
+/// sites before (adversarial review of #1047, item 2; all three shapes
+/// verified dispatching under tclsh 9.0.4).  A `$var` receiver does not
+/// survive the boundary — `$f` inside `namespace eval ::zz` names `::zz::f`,
+/// and inside an `apply` lambda a fresh local — so the caller drops
+/// `var_set` for the descended subtree
+/// ([`ObjMethodScan::frame_shifted`]).
+///
+/// Registry-driven throughout: which arguments are bodies, and whether they
+/// are same-frame, comes from the command's spec, never from its name.
+fn frame_shifted_dispatch_regions(
+    source: &str,
+    dialect: &str,
+    cmd: &tcl_compiler::segmenter::SegmentedCommand,
+) -> Vec<(usize, usize)> {
+    use tcl_lexer::TokenType;
+    let mut regions: Vec<(usize, usize)> = Vec::new();
+    let Some(cmd_name) = cmd.texts.first() else {
+        return regions;
+    };
+    let registry = tcl_registry::registry_for_dialect(dialect);
+    let args: Vec<&str> = cmd.texts.iter().skip(1).map(String::as_str).collect();
+    // `plain_body_arg_indices` is `arg_indices_for_role(Body)` gated on the
+    // call's resolved `BodyKind`, so an empty plain list against a non-empty
+    // body list means every body argument of *this* call is `Structural`.
+    if registry.plain_body_arg_indices(cmd_name, &args).is_empty() {
+        for idx in registry.arg_indices_for_role(cmd_name, &args, tcl_registry::ArgRole::Body) {
+            let Some(tok) = cmd.argv.get(idx + 1) else {
+                continue;
+            };
+            // Only a braced literal body is script at these exact offsets;
+            // a `$var` / `[cmd]` body is assembled at runtime.
+            if tok.kind != TokenType::Str {
+                continue;
+            }
+            let (start, end) = strip_outer_braces(source, tok.span);
+            if start < end {
+                regions.push((start, end));
+            }
+        }
+    }
+    for idx in registry.arg_indices_for_role(cmd_name, &args, tcl_registry::ArgRole::LambdaLiteral)
+    {
+        let Some(&tok) = cmd.argv.get(idx + 1) else {
+            continue;
+        };
+        if tok.kind != TokenType::Str {
+            continue;
+        }
+        let Some(body) = tcl_compiler::lambda_literal::split_lambda_literal(source, tok)
+            .and_then(|elems| elems.braced_body())
+        else {
+            continue;
+        };
+        let (start, end) = (body.start() as usize, body.end() as usize);
+        if start < end && end <= source.len() {
+            regions.push((start, end));
         }
     }
     regions
@@ -3356,6 +3478,68 @@ mod tests {
                 "{sites:?}"
             );
         }
+    }
+
+    /// TP (adversarial review of #1047, item 2): a bare class-command
+    /// dispatch written inside an `apply` lambda body or a `namespace eval`
+    /// body — at the top level or nested inside a method — is a real call.
+    /// All three shapes were confirmed dispatching under tclsh 9.0.4
+    /// (`MAKE CALLED` printed three times).
+    #[test]
+    fn find_obj_method_call_sites_reaches_lambda_and_namespace_eval_bodies() {
+        let src = "oo::class create Factory {\n\
+                       classmethod make {} { return 1 }\n\
+                       method inst {} { apply {{} { Factory make }} }\n\
+                       method nsev {} { namespace eval ::zz { Factory make } }\n\
+                   }\n\
+                   namespace eval ::top2 { Factory make }\n";
+        let analysis = analyse(src);
+        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Factory", "make", true);
+        assert_eq!(sites.len(), 3, "{sites:?}");
+        for s in &sites {
+            assert_eq!(
+                &src[s.start() as usize..s.end() as usize],
+                "make",
+                "{sites:?}"
+            );
+        }
+    }
+
+    /// TN — the instance half must **not** follow the class-command half
+    /// through a frame shift.  `$f` inside `namespace eval ::zz` names
+    /// `::zz::f`, and inside an `apply` lambda a fresh local, so neither is
+    /// a dispatch on the outer `f` (tclsh 9.0.4: both raise `can't read
+    /// "f": no such variable`).
+    #[test]
+    fn find_obj_method_call_sites_excludes_var_receivers_across_a_frame_shift() {
+        let src = "oo::class create Dog {\n\
+                       method bark {} {}\n\
+                   }\n\
+                   set f [Dog new]\n\
+                   namespace eval ::zz { $f bark }\n\
+                   apply {{} { $f bark }}\n\
+                   $f bark\n";
+        let analysis = analyse(src);
+        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Dog", "bark", false);
+        assert_eq!(sites.len(), 1, "{sites:?}");
+        let s = sites[0];
+        let line = src[..s.start() as usize].lines().count();
+        assert_eq!(line, 7, "only the same-frame `$f bark` matches: {sites:?}");
+    }
+
+    /// TN — a bare (backslash-escaped) `apply` body element is decoded
+    /// before `apply` evaluates it, so its source slice is not the script
+    /// that runs; the scan must not re-parse it in place (Codex review on
+    /// #1047).
+    #[test]
+    fn find_obj_method_call_sites_skips_escaped_lambda_body_element() {
+        let src = "oo::class create Factory {\n\
+                       classmethod make {} { return 1 }\n\
+                   }\n\
+                   apply {{} Factory\\ make}\n";
+        let analysis = analyse(src);
+        let sites = find_obj_method_call_sites(src, "tcl", &analysis, "::Factory", "make", true);
+        assert!(sites.is_empty(), "{sites:?}");
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -539,19 +539,38 @@ pub fn method_target_with_access(
     if let Some(class_def) = crate::definition::enclosing_class_at(analysis, cursor)
         .and_then(|q| analysis.all_classes.get(q))
     {
-        let has_method = class_def.methods.contains_key(&word);
-        let has_classmethod = class_def.class_methods.contains_key(&word);
-        if has_method || has_classmethod {
+        let method_decl = class_def.methods.get(&word);
+        let classmethod_decl = class_def.class_methods.get(&word);
+        // A member-name-shaped word anywhere inside the class body is not by
+        // itself a reference to that member.  It only is when the cursor sits
+        // on the member's **own declaration name**, or on a bareword that
+        // `link` genuinely made bareword-callable and pointed back at this
+        // same member (`ClassDef::linked_members`, issue #923 idx 113 — an
+        // un-linked bareword errors "invalid command name" in real Tcl, so it
+        // names nothing).  This is the gate the in-document provider's
+        // `definition::lookup_class_member` already applies; without it here,
+        // any same-spelled word — a parameter, a literal, an un-linked
+        // sibling call — was read as the member and handed to the workspace
+        // resolver, which then answered non-deterministically (issue #1028).
+        let on_declaration = |m: &tcl_compiler::analyser::MethodDef| {
+            m.name_span.start() <= cursor && cursor < m.name_span.end()
+        };
+        let cursor_on_method_decl = method_decl.is_some_and(on_declaration);
+        let cursor_on_classmethod_decl = classmethod_decl.is_some_and(on_declaration);
+        let linked_to_self = class_def
+            .linked_members
+            .get(&word)
+            .is_some_and(|target| *target == word);
+        if (method_decl.is_some() || classmethod_decl.is_some())
+            && (cursor_on_method_decl || cursor_on_classmethod_decl || linked_to_self)
+        {
             // A `method` and a `classmethod` of the same name are distinct
             // members; unambiguous when only one exists, otherwise prefer
-            // whichever one's declaration the cursor is actually on (falls
-            // back to the method when the cursor is elsewhere in the body,
-            // e.g. a `my word` call site — the pre-existing preference).
-            let is_classmethod = has_classmethod
-                && (!has_method
-                    || class_def.class_methods.get(&word).is_some_and(|m| {
-                        m.name_span.start() <= cursor && cursor < m.name_span.end()
-                    }));
+            // whichever one's declaration the cursor is actually on (a linked
+            // bareword that could be either falls back to the method — the
+            // pre-existing preference).
+            let is_classmethod =
+                classmethod_decl.is_some() && (method_decl.is_none() || cursor_on_classmethod_decl);
             return Some((
                 class_def.qualified_name.clone(),
                 word,
@@ -2318,6 +2337,78 @@ mod tests {
              the unrelated instance method and must be untouched: {edits:?}"
         );
         assert_eq!(edits[0].range.start_line, 2, "{edits:?}");
+    }
+
+    // `method_target_with_access`'s class-body fallback — the idx-113 link
+    // gate (issue #1028).
+
+    /// TP: the cursor on a method's own declaration name is the member.
+    #[test]
+    fn method_target_fires_on_the_members_own_declaration_name() {
+        let src = "oo::class create Widget {\n    method foo {x} { return $x }\n    method bar {} { return [foo 42] }\n}\n";
+        let analysis = analyse(src);
+        let target = method_target_with_access(src, 1, 11, &analysis);
+        assert_eq!(
+            target,
+            Some((
+                "::Widget".to_owned(),
+                "foo".to_owned(),
+                false,
+                crate::workspace_index::MethodAccess::Internal
+            )),
+            "cursor on the `foo` declaration must resolve to Widget's `foo`"
+        );
+    }
+
+    /// TP: a bareword sibling call that `link` genuinely made callable is a
+    /// reference to the member — tclsh9.0-verified (`link foo` in the
+    /// constructor makes `[foo 42]` inside another method dispatch to
+    /// `Widget`'s `foo`; `link` does not exist in 8.6's `TclOO`).
+    #[test]
+    fn method_target_fires_on_a_linked_bareword_call() {
+        let src = "oo::class create Widget {\n    constructor {} { link foo }\n    method foo {x} { return $x }\n    method bar {} { return [foo 42] }\n}\n";
+        let analysis = Analyser::new().analyse(src, "tcl9.0").clone();
+        let target = method_target_with_access(src, 3, 28, &analysis);
+        assert_eq!(
+            target,
+            Some((
+                "::Widget".to_owned(),
+                "foo".to_owned(),
+                false,
+                crate::workspace_index::MethodAccess::Internal
+            )),
+            "a linked bareword sibling call must resolve to the member"
+        );
+    }
+
+    /// FP guard (issue #1028): an **un-linked** bareword sibling call names
+    /// nothing — real Tcl raises `invalid command name "foo"` there
+    /// (tclsh9.0-verified) — so the resolver must abstain rather than hand
+    /// the word to the workspace resolver, which used to answer it
+    /// non-deterministically.
+    #[test]
+    fn method_target_abstains_on_an_unlinked_bareword_sibling_call() {
+        let src = "oo::class create Widget {\n    method foo {x} { return $x }\n    method bar {} { return [foo 42] }\n}\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            method_target_with_access(src, 2, 28, &analysis),
+            None,
+            "an un-linked bareword sibling call is not a reference to the method"
+        );
+    }
+
+    /// FP guard: a *parameter* that happens to share a sibling method's name
+    /// is not that method either — the old fallback fired on any
+    /// member-name-shaped word anywhere in the class body span.
+    #[test]
+    fn method_target_abstains_on_a_parameter_sharing_a_method_name() {
+        let src = "oo::class create Widget {\n    method foo {x} { return $x }\n    method bar {foo} { return $foo }\n}\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            method_target_with_access(src, 2, 16, &analysis),
+            None,
+            "a parameter word must not resolve to the same-named method"
+        );
     }
 
     // property rename

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -339,6 +339,30 @@ pub struct WorkspaceNamespaceExport {
     pub pattern: String,
 }
 
+/// Collect `items` into source order by the span `key` reports, so a
+/// `HashMap`-valued analyser table lands in the index deterministically
+/// instead of in the process's random hash order (issue #1028).
+fn sorted_by_span<'a, T, I, F>(items: I, key: F) -> Vec<&'a T>
+where
+    I: IntoIterator<Item = &'a T>,
+    F: Fn(&T) -> Span,
+{
+    let mut out: Vec<&T> = items.into_iter().collect();
+    out.sort_by_key(|item| {
+        let span = key(item);
+        (span.start(), span.end())
+    });
+    out
+}
+
+/// The names of a `HashSet`-valued analyser table, in a stable order.  See
+/// [`sorted_by_span`] for why the source order matters.
+fn sorted_names(names: &std::collections::HashSet<String>) -> Vec<String> {
+    let mut out: Vec<String> = names.iter().cloned().collect();
+    out.sort();
+    out
+}
+
 /// Cross-document aggregate of proc / class definitions,
 /// command-invocation sites, `source` references, command
 /// name-links, and `package require` declarations.
@@ -380,7 +404,14 @@ impl WorkspaceIndex {
     /// Call [`Self::remove_document`] first when re-indexing a
     /// changed document to avoid stale duplicates.
     pub fn add_document(&mut self, uri: &str, analysis: &AnalysisResult) {
-        for proc_def in analysis.all_procs.values() {
+        // `all_procs` / `all_classes` / a class's `methods` are `HashMap`s, so
+        // iterating them directly would order this document's index entries by
+        // the process's random hash seed — and consumers that answer with the
+        // *first* matching record (go-to-definition's dispatch entry, most
+        // visibly) then answer differently run to run (issue #1028).  Source
+        // order is the stable, meaningful order: it is also the order the
+        // records take effect in when the file is sourced.
+        for proc_def in sorted_by_span(analysis.all_procs.values(), |p| p.name_span) {
             self.procs.push(WorkspaceProc {
                 uri: uri.to_owned(),
                 name: proc_def.name.clone(),
@@ -390,23 +421,27 @@ impl WorkspaceIndex {
                 nested: analysis.offset_is_inside_any_definition_body(proc_def.name_span.start()),
             });
         }
-        for class_def in analysis.all_classes.values() {
-            let methods: Vec<WorkspaceMethod> = class_def
-                .methods
-                .values()
-                .map(|m| WorkspaceMethod {
-                    name: m.name.clone(),
-                    kind: m.kind.clone(),
-                    exported: m.visibility == "public",
-                    private: m.visibility == "private",
-                })
-                .chain(class_def.class_methods.values().map(|m| WorkspaceMethod {
-                    name: m.name.clone(),
-                    kind: "classmethod".to_string(),
-                    exported: m.visibility == "public",
-                    private: m.visibility == "private",
-                }))
-                .collect();
+        for class_def in sorted_by_span(analysis.all_classes.values(), |c| c.name_span) {
+            let methods: Vec<WorkspaceMethod> =
+                sorted_by_span(class_def.methods.values(), |m| m.name_span)
+                    .into_iter()
+                    .map(|m| WorkspaceMethod {
+                        name: m.name.clone(),
+                        kind: m.kind.clone(),
+                        exported: m.visibility == "public",
+                        private: m.visibility == "private",
+                    })
+                    .chain(
+                        sorted_by_span(class_def.class_methods.values(), |m| m.name_span)
+                            .into_iter()
+                            .map(|m| WorkspaceMethod {
+                                name: m.name.clone(),
+                                kind: "classmethod".to_string(),
+                                exported: m.visibility == "public",
+                                private: m.visibility == "private",
+                            }),
+                    )
+                    .collect();
             self.classes.push(WorkspaceClass {
                 uri: uri.to_owned(),
                 name: class_def.name.clone(),
@@ -415,8 +450,8 @@ impl WorkspaceIndex {
                 superclasses: class_def.superclasses.clone(),
                 mixins: class_def.mixins.clone(),
                 methods,
-                exports: class_def.exports.iter().cloned().collect(),
-                unexports: class_def.unexports.iter().cloned().collect(),
+                exports: sorted_names(&class_def.exports),
+                unexports: sorted_names(&class_def.unexports),
                 via_define: class_def.via_define,
                 metaclass: class_def.metaclass.clone(),
             });
@@ -865,11 +900,18 @@ impl WorkspaceIndex {
     ) -> Vec<&'a WorkspaceClass> {
         let mut out: Vec<&WorkspaceClass> = Vec::new();
         for class_q in self.class_linearisation(receiver_class) {
-            let records: Vec<&WorkspaceClass> = self
+            // Several records of one class (its creation site plus every
+            // `oo::define` stub, possibly spread over files) are all kept, and
+            // the *first* is what go-to-definition answers with — so the order
+            // has to be a property of the workspace, not of when each document
+            // happened to be indexed.  Document URI then source position is
+            // that stable order (issue #1028).
+            let mut records: Vec<&WorkspaceClass> = self
                 .classes
                 .iter()
                 .filter(|c| c.qualified_name == class_q)
                 .collect();
+            records.sort_by_key(|c| (c.uri.as_str(), c.name_span.start(), c.name_span.end()));
             // The class-level effective export union: any record exporting
             // the name keeps it callable; explicit unexports matter only
             // when no record exports it.

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -151,6 +151,16 @@ impl WorkspaceClass {
             .iter()
             .find(|m| m.name == name && m.kind != "classmethod")
     }
+
+    /// The typed record for the *class-receiver* member `name` — a
+    /// `classmethod` / `self method` / snit `typemethod` — if this record
+    /// defines one.  The counterpart of [`Self::instance_method`].
+    #[must_use]
+    pub fn class_method(&self, name: &str) -> Option<&WorkspaceMethod> {
+        self.methods
+            .iter()
+            .find(|m| m.name == name && m.kind == "classmethod")
+    }
 }
 
 /// One method a class record directly defines, as indexed for cross-file
@@ -170,6 +180,18 @@ pub struct WorkspaceMethod {
     /// dispatch *and* to subclasses; callable only via `my` within the
     /// declaring class's own methods.
     pub private: bool,
+    /// `true` for a stock-`TclOO` `self method` (as opposed to `ooutil`'s
+    /// `classmethod` keyword).  Both land in the class-receiver bucket
+    /// (`kind == "classmethod"`), but a `self method` is visible **only**
+    /// on the exact class object that declared it: `Gadget make` on a
+    /// subclass of a class declaring `self method make` errors `unknown
+    /// method "make"` under tclsh 8.6 and 9.0.4, whereas `classmethod`
+    /// propagates to the subclass's own bound command through its
+    /// `Delegate`-mixin machinery.  The single-document scan reads
+    /// [`tcl_compiler::analyser::MethodDef::is_self_method`] for this;
+    /// carrying it here is what lets a *cross-file* consumer scan tell the
+    /// two apart (Codex review on #1047).
+    pub is_self_method: bool,
 }
 
 /// The access context of a method call site — `TclOO` dispatches an
@@ -430,6 +452,7 @@ impl WorkspaceIndex {
                         kind: m.kind.clone(),
                         exported: m.visibility == "public",
                         private: m.visibility == "private",
+                        is_self_method: m.is_self_method,
                     })
                     .chain(
                         sorted_by_span(class_def.class_methods.values(), |m| m.name_span)
@@ -439,6 +462,7 @@ impl WorkspaceIndex {
                                 kind: "classmethod".to_string(),
                                 exported: m.visibility == "public",
                                 private: m.visibility == "private",
+                                is_self_method: m.is_self_method,
                             }),
                     )
                     .collect();

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4600,29 +4600,51 @@ impl Backend {
 
     /// Resolve the call-site reference [`Location`]s for the symbol whose name
     /// starts at `position` — the locations the code-lens peek
-    /// (`tcl-lsp.showReferences`) opens.  Mirrors the [`Self::references`]
-    /// handler (local hits + cross-document call sites, deduped) but never
-    /// includes the declaration, matching the lens's "N references" call-site
-    /// count.
+    /// (`tcl-lsp.showReferences`) opens.  The declaration is never included,
+    /// matching the lens's "N references" call-site count; everything else is
+    /// literally [`Self::reference_locations`], the same path the
+    /// `textDocument/references` handler runs (issue #991 — the lens used to
+    /// skip the method/classmethod cross-file layer the handler applied, so a
+    /// lens click showed fewer sites than Find All References on the very
+    /// same declaration).
     async fn reference_locations_at(
         &self,
         uri: &Uri,
-        text: &str,
-        dialect: &str,
+        doc: &DocumentState,
         analysis: &AnalysisResult,
         position: Position,
     ) -> Vec<Location> {
-        let owned_text = text.to_owned();
-        let owned_dialect = dialect.to_owned();
+        self.reference_locations(uri, doc, analysis, position, false)
+            .await
+    }
+
+    /// Every reference [`Location`] for the symbol at `position`: the
+    /// single-document hits, the cross-document call sites (declarations too
+    /// when `include_declaration`), and the `TclOO` method / classmethod
+    /// cross-file layer — override family, inheritors, and pure consumers.
+    ///
+    /// The **one** path behind both `textDocument/references` and the code
+    /// lens's click target.  They must not re-derive it separately: the lens
+    /// listing fewer sites than the peek on the same symbol is issue #991.
+    async fn reference_locations(
+        &self,
+        uri: &Uri,
+        doc: &DocumentState,
+        analysis: &AnalysisResult,
+        position: Position,
+        include_declaration: bool,
+    ) -> Vec<Location> {
+        let text = doc.text.clone();
+        let dialect = doc.dialect.clone();
         let analysis_for_worker = analysis.clone();
         let ranges = tokio::task::spawn_blocking(move || {
             core_references::references(
-                &owned_text,
-                &owned_dialect,
+                &text,
+                &dialect,
                 position.line,
                 position.character,
                 &analysis_for_worker,
-                false,
+                include_declaration,
             )
         })
         .await
@@ -4631,21 +4653,43 @@ impl Backend {
         // declaration to anchor the single-document pass on, so an empty
         // `ranges` here does not mean "genuinely zero" — see
         // `workspace_resolved_references`'s own doc.
+        let local_found_nothing = ranges.is_empty();
         let mut locations: Vec<Location> = ranges
-            .iter()
+            .into_iter()
             .map(|r| Location {
                 uri: uri.clone(),
-                range: lift_lsp_range(*r),
+                range: lift_lsp_range(r),
             })
             .collect();
-        let cross = if ranges.is_empty() {
-            self.workspace_resolved_references(uri, text, analysis, position, false)
-                .await
+        let cross = if local_found_nothing {
+            self.workspace_resolved_references(
+                uri,
+                &doc.text,
+                analysis,
+                position,
+                include_declaration,
+            )
+            .await
         } else {
-            self.cross_document_references(uri, text, analysis, position, false)
+            self.cross_document_references(uri, &doc.text, analysis, position, include_declaration)
                 .await
         };
         locations.extend(cross);
+        // Cross-document `TclOO` method sites: when the cursor names a method
+        // (its declaration inside a class body, or an `$obj method` / `my
+        // method` call), gather the method's sites across its override family
+        // in sibling documents, plus pure-consumer documents the family pass
+        // can't see — the single-document provider above only sees this file.
+        locations.extend(
+            self.cross_file_method_and_consumer_references(
+                uri,
+                doc,
+                analysis,
+                position,
+                include_declaration,
+            )
+            .await,
+        );
         dedup_locations(&mut locations);
         locations
     }
@@ -8992,69 +9036,9 @@ impl LanguageServer for Backend {
         let analysis = self
             .analysis_for(&uri, doc.text.clone(), doc.dialect.clone())
             .await;
-        let text = doc.text.clone();
-        let dialect = doc.dialect.clone();
-        let analysis_for_worker = analysis.clone();
-        let ranges = tokio::task::spawn_blocking(move || {
-            core_references::references(
-                &text,
-                &dialect,
-                pos.line,
-                pos.character,
-                &analysis_for_worker,
-                include_decl,
-            )
-        })
-        .await
-        .map_err(|err| jsonrpc::Error {
-            code: jsonrpc::ErrorCode::InternalError,
-            message: format!("references worker panicked: {err}").into(),
-            data: None,
-        })?;
-        // Current-document hits. Empty here does not necessarily mean
-        // genuinely zero: a pure-consumer document (issue #923 idx 71 —
-        // the cursor's proc/class has no local declaration, only a
-        // `source`d-in or workspace-sibling one) leaves the single-document
-        // pass with nothing to anchor on even though this very document's
-        // own call sites (including the one under the cursor) are real
-        // references — see `workspace_resolved_references`'s own doc.
-        let local_found_nothing = ranges.is_empty();
-        let mut locations: Vec<Location> = ranges
-            .into_iter()
-            .map(|r| Location {
-                uri: uri.clone(),
-                range: lift_lsp_range(r),
-            })
-            .collect();
-        // Cross-document call sites (and, when requested,
-        // sibling-document definition sites). A pure-consumer document
-        // (issue #923 idx 71) resolves through the workspace oracle without
-        // excluding the current document, so its own call sites aren't
-        // silently dropped alongside it.
-        let cross = if local_found_nothing {
-            self.workspace_resolved_references(&uri, &doc.text, &analysis, pos, include_decl)
-                .await
-        } else {
-            self.cross_document_references(&uri, &doc.text, &analysis, pos, include_decl)
-                .await
-        };
-        locations.extend(cross);
-        // Cross-document TclOO method sites: when the cursor names a method
-        // (its declaration inside a class body, or an `$obj method` / `my
-        // method` call), gather the method's sites across its override family in
-        // sibling documents, plus pure-consumer documents the family pass can't
-        // see — the single-document provider above only sees this file.
-        locations.extend(
-            self.cross_file_method_and_consumer_references(
-                &uri,
-                &doc,
-                &analysis,
-                pos,
-                include_decl,
-            )
-            .await,
-        );
-        dedup_locations(&mut locations);
+        let locations = self
+            .reference_locations(&uri, &doc, &analysis, pos, include_decl)
+            .await;
         if locations.is_empty() {
             return Ok(None);
         }
@@ -10137,7 +10121,7 @@ impl LanguageServer for Backend {
             data: None,
         })?;
         let mut lens = lens;
-        if let Some(matching) = lenses.into_iter().find(|l| l.qname == qname) {
+        if lenses.iter().any(|l| l.qname == qname) {
             // Resolve the actual reference locations so clicking the lens opens
             // a peek (the lens title alone is informational — a bare title with
             // no command is rendered but inert, the "reference is not active"
@@ -10146,7 +10130,7 @@ impl LanguageServer for Backend {
             // delegates to the built-in `editor.action.showReferences`.
             let position = lens.range.start;
             let locations = self
-                .reference_locations_at(&uri, &doc.text, &doc.dialect, &analysis, position)
+                .reference_locations_at(&uri, &doc, &analysis, position)
                 .await;
             let arguments = vec![
                 serde_json::Value::String(uri.to_string()),
@@ -10154,7 +10138,12 @@ impl LanguageServer for Backend {
                 serde_json::to_value(&locations).unwrap_or(serde_json::Value::Null),
             ];
             lens.command = Some(tower_lsp_server::ls_types::Command {
-                title: matching.command_title,
+                // The label counts exactly the sites the click opens — the
+                // core provider's own count is single-document for a class
+                // member (see `tcl_lsp_core::code_lens`'s module doc), so
+                // reusing it here would show a smaller number than the peek
+                // it hands the editor (issue #991).
+                title: core_code_lens::reference_count_title(locations.len()),
                 command: "tcl-lsp.showReferences".to_owned(),
                 arguments: Some(arguments),
             });

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2675,6 +2675,44 @@ struct RenameContext<'a> {
     registry: &'a CommandRegistry,
 }
 
+/// The workspace facts one pure-consumer method scan needs, resolved under a
+/// single index read by [`Backend::consumer_scan_plan`].
+struct ConsumerScan {
+    /// Qualified names of every class whose instances dispatch the method to
+    /// the family — the override-family definers plus the pure inheritors.
+    family: Vec<String>,
+    /// Candidate consumer documents: those invoking a family constructor.
+    consumer_uris: Vec<String>,
+    /// Class names valid as a bare classmethod-dispatch head; empty for an
+    /// instance method.  See [`Backend::classmethod_dispatch_names`].
+    classmethod_cmd_names: Vec<String>,
+}
+
+/// The family classes one document declares: the **definers** that (re)define
+/// the method and the pure **inheritors** that only inherit it.
+#[derive(Default)]
+struct FamilyClasses {
+    definers: Vec<String>,
+    inheritors: Vec<String>,
+}
+
+/// A method's override family grouped by declaring document, plus the class
+/// names valid as a bare classmethod-dispatch head.  See
+/// [`Backend::method_family_by_document`].
+struct MethodFamily {
+    by_uri: Vec<(String, FamilyClasses)>,
+    classmethod_cmd_names: Vec<String>,
+}
+
+/// One document a consumer scan visits, with the text and index needed to
+/// lift its spans to LSP ranges.
+struct ConsumerDoc {
+    uri: Uri,
+    text: String,
+    dialect: String,
+    line_index: tcl_lexer::LineIndex,
+}
+
 impl Backend {
     /// Build a fresh backend wrapping the given client.
     ///
@@ -4717,112 +4755,257 @@ impl Backend {
         method: &str,
         is_classmethod: bool,
     ) -> Vec<Location> {
-        // The family + inheritor classes whose instances dispatch `method` to
-        // the family, the workspace class oracle, and the candidate consumer
-        // documents — collected under one index read.
-        //
-        // `classmethod_cmd_names` carries the workspace-wide answer to "given
-        // `is_classmethod` is true, which class names bare-dispatch it" — a
-        // pure-consumer document (e.g. one that only calls `Factory make`)
-        // has no local `ClassDef` for `Factory`, so
-        // `core_references::obj_method_call_sites` cannot derive this itself
-        // the way the same-document path does.
-        let (family, consumer_uris, classmethod_cmd_names) = {
-            let index = self.workspace_index.read().await;
-            let definers = index.method_override_family(seed_class, method);
-            let inheritors = index.method_inheritor_classes(seed_class, method);
-            let classmethod_cmd_names = Self::classmethod_dispatch_names(
-                &definers,
-                &inheritors,
-                is_classmethod,
-                current_dialect,
-            );
-            let mut family: Vec<String> = definers
-                .iter()
-                .map(|wc| wc.qualified_name.clone())
-                .collect();
-            family.extend(inheritors.iter().map(|wc| wc.qualified_name.clone()));
-            if family.is_empty() {
-                return Vec::new();
-            }
-            let family_norm: std::collections::HashSet<&str> =
-                family.iter().map(|s| s.trim_start_matches("::")).collect();
-            let consumer_uris = index.documents_invoking_classes(&family_norm);
-            (family, consumer_uris, classmethod_cmd_names)
+        self.consumer_method_site_ranges(
+            current_uri,
+            current_source,
+            current_dialect,
+            seed_class,
+            method,
+            is_classmethod,
+        )
+        .await
+        .into_iter()
+        .flat_map(|(uri, ranges)| {
+            ranges.into_iter().map(move |range| Location {
+                uri: uri.clone(),
+                range,
+            })
+        })
+        .collect()
+    }
+
+    /// The pure-consumer `$obj method` / bare classmethod-dispatch sites of
+    /// `(seed_class, method)`, grouped per document as LSP ranges.
+    ///
+    /// The one resolver behind **both** the consumer leg of Find All
+    /// References ([`Self::cross_file_consumer_method_references`]) and the
+    /// consumer leg of rename ([`Self::cross_file_method_rename`]).  They
+    /// must agree site-for-site: a site references sees but rename misses is
+    /// a call left bound to a name that no longer exists (issue #993), so
+    /// the two never re-derive the set independently.
+    async fn consumer_method_site_ranges(
+        &self,
+        current_uri: &Uri,
+        current_source: &str,
+        current_dialect: &str,
+        seed_class: &str,
+        method: &str,
+        is_classmethod: bool,
+    ) -> Vec<(Uri, Vec<Range>)> {
+        let Some(plan) = self
+            .consumer_scan_plan(current_dialect, seed_class, method, is_classmethod)
+            .await
+        else {
+            return Vec::new();
         };
-        let mut out = Vec::new();
+        let mut out: Vec<(Uri, Vec<Range>)> = Vec::new();
         let mut scanned: std::collections::HashSet<String> = std::collections::HashSet::new();
-        for u in consumer_uris
-            .into_iter()
+        for u in plan
+            .consumer_uris
+            .iter()
+            .cloned()
             .chain(std::iter::once(current_uri.as_str().to_owned()))
         {
             if !scanned.insert(u.clone()) {
                 continue;
             }
-            let (parsed, source, dialect, line_index, text) = if u == current_uri.as_str() {
-                let li = tcl_lexer::LineIndex::new(current_source);
-                (
-                    current_uri.clone(),
-                    current_source.to_owned(),
-                    current_dialect.to_owned(),
-                    li,
-                    current_source.to_owned(),
-                )
+            let doc = if u == current_uri.as_str() {
+                ConsumerDoc {
+                    uri: current_uri.clone(),
+                    text: current_source.to_owned(),
+                    dialect: current_dialect.to_owned(),
+                    line_index: tcl_lexer::LineIndex::new(current_source),
+                }
             } else {
                 let Ok(parsed) = Uri::from_str(&u) else {
                     continue;
                 };
-                let Some(doc) = self.read_document(&parsed).await else {
+                let Some(state) = self.read_document(&parsed).await else {
                     continue;
                 };
-                (
-                    parsed,
-                    doc.text.clone(),
-                    doc.dialect.clone(),
-                    doc.line_index.clone(),
-                    doc.text.clone(),
-                )
-            };
-            let analysis = self.analyse_with_workspace_classes(&source, &dialect).await;
-            let family_cl = family.clone();
-            let method_owned = method.to_owned();
-            let classmethod_cmd_names_cl = classmethod_cmd_names.clone();
-            let spans: Vec<tcl_lexer::Span> = tokio::task::spawn_blocking(move || {
-                let mut all: Vec<tcl_lexer::Span> = Vec::new();
-                for cq in &family_cl {
-                    all.extend(core_references::obj_method_call_sites(
-                        &source,
-                        &dialect,
-                        &analysis,
-                        cq,
-                        &method_owned,
-                        is_classmethod,
-                        &classmethod_cmd_names_cl,
-                    ));
+                ConsumerDoc {
+                    uri: parsed,
+                    text: state.text.clone(),
+                    dialect: state.dialect.clone(),
+                    line_index: state.line_index.clone(),
                 }
-                all
-            })
-            .await
-            .unwrap_or_default();
-            for span in spans {
-                let start = line_index.position_at_utf16(span.start(), &text);
-                let end = line_index.position_at_utf16(span.end(), &text);
-                out.push(Location {
-                    uri: parsed.clone(),
-                    range: Range {
-                        start: Position {
-                            line: start.line,
-                            character: start.character.get(),
-                        },
-                        end: Position {
-                            line: end.line,
-                            character: end.character.get(),
-                        },
-                    },
-                });
+            };
+            let ranges = self
+                .consumer_ranges_in_document(&doc, &plan, method, is_classmethod)
+                .await;
+            if !ranges.is_empty() {
+                out.push((doc.uri, ranges));
             }
         }
         out
+    }
+
+    /// The family classes, candidate consumer documents, and classmethod
+    /// dispatch heads for `(seed_class, method)` — one index read.  `None`
+    /// when the family is empty (the class isn't indexed yet), which means
+    /// there is nothing for a consumer scan to match against.
+    ///
+    /// `classmethod_cmd_names` carries the workspace-wide answer to "given
+    /// `is_classmethod` is true, which class names bare-dispatch it" — a
+    /// pure-consumer document (e.g. one that only calls `Factory make`) has
+    /// no local `ClassDef` for `Factory`, so
+    /// `core_references::obj_method_call_sites` cannot derive this itself the
+    /// way the same-document path does.
+    async fn consumer_scan_plan(
+        &self,
+        dialect: &str,
+        seed_class: &str,
+        method: &str,
+        is_classmethod: bool,
+    ) -> Option<ConsumerScan> {
+        let index = self.workspace_index.read().await;
+        let definers = index.method_override_family(seed_class, method);
+        let inheritors = index.method_inheritor_classes(seed_class, method);
+        let classmethod_cmd_names =
+            Self::classmethod_dispatch_names(&definers, &inheritors, is_classmethod, dialect);
+        let mut family: Vec<String> = definers
+            .iter()
+            .map(|wc| wc.qualified_name.clone())
+            .collect();
+        family.extend(inheritors.iter().map(|wc| wc.qualified_name.clone()));
+        if family.is_empty() {
+            return None;
+        }
+        family.sort();
+        family.dedup();
+        let family_norm: std::collections::HashSet<&str> =
+            family.iter().map(|s| s.trim_start_matches("::")).collect();
+        // The index answers with a `HashSet`; sort so the per-document scan
+        // order (and so the emitted edit / location order) does not ride on
+        // hash iteration order.
+        let mut consumer_uris: Vec<String> = index
+            .documents_invoking_classes(&family_norm)
+            .into_iter()
+            .collect();
+        consumer_uris.sort();
+        drop(index);
+        Some(ConsumerScan {
+            family,
+            consumer_uris,
+            classmethod_cmd_names,
+        })
+    }
+
+    /// The consumer call-site ranges of `method` within one document, scanned
+    /// against an analysis carrying the workspace class oracle so a
+    /// constructor whose class lives in another file still types `$obj`.
+    async fn consumer_ranges_in_document(
+        &self,
+        doc: &ConsumerDoc,
+        plan: &ConsumerScan,
+        method: &str,
+        is_classmethod: bool,
+    ) -> Vec<Range> {
+        let analysis = self
+            .analyse_with_workspace_classes(&doc.text, &doc.dialect)
+            .await;
+        let source = doc.text.clone();
+        let dialect = doc.dialect.clone();
+        let family = plan.family.clone();
+        let method_owned = method.to_owned();
+        let classmethod_cmd_names = plan.classmethod_cmd_names.clone();
+        let spans: Vec<tcl_lexer::Span> = tokio::task::spawn_blocking(move || {
+            let mut all: Vec<tcl_lexer::Span> = Vec::new();
+            for cq in &family {
+                all.extend(core_references::obj_method_call_sites(
+                    &source,
+                    &dialect,
+                    &analysis,
+                    cq,
+                    &method_owned,
+                    is_classmethod,
+                    &classmethod_cmd_names,
+                ));
+            }
+            all
+        })
+        .await
+        .unwrap_or_default();
+        let mut ranges: Vec<Range> = spans
+            .into_iter()
+            .map(|span| {
+                let start = doc.line_index.position_at_utf16(span.start(), &doc.text);
+                let end = doc.line_index.position_at_utf16(span.end(), &doc.text);
+                Range {
+                    start: Position {
+                        line: start.line,
+                        character: start.character.get(),
+                    },
+                    end: Position {
+                        line: end.line,
+                        character: end.character.get(),
+                    },
+                }
+            })
+            .collect();
+        // Stable order regardless of which family class matched a site first,
+        // so a rename's edit list and the reference peek's location list are
+        // reproducible across runs.
+        ranges.sort_by_key(|r| (r.start.line, r.start.character, r.end.line, r.end.character));
+        ranges.dedup();
+        ranges
+    }
+
+    /// The override-family classes of `(seed_class, method)` grouped by the
+    /// document that declares them: per URI, the **definers** (whose
+    /// declaration + call sites participate) and the pure **inheritors**
+    /// (whose `my method` / `$obj method` sites participate, but which
+    /// declare no copy of the method).  A document may contribute either or
+    /// both.  Sorted by URI so the visit order — and so the order sites are
+    /// emitted in — never rides on hash iteration order.
+    ///
+    /// `classmethod_cmd_names`: see [`Self::classmethod_dispatch_names`] — a
+    /// pure-inheritor document's own `all_classes` never lists the definer's
+    /// `class_methods`, so it cannot tell a classmethod's bare dispatch heads
+    /// apart from any other bare word without this.
+    ///
+    /// Shared by rename ([`Self::cross_file_method_rename`]) and references
+    /// ([`Self::cross_file_method_references`]) so the two resolve the same
+    /// family from the same index read.
+    async fn method_family_by_document(
+        &self,
+        dialect: &str,
+        seed_class: &str,
+        method: &str,
+        is_classmethod: bool,
+    ) -> MethodFamily {
+        let index = self.workspace_index.read().await;
+        let definers = index.method_override_family(seed_class, method);
+        let inheritors = index.method_inheritor_classes(seed_class, method);
+        let classmethod_cmd_names =
+            Self::classmethod_dispatch_names(&definers, &inheritors, is_classmethod, dialect);
+        let mut by_uri: std::collections::BTreeMap<String, FamilyClasses> =
+            std::collections::BTreeMap::new();
+        for wc in definers {
+            by_uri
+                .entry(wc.uri.clone())
+                .or_default()
+                .definers
+                .push(wc.qualified_name.clone());
+        }
+        for wc in inheritors {
+            by_uri
+                .entry(wc.uri.clone())
+                .or_default()
+                .inheritors
+                .push(wc.qualified_name.clone());
+        }
+        for classes in by_uri.values_mut() {
+            classes.definers.sort();
+            classes.definers.dedup();
+            classes.inheritors.sort();
+            classes.inheritors.dedup();
+        }
+        drop(index);
+        MethodFamily {
+            by_uri: by_uri.into_iter().collect(),
+            classmethod_cmd_names,
+        }
     }
 
     /// Cross-file rename of a `TclOO` method across its override family.
@@ -4836,57 +5019,39 @@ impl Backend {
     /// indexed yet, so the caller can fall back to the single-document
     /// path).
     ///
-    /// Coverage is bounded by the analyser's single-document instance
-    /// tracking: a `$obj method` site is only rewritten in a document the
-    /// index knows defines or inherits the family class (the same constraint
-    /// under which the site is resolvable at all), so no unresolved site is
-    /// silently left pointing at the old name that the analysis could have
-    /// caught.  Documents holding a purely-inheriting subclass (a family
-    /// member's descendant that doesn't override the method) are visited too,
-    /// so their `my method` / `$obj method` sites are not missed just because
-    /// the subclass lives in a different file from the definer.
+    /// Documents holding a purely-inheriting subclass (a family member's
+    /// descendant that doesn't override the method) are visited too, so their
+    /// `my method` / `$obj method` sites are not missed just because the
+    /// subclass lives in a different file from the definer.  **Pure-consumer**
+    /// documents — ones that neither define nor extend any family class and
+    /// only call `$obj method` / `Class method` — are covered by the same
+    /// resolver Find All References uses ([`Self::consumer_method_site_ranges`],
+    /// issue #993); leaving them out rewrote the declaration while the consumer
+    /// kept calling a name that no longer existed.
     async fn cross_file_method_rename(
         &self,
+        current_uri: &Uri,
+        current_doc: &DocumentState,
         seed_class: &str,
         method: &str,
         new_name: &str,
         is_classmethod: bool,
-        dialect: &str,
     ) -> std::collections::HashMap<Uri, Vec<TextEdit>> {
+        let dialect = current_doc.dialect.as_str();
         let mut changes: std::collections::HashMap<Uri, Vec<TextEdit>> =
             std::collections::HashMap::new();
-        // Classes grouped by document: the override-family definers (whose
-        // declaration + call sites rename) and the pure inheritors (whose
-        // `my method` / `$obj method` sites rename, but which declare no copy
-        // of the method).  A document may contribute either or both.
-        //
-        // `classmethod_cmd_names`: see [`Self::classmethod_dispatch_names`] —
-        // a pure-inheritor document's own `all_classes` never lists the
-        // definer's `class_methods`, so it cannot tell a classmethod's bare
-        // dispatch heads apart from any other bare word without this.
-        let (by_uri, classmethod_cmd_names) = {
-            let index = self.workspace_index.read().await;
-            let definers = index.method_override_family(seed_class, method);
-            let inheritors = index.method_inheritor_classes(seed_class, method);
-            let classmethod_cmd_names =
-                Self::classmethod_dispatch_names(&definers, &inheritors, is_classmethod, dialect);
-            let mut m: std::collections::HashMap<String, (Vec<String>, Vec<String>)> =
-                std::collections::HashMap::new();
-            for wc in definers {
-                m.entry(wc.uri.clone())
-                    .or_default()
-                    .0
-                    .push(wc.qualified_name.clone());
-            }
-            for wc in inheritors {
-                m.entry(wc.uri.clone())
-                    .or_default()
-                    .1
-                    .push(wc.qualified_name.clone());
-            }
-            (m, classmethod_cmd_names)
-        };
-        for (u, (definers, inheritors)) in by_uri {
+        let family = self
+            .method_family_by_document(dialect, seed_class, method, is_classmethod)
+            .await;
+        let classmethod_cmd_names = family.classmethod_cmd_names;
+        for (
+            u,
+            FamilyClasses {
+                definers,
+                inheritors,
+            },
+        ) in family.by_uri
+        {
             let Ok(parsed) = Uri::from_str(&u) else {
                 continue;
             };
@@ -4930,26 +5095,38 @@ impl Backend {
             if spans.is_empty() {
                 continue;
             }
-            let line_index = target_doc.line_index.clone();
-            let bucket = changes.entry(parsed).or_default();
-            for span in spans {
-                let start = line_index.position_at_utf16(span.start(), &target_doc.text);
-                let end = line_index.position_at_utf16(span.end(), &target_doc.text);
-                let edit = TextEdit {
-                    range: Range {
-                        start: Position {
-                            line: start.line,
-                            character: start.character.get(),
-                        },
-                        end: Position {
-                            line: end.line,
-                            character: end.character.get(),
-                        },
-                    },
-                    new_text: new_name.to_owned(),
-                };
-                if !bucket.iter().any(|e| e.range == edit.range) {
-                    bucket.push(edit);
+            merge_span_edits(
+                changes.entry(parsed).or_default(),
+                spans,
+                &target_doc.line_index,
+                &target_doc.text,
+                new_name,
+            );
+        }
+        // The consumer leg (issue #993): documents that only *call* the
+        // method.  Same resolver as the references path, so what Find All
+        // References reports as a call site is exactly what rename rewrites.
+        // A document already visited above contributes here too (its own
+        // `$obj method` sites may resolve only through the workspace class
+        // oracle); the per-range guard keeps the edit set duplicate-free.
+        let consumer = self
+            .consumer_method_site_ranges(
+                current_uri,
+                &current_doc.text,
+                dialect,
+                seed_class,
+                method,
+                is_classmethod,
+            )
+            .await;
+        for (uri, ranges) in consumer {
+            let bucket = changes.entry(uri).or_default();
+            for range in ranges {
+                if !bucket.iter().any(|e| e.range == range) {
+                    bucket.push(TextEdit {
+                        range,
+                        new_text: new_name.to_owned(),
+                    });
                 }
             }
         }
@@ -4977,30 +5154,19 @@ impl Backend {
         is_classmethod: bool,
         dialect: &str,
     ) -> Vec<Location> {
-        let (by_uri, classmethod_cmd_names) = {
-            let index = self.workspace_index.read().await;
-            let definers = index.method_override_family(seed_class, method);
-            let inheritors = index.method_inheritor_classes(seed_class, method);
-            let classmethod_cmd_names =
-                Self::classmethod_dispatch_names(&definers, &inheritors, is_classmethod, dialect);
-            let mut m: std::collections::HashMap<String, (Vec<String>, Vec<String>)> =
-                std::collections::HashMap::new();
-            for wc in definers {
-                m.entry(wc.uri.clone())
-                    .or_default()
-                    .0
-                    .push(wc.qualified_name.clone());
-            }
-            for wc in inheritors {
-                m.entry(wc.uri.clone())
-                    .or_default()
-                    .1
-                    .push(wc.qualified_name.clone());
-            }
-            (m, classmethod_cmd_names)
-        };
+        let family = self
+            .method_family_by_document(dialect, seed_class, method, is_classmethod)
+            .await;
+        let classmethod_cmd_names = family.classmethod_cmd_names;
         let mut out = Vec::new();
-        for (u, (definers, inheritors)) in by_uri {
+        for (
+            u,
+            FamilyClasses {
+                definers,
+                inheritors,
+            },
+        ) in family.by_uri
+        {
             if u == current_uri.as_str() {
                 continue;
             }
@@ -10363,11 +10529,12 @@ impl LanguageServer for Backend {
         {
             let changes = self
                 .cross_file_method_rename(
+                    &uri,
+                    &doc,
                     &seed_class,
                     &method,
                     &new_name,
                     is_classmethod,
-                    &doc.dialect,
                 )
                 .await;
             if !changes.is_empty() {
@@ -10756,6 +10923,38 @@ fn lift_lsp_range(r: CoreLspRange) -> Range {
             line: r.end_line,
             character: r.end_character,
         },
+    }
+}
+
+/// Lift `spans` (byte offsets into `text`) to LSP ranges and append each as a
+/// `new_name` rename edit to `bucket`, skipping any range already there — two
+/// family classes in one document can report the same site.
+fn merge_span_edits(
+    bucket: &mut Vec<TextEdit>,
+    spans: Vec<tcl_lexer::Span>,
+    line_index: &tcl_lexer::LineIndex,
+    text: &str,
+    new_name: &str,
+) {
+    for span in spans {
+        let start = line_index.position_at_utf16(span.start(), text);
+        let end = line_index.position_at_utf16(span.end(), text);
+        let range = Range {
+            start: Position {
+                line: start.line,
+                character: start.character.get(),
+            },
+            end: Position {
+                line: end.line,
+                character: end.character.get(),
+            },
+        };
+        if !bucket.iter().any(|e| e.range == range) {
+            bucket.push(TextEdit {
+                range,
+                new_text: new_name.to_owned(),
+            });
+        }
     }
 }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4756,9 +4756,21 @@ impl Backend {
     /// [`core_workspace_index::WorkspaceMethod::kind`]) is the centralised
     /// answer instead of guessing from the command name, exactly as the
     /// same-document path reads `ClassDef::class_methods` locally.
+    ///
+    /// A stock-`TclOO` `self method` is **not** inherited: it lives on the
+    /// class object that declared it, and a subclass's own class command
+    /// never reaches it (`Gadget make` against a parent's `self method make`
+    /// errors `unknown method "make": must be create, destroy or new` under
+    /// tclsh 8.6 and 9.0.4).  `ooutil`'s `classmethod` keyword does
+    /// propagate.  Both share the `"classmethod"` receiver kind, so the
+    /// inheritors are folded in only when an indexed definer declares a
+    /// genuinely inheritable copy — otherwise a rename rewrote a subclass
+    /// consumer's `Gadget make`, which never called the renamed member at
+    /// all (Codex review on #1047).
     fn classmethod_dispatch_names(
         definers: &[&core_workspace_index::WorkspaceClass],
         inheritors: &[&core_workspace_index::WorkspaceClass],
+        method: &str,
         is_classmethod: bool,
         dialect: &str,
     ) -> Vec<String> {
@@ -4770,9 +4782,17 @@ impl Backend {
         if !is_classmethod {
             return Vec::new();
         }
+        let declarations: Vec<&core_workspace_index::WorkspaceMethod> = definers
+            .iter()
+            .filter_map(|wc| wc.class_method(method))
+            .collect();
+        // No indexed declaration at all (a class not yet indexed) keeps the
+        // inheritors, as before — the exclusion needs positive knowledge that
+        // every declaration is a `self method`.
+        let inheritable = declarations.is_empty() || declarations.iter().any(|m| !m.is_self_method);
         definers
             .iter()
-            .chain(inheritors.iter())
+            .chain(inheritors.iter().filter(|_| inheritable))
             .filter(|wc| !wc.is_itcl(dialect))
             .flat_map(|wc| [wc.name.clone(), wc.qualified_name.clone()])
             .collect()
@@ -4905,8 +4925,13 @@ impl Backend {
         let index = self.workspace_index.read().await;
         let definers = index.method_override_family(seed_class, method);
         let inheritors = index.method_inheritor_classes(seed_class, method);
-        let classmethod_cmd_names =
-            Self::classmethod_dispatch_names(&definers, &inheritors, is_classmethod, dialect);
+        let classmethod_cmd_names = Self::classmethod_dispatch_names(
+            &definers,
+            &inheritors,
+            method,
+            is_classmethod,
+            dialect,
+        );
         let mut family: Vec<String> = definers
             .iter()
             .map(|wc| wc.qualified_name.clone())
@@ -5021,8 +5046,13 @@ impl Backend {
         let index = self.workspace_index.read().await;
         let definers = index.method_override_family(seed_class, method);
         let inheritors = index.method_inheritor_classes(seed_class, method);
-        let classmethod_cmd_names =
-            Self::classmethod_dispatch_names(&definers, &inheritors, is_classmethod, dialect);
+        let classmethod_cmd_names = Self::classmethod_dispatch_names(
+            &definers,
+            &inheritors,
+            method,
+            is_classmethod,
+            dialect,
+        );
         let mut by_uri: std::collections::BTreeMap<String, FamilyClasses> =
             std::collections::BTreeMap::new();
         for wc in definers {
@@ -20512,6 +20542,63 @@ mod tests {
                 .any(|l| l.uri == consumer && l.range.start.line == 0),
             "`SubFactory make` (inherited classmethod) in the pure-consumer document missing: {refs:?}"
         );
+    }
+
+    /// TN (Codex review on #1047): a stock-`TclOO` `self method` is not
+    /// inherited, so a subclass's own class command never reaches it —
+    /// tclsh 8.6 and 9.0.4 both answer `Gadget make` with `unknown method
+    /// "make": must be create, destroy or new`.  A consumer document's
+    /// `Gadget make` therefore calls something else entirely and must not
+    /// appear as a reference (nor be rewritten by a rename) when the
+    /// parent's `self method make` is renamed.  The TP half — the parent's
+    /// own `Parent make` — must still be found.
+    #[tokio::test]
+    async fn cross_file_consumer_excludes_subclass_dispatch_of_a_self_method() {
+        let backend = test_backend();
+        let parent = Uri::from_str("file:///selfparent.tcl").unwrap();
+        let consumer = Uri::from_str("file:///selfconsumer.tcl").unwrap();
+        let parent_src = "oo::class create Parent {\n    self method make {} { return 1 }\n}\noo::class create Gadget {\n    superclass Parent\n}\n";
+        register(&backend, &parent, parent_src).await;
+        register(&backend, &consumer, "Parent make\nGadget make\n").await;
+        let refs = backend
+            .cross_file_consumer_method_references(
+                &parent, parent_src, "tcl8.6", "::Parent", "make", true,
+            )
+            .await;
+        assert!(
+            refs.iter()
+                .any(|l| l.uri == consumer && l.range.start.line == 0),
+            "`Parent make` (the declaring class's own dispatch) missing: {refs:?}"
+        );
+        assert!(
+            !refs
+                .iter()
+                .any(|l| l.uri == consumer && l.range.start.line == 1),
+            "`Gadget make` is not a call of a non-inherited `self method`: {refs:?}"
+        );
+    }
+
+    /// The rename half of the same rule: the consumer edit list rewrites
+    /// `Parent make` and leaves `Gadget make` alone.  References and rename
+    /// resolve consumer sites through the one resolver, so this pins that
+    /// they stay in step.
+    #[tokio::test]
+    async fn cross_file_rename_of_a_self_method_leaves_subclass_dispatch_alone() {
+        let backend = test_backend();
+        let parent = Uri::from_str("file:///selfparent2.tcl").unwrap();
+        let consumer = Uri::from_str("file:///selfconsumer2.tcl").unwrap();
+        let parent_src = "oo::class create Parent {\n    self method make {} { return 1 }\n}\noo::class create Gadget {\n    superclass Parent\n}\n";
+        register(&backend, &parent, parent_src).await;
+        register(&backend, &consumer, "Parent make\nGadget make\n").await;
+        let ranges = backend
+            .consumer_method_site_ranges(&parent, parent_src, "tcl8.6", "::Parent", "make", true)
+            .await;
+        let consumer_ranges: Vec<u32> = ranges
+            .iter()
+            .filter(|(uri, _)| *uri == consumer)
+            .flat_map(|(_, rs)| rs.iter().map(|r| r.start.line))
+            .collect();
+        assert_eq!(consumer_ranges, vec![0], "{ranges:?}");
     }
 
     #[tokio::test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2337,6 +2337,21 @@ pub struct Backend {
     /// [`Backend::semantic_tokens_core_data`]) can compare the enriched result
     /// it lands against what was last served, without borrowing `Backend`.
     last_semantic_tokens: SemanticTokensCache,
+    /// Per-URI memo of [`Backend::analyse_with_workspace_classes`] — the
+    /// analysis that resolves a cross-file constructor (`set d [::other::Cls
+    /// new]`) by feeding the workspace class set to instance inference.
+    ///
+    /// Unlike the ordinary document analysis this one is not a salsa query:
+    /// it depends on the workspace class set as well as the document, which
+    /// is not a salsa input.  Without a memo the consumer scan re-ran it once
+    /// per candidate document per request, so one code-lens resolve cost
+    /// (documents × analysis) — measured at 0.31 s over 40 consumer documents,
+    /// paid again for every lens the editor has on screen (adversarial review
+    /// of #1047, item 8).  Entries validate against a fingerprint of both
+    /// inputs rather than a revision counter, so a stale entry is impossible
+    /// however the document or the index changed; the URI key just keeps the
+    /// map small and evictable on `did_close`.
+    workspace_class_analyses: Arc<Mutex<HashMap<Uri, WorkspaceClassAnalysis>>>,
     /// Set while a debounced `workspace/semanticTokens/refresh` fire is
     /// scheduled (see [`SemanticTokensRefreshCtx::request_refresh_coalesced`]).
     /// The refresh carries no data — a client that receives it simply
@@ -2704,6 +2719,41 @@ struct MethodFamily {
     classmethod_cmd_names: Vec<String>,
 }
 
+/// One memoised workspace-class-oracle analysis — see
+/// [`Backend::workspace_class_analyses`].
+struct WorkspaceClassAnalysis {
+    /// Hash of everything the analysis depends on: the document's text and
+    /// dialect, and the workspace class set.  Recomputing it is a few
+    /// microseconds against the several milliseconds of a re-analysis.
+    fingerprint: (u64, u64),
+    analysis: Arc<AnalysisResult>,
+}
+
+/// Hash of one document's analysis inputs, for
+/// [`WorkspaceClassAnalysis::fingerprint`].
+fn document_fingerprint(source: &str, dialect: &str) -> u64 {
+    use std::hash::{Hash as _, Hasher as _};
+    let mut hasher = std::hash::DefaultHasher::new();
+    source.hash(&mut hasher);
+    dialect.hash(&mut hasher);
+    hasher.finish()
+}
+
+/// Order-independent hash of the workspace class set, for
+/// [`WorkspaceClassAnalysis::fingerprint`].  The set comes out of a
+/// `HashSet`, so iteration order carries no meaning and the combining step
+/// must not depend on it.
+fn class_set_fingerprint(classes: &std::collections::HashSet<String>) -> u64 {
+    use std::hash::{Hash as _, Hasher as _};
+    let mut combined = classes.len() as u64;
+    for name in classes {
+        let mut hasher = std::hash::DefaultHasher::new();
+        name.hash(&mut hasher);
+        combined = combined.wrapping_add(hasher.finish());
+    }
+    combined
+}
+
 /// One document a consumer scan visits, with the text and index needed to
 /// lift its spans to LSP ranges.
 struct ConsumerDoc {
@@ -2774,6 +2824,7 @@ impl Backend {
             closed_diag_gen: Arc::new(Mutex::new(HashMap::new())),
             client_supports_pull_diagnostics: std::sync::atomic::AtomicBool::new(false),
             last_semantic_tokens: Arc::new(Mutex::new(HashMap::new())),
+            workspace_class_analyses: Arc::new(Mutex::new(HashMap::new())),
             semantic_tokens_refresh_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             warm_task: std::sync::Mutex::new(None),
             edit_order: EditOrder::default(),
@@ -4067,7 +4118,7 @@ impl Backend {
         // external call resolves the exported dispatch entry only
         // (issue #945 faults 4 + 6).
         if let Some((class_q, method, _is_classmethod, access)) = self
-            .resolve_method_target(&doc.text, &doc.dialect, &analysis, pos)
+            .resolve_method_target(uri, &doc.text, &doc.dialect, &analysis, pos)
             .await
         {
             let method_defs = self
@@ -4699,22 +4750,52 @@ impl Backend {
     /// (`set d [::other::Cls new]`) still records `d`'s class.  Used only by the
     /// cross-file method reference / definition path; the normal cached
     /// analysis (which drives diagnostics) leaves the oracle empty.
+    ///
+    /// Memoised per `uri` in [`Self::workspace_class_analyses`] and validated
+    /// against a fingerprint of both inputs, so a consumer scan that visits
+    /// the same documents for every lens on screen analyses each of them
+    /// once.  Returns a shared `Arc` the caller can move into a
+    /// `spawn_blocking` worker, as [`Self::analysis_for`] does.
     async fn analyse_with_workspace_classes(
         &self,
+        uri: &Uri,
         source: &str,
         dialect: &str,
-    ) -> tcl_compiler::analyser::AnalysisResult {
+    ) -> Arc<AnalysisResult> {
         let workspace_classes = self.workspace_index.read().await.all_class_qnames();
-        let source = source.to_owned();
-        let dialect = dialect.to_owned();
-        tokio::task::spawn_blocking(move || {
-            tcl_compiler::analyser::Analyser::new()
-                .with_workspace_classes(workspace_classes)
-                .analyse(&source, &dialect)
-                .clone()
+        let fingerprint = (
+            document_fingerprint(source, dialect),
+            class_set_fingerprint(&workspace_classes),
+        );
+        if let Some(hit) = self
+            .workspace_class_analyses
+            .lock()
+            .await
+            .get(uri)
+            .filter(|entry| entry.fingerprint == fingerprint)
+        {
+            return Arc::clone(&hit.analysis);
+        }
+        let owned_source = source.to_owned();
+        let owned_dialect = dialect.to_owned();
+        let analysis: Arc<AnalysisResult> = tokio::task::spawn_blocking(move || {
+            Arc::new(
+                tcl_compiler::analyser::Analyser::new()
+                    .with_workspace_classes(workspace_classes)
+                    .analyse(&owned_source, &owned_dialect)
+                    .clone(),
+            )
         })
         .await
-        .unwrap_or_default()
+        .unwrap_or_default();
+        self.workspace_class_analyses.lock().await.insert(
+            uri.clone(),
+            WorkspaceClassAnalysis {
+                fingerprint,
+                analysis: Arc::clone(&analysis),
+            },
+        );
+        analysis
     }
 
     /// Resolve the `TclOO` method `(class, name, access)` under the cursor.
@@ -4725,6 +4806,7 @@ impl Backend {
     /// class oracle.
     async fn resolve_method_target(
         &self,
+        uri: &Uri,
         source: &str,
         dialect: &str,
         analysis: &AnalysisResult,
@@ -4735,7 +4817,9 @@ impl Backend {
         {
             return Some(target);
         }
-        let oracle = self.analyse_with_workspace_classes(source, dialect).await;
+        let oracle = self
+            .analyse_with_workspace_classes(uri, source, dialect)
+            .await;
         core_rename::method_target_with_access(source, pos.line, pos.character, &oracle)
     }
 
@@ -4971,7 +5055,7 @@ impl Backend {
         is_classmethod: bool,
     ) -> Vec<Range> {
         let analysis = self
-            .analyse_with_workspace_classes(&doc.text, &doc.dialect)
+            .analyse_with_workspace_classes(&doc.uri, &doc.text, &doc.dialect)
             .await;
         let source = doc.text.clone();
         let dialect = doc.dialect.clone();
@@ -5323,7 +5407,7 @@ impl Backend {
     ) -> Vec<Location> {
         let mut locations = Vec::new();
         if let Some((seed_class, method, is_classmethod, _access)) = self
-            .resolve_method_target(&doc.text, &doc.dialect, analysis, pos)
+            .resolve_method_target(uri, &doc.text, &doc.dialect, analysis, pos)
             .await
         {
             locations.extend(
@@ -8423,6 +8507,9 @@ impl LanguageServer for Backend {
         // Drop the cached semantic-token baseline so a reopened document starts
         // from a fresh `full` rather than diffing against a stale stream.
         self.last_semantic_tokens.lock().await.remove(uri);
+        // The workspace-class analysis memo is keyed by URI; a closed
+        // document's entry would otherwise linger for the process's life.
+        self.workspace_class_analyses.lock().await.remove(uri);
         // Re-index the file from disk rather than dropping it: the file still
         // exists on disk and was (or would be) part of the on-disk index, so
         // cross-document definition / references / rename / call-hierarchy — and
@@ -16092,6 +16179,7 @@ mod tests {
             closed_diag_gen: Arc::new(Mutex::new(HashMap::new())),
             client_supports_pull_diagnostics: std::sync::atomic::AtomicBool::new(false),
             last_semantic_tokens: Arc::new(Mutex::new(HashMap::new())),
+            workspace_class_analyses: Arc::new(Mutex::new(HashMap::new())),
             semantic_tokens_refresh_pending: Arc::new(std::sync::atomic::AtomicBool::new(false)),
             warm_task: std::sync::Mutex::new(None),
             edit_order: EditOrder::default(),

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -91,6 +91,8 @@ mod signature_help;
 mod structure;
 #[path = "e2e/tcl91.rs"]
 mod tcl91;
+#[path = "e2e/tcloo_navigation.rs"]
+mod tcloo_navigation;
 #[path = "e2e/tk_dialect.rs"]
 mod tk_dialect;
 #[path = "e2e/unicode_positions.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/code_actions.rs
+++ b/rust/tcl-lsp-server/tests/e2e/code_actions.rs
@@ -1449,3 +1449,46 @@ fn test_w201_no_rewrite_for_mixed_segment() {
         "a mixed segment does not decompose cleanly: {actions:?}"
     );
 }
+
+/// Issue #1000: refactor code actions must reach control flow inside an
+/// `apply` lambda body.  `apply`'s literal is `ArgRole::LambdaLiteral`, so
+/// the refactor descent has to split it and walk element 1; re-segmenting
+/// the whole `{argList body}` blob read `{m}` as a command name and left
+/// every `body_words`-backed action (if-to-switch, switch-to-dict,
+/// brace-expr, inline-variable, extract-to-datagroup) silently unavailable
+/// in there.  tclsh8.6/9.0-verified that this lambda really does run the
+/// `if` it wraps.
+#[test]
+fn test_if_to_switch_offered_inside_an_apply_lambda_body() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc handler {} {\n    apply {{m} {\n        if {$m eq \"GET\"} {\n            puts get\n        } elseif {$m eq \"POST\"} {\n            puts post\n        }\n    }} $x\n}\n";
+    lsp.open_ready(&uri, src);
+    // Cursor on the `if` inside the lambda body.
+    let actions = lsp.code_actions(&uri, range((2, 8), (2, 8)), json!([]));
+    assert!(
+        titles(&actions)
+            .iter()
+            .any(|t| t.to_lowercase().contains("switch")),
+        "the if-to-switch refactor must be offered inside the lambda: {actions:?}"
+    );
+}
+
+/// TN: the lambda's *argument list* is a plain word list, not code, so a
+/// cursor on it offers no control-flow refactor even when a parameter
+/// happens to be spelled like a command.
+#[test]
+fn test_no_refactor_offered_on_the_lambda_arg_list() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "apply {{if} {\n    puts $if\n}} 1\n";
+    lsp.open_ready(&uri, src);
+    // Cursor on the `if` parameter name in the argument list (line 0).
+    let actions = lsp.code_actions(&uri, range((0, 8), (0, 8)), json!([]));
+    assert!(
+        !titles(&actions)
+            .iter()
+            .any(|t| t.to_lowercase().contains("switch")),
+        "a parameter word named `if` is not an `if` command: {actions:?}"
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/code_actions.rs
+++ b/rust/tcl-lsp-server/tests/e2e/code_actions.rs
@@ -1474,6 +1474,29 @@ fn test_if_to_switch_offered_inside_an_apply_lambda_body() {
     );
 }
 
+/// TN (Codex review on #1047): a lambda body written as a **quoted** list
+/// element with escapes is backslash-decoded before `apply` evaluates it,
+/// so its source slice is not the script that runs — the source says `$m eq
+/// \"GET\"` where the real body says `$m eq "GET"` (tclsh 8.6 / 9.0.4 both
+/// run this lambda and answer `get` / `post`).  Re-parsing the slice in
+/// place offers a rewrite built from text that never executes, and lands
+/// its edits inside a string literal, so the descent must take only
+/// `{braced}` body elements.
+#[test]
+fn test_no_refactor_offered_inside_an_escaped_quoted_lambda_body() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "apply {{m} \"if {$m eq \\\"GET\\\"} {return get} elseif {$m eq \\\"POST\\\"} {return post}\"} GET\n";
+    lsp.open_ready(&uri, src);
+    // Cursor on the `if` word of the quoted body element.
+    let actions = lsp.code_actions(&uri, range((0, 12), (0, 12)), json!([]));
+    assert!(
+        kinds(&actions, "refactor").is_empty(),
+        "an escaped quoted body element is not script at these offsets: {:?}",
+        titles(&actions)
+    );
+}
+
 /// TN: the lambda's *argument list* is a plain word list, not code, so a
 /// cursor on it offers no control-flow refactor even when a parameter
 /// happens to be spelled like a command.

--- a/rust/tcl-lsp-server/tests/e2e/navigation_extras.rs
+++ b/rust/tcl-lsp-server/tests/e2e/navigation_extras.rs
@@ -141,6 +141,61 @@ fn method_outgoing_calls_nested_in_control_flow() {
     assert!(callees.contains("::C::greet"), "{callees:?}");
 }
 
+/// FN→TP (issue #995): a `classmethod` dispatches on the class's own
+/// command (`Factory make`), so neither its callers nor its callees have
+/// its name as a head word.  Incoming on `make` must find the sibling
+/// classmethod *and* the top-level statement; outgoing on `build` must find
+/// `make`.  tclsh9.0-verified — `Factory build` and the bare `Factory make`
+/// both enter `make` (8.6's `TclOO` has no `classmethod` keyword at all).
+#[test]
+fn classmethod_incoming_and_outgoing_calls_match_bare_class_dispatch() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "oo::class create Factory {\n    classmethod make {} { return 1 }\n    classmethod build {} { Factory make }\n}\nFactory make\n";
+    lsp.open_ready(&uri, src);
+    // `make`'s incoming calls: `build`'s body, plus the top-level statement.
+    let make_item = items(&lsp.prepare_call_hierarchy(&uri, 1, 16))[0].clone();
+    let incoming = calls(&lsp.incoming_calls(make_item));
+    let incoming_from: std::collections::BTreeSet<String> = incoming
+        .iter()
+        .map(|c| name_of(c.get("from").unwrap_or(&Value::Null)))
+        .collect();
+    assert!(
+        incoming_from.contains("::Factory::build"),
+        "the sibling classmethod's `Factory make` is a caller: {incoming_from:?}"
+    );
+    assert!(
+        incoming_from.contains("<top-level>"),
+        "the top-level `Factory make` is a caller: {incoming_from:?}"
+    );
+    // `build`'s outgoing calls: dispatches to `make`.
+    let build_item = items(&lsp.prepare_call_hierarchy(&uri, 2, 16))[0].clone();
+    let outgoing = calls(&lsp.outgoing_calls(build_item));
+    let outgoing_to: std::collections::BTreeSet<String> = outgoing
+        .iter()
+        .map(|c| name_of(c.get("to").unwrap_or(&Value::Null)))
+        .collect();
+    assert!(outgoing_to.contains("::Factory::make"), "{outgoing_to:?}");
+}
+
+/// FP guard (issue #995): `Factory make` where `Factory` is an ordinary
+/// proc calls *that proc* with the literal argument `make`
+/// (tclsh8.6/9.0-verified), so it is no edge at all to an unrelated class's
+/// same-named classmethod.
+#[test]
+fn bare_dispatch_on_a_same_named_proc_is_not_a_classmethod_edge() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "oo::class create Widget {\n    classmethod make {} { return 1 }\n}\nproc Factory {args} { return $args }\nFactory make\n";
+    lsp.open_ready(&uri, src);
+    let make_item = items(&lsp.prepare_call_hierarchy(&uri, 1, 16))[0].clone();
+    let incoming = calls(&lsp.incoming_calls(make_item));
+    assert!(
+        incoming.is_empty(),
+        "a proc call spelled `Factory make` must not edge to Widget's classmethod: {incoming:?}"
+    );
+}
+
 // -- TestImplementation --------------------------------------------------
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -173,6 +173,73 @@ fn tn_unrelated_same_named_proc_document_untouched_by_method_rename() {
     );
 }
 
+/// TN, the class gate under load: the consumer really *does* invoke a class
+/// — two of them — and both define `make`.  Only the `Factory` instance's
+/// call site may rename; the `Widget` instance's `$g make` calls a different
+/// method that keeps its name.  The `proc make` variant above never
+/// constructs anything, so it exercises only the "document mentions no class
+/// at all" cut, not this one (adversarial review of #1047).
+#[test]
+fn tn_second_classes_instance_dispatch_untouched_by_method_rename() {
+    let mut lsp = Lsp::tcl();
+    let factory = unique_uri("tcl");
+    lsp.open_ready(
+        &factory,
+        "oo::class create Factory {\n    method make {} { return 1 }\n}\n",
+    );
+    let widget = unique_uri("tcl");
+    lsp.open_ready(
+        &widget,
+        "oo::class create Widget {\n    method make {} { return 2 }\n}\n",
+    );
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(
+        &consumer,
+        "set f [Factory new]\nset g [Widget new]\n$f make\n$g make\n",
+    );
+
+    let edits = rename_edits(&lsp.rename(&factory, 1, 11, "produce"));
+    assert_eq!(
+        edit_lines(&edits, &consumer),
+        vec![2],
+        "only `$f make` (the Factory instance) may rename: {edits:?}"
+    );
+    assert!(
+        edit_lines(&edits, &widget).is_empty(),
+        "`Widget`'s own declaration must not rename: {edits:?}"
+    );
+}
+
+/// The classmethod twin of the two-class gate: `Factory make` renames,
+/// `Widget make` does not.  Both dispatch shapes are real under tclsh9.0.
+#[test]
+fn tn_second_classes_bare_dispatch_untouched_by_classmethod_rename() {
+    let mut lsp = Lsp::tcl();
+    let factory = unique_uri("tcl");
+    lsp.open_ready(
+        &factory,
+        "oo::class create Factory {\n    classmethod make {} { return 1 }\n}\n",
+    );
+    let widget = unique_uri("tcl");
+    lsp.open_ready(
+        &widget,
+        "oo::class create Widget {\n    classmethod make {} { return 2 }\n}\n",
+    );
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(&consumer, "Factory make\nWidget make\n");
+
+    let edits = rename_edits(&lsp.rename(&factory, 1, 16, "produce"));
+    assert_eq!(
+        edit_lines(&edits, &consumer),
+        vec![0],
+        "only the `Factory make` dispatch may rename: {edits:?}"
+    );
+    assert!(
+        edit_lines(&edits, &widget).is_empty(),
+        "`Widget`'s own classmethod declaration must not rename: {edits:?}"
+    );
+}
+
 /// TP (classmethod variant): a consumer document dispatching on the class's
 /// own command (`Factory make`, tclsh9.0-verified) is a consumer just like
 /// an instance-dispatch one, and renames with the declaration.

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -1,0 +1,182 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! `TclOO` cross-file navigation orchestration: rename, Find All References,
+//! and the code lens must all resolve a method through the *same* workspace
+//! machinery, so what one of them sees the others see too.
+//!
+//! * Issue #993 — rename skipped **pure-consumer** documents (a file that only
+//!   calls `$obj method` / `Class method` and declares nothing), silently
+//!   leaving them bound to a name that no longer exists.
+//! * Issue #991 — the code lens's click target and its displayed count both
+//!   came from narrower resolvers than Find All References on the same
+//!   declaration, so the three disagreed on the same symbol.
+//!
+//! Dispatch shapes are oracle-checked: `$f make` on an `oo::class` instance
+//! and bare `Factory make` on a 9.0 `classmethod` both dispatch to the class
+//! member (tclsh8.6 for the instance shape, tclsh9.0 for `classmethod`, which
+//! 8.6's `TclOO` has no keyword for), while `Factory make` where `Factory` is
+//! an ordinary proc calls that proc with the literal argument `make` — no
+//! method edge at all.
+
+use crate::common::helpers::*;
+use crate::common::{Lsp, unique_uri};
+use serde_json::Value;
+
+/// The start lines of every rename edit landing in `uri`.
+fn edit_lines(edits: &std::collections::BTreeMap<String, Vec<Value>>, uri: &str) -> Vec<i64> {
+    edits
+        .get(uri)
+        .into_iter()
+        .flatten()
+        .filter_map(|e| e["range"]["start"]["line"].as_i64())
+        .collect()
+}
+
+/// The `(uri, start line)` pairs of every location in a references /
+/// lens-resolve payload.
+fn location_lines(result: &Value, uri: &str) -> std::collections::BTreeSet<i64> {
+    locations(result)
+        .iter()
+        .filter(|l| l.uri == uri)
+        .filter_map(|l| {
+            l.range
+                .get("start")
+                .and_then(|s| s.get("line"))
+                .and_then(Value::as_i64)
+        })
+        .collect()
+}
+
+// Issue #993 — rename must reach pure-consumer documents.
+
+/// TP: `consumer.tcl` only ever *calls* `Factory`'s `make`; it declares no
+/// part of the class.  Renaming from the declaration must rewrite its
+/// `$f make` call site, or the consumer keeps calling a method that no
+/// longer exists under that name.
+#[test]
+fn tp_method_rename_reaches_pure_consumer_document() {
+    let mut lsp = Lsp::tcl();
+    let factory = unique_uri("tcl");
+    lsp.open_ready(
+        &factory,
+        "oo::class create Factory {\n    method make {} { return 1 }\n}\n",
+    );
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(&consumer, "set f [Factory new]\n$f make\n");
+
+    // Cursor on the `make` declaration name (line 1, col 11).
+    let edits = rename_edits(&lsp.rename(&factory, 1, 11, "produce"));
+    assert!(
+        edit_lines(&edits, &factory).contains(&1),
+        "the declaration itself must rename: {edits:?}"
+    );
+    assert_eq!(
+        edit_lines(&edits, &consumer),
+        vec![1],
+        "the pure-consumer `$f make` call site must rename too: {edits:?}"
+    );
+    assert!(
+        edits
+            .get(&consumer)
+            .is_some_and(|e| e.iter().all(|e| e["newText"] == "produce")),
+        "consumer edits must carry the new name: {edits:?}"
+    );
+}
+
+/// TN: a document with its own ordinary `proc make` — no `Factory` instance
+/// anywhere — is not a consumer of the class and must be left alone.
+#[test]
+fn tn_unrelated_same_named_proc_document_untouched_by_method_rename() {
+    let mut lsp = Lsp::tcl();
+    let factory = unique_uri("tcl");
+    lsp.open_ready(
+        &factory,
+        "oo::class create Factory {\n    method make {} { return 1 }\n}\n",
+    );
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(&consumer, "set f [Factory new]\n$f make\n");
+    let unrelated = unique_uri("tcl");
+    lsp.open_ready(&unrelated, "proc make {} { return 2 }\nmake\n");
+
+    let edits = rename_edits(&lsp.rename(&factory, 1, 11, "produce"));
+    assert_eq!(
+        edit_lines(&edits, &consumer),
+        vec![1],
+        "the real consumer must still rename: {edits:?}"
+    );
+    assert!(
+        edit_lines(&edits, &unrelated).is_empty(),
+        "an unrelated `proc make` document must NOT be rewritten: {edits:?}"
+    );
+}
+
+/// TP (classmethod variant): a consumer document dispatching on the class's
+/// own command (`Factory make`, tclsh9.0-verified) is a consumer just like
+/// an instance-dispatch one, and renames with the declaration.
+#[test]
+fn tp_classmethod_rename_reaches_consumer_bare_class_dispatch() {
+    let mut lsp = Lsp::tcl();
+    let factory = unique_uri("tcl");
+    lsp.open_ready(
+        &factory,
+        "oo::class create Factory {\n    classmethod make {} { return [Factory new] }\n}\n",
+    );
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(&consumer, "set f [Factory new]\nFactory make\n");
+
+    let edits = rename_edits(&lsp.rename(&factory, 1, 16, "produce"));
+    assert!(
+        edit_lines(&edits, &factory).contains(&1),
+        "the classmethod declaration must rename: {edits:?}"
+    );
+    assert_eq!(
+        edit_lines(&edits, &consumer),
+        vec![1],
+        "the consumer's bare `Factory make` dispatch must rename: {edits:?}"
+    );
+}
+
+/// Rename and Find All References must agree site-for-site on the consumer
+/// document — they now share one resolver, and a site one sees but the other
+/// misses is exactly the #993 corruption.
+#[test]
+fn tp_consumer_rename_and_references_agree_on_the_same_sites() {
+    let mut lsp = Lsp::tcl();
+    let factory = unique_uri("tcl");
+    lsp.open_ready(
+        &factory,
+        "oo::class create Factory {\n    method make {} { return 1 }\n}\n",
+    );
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(&consumer, "set f [Factory new]\n$f make\nputs [$f make]\n");
+
+    let refs = lsp.references(&factory, 1, 11, false);
+    let ref_lines = location_lines(&refs, &consumer);
+    let edits = rename_edits(&lsp.rename(&factory, 1, 11, "produce"));
+    let renamed: std::collections::BTreeSet<i64> =
+        edit_lines(&edits, &consumer).into_iter().collect();
+    assert_eq!(
+        renamed, ref_lines,
+        "every consumer site references reports must also rename: refs={refs:?} edits={edits:?}"
+    );
+    assert!(
+        renamed.contains(&1) && renamed.contains(&2),
+        "both consumer call sites must be covered: {edits:?}"
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -63,6 +63,53 @@ fn location_lines(result: &Value, uri: &str) -> std::collections::BTreeSet<i64> 
         .collect()
 }
 
+/// Every `(uri, start line)` pair in a references / lens-resolve payload.
+fn all_location_lines(result: &Value) -> std::collections::BTreeSet<(String, i64)> {
+    locations(result)
+        .iter()
+        .filter_map(|l| {
+            l.range
+                .get("start")
+                .and_then(|s| s.get("line"))
+                .and_then(Value::as_i64)
+                .map(|line| (l.uri.clone(), line))
+        })
+        .collect()
+}
+
+/// Resolve the code lens anchored at `line` in `uri`, returning its
+/// `command` object (`{title, command, arguments}`).
+fn resolve_lens_on_line(lsp: &mut Lsp, uri: &str, line: i64) -> Value {
+    let all = match lsp.code_lens(uri) {
+        Value::Array(a) => a,
+        _ => Vec::new(),
+    };
+    let lens = all
+        .iter()
+        .find(|l| l["range"]["start"]["line"].as_i64() == Some(line))
+        .unwrap_or_else(|| panic!("no lens anchored at line {line} of {uri}: {all:?}"))
+        .clone();
+    lsp.code_lens_resolve(lens)["command"].clone()
+}
+
+/// The lens label the server emits for `count` sites.
+fn expected_title(count: usize) -> Value {
+    Value::String(match count {
+        1 => "1 reference".to_owned(),
+        n => format!("{n} references"),
+    })
+}
+
+/// The `locations` argument a resolved lens hands `tcl-lsp.showReferences`.
+fn lens_locations(command: &Value) -> Value {
+    command
+        .get("arguments")
+        .and_then(Value::as_array)
+        .and_then(|a| a.get(2))
+        .cloned()
+        .unwrap_or(Value::Null)
+}
+
 // Issue #993 — rename must reach pure-consumer documents.
 
 /// TP: `consumer.tcl` only ever *calls* `Factory`'s `make`; it declares no
@@ -178,5 +225,115 @@ fn tp_consumer_rename_and_references_agree_on_the_same_sites() {
     assert!(
         renamed.contains(&1) && renamed.contains(&2),
         "both consumer call sites must be covered: {edits:?}"
+    );
+}
+
+// Issue #991 — code-lens click and count must match Find All References.
+
+/// TP: the lens above `Animal`'s `speak` must count — and, on click, open —
+/// the sibling document's override declaration and its `$d speak` dispatch,
+/// exactly as Find All References on the same declaration does.
+/// tclsh8.6/9.0-verified: `$d speak` on a `Dog` (superclass `Animal`) enters
+/// `Dog`'s override, which is a member of `Animal::speak`'s override family.
+#[test]
+fn tp_method_lens_click_and_count_match_find_all_references() {
+    let mut lsp = Lsp::tcl();
+    let animal = unique_uri("tcl");
+    lsp.open_ready(
+        &animal,
+        "oo::class create Animal {\n    method speak {} { return \"...\" }\n}\n",
+    );
+    let dog = unique_uri("tcl");
+    lsp.open_ready(
+        &dog,
+        "oo::class create Dog {\n    superclass Animal\n    method speak {} { return \"woof\" }\n}\nset d [Dog new]\n$d speak\n",
+    );
+
+    // Cursor on `speak`'s declaration in animal.tcl (line 1, col 11).
+    let refs = lsp.references(&animal, 1, 11, false);
+    let ref_sites = all_location_lines(&refs);
+    assert!(
+        !location_lines(&refs, &dog).is_empty(),
+        "Find All References must reach the sibling document: {refs:?}"
+    );
+
+    let command = resolve_lens_on_line(&mut lsp, &animal, 1);
+    let lens_sites = all_location_lines(&lens_locations(&command));
+    assert_eq!(
+        lens_sites, ref_sites,
+        "the lens click must open exactly what Find All References returns: {command:?}"
+    );
+    assert_eq!(
+        command["title"],
+        expected_title(ref_sites.len()),
+        "the lens count must be the number of sites its click opens: {command:?}"
+    );
+    assert!(
+        ref_sites.contains(&(dog.clone(), 5)),
+        "the sibling `$d speak` dispatch is one of them: {refs:?}"
+    );
+}
+
+/// TN: a method with genuinely no references anywhere still reads
+/// "0 references" and opens nothing — the cross-file layer must not invent
+/// sites for a member nobody calls.
+#[test]
+fn tn_method_with_no_cross_file_references_still_reads_zero() {
+    let mut lsp = Lsp::tcl();
+    let animal = unique_uri("tcl");
+    lsp.open_ready(
+        &animal,
+        "oo::class create Animal {\n    method speak {} { return \"...\" }\n    method quiet {} { return \"\" }\n}\n",
+    );
+    let dog = unique_uri("tcl");
+    lsp.open_ready(
+        &dog,
+        "oo::class create Dog {\n    superclass Animal\n    method speak {} { return \"woof\" }\n}\nset d [Dog new]\n$d speak\n",
+    );
+
+    // `quiet` (line 2) is declared once and never dispatched.
+    let command = resolve_lens_on_line(&mut lsp, &animal, 2);
+    assert_eq!(
+        command["title"],
+        Value::String("0 references".to_owned()),
+        "an uncalled method must not gain sites from the cross-file layer: {command:?}"
+    );
+    assert_eq!(
+        all_location_lines(&lens_locations(&command)),
+        std::collections::BTreeSet::new(),
+        "and its click must open nothing: {command:?}"
+    );
+}
+
+/// TP: the classmethod shape too — a bare `Factory make` dispatch in a
+/// consumer document counts towards, and opens from, the declaration's lens
+/// (tclsh9.0-verified dispatch).
+#[test]
+fn tp_classmethod_lens_click_and_count_reach_a_consumer_document() {
+    let mut lsp = Lsp::tcl();
+    let factory = unique_uri("tcl");
+    lsp.open_ready(
+        &factory,
+        "oo::class create Factory {\n    classmethod make {} { return [Factory new] }\n}\n",
+    );
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(&consumer, "Factory make\n");
+
+    let refs = lsp.references(&factory, 1, 16, false);
+    let ref_sites = all_location_lines(&refs);
+    assert!(
+        location_lines(&refs, &consumer).contains(&0),
+        "the consumer's bare dispatch must be a reference: {refs:?}"
+    );
+    let command = resolve_lens_on_line(&mut lsp, &factory, 1);
+    assert_eq!(
+        all_location_lines(&lens_locations(&command)),
+        ref_sites,
+        "the classmethod lens click must match Find All References: {command:?}"
+    );
+    assert_eq!(
+        command["title"],
+        expected_title(ref_sites.len()),
+        "and its count must be that same number: {command:?}"
     );
 }

--- a/rust/tcl-lsp-server/tests/preview_tickets_e2e.rs
+++ b/rust/tcl-lsp-server/tests/preview_tickets_e2e.rs
@@ -883,22 +883,15 @@ async fn list_wrapped_namespace_unknown_installer_suppresses_w123_e2e() {
 /// bareword-callable; without it, the call errors "invalid command
 /// name" in real tclsh and go-to-definition/hover must abstain, not
 /// guess.
-// QUARANTINED (Codex review, PR #1020): this test is genuinely flaky
-// (~1/15 in CI and locally). The *un-linked* half asserts a bareword sibling
-// call `[foo 42]` (no `link foo`) abstains from go-to-definition. The
-// in-document provider correctly abstains (the idx-113 link gate in
-// `lookup_class_member`), but the server's cross-document fallback
-// (`cross_document_definition` → `resolve_workspace_symbols`) then
-// *non-deterministically* resolves the bareword `foo` (candidate `::foo`) to
-// the enclosing class's `::Widget::foo` method: `workspace_command_exists`
-// answers from `defined_command_names`, which folds in TclOO method names
-// even though a method is not bareword-callable without `link`, and the
-// downstream method→definition resolution is HashMap-iteration-order
-// dependent. The proper fix is to apply the idx-113 link gate in the
-// workspace resolver (and stop methods satisfying a bareword
-// `workspace_command_exists`); tracked as its own issue alongside the `link`
-// modelling follow-up. Ignored so it stops flaking CI green until then.
-#[ignore = "flaky: workspace def fallback non-deterministically resolves an un-linked bareword method call (idx-113 link gate not applied cross-document); tracked as a follow-up issue"]
+// Was quarantined as flaky (issue #1028, ~1/15 in CI and locally) and is now
+// deterministic again. The culprit was *not* `defined_command_names` folding
+// method names (it no longer does): it was `rename::method_target_with_access`'s
+// class-body fallback firing on **any** member-name-shaped word inside a class
+// body span — receiver-less, link-gate-less — so the un-linked bareword `foo`
+// was handed to `cross_file_method_definition`, whose answer then rode on hash
+// iteration order. That fallback now applies the same idx-113 gate the
+// in-document `definition::lookup_class_member` does: the cursor must be on the
+// member's own declaration name, or on a bareword `link` really made callable.
 #[tokio::test]
 async fn class_member_bareword_call_requires_link_e2e() {
     let (mut reader, mut writer, server) = start_session().await;

--- a/rust/tcl-syntax/src/list.rs
+++ b/rust/tcl-syntax/src/list.rs
@@ -153,14 +153,23 @@ fn list_junk_fragment(src: &str) -> String {
 }
 
 /// One located list element: the interior byte range in the source, whether it
-/// is `literal` (no backslash collapse needed — Tcl's `literal` flag), and the
-/// offset to resume scanning at (past trailing whitespace).
+/// is `literal` (no backslash collapse needed — Tcl's `literal` flag), whether
+/// it was written `{brace}`-delimited, and the offset to resume scanning at
+/// (past trailing whitespace).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Element {
     /// Interior byte range (delimiters stripped).
     pub value: Range<usize>,
     /// `true` ⇒ take `s[value]` verbatim; `false` ⇒ collapse its backslashes.
     pub literal: bool,
+    /// `true` when the element was written as `{…}`.  A braced element's
+    /// value is its source text byte-for-byte at exactly `value`'s offsets —
+    /// no escape ever collapses inside braces — which is what a consumer
+    /// that re-parses the element *in place* (as script, as a nested list)
+    /// and reports source spans back needs.  A bare or double-quoted element
+    /// may be `literal` too (when it happens to contain no backslash), but
+    /// that is a property of the one value, not of the shape.
+    pub braced: bool,
     /// Resume offset for the next [`find_element`] call.
     pub next: usize,
 }
@@ -190,6 +199,7 @@ pub fn find_element(s: &str, start: usize) -> Result<Option<Element>, ListError>
     let mut open_braces: usize = 0;
     let mut in_quotes = false;
     let mut literal = true;
+    let braced = bytes[pos] == b'{';
     let elem_start;
     match bytes[pos] {
         b'{' => {
@@ -292,6 +302,7 @@ pub fn find_element(s: &str, start: usize) -> Result<Option<Element>, ListError>
     Ok(Some(Element {
         value: elem_start..elem_start + size,
         literal,
+        braced,
         next: pos,
     }))
 }


### PR DESCRIPTION
## Summary

Five TclOO navigation fixes, severity-first, each with failing-then-passing tests and tclsh8.6/9.0 oracle transcripts:

- **#993** — renaming a TclOO method/classmethod now rewrites call sites in pure-consumer documents (docs that only call, never define/extend). Previously rename silently left `$f make` pointing at a dead name — the one active-corruption bug in this cluster. The consumer resolver is now a single shared path used by both references and rename (`consumer_method_site_ranges`), so the two can't diverge again.
- **#1028** — the flaky un-linked-bareword go-to-definition is fixed and the quarantined e2e test un-ignored. The pinned root cause was stale; the real one: `method_target_with_access`'s class-body fallback fired on any member-name-shaped word with no idx-113 `linked_members` gate, then HashMap-ordered workspace resolution made the wrong answer intermittent. Both fixed (gate ported; `WorkspaceIndex` document indexing and `method_dispatch_chain` now source-ordered/stable). Flake loop: 32.5% failure pre-fix → **180/180 green** post-fix across fresh processes.
- **#991** — code-lens click and count now equal Find All References by construction: one `reference_locations` path backs the references handler and the lens resolve, and the lens title is computed from the same location set it opens.
- **#995** (remainder) — call hierarchy sees bare `ClassName method` classmethod dispatch (incoming, outgoing, and the top-level bucket), reusing `references::find_obj_method_call_sites` rather than re-deriving matching; all 25 pre-existing `my`-dispatch tests stay green (now 30).
- **#1000** — `body_words` handles `ArgRole::LambdaLiteral` via `split_lambda_literal`, so if-to-switch and the other four refactor code actions work inside `apply` lambda bodies; TN pins that the lambda's arg-list word is never misread as a command.

KCS feature notes updated (rename, definition, code-lens, references anchors, call-hierarchy, code-actions).

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Run on the integration of this PR with the two sibling PRs (merges are conflict-free):

- `make rust-check` / `make check-all` — pass (zero new clippy allows)
- `make prep-pr` — full workspace suite (306 test targets incl. native lsp_e2e): pass, 0 failures
- `make test-ext` — 710 passing · `make test-emacs` — pass · `make runtime-rust-test` — 400 passed
- #1028 flake loop: 40 pre-fix runs (13 failures) vs 180 post-fix runs (0 failures)
- Oracle: tclsh8.6 + tclsh9.0 transcripts for every dispatch-shape claim (classmethod is 9.0-only; `Factory make` on a proc named `Factory` is a proc call, not a method edge; etc.)

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? (no — LSP-side resolution/orchestration only; compiler facts untouched)
- [ ] If yes, I updated at least one relevant KCS note under `docs/kcs/compiler/`. (n/a; feature notes under `docs/kcs/features/` updated instead)
- [ ] If I added a new compiler KCS note, I linked it from both:
  - `docs/kcs/compiler/README.md`
  - `docs/kcs/README.md`

(no new compiler KCS note)

**Known follow-up (deliberate):** the shared `find_obj_method_call_sites` scanner is still namespace-blind (#981) — this PR makes that one fix cover five features at once; #981 and #990 (itcl colon dispatch) are next in the campaign queue.

**Merge order note:** conflict-free with the compiler PR (#1045) and the registry PR; merge after them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178kD1P7t6ne1shFtWwkK54

---
_Generated by [Claude Code](https://claude.ai/code/session_0178kD1P7t6ne1shFtWwkK54)_