### PR TITLE
Thread the resolved dialect through the CLI, CompilationUnit, lowering, and the LSP registry (#1048)

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,9 +65,14 @@ All editors connect to the native Rust binary `tcl-lsp-server` over stdio
 `#!/usr/bin/tclsh`, `#!/usr/bin/wish`, and `#!/usr/bin/expect`.
 Files named `presentation` (no extension) are auto-detected as APL.
 Per-file `# tcl-dialect:` comment directives pin a specific dialect.
-The `tcl diag` / `lint` / `validate` CLI verbs apply the same per-file
-detection (directive, shebang, content, extension) unless `--dialect` is
-passed, so the CLI and the editor report the same set for the same file.
+Every `tcl` CLI verb applies the same detection (directive, shebang,
+`package require Tcl` guard, content signals such as a `when EVENT {`
+handler, then extension) unless `--dialect` is passed — per input file for
+`diag` / `lint` / `validate` / `minimize`, and once for the whole
+invocation for the verbs that combine their inputs into one source
+(`opt`, `format`, `minify`, `explore`, `diagram`, the graph verbs, …).
+So the CLI and the editor report the same set, and apply the same
+optimisations, for the same file.
 Files named `tclpkg.tcl` are analysed as `tcl pkg` package manifests:
 their directives resolve against the manifest command set instead of
 drawing unknown-command warnings.

--- a/docs/design/compiler/expression-parsing.md
+++ b/docs/design/compiler/expression-parsing.md
@@ -75,6 +75,33 @@ These are registered in `binary_bp()` (`rust/tcl-syntax/src/expr/parser.rs`)
 alongside the standard operators, and recognised as operator tokens by
 `irules_ops()` in `rust/tcl-lexer/src/expr_lexer.rs`.
 
+### Who supplies the dialect
+
+`parse_expr(source, dialect)` takes the dialect because `irules_ops()` is
+gated on it: with `None` (or a non-iRules dialect) `contains` is an ordinary
+bareword, the parse fails, and the result is `ExprNode::Raw`. That fallback is
+silent — the expression still compiles, it simply stops being analysable — so a
+caller that forgets the dialect loses constant folding, type inference, and
+every diagnostic derived from them (I230, O101, O112) with no error anywhere.
+
+The dialect therefore has to be threaded from the document all the way down:
+
+| Layer | Carrier |
+|-------|---------|
+| Consumer (CLI verb, LSP document, analyser) | the dialect name (`f5-irules`) |
+| Compilation unit | `UnitBuildOptions::dialect`, set by `CompilationUnit::build_for_dialect` |
+| Lowering | `Lowerer::dialect`, set by `lower_to_ir_with_dialect` / `Lowerer::with_dialect` |
+| `if` / `while` / `for` conditions | `parse_expr(cond, self.dialect)` in `lowering/structured.rs` |
+| `expr` / `return [expr …]` / `set x [expr …]` | `LoweringCommand::dialect` in the lowering hooks |
+| Constant folding | `FoldPolicy::from_registry`, which reads the registry's stamped dialect profile |
+
+Two failure modes have been paid for once already (issue #1048): building a
+unit with `CompilationUnit::build_for` (or `build_for_with_config`, which
+fixes only the *lexer* config) while holding a real dialect, and handing the
+pipeline a registry with no profile stamped on it — `registry_for_dialect`
+stamps it, a hand-assembled `build_default` + `load_dialect` does not, and
+`FoldPolicy::from_registry` reads such a registry as plain Tcl.
+
 ## Decision rule
 
 - To add a new operator, add its binding power entry to `binary_bp()`, map its

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -70,6 +70,10 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
 - [kcs-issue-always-true-condition-in-a-sourced-library-file.md](kcs-issue-always-true-condition-in-a-sourced-library-file.md)
   — I230 says a condition is always true in a library file whose procedure
   is really called with different values from another file.
+- [kcs-issue-irule-word-operator-is-not-analysed.md](kcs-issue-irule-word-operator-is-not-analysed.md)
+  — an iRules word operator (`contains`, `starts_with`, …) is neither
+  folded by `tcl opt` nor reported by the analyser, because the file's
+  dialect never reached the optimiser or the expression parser.
 - [kcs-issue-duplicate-diagnostics.md](kcs-issue-duplicate-diagnostics.md)
   — the same finding is reported twice.
 - [kcs-issue-counter-numtests-array-init.md](kcs-issue-counter-numtests-array-init.md)

--- a/docs/kcs/kcs-issue-irule-word-operator-is-not-analysed.md
+++ b/docs/kcs/kcs-issue-irule-word-operator-is-not-analysed.md
@@ -1,0 +1,87 @@
+# KCS: My iRule's `contains` condition is never folded or flagged
+
+> **Audience:** User
+> **Type:** Issue
+
+## Applies to
+
+all-editors, tcl-lsp CLI, mcp
+
+## Question
+
+Why does an iRules word operator — `contains`, `starts_with`, `ends_with`,
+`matches_glob`, or `matches_regex` — behave as if the tools had never heard
+of it, so a condition that is obviously always true is neither simplified by
+`tcl opt` nor reported by the analyser?
+
+## Symptoms
+
+- `tcl opt myrule.irule` leaves `if {$x contains "cd"} { … }` untouched, but
+  the same file with `tcl opt --dialect f5-irules myrule.irule` folds it to
+  `if {1}` and reports **O101 Fold constant expression**.
+- Even with `--dialect f5-irules`, `tcl diag` reports nothing for that
+  condition, while the plain-Tcl equivalent (`if {$x == 1}`) draws
+  **I230 Condition … is always true**.
+- The editor shows the same gap: no I230 on an iRule word-operator condition
+  the analyser can prove constant.
+
+## Answer
+
+Update to a build that includes the fix for issue #1048. Two separate faults
+produced these symptoms, and both are fixed:
+
+1. **The command line dropped the detected dialect.** Only the diagnostics
+   verbs (`diag`, `lint`, `validate`) resolved a file's dialect from its
+   contents and name. Every other verb — `opt`, `format`, `minify`,
+   `explore`, `diagram`, `callgraph`, `dataflow`, `symbols`, `highlight`,
+   `dis`, `diff` — silently analysed the file as `tcl8.6`. They now use the
+   same detection: a `# tcl-dialect:` directive, a shebang, a
+   `package require Tcl` guard, content signals such as a `when EVENT {`
+   handler, then the file extension, falling back to `tcl8.6`.
+2. **The dialect never reached the compiler's expression parser.** Every
+   `if`, `while`, `for`, and `expr` condition was parsed with the plain-Tcl
+   operator set, so a word operator was not read as an operator at all — it
+   became an opaque expression the constant folder could not evaluate. The
+   condition is now parsed with the document's own operator set, which is
+   what lets the fold, and the I230 that reports it, happen.
+
+Check the fix with a two-line file, `probe.irule`:
+
+```tcl
+when HTTP_REQUEST {
+    set x "abcdef"
+    if {$x contains "cd"} { HTTP::respond 200 }
+}
+```
+
+```console
+$ tcl opt probe.irule
+when HTTP_REQUEST {
+    set x "abcdef"
+    if {1} { HTTP::respond 200 }
+}
+# optimised: 1 rewrite(s)
+# O101  Fold constant expression
+
+$ tcl diag probe.irule
+probe.irule:3:8: info    I230     Condition '$x contains "cd"' is always true; …
+```
+
+Both must now behave identically with and without `--dialect f5-irules`.
+
+Plain Tcl is deliberately unchanged: `contains` is not an operator there, so
+the same condition in a `.tcl` file still draws
+[W003](codes/kcs-diagnostic-w003-dialect-invalid-expr-operator.md) — "operator
+is not available in dialect 'tcl8.6'" — and no I230.
+
+If detection picks the wrong dialect for a file (an iRule with no `when`
+handler and a `.txt` name, say), name it explicitly with `--dialect`, or pin
+it in the file itself with a `# tcl-dialect: f5-irules` comment on one of
+the first few lines.
+
+## Related
+
+- [KCS index](README.md)
+- [Which commands does tcl-lsp consider available in a dialect?](kcs-qa-which-commands-are-available-in-a-dialect.md)
+- [Expression parsing — Pratt parser and braced vs unbraced expressions](../design/compiler/expression-parsing.md)
+- [Glossary](../GLOSSARY.md)

--- a/docs/kcs/kcs-issue-irule-word-operator-is-not-analysed.md
+++ b/docs/kcs/kcs-issue-irule-word-operator-is-not-analysed.md
@@ -5,7 +5,7 @@
 
 ## Applies to
 
-all-editors, tcl-lsp CLI, mcp
+all-editors, tcl-lsp CLI, mcp, diagnostic, lowering, sccp, const-fold
 
 ## Question
 

--- a/editors/vscode/src/test/i230WordOperator.test.ts
+++ b/editors/vscode/src/test/i230WordOperator.test.ts
@@ -1,0 +1,59 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+import * as assert from "assert";
+import * as vscode from "vscode";
+import { getDocUri, activate, waitForDiagnostics } from "./helper";
+
+// Fixture (`i230WordOperator.irul`):
+//   line 2: set x "abcdef"
+//   line 3: if {$x contains "cd"} { HTTP::respond 200 }
+//
+// Issue #1048: the document's dialect never reached the compiler's expression
+// parser, so an iRules word operator lowered to an opaque expression the
+// constant folder could not evaluate — the always-true condition drew no
+// I230 in the editor at all.
+
+function codeOf(d: vscode.Diagnostic): string | number | undefined {
+  return typeof d.code === "object" ? d.code?.value : d.code;
+}
+
+suite("I230 on an iRules word-operator condition", () => {
+  const docUri = getDocUri("i230WordOperator.irul");
+
+  test("reports the always-true `contains` condition", async () => {
+    await activate(docUri);
+    const diagnostics = await waitForDiagnostics(docUri, {
+      predicate: (diags) => diags.some((d) => codeOf(d) === "I230"),
+    });
+    const i230 = diagnostics.filter((d) => codeOf(d) === "I230");
+    assert.ok(
+      i230.length >= 1,
+      `expected an I230, got ${JSON.stringify(diagnostics.map((d) => [codeOf(d), d.message]))}`,
+    );
+    const onCondition = i230.find((d) => d.range.start.line === 3);
+    assert.ok(
+      onCondition,
+      `expected the I230 on the condition line, got ${JSON.stringify(i230.map((d) => d.range))}`,
+    );
+    assert.ok(
+      onCondition!.message.includes("contains"),
+      `message must quote the folded condition: ${onCondition!.message}`,
+    );
+  });
+});

--- a/editors/vscode/testFixture/i230WordOperator.irul
+++ b/editors/vscode/testFixture/i230WordOperator.irul
@@ -1,0 +1,5 @@
+# iRules word-operator constant-condition fixture (issue #1048).
+when HTTP_REQUEST {
+    set x "abcdef"
+    if {$x contains "cd"} { HTTP::respond 200 }
+}

--- a/rust/tcl-cli-support/src/input.rs
+++ b/rust/tcl-cli-support/src/input.rs
@@ -82,9 +82,48 @@ impl InputDocument {
         if let Some(d) = explicit {
             return d.to_string();
         }
-        let filename = self.path.as_deref().and_then(Path::to_str);
-        tcl_registry::dialects::detect_dialect(&self.source, filename, "tcl8.6").to_string()
+        tcl_registry::dialects::detect_dialect(&self.source, self.filename(), "tcl8.6").to_string()
     }
+
+    /// The dialect this document's own content or name gives away, or `None`
+    /// when nothing does. Same detector as [`Self::effective_dialect`], minus
+    /// the `tcl8.6` fallback — so a caller resolving one dialect for several
+    /// documents can tell "this file says nothing" from "this file says plain
+    /// Tcl".
+    #[must_use]
+    fn detected_dialect(&self) -> Option<&'static str> {
+        let detected = tcl_registry::dialects::detect_dialect(&self.source, self.filename(), "");
+        (!detected.is_empty()).then_some(detected)
+    }
+
+    /// The originating file name, for the detector's extension tier.
+    fn filename(&self) -> Option<&str> {
+        self.path.as_deref().and_then(Path::to_str)
+    }
+}
+
+/// The analysis dialect for a verb that works over **all** its input documents
+/// at once — the transforms (`format`, `opt`, `minify`), the graph verbs, the
+/// explorer, and the compile verbs, which combine their inputs into one source
+/// via [`combine_sources`].
+///
+/// An explicit `--dialect` wins. Otherwise the documents are detected in input
+/// order and the first one that gives something away decides the invocation
+/// (`probe.irule`, or a `.tcl` file opening `when HTTP_REQUEST {`, selects
+/// `f5-irules`); when no document does, the `tcl8.6` fallback applies. This is
+/// the same detector and priority order [`InputDocument::effective_dialect`]
+/// gives the per-document diagnostics verbs, so `tcl opt` and `tcl diag` agree
+/// about what a file is.
+#[must_use]
+pub fn combined_effective_dialect(documents: &[InputDocument], explicit: Option<&str>) -> String {
+    if let Some(d) = explicit {
+        return d.to_string();
+    }
+    documents
+        .iter()
+        .find_map(InputDocument::detected_dialect)
+        .unwrap_or("tcl8.6")
+        .to_owned()
 }
 
 /// `pkgIndex.tcl` is always accepted; otherwise the extension must be known.

--- a/rust/tcl-cli-support/src/lib.rs
+++ b/rust/tcl-cli-support/src/lib.rs
@@ -38,7 +38,9 @@ pub mod prompt;
 pub mod secret_input;
 
 pub use highlight::{highlight_ansi, highlight_html};
