### PR TITLE
Navigation survives command-table mutation: rename/alias hops, redefinition order, namespace code unwrap (#1064, audit idx 5/21/45/89/92)

### DIFF
--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -789,10 +789,38 @@ analyser's constructor typing already used
 factored into `tcl-compiler/src/analyser/indirection.rs` and consumed by
 both the diagnostics and the LSP's navigation providers, so the two cannot
 drift. Regression coverage is
-`rust/tcl-lsp-core/tests/command_table_mutation.rs` (19 TP/TN cases), unit
+`rust/tcl-lsp-core/tests/command_table_mutation.rs` (31 TP/TN cases), unit
 tests in `analyser/indirection.rs`, W123/E00x cases in
 `analyser/diagnostics/tests.rs`, and nine new
 `rust/tcl-lsp-server/tests/e2e/{definition,references,rename}.rs` cases.
+
+**Codex review of PR #1075 (P2 × 4)** hardened the ordering model into one
+shape — *a command name is a slot whose timeline is queried at (offset,
+context)* — after the first cut got three ordering/identity subtleties
+wrong. (1) A name carrying both a `rename` and an `interp alias` record was
+resolved by whichever map the code read first, not by which statement ran
+last (oracle, 9.0.4/8.6.14: `rename a x` then `interp alias {} x {} b` makes
+`x` return `B`); `indirection::latest_binding` now picks the later of the
+two in-effect bindings. (2) A `rename` hands over the command **object**, so
+the terminal name has to be read as of the *rename*, not the call — `proc p`
+/ `rename p oldp` / `proc p` leaves `oldp` running the first definition and
+`p` the second; `Indirection::resolve_at` carries that as-of time, and the
+reverse index (`names_reaching` → `Reaching`) carries it back so a reference
+query cannot merge two commands' sites (or double the survivor's lens
+count). An alias, which re-resolves by name at every invocation, keeps the
+call site's own offset as its as-of time. (3) The load-before-body shortcut
+stopped at nothing; it now stops at the executing body's own edge, so a
+`proc` or `rename` that is a *statement of that body* stays order-gated by
+offset (`proc outer {} { proc p …; p; proc p {a} … }` reaches the first),
+while a declaration outside it is still unconditionally in effect. The
+fourth P2 — a `[namespace code Tracer]` bareword callback double-recorded —
+**did not reproduce**: measured, the analyser's bareword-`Body` dispatch does
+not descend into a `[…]` substitution, so excluding that shape drops the
+callback's reference count from 1 to 0. The braced shape *is* the
+double-count risk the review identified, and was already guarded; the
+review's requested code-lens count test
+(`tp_lens_counts_each_namespace_code_callback_shape_once`) now pins all
+three shapes at one reference each.
 
 | idx | what was wrong | what changed |
 |---|---|---|

--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -112,7 +112,9 @@ idx 70 (high, §3's `d5e4d65`), idx 71 (high, §3's `2339d4a`), idx 76
 (high, §3's `0bde16e`), idx 77 (high, §3's `51a630f`), idx 84 (high,
 partial — §3's `7115bc8`), idx 86 (high, §3's `99cf07f`), idx 90 (high,
 §3's `7d476f5`), idx 95 (high, §3's `ef36c73`), idx 94 (high, §3's
-`959bca8`); the other 61
+`959bca8`); later sessions took that to **38 fixed** (PR A3's six plus
+idx 81 re-verified; PR #1071's idx 3/4/11; PR B1's idx 5/21/45/89/92 — see
+§6b for each). The other 47
 main-wave findings are clustered by feature/root-cause with a
 priority-ordered table in
 §6b, ready for a future session to pick up efficiently. Nothing
@@ -474,6 +476,15 @@ mathfunc-aware W123 / W002 work that landed on `rust` after the audit ran
 (`is_mathfunc_call` + `is_known_mathfunc_in_dialect`) and is counted with
 them. That makes **30 fixed, 55 remaining**.
 
+**2026-07-30 update — PR #1071 and PR B1
+(`claude/commandregistry-compiler-fixes-tshu8d-cmdtable`) fixed eight more,
+all tier 2:** idx 3, idx 4, and idx 11 landed in **PR #1071** (tcllib
+`textutil` submodule registry keys + W113 package-gating) — that PR's own
+tracker commit was deliberately dropped, so their rows are ticked here
+instead. idx 5, idx 21, idx 45, idx 89, and idx 92 are **PR B1**, the
+command-table-mutation cluster — see the "tier-2 findings fixed by PR B1"
+subsection after the tier-2 table. That makes **38 fixed, 47 remaining**.
+
 **By corpus** (confirmed only): ticklecharts 20, tk 17, argparse 10,
 SpiceGenTcl 10, tclopt 13 (6+7, split across two inconsistent corpus-label
 strings in the raw data — same corpus), tomato 7, pix 8.
@@ -686,7 +697,7 @@ users, a worse failure mode than the narrower, but fully oracle-grounded,
 `CONFIGURE`-tracking fix actually shipped. Left as a documented, low-risk
 follow-up for a session with Tk oracle access.
 
-#### Priority tier 2 — medium + low (60 + 1 = 61 findings, 1 already fixed), grouped by feature for clustering
+#### Priority tier 2 — medium + low (60 + 1 = 61 findings, 15 now fixed — 46 remaining), grouped by feature for clustering
 
 Group findings sharing a feature/root-cause together in one fix pass the
 way idx 107+115 and idx 118+119 were — many of these look like they share
@@ -697,16 +708,16 @@ mixin/oo::configurable class-scoping findings, idx 34/36).
 | feature | count | idx (severity) |
 |---|---|---|
 | tclOO | 10 | 15, 16, 34, 35, 36, 53, ~~54~~ **FIXED**, 55, 96, 97 (all medium) |
