### PR TITLE
VM: namespace inscope appends its tail as list elements (#1056)

### DIFF
--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -418,6 +418,14 @@ plain text join.
 Reconstructing that needs list quoting the analyser does not model, so any
 trailing word means the call is consumed without walking.
 
+The **VM** does model it, because it has to run the command:
+`tcl-vm/src/cmd_namespace.rs`'s `inscope_script` builds the tail as a
+`Value::list` (whose string rep is the canonical `tcl_syntax::list::join_list`
+quoting) and concatenates it onto the script through the shared
+`tcl_cmd_core::list::concat`, so neither the quoting nor the `Tcl_ConcatObj`
+trim rule is re-derived there. With no trailing word it evaluates the script
+verbatim, matching C's `objc == 3` arm (issue #1056).
+
 `catch` is deliberately outside the family: it takes a single bounded script
 argument, so its remaining words are result / options variable names.
 

--- a/rust/tcl-fuzz/src/generator.rs
+++ b/rust/tcl-fuzz/src/generator.rs
@@ -122,7 +122,7 @@ impl Gen {
             // proc / namespace definitions are top-level only (matching the
             // oracle): nesting them changes scope semantics in ways the
             // generator doesn't model.
-            let arms = if depth == 0 { 9 } else { 7 };
+            let arms = if depth == 0 { 10 } else { 7 };
             match self.rng.below(arms) {
                 0 => self.if_stmt(depth),
                 1 => self.while_stmt(depth),
@@ -133,6 +133,7 @@ impl Gen {
                 6 => self.try_stmt(depth),
                 7 => self.proc_stmt(depth),
                 8 => self.namespace_stmt(depth),
+                9 => self.inscope_stmt(),
                 _ => self.leaf_statement(depth),
             }
         }
@@ -424,6 +425,58 @@ impl Gen {
         let _ = writeln!(self.out, "namespace eval {ns} {{");
         self.block(depth + 1);
         self.out.push_str("}\n");
+    }
+
+    /// `namespace inscope ns script ?arg ...?` — the one member of the
+    /// `Tcl_ConcatObj` eval family whose trailing words are appended as **list
+    /// elements** rather than space-joined (`NamespaceInscopeCmd`,
+    /// `generic/tclNamesp.c`), so a word holding whitespace or list punctuation
+    /// must reach the invoked command as exactly one argument.
+    ///
+    /// The differential regression seed for issue #1056: the VM space-joined
+    /// the tail, so `namespace inscope ns {p} {x y}` called `p` with two
+    /// arguments instead of one. The probe proc reports both the argument
+    /// *count* and each argument's text, so a wrong split is a stdout mismatch
+    /// against the reference `tclsh` rather than a silent pass. A zero-word
+    /// tail is drawn too, covering C's `objc == 3` arm (script evaluated
+    /// verbatim, nothing appended).
+    fn inscope_stmt(&mut self) {
+        let ns = *self.rng.pick(NS_NAMES);
+        let _ = writeln!(
+            self.out,
+            "namespace eval {ns} {{proc _shape {{args}} \
+             {{return [llength $args]:[join $args ,]}}}}"
+        );
+        let mut call = format!("namespace inscope {ns} {{_shape}}");
+        for _ in 0..self.rng.below(4) {
+            let arg = self.inscope_arg();
+            let _ = write!(call, " {arg}");
+        }
+        let _ = writeln!(self.out, "puts [{call}]");
+    }
+
+    /// One trailing word for [`Gen::inscope_stmt`], chosen to exercise the
+    /// list-element quoting on the way back out: whitespace (inner and
+    /// padding), an empty element, and `$`/`[`/`;`/`"` — each of which forces
+    /// quoting, so the word must not substitute, split, or terminate the
+    /// command inside the built script.
+    ///
+    /// Every shape keeps `{}`/`[]` **byte-balanced**. An unbalanced-brace
+    /// element (`a\{b`, the backslash-quoting path) is valid Tcl but trips the
+    /// generator's balanced-delimiter invariant, which is a raw byte count —
+    /// that path is pinned by the VM's own unit tests instead.
+    fn inscope_arg(&mut self) -> &'static str {
+        self.rng.pick(&[
+            "{x y}",
+            "{}",
+            "{a b c}",
+            "{  padded  }",
+            "{a;b}",
+            "{$nosub}",
+            "{[nosub]}",
+            "{a\"b}",
+            "plain",
+        ])
     }
 
     /// Mutate a dict-valued variable in place. An unset target is created by
@@ -932,6 +985,61 @@ mod tests {
                 .any(|p| s.contains(&format!("puts [{p}")))
         });
         assert!(proc_called, "no generated proc was ever called");