-pub use input::{CliError, InputDocument, combine_sources, read_input_documents};
+pub use input::{
+    CliError, InputDocument, combine_sources, combined_effective_dialect, read_input_documents,
+};
 pub use output::{
     OutputTarget, ensure_ascii, expand_tabs, resolve_use_colour, write_binary_output,
     write_highlighted_output, write_text_output,

--- a/rust/tcl-cli/src/cli.rs
+++ b/rust/tcl-cli/src/cli.rs
@@ -76,8 +76,15 @@ pub struct InputArgs {
     pub package_path: Vec<PathBuf>,
 
     /// Dialect profile for parsing and registry lookups. Defaults to
-    /// per-file auto-detection (a `# tcl-dialect:` directive, shebang,
-    /// content signals, then the file extension), falling back to tcl8.6.
+    /// auto-detection (a `# tcl-dialect:` directive, shebang, content
+    /// signals, then the file extension), falling back to tcl8.6.
+    ///
+    /// Resolved per document by the diagnostics verbs (`diag` / `lint` /
+    /// `validate` / `minimize`) via
+    /// [`tcl_cli_support::InputDocument::effective_dialect`], and once for
+    /// the whole invocation by the verbs that combine their inputs into one
+    /// source (transforms, graphs, explore, compile) via
+    /// [`tcl_cli_support::combined_effective_dialect`].
     #[arg(long, value_name = "DIALECT")]
     pub dialect: Option<String>,
 
@@ -88,19 +95,6 @@ pub struct InputArgs {
     /// Output path ('-' or omitted for stdout).
     #[arg(long, short, value_name = "FILE")]
     pub output: Option<PathBuf>,
-}
-
-impl InputArgs {
-    /// The `--dialect` value with the historical `tcl8.6` fallback — for
-    /// verbs that take one dialect for the whole invocation (transforms,
-    /// graphs, explore).  The diagnostics verbs (`diag` / `lint` /
-    /// `validate`) instead resolve per document via
-    /// [`tcl_cli_support::InputDocument::effective_dialect`], which layers
-    /// in-source / filename detection under an explicit flag.
-    #[must_use]
-    pub fn dialect_or_default(&self) -> &str {
-        self.dialect.as_deref().unwrap_or("tcl8.6")
-    }
 }
 
 /// Paired `--colour` / `--no-colour` toggle (resolved against config + TTY).
@@ -182,9 +176,11 @@ pub enum Command {
         /// Inline right-hand source.
         #[arg(long = "right-source", value_name = "CODE")]
         right_source: Option<String>,
-        /// Dialect profile.
-        #[arg(long, default_value = "tcl8.6", value_name = "DIALECT")]
-        dialect: String,
+        /// Dialect profile. Defaults to auto-detection over the left-hand
+        /// input (directive, shebang, content signals, then extension),
+        /// falling back to tcl8.6.
+        #[arg(long, value_name = "DIALECT")]
+        dialect: Option<String>,
         /// Layers to show.
         #[arg(
             long,

--- a/rust/tcl-cli/src/commands/compile.rs
+++ b/rust/tcl-cli/src/commands/compile.rs
@@ -41,8 +41,8 @@ use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
 use tcl_compiler::codegen::format::format_module_asm;
 use tcl_compiler::codegen::wasm::wasm_codegen_module;
-use tcl_compiler::lowering::{lower_to_ir, lower_to_ir_for_bytecode};
-use tcl_compiler::optimiser::{apply_optimisations, optimise};
+use tcl_compiler::lowering::{lower_to_ir_for_bytecode_with_dialect, lower_to_ir_with_dialect};
+use tcl_compiler::optimiser::{apply_optimisations, optimise_with_dialect};
 use tcl_registry::CommandRegistry;
 
 use crate::cli::InputArgs;
@@ -51,9 +51,17 @@ use crate::cli::InputArgs;
 /// `compile_script(optimise=...)` entry: collect the rewrites, apply
 /// them, and compile the rewritten text. Returns the (possibly unchanged)
 /// source.
-fn maybe_optimise(source: &str, registry: &CommandRegistry, optimise_on: bool) -> String {
+fn maybe_optimise(
+    source: &str,
+    registry: &CommandRegistry,
+    dialect: &str,
+    optimise_on: bool,
+) -> String {
     if optimise_on {
-        apply_optimisations(source, &optimise(source, registry))
+        apply_optimisations(
+            source,
+            &optimise_with_dialect(source, registry, Some(dialect)),
+        )
     } else {
         source.to_owned()
     }
@@ -64,9 +72,19 @@ pub fn run_dis(input: &InputArgs, optimise_on: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
     let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let registry = registry_for_dialect(&dialect);
-    let source = maybe_optimise(&combine_sources(&documents), registry, optimise_on);
+    let source = maybe_optimise(
+        &combine_sources(&documents),
+        registry,
+        &dialect,
+        optimise_on,
+    );
 
-    let ir = lower_to_ir_for_bytecode(&source, registry);
+    let ir = lower_to_ir_for_bytecode_with_dialect(
+        &source,
+        registry,
+        tcl_lexer::LexerConfig::for_dialect(&dialect),
+        &dialect,
+    );
     let cfg = build_cfg_codegen(&ir, false);
     let module = codegen_module(&cfg, &ir, registry);
     let disassembly = format_module_asm(&module);
@@ -166,7 +184,12 @@ fn run_compwasm_tree_walker(
     let registry = registry_for_dialect(&dialect);
     let source = combine_sources(&documents);
 
-    let ir = lower_to_ir(&source, registry);
+    let ir = lower_to_ir_with_dialect(
+        &source,
+        registry,
+        tcl_lexer::LexerConfig::for_dialect(&dialect),
+        &dialect,
+    );
     let mut wasm = wasm_codegen_module(&ir, &source);
     let bytes = wasm.to_bytes();
 

--- a/rust/tcl-cli/src/commands/compile.rs
+++ b/rust/tcl-cli/src/commands/compile.rs
@@ -34,8 +34,8 @@
 //! the `optimise` rewrites), then compiles the rewritten source.
 
 use tcl_cli_support::{
-    OutputTarget, combine_sources, read_input_documents, registry_for_dialect, write_binary_output,
-    write_text_output,
+    OutputTarget, combine_sources, combined_effective_dialect, read_input_documents,
+    registry_for_dialect, write_binary_output, write_text_output,
 };
 use tcl_compiler::cfg_builder::build_cfg_codegen;
 use tcl_compiler::codegen::codegen_module;
@@ -62,7 +62,8 @@ fn maybe_optimise(source: &str, registry: &CommandRegistry, optimise_on: bool) -
 /// `tcl dis` — compile source and emit human-readable bytecode disassembly.
 pub fn run_dis(input: &InputArgs, optimise_on: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let registry = registry_for_dialect(input.dialect_or_default());
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let registry = registry_for_dialect(&dialect);
     let source = maybe_optimise(&combine_sources(&documents), registry, optimise_on);
 
     let ir = lower_to_ir_for_bytecode(&source, registry);
@@ -161,7 +162,8 @@ fn run_compwasm_tree_walker(
     wat_output: Option<&std::path::Path>,
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
-    let registry = registry_for_dialect(input.dialect_or_default());
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
+    let registry = registry_for_dialect(&dialect);
     let source = combine_sources(&documents);
 
     let ir = lower_to_ir(&source, registry);

--- a/rust/tcl-cli/src/commands/diagram.rs
+++ b/rust/tcl-cli/src/commands/diagram.rs
@@ -26,8 +26,8 @@
 
 use serde_json::Value;
 use tcl_cli_support::{
-    OutputTarget, combine_sources, ensure_ascii, read_input_documents, registry_for_dialect,
-    write_text_output,
+    OutputTarget, combine_sources, combined_effective_dialect, ensure_ascii, read_input_documents,
+    registry_for_dialect, write_text_output,
 };
 use tcl_diagram as diagram;
 
@@ -36,13 +36,10 @@ use crate::cli::InputArgs;
 /// `tcl diagram` — extract control-flow diagram data from the IR.
 pub fn run_diagram(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(input.dialect_or_default());
-    let data = diagram::diagram_data_with_config(
-        &source,
-        registry,
-        tcl_lexer::LexerConfig::for_dialect(input.dialect_or_default()),
-    );
+    let registry = registry_for_dialect(&dialect);
+    let data = diagram::diagram_data_for_dialect(&source, registry, &dialect);
 
     let target = OutputTarget::from_arg(input.output.as_deref());
 

--- a/rust/tcl-cli/src/commands/diff.rs
+++ b/rust/tcl-cli/src/commands/diff.rs
@@ -38,8 +38,8 @@ use std::path::{Path, PathBuf};
 
 use serde_json::{Map, Value, json};
 use tcl_cli_support::{
-    OutputTarget, combine_sources, difflib, ensure_ascii, read_input_documents,
-    registry_for_dialect, write_text_output,
+    OutputTarget, combine_sources, combined_effective_dialect, difflib, ensure_ascii,
+    read_input_documents, registry_for_dialect, write_text_output,
 };
 use tcl_compiler::compilation_unit::CompilationUnit;
 use tcl_compiler::segmenter::{SegmentedCommand, UnclosedDelimiter, segment_commands};
@@ -220,7 +220,7 @@ fn layer_payload(
             // native `tcl-explorer` serialiser reproduces that view, so reuse
             // it (through the shared `value_to_json` adapter) rather than
             // carrying a second IR serialiser.
-            let cu = CompilationUnit::build_for(src, registry, false);
+            let cu = CompilationUnit::build_for_dialect(src, registry, false, dialect);
             let ir = tcl_explorer::serialise::serialise_ir(&cu.ir_module, line_index, src);
             Ok(value_to_json(&ir).dumps_indent2())
         }
@@ -285,7 +285,7 @@ pub fn run_diff(
     right: Option<&Path>,
     left_source: Option<&str>,
     right_source: Option<&str>,
-    dialect: &str,
+    dialect: Option<&str>,
     show: &[String],
     json_out: bool,
     output: Option<&Path>,
@@ -319,6 +319,12 @@ pub fn run_diff(
     let left_src = combine_sources(&left_docs);
     let right_src = combine_sources(&right_docs);
 
+    // One dialect for the whole comparison — both sides are rendered through
+    // the same pipeline, so a per-side dialect would diff two different
+    // pipelines rather than two sources. Detected from the left-hand (baseline)
+    // input unless `--dialect` names one.
+    let dialect = combined_effective_dialect(&left_docs, dialect);
+    let dialect = dialect.as_str();
     let registry = registry_for_dialect(dialect);
     let left_index = LineIndex::new(&left_src);
     let right_index = LineIndex::new(&right_src);
@@ -430,7 +436,7 @@ mod tests {
             None,
             Some("set x 1"),
             Some("set x 2"),
-            "tcl8.6",
+            Some("tcl8.6"),
             &show,
             true,
             None,
@@ -443,7 +449,7 @@ mod tests {
             None,
             None,
             Some("set x 2"),
-            "tcl8.6",
+            Some("tcl8.6"),
             &show,
             true,
             None,

--- a/rust/tcl-cli/src/commands/explore.rs
+++ b/rust/tcl-cli/src/commands/explore.rs
@@ -26,7 +26,8 @@
 use serde_json::Value;
 
 use tcl_cli_support::{
-    OutputTarget, combine_sources, read_input_documents, resolve_use_colour, write_text_output,
+    OutputTarget, combine_sources, combined_effective_dialect, read_input_documents,
+    resolve_use_colour, write_text_output,
 };
 
 use crate::cli::{ColourArgs, InputArgs};
@@ -41,13 +42,14 @@ pub fn run_explore(
     colour: &ColourArgs,
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
 
     if tui {
-        return run_tui(&source, input.dialect_or_default());
+        return run_tui(&source, &dialect);
     }
 
-    let result = tcl_explorer::run_pipeline(&source, input.dialect_or_default());
+    let result = tcl_explorer::run_pipeline(&source, &dialect);
     let value = tcl_explorer::serialise_result(&result);
 
     let target = OutputTarget::from_arg(input.output.as_deref());

--- a/rust/tcl-cli/src/commands/graphs.rs
+++ b/rust/tcl-cli/src/commands/graphs.rs
@@ -32,8 +32,8 @@
 use serde::Serialize;
 use serde_json::{Value, json};
 use tcl_cli_support::{
-    OutputTarget, combine_sources, ensure_ascii, read_input_documents, registry_for_dialect,
-    write_text_output,
+    OutputTarget, combine_sources, combined_effective_dialect, ensure_ascii, read_input_documents,
+    registry_for_dialect, write_text_output,
 };
 use tcl_compiler::analyser::{Analyser, ProcDef, Scope, ScopeKind, VarDef};
 use tcl_lexer::LineIndex;
@@ -189,8 +189,9 @@ fn collect_scope_entries(
 /// iRules `when` events) across the combined input.
 pub fn run_symbols(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
-    let result = Analyser::new().analyse(&source, input.dialect_or_default());
+    let result = Analyser::new().analyse(&source, &dialect);
     let line_index = LineIndex::new(&source);
 
     let mut entries = detect_event_entries(&source, &line_index);
@@ -201,7 +202,7 @@ pub fn run_symbols(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     if json {
         let payload = SymbolsPayload {
             count: entries.len(),
-            dialect: input.dialect_or_default().to_string(),
+            dialect: dialect.clone(),
             inputs: documents.iter().map(|d| d.label.clone()).collect(),
             symbols: entries,
         };
@@ -301,8 +302,9 @@ fn append_symbolgraph_scope(lines: &mut Vec<String>, scope: &Value, depth: usize
 /// `tcl symbolgraph` — scope hierarchy with proc/variable references.
 pub fn run_symbolgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
-    let data = graphs::symbol_graph(&source, input.dialect_or_default());
+    let data = graphs::symbol_graph(&source, &dialect);
 
     let summary = data.get("summary").cloned().unwrap_or_else(|| json!({}));
     let count = |key: &str| summary.get(key).and_then(Value::as_i64).unwrap_or(0);
@@ -337,9 +339,10 @@ pub fn run_symbolgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> 
 #[allow(clippy::similar_names)] // caller / callee mirror the domain
 pub fn run_callgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(input.dialect_or_default());
-    let data = graphs::call_graph(&source, registry, input.dialect_or_default());
+    let registry = registry_for_dialect(&dialect);
+    let data = graphs::call_graph(&source, registry, &dialect);
 
     let target = OutputTarget::from_arg(input.output.as_deref());
 
@@ -425,9 +428,10 @@ pub fn run_callgraph(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
 /// side-effect classification.
 pub fn run_dataflow(input: &InputArgs, json_out: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(input.dialect_or_default());
-    let data = graphs::dataflow_graph(&source, registry, input.dialect_or_default());
+    let registry = registry_for_dialect(&dialect);
+    let data = graphs::dataflow_graph(&source, registry, &dialect);
 
     let target = OutputTarget::from_arg(input.output.as_deref());
 

--- a/rust/tcl-cli/src/commands/highlight.rs
+++ b/rust/tcl-cli/src/commands/highlight.rs
@@ -24,8 +24,8 @@
 //! is the order for this verb specifically.
 
 use tcl_cli_support::{
-    OutputTarget, combine_sources, expand_tabs, highlight_ansi, highlight_html,
-    read_input_documents, resolve_use_colour, write_text_output,
+    OutputTarget, combine_sources, combined_effective_dialect, expand_tabs, highlight_ansi,
+    highlight_html, read_input_documents, resolve_use_colour, write_text_output,
 };
 
 use crate::cli::{ColourArgs, InputArgs};
@@ -36,13 +36,14 @@ const DEFAULT_TAB_WIDTH: usize = 4;
 /// `tcl highlight` — emit syntax-highlighted source (ANSI or HTML).
 pub fn run_highlight(input: &InputArgs, format: &str, colour: &ColourArgs) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
     let target = OutputTarget::from_arg(input.output.as_deref());
 
     let mut out = if format == "html" {
-        highlight_html(&source, input.dialect_or_default())
+        highlight_html(&source, &dialect)
     } else if resolve_use_colour(colour.colour, colour.no_colour, &target) {
-        highlight_ansi(&source, input.dialect_or_default())
+        highlight_ansi(&source, &dialect)
     } else {
         source
     };

--- a/rust/tcl-cli/src/commands/minimize.rs
+++ b/rust/tcl-cli/src/commands/minimize.rs
@@ -369,7 +369,10 @@ pub fn run_minimize(input: &InputArgs, no_rename: bool, json: bool) -> anyhow::R
 
     let mut results: Vec<MinimizeItem> = Vec::new();
     for document in &documents {
-        match minimize_diagnostic(&document.source, code, rename, input.dialect_or_default()) {
+        // Per document, like `diag`: the reproducer is reduced under the same
+        // dialect the diagnostic was reported under.
+        let dialect = document.effective_dialect(input.dialect.as_deref());
+        match minimize_diagnostic(&document.source, code, rename, &dialect) {
             Ok(r) => results.push(MinimizeItem {
                 file: document.label.clone(),
                 code: r.code,

--- a/rust/tcl-cli/src/commands/misc.rs
+++ b/rust/tcl-cli/src/commands/misc.rs
@@ -34,7 +34,9 @@
 //! used to carry byte-identical copies of the same 6 codes and hint strings.
 
 use serde::Serialize;
-use tcl_cli_support::{OutputTarget, combine_sources, ensure_ascii, read_input_documents};
+use tcl_cli_support::{
+    OutputTarget, combine_sources, combined_effective_dialect, ensure_ascii, read_input_documents,
+};
 use tcl_compiler::analyser::Analyser;
 use tcl_lexer::LineIndex;
 
@@ -82,9 +84,10 @@ struct LegacyPayload {
 /// `tcl find-legacy` — report legacy patterns eligible for modernisation.
 pub fn run_find_legacy(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
 
-    let result = Analyser::new().analyse(&source, input.dialect_or_default());
+    let result = Analyser::new().analyse(&source, &dialect);
     let line_index = LineIndex::new(&source);
 
     let issues: Vec<LegacyIssue> = result
@@ -108,7 +111,7 @@ pub fn run_find_legacy(input: &InputArgs, json: bool) -> anyhow::Result<u8> {
     if json {
         let payload = LegacyPayload {
             count: issues.len(),
-            dialect: input.dialect_or_default().to_string(),
+            dialect: dialect.clone(),
             issues,
         };
         let rendered = ensure_ascii(&serde_json::to_string_pretty(&payload)?);

--- a/rust/tcl-cli/src/commands/transform.rs
+++ b/rust/tcl-cli/src/commands/transform.rs
@@ -24,8 +24,8 @@ use std::path::Path;
 
 use anyhow::Context;
 use tcl_cli_support::{
-    OutputTarget, combine_sources, read_input_documents, registry_for_dialect,
-    write_highlighted_output, write_text_output,
+    OutputTarget, combine_sources, combined_effective_dialect, read_input_documents,
+    registry_for_dialect, write_highlighted_output, write_text_output,
 };
 use tcl_lsp_core::formatting::{FormatterConfig, IndentStyle, formatting_with};
 use tcl_lsp_core::minify::{
@@ -52,13 +52,14 @@ pub fn run_format(
     colour: &ColourArgs,
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(input.dialect_or_default());
+    let registry = registry_for_dialect(&dialect);
 
     let mut config = FormatterConfig {
         // Tokenise with the dialect's rules so, e.g., an iRule's `}{` (valid in
         // TMM) parses as two words and is re-emitted as `} {`.
-        lexer_config: tcl_lexer::LexerConfig::for_dialect(input.dialect_or_default()),
+        lexer_config: tcl_lexer::LexerConfig::for_dialect(&dialect),
         ..Default::default()
     };
     if let Some(size) = indent_size {
@@ -85,13 +86,7 @@ pub fn run_format(
 
     let target = OutputTarget::from_arg(input.output.as_deref());
     let use_colour = tcl_cli_support::resolve_use_colour(colour.colour, colour.no_colour, &target);
-    write_highlighted_output(
-        &target,
-        &formatted,
-        use_colour,
-        DEFAULT_TAB_WIDTH,
-        input.dialect_or_default(),
-    )?;
+    write_highlighted_output(&target, &formatted, use_colour, DEFAULT_TAB_WIDTH, &dialect)?;
     Ok(0)
 }
 
@@ -107,9 +102,9 @@ pub fn run_opt(
     colour: &ColourArgs,
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(input.dialect_or_default());
-    let dialect = Some(input.dialect_or_default());
+    let registry = registry_for_dialect(&dialect);
 
     let profile = OptimisationProfile::parse(profile);
     let mut disabled: HashSet<String> = profile_to_disabled(profile)
@@ -139,7 +134,7 @@ pub fn run_opt(
     let (optimised, optimisations, _iterations) = optimise_source_multipass_filtered(
         &source,
         registry,
-        dialect,
+        Some(dialect.as_str()),
         profile.max_iterations(),
         &disabled,
     );
@@ -163,13 +158,7 @@ pub fn run_opt(
     }
 
     let use_colour = tcl_cli_support::resolve_use_colour(colour.colour, colour.no_colour, &target);
-    write_highlighted_output(
-        &target,
-        &rendered,
-        use_colour,
-        DEFAULT_TAB_WIDTH,
-        input.dialect_or_default(),
-    )?;
+    write_highlighted_output(&target, &rendered, use_colour, DEFAULT_TAB_WIDTH, &dialect)?;
 
     if !target.is_stdout() {
         eprintln!(
@@ -191,33 +180,24 @@ pub fn run_minify(
     colour: &ColourArgs,
 ) -> anyhow::Result<u8> {
     let documents = read_input_documents(&input.inputs, &input.source, !input.no_recursive)?;
+    let dialect = combined_effective_dialect(&documents, input.dialect.as_deref());
     let source = combine_sources(&documents);
-    let registry = registry_for_dialect(input.dialect_or_default());
+    let registry = registry_for_dialect(&dialect);
 
     let target = OutputTarget::from_arg(input.output.as_deref());
     let use_colour = tcl_cli_support::resolve_use_colour(colour.colour, colour.no_colour, &target);
 
     let (rendered, map) = if aggressive {
-        let result = minify_tcl_aggressive(&source, input.dialect_or_default(), isolated, registry);
+        let result = minify_tcl_aggressive(&source, &dialect, isolated, registry);
         (result.source, Some(result.symbol_map))
     } else if compact {
-        let (minified, sm) =
-            minify_tcl_compact(&source, input.dialect_or_default(), isolated, registry);
+        let (minified, sm) = minify_tcl_compact(&source, &dialect, isolated, registry);
         (minified, Some(sm))
     } else {
-        (
-            minify_tcl(&source, input.dialect_or_default(), registry),
-            None,
-        )
+        (minify_tcl(&source, &dialect, registry), None)
     };
 
-    write_highlighted_output(
-        &target,
-        &rendered,
-        use_colour,
-        DEFAULT_TAB_WIDTH,
-        input.dialect_or_default(),
-    )?;
+    write_highlighted_output(&target, &rendered, use_colour, DEFAULT_TAB_WIDTH, &dialect)?;
 
     if let Some(path) = symbol_map {
         // Always honour `--symbol-map FILE`, even for plain minify (which does

--- a/rust/tcl-cli/src/lib.rs
+++ b/rust/tcl-cli/src/lib.rs
@@ -129,7 +129,7 @@ fn dispatch(command: &Command) -> anyhow::Result<u8> {
             right.as_deref(),
             left_source.as_deref(),
             right_source.as_deref(),
-            dialect,
+            dialect.as_deref(),
             show,
             *json,
             output.as_deref(),

--- a/rust/tcl-cli/tests/cli.rs
+++ b/rust/tcl-cli/tests/cli.rs
@@ -205,6 +205,51 @@ fn diag_shares_call_sites_across_inputs() {
     );
 }
 
+/// Issue #1048: the transform verbs auto-detect a document's dialect, so an
+/// iRule folds the same with and without an explicit `--dialect`.
+///
+/// Before the fix `dialect_or_default()` returned `tcl8.6` whenever the flag
+/// was absent, so the optimiser ran the file as plain Tcl: `contains` was not
+/// an operator, the condition never folded, and no `O101` was reported.
+#[test]
+fn opt_detects_the_irules_dialect_without_the_flag() {
+    let input = fixtures_dir().join("wordOperator.irule");
+    let detected =
+        String::from_utf8(run_tcl(&["opt", input.to_str().unwrap()])).expect("utf-8 output");
+    let explicit = String::from_utf8(run_tcl(&[
+        "opt",
+        "--dialect",
+        "f5-irules",
+        input.to_str().unwrap(),
+    ]))
+    .expect("utf-8 output");
+    assert!(
+        detected.contains("if {1}") && detected.contains("O101"),
+        "the detected dialect must fold the word-operator condition: {detected}"
+    );
+    assert_eq!(
+        detected, explicit,
+        "detection must produce exactly what --dialect f5-irules produces"
+    );
+}
+
+/// The control for [`opt_detects_the_irules_dialect_without_the_flag`]: the
+/// same condition in plain Tcl source stays plain Tcl, where `contains` is not
+/// an operator and nothing folds.
+#[test]
+fn opt_leaves_a_word_operator_alone_in_plain_tcl() {
+    let out = String::from_utf8(run_tcl(&[
+        "opt",
+        "--source",
+        "set x \"abcdef\"\nif {$x contains \"cd\"} { puts hit }",
+    ]))
+    .expect("utf-8 output");
+    assert!(
+        !out.contains("if {1}"),
+        "plain Tcl has no `contains` operator, so the condition must not fold: {out}"
+    );
+}
+
 /// Like [`run_tcl`] but tolerates a non-zero exit — `diag` returns 1 whenever
 /// it reports a problem-severity finding, which is not a harness failure.
 fn run_tcl_allow_failure(args: &[&str]) -> Vec<u8> {

--- a/rust/tcl-cli/tests/compile_verbs.rs
+++ b/rust/tcl-cli/tests/compile_verbs.rs
@@ -70,6 +70,50 @@ fn dis_optimise_folds_constants() {
     );
 }
 
+/// Issue #1048 review follow-up: the compile verbs thread the resolved dialect
+/// into lowering, not just registry selection. An auto-detected iRule's
+/// word-operator condition must reach codegen as a real comparison node and
+/// disassemble to its dedicated opcode — dialect-blind lowering left it an
+/// opaque raw expression on the generic runtime-`expr` path.
+#[test]
+fn dis_lowers_word_operators_for_the_detected_dialect() {
+    let input =
+        std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join("tests/fixtures/wordOperator.irule");
+    let detected = String::from_utf8(run_tcl(&["dis", input.to_str().unwrap()])).expect("utf-8");
+    assert!(
+        detected.contains("iruleContains"),
+        "expected the contains word-operator opcode in:\n{detected}"
+    );
+    let explicit = String::from_utf8(run_tcl(&[
+        "dis",
+        "--dialect",
+        "f5-irules",
+        input.to_str().unwrap(),
+    ]))
+    .expect("utf-8");
+    assert_eq!(
+        detected, explicit,
+        "detection must disassemble exactly as --dialect f5-irules does"
+    );
+}
+
+/// The control for [`dis_lowers_word_operators_for_the_detected_dialect`]: the
+/// same condition in plain Tcl source has no word operators, so no iRules
+/// opcode may appear.
+#[test]
+fn dis_keeps_plain_tcl_free_of_irules_opcodes() {
+    let out = run_tcl(&[
+        "dis",
+        "--source",
+        "set x \"abcdef\"\nif {$x eq \"cd\"} { puts hit }\n",
+    ]);
+    let text = String::from_utf8(out).expect("utf-8");
+    assert!(
+        !text.contains("irule"),
+        "plain Tcl must not emit iRules opcodes:\n{text}"
+    );
+}
+
 #[test]
 fn compwasm_emits_valid_module_header() {
     let dir = std::env::temp_dir().join("tcl_compwasm_test");

--- a/rust/tcl-cli/tests/fixtures/wordOperator.irule
+++ b/rust/tcl-cli/tests/fixtures/wordOperator.irule
@@ -1,0 +1,4 @@
+when HTTP_REQUEST {
+    set x "abcdef"
+    if {$x contains "cd"} { HTTP::respond 200 }
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -159,8 +159,17 @@ impl Analyser {
         // `catch_unwind` cannot contain a SIGABRT.)
         let _ = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
             let dialect_opt = dialect_owned.as_deref();
-            let cu = crate::compilation_unit::CompilationUnit::build_for(source, registry, false)
-                .with_interprocedural(registry, dialect_opt);
+            // Build under the analyser's own dialect, not a blind default: the
+            // lowering needs it to parse a dialect-only operator (an iRules
+            // `contains` condition) as an operator, and the lattice pipeline
+            // needs it to fold one.
+            let cu = crate::compilation_unit::CompilationUnit::build_for_dialect(
+                source,
+                registry,
+                false,
+                dialect_opt.unwrap_or_default(),
+            )
+            .with_interprocedural(registry, dialect_opt);
             self.emit_cfg_ssa_diagnostics_with_cu(&cu, registry);
         }));
     }

--- a/rust/tcl-compiler/src/analyser/diagnostics.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics.rs
@@ -163,11 +163,23 @@ impl Analyser {
             // lowering needs it to parse a dialect-only operator (an iRules
             // `contains` condition) as an operator, and the lattice pipeline
             // needs it to fold one.
-            let cu = crate::compilation_unit::CompilationUnit::build_for_dialect(
+            //
+            // The *lexer* config stays the default rather than
+            // `for_dialect(dialect)`: the hosts that supply this unit through
+            // the `cu_override` seam (`tcl diag`'s `collect_rows`,
+            // `tcl_lsp_db::file_analysis_incremental`) build it with the
+            // default config, and the supplied unit must be the one this
+            // branch would have built. Changing it here would make an iRules
+            // document's diagnostics depend on which path built the unit.
+            let cu = crate::compilation_unit::CompilationUnit::build_with_options(
                 source,
-                registry,
-                false,
-                dialect_opt.unwrap_or_default(),
+                crate::compilation_unit::UnitBuildOptions {
+                    registry,
+                    defer_top_level: false,
+                    config: tcl_lexer::LexerConfig::default(),
+                    dialect: dialect_opt.unwrap_or_default(),
+                    external_call_sites: None,
+                },
             )
             .with_interprocedural(registry, dialect_opt);
             self.emit_cfg_ssa_diagnostics_with_cu(&cu, registry);

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -37,7 +37,6 @@ use crate::cfg_builder::build_cfg;
 use crate::def_use::{DefUseResult, build_def_use_chains};
 use crate::interprocedural::InterproceduralAnalysis;
 use crate::ir::Module as IrModule;
-use crate::lowering::lower_to_ir_with_config;
 use crate::memory_ssa::{MemorySsaFunction, build_memory_ssa};
 use crate::rendered_properties::{RenderedValueProps, propagate_rendered_props};
 use crate::sccp::{SccpResult, sccp_with_extra_escaping};
@@ -717,10 +716,19 @@ fn lower_and_build_cfg(
 ) -> (IrModule, CfgModule) {
     let registry = options.registry;
     let mut ir_module = match body_cache {
-        Some(bc) => {
-            crate::lowering::lower_to_ir_with_body_cache(source, registry, options.config, bc)
-        }
-        None => lower_to_ir_with_config(source, registry, options.config),
+        Some(bc) => crate::lowering::lower_to_ir_with_body_cache(
+            source,
+            registry,
+            options.config,
+            options.dialect,
+            bc,
+        ),
+        None => crate::lowering::lower_to_ir_with_dialect(
+            source,
+            registry,
+            options.config,
+            options.dialect,
+        ),
     };
     // Specialise Option-shape factories before any other
     // module-level passes so the synthesised child procs
@@ -941,8 +949,13 @@ impl CompilationUnit {
     /// top-level `foreach` / `catch` / `try` are compiled as
     /// opaque calls.
     ///
-    /// Lowers with the default (Tcl-8.5+) lexer config; use
-    /// [`Self::build_for_with_config`] to honour a document's dialect.
+    /// **Dialect-blind**: lowers with the default (Tcl-8.5+) lexer config and
+    /// an empty [`UnitBuildOptions::dialect`], so word tokenisation, the
+    /// expression grammar, and the fold policy are all plain Tcl.  Use it only
+    /// where the document genuinely has no dialect (tests, dialect-agnostic
+    /// helpers); a caller that knows the dialect must use
+    /// [`Self::build_for_dialect`], or an iRules word operator will neither
+    /// fold nor draw a constant-condition diagnostic.
     #[must_use]
     pub fn build_for(source: &str, registry: &CommandRegistry, defer_top_level: bool) -> Self {
         Self::build_for_with_config(
@@ -956,6 +969,12 @@ impl CompilationUnit {
     /// Like [`Self::build_for`] but lowers with an explicit dialect
     /// [`tcl_lexer::LexerConfig`] so `{*}` / `}{` tokenisation follows the
     /// document's dialect.
+    ///
+    /// The *analysis* dialect is still empty — this only fixes word
+    /// tokenisation.  Prefer [`Self::build_for_dialect`], which derives the
+    /// same config from the dialect name and additionally gives the lowering
+    /// and the lattice pipeline that dialect's expression grammar and fold
+    /// policy.
     #[must_use]
     pub fn build_for_with_config(
         source: &str,
@@ -970,6 +989,39 @@ impl CompilationUnit {
                 defer_top_level,
                 config,
                 dialect: "",
+                external_call_sites: None,
+            },
+            None,
+            None,
+        )
+    }
+
+    /// Build for a document whose dialect is known — the entry point every
+    /// production consumer holding a dialect string should use.
+    ///
+    /// Derives the lexer config from `dialect`
+    /// ([`tcl_lexer::LexerConfig::for_dialect`]) *and* records the dialect in
+    /// [`UnitBuildOptions::dialect`], so all three dialect-sensitive layers
+    /// agree: word tokenisation, the expression grammar the lowering parses
+    /// conditions with, and the fold policy the lattice pipeline runs under.
+    /// Pass `""` for plain Tcl.
+    ///
+    /// `registry` must be the registry for the same dialect
+    /// ([`tcl_registry::registry_for_dialect`]).
+    #[must_use]
+    pub fn build_for_dialect(
+        source: &str,
+        registry: &CommandRegistry,
+        defer_top_level: bool,
+        dialect: &str,
+    ) -> Self {
+        Self::build_with(
+            source,
+            UnitBuildOptions {
+                registry,
+                defer_top_level,
+                config: tcl_lexer::LexerConfig::for_dialect(dialect),
+                dialect,
                 external_call_sites: None,
             },
             None,
@@ -1682,7 +1734,8 @@ mod tests {
         let src = "namespace eval ::a { proc x {p1} { set q $p1 } }
                    namespace eval ::b { proc x {p2 extra} { set q $p2 } }
 ";
-        let m = lower_to_ir_with_config(src, &reg, tcl_lexer::LexerConfig::default());
+        let m =
+            crate::lowering::lower_to_ir_with_config(src, &reg, tcl_lexer::LexerConfig::default());
         let (_, proc_params, _) = crate::cfg_builder::prepare_cfg_context(&m);
         // `::b::x` sorts after `::a::x`, so the short name `x` deterministically
         // resolves to `::b::x`'s parameters on every run.

--- a/rust/tcl-compiler/src/lowering/hooks/control.rs
+++ b/rust/tcl-compiler/src/lowering/hooks/control.rs
@@ -67,7 +67,7 @@ pub fn try_lower_expr(cmd: &LoweringCommand<'_>) -> Option<Statement> {
     ) {
         return None;
     }
-    let expr = parse_expr(&cmd.args[0], None);
+    let expr = parse_expr(&cmd.args[0], cmd.dialect);
     // Anchor the expression text absolutely when the arg word's content is
     // a verbatim source slice (see `word_content_base`) so consumers can map
     // expression-AST leaf offsets to source operand spans.
@@ -129,7 +129,7 @@ pub fn try_lower_return(cmd: &LoweringCommand<'_>, aliases: &CommandAliasMap) ->
                     .unwrap_or(&cmd.args[0]);
                 let alias_names = expr_alias_names(aliases);
                 if let Some((expr_arg, _)) = extract_single_expr_arg(inner, &alias_names) {
-                    expr = Some(parse_expr(&expr_arg, None));
+                    expr = Some(parse_expr(&expr_arg, cmd.dialect));
                 }
             }
             _ => {}
@@ -310,6 +310,7 @@ mod tests {
             expand_word: expand,
             tokens: None,
             arg_kinds: kinds,
+            dialect: None,
         }
     }
 

--- a/rust/tcl-compiler/src/lowering/hooks/incr.rs
+++ b/rust/tcl-compiler/src/lowering/hooks/incr.rs
@@ -166,6 +166,7 @@ mod tests {
             expand_word: expand,
             tokens: None,
             arg_kinds: kinds,
+            dialect: None,
         }
     }
 

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -661,6 +661,15 @@ pub struct Lowerer<'r> {
     /// `LexerConfig::default()`; production callers thread the active
     /// dialect via [`Lowerer::with_config`] / [`lower_to_ir_with_config`].
     config: tcl_lexer::LexerConfig,
+    /// The document's analysis dialect (`None` for plain Tcl), threaded into
+    /// every `expr` / condition parse so a dialect-only operator — an iRules
+    /// word operator such as `contains` or `starts_with` — is parsed as that
+    /// operator instead of degrading to
+    /// [`crate::expr_ast::ExprNode::Raw`], which no downstream fold can
+    /// evaluate.  Separate from `config`: the lexer config carries the
+    /// dialect's *word* tokenisation, this carries its *expression* grammar.
+    /// Set by [`Lowerer::with_dialect`] / [`lower_to_ir_with_dialect`].
+    dialect: Option<&'r str>,
     /// Which lowering pass this instance performs — folds what would
     /// otherwise be two related bool fields (`for_bytecode`, `trace_visible`)
     /// into one three-state enum (`clippy::struct_excessive_bools`); see
@@ -720,10 +729,20 @@ impl<'r> Lowerer<'r> {
             dead_code_depth: 0,
             suppress_proc_register: false,
             config,
+            dialect: None,
             target: CompileTarget::Analysis,
             body_cache: None,
             nest_depth: 0,
         }
+    }
+
+    /// Set the document's analysis dialect (see [`Lowerer::dialect`]).  An
+    /// empty `dialect` means plain Tcl, matching
+    /// [`crate::compilation_unit::UnitBuildOptions::dialect`].
+    #[must_use]
+    pub fn with_dialect(mut self, dialect: &'r str) -> Self {
+        self.dialect = (!dialect.is_empty()).then_some(dialect);
+        self
     }
 
     /// Install a memoised per-procedure body-lowering callback (see
@@ -1279,6 +1298,7 @@ impl<'r> Lowerer<'r> {
             expand_word: seg.expand_word.as_deref(),
             tokens: Some(Self::cmd_tokens(seg)),
             arg_kinds: &Self::arg_kinds(seg),
+            dialect: self.dialect,
         };
         if let Some(stmt) = try_lower_hook(&hook_cmd, &self.aliases, self.registry) {
             return Some(stmt);
@@ -2479,8 +2499,8 @@ impl<'r> Lowerer<'r> {
 /// Lower Tcl source to an IR module.
 ///
 /// This is the main entry point for the lowering phase.  Lexes with the
-/// default (Tcl-8.5+) config; use [`lower_to_ir_with_config`] to honour a
-/// document's dialect.
+/// default (Tcl-8.5+) config and parses expressions in the plain-Tcl grammar;
+/// use [`lower_to_ir_with_dialect`] to honour a document's dialect.
 #[must_use]
 pub fn lower_to_ir(source: &str, registry: &CommandRegistry) -> Module {
     lower_to_ir_with_config(source, registry, tcl_lexer::LexerConfig::default())
@@ -2504,8 +2524,9 @@ pub fn lower_proc_body_isolated(
     namespace: &str,
     registry: &CommandRegistry,
     config: tcl_lexer::LexerConfig,
+    dialect: &str,
 ) -> Script {
-    let mut lowerer = Lowerer::with_config(registry, config);
+    let mut lowerer = Lowerer::with_config(registry, config).with_dialect(dialect);
     lowerer.proc_depth += 1;
     lowerer.const_map_stack.push(HashMap::new());
     let body = lowerer.lower_body(body_text, 0, namespace);
@@ -2667,8 +2688,8 @@ mod body_cache_eligible_tests {
         let reg = CommandRegistry::build_default();
         let cfg = tcl_lexer::LexerConfig::default();
         let src = "interp alias {} = {} expr\nproc f {x} { return [= {$x + 1}] }\n";
-        let cache = |body: &str, ns: &str| lower_proc_body_isolated(body, ns, &reg, cfg);
-        let cached = lower_to_ir_with_body_cache(src, &reg, cfg, &cache);
+        let cache = |body: &str, ns: &str| lower_proc_body_isolated(body, ns, &reg, cfg, "");
+        let cached = lower_to_ir_with_body_cache(src, &reg, cfg, "", &cache);
         let fresh = lower_to_ir_with_config(src, &reg, cfg);
         assert_ne!(
             format!("{cached:?}"),
@@ -2705,8 +2726,8 @@ mod body_cache_eligible_tests {
         let reg = CommandRegistry::build_default();
         let cfg = tcl_lexer::LexerConfig::default();
         let src = "rename puts myputs\nproc f {x} { myputs $x }\n";
-        let cache = |body: &str, ns: &str| lower_proc_body_isolated(body, ns, &reg, cfg);
-        let cached = lower_to_ir_with_body_cache(src, &reg, cfg, &cache);
+        let cache = |body: &str, ns: &str| lower_proc_body_isolated(body, ns, &reg, cfg, "");
+        let cached = lower_to_ir_with_body_cache(src, &reg, cfg, "", &cache);
         let fresh = lower_to_ir_with_config(src, &reg, cfg);
         assert_ne!(
             format!("{cached:?}"),
@@ -2716,21 +2737,28 @@ mod body_cache_eligible_tests {
     }
 }
 
-/// Like [`lower_to_ir_with_config`] but with a memoised per-procedure body-lowering
+/// Like [`lower_to_ir_with_dialect`] but with a memoised per-procedure body-lowering
 /// callback (SRV-INCREMENTAL Task 3): a top-level `proc`'s static body is lowered
 /// through `body_cache` `(offset-0 body text, namespace) -> offset-0 Script` and
 /// rebased, so an unchanged proc's body IR is reused across edits.  The caller must
 /// only install a cache for **context-free** files (see [`Lowerer::body_cache`]);
 /// byte-identity is guarded by the corpus differential gates.
+///
+/// The cached bodies must be produced by [`lower_proc_body_isolated`] under the
+/// **same** `dialect`, since the dialect selects the expression grammar the
+/// body's conditions are parsed with.
 #[must_use]
 pub fn lower_to_ir_with_body_cache(
     source: &str,
     registry: &CommandRegistry,
     config: tcl_lexer::LexerConfig,
+    dialect: &str,
     body_cache: &dyn Fn(&str, &str) -> Script,
 ) -> Module {
     lower_with(
-        Lowerer::with_config(registry, config).with_body_cache(body_cache),
+        Lowerer::with_config(registry, config)
+            .with_dialect(dialect)
+            .with_body_cache(body_cache),
         source,
     )
 }
@@ -2739,6 +2767,10 @@ pub fn lower_to_ir_with_body_cache(
 /// [`tcl_lexer::LexerConfig`], threaded into every body re-segmentation
 /// so `{*}` expansion (off for Tcl 8.4 / iRules) and the iRules `}{`
 /// ghost SEP are honoured.
+///
+/// Expressions are still parsed in the plain-Tcl grammar — a caller that
+/// knows the dialect *name* should use [`lower_to_ir_with_dialect`], which
+/// also gives `if` / `while` / `for` / `expr` the dialect's operator set.
 #[must_use]
 pub fn lower_to_ir_with_config(
     source: &str,
@@ -2746,6 +2778,29 @@ pub fn lower_to_ir_with_config(
     config: tcl_lexer::LexerConfig,
 ) -> Module {
     lower_with(Lowerer::with_config(registry, config), source)
+}
+
+/// Like [`lower_to_ir_with_config`] but also naming the document's analysis
+/// `dialect` (`""` for plain Tcl), so every `if` / `while` / `for` condition
+/// and every inlined `expr` is parsed with that dialect's operator set.
+///
+/// This is what makes an iRules word-operator condition — `if {$x contains
+/// "cd"}` — reach the IR as a real
+/// [`BinOp::Contains`](crate::expr_ast::BinOp::Contains) comparison instead of
+/// an opaque [`ExprNode::Raw`](crate::expr_ast::ExprNode::Raw), which is the
+/// only shape the constant folder (and the I230 constant-condition
+/// diagnostic behind it) can evaluate.
+#[must_use]
+pub fn lower_to_ir_with_dialect(
+    source: &str,
+    registry: &CommandRegistry,
+    config: tcl_lexer::LexerConfig,
+    dialect: &str,
+) -> Module {
+    lower_with(
+        Lowerer::with_config(registry, config).with_dialect(dialect),
+        source,
+    )
 }
 
 /// Like [`lower_to_ir`] but for the bytecode/VM compile path: constructs the

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -2810,8 +2810,25 @@ pub fn lower_to_ir_with_dialect(
 /// [`lower_to_ir`].
 #[must_use]
 pub fn lower_to_ir_for_bytecode(source: &str, registry: &CommandRegistry) -> Module {
+    lower_to_ir_for_bytecode_with_dialect(source, registry, tcl_lexer::LexerConfig::default(), "")
+}
+
+/// Like [`lower_to_ir_for_bytecode`] but also naming the document's `dialect`
+/// (`""` for plain Tcl) — the bytecode-path counterpart of
+/// [`lower_to_ir_with_dialect`], so a dialect expression such as an iRules
+/// word-operator condition compiles to its dedicated opcode rather than the
+/// generic runtime-`expr` fallback.
+#[must_use]
+pub fn lower_to_ir_for_bytecode_with_dialect(
+    source: &str,
+    registry: &CommandRegistry,
+    config: tcl_lexer::LexerConfig,
+    dialect: &str,
+) -> Module {
     lower_with(
-        Lowerer::with_config(registry, tcl_lexer::LexerConfig::default()).for_bytecode_backend(),
+        Lowerer::with_config(registry, config)
+            .with_dialect(dialect)
+            .for_bytecode_backend(),
         source,
     )
 }

--- a/rust/tcl-compiler/src/lowering/structured.rs
+++ b/rust/tcl-compiler/src/lowering/structured.rs
@@ -276,7 +276,7 @@ impl Lowerer<'_> {
             let cond_single = arg_single.get(cond_idx).copied().unwrap_or(false);
             let cond_text = condition_source_text(cond_tok, cond_single, &args[cond_idx]);
             clauses.push(IfClause {
-                condition: parse_expr(&cond_text, None),
+                condition: parse_expr(&cond_text, self.dialect),
                 condition_span: cond_tok.map_or(seg.span, |t| t.span),
                 condition_base: cond_tok
                     .and_then(|t| word_content_base(t.span, cond_single, &cond_text)),
@@ -346,7 +346,7 @@ impl Lowerer<'_> {
             init_span: arg_tokens[0].span,
             condition: parse_expr(
                 &condition_source_text(arg_tokens.get(1), arg_single[1], &args[1]),
-                None,
+                self.dialect,
             ),
             condition_span: arg_tokens[1].span,
             condition_base: word_content_base(
@@ -391,7 +391,7 @@ impl Lowerer<'_> {
             span: seg.span,
             condition: parse_expr(
                 &condition_source_text(arg_tokens.first(), arg_single[0], &args[0]),
-                None,
+                self.dialect,
             ),
             condition_span: arg_tokens[0].span,
             condition_base: word_content_base(

--- a/rust/tcl-compiler/src/lowering_hooks.rs
+++ b/rust/tcl-compiler/src/lowering_hooks.rs
@@ -56,6 +56,15 @@ pub struct LoweringCommand<'a> {
     /// Per-arg token kinds.
     /// Uses a simplified enum since we only check STR/ESC/CMD.
     pub arg_kinds: &'a [ArgTokenKind],
+    /// The document's analysis dialect, or `None` for plain Tcl.
+    ///
+    /// Threaded into [`crate::expr_parser::parse_expr`] by the hooks that
+    /// parse an expression (`expr`, `return [expr …]`, `set x [expr …]`), so
+    /// an iRules word operator (`contains`, `starts_with`, …) parses as the
+    /// operator it is rather than falling back to
+    /// [`crate::expr_ast::ExprNode::Raw`] — which no downstream fold can
+    /// evaluate.
+    pub dialect: Option<&'a str>,
 }
 
 /// Simplified token kind for hook arg inspection.
@@ -295,7 +304,7 @@ fn lower_set(cmd: &LoweringCommand<'_>, aliases: &CommandAliasMap) -> Statement 
                     .unwrap_or(value);
                 let alias_names = expr_alias_names(aliases);
                 if let Some((expr_arg, rel_base)) = extract_single_expr_arg(inner, &alias_names) {
-                    let expr = parse_expr(&expr_arg, None);
+                    let expr = parse_expr(&expr_arg, cmd.dialect);
                     // Anchor the expression text absolutely when both the
                     // `[...]` value word's content and the expr word within
                     // it are verbatim slices: absolute = the bracketed
@@ -796,6 +805,7 @@ mod tests {
             expand_word: None,
             tokens: None,
             arg_kinds: &kinds,
+            dialect: None,
         };
         let result = lower_set(&cmd, &aliases);
         assert!(
@@ -818,6 +828,7 @@ mod tests {
             expand_word: None,
             tokens: None,
             arg_kinds: &kinds,
+            dialect: None,
         };
         let result = lower_set(&cmd, &aliases);
         assert!(
@@ -839,6 +850,7 @@ mod tests {
             expand_word: None,
             tokens: None,
             arg_kinds: &kinds,
+            dialect: None,
         };
         let result = lower_upvar(&cmd);
         assert!(result.is_some());
@@ -931,6 +943,7 @@ mod tests {
             expand_word: None,
             tokens: None,
             arg_kinds: &kinds,
+            dialect: None,
         };
         let result = try_lower_hook(&cmd, &aliases, &registry);
         assert!(
@@ -957,6 +970,7 @@ mod tests {
             expand_word: None,
             tokens: None,
             arg_kinds: &kinds,
+            dialect: None,
         };
         assert!(try_lower_hook(&cmd, &aliases, &registry).is_none());
     }

--- a/rust/tcl-compiler/tests/dialect_threading.rs
+++ b/rust/tcl-compiler/tests/dialect_threading.rs
@@ -1,0 +1,212 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Dialect threading through lowering and the compilation unit (issue #1048).
+//!
+//! The document's dialect has to reach three layers before a dialect-only
+//! operator behaves like an operator: the lexer config (word tokenisation),
+//! the *expression* grammar the lowering parses conditions with, and the fold
+//! policy the lattice pipeline runs under. The lowering layer used to parse
+//! every `if` / `while` / `for` / `expr` condition with a hardcoded `None`
+//! dialect, so an iRules word operator reached the IR as an opaque
+//! `ExprNode::Raw` that no fold could evaluate — the constant-condition
+//! diagnostic (I230) could not fire even with an explicit `--dialect`.
+//!
+//! The cases below pin the four corners for I230 on a word-operator condition:
+//! it fires under `f5-irules` when the subject is constant (TP), stays silent
+//! in plain Tcl where `contains` is not an operator at all (TN), stays silent
+//! under `f5-irules` when the subject is *not* constant (FP guard), and the
+//! pre-existing plain-Tcl constant condition still fires (FN guard).
+
+use tcl_compiler::analyser::Analyser;
+use tcl_compiler::compilation_unit::CompilationUnit;
+use tcl_compiler::expr_ast::{BinOp, ExprNode};
+use tcl_compiler::ir::Statement;
+use tcl_compiler::lowering::{lower_to_ir_with_config, lower_to_ir_with_dialect};
+use tcl_registry::registry_for_dialect;
+
+const IRULES: &str = "f5-irules";
+const TCL: &str = "tcl8.6";
+
+/// A constant subject tested with an iRules word operator.
+const CONSTANT_WORD_OP: &str = "when HTTP_REQUEST {\n    set x \"abcdef\"\n    if {$x contains \"cd\"} { HTTP::respond 200 }\n}\n";
+
+/// The same shape with a non-constant right-hand side — nothing to fold.
+const DYNAMIC_WORD_OP: &str = "when HTTP_REQUEST {\n    set y [HTTP::uri]\n    set x [HTTP::host]\n    if {$x contains $y} { HTTP::respond 200 }\n}\n";
+
+/// Every analyser diagnostic code for `src` under `dialect`.
+fn codes(src: &str, dialect: &str) -> Vec<String> {
+    Analyser::new()
+        .analyse(src, dialect)
+        .diagnostics
+        .iter()
+        .map(|d| d.code.to_string())
+        .collect()
+}
+
+fn fires(src: &str, dialect: &str, code: &str) -> bool {
+    codes(src, dialect).iter().any(|c| c == code)
+}
+
+/// The condition of the first `if` clause in the first `when` handler.
+fn first_if_condition(module: &tcl_compiler::ir::Module) -> ExprNode {
+    for proc in module.procedures.values() {
+        for stmt in &proc.body.statements {
+            if let Statement::If { clauses, .. } = stmt
+                && let Some(first) = clauses.first()
+            {
+                return first.condition.clone();
+            }
+        }
+    }
+    panic!("no `if` statement lowered from the source");
+}
+
+// Lowering
+
+/// Lowering under `f5-irules` parses the word operator as the operator it is;
+/// the dialect-blind lowering degrades it to `ExprNode::Raw`, which is exactly
+/// what stopped the fold.
+#[test]
+fn lowering_parses_a_word_operator_condition_under_the_irules_dialect() {
+    let registry = registry_for_dialect(IRULES);
+    let config = tcl_lexer::LexerConfig::for_dialect(IRULES);
+
+    let with_dialect = lower_to_ir_with_dialect(CONSTANT_WORD_OP, registry, config, IRULES);
+    assert!(
+        matches!(
+            first_if_condition(&with_dialect),
+            ExprNode::Binary {
+                op: BinOp::Contains,
+                ..
+            }
+        ),
+        "an iRules `contains` condition must lower to a Contains comparison"
+    );
+
+    let dialect_blind = lower_to_ir_with_config(CONSTANT_WORD_OP, registry, config);
+    assert!(
+        matches!(first_if_condition(&dialect_blind), ExprNode::Raw { .. }),
+        "without the dialect the same condition is only an opaque Raw node"
+    );
+}
+
+/// Plain Tcl must keep treating `contains` as a function-call word, not an
+/// operator — the condition stays `Raw` there, which is what leaves W003 to
+/// report the unavailable operator.
+#[test]
+fn lowering_leaves_a_word_operator_raw_in_plain_tcl() {
+    let registry = registry_for_dialect(TCL);
+    let module = lower_to_ir_with_dialect(
+        "set x \"abcdef\"\nif {$x contains \"cd\"} { puts hit }\n",
+        registry,
+        tcl_lexer::LexerConfig::for_dialect(TCL),
+        TCL,
+    );
+    let condition = module
+        .top_level
+        .statements
+        .iter()
+        .find_map(|stmt| match stmt {
+            Statement::If { clauses, .. } => clauses.first().map(|c| c.condition.clone()),
+            _ => None,
+        })
+        .expect("an `if` statement");
+    assert!(
+        matches!(condition, ExprNode::Raw { .. }),
+        "plain Tcl has no `contains` operator, so the condition must stay Raw"
+    );
+}
+
+// The compilation unit
+
+/// `build_for_dialect` folds the constant word-operator branch; the
+/// dialect-blind `build_for` on the same source does not.
+#[test]
+fn build_for_dialect_folds_a_word_operator_branch() {
+    let registry = registry_for_dialect(IRULES);
+    let with_dialect =
+        CompilationUnit::build_for_dialect(CONSTANT_WORD_OP, registry, false, IRULES);
+    let folded: usize = with_dialect
+        .functions()
+        .map(|fu| fu.sccp.constant_branches.len())
+        .sum();
+    assert!(
+        folded > 0,
+        "the constant `contains` branch must fold under an iRules build"
+    );
+
+    let blind = CompilationUnit::build_for(CONSTANT_WORD_OP, registry, false);
+    let blind_folded: usize = blind
+        .functions()
+        .map(|fu| fu.sccp.constant_branches.len())
+        .sum();
+    assert_eq!(
+        blind_folded, 0,
+        "a dialect-blind build has no word operator to fold"
+    );
+}
+
+// I230 — TP / TN / FP / FN
+
+/// TP: a constant iRules word-operator condition draws I230 under `f5-irules`.
+#[test]
+fn i230_fires_on_a_constant_word_operator_condition_under_irules() {
+    assert!(
+        fires(CONSTANT_WORD_OP, IRULES, "I230"),
+        "codes: {:?}",
+        codes(CONSTANT_WORD_OP, IRULES)
+    );
+}
+
+/// TN: the same shape in plain Tcl draws no I230 — `contains` is not an
+/// operator there, so there is no constant condition. W003 reports the
+/// unavailable operator instead.
+#[test]
+fn i230_stays_silent_on_a_word_operator_condition_in_plain_tcl() {
+    let src = "set x \"abcdef\"\nif {$x contains \"cd\"} { puts hit }\n";
+    let found = codes(src, TCL);
+    assert!(
+        !found.iter().any(|c| c == "I230"),
+        "plain Tcl must not fold a word operator: {found:?}"
+    );
+    assert!(
+        found.iter().any(|c| c == "W003"),
+        "plain Tcl reports the unavailable operator instead: {found:?}"
+    );
+}
+
+/// FP guard: a word-operator condition on values the lattice cannot resolve
+/// must not draw I230 under `f5-irules` either — the fold has to be proven,
+/// not assumed from the operator.
+#[test]
+fn i230_stays_silent_on_a_non_constant_word_operator_condition() {
+    let found = codes(DYNAMIC_WORD_OP, IRULES);
+    assert!(
+        !found.iter().any(|c| c == "I230"),
+        "neither operand is constant, so nothing folds: {found:?}"
+    );
+}
+
+/// FN guard: the pre-existing plain-Tcl constant condition still fires, so the
+/// dialect threading did not narrow I230's ordinary reach.
+#[test]
+fn i230_still_fires_on_a_plain_tcl_constant_condition() {
+    let src = "set x 1\nif {$x == 1} { puts hit }\n";
+    assert!(fires(src, TCL, "I230"), "codes: {:?}", codes(src, TCL));
+}

--- a/rust/tcl-diagram/src/attach.rs
+++ b/rust/tcl-diagram/src/attach.rs
@@ -453,12 +453,7 @@ pub fn attach_reach(source: &str) -> AttachReach {
         return reach;
     }
     let registry = tcl_registry::registry_for_dialect("f5-irules");
-    let cu = CompilationUnit::build_for_with_config(
-        source,
-        registry,
-        false,
-        LexerConfig::for_dialect("f5-irules"),
-    );
+    let cu = CompilationUnit::build_for_dialect(source, registry, false, "f5-irules");
 
     // Each `when` handler (and any user proc) is its own frame; walk each with a
     // fresh env in source order for stable output.
@@ -491,12 +486,7 @@ pub fn proc_call_refs(source: &str) -> Vec<String> {
         return out;
     }
     let registry = tcl_registry::registry_for_dialect("f5-irules");
-    let cu = CompilationUnit::build_for_with_config(
-        source,
-        registry,
-        false,
-        LexerConfig::for_dialect("f5-irules"),
-    );
+    let cu = CompilationUnit::build_for_dialect(source, registry, false, "f5-irules");
     let mut procs: Vec<_> = cu.ir_module.procedures.values().collect();
     procs.sort_by_key(|p| p.span.start());
     for proc in procs {

--- a/rust/tcl-diagram/src/data.rs
+++ b/rust/tcl-diagram/src/data.rs
@@ -437,22 +437,19 @@ fn walk_script(
 }
 
 /// Extract structured `{events, procedures}` flow data from a source, using
-/// the caller-supplied registry to classify diagram-action commands. Lexes with
-/// the stock-Tcl preset; use [`diagram_data_with_config`] for a dialect (e.g.
-/// `f5-irules`, so an iRule's `}{` control flow is parsed correctly).
+/// the caller-supplied registry to classify diagram-action commands. Parses as
+/// plain Tcl; use [`diagram_data_for_dialect`] for a dialect (e.g. `f5-irules`,
+/// so an iRule's `}{` control flow is parsed correctly).
 #[must_use]
 pub fn diagram_data(source: &str, registry: &CommandRegistry) -> Value {
-    diagram_data_with_config(source, registry, tcl_lexer::LexerConfig::default())
+    diagram_data_for_dialect(source, registry, "")
 }
 
-/// [`diagram_data`] with an explicit lexer preset.
+/// [`diagram_data`] for an explicit dialect. `registry` must be that
+/// dialect's registry.
 #[must_use]
-pub fn diagram_data_with_config(
-    source: &str,
-    registry: &CommandRegistry,
-    config: tcl_lexer::LexerConfig,
-) -> Value {
-    let cu = CompilationUnit::build_for_with_config(source, registry, false, config);
+pub fn diagram_data_for_dialect(source: &str, registry: &CommandRegistry, dialect: &str) -> Value {
+    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect);
     let module = &cu.ir_module;
 
     // Recover the source-order dict iteration (the procedures map is a

--- a/rust/tcl-diagram/src/graph.rs
+++ b/rust/tcl-diagram/src/graph.rs
@@ -25,7 +25,7 @@
 use serde_json::Value;
 use tcl_registry::CommandRegistry;
 
-use crate::data::diagram_data_with_config;
+use crate::data::diagram_data_for_dialect;
 
 const MAX_NODES: usize = 600;
 
@@ -256,11 +256,7 @@ pub fn irule_flowchart_graph(source: &str, registry: &CommandRegistry) -> String
     // Always the iRules dialect: lex with the f5-irules preset so `if {expr}{body}`
     // (`}{` valid in TMM) forms correct control-flow branches instead of the
     // stock-Tcl mis-segmentation.
-    let data = diagram_data_with_config(
-        source,
-        registry,
-        tcl_lexer::LexerConfig::for_dialect("f5-irules"),
-    );
+    let data = diagram_data_for_dialect(source, registry, "f5-irules");
     let events = data
         .get("events")
         .and_then(Value::as_array)

--- a/rust/tcl-diagram/src/lib.rs
+++ b/rust/tcl-diagram/src/lib.rs
@@ -38,5 +38,5 @@ mod data;
 mod graph;
 
 pub use attach::{AttachPattern, AttachReach, attach_reach, irule_attach_patterns, proc_call_refs};
-pub use data::{diagram_data, diagram_data_with_config};
+pub use data::{diagram_data, diagram_data_for_dialect};
 pub use graph::irule_flowchart_graph;

--- a/rust/tcl-explorer/src/lib.rs
+++ b/rust/tcl-explorer/src/lib.rs
@@ -122,15 +122,15 @@ impl ExplorerResult {
 #[must_use]
 pub fn run_pipeline(source: &str, dialect: &str) -> ExplorerResult {
     let registry = registry_for_dialect(dialect);
-    // Tokenise with the requested dialect's lexer config so dialect-sensitive
-    // parsing is honoured: Tcl 8.4 / iRules disable `{*}` expansion, and
-    // iRules enable the `}{` brace-separator. `build_for` would otherwise use
-    // the default Tcl-8.5+ config and mis-tokenise those dialects.
-    let config = tcl_lexer::LexerConfig::for_dialect(dialect);
+    // Build for the requested dialect so every dialect-sensitive layer is
+    // honoured: Tcl 8.4 / iRules disable `{*}` expansion, iRules enable the
+    // `}{` brace-separator, and the iRules word operators (`contains`, …) are
+    // real expression operators. `build_for` would otherwise use the default
+    // Tcl-8.5+ config and plain-Tcl grammar for both.
     // Memory-SSA is built so the `dataflow` view can surface alias sets
     // (upvar / global / variable / namespace upvar). Without it the
     // `aliases` list degrades to empty.
-    let unit = CompilationUnit::build_for_with_config(source, registry, false, config)
+    let unit = CompilationUnit::build_for_dialect(source, registry, false, dialect)
         .with_interprocedural(registry, Some(dialect))
         .with_memory_ssa(registry);
 

--- a/rust/tcl-lsp-core/src/graphs.rs
+++ b/rust/tcl-lsp-core/src/graphs.rs
@@ -448,7 +448,7 @@ pub fn call_graph(source: &str, registry: &CommandRegistry, dialect: &str) -> Va
     // Build the full compilation unit (via `ensure_compilation_unit`) so the
     // interprocedural pass sees the same lowered IR — raw `lower_to_ir` alone
     // does not surface nested `[cmd …]` call sites to the call scanner.
-    let cu = CompilationUnit::build_for(source, registry, false)
+    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect)
         .with_interprocedural(registry, Some(dialect));
     let ir_module = &cu.ir_module;
     let interproc = cu
@@ -760,7 +760,7 @@ fn tainted_var_names(fu: &FunctionUnit) -> Vec<&str> {
 /// Build the dataflow / taint graph payload.
 #[must_use]
 pub fn dataflow_graph(source: &str, registry: &CommandRegistry, dialect: &str) -> Value {
-    let cu = CompilationUnit::build_for(source, registry, false)
+    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect)
         .with_interprocedural(registry, Some(dialect));
     let line_index = LineIndex::new(source);
 
@@ -935,7 +935,7 @@ pub fn def_use_graph(source: &str, registry: &CommandRegistry, dialect: &str) ->
         }
     }
 
-    let cu = CompilationUnit::build_for(source, registry, false)
+    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect)
         .with_interprocedural(registry, Some(dialect));
 
     let mut proc_names: Vec<&String> = cu.procedures.keys().collect();
@@ -1004,7 +1004,7 @@ fn memory_function_json(
 /// `variable`) with the reason and locations, plus memory-op counts.
 #[must_use]
 pub fn memory_alias_graph(source: &str, registry: &CommandRegistry, dialect: &str) -> Value {
-    let cu = CompilationUnit::build_for(source, registry, false)
+    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect)
         .with_interprocedural(registry, Some(dialect))
         .with_memory_ssa(registry);
 

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -229,8 +229,7 @@ fn collect_type_hints(
     line_index: &LineIndex,
     out: &mut Vec<InlayHint>,
 ) {
-    let config = tcl_lexer::LexerConfig::for_dialect(dialect);
-    let cu = CompilationUnit::build_for_with_config(source, registry, false, config);
+    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect);
 
     // Build a *per-function* name → display map, keyed by the function's
     // qualified name (leading `::` stripped so it matches the analyser's

--- a/rust/tcl-lsp-core/src/minify.rs
+++ b/rust/tcl-lsp-core/src/minify.rs
@@ -972,7 +972,7 @@ fn compact_names(
     let mut edits: Vec<Edit> = Vec::new();
 
     let barrier_scopes = find_barrier_scopes(&analysis, registry, isolated);
-    let rmw_targets = rmw_target_var_names(source, registry);
+    let rmw_targets = rmw_target_var_names(source, dialect, registry);
     let builtin_names: FxHashSet<&str> = registry.command_names().collect();
 
     let scope_ctx = ScopeCtx {
@@ -1321,8 +1321,12 @@ fn process_scope(ctx: ScopeCtx<'_>, scope: &Scope, scope_label: &str, out: &mut 
 /// target argument. The name compaction excludes them so it cannot rename
 /// the `set` / `$var` sites while leaving the `incr var` target untouched
 /// (which would corrupt the program).
-fn rmw_target_var_names(source: &str, registry: &CommandRegistry) -> FxHashSet<String> {
-    let cu = CompilationUnit::build_for(source, registry, false);
+fn rmw_target_var_names(
+    source: &str,
+    dialect: &str,
+    registry: &CommandRegistry,
+) -> FxHashSet<String> {
+    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect);
     let mut names = FxHashSet::default();
     let mut units: Vec<&FunctionUnit> = vec![&cu.top_level];
     units.extend(cu.procedures.values());
@@ -1869,8 +1873,7 @@ fn fold_static_substrings(
     dialect: &str,
     registry: &CommandRegistry,
 ) -> (String, usize, BTreeMap<String, String>) {
-    let cu = CompilationUnit::build_for(source, registry, false);
-    let _ = dialect;
+    let cu = CompilationUnit::build_for_dialect(source, registry, false, dialect);
     let mut edits: Vec<Edit> = Vec::new();
     let mut fold_map: BTreeMap<String, String> = BTreeMap::new();
 

--- a/rust/tcl-lsp-db/examples/cc_diff.rs
+++ b/rust/tcl-lsp-db/examples/cc_diff.rs
@@ -49,7 +49,7 @@ fn main() {
     );
     let memo = compiler_check_diagnostics(&db, file, cfg);
     let reg = db.registry(&dialect);
-    let fresh = compiler_check_diagnostics_uncached(&src, &reg, &dialect, None, None);
+    let fresh = compiler_check_diagnostics_uncached(&src, reg, &dialect, None, None);
 
     let ck = |d: &tcl_compiler::compiler_checks::Diagnostic| (d.span.start(), d.span.end(), d.code);
     let ms: BTreeSet<_> = memo.checks.iter().map(ck).collect();

--- a/rust/tcl-lsp-db/examples/stress_concurrent_analysis.rs
+++ b/rust/tcl-lsp-db/examples/stress_concurrent_analysis.rs
@@ -364,7 +364,7 @@ fn final_correctness_check(
     let fresh_tokens = tcl_lsp_core::semantic_tokens::full_with_cu_and_analysis(
         &final_text,
         &params.dialect,
-        &registry,
+        registry,
         None,
         Some(&fresh),
     );

--- a/rust/tcl-lsp-db/examples/tail_profile.rs
+++ b/rust/tcl-lsp-db/examples/tail_profile.rs
@@ -142,16 +142,16 @@ fn main() {
     let registry = db.registry(dialect);
     let cfg_lexer = tcl_lexer::LexerConfig::for_dialect(dialect);
     let build = || {
-        CompilationUnit::build_for_with_config(&src, &registry, false, cfg_lexer)
-            .with_interprocedural(&registry, Some(dialect))
+        CompilationUnit::build_for_with_config(&src, registry, false, cfg_lexer)
+            .with_interprocedural(registry, Some(dialect))
     };
     time("CompilationUnit::build_for + interproc", 3, build);
     let cu = build();
     time("run_all_checks", 3, || {
-        tcl_compiler::compiler_checks::run_all_checks(&cu, &registry, Some(dialect))
+        tcl_compiler::compiler_checks::run_all_checks(&cu, registry, Some(dialect))
     });
     time("optimise_unit", 3, || {
-        tcl_compiler::optimiser::optimise_unit(&cu, &registry, Some(dialect))
+        tcl_compiler::optimiser::optimise_unit(&cu, registry, Some(dialect))
     });
     println!("  (functions in unit: {})", cu.functions().count());
 
@@ -160,16 +160,16 @@ fn main() {
     // memo; the whole-unit interproc taint solve does not.
     println!("\n== run_all_checks phase decomposition (whole-file, no memo) ==");
     let t_gvn = time("GVN redundancy/partial/loop (per-fn)", 3, || {
-        find_redundancies_for_cu(&cu, &registry, Some(dialect)).len()
-            + find_partial_redundancies_for_cu(&cu, &registry, Some(dialect)).len()
-            + find_loop_invariants_for_cu(&cu, &registry, Some(dialect)).len()
+        find_redundancies_for_cu(&cu, registry, Some(dialect)).len()
+            + find_partial_redundancies_for_cu(&cu, registry, Some(dialect)).len()
+            + find_loop_invariants_for_cu(&cu, registry, Some(dialect)).len()
     });
     let t_shimmer = time("shimmer + thunking (per-fn)", 3, || {
-        find_shimmer_warnings_for_cu(&cu, &registry).len()
-            + find_thunking_warnings_for_cu(&cu, &registry).len()
+        find_shimmer_warnings_for_cu(&cu, registry).len()
+            + find_thunking_warnings_for_cu(&cu, registry).len()
     });
     let t_taint = time("solve_interprocedural_taints (whole-unit)", 3, || {
-        solve_interprocedural_taints(&cu, &registry, Some(dialect))
+        solve_interprocedural_taints(&cu, registry, Some(dialect))
     });
     println!(
         "  per-function (GVN+shimmer) ~ {:.0} ms  |  whole-unit taint solve ~ {:.0} ms",
@@ -198,7 +198,7 @@ fn main() {
                 &db,
                 &edited,
                 tcl_compiler::compilation_unit::UnitBuildOptions {
-                    registry: &registry,
+                    registry,
                     defer_top_level: false,
                     config: cfg_d,
                     dialect,

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -34,7 +34,7 @@
 //! tracked query is sound and avoids requiring `CommandRegistry: PartialEq`.
 
 use std::collections::{BTreeSet, HashMap, HashSet};
-use std::sync::{Arc, Mutex};
+use std::sync::Arc;
 
 use tcl_compiler::cfg_builder::build_cfg_function_with_upvars;
 use tcl_compiler::cfg_builder::global_write_info::GlobalWriteInfo;
@@ -61,7 +61,6 @@ use tcl_compiler::analyser::{
     build_class_hierarchy,
 };
 use tcl_compiler::signature_scan::types::ParamDef;
-use tcl_dialect::DialectSet;
 use tcl_lsp_core::document_symbols::DocumentSymbol;
 use tcl_lsp_core::folding::FoldingRange;
 use tcl_lsp_core::semantic_tokens::{SemanticTokens, VarNameArgRoles};
@@ -73,20 +72,19 @@ use tcl_registry::CommandRegistry;
 pub trait TclDb: salsa::Database {
     /// The dialect-loaded command registry (built once per canonical dialect
     /// key, then shared).  Immutable for the process lifetime.
-    fn registry(&self, dialect: &str) -> Arc<CommandRegistry>;
+    fn registry(&self, dialect: &str) -> &'static CommandRegistry;
 }
 
 /// The Tcl LSP query database.
 ///
 /// Cloneable so a worker thread can run queries against a handle while the
-/// main thread sets inputs (the rust-analyzer snapshot pattern).  The
-/// `registries` map is shared across clones (it is a process-wide static
-/// cache, not per-snapshot state).
+/// main thread sets inputs (the rust-analyzer snapshot pattern).  The command
+/// registry it hands out is the process-wide per-profile cache in
+/// `tcl-registry`, not per-snapshot state.
 #[salsa::db]
 #[derive(Default, Clone)]
 pub struct TclDatabase {
     storage: salsa::Storage<Self>,
-    registries: Arc<Mutex<HashMap<String, Arc<CommandRegistry>>>>,
 }
 
 #[salsa::db]
@@ -105,32 +103,23 @@ impl TclDatabase {
                 logger(format!("{database_key:?}"));
             }
         })));
-        Self {
-            storage,
-            registries: Arc::default(),
-        }
+        Self { storage }
     }
 }
 
 #[salsa::db]
 impl TclDb for TclDatabase {
-    fn registry(&self, dialect: &str) -> Arc<CommandRegistry> {
-        // Canonical key: parseable dialects keep their string; unparseable /
-        // plain-Tcl collapse to "" (one shared base registry).  Mirrors the
-        // server's former `registry_for_dialect`.
-        let parsed = DialectSet::parse(dialect);
-        let key = if parsed.is_some() { dialect } else { "" };
-        let mut map = self.registries.lock().expect("registry cache poisoned");
-        if let Some(r) = map.get(key) {
-            return Arc::clone(r);
-        }
-        let mut registry = CommandRegistry::build_default();
-        if let Some(d) = parsed {
-            registry.load_dialect(d);
-        }
-        let arc = Arc::new(registry);
-        map.insert(key.to_owned(), Arc::clone(&arc));
-        arc
+    fn registry(&self, dialect: &str) -> &'static CommandRegistry {
+        // The shared per-profile cache, not a locally-assembled registry: it
+        // resolves the name through the dialect catalogue (so an alias or a
+        // typo lands on the right entry), loads the profile's base layers and
+        // EDA packs, and — the part a hand-rolled `build_default +
+        // load_dialect` silently dropped — *stamps the profile* on the
+        // registry. Every registry-derived behaviour query keys off that
+        // stamp, so without it `FoldPolicy::from_registry` read the LSP's
+        // iRules documents as plain Tcl and declined every word-operator fold
+        // (issue #1048).
+        tcl_registry::registry_for_dialect(dialect)
     }
 }
 
@@ -342,7 +331,7 @@ pub fn file_link_targets(db: &dyn TclDb, file: SourceFile) -> Arc<BTreeSet<Strin
     };
     let dialect = file.dialect(db).clone();
     let registry = db.registry(&dialect);
-    let scanned = tcl_compiler::signature_scan::extract_signatures(file.text(db), &registry);
+    let scanned = tcl_compiler::signature_scan::extract_signatures(file.text(db), registry);
     let parent = std::path::Path::new(path);
     Arc::new(
         scanned
@@ -463,7 +452,7 @@ pub fn file_call_site_evidence(
         .collect();
     let scanned = tcl_compiler::unit_scope::scan_source_call_sites(
         file.text(db),
-        &registry,
+        registry,
         &dialect,
         &known,
         &reach,
@@ -1068,7 +1057,7 @@ pub fn function_lattice<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<
         key.qname(db),
         cfg,
         key.params(db),
-        &registry,
+        registry,
         param_constants.as_ref(),
         &known_classes,
         trace_facts,
@@ -1119,7 +1108,7 @@ pub fn lower_proc_body<'db>(db: &'db dyn TclDb, key: ProcBodyKey<'db>) -> Arc<Sc
     Arc::new(tcl_compiler::lowering::lower_proc_body_isolated(
         key.body_text(db),
         key.namespace(db),
-        &registry,
+        registry,
         config,
         key.dialect(db),
     ))
@@ -1390,7 +1379,7 @@ pub fn taint_cascade<'db>(
         ia.procedures.insert(r.qname.clone(), s);
     }
 
-    Arc::new(baseline.interproc_taints(&registry, &ia, dialect_opt))
+    Arc::new(baseline.interproc_taints(registry, &ia, dialect_opt))
 }
 
 /// Interned identity of one procedure's *interprocedural summary-fixpoint*
@@ -1577,7 +1566,7 @@ pub fn proc_summary_cascade<'db>(
         qname,
         params,
         &fu,
-        &registry,
+        registry,
         Some(&ia),
         dialect_opt,
         &known,
@@ -1601,7 +1590,7 @@ pub fn function_checks<'db>(db: &'db dyn TclDb, key: FnLatticeKey<'db>) -> Arc<V
     // Per-procedure memo — procs have no implicit instance variables.
     Arc::new(tcl_compiler::compiler_checks::function_nontaint_checks(
         &fu,
-        &registry,
+        registry,
         dialect_opt,
         None::<&std::collections::HashSet<String>>,
     ))
@@ -1685,7 +1674,7 @@ pub fn proc_taint_solve<'db>(
         db,
         file.text(db),
         UnitBuildOptions {
-            registry: &registry,
+            registry,
             defer_top_level: false,
             config: cfg.to_config(db),
             dialect: &dialect,
@@ -1696,7 +1685,7 @@ pub fn proc_taint_solve<'db>(
 
     let taints = tcl_compiler::taint_interproc::solve_interprocedural_taints_with(
         &cu,
-        &registry,
+        registry,
         dialect_opt,
         &mut |qname, params, fu, known, summaries| match lattice_keys.get(qname) {
             // Memoised path: the proc has an offset-0 baseline key.
@@ -1724,7 +1713,7 @@ pub fn proc_taint_solve<'db>(
                 qname,
                 params,
                 fu,
-                &registry,
+                registry,
                 interproc,
                 dialect_opt,
                 known,
@@ -1761,7 +1750,7 @@ pub fn proc_taint_solve<'db>(
                 // per-function checks need no rebase.
                 for d in tcl_compiler::compiler_checks::function_nontaint_checks(
                     fu,
-                    &registry,
+                    registry,
                     dialect_opt,
                     None::<&std::collections::HashSet<String>>,
                 ) {
@@ -1785,7 +1774,7 @@ pub fn proc_taint_solve<'db>(
     for fu in cu.analysable_methods_and_body_units() {
         for d in tcl_compiler::compiler_checks::shimmer_family_checks(
             fu,
-            &registry,
+            registry,
             dialect_opt,
             cu.method_instance_vars(&fu.name),
         ) {
@@ -1793,7 +1782,7 @@ pub fn proc_taint_solve<'db>(
         }
     }
 
-    let optimisations = solve_optimisations(db, &cu, &lattice_keys, &registry, dialect_opt);
+    let optimisations = solve_optimisations(db, &cu, &lattice_keys, registry, dialect_opt);
     Arc::new(CheckSolve {
         taints,
         fn_checks,
@@ -2050,7 +2039,7 @@ pub fn function_optimisations<'db>(
         has_dynamic_variable_trace: false,
     };
     let empty_cfg = tcl_compiler::cfg::Function::new("::", "entry");
-    let top_fu = FunctionUnit::build("::", empty_cfg.clone(), &[], &registry);
+    let top_fu = FunctionUnit::build("::", empty_cfg.clone(), &[], registry);
     let mut cfg_procs = HashMap::new();
     cfg_procs.insert(qname.clone(), fu.cfg.clone());
     let mut fu_procs = HashMap::new();
@@ -2074,7 +2063,7 @@ pub fn function_optimisations<'db>(
     };
     Arc::new(tcl_compiler::optimiser::optimise_unit_raw(
         &cu,
-        &registry,
+        registry,
         dialect_opt,
     ))
 }
@@ -2313,7 +2302,7 @@ pub fn compilation_unit<'db>(
         db,
         file.text(db),
         UnitBuildOptions {
-            registry: &registry,
+            registry,
             defer_top_level: false,
             config: cfg.to_config(db),
             dialect: &dialect,
@@ -2450,7 +2439,7 @@ pub fn compiler_check_diagnostics(
     let generic_patterns = config.generic_variable_patterns(db).as_deref();
     tcl_compiler::compiler_checks::push_taint_and_module_checks(
         &cu,
-        &registry,
+        registry,
         dialect_opt,
         &solve.taints,
         generic_patterns,
@@ -2546,7 +2535,7 @@ pub fn semantic_tokens(db: &dyn TclDb, file: SourceFile, config: AnalyserConfig)
     tcl_lsp_core::semantic_tokens::full_with_cu_and_analysis(
         file.text(db),
         file.dialect(db),
-        &registry,
+        registry,
         Some(&cu),
         Some(&analysis),
     )
@@ -2652,7 +2641,7 @@ pub fn semantic_tokens_project(
     tcl_lsp_core::semantic_tokens::full_with_cu_and_classes_and_roles(
         file.text(db),
         file.dialect(db),
-        &registry,
+        registry,
         Some(&cu),
         Some(&classes),
         Some(&proc_roles),
@@ -2663,12 +2652,13 @@ pub fn semantic_tokens_project(
 #[salsa::tracked]
 pub fn folding_ranges(db: &dyn TclDb, file: SourceFile) -> Vec<FoldingRange> {
     let registry = db.registry(file.dialect(db));
-    tcl_lsp_core::folding::folding_ranges(file.text(db), file.dialect(db), &registry)
+    tcl_lsp_core::folding::folding_ranges(file.text(db), file.dialect(db), registry)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
     fn cfg(db: &TclDatabase) -> AnalyserConfig {
         AnalyserConfig::new(
@@ -2715,7 +2705,7 @@ mod tests {
         let registry = db.registry(dialect);
         let file = SourceFile::new(&db, src.to_owned(), dialect.to_owned(), None);
         let got = compiler_check_diagnostics(&db, file, cfg(&db));
-        let want = compiler_check_diagnostics_uncached(src, &registry, dialect, None, None);
+        let want = compiler_check_diagnostics_uncached(src, registry, dialect, None, None);
         assert!(
             got.optimisations.iter().any(|o| o.code == DiagCode::O122),
             "expected O122 to fire on the tail-recursive proc"
@@ -2753,7 +2743,7 @@ mod tests {
         let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned(), None);
         let got = semantic_tokens(&db, file, cfg(&db));
         let reg = db.registry("tcl");
-        let expected = tcl_lsp_core::semantic_tokens::full(SRC, "tcl", &reg);
+        let expected = tcl_lsp_core::semantic_tokens::full(SRC, "tcl", reg);
         assert_eq!(got, expected);
         assert!(!got.data.is_empty());
     }
@@ -2776,7 +2766,7 @@ mod tests {
         let file = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned(), None);
         let enriched = semantic_tokens(&db, file, cfg(&db));
         let reg = db.registry("tcl9.0");
-        let coarse = tcl_lsp_core::semantic_tokens::full(src, "tcl9.0", &reg);
+        let coarse = tcl_lsp_core::semantic_tokens::full(src, "tcl9.0", reg);
         assert_ne!(
             enriched, coarse,
             "the CompilationUnit-informed regex-source retag must change the \
@@ -2796,7 +2786,7 @@ mod tests {
         let file = SourceFile::new(&db, src.to_owned(), "tcl9.0".to_owned(), None);
         let enriched = semantic_tokens(&db, file, cfg(&db));
         let reg = db.registry("tcl9.0");
-        let coarse = tcl_lsp_core::semantic_tokens::full(src, "tcl9.0", &reg);
+        let coarse = tcl_lsp_core::semantic_tokens::full(src, "tcl9.0", reg);
         assert_eq!(
             enriched, coarse,
             "a non-constant pattern source must not be retagged by either tier"
@@ -2824,7 +2814,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(
             &db,
@@ -3133,7 +3122,6 @@ mod tests {
         };
         let db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(
             &db,
@@ -3193,7 +3181,6 @@ mod tests {
         };
         let db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(
             &db,
@@ -3311,7 +3298,7 @@ mod tests {
         let file = SourceFile::new(&db, SRC.to_owned(), "tcl".to_owned(), None);
         let got = folding_ranges(&db, file);
         let reg = db.registry("tcl");
-        let expected = tcl_lsp_core::folding::folding_ranges(SRC, "tcl", &reg);
+        let expected = tcl_lsp_core::folding::folding_ranges(SRC, "tcl", reg);
         assert_eq!(got, expected);
     }
 
@@ -3415,7 +3402,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(
             &db,
@@ -3475,7 +3461,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(
             &db,
@@ -3548,7 +3533,7 @@ mod tests {
                 ),
             );
             let registry = db.registry(dialect);
-            let want = compiler_check_diagnostics_uncached(src, &registry, dialect, None, None);
+            let want = compiler_check_diagnostics_uncached(src, registry, dialect, None, None);
             assert_eq!(
                 got.checks, want.checks,
                 "checks differ for ({dialect}):\n{src}"
@@ -3612,7 +3597,7 @@ mod tests {
                     None,
                 ),
             );
-            let want = compiler_check_diagnostics_uncached(src, &registry, dialect, None, None);
+            let want = compiler_check_diagnostics_uncached(src, registry, dialect, None, None);
             assert_eq!(
                 got.checks, want.checks,
                 "cascade checks diverge after edit to:\n{src}"
@@ -3705,7 +3690,7 @@ mod tests {
             file.set_text(&mut db).to(src.clone());
 
             let got = compiler_check_diagnostics(&db, file, cfg(&db));
-            let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None, None);
+            let want = compiler_check_diagnostics_uncached(&src, registry, dialect, None, None);
             assert_eq!(
                 got.checks, want.checks,
                 "iter {iter}: checks diverge from fresh build for state {state:?}:\n{src}"
@@ -3743,7 +3728,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         // Three procedures with no taint-relevant call edges between them.
         let file = SourceFile::new(
@@ -3824,7 +3808,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         // Three independent procs (no foldable cross-proc calls, no pure-non-const
         // proc → the memo path, not the whole-module fallback).
@@ -3885,7 +3868,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let file = SourceFile::new(
             &db,
@@ -3956,7 +3938,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let file = SourceFile::new(
             &db,
@@ -4036,7 +4017,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let a = SourceFile::new(
             &db,
@@ -4109,7 +4089,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let a = SourceFile::new(
             &db,
@@ -4194,7 +4173,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(
             &db,
@@ -5365,7 +5343,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let src = "namespace eval ::a { proc x {p} { set q $p; return $q } }\n\
                    namespace eval ::b { proc x {p} { set q $p; return $q } }\n\
@@ -5413,7 +5390,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(
             &db,
@@ -5475,7 +5451,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(
             &db,
@@ -5561,7 +5536,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(
             &db,
@@ -5638,7 +5612,6 @@ mod tests {
         };
         let mut db = TclDatabase {
             storage: salsa::Storage::new(Some(Box::new(sink))),
-            registries: Arc::default(),
         };
         let cfg = AnalyserConfig::new(
             &db,

--- a/rust/tcl-lsp-db/src/lib.rs
+++ b/rust/tcl-lsp-db/src/lib.rs
@@ -1121,6 +1121,7 @@ pub fn lower_proc_body<'db>(db: &'db dyn TclDb, key: ProcBodyKey<'db>) -> Arc<Sc
         key.namespace(db),
         &registry,
         config,
+        key.dialect(db),
     ))
 }
 

--- a/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
+++ b/rust/tcl-lsp-db/tests/compiler_check_corpus.rs
@@ -99,7 +99,7 @@ fn compiler_check_memo_matches_uncached_graphops() {
     let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
     let got = compiler_check_diagnostics(&db, file, default_config(&db));
     let registry = db.registry(dialect);
-    let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None, None);
+    let want = compiler_check_diagnostics_uncached(&src, registry, dialect, None, None);
     assert_eq!(
         got.checks, want.checks,
         "graphops checks diverge (memo vs uncached)"
@@ -129,7 +129,7 @@ fn compiler_check_memo_matches_uncached_init() {
     let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
     let got = compiler_check_diagnostics(&db, file, default_config(&db));
     let registry = db.registry(dialect);
-    let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None, None);
+    let want = compiler_check_diagnostics_uncached(&src, registry, dialect, None, None);
     assert_eq!(
         got.checks, want.checks,
         "init.tcl checks diverge (memo vs uncached)"
@@ -171,7 +171,7 @@ fn compiler_check_memo_matches_uncached_over_corpus() {
         let file = SourceFile::new(&db, src.clone(), dialect.to_owned(), None);
         let got = compiler_check_diagnostics(&db, file, default_config(&db));
         let registry = db.registry(dialect);
-        let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None, None);
+        let want = compiler_check_diagnostics_uncached(&src, registry, dialect, None, None);
         checked += 1;
         if got.checks != want.checks || got.optimisations != want.optimisations {
             let detail = format!(
@@ -270,7 +270,7 @@ fn compiler_check_memo_matches_uncached_under_corpus_edits() {
             file.set_text(&mut db).to(src.clone());
 
             let got = compiler_check_diagnostics(&db, file, default_config(&db));
-            let want = compiler_check_diagnostics_uncached(&src, &registry, dialect, None, None);
+            let want = compiler_check_diagnostics_uncached(&src, registry, dialect, None, None);
             checked += 1;
             if got.checks != want.checks || got.optimisations != want.optimisations {
                 let detail = format!(

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -3725,8 +3725,8 @@ impl Backend {
             // user-class object-method resolution still apply, matching the
             // salsa path below.
             return tokio::task::spawn_blocking(move || {
-                let cu = tcl_compiler::compilation_unit::CompilationUnit::build_for(
-                    &text, &registry, false,
+                let cu = tcl_compiler::compilation_unit::CompilationUnit::build_for_dialect(
+                    &text, &registry, false, &dialect,
                 );
                 let analysis = tcl_compiler::analyser::Analyser::new().analyse(&text, &dialect);
                 core_semantic_tokens::full_with_cu_and_analysis(

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -377,7 +377,7 @@ struct RangeConvergenceInputs {
     uri: String,
     /// The coarse token stream already served, to diff the enriched recompute against.
     served: Vec<u32>,
-    registry: Arc<CommandRegistry>,
+    registry: &'static CommandRegistry,
     text: String,
     dialect: String,
     range: CoreLspRange,
@@ -508,7 +508,7 @@ struct DiagToggles {
 #[derive(Clone)]
 struct DiagInputs {
     client: Client,
-    registry: Arc<CommandRegistry>,
+    registry: &'static CommandRegistry,
     disabled: HashSet<String>,
     /// `tclLsp.diagnosticSeverity.<CODE>` per-code LSP severity overrides,
     /// resolved for this document's folder. Applied as a display-side re-label
@@ -1155,7 +1155,7 @@ async fn compute_project_diags(
 /// worker panic (settle) — matching [`compute_base_analysis`].
 async fn compute_compiler_diags(
     ctx: &SalsaAnalysisCtx<'_>,
-    registry: &Arc<CommandRegistry>,
+    registry: &'static CommandRegistry,
     generic_variable_patterns: Option<&[String]>,
 ) -> ControlFlow<bool, Arc<tcl_lsp_db::CompilerDiagnostics>> {
     let &SalsaAnalysisCtx {
@@ -1192,13 +1192,13 @@ async fn compute_compiler_diags(
         }
     } else {
         let (c_text, c_dialect) = (text.to_owned(), dialect.to_owned());
-        let c_registry = Arc::clone(registry);
+        let c_registry = registry;
         let c_generic = generic_variable_patterns.map(<[String]>::to_vec);
         ControlFlow::Continue(
             tokio::task::spawn_blocking(move || {
                 Arc::new(tcl_lsp_db::compiler_check_diagnostics_uncached(
                     &c_text,
-                    &c_registry,
+                    c_registry,
                     &c_dialect,
                     c_generic.as_deref(),
                     // The no-salsa-input fallback: this document is not in the
@@ -1608,7 +1608,7 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
         &salsa_ctx,
         &lift_inputs,
         &AnalyserPathInputs {
-            registry: &registry,
+            registry,
             extra_commands: &extra_commands,
             generic_variable_patterns: generic_variable_patterns.as_deref(),
             non_ascii_mode,
@@ -1626,7 +1626,7 @@ async fn run_diagnostics_core(inputs: DiagInputs, uri: &Uri, job: DiagJob) -> bo
 
 /// The non-document-buffer handles the analyser/compiler/publish path needs.
 struct AnalyserPathInputs<'a> {
-    registry: &'a Arc<CommandRegistry>,
+    registry: &'static CommandRegistry,
     extra_commands: &'a HashSet<String>,
     generic_variable_patterns: Option<&'a [String]>,
     non_ascii_mode: NonAsciiMode,
@@ -1944,7 +1944,7 @@ async fn refine_and_lift_diagnostics(
     compiler_diags: &Arc<tcl_lsp_db::CompilerDiagnostics>,
     inherited_requires: &[String],
     package_resolver: &Arc<RwLock<PackageResolver>>,
-    registry: &Arc<CommandRegistry>,
+    registry: &'static CommandRegistry,
     inputs: &LiftInputs<'_>,
 ) -> Result<Vec<tower_lsp_server::ls_types::Diagnostic>, tokio::task::JoinError> {
     // #723 + #804: refine the analyser's single-file W120 against the workspace
@@ -3320,10 +3320,14 @@ impl Backend {
     /// 1. The LSP ``languageId`` field — when it names a known
     ///    dialect (``"tcl-irule"`` / ``"f5-irules"`` / ``"tcl9.0"``
     ///    / etc.), use it directly.
-    /// 2. The per-folder override map (`folder_dialects`) — when
+    /// 2. Detection over the document itself — for the bare ``"tcl"``
+    ///    id every editor sends for a `.tcl` buffer, the shared
+    ///    [`tcl_registry::dialects::detect_dialect`] (directive,
+    ///    shebang, version guard, content signatures, then extension).
+    /// 3. The per-folder override map (`folder_dialects`) — when
     ///    the document URI sits under one of the configured folder
     ///    URLs, use the deepest-matching folder's dialect.
-    /// 3. The session-wide ``default_dialect`` fallback.
+    /// 4. The session-wide ``default_dialect`` fallback.
     async fn dialect_for_open(&self, uri: &Uri, language_id: &str, text: &str) -> String {
         // An explicit BIG-IP language id (`tcl-bigip`, advertised by the VS
         // Code extension, or the canonical `f5-bigip`) selects the BIG-IP
@@ -3360,12 +3364,21 @@ impl Backend {
         // 8.6+-only commands like `try` in an 8.4/8.5 file.  An explicit
         // versioned or non-Tcl `languageId` still takes precedence (it is a
         // deliberate editor choice), so only the bare `"tcl"` id defers here.
-        // Delegates to `detect_dialect_from_source`
-        // (directive > shebang > `package require Tcl`).
-        if language_id == "tcl"
-            && let Some(d) = tcl_registry::detect_dialect_from_source(text)
-        {
-            return d.to_owned();
+        // Delegates to the shared `detect_dialect` (directive > shebang >
+        // `package require Tcl` > content signatures > file extension), the
+        // same detector `tcl diag` resolves a document with — so the editor
+        // and the CLI report the same set for the same file. The
+        // content-signature tier is what recognises an iRule saved as
+        // `.tcl` (or opened by an editor with no iRules language mode) from
+        // its `when EVENT {` handlers; the extension tier never fires for a
+        // plain `.tcl` name, so the folder override and session default below
+        // still decide an ordinary Tcl buffer (issue #805). An empty `default`
+        // is the "nothing detected" sentinel: it keeps that deferral intact.
+        if language_id == "tcl" {
+            let detected = tcl_registry::dialects::detect_dialect(text, Some(uri.as_str()), "");
+            if !detected.is_empty() {
+                return detected.to_owned();
+            }
         }
         // A *versioned* or non-Tcl language id (`tcl8.4`, `tcl9.0`,
         // `f5-irules`, …) is a deliberate, specific choice and wins over the
@@ -3681,12 +3694,12 @@ impl Backend {
     ) -> Option<core_semantic_tokens::SemanticTokens> {
         if is_apl_source(uri, &doc.language_id) {
             let registry = self.registry_for_dialect(IAPPS_DIALECT).await;
-            return Some(core_semantic_tokens::apl_range(&doc.text, range, &registry));
+            return Some(core_semantic_tokens::apl_range(&doc.text, range, registry));
         }
         if Self::is_bigip_dialect(&doc.dialect) {
             let registry = self.registry_for_dialect(IRULES_DIALECT).await;
             return Some(core_semantic_tokens::bigip_conf_range(
-                &doc.text, range, &registry,
+                &doc.text, range, registry,
             ));
         }
         None
@@ -3708,13 +3721,13 @@ impl Backend {
         if is_apl_source(uri, &doc.language_id) {
             // The iApps registry: an APL `[ … ]` bracket expression is iApp Tcl.
             let registry = self.registry_for_dialect(IAPPS_DIALECT).await;
-            return Ok(core_semantic_tokens::apl_full(&doc.text, &registry).data);
+            return Ok(core_semantic_tokens::apl_full(&doc.text, registry).data);
         }
         if Self::is_bigip_dialect(&doc.dialect) {
             // The iRules registry, not the BIG-IP one: a `ltm rule { … }` body is
             // iRules code embedded in the config, and is walked as such.
             let registry = self.registry_for_dialect(IRULES_DIALECT).await;
-            return Ok(core_semantic_tokens::bigip_conf_full(&doc.text, &registry).data);
+            return Ok(core_semantic_tokens::bigip_conf_full(&doc.text, registry).data);
         }
 
         let Some(mut enriched) = self.db_semantic_tokens(uri).await else {
@@ -3726,13 +3739,13 @@ impl Backend {
             // salsa path below.
             return tokio::task::spawn_blocking(move || {
                 let cu = tcl_compiler::compilation_unit::CompilationUnit::build_for_dialect(
-                    &text, &registry, false, &dialect,
+                    &text, registry, false, &dialect,
                 );
                 let analysis = tcl_compiler::analyser::Analyser::new().analyse(&text, &dialect);
                 core_semantic_tokens::full_with_cu_and_analysis(
                     &text,
                     &dialect,
-                    &registry,
+                    registry,
                     Some(&cu),
                     Some(&analysis),
                 )
@@ -3782,7 +3795,7 @@ impl Backend {
         let registry = self.registry_for_dialect(&doc.dialect).await;
         let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
         tokio::task::spawn_blocking(move || {
-            core_semantic_tokens::full(&text, &dialect, &registry).data
+            core_semantic_tokens::full(&text, &dialect, registry).data
         })
         .await
         .map_err(|err| jsonrpc::Error {
@@ -5883,7 +5896,7 @@ impl Backend {
         let dialect = doc.dialect.clone();
         let value = tokio::task::spawn_blocking(move || {
             if aggressive {
-                let res = core_minify::minify_tcl_aggressive(&text, &dialect, isolated, &registry);
+                let res = core_minify::minify_tcl_aggressive(&text, &dialect, isolated, registry);
                 serde_json::json!({
                     "source": res.source,
                     "originalLength": res.original_length,
@@ -5893,7 +5906,7 @@ impl Backend {
                 })
             } else if compact {
                 let (minified, symbol_map) =
-                    core_minify::minify_tcl_compact(&text, &dialect, isolated, &registry);
+                    core_minify::minify_tcl_compact(&text, &dialect, isolated, registry);
                 serde_json::json!({
                     "source": minified,
                     "originalLength": text.len(),
@@ -5901,7 +5914,7 @@ impl Backend {
                     "symbolMap": symbol_map.format(),
                 })
             } else {
-                let minified = core_minify::minify_tcl(&text, &dialect, &registry);
+                let minified = core_minify::minify_tcl(&text, &dialect, registry);
                 serde_json::json!({
                     "source": minified,
                     "originalLength": text.len(),
@@ -5950,10 +5963,10 @@ impl Backend {
         let value = tokio::task::spawn_blocking(move || {
             let dialect_opt = Some(dialect.as_str());
             let (source, opts) = if profile == "full" {
-                tcl_compiler::optimiser::optimise_source_multipass(&text, &registry, dialect_opt, 5)
+                tcl_compiler::optimiser::optimise_source_multipass(&text, registry, dialect_opt, 5)
             } else {
                 let opts =
-                    tcl_compiler::optimiser::optimise_with_dialect(&text, &registry, dialect_opt);
+                    tcl_compiler::optimiser::optimise_with_dialect(&text, registry, dialect_opt);
                 let applied = tcl_compiler::optimiser::apply_optimisations(&text, &opts);
                 (applied, opts)
             };
@@ -6810,7 +6823,7 @@ impl Backend {
         let profile = tcl_dialect::DialectProfile::by_name(&dialect);
         let mut subs: Vec<serde_json::Value> = {
             use tcl_registry::ProfileQueries;
-            profile.resolve_command(&registry, &name)
+            profile.resolve_command(registry, &name)
         }
         .map(|spec| {
             spec.subcommands
@@ -7134,21 +7147,17 @@ impl Backend {
             .with_extra_commands(extra_commands)
     }
 
-    /// Return an `Arc<CommandRegistry>` with `dialect` loaded on
-    /// top of the default Tcl + stdlib + tcllib specs.
+    /// Return the command registry with `dialect` loaded on top of the
+    /// default Tcl + stdlib + tcllib specs.
     ///
-    /// The result is cached per canonical dialect key. Concurrent
-    /// first-use requests may build the same registry more than once,
-    /// but only one `Arc` is inserted; keeping construction outside the
-    /// mutex avoids blocking unrelated cache hits on spec loading.
-    /// Unparseable dialect strings collapse to the empty-string key so
-    /// they share a single cached "plain Tcl" registry rather than
-    /// leaking a fresh allocation per typo.
-    async fn registry_for_dialect(&self, dialect: &str) -> Arc<CommandRegistry> {
-        // The dialect-loaded registry lives on the query database as a durable
-        // (non-salsa) value, built once per canonical dialect key and shared.
-        // Clone the db handle (cheap; shares the registry map) so the lookup /
-        // one-time build doesn't hold the db mutex.
+    /// The registry is the process-wide per-profile cache in `tcl-registry`,
+    /// built once per dialect profile and shared for the process lifetime —
+    /// an unknown or unparseable dialect string resolves to the plain-Tcl
+    /// profile rather than leaking a fresh registry per typo.
+    async fn registry_for_dialect(&self, dialect: &str) -> &'static CommandRegistry {
+        // Routed through the query database so every consumer (the salsa
+        // queries included) reads one registry per dialect.  Clone the db
+        // handle (cheap) so the lookup does not hold the db mutex.
         let db = self.db.lock().await.clone();
         db.registry(dialect)
     }
@@ -7286,10 +7295,9 @@ impl Backend {
         uri: &Uri,
         text: &str,
         dialect: &str,
-        registry: &Arc<CommandRegistry>,
+        registry: &'static CommandRegistry,
     ) -> tcl_lsp_db::CompilerDiagnostics {
-        let (c_text, c_dialect, c_registry) =
-            (text.to_owned(), dialect.to_owned(), Arc::clone(registry));
+        let (c_text, c_dialect, c_registry) = (text.to_owned(), dialect.to_owned(), registry);
         // URI-scoped (folder/project override aware), matching the push
         // path's `resolved_generic_variable_patterns(uri)` so IRULE4002
         // honours a folder's `diagnostics.genericVariablePatterns` override.
@@ -7301,7 +7309,7 @@ impl Backend {
         tokio::task::spawn_blocking(move || {
             tcl_lsp_db::compiler_check_diagnostics_uncached(
                 &c_text,
-                &c_registry,
+                c_registry,
                 &c_dialect,
                 c_generic.as_deref(),
                 c_evidence.as_deref(),
@@ -7357,7 +7365,7 @@ impl Backend {
         let cross_file_on = self.cross_file_resolution_enabled(uri).await;
         let project_arities = self.project_arities_if(cross_file_on).await;
         let compiler_diags = self
-            .compiler_diagnostics_for(uri, &text, &dialect, &registry)
+            .compiler_diagnostics_for(uri, &text, &dialect, registry)
             .await;
 
         // XC100-301 translatability lints — independent toggle, f5-irules only.
@@ -7398,7 +7406,7 @@ impl Backend {
             analysis.as_ref(),
             &inherited_requires,
             &self.package_resolver,
-            &registry,
+            registry,
         )
         .await;
         // #832: drop any W123 the package database can resolve (auto-loaded
@@ -8130,7 +8138,7 @@ impl Backend {
                         &text,
                         &dialect,
                         range,
-                        &registry,
+                        registry,
                         cu.as_deref(),
                         analysis.as_deref(),
                     )
@@ -8736,7 +8744,7 @@ impl LanguageServer for Backend {
         // handler.
         let text = doc.text.clone();
         let edits = tokio::task::spawn_blocking(move || {
-            core_formatting::formatting_with(&text, &config, &registry)
+            core_formatting::formatting_with(&text, &config, registry)
         })
         .await
         .map_err(|err| jsonrpc::Error {
@@ -8781,7 +8789,7 @@ impl LanguageServer for Backend {
         // is contained as a JSON-RPC error rather than unwinding the event
         // loop (defence in depth).
         let ranges = tokio::task::spawn_blocking(move || {
-            tcl_lsp_core::folding::folding_ranges(&doc.text, &doc.dialect, &registry)
+            tcl_lsp_core::folding::folding_ranges(&doc.text, &doc.dialect, registry)
         })
         .await
         .map_err(|err| jsonrpc::Error {
@@ -8892,7 +8900,7 @@ impl LanguageServer for Backend {
                 pos.line,
                 pos.character,
                 &analysis,
-                Some(&registry),
+                Some(registry),
                 Some(&*workspace),
                 &doc.dialect,
             )
@@ -8975,7 +8983,7 @@ impl LanguageServer for Backend {
                 pos.character,
                 &dialect,
                 &analysis,
-                &registry,
+                registry,
             )
         })
         .await
@@ -9827,13 +9835,13 @@ impl LanguageServer for Backend {
         // Pure-CPU tokenisation on a worker so a parser panic is contained
         // as a JSON-RPC error.
         let (text, dialect) = (doc.text.clone(), doc.dialect.clone());
-        let serve_registry = Arc::clone(&registry);
+        let serve_registry = registry;
         let core_data = tokio::task::spawn_blocking(move || {
             core_semantic_tokens::range_with_cu_and_analysis(
                 &text,
                 &dialect,
                 core_range,
-                &serve_registry,
+                serve_registry,
                 cached_cu.as_deref(),
                 cached_analysis.as_deref(),
             )
@@ -9854,7 +9862,7 @@ impl LanguageServer for Backend {
                 RangeConvergenceInputs {
                     uri: uri.as_str().to_owned(),
                     served: core_data.clone(),
-                    registry: Arc::clone(&registry),
+                    registry,
                     text: doc.text.clone(),
                     dialect: doc.dialect.clone(),
                     range: core_range,
@@ -10067,7 +10075,7 @@ impl LanguageServer for Backend {
                 &doc.dialect,
                 range,
                 Some(&analysis),
-                Some(&registry),
+                Some(registry),
                 type_hints,
                 parameter_hints,
             )
@@ -10317,7 +10325,7 @@ impl LanguageServer for Backend {
         let actions = tokio::task::spawn_blocking(move || {
             let mut actions = core_code_actions::code_actions(&doc.text, range, Some(&analysis));
             actions.extend(core_code_actions::package_require_actions(
-                &doc.text, range, &registry,
+                &doc.text, range, registry,
             ));
             actions.extend(core_code_actions::context_diagnostic_actions(
                 &doc.text,
@@ -10335,7 +10343,7 @@ impl LanguageServer for Backend {
             }
             // iRules-only: the `# Profiles:` header source action.
             if dialect == "f5-irules"
-                && let Some(a) = core_code_actions::profiles_action(&doc.text, &analysis, &registry)
+                && let Some(a) = core_code_actions::profiles_action(&doc.text, &analysis, registry)
             {
                 actions.push(a);
             }
@@ -10346,7 +10354,7 @@ impl LanguageServer for Backend {
             // plain-Tcl document's checks simply carry no IRULE-family fixes.
             let checks = tcl_lsp_db::compiler_check_diagnostics_uncached(
                 &doc.text,
-                &registry,
+                registry,
                 &dialect,
                 generic_patterns.as_deref(),
                 evidence.as_deref(),
@@ -10425,7 +10433,7 @@ impl LanguageServer for Backend {
         // a JSON-RPC error.
         let text = doc.text.clone();
         let edits = tokio::task::spawn_blocking(move || {
-            core_formatting::formatting_with(&text, &config, &registry)
+            core_formatting::formatting_with(&text, &config, registry)
         })
         .await
         .map_err(|err| jsonrpc::Error {
@@ -10467,7 +10475,7 @@ impl LanguageServer for Backend {
         // a JSON-RPC error.
         let text = doc.text.clone();
         let edits = tokio::task::spawn_blocking(move || {
-            core_formatting::range_formatting(&text, range, &config, &registry)
+            core_formatting::range_formatting(&text, range, &config, registry)
         })
         .await
         .map_err(|err| jsonrpc::Error {
@@ -10655,7 +10663,7 @@ impl LanguageServer for Backend {
         let dialect = doc.dialect.clone();
         let analysis_for_worker = analysis.clone();
         let new_name_worker = new_name.clone();
-        let registry_worker = Arc::clone(&registry);
+        let registry_worker = registry;
         let edits = tokio::task::spawn_blocking(move || {
             core_rename::rename(
                 &text,
@@ -10664,7 +10672,7 @@ impl LanguageServer for Backend {
                 pos.character,
                 &new_name_worker,
                 &analysis_for_worker,
-                Some(&registry_worker),
+                Some(registry_worker),
             )
         })
         .await
@@ -10705,7 +10713,7 @@ impl LanguageServer for Backend {
                     analysis: &analysis,
                     pos,
                     new_name: &new_name,
-                    registry: &registry,
+                    registry,
                 },
                 local_rejected,
                 &mut changes,
@@ -10862,7 +10870,7 @@ impl LanguageServer for Backend {
                 pos.line,
                 pos.character,
                 &analysis,
-                Some(&registry),
+                Some(registry),
             )
         })
         .await
@@ -10908,7 +10916,7 @@ impl LanguageServer for Backend {
                 pos.line,
                 pos.character,
                 &analysis,
-                Some(&registry),
+                Some(registry),
                 hover_profile,
             )
         })
@@ -18665,14 +18673,20 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn registry_for_dialect_reuses_cached_arc() {
+    async fn registry_for_dialect_reuses_cached_registry() {
         let backend = test_backend();
         let first = backend.registry_for_dialect("f5-irules").await;
         let second = backend.registry_for_dialect("f5-irules").await;
 
         assert!(
-            Arc::ptr_eq(&first, &second),
+            std::ptr::eq(first, second),
             "repeated dialect lookups should return the cached registry",
+        );
+        assert!(
+            first
+                .profile()
+                .is_some_and(tcl_dialect::DialectProfile::is_irules),
+            "the shared cache stamps the dialect profile the fold policy reads",
         );
     }
 
@@ -21108,7 +21122,7 @@ mod tests {
             .expect("worker did not panic")
             .expect("not cancelled");
         let registry = backend.registry_for_dialect("tcl9.0").await;
-        let coarse = core_semantic_tokens::full(src, "tcl9.0", &registry);
+        let coarse = core_semantic_tokens::full(src, "tcl9.0", registry);
 
         assert!(!served.data.is_empty(), "must never serve an empty stream");
         assert!(

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -1817,7 +1817,17 @@ fn break_arm_escaping_loop_still_fires() {
 fn when_body_not_analysed_under_plain_tcl() {
     let mut lsp = Lsp::tcl();
     let uri = unique_uri("tcl");
-    let diags = lsp.open_ready(&uri, "when HTTP_REQUEST {\n    boguscmd $undefvar\n}\n");
+    // Opened with the *versioned* `tcl8.6` language id, which is a deliberate
+    // editor choice and outranks detection. The bare `tcl` id every editor
+    // sends for a `.tcl` buffer now defers to the shared detector, and a
+    // `when EVENT {` handler is one of its iRules content signatures (issue
+    // #1048) — so this source would otherwise be analysed as an iRule, which
+    // is not the case under test.
+    let diags = lsp.open_ready_lang(
+        &uri,
+        "when HTTP_REQUEST {\n    boguscmd $undefvar\n}\n",
+        "tcl8.6",
+    );
     // `when` itself is unknown under Tcl, but the opaque body must not be
     // recursed into: no W123 naming the body command, no W210 on its var.
     let body_w123: Vec<&Value> = diags

--- a/rust/tcl-lsp-server/tests/e2e/irules.rs
+++ b/rust/tcl-lsp-server/tests/e2e/irules.rs
@@ -1377,3 +1377,81 @@ fn when_body_is_analysed_under_irules() {
         irules_codes(&diags)
     );
 }
+
+// -- TestIrulesWordOperatorFold ------------------------------------------
+// Issue #1048: the dialect reaches the lowering, so a word-operator condition
+// on a known-constant subject folds and draws I230 on the wire.
+
+/// Open `source` as an iRule and poll the version-1 publish until `marker`
+/// lands, returning the final diagnostics. Mirrors [`deep_diags`], but for a
+/// caller-chosen marker.
+fn diags_until(lsp: &mut Lsp, source: &str, marker: &str) -> Vec<Value> {
+    let uri = unique_uri("irule");
+    lsp.open_ready_lang(&uri, source, "tcl-irule");
+    let deadline = std::time::Instant::now() + Duration::from_secs(25);
+    let mut diags = Vec::new();
+    while std::time::Instant::now() < deadline {
+        diags = lsp.await_diagnostics_version(&uri, Some(1), Duration::from_secs(25));
+        if diags.iter().any(|d| code_str(d) == marker) {
+            return diags;
+        }
+        std::thread::sleep(Duration::from_millis(200));
+    }
+    panic!("{marker} never published; saw {:?}", irules_codes(&diags));
+}
+
+/// `$x contains "cd"` with `$x` a known literal is a constant condition, so the
+/// alternate branch is unreachable and I230 fires.
+///
+/// Before issue #1048 the lowering parsed every condition with no dialect, so
+/// the word operator reached the IR as an opaque expression the fold could not
+/// evaluate — I230 could not fire here even with the iRules dialect selected.
+/// The plain-Tcl control (the same text must draw no I230, only W003) lives in
+/// `tcl-compiler`'s `dialect_threading` suite: this server is iRules-dedicated,
+/// so opening a plain Tcl document on it would switch its dialect.
+#[test]
+fn i230_fires_on_irules_word_operator_condition() {
+    let mut lsp = Lsp::irules();
+    let diags = diags_until(
+        &mut lsp,
+        "when HTTP_REQUEST {\n\
+        \x20   set x \"abcdef\"\n\
+        \x20   if {$x contains \"cd\"} { HTTP::respond 200 }\n\
+        }\n",
+        "I230",
+    );
+    let i230: Vec<&Value> = diags.iter().filter(|d| code_str(d) == "I230").collect();
+    assert!(!i230.is_empty(), "{:?}", irules_codes(&diags));
+    // The message names the condition it folded, not some other branch.
+    let message = i230[0]
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        message.contains("contains"),
+        "I230 must be reported for the word-operator condition; got {message:?}"
+    );
+}
+
+/// FP guard: neither operand of `$x contains $y` is knowable here, so the
+/// condition is not constant and I230 must stay silent — the fold is proven,
+/// not assumed from the operator. `IRULE1004` (the missing-priority hint on the
+/// `when` handler) is the settle marker.
+#[test]
+fn i230_silent_on_non_constant_irules_word_operator_condition() {
+    let mut lsp = Lsp::irules();
+    let diags = diags_until(
+        &mut lsp,
+        "when HTTP_REQUEST {\n\
+        \x20   set y [HTTP::uri]\n\
+        \x20   set x [HTTP::host]\n\
+        \x20   if {$x contains $y} { HTTP::respond 200 }\n\
+        }\n",
+        "IRULE1004",
+    );
+    assert!(
+        !irules_codes(&diags).contains("I230"),
+        "{:?}",
+        irules_codes(&diags)
+    );
+}

--- a/rust/tcl-mcp/src/irule_test.rs
+++ b/rust/tcl-mcp/src/irule_test.rs
@@ -283,11 +283,7 @@ pub fn irule_cfg_paths(args: &Value) -> Value {
 /// priority (high → normal → low).
 fn extract_test_paths(source: &str) -> Vec<PathInfo> {
     let registry = registry_for_dialect(IRULES_DIALECT);
-    let data = tcl_diagram::diagram_data_with_config(
-        source,
-        registry,
-        tcl_lexer::LexerConfig::for_dialect(IRULES_DIALECT),
-    );
+    let data = tcl_diagram::diagram_data_for_dialect(source, registry, IRULES_DIALECT);
     if data.get("error").is_some() {
         return Vec::new();
     }

--- a/rust/tcl-mcp/src/tools.rs
+++ b/rust/tcl-mcp/src/tools.rs
@@ -305,11 +305,7 @@ fn memory_aliases(args: &Value) -> Value {
 fn diagram(args: &Value) -> Value {
     let source = arg_str(args, "source");
     let dialect = resolve_dialect(args, source);
-    tcl_diagram::diagram_data_with_config(
-        source,
-        registry(&dialect),
-        tcl_lexer::LexerConfig::for_dialect(&dialect),
-    )
+    tcl_diagram::diagram_data_for_dialect(source, registry(&dialect), &dialect)
 }
 
 fn detect_dialect(args: &Value) -> Value {


### PR DESCRIPTION
## Summary

Fixes #1048 — and the two deeper legs found while verifying it. The detected dialect now reaches every consumer, so iRules word-operator expressions fold and draw I230 without an explicit `--dialect`:

- **CLI**: `dialect_or_default()` documented per-file auto-detection but returned the literal `"tcl8.6"`. New `combined_effective_dialect` (in `tcl-cli-support`) runs the full registry detector per input; wired into `opt`, `format`, `minify`, `dis`, `compwasm`, `diagram`, `explore`, `symbols`, `symbolgraph`, `callgraph`, `dataflow`, `highlight`, `find-legacy`, and `diff` (`minimize` resolves per document like `diag` already did). `dialect_or_default()` is deleted.
- **CompilationUnit**: new `build_for_dialect(source, registry, defer, dialect)` sets both `LexerConfig::for_dialect` and `UnitBuildOptions::dialect`. Converted the dialect-blind production call sites: the analyser's `emit_cfg_ssa_diagnostics` fallback, `tcl-lsp-core` `graphs.rs` (×4), `minify.rs` (the literal `let _ = dialect;` is gone, and `rmw_target_var_names` now takes a dialect), `inlay_hints.rs`, `tcl-diagram` (×3), `tcl-explorer`, the `tcl-lsp-server` semantic-token fallback, and `tcl-cli/diff.rs`.
- **Lowering (the leg that actually blocked I230, even with `--dialect`)**: every `if`/`while`/`for`/`expr` condition was parsed with a hardcoded `None` dialect, freezing word-operator conditions as `ExprNode::Raw` that SCCP could never fold — `tcl opt` only worked via `branch_folding`'s text-reparse fallback. The `Lowerer` now carries the dialect and passes it at all five `parse_expr` sites, so the IR carries real `BinOp` nodes and I230 fires through SCCP.
- **LSP**: `dialect_for_open`'s bare-`"tcl"` branch now uses the full content-signature detector (CLI/editor parity — a `.tcl` buffer whose content is an iRule is analysed as `f5-irules` in the editor, as it already was on the CLI; one existing e2e test re-pinned to a versioned language id accordingly). Separately, `TclDatabase::registry` hand-assembled a registry and never stamped the dialect profile, so `FoldPolicy::from_registry` saw every LSP document as plain Tcl — it now returns the profile-stamped `registry_for_dialect(dialect)`.

**Tests** (TP/FP/TN/FN): new `rust/tcl-compiler/tests/dialect_threading.rs` (7 tests — I230 fires on a constant word-operator condition under f5-irules; stays silent in plain Tcl where W003 fires instead; silent on non-constant conditions; plain-Tcl I230 still fires; lowering parses vs leaves Raw per dialect); CLI tests asserting `tcl opt` with no flag is byte-identical to `--dialect f5-irules` on an `.irule` fixture; lsp_e2e `irules.rs` I230 TP + FP-guard; VS Code extension test (`i230WordOperator.test.ts`). The PR #1046 FoldPolicy/SCCP regression tests and the W003 pair stay green.

**Deferred** (noted for follow-ups): `tcl diag`'s `collect_rows` and `tcl-lsp-db`'s `compilation_unit` still build the analysis unit with the default `LexerConfig` (moving those seams needs a re-baseline of the per-item/file-analysis differential corpora); the FP-catalogue harness under `analyser/diagnostics/fp/` still uses `build_for`. Hover's dialect gap is filed as #1054.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `make check-all` — PASSED on this branch; `make xtask-check` — all drift gates green.
  - `cargo test -p tcl-compiler -p tcl-cli -p tcl-lsp-core -p tcl-lsp-server` — 10,976 passed, 0 failed (plus the other touched crates: tcl-lsp-db, tcl-mcp, tcl-diagram, tcl-explorer, tcl-cli-support, registry/syntax/lexer/irules/f5-xc/bigip green).
  - `make test-rust` (full workspace, `--all-features`) — green on the local integration merge of this branch with the sibling registry-first branch (230 suites), proving the two compose.
  - `make test-emacs` — green. `make runtime-rust-test` — 324/325; the 1 failure reproduces at the base commit and is filed as #1058.
  - `make test-ext` — 682 passing including the new I230 tests; the 10 failures are the pre-existing environment-dependent `variableContexts` suite, verified failing at the base commit with a base-built server, filed as #1059.
  - CLI verified end-to-end: `tcl opt probe.irule` (no flag) → `if {1}` + O101, byte-identical to `--dialect f5-irules`; `tcl diag probe.irule` → I230; the same condition in `.tcl` → W003 only.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — dialect now reaches lowering/SCCP, changing where I230 can fire.
- [x] Updated KCS: new `docs/kcs/kcs-issue-irule-word-operator-is-not-analysed.md`, indexed in `docs/kcs/README.md`.
- [x] Linked from the KCS index (the note lives at the top level, not `docs/kcs/compiler/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_