-| namespaces | 8 | 3, 19, 43, 44, 64, 65, 75, 85 (all medium) |
+| namespaces | 8 | ~~3~~ **FIXED** (#1071), 19, 43, 44, 64, 65, 75, 85 (all medium) |
 | tricky_indirection | 7 | 0 (medium, **FIXED** — see below), 1, 2, 14, 49, 50, 51 (all medium) |
 | upvar | 7 | 7, 22, 57, 58, 59, 98, 99 (all medium) |
-| proc_args | 7 | 11, 28, 37, 62, 67, 78, ~~104~~ **FIXED** (all medium) |
+| proc_args | 7 | ~~11~~ **FIXED** (#1071), 28, 37, 62, 67, 78, ~~104~~ **FIXED** (all medium) |
 | tcl_mathop | 4 | ~~30~~ **FIXED**, 80, ~~81~~ **ALREADY FIXED**, ~~103~~ **FIXED** (all medium) |
-| package_loading | 3 | 4, 42, 72 (all medium) |
+| package_loading | 3 | ~~4~~ **FIXED** (#1071), 42, 72 (all medium) |
 | source | 3 | 27, 41, 102 (all medium) |
-| tracing | 3 | 47, ~~48~~ **FIXED**, 92 (all medium) |
-| rename | 2 | 5, 45 (all medium) |
-| aliasing | 2 | 21, 89 (all medium) |
+| tracing | 3 | 47, ~~48~~ **FIXED**, ~~92~~ **FIXED** (PR B1) (all medium) |
+| rename | 2 | ~~5~~ **ALREADY FIXED** (pinned, PR B1), ~~45~~ **FIXED** (PR B1) (all medium) |
+| aliasing | 2 | ~~21~~ **FIXED** (PR B1), ~~89~~ **FIXED** (PR B1) (all medium) |
 | uplevel | 2 | 38 (medium), 100 (low) |
 | eval | 1 | ~~24~~ **FIXED** (medium) |
 | autoindex | 1 | 73 (medium) |
@@ -766,6 +777,30 @@ plus new `rust/tcl-lsp-server/tests/e2e/{hover,completion}.rs` cases.
 | 81 (tcl_mathop) | Every built-in `expr` math function drew a false `W123 Unknown command`, several with actively-wrong "did you mean" fixes. | **Already fixed** on `rust` after the audit ran: `SignatureCommandInvocation::is_mathfunc_call` plus `is_known_mathfunc_in_dialect` gate the W123 check. Verified, not re-fixed. |
 | 103 (tcl_mathop) | Zero `CommandSpec` entries for `tcl::mathfunc::*`, so the generic per-dispatch-site W002 availability check was blind to the plain-command spelling. | The registry data (`tcl-registry/src/commands/tcl/mathfunc_generated.rs`) **already landed** on `rust`. What PR A3 adds is the query layer the LSP needed on top of it — `tcl-registry/src/mathfunc.rs` — and a test pinning that both qualified spellings exist and gate correctly (`isinf` 9.0+, the command table itself 8.5+ per TIP 232). |
 | 104 (proc_args) | A proc parameter's own name token and its **default-value literal** both resolved to an unrelated same-named command (`{destroy destroy}` in `tk.tcl`'s `::tk::RestoreFocusGrab` showed Tk's `destroy` documentation). | The name token was already answered by idx 9's declaration-offset search; the remaining data words are now guarded generally by `definition::parameter_list_position_at`, consulted by both hover and go-to-definition. A *literal* parameter list holds no command references at all, so the guard needs no per-command knowledge. **Codex review of PR #1073 (P2)** narrowed it from the whole name-token-to-body region to the actual literal parameter-list **word**: `proc`'s parameter list is an ordinary Tcl word and may be computed (`proc p [makeargs] {…}` runs `[makeargs]` at definition time — oracle-confirmed on 9.0.4 and 8.6.16, as are the `$params` and `"m n"` forms), so a word containing `$` / `[` / `"` / a backslash escape stays navigable. A computed list also suppresses the bareword-*declaration* step, because the analyser records a stub `VarDef` named after the whole word (`"[makeargs]"`) that would otherwise make go-to-definition point at the cursor's own token instead of resolving the call. |
+
+#### Tier-2 findings fixed by PR B1 (2026-07-30)
+
+Landed together on
+`claude/commandregistry-compiler-fixes-tshu8d-cmdtable` alongside issue
+#1064 and issue #1062's deferred B1/B2, because all five share one theme:
+**navigation must survive command-table mutation**. The hop walk the
+analyser's constructor typing already used
+(`diagnostics::var_command::class_reachable_by_indirection`, PR #1062) is
+factored into `tcl-compiler/src/analyser/indirection.rs` and consumed by
+both the diagnostics and the LSP's navigation providers, so the two cannot
+drift. Regression coverage is
+`rust/tcl-lsp-core/tests/command_table_mutation.rs` (19 TP/TN cases), unit
+tests in `analyser/indirection.rs`, W123/E00x cases in
+`analyser/diagnostics/tests.rs`, and nine new
+`rust/tcl-lsp-server/tests/e2e/{definition,references,rename}.rs` cases.
+
+| idx | what was wrong | what changed |
+|---|---|---|
+| 5 (rename) | `rename OLD NEW` never checked that `OLD` resolves to a known command, so a guaranteed tclsh abort (`can't rename "X": command doesn't exist`, `can't delete "X": …`) produced no diagnostic at all. | **Already fixed** on `rust` by idx 39's work (`handle_rename` records `OLD`'s own token as an ordinary `SignatureCommandInvocation`, which feeds W123). Re-verified against tclsh 9.0.4 and 8.6.16 for both the delete and the alias form, and pinned with four TP/TN regression tests; not re-fixed. |
+| 21 (aliasing) | `references()` never consulted `analysis.command_aliases` in either direction: a proc's reference set omitted every call site spelled through a live `interp alias`, and the alias name itself had no navigable reference set. | `proc_reference_spans` / `class_reference_spans` now union in `indirection::names_reaching` — every name whose in-effect chain terminates on the definition — and `resolve_proc_target_at` hops forward, so a query from either spelling answers one unified set. Order-gated per call site, so a call written before the alias is not attributed. Deliberately **not** wired into `invocation_references_proc`/`_class`, so rename still leaves the alias's own call sites alone (they spell a different command's name) — the same split the wildcard-import fallback already uses. |
+| 45 (rename) | `all_procs.insert` clobbered on self-redefinition, so the displaced definition's span and parameter list vanished: go-to-definition from a call *between* two declarations jumped to the later header, and a genuine `wrong # args` against the first signature went unreported. | New `AnalysisResult::superseded_procs` keeps the displaced `ProcDef`s (empty for every document without a redefinition), with `proc_declarations` / `proc_def_in_effect_at` as the order-gated queries — the `proc` analogue of `rename_offsets`/`alias_offsets`. `definition()` resolves the in-effect definition, the arity resolver checks the in-effect signature, and `UserResolutionFacts::proc_offsets` now records the *earliest* declaration so the shadowing suppression is order-correct too. The cross-document declaration test was already handled by idx 31. |
+| 89 (aliasing) | `definition()` resolved a call to a same-named proc that an `interp alias` had already replaced (the real `tk/library/accessibility.tcl` `interp alias {} ::ttk::spinbox {} ::tk::spinbox` trick), because the alias fallback sat *after* the proc resolution and was unreachable. | The indirection hop is now one uniform tier asked **before** the ordinary call resolution, covering `rename` and `interp alias`, procs and classes alike (`indirect_definition_target`, plus the hop inside `resolve_proc_target_at` / `resolve_class_target_at`). Order-gating keeps the pre-mutation call resolving the ordinary way, in-document and — via `definition::indirection_pending_at`, consulted by the server's `resolve_workspace_symbols` — through the position-free workspace index too. The trailing ungated alias fallback is gone. |
+| 92 (tracing) | `[namespace code [list Handler]]` in a command-prefix slot (Tk's own `fontchooser.tcl` uses it ten times) recorded nothing, so find-references / rename / call-hierarchy / code-lens silently dropped every such callback site. | New `Traits::WRAPS_COMMAND_PREFIX`, set on the `namespace code` **subcommand**: the value it returns is itself a command prefix. `extract_wrapped_prefix_head` unwraps exactly one level — the wrapping command's own `ArgRole::Body` word — and re-runs the ordinary extraction on it, so the `[list X a]`, bareword, and (already-covered) braced shapes all work through one rule with no command name in the walker. A braced wrapped word is skipped, since the analyser already walks it as a script and recording it twice would double-count the site. |
 
 ### 6c. Broader mandate coverage check
 
@@ -864,14 +899,15 @@ just no longer the primary "what's left" pointer.
 4. Pick the next finding to fix — two ready queues, both fully triaged:
    - §6a: 2 remaining tcllib findings (idx 128/24), no
      refined plan for either — use `07`'s `root_cause_hint` directly.
-   - §6b: 62 remaining main-wave findings (idx 61, idx 9, idx 10, idx 18,
-     idx 29, idx 31, idx 32, idx 33, idx 39, idx 46, idx 52, idx 56, idx
-     63, idx 68, idx 70, idx 71, idx 76, idx 77, idx 84, idx 86, idx 90,
-     idx 95, and idx 94 are fixed — idx 46, idx 63, and idx 84 only
-     partially, see their §3/§6b rows for what's still open — so far),
+   - §6b: 47 remaining main-wave findings (38 fixed so far — the tier-1
+     set idx 61/9/10/18/29/31/32/33/39/46/52/56/63/68/70/71/76/77/84/86/
+     90/94/95 plus idx 0, and the tier-2 set idx 24/30/48/54/81/103/104
+     (PR A3), idx 3/4/11 (PR #1071), idx 5/21/45/89/92 (PR B1) — idx 46,
+     idx 63, and idx 84 only partially, see their §3/§6b rows for what's
+     still open),
      fully triaged into a
      priority-ordered critical/high table (1 remaining, start here) and a feature-clustered medium/low
-     table (61 findings, group by feature when fixing). Likely the
+     table (46 remaining, group by feature when fixing). Likely the
      higher-leverage queue given its size and the presence of several
      zero-results go-to-definition/references failures on common
      real-world idioms.
@@ -916,7 +952,7 @@ just no longer the primary "what's left" pointer.
    confirm byte-for-byte what actually landed matches local before trusting
    it (see idx 95's `7953d5e`/`ef36c73` commits and the surrounding
    session transcript for the full story — it worked, but took real care).
-7. Both queues (§6a's 2 tcllib findings, §6b's 62 main-wave findings) are
+7. Both queues (§6a's 2 tcllib findings, §6b's 47 main-wave findings) are
    independent — fix from whichever queue makes sense, no need to exhaust
    one before starting the other. Keep this document's counts current as
    findings get fixed: move a finished idx out of §6a/§6b's tables and into

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -34,14 +34,26 @@ replaced it. Both are order-gated: a call written *before* the `rename` or
 `interp alias` still resolves the ordinary way (or, if nothing else defines
 it, not at all), which is what real Tcl does. A call inside a proc or class
 body sees every one of the file's renames and aliases regardless of where
-they are written, because the whole file loads before any body runs. An
-alias that binds leading arguments (`interp alias {} c {} target extra`) is
-not the same call, so Go to Definition abstains rather than pointing at a
-signature that does not describe it.
+they are written, because the whole file loads before any body runs — but
+only those written *outside* that body. A `rename` or `proc` that is itself
+a statement of the body being read is an ordinary statement of the running
+script, so it counts only from where it is written onward, exactly as at the
+top level. An alias that binds leading arguments (`interp alias {} c {}
+target extra`) is not the same call, so Go to Definition abstains rather
+than pointing at a signature that does not describe it.
+
+When a name carries both a `rename` and an `interp alias`, the one written
+**later** is what the call reaches — an alias silently replaces whatever the
+name held, and so does a rename.
 
 A proc declared twice in one file is two definitions of one command. A call
 between the two jumps to the **first** header, a call after both jumps to
 the second, and a cursor on either header stays on that header.
+
+A `rename` moves the command **object**, so it splits a redefined name into
+two genuinely different commands: after `proc p …`, `rename p oldp`, `proc p
+…`, the name `oldp` jumps to the *first* header — a later `proc p` cannot
+change what `oldp` runs — while `p` jumps to the second.
 
 A `TclOO` member name written as a bare word inside a class body is only a
 jump target when it really is one: the cursor must sit on the member's own

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -26,6 +26,23 @@ Resolves proc calls, variable references, namespace-qualified names, and BIG-IP 
 - `server/features/definition.py`
 - `analyser/proc_lookup.py`
 
+Go to Definition follows the **command table as it stands where the cursor
+is**, not merely how the word is spelled. A `rename OLD NEW` makes `NEW`
+jump to `OLD`'s declaration; an `interp alias {} NAME {} TARGET` makes
+`NAME` jump to `TARGET`, even when a same-named proc exists — the alias has
+replaced it. Both are order-gated: a call written *before* the `rename` or
+`interp alias` still resolves the ordinary way (or, if nothing else defines
+it, not at all), which is what real Tcl does. A call inside a proc or class
+body sees every one of the file's renames and aliases regardless of where
+they are written, because the whole file loads before any body runs. An
+alias that binds leading arguments (`interp alias {} c {} target extra`) is
+not the same call, so Go to Definition abstains rather than pointing at a
+signature that does not describe it.
+
+A proc declared twice in one file is two definitions of one command. A call
+between the two jumps to the **first** header, a call after both jumps to
+the second, and a cursor on either header stays on that header.
+
 A `TclOO` member name written as a bare word inside a class body is only a
 jump target when it really is one: the cursor must sit on the member's own
 declaration, or on a bare word that `link` (Tcl 9.0's `oo::Helpers::link`)

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -34,6 +34,23 @@ Triggering from the classmethod's own bare dispatch site (not just its declarati
 
 A class is found through every use of its name, not only `<Class> new` instantiations: a `superclass`, `mixin`, or `[incr Tcl]` `inherit` argument that names the class is a reference to it, and a `forward` member's delegated command is a reference to that command. These references are resolved by the class's namespace exactly as a call would be, so a fully-qualified `superclass ::ns::Base` in one file is found from `::ns::Base`'s declaration in another, and a same-named class in an unrelated namespace is never cross-linked. Because the same references drive rename, renaming a class rewrites every `superclass` / `mixin` / `inherit` site that names it, keeping the inheritance graph intact.
 
+A command reached through a **mutated command table** is found too. An
+`interp alias {} sayHi {} greet` makes every `sayHi` call a real call site of
+`greet`, and a `rename greet hello` makes every later `hello` one, so both
+appear in `greet`'s reference set — and a query started from the alias or the
+renamed-to name answers the same unified set. Both directions are order-gated:
+a call written before the `interp alias` or `rename` is not attributed to the
+target, matching Tcl, where it raises `invalid command name`. Rename
+deliberately does **not** rewrite those call sites — they spell a *different*
+command's name, which keeps its own spelling when the target is renamed.
+
+A callback wrapped for its namespace — `trace add variable v w [namespace
+code [list Handler]]`, the idiom Tk's own `fontchooser.tcl` uses — is a
+reference to `Handler`, in the `[list …]`, braced, and bareword forms alike.
+
+A proc declared twice in one file is one command with two headers: a query
+from either header returns the same set.
+
 ## Example
 
 ```tcl

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -42,14 +42,22 @@ renamed-to name answers the same unified set. Both directions are order-gated:
 a call written before the `interp alias` or `rename` is not attributed to the
 target, matching Tcl, where it raises `invalid command name`. Rename
 deliberately does **not** rewrite those call sites — they spell a *different*
-command's name, which keeps its own spelling when the target is renamed.
+command's name, which keeps its own spelling when the target is renamed. When
+a name carries both a `rename` and an `interp alias`, the one written later is
+the one whose call sites are attributed.
 
 A callback wrapped for its namespace — `trace add variable v w [namespace
 code [list Handler]]`, the idiom Tk's own `fontchooser.tcl` uses — is a
 reference to `Handler`, in the `[list …]`, braced, and bareword forms alike.
+Each such callback counts once, so the reference lens above the declaration
+reads the same number Find All References opens.
 
 A proc declared twice in one file is one command with two headers: a query
-from either header returns the same set.
+from either header returns the same set. A `rename` between the two
+declarations breaks that, because it takes the command **object** away under
+its own name: `proc p …`, `rename p oldp`, `proc p …` leaves two unrelated
+commands, and the surviving `p`'s reference set excludes the `oldp` call
+sites — they belong to the definition the rename carried off.
 
 ## Example
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/tests.rs
@@ -1122,6 +1122,56 @@ fn w127_fires_on_invalid_subcommand_closed_value() {
     );
 }
 
+/// Diagnostic codes for `src` under the Tcl 9.0 profile, in emission order.
+fn all_codes(src: &str) -> Vec<String> {
+    let mut a = Analyser::new();
+    a.analyse(src, "tcl9.0")
+        .diagnostics
+        .into_iter()
+        .map(|d| d.code.to_string())
+        .collect()
+}
+
+#[test]
+fn e003_tp_call_between_two_declarations_checks_the_first_signature() {
+    // TP — issue #923 idx 45. `p a b` sits between a zero-parameter `proc p`
+    // and a later one-parameter redefinition; tclsh 9.0.4 and 8.6.16 both
+    // fail it with `wrong # args: should be "p"` — the *first* signature.
+    // `all_procs` alone only remembers the second, so the call resolved to
+    // nothing and the guaranteed failure went unreported.
+    let src = "proc p {} { return 1 }\np a b\nproc p {a} { return $a }\n";
+    assert!(
+        all_codes(src).contains(&"E003".to_string()),
+        "the in-between call is checked against the first definition: {:?}",
+        all_codes(src)
+    );
+}
+
+#[test]
+fn e003_tn_call_between_two_declarations_matching_the_first_is_silent() {
+    // TN — the paired guard: the same position with an argument count the
+    // *first* definition accepts (and the second would reject) must stay
+    // silent. tclsh: `p` there returns `first`.
+    let src = "proc p {} { return 1 }\np\nproc p {a} { return $a }\n";
+    assert!(
+        !all_codes(src).contains(&"E003".to_string()),
+        "a call the in-effect definition accepts is not an arity error: {:?}",
+        all_codes(src)
+    );
+}
+
+#[test]
+fn e003_tp_call_after_both_declarations_checks_the_last_signature() {
+    // TP — last-redefinition-wins is still right after the second header:
+    // tclsh fails a bare `p` with `wrong # args: should be "p a"`.
+    let src = "proc p {} { return 1 }\nproc p {a} { return $a }\np\n";
+    assert!(
+        all_codes(src).contains(&"E002".to_string()),
+        "the trailing call is checked against the second definition: {:?}",
+        all_codes(src)
+    );
+}
+
 // E002 / E003 arity
 
 #[test]
@@ -11262,6 +11312,41 @@ fn w123_codes(src: &str) -> Vec<String> {
         .filter(|d| d.code == DiagCode::W123)
         .map(|d| d.code.to_string())
         .collect()
+}
+
+#[test]
+fn w123_tp_rename_of_a_nonexistent_command_is_flagged() {
+    // TP — issue #923 idx 5. `rename OLD NEW` requires `OLD` to exist:
+    // tclsh 9.0.4 and 8.6.16 both abort with `can't rename
+    // "definitelyNotDefinedAnywhere": command doesn't exist` (exit 1). `OLD`
+    // is recorded as an ordinary command reference, so W123 reports the
+    // guaranteed failure at the token that causes it.
+    let src = "rename definitelyNotDefinedAnywhere someAlias\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_string()]);
+}
+
+#[test]
+fn w123_tp_deleting_rename_of_a_nonexistent_command_is_flagged() {
+    // TP — the delete form of the same finding: tclsh 9.0.4 and 8.6.16 both
+    // abort with `can't delete "totallyBogusCommand": command doesn't exist`.
+    let src = "rename totallyBogusCommand {}\nputs done\n";
+    assert_eq!(w123_codes(src), vec!["W123".to_string()]);
+}
+
+#[test]
+fn w123_tn_rename_of_an_existing_proc_is_silent() {
+    // TN — the paired guard: the source exists, so the rename is legal
+    // (tclsh: `hello` then returns `hi`) and neither operand is flagged.
+    let src = "proc greet {} { return hi }\nrename greet hello\nhello\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
+}
+
+#[test]
+fn w123_tn_rename_of_a_builtin_is_silent() {
+    // TN — renaming a registry builtin away is the standard wrap idiom and
+    // must not report the builtin as unknown.
+    let src = "rename puts ::original_puts\nproc puts {args} { }\n";
+    assert_eq!(w123_codes(src), Vec::<String>::new());
 }
 
 #[test]

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -373,7 +373,11 @@ struct UserResolutionFacts {
     /// convention (a genuinely order-violating call is rare enough that
     /// abstaining from a real builtin-mismatch report is the safer trade).
     non_proc_qnames: FxHashSet<String>,
-    /// Qualified proc name → its definition token offset.
+    /// Qualified proc name → the offset of its *earliest* declaration —
+    /// the point from which the name denotes a user command at all. A name
+    /// declared twice keeps the first offset here (`all_procs` alone only
+    /// remembers the second), so a call between the two still suppresses the
+    /// builtin-mismatch diagnostic it shadows (issue #923 idx 45).
     proc_offsets: FxHashMap<String, u32>,
     /// Qualified *new* name (a static `rename OLD NEW`) → the `rename`
     /// statement's token offset. `rename` moves an existing command's
@@ -393,8 +397,16 @@ impl UserResolutionFacts {
         let proc_offsets: FxHashMap<String, u32> = a
             .result
             .all_procs
-            .iter()
-            .map(|(qname, def)| (qname.clone(), def.name_span.start()))
+            .keys()
+            .map(|qname| {
+                let earliest = a
+                    .result
+                    .proc_declarations(qname)
+                    .map(|def| def.name_span.start())
+                    .min()
+                    .unwrap_or(u32::MAX);
+                (qname.clone(), earliest)
+            })
             .collect();
         let rename_offsets: FxHashMap<String, u32> = a
             .result
@@ -1434,7 +1446,7 @@ impl Analyser {
             if facts.stub_names.contains(bare) {
                 continue;
             }
-            let Some(arity) = self.resolve_indirect_call_target(&cand, &facts.proc_offsets) else {
+            let Some(arity) = self.resolve_indirect_call_target(&cand) else {
                 continue;
             };
             // The surplus-run anchor: only computable now that the resolved
@@ -1980,11 +1992,32 @@ impl Analyser {
     /// builtin only counts once at least one hop has happened — a
     /// *direct* hit on a builtin name is [`Self::check_simple_arity`]'s
     /// job, not this one's.
-    fn resolve_indirect_call_target(
-        &self,
+    /// The declaration of `qualified` that `cand`'s call actually dispatches
+    /// — the latest one written before it under the top-level order gate,
+    /// the last in the file inside a body.
+    ///
+    /// A qualified name declared twice is two definitions with two parameter
+    /// lists, and `all_procs` only ever keeps the second; asking it alone made
+    /// a call *between* the two unresolvable (the sole surviving definition
+    /// fails the order gate), so a genuine `wrong # args` against the first
+    /// definition went unreported. Oracle (tclsh 8.6.16 and 9.0.4): with
+    /// `proc p {} {…}`, `p a b` between the declarations fails `wrong # args:
+    /// should be "p"` — against the *first* signature, whatever the later one
+    /// says (issue #923 idx 45).
+    fn proc_definition_reached_by<'a>(
+        &'a self,
+        qualified: &str,
         cand: &PendingUserCallArity,
-        proc_offsets: &FxHashMap<String, u32>,
-    ) -> Option<Arity> {
+    ) -> Option<&'a super::super::types::ProcDef> {
+        if !cand.enforce_order {
+            return self.result.all_procs.get(qualified);
+        }
+        self.result
+            .proc_declarations(qualified)
+            .rfind(|def| Self::fact_in_effect(cand, def.name_span.start()))
+    }
+
+    fn resolve_indirect_call_target(&self, cand: &PendingUserCallArity) -> Option<Arity> {
         const MAX_HOPS: u8 = 8;
         let mut cur = cand.cmd_name.clone();
         let mut prepended_total: u16 = 0;
@@ -2006,15 +2039,10 @@ impl Analyser {
         for _ in 0..MAX_HOPS {
             let candidates = qualify_candidates(&cand.ns, &cur);
             for c in &candidates {
-                let Some(def) = self.result.all_procs.get(c) else {
+                let Some(def) = self.proc_definition_reached_by(c, cand) else {
                     continue;
                 };
-                let Some(&proc_off) = proc_offsets.get(c.as_str()) else {
-                    continue;
-                };
-                if cand.enforce_order && proc_off >= cand.call_off {
-                    continue;
-                }
+                let proc_off = def.name_span.start();
                 // A deletion recorded for `c` only shadows *this* proc
                 // definition when it postdates `proc_off` — a re-`proc`
                 // after a `rename c {}` supersedes the deletion (see

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -683,12 +683,6 @@ impl Analyser {
         }
     }
 
-    /// Maximum command-name hops [`Self::class_reachable_by_indirection`]
-    /// follows. Mirrors the eight-hop cap the user-call arity resolver uses
-    /// for the same chains (`validity.rs`), so a `rename a b; rename b c; …`
-    /// cycle cannot spin.
-    const MAX_CLASS_NAME_HOPS: u8 = 8;
-
     /// The canonical class a *written* command name reaches at `call_off`
     /// after following `rename` and `interp alias` indirection, or `None`
     /// when it reaches no live class.
@@ -701,14 +695,17 @@ impl Analyser {
     /// through `renamed_commands` (which maps `new → old`) and returns the
     /// canonical name, which is what the method lookup needs (issue #1049).
     ///
-    /// Both hop kinds are order-gated on the offset that established them,
-    /// via the same rule the user-call arity resolver uses: unconditional
-    /// inside a proc/method body (the whole file loads before any body runs)
-    /// and textual-order-gated at top level. `[Cat new]` written *before* the
-    /// rename therefore resolves to nothing — matching tclsh, where it is
-    /// simply an unknown command.
+    /// The hop walk itself — order gating, the eight-hop cap, and the
+    /// argument-prepending decline — lives in
+    /// [`crate::analyser::indirection::walk`], which the LSP's navigation
+    /// providers consume through the same entry point (issue #1064): a class
+    /// that go-to-definition follows a rename to and a class this pass types a
+    /// constructor through can never be resolved by two different rules.
+    /// What stays here is the part that is genuinely class-specific — class
+    /// -name canonicalisation and the liveness question at the terminal name.
     ///
-    /// The two hop kinds are not symmetric, and the asymmetry is deliberate:
+    /// The two hop kinds are not symmetric in that liveness question, and the
+    /// asymmetry is deliberate:
     ///
     /// - A `rename` moves the command once and for all, so the old name being
     ///   gone afterwards is exactly what freed it up — chasing back through it
@@ -725,70 +722,20 @@ impl Analyser {
     ///   target requires the strict direct-class check there — a rename
     ///   *source* name is vacated, so an alias pointing at it fails `invalid
     ///   command name` at run time (tclsh8.6.14/9.0.4-confirmed) and the
-    ///   lenient rename-source rule below must not resurrect it. A
-    ///   `-prependedargs` alias (`interp alias {} Cat {} Dog extra`) is
-    ///   declined outright: the bound words shift the constructor's
-    ///   arguments, so `Cat new` is not the call `Dog new` would be.
+    ///   lenient rename-source rule below must not resurrect it.
     fn class_reachable_by_indirection(&self, written: &str, call_off: u32) -> Option<String> {
-        let mut cur = self.canonicalise_class_name(written);
-        let mut hopped = false;
-        let mut via_alias = false;
-        for _ in 0..Self::MAX_CLASS_NAME_HOPS {
-            // `renamed_commands` / `command_aliases` are keyed by the
-            // qualified name the scanner resolved; `cur` starts as written.
-            let key = crate::naming::normalise_qualified_name(&cur);
-            if let Some(old) = self.result.renamed_commands.get(&key) {
-                let established = *self.result.rename_offsets.get(&key)?;
-                if !self.indirection_in_effect(established, call_off) {
-                    return None;
-                }
-                cur = self.canonicalise_class_name(old);
-                // A rename destination is a live command name in its own
-                // right — the class data just stays keyed by the source —
-                // so the chain is back on the rename-chase rule.
-                via_alias = false;
-            } else if let Some(alias) = self.result.command_aliases.get(&key) {
-                if !alias.extras.is_empty() {
-                    return None;
-                }
-                let established = *self.result.alias_offsets.get(&key)?;
-                if !self.indirection_in_effect(established, call_off) {
-                    return None;
-                }
-                let target = self.canonicalise_class_name(&alias.target);
-                if target == cur {
-                    return None;
-                }
-                cur = target;
-                via_alias = true;
-            } else {
-                // Terminal name. Reached through a rename chase, the class
-                // survives its source name being vacated
-                // (`class_live_by_name_for_call`); reached straight from an
-                // alias, the name itself must resolve, so only a directly
-                // live class will do.
-                let live = if via_alias {
-                    self.class_live_for_call(&cur, call_off)
-                } else {
-                    self.class_live_by_name_for_call(&cur, call_off)
-                };
-                return (hopped && live).then(|| self.canonicalise_class_name(&cur));
+        let hop = crate::analyser::indirection::walk(&self.result, written, call_off, &|name| {
+            self.canonicalise_class_name(name)
+        })?;
+        let live = match hop.last_hop {
+            crate::analyser::indirection::LastHop::Alias => {
+                self.class_live_for_call(&hop.target, call_off)
             }
-            hopped = true;
-        }
-        None
-    }
-
-    /// Whether an indirection established at `established` is observably in
-    /// effect by the time the call at `call_off` runs.
-    ///
-    /// Order-gated at top level and unconditional inside a definition body —
-    /// the whole file loads, running every top-level statement, before any
-    /// body runs, so a rename written after a method that uses it is still in
-    /// effect when that method executes. The same rule `validity.rs`'s
-    /// `fact_in_effect` applies to proc definitions, renames, and aliases.
-    fn indirection_in_effect(&self, established: u32, call_off: u32) -> bool {
-        established < call_off || self.result.offset_is_inside_any_definition_body(call_off)
+            crate::analyser::indirection::LastHop::Rename => {
+                self.class_live_by_name_for_call(&hop.target, call_off)
+            }
+        };
+        live.then_some(hop.target)
     }
 
     /// Whether `qualified` names a class that is still live at `call_off`

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -952,12 +952,7 @@ impl Analyser {
         // ``result.all_procs`` is keyed by the fully-qualified
         // name. The full qualified name is still on
         // ``ProcDef.qualified_name`` for callers that need it.
-        self.result
-            .all_procs
-            .insert(qualified.clone(), proc.clone());
-        self.result
-            .proc_declaration_sites
-            .push((qualified.clone(), name_span));
+        self.register_proc_definition(&qualified, &proc, name_span);
         let simple_key = proc.name.clone();
         let path = scope_path.to_vec();
         if let Some(scope) = super::scope::scope_at_mut(&mut self.result.global_scope, &path) {
@@ -990,6 +985,44 @@ impl Analyser {
         }
 
         true
+    }
+
+    /// Record one `proc` declaration into the whole-document tables —
+    /// `all_procs` (keyed by qualified name, last redefinition winning, which
+    /// is plain Tcl's own semantics), the never-deduplicated
+    /// `proc_declaration_sites` span list, and, when this declaration
+    /// displaces an earlier one of the same qualified name,
+    /// `superseded_procs`.
+    ///
+    /// The displaced definition is kept because "last wins" is only true
+    /// *from the second declaration onward*: a call written between the two
+    /// reaches the first one, with the first one's span and parameter list.
+    /// Oracle (tclsh 8.6.16 and 9.0.4): with `proc p {} {return first}`,
+    /// `p` between the declarations returns `first`, and after a later
+    /// `proc p {a} {…}` the same bare `p` fails `wrong # args: should be "p
+    /// a"`. Dropping the first definition on the map insert made
+    /// go-to-definition from the in-between call jump to the *later* header
+    /// and left its arity unknowable (issue #923 idx 45).
+    ///
+    /// `superseded_procs` stays empty for every document without a
+    /// redefinition, so the common case pays one `HashMap::insert` return
+    /// value and nothing else.
+    fn register_proc_definition(
+        &mut self,
+        qualified: &str,
+        proc: &ProcDef,
+        name_span: tcl_lexer::Span,
+    ) {
+        if let Some(previous) = self.result.all_procs.insert(qualified.into(), proc.clone()) {
+            self.result
+                .superseded_procs
+                .entry(qualified.to_string())
+                .or_default()
+                .push(previous);
+        }
+        self.result
+            .proc_declaration_sites
+            .push((qualified.to_string(), name_span));
     }
 
     /// Walks a `proc`'s body in a freshly created child scope: binds formal
@@ -1162,12 +1195,7 @@ impl Analyser {
             param_traits,
         };
 
-        self.result
-            .all_procs
-            .insert(qualified.clone(), proc.clone());
-        self.result
-            .proc_declaration_sites
-            .push((qualified.clone(), name_span));
+        self.register_proc_definition(&qualified, &proc, name_span);
         let simple_key = proc.name.clone();
         let path = scope_path.to_vec();
         if let Some(scope) = super::scope::scope_at_mut(&mut self.result.global_scope, &path) {

--- a/rust/tcl-compiler/src/analyser/indirection.rs
+++ b/rust/tcl-compiler/src/analyser/indirection.rs
@@ -34,22 +34,54 @@
 //! #1049, PR #1062), which now consumes it, so the navigation providers in
 //! `tcl-lsp-core` cannot drift from the diagnostics.
 //!
+//! # The model
+//!
+//! A command *name* is not a definition; it is a slot whose contents change
+//! over the life of the script.  Every statement that writes such a slot —
+//! `proc`, `rename`, `interp alias` — is an event on that name's timeline, and
+//! the question every consumer really asks is *"what does this name hold at
+//! this point, in this execution context?"*.  This module answers it for the
+//! two mutation kinds; [`AnalysisResult::proc_def_in_effect_at`] answers the
+//! `proc` half of the same question, under the same order rules.
+//!
 //! # Rules
 //!
 //! - **Order-gating.**  A hop counts only once the statement that established
-//!   it has run: textual order at top level, unconditional inside a
-//!   proc/class body (the whole file loads, running every top-level
-//!   statement, before any body runs).  Oracle (tclsh 8.6.16 and 9.0.4):
+//!   it has run: textual order at top level, and — for a statement written
+//!   *outside* the body now executing — unconditionally inside a proc/class
+//!   body, because the whole file loads, running every top-level statement,
+//!   before any body runs.  A mutation that is itself a statement *of that
+//!   same body* is an ordinary statement of the running script and stays
+//!   order-gated by offset ([`in_effect`]).  Oracle (tclsh 8.6.14/9.0.4):
 //!   with `proc greet {} {…}`, a `hello` written before `rename greet hello`
 //!   raises `invalid command name "hello"`, and one written after returns
 //!   `greet`'s body — while `greet` itself then raises `invalid command name
 //!   "greet"`.
+//! - **Latest binding wins.**  A name may carry both a `rename` record and an
+//!   `interp alias` record; the one written later is the one the slot holds
+//!   ([`latest_binding`]).  Oracle (8.6.14/9.0.4): `proc a {} {return A};
+//!   proc b {} {return B}; rename a x; interp alias {} x {} b; x` → `B` — the
+//!   alias replaced the renamed-in command.  (The reverse order is not a
+//!   reachable program: `rename a x` onto a live `x` aborts with `can't
+//!   rename to "x": command already exists`, so the code after it never runs;
+//!   the same latest-wins rule is applied there for want of a reachable
+//!   alternative.)
+//! - **A rename moves the command object, an alias re-resolves by name.**
+//!   `rename p oldp` hands `oldp` the *object* `p` held at the rename, so a
+//!   later `proc p` does not change what `oldp` runs — oracle (8.6.14/9.0.4):
+//!   `proc p {} {return first}; rename p oldp; proc p {} {return second}` has
+//!   `oldp` → `first` (and `oldp`'s arity is the *first* signature:
+//!   `wrong # args: should be "oldp a"` for `proc p {a}`), while `p` →
+//!   `second`.  An `interp alias`, by contrast, looks its target up by name on
+//!   every invocation, so it sees the table as it stands *at the call*.
+//!   [`Indirection::resolve_at`] carries whichever of the two as-of times
+//!   applies, and consumers resolve the terminal name at that time.
 //! - **Hop cap.**  Eight hops, the same cap the user-call arity resolver
 //!   (`diagnostics::validity`) applies to the identical chains, so a
 //!   `rename a b; rename b c; …` cycle cannot spin.
 //! - **Prepended arguments decline.**  `interp alias {} Cat {} Dog extra`
 //!   binds a leading argument, so `Cat …` is not the call `Dog …` would be
-//!   (tclsh 8.6.16/9.0.4: `interp alias {} withextra {} target pre` makes
+//!   (tclsh 8.6.14/9.0.4: `interp alias {} withextra {} target pre` makes
 //!   `withextra x` fail `wrong # args: should be "withextra"`).  Such a chain
 //!   is declined outright rather than resolved to the target.
 //! - **Self-alias decline.**  An alias whose canonical target is its own name
@@ -86,19 +118,94 @@ pub struct Indirection {
     /// chain is in effect at a call site only once *this* offset is
     /// ([`in_effect`]).
     pub established: u32,
+    /// The point in the document at which [`Self::target`]'s own definition
+    /// must be resolved — the *as-of* time the chain's last hop fixed.
+    ///
+    /// A `rename` hands over the command **object**, so the terminal name has
+    /// to be read as the table stood *at the rename*: after `proc p {} {return
+    /// first}; rename p oldp; proc p {} {return second}`, `oldp` still runs the
+    /// first definition (oracle in the module docs), and resolving `::p`
+    /// against the final proc table would answer with the second.  An
+    /// `interp alias` re-resolves its target by name on every invocation, so
+    /// there the as-of time is the call site's own offset and this field
+    /// carries the `call_off` the walk was given.
+    pub resolve_at: u32,
 }
 
 /// Whether an indirection established at `established` is observably in
 /// effect by the time the call at `call_off` runs.
 ///
-/// Order-gated at top level and unconditional inside a definition body — the
-/// whole file loads, running every top-level statement, before any body runs,
-/// so a rename written after a method that uses it is still in effect when
-/// that method executes.  The same rule `diagnostics::validity`'s
-/// `fact_in_effect` applies to proc definitions, renames, and aliases.
+/// Order-gated by offset, with one exception: a statement written *outside*
+/// the definition body that is executing at `call_off` has already run,
+/// because the whole file loads — running every top-level statement — before
+/// any body runs, so a rename written after a method that uses it is still in
+/// effect when that method executes.
+///
+/// The exception does **not** extend to a mutation that is itself a statement
+/// of that same body: there it is an ordinary statement of the running script
+/// and the offsets are in genuine execution order (oracle in
+/// [`AnalysisResult::proc_def_in_effect_at`], whose `proc` timeline obeys the
+/// identical rule).  Bodies nest, so "that same body" means the innermost
+/// recorded body containing `call_off`; a mutation sitting in some *other*
+/// proc's body stays leniently in effect, since whether that proc ever runs is
+/// not statically decidable.
 #[must_use]
 pub fn in_effect(result: &AnalysisResult, established: u32, call_off: u32) -> bool {
-    established < call_off || result.offset_is_inside_any_definition_body(call_off)
+    if established < call_off {
+        return true;
+    }
+    result
+        .innermost_definition_body_span(call_off)
+        .is_some_and(|body| !(body.start() <= established && established < body.end()))
+}
+
+/// The binding a command name's slot holds, as of `as_of` — the later of its
+/// `rename` and `interp alias` records among those already in effect.
+///
+/// Both maps may carry the same key: `rename a x` then `interp alias {} x {}
+/// b` leaves `x` with a rename record *and* an alias record, and only the
+/// offsets say which one the slot actually holds (oracle in the module docs:
+/// the alias wins, because it ran last).  Reading one map before the other —
+/// as this walk originally did — silently prefers whichever kind the code
+/// happened to check first.
+fn latest_binding<'a>(result: &'a AnalysisResult, key: &str, as_of: u32) -> Option<Binding<'a>> {
+    let rename = result
+        .renamed_commands
+        .get(key)
+        .zip(result.rename_offsets.get(key))
+        .map(|(old, &at)| Binding {
+            kind: LastHop::Rename,
+            source: old.as_str(),
+            at,
+            prepends_args: false,
+        });
+    let alias = result
+        .command_aliases
+        .get(key)
+        .zip(result.alias_offsets.get(key))
+        .map(|(alias, &at)| Binding {
+            kind: LastHop::Alias,
+            source: alias.target.as_str(),
+            at,
+            prepends_args: !alias.extras.is_empty(),
+        });
+    [rename, alias]
+        .into_iter()
+        .flatten()
+        .filter(|b| in_effect(result, b.at, as_of))
+        .max_by_key(|b| b.at)
+}
+
+/// One command-table binding as [`latest_binding`] resolved it.
+struct Binding<'a> {
+    kind: LastHop,
+    /// Where the name's contents came from: the rename's `OLD` word, or the
+    /// alias's target command.
+    source: &'a str,
+    /// Offset of the statement that installed it.
+    at: u32,
+    /// Whether an alias binds leading arguments (never true for a rename).
+    prepends_args: bool,
 }
 
 /// Follow `written`'s `rename` / `interp alias` chain as observed by a call
@@ -127,67 +234,85 @@ pub fn walk(
     let mut hopped = false;
     let mut last_hop = LastHop::Rename;
     let mut established = 0u32;
+    // The as-of time each further hop is read at.  A rename freezes it to the
+    // rename's own offset (the object handed over is the one the source name
+    // held *then*); an alias releases it back to the call, since it re-resolves
+    // its target by name every time it fires.
+    let mut as_of = call_off;
     for _ in 0..MAX_COMMAND_NAME_HOPS {
         let key = crate::naming::normalise_qualified_name(&cur);
-        if let Some(old) = result.renamed_commands.get(&key) {
-            let at = *result.rename_offsets.get(&key)?;
-            if !in_effect(result, at, call_off) {
-                return None;
-            }
-            established = established.max(at);
-            cur = canonicalise(old);
-            // A rename destination is a live command name in its own right —
-            // the definition just keeps its original identity — so the chain
-            // is back on the rename-chase rule.
-            last_hop = LastHop::Rename;
-        } else if let Some(alias) = result.command_aliases.get(&key) {
-            if !alias.extras.is_empty() {
-                return None;
-            }
-            let at = *result.alias_offsets.get(&key)?;
-            if !in_effect(result, at, call_off) {
-                return None;
-            }
-            let target = canonicalise(&alias.target);
-            if target == cur {
-                return None;
-            }
-            established = established.max(at);
-            cur = target;
-            last_hop = LastHop::Alias;
-        } else {
+        let Some(binding) = latest_binding(result, &key, as_of) else {
             return hopped.then_some(Indirection {
                 target: cur,
                 last_hop,
                 established,
+                resolve_at: as_of,
             });
+        };
+        if binding.prepends_args {
+            return None;
         }
+        let source = canonicalise(binding.source);
+        if source == cur {
+            return None;
+        }
+        established = established.max(binding.at);
+        as_of = match binding.kind {
+            LastHop::Rename => binding.at,
+            LastHop::Alias => call_off,
+        };
+        cur = source;
+        // A rename destination is a live command name in its own right — the
+        // definition just keeps its original identity — so a chain ending
+        // there is back on the rename-chase rule.
+        last_hop = binding.kind;
         hopped = true;
     }
     None
 }
 
+/// How a name found by [`names_reaching`] reaches the queried definition.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Reaching {
+    /// The offset from which the whole chain is in effect — a call site
+    /// earlier than this is not reached by it ([`in_effect`]).
+    pub established: u32,
+    /// The as-of time at which the terminal name's definition must be read to
+    /// decide *which* declaration of it this chain actually captured
+    /// ([`Indirection::resolve_at`]).
+    ///
+    /// `None` when the chain's final hop was an alias: an alias re-resolves
+    /// its target by name at every invocation, so the as-of time is each call
+    /// site's own offset rather than one fixed point.
+    pub resolve_at: Option<u32>,
+}
+
 /// Every written command name whose indirection chain terminates on
-/// `target`, paired with the offset at which the whole chain takes effect.
+/// `target`, paired with how it gets there ([`Reaching`]).
 ///
 /// The reverse of [`walk`], for consumers that start from a definition rather
 /// than from a call site — find-references has to attribute a call spelled
 /// through a live alias (`interp alias {} sayHi {} greet` makes `[sayHi]` a
 /// call site of `greet`) to the proc it really reaches (issue #923 idx 21).
 ///
+/// The name alone is not the answer: when the terminal name has been
+/// redeclared, only *one* of its declarations is the one the chain captured,
+/// so [`Reaching::resolve_at`] is carried back for the caller to check the
+/// identity against ([`AnalysisResult::proc_def_in_effect_at`]).
+///
 /// Built by walking each recorded alias / rename name once, so the cost is
 /// `O((aliases + renames) × MAX_COMMAND_NAME_HOPS)` — bounded by the size of
 /// two normally-tiny maps, never by the number of invocations or the size of
 /// the tree.  The `call_off` used for the walk's own order gate is
 /// [`u32::MAX`] (every fact in effect); the caller re-gates each candidate
-/// call site against the returned offset with [`in_effect`], which is what
-/// keeps a call written *before* the alias out of the set.
+/// call site against [`Reaching::established`] with [`in_effect`], which is
+/// what keeps a call written *before* the alias out of the set.
 #[must_use]
 pub fn names_reaching(
     result: &AnalysisResult,
     target: &str,
     canonicalise: &dyn Fn(&str) -> String,
-) -> HashMap<String, u32> {
+) -> HashMap<String, Reaching> {
     let canonical_target = canonicalise(target);
     let mut out = HashMap::new();
     let names = result
@@ -199,7 +324,16 @@ pub fn names_reaching(
             continue;
         };
         if hop.target == canonical_target {
-            out.insert(name.clone(), hop.established);
+            out.insert(
+                name.clone(),
+                Reaching {
+                    established: hop.established,
+                    resolve_at: match hop.last_hop {
+                        LastHop::Rename => Some(hop.resolve_at),
+                        LastHop::Alias => None,
+                    },
+                },
+            );
         }
     }
     out
@@ -294,5 +428,121 @@ mod tests {
         let src = "proc greet {} { }\ngreet\n";
         let r = analyse(src);
         assert!(names_reaching(&r, "::greet", &qualify).is_empty());
+    }
+
+    /// tclsh 9.0.4 and 8.6.14: `proc a …; proc b …; rename a x; interp alias
+    /// {} x {} b; x` prints `B`.  Both records key on `::x`; only the offsets
+    /// say which one the slot holds.
+    #[test]
+    fn the_later_of_a_rename_and_an_alias_on_one_name_wins() {
+        let src = concat!(
+            "proc a {} { return A }\n",
+            "proc b {} { return B }\n",
+            "rename a x\n",
+            "interp alias {} x {} b\n",
+            "x\n",
+        );
+        let r = analyse(src);
+        let hop = walk(&r, "x", after(src, "x\n"), &qualify).expect("hop");
+        assert_eq!(hop.target, "::b");
+        assert_eq!(hop.last_hop, LastHop::Alias);
+    }
+
+    /// The same document read between the two mutations: only the rename has
+    /// run, so the earlier binding is still the live one.
+    #[test]
+    fn the_earlier_binding_governs_until_the_later_one_runs() {
+        let src = concat!(
+            "proc a {} { return A }\n",
+            "proc b {} { return B }\n",
+            "rename a x\n",
+            "x\n",
+            "interp alias {} x {} b\n",
+        );
+        let r = analyse(src);
+        let call = u32::try_from(src.find("\nx\n").expect("call") + 1).expect("tiny test source");
+        let hop = walk(&r, "x", call, &qualify).expect("hop");
+        assert_eq!(hop.target, "::a");
+        assert_eq!(hop.last_hop, LastHop::Rename);
+    }
+
+    /// A rename freezes the as-of time at the rename itself: `oldp` holds the
+    /// object `p` had *then*, so a later `proc p` cannot change it (oracle:
+    /// `oldp` → `first`, `p` → `second` on 9.0.4 and 8.6.14).
+    #[test]
+    fn a_rename_hop_resolves_the_target_as_of_the_rename() {
+        let src = concat!(
+            "proc p {} { return first }\n",
+            "rename p oldp\n",
+            "proc p {} { return second }\n",
+            "oldp\n",
+        );
+        let r = analyse(src);
+        let hop = walk(&r, "oldp", after(src, "oldp\n"), &qualify).expect("hop");
+        assert_eq!(hop.target, "::p");
+        let rename_off = u32::try_from(src.find("rename").expect("rename")).expect("tiny");
+        assert!(
+            hop.resolve_at >= rename_off && hop.resolve_at < after(src, "rename p oldp"),
+            "as-of time is the rename statement, not the call site"
+        );
+        let captured = r
+            .proc_def_in_effect_at("::p", hop.resolve_at)
+            .expect("captured definition");
+        assert_eq!(
+            captured.name_span.start(),
+            u32::try_from(src.find("p {}").expect("first header")).expect("tiny"),
+            "the chain captured the first declaration"
+        );
+    }
+
+    /// An alias looks its target up by name on every invocation, so its as-of
+    /// time is the call site, not the alias statement.
+    #[test]
+    fn an_alias_hop_resolves_the_target_as_of_the_call() {
+        let src = concat!(
+            "proc greet {} { }\n",
+            "interp alias {} sayHi {} greet\n",
+            "sayHi\n",
+        );
+        let r = analyse(src);
+        let call = after(src, "sayHi\n");
+        let hop = walk(&r, "sayHi", call, &qualify).expect("hop");
+        assert_eq!(hop.last_hop, LastHop::Alias);
+        assert_eq!(hop.resolve_at, call);
+    }
+
+    /// A mutation that is a statement of the body now executing is ordinary
+    /// script order — the load-before-body shortcut stops at the body's edge.
+    #[test]
+    fn a_same_body_mutation_below_the_call_is_not_in_effect() {
+        let src = concat!(
+            "proc a {} { return A }\n",
+            "proc outer {} {\n",
+            "    x\n",
+            "    rename a x\n",
+            "}\n",
+        );
+        let r = analyse(src);
+        let call = u32::try_from(src.find("    x\n").expect("call") + 4).expect("tiny");
+        assert!(walk(&r, "x", call, &qualify).is_none());
+    }
+
+    /// …but a mutation in some *other* body stays leniently in effect: whether
+    /// that body ever runs is not statically decidable.
+    #[test]
+    fn a_mutation_in_another_body_is_still_in_effect() {
+        let src = concat!(
+            "proc a {} { return A }\n",
+            "proc installer {} {\n",
+            "    rename a x\n",
+            "}\n",
+            "proc caller {} {\n",
+            "    x\n",
+            "}\n",
+        );
+        let r = analyse(src);
+        let call = u32::try_from(src.rfind("    x\n").expect("call") + 4).expect("tiny");
+        let hop = walk(&r, "x", call, &qualify).expect("hop");
+        assert_eq!(hop.target, "::a");
     }
 }

--- a/rust/tcl-compiler/src/analyser/indirection.rs
+++ b/rust/tcl-compiler/src/analyser/indirection.rs
@@ -1,0 +1,298 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Command-table indirection: the one hop-walk shared by the analyser's
+//! diagnostics and the LSP's navigation providers.
+//!
+//! Tcl's command table is mutable at run time.  `rename OLD NEW` moves a
+//! command to a new name; `interp alias {} ALIAS {} TARGET` installs a second
+//! name that re-resolves to `TARGET` on every invocation (and silently
+//! replaces an existing command of that name).  A call site written after
+//! either statement therefore reaches a *different* definition than its
+//! spelling suggests, and everything that answers "what does this word name?"
+//! — the W307/W308 method checks, go-to-definition, find-references, rename,
+//! call hierarchy — has to follow the same chain, the same way, or they
+//! disagree with each other and with `tclsh`.
+//!
+//! This module is that single implementation.  It was factored out of
+//! `diagnostics::var_command`'s `class_reachable_by_indirection` (issue
+//! #1049, PR #1062), which now consumes it, so the navigation providers in
+//! `tcl-lsp-core` cannot drift from the diagnostics.
+//!
+//! # Rules
+//!
+//! - **Order-gating.**  A hop counts only once the statement that established
+//!   it has run: textual order at top level, unconditional inside a
+//!   proc/class body (the whole file loads, running every top-level
+//!   statement, before any body runs).  Oracle (tclsh 8.6.16 and 9.0.4):
+//!   with `proc greet {} {…}`, a `hello` written before `rename greet hello`
+//!   raises `invalid command name "hello"`, and one written after returns
+//!   `greet`'s body — while `greet` itself then raises `invalid command name
+//!   "greet"`.
+//! - **Hop cap.**  Eight hops, the same cap the user-call arity resolver
+//!   (`diagnostics::validity`) applies to the identical chains, so a
+//!   `rename a b; rename b c; …` cycle cannot spin.
+//! - **Prepended arguments decline.**  `interp alias {} Cat {} Dog extra`
+//!   binds a leading argument, so `Cat …` is not the call `Dog …` would be
+//!   (tclsh 8.6.16/9.0.4: `interp alias {} withextra {} target pre` makes
+//!   `withextra x` fail `wrong # args: should be "withextra"`).  Such a chain
+//!   is declined outright rather than resolved to the target.
+//! - **Self-alias decline.**  An alias whose canonical target is its own name
+//!   is not a hop.
+
+use std::collections::HashMap;
+
+use super::types::AnalysisResult;
+
+/// Maximum command-name hops [`walk`] follows.
+pub const MAX_COMMAND_NAME_HOPS: u8 = 8;
+
+/// Which kind of command-table mutation the last hop of a chain crossed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LastHop {
+    /// `rename OLD NEW` — the definition keeps its original identity and the
+    /// source name is vacated, so a consumer may treat a *rename source* as
+    /// still denoting the thing it named.
+    Rename,
+    /// `interp alias {} ALIAS {} TARGET` — re-resolved by name on every
+    /// invocation, so the terminal name must itself be a live command.
+    Alias,
+}
+
+/// Where a written command name ends up after following the command table's
+/// recorded `rename` / `interp alias` indirection.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Indirection {
+    /// The canonical name the chain terminates on.
+    pub target: String,
+    /// The kind of the final hop — see [`LastHop`].
+    pub last_hop: LastHop,
+    /// The latest offset among the statements the chain crossed: the whole
+    /// chain is in effect at a call site only once *this* offset is
+    /// ([`in_effect`]).
+    pub established: u32,
+}
+
+/// Whether an indirection established at `established` is observably in
+/// effect by the time the call at `call_off` runs.
+///
+/// Order-gated at top level and unconditional inside a definition body — the
+/// whole file loads, running every top-level statement, before any body runs,
+/// so a rename written after a method that uses it is still in effect when
+/// that method executes.  The same rule `diagnostics::validity`'s
+/// `fact_in_effect` applies to proc definitions, renames, and aliases.
+#[must_use]
+pub fn in_effect(result: &AnalysisResult, established: u32, call_off: u32) -> bool {
+    established < call_off || result.offset_is_inside_any_definition_body(call_off)
+}
+
+/// Follow `written`'s `rename` / `interp alias` chain as observed by a call
+/// at `call_off`, returning where it terminates — or `None` when the word
+/// names no mutated command, when the chain is not yet in effect, or when it
+/// crosses an argument-prepending alias.
+///
+/// `canonicalise` maps a written name onto the identity the caller keys its
+/// own tables by; pass a plain qualifier for command names, or a class-name
+/// resolver for the class tables (which is what
+/// `diagnostics::var_command::class_reachable_by_indirection` does).  The
+/// maps themselves are keyed by the qualified name the scanner resolved, so
+/// every lookup normalises through [`crate::naming::normalise_qualified_name`].
+///
+/// Cost is `O(MAX_COMMAND_NAME_HOPS)` hash lookups — no scan of the
+/// invocation list or of the source, so this is safe on a per-request LSP
+/// path.
+#[must_use]
+pub fn walk(
+    result: &AnalysisResult,
+    written: &str,
+    call_off: u32,
+    canonicalise: &dyn Fn(&str) -> String,
+) -> Option<Indirection> {
+    let mut cur = canonicalise(written);
+    let mut hopped = false;
+    let mut last_hop = LastHop::Rename;
+    let mut established = 0u32;
+    for _ in 0..MAX_COMMAND_NAME_HOPS {
+        let key = crate::naming::normalise_qualified_name(&cur);
+        if let Some(old) = result.renamed_commands.get(&key) {
+            let at = *result.rename_offsets.get(&key)?;
+            if !in_effect(result, at, call_off) {
+                return None;
+            }
+            established = established.max(at);
+            cur = canonicalise(old);
+            // A rename destination is a live command name in its own right —
+            // the definition just keeps its original identity — so the chain
+            // is back on the rename-chase rule.
+            last_hop = LastHop::Rename;
+        } else if let Some(alias) = result.command_aliases.get(&key) {
+            if !alias.extras.is_empty() {
+                return None;
+            }
+            let at = *result.alias_offsets.get(&key)?;
+            if !in_effect(result, at, call_off) {
+                return None;
+            }
+            let target = canonicalise(&alias.target);
+            if target == cur {
+                return None;
+            }
+            established = established.max(at);
+            cur = target;
+            last_hop = LastHop::Alias;
+        } else {
+            return hopped.then_some(Indirection {
+                target: cur,
+                last_hop,
+                established,
+            });
+        }
+        hopped = true;
+    }
+    None
+}
+
+/// Every written command name whose indirection chain terminates on
+/// `target`, paired with the offset at which the whole chain takes effect.
+///
+/// The reverse of [`walk`], for consumers that start from a definition rather
+/// than from a call site — find-references has to attribute a call spelled
+/// through a live alias (`interp alias {} sayHi {} greet` makes `[sayHi]` a
+/// call site of `greet`) to the proc it really reaches (issue #923 idx 21).
+///
+/// Built by walking each recorded alias / rename name once, so the cost is
+/// `O((aliases + renames) × MAX_COMMAND_NAME_HOPS)` — bounded by the size of
+/// two normally-tiny maps, never by the number of invocations or the size of
+/// the tree.  The `call_off` used for the walk's own order gate is
+/// [`u32::MAX`] (every fact in effect); the caller re-gates each candidate
+/// call site against the returned offset with [`in_effect`], which is what
+/// keeps a call written *before* the alias out of the set.
+#[must_use]
+pub fn names_reaching(
+    result: &AnalysisResult,
+    target: &str,
+    canonicalise: &dyn Fn(&str) -> String,
+) -> HashMap<String, u32> {
+    let canonical_target = canonicalise(target);
+    let mut out = HashMap::new();
+    let names = result
+        .renamed_commands
+        .keys()
+        .chain(result.command_aliases.keys());
+    for name in names {
+        let Some(hop) = walk(result, name, u32::MAX, canonicalise) else {
+            continue;
+        };
+        if hop.target == canonical_target {
+            out.insert(name.clone(), hop.established);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{LastHop, names_reaching, walk};
+    use crate::analyser::Analyser;
+    use crate::analyser::types::AnalysisResult;
+
+    fn analyse(src: &str) -> AnalysisResult {
+        let mut a = Analyser::new();
+        a.analyse(src, "tcl9.0")
+    }
+
+    /// Byte offset just past the last occurrence of `needle`.
+    fn after(src: &str, needle: &str) -> u32 {
+        u32::try_from(src.rfind(needle).expect("needle present") + needle.len())
+            .expect("tiny test source")
+    }
+
+    fn qualify(name: &str) -> String {
+        crate::naming::normalise_qualified_name(name)
+    }
+
+    #[test]
+    fn rename_destination_reaches_the_original_name() {
+        let src = "proc greet {} { return hi }\nrename greet hello\nhello\n";
+        let r = analyse(src);
+        let hop = walk(&r, "hello", after(src, "hello"), &qualify).expect("hop");
+        assert_eq!(hop.target, "::greet");
+        assert_eq!(hop.last_hop, LastHop::Rename);
+    }
+
+    #[test]
+    fn a_rename_written_after_the_call_is_not_in_effect() {
+        let src = "proc greet {} { return hi }\nhello\nrename greet hello\n";
+        let r = analyse(src);
+        let call = u32::try_from(src.find("hello").expect("call")).expect("tiny test source");
+        assert!(walk(&r, "hello", call, &qualify).is_none());
+    }
+
+    #[test]
+    fn an_alias_chain_walks_through_a_rename() {
+        // tclsh 8.6.16/9.0.4: `rename Dog Cat; interp alias {} Pup {} Cat`
+        // makes `Pup new` build a Dog.
+        let src = concat!(
+            "proc Dog {args} { }\n",
+            "rename Dog Cat\n",
+            "interp alias {} Pup {} Cat\n",
+            "Pup new\n",
+        );
+        let r = analyse(src);
+        let hop = walk(&r, "Pup", after(src, "Pup new"), &qualify).expect("hop");
+        assert_eq!(hop.target, "::Dog");
+        // The final hop landed on a rename destination, so the chain ends on
+        // the lenient rename-chase rule, not the strict alias one.
+        assert_eq!(hop.last_hop, LastHop::Rename);
+    }
+
+    #[test]
+    fn an_argument_prepending_alias_is_declined() {
+        let src = "proc target {a} { }\ninterp alias {} withextra {} target pre\nwithextra\n";
+        let r = analyse(src);
+        assert!(walk(&r, "withextra", after(src, "withextra\n"), &qualify).is_none());
+    }
+
+    #[test]
+    fn an_unmutated_name_is_not_a_hop() {
+        let src = "proc greet {} { }\ngreet\n";
+        let r = analyse(src);
+        assert!(walk(&r, "greet", after(src, "greet\n"), &qualify).is_none());
+    }
+
+    #[test]
+    fn names_reaching_finds_both_hop_kinds() {
+        let src = concat!(
+            "proc greet {} { }\n",
+            "interp alias {} sayHi {} greet\n",
+            "rename greet hello\n",
+        );
+        let r = analyse(src);
+        let reaching = names_reaching(&r, "::greet", &qualify);
+        let mut names: Vec<&str> = reaching.keys().map(String::as_str).collect();
+        names.sort_unstable();
+        assert_eq!(names, vec!["::hello", "::sayHi"]);
+    }
+
+    #[test]
+    fn names_reaching_is_empty_for_an_unmutated_command() {
+        let src = "proc greet {} { }\ngreet\n";
+        let r = analyse(src);
+        assert!(names_reaching(&r, "::greet", &qualify).is_empty());
+    }
+}

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -51,6 +51,7 @@ pub mod confusables_table;
 pub mod diagnostics;
 pub mod dispatch;
 pub mod handlers;
+pub mod indirection;
 pub mod irules_event_checks;
 pub mod item_tree;
 pub mod oo;

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -506,6 +506,19 @@ impl Analyser {
         }
         let r = frag.result;
         self.result.all_procs.extend(r.all_procs);
+        // Per qualified name, not a flat `extend`: a body that redefines a
+        // proc it defines itself carries its own displaced definitions, and a
+        // flat extend would replace rather than append to whatever the shell
+        // already recorded for that name. (A body redefining a proc defined
+        // *outside* it forces a full re-analyse above, so the shell and the
+        // body never contend for the same key here.)
+        for (qualified, defs) in r.superseded_procs {
+            self.result
+                .superseded_procs
+                .entry(qualified)
+                .or_default()
+                .extend(defs);
+        }
         self.result.all_classes.extend(r.all_classes);
         self.merge_body_variables(r.all_variables, shell_var_keys);
         self.result.command_aliases.extend(r.command_aliases);
@@ -956,6 +969,11 @@ fn rebase_fragment(frag: &mut BodyFragment, d: u32, line_delta: i32) {
     let r = &mut frag.result;
     for p in r.all_procs.values_mut() {
         rebase_proc(p, d);
+    }
+    for defs in r.superseded_procs.values_mut() {
+        for p in defs.iter_mut() {
+            rebase_proc(p, d);
+        }
     }
     for c in r.all_classes.values_mut() {
         rebase_class(c, d);

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1132,16 +1132,31 @@ impl AnalysisResult {
 
     /// The definition of `qualified` a call at `call_off` actually reaches.
     ///
-    /// Order-gated the same way every other command-table fact is: at top
-    /// level the latest declaration written before the call wins, and inside
-    /// any definition body the last declaration in the file wins, because the
+    /// Order-gated the same way every other command-table fact is
+    /// ([`crate::analyser::indirection::in_effect`], which shares the rule):
+    /// at load time the latest declaration written before the call wins, and
+    /// a call *inside a definition body* additionally sees every declaration
+    /// written outside that body, wherever it sits in the file, because the
     /// whole file loads — running every top-level `proc` — before any body
-    /// runs.  A call that precedes *every* declaration reaches none of them,
-    /// but the winner is still returned so a consumer that has its own
-    /// order gate (go-to-definition's lenient "show me the declaration
-    /// anyway") behaves exactly as it did before redefinitions were tracked.
+    /// runs.
     ///
-    /// Oracle (tclsh 8.6.16 and 9.0.4) for `proc p {} {return first}` / `p` /
+    /// That load-before-body shortcut stops at the body's own edge.  A `proc`
+    /// written as a statement *of the body now executing* is an ordinary
+    /// statement of the running script, so it is gated by offset like any
+    /// other, and — having run later than everything the file's load
+    /// installed — it outranks them all.  Oracle (tclsh 8.6.14 and 9.0.4) for
+    /// `proc outer {} { proc p {} {return one}; p; proc p {a} {…} }`: the bare
+    /// `p` between the two returns `one`, and `p X` after them dispatches the
+    /// one-parameter definition, while the counterpart
+    /// `proc outer {} { later }` / `proc later {} {…}` — declared outside,
+    /// after — resolves fine (`LATER`), which is what the shortcut exists for.
+    ///
+    /// A call that precedes *every* declaration reaches none of them, but the
+    /// winner is still returned so a consumer that has its own order gate
+    /// (go-to-definition's lenient "show me the declaration anyway") behaves
+    /// exactly as it did before redefinitions were tracked.
+    ///
+    /// Oracle (tclsh 8.6.14 and 9.0.4) for `proc p {} {return first}` / `p` /
     /// `proc p {a} {…}` / `p x`: the first call returns `first`, the second
     /// dispatches the one-parameter definition, and a bare `p` after the
     /// redefinition fails `wrong # args: should be "p a"`.
@@ -1151,14 +1166,42 @@ impl AnalysisResult {
         let Some(earlier) = self.superseded_procs.get(qualified) else {
             return Some(winner);
         };
-        if self.offset_is_inside_any_definition_body(call_off) {
-            return Some(winner);
-        }
-        earlier
-            .iter()
-            .chain(std::iter::once(winner))
-            .rfind(|def| def.name_span.start() < call_off)
+        let declarations = || earlier.iter().chain(std::iter::once(winner));
+        let Some(body) = self.innermost_definition_body_span(call_off) else {
+            // Load time: plain textual order.
+            return declarations()
+                .rfind(|def| def.name_span.start() < call_off)
+                .or(Some(winner));
+        };
+        let in_this_body = |def: &&ProcDef| {
+            let at = def.name_span.start();
+            body.start() <= at && at < body.end()
+        };
+        // A declaration this body already executed beats everything the file's
+        // load installed; failing that, the last declaration from outside.
+        declarations()
+            .rfind(|def| in_this_body(def) && def.name_span.start() < call_off)
+            .or_else(|| declarations().rfind(|def| !in_this_body(def)))
             .or(Some(winner))
+    }
+
+    /// The body span of the *innermost* recorded proc or class definition
+    /// containing `off` — the body that is actually executing when the
+    /// statement at `off` runs — or `None` at load-time (top level).
+    ///
+    /// The span form of [`Self::enclosing_definition_qualified_name`], for the
+    /// order-gating rules that need to ask "is this other statement part of
+    /// the *same* running body, or did it already run at load time?" —
+    /// [`Self::proc_def_in_effect_at`] and
+    /// [`crate::analyser::indirection::in_effect`].
+    #[must_use]
+    pub fn innermost_definition_body_span(&self, off: u32) -> Option<Span> {
+        self.all_procs
+            .values()
+            .map(|p| p.body_span)
+            .chain(self.all_classes.values().map(|c| c.body_span))
+            .filter(|span| span.start() <= off && off < span.end())
+            .min_by_key(|span| span.end() - span.start())
     }
 
     /// The qualified name of the *innermost* recorded proc or class

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -845,6 +845,25 @@ pub struct AnalysisResult {
     /// (issue #923 idx 31, main audit wave) — `all_procs`' own span alone
     /// can never satisfy that lookup, since it only ever holds the winner's.
     pub proc_declaration_sites: Vec<(String, Span)>,
+    /// The `ProcDef`s a later same-named `proc` displaced from
+    /// [`Self::all_procs`], keyed by qualified name, in source order —
+    /// empty for every document that redefines nothing.
+    ///
+    /// `all_procs` keeps plain Tcl's "last redefinition wins", which is the
+    /// right answer for a call site *after* the last declaration and the
+    /// wrong one for a call between two of them: that call reaches the
+    /// earlier definition, with the earlier definition's span and parameter
+    /// list. This is the order-gated companion the map cannot express —
+    /// the `proc` analogue of [`Self::rename_offsets`] /
+    /// [`Self::alias_offsets`] — and
+    /// [`Self::proc_def_in_effect_at`] is how consumers ask it (issue #923
+    /// idx 45).
+    ///
+    /// Distinct from [`Self::proc_declaration_sites`], which records only
+    /// *spans* (enough to recognise a shadowed declaration's own name token,
+    /// issue #923 idx 31) and so cannot answer what the displaced definition's
+    /// parameters were.
+    pub superseded_procs: HashMap<String, Vec<ProcDef>>,
     /// Classes keyed by qualified name.
     pub all_classes: HashMap<String, ClassDef>,
     /// Every class-body span contributing member declarations to a
@@ -1092,6 +1111,54 @@ impl AnalysisResult {
             .map(|p| p.body_span)
             .chain(self.all_classes.values().map(|c| c.body_span))
             .any(|span| span.start() <= off && off < span.end())
+    }
+
+    /// Every declaration of `qualified` in this document, in source order —
+    /// the definitions a later same-named `proc` displaced
+    /// ([`Self::superseded_procs`]) followed by the winner
+    /// ([`Self::all_procs`]).  One element for the overwhelmingly common
+    /// single-declaration case.
+    pub fn proc_declarations<'a>(
+        &'a self,
+        qualified: &str,
+    ) -> impl DoubleEndedIterator<Item = &'a ProcDef> + 'a {
+        self.superseded_procs
+            .get(qualified)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .chain(self.all_procs.get(qualified))
+    }
+
+    /// The definition of `qualified` a call at `call_off` actually reaches.
+    ///
+    /// Order-gated the same way every other command-table fact is: at top
+    /// level the latest declaration written before the call wins, and inside
+    /// any definition body the last declaration in the file wins, because the
+    /// whole file loads — running every top-level `proc` — before any body
+    /// runs.  A call that precedes *every* declaration reaches none of them,
+    /// but the winner is still returned so a consumer that has its own
+    /// order gate (go-to-definition's lenient "show me the declaration
+    /// anyway") behaves exactly as it did before redefinitions were tracked.
+    ///
+    /// Oracle (tclsh 8.6.16 and 9.0.4) for `proc p {} {return first}` / `p` /
+    /// `proc p {a} {…}` / `p x`: the first call returns `first`, the second
+    /// dispatches the one-parameter definition, and a bare `p` after the
+    /// redefinition fails `wrong # args: should be "p a"`.
+    #[must_use]
+    pub fn proc_def_in_effect_at(&self, qualified: &str, call_off: u32) -> Option<&ProcDef> {
+        let winner = self.all_procs.get(qualified)?;
+        let Some(earlier) = self.superseded_procs.get(qualified) else {
+            return Some(winner);
+        };
+        if self.offset_is_inside_any_definition_body(call_off) {
+            return Some(winner);
+        }
+        earlier
+            .iter()
+            .chain(std::iter::once(winner))
+            .rfind(|def| def.name_span.start() < call_off)
+            .or(Some(winner))
     }
 
     /// The qualified name of the *innermost* recorded proc or class

--- a/rust/tcl-compiler/src/signature_scan/command_prefix.rs
+++ b/rust/tcl-compiler/src/signature_scan/command_prefix.rs
@@ -52,7 +52,10 @@
 //!   `Traits::WRAPS_COMMAND_PREFIX` command): the wrapper's own result is a
 //!   command prefix, so its wrapped word is unwrapped one level and run back
 //!   through the shapes above. The idiom Tk's `library/fontchooser.tcl` uses
-//!   for its trace callbacks (issue #923 idx 92).
+//!   for its trace callbacks (issue #923 idx 92). A *braced* wrapped word is
+//!   excluded: the analyser already walks it as a script, and a second record
+//!   at the same span would double the code-lens reference count (see
+//!   [`extract_wrapped_prefix_head`]).
 //!
 //! A dynamic head (`$var`/`[cmd]`, in any shape) can't be resolved to a
 //! proc and recording it would false-fire W123, so it stays unrecorded.
@@ -256,10 +259,27 @@ fn extract_prefix_head(
 /// (`[list X a]`, a bareword, a braced `{X a}`) works wrapped too, and no
 /// command name appears in this walker.
 ///
-/// A **braced** wrapped argument is deliberately left alone: the analyser
-/// already walks it as an ordinary `Body` and records its head, so extracting
-/// it here as well would double-count the same call site in the reference
-/// list and the code-lens count.
+/// A **braced** wrapped argument is deliberately left alone.  Every recorded
+/// call site must have exactly one recorder: Find All References dedupes by
+/// range and would hide a duplicate, but `code_lens` counts
+/// `proc_reference_spans().len()` raw, so a second record at the identical
+/// span makes one callback read as *two* references.  The braced word is one
+/// the analyser already walks — `Analyser::analyse_body` descends it as an
+/// ordinary script and records its head — and measuring it confirms the
+/// double: with this guard removed, `[namespace code {Tracer}]` reports two
+/// references for one callback.  Pinned by
+/// `command_table_mutation::tp_lens_counts_each_namespace_code_callback_shape_once`.
+///
+/// The **bareword** shape (`[namespace code Tracer]`) is *not* excluded, even
+/// though `Analyser::dispatch_one_body_argument` does dispatch a bareword
+/// `Body` word as a zero-argument call (the issue #923 idx 61 fix).  That
+/// dispatch runs on the analyser's own statement walk, which does not descend
+/// into a `[…]` command substitution — and a `namespace code` wrapper is
+/// always inside one, since its result has to be substituted to be used.
+/// Measured, not assumed: excluding the bareword shape here drops the
+/// callback's reference count from 1 to 0 (PR #1075 review, P2 — the review's
+/// double-count diagnosis holds for the braced word, which was already
+/// guarded, but not for this one).
 ///
 /// [`ArgRole::Body`]: tcl_registry::arg_role::ArgRole::Body
 fn extract_wrapped_prefix_head(

--- a/rust/tcl-compiler/src/signature_scan/command_prefix.rs
+++ b/rust/tcl-compiler/src/signature_scan/command_prefix.rs
@@ -27,7 +27,7 @@
 //! feeding find-references, call-hierarchy, call-graph, code-lens, W123, and
 //! the callback-arity check off one substrate.
 //!
-//! Three prefix shapes are recognised:
+//! Four prefix shapes are recognised:
 //!
 //! - A **literal bareword** head (a single `Esc` token, not quoted, not a
 //!   `$var`/`[cmd]` substitution) — mirroring the highlight guard in
@@ -47,6 +47,12 @@
 //!   Same head/baked-count semantics as the braced shape, just constructed
 //!   dynamically; the *value* of the trailing arguments isn't needed, only
 //!   their count.
+//! - A **namespace-wrapped prefix** (`[namespace code [list cmd extra]]`, a
+//!   single `Cmd` token whose sole content is a call to a
+//!   `Traits::WRAPS_COMMAND_PREFIX` command): the wrapper's own result is a
+//!   command prefix, so its wrapped word is unwrapped one level and run back
+//!   through the shapes above. The idiom Tk's `library/fontchooser.tcl` uses
+//!   for its trace callbacks (issue #923 idx 92).
 //!
 //! A dynamic head (`$var`/`[cmd]`, in any shape) can't be resolved to a
 //! proc and recording it would false-fire W123, so it stays unrecorded.
@@ -230,9 +236,68 @@ fn extract_prefix_head(
         return Some((head.to_string(), head_span, baked));
     }
     if tok.kind == TokenType::Cmd {
-        return extract_list_quoted_prefix_head(registry, tok, text);
+        return extract_list_quoted_prefix_head(registry, tok, text)
+            .or_else(|| extract_wrapped_prefix_head(registry, tok, text));
     }
     None
+}
+
+/// Extract `(head, head_span, baked_arg_count)` from a command-prefix
+/// argument built by a [`tcl_registry::Traits::WRAPS_COMMAND_PREFIX`] command
+/// — `[namespace code [list Tracer]]`, the idiom Tk's own
+/// `library/fontchooser.tcl` uses for every one of its trace callbacks.
+///
+/// `namespace code script` returns `::namespace inscope NS script`: invoking
+/// it runs `script` in `NS` with the caller's arguments appended, so the
+/// command the callback really reaches is `script`'s own head. Unwrap exactly
+/// one level — the inner script must be a single call to a wrapping command,
+/// whose [`ArgRole::Body`] argument is then run back through
+/// [`extract_prefix_head`], so every shape that works directly
+/// (`[list X a]`, a bareword, a braced `{X a}`) works wrapped too, and no
+/// command name appears in this walker.
+///
+/// A **braced** wrapped argument is deliberately left alone: the analyser
+/// already walks it as an ordinary `Body` and records its head, so extracting
+/// it here as well would double-count the same call site in the reference
+/// list and the code-lens count.
+///
+/// [`ArgRole::Body`]: tcl_registry::arg_role::ArgRole::Body
+fn extract_wrapped_prefix_head(
+    registry: &CommandRegistry,
+    tok: Token,
+    text: &str,
+) -> Option<(String, Span, usize)> {
+    let inner = text.strip_prefix('[')?.strip_suffix(']')?;
+    let content_start = tok.span.start() + u32::from(tok.content_offset);
+    let mut segs = segment_commands_with_offset(inner, content_start);
+    if segs.len() != 1 {
+        return None;
+    }
+    let seg = segs.pop()?;
+    let args: Vec<&str> = seg.texts.get(1..)?.iter().map(String::as_str).collect();
+    if !registry
+        .invocation_traits(
+            &seg.texts[0],
+            &args,
+            tcl_registry::prelude::DialectSet::empty(),
+        )
+        .contains(tcl_registry::Traits::WRAPS_COMMAND_PREFIX)
+    {
+        return None;
+    }
+    let wrapped = *registry
+        .arg_indices_for_role(&seg.texts[0], &args, tcl_registry::ArgRole::Body)
+        .first()?;
+    let wrapped_tok = *seg.argv.get(wrapped + 1)?;
+    if wrapped_tok.kind == TokenType::Str {
+        return None;
+    }
+    extract_prefix_head(
+        registry,
+        wrapped_tok,
+        seg.texts.get(wrapped + 1)?,
+        *seg.single_token_word.get(wrapped + 1)?,
+    )
 }
 
 /// Extract `(head, head_span, baked_arg_count)` from a `[list cmd a b]`

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -41,12 +41,26 @@
 //!   behaviour for procs whose defining namespace isn't
 //!   statically visible at the call.
 //!
-//! Command-alias resolution: when the cursor's word matches an
-//! `interp alias {} ALIAS {} TARGET` recorded in
-//! `analysis.command_aliases`, the provider jumps to the target
-//! proc's definition (when the target is a user proc), resolving
-//! the target from the global namespace — where an alias target
-//! is looked up when the alias fires.
+//! Command-table indirection: Tcl's command table is mutable, so a
+//! word's spelling does not by itself name the definition the call
+//! reaches. When `analysis.renamed_commands` / `analysis.command_aliases`
+//! record a `rename OLD NEW` or an `interp alias {} ALIAS {} TARGET`
+//! that is **in effect at the cursor**, the provider follows the chain
+//! (via the shared walk in `tcl_compiler::analyser::indirection`, which
+//! the analyser's own constructor typing uses) and resolves the terminal
+//! name from the global namespace — where an alias target and a rename
+//! source are both looked up when the binding fires. This is asked
+//! *before* the ordinary call resolution, because an alias silently
+//! replaces a same-named command. It is order-gated: a call written
+//! before the mutation resolves the ordinary way, matching tclsh, where
+//! it is `invalid command name`. An argument-prepending alias is
+//! declined — it is not the call the target would receive.
+//!
+//! Redefinition: a proc declared twice in one document is two
+//! definitions of one command. `all_procs` keeps the last (plain Tcl's
+//! own rule) and `AnalysisResult::superseded_procs` keeps the rest, so a
+//! call between the two resolves to the definition in effect there and a
+//! cursor on either header stays on that header.
 //!
 //! Class-member lookup: when the cursor sits on a
 //! word inside a class body span, the provider walks that
@@ -197,7 +211,7 @@ pub fn definition(
                 source,
                 "::",
                 target,
-                Some(tcl_registry::registry_for_dialect("")),
+                Some(tcl_registry::registry_for_dialect(&analysis.dialect)),
             )
         {
             return vec![span_to_range(source, &line_index, proc_def.name_span)];
@@ -206,23 +220,26 @@ pub fn definition(
     // `next` / `nextto` inside a method body — jump to the super-method in
     // the MRO chain that the enclosing method overrides (`next`), or to the
     // named class's copy of it (`nextto Cls`).
-    if is_next_chain_keyword(&word)
+    if is_next_chain_keyword_in(&analysis.dialect, &word)
         && let Some(span) =
             next_dispatch_target(analysis, source, &line_index, line, character, &word)
     {
         return vec![span_to_range(source, &line_index, span)];
     }
-    // Prefer the proc whose own declaration name span covers the cursor (so
-    // a same-named proc in another namespace's own decl resolves to *that*
+    // Prefer the declaration whose own name span covers the cursor (so a
+    // same-named proc in another namespace's own decl resolves to *that*
     // one — mirrors `references::proc_references` / `rename::rename_proc`;
-    // #924).
+    // #924).  `proc_declaration_sites` rather than `all_procs`, so a
+    // declaration a later same-named `proc` displaced still resolves to
+    // itself instead of silently jumping to its own successor (issue #923
+    // idx 45) — the map only ever keeps the winner's span.
     let cursor_offset = byte_offset_at(&line_index, source, line, character);
-    if let Some((_, proc_def)) = analysis
-        .all_procs
+    if let Some((_, span)) = analysis
+        .proc_declaration_sites
         .iter()
-        .find(|(_, p)| p.name_span.start() <= cursor_offset && cursor_offset < p.name_span.end())
+        .find(|(_, span)| span.start() <= cursor_offset && cursor_offset < span.end())
     {
-        return vec![span_to_range(source, &line_index, proc_def.name_span)];
+        return vec![span_to_range(source, &line_index, *span)];
     }
     // Otherwise it is a CALL — resolve namespace-aware, following C Tcl's
     // command resolution (`Tcl_FindCommand`, `tclNamesp.c`): the caller's
@@ -237,6 +254,21 @@ pub fn definition(
         cursor_offset,
         &analysis.namespace_overrides,
     );
+    // The command table may have been *mutated* before this call runs: a
+    // `rename OLD NEW` moved a definition onto this word, or an `interp
+    // alias` installed (or silently replaced) it. That is what the call
+    // actually reaches, so it is asked ahead of the ordinary resolution
+    // below — which would otherwise answer with a same-named `proc` the
+    // alias has already displaced (issue #923 idx 89; tclsh 8.6.16/9.0.4:
+    // after `interp alias {} ::ttk::spinbox {} ::tk::spinbox`, calling
+    // `::ttk::spinbox` runs `::tk::spinbox`'s body, and the original proc is
+    // unreachable under that name). The hop is order-gated, so a rename or
+    // alias written *after* this call site does not apply and the ordinary
+    // resolution below still wins (tclsh: a `hello` before `rename greet
+    // hello` is `invalid command name "hello"`).
+    if let Some(span) = indirect_definition_target(analysis, source, cursor_offset, &word) {
+        return vec![span_to_range(source, &line_index, span)];
+    }
     // `Factory::make` — [incr Tcl]'s colon-qualified class-proc dispatch
     // (issue #990).  Asked **before** the stock proc resolution below, because
     // itcl installs a custom command resolver on every class namespace and Tcl
@@ -255,9 +287,15 @@ pub fn definition(
         source,
         &namespace,
         &word,
-        Some(tcl_registry::registry_for_dialect("")),
+        Some(tcl_registry::registry_for_dialect(&analysis.dialect)),
     ) {
-        return vec![span_to_range(source, &line_index, proc_def.name_span)];
+        // A proc redefined later in the document is two definitions sharing
+        // one name; the call reaches whichever was in effect where it is
+        // written, not unconditionally the last (issue #923 idx 45).
+        let in_effect = analysis
+            .proc_def_in_effect_at(&proc_def.qualified_name, cursor_offset)
+            .unwrap_or(proc_def);
+        return vec![span_to_range(source, &line_index, in_effect.name_span)];
     }
     if let Some(span) = class_declaration_at(analysis, &word, cursor_offset) {
         return vec![span_to_range(source, &line_index, span)];
@@ -270,23 +308,33 @@ pub fn definition(
     if let Some(span) = lookup_class_member(analysis, &word, cursor_offset) {
         return vec![span_to_range(source, &line_index, span)];
     }
-    // Alias resolution — when the cursor's word matches an
-    // `interp alias {} ALIAS {} TARGET` recorded in
-    // `analysis.command_aliases`, jump to the TARGET proc.  An alias target
-    // is looked up when the alias fires, from the global namespace, so its
-    // resolution context is `"::"` wherever the alias was written.
-    if let Some(alias) = lookup_alias(analysis, &word)
-        && let Some(proc_def) = resolve_called_proc(
-            analysis,
-            source,
-            "::",
-            &alias.target,
-            Some(tcl_registry::registry_for_dialect("")),
-        )
-    {
-        return vec![span_to_range(source, &line_index, proc_def.name_span)];
-    }
     Vec::new()
+}
+
+/// The declaration span a word reaches through the document's command-table
+/// mutations — `rename OLD NEW` and `interp alias {} ALIAS {} TARGET` — or
+/// `None` when no in-effect indirection covers it.
+///
+/// One tier for both hop kinds and both target kinds, so nothing that
+/// navigates has to know which mutation produced the binding.  The chain
+/// itself is resolved by [`command_indirection_target`]; the terminal name is
+/// then resolved as an ordinary command would be: as a user `proc` (from the
+/// global namespace, where an alias target and a rename source are both
+/// looked up when the binding fires) and then as a class.  A chain ending on a
+/// registry builtin (`interp alias {} mycmd {} puts`) has no Tcl source to
+/// jump to, so it correctly answers nothing rather than guessing.
+fn indirect_definition_target(
+    analysis: &AnalysisResult,
+    source: &str,
+    cursor_off: u32,
+    word: &str,
+) -> Option<tcl_lexer::Span> {
+    let target = command_indirection_target(analysis, word, cursor_off)?;
+    let registry = tcl_registry::registry_for_dialect(&analysis.dialect);
+    if let Some(proc_def) = resolve_called_proc(analysis, source, "::", &target, Some(registry)) {
+        return Some(proc_def.name_span);
+    }
+    class_declaration_at(analysis, &target, cursor_off)
 }
 
 /// The cursor context [`position_definition`] needs beyond the offset.
@@ -725,13 +773,11 @@ fn lookup_method_in_class(
 /// these keywords propagates through its `CommandSpec`, never through a
 /// walker edit.
 ///
-/// The dialect-less callers below pass `""`, which resolves to the
-/// permissive plain-Tcl profile — availability mask `ALL_TCL`, so every 8.6+
-/// `TclOO` keyword resolves. `definition` reaches its providers without a
-/// dialect string in scope (as its three pre-existing
-/// `registry_for_dialect("")` call sites already show); threading a real
-/// dialect through every `go-to-definition` entry point is worth doing, but
-/// as its own change.
+/// `definition` threads `AnalysisResult::dialect` — the dialect the document
+/// was actually analysed under — through its own registry lookups (issue
+/// #1064). The remaining `""` callers are the ones with no analysis in scope;
+/// `""` resolves to the permissive plain-Tcl profile (availability mask
+/// `ALL_TCL`), so every 8.6+ `TclOO` keyword still resolves there.
 pub(crate) fn method_dispatch_keyword_in(
     dialect: &str,
     word: &str,
@@ -746,9 +792,10 @@ pub(crate) fn is_self_dispatch_keyword(word: &str) -> bool {
     method_dispatch_keyword_in("", word) == Some(tcl_registry::MethodDispatchKind::SelfDispatch)
 }
 
-/// Whether `word` is a `TclOO` next-chain keyword (`next` / `nextto`).
-fn is_next_chain_keyword(word: &str) -> bool {
-    method_dispatch_keyword_in("", word) == Some(tcl_registry::MethodDispatchKind::NextChain)
+/// Whether `word` is a `TclOO` next-chain keyword (`next` / `nextto`) under
+/// `dialect` — a registry that predates `TclOO` answers `false`.
+fn is_next_chain_keyword_in(dialect: &str, word: &str) -> bool {
+    method_dispatch_keyword_in(dialect, word) == Some(tcl_registry::MethodDispatchKind::NextChain)
 }
 
 /// Whether a next-chain keyword names an explicit resume-from class in its
@@ -1063,22 +1110,61 @@ pub(crate) fn classmethod_dispatch_class(
         .map(|_| provider_q.to_string())
 }
 
-/// Look up an alias by name.  Accepts the alias's simple or
-/// qualified form (`mycmd` and `::mycmd` both match an alias
-/// stored with `qualified_name == "::mycmd"`).
-fn lookup_alias<'a>(
-    analysis: &'a AnalysisResult,
-    name: &str,
-) -> Option<&'a tcl_compiler::signature_scan::types::SignatureCommandAlias> {
-    let qualified = if name.starts_with("::") {
-        name.to_string()
-    } else {
-        format!("::{name}")
-    };
-    analysis
-        .command_aliases
-        .get(&qualified)
-        .or_else(|| analysis.command_aliases.get(name))
+/// The command name a word written at `cursor_off` actually reaches once the
+/// document's `rename` / `interp alias` statements are taken into account, or
+/// `None` when the command table leaves the word alone there.
+///
+/// The single navigation entry to the shared hop walk
+/// ([`tcl_compiler::analyser::indirection::walk`]) that the analyser's
+/// constructor typing already uses — order-gated, hop-capped, and declining an
+/// argument-prepending alias, all decided in one place so a class that W307
+/// resolves through a rename and a class go-to-definition resolves through the
+/// same rename can never disagree (issues #1062 B1/B2, #1064).
+///
+/// Navigation asks only "which name does this reach"; whether that name has a
+/// user `proc` / class to jump to is the caller's own question, so no liveness
+/// predicate is applied here.  Canonicalisation is the plain
+/// qualified-name normalisation the alias/rename tables are keyed by — a
+/// bare `mycmd` matches an alias stored as `::mycmd`, exactly like the
+/// `lookup_alias` it replaces.
+///
+/// `O(1)` hash lookups bounded by the hop cap: no invocation scan, no source
+/// rescan, so it is safe to call on every request.
+#[must_use]
+pub(crate) fn command_indirection_target(
+    analysis: &AnalysisResult,
+    word: &str,
+    cursor_off: u32,
+) -> Option<String> {
+    tcl_compiler::analyser::indirection::walk(
+        analysis,
+        word,
+        cursor_off,
+        &tcl_syntax::naming::normalise_qualified_name,
+    )
+    .map(|hop| hop.target)
+}
+
+/// Whether `qualified` is a name **this document** only gains through a
+/// `rename` / `interp alias` that has not run yet at `cursor_off`.
+///
+/// The workspace index's command links are position-free by design — a
+/// mutation in *another* file is unconditionally in effect, since that file
+/// loads wholesale — but a link this same document established later in its
+/// own text is not, and following it would resolve a call tclsh answers with
+/// `invalid command name`. The cross-document resolver
+/// (`tcl-lsp-server::resolve_workspace_symbols`) asks this before chasing a
+/// link so its ordering matches the in-document provider's (issue #1064).
+#[must_use]
+pub fn indirection_pending_at(analysis: &AnalysisResult, qualified: &str, cursor_off: u32) -> bool {
+    let key = tcl_syntax::naming::normalise_qualified_name(qualified);
+    let established = analysis
+        .rename_offsets
+        .get(&key)
+        .or_else(|| analysis.alias_offsets.get(&key));
+    established.is_some_and(|&at| {
+        !tcl_compiler::analyser::indirection::in_effect(analysis, at, cursor_off)
+    })
 }
 
 /// Resolve `head sub` (as returned by [`instance_method_at_cursor`], with
@@ -2191,6 +2277,20 @@ pub(crate) fn resolve_proc_target_at<'a>(
     {
         return Some(hit);
     }
+    // A declaration a later same-named `proc` displaced keeps its own name
+    // token, which `all_procs` (winner-only) can never match; it still
+    // declares that qualified name, so resolve through to whichever
+    // definition currently wins for it — the same rule
+    // `tcl-lsp-server::resolve_workspace_symbols` applies cross-document
+    // (issue #923 idx 31 / idx 45).
+    if let Some((qualified, _)) = analysis
+        .proc_declaration_sites
+        .iter()
+        .find(|(_, span)| span.start() <= cursor_off && cursor_off < span.end())
+        && let Some(hit) = analysis.all_procs.get_key_value(qualified)
+    {
+        return Some(hit);
+    }
     // An `expr` math-function call site resolves through the analyser's own
     // two-candidate mathfunc rule, not the ordinary bareword one — so
     // find-references / rename / call-hierarchy / linked-editing triggered
@@ -2203,6 +2303,16 @@ pub(crate) fn resolve_proc_target_at<'a>(
             .resolved_qualified_name
             .as_deref()
             .and_then(|resolved| analysis.all_procs.get_key_value(resolved));
+    }
+    // A word the command table has moved onto (a `rename` destination, an
+    // `interp alias` name) targets the definition it really reaches, so
+    // find-references / rename / call-hierarchy issued from either spelling
+    // converge on one proc (issues #1062 B1/B2, #1064). Order-gated, so a
+    // call written before the mutation still resolves the ordinary way.
+    if let Some(target) = command_indirection_target(analysis, word, cursor_off)
+        && let Some(hit) = analysis.all_procs.get_key_value(&target)
+    {
+        return Some(hit);
     }
     let ns = namespace_context_at(
         &analysis.global_scope,
@@ -2229,6 +2339,18 @@ pub(crate) fn resolve_class_target_at<'a>(
         .all_classes
         .iter()
         .find(|(_, c)| c.name_span.start() <= cursor_off && cursor_off < c.name_span.end())
+    {
+        return Some(hit);
+    }
+    // A `rename Dog Cat` / `interp alias {} Pup {} Dog` makes the written word
+    // reach a class keyed under a different name; the class's own identity
+    // (its `ClassDef`, its method table) is unchanged by the move, so the
+    // canonical name is what the lookup needs. Order-gated by the shared
+    // walk, so `Cat` written before the rename still resolves to nothing here
+    // (issue #1064; the diagnostics side of the same fact is
+    // `class_reachable_by_indirection`).
+    if let Some(target) = command_indirection_target(analysis, word, cursor_off)
+        && let Some(hit) = analysis.all_classes.get_key_value(&target)
     {
         return Some(hit);
     }

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -317,24 +317,37 @@ pub fn definition(
 ///
 /// One tier for both hop kinds and both target kinds, so nothing that
 /// navigates has to know which mutation produced the binding.  The chain
-/// itself is resolved by [`command_indirection_target`]; the terminal name is
-/// then resolved as an ordinary command would be: as a user `proc` (from the
+/// itself is resolved by [`command_indirection`]; the terminal name is then
+/// resolved as an ordinary command would be: as a user `proc` (from the
 /// global namespace, where an alias target and a rename source are both
 /// looked up when the binding fires) and then as a class.  A chain ending on a
 /// registry builtin (`interp alias {} mycmd {} puts`) has no Tcl source to
 /// jump to, so it correctly answers nothing rather than guessing.
+///
+/// The terminal *name* is not by itself the answer when that name has been
+/// redeclared: a `rename` hands over the command **object**, so the definition
+/// the chain captured is the one in effect at the hop's own as-of time
+/// (`Indirection::resolve_at`), not whichever declaration ends up winning the
+/// name.  Oracle (tclsh 8.6.14/9.0.4): `proc p {} {return first}; rename p
+/// oldp; proc p {} {return second}` leaves `oldp` running `first` — so `oldp`
+/// jumps to the *first* header while `p` jumps to the second (PR #1075
+/// review, P2).
 fn indirect_definition_target(
     analysis: &AnalysisResult,
     source: &str,
     cursor_off: u32,
     word: &str,
 ) -> Option<tcl_lexer::Span> {
-    let target = command_indirection_target(analysis, word, cursor_off)?;
+    let hop = command_indirection(analysis, word, cursor_off)?;
     let registry = tcl_registry::registry_for_dialect(&analysis.dialect);
-    if let Some(proc_def) = resolve_called_proc(analysis, source, "::", &target, Some(registry)) {
-        return Some(proc_def.name_span);
+    if let Some(proc_def) = resolve_called_proc(analysis, source, "::", &hop.target, Some(registry))
+    {
+        let captured = analysis
+            .proc_def_in_effect_at(&proc_def.qualified_name, hop.resolve_at)
+            .unwrap_or(proc_def);
+        return Some(captured.name_span);
     }
-    class_declaration_at(analysis, &target, cursor_off)
+    class_declaration_at(analysis, &hop.target, cursor_off)
 }
 
 /// The cursor context [`position_definition`] needs beyond the offset.
@@ -1131,18 +1144,27 @@ pub(crate) fn classmethod_dispatch_class(
 /// `O(1)` hash lookups bounded by the hop cap: no invocation scan, no source
 /// rescan, so it is safe to call on every request.
 #[must_use]
-pub(crate) fn command_indirection_target(
+pub(crate) fn command_indirection(
     analysis: &AnalysisResult,
     word: &str,
     cursor_off: u32,
-) -> Option<String> {
+) -> Option<tcl_compiler::analyser::indirection::Indirection> {
     tcl_compiler::analyser::indirection::walk(
         analysis,
         word,
         cursor_off,
         &tcl_syntax::naming::normalise_qualified_name,
     )
-    .map(|hop| hop.target)
+}
+
+/// [`command_indirection`] for the callers that only need the terminal name.
+#[must_use]
+pub(crate) fn command_indirection_target(
+    analysis: &AnalysisResult,
+    word: &str,
+    cursor_off: u32,
+) -> Option<String> {
+    command_indirection(analysis, word, cursor_off).map(|hop| hop.target)
 }
 
 /// Whether `qualified` is a name **this document** only gains through a
@@ -1155,14 +1177,22 @@ pub(crate) fn command_indirection_target(
 /// `invalid command name`. The cross-document resolver
 /// (`tcl-lsp-server::resolve_workspace_symbols`) asks this before chasing a
 /// link so its ordering matches the in-document provider's (issue #1064).
+///
+/// A name can carry both a `rename` and an `interp alias` record; the document
+/// gains the name as soon as the *first* of them runs, so the question is
+/// asked of the earliest — reading one map ahead of the other would call a
+/// name pending on the strength of a mutation that is not the one that
+/// introduced it (PR #1075 review, P2).
 #[must_use]
 pub fn indirection_pending_at(analysis: &AnalysisResult, qualified: &str, cursor_off: u32) -> bool {
     let key = tcl_syntax::naming::normalise_qualified_name(qualified);
-    let established = analysis
+    let earliest = analysis
         .rename_offsets
         .get(&key)
-        .or_else(|| analysis.alias_offsets.get(&key));
-    established.is_some_and(|&at| {
+        .into_iter()
+        .chain(analysis.alias_offsets.get(&key))
+        .min();
+    earliest.is_some_and(|&at| {
         !tcl_compiler::analyser::indirection::in_effect(analysis, at, cursor_off)
     })
 }

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -165,6 +165,7 @@ pub(crate) fn proc_reference_spans(
     qname: &str,
     proc_def: &tcl_compiler::analyser::ProcDef,
 ) -> Vec<tcl_lexer::Span> {
+    let indirect = indirect_names_reaching(analysis, &proc_def.qualified_name);
     analysis
         .command_invocations
         .iter()
@@ -176,9 +177,73 @@ pub(crate) fn proc_reference_spans(
                     &proc_def.name,
                     &proc_def.qualified_name,
                 )
+                || invocation_references_via_indirection(analysis, inv, &indirect)
         })
         .map(|inv| inv.range)
         .collect()
+}
+
+/// Every command name whose in-document `rename` / `interp alias` chain
+/// terminates on `qualified`, with the offset from which the whole chain is
+/// in effect — the reverse of go-to-definition's forward hop
+/// ([`crate::definition::command_indirection_target`]), so both directions of
+/// navigation read one table.
+///
+/// Built once per reference query by walking the two (normally tiny) command
+/// -mutation maps, never by rescanning the tree, so the per-invocation test
+/// below stays a single hash lookup.
+fn indirect_names_reaching(
+    analysis: &AnalysisResult,
+    qualified: &str,
+) -> std::collections::HashMap<String, u32> {
+    tcl_compiler::analyser::indirection::names_reaching(
+        analysis,
+        qualified,
+        &tcl_syntax::naming::normalise_qualified_name,
+    )
+}
+
+/// Whether call site `inv` reaches this definition **only** through a live
+/// command-table mutation — `interp alias {} sayHi {} greet` makes every
+/// `[sayHi]` a real call site of `greet` (tclsh 8.6.16/9.0.4: both calls
+/// execute `greet`'s body), and `rename greet hello` makes every later
+/// `hello` one (issue #923 idx 21).
+///
+/// Order-gated against the offset that established the chain, so a call
+/// written *before* the alias — which tclsh answers with `invalid command
+/// name` — is not attributed to the target.
+///
+/// Additive to the shared matching rule and deliberately **not** wired into
+/// [`invocation_references_proc`] / [`invocation_references_class`], for
+/// exactly the reason the wildcard-import fallback above isn't: the call
+/// spells the *alias's* name, which a rename of the target must not rewrite
+/// (`rename::rename_proc` calls those two directly and so never sees this),
+/// while Find All References and the code-lens count legitimately want it.
+#[must_use]
+fn invocation_references_via_indirection(
+    analysis: &AnalysisResult,
+    inv: &tcl_compiler::signature_scan::types::SignatureCommandInvocation,
+    indirect: &std::collections::HashMap<String, u32>,
+) -> bool {
+    if indirect.is_empty() {
+        return false;
+    }
+    let candidates = inv
+        .resolution_candidates
+        .iter()
+        .map(String::as_str)
+        .chain(std::iter::once(inv.name.as_str()));
+    candidates.into_iter().any(|cand| {
+        indirect
+            .get(&tcl_syntax::naming::normalise_qualified_name(cand))
+            .is_some_and(|&established| {
+                tcl_compiler::analyser::indirection::in_effect(
+                    analysis,
+                    established,
+                    inv.range.start(),
+                )
+            })
+    })
 }
 
 /// Whether a single call site `inv` references a named proc/class
@@ -588,6 +653,7 @@ pub(crate) fn class_reference_spans(
     qname: &str,
     class_def: &tcl_compiler::analyser::ClassDef,
 ) -> Vec<tcl_lexer::Span> {
+    let indirect = indirect_names_reaching(analysis, &class_def.qualified_name);
     analysis
         .command_invocations
         .iter()
@@ -599,6 +665,7 @@ pub(crate) fn class_reference_spans(
                     &class_def.name,
                     &class_def.qualified_name,
                 )
+                || invocation_references_via_indirection(analysis, inv, &indirect)
         })
         .map(|inv| inv.range)
         .collect()

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -177,17 +177,16 @@ pub(crate) fn proc_reference_spans(
                     &proc_def.name,
                     &proc_def.qualified_name,
                 )
-                || invocation_references_via_indirection(analysis, inv, &indirect)
+                || invocation_references_via_indirection(analysis, inv, &indirect, Some(proc_def))
         })
         .map(|inv| inv.range)
         .collect()
 }
 
 /// Every command name whose in-document `rename` / `interp alias` chain
-/// terminates on `qualified`, with the offset from which the whole chain is
-/// in effect — the reverse of go-to-definition's forward hop
-/// ([`crate::definition::command_indirection_target`]), so both directions of
-/// navigation read one table.
+/// terminates on `qualified`, with how it gets there — the reverse of
+/// go-to-definition's forward hop ([`crate::definition::command_indirection`]),
+/// so both directions of navigation read one table.
 ///
 /// Built once per reference query by walking the two (normally tiny) command
 /// -mutation maps, never by rescanning the tree, so the per-invocation test
@@ -195,7 +194,7 @@ pub(crate) fn proc_reference_spans(
 fn indirect_names_reaching(
     analysis: &AnalysisResult,
     qualified: &str,
-) -> std::collections::HashMap<String, u32> {
+) -> std::collections::HashMap<String, tcl_compiler::analyser::indirection::Reaching> {
     tcl_compiler::analyser::indirection::names_reaching(
         analysis,
         qualified,
@@ -213,6 +212,16 @@ fn indirect_names_reaching(
 /// written *before* the alias — which tclsh answers with `invalid command
 /// name` — is not attributed to the target.
 ///
+/// `target` additionally pins the chain's *identity* when the terminal name
+/// has more than one declaration.  A `rename` hands over the command object,
+/// so `proc p {} {return first}; rename p oldp; proc p {} {return second}`
+/// leaves `oldp` and `p` naming two genuinely different commands (oracle,
+/// tclsh 8.6.14/9.0.4: `oldp` → `first`, `p` → `second`).  Attributing the
+/// `oldp` call sites to whichever declaration currently wins the name `p`
+/// would merge two distinct commands' reference sets and double the winner's
+/// code-lens count (PR #1075 review, P2).  Classes pass `None`: a class name
+/// has exactly one declaration, so there is no identity to disambiguate.
+///
 /// Additive to the shared matching rule and deliberately **not** wired into
 /// [`invocation_references_proc`] / [`invocation_references_class`], for
 /// exactly the reason the wildcard-import fallback above isn't: the call
@@ -223,11 +232,24 @@ fn indirect_names_reaching(
 fn invocation_references_via_indirection(
     analysis: &AnalysisResult,
     inv: &tcl_compiler::signature_scan::types::SignatureCommandInvocation,
-    indirect: &std::collections::HashMap<String, u32>,
+    indirect: &std::collections::HashMap<String, tcl_compiler::analyser::indirection::Reaching>,
+    target: Option<&tcl_compiler::analyser::ProcDef>,
 ) -> bool {
     if indirect.is_empty() {
         return false;
     }
+    let call_off = inv.range.start();
+    let captures_target = |reaching: &tcl_compiler::analyser::indirection::Reaching| {
+        let Some(def) = target else {
+            return true;
+        };
+        // An alias re-resolves by name at every invocation, so its as-of time
+        // is this call site's own offset; a rename froze one.
+        let as_of = reaching.resolve_at.unwrap_or(call_off);
+        analysis
+            .proc_def_in_effect_at(&def.qualified_name, as_of)
+            .is_some_and(|captured| captured.name_span == def.name_span)
+    };
     let candidates = inv
         .resolution_candidates
         .iter()
@@ -236,12 +258,12 @@ fn invocation_references_via_indirection(
     candidates.into_iter().any(|cand| {
         indirect
             .get(&tcl_syntax::naming::normalise_qualified_name(cand))
-            .is_some_and(|&established| {
+            .is_some_and(|reaching| {
                 tcl_compiler::analyser::indirection::in_effect(
                     analysis,
-                    established,
-                    inv.range.start(),
-                )
+                    reaching.established,
+                    call_off,
+                ) && captures_target(reaching)
             })
     })
 }
@@ -665,7 +687,7 @@ pub(crate) fn class_reference_spans(
                     &class_def.name,
                     &class_def.qualified_name,
                 )
-                || invocation_references_via_indirection(analysis, inv, &indirect)
+                || invocation_references_via_indirection(analysis, inv, &indirect, None)
         })
         .map(|inv| inv.range)
         .collect()

--- a/rust/tcl-lsp-core/tests/command_table_mutation.rs
+++ b/rust/tcl-lsp-core/tests/command_table_mutation.rs
@@ -46,6 +46,26 @@
 //!   inscope ::demo Tracer}}` and writing the variable dispatches
 //!   `::demo::Tracer`, so the wrapped `Tracer` word is a real call site.
 //!
+//! Three further claims were pinned on tclsh 9.0.4 and 8.6.14 for the PR
+//! #1075 review round:
+//!
+//! * `proc a {} {return A}` / `proc b {} {return B}` / `rename a x` /
+//!   `interp alias {} x {} b` — `x` returns `B`: the *later* of the two
+//!   bindings on one name is the one the slot holds. (The mirror order is not
+//!   a reachable program: `rename a x` onto a live `x` aborts with `can't
+//!   rename to "x": command already exists`.)
+//! * `proc p {} {return first}` / `rename p oldp` / `proc p {} {return
+//!   second}` — `oldp` returns `first` and `p` returns `second`, and `oldp`'s
+//!   arity is the *first* signature (`wrong # args: should be "oldp a"` for
+//!   `proc p {a}`). A rename hands over the command object, so the two names
+//!   are two different commands.
+//! * `proc outer {} { proc p {} {return one}; p; proc p {a} {…} }` — the bare
+//!   `p` returns `one`: a declaration that is a statement of the body now
+//!   running is in genuine execution order, not covered by the
+//!   load-before-body shortcut. That shortcut still holds for a declaration
+//!   *outside* the body: `proc outer {} { later }` / `proc later {…}` prints
+//!   `LATER`.
+//!
 //! Issue #1064, issue #1062's deferred B1/B2, and issue #923 differential
 //! -audit findings idx 21 / 45 / 89 / 92.
 
@@ -60,6 +80,26 @@ fn analyse(source: &str) -> AnalysisResult {
 
 fn start_lines(ranges: &[LspRange]) -> Vec<u32> {
     ranges.iter().map(|r| r.start_line).collect()
+}
+
+/// The reference count the code lens *displays* for `qname`.
+///
+/// Distinct from [`refs`] on purpose: `references()` dedupes by range, so a
+/// call site recorded twice is invisible there, while `code_lenses` counts
+/// `proc_reference_spans().len()` raw and would show it doubled (PR #1075
+/// review, P2).
+fn lens_count(source: &str, qname: &str) -> usize {
+    let analysis = analyse(source);
+    let title = tcl_lsp_core::code_lens::code_lenses(source, "tcl9.0", Some(&analysis), None, "")
+        .into_iter()
+        .find(|lens| lens.qname == qname)
+        .map_or_else(|| panic!("no lens for {qname}"), |lens| lens.command_title);
+    // `reference_count_title` renders "N references" / "1 reference".
+    title
+        .split_whitespace()
+        .next()
+        .and_then(|n| n.parse().ok())
+        .unwrap_or_else(|| panic!("unparsable lens title {title:?}"))
 }
 
 fn refs(source: &str) -> impl Fn(u32, u32) -> Vec<u32> + '_ {
@@ -296,6 +336,222 @@ fn tp_references_agree_from_either_declaration_of_a_redefined_proc() {
     );
 }
 
+// Latest binding wins when a name carries both a rename and an alias
+// (PR #1075 review, P2)
+
+/// `proc a`, `proc b`, `rename a x`, `interp alias {} x {} b` — oracle
+/// (tclsh 9.0.4 and 8.6.14): `x` returns `B`.  The alias ran last, so it is
+/// what the slot holds; the earlier rename is dead.
+const RENAME_THEN_ALIAS: &str = concat!(
+    "proc a {} { return A }\n",
+    "proc b {} { return B }\n",
+    "rename a x\n",
+    "interp alias {} x {} b\n",
+    "x\n",
+);
+
+#[test]
+fn tp_definition_prefers_the_later_alias_over_an_earlier_rename() {
+    let analysis = analyse(RENAME_THEN_ALIAS);
+    assert_eq!(
+        start_lines(&definition(RENAME_THEN_ALIAS, 4, 0, &analysis)),
+        vec![1],
+        "`x` reaches `b`, the binding written last — not `a`'s rename"
+    );
+}
+
+#[test]
+fn tp_definition_uses_the_rename_while_it_is_still_the_latest_binding() {
+    // The same document read *between* the two mutations: only the rename has
+    // run there, so `x` is still `a` (tclsh: a call placed there prints `A`).
+    let src = concat!(
+        "proc a {} { return A }\n",
+        "proc b {} { return B }\n",
+        "rename a x\n",
+        "x\n",
+        "interp alias {} x {} b\n",
+    );
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 3, 0, &analysis)),
+        vec![0],
+        "before the alias replaces it, the rename is the live binding"
+    );
+}
+
+#[test]
+fn tp_references_follow_the_latest_binding_not_the_first_map_read() {
+    let query = refs(RENAME_THEN_ALIAS);
+    assert_eq!(
+        query(1, 5),
+        vec![1, 3, 4],
+        "`b` owns the post-alias `x` call site"
+    );
+    assert_eq!(
+        query(0, 5),
+        vec![0, 2],
+        "`a` keeps only its declaration and the rename's own source word"
+    );
+}
+
+#[test]
+fn tp_alias_onto_a_live_command_still_resolves_when_written_first() {
+    // The mirror order is not a reachable program — `rename a x` onto a live
+    // `x` aborts with `can't rename to "x": command already exists` (tclsh
+    // 9.0.4 and 8.6.14) — but the walk must still terminate and answer with
+    // the latest binding rather than looping or preferring by map order.
+    let src = concat!(
+        "proc a {} { return A }\n",
+        "proc b {} { return B }\n",
+        "interp alias {} x {} b\n",
+        "rename a x\n",
+        "x\n",
+    );
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 4, 0, &analysis)),
+        vec![0],
+        "the rename is the later binding of the two"
+    );
+}
+
+// A rename moves the command object (PR #1075 review, P2)
+
+/// Oracle (tclsh 9.0.4 and 8.6.14): `oldp` → `first`, `p` → `second`.  The
+/// rename handed `oldp` the object `p` held *then*; the later `proc p` builds
+/// a new, unrelated command under the vacated name.
+const RENAME_THEN_REDEFINE: &str = concat!(
+    "proc p {} { return first }\n",
+    "rename p oldp\n",
+    "proc p {} { return second }\n",
+    "oldp\n",
+    "p\n",
+);
+
+#[test]
+fn tp_definition_through_a_rename_reaches_the_declaration_it_captured() {
+    let analysis = analyse(RENAME_THEN_REDEFINE);
+    assert_eq!(
+        start_lines(&definition(RENAME_THEN_REDEFINE, 3, 0, &analysis)),
+        vec![0],
+        "`oldp` runs the definition the rename froze, not `p`'s successor"
+    );
+    assert_eq!(
+        start_lines(&definition(RENAME_THEN_REDEFINE, 4, 0, &analysis)),
+        vec![2],
+        "`p` itself reaches the redefinition"
+    );
+}
+
+#[test]
+fn tn_references_do_not_merge_two_commands_split_by_a_rename() {
+    // `oldp` and `p` are two different commands after the redefinition, so
+    // the `oldp` call site is not a reference to the surviving `p`.
+    let query = refs(RENAME_THEN_REDEFINE);
+    assert!(
+        !query(2, 5).contains(&3),
+        "the `oldp` call belongs to the captured definition, not to `p`"
+    );
+    assert_eq!(
+        query(2, 5),
+        vec![1, 2, 4],
+        "the rename's own source word, this header, and `p`'s own call"
+    );
+}
+
+#[test]
+fn tp_references_through_a_rename_without_a_redefinition_are_unaffected() {
+    // TN guard for the identity check: with a single declaration there is
+    // nothing to disambiguate, so idx 21's plain case still unifies.
+    let src = "proc greet {} { return hi }\nrename greet hello\nhello\n";
+    assert_eq!(refs(src)(0, 6), vec![0, 1, 2]);
+}
+
+// Same-body redefinition order (PR #1075 review, P2)
+
+#[test]
+fn tp_definition_inside_a_body_respects_that_bodys_own_redefinitions() {
+    // Oracle (tclsh 9.0.4 and 8.6.14) for
+    // `proc outer {} { proc p {} {return one}; p; proc p {a} {…} }`: the bare
+    // `p` prints `one`.  The redefinitions are statements of the body that is
+    // running, so they are in genuine execution order — the load-before-body
+    // shortcut does not apply to them.
+    let src = concat!(
+        "proc outer {} {\n",
+        "    proc p {} { return one }\n",
+        "    p\n",
+        "    proc p {a} { return two }\n",
+        "}\n",
+    );
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 2, 4, &analysis)),
+        vec![1],
+        "the in-between call reaches the declaration already executed"
+    );
+}
+
+#[test]
+fn tp_definition_inside_a_body_still_sees_a_later_top_level_declaration() {
+    // TN for the same rule: a proc declared *outside* the body, after it, has
+    // run by the time the body executes (tclsh: `outer` prints `LATER`).
+    // This is what the load-before-body shortcut exists for.
+    let src = concat!(
+        "proc outer {} {\n",
+        "    later\n",
+        "}\n",
+        "proc later {} { return LATER }\n",
+        "outer\n",
+    );
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 1, 4, &analysis)),
+        vec![3],
+        "a declaration outside the running body is already in effect"
+    );
+}
+
+#[test]
+fn tn_definition_declines_a_same_body_rename_written_after_the_call() {
+    // The identical rule for the mutation timeline: a `rename` that is a
+    // statement of the running body has not run yet at an earlier call in
+    // that same body (tclsh: `invalid command name "x"`).
+    let src = concat!(
+        "proc a {} { return A }\n",
+        "proc outer {} {\n",
+        "    x\n",
+        "    rename a x\n",
+        "}\n",
+    );
+    let analysis = analyse(src);
+    assert!(
+        definition(src, 2, 4, &analysis).is_empty(),
+        "a same-body rename below the call has not run yet"
+    );
+}
+
+#[test]
+fn tp_definition_follows_a_rename_from_another_bodys_statement() {
+    // TN guard for the narrowing above: a rename inside a *different* body is
+    // still leniently in effect — whether that body ever runs is not
+    // statically decidable, and this is the pre-existing behaviour.
+    let src = concat!(
+        "proc a {} { return A }\n",
+        "proc installer {} {\n",
+        "    rename a x\n",
+        "}\n",
+        "proc caller {} {\n",
+        "    x\n",
+        "}\n",
+    );
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 5, 4, &analysis)),
+        vec![0],
+        "a rename in another body still resolves the call"
+    );
+}
+
 // `namespace code [list X]` callbacks (issue #923 idx 92)
 
 const TRACER: &str = concat!(
@@ -352,6 +608,44 @@ fn tn_namespace_code_does_not_double_count_a_braced_callback() {
         vec![2, 4],
         "exactly one call site, not two"
     );
+}
+
+/// The bare, `[list]`-wrapped, and braced forms of the same callback, which
+/// must all read as exactly one reference apiece.
+fn tracer_source(callback: &str) -> String {
+    format!(
+        concat!(
+            "namespace eval ::demo {{\n",
+            "    variable S\n",
+            "    proc Tracer {{a b op}} {{ }}\n",
+            "    proc Setup {{}} {{\n",
+            "        trace add variable S(size) write {callback}\n",
+            "    }}\n",
+            "}}\n",
+        ),
+        callback = callback
+    )
+}
+
+#[test]
+fn tp_lens_counts_each_namespace_code_callback_shape_once() {
+    // The lens count is the raw span count, so a call site recorded by both
+    // the body recursion and the command-prefix unwrap shows up as two
+    // references for one callback (PR #1075 review, P2). One recorder per
+    // shape: `[namespace code X]` and `[namespace code {X}]` are recorded by
+    // the analyser's `ArgRole::Body` walk, `[namespace code [list X]]` — which
+    // that walk's `has_substitution` guard stops at — by the unwrap.
+    for callback in [
+        "[namespace code Tracer]",
+        "[namespace code {Tracer}]",
+        "[namespace code [list Tracer]]",
+    ] {
+        assert_eq!(
+            lens_count(&tracer_source(callback), "::demo::Tracer"),
+            1,
+            "one callback site, one reference, for {callback}"
+        );
+    }
 }
 
 #[test]

--- a/rust/tcl-lsp-core/tests/command_table_mutation.rs
+++ b/rust/tcl-lsp-core/tests/command_table_mutation.rs
@@ -1,0 +1,376 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Navigation across a **mutated command table**: `rename`, `interp alias`,
+//! and `proc` self-redefinition, plus the `[namespace code [list X]]`
+//! callback wrapper.
+//!
+//! Tcl's command table is not fixed at parse time, so a call site's spelling
+//! does not by itself name the definition it reaches. Every claim below is
+//! pinned to real C Tcl (tclsh 9.0.4 and tclsh 8.6.16 agree on all of them):
+//!
+//! * `proc greet {} {return hi}` / `rename greet hello` — `hello` then
+//!   returns `hi`, `greet` raises `invalid command name "greet"`, and a
+//!   `hello` written *before* the rename raises `invalid command name
+//!   "hello"`. Go-to-definition therefore resolves `hello` after the rename
+//!   and abstains before it.
+//! * `interp alias {} sayHi {} greet` + two `[sayHi]` calls — `greet`'s body
+//!   runs twice, so both `[sayHi]` sites are real references to `greet`.
+//! * `proc ::ttk::spinbox …` / `proc ::tk::spinbox …` / `interp alias {}
+//!   ::ttk::spinbox {} ::tk::spinbox` — a later `::ttk::spinbox` call prints
+//!   `classic tk::spinbox:`, i.e. the alias has replaced the original proc,
+//!   which is unreachable under that name from the alias onward.
+//! * `interp alias {} withextra {} target pre` — `withextra x` fails `wrong #
+//!   args: should be "withextra"`, so an argument-prepending alias is not the
+//!   same call and navigation declines it.
+//! * `proc p {} {return first}` / `p` / `proc p {a} {…}` / `p x` — the first
+//!   call returns `first` and the second dispatches the one-parameter
+//!   definition, so the two call sites resolve to two different headers.
+//! * `trace add variable S(size) write [namespace code [list Tracer]]` —
+//!   `trace info variable ::demo::S(size)` reports `{write {::namespace
+//!   inscope ::demo Tracer}}` and writing the variable dispatches
+//!   `::demo::Tracer`, so the wrapped `Tracer` word is a real call site.
+//!
+//! Issue #1064, issue #1062's deferred B1/B2, and issue #923 differential
+//! -audit findings idx 21 / 45 / 89 / 92.
+
+use tcl_compiler::analyser::{Analyser, AnalysisResult};
+use tcl_lsp_core::definition::{LspRange, definition};
+use tcl_lsp_core::references::references;
+
+fn analyse(source: &str) -> AnalysisResult {
+    let mut a = Analyser::new();
+    a.analyse(source, "tcl9.0")
+}
+
+fn start_lines(ranges: &[LspRange]) -> Vec<u32> {
+    ranges.iter().map(|r| r.start_line).collect()
+}
+
+fn refs(source: &str) -> impl Fn(u32, u32) -> Vec<u32> + '_ {
+    let analysis = analyse(source);
+    move |line, character| {
+        let mut lines = start_lines(&references(
+            source, "tcl9.0", line, character, &analysis, true,
+        ));
+        lines.sort_unstable();
+        lines
+    }
+}
+
+// rename — go-to-definition (issue #1064)
+
+#[test]
+fn tp_definition_follows_rename_to_the_original_proc() {
+    // TP: `hello` after `rename greet hello` runs `greet`'s body.
+    let src = "proc greet {} { return hi }\nrename greet hello\nhello\n";
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 2, 1, &analysis)),
+        vec![0],
+        "the renamed-to name resolves to the original declaration"
+    );
+}
+
+#[test]
+fn tn_definition_declines_a_rename_written_after_the_call() {
+    // TN: order gate. tclsh raises `invalid command name "hello"` for a call
+    // that precedes the rename, so there is nothing to navigate to.
+    let src = "proc greet {} { return hi }\nhello\nrename greet hello\n";
+    let analysis = analyse(src);
+    assert!(
+        definition(src, 1, 1, &analysis).is_empty(),
+        "a rename that has not run yet must not resolve the call"
+    );
+}
+
+#[test]
+fn tp_definition_follows_rename_inside_a_body_regardless_of_order() {
+    // TP: the whole file loads before any body runs, so a rename written
+    // after a proc that uses the new name is still in effect when that body
+    // executes (tclsh 9.0.4/8.6.16: `caller` prints `hi`).
+    let src = "proc greet {} { return hi }\nproc caller {} { hello }\nrename greet hello\ncaller\n";
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 1, 18, &analysis)),
+        vec![0],
+        "a body-internal call sees the file's renames"
+    );
+}
+
+#[test]
+fn tp_definition_follows_rename_to_a_class() {
+    // TP: `rename Dog Cat` makes `Cat` the class command; the `ClassDef` is
+    // unchanged (tclsh: `[Cat new]` builds a Dog and answers `bark`).
+    let src = "oo::class create Dog {\n    method bark {} { return woof }\n}\nrename Dog Cat\nset d [Cat new]\n";
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 4, 8, &analysis)),
+        vec![0],
+        "the renamed class command resolves to the class declaration"
+    );
+}
+
+// interp alias — go-to-definition (issue #923 idx 89)
+
+#[test]
+fn tp_definition_prefers_an_alias_over_the_proc_it_replaced() {
+    // TP: the alias silently replaces the same-named proc, so the call
+    // reaches `::tk::spinbox`, not the now-dead `::ttk::spinbox` body.
+    let src = concat!(
+        "namespace eval ::ttk {}\n",
+        "namespace eval ::tk {}\n",
+        "proc ::ttk::spinbox {w args} { }\n",
+        "proc ::tk::spinbox {w args} { }\n",
+        "interp alias {} ::ttk::spinbox {} ::tk::spinbox\n",
+        "::ttk::spinbox .sb\n",
+    );
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 5, 2, &analysis)),
+        vec![3],
+        "the call after the alias resolves to the alias target"
+    );
+}
+
+#[test]
+fn tn_definition_keeps_the_original_proc_before_the_alias_runs() {
+    // TN: the same call written *before* the alias still reaches the
+    // original proc — the mutation has not happened yet.
+    let src = concat!(
+        "namespace eval ::ttk {}\n",
+        "namespace eval ::tk {}\n",
+        "proc ::ttk::spinbox {w args} { }\n",
+        "proc ::tk::spinbox {w args} { }\n",
+        "::ttk::spinbox .early\n",
+        "interp alias {} ::ttk::spinbox {} ::tk::spinbox\n",
+    );
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 4, 2, &analysis)),
+        vec![2],
+        "the pre-alias call still reaches the original proc"
+    );
+}
+
+#[test]
+fn tn_definition_declines_an_argument_prepending_alias() {
+    // TN: `interp alias {} withextra {} target pre` binds a leading argument,
+    // so `withextra` is not the call `target` would be; navigation abstains
+    // rather than pointing at a signature that does not describe it.
+    let src = "proc target {a} { return $a }\ninterp alias {} withextra {} target pre\nwithextra\n";
+    let analysis = analyse(src);
+    assert!(
+        definition(src, 2, 2, &analysis).is_empty(),
+        "an alias with prepended arguments is not a navigable hop"
+    );
+}
+
+// find-references across the mutation (issue #923 idx 21 / 89)
+
+#[test]
+fn tp_references_include_call_sites_spelled_through_an_alias() {
+    // TP: both `[sayHi]` calls really execute `greet`, so a reference query
+    // from `greet`'s declaration must list them.
+    let src =
+        "proc greet {} { return hi }\ninterp alias {} sayHi {} greet\nputs [sayHi]\nputs [sayHi]\n";
+    assert_eq!(
+        refs(src)(0, 6),
+        vec![0, 1, 2, 3],
+        "declaration, the alias target word, and both alias call sites"
+    );
+}
+
+#[test]
+fn tp_references_from_the_alias_name_offer_the_targets_sites() {
+    // TP: the reverse direction — a query on the alias's own call site
+    // resolves through to the target and answers the same unified set, the
+    // convention rename/references already use for a renamed classmethod.
+    let src =
+        "proc greet {} { return hi }\ninterp alias {} sayHi {} greet\nputs [sayHi]\nputs [sayHi]\n";
+    assert_eq!(
+        refs(src)(2, 6),
+        vec![0, 1, 2, 3],
+        "the alias name resolves to the target's reference set"
+    );
+}
+
+#[test]
+fn tp_references_include_call_sites_spelled_through_a_rename() {
+    let src = "proc greet {} { return hi }\nrename greet hello\nhello\n";
+    assert_eq!(
+        refs(src)(0, 6),
+        vec![0, 1, 2],
+        "declaration, the rename's own source word, and the renamed call"
+    );
+}
+
+#[test]
+fn tn_references_exclude_a_call_written_before_the_alias() {
+    // TN: `sayHi` before the alias is `invalid command name` in tclsh, so it
+    // is not a reference to `greet`.
+    let src = "proc greet {} { return hi }\nputs [sayHi]\ninterp alias {} sayHi {} greet\n";
+    assert_eq!(
+        refs(src)(0, 6),
+        vec![0, 2],
+        "only the declaration and the alias target word"
+    );
+}
+
+#[test]
+fn tp_references_on_an_alias_target_reach_the_shadowing_call_site() {
+    // TP: idx 89's other half — `::tk::spinbox`'s reference set must include
+    // the `::ttk::spinbox` call the alias redirects onto it.
+    let src = concat!(
+        "namespace eval ::ttk {}\n",
+        "namespace eval ::tk {}\n",
+        "proc ::ttk::spinbox {w args} { }\n",
+        "proc ::tk::spinbox {w args} { }\n",
+        "interp alias {} ::ttk::spinbox {} ::tk::spinbox\n",
+        "::ttk::spinbox .sb\n",
+    );
+    assert_eq!(
+        refs(src)(3, 12),
+        vec![3, 4, 5],
+        "declaration, the alias target word, and the redirected call site"
+    );
+}
+
+// proc self-redefinition (issue #923 idx 45)
+
+#[test]
+fn tp_definition_between_two_declarations_reaches_the_first() {
+    // TP: the in-between call runs the first definition (tclsh: `first`).
+    let src = "proc p {} { return 1 }\np\nproc p {a} { return $a }\np x\n";
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 1, 0, &analysis)),
+        vec![0],
+        "the call between the two declarations reaches the first"
+    );
+    assert_eq!(
+        start_lines(&definition(src, 3, 0, &analysis)),
+        vec![2],
+        "the call after both reaches the second"
+    );
+}
+
+#[test]
+fn tp_definition_on_a_superseded_header_stays_on_that_header() {
+    // TP: a cursor on the displaced declaration's own name token resolves to
+    // itself, not to its successor five lines down.
+    let src = "proc p {} { return 1 }\nproc p {a} { return $a }\n";
+    let analysis = analyse(src);
+    assert_eq!(
+        start_lines(&definition(src, 0, 5, &analysis)),
+        vec![0],
+        "the superseded declaration is still a declaration"
+    );
+}
+
+#[test]
+fn tp_references_agree_from_either_declaration_of_a_redefined_proc() {
+    // TP: both headers name one command, so both answer the same set.
+    let src = "proc p {} { return 1 }\np\nproc p {a} { return $a }\np x\n";
+    let query = refs(src);
+    assert_eq!(query(0, 5), query(2, 5), "both headers agree");
+    assert_eq!(
+        query(0, 5),
+        vec![1, 2, 3],
+        "declaration plus both call sites"
+    );
+}
+
+// `namespace code [list X]` callbacks (issue #923 idx 92)
+
+const TRACER: &str = concat!(
+    "namespace eval ::demo {\n",
+    "    variable S\n",
+    "    proc Tracer {a b op} { }\n",
+    "    proc Setup {} {\n",
+    "        trace add variable S(size) write [namespace code [list Tracer]]\n",
+    "    }\n",
+    "}\n",
+);
+
+#[test]
+fn tp_references_reach_a_namespace_code_list_wrapped_callback() {
+    // TP: the trace really dispatches `::demo::Tracer`, so the wrapped word
+    // is a call site of it.
+    assert_eq!(
+        refs(TRACER)(2, 10),
+        vec![2, 4],
+        "declaration plus the wrapped callback site"
+    );
+}
+
+#[test]
+fn tp_references_reach_a_namespace_code_bareword_callback() {
+    // TP: the bare form is the same fact with no `[list]` around it.
+    let src = concat!(
+        "namespace eval ::demo {\n",
+        "    variable S\n",
+        "    proc Tracer {a b op} { }\n",
+        "    proc Setup {} {\n",
+        "        trace add variable S(size) write [namespace code Tracer]\n",
+        "    }\n",
+        "}\n",
+    );
+    assert_eq!(refs(src)(2, 10), vec![2, 4]);
+}
+
+#[test]
+fn tn_namespace_code_does_not_double_count_a_braced_callback() {
+    // TN/FP guard: the braced form is already walked as an ordinary script
+    // body, so the command-prefix unwrap must not record it a second time.
+    let src = concat!(
+        "namespace eval ::demo {\n",
+        "    variable S\n",
+        "    proc Tracer {a b op} { }\n",
+        "    proc Setup {} {\n",
+        "        trace add variable S(size) write [namespace code {Tracer}]\n",
+        "    }\n",
+        "}\n",
+    );
+    assert_eq!(
+        refs(src)(2, 10),
+        vec![2, 4],
+        "exactly one call site, not two"
+    );
+}
+
+#[test]
+fn tn_namespace_code_with_a_dynamic_head_stays_unrecorded() {
+    // TN: `[namespace code [list $cb]]` names no statically-known command;
+    // recording it would invent a reference (and a W123) out of a runtime
+    // value.
+    let src = concat!(
+        "namespace eval ::demo {\n",
+        "    variable S\n",
+        "    proc Tracer {a b op} { }\n",
+        "    proc Setup {cb} {\n",
+        "        trace add variable S(size) write [namespace code [list $cb]]\n",
+        "    }\n",
+        "}\n",
+    );
+    assert_eq!(
+        refs(src)(2, 10),
+        vec![2],
+        "the declaration only — a dynamic head is not a reference"
+    );
+}

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4520,6 +4520,7 @@ impl Backend {
         };
         let covers =
             |sp: tcl_lexer::Span| (sp.start() as usize) <= offset && offset < (sp.end() as usize);
