### PR TITLE
Dispatch precision: namespace-scoped bare dispatch, itcl colon-qualified class procs, non-identifier method names (#981 #990, #1019 idx 16)

### DIFF
--- a/docs/kcs/features/kcs-feature-call-hierarchy.md
+++ b/docs/kcs/features/kcs-feature-call-hierarchy.md
@@ -79,6 +79,11 @@ kinds read consistently in the same list.
   [Find References](kcs-feature-references.md)).
 - An external `$obj method` call from a different class or document is not
   an incoming edge on the method (intra-class only).
+- [incr Tcl]'s class-scoped `proc` gets edges for its real
+  `Factory::make` dispatch shape, but only within one document — a call in
+  a sibling file is not an incoming edge. itcl's two-word `Factory make`
+  is object creation (`ClassName instanceName`), not a dispatch, and is
+  correctly never an edge.
 
 ## Test anchors
 
@@ -88,6 +93,9 @@ kinds read consistently in the same list.
   `outgoing_calls_from_proc_reach_bare_class_dispatch`,
   `classmethod_incoming_covers_lambda_and_namespace_eval_bodies`,
   `classmethod_incoming_names_proc_callers_qualified`,
+  `incoming_calls_for_an_itcl_class_proc_find_colon_qualified_dispatch`,
+  `outgoing_calls_from_an_itcl_class_proc_reach_the_sibling_class_proc`,
+  `itcl_two_word_object_creation_is_not_a_call_hierarchy_edge`,
   and `prepare_resolves_classmethod_over_same_named_method_by_cursor`)
 - `rust/tcl-lsp-server/tests/e2e/navigation_extras.rs`
   (`method_incoming_and_outgoing_calls_match_my_dispatch`,

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -79,6 +79,13 @@ double-quoted string.
   and a call site found in it would point at the wrong bytes.
 - Expect's `expect { -re pattern body … }` clause list is not descended (only
   a plain `{pattern body …}` clause list, `switch`'s shape, is).
+- A method whose name is a bare operator — Tcl lets you write `method + {o}
+  {…}` — is not resolved from its call site. Every other method name is:
+  hyphens, dots, and TIP 558's generated property accessors
+  (`<ReadProp-NAME>` / `<WriteProp-NAME>`, produced by `oo::configurable`'s
+  `property`) are all part of the name. Operator-only names stay out because
+  `expr {$a < $b}` would otherwise read as `$a` dispatching a method called
+  `<`, and `expr` bodies are far more common than operator-named methods.
 - [incr Tcl] dispatches a class-scoped `proc` (itcl's own class-method form)
   as a single `::`-qualified identifier — `Factory::make`, not `Factory make`
   — which is a different call shape entirely from `classmethod` /
@@ -107,7 +114,9 @@ double-quoted string.
   `obj_method_dispatch`, `next_dispatch`, `classmethod_dispatch` —
   control-flow-nested dispatch TP/FP/TN matrix (issue #957) and the
   classmethod/typemethod/itcl-proc TP/FP/TN/FN matrix, including issue #956's
-  exact repro and call-site-cursor resolution)
+  exact repro and call-site-cursor resolution;
+  `non_identifier_method_names` — hyphenated / dotted / TIP 558
+  angle-bracketed method names)
 - `rust/tcl-lsp-core/src/references.rs` (`mod tests`, including
   `references_for_property_includes_decl_and_my_dispatch_call_sites`,
   `references_disambiguates_property_and_method_sharing_a_name_by_cursor`,

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -86,15 +86,16 @@ double-quoted string.
   `property`) are all part of the name. Operator-only names stay out because
   `expr {$a < $b}` would otherwise read as `$a` dispatching a method called
   `<`, and `expr` bodies are far more common than operator-named methods.
-- [incr Tcl] dispatches a class-scoped `proc` (itcl's own class-method form)
-  as a single `::`-qualified identifier — `Factory::make`, not `Factory make`
-  — which is a different call shape entirely from `classmethod` /
-  `typemethod`'s two-word dispatch. Find References does not yet follow this
-  form (it would need to be resolved through the ordinary proc-reference
-  path, not the object-method scanner). The reverse direction is guarded,
-  though: itcl's own two-word instance-creation syntax (`ClassName
-  instanceName`), which can coincidentally share text shape with a
-  same-named class-proc, is never mistaken for a dispatch of it.
+- [incr Tcl]'s class-scoped `proc` dispatch is followed **within one
+  document only**. itcl gives every class a real namespace and installs its
+  class-scoped `proc`s as commands inside it, so `Factory::make` is a genuine
+  command name; Find References, Go to Definition, Rename, and Call Hierarchy
+  all resolve it against the call's own namespace. A call written in a
+  *sibling file* is not found — the cross-file layer still looks only for the
+  two-word `Class method` shape. The two-word form in itcl source is
+  guarded in the other direction too: `Factory make` there is itcl's
+  instance-creation syntax (`ClassName instanceName`), never a class-proc
+  dispatch, and is never counted as one.
 - A classmethod's / typemethod's own-class-command dispatch (unlike an
   instance's `$obj method`) is matched by exact name-set membership (the
   class's as-written simple name plus its fully `::`-qualified name), so a
@@ -116,7 +117,8 @@ double-quoted string.
   classmethod/typemethod/itcl-proc TP/FP/TN/FN matrix, including issue #956's
   exact repro and call-site-cursor resolution;
   `non_identifier_method_names` — hyphenated / dotted / TIP 558
-  angle-bracketed method names)
+  angle-bracketed method names; `itcl_class_proc_dispatch` — the
+  colon-qualified [incr Tcl] class-proc TP/FP/TN matrix)
 - `rust/tcl-lsp-core/src/references.rs` (`mod tests`, including
   `references_for_property_includes_decl_and_my_dispatch_call_sites`,
   `references_disambiguates_property_and_method_sharing_a_name_by_cursor`,

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -96,17 +96,14 @@ double-quoted string.
   guarded in the other direction too: `Factory make` there is itcl's
   instance-creation syntax (`ClassName instanceName`), never a class-proc
   dispatch, and is never counted as one.
-- A classmethod's / typemethod's own-class-command dispatch (unlike an
-  instance's `$obj method`) is matched by exact name-set membership (the
-  class's as-written simple name plus its fully `::`-qualified name), so a
-  call spelled with a *partial* namespace qualifier from a sibling namespace
-  is not matched — the same imprecision `CLASS create NAME` object-command
-  dispatch already has. The same imprecision can also over-match: two
-  unrelated classes sharing a simple (tail) name in different namespaces
-  aren't distinguished by lexical scope, so a bare dispatch inside one
-  namespace can be wrongly attributed to the other's same-named class —
-  renaming from the wrong one's declaration could then rewrite the
-  unrelated class's call site. Tracked as a follow-up; not yet fixed.
+- A `CLASS create NAME` object command (`rex bark`) is matched by name text
+  alone. Two object commands called `rex` in different namespaces are one
+  name as far as the analyser is concerned — it records instance-command
+  names without their creating namespace — so a bare `rex bark` in either
+  namespace counts for whichever `rex` the analyser bound first. A
+  classmethod's own-class-command dispatch (`Factory make`) does **not**
+  have this problem: it is resolved against the call's own namespace, first
+  the current one and then the global one, exactly as Tcl resolves it.
 
 ## Test anchors
 
@@ -118,7 +115,9 @@ double-quoted string.
   exact repro and call-site-cursor resolution;
   `non_identifier_method_names` — hyphenated / dotted / TIP 558
   angle-bracketed method names; `itcl_class_proc_dispatch` — the
-  colon-qualified [incr Tcl] class-proc TP/FP/TN matrix)
+  colon-qualified [incr Tcl] class-proc TP/FP/TN matrix;
+  `namespace_scoped_class_dispatch` — two same-named classes in different
+  namespaces are not cross-linked)
 - `rust/tcl-lsp-core/src/references.rs` (`mod tests`, including
   `references_for_property_includes_decl_and_my_dispatch_call_sites`,
   `references_disambiguates_property_and_method_sharing_a_name_by_cursor`,

--- a/rust/tcl-lsp-core/src/call_hierarchy.rs
+++ b/rust/tcl-lsp-core/src/call_hierarchy.rs
@@ -66,6 +66,13 @@
 //! command, so all four really do dispatch it (tclsh9.0-verified), and the
 //! `my`-scope rule ([`dispatch_reaches`]) does not gate this shape.
 //!
+//! The same scanner also carries [incr Tcl]'s class-scoped `proc` shape — a
+//! single `::`-qualified `Factory::make` word rather than two words (issue
+//! #990) — so an itcl class proc gets the same edges from the same place.
+//! itcl's own two-word `Factory make` is object *creation*
+//! (`ClassName instanceName`) and never becomes an edge, which is the
+//! registry-driven definer-family rule the scanner already applies.
+//!
 //! Still out of scope: a `next` / `nextto` super-dispatch is not a
 //! call-hierarchy edge (it *is* a reference — see
 //! [`crate::references::method_next_dispatch_spans`] — but attributing it a
@@ -1609,6 +1616,53 @@ mod tests {
         let callees: Vec<&str> = outgoing.iter().map(|c| c.to.name.as_str()).collect();
         assert_eq!(callees, vec!["::Factory::make"], "{outgoing:?}");
         assert_eq!(outgoing[0].from_ranges.len(), 1, "{outgoing:?}");
+    }
+
+    /// FN→TP (issue #990): [incr Tcl]'s class-scoped `proc` dispatches as a
+    /// single `::`-qualified word, so the two-word scan that finds a
+    /// `classmethod`'s edges never saw it and itcl call hierarchies were
+    /// empty.  Oracle (tclsh 8.6.14 + Itcl 3.4): a bare `make` inside a
+    /// sibling class `proc`, `Factory::make` inside a method body, and a
+    /// top-level `Factory::make` all enter `make`.
+    #[test]
+    fn incoming_calls_for_an_itcl_class_proc_find_colon_qualified_dispatch() {
+        let src = "itcl::class Factory {\n    proc make {} { return 1 }\n    proc build {} { return [make] }\n    method viaInstance {} { return [Factory::make] }\n}\nFactory::make\n";
+        let analysis = analyse(src);
+        // Cursor on `make`'s declaration name (line 1, col 10).
+        let items = prepare(src, 1, 10, &analysis);
+        assert_eq!(items[0].name, "::Factory::make", "{items:?}");
+        let incoming = incoming_calls(src, "tcl8.6", &items[0], &analysis);
+        let callers: Vec<&str> = incoming.iter().map(|c| c.from.name.as_str()).collect();
+        assert_eq!(
+            callers,
+            vec!["::Factory::build", "::Factory::viaInstance", "<top-level>"],
+            "{incoming:?}"
+        );
+    }
+
+    /// FN→TP: the outgoing direction of the same shape — `build`'s body
+    /// dispatches `make`, so `make` is its callee.
+    #[test]
+    fn outgoing_calls_from_an_itcl_class_proc_reach_the_sibling_class_proc() {
+        let src = "itcl::class Factory {\n    proc make {} { return 1 }\n    proc build {} { return [make] }\n}\nFactory::make\n";
+        let analysis = analyse(src);
+        let items = prepare(src, 2, 10, &analysis);
+        assert_eq!(items[0].name, "::Factory::build", "{items:?}");
+        let outgoing = outgoing_calls(src, "tcl8.6", &items[0], &analysis);
+        let callees: Vec<&str> = outgoing.iter().map(|c| c.to.name.as_str()).collect();
+        assert_eq!(callees, vec!["::Factory::make"], "{outgoing:?}");
+    }
+
+    /// TN: itcl's two-word `Factory make` is object *creation*
+    /// (`ClassName instanceName`), never a class-proc dispatch, so it adds
+    /// no call-hierarchy edge.
+    #[test]
+    fn itcl_two_word_object_creation_is_not_a_call_hierarchy_edge() {
+        let src = "itcl::class Factory {\n    proc make {} { return 1 }\n}\nFactory make\n";
+        let analysis = analyse(src);
+        let items = prepare(src, 1, 10, &analysis);
+        let incoming = incoming_calls(src, "tcl8.6", &items[0], &analysis);
+        assert!(incoming.is_empty(), "{incoming:?}");
     }
 
     /// TP: a class command is an ordinary global command, so an *instance*

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -256,24 +256,17 @@ pub fn definition(
     ) {
         return vec![span_to_range(source, &line_index, proc_def.name_span)];
     }
-    // Cursor sitting on a class's own declaration name → that class.
-    if let Some((_, class_def)) = analysis
-        .all_classes
-        .iter()
-        .find(|(_, c)| c.name_span.start() <= cursor_offset && cursor_offset < c.name_span.end())
-    {
-        return vec![span_to_range(source, &line_index, class_def.name_span)];
+    // `Factory::make` — [incr Tcl]'s colon-qualified class-proc dispatch
+    // (issue #990).  Structurally identical to a qualified proc call, so it
+    // is tried only once `resolve_called_proc` has found no real proc: a
+    // genuine `::ns::helper` call keeps priority, and this fires only when
+    // the written word's parent namespace really is an itcl class declaring
+    // that class-scoped `proc`.
+    if let Some(span) = itcl_class_proc_declaration(analysis, &namespace, &word) {
+        return vec![span_to_range(source, &line_index, span)];
     }
-    // A call / reference that names a class (`superclass X`, `X new`, …).  Skip
-    // a document-local `oo::define` extension stub (`via_define`): the real
-    // `oo::class create` site lives in another file, and the cross-document
-    // resolver prefers it — pinning navigation to the local extension would
-    // shadow the true definition.  When the class *is* created here,
-    // `via_define` is false and this is that creation site.
-    if let Some((_, class_def)) = analysis.all_classes.iter().find(|(qname, c)| {
-        !c.via_define && (c.name == word || *qname == &word || *qname == &format!("::{word}"))
-    }) {
-        return vec![span_to_range(source, &line_index, class_def.name_span)];
+    if let Some(span) = class_declaration_at(analysis, &word, cursor_offset) {
+        return vec![span_to_range(source, &line_index, span)];
     }
     // Class-member lookup — when the cursor sits inside a
     // class body, walk that class's methods / properties /
@@ -1470,6 +1463,221 @@ fn proc_visible_from_namespace<'a>(
     tcl_syntax::naming::command_resolution_candidates(namespace, path, word)
         .into_iter()
         .find_map(|qname| analysis.all_procs.get(&qname))
+}
+
+/// The qualified name C Tcl's command resolution **commits to** when the
+/// written word `word` is called from `namespace`: the first candidate from
+/// [`tcl_syntax::naming::command_resolution_candidates`] (the caller's
+/// namespace, then each `namespace path` entry, then global; an absolute
+/// `::`-prefixed word is exact) for which `exists` reports a real command.
+///
+/// Tcl commits to the first existing candidate and never falls through to a
+/// same-tail alternative, which is precisely what a name-set match cannot
+/// express.  A caller asking "does this call reach *my* definition?" must
+/// therefore compare the returned name against its own qualified name, not
+/// against the word's tail: written inside `namespace eval ::b`, a bare
+/// `Factory` reaches `::b::Factory` whenever that exists, and only otherwise
+/// `::Factory` — never `::a::Factory`, however identically the tail is
+/// spelled (verified against tclsh 8.6.14 / 9.0.4).
+///
+/// This is the single namespace-resolution primitive behind the bare
+/// object-command / classmethod dispatch matcher (issue #981) and the [incr
+/// Tcl] class-proc resolver (issue #990), so those two cannot disagree about
+/// which definition a written word reaches.
+///
+/// Deliberate limits: `exists` sees only what this document's analysis
+/// knows, so a command defined in a sibling file does not shadow a local
+/// candidate here (the cross-document layer supplies its own predicate), and
+/// runtime-only bindings — `rename`, `interp alias`, `unknown` — are not
+/// modelled.
+pub(crate) fn resolved_command_name(
+    analysis: &AnalysisResult,
+    namespace: &str,
+    word: &str,
+    exists: &dyn Fn(&str) -> bool,
+) -> Option<String> {
+    let path = analysis
+        .namespace_paths
+        .get(namespace)
+        .map_or(&[][..], Vec::as_slice);
+    tcl_syntax::naming::command_resolution_candidates(namespace, path, word)
+        .into_iter()
+        .find(|qname| exists(qname))
+}
+
+/// Whether `cd`'s definer command dispatches its class-scoped members as a
+/// single `::`-qualified identifier (`Factory::make`) rather than the
+/// two-word `Factory make` shape — true for [incr Tcl] only.  Registry data
+/// ([`tcl_registry::definer::DefinerFamily`]), not a hardcoded command-name
+/// check: `cd.metaclass` is looked up in `dialect`'s registry and its
+/// attached [`tcl_registry::definer::DefinitionBodyGrammar::family`]
+/// compared.  A metaclass the registry does not recognise as a definer
+/// (which should not happen for a real `ClassDef`) is conservatively treated
+/// as *not* itcl.
+pub(crate) fn is_itcl_class(cd: &tcl_compiler::analyser::types::ClassDef, dialect: &str) -> bool {
+    tcl_registry::registry_for_dialect(dialect)
+        .get(&cd.metaclass)
+        .and_then(|spec| spec.definition_body)
+        .is_some_and(|g| g.family == tcl_registry::definer::DefinerFamily::Itcl)
+}
+
+/// Read `qname` as an [incr Tcl] class-scoped `proc` — itcl's equivalent of
+/// `TclOO`'s `classmethod` — returning `(class qualified name, member name)`
+/// when its parent namespace names an itcl class that declares that member.
+///
+/// itcl gives every class a real namespace of the same name and installs its
+/// class-scoped `proc`s as ordinary commands inside it, so `::app::Factory`'s
+/// `proc make` is genuinely the command `::app::Factory::make`.  Verified on
+/// tclsh 8.6.14 with Itcl 3.4: `info commands ::Factory::*` lists it, and
+/// `::app::Factory::make`, `app::Factory::make`, and a bare `Factory::make`
+/// from inside `::app` all dispatch it.  An *instance* method is not
+/// reachable this way — calling `::Factory::inst` errors `namespace "::" is
+/// not a class namespace` — so only `class_methods` is consulted.
+pub(crate) fn itcl_class_proc_at<'a>(
+    analysis: &'a AnalysisResult,
+    dialect: &str,
+    qname: &str,
+) -> Option<(&'a String, String)> {
+    let separator = qname.rfind("::")?;
+    let (parent, tail) = qname.split_at(separator);
+    let member = tail.trim_start_matches(':');
+    if member.is_empty() {
+        return None;
+    }
+    let (class_q, class_def) = analysis.all_classes.get_key_value(parent)?;
+    (is_itcl_class(class_def, dialect) && class_def.class_methods.contains_key(member))
+        .then(|| (class_q, member.to_owned()))
+}
+
+/// Resolve a written command word to the [incr Tcl] class-scoped `proc` it
+/// dispatches, following Tcl's own resolution order via
+/// [`resolved_command_name`] — so a call is attributed to the class the
+/// runtime would actually reach, and an ordinary proc or class command at a
+/// higher-priority candidate shadows it exactly as it would at runtime.
+pub(crate) fn itcl_class_proc_target<'a>(
+    analysis: &'a AnalysisResult,
+    dialect: &str,
+    namespace: &str,
+    word: &str,
+) -> Option<(&'a String, String)> {
+    let winner = resolved_command_name(analysis, namespace, word, &|candidate| {
+        analysis.all_procs.contains_key(candidate)
+            || analysis.all_classes.contains_key(candidate)
+            || itcl_class_proc_at(analysis, dialect, candidate).is_some()
+    })
+    .or_else(|| itcl_self_qualified_candidate(analysis, dialect, namespace, word))?;
+    itcl_class_proc_at(analysis, dialect, &winner)
+}
+
+/// [incr Tcl]'s own class-namespace command resolver: written *inside* a
+/// class's namespace — any method or class-`proc` body — the class's own
+/// **simple** name qualifies its members, so `Factory::make` reaches
+/// `::app::Factory::make` even though stock Tcl resolution would try only
+/// `::app::Factory::Factory::make` and `::Factory::make`, neither of which
+/// exists.
+///
+/// Pinned against tclsh 8.6.14 + Itcl 3.4 from inside `::app::Factory`:
+/// `Factory::make` succeeds, while a *sibling* class's simple name
+/// (`Other::omake`) fails — the rule covers the enclosing class only, not
+/// every class in the parent namespace.  The ordinary spellings
+/// (`app::Factory::make`, `::app::Factory::make`, `app::Other::omake`) all
+/// succeed by stock global fallback and are already covered by
+/// [`resolved_command_name`], so this is tried last: a real command at any
+/// standard candidate always wins.
+fn itcl_self_qualified_candidate(
+    analysis: &AnalysisResult,
+    dialect: &str,
+    namespace: &str,
+    word: &str,
+) -> Option<String> {
+    let class_def = analysis.all_classes.get(namespace)?;
+    if !is_itcl_class(class_def, dialect) {
+        return None;
+    }
+    let member = word
+        .strip_prefix(class_def.name.as_str())?
+        .strip_prefix("::")?;
+    (!member.is_empty() && !member.contains("::"))
+        .then(|| format!("{}::{member}", class_def.qualified_name))
+}
+
+/// The declaration name span of the class the cursor names: the class whose
+/// own declaration name span contains `cursor_offset`, else the class `word`
+/// refers to as a call or reference (`superclass X`, `X new`, …).
+///
+/// A document-local `oo::define` extension stub (`via_define`) is skipped
+/// for the second case: the real `oo::class create` site lives in another
+/// file and the cross-document resolver prefers it, so pinning navigation to
+/// the local extension would shadow the true definition.  When the class *is*
+/// created here, `via_define` is false and this is that creation site.
+fn class_declaration_at(
+    analysis: &AnalysisResult,
+    word: &str,
+    cursor_offset: u32,
+) -> Option<tcl_lexer::Span> {
+    if let Some((_, class_def)) = analysis
+        .all_classes
+        .iter()
+        .find(|(_, c)| c.name_span.start() <= cursor_offset && cursor_offset < c.name_span.end())
+    {
+        return Some(class_def.name_span);
+    }
+    analysis
+        .all_classes
+        .iter()
+        .find(|(qname, c)| {
+            !c.via_define
+                && (c.name == word || qname.as_str() == word || *qname == &format!("::{word}"))
+        })
+        .map(|(_, class_def)| class_def.name_span)
+}
+
+/// The declaration name span of the [incr Tcl] class-scoped `proc` that the
+/// written word `word`, called from `namespace`, dispatches — go-to-definition's
+/// half of [`itcl_class_proc_target`].
+///
+/// The empty dialect string picks the default Tcl registry, which is where
+/// the itcl definer grammar lives; `definition` has no dialect of its own to
+/// thread through.
+fn itcl_class_proc_declaration(
+    analysis: &AnalysisResult,
+    namespace: &str,
+    word: &str,
+) -> Option<tcl_lexer::Span> {
+    let (class_q, member) = itcl_class_proc_target(analysis, "", namespace, word)?;
+    analysis
+        .all_classes
+        .get(class_q)
+        .and_then(|cd| cd.class_methods.get(&member))
+        .map(|decl| decl.name_span)
+}
+
+/// [`itcl_class_proc_target`] for the word under the cursor: the
+/// `(class qualified name, member name)` of the [incr Tcl] class-scoped
+/// `proc` a `Factory::make` call site at `(line, character)` dispatches.
+///
+/// The one cursor entry point shared by go-to-definition, Find All
+/// References, rename, and the cross-file rename seed, so none of them can
+/// disagree about which class-proc a given call site names.  Returns `None`
+/// off any word, and for every spelling that is not this dispatch shape.
+#[must_use]
+pub fn itcl_class_proc_target_at(
+    source: &str,
+    dialect: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+) -> Option<(String, String)> {
+    let (word, _start, _end) = crate::hover::find_word_span_at_position(source, line, character)?;
+    let line_index = LineIndex::new(source);
+    let cursor = byte_offset_at(&line_index, source, line, character);
+    let namespace = namespace_context_at(
+        &analysis.global_scope,
+        cursor,
+        &analysis.namespace_overrides,
+    );
+    itcl_class_proc_target(analysis, dialect, &namespace, &word)
+        .map(|(class_q, member)| (class_q.clone(), member))
 }
 
 /// Resolve a bareword `word` (`namespace` context, honouring `namespace

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -759,6 +759,25 @@ fn canonicalise_class(analysis: &AnalysisResult, owner: &str, name: &str) -> Str
 /// [`receiver_instance_class`], which gates bare receivers on
 /// `created_instance_commands` (so a plain variable's bare name — never a
 /// valid dispatch — does not resolve).
