### PR TITLE
tcllib textutil submodule registry keys + W113 package-gating (issue #923 audit idx 3/4/11)

### DIFF
--- a/README.md
+++ b/README.md
@@ -412,6 +412,22 @@ set d [Pup new]
 $d fly                         ;# W308: unknown method 'fly' on ::Dog
 ```
 
+W113 ("proc shadows a built-in") only fires for a genuine core
+built-in. A proc named after a command that is gated behind `package
+require` — a tcllib package, `argparse`, an `itcl`/TclOO helper, … — is
+not flagged: that command does not exist until its package is loaded,
+and even then a proc of the same name is that package's own
+implementation, not a shadow of a core built-in. The one exception is a
+package a dialect profile ships **ambiently** (an F5 command pack, an
+EDA vendor tool surface) — that command is the profile's genuine,
+always-present surface, so redefining it still warns.
+
+```tcl
+package require argparse
+proc ::argparse {args} { ... }   ;# no W113: argparse is package-gated, not a core built-in
+proc ::set {a b} { ... }         ;# W113: 'set' is a genuine core built-in
+```
+
 ### Completions
 
 Context-aware completions for commands, subcommands, variables, proc names
@@ -2223,7 +2239,7 @@ In a project with an "entry" file that runs the `package require`s and then
 | W110 | `==`/`!=` on strings in `expr` (use `eq`/`ne`) | Replace operator |
 | W111 | Line exceeds configured maximum length | |
 | W112 | Trailing whitespace | Remove whitespace |
-| W113 | Procedure shadows a built-in command | |
+| W113 | Procedure shadows a built-in command (package-gated commands, e.g. `argparse` or a tcllib package, are excluded) | |
 | W114 | Redundant nested `[expr]` -- already in expression context | Unwrap the nested `expr` |
 | W115 | Backslash-newline in comment silently swallows the next line | Convert to per-line comments |
 | W116 | Stub command shadows a built-in command | |

--- a/docs/kcs/codes/kcs-diagnostic-w113-proc-shadows-builtin.md
+++ b/docs/kcs/codes/kcs-diagnostic-w113-proc-shadows-builtin.md
@@ -43,6 +43,27 @@ proc my_set {name value} {
 
 Choose a name that does not collide with a built-in command.
 
+## Package-gated commands are excluded
+
+This warning only fires for a genuine core built-in. A proc named after
+a command that is gated behind `package require` — a tcllib package,
+`argparse`, an `itcl`/TclOO helper, … — is not flagged: that command
+does not exist until its package is loaded, and even then a proc of the
+same name is that package's own implementation, not a shadow of a core
+built-in.
+
+```tcl
+package require argparse
+proc ::argparse {args} {
+    # ... this is argparse's own definition, not a redefinition
+}
+```
+
+The one exception is a package a dialect profile ships **ambiently** —
+an F5 command pack or an EDA vendor tool surface, part of that profile's
+genuine, always-present command surface (not something the file ever
+`package require`s) — so redefining one of those still warns.
+
 ## How to suppress
 
 Add `# noqa: W113` at the end of the offending line.

--- a/editors/zed/src/generated/tcl_commands.json
+++ b/editors/zed/src/generated/tcl_commands.json
@@ -9809,7 +9809,8 @@
     },
     {
       "name": "textutil::string::longestCommonPrefix",
-      "summary": "Returns the longest common prefix of the given strings."
+      "summary": "Returns the longest common prefix of the given strings.",
+      "pure": true
     },
     {
       "name": "textutil::string::longestCommonPrefixList",
@@ -9835,19 +9836,23 @@
     },
     {
       "name": "textutil::tabify::tabify",
-      "summary": "Replaces all appropriate occurrences of num spaces with a tab character in string."
+      "summary": "Replaces all appropriate occurrences of num spaces with a tab character in string.",
+      "pure": true
     },
     {
       "name": "textutil::tabify::tabify2",
-      "summary": "Like tabify, but works line by line and only replaces spaces at true tab-stop-aligned positions."
+      "summary": "Like tabify, but works line by line and only replaces spaces at true tab-stop-aligned positions.",
+      "pure": true
     },
     {
       "name": "textutil::tabify::untabify",
-      "summary": "Replaces all tabs in string with the appropriate number of spaces, assuming a tab size of num."
+      "summary": "Replaces all tabs in string with the appropriate number of spaces, assuming a tab size of num.",
+      "pure": true
     },
     {
       "name": "textutil::tabify::untabify2",
-      "summary": "Like untabify, but works line by line."
+      "summary": "Like untabify, but works line by line.",
+      "pure": true
     },
     {
       "name": "textutil::tail",
@@ -9872,11 +9877,13 @@
     },
     {
       "name": "textutil::trim::trimleft",
-      "summary": "Removes any leading occurrences of the characters in trim (a regular expression, default whitespace) from string."
+      "summary": "Removes any leading occurrences of the characters in trim (a regular expression, default whitespace) from string.",
+      "pure": true
     },
     {
       "name": "textutil::trim::trimright",
-      "summary": "Removes any trailing occurrences of the characters in trim (a regular expression, default whitespace) from string."
+      "summary": "Removes any trailing occurrences of the characters in trim (a regular expression, default whitespace) from string.",
+      "pure": true
     },
     {
       "name": "textutil::trimEmptyHeading",

--- a/editors/zed/src/generated/tcl_commands.json
+++ b/editors/zed/src/generated/tcl_commands.json
@@ -9697,11 +9697,19 @@
     },
     {
       "name": "textutil::adjust",
-      "summary": "Adjust a text block to a given line length."
+      "summary": "Adjust a text block to a given line length. Re-exported alias for `textutil::adjust::adjust`, provided by the `textutil` umbrella package (not by `package require textutil::adjust` alone)."
+    },
+    {
+      "name": "textutil::adjust::adjust",
+      "summary": "Adjust/reformat a paragraph of text to a given line length, with optional justification and hyphenation."
     },
     {
       "name": "textutil::adjust::getPredefined",
       "summary": "Use this command to query the package for the full path name of the hyphenation file filename coming with the pac"
+    },
+    {
+      "name": "textutil::adjust::indent",
+      "summary": "Indent each line of text by prefixing it with prefix, skipping the first skip lines."
     },
     {
       "name": "textutil::adjust::listPredefined",
@@ -9741,7 +9749,7 @@
     },
     {
       "name": "textutil::indent",
-      "summary": "Indent each line of text by a given prefix."
+      "summary": "Indent each line of text by a given prefix. Re-exported alias for `textutil::adjust::indent`, provided by the `textutil` umbrella package (not by `package require textutil::adjust` alone)."
     },
     {
       "name": "textutil::longestCommonPrefix",
@@ -9800,6 +9808,10 @@
       "summary": "A convenience command."
     },
     {
+      "name": "textutil::string::longestCommonPrefix",
+      "summary": "Returns the longest common prefix of the given strings."
+    },
+    {
       "name": "textutil::string::longestCommonPrefixList",
       "summary": "tcllib command."
     },