+    }
+
+    /// Issue #1056's regression seed. `namespace inscope` was never generated
+    /// at all, so the whole list-element tail rule went differentially
+    /// untested and the VM's space-join (which turned `{x y}` into two
+    /// arguments) could not be caught by a campaign. Proves the production is
+    /// live and that every interesting tail shape — the whitespace-bearing
+    /// word that is the minimal reproducer, an empty element, and the
+    /// substitution/terminator characters that force list quoting — actually
+    /// reaches a generated script.
+    #[test]
+    fn namespace_inscope_list_args_are_exercised() {
+        let cfg = GenConfig {
+            max_depth: 4,
+            max_stmts: 16,
+            ..GenConfig::default()
+        };
+        let corpus: Vec<String> = (0..600u64).map(|s| generate(s, &cfg)).collect();
+        let inscope_lines: Vec<&str> = corpus
+            .iter()
+            .flat_map(|s| s.lines())
+            .filter(|l| l.contains("namespace inscope "))
+            .collect();
+        assert!(
+            !inscope_lines.is_empty(),
+            "`namespace inscope` is never generated"
+        );
+        // The probe proc must accompany every call, else the differential has
+        // nothing to compare.
+        assert!(
+            corpus
+                .iter()
+                .any(|s| s.contains("proc _shape {args}") && s.contains("namespace inscope ")),
+            "the inscope probe proc is not emitted alongside the call"
+        );
+        for arg in [
+            "{x y}",
+            "{  padded  }",
+            "{}",
+            "{a;b}",
+            "{$nosub}",
+            "{[nosub]}",
+        ] {
+            assert!(
+                inscope_lines.iter().any(|l| l.contains(arg)),
+                "inscope tail shape never generated: {arg:?}"
+            );
+        }
+        // The bug's shape specifically: a trailing word containing whitespace.
+        assert!(
+            inscope_lines
+                .iter()
+                .any(|l| l.contains("{_shape} {x y}") || l.contains("{_shape} {a b c}")),
+            "no whitespace-bearing first tail word — the #1056 reproducer is not covered"
+        );
     }
 
     /// Issue #983's plan: `expr()`'s operator menu used to omit the TIP 461