+///
+/// The method-name word is bounded by [`crate::hover::word_char_bounds`] —
+/// the same lexer-faithful rule every other cursor-word consumer uses — so
+/// a method whose name is not a programming-language identifier still
+/// resolves.  Tcl imposes no character restriction on a method name:
+/// `$obj with-dash`, `$obj a.b`, and TIP 558's generated property accessors
+/// (`my <ReadProp-x>` / `my <WriteProp-x>`, produced by `oo::configurable`'s
+/// `property`) all dispatch for real (verified against tclsh 8.6.14 and
+/// 9.0.4), and an identifier rule that stopped at `-` / `<` / `>` silently
+/// truncated those names to something no class declares (issue #1019 idx
+/// 16).
+///
+/// A word carrying no alphanumeric / `_` content at all — `<`, `<=`, `-`,
+/// `::` — is rejected: those are expression operators and separators, so
+/// `expr {$a < $b}` must not read as `$a` dispatching a method named `<`.
+/// Tcl *would* let a class declare a method literally named `+` or `<`, and
+/// this deliberately does not resolve those: `expr` bodies are far more
+/// common than operator-named methods, and rejecting them keeps the
+/// pre-existing behaviour rather than trading one gap for a false positive.
 pub(crate) fn instance_method_at_cursor(
     source: &str,
     line: u32,
@@ -767,21 +786,13 @@ pub(crate) fn instance_method_at_cursor(
     let line_text = source.split('\n').nth(line as usize)?;
     let chars: Vec<char> = line_text.chars().collect();
     let col = utf16_col_to_char_col(line_text, character).min(chars.len());
-    let is_ident = |c: char| c.is_alphanumeric() || c == '_' || c == ':';
 
     // Method-name word bounds around the cursor.
-    let mut wstart = col;
-    while wstart > 0 && is_ident(chars[wstart - 1]) {
-        wstart -= 1;
-    }
-    let mut wend = col;
-    while wend < chars.len() && is_ident(chars[wend]) {
-        wend += 1;
-    }
-    if wstart == wend {
+    let (wstart, wend) = crate::hover::word_char_bounds(&chars, col)?;
+    let method: String = chars[wstart..wend].iter().collect();
+    if !method.chars().any(|c| c.is_alphanumeric() || c == '_') {
         return None;
     }
-    let method: String = chars[wstart..wend].iter().collect();
 
     // Command-segment start: nearest `;` / `[` / `{` to the
     // left, else the line start.
@@ -3093,6 +3104,102 @@ mod tests {
         // command.
         let src = "[x] bark\n";
         assert_eq!(instance_method_at_cursor(src, 0, 5), None);
+    }
+
+    // Method names with non-identifier characters (issue #1019 idx 16).
+    // Oracle (tclsh 8.6.14 + 9.0.4): `method with-dash`, `method a.b`, and
+    // TIP 558's `<ReadProp-x>` / `<WriteProp-x>` all dispatch for real.
+
+    #[test]
+    fn instance_method_at_cursor_keeps_a_hyphenated_method_name_whole() {
+        // TP — `-` is part of the method word, not a boundary.
+        let src = "$d with-dash\n";
+        assert_eq!(
+            instance_method_at_cursor(src, 0, 8),
+            Some(("d".to_string(), "with-dash".to_string(), true))
+        );
+    }
+
+    #[test]
+    fn instance_method_at_cursor_keeps_an_angle_bracketed_method_name_whole() {
+        // TP — the TIP 558 property-accessor shape, cursor inside the name.
+        let src = "my <ReadProp-colour>\n";
+        assert_eq!(
+            instance_method_at_cursor(src, 0, 8),
+            Some(("my".to_string(), "<ReadProp-colour>".to_string(), false))
+        );
+    }
+
+    #[test]
+    fn instance_method_at_cursor_keeps_a_dotted_method_name_whole() {
+        // TP — `method a.b` dispatches in real Tcl; `.` is not a boundary.
+        let src = "$d a.b\n";
+        assert_eq!(
+            instance_method_at_cursor(src, 0, 4),
+            Some(("d".to_string(), "a.b".to_string(), true))
+        );
+    }
+
+    #[test]
+    fn instance_method_at_cursor_rejects_subtraction_in_an_expression() {
+        // TN — `$x-1` is arithmetic. The whole `x-1` run is one word whose
+        // head slice is a bare `$`, so nothing dispatches.
+        let src = "expr {$x-1}\n";
+        assert_eq!(instance_method_at_cursor(src, 0, 8), None);
+        assert_eq!(instance_method_at_cursor(src, 0, 9), None);
+    }
+
+    #[test]
+    fn instance_method_at_cursor_rejects_a_bare_comparison_operator() {
+        // TN — `expr {$a < $b}` must not read as `$a` dispatching `<`:
+        // the word carries no alphanumeric content.
+        let src = "expr {$a < $b}\n";
+        assert_eq!(instance_method_at_cursor(src, 0, 9), None);
+    }
+
+    #[test]
+    fn hyphenated_and_angle_bracketed_methods_resolve_from_a_call_site() {
+        // TP — end-to-end. `with-dash` starts with an ASCII lowercase
+        // letter so it is exported and dispatches externally; the TIP 558
+        // accessor `<ReadProp-x>` starts with `<` so it is *unexported* and
+        // only reachable from inside the class via `my` (oracle: tclsh
+        // 9.0.4 answers `unknown method "<foo>"` for an external call but
+        // runs `my <ReadProp-x>` fine).
+        let src = concat!(
+            "oo::class create C {\n",
+            "    method with-dash {} { return 1 }\n",
+            "    method <ReadProp-x> {} { return 2 }\n",
+            "    method probe {} { my <ReadProp-x> }\n",
+            "}\n",
+            "C create rex\n",
+            "rex with-dash\n",
+        );
+        let analysis = analyse(src);
+        let dash = definition(src, 6, 6, &analysis);
+        assert_eq!(dash.len(), 1, "{dash:?}");
+        assert_eq!(dash[0].start_line, 1);
+        assert_eq!(dash[0].start_character, 11);
+        let prop = definition(src, 3, 28, &analysis);
+        assert_eq!(prop.len(), 1, "{prop:?}");
+        assert_eq!(prop[0].start_line, 2);
+        assert_eq!(prop[0].start_character, 11);
+    }
+
+    #[test]
+    fn unexported_angle_bracketed_method_is_not_externally_dispatchable() {
+        // TN — the export rule still applies to the widened word: an
+        // external `rex <ReadProp-x>` is `unknown method` in real Tcl
+        // (verified, tclsh 8.6.14 + 9.0.4), so it must resolve to nothing
+        // rather than to the declaration.
+        let src = concat!(
+            "oo::class create C {\n",
+            "    method <ReadProp-x> {} { return 2 }\n",
+            "}\n",
+            "C create rex\n",
+            "rex <ReadProp-x>\n",
+        );
+        let analysis = analyse(src);
+        assert!(definition(src, 4, 8, &analysis).is_empty());
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -247,6 +247,19 @@ pub fn definition(
         cursor_offset,
         &analysis.namespace_overrides,
     );
+    // `Factory::make` — [incr Tcl]'s colon-qualified class-proc dispatch
+    // (issue #990).  Asked **before** the stock proc resolution below, because
+    // itcl installs a custom command resolver on every class namespace and Tcl
+    // consults it ahead of the ordinary lookup: inside a class's own bodies the
+    // class proc wins even when a real `::Factory::make` proc exists (oracle in
+    // `itcl_self_qualified_candidate`).  Order is safe because
+    // `itcl_class_proc_target` applies the whole precedence itself — its own
+    // resolver first, then stock resolution — and answers `None` unless the
+    // winning candidate really is an itcl class-scoped `proc`, so a genuine
+    // `::ns::helper` call still falls through to `resolve_called_proc`.
+    if let Some(span) = itcl_class_proc_declaration(analysis, &namespace, &word) {
+        return vec![span_to_range(source, &line_index, span)];
+    }
     if let Some(proc_def) = resolve_called_proc(
         analysis,
         source,
@@ -255,15 +268,6 @@ pub fn definition(
         Some(tcl_registry::registry_for_dialect("")),
     ) {
         return vec![span_to_range(source, &line_index, proc_def.name_span)];
-    }
-    // `Factory::make` — [incr Tcl]'s colon-qualified class-proc dispatch
-    // (issue #990).  Structurally identical to a qualified proc call, so it
-    // is tried only once `resolve_called_proc` has found no real proc: a
-    // genuine `::ns::helper` call keeps priority, and this fires only when
-    // the written word's parent namespace really is an itcl class declaring
-    // that class-scoped `proc`.
-    if let Some(span) = itcl_class_proc_declaration(analysis, &namespace, &word) {
-        return vec![span_to_range(source, &line_index, span)];
     }
     if let Some(span) = class_declaration_at(analysis, &word, cursor_offset) {
         return vec![span_to_range(source, &line_index, span)];
@@ -1550,22 +1554,37 @@ pub(crate) fn itcl_class_proc_at<'a>(
 }
 
 /// Resolve a written command word to the [incr Tcl] class-scoped `proc` it
-/// dispatches, following Tcl's own resolution order via
-/// [`resolved_command_name`] — so a call is attributed to the class the
-/// runtime would actually reach, and an ordinary proc or class command at a
-/// higher-priority candidate shadows it exactly as it would at runtime.
+/// dispatches.
+///
+/// Two resolvers, in the order the interpreter applies them:
+///
+/// 1. [`itcl_self_qualified_candidate`] — itcl installs a **custom command
+///    resolver** on each class namespace, and it is consulted *before* the
+///    ordinary namespace lookup, so inside a class's own namespace the class's
+///    simple name qualifies its members ahead of every stock candidate.
+/// 2. [`resolved_command_name`] — stock Tcl resolution (current namespace,
+///    `namespace path`, then global) for every other call site, so a call is
+///    attributed to the class the runtime would actually reach and an ordinary
+///    proc or class command shadows it exactly as it would at runtime.
 pub(crate) fn itcl_class_proc_target<'a>(
     analysis: &'a AnalysisResult,
     dialect: &str,
     namespace: &str,
     word: &str,
 ) -> Option<(&'a String, String)> {
-    let winner = resolved_command_name(analysis, namespace, word, &|candidate| {
-        analysis.all_procs.contains_key(candidate)
-            || analysis.all_classes.contains_key(candidate)
-            || itcl_class_proc_at(analysis, dialect, candidate).is_some()
-    })
-    .or_else(|| itcl_self_qualified_candidate(analysis, dialect, namespace, word))?;
+    let winner = itcl_self_qualified_candidate(analysis, dialect, namespace, word)
+        // The custom resolver only claims a member the class really declares;
+        // anything else falls through to the stock candidates (oracle: a
+        // sibling class's `Other::omake`, and an undeclared `Factory::nope`,
+        // both raise `invalid command name` rather than resolving).
+        .filter(|candidate| itcl_class_proc_at(analysis, dialect, candidate).is_some())
+        .or_else(|| {
+            resolved_command_name(analysis, namespace, word, &|candidate| {
+                analysis.all_procs.contains_key(candidate)
+                    || analysis.all_classes.contains_key(candidate)
+                    || itcl_class_proc_at(analysis, dialect, candidate).is_some()
+            })
+        })?;
     itcl_class_proc_at(analysis, dialect, &winner)
 }
 
@@ -1576,14 +1595,28 @@ pub(crate) fn itcl_class_proc_target<'a>(
 /// `::app::Factory::Factory::make` and `::Factory::make`, neither of which
 /// exists.
 ///
-/// Pinned against tclsh 8.6.14 + Itcl 3.4 from inside `::app::Factory`:
-/// `Factory::make` succeeds, while a *sibling* class's simple name
-/// (`Other::omake`) fails — the rule covers the enclosing class only, not
-/// every class in the parent namespace.  The ordinary spellings
-/// (`app::Factory::make`, `::app::Factory::make`, `app::Other::omake`) all
-/// succeed by stock global fallback and are already covered by
-/// [`resolved_command_name`], so this is tried last: a real command at any
-/// standard candidate always wins.
+/// This resolver **pre-empts** the stock candidates rather than backing them
+/// up: itcl installs a custom command resolver (`Itcl_ClassCmdResolver`) on
+/// every class namespace, and Tcl consults a namespace's resolver *before* its
+/// ordinary command lookup.  A real command at a stock candidate — even the
+/// current-namespace-relative one — does **not** win.
+///
+/// Pinned against tclsh 8.6 + Itcl 3.4 (probes `itcl2.tcl`, `itcl2b.tcl`,
+/// `itcl2c.tcl`), with a class `::app::Factory` declaring `proc make`:
+///
+/// | Written          | Called from            | Also defined                      | Dispatches |
+/// |------------------|------------------------|-----------------------------------|------------|
+/// | `Factory::make`  | the class's own bodies | `::Factory::make` (a plain proc)   | the **class proc** |
+/// | `Factory::make`  | the class's own bodies | `::app::Factory::Factory::make`    | the **class proc** |
+/// | `Factory::make`  | `::app`                | —                                 | the class proc, by stock relative lookup |
+/// | `Factory::make`  | `::` or `::other`      | `::Factory::make`                 | the **plain proc** |
+/// | `Other::omake`   | `::app::Factory`       | class `::app::Other` with `omake`  | nothing — `invalid command name` |
+/// | `Factory::nope`  | `::app::Factory`       | —                                 | nothing — `invalid command name` |
+///
+/// So the rule covers the *enclosing* class only, and only for members it
+/// declares; the ordinary spellings (`app::Factory::make`,
+/// `::app::Factory::make`) keep resolving through
+/// [`resolved_command_name`].
 fn itcl_self_qualified_candidate(
     analysis: &AnalysisResult,
     dialect: &str,

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -2218,6 +2218,37 @@ fn clock_format_string_at_position(source: &str, line: u32, character: u32) -> O
     string_literal_with_percent_at(line_text, character)
 }
 
+/// The `[start, end)` char-index bounds of the bare Tcl word around `col`
+/// in `chars` (one source line), using [`WORD_DELIMS`].
+///
+/// This is the single word-bounding rule shared by every cursor-word
+/// consumer, so hover, definition, references, and rename all agree on
+/// where a word starts and ends.  It deliberately follows the *lexer's*
+/// notion of a bare word — bounded by whitespace and the structural
+/// characters `;{}[]"$` — rather than a programming-language identifier
+/// rule.  Tcl puts no character restriction on a command or method name, so
+/// `with-dash`, `a.b`, and TIP 558's generated property accessors
+/// `<ReadProp-x>` / `<WriteProp-x>` are all one word (verified against
+/// tclsh 8.6.14 and 9.0.4).
+///
+/// Returns `None` when the cursor sits on a delimiter run (empty word).
+///
+/// Deliberately *not* handled: a word split across lines by a
+/// backslash-newline continuation, and the interior structure of a word
+/// that mixes literal text with substitutions (`pre[cmd]post`) — the
+/// caller sees the literal slice only.
+pub(crate) fn word_char_bounds(chars: &[char], col: usize) -> Option<(usize, usize)> {
+    let mut start = col.min(chars.len());
+    while start > 0 && !WORD_DELIMS.contains(&chars[start - 1]) {
+        start -= 1;
+    }
+    let mut end = col.min(chars.len());
+    while end < chars.len() && !WORD_DELIMS.contains(&chars[end]) {
+        end += 1;
+    }
+    (start != end).then_some((start, end))
+}
+
 /// Find the word and its `[start, end)` columns at the given
 /// position, using Tcl's word delimiters.
 ///
@@ -2236,18 +2267,7 @@ pub fn find_word_span_at_position(
     if col >= chars.len() {
         return None;
     }
-
-    let mut start = col;
-    while start > 0 && !WORD_DELIMS.contains(&chars[start - 1]) {
-        start -= 1;
-    }
-    let mut end = col;
-    while end < chars.len() && !WORD_DELIMS.contains(&chars[end]) {
-        end += 1;
-    }
-    if start == end {
-        return None;
-    }
+    let (start, end) = word_char_bounds(&chars, col)?;
     let word: String = chars[start..end].iter().collect();
     let prefix: String = chars[..start].iter().collect();
     let start_u32 = crate::definition::utf16_len(&prefix);

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -80,6 +80,16 @@
 //!   (`AnalysisResult::created_instance_commands`), so two same-named object
 //!   commands in different namespaces are already indistinguishable in the
 //!   data this scanner reads — qualifying them is an analyser-shape change.
+//! * An **explicit** `namespace import ::a::Factory` is followed: the imported
+//!   name is a real command in the importing namespace, so it joins the
+//!   resolver's `exists` universe and resolves through to the source command
+//!   for the class-identity test ([`explicit_import_aliases`]).  A **wildcard**
+//!   import (`namespace import ::a::*`) is **not**: reproducing it needs the
+//!   export-gated import *snapshot* — which commands existed in `::a` when the
+//!   import ran — that issue #1027 tracks, and treating every exported command
+//!   as imported regardless of definition order would invent aliases the
+//!   runtime never created.  So a wildcard-imported class's bare dispatch is
+//!   still not matched, and a rename still leaves it stale.
 //! * [incr Tcl]'s class-scoped `proc` uses a different dispatch shape
 //!   entirely — a single `::`-qualified command word (`Factory::make`), not
 //!   two words — so it is matched by [`crate::definition::itcl_class_proc_target`]
@@ -1791,6 +1801,7 @@ fn dispatch_receivers<'a>(
             .collect(),
         class_targets: FxHashSet::default(),
         class_tails: FxHashSet::default(),
+        import_aliases: explicit_import_aliases(analysis),
     };
     // A `classmethod` dispatches on the *class's own* command (`Factory
     // make`) — never on an instance: TclOO's `classmethod` sugar puts the
@@ -1985,6 +1996,47 @@ struct CommandReceivers {
     /// in the document.
     class_tails: FxHashSet<String>,
     object_commands: FxHashSet<String>,
+    /// `namespace import`-created command aliases: the *imported* name in the
+    /// importing namespace (`::b::Factory`) mapped to the source command
+    /// (`::a::Factory`).  See [`explicit_import_aliases`].
+    import_aliases: FxHashMap<String, String>,
+}
+
+/// The command aliases an **explicit** (pattern-free) `namespace import`
+/// creates, as `imported qualified name → source qualified name`.
+///
+/// `namespace import ::a::Factory` inside `::b` creates a real command
+/// `::b::Factory` that dispatches `::a::Factory` — tclsh 9.0.4 (probe
+/// `ns981.tcl`) confirms both halves: `Factory make` inside `::b` prints
+/// `A-MADE`, and `info commands ::b::Factory` lists `::b::Factory`.  Without
+/// these entries the bare-dispatch resolver's `exists` universe has no
+/// candidate for the imported name at all, so the call site is invisible and
+/// a rename leaves it stale.
+///
+/// **Wildcard imports are deliberately excluded.**  `namespace import ::a::*`
+/// needs the export-gated import *snapshot* model (which commands existed in
+/// `::a` at the moment the import ran, filtered by `namespace export`) — issue
+/// #1027.  Half-building it here, by treating every exported command as
+/// imported regardless of definition order, would invent aliases the runtime
+/// never created.  A pattern containing any glob metacharacter is skipped.
+fn explicit_import_aliases(analysis: &AnalysisResult) -> FxHashMap<String, String> {
+    analysis
+        .namespace_imports
+        .iter()
+        .filter(|import| !import.pattern.contains(['*', '?', '[']))
+        .filter_map(|import| {
+            let tail = std::str::from_utf8(tcl_syntax::naming::written_command_tail(
+                import.pattern.as_bytes(),
+            ))
+            .ok()?;
+            (!tail.is_empty()).then(|| {
+                (
+                    tcl_syntax::naming::qualify(&import.ns, tail),
+                    tcl_syntax::naming::normalise_qualified_name(&import.pattern),
+                )
+            })
+        })
+        .collect()
 }
 
 impl CommandReceivers {
@@ -2006,12 +2058,19 @@ impl CommandReceivers {
     /// class command in `class_targets` — resolved the way Tcl resolves it,
     /// from the namespace lexically in effect there.
     ///
-    /// The `exists` universe is this document's procs and classes plus the
-    /// caller-supplied targets themselves: a pure-consumer document does not
-    /// declare the class it calls, so without the targets no candidate would
-    /// ever "exist" and every cross-file consumer site would be lost.  A
-    /// same-named proc or class at a higher-priority candidate still shadows
-    /// the target, exactly as it would at runtime.
+    /// The `exists` universe is this document's procs and classes, the
+    /// caller-supplied targets themselves, and every explicit
+    /// `namespace import` alias: a pure-consumer document does not declare the
+    /// class it calls, so without the targets no candidate would ever "exist"
+    /// and every cross-file consumer site would be lost.  A same-named proc or
+    /// class at a higher-priority candidate still shadows the target, exactly
+    /// as it would at runtime.
+    ///
+    /// An imported name is a real command in the importing namespace, so it
+    /// both *exists* as a candidate and, when it wins, resolves through to the
+    /// source command for the class-identity test — otherwise
+    /// `namespace import ::a::Factory; Factory make` inside `::b` matches
+    /// nothing (the winning `::b::Factory` is not itself a class target).
     fn class_head_matches(&self, analysis: &AnalysisResult, raw: &str, offset: u32) -> bool {
         if self.class_targets.is_empty() {
             return false;
@@ -2033,8 +2092,12 @@ impl CommandReceivers {
             self.class_targets.contains(candidate)
                 || analysis.all_classes.contains_key(candidate)
                 || analysis.all_procs.contains_key(candidate)
+                || self.import_aliases.contains_key(candidate)
         })
-        .is_some_and(|winner| self.class_targets.contains(&winner))
+        .is_some_and(|winner| {
+            let dispatched = self.import_aliases.get(&winner).unwrap_or(&winner);
+            self.class_targets.contains(dispatched)
+        })
     }
 }
 

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -70,13 +70,16 @@
 //!   the workspace index to find which documents to scan and (for a
 //!   classmethod) which class names are valid bare-dispatch heads when the
 //!   scanned document doesn't declare the class itself.
-//! * A classmethod's class-command dispatch is matched by exact name-set
-//!   membership (the class's as-written simple name plus its fully
-//!   `::`-qualified name) rather than full namespace-relative resolution —
-//!   a call spelled with a *partial* namespace qualifier from a sibling
-//!   namespace (`ns::Factory make` where the class is `::ns::Factory`) is
-//!   not matched.  The same imprecision already applies to `CLASS create
-//!   NAME` object-command dispatch above.
+//! * A classmethod's class-command dispatch is matched by *resolving* the
+//!   written head against the call site's own lexical namespace with C Tcl's
+//!   rule (current namespace, then `namespace path`, then global — see
+//!   [`CommandReceivers::class_head_matches`]), so two classes sharing a
+//!   simple name in different namespaces are never cross-linked (issue
+//!   #981).  A `CLASS create NAME` **object command** is still matched by
+//!   text: the analyser records instance-command names unqualified
+//!   (`AnalysisResult::created_instance_commands`), so two same-named object
+//!   commands in different namespaces are already indistinguishable in the
+//!   data this scanner reads — qualifying them is an analyser-shape change.
 //! * [incr Tcl]'s class-scoped `proc` uses a different dispatch shape
 //!   entirely — a single `::`-qualified command word (`Factory::make`), not
 //!   two words — so it is matched by [`crate::definition::itcl_class_proc_target`]
@@ -1737,6 +1740,123 @@ fn itcl_class_proc_call_sites(
         })
         .collect()
 }
+/// The receiver sets a dispatch scan for `method` on `class_q` must match:
+/// the `$v method` variables, and the bare-word command receivers.
+///
+/// `target` is `(class_q, method, is_classmethod)`, bundled to keep the
+/// parameter count inside the lint budget; `is_classmethod` is the caller's
+/// already-resolved fact about which of a possibly-same-named
+/// `method` / `classmethod` pair is meant, never re-derived here.
+fn dispatch_receivers<'a>(
+    analysis: &'a AnalysisResult,
+    dialect: &str,
+    target: (&str, &str, bool),
+    extra_cmd_names: &[String],
+) -> (FxHashSet<&'a str>, CommandReceivers) {
+    let (class_q, method, is_classmethod) = target;
+    let hierarchy = analysis.class_hierarchy();
+    // A classmethod dispatches on the class's own command, never an
+    // instance — instance-receiver matching only ever applies to a `method`.
+    // Variables whose `$obj method` dispatch resolves to `class_q`'s copy of
+    // `method` — its own instances **plus** instances of any subclass that
+    // *inherits* this definition (the subclass's MRO resolves `method` to
+    // `class_q`).  An exact-class-equality filter dropped the inheriting-
+    // subclass sites, silently leaving them pointing at the old name after an
+    // inherited-method rename.  A subclass that *overrides* `method` resolves
+    // to itself, so its instances are excluded here and rewritten under that
+    // subclass's own family entry — each site is attributed to exactly one
+    // family member (no double count).
+    let var_set: FxHashSet<&str> = if is_classmethod {
+        FxHashSet::default()
+    } else {
+        analysis
+            .instance_classes
+            .iter()
+            .filter(|(_, c)| {
+                c.as_str() == class_q || hierarchy.method_target(c, method) == Some(class_q)
+            })
+            .map(|(v, _)| v.as_str())
+            .collect()
+    };
+    // Receivers that are also *object commands* — bound by `CLASS create NAME`
+    // (so `NAME` is a command, dispatched bare as `NAME method`, not `$NAME
+    // method`).  A `set v [CLASS new]` receiver is a *variable* only and never
+    // enters this set, so a bare `v method` is (correctly) not matched.
+    let mut receivers = CommandReceivers {
+        object_commands: var_set
+            .iter()
+            .copied()
+            .filter(|name| analysis.created_instance_commands.contains(*name))
+            .map(str::to_owned)
+            .collect(),
+        class_targets: FxHashSet::default(),
+        class_tails: FxHashSet::default(),
+    };
+    // A `classmethod` dispatches on the *class's own* command (`Factory
+    // make`) — never on an instance: TclOO's `classmethod` sugar puts the
+    // method on the class object's own class, which no instance's MRO
+    // reaches.  When the caller says `method` is a classmethod, and
+    // `class_q`'s definer family actually uses this two-word dispatch shape,
+    // fold in the defining class's fully qualified name plus that of any
+    // subclass that inherits (does not override) it — the same inheritance
+    // test as the instance `var_set` above, so a `Sub make` dispatch on an
+    // inheriting subclass counts too.  Never runs for a plain `method` — even
+    // one that shares a name with a `classmethod` on the same class — which
+    // must never gain a phantom `ClassName method` match.
+    //
+    // Only the *qualified* name goes in: a written head is matched by
+    // resolving it against the call site's own namespace
+    // ([`CommandReceivers::class_head_matches`]), not by name-set membership,
+    // so a bare `Factory` inside `namespace eval ::b` reaches `::b::Factory`
+    // and never `::a::Factory` (issue #981).
+    //
+    // The definer-family check matters because [incr Tcl]'s class-scoped
+    // `proc` lands in this same `class_methods` bucket (so the declaration
+    // side finds it) but dispatches as a single `::`-qualified identifier
+    // (`Factory::make`) — a bare two-word `Factory make` in itcl source is
+    // unrelated instance-creation syntax (`ClassName instanceName`), not a
+    // call to this proc.  The dispatch shape is registry data
+    // (`DefinerFamily`), not something to infer from the shared storage
+    // bucket.
+    //
+    // Unlike `ooutil`'s `classmethod` keyword (which propagates to a
+    // subclass's own bound command via its `Delegate`-mixin machinery —
+    // confirmed against tclsh 9.0.4/8.6), a plain stock-`TclOO` `self
+    // method` is visible ONLY on the exact class that declared it, so the
+    // inheriting-subclass half of this loop is skipped for those
+    // (`MethodDef::is_self_method`, issue #923 idx 120).
+    if is_classmethod
+        && let Some(cq_method) = analysis
+            .all_classes
+            .get(class_q)
+            .filter(|cd| !is_itcl_class(cd, dialect))
+            .and_then(|cd| cd.class_methods.get(method))
+    {
+        if let Some(cd) = analysis.all_classes.get(class_q) {
+            receivers.add_class_target(&cd.qualified_name);
+        }
+        if !cq_method.is_self_method {
+            for (other_q, other_cd) in &analysis.all_classes {
+                if other_q.as_str() != class_q
+                    && hierarchy.method_target(other_q, method) == Some(class_q)
+                    && !is_itcl_class(other_cd, dialect)
+                {
+                    receivers.add_class_target(&other_cd.qualified_name);
+                }
+            }
+        }
+    }
+    // The caller's workspace-wide classmethod knowledge, for a document where
+    // the class itself isn't known locally.  Meaningless for a plain method.
+    // Qualified names, so the same namespace-resolution rule applies to a
+    // pure-consumer document as to one that declares the class.
+    if is_classmethod {
+        for name in extra_cmd_names {
+            receivers.add_class_target(name);
+        }
+    }
+    (var_set, receivers)
+}
 
 /// [`find_obj_method_call_sites`], plus `extra_cmd_names` — bare command
 /// names to treat as valid classmethod-dispatch heads for `method`
@@ -1781,103 +1901,22 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
     } else {
         Vec::new()
     };
-    let hierarchy = analysis.class_hierarchy();
-    // A classmethod dispatches on the class's own command, never an
-    // instance — instance-receiver matching only ever applies to a `method`.
-    // Variables whose `$obj method` dispatch resolves to `class_q`'s copy of
-    // `method` — its own instances **plus** instances of any subclass that
-    // *inherits* this definition (the subclass's MRO resolves `method` to
-    // `class_q`).  An exact-class-equality filter dropped the inheriting-
-    // subclass sites, silently leaving them pointing at the old name after an
-    // inherited-method rename.  A subclass that *overrides* `method` resolves
-    // to itself, so its instances are excluded here and rewritten under that
-    // subclass's own family entry — each site is attributed to exactly one
-    // family member (no double count).
-    let var_set: FxHashSet<&str> = if is_classmethod {
-        FxHashSet::default()
-    } else {
-        analysis
-            .instance_classes
-            .iter()
-            .filter(|(_, c)| {
-                c.as_str() == class_q || hierarchy.method_target(c, method) == Some(class_q)
-            })
-            .map(|(v, _)| v.as_str())
-            .collect()
-    };
-    // Receivers that are also *object commands* — bound by `CLASS create NAME`
-    // (so `NAME` is a command, dispatched bare as `NAME method`, not `$NAME
-    // method`).  A `set v [CLASS new]` receiver is a *variable* only and never
-    // enters this set, so a bare `v method` is (correctly) not matched.
-    let mut cmd_set: FxHashSet<&str> = var_set
-        .iter()
-        .copied()
-        .filter(|name| analysis.created_instance_commands.contains(*name))
-        .collect();
-    // A `classmethod` dispatches on the *class's own* command (`Factory
-    // make`) — never on an instance: TclOO's `classmethod` sugar puts the
-    // method on the class object's own class, which no instance's MRO
-    // reaches.  When the caller says `method` is a classmethod, and
-    // `class_q`'s definer family actually uses this two-word dispatch shape,
-    // fold in the defining class's own name (simple + qualified) plus the
-    // own name of any subclass that inherits (does not override) it — the
-    // same inheritance test as the instance `var_set` above, so a `Sub make`
-    // dispatch on an inheriting subclass counts too.  Never runs for a plain
-    // `method` — even one that shares a name with a `classmethod` on the same
-    // class — which must never gain a phantom `ClassName method` match.
-    //
-    // The definer-family check matters because [incr Tcl]'s class-scoped
-    // `proc` lands in this same `class_methods` bucket (so the declaration
-    // side finds it) but dispatches as a single `::`-qualified identifier
-    // (`Factory::make`) — a bare two-word `Factory make` in itcl source is
-    // unrelated instance-creation syntax (`ClassName instanceName`), not a
-    // call to this proc.  The dispatch shape is registry data
-    // (`DefinerFamily`), not something to infer from the shared storage
-    // bucket.
-    //
-    // Unlike `ooutil`'s `classmethod` keyword (which propagates to a
-    // subclass's own bound command via its `Delegate`-mixin machinery —
-    // confirmed against tclsh 9.0.4/8.6), a plain stock-`TclOO` `self
-    // method` is visible ONLY on the exact class that declared it, so the
-    // inheriting-subclass half of this loop is skipped for those
-    // (`MethodDef::is_self_method`, issue #923 idx 120).
-    if is_classmethod
-        && let Some(cq_method) = analysis
-            .all_classes
-            .get(class_q)
-            .filter(|cd| !is_itcl_class(cd, dialect))
-            .and_then(|cd| cd.class_methods.get(method))
-    {
-        if let Some(cd) = analysis.all_classes.get(class_q) {
-            cmd_set.insert(cd.name.as_str());
-            cmd_set.insert(cd.qualified_name.as_str());
-        }
-        if !cq_method.is_self_method {
-            for (other_q, other_cd) in &analysis.all_classes {
-                if other_q.as_str() != class_q
-                    && hierarchy.method_target(other_q, method) == Some(class_q)
-                    && !is_itcl_class(other_cd, dialect)
-                {
-                    cmd_set.insert(other_cd.name.as_str());
-                    cmd_set.insert(other_cd.qualified_name.as_str());
-                }
-            }
-        }
-    }
-    // The caller's workspace-wide classmethod knowledge, for a document where
-    // the class itself isn't known locally.  Meaningless for a plain method.
-    if is_classmethod {
-        cmd_set.extend(extra_cmd_names.iter().map(String::as_str));
-    }
-    if var_set.is_empty() && cmd_set.is_empty() {
+    let (var_set, receivers) = dispatch_receivers(
+        analysis,
+        dialect,
+        (class_q, method, is_classmethod),
+        extra_cmd_names,
+    );
+    if var_set.is_empty() && !receivers.has_any() {
         return out;
     }
     let mut seen: FxHashSet<(u32, u32)> = out.iter().map(|s| (s.start(), s.end())).collect();
     let ctx = ObjMethodScan {
         source,
         dialect,
+        analysis,
         var_set: &var_set,
-        cmd_set: &cmd_set,
+        receivers: &receivers,
         method,
         var_receivers_in_scope: true,
     };
@@ -1917,23 +1956,107 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
     out
 }
 
+/// The bare-word command receivers a dispatch scan matches — the two kinds
+/// are matched by *different* rules, because the analysis knows different
+/// things about them.
+///
+/// * `class_targets` — the fully `::`-qualified names of the classes whose
+///   own class command dispatches the method (`Factory make`).  A written
+///   head is matched by **resolving** it against the call site's lexical
+///   namespace with Tcl's own rule and comparing the winner against this
+///   set, never by comparing the text.  So, with a class in `::a` and
+///   another in `::b`, a bare `Factory make` written inside `namespace eval
+///   ::b` reaches `::b::Factory` and is *not* attributed to `::a::Factory`
+///   (issue #981; pinned against tclsh 8.6.14 and 9.0.4, which answer
+///   `b-made` there, `invalid command name "Factory"` where no candidate
+///   exists, and the global class where only that exists).
+///
+/// * `object_commands` — the instance-command names bound by `CLASS create
+///   NAME`.  These stay an exact text match: the analyser records them
+///   unqualified (`AnalysisResult::created_instance_commands` is a set of
+///   bare names with no creation namespace, and `instance_classes` keeps one
+///   binding per bare name), so two same-named object commands in different
+///   namespaces are already indistinguishable in the data this scanner
+///   reads.  Qualifying them is an analyser-shape change, not a scanner one.
+struct CommandReceivers {
+    class_targets: FxHashSet<String>,
+    /// Simple (tail) names of every entry in `class_targets` — the cheap
+    /// pre-filter that keeps the namespace resolution off every command head
+    /// in the document.
+    class_tails: FxHashSet<String>,
+    object_commands: FxHashSet<String>,
+}
+
+impl CommandReceivers {
+    /// Register a class whose own command dispatches the method, by its
+    /// fully qualified name.
+    fn add_class_target(&mut self, qualified_name: &str) {
+        let tail = tcl_syntax::naming::written_command_tail(qualified_name.as_bytes());
+        if let Ok(tail) = std::str::from_utf8(tail) {
+            self.class_tails.insert(tail.to_owned());
+        }
+        self.class_targets.insert(qualified_name.to_owned());
+    }
+
+    fn has_any(&self) -> bool {
+        !self.class_targets.is_empty() || !self.object_commands.is_empty()
+    }
+
+    /// Whether the bare head `raw`, written at byte offset `offset`, is a
+    /// class command in `class_targets` — resolved the way Tcl resolves it,
+    /// from the namespace lexically in effect there.
+    ///
+    /// The `exists` universe is this document's procs and classes plus the
+    /// caller-supplied targets themselves: a pure-consumer document does not
+    /// declare the class it calls, so without the targets no candidate would
+    /// ever "exist" and every cross-file consumer site would be lost.  A
+    /// same-named proc or class at a higher-priority candidate still shadows
+    /// the target, exactly as it would at runtime.
+    fn class_head_matches(&self, analysis: &AnalysisResult, raw: &str, offset: u32) -> bool {
+        if self.class_targets.is_empty() {
+            return false;
+        }
+        let Ok(tail) =
+            std::str::from_utf8(tcl_syntax::naming::written_command_tail(raw.as_bytes()))
+        else {
+            return false;
+        };
+        if !self.class_tails.contains(tail) {
+            return false;
+        }
+        let namespace = crate::definition::namespace_context_at(
+            &analysis.global_scope,
+            offset,
+            &analysis.namespace_overrides,
+        );
+        crate::definition::resolved_command_name(analysis, &namespace, raw, &|candidate| {
+            self.class_targets.contains(candidate)
+                || analysis.all_classes.contains_key(candidate)
+                || analysis.all_procs.contains_key(candidate)
+        })
+        .is_some_and(|winner| self.class_targets.contains(&winner))
+    }
+}
+
 /// Read-only context for the object-method call-site scan: the document
-/// `source`, its `dialect`, the `method` being looked up, and two receiver
-/// sets — `var_set` matches `$v method` dispatch (variables holding an
-/// object, keyed by bare name) and `cmd_set` matches `NAME method` dispatch
-/// (object *commands* bound by `CLASS create NAME`).
+/// `source`, its `dialect`, its `analysis`, the `method` being looked up, and
+/// the receiver sets — `var_set` matches `$v method` dispatch (variables
+/// holding an object, keyed by bare name) and `receivers` matches `NAME
+/// method` dispatch (object commands bound by `CLASS create NAME`, and class
+/// commands resolved namespace-aware).
 #[derive(Clone, Copy)]
 struct ObjMethodScan<'a> {
     source: &'a str,
     dialect: &'a str,
+    analysis: &'a AnalysisResult,
     var_set: &'a FxHashSet<&'a str>,
-    cmd_set: &'a FxHashSet<&'a str>,
+    receivers: &'a CommandReceivers,
     method: &'a str,
     /// `false` once the scan has descended through a frame-shifting region
     /// ([`frame_shifted_dispatch_regions`]), where a `$var` receiver's bare
     /// name no longer names the enclosing frame's variable — so `var_set`
-    /// stops matching while `cmd_set` (an ordinary command, resolvable from
-    /// any frame) keeps going.
+    /// stops matching while `receivers` (ordinary commands, resolvable from
+    /// any frame) keep going.
     var_receivers_in_scope: bool,
 }
 
