### PR TITLE
Document the parallel-worktree CARGO_TARGET_DIR hazard and add the agent-build-env helper (#1052)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -251,6 +251,44 @@ A publish secret stored any other way — a plain repo secret, an org secret,
 or one reachable by a job with no protected `environment:` — violates the
 contract.
 
+### Parallel worktrees and agent build isolation
+
+**Never share one `CARGO_TARGET_DIR` across concurrently-building git
+worktrees of this workspace.**  Cargo's unit hashing does not reliably
+disambiguate workspace-member crates built from different worktree paths of
+the same workspace (same package name/version/features), so concurrent
+builds race on the same `deps/` outputs.  Observed failure modes (all real,
+from the 2026-07-29 multi-agent session — issue #1052): an xtask binary
+linking a **sibling branch's** `libtcl_registry` rlib and failing the drift
+gate on a diagnostic that branch doesn't have; phantom `E0603` privacy
+errors naming line numbers from a different checkout; alternating
+cannot-find/no-variant errors on symbols plainly present in the tree;
+a full-suite run reporting failures from a pre-fix `libtcl_compiler` that
+had already been fixed.  A green or red produced this way is
+**untrustworthy** — the test ran against code that is not in the tree
+being tested.
+
+Rules:
+
+- Give each worktree its **own** `CARGO_TARGET_DIR` — the per-worktree
+  default (`<worktree-root>/target`) is already correct; the hazard only
+  appears when a shared dir is exported to save disk.
+- To keep per-worktree dirs affordable, build with `CARGO_INCREMENTAL=0`
+  and `CARGO_PROFILE_DEV_DEBUG=0` (~3-4 GB per dir instead of ~15 GB).
+- Sharing **`CARGO_HOME`** (the registry/git dependency cache) across
+  worktrees is safe — external-crate artefacts do not exhibit the
+  collision, only workspace members do.
+- Treat any build or test result produced **after an ENOSPC event** as
+  untrustworthy until a clean rebuild — disk-full aggravates the
+  fingerprint corruption.  `cargo clean -p <crate>` (or `touch`ing the
+  crate's `lib.rs`) recovers a wedged crate; neither prevents recurrence
+  while a target dir stays shared.
+
+`source scripts/dev/agent-build-env.sh` pins all of this for the current
+worktree (`--check` shows what it would set and warns if the current
+`CARGO_TARGET_DIR` points elsewhere).  Agent instructions should reference
+that helper rather than repeating the env-var incantations.
+
 **Stable vs pre-release channels (odd/even-minor).**  Two lines run in
 parallel and the tag alone decides which:
 

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -35,6 +35,10 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   you want to know whether the Tcl Language Server started at all.
 - [kcs-issue-stale-compiler-cache.md](kcs-issue-stale-compiler-cache.md)
   — stale incremental cache produces wrong diagnostics.
+- [kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md](kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md)
+  — builds in one git worktree fail or pass with artefacts from a
+  sibling checkout because the worktrees share one cargo target
+  directory.
 - [kcs-issue-memory-grows-while-editing.md](kcs-issue-memory-grows-while-editing.md)
   — the language server's memory use climbs with every keystroke and never
   comes back down.

--- a/docs/kcs/kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md
+++ b/docs/kcs/kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md
@@ -1,0 +1,55 @@
+# KCS: Parallel worktree builds serve stale or cross-checkout artefacts
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+tcl-lsp-cli
+
+## Question
+
+Why does a build or test run in one git worktree fail (or pass) with
+errors that name code from a *different* checkout of this repository?
+
+## Symptoms
+
+- A binary built in one worktree behaves like a sibling branch: for
+  example, `cargo xtask diag-tables` emits a diagnostic that exists only
+  on another branch, and the drift gate fails spuriously.
+- Phantom compile errors (`E0603: … is private`, "cannot find …",
+  "no variant named …") that name line numbers or symbols from another
+  checkout, varying from run to run, while the source in front of you
+  plainly contains the item.
+- A test suite reports failures whose output matches code that was
+  already fixed in the tree being tested.
+
+## Answer
+
+The worktrees are sharing one `CARGO_TARGET_DIR`.  Cargo's unit hashing
+does not reliably tell apart workspace-member crates built from different
+worktree paths of the same workspace, so concurrent builds overwrite each
+other's `deps/` outputs, and a later link step can pick up the sibling
+worktree's rlib.
+
+1. Give every worktree its own `CARGO_TARGET_DIR`.  The easiest way is
+   `source scripts/dev/agent-build-env.sh` in each shell — it pins the
+   target dir to `<worktree-root>/target` and sets `CARGO_INCREMENTAL=0`
+   and `CARGO_PROFILE_DEV_DEBUG=0` so each dir stays around 3-4 GB.
+2. Recover the wedged worktree with `cargo clean -p <crate>` for the
+   affected crate (or a full `cargo clean`), then rebuild.
+3. Re-run whatever gate produced the suspect result.  Any green or red
+   produced while the dir was shared — or after a disk-full (ENOSPC)
+   event — is untrustworthy until reproduced on a clean, isolated build.
+
+Sharing `CARGO_HOME` (the downloaded-dependency cache) across worktrees
+is safe; only workspace-member artefacts collide.
+
+The success signal: repeated builds in both worktrees stop flip-flopping,
+and `scripts/dev/agent-build-env.sh --check` reports a per-worktree
+target dir with no warning.
+
+## File-path anchors
+
+- `scripts/dev/agent-build-env.sh`
+- `AGENTS.md` — "Parallel worktrees and agent build isolation"

--- a/docs/kcs/kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md
+++ b/docs/kcs/kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md
@@ -49,7 +49,9 @@ The success signal: repeated builds in both worktrees stop flip-flopping,
 and `scripts/dev/agent-build-env.sh --check` reports a per-worktree
 target dir with no warning.
 
-## File-path anchors
+## Related
 
-- `scripts/dev/agent-build-env.sh`
-- `AGENTS.md` — "Parallel worktrees and agent build isolation"
+- [KCS index](README.md)
+- The "Parallel worktrees and agent build isolation" section of
+  [AGENTS.md](../../AGENTS.md) — the contributor-facing rules the helper
+  script enforces.

--- a/scripts/dev/agent-build-env.sh
+++ b/scripts/dev/agent-build-env.sh
@@ -1,0 +1,85 @@
+#!/usr/bin/env bash
+# tcl-lsp — a language server and toolchain for Tcl
+# Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU Affero General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with this program.  If not, see <https://www.gnu.org/licenses/>.
+#
+# SPDX-License-Identifier: AGPL-3.0-or-later
+
+# agent-build-env.sh — per-worktree cargo build isolation for parallel agents.
+#
+# Sharing one CARGO_TARGET_DIR across concurrently-building git worktrees of
+# this workspace serves stale or cross-checkout rlibs: cargo's unit hashing
+# does not disambiguate workspace-member crates built from different worktree
+# paths of the same workspace (same package name/version/features), so
+# concurrent builds race on the same deps/ outputs.  A test run can then pass
+# or fail against code that is not in the tree being tested.  See the
+# "Parallel worktrees and agent build isolation" section of AGENTS.md and
+# issue #1052 for the observed failure modes.
+#
+# This helper pins the build environment for the current worktree:
+#
+#   CARGO_TARGET_DIR         -> <worktree-root>/target  (never shared)
+#   CARGO_INCREMENTAL=0      -> smaller target dir, no incremental-cache races
+#   CARGO_PROFILE_DEV_DEBUG=0 -> keeps a dev target dir ~3-4 GB, not ~15 GB
+#
+# CARGO_HOME (the registry/git dependency cache) is deliberately left alone:
+# sharing it across worktrees is safe — only workspace-member artefacts
+# exhibit the collision.
+#
+# Usage:
+#   source scripts/dev/agent-build-env.sh          # export into current shell
+#   eval "$(scripts/dev/agent-build-env.sh --print)"  # same, for eval users
+#   scripts/dev/agent-build-env.sh --check         # show what would be set
+
+agent_build_env__main() {
+    local worktree_root
+    if ! worktree_root="$(git rev-parse --show-toplevel 2>/dev/null)"; then
+        echo "agent-build-env.sh: not inside a git worktree" >&2
+        return 1
+    fi
+
+    local target_dir="${worktree_root}/target"
+
+    case "${1:-}" in
+        --print)
+            printf 'export CARGO_TARGET_DIR=%q\n' "${target_dir}"
+            printf 'export CARGO_INCREMENTAL=0\n'
+            printf 'export CARGO_PROFILE_DEV_DEBUG=0\n'
+            ;;
+        --check)
+            echo "worktree root:            ${worktree_root}"
+            echo "CARGO_TARGET_DIR:         ${target_dir}"
+            echo "CARGO_INCREMENTAL:        0"
+            echo "CARGO_PROFILE_DEV_DEBUG:  0"
+            if [ -n "${CARGO_TARGET_DIR:-}" ] \
+                && [ "${CARGO_TARGET_DIR}" != "${target_dir}" ]; then
+                echo "WARNING: CARGO_TARGET_DIR is currently" \
+                    "'${CARGO_TARGET_DIR}' — if another worktree builds into" \
+                    "it concurrently, artefacts are untrustworthy." >&2
+            fi
+            ;;
+        '')
+            export CARGO_TARGET_DIR="${target_dir}"
+            export CARGO_INCREMENTAL=0
+            export CARGO_PROFILE_DEV_DEBUG=0
+            ;;
+        *)
+            echo "usage: source agent-build-env.sh | agent-build-env.sh --print | --check" >&2
+            return 2
+            ;;
+    esac
+}
+
+agent_build_env__main "$@"

