### PR TITLE
Registry-first barrier gate, per-clause try conditionality, lambda-literal descent (#1055 #1065, audit idx 0)

### DIFF
--- a/docs/design/compiler/command-registry.md
+++ b/docs/design/compiler/command-registry.md
@@ -467,11 +467,21 @@ trait-carrying specs, per dialect.
 `BRANCH_SELECTED_BODY` marks a command whose body arguments run only when
 its own run-time selection picks them, and which performs no iteration —
 `if` (at most one clause body plus an optional `else`) and `try` (handler
-bodies reached only on the matching exception).
+bodies reached only on the matching exception, with `finally` the one
+exception that always runs).
 
 The fact a consumer needs is that nothing established inside such a body
 **dominates** the code after the command: a `package require` there is
 conditional, and a variable written there is not reliably set afterwards.
+
+The trait is command-level, so a command whose *clauses* differ — `try` — has
+its per-clause answer decided by the consumer that already models the clause
+grammar. `try`'s analyser hook raises `conditional_depth` for the main body
+and each `on` / `trap` handler body, and not for `finally`, which always runs
+(issue #1065); the per-clause table lives in
+[package-loading.md](../contracts/package-loading.md#analyser-extraction).
+A consumer reaching a body through the *generic* `ArgRole::Body` walk gets
+the command-level answer for every body, which is correct for `if`.
 
 Deliberately narrower than `CONTROL_FLOW`, which also covers `while` / `for`
 / `foreach` / `lmap` / `switch`. A loop body is *repeatable* as well as

--- a/docs/design/compiler/lowering-dispatch.md
+++ b/docs/design/compiler/lowering-dispatch.md
@@ -96,13 +96,27 @@ and lowers to richer IR nodes instead of the generic `IRBarrier`:
 
 1. Body argument's word-token type is `TokenType.STR` (braced literal).
    Anything else (ESC, VAR, CMD) stays on the barrier path.
-2. The body does not contain any nested `_DYNAMIC_BARRIER_COMMANDS` whose
-   own body is still dynamic. A braced `eval {uplevel 1 $x}` stays a
-   barrier because the inner `uplevel` has a dynamic body. See
-   `compiler/lowering_hooks/_barrier_gate.py::body_has_dynamic_barrier`.
-3. For `uplevel`, the level specifier must be absent, a bare integer, or
-   `#N` with a plain `TokenType.ESC` level token. `uplevel $lvl {...}`
-   stays a barrier.
+2. The body does not contain a nested script evaluator whose own script is
+   still dynamic. A braced `eval {uplevel 1 $x}` stays a barrier because
+   the inner `uplevel` has a dynamic body. See
+   `rust/tcl-compiler/src/lowering/mod.rs::body_has_dynamic_barrier`.
+   Both halves of that question are registry answers, never a name test
+   (issue #1055): a command is an evaluator when
+   `CommandRegistry::invocation_traits` — which composes `spec.traits |
+   sub.traits`, so the compound members `namespace eval`, `namespace
+   inscope`, and `interp eval` resolve too — reports
+   `Traits::EVALUATES_CODE`, and *which* words make up its script comes from
+   `arg_indices_for_role(…, ArgRole::Body)` plus, for a
+   `Traits::SCRIPT_CONCATENATES_ARGS` evaluator, every word after the first
+   script word (they concatenate into the same script, so a dynamic tail is
+   dynamic). An evaluator the registry exposes no script word for — a
+   malformed `uplevel 1`, or a command-prefix evaluator like `coroprobe` —
+   poisons the gate rather than being guessed at.
+3. For `uplevel`, the *lowering hook* still requires a static level (absent,
+   a bare integer, or `#N`) — `uplevel $lvl {...}` stays a barrier. The
+   gate in (2) does not re-derive the level: it asks the registry which word
+   is the script, so a dynamic level in a *nested* `uplevel $lvl {literal}`
+   does not by itself poison an outer relaxation.
 
 The gate is token-level. **No SSA or escape analysis is required** at
 lowering time; we look only at the lexed word structure.

--- a/docs/design/contracts/package-loading.md
+++ b/docs/design/contracts/package-loading.md
@@ -45,8 +45,28 @@ per-dialect spec packs, never as name-matching in a consumer (see
    require.
 3. Each `SignaturePackageRequire` carries the name, the optional version, its
    source span, and a `conditional` flag set when the require sits inside a
-   guarded branch (`if` / `catch` / `try`), so version inference does not
-   promote a guarded `package require Tcl 8.6` to an unconditional minimum.
+   guarded branch, so version inference does not promote a guarded
+   `package require Tcl 8.6` to an unconditional minimum. "Guarded" is
+   registry-driven, not a command-name list: the analyser raises
+   `conditional_depth` for a body the registry marks
+   `Traits::BRANCH_SELECTED_BODY` (`if`, `try`), plus `catch`'s script.
+   Per `try` clause, following C Tcl's own semantics (Tcl 9.0.4 `try(n)`;
+   `TclNRTryObjCmd` in `generic/tclCmdMZ.c`):
+
+   | `try` clause      | conditional | why |
+   |-------------------|-------------|-----|
+   | main body         | yes | it always *starts*, but an exception a handler swallows can cut it short, so nothing in it dominates the code after the `try` |
+   | `on` / `trap` body | yes | reached only on a matching completion code / `-errorcode` prefix |
+   | `finally` body    | **no** | it always runs, whatever the body and handlers did, so whenever control reaches past the `try` it has run |
+
+   The `if` modelling is the same shape: the always-evaluated condition is an
+   `ArgRole::Expr` argument and is never depth-bumped, only the
+   branch-selected bodies are (issue #1065).
+   The background `signature_scan` pre-pass answers the same question more
+   coarsely — it walks only `if` / `catch` / `try` bodies and marks *every*
+   recursed body conditional, `finally` included. It is a shallow index for
+   files never opened in the foreground, not a second authority; the
+   analyser's per-clause answer above is the precise one.
 4. Version is captured but currently only used by the package resolver and the
    version-gate diagnostics, not by the per-document command filter.
 

--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -98,7 +98,7 @@ pushed to this branch (§3/§6a); 2 tcllib findings remain, each with a
 detailed `root_cause_hint` but no refined plan (§6a). The main-wave audit
 (other 7 corpora, 105 findings total) is now **fully complete and triaged**
 (§6b): 85 CONFIRMED (1 critical, 23 high, 60 medium, 1 low), 20 REFUTED.
-Twenty-four of these are **fixed**: idx 0 (medium, `acc4b7446` on
+Twenty-four of these are **fixed**: idx 0 (medium, PR #1068 on
 `claude/commandregistry-compiler-fixes-tshu8d-quickfixes`), idx 61
 (critical, §3's `438e56f`), idx 9
 (high, §3's `51d0a35`), idx 10 (high, §3's `2330862`), idx 18 (high, §3's
@@ -449,7 +449,7 @@ tclopt, ticklecharts, pix, tomato, tk) are differentially audited and
 merged into `data/06-main-audit-results-COMPLETE-105of105.json` (idx 0–48
 from the original `06-...-PARTIAL-49of105.json` batch, idx 49–104 from the
 `wf_61c6b92a-e22` workflow's completed resume run). **85 CONFIRMED, 20
-REFUTED.** Of the 85 CONFIRMED: **24 fixed** (idx 0, medium — `acc4b7446`
+REFUTED.** Of the 85 CONFIRMED: **24 fixed** (idx 0, medium — PR #1068
 on `claude/commandregistry-compiler-fixes-tshu8d-quickfixes`; idx 61,
 critical — §3's
 `438e56f`; idx 9, high — §3's `51d0a35`; idx 10, high — §3's `2330862`;
@@ -703,7 +703,7 @@ mixin/oo::configurable class-scoping findings, idx 34/36).
 | autoindex | 1 | 73 (medium) |
 | safe_interp | 1 | 91 (medium) |
 
-**idx 0 — FIXED** (`acc4b7446`, branch
+**idx 0 — FIXED** (PR #1068, branch
 `claude/commandregistry-compiler-fixes-tshu8d-quickfixes`). The audit's
 headline `{*}$validateHelper` indirection claim was already correct
 abstention (REFUTED by the audit itself); the real bug it uncovered was a
@@ -714,11 +714,20 @@ reached its arguments through the shared registry-aware `descend_command`,
 which resolved `ArgRole::Body` only — so the whole `{params body}` list was
 re-segmented as script source and the parameter list became a command head.
 Once `ArgRole::LambdaLiteral` stopped that, an FN took its place: the
-lambda's real body was walked by nothing at all. `descend_command` now
-resolves `ArgRole::LambdaLiteral` alongside `ArgRole::Body` and descends only
-the braced *body element*, via the shared `split_lambda_literal` primitive —
-one fix in the single registry-aware descent entry point, so both collectors
-get it, with no command name anywhere in the change. Full write-up in
+lambda's real body was walked by nothing at all.
+
+Fixed by giving the substitution walk the same dispatch the top level has:
+`dispatch_nested_segment` gained an `AnalyserHookId::Apply` arm beside its
+existing `Proc` / `OoDefine` arms, so a substitution-position `apply` runs
+`handle_apply_command` — the lambda's own scope, rooted at the lambda's
+namespace, with its parameters bound there. `descend_command` deliberately
+still resolves `ArgRole::Body` only. A first attempt (corrected on Codex
+review of the PR) descended the lambda's body *element* from
+`descend_command` instead; that fixed the span but handed the body to the
+collectors as an ordinary body, which they walk in the **enclosing** scope —
+so a lambda-body `set` became a local of the calling proc and an
+explicit-namespace lambda resolved its calls in the caller's namespace. Full
+write-up, including why the sub-span alone is not enough, in
 [the `apply` lambda KCS note](../../kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md)
 (instance 8).
 

--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -98,7 +98,9 @@ pushed to this branch (§3/§6a); 2 tcllib findings remain, each with a
 detailed `root_cause_hint` but no refined plan (§6a). The main-wave audit
 (other 7 corpora, 105 findings total) is now **fully complete and triaged**
 (§6b): 85 CONFIRMED (1 critical, 23 high, 60 medium, 1 low), 20 REFUTED.
-Twenty-three of these are **fixed**: idx 61 (critical, §3's `438e56f`), idx 9
+Twenty-four of these are **fixed**: idx 0 (medium, `acc4b7446` on
+`claude/commandregistry-compiler-fixes-tshu8d-quickfixes`), idx 61
+(critical, §3's `438e56f`), idx 9
 (high, §3's `51d0a35`), idx 10 (high, §3's `2330862`), idx 18 (high, §3's
 `1f5fe71`), idx 29 (high, already resolved by idx 18's fix, pinned in
 §3's `d218463`), idx 31 (high, §3's `89b75a5`), idx 32 (high, §3's
@@ -110,7 +112,7 @@ idx 70 (high, §3's `d5e4d65`), idx 71 (high, §3's `2339d4a`), idx 76
 (high, §3's `0bde16e`), idx 77 (high, §3's `51a630f`), idx 84 (high,
 partial — §3's `7115bc8`), idx 86 (high, §3's `99cf07f`), idx 90 (high,
 §3's `7d476f5`), idx 95 (high, §3's `ef36c73`), idx 94 (high, §3's
-`959bca8`); the other 62
+`959bca8`); the other 61
 main-wave findings are clustered by feature/root-cause with a
 priority-ordered table in
 §6b, ready for a future session to pick up efficiently. Nothing
@@ -447,7 +449,9 @@ tclopt, ticklecharts, pix, tomato, tk) are differentially audited and
 merged into `data/06-main-audit-results-COMPLETE-105of105.json` (idx 0–48
 from the original `06-...-PARTIAL-49of105.json` batch, idx 49–104 from the
 `wf_61c6b92a-e22` workflow's completed resume run). **85 CONFIRMED, 20
-REFUTED.** Of the 85 CONFIRMED: **23 fixed** (idx 61, critical — §3's
+REFUTED.** Of the 85 CONFIRMED: **24 fixed** (idx 0, medium — `acc4b7446`
+on `claude/commandregistry-compiler-fixes-tshu8d-quickfixes`; idx 61,
+critical — §3's
 `438e56f`; idx 9, high — §3's `51d0a35`; idx 10, high — §3's `2330862`;
 idx 18, high — §3's `1f5fe71`; idx 29, high, same root cause as idx 18 —
 §3's `d218463`; idx 31, high — §3's `89b75a5`; idx 32, high — §3's
@@ -459,7 +463,7 @@ partial — §3's `65dda01`; idx 68, high — §3's `134c31c`; idx 70, high —
 `0bde16e`; idx 77, high — §3's `51a630f`; idx 84, high, partial — §3's
 `7115bc8`; idx 86, high — §3's `99cf07f`; idx 90, high — §3's `7d476f5`;
 idx 95, high — §3's `ef36c73`; idx 94, high — §3's `959bca8`),
-**62 remaining**.
+**61 remaining**.
 
 **By corpus** (confirmed only): ticklecharts 20, tk 17, argparse 10,
 SpiceGenTcl 10, tclopt 13 (6+7, split across two inconsistent corpus-label
@@ -673,7 +677,7 @@ users, a worse failure mode than the narrower, but fully oracle-grounded,
 `CONFIGURE`-tracking fix actually shipped. Left as a documented, low-risk
 follow-up for a session with Tk oracle access.
 
-#### Priority tier 2 — medium + low (60 + 1 = 61 findings), grouped by feature for clustering
+#### Priority tier 2 — medium + low (60 + 1 = 61 findings, 1 already fixed), grouped by feature for clustering
 
 Group findings sharing a feature/root-cause together in one fix pass the
 way idx 107+115 and idx 118+119 were — many of these look like they share
@@ -685,7 +689,7 @@ mixin/oo::configurable class-scoping findings, idx 34/36).
 |---|---|---|
 | tclOO | 10 | 15, 16, 34, 35, 36, 53, 54, 55, 96, 97 (all medium) |
 | namespaces | 8 | 3, 19, 43, 44, 64, 65, 75, 85 (all medium) |
-| tricky_indirection | 7 | 0, 1, 2, 14, 49, 50, 51 (all medium) |
+| tricky_indirection | 7 | 0 (medium, **FIXED** — see below), 1, 2, 14, 49, 50, 51 (all medium) |
 | upvar | 7 | 7, 22, 57, 58, 59, 98, 99 (all medium) |
 | proc_args | 7 | 11, 28, 37, 62, 67, 78, 104 (all medium) |
 | tcl_mathop | 4 | 30, 80, 81, 103 (all medium) |
@@ -698,6 +702,25 @@ mixin/oo::configurable class-scoping findings, idx 34/36).
 | eval | 1 | 24 (medium) |
 | autoindex | 1 | 73 (medium) |
 | safe_interp | 1 | 91 (medium) |
+
+**idx 0 — FIXED** (`acc4b7446`, branch
+`claude/commandregistry-compiler-fixes-tshu8d-quickfixes`). The audit's
+headline `{*}$validateHelper` indirection claim was already correct
+abstention (REFUTED by the audit itself); the real bug it uncovered was a
+literal `apply {{params} {body}}` inside a `[…]` command substitution
+reporting `W123 Unknown command '<the parameter list>'`. `apply` reached that
+way never went through `AnalyserHookId::Apply`; the substitution collectors
+reached its arguments through the shared registry-aware `descend_command`,
+which resolved `ArgRole::Body` only — so the whole `{params body}` list was
+re-segmented as script source and the parameter list became a command head.
+Once `ArgRole::LambdaLiteral` stopped that, an FN took its place: the
+lambda's real body was walked by nothing at all. `descend_command` now
+resolves `ArgRole::LambdaLiteral` alongside `ArgRole::Body` and descends only
+the braced *body element*, via the shared `split_lambda_literal` primitive —
+one fix in the single registry-aware descent entry point, so both collectors
+get it, with no command name anywhere in the change. Full write-up in
+[the `apply` lambda KCS note](../../kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md)
+(instance 8).
 
 Each idx's full detail (summary, failure_scenario, oracle_output,
 lsp_output, root_cause_hint) is in

--- a/docs/kcs/codes/kcs-diagnostic-w135-command-needs-newer-package.md
+++ b/docs/kcs/codes/kcs-diagnostic-w135-command-needs-newer-package.md
@@ -41,6 +41,17 @@ ttk::button .b -text Hi
 
 Raise the `package require` to at least the version the command needs. A `package require` *without* a version is treated as permissive (no floor to compare against), so it never draws W135.
 
+## A guarded `package require` does not raise the floor
+
+Only a `package require` that definitely runs sets the version floor. One inside a branch that may not be taken — an `if` body, a `catch` script, a `try` body, or a `try` `on`/`trap` handler — is recorded as *guarded* and is ignored when comparing versions, because at runtime the package may never have been loaded on the path that reaches the command:
+
+```tcl
+catch {package require Tk 8.6}
+ttk::button .b -text Hi     ;# still W135 — the require may not have run
+```
+
+A `try`'s `finally` script is the one exception: it always runs, whatever the body and the handlers did, so a `package require` there *does* raise the floor. Move the require out of the guard (or add an unguarded one) if you mean it to count.
+
 ## How to suppress
 
 Add `# noqa: W135` at the end of the offending line.

--- a/docs/kcs/codes/kcs-diagnostic-w136-option-needs-newer-package.md
+++ b/docs/kcs/codes/kcs-diagnostic-w136-option-needs-newer-package.md
@@ -41,6 +41,8 @@ entry .e -placeholder "type here"
 
 Raise the `package require` to at least the version the option needs. A `package require` *without* a version is treated as permissive (no floor to compare against), so it never draws W136.
 
+A `package require` inside a branch that may not be taken does not raise the floor either — see [the guarded-require section of the W135 note](kcs-diagnostic-w135-command-needs-newer-package.md#a-guarded-package-require-does-not-raise-the-floor).
+
 ## How to suppress
 
 Add `# noqa: W136` at the end of the offending line.

--- a/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
+++ b/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
@@ -321,15 +321,33 @@ differential audit's finding **idx 0** (georgtree/argparse), which found the
      unknown command inside it escaped W123 and every other per-command
      check whenever the `apply` sat inside a `[…]`.
 
-   Fixed in `descend_command` itself rather than in either collector — it is
-   the single registry-aware descent entry point, so both callers (and any
-   future one) get it at once. It now resolves `ArgRole::LambdaLiteral`
-   arguments alongside `ArgRole::Body` ones and descends **only the braced
-   body element**, via the same `split_lambda_literal` /
-   `LambdaLiteralElements::braced_body` primitive every other consumer uses.
-   `descend_span` (new, beside `descend_token`) descends a list *element*'s
-   content span rather than a whole delimited word. No command name appears
-   anywhere in the change.
+   Fixed by giving the substitution walk the *same* dispatch the top level
+   has: `dispatch_nested_segment` gained an `AnalyserHookId::Apply` arm, beside
+   the `Proc` / `OoDefine` arms it already had, so a substitution-position
+   `apply` runs `handle_apply_command` — which builds the lambda's own `Proc`
+   scope rooted at the lambda's namespace, binds its parameters there, and
+   walks the body in it. `descend_command` still resolves `ArgRole::Body` only,
+   so nothing walks the lambda twice and nothing walks it in the wrong scope.
+
+   The first attempt at this fix (PR #1068, corrected before merge on review)
+   instead taught `descend_command` to descend the lambda's braced *body
+   element*. That killed the FP and the FN, but it was still wrong in the same
+   way instances 2 / 4 / 5 / 6 above were wrong: it handed the body to the
+   generic collectors as an ordinary `Body` argument, and every one of them
+   walks a body in the **enclosing** scope. So
+   `proc p {} { set r [apply {{} {gets stdin leaked}}]; puts $leaked }`
+   recorded `leaked` as a local of `p` (tclsh9.0.4: `puts $leaked` raises
+   `can't read "leaked": no such variable` — the lambda's frame is gone by
+   then), and a lambda with an explicit namespace element resolved its
+   bareword calls in the caller's namespace rather than that one. **Getting
+   the sub-span right is not enough for a lambda body — it needs the frame
+   too**, which is precisely why the isolated walk belongs to `apply`'s hook
+   and not to a generic body descent. `descend_command`'s doc comment now says
+   so, with a TN test pinning that it yields no body for a `LambdaLiteral`
+   argument.
+
+   No command name appears anywhere in the change: the substitution dispatch
+   matches on the registry-stamped hook, exactly as the top-level chain does.
 
 ## Failure modes
 
@@ -399,13 +417,14 @@ differential audit's finding **idx 0** (georgtree/argparse), which found the
   `package_ifneeded_literal_script_recurses_as_body`,
   `my_call_inside_apply_lambda_body_does_not_resolve`
 - `rust/tcl-compiler/src/parsing/syntax/descend.rs` —
-  `descend_command_resolves_the_lambda_body_element`,
-  `descend_command_skips_untrustworthy_lambda_shapes`
+  `descend_command_yields_no_body_for_a_lambda_literal`
 - `rust/tcl-compiler/src/analyser/diagnostics/tests.rs` —
   `apply_lambda_in_command_substitution_does_not_report_its_parameter_list`
   (the audit's own repro), `apply_lambda_body_in_command_substitution_is_walked`,
   `plain_body_argument_in_command_substitution_still_walked`,
-  `apply_lambda_parameters_named_like_commands_draw_no_unknown_command`
+  `apply_lambda_parameters_named_like_commands_draw_no_unknown_command`,
+  `apply_lambda_in_command_substitution_keeps_its_own_frame`,
+  `apply_lambda_in_command_substitution_records_its_namespace`
 - `rust/tcl-compiler/src/lambda_literal.rs` — `split_lambda_literal`'s own
   unit tests (params/body/namespace splitting, dynamic-lambda guard) and
   `split_lambda_literal_decoded`'s (`decodes_bare_body_backslash_escape`,

--- a/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
+++ b/docs/kcs/kcs-issue-apply-lambda-body-not-highlighted-via-list-quoting.md
@@ -299,6 +299,38 @@ no instances of its own:
    inference. Not a fix here since there's nothing live to fix; a flag for
    whoever touches that iterator next.
 
+An eighth instance surfaced from a different direction — the issue-923
+differential audit's finding **idx 0** (georgtree/argparse), which found the
+*original*, pre-role misparse still live in one walker:
+
+8. **The `[…]`-substitution collectors re-segmented the whole lambda list as
+   a script.** `apply` reached through the analyser's substitution walk —
+   `set r [apply {{name opt args} {…}} …]`, `puts [apply {…} …]`, anything
+   where `apply` is not the outermost command of a statement — never went
+   through `AnalyserHookId::Apply`. Instead `record_command_invocations` /
+   `collect_segment_recursive`
+   ([`rust/tcl-compiler/src/analyser/commands.rs`](../../rust/tcl-compiler/src/analyser/commands.rs))
+   reached its arguments through the shared registry-aware
+   [`descend_command`](../../rust/tcl-compiler/src/parsing/syntax/descend.rs),
+   which resolved `ArgRole::Body` only. Two symptoms, one cause:
+   - a **false positive** `W123 Unknown command 'name opt args'` on the
+     lambda's own parameter list, because an earlier revision of the
+     collector descended the whole `{params body}` word as script source;
+   - once the `LambdaLiteral` role stopped that, a **false negative** in its
+     place: the lambda's real body was walked by *nothing*, so a genuinely
+     unknown command inside it escaped W123 and every other per-command
+     check whenever the `apply` sat inside a `[…]`.
+
+   Fixed in `descend_command` itself rather than in either collector — it is
+   the single registry-aware descent entry point, so both callers (and any
+   future one) get it at once. It now resolves `ArgRole::LambdaLiteral`
+   arguments alongside `ArgRole::Body` ones and descends **only the braced
+   body element**, via the same `split_lambda_literal` /
+   `LambdaLiteralElements::braced_body` primitive every other consumer uses.
+   `descend_span` (new, beside `descend_token`) descends a list *element*'s
+   content span rather than a whole delimited word. No command name appears
+   anywhere in the change.
+
 ## Failure modes
 
 - Tagging a lambda-literal-shaped argument `ArgRole::Body` instead of
@@ -366,6 +398,14 @@ no instances of its own:
   lambda as executable),
   `package_ifneeded_literal_script_recurses_as_body`,
   `my_call_inside_apply_lambda_body_does_not_resolve`
+- `rust/tcl-compiler/src/parsing/syntax/descend.rs` —
+  `descend_command_resolves_the_lambda_body_element`,
+  `descend_command_skips_untrustworthy_lambda_shapes`
+- `rust/tcl-compiler/src/analyser/diagnostics/tests.rs` —
+  `apply_lambda_in_command_substitution_does_not_report_its_parameter_list`
+  (the audit's own repro), `apply_lambda_body_in_command_substitution_is_walked`,
+  `plain_body_argument_in_command_substitution_still_walked`,
+  `apply_lambda_parameters_named_like_commands_draw_no_unknown_command`
 - `rust/tcl-compiler/src/lambda_literal.rs` — `split_lambda_literal`'s own
   unit tests (params/body/namespace splitting, dynamic-lambda guard) and
   `split_lambda_literal_decoded`'s (`decodes_bare_body_backslash_escape`,

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -86,6 +86,18 @@ struct DispatchSite<'a> {
     scope_path: &'a [usize],
 }
 
+/// One resolved analyser-hook dispatch: the hook the head resolved to, plus
+/// the composed traits (`spec.traits | sub.traits`) of the concrete spec /
+/// subcommand it resolved to.
+///
+/// Carrying the traits alongside the hook is what lets a handler ask a
+/// registry question about *its own invocation* without re-fetching a spec by
+/// literal name — see [`Analyser::resolve_analyser_hook_call`].
+struct ResolvedAnalyserHook {
+    hook: tcl_registry::hooks::AnalyserHookId,
+    traits: tcl_registry::Traits,
+}
+
 /// Shared core registry standing in for [`Analyser::registry`] when a
 /// handler runs outside an `analyse*` entry point (unit harnesses drive
 /// handlers on a bare `Analyser::new()`, which never populates the
@@ -873,6 +885,41 @@ impl Analyser {
         cmd_name: &str,
         args: &[String],
     ) -> Option<tcl_registry::hooks::AnalyserHookId> {
+        self.resolve_analyser_hook_call(cmd_name, args)
+            .map(|resolved| resolved.hook)
+    }
+
+    /// The traits [`Self::dispatch_analyser_hook`] threads into a hook handler
+    /// for this head — `None` when the head resolves no hook.
+    ///
+    /// Test-support only: it lets a handler's own unit tests, which call the
+    /// handler directly rather than through the dispatch, obtain exactly the
+    /// traits production passes, so a hand-written trait set can never drift
+    /// from what the dispatch actually resolves.
+    #[cfg(test)]
+    pub(in crate::analyser) fn resolved_analyser_hook_traits(
+        &self,
+        cmd_name: &str,
+        args: &[String],
+    ) -> Option<tcl_registry::Traits> {
+        self.resolve_analyser_hook_call(cmd_name, args)
+            .map(|resolved| resolved.traits)
+    }
+
+    /// [`Self::resolve_analyser_hook`] plus the traits of the concrete spec /
+    /// subcommand the head resolved to — one resolution, both facts.
+    ///
+    /// A handler reached through hook dispatch must read its command's traits
+    /// from *this* resolution rather than re-fetching a spec by literal name:
+    /// the name test puts per-command knowledge back in the analyser, and it
+    /// silently diverges the moment a dialect variant (or a subcommand) shares
+    /// the hook. Traits are composed `spec.traits | sub.traits`, matching
+    /// [`tcl_registry::CommandRegistry::invocation_traits`].
+    fn resolve_analyser_hook_call(
+        &self,
+        cmd_name: &str,
+        args: &[String],
+    ) -> Option<ResolvedAnalyserHook> {
         if let Some(bare) = cmd_name.strip_prefix("::")
             && !bare.contains("::")
         {
@@ -880,13 +927,18 @@ impl Analyser {
         }
         let registry = self.registry.unwrap_or_else(fallback_registry);
         let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
-        registry
-            .resolve_call(
-                cmd_name,
-                &arg_strs,
-                tcl_registry::prelude::DialectSet::empty(),
-            )
-            .and_then(|resolved| resolved.analyser_hook)
+        let resolved = registry.resolve_call(
+            cmd_name,
+            &arg_strs,
+            tcl_registry::prelude::DialectSet::empty(),
+        )?;
+        Some(ResolvedAnalyserHook {
+            hook: resolved.analyser_hook?,
+            traits: resolved.spec.traits
+                | resolved
+                    .sub
+                    .map_or_else(tcl_registry::Traits::empty, |sub| sub.traits),
+        })
     }
 
     /// The single typed `match` over the resolved [`AnalyserHookId`].
@@ -911,7 +963,9 @@ impl Analyser {
         scope_path: &[usize],
     ) -> bool {
         use tcl_registry::hooks::AnalyserHookId as Hook;
-        let Some(hook) = self.resolve_analyser_hook(cmd_name, args) else {
+        let Some(ResolvedAnalyserHook { hook, traits }) =
+            self.resolve_analyser_hook_call(cmd_name, args)
+        else {
             // No stamped family — the definition-grammar-driven definers
             // (TclOO metaclass create, snit::type/widget, itcl::class) get
             // their chance, then the tracked-interpreter-handle dispatch
@@ -947,7 +1001,11 @@ impl Analyser {
             Hook::For => self.handle_for_command(args, arg_tokens, scope_path),
             Hook::Switch => self.handle_switch_command(args, arg_tokens, scope_path),
             Hook::Catch => self.handle_catch_command(args, arg_tokens, scope_path),
-            Hook::Try => self.handle_try_command(args, arg_tokens, scope_path),
+            // `traits` are this invocation's own, from the same resolution
+            // that produced the hook — the handler reads
+            // `BRANCH_SELECTED_BODY` off them rather than re-fetching a spec
+            // by literal name (PR #1068 review).
+            Hook::Try => self.handle_try_command(args, arg_tokens, scope_path, traits),
             // apply {{params} body} — owns its body walk (binds params,
             // analyses element 1) so the generic `ArgRole::Body`
             // recursion never mis-reads the parameter list as a command.
@@ -2493,18 +2551,23 @@ impl Analyser {
             }
         }
 
-        // A definition command (`proc`, a class definer, `oo::define`)
-        // nested inside a substitution — the feature-detection idiom
-        // `if {![catch {oo::configurable create Greeter {…}}]} {…}` — still
-        // defines its procedure/class and walks its body by the definer
-        // grammar, exactly as the top-level dispatch does.  Without this the
-        // definer's member keywords (`property`, `constructor`) and the
-        // defined name (`Greeter`) all draw W123 as unknown commands, even
-        // though W002 already reported the dialect-gated definer once.  The
-        // generic collector skips these bodies (`definition_handler_owns_body`)
-        // so members are never also dispatched as plain commands.  The
+        // A definition command (`proc`, a class definer, `oo::define`) or an
+        // `apply` lambda nested inside a substitution — the feature-detection
+        // idiom `if {![catch {oo::configurable create Greeter {…}}]} {…}`, or
+        // the ordinary `set r [apply {{…} {…}} …]` — still defines its
+        // procedure/class and walks its body **in the body's own scope**,
+        // exactly as the top-level dispatch does.  Without this the definer's
+        // member keywords (`property`, `constructor`) and the defined name
+        // (`Greeter`) all draw W123 as unknown commands, even though W002
+        // already reported the dialect-gated definer once, and a lambda body
+        // reached this way is walked by nothing at all (issue-923 audit
+        // finding idx 0).  The generic collector descends none of these
+        // bodies — a definer's by `definition_handler_owns_body`, a lambda's
+        // because `apply`'s script argument is `ArgRole::LambdaLiteral`, which
+        // `descend_command` deliberately does not resolve — so no body is ever
+        // also dispatched as a plain script in the *enclosing* scope.  The
         // dispatch mirrors the top-level chain exactly: the stamped `Proc` /
-        // `OoDefine` hooks first (the handlers no longer name-guard
+        // `OoDefine` / `Apply` hooks first (the handlers no longer name-guard
         // themselves), then the grammar-driven definer trio only on the
         // hookless path.
         // Each handler returns whether it claimed the command; nothing
@@ -2521,6 +2584,17 @@ impl Analyser {
                 }
                 Some(Hook::OoDefine) => {
                     self.handle_oo_define_command(&cmd_name, args, arg_tokens, scope_path);
+                }
+                // `apply {{params} body ?ns?}` — the handler builds the
+                // lambda's own `Proc` scope rooted at the lambda's namespace
+                // (element 2, or `::`), binds its parameters there, and walks
+                // the body in it.  Routing the substitution-position call
+                // through the same handler is what keeps the lambda's frame
+                // isolated: a variable the body sets is a local of the lambda,
+                // not of the enclosing proc, and a bareword call inside it
+                // resolves in the lambda's namespace (PR #1068 review).
+                Some(Hook::Apply) => {
+                    self.handle_apply_command(args, arg_tokens, scope_path);
                 }
                 None => {
                     let _claimed = self

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -384,6 +384,116 @@ Greeter new x
     );
 }
 
+/// FIX (issue-923 differential audit, finding idx 0) — a literal
+/// `apply {{params} {body}}` inside a `[…]` command substitution reported
+/// `Unknown command '<the parameter list>'`: the substitution collectors
+/// re-segmented the whole `{params body}` list as if it were script source,
+/// so the parameter-list word became a command head.
+///
+/// The fix is registry-role-driven, not `apply`-aware: `descend_command`
+/// resolves `ArgRole::LambdaLiteral` arguments through
+/// `lambda_literal::split_lambda_literal` and descends only the body
+/// element, so the parameter list is never walked as code and the body is.
+///
+/// Source is the audit's own repro — the `validateHelper` lambda body
+/// verbatim from `georgtree/argparse`'s `argparse.tcl:19-34`, with the outer
+/// `{*}$validateHelper` variable indirection removed so `apply` is called
+/// literally. Oracle: tclsh9.0.4 and tclsh8.6.14 both run it and print
+/// `green`, so every command in it is real.
+#[test]
+fn apply_lambda_in_command_substitution_does_not_report_its_parameter_list() {
+    let src = r#"set result [apply {{name opt args} {
+    if {[dict exists $opt enum]} {
+        set command [list tcl::prefix match -message "$name value" \
+                             {*}[if {[uplevel 1 {info exists exact}]} {list -exact}] [dict get $opt enum]]
+        set args [lmap arg $args {{*}$command $arg}]
+    }
+    return $args
+}} widget [dict create enum {red green blue}] gr]
+puts $result
+"#;
+    let mut a = crate::analyser::Analyser::new();
+    let unknown: Vec<String> = a
+        .analyse(src, "tcl9.0")
+        .diagnostics
+        .iter()
+        .filter(|d| d.code == DiagCode::W123)
+        .map(|d| d.message.clone())
+        .collect();
+    assert!(
+        unknown.is_empty(),
+        "the lambda's parameter list is not a command: {unknown:?}"
+    );
+}
+
+/// FN half of the same fix: descending the lambda's *body* element is what
+/// makes the commands inside it visible at all.  Before the fix a lambda
+/// body nested in a `[…]` substitution was walked by nothing, so a genuinely
+/// unknown command in it escaped W123 entirely.
+#[test]
+fn apply_lambda_body_in_command_substitution_is_walked() {
+    for src in [
+        "set r [apply {{a} {zz9unknowncmd}} 5]\nputs $r\n",
+        "puts [apply {{a} {zz9unknowncmd}} 5]\n",
+        "proc p {} { set r [apply {{a} {zz9unknowncmd}} 5]; return $r }\n",
+        "set r [catch {apply {{a} {zz9unknowncmd}} 5}]\nputs $r\n",
+        // Three-element lambda: element 2 is a namespace, not a script.
+        "set r [apply {{a} {zz9unknowncmd} ::ns} 5]\nputs $r\n",
+    ] {
+        let codes = codes_for_dialect(src, "tcl9.0");
+        assert!(
+            codes.contains(&"W123".to_string()),
+            "the lambda body's unknown command must be reported for {src:?}: {codes:?}"
+        );
+    }
+    // TP control — the same command at the top level was already reported.
+    assert!(
+        codes_for_dialect("apply {{a} {zz9unknowncmd}} 5\n", "tcl9.0")
+            .contains(&"W123".to_string())
+    );
+}
+
+/// TN for the lambda carve-out: an ordinary registry `ArgRole::Body`
+/// argument nested in the same substitution position is still a script and
+/// is still walked — the fix narrows nothing but the lambda shape.
+#[test]
+fn plain_body_argument_in_command_substitution_still_walked() {
+    for src in [
+        "set r [if {1} {zz9unknowncmd}]\nputs $r\n",
+        "set r [eval {zz9unknowncmd}]\nputs $r\n",
+        "set r [uplevel 1 {zz9unknowncmd}]\nputs $r\n",
+    ] {
+        let codes = codes_for_dialect(src, "tcl9.0");
+        assert!(
+            codes.contains(&"W123".to_string()),
+            "a plain body argument is still a script for {src:?}: {codes:?}"
+        );
+    }
+}
+
+/// FP guard — a lambda whose parameters are *named* like commands must draw
+/// no W123: the parameter list is never a script, whatever the words in it
+/// happen to spell.  Oracle (tclsh9.0.4, tclsh8.6.14): `apply {{set list}
+/// {…}} a b` binds locals named `set` and `list` and runs fine — the words
+/// are formal-parameter names, not calls.
+#[test]
+fn apply_lambda_parameters_named_like_commands_draw_no_unknown_command() {
+    for src in [
+        "set r [apply {{set list} {return \"$set$list\"}} a b]\nputs $r\n",
+        // A defaulted parameter whose default value is a bareword.
+        "set r [apply {{a {puts x}} {return $a}} 1]\nputs $r\n",
+        // A parameter list whose words are not commands at all — the shape
+        // that used to be reported as `Unknown command 'name opt args'`.
+        "set r [apply {{name opt args} {return $name}} a b c]\nputs $r\n",
+    ] {
+        let codes = codes_for_dialect(src, "tcl9.0");
+        assert!(
+            !codes.contains(&"W123".to_string()),
+            "parameter names are not command calls for {src:?}: {codes:?}"
+        );
+    }
+}
+
 #[test]
 fn w211_deliberately_skips_destructuring_writer_outputs() {
     // Policy pin (review-2 audit): a command-output variable the script

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -494,6 +494,122 @@ fn apply_lambda_parameters_named_like_commands_draw_no_unknown_command() {
     }
 }
 
+/// Scope isolation for the substitution-position lambda (PR #1068 review).
+///
+/// `apply`'s lambda body runs in a **fresh call frame**, so a variable it sets
+/// is a local of the lambda, never of the enclosing proc. Walking the body as
+/// an ordinary registry `Body` argument would bind it in whatever scope the
+/// `[…]` substitution sits in; routing the call through `apply`'s own analyser
+/// hook is what keeps the frame separate.
+///
+/// Oracle (tclsh9.0.4) for the reviewer's own repro
+/// `proc p {} { set r [apply {{} {gets stdin leaked}}]; puts $leaked }`:
+/// `can't read "leaked": no such variable` from `puts $leaked` — the lambda's
+/// `leaked` is invisible in `p`.
+#[test]
+fn apply_lambda_in_command_substitution_keeps_its_own_frame() {
+    let scoped_vars = |src: &str| -> Vec<String> {
+        let mut a = crate::analyser::Analyser::new();
+        let mut keys: Vec<String> = a.analyse(src, "tcl9.0").all_variables.into_keys().collect();
+        keys.sort();
+        keys
+    };
+    // TP — the reviewer's repro. `leaked` belongs to the lambda, not to `p`.
+    let vars = scoped_vars(
+        "proc p {} {\n    set r [apply {{} {gets stdin leaked}}]\n    puts $leaked\n}\n",
+    );
+    assert!(
+        !vars.iter().any(|v| v == "p::leaked"),
+        "the lambda's local must not leak into the enclosing proc: {vars:?}"
+    );
+    assert!(
+        vars.iter()
+            .any(|v| v.starts_with("apply@") && v.ends_with("::leaked")),
+        "the lambda's local belongs to the lambda's own scope: {vars:?}"
+    );
+    // …and the read after the `try`-less lambda still warns, matching the
+    // oracle's `can't read "leaked"`.
+    assert!(
+        codes_for_dialect(
+            "proc p {} {\n    set r [apply {{} {gets stdin leaked}}]\n    puts $leaked\n}\n",
+            "tcl9.0",
+        )
+        .contains(&"W210".to_string()),
+        "an undefined read after the lambda must still warn"
+    );
+    // TP — a plain `set` inside the lambda body, same isolation.
+    let vars = scoped_vars("proc p {} {\n    set r [apply {{} {set inner 1}}]\n    return $r\n}\n");
+    assert!(
+        !vars.iter().any(|v| v == "p::inner"),
+        "a lambda-body `set` must not bind in the caller: {vars:?}"
+    );
+    // TP — the lambda's *parameters* are bound too, in the lambda's scope
+    // (before the fix the substitution-position lambda registered none).
+    let vars = scoped_vars("set r [apply {{name opt args} {return $name}} a b c]\n");
+    for want in ["name", "opt", "args"] {
+        assert!(
+            vars.iter()
+                .any(|v| v.starts_with("apply@") && v.ends_with(&format!("::{want}"))),
+            "parameter {want} must bind in the lambda scope: {vars:?}"
+        );
+    }
+    // TN — a genuine enclosing-scope binding from the same statement is
+    // unaffected: `set r […]` still binds `r` in `p`.
+    let vars = scoped_vars("proc p {} {\n    set r [apply {{} {set inner 1}}]\n    return $r\n}\n");
+    assert!(
+        vars.iter().any(|v| v == "p::r"),
+        "the enclosing `set` still binds in the caller: {vars:?}"
+    );
+}
+
+/// The lambda's namespace argument decides where its body's bareword calls
+/// resolve — element 2, or the **global** namespace when absent, never the
+/// caller's (`doc/apply.n`; `TclNRApplyObjCmd` in `generic/tclProc.c`
+/// `::`-prefixes the word before the lookup).
+///
+/// Oracle (tclsh9.0.4 and tclsh8.6.14): with `helper` defined only in
+/// `::myns`, `apply {{} {helper} ::myns}` returns its result, while
+/// `apply {{} {helper}}` fails `invalid command name "helper"`.
+///
+/// The analyser records that namespace as a span-keyed override the LSP's
+/// command resolution consults. A substitution-position lambda recorded none
+/// at all before this fix (PR #1068 review).
+#[test]
+fn apply_lambda_in_command_substitution_records_its_namespace() {
+    let overrides = |src: &str| -> Vec<String> {
+        let mut a = crate::analyser::Analyser::new();
+        a.analyse(src, "tcl9.0")
+            .namespace_overrides
+            .into_iter()
+            .map(|(_, ns)| ns)
+            .collect()
+    };
+    // TP — explicit third element wins, in substitution position.
+    assert_eq!(
+        overrides("proc caller {} {\n    return [apply {{} {helper} ::myns}]\n}\n"),
+        vec!["::myns".to_string()],
+    );
+    // TP — an unqualified namespace word is still resolved against the global
+    // namespace, not the caller's.
+    assert_eq!(
+        overrides(
+            "namespace eval ::outer {\n    proc caller {} {\n        return [apply {{} {helper} sub}]\n    }\n}\n"
+        ),
+        vec!["::sub".to_string()],
+    );
+    // TN — no third element means the global namespace, not `caller`'s.
+    assert_eq!(
+        overrides("proc caller {} {\n    return [apply {{} {helper}}]\n}\n"),
+        vec!["::".to_string()],
+    );
+    // TN — the statement-position form was always right; it must stay
+    // byte-identical to the substitution-position answer.
+    assert_eq!(
+        overrides("proc caller {} {\n    apply {{} {helper} ::myns}\n}\n"),
+        overrides("proc caller {} {\n    return [apply {{} {helper} ::myns}]\n}\n"),
+    );
+}
+
 #[test]
 fn w211_deliberately_skips_destructuring_writer_outputs() {
     // Policy pin (review-2 audit): a command-output variable the script

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -3181,12 +3181,19 @@ impl Analyser {
     /// and the `on` / `trap` handler bodies are branch-selected, the
     /// `finally` body is not.  See [`Self::analyse_selected_body`].
     ///
+    /// `traits` are the composed traits of the concrete spec / subcommand the
+    /// dispatch already resolved this head to, threaded in rather than
+    /// re-fetched by name: a name lookup would put per-command knowledge back
+    /// in the analyser and would silently diverge from the dispatch the moment
+    /// a dialect variant shares this hook.
+    ///
     /// Dispatched via [`tcl_registry::hooks::AnalyserHookId::Try`].
     pub fn handle_try_command(
         &mut self,
         args: &[String],
         arg_tokens: &[Token],
         scope_path: &[usize],
+        traits: tcl_registry::Traits,
     ) -> bool {
         if args.is_empty() {
             return false;
@@ -3196,16 +3203,8 @@ impl Analyser {
         // carried by exactly `if` and `try`.  `try` reaches its bodies
         // through this hook instead of that walk, so without asking here a
         // `package require` inside a `try` was recorded unconditional
-        // (issue #1065).  The literal spec name is sound for the same reason
-        // `handle_catch_command`'s is: `AnalyserHookId::Try` dispatch has
-        // already resolved the head (qualified spellings included) to this
-        // spec.
-        let branch_selected = self.registry.is_some_and(|registry| {
-            registry.get("try").is_some_and(|spec| {
-                spec.traits
-                    .contains(tcl_registry::Traits::BRANCH_SELECTED_BODY)
-            })
-        });
+        // (issue #1065).
+        let branch_selected = traits.contains(tcl_registry::Traits::BRANCH_SELECTED_BODY);
         // Main try body at args[0].
         if let Some(body_tok) = arg_tokens.first().copied() {
             self.analyse_selected_body(&args[0], body_tok, scope_path, branch_selected);
@@ -7815,25 +7814,50 @@ mod tests {
 
     // handle_try_command
 
+    /// The traits `AnalyserHookId::Try` dispatch threads into
+    /// `handle_try_command` in production, resolved through that same path so
+    /// these unit tests cannot drift from it.
+    fn try_traits(a: &Analyser, args: &[String]) -> tcl_registry::Traits {
+        a.resolved_analyser_hook_traits("try", args)
+            .expect("`try` resolves the Try analyser hook")
+    }
+
     #[test]
     fn handle_try_canonical_returns_true() {
         let mut a = Analyser::new();
-        let handled = a.handle_try_command(&["body".to_string()], &[str_tok(span(0, 4))], &[]);
+        let args = ["body".to_string()];
+        let traits = try_traits(&a, &args);
+        let handled = a.handle_try_command(&args, &[str_tok(span(0, 4))], &[], traits);
         assert!(handled);
     }
 
     #[test]
     fn handle_try_no_args_returns_false() {
         let mut a = Analyser::new();
-        let handled = a.handle_try_command(&[], &[], &[]);
+        let traits = try_traits(&a, &[]);
+        let handled = a.handle_try_command(&[], &[], &[], traits);
         assert!(!handled);
+    }
+
+    /// The dispatch really does resolve `BRANCH_SELECTED_BODY` for a `try`
+    /// call, so the depth bump keys off a fact and not off a default.
+    #[test]
+    fn try_dispatch_resolves_the_branch_selected_body_trait() {
+        let a = Analyser::new();
+        let args = ["body".to_string()];
+        assert!(
+            try_traits(&a, &args).contains(tcl_registry::Traits::BRANCH_SELECTED_BODY),
+            "hook dispatch must hand the handler `try`'s own traits"
+        );
     }
 
     #[test]
     fn handle_try_walks_main_body() {
         // ``try {set y 1}`` — main body walks and lands ``y``.
         let mut a = Analyser::new();
-        a.handle_try_command(&["set y 1".to_string()], &[str_tok(span(5, 14))], &[]);
+        let args = ["set y 1".to_string()];
+        let traits = try_traits(&a, &args);
+        a.handle_try_command(&args, &[str_tok(span(5, 14))], &[], traits);
         assert!(a.result.global_scope.variables.contains_key("y"));
     }
 
@@ -7841,14 +7865,17 @@ mod tests {
     fn handle_try_walks_finally_body() {
         // ``try {} finally {set z 1}`` — finally clause body walks.
         let mut a = Analyser::new();
+        let args = [String::new(), "finally".to_string(), "set z 1".to_string()];
+        let traits = try_traits(&a, &args);
         a.handle_try_command(
-            &[String::new(), "finally".to_string(), "set z 1".to_string()],
+            &args,
             &[
                 str_tok(span(5, 7)),
                 esc_tok(span(8, 15)),
                 str_tok(span(16, 25)),
             ],
             &[],
+            traits,
         );
         assert!(a.result.global_scope.variables.contains_key("z"));
     }
@@ -7859,14 +7886,16 @@ mod tests {
         // handler body at offset i+3 walks; the varList at i+2
         // is *not* defined as a local.
         let mut a = Analyser::new();
+        let args = [
+            String::new(),
+            "on".to_string(),
+            "error".to_string(),
+            "result options".to_string(),
+            "set q 1".to_string(),
+        ];
+        let traits = try_traits(&a, &args);
         a.handle_try_command(
-            &[
-                String::new(),
-                "on".to_string(),
-                "error".to_string(),
-                "result options".to_string(),
-                "set q 1".to_string(),
-            ],
+            &args,
             &[
                 str_tok(span(5, 7)),
                 esc_tok(span(8, 10)),
@@ -7875,6 +7904,7 @@ mod tests {
                 str_tok(span(34, 43)),
             ],
             &[],
+            traits,
         );
         assert!(a.result.global_scope.variables.contains_key("q"));
         // The `on error {result options}` var-list binds the result message +
@@ -7889,14 +7919,16 @@ mod tests {
         // ``try {} trap NONE {result} {set q 1}`` — same shape
         // as ``on``, but the keyword is ``trap``.
         let mut a = Analyser::new();
+        let args = [
+            String::new(),
+            "trap".to_string(),
+            "NONE".to_string(),
+            "result".to_string(),
+            "set q 1".to_string(),
+        ];
+        let traits = try_traits(&a, &args);
         a.handle_try_command(
-            &[
-                String::new(),
-                "trap".to_string(),
-                "NONE".to_string(),
-                "result".to_string(),
-                "set q 1".to_string(),
-            ],
+            &args,
             &[
                 str_tok(span(5, 7)),
                 esc_tok(span(8, 12)),
@@ -7905,6 +7937,7 @@ mod tests {
                 str_tok(span(27, 36)),
             ],
             &[],
+            traits,
         );
         assert!(a.result.global_scope.variables.contains_key("q"));
     }

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -3177,6 +3177,10 @@ impl Analyser {
     ///   (4 words) — define the handler's ``VARLIST`` (e.g.
     ///   ``{result options}``), then recurse into ``BODY``.
     ///
+    /// Conditional-body depth, per clause kind (issue #1065): the main body
+    /// and the `on` / `trap` handler bodies are branch-selected, the
+    /// `finally` body is not.  See [`Self::analyse_selected_body`].
+    ///
     /// Dispatched via [`tcl_registry::hooks::AnalyserHookId::Try`].
     pub fn handle_try_command(
         &mut self,
@@ -3187,9 +3191,24 @@ impl Analyser {
         if args.is_empty() {
             return false;
         }
+        // The same trait-driven depth the generic body walk in
+        // `dispatch_body_arguments` applies — `Traits::BRANCH_SELECTED_BODY`,
+        // carried by exactly `if` and `try`.  `try` reaches its bodies
+        // through this hook instead of that walk, so without asking here a
+        // `package require` inside a `try` was recorded unconditional
+        // (issue #1065).  The literal spec name is sound for the same reason
+        // `handle_catch_command`'s is: `AnalyserHookId::Try` dispatch has
+        // already resolved the head (qualified spellings included) to this
+        // spec.
+        let branch_selected = self.registry.is_some_and(|registry| {
+            registry.get("try").is_some_and(|spec| {
+                spec.traits
+                    .contains(tcl_registry::Traits::BRANCH_SELECTED_BODY)
+            })
+        });
         // Main try body at args[0].
         if let Some(body_tok) = arg_tokens.first().copied() {
-            self.analyse_body(&args[0], body_tok, scope_path);
+            self.analyse_selected_body(&args[0], body_tok, scope_path, branch_selected);
         }
         // Walk handler / finally clauses.
         let mut i = 1;
@@ -3197,6 +3216,8 @@ impl Analyser {
             let kw = args[i].as_str();
             if kw == "finally" && i + 1 < args.len() {
                 if let Some(body_tok) = arg_tokens.get(i + 1).copied() {
+                    // A `finally` body is *not* branch-selected — see
+                    // `analyse_selected_body`.
                     self.analyse_body(&args[i + 1], body_tok, scope_path);
                 }
                 i += 2;
@@ -3215,7 +3236,7 @@ impl Analyser {
                 if let Some(body_tok) = arg_tokens.get(i + 3).copied()
                     && args[i + 3] != "-"
                 {
-                    self.analyse_body(&args[i + 3], body_tok, scope_path);
+                    self.analyse_selected_body(&args[i + 3], body_tok, scope_path, branch_selected);
                 }
                 i += 4;
             } else {
@@ -3223,6 +3244,57 @@ impl Analyser {
             }
         }
         true
+    }
+
+    /// [`Self::analyse_body`] with `conditional_depth` raised for the walk
+    /// when the owning command's bodies are branch-selected, so facts
+    /// recorded inside (a `package require`, a const-string write) do not
+    /// claim to dominate the code after the command.
+    ///
+    /// `branch_selected` comes from the owning command's
+    /// [`tcl_registry::Traits::BRANCH_SELECTED_BODY`] — the same trait the
+    /// generic body walk keys on — never from the command's name.
+    ///
+    /// Which of `try`'s clause bodies pass `true` follows C Tcl's `try`
+    /// semantics, modelled the way `if` already is: `if`'s always-evaluated
+    /// condition is an `ArgRole::Expr` argument and is never depth-bumped,
+    /// only its branch-selected bodies are.  For `try`:
+    ///
+    /// - the **main body** always *starts* running, but any statement in it
+    ///   may be superseded by an exception a handler then swallows, so
+    ///   nothing it establishes dominates the code after the `try`.
+    ///   Branch-selected — the same guarded-probe reading
+    ///   [`Self::handle_catch_command`] applies to `catch`'s script, and
+    ///   `try { package require Foo } on error {} {}` is precisely the
+    ///   idiomatic optional-dependency check.
+    /// - an **`on` / `trap` handler body** runs only when the body completed
+    ///   with a matching completion code / `-errorcode` prefix.
+    ///   Branch-selected.
+    /// - a **`finally` body** always runs: "an optional trailing finally
+    ///   script always runs — even when body or the handler raised an error,
+    ///   and irrespective of which handler, if any, matched" (Tcl 9.0.4
+    ///   `try(n)`; in `generic/tclCmdMZ.c` both of `TclNRTryObjCmd`'s
+    ///   continuations, `TryPostBody` and `TryPostHandler`, schedule the
+    ///   finally script before propagating).  So whenever control reaches
+    ///   past the `try` at all, the finally body has run — it is the one
+    ///   `try` clause that is **not** branch-selected, exactly as
+    ///   [`tcl_registry::Traits::BRANCH_SELECTED_BODY`]'s own documentation
+    ///   names it.  It is no more conditional than a straight-line statement,
+    ///   which can equally fail part-way.
+    fn analyse_selected_body(
+        &mut self,
+        body_text: &str,
+        body_tok: Token,
+        scope_path: &[usize],
+        branch_selected: bool,
+    ) {
+        if branch_selected {
+            self.conditional_depth += 1;
+        }
+        self.analyse_body(body_text, body_tok, scope_path);
+        if branch_selected {
+            self.conditional_depth -= 1;
+        }
     }
 
     /// Register the local-alias names introduced by `upvar`.
@@ -8821,14 +8893,79 @@ mod tests {
             vec![false],
             "a loop body is skippable-and-repeatable, a different question",
         );
-        // `try` carries the trait too, but reaches its bodies through its own
-        // analyser hook rather than the generic body walk, so this depth is
-        // never bumped for it. Pinned as it stands: the trait swap is
-        // behaviour-preserving, and closing that gap is a separate change to
-        // `handle_try_command`.
+        // `try` carries the trait too and reaches its bodies through its own
+        // analyser hook; that hook now honours the same trait (issue #1065),
+        // so the main body is conditional like `if`'s.
         assert_eq!(
             conditional_flags("try { package require Tcl 8.6 } on error {} {}\n"),
+            vec![true],
+        );
+    }
+
+    /// FIX (issue #1065) — `handle_try_command` bumps the branch-selected
+    /// depth per clause kind, so a `package require` records the right
+    /// conditionality wherever in a `try` it sits.
+    ///
+    /// Clause semantics are C Tcl's (Tcl 9.0.4 `try(n)`, `TclNRTryObjCmd` in
+    /// `generic/tclCmdMZ.c`): the main body may be cut short by an exception a
+    /// handler swallows and the `on`/`trap` handlers run only on a match — both
+    /// branch-selected — while `finally` always runs, so it is not.  See
+    /// `Analyser::analyse_selected_body` for the full reasoning.
+    #[test]
+    fn package_require_conditionality_per_try_clause_kind() {
+        let conditional_flags = |src: &str| -> Vec<bool> {
+            let mut a = crate::analyser::Analyser::new();
+            a.analyse(src, "tcl8.6")
+                .package_requires
+                .iter()
+                .map(|p| p.conditional)
+                .collect()
+        };
+        // TP — the issue's own repro: the guarded optional-dependency idiom.
+        assert_eq!(
+            conditional_flags("try { package require Foo } on error {} {}\n"),
+            vec![true],
+            "a require in the main try body is conditional",
+        );
+        // TP — an `on` handler body.
+        assert_eq!(
+            conditional_flags("try { set x 1 } on error {} { package require Foo }\n"),
+            vec![true],
+            "a require in an `on` handler is conditional",
+        );
+        // TP — a `trap` handler body.
+        assert_eq!(
+            conditional_flags(
+                "try { set x 1 } trap {POSIX ENOENT} {m o} { package require Foo }\n"
+            ),
+            vec![true],
+            "a require in a `trap` handler is conditional",
+        );
+        // TN — a `finally` body always runs, so it is not branch-selected.
+        assert_eq!(
+            conditional_flags("try { set x 1 } finally { package require Foo }\n"),
             vec![false],
+            "a `finally` body always runs — the require is unconditional",
+        );
+        // TN — a top-level require, the control.
+        assert_eq!(conditional_flags("package require Foo\n"), vec![false]);
+        // FN guard — the depth is restored after the walk, so a require that
+        // follows the whole `try` command is still unconditional.
+        assert_eq!(
+            conditional_flags(
+                "try { package require A } on error {} { package require B } finally { package require C }\npackage require D\n"
+            ),
+            vec![true, true, false, false],
+            "main body + handler conditional; finally and the following \
+             top-level require unconditional",
+        );
+        // FP guard — nesting a `try` inside an `if` must not leave the depth
+        // stuck: the require after both is still unconditional.
+        assert_eq!(
+            conditional_flags(
+                "if {$x} { try { package require A } finally { set y 1 } }\npackage require B\n"
+            ),
+            vec![true, false],
         );
     }
 

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -429,36 +429,46 @@ fn eval_list_literal_body(cmd_text: &str) -> Option<String> {
 /// The walk is deliberately shallow and token-based:
 ///
 /// 1. Segment the body into commands.
-/// 2. For each command whose name is in the dynamic-barrier set,
-///    inspect its own body-shaped argument (last arg).  If it isn't
-///    a `Str` token (a braced literal), poison.
+/// 2. For each command the registry marks as evaluating code, ask the
+///    registry which words its script is made of and poison unless
+///    every one of them is a braced literal (`Str`) word.
 /// 3. Recurse into nested braced bodies and into braced-arg shapes
 ///    of non-barrier commands so a nested
 ///    `if { … } { eval $x }` still trips the gate.
+///
+/// Which word is the script is **never** re-derived here (issue #1055):
+/// [`CommandRegistry::arg_indices_for_role`] answers it, so `uplevel`'s
+/// optional-level shape is resolved by the one contract-tested
+/// `uplevel_arg_roles` resolver instead of a second, subtly different
+/// level-word sniff.  The barrier test likewise composes subcommand
+/// traits ([`CommandRegistry::invocation_traits`]), so the compound
+/// eval-family members — `namespace eval`, `namespace inscope`,
+/// `interp eval`, all of which carry the eval-family bits on the
+/// *subcommand* — flow through the same path a bare `eval` does.
 ///
 /// Returns `true` when the body contains a nested dynamic-shape
 /// barrier (the caller should fall back to `IRBarrier`); `false`
 /// when the body is safe to relax.
 fn body_has_dynamic_barrier(body_text: &str, registry: &CommandRegistry) -> bool {
     use tcl_lexer::TokenType;
+    use tcl_registry::prelude::Traits;
     let commands = segment_commands(body_text);
     for sc in &commands {
         if sc.argv.is_empty() || sc.texts.is_empty() {
             continue;
         }
-        let name = sc.texts[0].as_str();
-        // A "dynamic barrier" command evaluates a script in another
-        // frame (`eval` / `uplevel`).  Sourced from the registry's
-        // `EVALUATES_CODE` trait (stamped on exactly those two)
-        // rather than a hardcoded name list; strip any leading `::`
-        // so the fully-qualified spellings resolve too.
-        let is_barrier = registry
-            .get(name.strip_prefix("::").unwrap_or(name))
-            .is_some_and(|s| {
-                s.traits
-                    .contains(tcl_registry::prelude::Traits::EVALUATES_CODE)
-            });
-        if !is_barrier {
+        let raw_name = sc.texts[0].as_str();
+        // Strip any leading `::` so the fully-qualified spellings resolve too.
+        let name = raw_name.strip_prefix("::").unwrap_or(raw_name);
+        let args: Vec<&str> = sc.texts[1..].iter().map(String::as_str).collect();
+        // A "dynamic barrier" command evaluates a script (`eval`,
+        // `uplevel`, `namespace eval`, `interp eval`, …).  Sourced from
+        // the registry's `EVALUATES_CODE` trait rather than a hardcoded
+        // name list.  `DialectSet::empty()` because the question is the
+        // command's *shape*, not its availability: a barrier is a barrier
+        // whichever dialect the file is analysed as.
+        let traits = registry.invocation_traits(name, &args, DialectSet::empty());
+        if !traits.contains(Traits::EVALUATES_CODE) {
             // Recurse into braced args of non-barrier commands so
             // nested barriers still trip the gate.
             for (i, tok) in sc.argv.iter().enumerate() {
@@ -475,45 +485,39 @@ fn body_has_dynamic_barrier(body_text: &str, registry: &CommandRegistry) -> bool
             }
             continue;
         }
-        // Name is a barrier — inspect its own body.
-        let args = &sc.texts[1..];
-        let arg_tokens = &sc.argv[1..];
-        if args.is_empty() {
-            // Malformed: no body. Poison so the outer hook falls
-            // back to IRBarrier (runtime can report the error).
+        // Name is a barrier — inspect the words its script is made of.
+        let body_indices = registry.arg_indices_for_role(name, &args, ArgRole::Body);
+        let Some(&first_body) = body_indices.first() else {
+            // The registry can point at no script word: a malformed call
+            // (`uplevel 1` — a wrong-#args error) or an evaluator whose
+            // code argument is a command *prefix* rather than a script
+            // (`coroprobe` / `coroinject`).  Poison so the outer hook
+            // falls back to IRBarrier and the runtime decides.
             return true;
-        }
-        // For ``uplevel`` skip the level arg if literal.
-        let body_idx = if name == "uplevel" || name == "::uplevel" {
-            let level = &args[0];
-            let level_is_int = !level.is_empty()
-                && (level.starts_with('#')
-                    || level
-                        .trim_start_matches('-')
-                        .chars()
-                        .all(|c| c.is_ascii_digit()));
-            if level_is_int {
-                if args.len() < 2 {
-                    return true;
-                }
-                let level_tok = &arg_tokens[0];
-                if level_tok.kind != TokenType::Esc {
-                    return true;
-                }
-                args.len() - 1
-            } else {
-                args.len() - 1
-            }
-        } else {
-            args.len() - 1
         };
-        let body_tok_nested = &arg_tokens[body_idx];
-        if body_tok_nested.kind != TokenType::Str {
-            return true;
-        }
-        // Recurse into the literal nested body.
-        if body_has_dynamic_barrier(&args[body_idx], registry) {
-            return true;
+        // `SCRIPT_CONCATENATES_ARGS`: the trailing words concatenate into
+        // the one script Tcl evaluates, so `uplevel 1 {set x 1} $tail`
+        // is dynamic even though the marked body word is a literal.  Check
+        // the whole tail from the first script word, not just the marked
+        // ones.
+        let script_words: Vec<usize> = if traits.contains(Traits::SCRIPT_CONCATENATES_ARGS) {
+            (first_body..args.len()).collect()
+        } else {
+            body_indices
+        };
+        for idx in script_words {
+            // `sc.argv` / `sc.texts` include the command name at 0, so the
+            // arg-relative index shifts by one.
+            let (Some(tok), Some(text)) = (sc.argv.get(idx + 1), sc.texts.get(idx + 1)) else {
+                return true;
+            };
+            if tok.kind != TokenType::Str {
+                return true;
+            }
+            // Recurse into the literal nested script word.
+            if body_has_dynamic_barrier(text, registry) {
+                return true;
+            }
         }
     }
     false
@@ -4491,6 +4495,92 @@ mod tests {
         // ``::eval`` and ``::uplevel`` are also caught.
         assert!(body_has_dynamic_barrier("::eval $x", &reg()));
         assert!(body_has_dynamic_barrier("::uplevel 1 $body", &reg()));
+    }
+
+    /// Issue #1055 — the gate resolves `uplevel`'s script word through the
+    /// registry's `ArgRole::Body` resolver, not a local level-word sniff, so
+    /// every documented `uplevel ?level? arg ?arg ...?` shape agrees with
+    /// `uplevel_body_arg_role_skips_optional_level` in `tcl-registry`.
+    #[test]
+    fn body_has_dynamic_barrier_uplevel_level_shapes_follow_the_registry() {
+        let r = reg();
+        // TN — a literal script in each level spelling relaxes.
+        for clean in [
+            "uplevel {set x 1}",
+            "uplevel 1 {set x 1}",
+            "uplevel #0 {set x 1}",
+            "uplevel $lvl {set x 1}",
+            "uplevel [expr {$n - 1}] {set x 1}",
+        ] {
+            assert!(
+                !body_has_dynamic_barrier(clean, &r),
+                "{clean} must not poison"
+            );
+        }
+        // TP — a substituted script word in each level spelling poisons.
+        for dirty in [
+            "uplevel $body",
+            "uplevel 1 $body",
+            "uplevel #0 $body",
+            "uplevel $lvl $body",
+            "uplevel 1 [gen]",
+        ] {
+            assert!(body_has_dynamic_barrier(dirty, &r), "{dirty} must poison");
+        }
+        // FN guard — the words after the script word concatenate into it
+        // (`SCRIPT_CONCATENATES_ARGS`), so a dynamic tail is still dynamic
+        // even though the marked body word is a braced literal.
+        assert!(body_has_dynamic_barrier("uplevel 1 {set x} $tail", &reg()));
+        assert!(body_has_dynamic_barrier("eval {set x} $tail", &reg()));
+        // …and an all-literal multi-word tail stays clean.
+        assert!(!body_has_dynamic_barrier("uplevel 1 {set x} {1}", &reg()));
+        // A bodyless `uplevel 1` is a wrong-#args error the registry exposes
+        // no body word for — poison rather than guess.
+        assert!(body_has_dynamic_barrier("uplevel 1", &reg()));
+        // The deleted local sniff accepted `-N` as a level (it stripped a
+        // leading `-` before the digit test); the registry does not, and the
+        // registry is right.  Oracle, tclsh8.6.14: with `proc -1 {args} {…}`
+        // defined, `uplevel -1 {set x 1}` *calls* `-1` with `set x 1` — the
+        // word is the script's first word, not a level.  tclsh9.0.4 instead
+        // errors `bad level "-1"`.  Under either reading the word is an
+        // unbraced script word, so the gate poisons.
+        assert!(body_has_dynamic_barrier("uplevel -1 {set x 1}", &reg()));
+    }
+
+    /// Issue #1055, the generalisation dividend: the eval-family *subcommand*
+    /// members carry `EVALUATES_CODE` / `SCRIPT_CONCATENATES_ARGS` on the
+    /// subcommand, not on the `namespace` / `interp` spec.  Composing them
+    /// (`invocation_traits`) plus registry-resolved body indices makes them
+    /// flow through the same path a bare `eval` does, which a parent-only
+    /// trait test missed entirely.
+    #[test]
+    fn body_has_dynamic_barrier_covers_compound_eval_family() {
+        let r = reg();
+        // TP — the script is substituted.
+        assert!(body_has_dynamic_barrier("namespace eval ns $body", &r));
+        assert!(body_has_dynamic_barrier("namespace inscope ns $body", &r));
+        assert!(body_has_dynamic_barrier("interp eval slave $body", &r));
+        // TN — a braced literal script relaxes, and its own contents are
+        // still recursed.
+        assert!(!body_has_dynamic_barrier("namespace eval ns {set x 1}", &r));
+        assert!(body_has_dynamic_barrier("namespace eval ns {eval $x}", &r));
+        // TN — a `namespace` subcommand that evaluates nothing is not a
+        // barrier, however dynamic its arguments are.
+        assert!(!body_has_dynamic_barrier("namespace delete $ns", &r));
+        assert!(!body_has_dynamic_barrier("namespace current", &r));
+    }
+
+    /// TN for the barrier test itself: an ordinary command with a
+    /// substituted argument is not a script evaluator, so it never poisons —
+    /// the gate keys on the registry trait, not on "has a `$var` argument".
+    #[test]
+    fn body_has_dynamic_barrier_non_body_command_is_clean() {
+        let r = reg();
+        assert!(!body_has_dynamic_barrier("set x $y", &r));
+        assert!(!body_has_dynamic_barrier("puts [format %s $x]", &r));
+        assert!(!body_has_dynamic_barrier("lappend acc $item", &r));
+        // A user command the registry does not know at all is not a barrier.
+        assert!(!body_has_dynamic_barrier("mycmd $script", &r));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/parsing/syntax/descend.rs
+++ b/rust/tcl-compiler/src/parsing/syntax/descend.rs
@@ -145,29 +145,74 @@ pub fn descend_token(sm: &SourceMap<'_>, token: Token, config: LexerConfig) -> D
     }
 }
 
-/// A registry-resolved `Body` argument of a command, descended.
+/// Descend an already-delimiter-free source region as a child CST.
+///
+/// The [`descend_token`] counterpart for a region that is *not* a whole
+/// word: a list **element** inside a braced word, such as the body element
+/// of an [`ArgRole::LambdaLiteral`] argument. `span` must address the
+/// element's content (no wrapping `{}`), so the child anchors at exactly
+/// `span.start()` and the region is by definition terminated — a caller
+/// that only has a whole delimited word wants `descend_token` instead.
+#[must_use]
+pub fn descend_span(sm: &SourceMap<'_>, span: tcl_lexer::Span, config: LexerConfig) -> Descended {
+    let (start, _end) = sm.range_positions(span);
+    let inner = sm.text(span);
+    let (document, _warnings) = build_document(inner, config);
+    let tree = SyntaxTree::with_parts(
+        document,
+        start.offset,
+        start.line,
+        start.character.get(),
+        inner.to_string(),
+        build_line_starts(inner),
+    );
+    Descended {
+        tree,
+        terminated: true,
+    }
+}
+
+/// A registry-resolved script argument of a command, descended.
 #[derive(Debug, Clone)]
 pub struct CommandBody {
     /// The real argument index (into `args` / `arg_tokens`).
     pub index: usize,
-    /// The body word's inner text.
+    /// The script's own text — the body word's inner text for an
+    /// [`ArgRole::Body`] argument, the body *element*'s text for an
+    /// [`ArgRole::LambdaLiteral`] one.
     pub text: String,
-    /// The owning `Str` token.
+    /// The owning `Str` word token.  For a lambda literal this is the whole
+    /// `{params body ?ns?}` word, not the body element — [`Self::text`] and
+    /// [`Self::descended`] are the element.
     pub token: Token,
-    /// The body's child CST.
+    /// The script's child CST.
     pub descended: Descended,
 }
 
-/// Descend each [`ArgRole::Body`] argument of a command as a child CST.
+/// Descend each script-bearing argument of a command as a child CST —
+/// [`ArgRole::Body`] arguments and the body element of
+/// [`ArgRole::LambdaLiteral`] ones.
 ///
 /// The single registry-aware descent entry point — the analogue of
-/// `green_tree.descend_command`, resolving body arguments through the
+/// `green_tree.descend_command`, resolving arguments through the
 /// registry's [`CommandRegistry::arg_indices_for_role`] (the Rust
 /// `iter_body_arguments`) so the set of descended bodies matches exactly.
 /// A body that is not a non-empty `Str` word is skipped (it is data, not
 /// a script the tree should re-lex).  [`ArgRole::Expr`] arguments are
 /// deliberately not routed here — they are handled by the expression
 /// lexer.
+///
+/// A [`ArgRole::LambdaLiteral`] argument (`apply {{params} {body}} …`) is a
+/// two- or three-element **list**, not a script: element 0 is the parameter
+/// list and element 1 the real body.  Descending the whole word would read
+/// the parameter list as a command head — the `Unknown command 'name opt
+/// args'` false positive of the issue-923 audit's finding idx 0, and the
+/// mis-parse `apply`'s own analyser hook exists to prevent — so only the
+/// body element is descended, via [`crate::lambda_literal`]'s shared split.
+/// Only a `{braced}` body element is descended: a bare or quoted element's
+/// backslash escapes collapse before `apply` ever evaluates it, so its
+/// source slice is not the script that runs (see
+/// [`crate::lambda_literal::LambdaLiteralElements::braced_body`]).
 ///
 /// `args` and `arg_tokens` are the command's arguments (excluding the
 /// command name), parallel and 0-indexed; `sm` maps the region the tokens
@@ -194,6 +239,29 @@ pub fn descend_command(
             text: text.to_string(),
             token,
             descended: descend_token(sm, token, config),
+        });
+    }
+    for index in registry.arg_indices_for_role(cmd_name, args, ArgRole::LambdaLiteral) {
+        let Some(&token) = arg_tokens.get(index) else {
+            continue;
+        };
+        if token.kind != TokenType::Str {
+            continue;
+        }
+        let Some(body) = crate::lambda_literal::split_lambda_literal(sm.source(), token)
+            .and_then(|elems| elems.braced_body())
+        else {
+            continue;
+        };
+        let text = sm.text(body);
+        if text.trim().is_empty() {
+            continue;
+        }
+        bodies.push(CommandBody {
+            index,
+            text: text.to_string(),
+            token,
+            descended: descend_span(sm, body, config),
         });
     }
     bodies
@@ -353,5 +421,65 @@ mod tests {
         let loop_body = bodies.iter().find(|b| b.index == 3).unwrap();
         assert!(loop_body.descended.is_terminated());
         assert_eq!(loop_body.descended.tree().text(), "puts $i");
+    }
+
+    /// Helper: `descend_command` over the first command of `src`.
+    fn bodies_of(registry: &CommandRegistry, src: &str) -> Vec<CommandBody> {
+        let sm = SourceMap::new(src);
+        let segs = crate::segmenter::segment_commands(src);
+        let cmd = &segs[0];
+        let args: Vec<&str> = cmd.args().iter().map(String::as_str).collect();
+        descend_command(
+            registry,
+            &sm,
+            cmd.name(),
+            &args,
+            cmd.arg_tokens(),
+            LexerConfig::default(),
+        )
+    }
+
+    /// Audit finding idx 0 — an `ArgRole::LambdaLiteral` argument yields its
+    /// **body element** as the descended script, never the whole
+    /// `{params body}` list (whose first word would be read as a command
+    /// head).
+    #[test]
+    fn descend_command_resolves_the_lambda_body_element() {
+        let registry = CommandRegistry::build_default();
+        let bodies = bodies_of(&registry, "apply {{name opt args} {puts $name}} a b c");
+        assert_eq!(bodies.len(), 1, "one script argument: {bodies:?}");
+        assert_eq!(bodies[0].index, 0, "the lambda word is arg 0");
+        assert_eq!(bodies[0].text, "puts $name");
+        assert_eq!(bodies[0].descended.tree().text(), "puts $name");
+        // Anchored absolutely at the body element, not at the lambda word.
+        let src = "apply {{name opt args} {puts $name}} a b c";
+        assert_eq!(
+            &src[24..34],
+            "puts $name",
+            "the body element sits at 24..34"
+        );
+        // A three-element lambda: element 2 is a namespace, not a script.
+        let three = bodies_of(&registry, "apply {{a} {puts $a} ::ns} 1");
+        assert_eq!(three.len(), 1);
+        assert_eq!(three[0].text, "puts $a");
+    }
+
+    /// A lambda the split cannot trust yields no script: a `$var`-computed
+    /// literal (not a `Str` word), an empty body, a one-element list, and a
+    /// bare (unbraced, so escape-collapsing) body element.
+    #[test]
+    fn descend_command_skips_untrustworthy_lambda_shapes() {
+        let registry = CommandRegistry::build_default();
+        for src in [
+            "apply $lambda 1",
+            "apply {{a} {}} 1",
+            "apply {{a}} 1",
+            r"apply {{} puts\ hi}",
+        ] {
+            assert!(
+                bodies_of(&registry, src).is_empty(),
+                "{src} must yield no descended script"
+            );
+        }
     }
 }

--- a/rust/tcl-compiler/src/parsing/syntax/descend.rs
+++ b/rust/tcl-compiler/src/parsing/syntax/descend.rs
@@ -145,56 +145,23 @@ pub fn descend_token(sm: &SourceMap<'_>, token: Token, config: LexerConfig) -> D
     }
 }
 
-/// Descend an already-delimiter-free source region as a child CST.
-///
-/// The [`descend_token`] counterpart for a region that is *not* a whole
-/// word: a list **element** inside a braced word, such as the body element
-/// of an [`ArgRole::LambdaLiteral`] argument. `span` must address the
-/// element's content (no wrapping `{}`), so the child anchors at exactly
-/// `span.start()` and the region is by definition terminated — a caller
-/// that only has a whole delimited word wants `descend_token` instead.
-#[must_use]
-pub fn descend_span(sm: &SourceMap<'_>, span: tcl_lexer::Span, config: LexerConfig) -> Descended {
-    let (start, _end) = sm.range_positions(span);
-    let inner = sm.text(span);
-    let (document, _warnings) = build_document(inner, config);
-    let tree = SyntaxTree::with_parts(
-        document,
-        start.offset,
-        start.line,
-        start.character.get(),
-        inner.to_string(),
-        build_line_starts(inner),
-    );
-    Descended {
-        tree,
-        terminated: true,
-    }
-}
-
-/// A registry-resolved script argument of a command, descended.
+/// A registry-resolved `Body` argument of a command, descended.
 #[derive(Debug, Clone)]
 pub struct CommandBody {
     /// The real argument index (into `args` / `arg_tokens`).
     pub index: usize,
-    /// The script's own text — the body word's inner text for an
-    /// [`ArgRole::Body`] argument, the body *element*'s text for an
-    /// [`ArgRole::LambdaLiteral`] one.
+    /// The body word's inner text.
     pub text: String,
-    /// The owning `Str` word token.  For a lambda literal this is the whole
-    /// `{params body ?ns?}` word, not the body element — [`Self::text`] and
-    /// [`Self::descended`] are the element.
+    /// The owning `Str` token.
     pub token: Token,
-    /// The script's child CST.
+    /// The body's child CST.
     pub descended: Descended,
 }
 
-/// Descend each script-bearing argument of a command as a child CST —
-/// [`ArgRole::Body`] arguments and the body element of
-/// [`ArgRole::LambdaLiteral`] ones.
+/// Descend each [`ArgRole::Body`] argument of a command as a child CST.
 ///
 /// The single registry-aware descent entry point — the analogue of
-/// `green_tree.descend_command`, resolving arguments through the
+/// `green_tree.descend_command`, resolving body arguments through the
 /// registry's [`CommandRegistry::arg_indices_for_role`] (the Rust
 /// `iter_body_arguments`) so the set of descended bodies matches exactly.
 /// A body that is not a non-empty `Str` word is skipped (it is data, not
@@ -202,17 +169,14 @@ pub struct CommandBody {
 /// deliberately not routed here — they are handled by the expression
 /// lexer.
 ///
-/// A [`ArgRole::LambdaLiteral`] argument (`apply {{params} {body}} …`) is a
-/// two- or three-element **list**, not a script: element 0 is the parameter
-/// list and element 1 the real body.  Descending the whole word would read
-/// the parameter list as a command head — the `Unknown command 'name opt
-/// args'` false positive of the issue-923 audit's finding idx 0, and the
-/// mis-parse `apply`'s own analyser hook exists to prevent — so only the
-/// body element is descended, via [`crate::lambda_literal`]'s shared split.
-/// Only a `{braced}` body element is descended: a bare or quoted element's
-/// backslash escapes collapse before `apply` ever evaluates it, so its
-/// source slice is not the script that runs (see
-/// [`crate::lambda_literal::LambdaLiteralElements::braced_body`]).
+/// [`ArgRole::LambdaLiteral`] arguments are **also** deliberately not routed
+/// here, and a caller must not treat one as an ordinary body.  A lambda
+/// literal is a `{params body ?ns?}` *list*, and its body runs in a fresh
+/// call frame homed to the lambda's own namespace — never the caller's — so
+/// walking it needs an isolated scope, not just the right sub-span.  The
+/// owning consumer routes it through `apply`'s analyser hook instead; see
+/// `Analyser::dispatch_nested_segment` (issue-923 audit finding idx 0, and
+/// its PR #1068 review follow-up).
 ///
 /// `args` and `arg_tokens` are the command's arguments (excluding the
 /// command name), parallel and 0-indexed; `sm` maps the region the tokens
@@ -239,29 +203,6 @@ pub fn descend_command(
             text: text.to_string(),
             token,
             descended: descend_token(sm, token, config),
-        });
-    }
-    for index in registry.arg_indices_for_role(cmd_name, args, ArgRole::LambdaLiteral) {
-        let Some(&token) = arg_tokens.get(index) else {
-            continue;
-        };
-        if token.kind != TokenType::Str {
-            continue;
-        }
-        let Some(body) = crate::lambda_literal::split_lambda_literal(sm.source(), token)
-            .and_then(|elems| elems.braced_body())
-        else {
-            continue;
-        };
-        let text = sm.text(body);
-        if text.trim().is_empty() {
-            continue;
-        }
-        bodies.push(CommandBody {
-            index,
-            text: text.to_string(),
-            token,
-            descended: descend_span(sm, body, config),
         });
     }
     bodies
@@ -439,38 +380,25 @@ mod tests {
         )
     }
 
-    /// Audit finding idx 0 — an `ArgRole::LambdaLiteral` argument yields its
-    /// **body element** as the descended script, never the whole
-    /// `{params body}` list (whose first word would be read as a command
-    /// head).
+    /// TN pin (issue-923 audit finding idx 0 + its PR #1068 review) — a
+    /// `LambdaLiteral` argument yields **no** `CommandBody` at all.
+    ///
+    /// Two things would be wrong with descending it here. Descending the whole
+    /// `{params body}` word reads the parameter list as a command head (the
+    /// audit's `Unknown command 'name opt args'` false positive). Descending
+    /// just the body *element* fixes the sub-span but still hands the caller
+    /// an ordinary body, which every `descend_command` consumer walks in the
+    /// **enclosing** scope — and a lambda body runs in a fresh frame homed to
+    /// the lambda's own namespace, so its locals would leak into the calling
+    /// proc and its bareword calls would resolve in the wrong namespace.
+    /// The isolated walk belongs to `apply`'s analyser hook; see
+    /// `Analyser::dispatch_nested_segment`.
     #[test]
-    fn descend_command_resolves_the_lambda_body_element() {
-        let registry = CommandRegistry::build_default();
-        let bodies = bodies_of(&registry, "apply {{name opt args} {puts $name}} a b c");
-        assert_eq!(bodies.len(), 1, "one script argument: {bodies:?}");
-        assert_eq!(bodies[0].index, 0, "the lambda word is arg 0");
-        assert_eq!(bodies[0].text, "puts $name");
-        assert_eq!(bodies[0].descended.tree().text(), "puts $name");
-        // Anchored absolutely at the body element, not at the lambda word.
-        let src = "apply {{name opt args} {puts $name}} a b c";
-        assert_eq!(
-            &src[24..34],
-            "puts $name",
-            "the body element sits at 24..34"
-        );
-        // A three-element lambda: element 2 is a namespace, not a script.
-        let three = bodies_of(&registry, "apply {{a} {puts $a} ::ns} 1");
-        assert_eq!(three.len(), 1);
-        assert_eq!(three[0].text, "puts $a");
-    }
-
-    /// A lambda the split cannot trust yields no script: a `$var`-computed
-    /// literal (not a `Str` word), an empty body, a one-element list, and a
-    /// bare (unbraced, so escape-collapsing) body element.
-    #[test]
-    fn descend_command_skips_untrustworthy_lambda_shapes() {
+    fn descend_command_yields_no_body_for_a_lambda_literal() {
         let registry = CommandRegistry::build_default();
         for src in [
+            "apply {{name opt args} {puts $name}} a b c",
+            "apply {{a} {puts $a} ::ns} 1",
             "apply $lambda 1",
             "apply {{a} {}} 1",
             "apply {{a}} 1",
@@ -478,7 +406,7 @@ mod tests {
         ] {
             assert!(
                 bodies_of(&registry, src).is_empty(),
-                "{src} must yield no descended script"
+                "{src} must yield no descended body"
             );
         }
     }

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1025,12 +1025,34 @@ impl CommandRegistry {
     /// carries no linkage — a user proc named `source` is a user proc.
     #[must_use]
     pub fn unit_linkage(&self, name: &str, args: &[&str], dialect: DialectSet) -> Traits {
+        self.invocation_traits(name, args, dialect)
+            .intersection(crate::traits::UNIT_LINKAGE_TRAITS)
+    }
+
+    /// Every trait this concrete invocation carries — `spec.traits |
+    /// sub.traits`, composed exactly as [`crate::spec::SubCommand::traits`]
+    /// documents.
+    ///
+    /// The invocation-level counterpart of `self.get(name).traits`: a
+    /// subcommand's traits are *additive* over its parent's, so a consumer
+    /// asking a trait question about a compound command must compose them.
+    /// `namespace eval` / `namespace inscope` / `interp eval` carry the
+    /// eval-family bits ([`Traits::EVALUATES_CODE`],
+    /// [`Traits::SCRIPT_CONCATENATES_ARGS`]) on the **subcommand**, not on
+    /// the `namespace` / `interp` spec, so a parent-only trait test silently
+    /// misses them.
+    ///
+    /// Resolved through [`Self::resolve_call`], so the subcommand word is
+    /// honoured; pass [`DialectSet::empty`] to skip dialect gating (the
+    /// plain [`Self::get`] lookup) when the question is "what shape is this
+    /// command" rather than "is it available here". An unknown command
+    /// carries no traits.
+    #[must_use]
+    pub fn invocation_traits(&self, name: &str, args: &[&str], dialect: DialectSet) -> Traits {
         let Some(resolved) = self.resolve_call(name, args, dialect) else {
             return Traits::empty();
         };
-        let traits =
-            resolved.spec.traits | resolved.sub.map_or_else(Traits::empty, |sub| sub.traits);
-        traits.intersection(crate::traits::UNIT_LINKAGE_TRAITS)
+        resolved.spec.traits | resolved.sub.map_or_else(Traits::empty, |sub| sub.traits)
     }
 
     /// Whether `name` is valid only at the top level of an iRule script
@@ -4069,6 +4091,56 @@ mod tests {
         assert_eq!(
             reg.unit_linkage("package", &["names"], empty),
             Traits::empty()
+        );
+    }
+
+    /// `invocation_traits` composes `spec.traits | sub.traits` for the
+    /// concrete call, which is the only way the eval-family bits on the
+    /// compound members are visible: `namespace eval` / `namespace inscope` /
+    /// `interp eval` carry `EVALUATES_CODE` on the **subcommand**, so a
+    /// parent-only `get(name).traits` test misses them (issue #1055).
+    #[test]
+    fn invocation_traits_compose_subcommand_traits() {
+        let reg = CommandRegistry::build_default();
+        let empty = DialectSet::empty();
+        // TP — the eval family, bare and compound.
+        for (name, args) in [
+            ("eval", &["{set x 1}"][..]),
+            ("uplevel", &["1", "{set x 1}"][..]),
+            ("namespace", &["eval", "ns", "{set x 1}"][..]),
+            ("namespace", &["inscope", "ns", "{set x 1}"][..]),
+            ("interp", &["eval", "slave", "{set x 1}"][..]),
+        ] {
+            let traits = reg.invocation_traits(name, args, empty);
+            assert!(
+                traits.contains(Traits::EVALUATES_CODE),
+                "{name} {args:?} must carry EVALUATES_CODE"
+            );
+            assert!(
+                traits.contains(Traits::SCRIPT_CONCATENATES_ARGS),
+                "{name} {args:?} must carry SCRIPT_CONCATENATES_ARGS"
+            );
+        }
+        // TN — the parent spec alone carries neither bit, which is exactly
+        // why composing is required.
+        let parent = reg.get("namespace").expect("namespace spec").traits;
+        assert!(!parent.contains(Traits::EVALUATES_CODE));
+        // TN — a sibling subcommand that evaluates nothing stays clean.
+        assert!(
+            !reg.invocation_traits("namespace", &["delete", "ns"], empty)
+                .contains(Traits::EVALUATES_CODE)
+        );
+        // TN — an unknown command carries no traits at all.
+        assert_eq!(
+            reg.invocation_traits("no_such_command_xyz", &["a"], empty),
+            Traits::empty()
+        );
+        // The parent's own traits still compose in — a subcommand's traits
+        // are additive, not a replacement.
+        assert!(
+            reg.invocation_traits("namespace", &["eval", "ns", "{}"], empty)
+                .contains(Traits::LANGUAGE_KEYWORD),
+            "the parent `namespace` spec's own bits survive composition"
         );
     }
 


### PR DESCRIPTION
## Summary

Fixes #1055, fixes #1065, and closes issue-923 audit idx 0's remaining half. All three land as registry data consumed generically.

- **#1055** — `body_has_dynamic_barrier` no longer hardcodes `uplevel` or its level-word sniff. Both halves are registry answers: a new `CommandRegistry::invocation_traits(name, args, dialect)` composes `spec.traits | sub.traits` (the compound eval family — `namespace eval`/`namespace inscope`/`interp eval` — carries `EVALUATES_CODE` on the *subcommand*, so the old parent-only trait test missed all three; `eval { namespace eval ns $x }` used to relax the outer barrier — pinned), and the script words come from `arg_indices_for_role(…, ArgRole::Body)` plus every following word under `SCRIPT_CONCATENATES_ARGS` (a dynamic concatenated tail is dynamic — the property the old last-arg heuristic covered by accident). Unresolvable script position → poison, never guess. `unit_linkage` delegates to the same query.
- **#1065** — `handle_try_command` raises conditional depth per clause off the resolved spec's `BRANCH_SELECTED_BODY`, C-Tcl-faithfully: main body **conditional** (an exception a handler swallows cuts it short — same guarded-probe reading `catch` already has; `try { package require X } on error {} {}` is the idiomatic optional-dependency probe), `on`/`trap` **conditional**, `finally` **not** (`TryPostBody`/`TryPostHandler` both schedule it — it has run whenever control passes the `try`). The acknowledged-wrong pinned expectation flips `false` → `true`. `signature_scan`'s shallow pre-pass stays coarser by design, documented as index-not-authority in `package-loading.md`.
- **audit idx 0** — the reported W123 FP on `apply`'s param list was already fixed by the `ArgRole::LambdaLiteral` work; what remained was the FN it left: `descend_command` resolved `ArgRole::Body` only, so a lambda body inside `[…]` was walked by nothing — `set r [apply {{a} {zz9unknowncmd}} 5]` produced zero diagnostics. It now resolves `LambdaLiteral` beside `Body` and descends only the braced body element via the shared `split_lambda_literal` primitive. The audit's verbatim argparse repro is pinned, plus FP guards (`apply {{set list} {…}}` draws no W123).

Two oracle findings surfaced and deliberately **not** widened into this PR (transcripts in test comments):
- `uplevel -1` is a genuine 8.6-vs-9.0 divergence (8.6.14 runs a command named `-1`; 9.0.4 errors `bad level`), and both accept `+1`/`-0`/` 1` which `word_is_literal_level` rejects — registry-precision follow-up.
- `apply {{a} {puts $a}} 5` as a bare statement draws a pre-existing W210 FP on the top-level `handle_apply_command` path (the `[…]` form is clean) — separate finding.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-compiler -p tcl-registry` — 8,029 passed, 0 failed.
  - `cargo test -p tcl-lsp-core` — 2,207 passed; `cargo test -p tcl-irules -p tcl-cli` — 48 passed.
  - `cargo test -p tcl-lsp-server` (30 e2e suites) — 1,081 passed; 3 `semantic_tokens_reference_client` latency-barrier timeouts under parallel load only, all 10 pass serially (pre-existing load sensitivity, not content divergence).
  - `cargo clippy -p tcl-compiler -p tcl-registry --all-targets` — zero warnings, **zero new allows**; `cargo fmt --check` clean; `cargo xtask kcs-index-links` passes.
  - Every Tcl semantic claim verified on in-container tclsh 9.0.4 **and** 8.6.14.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — barrier gating is now invocation-trait-driven, `try` conditionality is per-clause, and lambda bodies are walked in substitution position.
- [x] I updated at least one relevant KCS note: `lowering-dispatch.md`, `package-loading.md` (per-clause try table + C Tcl citation), `command-registry.md` (`BRANCH_SELECTED_BODY` names `finally`), W135/W136 pages (guarded-require section), the apply-lambda KCS note, and audit `STATUS.md` §6b (idx 0 ticked: 24 fixed / 61 remaining).
- [ ] New compiler KCS note linked. (n/a — existing notes updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_