@@ -9822,6 +9834,22 @@
       "pure": true
     },
     {
+      "name": "textutil::tabify::tabify",
+      "summary": "Replaces all appropriate occurrences of num spaces with a tab character in string."
+    },
+    {
+      "name": "textutil::tabify::tabify2",
+      "summary": "Like tabify, but works line by line and only replaces spaces at true tab-stop-aligned positions."
+    },
+    {
+      "name": "textutil::tabify::untabify",
+      "summary": "Replaces all tabs in string with the appropriate number of spaces, assuming a tab size of num."
+    },
+    {
+      "name": "textutil::tabify::untabify2",
+      "summary": "Like untabify, but works line by line."
+    },
+    {
       "name": "textutil::tail",
       "summary": "Remove the first character.",
       "pure": true
@@ -9831,12 +9859,24 @@
       "summary": "Remove leading whitespace from each line of text."
     },
     {
+      "name": "textutil::trim::trim",
+      "summary": "Removes any leading and trailing occurrences of the characters in trim (a regular expression, default whitespace) from string."
+    },
+    {
       "name": "textutil::trim::trimEmptyHeading",
       "summary": "Looks for empty lines (including lines consisting of only whitespace) at the beginning of the string and removes "
     },
     {
       "name": "textutil::trim::trimPrefix",
       "summary": "Removes the prefix from the beginning of string and returns the result."
+    },
+    {
+      "name": "textutil::trim::trimleft",
+      "summary": "Removes any leading occurrences of the characters in trim (a regular expression, default whitespace) from string."
+    },
+    {
+      "name": "textutil::trim::trimright",
+      "summary": "Removes any trailing occurrences of the characters in trim (a regular expression, default whitespace) from string."
     },
     {
       "name": "textutil::trimEmptyHeading",

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -683,6 +683,22 @@ impl Analyser {
     /// — its own definition or a deliberate override, not shadowing a built-in.
     /// And the overridable Tcl *library* procedures (`unknown`, `history`,
     /// `auto_*`, …) are script-defined, documented user-replaceable overlays.
+    /// A third-party/package command (`argparse`, a tcllib/itcl/ticklecharts
+    /// proc, …) is excluded too (issue #923 idx 11): `registry.command_names()`
+    /// is the full package-inclusive command universe, not the set of names a
+    /// bare Tcl interpreter actually starts with, so a proc named after a
+    /// registered package command (e.g. `proc ::argparse {args} {...}`
+    /// defining the `argparse` package's own entry point) is not shadowing
+    /// anything until that package is actually loaded — and even then it is
+    /// the package's own definition, not a redefinition of a core built-in.
+    /// The gate reads `CommandSpec::owning_package` (`required_package` or
+    /// its `tcllib_package` alias) rather than a hardcoded package-name list,
+    /// so it stays correct as new package specs are added. A package a
+    /// profile ships **ambient** (an F5 command pack, an EDA vendor tool
+    /// surface) is the exception: that profile's real, always-present command
+    /// surface, so it keeps firing W113 like any other core built-in (e.g.
+    /// iRules' `pool`, which — being ambient and never `required_package`-gated
+    /// in the first place — is untouched by this filter).
     fn emit_w113_proc_shadows_builtin(&mut self, raw_name: &str, qualified: &str, name_span: Span) {
         let normalised_proc: String = raw_name.trim_start_matches(':').to_string();
         let normalised_qual: String = qualified.trim_start_matches(':').to_string();
@@ -704,7 +720,9 @@ impl Analyser {
             }
         };
         let shadow_name = shadow_name.filter(|name| {
-            !name.contains("::") && !overridable_library_procs().contains(name.as_str())
+            !name.contains("::")
+                && !overridable_library_procs().contains(name.as_str())
+                && !self.is_package_gated_non_ambient(name)
         });
         if shadow_name.is_some() {
             // The permissive fallback profile means "no specific dialect" —
@@ -723,6 +741,27 @@ impl Analyser {
                 fixes: Vec::new(),
             });
         }
+    }
+
+    /// Whether `name` (a bare or fully-qualified command name already known
+    /// to be in `registry.command_names()`) resolves to a `CommandSpec` gated
+    /// behind a `required_package` / `tcllib_package` (`CommandSpec::
+    /// owning_package`) that this profile does **not** ship ambiently
+    /// (issue #923 idx 11).
+    ///
+    /// Data-driven, not a hardcoded package-name list: the answer comes
+    /// straight from the resolved spec's package attribution and the
+    /// profile's own `is_ambient_package` query (the same query
+    /// `emit_missing_package_require_diagnostics` / W120 already uses for the
+    /// converse fact), so a new package-gated spec is covered automatically —
+    /// no per-package entry to remember to add here.
+    fn is_package_gated_non_ambient(&self, name: &str) -> bool {
+        use tcl_registry::ProfileQueries;
+        let registry = tcl_registry::cache::registry_for_profile(self.profile);
+        self.profile
+            .resolve_command(registry, name)
+            .and_then(tcl_registry::CommandSpec::owning_package)
+            .is_some_and(|pkg| !self.profile.is_ambient_package(pkg))
     }
 
     /// **W314.** The definition's name has no absolute (fully-qualified)

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -2409,6 +2409,60 @@ mod unresolved_command {
         );
     }
 