--- a/rust/tcl-vm/src/cmd_namespace.rs
+++ b/rust/tcl-vm/src/cmd_namespace.rs
@@ -377,18 +377,54 @@ fn ns_inscope(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {
     let Some((ns, parts)) = rest.split_first() else {
         return err("wrong # args: should be \"namespace inscope namespace arg ?arg ...?\"");
     };
-    if parts.is_empty() {
+    let Some((script, extra)) = parts.split_first() else {
         return err("wrong # args: should be \"namespace inscope namespace arg ?arg ...?\"");
-    }
+    };
     let target = canon_ns(vm, &ns.to_str());
-    let body = parts
-        .iter()
-        .map(|v| v.to_str().to_string())
-        .collect::<Vec<_>>()
-        .join(" ");
+    let body = inscope_script(vm, script, extra);
     let mut call_argv = vec![Value::string("namespace"), Value::string("inscope")];
     call_argv.extend(rest.iter().cloned());
     eval_in_ns(vm, target, &body, call_argv)
+}
+
+/// The script `namespace inscope ns script ?arg ...?` evaluates:
+/// `Tcl_ConcatObj(script, list(arg …))` — `NamespaceInscopeCmd`
+/// (`generic/tclNamesp.c`) collects the trailing words into a **list object**
+/// and concatenates that list's string representation onto `script`. So the
+/// tail arrives as list *elements*, not as space-joined script text, and each
+/// word reaches the invoked command as exactly one argument however much
+/// whitespace or list punctuation it holds:
+///
+/// ```text
+/// namespace inscope :: {puts} {a b}   → prints "a b"  (one argument)
+/// namespace eval    :: {puts} {a b}   → error: can not find channel named "a"
+/// ```
+///
+/// (`namespace eval`'s plain space-join is right for *its* concat semantics;
+/// `inscope` is the one family member that list-quotes — the registry models
+/// the split as `SCRIPT_APPENDS_LIST_ARGS` refining `SCRIPT_CONCATENATES_ARGS`.
+/// Issue #1056: the VM used to space-join here too, so `{x y}` became two
+/// arguments.)
+///
+/// Both halves reuse the canonical implementations rather than re-deriving
+/// them: the list's string rep comes from `Value::list`'s
+/// `tcl_syntax::list::join_list` quoting (`Tcl_ScanElement` /
+/// `Tcl_ConvertElement`), and the concatenation itself is the shared
+/// `tcl_cmd_core::list::concat` (`Tcl_ConcatObj`) — which trims each part and
+/// drops one that is empty after trimming, so an all-whitespace `script`
+/// contributes no leading separator.
+///
+/// With no trailing words C takes the `objc == 3` arm and evaluates `script`
+/// verbatim (no concat, hence no trim and no trailing space), which the early
+/// return mirrors.
+fn inscope_script(vm: &mut Vm, script: &Value, extra: &[Value]) -> String {
+    if extra.is_empty() {
+        return script.to_str().to_string();
+    }
+    let tail = Value::list(extra.to_vec());
+    tcl_cmd_core::list::concat(vm, &[script.clone(), tail])
+        .to_str()
+        .to_string()
 }
 
 fn ns_eval(vm: &mut Vm, rest: &[Value]) -> Completion<Value> {

--- a/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
+++ b/rust/tcl-vm/tests/cmd_info_prefix_e2e.rs
@@ -705,6 +705,253 @@ fn namespace_inscope() {
     );
 }
 
+/// A namespace holding a `shape` proc that reports its argument *count* and
+/// each argument's exact text — the probe every `namespace inscope` tail test
+/// below calls, so a wrongly-split argument shows up as a different count.
+const SHAPE_NS: &str = "namespace eval foo \
+     {proc shape {args} {return [llength $args]:[join $args ,]}}; ";
+
+/// Issue #1056 — the differential pair that separates `namespace inscope` from
+/// the rest of the `Tcl_ConcatObj` eval family. `inscope` appends its trailing
+/// words as **list elements** (`NamespaceInscopeCmd` builds a list object and
+/// concatenates its string rep), so `{a b}` reaches `puts` as one argument;
+/// `namespace eval` space-joins, so the same words become two and `puts`
+/// reports a bad channel. The VM used to space-join in both.
+#[test]
+fn namespace_inscope_appends_list_args_where_eval_concatenates() {
+    // tclsh (both): prints "a b" — a single argument.
+    let (ok, res, out) = run("namespace inscope :: {puts} {a b}");
+    assert!(ok, "must not error: {res}");
+    assert_eq!(out, "a b\n");
+    // tclsh (both): `namespace eval` splits the same words -> bad channel "a".
+    let (ok, msg, _) = run("namespace eval :: {puts} {a b}");
+    assert!(!ok);
+    assert_eq!(msg, r#"can not find channel named "a""#);
+}
+
+/// Trailing words survive as one argument each, whatever whitespace or list
+/// punctuation they hold — the list quoting (`Tcl_ScanElement` /
+/// `Tcl_ConvertElement`) round-trips them.
+#[test]
+fn namespace_inscope_tail_args_are_list_elements() {
+    // tclsh (both): -> "1:x y"
+    assert_eq!(
+        run(&format!("{SHAPE_NS}namespace inscope foo shape {{x y}}")).1,
+        "1:x y"
+    );
+    // tclsh (both): two whitespace-bearing words stay two arguments -> "2:x y,p q"
+    assert_eq!(
+        run(&format!(
+            "{SHAPE_NS}namespace inscope foo shape {{x y}} {{p q}}"
+        ))
+        .1,
+        "2:x y,p q"
+    );
+    // tclsh (both): a leading/trailing-space word keeps its spaces -> "1:  sp  "
+    assert_eq!(
+        run(&format!("{SHAPE_NS}namespace inscope foo shape \"  sp  \"")).1,
+        "1:  sp  "
+    );
+    // tclsh (both): the script may itself be several words -> "2:one,two three"
+    assert_eq!(
+        run(&format!(
+            "{SHAPE_NS}namespace inscope foo {{shape one}} {{two three}}"
+        ))
+        .1,
+        "2:one,two three"
+    );
+}
+
+/// The list quoting must be canonical, so a word that is not brace-safe still
+/// round-trips: an unbalanced brace and a lone backslash take the backslash
+/// form, an empty word becomes `{}`, and `$`/`[`/`;` are braced so no
+/// substitution or command termination happens inside the built script.
+#[test]
+fn namespace_inscope_tail_args_special_characters() {
+    // tclsh (both): empty word -> "{}" -> one empty argument.
+    assert_eq!(
+        run(&format!("{SHAPE_NS}namespace inscope foo shape {{}}")).1,
+        "1:"
+    );
+    // tclsh (both): unbalanced open brace -> `a\{b`.
+    assert_eq!(
+        run(&format!("{SHAPE_NS}namespace inscope foo shape a\\{{b")).1,
+        "1:a{b"
+    );
+    // tclsh (both): a lone backslash -> `\\`.
+    assert_eq!(
+        run(&format!("{SHAPE_NS}namespace inscope foo shape \\\\")).1,
+        "1:\\"
+    );
+    // tclsh (both): an unbalanced double quote.
+    assert_eq!(
+        run(&format!("{SHAPE_NS}namespace inscope foo shape \"a\\\"b\"")).1,
+        "1:a\"b"
+    );
+    // tclsh (both): `$`/`[`/`;` are braced, so nothing substitutes and the
+    // command does not terminate early.
+    assert_eq!(
+        run(&format!("{SHAPE_NS}namespace inscope foo shape {{$nope}}")).1,
+        "1:$nope"
+    );
+    assert_eq!(
+        run(&format!("{SHAPE_NS}namespace inscope foo shape {{[nope]}}")).1,
+        "1:[nope]"
+    );
+    assert_eq!(
+        run(&format!("{SHAPE_NS}namespace inscope foo shape {{a;b}}")).1,
+        "1:a;b"
+    );
+    // tclsh (both): a mixed tail -> 4 arguments, the empty one preserved.
+    assert_eq!(
+        run(&format!(
+            "{SHAPE_NS}namespace inscope foo shape {{a b}} {{}} c\\{{d \\\\"
+        ))
+        .1,
+        "4:a b,,c{d,\\"
+    );
+}
+
+/// Zero trailing words: C takes the `objc == 3` arm and evaluates the script
+/// verbatim — no list is appended and no trailing space is added, so a list
+/// *inside* the script stays one argument and a plain script is untouched.
+#[test]
+fn namespace_inscope_zero_tail_args_leaves_script_verbatim() {
+    // tclsh (both): -> "1:x y"
+    assert_eq!(
+        run(&format!(
+            "{SHAPE_NS}namespace inscope foo {{shape {{x y}}}}"
+        ))
+        .1,
+        "1:x y"
+    );
+    // tclsh (both): the body still sees foo's variable -> "hi"
+    assert_eq!(
+        run("namespace eval foo {variable v hi}; namespace inscope foo {set v}").1,
+        "hi"
+    );
+}
+
+/// `Tcl_ConcatObj` trims each part and drops one that is empty after trimming:
+/// a padded script loses its padding, and an all-whitespace script contributes
+/// no leading separator at all (the tail alone becomes the script).
+#[test]
+fn namespace_inscope_script_is_concat_trimmed() {
+    // tclsh (both): -> "1:tail"
+    assert_eq!(
+        run(&format!(
+            "{SHAPE_NS}namespace inscope foo {{  shape  }} tail"
+        ))
+        .1,
+        "1:tail"
+    );
+    // tclsh (both): whitespace-only script -> the tail is the whole command.
+    assert_eq!(
+        run(&format!("{SHAPE_NS}namespace inscope foo {{   }} shape hi")).1,
+        "1:hi"
+    );
+}
+
+/// Namespace resolution is unchanged by the list-args fix: the target name is
+/// still resolved relative to the current namespace, and the body still sees
+/// the target's variables.
+#[test]
+fn namespace_inscope_relative_resolution_unchanged() {
+    // tclsh (both): `bar` resolves against `foo` -> "1:x y"
+    assert_eq!(
+        run("namespace eval foo {namespace eval bar \
+             {proc shape {args} {return [llength $args]:[join $args ,]}}}; \
+             namespace eval foo {namespace inscope bar shape {x y}}")
+        .1,
+        "1:x y"
+    );
+    // tclsh (both): the invoked proc sees its own namespace variable -> "hi/1/x y"
+    assert_eq!(
+        run("namespace eval foo {variable v hi; \
+             proc shape {args} {variable v; return $v/[llength $args]/[lindex $args 0]}}; \
+             namespace inscope foo shape {x y}")
+        .1,
+        "hi/1/x y"
+    );
+}
+
+/// The exact tail shapes the differential fuzzer's `namespace inscope`
+/// production emits (`rust/tcl-fuzz/src/generator.rs`, `inscope_arg`), pinned
+/// here so the VM side of the campaign's regression seed is asserted without
+/// having to run a campaign. Each expectation is the reference `tclsh` output
+/// for the identical generated line.
+#[test]
+fn namespace_inscope_fuzz_generator_tail_shapes() {
+    let ns = "namespace eval n1 {proc _shape {args} \
+              {return [llength $args]:[join $args ,]}}; ";
+    // tclsh (both): -> "0:" (zero-word tail, script evaluated verbatim).
+    assert_eq!(run(&format!("{ns}namespace inscope n1 {{_shape}}")).1, "0:");
+    // tclsh (both): -> "3:[nosub],a b c,x y"
+    assert_eq!(
+        run(&format!(
+            "{ns}namespace inscope n1 {{_shape}} {{[nosub]}} {{a b c}} {{x y}}"
+        ))
+        .1,
+        "3:[nosub],a b c,x y"
+    );
+    // tclsh (both): -> "3:  padded  ,a;b,[nosub]"
+    assert_eq!(
+        run(&format!(
+            "{ns}namespace inscope n1 {{_shape}} {{  padded  }} {{a;b}} {{[nosub]}}"
+        ))
+        .1,
+        "3:  padded  ,a;b,[nosub]"
+    );
+    // tclsh (both): -> "3:a\"b,a b c,plain"
+    assert_eq!(
+        run(&format!(
+            "{ns}namespace inscope n1 {{_shape}} {{a\"b}} {{a b c}} plain"
+        ))
+        .1,
+        "3:a\"b,a b c,plain"
+    );
+    // tclsh (both): -> "3:,$nosub,[nosub]" (leading empty element preserved).
+    assert_eq!(
+        run(&format!(
+            "{ns}namespace inscope n1 {{_shape}} {{}} {{$nosub}} {{[nosub]}}"
+        ))
+        .1,
+        "3:,$nosub,[nosub]"
+    );
+    // tclsh (both): -> "3:plain,  padded  ,[nosub]"
+    assert_eq!(
+        run(&format!(
+            "{ns}namespace inscope n1 {{_shape}} plain {{  padded  }} {{[nosub]}}"
+        ))
+        .1,
+        "3:plain,  padded  ,[nosub]"
+    );
+}
+
+/// A `namespace code` capture invoked with an extra argument is the real-world
+/// path through the list-args rule (Tk-style callbacks): the appended word
+/// arrives at the captured command as one argument.
+#[test]
+fn namespace_code_capture_invoked_with_extra_arg() {
+    // tclsh (both): -> "cb:1:x y"
+    assert_eq!(
+        run(
+            "proc cb {args} {return cb:[llength $args]:[join $args ,]}; \
+             set cap [namespace code cb]; eval $cap [list {x y}]"
+        )
+        .1,
+        "cb:1:x y"
+    );
+    assert_eq!(
+        run(
+            "proc cb {args} {return cb:[llength $args]:[join $args ,]}; \
+             ::namespace inscope :: cb {x y}"
+        )
+        .1,
+        "cb:1:x y"
+    );
+}
+
 /// `namespace export` + `namespace import` — an exported proc becomes callable
 /// unqualified after import.
 #[test]


### PR DESCRIPTION
## Summary

Fixes #1056. The VM's `ns_inscope` space-joined its trailing words; C Tcl's `NamespaceInscopeCmd` does `Tcl_ConcatObj(script, Tcl_NewListObj(...))` — the tail is appended as **list elements**, so `namespace inscope ::n p {x y}` must invoke `p` with the single argument `x y`. The analyser has modelled this correctly since #1062 (`SCRIPT_APPENDS_LIST_ARGS`); the VM now matches.

- New `inscope_script` helper composes the two existing canonical implementations rather than adding any new quoting code: element quoting via `Value::list`'s lazy string rep (`tcl_syntax::list::join_list`, the shared `Tcl_ScanElement`/`Tcl_ConvertElement`, hash-rule-faithful) and concatenation via `tcl_cmd_core::list::concat` (the shared `Tcl_ConcatObj`, backslash-aware trim + drop-empty-part, already used by the `concatStk` opcode).
- Zero-trailing-words mirrors C's `objc == 3` arm: script evaluated verbatim, no trim, no trailing space.
- Edge cases pinned against captured tclsh 9.0.4 **and** 8.6.14 transcripts (they agree on all): the eval/inscope differential pair, `{}` empty arg (incl. leading position), `a{b` / lone `\` / `a"b` escaping, `$nosub`/`[nosub]`/`a;b` staying unsubstituted single arguments, whitespace-padded and all-whitespace scripts (separator dropped), multi-word scripts, and namespace-relative target resolution unchanged.
- Fuzz: new `inscope_stmt`/`inscope_arg` generator productions (9 tail shapes) + a 600-seed liveness sweep, following the `RUST_ISSUE_064`/#983 convention — the differential fuzzer now exercises inscope tails permanently.
- Swept for duplicated lowering paths: analyser is trait-driven (no name checks); eBPF/WASM/explorer have zero inscope paths. One true twin found: `runtime/rust/src/cmd_namespace.rs:577` has the identical space-join bug — deliberately **not** touched here (separate crate outside the workspace with its own gates); handed to the harness PR alongside the `have_tommath` work.
- `docs/design/compiler/command-registry.md` updated so the `SCRIPT_APPENDS_LIST_ARGS` contract records the VM-side implementation and the shared helpers.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-vm` — 747 passed, 0 failed (26 suites; `cmd_info_prefix_e2e` 61 → 69 tests).
  - `cargo test -p tcl-fuzz` — 28 passed, 0 failed.
  - `cargo clippy -p tcl-vm -p tcl-fuzz --all-targets -- -D warnings` — clean, zero new allows.
  - `cargo fmt -- --check` — clean.
  - Oracle: every expectation captured from tclsh 9.0.4 and 8.6.14; 40 generated inscope-bearing fuzz scripts validated against tclsh 9.0 with argument counts matching the VM.
  - Note: `wasm_coro_e2e` (2 tests) fails only under an exported `CARGO_TARGET_DIR` (its nested `cargo build` inherits it and writes where the test doesn't look) — passes without it; pre-existing harness interaction, being addressed with the test-harness PR.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? No — VM runtime semantics only; the analyser-side contract (`SCRIPT_APPENDS_LIST_ARGS`) is unchanged and now honoured by the VM.
- [x] I updated at least one relevant KCS note: `docs/design/compiler/command-registry.md` (trait contract now records the VM implementation). The analyser-side note from #1062 needed no change.
- [ ] New compiler KCS note linked. (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_