+        let offset_u32 = u32::try_from(offset).unwrap_or(u32::MAX);
 
         // A declaration in a *sourced* document resolves standalone to its
         // global-rooted name; the index holds one source-site re-homed twin
@@ -4583,6 +4584,15 @@ impl Backend {
                 // declaration-vs-call-site / cross-file oracle), not a
                 // caller of it, so it needs its own copy of the same check.
                 let has_builtin = registry.get(cand.trim_start_matches("::")).is_some();
+                // A name this document only gains from a `rename` / `interp
+                // alias` written *after* the cursor is not a command here yet
+                // (tclsh: `invalid command name`), so its workspace link must
+                // not settle the call — the index's links are position-free
+                // because a mutation in another file loads wholesale, which
+                // is not true of one in this file (issue #1064).
+                if core_definition::indirection_pending_at(analysis, cand, offset_u32) {
+                    return false;
+                }
                 let same_file_hit = analysis.all_procs.get(cand).is_some_and(|p| {
                     !has_builtin
                         || !analysis.offset_is_inside_any_definition_body(p.name_span.start())

--- a/rust/tcl-lsp-server/tests/e2e/definition.rs
+++ b/rust/tcl-lsp-server/tests/e2e/definition.rs
@@ -488,6 +488,99 @@ fn foreach_rename_reinstall_idiom_resolves_to_the_wrapper_not_the_stale_original
     );
 }
 
+/// Issue #1064 / #1062's deferred B1: go-to-definition follows a `rename`.
+/// tclsh 9.0.4 and 8.6.16 both prove `hello` runs `greet`'s body after
+/// `rename greet hello` (and that `greet` is then `invalid command name`),
+/// so the call site's declaration is the original `proc greet` header.
+#[test]
+fn definition_follows_a_rename_to_the_original_proc_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc greet {} { return hi }\nrename greet hello\nhello\n",
+    );
+    // Line 2: `hello` — cursor on the renamed-to call.
+    let locs = locations(&lsp.definition(&uri, 2, 1));
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(
+        start_line(&locs[0]),
+        0,
+        "the renamed-to call resolves to `proc greet` (line 0): {locs:?}"
+    );
+}
+
+/// The order-gated other direction of the same fact: a call written *before*
+/// the rename is `invalid command name "hello"` on both tclsh 9.0.4 and
+/// 8.6.16, so there is nothing to navigate to and the provider must abstain
+/// rather than resolve backwards through a mutation that has not run.
+#[test]
+fn definition_declines_a_rename_written_after_the_call_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc greet {} { return hi }\nhello\nrename greet hello\n",
+    );
+    let locs = locations(&lsp.definition(&uri, 1, 1));
+    assert!(
+        locs.is_empty(),
+        "a rename that has not run yet must not resolve the call: {locs:?}"
+    );
+}
+
+/// idx 89 (differential-audit main audit wave): `interp alias {} NAME {}
+/// TARGET` silently *replaces* an existing command of that name — the real
+/// `tk/library/accessibility.tcl` `interp alias {} ::ttk::spinbox {}
+/// ::tk::spinbox` trick. tclsh 9.0.4 and 8.6.16 both print `classic
+/// tk::spinbox:` for a later `::ttk::spinbox` call, so the original proc is
+/// dead code under that name and the call's definition is the alias target.
+#[test]
+fn definition_prefers_an_alias_over_the_proc_it_replaced_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval ::ttk {}\nnamespace eval ::tk {}\nproc ::ttk::spinbox {w args} { }\nproc ::tk::spinbox {w args} { }\ninterp alias {} ::ttk::spinbox {} ::tk::spinbox\n::ttk::spinbox .sb\n",
+    );
+    // Line 5: `::ttk::spinbox .sb` — cursor on the call's head.
+    let locs = locations(&lsp.definition(&uri, 5, 2));
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(
+        start_line(&locs[0]),
+        3,
+        "must resolve to the alias target `proc ::tk::spinbox` (line 3), not the replaced `::ttk::spinbox` (line 2): {locs:?}"
+    );
+}
+
+/// idx 45 (differential-audit main audit wave): a proc redefined later in the
+/// same document is two definitions sharing one name. tclsh 9.0.4 and 8.6.16
+/// both prove the call *between* them runs the first body, so it must
+/// resolve to the first header even though the map keeps only the second.
+#[test]
+fn definition_between_two_declarations_reaches_the_first_end_to_end() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc p {} { return first }\np\nproc p {a} { return $a }\np x\n",
+    );
+    let first = locations(&lsp.definition(&uri, 1, 0));
+    assert_eq!(first.len(), 1, "{first:?}");
+    assert_eq!(
+        start_line(&first[0]),
+        0,
+        "the in-between call reaches the first definition: {first:?}"
+    );
+    let second = locations(&lsp.definition(&uri, 3, 0));
+    assert_eq!(second.len(), 1, "{second:?}");
+    assert_eq!(
+        start_line(&second[0]),
+        2,
+        "the trailing call reaches the redefinition: {second:?}"
+    );
+}
+
 /// idx 90 (differential-audit main audit wave, high severity): `tcl::OptProc`
 /// had no `AnalyserHookId` at all, so go-to-definition from a real call
 /// site fell through to nothing (the stub proc's stale, unresolved

