### PR TITLE
Resolver correctness: analyser namespace-homing consolidation, pkgIndex reachability for W123, hover cross-document fallback (#1017 #1018, #1019 idx 42/85)

### DIFF
--- a/docs/design/colon-names-and-addressability.md
+++ b/docs/design/colon-names-and-addressability.md
@@ -98,7 +98,7 @@ applying it to constructed keys.
   conformance vector machinery (which builds colon-named definitions
   *relatively*, since no absolute spelling exists to write).
 - `tcl-compiler/src/analyser/` — `join_namespace` /
-  `namespace_from_scope_path` / `advance_command_resolution_namespace`
+  `command_resolution_namespace` / `advance_command_resolution_namespace`
   join-then-never-reparse; definition handlers derive simple names via
   `key_tail` and emit W314.
 - `tcl-vm/src/interp.rs` — `register_command` takes canonical unrooted keys

--- a/docs/design/rust/incremental-analysis.md
+++ b/docs/design/rust/incremental-analysis.md
@@ -921,8 +921,8 @@ in the stateful scope walk:
 
 - `handle_proc_command` (`analyser/handlers.rs:292`): `name = args[0]`,
   body span = `arg_tokens[2].span`, qualified via
-  `namespace_from_scope_path(scope_path)` + `qualify(ns, name)`
-  (`handlers.rs:65`, currently `pub(super)` — expose it).
+  `command_resolution_namespace(scope_path)` + `qualify(ns, name)`
+  (`analyser/scope.rs`, currently `pub(super)` — expose it).
 - `handle_namespace_eval_command` (`handlers.rs:477`) creates the child scope
   whose path drives qualification; `oo::class create` /`oo::define`
   (`handlers.rs:1154,1229`) for classes/methods; `interp alias` /`namespace

--- a/docs/design/tricky-name-resolution-surfaces.md
+++ b/docs/design/tricky-name-resolution-surfaces.md
@@ -66,7 +66,7 @@ actively corrupt code or mislead the user. They are the top-priority defects.
 | D1 | **TclOO object variables** (`variable v` / `my variable v`) | variable | Rename of `$v` emits a decl edit whose range is the **entire method body** and whose replacement is just the new name — `{ return $v }` becomes `w`, **destroying the body**. Cross-method uses split into two distinct vars. | M4 |
 | D2 | **`uplevel #0 { … }`** cursor resolution | variable | `lookup_var_in_scope_chain` lacks the proc-local-drop guard, so a `$g` in the body resolves to an **invisible proc-local** of the same name instead of the global the runtime reads. Drives Go-to-Def / Hover / References / Rename to the wrong var. | M4 |
 | D3 | **`uplevel 1`/`2` / bare `uplevel`** body vars | variable | Body vars are attributed to the **enclosing proc's own scope**; a same-named proc-local absorbs a use that at runtime targets the caller's frame — wrong reference link and wrong rename edit. | M4 |
-| D4 | **Nested `proc`/`oo::class create`** under a **qualified-name** enclosing proc | command / class / method | Definition homed by lexical `namespace_from_scope_path`, not the proc's defining namespace; on name collision two defs **hash to the same `all_procs` key and one overwrites the other**, so navigation binds to the wrong same-named symbol. | none (NEW) |
+| D4 | **Nested `proc`/`oo::class create`** under a **qualified-name** enclosing proc | command / class / method | ~~Definition homed by a purely lexical namespace walk, not the proc's defining namespace; on name collision two defs **hash to the same `all_procs` key and one overwrites the other**, so navigation binds to the wrong same-named symbol.~~ **CLOSED** — every analyser site now homes through `command_resolution_namespace`; see [§1.8](#18-nested-proc--ooclass-create-re-homing--closed) | done (#923 idx 85) |
 | D5 | **Event/idle callbacks** (`after`, `fileevent`, `bind`, `-command`) | command / variable | Body walked in the **enclosing** namespace, but Tcl runs it at **global (`::`)** scope; a `helper` in `namespace eval ::x { after 0 { helper } }` binds to `::x::helper` (wrong) instead of `::helper`. Confident-wrong only under `::x::helper`-vs-`::helper` collision. | none (NEW) |
 | D6 | **`oo::objdefine` per-object method** under name collision | method | Body ignored; if a class method shares the name, `lookup_method_in_class` returns the **class method's** span even though `$o m` dispatches the per-object override at runtime. | none (NEW) |
 
@@ -397,34 +397,38 @@ the ensemble configuration string. Same fix location, same milestone.
 - **Milestone:** none. Adjacent to but distinct from the M5 `$cmd` limitation (these
   names ARE literals in source, just embedded in data). **NEW — M5-adjacent** (see §6).
 
-### 1.8 Nested `proc` / `oo::class create` re-homing — **CONFIRMED** (medium) — DANGEROUS (D4)
+### 1.8 Nested `proc` / `oo::class create` re-homing — **CLOSED**
 
 - **Real Tcl:** a nested definition qualifies its name against the *runtime-current*
   namespace of the enclosing proc (its defining namespace), and a proc body runs with
   the proc's defining namespace current. `rust/tcl-vm/src/command.rs:1067`
   (`qualify_name` against current ns); `exec.rs:1085` (`push_ns(proc.namespace)` — body
   runs in defining ns); `cmd_oo.rs:951` (class create qualifies likewise).
-- **LSP today:** `handle_proc_command` computes the FQN from
-  `namespace_from_scope_path` (`handlers.rs:570,623-625`), which collects ONLY
-  `ScopeKind::Namespace` names and **skips proc/method scopes** (`scope.rs:465-497`,
-  pinned by `namespace_from_scope_path_skips_proc_scopes` at `scope.rs:1144`). The
-  correct defining-namespace rule already exists —
-  `command_resolution_namespace`/`advance_command_resolution_namespace`
-  (`scope.rs:112-136,513`) — but is used only for arity-shadow and call-site
-  resolution, NOT for definition homing.
-- **Gap:** both. Empirically confirmed by dumping `all_procs`/`all_classes` keys:
+- **The gap that was:** definition homing used a purely lexical namespace walk that
+  collected only `ScopeKind::Namespace` names and **skipped proc/method scopes**, so a
+  definition made inside `proc ::x::mk {} {...}` homed to `::` rather than `::x`.
+  Empirically confirmed at the time by dumping `all_procs`/`all_classes` keys:
   (A) `namespace eval ::x { proc mk {} { proc helper {} {} } }` → `::x::helper` **correct**;
   (B) `proc ::x::mk {} { proc helper {} {} }` → `::helper` **wrong** (real: `::x::helper`);
   (C) `namespace eval ::x { proc ::y::mk {} { proc helper {} {} } }` → `::x::helper`
   **wrong** (real: `::y::helper`);
   (D) `proc ::x::mk {} { oo::class create Helper {} }` → `::Helper` **wrong** (real:
-  `::x::Helper`). **False positive:** if a real global `::helper` also exists, both hash
-  to the same `all_procs` key and one silently overwrites the other → navigation binds to
-  the wrong same-named symbol.
-- **Milestone:** none. **NEW** — wire the existing `command_resolution_namespace`
-  helper into definition homing (`handlers.rs:570,623-625`; `oo.rs:335,385`). Slot into
-  **M1-adjacent / M0.5** (it is definition-side homing, distinct from the M0 call-site
-  target-selection family).
+  `::x::Helper`). The false positive: with a real global `::helper` also present, both
+  hashed to the same `all_procs` key and one silently overwrote the other.
+- **Fix:** `Analyser::command_resolution_namespace` (`analyser/scope.rs`) — built on the
+  shared `advance_command_resolution_namespace` per-scope-kind rule — is now the *single*
+  answer to "which namespace is current here?" for every analyser site. The purely
+  lexical walk has been deleted, so a new call site cannot pick the wrong one. Converted
+  in issue #923 idx 85: `proc` / TclOO `oo::class create` (earlier wave), then
+  `namespace ensemble create|configure`, `oo::define`, snit `type`/`widget`, itcl
+  `class`, `namespace import`, `namespace export`, `<pkg>::import` aliases, command-alias
+  resolution, `apply`'s relative namespace pin, registry-definer symbol qualification,
+  the imported-command body-role fallback, and the deferred method-body namespace.
+- **Known limits:** a TclOO **method** body resolves globally
+  (`Scope::oo_global_resolution`) because at run time it executes in the *object's*
+  namespace, which is not statically known — so a `namespace import` written inside a
+  TclOO method is attributed to `::`, not to the (unknowable) per-object namespace.
+  That is a deliberate, tclsh-pinned approximation, not a residual of this gap.
 
 ### 1.9 `interp eval CHILD SCRIPT` — cross-interp merge — **PLAUSIBLE** (medium) — DANGEROUS (PD1)
 
@@ -863,7 +867,7 @@ milestone slots are ordered by (severity × independence), matching the fix-plan
 
 | New item | Surfaces | What it does | Slot | Depends on |
 |----------|----------|--------------|------|------------|
