### PR TITLE
Dynamic-name barriers in SSA/dataflow + registry-first out-var harvesting (issue #923 audit idx 1/2/49/64)

### DIFF
--- a/docs/design/compiler/ssa-construction.md
+++ b/docs/design/compiler/ssa-construction.md
@@ -164,9 +164,23 @@ Three points of design matter:
   module names no command.
 - **What is *not* a dynamic name.**  `a($k)` is a run-time element of the
   statically named array `a` (the [place model](../compiler/memory-ssa.md)
-  already tracks that), and `${ns}::tail` binds its static tail whatever the
-  namespace resolves to.  Treating either as a whole-name clobber would
-  silence array and namespace diagnostics wholesale.
+  already tracks that); `${ns}::tail` binds its static tail whatever the
+  namespace resolves to; and a **brace-quoted** word is a literal name however
+  many `$`s it holds — `set {$n} v` creates a variable *called* `$n` and
+  leaves `n` alone (tclsh 9.0.4 / 8.6.14: `info exists {$n}` → 1 while
+  `info exists n` → 0).  Treating any of them as a whole-name clobber would
+  silence array, namespace, and ordinary diagnostics wholesale.  The
+  brace-quoted case cannot be told from a substitution on the word's text
+  alone, so the scan reads the per-word `braced_literal` / `argv_kinds` +
+  `single_token_word` quoting facts rather than looking for a `$`.
+- **A computed command *head* is not a computed name.**  `$cmd length foo`
+  names an unknown command, so no argument of it has a knowable role — the
+  walk skips such a call and raises no flag.  Skipping is load-bearing: a head
+  word's text is its lexical content, so `$set` reads back as `set`, and
+  resolving that would answer for a command that never runs.  Raising a flag
+  instead would be wildly over-broad (`$obj method` and every TclOO dispatch
+  would blind their whole function); unknown-command blindness is already
+  `Statement::Barrier`'s job.
 
 Consumers and the direction each abstains in:
 
@@ -180,6 +194,27 @@ Consumers and the direction each abstains in:
 `eval $body` / `uplevel 1 $body` are deliberately **out of scope**: they run
 arbitrary code, a strictly larger blindness than a computed name, and lower to
 `Statement::Barrier` where the per-consumer barrier rules already apply.
+
+### Known limitation — a brace-quoted `$`-bearing name is mis-keyed
+
+A variable whose literal name contains a `$` (`set {$n} 1`) is recognised as
+*not dynamic* by the barrier, but the SSA naming layer below still mis-keys
+it. `is_dynamic_write_target` reads the name text without consulting the IR's
+`name_braced` flag, so it calls `$n` a dynamic target: the assignment produces
+no def, and `uses_of` records a read of `n` instead — surfacing as
+`W210 Variable 'n' is read before it is set` on code that never touches `n`.
+
+This is pre-existing and independent of the barrier. Making the target
+braced-aware is *not* a local fix: `element_var_name_braced` normalises a
+braced `$n` down to `n`, so the def would be recorded against the wrong
+variable — measured, that trades the false positive for a *missed* one
+(`set {$n} 1; puts $n` stops warning, though tclsh errors `can't read "n"`)
+plus two fresh false `W220`s. A correct fix has to teach the shared naming
+helper that a braced literal keeps its `$`, which reaches defs, reads, rename,
+and highlighting together.
+
+The shape is rare and the current verdict is a false positive rather than a
+missed error, so it is recorded here rather than half-fixed.
 
 ## Related docs
 

--- a/docs/design/compiler/ssa-construction.md
+++ b/docs/design/compiler/ssa-construction.md
@@ -135,6 +135,52 @@ memory-SSA (`compiler/memory_ssa.py`).  Memory-SSA versions each
 store/load to aliased locations and builds alias sets, enabling
 alias-aware optimisation and taint tracking.
 
+### The dynamic-name barrier
+
+Name-level SSA can only answer "is `x` defined here?" and "is this store to
+`x` ever read?" while every access in the function *spells its target out*.
+Tcl lets a program compute the name (`set $switch {}`, `lappend out [set
+$name]`, `unset $n`), and the lowering deliberately declines to guess: such a
+call stays a generic `Call` with an empty `defs` list.  Nothing in the SSA
+graph then records that the name space was touched.
+
+`rust/tcl-compiler/src/dynamic_names.rs` supplies the missing fact as a
+per-function summary, `DynamicNameBarrier`, carried on `FunctionUnit`:
+
+| flag | set by | what stops being provable |
+|---|---|---|
+| `writes` | a `VarWrite`-role argument whose name substitutes (`set $v 1`, `array set $a {…}`, `global $n`) | "`x` was never defined in this function" |
+| `destroys` | the same, on a `DESTROYS_VARIABLE` command (`unset $n`) | "this parameter certainly exists" |
+| `reads` | a `VarRead`-role argument whose name substitutes (`[set $v]`, `parray $a`), or a `PERFORMS_SUBSTITUTION` command over a non-braced template (`subst $tmpl`) | "this store is never read" |
+
+Three points of design matter:
+
+- **Flags, not a name set.**  A computed name can land anywhere, so
+  enumerating candidates would be both unsound and unbounded.  The whole
+  lattice is three bits, computed in one flow-insensitive walk, so each
+  consumer pays `O(1)`.
+- **The roles come from the registry.**  `ArgRole::VarWrite` /
+  `ArgRole::VarRead` / the two traits are the only membership tests; the
+  module names no command.
+- **What is *not* a dynamic name.**  `a($k)` is a run-time element of the
+  statically named array `a` (the [place model](../compiler/memory-ssa.md)
+  already tracks that), and `${ns}::tail` binds its static tail whatever the
+  namespace resolves to.  Treating either as a whole-name clobber would
+  silence array and namespace diagnostics wholesale.
+
+Consumers and the direction each abstains in:
+
+| consumer | flag | abstention |
+|---|---|---|
+| `sccp::existence_constant_branches` → I230, O101 | `writes` (absent fold), `destroys` (present fold) | do not fold |
+| read-before-set → W210 | `writes` | stay silent |
+| dead store / unused → W211, W220 | `reads` | stay silent |
+| `optimiser::elimination` → O109, O126 | `reads` | do not eliminate |
+
+`eval $body` / `uplevel 1 $body` are deliberately **out of scope**: they run
+arbitrary code, a strictly larger blindness than a computed name, and lower to
+`Statement::Barrier` where the per-consumer barrier rules already apply.
+
 ## Related docs
 
 - [Examples 5–9 in walkthroughs](../../../docs/design/example-script-walkthroughs.md#example-5-if-x--set-y-10-)

--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -474,6 +474,23 @@ mathfunc-aware W123 / W002 work that landed on `rust` after the audit ran
 (`is_mathfunc_call` + `is_known_mathfunc_in_dialect`) and is counted with
 them. That makes **30 fixed, 55 remaining**.
 
+**2026-07-30 update — PR B4 (`claude/commandregistry-compiler-fixes-tshu8d-ssa-dynamic`)
+fixed four more, all tier 2 — the "dynamic-name blindness in SSA/dataflow"
+cluster:** idx 1, idx 2, idx 49, and idx 64. idx 1/2 are two halves of one
+new fact, the [dynamic-name barrier](../../../rust/tcl-compiler/src/dynamic_names.rs)
+(`tcl_compiler::dynamic_names`): after a `set $var value` any name may be
+defined, so the `[info exists X]` existence fold and read-before-set must
+abstain; after a `[set $name]` / `subst $tmpl` any store may be observed, so
+"never read" / "set but never used" must abstain. idx 49 deleted
+`cmd_substitution_out_vars`'s hardcoded `catch`/`scan`/`gets`/`regexp` list
+in favour of the registry's `ArgRole::VarWrite` query, which also covers
+`set`/`incr`/`append`/`lappend`/`lset`/`lassign`/`binary scan`/`regsub`/…
+idx 64's own re-lex root cause was **already fixed** on `rust` by the
+value-body scan mode (issue #923 idx 125's `quoted_body` work); it is
+counted here because its repros are now pinned as regression tests
+(FP-DS-13) rather than left unguarded. That makes **34 fixed, 51
+remaining**.
+
 **By corpus** (confirmed only): ticklecharts 20, tk 17, argparse 10,
 SpiceGenTcl 10, tclopt 13 (6+7, split across two inconsistent corpus-label
 strings in the raw data — same corpus), tomato 7, pix 8.
@@ -697,8 +714,8 @@ mixin/oo::configurable class-scoping findings, idx 34/36).
 | feature | count | idx (severity) |
 |---|---|---|
 | tclOO | 10 | 15, 16, 34, 35, 36, 53, ~~54~~ **FIXED**, 55, 96, 97 (all medium) |
-| namespaces | 8 | 3, 19, 43, 44, 64, 65, 75, 85 (all medium) |
-| tricky_indirection | 7 | 0 (medium, **FIXED** — see below), 1, 2, 14, 49, 50, 51 (all medium) |
+| namespaces | 8 | 3, 19, 43, 44, ~~64~~ **FIXED**, 65, 75, 85 (all medium) |
+| tricky_indirection | 7 | 0 (medium, **FIXED** — see below), ~~1~~ **FIXED**, ~~2~~ **FIXED**, 14, ~~49~~ **FIXED**, 50, 51 (all medium) |
 | upvar | 7 | 7, 22, 57, 58, 59, 98, 99 (all medium) |
 | proc_args | 7 | 11, 28, 37, 62, 67, 78, ~~104~~ **FIXED** (all medium) |
 | tcl_mathop | 4 | ~~30~~ **FIXED**, 80, ~~81~~ **ALREADY FIXED**, ~~103~~ **FIXED** (all medium) |

--- a/docs/kcs/codes/kcs-diagnostic-i230-constant-existence-check.md
+++ b/docs/kcs/codes/kcs-diagnostic-i230-constant-existence-check.md
@@ -5,7 +5,7 @@
 
 ## Applies to
 
-all-editors, diagnostic, sccp
+all-editors, diagnostic, sccp, dataflow
 
 ## Profiles
 
@@ -99,6 +99,31 @@ before may correctly have gone away:
 - A body run by `uplevel 0`. That is the *current* frame, not the global
   one — only `uplevel #0` is global — so its calls count against the
   enclosing namespace's procs.
+
+## Where a computed variable name stops the fold
+
+Tcl can compute a variable's *name* at run time, and the analyser cannot know
+which name it lands on:
+
+```tcl
+proc parse {args} {
+    foreach a $args {
+        set switch [string trimleft $a -]
+        set $switch {}          ;# defines whatever $switch spells
+    }
+    if {[info exists mixed]} { return has-mixed }   ;# no I230
+    return no-mixed
+}
+```
+
+`set $switch {}` may well have created `mixed`, so the check is not provably
+false and no `I230` is reported. The mirror case is `unset $n`, which may
+remove a variable the analyser thought certain to exist — including a
+parameter — so it stops the "always true" fold in the same way. The optimiser
+follows suit and leaves both branches in place, because folding away a branch
+that really runs would change the program.
+
+Spell the name out to get the fold (and the diagnostic) back.
 
 ## Fix
 

--- a/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
+++ b/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
@@ -5,7 +5,7 @@
 
 ## Applies to
 
-all-editors, diagnostic, liveness
+all-editors, diagnostic, liveness, dataflow
 
 ## Profiles
 
@@ -85,6 +85,42 @@ genuine errors:
 A body that assigns the variable only under an inner condition
 (`foreach x $items { if {$x} { set y 1 } }; puts $y`) is also still flagged —
 the variable can be unset even when the loop runs.
+
+## Commands that set a variable inside a condition
+
+A command that writes a variable named by one of its own arguments does so
+before either branch of the `if` (or the first turn of the `while`) can run,
+so the guarded body may read that variable safely:
+
+```tcl
+proc find {lst} {
+    if {[set idx [lsearch $lst foo]] > -1} {
+        puts $idx          ;# not flagged — the condition set it
+    }
+}
+```
+
+Which argument writes which variable comes from the command registry, so this
+covers every command it knows: `set`, `incr`, `append`, `lappend`, `lset`,
+`catch`, `gets`, `scan`, `regexp`, `regsub`, `lassign`, `binary scan`, and the
+rest. `unset` is the exception — it removes a variable rather than creating
+one, so a read after it is still flagged.
+
+## Computed variable names silence the check
+
+Tcl can compute a variable's *name* at run time:
+
+```tcl
+proc handle {name} {
+    set $name 1        ;# sets whatever variable $name spells
+    puts $foo           ;# not flagged — `$name` may have been "foo"
+}
+```
+
+Once a proc contains a write like that, no local in it can still be proved
+unset, so `W210` goes silent for the whole proc. That is deliberate: a warning
+that cannot be proved is worse than a missing one. Spell the name out to get
+the check back.
 
 ## How to suppress
 

--- a/docs/kcs/codes/kcs-diagnostic-w211-variable-set-not-used.md
+++ b/docs/kcs/codes/kcs-diagnostic-w211-variable-set-not-used.md
@@ -5,7 +5,7 @@
 
 ## Applies to
 
-all-editors, diagnostic, liveness
+all-editors, diagnostic, liveness, dataflow
 
 ## Profiles
 
@@ -39,6 +39,26 @@ Remove the unused assignment, or use the variable:
 set result [expr {1 + 1}]
 puts $result
 ```
+
+## Reads through a computed name
+
+A variable read through a name Tcl computes at run time counts as a use, even
+though no `$name` token spells it:
+
+```tcl
+proc dump {} {
+    set alpha 10           ;# not flagged — the loop below reads it
+    set beta 20
+    foreach v [info locals] { puts [set $v] }
+}
+```
+
+Once a proc contains such a read — `[set $v]`, the double-`subst`
+`[subst $[subst $v]]` idiom, or a `subst` over a template held in a variable —
+`W211` goes silent for that whole proc, because no local in it can still be
+proved unused. See
+[W220](kcs-diagnostic-w220-dead-store.md#computed-variable-names-silence-the-check)
+for the same rule on the dead-store side.
 
 ## How to suppress
 

--- a/docs/kcs/codes/kcs-diagnostic-w220-dead-store.md
+++ b/docs/kcs/codes/kcs-diagnostic-w220-dead-store.md
@@ -5,7 +5,7 @@
 
 ## Applies to
 
-all-editors, diagnostic, dce
+all-editors, diagnostic, dce, dataflow
 
 ## Profiles
 
@@ -48,6 +48,31 @@ puts $x
 ```
 
 Remove the redundant first assignment.
+
+## Computed variable names silence the check
+
+Tcl can compute a variable's *name* at run time, and a read through a computed
+name can reach any local at all:
+
+```tcl
+proc dump {} {
+    set alpha 10
+    set beta 20
+    foreach v [info locals] {
+        puts [set $v]      ;# reads alpha and beta, with no `$alpha` anywhere
+    }
+}
+```
+
+`[set $v]` — and the same idiom spelled `[subst $[subst $v]]`, or a `subst`
+over a template held in a variable — names its target from run-time data, so
+no assignment in the proc can still be proved unread. Once one appears,
+`W220` and [`W211`](kcs-diagnostic-w211-variable-set-not-used.md) both go
+silent for the whole proc, and the optimiser stops removing stores there
+([`O109`](kcs-optimisation-o109-dead-store.md) /
+[`O126`](kcs-optimisation-o126-unused-variable-removal.md)).
+Removing a store the analyser cannot see the reader for would change what the
+program prints, so the analysis abstains instead.
 
 ## How to suppress
 

--- a/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs
@@ -273,6 +273,12 @@ file; this call falls through to the 'unknown' handler."
         use crate::ir::Statement;
         use crate::ir_helpers::expr_has_command;
         use std::fmt::Write as _;
+        // A dynamic read (`[set $name]`, `subst $tmpl`) can observe *any*
+        // store, so "this assignment is never read" is unprovable anywhere in
+        // the function (issue #923 audit idx 2/64).  Abstain toward silence.
+        if fu.dynamic_names.reads {
+            return;
+        }
         let hidden_reads = self.substitution_hidden_reads(fu);
         // Array-element / dict-path writes the
         // name-level SSA mis-folds but that a read actually observes.
@@ -545,6 +551,13 @@ file; this call falls through to the 'unknown' handler."
     ) {
         use crate::def_use::DefKind;
         use std::fmt::Write as _;
+        // A dynamic read (`foreach v [info locals] {… [set $v] …}`) reaches
+        // every local by a name no literal `$x` token spells, so "set but
+        // never used" is unprovable (issue #923 audit idx 2).  Abstain toward
+        // silence.
+        if fu.dynamic_names.reads {
+            return;
+        }
         // W211 is a per-variable verdict ("the variable is set but never
         // used"), not per-assignment: a variable set several times and never
         // read fires once, at its earliest definition. Collect the earliest
@@ -1013,6 +1026,15 @@ file; this call falls through to the 'unknown' handler."
     ) {
         use crate::def_use::DefKind;
         use std::fmt::Write as _;
+
+        // A dynamic write (`set $name value`) defines a variable this pass
+        // cannot name, so *no* local can still be proved unset (issue #923
+        // audit idx 1 — tclsh 9.0.4 / 8.6.14: `proc g {n} {set $n 1; puts
+        // $foo}; g foo` prints `1`).  Abstain toward silence for the whole
+        // function.
+        if fu.dynamic_names.writes {
+            return;
+        }
 
         // Top-level RBS uses the ``extra_known_defined`` set
         // (computed from ``globals_written_by_procs``) to suppress
@@ -1790,7 +1812,7 @@ file; this call falls through to the 'unknown' handler."
                 || tcl_registry::cache::registry_for_dialect("tcl8.6"),
                 |r| r,
             );