--- a/rust/tcl-lsp-server/tests/e2e/references.rs
+++ b/rust/tcl-lsp-server/tests/e2e/references.rs
@@ -499,6 +499,69 @@ fn references_reach_the_current_documents_own_call_when_it_has_no_local_declarat
     assert_eq!(lines.len(), 2, "{lines:?}");
 }
 
+/// idx 21 (differential-audit main audit wave): `interp alias {} sayHi {}
+/// greet` makes every `[sayHi]` a real call site of `greet` — tclsh 9.0.4
+/// and 8.6.16 both execute `greet`'s body twice for the two calls below.
+/// Find-references never consulted the alias table, so a user asking whether
+/// `greet` was safe to delete was told it had no callers.
+#[test]
+fn references_include_call_sites_spelled_through_an_alias() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc greet {} { return hi }\ninterp alias {} sayHi {} greet\nputs [sayHi]\nputs [sayHi]\n",
+    );
+    // Line 0: cursor on the `greet` declaration.
+    let lines = start_lines(&lsp.references(&uri, 0, 6, true));
+    assert!(lines.contains(&0), "decl missing: {lines:?}");
+    assert!(
+        lines.contains(&2) && lines.contains(&3),
+        "both alias call sites must be reported: {lines:?}"
+    );
+}
+
+/// The reverse direction of the same fact: a query from the alias's own call
+/// site resolves through to the target and answers the identical unified set.
+#[test]
+fn references_from_an_alias_call_site_offer_the_targets_sites() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc greet {} { return hi }\ninterp alias {} sayHi {} greet\nputs [sayHi]\nputs [sayHi]\n",
+    );
+    // Line 2: cursor on the `sayHi` call.
+    let lines = start_lines(&lsp.references(&uri, 2, 6, true));
+    assert!(lines.contains(&0), "the target's decl missing: {lines:?}");
+    assert!(
+        lines.contains(&2) && lines.contains(&3),
+        "both alias call sites must be reported: {lines:?}"
+    );
+}
+
+/// idx 92 (differential-audit main audit wave): the `[namespace code [list
+/// ProcName]]` callback wrapper Tk's own `library/fontchooser.tcl` uses ten
+/// times. tclsh 9.0.4 and 8.6.16 both report the installed trace as
+/// `{write {::namespace inscope ::demo Tracer}}` and really dispatch
+/// `::demo::Tracer` on a write, so the wrapped word is a genuine call site.
+#[test]
+fn references_reach_a_namespace_code_list_wrapped_callback() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval ::demo {\n    variable S\n    proc Tracer {a b op} { }\n    proc Setup {} {\n        trace add variable S(size) write [namespace code [list Tracer]]\n    }\n}\n",
+    );
+    // Line 2: cursor on the `Tracer` declaration.
+    let lines = start_lines(&lsp.references(&uri, 2, 10, true));
+    assert!(lines.contains(&2), "decl missing: {lines:?}");
+    assert!(
+        lines.contains(&4),
+        "the `[namespace code [list Tracer]]` callback site is missing: {lines:?}"
+    );
+}
+
 /// idx 63 (differential-audit main audit wave, high severity): a `my
 /// methodName` call written inside a `switch` arm body is a genuine,
 /// statically-known call site (tclsh9.0/8.6-verified) — the real corpus