+    // issue #923 idx 3/4: tcllib `textutil::adjust` submodule commands were
+    // registered under the wrong (umbrella-only) 2-segment name, so the
+    // real 3-segment commands the common `package require textutil::adjust;
+    // namespace import textutil::adjust::*` idiom (georgtree_argparse's
+    // `argparse.tcl:380-382`) actually resolves to had no registry entry at
+    // all. Ground truth (tclsh 9.0.4 + real tcllib-2.0): `package require
+    // textutil::adjust` creates `::textutil::adjust::adjust` /
+    // `::textutil::adjust::indent`, never a bare `::textutil::adjust`.
+    mod textutil_adjust_idx3_idx4 {
+        use super::*;
+
+        #[test]
+        fn qualified_submodule_calls_resolve_after_package_require() {
+            // As phrased by the fix's own acceptance criterion: a call to
+            // the real, canonical name resolves once the submodule package
+            // is required. Note `package require` (any package, this file's
+            // included) blanket-suppresses W123 file-wide (`emit_unresolved_
+            // command_diagnostics`'s conservative "package may define
+            // anything at runtime" gate) — so this pins that the call
+            // resolves under the real-world idiom, while the two tests below
+            // isolate the registry-data fact itself (no `package require` in
+            // scope, so the file-wide suppression gate does not mask it).
+            let src = "package require textutil::adjust\n\
+                       namespace import textutil::adjust::*\n\
+                       set a [adjust hello -length 20]\n\
+                       set b [indent $a \"  \"]\n";
+            assert!(w123(src).is_empty(), "got {:?}", w123(src));
+        }
+
+        #[test]
+        fn qualified_submodule_names_are_directly_registry_known() {
+            // TP, isolating the registry-data fact with no `package require`
+            // in scope (so the blanket suppression gate above cannot mask
+            // it): the literal, fully-qualified 3-segment names must be
+            // directly known to W123's registry-name set.
+            let src = "textutil::adjust::adjust hello -length 20\n\
+                       textutil::adjust::indent hello \"  \"\n";
+            assert!(w123(src).is_empty(), "got {:?}", w123(src));
+        }
+
+        #[test]
+        fn a_bare_unimported_flat_name_still_unresolved() {
+            // TN/FN contrast: with no `package require`, no `namespace
+            // import`, and no umbrella alias in play, the *bare* flattened
+            // names (`adjust`/`indent` with no qualification at all) are
+            // correctly still unknown — the fix adds the submodule's real
+            // names, it does not fabricate a global bare alias that only
+            // the `textutil` umbrella actually provides.
+            let d = w123("adjust hello -length 20\n");
+            assert_eq!(d.len(), 1, "got {d:?}");
+            assert!(d[0].contains("adjust"));
+        }
+    }
+
     #[test]
     fn coroutine_name_is_a_known_command() {
         // `coroutine NAME cmd ?arg …?` creates the command NAME

--- a/rust/tcl-compiler/tests/checks.rs
+++ b/rust/tcl-compiler/tests/checks.rs
@@ -1849,6 +1849,44 @@ mod builtin_shadow {
         ));
         assert!(!fires("proc ::snit::type {name def} {}", D, "W113"));
     }
+
+    // issue #923 idx 11: a bare-name `proc` whose only registry match is a
+    // `required_package`-gated third-party command (argparse, a tcllib
+    // package, …) must not fire W113 — that command does not exist in a
+    // stock interpreter until its package is loaded, so defining a proc of
+    // the same name is not shadowing a built-in; it is (often) that
+    // package's own implementation. Ground truth (tclsh 9.0.4 / 8.6.14):
+    // `info commands argparse` is empty and calling it errors
+    // `invalid command name "argparse"` before the package is sourced.
+    #[test]
+    fn package_gated_command_name_not_flagged() {
+        // TP (repro, argparse.tcl:17's exact shape): defining the
+        // `argparse` package's own entry point must not warn that it
+        // shadows a built-in — `argparse` is required_package-gated
+        // (rust/tcl-registry/src/commands/argparse/command.rs), not a core
+        // command.
+        assert!(!fires("proc ::argparse {args} {}", D, "W113"));
+        // A tcllib package command name hits the same gate.
+        assert!(!fires("proc ::textutil::adjust {s} {}", D, "W113"));
+    }
+
+    // TN: a genuine core built-in (no `required_package`) still fires,
+    // across dialects — the package-gating filter must not blunt the
+    // original check.
+    #[test]
+    fn ungated_builtin_shadow_still_fires_across_dialects() {
+        assert_eq!(count("proc set {a b} {}", "tcl8.4", "W113"), 1);
+        assert_eq!(count("proc set {a b} {}", "tcl9.0", "W113"), 1);
+    }
+
+    // TN: iRules' `pool` is ambient (part of the profile's real, always-
+    // present command surface) and carries no `required_package` at all —
+    // it must keep firing W113 exactly as before this fix, proving the new
+    // filter does not touch commands that were never package-gated.
+    #[test]
+    fn ambient_irules_command_still_flagged() {
+        assert_eq!(count("proc pool {a} {}", IR, "W113"), 1);
+    }
 }
 
 // ===========================================================================