@@ -1949,7 +2072,16 @@ impl ObjMethodScan<'_> {
     /// Whether this context can still match anything — a frame-shifted scan
     /// with no command receivers to look for has nothing left to do.
     fn has_receivers(&self) -> bool {
-        !self.cmd_set.is_empty() || (self.var_receivers_in_scope && !self.var_set.is_empty())
+        self.receivers.has_any() || (self.var_receivers_in_scope && !self.var_set.is_empty())
+    }
+
+    /// Whether the bare-word head `raw` at `offset` names a receiver whose
+    /// dispatch this scan is looking for.
+    fn command_receiver_matches(&self, raw: &str, offset: u32) -> bool {
+        self.receivers.object_commands.contains(raw)
+            || self
+                .receivers
+                .class_head_matches(self.analysis, raw, offset)
     }
 }
 
@@ -2018,11 +2150,12 @@ fn scan_obj_method_region(
                     ctx.var_receivers_in_scope
                         && strip_var_decoration(raw).is_some_and(|name| ctx.var_set.contains(name))
                 } else {
-                    // A bare-word object command (`rex bark`).  `cmd_set` holds
-                    // only plain names, and a braced / bracketed / substituted
-                    // head's source slice keeps its delimiters (`{rex}`, `[x]`),
-                    // so an exact match admits only a genuine bare word.
-                    ctx.cmd_set.contains(raw)
+                    // A bare-word object command (`rex bark`) or class command
+                    // (`Factory make`).  Both receiver sets hold only plain
+                    // names, and a braced / bracketed / substituted head's
+                    // source slice keeps its delimiters (`{rex}`, `[x]`), so
+                    // neither can admit anything but a genuine bare word.
+                    ctx.command_receiver_matches(raw, head.span.start())
                 };
                 if receiver_matches {
                     let m_start = method_tok.span.start() as usize;

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -77,6 +77,14 @@
 //!   namespace (`ns::Factory make` where the class is `::ns::Factory`) is
 //!   not matched.  The same imprecision already applies to `CLASS create
 //!   NAME` object-command dispatch above.
+//! * [incr Tcl]'s class-scoped `proc` uses a different dispatch shape
+//!   entirely — a single `::`-qualified command word (`Factory::make`), not
+//!   two words — so it is matched by [`crate::definition::itcl_class_proc_target`]
+//!   against `analysis.command_invocations`, with Tcl's own
+//!   current-namespace-then-global resolution rather than by name-set
+//!   membership.  That path is single-document: a call in a sibling file is
+//!   not found, because the cross-file layer below still carries only the
+//!   two-word shape's name sets.
 //! * `uplevel`'s body is `BodyKind::Structural` (a different call frame in
 //!   the general case — level `0` and level `1`+ can't be told apart from
 //!   the static registry spec alone), so a `my`/`next`/`$obj method`
@@ -395,6 +403,15 @@ pub fn references(
 
     // Proc references.
     if let Some(out) = proc_references(&ctx, &word) {
+        return out;
+    }
+
+    // `Factory::make` — [incr Tcl]'s colon-qualified class-proc dispatch
+    // (issue #990). Tried *after* `proc_references` so an ordinary
+    // namespace-qualified proc call of the same spelling keeps priority:
+    // this only ever fires when nothing resolves as a proc and the written
+    // word's parent namespace really is an itcl class declaring that member.
+    if let Some(out) = itcl_class_proc_references(&ctx) {
         return out;
     }
 
@@ -745,6 +762,42 @@ fn classmethod_call_site_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
     call_spans.extend(method_next_dispatch_spans(
         analysis, source, dialect, &class_q, &method, true,
     ));
+    Some(build_member_ranges(
+        source,
+        line_index,
+        decl_span,
+        call_spans,
+        include_declaration,
+    ))
+}
+
+/// Build references for a `Factory::make` call site — [incr Tcl]'s
+/// colon-qualified class-proc dispatch (issue #990).
+///
+/// itcl's class-scoped `proc` is its equivalent of `TclOO`'s `classmethod`,
+/// but it is invoked as a *single* `::`-qualified command word, not as a
+/// two-word `Factory make` dispatch (which in itcl is the unrelated
+/// `ClassName instanceName` object-creation syntax).  The word is resolved
+/// with Tcl's own current-namespace-then-global rule
+/// ([`crate::definition::itcl_class_proc_target`]), so it reaches the class
+/// the runtime would reach and nothing else.
+///
+/// Returns `None` for every other spelling, leaving ordinary qualified proc
+/// calls to [`proc_references`].
+fn itcl_class_proc_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
+    let RefCtx {
+        source,
+        dialect,
+        line_index,
+        line,
+        character,
+        analysis,
+        include_declaration,
+    } = *ctx;
+    let (class_q, member) =
+        crate::definition::itcl_class_proc_target_at(source, dialect, line, character, analysis)?;
+    let (decl_span, call_spans) =
+        method_references_for_class(source, dialect, analysis, &class_q, &member, true)?;
     Some(build_member_ranges(
         source,
         line_index,
@@ -1633,20 +1686,56 @@ pub(crate) fn find_obj_method_call_sites(
     )
 }
 
-/// Whether `cd`'s definer command dispatches its class-scoped members as a
-/// single `::`-qualified identifier (`Factory::make`) rather than the
-/// two-word `Factory make` shape — true for [incr Tcl] only.  Registry data
-/// (`DefinerFamily`), not a hardcoded command-name check: `cd.metaclass` is
-/// looked up in `dialect`'s registry and its attached
-/// [`tcl_registry::definer::DefinitionBodyGrammar::family`] compared.  A
-/// metaclass the registry doesn't recognise as a definer (shouldn't happen
-/// for a real `ClassDef`) is conservatively treated as *not* itcl, matching
-/// prior behaviour.
-fn is_itcl_class(cd: &tcl_compiler::analyser::types::ClassDef, dialect: &str) -> bool {
-    tcl_registry::registry_for_dialect(dialect)
-        .get(&cd.metaclass)
-        .and_then(|spec| spec.definition_body)
-        .is_some_and(|g| g.family == tcl_registry::definer::DefinerFamily::Itcl)
+use crate::definition::is_itcl_class;
+
+/// Every call site in this document that dispatches `class_q`'s [incr Tcl]
+/// class-scoped `proc` named `member` — the single `::`-qualified
+/// `Factory::make` shape, which is a *different call shape entirely* from
+/// the two-word `Factory make` dispatch `classmethod` / `typemethod` use
+/// (issue #990).
+///
+/// Each returned span covers only the call's final `::`-segment (the `make`
+/// of `Factory::make`), so a rename rewrites the member name and leaves the
+/// as-written qualifier alone — `Factory::make` → `Factory::produce`.
+///
+/// Sites come from `analysis.command_invocations` rather than a text scan:
+/// an itcl class proc really is an ordinary command, so the analyser has
+/// already indexed every call to it, including those nested inside `[...]`
+/// substitutions and control-flow bodies.  Each candidate is then resolved
+/// with [`crate::definition::itcl_class_proc_target`], which applies Tcl's
+/// own current-namespace-then-global rule to the call's *lexical* namespace
+/// — so `Factory::make` written inside `namespace eval ::app` reaches
+/// `::app::Factory`, and the same text written at the top level (where only
+/// `::app::Factory` exists) reaches nothing at all.
+fn itcl_class_proc_call_sites(
+    analysis: &AnalysisResult,
+    dialect: &str,
+    class_q: &str,
+    member: &str,
+) -> Vec<tcl_lexer::Span> {
+    analysis
+        .command_invocations
+        .iter()
+        .filter_map(|inv| {
+            let namespace = crate::definition::namespace_context_at(
+                &analysis.global_scope,
+                inv.range.start(),
+                &analysis.namespace_overrides,
+            );
+            let (target_class, target_member) = crate::definition::itcl_class_proc_target(
+                analysis, dialect, &namespace, &inv.name,
+            )?;
+            if target_class != class_q || target_member != member {
+                return None;
+            }
+            let tail = tcl_syntax::naming::written_command_tail(inv.name.as_bytes());
+            let tail_len = u32::try_from(tail.len()).ok()?;
+            Some(tcl_lexer::Span::new(
+                inv.range.end().saturating_sub(tail_len),
+                inv.range.end(),
+            ))
+        })
+        .collect()
 }
 
 /// [`find_obj_method_call_sites`], plus `extra_cmd_names` — bare command
@@ -1675,6 +1764,23 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
     is_classmethod: bool,
     extra_cmd_names: &[String],
 ) -> Vec<tcl_lexer::Span> {
+    // [incr Tcl] class-scoped `proc`s land in the same `class_methods`
+    // bucket as a `classmethod`, but dispatch as a single `::`-qualified
+    // identifier (`Factory::make`) — a shape the two-word scanner below
+    // cannot see, and whose two-word look-alike is unrelated
+    // instance-creation syntax.  Collected first so every consumer of this
+    // scanner (references, rename, the code lens, call hierarchy) gets itcl
+    // edges from one place.
+    let mut out: Vec<tcl_lexer::Span> = if is_classmethod
+        && analysis
+            .all_classes
+            .get(class_q)
+            .is_some_and(|cd| is_itcl_class(cd, dialect))
+    {
+        itcl_class_proc_call_sites(analysis, dialect, class_q, method)
+    } else {
+        Vec::new()
+    };
     let hierarchy = analysis.class_hierarchy();
     // A classmethod dispatches on the class's own command, never an
     // instance — instance-receiver matching only ever applies to a `method`.
@@ -1764,10 +1870,9 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
         cmd_set.extend(extra_cmd_names.iter().map(String::as_str));
     }
     if var_set.is_empty() && cmd_set.is_empty() {
-        return Vec::new();
+        return out;
     }
-    let mut out: Vec<tcl_lexer::Span> = Vec::new();
-    let mut seen: FxHashSet<(u32, u32)> = FxHashSet::default();
+    let mut seen: FxHashSet<(u32, u32)> = out.iter().map(|s| (s.start(), s.end())).collect();
     let ctx = ObjMethodScan {
         source,
         dialect,

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -361,6 +361,16 @@ pub fn rename(
     ) {
         return edits;
     }
+    if let Some(edits) = rename_itcl_class_proc(
+        source,
+        dialect,
+        (line, character),
+        new_name,
+        analysis,
+        &line_index,
+    ) {
+        return edits;
+    }
     // `$obj method` external call site — when the cursor sits
     // on the method-name token of an instance-method call and
     // `$obj`'s class is known, rename the method across its
@@ -422,6 +432,38 @@ pub fn rename(
 /// cursor would silently break the override relationship.  See
 /// [`override_family`].  Shared by the in-class-body and external
 /// `$obj method` rename entry points.
+/// Rename an [incr Tcl] class-scoped `proc` from a `Factory::make` call site
+/// or its declaration (issue #990).
+///
+/// Tried after the proc / class rename paths so an ordinary qualified proc
+/// call of the same spelling keeps priority.  The edits come from the shared
+/// member-reference collector, whose itcl call sites cover only the final
+/// `::`-segment — so the as-written qualifier survives the rewrite.
+///
+/// Single-document: a `Factory::make` call in a sibling file is not
+/// rewritten, because the cross-file rename layer still carries only the
+/// two-word `Class method` dispatch shape.
+fn rename_itcl_class_proc(
+    source: &str,
+    dialect: &str,
+    cursor: (u32, u32),
+    new_name: &str,
+    analysis: &AnalysisResult,
+    line_index: &LineIndex,
+) -> Option<Vec<TextEdit>> {
+    let (line, character) = cursor;
+    let (class_q, member) =
+        crate::definition::itcl_class_proc_target_at(source, dialect, line, character, analysis)?;
+    rename_method_in_class(
+        source,
+        dialect,
+        (&class_q, &member, true),
+        new_name,
+        analysis,
+        line_index,
+    )
+}
+
 fn rename_method_in_class(
     source: &str,
     dialect: &str,

--- a/rust/tcl-lsp-core/tests/name_resolution.rs
+++ b/rust/tcl-lsp-core/tests/name_resolution.rs
@@ -300,24 +300,21 @@ mod classmethod_dispatch {
         );
     }
 
-    /// FP guard: [incr Tcl]'s class-scoped `proc` maps to the same
-    /// `class_methods` bucket as `classmethod`/`typemethod` (so the
-    /// declaration-side lookup reaches this fix's code path too), but itcl
+    /// FN→TP (issue #990): [incr Tcl]'s class-scoped `proc` maps to the same
+    /// `class_methods` bucket as `classmethod`/`typemethod`, but itcl
     /// dispatches it as a single `::`-qualified identifier
-    /// (`Factory::make`), never the two-word `Factory make` form this fix's
-    /// `cmd_set` scan matches. Widening `cmd_set` with `Factory`'s bare name
-    /// must not fabricate a phantom reference for an unrelated bare `Factory`
-    /// command elsewhere, and the real `Factory::make` call is simply out of
-    /// this scanner's shape (a distinct, pre-existing gap — namespace-style
-    /// dispatch is a job for the ordinary proc-reference path, not this
-    /// object-method scanner).
+    /// (`Factory::make`), never the two-word `Factory make` form the
+    /// `cmd_set` scan matches — so that call site used to be invisible.  It
+    /// is now resolved through the qualified-name path instead, keyed on the
+    /// definer family, and the two-word scan still never matches it.
     #[test]
-    fn fp_itcl_class_proc_colon_dispatch_not_confused_with_bare_dispatch() {
+    fn fn_to_tp_itcl_class_proc_colon_dispatch_is_a_reference() {
         let src = "itcl::class Factory {\n    proc make {} {\n        return 1\n    }\n}\nFactory::make\n";
-        // Only the declaration; the `::`-qualified call is not the
-        // two-word shape this scanner looks for, so it must not appear —
-        // and no bare `Factory make` exists here to spuriously match either.
-        assert_eq!(refs_at(src, 1, 9), vec![1], "declaration only");
+        assert_eq!(
+            refs_at(src, 1, 9),
+            vec![1, 5],
+            "decl + the `Factory::make` class-proc dispatch"
+        );
     }
 
     /// FP guard: a bare two-word `Factory make` must not be treated as a
@@ -335,6 +332,143 @@ mod classmethod_dispatch {
             refs_at(src, 1, 9),
             vec![1],
             "declaration only — `Factory make` is itcl instance creation, not a class-proc dispatch"
+        );
+    }
+}
+
+// ────────── #990 — [incr Tcl] `Factory::make` class-proc dispatch ──────────
+
+/// itcl gives every class a real namespace of the same name and installs its
+/// class-scoped `proc`s as ordinary commands inside it, so `Factory`'s `proc
+/// make` is genuinely the command `::app::Factory::make`.
+///
+/// Oracle (tclsh 8.6.14 + Itcl 3.4), for a class declared in `::app`:
+///
+/// | spelling | from | result |
+/// |---|---|---|
+/// | `::app::Factory::make` | anywhere | dispatches |
+/// | `app::Factory::make` | global / any namespace | dispatches |
+/// | `Factory::make` | inside `namespace eval ::app` | dispatches |
+/// | `Factory::make` | global or `::other` | `invalid command name` |
+/// | `Factory::make` | inside the class's own body | dispatches (itcl's own class-namespace resolver) |
+/// | `Other::omake` | inside `Factory`'s body | `invalid command name` |
+/// | bare `make` | inside any of the class's bodies | dispatches |
+/// | `::Factory::inst` (an *instance* method) | anywhere | `namespace "::" is not a class namespace` |
+mod itcl_class_proc_dispatch {
+    use super::*;
+
+    fn itcl_src() -> String {
+        concat!(
+            "namespace eval ::app {\n",
+            "    itcl::class Factory {\n",
+            "        proc make {} { return 1 }\n",
+            "        proc other {} { return [make] }\n",
+            "        method inst {} { return [Factory::make] }\n",
+            "    }\n",
+            "    proc caller {} { return [Factory::make] }\n",
+            "}\n",
+            "::app::Factory::make\n",
+            "app::Factory::make\n",
+        )
+        .to_owned()
+    }
+
+    /// FN→TP: every real dispatch spelling is a reference to the declaration.
+    #[test]
+    fn tp_every_dispatch_spelling_is_a_reference() {
+        assert_eq!(
+            refs_at(&itcl_src(), 2, 14),
+            vec![2, 3, 4, 6, 8, 9],
+            "decl + bare sibling + self-qualified + namespace-relative + absolute + global-relative"
+        );
+    }
+
+    /// FN→TP: the reverse direction — the cursor on a call site finds the
+    /// same set.
+    #[test]
+    fn tp_references_from_the_call_site_match_the_declaration() {
+        let src = itcl_src();
+        assert_eq!(refs_at(&src, 8, 18), refs_at(&src, 2, 14));
+    }
+
+    /// TN: the same text written where the class is *not* reachable resolves
+    /// to nothing — real Tcl answers `invalid command name` there.
+    #[test]
+    fn tn_unreachable_spelling_is_not_a_reference() {
+        let src = concat!(
+            "namespace eval ::app {\n",
+            "    itcl::class Factory {\n",
+            "        proc make {} { return 1 }\n",
+            "    }\n",
+            "}\n",
+            "Factory::make\n",
+        );
+        assert_eq!(refs_at(src, 2, 14), vec![2], "declaration only");
+    }
+
+    /// TN: an ordinary `::`-qualified proc call is untouched — `Factory` here
+    /// is a plain namespace, not a class, so this stays a proc reference and
+    /// never routes through the class-proc resolver.
+    #[test]
+    fn tn_plain_namespace_qualified_proc_call_is_still_a_proc_reference() {
+        let src = "namespace eval ::Factory {\n    proc make {} { return 1 }\n}\nFactory::make\n";
+        assert_eq!(refs_at(src, 1, 9), vec![1, 3], "decl + the proc call site");
+    }
+
+    /// FP guard: a *sibling* itcl class's simple name does not resolve from
+    /// inside another class's body — itcl's class-namespace resolver covers
+    /// the enclosing class only (`Other::omake` errors there).
+    #[test]
+    fn fp_sibling_class_simple_name_does_not_resolve_from_another_class_body() {
+        let src = concat!(
+            "namespace eval ::app {\n",
+            "    itcl::class Other {\n",
+            "        proc omake {} { return 1 }\n",
+            "    }\n",
+            "    itcl::class Factory {\n",
+            "        proc probe {} { return [Other::omake] }\n",
+            "    }\n",
+            "}\n",
+        );
+        assert_eq!(refs_at(src, 2, 14), vec![2], "declaration only");
+    }
+
+    /// FP guard: an itcl *instance* method is not addressable as
+    /// `Class::method` — only class-scoped `proc`s are — so that spelling
+    /// resolves to nothing.
+    #[test]
+    fn fp_instance_method_is_not_addressable_as_a_qualified_name() {
+        let src = concat!(
+            "itcl::class Factory {\n",
+            "    method inst {} { return 1 }\n",
+            "}\n",
+            "Factory::inst\n",
+        );
+        assert_eq!(refs_at(src, 1, 12), vec![1], "declaration only");
+    }
+
+    /// FP guard: a real proc at a higher-priority resolution candidate
+    /// shadows the class proc, exactly as it would at runtime — oracle
+    /// (tclsh 8.6.14 + Itcl 3.4): this exact script prints
+    /// `from ::app -> shadowing-proc` and `from global -> class-proc`.
+    #[test]
+    fn fp_a_shadowing_proc_wins_over_the_class_proc() {
+        let src = concat!(
+            "itcl::class Factory {\n",
+            "    proc make {} { return \"class-proc\" }\n",
+            "}\n",
+            "namespace eval ::app {\n",
+            "    namespace eval Factory {}\n",
+            "    proc Factory::make {} { return \"shadowing-proc\" }\n",
+            "    Factory::make\n",
+            "}\n",
+            "Factory::make\n",
+        );
+        assert_eq!(
+            refs_at(src, 6, 14),
+            vec![5, 6],
+            "the shadowing proc's declaration + the `::app` call — not the class proc, \
+             and not the global call that still reaches the class proc"
         );
     }
 }

--- a/rust/tcl-lsp-core/tests/name_resolution.rs
+++ b/rust/tcl-lsp-core/tests/name_resolution.rs
@@ -1133,4 +1133,83 @@ mod namespace_scoped_class_dispatch {
         );
         assert_eq!(refs_at(src, 2, 15), vec![2, 5], "decl + `rex make`");
     }
+
+    /// FN→TP: an **explicit** `namespace import` creates a real command in the
+    /// importing namespace, so a bare dispatch through the imported name is a
+    /// reference to the source class's method.  Post-#1047 this one scanner
+    /// also drives rename, so missing it left the call site stale.
+    ///
+    /// Oracle (tclsh 9.0.4, probe `ns981.tcl`):
+    ///
+    /// ```text
+    /// 1) import+bare in ::b : A-MADE
+    ///    info commands ::b::Factory = ::b::Factory
+    /// ```
+    #[test]
+    fn fn_to_tp_an_explicit_namespace_import_is_followed() {
+        let src = concat!(
+            "namespace eval ::a {\n",
+            "    oo::class create Factory {\n",
+            "        classmethod make {} { return 1 }\n",
+            "    }\n",
+            "    namespace export Factory\n",
+            "}\n",
+            "namespace eval ::b {\n",
+            "    namespace import ::a::Factory\n",
+            "    Factory make\n",
+            "}\n",
+        );
+        assert_eq!(
+            refs_at(src, 2, 20),
+            vec![2, 8],
+            "decl + the bare dispatch through the imported name"
+        );
+    }
+
+    /// TN (deliberate boundary): a **wildcard** import is not followed.
+    /// Reproducing it needs the export-gated import snapshot of issue #1027 —
+    /// which commands existed in `::a` when the import ran — and inventing
+    /// aliases without it would match sites the runtime never dispatches.
+    /// Documented in this module's limitations list.
+    #[test]
+    fn tn_a_wildcard_import_is_not_followed() {
+        let src = concat!(
+            "namespace eval ::a {\n",
+            "    oo::class create Factory {\n",
+            "        classmethod make {} { return 1 }\n",
+            "    }\n",
+            "    namespace export Factory\n",
+            "}\n",
+            "namespace eval ::b {\n",
+            "    namespace import ::a::*\n",
+            "    Factory make\n",
+            "}\n",
+        );
+        assert_eq!(
+            refs_at(src, 2, 20),
+            vec![2],
+            "declaration only — the wildcard-import model is out of scope (#1027)"
+        );
+    }
+
+    /// FP guard: importing a *different* command does not make an unrelated
+    /// bare `Factory make` a reference — the alias only maps the name it
+    /// really imports.
+    #[test]
+    fn fp_an_unrelated_import_does_not_match() {
+        let src = concat!(
+            "namespace eval ::a {\n",
+            "    oo::class create Factory {\n",
+            "        classmethod make {} { return 1 }\n",
+            "    }\n",
+            "    proc helper {} { return 2 }\n",
+            "    namespace export helper\n",
+            "}\n",
+            "namespace eval ::b {\n",
+            "    namespace import ::a::helper\n",
+            "    Factory make\n",
+            "}\n",
+        );
+        assert_eq!(refs_at(src, 2, 20), vec![2], "declaration only");
+    }
 }

--- a/rust/tcl-lsp-core/tests/name_resolution.rs
+++ b/rust/tcl-lsp-core/tests/name_resolution.rs
@@ -934,3 +934,139 @@ mod non_identifier_method_names {
         assert_eq!(refs_at(src, 1, 13), vec![1], "declaration only");
     }
 }