--- a/rust/tcl-lsp-server/tests/e2e/rename.rs
+++ b/rust/tcl-lsp-server/tests/e2e/rename.rs
@@ -636,6 +636,68 @@ fn rename_rewrites_the_renames_own_old_word_too() {
     assert!(for_uri.iter().all(|e| e["newText"] == "newName"));
 }
 
+/// FP guard for issue #923 idx 21: find-references now attributes an alias's
+/// call sites to the target proc, but **rename must not rewrite them**. A
+/// `[sayHi]` call names the *alias*, which keeps its own spelling when the
+/// target is renamed — tclsh 9.0.4/8.6.16 confirm `interp alias {} sayHi {}
+/// greet` followed by `rename greet hi2` leaves `sayHi` bound (it re-resolves
+/// `greet`, which is now gone, and fails) — so rewriting the call site would
+/// change a different command's name.
+#[test]
+fn rename_does_not_rewrite_call_sites_that_go_through_an_alias() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc greet {} { return hi }\ninterp alias {} sayHi {} greet\nputs [sayHi]\n",
+    );
+    // Line 0: cursor on the `greet` declaration.
+    let result = lsp.rename(&uri, 0, 6, "welcome");
+    let edits = rename_edits(&result);
+    let for_uri = edits.get(&uri).cloned().unwrap_or_default();
+    let lines: Vec<i64> = for_uri
+        .iter()
+        .filter_map(|e| e["range"]["start"]["line"].as_i64())
+        .collect();
+    assert!(lines.contains(&0), "decl missing: {for_uri:?}");
+    assert!(
+        lines.contains(&1),
+        "the alias's own TARGET word names `greet` and must be rewritten: {for_uri:?}"
+    );
+    assert!(
+        !lines.contains(&2),
+        "the `[sayHi]` call names the alias, not `greet`, and must be left alone: {for_uri:?}"
+    );
+}
+
+/// idx 45 (differential-audit main audit wave): rename issued from the
+/// declaration a later same-named `proc` displaced must still reach every
+/// call site — the displaced header declares the same command, so a partial
+/// edit would leave callers bound to a name that no longer exists.
+#[test]
+fn rename_from_a_superseded_declaration_rewrites_every_site() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc p {} { return first }\np\nproc p {a} { return $a }\np x\n",
+    );
+    // Line 0: cursor on the *first* (later displaced) `p` declaration.
+    let result = lsp.rename(&uri, 0, 5, "q");
+    let edits = rename_edits(&result);
+    let for_uri = edits.get(&uri).cloned().unwrap_or_default();
+    let lines: Vec<i64> = for_uri
+        .iter()
+        .filter_map(|e| e["range"]["start"]["line"].as_i64())
+        .collect();
+    for expected in [1_i64, 2, 3] {
+        assert!(
+            lines.contains(&expected),
+            "line {expected} must be rewritten: {for_uri:?}"
+        );
+    }
+}
+
 /// idx 56 (differential-audit main audit wave, high severity): a proc
 /// installed directly into `::oo::Helpers` (the documented "`TclOO` Tricks"
 /// idiom — real corpus usage: nico-robert/ticklecharts installs `classvar`/