--- a/rust/tcl-registry/src/commands/tcllib/misc_ext.rs
+++ b/rust/tcl-registry/src/commands/tcllib/misc_ext.rs
@@ -2553,7 +2553,33 @@ const TEXTUTIL_CMDS: &[Row] = &[(
 )];
 
 /// The `textutil::adjust` package.
+///
+/// `adjust` and `indent` are the package's two primary, most-used commands
+/// (tcllib-2.0 `modules/textutil/adjust.tcl`); they are also re-exported as
+/// the flattened `::textutil::adjust` / `::textutil::indent` aliases by the
+/// `textutil` umbrella package (`textutil.tcl`'s `namespace import -force
+/// adjust::adjust adjust::indent adjust::undent`) — see
+/// `textutil__adjust.rs` / `textutil__indent.rs` for those, which are gated
+/// on `required_package: "textutil"` (the umbrella), not this package.
+/// Requiring `textutil::adjust` alone grants only these three-segment names
+/// (issue #923 idx 3/4, confirmed against tclsh 9.0.4 + real tcllib-2.0: a
+/// bare `::textutil::adjust` command exists only after `package require
+/// textutil`, never after `package require textutil::adjust` alone).
 const TEXTUTIL__ADJUST_CMDS: &[Row] = &[
+    (
+        "textutil::adjust::adjust",
+        Arity::at_least(1),
+        &[
+            "textutil::adjust::adjust string ?-length num? ?-justify left|right|center|plain? ?-hyphenate bool? ?-full bool? ?-strictlength bool?",
+        ],
+        "Adjust/reformat a paragraph of text to a given line length, with optional justification and hyphenation.",
+    ),
+    (
+        "textutil::adjust::indent",
+        Arity::new(2, 3),
+        &["textutil::adjust::indent text prefix ?skip?"],
+        "Indent each line of text by prefixing it with prefix, skipping the first skip lines.",
+    ),
     (
         "textutil::adjust::readPatterns",
         Arity::exact(1),
@@ -2626,10 +2652,43 @@ const TEXTUTIL__STRING_CMDS: &[Row] = &[
         &["textutil::string::longestCommonPrefixList list"],
         "tcllib command.",
     ),
+    (
+        "textutil::string::longestCommonPrefix",
+        Arity::at_least(0),
+        &["textutil::string::longestCommonPrefix ?string...?"],
+        "Returns the longest common prefix of the given strings.",
+    ),
 ];
 
 /// The `textutil::trim` package.
+///
+/// `trim`/`trimleft`/`trimright` are also re-exported as the flattened
+/// `::textutil::trim` / `::textutil::trimleft` / `::textutil::trimright`
+/// aliases by the `textutil` umbrella package — see `textutil__trim.rs` /
+/// `textutil__trimleft.rs` / `textutil__trimright.rs` for those (gated on
+/// `required_package: "textutil"`, not this package). Requiring
+/// `textutil::trim` alone grants only these three-segment names (same
+/// meta-package-flattening shape as `textutil::adjust`, issue #923 idx 3/4;
+/// confirmed against tclsh 9.0.4 + real tcllib-2.0).
 const TEXTUTIL__TRIM_CMDS: &[Row] = &[
+    (
+        "textutil::trim::trim",
+        Arity::new(1, 2),
+        &["textutil::trim::trim string ?trim?"],
+        "Removes any leading and trailing occurrences of the characters in trim (a regular expression, default whitespace) from string.",
+    ),
+    (
+        "textutil::trim::trimleft",
+        Arity::new(1, 2),
+        &["textutil::trim::trimleft string ?trim?"],
+        "Removes any leading occurrences of the characters in trim (a regular expression, default whitespace) from string.",
+    ),
+    (
+        "textutil::trim::trimright",
+        Arity::new(1, 2),
+        &["textutil::trim::trimright string ?trim?"],
+        "Removes any trailing occurrences of the characters in trim (a regular expression, default whitespace) from string.",
+    ),
     (
         "textutil::trim::trimPrefix",
         Arity::exact(2),
@@ -2641,6 +2700,44 @@ const TEXTUTIL__TRIM_CMDS: &[Row] = &[
         Arity::exact(1),
         &["textutil::trim::trimEmptyHeading string"],
         "Looks for empty lines (including lines consisting of only whitespace) at the beginning of the string and removes ",
+    ),
+];
+
+/// The `textutil::tabify` package.
+///
+/// `tabify`/`untabify`/`tabify2`/`untabify2` are also re-exported as the
+/// flattened `::textutil::tabify` / `::textutil::untabify` /
+/// `::textutil::tabify2` / `::textutil::untabify2` aliases by the `textutil`
+/// umbrella package — see `textutil__tabify.rs` / `textutil__untabify.rs` /
+/// `textutil__tabify2.rs` / `textutil__untabify2.rs` for those (gated on
+/// `required_package: "textutil"`, not this package). Requiring
+/// `textutil::tabify` alone grants only these three-segment names (same
+/// meta-package-flattening shape as `textutil::adjust`, issue #923 idx 3/4;
+/// confirmed against tclsh 9.0.4 + real tcllib-2.0).
+const TEXTUTIL__TABIFY_CMDS: &[Row] = &[
+    (
+        "textutil::tabify::tabify",
+        Arity::new(1, 2),
+        &["textutil::tabify::tabify string ?num?"],
+        "Replaces all appropriate occurrences of num spaces with a tab character in string.",
+    ),
+    (
+        "textutil::tabify::untabify",
+        Arity::new(1, 2),
+        &["textutil::tabify::untabify string ?num?"],
+        "Replaces all tabs in string with the appropriate number of spaces, assuming a tab size of num.",
+    ),
+    (
+        "textutil::tabify::tabify2",
+        Arity::new(1, 2),
+        &["textutil::tabify::tabify2 string ?num?"],
+        "Like tabify, but works line by line and only replaces spaces at true tab-stop-aligned positions.",
+    ),
+    (
+        "textutil::tabify::untabify2",
+        Arity::new(1, 2),
+        &["textutil::tabify::untabify2 string ?num?"],
+        "Like untabify, but works line by line.",
     ),
 ];
 
@@ -2813,6 +2910,7 @@ const GROUPS: &[(&str, &[Row])] = &[
     ("textutil::adjust", TEXTUTIL__ADJUST_CMDS),
     ("textutil::patch", TEXTUTIL__PATCH_CMDS),
     ("textutil::string", TEXTUTIL__STRING_CMDS),
+    ("textutil::tabify", TEXTUTIL__TABIFY_CMDS),
     ("textutil::trim", TEXTUTIL__TRIM_CMDS),
     ("uevent", UEVENT_CMDS),
     ("zipfile::decode", ZIPFILE__DECODE_CMDS),

--- a/rust/tcl-registry/src/commands/tcllib/misc_ext.rs
+++ b/rust/tcl-registry/src/commands/tcllib/misc_ext.rs
@@ -20,6 +20,11 @@
 //!
 //! Remaining flat commands across many packages (html, ip, sha1/sha2/md5 incremental APIs, grammar, simulation, nettool, cron, zipfile, …), each attributed to its namespace package.
 
+use super::{
+    textutil__adjust, textutil__indent, textutil__longestcommonprefix, textutil__tabify,
+    textutil__tabify2, textutil__trim, textutil__trimleft, textutil__trimright, textutil__undent,
+    textutil__untabify, textutil__untabify2,
+};
 use crate::prelude::*;
 
 /// A row in a package command table: name, arity, synopsis, and summary.
@@ -2941,9 +2946,58 @@ fn processman_onexit_spec() -> CommandSpec {
     }
 }
 
+/// `(submodule-qualified name, that command's canonical spec)` pairs: every
+/// `Row`-declared submodule command above that is *also* re-exported,
+/// unmodified, as a flattened `textutil::NAME` umbrella alias by one of the
+/// individual `textutil__*.rs` files elsewhere in this crate (`adjust` /
+/// `indent` / `undent` from the `textutil::adjust` package; `trim` /
+/// `trimleft` / `trimright` from `textutil::trim`; `tabify` / `untabify` /
+/// `tabify2` / `untabify2` from `textutil::tabify`; `longestCommonPrefix`
+/// from `textutil::string`).
+///
+/// The umbrella alias file is the sole source of truth for that command's
+/// trait descriptors (`Traits::PURE`, …) — [`sync_textutil_submodule_traits`]
+/// copies them onto the `Row`-built submodule spec below rather than a
+/// second, independent `Traits::PURE` declaration, so the two spellings of
+/// the same real tcllib command can never drift apart (issue #923 idx 3/4
+/// review follow-up: the submodule spec was built via the generic `Row` →
+/// `CommandSpec::DEFAULT` path and so silently lacked the `Traits::PURE` its
+/// umbrella sibling already carried, blocking purity-based GVN/DCE on the
+/// canonical three-segment spelling only).
+fn textutil_submodule_trait_sources() -> Vec<(&'static str, CommandSpec)> {
+    vec![
+        ("textutil::adjust::adjust", textutil__adjust::spec()),
+        ("textutil::adjust::indent", textutil__indent::spec()),
+        ("textutil::adjust::undent", textutil__undent::spec()),
+        ("textutil::trim::trim", textutil__trim::spec()),
+        ("textutil::trim::trimleft", textutil__trimleft::spec()),
+        ("textutil::trim::trimright", textutil__trimright::spec()),
+        ("textutil::tabify::tabify", textutil__tabify::spec()),
+        ("textutil::tabify::untabify", textutil__untabify::spec()),
+        ("textutil::tabify::tabify2", textutil__tabify2::spec()),
+        ("textutil::tabify::untabify2", textutil__untabify2::spec()),
+        (
+            "textutil::string::longestCommonPrefix",
+            textutil__longestcommonprefix::spec(),
+        ),
+    ]
+}
+
+/// Apply [`textutil_submodule_trait_sources`]'s canonical traits onto their
+/// matching `specs` entries in place. A missing name is a silent no-op — the
+/// pairing is exhaustively checked by the `registry_commands.rs` contract
+/// test instead of panicking here.
+fn sync_textutil_submodule_traits(specs: &mut [CommandSpec]) {
+    for (name, canonical) in textutil_submodule_trait_sources() {
+        if let Some(spec) = specs.iter_mut().find(|s| s.name == name) {
+            spec.traits = canonical.traits;
+        }
+    }
+}
+
 /// All command specs in this group.
 pub fn specs() -> Vec<CommandSpec> {
-    GROUPS
+    let mut specs: Vec<CommandSpec> = GROUPS
         .iter()
         .flat_map(|&(pkg, table)| rows(pkg, table))
         // The `html` package uses the richer [`HtmlRow`] table (per-command
@@ -2951,5 +3005,7 @@ pub fn specs() -> Vec<CommandSpec> {
         // 4-tuple [`Row`], so it is appended separately (issue #811).
         .chain(html_rows(HTML_CMDS))
         .chain(std::iter::once(processman_onexit_spec()))
-        .collect()
+        .collect();
+    sync_textutil_submodule_traits(&mut specs);
+    specs
 }

--- a/rust/tcl-registry/src/commands/tcllib/textutil__adjust.rs
+++ b/rust/tcl-registry/src/commands/tcllib/textutil__adjust.rs
@@ -16,7 +16,19 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `textutil::adjust` command.
+//! `textutil::adjust` — the flattened, umbrella-only alias.
+//!
+//! This is **not** the `textutil::adjust` *package*'s own command (that is
+//! `::textutil::adjust::adjust`, registered as `"textutil::adjust::adjust"`
+//! in `misc_ext.rs`'s `TEXTUTIL__ADJUST_CMDS`, gated on `required_package:
+//! "textutil::adjust"`). It is the bare `::textutil::adjust` re-export the
+//! `textutil` *umbrella* package creates via `namespace import -force
+//! adjust::adjust ...` (tcllib-2.0 `modules/textutil/textutil.tcl`) — real
+//! and callable, but only after `package require textutil`, never after
+//! `package require textutil::adjust` alone (issue #923 idx 3/4; confirmed
+//! against tclsh 9.0.4 + real tcllib-2.0: `package require textutil::adjust`
+//! creates no bare `::textutil::adjust` command, only the three-segment
+//! `::textutil::adjust::adjust`).
 use crate::prelude::*;
 const FORMS: &[FormSpec] = &[FormSpec {
     kind: FormKind::Default,
@@ -30,7 +42,7 @@ pub fn spec() -> CommandSpec {
         dialects: None,
         arity: Arity::at_least(1),
         hover: Some(HoverSnippet {
-            summary: "Adjust a text block to a given line length.",
+            summary: "Adjust a text block to a given line length. Re-exported alias for `textutil::adjust::adjust`, provided by the `textutil` umbrella package (not by `package require textutil::adjust` alone).",
             synopsis: &[
                 "textutil::adjust string ?-length num? ?-justify left|right|center|plain? ?-hyphenate bool? ?-full bool? ?-strictlength bool?",
             ],

--- a/rust/tcl-registry/src/commands/tcllib/textutil__indent.rs
+++ b/rust/tcl-registry/src/commands/tcllib/textutil__indent.rs
@@ -16,7 +16,18 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! `textutil::indent` command.
+//! `textutil::indent` — the flattened, umbrella-only alias.
+//!
+//! There is no `textutil::indent` *package* — `indent` lives inside the
+//! `textutil::adjust` package (`::textutil::adjust::indent`, registered as
+//! `"textutil::adjust::indent"` in `misc_ext.rs`'s `TEXTUTIL__ADJUST_CMDS`,
+//! gated on `required_package: "textutil::adjust"`). This entry is the bare
+//! `::textutil::indent` re-export the `textutil` *umbrella* package creates
+//! via `namespace import -force adjust::indent` (tcllib-2.0
+//! `modules/textutil/textutil.tcl`) — real and callable, but only after
+//! `package require textutil`, never after `package require
+//! textutil::adjust` alone (issue #923 idx 3/4; confirmed against tclsh
+//! 9.0.4 + real tcllib-2.0).
 use crate::prelude::*;
 const FORMS: &[FormSpec] = &[FormSpec {
     kind: FormKind::Default,
@@ -30,7 +41,7 @@ pub fn spec() -> CommandSpec {
         dialects: None,
         arity: Arity::new(2, 3),
         hover: Some(HoverSnippet {
-            summary: "Indent each line of text by a given prefix.",
+            summary: "Indent each line of text by a given prefix. Re-exported alias for `textutil::adjust::indent`, provided by the `textutil` umbrella package (not by `package require textutil::adjust` alone).",
             synopsis: &["textutil::indent text prefix ?skip?"],
             snippet: "",
             source: "tcllib textutil package",

--- a/rust/tcl-registry/tests/registry_commands.rs
+++ b/rust/tcl-registry/tests/registry_commands.rs
@@ -2126,3 +2126,138 @@ fn script_append_list_refinement_is_inscope_only() {
         );
     }
 }
+
+// ===========================================================================
+// issue #923 idx 3/4 — tcllib `textutil::adjust` submodule vs the `textutil`
+// umbrella package's flattened re-export aliases.
+//
+// Ground truth (tclsh 9.0.4 + real tcllib-2.0 `modules/textutil/`, verified
+// directly — see the PR's commit message for the exact transcripts):
+//   - `package require textutil::adjust` alone creates only the three-segment
+//     `::textutil::adjust::adjust` / `::textutil::adjust::indent` /
+//     `::textutil::adjust::undent` (plus `readPatterns`/`listPredefined`/
+//     `getPredefined`) — no bare `::textutil::adjust` command exists.
+//   - `package require textutil` (the umbrella) additionally creates the
+//     flattened `::textutil::adjust` / `::textutil::indent` / `::textutil::undent`
+//     aliases via `namespace import -force adjust::adjust adjust::indent
+//     adjust::undent` — real and callable, but ONLY after requiring the
+//     umbrella, never after requiring the submodule alone.
+// The same shape recurs in `textutil::trim` (trim/trimleft/trimright) and
+// `textutil::tabify` (tabify/untabify/tabify2/untabify2).
+// ===========================================================================
+mod textutil_submodule_vs_umbrella {
+    use super::*;
+
+    /// TP — the real submodule-qualified commands the common `package
+    /// require textutil::adjust; namespace import textutil::adjust::*`
+    /// idiom (tcllib-consuming corpora like `georgtree_argparse`) actually
+    /// resolves to must be registered, gated on the submodule package.
+    #[test]
+    fn textutil_adjust_submodule_commands_registered() {
+        let (reg, ds) = reg_and_set("tcl8.6");
+        for (name, pkg) in [
+            ("textutil::adjust::adjust", "textutil::adjust"),
+            ("textutil::adjust::indent", "textutil::adjust"),
+            ("textutil::adjust::undent", "textutil::adjust"),
+        ] {
+            let spec = reg
+                .get_for_dialect(name, ds)
+                .unwrap_or_else(|| panic!("{name} must be registered"));
+            assert_eq!(
+                spec.required_package,
+                Some(pkg),
+                "{name} must be gated on the submodule package, not the umbrella"
+            );
+        }
+    }
+
+    /// TP — the umbrella package's flattened re-export aliases are also
+    /// registered, distinctly gated on `textutil` (not `textutil::adjust`).
+    #[test]
+    fn textutil_umbrella_aliases_registered_distinctly() {
+        let (reg, ds) = reg_and_set("tcl8.6");
+        for name in ["textutil::adjust", "textutil::indent"] {
+            let spec = reg
+                .get_for_dialect(name, ds)
+                .unwrap_or_else(|| panic!("{name} (umbrella alias) must be registered"));
+            assert_eq!(
+                spec.required_package,
+                Some("textutil"),
+                "{name} is the umbrella's re-export, gated on requiring `textutil` itself"
+            );
+        }
+    }
+
+    /// TN — the umbrella-vs-submodule distinction is not collapsed: the
+    /// 2-segment alias and the 3-segment submodule command are two distinct
+    /// registry entries with two distinct package gates, so requiring
+    /// `textutil::adjust` alone must not read as granting the umbrella's
+    /// `textutil::adjust` alias name (they carry different `required_package`
+    /// values even though one's name is a prefix of the other's).
+    #[test]
+    fn submodule_and_umbrella_names_are_distinct_keys() {
+        let (reg, ds) = reg_and_set("tcl8.6");
+        let submodule = reg
+            .get_for_dialect("textutil::adjust::adjust", ds)
+            .expect("submodule command registered");
+        let umbrella = reg
+            .get_for_dialect("textutil::adjust", ds)
+            .expect("umbrella alias registered");
+        assert_ne!(submodule.required_package, umbrella.required_package);
+        assert_eq!(umbrella.required_package, Some("textutil"));
+        assert_eq!(submodule.required_package, Some("textutil::adjust"));
+    }
+
+    /// TN — a name shaped like the wrong guess this finding started from
+    /// (`textutil::indent` treated as if it were its own *package*, i.e. a
+    /// `textutil::indent::indent` submodule path) does not exist: `indent`
+    /// lives inside the `textutil::adjust` package only, and there never was
+    /// a separate `textutil::indent` package in real tcllib.
+    #[test]
+    fn no_fabricated_textutil_indent_package_submodule() {
+        let (reg, ds) = reg_and_set("tcl8.6");
+        assert!(
+            reg.get_for_dialect("textutil::indent::indent", ds)
+                .is_none()
+        );
+    }
+
+    /// TP/TN sibling sweep (verified against tclsh 9.0.4 the same way):
+    /// `textutil::trim` and `textutil::tabify` show the exact same
+    /// meta-package-flattening shape — the submodule-qualified commands must
+    /// be registered too, distinctly from their umbrella aliases.
+    #[test]
+    fn sibling_submodules_trim_and_tabify_also_registered() {
+        let (reg, ds) = reg_and_set("tcl8.6");
+        for name in [
+            "textutil::trim::trim",
+            "textutil::trim::trimleft",
+            "textutil::trim::trimright",
+            "textutil::tabify::tabify",
+            "textutil::tabify::untabify",
+            "textutil::tabify::tabify2",
+            "textutil::tabify::untabify2",
+            "textutil::string::longestCommonPrefix",
+        ] {
+            assert!(
+                reg.get_for_dialect(name, ds).is_some(),
+                "{name} must be registered (tclsh 9.0.4-verified real tcllib command)"
+            );
+        }
+        // Their umbrella aliases remain separately registered too.
+        for name in [
+            "textutil::trim",
+            "textutil::trimleft",
+            "textutil::trimright",
+            "textutil::tabify",
+            "textutil::untabify",
+            "textutil::tabify2",
+            "textutil::untabify2",
+        ] {
+            let spec = reg
+                .get_for_dialect(name, ds)
+                .unwrap_or_else(|| panic!("{name} (umbrella alias) must be registered"));
+            assert_eq!(spec.required_package, Some("textutil"));
+        }
+    }
+}

--- a/rust/tcl-registry/tests/registry_commands.rs
+++ b/rust/tcl-registry/tests/registry_commands.rs
@@ -2260,4 +2260,58 @@ mod textutil_submodule_vs_umbrella {
             assert_eq!(spec.required_package, Some("textutil"));
         }
     }
+
+    /// Contract test (code-review follow-up on this PR): the umbrella alias
+    /// and the submodule-qualified canonical name are the *same real tcllib
+    /// command* under two different call spellings, so every trait
+    /// descriptor (`Traits::PURE` and any future one) must agree between
+    /// them — a consumer doing purity-based GVN/DCE must not see a different
+    /// answer purely because of which spelling a call site happens to use.
+    /// `rust/tcl-registry/src/commands/tcllib/misc_ext.rs`'s
+    /// `sync_textutil_submodule_traits` is what keeps this true (it derives
+    /// the submodule spec's traits from the umbrella alias file rather than
+    /// declaring them a second time); this test is the general guard that
+    /// catches the *next* drift — a newly added re-exported command whose
+    /// submodule row is never wired into that sync list — not just today's.
+    #[test]
+    fn umbrella_alias_and_submodule_canonical_name_agree_on_traits() {
+        let (reg, ds) = reg_and_set("tcl8.6");
+        for (umbrella, submodule) in [
+            ("textutil::adjust", "textutil::adjust::adjust"),
+            ("textutil::indent", "textutil::adjust::indent"),
+            ("textutil::undent", "textutil::adjust::undent"),
+            ("textutil::trim", "textutil::trim::trim"),
+            ("textutil::trimleft", "textutil::trim::trimleft"),
+            ("textutil::trimright", "textutil::trim::trimright"),
+            ("textutil::tabify", "textutil::tabify::tabify"),
+            ("textutil::untabify", "textutil::tabify::untabify"),
+            ("textutil::tabify2", "textutil::tabify::tabify2"),
+            ("textutil::untabify2", "textutil::tabify::untabify2"),
+        ] {
+            let umbrella_spec = reg
+                .get_for_dialect(umbrella, ds)
+                .unwrap_or_else(|| panic!("{umbrella} (umbrella alias) must be registered"));
+            let submodule_spec = reg.get_for_dialect(submodule, ds).unwrap_or_else(|| {
+                panic!("{submodule} (submodule canonical name) must be registered")
+            });
+            assert_eq!(
+                umbrella_spec.traits, submodule_spec.traits,
+                "{umbrella} and {submodule} are the same real tcllib command \
+                 and must carry identical traits (got {:?} vs {:?})",
+                umbrella_spec.traits, submodule_spec.traits
+            );
+        }
+        // The `textutil::string` package has no bare `longestCommonPrefix`
+        // 2-segment umbrella alias file of its own name (the umbrella only
+        // re-exports it as `textutil::longestCommonPrefix`), covered above
+        // by `textutil_umbrella_aliases_registered_distinctly`'s sibling
+        // tests; check it here too for the same trait-parity property.
+        let umbrella_spec = reg
+            .get_for_dialect("textutil::longestCommonPrefix", ds)
+            .expect("textutil::longestCommonPrefix (umbrella alias) must be registered");
+        let submodule_spec = reg
+            .get_for_dialect("textutil::string::longestCommonPrefix", ds)
+            .expect("textutil::string::longestCommonPrefix must be registered");
+        assert_eq!(umbrella_spec.traits, submodule_spec.traits);
+    }
 }


### PR DESCRIPTION
## Summary

Registry-data corrections from the issue-923 differential audit, all oracle-verified by running real tcllib-2.0 sources under the container's tclsh 9.0.4 (no tcllib install existed, so the actual `modules/textutil/*.tcl` were fetched and executed with `auto_path` pointed at them — genuine C-Tcl ground truth, transcripts in the code/tests).

- **idx 3 + 4** — the existing `textutil::adjust`/`textutil::indent` entries were *correct* (they describe the umbrella `textutil` package's `namespace import -force` re-exports) but the real submodule commands had no entries at all: `package require textutil::adjust` actually provides `::textutil::adjust::adjust`, `::…::indent`, etc. (the argparse.tcl idiom). Added the submodule-keyed entries (`required_package: "textutil::adjust"`), kept the umbrella aliases with the distinction documented — so requiring the submodule does not grant the umbrella's names and vice versa.
- **Sibling sweep, same oracle method:** the identical gap existed and is fixed in `textutil::trim` (bare `trim`/`trimleft`/`trimright` missing), `textutil::tabify` (all four commands missing), and `textutil::string` (`longestCommonPrefix` missing). `repeat`/`split`/`wcswidth`/`patch`/`expander` verified already correct.
- **idx 11** — W113 ("shadows built-in") unioned the full package-inclusive `command_names()` into its builtin universe, so `proc ::argparse {args} {…}` — argparse's own entry point — drew a false shadow warning (oracle: bare tclsh has no `argparse`). New `is_package_gated_non_ambient` reads `owning_package` + `DialectProfile::is_ambient_package` — the exact query W120 already uses for the converse — with no hardcoded package list. iRules ambient commands (`pool`) still flag, pinned across tcl8.4/tcl9.0.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-registry -p tcl-compiler` — 8,029 passed, 0 failed (71 binaries).
  - New tests: 5 registry (submodule-vs-umbrella TP/TN, no-fabricated-package guard, sibling sweep), 3 W123-level (idiom resolution + bare-name contrast), 3 W113 (TP package-gated, TN core builtin across dialects, TN ambient iRules).
  - `cargo clippy -p tcl-registry -p tcl-compiler --all-targets -- -D warnings` — clean, **zero new allows**; `cargo fmt --check` clean.
  - Full xtask drift-gate sweep — all pass; the stale Zed command catalog was regenerated and committed (`gen-editor-catalogs` caught it).

Note: audit `STATUS.md` ticks for idx 3/4/11 are deliberately left out of this branch to keep it conflict-free with #1068 (which edits the same count lines) — the tracker updates land centrally after merge.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — W113's builtin universe is now package-gated via registry data.
- [x] I updated at least one relevant KCS note: doc comments on the corrected registry groups document the umbrella-vs-submodule contract; audit tracker updates follow post-merge as noted above.
- [ ] New compiler KCS note linked. (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_