--- a/scripts/dev/agent-build-env.sh
+++ b/scripts/dev/agent-build-env.sh
@@ -82,4 +82,13 @@ agent_build_env__main() {
     esac
 }
 
-agent_build_env__main "$@"
+# When sourced, never forward "$@": with no explicit source arguments,
+# bash leaves the caller's positional parameters in place, and a caller
+# argument like "build" would be misread as an unknown mode, erroring out
+# with nothing exported.  Sourcing is always the plain export form; the
+# --print/--check modes are for direct execution.
+if [ "${BASH_SOURCE[0]}" != "$0" ]; then
+    agent_build_env__main
+else
+    agent_build_env__main "$@"
+fi


### PR DESCRIPTION
## Summary

- AGENTS.md gains a **"Parallel worktrees and agent build isolation"** subsection in the build-system notes: never share one `CARGO_TARGET_DIR` across concurrently-building worktrees of this workspace (cargo's unit hashing does not disambiguate workspace members by worktree path); per-worktree dirs with `CARGO_INCREMENTAL=0 CARGO_PROFILE_DEV_DEBUG=0` keep each dir ~3-4 GB; sharing `CARGO_HOME` is explicitly safe; any result produced after an ENOSPC event is untrustworthy until a clean rebuild; `cargo clean -p <crate>` is the recovery.
- New `scripts/dev/agent-build-env.sh` — the canonical helper agent instructions can reference: `source` it to pin the per-worktree environment, `--print` for `eval` users, `--check` for a non-mutating report that warns when `CARGO_TARGET_DIR` points outside the worktree.
- New contributor KCS note `docs/kcs/kcs-issue-parallel-worktree-builds-serve-stale-artefacts.md` (symptom → diagnosis → recovery), indexed in `docs/kcs/README.md`.

Fixes #1052.

The failure modes documented are the ones observed live in the 2026-07-29 multi-agent session — including, fittingly, an ENOSPC-poisoned test run during this very round's gating, which was discarded and re-run clean per the new guidance.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `make check-all` — PASSED on this branch.
  - `make xtask-check` — all drift gates green (includes the `kcs-index-links` gate that validates the new note's indexing and audience header).
  - `bash -n scripts/dev/agent-build-env.sh` + smoke-run of `--check` and `--print`.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? — No; documentation and dev tooling only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_