### PR TITLE
Registry-first: eval-family script concatenation, rename/alias-aware constructor typing, TclOO dispatch-keyword facility (#1049 #1050 #1051)

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,6 +371,42 @@ rename helper {}
 proc caller {} { helper }      ;# W123: helper was deleted, never re-established
 ```
 
+The eval family (`eval`, `uplevel`, `namespace eval`, `interp eval`) is
+analysed the way Tcl runs it: the trailing words concatenate into one
+script, so a multi-word call is walked as the script it actually
+evaluates rather than its first word alone — no invented arity errors,
+and the variables it really sets count as written. A brace-quoted word
+is static script text even when it contains `$` or `[` (the braces
+blocked the substitution; `eval` resolves it when the script runs). A
+genuinely dynamic word (`eval $cmd arg`) makes the script unknowable,
+so the analyser claims nothing instead of guessing — and `namespace
+inscope` is honoured as the one member whose tail appends as list
+elements rather than joining. Everything found inside the concatenated
+script — definitions, references, diagnostics — is anchored at its real
+source bytes, so rename and go-to-definition work inside these calls.
+
+```tcl
+eval set l2 hello              ;# runs 'set l2 hello' — no wrong-#-args, l2 is set
+eval {set l2} {$value}         ;# same script; $value resolves when it runs
+namespace eval ::cfg set port 8080   ;# ::cfg::port is really written
+```
+
+Object typing follows commands through `rename` and `interp alias`
+chains: a class constructor reached under a renamed or aliased name
+still types the object it builds, so method validation (W308) names the
+real class instead of degrading into untyped-dispatch noise — while a
+constructor called before the rename/alias exists, an alias with bound
+extra words, or an alias landing on a vacated name stays untyped, just
+as it fails in tclsh.
+
+```tcl
+oo::class create Dog { method bark {} { return woof } }
+rename Dog Cat
+interp alias {} Pup {} Cat
+set d [Pup new]
+$d fly                         ;# W308: unknown method 'fly' on ::Dog
+```
+
 ### Completions
 
 Context-aware completions for commands, subcommands, variables, proc names

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -391,11 +391,25 @@ eval {set l2} hello     == set l2 hello
 
 The consumer contract is that no pass may treat the first `BODY`-role word as
 the whole script when the trait is present and further words follow. Either
-join them per the rule above — sound only when every trailing word is a
-static literal, since substitution runs *before* concatenation — or consume
-the command without walking it. Analysing `eval set l2 hello` as the
-one-word script `set` invents a wrong-#-args error and loses the write to
-`l2` (issue #1051).
+walk the tail as one script — sound only when every word is statically-known
+script text, since substitution runs *before* concatenation; a braced word
+qualifies even when its contents carry `$`/`[`, because the braces blocked
+the outer substitution and the eval-family command itself resolves them when
+the script runs — or consume the command without walking it. Analysing
+`eval set l2 hello` as the one-word script `set` invents a wrong-#-args
+error and loses the write to `l2` (issue #1051).
+
+A consumer that records *spans* while walking (the analyser's
+`dispatch_concatenated_script`) must not walk a freshly-joined string
+against a linear anchor: stripped delimiters, dropped words, and collapsed
+whitespace shift every offset after the first divergence, so recorded
+references become rename hazards. `analyser::utils::concat_script_window`
+is the shared answer — it rebuilds the equivalent script *in place* over
+the words' source window (content bytes at their true offsets, structural
+bytes blanked to spaces, whitespace runs being separator-equivalent), so
+every recorded span maps to the exact source bytes it describes. Consumers
+that harvest names only (the CFG barrier-write harvest) may still use a
+plain text join.
 
 `namespace inscope` is the one member that does not space-join:
 `namespace inscope ns script ?arg ...?` is `namespace eval ns [concat script

--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -366,6 +366,108 @@ contains, so it defers to host-supplied cross-file evidence. See
 convenience over a namespace the same file defines, and `unit_scope`'s
 evidence scan already models the import as a real caller path.
 
+### The `Tcl_ConcatObj` eval family
+
+Five commands evaluate the **concatenation** of every trailing word from
+their first `BODY`-role argument onwards, rather than that one word alone:
+
+| Trait | Set on | Means |
+|---|---|---|
+| `SCRIPT_CONCATENATES_ARGS` | `eval`, `uplevel`, `namespace eval`, `namespace inscope`, `interp eval` | every word from the first `BODY` index to the end of the call is part of one script |
+| `SCRIPT_APPENDS_LIST_ARGS` | `namespace inscope` | refines the above: the tail is appended as *list elements*, not space-joined |
+
+`Tcl_ConcatObj` (`generic/tclUtil.c`) takes each word's **string
+representation** — so a braced word contributes its *contents*, the outer
+braces already removed by Tcl's word parsing — trims ASCII whitespace from
+each end, drops words that trim to nothing, and joins the rest with a single
+space. Commands therefore span word boundaries:
+
+```text
+concat {set x} {5}      -> set x 5
+concat "  a  " "  b  "  -> a b
+eval set l2 hello       == set l2 hello
+eval {set l2} hello     == set l2 hello
+```
+
+The consumer contract is that no pass may treat the first `BODY`-role word as
+the whole script when the trait is present and further words follow. Either
+join them per the rule above — sound only when every trailing word is a
+static literal, since substitution runs *before* concatenation — or consume
+the command without walking it. Analysing `eval set l2 hello` as the
+one-word script `set` invents a wrong-#-args error and loses the write to
+`l2` (issue #1051).
+
+`namespace inscope` is the one member that does not space-join:
+`namespace inscope ns script ?arg ...?` is `namespace eval ns [concat script
+[list arg ...]]`, so `namespace inscope :: {puts} {a b}` prints `a b` where
+`namespace eval :: {puts} {a b}` errors `can not find channel named "a"`.
+Reconstructing that needs list quoting the analyser does not model, so any
+trailing word means the call is consumed without walking.
+
+`catch` is deliberately outside the family: it takes a single bounded script
+argument, so its remaining words are result / options variable names.
+
+The `EXPR_CONCATENATES_ARGS` trait is the expression-side counterpart, for
+`expr`'s whole-tail expression.
+
+### `TclOO` method-context keywords
+
+Three traits classify the words that appear at the head of a call inside a
+`TclOO` method body. They sit on **different axes** and must not be
+conflated:
+
+| Trait | Set on | Means |
+|---|---|---|
+| `TCLOO_SELF_DISPATCH` | `my` | instance self-dispatch — the next word names a method on *this* object, reaching non-exported (and, from 9.0, private) methods |
+| `TCLOO_NEXT_CHAIN` | `next`, `nextto` | superclass chain — no word names a method; the callee is the next implementation of the *currently executing* one |
+| `TCLOO_INTROSPECTION` | `self` | introspection, never dispatch — its argument is a closed subcommand set |
+
+`link` carries none of them, deliberately: it *creates* per-object bareword
+commands (`link {alias method}`), so the barewords it installs are per-class
+data rather than language keywords (issue #1026).
+
+`CommandRegistry::method_dispatch_keyword(head) -> Option<MethodDispatchKind>`
+is the single query every consumer uses instead of a `head == "my"` /
+`matches!(head, "my" | "next" | "nextto")` literal (issue #1050). It:
+
+- normalises a leading `::`, matching `get`;
+- answers under the **registry instance's own** dialect profile, so a
+  registry built by `registry_for_dialect("tcl8.5")` returns `None` for all
+  four (every one is `TCL86_PLUS`), while a profile-less
+  `CommandRegistry::build_default()` answers dialect-agnostically;
+- returns `SelfDispatch` / `NextChain` / `Introspection`, so a consumer that
+  wants "does the next word name a method" can ask for `SelfDispatch` alone.
+
+`nextto`'s explicit resume-from class is distinguished from `next`
+*structurally* — an `ArgRole::Name` at argument index 0 on the spec — not by
+name, so a consumer capturing that target queries the role rather than
+matching the spelling.
+
+A future dialect variant of any of these keywords propagates through its
+`CommandSpec`, never through a walker edit; the contract tests in
+`registry_commands.rs` assert the consumer-visible keyword set equals the
+trait-carrying specs, per dialect.
+
+### Branch-selected bodies
+
+`BRANCH_SELECTED_BODY` marks a command whose body arguments run only when
+its own run-time selection picks them, and which performs no iteration —
+`if` (at most one clause body plus an optional `else`) and `try` (handler
+bodies reached only on the matching exception).
+
+The fact a consumer needs is that nothing established inside such a body
+**dominates** the code after the command: a `package require` there is
+conditional, and a variable written there is not reliably set afterwards.
+
+Deliberately narrower than `CONTROL_FLOW`, which also covers `while` / `for`
+/ `foreach` / `lmap` / `switch`. A loop body is *repeatable* as well as
+skippable, so the two questions have different answers and different
+consumers — the analyser's `control_flow_body_depth` (straight-line-ness,
+driven by `CONTROL_FLOW`) and `conditional_depth` (domination, driven by this
+trait) stay separate. Also distinct from `HAS_BOOLEAN_COND`, which is about
+an argument being *read* as a boolean expression rather than about which
+bodies run.
+
 ### Resolution priority
 
 Three mechanisms assign roles to command arguments. They are evaluated in

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -67,6 +67,10 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   `tailcall` in a safe-interpreter body, and the *Inline proc* code action
   is missing on `file`, `exec`, `open`, and seven other commands — two
   symptoms of one trait-flag bit collision.
+- [kcs-issue-false-diagnostics-inside-a-multi-word-eval.md](kcs-issue-false-diagnostics-inside-a-multi-word-eval.md)
+  — a multi-word `eval`, `uplevel`, or `namespace eval` draws a false E002
+  "wrong number of arguments", and a variable the call sets is still
+  reported as read before it is set (W210).
 - [kcs-issue-always-true-condition-in-a-sourced-library-file.md](kcs-issue-always-true-condition-in-a-sourced-library-file.md)
   — I230 says a condition is always true in a library file whose procedure
   is really called with different values from another file.

--- a/docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md
+++ b/docs/kcs/codes/kcs-diagnostic-w123-unresolved-command.md
@@ -104,6 +104,35 @@ though the command itself survives under its new name. `rename Dog Cat`
 moves the class to `Cat`; `Dog new` afterwards fails with `invalid
 command name "Dog"`, so the old name is reported.
 
+## What a `proc unknown` changes
+
+Defining your own `unknown` handler at **global** scope switches this check
+off for the whole file: Tcl sends every unresolved command word to that
+handler, so the analyser cannot prove any name is really unresolved.
+
+```tcl
+proc unknown {cmd args} { exec $cmd {*}$args }
+totallyBogusCommand
+```
+
+Nothing is flagged here.
+
+A `proc unknown` written **inside a namespace** is an ordinary procedure
+that happens to share the name, and changes nothing:
+
+```tcl
+namespace eval ::mylib {
+    proc unknown {cmd args} { exec $cmd {*}$args }
+}
+totallyBogusCommand
+```
+
+The analyser still reports **`W123`** on `totallyBogusCommand`, and running
+this really does fail with `invalid command name "totallyBogusCommand"` —
+Tcl consults `::unknown` for a bare unresolved word regardless of the calling
+namespace. To register a per-namespace handler, use `namespace unknown NAME`,
+which the analyser models separately.
+
 A built-in `expr` math function (`sin`, `max`, `abs`, …) called with
 function-call syntax inside `expr` resolves to the command it dispatches to
 (`::tcl::mathfunc::<name>`) and never draws `W123`, whether or not it has

--- a/docs/kcs/codes/kcs-diagnostic-w308-unknown-tcloo-method.md
+++ b/docs/kcs/codes/kcs-diagnostic-w308-unknown-tcloo-method.md
@@ -88,6 +88,38 @@ The analyser reports **`W308`** on `$d fly`. The vacated name `Dog` is a
 separate question, and is reported separately as `W123` if anything
 still calls it.
 
+Objects built through the *new* name are checked too, because the class
+itself is unchanged — only the command that reaches it moved:
+
+```tcl
+oo::class create Dog { method bark {} { return woof } }
+rename Dog Cat
+set d [Cat new]
+$d fly
+```
+
+The analyser reports **`W308`** on `$d fly`, naming the class `::Dog`, and
+`$d bark` stays quiet. An `interp alias {} Cat {} Dog` and a chain of
+renames (`rename Dog Cat; rename Cat Kitten`) work the same way.
+
+Order matters, because the rename has to have run:
+
+```tcl
+oo::class create Dog { method bark {} { return woof } }
+set d [Cat new]
+rename Dog Cat
+$d fly
+```
+
+Here `Cat` does not exist yet when `[Cat new]` runs, so nothing is built and
+the analyser makes no claim about the method. The out-of-order call itself is
+reported as `W128` instead. Inside a procedure or method body the order does
+not matter — the whole file loads before any body runs.
+
+An alias that binds extra words (`interp alias {} Cat {} Dog create`) is left
+alone. Those words shift the constructor's own arguments, so `Cat new` is not
+the call `Dog new` would be.
+
 ## Fix
 
 Call a method the class actually defines, or add the method to the class:

--- a/docs/kcs/kcs-issue-false-diagnostics-inside-a-multi-word-eval.md
+++ b/docs/kcs/kcs-issue-false-diagnostics-inside-a-multi-word-eval.md
@@ -1,0 +1,104 @@
+# KCS: Why does a multi-word `eval` report a wrong-argument-count error?
+
+> **Audience:** User
+> **Type:** Issue
+
+## Applies to
+
+all-editors, diagnostic, analyser
+
+## Question
+
+Why does `eval set total 0` draw a "wrong number of arguments" error, and why
+is a variable it sets still reported as read before it is set?
+
+## Symptoms
+
+- A red squiggle under a multi-word `eval`, `uplevel`, or `namespace eval`
+  call, reporting **`E002`** — too few arguments — for a command that is
+  perfectly well formed.
+- A yellow squiggle further down the file reporting **`W210`** — "Variable
+  'total' is read before it is set" — even though the `eval` above it sets
+  that very variable.
+- The same code written as `eval {set total 0}`, with the whole script in one
+  braced word, reports nothing.
+
+## Why
+
+`eval` does not evaluate its first argument as a script. It **joins all of
+its arguments** into one script first, and then evaluates that. So these
+three lines are the same program:
+
+```tcl
+eval set total 0
+eval {set total} 0
+eval {set total 0}
+```
+
+The analyser used to walk only the first script word and ignore the rest. It
+therefore analysed `eval set total 0` as if the whole script were the single
+word `set` — which really is a wrong-argument-count error — and never saw the
+write to `total`, so a later `puts $total` looked like a read before set.
+
+The same joining rule applies to `uplevel`, `namespace eval`, and
+`interp eval`. It does **not** apply to `catch`, whose script is a single
+bounded argument.
+
+## Answer
+
+Both false reports are fixed — no configuration change or workaround is
+needed. Update to a build containing the fix.
+
+To confirm the fix is present, put this in a file and check the Problems
+view:
+
+```tcl
+eval set total 0
+puts $total
+```
+
+Before the fix: one `E002` on the `eval` line and one `W210` on the `puts`
+line. After the fix: nothing.
+
+A genuinely malformed joined script is still reported, because the analyser
+now checks the script Tcl actually runs:
+
+```tcl
+eval set
+```
+
+still reports `E002` — the joined script really is `set` on its own.
+
+## When the analyser stays quiet
+
+When any word of the call is substituted, the script cannot be known before
+the program runs:
+
+```tcl
+eval $cmd arg
+```
+
+`$cmd` could hold anything, so the analyser makes no claim at all about the
+call — no argument-count check, and no assumption about which variables it
+sets. The security warning **`W101`** still fires, because building a script
+by concatenation from a variable is exactly the injection risk it reports.
+
+`namespace inscope` is quiet for a different reason. Its trailing words are
+appended as whole list elements rather than joined into the script text, so
+`namespace inscope ::app {handler} ready` passes `ready` to `handler` as one
+argument. The analyser does not reconstruct that quoting, so it makes no
+claim about the call.
+
+## How to suppress
+
+If you still see one of these on a shape not covered above, add
+`# noqa: E002` or `# noqa: W210` at the end of the offending line, and please
+open an issue with the snippet.
+
+## Related
+
+- [KCS index](README.md)
+- [Glossary](../GLOSSARY.md)
+- [E002 — too few arguments](codes/kcs-diagnostic-e002-too-few-arguments.md)
+- [W210 — variable read before set](codes/kcs-diagnostic-w210-variable-read-before-set.md)
+- [W101 — string-concatenated eval](codes/kcs-diagnostic-w101-eval-string-concatenation.md)

--- a/editors/vscode/src/test/precisionFalsePositives.test.ts
+++ b/editors/vscode/src/test/precisionFalsePositives.test.ts
@@ -375,3 +375,45 @@ suite("Variable-name positions (W212/W216)", () => {
     assert.ok(!linesWithCode(diags, "W212").includes(3), "upvar line must not fire W212");
   });
 });
+
+// The `Tcl_ConcatObj` eval family (issue #1051).
+//
+// `eval`, `uplevel`, `namespace eval`, and `interp eval` evaluate the
+// *concatenation* of every trailing script word, so analysing only the first
+// one invents an E002 and loses the writes the joined script performs. The
+// fixture's last line (`eval set`, line index 9) is a genuinely short joined
+// script and MUST fire E002 — that doubles as the marker that analysis ran.
+// `namespace inscope`'s tail is list-appended rather than joined, so its line
+// must stay silent too.
+suite("Multi-word eval concatenation (#1051)", () => {
+  const docUri = getDocUri("multiWordEval.tcl");
+
+  test("a genuinely short joined script still fires E002 (true case)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "E002"),
+    });
+    assert.deepStrictEqual(
+      linesWithCode(diags, "E002"),
+      [9],
+      "only the `eval set` line is a short joined script",
+    );
+  });
+
+  test("well-formed multi-word eval draws no E002 and no W210 (false case)", async () => {
+    await activate(docUri);
+    const diags = await waitForDiagnostics(docUri, {
+      predicate: (d) => d.some((x) => codeOf(x) === "E002"),
+    });
+    for (const ln of linesWithCode(diags, "E002")) {
+      assert.strictEqual(ln, 9, `E002 fired on well-formed eval line ${ln}`);
+    }
+    // The joined scripts really do set `total` and `label`, so the reads on
+    // lines 3 and 5 are not read-before-set.
+    assert.strictEqual(
+      linesWithCode(diags, "W210").length,
+      0,
+      "a variable a multi-word eval sets must not read as read-before-set",
+    );
+  });
+});

--- a/editors/vscode/testFixture/multiWordEval.tcl
+++ b/editors/vscode/testFixture/multiWordEval.tcl
@@ -1,0 +1,10 @@
+# Issue #1051 — the Tcl_ConcatObj eval family joins every trailing script word.
+# Verified against tclsh 8.6.14 and tclsh 9.0.4.
+eval set total 0
+puts $total
+eval {set label} hello
+puts $label
+namespace eval ::app { proc handler {tag} { puts $tag } }
+namespace inscope ::app {handler} ready
+# The joined script really is checked: `set` on its own is wrong # args.
+eval set

--- a/rust/tcl-compiler/src/analyser/class_lattice.rs
+++ b/rust/tcl-compiler/src/analyser/class_lattice.rs
@@ -602,7 +602,14 @@ fn classify_rhs<S: std::hash::BuildHasher + Clone>(
             return AssignKind::Constructor { class, in_index };
         }
         // Introspection heads whose result is a runtime class handle.
-        if head == "self" {
+        // `self` is the `TclOO` introspection keyword — registry data
+        // (`Traits::TCLOO_INTROSPECTION`), queried rather than spelled
+        // (issue #1050). Resolved against the dialect-agnostic default
+        // registry: this classifier is reached without a dialect in scope,
+        // and `TclOO` introspection is core Tcl from 8.6 onwards.
+        if tcl_registry::cache::default_registry().method_dispatch_keyword(&head)
+            == Some(tcl_registry::MethodDispatchKind::Introspection)
+        {
             return AssignKind::Introspection;
         }
         if head == "oo::copy" || head == "::oo::copy" {

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1503,11 +1503,22 @@ impl Analyser {
                 .or_default()
                 .insert(name.clone());
         }
+        // Registry facts, not command names (gap-review C3). The event
+        // handler is whatever carries `IS_EVENT_HANDLER` — `when` today, but
+        // a dialect that adds another gets the same treatment without an edit
+        // here; its synopsis (`when EVENT { body }`) puts the event name in
+        // the first argument. `conditional_depth` rises for a command whose
+        // bodies are branch-selected (`BRANCH_SELECTED_BODY` — `if` / `try`),
+        // which is what makes a `package require` inside one conditional.
+        let spec_traits = registry
+            .get(cmd_name)
+            .map_or_else(tcl_registry::Traits::empty, |s| s.traits);
+        let is_event_handler = spec_traits.contains(tcl_registry::Traits::IS_EVENT_HANDLER);
         let prev_event = self.current_event.clone();
-        if cmd_name == "when" && !args.is_empty() {
+        if is_event_handler && !args.is_empty() {
             self.current_event = Some(args[0].clone());
         }
-        let is_conditional = matches!(cmd_name, "if" | "try");
+        let is_conditional = spec_traits.contains(tcl_registry::Traits::BRANCH_SELECTED_BODY);
         if is_conditional {
             self.conditional_depth += 1;
         }
@@ -1517,9 +1528,7 @@ impl Analyser {
         // or many, so anything inside it is not straight-line. `namespace
         // eval` / `eval` / `uplevel` bodies carry no such trait and stay
         // straight-line, which is correct — they always run.
-        let is_control_flow = registry
-            .get(cmd_name)
-            .is_some_and(|s| s.traits.contains(tcl_registry::Traits::CONTROL_FLOW));
+        let is_control_flow = spec_traits.contains(tcl_registry::Traits::CONTROL_FLOW);
         if is_control_flow {
             self.control_flow_body_depth += 1;
         }
@@ -1543,7 +1552,7 @@ impl Analyser {
         if is_control_flow {
             self.control_flow_body_depth -= 1;
         }
-        if cmd_name == "when" {
+        if is_event_handler {
             self.current_event = prev_event;
         }
     }

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1652,6 +1652,17 @@ impl Analyser {
             arg_single.get(first).copied().unwrap_or(false),
         );
         let Some(script) = super::utils::concat_script_words(words, tokens) else {
+            // The tail cannot be joined (a dynamic word). A braced first word
+            // is still a literal script prefix — concatenation appends after
+            // it, so its own commands run as written — and walking it keeps
+            // every scope/definition it declares visible to the editor. The
+            // `eval {script} $extra` shape (and a brace-mangled document
+            // whose mis-extended body word drags real code into this arm)
+            // must not lose the script to the decline.
+            if first_tok.kind == TokenType::Str {
+                self.analyse_body(&words[0], *first_tok, scope_path);
+                return;
+            }
             // Declining the walk must not lose the *reference* a `$cmd` script
             // word carries — `uplevel #0 $cmd [list x y]` still dispatches
             // whatever `$cmd` holds.

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1441,47 +1441,37 @@ impl Analyser {
             &body_args,
             tcl_registry::arg_role::ArgRole::Body,
         );
-        // Fallback for an *imported* command called by its unqualified name:
-        // `namespace import ::tcltest::*` followed by `test name desc { body }`
-        // calls the registry's `tcltest::test`, whose body roles only resolve
-        // under the qualified name. Re-query through each recorded import so the
-        // body walk reaches inside the imported command's body. Conservative:
-        // only when the bare name owns no body itself,
-        // and only against a namespace explicitly imported in this document.
         // The registry command name that actually owns the body role — usually
         // `cmd_name`, but the qualified target when an import fallback resolved
         // it.  Used to read the scoped-body environment from the same spec.
         let mut body_cmd_owned: Option<String> = None;
-        if body_indices.is_empty() && !cmd_name.contains("::") {
-            for imp in &self.result.namespace_imports {
-                // An import is only in effect where it was made: in its own
-                // namespace, or — for an import at global scope — everywhere, via
-                // Tcl's unqualified-name fallback to `::`. An import inside
-                // `namespace eval ns { … }` must NOT resolve a bare call made in a
-                // sibling or parent namespace.
-                if imp.ns != cur_ns && imp.ns != "::" {
-                    continue;
-                }
-                let candidate = if let Some(prefix) = imp.pattern.strip_suffix('*') {
-                    format!("{prefix}{cmd_name}")
-                } else if imp.pattern.rsplit("::").next() == Some(cmd_name) {
-                    imp.pattern.clone()
-                } else {
-                    continue;
-                };
-                let idxs = registry.arg_indices_for_role(
-                    &candidate,
-                    &body_args,
-                    tcl_registry::arg_role::ArgRole::Body,
-                );
-                if !idxs.is_empty() {
-                    body_indices = idxs;
-                    body_cmd_owned = Some(candidate);
-                    break;
-                }
-            }
+        if body_indices.is_empty()
+            && let Some((idxs, candidate)) =
+                self.imported_body_indices(cmd_name, &body_args, &cur_ns)
+        {
+            body_indices = idxs;
+            body_cmd_owned = Some(candidate);
         }
         if body_indices.is_empty() {
+            return;
+        }
+        // The `Tcl_ConcatObj` eval family: when the spec carries
+        // `SCRIPT_CONCATENATES_ARGS` and words follow the first body index,
+        // the script is the *concatenation* of every trailing word, not the
+        // first one on its own.  Walking only the first would analyse
+        // `eval set l2 hello` as the one-word script `set` — a false E002
+        // plus a lost write to `l2` that then draws a false W210 (#1051).
+        if body_indices.first().is_some_and(|&first| {
+            first + 1 < args.len()
+                && registry.get(cmd_name).is_some_and(|s| {
+                    s.traits
+                        .contains(tcl_registry::Traits::SCRIPT_CONCATENATES_ARGS)
+                })
+        }) {
+            let first = body_indices[0];
+            self.dispatch_concatenated_script(
+                cmd_name, args, arg_tokens, arg_single, first, scope_path,
+            );
             return;
         }
         // Scoped command environment for this command's body args, if any — the
@@ -1558,6 +1548,119 @@ impl Analyser {
         }
     }
 
+    /// Body-role indices for an *imported* command called by its unqualified
+    /// name, plus the qualified registry name that owns them.
+    ///
+    /// `namespace import ::tcltest::*` followed by `test name desc { body }`
+    /// calls the registry's `tcltest::test`, whose body roles only resolve
+    /// under the qualified name. Re-queries through each recorded import so
+    /// the body walk reaches inside the imported command's body.
+    ///
+    /// Conservative on both axes: the caller only asks when the bare name owns
+    /// no body itself, and an import is only in effect where it was made — in
+    /// its own namespace, or, for an import at global scope, everywhere via
+    /// Tcl's unqualified-name fallback to `::`. An import inside
+    /// `namespace eval ns { … }` must not resolve a bare call made in a
+    /// sibling or parent namespace.
+    fn imported_body_indices(
+        &self,
+        cmd_name: &str,
+        body_args: &[&str],
+        cur_ns: &str,
+    ) -> Option<(Vec<usize>, String)> {
+        let registry = self.registry?;
+        if cmd_name.contains("::") {
+            return None;
+        }
+        for imp in &self.result.namespace_imports {
+            if imp.ns != cur_ns && imp.ns != "::" {
+                continue;
+            }
+            let candidate = if let Some(prefix) = imp.pattern.strip_suffix('*') {
+                format!("{prefix}{cmd_name}")
+            } else if imp.pattern.rsplit("::").next() == Some(cmd_name) {
+                imp.pattern.clone()
+            } else {
+                continue;
+            };
+            let idxs = registry.arg_indices_for_role(
+                &candidate,
+                body_args,
+                tcl_registry::arg_role::ArgRole::Body,
+            );
+            if !idxs.is_empty() {
+                return Some((idxs, candidate));
+            }
+        }
+        None
+    }
+
+    /// Analyse the script a [`tcl_registry::Traits::SCRIPT_CONCATENATES_ARGS`]
+    /// command actually evaluates: the `Tcl_ConcatObj` join of every word from
+    /// `first` (its first `ArgRole::Body` index) to the end of the call.
+    ///
+    /// Two outcomes, both sound:
+    ///
+    /// - **Every trailing word is a static literal** — join them per
+    ///   [`super::utils::concat_script_words`] and walk the result as one
+    ///   script, anchored across the whole word range so its diagnostics land
+    ///   inside the call rather than on the first word alone. `eval set l2
+    ///   hello` is analysed as `set l2 hello`, so `l2` is recorded as written
+    ///   and no arity error is invented.
+    /// - **Any word is dynamic** — consume the command without walking, the
+    ///   same answer `handle_interp_eval_command` gives a multi-word
+    ///   `interp eval`: substitution happens before concatenation, so the real
+    ///   script is unknowable and every definedness or arity fact derived from
+    ///   the written words would be a guess.
+    ///
+    /// The join can only ever be shorter than the source region it stands for
+    /// (word delimiters and inter-word whitespace collapse), so a mapped
+    /// offset always lands within the call. The length check below keeps that
+    /// an enforced invariant rather than an assumption.
+    fn dispatch_concatenated_script(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        arg_single: &[bool],
+        first: usize,
+        scope_path: &[usize],
+    ) {
+        let (Some(words), Some(tokens)) = (args.get(first..), arg_tokens.get(first..)) else {
+            return;
+        };
+        let (Some(first_tok), Some(last_tok)) = (tokens.first(), tokens.last()) else {
+            return;
+        };
+        // W105 still belongs to the written first word (`eval set …` is an
+        // unbraced body however the tail concatenates), so fire it before the
+        // shape decision — with that word's own single-token flag, so a bare
+        // `eval $cmd arg` stays exempt exactly as `eval $cmd` is.
+        self.emit_w105_unbraced_body(
+            cmd_name,
+            &words[0],
+            *first_tok,
+            arg_single.get(first).copied().unwrap_or(false),
+        );
+        let Some(script) = super::utils::concat_script_words(words, tokens) else {
+            // Declining the walk must not lose the *reference* a `$cmd` script
+            // word carries — `uplevel #0 $cmd [list x y]` still dispatches
+            // whatever `$cmd` holds.
+            self.record_var_body_const_dispatch(*first_tok, scope_path);
+            return;
+        };
+        let start = first_tok.span.start() + u32::from(first_tok.content_offset);
+        let end = last_tok.span.end();
+        if script.is_empty() || u32::try_from(script.len()).is_ok_and(|len| start + len > end) {
+            return;
+        }
+        // `analyse_body` walks only a `Str` (braced) body and anchors at
+        // `span.start() + content_offset`, so the synthetic token carries the
+        // joined script's own base offset with no delimiter to skip.
+        let anchor = Token::new(TokenType::Str, tcl_lexer::Span::new(start, end));
+        self.analyse_body(&script, anchor, scope_path);
+    }
+
     /// Analyse a single body-role argument: fires `W105`, walks the script
     /// (through a scoped command environment when `body_scope` names one),
     /// and — for a bareword (unbraced) body — also dispatches it as a
@@ -1602,37 +1705,7 @@ impl Analyser {
                 scope_path,
             );
         }
-        // A bare `$var` body (`eval $cmd`, `uplevel #0 $cmd …`) dynamically
-        // evaluates $var's value as a script at runtime — its first word is
-        // the command actually dispatched, exactly the same "value is a
-        // command prefix" shape `{*}$cmd` already gets via `head_expanded`
-        // (issue #923 idx 94). `analyse_body` above only ever recurses a
-        // literal `Str` body, so this site was previously invisible to
-        // `command_invocations` entirely (missed by references/rename,
-        // unlike hover/go-to-definition's independent cursor-token walk) —
-        // record it the same way `record_var_or_cmd_command_site` records a
-        // command's own `$cmd`-headed dispatch, for `settle_const_dispatches`
-        // to resolve in the CFG/SSA phase. Guarded to a "pure" reference
-        // (`var_name == raw`) so a composite word like `${cmd}Suffix` (a
-        // literal-concatenated value, not $cmd's own value) is left alone.
-        if body_tok.kind == TokenType::Var {
-            let sm = tcl_lexer::SourceMap::new(&self.source);
-            let raw = sm.token_text(body_tok);
-            let var_name = raw
-                .split_once('}')
-                .map_or(raw, |(name, _)| name)
-                .to_string();
-            if var_name == raw {
-                let ns = self.command_resolution_namespace(scope_path);
-                self.pending_const_dispatches
-                    .push(super::state::ConstDispatchSite {
-                        var_name,
-                        span: body_tok.span,
-                        ns,
-                        head_expanded: true,
-                    });
-            }
-        }
+        self.record_var_body_const_dispatch(body_tok, scope_path);
         // When the body runs in a scoped command environment, record its
         // region (so the post-walk W123 pass and the LSP providers can
         // resolve the scoped heads by position) and push the environment
@@ -1651,6 +1724,50 @@ impl Analyser {
         } else {
             self.analyse_body(body_text, body_tok, scope_path);
         }
+    }
+
+    /// Record a bare `$var` script word (`eval $cmd`, `uplevel #0 $cmd …`) as
+    /// a pending const-dispatch site: the variable's value is the command
+    /// prefix actually dispatched, exactly the "value is a command prefix"
+    /// shape `{*}$cmd` gets via `head_expanded` (issue #923 idx 94).
+    ///
+    /// `analyse_body` only ever recurses a literal `Str` body, so without
+    /// this the site is invisible to `command_invocations` — found by
+    /// hover/definition (which resolve independently off the cursor token)
+    /// but missed by references/rename. Recorded the same way
+    /// `record_var_or_cmd_command_site` records a command's own `$cmd`-headed
+    /// dispatch, for `settle_const_dispatches` to resolve in the CFG/SSA
+    /// phase.
+    ///
+    /// Shared by the ordinary body walk and the
+    /// [`tcl_registry::Traits::SCRIPT_CONCATENATES_ARGS`] decline path: a
+    /// multi-word `uplevel #0 $cmd [list x y]` yields no analysable script,
+    /// but `$cmd` is still a real dispatch whose reference must be recorded.
+    ///
+    /// Guarded to a "pure" reference (`var_name == raw`) so a composite word
+    /// like `${cmd}Suffix` — a literal-concatenated value, not `$cmd`'s own —
+    /// is left alone.
+    fn record_var_body_const_dispatch(&mut self, body_tok: Token, scope_path: &[usize]) {
+        if body_tok.kind != TokenType::Var {
+            return;
+        }
+        let sm = tcl_lexer::SourceMap::new(&self.source);
+        let raw = sm.token_text(body_tok);
+        let var_name = raw
+            .split_once('}')
+            .map_or(raw, |(name, _)| name)
+            .to_string();
+        if var_name != raw {
+            return;
+        }
+        let ns = self.command_resolution_namespace(scope_path);
+        self.pending_const_dispatches
+            .push(super::state::ConstDispatchSite {
+                var_name,
+                span: body_tok.span,
+                ns,
+                head_expanded: true,
+            });
     }
 
     /// Record each [`tcl_registry::arg_role::ArgRole::CommandPrefix`] callback

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1610,22 +1610,20 @@ impl Analyser {
     ///
     /// Two outcomes, both sound:
     ///
-    /// - **Every trailing word is a static literal** — join them per
-    ///   [`super::utils::concat_script_words`] and walk the result as one
-    ///   script, anchored across the whole word range so its diagnostics land
-    ///   inside the call rather than on the first word alone. `eval set l2
-    ///   hello` is analysed as `set l2 hello`, so `l2` is recorded as written
-    ///   and no arity error is invented.
-    /// - **Any word is dynamic** — consume the command without walking, the
-    ///   same answer `handle_interp_eval_command` gives a multi-word
-    ///   `interp eval`: substitution happens before concatenation, so the real
-    ///   script is unknowable and every definedness or arity fact derived from
-    ///   the written words would be a guess.
-    ///
-    /// The join can only ever be shorter than the source region it stands for
-    /// (word delimiters and inter-word whitespace collapse), so a mapped
-    /// offset always lands within the call. The length check below keeps that
-    /// an enforced invariant rather than an assumption.
+    /// - **Every trailing word is static script text** — walk the tail as
+    ///   one script via [`super::utils::concat_script_window`], which
+    ///   rebuilds it *in place* (content bytes at their true source offsets,
+    ///   delimiters and gaps blanked to spaces) so every span the walk
+    ///   records — command references, variable reads and writes,
+    ///   diagnostics — lands on the exact bytes it describes, rename-safe.
+    ///   `eval set l2 hello` is analysed as `set l2 hello`, so `l2` is
+    ///   recorded as written and no arity error is invented.
+    /// - **Any word is dynamic** (or its bytes cannot be mapped) — consume
+    ///   the command without walking, the same answer
+    ///   `handle_interp_eval_command` gives a multi-word `interp eval`:
+    ///   substitution happens before concatenation, so the real script is
+    ///   unknowable and every definedness or arity fact derived from the
+    ///   written words would be a guess.
     fn dispatch_concatenated_script(
         &mut self,
         cmd_name: &str,
@@ -1638,7 +1636,7 @@ impl Analyser {
         let (Some(words), Some(tokens)) = (args.get(first..), arg_tokens.get(first..)) else {
             return;
         };
-        let (Some(first_tok), Some(last_tok)) = (tokens.first(), tokens.last()) else {
+        let Some(first_tok) = tokens.first() else {
             return;
         };
         // W105 still belongs to the written first word (`eval set …` is an
@@ -1651,8 +1649,9 @@ impl Analyser {
             *first_tok,
             arg_single.get(first).copied().unwrap_or(false),
         );
-        let Some(script) = super::utils::concat_script_words(words, tokens) else {
-            // The tail cannot be joined (a dynamic word). A braced first word
+        let Some((script, span)) = super::utils::concat_script_window(words, tokens, &self.source)
+        else {
+            // The tail cannot be walked (a dynamic word). A braced first word
             // is still a literal script prefix — concatenation appends after
             // it, so its own commands run as written — and walking it keeps
             // every scope/definition it declares visible to the editor. The
@@ -1669,15 +1668,10 @@ impl Analyser {
             self.record_var_body_const_dispatch(*first_tok, scope_path);
             return;
         };
-        let start = first_tok.span.start() + u32::from(first_tok.content_offset);
-        let end = last_tok.span.end();
-        if script.is_empty() || u32::try_from(script.len()).is_ok_and(|len| start + len > end) {
-            return;
-        }
         // `analyse_body` walks only a `Str` (braced) body and anchors at
-        // `span.start() + content_offset`, so the synthetic token carries the
-        // joined script's own base offset with no delimiter to skip.
-        let anchor = Token::new(TokenType::Str, tcl_lexer::Span::new(start, end));
+        // `span.start() + content_offset`; the window's text starts at its
+        // span's own first byte, so the anchor carries no delimiter to skip.
+        let anchor = Token::new(TokenType::Str, span);
         self.analyse_body(&script, anchor, scope_path);
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -578,20 +578,19 @@ fn collect_script_concat_writes(
             // (concatenation only appends after it), so its writes are
             // recovered from that word alone — mirroring the analyser's
             // `dispatch_concatenated_script` fallback.
-            let script = match concat_barrier_words(tokens, first + 1) {
-                Some(script) => script,
-                None => {
-                    let (Some(text), Some(&kind)) = (
-                        tokens.argv_texts.get(first + 1),
-                        tokens.argv_kinds.get(first + 1),
-                    ) else {
-                        continue;
-                    };
-                    if kind != tcl_lexer::TokenType::Str {
-                        continue;
-                    }
-                    text.clone()
+            let script = if let Some(script) = concat_barrier_words(tokens, first + 1) {
+                script
+            } else {
+                let (Some(text), Some(&kind)) = (
+                    tokens.argv_texts.get(first + 1),
+                    tokens.argv_kinds.get(first + 1),
+                ) else {
+                    continue;
+                };
+                if kind != tcl_lexer::TokenType::Str {
+                    continue;
                 }
+                text.clone()
             };
             let mut writes = Vec::new();
             crate::ir_helpers::script_text_out_vars(&script, &mut writes);

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -572,8 +572,26 @@ fn collect_script_concat_writes(
             };
             // `argv_texts` / `argv_kinds` include the command word at index 0;
             // `args` does not, so the body index shifts by one.
-            let Some(script) = concat_barrier_words(tokens, first + 1) else {
-                continue;
+            //
+            // A dynamic tail declines the join, not the braced first word:
+            // `eval {set l2 5} $extra` still runs `set l2 5` as written
+            // (concatenation only appends after it), so its writes are
+            // recovered from that word alone — mirroring the analyser's
+            // `dispatch_concatenated_script` fallback.
+            let script = match concat_barrier_words(tokens, first + 1) {
+                Some(script) => script,
+                None => {
+                    let (Some(text), Some(&kind)) = (
+                        tokens.argv_texts.get(first + 1),
+                        tokens.argv_kinds.get(first + 1),
+                    ) else {
+                        continue;
+                    };
+                    if kind != tcl_lexer::TokenType::Str {
+                        continue;
+                    }
+                    text.clone()
+                }
             };
             let mut writes = Vec::new();
             crate::ir_helpers::script_text_out_vars(&script, &mut writes);

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -145,6 +145,37 @@ pub(in crate::analyser) fn has_substitution_of_kind(
         || matches!(kind, tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd)
 }
 
+/// Whether one word of a [`tcl_registry::Traits::SCRIPT_CONCATENATES_ARGS`]
+/// tail contributes *statically-known script text* to the `Tcl_ConcatObj`
+/// join — the one predicate every eval-family static-tail check shares
+/// (`utils::concat_script_window`, `concat_barrier_words`), so what counts
+/// as static moves everywhere at once.
+///
+/// A braced (`Str`) word always does: the braces blocked every outer
+/// substitution, so its contents reach the join byte-for-byte — a `$` or
+/// `[` inside is script *text* that the eval-family command itself
+/// resolves when the joined script runs, not a value consumed before it
+/// (tclsh8.6.14 / tclsh9.0.4: `set value 5; eval {set l2} {$value};
+/// puts $l2` → `5`).
+///
+/// Any other word is static only when nothing runs before the join: no
+/// `$`/`[` substitution ([`has_substitution_of_kind`], which also rejects
+/// whole-word `Var`/`Cmd` tokens), no backslash (the outer parse decodes
+/// it, so the joined text is not the written text), and no quote byte
+/// (quoting is consumed by the outer parse, never carried into the join).
+/// A `{*}` expansion prefix restructures the words entirely and is never
+/// static.
+pub(in crate::analyser) fn word_is_static_script_text(
+    text: &str,
+    kind: tcl_lexer::TokenType,
+) -> bool {
+    match kind {
+        tcl_lexer::TokenType::Str => true,
+        tcl_lexer::TokenType::Expand => false,
+        _ => !has_substitution_of_kind(text, kind) && !text.contains(['\\', '"']),
+    }
+}
+
 /// An identifier-continuation byte: ASCII alphanumeric, `_`, or `:` (the
 /// namespace-separator byte).
 pub(super) fn is_ident_continue(b: u8) -> bool {
@@ -601,9 +632,11 @@ fn collect_script_concat_writes(
 }
 
 /// The `Tcl_ConcatObj` join of a barrier call's words from `first` onwards,
-/// or `None` when any of them carries a substitution (the real script is then
-/// unknowable — see `crate::analyser::utils::concat_script_words`, which
-/// applies the same rule to the analyser's own token slices).
+/// or `None` when any of them is not statically-known script text (the real
+/// script is then unknowable — see [`word_is_static_script_text`], the same
+/// predicate `crate::analyser::utils::concat_script_window` applies to the
+/// analyser's own token slices). This join is consumed for write-name
+/// harvesting only, never for spans, so a plain text join suffices here.
 fn concat_barrier_words(tokens: &crate::ir::CommandTokens, first: usize) -> Option<String> {
     let texts = tokens.argv_texts.get(first..)?;
     let kinds = tokens.argv_kinds.get(first..)?;
@@ -612,7 +645,7 @@ fn concat_barrier_words(tokens: &crate::ir::CommandTokens, first: usize) -> Opti
     }
     let mut joined = String::new();
     for (text, &kind) in texts.iter().zip(kinds) {
-        if has_substitution_of_kind(text, kind) {
+        if !word_is_static_script_text(text, kind) {
             return None;
         }
         let trimmed = text.trim_matches(|c: char| c.is_ascii_whitespace());

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -128,12 +128,21 @@ pub(super) fn is_braced_word(tok: &tcl_lexer::Token) -> bool {
 /// True when `text` carries a substitution (`$` / `[`) or `tok` is a
 /// `Var` / `Cmd` token.
 pub(in crate::analyser) fn has_substitution(text: &str, tok: &tcl_lexer::Token) -> bool {
+    has_substitution_of_kind(text, tok.kind)
+}
+
+/// [`has_substitution`] for a consumer that holds the word's token *kind*
+/// without the token itself — the IR's `CommandTokens` records `argv_kinds`
+/// alongside `argv_texts`, with no `Token` to hand.  The one predicate both
+/// spellings share, so a change to what counts as a substitution reaches
+/// every static-word check at once.
+pub(in crate::analyser) fn has_substitution_of_kind(
+    text: &str,
+    kind: tcl_lexer::TokenType,
+) -> bool {
     text.contains('$')
         || text.contains('[')
-        || matches!(
-            tok.kind,
-            tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd
-        )
+        || matches!(kind, tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd)
 }
 
 /// An identifier-continuation byte: ASCII alphanumeric, `_`, or `:` (the
@@ -392,6 +401,13 @@ pub(super) struct UndefSuppression {
     /// `$tmp` read in the same expression looks read-before-set.  Name-level,
     /// suppress-only.
     cmd_sub_writes: FxHashSet<String>,
+    /// Names written by a `Traits::SCRIPT_CONCATENATES_ARGS` call whose
+    /// script the lowering left as an opaque barrier — `eval set l2 hello`
+    /// really does set `l2` in the caller's own frame, but its words reach
+    /// the IR as barrier arguments with no def attached, so a later
+    /// `puts $l2` looked read-before-set (issue #1051).  Name-level,
+    /// suppress-only.
+    script_concat_writes: FxHashSet<String>,
     /// `(name, version)` pairs killed by an `unset` — undef at their reads,
     /// so a direct read of one is read-before-set just like a version-0
     /// origin.
@@ -455,6 +471,7 @@ impl UndefSuppression {
         if self.alias_tails.contains(name)
             || self.dict_vars.contains(name)
             || self.cmd_sub_writes.contains(name)
+            || self.script_concat_writes.contains(name)
         {
             return true;
         }
@@ -494,6 +511,103 @@ fn collect_expr_cmd_sub_writes(
         }
     }
     out
+}
+
+/// Names written by a [`tcl_registry::Traits::SCRIPT_CONCATENATES_ARGS`]
+/// command whose trailing words are all static literals.
+///
+/// The lowering only inlines the single-word `eval {script}` shape; a
+/// multi-word `eval set l2 hello` stays a `Statement::Barrier`, so SSA sees
+/// no definition of `l2` and a later `puts $l2` reads a version-0 origin.
+/// Reconstructing the `Tcl_ConcatObj` join here recovers the write without
+/// claiming anything the barrier does not already guarantee — name-level and
+/// suppress-only, exactly like [`collect_expr_cmd_sub_writes`].
+///
+/// Gated on [`tcl_registry::BodyKind::Plain`], which is the registry's own
+/// record of *whose frame the body runs in*.  `eval` is `Plain` — its script
+/// runs in the caller's own frame, so its writes are this function's writes.
+/// `uplevel`, `namespace eval`, `namespace inscope`, and `interp eval` are
+/// all `Structural`: their scripts write somewhere else entirely, and
+/// tclsh8.6.14/9.0.4 confirm the difference —
+/// `proc p {} {uplevel 1 set x 5; puts $x}` errors `can't read "x"` because
+/// the `set` landed in the *caller's* frame. Suppressing on those would hide
+/// a real read-before-set.
+fn collect_script_concat_writes(
+    fu: &crate::compilation_unit::FunctionUnit,
+    considered: &HashSet<BlockId>,
+) -> FxHashSet<String> {
+    use crate::ir::Statement;
+    let registry = tcl_registry::cache::registry_for_dialect("tcl8.6");
+    let mut out = FxHashSet::default();
+    for &bn in considered {
+        let Some(block) = fu.cfg.blocks.get(&bn) else {
+            continue;
+        };
+        for stmt in &block.statements {
+            let Statement::Barrier {
+                command,
+                args,
+                tokens: Some(tokens),
+                ..
+            } = stmt
+            else {
+                continue;
+            };
+            let Some(spec) = registry.get(command) else {
+                continue;
+            };
+            if !spec
+                .traits
+                .contains(tcl_registry::Traits::SCRIPT_CONCATENATES_ARGS)
+                || spec.body_kind != tcl_registry::BodyKind::Plain
+            {
+                continue;
+            }
+            let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+            let Some(&first) = registry
+                .arg_indices_for_role(command, &arg_strs, tcl_registry::ArgRole::Body)
+                .first()
+            else {
+                continue;
+            };
+            // `argv_texts` / `argv_kinds` include the command word at index 0;
+            // `args` does not, so the body index shifts by one.
+            let Some(script) = concat_barrier_words(tokens, first + 1) else {
+                continue;
+            };
+            let mut writes = Vec::new();
+            crate::ir_helpers::script_text_out_vars(&script, &mut writes);
+            out.extend(writes);
+        }
+    }
+    out
+}
+
+/// The `Tcl_ConcatObj` join of a barrier call's words from `first` onwards,
+/// or `None` when any of them carries a substitution (the real script is then
+/// unknowable — see `crate::analyser::utils::concat_script_words`, which
+/// applies the same rule to the analyser's own token slices).
+fn concat_barrier_words(tokens: &crate::ir::CommandTokens, first: usize) -> Option<String> {
+    let texts = tokens.argv_texts.get(first..)?;
+    let kinds = tokens.argv_kinds.get(first..)?;
+    if texts.len() < 2 || texts.len() != kinds.len() {
+        return None;
+    }
+    let mut joined = String::new();
+    for (text, &kind) in texts.iter().zip(kinds) {
+        if has_substitution_of_kind(text, kind) {
+            return None;
+        }
+        let trimmed = text.trim_matches(|c: char| c.is_ascii_whitespace());
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !joined.is_empty() {
+            joined.push(' ');
+        }
+        joined.push_str(trimmed);
+    }
+    Some(joined)
 }
 
 /// `dict with` / `dict update` key-aware suppression: record the dict-var
@@ -645,6 +759,7 @@ pub(super) fn build_undef_suppression(
     );
     let mut s = UndefSuppression {
         cmd_sub_writes: collect_expr_cmd_sub_writes(fu, considered),
+        script_concat_writes: collect_script_concat_writes(fu, considered),
         killed,
         can_undef,
         loop_entry_only_undef,

--- a/rust/tcl-compiler/src/analyser/diagnostics/security.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/security.rs
@@ -50,35 +50,43 @@ impl Analyser {
     /// into a script and re-parses the result (`eval`).
     ///
     /// [`Traits::EVALUATES_CODE`] alone is too wide for this shape:
-    /// `uplevel` carries it but takes an optional leading `level` word
-    /// (its script position is call-shape-dependent, owned by W301), and
     /// the coroutine injectors (`coroinject` / `coroprobe`) carry it but
     /// take a coroutine name plus a command *prefix* — a word list that is
-    /// never re-parsed.  The concat-reparse shape is the spec that pairs
-    /// the trait with [`Traits::TAINT_SINK`] and statically declares its
-    /// whole tail a script: a fixed [`ArgRole::Body`] at argument 0 with
-    /// no dynamic resolver.
+    /// never re-parsed.  The concat-reparse shape is
+    /// [`Traits::SCRIPT_CONCATENATES_ARGS`], the registry's own record of
+    /// "every trailing word joins into one re-parsed script", paired with
+    /// [`Traits::TAINT_SINK`].
+    ///
+    /// `uplevel` is excluded by [`Traits::EVALUATES_IN_SHIFTED_FRAME`], which
+    /// is *why* it belongs to W301 instead: injecting into a script that runs
+    /// in the caller's frame is a frame-escalation finding with its own
+    /// message, not the same warning as injecting into a same-frame `eval`.
+    ///
+    /// The gate used to read that split *indirectly* — "no
+    /// `arg_role_resolver`, with a fixed [`ArgRole::Body`] at argument 0" —
+    /// which made W101's scope an accident of how a spec spells its argument
+    /// layout rather than of what the command does. Both halves now name the
+    /// semantics, so re-modelling `eval`'s roles cannot silently switch W101
+    /// off (issue #1051).
     fn is_concat_eval_command(&self, cmd_name: &str) -> bool {
         self.security_spec(cmd_name).is_some_and(|s| {
             s.traits
-                .contains(Traits::EVALUATES_CODE | Traits::TAINT_SINK)
-                && s.arg_role_resolver.is_none()
-                && s.arg_role_at(0) == Some(ArgRole::Body)
+                .contains(Traits::SCRIPT_CONCATENATES_ARGS | Traits::TAINT_SINK)
+                && !s.traits.contains(Traits::EVALUATES_IN_SHIFTED_FRAME)
         })
     }
 
-    /// W301's gate: a code-evaluating taint sink whose script position is
-    /// call-shape-dependent — an optional leading `level` word resolved
-    /// dynamically (`uplevel`).  The complement of
-    /// [`Self::is_concat_eval_command`] within the
-    /// `EVALUATES_CODE + TAINT_SINK` pair: the registry models `uplevel`'s
-    /// "script starts after the optional level" layout as an
-    /// `arg_role_resolver` where `eval` has a static role table.
+    /// W301's gate: a concat-reparse taint sink whose script runs in a
+    /// **different stack frame** than the call is written in — `uplevel`.
+    /// The exact complement of [`Self::is_concat_eval_command`] within the
+    /// [`Traits::SCRIPT_CONCATENATES_ARGS`] + [`Traits::TAINT_SINK`] pair, so
+    /// every family member is owned by exactly one of the two codes and
+    /// neither double-reports.
     fn is_level_eval_command(&self, cmd_name: &str) -> bool {
         self.security_spec(cmd_name).is_some_and(|s| {
             s.traits
-                .contains(Traits::EVALUATES_CODE | Traits::TAINT_SINK)
-                && s.arg_role_resolver.is_some()
+                .contains(Traits::SCRIPT_CONCATENATES_ARGS | Traits::TAINT_SINK)
+                && s.traits.contains(Traits::EVALUATES_IN_SHIFTED_FRAME)
         })
     }
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5526,6 +5526,153 @@ fn w123_tp_a_rename_in_a_dead_branch_is_not_an_unconditional_deletion() {
 }
 
 #[test]
+fn w308_tp_a_renamed_class_name_still_types_its_constructor_1049() {
+    // TP — `rename Dog Cat` moves the class *command*; the class itself is
+    // unchanged, so `Cat new` builds a Dog and `$d fly` is still an unknown
+    // method. Before #1049 the constructor did not type at all, so the
+    // dispatch fell through to W307 noise instead.
+    //
+    // Oracle (tclsh8.6.14 and tclsh9.0.4): `oo::class create Dog { method
+    // bark {} { return woof } }; rename Dog Cat; set d [Cat new]; $d fly`
+    // fails with `unknown method "fly": must be bark or destroy`, while
+    // `$d bark` returns `woof`.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog Cat\nset d [Cat new]\n$d fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "a class reached through a rename still validates its methods; got {:?}",
+        r.diagnostics,
+    );
+    // The object is typed, so the dispatch is not an unanalysable one.
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W307),
+        "a typed dispatch must not also draw W307; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w308_tn_a_renamed_class_still_accepts_its_real_methods_1049() {
+    // TN — the same shape with a method the class really has draws nothing.
+    // Oracle (tclsh8.6.14 / tclsh9.0.4): `$d bark` → `woof`.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog Cat\nset d [Cat new]\n$d bark\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics.is_empty(),
+        "a valid method on a renamed class is silent; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w308_tn_a_constructor_written_before_its_rename_does_not_type_1049() {
+    // TN — the order gate. At top level the rename has not run yet when
+    // `[Cat new]` executes, so `Cat` is simply an unknown command there and
+    // nothing may be typed from it. The paired guard for
+    // `w123_tp_a_class_renamed_away_still_flags_its_old_name`, from the
+    // other side of the rename.
+    //
+    // Oracle (tclsh8.6.14 / tclsh9.0.4): `oo::class create Dog {…}; Cat new`
+    // — before any `rename` — fails with `invalid command name "Cat"`.
+    // The out-of-order call itself is W128's ("called after it was renamed or
+    // deleted earlier in this file" — the same order fact from the other
+    // side); W123 owns the case where the name is never established at all,
+    // as `w123_tp_a_class_renamed_away_still_flags_its_old_name` pins.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nCat new\nset d [Cat new]\nrename Dog Cat\n$d fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    let codes: HashSet<String> = r.diagnostics.iter().map(|d| d.code.to_string()).collect();
+    assert!(
+        !codes.contains("W308"),
+        "nothing may be typed from a name the rename has not created yet; got {:?}",
+        r.diagnostics,
+    );
+    assert!(
+        codes.contains("W128"),
+        "and the out-of-order use is still reported; got {codes:?}",
+    );
+}
+
+#[test]
+fn w308_tp_a_chain_of_renames_still_reaches_the_class_1049() {
+    // TP — `rename Dog Cat; rename Cat Kitten` leaves the class reachable
+    // under the last name; the hop walk follows the chain (bounded).
+    //
+    // Oracle (tclsh8.6.14 / tclsh9.0.4): `oo::class create Dog {…}; rename
+    // Dog Cat; rename Cat Kitten; set d [Kitten new]` succeeds, and
+    // `$d fly` fails `unknown method "fly"`.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog Cat\nrename Cat Kitten\nset d [Kitten new]\n$d fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "a chained rename still reaches the class; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w308_tp_an_interp_alias_of_a_class_types_its_constructor_1049() {
+    // TP — `interp alias {} Cat {} Dog` makes `Cat` dispatch to the class
+    // command, so `Cat new` builds a Dog exactly as `Dog new` does.
+    //
+    // Oracle (tclsh8.6.14 / tclsh9.0.4): `oo::class create Dog {…}; interp
+    // alias {} Cat {} Dog; set d [Cat new]` returns an `::oo::Obj*` handle.
+    let src = "oo::class create Dog { method bark {} { return woof } }\ninterp alias {} Cat {} Dog\nset d [Cat new]\n$d fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "an aliased class command still types its constructor; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w308_tn_an_alias_with_prepended_args_is_declined_1049() {
+    // TN — `interp alias {} Cat {} Dog create` prepends words, so `Cat new`
+    // is really `Dog create new`, not the constructor call the plain alias
+    // would make. The hop declines rather than mistyping.
+    //
+    // Oracle (tclsh8.6.14 / tclsh9.0.4): with that alias, `Cat new` runs
+    // `Dog create new` — it creates an *object command named `new`*, and the
+    // value is `::new`, not a fresh anonymous handle.
+    let src = "oo::class create Dog { method bark {} { return woof } }\ninterp alias {} Cat {} Dog create\nset d [Cat new]\n$d fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W308),
+        "a prepended-args alias must not be typed as a plain constructor; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w308_tp_a_renamed_class_types_a_direct_constructor_dispatch_1049() {
+    // TP — the same fix at the direct-dispatch site (`[Cat new] fly`), which
+    // types the constructor result inline rather than through a variable.
+    let src =
+        "oo::class create Dog { method bark {} { return woof } }\nrename Dog Cat\n[Cat new] fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "a direct dispatch on a renamed constructor still validates; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
 fn w308_fp_issue_1010_reestablished_class_constructor_still_flags_unknown_method() {
     let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog {}\noo::class create Dog { method bark {} { return woof } }\n[Dog new] fly";
     let mut a = Analyser::new();

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -5656,6 +5656,73 @@ fn w308_tn_an_alias_with_prepended_args_is_declined_1049() {
 }
 
 #[test]
+fn w308_tp_an_alias_to_a_renamed_class_name_reaches_the_class_1049() {
+    // TP — the alias's target is not a directly-live class but a *rename
+    // destination*: `Cat` resolves onward to the class still keyed `::Dog`.
+    // The alias hop must keep walking the chain and judge liveness where it
+    // terminates, not demand a class at the hop itself.
+    //
+    // Oracle (tclsh8.6.14 / tclsh9.0.4): `oo::class create Dog {…}; rename
+    // Dog Cat; interp alias {} Pup {} Cat; set d [Pup new]` — `$d bark` →
+    // `woof`, `$d fly` fails `unknown method "fly": must be bark or destroy`.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog Cat\ninterp alias {} Pup {} Cat\nset d [Pup new]\n$d fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "an alias to a rename destination still reaches the class; got {:?}",
+        r.diagnostics,
+    );
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W307),
+        "a typed dispatch must not also draw W307; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w308_tp_a_chain_of_aliases_reaches_the_class_1049() {
+    // TP — an alias whose target is another alias resolves hop by hop, the
+    // way Tcl re-resolves each name at invocation.
+    //
+    // Oracle (tclsh8.6.14 / tclsh9.0.4): `interp alias {} Cat {} Dog; interp
+    // alias {} Pup {} Cat; set d [Pup new]; $d fly` fails `unknown method
+    // "fly": must be bark or destroy`.
+    let src = "oo::class create Dog { method bark {} { return woof } }\ninterp alias {} Cat {} Dog\ninterp alias {} Pup {} Cat\nset d [Pup new]\n$d fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        r.diagnostics
+            .iter()
+            .any(|d| d.code == DiagCode::W308 && d.message.contains("fly")),
+        "a chain of aliases still reaches the class; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
+fn w308_tn_an_alias_to_the_vacated_source_name_stays_untyped_1049() {
+    // TN — the guard the chain walk must not lose: an alias pointing at a
+    // rename *source* lands on a vacated name. The class survives under
+    // `::Cat`, but the alias re-resolves `Dog` by name at each call and
+    // finds nothing — the lenient rename-source rule that keeps existing
+    // objects typed must not resurrect the name for an alias.
+    //
+    // Oracle (tclsh8.6.14 / tclsh9.0.4): `rename Dog Cat; interp alias {}
+    // Pup {} Dog; Pup new` fails `invalid command name "Dog"`.
+    let src = "oo::class create Dog { method bark {} { return woof } }\nrename Dog Cat\ninterp alias {} Pup {} Dog\nset d [Pup new]\n$d fly\n";
+    let mut a = Analyser::new();
+    let r = a.analyse(src, "tcl");
+    assert!(
+        !r.diagnostics.iter().any(|d| d.code == DiagCode::W308),
+        "an alias to a vacated name resolves to nothing and must not type; got {:?}",
+        r.diagnostics,
+    );
+}
+
+#[test]
 fn w308_tp_a_renamed_class_types_a_direct_constructor_dispatch_1049() {
     // TP — the same fix at the direct-dispatch site (`[Cat new] fly`), which
     // types the constructor result inline rather than through a variable.

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -716,13 +716,23 @@ impl Analyser {
     ///   encodes this by treating a rename *source* class as unconditionally
     ///   live.
     /// - An `interp alias` is re-resolved by name on every invocation, so its
-    ///   target must be a live class in its own right. A `-prependedargs`
-    ///   alias (`interp alias {} Cat {} Dog extra`) is declined outright: the
-    ///   bound words shift the constructor's arguments, so `Cat new` is not
-    ///   the call `Dog new` would be.
+    ///   target must resolve to a live command at the call site — but "live"
+    ///   is judged where the chain *terminates*, not at the alias hop itself:
+    ///   the target may be another alias or a rename destination (`rename Dog
+    ///   Cat; interp alias {} Pup {} Cat` — `Pup new` builds a Dog,
+    ///   tclsh8.6.14/9.0.4-confirmed), and demanding a directly-live class at
+    ///   the hop breaks exactly those chains. A chain that ends *on* an alias
+    ///   target requires the strict direct-class check there — a rename
+    ///   *source* name is vacated, so an alias pointing at it fails `invalid
+    ///   command name` at run time (tclsh8.6.14/9.0.4-confirmed) and the
+    ///   lenient rename-source rule below must not resurrect it. A
+    ///   `-prependedargs` alias (`interp alias {} Cat {} Dog extra`) is
+    ///   declined outright: the bound words shift the constructor's
+    ///   arguments, so `Cat new` is not the call `Dog new` would be.
     fn class_reachable_by_indirection(&self, written: &str, call_off: u32) -> Option<String> {
         let mut cur = self.canonicalise_class_name(written);
         let mut hopped = false;
+        let mut via_alias = false;
         for _ in 0..Self::MAX_CLASS_NAME_HOPS {
             // `renamed_commands` / `command_aliases` are keyed by the
             // qualified name the scanner resolved; `cur` starts as written.
@@ -733,6 +743,10 @@ impl Analyser {
                     return None;
                 }
                 cur = self.canonicalise_class_name(old);
+                // A rename destination is a live command name in its own
+                // right — the class data just stays keyed by the source —
+                // so the chain is back on the rename-chase rule.
+                via_alias = false;
             } else if let Some(alias) = self.result.command_aliases.get(&key) {
                 if !alias.extras.is_empty() {
                     return None;
@@ -745,15 +759,20 @@ impl Analyser {
                 if target == cur {
                     return None;
                 }
-                // An alias re-resolves by name each call, so its target must
-                // be live at the call site in its own right.
-                if !self.class_live_for_call(&target, call_off) {
-                    return None;
-                }
                 cur = target;
+                via_alias = true;
             } else {
-                return (hopped && self.class_live_by_name_for_call(&cur, call_off))
-                    .then(|| self.canonicalise_class_name(&cur));
+                // Terminal name. Reached through a rename chase, the class
+                // survives its source name being vacated
+                // (`class_live_by_name_for_call`); reached straight from an
+                // alias, the name itself must resolve, so only a directly
+                // live class will do.
+                let live = if via_alias {
+                    self.class_live_for_call(&cur, call_off)
+                } else {
+                    self.class_live_by_name_for_call(&cur, call_off)
+                };
+                return (hopped && live).then(|| self.canonicalise_class_name(&cur));
             }
             hopped = true;
         }

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -595,7 +595,14 @@ impl Analyser {
             let Some((target, prepended)) = method_def.forward_target.as_ref() else {
                 break;
             };
-            if target == "my" || target == "::my" {
+            // `forward m my other` re-dispatches on the same instance. The
+            // self-dispatch keyword comes from the registry (which resolves
+            // the `::`-qualified spelling itself), not a name literal
+            // (issue #1050).
+            if self.registry.is_some_and(|r| {
+                r.method_dispatch_keyword(target)
+                    == Some(tcl_registry::MethodDispatchKind::SelfDispatch)
+            }) {
                 let (next_method, rest) = prepended.split_first()?;
                 let next_provider = hierarchy.method_target(receiver_class, next_method)?;
                 // `my` dispatches on the same instance, so only an
@@ -1381,7 +1388,22 @@ impl Analyser {
             // the dispatched method resolves in the enclosing class and its
             // body is a simple `return <literal>`, the result is a plain
             // string, not an object — so the *outer* dispatch fires W307.
-            if matches!(head, "my" | "self") {
+            // `my <method>` (self-dispatch) and `self <subcommand>`
+            // (introspection) both return something the analyser treats as an
+            // object handle by default. Both kinds come from the registry;
+            // `next`/`nextto` are deliberately *not* included — they return
+            // the next implementation's result, not a handle.
+            if self
+                .registry
+                .and_then(|r| r.method_dispatch_keyword(head))
+                .is_some_and(|kind| {
+                    matches!(
+                        kind,
+                        tcl_registry::MethodDispatchKind::SelfDispatch
+                            | tcl_registry::MethodDispatchKind::Introspection
+                    )
+                })
+            {
                 let returns_literal = arg_strs.first().is_some_and(|method| {
                     self.oo_self_method_returns_literal(site.cmd_span.start(), method)
                 });

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -162,6 +162,13 @@ impl Analyser {
                             || self.class_live_for_call(&head, off)
                         {
                             class_qn = Some(qn);
+                        } else {
+                            // The head may reach a live class through a
+                            // `rename` or `interp alias` — `rename Dog Cat`
+                            // then `set d [Cat new]` types `d` as `::Dog`
+                            // (issue #1049). Resolved to the *canonical*
+                            // name so the `ClassDef` / method lookup keys.
+                            class_qn = self.class_reachable_by_indirection(&head, off);
                         }
                     }
                     // The constructor's class head is a `$var` reference
@@ -667,6 +674,95 @@ impl Analyser {
             proc_by_tail,
             class_by_tail,
         }
+    }
+
+    /// Maximum command-name hops [`Self::class_reachable_by_indirection`]
+    /// follows. Mirrors the eight-hop cap the user-call arity resolver uses
+    /// for the same chains (`validity.rs`), so a `rename a b; rename b c; …`
+    /// cycle cannot spin.
+    const MAX_CLASS_NAME_HOPS: u8 = 8;
+
+    /// The canonical class a *written* command name reaches at `call_off`
+    /// after following `rename` and `interp alias` indirection, or `None`
+    /// when it reaches no live class.
+    ///
+    /// `rename Dog Cat` makes `Cat` the class command: tclsh8.6.14 and
+    /// tclsh9.0.4 both accept `set d [Cat new]; $d bark` and both reject
+    /// `$d fly` with `unknown method "fly": must be bark or destroy`. The
+    /// class's own identity is unchanged by the rename — its `ClassDef` and
+    /// method table are still keyed by `::Dog` — so this resolves *forward*
+    /// through `renamed_commands` (which maps `new → old`) and returns the
+    /// canonical name, which is what the method lookup needs (issue #1049).
+    ///
+    /// Both hop kinds are order-gated on the offset that established them,
+    /// via the same rule the user-call arity resolver uses: unconditional
+    /// inside a proc/method body (the whole file loads before any body runs)
+    /// and textual-order-gated at top level. `[Cat new]` written *before* the
+    /// rename therefore resolves to nothing — matching tclsh, where it is
+    /// simply an unknown command.
+    ///
+    /// The two hop kinds are not symmetric, and the asymmetry is deliberate:
+    ///
+    /// - A `rename` moves the command once and for all, so the old name being
+    ///   gone afterwards is exactly what freed it up — chasing back through it
+    ///   is always valid. [`Self::class_live_by_name_for_call`] already
+    ///   encodes this by treating a rename *source* class as unconditionally
+    ///   live.
+    /// - An `interp alias` is re-resolved by name on every invocation, so its
+    ///   target must be a live class in its own right. A `-prependedargs`
+    ///   alias (`interp alias {} Cat {} Dog extra`) is declined outright: the
+    ///   bound words shift the constructor's arguments, so `Cat new` is not
+    ///   the call `Dog new` would be.
+    fn class_reachable_by_indirection(&self, written: &str, call_off: u32) -> Option<String> {
+        let mut cur = self.canonicalise_class_name(written);
+        let mut hopped = false;
+        for _ in 0..Self::MAX_CLASS_NAME_HOPS {
+            // `renamed_commands` / `command_aliases` are keyed by the
+            // qualified name the scanner resolved; `cur` starts as written.
+            let key = crate::naming::normalise_qualified_name(&cur);
+            if let Some(old) = self.result.renamed_commands.get(&key) {
+                let established = *self.result.rename_offsets.get(&key)?;
+                if !self.indirection_in_effect(established, call_off) {
+                    return None;
+                }
+                cur = self.canonicalise_class_name(old);
+            } else if let Some(alias) = self.result.command_aliases.get(&key) {
+                if !alias.extras.is_empty() {
+                    return None;
+                }
+                let established = *self.result.alias_offsets.get(&key)?;
+                if !self.indirection_in_effect(established, call_off) {
+                    return None;
+                }
+                let target = self.canonicalise_class_name(&alias.target);
+                if target == cur {
+                    return None;
+                }
+                // An alias re-resolves by name each call, so its target must
+                // be live at the call site in its own right.
+                if !self.class_live_for_call(&target, call_off) {
+                    return None;
+                }
+                cur = target;
+            } else {
+                return (hopped && self.class_live_by_name_for_call(&cur, call_off))
+                    .then(|| self.canonicalise_class_name(&cur));
+            }
+            hopped = true;
+        }
+        None
+    }
+
+    /// Whether an indirection established at `established` is observably in
+    /// effect by the time the call at `call_off` runs.
+    ///
+    /// Order-gated at top level and unconditional inside a definition body —
+    /// the whole file loads, running every top-level statement, before any
+    /// body runs, so a rename written after a method that uses it is still in
+    /// effect when that method executes. The same rule `validity.rs`'s
+    /// `fact_in_effect` applies to proc definitions, renames, and aliases.
+    fn indirection_in_effect(&self, established: u32, call_off: u32) -> bool {
+        established < call_off || self.result.offset_is_inside_any_definition_body(call_off)
     }
 
     /// Whether `qualified` names a class that is still live at `call_off`
@@ -1211,6 +1307,36 @@ impl Analyser {
         self.emit_cmd_command_diagnostics(registry, hierarchy.as_ref());
     }
 
+    /// Whether `site` is a `[cmd]::method` namespaced-ensemble dispatch
+    /// (FP-OBJ-07): a command-substitution head composed with a literal
+    /// `::method` tail.
+    ///
+    /// The literal tail is static method-name evidence — the dispatch is
+    /// well-formed, with only the namespace prefix computed at run time — so
+    /// W307 must not fire. A bare `[cmd] arg` dispatch with no `::method`
+    /// tail has no such evidence and still fires.
+    fn is_namespaced_ensemble_dispatch(
+        &self,
+        site: &crate::analyser::state::CmdCommandSite,
+    ) -> bool {
+        let start = site.cmd_span.start() as usize;
+        let end = (site.cmd_span.end() as usize).min(self.source.len());
+        let Some(word) = self.source.get(start..end) else {
+            return false;
+        };
+        if !word.starts_with('[') {
+            return false;
+        }
+        let Some(sep) = word.find("]::") else {
+            return false;
+        };
+        let tail = &word[sep + 3..];
+        !tail.is_empty()
+            && tail
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == ':')
+    }
+
     /// Emit W307/W308 for `[cmd] method` command-substitution dispatch sites.
     ///
     /// W307 fires only when the inner command's return type is unknown AND the
@@ -1224,28 +1350,8 @@ impl Analyser {
     ) {
         let cmd_sites = std::mem::take(&mut self.cmd_command_sites);
         for site in &cmd_sites {
-            // `[cmd]::method` namespaced-ensemble dispatch (FP-OBJ-07): a
-            // command-substitution head composed with a literal `::method` tail.
-            // The literal tail is static method-name evidence — the dispatch is
-            // well-formed (only the namespace prefix is computed at runtime), so
-            // W307 must not fire. A bare `[cmd] arg` dispatch with no `::method`
-            // tail has no such evidence and still fires.
-            {
-                let s = site.cmd_span.start() as usize;
-                let e = (site.cmd_span.end() as usize).min(self.source.len());
-                let word = &self.source[s..e];
-                if word.starts_with('[')
-                    && let Some(p) = word.find("]::")
-                {
-                    let tail = &word[p + 3..];
-                    if !tail.is_empty()
-                        && tail
-                            .chars()
-                            .all(|c| c.is_alphanumeric() || c == '_' || c == ':')
-                    {
-                        continue;
-                    }
-                }
+            if self.is_namespaced_ensemble_dispatch(site) {
+                continue;
             }
             // No blanket `in_method` suppression: an in-method `[cmd] method`
             // dispatch must earn its silence from a positive signal (a known
@@ -1298,11 +1404,21 @@ impl Analyser {
             // command) so we recognise the constructor pattern
             // explicitly here — ``known_class new/create`` maps to
             // ``TclType.OBJECT`` with the class name attached.
-            let class_qn = self.canonicalise_class_name(head);
+            let mut class_qn = self.canonicalise_class_name(head);
             // Renamed/deleted with no re-establishment fails the call (issue #1010).
             let off = site.cmd_span.start();
-            let head_is_known_class =
+            let mut head_is_known_class =
                 self.class_live_for_call(&class_qn, off) || self.class_live_for_call(head, off);
+            // …but a `rename`/`interp alias` can make a *different* written
+            // name reach the class, and the constructor call is then perfectly
+            // ordinary (issue #1049). Resolve to the canonical name so the
+            // object type carries the identity the method tables are keyed by.
+            if !head_is_known_class
+                && let Some(reached) = self.class_reachable_by_indirection(head, off)
+            {
+                class_qn = reached;
+                head_is_known_class = true;
+            }
             let is_constructor_call = head_is_known_class
                 && arg_strs
                     .first()

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1589,11 +1589,76 @@ impl Analyser {
 
         // Body recursion lets procs and classes declared inside
         // ``namespace eval`` register with the correct namespace
-        // prefix.
-        if let (Some(text), Some(tok)) = (body_text, body_tok) {
+        // prefix.  Words past the body join into the script exactly as
+        // `eval`'s do, so a multi-word call is analysed as the whole
+        // concatenation or not at all (issue #1051) — never as its first
+        // word alone, which invented an E002 on the trailing words'
+        // arguments and lost every write they performed.
+        if args.len() > 3 {
+            self.analyse_namespace_eval_tail(args, arg_tokens, &child_path);
+        } else if let (Some(text), Some(tok)) = (body_text, body_tok) {
             self.analyse_body(&text, tok, &child_path);
         }
         true
+    }
+
+    /// Analyse the script a multi-word `namespace eval` / `namespace inscope`
+    /// evaluates, in the namespace scope `child_path` already opened for it.
+    ///
+    /// The two subcommands share this hook but not their tail semantics, and
+    /// the registry records the split:
+    ///
+    /// - `namespace eval ns arg ?arg …?` carries
+    ///   [`tcl_registry::Traits::SCRIPT_CONCATENATES_ARGS`] alone — the tail
+    ///   space-joins into the script (`namespace eval ::n set l2 hello` sets
+    ///   `::n::l2`, tclsh8.6.14/9.0.4-confirmed), so a fully-static tail is
+    ///   joined and walked.
+    /// - `namespace inscope ns script ?arg …?` adds
+    ///   [`tcl_registry::Traits::SCRIPT_APPENDS_LIST_ARGS`] — the tail is
+    ///   appended as *list elements*, so `namespace inscope :: {puts} {a b}`
+    ///   prints `a b` where `namespace eval :: {puts} {a b}` errors. A join
+    ///   would be simply wrong, and reconstructing the list quoting is beyond
+    ///   what the analyser models, so any trailing word means the call is
+    ///   consumed without walking.
+    ///
+    /// A dynamic word takes the same consume-without-walk route as
+    /// [`Self::handle_interp_eval_command`]'s multi-word arm: substitution
+    /// runs before concatenation, so the real script is unknowable.
+    fn analyse_namespace_eval_tail(
+        &mut self,
+        args: &[String],
+        arg_tokens: &[Token],
+        child_path: &[usize],
+    ) {
+        let Some(registry) = self.registry else {
+            return;
+        };
+        let list_append = registry
+            .get("namespace")
+            .and_then(|spec| spec.subcommand(&args[0]))
+            .is_some_and(|sub| {
+                sub.traits
+                    .contains(tcl_registry::Traits::SCRIPT_APPENDS_LIST_ARGS)
+            });
+        if list_append {
+            return;
+        }
+        let (Some(words), Some(tokens)) = (args.get(2..), arg_tokens.get(2..)) else {
+            return;
+        };
+        let (Some(first_tok), Some(last_tok)) = (tokens.first(), tokens.last()) else {
+            return;
+        };
+        let Some(script) = super::utils::concat_script_words(words, tokens) else {
+            return;
+        };
+        let start = first_tok.span.start() + u32::from(first_tok.content_offset);
+        let end = last_tok.span.end();
+        if script.is_empty() || u32::try_from(script.len()).is_ok_and(|len| start + len > end) {
+            return;
+        }
+        let anchor = Token::new(TokenType::Str, tcl_lexer::Span::new(start, end));
+        self.analyse_body(&script, anchor, child_path);
     }
 
     /// Handle `interp eval PATH SCRIPT`: the script runs in a **child**

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1683,11 +1683,12 @@ impl Analyser {
         let (Some(words), Some(tokens)) = (args.get(2..), arg_tokens.get(2..)) else {
             return;
         };
-        let (Some(first_tok), Some(last_tok)) = (tokens.first(), tokens.last()) else {
+        let Some(first_tok) = tokens.first() else {
             return;
         };
-        let Some(script) = super::utils::concat_script_words(words, tokens) else {
-            // The tail cannot be joined (a dynamic word). A braced first word
+        let Some((script, span)) = super::utils::concat_script_window(words, tokens, &self.source)
+        else {
+            // The tail cannot be walked (a dynamic word). A braced first word
             // is still a literal script prefix — concatenation appends after
             // it — and it is the namespace's whole visible body in the common
             // mangled-document case (an unbalanced brace inside the body word
@@ -1698,12 +1699,7 @@ impl Analyser {
             }
             return;
         };
-        let start = first_tok.span.start() + u32::from(first_tok.content_offset);
-        let end = last_tok.span.end();
-        if script.is_empty() || u32::try_from(script.len()).is_ok_and(|len| start + len > end) {
-            return;
-        }
-        let anchor = Token::new(TokenType::Str, tcl_lexer::Span::new(start, end));
+        let anchor = Token::new(TokenType::Str, span);
         self.analyse_body(&script, anchor, child_path);
     }
 

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -851,13 +851,12 @@ impl Analyser {
             doc = super::utils::extract_body_docstring(&args[2]);
         }
 
-        // When a user defines ``proc unknown ...`` (or
-        // ``::tcl::unknown``), inspect the body to determine which
-        // commands the handler can resolve.  The result gates
-        // W123 (unresolved command) — if the user provided their
-        // own ``unknown`` we can't statically prove a command is
-        // truly unresolved.
-        if matches!(simple.as_str(), "unknown") || qualified == "::tcl::unknown" {
+        // When a user defines the *global* unresolved-command handler,
+        // inspect the body to determine which commands it can resolve. The
+        // result gates W123 (unresolved command) file-wide — with a
+        // user-supplied handler in place we cannot statically prove a
+        // command is truly unresolved.
+        if self.defines_global_unresolved_handler(&qualified) {
             let info = self.extract_unknown_proc_info(&args[2], &params);
             self.result.unknown_proc_info = Some(info);
         }
@@ -1511,6 +1510,44 @@ impl Analyser {
         }
         self.last_comment = saved_comment;
         true
+    }
+
+    /// Whether a `proc` defined as `qualified` is the interpreter's *global*
+    /// unresolved-command handler — the one whose presence gates W123 for the
+    /// whole file.
+    ///
+    /// Which command is the handler comes from
+    /// [`tcl_registry::Traits::UNRESOLVED_COMMAND_HANDLER`], never a literal
+    /// name here — the same registry query `tcl_compiler::unit_scope` uses for
+    /// the interprocedural call-site seed.
+    ///
+    /// **Global only.** Tcl consults `::unknown` for a bare unresolved word
+    /// regardless of the calling namespace, so a namespace-local
+    /// `proc unknown` inside `namespace eval ::mylib { … }` is an ordinary
+    /// proc that happens to share the name and must not suppress anything.
+    /// tclsh8.6.14 and tclsh9.0.4 both confirm the split: with a global
+    /// `proc unknown {args} {return handled}` a call to
+    /// `totallyBogusCommand` returns `handled`, while with the same proc
+    /// defined inside `namespace eval ::mylib` it still fails
+    /// `invalid command name "totallyBogusCommand"`. (`namespace unknown
+    /// NAME` registers a per-namespace handler explicitly; that path is
+    /// modelled separately by its handler argument's
+    /// [`tcl_registry::ArgRole::CommandPrefix`] role.)
+    ///
+    /// `::tcl::unknown` is admitted alongside `::unknown`: it is the Tcl
+    /// library's own handler spelling, installed as the interpreter-wide
+    /// handler rather than scoped to callers inside `::tcl`.
+    fn defines_global_unresolved_handler(&self, qualified: &str) -> bool {
+        let Some(registry) = self.registry else {
+            return false;
+        };
+        let mut carriers =
+            registry.commands_with_trait(tcl_registry::Traits::UNRESOLVED_COMMAND_HANDLER);
+        carriers.sort_unstable();
+        carriers.iter().any(|name| {
+            qualified == crate::naming::qualify("::", name)
+                || qualified == crate::naming::qualify("::tcl", name)
+        })
     }
 
     /// Handle `namespace eval`: opens a new namespace scope and
@@ -8513,6 +8550,102 @@ mod tests {
         let r = a.analyse("proc unknown {cmd args} {}", "tcl");
         let info = r.unknown_proc_info.expect("unknown_proc_info populated");
         assert!(info.empty_stub);
+    }
+
+    /// Pin (gap-review C3) — `conditional_depth` is driven by
+    /// `Traits::BRANCH_SELECTED_BODY`, so exactly the branch-selected bodies
+    /// mark a `package require` conditional.
+    ///
+    /// `if` and `try` bodies are branch-selected: at most one runs, chosen at
+    /// run time, so nothing inside dominates the code after the command. A
+    /// `while` body is skippable *and* repeatable — a different question,
+    /// owned by `control_flow_body_depth` — and does **not** mark the require
+    /// conditional. A top-level require is unconditional.
+    #[test]
+    fn package_require_conditionality_follows_the_branch_selected_body_trait() {
+        let conditional_flags = |src: &str| -> Vec<bool> {
+            let mut a = crate::analyser::Analyser::new();
+            a.analyse(src, "tcl8.6")
+                .package_requires
+                .iter()
+                .map(|p| p.conditional)
+                .collect()
+        };
+        assert_eq!(conditional_flags("package require Tcl 8.6\n"), vec![false]);
+        assert_eq!(
+            conditional_flags("if {$x} { package require Tcl 8.6 }\n"),
+            vec![true],
+        );
+        assert_eq!(
+            conditional_flags("while {$x} { package require Tcl 8.6 }\n"),
+            vec![false],
+            "a loop body is skippable-and-repeatable, a different question",
+        );
+        // `try` carries the trait too, but reaches its bodies through its own
+        // analyser hook rather than the generic body walk, so this depth is
+        // never bumped for it. Pinned as it stands: the trait swap is
+        // behaviour-preserving, and closing that gap is a separate change to
+        // `handle_try_command`.
+        assert_eq!(
+            conditional_flags("try { package require Tcl 8.6 } on error {} {}\n"),
+            vec![false],
+        );
+    }
+
+    /// FIX (gap-review C2) — a `proc unknown` nested inside `namespace eval`
+    /// is an ordinary namespace proc, not the interpreter's handler, so it
+    /// must not seed `unknown_proc_info` and suppress W123 file-wide.
+    ///
+    /// The body is the dynamic (`exec`-dispatching) shape that *would*
+    /// suppress W123 file-wide if this were the global handler, so the test
+    /// isolates the scope question rather than the body-shape one.
+    ///
+    /// Oracle (tclsh8.6.14 and tclsh9.0.4): with
+    /// `namespace eval ::mylib { proc unknown {args} { return handled } }`,
+    /// calling `totallyBogusCommand` still fails
+    /// `invalid command name "totallyBogusCommand"` — only a *global*
+    /// `proc unknown` makes it return `handled`.
+    #[test]
+    fn analyse_namespace_local_unknown_proc_does_not_seed_the_global_handler() {
+        let mut a = crate::analyser::Analyser::new();
+        let r = a.analyse(
+            "namespace eval ::mylib { proc unknown {cmd args} { exec $cmd {*}$args } }\n\
+             totallyBogusCommand\n",
+            "tcl9.0",
+        );
+        assert!(
+            r.unknown_proc_info.is_none(),
+            "a namespace-local proc named unknown is not the global handler",
+        );
+        assert!(
+            r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W123),
+            "so the bogus command is still unresolved; got {:?}",
+            r.diagnostics,
+        );
+    }
+
+    /// TP guard — the global handler still seeds the info (and still
+    /// suppresses W123), which is the behaviour the C2 fix must not disturb.
+    #[test]
+    fn analyse_global_unknown_proc_still_seeds_the_handler() {
+        let mut a = crate::analyser::Analyser::new();
+        let r = a.analyse(
+            "proc unknown {cmd args} { exec $cmd {*}$args }\ntotallyBogusCommand\n",
+            "tcl9.0",
+        );
+        assert!(
+            r.unknown_proc_info.is_some(),
+            "a global proc unknown is the handler",
+        );
+        assert!(
+            !r.diagnostics
+                .iter()
+                .any(|d| d.code == tcl_core_types::DiagCode::W123),
+            "and it suppresses the unresolved-command warning; got {:?}",
+            r.diagnostics,
+        );
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1687,6 +1687,15 @@ impl Analyser {
             return;
         };
         let Some(script) = super::utils::concat_script_words(words, tokens) else {
+            // The tail cannot be joined (a dynamic word). A braced first word
+            // is still a literal script prefix — concatenation appends after
+            // it — and it is the namespace's whole visible body in the common
+            // mangled-document case (an unbalanced brace inside the body word
+            // drags trailing text into extra words). Walk it rather than
+            // discarding every proc and variable the namespace declares.
+            if first_tok.kind == TokenType::Str {
+                self.analyse_body(&words[0], *first_tok, child_path);
+            }
             return;
         };
         let start = first_tok.span.start() + u32::from(first_tok.content_offset);

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -524,6 +524,14 @@ impl Analyser {
                 self.lexer_config(),
             );
             for cmd in &cmds {
+                // `link` is deliberately *not* a method-dispatch keyword and
+                // carries none of the `TCLOO_*` traits (issue #1050): it
+                // *creates* per-object bareword commands rather than
+                // dispatching one, so the barewords it installs are per-class
+                // data, not language keywords. Recognising the `link` call
+                // itself is a spec-name match with no behavioural fact behind
+                // it to query — the migration to a registry-modelled member
+                // grammar for `oo::Helpers` is tracked by issue #1026.
                 if cmd.is_partial || cmd.texts.first().map(String::as_str) != Some("link") {
                     continue;
                 }

--- a/rust/tcl-compiler/src/analyser/utils.rs
+++ b/rust/tcl-compiler/src/analyser/utils.rs
@@ -823,6 +823,136 @@ pub fn irules_top_level_only(registry: &CommandRegistry) -> HashSet<String> {
         .collect()
 }
 
+/// Join the trailing words of a [`Traits::SCRIPT_CONCATENATES_ARGS`] call
+/// into the script Tcl will actually evaluate, or `None` when the join is
+/// not statically knowable.
+///
+/// `Tcl_ConcatObj` (`generic/tclUtil.c`) is the one rule the whole eval
+/// family shares: take each word's **string representation**, trim ASCII
+/// whitespace from both ends of it, drop the ones that end up empty, and
+/// join the rest with a single space. A braced word contributes its
+/// *contents* — Tcl's word parsing has already removed the outer braces
+/// before `Tcl_ConcatObj` ever sees the value — so braced and bare words
+/// concatenate identically and a command may span word boundaries.
+///
+/// Pinned against tclsh8.6.14 and tclsh9.0.4:
+///
+/// ```text
+/// concat {set x} {5}       → set x 5        (braces gone, single space)
+/// concat "  a  " "  b  "   → a b            (each word trimmed)
+/// concat a {} b            → a b            (empty word dropped)
+/// eval set l2 hello        ≡ set l2 hello
+/// eval {set l2} hello      ≡ set l2 hello
+/// eval {set l2 hello}      ≡ set l2 hello
+/// ```
+///
+/// Returns `None` as soon as any word carries a substitution, because
+/// substitution runs *before* concatenation: `eval $cmd arg` can build any
+/// script at all, so no analysis of the written text is sound. Callers must
+/// then consume the command without walking it rather than guess.
+///
+/// The static-word test is the analyser's one predicate for it,
+/// `diagnostics::helpers::has_substitution`, so this helper and every other
+/// static-word check move together.
+///
+/// This is **not** the rule for `namespace inscope`, whose tail is appended
+/// as list elements — see [`Traits::SCRIPT_APPENDS_LIST_ARGS`].
+#[must_use]
+pub fn concat_script_words(words: &[String], tokens: &[Token]) -> Option<String> {
+    if words.is_empty() || words.len() != tokens.len() {
+        return None;
+    }
+    let mut joined = String::new();
+    for (word, tok) in words.iter().zip(tokens) {
+        if crate::analyser::diagnostics::helpers::has_substitution(word, tok) {
+            return None;
+        }
+        let trimmed = word.trim_matches(|c: char| c.is_ascii_whitespace());
+        if trimmed.is_empty() {
+            continue;
+        }
+        if !joined.is_empty() {
+            joined.push(' ');
+        }
+        joined.push_str(trimmed);
+    }
+    Some(joined)
+}
+
+#[cfg(test)]
+mod concat_script_words_tests {
+    use super::concat_script_words;
+    use tcl_lexer::{Span, Token, TokenType};
+
+    fn words(pairs: &[(&str, TokenType)]) -> (Vec<String>, Vec<Token>) {
+        let mut texts = Vec::new();
+        let mut toks = Vec::new();
+        let mut at = 0u32;
+        for (text, kind) in pairs {
+            let len = u32::try_from(text.len()).expect("short fixture");
+            texts.push((*text).to_owned());
+            toks.push(Token::new(*kind, Span::new(at, at + len)));
+            at += len + 1;
+        }
+        (texts, toks)
+    }
+
+    /// `Tcl_ConcatObj` joins the words' string representations with a single
+    /// space; a braced word's string rep is its contents, so bare and braced
+    /// words concatenate identically.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `concat {set x} {5}` → `set x 5`.
+    #[test]
+    fn braced_and_bare_words_join_identically() {
+        let (t, k) = words(&[("set l2", TokenType::Str), ("hello", TokenType::Esc)]);
+        assert_eq!(concat_script_words(&t, &k).as_deref(), Some("set l2 hello"));
+        let (t, k) = words(&[
+            ("set", TokenType::Esc),
+            ("l2", TokenType::Esc),
+            ("hello", TokenType::Esc),
+        ]);
+        assert_eq!(concat_script_words(&t, &k).as_deref(), Some("set l2 hello"));
+    }
+
+    /// Each word is trimmed, and one that trims to nothing is dropped.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `concat "  a  " "  b  "` → `a b`;
+    /// `concat a {} b` → `a b`; `concat {  } a` → `a`.
+    #[test]
+    fn words_are_trimmed_and_empty_ones_dropped() {
+        let (t, k) = words(&[("  a  ", TokenType::Str), ("  b  ", TokenType::Str)]);
+        assert_eq!(concat_script_words(&t, &k).as_deref(), Some("a b"));
+        let (t, k) = words(&[
+            ("a", TokenType::Esc),
+            ("", TokenType::Str),
+            ("b", TokenType::Esc),
+        ]);
+        assert_eq!(concat_script_words(&t, &k).as_deref(), Some("a b"));
+    }
+
+    /// Substitution runs before concatenation, so one dynamic word makes the
+    /// whole join unknowable — the helper declines rather than guessing.
+    #[test]
+    fn a_dynamic_word_anywhere_declines() {
+        let (t, k) = words(&[("set", TokenType::Esc), ("$name", TokenType::Var)]);
+        assert_eq!(concat_script_words(&t, &k), None);
+        let (t, k) = words(&[("$cmd", TokenType::Var), ("arg", TokenType::Esc)]);
+        assert_eq!(concat_script_words(&t, &k), None);
+        let (t, k) = words(&[("puts", TokenType::Esc), ("[f]", TokenType::Cmd)]);
+        assert_eq!(concat_script_words(&t, &k), None);
+    }
+
+    /// The join is never longer than the words it came from, so a mapped
+    /// offset can only ever land inside the call.
+    #[test]
+    fn the_join_never_grows() {
+        let (t, k) = words(&[("set l2", TokenType::Str), ("hello", TokenType::Esc)]);
+        let joined = concat_script_words(&t, &k).expect("static");
+        let raw: usize = t.iter().map(String::len).sum::<usize>() + t.len() - 1;
+        assert!(joined.len() <= raw);
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/tcl-compiler/src/analyser/utils.rs
+++ b/rust/tcl-compiler/src/analyser/utils.rs
@@ -823,9 +823,10 @@ pub fn irules_top_level_only(registry: &CommandRegistry) -> HashSet<String> {
         .collect()
 }
 
-/// Join the trailing words of a [`Traits::SCRIPT_CONCATENATES_ARGS`] call
-/// into the script Tcl will actually evaluate, or `None` when the join is
-/// not statically knowable.
+/// The exact source window a [`Traits::SCRIPT_CONCATENATES_ARGS`] tail
+/// evaluates — every content byte at its true offset, every structural
+/// byte blanked to a space — or `None` when the script is not statically
+/// knowable.
 ///
 /// `Tcl_ConcatObj` (`generic/tclUtil.c`) is the one rule the whole eval
 /// family shares: take each word's **string representation**, trim ASCII
@@ -835,121 +836,230 @@ pub fn irules_top_level_only(registry: &CommandRegistry) -> HashSet<String> {
 /// before `Tcl_ConcatObj` ever sees the value — so braced and bare words
 /// concatenate identically and a command may span word boundaries.
 ///
+/// Joining the trimmed texts into a fresh string reproduces those bytes
+/// but loses their *positions*: stripped delimiters, dropped words, and
+/// collapsed whitespace shift every byte after the first divergence, so a
+/// span recorded while walking the joined text can land on the wrong
+/// source bytes (in `eval {} foo` the reconstructed `foo` starts at the
+/// empty word's closing brace, and a rename would edit that delimiter
+/// instead of the command). So this builds the equivalent script *in
+/// place* instead: a buffer covering the words' whole span in `source`,
+/// holding each word's content bytes at their real offsets and a space
+/// everywhere else (delimiters, inter-word gaps). Script parsing treats
+/// any whitespace run as one separator, so the window parses into exactly
+/// the words the trimmed-and-joined text would — `Tcl_ConcatObj`'s trim,
+/// drop, and single-space steps all degenerate to "more whitespace" —
+/// while every span the walk records maps to the source bytes it
+/// describes.
+///
 /// Pinned against tclsh8.6.14 and tclsh9.0.4:
 ///
 /// ```text
-/// concat {set x} {5}       → set x 5        (braces gone, single space)
-/// concat "  a  " "  b  "   → a b            (each word trimmed)
-/// concat a {} b            → a b            (empty word dropped)
 /// eval set l2 hello        ≡ set l2 hello
-/// eval {set l2} hello      ≡ set l2 hello
-/// eval {set l2 hello}      ≡ set l2 hello
+/// eval {set l2} hello      ≡ set l2 hello   (braces gone, contents kept)
+/// eval "set q" 7           ≡ set q 7        (quotes gone; a space inside
+///                                            a quoted word separates —
+///                                            the re-parse splits it just
+///                                            as the join would)
+/// eval {set l2} {$value}   ≡ set l2 $value  (braces blocked the outer
+///                                            substitution, so the script
+///                                            text is static; `eval`
+///                                            itself resolves `$value`
+///                                            when the script runs)
+/// eval {} foo              ≡ foo            (an empty word is just more
+///                                            whitespace)
 /// ```
 ///
-/// Returns `None` as soon as any word carries a substitution, because
-/// substitution runs *before* concatenation: `eval $cmd arg` can build any
-/// script at all, so no analysis of the written text is sound. Callers must
+/// Returns `None` when any word is not statically-known script text
+/// ([`super::diagnostics::helpers::word_is_static_script_text`]: a
+/// substitution or a decode runs before concatenation, so the real script
+/// is unknowable), when a word's text does not sit verbatim at its
+/// token's content offset (bytes that cannot be mapped must not be
+/// analysed), or when the window holds no content at all. Callers must
 /// then consume the command without walking it rather than guess.
-///
-/// The static-word test is the analyser's one predicate for it,
-/// `diagnostics::helpers::has_substitution`, so this helper and every other
-/// static-word check move together.
 ///
 /// This is **not** the rule for `namespace inscope`, whose tail is appended
 /// as list elements — see [`Traits::SCRIPT_APPENDS_LIST_ARGS`].
 #[must_use]
-pub fn concat_script_words(words: &[String], tokens: &[Token]) -> Option<String> {
-    if words.is_empty() || words.len() != tokens.len() {
+pub fn concat_script_window(
+    words: &[String],
+    tokens: &[Token],
+    source: &str,
+) -> Option<(String, tcl_lexer::Span)> {
+    let (first, last) = (tokens.first()?, tokens.last()?);
+    if words.len() != tokens.len() {
         return None;
     }
-    let mut joined = String::new();
+    let start = first.span.start() as usize;
+    let end = last.span.end() as usize;
+    if end <= start || source.len() < end {
+        return None;
+    }
+    let mut window = vec![b' '; end - start];
     for (word, tok) in words.iter().zip(tokens) {
-        if crate::analyser::diagnostics::helpers::has_substitution(word, tok) {
+        if !crate::analyser::diagnostics::helpers::word_is_static_script_text(word, tok.kind) {
             return None;
         }
-        let trimmed = word.trim_matches(|c: char| c.is_ascii_whitespace());
-        if trimmed.is_empty() {
-            continue;
+        let content_start = tok.span.start() as usize + usize::from(tok.content_offset);
+        // The word's text must sit verbatim at its content offset — any
+        // divergence (an escape decode, a token shape this fn does not
+        // model) makes the bytes unmappable, and unmappable bytes must
+        // not be walked.
+        if source.get(content_start..content_start + word.len()) != Some(word.as_str()) {
+            return None;
         }
-        if !joined.is_empty() {
-            joined.push(' ');
-        }
-        joined.push_str(trimmed);
+        let off = content_start.checked_sub(start)?;
+        window
+            .get_mut(off..off + word.len())?
+            .copy_from_slice(word.as_bytes());
     }
-    Some(joined)
+    if window.iter().all(u8::is_ascii_whitespace) {
+        return None;
+    }
+    let window = String::from_utf8(window).ok()?;
+    Some((
+        window,
+        tcl_lexer::Span::new(u32::try_from(start).ok()?, u32::try_from(end).ok()?),
+    ))
 }
 
 #[cfg(test)]
-mod concat_script_words_tests {
-    use super::concat_script_words;
+mod concat_script_window_tests {
+    use super::concat_script_window;
     use tcl_lexer::{Span, Token, TokenType};
 
-    fn words(pairs: &[(&str, TokenType)]) -> (Vec<String>, Vec<Token>) {
+    /// Tail words of `source` from `from`, tokenised the way the analyser's
+    /// argv sees them: each `(text, kind)` pair is located in `source` (in
+    /// order), and a `Str`/quoted token's span covers its delimiters with
+    /// `content_offset` pointing past the opener.
+    fn tail(source: &str, from: usize, pairs: &[(&str, TokenType)]) -> (Vec<String>, Vec<Token>) {
         let mut texts = Vec::new();
         let mut toks = Vec::new();
-        let mut at = 0u32;
+        let mut at = from;
         for (text, kind) in pairs {
-            let len = u32::try_from(text.len()).expect("short fixture");
+            let delim = usize::from(matches!(*kind, TokenType::Str));
+            let content = if text.is_empty() {
+                // Locate an empty content by its `{}` delimiter pair.
+                source[at..].find("{}").expect("fixture") + at + 1
+            } else {
+                source[at..].find(text).expect("fixture") + at
+            };
+            let (s, e) = (content - delim, content + text.len() + delim);
+            let mut tok = Token::new(
+                *kind,
+                Span::new(u32::try_from(s).unwrap(), u32::try_from(e).unwrap()),
+            );
+            tok.content_offset = u8::try_from(delim).unwrap();
             texts.push((*text).to_owned());
-            toks.push(Token::new(*kind, Span::new(at, at + len)));
-            at += len + 1;
+            toks.push(tok);
+            at = e;
         }
         (texts, toks)
     }
 
-    /// `Tcl_ConcatObj` joins the words' string representations with a single
-    /// space; a braced word's string rep is its contents, so bare and braced
-    /// words concatenate identically.
+    /// A braced word's contents and a bare word join into one script, and
+    /// every content byte keeps its exact source offset — the window blanks
+    /// the `{`/`}` delimiters and gap to spaces rather than shifting bytes.
     ///
-    /// tclsh8.6.14 / tclsh9.0.4: `concat {set x} {5}` → `set x 5`.
+    /// tclsh8.6.14 / tclsh9.0.4: `eval {set l2} hello` ≡ `set l2 hello`.
     #[test]
-    fn braced_and_bare_words_join_identically() {
-        let (t, k) = words(&[("set l2", TokenType::Str), ("hello", TokenType::Esc)]);
-        assert_eq!(concat_script_words(&t, &k).as_deref(), Some("set l2 hello"));
-        let (t, k) = words(&[
-            ("set", TokenType::Esc),
-            ("l2", TokenType::Esc),
-            ("hello", TokenType::Esc),
-        ]);
-        assert_eq!(concat_script_words(&t, &k).as_deref(), Some("set l2 hello"));
+    fn braced_and_bare_words_window_in_place() {
+        let src = "eval {set l2} hello";
+        let (t, k) = tail(
+            src,
+            5,
+            &[("set l2", TokenType::Str), ("hello", TokenType::Esc)],
+        );
+        let (win, span) = concat_script_window(&t, &k, src).expect("static");
+        assert_eq!(win, " set l2  hello");
+        assert_eq!((span.start(), span.end()), (5, 19));
+        // The window is positionally exact: `hello` sits at its source offset.
+        let off = usize::try_from(span.start()).unwrap();
+        assert_eq!(off + win.find("hello").unwrap(), src.find("hello").unwrap());
     }
 
-    /// Each word is trimmed, and one that trims to nothing is dropped.
+    /// A braced word whose contents carry `$`/`[` is still *statically known
+    /// script text* — the braces blocked the outer substitution, and the
+    /// eval-family command itself resolves it when the script runs.
     ///
-    /// tclsh8.6.14 / tclsh9.0.4: `concat "  a  " "  b  "` → `a b`;
-    /// `concat a {} b` → `a b`; `concat {  } a` → `a`.
+    /// tclsh8.6.14 / tclsh9.0.4: `set value 5; eval {set l2} {$value};
+    /// puts $l2` → `5`.
     #[test]
-    fn words_are_trimmed_and_empty_ones_dropped() {
-        let (t, k) = words(&[("  a  ", TokenType::Str), ("  b  ", TokenType::Str)]);
-        assert_eq!(concat_script_words(&t, &k).as_deref(), Some("a b"));
-        let (t, k) = words(&[
-            ("a", TokenType::Esc),
-            ("", TokenType::Str),
-            ("b", TokenType::Esc),
-        ]);
-        assert_eq!(concat_script_words(&t, &k).as_deref(), Some("a b"));
+    fn a_braced_word_with_substitution_text_is_static() {
+        let src = "eval {set l2} {$value}";
+        let (t, k) = tail(
+            src,
+            5,
+            &[("set l2", TokenType::Str), ("$value", TokenType::Str)],
+        );
+        let (win, _) = concat_script_window(&t, &k, src).expect("braced text is static");
+        assert_eq!(win, " set l2   $value ");
     }
 
-    /// Substitution runs before concatenation, so one dynamic word makes the
-    /// whole join unknowable — the helper declines rather than guessing.
+    /// Substitution runs before concatenation, so a dynamic word (or a bare
+    /// word carrying `$`/`[`/escape/quote bytes) makes the real script
+    /// unknowable — the helper declines rather than guessing.
     #[test]
-    fn a_dynamic_word_anywhere_declines() {
-        let (t, k) = words(&[("set", TokenType::Esc), ("$name", TokenType::Var)]);
-        assert_eq!(concat_script_words(&t, &k), None);
-        let (t, k) = words(&[("$cmd", TokenType::Var), ("arg", TokenType::Esc)]);
-        assert_eq!(concat_script_words(&t, &k), None);
-        let (t, k) = words(&[("puts", TokenType::Esc), ("[f]", TokenType::Cmd)]);
-        assert_eq!(concat_script_words(&t, &k), None);
+    fn a_dynamic_or_decoded_word_anywhere_declines() {
+        let src = "eval $cmd arg";
+        let (t, k) = tail(src, 5, &[("$cmd", TokenType::Var), ("arg", TokenType::Esc)]);
+        assert_eq!(concat_script_window(&t, &k, src), None);
+        let src = "eval set $name";
+        let (t, k) = tail(
+            src,
+            5,
+            &[("set", TokenType::Esc), ("$name", TokenType::Var)],
+        );
+        assert_eq!(concat_script_window(&t, &k, src), None);
+        let src = "eval puts [f]";
+        let (t, k) = tail(src, 5, &[("puts", TokenType::Esc), ("[f]", TokenType::Cmd)]);
+        assert_eq!(concat_script_window(&t, &k, src), None);
+        // A backslash in a bare word decodes before the join — the decoded
+        // text matches no source bytes, so the window declines.
+        let src = "eval set\\ x 5";
+        let (t, k) = tail(
+            src,
+            5,
+            &[("set\\ x", TokenType::Esc), ("5", TokenType::Esc)],
+        );
+        assert_eq!(concat_script_window(&t, &k, src), None);
     }
 
-    /// The join is never longer than the words it came from, so a mapped
-    /// offset can only ever land inside the call.
+    /// An empty braced word contributes nothing — its delimiters blank to
+    /// whitespace and the remaining word keeps its exact offset. This is the
+    /// shape where a naive join anchors the tail one byte early.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `eval {} foo` runs `foo`.
     #[test]
-    fn the_join_never_grows() {
-        let (t, k) = words(&[("set l2", TokenType::Str), ("hello", TokenType::Esc)]);
-        let joined = concat_script_words(&t, &k).expect("static");
-        let raw: usize = t.iter().map(String::len).sum::<usize>() + t.len() - 1;
-        assert!(joined.len() <= raw);
+    fn an_empty_word_blanks_to_whitespace_and_offsets_hold() {
+        let src = "eval {} foo";
+        let (t, k) = tail(src, 5, &[("", TokenType::Str), ("foo", TokenType::Esc)]);
+        let (win, span) = concat_script_window(&t, &k, src).expect("static");
+        assert_eq!(win, "   foo");
+        let off = usize::try_from(span.start()).unwrap();
+        assert_eq!(off + win.find("foo").unwrap(), src.find("foo").unwrap());
+    }
+
+    /// A window with no content at all declines — there is no script to walk.
+    #[test]
+    fn an_all_whitespace_window_declines() {
+        let src = "eval {} {  }";
+        let (t, k) = tail(src, 5, &[("", TokenType::Str), ("  ", TokenType::Str)]);
+        assert_eq!(concat_script_window(&t, &k, src), None);
+    }
+
+    /// A word whose text does not sit verbatim at its token's content offset
+    /// cannot be mapped to source bytes, so the window declines.
+    #[test]
+    fn a_text_that_diverges_from_the_source_declines() {
+        let src = "eval {set l2} hello";
+        let (mut t, k) = tail(
+            src,
+            5,
+            &[("set l2", TokenType::Str), ("hello", TokenType::Esc)],
+        );
+        t[1] = "other".to_owned();
+        assert_eq!(concat_script_window(&t, &k, src), None);
     }
 }
 

--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -413,6 +413,22 @@ fn catch_body_out_vars(body_word: &str, out: &mut Vec<String>) {
         .strip_prefix('{')
         .and_then(|s| s.strip_suffix('}'))
         .unwrap_or(body_word);
+    script_text_out_vars(body, out);
+}
+
+/// Out-vars assigned by a run of **script text** — direct
+/// `set`/`append`/`lappend`/`incr` targets plus nested command-substitution
+/// writers (`gets`/`scan`/`regexp`/`catch`).
+///
+/// Shared by [`catch_body_out_vars`] (a `catch` body word, braces already
+/// stripped) and the analyser's read-before-set suppression for a
+/// [`tcl_registry::Traits::SCRIPT_CONCATENATES_ARGS`] call whose words the
+/// lowering left as an opaque barrier (`eval set l2 hello` — issue #1051).
+/// Both need the same answer from the same text, so they ask once here.
+///
+/// Suppress-only: over-collection is safe (it only avoids false warnings),
+/// under-collection merely leaves the status quo.
+pub(crate) fn script_text_out_vars(body: &str, out: &mut Vec<String>) {
     // First-arg-writer membership is the registry's
     // `writes_first_arg_variable` query (cached default registry — the set
     // is core Tcl in every dialect); over-collection stays safe per the

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -127,7 +127,10 @@ fn word_has_observable_side_effect(text: &str, purity: PurityCtx<'_>, depth: u32
             let proc_pure = interproc_pure.contains(cmd_name)
                 || interproc_pure.contains(format!("::{cmd_name}").as_str())
                 || interproc_pure.contains(cmd_name.trim_start_matches(':'));
-            let self_dispatch_pure = matches!(cmd_name, "my" | "::my")
+            // The self-dispatch keyword is registry data (`get` resolves the
+            // `::`-qualified spelling), not a name literal (issue #1050).
+            let self_dispatch_pure = registry.method_dispatch_keyword(cmd_name)
+                == Some(tcl_registry::MethodDispatchKind::SelfDispatch)
                 && !cmd_args.is_empty()
                 && enclosing_class.is_some_and(|cls| method_pure(cls, &cmd_args[0], pure_methods));
             if !proc_pure && !self_dispatch_pure {

--- a/rust/tcl-compiler/src/var_observability.rs
+++ b/rust/tcl-compiler/src/var_observability.rs
@@ -126,6 +126,24 @@ pub(crate) fn stmt_gen(stmt: &Statement, state: &mut State, registry: &CommandRe
     };
     // Alias / trace declarations key off the canonical command name.
     let canon = stmt.canonical_command_or_source();
+    // `my variable NAME …` (TclOO) binds each instance variable into the
+    // method's local scope — a namespace-style scope alias, exactly like a
+    // bare `variable`, but reached through the `my` dispatch so the base
+    // command word is `my` and the declared names follow a `variable`
+    // subcommand word. An instance variable's intrep is externally
+    // determined (the constructor / other methods can set it to anything),
+    // so a use-site / merge / loop-oscillation check must treat it as
+    // escaping — the same protection FP-SH-02 / FP-SH-16 give a bare
+    // `variable`. Whether the head *is* the self-dispatch keyword comes from
+    // the registry, not a name literal (issue #1050); `get` resolves the
+    // `::`-qualified spelling itself.
+    if registry.method_dispatch_keyword(canon)
+        == Some(tcl_registry::MethodDispatchKind::SelfDispatch)
+    {
+        for i in my_variable_declaration_indices(args) {
+            mark(state, args, i, EscapeFlag::NAMESPACE);
+        }
+    }
     match canon.strip_prefix("::").unwrap_or(canon) {
         "global" => {
             for i in global_declaration_indices(args) {
@@ -137,21 +155,8 @@ pub(crate) fn stmt_gen(stmt: &Statement, state: &mut State, registry: &CommandRe
                 mark(state, args, i, EscapeFlag::NAMESPACE);
             }
         }
-        // `my variable NAME …` (TclOO) binds each instance variable into the
-        // method's local scope — a namespace-style scope alias, exactly like a
-        // bare `variable`, but reached through the `my` dispatch so the base
-        // command word is `my` and the declared names follow a `variable`
-        // subcommand word. An instance variable's intrep is externally
-        // determined (the constructor / other methods can set it to anything),
-        // so a use-site / merge / loop-oscillation check must treat it as
-        // escaping — the same protection FP-SH-02 / FP-SH-16 give a bare
-        // `variable`. (Traces are handled below by the registry-driven
+        // (Traces are handled below by the registry-driven
         // `variable_trace_write_indices`, not a hardcoded `"trace"` arm.)
-        "my" => {
-            for i in my_variable_declaration_indices(args) {
-                mark(state, args, i, EscapeFlag::NAMESPACE);
-            }
-        }
         _ => {}
     }
 

--- a/rust/tcl-compiler/tests/checks.rs
+++ b/rust/tcl-compiler/tests/checks.rs
@@ -3133,6 +3133,39 @@ mod script_concatenation {
         assert!(!fires(src, D, "W210"), "{:?}", codes(src, D));
     }
 
+    /// FP — a dynamic tail declines the *join*, not the braced first word:
+    /// `eval {script} $extra` still runs `script` as written (concatenation
+    /// only appends after it), so the write it performs must stay recorded.
+    #[test]
+    fn eval_fp_braced_script_before_a_dynamic_tail_is_still_walked_1051() {
+        let src = "set extra x\neval {set l2 5} $extra\nputs $l2\n";
+        assert!(!fires(src, D, "W210"), "{:?}", codes(src, D));
+    }
+
+    /// FP — a `namespace eval` whose body word is dragged open by an
+    /// unbalanced brace *inside* it (here a `${gre` fragment in a comment)
+    /// turns into a multi-word call with an un-joinable tail. Declining the
+    /// join must not discard the braced body word — it is the namespace's
+    /// whole visible content, and dropping it removed every proc scope from
+    /// the tree (the editors' variableContexts fixture regression).
+    #[test]
+    fn namespace_eval_fp_mangled_body_word_keeps_its_proc_scopes_1051() {
+        let src = "namespace eval ::ns1 {\n    proc p1 {} {\n        scan \"1 2\" \"%d %d\" sx sy\n    }\n    proc t2 {greeting} {\n        # probe (``$gre``, ``${gre``, midword)\n    }\n}\nset \"weird}name\" 1\n";
+        let mut analyser = tcl_compiler::analyser::Analyser::new();
+        let result = analyser.analyse(src, D);
+        let ns = result
+            .global_scope
+            .children
+            .iter()
+            .find(|c| c.name.contains("ns1"))
+            .expect("namespace scope registered");
+        assert_eq!(
+            ns.children.len(),
+            2,
+            "proc scopes lost from the mangled namespace body"
+        );
+    }
+
     /// TN — `catch` is not in the family: its remaining words are result and
     /// options variable names, so nothing is joined into the script.
     ///

--- a/rust/tcl-compiler/tests/checks.rs
+++ b/rust/tcl-compiler/tests/checks.rs
@@ -2997,3 +2997,150 @@ mod private_tcl_namespace {
         assert!(!fires("::tcl::dictionary::foo", D, "W143"));
     }
 }
+
+// ===========================================================================
+// The `Tcl_ConcatObj` eval family — issue #1051.
+//
+// `eval`, `uplevel`, `namespace eval`, `namespace inscope`, and `interp eval`
+// evaluate the *concatenation* of every trailing script word, so analysing
+// only the first word invents diagnostics about a script that never runs.
+//
+// Every expectation here was pinned against tclsh8.6.14 and tclsh9.0.4 (both
+// agree on every shape); the transcript is quoted per test where the answer
+// is not obvious.
+// ===========================================================================
+mod script_concatenation {
+    use super::*;
+
+    /// FP — `eval set l2 hello` really runs `set l2 hello`, so neither the
+    /// wrong-#-args error nor the read-before-set warning is real.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `eval set l2 hello; puts $l2` → `hello`.
+    #[test]
+    fn eval_fp_multiword_script_is_analysed_as_the_concatenation_1051() {
+        let src = "eval set l2 hello\nputs $l2\n";
+        assert!(!fires(src, D, "E002"), "{:?}", codes(src, D));
+        assert!(!fires(src, D, "W210"), "{:?}", codes(src, D));
+    }
+
+    /// FP — a braced word contributes its *contents* to the join, so
+    /// `eval {set l2} hello` is the same script as `eval set l2 hello`.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `concat {set x} {5}` → `set x 5`; the outer
+    /// braces are gone by the time `Tcl_ConcatObj` sees the word.
+    #[test]
+    fn eval_fp_braced_word_contributes_its_contents_to_the_join_1051() {
+        let src = "eval {set l2} hello\nputs $l2\n";
+        assert!(!fires(src, D, "E002"), "{:?}", codes(src, D));
+        assert!(!fires(src, D, "W210"), "{:?}", codes(src, D));
+    }
+
+    /// TP — a genuinely short script still draws the arity error.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `eval {set}` →
+    /// `wrong # args: should be "set varName ?newValue?"`.
+    #[test]
+    fn eval_tp_short_script_still_draws_e002_1051() {
+        assert!(fires("eval {set}\n", D, "E002"));
+        assert!(fires("eval set\n", D, "E002"));
+    }
+
+    /// TN — a dynamic word makes the real script unknowable (substitution
+    /// runs before concatenation), so the call is consumed without walking:
+    /// no arity or definedness claim. W101 still fires — the injection risk
+    /// is exactly what makes the script unknowable.
+    #[test]
+    fn eval_tn_dynamic_word_declines_without_claiming_anything_1051() {
+        let src = "eval $cmd arg\n";
+        assert!(!fires(src, D, "E002"), "{:?}", codes(src, D));
+        assert!(!fires(src, D, "E003"), "{:?}", codes(src, D));
+        assert!(fires(src, D, "W101"), "{:?}", codes(src, D));
+    }
+
+    /// TP — W101 keeps firing on the plain injection shape. Its gate now
+    /// reads `SCRIPT_CONCATENATES_ARGS + TAINT_SINK` rather than inferring
+    /// the concat shape from how `eval`'s arg roles happen to be spelled.
+    #[test]
+    fn eval_tp_w101_still_fires_on_a_user_input_script_1051() {
+        assert!(fires("eval $userinput\n", D, "W101"));
+        // `uplevel` stays W301's — the script runs in another frame, which is
+        // a frame-escalation finding with its own message, not a second W101.
+        assert!(!fires("uplevel 1 \"set x $y\"\n", D, "W101"));
+    }
+
+    /// FP — `uplevel` concatenates its post-level words the same way.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `proc p {} {uplevel 1 set x 5}; p; puts $x`
+    /// → `5`. Written inside a proc because `uplevel 1` at top level errors
+    /// `bad level "1"` — there is no caller frame to reach.
+    #[test]
+    fn uplevel_fp_multiword_script_draws_no_arity_error_1051() {
+        let src = "proc p {} {\n    uplevel 1 set x 5\n}\np\nputs $x\n";
+        assert!(!fires(src, D, "E002"), "{:?}", codes(src, D));
+    }
+
+    /// TN — `uplevel`'s script runs in the **caller's** frame, so a write it
+    /// performs must not silence a read-before-set of the proc's own local.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `proc p {} {uplevel 1 set x 5; puts $x}; p`
+    /// → `can't read "x": no such variable`.
+    #[test]
+    fn uplevel_tn_shifted_frame_write_does_not_define_a_local_1051() {
+        let src = "proc p {} {\n    uplevel 1 set x 5\n    puts $x\n}\np\n";
+        assert!(fires(src, D, "W210"), "{:?}", codes(src, D));
+    }
+
+    /// FP — `namespace eval` concatenates too, and used to drop everything
+    /// past the first script word.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4:
+    /// `namespace eval ::n set l2 hello; puts $::n::l2` → `hello`.
+    #[test]
+    fn namespace_eval_fp_multiword_script_is_walked_as_one_1051() {
+        let src = "namespace eval ::n set l2 hello\n";
+        assert!(codes(src, D).is_empty(), "{:?}", codes(src, D));
+        // …and the joined script is really walked: an over-long one still
+        // reports. tclsh8.6.14 / tclsh9.0.4: `namespace eval ::n set a b c` →
+        // `wrong # args: should be "set varName ?newValue?"`.
+        assert!(fires("namespace eval ::n set a b c\n", D, "E003"));
+    }
+
+    /// FP — `namespace inscope`'s tail is appended as *list elements*, not
+    /// space-joined, so the trailing words are arguments to the script's
+    /// command. Analysing `{handler}` alone claimed a zero-argument call.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: the repro prints `ready`; and
+    /// `namespace inscope :: {puts} {a b}` prints `a b` (one argument) where
+    /// `namespace eval :: {puts} {a b}` errors
+    /// `can not find channel named "a"`.
+    #[test]
+    fn namespace_inscope_fp_list_appended_tail_draws_nothing_1051() {
+        let src = "namespace eval ::app { proc handler {tag} { puts $tag } }\n\
+                   namespace inscope ::app {handler} ready\n";
+        assert!(codes(src, D).is_empty(), "{:?}", codes(src, D));
+    }
+
+    /// TN — `interp eval`'s existing consume-without-walk behaviour is
+    /// unchanged: the script runs in a child interpreter, so nothing it
+    /// defines may leak into this one.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4:
+    /// `interp create i; interp eval i {set y} 7; interp eval i {set y}` → `7`.
+    #[test]
+    fn interp_eval_tn_multiword_stays_isolated_1051() {
+        let src = "interp create i\ninterp eval i {set y} 7\n";
+        assert!(!fires(src, D, "E002"), "{:?}", codes(src, D));
+        assert!(!fires(src, D, "W210"), "{:?}", codes(src, D));
+    }
+
+    /// TN — `catch` is not in the family: its remaining words are result and
+    /// options variable names, so nothing is joined into the script.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `catch {set z} m; puts $m` →
+    /// `can't read "z": no such variable` — `m` is a variable name, not
+    /// script text.
+    #[test]
+    fn catch_tn_is_not_in_the_concat_family_1051() {
+        assert!(fires("catch {set} m\n", D, "E002"));
+    }
+}

--- a/rust/tcl-compiler/tests/checks.rs
+++ b/rust/tcl-compiler/tests/checks.rs
@@ -3176,4 +3176,69 @@ mod script_concatenation {
     fn catch_tn_is_not_in_the_concat_family_1051() {
         assert!(fires("catch {set} m\n", D, "E002"));
     }
+
+    /// FP — a brace-quoted word is static *script text* even when it carries
+    /// `$`: the braces blocked the outer substitution, so the concatenated
+    /// script is knowable and `eval` resolves `$value` when it runs. Scanning
+    /// the text for `$` alone wrongly declined the walk and kept the false
+    /// read-before-set this family fix exists to remove.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `set value 5; eval {set l2} {$value};
+    /// puts $l2` → `5`.
+    #[test]
+    fn eval_fp_braced_word_with_substitution_text_is_static_1051() {
+        let src = "set value 5\neval {set l2} {$value}\nputs $l2\n";
+        assert!(!fires(src, D, "E002"), "{:?}", codes(src, D));
+        assert!(!fires(src, D, "W210"), "{:?}", codes(src, D));
+    }
+
+    /// FP — a quoted word without substitutions joins like any other; a
+    /// space inside it separates words when the script re-parses, exactly as
+    /// `Tcl_ConcatObj`'s join does.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `eval "set q" 7; puts $q` → `7`.
+    #[test]
+    fn eval_fp_quoted_word_joins_like_concat_1051() {
+        let src = "eval \"set q\" 7\nputs $q\n";
+        assert!(!fires(src, D, "E002"), "{:?}", codes(src, D));
+        assert!(!fires(src, D, "W210"), "{:?}", codes(src, D));
+    }
+
+    /// The walked script is anchored at its *real source bytes*: dropped
+    /// empty words and stripped delimiters shift a naive join left, so its
+    /// spans would edit delimiters on rename. `eval {} foo` is the smallest
+    /// such shape — the reconstructed `foo` must span exactly the written
+    /// `foo`, not start one byte early on the empty word's closing brace.
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `proc foo {} {}; eval {} foo` runs `foo`.
+    #[test]
+    fn eval_offsets_of_the_walked_script_land_on_real_source_bytes_1051() {
+        let src = "proc foo {} {}\neval {} foo\n";
+        let mut analyser = tcl_compiler::analyser::Analyser::new();
+        let result = analyser.analyse(src, D);
+        let expected = u32::try_from(src.rfind("foo").expect("fixture")).unwrap();
+        let inv = result
+            .command_invocations
+            .iter()
+            .find(|i| i.name == "foo")
+            .expect("the eval'd call is recorded");
+        assert_eq!(
+            (inv.range.start(), inv.range.end()),
+            (expected, expected + 3),
+            "the walked call must span the written `foo`"
+        );
+    }
+
+    /// TN — a backslash in a bare word decodes *before* the join, so the
+    /// written bytes are not the script text and the walk declines without
+    /// claiming anything (no invented arity error on what really runs).
+    ///
+    /// tclsh8.6.14 / tclsh9.0.4: `eval set\ x 5; puts $x` → `5` (the decoded
+    /// `set x` re-splits when the joined script is parsed).
+    #[test]
+    fn eval_tn_a_backslash_word_declines_without_claiming_anything_1051() {
+        let src = "eval set\\ x 5\n";
+        assert!(!fires(src, D, "E002"), "{:?}", codes(src, D));
+        assert!(!fires(src, D, "E003"), "{:?}", codes(src, D));
+    }
 }

--- a/rust/tcl-compiler/tests/var_escape_cfg.rs
+++ b/rust/tcl-compiler/tests/var_escape_cfg.rs
@@ -775,6 +775,29 @@ fn ir_eval_dynamic_body_is_pessimistic() {
 }
 
 #[test]
+fn ir_eval_multiword_body_escapes_through_the_joined_script() {
+    // Pin (#1051): `handle_eval` joins a multi-word `eval` with single spaces
+    // before scanning, exactly as `Tcl_ConcatObj` does at run time, so a `$x`
+    // buried in a trailing word still escapes.
+    //
+    // tclsh8.6.14 / tclsh9.0.4: `set x l2; eval set $x hello; puts $l2`
+    // → `hello` — the substituted word really is part of the script.
+    use tcl_compiler::var_escape::BarrierKind;
+    let s = escape_ir("proc ::p {} { set x 1\n eval set l2 $x }");
+    let p = summary(&s, "::p");
+    assert!(
+        p.dynamic_barrier(),
+        "a $-referencing word anywhere in the joined body is pessimistic"
+    );
+    assert!(
+        p.barriers.iter().any(|b| b.kind == BarrierKind::Eval),
+        "an Eval barrier is recorded for the joined body: {:?}",
+        p.barriers
+    );
+    assert!(p.is_frame("x"), "the referenced name escapes: {p:?}");
+}
+
+#[test]
 fn ir_uplevel_global_zero_literal_body_escapes_touched_names() {
     // tclsh: `uplevel #0 {set glob 1}` writes a global, observable past the
     // call. On the IR walk the literal `uplevel #0` body is treated like a

--- a/rust/tcl-lsp-core/src/call_hierarchy.rs
+++ b/rust/tcl-lsp-core/src/call_hierarchy.rs
@@ -138,6 +138,20 @@ pub fn prepare(
 
 /// Synthetic call-hierarchy name for a class method:
 /// `<class-qualified-name>::<method-name>` (e.g. `::C::greet`).
+/// Whether `head` is a `TclOO` method-context keyword under `dialect` —
+/// `my`, `next`, `nextto`, or `self`.
+///
+/// The registry-first replacement for the `matches!(head, "my" | "next" |
+/// "nextto")` literals this module carried (issue #1050): a dialect that
+/// gains or loses one of these propagates through its `CommandSpec`, never
+/// through an edit here. All three kinds are excluded together because none
+/// of them is an *unresolved command reference* — a dispatch keyword resolves
+/// through the object's method table and an introspection keyword resolves to
+/// nothing at all, so neither belongs in a bare-head call scan.
+fn is_method_dispatch_keyword(dialect: &str, head: &str) -> bool {
+    crate::definition::method_dispatch_keyword_in(dialect, head).is_some()
+}
+
 fn method_item_name(class_def: &ClassDef, method: &MethodDef) -> String {
     format!("{}::{}", class_def.qualified_name, method.name)
 }
@@ -602,11 +616,12 @@ fn unresolved_method_outgoing_calls(
     let mut by_head: std::collections::BTreeMap<String, Vec<LspRange>> =
         std::collections::BTreeMap::new();
     for (head, span) in segment_body_calls(source, dialect, source_method.body_span) {
-        // `my` / `next` / `nextto` are `TclOO` dispatch keywords, not
-        // unresolved command references — the actual dispatch target (the
-        // word *after* `my`) is handled by `method_outgoing_calls`'s
-        // `scan_my_method_sites` pass, never by this bare-head scan.
-        if matches!(head.as_str(), "my" | "next" | "nextto") {
+        // A `TclOO` method-context keyword is not an unresolved command
+        // reference — the actual dispatch target (the word *after* `my`) is
+        // handled by `method_outgoing_calls`'s `scan_my_method_sites` pass,
+        // never by this bare-head scan. Membership comes from the registry,
+        // not a name list (issue #1050).
+        if is_method_dispatch_keyword(dialect, &head) {
             continue;
         }
         // Local top-level proc?  Resolved from the class's namespace (a
@@ -1037,7 +1052,7 @@ fn method_outgoing_calls(
     );
     let class_ns = tcl_syntax::naming::key_holder_and_tail(&class_def.qualified_name).0;
     for (head, span) in segment_body_calls(source, dialect, source_method.body_span) {
-        if matches!(head.as_str(), "my" | "next" | "nextto") {
+        if is_method_dispatch_keyword(dialect, &head) {
             continue;
         }
         // Top-level user proc?  Resolved from the class's namespace (a

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -216,7 +216,7 @@ pub fn definition(
     // `next` / `nextto` inside a method body — jump to the super-method in
     // the MRO chain that the enclosing method overrides (`next`), or to the
     // named class's copy of it (`nextto Cls`).
-    if (word == "next" || word == "nextto")
+    if is_next_chain_keyword(&word)
         && let Some(span) =
             next_dispatch_target(analysis, source, &line_index, line, character, &word)
     {
@@ -330,7 +330,7 @@ fn instance_method_definition(
     }
     // `my m` — an internal call: dispatch starts at the *enclosing*
     // class and reaches unexported methods too (issue #945 fault 4).
-    if inst == "my" {
+    if is_self_dispatch_keyword(&inst) {
         let cursor = byte_offset_at(line_index, source, line, character);
         if let Some(class_q) = enclosing_class_at(analysis, cursor) {
             return Some(method_dispatch_definition(
@@ -647,6 +647,60 @@ fn lookup_method_in_class(
 /// down the object's MRO — statically we resolve it in `C`'s own MRO (the
 /// sound single-dispatch approximation): the next class after `C` that
 /// provides `m`.  `nextto Base` restarts the search at `Base`.  The
+/// The `TclOO` method-context keyword `word` is under `dialect`, or `None`.
+///
+/// The crate's single entry to
+/// [`tcl_registry::CommandRegistry::method_dispatch_keyword`], so every
+/// provider that used to carry a `head == "my"` /
+/// `matches!(head, "my" | "next" | "nextto")` literal now asks the registry
+/// through one place (issue #1050). A dialect that gains or loses one of
+/// these keywords propagates through its `CommandSpec`, never through a
+/// walker edit.
+///
+/// The dialect-less callers below pass `""`, which resolves to the
+/// permissive plain-Tcl profile — availability mask `ALL_TCL`, so every 8.6+
+/// `TclOO` keyword resolves. `definition` reaches its providers without a
+/// dialect string in scope (as its three pre-existing
+/// `registry_for_dialect("")` call sites already show); threading a real
+/// dialect through every `go-to-definition` entry point is worth doing, but
+/// as its own change.
+pub(crate) fn method_dispatch_keyword_in(
+    dialect: &str,
+    word: &str,
+) -> Option<tcl_registry::MethodDispatchKind> {
+    tcl_registry::registry_for_dialect(dialect).method_dispatch_keyword(word)
+}
+
+/// Whether `word` is the `TclOO` self-dispatch keyword (`my`) — the word
+/// after it names a method on the *enclosing* class, reaching non-exported
+/// methods a `$obj` dispatch cannot.
+pub(crate) fn is_self_dispatch_keyword(word: &str) -> bool {
+    method_dispatch_keyword_in("", word) == Some(tcl_registry::MethodDispatchKind::SelfDispatch)
+}
+
+/// Whether `word` is a `TclOO` next-chain keyword (`next` / `nextto`).
+fn is_next_chain_keyword(word: &str) -> bool {
+    method_dispatch_keyword_in("", word) == Some(tcl_registry::MethodDispatchKind::NextChain)
+}
+
+/// Whether a next-chain keyword names an explicit resume-from class in its
+/// first argument — `nextto`'s structural marker, an
+/// [`tcl_registry::ArgRole::Name`] at index 0 on the spec, which `next` does
+/// not declare. Distinguishing the two structurally rather than by name is
+/// what `TCLOO_NEXT_CHAIN`'s own documentation asks consumers to do.
+pub(crate) fn next_chain_names_a_target_in(dialect: &str, word: &str) -> bool {
+    method_dispatch_keyword_in(dialect, word) == Some(tcl_registry::MethodDispatchKind::NextChain)
+        && tcl_registry::registry_for_dialect(dialect)
+            .get(word)
+            .is_some_and(|spec| spec.arg_role_at(0) == Some(tcl_registry::ArgRole::Name))
+}
+
+/// [`next_chain_names_a_target_in`] against the dialect-less plain-Tcl
+/// profile.
+fn next_chain_names_a_target(word: &str) -> bool {
+    next_chain_names_a_target_in("", word)
+}
+
 /// enclosing class + method are found from the cursor's byte offset.
 fn next_dispatch_target(
     analysis: &AnalysisResult,
@@ -658,12 +712,12 @@ fn next_dispatch_target(
 ) -> Option<tcl_lexer::Span> {
     let cursor = byte_offset_at(line_index, source, line, character);
     let (class_q, method) = enclosing_method(analysis, cursor)?;
-    let start_from: Option<String> = if keyword == "nextto" {
+    let start_from: Option<String> = if next_chain_names_a_target(keyword) {
         // Byte offset of the cursor within its line, so `word_after` can pick
-        // the `nextto` occurrence the cursor is on (not merely the first).
+        // the occurrence the cursor is on (not merely the first).
         let line_start = byte_offset_at(line_index, source, line, 0);
         let cursor_in_line = cursor.saturating_sub(line_start) as usize;
-        let target = word_after(source, line, cursor_in_line, "nextto")?;
+        let target = word_after(source, line, cursor_in_line, keyword)?;
         Some(canonicalise_class(analysis, &class_q, &target))
     } else {
         None

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -361,7 +361,7 @@ pub fn hover_with_profile(
     // is split across a separate `oo::define` block).
     if let Some((inst, method, _)) =
         crate::definition::instance_method_at_cursor(source, line, character)
-        && inst == "my"
+        && crate::definition::is_self_dispatch_keyword(&inst)
         && let Some(class_q) = crate::definition::enclosing_class_at(analysis, cursor_offset)
         && let Some(text) = obj_method_hover_text(analysis, class_q, &method, registry)
     {

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -1328,7 +1328,17 @@ fn scan_my_method_region(
         if let (Some(head), Some(name_tok)) = (cmd.argv.first(), cmd.argv.get(1)) {
             let h_start = head.span.start() as usize;
             let h_end = head.span.end() as usize;
-            if h_start < source.len() && h_end <= source.len() && &source[h_start..h_end] == "my" {
+            // Registry query, not a `== "my"` literal: the self-dispatch
+            // keyword is spec data, so a dialect that gains or loses it
+            // propagates through `tcl-registry` rather than through this
+            // walker (issue #1050).
+            let head_is_self_dispatch = h_start < source.len()
+                && h_end <= source.len()
+                && crate::definition::method_dispatch_keyword_in(
+                    ctx.dialect,
+                    &source[h_start..h_end],
+                ) == Some(tcl_registry::MethodDispatchKind::SelfDispatch);
+            if head_is_self_dispatch {
                 let n_start = name_tok.span.start() as usize;
                 let n_end = name_tok.span.end() as usize;
                 if n_start < source.len()
@@ -1448,7 +1458,11 @@ fn scan_next_dispatch_region_with_target(
             let (h_start, h_end) = (head.span.start() as usize, head.span.end() as usize);
             if h_end <= source.len() && h_start < h_end {
                 let h = &source[h_start..h_end];
-                if h == "next" || h == "nextto" {
+                // The next-chain keywords come from the registry
+                // (`TCLOO_NEXT_CHAIN`), not a name list (issue #1050).
+                if crate::definition::method_dispatch_keyword_in(dialect, h)
+                    == Some(tcl_registry::MethodDispatchKind::NextChain)
+                {
                     // `texts` is the segmenter's already-*decoded* per-word
                     // reconstruction — unlike `argv`'s token span (which
                     // covers a braced/quoted word's raw delimiters per this
@@ -1460,7 +1474,12 @@ fn scan_next_dispatch_region_with_target(
                     // `{`/`"` in the target text, which
                     // `canonicalise_class_name` could never resolve to a
                     // real class (Codex review on #1011, P2).
-                    let target = (h == "nextto").then(|| cmd.texts.get(1).cloned()).flatten();
+                    // Only the spelling that declares an `ArgRole::Name` at
+                    // argument 0 names an explicit resume-from class —
+                    // `nextto`'s structural marker, per `TCLOO_NEXT_CHAIN`'s
+                    // own doc. `next` declares none, so it captures no target.
+                    let names_target = crate::definition::next_chain_names_a_target_in(dialect, h);
+                    let target = names_target.then(|| cmd.texts.get(1).cloned()).flatten();
                     out.push((head.span, target));
                 }
             }

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -512,7 +512,7 @@ pub fn method_target_with_access(
     {
         // `my method` — an internal call from inside the enclosing class.
         // Always instance-context: `my` never reaches a classmethod.
-        if inst == "my"
+        if crate::definition::is_self_dispatch_keyword(&inst)
             && let Some(class_q) = crate::definition::enclosing_class_at(analysis, cursor)
         {
             return Some((class_q.to_owned(), method, false, MethodAccess::Internal));

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -2612,10 +2612,15 @@ fn insert_self_method_overrides(
     ) else {
         return;
     };
-    // `my` is a bareword; `$self` / `$this` are variable handles for the object
-    // in snit / itcl method bodies.
-    let is_self_head =
-        head == "my" || object_handle_name(head).is_some_and(|n| n == "self" || n == "this");
+    // Two different axes, deliberately kept apart. `my` is the `TclOO`
+    // self-dispatch *command keyword* — registry data, queried through
+    // `method_dispatch_keyword` so a dialect that gains or loses it
+    // propagates through its `CommandSpec` (issue #1050). `$self` / `$this`
+    // are snit / itcl *object-handle variable names*, a naming convention of
+    // those class systems rather than a command at all, so they stay matched
+    // by name here.
+    let is_self_head = crate::definition::is_self_dispatch_keyword(head)
+        || object_handle_name(head).is_some_and(|n| n == "self" || n == "this");
     if !is_self_head {
         return;
     }
@@ -2789,7 +2794,10 @@ fn insert_oo_define_keyword_overrides(
     }
     mark_keyword(2);
     // `self` introduces the real definition keyword (`method`, `constructor`,
-    // …) at `seg.texts[3]`.
+    // …) at `seg.texts[3]`. This is the `oo::define` *definer-grammar*
+    // wrapper word, not the `TclOO` `self` introspection command — a
+    // different axis from `Traits::TCLOO_INTROSPECTION`, resolved through
+    // the definer grammar's own `MemberKind::Wrapper` modelling.
     if first == "self" && seg.texts.get(3).is_some_and(|w| grammar.is_member(w)) {
         mark_keyword(3);
     }

--- a/rust/tcl-lsp-server/tests/e2e/completion.rs
+++ b/rust/tcl-lsp-server/tests/e2e/completion.rs
@@ -832,3 +832,83 @@ fn subcommand_completion_version_gates_end_to_end() {
         "dict getwithdefault (9.0+) must be hidden in an 8.6 buffer: {got:?}"
     );
 }
+
+#[test]
+fn command_form_locals_complete_inside_a_namespaced_proc() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "namespace eval ::ns1 {\n    proc p1 {pp} {\n        lassign {1 2} la lb\n        catch {error boom} cres copts\n        puts $\n    }\n}\n";
+    lsp.open_ready(&uri, src);
+    let ls = labels(&mut lsp, &uri, 4, 14);
+    assert!(ls.contains(&"$pp".to_owned()), "param missing: {ls:?}");
+    assert!(
+        ls.contains(&"$la".to_owned()),
+        "lassign write missing: {ls:?}"
+    );
+    assert!(
+        ls.contains(&"$cres".to_owned()),
+        "catch write missing: {ls:?}"
+    );
+}
+
+#[test]
+fn command_form_locals_complete_inside_a_plain_proc() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "proc p1 {pp} {\n    lassign {1 2} la lb\n    puts $\n}\n";
+    lsp.open_ready(&uri, src);
+    let ls = labels(&mut lsp, &uri, 2, 10);
+    assert!(ls.contains(&"$pp".to_owned()), "param missing: {ls:?}");
+    assert!(
+        ls.contains(&"$la".to_owned()),
+        "lassign write missing: {ls:?}"
+    );
+}
+
+#[test]
+fn command_form_locals_complete_in_the_vscode_fixture() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let fixture = include_str!("../../../../editors/vscode/testFixture/variableContexts.tcl");
+    let mut lines: Vec<&str> = fixture.lines().collect();
+    let probe = lines
+        .iter()
+        .position(|l| l.contains("# PROBE_SCAN"))
+        .expect("PROBE_SCAN marker");
+    lines.insert(probe + 1, "        puts $");
+    let src = lines.join("\n");
+    lsp.open_ready(&uri, &src);
+    let at = u32::try_from(probe + 1).expect("line fits");
+    let ls = labels(&mut lsp, &uri, at, 14);
+    assert!(ls.contains(&"$sx".to_owned()), "scan write missing: {ls:?}");
+}
+
+#[test]
+fn uplevel_with_level_word_does_not_corrupt_sibling_scopes() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src = "namespace eval ::ns1 {\n    proc p1 {} {\n        scan \"1 2\" \"%d %d\" sx sy\n        puts $\n    }\n    proc p2 {} {\n        uplevel 1 {\n            set body_var 5\n        }\n    }\n}\n";
+    lsp.open_ready(&uri, src);
+    let ls = labels(&mut lsp, &uri, 3, 14);
+    assert!(ls.contains(&"$sx".to_owned()), "scan write missing: {ls:?}");
+}
+
+#[test]
+fn weird_set_names_do_not_break_scan_completion() {
+    for (name, weird) in [
+        ("brace", "set \"weird}name\" 1"),
+        ("paren", "set \"arr(weird)stuff)\" 2"),
+    ] {
+        let mut lsp = Lsp::tcl();
+        let uri = unique_uri("tcl");
+        let src = format!(
+            "namespace eval ::ns1 {{\n    proc p1 {{}} {{\n        scan \"1 2\" \"%d %d\" sx sy\n        puts $\n    }}\n}}\n{weird}\n"
+        );
+        lsp.open_ready(&uri, &src);
+        let ls = labels(&mut lsp, &uri, 3, 14);
+        assert!(
+            ls.contains(&"$sx".to_owned()),
+            "{name}: scan write missing: {ls:?}"
+        );
+    }
+}

--- a/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostic_matrix.rs
@@ -846,3 +846,52 @@ fn s102_fires_for_numeric_shimmer_masked_by_int_entry() {
     );
     assert!(codes(&diags).contains("S102"), "{diags:?}");
 }
+
+#[test]
+fn multiword_eval_reports_nothing_end_to_end_1051() {
+    // Issue #1051 — `eval` evaluates the *concatenation* of every trailing
+    // script word, so `eval set l2 hello` really runs `set l2 hello`. Walking
+    // only the first word invented an E002 and lost the write, which then drew
+    // a false W210 on the read below.
+    //
+    // Oracle (tclsh8.6.14 and tclsh9.0.4): `eval set l2 hello; puts $l2`
+    // prints `hello`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "eval set l2 hello\nputs $l2\n");
+    assert!(diags.is_empty(), "{diags:?}");
+}
+
+#[test]
+fn multiword_eval_still_reports_a_short_joined_script_1051() {
+    // The flip side: the joined script really is checked, so a genuinely
+    // short one still reports. Oracle: `eval set` fails
+    // `wrong # args: should be "set varName ?newValue?"`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(&uri, "eval set\n");
+    assert!(codes(&diags).contains("E002"), "{diags:?}");
+}
+
+#[test]
+fn a_renamed_class_still_reports_an_unknown_method_1049() {
+    // Issue #1049 — `rename Dog Cat` moves the class *command*; the class is
+    // unchanged, so `Cat new` builds a Dog and `$d fly` is still an unknown
+    // method. Before the fix the constructor did not type at all and the
+    // dispatch fell through to W307 noise.
+    //
+    // Oracle (tclsh8.6.14 and tclsh9.0.4): `$d fly` fails
+    // `unknown method "fly": must be bark or destroy`.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let diags = lsp.open_ready(
+        &uri,
+        "oo::class create Dog { method bark {} { return woof } }\nrename Dog Cat\nset d [Cat new]\n$d fly\n",
+    );
+    let found = codes(&diags);
+    assert!(found.contains("W308"), "{diags:?}");
+    assert!(
+        !found.contains("W307"),
+        "a typed dispatch is not W307: {diags:?}"
+    );
+}

--- a/rust/tcl-registry/src/commands/tcl/eval_.rs
+++ b/rust/tcl-registry/src/commands/tcl/eval_.rs
@@ -68,7 +68,8 @@ pub fn spec() -> CommandSpec {
             | Traits::EVALUATES_CODE
             | Traits::TAINT_SINK
             | Traits::CREATES_DYNAMIC_BARRIER
-            | Traits::DYNAMIC_EVAL_BODY,
+            | Traits::DYNAMIC_EVAL_BODY
+            | Traits::SCRIPT_CONCATENATES_ARGS,
         arity: Arity::at_least(1),
         arg_roles: &[(0, ArgRole::Body)],
         lowering_hook: Some(crate::hooks::LoweringHookId::Eval),

--- a/rust/tcl-registry/src/commands/tcl/if_.rs
+++ b/rust/tcl-registry/src/commands/tcl/if_.rs
@@ -217,6 +217,7 @@ pub fn spec() -> CommandSpec {
             | Traits::LANGUAGE_KEYWORD
             | Traits::HAS_BOOLEAN_COND
             | Traits::NEVER_INLINE_BODY
+            | Traits::BRANCH_SELECTED_BODY
             | Traits::STRUCTURALLY_CHECKED_ARITY,
         // The floor here is purely descriptive (hover / hint text): the real
         // minimum is enforced by `clause_shape_check`, which also covers the

--- a/rust/tcl-registry/src/commands/tcl/interp.rs
+++ b/rust/tcl-registry/src/commands/tcl/interp.rs
@@ -264,8 +264,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // parent `rename foo` must not edit a child `proc foo`).
         analyser_hook: Some(crate::hooks::AnalyserHookId::InterpEval),
         // Runs an arbitrary script — dynamic-dispatch consumers (memory-SSA
-        // clobber classification, side-effect analysis) key off this.
-        traits: Traits::EVALUATES_CODE,
+        // clobber classification, side-effect analysis) key off this.  The
+        // trailing words concatenate into the script (`Tcl_ConcatObj`), so
+        // the eval-family trait applies too.
+        traits: Traits::EVALUATES_CODE.union(Traits::SCRIPT_CONCATENATES_ARGS),
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -291,8 +291,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         body_kind: BodyKind::Structural,
         // Runs an arbitrary script that can touch namespace/global state —
         // dynamic-dispatch consumers (memory-SSA clobber classification)
-        // key off this.
-        traits: Traits::EVALUATES_CODE,
+        // key off this.  Words after the body concatenate into it exactly as
+        // `eval`'s do (`namespace eval ::n set l2 hello` sets `::n::l2`,
+        // tclsh8.6.14/9.0.4-confirmed), so the eval-family trait applies.
+        traits: Traits::EVALUATES_CODE.union(Traits::SCRIPT_CONCATENATES_ARGS),
         analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceEval),
         ..SubCommand::DEFAULT
     },
@@ -374,7 +376,13 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // caller's scope, where a bare command would resolve wrongly).
         analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceEval),
         body_kind: BodyKind::Structural,
-        traits: Traits::EVALUATES_CODE,
+        // In the eval family (the trailing words are script, not options),
+        // but with the list-append refinement: they arrive as whole list
+        // elements rather than space-joined text, so no consumer may join
+        // them.  See `Traits::SCRIPT_APPENDS_LIST_ARGS`.
+        traits: Traits::EVALUATES_CODE
+            .union(Traits::SCRIPT_CONCATENATES_ARGS)
+            .union(Traits::SCRIPT_APPENDS_LIST_ARGS),
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/commands/tcl/oo_my.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_my.rs
@@ -119,7 +119,7 @@ const SIDE_EFFECTS: &[SideEffect] = &[SideEffect {
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "my",
-        traits: Traits::LANGUAGE_KEYWORD,
+        traits: Traits::LANGUAGE_KEYWORD | Traits::TCLOO_SELF_DISPATCH,
         dialects: Some(DialectSet::TCL86_PLUS),
         arity: Arity::at_least(1),
         return_type: Some(TclType::String),

--- a/rust/tcl-registry/src/commands/tcl/oo_self.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_self.rs
@@ -120,7 +120,7 @@ const SELF_SUBCOMMAND_VALUES: &[ArgValue] = &[
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "self",
-        traits: Traits::PURE | Traits::LANGUAGE_KEYWORD,
+        traits: Traits::PURE | Traits::LANGUAGE_KEYWORD | Traits::TCLOO_INTROSPECTION,
         dialects: Some(DialectSet::TCL86_PLUS),
         arity: Arity::new(0, 1),
         return_type: Some(TclType::String),

--- a/rust/tcl-registry/src/commands/tcl/try_.rs
+++ b/rust/tcl-registry/src/commands/tcl/try_.rs
@@ -162,7 +162,8 @@ pub fn spec() -> CommandSpec {
             | Traits::BYTE_COMPILED
             | Traits::CONTROL_FLOW
             | Traits::LANGUAGE_KEYWORD
-            | Traits::NEVER_INLINE_BODY,
+            | Traits::NEVER_INLINE_BODY
+            | Traits::BRANCH_SELECTED_BODY,
         // `TCL86_PLUS`, via the mask-intersection rule
         // `CommandSpec::supports_dialect` / `ProfileQueries::is_available`,
         // already resolves availability correctly for every non-core

--- a/rust/tcl-registry/src/commands/tcl/uplevel_.rs
+++ b/rust/tcl-registry/src/commands/tcl/uplevel_.rs
@@ -176,7 +176,8 @@ pub fn spec() -> CommandSpec {
             | Traits::UNSAFE
             | Traits::CREATES_DYNAMIC_BARRIER
             | Traits::DYNAMIC_EVAL_BODY
-            | Traits::EVALUATES_IN_SHIFTED_FRAME,
+            | Traits::EVALUATES_IN_SHIFTED_FRAME
+            | Traits::SCRIPT_CONCATENATES_ARGS,
         arity: Arity::at_least(1),
         // The body runs in another stack frame (the `level`), not the
         // caller's, so its variable references belong to that frame — mark

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -142,7 +142,7 @@ pub use dialects::{
 pub use hover::ArgValue;
 pub use patterns::{FormatType, PatternType};
 pub use profile_queries::{ProfileQueries, VendorSurface};
-pub use registry::{CommandRegistry, ResolvedCall, ResolvedTerminator};
+pub use registry::{CommandRegistry, MethodDispatchKind, ResolvedCall, ResolvedTerminator};
 pub use spec::{
     BytePayloadSpec, CaseListSpec, CommandSpec, ContextGate, DefaultFormFirstWord, ObjectClassSpec,
     SubCommand, SubSubCommand,

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -474,6 +474,60 @@ impl CommandRegistry {
             .and_then(|specs| self.best_visible(specs, dialect))
     }
 
+    /// Resolve `head` the way this registry's own availability rules
+    /// resolve it: through [`Self::get_for_dialect`] against the dialect
+    /// profile this registry was built for, or through the dialect-agnostic
+    /// [`Self::get`] when it has no profile.
+    ///
+    /// The single place the "same availability rules as `get`" promise made
+    /// by the profile-aware behaviour queries is implemented, so a query
+    /// added later cannot quietly answer for a command the profile's
+    /// dialect does not have.
+    fn spec_for_this_registry(&self, head: &str) -> Option<&CommandSpec> {
+        match self.profile {
+            Some(profile) => self.get_for_dialect(head, profile.availability_mask),
+            None => self.get(head),
+        }
+    }
+
+    /// Which `TclOO` method-context keyword `head` is, if it is one.
+    ///
+    /// The registry-first replacement for the `head == "my"` /
+    /// `matches!(head, "my" | "next" | "nextto")` literals consumers used to
+    /// carry (issue #1050). Every consumer that needs "is this word a method
+    /// dispatch or introspection keyword, and which kind" asks here, so a
+    /// dialect that gains or loses one of them propagates through the specs
+    /// rather than through a walker edit.
+    ///
+    /// A leading `::` resolves to the bare name (consumers previously
+    /// matched `"my" | "::my"` by hand), matching [`Self::get`].
+    ///
+    /// Dialect-aware through the registry instance itself: a registry built
+    /// by `registry_for_dialect` / `registry_for_profile` answers under that
+    /// profile's availability mask, so all four keywords — every one of them
+    /// `TCL86_PLUS` — return `None` from a `tcl8.4` or `tcl8.5` registry. A
+    /// profile-less registry (`CommandRegistry::build_default`) answers
+    /// dialect-agnostically, exactly as [`Self::get`] does.
+    ///
+    /// `link` is **not** a keyword here and must not be added: it creates
+    /// per-class bareword commands rather than dispatching one (issue
+    /// #1026). Nor is `self`'s definer-grammar homonym — the `self` word
+    /// inside an `oo::define` body is a member-grammar wrapper, resolved
+    /// through [`crate::definer`], not a command head.
+    #[must_use]
+    pub fn method_dispatch_keyword(&self, head: &str) -> Option<MethodDispatchKind> {
+        let traits = self.spec_for_this_registry(head)?.traits;
+        if traits.contains(Traits::TCLOO_SELF_DISPATCH) {
+            Some(MethodDispatchKind::SelfDispatch)
+        } else if traits.contains(Traits::TCLOO_NEXT_CHAIN) {
+            Some(MethodDispatchKind::NextChain)
+        } else if traits.contains(Traits::TCLOO_INTROSPECTION) {
+            Some(MethodDispatchKind::Introspection)
+        } else {
+            None
+        }
+    }
+
     /// The single spec-selection rule (§5.3, D6): among the specs of one
     /// name visible under `dialect`, pick the **most specific** — a
     /// dialect-scoped spec beats a catch-all (`dialects: None`), a tighter
@@ -1554,6 +1608,32 @@ pub struct ResolvedTerminator {
     /// `0` for every subcommand-scoped match (no subcommand currently
     /// needs the reservation) and for any form without one declared.
     pub reserved_trailing_words: usize,
+}
+
+/// Which `TclOO` method-context keyword a command word is — the answer
+/// [`CommandRegistry::method_dispatch_keyword`] returns.
+///
+/// The three variants are three different axes, deliberately not merged: a
+/// consumer that wants "does the next word name a method" wants
+/// [`Self::SelfDispatch`] alone, and one that wants "is this a call into the
+/// method chain" wants `SelfDispatch | NextChain` but never
+/// [`Self::Introspection`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum MethodDispatchKind {
+    /// `my` — dispatches a method on the current object; the following word
+    /// is a method name on the enclosing class
+    /// ([`Traits::TCLOO_SELF_DISPATCH`]).
+    SelfDispatch,
+    /// `next` / `nextto` — invokes the next implementation of the
+    /// *currently executing* method along the receiver's method resolution
+    /// order, so no word names a method. `nextto`'s first word names the
+    /// *class* to resume from, marked [`ArgRole::Name`] on the spec
+    /// ([`Traits::TCLOO_NEXT_CHAIN`]).
+    NextChain,
+    /// `self` — introspects the current invocation and dispatches nothing;
+    /// its argument is a closed subcommand set, never a method name
+    /// ([`Traits::TCLOO_INTROSPECTION`]).
+    Introspection,
 }
 
 /// Outcome of [`CommandRegistry::resolve_call`].

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -482,6 +482,72 @@ declare_traits! {
     /// passes (expr re-lexing, W110) that consume the role.
     ExprConcatenatesArgs => EXPR_CONCATENATES_ARGS;
 
+    /// The command evaluates the concatenation of **every** trailing word
+    /// from its first [`crate::arg_role::ArgRole::Body`] argument onwards
+    /// as one script — the `Tcl_ConcatObj` eval family: `eval`, `uplevel`,
+    /// `namespace eval`, `namespace inscope`, and `interp eval`. The
+    /// script-side counterpart of [`Traits::EXPR_CONCATENATES_ARGS`].
+    ///
+    /// `Tcl_ConcatObj` (`generic/tclUtil.c`) takes each word's **string
+    /// representation** — so a braced word contributes its *contents*, the
+    /// outer braces already stripped by Tcl's word parsing — trims ASCII
+    /// whitespace from each end of it, and joins the results with a single
+    /// space. Commands therefore span word boundaries. tclsh8.6.14 and
+    /// tclsh9.0.4 both confirm:
+    ///
+    /// ```text
+    /// concat {set x} {5}      → set x 5
+    /// concat "  a  " "  b  "  → a b
+    /// eval set l2 hello       → sets l2 to "hello"
+    /// eval {set l2} hello     → sets l2 to "hello"
+    /// ```
+    ///
+    /// **Consumer contract.** A consumer that walks `ArgRole::Body`
+    /// arguments must never treat the first Body-role word as the whole
+    /// script when this trait is present and further words follow it.
+    /// Analysing `eval set l2 hello` as the one-word script `set` invents a
+    /// wrong-#-args error and loses the write to `l2`. Either join the
+    /// trailing words per the rule above (sound only when every one of them
+    /// is a static literal — a bare or braced word with no `$` / `[`
+    /// substitution) or decline to walk the command at all.
+    ///
+    /// **Limit.** The join is a *static* approximation. One dynamic word
+    /// makes the whole script unknowable at analysis time, because
+    /// substitution happens before concatenation: `eval $cmd arg` may run
+    /// any command at all. Consumers must consume such a call without
+    /// walking rather than guess.
+    ///
+    /// `catch` is deliberately **not** in this family: it takes a single
+    /// bounded script argument, so its remaining words are result/options
+    /// variable names, not script text.
+    ///
+    /// [`Traits::SCRIPT_APPENDS_LIST_ARGS`] refines the join rule for the
+    /// one family member that does not space-join.
+    ScriptConcatenatesArgs => SCRIPT_CONCATENATES_ARGS;
+
+    /// Refines [`Traits::SCRIPT_CONCATENATES_ARGS`] for the one family
+    /// member whose trailing words are appended as **list elements**
+    /// instead of being space-joined into the script text —
+    /// `namespace inscope`.
+    ///
+    /// `namespace inscope ns script ?arg ...?` is equivalent to
+    /// `namespace eval ns [concat script [list arg ...]]`
+    /// (`NamespaceInscopeCmd`, `generic/tclNamesp.c`), so each trailing word
+    /// arrives at the invoked command as exactly one argument, whatever
+    /// whitespace it contains. tclsh8.6.14 and tclsh9.0.4 both confirm the
+    /// divergence:
+    ///
+    /// ```text
+    /// namespace inscope :: {puts} {a b}   → prints "a b"  (one argument)
+    /// namespace eval    :: {puts} {a b}   → error: can not find channel named "a"
+    /// ```
+    ///
+    /// A consumer must therefore **not** space-join a call carrying this
+    /// trait. Reconstructing the real script needs list quoting the analyser
+    /// does not model, so the sound response to any trailing word here is to
+    /// consume the command without walking it.
+    ScriptAppendsListArgs => SCRIPT_APPENDS_LIST_ARGS;
+
     /// (Subcommand) installs or removes an active variable trace on a
     /// named target — `trace add|remove|variable|vdelete` (not
     /// `info`/`vinfo`, which only *query* trace state). A variable
@@ -544,6 +610,53 @@ declare_traits! {
     /// distinguished structurally via an [`crate::arg_role::ArgRole::Name`]
     /// at argument index 0, not by command name.
     TclooNextChain => TCLOO_NEXT_CHAIN;
+
+    /// `TclOO` `my` — dispatches a method on the **current object**, from
+    /// inside that object's own method, constructor, or destructor
+    /// (`TclOOMyObjCmd`, `generic/tclOO.c`). Unlike calling the object's
+    /// public command, `my` reaches non-exported (and, from 9.0, private)
+    /// methods, so a `my foo` word is a real reference to the enclosing
+    /// class's `foo` method and must resolve, rename, and report references
+    /// as one.
+    ///
+    /// One of the three `TclOO` method-context keyword traits, which sit on
+    /// distinct axes and must not be conflated by a consumer:
+    ///
+    /// - **`TCLOO_SELF_DISPATCH`** (`my`) — instance self-dispatch: the
+    ///   first argument names a method on *this* object.
+    /// - [`Traits::TCLOO_NEXT_CHAIN`] (`next` / `nextto`) — superclass
+    ///   chain: no method name at all, the callee is the next
+    ///   implementation of the *currently executing* method.
+    /// - [`Traits::TCLOO_INTROSPECTION`] (`self`) — introspection, never
+    ///   dispatch: it returns a description of the current invocation.
+    ///
+    /// `link` is deliberately outside all three. `link` *creates* bareword
+    /// commands in the object's namespace (`link {alias method}`), so those
+    /// barewords are per-class data — not language keywords — and no
+    /// consumer may treat `link` itself as a dispatch site (issue #1026).
+    ///
+    /// A dialect that gained or lost `my` would propagate through this
+    /// spec's `dialects` mask, so consumers query the registry rather than
+    /// spelling the name: see
+    /// [`crate::registry::CommandRegistry::method_dispatch_keyword`].
+    TclooSelfDispatch => TCLOO_SELF_DISPATCH;
+
+    /// `TclOO` `self` — **introspects** the current method invocation
+    /// (`TclOOSelfObjCmd`, `generic/tclOO.c`): which object is running,
+    /// which method, which declaring class, which instance namespace, and
+    /// where in the call chain it sits. It dispatches nothing.
+    ///
+    /// The distinction matters to every consumer that walks method bodies
+    /// looking for method references: a `self` word introduces no method
+    /// name, so a consumer that lumps it in with
+    /// [`Traits::TCLOO_SELF_DISPATCH`] would treat `self class` as a call
+    /// to a method named `class`. Its argument is a closed subcommand set
+    /// (`arg_values` / `closed_value_args` on the spec), not a method name.
+    ///
+    /// See [`Traits::TCLOO_SELF_DISPATCH`] for the full family and
+    /// [`crate::registry::CommandRegistry::method_dispatch_keyword`] for
+    /// the query consumers use instead of a literal name test.
+    TclooIntrospection => TCLOO_INTROSPECTION;
 
     /// Raises a *catchable* exception — completes `TCL_ERROR`, which
     /// `catch` / `try` intercept: `error` (`Tcl_ErrorObjCmd`,

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -658,6 +658,29 @@ declare_traits! {
     /// the query consumers use instead of a literal name test.
     TclooIntrospection => TCLOO_INTROSPECTION;
 
+    /// Each body argument runs only when this command's own run-time
+    /// selection picks it, and the command performs no iteration — `if`
+    /// (at most one clause body plus an optional `else`) and `try` (handler
+    /// bodies reached only on the matching exception, with `finally` the one
+    /// exception that always runs).
+    ///
+    /// The fact a consumer needs is that nothing established inside such a
+    /// body **dominates** the code after the command: a `package require`
+    /// there is conditional, and a variable written there is not reliably
+    /// set afterwards.
+    ///
+    /// Deliberately narrower than [`Traits::CONTROL_FLOW`], which also
+    /// covers `while` / `for` / `foreach` / `lmap`. A loop body is
+    /// *repeatable* as well as skippable, so the two questions have
+    /// different answers and different consumers —
+    /// `Analyser::control_flow_body_depth` (straight-line-ness, driven by
+    /// `CONTROL_FLOW`) and `Analyser::conditional_depth` (domination, driven
+    /// by this trait) must not be merged. Also distinct from
+    /// [`Traits::HAS_BOOLEAN_COND`], which is about an argument being read
+    /// as a boolean expression (`if` / `while` / `for`) rather than about
+    /// which bodies run.
+    BranchSelectedBody => BRANCH_SELECTED_BODY;
+
     /// Raises a *catchable* exception — completes `TCL_ERROR`, which
     /// `catch` / `try` intercept: `error` (`Tcl_ErrorObjCmd`,
     /// `generic/tclCmdAH.c`) and `throw` (`TclNRThrowObjCmd`,

--- a/rust/tcl-registry/tests/registry_commands.rs
+++ b/rust/tcl-registry/tests/registry_commands.rs
@@ -1948,6 +1948,40 @@ fn tcloo_dispatch_keyword_membership() {
     }
 }
 
+/// The consumer-visible keyword set equals the trait-carrying specs across
+/// every dialect a `TclOO` consumer may run under, including the F5 ones.
+///
+/// The guard for the #1050 migration: `tcl-lsp-core`'s references,
+/// call-hierarchy, definition, hover, rename, and semantic-token providers,
+/// plus the compiler's `var_command` / `elimination` / `class_lattice` /
+/// `var_observability` passes, all resolve these words through
+/// `method_dispatch_keyword`. If a consumer ever re-adds a literal name list
+/// it will disagree with this set the moment a dialect changes — which is
+/// exactly the drift this asserts cannot happen silently.
+#[test]
+fn tcloo_dispatch_keyword_set_matches_the_trait_carriers_per_dialect() {
+    for dialect in ["tcl8.6", "tcl9.0", "f5-irules", "f5-iapps", "expect"] {
+        let reg = registry_for_dialect(dialect);
+        let mut carriers: Vec<&str> = reg
+            .commands_with_trait(Traits::TCLOO_SELF_DISPATCH)
+            .into_iter()
+            .chain(reg.commands_with_trait(Traits::TCLOO_NEXT_CHAIN))
+            .chain(reg.commands_with_trait(Traits::TCLOO_INTROSPECTION))
+            .filter(|name| reg.method_dispatch_keyword(name).is_some())
+            .collect();
+        carriers.sort_unstable();
+        let mut answered: Vec<&str> = ["my", "next", "nextto", "self", "link", "puts", "proc"]
+            .into_iter()
+            .filter(|name| reg.method_dispatch_keyword(name).is_some())
+            .collect();
+        answered.sort_unstable();
+        assert_eq!(
+            carriers, answered,
+            "under {dialect} the answered keyword set must be exactly the trait carriers"
+        );
+    }
+}
+
 /// All four keywords are `TCL86_PLUS`, so a pre-8.6 dialect registry answers
 /// `None` — dialect-awareness comes from the registry instance, never from a
 /// per-consumer version check.
@@ -1972,6 +2006,46 @@ fn tcloo_dispatch_keywords_are_absent_before_86() {
         reg.method_dispatch_keyword("my"),
         Some(MethodDispatchKind::SelfDispatch)
     );
+}
+
+/// `BRANCH_SELECTED_BODY` is exactly `if` and `try` — the commands whose
+/// bodies are chosen at run time without iterating, so nothing established
+/// inside one dominates the code after it.
+///
+/// Deliberately narrower than `CONTROL_FLOW`, which also covers the loops.
+/// A loop body is skippable *and* repeatable, a different question with a
+/// different consumer (`control_flow_body_depth` versus
+/// `conditional_depth`) — the two must not be merged.
+///
+/// registry-metadata: "which bodies are branch-selected" is our
+/// classification. (`if`, `try`, `while`, `for`, `foreach`, and `switch` are
+/// all real tclsh 8.6/9.0 commands.)
+#[test]
+fn branch_selected_body_trait_membership() {
+    let (reg, ds) = reg_and_set("tcl8.6");
+    let mut carriers = reg.commands_with_trait(Traits::BRANCH_SELECTED_BODY);
+    carriers.sort_unstable();
+    assert_eq!(carriers, ["if", "try"]);
+    for negative in ["while", "for", "foreach", "switch", "lmap", "catch"] {
+        assert!(
+            !reg.get_for_dialect(negative, ds)
+                .expect("registered")
+                .traits
+                .contains(Traits::BRANCH_SELECTED_BODY),
+            "{negative} iterates or is otherwise not branch-selected"
+        );
+    }
+    // …and every carrier is control flow, so the narrower trait is a strict
+    // subset rather than an orthogonal axis.
+    for carrier in carriers {
+        assert!(
+            reg.get_for_dialect(carrier, ds)
+                .expect("registered")
+                .traits
+                .contains(Traits::CONTROL_FLOW),
+            "{carrier} must also be control flow"
+        );
+    }
 }
 
 /// The `Tcl_ConcatObj` eval family: every command whose trailing words after

--- a/rust/tcl-registry/tests/registry_commands.rs
+++ b/rust/tcl-registry/tests/registry_commands.rs
@@ -50,7 +50,8 @@ use tcl_registry::arity::Arity;
 use tcl_registry::events::EventRegistry;
 use tcl_registry::profiles::ProfileRegistry;
 use tcl_registry::{
-    ArgRole, CommandRegistry, KNOWN_DIALECTS, Traits, available_dialects, registry_for_dialect,
+    ArgRole, CommandRegistry, KNOWN_DIALECTS, MethodDispatchKind, Traits, available_dialects,
+    registry_for_dialect,
 };
 
 // ---------------------------------------------------------------------------
@@ -1879,4 +1880,175 @@ fn interp_create_defines_command_at_its_name_argument() {
     // The other interp subcommands bind no command name.
     let eval = spec.subcommand("eval").expect("interp eval modelled");
     assert_eq!(eval.defines_command_at, None);
+}
+
+// ===========================================================================
+// TclOO method-context keywords + the `Tcl_ConcatObj` eval family (#1050, #1051)
+// ===========================================================================
+
+/// The `TclOO` method-context keyword set is exactly `my` / `next` / `nextto`
+/// / `self`, and `CommandRegistry::method_dispatch_keyword` answers with the
+/// right kind for each.
+///
+/// This is the guard for issue #1050: the consumer-visible keyword set must
+/// equal the trait-carrying specs, so a consumer can never drift from the
+/// registry by re-adding a `head == "my"` literal.  `link` is deliberately
+/// out — it *creates* per-class bareword commands rather than dispatching one
+/// (issue #1026).
+///
+/// registry-metadata: which keyword is dispatch and which is introspection is
+/// our classification.  (`my`, `next`, `nextto`, `self`, and `link` are all
+/// real tclsh 8.6/9.0 `TclOO` commands.)
+#[test]
+fn tcloo_dispatch_keyword_membership() {
+    let reg = registry_for_dialect("tcl8.6");
+    assert_eq!(
+        reg.method_dispatch_keyword("my"),
+        Some(MethodDispatchKind::SelfDispatch)
+    );
+    assert_eq!(
+        reg.method_dispatch_keyword("next"),
+        Some(MethodDispatchKind::NextChain)
+    );
+    assert_eq!(
+        reg.method_dispatch_keyword("nextto"),
+        Some(MethodDispatchKind::NextChain)
+    );
+    assert_eq!(
+        reg.method_dispatch_keyword("self"),
+        Some(MethodDispatchKind::Introspection)
+    );
+    // A leading `::` resolves to the bare name — consumers used to match
+    // `"my" | "::my"` by hand.
+    assert_eq!(
+        reg.method_dispatch_keyword("::my"),
+        Some(MethodDispatchKind::SelfDispatch)
+    );
+    for negative in ["puts", "set", "link", "proc", "oo::define"] {
+        assert_eq!(
+            reg.method_dispatch_keyword(negative),
+            None,
+            "{negative} is not a method-dispatch keyword"
+        );
+    }
+    // The trait-carrying spec set and the query agree, in both directions.
+    let mut carriers: Vec<&str> = reg
+        .commands_with_trait(Traits::TCLOO_SELF_DISPATCH)
+        .into_iter()
+        .chain(reg.commands_with_trait(Traits::TCLOO_NEXT_CHAIN))
+        .chain(reg.commands_with_trait(Traits::TCLOO_INTROSPECTION))
+        .collect();
+    carriers.sort_unstable();
+    assert_eq!(carriers, ["my", "next", "nextto", "self"]);
+    for name in carriers {
+        assert!(
+            reg.method_dispatch_keyword(name).is_some(),
+            "{name} carries a dispatch trait so the query must answer for it"
+        );
+    }
+}
+
+/// All four keywords are `TCL86_PLUS`, so a pre-8.6 dialect registry answers
+/// `None` — dialect-awareness comes from the registry instance, never from a
+/// per-consumer version check.
+///
+/// tclsh: `TclOO` shipped with 8.6; `my` / `next` / `self` do not exist in
+/// 8.4 or 8.5.
+#[test]
+fn tcloo_dispatch_keywords_are_absent_before_86() {
+    for dialect in ["tcl8.4", "tcl8.5"] {
+        let reg = registry_for_dialect(dialect);
+        for keyword in ["my", "next", "nextto", "self"] {
+            assert_eq!(
+                reg.method_dispatch_keyword(keyword),
+                None,
+                "{keyword} must not resolve under {dialect}"
+            );
+        }
+    }
+    // …and still resolves under 9.0.
+    let reg = registry_for_dialect("tcl9.0");
+    assert_eq!(
+        reg.method_dispatch_keyword("my"),
+        Some(MethodDispatchKind::SelfDispatch)
+    );
+}
+
+/// The `Tcl_ConcatObj` eval family: every command whose trailing words after
+/// the first `ArgRole::Body` argument are part of the script it evaluates.
+///
+/// tclsh8.6.14 / tclsh9.0.4: `eval set l2 hello` sets `l2` to `hello`;
+/// `namespace eval ::n set l2 hello` sets `::n::l2`; `interp eval i {set y} 7`
+/// sets `y` to `7` in the child.  `catch` and `apply` take a single bounded
+/// script/lambda argument (`apply {{} {set q 1}} extra` errors "wrong # args"),
+/// so both stay out.
+#[test]
+fn script_concat_family_membership() {
+    let (reg, ds) = reg_and_set("tcl8.6");
+    for name in ["eval", "uplevel"] {
+        assert!(
+            reg.get_for_dialect(name, ds)
+                .expect("registered")
+                .traits
+                .contains(Traits::SCRIPT_CONCATENATES_ARGS),
+            "{name} concatenates its script words"
+        );
+    }
+    let ns = reg.get_for_dialect("namespace", ds).expect("namespace");
+    for sub in ["eval", "inscope"] {
+        assert!(
+            ns.subcommand(sub)
+                .expect("modelled")
+                .traits
+                .contains(Traits::SCRIPT_CONCATENATES_ARGS),
+            "namespace {sub} concatenates its script words"
+        );
+    }
+    assert!(
+        reg.get_for_dialect("interp", ds)
+            .expect("interp")
+            .subcommand("eval")
+            .expect("interp eval modelled")
+            .traits
+            .contains(Traits::SCRIPT_CONCATENATES_ARGS)
+    );
+    for negative in ["catch", "apply", "subst", "if"] {
+        assert!(
+            !reg.get_for_dialect(negative, ds)
+                .expect("registered")
+                .traits
+                .contains(Traits::SCRIPT_CONCATENATES_ARGS),
+            "{negative} takes a bounded script argument, not a concatenated tail"
+        );
+    }
+}
+
+/// `namespace inscope` is the one family member whose trailing words are
+/// appended as **list elements** rather than space-joined, so it carries the
+/// refinement trait and nothing else does.
+///
+/// tclsh8.6.14 / tclsh9.0.4: `namespace inscope :: {puts} {a b}` prints
+/// `a b` (one argument), while `namespace eval :: {puts} {a b}` errors
+/// "can not find channel named "a"".
+#[test]
+fn script_append_list_refinement_is_inscope_only() {
+    let (reg, ds) = reg_and_set("tcl8.6");
+    let ns = reg.get_for_dialect("namespace", ds).expect("namespace");
+    let refined = reg.subcommands_with_trait("namespace", Traits::SCRIPT_APPENDS_LIST_ARGS);
+    assert_eq!(refined, ["inscope"]);
+    assert!(
+        !ns.subcommand("eval")
+            .expect("modelled")
+            .traits
+            .contains(Traits::SCRIPT_APPENDS_LIST_ARGS),
+        "namespace eval space-joins its tail"
+    );
+    for name in ["eval", "uplevel"] {
+        assert!(
+            !reg.get_for_dialect(name, ds)
+                .expect("registered")
+                .traits
+                .contains(Traits::SCRIPT_APPENDS_LIST_ARGS)
+        );
+    }
 }

--- a/rust/tcl-registry/tests/registry_sweep.rs
+++ b/rust/tcl-registry/tests/registry_sweep.rs
@@ -157,6 +157,7 @@ const ALL_TRAITS: &[Traits] = &[
     Traits::SCRIPT_APPENDS_LIST_ARGS,
     Traits::TCLOO_SELF_DISPATCH,
     Traits::TCLOO_INTROSPECTION,
+    Traits::BRANCH_SELECTED_BODY,
 ];
 
 /// Assert the basic arity invariant shared by every `Arity` (command or

--- a/rust/tcl-registry/tests/registry_sweep.rs
+++ b/rust/tcl-registry/tests/registry_sweep.rs
@@ -153,6 +153,10 @@ const ALL_TRAITS: &[Traits] = &[
     Traits::ESTABLISHES_VARIABLE_TRACE,
     Traits::TRANSFERS_CONTROL,
     Traits::FIRE_AND_FORGET_TEARDOWN,
+    Traits::SCRIPT_CONCATENATES_ARGS,
+    Traits::SCRIPT_APPENDS_LIST_ARGS,
+    Traits::TCLOO_SELF_DISPATCH,
+    Traits::TCLOO_INTROSPECTION,
 ];
 
 /// Assert the basic arity invariant shared by every `Arity` (command or

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -435,11 +435,31 @@ pub const TRAITS: &[Variant] = &[
         "EXPR_CONCATENATES_ARGS",
         "concatenates its arguments into one expression",
     ),
+    v(
+        "SCRIPT_CONCATENATES_ARGS",
+        "concatenates its trailing words into one script",
+    ),
+    v(
+        "SCRIPT_APPENDS_LIST_ARGS",
+        "appends its trailing words to the script as list elements",
+    ),
     v("ESTABLISHES_VARIABLE_TRACE", "establishes a variable trace"),
     v("TRANSFERS_CONTROL", "transfers control elsewhere"),
     v("FIRE_AND_FORGET_TEARDOWN", "fire-and-forget teardown"),
     v("OPERATOR_COMMAND", "an operator in command form"),
     v("TCLOO_NEXT_CHAIN", "participates in the TclOO next chain"),
+    v(
+        "TCLOO_SELF_DISPATCH",
+        "dispatches on the current TclOO object",
+    ),
+    v(
+        "TCLOO_INTROSPECTION",
+        "introspects the current TclOO method context",
+    ),
+    v(
+        "BRANCH_SELECTED_BODY",
+        "its bodies run at most once, chosen by a branch",
+    ),
     v("CATCHABLE_THROW", "throws a catchable error"),
     v("BREAKS_LOOP", "breaks out of a loop"),
     v("CONTINUES_LOOP", "continues a loop"),


### PR DESCRIPTION
## Summary

Fixes #1049, fixes #1050, fixes #1051, plus two gap-review findings — all modelled as registry data consumed generically, per the registry-first rule.

**Registry facilities** (all appended to `declare_traits!`, documented with examples and limits, swept by `ALL_TRAITS`):
- `SCRIPT_CONCATENATES_ARGS` on `eval`, `uplevel`, `namespace eval`, `namespace inscope`, `interp eval` — the `Tcl_ConcatObj` family — with `SCRIPT_APPENDS_LIST_ARGS` as a refinement on `namespace inscope` (its tail is list-appended, not space-joined).
- `TCLOO_SELF_DISPATCH` on `my`, `TCLOO_INTROSPECTION` on `self` (joining the existing `TCLOO_NEXT_CHAIN` on `next`/`nextto`), surfaced through a new dialect-aware `CommandRegistry::method_dispatch_keyword(head) -> Option<MethodDispatchKind>` (`SelfDispatch` / `NextChain` / `Introspection`, `::`-normalising, `None` before 8.6).
- `BRANCH_SELECTED_BODY` on `if`/`try` (bodies chosen by a branch, no iteration) — replacing the `is_conditional` name literals in the generic body walk.
- Contract tests modelled on `control_flow_trait_membership` pin every membership set, the query↔trait agreement per dialect, and the pre-8.6 absence.

**#1051 — multi-word `eval` concatenation.** `dispatch_body_arguments` now mirrors the `EXPR_CONCATENATES_ARGS` precedent: a fully-static tail is joined per the oracle-pinned `Tcl_ConcatObj` semantics (braces already stripped by word parsing; per-word end-trim; empty words dropped; single-space join — encoded in the shared `concat_script_words` helper) and analysed as one script; any dynamic word declines like `interp eval` (no false facts). `handle_namespace_eval_command` gets the same treatment (`namespace eval` joins; `inscope` consumes-without-walk). The false W210 half is fixed via a `BodyKind::Plain`-gated suppression harvested from barrier statements, so a caller-frame `uplevel` write can never silence a real local read-before-set. W101's gate is re-pointed at the traits (semantics, not spec-shape spelling) with W301 as its exact complement — the eval-vs-uplevel split keeps its tests.

**#1049 — rename/alias-aware constructor typing.** New `class_reachable_by_indirection` in `var_command.rs`: a bounded, order-gated forward hop through `renamed_commands` **and** `command_aliases` (aliases with prepended args decline; chained renames walk with the same hop cap as the proc-arity resolver), returning the canonical class name. Wired into both constructor-typing sites, so `rename Dog Cat; set d [Cat new]; $d fly` draws W308 naming `::Dog` instead of W307 noise — while `[Cat new]` *before* the rename stays untyped (the analyser's order-fact diagnostic there is W128, with the W123 never-established case pinned separately). All PR #1045 liveness tests, the issue-1013 gates, and the constructor-typing regression suite stay green.

**#1050 — dispatch-keyword literals → registry query.** Every genuine `"my"`/`"next"`/`"nextto"`/`"self"` dispatch literal in `references.rs`, `call_hierarchy.rs`, `definition.rs`, `hover.rs`, `rename.rs`, `semantic_tokens.rs` (the `my` half only — `$self`/`$this` object-handle variable naming is a different axis, now commented), `var_command.rs`, `elimination.rs`, `class_lattice.rs`, and `var_observability.rs` now resolves through the query. The `oo::define self { … }` definer-grammar keyword is a different `self` and stays with the `definition_body` grammar; `oo.rs`'s `link` recognition is commented against #1026.

**Gap fixes.** The `"unknown"` name-literal in `handlers.rs` seeded the global unresolved-handler info for a *namespace-local* `proc unknown`, suppressing W123 file-wide (real Tcl only consults `::unknown` for bare global calls) — now resolved through `UNRESOLVED_COMMAND_HANDLER` + a global-scope requirement. The `"when"` literal in the generic body walk now uses `IS_EVENT_HANDLER`. A pre-existing quirk (`try` bodies not bumping conditional depth) is pinned by a test rather than silently widened. Also: the spec-studio traits catalogue gained the five new entries (its mirror gate caught the omission).

**Deferred with detail** (comments to follow on the issues): rename-aware go-to-definition (`resolve_class_target_at`/`lookup_alias` — B1/B2), arity-checking `namespace inscope`'s list-appended tail, `try` conditional-depth, `definition.rs` real-dialect threading.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `make check-all` — PASSED on this branch; `make xtask-check` — all drift gates green. `cargo clippy --workspace --all-targets` — 0 warnings, **no new allows** (two `too_many_lines` fixed by extraction).
  - `cargo test -p tcl-registry -p tcl-compiler -p tcl-lsp-core` — 10,133 passed, 0 failed; `cargo test -p tcl-lsp-server` — 1,365 passed (e2e additions in `diagnostic_matrix.rs`).
  - `make test-rust` (full workspace) — green on the local integration merge with the sibling dialect-threading branch (230 suites), proving the two compose.
  - `make test-emacs` — green. `make runtime-rust-test` — 324/325 (1 pre-existing base failure, filed #1058). `make test-ext` — 682 passing including the new multi-word-eval suite; 10 pre-existing environment failures filed #1059.
  - Every subtle expectation oracle-pinned on tclsh 8.6.14 **and** 9.0.4 (concat/brace semantics, `uplevel` frame targeting, `namespace inscope` list-append, alias-with-args constructor identity, namespace-local `unknown`).
  - `make gen-editor-settings` not needed — no diagnostic code/severity/message changed (behaviour-only).

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — eval-family script joining, constructor-typing indirection, and the unknown-handler scope gate.
- [x] Updated KCS: new `kcs-issue-false-diagnostics-inside-a-multi-word-eval.md`; updated the W308 and W123 per-code pages; `docs/design/compiler/command-registry.md` documents the new traits and query.
- [x] New notes linked from `docs/kcs/README.md` (top-level notes; per-code pages live under `docs/kcs/codes/`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_