--- a/rust/tcl-registry/examples/dump_specs.rs
+++ b/rust/tcl-registry/examples/dump_specs.rs
@@ -152,6 +152,7 @@ const BOOL_TRAITS: &[(&str, Traits)] = &[
     ("is_language_keyword", Traits::LANGUAGE_KEYWORD),
     ("produces_canonical_list", Traits::PRODUCES_CANONICAL_LIST),
     ("builds_command_prefix", Traits::BUILDS_COMMAND_PREFIX),
+    ("wraps_command_prefix", Traits::WRAPS_COMMAND_PREFIX),
     ("is_side_switch", Traits::IS_SIDE_SWITCH),
     ("defines_procedure", Traits::DEFINES_PROCEDURE),
     ("unsafe", Traits::UNSAFE),

--- a/rust/tcl-registry/src/command_snapshot.rs
+++ b/rust/tcl-registry/src/command_snapshot.rs
@@ -90,6 +90,7 @@ const TRAIT_FLAGS: &[(&str, Traits)] = &[
     ("performs_substitution", Traits::PERFORMS_SUBSTITUTION),
     ("produces_canonical_list", Traits::PRODUCES_CANONICAL_LIST),
     ("builds_command_prefix", Traits::BUILDS_COMMAND_PREFIX),
+    ("wraps_command_prefix", Traits::WRAPS_COMMAND_PREFIX),
     ("pure", Traits::PURE),
     ("pure_evaluation", Traits::PURE_EVALUATION),
     ("reads_variable_before_write", Traits::READS_BEFORE_WRITE),

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -218,6 +218,13 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // callback fires, so analyse it in this scope — a `Body` — for its
         // references / definitions.
         arg_roles: &[(0, ArgRole::Body)],
+        // …and the value it returns is itself a command prefix
+        // (`::namespace inscope NS script`), so a consumer sitting in a
+        // command-prefix position — `trace add variable v w [namespace code
+        // [list Tracer]]`, Tk's own `fontchooser.tcl` idiom — unwraps this
+        // one level and extracts the head from the script. See
+        // `Traits::WRAPS_COMMAND_PREFIX`.
+        traits: Traits::WRAPS_COMMAND_PREFIX,
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -328,6 +328,26 @@ declare_traits! {
     /// name appears in the consumer.
     BuildsCommandPrefix => BUILDS_COMMAND_PREFIX;
 
+    /// Wraps a script/prefix argument into a value that is *itself* a
+    /// command prefix: evaluating the result invokes whatever command
+    /// the wrapped argument names, with the caller's own arguments
+    /// appended.  Set on `namespace code`, whose result is
+    /// `::namespace inscope NS script` (verified on tclsh 8.6.16 and
+    /// 9.0.4: after `trace add variable S(size) write [namespace code
+    /// [list Tracer]]`, `trace info variable ::demo::S(size)` reports
+    /// `{write {::namespace inscope ::demo Tracer}}` and writing the
+    /// variable really dispatches `::demo::Tracer`).
+    ///
+    /// The wrapped word is the command's own
+    /// [`crate::arg_role::ArgRole::Body`] argument — the same position
+    /// that already describes the script — so no second index table is
+    /// needed.  Consumers unwrap one level and re-apply their ordinary
+    /// command-prefix extraction to what they find, which keeps
+    /// `[namespace code [list X]]`, `[namespace code {X a}]`, and
+    /// `[namespace code X]` all resolving through one rule and no
+    /// command name in the walker (issue #923 idx 92).
+    WrapsCommandPrefix => WRAPS_COMMAND_PREFIX;
+
     // Safety
     /// Inherently dangerous command.
     Unsafe => UNSAFE;

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -395,6 +395,10 @@ pub const TRAITS: &[Variant] = &[
     v("IS_UNESCAPE", "performs unescaping or decoding"),
     v("PRODUCES_CANONICAL_LIST", "produces a canonical list"),
     v("BUILDS_COMMAND_PREFIX", "builds a command prefix"),
+    v(
+        "WRAPS_COMMAND_PREFIX",
+        "wraps a script into a command prefix",
+    ),
     v("UNSAFE", "unsafe in sandboxed dialects"),
     v("PASSWORD_OPTION", "takes a password-bearing option"),
     v("IS_SIDE_SWITCH", "switches the iRules connection side"),


### PR DESCRIPTION
## Summary

Fixes #1064 (and #1062's deferred B1/B2). Navigation now survives `rename`, `interp alias`, and self-redefinition — issue-923 audit cluster C8. Every semantic claim oracle-pinned on tclsh 9.0.4 + 8.6.16 (nine transcripts, identical on both).

- **One indirection resolver.** The hop walk from #1062's `class_reachable_by_indirection` is extracted to `analyser/indirection.rs` (order-gate, 8-hop cap, prepended-args decline, self-alias decline) with a reverse index `names_reaching`; the diagnostics path keeps only its class-liveness asymmetry, and `tcl-lsp-core` consumes it through a single entry. Bounded O(): ≤8 hash lookups forward; the reverse index builds once per reference query over the two mutation maps (normally empty), never over the tree.
- **#1064 / idx 89 — definition.** The hop is a uniform tier asked *before* ordinary call resolution (an alias replaces the command — the oracle's ttk::spinbox/tk::spinbox pair proves the old resolver's answer is dead code), covering rename+alias × proc+class, order-gated in both directions. The ungated trailing `lookup_alias` block is deleted. Cross-document links gate on this document's pending indirections only (workspace loads are position-free by design). The three remaining `registry_for_dialect("")` sites now use `analysis.dialect`.
- **idx 21 — references** union alias/rename spellings per call site via `names_reaching` + `in_effect` — deliberately *not* in the rename set, so rename never rewrites a call site that spells a different command (e2e FP guard), matching #1063's convention.
- **idx 45 — self-redefinition order.** New `superseded_procs` + `proc_def_in_effect_at`: both `proc` registration sites funnel through one `register_proc_definition`; go-to-definition resolves the in-effect definition, and the arity checker now draws E003 against the *first* signature for calls between the two headers (previously the first definition vanished entirely). The finding's second root cause (`lower_proc` namespace homing / W214 FQN) is a different subsystem — flagged, not silently ticked.
- **idx 92 — `[namespace code [list X]]`** unwraps via a new `WRAPS_COMMAND_PREFIX` trait on the `namespace code` subcommand and re-runs the existing prefix-head extraction — one rule for list/bareword/braced shapes, no index literals; braced wrapped words skip (already walked as a script — double-count TN pinned).
- **idx 5 — stale finding:** W123 already fires on `rename`'s missing OLD (idx 39's work); verified on this tree and pinned with 2 TP + 2 TN instead of adding a second diagnostic.
- Bookkeeping: STATUS.md ticks idx 3/4/11 (the #1071 catch-up) + 5/21/45/89/92. **Known one-hunk overlap with #1074** on the running-count lines — combined resolution after both merge is 44 fixed / 41 remaining; I'll resolve on whichever merges second.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-compiler -p tcl-lsp-core -p tcl-registry -p tcl-spec-studio` — 10,402 passed, 0 failed (107 binaries).
  - lsp_e2e definition/references/rename — 91 passed (+9 new); full server suite 1,096 passed with the two documented CPU-starvation latency flakes green in isolation.
  - New: `command_table_mutation.rs` (19 TP/TN), 7 indirection unit tests, 7 W123/E002/E003 cases.
  - clippy `-D warnings` across five crates — clean, **zero new allows**; fmt clean; `cargo check --workspace --all-targets` clean; `make xtask-check` all gates OK.
  - Mid-session disk exhaustion handled per AGENTS.md — all reported results are from post-recovery runs.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — indirection facts centralised and exposed; proc redefinition is order-gated; `WRAPS_COMMAND_PREFIX` added.
- [x] I updated at least one relevant KCS note: `kcs-feature-definition.md`, `kcs-feature-references.md`, audit `STATUS.md` §6b.
- [ ] New compiler KCS note linked. (n/a — existing notes updated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_