-| **M0.5 — command name-link following** | 1.1, 1.2, 1.3, 1.5, 1.8, 1.10, 1.14, 3.1 | Make References/Rename/Call-Hierarchy (and the Go-to-Def/Hover path) consult `command_aliases`, `renamed_commands`, `namespace_imports`, forward targets, and the priority-ordered candidate list, so an alias/import/rename/forward is a followed reference and the definition/hover path becomes path-aware. Requires the analyser to record the missing **spans** (alias target word, `rename OLD NEW` args, import pattern, forward target token) and wire nested-def homing to `command_resolution_namespace`. Silent-correctness class — highest priority after M0. | **M0.5** (right after M0; several sub-items directly repair M0's "resolver already correct" assumption, esp. 1.14) | M0 (shared resolver in place) |
+| **M0.5 — command name-link following** | 1.1, 1.2, 1.3, 1.5, 1.8, 1.10, 1.14, 3.1 | Make References/Rename/Call-Hierarchy (and the Go-to-Def/Hover path) consult `command_aliases`, `renamed_commands`, `namespace_imports`, forward targets, and the priority-ordered candidate list, so an alias/import/rename/forward is a followed reference and the definition/hover path becomes path-aware. Requires the analyser to record the missing **spans** (alias target word, `rename OLD NEW` args, import pattern, forward target token) (nested-def homing is already wired to `command_resolution_namespace` — see §1.8). Silent-correctness class — highest priority after M0. | **M0.5** (right after M0; several sub-items directly repair M0's "resolver already correct" assumption, esp. 1.14) | M0 (shared resolver in place) |
 | **M4 explicit deliverables** | 2.1, 2.2, 2.3, 2.4 | Name upvar / global / variable / namespace-upvar **link-following** and TclOO **object variables** as first-class M4 deliverables (the spike text enumerates data models but not these link kinds). Fix the D1 whole-body-span rename corruption and the D2/D3 uplevel mis-scope even ahead of the broader spike. | within **M4** | — (M4 is a spike) |
 | **M3 sub-item — cross-file `oo::define` merge** | 3.5, 3.2, 3.3 | Dedup the cross-file `oo::define ::C` stub against the real ClassDef; honor a late cross-file `superclass`; add a per-object symbol store for `oo::objdefine`; add `next`/`nextto` reference sites. | within **M3** (per-object store may spill to M7) | M1, M2 |
 | **M6.5 — source-site namespace propagation** | 4.1, 4.3 | Re-home a sourced file's global-scope defs under the namespace active at the literal `source` call site; reuse `auto_path_eval` folding for computed source paths. | **M6.5** (after M6's lazy tier and M2's oracle) | M2, M6 |

--- a/docs/design/tricky-name-resolution-surfaces.md
+++ b/docs/design/tricky-name-resolution-surfaces.md
@@ -422,8 +422,19 @@ the ensemble configuration string. Same fix location, same milestone.
   in issue #923 idx 85: `proc` / TclOO `oo::class create` (earlier wave), then
   `namespace ensemble create|configure`, `oo::define`, snit `type`/`widget`, itcl
   `class`, `namespace import`, `namespace export`, `<pkg>::import` aliases, command-alias
-  resolution, `apply`'s relative namespace pin, registry-definer symbol qualification,
-  the imported-command body-role fallback, and the deferred method-body namespace.
+  resolution, registry-definer symbol qualification, the imported-command body-role
+  fallback, and the deferred method-body namespace.
+- **Not part of this conversion — `apply`'s namespace element:** an earlier revision of
+  this section listed `apply`'s relative namespace pin among the conversions. That was
+  wrong, and the code that followed it was a bug. `apply`'s optional third lambda
+  element is **never** relative to the caller: `doc/apply.n` states it "is interpreted
+  relative to the global namespace even if its name does not start with `::`", and
+  `tclProc.c`'s `TclNRApplyObjCmd` literally `::`-prefixes the word before looking the
+  namespace up. tclsh 9.0.4 confirms: with `::sub`, `::pin::sub`, and `::lex::sub` all
+  defined, `apply {{} {…} sub}` runs in `::sub` from a `namespace eval ::lex` body, from
+  inside `proc ::pin::caller`, and from a proc lexically in `::lex` but named
+  `::pin::c2`. `handle_apply_command` therefore qualifies the element against the global
+  namespace unconditionally; the absent-element case is likewise global.
 - **Known limits:** a TclOO **method** body resolves globally
   (`Scope::oo_global_resolution`) because at run time it executes in the *object's*
   namespace, which is not statically known — so a `namespace import` written inside a

--- a/docs/kcs/features/kcs-feature-hover.md
+++ b/docs/kcs/features/kcs-feature-hover.md
@@ -21,18 +21,43 @@ all-editors, MCP, analyser
 
 The hover provider resolves the symbol under the cursor and returns documentation from the command registry, proc signatures from analysis, variable types, and taint tracking status for iRules.
 
+### Commands defined in another file
+
+When nothing in the current document explains the word under the cursor and
+that word is a command being called, hover looks further afield — the same two
+steps go-to-definition takes:
+
+1. **Across the workspace.** A `proc` or class declared in another open
+   document, including one reached through `source`.
+2. **Through the library index.** A command an installed library auto-loads
+   (a `tclIndex` or `pkgIndex.tcl` on the configured library paths), even
+   though no file in the workspace declares it.
+
+The popup is rendered from the *defining* file, so it reads exactly as it does
+when you hover the declaration itself.
+
+Hover only looks further afield for a **command being called**. An ordinary
+argument word that happens to share a name with a proc in another file shows
+nothing, so a `puts widget` never pops up an unrelated `widget` procedure.
+
 ## File-path anchors
 
-- `server/features/hover.py`
+- `rust/tcl-lsp-core/src/hover.rs` — the provider and its renderers, including
+  `qualified_symbol_hover` for a symbol defined in another document
+- `rust/tcl-lsp-server/src/lib.rs` — `cross_document_hover`, the workspace and
+  library-index fallback
 
 ## Failure modes
 
 - Missing hover after command registry updates.
 - Incorrect position mapping in multi-line constructs.
+- A command reached only at run time (built by `eval`, or dispatched through a
+  variable) has no declaration to point at, so hover shows nothing.
 
 ## Test anchors
 
-- `tests/test_hover.py`
+- `rust/tcl-lsp-server/tests/e2e/hover.rs`
+- `rust/tcl-lsp-core/src/hover.rs` — renderer unit tests
 
 ## Screenshots
 

--- a/docs/kcs/features/kcs-feature-unknown-command-resolution.md
+++ b/docs/kcs/features/kcs-feature-unknown-command-resolution.md
@@ -44,6 +44,44 @@ W123 behaviour accordingly:
 - **User-defined procs**: Any `proc` defined in the file (or sourced via packages) is a known command.
 - **Command aliases**: Commands defined via `interp alias` are treated as known. See [Command Alias Resolution](../../../docs/design/contracts/command-alias-resolution.md).
 - **Namespace-qualified names**: Commands containing `::` are skipped (may come from `namespace import`).
+- **Library and package commands**: A command an installed library auto-loads
+  (through a `tclIndex` on the configured library paths), or that a package the
+  document requires defines, is treated as known — see below.
+
+### Guarded packages and the Tcl version you target
+
+A package's `pkgIndex.tcl` may only register itself on some Tcl releases. The
+tcllib idiom guards the whole file:
+
+```tcl
+if {![package vsatisfies [package provide Tcl] 8.5 9]} {return}
+package ifneeded log 1.5 [list source [file join $dir log.tcl]]
+```
+
+and the idiom C extensions use picks a branch:
+
+```tcl
+if {[package vsatisfies [package provide Tcl] 9.0-]} {
+    package ifneeded mypkg 1.0 [list load [file join $dir mypkg9.so]]
+} else {
+    package ifneeded mypkg 1.0 [list load [file join $dir mypkg8.so]]
+}
+```
+
+The server reads these guards and evaluates them against the Tcl version the
+document targets (the `tclLsp.dialect` setting, a folder override, or the
+version detected from the file). The outcome decides whether W123 is
+suppressed:
+
+| The guard says | W123 |
+|---|---|
+| the package **does** register on your Tcl version | suppressed — the command is real |
+| the guard cannot be read (it tests the platform, a file, or a variable) | suppressed — the server does not guess |
+| the package **does not** register on your Tcl version | **shown** — `package require` would fail here, so the call really is an error |
+
+The last row is the case that used to be missed: a package that cannot load on
+Tcl 9 no longer silences the warning for a Tcl 9 workspace. If you see W123 on
+a command you believe exists, check the `tclLsp.dialect` setting first.
 
 ## Operational context
 
@@ -57,21 +95,30 @@ against the union of: registry commands, user-defined procs, stub commands,
 
 ## File-path anchors
 
-- `analyser/_analyser/_diag_commands.py` — `_emit_unresolved_command_diagnostics`
-- `analyser/_analyser/_oo.py` — `_extract_unknown_proc_info`
-- `analyser/semantic_model.py` — `UnknownProcInfo`
-- `shared/text.py` — `edit_distance`, `suggest_similar`
-- `server/features/diagnostics.py` — `_to_lsp_diagnostic` (code description link)
+- `rust/tcl-compiler/src/analyser/diagnostics/unresolved.rs` — the W123 pass and
+  its known-name sets
+- `rust/tcl-lsp-server/src/lib.rs` — `refine_w123_diagnostics`, the workspace
+  refinement that consults the package database
+- `rust/tcl-lsp-core/src/package_resolver.rs` — the `auto_path` / `pkgIndex` /
+  `tclIndex` package database
+- `rust/tcl-lsp-core/src/package_resolver/reachability.rs` — which
+  `package ifneeded` declarations a given Tcl release actually runs
 
 ## Failure modes
 
 - False positives in codebases using dynamic command creation (e.g. `apply`, `coroutine`) not detected by the gating logic.
 - Forward-defined `unknown` proc in a sourced file (cross-file) is not detected — analysis is single-file.
+- A `pkgIndex.tcl` guard the server cannot read leaves the package "possibly
+  available", so a command it would never really provide is not flagged. That
+  is deliberate: a missed hint is a smaller problem than a warning on working
+  code.
 
 ## Test anchors
 
-- `tests/test_analyser.py` — W123 test cases
-- `tests/test_text_utils.py` — edit distance and suggestion tests
+- `rust/tcl-lsp-core/src/package_resolver/reachability/tests.rs` — guard
+  evaluation, per Tcl release
+- `rust/tcl-lsp-server/tests/e2e/diagnostics.rs` — end-to-end W123 cases,
+  including the guarded-package pair
 
 ## Example
 

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1417,13 +1417,15 @@ impl Analyser {
         arg_single: &[bool],
         scope_path: &[usize],
     ) {
-        // Current namespace for the imported-command fallback below. Computed
-        // before the immutable `registry` borrow (it needs `&mut self`), and
-        // only when imports were recorded — `namespace_from_scope_path` caches.
+        // Current namespace for the imported-command fallback below: the
+        // *command-resolution* namespace, since that is the one whose imports
+        // an unqualified call actually consults — the lexical walk skips proc
+        // scopes and so missed a qualified-name proc's own namespace
+        // (issue #923 idx 85). Computed only when imports were recorded.
         let cur_ns = if self.result.namespace_imports.is_empty() {
             String::new()
         } else {
-            self.namespace_from_scope_path(scope_path)
+            self.command_resolution_namespace(scope_path)
         };
         let Some(registry) = self.registry else {
             return;

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -461,7 +461,10 @@ impl Analyser {
             .max(name_tok.span.end());
         let full_span = Span::new(name_tok.span.start(), end);
 
-        let ns_prefix = self.namespace_from_scope_path(scope_path);
+        // A registry definer called inside `proc ::ns::p {}` creates its symbol
+        // in `::ns` (the proc's defining namespace), not `::` — the
+        // command-resolution rule, not the lexical one (issue #923 idx 85).
+        let ns_prefix = self.command_resolution_namespace(scope_path);
         let qualified = qualify(ns_prefix.trim_start_matches(':'), &name);
 
         let symbol = DefinedSymbol {
@@ -493,12 +496,14 @@ impl Analyser {
         scope_path: &[usize],
     ) -> Option<tcl_registry::SymbolDef> {
         let dialect = self.profile.availability_mask;
-        // `namespace_from_scope_path` needs `&mut self`; compute it before the
-        // shared `registry` borrow, and only when imports could matter.
+        // Which namespace's imports are in effect is the *command-resolution*
+        // namespace: a proc body resolves unqualified commands (and so the
+        // imports covering them) in the proc's defining namespace, which the
+        // lexical walk misses for a qualified-name proc (issue #923 idx 85).
         let cur_ns = if self.result.namespace_imports.is_empty() {
             String::new()
         } else {
-            self.namespace_from_scope_path(scope_path)
+            self.command_resolution_namespace(scope_path)
         };
         // Does `cmd_name` (or an imported bare form of it) name a registry
         // definer?  The `registry` borrow is confined to this block so the
@@ -823,7 +828,7 @@ impl Analyser {
         // lexical one: a proc defined inside another proc's body homes to that
         // enclosing proc's **defining** namespace (the prefix of its qualified
         // name), the way Tcl resolves the `proc` command at run time.  The
-        // lexical `namespace_from_scope_path` skips proc scopes and so homed a
+        // purely lexical namespace walk skips proc scopes and so homed a
         // nested `proc helper` under `proc a::outer` to `::helper`, overwriting
         // the real global `::helper` in `all_procs`; the command-resolution
         // namespace homes it to `::a::helper`.
@@ -1435,7 +1440,11 @@ impl Analyser {
         // relative to the caller (as `TclGetNamespaceFromObj`); absent → global.
         let body_ns = match elements.get(2).map(|(_, t)| t.as_str()) {
             Some(ns) if !ns.is_empty() && !ns.starts_with('$') && !ns.starts_with('[') => {
-                let caller_ns = self.namespace_from_scope_path(scope_path);
+                // "Relative to the caller" means the caller's *current*
+                // namespace at run time — the command-resolution namespace, so
+                // an `apply` inside `proc ::ns::p {}` pins against `::ns`
+                // (issue #923 idx 85).
+                let caller_ns = self.command_resolution_namespace(scope_path);
                 qualify(caller_ns.trim_start_matches(':'), ns)
             }
             _ => "::".to_string(),
@@ -2179,7 +2188,14 @@ impl Analyser {
         if !is_create && !is_configure {
             return;
         }
-        let ns = self.namespace_from_scope_path(scope_path);
+        // `namespace ensemble create` names the ensemble after the namespace
+        // the command *resolves in*, not the lexically enclosing one: run
+        // inside the body of `proc ::tk::foo {} {...}` declared at top level,
+        // the current namespace is `::tk`, so the ensemble is `::tk` — the
+        // purely lexical namespace walk skips proc scopes and homed it
+        // to `::` instead, losing every `<ns> sub` call site (issue #923
+        // idx 85).
+        let ns = self.command_resolution_namespace(scope_path);
         let ns_prefix = ns.trim_start_matches(':').to_owned();
 
         let (opts, opt_tokens, configure_target) = if is_create {
@@ -3752,7 +3768,9 @@ impl Analyser {
         args: &[String],
         scope_path: &[usize],
     ) -> (String, Vec<String>) {
-        let ns = self.namespace_from_scope_path(scope_path);
+        // An alias is looked up the way any unqualified command is, so the
+        // lookup namespace is the command-resolution one (issue #923 idx 85).
+        let ns = self.command_resolution_namespace(scope_path);
         // `alias::resolve_alias` accepts `CommandAliasMap` (alias map
         // keyed by qualified alias name) — the same shape as
         // `self.command_aliases` already uses.
@@ -3916,7 +3934,9 @@ impl Analyser {
             return false;
         }
         let raw_class_name = &args[0];
-        let ns_prefix = self.namespace_from_scope_path(scope_path);
+        // A relative class name resolves against the namespace current at the
+        // call — the command-resolution namespace (issue #923 idx 85).
+        let ns_prefix = self.command_resolution_namespace(scope_path);
         let ns_for_qualify = ns_prefix.trim_start_matches(':');
         // A dynamic target (`oo::define $class method ...`, the clay.tcl
         // `current_class`-based Ensemble DSL idiom) can't be resolved to the
@@ -4154,7 +4174,10 @@ impl Analyser {
         if idx < args.len() && args[idx] == "-force" {
             idx += 1;
         }
-        let importing_ns = self.namespace_from_scope_path(scope_path);
+        // `namespace import` imports into the namespace current at the call —
+        // the command-resolution namespace, so an import inside
+        // `proc ::ns::p {}` lands in `::ns` (issue #923 idx 85).
+        let importing_ns = self.command_resolution_namespace(scope_path);
         while idx < args.len() && idx < arg_tokens.len() {
             let pat_raw = args[idx].clone();
             // Patterns containing ``$`` / ``[`` substitutions can't be
@@ -4223,7 +4246,9 @@ impl Analyser {
             return;
         }
         let mut idx = 1;
-        let exporting_ns = self.namespace_from_scope_path(scope_path);
+        // As for `import`: the exporting namespace is the one current at the
+        // call, not the lexically enclosing one (issue #923 idx 85).
+        let exporting_ns = self.command_resolution_namespace(scope_path);
         if idx < args.len() && args[idx] == "-clear" {
             self.result
                 .namespace_exports
@@ -4315,7 +4340,7 @@ impl Analyser {
         // Relative aliases live under the current namespace —
         // ``namespace eval outer { some::ns::import vt }``
         // creates ``::outer::vt``, not ``::vt``.
-        let current_ns = self.namespace_from_scope_path(scope_path);
+        let current_ns = self.command_resolution_namespace(scope_path);
         let alias_ns = if alias.starts_with("::") {
             alias.clone()
         } else if current_ns == "::" {
@@ -6733,6 +6758,179 @@ mod tests {
         assert!(
             resolved.contains(&"::foo::show"),
             "the -subcommands name should map to `<ns>::show`: {resolved:?}",
+        );
+    }
+
+    /// Issue #923 idx 85 (tk-shaped): the ensemble-creating command runs inside
+    /// a proc whose *qualified name* homes it to `::tk`, but which is declared
+    /// at the top level with no enclosing `namespace eval`.  `namespace
+    /// current` there is `::tk` (tclsh 8.6.16 / 9.0.4-verified: the ensemble
+    /// created is `::tk` and `tk alpha` dispatches to `::tk::alpha`), so the
+    /// subcommand must map to `::tk::alpha` — the purely lexical namespace walk
+    /// skips proc scopes and mapped it to `::alpha`.
+    #[test]
+    fn namespace_ensemble_create_in_a_qualified_name_proc_homes_to_that_namespace_923_idx85() {
+        let mut a = Analyser::new();
+        let src = "namespace eval ::tk {}\n\
+                   proc ::tk::alpha {} {}\n\
+                   proc ::tk::SetupEnsemble {} {\n    \
+                   namespace ensemble create -subcommands {alpha}\n\
+                   }\n";
+        let r = a.analyse(src, "tcl8.6");
+        let resolved: Vec<&str> = r
+            .command_invocations
+            .iter()
+            .filter_map(|i| i.resolved_qualified_name.as_deref())
+            .collect();
+        assert!(
+            resolved.contains(&"::tk::alpha"),
+            "the subcommand should map to the proc's defining namespace: {resolved:?}",
+        );
+        assert!(
+            !resolved.contains(&"::alpha"),
+            "the lexical (global) namespace is the wrong home: {resolved:?}",
+        );
+        assert!(
+            a.ensemble_namespaces.contains("::tk"),
+            "the ensemble command itself is `::tk`: {:?}",
+            a.ensemble_namespaces,
+        );
+    }
+
+    /// TN control for the above: the ordinary lexical case — the ensemble is
+    /// created directly inside `namespace eval ::foo`, so both the lexical and
+    /// the command-resolution namespace agree on `::foo`.  Pinned so the idx 85
+    /// fix cannot regress the common shape.
+    #[test]
+    fn namespace_ensemble_create_lexically_inside_namespace_eval_is_unchanged_923_idx85() {
+        let mut a = Analyser::new();
+        let src = "namespace eval ::foo {\n    \
+                   proc alpha {} {}\n    \
+                   namespace ensemble create -subcommands {alpha}\n\
+                   }\n";
+        let r = a.analyse(src, "tcl8.6");
+        let resolved: Vec<&str> = r
+            .command_invocations
+            .iter()
+            .filter_map(|i| i.resolved_qualified_name.as_deref())
+            .collect();
+        assert!(
+            resolved.contains(&"::foo::alpha"),
+            "lexical case still maps to `::foo::alpha`: {resolved:?}",
+        );
+        assert!(a.ensemble_namespaces.contains("::foo"));
+    }
+
+    /// The definition-homing sweep behind issue #923 idx 85: every analyser
+    /// site that asks "which namespace is current here?" now answers with
+    /// [`Analyser::command_resolution_namespace`], so a definition made inside
+    /// a qualified-name proc's body homes to that proc's *defining* namespace.
+    /// These are cases (A)–(D) from `docs/design/tricky-name-resolution-surfaces.md`
+    /// §1.8, each with the real interpreter's answer as the expectation.
+    #[test]
+    fn definitions_inside_a_qualified_name_proc_home_to_its_defining_namespace_923_idx85() {
+        // (A) The already-correct lexical control.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "namespace eval ::x { proc mk {} { proc helper {} {} } }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.all_procs.contains_key("::x::helper"),
+            "(A) lexical case: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>(),
+        );
+
+        // (B) A qualified-name proc with no enclosing `namespace eval`.
+        let mut a = Analyser::new();
+        let r = a.analyse("proc ::x::mk {} { proc helper {} {} }\n", "tcl8.6");
+        assert!(
+            r.all_procs.contains_key("::x::helper"),
+            "(B) qualified encloser: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>(),
+        );
+
+        // (C) A qualified-name proc whose own name overrides the lexical
+        // `namespace eval` it sits in.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "namespace eval ::x { proc ::y::mk {} { proc helper {} {} } }\n",
+            "tcl8.6",
+        );
+        assert!(
+            r.all_procs.contains_key("::y::helper"),
+            "(C) absolute name rebases: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>(),
+        );
+
+        // (D) The same rule for a class, not a proc.
+        let mut a = Analyser::new();
+        let r = a.analyse("proc ::x::mk {} { oo::class create Helper {} }\n", "tcl8.6");
+        assert!(
+            r.all_classes.contains_key("::x::Helper"),
+            "(D) class create: {:?}",
+            r.all_classes.keys().collect::<Vec<_>>(),
+        );
+    }
+
+    /// The false positive the idx 85 family caused: a nested definition that
+    /// mis-homed to `::` collided with a real global of the same name and one
+    /// silently overwrote the other.  Both must survive under their own keys.
+    #[test]
+    fn a_nested_definition_no_longer_overwrites_a_same_named_global_923_idx85() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "proc helper {} { return global }\n\
+             proc ::x::mk {} { proc helper {} { return nested } }\n",
+            "tcl8.6",
+        );
+        let keys: Vec<&str> = r.all_procs.keys().map(String::as_str).collect();
+        assert!(
+            r.all_procs.contains_key("::helper"),
+            "global lost: {keys:?}"
+        );
+        assert!(
+            r.all_procs.contains_key("::x::helper"),
+            "nested lost: {keys:?}",
+        );
+    }
+
+    /// `namespace import` written inside a qualified-name proc imports into
+    /// that proc's defining namespace, not the global one (issue #923 idx 85).
+    #[test]
+    fn namespace_import_inside_a_qualified_name_proc_targets_that_namespace_923_idx85() {
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "namespace eval ::src { proc thing {} {} namespace export thing }\n\
+             proc ::dst::setup {} { namespace import ::src::thing }\n",
+            "tcl8.6",
+        );
+        let targets: Vec<&str> = r.namespace_imports.iter().map(|i| i.ns.as_str()).collect();
+        assert!(
+            targets.contains(&"::dst"),
+            "the import lands in the proc's defining namespace: {targets:?}",
+        );
+    }
+
+    /// A `-map` target inside the same qualified-name proc resolves the same
+    /// way (issue #923 idx 85, the `-map` half the finding actually named).
+    #[test]
+    fn namespace_ensemble_map_in_a_qualified_name_proc_resolves_targets_923_idx85() {
+        let mut a = Analyser::new();
+        let src = "namespace eval ::tk {}\n\
+                   proc ::tk::getImpl {} {}\n\
+                   proc ::tk::SetupEnsemble {} {\n    \
+                   namespace ensemble create -map {get getImpl}\n\
+                   }\n";
+        let r = a.analyse(src, "tcl8.6");
+        let resolved: Vec<&str> = r
+            .command_invocations
+            .iter()
+            .filter_map(|i| i.resolved_qualified_name.as_deref())
+            .collect();
+        assert!(
+            resolved.contains(&"::tk::getImpl"),
+            "the -map target resolves in the proc's defining namespace: {resolved:?}",
         );
     }
 

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -78,6 +78,31 @@ pub(super) fn qualify(ns_prefix: &str, name: &str) -> String {
     crate::naming::qualify(ns_prefix, name)
 }
 
+/// The [`super::types::Scope`] name for a routine whose written name is
+/// `resolved_name` (after [`Analyser::resolve_dynamic_word`]).
+///
+/// A `Proc` / `Method` scope's name is not decoration: it *is* the routine's
+/// qualified name for
+/// [`super::scope::advance_command_resolution_namespace`], which takes
+/// everything before the last `::` as the namespace the body runs in.  So a
+/// scope named with the raw, unresolved word invents a namespace out of the
+/// substitution: the real tcllib idiom `proc [namespace current]::_x {...}`
+/// inside `::pki` (tcllib 2.0 `modules/pki/pki.tcl`:316) made every definition
+/// in the body home to `::pki::[namespace current]`.
+///
+/// When the name still carries a `$` / `[` after resolution there is no
+/// trustworthy qualifier in it, so the scope keeps only the trailing segment —
+/// whose holder is the *lexical* parent namespace, which is where the idiom
+/// actually lands (tclsh 8.6.16 / 9.0.4: a `proc helper` inside
+/// `proc [namespace current]::_inner` in `::pki` becomes `::pki::helper`).
+pub(super) fn scope_name_for_routine(resolved_name: &str) -> &str {
+    if crate::naming::is_dynamic_word(resolved_name) {
+        crate::naming::key_tail(resolved_name)
+    } else {
+        resolved_name
+    }
+}
+
 /// Normalise a literal `interp` path word to the interpreter-domain map
 /// key: the path is a Tcl *list* naming a descent through child
 /// interpreters (`{s t}` = child `t` of child `s`), so whitespace runs
@@ -204,7 +229,10 @@ fn summarise_detail(description: &str) -> String {
 struct ProcBodyWalkArgs<'a> {
     /// Parent scope path, *before* the new proc scope is pushed.
     path: &'a [usize],
-    raw_name: &'a str,
+    /// The routine's name after [`Analyser::resolve_dynamic_word`] — the
+    /// `Scope` name is derived from it via [`scope_name_for_routine`], never
+    /// from the raw written word.
+    resolved_name: &'a str,
     body_span: Span,
     arg_tokens: &'a [Token],
     name_tok: Token,
@@ -904,14 +932,15 @@ impl Analyser {
         self.mark_locally_defined_in_enclosing_interp(&simple_key);
 
         // Walk the body in a fresh proc scope when the body is a
-        // braced literal. ``raw_name`` is used as the proc-scope
-        // name because ``define_var`` keys ``result.all_variables``
-        // on ``"<scope_name>::<var>"``, so the scope name must be
-        // the proc name to key that map consistently.
+        // braced literal. The *resolved* name is the proc-scope name:
+        // ``define_var`` keys ``result.all_variables`` on
+        // ``"<scope_name>::<var>"``, and the scope name is also what
+        // ``advance_command_resolution_namespace`` reads the body's namespace
+        // off — see ``scope_name_for_routine``.
         if body_tok.kind == TokenType::Str {
             self.walk_proc_body_in_new_scope(ProcBodyWalkArgs {
                 path: &path,
-                raw_name,
+                resolved_name: &resolved_name,
                 body_span,
                 arg_tokens,
                 name_tok,
@@ -934,7 +963,7 @@ impl Analyser {
     fn walk_proc_body_in_new_scope(&mut self, ctx: ProcBodyWalkArgs<'_>) {
         let ProcBodyWalkArgs {
             path,
-            raw_name,
+            resolved_name,
             body_span,
             arg_tokens,
             name_tok,
@@ -943,11 +972,15 @@ impl Analyser {
             body_tok,
             ns_prefix,
         } = ctx;
+        // One scope key for both the inline and the deferred path — a
+        // divergence here would make the per-item and whole-file walks
+        // disagree about which namespace the body runs in.
+        let scope_name = scope_name_for_routine(resolved_name);
         let proc_scope_idx = {
             let parent = super::scope::scope_at_mut(&mut self.result.global_scope, path)
                 .expect("scope_path resolved when registering proc must still resolve");
             let mut child =
-                super::types::Scope::new(super::types::ScopeKind::Proc, raw_name.to_string());
+                super::types::Scope::new(super::types::ScopeKind::Proc, scope_name.to_string());
             child.body_span = Some(body_span);
             parent.children.push(child);
             parent.children.len() - 1
@@ -1001,7 +1034,7 @@ impl Analyser {
                 is_method: false,
                 oo_global_resolution: false,
                 namespace: ns_prefix.to_string(),
-                scope_name: raw_name.to_string(),
+                scope_name: scope_name.to_string(),
                 params: params.to_vec(),
                 class_variables: Vec::new(),
                 safe_interp_ctx,
@@ -1105,11 +1138,15 @@ impl Analyser {
         self.mark_locally_defined_in_enclosing_interp(&simple_key);
 
         if body_tok.kind == TokenType::Str {
+            // The *resolved* name keys the scope — see
+            // `scope_name_for_routine`; the raw written word would invent a
+            // namespace out of a substitution.
+            let scope_name = scope_name_for_routine(&resolved_name).to_string();
             let proc_scope_idx = {
                 let parent = super::scope::scope_at_mut(&mut self.result.global_scope, &path)
                     .expect("scope_path resolved when registering proc must still resolve");
                 let mut child =
-                    super::types::Scope::new(super::types::ScopeKind::Proc, raw_name.clone());
+                    super::types::Scope::new(super::types::ScopeKind::Proc, scope_name.clone());
                 child.body_span = Some(body_span);
                 parent.children.push(child);
                 parent.children.len() - 1
@@ -1160,7 +1197,7 @@ impl Analyser {
                     is_method: false,
                     oo_global_resolution: false,
                     namespace: ns_prefix.clone(),
-                    scope_name: raw_name.clone(),
+                    scope_name,
                     params: combined_params,
                     class_variables: Vec::new(),
                     safe_interp_ctx,

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -1434,18 +1434,17 @@ impl Analyser {
 
         // `apply` runs the lambda body in the namespace named by lambda element
         // 2, or the *global* namespace when it is absent — never the caller's
-        // namespace (Tcl `apply` manual). Derive the body namespace so a nested
-        // `proc` registers under the qualified name the runtime `apply` would
-        // give it (`::p`, not `::caller::p`). A non-`::`-qualified pin resolves
-        // relative to the caller (as `TclGetNamespaceFromObj`); absent → global.
+        // namespace. Element 2 is interpreted relative to the **global**
+        // namespace even when it does not start with `::` (`doc/apply.n`:
+        // "If given, namespace is interpreted relative to the global namespace
+        // even if its name does not start with ::"; `tclProc.c`
+        // `TclNRApplyObjCmd` literally `::`-prefixes the word before the
+        // lookup). So `apply {{} {…} sub}` homes to `::sub` no matter which
+        // namespace the call sits in, and a nested `proc` registers under the
+        // qualified name the runtime `apply` would give it.
         let body_ns = match elements.get(2).map(|(_, t)| t.as_str()) {
             Some(ns) if !ns.is_empty() && !ns.starts_with('$') && !ns.starts_with('[') => {
-                // "Relative to the caller" means the caller's *current*
-                // namespace at run time — the command-resolution namespace, so
-                // an `apply` inside `proc ::ns::p {}` pins against `::ns`
-                // (issue #923 idx 85).
-                let caller_ns = self.command_resolution_namespace(scope_path);
-                qualify(caller_ns.trim_start_matches(':'), ns)
+                qualify("", ns)
             }
             _ => "::".to_string(),
         };
@@ -5393,10 +5392,11 @@ mod tests {
         );
         // Outer proc registered.
         assert!(a.result.all_procs.contains_key("::outer"));
-        // Inner proc registered under outer's qualified prefix?
-        // Namespace resolution skips proc scopes —
-        // so an `inner` proc declared inside ``outer`` qualifies as
-        // ``::inner`` (the outer proc is not a namespace).
+        // A nested definition homes to the enclosing proc's *defining*
+        // namespace (`command_resolution_namespace` /
+        // `advance_command_resolution_namespace`), not to a namespace named
+        // after the proc. ``outer`` is unqualified, so its defining namespace
+        // is ``::`` and the nested ``inner`` qualifies as ``::inner``.
         assert!(a.result.all_procs.contains_key("::inner"));
         // Outer's proc scope holds the nested proc scope as a child.
         let outer_scope = &a.result.global_scope.children[0];

--- a/rust/tcl-compiler/src/analyser/item_tree.rs
+++ b/rust/tcl-compiler/src/analyser/item_tree.rs
@@ -162,7 +162,7 @@ fn enclosing_namespace(qualified: &str) -> String {
 }
 
 /// Join a namespace prefix with a (possibly absolute) child name, mirroring the
-/// absolute-reset rule the analyser's `namespace_from_scope_path` uses.
+/// absolute-reset rule the analyser's `command_resolution_namespace` uses.
 fn join_ns(prefix: &str, name: &str) -> String {
     if name.starts_with("::") {
         name.to_string()

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -627,7 +627,11 @@ impl Analyser {
         // isolated `Method` scope matches the whole-file walk), the formal
         // params, and the class instance variables (pre-bound in every method).
         if self.defer_proc_bodies {
-            let namespace = self.namespace_from_scope_path(scope_path);
+            // Same rule `handle_proc_command` records for a deferred proc body:
+            // the command-resolution namespace, so the isolated per-item rebuild
+            // and the whole-file walk agree even when the class definer ran
+            // inside a qualified-name proc (issue #923 idx 85).
+            let namespace = self.command_resolution_namespace(scope_path);
             let safe_interp_ctx = self.safe_interp_ctx_snapshot();
             self.deferred_bodies.push(super::per_item::DeferredBody {
                 body_text: mb.body_text.clone(),
@@ -682,7 +686,10 @@ impl Analyser {
         }
         let raw_name = &args[0];
         let body = &args[1];
-        let ns_prefix = self.namespace_from_scope_path(scope_path);
+        // A relative type name homes to the namespace current at the call —
+        // the command-resolution namespace, so a `snit::type` created inside
+        // `proc ::ns::p {}` becomes `::ns::T` (issue #923 idx 85).
+        let ns_prefix = self.command_resolution_namespace(scope_path);
         // Constructed key in, construction-inverse tail out (#934): a colon
         // trim or `rsplit("::")` would collapse a lone-colon name.
         let qualified = super::handlers::qualify(&ns_prefix, raw_name);
@@ -1036,7 +1043,9 @@ impl Analyser {
         }
         let raw_name = &args[0];
         let body = &args[1];
-        let ns_prefix = self.namespace_from_scope_path(scope_path);
+        // As for snit: a relative itcl class name homes to the namespace
+        // current at the call, not the lexical one (issue #923 idx 85).
+        let ns_prefix = self.command_resolution_namespace(scope_path);
         // Constructed key in, construction-inverse tail out (#934): a colon
         // trim or `rsplit("::")` would collapse a lone-colon name.
         let qualified = super::handlers::qualify(&ns_prefix, raw_name);

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -30,7 +30,7 @@
 //! Helpers operate on ``&mut Analyser`` rather than free
 //! functions because most need both the scope under cursor
 //! (resolved from the path) and access to the analyser's
-//! tracking maps (``const_strings``, ``regex_vars``, ``ns_cache``,
+//! tracking maps (``const_strings``, ``regex_vars``,
 //! ``result.regex_patterns``).
 
 use std::collections::{HashMap, HashSet};
@@ -66,7 +66,7 @@ fn scope_at<'a>(root: &'a Scope, path: &[usize]) -> Option<&'a Scope> {
 
 /// Append a namespace component `part` onto the absolute namespace
 /// `ns` (`"::"`-rooted), mirroring the join in
-/// [`Analyser::namespace_from_scope_path`]: an absolute `part` rebases,
+/// [`Analyser::command_resolution_namespace`]: an absolute `part` rebases,
 /// a relative one is appended.
 ///
 /// `part` is a *written* namespace name — canonicalise it once (colon runs
@@ -1170,58 +1170,21 @@ impl Analyser {
         None
     }
 
-    /// Compute the namespace string for a scope path, with a
-    /// per-call cache.
-    ///
-    /// Walks the scope path collecting ``ScopeKind::Namespace``
-    /// names, then joins them via [`normalise_qualified_name`].
-    /// Caches the result on `self.ns_cache` keyed by the path.
-    pub fn namespace_from_scope_path(&mut self, scope_path: &[usize]) -> String {
-        if let Some(cached) = self.ns_cache.get(scope_path) {
-            return cached.clone();
-        }
-        let mut parts: Vec<String> = Vec::new();
-        let mut cursor = &self.result.global_scope;
-        // The global scope itself is not a namespace component;
-        // contribute its name only if we're past the root.
-        for &idx in scope_path {
-            let Some(child) = cursor.children.get(idx) else {
-                break;
-            };
-            if child.kind == ScopeKind::Namespace {
-                parts.push(child.name.clone());
-            }
-            cursor = child;
-        }
-        let result = if parts.is_empty() {
-            "::".to_string()
-        } else {
-            // One join per written segment — `join_namespace` canonicalises
-            // the written part and appends with an exact separator, so a
-            // namespace legitimately named `:` never collapses (#934).
-            let mut ns = "::".to_string();
-            for part in parts {
-                ns = join_namespace(&ns, &part);
-            }
-            ns
-        };
-        self.ns_cache.insert(scope_path.to_vec(), result.clone());
-        result
-    }
-
     /// Namespace in which an *unqualified* command invoked at
     /// `scope_path` resolves, following Tcl's command-resolution rule:
     /// the call's enclosing namespace, where a proc body resolves
     /// commands in the proc's **defining** namespace (the prefix of its
     /// qualified name) rather than its lexical parent.
     ///
-    /// This differs from [`Self::namespace_from_scope_path`] (which is
-    /// purely lexical and ignores proc scopes): `proc ::ns::p {...}`
-    /// declared at top level has defining namespace `::ns`, so an
-    /// unqualified `foo` in its body resolves to `::ns::foo` then
-    /// `::foo` — even though there is no enclosing `namespace eval`.
-    /// Used to scope the E002/E003 arity shadow guard to the command a
-    /// call actually resolves to.
+    /// This is deliberately **not** a purely lexical namespace walk.
+    /// `proc ::ns::p {...}` declared at top level has defining namespace
+    /// `::ns`, so an unqualified `foo` in its body resolves to `::ns::foo`
+    /// then `::foo` — even though there is no enclosing `namespace eval`.
+    /// A lexical walk (one that skips proc scopes) answers `::` there and
+    /// mis-homes everything the body creates or looks up: procs, classes,
+    /// ensembles, `namespace import`/`export` targets, and aliases
+    /// (issue #923 idx 85).  Every analyser site that needs "the namespace
+    /// current at this point" uses this one rule.
     #[must_use]
     pub(super) fn command_resolution_namespace(&self, scope_path: &[usize]) -> String {
         let mut ns = "::".to_string();
@@ -1871,44 +1834,49 @@ mod tests {
     }
 
     #[test]
-    fn namespace_from_scope_path_global_returns_root() {
-        let mut a = Analyser::new();
-        assert_eq!(a.namespace_from_scope_path(&[]), "::");
+    fn command_resolution_namespace_global_returns_root() {
+        let a = Analyser::new();
+        assert_eq!(a.command_resolution_namespace(&[]), "::");
     }
 
     #[test]
-    fn namespace_from_scope_path_single_relative() {
-        let mut a = make_analyser_with_namespace("ns1");
-        assert_eq!(a.namespace_from_scope_path(&[0]), "::ns1");
+    fn command_resolution_namespace_single_relative() {
+        let a = make_analyser_with_namespace("ns1");
+        assert_eq!(a.command_resolution_namespace(&[0]), "::ns1");
     }
 
     #[test]
-    fn namespace_from_scope_path_absolute_rebases() {
+    fn command_resolution_namespace_absolute_rebases() {
         let mut a = make_analyser_with_namespace("outer");
         // Add an absolute child namespace.
         a.result.global_scope.children[0]
             .children
             .push(Scope::new(ScopeKind::Namespace, "::abs"));
         // Path [0, 0] should rebase at ::abs, not nest under outer.
-        assert_eq!(a.namespace_from_scope_path(&[0, 0]), "::abs");
+        assert_eq!(a.command_resolution_namespace(&[0, 0]), "::abs");
+    }
+
+    /// A proc scope resolves in its own **defining** namespace, so a
+    /// qualified-name proc declared at the top level still answers `::ns1`
+    /// (issue #923 idx 85 — a purely lexical walk answered `::`).
+    #[test]
+    fn command_resolution_namespace_uses_a_procs_defining_namespace() {
+        let mut a = Analyser::new();
+        a.result
+            .global_scope
+            .children
+            .push(Scope::new(ScopeKind::Proc, "::ns1::myproc"));
+        assert_eq!(a.command_resolution_namespace(&[0]), "::ns1");
     }
 
     #[test]
-    fn namespace_from_scope_path_caches_result() {
-        let mut a = make_analyser_with_namespace("ns1");
-        let _ = a.namespace_from_scope_path(&[0]);
-        assert!(a.ns_cache.contains_key(&vec![0_usize]));
-    }
-
-    #[test]
-    fn namespace_from_scope_path_skips_proc_scopes() {
-        // proc scopes don't contribute to the namespace path.
+    fn command_resolution_namespace_nested_proc_keeps_the_enclosing_namespace() {
         let mut a = Analyser::new();
         let mut ns = Scope::new(ScopeKind::Namespace, "ns1");
         ns.children
             .push(Scope::new(ScopeKind::Proc, "::ns1::myproc"));
         a.result.global_scope.children.push(ns);
-        assert_eq!(a.namespace_from_scope_path(&[0, 0]), "::ns1");
+        assert_eq!(a.command_resolution_namespace(&[0, 0]), "::ns1");
     }
 
     /// The Method-scope namespace rule: a `TclOO` method (flagged) resolves

--- a/rust/tcl-compiler/src/analyser/snapshot.rs
+++ b/rust/tcl-compiler/src/analyser/snapshot.rs
@@ -146,9 +146,7 @@ impl Analyser {
     /// Restore analyser state from a snapshot.
     ///
     /// Replaces the result tree with an independent deep copy of the
-    /// snapshot, resets the per-walk tracking state, and clears the
-    /// ``ns_cache`` (it caches scope identity which is invalidated
-    /// by the deep-copy).
+    /// snapshot and resets the per-walk tracking state.
     ///
     /// Fields not in the snapshot (``disabled_diagnostics``,
     /// ``file_path``, ``builtin_names`` cache, ``body_depth``,
@@ -175,9 +173,6 @@ impl Analyser {
         self.pending_user_call_arity = snap.pending_user_call_arity;
         self.pending_ctor_arity = snap.pending_ctor_arity;
         self.pending_next_arity = snap.pending_next_arity;
-        // Cache invalidation — the namespace cache keys on scope
-        // path identity, which the deep-copy disrupts.
-        self.ns_cache.clear();
     }
 }
 
@@ -290,17 +285,6 @@ mod tests {
         // Snapshot still has ::foo and not ::bar.
         assert!(snap.result.all_procs.contains_key("::foo"));
         assert!(!snap.result.all_procs.contains_key("::bar"));
-    }
-
-    #[test]
-    fn restore_clears_namespace_cache() {
-        // ns_cache is invalidated by restore because its scope-path
-        // keys may no longer be valid against the restored tree.
-        let mut a = Analyser::new();
-        a.ns_cache.insert(vec![0, 1], "::ns".to_string());
-        let snap = a.snapshot();
-        a.restore(snap);
-        assert!(a.ns_cache.is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -2048,6 +2048,80 @@ mod tests {
         );
     }
 
+    /// TP — a *relative* (non-`::`-prefixed) lambda namespace element is
+    /// interpreted against the GLOBAL namespace, never the caller's.
+    ///
+    /// `doc/apply.n`: "If given, namespace is interpreted relative to the
+    /// global namespace even if its name does not start with `::`";
+    /// `tclProc.c`'s `TclNRApplyObjCmd` `::`-prefixes the word before the
+    /// lookup. tclsh 9.0.4 oracle (probe `a2b_apply.tcl`), with `::sub`,
+    /// `::pin::sub`, and `::lex::sub` all defined:
+    ///
+    /// ```text
+    /// lex-body current=::lex -> ns=::sub who=GLOBAL-SUB
+    /// proc current=::pin     -> ns=::sub who=GLOBAL-SUB
+    /// c2 current=::pin       -> ns=::sub who=GLOBAL-SUB
+    /// ```
+    #[test]
+    fn apply_relative_lambda_namespace_homes_globally_not_to_the_caller() {
+        let src = "namespace eval ::sub {}\n\
+                   namespace eval ::caller::sub {}\n\
+                   proc ::caller::p {} {\n\
+                       apply {{} { proc helper {} { return 1 } } sub}\n\
+                   }\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl");
+        assert!(
+            r.all_procs.contains_key("::sub::helper"),
+            "relative lambda ns must resolve against ::, not the caller: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !r.all_procs.contains_key("::caller::sub::helper"),
+            "relative lambda ns must NOT pin against the caller namespace: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>()
+        );
+        let (_, ns) = r
+            .namespace_overrides
+            .first()
+            .expect("the lambda body records a namespace override");
+        assert_eq!(ns, "::sub");
+    }
+
+    /// TN — an *absolute* namespace element is unaffected by the
+    /// global-relative rule: `::caller::sub` stays `::caller::sub`.
+    #[test]
+    fn apply_absolute_lambda_namespace_is_unchanged() {
+        let src = "namespace eval ::sub {}\n\
+                   namespace eval ::caller::sub {}\n\
+                   proc ::caller::p {} {\n\
+                       apply {{} { proc helper {} { return 1 } } ::caller::sub}\n\
+                   }\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl");
+        assert!(
+            r.all_procs.contains_key("::caller::sub::helper"),
+            "absolute lambda ns must be honoured verbatim: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// Control — no namespace element at all still means the global
+    /// namespace, from inside a qualified-name proc as much as anywhere.
+    #[test]
+    fn apply_without_a_namespace_element_stays_global_inside_a_qualified_proc() {
+        let src = "proc ::caller::p {} {\n\
+                       apply {{} { proc helper {} { return 1 } }}\n\
+                   }\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl");
+        assert!(
+            r.all_procs.contains_key("::helper"),
+            "an absent lambda ns means global: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>()
+        );
+    }
+
     #[test]
     fn apply_with_namespace_element_records_a_namespace_override() {
         // TP — issue #923 idx 116 Part 1 (the core mechanism): a literal

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -2036,6 +2036,71 @@ mod tests {
         );
     }
 
+    /// TP — the tcllib pki idiom: `proc [namespace current]::_x {...}` inside
+    /// `::pki`.  The body's own definitions must home to `::pki`, not to a
+    /// phantom namespace made out of the substitution's source text.
+    ///
+    /// Oracle (tclsh 8.6.16 and 9.0.4, probe `s5_probe.tcl`):
+    ///
+    /// ```text
+    /// inner exists: ::pki::_inner
+    /// helper homed at: ::pki::helper / global:
+    /// ```
+    #[test]
+    fn a_dynamically_named_procs_body_homes_to_the_lexical_namespace() {
+        let src = "namespace eval ::pki {\n\
+                       proc _outer {} {\n\
+                           proc [namespace current]::_inner {} {\n\
+                               proc helper {} { return HELPED }\n\
+                           }\n\
+                       }\n\
+                   }\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl");
+        assert!(
+            r.all_procs.contains_key("::pki::helper"),
+            "the body of a `[namespace current]`-named proc runs in ::pki: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !r.all_procs
+                .keys()
+                .any(|k| k.contains("[namespace current]") && k.ends_with("helper")),
+            "no phantom substitution-text namespace may appear: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// TN — a statically-named proc is untouched: the scope name is the
+    /// resolved name verbatim, so an ordinary qualified-name proc still homes
+    /// its nested definitions to its own defining namespace.
+    #[test]
+    fn a_statically_named_procs_body_still_homes_to_its_defining_namespace() {
+        let src = "proc ::pki::_outer {} { proc helper {} {} }\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl");
+        assert!(
+            r.all_procs.contains_key("::pki::helper"),
+            "{:?}",
+            r.all_procs.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// A `$`-spelled dynamic tail (`proc _$n {...}`) keeps the lexical
+    /// namespace too — the fallback is the trailing segment, whose holder is
+    /// the enclosing namespace.
+    #[test]
+    fn a_dollar_named_procs_body_homes_to_the_lexical_namespace() {
+        let src = "namespace eval ::pki { proc _$suffix {} { proc helper {} {} } }\n";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl");
+        assert!(
+            r.all_procs.contains_key("::pki::helper"),
+            "{:?}",
+            r.all_procs.keys().collect::<Vec<_>>()
+        );
+    }
+
     #[test]
     fn apply_body_proc_honours_explicit_lambda_namespace() {
         // A lambda pinning a namespace (element 2) runs its body there.

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -439,9 +439,6 @@ pub struct Analyser {
     /// as [`Self::var_command_sites`] but for ``[cmd] args``
     /// shapes.
     pub cmd_command_sites: Vec<CmdCommandSite>,
-    /// Cache: ``scope_path → namespace string`` for
-    /// ``namespace_from_scope``. Cleared on snapshot restore.
-    pub ns_cache: HashMap<Vec<usize>, String>,
     /// Namespaces where ``namespace ensemble create`` was seen —
     /// their tail names become valid commands.
     pub ensemble_namespaces: HashSet<String>,
@@ -911,7 +908,6 @@ impl Analyser {
             seed_scope_path: Vec::new(),
             widget_dispatch_sites: Vec::new(),
             cmd_command_sites: Vec::new(),
-            ns_cache: HashMap::new(),
             ensemble_namespaces: HashSet::new(),
             ensemble_command_maps: HashMap::new(),
             objdefined_vars: HashSet::new(),
@@ -1458,7 +1454,6 @@ impl Analyser {
         self.tk_possibly_active = super::tk_checks::tk_possibly_active(source, dialect);
         self.tk_dialect = dialect == "tk";
         self.unresolved_commands_emitted = false;
-        self.ns_cache.clear();
 
         let file_codes = super::utils::parse_file_suppression(source);
         for code in &file_codes {
@@ -1542,7 +1537,6 @@ impl Analyser {
         self.tk_possibly_active = super::tk_checks::tk_possibly_active(source, dialect);
         self.tk_dialect = dialect == "tk";
         self.unresolved_commands_emitted = false;
-        self.ns_cache.clear();
 
         let file_codes = super::utils::parse_file_suppression(source);
         for code in &file_codes {
@@ -2001,7 +1995,6 @@ mod tests {
         assert!(a.builtin_names.is_none());
         assert!(a.builtin_dialect.is_none());
         assert!(a.current_event.is_none());
-        assert!(a.ns_cache.is_empty());
         assert!(a.ensemble_namespaces.is_empty());
         assert!(a.objdefined_vars.is_empty());
         assert!(!a.unresolved_commands_emitted);

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -1091,7 +1091,7 @@ impl<'r> Lowerer<'r> {
             // `apply {{params} body ?ns?} …` — walk the braced body so nested
             // definitions register (like `namespace eval`), keeping the call a
             // runtime barrier because the body runs in a separate frame.
-            LoweringHookId::Apply => Some(self.lower_apply(seg, namespace)),
+            LoweringHookId::Apply => Some(self.lower_apply(seg)),
 
             // `array for {k v} arr body` (Tcl 9.0) — iterate array entries.
             // Like `apply`, the call stays a runtime barrier (C Tcl invokes
@@ -1913,7 +1913,7 @@ impl<'r> Lowerer<'r> {
         );
     }
 
-    fn lower_apply(&mut self, seg: &SegmentedCommand, namespace: &str) -> Statement {
+    fn lower_apply(&mut self, seg: &SegmentedCommand) -> Statement {
         use tcl_lexer::TokenType;
         let args = seg.args();
         let arg_tokens = seg.arg_tokens();
@@ -1947,12 +1947,15 @@ impl<'r> Lowerer<'r> {
         if let Some((body_text, body_offset)) = body_info {
             // `apply` evaluates the body in the namespace named by lambda element
             // 2, or the *global* namespace when it is absent — never the caller's
-            // namespace (Tcl `apply` manual). So a nested `proc` registers
-            // globally unless the lambda pins a namespace; a non-`::`-qualified
-            // pin resolves relative to the caller (as `TclGetNamespaceFromObj`).
+            // namespace. Element 2 is interpreted relative to the **global**
+            // namespace even when it does not start with `::` (`doc/apply.n`:
+            // "If given, namespace is interpreted relative to the global
+            // namespace even if its name does not start with ::"; `tclProc.c`
+            // `TclNRApplyObjCmd` `::`-prefixes the word before the lookup), so
+            // this must mirror the analyser's `handle_apply_command` exactly.
             let body_ns = match lambda_elems.get(2).map(|(_, t)| t.as_str()) {
                 Some(ns) if !ns.is_empty() && !ns.starts_with('$') && !ns.starts_with('[') => {
-                    join_namespace(namespace, ns)
+                    join_namespace("::", ns)
                 }
                 _ => "::".to_string(),
             };
@@ -3331,6 +3334,27 @@ mod tests {
         assert!(
             m.procedures.contains_key("::bar::helper"),
             "explicit lambda namespace must be honoured: {:?}",
+            m.procedures.keys().collect::<Vec<_>>()
+        );
+    }
+
+    /// TP — a relative lambda namespace element homes against the GLOBAL
+    /// namespace even from inside a qualified-name proc (`doc/apply.n`:
+    /// "interpreted relative to the global namespace even if its name does
+    /// not start with ::"; tclsh 9.0.4 probe `a2b_apply.tcl`). Mirrors the
+    /// analyser's `handle_apply_command` so IR and analysis agree.
+    #[test]
+    fn apply_relative_lambda_namespace_homes_globally_not_to_the_caller() {
+        let src = "proc ::caller::p {} { apply {{} { proc helper {} { return 1 } } sub} }\n";
+        let m = lower_to_ir(src, &reg());
+        assert!(
+            m.procedures.contains_key("::sub::helper"),
+            "relative lambda ns must resolve against ::: {:?}",
+            m.procedures.keys().collect::<Vec<_>>()
+        );
+        assert!(
+            !m.procedures.contains_key("::caller::sub::helper"),
+            "relative lambda ns must NOT pin against the caller: {:?}",
             m.procedures.keys().collect::<Vec<_>>()
         );
     }

--- a/rust/tcl-compiler/tests/differential_incremental.rs
+++ b/rust/tcl-compiler/tests/differential_incremental.rs
@@ -168,6 +168,40 @@ fn incremental_matches_fresh_for_apply_lambda_bodies() {
     }
 }
 
+/// Same parity guard for a **dynamically-named** `proc` — the tcllib pki
+/// idiom `proc [namespace current]::_x {...}` (tcllib 2.0
+/// `modules/pki/pki.tcl`:316) and its `$`-spelled cousins.  The `Scope` name
+/// these produce feeds `advance_command_resolution_namespace`, and the
+/// deferred (per-item) path builds its scope from `DeferredBody::scope_name`,
+/// so the two must derive it identically or the incremental walk homes the
+/// body's definitions in a different namespace from the full walk.
+#[test]
+fn incremental_matches_fresh_for_dynamically_named_procs() {
+    let dialect = "tcl8.6";
+    let sources = [
+        "namespace eval ::pki {\n  proc [namespace current]::_x {} { proc helper {} {} }\n}\n",
+        "namespace eval ::pki {\n  proc _outer {} {\n    proc [namespace current]::_x {} { proc helper {} { set v 1 } }\n  }\n}\n",
+        "set ns ::pki\nproc ${ns}::_x {} { proc helper {} {} }\n",
+        "namespace eval ::pki { proc _$suffix {} { proc helper {} {} } }\n",
+    ];
+    for src in sources {
+        let mut text = src.to_string();
+        let mut cur = segment_commands(&text);
+        for edit in ["", "\nset z 9\n", " "] {
+            let new_text = format!("{text}{edit}");
+            let inc = Analyser::new().analyse_incremental(&text, &cur, &new_text, dialect);
+            let fresh = Analyser::new().analyse(&new_text, dialect);
+            assert!(
+                inc == fresh,
+                "incremental != fresh for a dynamically-named proc:\n{}",
+                describe_analysis_divergence(src, &inc, &fresh)
+            );
+            text = new_text;
+            cur = segment_commands(&text);
+        }
+    }
+}
+
 #[test]
 #[ignore = "corpus fuzz; run explicitly with --ignored (needs tmp/ trees)"]
 fn incremental_matches_fresh_over_corpus() {

--- a/rust/tcl-dialect/src/lib.rs
+++ b/rust/tcl-dialect/src/lib.rs
@@ -51,7 +51,9 @@ pub use dialect_set::{DialectSet, KNOWN_DIALECTS, available_dialects};
 pub use grammar::{BracedVarStyle, LexerGrammar};
 pub use library::{LibraryPin, LibraryVersion, LibraryVersionOverrides, VersionKey};
 pub use profile::DialectProfile;
-pub use version::{TclVersion, Ternary, compare_versions, version_satisfies};
+pub use version::{
+    TclVersion, Ternary, compare_versions, requirement_names_patch_level, version_satisfies,
+};
 
 /// Crate version string.
 ///

--- a/rust/tcl-dialect/src/lib.rs
+++ b/rust/tcl-dialect/src/lib.rs
@@ -51,7 +51,7 @@ pub use dialect_set::{DialectSet, KNOWN_DIALECTS, available_dialects};
 pub use grammar::{BracedVarStyle, LexerGrammar};
 pub use library::{LibraryPin, LibraryVersion, LibraryVersionOverrides, VersionKey};
 pub use profile::DialectProfile;
-pub use version::{TclVersion, Ternary};
+pub use version::{TclVersion, Ternary, compare_versions, version_satisfies};
 
 /// Crate version string.
 ///

--- a/rust/tcl-dialect/src/version.rs
+++ b/rust/tcl-dialect/src/version.rs
@@ -78,6 +78,95 @@ impl TclVersion {
             _ => None,
         }
     }
+
+    /// The `major.minor` string this release reports as
+    /// `[package provide Tcl]`.
+    ///
+    /// The real interpreter reports a full patchlevel (`9.0.4`), but every
+    /// requirement form compares major-then-minor first, so the two-component
+    /// form answers identically for any requirement that does not name a patch
+    /// level — and the enum models no patch levels to name.
+    #[must_use]
+    pub fn version_string(self) -> &'static str {
+        match self {
+            Self::V8_4 => "8.4",
+            Self::V8_5 => "8.5",
+            Self::V8_6 => "8.6",
+            Self::V9_0 => "9.0",
+            Self::V9_1 => "9.1",
+        }
+    }
+
+    /// Does this release satisfy *any* of `requirements` — the answer
+    /// `package vsatisfies [package provide Tcl] REQ ?REQ …?` gives?
+    ///
+    /// An empty `requirements` list is `false`: real `package vsatisfies`
+    /// rejects it as a wrong-argument-count error, and no caller here has a
+    /// meaningful "satisfies nothing" question to ask.
+    #[must_use]
+    pub fn satisfies_any<S: AsRef<str>>(self, requirements: &[S]) -> bool {
+        requirements
+            .iter()
+            .any(|r| version_satisfies(self.version_string(), r.as_ref()))
+    }
+}
+
+/// Parse a dotted version into numeric components.
+fn version_components(v: &str) -> Vec<u64> {
+    v.split('.').map(|p| p.parse().unwrap_or(0)).collect()
+}
+
+/// Compare two dotted versions component-wise (missing components are 0).
+#[must_use]
+pub fn compare_versions(a: &str, b: &str) -> core::cmp::Ordering {
+    let (va, vb) = (version_components(a), version_components(b));
+    for i in 0..va.len().max(vb.len()) {
+        let x = va.get(i).copied().unwrap_or(0);
+        let y = vb.get(i).copied().unwrap_or(0);
+        match x.cmp(&y) {
+            core::cmp::Ordering::Equal => {}
+            other => return other,
+        }
+    }
+    core::cmp::Ordering::Equal
+}
+
+/// Does the concrete `version` satisfy one `package vsatisfies` requirement?
+///
+/// The three requirement forms Tcl accepts (`package(n)`, verified against
+/// `tclsh8.6` and `tclsh9.0`):
+///
+/// | Written  | Means            | `8.6` | `9.0` |
+/// |----------|------------------|-------|-------|
+/// | `8.5`    | `[8.5, 9)` — up to but excluding the *next major* | yes | no  |
+/// | `8.5-`   | `[8.5, ∞)`       | yes   | yes   |
+/// | `8.5-9.0`| `[8.5, 9.0)`     | yes   | no    |
+///
+/// This is the single implementation shared by the bytecode VM's `package
+/// vsatisfies` and the language server's `pkgIndex.tcl` guard evaluation, so
+/// the two can never disagree about what a guard means.
+#[must_use]
+pub fn version_satisfies(version: &str, requirement: &str) -> bool {
+    use core::cmp::Ordering;
+    let requirement = requirement.trim();
+    let (lo, hi) = if let Some((lo, hi)) = requirement.split_once('-') {
+        let hi = hi.trim();
+        (lo.trim(), (!hi.is_empty()).then(|| hi.to_owned()))
+    } else {
+        // Bare `X.Y` → the upper bound is the next major version.
+        let major = version_components(requirement)
+            .first()
+            .copied()
+            .unwrap_or(0);
+        (requirement, Some(format!("{}", major + 1)))
+    };
+    if compare_versions(version, lo) == Ordering::Less {
+        return false;
+    }
+    match hi {
+        Some(hi) => compare_versions(version, &hi) == Ordering::Less,
+        None => true,
+    }
 }
 
 /// A three-valued behaviour policy, so a non-Tcl profile (`f5-bigip`) and
@@ -157,5 +246,58 @@ mod tests {
         assert_eq!(Ternary::Yes.as_bool(), Some(true));
         assert_eq!(Ternary::No.as_bool(), Some(false));
         assert_eq!(Ternary::Inert.as_bool(), None);
+    }
+
+    /// Every row pinned against a live `package vsatisfies [package provide
+    /// Tcl] REQ` on `tclsh8.6` (8.6.14) and `tclsh9.0` (9.0.4).
+    #[test]
+    fn version_satisfies_matches_the_interpreter() {
+        use super::version_satisfies;
+        // Bare `X.Y` is bounded by the next *major*, not the next minor.
+        assert!(version_satisfies("8.6", "8.4"));
+        assert!(version_satisfies("8.6", "8.5"));
+        assert!(version_satisfies("8.6", "8.6"));
+        assert!(!version_satisfies("8.6", "9"));
+        assert!(!version_satisfies("9.0", "8.6"));
+        assert!(version_satisfies("9.0", "9"));
+        assert!(version_satisfies("9.0", "9.0"));
+        // Open-ended.
+        assert!(version_satisfies("8.6", "8.5-"));
+        assert!(version_satisfies("9.0", "8.5-"));
+        assert!(!version_satisfies("8.6", "9-"));
+        assert!(version_satisfies("9.0", "9-"));
+        // Explicit, half-open range.
+        assert!(version_satisfies("8.6", "8.5-9.0"));
+        assert!(!version_satisfies("9.0", "8.5-9.0"));
+        // Patch levels compare component-wise.
+        assert!(version_satisfies("8.5.2", "8.5-9.0"));
+    }
+
+    /// The tcllib `pkgIndex.tcl` head guard, both ways round.
+    #[test]
+    fn satisfies_any_is_the_multi_requirement_or() {
+        // `package vsatisfies [package provide Tcl] 8.5 9` — true on both.
+        assert!(TclVersion::V8_6.satisfies_any(&["8.5", "9"]));
+        assert!(TclVersion::V9_0.satisfies_any(&["8.5", "9"]));
+        // …but 8.4 satisfies neither requirement.
+        assert!(!TclVersion::V8_4.satisfies_any(&["8.5", "9"]));
+        // An empty requirement list is never satisfied.
+        assert!(!TclVersion::V9_0.satisfies_any::<&str>(&[]));
+    }
+
+    #[test]
+    fn version_string_round_trips_through_from_package_version() {
+        for v in [
+            TclVersion::V8_4,
+            TclVersion::V8_5,
+            TclVersion::V8_6,
+            TclVersion::V9_0,
+            TclVersion::V9_1,
+        ] {
+            assert_eq!(
+                TclVersion::from_package_version(v.version_string()),
+                Some(v)
+            );
+        }
     }
 }

--- a/rust/tcl-dialect/src/version.rs
+++ b/rust/tcl-dialect/src/version.rs
@@ -109,6 +109,61 @@ impl TclVersion {
             .iter()
             .any(|r| version_satisfies(self.version_string(), r.as_ref()))
     }
+
+    /// [`Self::satisfies_any`], but [`Ternary::Inert`] when the answer depends
+    /// on a **patch level** this enum does not model.
+    ///
+    /// `version_string` is `major.minor`, so a requirement naming a third
+    /// component is compared against `9.0` rather than the real `9.0.4`:
+    /// `vsatisfies 9.0.1-` reads as *unsatisfied* even though every shipped
+    /// 9.0 release from 9.0.1 on satisfies it.  That is the one direction that
+    /// turns into a false "this package cannot load" downstream, so a caller
+    /// that can abstain must, rather than take the wrong answer
+    /// ([`requirement_names_patch_level`]).
+    ///
+    /// The OR short-circuits exactly as `package vsatisfies` does: a
+    /// two-component requirement that *is* satisfied settles the whole test
+    /// [`Ternary::Yes`] however many patch-level requirements sit beside it.
+    /// Abstention is deliberately coarse — `9.0.1-` is undecidable even for a
+    /// target the `major.minor` comparison alone would settle (8.6 cannot
+    /// satisfy it) — because "conditional" is the safe direction and the
+    /// precision is not worth a second comparison rule.
+    #[must_use]
+    pub fn satisfies_any_ternary<S: AsRef<str>>(self, requirements: &[S]) -> Ternary {
+        let mut undecidable = false;
+        for requirement in requirements {
+            let requirement = requirement.as_ref();
+            if requirement_names_patch_level(requirement) {
+                undecidable = true;
+            } else if version_satisfies(self.version_string(), requirement) {
+                return Ternary::Yes;
+            }
+        }
+        if undecidable {
+            Ternary::Inert
+        } else {
+            Ternary::No
+        }
+    }
+}
+
+/// Whether a `package vsatisfies` requirement names a patch level — three or
+/// more dotted components in either bound (`9.0.1`, `9.0.1-`, `8.6-9.0.2`).
+///
+/// [`TclVersion`] models `major.minor` releases only, so such a requirement
+/// cannot be evaluated against it faithfully; see
+/// [`TclVersion::satisfies_any_ternary`].
+#[must_use]
+pub fn requirement_names_patch_level(requirement: &str) -> bool {
+    let requirement = requirement.trim();
+    let (lo, hi) = match requirement.split_once('-') {
+        Some((lo, hi)) => (lo.trim(), hi.trim()),
+        None => (requirement, ""),
+    };
+    [lo, hi]
+        .into_iter()
+        .filter(|bound| !bound.is_empty())
+        .any(|bound| bound.split('.').count() >= 3)
 }
 
 /// Parse a dotted version into numeric components.
@@ -184,6 +239,14 @@ pub enum Ternary {
     /// No opinion — the profile is not a Tcl runtime, or is the permissive
     /// unknown-dialect sink. Validators and const-folders abstain.
     Inert,
+}
+
+impl From<bool> for Ternary {
+    /// A decided boolean as a [`Ternary`] — the inverse of
+    /// [`Ternary::as_bool`], never producing [`Ternary::Inert`].
+    fn from(value: bool) -> Self {
+        if value { Self::Yes } else { Self::No }
+    }
 }
 
 impl Ternary {
@@ -283,6 +346,54 @@ mod tests {
         assert!(!TclVersion::V8_4.satisfies_any(&["8.5", "9"]));
         // An empty requirement list is never satisfied.
         assert!(!TclVersion::V9_0.satisfies_any::<&str>(&[]));
+    }
+
+    /// A requirement naming a patch level is undecidable against a
+    /// `major.minor`-only release model.
+    ///
+    /// Oracle (`tclsh9.0`, `[package provide Tcl]` = 9.0.4):
+    /// `vsatisfies 9.0.4 9.0.1` = 1, `vsatisfies 9.0.4 9.0.1-` = 1,
+    /// `vsatisfies 9.0.4 9.0.9-` = 0 — two shipped 9.0 releases disagree, so
+    /// the honest answer for the enum's `9.0` is neither.
+    #[test]
+    fn a_patch_level_requirement_is_undecidable() {
+        for requirement in ["9.0.1", "9.0.1-", "9.0-9.0.2", "8.6.0"] {
+            assert!(
+                super::requirement_names_patch_level(requirement),
+                "{requirement}"
+            );
+            assert_eq!(
+                TclVersion::V9_0.satisfies_any_ternary(&[requirement]),
+                Ternary::Inert,
+                "{requirement}"
+            );
+        }
+    }
+
+    /// TN — every two-component requirement form still decides, and the OR
+    /// short-circuits on a satisfied one beside an undecidable one.
+    #[test]
+    fn two_component_requirements_still_decide() {
+        for requirement in ["8.5", "8.5-", "8.5-9.0", "9-", "9"] {
+            assert!(
+                !super::requirement_names_patch_level(requirement),
+                "{requirement}"
+            );
+            assert_ne!(
+                TclVersion::V9_0.satisfies_any_ternary(&[requirement]),
+                Ternary::Inert,
+                "{requirement}"
+            );
+        }
+        assert_eq!(
+            TclVersion::V9_0.satisfies_any_ternary(&["9.0.1", "9"]),
+            Ternary::Yes,
+        );
+        assert_eq!(
+            TclVersion::V8_6.satisfies_any_ternary(&["9.0.1", "9"]),
+            Ternary::Inert,
+        );
+        assert_eq!(TclVersion::V8_6.satisfies_any_ternary(&["9"]), Ternary::No);
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -153,6 +153,34 @@ pub fn hover(
     )
 }
 
+/// Render the hover body for a proc or class that lives in **another**
+/// document, identified by its qualified name.
+///
+/// `defining_analysis` is the analyser result for the document the symbol is
+/// declared in — the same result an in-document hover there would use, so the
+/// rendering is identical whichever file the cursor is in (issue #1018).
+/// Class hover in particular reads superclass and mixin methods out of that
+/// analysis, which is why the *defining* file's result is required rather than
+/// the caller's.
+///
+/// `qualified` is the absolute name (`::math::zzqfrobnicate`); a proc is
+/// preferred over a class of the same name, matching go-to-definition's own
+/// ordering. Returns `None` when the name names neither.
+#[must_use]
+pub fn qualified_symbol_hover(
+    defining_analysis: &AnalysisResult,
+    qualified: &str,
+) -> Option<Hover> {
+    if let Some(proc_def) = defining_analysis.all_procs.get(qualified) {
+        return Some(Hover::markdown(proc_hover_text(proc_def)));
+    }
+    let class_def = defining_analysis.all_classes.get(qualified)?;
+    Some(Hover::markdown(class_hover_text(
+        defining_analysis,
+        class_def,
+    )))
+}
+
 /// `<ensemble> <subcommand>` hover — a static `namespace ensemble create
 /// -map`/`-subcommands` mapping (issue #923 idx 106), the hover twin of
 /// `definition()`'s identical check. Extracted from
@@ -3561,6 +3589,37 @@ mod tests {
         let proc_def = analysis.all_procs.values().next().unwrap();
         let text = proc_hover_text(proc_def);
         assert!(text.contains("{name world}"), "got: {text}");
+    }
+
+    /// Issue #1018: the cross-document renderer answers by qualified name and
+    /// produces the *same* body the in-document path does, for both a proc and
+    /// a class — one renderer, so a call-site hover in another file can never
+    /// drift from the declaration's own.
+    #[test]
+    fn qualified_symbol_hover_matches_the_in_document_rendering_1018() {
+        let src = "proc ::math::zzqfrobnicate {val args} { return $val }\noo::class create ::geo::Plane {\n    method fly {} {}\n}\n";
+        let analysis = analyse(src);
+
+        let proc_hover =
+            qualified_symbol_hover(&analysis, "::math::zzqfrobnicate").expect("proc hover");
+        assert_eq!(
+            proc_hover.value,
+            proc_hover_text(&analysis.all_procs["::math::zzqfrobnicate"]),
+        );
+        assert!(proc_hover.value.contains("val"), "{proc_hover:?}");
+
+        let class_hover = qualified_symbol_hover(&analysis, "::geo::Plane").expect("class hover");
+        assert_eq!(
+            class_hover.value,
+            class_hover_text(&analysis, &analysis.all_classes["::geo::Plane"]),
+        );
+
+        // A name neither map holds resolves to nothing — the fallback never
+        // invents a symbol.
+        assert!(qualified_symbol_hover(&analysis, "::math::nosuchthing").is_none());
+        // The lookup is by *qualified* name only; a bare tail is not a match,
+        // so a same-tailed proc in an unrelated namespace cannot be picked up.
+        assert!(qualified_symbol_hover(&analysis, "zzqfrobnicate").is_none());
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/package_resolver.rs
+++ b/rust/tcl-lsp-core/src/package_resolver.rs
@@ -74,6 +74,26 @@ pub struct PackageInfo {
     pub source_files: Vec<PathBuf>,
     /// The `pkgIndex.tcl` that declared this entry.
     pub pkg_index_path: PathBuf,
+    /// What must hold for the interpreter to reach this declaration at all —
+    /// empty for the ordinary unguarded index file.  See
+    /// [`reachability`] for the guard shapes modelled.
+    pub conditions: reachability::Conditions,
+}
+
+impl PackageInfo {
+    /// Whether a Tcl release running this index registers the declaration.
+    ///
+    /// `target` is the release the workspace targets; `None` (an unversioned
+    /// `tcl` dialect, or a non-Tcl one) leaves every version guard undecided,
+    /// so a guarded entry reports [`reachability::Availability::Conditional`]
+    /// rather than being guessed either way.
+    #[must_use]
+    pub fn availability(
+        &self,
+        target: Option<tcl_dialect::TclVersion>,
+    ) -> reachability::Availability {
+        self.conditions.availability(target)
+    }
 }
 
 /// One `proc → file` mapping from a `tclIndex` auto-load index.
@@ -95,7 +115,7 @@ pub struct AutoIndexEntry {
 /// non-separator tokens between `Sep` / `Eol` boundaries (so `a$b[c]` is one
 /// word). `{*}` expansion markers and comments are word/command boundaries,
 /// matching `resolver.py::_walk_command_words`.
-fn walk_command_words(text: &str) -> Vec<Vec<Vec<Token>>> {
+pub(super) fn walk_command_words(text: &str) -> Vec<Vec<Vec<Token>>> {
     let tokens = Lexer::new(text).tokenise_all().unwrap_or_default();
     let mut commands: Vec<Vec<Vec<Token>>> = Vec::new();
     let mut words: Vec<Vec<Token>> = Vec::new();
@@ -134,7 +154,7 @@ fn walk_command_words(text: &str) -> Vec<Vec<Vec<Token>>> {
 /// For a `[...]` command-substitution word the lexer's `Cmd` token excludes
 /// the closing `]` from its span, so this returns `[list …` (no trailing
 /// bracket) — exactly as `resolver.py::_word_raw` did.
-fn word_raw<'t>(text: &'t str, word: &[Token]) -> &'t str {
+pub(super) fn word_raw<'t>(text: &'t str, word: &[Token]) -> &'t str {
     let start = word[0].span.start() as usize;
     let end = word[word.len() - 1].span.end() as usize;
     text.get(start..end).unwrap_or("")
@@ -143,7 +163,7 @@ fn word_raw<'t>(text: &'t str, word: &[Token]) -> &'t str {
 /// The inner script text of `word` if it is a single wrapper word
 /// (`[...]` command substitution, `{...}` braced literal, or `"..."` quoted
 /// word); `None` for a bare word. Mirrors `resolver.py::_word_unwrap`.
-fn word_unwrap(text: &str, word: &[Token]) -> Option<String> {
+pub(super) fn word_unwrap(text: &str, word: &[Token]) -> Option<String> {
     if word.len() == 1 {
         let tok = word[0];
         if matches!(tok.kind, TokenType::Cmd | TokenType::Str) {
@@ -225,7 +245,6 @@ fn source_filename(text: &str, arg: &[Token]) -> Option<String> {
     None
 }
 
-/// Walk `commands` collecting `source <arg>` targets that exist under
 /// Cap on `[...]`/`{...}`/`"..."` wrapper-word nesting depth
 /// [`collect_source_targets`] will descend into — pathologically deep
 /// nesting in a `pkgIndex.tcl` `package ifneeded` body could otherwise
@@ -234,6 +253,7 @@ fn source_filename(text: &str, arg: &[Token]) -> Option<String> {
 const MAX_SOURCE_TARGET_SCAN_DEPTH: tcl_core_types::RecursionLimit =
     tcl_core_types::RecursionLimit(256);
 
+/// Walk `commands` collecting `source <arg>` targets that exist under
 /// `pkg_dir` (per `exists`), descending into `[...]` / `{...}` / `"..."`
 /// wrapper words. Mirrors `resolver.py::_collect_source_targets`.
 ///
@@ -316,6 +336,13 @@ fn is_version_word(word: &str) -> bool {
 /// (other than `pkgIndex.tcl`) reported by `list_tcl_files` — matching C
 /// Tcl-era `pkg_mkIndex` output, where the index always sources concrete
 /// files but hand-written indices sometimes don't.
+///
+/// Declarations are found through the [`reachability`] scan, so a declaration
+/// nested inside an `if` branch is found (the TEA "pick a Tcl 8 or Tcl 9
+/// library" shape) and each one carries the guard conditions standing in
+/// front of it. Nothing is filtered here: a caller that targets a specific
+/// Tcl release asks [`PackageInfo::availability`], and one that does not
+/// (go-to-definition, which is deliberately permissive) ignores the field.
 pub fn parse_pkg_index(
     content: &str,
     pkg_dir: &Path,
@@ -323,23 +350,31 @@ pub fn parse_pkg_index(
     exists: &dyn Fn(&Path) -> bool,
     list_tcl_files: &dyn Fn(&Path) -> Vec<PathBuf>,
 ) -> Vec<PackageInfo> {
+    // A `pkgIndex.tcl` is plain Tcl whatever dialect the workspace's own
+    // documents are in — `tclPkgUnknown` sources it in the ordinary
+    // interpreter — so the guard vocabulary (`package`, `if`, `return`) comes
+    // from the core registry, not the document's.  The lookup is cached and
+    // returns a `&'static`, so this costs nothing per file.
+    let registry = tcl_registry::registry_for_dialect("tcl");
     let mut out = Vec::new();
-    for words in walk_command_words(content) {
+    reachability::scan(content, registry, &mut |reached| {
+        let reachability::Reached {
+            text,
+            words,
+            conditions,
+        } = reached;
         if words.len() < 5 {
-            continue;
+            return;
         }
-        if word_raw(content, &words[0]) != "package" || word_raw(content, &words[1]) != "ifneeded" {
-            continue;
-        }
-        let name = word_raw(content, &words[2]);
-        let version = word_raw(content, &words[3]);
+        let name = word_raw(text, &words[2]);
+        let version = word_raw(text, &words[3]);
         if !is_version_word(version) {
-            continue;
+            return;
         }
         let body = &words[4..];
         let mut source_files = Vec::new();
         collect_source_targets(
-            content,
+            text,
             &[body.to_vec()],
             pkg_dir,
             exists,
@@ -359,9 +394,10 @@ pub fn parse_pkg_index(
                 version: version.to_owned(),
                 source_files,
                 pkg_index_path: pkg_index_path.to_owned(),
+                conditions,
             });
         }
-    }
+    });
     out
 }
 
@@ -843,15 +879,41 @@ impl PackageResolver {
     pub fn package_defined_commands(
         &self,
         available: &[String],
+        target: Option<tcl_dialect::TclVersion>,
         defined_commands: &dyn Fn(&Path) -> Vec<String>,
     ) -> HashSet<String> {
         let mut out = HashSet::new();
         for pkg in available {
-            for file in self.resolve(pkg, None) {
+            for file in self.reachable_files(pkg, target) {
                 out.extend(defined_commands(&file));
             }
         }
         out
+    }
+
+    /// The implementation files of `name` that a Tcl release `target` would
+    /// actually load, skipping any `package ifneeded` its `pkgIndex.tcl`
+    /// guards out ([`reachability`]).
+    ///
+    /// A declaration whose guards cannot be decided
+    /// ([`reachability::Availability::Conditional`]) counts as loadable: the
+    /// scan does not know it *won't* run, and treating "unsure" as "absent"
+    /// would resurrect exactly the false unknown-command reports this
+    /// modelling exists to remove (issue #923 idx 42).
+    #[must_use]
+    pub fn reachable_files(
+        &self,
+        name: &str,
+        target: Option<tcl_dialect::TclVersion>,
+    ) -> Vec<PathBuf> {
+        let Some(infos) = self.packages.get(name) else {
+            return Vec::new();
+        };
+        infos
+            .iter()
+            .filter(|i| i.availability(target) != reachability::Availability::Unavailable)
+            .flat_map(|i| i.source_files.iter().cloned())
+            .collect()
     }
 }
 
@@ -868,6 +930,8 @@ fn list_tcl_files(dir: &Path) -> Vec<PathBuf> {
     }
     files
 }
+
+pub mod reachability;
 
 #[cfg(test)]
 mod tests;

--- a/rust/tcl-lsp-core/src/package_resolver/reachability.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/reachability.rs
@@ -135,13 +135,16 @@ impl Condition {
                 requirements,
                 expect,
             } => match target {
-                Some(v) => {
-                    if v.satisfies_any(requirements) == *expect {
-                        Ternary::Yes
-                    } else {
-                        Ternary::No
-                    }
-                }
+                // A requirement naming a patch level (`9.0.1`, `9.0.1-`)
+                // cannot be evaluated against the two-component release model
+                // and comes back `Inert` — the one direction that would
+                // otherwise make a real 9.0.4 look like it fails its own
+                // guard, and so fire a false W123 on the package's commands.
+                Some(v) => match v.satisfies_any_ternary(requirements) {
+                    Ternary::Yes => Ternary::from(*expect),
+                    Ternary::No => Ternary::from(!*expect),
+                    Ternary::Inert => Ternary::Inert,
+                },
                 None => Ternary::Inert,
             },
             Self::Undecidable => Ternary::Inert,

--- a/rust/tcl-lsp-core/src/package_resolver/reachability.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/reachability.rs
@@ -67,13 +67,28 @@
 //!   `error`, `throw`, `exit`) ends the script — `tclPkgUnknown` sources the
 //!   index inside a `catch`, so a raise stops registration just as a `return`
 //!   does;
-//! * `if` / `elseif` / `else` chains, with the clause structure taken from the
-//!   registry's own `if` grammar ([`ArgRole::Expr`] / [`ArgRole::Body`]), so
-//!   `then` noise words and implicit else-bodies are handled without this
-//!   module re-deriving the grammar;
+//! * `if` / `elseif` / `else` chains, **symbolically**: each clause's guard
+//!   becomes a [`Condition`], the clause structure comes from the registry's
+//!   own `if` grammar ([`ArgRole::Expr`] / [`ArgRole::Body`]), and a branch
+//!   that terminates gates everything after the chain under the negated guard.
+//!   That last step is what makes the `if {GUARD} {return}` index head work,
+//!   and it is why only `if` may go through [`walk_if`]: `while` / `for` /
+//!   `foreach` have `Expr` and `Body` arguments too, so reading one as a clause
+//!   chain would treat `for {set i 0} {$i < $n} {incr i} {…}` as "if `$i < $n`
+//!   then `incr i`, else `…`" and gate the loop body behind a *negated* guard —
+//!   a false [`Condition::Impossible`] for anything declared in it.  The
+//!   load-bearing distinction is not "loops are not modelled" but
+//!   `spec.arg_role_resolver.is_some()`: `if`'s roles are computed from the
+//!   actual clause words by a resolver, while the loops carry fixed
+//!   `arg_roles`.
 //! * conditions that are a constant boolean (`1`, `0`, `true`, `no`, …) or a
 //!   `package vsatisfies [package provide Tcl] REQ …` test, optionally negated
 //!   with `!`.
+//! * every **other** body-taking command's script regions ([`ArgRole::Body`]
+//!   and `apply`'s [`ArgRole::LambdaLiteral`]) — visited, but under
+//!   [`Condition::Undecidable`], since this scan models neither whether nor how
+//!   often such a body runs.  Visiting them is not optional: Tcl 9 declares its
+//!   own core packages from inside `apply {{dir} { … foreach … }} $dir`.
 //!
 //! Deliberately **not** modelled — each yields [`Condition::Undecidable`], so
 //! the registration is reported as merely *conditional* rather than guessed
@@ -81,12 +96,17 @@
 //!
 //! * any other expression (`$::tcl_platform(platform) eq "windows"`,
 //!   `[file exists …]`, arithmetic, `&&` / `||` of two guards);
-//! * loops (`while`, `for`, `foreach`) — a `return` inside one is treated as
-//!   "may terminate", never "does terminate";
-//! * `catch`, `uplevel`, `eval`, and any other command that runs a script
-//!   argument;
+//! * which iterations of a loop run, or whether a `catch` / `eval` /
+//!   `namespace eval` / `apply` body runs at all — the body is walked, but
+//!   everything found in it is conditional, and a `return` inside one is
+//!   treated as "may terminate", never "does terminate";
 //! * a guard whose two branches disagree about terminating in a way that
-//!   cannot be written as one negated condition.
+//!   cannot be written as one negated condition;
+//! * a declaration whose *name* or *version* word is a substitution — Tcl 9's
+//!   own index writes `package ifneeded $package $version …` inside a
+//!   `foreach` over a literal list, and this scan reports the declaration but
+//!   does not evaluate the loop, so [`super::parse_pkg_index`] still cannot
+//!   name it.
 //!
 //! Nothing here is a *decision* about diagnostics — it reports availability,
 //! and the caller decides what to do with `Conditional`.
@@ -332,8 +352,74 @@ fn walk_script<'t>(
         {
             reached = reached.with(Condition::Undecidable);
         }
+        // Declarations *inside* that body still have to be found.  Every
+        // body-taking command's script regions are visited under
+        // [`Condition::Undecidable`]: this scan cannot say whether — or how
+        // many times — the body runs, and "conditional" is the safe direction
+        // (a conditional registration counts as loadable downstream, so a
+        // package whose commands really are there draws no false W123).
+        //
+        // Not looking at all was the defect: Tcl 9 ships its own core-package
+        // index as `apply {{dir} { … foreach … { package ifneeded … } }} $dir`
+        // (`library/pkgIndex.tcl` in the zipfs `tcl_library`), so a tcl9.0
+        // workspace saw http / msgcat / tcltest / platform / cookiejar declare
+        // nothing whatsoever.
+        for body in body_scripts(text, words, head, registry) {
+            walk_script(
+                &body,
+                registry,
+                &reached.with(Condition::Undecidable),
+                depth + 1,
+                visit,
+            );
+        }
     }
     Some(reached)
+}
+
+/// The script text of every body-role region of one command.
+///
+/// Both script-bearing argument roles, taken from the registry so no command
+/// name appears here:
+///
+/// * [`ArgRole::Body`] — the argument *is* the script (`foreach`'s body,
+///   `namespace eval`'s block, `catch`'s script, `eval`'s argument).
+/// * [`ArgRole::LambdaLiteral`] — the argument is `apply`'s
+///   `{params} {body} ?ns?` **list**, one word containing the script one level
+///   down.  Split with the shared
+///   [`tcl_compiler::lambda_literal`] splitter rather than re-deriving the
+///   shape; the decoded variant is the one documented for consumers that need
+///   the script text and report no spans back into it, so a bare or quoted
+///   body element's escapes collapse exactly as `apply` collapses them.
+///
+/// An `if` chain never reaches here — [`walk_if`] models its clauses
+/// symbolically and the caller continues past it.
+fn body_scripts(
+    text: &str,
+    words: &[Vec<Token>],
+    head: &str,
+    registry: &CommandRegistry,
+) -> Vec<String> {
+    let args: Vec<&str> = words[1..].iter().map(|w| word_raw(text, w)).collect();
+    let mut out: Vec<String> = registry
+        .arg_indices_for_role(head, &args, ArgRole::Body)
+        .into_iter()
+        .filter_map(|i| words[1..].get(i))
+        .map(|word| script_of(text, word))
+        .collect();
+    for index in registry.arg_indices_for_role(head, &args, ArgRole::LambdaLiteral) {
+        // A statically-splittable lambda is a single braced word; a `$var` /
+        // `[cmd]` lambda has nothing to walk and is skipped.
+        let Some([token]) = words[1..].get(index).map(Vec::as_slice) else {
+            continue;
+        };
+        if let Some(body) = tcl_compiler::lambda_literal::split_lambda_literal_decoded(text, *token)
+            .and_then(|elements| elements.body)
+        {
+            out.push(body.into_owned());
+        }
+    }
+    out
 }
 
 /// Whether any [`ArgRole::Body`] argument of this command contains a

--- a/rust/tcl-lsp-core/src/package_resolver/reachability.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/reachability.rs
@@ -1,0 +1,663 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Which `package ifneeded` declarations in a `pkgIndex.tcl` a given Tcl
+//! release actually runs.
+//!
+//! # Why a `pkgIndex.tcl` needs control flow at all
+//!
+//! `tclPkgUnknown` sources every `pkgIndex.tcl` on `$auto_path` in a frame
+//! where `$dir` names the package directory.  Real index files are therefore
+//! ordinary scripts, and the ones shipped with tcllib, Tk, and every TEA-built
+//! C extension use two guard idioms to keep a package off the wrong Tcl
+//! release:
+//!
+//! **Early return.**  Everything below the guard is skipped:
+//!
+//! ```tcl
+//! if {![package vsatisfies [package provide Tcl] 8.5 9]} {return}
+//! package ifneeded log 1.5 [list source [file join $dir log.tcl]]
+//! ```
+//!
+//! That is the head of 95 of tcllib 2.0's own `pkgIndex.tcl` files.  Reading
+//! the `package ifneeded` without the guard claims `log` is available on Tcl
+//! 8.4, where `package require log` really fails (issue #1017).
+//!
+//! **Branch selection.**  The declaration lives *inside* a branch:
+//!
+//! ```tcl
+//! if {[package vsatisfies [package provide Tcl] 9.0-]} {
+//!     package ifneeded tclopt 0.4 [list source [file join $dir tclopt.tcl]]
+//! } else {
+//!     package ifneeded tclopt 0.4 [list source [file join $dir tclopt.tcl]]
+//! }
+//! ```
+//!
+//! That is the standard TEA shape for picking a Tcl-8 or Tcl-9 shared
+//! library.  Reading only *top-level* commands misses it entirely and the
+//! package looks nonexistent, so its commands draw a false "unknown command"
+//! (issue #923 idx 42) — the same mechanism, the opposite error.
+//!
+//! # What this module models
+//!
+//! [`scan`] walks a `pkgIndex.tcl` and reports each `package ifneeded` it
+//! finds together with the [`Condition`]s that must hold for the interpreter
+//! to reach it.  Conditions stay **symbolic**: the scan runs once, when the
+//! `auto_path` is indexed, and each consumer evaluates the result against
+//! whatever Tcl release *it* targets ([`Conditions::availability`]).
+//!
+//! Modelled:
+//!
+//! * any command the registry marks [`Traits::TERMINATES_BLOCK`] (`return`,
+//!   `error`, `throw`, `exit`) ends the script — `tclPkgUnknown` sources the
+//!   index inside a `catch`, so a raise stops registration just as a `return`
+//!   does;
+//! * `if` / `elseif` / `else` chains, with the clause structure taken from the
+//!   registry's own `if` grammar ([`ArgRole::Expr`] / [`ArgRole::Body`]), so
+//!   `then` noise words and implicit else-bodies are handled without this
+//!   module re-deriving the grammar;
+//! * conditions that are a constant boolean (`1`, `0`, `true`, `no`, …) or a
+//!   `package vsatisfies [package provide Tcl] REQ …` test, optionally negated
+//!   with `!`.
+//!
+//! Deliberately **not** modelled — each yields [`Condition::Undecidable`], so
+//! the registration is reported as merely *conditional* rather than guessed
+//! either way:
+//!
+//! * any other expression (`$::tcl_platform(platform) eq "windows"`,
+//!   `[file exists …]`, arithmetic, `&&` / `||` of two guards);
+//! * loops (`while`, `for`, `foreach`) — a `return` inside one is treated as
+//!   "may terminate", never "does terminate";
+//! * `catch`, `uplevel`, `eval`, and any other command that runs a script
+//!   argument;
+//! * a guard whose two branches disagree about terminating in a way that
+//!   cannot be written as one negated condition.
+//!
+//! Nothing here is a *decision* about diagnostics — it reports availability,
+//! and the caller decides what to do with `Conditional`.
+
+use tcl_dialect::{TclVersion, Ternary};
+use tcl_lexer::{Token, TokenType};
+use tcl_registry::{CommandRegistry, Traits, arg_role::ArgRole};
+
+use super::{walk_command_words, word_raw, word_unwrap};
+
+/// Cap on `if`-body nesting this scan descends through.  A `pkgIndex.tcl` is
+/// machine-generated or hand-written boilerplate; nothing real nests deeply,
+/// and the limit keeps a pathological file from exhausting the native stack
+/// while the workspace indexer walks it.  See
+/// `docs/design/compiler/recursive-descent-depth-limits.md`.
+const MAX_GUARD_NESTING_DEPTH: tcl_core_types::RecursionLimit = tcl_core_types::RecursionLimit(32);
+
+/// One condition that must hold for a `package ifneeded` to be reached.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Condition {
+    /// `package vsatisfies [package provide Tcl] REQ …` must evaluate to
+    /// `expect`.  `requirements` are the requirement words as written
+    /// (`"8.5"`, `"9-"`, `"8.5-9.0"`).
+    TclSatisfies {
+        /// The requirement words; the test passes when the running release
+        /// satisfies **any** of them, as `package vsatisfies` does.
+        requirements: Vec<String>,
+        /// The value the test must take for the registration to be reached.
+        expect: bool,
+    },
+    /// The guard is real but this scan cannot evaluate it.
+    Undecidable,
+    /// The registration is unreachable on every Tcl release — it sits after
+    /// an unconditional terminator, or inside a constant-false branch.
+    Impossible,
+}
+
+impl Condition {
+    /// Evaluate this condition for a target release, or [`Ternary::Inert`]
+    /// when it cannot be decided (including when the target release itself is
+    /// unknown — an unversioned `tcl` or a non-Tcl dialect).
+    #[must_use]
+    fn holds(&self, target: Option<TclVersion>) -> Ternary {
+        match self {
+            Self::TclSatisfies {
+                requirements,
+                expect,
+            } => match target {
+                Some(v) => {
+                    if v.satisfies_any(requirements) == *expect {
+                        Ternary::Yes
+                    } else {
+                        Ternary::No
+                    }
+                }
+                None => Ternary::Inert,
+            },
+            Self::Undecidable => Ternary::Inert,
+            Self::Impossible => Ternary::No,
+        }
+    }
+
+    /// This condition with its sense flipped, or `None` when the negation is
+    /// not expressible as a single condition.
+    #[must_use]
+    fn negated(&self) -> Option<Self> {
+        match self {
+            Self::TclSatisfies {
+                requirements,
+                expect,
+            } => Some(Self::TclSatisfies {
+                requirements: requirements.clone(),
+                expect: !*expect,
+            }),
+            // "Cannot decide" negates to "cannot decide".
+            Self::Undecidable => Some(Self::Undecidable),
+            // "Never" negates to "always" — no condition at all.
+            Self::Impossible => None,
+        }
+    }
+}
+
+/// How certainly a `package ifneeded` runs under a given Tcl release.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Availability {
+    /// Every guard between the top of the index and this declaration was
+    /// evaluated and lets it through.
+    Available,
+    /// At least one guard could not be decided.  The declaration may or may
+    /// not run; nothing here says which.
+    Conditional,
+    /// A guard was evaluated and definitely skips this declaration.
+    Unavailable,
+}
+
+/// The conjunction of conditions guarding one `package ifneeded`.
+///
+/// Empty means "reached unconditionally" — the common, unguarded index file.
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct Conditions(Vec<Condition>);
+
+impl Conditions {
+    /// Whether a Tcl release running this index reaches the declaration.
+    ///
+    /// One definitely-false condition makes it [`Availability::Unavailable`],
+    /// whatever the others say; otherwise one undecidable condition makes it
+    /// [`Availability::Conditional`].
+    #[must_use]
+    pub fn availability(&self, target: Option<TclVersion>) -> Availability {
+        let mut undecided = false;
+        for condition in &self.0 {
+            match condition.holds(target) {
+                Ternary::No => return Availability::Unavailable,
+                Ternary::Inert => undecided = true,
+                Ternary::Yes => {}
+            }
+        }
+        if undecided {
+            Availability::Conditional
+        } else {
+            Availability::Available
+        }
+    }
+
+    /// Whether any guard at all stands in front of the declaration.
+    #[must_use]
+    pub fn is_unconditional(&self) -> bool {
+        self.0.is_empty()
+    }
+
+    fn with(&self, extra: Condition) -> Self {
+        let mut out = self.0.clone();
+        out.push(extra);
+        Self(out)
+    }
+}
+
+/// One `package ifneeded` declaration the scan reached, in the script text it
+/// was written in.
+pub struct Reached<'t> {
+    /// The script the declaration's tokens index into — the whole index file
+    /// for a top-level declaration, or an `if` body's inner text.
+    pub text: &'t str,
+    /// The declaration's words, `package` first.
+    pub words: &'t [Vec<Token>],
+    /// What must hold for the interpreter to run it.
+    pub conditions: Conditions,
+}
+
+/// Walk `content`, calling `visit` once per `package ifneeded` declaration
+/// reachable on *some* Tcl release, with the conditions guarding it.
+///
+/// A declaration under a constant-false guard is still visited, carrying
+/// [`Condition::Impossible`]: reporting it lets a consumer distinguish "this
+/// index does not mention the package" from "this index mentions it but can
+/// never register it".
+pub fn scan(content: &str, registry: &CommandRegistry, visit: &mut dyn FnMut(Reached<'_>)) {
+    walk_script(content, registry, &Conditions::default(), 0, visit);
+}
+
+/// Whether `words` registers a deferred package-load script — `package
+/// ifneeded NAME VERSION SCRIPT`.
+///
+/// Identified from registry data, not by name: the subcommand is resolved
+/// through the registry (so an unambiguous abbreviation — `package ifn` — is
+/// recognised exactly as the interpreter recognises it), and it qualifies when
+/// it both declares [`Traits::PROVIDES_PACKAGE`] ("running this makes a
+/// package available") and takes a [`ArgRole::Body`] script argument ("…via a
+/// script evaluated later").  `package provide` carries the trait but takes no
+/// script, so the pair picks out `ifneeded` alone.
+fn is_package_ifneeded(text: &str, words: &[Vec<Token>], registry: &CommandRegistry) -> bool {
+    if words.len() < 2 {
+        return false;
+    }
+    let head = word_raw(text, &words[0]).trim_start_matches("::");
+    let Some(spec) = registry.get(head) else {
+        return false;
+    };
+    spec.resolve_subcommand(word_raw(text, &words[1]))
+        .is_some_and(|sub| {
+            sub.traits.contains(Traits::PROVIDES_PACKAGE)
+                && sub.arg_roles.iter().any(|(_, role)| *role == ArgRole::Body)
+        })
+}
+
+/// Walk one script level in order.
+///
+/// Returns the conditions under which control reaches the *end* of the script,
+/// or `None` when it never does (an unconditional terminator).
+fn walk_script<'t>(
+    text: &'t str,
+    registry: &CommandRegistry,
+    reached: &Conditions,
+    depth: u32,
+    visit: &mut dyn FnMut(Reached<'_>),
+) -> Option<Conditions> {
+    if MAX_GUARD_NESTING_DEPTH.exceeded(depth) {
+        return Some(reached.with(Condition::Undecidable));
+    }
+    let commands = walk_command_words(text);
+    let mut reached = reached.clone();
+    for words in &commands {
+        if words.is_empty() {
+            continue;
+        }
+        if is_package_ifneeded(text, words, registry) {
+            visit(Reached {
+                text,
+                words,
+                conditions: reached.clone(),
+            });
+            continue;
+        }
+        let head = word_raw(text, &words[0]).trim_start_matches("::");
+        let Some(spec) = registry.get(head) else {
+            continue;
+        };
+        if spec.traits.contains(Traits::TERMINATES_BLOCK) {
+            return None;
+        }
+        if spec.traits.contains(Traits::HAS_BOOLEAN_COND) && spec.arg_role_resolver.is_some() {
+            match walk_if(text, words, head, registry, &reached, depth, visit) {
+                AfterIf::Stops => return None,
+                AfterIf::Continues(after) => {
+                    reached = after;
+                    continue;
+                }
+                AfterIf::NotAChain => {}
+            }
+        }
+        // Any *other* control-flow command (a loop, `switch`, `catch`, `try`)
+        // may or may not run its body, and this scan does not model how many
+        // times or under what condition.  If a body could terminate the
+        // script, everything below becomes undecidable rather than being
+        // claimed unconditional.  A body that cannot terminate — and the
+        // bodies of non-control-flow commands such as `proc`, whose `return`
+        // belongs to the procedure, not to this script — changes nothing.
+        if spec.traits.contains(Traits::CONTROL_FLOW)
+            && command_body_may_terminate(text, words, head, registry, depth)
+        {
+            reached = reached.with(Condition::Undecidable);
+        }
+    }
+    Some(reached)
+}
+
+/// Whether any [`ArgRole::Body`] argument of this command contains a
+/// terminator.
+fn command_body_may_terminate(
+    text: &str,
+    words: &[Vec<Token>],
+    head: &str,
+    registry: &CommandRegistry,
+    depth: u32,
+) -> bool {
+    let args: Vec<&str> = words[1..].iter().map(|w| word_raw(text, w)).collect();
+    registry
+        .arg_indices_for_role(head, &args, ArgRole::Body)
+        .into_iter()
+        .filter_map(|i| words[1..].get(i))
+        .any(|word| body_may_terminate(&script_of(text, word), registry, depth + 1))
+}
+
+/// The script text of a body word: the inside of a braced / quoted / bracketed
+/// word, or the word itself when it is bare (`if {$c} return`).
+fn script_of(text: &str, word: &[Token]) -> String {
+    word_unwrap(text, word).unwrap_or_else(|| word_raw(text, word).to_owned())
+}
+
+/// What an `if` chain does to control flow.
+enum AfterIf {
+    /// The command's words are not a clause chain this can read (a malformed
+    /// `if` the interpreter would reject), so the caller treats it as inert.
+    NotAChain,
+    /// No path out of the chain continues — the whole script ends here.
+    Stops,
+    /// Control continues past the chain, under these conditions.
+    Continues(Conditions),
+}
+
+/// Walk an `if` chain: visit the declarations in every branch, and report what
+/// happens to control flow after it.
+fn walk_if(
+    text: &str,
+    words: &[Vec<Token>],
+    head: &str,
+    registry: &CommandRegistry,
+    reached: &Conditions,
+    depth: u32,
+    visit: &mut dyn FnMut(Reached<'_>),
+) -> AfterIf {
+    let args: Vec<&str> = words[1..].iter().map(|w| word_raw(text, w)).collect();
+    let Some(clauses) = clause_chain(head, &args, registry) else {
+        return AfterIf::NotAChain;
+    };
+
+    // Conditions accumulated from every earlier clause having tested false —
+    // what must hold for this clause to be *considered* at all.
+    let mut earlier_false = Conditions::default();
+    // One entry per branch that stops control continuing past the chain,
+    // carrying the single condition that selects it where there is one.
+    let mut terminating: Vec<Option<Condition>> = Vec::new();
+    let mut has_else = false;
+    let mut definitely_taken_terminates = false;
+
+    for clause in &clauses {
+        let branch_conditions = match clause.expr {
+            // The `else` branch runs exactly when every earlier test failed.
+            None => {
+                has_else = true;
+                earlier_false.clone()
+            }
+            Some(expr_index) => {
+                let guard = guard_expr(text, &words[1..][expr_index]);
+                let mut conditions = earlier_false.clone();
+                if let Some(condition) = guard.condition(true) {
+                    conditions = conditions.with(condition);
+                }
+                if let Some(condition) = guard.condition(false) {
+                    earlier_false = earlier_false.with(condition);
+                }
+                conditions
+            }
+        };
+        let body_text = script_of(text, &words[1..][clause.body]);
+        let mut branch_reached = reached.clone();
+        for condition in &branch_conditions.0 {
+            branch_reached = branch_reached.with(condition.clone());
+        }
+        if walk_script(&body_text, registry, &branch_reached, depth + 1, visit).is_none() {
+            if branch_conditions.is_unconditional() {
+                definitely_taken_terminates = true;
+            }
+            terminating.push(match branch_conditions.0.as_slice() {
+                [only] => Some(only.clone()),
+                _ => None,
+            });
+        } else if body_may_terminate(&body_text, registry, depth + 1) {
+            terminating.push(Some(Condition::Undecidable));
+        }
+    }
+
+    if definitely_taken_terminates || (has_else && terminating.len() == clauses.len()) {
+        return AfterIf::Stops;
+    }
+    AfterIf::Continues(match terminating.as_slice() {
+        // Nothing in the chain stops control continuing.
+        [] => reached.clone(),
+        // Exactly one branch terminates, under one negatable condition: what
+        // follows is guarded by that condition's negation.  This is the shape
+        // every real `if {GUARD} {return}` index-file head takes.
+        [Some(condition)] => match condition.negated() {
+            Some(negated) => reached.with(negated),
+            None => reached.clone(),
+        },
+        _ => reached.with(Condition::Undecidable),
+    })
+}
+
+/// Whether `script` contains a terminator anywhere, however deeply guarded.
+///
+/// Used only to decide that a branch *might* stop the script, so an
+/// undecidable guard is recorded rather than none at all.
+fn body_may_terminate(script: &str, registry: &CommandRegistry, depth: u32) -> bool {
+    if MAX_GUARD_NESTING_DEPTH.exceeded(depth) {
+        return false;
+    }
+    walk_command_words(script).iter().any(|words| {
+        words.first().is_some_and(|first| {
+            let head = word_raw(script, first).trim_start_matches("::");
+            registry
+                .get(head)
+                .is_some_and(|spec| spec.traits.contains(Traits::TERMINATES_BLOCK))
+        }) || words.iter().any(|word| {
+            word_unwrap(script, word)
+                .is_some_and(|inner| body_may_terminate(&inner, registry, depth + 1))
+        })
+    })
+}
+
+/// One clause of an `if` chain: an optional condition word and its body word,
+/// as argument indices (0 = the word after the command name).
+struct Clause {
+    expr: Option<usize>,
+    body: usize,
+}
+
+/// Pair an `if` invocation's argument words into clauses, using the registry's
+/// own grammar for the command rather than re-deriving it here.
+///
+/// Returns `None` when the shape is not a clause chain (no bodies, or a
+/// trailing condition with no body — a malformed `if` the interpreter would
+/// reject anyway).
+fn clause_chain(head: &str, args: &[&str], registry: &CommandRegistry) -> Option<Vec<Clause>> {
+    let exprs = registry.arg_indices_for_role(head, args, ArgRole::Expr);
+    let bodies = registry.arg_indices_for_role(head, args, ArgRole::Body);
+    if bodies.is_empty() {
+        return None;
+    }
+    let mut clauses = Vec::with_capacity(bodies.len());
+    for &body in &bodies {
+        // The clause's condition is the last `Expr` word before the body that
+        // no earlier clause has claimed.
+        let expr = exprs
+            .iter()
+            .copied()
+            .rfind(|&e| e < body && !clauses.iter().any(|c: &Clause| c.expr == Some(e)));
+        clauses.push(Clause { expr, body });
+    }
+    Some(clauses)
+}
+
+/// A guard expression this scan understands.
+#[derive(Debug, Clone, PartialEq, Eq)]
+enum Guard {
+    /// A literal boolean (`1`, `0`, `true`, `off`, …).
+    Constant(bool),
+    /// `package vsatisfies [package provide Tcl] REQ …`, `negated` when
+    /// written under a leading `!`.
+    TclSatisfies {
+        requirements: Vec<String>,
+        negated: bool,
+    },
+    /// Anything else.
+    Unknown,
+}
+
+impl Guard {
+    /// The condition that must hold for this guard to take the value
+    /// `expect`, or `None` when the guard already settles it.
+    fn condition(&self, expect: bool) -> Option<Condition> {
+        match self {
+            Self::Constant(value) => (*value != expect).then_some(Condition::Impossible),
+            Self::TclSatisfies {
+                requirements,
+                negated,
+            } => Some(Condition::TclSatisfies {
+                requirements: requirements.clone(),
+                expect: expect != *negated,
+            }),
+            Self::Unknown => Some(Condition::Undecidable),
+        }
+    }
+}
+
+/// Read a guard word (`if`'s condition) into a [`Guard`].
+///
+/// A braced or quoted condition — the universal spelling — is read from its
+/// inner text; a bare condition is read as written.
+fn guard_expr(text: &str, word: &[Token]) -> Guard {
+    parse_guard(script_of(text, word).trim())
+}
+
+/// Parse a condition's source text.
+fn parse_guard(expr: &str) -> Guard {
+    let expr = expr.trim();
+    if let Some(rest) = expr.strip_prefix('!') {
+        return match parse_guard(rest) {
+            Guard::Constant(value) => Guard::Constant(!value),
+            Guard::TclSatisfies {
+                requirements,
+                negated,
+            } => Guard::TclSatisfies {
+                requirements,
+                negated: !negated,
+            },
+            Guard::Unknown => Guard::Unknown,
+        };
+    }
+    // A whole-expression `[...]` substitution: unwrap and read the command.
+    if let Some(inner) = bracketed_body(expr) {
+        return parse_vsatisfies(inner);
+    }
+    // The same acceptor `if` itself uses (`Tcl_GetBooleanFromObj`'s string
+    // path), so `1`, `true`, `yes`, `on`, `2`, and `0x0` read exactly as the
+    // interpreter reads them.
+    match tcl_syntax::boolean::truthiness(expr) {
+        Some(value) => Guard::Constant(value),
+        None => Guard::Unknown,
+    }
+}
+
+/// The inner text of `expr` when it is exactly one `[...]` substitution.
+fn bracketed_body(expr: &str) -> Option<&str> {
+    let inner = expr.strip_prefix('[')?.strip_suffix(']')?;
+    // Reject `[a] + [b]`, where the outer brackets are not a matched pair.
+    let mut depth = 0i32;
+    for ch in inner.chars() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth < 0 {
+                    return None;
+                }
+            }
+            _ => {}
+        }
+    }
+    (depth == 0).then_some(inner)
+}
+
+/// Read `package vsatisfies [package provide Tcl] REQ …` — the only
+/// non-constant test this scan evaluates.
+///
+/// The subject must be a `[package provide Tcl]` or `[package require Tcl]`
+/// substitution: a `vsatisfies` over some *other* package says nothing about
+/// the Tcl release, and guessing there would be worse than abstaining.
+fn parse_vsatisfies(script: &str) -> Guard {
+    let commands = walk_command_words(script);
+    let [words] = commands.as_slice() else {
+        return Guard::Unknown;
+    };
+    if words.len() < 4 {
+        return Guard::Unknown;
+    }
+    if word_raw(script, &words[0]).trim_start_matches("::") != "package"
+        || word_raw(script, &words[1]) != "vsatisfies"
+    {
+        return Guard::Unknown;
+    }
+    if !is_tcl_version_subject(script, &words[2]) {
+        return Guard::Unknown;
+    }
+    let requirements: Vec<String> = words[3..]
+        .iter()
+        .map(|w| word_raw(script, w).trim_matches(['{', '}', '"']).to_owned())
+        .collect();
+    if requirements.iter().any(|r| !is_requirement_word(r)) {
+        return Guard::Unknown;
+    }
+    Guard::TclSatisfies {
+        requirements,
+        negated: false,
+    }
+}
+
+/// Whether `word` is `[package provide Tcl]` / `[package require Tcl]` — the
+/// running interpreter's own version.
+fn is_tcl_version_subject(script: &str, word: &[Token]) -> bool {
+    if word.len() != 1 || word[0].kind != TokenType::Cmd {
+        return false;
+    }
+    let Some(inner) = word_unwrap(script, word) else {
+        return false;
+    };
+    let commands = walk_command_words(&inner);
+    let [words] = commands.as_slice() else {
+        return false;
+    };
+    if words.len() != 3 {
+        return false;
+    }
+    word_raw(&inner, &words[0]).trim_start_matches("::") == "package"
+        && matches!(word_raw(&inner, &words[1]), "provide" | "require")
+        // `Tcl` is matched case-sensitively — `tk` and the lowercase `tcl`
+        // alias are other packages.
+        && word_raw(&inner, &words[2]) == "Tcl"
+}
+
+/// Whether `word` has the shape of a version requirement (`8.5`, `9-`,
+/// `8.5-9.0`) rather than a substitution or an option flag.
+fn is_requirement_word(word: &str) -> bool {
+    !word.is_empty()
+        && !word.starts_with('$')
+        && !word.starts_with('[')
+        && !word.starts_with('-')
+        && word
+            .bytes()
+            .all(|b| b.is_ascii_digit() || b == b'.' || b == b'-' || b == b'a' || b == b'b')
+}
+
+#[cfg(test)]
+mod tests;

--- a/rust/tcl-lsp-core/src/package_resolver/reachability/tests.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/reachability/tests.rs
@@ -282,6 +282,80 @@ fn the_then_noise_word_and_a_braceless_return_are_understood() {
     );
 }
 
+/// A requirement naming a **patch level** cannot be evaluated against the
+/// two-component release model, so the guard abstains instead of deciding it
+/// wrongly.
+///
+/// Oracle (`tclsh9.0`, `[package provide Tcl]` = 9.0.4):
+///
+/// ```text
+/// vsatisfies 9.0.4 9.0.1  = 1
+/// vsatisfies 9.0.4 9.0.1- = 1
+/// vsatisfies 9.0.4 9.0.9- = 0
+/// ```
+///
+/// `TclVersion::V9_0`'s `version_string` is `9.0`, which compares *below*
+/// `9.0.1` — so evaluating the requirement would report the guard as failing
+/// on a real 9.0.4 and mark the package `Unavailable`, the one direction that
+/// makes W123 fire falsely on its commands.  Two shipped 9.0 releases disagree
+/// about `9.0.9-`, so "conditional" is the only honest answer.
+#[test]
+fn a_patch_level_requirement_leaves_the_declaration_conditional() {
+    for requirement in ["9.0.1", "9.0.1-", "9.0-9.0.2"] {
+        let src = format!(
+            "if {{![package vsatisfies [package provide Tcl] {requirement}]}} {{return}}\n\
+             package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n"
+        );
+        assert_eq!(
+            only(&src, V90),
+            Availability::Conditional,
+            "a patch-level requirement must abstain: {requirement}",
+        );
+        assert_eq!(
+            only(&src, V86),
+            Availability::Conditional,
+            "a patch-level requirement must abstain: {requirement}",
+        );
+    }
+}
+
+/// TN for the same rule: a requirement that *is* satisfiable two-component
+/// still settles the whole `vsatisfies` OR, however many patch-level
+/// requirements sit beside it — real `package vsatisfies` is an OR.
+#[test]
+fn a_satisfied_two_component_requirement_still_decides_beside_a_patch_level_one() {
+    let src = "if {![package vsatisfies [package provide Tcl] 9.0.1 9]} {return}\n\
+               package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n";
+    // 9.0 satisfies the bare `9`, so the guard is decided true regardless of
+    // the undecidable `9.0.1`.
+    assert_eq!(only(src, V90), Availability::Available);
+    // 8.6 satisfies neither the bare `9` nor (decidably) `9.0.1`.
+    assert_eq!(only(src, V86), Availability::Conditional);
+}
+
+/// Control — the two-component matrix this module already decided is
+/// unchanged by the patch-level rule.
+#[test]
+fn the_two_component_requirement_matrix_is_unchanged() {
+    for (requirement, on_86, on_90) in [
+        ("8.5", Availability::Available, Availability::Unavailable),
+        ("8.5-", Availability::Available, Availability::Available),
+        (
+            "8.5-9.0",
+            Availability::Available,
+            Availability::Unavailable,
+        ),
+        ("9-", Availability::Unavailable, Availability::Available),
+    ] {
+        let src = format!(
+            "if {{![package vsatisfies [package provide Tcl] {requirement}]}} {{return}}\n\
+             package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n"
+        );
+        assert_eq!(only(&src, V86), on_86, "8.6 / {requirement}");
+        assert_eq!(only(&src, V90), on_90, "9.0 / {requirement}");
+    }
+}
+
 /// Deeply nested guards must not recurse without bound; past the cap the scan
 /// abstains rather than descending further.
 #[test]

--- a/rust/tcl-lsp-core/src/package_resolver/reachability/tests.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/reachability/tests.rs
@@ -1,0 +1,300 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Guard-reachability tests.  Every expectation is the answer a real
+//! `tclsh8.6` / `tclsh9.0` gives for the same index file.
+
+use super::{Availability, scan};
+use tcl_dialect::TclVersion;
+
+/// `(package name, availability)` for each declaration `content` yields,
+/// evaluated for `target`.
+fn availabilities(content: &str, target: Option<TclVersion>) -> Vec<(String, Availability)> {
+    let registry = tcl_registry::registry_for_dialect("tcl");
+    let mut out = Vec::new();
+    scan(content, registry, &mut |reached| {
+        let name = super::word_raw(reached.text, &reached.words[2]).to_owned();
+        out.push((name, reached.conditions.availability(target)));
+    });
+    out
+}
+
+/// The availability of the single declaration `content` yields.
+fn only(content: &str, target: Option<TclVersion>) -> Availability {
+    let found = availabilities(content, target);
+    assert_eq!(found.len(), 1, "expected one declaration, got {found:?}");
+    found[0].1
+}
+
+const V86: Option<TclVersion> = Some(TclVersion::V8_6);
+const V90: Option<TclVersion> = Some(TclVersion::V9_0);
+
+/// The unguarded index file — by far the commonest shape — is unconditional
+/// on every release.
+#[test]
+fn an_unguarded_declaration_is_available_everywhere() {
+    let src = "package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n";
+    assert_eq!(only(src, V86), Availability::Available);
+    assert_eq!(only(src, V90), Availability::Available);
+    assert_eq!(only(src, None), Availability::Available);
+}
+
+/// Issue #1017's exact repro, shrunk from tcllib's `modules/try/pkgIndex.tcl`
+/// `file::home` gate.
+///
+/// Oracle: `tclsh9.0` → `package require mypkg` fails ("can't find package
+/// mypkg"); `tclsh8.6` → it loads and returns 1.0.
+#[test]
+fn a_vsatisfies_early_return_gates_the_declaration_1017() {
+    let src = "if {[package vsatisfies [package provide Tcl] 9-]} { return }\n\
+               package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n";
+    assert_eq!(only(src, V90), Availability::Unavailable);
+    assert_eq!(only(src, V86), Availability::Available);
+    // With no known target release the guard cannot be decided either way.
+    assert_eq!(only(src, None), Availability::Conditional);
+}
+
+/// The real tcllib head guard — a *negated* test with two requirements.
+///
+/// Oracle: `package vsatisfies [package provide Tcl] 8.5 9` is 1 on both
+/// 8.6.14 and 9.0.4, so the `return` never fires on either and the package
+/// loads; it does fire on 8.4.
+#[test]
+fn the_tcllib_head_guard_admits_both_supported_releases() {
+    let src = "if {![package vsatisfies [package provide Tcl] 8.5 9]} {return}\n\
+               package ifneeded log 1.5 [list source [file join $dir log.tcl]]\n";
+    assert_eq!(only(src, V86), Availability::Available);
+    assert_eq!(only(src, V90), Availability::Available);
+    assert_eq!(only(src, Some(TclVersion::V8_4)), Availability::Unavailable);
+}
+
+/// The trivial control from issue #1017: unreachable under *every* release,
+/// with no version reasoning involved at all.
+#[test]
+fn a_constant_true_early_return_gates_the_declaration_1017() {
+    for src in [
+        "if {1} { return }\npackage ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+        "if {true} {return}\npackage ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+        "return\npackage ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+    ] {
+        assert!(
+            availabilities(src, V90).is_empty(),
+            "nothing after an unconditional return is reachable: {src}",
+        );
+    }
+}
+
+/// The negative control from issue #1017, which already behaved: a
+/// declaration nested in a constant-false branch never registers.  It is now
+/// *seen* (the scan descends into branches) and reported unavailable, rather
+/// than being invisible by accident.
+#[test]
+fn a_constant_false_branch_never_registers_1017() {
+    let src =
+        "if {0} {\n  package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n}\n";
+    assert_eq!(only(src, V90), Availability::Unavailable);
+    assert_eq!(only(src, V86), Availability::Unavailable);
+}
+
+/// Issue #923 idx 42: the TEA idiom that picks a Tcl-8 or Tcl-9 build.  Both
+/// arms declare the package, so it is available on both releases — the
+/// over-flagging direction of the same mechanism.
+///
+/// Oracle: `tclsh8.6` and `tclsh9.0` both load the package and run its
+/// command.
+#[test]
+fn both_arms_of_a_tea_version_branch_declare_the_package_923_idx42() {
+    let src = "if {[package vsatisfies [package provide Tcl] 9.0-]} {\n\
+               \x20   package ifneeded tclopt 0.4 [list source [file join $dir tclopt.tcl]]\n\
+               } else {\n\
+               \x20   package ifneeded tclopt 0.4 [list source [file join $dir tclopt.tcl]]\n\
+               }\n";
+    for target in [V86, V90] {
+        let found = availabilities(src, target);
+        assert_eq!(found.len(), 2, "both arms are scanned: {found:?}");
+        assert!(
+            found
+                .iter()
+                .any(|(_, availability)| *availability == Availability::Available),
+            "one arm must be the taken one for {target:?}: {found:?}",
+        );
+        assert!(
+            found
+                .iter()
+                .any(|(_, availability)| *availability == Availability::Unavailable),
+            "…and the other the untaken one: {found:?}",
+        );
+    }
+}
+
+/// The whole `modules/try/pkgIndex.tcl` from tcllib 2.0, verbatim: two guards
+/// in sequence, the second wrapping a `package provide` beside its `return`.
+///
+/// Oracle (`tclsh8.6`): `try`, `throw`, and `file::home` all load.
+/// Oracle (`tclsh9.0`): `try` and `throw` load; `file::home` is provided by
+/// the guard's own `package provide`, so `fhome.tcl` is never sourced.
+#[test]
+fn the_real_tcllib_try_index_resolves_per_release() {
+    let src = "if {![package vsatisfies [package provide Tcl] 8.5 9]} {\n\
+               \x20   return\n\
+               }\n\
+               package ifneeded try   1.1 [list source [file join $dir try.tcl]]\n\
+               package ifneeded throw 1.1 [list source [file join $dir throw.tcl]]\n\
+               if {[package vsatisfies [package provide Tcl] 9-]} {\n\
+               \x20   package provide file::home 1\n\
+               \x20   return\n\
+               }\n\
+               package ifneeded file::home 1 [list source [file join $dir fhome.tcl]]\n";
+
+    let on_86 = availabilities(src, V86);
+    assert_eq!(
+        on_86,
+        vec![
+            ("try".to_owned(), Availability::Available),
+            ("throw".to_owned(), Availability::Available),
+            ("file::home".to_owned(), Availability::Available),
+        ],
+    );
+
+    let on_90 = availabilities(src, V90);
+    assert_eq!(
+        on_90,
+        vec![
+            ("try".to_owned(), Availability::Available),
+            ("throw".to_owned(), Availability::Available),
+            ("file::home".to_owned(), Availability::Unavailable),
+        ],
+    );
+}
+
+/// A guard this scan does not model must leave the declaration *conditional*,
+/// never decided.  These are the documented limits, pinned so a future change
+/// that starts guessing is caught.
+#[test]
+fn an_unmodelled_guard_leaves_the_declaration_conditional() {
+    for src in [
+        // A platform test, not a version test.
+        "if {$::tcl_platform(platform) eq \"windows\"} { return }\n\
+         package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+        // A filesystem probe.
+        "if {![file exists [file join $dir mypkg.tcl]]} { return }\n\
+         package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+        // A compound expression over two version tests.
+        "if {[package vsatisfies [package provide Tcl] 9-] && $::force} { return }\n\
+         package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+        // `vsatisfies` over a package that is not Tcl says nothing about the
+        // Tcl release.
+        "if {[package vsatisfies [package provide Tk] 9-]} { return }\n\
+         package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+        // A loop body: a `return` inside one is never treated as certain.
+        "foreach v {8 9} { if {$v} { return } }\n\
+         package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+    ] {
+        assert_eq!(
+            only(src, V90),
+            Availability::Conditional,
+            "must abstain, not decide: {src}",
+        );
+    }
+}
+
+/// `error` / `throw` / `exit` end the script exactly as `return` does —
+/// `tclPkgUnknown` sources each index inside a `catch`, so a raise stops
+/// registration.  Recognised from the registry's `TERMINATES_BLOCK` trait,
+/// so this needs no per-command list here.
+#[test]
+fn any_registry_terminator_ends_the_index() {
+    for terminator in ["return", "error boom", "exit 1"] {
+        let src = format!(
+            "if {{[package vsatisfies [package provide Tcl] 9-]}} {{ {terminator} }}\n\
+             package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n"
+        );
+        assert_eq!(only(&src, V90), Availability::Unavailable, "{terminator}");
+        assert_eq!(only(&src, V86), Availability::Available, "{terminator}");
+    }
+}
+
+/// A guard body that does something *other* than terminate leaves everything
+/// after it unconditional — the guard selects behaviour, not reachability.
+#[test]
+fn a_non_terminating_guard_body_does_not_gate_what_follows() {
+    let src = "if {[package vsatisfies [package provide Tcl] 9-]} { set extra 1 }\n\
+               package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n";
+    assert_eq!(only(src, V90), Availability::Available);
+    assert_eq!(only(src, V86), Availability::Available);
+}
+
+/// An `elseif` chain: each arm's condition is read, and an arm is reached only
+/// when every earlier one tested false.
+#[test]
+fn an_elseif_chain_selects_one_arm_per_release() {
+    let src = "if {[package vsatisfies [package provide Tcl] 9-]} {\n\
+               \x20   package ifneeded mypkg 2.0 [list source [file join $dir new.tcl]]\n\
+               } elseif {[package vsatisfies [package provide Tcl] 8.5-]} {\n\
+               \x20   package ifneeded mypkg 1.0 [list source [file join $dir old.tcl]]\n\
+               }\n";
+    assert_eq!(
+        availabilities(src, V90),
+        vec![
+            ("mypkg".to_owned(), Availability::Available),
+            ("mypkg".to_owned(), Availability::Unavailable),
+        ],
+    );
+    assert_eq!(
+        availabilities(src, V86),
+        vec![
+            ("mypkg".to_owned(), Availability::Unavailable),
+            ("mypkg".to_owned(), Availability::Available),
+        ],
+    );
+}
+
+/// The `then` noise word and a brace-less body are part of `if`'s real
+/// grammar; the clause chain comes from the registry, so both work without
+/// this module knowing about them.
+#[test]
+fn the_then_noise_word_and_a_braceless_return_are_understood() {
+    let src = "if {1} then {return}\n\
+               package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n";
+    assert!(availabilities(src, V90).is_empty());
+
+    let bare = "if {![package vsatisfies [package provide Tcl] 8.5 9]} return\n\
+                package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n";
+    assert_eq!(only(bare, V86), Availability::Available);
+    assert_eq!(
+        only(bare, Some(TclVersion::V8_4)),
+        Availability::Unavailable
+    );
+}
+
+/// Deeply nested guards must not recurse without bound; past the cap the scan
+/// abstains rather than descending further.
+#[test]
+fn pathological_nesting_terminates() {
+    let depth = 200;
+    let mut src = String::new();
+    for _ in 0..depth {
+        src.push_str("if {1} {\n");
+    }
+    src.push_str("package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n");
+    for _ in 0..depth {
+        src.push_str("}\n");
+    }
+    // The only requirement is that this returns at all.
+    let _ = availabilities(&src, V90);
+}

--- a/rust/tcl-lsp-core/src/package_resolver/reachability/tests.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/reachability/tests.rs
@@ -282,6 +282,111 @@ fn the_then_noise_word_and_a_braceless_return_are_understood() {
     );
 }
 
+/// Tcl 9's **own** core-package index — `apply {{dir} { … foreach … }} $dir`
+/// (the zipfs `tcl_library/pkgIndex.tcl`, shrunk to three packages and
+/// otherwise verbatim).  Before the body descent this scan saw only the
+/// `apply` call, so http / msgcat / tcltest declared nothing at all on a
+/// tcl9.0 workspace.  Each declaration is reached under an undecidable guard
+/// (the `apply` frame, the `foreach` iteration, the `if … continue`), so all
+/// three are `Conditional` — which counts as loadable downstream.
+#[test]
+fn the_tcl9_zipfs_index_shape_declares_its_packages() {
+    let src = "apply {{dir} {\n\
+               \x20 set isafe [interp issafe]\n\
+               \x20 foreach {safe package version file} {\n\
+               \x20   0 http    2.10.2 {http http.tcl}\n\
+               \x20   1 msgcat  1.7.1  {msgcat msgcat.tcl}\n\
+               \x20   1 tcltest 2.5.11 {tcltest tcltest.tcl}\n\
+               \x20 } {\n\
+               \x20   if {$isafe && !$safe} continue\n\
+               \x20   package ifneeded $package $version [list source [file join $dir {*}$file]]\n\
+               \x20 }\n\
+               }} $dir\n";
+    let found = availabilities(src, V90);
+    assert_eq!(
+        found,
+        vec![("$package".to_owned(), Availability::Conditional)],
+        "the declaration inside the apply/foreach body must be reached",
+    );
+}
+
+/// The same shape with literal name and version words, which is what a
+/// consumer can actually key on — the `apply` lambda body and the `foreach`
+/// body are both descended, and the declaration comes back `Conditional`.
+#[test]
+fn a_declaration_inside_an_apply_lambda_and_a_foreach_is_conditional() {
+    let src = "apply {{dir} {\n\
+               \x20 foreach f {mypkg.tcl} {\n\
+               \x20   package ifneeded mypkg 1.0 [list source [file join $dir $f]]\n\
+               \x20 }\n\
+               }} $dir\n";
+    assert_eq!(only(src, V90), Availability::Conditional);
+    assert_eq!(only(src, V86), Availability::Conditional);
+    assert_eq!(only(src, None), Availability::Conditional);
+}
+
+/// The other body-taking commands the module names, each reached through its
+/// registry [`super::ArgRole::Body`] argument rather than by name.
+#[test]
+fn every_body_taking_command_is_descended() {
+    for wrapper in [
+        "namespace eval ::pkg { PLACEHOLDER }",
+        "catch { PLACEHOLDER }",
+        "eval { PLACEHOLDER }",
+        "foreach v {1} { PLACEHOLDER }",
+        "while {0} { PLACEHOLDER }",
+        "uplevel #0 { PLACEHOLDER }",
+    ] {
+        let src = wrapper.replace(
+            "PLACEHOLDER",
+            "package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]",
+        );
+        assert_eq!(
+            only(&src, V90),
+            Availability::Conditional,
+            "must be reached, conditionally: {wrapper}",
+        );
+    }
+}
+
+/// TN — the descent must not turn an *unguarded* top-level declaration
+/// conditional, and must not disturb the #1017 guarded-return result.
+#[test]
+fn the_body_descent_leaves_top_level_declarations_alone() {
+    let plain = "package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n";
+    assert_eq!(only(plain, V90), Availability::Available);
+    assert_eq!(only(plain, V86), Availability::Available);
+
+    // Issue #1017's guarded-return TP still decides both ways.
+    let guarded = "if {[package vsatisfies [package provide Tcl] 9-]} { return }\n\
+                   package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n";
+    assert_eq!(only(guarded, V90), Availability::Unavailable);
+    assert_eq!(only(guarded, V86), Availability::Available);
+}
+
+/// TN — a declaration in a constant-false `if` branch stays `Unavailable`:
+/// `if` still goes through the symbolic clause walk, not the generic body
+/// descent, so its conditions are not flattened to `Undecidable`.
+#[test]
+fn if_branches_keep_their_symbolic_conditions() {
+    let src =
+        "if {0} {\n  package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n}\n";
+    assert_eq!(only(src, V90), Availability::Unavailable);
+
+    // And a single declaration is visited once, not twice.
+    let once =
+        "if {1} {\n  package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n}\n";
+    assert_eq!(availabilities(once, V90).len(), 1);
+}
+
+/// A dynamic (`$var` / `[cmd]`) lambda has no statically splittable body, so
+/// there is nothing to descend and nothing is invented.
+#[test]
+fn a_dynamic_lambda_is_not_descended() {
+    let src = "apply $loader $dir\n";
+    assert!(availabilities(src, V90).is_empty());
+}
+
 /// A requirement naming a **patch level** cannot be evaluated against the
 /// two-component release model, so the guard abstains instead of deciding it
 /// wrongly.

--- a/rust/tcl-lsp-core/src/package_resolver/tests.rs
+++ b/rust/tcl-lsp-core/src/package_resolver/tests.rs
@@ -593,15 +593,15 @@ fn package_defined_commands_unions_available_package_sources() {
             Vec::new()
         }
     };
-    let cmds = resolver.package_defined_commands(&["mylib".to_owned()], &extract);
+    let cmds = resolver.package_defined_commands(&["mylib".to_owned()], None, &extract);
     assert!(
         cmds.contains("draw"),
         "available package's command surfaced"
     );
     // A package the paths don't know contributes nothing (no source files).
-    let none = resolver.package_defined_commands(&["absent".to_owned()], &extract);
+    let none = resolver.package_defined_commands(&["absent".to_owned()], None, &extract);
     assert!(none.is_empty());
     // No available packages ⇒ empty, extractor never consulted.
-    let empty = resolver.package_defined_commands(&[], &extract);
+    let empty = resolver.package_defined_commands(&[], None, &extract);
     assert!(empty.is_empty());
 }

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4284,6 +4284,92 @@ impl Backend {
         resolved
     }
 
+    /// Hover for a command head the current document cannot resolve, using
+    /// the same two fallback tiers `compute_definition` already has: the
+    /// cross-document workspace index, then the autoload / package database
+    /// (issue #1018).
+    ///
+    /// Go-to-definition, find-references, and the unknown-command diagnostic
+    /// all resolve a tcllib-shaped command whose `proc` lives in a sibling
+    /// file reached through `source` or `auto_path`/`tclIndex`.  Hover used to
+    /// be the one provider that gave up at the file boundary and silently
+    /// showed nothing, at the very call site the other three resolved.
+    ///
+    /// The body is rendered from the *defining* document's own analysis
+    /// ([`core_hover::qualified_symbol_hover`]) — the same renderer, and the
+    /// same input, that hovering the declaration itself uses, so the two can
+    /// never disagree.
+    async fn cross_document_hover(
+        &self,
+        uri: &Uri,
+        source: &str,
+        pos: Position,
+        analysis: &AnalysisResult,
+    ) -> Option<CoreHover> {
+        // Cross-document tier: a proc / class defined in a sibling document
+        // the workspace index knows about.
+        let symbols = self
+            .resolve_workspace_symbols(uri, source, analysis, pos)
+            .await;
+        for qualified in &symbols {
+            if let Some(hover) = self.hover_for_indexed_symbol(qualified).await {
+                return Some(hover);
+            }
+        }
+        // Autoload tier (M8's hover twin): the command is defined nowhere in
+        // the open workspace, but `tclIndex` / `pkgIndex.tcl` on the configured
+        // library paths says which file defines it.  `ensure_autoload_indexed`
+        // merges that file into the workspace index, so the render below reads
+        // it exactly like any other indexed document.
+        let (word, namespace) = core_definition::command_head_and_namespace_at(
+            source,
+            analysis,
+            pos.line,
+            pos.character,
+        )?;
+        let qualified = self.ensure_autoload_indexed(&word, &namespace).await?;
+        self.hover_for_indexed_symbol(&qualified).await
+    }
+
+    /// Render `qualified` from whichever indexed document declares it.
+    ///
+    /// A name several documents declare renders from the first that yields a
+    /// body; go-to-definition offers every site, but a hover has one popup, so
+    /// picking one is the only option and the index's own order decides.
+    async fn hover_for_indexed_symbol(&self, qualified: &str) -> Option<CoreHover> {
+        let target_uris: Vec<String> = {
+            let index = self.workspace_index.read().await;
+            index
+                .proc_definitions_qualified(qualified, "")
+                .into_iter()
+                .map(|p| p.uri.clone())
+                .chain(
+                    index
+                        .class_definitions_qualified(qualified, "")
+                        .into_iter()
+                        .map(|c| c.uri.clone()),
+                )
+                .collect()
+        };
+        for target_uri in target_uris {
+            let Ok(parsed) = Uri::from_str(&target_uri) else {
+                continue;
+            };
+            let Some(target_doc) = self.read_document(&parsed).await else {
+                continue;
+            };
+            // Memoised by `analysis_for`, so a hover over an already-analysed
+            // sibling costs a cache hit, not a second whole-file walk.
+            let target_analysis = self
+                .analysis_for(&parsed, target_doc.text.clone(), target_doc.dialect.clone())
+                .await;
+            if let Some(hover) = core_hover::qualified_symbol_hover(&target_analysis, qualified) {
+                return Some(hover);
+            }
+        }
+        None
+    }
+
     /// Resolve the symbol at `pos` against the workspace index
     /// when the current document has no local definition.  Only
     /// fires on bare command words (not `$var` references), and
@@ -10906,12 +10992,19 @@ impl LanguageServer for Backend {
             .analysis_for(&uri, doc.text.clone(), doc.dialect.clone())
             .await;
         let hover_profile = tcl_dialect::DialectProfile::by_name(&doc.dialect);
+        // The cross-document fallback must only fire on a command head, the
+        // same gate `compute_definition` applies — otherwise an argument word
+        // that happens to share a sibling proc's name would pop up that proc's
+        // signature.  Computed here, while `analysis` is still in scope.
+        let on_command_head = position_is_command_head(&doc.text, pos, &analysis);
+        let text = doc.text.clone();
+        let analysis_worker = Arc::clone(&analysis);
         let result = tokio::task::spawn_blocking(move || {
             core_hover::hover_with_profile(
-                &doc.text,
+                &text,
                 pos.line,
                 pos.character,
-                &analysis,
+                &analysis_worker,
                 Some(&registry),
                 hover_profile,
             )
@@ -10922,7 +11015,19 @@ impl LanguageServer for Backend {
             message: format!("hover worker panicked: {err}").into(),
             data: None,
         })?;
-        Ok(result.map(lift_hover))
+        if let Some(hover) = result {
+            return Ok(Some(lift_hover(hover)));
+        }
+        // Nothing in this document explains the word.  If it is a command
+        // head, resolve it the way go-to-definition does — across the
+        // workspace, then through the autoload / package database (#1018).
+        if !on_command_head {
+            return Ok(None);
+        }
+        Ok(self
+            .cross_document_hover(&uri, &doc.text, pos, &analysis)
+            .await
+            .map(lift_hover))
     }
 }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -1083,7 +1083,11 @@ async fn widen_recovery_extra_commands(
         names.insert(name.trim_start_matches("::").to_owned());
     }
     if !requires.is_empty() {
-        let commands = resolver.package_defined_commands(&requires, &|path| {
+        // Same release-aware package view the W123 refinement uses, so the
+        // known-name set and the diagnostic filter cannot disagree about which
+        // guarded packages this document can actually load.
+        let target = tcl_dialect::TclVersion::from_dialect(Some(dialect));
+        let commands = resolver.package_defined_commands(&requires, target, &|path| {
             std::fs::read_to_string(path)
                 .map(|text| defined_command_tails(&text, dialect))
                 .unwrap_or_default()
@@ -12366,6 +12370,25 @@ fn defined_command_tails(text: &str, dialect: &str) -> Vec<String> {
 /// resolve to a real library definition must not be reported "unknown". The
 /// check is entirely data-driven — the resolver is queried *by the flagged
 /// name*, never matched against a hard-coded command list.
+///
+/// # `pkgIndex.tcl` guards
+///
+/// A package whose `pkgIndex.tcl` gates its `package ifneeded` behind a
+/// version guard supplies commands only on the releases that guard admits, so
+/// the package database is queried for the release `dialect` names. The
+/// three-way answer maps onto the suppression like this:
+///
+/// | Availability  | W123 | Why |
+/// |---------------|------|-----|
+/// | `Available`   | suppressed | the command really is provided (issue #832) |
+/// | `Conditional` | suppressed | a guard the scan could not read; treating "unsure" as "absent" is what produced the false unknown-command reports of issue #923 idx 42 |
+/// | `Unavailable` | **fires**  | the guard was read and definitely skips the declaration, so `package require` really fails and the call really is an error (issue #1017) |
+///
+/// `Conditional` is suppressed outright rather than reported more quietly:
+/// W123's own default severity is already `Hint`, the lowest LSP severity, so
+/// there is no lower-confidence channel to downgrade into. Between a silent
+/// miss and a false "unknown command" on working code, the miss is the lesser
+/// error for a hint whose whole purpose is precision.
 fn refine_w123_diagnostics(
     diags: Vec<tcl_compiler::analyser::Diagnostic>,
     available: &[String],
@@ -12375,10 +12398,11 @@ fn refine_w123_diagnostics(
     // Command names the document's available packages define via their
     // `pkgIndex` implementation files. Empty in the common no-`package require`
     // case (where auto-load alone carries the fix), so no file is read then.
+    let target = tcl_dialect::TclVersion::from_dialect(Some(dialect));
     let package_commands = if available.is_empty() {
         HashSet::new()
     } else {
-        resolver.package_defined_commands(available, &|path| {
+        resolver.package_defined_commands(available, target, &|path| {
             std::fs::read_to_string(path)
                 .map(|text| defined_command_tails(&text, dialect))
                 .unwrap_or_default()

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -2592,6 +2592,15 @@ static GUARDED_PKG_N: std::sync::atomic::AtomicUsize = std::sync::atomic::Atomic
 /// `mypkgHello`; `tclsh9.0` fails with `can't find package mypkg`, so the call
 /// is a genuine `invalid command name` error there.
 fn guarded_pkg_libdir() -> std::path::PathBuf {
+    pkg_libdir_with_index(
+        "if {[package vsatisfies [package provide Tcl] 9-]} { return }\n\
+         package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+    )
+}
+
+/// Build a `mypkg` library dir whose `pkgIndex.tcl` is exactly `index`, next to
+/// a `mypkg.tcl` defining `mypkgHello`.
+fn pkg_libdir_with_index(index: &str) -> std::path::PathBuf {
     use std::sync::atomic::Ordering;
     let libdir = std::env::temp_dir().join(format!(
         "tcl-lsp-e2e-guardedpkg-{}-{}",
@@ -2600,12 +2609,7 @@ fn guarded_pkg_libdir() -> std::path::PathBuf {
     ));
     let pkgdir = libdir.join("mypkg");
     std::fs::create_dir_all(&pkgdir).expect("mk mypkg lib dir");
-    std::fs::write(
-        pkgdir.join("pkgIndex.tcl"),
-        "if {[package vsatisfies [package provide Tcl] 9-]} { return }\n\
-         package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
-    )
-    .expect("write pkgIndex.tcl");
+    std::fs::write(pkgdir.join("pkgIndex.tcl"), index).expect("write pkgIndex.tcl");
     std::fs::write(
         pkgdir.join("mypkg.tcl"),
         "proc mypkgHello {} { return hi }\n",
@@ -2676,6 +2680,55 @@ fn guarded_pkgindex_available_on_target_suppresses_w123_issue_1017() {
     assert!(
         !has_code(&diags, "W123"),
         "a package the guard admits on 8.6 must suppress W123, got: {:?}",
+        codes(&diags),
+    );
+    let _ = std::fs::remove_dir_all(&libdir);
+}
+
+/// TN — Tcl 9's own core-package index shape: the `package ifneeded` lives
+/// inside `apply {{dir} { … foreach … }} $dir` (the zipfs
+/// `tcl_library/pkgIndex.tcl`).  The declaration is only *conditional* — this
+/// analysis models neither the `apply` frame nor the loop — and a conditional
+/// registration counts as loadable, so flagging the call would be a false
+/// positive.
+///
+/// Oracle: `tclsh9.0` sources exactly this shape at startup and
+/// `package require http` works, which is what makes an "unknown command"
+/// verdict on such a package wrong.
+#[test]
+fn apply_wrapped_pkgindex_declaration_suppresses_w123() {
+    let libdir = pkg_libdir_with_index(
+        "apply {{dir} {\n\
+         \x20 foreach f {mypkg.tcl} {\n\
+         \x20   package ifneeded mypkg 1.0 [list source [file join $dir $f]]\n\
+         \x20 }\n\
+         }} $dir\n",
+    );
+    let diags = guarded_pkg_child_diagnostics("tcl9.0", &libdir);
+    assert!(
+        !has_code(&diags, "W123"),
+        "a package declared inside an apply/foreach body must suppress W123, got: {:?}",
+        codes(&diags),
+    );
+    let _ = std::fs::remove_dir_all(&libdir);
+}
+
+/// TN — a guard naming a **patch level** cannot be decided against the
+/// `major.minor` release model, so it must not decide the package away.
+///
+/// Oracle (`tclsh9.0`, `[package provide Tcl]` = 9.0.4):
+/// `package vsatisfies 9.0.4 9.0.1-` = 1, so the real interpreter takes the
+/// guard's true arm, `mypkg` registers, and `mypkgHello` resolves.
+#[test]
+fn patch_level_guarded_pkgindex_suppresses_w123() {
+    let libdir = pkg_libdir_with_index(
+        "if {![package vsatisfies [package provide Tcl] 9.0.1-]} { return }\n\
+         package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+    );
+    let diags = guarded_pkg_child_diagnostics("tcl9.0", &libdir);
+    assert!(
+        !has_code(&diags, "W123"),
+        "a patch-level guard must abstain rather than exclude the package, got: {:?}",
         codes(&diags),
     );
     let _ = std::fs::remove_dir_all(&libdir);

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -2575,6 +2575,112 @@ fn autoload_library_command_go_to_definition_m8() {
     let _ = std::fs::remove_dir_all(&libdir);
 }
 
+// -- Issue #1017 / #923 idx 42: pkgIndex.tcl version guards ---------------
+// A `pkgIndex.tcl` that gates its `package ifneeded` behind
+// `package vsatisfies [package provide Tcl] …` supplies its commands only on
+// the releases the guard admits, so whether a call is "unknown" depends on the
+// dialect the workspace targets.
+
+/// Per-call counter for the guarded-pkgIndex fixture dir.
+static GUARDED_PKG_N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// Build a library dir whose `pkgIndex.tcl` carries the tcllib `file::home`
+/// gate — `if {[package vsatisfies [package provide Tcl] 9-]} { return }` —
+/// in front of its only `package ifneeded`.
+///
+/// Oracle (both shapes verified by hand): `tclsh8.6` loads `mypkg` and runs
+/// `mypkgHello`; `tclsh9.0` fails with `can't find package mypkg`, so the call
+/// is a genuine `invalid command name` error there.
+fn guarded_pkg_libdir() -> std::path::PathBuf {
+    use std::sync::atomic::Ordering;
+    let libdir = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-guardedpkg-{}-{}",
+        std::process::id(),
+        GUARDED_PKG_N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let pkgdir = libdir.join("mypkg");
+    std::fs::create_dir_all(&pkgdir).expect("mk mypkg lib dir");
+    std::fs::write(
+        pkgdir.join("pkgIndex.tcl"),
+        "if {[package vsatisfies [package provide Tcl] 9-]} { return }\n\
+         package ifneeded mypkg 1.0 [list source [file join $dir mypkg.tcl]]\n",
+    )
+    .expect("write pkgIndex.tcl");
+    std::fs::write(
+        pkgdir.join("mypkg.tcl"),
+        "proc mypkgHello {} { return hi }\n",
+    )
+    .expect("write mypkg.tcl");
+    libdir
+}
+
+/// Open `package require mypkg` + `source <child>` in one document and the
+/// bare `mypkgHello` call in another, then poll the child's diagnostics until
+/// the asynchronously-built package database has settled.
+///
+/// The call must live in a file with no `package require` of its own — the
+/// analyser drops every W123 in a file that has one — so the requirement
+/// reaches it through the `source` ancestor (#804), exactly as in the issue's
+/// repro.
+fn guarded_pkg_child_diagnostics(dialect: &str, libdir: &std::path::Path) -> Vec<Value> {
+    let mut lsp = Lsp::with_config(serde_json::json!({
+        "dialect": dialect,
+        "libraryPaths": [ libdir.to_string_lossy() ],
+    }));
+    let child = unique_uri("tcl");
+    let child_name = child.rsplit('/').next().expect("child basename").to_owned();
+    let entry = unique_uri("tcl");
+    lsp.open_ready(
+        &entry,
+        &format!("package require mypkg\nsource {child_name}\n"),
+    );
+    lsp.open_document(&child, "mypkgHello\n");
+
+    // The package database is (re)built asynchronously at startup; the pull
+    // path is deterministic once it is live.  Poll until the answer stops
+    // changing rather than assuming either outcome.
+    let mut diags = lsp.pull_diagnostics(&child);
+    let deadline = std::time::Instant::now() + Duration::from_secs(15);
+    while std::time::Instant::now() < deadline {
+        std::thread::sleep(Duration::from_millis(100));
+        let next = lsp.pull_diagnostics(&child);
+        if codes(&next) == codes(&diags) {
+            return next;
+        }
+        diags = next;
+    }
+    diags
+}
+
+/// TP (issue #1017): under a 9.x target the guard's `return` fires, `mypkg`
+/// never registers, and the call really is an unknown command.
+#[test]
+fn guarded_pkgindex_unavailable_on_target_still_fires_w123_issue_1017() {
+    let libdir = guarded_pkg_libdir();
+    let diags = guarded_pkg_child_diagnostics("tcl9.0", &libdir);
+    assert!(
+        has_code(&diags, "W123"),
+        "a package its pkgIndex guard excludes on 9.x must not suppress W123 (#1017), got: {:?}",
+        codes(&diags),
+    );
+    let _ = std::fs::remove_dir_all(&libdir);
+}
+
+/// TN (issue #923 idx 42's direction): under an 8.6 target the same guard does
+/// not fire, the package registers, and flagging the call would be a false
+/// positive.
+#[test]
+fn guarded_pkgindex_available_on_target_suppresses_w123_issue_1017() {
+    let libdir = guarded_pkg_libdir();
+    let diags = guarded_pkg_child_diagnostics("tcl8.6", &libdir);
+    assert!(
+        !has_code(&diags, "W123"),
+        "a package the guard admits on 8.6 must suppress W123, got: {:?}",
+        codes(&diags),
+    );
+    let _ = std::fs::remove_dir_all(&libdir);
+}
+
 /// Per-call counter for the autoload references/rename fixture dir.
 static AUTOLOAD_REFS_N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
 

--- a/rust/tcl-lsp-server/tests/e2e/hover.rs
+++ b/rust/tcl-lsp-server/tests/e2e/hover.rs
@@ -594,3 +594,162 @@ fn my_dispatch_hover_resolves_when_class_extended_via_separate_oo_define() {
     assert!(h.contains("method"), "hover: {h}");
     assert!(h.contains("geo::Plane::GetType"), "hover: {h}");
 }
+
+// -- Issue #1018: cross-document and autoload hover ----------------------
+//
+// Go-to-definition, find-references, and the unknown-command diagnostic all
+// resolve a command whose `proc` lives in a sibling file. Hover was the one
+// provider that gave up at the file boundary and showed nothing — at the exact
+// call site the other three resolved. These are the first cross-file cases in
+// this suite.
+
+/// The plain `source` control: `main.tcl` sources `lib.tcl`, which declares
+/// `greetPerson`. Hovering the call in `main.tcl` must render the real
+/// signature, exactly as hovering the declaration in `lib.tcl` does.
+#[test]
+fn hover_resolves_a_proc_defined_in_a_sourced_sibling_1018() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    let lib_name = lib.rsplit('/').next().expect("lib basename").to_owned();
+    let main = unique_uri("tcl");
+    lsp.open_ready(
+        &lib,
+        "proc greetPerson {name {greeting hello}} {\n    return \"$greeting, $name\"\n}\n",
+    );
+    lsp.open_ready(&main, &format!("source {lib_name}\ngreetPerson Alice\n"));
+
+    let call = hover(&mut lsp, &main, 1, 4);
+    assert!(
+        call.contains("greetPerson"),
+        "cross-file call hover must name the proc: {call:?}",
+    );
+    assert!(
+        call.contains("name") && call.contains("greeting"),
+        "…and render its real parameter list: {call:?}",
+    );
+
+    // The same symbol hovered at its own declaration renders the same body —
+    // one renderer, one input, so the two views cannot drift apart.
+    let decl = hover(&mut lsp, &lib, 0, 8);
+    assert_eq!(call, decl, "call-site and declaration hover must agree");
+}
+
+/// TN: a command nothing in the workspace defines still hovers nothing. The
+/// fallback resolves real symbols; it does not invent one for a typo.
+#[test]
+fn hover_stays_empty_for_a_command_no_document_defines_1018() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    let lib_name = lib.rsplit('/').next().expect("lib basename").to_owned();
+    let main = unique_uri("tcl");
+    lsp.open_ready(&lib, "proc greetPerson {name} { return $name }\n");
+    lsp.open_ready(&main, &format!("source {lib_name}\ngreetPersonn Alice\n"));
+    assert!(
+        hover_text(&lsp.hover(&main, 1, 4)).is_empty(),
+        "a command no document defines must hover nothing",
+    );
+}
+
+/// FP guard: the fallback is gated on the cursor sitting on a *command head*.
+/// An argument word that happens to match a sibling document's proc name must
+/// not pop that proc's signature up.
+#[test]
+fn hover_does_not_resolve_an_argument_word_across_documents_1018() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    let lib_name = lib.rsplit('/').next().expect("lib basename").to_owned();
+    let main = unique_uri("tcl");
+    lsp.open_ready(&lib, "proc zqwidget {name} { return $name }\n");
+    // `zqwidget` here is `puts`'s argument, not a command head.
+    lsp.open_ready(&main, &format!("source {lib_name}\nputs zqwidget\n"));
+    let text = hover_text(&lsp.hover(&main, 1, 7));
+    assert!(
+        !text.contains("proc ::zqwidget"),
+        "an argument word must not resolve to a sibling proc: {text:?}",
+    );
+}
+
+/// Per-call counter for the autoload-hover fixture dir.
+static AUTOLOAD_HOVER_N: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+
+/// The issue's own repro (tcllib's `modules/math/math.tcl` shape): a package
+/// whose commands are declared in a sibling file reached through
+/// `auto_path` / `tclIndex`, with no `source` edge to follow.
+///
+/// Oracle (`tclsh8.6` and `tclsh9.0`, identical): the script runs and prints
+/// `frob 1 2 3 4` / `42`, so `::math::zzqfrobnicate` and `::math::wibblenum`
+/// in `misc.tcl` are the real, unambiguous targets. Go-to-definition already
+/// jumped there; hover showed nothing.
+#[test]
+fn hover_resolves_an_autoloaded_library_proc_1018() {
+    use std::sync::atomic::Ordering;
+
+    let libdir = std::env::temp_dir().join(format!(
+        "tcl-lsp-e2e-hover-autoload-{}-{}",
+        std::process::id(),
+        AUTOLOAD_HOVER_N.fetch_add(1, Ordering::Relaxed)
+    ));
+    let pkgdir = libdir.join("mathlib");
+    std::fs::create_dir_all(&pkgdir).expect("mk mathlib dir");
+    std::fs::write(
+        pkgdir.join("misc.tcl"),
+        "proc ::math::zzqfrobnicate {val args} {\n    return \"frob $val $args\"\n}\n\
+         proc ::math::wibblenum {n} {\n    return [expr {$n * 2}]\n}\n",
+    )
+    .expect("write misc.tcl");
+    std::fs::write(
+        pkgdir.join("tclIndex"),
+        "# Tcl autoload index file, version 2.0\n\
+         set auto_index(::math::zzqfrobnicate) [list source [file join $dir misc.tcl]]\n\
+         set auto_index(::math::wibblenum) [list source [file join $dir misc.tcl]]\n",
+    )
+    .expect("write tclIndex");
+
+    let mut lsp = Lsp::with_config(serde_json::json!({
+        "libraryPaths": [ libdir.to_string_lossy() ],
+    }));
+    let uri = unique_uri("tcl");
+    lsp.open_ready(&uri, "package require math\nmath::zzqfrobnicate 1 2 3 4\n");
+
+    // The package database is built asynchronously at startup; poll until the
+    // autoload tier can answer, then assert on what it rendered.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(15);
+    let mut text = hover(&mut lsp, &uri, 1, 8);
+    while text.is_empty() && std::time::Instant::now() < deadline {
+        std::thread::sleep(std::time::Duration::from_millis(100));
+        text = hover(&mut lsp, &uri, 1, 8);
+    }
+    assert!(
+        text.contains("math::zzqfrobnicate"),
+        "autoload hover must name the resolved proc: {text:?}",
+    );
+    assert!(
+        text.contains("val") && text.contains("args"),
+        "…and render its real signature: {text:?}",
+    );
+
+    // TN on the same fixture: a name the `tclIndex` does not declare still
+    // hovers nothing, so the tier resolves rather than blanket-suppressing.
+    let typo = unique_uri("tcl");
+    lsp.open_ready(&typo, "package require math\nmath::zzqfrobnicat 1\n");
+    assert!(
+        hover_text(&lsp.hover(&typo, 1, 8)).is_empty(),
+        "a command no index declares must hover nothing",
+    );
+
+    let _ = std::fs::remove_dir_all(&libdir);
+}
+
+/// Same-file hover is unchanged — the fallback only runs when the
+/// in-document provider has already declined.
+#[test]
+fn hover_same_file_behaviour_is_unchanged_1018() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc greetPerson {name} { return $name }\ngreetPerson Alice\n",
+    );
+    let text = hover(&mut lsp, &uri, 1, 4);
+    assert!(text.contains("greetPerson"), "same-file hover: {text:?}");
+}

--- a/rust/tcl-vm/src/cmd_package.rs
+++ b/rust/tcl-vm/src/cmd_package.rs
@@ -24,6 +24,7 @@
 
 use std::cmp::Ordering;
 
+use tcl_dialect::{compare_versions as cmp_version, version_satisfies as vsatisfies};
 use tcl_runtime_api::Completion;
 
 use crate::interp::{Vm, err, ok};
@@ -121,56 +122,6 @@ fn pkg_require(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
             }
         }
         None => err(format!("can't find package {name}")),
-    }
-}
-
-/// Parse a dotted version into numeric components.
-fn parse_version(v: &str) -> Vec<u64> {
-    v.split('.').map(|p| p.parse().unwrap_or(0)).collect()
-}
-
-/// Compare two dotted versions component-wise (missing components are 0).
-fn cmp_version(a: &str, b: &str) -> Ordering {
-    let (va, vb) = (parse_version(a), parse_version(b));
-    for i in 0..va.len().max(vb.len()) {
-        let x = va.get(i).copied().unwrap_or(0);
-        let y = vb.get(i).copied().unwrap_or(0);
-        match x.cmp(&y) {
-            Ordering::Equal => {}
-            other => return other,
-        }
-    }
-    Ordering::Equal
-}
-
-/// Does `version` satisfy a Tcl version requirement?
-///
-/// - `8.5` → `[8.5, 9)` (up to but excluding the next major).
-/// - `8.5-` → `[8.5, ∞)`.
-/// - `8.5-9.0` → `[8.5, 9.0)`.
-fn vsatisfies(version: &str, req: &str) -> bool {
-    let req = req.trim();
-    let (lo, hi) = if let Some((lo, hi)) = req.split_once('-') {
-        let hi = hi.trim();
-        (
-            lo.trim().to_string(),
-            if hi.is_empty() {
-                None
-            } else {
-                Some(hi.to_string())
-            },
-        )
-    } else {
-        // Bare `X.Y` → upper bound is the next major version.
-        let major = parse_version(req).first().copied().unwrap_or(0);
-        (req.to_string(), Some(format!("{}", major + 1)))
-    };
-    if cmp_version(version, &lo) == Ordering::Less {
-        return false;
-    }
-    match hi {
-        Some(hi) => cmp_version(version, &hi) == Ordering::Less,
-        None => true,
     }
 }
 


### PR DESCRIPTION
## Summary

Three resolver fixes plus four adversarial-review corrections, oracle-verified on tclsh8.6.16 + tclsh9.0.4:

- **#1019 idx 85 → generalised** — `handle_namespace_ensemble` used the lexical namespace walk (skips proc scopes), so an ensemble created inside `proc ::tk::Setup {}` homed to `::`. Fixed by swapping to `command_resolution_namespace` — and then sweeping **every** remaining caller of the lexical helper, all of which had the same blind spot (`oo::define`, snit/itcl definers, `namespace import`/`export` homing, alias resolution, registry definer qualification, deferred method bodies). The lexical helper and its cache are **deleted**: one function now answers "which namespace is current here?", so a future call site cannot pick the wrong one. Closes design-doc item D4.
- **#1017 + #1019 idx 42** — `pkgIndex.tcl` reachability: `package ifneeded` declarations behind guards are modelled symbolically (registry-driven — `TERMINATES_BLOCK` traits for early returns, `if`'s own grammar roles for clause chains, shared `truthiness`, `vsatisfies` via the consolidated `tcl_dialect::version_satisfies` that the VM now also uses) and evaluated per consumer against the workspace's target Tcl release. Fixes both directions: a `vsatisfies`-guarded package that can't load on the target no longer suppresses W123 (#1017), and a genuinely-available guarded package no longer over-flags (idx 42). Undecidable guards yield `Conditional`, which suppresses (W123 is already a Hint; a missed hint beats a false "unknown command" — decision table in the code).
- **#1018** — hover falls back to the same cross-document + autoload resolution tiers as go-to-definition (shared `position_is_command_head` gate, same renderer as the declaration site so the two cannot drift, memoised workspace analyses). The hover e2e suite gained its first cross-file coverage, with the plain-`source` control asserted byte-identical to the declaration's own hover.

**Adversarial-review fixes included:**
- **`apply`'s relative namespace was being resolved against the caller's namespace — real Tcl resolves it against the global namespace unconditionally** (`doc/apply.n`, `tclProc.c` literally prefixes `::`). Both the analyser *and* IR lowering had the bug (lowering's found while fixing — the two would otherwise disagree); both fixed with TP/TN/control tests, and the design doc corrected.
- pkgIndex reachability now descends `Body`/`LambdaLiteral` regions of body-taking commands as `Undecidable` — Tcl 9's own zipfs library index is `apply {{dir} { foreach {...} { package ifneeded ... } }}`, previously invisible. (Residual documented: the foreach loop variables aren't evaluated, so the core packages are reached but not yet named.)
- Patch-level version requirements (`9.0.1-`) are now `Undecidable` instead of falsely Unavailable against the two-component version model (the one direction that made W123 fire wrongly; two shipped 9.0 releases genuinely disagree on the answer).
- Dynamically-named procs (`proc [namespace current]::x` — real tcllib pki idiom) no longer produce phantom scope namespaces: scopes are keyed by the resolved name with a lexical fallback, with an incremental-vs-fresh parity guard.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.

Run on the integration of this PR with the sibling dispatch PR and the merged #1057 (conflict-free):

- `make rust-check` / `make check-all` — pass, zero new clippy allows
- `make prep-pr` — full workspace suite: pass, 0 failures
- `make test-ext` / `make test-emacs` / `make runtime-rust-test` (400 passed) — pass
- Per-branch: 11,036 tests passed, 0 failed
- Oracle: the full `vsatisfies` requirement matrix pinned as tests on both interpreters; the `apply` namespace rule verified against both plus the C source; the tcllib `modules/try/pkgIndex.tcl` parsed verbatim as a test fixture

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? **Yes** — analyser namespace homing for definitions inside qualified-name procs, and `apply` lambda-body homing (analyser + lowering).
- [x] I updated at least one relevant KCS note: `docs/design/tricky-name-resolution-surfaces.md` (D4 closed, §1.8 corrected), `docs/design/colon-names-and-addressability.md`, `docs/rust/incremental-analysis.md`, plus W123/refine doc comments.
- [ ] New compiler KCS note linked. (n/a — existing notes updated)

**Merge order:** conflict-free with the dispatch PR; either order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0178kD1P7t6ne1shFtwwkK54

---
_Generated by [Claude Code](https://claude.ai/code/session_0178kD1P7t6ne1shFtWwkK54)_