+
+// ─────── #981 — namespace-aware bare class-command dispatch matching ───────
+
+/// A bare `Factory make` is resolved the way Tcl resolves it — current
+/// namespace first, then global — instead of by matching the class's simple
+/// name as text.  Two classes sharing a tail name in different namespaces are
+/// therefore no longer cross-linked, which matters because since #1047 this
+/// one scanner feeds references, rename (including consumer-document edits),
+/// the code lens count and click, and call hierarchy: a wrong match rewrites
+/// real code.
+///
+/// Oracle, identical on tclsh 8.6.14 and 9.0.4, for classes in `::a` and
+/// `::b` each declaring `make`:
+///
+/// | written | in | result |
+/// |---|---|---|
+/// | `Factory make` | `::b` | `b-made` — `::b::Factory`, never `::a::Factory` |
+/// | `Factory make` | `::a` | `a-made` |
+/// | `Factory make` | `::c`, with no `::c::Factory` and no `::Factory` | `invalid command name "Factory"` |
+/// | `Factory make` | `::d`, with a global `::Factory` | the global class |
+/// | `::a::Factory make` | global | `a-made` |
+mod namespace_scoped_class_dispatch {
+    use super::*;
+
+    /// Two same-tailed classes, one dispatch each.
+    fn two_namespaces() -> &'static str {
+        concat!(
+            "namespace eval ::a {\n",
+            "    oo::class create Factory {\n",
+            "        classmethod make {} { return 1 }\n",
+            "    }\n",
+            "    Factory make\n",
+            "}\n",
+            "namespace eval ::b {\n",
+            "    oo::class create Factory {\n",
+            "        classmethod make {} { return 2 }\n",
+            "    }\n",
+            "    Factory make\n",
+            "}\n",
+            "::a::Factory make\n",
+        )
+    }
+
+    /// TN (the issue's own repro) + TP in one: `::a::Factory::make` counts
+    /// its own namespace's bare dispatch and the absolute spelling, and does
+    /// **not** count `::b`'s bare dispatch.
+    #[test]
+    fn tn_bare_dispatch_in_a_sibling_namespace_is_not_cross_linked() {
+        assert_eq!(
+            refs_at(two_namespaces(), 2, 20),
+            vec![2, 4, 12],
+            "decl + the `::a` bare dispatch + the absolute `::a::Factory make`"
+        );
+    }
+
+    /// TN, the mirror direction: `::b::Factory::make` likewise keeps only its
+    /// own sites.
+    #[test]
+    fn tn_the_mirror_direction_is_scoped_too() {
+        assert_eq!(
+            refs_at(two_namespaces(), 8, 20),
+            vec![8, 10],
+            "decl + the `::b` bare dispatch only"
+        );
+    }
+
+    /// TP: the global-fallback case still matches — a bare `Factory make`
+    /// inside a namespace that declares no `Factory` reaches the global class.
+    #[test]
+    fn tp_global_fallback_dispatch_still_matches() {
+        let src = concat!(
+            "oo::class create Factory {\n",
+            "    classmethod make {} { return 1 }\n",
+            "}\n",
+            "namespace eval ::d {\n",
+            "    Factory make\n",
+            "}\n",
+            "Factory make\n",
+        );
+        assert_eq!(
+            refs_at(src, 1, 16),
+            vec![1, 4, 6],
+            "decl + the `::d` fallback dispatch + the top-level one"
+        );
+    }
+
+    /// TN: where neither the current namespace nor the global namespace has a
+    /// `Factory`, the call is `invalid command name` in real Tcl — so it is
+    /// not a reference to the class in some *other* namespace.
+    #[test]
+    fn tn_dispatch_with_no_reachable_candidate_matches_nothing() {
+        let src = concat!(
+            "namespace eval ::a {\n",
+            "    oo::class create Factory {\n",
+            "        classmethod make {} { return 1 }\n",
+            "    }\n",
+            "}\n",
+            "namespace eval ::c {\n",
+            "    Factory make\n",
+            "}\n",
+        );
+        assert_eq!(refs_at(src, 2, 20), vec![2], "declaration only");
+    }
+
+    /// FP guard: a same-named *proc* in the calling namespace shadows the
+    /// class, so the bare call is not a class dispatch at all.
+    #[test]
+    fn fp_a_shadowing_proc_in_the_calling_namespace_wins() {
+        let src = concat!(
+            "oo::class create Factory {\n",
+            "    classmethod make {} { return 1 }\n",
+            "}\n",
+            "namespace eval ::e {\n",
+            "    proc Factory {args} { return 2 }\n",
+            "    Factory make\n",
+            "}\n",
+        );
+        assert_eq!(refs_at(src, 1, 16), vec![1], "declaration only");
+    }
+
+    /// TP: the object-command (`CLASS create NAME`) matcher keeps working —
+    /// a bare `rex make` on an instance command still resolves.
+    #[test]
+    fn tp_object_command_dispatch_still_matches() {
+        let src = concat!(
+            "namespace eval ::a {\n",
+            "    oo::class create Factory {\n",
+            "        method make {} { return 1 }\n",
+            "    }\n",
+            "    Factory create rex\n",
+            "    rex make\n",
+            "}\n",
+        );
+        assert_eq!(refs_at(src, 2, 15), vec![2, 5], "decl + `rex make`");
+    }
+}