-            crate::sccp::existence_constant_branches(&fu.cfg, &params, registry)
+            crate::sccp::existence_constant_branches(&fu.cfg, &params, registry, fu.dynamic_names)
         };
         for cb in branches {
             let Some(span) = cb.span.map(|s| fu.abs_span(s)) else {

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/ds.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/ds.rs
@@ -697,3 +697,172 @@ fn fp_ds_11_clean_uplevel_body_is_silent() {
         codes(src, D)
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-DS-12 — a dynamic-name read makes every store observable
+// (issue #923 audit idx 2 and 64)
+// ---------------------------------------------------------------------------
+//
+// `foreach v [info locals] { … [set $v] … }` reads every local through a name
+// no literal `$x` token spells, so neither "set but never used" (W211) nor
+// "assignment never read" (W220) is provable once such a read exists.
+//
+// Oracle (tclsh 9.0.4 and 8.6.14, identical):
+//   proc collect {} { set alpha 10; set beta 20; set gamma 30
+//                     set r [dict create]
+//                     foreach v [info locals] {
+//                         if {$v in {r v}} { continue }
+//                         dict append r $v [subst $[subst $v]] }
+//                     return $r }
+//   collect                                  → alpha 10 beta 20 gamma 30
+//   set ns "ctx"; puts "{ $ns"               → `{ ctx`
+
+const FP_DS_12_REPRO: &str = "\
+proc collect {} {
+    set alpha 10
+    set beta 20
+    set resultDict [dict create]
+    foreach locVar [info locals] {
+        dict append resultDict $locVar [subst $[subst $locVar]]
+    }
+    return $resultDict
+}
+";
+
+#[test]
+fn fp_ds_12_double_subst_dereference_keeps_locals_live() {
+    assert!(
+        !fires(FP_DS_12_REPRO, D, "W211"),
+        "FP-DS-12: `[subst $[subst $locVar]]` reads every local; emitted: {:?}",
+        codes(FP_DS_12_REPRO, D)
+    );
+    assert!(
+        !fires(FP_DS_12_REPRO, D, "W220"),
+        "FP-DS-12: no store is provably dead beside a dynamic read; emitted: {:?}",
+        codes(FP_DS_12_REPRO, D)
+    );
+}
+
+#[test]
+fn fp_ds_12_single_indirect_dereference_keeps_locals_live() {
+    // The audit's second control: one level of indirection (`[set $locVar]`)
+    // reproduces the same false positives.
+    let src = "\
+proc collect2 {} {
+    set alpha 10
+    set beta 20
+    set out {}
+    foreach locVar [info locals] {
+        lappend out $locVar [set $locVar]
+    }
+    return $out
+}
+";
+    assert!(
+        !fires(src, D, "W211"),
+        "FP-DS-12: `[set $locVar]` reads every local; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_12_dynamic_read_keeps_an_overwritten_store_live() {
+    let src = "proc f {n} { set a 1\n puts [set $n]\n set a 2\n return $a }\n";
+    assert!(
+        !fires(src, D, "W220"),
+        "FP-DS-12: the dynamic read may observe the first store; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_12_genuine_unused_and_dead_store_still_fire() {
+    // TP controls: with no dynamic read in the function, both verdicts stand.
+    let unused = "proc g {} { set alpha 10; set beta 20; return $beta }\n";
+    assert!(
+        fires(unused, D, "W211"),
+        "FP-DS-12 TP: a genuinely unused local must still fire W211; emitted: {:?}",
+        codes(unused, D)
+    );
+    let dead = "proc f {} { set a 1\n set a 2\n return $a }\n";
+    assert!(
+        fires(dead, D, "W220"),
+        "FP-DS-12 TP: a genuine dead store must still fire W220; emitted: {:?}",
+        codes(dead, D)
+    );
+}
+
+#[test]
+fn fp_ds_12_literal_subst_template_is_not_a_dynamic_read() {
+    // TN control: `subst {$a}` carries its names in source text, so the
+    // ordinary scanners see them and the barrier stays clear — an unrelated
+    // dead store in the same proc must still fire.
+    let src = "proc f {} { set a 1\n set b 1\n set b 2\n return [subst {$a$b}] }\n";
+    assert!(
+        fires(src, D, "W220"),
+        "FP-DS-12 TN: a literal subst template must not blind the pass; \
+emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+// ---------------------------------------------------------------------------
+// FP-DS-13 — an unmatched `{` inside a double-quoted string does not hide
+// the `$var` read (issue #923 audit idx 64, `namespaces` corpus `pix`)
+// ---------------------------------------------------------------------------
+//
+// The dead-store read scan runs over the segmenter's already-dequoted word
+// text.  Re-lexing that text with ordinary top-level rules used to read a
+// stray `{` as opening a brace-quoted (non-substituting) word, so `$ns`
+// stopped being a read and every `set ns …` feeding a multi-line
+// `puts $fp "namespace eval ::pix {\n … $ns …\n}"` looked dead.
+//
+// Oracle (tclsh 9.0.4 and 8.6.14, identical):
+//   set ns "ctx"; puts "{ $ns"               → `{ ctx`
+
+#[test]
+fn fp_ds_13_unmatched_brace_in_quoted_string_keeps_the_read() {
+    let src = "set ns \"ctx\"\nputs \"{ $ns\"\n";
+    assert!(
+        !fires(src, D, "W220"),
+        "FP-DS-13: `$ns` inside `\"{{ $ns\"` is a read; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_13_real_pixdoc_generation_shape_keeps_the_reads() {
+    let src = "\
+proc gen {fp} {
+    set ns \"ctx\"
+    set preamble \"hello\"
+    puts $fp \"namespace eval ::pix {
+        namespace eval $ns {
+            variable _ruff_preamble $preamble
+        }
+    }\"
+}
+";
+    assert!(
+        !fires(src, D, "W220"),
+        "FP-DS-13: both `set ns` and `set preamble` feed the string; emitted: {:?}",
+        codes(src, D)
+    );
+    assert!(
+        !fires(src, D, "W211"),
+        "FP-DS-13: neither local is unused; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_ds_13_overwritten_store_beside_a_quoted_read_still_fires() {
+    // TP control: the same shape with a genuinely overwritten first store.
+    let src = "proc f {} { set ns \"ctx\"\n set ns \"other\"\n return \"{ $ns\" }\n";
+    assert!(
+        fires(src, D, "W220"),
+        "FP-DS-13 TP: a real dead store beside a quoted read still fires; \
+emitted: {:?}",
+        codes(src, D)
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/ds.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/ds.rs
@@ -866,3 +866,53 @@ emitted: {:?}",
         codes(src, D)
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-DS-14 — a brace-quoted variable name does not blind the function
+// (PR #1076 review, P2)
+// ---------------------------------------------------------------------------
+//
+// `{$n}` is Tcl's literal spelling for a variable *called* `$n`; nothing is
+// computed, so the dynamic-name barrier must stay clear and every diagnostic
+// in the function must stay live.
+//
+// Oracle (tclsh 9.0.4 and 8.6.14, identical):
+//   set {$n} v; info exists {$n} → 1 ; info exists n → 0
+//   set i 5; set {arr($i)} 1; array names arr → {$i} ; info exists arr(5) → 0
+
+#[test]
+fn fp_ds_14_brace_quoted_name_keeps_unrelated_diagnostics_live() {
+    for (label, src) in [
+        (
+            "write",
+            "proc f {} { set {$n} 1\n set a 1\n set a 2\n return $a }\n",
+        ),
+        (
+            "read",
+            "proc f {} { set b [set {$n}]\n set a 1\n set a 2\n return \"$a$b\" }\n",
+        ),
+        (
+            "destroy",
+            "proc f {} { unset -nocomplain {$n}\n set a 1\n set a 2\n return $a }\n",
+        ),
+    ] {
+        assert!(
+            fires(src, D, "W220"),
+            "FP-DS-14 ({label}): a brace-quoted name is literal and must not \
+blind the dead-store pass; emitted: {:?}",
+            codes(src, D)
+        );
+    }
+}
+
+#[test]
+fn fp_ds_14_unbraced_computed_name_still_blinds_the_pass() {
+    // TN control: dropping the braces makes the name genuinely computed, so
+    // the read barrier applies and W220 correctly goes silent.
+    let src = "proc f {n} { set b [set $n]\n set a 1\n set a 2\n return \"$a$b\" }\n";
+    assert!(
+        !fires(src, D, "W220"),
+        "FP-DS-14 TN: `[set $n]` may observe the first store; emitted: {:?}",
+        codes(src, D)
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
@@ -1554,3 +1554,112 @@ fn fp_rbs_callbyname_upvar_alias_still_suppresses() {
         "upvar-aliased callee write must continue to suppress caller W211/W220; emitted: {cs:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-RBS-20 — a condition-embedded variable writer defines its target
+// (issue #923 audit idx 49)
+// ---------------------------------------------------------------------------
+//
+// `condition_command_out_vars` used to hardcode `catch` / `scan` / `gets` /
+// `regexp`, so the ubiquitous `if {[set VAR EXPR] rel N} {…$VAR…}` idiom
+// (ticklecharts utils.tcl:1068-1071) read as read-before-set.  It now asks
+// the registry for the call's `ArgRole::VarWrite` positions, so every command
+// the registry knows writes an out-var answers.
+//
+// Oracle (tclsh 9.0.4 and 8.6.14, identical):
+//   proc bar {lst} { if {[set idx [lsearch $lst foo]] > -1} { puts $idx } }
+//   bar {a foo b}                                    → 1
+//   proc loopy {} { set i 0; while {[incr i] < 3} { puts $i } }
+//   loopy                                            → 1 2
+//   proc lass {lst} { lassign $lst a b; puts "$a-$b" }
+//   lass {1 2}                                       → 1-2
+//   proc binscan {} { binary scan "AB" H2H2 hi lo; puts "$hi $lo" }
+//   binscan                                          → 41 42
+
+#[test]
+fn fp_rbs_20_set_in_if_condition_defines_its_target() {
+    let src = "proc bar {lst} { if {[set idx [lsearch $lst foo]] > -1} { puts $idx } }\n";
+    assert!(
+        !fires(src, D, "W210"),
+        "FP-RBS-20: `if {{[set idx …]}}` defines idx; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rbs_20_incr_in_while_condition_defines_its_target() {
+    let src = "proc loopy {} { while {[incr j] < 3} { puts $j } }\n";
+    assert!(
+        !fires(src, D, "W210"),
+        "FP-RBS-20: `while {{[incr j] …}}` defines j; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rbs_20_lassign_in_condition_defines_its_targets() {
+    let src = "proc la {lst} { if {[lassign $lst a b] eq {}} { puts $a$b } }\n";
+    assert!(
+        !fires(src, D, "W210"),
+        "FP-RBS-20: `lassign` writes a and b; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rbs_20_binary_scan_in_condition_defines_its_targets() {
+    let src = "proc bs {d} { if {[binary scan $d H2H2 hi lo] == 2} { puts $hi$lo } }\n";
+    assert!(
+        !fires(src, D, "W210"),
+        "FP-RBS-20: `binary scan` writes hi and lo; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rbs_20_previously_hardcoded_four_still_silent() {
+    // Regression net for the deleted name list: catch / scan / gets / regexp
+    // must keep the recognition the registry query replaced.
+    for src in [
+        "proc c {} { if {[catch {error x} msg]} { puts $msg } }\n",
+        "proc s {t} { if {[scan $t {%d %d} a b] == 2} { puts $a$b } }\n",
+        "proc g {fp} { while {[gets $fp line] >= 0} { puts $line } }\n",
+        "proc r {s} { if {[regexp {(a)(b)} $s m a b]} { puts $m$a$b } }\n",
+    ] {
+        assert!(
+            !fires(src, D, "W210"),
+            "FP-RBS-20: registry query must cover the old hardcoded four; \
+{src} emitted: {:?}",
+            codes(src, D)
+        );
+    }
+}
+
+#[test]
+fn fp_rbs_20_genuine_read_before_set_still_fires() {
+    // TP control: a condition with no variable writer at all leaves the body
+    // read genuinely undefined.
+    let src = "proc t {} { if {[string length foo] > 0} { puts $undefinedvar } }\n";
+    assert!(
+        fires(src, D, "W210"),
+        "FP-RBS-20 TP: an unwritten body read must still fire W210; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rbs_20_condition_unset_is_not_a_definition() {
+    // TN control: `unset` carries `ArgRole::VarWrite` on the name it removes,
+    // so the registry harvest must exclude `Traits::DESTROYS_VARIABLE` —
+    // otherwise the harvest would claim `gone` is defined and swallow a real
+    // warning.  tclsh 9.0.4 / 8.6.14 agree the read is an error:
+    //   proc t {} { if {[catch {unset gone}]} { puts $gone } }
+    //   catch {t} err → 1, err → `can't read "gone": no such variable`
+    let src = "proc t {} { if {[catch {unset gone}]} { puts $gone } }\n";
+    assert!(
+        fires(src, D, "W210"),
+        "FP-RBS-20 TN: a condition `unset` must not manufacture a def; \
+emitted: {:?}",
+        codes(src, D)
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
@@ -1663,3 +1663,36 @@ emitted: {:?}",
         codes(src, D)
     );
 }
+
+#[test]
+fn fp_rbs_20_substituted_command_head_harvests_nothing() {
+    // TN control (PR #1076 review, P2): the head word's *content* spelling
+    // drops the `$`, so `[$set length foo]` used to resolve as the builtin
+    // `set` and harvest `length` as a definition — silencing a genuine
+    // warning.  Which command runs is run-time data, so nothing may be
+    // claimed about what it writes.
+    //
+    // tclsh 9.0.4 / 8.6.14 (identical): calling `f string` executes
+    // `string length foo`, which defines nothing —
+    //   catch {f string} err → 1, err → `can't read "length": no such variable`
+    let src = "proc f {set} { if {[$set length foo]} { puts $length } }\n";
+    assert!(
+        fires(src, D, "W210"),
+        "FP-RBS-20 TN: a substituted head must not harvest its lookalike \
+builtin's out-vars; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rbs_20_literal_head_named_like_the_variable_still_harvests() {
+    // TP control for the pair above: a *literal* `set` head keeps the
+    // recognition — the guard must key on substitution, not on the spelling.
+    let src = "proc f {} { if {[set length foo]} { puts $length } }\n";
+    assert!(
+        !fires(src, D, "W210"),
+        "FP-RBS-20: a literal `set` head still defines its target; \
+emitted: {:?}",
+        codes(src, D)
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rch.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rch.rs
@@ -216,3 +216,109 @@ fn fp_rch_04_infinite_loop_dead_code_fires() {
         all_codes(FP_RCH_04_REPRO, D)
     );
 }
+
+// ---------------------------------------------------------------------------
+// FP-RCH-05 — a dynamic-name write / destroy weakens the existence fold
+// (issue #923 audit idx 1)
+// ---------------------------------------------------------------------------
+//
+// `set $switch {}` defines whatever variable `$switch` names, so
+// `[info exists mixed]` cannot be folded to a constant `false` and neither
+// I230 (analyser) nor O101 (optimiser fold / DCE) may claim the guarded arm
+// is unreachable.  `unset $n` is the mirror image: it can remove a parameter,
+// so even the "a parameter always exists" fold has to abstain.
+//
+// Oracle (tclsh 9.0.4 and 8.6.14, identical):
+//   proc f {} { set x foo; set $x bar; if {[info exists foo]} { return yes }
+//               return no }
+//   f                                                       → yes
+//   proc f {p n} { unset $n; if {[info exists p]} { return yes }; return no }
+//   f hello p                                               → no
+//   f hello n                                               → yes
+
+const FP_RCH_05_REPRO: &str = "\
+proc f {} {
+    set x foo
+    # Defines the variable *named by* $x — i.e. `foo`.
+    set $x bar
+    if {[info exists foo]} { return yes }
+    return no
+}
+";
+
+#[test]
+fn fp_rch_05_dynamic_write_blocks_the_absent_fold() {
+    assert!(
+        !fires(FP_RCH_05_REPRO, D, "I230"),
+        "FP-RCH-05: `set $x bar` may define `foo`; emitted {:?}",
+        all_codes(FP_RCH_05_REPRO, D)
+    );
+    assert!(
+        !o107_fires(FP_RCH_05_REPRO, D),
+        "FP-RCH-05: the reachable arm must not be optimised away; emitted {:?}",
+        all_codes(FP_RCH_05_REPRO, D)
+    );
+}
+
+#[test]
+fn fp_rch_05_static_write_still_folds() {
+    // TN control: with no dynamic write, a never-defined local really is
+    // absent and the fold must survive.
+    let src = "\
+proc f {} {
+    set x foo
+    if {[info exists foo]} { return yes }
+    return no
+}
+";
+    assert!(
+        fires(src, D, "I230"),
+        "FP-RCH-05 TN: a never-defined local still folds to absent; emitted {:?}",
+        all_codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rch_05_dynamic_unset_blocks_the_present_fold() {
+    let src = "\
+proc f {p n} {
+    unset $n
+    if {[info exists p]} { return $p }
+    return no
+}
+";
+    assert!(
+        !fires(src, D, "I230"),
+        "FP-RCH-05: `unset $n` may remove the parameter; emitted {:?}",
+        all_codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rch_05_parameter_without_dynamic_unset_still_folds() {
+    // TN control: a parameter with no dynamic destroy anywhere always exists.
+    let src = "proc f {p} { if {[info exists p]} { return $p }\n    return no\n}\n";
+    assert!(
+        fires(src, D, "I230"),
+        "FP-RCH-05 TN: a parameter still folds to present; emitted {:?}",
+        all_codes(src, D)
+    );
+}
+
+#[test]
+fn fp_rch_05_dynamic_array_element_key_still_folds() {
+    // TN control: `set a($k) 1` names a run-time *element* of the statically
+    // named array `a` — it cannot conjure the local `foo`, so the fold stands.
+    let src = "\
+proc f {k} {
+    set a($k) 1
+    if {[info exists foo]} { return yes }
+    return no
+}
+";
+    assert!(
+        fires(src, D, "I230"),
+        "FP-RCH-05 TN: a dynamic element key is not a dynamic name; emitted {:?}",
+        all_codes(src, D)
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/helpers.rs
@@ -523,6 +523,7 @@ fn collect_expr_cmd_sub_writes(
     considered: &HashSet<BlockId>,
 ) -> FxHashSet<String> {
     use crate::ir::Statement;
+    let registry = tcl_registry::cache::registry_for_dialect("tcl8.6");
     let mut out = FxHashSet::default();
     for &bn in considered {
         let Some(block) = fu.cfg.blocks.get(&bn) else {
@@ -530,7 +531,9 @@ fn collect_expr_cmd_sub_writes(
         };
         for stmt in &block.statements {
             if let Statement::AssignExpr { expr, .. } = stmt {
-                out.extend(crate::ir_helpers::condition_command_out_vars(expr));
+                out.extend(crate::ir_helpers::condition_command_out_vars(
+                    expr, registry,
+                ));
             }
         }
         // A branch condition (`if {![catch {set x 1}]} …`) evaluates its command
@@ -538,7 +541,9 @@ fn collect_expr_cmd_sub_writes(
         // catch result var *and* the catch body's assignments — are (maybe) set
         // in the taken arm and must not look read-before-set.
         if let Some(crate::cfg::Terminator::Branch { condition, .. }) = &block.terminator {
-            out.extend(crate::ir_helpers::condition_command_out_vars(condition));
+            out.extend(crate::ir_helpers::condition_command_out_vars(
+                condition, registry,
+            ));
         }
     }
     out
@@ -624,7 +629,7 @@ fn collect_script_concat_writes(
                 text.clone()
             };
             let mut writes = Vec::new();
-            crate::ir_helpers::script_text_out_vars(&script, &mut writes);
+            crate::ir_helpers::script_text_out_vars(&script, registry, &mut writes);
             out.extend(writes);
         }
     }

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -514,9 +514,9 @@ impl CfgBuilder {
     }
 
     /// Condition-position command-substitution out-vars (issue #923 idx
-    /// 122): unions the hardcoded-builtin scan
-    /// ([`crate::ir_helpers::condition_command_out_vars`] — `catch` /
-    /// `scan` / `gets` / `regexp`) with the same known-upvar-proc /
+    /// 122): unions the registry's `ArgRole::VarWrite` scan
+    /// ([`crate::ir_helpers::condition_command_out_vars`]) with the same
+    /// known-upvar-proc /
     /// known-global-writer resolution every *other* embedded-substitution
     /// site already gets ([`Self::upvar_defs_from_text`] /
     /// [`Self::global_write_defs_from_text`]).  Without this, a user
@@ -529,7 +529,11 @@ impl CfgBuilder {
     /// upvar write) completes before the body ever runs
     /// (tclsh9.0/8.6-verified).
     fn condition_out_vars(&self, condition: &ExprNode) -> Vec<String> {
-        let mut out = crate::ir_helpers::condition_command_out_vars(condition);
+        // The CFG builder carries no registry handle (see the module note at
+        // `registry_derived_cfg_classes`); the write-role answer is core Tcl in
+        // every dialect, so the cached default registry is the right source.
+        let registry = tcl_registry::cache::registry_for_dialect("tcl8.6");
+        let mut out = crate::ir_helpers::condition_command_out_vars(condition, registry);
         let mut cmds = Vec::new();
         crate::ir_helpers::collect_expr_commands(condition, &mut cmds);
         for cmd_text in &cmds {

--- a/rust/tcl-compiler/src/compilation_unit.rs
+++ b/rust/tcl-compiler/src/compilation_unit.rs
@@ -221,6 +221,15 @@ pub struct FunctionUnit {
     pub rendered_props: HashMap<ValueKey, RenderedValueProps>,
     /// Optional memory-SSA annotations (populated on demand).
     pub memory_ssa: Option<MemorySsaFunction>,
+    /// Whether this function accesses variables whose *name* is computed at
+    /// run time (`set $var v` / `[set $name]` / `unset $n`).
+    ///
+    /// Three flags, no name set — a dynamic access clobbers the whole name
+    /// space, so the consumers ([`crate::sccp::existence_constant_branches`]'s
+    /// existence fold, the W210 / W211 / W220 emitters, and the optimiser's
+    /// O101 / O109 / O126) read it in `O(1)` and abstain.  See
+    /// [`crate::dynamic_names`].
+    pub dynamic_names: crate::dynamic_names::DynamicNameBarrier,
     /// Single source of truth for the deep-analysis complexity guard: when
     /// `true` (CFG block count **or** body bytes over the ceiling), `ssa` and
     /// the dataflow lattices are trivial and **every** per-proc diagnostic /
@@ -453,9 +462,17 @@ impl FunctionUnit {
         // parameter/existence facts to fold them itself.
         let param_set: std::collections::HashSet<&str> =
             params.iter().map(String::as_str).collect();
+        // Dynamic-name facts (issue #923 audit cluster C10): a `set $var v`
+        // means any name may be defined, an `unset $n` that any name may have
+        // stopped existing — so the existence fold must abstain in that
+        // direction rather than hand the optimiser a wrong constant branch.
+        let dynamic_names = crate::dynamic_names::dynamic_name_barrier(&cfg, registry);
         sccp.constant_branches
             .extend(crate::sccp::existence_constant_branches(
-                &cfg, &param_set, registry,
+                &cfg,
+                &param_set,
+                registry,
+                dynamic_names,
             ));
         let types = propagate_types(
             &cfg,
@@ -497,6 +514,7 @@ impl FunctionUnit {
             taints,
             rendered_props,
             memory_ssa: None,
+            dynamic_names,
             complexity_guarded: false,
             base_offset: 0,
         }
@@ -520,6 +538,9 @@ impl FunctionUnit {
             taints: HashMap::new(),
             rendered_props: HashMap::new(),
             memory_ssa: None,
+            // A guarded unit's lattices are all trivial and every per-proc
+            // pass skips it, so the barrier stays clear (never consulted).
+            dynamic_names: crate::dynamic_names::DynamicNameBarrier::default(),
             complexity_guarded: true,
             base_offset: 0,
         }

--- a/rust/tcl-compiler/src/dynamic_names.rs
+++ b/rust/tcl-compiler/src/dynamic_names.rs
@@ -1,0 +1,453 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Dynamic-name barrier facts — issue #923 audit cluster C10.
+//!
+//! Name-level SSA and the def-use chains built on it answer questions of the
+//! form "is `x` defined here?" and "is this store to `x` ever read?".  Both
+//! are only answerable while every variable access in the function spells its
+//! target out.  Tcl lets a program compute the name instead:
+//!
+//! ```tcl
+//! set $switch {}          ;# writes whatever variable $switch names
+//! lappend out [set $name] ;# reads whatever variable $name names
+//! ```
+//!
+//! After a **dynamic write**, *any* name may be defined, so "`x` was never
+//! defined here" is no longer provable.  After a **dynamic read**, *any*
+//! store may have been observed, so "this store is never read" is no longer
+//! provable.  After a **dynamic destroy** (`unset $n`), *any* name may have
+//! ceased to exist, so even "this parameter certainly exists" is no longer
+//! provable.
+//!
+//! The three facts are deliberately **flags, not name sets**: a dynamic
+//! access clobbers the whole name space, so enumerating candidates would be
+//! both unsound (the value can come from anywhere) and unbounded.  Three
+//! bools is the whole lattice, computed in one flow-insensitive walk, so the
+//! consumers pay `O(1)` per query.
+//!
+//! Which argument of which command names a variable is **the registry's**
+//! answer ([`ArgRole::VarWrite`] / [`ArgRole::VarRead`] /
+//! [`Traits::DESTROYS_VARIABLE`] / [`Traits::PERFORMS_SUBSTITUTION`]) — this
+//! module holds no command names.
+//!
+//! # Soundness direction
+//!
+//! Every consumer abstains when its fact is set: warnings go silent
+//! (`W210` / `W211` / `W220` / `I230`) and the optimiser declines to fold or
+//! eliminate (`O101` / `O109` / `O126`).  Both are the same direction — say
+//! less rather than say something wrong.
+//!
+//! # Not covered
+//!
+//! `eval $body` / `uplevel 1 $body` run *arbitrary code*, a strictly larger
+//! blindness than a computed name: they can read, write, and destroy names
+//! this walk never sees a role for.  Those lower to
+//! [`Statement::Barrier`](crate::ir::Statement::Barrier) and are handled (or
+//! not) by the per-consumer barrier rules, not here.
+
+use tcl_registry::{ArgRole, CommandRegistry, Traits};
+
+use crate::cfg::{Function as CfgFunction, Terminator};
+use crate::depth_guard::MAX_BRACKET_TEXT_DEPTH;
+use crate::expr_ast::ExprNode;
+use crate::ir::Statement;
+
+/// Whether a function accesses variables whose *name* is computed at run
+/// time, split by the direction each blinds.
+///
+/// See the [module docs](self) for the lattice and the soundness direction
+/// each flag imposes on its consumers.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq, Hash)]
+pub struct DynamicNameBarrier {
+    /// A command creates or overwrites a variable whose name is computed at
+    /// run time (`set $var v`, `lappend $n 1`, `array set $a {…}`).  After
+    /// it, **any** name may be defined.
+    pub writes: bool,
+    /// A command destroys a variable whose name is computed at run time
+    /// (`unset $n`).  After it, **any** name may have ceased to exist.
+    pub destroys: bool,
+    /// A command reads a variable whose name is computed at run time
+    /// (`set $v`, `parray $a`, `subst $tmpl`).  After it, **any** store may
+    /// have been observed.
+    pub reads: bool,
+}
+
+impl DynamicNameBarrier {
+    /// True when no direction is blinded — the function names every variable
+    /// it touches.
+    #[must_use]
+    pub const fn is_clear(self) -> bool {
+        !self.writes && !self.destroys && !self.reads
+    }
+}
+
+/// Whether *word* — an argument sitting in a registry-declared
+/// variable-name role — names a variable the compiler cannot resolve
+/// statically.
+///
+/// `word` arrives either as the segmenter's *reconstructed* text, in which a
+/// `$name` substitution is canonicalised to its braced spelling `${name}`, or
+/// as a token's verbatim `$name` spelling.  Both mean the same thing —
+/// `${name}` really is a substitution in Tcl, not a literal name (tclsh
+/// 9.0.4 / 8.6.14: `set x foo; set ${x} bar; info exists foo` → `1`) — so any
+/// `$` or `[` in the *name position* means the name comes from run-time data.
+///
+/// Three shapes are deliberately **not** dynamic:
+///
+/// - `a($k)` — a run-time-chosen *element* of the statically named array
+///   `a`. The [place model](crate::place) already tracks element identity;
+///   treating it as a whole-name clobber would silence array diagnostics
+///   wholesale.
+/// - `${ns}::tail` — a `::`-qualified name binds or targets its **tail**, so
+///   a computed *namespace* leaves the name itself known.  `variable
+///   ${name}::graphAttr` creates the local `graphAttr` whatever `$name`
+///   holds (tclsh 9.0.4 / 8.6.14), and cannot conjure any other local.
+/// - the empty word — `set {} 1` names the (literal) empty-named variable.
+#[must_use]
+pub fn names_a_dynamic_variable(word: &str) -> bool {
+    if word.is_empty() {
+        return false;
+    }
+    let base = word.split_once('(').map_or(word, |(base, _)| base);
+    let tail = base.rsplit("::").next().unwrap_or(base);
+    tail.contains('$') || tail.contains('[')
+}
+
+/// Compute the [`DynamicNameBarrier`] for `cfg`.
+///
+/// One flow-insensitive walk over every statement, terminator condition, and
+/// nested `[…]` command substitution in the function.  Flow-insensitivity is
+/// the conservative choice: a read *before* the dynamic write is blinded too,
+/// which only ever silences, never invents, a fact.
+#[must_use]
+pub fn dynamic_name_barrier(cfg: &CfgFunction, registry: &CommandRegistry) -> DynamicNameBarrier {
+    let mut barrier = DynamicNameBarrier::default();
+    for block in cfg.blocks.values() {
+        for stmt in &block.statements {
+            scan_statement(stmt, registry, &mut barrier);
+            // The CFG builder flattens structured control flow, but a
+            // non-lowered (glob / regexp / fall-through) `switch` keeps its
+            // arm bodies inline; descend through whatever nests.
+            for script in crate::ir_helpers::nested_bodies(stmt) {
+                crate::ir::for_each_statement(script, &mut |inner| {
+                    scan_statement(inner, registry, &mut barrier);
+                });
+            }
+        }
+        match &block.terminator {
+            Some(Terminator::Branch { condition, .. }) => {
+                scan_expr(condition, registry, &mut barrier);
+            }
+            // `return [set $n]` lowers to a terminator, not a statement.
+            Some(Terminator::Return { value, expr, .. }) => {
+                if let Some(v) = value {
+                    scan_text(v, registry, &mut barrier, 0);
+                }
+                if let Some(e) = expr {
+                    scan_expr(e, registry, &mut barrier);
+                }
+            }
+            _ => {}
+        }
+    }
+    barrier
+}
+
+fn scan_statement(stmt: &Statement, registry: &CommandRegistry, barrier: &mut DynamicNameBarrier) {
+    match stmt {
+        Statement::Call {
+            command,
+            args,
+            tokens,
+            ..
+        }
+        | Statement::Barrier {
+            command,
+            args,
+            tokens,
+            ..
+        } => {
+            // `args` is the segmenter's *reconstructed* text, which cannot
+            // tell a brace-quoted `{$a}` (literal) from a substituted `$a`;
+            // the per-word token kinds can. Index 0 of `argv_kinds` /
+            // `single_token_word` is the command word, so the argument
+            // entries start at 1.
+            let braced: Option<Vec<bool>> = tokens.as_ref().map(|t| {
+                t.argv_kinds
+                    .iter()
+                    .zip(t.single_token_word.iter())
+                    .skip(1)
+                    .map(|(kind, &single)| single && *kind == tcl_lexer::TokenType::Str)
+                    .collect()
+            });
+            scan_command(command, args, braced.as_deref(), registry, barrier);
+            for arg in args {
+                scan_text(arg, registry, barrier, 0);
+            }
+        }
+        Statement::AssignConst { value, .. } | Statement::AssignValue { value, .. } => {
+            scan_text(value, registry, barrier, 0);
+        }
+        Statement::AssignExpr { expr, .. } | Statement::ExprEval { expr, .. } => {
+            scan_expr(expr, registry, barrier);
+        }
+        Statement::Return { value, expr, .. } => {
+            if let Some(v) = value {
+                scan_text(v, registry, barrier, 0);
+            }
+            if let Some(e) = expr {
+                scan_expr(e, registry, barrier);
+            }
+        }
+        // A non-lowered `switch`'s subject is a word; its arm bodies are
+        // reached by the caller's `nested_bodies` descent.
+        Statement::Switch { subject, .. } => {
+            scan_text(subject, registry, barrier, 0);
+        }
+        // `Incr` names its target literally (the lowering declines a
+        // substituted name); every remaining statement carries no word text.
+        _ => {}
+    }
+}
+
+fn scan_expr(expr: &ExprNode, registry: &CommandRegistry, barrier: &mut DynamicNameBarrier) {
+    let mut cmds = Vec::new();
+    crate::ir_helpers::collect_expr_commands(expr, &mut cmds);
+    for cmd_text in &cmds {
+        let trimmed = cmd_text.trim();
+        let inner = trimmed
+            .strip_prefix('[')
+            .and_then(|s| s.strip_suffix(']'))
+            .unwrap_or(trimmed);
+        scan_script_text(inner, registry, barrier, 0);
+    }
+}
+
+/// Scan a word's raw text for nested `[…]` command substitutions.
+fn scan_text(text: &str, registry: &CommandRegistry, barrier: &mut DynamicNameBarrier, depth: u32) {
+    // Native-stack safety net (issue #996): `[a [b [c …]]]` nests inside one
+    // word. Past the cap, stop descending — an unset flag is the "no barrier
+    // proved" fallback, which matches every other bounded walk's contract of
+    // returning what it gathered rather than crashing.
+    if MAX_BRACKET_TEXT_DEPTH.exceeded(depth) {
+        return;
+    }
+    for inner in crate::var_refs::command_subst_texts(text) {
+        scan_script_text(&inner, registry, barrier, depth + 1);
+    }
+}
+
+/// Scan a run of script text (a `[…]` substitution's own content) for
+/// dynamic-name accesses, then descend into whatever `[…]` it nests.
+fn scan_script_text(
+    text: &str,
+    registry: &CommandRegistry,
+    barrier: &mut DynamicNameBarrier,
+    depth: u32,
+) {
+    if MAX_BRACKET_TEXT_DEPTH.exceeded(depth) {
+        return;
+    }
+    for words in crate::ir_helpers::tokenise_command_words(text) {
+        let Some((command, args)) = words.split_first() else {
+            continue;
+        };
+        // The *raw* spelling is what carries the name-position `$` / `[`; the
+        // content spelling has already dropped it.
+        let arg_texts: Vec<String> = args.iter().map(|w| w.raw.clone()).collect();
+        let braced: Vec<bool> = args.iter().map(|w| w.braced_literal).collect();
+        scan_command(&command.text, &arg_texts, Some(&braced), registry, barrier);
+    }
+    // The script's own words may nest further substitutions; `text` still has
+    // their brackets intact (a word's raw spelling does not — a delimited
+    // token's closer sits one past its span), so recurse from here.
+    scan_text(text, registry, barrier, depth);
+}
+
+/// Whether a template word handed to a substituting command was itself
+/// produced by substitution — i.e. its content comes from run-time data
+/// rather than from source text the ordinary scanners can read.
+///
+/// A brace-quoted word (`subst {$a}`) is the one literal form that can
+/// legally carry a `$`, and Tcl leaves it verbatim: the `$a` inside is
+/// source text naming `a`, so the read is *not* blind.  Every other word
+/// carrying `$` or `[` (`subst $t`, `subst "$t"`, `subst [gen]`) reaches
+/// `subst` already substituted, so the names it then expands come from data.
+fn template_word_is_substituted(word: &str, braced_literal: bool) -> bool {
+    !braced_literal && (word.contains('$') || word.contains('['))
+}
+
+/// Apply the registry's name-role answers for one `command args…` call.
+///
+/// `arg_braced`, when present, says for each argument whether it is a single
+/// brace-quoted word — a distinction the segmenter's reconstructed `args`
+/// text has already erased, and the one thing that separates a literal
+/// `subst {$a}` template from a substituted `subst $a` one.
+fn scan_command(
+    command: &str,
+    args: &[String],
+    arg_braced: Option<&[bool]>,
+    registry: &CommandRegistry,
+    barrier: &mut DynamicNameBarrier,
+) {
+    let Some(spec) = registry.get(command) else {
+        return;
+    };
+    let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let destroys = spec.traits.contains(Traits::DESTROYS_VARIABLE);
+
+    for idx in registry.arg_indices_for_role(command, &arg_strs, ArgRole::VarWrite) {
+        if arg_strs
+            .get(idx)
+            .is_some_and(|w| names_a_dynamic_variable(w))
+        {
+            if destroys {
+                barrier.destroys = true;
+            } else {
+                barrier.writes = true;
+            }
+        }
+    }
+    for idx in registry.arg_indices_for_role(command, &arg_strs, ArgRole::VarRead) {
+        if arg_strs
+            .get(idx)
+            .is_some_and(|w| names_a_dynamic_variable(w))
+        {
+            barrier.reads = true;
+        }
+    }
+    // A template-expanding command (`subst`) performs `$name` substitution
+    // over its argument string. With a literal template the names are in the
+    // text and the ordinary scanners see them; with a computed one the names
+    // come from run-time data, so every local is reachable —
+    // `[subst $[subst $locVar]]` (issue #923 idx 2) is exactly this shape.
+    if spec.traits.contains(Traits::PERFORMS_SUBSTITUTION)
+        && arg_strs.iter().enumerate().any(|(i, w)| {
+            !w.starts_with('-')
+                && template_word_is_substituted(
+                    w,
+                    arg_braced.and_then(|b| b.get(i)).copied().unwrap_or(false),
+                )
+        })
+    {
+        barrier.reads = true;
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn barrier_for(src: &str) -> DynamicNameBarrier {
+        let registry = tcl_registry::registry_for_dialect("tcl8.6");
+        let cu = crate::compilation_unit::CompilationUnit::build_for(src, registry, false);
+        let fu = cu.procedures.values().next().unwrap_or(&cu.top_level);
+        dynamic_name_barrier(&fu.cfg, registry)
+    }
+
+    #[test]
+    fn braced_substitution_is_dynamic_plain_name_is_not() {
+        // `${x}` is a substitution, not a literal name — tclsh 9.0.4 / 8.6.14:
+        // `set x foo; set ${x} bar; info exists foo` → 1.
+        assert!(names_a_dynamic_variable("${x}"));
+        assert!(!names_a_dynamic_variable("plain"));
+        assert!(!names_a_dynamic_variable(""));
+    }
+
+    #[test]
+    fn qualified_name_with_a_dynamic_namespace_binds_a_static_tail() {
+        // `variable ${name}::graphAttr` creates the local `graphAttr`
+        // whatever `$name` holds, so no other local becomes reachable.
+        assert!(!names_a_dynamic_variable("${name}::graphAttr"));
+        assert!(names_a_dynamic_variable("::ns::${tail}"));
+    }
+
+    #[test]
+    fn array_element_with_dynamic_key_is_not_a_name_barrier() {
+        // The base array `a` is statically named; only the element key is
+        // computed, which the place model already tracks.
+        assert!(!names_a_dynamic_variable("a($k)"));
+        assert!(names_a_dynamic_variable("$a(k)"));
+    }
+
+    #[test]
+    fn substituted_and_bracketed_names_are_dynamic() {
+        assert!(names_a_dynamic_variable("$x"));
+        assert!(names_a_dynamic_variable("[string trim $x]"));
+        assert!(names_a_dynamic_variable("pre$x"));
+    }
+
+    #[test]
+    fn plain_proc_has_no_barrier() {
+        assert!(barrier_for("proc f {} { set a 1; return $a }\n").is_clear());
+    }
+
+    #[test]
+    fn dynamic_set_sets_the_write_flag_only() {
+        let b = barrier_for("proc f {n} { set $n 1; return ok }\n");
+        assert!(b.writes, "`set $n 1` is a dynamic write");
+        assert!(!b.reads);
+        assert!(!b.destroys);
+    }
+
+    #[test]
+    fn dynamic_one_arg_set_sets_the_read_flag_only() {
+        let b = barrier_for("proc f {n} { return [set $n] }\n");
+        assert!(b.reads, "`[set $n]` is a dynamic read");
+        assert!(!b.writes);
+        assert!(!b.destroys);
+    }
+
+    #[test]
+    fn dynamic_unset_sets_the_destroy_flag_only() {
+        let b = barrier_for("proc f {n} { unset $n; return ok }\n");
+        assert!(b.destroys, "`unset $n` is a dynamic destroy");
+        assert!(!b.writes);
+    }
+
+    #[test]
+    fn dynamic_subst_template_sets_the_read_flag() {
+        let b = barrier_for("proc f {t} { return [subst $t] }\n");
+        assert!(b.reads, "`subst $t` can dereference any name");
+    }
+
+    #[test]
+    fn literal_subst_template_is_not_a_barrier() {
+        let b = barrier_for("proc f {} { set a 1; return [subst {$a}] }\n");
+        assert!(b.is_clear(), "a literal template names its reads");
+    }
+
+    #[test]
+    fn dynamic_array_set_is_a_write_barrier() {
+        let b = barrier_for("proc f {n} { array set $n {x 1} }\n");
+        assert!(b.writes);
+    }
+
+    #[test]
+    fn dynamic_name_nested_in_a_command_substitution_is_seen() {
+        let b = barrier_for("proc f {n} { set out {}; lappend out [set $n]; return $out }\n");
+        assert!(b.reads, "the dynamic read sits inside a `[…]` argument");
+    }
+
+    #[test]
+    fn dynamic_name_in_a_branch_condition_is_seen() {
+        let b = barrier_for("proc f {n} { if {[set $n] eq {}} { return empty }; return full }\n");
+        assert!(b.reads);
+    }
+}

--- a/rust/tcl-compiler/src/dynamic_names.rs
+++ b/rust/tcl-compiler/src/dynamic_names.rs
@@ -60,6 +60,34 @@
 //! this walk never sees a role for.  Those lower to
 //! [`Statement::Barrier`](crate::ir::Statement::Barrier) and are handled (or
 //! not) by the per-consumer barrier rules, not here.
+//!
+//! A **computed command head** (`$cmd length foo`, `[pick] $n 1`) is the same
+//! case one level up: the *command* is run-time data, so no argument of it has
+//! a knowable role, and the walk skips the call entirely.
+//!
+//! Skipping is load-bearing, not just imprecise-but-harmless.  A head word's
+//! text is its lexical *content*, so `$set` reads back as `set` and `[pick]`
+//! as `pick`; resolving that against the registry answers for a command that
+//! never runs.  `proc f {set} {if {[$set length foo]} {puts $length}}` really
+//! executes `string length foo` when called as `f string`, defining nothing
+//! (tclsh 9.0.4 / 8.6.14 both error `can't read "length": no such variable`).
+//!
+//! Such a call deliberately raises **no** flag either, rather than all three:
+//!
+//! - This module answers one question — *was a **known** command handed a
+//!   computed name?*  "Could an unknown command do anything?" is a different,
+//!   much larger question — the same one that puts `eval` / `uplevel` out of
+//!   scope above.
+//! - Unknown-command blindness already has an owner.  A `$cmd …` statement
+//!   lowers to [`Statement::Barrier`], and
+//!   [`existence_constant_branches`](crate::sccp::existence_constant_branches)
+//!   bails on a function containing any barrier before it consults these flags
+//!   at all.
+//! - Raising a flag would be wildly over-broad: `$obj method`, `$cmd arg`, and
+//!   every `TclOO` dispatch would silence `W210` / `W211` / `W220` / `I230`
+//!   and switch off `O101` / `O109` / `O126` for the whole function.  An
+//!   over-broad fact kills real diagnostics just as surely as a wrong one
+//!   invents false positives.
 
 use tcl_registry::{ArgRole, CommandRegistry, Traits};
 
@@ -107,6 +135,10 @@ impl DynamicNameBarrier {
 /// `${name}` really is a substitution in Tcl, not a literal name (tclsh
 /// 9.0.4 / 8.6.14: `set x foo; set ${x} bar; info exists foo` → `1`) — so any
 /// `$` or `[` in the *name position* means the name comes from run-time data.
+///
+/// The caller must first rule out a **brace-quoted** word: `{$n}` carries the
+/// same `$` but substitutes nothing, and this function cannot tell the two
+/// spellings apart on text alone.  [`scan_command`] applies that check.
 ///
 /// Three shapes are deliberately **not** dynamic:
 ///
@@ -196,7 +228,19 @@ fn scan_statement(stmt: &Statement, registry: &CommandRegistry, barrier: &mut Dy
                     .map(|(kind, &single)| single && *kind == tcl_lexer::TokenType::Str)
                     .collect()
             });
-            scan_command(command, args, braced.as_deref(), registry, barrier);
+            // `command` likewise reports the head word's *content*, so a
+            // substituted head (`$cmd length foo`) arrives spelled as whatever
+            // variable it reads — resolving that against the registry would
+            // answer for a command that never runs (see the module docs).
+            let head_dynamic = tokens
+                .as_ref()
+                .and_then(|t| t.argv_kinds.first())
+                .is_some_and(|kind| {
+                    matches!(kind, tcl_lexer::TokenType::Var | tcl_lexer::TokenType::Cmd)
+                });
+            if !head_dynamic {
+                scan_command(command, args, braced.as_deref(), registry, barrier);
+            }
             for arg in args {
                 scan_text(arg, registry, barrier, 0);
             }
@@ -268,6 +312,10 @@ fn scan_script_text(
         let Some((command, args)) = words.split_first() else {
             continue;
         };
+        // A substituted head names an unknown command (see the module docs).
+        if command.substituted {
+            continue;
+        }
         // The *raw* spelling is what carries the name-position `$` / `[`; the
         // content spelling has already dropped it.
         let arg_texts: Vec<String> = args.iter().map(|w| w.raw.clone()).collect();
@@ -297,8 +345,9 @@ fn template_word_is_substituted(word: &str, braced_literal: bool) -> bool {
 ///
 /// `arg_braced`, when present, says for each argument whether it is a single
 /// brace-quoted word — a distinction the segmenter's reconstructed `args`
-/// text has already erased, and the one thing that separates a literal
-/// `subst {$a}` template from a substituted `subst $a` one.
+/// text has already erased, and the one thing that separates a literal name
+/// or template (`set {$n} 1`, `subst {$a}`) from a substituted one
+/// (`set $n 1`, `subst $a`).
 fn scan_command(
     command: &str,
     args: &[String],
@@ -311,12 +360,24 @@ fn scan_command(
     };
     let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
     let destroys = spec.traits.contains(Traits::DESTROYS_VARIABLE);
+    // A brace-quoted word is Tcl's literal spelling for a name that contains
+    // `$` or `[`: `set {$n} v` creates a variable *called* `$n`, unrelated to
+    // `n` (tclsh 9.0.4 / 8.6.14: `set {$n} v; info exists {$n}` → 1 while
+    // `info exists n` → 0). Such a name is statically known, so it is not a
+    // barrier — reading the word's text alone would see the `$` and blind the
+    // whole function for code that only ever names variables statically.
+    let dynamic_name_at = |idx: usize| {
+        !arg_braced
+            .and_then(|b| b.get(idx))
+            .copied()
+            .unwrap_or(false)
+            && arg_strs
+                .get(idx)
+                .is_some_and(|w| names_a_dynamic_variable(w))
+    };
 
     for idx in registry.arg_indices_for_role(command, &arg_strs, ArgRole::VarWrite) {
-        if arg_strs
-            .get(idx)
-            .is_some_and(|w| names_a_dynamic_variable(w))
-        {
+        if dynamic_name_at(idx) {
             if destroys {
                 barrier.destroys = true;
             } else {
@@ -325,10 +386,7 @@ fn scan_command(
         }
     }
     for idx in registry.arg_indices_for_role(command, &arg_strs, ArgRole::VarRead) {
-        if arg_strs
-            .get(idx)
-            .is_some_and(|w| names_a_dynamic_variable(w))
-        {
+        if dynamic_name_at(idx) {
             barrier.reads = true;
         }
     }
@@ -449,5 +507,64 @@ mod tests {
     fn dynamic_name_in_a_branch_condition_is_seen() {
         let b = barrier_for("proc f {n} { if {[set $n] eq {}} { return empty }; return full }\n");
         assert!(b.reads);
+    }
+
+    // PR #1076 review, P2 — a brace-quoted name is a *literal* name.
+    //
+    // tclsh 9.0.4 / 8.6.14 (identical):
+    //   set {$n} v; info exists {$n} → 1 ; info exists n → 0
+    //   set i 5; set {arr($i)} 1; array names arr → {$i} ; info exists arr(5) → 0
+
+    #[test]
+    fn brace_quoted_write_target_is_not_a_barrier() {
+        let b = barrier_for("proc f {} { set {$n} 1; return ok }\n");
+        assert!(
+            b.is_clear(),
+            "`set {{$n}} 1` names the literal variable `$n`, so nothing is \
+computed; got {b:?}"
+        );
+    }
+
+    #[test]
+    fn brace_quoted_read_target_is_not_a_barrier() {
+        let b = barrier_for("proc f {} { return [set {$n}] }\n");
+        assert!(b.is_clear(), "got {b:?}");
+    }
+
+    #[test]
+    fn brace_quoted_destroy_target_is_not_a_barrier() {
+        let b = barrier_for("proc f {} { unset {$n}; return ok }\n");
+        assert!(b.is_clear(), "got {b:?}");
+    }
+
+    #[test]
+    fn unbraced_substituted_target_still_raises_the_write_flag() {
+        // TN control for the three above: dropping the braces restores the
+        // barrier, so the brace check cannot be over-applied.
+        let b = barrier_for("proc f {n} { set $n 1; return ok }\n");
+        assert!(b.writes, "`set $n 1` is still a dynamic write; got {b:?}");
+    }
+
+    // PR #1076 review, P2 — a computed command head is an unknown command.
+
+    #[test]
+    fn substituted_command_head_raises_no_flag() {
+        // The head's content spelling is `set`, but `string length foo` is
+        // what runs. Resolving the lookalike would answer for a command that
+        // never executes, so the call contributes nothing — see the module
+        // docs for why it raises no flag either.
+        let b = barrier_for("proc f {set n} { $set $n 1; return ok }\n");
+        assert!(
+            b.is_clear(),
+            "a computed head is an unknown command, not a computed name; got {b:?}"
+        );
+    }
+
+    #[test]
+    fn literal_head_with_a_computed_name_still_raises_the_write_flag() {
+        // TN control: the same argument shape under a *literal* head is the
+        // genuine dynamic write.
+        let b = barrier_for("proc f {n} { set $n 1; return ok }\n");
+        assert!(b.writes, "got {b:?}");
     }
 }

--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -25,9 +25,9 @@
 //! definitions produced by command substitutions.
 
 use tcl_lexer::{Lexer, SourceMap, TokenType};
-use tcl_registry::{ArgRole, CommandRegistry};
+use tcl_registry::{ArgRole, CommandRegistry, Traits};
 
-use crate::depth_guard::MAX_EXPR_NODE_DEPTH;
+use crate::depth_guard::{MAX_BRACKET_TEXT_DEPTH, MAX_EXPR_NODE_DEPTH};
 use crate::expr_ast::ExprNode;
 use crate::ir::{Script, Statement};
 use crate::naming::normalise_var_name;
@@ -248,11 +248,11 @@ pub fn defs_from_expr(expr: &ExprNode, registry: &CommandRegistry) -> Vec<String
             .unwrap_or(cmd_text);
 
         let words = tokenise_to_words(text);
-        if words.is_empty() {
+        let Some((cmd_word, arg_words)) = words.split_first() else {
             continue;
-        }
-        let cmd_name = &words[0];
-        let args: Vec<&str> = words[1..].iter().map(String::as_str).collect();
+        };
+        let cmd_name = &cmd_word.text;
+        let args: Vec<&str> = arg_words.iter().map(|w| w.text.as_str()).collect();
 
         // VarWrite positions.
         for idx in registry.arg_indices_for_role(cmd_name, &args, ArgRole::VarWrite) {
@@ -284,17 +284,14 @@ pub fn defs_from_expr(expr: &ExprNode, registry: &CommandRegistry) -> Vec<String
 /// (e.g. `set x 1` inside a `catch` body).
 fn defs_from_body_script(body_text: &str, registry: &CommandRegistry) -> Vec<String> {
     let mut defs = Vec::new();
-    let words_list = tokenise_to_command_words(body_text);
-
-    for words in &words_list {
-        if words.is_empty() {
+    for words in tokenise_command_words(body_text) {
+        let Some((cmd_word, arg_words)) = words.split_first() else {
             continue;
-        }
-        let cmd_name = &words[0];
-        let args: Vec<&str> = words[1..].iter().map(String::as_str).collect();
-        for idx in registry.arg_indices_for_role(cmd_name, &args, ArgRole::VarWrite) {
-            if idx < args.len() {
-                let name = normalise_var_name(args[idx]);
+        };
+        let args: Vec<&str> = arg_words.iter().map(|w| w.text.as_str()).collect();
+        for idx in registry.arg_indices_for_role(&cmd_word.text, &args, ArgRole::VarWrite) {
+            if let Some(arg) = args.get(idx) {
+                let name = normalise_var_name(arg);
                 if !name.is_empty() {
                     defs.push(name.to_owned());
                 }
@@ -304,13 +301,19 @@ fn defs_from_body_script(body_text: &str, registry: &CommandRegistry) -> Vec<Str
     defs
 }
 
-/// Out-variable names assigned by `catch` / `regexp` / `scan` command
-/// substitutions appearing in `condition` (an `if`/`while` condition expr).
-/// These builtins write result variables as a side effect, so a read of
-/// such a variable in the guarded body is **not** read-before-set — the
-/// CFG records them as defs on the synthetic `<cond>` statement so the
-/// def-use / W210 analysis sees the write.
-pub(crate) fn condition_command_out_vars(condition: &ExprNode) -> Vec<String> {
+/// Out-variable names assigned by command substitutions appearing in
+/// `condition` (an `if`/`while` condition expr).
+///
+/// A command that writes a variable named by one of its own arguments does
+/// so *before* either branch runs, so a read of such a variable in the
+/// guarded body is **not** read-before-set — the CFG records them as defs on
+/// the synthetic `<cond>` statement so the def-use / W210 analysis sees the
+/// write.  Which arguments those are is the registry's
+/// [`ArgRole::VarWrite`] answer, never a name list here (issue #923 idx 49).
+pub(crate) fn condition_command_out_vars(
+    condition: &ExprNode,
+    registry: &CommandRegistry,
+) -> Vec<String> {
     let mut cmds = Vec::new();
     collect_expr_commands(condition, &mut cmds);
     let mut out = Vec::new();
@@ -320,131 +323,124 @@ pub(crate) fn condition_command_out_vars(condition: &ExprNode) -> Vec<String> {
             .strip_prefix('[')
             .and_then(|s| s.strip_suffix(']'))
             .unwrap_or(trimmed);
-        cmd_substitution_out_vars(&tokenise_to_words(inner), &mut out);
+        cmd_substitution_out_vars(&tokenise_to_words(inner), registry, &mut out, 0);
     }
     out
 }
 
-/// A word usable as a variable name: identifier characters only (so
-/// `{script}`, `$ref`, `[sub]` and quoted words are rejected).
-fn is_bare_var_word(word: &str) -> bool {
-    !word.is_empty()
+/// A word usable as a variable name: a *literal* identifier (so `{script}`,
+/// `[sub]`, quoted words, and — via [`CommandWord::substituted`] — the
+/// run-time-computed `$ref` are all rejected).
+///
+/// The substitution check has to come from the token stream, not the text:
+/// the word's *content* spelling drops the `$`, so `set $n 1` would otherwise
+/// read as a definition of a variable called `n` and silence a genuine
+/// warning about it.
+fn is_bare_var_word(word: &CommandWord) -> bool {
+    !word.substituted
+        && !word.text.is_empty()
         && word
+            .text
             .bytes()
             .all(|b| b.is_ascii_alphanumeric() || b == b'_' || b == b':')
 }
 
-fn push_out_var(word: &str, out: &mut Vec<String>) {
+fn push_out_var(word: &CommandWord, out: &mut Vec<String>) {
     if is_bare_var_word(word) {
-        let normalised = normalise_var_name(word);
+        let normalised = normalise_var_name(&word.text);
         if !normalised.is_empty() && !out.iter().any(|v| v == normalised) {
             out.push(normalised.to_owned());
         }
     }
 }
 
-/// Out-vars written by the builtin named by `words[0]`, appended to `out`.
-fn cmd_substitution_out_vars(words: &[String], out: &mut Vec<String>) {
-    match words.first().map(String::as_str) {
-        // `catch SCRIPT ?resultVar? ?optionsVar?`
-        Some("catch") => {
-            if let Some(w) = words.get(2) {
-                push_out_var(w, out);
-            }
-            if let Some(w) = words.get(3) {
-                push_out_var(w, out);
-            }
-            // The SCRIPT body (words[1]) runs in the current scope, so variables
-            // it assigns are (maybe) set once the catch completes — e.g.
-            // `if {![catch {set x 1}]} { puts $x }` (tclsh prints 1, so the read
-            // is safe). Recover the body's writes too.
-            if let Some(body) = words.get(1) {
-                catch_body_out_vars(body, out);
-            }
+/// Out-vars written by the command named by `words[0]`, appended to `out`.
+///
+/// Registry-first: the write positions come from
+/// [`CommandRegistry::arg_indices_for_role`]`(…, `[`ArgRole::VarWrite`]`)`,
+/// which is the same machinery the analyser's out-var handling and W210's
+/// suppression harvest already consult.  It answers for every command the
+/// registry knows — `catch` / `scan` / `gets` / `regexp` as before, plus
+/// `set` / `append` / `lappend` / `incr` / `lset` / `regsub` / `lassign` /
+/// `binary scan` / `dict update` / `array set` / … — so
+/// `if {[set idx [lsearch $l foo]] > -1} {puts $idx}` no longer looks
+/// read-before-set (issue #923 idx 49; tclsh 9.0.4 / 8.6.14 both print the
+/// index).
+///
+/// Bodies that run in the *caller's own* frame
+/// ([`CommandRegistry::plain_body_arg_indices`] — `catch`'s script, and any
+/// other `Plain` body) are descended into as well: their assignments are
+/// (maybe) set once the substitution completes.  A `Structural` body
+/// (`uplevel`, `namespace eval`, `proc`) writes somewhere else entirely and
+/// is never harvested.
+///
+/// Destroyers ([`Traits::DESTROYS_VARIABLE`] — `unset`) are skipped: an
+/// `unset` in a condition removes a variable rather than defining one, and
+/// claiming it as a def would mask a genuine W213.
+///
+/// Suppress-only: over-collection avoids false warnings, under-collection
+/// leaves the status quo.
+fn cmd_substitution_out_vars(
+    words: &[CommandWord],
+    registry: &CommandRegistry,
+    out: &mut Vec<String>,
+    depth: u32,
+) {
+    // Native-stack safety net (issue #996): `catch {catch {catch …}}` nests
+    // body text inside one word, so the bracket-text cap applies. Past it,
+    // stop harvesting — under-collection is the safe direction here.
+    if MAX_BRACKET_TEXT_DEPTH.exceeded(depth) {
+        return;
+    }
+    let Some((cmd_word, arg_words)) = words.split_first() else {
+        return;
+    };
+    let cmd = &cmd_word.text;
+    if registry
+        .get(cmd)
+        .is_some_and(|s| s.traits.contains(Traits::DESTROYS_VARIABLE))
+    {
+        return;
+    }
+    let args: Vec<&str> = arg_words.iter().map(|w| w.text.as_str()).collect();
+    for idx in registry.arg_indices_for_role(cmd, &args, ArgRole::VarWrite) {
+        if let Some(w) = arg_words.get(idx) {
+            push_out_var(w, out);
         }
-        // `scan STRING FORMAT ?varName ...?`
-        Some("scan") => {
-            for w in words.iter().skip(3) {
-                push_out_var(w, out);
-            }
+    }
+    for idx in registry.plain_body_arg_indices(cmd, &args) {
+        // The word's *content* spelling already has the enclosing braces
+        // stripped, so it is the body script text as written.  A body reached
+        // through a substitution (`catch $script`) is unknown text and
+        // contributes nothing.
+        if let Some(body) = arg_words.get(idx).filter(|w| !w.substituted) {
+            script_text_out_vars_at(&body.text, registry, out, depth);
         }
-        // `gets channelId ?varName?` writes the line into `varName` in the
-        // current scope (e.g. `while {[gets $fp line] >= 0} {…}`).
-        Some("gets") => {
-            if let Some(w) = words.get(2) {
-                push_out_var(w, out);
-            }
-        }
-        // `regexp ?switches? EXP STRING ?matchVar subVar ...?`
-        Some("regexp") => {
-            let mut i = 1;
-            while i < words.len() && words[i].starts_with('-') {
-                if words[i] == "--" {
-                    i += 1;
-                    break;
-                }
-                // `-start` consumes a value; every other regexp switch is a
-                // valueless flag.
-                if words[i] == "-start" {
-                    i += 1;
-                }
-                i += 1;
-            }
-            // Skip EXP and STRING; the remaining words are out-vars.
-            for w in words.iter().skip(i + 2) {
-                push_out_var(w, out);
-            }
-        }
-        _ => {}
     }
 }
 
-/// Out-vars assigned by the *body* of a `catch {SCRIPT}` — direct
-/// `set`/`append`/`lappend`/`incr` targets plus nested command-substitution
-/// writers (`gets`/`scan`/`regexp`/`catch`). Suppress-only: keeps a read of a
-/// catch-body-assigned variable *after* the catch from looking
-/// read-before-set. Over-collection here is safe (it only avoids false
-/// warnings); a body whose error precedes the assignment is the conservative
-/// stance read-before-set already takes for command substitutions.
-fn catch_body_out_vars(body_word: &str, out: &mut Vec<String>) {
-    // The body is usually a single braced word; strip the braces to recover the
-    // script text. A non-braced body (e.g. a bare command) is scanned as-is.
-    let body = body_word
-        .strip_prefix('{')
-        .and_then(|s| s.strip_suffix('}'))
-        .unwrap_or(body_word);
-    script_text_out_vars(body, out);
-}
-
-/// Out-vars assigned by a run of **script text** — direct
-/// `set`/`append`/`lappend`/`incr` targets plus nested command-substitution
-/// writers (`gets`/`scan`/`regexp`/`catch`).
+/// Out-vars assigned by a run of **script text**.
 ///
-/// Shared by [`catch_body_out_vars`] (a `catch` body word, braces already
-/// stripped) and the analyser's read-before-set suppression for a
+/// Shared by [`cmd_substitution_out_vars`]'s `Plain`-body descent (a `catch`
+/// script) and the analyser's read-before-set suppression for a
 /// [`tcl_registry::Traits::SCRIPT_CONCATENATES_ARGS`] call whose words the
 /// lowering left as an opaque barrier (`eval set l2 hello` — issue #1051).
 /// Both need the same answer from the same text, so they ask once here.
 ///
 /// Suppress-only: over-collection is safe (it only avoids false warnings),
 /// under-collection merely leaves the status quo.
-pub(crate) fn script_text_out_vars(body: &str, out: &mut Vec<String>) {
-    // First-arg-writer membership is the registry's
-    // `writes_first_arg_variable` query (cached default registry — the set
-    // is core Tcl in every dialect); over-collection stays safe per the
-    // suppress-only contract above.
-    let registry = tcl_registry::cache::registry_for_dialect("tcl8.6");
-    for words in tokenise_to_command_words(body) {
-        match words.first() {
-            // Direct assignment commands write their first argument.
-            Some(cmd) if registry.writes_first_arg_variable(cmd) => {
-                if let Some(w) = words.get(1) {
-                    push_out_var(w, out);
-                }
-            }
-            // Nested command-sub writers (`gets`/`scan`/`regexp`/`catch`).
-            _ => cmd_substitution_out_vars(&words, out),
-        }
+pub(crate) fn script_text_out_vars(body: &str, registry: &CommandRegistry, out: &mut Vec<String>) {
+    script_text_out_vars_at(body, registry, out, 0);
+}
+
+fn script_text_out_vars_at(
+    body: &str,
+    registry: &CommandRegistry,
+    out: &mut Vec<String>,
+    depth: u32,
+) {
+    for words in tokenise_command_words(body) {
+        cmd_substitution_out_vars(&words, registry, out, depth + 1);
     }
 }
 
@@ -541,46 +537,47 @@ fn collect_expr_commands_at(expr: &ExprNode, out: &mut Vec<String>, depth: u32) 
 }
 
 /// Tokenise source text into a flat list of words (single command).
-fn tokenise_to_words(source: &str) -> Vec<String> {
-    let sm = SourceMap::new(source);
-    let lexer = Lexer::new(source);
-    let Ok(tokens) = lexer.tokenise_all() else {
-        return Vec::new();
-    };
+fn tokenise_to_words(source: &str) -> Vec<CommandWord> {
+    tokenise_command_words(source)
+        .into_iter()
+        .next()
+        .unwrap_or_default()
+}
 
-    let mut words = Vec::new();
-    let mut prev_is_sep = true;
-    for tok in &tokens {
-        match tok.kind {
-            TokenType::Sep | TokenType::Eol | TokenType::Eof | TokenType::Comment => {
-                prev_is_sep = true;
-            }
-            _ => {
-                let text = sm.token_text(*tok);
-                if prev_is_sep {
-                    words.push(text.to_owned());
-                } else if let Some(last) = words.last_mut() {
-                    last.push_str(text);
-                } else {
-                    words.push(text.to_owned());
-                }
-                prev_is_sep = false;
-            }
-        }
-    }
-    words
+/// One word of a tokenised command, in both spellings its consumers need.
+///
+/// The lexer's `token_text` strips a token's `$` / `${` / `[` / `{` / `"`
+/// prefix, which is what a name-harvesting caller wants (`{set x 1}` → the
+/// script text) but which erases the distinction that decides whether a word
+/// *is* a name: `set $x 1` and `set x 1` both reduce to `["set", "x", "1"]`.
+/// Carrying both spellings plus the two quoting facts lets every consumer ask
+/// its own question of one tokenisation.
+#[derive(Debug, Clone)]
+pub(crate) struct CommandWord {
+    /// Concatenated token **content** — `$x` → `x`, `{s}` → `s`.
+    pub text: String,
+    /// Concatenated **verbatim** source spelling — `$x` stays `$x`.  A
+    /// delimited token's closer is one past its span (the inner-end
+    /// convention), so a braced word reads back as `{s` — enough to answer
+    /// "does the name position substitute?", not enough to re-parse.
+    pub raw: String,
+    /// Some constituent token is a `$` / `[` substitution, so the word's
+    /// value is not its source text.
+    pub substituted: bool,
+    /// The word is a single brace-quoted token (`{…}`): Tcl leaves its
+    /// content literal, so a `$` inside is source text, not a substitution.
+    pub braced_literal: bool,
 }
 
 /// Tokenise source text into a list of commands, each a list of words.
-fn tokenise_to_command_words(source: &str) -> Vec<Vec<String>> {
+pub(crate) fn tokenise_command_words(source: &str) -> Vec<Vec<CommandWord>> {
     let sm = SourceMap::new(source);
-    let lexer = Lexer::new(source);
-    let Ok(tokens) = lexer.tokenise_all() else {
+    let Ok(tokens) = Lexer::new(source).tokenise_all() else {
         return Vec::new();
     };
 
     let mut commands = Vec::new();
-    let mut words: Vec<String> = Vec::new();
+    let mut words: Vec<CommandWord> = Vec::new();
     let mut prev_is_sep = true;
 
     for tok in &tokens {
@@ -595,13 +592,21 @@ fn tokenise_to_command_words(source: &str) -> Vec<Vec<String>> {
                 prev_is_sep = true;
             }
             _ => {
-                let text = sm.token_text(*tok);
-                if prev_is_sep {
-                    words.push(text.to_owned());
-                } else if let Some(last) = words.last_mut() {
-                    last.push_str(text);
-                } else {
-                    words.push(text.to_owned());
+                let substituted = matches!(tok.kind, TokenType::Var | TokenType::Cmd);
+                match words.last_mut() {
+                    Some(last) if !prev_is_sep => {
+                        last.text.push_str(sm.token_text(*tok));
+                        last.raw.push_str(sm.text(tok.span));
+                        last.substituted |= substituted;
+                        // A compound word (`{a}$b`) is no longer literal.
+                        last.braced_literal = false;
+                    }
+                    _ => words.push(CommandWord {
+                        text: sm.token_text(*tok).to_owned(),
+                        raw: sm.text(tok.span).to_owned(),
+                        substituted,
+                        braced_literal: tok.kind == TokenType::Str,
+                    }),
                 }
                 prev_is_sep = false;
             }
@@ -795,7 +800,25 @@ mod tests {
     #[test]
     fn tokenise_simple_command() {
         let words = tokenise_to_words("set x 1");
-        assert_eq!(words, vec!["set", "x", "1"]);
+        let texts: Vec<&str> = words.iter().map(|w| w.text.as_str()).collect();
+        assert_eq!(texts, vec!["set", "x", "1"]);
+        assert!(words.iter().all(|w| !w.substituted));
+    }
+
+    #[test]
+    fn tokenise_keeps_both_spellings_and_the_substitution_flag() {
+        let words = tokenise_to_words("set $x {a $b}");
+        let texts: Vec<&str> = words.iter().map(|w| w.text.as_str()).collect();
+        let raws: Vec<&str> = words.iter().map(|w| w.raw.as_str()).collect();
+        // Content drops the `$`; raw keeps it. A delimited token's closer is
+        // one past its span, so the braced word's raw spelling stops at `b`.
+        assert_eq!(texts, vec!["set", "x", "a $b"]);
+        assert_eq!(raws, vec!["set", "$x", "{a $b"]);
+        assert_eq!(
+            words.iter().map(|w| w.substituted).collect::<Vec<_>>(),
+            vec![false, true, false]
+        );
+        assert!(words[2].braced_literal, "`{{a $b}}` is a literal word");
     }
 
     #[test]
@@ -824,5 +847,97 @@ mod tests {
             d.contains(&"x".to_string()),
             "should find set's VarWrite; got {d:?}"
         );
+    }
+
+    /// Out-vars a condition-embedded `[cmd …]` contributes, as
+    /// [`condition_command_out_vars`] sees them.
+    fn cond_out_vars(cmd_text: &str) -> Vec<String> {
+        let registry = tcl_registry::cache::registry_for_dialect("tcl8.6");
+        let expr = ExprNode::Command {
+            text: format!("[{cmd_text}]"),
+            start: 0,
+            end: 0,
+        };
+        condition_command_out_vars(&expr, registry)
+    }
+
+    /// Contract for issue #923 audit idx 49: the registry's
+    /// `ArgRole::VarWrite` query must answer for every command the deleted
+    /// `catch` / `scan` / `gets` / `regexp` name list covered.
+    #[test]
+    fn registry_query_covers_the_deleted_hardcoded_four() {
+        for (cmd_text, expected) in [
+            ("catch {error x} msg opts", vec!["msg", "opts"]),
+            ("scan $t {%d %d} a b", vec!["a", "b"]),
+            ("gets $fp line", vec!["line"]),
+            ("regexp {(a)(b)} $s m p q", vec!["m", "p", "q"]),
+            // The switch-skipping the hand-rolled `regexp` loop did by hand
+            // is the registry resolver's job now.
+            ("regexp -nocase -- $re $s m", vec!["m"]),
+        ] {
+            let got = cond_out_vars(cmd_text);
+            for name in &expected {
+                assert!(
+                    got.iter().any(|v| v == name),
+                    "`{cmd_text}` must still yield `{name}`; got {got:?}"
+                );
+            }
+        }
+    }
+
+    /// …and it exceeds that list: commands the hardcoded four never covered,
+    /// each verified against tclsh 9.0.4 / 8.6.14 first.
+    #[test]
+    fn registry_query_exceeds_the_deleted_hardcoded_four() {
+        for (cmd_text, expected) in [
+            // `proc bar {lst} {if {[set idx [lsearch $lst foo]] > -1} {puts $idx}}`
+            // `bar {a foo b}` → 1
+            ("set idx [lsearch $lst foo]", vec!["idx"]),
+            // `proc loopy {} {set i 0; while {[incr i] < 3} {puts $i}}` → 1 2
+            ("incr i", vec!["i"]),
+            // `proc lass {lst} {lassign $lst a b; puts "$a-$b"}`
+            // `lass {1 2}` → 1-2
+            ("lassign $lst a b", vec!["a", "b"]),
+            // `proc binscan {} {binary scan "AB" H2H2 hi lo; puts "$hi $lo"}`
+            // → 41 42
+            ("binary scan $d H2H2 hi lo", vec!["hi", "lo"]),
+            // `regsub` writes its result variable.
+            ("regsub $re $s $r out", vec!["out"]),
+        ] {
+            let got = cond_out_vars(cmd_text);
+            for name in &expected {
+                assert!(
+                    got.iter().any(|v| v == name),
+                    "`{cmd_text}` must yield `{name}`; got {got:?}"
+                );
+            }
+        }
+    }
+
+    /// A `Plain` body (`catch`'s script) runs in the caller's own frame, so
+    /// its writes are harvested; a destroyer is not a definition.
+    #[test]
+    fn condition_out_vars_descends_plain_bodies_but_skips_destroyers() {
+        let got = cond_out_vars("catch {set inner 1} msg");
+        assert!(got.iter().any(|v| v == "inner"), "got {got:?}");
+        assert!(got.iter().any(|v| v == "msg"), "got {got:?}");
+
+        // tclsh 9.0.4 / 8.6.14:
+        // `proc t {} {if {[catch {unset gone}]} {puts $gone}}`
+        // `catch {t} err` → 1, err → `can't read "gone": no such variable`
+        let got = cond_out_vars("catch {unset gone}");
+        assert!(
+            !got.iter().any(|v| v == "gone"),
+            "`unset` destroys rather than defines; got {got:?}"
+        );
+    }
+
+    /// A dynamic target contributes no *name* — `push_out_var` only accepts a
+    /// bare identifier, so `set $n 1` in a condition stays silent rather than
+    /// inventing a def called `n`.
+    #[test]
+    fn condition_out_vars_ignores_a_dynamic_target() {
+        let got = cond_out_vars("set $n 1");
+        assert!(got.is_empty(), "got {got:?}");
     }
 }

--- a/rust/tcl-compiler/src/ir_helpers.rs
+++ b/rust/tcl-compiler/src/ir_helpers.rs
@@ -378,8 +378,19 @@ fn push_out_var(word: &CommandWord, out: &mut Vec<String>) {
 /// `unset` in a condition removes a variable rather than defining one, and
 /// claiming it as a def would mask a genuine W213.
 ///
+/// A **substituted command head** (`[$cmd length foo]`) is skipped for the
+/// same reason: which command runs is run-time data, so nothing can be
+/// claimed about what it writes.  The word's *content* spelling drops the
+/// `$`, so without this check the head of `[$set length foo]` resolves as the
+/// builtin `set` and the harvest invents a definition of `length` — enough to
+/// swallow a genuine warning.  tclsh 9.0.4 / 8.6.14: `proc f {set} {if
+/// {[$set length foo]} {puts $length}}; f string` errors `can't read
+/// "length": no such variable`, so the read really is unsafe.
+///
 /// Suppress-only: over-collection avoids false warnings, under-collection
-/// leaves the status quo.
+/// leaves the status quo — but a name harvested from the *wrong* command is
+/// not over-collection, it is a wrong fact, so the skip is a correctness
+/// requirement rather than a precision nicety.
 fn cmd_substitution_out_vars(
     words: &[CommandWord],
     registry: &CommandRegistry,
@@ -395,6 +406,9 @@ fn cmd_substitution_out_vars(
     let Some((cmd_word, arg_words)) = words.split_first() else {
         return;
     };
+    if cmd_word.substituted {
+        return;
+    }
     let cmd = &cmd_word.text;
     if registry
         .get(cmd)
@@ -939,5 +953,42 @@ mod tests {
     fn condition_out_vars_ignores_a_dynamic_target() {
         let got = cond_out_vars("set $n 1");
         assert!(got.is_empty(), "got {got:?}");
+    }
+
+    /// PR #1076 review, P2: a command word that is itself a substitution names
+    /// an unknown command, so nothing may be harvested from it — not even when
+    /// its *content* spelling collides with a builtin.
+    ///
+    /// tclsh 9.0.4 / 8.6.14: `proc f {set} {if {[$set length foo]} {puts
+    /// $length}}; f string` runs `string length foo` and then errors
+    /// `can't read "length": no such variable`.
+    #[test]
+    fn condition_out_vars_ignores_a_substituted_command_head() {
+        for cmd_text in ["$set length foo", "$catch {error x} msg", "[pick] $fp line"] {
+            let got = cond_out_vars(cmd_text);
+            assert!(
+                got.is_empty(),
+                "`{cmd_text}` has a computed head; nothing is knowable about \
+what it writes, got {got:?}"
+            );
+        }
+    }
+
+    /// TP control for the pair above: the same words under a *literal* head
+    /// keep harvesting, so the guard keys on substitution rather than on the
+    /// spelling.
+    #[test]
+    fn condition_out_vars_still_harvests_a_literal_head() {
+        assert!(
+            cond_out_vars("set length foo")
+                .iter()
+                .any(|v| v == "length")
+        );
+        assert!(
+            cond_out_vars("catch {error x} msg")
+                .iter()
+                .any(|v| v == "msg")
+        );
+        assert!(cond_out_vars("gets $fp line").iter().any(|v| v == "line"));
     }
 }

--- a/rust/tcl-compiler/src/lib.rs
+++ b/rust/tcl-compiler/src/lib.rs
@@ -103,6 +103,7 @@ pub mod dataflow_graph;
 pub mod dead_stores;
 pub mod def_use;
 mod depth_guard;
+pub mod dynamic_names;
 pub mod execution_intent;
 // The `expr` AST + Pratt parser now live in the shared `tcl-syntax` crate
 // (consumed by both the compiler and the runtime port). Re-exported under the

--- a/rust/tcl-compiler/src/optimiser/branch_folding.rs
+++ b/rust/tcl-compiler/src/optimiser/branch_folding.rs
@@ -475,6 +475,7 @@ mod tests {
             taints: std::collections::HashMap::new(),
             rendered_props: std::collections::HashMap::new(),
             memory_ssa: None,
+            dynamic_names: crate::dynamic_names::DynamicNameBarrier::default(),
             complexity_guarded: false,
             base_offset: 0,
         }

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -438,6 +438,13 @@ fn emit_dead_stores_and_unused(
     purity: PurityCtx<'_>,
     proc_index: &crate::interprocedural::ProcIndex,
 ) -> HashSet<(String, u32)> {
+    // A dynamic read (`[set $name]`, `subst $tmpl`) can observe *any* store,
+    // so no assignment in this function is provably dead (issue #923 audit
+    // idx 2/64).  Deleting one would change what the program prints, so the
+    // optimiser abstains toward not folding — no O109/O126, and no ADCE seed.
+    if fu.dynamic_names.reads {
+        return HashSet::new();
+    }
     let unreachable = unreachable_blocks(&fu.cfg, &fu.sccp);
     // Alias recognition is registry-driven; a registry-less context (unit
     // tests) falls back to the cached default so `global`/`upvar` bindings

--- a/rust/tcl-compiler/src/sccp.rs
+++ b/rust/tcl-compiler/src/sccp.rs
@@ -851,11 +851,24 @@ fn collect_constant_branches(
 /// Scope-alias locals (`global` / `variable` / `upvar` / `namespace
 /// upvar` bindings) are never folded — their existence tracks the
 /// linked out-of-frame variable.
+///
+/// `dynamic_names` carries the function's
+/// [dynamic-name barrier](crate::dynamic_names) and gates each direction
+/// independently (issue #923 audit idx 1):
+///
+/// - a **dynamic write** (`set $switch {}`) can define *any* name, so the
+///   "never defined here, therefore absent" fold is no longer provable;
+/// - a **dynamic destroy** (`unset $n`) can remove *any* name, so even the
+///   "it's a parameter, therefore present" fold is no longer provable.
+///
+/// Both abstain by declining the fold, which silences I230 and leaves O101
+/// with nothing to fold — say less rather than say something wrong.
 #[must_use]
 pub fn existence_constant_branches<S: std::hash::BuildHasher>(
     cfg: &CfgFunction,
     params: &HashSet<&str, S>,
     registry: &tcl_registry::CommandRegistry,
+    dynamic_names: crate::dynamic_names::DynamicNameBarrier,
 ) -> Vec<ConstantBranch> {
     let mut out = Vec::new();
     if cfg.blocks.values().any(|b| {
@@ -934,11 +947,20 @@ pub fn existence_constant_branches<S: std::hash::BuildHasher>(
             continue;
         }
         let exists = if params.contains(var.as_str()) {
-            if unset.contains(var.as_str()) {
+            // A literal `unset x` already blocks this; a computed
+            // `unset $n` can name the parameter just as well
+            // (tclsh 9.0.4 / 8.6.14: `proc f {p n} {unset $n; info exists p}`
+            // → `0` for `f hello p`), so the barrier blocks it too.
+            if unset.contains(var.as_str()) || dynamic_names.destroys {
                 continue;
             }
             true
         } else if !defined.contains(&var) {
+            // `set $switch {}` may have defined exactly this name — the
+            // argparse idiom the fold used to call unreachable.
+            if dynamic_names.writes {
+                continue;
+            }
             false
         } else {
             continue;

--- a/rust/tcl-compiler/tests/core_analyses.rs
+++ b/rust/tcl-compiler/tests/core_analyses.rs
@@ -999,16 +999,16 @@ mod no_read_before_set {
     }
 
     #[test]
-    fn cmd_sub_set_in_branch_condition_diverges() {
-        // Same shape in a branch condition — `if {[set x 1]} { puts $x }`. The
-        // `set x 1` inside the condition's command substitution defines x (tclsh:
-        // x is 1 in the body). The analyser does not scan branch-condition
-        // cmd-sub writes, so `$x` is flagged W210. Sound over-warn; actual
-        // verdict asserted.
+    fn cmd_sub_set_in_branch_condition_is_a_definition() {
+        // `if {[set x 1]} { puts $x }` — the `set x 1` inside the condition's
+        // command substitution defines x before either arm runs (tclsh 9.0.4 /
+        // 8.6.14 print `1`). The condition out-var harvest asks the registry
+        // which arguments carry `ArgRole::VarWrite`, so `set` answers like
+        // `catch` / `gets` / `regexp` / `scan` always did (issue #923 idx 49).
         let src = "proc p {} { if {[set x 1]} { puts $x } }\n";
         assert!(
-            fires(src, "W210"),
-            "Rust flags the cmd-sub-defined $x in a branch condition"
+            !fires(src, "W210"),
+            "a condition-embedded `set` defines its target"
         );
     }
 

--- a/rust/tcl-fuzz/src/generator.rs
+++ b/rust/tcl-fuzz/src/generator.rs
@@ -122,7 +122,7 @@ impl Gen {
             // proc / namespace definitions are top-level only (matching the
             // oracle): nesting them changes scope semantics in ways the
             // generator doesn't model.
-            let arms = if depth == 0 { 10 } else { 7 };
+            let arms = if depth == 0 { 11 } else { 7 };
             match self.rng.below(arms) {
                 0 => self.if_stmt(depth),
                 1 => self.while_stmt(depth),
@@ -134,6 +134,7 @@ impl Gen {
                 7 => self.proc_stmt(depth),
                 8 => self.namespace_stmt(depth),
                 9 => self.inscope_stmt(),
+                10 => self.dynamic_name_stmt(),
                 _ => self.leaf_statement(depth),
             }
         }
@@ -453,6 +454,49 @@ impl Gen {
             let _ = write!(call, " {arg}");
         }
         let _ = writeln!(self.out, "puts [{call}]");
+    }
+
+    /// Variable access whose *name* is computed at run time — `set $n v`,
+    /// `[set $n]`, `lappend $n w`, `unset $n`, and a `subst` over a
+    /// variable-held template.
+    ///
+    /// The compiler's SSA / dataflow treats these as whole-name-space
+    /// barriers (issue #923 audit cluster C10,
+    /// `tcl_compiler::dynamic_names`), which gates the constant-branch fold
+    /// and dead-store elimination feeding this backend's input IR — so the
+    /// differential needs the shapes present to catch a VM that resolves a
+    /// computed name differently from C Tcl.
+    ///
+    /// Every arm keeps to a private `_dn*` name space the other productions
+    /// never touch, so the emitted lines stay deterministic wherever they land
+    /// in the script.  Output is the resolved value plus an `info exists`
+    /// probe, so a wrong resolution is a stdout mismatch rather than a silent
+    /// pass.  tclsh 9.0.4 / 8.6.14 agree on all five arms.
+    fn dynamic_name_stmt(&mut self) {
+        match self.rng.below(5) {
+            // `set $n v` writes, `[set $n]` reads back — the argparse idiom.
+            0 => self.out.push_str(
+                "set _dnn _dnv\nset $_dnn hello\nputs [set $_dnn]\nputs [info exists _dnv]\n",
+            ),
+            // A read-modify-write through a computed name.
+            1 => self.out.push_str(
+                "set _dnn _dna\nlappend $_dnn one\nlappend $_dnn two\nputs [set $_dnn]\n",
+            ),
+            // `append` through a computed name.
+            2 => self
+                .out
+                .push_str("set _dnn _dnb\nappend $_dnn ab\nappend $_dnn cd\nputs [set $_dnn]\n"),
+            // A template held in a variable: `subst` expands names that only
+            // exist in run-time data.
+            3 => self
+                .out
+                .push_str("set _dnv 7\nset _dnt {$_dnv}\nputs [subst $_dnt]\n"),
+            // A computed-name destroy, probed either side.
+            _ => self.out.push_str(
+                "set _dnn _dnu\nset $_dnn gone\nputs [info exists _dnu]\n\
+                 unset $_dnn\nputs [info exists _dnu]\n",
+            ),
+        }
     }
 
     /// One trailing word for [`Gen::inscope_stmt`], chosen to exercise the
@@ -1099,6 +1143,49 @@ mod tests {
                 !corpus.iter().any(|s| s.contains(func)),
                 "TIP 745 (9.1-only) function must never be generated: {func:?}"
             );
+        }
+    }
+
+    /// Issue #923 audit cluster C10's coverage seed. Variable access through
+    /// a **computed name** was never generated, so the whole dynamic-name
+    /// path — which the compiler now treats as a dataflow barrier gating the
+    /// constant-branch fold and dead-store elimination that feed this
+    /// backend's input IR — went differentially untested. Proves every arm
+    /// reaches a generated script.
+    #[test]
+    fn dynamic_name_shapes_are_exercised() {
+        let cfg = GenConfig {
+            max_depth: 4,
+            max_stmts: 16,
+            ..GenConfig::default()
+        };
+        let corpus: Vec<String> = (0..600u64).map(|s| generate(s, &cfg)).collect();
+        for needle in [
+            "set $_dnn hello",
+            "puts [set $_dnn]",
+            "lappend $_dnn one",
+            "append $_dnn ab",
+            "puts [subst $_dnt]",
+            "unset $_dnn",
+        ] {
+            assert!(
+                corpus.iter().any(|s| s.contains(needle)),
+                "dynamic-name production never generated: {needle:?}"
+            );
+        }
+        // The shapes must stay inside their private `_dn*` name space, so
+        // wherever they land they cannot perturb the rest of a script.
+        for line in corpus
+            .iter()
+            .flat_map(|s| s.lines())
+            .filter(|l| l.contains("_dn"))
+        {
+            for v in VARS {
+                assert!(
+                    !line.contains(&format!("${v} ")) && !line.ends_with(&format!("${v}")),
+                    "dynamic-name line touches shared variable {v:?}: {line:?}"
+                );
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

Issue-923 audit cluster C10 — dynamic-name blindness in SSA/dataflow. The general fix is one new fact, not four patches: `DynamicNameBarrier` (new `dynamic_names.rs`), a per-function summary of three flags — `writes` (a `VarWrite`-role arg whose name substitutes), `destroys` (same on a `DESTROYS_VARIABLE` command), `reads` (`VarRead`-role substituting name, or `PERFORMS_SUBSTITUTION` over a non-braced template). Membership is entirely registry roles/traits — the module names no command. One flow-insensitive walk, no name sets, O(1) per consumer. `a($k)` and `${ns}::tail` are deliberately *not* barriers (the place model owns run-time elements; computed-namespace-static-tail is the `variable ${name}::graphAttr` idiom, and clobbering it broke a TP control).

Per-finding, with explicit soundness directions (oracle transcripts from tclsh 9.0.4 + 8.6.14, identical, in tests):

- **idx 1** — `[info exists X]` stops constant-folding → absent under `writes` and → present under `destroys`; W210 goes silent under `writes` (the confirmed FP: `proc f {n} {set $n 1; puts $foo}` printed while W210 fired). Abstain-toward-silence for warnings, abstain-toward-no-fold for O101/O107/DCE.
- **idx 2** — W211/W220 go silent under `reads`; O109/O126 stop eliminating — deleting a store whose only reader is a computed name is a miscompile, and the probe showed both firing on exactly those shapes.
- **idx 49** — the hardcoded `catch/scan/gets/regexp` list is **deleted**; `cmd_substitution_out_vars` asks `arg_indices_for_role(VarWrite)` + plain-body descent. No registry data was missing — it already knew the four plus more (`lassign`, `binary scan`, `dict update`, … each tclsh-verified). `DESTROYS_VARIABLE` is excluded so a condition `unset` can't manufacture a def. Suppress-only, abstain-toward-silence.
- **idx 64** — root cause (re-lex of quoted bodies) verified **already fixed** by the idx-125 value-body scan mode; both the minimal and real pixdoc repros now pinned as regressions rather than left unguarded.
- **Extra precision bug found en route:** the word tokenisers reported token *content*, dropping `$` — so `if {[set $n 1]}` harvested a false def named `n` that would silence a genuine W210. Fixed with a substitution guard, and the two near-duplicate tokenisers collapsed into one `tokenise_command_words`.

Since barrier facts change optimiser behaviour, the differential fuzzer's grammar gained a `dynamic_name_stmt` production (5 arms, namespaced so it can't perturb the rest of a script), following the #1067 precedent.

**Out of scope, documented:** `eval $body`/`uplevel 1 $body` produce the same FP class (probe-confirmed) but are a strictly larger blindness no audit finding names — recorded in the module/design docs and headed for the upvar/uplevel model PR.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-compiler -p tcl-registry -p tcl-fuzz` — 72 binaries, 8,116 passed, 0 failed (all optimiser suites included).
  - New: FP-RCH-05 (5), FP-DS-12/13 (8), FP-RBS-20 (7), registry answer-set contract (old four + five the list missed), 11 `dynamic_names` unit tests, fuzz coverage test; the pinned known-divergence test inverted to assert the fix.
  - clippy `-D warnings` on all three crates — clean, **zero new allows** (grep-verified); fmt clean; `make xtask-check` all gates OK.
  - `tcl-vm` untouched (no registry data change).
  - Mid-session ENOSPC handled per AGENTS.md; all results are post-recovery runs.

Note: STATUS.md count lines have known one-hunk overlaps with #1074/#1075 (each PR adjusted independently); I'll resolve on whichever merges last.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — the barrier is a new fact consumed by W210/W211/W220/I230 and the optimiser; out-var harvesting is registry-driven.
- [x] I updated at least one relevant KCS note: W210/W211/W220/I230 per-code pages (computed-name sections), `ssa-construction.md` design section, audit `STATUS.md`.
- [ ] New compiler KCS note linked. (n/a — existing notes updated; design section added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_