### PR TITLE
Harness hardening: VS Code settle signal, tommath gating, runtime ns_inscope twin, wasm_coro_e2e target-dir (#1059, #1058 gating)

### DIFF
--- a/editors/vscode/src/test/runTest.ts
+++ b/editors/vscode/src/test/runTest.ts
@@ -18,6 +18,8 @@
 
 import * as path from "path";
 import * as fs from "fs";
+import * as os from "os";
+import * as crypto from "crypto";
 import { execSync } from "child_process";
 import { runTests } from "@vscode/test-electron";
 
@@ -87,11 +89,29 @@ async function main() {
     // No stale marker to remove.
   }
 
+  // The user-data dir's IPC lock file is a Unix domain socket
+  // (`<dir>/<version>-main.sock`), whose path is capped at ~107 bytes by
+  // `sun_path` — comfortably long for a normal checkout, but a checkout
+  // nested several levels deep (e.g. an isolated agent worktree under
+  // `.claude/worktrees/<id>/`) can push
+  // `<extensionDevelopmentPath>/.vscode-test/user-data/<ver>-main.sock`
+  // over that limit, which fails as `EINVAL: listen` with no useful
+  // message pointing at the real cause. Keep the user-data dir under the
+  // system temp dir instead — short regardless of how deeply this checkout
+  // is nested — but derive its name from `extensionDevelopmentPath` so
+  // repeated runs against the *same* checkout keep reusing (and clearing)
+  // the same directory rather than leaking a fresh one every time, while
+  // a different checkout (a different worktree) gets its own.
+  const checkoutId = crypto
+    .createHash("sha1")
+    .update(extensionDevelopmentPath)
+    .digest("hex")
+    .slice(0, 12);
+  const userDataDir = path.join(os.tmpdir(), `tcl-lsp-vscode-test-${checkoutId}`, "user-data");
   // Clear persisted user settings from prior test runs so tests start
   // with a clean slate.  Settings modified via workspace.getConfiguration
   // .update() persist in the user-data directory and can pollute
   // subsequent runs.
-  const userDataDir = path.resolve(extensionDevelopmentPath, ".vscode-test", "user-data");
   const userSettingsFile = path.resolve(userDataDir, "User", "settings.json");
   try {
     const { writeFileSync, mkdirSync } = require("fs");
@@ -112,6 +132,7 @@ async function main() {
       launchArgs: [
         testWorkspace,
         "--disable-extensions", // Disable other extensions
+        `--user-data-dir=${userDataDir}`,
       ],
     });
 

--- a/editors/vscode/src/test/variableContexts.test.ts
+++ b/editors/vscode/src/test/variableContexts.test.ts
@@ -18,7 +18,14 @@
 
 import * as assert from "assert";
 import * as vscode from "vscode";
-import { getDocUri, activate, waitForDiagnostics, pollUntil } from "./helper";
+import {
+  getDocUri,
+  activate,
+  waitForDiagnostics,
+  waitForDeepDiagnostics,
+  getServerLogSize,
+  pollUntil,
+} from "./helper";
 
 function labelOf(item: vscode.CompletionItem): string {
   return typeof item.label === "string" ? item.label : item.label.label;
@@ -68,6 +75,32 @@ async function completionItemsAt(
 }
 
 /**
+ * Insert *insertion* at the end of the line containing *marker* (so the
+ * probe sits on the line after the marker, matching the fixture's
+ * indentation), and return the position right after the inserted text —
+ * the spot completion should be requested at. Shared by ``probeAt`` (one
+ * probe, revert immediately) and the "command contexts" suite below
+ * (all ten probes inserted up front, reverted once at the end).
+ */
+async function insertProbe(
+  uri: vscode.Uri,
+  doc: vscode.TextDocument,
+  marker: string,
+  insertion: string,
+): Promise<vscode.Position> {
+  const text = doc.getText();
+  const idx = text.indexOf(marker);
+  assert.ok(idx >= 0, `Marker '${marker}' not found in fixture`);
+  const markerLine = doc.positionAt(idx).line;
+  const eolPos = doc.lineAt(markerLine).range.end;
+  const eolOffset = doc.offsetAt(eolPos);
+  const edit = new vscode.WorkspaceEdit();
+  edit.insert(uri, eolPos, insertion);
+  await vscode.workspace.applyEdit(edit);
+  return doc.positionAt(eolOffset + insertion.length);
+}
+
+/**
  * Marker-based completion probing: find ``# PROBE_X`` in the fixture,
  * insert the supplied probe text on the line after the marker, position
  * the cursor at the end of the inserted text, request completion (waiting
@@ -85,23 +118,28 @@ async function probeAt(
   expect: string[],
 ): Promise<vscode.CompletionItem[]> {
   const doc = await activate(uri);
-  const text = doc.getText();
-  const idx = text.indexOf(marker);
-  assert.ok(idx >= 0, `Marker '${marker}' not found in fixture`);
-  // Insert at the end of the marker line so the probe sits on the
-  // following line (matching the comment indentation).
-  const markerLine = doc.positionAt(idx).line;
-  const eolPos = doc.lineAt(markerLine).range.end;
-  const eolOffset = doc.offsetAt(eolPos);
-  const edit = new vscode.WorkspaceEdit();
-  edit.insert(uri, eolPos, insertion);
-  await vscode.workspace.applyEdit(edit);
-  const completionPos = doc.positionAt(eolOffset + insertion.length);
+  const completionPos = await insertProbe(uri, doc, marker, insertion);
   try {
     return await completionItemsAt(uri, completionPos, expect);
   } finally {
     await vscode.commands.executeCommand("workbench.action.files.revert", doc);
   }
+}
+
+/** One completion request at *position*, no polling. Only safe to call
+ * against an already-settled document — see the "command contexts" suite's
+ * ``suiteSetup``, which waits for the deep-diagnostics signal before any
+ * test calls this. */
+async function completionAt(
+  uri: vscode.Uri,
+  position: vscode.Position,
+): Promise<vscode.CompletionItem[]> {
+  const result = (await vscode.commands.executeCommand(
+    "vscode.executeCompletionItemProvider",
+    uri,
+    position,
+  )) as vscode.CompletionList;
+  return result.items;
 }
 
 function insertedText(item: vscode.CompletionItem): string | undefined {
@@ -122,12 +160,75 @@ function textEditOf(item: vscode.CompletionItem): vscode.TextEdit | undefined {
 suite("Variable Completion: command contexts", () => {
   const docUri = getDocUri("variableContexts.tcl");
 
-  // Each command-form probe inserts ``\n        puts $`` after the
-  // marker line so the cursor lands right after a fresh ``$`` inside
-  // the surrounding proc body.
+  // Each command-form probe inserts ``\n        puts $`` (or, for the three
+  // forms whose marker sits one indent level deeper, ``\n            puts
+  // $``) after the marker line so the cursor lands right after a fresh
+  // ``$`` inside the surrounding proc body.
+  //
+  // These ten probes used to each insert their own probe text and
+  // independently poll ``completionItemsAt`` on a fresh 10s budget before
+  // reverting — ten such polls stacked on top of Electron startup produced
+  // the intermittent cumulative timeout under constrained containers
+  // (issue #1059), even though any single probe settles in well under a
+  // second once the server has caught up. Every probe marker sits in its
+  // own, syntactically independent proc (see
+  // ``testFixture/variableContexts.tcl``), so all ten insertions can
+  // coexist in one edit batch: ``suiteSetup`` applies them all up front and
+  // waits ONCE for the server's ``[timing] deep diagnostics`` marker for
+  // this document (``waitForDeepDiagnostics``) — a real "the server
+  // finished re-analysing the edited document" signal (the same one
+  // ``helper.ts`` uses elsewhere), not a sleep. Every test below then
+  // requests completion exactly once against that already-settled state,
+  // so a genuine regression in any one probe still fails loudly on its own
+  // assertion — the batching only removes the redundant repeated waiting,
+  // it does not merge the ten checks into one.
+  const PROBES = [
+    { key: "variable", marker: "# PROBE_VARIABLE", insertion: "\n        puts $" },
+    { key: "nsUpvar", marker: "# PROBE_NS_UPVAR", insertion: "\n        puts $" },
+    { key: "lassign", marker: "# PROBE_LASSIGN", insertion: "\n        puts $" },
+    { key: "regexp", marker: "# PROBE_REGEXP", insertion: "\n        puts $" },
+    { key: "regsub", marker: "# PROBE_REGSUB", insertion: "\n        puts $" },
+    { key: "scan", marker: "# PROBE_SCAN", insertion: "\n        puts $" },
+    { key: "catch", marker: "# PROBE_CATCH", insertion: "\n        puts $" },
+    { key: "tryOnError", marker: "# PROBE_TRY", insertion: "\n            puts $" },
+    { key: "dictUpdate", marker: "# PROBE_DICT_UPDATE", insertion: "\n            puts $" },
+    { key: "uplevelOne", marker: "# PROBE_UPLEVEL_ONE", insertion: "\n            puts $" },
+  ] as const;
+  const positions = new Map<string, vscode.Position>();
+  let doc: vscode.TextDocument;
+
+  function positionFor(key: (typeof PROBES)[number]["key"]): vscode.Position {
+    const pos = positions.get(key);
+    assert.ok(pos, `no probe position recorded for '${key}' — did suiteSetup run?`);
+    return pos as vscode.Position;
+  }
+
+  suiteSetup(async function () {
+    this.timeout(30_000);
+    doc = await activate(docUri);
+    for (let i = 0; i < PROBES.length; i++) {
+      const p = PROBES[i];
+      const isLast = i === PROBES.length - 1;
+      // Capture the log-size baseline right before the LAST edit only: it
+      // must be taken after every earlier edit (so an intermediate deep
+      // pass that happens to land between two of our edits does not
+      // satisfy the wait prematurely) but before this edit is applied (so
+      // the wait cannot miss a publish that lands between capturing the
+      // baseline and awaiting it).
+      const since = isLast ? getServerLogSize() : undefined;
+      positions.set(p.key, await insertProbe(docUri, doc, p.marker, p.insertion));
+      if (isLast) {
+        await waitForDeepDiagnostics(docUri, { since, timeout: 20_000 });
+      }
+    }
+  });
+
+  suiteTeardown(async () => {
+    await vscode.commands.executeCommand("workbench.action.files.revert", doc);
+  });
 
   test("variable: namespace var alias is in scope inside the proc", async () => {
-    const items = await probeAt(docUri, "# PROBE_VARIABLE", "\n        puts $", ["$namespace_var"]);
+    const items = await completionAt(docUri, positionFor("variable"));
     const labels = items.map(labelOf);
     assert.ok(
       labels.includes("$namespace_var"),
@@ -136,7 +237,7 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("namespace upvar: local alias is in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_NS_UPVAR", "\n        puts $", ["$local_ns_var"]);
+    const items = await completionAt(docUri, positionFor("nsUpvar"));
     const labels = items.map(labelOf);
     assert.ok(
       labels.includes("$local_ns_var"),
@@ -145,11 +246,7 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("lassign: each destructured var is in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_LASSIGN", "\n        puts $", [
-      "$la",
-      "$lb",
-      "$lc",
-    ]);
+    const items = await completionAt(docUri, positionFor("lassign"));
     const labels = items.map(labelOf);
     for (const v of ["$la", "$lb", "$lc"]) {
       assert.ok(
@@ -160,11 +257,7 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("regexp: capture-group vars are in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_REGEXP", "\n        puts $", [
-      "$rx_full",
-      "$rx_key",
-      "$rx_value",
-    ]);
+    const items = await completionAt(docUri, positionFor("regexp"));
     const labels = items.map(labelOf);
     for (const v of ["$rx_full", "$rx_key", "$rx_value"]) {
       assert.ok(
@@ -175,13 +268,13 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("regsub: output var is in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_REGSUB", "\n        puts $", ["$rs_out"]);
+    const items = await completionAt(docUri, positionFor("regsub"));
     const labels = items.map(labelOf);
     assert.ok(labels.includes("$rs_out"), `Expected $rs_out: ${labels.slice(0, 30).join(", ")}`);
   });
 
   test("scan: each output var is in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_SCAN", "\n        puts $", ["$sx", "$sy", "$sz"]);
+    const items = await completionAt(docUri, positionFor("scan"));
     const labels = items.map(labelOf);
     for (const v of ["$sx", "$sy", "$sz"]) {
       assert.ok(labels.includes(v), `Expected ${v} after scan: ${labels.slice(0, 30).join(", ")}`);
@@ -189,10 +282,7 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("catch: resultVar and optionsVar are in scope", async () => {
-    const items = await probeAt(docUri, "# PROBE_CATCH", "\n        puts $", [
-      "$catch_result",
-      "$catch_opts",
-    ]);
+    const items = await completionAt(docUri, positionFor("catch"));
     const labels = items.map(labelOf);
     assert.ok(
       labels.includes("$catch_result"),
@@ -205,10 +295,7 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("try on error: handler binding-list vars are in scope inside body", async () => {
-    const items = await probeAt(docUri, "# PROBE_TRY", "\n            puts $", [
-      "$try_msg",
-      "$try_opts",
-    ]);
+    const items = await completionAt(docUri, positionFor("tryOnError"));
     const labels = items.map(labelOf);
     for (const v of ["$try_msg", "$try_opts"]) {
       assert.ok(
@@ -219,10 +306,7 @@ suite("Variable Completion: command contexts", () => {
   });
 
   test("dict update: alias vars are in scope inside body", async () => {
-    const items = await probeAt(docUri, "# PROBE_DICT_UPDATE", "\n            puts $", [
-      "$alias_a",
-      "$alias_b",
-    ]);
+    const items = await completionAt(docUri, positionFor("dictUpdate"));
     const labels = items.map(labelOf);
     for (const v of ["$alias_a", "$alias_b"]) {
       assert.ok(
@@ -238,11 +322,8 @@ suite("Variable Completion: command contexts", () => {
     // suggest a variable that does not exist at runtime. Completion abstains on
     // the proc's locals (matching the server-side
     // ``dollar_completion_uplevel_one_abstains_from_proc_scope``) while still
-    // offering the body's own declarations. Poll for the body-local so the
-    // request has settled, then assert the proc-local is absent.
-    const items = await probeAt(docUri, "# PROBE_UPLEVEL_ONE", "\n            puts $", [
-      "$body_var",
-    ]);
+    // offering the body's own declarations.
+    const items = await completionAt(docUri, positionFor("uplevelOne"));
     const labels = items.map(labelOf);
     assert.ok(
       labels.includes("$body_var"),

--- a/runtime/rust/Cargo.toml
+++ b/runtime/rust/Cargo.toml
@@ -33,6 +33,21 @@
 # Gate: `make runtime-rust-test` runs the native `cargo test` here. The leak
 # round-trip test is the T1.1 acceptance (zero residual under the alloc/free
 # counters).
+#
+# The empty `[workspace]` table below pins this crate as its OWN workspace
+# root rather than relying solely on the parent's `exclude` entry. Cargo's
+# ancestor search does not stop at the first excluding parent — when this
+# crate is checked out in a git worktree that is itself nested inside
+# another checkout of this repo (e.g.
+# `<repo>/.claude/worktrees/<agent>/runtime/rust`), the walk continues past
+# the worktree's own (correctly-excluding) root and lands on the outer
+# checkout's `Cargo.toml`, whose `exclude` entry is resolved relative to
+# ITS OWN directory and so does not match the nested worktree path — cargo
+# then reports "current package believes it's in a workspace when it's
+# not". Declaring the workspace here locally short-circuits the ancestor
+# search entirely, independent of where this checkout is nested.
+[workspace]
+
 [package]
 name = "tcl-runtime"
 version = "0.1.0"

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -572,19 +572,62 @@ fn drop_fresh(obj: *mut TclObj) {
 
 /// `namespace inscope ns cmd ?arg ...?` — evaluate `cmd` (with the extra args
 /// appended) in namespace `ns`. Like `namespace eval` but used by
-/// `namespace code` scripts. (The extra args are space-appended — the
-/// list-element-quoting refinement matters only for the multi-arg form.)
+/// `namespace code` scripts.
+///
+/// `NamespaceInscopeCmd` (`generic/tclNamesp.c`) is the one member of the
+/// `Tcl_ConcatObj` eval family whose trailing words are **not** space-joined
+/// into the script text: it collects the extra args into a **list object**
+/// and concatenates that list's string rep onto the script, so each extra
+/// word reaches the invoked command as exactly one argument however much
+/// whitespace or list punctuation it holds:
+///
+/// ```text
+/// namespace inscope :: {puts} {a b}   → prints "a b"  (one argument)
+/// namespace eval    :: {puts} {a b}   → error: can not find channel named "a"
+/// ```
+///
+/// (Twin of #1056/#1067, already fixed for the bytecode VM.) With no extra
+/// args, C takes the `objc == 3` arm and evaluates the script verbatim — no
+/// concat, so no trim and no trailing space, which the early return mirrors.
 fn ns_inscope(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
     if argv.len() < 4 {
         return interp.wrong_args(b"namespace inscope name arg ?arg...?");
     }
     let name = obj_bytes(argv[2]);
-    let mut script = obj_bytes(argv[3]);
-    for &a in &argv[4..] {
-        script.push(b' ');
-        script.extend_from_slice(&obj_bytes(a));
-    }
+    let script = inscope_script(argv[3], &argv[4..]);
     interp.ns_eval(&name, &script)
+}
+
+/// Build the script `ns_inscope` evaluates: `Tcl_ConcatObj(script, list(tail))`.
+/// No tail args → `script` verbatim (C's `objc == 3` arm). Otherwise the
+/// tail's list-element quoting reuses the crate's canonical
+/// [`list::append_list_element`] (`TclScanElement`/`TclConvertElement` — the
+/// same helper the list type's own string rep uses), and the two-part concat
+/// reuses `tcl_cmd_core::list::trim_concat_element` (`Tcl_ConcatObj`'s
+/// backslash-aware right trim + drop-empty-part rule): a whitespace-padded
+/// script is trimmed, and an all-whitespace script contributes no leading
+/// separator (the tail becomes the whole command).
+fn inscope_script(script: *mut TclObj, tail: &[*mut TclObj]) -> Vec<u8> {
+    let script_bytes = obj_bytes(script);
+    if tail.is_empty() {
+        return script_bytes;
+    }
+    let mut tail_list = Vec::new();
+    for (i, &a) in tail.iter().enumerate() {
+        if i > 0 {
+            tail_list.push(b' ');
+        }
+        list::append_list_element(&mut tail_list, &obj_bytes(a), i == 0);
+    }
+    let script_str = String::from_utf8_lossy(&script_bytes);
+    let trimmed = tcl_cmd_core::list::trim_concat_element(&script_str);
+    if trimmed.is_empty() {
+        return tail_list;
+    }
+    let mut out = trimmed.as_bytes().to_vec();
+    out.push(b' ');
+    out.extend_from_slice(&tail_list);
+    out
 }
 
 /// `namespace origin command` — the fully-qualified original name of `command`
@@ -1178,6 +1221,18 @@ mod tests {
     /// the `tcl-syntax` conformance test) must dispatch identically
     /// through this runtime's namespace tree — the anti-drift gate for
     /// `Namespaces::home_of`.
+    ///
+    /// `vector_script` wraps every call in `if {[catch {…} __r]} {…}`
+    /// (`tcl-syntax`'s shared script renderer), so this test needs `if` —
+    /// which `builtins::install` only registers under `have_tommath`
+    /// (issue #1058). Without libtommath vendored, every vector fails
+    /// identically with `invalid command name "if"`, which is a build
+    /// environment gap, not a dispatch regression — ignore with the
+    /// real reason instead of failing on a mundane cause.
+    #[cfg_attr(
+        not(have_tommath),
+        ignore = "libtommath not vendored; if/while/for/expr unavailable (issue #1058)"
+    )]
     #[test]
     fn dispatch_matches_every_conformance_vector() {
         use tcl_syntax::naming::conformance::{vector_script, vectors};
@@ -1458,6 +1513,96 @@ mod tests {
             assert_eq!(i.eval_str(b"::a::b::path list v 5"), Code::Ok);
             assert_eq!(i.result_bytes(), b"5");
             i.eval_str(b"unset v");
+        });
+    }
+
+    // -- namespace inscope (issue #1058's twin of #1056/#1067) -----------------
+    //
+    // These avoid `if`/`while`/`for`/`expr` (and anything else `have_tommath`-
+    // gated) entirely, so they run identically with or without the bignum
+    // tower — unlike `dispatch_matches_every_conformance_vector` above, which
+    // genuinely needs `if`.
+
+    #[test]
+    fn inscope_zero_tail_args_evaluates_script_verbatim() {
+        leak_free(|i| {
+            i.eval_str(b"proc probe {args} { return $args }");
+            // C's `objc == 3` arm: no tail, so no list is appended and no
+            // concat/trim/trailing space happens — the script runs as-is.
+            assert_eq!(i.eval_str(b"namespace inscope :: probe"), Code::Ok);
+            assert_eq!(i.result_bytes(), b"");
+        });
+    }
+
+    #[test]
+    fn inscope_tail_args_become_list_elements_not_joined_words() {
+        // `NamespaceInscopeCmd` (`generic/tclNamesp.c`) collects the tail
+        // into a LIST and concatenates its string rep onto `script`
+        // (`Tcl_ConcatObj` over `[script, list(tail)]`), so however many
+        // words a tail argument holds, it reaches the invoked command as
+        // exactly one argument.
+        leak_free(|i| {
+            i.eval_str(b"proc probe {args} { return $args }");
+
+            // A tail word with an embedded space stays ONE argument (the
+            // pre-fix bug: it split into two words, "x" and "y").
+            assert_eq!(
+                i.eval_str(b"llength [namespace inscope :: probe {x y}]"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"1");
+            assert_eq!(
+                i.eval_str(b"lindex [namespace inscope :: probe {x y}] 0"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"x y");
+
+            // An empty-string tail arg round-trips as one empty argument.
+            assert_eq!(
+                i.eval_str(b"llength [namespace inscope :: probe {}]"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"1");
+            assert_eq!(
+                i.eval_str(b"lindex [namespace inscope :: probe {}] 0"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"");
+
+            // Multiple tail words each keep their own arg boundary.
+            assert_eq!(
+                i.eval_str(b"llength [namespace inscope :: probe a {b c} d]"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"3");
+
+            // Special characters round-trip through the list-element
+            // quoting (`list::append_list_element`): an unbalanced brace, a
+            // lone backslash, and an embedded double quote. `lindex`
+            // recovers the raw element value regardless of which of the
+            // four renderings (none/brace/mask/escape) quoting picked.
+            i.eval_str(b"set v1 \"a\\{b\"");
+            assert_eq!(
+                i.eval_str(b"lindex [namespace inscope :: probe $v1] 0"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"a{b");
+
+            i.eval_str(b"set v2 \"\\\\\"");
+            assert_eq!(
+                i.eval_str(b"lindex [namespace inscope :: probe $v2] 0"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"\\");
+
+            i.eval_str(b"set v3 {a\"b}");
+            assert_eq!(
+                i.eval_str(b"lindex [namespace inscope :: probe $v3] 0"),
+                Code::Ok
+            );
+            assert_eq!(i.result_bytes(), b"a\"b");
+
+            i.eval_str(b"unset v1 v2 v3");
         });
     }
 }

--- a/runtime/rust/src/cmd_namespace.rs
+++ b/runtime/rust/src/cmd_namespace.rs
@@ -603,8 +603,11 @@ fn ns_inscope(interp: &mut Interp, argv: &[*mut TclObj]) -> Code {
 /// tail's list-element quoting reuses the crate's canonical
 /// [`list::append_list_element`] (`TclScanElement`/`TclConvertElement` — the
 /// same helper the list type's own string rep uses), and the two-part concat
-/// reuses `tcl_cmd_core::list::trim_concat_element` (`Tcl_ConcatObj`'s
-/// backslash-aware right trim + drop-empty-part rule): a whitespace-padded
+/// reuses [`list::trim_concat_element_bytes`] (`Tcl_ConcatObj`'s
+/// backslash-aware right trim + drop-empty-part rule, operating on raw
+/// bytes — this runtime's Tcl strings are arbitrary byte slices, not
+/// necessarily UTF-8, so a lossy `&str` round-trip here would mangle a
+/// non-UTF-8 script byte instead of passing it through): a whitespace-padded
 /// script is trimmed, and an all-whitespace script contributes no leading
 /// separator (the tail becomes the whole command).
 fn inscope_script(script: *mut TclObj, tail: &[*mut TclObj]) -> Vec<u8> {
@@ -619,12 +622,11 @@ fn inscope_script(script: *mut TclObj, tail: &[*mut TclObj]) -> Vec<u8> {
         }
         list::append_list_element(&mut tail_list, &obj_bytes(a), i == 0);
     }
-    let script_str = String::from_utf8_lossy(&script_bytes);
-    let trimmed = tcl_cmd_core::list::trim_concat_element(&script_str);
+    let trimmed = list::trim_concat_element_bytes(&script_bytes);
     if trimmed.is_empty() {
         return tail_list;
     }
-    let mut out = trimmed.as_bytes().to_vec();
+    let mut out = trimmed.to_vec();
     out.push(b' ');
     out.extend_from_slice(&tail_list);
     out
@@ -1603,6 +1605,71 @@ mod tests {
             assert_eq!(i.result_bytes(), b"a\"b");
 
             i.eval_str(b"unset v1 v2 v3");
+        });
+    }
+
+    #[test]
+    fn inscope_non_utf8_script_treats_both_arms_consistently() {
+        // The script is a raw-byte *value* holding a non-UTF-8 byte
+        // (`0x80`) — produced via `binary format`'s `c` (raw byte)
+        // directive, not a `\xHH` escape (which substitutes a *Unicode
+        // code point* and this runtime stores as valid UTF-8, `0xC2 0x80`
+        // — not a genuinely invalid byte, so it would not exercise the
+        // bug).
+        //
+        // `namespace inscope`/`eval` scripts are themselves re-parsed as a
+        // fresh script (`parse::parse_script` — see its doc comment: "the
+        // UTF-8 internal-rep invariant"), so a script value that is not
+        // valid UTF-8 parses to no commands and evaluates as a harmless
+        // no-op (`Code::Ok`, empty result) — a separate, pre-existing
+        // `parse_script` limitation this fix does not touch, and unrelated
+        // to `list::append_list_element`'s (byte-exact, unaffected)
+        // quoting of the tail.
+        //
+        // What the fix DOES change: before it, the tail arm converted the
+        // script half to `&str` via `String::from_utf8_lossy`, silently
+        // replacing the invalid byte with the *valid*-UTF-8 3-byte U+FFFD
+        // sequence — so the composed script could flip from "not valid
+        // UTF-8" (parses to nothing, `Code::Ok`, empty) to "accidentally
+        // valid UTF-8" (parses fine, dispatches to a different,
+        // non-existent command, `Code::Error`) purely because a tail arg
+        // was appended. The zero-tail and tail arms must treat the exact
+        // same script bytes identically; [`list::trim_concat_element_bytes`]
+        // never performs that lossy conversion, so both arms agree here.
+        leak_free(|i| {
+            assert_eq!(
+                i.eval_str(b"set name [binary format a3c cmd 128]"),
+                Code::Ok
+            );
+            assert_eq!(
+                i.result_bytes(),
+                [b'c', b'm', b'd', 0x80],
+                "binary format should produce the raw 0x80 byte"
+            );
+
+            assert_eq!(
+                i.eval_str(b"namespace inscope :: $name"),
+                Code::Ok,
+                "zero-tail arm"
+            );
+            assert_eq!(
+                i.result_bytes(),
+                b"",
+                "zero-tail arm: an invalid-UTF-8 script is a harmless no-op"
+            );
+
+            assert_eq!(
+                i.eval_str(b"namespace inscope :: $name extra"),
+                Code::Ok,
+                "tail arm must agree with the zero-tail arm, not error on a mangled name"
+            );
+            assert_eq!(
+                i.result_bytes(),
+                b"",
+                "tail arm: must stay a no-op, exactly like the zero-tail arm"
+            );
+
+            i.eval_str(b"unset name");
         });
     }
 }

--- a/runtime/rust/src/list.rs
+++ b/runtime/rust/src/list.rs
@@ -225,6 +225,37 @@ fn is_ws(c: u8) -> bool {
     matches!(c, b' ' | b'\t' | b'\n' | b'\r' | 0x0b | 0x0c)
 }
 
+/// Byte-oriented, backslash-aware trim for one `Tcl_ConcatObj` part —
+/// same semantics as `tcl_cmd_core::list::trim_concat_element`
+/// (`TclTrimLeft`/`TclTrimRight`: the right trim keeps a trailing
+/// whitespace byte escaped by an odd run of backslashes), but operating
+/// directly on bytes rather than `&str`. This runtime treats Tcl strings
+/// as arbitrary byte slices — not necessarily UTF-8 — so a caller
+/// concatenating raw command/argument bytes (e.g. `namespace inscope`'s
+/// script half, `cmd_namespace::inscope_script`) must not round-trip
+/// through `String::from_utf8_lossy`, which would mangle a non-UTF-8 byte
+/// into the 3-byte U+FFFD replacement sequence and change the value.
+#[must_use]
+pub(crate) fn trim_concat_element_bytes(s: &[u8]) -> &[u8] {
+    let mut start = 0;
+    while start < s.len() && is_ws(s[start]) {
+        start += 1;
+    }
+    let mut end = s.len();
+    while end > start && is_ws(s[end - 1]) {
+        let backslashes = s[start..end - 1]
+            .iter()
+            .rev()
+            .take_while(|&&b| b == b'\\')
+            .count();
+        if backslashes % 2 == 1 {
+            break; // escaped whitespace: part of the element.
+        }
+        end -= 1;
+    }
+    &s[start..end]
+}
+
 /// Append `elem` to `buf` in canonical Tcl list-element form. Faithful port of
 /// `TclScanElement`/`TclConvertElement` (`tclUtil.c`) in the **COMPAT** build
 /// configuration Tcl 9.0.3 ships, which picks among four renderings:

--- a/rust/tcl-vm/tests/wasm_coro_e2e.rs
+++ b/rust/tcl-vm/tests/wasm_coro_e2e.rs
@@ -175,9 +175,18 @@ fn vm_coroutines_run_on_wasm32() {
     let harness = dir.join("harness.mjs");
     std::fs::write(&harness, HARNESS_MJS).expect("write harness");
 
+    // An explicit `--target-dir` (rather than relying on the default,
+    // cwd-relative `target/`) keeps this build's output where the artifact
+    // lookup below expects it regardless of the ambient environment: a CLI
+    // flag outranks an inherited `CARGO_TARGET_DIR` (the agent build
+    // isolation env var — see `scripts/dev/agent-build-env.sh`), which this
+    // child process would otherwise pick up and build into instead.
+    let target_dir = dir.join("target");
     let build = Command::new(env!("CARGO"))
         .current_dir(&dir)
         .args(["build", "--release", "--target", "wasm32-unknown-unknown"])
+        .arg("--target-dir")
+        .arg(&target_dir)
         .output()
         .expect("run cargo build");
     assert!(
@@ -186,7 +195,7 @@ fn vm_coroutines_run_on_wasm32() {
         String::from_utf8_lossy(&build.stderr)
     );
 
-    let wasm = dir.join("target/wasm32-unknown-unknown/release/tcl_vm_wasm_coro.wasm");
+    let wasm = target_dir.join("wasm32-unknown-unknown/release/tcl_vm_wasm_coro.wasm");
     assert!(wasm.exists(), "wasm artifact missing at {}", wasm.display());
 
     let out = run_node(&harness, &wasm);
@@ -223,6 +232,10 @@ fn vm_wasm_crate_runs_coroutines_via_abi() {
     }
     let crate_path = crate_dir().join("..").join("tcl-vm-wasm");
     let manifest = crate_path.join("Cargo.toml");
+    // Explicit `--target-dir`, for the same reason as `vm_coroutines_run_on_wasm32`
+    // above: an inherited `CARGO_TARGET_DIR` would otherwise redirect this build
+    // away from the fixed path the artifact lookup below checks.
+    let target_dir = crate_path.join("target");
     let build = Command::new(env!("CARGO"))
         .args([
             "build",
@@ -232,6 +245,8 @@ fn vm_wasm_crate_runs_coroutines_via_abi() {
             "--manifest-path",
             manifest.to_str().expect("manifest path utf-8"),
         ])
+        .arg("--target-dir")
+        .arg(&target_dir)
         .output()
         .expect("run cargo build");
     assert!(
@@ -239,7 +254,7 @@ fn vm_wasm_crate_runs_coroutines_via_abi() {
         "tcl-vm-wasm build failed:\n{}",
         String::from_utf8_lossy(&build.stderr)
     );
-    let wasm = crate_path.join("target/wasm32-unknown-unknown/release/tcl_vm_wasm.wasm");
+    let wasm = target_dir.join("wasm32-unknown-unknown/release/tcl_vm_wasm.wasm");
     assert!(wasm.exists(), "wasm artifact missing at {}", wasm.display());
 
     // `verify.mjs` runs a generator, the resume-value idiom, a yield-across-catch

--- a/rust/tcl-vm/tests/wasm_coro_e2e.rs
+++ b/rust/tcl-vm/tests/wasm_coro_e2e.rs
@@ -41,6 +41,49 @@ fn crate_dir() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR"))
 }
 
+/// A short, filesystem-safe key derived from `path`'s absolute form —
+/// stable across repeated runs against the same checkout, but distinct per
+/// checkout, so two concurrently-building checkouts of this repository
+/// (e.g. isolated agent worktrees, each with their own `rust/tcl-compiler`,
+/// `rust/tcl-registry`, … under a *different* absolute path) never share
+/// the same scratch project / target directory. Sharing one would corrupt
+/// artefacts exactly the way AGENTS.md's "parallel worktrees" section
+/// describes for a shared `CARGO_TARGET_DIR`: cargo's unit hashing does not
+/// disambiguate same-named workspace members built from different checkout
+/// paths, so one checkout's build can silently link another's rlib.
+/// Mirrors the same checkout-hashed pattern
+/// `editors/vscode/src/test/runTest.ts` uses for its user-data dir.
+fn checkout_key(path: &Path) -> String {
+    use std::collections::hash_map::DefaultHasher;
+    use std::hash::{Hash, Hasher};
+    let mut hasher = DefaultHasher::new();
+    path.hash(&mut hasher);
+    format!("{:016x}", hasher.finish())
+}
+
+#[test]
+fn checkout_key_is_stable_and_distinguishes_checkouts() {
+    let a = checkout_key(Path::new("/home/user/tcl-lsp"));
+    let b = checkout_key(Path::new("/home/user/tcl-lsp"));
+    assert_eq!(a, b, "the same checkout path must hash to the same key");
+
+    let c = checkout_key(Path::new(
+        "/home/user/tcl-lsp/.claude/worktrees/some-other-agent",
+    ));
+    assert_ne!(
+        a, c,
+        "two different checkout paths must hash to different keys, so \
+         concurrent worktrees never collide on the same scratch dir"
+    );
+
+    // Filesystem-safe: plain lowercase hex, no path separators or other
+    // characters a directory-name component would need to escape.
+    assert!(
+        a.chars().all(|c| c.is_ascii_hexdigit()),
+        "key must be plain hex: {a:?}"
+    );
+}
+
 fn have_node() -> bool {
     Command::new("node")
         .arg("--version")
@@ -165,9 +208,13 @@ fn vm_coroutines_run_on_wasm32() {
         return;
     }
 
-    // A stable scratch dir keeps the (large) wasm dependency build cached between
-    // runs; only this crate's source changing forces a rebuild.
-    let dir = std::env::temp_dir().join("tcl_vm_wasm_coro");
+    // A stable, checkout-keyed scratch dir (see `checkout_key`) keeps the
+    // (large) wasm dependency build cached between repeated runs against
+    // the SAME checkout — only this crate's source changing forces a
+    // rebuild — while keeping two checkouts building concurrently (e.g.
+    // isolated agent worktrees) from sharing one `Cargo.toml`/`target/`,
+    // which would corrupt each other's artefacts.
+    let dir = std::env::temp_dir().join(format!("tcl_vm_wasm_coro-{}", checkout_key(&crate_dir())));
     let src = dir.join("src");
     std::fs::create_dir_all(&src).expect("create crate dir");
     std::fs::write(dir.join("Cargo.toml"), cargo_toml()).expect("write Cargo.toml");


### PR DESCRIPTION
## Summary

Fixes #1059; hardens the #1058 failure mode (the underlying runtime bug stays open); completes #1056's sweep into `runtime/rust`; fixes the `wasm_coro_e2e`/`CARGO_TARGET_DIR` interaction found during #1067.

- **#1059** — the "command contexts" suite no longer stacks ten independent 10s completion polls: all ten probe edits (independent procs in the fixture) apply up front in `suiteSetup`, which awaits the server's existing deep-diagnostics settle signal **once**; each test then makes a single non-polling completion request against settled state. Ten individually-asserting tests unchanged. Root-caused a second, real failure mode while at it: `@vscode/test-electron`'s user-data-dir IPC lock is a Unix domain socket (~107-byte path cap), so deeply nested checkouts hit `EINVAL: listen` — `runTest.ts` now uses a short checkout-hashed user-data dir under the OS temp dir. Suite now runs 10/10 in ~2s; full file 29/29; fixture left clean.
- **#1058 gating** — `dispatch_matches_every_conformance_vector` was the one runtime test that fails misleadingly when libtommath isn't vendored (`if`/`while`/`for`/`expr` compiled out; every other tommath-dependent test was already item-gated). It now carries `#[cfg_attr(not(have_tommath), ignore = "libtommath not vendored; if/while/for/expr unavailable (issue #1058)")]`, so constrained environments show an explicit ignore instead of a phantom failure. The actual reported bug (braced `proc {p}` name then unresolvable `if`) still needs a libtommath-capable environment — #1058 remains open for that.
- **runtime `ns_inscope` twin** — `runtime/rust/src/cmd_namespace.rs` had the identical space-join bug fixed in the workspace VM by #1067. Fixed via the crate's own `list::append_list_element` + the shared `trim_concat_element` (no new quoting code); zero-tail-args keeps the verbatim early return. Tests use direct command shapes that avoid the tommath-gated builtins, so they run (and pass) even in constrained containers.
- **`wasm_coro_e2e`** — both tests' nested `cargo build` now pass an explicit `--target-dir` and read the artifact from that same path; verified passing with and without `CARGO_TARGET_DIR` exported.
- Incidental: `runtime/rust/Cargo.toml` gains an empty `[workspace]` table — cargo's ancestor search could escape a git-worktree layout and bind the crate to the outer checkout's workspace, breaking every cargo invocation against it.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test --manifest-path runtime/rust/Cargo.toml` — 326 passed, 1 ignored (reason visible), 0 failed.
  - `cargo clippy --manifest-path runtime/rust/Cargo.toml --all-targets -- -D warnings` + `cargo fmt --check` — clean, zero new allows.
  - `cargo test -p tcl-vm --test wasm_coro_e2e --release` — 2 passed, in both `CARGO_TARGET_DIR` states; clippy/fmt clean.
  - `MOCHA_GREP="command contexts" TCL_LSP_SERVER_BIN=<abs> xvfb-run -a npm test` — 10 passing (~2s); full `variableContexts` file 29/29; `npm run lint` clean; `git status` clean after runs.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? No — runtime/VM semantics (`ns_inscope` list-append, matching the `SCRIPT_APPENDS_LIST_ARGS` contract) and test harness only.
- [x] I updated at least one relevant KCS note. (n/a — no contract change; the trait contract doc was updated in #1067.)
- [ ] New compiler KCS note linked. (n/a)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_