--- a/rust/tcl-lsp-core/tests/name_resolution.rs
+++ b/rust/tcl-lsp-core/tests/name_resolution.rs
@@ -736,3 +736,67 @@ mod apply_lambda {
         );
     }
 }
+
+// ───────────── #1019 idx 16 — non-identifier method names ─────────────
+
+/// Tcl puts no character restriction on a method name.  The cursor-word
+/// rule used to stop at `-`, `<`, and `>`, so a hyphenated method and TIP
+/// 558's generated property accessors (`<ReadProp-NAME>` /
+/// `<WriteProp-NAME>`) were truncated to a name no class declares, and never
+/// resolved from a call site.
+///
+/// Oracle (tclsh 8.6.14 + 9.0.4): `method with-dash`, `method a.b`, and
+/// `method <ReadProp-x>` all define real, dispatchable methods, and
+/// `oo::configurable`'s `property x` generates exactly `<ReadProp-x>` /
+/// `<WriteProp-x>`.  Only `with-dash` / `a.b` are *exported* (`TclOO` exports
+/// a method iff its name starts with an ASCII lowercase letter), so the
+/// angle-bracketed pair is reachable through `my` only.
+mod non_identifier_method_names {
+    use super::*;
+
+    /// FN→TP: a hyphenated method's external call site is a reference.
+    #[test]
+    fn tp_hyphenated_method_call_site_is_a_reference() {
+        let src = "oo::class create C {\n    method with-dash {} { return 1 }\n}\nC create rex\nrex with-dash\n";
+        assert_eq!(refs_at(src, 1, 13), vec![1, 4], "decl + `rex with-dash`");
+    }
+
+    /// FN→TP: the cursor *on the call site* resolves back to the declaration
+    /// too — the reverse direction, which shares the same word rule.
+    #[test]
+    fn tp_hyphenated_method_references_from_the_call_site() {
+        let src = "oo::class create C {\n    method with-dash {} { return 1 }\n}\nC create rex\nrex with-dash\n";
+        assert_eq!(refs_at(src, 4, 7), vec![1, 4]);
+    }
+
+    /// FN→TP: the TIP 558 accessor shape, dispatched internally via `my`.
+    #[test]
+    fn tp_angle_bracketed_property_accessor_my_dispatch_is_a_reference() {
+        let src = "oo::class create C {\n    method <ReadProp-x> {} { return 2 }\n    method probe {} { my <ReadProp-x> }\n}\n";
+        assert_eq!(refs_at(src, 1, 13), vec![1, 2], "decl + `my <ReadProp-x>`");
+    }
+
+    /// TP: a dotted method name is one word too.
+    #[test]
+    fn tp_dotted_method_call_site_is_a_reference() {
+        let src =
+            "oo::class create C {\n    method a.b {} { return 1 }\n}\nC create rex\nrex a.b\n";
+        assert_eq!(refs_at(src, 1, 12), vec![1, 4]);
+    }
+
+    /// FP guard: `$x-1` is arithmetic, not a `-1` method on `$x`, even when
+    /// `x` really does hold an object whose class has methods.
+    #[test]
+    fn fp_subtraction_on_an_object_variable_is_not_a_method_call() {
+        let src = "oo::class create C {\n    method with-dash {} { return 1 }\n}\nset x [C new]\nset y [expr {$x-1}]\n";
+        assert_eq!(refs_at(src, 1, 13), vec![1], "declaration only");
+    }
+
+    /// TN: a hyphenated *option flag* written after an unrelated command is
+    /// not a reference to a same-named method.
+    #[test]
+    fn tn_option_flag_is_not_a_method_reference() {
+        let src = "oo::class create C {\n    method with-dash {} { return 1 }\n}\nputs -nonewline with-dash\n";
+        assert_eq!(refs_at(src, 1, 13), vec![1], "declaration only");
+    }
+}

