### PR TITLE
Per-proc frame-effect summaries for upvar/uplevel caller-frame injection (issue #923 audit idx 7/22/38/57/59/98)

### DIFF
--- a/docs/design/compiler/ssa-construction.md
+++ b/docs/design/compiler/ssa-construction.md
@@ -191,9 +191,116 @@ Consumers and the direction each abstains in:
 | dead store / unused → W211, W220 | `reads` | stay silent |
 | `optimiser::elimination` → O109, O126 | `reads` | do not eliminate |
 
-`eval $body` / `uplevel 1 $body` are deliberately **out of scope**: they run
-arbitrary code, a strictly larger blindness than a computed name, and lower to
-`Statement::Barrier` where the per-consumer barrier rules already apply.
+### The caller-frame injection model
+
+A computed name is one way to lose the name space.  The other is to have
+somebody *else* write it.  Tcl's frame-crossing primitives make a callee's
+writes land in the **caller's** frame, and the caller's own text shows
+nothing:
+
+```tcl
+proc setdef {d key args} { upvar 1 $d _dict; dict set _dict $key … }
+proc build {} { setdef options name -type str; return [dict get $options name] }
+```
+
+`options` is never assigned in `build`, yet it is set twice before the read.
+`rust/tcl-compiler/src/cfg_builder/upvar_info.rs` supplies the missing fact
+as a per-procedure **frame-effect summary** (`UpvarInfo` — the name is kept
+because the salsa interning layer imports it by that path):
+
+| bucket | shape | resolved |
+|---|---|---|
+| `literal_targets` | `upvar 1 caller_x x` | at summary time |
+| `param_targets` | `upvar 1 $param x` | at the call site, from the argument passed for `param` |
+| `args_tail_upvar` | `upvar 1 $args x` | at the call site, positionally |
+| `uplevel_literal_writes` | `uplevel 1 {set n …}`, `uplevel 1 [list set n …]` | at summary time |
+| `uplevel_param_writes` | `uplevel 1 [list set $param …]` | at the call site, like `param_targets` |
+| `uplevel_forwarded_calls` | `uplevel 1 [list callee …]` | one hop, in `detect_upvar_procs` |
+| `has_unresolvable_caller_target` | `upvar 1 $computed x` | not resolvable — widen |
+| `caller_frame_opaque_writes` / `_reads` | `uplevel 1 $body`, `upvar 2 …`, `upvar $lvl …` | not resolvable — widen |
+
+**Complexity.**  One walk per procedure to build the summary; one hash
+lookup plus work proportional to the *bound arguments* at each call site.
+The forwarded-call hop composes against the **own-body** summaries, never
+the composed ones, so a recursive or mutually-recursive forward cannot
+diverge — a single level by construction, no fixpoint and no iteration cap.
+
+**Frame targeting is the whole game.**  Only a `Relative(1)` level (or an
+omitted one) reaches the direct caller.  Which argument is the level word,
+and how to read it, is registry data —
+[`FrameEffectSpec`](../../../rust/tcl-registry/src/frame_effect.rs) on
+`CommandSpec`, so no consumer names `upvar` or `uplevel`:
+
+| written in the callee | frame written | contributed |
+|---|---|---|
+| `upvar 1 x y` / `upvar x y` | the caller | a named binding |
+| `upvar #0 g l` | the global frame | nothing — `global_write_info` owns it |
+| `upvar 0 x y` | the callee's own frame | nothing |
+| `upvar 2 far f`, `upvar $lvl a b` | somewhere further out | widen |
+| `uplevel 1 $body` | the caller | opaque write **and** read |
+| `uplevel 0 $body` / `eval $body` | the callee's own frame | the callee's own barrier |
+
+C Tcl decides whether `upvar`'s level word is present from the **argument
+count parity** (`Tcl_UpvarObjCmd` tests `objc`), never from the word's text.
+Three consumers had each re-derived that by sniffing for digits or `#`, and
+two of them were wrong: `upvar $lvl a b` has three words, so `$lvl` *is* the
+level and `(a, b)` is the pair, but a text sniff sees no level and pairs
+`($lvl, a)` — losing the commonest by-reference binding of all. Pinned on
+tclsh 9.0.4 and 8.6.14, identical:
+
+```tcl
+proc t3 {} {upvar 1 b; return [catch {set b} e]:$e}
+proc h3 {} {set 1 ONE; return [t3]}
+h3                          ;# → 0:ONE   — `1` is the otherVar, not a level
+catch {upvar foo bar baz} e ;# → bad level "foo"  — 3 words ⇒ the first IS the level
+```
+
+**Where the fact lands.**  A *named* caller-frame write is merged into the
+call statement's `defs`, so name-level SSA sees the definition and every
+existing consumer works unchanged.  An *opaque* one has no name to merge, so
+the CFG builder records it on `cfg::Function::caller_frame_barrier` and
+`dynamic_name_barrier` joins it into the same three-bit lattice above.
+Deliberately **not** a per-call-site fact: every consumer of that lattice
+already reads it once per function and abstains for the whole function, so a
+per-site fact would need flow-sensitivity none of them have and would buy
+nothing.
+
+**Soundness direction.**  Identical to the dynamic-name barrier's — abstain
+toward silence for warnings, toward no-fold for the optimiser.  A level the
+summary cannot place at the direct caller is *widened*, not dropped:
+dropping an `upvar 2` write would leave it invisible to the frame that
+receives it and produce a false `W210`, while widening only ever silences
+one.
+
+This also closes the `eval $body` / `uplevel 1 $body` gap that the
+dynamic-name barrier left out of scope.  The two are **not** the same
+effect, and the difference is load-bearing — tclsh 9.0.4 / 8.6.14,
+identical:
+
+```tcl
+proc runner {body} {set helper 42; uplevel 1 $body}
+runner {set x $helper}      ;# → can't read "helper": no such variable
+proc evalrunner {body} {set helper 42; eval $body}
+evalrunner {set helper}     ;# → 42
+```
+
+So `eval $body` blinds the frame it is written in, while `uplevel 1 $body`
+blinds that procedure's *callers* and leaves its own locals provable.
+
+**What cross-document (PR C1b) needs.**  `detect_upvar_procs` takes one
+`Module`, i.e. one file's parse, so a helper defined in another file is
+invisible however the call spells it (issue #923 audit idx 59's real
+ticklecharts layout: `setdef` in `utils.tcl`, 1876 call sites in
+`options.tcl`).  The summary is already a pure function of a procedure's
+body plus its parameter list and is `Hash`/`Eq`, so the workspace layer can
+intern one per procedure and merge the maps before `prepare_cfg_context`
+runs — no change to the model, only to who supplies the map.  The navigation
+providers need the same map plus the call site's scope, which the analyser's
+`SignatureCommandInvocation` does not yet carry.
+
+`eval $body` / `uplevel 1 $body` are no longer out of scope — see the
+caller-frame injection model above.  They still lower to
+`Statement::Barrier`, so the per-consumer barrier rules apply as well.
 
 ### Known limitation — a brace-quoted `$`-bearing name is mis-keyed
 

--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -511,6 +511,32 @@ counted here because its repros are now pinned as regression tests
 (FP-DS-13) rather than left unguarded. That makes **48 fixed, 37
 remaining**.
 
+**2026-07-30 update — PR C1a (`claude/commandregistry-compiler-fixes-tshu8d-upvar-model`)
+fixed four more, all tier 2 — the "caller-frame injection" cluster:** idx 7,
+idx 38, idx 57, and idx 59. All four are the same missing fact from four
+angles, now supplied by the per-proc
+[frame-effect summary](../../../rust/tcl-compiler/src/cfg_builder/upvar_info.rs):
+*which names does a call to this procedure write in **my** frame?* — computed
+once per procedure from the registry's new
+[`FrameEffectSpec`](../../../rust/tcl-registry/src/frame_effect.rs) and read
+at every call site. idx 57/59 were the summary being keyed only under the
+bare and fully-absolute spellings, so the ordinary relative-qualified call
+(`demo::setdef`) silently missed. idx 38 is `uplevel 1 [list set $v …]`: a
+constructed body names its command statically, so `set`'s own `VarWrite`
+role says which word is the caller-frame target. idx 7 is `argparse`, whose
+caller-frame locals come from a definition-list mini-language nothing here
+interprets — registry-declared as an opaque caller-frame injection, so the
+calling proc widens instead of guessing. **idx 22 and idx 98 are PARTIAL**:
+the analyser half landed (a fully-qualified or `#0` `upvar` target now gets a
+link target; the caller-frame defs now reach the dataflow), but their
+headline symptom is hover / go-to-definition / find-references returning
+nothing, and those consumers live in `tcl-lsp-core` — PR C1b takes them
+together with idx 58/99/100. idx 59's **cross-file** half is likewise
+unfixed: `detect_upvar_procs` is single-`Module`, so a helper defined in
+another file is invisible whatever the spelling (see "what C1b needs" in
+[`ssa-construction.md`](../../design/compiler/ssa-construction.md)). That
+makes **52 fixed, 33 remaining**.
+
 **By corpus** (confirmed only): ticklecharts 20, tk 17, argparse 10,
 SpiceGenTcl 10, tclopt 13 (6+7, split across two inconsistent corpus-label
 strings in the raw data — same corpus), tomato 7, pix 8.
@@ -723,7 +749,7 @@ users, a worse failure mode than the narrower, but fully oracle-grounded,
 `CONFIGURE`-tracking fix actually shipped. Left as a documented, low-risk
 follow-up for a session with Tk oracle access.
 
-#### Priority tier 2 — medium + low (60 + 1 = 61 findings, 26 now fixed — 35 remaining), grouped by feature for clustering
+#### Priority tier 2 — medium + low (60 + 1 = 61 findings, 30 now fixed — 31 remaining), grouped by feature for clustering
 
 Group findings sharing a feature/root-cause together in one fix pass the
 way idx 107+115 and idx 118+119 were — many of these look like they share
@@ -736,7 +762,7 @@ mixin/oo::configurable class-scoping findings, idx 34/36).
 | tclOO | 10 | 15, 16, 34, 35, 36, ~~53~~ **FIXED**, ~~54~~ **FIXED**, ~~55~~ **FIXED**, ~~96~~ **FIXED**, ~~97~~ **FIXED** (all medium) |
 | namespaces | 8 | ~~3~~ **FIXED** (#1071), 19, ~~43~~ **ALREADY FIXED**, ~~44~~ **FIXED**, ~~64~~ **FIXED**, 65, 75, 85 (all medium) |
 | tricky_indirection | 7 | 0 (medium, **FIXED** — see below), ~~1~~ **FIXED**, ~~2~~ **FIXED**, 14, ~~49~~ **FIXED**, 50, 51 (all medium) |
-| upvar | 7 | 7, 22, 57, 58, 59, 98, 99 (all medium) |
+| upvar | 7 | ~~7~~ **FIXED** (PR C1a), 22 (**PARTIAL** — model landed, navigation in C1b), ~~57~~ **FIXED** (PR C1a), 58, ~~59~~ **FIXED** (PR C1a, single-document; cross-file open), 98 (**PARTIAL** — same), 99 (all medium) |
 | proc_args | 7 | ~~11~~ **FIXED** (#1071), 28, 37, 62, 67, 78, ~~104~~ **FIXED** (all medium) |
 | tcl_mathop | 4 | ~~30~~ **FIXED**, 80, ~~81~~ **ALREADY FIXED**, ~~103~~ **FIXED** (all medium) |
 | package_loading | 3 | ~~4~~ **FIXED** (#1071), 42, 72 (all medium) |
@@ -744,7 +770,7 @@ mixin/oo::configurable class-scoping findings, idx 34/36).
 | tracing | 3 | 47, ~~48~~ **FIXED**, ~~92~~ **FIXED** (PR B1) (all medium) |
 | rename | 2 | ~~5~~ **ALREADY FIXED** (pinned, PR B1), ~~45~~ **FIXED** (PR B1) (all medium) |
 | aliasing | 2 | ~~21~~ **FIXED** (PR B1), ~~89~~ **FIXED** (PR B1) (all medium) |
-| uplevel | 2 | 38 (medium), 100 (low) |
+| uplevel | 2 | ~~38~~ **FIXED** (PR C1a) (medium), 100 (low) |
 | eval | 1 | ~~24~~ **FIXED** (medium) |
 | autoindex | 1 | 73 (medium) |
 | safe_interp | 1 | 91 (medium) |

--- a/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
+++ b/docs/kcs/codes/kcs-diagnostic-w210-variable-read-before-set.md
@@ -122,6 +122,44 @@ unset, so `W210` goes silent for the whole proc. That is deliberate: a warning
 that cannot be proved is worse than a missing one. Spell the name out to get
 the check back.
 
+## A procedure you call can set your variables
+
+Tcl lets a procedure write its **caller's** variables, so a variable nothing in
+your own code assigns can still be set by the time you read it:
+
+```tcl
+proc setdef {dictVar key value} {
+    upvar 1 $dictVar d       ;# `d` is an alias for the caller's variable
+    dict set d $key $value
+}
+proc build {} {
+    setdef options name blue ;# creates `options` in `build`
+    return [dict get $options name]
+}
+```
+
+The analyser works out, once per procedure, which of your variables a call to
+it writes, and treats the call as the assignment. That covers `upvar` with a
+literal name or a by-name parameter, `uplevel 1 {…}`, and
+`uplevel 1 [list set …]`. It also follows one hop of `uplevel 1 [list helper
+…]`, where `helper`'s own `upvar` reaches one frame further out than a plain
+call would.
+
+Which frame the write lands in matters, and only a write to *your* frame
+counts. `upvar #0` writes a global, `upvar 0` writes the callee's own local,
+and `upvar 2` writes your caller's caller — none of them is an assignment to
+your variable.
+
+When the name cannot be worked out — `uplevel 1 $script`, a computed
+`upvar` target, or `argparse`, which names its variables from its own
+definition list — the procedure could write *any* of your variables, so
+`W210` goes silent for the whole calling procedure, exactly as it does for a
+computed name.
+
+Note the difference between `eval` and `uplevel`: `eval $script` runs in the
+procedure that writes it, so it can set that procedure's own locals;
+`uplevel 1 $script` runs one frame up, so it cannot.
+
 ## How to suppress
 
 Add `# noqa: W210` at the end of the offending line.

--- a/docs/kcs/codes/kcs-diagnostic-w211-variable-set-not-used.md
+++ b/docs/kcs/codes/kcs-diagnostic-w211-variable-set-not-used.md
@@ -60,6 +60,27 @@ proved unused. See
 [W220](kcs-diagnostic-w220-dead-store.md#computed-variable-names-silence-the-check)
 for the same rule on the dead-store side.
 
+## Reads from a procedure you call
+
+A procedure can run a script in its **caller's** frame, and that script can
+read the caller's variables:
+
+```tcl
+proc runner {script} { uplevel 1 $script }
+proc host {expr} {
+    set threshold 10       ;# not flagged — `$script` may read it
+    runner $expr
+}
+```
+
+When the script is not readable, the callee could read any of the caller's
+variables, so `W211` goes silent for the whole calling procedure. Which frame
+the script runs in decides whose variables are protected: `uplevel 1 $script`
+protects the *caller's*, `eval $script` protects the procedure that writes it.
+See
+[W220](kcs-diagnostic-w220-dead-store.md#a-procedure-you-call-can-read-your-variables)
+for the same rule on the dead-store side.
+
 ## How to suppress
 
 Add `# noqa: W211` at the end of the offending line, or set

--- a/docs/kcs/codes/kcs-diagnostic-w220-dead-store.md
+++ b/docs/kcs/codes/kcs-diagnostic-w220-dead-store.md
@@ -74,6 +74,32 @@ silent for the whole proc, and the optimiser stops removing stores there
 Removing a store the analyser cannot see the reader for would change what the
 program prints, so the analysis abstains instead.
 
+## A procedure you call can read your variables
+
+A procedure can run a whole script in its **caller's** frame, so a store the
+calling code never appears to read may well be read there:
+
+```tcl
+proc runner {script} { uplevel 1 $script }
+proc host {expr} {
+    set threshold 10       ;# not a dead store — `$script` may read it
+    runner $expr
+}
+```
+
+When the script is not readable — `uplevel 1 $script`, or a computed `upvar`
+target — the callee could read *any* of your variables, so `W220` and
+[`W211`](kcs-diagnostic-w211-variable-set-not-used.md) both go silent for the
+whole calling procedure and the optimiser stops removing stores there. A
+brace-quoted script (`runner {puts $threshold}`) is ordinary source text the
+analyser reads directly, so it does not silence anything.
+
+The frame the script runs in decides whose variables are at risk. Inside
+`runner` itself, `uplevel 1 $script` runs one frame *up*, so `runner`'s own
+locals stay provable — a `set` in `runner` that nothing in `runner` reads is
+still a real dead store. `eval $script` is the other way round: it runs where
+it is written, so it protects that procedure's own locals instead.
+
 ## How to suppress
 
 Add `# noqa: W220` at the end of the offending line.

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -3687,11 +3687,32 @@ impl Analyser {
         }
     }
 
-    /// Register the local-alias names introduced by `upvar`.
+    /// Register the local-alias names introduced by `upvar`, and link the
+    /// alias to its target cell whenever the target is frame-independent.
     ///
-    /// `upvar ?level? otherVar myVar ?otherVar myVar ...?` — an optional
-    /// leading level makes the arg count odd; each pair after it binds the
-    /// local alias `myVar`.
+    /// `upvar ?level? otherVar myVar ?otherVar myVar ...?` — C Tcl decides
+    /// whether the level word is present from the **argument count parity**
+    /// (`Tcl_UpvarObjCmd` tests `objc`), so an odd count means the first word
+    /// is the level. tclsh 9.0.4 / 8.6.14, identical: `upvar 1 b` has an even
+    /// count and therefore aliases the caller variable literally named `1`,
+    /// while `upvar $lvl a b` really does take `$lvl` as its level.
+    ///
+    /// **`otherVar`** normally names a variable in *another frame*, which has
+    /// no namespace path to link to — a bare `x` at level 1 is whatever local
+    /// the caller happens to have. Two spellings escape that and name one
+    /// fixed cell whatever the call depth, so both get a link target
+    /// (issue #923 audit idx 98, where `upvar ::tk::FocusGrab($index) data`
+    /// left the array completely unregistered):
+    ///
+    /// * a **fully-qualified** target — `upvar 1 ::myns::q g` binds
+    ///   `::myns::q` from any depth (tclsh 9.0.4 / 8.6.14: reached
+    ///   identically through `upvar 1` and `upvar 2`);
+    /// * any target at **`#0`** — the global frame, so `upvar #0 counter c`
+    ///   binds `::counter` however deep the call stack is.
+    ///
+    /// An array element (`::tk::FocusGrab($index)`) links to its **base**:
+    /// the element key is runtime data, but the array it lives in is the
+    /// named cell every sibling access shares.
     ///
     /// Dispatched via [`tcl_registry::hooks::AnalyserHookId::Upvar`].
     pub fn handle_upvar_command(
@@ -3700,19 +3721,53 @@ impl Analyser {
         arg_tokens: &[Token],
         scope_path: &[usize],
     ) {
+        use tcl_registry::frame_effect::FrameLevel;
+
         if args.is_empty() || arg_tokens.is_empty() {
             return;
         }
         let pair_start = usize::from(args.len() % 2 == 1);
+        let level = if pair_start == 1 {
+            FrameLevel::parse(&args[0]).unwrap_or(FrameLevel::Dynamic)
+        } else {
+            FrameLevel::DEFAULT
+        };
         let mut i = pair_start + 1;
         while i < args.len() && i < arg_tokens.len() {
             // The local alias name may be dynamic (`upvar 1 x $local`) — skip
             // it rather than record the substitution text.
             if !crate::naming::is_dynamic_word(&args[i]) {
                 self.define_var(&args[i], arg_tokens[i], scope_path, false, None);
+                if let Some(target) = Self::upvar_link_target(&args[i - 1], level) {
+                    self.set_var_link_target(&args[i], scope_path, target);
+                }
             }
             i += 2;
         }
+    }
+
+    /// The fixed cell an `upvar` `otherVar` word names, or `None` when it
+    /// names a frame-relative variable with no stable path.
+    ///
+    /// See [`Self::handle_upvar_command`] for the two qualifying spellings
+    /// and their oracle transcripts.
+    fn upvar_link_target(
+        other: &str,
+        level: tcl_registry::frame_effect::FrameLevel,
+    ) -> Option<String> {
+        // `a($k)` names the array `a`; the element key is runtime data, so
+        // the base is tested for dynamism, not the whole word.
+        let base = other.split_once('(').map_or(other, |(base, _)| base);
+        if base.is_empty() || crate::naming::is_dynamic_word(base) {
+            return None;
+        }
+        if base.starts_with("::") {
+            return Some(base.to_owned());
+        }
+        if level.is_global_frame() {
+            return Some(format!("::{base}"));
+        }
+        None
     }
 
     /// Register the local aliases introduced by `namespace upvar`.
@@ -5963,6 +6018,94 @@ mod tests {
         let mut a = Analyser::new();
         a.handle_variable_command(&["x".to_string()], &[esc_tok(span(0, 1))], &[]);
         assert!(a.result.global_scope.variables.contains_key("x"));
+    }
+
+    // handle_upvar_command — the `otherVar` link (issue #923 audit idx 98)
+
+    /// Run `upvar <args>` through the handler and report the alias's link
+    /// target, if it got one.
+    fn upvar_link_of(args: &[&str], local: &str) -> Option<String> {
+        let mut a = Analyser::new();
+        let owned: Vec<String> = args.iter().map(|s| (*s).to_string()).collect();
+        let toks: Vec<Token> = (0..owned.len())
+            .map(|i| {
+                esc_tok(span(
+                    u32::try_from(i).unwrap() * 4,
+                    u32::try_from(i).unwrap() * 4 + 1,
+                ))
+            })
+            .collect();
+        a.handle_upvar_command(&owned, &toks, &[]);
+        a.result
+            .global_scope
+            .variables
+            .get(local)
+            .and_then(|v| v.link_target.clone())
+    }
+
+    #[test]
+    fn upvar_links_a_fully_qualified_other_var_at_any_level() {
+        // `upvar 1 ::myns::q g` binds `::myns::q` from any call depth
+        // (tclsh 9.0.4 / 8.6.14: reached identically through `upvar 1` and
+        // `upvar 2`), so the alias has a stable cell to link to.
+        assert_eq!(
+            upvar_link_of(&["1", "::myns::q", "g"], "g"),
+            Some("::myns::q".to_string()),
+        );
+        assert_eq!(
+            upvar_link_of(&["2", "::myns::q", "g"], "g"),
+            Some("::myns::q".to_string()),
+        );
+    }
+
+    #[test]
+    fn upvar_links_an_array_other_var_to_its_base() {
+        // tk.tcl:177 `upvar ::tk::FocusGrab($index) data` — the element key
+        // is runtime data, the array is the named cell every sibling access
+        // shares.
+        assert_eq!(
+            upvar_link_of(&["::tk::FocusGrab($index)", "data"], "data"),
+            Some("::tk::FocusGrab".to_string()),
+        );
+    }
+
+    #[test]
+    fn upvar_at_level_hash_zero_links_to_the_global_cell() {
+        // tclsh 9.0.4 / 8.6.14: `upvar #0 counter c` reaches `::counter`
+        // however deep the stack is.
+        assert_eq!(
+            upvar_link_of(&["#0", "counter", "c"], "c"),
+            Some("::counter".to_string()),
+        );
+    }
+
+    #[test]
+    fn upvar_does_not_link_a_frame_relative_other_var() {
+        // TN — `upvar 1 x y` names whatever local the *caller* happens to
+        // have; there is no namespace path for it, so inventing one would
+        // unify unrelated cells.
+        assert_eq!(upvar_link_of(&["1", "x", "y"], "y"), None);
+        assert_eq!(upvar_link_of(&["x", "y"], "y"), None);
+        // A computed target has no readable name at all.
+        assert_eq!(upvar_link_of(&["1", "$name", "obj"], "obj"), None);
+        // A computed *level* could be `#0`, but could equally be `1` — the
+        // alias must not be linked on a guess.
+        assert_eq!(upvar_link_of(&["$lvl", "counter", "c"], "c"), None);
+    }
+
+    #[test]
+    fn upvar_level_word_presence_follows_argument_count_parity() {
+        // `upvar 1 b` is TWO words, so there is no level word and `1` is the
+        // caller-side variable name — the alias is `b` (tclsh 9.0.4 /
+        // 8.6.14: with `set 1 ONE` in the caller, the callee reads `ONE`).
+        let mut a = Analyser::new();
+        a.handle_upvar_command(
+            &["1".to_string(), "b".to_string()],
+            &[esc_tok(span(0, 1)), esc_tok(span(2, 3))],
+            &[],
+        );
+        assert!(a.result.global_scope.variables.contains_key("b"));
+        assert!(!a.result.global_scope.variables.contains_key("1"));
     }
 
     // handle_proc_command

--- a/rust/tcl-compiler/src/analyser/param_traits.rs
+++ b/rust/tcl-compiler/src/analyser/param_traits.rs
@@ -937,11 +937,15 @@ fn handle_upvar<'p>(
     traits: &mut HashMap<&'p str, HashSet<ProcArgTrait>>,
     aliases: &mut Aliases<'p>,
 ) {
-    // `upvar ?level? otherVar myVar ?otherVar myVar ...?` — an optional leading
-    // level word (`1`, `#0`) shifts the first pair.
-    let has_level = args
-        .first()
-        .is_some_and(|h| h.chars().all(|c| c.is_ascii_digit()) || h.starts_with('#'));
+    // `upvar ?level? otherVar myVar ?otherVar myVar ...?` — C Tcl decides
+    // whether the level word is present from the **argument count parity**
+    // (`Tcl_UpvarObjCmd` tests `objc`), not from the word's text.  Sniffing
+    // the text instead dropped the commonest by-reference idiom of all:
+    // `upvar $lvl a b` has three words, so `$lvl` *is* the level and `(a, b)`
+    // is the pair, but a digits-or-`#` test sees no level and pairs
+    // `($lvl, a)` — losing the `a`/`b` binding entirely.  tclsh 9.0.4 /
+    // 8.6.14 agree; see `tcl_registry::frame_effect::FrameLevelWord`.
+    let has_level = args.len() % 2 == 1;
     let pairs = args.get(usize::from(has_level)..).unwrap_or(&[]);
     record_upvar_pairs(pairs, param_set, traits, aliases);
 }

--- a/rust/tcl-compiler/src/cfg.rs
+++ b/rust/tcl-compiler/src/cfg.rs
@@ -214,6 +214,18 @@ pub struct Function {
     /// body still gets the body frame the uncompiled command would add to
     /// `errorInfo` (the LSP keeps its inlined view). Empty when none were folded.
     pub inline_eval_spans: Vec<tcl_lexer::Span>,
+    /// Caller-frame injection this function is *subject to*: a callee whose
+    /// [frame-effect summary](crate::cfg_builder::upvar_info::UpvarInfo)
+    /// says it writes or reads names in **this** frame that no static
+    /// analysis can enumerate (`helper $x` where `helper` runs
+    /// `uplevel 1 $body`, or `argparse`'s definition-list injection).
+    ///
+    /// Recorded here, on the CFG, because it is the CFG builder — the one
+    /// stage holding the module-wide proc summaries — that can see it, while
+    /// the consumers ([`crate::dynamic_names::dynamic_name_barrier`] and
+    /// everything downstream of it) run per function with only the CFG in
+    /// hand.  Cleared for any CFG built without an upvar context.
+    pub caller_frame_barrier: crate::dynamic_names::DynamicNameBarrier,
     /// Block-name interner: names indexed by [`BlockId`]`.0`, in creation order.
     block_names: Vec<String>,
     /// Reverse interner index: block name → its [`BlockId`].
@@ -231,6 +243,7 @@ impl Function {
             loop_nodes: HashMap::new(),
             exception_edges: Vec::new(),
             inline_eval_spans: Vec::new(),
+            caller_frame_barrier: crate::dynamic_names::DynamicNameBarrier::default(),
             block_names: Vec::new(),
             name_to_id: FxHashMap::default(),
         };

--- a/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/global_write_info.rs
@@ -159,16 +159,12 @@ pub fn detect_global_write_procs(module: &Module) -> HashMap<String, GlobalWrite
     own
 }
 
-/// Both the short and fully-qualified forms of `qname`, matching
-/// [`super::detect_upvar_procs`]'s registration convention.
+/// Every call-site spelling of `qname`, from the one helper
+/// [`super::detect_upvar_procs`] and [`super::prepare_cfg_context`] also
+/// use — the three maps are looked up by the same key at the same call
+/// site, so they must agree on what keys exist.
 fn registered_keys(qname: &str) -> Vec<String> {
-    let mut keys = vec![qname.to_owned()];
-    if let Some((_, short)) = qname.rsplit_once("::")
-        && !short.is_empty()
-    {
-        keys.push(short.to_owned());
-    }
-    keys
+    super::qualified_lookup_keys(qname)
 }
 
 /// Pass 1: union every `global` / `variable` declaration in `body` into one

--- a/rust/tcl-compiler/src/cfg_builder/mod.rs
+++ b/rust/tcl-compiler/src/cfg_builder/mod.rs
@@ -173,6 +173,13 @@ pub(crate) struct CfgBuilder {
     /// function currently being built — drained into [`crate::cfg::Function`] so
     /// codegen can re-derive each body's `errorInfo` frame (see that field).
     inline_eval_spans: Vec<tcl_lexer::Span>,
+    /// Caller-frame injection the function currently being built is subject
+    /// to: the union of every called procedure's
+    /// [`UpvarInfo::caller_frame_barrier`].  Drained into
+    /// [`crate::cfg::Function::caller_frame_barrier`], which
+    /// [`crate::dynamic_names::dynamic_name_barrier`] folds into the
+    /// function's blindness lattice.
+    caller_frame_barrier: crate::dynamic_names::DynamicNameBarrier,
     /// Current `lower_script` recursion depth, bounded by [`MAX_LOWER_DEPTH`]
     /// so deeply-nested bodies cannot overflow the stack.
     depth: u32,
@@ -223,6 +230,7 @@ impl CfgBuilder {
             throw_blocks: None,
             last_terminal_block: None,
             inline_eval_spans: Vec::new(),
+            caller_frame_barrier: crate::dynamic_names::DynamicNameBarrier::default(),
             depth: 0,
         }
     }
@@ -258,7 +266,34 @@ impl CfgBuilder {
     /// `upvar #0`, see [`global_write_info`]) — a global name doesn't
     /// depend on call-site arguments, so no params-based mapping is
     /// needed, just the literal name list.
-    fn apply_upvar_invalidation(&self, mut stmt: Statement) -> Vec<Statement> {
+    fn apply_upvar_invalidation(&mut self, stmt: Statement) -> Vec<Statement> {
+        self.record_caller_frame_barrier(&stmt);
+        self.upvar_invalidated(stmt)
+    }
+
+    /// Whole-frame blindness the statement's calls impose on *this*
+    /// function, as distinct from the per-name `defs` widening
+    /// [`Self::upvar_invalidated`] applies.
+    ///
+    /// A callee that runs `uplevel 1 $body` — or aliases a caller-frame name
+    /// it cannot place — reaches names no `defs` list can enumerate.
+    /// Recorded flow-insensitively on the function, in the same lattice and
+    /// the same abstention direction as the dynamic-name barrier
+    /// ([`crate::dynamic_names`]).
+    fn record_caller_frame_barrier(&mut self, stmt: &Statement) {
+        for command in Self::called_command_names(stmt) {
+            if let Some(info) = self.upvar_procs.get(command.as_str()) {
+                self.caller_frame_barrier =
+                    self.caller_frame_barrier.union(info.caller_frame_barrier());
+            }
+        }
+    }
+
+    /// The `defs`-widening half of [`Self::apply_upvar_invalidation`], with
+    /// no side effect on the function-level barrier — so a speculative query
+    /// ([`Self::init_written_names`]) can ask what a statement writes without
+    /// recording the statement twice.
+    fn upvar_invalidated(&self, mut stmt: Statement) -> Vec<Statement> {
         // 0. A callee whose `upvar` caller-side name is unresolvable
         //    (`upvar 1 $computed x`) can write ANY caller variable — no
         //    per-name def list is sound, so widen the call site with an
@@ -384,6 +419,57 @@ impl CfgBuilder {
         }
 
         vec![stmt]
+    }
+
+    /// Every command word a statement invokes: its own head, plus the head
+    /// of every `[…]` substitution nested in its arguments (or, for an
+    /// assignment, in its value).
+    ///
+    /// The caller-frame barrier is a *whole-function* fact, so it has to be
+    /// raised wherever a call appears — `helper $x`, `set y [helper $x]`,
+    /// and `if {[helper $x]} …` alike. Bounded by
+    /// [`MAX_EMBEDDED_SUBST_DEPTH`], like every other bracket descent here.
+    fn called_command_names(stmt: &Statement) -> Vec<String> {
+        let mut out: Vec<String> = Vec::new();
+        let mut texts: Vec<&str> = Vec::new();
+        match stmt {
+            Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. } => {
+                out.push(command.clone());
+                texts.extend(args.iter().map(String::as_str));
+            }
+            Statement::AssignValue { value, .. } | Statement::AssignConst { value, .. } => {
+                texts.push(value.as_str());
+            }
+            _ => {}
+        }
+        for text in texts {
+            Self::command_heads_in_text(text, 0, &mut out);
+        }
+        out
+    }
+
+    /// Accumulate the head word of every `[…]` substitution in *text*,
+    /// descending into nested brackets.
+    fn command_heads_in_text(text: &str, depth: u32, out: &mut Vec<String>) {
+        use tcl_lexer::{Lexer, SourceMap, TokenType};
+
+        if !text.contains('[') || depth >= MAX_EMBEDDED_SUBST_DEPTH {
+            return;
+        }
+        let sm = SourceMap::new(text);
+        let Ok(tokens) = Lexer::new(text).tokenise_all() else {
+            return;
+        };
+        for tok in &tokens {
+            if tok.kind != TokenType::Cmd {
+                continue;
+            }
+            let inner = sm.token_text(*tok);
+            if let Some(head) = words_from_text(inner).first() {
+                out.push(head.clone());
+            }
+            Self::command_heads_in_text(inner, depth + 1, out);
+        }
     }
 
     /// Scan *text* for `[command_substitution]` tokens and
@@ -777,6 +863,7 @@ impl CfgBuilder {
             .map(|(from, to)| (self.bid(&from), self.bid(&to)))
             .collect();
         func.inline_eval_spans = std::mem::take(&mut self.inline_eval_spans);
+        func.caller_frame_barrier = self.caller_frame_barrier;
         func
     }
 
@@ -1256,11 +1343,46 @@ impl CfgBuilder {
 
 // Public API
 
-/// Scan a module for procedures whose bodies contain `upvar`
-/// declarations, returning a map from command name to
-/// [`UpvarInfo`].  Both the fully qualified name (`::ns::foo`) and
-/// the short name (`foo`) are registered so call sites using either
-/// spelling resolve to the same info.
+/// Every spelling a call site may use for the procedure named `qname`.
+///
+/// A qualified definition is reachable by its absolute name, by its bare
+/// tail, **and** by any `::`-boundary suffix in between: written from
+/// `::other`, the word `demo::setdef` resolves relative to the current
+/// namespace first and then falls back to `::demo::setdef`, so that
+/// spelling has to key the same summary (issue #923 audit idx 59, where the
+/// relative-qualified spelling silently missed the caller-frame defs while
+/// the bare and absolute spellings both worked).
+///
+/// Registering a suffix is the same over-approximation the bare tail
+/// already was: a same-named proc in a different namespace can claim the
+/// key. The consequence is a *widened* `defs` list at a call site, which
+/// only ever silences a warning.
+#[must_use]
+pub fn qualified_lookup_keys(qname: &str) -> Vec<String> {
+    let mut keys = vec![qname.to_owned()];
+    let mut push = |key: &str| {
+        if !key.is_empty() && !keys.iter().any(|k| k == key) {
+            keys.push(key.to_owned());
+        }
+    };
+    // `::demo::setdef` → `demo::setdef` → `setdef`: drop one leading
+    // namespace segment at a time, so every relative spelling of the same
+    // definition keys the same summary.
+    let mut rest = qname.trim_start_matches("::");
+    push(rest);
+    while let Some((_, tail)) = rest.split_once("::") {
+        let tail = tail.trim_start_matches("::");
+        push(tail);
+        rest = tail;
+    }
+    keys
+}
+
+/// Scan a module for procedures with a caller-frame effect
+/// (`upvar` / `uplevel`), returning a map from command name to its
+/// [frame-effect summary][UpvarInfo].  Every spelling a call site may use
+/// ([`qualified_lookup_keys`]) is registered so the lookup does not depend
+/// on how the caller happened to write the name.
 #[must_use]
 pub fn detect_upvar_procs(module: &Module) -> HashMap<String, UpvarInfo> {
     let mut result: HashMap<String, UpvarInfo> = HashMap::new();
@@ -1273,15 +1395,58 @@ pub fn detect_upvar_procs(module: &Module) -> HashMap<String, UpvarInfo> {
     // by luck of the process start (issue #1035 follow-up).
     let mut entries: Vec<(&String, &crate::ir::Procedure)> = module.procedures.iter().collect();
     entries.sort_by(|a, b| a.0.cmp(b.0));
+    let mut own: Vec<(&String, &crate::ir::Procedure, UpvarInfo)> = Vec::new();
     for (qname, proc) in entries {
-        let info = collect_upvar_targets(&proc.body, &proc.params);
+        own.push((qname, proc, collect_upvar_targets(&proc.body, &proc.params)));
+    }
+
+    // One hop, no fixpoint: `uplevel <caller frame> [list callee …]` puts
+    // the callee's own caller-frame effects into *this* proc's caller
+    // (issue #1019). Composing against the *own-body* summaries — not the
+    // composed ones — bounds the walk at a single level by construction, so
+    // a recursive or mutually-recursive forward cannot diverge. A two-hop
+    // chain is left to the opaque-widening path, which is the safe
+    // direction.
+    // `own` is already qualified-name-sorted, so a short key shared by two
+    // procedures resolves to the same one every run.
+    let mut by_name: HashMap<String, (&UpvarInfo, &[String])> = HashMap::new();
+    for (qname, proc, info) in &own {
+        for key in qualified_lookup_keys(qname) {
+            by_name.insert(key, (info, proc.params.as_slice()));
+        }
+    }
+    let mut composed: Vec<(&String, UpvarInfo)> = Vec::new();
+    for (qname, proc, own_info) in &own {
+        let mut info = own_info.clone();
+        for (callee, constructed) in &own_info.uplevel_forwarded_calls {
+            if let Some((callee_info, callee_params)) = by_name.get(callee.as_str()) {
+                upvar_info::compose_forwarded(
+                    callee_info,
+                    callee_params,
+                    constructed,
+                    &proc.params,
+                    &mut info,
+                );
+            } else {
+                // The forwarded command is not a procedure this unit can
+                // see (a cross-file helper, a runtime-installed command).
+                // It still runs in the caller's frame, so widen.
+                info.caller_frame_opaque_writes = true;
+                info.caller_frame_opaque_reads = true;
+            }
+        }
+        composed.push((qname, info));
+    }
+
+    for (qname, info) in composed {
         if info.is_empty() {
             continue;
         }
-        if let Some((_, short)) = qname.rsplit_once("::")
-            && !short.is_empty()
-        {
-            result.insert(short.to_owned(), info.clone());
+        for key in qualified_lookup_keys(qname) {
+            if key == *qname {
+                continue;
+            }
+            result.insert(key, info.clone());
         }
         result.insert(qname.clone(), info);
     }
@@ -1318,12 +1483,9 @@ pub fn prepare_cfg_context(module: &Module) -> CfgContext {
     let mut entries: Vec<(&String, &crate::ir::Procedure)> = module.procedures.iter().collect();
     entries.sort_by(|a, b| a.0.cmp(b.0));
     for (qname, proc) in entries {
-        if let Some((_, short)) = qname.rsplit_once("::")
-            && !short.is_empty()
-        {
-            proc_params.insert(short.to_owned(), proc.params.clone());
+        for key in qualified_lookup_keys(qname) {
+            proc_params.insert(key, proc.params.clone());
         }
-        proc_params.insert(qname.clone(), proc.params.clone());
     }
     (upvar_procs, proc_params, global_write_procs)
 }
@@ -1924,7 +2086,7 @@ impl CfgBuilder {
             // characterised here — clear every constant binding to stay sound.
             _ => return None,
         };
-        for s in self.apply_upvar_invalidation(stmt.clone()) {
+        for s in self.upvar_invalidated(stmt.clone()) {
             // A widening barrier means the callee can write ANY caller
             // variable (an `upvar` with a dynamic caller-side name) — no
             // per-name set exists, so report "can't tell" and let the
@@ -2021,7 +2183,7 @@ fn is_catchable_throw(command: &str) -> bool {
 /// [`crate::naming::normalise_var_name`].
 ///
 /// Returns an empty list when the text fails to lex.
-fn words_from_text(text: &str) -> Vec<String> {
+pub(super) fn words_from_text(text: &str) -> Vec<String> {
     use tcl_lexer::{Lexer, SourceMap, TokenType};
 
     let sm = SourceMap::new(text);

--- a/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
+++ b/rust/tcl-compiler/src/cfg_builder/upvar_info.rs
@@ -16,17 +16,24 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! Per-proc `upvar` declaration summary.
+//! Per-proc **frame-effect summary** — which names a procedure injects into
+//! the frame of whoever calls it.
 //!
-//! The proc-summary
-//! integration point pre-populates caller-side `defs` from
-//! [`UpvarInfo::literal_targets`] / [`UpvarInfo::param_targets`] /
-//! [`UpvarInfo::args_tail_upvar`] so callers see the local-side names
-//! the callee is going to write at runtime.
+//! Tcl procedures routinely write their caller's variables: `upvar` aliases
+//! a caller-frame name into a local, and `uplevel` runs a whole script up
+//! there.  Neither shows up in the caller's own text, so single-function
+//! dataflow sees a read of a variable nothing ever assigned.  This module
+//! computes, once per procedure, *what a call to it does to the caller's
+//! frame*; [`super::CfgBuilder::apply_upvar_invalidation`] then consults it
+//! at every call site — a hash lookup plus work proportional to the bound
+//! arguments, with no fixpoint.
 //!
-//! ## Three shapes
+//! The type is still named [`UpvarInfo`] because the salsa interning layer
+//! (`tcl-lsp-db`) stores it by that path; it covers `uplevel` as well.
 //!
-//! `upvar` declarations come in three classifiable shapes:
+//! ## What the summary records
+//!
+//! **Named caller-frame bindings** — `upvar`, resolvable to a name:
 //!
 //! * **`literal_targets`** — `upvar 1 caller_name local_name`: the source
 //!   name is a literal (no `$` substitution), so we know exactly which
@@ -38,8 +45,59 @@
 //! * **`args_tail_upvar`** — `upvar 1 args local_name`: the source is the
 //!   proc's `args` parameter (the trailing-vararg slot).  Each
 //!   call-site arg in the tail position is substituted into the alias.
+//!
+//! **Named caller-frame writes without an alias** — `uplevel`, whose script
+//! runs in the caller's frame rather than binding a local:
+//!
+//! * **`uplevel_literal_writes`** — `uplevel 1 {set n …}` (a brace-literal
+//!   body the lowering already turned into [`Statement::UpFrame`]) and
+//!   `uplevel 1 [list set n …]`.
+//! * **`uplevel_param_writes`** — `uplevel 1 [list set $param …]`: the
+//!   written name is the value of `<param>`, resolved at the call site
+//!   exactly like `param_targets`.
+//! * **`uplevel_forwarded_calls`** — `uplevel 1 [list worker $p]`: the
+//!   constructed script *calls* another proc, so that proc's own `upvar 1`
+//!   reaches one frame further out than a plain call would — into **this**
+//!   proc's caller ([issue #1019][]).  Resolved one hop, in
+//!   [`super::detect_upvar_procs`], where the module-wide map exists.
+//!
+//! **Opaque caller-frame effects** — the effect is real but the names are
+//! not knowable:
+//!
+//! * **`has_unresolvable_caller_target`** — `upvar 1 $computed x`.
+//! * **`caller_frame_opaque_writes` / `caller_frame_opaque_reads`** —
+//!   `uplevel 1 $body`: arbitrary code in the caller's frame.
+//!
+//! ## Frame targeting is not decoration
+//!
+//! Only a **`Relative(1)`** level (or an omitted one) touches the direct
+//! caller.  Everything else is a different frame and must not be reported
+//! as a caller-frame binding — pinned on tclsh 9.0.4 and 8.6.14, identical:
+//!
+//! | written in the callee | frame written | in this summary |
+//! |---|---|---|
+//! | `upvar 1 x y` / `upvar x y` | the caller | named binding |
+//! | `upvar #0 g l` | the global frame | nothing — [`super::global_write_info`] owns it |
+//! | `upvar 0 x y` | the callee's **own** frame | nothing |
+//! | `upvar 2 far f` | the caller's caller | widen (see below) |
+//! | `upvar $lvl a b` | unknown | widen |
+//! | `uplevel 1 $body` | the caller | opaque write **and** read |
+//! | `eval $body` | the callee's own frame | nothing — [`crate::dynamic_names`] owns it |
+//!
+//! A level the summary cannot place at the direct caller is widened to an
+//! opaque caller-frame write rather than dropped.  Dropping it would leave
+//! a real `upvar 2` write invisible to the grandparent frame that receives
+//! it, producing a false `W210`; widening only ever silences one. That is
+//! the [documented abstention direction][soundness] for every consumer of
+//! this summary.
+//!
+//! [issue #1019]: https://github.com/bitwisecook/tcl-lsp/issues/1019
+//! [soundness]: crate::dynamic_names
 
-use std::collections::BTreeMap;
+use std::collections::{BTreeMap, BTreeSet};
+
+use tcl_registry::frame_effect::{FrameArgLayout, FrameEffectSpec, FrameLevel};
+use tcl_registry::{ArgRole, CommandRegistry};
 
 use crate::ir::{Script, Statement};
 
@@ -73,6 +131,33 @@ pub struct UpvarInfo {
     /// [`Self::caller_side_defs`] under-approximates and the call site must
     /// widen to an opaque caller-frame clobber instead of trusting it.
     pub has_unresolvable_caller_target: bool,
+    /// Literal caller-frame names the proc writes through an `uplevel`
+    /// script that runs in the caller's frame — `uplevel 1 {set n 1}` and
+    /// `uplevel 1 [list set n 1]`.  Unlike `upvar`, no local alias is
+    /// created, so these have no key to hang off.
+    pub uplevel_literal_writes: BTreeSet<String>,
+    /// Parameter names whose **value** names a caller-frame variable the
+    /// proc writes through an `uplevel` script — `uplevel 1 [list set
+    /// $varName …]`.  Resolved at the call site against the actual argument
+    /// passed for that parameter, exactly like [`Self::param_targets`].
+    pub uplevel_param_writes: BTreeSet<String>,
+    /// `uplevel <caller frame> [list CMD ARG…]` sites whose `CMD` is not a
+    /// registry command — a candidate user proc whose own caller-frame
+    /// effects land in *this* proc's caller.  Stored unresolved because a
+    /// per-proc walk cannot see the module; [`super::detect_upvar_procs`]
+    /// resolves each entry one hop against the completed map.
+    ///
+    /// Each entry is `(command, constructed argument words)`.
+    pub uplevel_forwarded_calls: Vec<(String, Vec<String>)>,
+    /// The proc runs a script it cannot read in its caller's frame
+    /// (`uplevel 1 $body`), or aliases a caller-frame name it cannot place
+    /// (`upvar 2 …`, `upvar $lvl …`).  **Any** caller-frame name may be
+    /// created or overwritten, so a call site must widen instead of
+    /// enumerating.
+    pub caller_frame_opaque_writes: bool,
+    /// The same script may **read** any caller-frame name, so no store in
+    /// the caller can be proved dead across the call.
+    pub caller_frame_opaque_reads: bool,
 }
 
 impl UpvarInfo {
@@ -84,10 +169,33 @@ impl UpvarInfo {
         self.literal_targets.is_empty()
             && self.param_targets.is_empty()
             && self.args_tail_upvar.is_empty()
+            && self.uplevel_literal_writes.is_empty()
+            && self.uplevel_param_writes.is_empty()
+            && self.uplevel_forwarded_calls.is_empty()
             // A flag-only summary still matters: an unresolvable caller
             // target means call sites must widen, so the info must not be
             // dropped by `detect_upvar_procs`'s emptiness filter.
             && !self.has_unresolvable_caller_target
+            && !self.caller_frame_opaque_writes
+            && !self.caller_frame_opaque_reads
+    }
+
+    /// The caller-frame barrier a call to this proc imposes on the calling
+    /// function: `writes` when any name in the caller's frame may be
+    /// created or overwritten under a name this analysis cannot enumerate,
+    /// `reads` when any store in the caller may be observed.
+    ///
+    /// `destroys` rides with `reads`: only an arbitrary script
+    /// (`uplevel 1 $body`) can `unset` a caller-frame name, and that is
+    /// exactly the case that sets `reads` too.  An unresolvable `upvar`
+    /// target writes through an alias, which cannot destroy the binding.
+    #[must_use]
+    pub fn caller_frame_barrier(&self) -> crate::dynamic_names::DynamicNameBarrier {
+        crate::dynamic_names::DynamicNameBarrier {
+            writes: self.caller_frame_opaque_writes || self.has_unresolvable_caller_target,
+            destroys: self.caller_frame_opaque_reads,
+            reads: self.caller_frame_opaque_reads,
+        }
     }
 
     /// Resolve the caller-frame name aliased by *local* in this
@@ -143,10 +251,18 @@ impl UpvarInfo {
                 defs.push(name);
             }
         };
-        for caller_lit in self.literal_targets.values() {
+        for caller_lit in self
+            .literal_targets
+            .values()
+            .chain(self.uplevel_literal_writes.iter())
+        {
             push(caller_lit.clone());
         }
-        for param_name in self.param_targets.values() {
+        for param_name in self
+            .param_targets
+            .values()
+            .chain(self.uplevel_param_writes.iter())
+        {
             if let Some(idx) = params.iter().position(|p| p == param_name)
                 && let Some(arg) = call_args.get(idx)
             {
@@ -206,86 +322,117 @@ fn is_var_name(name: &str) -> bool {
             .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == ':')
 }
 
-/// `upvar ?level? src1 dst1 ?src2 dst2 ...?` — return the
-/// `(src, dst)` pairs.  Skips the optional level word (a literal
-/// integer with optional `#` prefix).
-fn upvar_pairs(args: &[String]) -> Vec<(&str, &str)> {
-    if args.is_empty() {
-        return Vec::new();
-    }
-    let head = &args[0];
-    let no_dash = head.trim_start_matches('-');
-    let is_level_literal = (!no_dash.is_empty() && no_dash.chars().all(|c| c.is_ascii_digit()))
-        || (head.starts_with('#') && head[1..].chars().all(|c| c.is_ascii_digit()));
-    let start = usize::from(is_level_literal);
-    let mut pairs = Vec::new();
-    let mut i = start;
-    while i + 1 < args.len() {
-        pairs.push((args[i].as_str(), args[i + 1].as_str()));
-        i += 2;
-    }
-    pairs
+/// Resolve a frame-crossing command's level word and its remaining
+/// arguments through the registry's [`FrameEffectSpec`].
+fn resolve_frame_args(spec: FrameEffectSpec, args: &[String]) -> (FrameLevel, &[String]) {
+    let refs: Vec<&str> = args.iter().map(String::as_str).collect();
+    let taken = spec.level_word_len(&refs);
+    let level = if taken == 0 {
+        FrameLevel::DEFAULT
+    } else {
+        FrameLevel::parse(&args[0]).unwrap_or(FrameLevel::Dynamic)
+    };
+    (level, &args[taken..])
 }
 
-/// Collect upvar targets from a proc body.
+/// Collect the per-proc frame-effect summary from a proc body.
 ///
 /// `params` is the proc's parameter list (used to gate
 /// `param_targets`).  `body` is the lowered IR body.  Walks every
-/// `Statement::Call` and `Statement::Barrier` for `upvar`
-/// invocations, classifies each pair into one of the three buckets,
-/// and accumulates the result in [`UpvarInfo`].
+/// statement for a registry-declared frame-crossing command
+/// ([`FrameEffectSpec`]) and accumulates the result in [`UpvarInfo`].
 #[must_use]
 pub fn collect_upvar_targets(body: &Script, params: &[String]) -> UpvarInfo {
+    // The frame grammar of `upvar` / `uplevel` is core Tcl and identical in
+    // every dialect, so the cached default registry is the right source —
+    // the same reasoning (and the same issue #1035 allocation concern)
+    // `global_write_info::detect_global_write_procs` records for its own
+    // scan, which runs on the same per-keystroke path.
+    let registry = tcl_registry::cache::default_registry();
     let mut info = UpvarInfo::default();
-    walk_script(&body.statements, params, &mut info);
+    walk_script(&body.statements, params, registry, &mut info);
     info
 }
 
-fn walk_script(stmts: &[Statement], params: &[String], info: &mut UpvarInfo) {
+fn walk_script(
+    stmts: &[Statement],
+    params: &[String],
+    registry: &CommandRegistry,
+    info: &mut UpvarInfo,
+) {
     for stmt in stmts {
-        walk_stmt(stmt, params, info);
+        walk_stmt(stmt, params, registry, info);
     }
 }
 
-fn walk_stmt(stmt: &Statement, params: &[String], info: &mut UpvarInfo) {
+fn walk_stmt(
+    stmt: &Statement,
+    params: &[String],
+    registry: &CommandRegistry,
+    info: &mut UpvarInfo,
+) {
     match stmt {
-        Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. }
-            if command == "upvar" =>
-        {
-            record_upvar_call(args, params, info);
+        Statement::Call { command, args, .. } | Statement::Barrier { command, args, .. } => {
+            let Some(spec) = registry.frame_effect(command) else {
+                return;
+            };
+            match spec.layout {
+                FrameArgLayout::AliasPairs => record_upvar_call(spec, args, params, info),
+                FrameArgLayout::ScriptInSelectedFrame => {
+                    record_uplevel_call(spec, args, params, registry, info);
+                }
+                // A script that runs in the *callee's own* frame, and an
+                // opaque injection into whoever called the command, are both
+                // effects on the frame the command is written in — not on
+                // this proc's caller. `crate::dynamic_names` owns them.
+                FrameArgLayout::ScriptInCurrentFrame | FrameArgLayout::OpaqueCallerVars => {}
+            }
+        }
+        // `uplevel <level> {literal body}` — the lowering already proved the
+        // body readable and inlined it here. Its writes land in the frame
+        // `frame_shift`/`absolute` select, so only the caller-frame form
+        // contributes; every other level is a different frame.
+        Statement::UpFrame {
+            frame_shift,
+            absolute,
+            body,
+            ..
+        } => {
+            if !*absolute && *frame_shift == 1 {
+                record_upframe_body(&body.statements, info);
+            }
         }
         Statement::If {
             clauses, else_body, ..
         } => {
             for c in clauses {
-                walk_script(&c.body.statements, params, info);
+                walk_script(&c.body.statements, params, registry, info);
             }
             if let Some(e) = else_body {
-                walk_script(&e.statements, params, info);
+                walk_script(&e.statements, params, registry, info);
             }
         }
         Statement::For {
             init, next, body, ..
         } => {
-            walk_script(&init.statements, params, info);
-            walk_script(&next.statements, params, info);
-            walk_script(&body.statements, params, info);
+            walk_script(&init.statements, params, registry, info);
+            walk_script(&next.statements, params, registry, info);
+            walk_script(&body.statements, params, registry, info);
         }
         Statement::While { body, .. }
         | Statement::Foreach { body, .. }
         | Statement::Catch { body, .. }
-        | Statement::Block { body, .. }
-        | Statement::UpFrame { body, .. } => walk_script(&body.statements, params, info),
+        | Statement::Block { body, .. } => walk_script(&body.statements, params, registry, info),
         Statement::Switch {
             arms, default_body, ..
         } => {
             for arm in arms {
                 if let Some(b) = &arm.body {
-                    walk_script(&b.statements, params, info);
+                    walk_script(&b.statements, params, registry, info);
                 }
             }
             if let Some(b) = default_body {
-                walk_script(&b.statements, params, info);
+                walk_script(&b.statements, params, registry, info);
             }
         }
         Statement::Try {
@@ -294,20 +441,44 @@ fn walk_stmt(stmt: &Statement, params: &[String], info: &mut UpvarInfo) {
             finally_body,
             ..
         } => {
-            walk_script(&body.statements, params, info);
+            walk_script(&body.statements, params, registry, info);
             for h in handlers {
-                walk_script(&h.body.statements, params, info);
+                walk_script(&h.body.statements, params, registry, info);
             }
             if let Some(f) = finally_body {
-                walk_script(&f.statements, params, info);
+                walk_script(&f.statements, params, registry, info);
             }
         }
         _ => {}
     }
 }
 
-fn record_upvar_call(args: &[String], params: &[String], info: &mut UpvarInfo) {
-    for (src, dst) in upvar_pairs(args) {
+/// `upvar ?level? otherVar myVar …` — classify each pair against the frame
+/// the level word selects.
+fn record_upvar_call(
+    spec: FrameEffectSpec,
+    args: &[String],
+    params: &[String],
+    info: &mut UpvarInfo,
+) {
+    let (level, rest) = resolve_frame_args(spec, args);
+    if !level.is_caller_frame() {
+        // A level this summary cannot place at the direct caller. `#0` and
+        // `0` genuinely miss the caller's frame (the global frame is
+        // `global_write_info`'s business, the callee's own frame nobody
+        // else's), so they contribute nothing. Everything else — `upvar 2`,
+        // `upvar #3`, `upvar $lvl` — writes *some* frame further out, and
+        // dropping it would leave that write invisible where it lands, so
+        // widen. See the module doc's frame table.
+        if !level.is_global_frame() && !level.is_current_frame() {
+            info.caller_frame_opaque_writes = true;
+        }
+        return;
+    }
+    let mut i = 0;
+    while i + 1 < rest.len() {
+        let (src, dst) = (rest[i].as_str(), rest[i + 1].as_str());
+        i += 2;
         if !is_literal_name(dst) {
             // Dynamic destination — can't classify.  Caller-side
             // analysis falls back to the dynamic-barrier path.
@@ -337,6 +508,197 @@ fn record_upvar_call(args: &[String], params: &[String], info: &mut UpvarInfo) {
             // Fully dynamic source (`upvar 1 [pick] x`, `upvar 1 a($i) x`,
             // …) — same widening as above.
             info.has_unresolvable_caller_target = true;
+        }
+    }
+}
+
+/// `uplevel ?level? arg …` — the concatenated `arg`s run as a script in the
+/// frame the level selects.
+///
+/// Three body shapes are distinguishable, and only the third is opaque:
+///
+/// * a **brace literal** never reaches here — the lowering turned it into
+///   [`Statement::UpFrame`], handled by [`record_upframe_body`];
+/// * a **constructed list** (`[list set $v 1]`) names its command
+///   statically, so [`record_constructed_body`] can read it;
+/// * anything else (`$body`, `[build]`, `"$a $b"`) is arbitrary code —
+///   widen both directions.
+fn record_uplevel_call(
+    spec: FrameEffectSpec,
+    args: &[String],
+    params: &[String],
+    registry: &CommandRegistry,
+    info: &mut UpvarInfo,
+) {
+    let (level, rest) = resolve_frame_args(spec, args);
+    if !level.is_caller_frame() {
+        // Same reasoning as `record_upvar_call`: `uplevel 0` stays in the
+        // callee's own frame and `uplevel #0` runs in the global one, so
+        // neither touches the caller; any other level does, somewhere this
+        // summary cannot name.
+        if !level.is_global_frame() && !level.is_current_frame() {
+            info.caller_frame_opaque_writes = true;
+            info.caller_frame_opaque_reads = true;
+        }
+        return;
+    }
+    // `uplevel` concat-joins every remaining word into one script (its
+    // `SCRIPT_CONCATENATES_ARGS` trait). A single constructed-list word is
+    // the readable case; a multi-word join is not worth reassembling.
+    if let [single] = rest
+        && record_constructed_body(single, params, registry, info)
+    {
+        return;
+    }
+    info.caller_frame_opaque_writes = true;
+    info.caller_frame_opaque_reads = true;
+}
+
+/// The statements of an inlined `uplevel 1 {literal}` body: every literal
+/// name it assigns is a caller-frame write.
+///
+/// A body statement whose target is *not* a plain literal name means the
+/// body writes somewhere this summary cannot name, so widen — the same
+/// direction the constructed-list path takes.
+fn record_upframe_body(stmts: &[Statement], info: &mut UpvarInfo) {
+    for stmt in stmts {
+        for name in crate::ssa::defs_of(stmt) {
+            if is_literal_name(&name) {
+                info.uplevel_literal_writes.insert(name);
+            } else {
+                info.caller_frame_opaque_writes = true;
+            }
+        }
+    }
+}
+
+/// Read a `[list CMD ARG…]` body word, recording the caller-frame names the
+/// constructed command writes.  Returns `false` when the word is not a
+/// readable constructed list, so the caller can widen.
+///
+/// `[list …]` is recognised through the registry's
+/// [`ReturnElements::ListOfArgs`](tcl_registry::ReturnElements) — the same
+/// fact the concat rules of #1068 read — not by matching the name `list`.
+fn record_constructed_body(
+    word: &str,
+    params: &[String],
+    registry: &CommandRegistry,
+    info: &mut UpvarInfo,
+) -> bool {
+    let Some(inner) = word.strip_prefix('[').and_then(|w| w.strip_suffix(']')) else {
+        return false;
+    };
+    let words = super::words_from_text(inner);
+    let Some((builder, constructed)) = words.split_first() else {
+        return false;
+    };
+    if !registry.get(builder).is_some_and(|spec| {
+        matches!(
+            spec.return_elements,
+            Some(tcl_registry::ReturnElements::ListOfArgs { from: 0 })
+        )
+    }) {
+        return false;
+    }
+    let Some((command, cargs)) = constructed.split_first() else {
+        return false;
+    };
+    if !is_literal_name(command) {
+        return false;
+    }
+    let arg_refs: Vec<&str> = cargs.iter().map(String::as_str).collect();
+    if registry.get(command).is_some() {
+        // A registry command: its own `VarWrite` roles say which words name
+        // the variables it creates, and they name them in whatever frame it
+        // runs in — here, the caller's.
+        let indices = registry.arg_indices_for_role(command, &arg_refs, ArgRole::VarWrite);
+        if indices.is_empty() {
+            // A known command that writes no variable (`uplevel 1 [list
+            // puts hi]`) has no caller-frame effect at all.
+            return true;
+        }
+        for idx in indices {
+            let Some(target) = arg_refs.get(idx) else {
+                continue;
+            };
+            if is_literal_name(target) {
+                info.uplevel_literal_writes.insert((*target).to_string());
+            } else if let Some(param) = is_dollar_param_ref(target)
+                && params.iter().any(|p| p == param)
+            {
+                info.uplevel_param_writes.insert(param.to_string());
+            } else {
+                info.caller_frame_opaque_writes = true;
+            }
+        }
+        return true;
+    }
+    // Not a registry command — a candidate user proc. Its own `upvar 1`
+    // reaches *this* proc's caller, one frame further out than a plain call
+    // would (issue #1019), but only the module-wide pass can resolve it.
+    info.uplevel_forwarded_calls
+        .push((command.clone(), constructed[1..].to_vec()));
+    true
+}
+
+/// Compose a callee's caller-frame effects into `info`, for a
+/// `uplevel <caller frame> [list callee ARG…]` forward.
+///
+/// The callee's `upvar 1` binds a name in *its* caller's frame — which,
+/// because the constructed script runs in `info`'s own caller's frame, is
+/// that same frame.  So each of the callee's caller-frame names becomes one
+/// of `info`'s, translated through the constructed argument list:
+/// a literal argument contributes a literal name, a `$param` argument
+/// contributes a param write, anything else widens.
+///
+/// tclsh 9.0.4 / 8.6.14, identical: with
+/// `proc worker {nvar} {upvar 1 $nvar v; set v WORKED}` and
+/// `proc wrapper {nvar} {uplevel 1 [list worker $nvar]}`, calling
+/// `wrapper target` leaves `target` set in *wrapper's* caller — while the
+/// plain-call spelling `proc wrapper2 {nvar} {worker $nvar}` raises
+/// `can't read "target": no such variable`.
+pub(super) fn compose_forwarded(
+    callee: &UpvarInfo,
+    callee_params: &[String],
+    constructed: &[String],
+    params: &[String],
+    info: &mut UpvarInfo,
+) {
+    if callee.has_unresolvable_caller_target
+        || callee.caller_frame_opaque_writes
+        || !callee.args_tail_upvar.is_empty()
+    {
+        info.caller_frame_opaque_writes = true;
+    }
+    if callee.caller_frame_opaque_reads {
+        info.caller_frame_opaque_reads = true;
+    }
+    for name in callee
+        .literal_targets
+        .values()
+        .chain(callee.uplevel_literal_writes.iter())
+    {
+        info.uplevel_literal_writes.insert(name.clone());
+    }
+    for param_name in callee
+        .param_targets
+        .values()
+        .chain(callee.uplevel_param_writes.iter())
+    {
+        let Some(idx) = callee_params.iter().position(|p| p == param_name) else {
+            continue;
+        };
+        let Some(arg) = constructed.get(idx) else {
+            continue;
+        };
+        if is_literal_name(arg) {
+            info.uplevel_literal_writes.insert(arg.clone());
+        } else if let Some(param) = is_dollar_param_ref(arg)
+            && params.iter().any(|p| p == param)
+        {
+            info.uplevel_param_writes.insert(param.to_string());
+        } else {
+            info.caller_frame_opaque_writes = true;
         }
     }
 }
@@ -436,10 +798,146 @@ mod tests {
     }
 
     #[test]
-    fn level_hash_zero_still_classified() {
+    fn level_hash_zero_is_not_a_caller_frame_binding() {
+        // TN — `upvar #0 g local_g` binds the **global** `g`, not the
+        // caller's, however deep the call stack is (tclsh 9.0.4 / 8.6.14:
+        // `proc deep {} {upvar #0 gvar g; set g DEEP}` called two frames
+        // down sets `::gvar`).  Reporting it as a caller-frame def would
+        // mark an unrelated *local* named `g` defined in every caller.
+        // `global_write_info` owns the real, global effect.
         let body = lower("upvar #0 g local_g");
         let info = collect_upvar_targets(&body, &[]);
-        assert_eq!(info.literal_targets.get("local_g"), Some(&"g".to_string()),);
+        assert!(info.literal_targets.is_empty(), "got {info:?}");
+        assert!(!info.caller_frame_opaque_writes, "got {info:?}");
+    }
+
+    #[test]
+    fn level_zero_is_the_callees_own_frame_and_contributes_nothing() {
+        // TN — `upvar 0 x y` aliases the *callee's own* local `x` (tclsh
+        // 9.0.4 / 8.6.14: `upvar 0 target alias` inside a proc whose caller
+        // has `target` reads `can't read "alias"`), so no caller effect.
+        let body = lower("upvar 0 x y");
+        let info = collect_upvar_targets(&body, &[]);
+        assert!(info.is_empty(), "got {info:?}");
+    }
+
+    #[test]
+    fn level_beyond_the_caller_widens_rather_than_binding() {
+        // `upvar 2 far f` writes the caller's *caller*. Naming `far` as a
+        // caller-frame def would be wrong; dropping it would hide the write
+        // from the frame that does receive it. Widen — the abstain-toward-
+        // silence direction (tclsh 9.0.4 / 8.6.14: `proc gp {} {upvar 2 far
+        // f; set f FAR}` through one intermediate frame sets the
+        // grandparent's `far`).
+        for src in ["upvar 2 far f", "upvar #3 far f", "upvar $lvl a b"] {
+            let body = lower(src);
+            let info = collect_upvar_targets(&body, &["lvl".to_string()]);
+            assert!(
+                info.caller_frame_opaque_writes,
+                "{src} must widen; got {info:?}"
+            );
+            assert!(info.literal_targets.is_empty(), "{src}: got {info:?}");
+        }
+    }
+
+    #[test]
+    fn level_word_presence_follows_argument_count_parity() {
+        // `upvar $lvl a b` — three words, so `$lvl` is the level and
+        // `(a, b)` is the pair. A text-sniffing level test saw no level here
+        // and paired `($lvl, a)`, losing the binding (tclsh 9.0.4 / 8.6.14:
+        // `proc t4 {lvl} {upvar $lvl a b; set b 4}` really does set the
+        // caller's `a`).  The level is dynamic, so the summary widens.
+        let body = lower("upvar $lvl a b");
+        let info = collect_upvar_targets(&body, &["lvl".to_string()]);
+        assert!(info.caller_frame_opaque_writes, "got {info:?}");
+
+        // `upvar 1 b` — two words, so there is NO level word and `1` is the
+        // caller-side *variable name* (tclsh 9.0.4 / 8.6.14: with `set 1
+        // ONE` in the caller, the callee reads `ONE` through the alias).
+        let body = lower("upvar 1 b");
+        let info = collect_upvar_targets(&body, &[]);
+        assert_eq!(info.literal_targets.get("b"), Some(&"1".to_string()));
+
+        // `upvar 1 a b c` — four words, so no level: two pairs, `(1, a)` and
+        // `(b, c)` (tclsh 9.0.4 / 8.6.14 accept it without error).
+        let body = lower("upvar 1 a b c");
+        let info = collect_upvar_targets(&body, &[]);
+        assert_eq!(info.literal_targets.get("a"), Some(&"1".to_string()));
+        assert_eq!(info.literal_targets.get("c"), Some(&"b".to_string()));
+    }
+
+    #[test]
+    fn uplevel_literal_body_records_caller_frame_writes() {
+        // `uplevel 1 {set litVar hello}` — the lowering inlines the literal
+        // body as `Statement::UpFrame`; its writes land in the caller.
+        let body = lower("uplevel 1 {set litVar hello}");
+        let info = collect_upvar_targets(&body, &[]);
+        assert!(
+            info.uplevel_literal_writes.contains("litVar"),
+            "got {info:?}"
+        );
+        assert!(!info.caller_frame_opaque_writes, "got {info:?}");
+    }
+
+    #[test]
+    fn uplevel_constructed_list_resolves_the_written_name() {
+        // `uplevel 1 [list set $varName …]` — the constructed script names
+        // its command statically, and `set`'s own `VarWrite` role says which
+        // word is the target (tclsh 9.0.4 / 8.6.14: the caller's variable is
+        // genuinely created).
+        let body = lower("uplevel 1 [list set $varName 1]");
+        let info = collect_upvar_targets(&body, &["varName".to_string()]);
+        assert!(
+            info.uplevel_param_writes.contains("varName"),
+            "got {info:?}"
+        );
+        assert!(!info.caller_frame_opaque_writes, "got {info:?}");
+
+        // A literal target needs no call-site resolution.
+        let body = lower("uplevel 1 [list set fixed 1]");
+        let info = collect_upvar_targets(&body, &[]);
+        assert!(
+            info.uplevel_literal_writes.contains("fixed"),
+            "got {info:?}"
+        );
+
+        // A target that is neither literal nor a parameter (a `foreach`
+        // variable, say) is unknowable — widen.
+        let body = lower("foreach v $vs { uplevel 1 [list set $v 1] }");
+        let info = collect_upvar_targets(&body, &["vs".to_string()]);
+        assert!(info.caller_frame_opaque_writes, "got {info:?}");
+    }
+
+    #[test]
+    fn uplevel_dynamic_body_is_an_opaque_caller_frame_barrier() {
+        let body = lower("uplevel 1 $script");
+        let info = collect_upvar_targets(&body, &["script".to_string()]);
+        assert!(info.caller_frame_opaque_writes, "got {info:?}");
+        assert!(info.caller_frame_opaque_reads, "got {info:?}");
+        let barrier = info.caller_frame_barrier();
+        assert!(barrier.writes && barrier.reads && barrier.destroys);
+    }
+
+    #[test]
+    fn uplevel_at_the_current_or_global_frame_is_not_a_caller_effect() {
+        // TN — `uplevel 0 $s` re-enters the callee's own frame and
+        // `uplevel #0 $s` the global one; neither touches the caller.
+        // `crate::dynamic_names` raises the *callee's* own barrier for both.
+        for src in ["uplevel 0 $s", "uplevel #0 $s"] {
+            let body = lower(src);
+            let info = collect_upvar_targets(&body, &["s".to_string()]);
+            assert!(info.is_empty(), "{src}: got {info:?}");
+        }
+    }
+
+    #[test]
+    fn uplevel_of_a_side_effect_free_command_has_no_caller_effect() {
+        // TN — `uplevel 1 [list puts hi]` writes no variable anywhere, so
+        // the summary must stay clear rather than widening on the mere
+        // presence of an `uplevel`.
+        let body = lower("uplevel 1 [list puts hi]");
+        let info = collect_upvar_targets(&body, &[]);
+        assert!(info.is_empty(), "got {info:?}");
     }
 
     #[test]

--- a/rust/tcl-compiler/src/dynamic_names.rs
+++ b/rust/tcl-compiler/src/dynamic_names.rs
@@ -53,13 +53,50 @@
 //! eliminate (`O101` / `O109` / `O126`).  Both are the same direction — say
 //! less rather than say something wrong.
 //!
-//! # Not covered
+//! # Caller-frame injection (issue #923 audit cluster C1)
 //!
-//! `eval $body` / `uplevel 1 $body` run *arbitrary code*, a strictly larger
-//! blindness than a computed name: they can read, write, and destroy names
-//! this walk never sees a role for.  Those lower to
-//! [`Statement::Barrier`](crate::ir::Statement::Barrier) and are handled (or
-//! not) by the per-consumer barrier rules, not here.
+//! A second, independent way to lose the name space is to have somebody
+//! *else* write it.  Tcl's frame-crossing commands make a callee's writes
+//! land in the caller's frame, and the caller's own text shows nothing:
+//!
+//! ```tcl
+//! proc runner {body} { uplevel 1 $body }   ;# runs $body in the CALLER's frame
+//! proc f {s} { runner $s; puts $x }        ;# $x may well be set — by $s
+//! ```
+//!
+//! Which frame each such command targets is registry data
+//! ([`FrameEffectSpec`]), and the answer decides who goes blind:
+//!
+//! | shape | frame written | recorded by |
+//! |---|---|---|
+//! | `eval $body` | the frame it is written in | this module, directly |
+//! | `argparse {…}` | the frame that *called* it | this module, directly |
+//! | `uplevel 1 $body` in a proc | that proc's caller | the proc's [frame-effect summary][sum], read at each call site |
+//! | `upvar 1 $computed x` | that proc's caller | the same summary |
+//!
+//! The first two are visible in the function's own statements, so the walk
+//! below raises the flags itself.  The last two are visible only with the
+//! module-wide proc summaries, which the CFG builder holds and this
+//! per-function walk does not — so it records them on
+//! [`CfgFunction::caller_frame_barrier`], and
+//! [`dynamic_name_barrier`] folds them in.  Either way the fact lands in
+//! the same three bits, so every consumer's abstention rule is unchanged
+//! and the cost stays `O(1)` per query.
+//!
+//! Deliberately **not** a per-call-site fact: every consumer of this
+//! lattice (`W210` / `W211` / `W220` / `I230`, `O101` / `O109` / `O126`)
+//! already reads it once per function and abstains for the whole function.
+//! A per-site fact would need flow-sensitivity none of them have, and would
+//! buy nothing — the flow-insensitive union is what they would compute.
+//!
+//! `uplevel 1 $body` written *inside* a proc raises nothing for that proc:
+//! the script runs one frame **up**, so the proc's own locals are
+//! untouched. tclsh 9.0.4 / 8.6.14, identical: `proc runner {body} {set
+//! helper 42; uplevel 1 $body}` invoked with `{set x $helper}` raises
+//! `can't read "helper": no such variable`, while the same body under
+//! `eval $body` reads `42`.
+//!
+//! [sum]: crate::cfg_builder::upvar_info::UpvarInfo
 //!
 //! A **computed command head** (`$cmd length foo`, `[pick] $n 1`) is the same
 //! case one level up: the *command* is run-time data, so no argument of it has
@@ -89,6 +126,7 @@
 //!   over-broad fact kills real diagnostics just as surely as a wrong one
 //!   invents false positives.
 
+use tcl_registry::frame_effect::{FrameArgLayout, FrameEffectSpec};
 use tcl_registry::{ArgRole, CommandRegistry, Traits};
 
 use crate::cfg::{Function as CfgFunction, Terminator};
@@ -123,6 +161,26 @@ impl DynamicNameBarrier {
     pub const fn is_clear(self) -> bool {
         !self.writes && !self.destroys && !self.reads
     }
+
+    /// Union with `other` — the lattice join.  Blindness only accumulates,
+    /// so merging two sources of it (this walk and the CFG builder's
+    /// caller-frame record) is a per-flag `or`.
+    #[must_use]
+    pub const fn union(self, other: Self) -> Self {
+        Self {
+            writes: self.writes || other.writes,
+            destroys: self.destroys || other.destroys,
+            reads: self.reads || other.reads,
+        }
+    }
+
+    /// Every direction blinded — an arbitrary script ran in this frame, so
+    /// any name may have been created, read, or destroyed.
+    pub const OPAQUE_SCRIPT: Self = Self {
+        writes: true,
+        destroys: true,
+        reads: true,
+    };
 }
 
 /// Whether *word* — an argument sitting in a registry-declared
@@ -169,7 +227,9 @@ pub fn names_a_dynamic_variable(word: &str) -> bool {
 /// which only ever silences, never invents, a fact.
 #[must_use]
 pub fn dynamic_name_barrier(cfg: &CfgFunction, registry: &CommandRegistry) -> DynamicNameBarrier {
-    let mut barrier = DynamicNameBarrier::default();
+    // Caller-frame injection the CFG builder already resolved against the
+    // module-wide proc summaries — the same three bits, joined in.
+    let mut barrier = cfg.caller_frame_barrier;
     for block in cfg.blocks.values() {
         for stmt in &block.statements {
             scan_statement(stmt, registry, &mut barrier);
@@ -341,6 +401,71 @@ fn template_word_is_substituted(word: &str, braced_literal: bool) -> bool {
     !braced_literal && (word.contains('$') || word.contains('['))
 }
 
+/// Raise the flags a frame-crossing command imposes on the frame it is
+/// *written in*.
+///
+/// Only two of the four layouts do:
+///
+/// * [`FrameArgLayout::ScriptInCurrentFrame`] — `eval $body` runs unreadable
+///   code right here.
+/// * [`FrameArgLayout::OpaqueCallerVars`] — `argparse` creates locals in the
+///   frame that called it, which *is* this one.
+///
+/// [`FrameArgLayout::AliasPairs`] (`upvar`) binds a statically named local,
+/// and [`FrameArgLayout::ScriptInSelectedFrame`] (`uplevel`) runs its script
+/// somewhere else — unless the level word selects this very frame
+/// (`uplevel 0 $body`), or the global frame (`uplevel #0 $body`), whose
+/// names a proc cannot separate from its own bare locals.  Both of those
+/// land here.
+fn scan_frame_effect(
+    frame: FrameEffectSpec,
+    args: &[&str],
+    arg_braced: Option<&[bool]>,
+    barrier: &mut DynamicNameBarrier,
+) {
+    match frame.layout {
+        // Every caller-frame variable `argparse` creates is named from its
+        // definition-list mini-language, which nothing here interprets.
+        FrameArgLayout::OpaqueCallerVars => barrier.writes = true,
+        FrameArgLayout::ScriptInCurrentFrame => {
+            if script_words_are_opaque(args, arg_braced, 0) {
+                *barrier = barrier.union(DynamicNameBarrier::OPAQUE_SCRIPT);
+            }
+        }
+        FrameArgLayout::ScriptInSelectedFrame => {
+            let taken = frame.level_word_len(args);
+            let (level, script) = frame.resolve(args);
+            // A caller-frame or further-up `uplevel` is the callee's effect
+            // on *its* caller, summarised per proc and applied at call
+            // sites; it does not blind the frame it is written in.
+            if !level.is_current_frame() && !level.is_global_frame() {
+                return;
+            }
+            if script_words_are_opaque(script, arg_braced, taken) {
+                *barrier = barrier.union(DynamicNameBarrier::OPAQUE_SCRIPT);
+            }
+        }
+        FrameArgLayout::AliasPairs => {}
+    }
+}
+
+/// Whether a script assembled from `words` is code this analysis cannot
+/// read — i.e. any word substitutes.
+///
+/// A brace-quoted word is source text the ordinary walkers already see (the
+/// lowering inlines it), so a fully literal script is not a barrier.
+/// `offset` is where `words` starts within the original argument list, so
+/// the per-word `braced` flags line up.
+fn script_words_are_opaque(words: &[&str], arg_braced: Option<&[bool]>, offset: usize) -> bool {
+    words.iter().enumerate().any(|(i, w)| {
+        let braced = arg_braced
+            .and_then(|b| b.get(offset + i))
+            .copied()
+            .unwrap_or(false);
+        !braced && (w.contains('$') || w.contains('['))
+    })
+}
+
 /// Apply the registry's name-role answers for one `command args…` call.
 ///
 /// `arg_braced`, when present, says for each argument whether it is a single
@@ -359,6 +484,9 @@ fn scan_command(
         return;
     };
     let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+    if let Some(frame) = spec.frame_effect {
+        scan_frame_effect(frame, &arg_strs, arg_braced, barrier);
+    }
     let destroys = spec.traits.contains(Traits::DESTROYS_VARIABLE);
     // A brace-quoted word is Tcl's literal spelling for a name that contains
     // `$` or `[`: `set {$n} v` creates a variable *called* `$n`, unrelated to

--- a/rust/tcl-compiler/tests/caller_frame_effects.rs
+++ b/rust/tcl-compiler/tests/caller_frame_effects.rs
@@ -1,0 +1,343 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Caller-frame injection — issue #923 differential-audit cluster C1
+//! (idx 7, 22, 38, 57, 59, 98) plus the `eval` / `uplevel` FP class #1076
+//! left documented as out of scope.
+//!
+//! Every case below is a whole-file diagnostic run, so it exercises the real
+//! chain: the per-proc [frame-effect
+//! summary](tcl_compiler::cfg_builder::upvar_info) → the CFG builder's
+//! call-site widening and caller-frame barrier → `W210` / `W211` / `W220`.
+//!
+//! # C Tcl ground truth
+//!
+//! Every claim about which frame a write lands in is pinned on **tclsh
+//! 9.0.4** and **tclsh 8.6.14**, which agree on all of it.  The transcripts
+//! are quoted at each test.  Two facts do most of the work:
+//!
+//! ```text
+//! proc worker  {nvar} {upvar 1 $nvar v; set v WORKED}
+//! proc wrapper {nvar} {uplevel 1 [list worker $nvar]}   ;# forwards one frame
+//! proc wrap2   {nvar} {worker $nvar}                    ;# does NOT forward
+//! proc host  {} {wrapper target;  set target}  ;# → WORKED
+//! proc host2 {} {wrap2   target2; set target2} ;# → can't read "target2"
+//! ```
+//!
+//! # Soundness direction
+//!
+//! Every fix here abstains **toward silence**: where the caller-frame effect
+//! cannot be named, the analysis says nothing rather than guessing.  Each
+//! false-positive test is therefore paired with a true-positive control that
+//! must keep firing, so the suppression cannot be over-applied.
+
+use std::collections::HashSet;
+
+use tcl_compiler::analyser::Analyser;
+
+const D: &str = "tcl8.6";
+
+/// Variable names reported by `code` for `src`.
+fn vars_for(src: &str, code: &str) -> HashSet<String> {
+    Analyser::new()
+        .analyse(src, D)
+        .diagnostics
+        .iter()
+        .filter(|d| d.code.as_str() == code)
+        .filter_map(|d| d.message.split('\'').nth(1).map(str::to_owned))
+        .collect()
+}
+
+fn w210(src: &str) -> HashSet<String> {
+    vars_for(src, "W210")
+}
+
+fn w211(src: &str) -> HashSet<String> {
+    vars_for(src, "W211")
+}
+
+// idx 57 / 59 — a proc that upvar-writes a by-name out-parameter.
+
+/// The ticklecharts `setdef` / `estruct` shape: `upvar 1 $name local` plus a
+/// write through the alias, called with a literal name.
+const OUT_PARAM_HELPER: &str = "\
+namespace eval demo {
+    proc estruct {name value} {
+        upvar 1 $name obj
+        set obj [list struct $name $value]
+    }
+}
+";
+
+#[test]
+fn idx57_out_param_write_is_seen_through_every_call_spelling() {
+    // tclsh 9.0.4 / 8.6.14: `demo::estruct itemLegend1 {a b}` leaves
+    // `itemLegend1` set in the caller — reading it is not read-before-set.
+    // The bare and fully-absolute spellings already worked; the ordinary
+    // relative-qualified one (`demo::estruct`) silently missed, because the
+    // summary was keyed only under `estruct` and `::demo::estruct`
+    // (issue #923 audit idx 59's isolation ladder p1/p2/p3).
+    for call in [
+        "estruct itemLegend1 {a b}",
+        "demo::estruct itemLegend1 {a b}",
+        "::demo::estruct itemLegend1 {a b}",
+    ] {
+        let src = format!(
+            "{OUT_PARAM_HELPER}\nnamespace eval demo {{\n proc user {{}} {{\n {call}\n puts $itemLegend1\n }}\n}}\n"
+        );
+        assert!(
+            !w210(&src).contains("itemLegend1"),
+            "`{call}` writes the caller's itemLegend1; got {:?}",
+            w210(&src),
+        );
+    }
+}
+
+#[test]
+fn idx57_control_an_unrelated_local_still_reports() {
+    // TP control — the suppression is per-name, not a blanket silence: a
+    // local the helper never touches is still read-before-set (tclsh 9.0.4 /
+    // 8.6.14 raise `can't read "neverSet"`).
+    let src = format!(
+        "{OUT_PARAM_HELPER}\nproc user {{}} {{\n estruct itemLegend1 {{a b}}\n puts $neverSet\n}}\n"
+    );
+    assert!(w210(&src).contains("neverSet"), "got {:?}", w210(&src));
+}
+
+#[test]
+fn idx57_control_a_proc_without_an_upvar_does_not_suppress() {
+    // TN control — a same-shaped helper that does *not* upvar writes nothing
+    // in the caller, so the read stays a genuine finding (tclsh 9.0.4 /
+    // 8.6.14: `can't read "itemLegend1"`).
+    let src = "\
+proc estruct {name value} { set obj [list struct $name $value] }
+proc user {} {
+    estruct itemLegend1 {a b}
+    puts $itemLegend1
+}
+";
+    assert!(w210(src).contains("itemLegend1"), "got {:?}", w210(src));
+}
+
+// idx 38 — `uplevel <caller> [list set …]`, the tclopt `NewArrays` shape.
+
+#[test]
+fn idx38_uplevel_constructed_set_defines_the_callers_variable() {
+    // tclsh 9.0.4 / 8.6.14: `NewArrays {p q}` leaves `p` and `q` set in the
+    // caller; removing the call makes the read error, so the call is what
+    // materialises them.
+    let src = "\
+proc NewArrays {varNames lengths} {
+    foreach varName $varNames length $lengths {
+        uplevel 1 [list set $varName [list array $length]]
+    }
+}
+proc Qfrac {n} {
+    NewArrays {rdiagArray acnormArray} [list $n $n]
+    return [list $rdiagArray $acnormArray]
+}
+";
+    assert!(w210(src).is_empty(), "got {:?}", w210(src));
+}
+
+#[test]
+fn idx38_scalar_param_target_resolves_to_the_exact_name() {
+    // The single-parameter variant (`controls2.tcl`'s
+    // `CaseComputedNoForeachHelper`): `$varName` *is* a parameter, so the
+    // caller-frame name resolves precisely rather than widening.
+    let src = "\
+proc MakeOne {varName} { uplevel 1 [list set $varName made] }
+proc host {} {
+    MakeOne wanted
+    puts $wanted
+    puts $notWritten
+}
+";
+    let found = w210(src);
+    assert!(!found.contains("wanted"), "got {found:?}");
+    // TP control: precision, not silence — an unrelated read still reports.
+    assert!(found.contains("notWritten"), "got {found:?}");
+}
+
+#[test]
+fn idx38_literal_uplevel_body_defines_the_callers_variable() {
+    // `uplevel 1 {set litVar hello}` — the brace-literal body the lowering
+    // inlines. tclsh 9.0.4 / 8.6.14 set the caller's `litVar`.
+    let src = "\
+proc lit {} { uplevel 1 {set litVar hello} }
+proc host {} { lit; puts $litVar }
+";
+    assert!(!w210(src).contains("litVar"), "got {:?}", w210(src));
+}
+
+// idx 7 — `argparse`, which injects caller-frame locals from its own DSL.
+
+#[test]
+fn idx7_argparse_injects_caller_frame_locals() {
+    // tclsh 9.0.4 / 8.6.14 (argparse 0.5): `upvarProc p 1 2` prints
+    // `a=unset-sentinel b=1 c=2` — `a` is a `-upvar` alias of the caller's
+    // `p`, `b`/`c` are ordinary argparse-set locals. None of the three is
+    // assigned anywhere in `upvarProc`'s own text.
+    let src = "\
+package require argparse
+proc upvarProc {args} {
+    argparse {
+        {a -upvar}
+        b
+        c
+    }
+    puts \"a=$a b=$b c=$c\"
+}
+";
+    assert!(w210(src).is_empty(), "got {:?}", w210(src));
+}
+
+#[test]
+fn idx7_control_a_proc_without_argparse_still_reports() {
+    // TP control — `argparse`'s blindness is confined to the frame it is
+    // called in.
+    let src = "\
+package require argparse
+proc plain {args} { puts \"a=$a\" }
+";
+    assert!(w210(src).contains("a"), "got {:?}", w210(src));
+}
+
+// The `eval` / `uplevel <dynamic body>` FP class (#1076 "not covered").
+
+#[test]
+fn eval_of_an_unreadable_script_blinds_its_own_frame() {
+    // tclsh 9.0.4 / 8.6.14: `eval $b` runs in the frame it is written in, so
+    // `f {set injected 1}` really does create `injected` there.
+    let src = "proc f {b} { eval $b; puts $injected }\n";
+    assert!(w210(src).is_empty(), "got {:?}", w210(src));
+}
+
+#[test]
+fn uplevel_of_an_unreadable_script_blinds_the_callers_frame_not_its_own() {
+    // The frame distinction, both directions at once.
+    //
+    // tclsh 9.0.4 / 8.6.14: `proc runner {body} {set helper 42; uplevel 1
+    // $body}` invoked with `{set x $helper}` raises `can't read "helper"` —
+    // the script runs one frame *up*, so `runner`'s own `helper` is
+    // genuinely unreachable and "set but never used" is a true positive.
+    // The caller, though, may well have been written by that script.
+    let src = "\
+proc runner {body} { set helper 42; uplevel 1 $body }
+proc host {s} { runner $s; puts $injected }
+";
+    assert!(
+        w211(src).contains("helper"),
+        "the callee's own local is genuinely unread; got {:?}",
+        w211(src),
+    );
+    assert!(
+        !w210(src).contains("injected"),
+        "the caller's frame is what the script writes; got {:?}",
+        w210(src),
+    );
+}
+
+#[test]
+fn uplevel_at_the_current_frame_blinds_the_frame_it_is_written_in() {
+    // `uplevel 0 $b` re-enters the current frame — tclsh 9.0.4 / 8.6.14
+    // treat it as `eval` for variable purposes.
+    let src = "proc f {b} { uplevel 0 $b; puts $injected }\n";
+    assert!(w210(src).is_empty(), "got {:?}", w210(src));
+}
+
+#[test]
+fn control_a_literal_eval_body_is_not_a_barrier() {
+    // TN control — a brace-literal script is source text the ordinary
+    // walkers read, so it must not blind anything.
+    let src = "proc f {} { eval {puts hi}; puts $neverSet }\n";
+    assert!(w210(src).contains("neverSet"), "got {:?}", w210(src));
+}
+
+// issue #1019 — `uplevel <caller> [list callee …]` forwards one frame.
+
+#[test]
+fn idx1019_uplevel_constructed_call_forwards_the_callees_upvar_one_frame() {
+    // tclsh 9.0.4 / 8.6.14: `wrapper target` leaves `target` set in
+    // *wrapper's* caller, because `worker` runs in that frame and its own
+    // `upvar 1` therefore reaches one level further out.
+    let src = "\
+proc worker {nvar} { upvar 1 $nvar v; set v WORKED }
+proc wrapper {nvar} { uplevel 1 [list worker $nvar] }
+proc host {} { wrapper target; puts $target }
+";
+    assert!(!w210(src).contains("target"), "got {:?}", w210(src));
+}
+
+#[test]
+fn idx1019_control_a_plain_call_wrapper_does_not_forward() {
+    // TP control — the same wrapper written as a *plain* call shares values,
+    // not frames: `worker`'s `upvar 1` reaches the wrapper, not the
+    // wrapper's caller. tclsh 9.0.4 / 8.6.14 raise `can't read "target2"`.
+    let src = "\
+proc worker {nvar} { upvar 1 $nvar v; set v WORKED }
+proc wrapper2 {nvar} { worker $nvar }
+proc host2 {} { wrapper2 target2; puts $target2 }
+";
+    assert!(w210(src).contains("target2"), "got {:?}", w210(src));
+}
+
+// Frame targeting — the levels that are *not* the caller.
+
+#[test]
+fn upvar_hash_zero_raises_no_caller_frame_barrier() {
+    // TP control for the frame table: `upvar #0 counter c` binds the
+    // *global* `counter` (tclsh 9.0.4 / 8.6.14, from any call depth), which
+    // is `global_write_info`'s business, not a caller-frame effect — so it
+    // must not blind the calling function. An unrelated local there is still
+    // read-before-set (tclsh raises `can't read "unrelated"`).
+    //
+    // The complementary half — that `counter` is not recorded as a
+    // *caller-frame* binding — is pinned on the summary itself by
+    // `cfg_builder::upvar_info::tests::level_hash_zero_is_not_a_caller_frame_binding`.
+    let src = "\
+proc setsGlobal {} { upvar #0 counter c; incr c }
+proc host {} { setsGlobal; puts $unrelated }
+";
+    assert!(w210(src).contains("unrelated"), "got {:?}", w210(src));
+}
+
+#[test]
+fn upvar_beyond_the_caller_widens_instead_of_naming() {
+    // `upvar 2 far f` writes the caller's caller (tclsh 9.0.4 / 8.6.14:
+    // `proc gp {} {upvar 2 far f; set f FAR}` through one intermediate frame
+    // sets the grandparent's `far`). Naming `far` as a *direct* caller def
+    // would be wrong, so the summary widens — and the direct caller goes
+    // quiet rather than reporting a read it cannot disprove.
+    let src = "\
+proc gp {} { upvar 2 far f; set f FAR }
+proc par {} { gp; puts $anything }
+";
+    assert!(w210(src).is_empty(), "got {:?}", w210(src));
+}
+
+#[test]
+fn upvar_with_a_computed_level_widens() {
+    // `upvar $lvl a b` — three words, so `$lvl` is the level (C Tcl decides
+    // on argument-count parity). The frame is unknown, so widen.
+    let src = "\
+proc reach {lvl} { upvar $lvl a b; set b 1 }
+proc host {} { reach 1; puts $a }
+";
+    assert!(!w210(src).contains("a"), "got {:?}", w210(src));
+}

--- a/rust/tcl-compiler/tests/core_analyses.rs
+++ b/rust/tcl-compiler/tests/core_analyses.rs
@@ -1200,15 +1200,24 @@ mod soundness_gates {
 // ---------------------------------------------------------------------------
 // TestFlowSensitiveNarrowing — true-region reads are safe; false region flags.
 //
-// The leading `eval $cmd` barrier keeps both arms live (no fold), so narrowing
-// — not DCE — governs the verdict. `cmd` is itself the genuine read-before-set
-// in each reproducer.
+// The leading `uplevel 1 $cmd` barrier keeps both arms live (no fold), so
+// narrowing — not DCE — governs the verdict. `cmd` is itself the genuine
+// read-before-set in each reproducer.
+//
+// The scaffolding is `uplevel 1`, not `eval`, precisely because of the frame
+// difference: `uplevel 1 $cmd` runs the script one frame **up**, so it cannot
+// define a local of `p` and leaves `p`'s own name space provable, while
+// `eval $cmd` runs *here* and therefore blinds every W210 in `p` (tclsh 9.0.4 /
+// 8.6.14: `proc runner {b} {set helper 42; uplevel 1 $b}` invoked with
+// `{set x $helper}` raises `can't read "helper"`, while the same body under
+// `eval $b` reads `42`). Both are `Statement::Barrier`s, so either disables the
+// existence fold; only one of them is a name barrier.
 // ---------------------------------------------------------------------------
 mod flow_sensitive_narrowing {
     use super::*;
 
     fn flagged(body: &str) -> std::collections::HashSet<String> {
-        w210_vars(&format!("proc p {{}} {{ eval $cmd; {body} }}"))
+        w210_vars(&format!("proc p {{}} {{ uplevel 1 $cmd; {body} }}"))
     }
 
     #[test]
@@ -1275,7 +1284,7 @@ mod info_vars_narrowing {
     use super::*;
 
     fn flagged(body: &str) -> std::collections::HashSet<String> {
-        w210_vars(&format!("proc p {{}} {{ eval $cmd; {body} }}"))
+        w210_vars(&format!("proc p {{}} {{ uplevel 1 $cmd; {body} }}"))
     }
 
     #[test]
@@ -1338,7 +1347,7 @@ mod catch_narrowing {
     use super::*;
 
     fn flagged(body: &str) -> std::collections::HashSet<String> {
-        w210_vars(&format!("proc p {{}} {{ eval $cmd; {body} }}"))
+        w210_vars(&format!("proc p {{}} {{ uplevel 1 $cmd; {body} }}"))
     }
 
     #[test]

--- a/rust/tcl-fuzz/src/generator.rs
+++ b/rust/tcl-fuzz/src/generator.rs
@@ -122,7 +122,7 @@ impl Gen {
             // proc / namespace definitions are top-level only (matching the
             // oracle): nesting them changes scope semantics in ways the
             // generator doesn't model.
-            let arms = if depth == 0 { 11 } else { 7 };
+            let arms = if depth == 0 { 12 } else { 7 };
             match self.rng.below(arms) {
                 0 => self.if_stmt(depth),
                 1 => self.while_stmt(depth),
@@ -135,6 +135,7 @@ impl Gen {
                 8 => self.namespace_stmt(depth),
                 9 => self.inscope_stmt(),
                 10 => self.dynamic_name_stmt(),
+                11 => self.caller_frame_stmt(),
                 _ => self.leaf_statement(depth),
             }
         }
@@ -495,6 +496,64 @@ impl Gen {
             _ => self.out.push_str(
                 "set _dnn _dnu\nset $_dnn gone\nputs [info exists _dnu]\n\
                  unset $_dnn\nputs [info exists _dnu]\n",
+            ),
+        }
+    }
+
+    /// A procedure that writes its **caller's** frame — `upvar`'s three
+    /// resolvable shapes, `uplevel`'s literal / constructed / opaque bodies,
+    /// and the one-frame forward `uplevel 1 [list callee …]`.
+    ///
+    /// The compiler summarises these per procedure (issue #923 audit cluster
+    /// C1, `tcl_compiler::cfg_builder::upvar_info`) and applies the summary
+    /// at every call site, widening the caller's `defs` or raising a
+    /// caller-frame barrier.  Both gate the constant-branch fold and
+    /// dead-store elimination that feed this backend's input IR, so the
+    /// differential needs the shapes present to catch a VM whose frame
+    /// targeting differs from C Tcl's.
+    ///
+    /// Every arm keeps to a private `_cf*` name space the other productions
+    /// never touch, and every proc is defined and called inside the same
+    /// emitted run, so the lines stay deterministic wherever they land in the
+    /// script.  Output is the injected value plus an `info exists` probe, so
+    /// a write landing in the wrong frame is a stdout mismatch rather than a
+    /// silent pass.  tclsh 9.0.4 / 8.6.14 agree on all six arms.
+    fn caller_frame_stmt(&mut self) {
+        match self.rng.below(6) {
+            // `upvar 1 $param local` — the by-reference out-parameter.
+            0 => self.out.push_str(
+                "proc _cfa {n} {upvar 1 $n v; set v made}\n\
+                 proc _cfa0 {} {_cfa _cfx; puts $_cfx; puts [info exists _cfx]}\n_cfa0\n",
+            ),
+            // `upvar 1 literal local` — a fixed caller-side name.
+            1 => self.out.push_str(
+                "proc _cfb {} {upvar 1 _cfy v; set v lit}\n\
+                 proc _cfb0 {} {_cfb; puts $_cfy}\n_cfb0\n",
+            ),
+            // `upvar #0` reaches the global frame from any depth.
+            2 => self.out.push_str(
+                "proc _cfc {} {upvar #0 _cfg g; set g glob}\n\
+                 proc _cfc0 {} {_cfc}\n_cfc0\nputs $::_cfg\n",
+            ),
+            // `uplevel 1 {literal}` — the body runs one frame up.
+            3 => self.out.push_str(
+                "proc _cfd {} {uplevel 1 {set _cfz up}}\n\
+                 proc _cfd0 {} {_cfd; puts $_cfz}\n_cfd0\n",
+            ),
+            // `uplevel 1 [list set $name …]` — a constructed body naming its
+            // command statically.
+            4 => self.out.push_str(
+                "proc _cfe {n} {uplevel 1 [list set $n cons]}\n\
+                 proc _cfe0 {} {_cfe _cfw; puts $_cfw}\n_cfe0\n",
+            ),
+            // `uplevel 1 [list callee …]` forwards the callee's own `upvar 1`
+            // one frame further out; the plain-call spelling does not.
+            _ => self.out.push_str(
+                "proc _cff {n} {upvar 1 $n v; set v fwd}\n\
+                 proc _cff1 {n} {uplevel 1 [list _cff $n]}\n\
+                 proc _cff2 {n} {_cff $n}\n\
+                 proc _cff0 {} {_cff1 _cfv; puts $_cfv; \
+_cff2 _cfu; puts [info exists _cfu]}\n_cff0\n",
             ),
         }
     }
@@ -1184,6 +1243,49 @@ mod tests {
                 assert!(
                     !line.contains(&format!("${v} ")) && !line.ends_with(&format!("${v}")),
                     "dynamic-name line touches shared variable {v:?}: {line:?}"
+                );
+            }
+        }
+    }
+
+    /// Issue #923 audit cluster C1's coverage seed. A procedure writing its
+    /// **caller's** frame was never generated, so the whole caller-frame
+    /// path — which the compiler now summarises per procedure and applies at
+    /// every call site, gating the constant-branch fold and dead-store
+    /// elimination that feed this backend's input IR — went differentially
+    /// untested. Proves every arm reaches a generated script.
+    #[test]
+    fn caller_frame_shapes_are_exercised() {
+        let cfg = GenConfig {
+            max_depth: 4,
+            max_stmts: 16,
+            ..GenConfig::default()
+        };
+        let corpus: Vec<String> = (0..600u64).map(|s| generate(s, &cfg)).collect();
+        for needle in [
+            "upvar 1 $n v",
+            "upvar 1 _cfy v",
+            "upvar #0 _cfg g",
+            "uplevel 1 {set _cfz up}",
+            "uplevel 1 [list set $n cons]",
+            "uplevel 1 [list _cff $n]",
+        ] {
+            assert!(
+                corpus.iter().any(|s| s.contains(needle)),
+                "caller-frame production never generated: {needle:?}"
+            );
+        }
+        // The shapes must stay inside their private `_cf*` name space, so
+        // wherever they land they cannot perturb the rest of a script.
+        for line in corpus
+            .iter()
+            .flat_map(|s| s.lines())
+            .filter(|l| l.contains("_cf"))
+        {
+            for v in VARS {
+                assert!(
+                    !line.contains(&format!("${v} ")) && !line.ends_with(&format!("${v}")),
+                    "caller-frame line touches shared variable {v:?}: {line:?}"
                 );
             }
         }

--- a/rust/tcl-registry/src/commands/argparse/command.rs
+++ b/rust/tcl-registry/src/commands/argparse/command.rs
@@ -251,6 +251,21 @@ pub fn spec() -> CommandSpec {
         forms: FORMS,
         options: OPTIONS,
         side_effects: SIDE_EFFECTS,
+        // `argparse` creates one local per recognised element **in the frame
+        // that called it** — `argparse.tcl:964` runs
+        // `uplevel 1 [list ::upvar … $val $key]` for `-upvar` elements and
+        // `uplevel 1 [list set …]` for the rest.  The names come from the
+        // definition list's own mini-language (`-key`/`-alias`/`-pass`
+        // rewrite them, `-inline` suppresses them entirely), which this
+        // analysis does not interpret, so the effect is an *opaque*
+        // caller-frame injection: a consumer must widen rather than
+        // enumerate.  tclsh 9.0.4 / 8.6.14: `proc p {args} {argparse {{a
+        // -upvar} b c}; puts "$a $b $c"}` reads three locals nothing in `p`
+        // ever assigns.
+        frame_effect: Some(FrameEffectSpec {
+            level_word: FrameLevelWord::None,
+            layout: FrameArgLayout::OpaqueCallerVars,
+        }),
         required_package: Some("argparse"),
         ..CommandSpec::DEFAULT
     }

--- a/rust/tcl-registry/src/commands/tcl/eval_.rs
+++ b/rust/tcl-registry/src/commands/tcl/eval_.rs
@@ -72,6 +72,17 @@ pub fn spec() -> CommandSpec {
             | Traits::SCRIPT_CONCATENATES_ARGS,
         arity: Arity::at_least(1),
         arg_roles: &[(0, ArgRole::Body)],
+        // `eval` concatenates its args and runs the result **in the calling
+        // frame** — no level word, no frame shift.  A script it cannot read
+        // statically (`eval $body`) can therefore create, read, or destroy
+        // any local of the frame the `eval` is written in (tclsh 9.0.4 /
+        // 8.6.14: `proc f {b} {set helper 42; eval $b}` called with
+        // `{set helper}` returns `42`, while the same body under
+        // `uplevel 1 $b` raises `can't read "helper"`).
+        frame_effect: Some(FrameEffectSpec {
+            level_word: FrameLevelWord::None,
+            layout: FrameArgLayout::ScriptInCurrentFrame,
+        }),
         lowering_hook: Some(crate::hooks::LoweringHookId::Eval),
         return_type: Some(TclType::String),
         hover: Some(HoverSnippet {

--- a/rust/tcl-registry/src/commands/tcl/uplevel_.rs
+++ b/rust/tcl-registry/src/commands/tcl/uplevel_.rs
@@ -186,6 +186,15 @@ pub fn spec() -> CommandSpec {
         // scope), exactly as `proc` / `namespace eval` bodies are.
         body_kind: BodyKind::Structural,
         arg_role_resolver: Some(uplevel_arg_roles),
+        // `uplevel ?level? arg …` — the level word is probed from the
+        // leading word's text (`Tcl_UplevelObjCmd` → `TclObjGetFrame`), and
+        // the script it runs belongs to the frame that word selects, not to
+        // the frame the call is written in.  `uplevel_script_start` above is
+        // the same rule expressed for the arg-role layer.
+        frame_effect: Some(FrameEffectSpec {
+            level_word: FrameLevelWord::LeadingProbe,
+            layout: FrameArgLayout::ScriptInSelectedFrame,
+        }),
         lowering_hook: Some(crate::hooks::LoweringHookId::Uplevel),
         return_type: Some(TclType::String),
         hover: Some(HoverSnippet {

--- a/rust/tcl-registry/src/commands/tcl/upvar_.rs
+++ b/rust/tcl-registry/src/commands/tcl/upvar_.rs
@@ -98,6 +98,16 @@ pub fn spec() -> CommandSpec {
             examples: "proc add2 name {\n    upvar $name x\n    set x [expr {$x + 2}]\n}\nset n 5\nadd2 n\nputs $n\n\n# level defaults to 1 (the caller); an explicit level reaches further up the stack\nproc decr {varName {decrement 1}} {\n    upvar 1 $varName var\n    incr var [expr {-$decrement}]\n}\n\n# level #0 links straight to the global scope, regardless of call depth\nproc bumpCounter {} {\n    upvar #0 counter c\n    incr c\n}",
             return_value: "The empty string.",
         }),
+        // `upvar ?level? otherVar myVar …` — C Tcl reads the level word off
+        // the *argument count parity* (`Tcl_UpvarObjCmd` tests `objc`), never
+        // off the word's text, so `upvar 1 b` aliases the caller variable
+        // literally named `1` while `upvar $lvl a b` really does take `$lvl`
+        // as its level.  tclsh 9.0.4 / 8.6.14 agree; see
+        // `FrameLevelWord::ArityParity` for the pinned table.
+        frame_effect: Some(FrameEffectSpec {
+            level_word: FrameLevelWord::ArityParity,
+            layout: FrameArgLayout::AliasPairs,
+        }),
         lowering_hook: Some(LoweringHookId::Upvar),
         codegen_hook: Some(CodegenHookId::Upvar),
         forms: FORMS,

--- a/rust/tcl-registry/src/frame_effect.rs
+++ b/rust/tcl-registry/src/frame_effect.rs
@@ -1,0 +1,326 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Frame-effect descriptors — which arguments of a command select a stack
+//! frame, name a variable *in* that frame, or carry a script that runs
+//! there.
+//!
+//! Tcl's frame-crossing primitives are few but their argument grammars are
+//! all different, and every consumer that reasons about caller-frame
+//! injection (`tcl_compiler`'s frame-effect summaries, the parameter-trait
+//! inference, the analyser's alias handlers) needs the same three answers:
+//!
+//! 1. **Is there a level word, and where?**  `upvar` decides on argument
+//!    *count parity*; `uplevel` probes the leading word's text.
+//! 2. **What do the remaining arguments do?**  `upvar` takes
+//!    `otherVar myVar` pairs; `uplevel` concatenates a script.
+//! 3. **Which frame does the effect land in?**  The one the level word
+//!    selects, the current one, or the command's own caller's.
+//!
+//! Answering them by matching command names in the consumer is exactly the
+//! duplication the registry exists to prevent — three copies of the level
+//! rule had already drifted apart before this descriptor existed, two of
+//! them wrong (see [`FrameLevelWord::ArityParity`]).
+//!
+//! # C Tcl provenance
+//!
+//! Every rule below is pinned against `tclsh 9.0.4` **and** `tclsh 8.6.14`,
+//! which agree on all of it:
+//!
+//! ```tcl
+//! proc t3 {} { return [catch {set b} e]:$e }   ;# body: upvar 1 b
+//! proc h3 {} { set 1 ONE; return [t3] }
+//! h3   ;# → 0:ONE   — `1` is the *otherVar*, not a level
+//!
+//! proc t6 {} { return [catch {upvar foo bar baz} e]:$e }
+//! t6   ;# → 1:bad level "foo"   — 3 words ⇒ the first IS the level
+//! ```
+
+/// Which stack frame an `upvar` / `uplevel` level word selects.
+///
+/// `Relative(1)` — the caller — is the default whenever the word is absent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FrameLevel {
+    /// `N` — *N* frames up from the current one. `Relative(0)` is the
+    /// current frame itself (`uplevel 0 …` re-enters it; `upvar 0 x y`
+    /// aliases a *local*).
+    Relative(u32),
+    /// `#N` — absolute frame number counted down from the global frame.
+    /// `Absolute(0)` is the global frame, whatever the call depth.
+    Absolute(u32),
+    /// The word is present but its value is computed at run time
+    /// (`upvar $lvl x y`, `uplevel [expr {$n-1}] $s`).
+    Dynamic,
+}
+
+impl FrameLevel {
+    /// The frame every level-taking command targets when its level word is
+    /// omitted — the immediate caller.
+    pub const DEFAULT: Self = Self::Relative(1);
+
+    /// True when this level names the **immediate caller's** frame, the one
+    /// a per-proc frame-effect summary can hand to a call site.
+    #[must_use]
+    pub const fn is_caller_frame(self) -> bool {
+        matches!(self, Self::Relative(1))
+    }
+
+    /// True when this level names the frame the command is *written* in —
+    /// `uplevel 0 …`, whose script shares the current frame's variables.
+    #[must_use]
+    pub const fn is_current_frame(self) -> bool {
+        matches!(self, Self::Relative(0))
+    }
+
+    /// True when this level names the global frame (`#0`).
+    #[must_use]
+    pub const fn is_global_frame(self) -> bool {
+        matches!(self, Self::Absolute(0))
+    }
+
+    /// Parse a level word.
+    ///
+    /// Returns `None` when the word cannot be a level at all — C Tcl's
+    /// `TclObjGetFrame` accepts an optional `#`, then an integer parsed by
+    /// `Tcl_GetIntFromObj`, so `+1` and `0x1` are levels (tclsh 9.0.4 /
+    /// 8.6.14: `upvar 0x1 target alias` reaches the caller) while `1.0` and
+    /// `-1` are `bad level` errors.
+    #[must_use]
+    pub fn parse(word: &str) -> Option<Self> {
+        if word.contains('$') || word.contains('[') {
+            return Some(Self::Dynamic);
+        }
+        let trimmed = word.trim();
+        let (absolute, digits) = match trimmed.strip_prefix('#') {
+            Some(rest) => (true, rest.trim_start()),
+            None => (false, trimmed),
+        };
+        let digits = digits.strip_prefix('+').unwrap_or(digits);
+        let value = if let Some(hex) = digits
+            .strip_prefix("0x")
+            .or_else(|| digits.strip_prefix("0X"))
+        {
+            u32::from_str_radix(hex, 16).ok()?
+        } else {
+            digits.parse::<u32>().ok()?
+        };
+        Some(if absolute {
+            Self::Absolute(value)
+        } else {
+            Self::Relative(value)
+        })
+    }
+
+    /// Whether *word* could be the level word of a command that probes its
+    /// leading argument for one ([`FrameLevelWord::LeadingProbe`]).
+    #[must_use]
+    pub fn word_could_be_level(word: &str) -> bool {
+        Self::parse(word).is_some()
+    }
+}
+
+/// How a command spells its optional frame-level word.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FrameLevelWord {
+    /// No level word at all.
+    None,
+    /// **Argument-count parity**, `upvar`'s rule: the level word is present
+    /// exactly when the number of words after the command name is *odd*.
+    ///
+    /// C Tcl decides this on `objc`, never on the word's text
+    /// (`Tcl_UpvarObjCmd`), which is why the two spellings below mean
+    /// opposite things — pinned on tclsh 9.0.4 and 8.6.14, identical:
+    ///
+    /// | written | words | level | pairs |
+    /// |---|---|---|---|
+    /// | `upvar 1 a b`     | 3 | `1`      | `(a, b)` |
+    /// | `upvar a b`       | 2 | default  | `(a, b)` |
+    /// | `upvar 1 b`       | 2 | default  | `(1, b)` — `1` is a *variable name* |
+    /// | `upvar $lvl a b`  | 3 | `$lvl`   | `(a, b)` |
+    /// | `upvar 1 a b c`   | 4 | default  | `(1, a)`, `(b, c)` |
+    /// | `upvar foo bar baz` | 3 | `foo` → `bad level "foo"` | — |
+    ///
+    /// A text-sniffing consumer gets the third and fourth rows backwards:
+    /// it drops a real binding for `upvar $lvl a b` (the commonest
+    /// by-reference idiom of all) and invents a level for `upvar 1 b`.
+    ArityParity,
+    /// **Leading-word probe**, `uplevel`'s rule: the first word is the level
+    /// when it parses as one, or when it substitutes *and* a further word
+    /// follows (`uplevel $lvl {…}`; a lone `uplevel $body` is a body).
+    LeadingProbe,
+}
+
+/// What the arguments after the (optional) level word do, and which frame
+/// the effect lands in.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FrameArgLayout {
+    /// `otherVar myVar` pairs — each `otherVar` names a variable in the
+    /// **selected** frame and each `myVar` the local alias bound to it
+    /// (`upvar`).
+    AliasPairs,
+    /// The remaining words concatenate into a script evaluated in the
+    /// **selected** frame (`uplevel`), so its variable accesses belong to
+    /// that frame, not to the one the call is written in.
+    ScriptInSelectedFrame,
+    /// The command's [`crate::ArgRole::Body`] argument runs in the
+    /// **current** frame, sharing its variables (`eval`).
+    ScriptInCurrentFrame,
+    /// The command injects variables into the frame of **its own caller**
+    /// under names it derives from an argument mini-language this analysis
+    /// does not interpret (`argparse`'s definition list).  Every such name
+    /// is unknowable, so a consumer must widen rather than enumerate.
+    OpaqueCallerVars,
+}
+
+/// How a command crosses stack frames — the registry's answer to "which
+/// argument is the level word, which names a variable in another frame, and
+/// which carries a script that runs there".
+///
+/// Attached to a [`CommandSpec`](crate::CommandSpec) via
+/// `CommandSpec::frame_effect`; absent means the command has no
+/// frame-crossing argument grammar.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FrameEffectSpec {
+    /// How the optional level word is located.
+    pub level_word: FrameLevelWord,
+    /// What the post-level arguments do.
+    pub layout: FrameArgLayout,
+}
+
+impl FrameEffectSpec {
+    /// How many leading words of `args` (the argument list *after* the
+    /// command name) the level word occupies — `1` or `0`.
+    ///
+    /// `args` must be the whole post-command word list, because
+    /// [`FrameLevelWord::ArityParity`] answers from its length.
+    #[must_use]
+    pub fn level_word_len(&self, args: &[&str]) -> usize {
+        match self.level_word {
+            FrameLevelWord::None => 0,
+            FrameLevelWord::ArityParity => usize::from(args.len() % 2 == 1),
+            FrameLevelWord::LeadingProbe => match args.first() {
+                // A word that parses as a level is one, whatever follows:
+                // `uplevel 1 2 3` runs the script `2 3` at level 1 (tclsh
+                // 9.0.4 / 8.6.14 both report `invalid command name "2"`).
+                Some(w) if FrameLevel::parse(w).is_some_and(|l| l != FrameLevel::Dynamic) => 1,
+                // A substituted word only separates from the script when a
+                // script word follows it.
+                Some(w) if args.len() >= 2 && FrameLevel::parse(w) == Some(FrameLevel::Dynamic) => {
+                    1
+                }
+                _ => 0,
+            },
+        }
+    }
+
+    /// The frame this invocation targets, and the arguments that follow the
+    /// level word.
+    #[must_use]
+    pub fn resolve<'a>(&self, args: &'a [&'a str]) -> (FrameLevel, &'a [&'a str]) {
+        let taken = self.level_word_len(args);
+        let level = if taken == 0 {
+            FrameLevel::DEFAULT
+        } else {
+            FrameLevel::parse(args[0]).unwrap_or(FrameLevel::Dynamic)
+        };
+        (level, &args[taken..])
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const UPVAR: FrameEffectSpec = FrameEffectSpec {
+        level_word: FrameLevelWord::ArityParity,
+        layout: FrameArgLayout::AliasPairs,
+    };
+    const UPLEVEL: FrameEffectSpec = FrameEffectSpec {
+        level_word: FrameLevelWord::LeadingProbe,
+        layout: FrameArgLayout::ScriptInSelectedFrame,
+    };
+
+    #[test]
+    fn level_words_c_tcl_accepts() {
+        // tclsh 9.0.4 / 8.6.14: `upvar 0x1 target alias` and `upvar +1 …`
+        // both reach the caller; `1.0` and `-1` raise `bad level`.
+        assert_eq!(FrameLevel::parse("1"), Some(FrameLevel::Relative(1)));
+        assert_eq!(FrameLevel::parse("0"), Some(FrameLevel::Relative(0)));
+        assert_eq!(FrameLevel::parse("#0"), Some(FrameLevel::Absolute(0)));
+        assert_eq!(FrameLevel::parse("#1"), Some(FrameLevel::Absolute(1)));
+        assert_eq!(FrameLevel::parse(" 1"), Some(FrameLevel::Relative(1)));
+        assert_eq!(FrameLevel::parse("+1"), Some(FrameLevel::Relative(1)));
+        assert_eq!(FrameLevel::parse("0x1"), Some(FrameLevel::Relative(1)));
+        assert_eq!(FrameLevel::parse("$lvl"), Some(FrameLevel::Dynamic));
+        assert_eq!(
+            FrameLevel::parse("[expr {$n-1}]"),
+            Some(FrameLevel::Dynamic)
+        );
+        assert_eq!(FrameLevel::parse("1.0"), None);
+        assert_eq!(FrameLevel::parse("-1"), None);
+        assert_eq!(FrameLevel::parse("foo"), None);
+        assert_eq!(FrameLevel::parse(""), None);
+    }
+
+    #[test]
+    fn upvar_level_word_is_decided_by_arity_parity() {
+        // The oracle table in `FrameLevelWord::ArityParity`'s doc.
+        assert_eq!(UPVAR.resolve(&["1", "a", "b"]).0, FrameLevel::Relative(1));
+        assert_eq!(UPVAR.resolve(&["1", "a", "b"]).1, ["a", "b"]);
+        // Two words: no level, `1` is the caller-side *name*.
+        assert_eq!(UPVAR.resolve(&["1", "b"]).0, FrameLevel::DEFAULT);
+        assert_eq!(UPVAR.resolve(&["1", "b"]).1, ["1", "b"]);
+        // A computed level is still a level — parity, not text, decides.
+        assert_eq!(UPVAR.resolve(&["$lvl", "a", "b"]).0, FrameLevel::Dynamic);
+        assert_eq!(UPVAR.resolve(&["$lvl", "a", "b"]).1, ["a", "b"]);
+        // Four words: two pairs, no level.
+        assert_eq!(UPVAR.resolve(&["1", "a", "b", "c"]).1, ["1", "a", "b", "c"]);
+        // Three non-level words: the first IS taken as a level and errors.
+        assert_eq!(UPVAR.resolve(&["foo", "bar", "baz"]).0, FrameLevel::Dynamic);
+    }
+
+    #[test]
+    fn uplevel_level_word_is_probed_from_the_leading_text() {
+        assert_eq!(
+            UPLEVEL.resolve(&["1", "{set x 1}"]).0,
+            FrameLevel::Relative(1)
+        );
+        assert_eq!(
+            UPLEVEL.resolve(&["#0", "{set x 1}"]).0,
+            FrameLevel::Absolute(0)
+        );
+        // A lone substituted word is the body, not a level.
+        assert_eq!(UPLEVEL.resolve(&["$body"]).0, FrameLevel::DEFAULT);
+        assert_eq!(UPLEVEL.resolve(&["$body"]).1, ["$body"]);
+        // With a following word it separates.
+        assert_eq!(UPLEVEL.resolve(&["$lvl", "$body"]).0, FrameLevel::Dynamic);
+        assert_eq!(UPLEVEL.resolve(&["$lvl", "$body"]).1, ["$body"]);
+        // No level word at all.
+        assert_eq!(UPLEVEL.resolve(&["{expr {1+1}}"]).0, FrameLevel::DEFAULT);
+    }
+
+    #[test]
+    fn frame_predicates() {
+        assert!(FrameLevel::DEFAULT.is_caller_frame());
+        assert!(FrameLevel::Relative(0).is_current_frame());
+        assert!(FrameLevel::Absolute(0).is_global_frame());
+        assert!(!FrameLevel::Relative(2).is_caller_frame());
+        assert!(!FrameLevel::Dynamic.is_caller_frame());
+        assert!(!FrameLevel::Absolute(1).is_global_frame());
+    }
+}

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -68,6 +68,7 @@ mod event_descriptions;
 pub mod event_facts;
 pub mod events;
 pub mod forms;
+pub mod frame_effect;
 pub mod hooks;
 pub mod hover;
 pub mod mathfunc;
@@ -106,6 +107,7 @@ pub mod prelude {
     pub use crate::dialects::DialectSet;
     pub use crate::events::EventRequires;
     pub use crate::forms::{CommandForm, SubCommandForm};
+    pub use crate::frame_effect::{FrameArgLayout, FrameEffectSpec, FrameLevel, FrameLevelWord};
     pub use crate::hooks::{
         AnalyserHookId, ArgTypeHint, CodegenHookId, LoweringHookId, TclVersion,
         VersionedConstFoldFn, WasmCodegenHookId,
@@ -140,6 +142,7 @@ pub use dialects::{
     DETECT_SCAN_BYTES, KNOWN_DIALECTS, available_dialects, detect_dialect,
     detect_dialect_directive, detect_dialect_from_source, dialect_from_extension,
 };
+pub use frame_effect::{FrameArgLayout, FrameEffectSpec, FrameLevel, FrameLevelWord};
 pub use hover::ArgValue;
 pub use patterns::{FormatType, PatternType};
 pub use profile_queries::{ProfileQueries, VendorSurface};

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1202,6 +1202,18 @@ impl CommandRegistry {
         })
     }
 
+    /// How *name* crosses stack frames, if it does — the registry's
+    /// [`FrameEffectSpec`](crate::frame_effect::FrameEffectSpec).
+    ///
+    /// The single membership test for "is this a frame-crossing command?".
+    /// A consumer reads the returned descriptor to find the level word and
+    /// the affected arguments; it never names `upvar` / `uplevel` / `eval`
+    /// itself.
+    #[must_use]
+    pub fn frame_effect(&self, name: &str) -> Option<crate::frame_effect::FrameEffectSpec> {
+        self.get(name).and_then(|spec| spec.frame_effect)
+    }
+
     /// Resolve argument indices for a given role.
     ///
     /// For subcommand-based commands (e.g. `dict create`), pass the

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -29,6 +29,7 @@ use crate::clause_shape::ClauseShapeChecker;
 use crate::command_table::CommandTableEffect;
 use crate::dialects::DialectSet;
 use crate::forms::{CommandForm, SubCommandForm};
+use crate::frame_effect::FrameEffectSpec;
 use crate::hooks::{
     AnalyserHookId, ArgTypeHint, CodegenHookId, ConstFoldFn, InlineCodegenHookId, LoweringHookId,
     TclVersion, VersionedConstFoldFn, WasmCodegenHookId,
@@ -298,6 +299,18 @@ pub struct CommandSpec {
 
     /// Dynamic argument role resolver (for variable-layout commands).
     pub arg_role_resolver: Option<ArgRoleResolver>,
+
+    /// How the command crosses stack frames — which argument is the level
+    /// word, which arguments name variables in the selected frame, and
+    /// which carry a script that runs there.  See
+    /// [`FrameEffectSpec`](crate::frame_effect::FrameEffectSpec).
+    ///
+    /// `None` (the default) means the command has no frame-crossing
+    /// argument grammar.  Distinct from [`Traits::CREATES_SCOPE_ALIAS`] and
+    /// [`Traits::EVALUATES_IN_SHIFTED_FRAME`], which say *that* a command
+    /// crosses frames; this says *how*, in enough detail for a consumer to
+    /// read the level and the affected names without naming the command.
+    pub frame_effect: Option<FrameEffectSpec>,
 
     /// Clause-chain shape validator, for a command whose valid argument
     /// shapes aren't a single `min..=max` [`Arity`] range (`if`'s
@@ -839,6 +852,7 @@ impl CommandSpec {
         arity: Arity::any(),
         arg_roles: &[],
         arg_role_resolver: None,
+        frame_effect: None,
         clause_shape_check: None,
         command_prefixes: &[],
         command_prefix_resolver: None,

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -600,6 +600,10 @@ fn command_identity(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
         lost.expr("arg_role_resolver", spec.arg_role_resolver.is_some()),
     );
     d.insert(
+        "frame_effect".into(),
+        lost.expr("frame_effect", spec.frame_effect.is_some()),
+    );
+    d.insert(
         "clause_shape_check".into(),
         lost.expr("clause_shape_check", spec.clause_shape_check.is_some()),
     );

--- a/rust/tcl-spec-studio/src/schema.rs
+++ b/rust/tcl-spec-studio/src/schema.rs
@@ -289,6 +289,15 @@ pub const COMMAND_FIELDS: &[FieldSchema] = &[
         "Callback assigning roles from the actual argument list; wins over `arg_roles`.",
     ),
     f(
+        "frame_effect",
+        "Frame effect",
+        ADVANCED,
+        FieldKind::RustExpr {
+            hint: "Some(frame_effect::UPVAR)",
+        },
+        "How the command crosses stack frames: level word, frame-selected variable args, and caller-frame scripts.",
+    ),
+    f(
         "clause_shape_check",
         "Clause-shape checker",
         ADVANCED,


### PR DESCRIPTION
## Summary

Issue-923 audit cluster C1's dataflow half: the analyser now models *which names a call writes into the caller's frame* as a per-proc **frame-effect summary**, consulted at every call site. This kills the ticklecharts/argparse W210 false-positive family at its root.

- **The model** — `cfg_builder::upvar_info` becomes a summary over eight buckets (literal targets, param-resolved targets, `$args`-tail, `uplevel [list set …]` literal/param writes, one-hop forwarded calls, and opaque widening for `upvar 2`/`upvar $lvl`/`uplevel 1 $body`). Built in one walk per proc; call-site cost is a hash lookup plus work proportional to bound args. Forwarding composes against own-body summaries only, so recursion needs no fixpoint by construction.
- **Registry-first** — level-word position, level-word grammar, frame-selected variable args, and frame-selected script args are new registry data: `CommandSpec::frame_effect` (`FrameEffectSpec`, new `tcl-registry/src/frame_effect.rs`) on `upvar`, `uplevel`, `eval`, `argparse`. No consumer names a command.
- **Level-word semantics from the C source, oracle-pinned on 9.0.4 + 8.6.14** (identical): `upvar`'s level detection is *argument-count parity*, not text (`upvar 1 b` treats `1` as a variable pair!); `uplevel`'s is content-probed. Accepted/rejected level spellings pinned (`#0`, `+1`, `0x1`, `" 1"` accepted; `-1`, `1.0` rejected). Two parity bugs this table exposed in existing code (`param_traits::handle_upvar`, `upvar_pairs`) are fixed, and `upvar #0` is no longer mis-filed as a caller-frame binding.
- **Where facts land** — named caller-frame writes merge into the call's `defs` (existing consumers unchanged); opaque effects set `cfg::Function::caller_frame_barrier`, which joins #1076's `DynamicNameBarrier` lattice (same fact, same O(1) consumers — a per-callsite fact would compute the same union without the flow-sensitivity to exploit it). This also closes the `eval $body`/`uplevel 1 $body` FP class #1076 documented: `eval` blinds its own frame, `uplevel 1 $body` blinds the caller's and leaves its own locals provable — the frame distinction this PR establishes.
- **Findings**: idx 7 fixed (argparse's 3 W210 FPs → 0), idx 38 fixed (`uplevel 1 [list set $v …]`, 3 FPs → 0), idx 57 W210-half fixed, idx 59 fixed single-document (shared `qualified_lookup_keys` so the three fact maps can't disagree on qualified spellings), idx 22/98 partial — the dataflow halves land here, their hover/references symptoms are C1b's scope in `tcl-lsp-core`, and the cross-file summary merge is specified in `ssa-construction.md` for C1b (the summary is a pure hashable function of body+params, ready to intern). The old `uplevel 1 [list …]` TODO in `cfg_builder` is closed with the plain-call TN that sank the previously-reverted attempt now pinned.
- Soundness directions all explicit: abstain-toward-silence for W210/W211/W220, abstain-toward-no-fold for O109/O126, and unplaceable levels **widen rather than drop** (dropping would manufacture a false W210 where the write lands).
- Fuzz: new `caller_frame_stmt` generator production (6 arms, `_cf*`-namespaced) per the #1076 precedent; a 400-iteration differential campaign against tclsh 9.0.4 matched 400/400.

## Validation

- [x] I ran relevant tests/checks locally and listed the exact commands.
  - `cargo test -p tcl-compiler -p tcl-registry -p tcl-fuzz` — 73 binaries, 8,214 passed, 0 failed (clean rebuild); `cargo test -p tcl-lsp-core` — 2,286 passed; `cargo test -p tcl-lsp-db -p tcl-vm` — 828 passed.
  - New `caller_frame_effects.rs` — 17 whole-file cases, every FP paired with a TP control that must keep firing plus over-suppression TNs; oracle-pinned level tables; forwarded-call and opaque-widening units.
  - `cargo clippy --workspace --all-targets` — 0 warnings, **zero new allows** (diff-verified); fmt clean; `make xtask-check` all 12 gates OK.
  - Two mid-session ENOSPC events handled per AGENTS.md — every reported result reproduced after `cargo clean`.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — caller-frame injection is a first-class dataflow fact; `FrameEffectSpec` is new registry surface; the barrier lattice gains a caller-frame source.
- [x] I updated at least one relevant KCS note: W210/W220 pages gain caller-frame sections beside #1076's computed-name ones; `ssa-construction.md` gains the frame-effect design section including the C1b cross-file specification; audit `STATUS.md` ticked.
- [ ] New compiler KCS note linked. (n/a — existing notes extended)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_