### PR TITLE
Class factories and dynamically-installed members (issue #923 audit idx 43/44/53/55/96/97)

### DIFF
--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -474,6 +474,14 @@ mathfunc-aware W123 / W002 work that landed on `rust` after the audit ran
 (`is_mathfunc_call` + `is_known_mathfunc_in_dialect`) and is counted with
 them. That makes **30 fixed, 55 remaining**.
 
+**2026-07-30 update — PR B3 (`claude/commandregistry-compiler-fixes-tshu8d-factories`)
+fixed six more, all tier 2 — the "class factories and dynamically-installed
+members" cluster:** idx 44, idx 53, idx 55, idx 96, and idx 97 are newly
+fixed; idx 43 was **re-verified as already fixed** by the `foreach`-literal
+simulation that landed for idx 86 (PR #1020) and is pinned with a regression
+test rather than re-fixed. See the "tier-2 findings fixed by PR B3"
+subsection after the tier-2 table. That makes **36 fixed, 49 remaining**.
+
 **By corpus** (confirmed only): ticklecharts 20, tk 17, argparse 10,
 SpiceGenTcl 10, tclopt 13 (6+7, split across two inconsistent corpus-label
 strings in the raw data — same corpus), tomato 7, pix 8.
@@ -696,8 +704,8 @@ mixin/oo::configurable class-scoping findings, idx 34/36).
 
 | feature | count | idx (severity) |
 |---|---|---|
-| tclOO | 10 | 15, 16, 34, 35, 36, 53, ~~54~~ **FIXED**, 55, 96, 97 (all medium) |
-| namespaces | 8 | 3, 19, 43, 44, 64, 65, 75, 85 (all medium) |
+| tclOO | 10 | 15, 16, 34, 35, 36, ~~53~~ **FIXED**, ~~54~~ **FIXED**, ~~55~~ **FIXED**, ~~96~~ **FIXED**, ~~97~~ **FIXED** (all medium) |
+| namespaces | 8 | 3, 19, ~~43~~ **ALREADY FIXED**, ~~44~~ **FIXED**, 64, 65, 75, 85 (all medium) |
 | tricky_indirection | 7 | 0 (medium, **FIXED** — see below), 1, 2, 14, 49, 50, 51 (all medium) |
 | upvar | 7 | 7, 22, 57, 58, 59, 98, 99 (all medium) |
 | proc_args | 7 | 11, 28, 37, 62, 67, 78, ~~104~~ **FIXED** (all medium) |
@@ -766,6 +774,25 @@ plus new `rust/tcl-lsp-server/tests/e2e/{hover,completion}.rs` cases.
 | 81 (tcl_mathop) | Every built-in `expr` math function drew a false `W123 Unknown command`, several with actively-wrong "did you mean" fixes. | **Already fixed** on `rust` after the audit ran: `SignatureCommandInvocation::is_mathfunc_call` plus `is_known_mathfunc_in_dialect` gate the W123 check. Verified, not re-fixed. |
 | 103 (tcl_mathop) | Zero `CommandSpec` entries for `tcl::mathfunc::*`, so the generic per-dispatch-site W002 availability check was blind to the plain-command spelling. | The registry data (`tcl-registry/src/commands/tcl/mathfunc_generated.rs`) **already landed** on `rust`. What PR A3 adds is the query layer the LSP needed on top of it — `tcl-registry/src/mathfunc.rs` — and a test pinning that both qualified spellings exist and gate correctly (`isinf` 9.0+, the command table itself 8.5+ per TIP 232). |
 | 104 (proc_args) | A proc parameter's own name token and its **default-value literal** both resolved to an unrelated same-named command (`{destroy destroy}` in `tk.tcl`'s `::tk::RestoreFocusGrab` showed Tk's `destroy` documentation). | The name token was already answered by idx 9's declaration-offset search; the remaining data words are now guarded generally by `definition::parameter_list_position_at`, consulted by both hover and go-to-definition. A *literal* parameter list holds no command references at all, so the guard needs no per-command knowledge. **Codex review of PR #1073 (P2)** narrowed it from the whole name-token-to-body region to the actual literal parameter-list **word**: `proc`'s parameter list is an ordinary Tcl word and may be computed (`proc p [makeargs] {…}` runs `[makeargs]` at definition time — oracle-confirmed on 9.0.4 and 8.6.16, as are the `$params` and `"m n"` forms), so a word containing `$` / `[` / `"` / a backslash escape stays navigable. A computed list also suppresses the bareword-*declaration* step, because the analyser records a stub `VarDef` named after the whole word (`"[makeargs]"`) that would otherwise make go-to-definition point at the cursor's own token instead of resolving the call. |
+
+#### Tier-2 findings fixed by PR B3 (2026-07-30)
+
+Landed together on `claude/commandregistry-compiler-fixes-tshu8d-factories`
+as one cluster: every one of them is a place where a class, a member, or a
+command name is **installed dynamically** and the analyser gave up on a shape
+that is in fact statically determined. Regression coverage is the
+`class_factories` module in `rust/tcl-compiler/tests/analyser.rs` (19 TP/TN
+cases), plus the updated `handle_oo_define_command` unit tests. Ground truth
+for each shape was taken from tclsh 9.0.4 **and** tclsh 8.6.16, which agree
+on all of them.
+
+| idx | what was wrong | what changed |
+|---|---|---|
+| 43 (namespaces) | `foreach ptype {elist elist.n …} { proc ticklecharts::${ptype} … }` filed one bogus `ProcDef` under the literal `${ptype}` template, so go-to-definition/hover found nothing for the real procs, W123 fired on all five, and the outline showed `${ptype}`. | **Already fixed** on `rust` by the idx 86 `foreach`-literal simulation (PR #1020): `handle_foreach_command` binds the loop variable to each literal element and re-dispatches `proc`, so every element is registered under its real qualified name. Verified, not re-fixed; pinned by `foreach_installed_procs_are_enumerated_per_literal_element`. |
+| 44 (namespaces) | `${ns}::setdef` resolved to nothing — go-to-definition, find-references, and call-hierarchy silently dropped every call site. | Two halves. (1) **Wrong source bytes**: for a braced composite word the lexer merges the whole word into one `Var` token, so its raw text is `ns}::setdef`, not the variable name — `resolve_dynamic_word` looked that up as a variable and always missed. It now truncates at the brace the lexer left in place (the same rule `record_var_or_cmd_command_site` already used for its W307 head reading) and folds the literal tail. (2) The command **head** itself now goes through that folding before `resolve_command_qualified_name`, via `resolve_dynamic_command_head`, using the *dominating*-constant lattice so a branch-conditional binding still abstains. |
+| 53 (tclOO) | `constructor {*}[…]` / `method {*}{…}` members were dropped entirely — `extract_method_def` saw one word where the grammar wanted two or three — so `chart3D`'s whole reflected method surface was missing from the outline with no diagnostic. | `{*}` is applied by the *parser*, so a `{*}`-marked **braced literal** word is not one word but the elements of the list it holds. `splice_static_member_expansions` normalises those words before the member grammar's layout is read off them, with each spliced word carrying its own real source span. A `{*}` over a substitution has no statically-knowable element list and is left verbatim, so the member still abstains — verified against both interpreters, which run `method {*}{foo {} {…}}` and `constructor {*}[info class constructor ::Base]` alike. |
+| 55 (tclOO) | `foreach class {…} { oo::define $class {…} }` bucketed every injected member under a synthetic `@dynclass@<offset>` key, so a real, tclsh-proven method drew a false `W308 Unknown method` and resolved nowhere. | `handle_oo_define_command` now folds its target word through `resolve_dynamic_word` (falling back to the synthetic key only when the target is genuinely unresolvable), and the `foreach`-literal simulation was generalised from a hardcoded `rename`/`proc` name match to the new registry trait `Traits::INSTALLS_NAMED_DEFINITION`, carried by `proc`, `rename`, `oo::define`, and `oo::objdefine`. Cost stays `O(elements × body-commands)` with no fixpoint. |
+| 96, 97 (tclOO) | A class created through a **user-defined metaclass** — Tk's own `::tk::Megawidget` idiom — never entered `all_classes` at all: no document symbols, no find-references, and `next` inside an override resolved nowhere. `is_class_definer` could only ever match the registry's own four metaclass commands. | Metaclass-ness now propagates down the recorded superclass chain: a class whose chain reaches an `IS_OO_METACLASS` command with a `TclOo` grammar is itself a class factory (`user_metaclass_of_command`). The registry stays the seed; only the inheritance step is TclOO language semantics. The manufacturer's **word layout** is read off its own `create` override rather than assumed — Tk's `{name superclasses body}` puts the body at argument 3 — and the members that override splices into every body it makes (`[list superclass ::tk::MegawidgetClass {*}$superclasses]`) are resolved against the call's own arguments and applied through the same registry-grammar routing a written-out member uses. When the override cannot be read the class is still recorded but marked `ClassDef::inheritance_unknown`, which makes W308 abstain exactly as an out-of-index superclass already does. Superclass lists now match `info class superclasses` on both interpreters exactly. |
 
 ### 6c. Broader mandate coverage check
 

--- a/docs/kcs/README.md
+++ b/docs/kcs/README.md
@@ -61,6 +61,11 @@ a design doc. Put it under [`../design/`](../design/README.md) instead.
   when `apply` is reached indirectly through `[list apply {...} $x]`
   (the pkgIndex.tcl `package ifneeded ... [list apply {dir {...}} $dir]`
   idiom), even though a direct `apply {...}` call highlights fine.
+- [kcs-issue-classes-made-by-a-class-factory-are-invisible.md](kcs-issue-classes-made-by-a-class-factory-are-invisible.md)
+  — a class made by a user-defined `TclOO` metaclass, a member whose
+  signature arrives through `{*}` expansion, a class named by a `foreach`
+  loop variable, or a command head built from a namespace variable is
+  missing from the outline and resolves nowhere.
 - [kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md](kcs-issue-w129-safe-interp-hidden-command-via-bracket-indirection.md)
   — W129 (a command hidden in a safe interpreter) does not warn when the
   hidden command is reached only through a `[...]` bracket substitution —

--- a/docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md
+++ b/docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md
@@ -1,0 +1,175 @@
+# KCS: Classes and members installed dynamically are missing from the outline
+
+> **Audience:** Contributor
+> **Type:** Issue
+
+## Applies to
+
+all-editors, analyser
+
+## Symptom
+
+A class, a method, or a proc that a real interpreter genuinely creates is
+absent from the document outline, and go-to-definition, find-references, and
+hover all return nothing at its call sites. Sometimes a `W308 Unknown
+method` fires on a call that tclsh runs happily, or the outline shows a
+nonsense entry named after the unsubstituted source text (`${ptype}`,
+`@dynclass@1859`).
+
+All four shapes below come from real corpora (issue #923 audit cluster C3)
+and all four run correctly under tclsh 8.6.16 and 9.0.4:
+
+```tcl
+# 1. A class factory — a class whose own superclass is oo::class.
+oo::class create Megawidget {
+    superclass oo::class
+    self method create {name superclasses body} {
+        next $name [list superclass MegawidgetClass {*}$superclasses]\;$body
+    }
+}
+Megawidget create SimpleWidget {} { method CreateHull {} { my TraceOption a b } }
+
+# 2. A member whose signature arrives through {*} expansion.
+oo::define S { method {*}{foo {} {return 1}} }
+
+# 3. A class named by a foreach loop variable over a literal list.
+foreach class {chart timeline} { oo::define $class { method RenderTsb {} {…} } }
+
+# 4. A command head built from a namespace held in a variable.
+set ns ticklecharts
+${ns}::setdef _options id -default $value
+```
+
+## Operational context
+
+Each of these is a place where a name is *written* dynamically but is in fact
+statically determined. The analyser's job is to tell those apart from names
+that genuinely are not knowable until run time, and to abstain only on the
+latter.
+
+- **Class factories.** `oo::class`, `oo::abstract`, `oo::configurable`, and
+  `oo::singleton` carry `Traits::IS_OO_METACLASS` in the
+  [command registry](../design/compiler/command-registry.md). A class whose
+  own superclass chain reaches one of them is *also* a class factory —
+  that is TclOO language semantics, not per-command knowledge — so
+  `Analyser::user_metaclass_of_command` walks the recorded superclass chain
+  from the registry seed. Tk's `library/megawidget.tcl` is the canonical
+  real user of the idiom.
+- **The factory's word layout.** A factory that overrides the manufacturer
+  (`self method create {name superclasses body}`) changes where the body
+  word sits — argument 3, not the builtin `create Name Body` argument 2 —
+  and splices superclasses the caller never wrote. Both facts are read off
+  the override's own `next` call, never assumed.
+- **`{*}` expansion.** Tcl applies `{*}` while *parsing*, so a `{*}`-marked
+  braced literal is not one word but the elements of the list it holds. The
+  member grammar's fixed argument layout applies to those elements.
+- **`foreach` over a literal list.** The loop variable takes a different
+  concrete value each iteration, so a command that installs a name from it
+  installs several. Which commands those are is registry data:
+  `Traits::INSTALLS_NAMED_DEFINITION`.
+- **A composite command head.** The lexer merges `${ns}::setdef` into one
+  `Var` token whose text is `ns}::setdef`. The variable's name ends at the
+  brace the lexer left in place; everything after is an ordinary word
+  suffix.
+
+## Decision rules / contracts
+
+1. **Metaclass-ness propagates; the seed stays in the registry.** Do not
+   add a command name to the analyser to recognise a factory. The registry
+   trait plus the recorded superclass chain is the whole rule.
+2. **Read a factory's argument layout, do not guess it.** A prologue built
+   from anything the analyser cannot read yields
+   `ClassDef::inheritance_unknown`, which makes W308 abstain the same way an
+   out-of-index superclass already does. Recording a guessed superclass
+   list is worse than recording none.
+3. **Only reference-only members are injected.** `superclass`, `mixin`,
+   `filter`, `export`, … (the definition grammar's `all_args_ref` set) name
+   existing entities, so each injected word keeps a real source span —
+   either in the factory's own body or in the creation call's arguments. A
+   *definition* member cannot be injected: it would have no honest span.
+4. **`{*}` of a literal splices; `{*}` of a substitution abstains.**
+   `method {*}{foo {} {…}}` defines a real `foo`;
+   `constructor {*}[info class constructor ::Base]` is equally real but has
+   no statically-knowable element list, so the member is left unrecorded
+   rather than invented with wrong parameters.
+5. **A resolved dynamic head is a reference, never a rename target.** Its
+   span spells only part of the name, so the invocation is marked
+   `indirect`: find-references reports it, rename skips it. Rewriting the
+   span would splice the new name over the substitution — the same
+   corruption as
+   [the closing-delimiter issue](kcs-issue-highlight-drops-closing-delimiter.md).
+6. **A whole-word `$cmd` head belongs to the flow-sensitive engine.** The
+   walk must not pre-resolve it from its lexical last-write-wins map; the
+   CFG/SSA value model settles it. Only the composite shapes that engine
+   skips are folded during the walk.
+7. **The `foreach` simulation stays narrow.** It re-dispatches only
+   `Traits::INSTALLS_NAMED_DEFINITION` commands, once per literal element.
+   Re-walking the whole body per iteration would duplicate every diagnostic
+   and scope entry, and there is no fixpoint — the element list is a
+   bounded literal.
+
+## File-path anchors
+
+- `rust/tcl-compiler/src/analyser/handlers.rs` —
+  `handle_oo_class_command`, `user_metaclass_of_command`,
+  `manufacturer_layout`, `manufacturer_word_positions`,
+  `manufacturer_injected_members`, `literal_list_words`,
+  `handle_oo_define_command`, `handle_foreach_command`,
+  `simulate_remaining_foreach_iterations`, `resolve_dynamic_word`
+- `rust/tcl-compiler/src/analyser/oo.rs` —
+  `splice_static_member_expansions`, `extract_method_def`
+- `rust/tcl-compiler/src/analyser/commands.rs` —
+  `resolve_dynamic_command_head`, `head_is_whole_word_variable`
+- `rust/tcl-compiler/src/analyser/types.rs` —
+  `ClassDef::inheritance_unknown`
+- `rust/tcl-compiler/src/analyser/diagnostics/var_command.rs` —
+  `has_external_super_or_mixin` (the W308 abstention)
+- `rust/tcl-registry/src/traits.rs` — `Traits::INSTALLS_NAMED_DEFINITION`,
+  `Traits::IS_OO_METACLASS`
+
+## Failure modes
+
+- Assuming the builtin `create Name Body` layout for a factory that
+  overrides the manufacturer walks the *superclass* word as a script and
+  loses every member of the new class.
+- Recording a factory-made class with an empty superclass list when the
+  prologue could not be read turns every inherited method into a false
+  `W308 Unknown method`. Set `inheritance_unknown` instead.
+- Splicing `{*}` over a substituted word invents a parameter list and a body
+  span that point at the wrong text — worse than the omission it replaces.
+- Folding a whole-word `$cmd` head during the walk makes the walk and the
+  flow-sensitive engine disagree about which spans are safe to rewrite, and
+  a rename then corrupts the source.
+- Reading a composite `Var` token's whole text as a variable name looks up a
+  variable that cannot exist, so a statically-resolvable head silently
+  resolves to nothing with no diagnostic at all.
+
+## Triage checklist
+
+1. Run the shape under `tclsh9.0` *and* `tclsh8.6` and confirm what the
+   interpreter really creates (`info class superclasses`, `info class
+   methods -all`, `info class constructor`). The oracle decides, not the
+   source text.
+2. Check whether the class reached `AnalysisResult::all_classes` at all, and
+   under what key — an `@dynclass@<offset>` key means the target word was
+   treated as unresolvable.
+3. If a factory is involved, check whether its own `ClassDef` was recorded
+   *before* the creation call, and whether its superclass chain reaches a
+   registry metaclass.
+4. If members are missing, check whether the member command's words were
+   `{*}`-expanded and whether the expanded word is a braced literal.
+5. If a call site resolves to nothing, check whether the head's `Var` token
+   text contains a `}` — a composite head whose variable name is the text up
+   to that brace.
+6. Before claiming a fix, confirm the invocation's `indirect` flag matches
+   whether the span really spells the name.
+
+## Test anchors
+
+- `rust/tcl-compiler/tests/analyser.rs` — the `class_factories` module
+  (19 TP/TN cases covering all four shapes plus their abstentions)
+- `rust/tcl-compiler/src/analyser/handlers.rs` —
+  `two_dynamic_oo_define_targets_sharing_a_variable_name_never_merge`,
+  `dynamic_oo_define_target_does_not_touch_a_same_named_literal_class`
+- `rust/tcl-lsp-core/tests/references_rename.rs` —
+  `rename_rewrites_the_defining_literal_and_never_the_dispatch_span_945`

--- a/docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md
+++ b/docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md
@@ -32,8 +32,9 @@ Megawidget create SimpleWidget {} { method CreateHull {} { my TraceOption a b } 
 # 2. A member whose signature arrives through {*} expansion.
 oo::define S { method {*}{foo {} {return 1}} }
 
-# 3. A class named by a foreach loop variable over a literal list.
+# 3. A class (or an object) named by a foreach loop variable over a literal list.
 foreach class {chart timeline} { oo::define $class { method RenderTsb {} {…} } }
+foreach o {::a ::b} { oo::objdefine $o { method probe {} {…} } }
 
 # 4. A command head built from a namespace held in a variable.
 set ns ticklecharts
@@ -82,40 +83,73 @@ latter.
    `ClassDef::inheritance_unknown`, which makes W308 abstain the same way an
    out-of-index superclass already does. Recording a guessed superclass
    list is worse than recording none.
-3. **Only reference-only members are injected.** `superclass`, `mixin`,
+3. **Reading the *whole* prologue is a precondition.** Every piece of the
+   definition word the factory hands `next` must be accounted for — a
+   `[list <member> …]` group that was parsed, the factory's own `$param`
+   read, or separator text. "Found no nested command" is **not** the same
+   as "injects nothing": `next $name "superclass Base\n$body"` injects a
+   superclass with no command substitution at all, and calling that a
+   known-empty injection lets W308 fire on every inherited method. Only a
+   prologue whose pieces are all accounted for may report an empty
+   injection.
+4. **A relative superclass resolves in its owner's namespace.** `superclass
+   Meta` inside `::n::DerivedMeta` names `::n::Meta`. Resolve it through
+   the shared `class_hierarchy::resolve_class_name` — the same
+   current-namespace-then-global rule the class lattice and MRO builder
+   use — never a local pair of `name` / `::name` lookups. That also
+   inherits its sound-by-abstention behaviour on an ambiguous tail, so a
+   same-named class in an unrelated namespace is never cross-linked.
+5. **Only reference-only members are injected.** `superclass`, `mixin`,
    `filter`, `export`, … (the definition grammar's `all_args_ref` set) name
    existing entities, so each injected word keeps a real source span —
    either in the factory's own body or in the creation call's arguments. A
    *definition* member cannot be injected: it would have no honest span.
-4. **`{*}` of a literal splices; `{*}` of a substitution abstains.**
+6. **`{*}` of a literal splices; `{*}` of a substitution abstains.**
    `method {*}{foo {} {…}}` defines a real `foo`;
    `constructor {*}[info class constructor ::Base]` is equally real but has
    no statically-knowable element list, so the member is left unrecorded
    rather than invented with wrong parameters.
-5. **A resolved dynamic head is a reference, never a rename target.** Its
+7. **A resolved dynamic head is a reference, never a rename target.** Its
    span spells only part of the name, so the invocation is marked
    `indirect`: find-references reports it, rename skips it. Rewriting the
    span would splice the new name over the substitution — the same
    corruption as
    [the closing-delimiter issue](kcs-issue-highlight-drops-closing-delimiter.md).
-6. **A whole-word `$cmd` head belongs to the flow-sensitive engine.** The
+8. **A whole-word `$cmd` head belongs to the flow-sensitive engine.** The
    walk must not pre-resolve it from its lexical last-write-wins map; the
    CFG/SSA value model settles it. Only the composite shapes that engine
    skips are folded during the walk.
-7. **The `foreach` simulation stays narrow.** It re-dispatches only
+9. **The `foreach` simulation stays narrow.** It re-dispatches only
    `Traits::INSTALLS_NAMED_DEFINITION` commands, once per literal element.
    Re-walking the whole body per iteration would duplicate every diagnostic
    and scope entry, and there is no fixpoint — the element list is a
    bounded literal.
+10. **The trait is a promise the dispatch must keep.** Stamping
+   `INSTALLS_NAMED_DEFINITION` on a spec whose analyser hook has no arm in
+   the re-dispatch match is worse than not stamping it — the registry says
+   the command is re-run per element and nothing does.
+   `every_installer_spec_lands_on_a_live_redispatch_arm` fails the build
+   for exactly that.
+11. **Re-dispatch must be idempotent per source site.** The ordinary body
+   walk already covered the first element, so a site is visited twice under
+   the loop variable's own key. One source site can never declare the same
+   member twice, so `(objdefine_offset, member name)` is an exact
+   "already recorded" identity — no iteration counter needed, and a genuinely
+   separate block on the same object still accumulates.
 
 ## File-path anchors
 
 - `rust/tcl-compiler/src/analyser/handlers.rs` —
   `handle_oo_class_command`, `user_metaclass_of_command`,
   `manufacturer_layout`, `manufacturer_word_positions`,
-  `manufacturer_injected_members`, `literal_list_words`,
-  `handle_oo_define_command`, `handle_foreach_command`,
-  `simulate_remaining_foreach_iterations`, `resolve_dynamic_word`
+  `manufacturer_injected_members`, `injected_member_from_group`,
+  `prologue_pieces`, `literal_list_words`, `handle_oo_define_command`,
+  `handle_oo_objdefine`, `record_object_methods`,
+  `handle_foreach_command`, `simulate_remaining_foreach_iterations`,
+  `resolve_dynamic_word`
+- `rust/tcl-compiler/src/analyser/class_hierarchy.rs` —
+  `resolve_class_name`, `build_tail_index` (the shared owner-aware
+  relative-name resolution the chain walk reuses)
 - `rust/tcl-compiler/src/analyser/oo.rs` —
   `splice_static_member_expansions`, `extract_method_def`
 - `rust/tcl-compiler/src/analyser/commands.rs` —
@@ -143,6 +177,12 @@ latter.
 - Reading a composite `Var` token's whole text as a variable name looks up a
   variable that cannot exist, so a statically-resolvable head silently
   resolves to nothing with no diagnostic at all.
+- Treating "no nested command in the prologue" as "the prologue injects
+  nothing" turns a string-built `superclass` into a claim that the class has
+  no superclass, and every inherited method then draws a false `W308`.
+- Resolving a relative `superclass` with a bare `name` / `::name` pair skips
+  the declaring class's own namespace, so a namespaced metaclass chain never
+  reaches the registry seed and its factory calls record nothing.
 
 ## Triage checklist
 
@@ -163,11 +203,23 @@ latter.
    to that brace.
 6. Before claiming a fix, confirm the invocation's `indirect` flag matches
    whether the span really spells the name.
+7. If a factory-made class reports no superclass, check whether its
+   prologue was *read* or merely *found empty* — `inheritance_unknown`
+   distinguishes them.
+8. If a namespaced factory chain does not resolve, check the owner
+   namespace the `superclass` word was written in, not just its bare and
+   global spellings.
 
 ## Test anchors
 
 - `rust/tcl-compiler/tests/analyser.rs` — the `class_factories` module
-  (19 TP/TN cases covering all four shapes plus their abstentions)
+  (26 TP/TN cases covering all four shapes plus their abstentions)
+- `rust/tcl-compiler/src/analyser/handlers.rs` —
+  `every_installer_spec_lands_on_a_live_redispatch_arm`,
+  `foreach_objdefine_records_per_object_facts_for_every_literal_element`,
+  `foreach_objdefine_does_not_double_record_the_first_element`,
+  `foreach_objdefine_does_not_duplicate_body_diagnostics`,
+  `foreach_objdefine_over_a_dynamic_list_abstains`
 - `rust/tcl-compiler/src/analyser/handlers.rs` —
   `two_dynamic_oo_define_targets_sharing_a_variable_name_never_merge`,
   `dynamic_oo_define_target_does_not_touch_a_same_named_literal_class`

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -93,9 +93,9 @@ struct DispatchSite<'a> {
 /// Carrying the traits alongside the hook is what lets a handler ask a
 /// registry question about *its own invocation* without re-fetching a spec by
 /// literal name — see [`Analyser::resolve_analyser_hook_call`].
-struct ResolvedAnalyserHook {
-    hook: tcl_registry::hooks::AnalyserHookId,
-    traits: tcl_registry::Traits,
+pub(super) struct ResolvedAnalyserHook {
+    pub(super) hook: tcl_registry::hooks::AnalyserHookId,
+    pub(super) traits: tcl_registry::Traits,
 }
 
 /// Shared core registry standing in for [`Analyser::registry`] when a
@@ -545,6 +545,66 @@ impl Analyser {
         false
     }
 
+    /// The command head this call actually dispatches to, folding a
+    /// statically-determined dynamic head to the name it names.
+    ///
+    /// A head written with a substitution is not automatically a runtime
+    /// unknown: `set ns ticklecharts; ${ns}::setdef …` dispatches to
+    /// `::ticklecharts::setdef` on every execution, and the `TclOO` idiom
+    /// `set ns [namespace qualifiers [self class]]; ${ns}::setdef …` is the
+    /// same shape one level removed (issue #923 idx 44 — go-to-definition,
+    /// find-references, and call-hierarchy all silently dropped every such
+    /// call site).  [`Analyser::resolve_dynamic_word`] does the folding
+    /// through the *dominating* constant lattice, so a branch-conditional
+    /// or otherwise unprovable binding still abstains and the written text
+    /// is kept unchanged — the written text never resolves to anything, so
+    /// abstaining is exactly the previous behaviour.
+    ///
+    /// A folded head that is still dynamic (a partially-resolved
+    /// interpolation) is discarded rather than half-applied.
+    ///
+    /// A head that is a **whole-word** variable read (`$cmd`) is left alone:
+    /// that shape belongs to the flow-sensitive M7 dispatch engine
+    /// (`pending_const_dispatches` ->
+    /// [`super::diagnostics::const_dispatch`]), which settles it from the
+    /// CFG/SSA value model rather than the walk's lexical map and marks the
+    /// resulting invocation `indirect`.  Only the composite shapes M7
+    /// explicitly skips are folded here.
+    fn resolve_dynamic_command_head<'w>(
+        &self,
+        cmd_name: &'w str,
+        cmd_tok: Token,
+        head_is_single_token: bool,
+        scope_path: &[usize],
+    ) -> std::borrow::Cow<'w, str> {
+        if !crate::naming::is_dynamic_word(cmd_name) || self.head_is_whole_word_variable(cmd_tok) {
+            return std::borrow::Cow::Borrowed(cmd_name);
+        }
+        self.resolve_dynamic_word(cmd_name, Some(cmd_tok), head_is_single_token, scope_path)
+            .filter(|folded| !crate::naming::is_dynamic_word(folded))
+            .map_or(
+                std::borrow::Cow::Borrowed(cmd_name),
+                std::borrow::Cow::Owned,
+            )
+    }
+
+    /// Whether the command head is a bare whole-word variable read (`$cmd`,
+    /// `$ns::cmd`) rather than a composite (`${ns}::tail`) — the same
+    /// truncate-at-the-brace test
+    /// [`Self::record_var_or_cmd_command_site`] uses to decide which shape
+    /// M7 owns, so the two can never disagree about it.
+    fn head_is_whole_word_variable(&self, cmd_tok: Token) -> bool {
+        if cmd_tok.kind != TokenType::Var {
+            return false;
+        }
+        let sm = Analyser::source_map(
+            &self.source,
+            &self.cached_line_index,
+            self.cached_line_index_source_len,
+        );
+        !sm.token_text(cmd_tok).contains('}')
+    }
+
     /// Process a single segmented command.
     ///
     /// Walks `args` against every handler and stops at the first
@@ -615,7 +675,19 @@ impl Analyser {
         // `file_decls` is identical to a full `analyse` (gated by the
         // `file_decls_corpus` corpus test).
         if !self.structure_only {
-            let resolved = self.resolve_command_qualified_name(cmd_name, scope_path);
+            // A `${ns}::setdef`-shaped head is only *written* dynamically —
+            // when `ns` is a constant that dominates this call the target is
+            // as statically determined as a literal one, so resolution runs
+            // on the folded name (issue #923 idx 44).  A head that cannot be
+            // folded keeps its written text and resolves to nothing, exactly
+            // as before.
+            let head = self.resolve_dynamic_command_head(
+                cmd_name,
+                cmd_tok,
+                single_token_word.first().copied().unwrap_or(false),
+                scope_path,
+            );
+            let resolved = self.resolve_command_qualified_name(&head, scope_path);
             // Argument count for cross-file arity checking.  A `{*}`-
             // expanded argument makes the runtime count unknown, so record `None`
             // and let arity checking skip conservatively.
@@ -634,7 +706,13 @@ impl Analyser {
                     argc: arg_count,
                     callback_arity: None,
                     callback_baked_args: 0,
-                    indirect: false,
+                    // A folded head resolves to a real command, but its span
+                    // is not the written name — `${ns}::setdef` spells only
+                    // the tail — so it is a *reference*, never a rename
+                    // target: overwriting the span would splice the new name
+                    // over the substitution itself (the same class of
+                    // corruption as issue #923 idx 95).
+                    indirect: matches!(head, std::borrow::Cow::Owned(_)),
                     rename_safe: true,
                     existence_probe: false,
                     is_mathfunc_call: false,
@@ -915,7 +993,7 @@ impl Analyser {
     /// silently diverges the moment a dialect variant (or a subcommand) shares
     /// the hook. Traits are composed `spec.traits | sub.traits`, matching
     /// [`tcl_registry::CommandRegistry::invocation_traits`].
-    fn resolve_analyser_hook_call(
+    pub(super) fn resolve_analyser_hook_call(
         &self,
         cmd_name: &str,
         args: &[String],
@@ -990,7 +1068,9 @@ impl Analyser {
             // analysed in an isolated scope; a `{}`/multi-word/dynamic shape
             // falls through to the generic body walk in the current scope.
             Hook::InterpEval => self.handle_interp_eval_command(args, arg_tokens, scope_path),
-            Hook::OoDefine => self.handle_oo_define_command(cmd_name, args, arg_tokens, scope_path),
+            Hook::OoDefine => {
+                self.handle_oo_define_command(cmd_name, args, arg_tokens, arg_single, scope_path)
+            }
             Hook::NamespaceEval => self.handle_namespace_eval_command(args, arg_tokens, scope_path),
             // uplevel #0 { body } — opens a global-frame child scope so
             // the body's locals don't leak into the enclosing proc's
@@ -2583,7 +2663,9 @@ impl Analyser {
                     self.handle_opt_proc_command(args, arg_tokens, arg_single, scope_path);
                 }
                 Some(Hook::OoDefine) => {
-                    self.handle_oo_define_command(&cmd_name, args, arg_tokens, scope_path);
+                    self.handle_oo_define_command(
+                        &cmd_name, args, arg_tokens, arg_single, scope_path,
+                    );
                 }
                 // `apply {{params} body ?ns?}` — the handler builds the
                 // lambda's own `Proc` scope rooted at the lambda's namespace

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1163,7 +1163,7 @@ impl Analyser {
                 self.handle_interp_alias(args, scope_path, cmd_tok.span.start());
                 false
             }
-            Hook::OoObjdefine => self.handle_oo_objdefine(args, arg_tokens, scope_path),
+            Hook::OoObjdefine => self.handle_oo_objdefine(args, arg_tokens, arg_single, scope_path),
             Hook::PackageRequire => {
                 self.handle_package_require(cmd_tok, args, arg_tokens);
                 false

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -1766,10 +1766,16 @@ impl Analyser {
     /// [`Self::w308_for_object_var`] and [`Self::validate_method_on_class`]
     /// so the two escape hatches cannot drift.
     fn has_external_super_or_mixin(&self, cd: &super::types::ClassDef) -> bool {
-        cd.superclasses
-            .iter()
-            .chain(&cd.mixins)
-            .any(|s| !self.result.all_classes.contains_key(s) && !OO_BASE.contains(&s.as_str()))
+        // A class manufactured by a user-defined metaclass whose `create`
+        // override could not be read has an unknown superclass list, which is
+        // the same situation as a superclass outside the index: a method it
+        // inherits is not a method it is missing (issue #923 idx 96/97).
+        cd.inheritance_unknown
+            || cd
+                .superclasses
+                .iter()
+                .chain(&cd.mixins)
+                .any(|s| !self.result.all_classes.contains_key(s) && !OO_BASE.contains(&s.as_str()))
     }
 
     /// Suppress W123 diagnostics whose command-name contains a

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -344,6 +344,113 @@ fn literal_list_words(text: &str, tok: Token) -> Option<Vec<(String, Token)>> {
     Some(words)
 }
 
+/// One piece of a manufacturer prologue word, as
+/// [`Analyser::manufacturer_injected_members`] accounts for it.
+#[derive(Debug, PartialEq, Eq)]
+enum ProloguePiece<'a> {
+    /// A `[…]` command substitution — one prologue member to read.
+    Substitution,
+    /// A `$name` / `${name}` variable read.
+    VarRead(&'a str),
+    /// Whitespace, a statement separator, or an escaped separator — text
+    /// that joins pieces without contributing any member of its own.
+    Separator,
+    /// Anything else: literal prologue text, or a fragment the scanner
+    /// cannot classify.  Its presence means the prologue is *not* fully
+    /// read.
+    Opaque,
+}
+
+/// Split a manufacturer prologue word into the pieces its reader must
+/// account for.
+///
+/// Operates on the word's round-tripped source text (the segmenter's own
+/// per-word reconstruction), which preserves every substitution verbatim.
+/// A single `Opaque` piece is enough for the caller to abstain, so the scan
+/// stops at the first one.
+fn prologue_pieces(word: &str) -> Vec<ProloguePiece<'_>> {
+    let mut pieces = Vec::new();
+    let mut rest = word;
+    while !rest.is_empty() {
+        let first = rest.as_bytes()[0];
+        if first.is_ascii_whitespace() || first == b';' {
+            rest = &rest[1..];
+            if !matches!(pieces.last(), Some(ProloguePiece::Separator)) {
+                pieces.push(ProloguePiece::Separator);
+            }
+            continue;
+        }
+        // A backslash escape of a separator (`\;` — the idiomatic way to
+        // end the injected statement inside one word) joins, like the
+        // separator it escapes.
+        if first == b'\\' {
+            let escaped = rest.as_bytes().get(1).copied();
+            if escaped.is_some_and(|c| c.is_ascii_whitespace() || c == b';' || c == b'n') {
+                rest = &rest[2..];
+                if !matches!(pieces.last(), Some(ProloguePiece::Separator)) {
+                    pieces.push(ProloguePiece::Separator);
+                }
+                continue;
+            }
+            pieces.push(ProloguePiece::Opaque);
+            break;
+        }
+        if first == b'[' {
+            let Some(end) = matching_bracket(rest) else {
+                pieces.push(ProloguePiece::Opaque);
+                break;
+            };
+            pieces.push(ProloguePiece::Substitution);
+            rest = &rest[end + 1..];
+            continue;
+        }
+        if first == b'$' {
+            let after = &rest[1..];
+            if let Some(braced) = after.strip_prefix('{') {
+                let Some(close) = braced.find('}') else {
+                    pieces.push(ProloguePiece::Opaque);
+                    break;
+                };
+                pieces.push(ProloguePiece::VarRead(&braced[..close]));
+                rest = &braced[close + 1..];
+                continue;
+            }
+            let len = after
+                .find(|c: char| !(c.is_alphanumeric() || c == '_' || c == ':'))
+                .unwrap_or(after.len());
+            if len == 0 {
+                pieces.push(ProloguePiece::Opaque);
+                break;
+            }
+            pieces.push(ProloguePiece::VarRead(&after[..len]));
+            rest = &after[len..];
+            continue;
+        }
+        pieces.push(ProloguePiece::Opaque);
+        break;
+    }
+    pieces
+}
+
+/// Byte offset of the `]` closing the `[` at the start of `text`, honouring
+/// nesting.  `None` when it is unbalanced.
+fn matching_bracket(text: &str) -> Option<usize> {
+    let mut depth = 0usize;
+    for (offset, ch) in text.char_indices() {
+        match ch {
+            '[' => depth += 1,
+            ']' => {
+                depth -= 1;
+                if depth == 0 {
+                    return Some(offset);
+                }
+            }
+            _ => {}
+        }
+    }
+    None
+}
+
 /// Resolve one prologue member statement from a manufacturer override into
 /// the member the creation call actually installs.
 ///
@@ -3137,6 +3244,14 @@ impl Analyser {
                             scope_path,
                         );
                     }
+                    Hook::OoObjdefine => {
+                        self.handle_oo_objdefine(args, arg_tokens, arg_single, scope_path);
+                    }
+                    // Unreachable for a spec carrying the trait —
+                    // `installer_hook_is_redispatched` pins that every one
+                    // of them lands on an arm above, so a newly-stamped
+                    // spec cannot silently promise a re-dispatch this match
+                    // never delivers (Codex review of PR #1074).
                     _ => {}
                 }
             }
@@ -4038,12 +4153,22 @@ impl Analyser {
     /// name is present), mirroring [`Self::handle_oo_define_command`],
     /// so the generic body recursion does not also descend the body.
     ///
+    /// A receiver written as a substitution keeps its **variable** name as
+    /// the `objdefined_vars` / `object_methods` key — that is what a
+    /// `$obj method` dispatch site is keyed by — but when the word also
+    /// folds to a dominating constant (`foreach o {::a ::b} { oo::objdefine
+    /// $o { … } }`) the per-object facts are recorded under the *object's*
+    /// own name as well, so a bare `::a probe` call sees them too.  tclsh
+    /// 9.0.4 / 8.6.16 both confirm every literal element really gains the
+    /// method.
+    ///
     /// Dispatched via
     /// [`tcl_registry::hooks::AnalyserHookId::OoObjdefine`].
     pub fn handle_oo_objdefine(
         &mut self,
         args: &[String],
         arg_tokens: &[Token],
+        arg_single: &[bool],
         scope_path: &[usize],
     ) -> bool {
         if args.is_empty() {
@@ -4056,6 +4181,19 @@ impl Analyser {
         if !obj_name.is_empty() {
             self.objdefined_vars.insert(obj_name.clone());
         }
+        // The object the receiver word actually names this time round, when
+        // it is statically determined.
+        let resolved_obj = self
+            .resolve_dynamic_word(
+                &args[0],
+                arg_tokens.first().copied(),
+                arg_single.first().copied().unwrap_or(false),
+                scope_path,
+            )
+            .map(|name| name.trim().to_string())
+            .filter(|name| {
+                !name.is_empty() && *name != obj_name && !crate::naming::is_dynamic_word(name)
+            });
 
         // `oo::objdefine $obj` with no definition script — the object variable
         // is recorded above; there is nothing more to walk.
@@ -4125,18 +4263,19 @@ impl Analyser {
         // Each record carries the objdefine site's receiver offset, so
         // consumers key it by the receiver's *binding identity* — never by
         // the textual tail alone (issue #945 fault 5).
-        if !obj_name.is_empty() && !object_class.methods.is_empty() {
+        if !object_class.methods.is_empty() {
             let objdefine_offset = arg_tokens.first().map_or(0, |t| t.span.start());
-            self.result
-                .object_methods
-                .entry(obj_name)
-                .or_default()
-                .extend(object_class.methods.into_values().map(|def| {
-                    super::types::ObjectMethodDef {
-                        def,
-                        objdefine_offset,
-                    }
-                }));
+            // Source-ordered, so the recorded sequence is the same on every
+            // run (and the same under each key) rather than the hash map's
+            // iteration order.
+            let mut methods: Vec<super::types::MethodDef> =
+                object_class.methods.into_values().collect();
+            methods.sort_by_key(|def| def.name_span.start());
+            for key in [Some(obj_name), resolved_obj].into_iter().flatten() {
+                if !key.is_empty() {
+                    self.record_object_methods(key, &methods, objdefine_offset);
+                }
+            }
         }
 
         true
@@ -4399,9 +4538,22 @@ impl Analyser {
     /// are injected: they name existing entities, so every injected word
     /// keeps a real source span, either in the manufacturer's own body
     /// (a literal it always splices) or in this call's arguments (a
-    /// `{*}$param` splice).  A prologue built any other way yields `None`
-    /// and the class is recorded with its inheritance marked unknown, so no
-    /// method check fires against a superclass list that was guessed.
+    /// `{*}$param` splice).
+    ///
+    /// **Reading the whole prologue is a precondition, not a best effort.**
+    /// The definition word `next` receives is scanned piece by piece, and
+    /// every piece must be one the analyser can account for: a `[list
+    /// <member> …]` group it parsed, the manufacturer's own `$param` read
+    /// (the caller's body, spliced in verbatim), or list/statement
+    /// separator text.  Anything else — most importantly a **string-built**
+    /// prologue such as `next $name "superclass Base\n$body"`, which
+    /// injects a superclass with no nested command at all (tclsh 9.0.4 /
+    /// 8.6.16: `info class superclasses` really reports `::Base`, and its
+    /// methods really are inherited) — yields `None`, and the class is
+    /// recorded with its inheritance marked unknown.  Returning a
+    /// *known-empty* injection for a prologue that was merely unreadable
+    /// would claim the class has no superclass and let W308 fire on
+    /// perfectly good inherited methods.
     fn manufacturer_injected_members(
         &self,
         meta: &UserMetaclass,
@@ -4409,43 +4561,89 @@ impl Analyser {
         args: &[String],
         arg_tokens: &[Token],
     ) -> Option<Vec<InjectedMember>> {
-        let registry = self.registry.as_ref()?;
         let params: Vec<&str> = override_def
             .params
             .iter()
             .map(|p| p.name.as_str())
             .collect();
         let next_seg = self.manufacturer_next_call(override_def)?;
-        let config = self.lexer_config();
-        let sm = SourceMap::new(&self.source);
+        // The definition word is `next`'s last argument that reads one of
+        // the override's parameters — the builtin `create Name Body`
+        // layout's `Body` position, which is what the prologue is composed
+        // into.
+        let (word_index, prologue) =
+            next_seg.args().iter().enumerate().rev().find(|(_, word)| {
+                interpolated_var_names(word)
+                    .iter()
+                    .any(|name| params.contains(name))
+            })?;
+        // `Cmd` sub-tokens of that word, in source order — the word is
+        // `next`'s last argument, so every command substitution at or after
+        // its first token belongs to it.
+        let word_start = next_seg.argv.get(word_index + 1)?.span.start();
+        let mut groups = next_seg
+            .all_tokens
+            .iter()
+            .filter(|tok| tok.kind == TokenType::Cmd && tok.span.start() >= word_start);
         let mut injected: Vec<InjectedMember> = Vec::new();
-        for tok in &next_seg.all_tokens {
-            if tok.kind != TokenType::Cmd {
-                continue;
-            }
-            let descended = descend_token(&sm, *tok, config);
-            for seg in segments_from_tree(descended.tree(), &sm) {
-                // The prologue is built by a command that quotes its
-                // arguments into a canonical list — registry data
-                // (`PRODUCES_CANONICAL_LIST`), never a command name here.
-                if !registry.get(seg.name()).is_some_and(|spec| {
-                    spec.traits
-                        .contains(tcl_registry::Traits::PRODUCES_CANONICAL_LIST)
-                }) {
-                    continue;
+        for piece in prologue_pieces(prologue) {
+            match piece {
+                ProloguePiece::Separator => {}
+                ProloguePiece::VarRead(name) if params.contains(&name) => {}
+                ProloguePiece::Substitution => {
+                    injected.push(self.injected_member_from_group(
+                        meta,
+                        *groups.next()?,
+                        &params,
+                        args,
+                        arg_tokens,
+                    )?);
                 }
-                let Some(member) = seg
-                    .args()
-                    .first()
-                    .and_then(|keyword| meta.grammar.member(keyword))
-                else {
-                    continue;
-                };
-                member.all_args_ref?;
-                injected.push(resolve_injected_member(&seg, &params, args, arg_tokens)?);
+                // Literal prologue text, a read of something that is not a
+                // manufacturer parameter, or an unreadable fragment: the
+                // prologue is not fully accounted for.
+                ProloguePiece::VarRead(_) | ProloguePiece::Opaque => return None,
             }
         }
         Some(injected)
+    }
+
+    /// The definition-body member one `[…]` group of a manufacturer
+    /// prologue installs, or `None` when the group is not a
+    /// reference-only member built by a canonical-list command.
+    fn injected_member_from_group(
+        &self,
+        meta: &UserMetaclass,
+        group: Token,
+        params: &[&str],
+        args: &[String],
+        arg_tokens: &[Token],
+    ) -> Option<InjectedMember> {
+        let registry = self.registry.as_ref()?;
+        let sm = SourceMap::new(&self.source);
+        let descended = descend_token(&sm, group, self.lexer_config());
+        let mut segs = segments_from_tree(descended.tree(), &sm).into_iter();
+        let seg = segs.next()?;
+        // One group builds one member; a `[a; b]` compound is not a shape
+        // the prologue reader accounts for.
+        if segs.next().is_some() {
+            return None;
+        }
+        // The prologue is built by a command that quotes its arguments into
+        // a canonical list — registry data (`PRODUCES_CANONICAL_LIST`),
+        // never a command name here.
+        if !registry.get(seg.name()).is_some_and(|spec| {
+            spec.traits
+                .contains(tcl_registry::Traits::PRODUCES_CANONICAL_LIST)
+        }) {
+            return None;
+        }
+        let member = seg
+            .args()
+            .first()
+            .and_then(|keyword| meta.grammar.member(keyword))?;
+        member.all_args_ref?;
+        resolve_injected_member(&seg, params, args, arg_tokens)
     }
 
     /// The recorded class `cmd_name` names when that class is **itself a
@@ -4464,6 +4662,16 @@ impl Analyser {
     /// by exactly the grammar the language gives them without the walker
     /// naming a metaclass command.
     ///
+    /// A `superclass` word is written as the *declaring* class sees it, so
+    /// a relative name (`superclass Meta` inside `::n::DerivedMeta`) is
+    /// resolved through the shared owner-aware class-name resolution
+    /// ([`super::class_hierarchy::resolve_class_name`]) — the same
+    /// current-namespace-then-global rule the class lattice and the MRO
+    /// builder already implement, never a re-derivation of it here.  That
+    /// keeps this chain walk sound-by-abstention in the same places they
+    /// are: an ambiguous simple name resolves to nothing rather than
+    /// cross-linking a same-named class in an unrelated namespace.
+    ///
     /// Chain walking is depth-bounded and visited-checked, so a cyclic
     /// `superclass` declaration (rejected by real Tcl, but writable in a
     /// half-edited buffer) terminates.
@@ -4474,15 +4682,23 @@ impl Analyser {
     ) -> Option<UserMetaclass> {
         let registry = self.registry.as_ref()?;
         let qualified = self.resolve_command_qualified_name(cmd_name, scope_path);
-        let start = self.result.all_classes.get(&qualified)?;
+        if !self.result.all_classes.contains_key(&qualified) {
+            return None;
+        }
+        let tail_index = super::class_hierarchy::build_tail_index(self.result.all_classes.keys());
         let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-        let mut queue: Vec<&super::types::ClassDef> = vec![start];
+        let mut queue: Vec<String> = vec![qualified.clone()];
         // Bounded by the recorded class count — every class is visited once.
-        while let Some(class) = queue.pop() {
-            if !seen.insert(class.qualified_name.clone()) {
+        while let Some(class_qname) = queue.pop() {
+            if !seen.insert(class_qname.clone()) {
                 continue;
             }
+            let Some(class) = self.result.all_classes.get(&class_qname) else {
+                continue;
+            };
             for parent in &class.superclasses {
+                // The registry seed: `oo::class` and its siblings are named
+                // as commands, so a leading `::` is the same command.
                 let bare = parent.strip_prefix("::").unwrap_or(parent);
                 if let Some(spec) = registry.get(bare)
                     && spec.traits.contains(tcl_registry::Traits::IS_OO_METACLASS)
@@ -4491,19 +4707,49 @@ impl Analyser {
                 {
                     return Some(UserMetaclass { qualified, grammar });
                 }
-                // A superclass recorded relative to the file's own namespace
-                // is stored as written, so try both spellings.
-                let next = self
-                    .result
-                    .all_classes
-                    .get(parent)
-                    .or_else(|| self.result.all_classes.get(&format!("::{bare}")));
-                if let Some(next) = next {
+                if let Some(next) = super::class_hierarchy::resolve_class_name(
+                    parent,
+                    &class_qname,
+                    |candidate| self.result.all_classes.contains_key(candidate),
+                    &tail_index,
+                ) {
                     queue.push(next);
                 }
             }
         }
         None
+    }
+
+    /// Add one `oo::objdefine` site's per-object methods under `key`,
+    /// skipping any the same site already contributed.
+    ///
+    /// The `foreach`-literal simulation re-dispatches an installer once per
+    /// remaining element, and the ordinary walk already covered the first
+    /// one, so the first element's site is visited twice under the
+    /// *variable*'s key.  A single source site can never legitimately
+    /// declare the same member twice, so `(objdefine_offset, name)` is an
+    /// exact identity for "already recorded" — no iteration count is
+    /// needed, and a genuinely separate `oo::objdefine` block on the same
+    /// object (a different offset) still accumulates.
+    fn record_object_methods(
+        &mut self,
+        key: String,
+        methods: &[super::types::MethodDef],
+        objdefine_offset: u32,
+    ) {
+        let recorded = self.result.object_methods.entry(key).or_default();
+        for def in methods {
+            if recorded
+                .iter()
+                .any(|m| m.objdefine_offset == objdefine_offset && m.def.name == def.name)
+            {
+                continue;
+            }
+            recorded.push(super::types::ObjectMethodDef {
+                def: def.clone(),
+                objdefine_offset,
+            });
+        }
     }
 
     /// Handle `oo::class create NAME ?BODY?` — record the class.
@@ -9014,26 +9260,164 @@ mod tests {
         assert!(!r.source_targets[0].is_literal, "{:?}", r.source_targets[0]);
     }
 
+    // The `INSTALLS_NAMED_DEFINITION` re-dispatch contract.
+
+    #[test]
+    fn every_installer_spec_lands_on_a_live_redispatch_arm() {
+        // Drift gate — the trait is a *promise* that
+        // `simulate_remaining_foreach_iterations` re-runs the command once
+        // per literal `foreach` element.  A spec that carries it but whose
+        // analyser hook has no arm in that match silently promises nothing
+        // (Codex review of PR #1074: `oo::objdefine` was exactly that).
+        // Registry-driven, so a newly-stamped spec fails here rather than
+        // in a corpus months later.
+        use tcl_registry::hooks::AnalyserHookId as Hook;
+        let redispatched = [Hook::Proc, Hook::Rename, Hook::OoDefine, Hook::OoObjdefine];
+        let registry = tcl_registry::CommandRegistry::build_default();
+        let mut checked = 0usize;
+        for name in registry.command_names() {
+            for spec in registry.specs(name) {
+                if !spec
+                    .traits
+                    .contains(tcl_registry::Traits::INSTALLS_NAMED_DEFINITION)
+                {
+                    continue;
+                }
+                checked += 1;
+                let hook = spec.analyser_hook.unwrap_or_else(|| {
+                    panic!("{name} carries INSTALLS_NAMED_DEFINITION but has no analyser hook")
+                });
+                assert!(
+                    redispatched.contains(&hook),
+                    "{name} carries INSTALLS_NAMED_DEFINITION but its hook {hook:?} has no \
+                     arm in the foreach re-dispatch — the trait promises a re-dispatch \
+                     the match does not deliver",
+                );
+            }
+        }
+        assert!(
+            checked >= 4,
+            "expected proc/rename/oo::define/oo::objdefine, saw {checked}"
+        );
+    }
+
+    #[test]
+    fn foreach_objdefine_records_per_object_facts_for_every_literal_element() {
+        // TP — issue #923 idx 55's sibling shape.  tclsh 9.0.4 and 8.6.16
+        // both run `foreach o {::a ::b} { oo::objdefine $o { method probe
+        // {} {…} } }` and report `probe` in `info object methods` for
+        // *both* objects, so both must carry the per-object method fact.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "oo::class create Base { method hello {} { return hi } }\n\
+             Base create ::a\n\
+             Base create ::b\n\
+             foreach o {::a ::b} {\n    oo::objdefine $o {\n        method probe {} { return probed }\n    }\n}\n",
+            "tcl9.0",
+        );
+        for obj in ["::a", "::b"] {
+            let methods = r
+                .object_methods
+                .get(obj)
+                .unwrap_or_else(|| panic!("{obj} has per-object methods: {:?}", r.object_methods));
+            assert!(
+                methods.iter().any(|m| m.def.name == "probe"),
+                "{obj} gained probe: {methods:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn foreach_objdefine_does_not_double_record_the_first_element() {
+        // FP guard — the ordinary body walk covers the first element and
+        // the simulation covers the rest, so the first element's site is
+        // visited twice under the loop variable's own key.  One source site
+        // can never declare the same member twice, so it must appear once.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "oo::class create Base { method hello {} { return hi } }\n\
+             Base create ::a\n\
+             Base create ::b\n\
+             foreach o {::a ::b} {\n    oo::objdefine $o {\n        method probe {} { return probed }\n    }\n}\n",
+            "tcl9.0",
+        );
+        for (key, methods) in &r.object_methods {
+            let probes = methods.iter().filter(|m| m.def.name == "probe").count();
+            assert!(
+                probes <= 1,
+                "{key} recorded probe {probes} times: {methods:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn foreach_objdefine_does_not_duplicate_body_diagnostics() {
+        // FP guard — re-running the installer per element re-walks the
+        // per-object method bodies, so a diagnostic raised inside one must
+        // still be reported once per site, never once per iteration.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "oo::class create Base { method hello {} { return hi } }\n\
+             Base create ::a\n\
+             Base create ::b\n\
+             foreach o {::a ::b} {\n    oo::objdefine $o {\n        method probe {} { return $undefinedVar }\n    }\n}\n",
+            "tcl9.0",
+        );
+        let mut seen = std::collections::HashSet::new();
+        for diag in &r.diagnostics {
+            assert!(
+                seen.insert((diag.code.to_string(), diag.span)),
+                "duplicate diagnostic {:?} at {:?}",
+                diag.code,
+                diag.span,
+            );
+        }
+    }
+
+    #[test]
+    fn foreach_objdefine_over_a_dynamic_list_abstains() {
+        // TN — a runtime element list names no object the walk can know, so
+        // the per-object facts stay under the loop variable's own key and
+        // are never attributed to a literal object.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "oo::class create Base { method hello {} { return hi } }\n\
+             Base create ::a\n\
+             foreach o $objects {\n    oo::objdefine $o {\n        method probe {} { return probed }\n    }\n}\n",
+            "tcl9.0",
+        );
+        assert!(
+            !r.object_methods.contains_key("::a"),
+            "a runtime receiver must not be attributed to a literal object: {:?}",
+            r.object_methods,
+        );
+        assert!(
+            r.object_methods.contains_key("o"),
+            "the facts stay under the receiver variable: {:?}",
+            r.object_methods,
+        );
+    }
+
     // handle_oo_objdefine
 
     #[test]
     fn handle_oo_objdefine_records_dollar_var() {
         let mut a = Analyser::new();
-        a.handle_oo_objdefine(&["$obj".to_string()], &[], &[]);
+        a.handle_oo_objdefine(&["$obj".to_string()], &[], &[], &[]);
         assert!(a.objdefined_vars.contains("obj"));
     }
 
     #[test]
     fn handle_oo_objdefine_records_braced_dollar_var() {
         let mut a = Analyser::new();
-        a.handle_oo_objdefine(&["${obj}".to_string()], &[], &[]);
+        a.handle_oo_objdefine(&["${obj}".to_string()], &[], &[], &[]);
         assert!(a.objdefined_vars.contains("obj"));
     }
 
     #[test]
     fn handle_oo_objdefine_records_bare_name() {
         let mut a = Analyser::new();
-        a.handle_oo_objdefine(&["obj".to_string()], &[], &[]);
+        a.handle_oo_objdefine(&["obj".to_string()], &[], &[], &[]);
         assert!(a.objdefined_vars.contains("obj"));
     }
 

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -222,6 +222,180 @@ fn summarise_detail(description: &str) -> String {
     }
 }
 
+/// A recorded class that is itself a `TclOO` class factory, with the
+/// definition-body grammar the bodies it manufactures obey.
+///
+/// See [`Analyser::user_metaclass_of_command`].
+struct UserMetaclass {
+    /// Fully-qualified name of the factory class.
+    qualified: String,
+    /// The root registry metaclass's definition-body grammar.
+    grammar: &'static tcl_registry::definer::DefinitionBodyGrammar,
+}
+
+/// One definition-body member a class factory injects into every class it
+/// manufactures, with each word resolved to a real source token.
+struct InjectedMember {
+    /// Member keyword followed by its argument words.
+    texts: Vec<String>,
+    /// Parallel tokens — each in the manufacturer's own body (a literal it
+    /// always splices) or in the creation call (a `{*}$param` splice).
+    argv: Vec<Token>,
+}
+
+/// Where a class-manufacturing call's words sit, and what its manufacturer
+/// contributes on top of the written body.
+///
+/// See [`Analyser::manufacturer_layout`].
+struct ManufacturerLayout {
+    /// Argument index of the new class's name.
+    name_arg: usize,
+    /// Argument index of the new class's definition body.
+    body_arg: usize,
+    /// Members the manufacturer always injects.
+    injected: Vec<InjectedMember>,
+    /// `true` when the manufacturer override could not be read, so the
+    /// class's superclass list is unknown — see
+    /// [`super::types::ClassDef::inheritance_unknown`].
+    inheritance_unknown: bool,
+}
+
+impl ManufacturerLayout {
+    /// `oo::class`'s own shape: `create Name Body` / `new Body` /
+    /// `createWithNamespace Name ns Body`, with nothing injected.  The
+    /// name/body indices match the registry's `oo_class_arg_roles`.
+    fn builtin() -> Self {
+        Self {
+            name_arg: 1,
+            body_arg: 2,
+            injected: Vec::new(),
+            inheritance_unknown: false,
+        }
+    }
+}
+
+/// Every `$name` / `${name}` variable reference in `word`, in written order.
+///
+/// A deliberately syntactic scan: the callers need the *names* a template
+/// word reads, not its value, and the word may embed a command
+/// substitution (`[list … {*}$supers]`) that a value-folding splitter
+/// refuses outright.
+fn interpolated_var_names(word: &str) -> Vec<&str> {
+    let mut names = Vec::new();
+    let mut rest = word;
+    while let Some(dollar) = rest.find('$') {
+        let after = &rest[dollar + 1..];
+        if let Some(braced) = after.strip_prefix('{') {
+            if let Some(close) = braced.find('}') {
+                names.push(&braced[..close]);
+                rest = &braced[close + 1..];
+                continue;
+            }
+            rest = after;
+            continue;
+        }
+        let len = after
+            .find(|c: char| !(c.is_alphanumeric() || c == '_' || c == ':'))
+            .unwrap_or(after.len());
+        if len > 0 {
+            names.push(&after[..len]);
+        }
+        rest = &after[len..];
+    }
+    names
+}
+
+/// A literal list word's elements, each with the source span it occupies
+/// inside the word — the static half of `{*}` expansion.
+///
+/// Returns `None` when the word is not a literal (a substitution's runtime
+/// value is not a knowable list) or when an unbraced element itself
+/// interpolates, so a caller can abstain instead of splicing text the
+/// runtime would never produce.  An empty word yields an empty splice,
+/// which is exactly what `{*}{}` contributes.
+fn literal_list_words(text: &str, tok: Token) -> Option<Vec<(String, Token)>> {
+    if !matches!(tok.kind, TokenType::Str | TokenType::Esc) {
+        return None;
+    }
+    if tok.kind == TokenType::Esc && crate::naming::is_dynamic_word(text) {
+        return None;
+    }
+    let base = tok.span.start() + u32::from(tok.content_offset);
+    let mut words = Vec::new();
+    let mut pos = 0usize;
+    while let Some(element) = tcl_syntax::list::find_element(text, pos).ok()? {
+        let value = text.get(element.value.clone())?;
+        if !element.braced && crate::naming::is_dynamic_word(value) {
+            return None;
+        }
+        let start = base + u32::try_from(element.value.start).ok()?;
+        let end = base + u32::try_from(element.value.end).ok()?;
+        words.push((
+            value.to_string(),
+            Token {
+                kind: TokenType::Esc,
+                span: Span::new(start, end),
+                content_offset: 0,
+                in_quote: false,
+            },
+        ));
+        pos = element.next;
+    }
+    Some(words)
+}
+
+/// Resolve one prologue member statement from a manufacturer override into
+/// the member the creation call actually installs.
+///
+/// A literal word is kept with its own token (it lives in the
+/// manufacturer's body, which is where the reference genuinely is written).
+/// A `{*}$param` word splices the creation call's corresponding argument,
+/// whose literal list elements carry call-site tokens.  Anything else —
+/// a substitution with no statically-known value, or a `{*}` over one —
+/// yields `None`, and the caller abstains rather than inventing a
+/// superclass list.
+fn resolve_injected_member(
+    seg: &SegmentedCommand,
+    params: &[&str],
+    args: &[String],
+    arg_tokens: &[Token],
+) -> Option<InjectedMember> {
+    let texts_in = seg.args();
+    let tokens_in = seg.arg_tokens();
+    let mut member_words: Vec<String> = Vec::new();
+    let mut member_tokens: Vec<Token> = Vec::new();
+    for (i, (text, tok)) in texts_in.iter().zip(tokens_in.iter()).enumerate() {
+        let expanded = seg
+            .expand_word
+            .as_ref()
+            .and_then(|e| e.get(i + 1).copied())
+            .unwrap_or(false);
+        if expanded {
+            let refs = interpolated_var_names(text);
+            let [name] = refs.as_slice() else {
+                return None;
+            };
+            let arg_index = params.iter().position(|p| p == name)? + 1;
+            let call_tok = *arg_tokens.get(arg_index)?;
+            let call_text = args.get(arg_index)?;
+            for (element, element_tok) in literal_list_words(call_text, call_tok)? {
+                member_words.push(element);
+                member_tokens.push(element_tok);
+            }
+            continue;
+        }
+        if crate::naming::is_dynamic_word(text) {
+            return None;
+        }
+        member_words.push(text.clone());
+        member_tokens.push(*tok);
+    }
+    Some(InjectedMember {
+        texts: member_words,
+        argv: member_tokens,
+    })
+}
+
 /// Bundled arguments for [`Analyser::walk_proc_body_in_new_scope`] — kept
 /// under clippy's argument-count limit (mirrors `TaintScan` in `taint.rs`).
 #[derive(Clone, Copy)]
@@ -2868,16 +3042,26 @@ impl Analyser {
     /// For each literal element *after* the first (the first iteration is
     /// already covered by [`Self::handle_foreach_command`]'s own
     /// pre-binding + the loop's one normal body walk), narrowly re-dispatch
-    /// just the body's own `rename`/`proc` sub-commands with `var`
-    /// temporarily rebound to that element — the two commands whose
-    /// handlers already resolve a constant-foldable dynamic word via
-    /// [`Self::resolve_dynamic_word`], and the two go-to-definition/
-    /// references/rename need correctly resolved per iteration (issue #923
-    /// idx 86). Every *other* command in the body keeps the single
-    /// evaluation the normal walk above already gave it — deliberately
-    /// narrow, matching the issue #923 idx 110 precedent: this does not
-    /// generally re-walk the body per iteration (which would duplicate
-    /// diagnostics/scope entries for everything else), only these two.
+    /// just the body's own **named-definition installers** with `var`
+    /// temporarily rebound to that element — the commands whose registry
+    /// spec carries [`tcl_registry::Traits::INSTALLS_NAMED_DEFINITION`],
+    /// because those (and only those) name their target with a word whose
+    /// substituted value changes per iteration, so each element installs a
+    /// *different* definition (issue #923 idx 86 for `proc`/`rename`, idx
+    /// 55 for `oo::define`'s class target). Which commands those are is
+    /// registry data, never a name list here — a newly-stamped spec joins
+    /// the simulation with no edit to this walker.
+    ///
+    /// Every *other* command in the body keeps the single evaluation the
+    /// normal walk above already gave it — deliberately narrow, matching
+    /// the issue #923 idx 110 precedent: this does not generally re-walk
+    /// the body per iteration (which would duplicate diagnostics/scope
+    /// entries for everything else).
+    ///
+    /// Cost is `O(elements × body-commands)` with no fixpoint: the element
+    /// list is a bounded literal and each element re-dispatches only the
+    /// already-segmented installer commands.
+    ///
     /// Leaves `var` bound to the *last* element afterwards — the same
     /// value real Tcl leaves the loop variable holding once `foreach`
     /// completes.
@@ -2888,6 +3072,8 @@ impl Analyser {
         body_tok: Token,
         scope_path: &[usize],
     ) {
+        use tcl_registry::hooks::AnalyserHookId as Hook;
+
         if elements.len() < 2 || body_tok.kind != TokenType::Str {
             return;
         }
@@ -2907,24 +3093,47 @@ impl Analyser {
             let descended = descend_token(&sm, body_tok, config);
             segments_from_tree(descended.tree(), &sm)
         };
+        // Which of the body's commands install a per-iteration name is a
+        // fixed property of the segmented body, so classify once (registry
+        // lookup per body command) rather than once per element.
+        let installers: Vec<(SegmentedCommand, Hook)> = segs
+            .iter()
+            .filter_map(|seg| {
+                let resolved = self.resolve_analyser_hook_call(seg.name(), seg.args())?;
+                resolved
+                    .traits
+                    .contains(tcl_registry::Traits::INSTALLS_NAMED_DEFINITION)
+                    .then(|| (seg.clone(), resolved.hook))
+            })
+            .collect();
+        if installers.is_empty() {
+            return;
+        }
         for element in &elements[1..] {
             self.set_const_string(var, element.clone(), body_tok.span, scope_path);
-            for seg in &segs {
-                match seg.name() {
-                    "rename" => {
+            for (seg, hook) in &installers {
+                let args = seg.args();
+                let arg_tokens = seg.arg_tokens();
+                let arg_single = seg.arg_single_token();
+                match hook {
+                    Hook::Proc => {
+                        self.handle_proc_command(args, arg_tokens, arg_single, scope_path);
+                    }
+                    Hook::Rename => {
                         self.handle_rename(
-                            seg.args(),
-                            seg.arg_tokens(),
-                            seg.arg_single_token(),
+                            args,
+                            arg_tokens,
+                            arg_single,
                             scope_path,
                             seg.span.start(),
                         );
                     }
-                    "proc" => {
-                        self.handle_proc_command(
-                            seg.args(),
-                            seg.arg_tokens(),
-                            seg.arg_single_token(),
+                    Hook::OoDefine => {
+                        self.handle_oo_define_command(
+                            seg.name(),
+                            args,
+                            arg_tokens,
+                            arg_single,
                             scope_path,
                         );
                     }
@@ -3579,8 +3788,10 @@ impl Analyser {
     /// as data rather than computing it — [`Self::handle_rename`]'s
     /// `OLD`/`NEW` words, and [`Self::handle_source_command`]'s path word
     /// (issue #923 idx 46: `set p "e.tcl"; source $p`, the same shape
-    /// `rename $old new` already resolved for idx 3).
-    fn resolve_dynamic_word(
+    /// `rename $old new` already resolved for idx 3), the `oo::define`
+    /// target word, and the command head itself
+    /// ([`Self::resolve_dynamic_command_head`]).
+    pub(super) fn resolve_dynamic_word(
         &self,
         text: &str,
         tok: Option<Token>,
@@ -3610,10 +3821,34 @@ impl Analyser {
                 &self.cached_line_index,
                 self.cached_line_index_source_len,
             );
-            let var_name = sm.token_text(tok);
-            return self
-                .lookup_dominating_const_string(var_name, scope_path)
-                .map(str::to_string);
+            // The token's *true source bytes*, which for a braced composite
+            // head (`${ns}::setdef`) are the whole word — the lexer merges
+            // the `${…}` substitution and everything glued to it into one
+            // `Var` token, so the raw text is `ns}::setdef`, not the
+            // variable name.  Reading it whole looks up a variable that
+            // cannot exist and abstains on a word that is in fact
+            // statically resolvable (issue #923 idx 44).  The dispatched
+            // variable ends at the brace the lexer left in place; the rest
+            // is an ordinary word suffix, folded like any other (it may
+            // itself interpolate, `${ns}::${sub}`).  Same truncation rule
+            // as `record_var_or_cmd_command_site`'s W307 head reading, so
+            // the two agree on which bytes name the variable.
+            let raw = sm.token_text(tok);
+            let (var_name, suffix) = if tok.content_offset >= 2 {
+                raw.split_once('}')
+                    .map_or((raw, ""), |(name, rest)| (name, rest))
+            } else {
+                (raw, "")
+            };
+            let value = self.lookup_dominating_const_string(var_name, scope_path)?;
+            if suffix.is_empty() {
+                return Some(value.to_string());
+            }
+            let folded_suffix = crate::text::fold_interpolation_single(suffix, |name| {
+                self.lookup_dominating_const_string(name, scope_path)
+                    .map(str::to_string)
+            })?;
+            return Some(format!("{value}{folded_suffix}"));
         }
         crate::text::fold_interpolation_single(text, |name| {
             self.lookup_dominating_const_string(name, scope_path)
@@ -4050,6 +4285,227 @@ impl Analyser {
             .and_then(|s| s.definition_body)
     }
 
+    /// The word layout of `Meta create …` plus whatever members the
+    /// manufacturer injects into every class it makes.
+    ///
+    /// A user metaclass that does not override the manufacturer inherits
+    /// `oo::class`'s own `create Name Body` shape, so the builtin layout
+    /// applies unchanged.  One that *does* override it declares its own
+    /// shape in the override's parameter list, and that override is read
+    /// here rather than guessed: Tk's `self method create {name superclasses
+    /// body}` puts the body at argument 3, not 2, and splices a superclass
+    /// the caller never wrote (issue #923 idx 96/97).
+    fn manufacturer_layout(
+        &self,
+        meta: &UserMetaclass,
+        args: &[String],
+        arg_tokens: &[Token],
+    ) -> ManufacturerLayout {
+        // `args[0]` is the manufacturer subcommand this call actually used,
+        // so the override looked up is the one that will run.
+        let override_def = self
+            .result
+            .all_classes
+            .get(&meta.qualified)
+            .and_then(|class| class.class_methods.get(&args[0]));
+        let Some(override_def) = override_def else {
+            return ManufacturerLayout::builtin();
+        };
+        let positions = self.manufacturer_word_positions(override_def);
+        let (name_arg, body_arg) = positions.unwrap_or((1, 2));
+        let injected = positions
+            .and_then(|_| self.manufacturer_injected_members(meta, override_def, args, arg_tokens));
+        ManufacturerLayout {
+            name_arg,
+            body_arg,
+            inheritance_unknown: injected.is_none(),
+            injected: injected.unwrap_or_default(),
+        }
+    }
+
+    /// Which of the creation call's argument words carry the new class's
+    /// name and body, read off the manufacturer override's own `next` call.
+    ///
+    /// The override re-enters the manufacturer chain through `next`
+    /// (identified by [`tcl_registry::registry::MethodDispatchKind::NextChain`],
+    /// registry data), whose arguments sit at the *builtin* `create Name
+    /// Body` positions.  Whichever of the override's parameters those
+    /// arguments read is therefore the caller's name / body word: the first
+    /// parameter reference is the name, the last is the body (the body is
+    /// always spliced in last — everything between is the definition
+    /// prologue the manufacturer builds).  Returns `None` when the override
+    /// cannot be read that way, and the caller falls back to the builtin
+    /// positions with inheritance marked unknown.
+    fn manufacturer_word_positions(
+        &self,
+        override_def: &super::types::MethodDef,
+    ) -> Option<(usize, usize)> {
+        let params: Vec<&str> = override_def
+            .params
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        let next_seg = self.manufacturer_next_call(override_def)?;
+        // Parameter `i` of the override binds argument `i + 1` of the call
+        // (argument 0 being the manufacturer subcommand itself).
+        let param_arg = |name: &str| params.iter().position(|p| *p == name).map(|i| i + 1);
+        let refs: Vec<&str> = next_seg
+            .args()
+            .iter()
+            .flat_map(|word| interpolated_var_names(word))
+            .collect();
+        let name_arg = param_arg(refs.first().copied()?)?;
+        let body_arg = param_arg(refs.last().copied()?)?;
+        (name_arg != body_arg).then_some((name_arg, body_arg))
+    }
+
+    /// The manufacturer override's `next` statement, re-segmented from its
+    /// own source bytes.
+    fn manufacturer_next_call(
+        &self,
+        override_def: &super::types::MethodDef,
+    ) -> Option<SegmentedCommand> {
+        let registry = self.registry.as_ref()?;
+        let start = override_def.body_span.start() as usize;
+        let end = override_def.body_span.end() as usize;
+        let raw = self.source.get(start..end)?;
+        // `MethodDef` keeps the body **word**'s span, whose start sits on
+        // the opening delimiter; the script is its content.
+        let (body, base) = raw
+            .strip_prefix(['{', '"'])
+            .map_or((raw, start), |inner| (inner, start.saturating_add(1)));
+        crate::segmenter::segment_commands_with_offset_and_config(
+            body,
+            u32::try_from(base).unwrap_or(0),
+            self.lexer_config(),
+        )
+        .into_iter()
+        .find(|seg| {
+            !seg.is_partial
+                && registry.method_dispatch_keyword(seg.name())
+                    == Some(tcl_registry::registry::MethodDispatchKind::NextChain)
+        })
+    }
+
+    /// The definition-body members the manufacturer splices into every class
+    /// it makes, resolved against *this* call's arguments.
+    ///
+    /// Tk's `Megawidget` hands `next` a `[list superclass ::tk::MegawidgetClass
+    /// {*}$superclasses]` prologue, so every class it makes really does
+    /// inherit `::tk::MegawidgetClass` plus whatever the caller passed —
+    /// tclsh 9.0.4 and 8.6.16 both report exactly that from `info class
+    /// superclasses`.  Only **reference-only** members (`superclass`,
+    /// `mixin`, `filter`, `export`, … — the grammar's `all_args_ref` set)
+    /// are injected: they name existing entities, so every injected word
+    /// keeps a real source span, either in the manufacturer's own body
+    /// (a literal it always splices) or in this call's arguments (a
+    /// `{*}$param` splice).  A prologue built any other way yields `None`
+    /// and the class is recorded with its inheritance marked unknown, so no
+    /// method check fires against a superclass list that was guessed.
+    fn manufacturer_injected_members(
+        &self,
+        meta: &UserMetaclass,
+        override_def: &super::types::MethodDef,
+        args: &[String],
+        arg_tokens: &[Token],
+    ) -> Option<Vec<InjectedMember>> {
+        let registry = self.registry.as_ref()?;
+        let params: Vec<&str> = override_def
+            .params
+            .iter()
+            .map(|p| p.name.as_str())
+            .collect();
+        let next_seg = self.manufacturer_next_call(override_def)?;
+        let config = self.lexer_config();
+        let sm = SourceMap::new(&self.source);
+        let mut injected: Vec<InjectedMember> = Vec::new();
+        for tok in &next_seg.all_tokens {
+            if tok.kind != TokenType::Cmd {
+                continue;
+            }
+            let descended = descend_token(&sm, *tok, config);
+            for seg in segments_from_tree(descended.tree(), &sm) {
+                // The prologue is built by a command that quotes its
+                // arguments into a canonical list — registry data
+                // (`PRODUCES_CANONICAL_LIST`), never a command name here.
+                if !registry.get(seg.name()).is_some_and(|spec| {
+                    spec.traits
+                        .contains(tcl_registry::Traits::PRODUCES_CANONICAL_LIST)
+                }) {
+                    continue;
+                }
+                let Some(member) = seg
+                    .args()
+                    .first()
+                    .and_then(|keyword| meta.grammar.member(keyword))
+                else {
+                    continue;
+                };
+                member.all_args_ref?;
+                injected.push(resolve_injected_member(&seg, &params, args, arg_tokens)?);
+            }
+        }
+        Some(injected)
+    }
+
+    /// The recorded class `cmd_name` names when that class is **itself a
+    /// class factory** — a user-defined `TclOO` metaclass.
+    ///
+    /// A class is a factory when its (possibly indirect) superclass chain
+    /// reaches a command the registry marks [`tcl_registry::Traits::IS_OO_METACLASS`]
+    /// with a `TclOo` definition-body grammar — the same seed
+    /// [`Self::handle_oo_class_command`] uses for a written-out
+    /// `oo::class create`.  Only the inheritance step is added here, and
+    /// that is `TclOO` language semantics (`oo::class`'s subclasses
+    /// manufacture classes), not per-command knowledge.
+    ///
+    /// The returned grammar is the *root registry metaclass's* own
+    /// definition-body grammar, so the bodies this factory makes are walked
+    /// by exactly the grammar the language gives them without the walker
+    /// naming a metaclass command.
+    ///
+    /// Chain walking is depth-bounded and visited-checked, so a cyclic
+    /// `superclass` declaration (rejected by real Tcl, but writable in a
+    /// half-edited buffer) terminates.
+    fn user_metaclass_of_command(
+        &self,
+        cmd_name: &str,
+        scope_path: &[usize],
+    ) -> Option<UserMetaclass> {
+        let registry = self.registry.as_ref()?;
+        let qualified = self.resolve_command_qualified_name(cmd_name, scope_path);
+        let start = self.result.all_classes.get(&qualified)?;
+        let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+        let mut queue: Vec<&super::types::ClassDef> = vec![start];
+        // Bounded by the recorded class count — every class is visited once.
+        while let Some(class) = queue.pop() {
+            if !seen.insert(class.qualified_name.clone()) {
+                continue;
+            }
+            for parent in &class.superclasses {
+                let bare = parent.strip_prefix("::").unwrap_or(parent);
+                if let Some(spec) = registry.get(bare)
+                    && spec.traits.contains(tcl_registry::Traits::IS_OO_METACLASS)
+                    && let Some(grammar) = spec.definition_body
+                    && grammar.family == tcl_registry::definer::DefinerFamily::TclOo
+                {
+                    return Some(UserMetaclass { qualified, grammar });
+                }
+                // A superclass recorded relative to the file's own namespace
+                // is stored as written, so try both spellings.
+                let next = self
+                    .result
+                    .all_classes
+                    .get(parent)
+                    .or_else(|| self.result.all_classes.get(&format!("::{bare}")));
+                if let Some(next) = next {
+                    queue.push(next);
+                }
+            }
+        }
+        None
+    }
+
     /// Handle `oo::class create NAME ?BODY?` — record the class.
     ///
     /// Records a [`super::types::ClassDef`] in ``result.all_classes``
@@ -4083,7 +4539,21 @@ impl Analyser {
         //    create method …` (a class literally named `create`) must not be
         //    mistaken for a creation and stolen from `handle_oo_define_command`.
         // define/objdefine carry no `IS_OO_METACLASS`, so they fall through.
-        let is_class_definer = self
+        //
+        // The cheap shape tests come first: this runs for *every* command
+        // with no stamped analyser hook, and only a `create` / `new` /
+        // `createWithNamespace` head can possibly introduce a class, so the
+        // registry and class-chain lookups below are reached by almost
+        // nothing.
+        if args.len() < 2 || arg_tokens.len() < 2 {
+            return false;
+        }
+        // `create Name ?body?`, `new ?body?`, and `createWithNamespace Name ns
+        // ?body?` all introduce a class.
+        if !matches!(args[0].as_str(), "create" | "new" | "createWithNamespace") {
+            return false;
+        }
+        let registry_definer = self
             .registry
             .as_ref()
             .and_then(|r| r.get(cmd_name))
@@ -4092,15 +4562,37 @@ impl Analyser {
                     && s.definition_body
                         .is_some_and(|g| g.family == tcl_registry::definer::DefinerFamily::TclOo)
             });
-        if !is_class_definer || args.len() < 2 || arg_tokens.len() < 2 {
+        // …but *being* a metaclass is a property of the class, not of the
+        // registry: `oo::class create Megawidget { superclass ::oo::class … }`
+        // makes `Megawidget` every bit as much a class factory as `oo::class`
+        // itself, and Tk's own `library/megawidget.tcl` builds `SimpleWidget`
+        // / `FocusableWidget` / `IconList` that way (issue #923 idx 96/97).
+        // A registry lookup alone can never see it, so metaclass-ness also
+        // propagates down the recorded superclass chain — the *seed* is still
+        // registry data (`IS_OO_METACLASS`), only the inheritance step is
+        // `TclOO` language semantics.
+        let user_metaclass = if registry_definer {
+            None
+        } else {
+            self.user_metaclass_of_command(cmd_name, scope_path)
+        };
+        if !registry_definer && user_metaclass.is_none() {
             return false;
         }
-        // `create Name ?body?`, `new ?body?`, and `createWithNamespace Name ns
-        // ?body?` all introduce a class.
-        if !matches!(args[0].as_str(), "create" | "new" | "createWithNamespace") {
+        // Where the name and body words sit, and what the manufacturer
+        // splices into every body it makes.  For a registry metaclass this is
+        // the builtin `create Name Body` layout; a user metaclass that
+        // *overrides* the manufacturer (`self method create {name superclasses
+        // body} { next $name [list superclass Base {*}$superclasses];$body }`)
+        // declares its own, read off the override.
+        let layout = match user_metaclass.as_ref() {
+            None => ManufacturerLayout::builtin(),
+            Some(meta) => self.manufacturer_layout(meta, args, arg_tokens),
+        };
+        if layout.name_arg >= args.len() || layout.name_arg >= arg_tokens.len() {
             return false;
         }
-        let raw_name = &args[1];
+        let raw_name = &args[layout.name_arg];
         // Home the class to the command-resolution namespace (see the same
         // reasoning in `handle_proc_command`): a class created inside a
         // qualified-name proc's body homes to that proc's defining namespace,
@@ -4109,11 +4601,11 @@ impl Analyser {
         let ns_prefix = self.command_resolution_namespace(scope_path);
         let qualified = qualify(&ns_prefix, raw_name);
         let simple = crate::naming::key_tail(&qualified).to_string();
-        let name_span = arg_tokens[1].span;
+        let name_span = arg_tokens[layout.name_arg].span;
         // **W314** — the class name has no absolute written form (#934).
         self.emit_w314_no_absolute_name(raw_name, name_span);
-        let body_tok_opt = arg_tokens.get(2).copied();
-        let body_span = body_tok_opt.map_or(arg_tokens[1].span, |t| t.span);
+        let body_tok_opt = arg_tokens.get(layout.body_arg).copied();
+        let body_span = body_tok_opt.map_or(name_span, |t| t.span);
         let doc = std::mem::take(&mut self.last_comment);
         let mut class = super::types::ClassDef {
             name: simple,
@@ -4122,13 +4614,34 @@ impl Analyser {
             body_span,
             metaclass: cmd_name.to_string(),
             doc,
+            inheritance_unknown: layout.inheritance_unknown,
             ..Default::default()
         };
+        // A user metaclass has no spec of its own, so the bodies it makes are
+        // governed by the definition grammar of the registry metaclass at the
+        // root of its superclass chain — the same `TclOO` grammar, reached
+        // without naming it here.
+        let grammar = user_metaclass
+            .as_ref()
+            .map_or_else(|| self.definition_grammar(cmd_name), |m| Some(m.grammar));
+        // Members the manufacturer itself injects (Tk's `Megawidget` splices
+        // `superclass ::tk::MegawidgetClass` plus whatever the caller passed)
+        // are applied through the *same* registry-grammar routing as a member
+        // written in the body, so no member keyword is known here by name.
+        if let Some(grammar) = grammar {
+            for injected in &layout.injected {
+                super::oo::apply_oo_subcommand(
+                    grammar,
+                    &injected.texts,
+                    &injected.argv,
+                    &mut class,
+                );
+            }
+        }
         // Walk the class body when present — populates
         // ``superclasses`` / ``mixins`` / ``methods`` /
         // ``class_methods`` from the OO-define subcommands.
-        if let (Some(body_text), Some(body_tok)) = (args.get(2), body_tok_opt) {
-            let grammar = self.definition_grammar(cmd_name);
+        if let (Some(body_text), Some(body_tok)) = (args.get(layout.body_arg), body_tok_opt) {
             let definer_disabled = self.command_dialect_disabled(cmd_name);
             self.parse_oo_definition_body(
                 body_text,
@@ -4181,12 +4694,29 @@ impl Analyser {
         cmd_name: &str,
         args: &[String],
         arg_tokens: &[Token],
+        arg_single: &[bool],
         scope_path: &[usize],
     ) -> bool {
         if args.is_empty() {
             return false;
         }
-        let raw_class_name = &args[0];
+        // A target word written with a substitution may still name exactly
+        // one class: `foreach cls {A B} { oo::define $cls { … } }` binds
+        // `cls` to a literal element per iteration, so each iteration
+        // extends a real, named class (issue #923 idx 55 — the ticklecharts
+        // `etsb.tcl` monkey-patch of four literally-listed classes).  Fold
+        // through the same dominating-constant lattice every other
+        // identity-resolving word uses; only a genuinely unresolvable
+        // target falls through to the synthetic key below.
+        let resolved_class_name = self
+            .resolve_dynamic_word(
+                &args[0],
+                arg_tokens.first().copied(),
+                arg_single.first().copied().unwrap_or(false),
+                scope_path,
+            )
+            .filter(|name| !crate::naming::is_dynamic_word(name));
+        let raw_class_name = resolved_class_name.as_ref().unwrap_or(&args[0]);
         // A relative class name resolves against the namespace current at the
         // call — the command-resolution namespace (issue #923 idx 85).
         let ns_prefix = self.command_resolution_namespace(scope_path);
@@ -8747,10 +9277,15 @@ mod tests {
         // method into the second's ClassDef (and vice versa via the
         // dual-registration into `scope.classes`), producing a document
         // symbol whose child method range sits outside its own parent's.
+        // The targets here are *parameters*, so no constant dominates
+        // either call and both stay genuinely dynamic — the shape this
+        // guard is about.  (A target bound to a dominating constant is a
+        // different, statically-resolvable case: see
+        // `oo_define_resolves_a_dominating_constant_target`.)
         let mut a = Analyser::new();
         let r = a.analyse(
-            "proc addFoo {} {\n    set class ::A\n    oo::define $class method foo {} { return foo }\n}\n\
-             proc addBar {} {\n    set class ::B\n    oo::define $class method bar {} { return bar }\n}\n",
+            "proc addFoo {class} {\n    oo::define $class method foo {} { return foo }\n}\n\
+             proc addBar {class} {\n    oo::define $class method bar {} { return bar }\n}\n",
             "tcl8.6",
         );
         let synthetic: Vec<_> = r
@@ -8782,14 +9317,19 @@ mod tests {
 
     #[test]
     fn dynamic_oo_define_target_does_not_touch_a_same_named_literal_class() {
-        // FP guard — a literal class that happens to share source text with
-        // an unrelated dynamic target (`$Widget` vs a real class literally
-        // named `Widget`) must never be found/extended by the dynamic call:
-        // the synthetic key can never collide with a real qualified name.
+        // FP guard — a class whose *written* name matches nothing knowable
+        // (`$class` bound to a parameter) must never be found/extended
+        // through a literal class that happens to share the variable's
+        // source text: the synthetic key can never collide with a real
+        // qualified name.  A target bound to a dominating constant *is*
+        // resolvable and does extend the real class — tclsh 9.0.4/8.6.16
+        // agree — which is
+        // `oo_define_resolves_a_dominating_constant_target`'s case, not
+        // this one.
         let mut a = Analyser::new();
         let r = a.analyse(
             "oo::class create Widget {\n    method real {} {}\n}\n\
-             proc addDynamic {} {\n    set class Widget\n    oo::define $class method dynamic {} {}\n}\n",
+             proc addDynamic {class} {\n    oo::define $class method dynamic {} {}\n}\n",
             "tcl8.6",
         );
         let widget = &r.all_classes["::Widget"];
@@ -8810,6 +9350,7 @@ mod tests {
             &["MyClass".to_string(), "method m {} {}".to_string()],
             &[],
             &[],
+            &[],
         );
         assert!(handled);
     }
@@ -8817,7 +9358,7 @@ mod tests {
     #[test]
     fn handle_oo_define_no_args_returns_false() {
         let mut a = Analyser::new();
-        let handled = a.handle_oo_define_command("oo::define", &[], &[], &[]);
+        let handled = a.handle_oo_define_command("oo::define", &[], &[], &[], &[]);
         assert!(!handled);
     }
 

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -413,16 +413,31 @@ impl Analyser {
             if cmd.is_partial || cmd.argv.is_empty() {
                 continue;
             }
+            // `{*}` of a literal list is spliced by the *parser*, so the
+            // member's words are the list's elements — `method
+            // {*}{foo {} {return 1}}` really defines `foo` (tclsh 9.0.4 and
+            // 8.6.16 both run it).  Normalise those words before the
+            // grammar's fixed layout is read off them, or the member is one
+            // word long and gets dropped as malformed (issue #923 idx 53).
+            // A `{*}` over a *substituted* word (`{*}[info class definition
+            // …]`) has no statically-known element list, so it is left
+            // exactly as written and the member still abstains.
+            let spliced = splice_static_member_expansions(cmd);
+            let (texts, argv) = spliced
+                .as_ref()
+                .map_or((cmd.texts.as_slice(), cmd.argv.as_slice()), |(t, a)| {
+                    (t.as_slice(), a.as_slice())
+                });
             // A member keyword gated to a newer core — `classmethod`,
             // `private`, `initialise`/`initialize`, `definitionnamespace`,
             // and `property` are all 9.0+ — does not exist in this dialect's
             // definition grammar.  Flag it with the same disabled-in-dialect
             // diagnostic a command draws, then carry on recording it (see
             // the emitter's doc for why reporting must not erase).
-            if let (Some(subcmd), Some(tok)) = (cmd.texts.first(), cmd.argv.first()) {
+            if let (Some(subcmd), Some(tok)) = (texts.first(), argv.first()) {
                 self.emit_w002_oo_member_disabled(grammar, subcmd, *tok, definer_disabled);
             }
-            apply_oo_subcommand(grammar, &cmd.texts, &cmd.argv, class_def);
+            apply_oo_subcommand(grammar, texts, argv, class_def);
             // A member argument that *names* a command — the class a
             // `superclass`/`mixin` extends, the command a `forward` delegates to
             // — is a first-class command reference.  Record it so references /
@@ -430,13 +445,13 @@ impl Analyser {
             // direct call.  Which arguments name commands is registry data (the
             // member grammar's `all_args_ref` / `ArgRole::CommandName`), never a
             // member keyword the walker knows by name.
-            self.record_member_command_references(grammar, &cmd.texts, &cmd.argv, scope_path);
-            if let Some(mb) = collect_method_body(grammar, &cmd.texts, &cmd.argv) {
+            self.record_member_command_references(grammar, texts, argv, scope_path);
+            if let Some(mb) = collect_method_body(grammar, texts, argv) {
                 method_bodies.push(mb);
             }
-            match cmd.texts.first().map(String::as_str) {
+            match texts.first().map(String::as_str) {
                 Some("property") => {
-                    collect_property_accessor_bodies(&cmd.texts, &cmd.argv, &mut accessor_bodies);
+                    collect_property_accessor_bodies(texts, argv, &mut accessor_bodies);
                 }
                 Some(kw @ ("initialise" | "initialize")) => {
                     // A class-level init script: unlike a method, its body (the
@@ -448,7 +463,7 @@ impl Analyser {
                         .and_then(|m| m.indices_for(ArgRole::Body).next())
                         .map(|i| i + 1)
                         && let (Some(body), Some(tok)) =
-                            (cmd.texts.get(body_idx), cmd.argv.get(body_idx).copied())
+                            (texts.get(body_idx), argv.get(body_idx).copied())
                         && tok.kind == TokenType::Str
                     {
                         init_bodies.push((body.clone(), tok));
@@ -1408,6 +1423,62 @@ fn walk_unknown_stmt(stmt: &Statement, first_param: &str, info: &mut UnknownProc
     }
 }
 
+/// One definition-body member command's words with every **statically
+/// determined** `{*}` expansion already spliced, or `None` when the command
+/// has no expansion the analyser can resolve (the overwhelmingly common
+/// case, kept allocation-free).
+///
+/// Tcl expands `{*}` during parsing, so a `{*}`-marked word whose text is a
+/// literal is *not* one word — it is the elements of the list it holds, and
+/// the member grammar's fixed argument layout applies to those.  Without
+/// this normalisation `constructor {*}{args {…}}` / `method
+/// {*}{foo {} {…}}` look one word short of their grammar and the member is
+/// dropped entirely, with no diagnostic (issue #923 idx 53).  Verified
+/// against tclsh 9.0.4 and 8.6.16: both forms define a real, callable
+/// member, in the `oo::class create` body *and* the `oo::define` body.
+///
+/// Only a single **braced** (`Str`) word splices: braces suppress
+/// substitution, so its element list is exactly what the runtime sees.  A
+/// `{*}` over a variable or command substitution (`{*}[info class
+/// definition …]`, the ticklecharts `chart3D` reflection idiom) has no
+/// statically-knowable element list and is left verbatim — the member then
+/// abstains exactly as before rather than being recorded with invented
+/// parameters or a body span pointing at the wrong text.
+///
+/// Element spans come from the segmenter
+/// ([`crate::segmenter::flatten_clause_list_elements`]), so each spliced
+/// word carries its own true source range and downstream consumers
+/// (document symbols, `my`-dispatch, hover) get real positions rather than
+/// the whole-list span.
+fn splice_static_member_expansions(
+    cmd: &crate::segmenter::SegmentedCommand,
+) -> Option<(Vec<String>, Vec<Token>)> {
+    let expand = cmd.expand_word.as_ref()?;
+    if !expand.iter().any(|&e| e) {
+        return None;
+    }
+    let mut texts: Vec<String> = Vec::with_capacity(cmd.texts.len());
+    let mut argv: Vec<Token> = Vec::with_capacity(cmd.argv.len());
+    let mut spliced = false;
+    for (i, (text, tok)) in cmd.texts.iter().zip(cmd.argv.iter()).enumerate() {
+        let is_static_expansion = expand.get(i).copied().unwrap_or(false)
+            && tok.kind == TokenType::Str
+            && cmd.single_token_word.get(i).copied().unwrap_or(false);
+        if is_static_expansion {
+            spliced = true;
+            for (element, element_tok) in crate::segmenter::flatten_clause_list_elements(text, *tok)
+            {
+                texts.push(element);
+                argv.push(element_tok);
+            }
+            continue;
+        }
+        texts.push(text.clone());
+        argv.push(*tok);
+    }
+    spliced.then_some((texts, argv))
+}
+
 /// Per-subcommand dispatcher shared by the body-form and
 /// inline-form walkers.
 ///
@@ -1673,7 +1744,7 @@ fn apply_oo_ctor_or_dtor(
     Some(md)
 }
 
-fn apply_oo_subcommand(
+pub(super) fn apply_oo_subcommand(
     grammar: &DefinitionBodyGrammar,
     texts: &[String],
     argv: &[Token],

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -622,6 +622,14 @@ pub struct ClassDef {
     /// for an ``oo::define`` that extends a class created earlier in the same
     /// file.
     pub via_define: bool,
+    /// `true` when the class was manufactured by a **user-defined metaclass**
+    /// whose `create` override the analyser could not read, so the superclass
+    /// list it splices into the class is unknown.  The class itself is real
+    /// and its own body is fully modelled; only its inheritance is opaque.
+    /// Method-existence checks (W308) must abstain on such a class exactly as
+    /// they do for one whose superclass lives outside the workspace index —
+    /// a method it inherits is not one it is missing (issue #923 idx 96/97).
+    pub inheritance_unknown: bool,
 }
 
 impl Default for ClassDef {
@@ -655,6 +663,7 @@ impl Default for ClassDef {
             linked_members: HashMap::new(),
             doc: String::new(),
             via_define: false,
+            inheritance_unknown: false,
         }
     }
 }

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -3858,3 +3858,452 @@ mod report_scoped_commands {
         );
     }
 }
+
+// ===========================================================================
+// Class factories and dynamically-installed members — issue #923 audit
+// cluster C3 (idx 43/44/53/55/96/97).
+//
+// C-Tcl ground truth for every case below comes from tclsh 9.0.4 and
+// tclsh 8.6.16, which agree on all of them:
+//
+// * `oo::class create Megawidget { superclass oo::class; self method create
+//   {name superclasses body} { next $name [list superclass MegawidgetClass
+//   {*}$superclasses]\;$body } }` then `Megawidget create SimpleWidget {}
+//   {…}` / `Megawidget create FocusableWidget SimpleWidget {…}` /
+//   `Megawidget create IconList FocusableWidget {…}` report
+//   `info class superclasses` = `::MegawidgetClass`,
+//   `::MegawidgetClass ::SimpleWidget`, and
+//   `::MegawidgetClass ::FocusableWidget` respectively, and `my CreateHull`
+//   from an `IconList` instance really runs `FocusableWidget`'s override.
+// * `oo::define S { method {*}{foo {} {return foo-ran}} }` defines a real,
+//   callable `foo`; so does the same `{*}` form inside an `oo::class create`
+//   body.  `constructor {*}[info class constructor ::Base]` /
+//   `method $m {*}[info class definition ::Base $m]` are equally real but
+//   carry no statically-knowable element list.
+// * `set ns tc; ${ns}::setdef …` dispatches to `::tc::setdef`.
+// ===========================================================================
+mod class_factories {
+    use super::*;
+    use tcl_compiler::analyser::{AnalysisResult, ClassDef};
+
+    fn analysis(src: &str, dialect: &str) -> AnalysisResult {
+        Analyser::new().analyse(src, dialect)
+    }
+
+    fn class(src: &str, qn: &str) -> ClassDef {
+        analysis(src, "tcl9.0")
+            .all_classes
+            .get(qn)
+            .cloned()
+            .unwrap_or_else(|| panic!("class {qn} recorded"))
+    }
+
+    /// The Tk `library/megawidget.tcl` factory, reduced to its mechanism.
+    const MEGAWIDGET: &str = concat!(
+        "oo::class create Megawidget {\n",
+        "    superclass oo::class\n",
+        "    self method create {name superclasses body} {\n",
+        "        next $name [list superclass MegawidgetClass {*}$superclasses]\\;$body\n",
+        "    }\n",
+        "}\n",
+        "oo::class create MegawidgetClass {\n",
+        "    method TraceOption {a b} { return traced }\n",
+        "}\n",
+        "Megawidget create SimpleWidget {} {\n",
+        "    method CreateHull {} { my TraceOption a b }\n",
+        "}\n",
+        "Megawidget create FocusableWidget SimpleWidget {\n",
+        "    method CreateHull {} { my TraceOption c d }\n",
+        "}\n",
+        "Megawidget create IconList FocusableWidget {\n",
+        "    method GetSpecs {} { return iconlist }\n",
+        "}\n",
+    );
+
+    #[test]
+    fn user_metaclass_creates_real_classes() {
+        // TP — idx 96/97: a class whose own superclass chain reaches
+        // `oo::class` is a class factory, so its `create` calls introduce
+        // real classes.  Before this they never entered `all_classes` at
+        // all: no outline entry, no references, no `next` resolution.
+        let r = analysis(MEGAWIDGET, "tcl9.0");
+        for name in ["::SimpleWidget", "::FocusableWidget", "::IconList"] {
+            assert!(
+                r.all_classes.contains_key(name),
+                "{name} recorded: {:?}",
+                r.all_classes.keys().collect::<Vec<_>>()
+            );
+        }
+    }
+
+    #[test]
+    fn user_metaclass_body_argument_is_read_from_the_create_override() {
+        // TP — the override's signature is `{name superclasses body}`, so
+        // the body is argument 3, not the builtin `create Name Body`
+        // argument 2.  Reading the builtin position would walk the
+        // superclass word as a script and lose every member.
+        assert!(
+            class(MEGAWIDGET, "::SimpleWidget")
+                .methods
+                .contains_key("CreateHull")
+        );
+        assert!(
+            class(MEGAWIDGET, "::IconList")
+                .methods
+                .contains_key("GetSpecs")
+        );
+    }
+
+    #[test]
+    fn user_metaclass_splices_its_own_and_the_callers_superclasses() {
+        // TP — matches `info class superclasses` on tclsh 9.0.4 / 8.6.16
+        // exactly, including the implicit `MegawidgetClass` the factory
+        // injects and the caller-supplied list spliced by `{*}$superclasses`.
+        assert_eq!(
+            class(MEGAWIDGET, "::SimpleWidget").superclasses,
+            ["MegawidgetClass"]
+        );
+        assert_eq!(
+            class(MEGAWIDGET, "::FocusableWidget").superclasses,
+            ["MegawidgetClass", "SimpleWidget"]
+        );
+        assert_eq!(
+            class(MEGAWIDGET, "::IconList").superclasses,
+            ["MegawidgetClass", "FocusableWidget"]
+        );
+    }
+
+    #[test]
+    fn a_factory_made_class_with_a_readable_override_is_not_opaque() {
+        // TN — inheritance is fully known here, so method checks stay live
+        // rather than being blanket-suppressed.
+        assert!(!class(MEGAWIDGET, "::FocusableWidget").inheritance_unknown);
+    }
+
+    #[test]
+    fn an_unreadable_manufacturer_override_marks_inheritance_unknown() {
+        // Abstention — the override builds its prologue from a runtime
+        // value, so the superclass list cannot be known.  The class is
+        // still recorded (it exists), but its inheritance is flagged
+        // opaque so no method-existence check fires against a guess.
+        let src = concat!(
+            "oo::class create Meta {\n",
+            "    superclass oo::class\n",
+            "    self method create {name extra body} {\n",
+            "        next $name [list superclass [pickBase $extra]]\\;$body\n",
+            "    }\n",
+            "}\n",
+            "Meta create Widget somewhere {\n",
+            "    method m {} { return 1 }\n",
+            "}\n",
+        );
+        let cd = class(src, "::Widget");
+        assert!(cd.inheritance_unknown, "{cd:?}");
+        assert!(cd.superclasses.is_empty(), "{cd:?}");
+        assert!(cd.methods.contains_key("m"), "{cd:?}");
+    }
+
+    #[test]
+    fn an_ordinary_class_is_not_treated_as_a_factory() {
+        // TN — `Dog` is a plain class, so `Dog create rex` makes an
+        // *instance*, never a class.  Only a chain that reaches
+        // `oo::class` manufactures classes.
+        let src = concat!(
+            "oo::class create Dog {\n",
+            "    method bark {} { return woof }\n",
+            "}\n",
+            "Dog create rex\n",
+        );
+        assert!(
+            !analysis(src, "tcl9.0").all_classes.contains_key("::rex"),
+            "an instance is not a class"
+        );
+    }
+
+    #[test]
+    fn a_factory_without_a_create_override_keeps_the_builtin_layout() {
+        // TP — no override means the inherited `oo::class` manufacturer
+        // runs, so `Meta create Name Body` has its body at argument 2 and
+        // splices no extra superclass.
+        let src = concat!(
+            "oo::class create Meta {\n",
+            "    superclass oo::class\n",
+            "}\n",
+            "Meta create Plain {\n",
+            "    method m {} { return 1 }\n",
+            "}\n",
+        );
+        let cd = class(src, "::Plain");
+        assert!(cd.methods.contains_key("m"), "{cd:?}");
+        assert!(cd.superclasses.is_empty(), "{cd:?}");
+        assert!(!cd.inheritance_unknown, "{cd:?}");
+    }
+
+    #[test]
+    fn oo_define_over_a_literal_foreach_list_extends_every_named_class() {
+        // TP — idx 55: the ticklecharts `etsb.tcl` monkey-patch.  Each
+        // literal element names a real class, so each gets the injected
+        // method; nothing lands under a synthetic `@dynclass@` key.
+        let src = concat!(
+            "oo::class create chart { method Render {} { return 1 } }\n",
+            "oo::class create timeline { method Render {} { return 1 } }\n",
+            "foreach cls {chart timeline} {\n",
+            "    oo::define $cls {\n",
+            "        method RenderTsb {} { return tsb }\n",
+            "    }\n",
+            "}\n",
+        );
+        let r = analysis(src, "tcl9.0");
+        for name in ["::chart", "::timeline"] {
+            assert!(
+                r.all_classes[name].methods.contains_key("RenderTsb"),
+                "{name} gained RenderTsb: {:?}",
+                r.all_classes[name].methods.keys().collect::<Vec<_>>()
+            );
+        }
+        assert!(
+            !r.all_classes.keys().any(|k| k.contains("@dynclass@")),
+            "no synthetic class survives: {:?}",
+            r.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn the_foreach_simulation_does_not_duplicate_body_diagnostics() {
+        // FP guard — the simulation re-dispatches only the named-definition
+        // installer, once per element.  A diagnostic raised inside the
+        // injected member's own body must still be reported exactly once
+        // per class it lands on, never once per (class × iteration).
+        let src = concat!(
+            "oo::class create chart { method Render {} { return 1 } }\n",
+            "oo::class create timeline { method Render {} { return 1 } }\n",
+            "foreach cls {chart timeline} {\n",
+            "    oo::define $cls {\n",
+            "        method RenderTsb {} { return $undefinedVar }\n",
+            "    }\n",
+            "}\n",
+        );
+        let spans: Vec<_> = analysis(src, "tcl9.0")
+            .diagnostics
+            .iter()
+            .map(|d| (d.code.to_string(), d.span))
+            .collect();
+        let mut seen = std::collections::HashSet::new();
+        for entry in &spans {
+            assert!(
+                seen.insert(entry.clone()),
+                "duplicate diagnostic {entry:?} in {spans:?}",
+            );
+        }
+    }
+
+    #[test]
+    fn oo_define_over_a_dynamic_list_still_abstains() {
+        // TN — the element list is a runtime value, so no class name is
+        // knowable and the members stay on a per-call-site synthetic key
+        // rather than being attributed to a guess.
+        let src = concat!(
+            "oo::class create chart { method Render {} { return 1 } }\n",
+            "foreach cls $classes {\n",
+            "    oo::define $cls {\n",
+            "        method RenderTsb {} { return tsb }\n",
+            "    }\n",
+            "}\n",
+        );
+        let r = analysis(src, "tcl9.0");
+        assert!(
+            !r.all_classes["::chart"].methods.contains_key("RenderTsb"),
+            "a runtime target must not be attributed to a literal class"
+        );
+        assert!(
+            r.all_classes.keys().any(|k| k.contains("@dynclass@")),
+            "the members land on a synthetic key: {:?}",
+            r.all_classes.keys().collect::<Vec<_>>()
+        );
+    }
+
+    #[test]
+    fn oo_define_resolves_a_dominating_constant_target() {
+        // TP — the narrowest form of the same fact: a target bound by a
+        // plain `set` that dominates the call extends the real class.
+        let src = concat!(
+            "oo::class create Widget {\n",
+            "    method real {} { return 1 }\n",
+            "}\n",
+            "set cls Widget\n",
+            "oo::define $cls method added {} { return 2 }\n",
+        );
+        let cd = class(src, "::Widget");
+        assert!(cd.methods.contains_key("real"), "{cd:?}");
+        assert!(cd.methods.contains_key("added"), "{cd:?}");
+    }
+
+    #[test]
+    fn static_brace_expansion_splices_a_member_signature() {
+        // TP — idx 53: `{*}` of a braced literal is spliced by the parser,
+        // so `method {*}{foo {} {…}}` defines a real `foo` (verified on
+        // tclsh 9.0.4 and 8.6.16, in both the `oo::class create` body and
+        // an `oo::define` body).
+        let src = concat!(
+            "oo::class create S {\n",
+            "    method {*}{foo {x} {return foo-$x}}\n",
+            "    constructor {*}{{a b} {return ctor}}\n",
+            "}\n",
+        );
+        let cd = class(src, "::S");
+        assert!(cd.methods.contains_key("foo"), "{cd:?}");
+        assert_eq!(cd.methods["foo"].params.len(), 1);
+        assert_eq!(cd.constructors.len(), 1, "{cd:?}");
+        assert_eq!(cd.constructors[0].params.len(), 2);
+    }
+
+    #[test]
+    fn static_brace_expansion_splices_in_an_oo_define_body_too() {
+        // TP — same mechanism through the `oo::define` body form.
+        let src = concat!(
+            "oo::class create S {}\n",
+            "oo::define S {\n",
+            "    method {*}{bar {} {return bar}}\n",
+            "}\n",
+        );
+        assert!(class(src, "::S").methods.contains_key("bar"));
+    }
+
+    #[test]
+    fn substituted_brace_expansion_still_abstains() {
+        // TN — `{*}[info class definition …]` reflects a signature whose
+        // words are only known at run time, so the member is left
+        // unrecorded rather than invented with wrong parameters or a body
+        // span pointing at the wrong text.
+        let src = concat!(
+            "oo::class create chart3D {\n",
+            "    constructor {*}[info class constructor chart]\n",
+            "    method options {*}[classDef chart options]\n",
+            "    method getType {} { return chart3D }\n",
+            "}\n",
+        );
+        let cd = class(src, "::chart3D");
+        assert!(cd.methods.contains_key("getType"), "{cd:?}");
+        assert!(!cd.methods.contains_key("options"), "{cd:?}");
+        assert!(cd.constructors.is_empty(), "{cd:?}");
+    }
+
+    #[test]
+    fn a_braced_variable_command_head_resolves_through_its_constant() {
+        // TP — idx 44: the head's *variable* is `ns`, not the whole token
+        // text `ns}::setdef` the lexer hands over for a braced composite
+        // word.  Reading the true source bytes makes the call resolve to
+        // the proc it really dispatches to (tclsh 9.0.4 / 8.6.16 both run
+        // `::tc::setdef`).
+        let src = concat!(
+            "namespace eval tc { proc setdef {a b} { return 1 } }\n",
+            "set ns tc\n",
+            "${ns}::setdef x y\n",
+        );
+        let resolved: Vec<String> = analysis(src, "tcl8.6")
+            .command_invocations
+            .iter()
+            .filter(|inv| inv.name.contains("${ns}"))
+            .filter_map(|inv| inv.resolved_qualified_name.clone())
+            .collect();
+        assert_eq!(resolved, ["::tc::setdef"]);
+    }
+
+    #[test]
+    fn a_resolved_braced_variable_head_is_a_reference_not_a_rename_target() {
+        // FP guard — the head's span is `${ns}::setdef`, which spells only
+        // the tail.  Rewriting that span with a new name would splice it
+        // over the substitution and corrupt the source (the idx 95 lesson),
+        // so the invocation is marked `indirect`: references report it,
+        // rename skips it.
+        let src = concat!(
+            "namespace eval tc { proc setdef {a b} { return 1 } }\n",
+            "set ns tc\n",
+            "${ns}::setdef x y\n",
+        );
+        let r = analysis(src, "tcl8.6");
+        let inv = r
+            .command_invocations
+            .iter()
+            .find(|inv| inv.name.contains("${ns}"))
+            .expect("the composite head is recorded");
+        assert!(inv.indirect, "{inv:?}");
+    }
+
+    #[test]
+    fn a_whole_word_variable_head_is_left_to_the_flow_sensitive_engine() {
+        // TN — `$cmd` is M7's shape, settled from the CFG/SSA value model
+        // rather than the walk's lexical map.  The walk must not
+        // pre-resolve it from a last-write-wins constant, or the two
+        // disagree about which sites are safe to rewrite.
+        let src = "proc target {} { return hi }\nset cmd target\n$cmd\n";
+        let r = analysis(src, "tcl8.6");
+        let inv = r
+            .command_invocations
+            .iter()
+            .find(|inv| inv.name == "${cmd}")
+            .expect("the variable head is recorded");
+        assert_eq!(
+            inv.resolved_qualified_name.as_deref(),
+            Some("::${cmd}"),
+            "the walk leaves this head unfolded for M7 to settle: {inv:?}",
+        );
+    }
+
+    #[test]
+    fn a_braced_variable_command_head_abstains_on_a_branch_binding() {
+        // TN — a head whose variable is written differently on two
+        // branches has no single dominating value, so resolution must not
+        // pin either one.
+        let src = concat!(
+            "namespace eval a { proc go {} { return 1 } }\n",
+            "namespace eval b { proc go {} { return 1 } }\n",
+            "set ns a\n",
+            "if {$cond} { set ns b }\n",
+            "${ns}::go\n",
+        );
+        let resolved: Vec<String> = analysis(src, "tcl8.6")
+            .command_invocations
+            .iter()
+            .filter(|inv| inv.name.contains("${ns}"))
+            .filter_map(|inv| inv.resolved_qualified_name.clone())
+            .collect();
+        assert_eq!(
+            resolved,
+            ["::${ns}::go"],
+            "an unresolved head stays as written"
+        );
+    }
+
+    #[test]
+    fn foreach_installed_procs_are_enumerated_per_literal_element() {
+        // Previously-fixed regression pin — idx 43 (the ticklecharts
+        // `etypes.tcl` ensemble).  The `foreach`-literal simulation landed
+        // for issue #923 idx 86 (PR #1020) and already covers `proc`, so
+        // every element's proc is registered under its real qualified
+        // name.  Pinned here so the idx 43 shape cannot regress.
+        let src = concat!(
+            "namespace eval ticklecharts {}\n",
+            "foreach ptype {elist elist.n elist.s} {\n",
+            "    proc ticklecharts::${ptype} {args} { return $args }\n",
+            "}\n",
+        );
+        let r = analysis(src, "tcl8.6");
+        for name in [
+            "::ticklecharts::elist",
+            "::ticklecharts::elist.n",
+            "::ticklecharts::elist.s",
+        ] {
+            assert!(
+                r.all_procs.contains_key(name),
+                "{name} registered: {:?}",
+                r.all_procs.keys().collect::<Vec<_>>()
+            );
+        }
+        assert!(
+            !r.all_procs.keys().any(|k| k.contains('$')),
+            "no proc is filed under the unsubstituted template: {:?}",
+            r.all_procs.keys().collect::<Vec<_>>()
+        );
+    }
+}

--- a/rust/tcl-compiler/tests/analyser.rs
+++ b/rust/tcl-compiler/tests/analyser.rs
@@ -4003,6 +4003,210 @@ mod class_factories {
         assert!(cd.methods.contains_key("m"), "{cd:?}");
     }
 
+    /// A factory whose `create` override composes the definition body as a
+    /// **string** — no nested command anywhere — yet really does inject a
+    /// superclass.  tclsh 9.0.4 and 8.6.16 both report `StrWidget supers:
+    /// ::StrBase` for this and run `[[StrWidget new] inherited]`.
+    const STRING_PROLOGUE_META: &str = concat!(
+        "oo::class create StrBase {\n",
+        "    method inherited {} { return inherited-ran }\n",
+        "}\n",
+        "oo::class create StrMeta {\n",
+        "    superclass oo::class\n",
+        "    self method create {name body} {\n",
+        "        next $name \"superclass StrBase\\n$body\"\n",
+        "    }\n",
+        "}\n",
+        "StrMeta create StrWidget {\n",
+        "    method own {} { return own-ran }\n",
+        "}\n",
+    );
+
+    /// The same shape with the override passing `$body` straight through —
+    /// nothing composed, nothing injected.  tclsh 9.0.4 / 8.6.16 report
+    /// only the implicit `::oo::object` for it, i.e. a genuinely empty
+    /// injection.
+    const DIRECT_BODY_META: &str = concat!(
+        "oo::class create PlainMeta {\n",
+        "    superclass oo::class\n",
+        "    self method create {name body} {\n",
+        "        next $name $body\n",
+        "    }\n",
+        "}\n",
+        "PlainMeta create PlainWidget {\n",
+        "    method own {} { return plain-own }\n",
+        "}\n",
+    );
+
+    #[test]
+    fn a_string_built_prologue_is_opaque_not_empty() {
+        // TP — the prologue injects `superclass StrBase` with no command
+        // substitution at all, so the scan finds nothing to read.  Claiming
+        // a *known-empty* injection would assert the class has no
+        // superclass and let W308 fire on every inherited method; the only
+        // sound answer is opaque.
+        let cd = class(STRING_PROLOGUE_META, "::StrWidget");
+        assert!(cd.inheritance_unknown, "{cd:?}");
+        assert!(
+            cd.methods.contains_key("own"),
+            "the class is still real: {cd:?}"
+        );
+    }
+
+    #[test]
+    fn an_opaque_prologue_suppresses_w308_on_inherited_methods() {
+        // TP (consumer) — `inherited` really runs on both interpreters, so
+        // no unknown-method warning may fire for it.
+        let src = concat!(
+            "oo::class create StrBase {\n",
+            "    method inherited {} { return inherited-ran }\n",
+            "}\n",
+            "oo::class create StrMeta {\n",
+            "    superclass oo::class\n",
+            "    self method create {name body} {\n",
+            "        next $name \"superclass StrBase\\n$body\"\n",
+            "    }\n",
+            "}\n",
+            "StrMeta create StrWidget {\n",
+            "    method own {} { return own-ran }\n",
+            "}\n",
+            "set w [StrWidget new]\n",
+            "$w inherited\n",
+        );
+        assert!(
+            !fires(src, "tcl9.0", "W308"),
+            "an unreadable prologue must abstain: {:?}",
+            codes(src, "tcl9.0")
+        );
+    }
+
+    #[test]
+    fn a_provably_direct_body_still_yields_a_known_empty_injection() {
+        // TN — `next $name $body` composes nothing, so the injection is
+        // known-empty and the class's inheritance is fully known.  This is
+        // the half that must *not* become opaque, or the abstention above
+        // would cost every precise diagnostic on a factory-made class.
+        let cd = class(DIRECT_BODY_META, "::PlainWidget");
+        assert!(!cd.inheritance_unknown, "{cd:?}");
+        assert!(cd.superclasses.is_empty(), "{cd:?}");
+        assert!(cd.methods.contains_key("own"), "{cd:?}");
+    }
+
+    #[test]
+    fn a_provably_direct_body_keeps_method_checks_live() {
+        // FN guard — the known-empty case must stay precise: a method that
+        // exists nowhere on the class still warns.
+        let src = concat!(
+            "oo::class create PlainMeta {\n",
+            "    superclass oo::class\n",
+            "    self method create {name body} {\n",
+            "        next $name $body\n",
+            "    }\n",
+            "}\n",
+            "PlainMeta create PlainWidget {\n",
+            "    method own {} { return plain-own }\n",
+            "}\n",
+            "set w [PlainWidget new]\n",
+            "$w nosuchmethod\n",
+        );
+        assert!(
+            fires(src, "tcl9.0", "W308"),
+            "a known-empty injection keeps method checks live: {:?}",
+            codes(src, "tcl9.0")
+        );
+    }
+
+    #[test]
+    fn a_relative_superclass_reaches_the_metaclass_in_its_own_namespace() {
+        // TP — `::n::DerivedMeta` declares `superclass Meta`, which Tcl
+        // resolves in the declaring class's own namespace: tclsh 9.0.4 /
+        // 8.6.16 both report `info class superclasses ::n::DerivedMeta` =
+        // `::n::Meta`, and `::n::DerivedMeta create ::NsWidget {…}` really
+        // makes a class.  Looking only at `Meta` / `::Meta` missed it.
+        let src = concat!(
+            "namespace eval ::n {\n",
+            "    oo::class create Meta {\n",
+            "        superclass oo::class\n",
+            "        self method create {name body} { next $name $body }\n",
+            "    }\n",
+            "    oo::class create DerivedMeta {\n",
+            "        superclass Meta\n",
+            "    }\n",
+            "}\n",
+            "::n::DerivedMeta create ::NsWidget {\n",
+            "    method nsown {} { return ns-own }\n",
+            "}\n",
+        );
+        let cd = class(src, "::NsWidget");
+        assert!(cd.methods.contains_key("nsown"), "{cd:?}");
+    }
+
+    #[test]
+    fn a_relative_superclass_prefers_its_own_namespace_over_a_decoy() {
+        // TN (cross-link guard, the #1063 precedent) — a same-tailed class
+        // in an unrelated namespace must not be picked when the declaring
+        // namespace has its own.  Here `::other::Meta` is a plain class and
+        // `::n::Meta` is the real metaclass; picking the decoy would leave
+        // `::NsWidget` unrecorded.
+        let src = concat!(
+            "namespace eval ::other {\n",
+            "    oo::class create Meta {\n",
+            "        method notafactory {} { return 1 }\n",
+            "    }\n",
+            "}\n",
+            "namespace eval ::n {\n",
+            "    oo::class create Meta {\n",
+            "        superclass oo::class\n",
+            "        self method create {name body} { next $name $body }\n",
+            "    }\n",
+            "    oo::class create DerivedMeta {\n",
+            "        superclass Meta\n",
+            "    }\n",
+            "}\n",
+            "::n::DerivedMeta create ::NsWidget {\n",
+            "    method nsown {} { return ns-own }\n",
+            "}\n",
+        );
+        assert!(class(src, "::NsWidget").methods.contains_key("nsown"));
+    }
+
+    #[test]
+    fn a_relative_superclass_does_not_cross_link_to_another_namespace() {
+        // TN — the declaring namespace's own `Meta` is an ordinary class,
+        // so the chain ends there.  Reaching sideways into `::other::Meta`
+        // (which *is* a metaclass) would manufacture a class creation real
+        // Tcl never performs — `::n::Meta` shadows it from `::n`.
+        let src = concat!(
+            "namespace eval ::other {\n",
+            "    oo::class create Meta {\n",
+            "        superclass oo::class\n",
+            "        self method create {name body} { next $name $body }\n",
+            "    }\n",
+            "}\n",
+            "namespace eval ::n {\n",
+            "    oo::class create Meta {\n",
+            "        method notafactory {} { return 1 }\n",
+            "    }\n",
+            "    oo::class create DerivedMeta {\n",
+            "        superclass Meta\n",
+            "    }\n",
+            "}\n",
+            "::n::DerivedMeta create ::NsWidget {\n",
+            "    method nsown {} { return ns-own }\n",
+            "}\n",
+        );
+        assert!(
+            !analysis(src, "tcl9.0")
+                .all_classes
+                .contains_key("::NsWidget"),
+            "a non-factory chain must not manufacture a class: {:?}",
+            analysis(src, "tcl9.0")
+                .all_classes
+                .keys()
+                .collect::<Vec<_>>(),
+        );
+    }
+
     #[test]
     fn an_ordinary_class_is_not_treated_as_a_factory() {
         // TN — `Dog` is a plain class, so `Dog create rex` makes an

--- a/rust/tcl-registry/src/commands/tcl/oo_define.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_define.rs
@@ -276,7 +276,10 @@ pub(crate) fn collect_property_body_roles(args: &[&str], start: usize) -> Vec<(u
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "oo::define",
-        traits: Traits::NOT_PROC_FACTORY | Traits::LANGUAGE_KEYWORD | Traits::NEVER_INLINE_BODY,
+        traits: Traits::NOT_PROC_FACTORY
+            | Traits::LANGUAGE_KEYWORD
+            | Traits::INSTALLS_NAMED_DEFINITION
+            | Traits::NEVER_INLINE_BODY,
         dialects: Some(DialectSet::TCL86_PLUS),
         arity: Arity::at_least(2),
         arg_roles: &[(0, ArgRole::Name)],

--- a/rust/tcl-registry/src/commands/tcl/oo_objdefine.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_objdefine.rs
@@ -127,7 +127,10 @@ use super::oo_define::oo_define_arg_roles;
 pub fn spec() -> CommandSpec {
     CommandSpec {
         name: "oo::objdefine",
-        traits: Traits::NOT_PROC_FACTORY | Traits::LANGUAGE_KEYWORD | Traits::NEVER_INLINE_BODY,
+        traits: Traits::NOT_PROC_FACTORY
+            | Traits::LANGUAGE_KEYWORD
+            | Traits::INSTALLS_NAMED_DEFINITION
+            | Traits::NEVER_INLINE_BODY,
         dialects: Some(DialectSet::TCL86_PLUS),
         arity: Arity::at_least(2),
         // `oo::objdefine` has the same body-shape rules as

--- a/rust/tcl-registry/src/commands/tcl/proc_.rs
+++ b/rust/tcl-registry/src/commands/tcl/proc_.rs
@@ -61,6 +61,7 @@ pub fn spec() -> CommandSpec {
         name: "proc",
         dialects: Some(DialectSet::ALL_TCL),
         traits: Traits::NOT_PROC_FACTORY
+            | Traits::INSTALLS_NAMED_DEFINITION
             | Traits::BYTE_COMPILED
             | Traits::LANGUAGE_KEYWORD
             | Traits::DEFINES_PROCEDURE

--- a/rust/tcl-registry/src/commands/tcl/rename_.rs
+++ b/rust/tcl-registry/src/commands/tcl/rename_.rs
@@ -87,7 +87,10 @@ pub fn spec() -> CommandSpec {
         // deletes the command outright) and errors when `oldName` doesn't
         // exist — the property the W302 fire-and-forget suppression
         // (`catch {rename foo ""}`) keys off.
-        traits: Traits::BYTE_COMPILED | Traits::LANGUAGE_KEYWORD | Traits::FIRE_AND_FORGET_TEARDOWN,
+        traits: Traits::BYTE_COMPILED
+            | Traits::LANGUAGE_KEYWORD
+            | Traits::INSTALLS_NAMED_DEFINITION
+            | Traits::FIRE_AND_FORGET_TEARDOWN,
         arity: Arity::exact(2),
         arg_roles: &[(0, ArgRole::Name), (1, ArgRole::Name)],
         return_type: Some(TclType::String),

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -806,6 +806,29 @@ declare_traits! {
     /// b }` calls `::helper`, never the `::foo::helper` sitting in the
     /// enclosing namespace.
     EvaluatesInShiftedFrame => EVALUATES_IN_SHIFTED_FRAME;
+
+    /// Installs, moves, or extends a **named definition** whose target is
+    /// named by an [`crate::arg_role::ArgRole::Name`] argument word —
+    /// `proc`, `rename`, `oo::define`, `oo::objdefine`.  Every one of them
+    /// re-reads that word on every execution, so running the *same written
+    /// command* twice with a different value bound to the substitution in
+    /// it defines two different things.
+    ///
+    /// The analyser consults this when it simulates a
+    /// literal-list `foreach`'s remaining iterations
+    /// (`tcl_compiler::analyser::Analyser::handle_foreach_command`): the
+    /// loop variable takes a different concrete value each time round, so
+    /// exactly the commands carrying this trait have to be re-dispatched
+    /// per element to see the whole set of names the loop installs —
+    /// `foreach t {A B} { oo::define $t { … } }` extends both `A` and `B`
+    /// (issue #923 idx 55/86).  Every *other* command in the body keeps the
+    /// single evaluation the ordinary walk gave it, so the simulation
+    /// cannot duplicate diagnostics or scope entries.
+    ///
+    /// Not carried by commands that merely *shift context* by name
+    /// (`namespace eval`, `coroutine`): re-running those would re-walk a
+    /// body, which is what the narrowness above rules out.
+    InstallsNamedDefinition => INSTALLS_NAMED_DEFINITION;
 }
 
 /// Every trait that widens a file's caller set beyond the file itself — the

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -482,6 +482,10 @@ pub const TRAITS: &[Variant] = &[
         "EVALUATES_IN_SHIFTED_FRAME",
         "runs its body script in another stack frame",
     ),
+    v(
+        "INSTALLS_NAMED_DEFINITION",
+        "installs, moves, or extends a definition named by an argument",
+    ),
 ];
 
 /// [`TaintColour`] bits.


### PR DESCRIPTION
## Summary

Issue-923 audit cluster C3 — classes made by class factories (Tk megawidget metaclasses, ticklecharts-style installers) are no longer invisible. All recognition is registry data; oracle-verified on tclsh 9.0.4 + 8.6.16 (identical transcripts, committed in test docs).

- **idx 96/97 — metaclass-manufactured classes.** Metaclass-ness now propagates down the recorded superclass chain (`IS_OO_METACLASS` + the TclOo grammar stays the seed). The manufacturer's word layout is *read* off its own `create` override's `next` call (via `MethodDispatchKind::NextChain`), so Tk's `{name superclasses body}` shape resolves without naming any command; prologue-injected members (`[list superclass … {*}$superclasses]`, recognised via `PRODUCES_CANONICAL_LIST` + the grammar's all-args set) are resolved against the call's own arguments through `apply_oo_subcommand`. An unreadable override sets a new `ClassDef::inheritance_unknown`, wired into `has_external_super_or_mixin` so W308 abstains instead of guessing.
- **idx 55 — foreach-driven installers.** `handle_oo_define_command` folds its target through the dominating-constant resolver, and `simulate_remaining_foreach_iterations` is generalised from a hardcoded `"rename"`/`"proc"` match to the new registry trait `INSTALLS_NAMED_DEFINITION` (`proc`, `rename`, `oo::define`, `oo::objdefine`). O(elements × body-commands), no fixpoint.
- **idx 53 — `{*}`-expanded member signatures.** Braced-literal `{*}` words splice statically into the member grammar with per-element real source spans; `{*}` over a substitution has no knowable element list and abstains (both directions oracle-pinned, including the `oo::class create` and `oo::define` body forms).
- **idx 44 — wrong source bytes in dynamic heads.** The lexer's merged composite `Var` token (`ns}::setdef`) is truncated at the brace it left in place (the same rule the W307 site already used) and folded on the dominating-constant lattice before `resolve_command_qualified_name`. Folded heads are marked `indirect` — references report them, rename skips them (the idx-95 corruption class); whole-word `$cmd` heads stay with the flow-sensitive engine so the two never disagree.
- **idx 43 — previously fixed** by the #1020 foreach-literal simulation; verified on current rust and pinned rather than re-fixed.

Two pre-existing guards asserting that `set class Widget; oo::define $class …` stays unresolved were re-pointed at genuinely-dynamic (parameter-bound) targets — tclsh contradicts the old assertion, and that shape now correctly resolves.

**Known limits (documented in the KCS note):** dynamic `{*}[info class constructor …]` reflection abstains by design; `[self class]` folding (idx 44's real-corpus form) and `self method` outline entries are separate gaps, untouched.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-compiler -p tcl-registry` — 8,068 tests / 71 suites, green (clean rebuild after a mid-session ENOSPC, per AGENTS.md).
  - `cargo test -p tcl-lsp-core` — 2,255 tests green (class_lattice, W307/W308, document symbols, references/rename consumers); `cargo test -p tcl-spec-studio` — green (traits catalogue drift gate covers the new trait).
  - lsp_e2e — 1,089 passing; four parallel-run latency flakes all pass serially (pre-existing load sensitivity).
  - `cargo clippy --workspace --all-targets` — clean, **zero new allows** (five lints introduced en route were fixed, not allowed).
  - `cargo fmt --all --check`, `cargo xtask gen-editor-settings --check`, `command-backing --check` — clean.
  - New `class_factories` test module: 19 TP/TN cases including rename-safety FP guard and duplicate-diagnostic guard.
  - Oracle scripts for idx 96/53/55 committed transcripts from tclsh 9.0.4 and 8.6.16.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — factory-manufactured classes now populate the class model; W308 gains the `inheritance_unknown` abstention; foreach-installer simulation is trait-driven.
- [x] I updated at least one relevant KCS note: new `docs/kcs/kcs-issue-classes-made-by-a-class-factory-are-invisible.md` (7 decision rules, failure modes, test anchors), indexed in `docs/kcs/README.md`; audit `STATUS.md` §6b ticked (36 fixed / 49 remaining).
- [x] New compiler KCS note linked from `docs/kcs/README.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_