--- a/rust/tcl-lsp-core/tests/name_resolution.rs
+++ b/rust/tcl-lsp-core/tests/name_resolution.rs
@@ -447,6 +447,70 @@ mod itcl_class_proc_dispatch {
         assert_eq!(refs_at(src, 1, 12), vec![1], "declaration only");
     }
 
+    /// FN→TP: itcl's class-namespace resolver **pre-empts** the stock global
+    /// fallback.  A global `::Factory::make` proc exists here, which stock
+    /// resolution reaches from inside the class's own namespace — but itcl
+    /// installs a custom command resolver on every class namespace and Tcl
+    /// consults it first, so the class's own bodies still dispatch the class
+    /// proc.
+    ///
+    /// Oracle (tclsh 8.6 + Itcl 3.4, probe `itcl2.tcl` — this script's exact
+    /// shape):
+    ///
+    /// ```text
+    /// A) from inside class proc  : ITCL-CLASSPROC
+    /// B) from inside method      : ITCL-CLASSPROC
+    /// C) from ::app              : ITCL-CLASSPROC
+    /// D) from global             : GLOBAL-NS-PROC
+    /// E) from ::other            : GLOBAL-NS-PROC
+    /// ```
+    #[test]
+    fn fn_to_tp_the_class_resolver_pre_empts_a_global_namespace_proc() {
+        let src = concat!(
+            "namespace eval ::Factory { proc make {} { return \"GLOBAL-NS-PROC\" } }\n",
+            "namespace eval ::app {\n",
+            "    itcl::class Factory {\n",
+            "        proc make {} { return \"ITCL-CLASSPROC\" }\n",
+            "        proc probeSelf {} { return [Factory::make] }\n",
+            "        method viaSelf {} { return [Factory::make] }\n",
+            "    }\n",
+            "}\n",
+            "Factory::make\n",
+        );
+        let analysis = analyse(src);
+        // Inside the class's own bodies (a class `proc` body and a `method`
+        // body) the class proc wins, even though `::Factory::make` exists.
+        for (line, character) in [(4, 37), (5, 39)] {
+            assert_eq!(
+                tcl_lsp_core::definition::itcl_class_proc_target_at(
+                    src, "tcl8.6", line, character, &analysis
+                ),
+                Some(("::app::Factory".to_owned(), "make".to_owned())),
+                "line {line}: itcl's class resolver must pre-empt the global proc",
+            );
+            // Go-to-definition lands on the class proc's declaration (line 3),
+            // not the global proc's (line 0).
+            assert_eq!(
+                ref_lines(&tcl_lsp_core::definition::definition(
+                    src, line, character, &analysis
+                )),
+                vec![3],
+                "line {line}: go-to-definition must reach the class proc",
+            );
+        }
+        // From the global namespace the ordinary proc wins (oracle rows D/E).
+        assert_eq!(
+            tcl_lsp_core::definition::itcl_class_proc_target_at(src, "tcl8.6", 8, 2, &analysis),
+            None,
+            "from global, `Factory::make` is the plain ::Factory::make proc",
+        );
+        assert_eq!(
+            ref_lines(&tcl_lsp_core::definition::definition(src, 8, 2, &analysis)),
+            vec![0],
+            "go-to-definition from global reaches the plain proc",
+        );
+    }
+
     /// FP guard: a real proc at a higher-priority resolution candidate
     /// shadows the class proc, exactly as it would at runtime — oracle
     /// (tclsh 8.6.14 + Itcl 3.4): this exact script prints

--- a/rust/tcl-lsp-core/tests/references_rename.rs
+++ b/rust/tcl-lsp-core/tests/references_rename.rs
@@ -2011,3 +2011,63 @@ fn rename_plain_namespace_qualified_proc_is_unaffected() {
         "namespace eval ::Factory {\n    proc produce {} { return 1 }\n}\nFactory::produce\n"
     );
 }
+
+// ---------------------------------------------------------------------------
+// rename — namespace-scoped bare class dispatch (issue #981)
+// ---------------------------------------------------------------------------
+
+/// Two classes sharing a simple name in different namespaces, one bare
+/// `Factory make` dispatch each.  Oracle (tclsh 8.6.14 and 9.0.4): the
+/// dispatch inside `::b` reaches `::b::Factory`, so renaming `::a`'s
+/// classmethod must not rewrite it — before the fix it did, silently
+/// corrupting an unrelated class's call site.
+const TWO_NAMESPACE_FACTORIES: &str = concat!(
+    "namespace eval ::a {\n",
+    "    oo::class create Factory {\n",
+    "        classmethod make {} { return 1 }\n",
+    "    }\n",
+    "    Factory make\n",
+    "}\n",
+    "namespace eval ::b {\n",
+    "    oo::class create Factory {\n",
+    "        classmethod make {} { return 2 }\n",
+    "    }\n",
+    "    Factory make\n",
+    "}\n",
+);
+
+/// TN: renaming `::a`'s classmethod rewrites only `::a`'s own sites.
+#[test]
+fn rename_classmethod_does_not_rewrite_a_sibling_namespaces_dispatch() {
+    let src = TWO_NAMESPACE_FACTORIES;
+    let analysis = analyse(src);
+    let edits = rename(src, "tcl8.6", 2, 20, "produce", &analysis, None);
+    assert_eq!(edit_lines(&edits), vec![2, 4], "{edits:?}");
+    assert_eq!(
+        apply_edits(src, &edits),
+        concat!(
+            "namespace eval ::a {\n",
+            "    oo::class create Factory {\n",
+            "        classmethod produce {} { return 1 }\n",
+            "    }\n",
+            "    Factory produce\n",
+            "}\n",
+            "namespace eval ::b {\n",
+            "    oo::class create Factory {\n",
+            "        classmethod make {} { return 2 }\n",
+            "    }\n",
+            "    Factory make\n",
+            "}\n",
+        ),
+        "`::b`'s class and its dispatch must be untouched"
+    );
+}
+
+/// TN, the mirror direction: renaming `::b`'s classmethod leaves `::a` alone.
+#[test]
+fn rename_classmethod_is_scoped_in_the_other_direction_too() {
+    let src = TWO_NAMESPACE_FACTORIES;
+    let analysis = analyse(src);
+    let edits = rename(src, "tcl8.6", 8, 20, "produce", &analysis, None);
+    assert_eq!(edit_lines(&edits), vec![8, 10], "{edits:?}");
+}

--- a/rust/tcl-lsp-core/tests/references_rename.rs
+++ b/rust/tcl-lsp-core/tests/references_rename.rs
@@ -1943,3 +1943,71 @@ fn rename_rewrites_a_consumed_dispatch_table_literal_m7() {
         .expect("table edit");
     assert_eq!(table_edit.new_text, "sum");
 }
+
+// ---------------------------------------------------------------------------
+// rename — [incr Tcl] `Factory::make` class-proc dispatch (issue #990)
+// ---------------------------------------------------------------------------
+
+/// TP: renaming an itcl class-scoped `proc` rewrites its declaration, its
+/// bare sibling call, and the tail of every `::`-qualified dispatch — the
+/// as-written qualifier is preserved (`Factory::make` → `Factory::produce`),
+/// exactly as an ordinary qualified proc rename already does.
+#[test]
+fn rename_itcl_class_proc_rewrites_every_dispatch_spelling() {
+    let src = concat!(
+        "itcl::class Factory {\n",
+        "    proc make {} { return 1 }\n",
+        "    proc other {} { return [make] }\n",
+        "}\n",
+        "Factory::make\n",
+        "::Factory::make\n",
+    );
+    let analysis = analyse(src);
+    // Cursor on the declaration name.
+    let edits = rename(src, "tcl8.6", 1, 10, "produce", &analysis, None);
+    assert_eq!(edit_lines(&edits), vec![1, 2, 4, 5], "{edits:?}");
+    assert_eq!(
+        apply_edits(src, &edits),
+        concat!(
+            "itcl::class Factory {\n",
+            "    proc produce {} { return 1 }\n",
+            "    proc other {} { return [produce] }\n",
+            "}\n",
+            "Factory::produce\n",
+            "::Factory::produce\n",
+        ),
+        "the qualifier must survive; only the member name changes"
+    );
+}
+
+/// TP: the same rename triggered *from* a `::`-qualified call site reaches
+/// the same set.
+#[test]
+fn rename_itcl_class_proc_from_the_call_site_matches_the_declaration() {
+    let src = concat!(
+        "itcl::class Factory {\n",
+        "    proc make {} { return 1 }\n",
+        "}\n",
+        "Factory::make\n",
+    );
+    let analysis = analyse(src);
+    let from_site = rename(src, "tcl8.6", 3, 11, "produce", &analysis, None);
+    let from_decl = rename(src, "tcl8.6", 1, 10, "produce", &analysis, None);
+    assert_eq!(edit_lines(&from_site), vec![1, 3], "{from_site:?}");
+    assert_eq!(edit_lines(&from_site), edit_lines(&from_decl));
+}
+
+/// TN: an ordinary namespace-qualified proc of the same spelling is renamed
+/// by the plain proc path and is unaffected by the class-proc resolver —
+/// `Factory` here is a namespace, not a class.
+#[test]
+fn rename_plain_namespace_qualified_proc_is_unaffected() {
+    let src = "namespace eval ::Factory {\n    proc make {} { return 1 }\n}\nFactory::make\n";
+    let analysis = analyse(src);
+    let edits = rename(src, "tcl8.6", 3, 11, "produce", &analysis, None);
+    assert_eq!(edit_lines(&edits), vec![1, 3], "{edits:?}");
+    assert_eq!(
+        apply_edits(src, &edits),
+        "namespace eval ::Factory {\n    proc produce {} { return 1 }\n}\nFactory::produce\n"
+    );
+}

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4824,9 +4824,16 @@ impl Backend {
     }
 
     /// Whether `method` is a `classmethod` on any of `definers`, and — if
-    /// so — the (qualified + simple name) set of every class in
-    /// `definers`/`inheritors` valid as a bare classmethod-dispatch head
+    /// so — the fully `::`-qualified name of every class in
+    /// `definers`/`inheritors` whose own command dispatches it
     /// (`Factory make`).
+    ///
+    /// **Qualified names only.**  The core scanner resolves each written head
+    /// against the call site's own lexical namespace and compares the winner
+    /// against these names, so handing it simple names too would re-introduce
+    /// exactly the namespace-blind text match issue #981 removed: with a
+    /// `Factory` in `::a` and another in `::b`, a bare `Factory make` inside
+    /// `namespace eval ::b` must be attributed to `::b::Factory` alone.
     ///
     /// A `classmethod` dispatches on the *class's own* command, never on an
     /// instance, so the same-document analyser can only widen its dispatch
@@ -4878,7 +4885,7 @@ impl Backend {
             .iter()
             .chain(inheritors.iter().filter(|_| inheritable))
             .filter(|wc| !wc.is_itcl(dialect))
-            .flat_map(|wc| [wc.name.clone(), wc.qualified_name.clone()])
+            .map(|wc| wc.qualified_name.clone())
             .collect()
     }
 
@@ -20601,6 +20608,63 @@ mod tests {
             refs.iter()
                 .any(|l| l.uri == consumer && l.range.start.line == 0),
             "`Factory make` in the pure-consumer document missing: {refs:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn cross_file_consumer_bare_dispatch_is_namespace_scoped() {
+        // Issue #981, the consumer-document variant. Two classes named
+        // `Factory`, in `::a` and `::b`, each declaring `make`; a consumer
+        // document dispatches `Factory make` inside `namespace eval ::b`.
+        // Real Tcl resolves that bare word to `::b::Factory` (tclsh 8.6.14
+        // and 9.0.4 both answer `b-made`), so it must count for `::b`'s
+        // classmethod and *not* `::a`'s — a name-set match counted it for
+        // both, and rename then rewrote an unrelated class's call site.
+        let backend = test_backend();
+        let a = Uri::from_str("file:///a.tcl").unwrap();
+        let b = Uri::from_str("file:///b.tcl").unwrap();
+        let consumer = Uri::from_str("file:///consumer.tcl").unwrap();
+        let a_src = "namespace eval ::a {\n    oo::class create Factory {\n        classmethod make {} { return 1 }\n    }\n}\n";
+        let b_src = "namespace eval ::b {\n    oo::class create Factory {\n        classmethod make {} { return 2 }\n    }\n}\n";
+        register(&backend, &a, a_src).await;
+        register(&backend, &b, b_src).await;
+        register(
+            &backend,
+            &consumer,
+            "namespace eval ::b {\n    Factory make\n}\n",
+        )
+        .await;
+
+        let from_a = backend
+            .cross_file_consumer_method_references(
+                &a,
+                a_src,
+                "tcl8.6",
+                "::a::Factory",
+                "make",
+                true,
+            )
+            .await;
+        assert!(
+            !from_a.iter().any(|l| l.uri == consumer),
+            "`::b`'s bare dispatch must not count for `::a::Factory`: {from_a:?}"
+        );
+
+        let from_b = backend
+            .cross_file_consumer_method_references(
+                &b,
+                b_src,
+                "tcl8.6",
+                "::b::Factory",
+                "make",
+                true,
+            )
+            .await;
+        assert!(
+            from_b
+                .iter()
+                .any(|l| l.uri == consumer && l.range.start.line == 1),
+            "and it must count for `::b::Factory`: {from_b:?}"
         );
     }
 

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -405,6 +405,79 @@ fn tp_classmethod_lens_click_and_count_reach_a_consumer_document() {
     );
 }
 
+// Issue #990 — [incr Tcl]'s colon-qualified class-proc dispatch.
+
+/// TP: `Factory::make` is how [incr Tcl] dispatches a class-scoped `proc`
+/// (its equivalent of `TclOO`'s `classmethod`), and it is a *single*
+/// `::`-qualified command word rather than the two-word `Factory make` shape
+/// `TclOO` / snit use.  Definition, references, and rename must all follow it.
+///
+/// Oracle (tclsh 8.6.14 + Itcl 3.4): `Factory::make` and `::Factory::make`
+/// both dispatch the class proc, a bare `make` inside a sibling class body
+/// does too, and the two-word `Factory make` instead creates an *object*
+/// named `make`.
+#[test]
+fn tp_itcl_class_proc_colon_dispatch_navigates_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        concat!(
+            "itcl::class Factory {\n",
+            "    proc make {} { return 1 }\n",
+            "    proc other {} { return [make] }\n",
+            "}\n",
+            "Factory::make\n",
+            "::Factory::make\n",
+        ),
+    );
+
+    // Go-to-definition from the qualified call site reaches the `proc`.
+    let def = lsp.definition(&uri, 4, 11);
+    assert_eq!(
+        start_lines(&def),
+        [1].into_iter().collect(),
+        "`Factory::make` must reach the class proc: {def:?}"
+    );
+
+    // References from the declaration cover every dispatch spelling.
+    let refs = lsp.references(&uri, 1, 10, true);
+    assert_eq!(
+        start_lines(&refs),
+        [1, 2, 4, 5].into_iter().collect(),
+        "decl + bare sibling call + both qualified dispatches: {refs:?}"
+    );
+
+    // Rename rewrites the member name and preserves each qualifier.
+    let edits = rename_edits(&lsp.rename(&uri, 1, 10, "produce"));
+    assert_eq!(edit_lines(&edits, &uri), vec![1, 2, 4, 5], "{edits:?}");
+    assert!(
+        edits
+            .get(&uri)
+            .is_some_and(|e| e.iter().all(|e| e["newText"] == "produce")),
+        "each edit replaces only the member name: {edits:?}"
+    );
+}
+
+/// TN: itcl's two-word `Factory make` is object *creation*
+/// (`ClassName instanceName`) — never a class-proc dispatch — so the class
+/// proc keeps only its declaration.
+#[test]
+fn tn_itcl_two_word_object_creation_is_not_a_class_proc_dispatch() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "itcl::class Factory {\n    proc make {} { return 1 }\n}\nFactory make\n",
+    );
+    let refs = lsp.references(&uri, 1, 10, true);
+    assert_eq!(
+        start_lines(&refs),
+        [1].into_iter().collect(),
+        "declaration only: {refs:?}"
+    );
+}
+
 // Issue #1019 idx 16 — method names that are not identifiers.
 
 /// TP: a hyphenated method (`with-dash`) and a TIP 558 property accessor

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -405,6 +405,79 @@ fn tp_classmethod_lens_click_and_count_reach_a_consumer_document() {
     );
 }
 
+// Issue #981 — bare class-command dispatch is namespace-scoped.
+
+/// TN, the issue's own repro, across files: two classes named `Factory` in
+/// `::a` and `::b`, each with its own `make`, and a consumer document that
+/// dispatches `Factory make` inside `namespace eval ::b`.  Real Tcl resolves
+/// that to `::b::Factory` (verified on tclsh 8.6.14 and 9.0.4), so a rename
+/// of `::a::Factory`'s `make` must not rewrite it — which it did before,
+/// corrupting an unrelated class's call site in a different file.
+#[test]
+fn tn_consumer_bare_dispatch_is_attributed_to_its_own_namespaces_class() {
+    let mut lsp = Lsp::tcl();
+    let a = unique_uri("tcl");
+    lsp.open_ready(
+        &a,
+        "namespace eval ::a {\n    oo::class create Factory {\n        classmethod make {} { return 1 }\n    }\n}\n",
+    );
+    let b = unique_uri("tcl");
+    lsp.open_ready(
+        &b,
+        "namespace eval ::b {\n    oo::class create Factory {\n        classmethod make {} { return 2 }\n    }\n}\n",
+    );
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(&consumer, "namespace eval ::b {\n    Factory make\n}\n");
+
+    let refs = lsp.references(&a, 2, 20, false);
+    assert!(
+        location_lines(&refs, &consumer).is_empty(),
+        "`::b`'s bare dispatch is not a reference to `::a::Factory`'s make: {refs:?}"
+    );
+
+    let edits = rename_edits(&lsp.rename(&a, 2, 20, "produce"));
+    assert!(
+        edit_lines(&edits, &consumer).is_empty(),
+        "and rename must not rewrite it: {edits:?}"
+    );
+    assert!(
+        edit_lines(&edits, &b).is_empty(),
+        "nor `::b`'s own class: {edits:?}"
+    );
+}
+
+/// TP: the same consumer document *is* attributed to `::b::Factory`, so the
+/// scoping is a re-attribution, not a loss — and the cross-file consumer
+/// rename from #1047 still reaches it.
+#[test]
+fn tp_consumer_bare_dispatch_belongs_to_the_matching_namespaces_class() {
+    let mut lsp = Lsp::tcl();
+    let a = unique_uri("tcl");
+    lsp.open_ready(
+        &a,
+        "namespace eval ::a {\n    oo::class create Factory {\n        classmethod make {} { return 1 }\n    }\n}\n",
+    );
+    let b = unique_uri("tcl");
+    lsp.open_ready(
+        &b,
+        "namespace eval ::b {\n    oo::class create Factory {\n        classmethod make {} { return 2 }\n    }\n}\n",
+    );
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(&consumer, "namespace eval ::b {\n    Factory make\n}\n");
+
+    let refs = lsp.references(&b, 2, 20, false);
+    assert!(
+        location_lines(&refs, &consumer).contains(&1),
+        "`::b`'s bare dispatch must be a reference to `::b::Factory`'s make: {refs:?}"
+    );
+    let edits = rename_edits(&lsp.rename(&b, 2, 20, "produce"));
+    assert_eq!(
+        edit_lines(&edits, &consumer),
+        vec![1],
+        "and rename must rewrite it: {edits:?}"
+    );
+}
+
 // Issue #990 — [incr Tcl]'s colon-qualified class-proc dispatch.
 
 /// TP: `Factory::make` is how [incr Tcl] dispatches a class-scoped `proc`

--- a/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
+++ b/rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs
@@ -404,3 +404,96 @@ fn tp_classmethod_lens_click_and_count_reach_a_consumer_document() {
         "and its count must be that same number: {command:?}"
     );
 }
+
+// Issue #1019 idx 16 — method names that are not identifiers.
+
+/// TP: a hyphenated method (`with-dash`) and a TIP 558 property accessor
+/// (`<ReadProp-x>`) are ordinary dispatchable method names — oracle-checked
+/// on tclsh 8.6.14 and 9.0.4 — so definition, references, hover, and rename
+/// must all resolve them from their call sites.  Before the fix the cursor
+/// word stopped at `-` / `<` / `>`, truncating the name to something no
+/// class declares.
+#[test]
+fn tp_non_identifier_method_names_navigate_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        concat!(
+            "oo::class create Widget {\n",
+            "    method with-dash {} { return 1 }\n",
+            "    method <ReadProp-x> {} { return 2 }\n",
+            "    method probe {} { my <ReadProp-x> }\n",
+            "}\n",
+            "Widget create rex\n",
+            "rex with-dash\n",
+        ),
+    );
+
+    // Go-to-definition from the hyphenated call site (line 6).
+    let def = lsp.definition(&uri, 6, 7);
+    assert_eq!(
+        start_lines(&def),
+        [1].into_iter().collect(),
+        "`rex with-dash` must reach the declaration: {def:?}"
+    );
+
+    // Go-to-definition from the `my <ReadProp-x>` internal dispatch.
+    let prop_def = lsp.definition(&uri, 3, 28);
+    assert_eq!(
+        start_lines(&prop_def),
+        [2].into_iter().collect(),
+        "`my <ReadProp-x>` must reach the accessor declaration: {prop_def:?}"
+    );
+
+    // References from the declaration cover the call site.
+    let refs = lsp.references(&uri, 1, 13, true);
+    assert_eq!(
+        start_lines(&refs),
+        [1, 6].into_iter().collect(),
+        "declaration + `rex with-dash`: {refs:?}"
+    );
+
+    // Hover on the call site names the method.
+    let hover = hover_text(&lsp.hover(&uri, 6, 7));
+    assert!(
+        hover.contains("with-dash"),
+        "hover must describe the hyphenated method: {hover:?}"
+    );
+
+    // Rename rewrites both sites.  The *new* name still has to pass the
+    // existing safe-symbol gate (`is_safe_symbol_name`), which is about what
+    // an editor may write, not about what Tcl can dispatch — so renaming
+    // *from* a hyphenated name works, renaming *to* one does not.
+    let edits = rename_edits(&lsp.rename(&uri, 1, 13, "renamed"));
+    assert_eq!(
+        edit_lines(&edits, &uri),
+        vec![1, 6],
+        "both the declaration and the call site must rename: {edits:?}"
+    );
+}
+
+/// TN: `$x-1` is arithmetic.  The widened word rule must not read it as a
+/// `-1` method dispatch on an object-holding variable, so the class's own
+/// method keeps exactly one reference (its declaration).
+#[test]
+fn tn_subtraction_is_not_a_method_dispatch() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        concat!(
+            "oo::class create Widget {\n",
+            "    method with-dash {} { return 1 }\n",
+            "}\n",
+            "set x [Widget new]\n",
+            "set y [expr {$x-1}]\n",
+        ),
+    );
+    let refs = lsp.references(&uri, 1, 13, true);
+    assert_eq!(
+        start_lines(&refs),
+        [1].into_iter().collect(),
+        "only the declaration: {refs:?}"
+    );
+}


### PR DESCRIPTION
## Summary

Three dispatch-precision fixes plus two adversarial-review hardenings, all oracle-verified against tclsh8.6/9.0 (and real Itcl 3.4 for the itcl work):

- **#981** — bare `ClassName method` dispatch matching is now namespace-scoped instead of a flat name-set: the head is resolved through `tcl_syntax::naming::command_resolution_candidates` (Tcl's real current-then-global rule, `namespace path` included) against the lexical namespace at the call site, so two classes named `Factory` in `::a`/`::b` no longer cross-link. Since #1047 this scanner feeds references, rename (incl. consumer docs), the code lens, and call hierarchy — a wrong match rewrites code, so this was the highest-precision-stakes fix. The cross-file `extra_cmd_names` contract now carries qualified names only.
- **#990** — itcl `Factory::make` colon-qualified class-proc dispatch resolves (references, rename tail-only rewrite, go-to-definition, and call-hierarchy edges), collected inside the one shared scanner so all four features gained it at a single insertion point. itcl's class-namespace resolver extension (its own name qualifies members inside the class's namespace) is modelled with oracle-pinned precedence — see below.
- **#1019 idx 16** — method names that aren't identifiers (`with-dash`, `a.b`, TIP-557 `<ReadProp-x>`) resolve from call sites; the hand-rolled `is_ident` rule is replaced by the lexer's shared `word_char_bounds` primitive, with a no-alphanumeric guard so `expr {$a < $b}` never reads as dispatch.

**Adversarial-review fixes included** (the review ran against real interpreters before this PR opened):
- itcl precedence was wrong in the first cut: the oracle shows `Itcl_ClassCmdResolver` pre-empts even the current-namespace-relative candidate, and a global `::Factory::make` proc must lose inside the class's own bodies but win outside — the candidate order (and a second ordering bug in the definition path) is now pinned by a five-row oracle table in the code.
- Explicit `namespace import ::a::Factory` now joins the resolver's command universe (the import creates a real command; post-#1047, missing it made rename leave stale call sites). Wildcard imports are deliberately out of scope — that's #1027's import-snapshot model — and the boundary is documented in the module limitations list.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Run on the integration of this PR with the sibling resolver PR and the merged #1057 (conflict-free):

- `make rust-check` / `make check-all` — pass, zero new clippy allows
- `make prep-pr` — full workspace suite: pass, 0 failures
- `make test-ext` / `make test-emacs` / `make runtime-rust-test` (400 passed) — pass
- Per-branch: 11,031 tests passed, 0 failed
- Oracle: tclsh8.6.14 + tclsh9.0.4 for every resolution claim; **Itcl 3.4 installed and measured live** for #990 (Itcl 4 / tclsh9 itcl unavailable in this container — stated, not assumed)

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? (no — LSP-side resolution only)
- [ ] If yes, I updated at least one relevant KCS note. (n/a; feature notes under `docs/kcs/features/` updated: references, call-hierarchy)
- [ ] New compiler KCS note linked. (n/a)

**Known limits, documented in-code:** itcl colon dispatch is single-document (the cross-file layer carries the two-word shape only); the `CLASS create NAME` object-command matcher stays a text match pending analyser-shape work (`created_instance_commands` is a bare-name set); methods literally named `+`/`<` still don't resolve (expr-body FP trade, documented).

**Merge order:** merge before the resolver PR is fine; both are conflict-free with each other and `rust`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178kD1P7t6ne1shFtWwkK54

---
_Generated by [Claude Code](https://claude.ai/code/session_0178kD1P7t6ne1shFtWwkK54)_