### PR TITLE
Rename safety gate: untracked receivers, namespace-scoped object commands, workspace variable rename (audit idx 79, #981, #1087)

### DIFF
--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -36,6 +36,30 @@ The `variable_refs` rows come from `qualified_var_refs`, which the analyser
 cell resolves in the recording document: the cross-file case is precisely
 the one where it does not.
 
+### The variable tier's rename half
+
+Go-to-definition, hover, and find-references answer a namespace variable
+*from the index alone* — an exact qualified-name match, no other document
+read.  **Rename cannot**, and the difference is contractual, not an
+optimisation gap: the index deliberately holds only namespace-scoped
+declarations and qualified occurrences, while a rename must also rewrite the
+`variable v` / `global v` / `namespace upvar` **aliases** inside proc and
+method bodies and every unqualified `$v` they enable.  Those are proc-scope
+bindings — a per-document identity, so by rule 4 above they do not belong in
+the index — but they name the very same cell, and leaving them behind breaks
+the program.
+
+So the rename tier uses the index only to pick *which documents to visit*
+(`variable_definitions_qualified`, `variable_refs_of`, and
+`documents_in_namespace` — every document declaring anything directly in the
+cell's namespace, since an unqualified alias can only be written there), then
+re-analyses each and computes its share with
+`tcl_lsp_core::rename::namespace_variable_rename_edits`, which reads
+`VarDef::link_target` for the alias union.  A document in that namespace that
+computes a variable name (`set $n 1`, `variable $n`) refuses the whole rename
+(`tcl_lsp_core::rename_safety::namespace_variable_rename_hazard`) rather than
+emitting an edit set that silently misses it.
+
 ## Derived views and their invalidation
 
 `WorkspaceIndex::generation()` is bumped by `add_document` /
@@ -79,6 +103,9 @@ cache.
   `extend_resolver_with_document_auto_paths`, `ensure_library_indexed`)
 - `rust/tcl-compiler/src/analyser/scope.rs` (`namespace_variables`,
   `attach_qualified_var_references`)
+- `rust/tcl-lsp-core/src/rename.rs` (`namespace_variable_rename_edits`)
+- `rust/tcl-lsp-core/src/rename_safety.rs`
+  (`namespace_variable_rename_hazard`)
 
 ## Failure modes
 
@@ -92,6 +119,9 @@ cache.
 
 - `rust/tcl-lsp-core/src/workspace_index.rs` (`mod tests`)
 - `rust/tcl-lsp-server/tests/e2e/issue923_crossdoc.rs`
+- `rust/tcl-lsp-server/tests/e2e/rename_safety.rs` (the variable tier's
+  rename half: TP cross-document, FN-guard proc-local alias, TN sibling
+  namespace, FP-guard computed variable name)
 - `rust/tcl-lsp-server/tests/e2e/issue923_class_refs.rs`
 - `rust/tcl-lsp-server/src/lib.rs` unit tests
   (`watcher_and_rename_globs_cover_every_indexed_extension`,

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -49,16 +49,38 @@ bindings — a per-document identity, so by rule 4 above they do not belong in
 the index — but they name the very same cell, and leaving them behind breaks
 the program.
 
-So the rename tier uses the index only to pick *which documents to visit*
-(`variable_definitions_qualified`, `variable_refs_of`, and
-`documents_in_namespace` — every document declaring anything directly in the
-cell's namespace, since an unqualified alias can only be written there), then
-re-analyses each and computes its share with
+So the rename tier uses the index only to pick *which documents to visit*,
+then re-analyses each and computes its share with
 `tcl_lsp_core::rename::namespace_variable_rename_edits`, which reads
-`VarDef::link_target` for the alias union.  A document in that namespace that
-computes a variable name (`set $n 1`, `variable $n`) refuses the whole rename
-(`tcl_lsp_core::rename_safety::namespace_variable_rename_hazard`) rather than
-emitting an edit set that silently misses it.
+`VarDef::link_target` for the alias union.  Four candidate sources, and all
+four are load-bearing — no one of them subsumes another:
+
+| source | catches |
+| --- | --- |
+| `variable_definitions_qualified` | the documents declaring the cell |
+| `variable_refs_of` | the documents naming it qualified (`$::ns::v`) |
+| `documents_in_namespace` | an unqualified alias written *inside* `::ns` (`namespace eval ns { proc p {} { variable v; … } }`) — proc-scope, so not indexed itself, but its enclosing proc is |
+| `documents_aliasing_variable` | an alias written from *any other* namespace (a global `proc p {} { namespace upvar ::ns v local; … }`) — which declares nothing in `::ns` and writes no qualified occurrence, so all three of the above miss it |
+
+That last table is the one exception to rule 4's "proc locals are not
+indexed", and it is not really an exception: what is recorded is the
+**qualified cell** the alias names — as spellable from another document as a
+declaration is — never the local spelling, which stays a per-document
+question.  It exists because coverage has to be *provable*: without it a
+rename moves the declaration and the alias is left bound to a variable that
+no longer exists (tclsh 9.0.4 / 8.6.16 alike: `can't read "local": no such
+variable`).
+
+Two shapes refuse the rename outright rather than emit an edit set that
+silently misses something:
+
+- a candidate document that **computes a variable name** (`set $n 1`,
+  `variable $n`) — `tcl_lsp_core::rename_safety::namespace_variable_rename_hazard`;
+- any document that **aliases a computed cell** (`namespace upvar $ns v
+  local`) which could be this one — `documents_with_ambiguous_alias_of`.
+  A computed cell names no fixed variable, so it can be neither found by a
+  candidate scan nor rewritten.  The match stays narrow: whichever half of
+  the cell is still written literally must agree with the cell being renamed.
 
 ## Derived views and their invalidation
 
@@ -120,8 +142,9 @@ cache.
 - `rust/tcl-lsp-core/src/workspace_index.rs` (`mod tests`)
 - `rust/tcl-lsp-server/tests/e2e/issue923_crossdoc.rs`
 - `rust/tcl-lsp-server/tests/e2e/rename_safety.rs` (the variable tier's
-  rename half: TP cross-document, FN-guard proc-local alias, TN sibling
-  namespace, FP-guard computed variable name)
+  rename half: TP cross-document, TP out-of-namespace alias, FN-guard
+  proc-local alias, TN sibling namespace, FP-guard computed variable name,
+  FP-guard computed alias cell, FN-guard computed alias of another cell)
 - `rust/tcl-lsp-server/tests/e2e/issue923_class_refs.rs`
 - `rust/tcl-lsp-server/src/lib.rs` unit tests
   (`watcher_and_rename_globs_cover_every_indexed_extension`,

--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -706,32 +706,69 @@ tier 1 24 + tier 2 45 = 69 of the 85 CONFIRMED, leaving 16 — all tier 2, and
 two of those (idx 22 / 98) are the PARTIALs PR C1b narrowed rather than
 untouched findings.
 
-**Residuals left open by PR C3, deliberately** (each needs a decision this PR
-declined to guess at):
+**Residuals PR C3 first left open, then closed in review.** Codex's review of
+PR #1091 raised all three as P1 soundness holes rather than acceptable
+deferrals, and they were fixed in the same PR. Recorded here because the
+reasoning is the useful part:
 
-- The **method-rename safety gate is scanned per document**, over the
-  request's own document plus every override-family document the index
-  names. A *pure-consumer* document — one that only calls the method and
-  declares no part of the class — is rewritten by the consumer leg but is not
-  scanned for hazards, so an untracked-receiver dispatch living only there
-  does not refuse. Completing it needs the consumer-scan plan
-  (`Backend::consumer_scan_plan`) to feed the gate the same document set it
-  feeds the edit collector.
-- **Namespace-variable rename across a `namespace eval` block that declares
-  nothing indexed.** `documents_in_namespace` finds a document by the procs /
-  classes / namespace variables it declares in the cell's namespace; a file
-  whose only content there is `namespace eval ns { puts $v }` (an alias-free
-  bare read, which is not the cell anyway) or an alias inside a `namespace
-  eval` that declares nothing else is not a candidate. Closing it needs the
-  index to record namespace *participation* as its own fact rather than
-  inferring it from declarations.
-- **`upvar` / `namespace upvar` reaching the cell from outside its
-  namespace.** `namespace upvar ::ns v local` writes a qualified occurrence
-  and is rewritten; a `upvar #0 ::ns::v local` likewise. A level-crossing
-  `upvar` whose target is assembled from a variable is caught by the dynamic-
-  name gate and refuses, which is correct but blunt — a per-site provenance
-  answer (the `rename_safe` treatment `WorkspaceInvocation` already gets on
-  the command side) would refuse far less often.
+- **The gate's document set must equal the edit collector's** (issue #1092).
+  The gate originally scanned the request's own document plus the
+  override-family documents; the edit collector also rewrites *pure-consumer*
+  documents — ones that only call the method — through
+  `Backend::consumer_scan_plan`. A gate narrower than the collector is a
+  hollow guarantee: a hazard living only in a consumer document produced no
+  refusal while the declaration moved out from under the call. Both now
+  resolve their document set from the same `consumer_scan_plan` read, and the
+  gate scans each against the same workspace-class-oracle analysis the
+  consumer edit leg uses (memoised, so a document is analysed once between
+  them). Oracle, 9.0.4 / 8.6.16 identically: with `Dog::speak` renamed to
+  `bark` and a consumer's `[$who speak]` left behind, `unknown method
+  "speak": must be bark or destroy`, rc 1.
+- **Alias coverage is a fact, not an inference.** The candidate set was
+  presumed complete because "an unqualified alias can only be written in a
+  document with code in that namespace" — which is false: a *global* `proc p
+  {} { namespace upvar ::ns v local; return $local }` binds `::ns::v` while
+  declaring nothing in `::ns` and writing no qualified occurrence, so it sat
+  in none of the three sources. The compiler now enumerates alias links
+  (`analyser::variable_alias_links`) and the index records the qualified cell
+  each document binds (`documents_aliasing_variable`), so candidacy is looked
+  up rather than assumed. The one shape that cannot be indexed — an alias
+  whose *cell* is computed, `namespace upvar $ns v local` — refuses, matched
+  narrowly on whichever half of the cell is still literal. Oracle: renaming
+  `::mypkg::version` under such an alias gives `can't read "local": no such
+  variable`, rc 1.
+- **An alias's local spelling is not the cell's name.** The rename rewrote
+  each alias's *declaration* span, which for `namespace upvar ::ns v local`
+  is the `local` token — producing `namespace upvar ::ns v total; … $total`
+  and leaving the alias bound to the renamed-away cell (both interpreters:
+  `can't read "total": no such variable`, rc 1). `VarDef::link_target_span`
+  now records which word names the cell, and the rename splits on it:
+  `variable v` / `global ::ns::v` name the cell with their own declaration
+  word, so word and reads travel together; `namespace upvar` / `upvar #0`
+  name it one word earlier, so only that word changes. A same-*spelled*
+  `namespace upvar ::ns v v` takes the minimal edit — both interpreters
+  accept either answer, so the word whose meaning the rename does not change
+  is left alone.
+
+**Residuals still open after that review** (documented, not half-fixed):
+
+- **The gate's fan-out is only as complete as the index.** Its document set
+  is `consumer_scan_plan`'s, which is derived from `method_override_family` /
+  `method_inheritor_classes` / `documents_invoking_classes`. A consumer that
+  reaches an instance without invoking a family constructor in its own text —
+  one handed the object through a global, a `dict`, or a callback registered
+  elsewhere — is in none of those, so neither the edit collector nor the gate
+  sees it. Closing it needs cross-document instance provenance, which the
+  index does not model at all.
+- **A computed alias cell refuses workspace-wide, not per-site.** One
+  `namespace upvar $ns version local` anywhere blocks every rename of any
+  `…::version`. The narrow match (literal half must agree) keeps this from
+  being catastrophic, but a per-site provenance answer — the `rename_safe`
+  treatment `WorkspaceInvocation` already gets on the command side — would
+  refuse far less often.
+- **A level-crossing `upvar` with an assembled target** is caught by the
+  dynamic-name gate and refuses. Correct but blunt, and the same provenance
+  work would fix it.
 
 **By corpus** (confirmed only): ticklecharts 20, tk 17, argparse 10,
 SpiceGenTcl 10, tclopt 13 (6+7, split across two inconsistent corpus-label

--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -632,6 +632,107 @@ definitions when `crossFileResolution` is on, so the diagnostic stops
 contradicting go-to-definition on the very same span (idx 80). On top of PR C1b's idx 58 above, that makes
 **67 fixed, 18 remaining**.
 
+**2026-07-31 update — PR C3
+(`claude/commandregistry-compiler-fixes-tshu8d-rename`) fixed idx 79, the
+last open tier-1 finding — the rename safety gate for untracked receivers:**
+the finding's live half was always "renaming a member emits a `WorkspaceEdit`
+touching only the declaration, and applying it breaks the program". The two
+directions the previous session considered and rejected (broaden
+`lookup_class_member` to `$var method`; a `rename_blocked`-style gate) are
+resolved the second way, built as a first-class mechanism rather than a
+patch: `tcl-lsp-core`'s new
+[`rename_safety`](../../../rust/tcl-lsp-core/src/rename_safety.rs) module,
+whose refusals travel as an **LSP error with a precise reason** (a `null`
+result would read to the editor as "nothing renameable here" — exactly the
+wrong signal when the symbol *is* renameable but the rename would break the
+program). Four hazards refuse: an untracked-receiver dispatch of the renamed
+member (`$other X` where nothing binds `other` to a class — idx 79's own
+shape); a member name computed at run time on a receiver of the family
+(`$obj $m`, and `my $m` through the registry's own self-dispatch keyword); an
+object command bound by two different classes; and an `export` / `unexport` /
+`filter` recorded for the member whose word cannot be located to rewrite.
+Everything else renames as before — the over-refusal risk the earlier note
+flagged is bounded by three FN guards: a receiver tracked to an *unrelated*
+class is provably not this dispatch, an untracked receiver naming a
+*different* member is irrelevant, and a literal `my method` is exactly what
+the reference scan already rewrites.
+
+Two further faults were found and fixed while building the gate, both of the
+same "the emitted edit set breaks the program" family. First, **rename never
+rewrote the class's own `export` list** — and a `TclOO` method whose name
+starts with an upper-case letter is unexported by default (probed on 9.0.4:
+`oo::class create A { method Foo {} {return 1} }; [A new] Foo` errors
+`unknown method "Foo": must be destroy`), so `method Foo` + `export Foo`
+renamed to `Bar` left `Bar` unexported and every call to it failing
+(`unknown method "Bar": must be destroy`, identical on 8.6.16). That is why
+idx 79's own corpus file carries `export X Y Z Get` at all. The `export` /
+`unexport` / `filter` / `deletemethod` / `renamemethod` words are the
+registry's own [`MemberRefKind::Method`] members, so
+`references::member_reference_spans` collects them from the definer grammar
+with no member keyword named in the walker, and both find-references and
+rename read them from that one place. Second, **issue #981's object-command
+residual**: `created_instance_commands` was a bare-name set, so
+`::a::Factory create rex` and `::b::Widget create rex` were one name.
+tclsh 9.0.4 / 8.6.16 agree they are two coexisting commands (`rex make`
+prints `a-made` inside `::a` and `b-made` inside `::b`), and renaming
+`::b::Widget::make` while also rewriting `::a`'s `rex make` — what the server
+emitted — makes both interpreters fail `unknown method "produce": must be
+destroy or make`. The analyser now records the creation site's namespace
+(`AnalysisResult::instance_command_bindings`) and the dispatch scanner
+resolves a written head against the call site's own namespace with the same
+`command_resolution_candidates` rule PR #1063 applied to classmethods, fixing
+the cross-namespace false positive **and** the lost-own-site false negative
+in one step.
+
+The PR also wires **rename to the workspace namespace-variable tier** PR
+#1086 built the reference set for. The index alone cannot drive it: it holds
+namespace-scoped declarations and qualified occurrences, but a rename must
+also rewrite the `variable v` / `global v` / `namespace upvar` aliases inside
+proc bodies and their unqualified `$v` reads, which are proc-scope bindings
+the index deliberately does not carry. So the index picks *which documents to
+visit* (`documents_in_namespace`, new) and each is re-analysed and rewritten
+through `VarDef::link_target`. A collision with an existing cell, or a
+document in that namespace computing a variable name (a registry
+`ArgRole::VarWrite` / `VarRead` word that `names_a_dynamic_variable`),
+refuses. That makes **69 fixed, 16 remaining** — tier 1 is now **24 of 24**
+(idx 79 was its last open finding) and tier 2 stays 45 of 61.
+
+*Counts recomputed from the two priority tables themselves, not carried
+forward.* The running total the PR C2 paragraph above states (67 fixed / 18
+remaining) is one low against the tables it summarises: tier 1 already read
+23 fixed and tier 2's own header 45, i.e. 68 fixed / 17 remaining before this
+PR. The tables are the per-finding record and win; the arithmetic here is
+tier 1 24 + tier 2 45 = 69 of the 85 CONFIRMED, leaving 16 — all tier 2, and
+two of those (idx 22 / 98) are the PARTIALs PR C1b narrowed rather than
+untouched findings.
+
+**Residuals left open by PR C3, deliberately** (each needs a decision this PR
+declined to guess at):
+
+- The **method-rename safety gate is scanned per document**, over the
+  request's own document plus every override-family document the index
+  names. A *pure-consumer* document — one that only calls the method and
+  declares no part of the class — is rewritten by the consumer leg but is not
+  scanned for hazards, so an untracked-receiver dispatch living only there
+  does not refuse. Completing it needs the consumer-scan plan
+  (`Backend::consumer_scan_plan`) to feed the gate the same document set it
+  feeds the edit collector.
+- **Namespace-variable rename across a `namespace eval` block that declares
+  nothing indexed.** `documents_in_namespace` finds a document by the procs /
+  classes / namespace variables it declares in the cell's namespace; a file
+  whose only content there is `namespace eval ns { puts $v }` (an alias-free
+  bare read, which is not the cell anyway) or an alias inside a `namespace
+  eval` that declares nothing else is not a candidate. Closing it needs the
+  index to record namespace *participation* as its own fact rather than
+  inferring it from declarations.
+- **`upvar` / `namespace upvar` reaching the cell from outside its
+  namespace.** `namespace upvar ::ns v local` writes a qualified occurrence
+  and is rewritten; a `upvar #0 ::ns::v local` likewise. A level-crossing
+  `upvar` whose target is assembled from a variable is caught by the dynamic-
+  name gate and refuses, which is correct but blunt — a per-site provenance
+  answer (the `rename_safe` treatment `WorkspaceInvocation` already gets on
+  the command side) would refuse far less often.
+
 **By corpus** (confirmed only): ticklecharts 20, tk 17, argparse 10,
 SpiceGenTcl 10, tclopt 13 (6+7, split across two inconsistent corpus-label
 strings in the raw data — same corpus), tomato 7, pix 8.
@@ -641,7 +742,7 @@ namespaces 11, proc_args 10, upvar 7, source 6, tcl_mathop 5, rename 4,
 package_loading 3, uplevel 3, tracing 3, aliasing 2, safe_interp 2, eval 1,
 autoindex 1.
 
-#### Priority tier 1 — critical + high (24 findings, 23 already fixed)
+#### Priority tier 1 — critical + high (24 findings, all 24 fixed)
 
 Fix these first — each is either data-loss-risk (a rename that silently
 breaks the program, idx 61) or a full-zero-results failure of a core
@@ -671,7 +772,7 @@ not a substitute.
 | 71 | high | pix | source | **FIXED** (`2339d4a`) — find-references dropped every call site in the same document a query was issued from whenever that document has no local declaration (a proc reached only through a `source`d-in/sibling file); the `.test`-extension half was already fixed by idx 10. |
 | 76 | high | tomato | tclOO | **FIXED** (`0bde16e`) — the headline "wrong class guessed" hypothesis is REFUTED (correct abstention); tracing it found hover had no resolution path at all for a plain `my methodName` call, unlike already-working go-to-definition/references. |
 | 77 | high | tomato | tclOO | **FIXED** (`51a630f`) — the whole CFG/SSA dataflow diagnostic family (W210 and siblings) never ran on any TclOO/snit method body; the crash-causing unbound `$other` read now flags. |
-| 79 | high | tomato | proc_args | **INVESTIGATED, NOT FIXED** (session of 2026-07-23) — see the dedicated note right after this table for why: the audit's own "definition/hover resolve, references/rename don't" framing is now stale (idx 113 already narrowed `lookup_class_member` to require `link`, so definition/hover now *also* abstain on this shape), but the underlying rename-safety risk it flagged is still real and a sound fix needs receiver-type inference this campaign doesn't have. |
+| 79 | high | tomato | proc_args | **FIXED** (PR C3) — rename emitted a declaration-only `WorkspaceEdit` for a member also dispatched on an untracked receiver (`[$other X]` in a copy constructor); applying it broke the program on both interpreters. Now refused, with a precise LSP error, by the new `rename_safety` gate — plus two faults found alongside it: the `export` list was never renamed with the method, and issue #981's object-command dispatch was namespace-blind. See the dedicated note after this table. |
 | 84 | high | tk | namespaces | **PARTIALLY FIXED** (`7115bc8`) — `namespace ensemble configure` (as opposed to `create`) was invisible to the analyser, so the real `tk/library/systray.tcl` (and `print.tcl`/`fileicon.tcl`/`accessibility.tcl`) idiom of splicing `systray`/`sysnotify` onto the pre-existing `tk` ensemble drew 5 false W001s and risked wrong go-to-definition/hover navigation for the 2-word shape; both now fixed. The 3rd-word case (`tk systray create`/…) remains open — a separate, general, pre-existing limitation, not idx-84-specific; see the dedicated note after this table. |
 | 86 | high | tk | rename | **FIXED** (`99cf07f`) — `tk/library/accessibility.tcl`'s `foreach wtype {...} { rename ::$wtype ::tk::ac... }` loop-generated rename/proc targets weren't tracked (nor was a plain `proc ::$wtype {...}` outside any loop — `proc`'s name never attempted constant-folding at all); go-to-definition on a post-rename call fell through to the stale original, and the outline showed a garbled `${wtype}`-named entry. |
 | 90 | high | tk | safe_interp | **FIXED** (`7d476f5`) — `tcl::OptProc` (the `opt` package's automatic-option-parsing proc definer) had no `AnalyserHookId` at all, so `all_procs` kept a stub `{}`-arity `ProcDef` for every real call — false E003, and wrong hover/go-to-definition/references/document-symbol signature. |
@@ -745,9 +846,35 @@ session:
   false-positive risk as the first option, depending on how conservatively
   it's tuned.
 
-Left open for a future session with more room to design the safety-gate
-direction carefully — not attempted lightly, and not silently: this note is
-that record.
+**Resolved 2026-07-31 by PR C3** — the second direction, built properly.
+`tcl-lsp-core`'s new [`rename_safety`](../../../rust/tcl-lsp-core/src/rename_safety.rs)
+module is the gate, and the tuning worry the note raised is answered by
+making the *receiver's binding state*, not the mere presence of a `$var
+method` shape, the deciding fact:
+
+| receiver | member word | verdict | why |
+|---|---|---|---|
+| tracked to a family class | literal | rename | the reference scan already finds and rewrites the site |
+| tracked to an unrelated class | literal | rename | that dispatch provably reaches the other class's table |
+| **untracked** | literal, == the renamed member | **refuse** | may be this class; nothing proves it is not (idx 79's own `[$other X]`) |
+| untracked | literal, some other member | rename | cannot affect the member being renamed |
+| tracked to a family class | computed (`$m` / `[…]`) | **refuse** | no edit keeps `$obj $m` consistent with a renamed declaration |
+| `my` (registry self-dispatch keyword) | computed | **refuse** | same, from inside the class |
+
+So a class full of internal `$var method` helpers still renames freely
+whenever those receivers are bound (`set v [Cls new]`) or name a different
+member — the false-abstention case the note worried about — while the exact
+shape the finding is about refuses. Refusals travel as an **LSP error with
+the reason**, not a `null` result, so the editor tells the user rather than
+appearing to do nothing.
+
+Two adjacent faults surfaced while building it and are fixed in the same PR:
+the `export` list was never renamed with the method (an upper-case-named
+`TclOO` method is unexported by default, so `method Foo` + `export Foo`
+renamed to `Bar` left `Bar` unexported — `unknown method "Bar": must be
+destroy` on 9.0.4 and 8.6.16 alike; this is exactly why the corpus file
+carries `export X Y Z Get`), and issue #981's object-command dispatch was
+namespace-blind. See the PR C3 paragraph in the running ledger above.
 
 **idx 84, in detail (partially fixed — `CONFIGURE`-tracking landed, 3rd-word
 navigation deliberately deferred):** the finding's own repro is real:

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -122,10 +122,24 @@ When nothing binds the name, Find All References returns nothing rather than
 falling back to a command or method of the same name — a `$`-led token can
 only ever be the variable.
 
+### Method-name references in a class body
+
+A method's references include the definition-body words that *name* it, not
+just the calls that dispatch it: `export m`, `unexport m`, `filter m`,
+`deletemethod m`, `renamemethod m n`. Those are the registry's own
+method-reference members, so the same list holds for `TclOO`, snit, and
+[incr Tcl] without the provider naming a keyword. They matter beyond
+completeness: a `TclOO` method whose name starts with an upper-case letter is
+unexported by default, so an `export` list that disagrees with its
+declaration is a broken class, and Rename rewrites those words for exactly
+that reason.
+
 ## File-path anchors
 
 - `rust/tcl-lsp-core/src/references.rs` (`find_obj_method_call_sites` —
-  instance dispatch plus a classmethod's own-class-command dispatch)
+  instance dispatch plus a classmethod's own-class-command dispatch;
+  `member_reference_spans` — `export` / `unexport` / `filter` method-name
+  words, from the definer grammar)
 - `rust/tcl-lsp-core/src/caller_frame.rs` (caller-frame variables — the
   call-site word and the reads it feeds, shared with Hover and Go to
   Definition)
@@ -171,14 +185,22 @@ only ever be the variable.
   guarded in the other direction too: `Factory make` there is itcl's
   instance-creation syntax (`ClassName instanceName`), never a class-proc
   dispatch, and is never counted as one.
-- A `CLASS create NAME` object command (`rex bark`) is matched by name text
-  alone. Two object commands called `rex` in different namespaces are one
-  name as far as the analyser is concerned — it records instance-command
-  names without their creating namespace — so a bare `rex bark` in either
-  namespace counts for whichever `rex` the analyser bound first. A
-  classmethod's own-class-command dispatch (`Factory make`) does **not**
-  have this problem: it is resolved against the call's own namespace, first
-  the current one and then the global one, exactly as Tcl resolves it.
+- A `CLASS create NAME` object command (`rex bark`) is resolved against the
+  call's own namespace, exactly like a classmethod's class-command dispatch
+  (`Factory make`). `CLASS create NAME` binds `NAME` in the *creation site's*
+  namespace, so `::a::Factory create rex` and `::b::Widget create rex` are
+  two different commands that coexist (tclsh 9.0 and 8.6 both dispatch `rex
+  make` inside `::a` to `::a::rex` and inside `::b` to `::b::rex`), and the
+  two are never cross-linked. This was issue #981's object-command half,
+  closed by PR C3: previously the two were one flat name, so references on
+  one class's method counted the other's call site and a rename rewrote it.
+  Object commands created by a *registry* object factory (a Tk widget path,
+  a tcllib naming factory) still match by bare name — those carry no
+  creating user class to attribute a dispatch to in the first place.
+- When two different classes bind the **same qualified** object command in
+  one namespace, which class a later `NAME method` reaches is a runtime
+  fact. References still report both call sites; **rename refuses**, with a
+  reason (see [Rename](kcs-feature-rename.md)).
 
 ## Test anchors
 
@@ -192,7 +214,8 @@ only ever be the variable.
   angle-bracketed method names; `itcl_class_proc_dispatch` — the
   colon-qualified [incr Tcl] class-proc TP/FP/TN matrix;
   `namespace_scoped_class_dispatch` — two same-named classes in different
-  namespaces are not cross-linked)
+  namespaces are not cross-linked, and (PR C3) two same-named `CLASS create
+  NAME` object commands in different namespaces are not either)
 - `rust/tcl-lsp-core/src/references.rs` (`mod tests`, including
   `references_for_property_includes_decl_and_my_dispatch_call_sites`,
   `references_disambiguates_property_and_method_sharing_a_name_by_cursor`,

--- a/docs/kcs/features/kcs-feature-rename.md
+++ b/docs/kcs/features/kcs-feature-rename.md
@@ -89,12 +89,21 @@ destroy` for the renamed method.
 Renaming a **namespace variable** written with a `::` qualifier
 (`$::ns::v`, `set app::ns::v 1`) renames the cell across the whole
 workspace: the `variable v` declaration wherever it lives, every
-`variable` / `global` / `namespace upvar` alias of it inside a proc or
-method body *and* that alias's own unqualified `$v` reads, and every
-qualified occurrence in any file. An unqualified `$v` that is not such an
-alias is deliberately left alone — a bare name means whatever the local
-scope chain supplies, which is a per-file question the cell's identity
-cannot answer.
+`variable` / `global` / `namespace upvar` / `upvar #0` alias of it — in any
+file and any namespace, including a global proc that only does `namespace
+upvar ::ns v local` — and every qualified occurrence anywhere. An
+unqualified `$v` that is not such an alias is deliberately left alone: a bare
+name means whatever the local scope chain supplies, which is a per-file
+question the cell's identity cannot answer.
+
+Which *word* of an alias changes depends on which one names the cell.
+`variable v` and `global ::ns::v` name it with the very word that introduces
+the local alias, so renaming the cell renames that word **and** every
+unqualified `$v` it enables. `namespace upvar ::ns v local` names it one word
+earlier: only that `v` changes, and `local` (with all its reads) is left
+exactly as written, because the cell's name never determined it. Rewriting
+`local` instead would leave the alias pointing at the cell that was renamed
+away — `can't read "total": no such variable` on tclsh 9.0 and 8.6 alike.
 
 A method, a classmethod, and a property can share one name within the same
 class (rare, but each lives in its own independent table, so it's legal);
@@ -124,8 +133,16 @@ code. The gate refuses when:
 - an `export` / `unexport` / `filter` naming the member was recorded but its
   word cannot be located to rewrite;
 - for a namespace variable: the new name would **collide** with a cell that
-  already exists, or a file in that namespace **computes a variable name**
-  (`set $n 1`, `variable $n`) that might be this very cell.
+  already exists, a file in that namespace **computes a variable name**
+  (`set $n 1`, `variable $n`) that might be this very cell, or a file
+  **aliases a cell computed at run time** (`namespace upvar $ns v local`)
+  that could be this one.
+
+The gate is checked across **every file the rename would edit** — the class's
+own file, every file defining or extending a class in its override family,
+and every file that merely *calls* the member. A dispatch it cannot account
+for in any of them refuses the whole rename, because a rename that is only
+partly safe is not safe at all.
 
 In each case, running **Find References** first shows you what rename can and
 cannot see.
@@ -143,7 +160,8 @@ cannot see.
   example a `foreach` list element), no edit set can keep that dispatch
   working, so the rename is refused outright.
 - The editor shows an error naming an untracked receiver, a computed member
-  name, an ambiguous object command, or a computed variable name. That is
+  name, an ambiguous object command, a computed variable name, or a computed
+  alias cell. That is
   the safety gate above: the rename is refused deliberately, because the
   edit set it could produce would change what the program does. Give the
   receiver a spelling the analyser can follow (`set other [Vector3d new

--- a/docs/kcs/features/kcs-feature-rename.md
+++ b/docs/kcs/features/kcs-feature-rename.md
@@ -78,11 +78,57 @@ bare-callable command (only `my method` dispatches it), a method / property
 rename only ever rewrites `my`-dispatched sites — never an unrelated bare
 command invocation that happens to share the renamed name.
 
+Renaming a method also rewrites the class's own `export` / `unexport` /
+`filter` lists, which name methods rather than merely mentioning them.
+Leaving one behind is not cosmetic: a `TclOO` method whose name starts with
+an upper-case letter is *unexported* by default, so a class that writes
+`method Foo {} {...}` plus `export Foo` stops working the moment the two
+disagree — tclsh 9.0 and 8.6 both answer `unknown method "Bar": must be
+destroy` for the renamed method.
+
+Renaming a **namespace variable** written with a `::` qualifier
+(`$::ns::v`, `set app::ns::v 1`) renames the cell across the whole
+workspace: the `variable v` declaration wherever it lives, every
+`variable` / `global` / `namespace upvar` alias of it inside a proc or
+method body *and* that alias's own unqualified `$v` reads, and every
+qualified occurrence in any file. An unqualified `$v` that is not such an
+alias is deliberately left alone — a bare name means whatever the local
+scope chain supplies, which is a per-file question the cell's identity
+cannot answer.
+
 A method, a classmethod, and a property can share one name within the same
 class (rare, but each lives in its own independent table, so it's legal);
 renaming resolves to whichever declaration the cursor actually sits on
 rather than a fixed priority, so the rename never silently retargets a
 different member than the one you clicked.
+
+### When rename refuses
+
+Rename answers with an **error and a reason**, not a silent no-op, whenever
+it can see that no edit set would keep the program running. Precision is the
+point: a refused rename costs you a keystroke, a wrong one silently breaks
+code. The gate refuses when:
+
+- a member of the class you are renaming is dispatched on a **receiver whose
+  class is not tracked** — `$other X` where `$other` came from `lindex
+  $args 0`, a `dict get`, or any other value the source does not tie to a
+  constructor. The call may well reach the member you are renaming (real
+  `TclOO` code does exactly this in copy constructors), and nothing in the
+  source proves it does not;
+- a member name is **computed at run time** on a receiver of the class —
+  `$obj $m`, `my $m`. No edit can keep such a site consistent with a renamed
+  declaration;
+- two different classes bind the **same object command** (`Factory create
+  rex` and `Widget create rex` in one namespace), so which class a later
+  `rex make` reaches is a runtime fact;
+- an `export` / `unexport` / `filter` naming the member was recorded but its
+  word cannot be located to rewrite;
+- for a namespace variable: the new name would **collide** with a cell that
+  already exists, or a file in that namespace **computes a variable name**
+  (`set $n 1`, `variable $n`) that might be this very cell.
+
+In each case, running **Find References** first shows you what rename can and
+cannot see.
 
 ## Failure modes
 
@@ -96,6 +142,13 @@ different member than the one you clicked.
   gets its value from a constant with no exact source spelling (for
   example a `foreach` list element), no edit set can keep that dispatch
   working, so the rename is refused outright.
+- The editor shows an error naming an untracked receiver, a computed member
+  name, an ambiguous object command, or a computed variable name. That is
+  the safety gate above: the rename is refused deliberately, because the
+  edit set it could produce would change what the program does. Give the
+  receiver a spelling the analyser can follow (`set other [Vector3d new
+  ...]`) — or rename by hand, checking each site — rather than expecting a
+  partial edit set.
 
 ## Screenshots
 

--- a/editors/vscode/src/test/renameSymbol.test.ts
+++ b/editors/vscode/src/test/renameSymbol.test.ts
@@ -206,6 +206,84 @@ suite("Rename Symbol", () => {
     );
   });
 
+  // Issue #923 finding idx 79 — the rename **safety gate**.
+  //
+  // `$other` in `Vector3d`'s copy constructor really is a `Vector3d` at run
+  // time (tclsh 9.0.4 / 8.6.16 both print `7 9 7 9` for this fixture), but it
+  // comes from `[lindex $args 0]` behind a runtime `info object isa` test, so
+  // the analyser has no class binding for it.  Renaming `X` used to emit an
+  // edit set touching only the declaration and the `export` list; applying it
+  // and re-running gives, on both interpreters:
+  //
+  //   unknown method "X": must be Get, GetX, Y or destroy
+  //       while executing
+  //   "$other X"
+  //
+  // The server now refuses with an LSP error, so VS Code surfaces the reason
+  // instead of quietly applying nothing.  This test is the editor-facing half:
+  // the command must *reject*, not resolve to an empty edit.
+  test("rename refuses a method dispatched on an untracked receiver", async () => {
+    const uri = getDocUri("renameUntrackedReceiver.tcl");
+    await activate(uri);
+
+    // `X` in `method X {} { return $_x }` — line 14 (0-based), col 11.
+    const pos = new vscode.Position(14, 11);
+
+    let rejected: unknown;
+    let resolved: vscode.WorkspaceEdit | undefined;
+    try {
+      resolved = (await vscode.commands.executeCommand(
+        "vscode.executeDocumentRenameProvider",
+        uri,
+        pos,
+        "GetX",
+      )) as vscode.WorkspaceEdit | undefined;
+    } catch (err) {
+      rejected = err;
+    }
+
+    assert.ok(
+      rejected !== undefined,
+      `the rename must be refused, not answered with ${JSON.stringify(
+        resolved?.entries().map(([u, edits]) => [u.path, edits.length]),
+      )}`,
+    );
+    assert.match(
+      String(rejected),
+      /not tracked/,
+      `the refusal must carry the gate's reason: ${String(rejected)}`,
+    );
+  });
+
+  // FN guard for the gate above: a member the untracked receiver never names
+  // still renames normally — over-refusal would make the feature unusable on
+  // any class with an internal `$var method` helper.
+  test("rename still applies for a member the untracked receiver never names", async () => {
+    const uri = getDocUri("renameUntrackedReceiver.tcl");
+    await activate(uri);
+
+    // `Get` in `method Get {} { ... }` — line 16 (0-based), col 11.
+    const pos = new vscode.Position(16, 11);
+
+    const edit = (await vscode.commands.executeCommand(
+      "vscode.executeDocumentRenameProvider",
+      uri,
+      pos,
+      "Fetch",
+    )) as vscode.WorkspaceEdit | undefined;
+
+    assert.ok(edit, "an unaffected member must still rename");
+    const docEntry = edit!.entries().find(([u]) => u.toString() === uri.toString());
+    assert.ok(docEntry, "Should include edits for renameUntrackedReceiver.tcl");
+    const lines = docEntry![1].map((te) => te.range.start.line);
+    assert.ok(
+      lines.includes(16) && lines.includes(17),
+      `the declaration (16) and its \`export\` word (17) must both rename; got ${JSON.stringify(
+        lines,
+      )}`,
+    );
+  });
+
   // Issue #923: renaming a class must rewrite every `superclass` site that
   // names it, or the inheritance graph is silently broken.  In `oo-shapes.tcl`
   // both `Dog` and `Cat` declare `superclass Animal`.

--- a/editors/vscode/testFixture/renameUntrackedReceiver.tcl
+++ b/editors/vscode/testFixture/renameUntrackedReceiver.tcl
@@ -1,0 +1,22 @@
+# Issue #923 differential-audit finding idx 79 — an untracked receiver.
+oo::class create Vector3d {
+    variable _x _y
+    constructor {args} {
+        if {[llength $args] == 1} {
+            set other [lindex $args 0]
+            if {[info object isa typeof $other ::Vector3d]} {
+                set _x [$other X]
+                set _y [$other Y]
+            }
+        } else {
+            lassign $args _x _y
+        }
+    }
+    method X {} { return $_x }
+    method Y {} { return $_y }
+    method Get {} { return "$_x $_y" }
+    export X Y Get
+}
+set v1 [Vector3d new 7 9]
+set v2 [Vector3d new $v1]
+puts "[$v1 Get] [$v2 Get]"

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -797,7 +797,8 @@ impl Analyser {
             // `Cls create inst`) so the LSP providers can resolve
             // ``$v method`` / ``inst method`` call sites to the
             // object's class.
-            self.record_instance_creation(cmd_name, args);
+            let creation_ns = self.command_resolution_namespace(scope_path);
+            self.record_instance_creation(cmd_name, args, &creation_ns);
 
             // When the constructor's class head is a `$var` reference
             // instead of a literal bareword, defer to the flow-sensitive
@@ -3023,7 +3024,12 @@ impl Analyser {
     /// excluded because `oo::class` isn't a user class).
     /// Best-effort and not flow-sensitive: the last assignment
     /// to a given name wins.
-    pub(crate) fn record_instance_creation(&mut self, cmd_name: &str, args: &[String]) {
+    pub(crate) fn record_instance_creation(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        creation_ns: &str,
+    ) {
         // Registry `defines_command_at` — a spec-declared argument whose
         // literal value becomes a callable command name (`coroutine NAME cmd
         // …`, `interp create NAME`).  Registry data only, so it is recorded
@@ -3050,7 +3056,7 @@ impl Analyser {
             let shape_b = args.len() >= 2 && args[0] == "create";
             // A registry factory already bound above needs no user-class replay.
             if (shape_a || shape_b) && !bound_registry_factory {
-                pending.push((cmd_name.to_owned(), args.to_vec()));
+                pending.push((cmd_name.to_owned(), args.to_vec(), creation_ns.to_owned()));
             }
             return;
         }
@@ -3077,8 +3083,20 @@ impl Analyser {
                 // Known user class: record the object → class mapping (for
                 // `$obj method` / method validation) and the created command
                 // name.
-                self.result.instance_classes.insert(name.clone(), class_q);
+                self.result
+                    .instance_classes
+                    .insert(name.clone(), class_q.clone());
                 self.result.created_instance_commands.insert(name.clone());
+                // …plus the namespace-qualified binding the dispatch scanner
+                // needs to tell `::a::rex` from `::b::rex` (issue #981).
+                let qualified_name = crate::naming::qualify(creation_ns, name);
+                let binding = super::types::InstanceCommandBinding {
+                    qualified_name,
+                    class_q,
+                };
+                if !self.result.instance_command_bindings.contains(&binding) {
+                    self.result.instance_command_bindings.push(binding);
+                }
             } else if self.command_head_could_be_external_class(cmd_name) {
                 // Unknown (external-package) class: the `create NAME` idiom
                 // still binds a new command, so register the name to suppress

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -649,7 +649,10 @@ impl Analyser {
                 } else {
                     format!("::{name}")
                 };
-                self.set_var_link_target(local, scope_path, target);
+                // The declaration word *is* the cell's name here (`global v`
+                // / `global ::ns::v`), so a rename of the cell rewrites this
+                // very word — see `VarDef::link_target_span`.
+                self.set_var_link_target(local, scope_path, target, tok.span);
             }
         }
     }
@@ -694,7 +697,8 @@ impl Analyser {
                 } else {
                     format!("{ns_prefix}::{}", args[i])
                 };
-                self.set_var_link_target(local, scope_path, target);
+                // As with `global`, the declaration word names the cell.
+                self.set_var_link_target(local, scope_path, target, tok.span);
             }
             i += if i + 1 < args.len() { 2 } else { 1 };
         }
@@ -3761,8 +3765,13 @@ impl Analyser {
             // it rather than record the substitution text.
             if !crate::naming::is_dynamic_word(&args[i]) {
                 self.define_var(&args[i], arg_tokens[i], scope_path, false, None);
-                if let Some(target) = Self::upvar_link_target(&args[i - 1], level) {
-                    self.set_var_link_target(&args[i], scope_path, target);
+                if let Some(target) = Self::upvar_link_target(&args[i - 1], level)
+                    && let Some(other_tok) = arg_tokens.get(i - 1)
+                {
+                    // `otherVar` (at `i - 1`) names the cell; `args[i]` is an
+                    // independent local spelling.  Renaming the cell must
+                    // rewrite the former, never the latter.
+                    self.set_var_link_target(&args[i], scope_path, target, other_tok.span);
                 }
             }
             i += 2;
@@ -3836,7 +3845,11 @@ impl Analyser {
                 } else {
                     format!("{target_ns}::{other}")
                 };
-                self.set_var_link_target(&args[i], scope_path, target);
+                if let Some(other_tok) = arg_tokens.get(i - 1) {
+                    // `otherVar` (at `i - 1`) names the cell, not the local
+                    // alias at `i` — see `VarDef::link_target_span`.
+                    self.set_var_link_target(&args[i], scope_path, target, other_tok.span);
+                }
             }
             i += 2;
         }

--- a/rust/tcl-compiler/src/analyser/mod.rs
+++ b/rust/tcl-compiler/src/analyser/mod.rs
@@ -77,9 +77,9 @@ pub use item_tree::{FileDecls, Item, ItemId, ItemKind, ItemSig, ItemTree};
 // core light) can share it. Re-exported here so `tcl_compiler::analyser::…`
 // callers are unchanged.
 pub use scope::{
-    command_resolution_namespace_at, innermost_scope_is_oo_method_frame,
+    VariableAliasLink, command_resolution_namespace_at, innermost_scope_is_oo_method_frame,
     innermost_scope_reaches_oo_helpers, lookup_var_by_qualified_name, lookup_var_in_namespace,
-    namespace_variables, qualified_name_for_var_decl,
+    namespace_variables, qualified_name_for_var_decl, variable_alias_links,
 };
 pub use snapshot::AnalyserSnapshot;
 pub use state::{Analyser, NonAsciiMode};

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -898,6 +898,10 @@ fn merge_one_var(
         // deferred proc body).
         if existing.link_target.is_none() {
             existing.link_target = v.link_target;
+            // The span of the word naming that cell travels with it — the two
+            // are one fact (see `VarDef::link_target_span`), so they must never
+            // be merged apart.
+            existing.link_target_span = v.link_target_span;
         }
     } else {
         dst.insert(k, v);
@@ -910,6 +914,12 @@ fn shift(s: tcl_lexer::Span, d: u32) -> tcl_lexer::Span {
 
 fn rebase_vardef(v: &mut super::types::VarDef, d: u32) {
     v.definition_span = shift(v.definition_span, d);
+    // The cell-naming word is a span into the same body and rebases with the
+    // rest; leaving it body-relative would point a rename at the wrong bytes
+    // of the whole document.
+    if let Some(span) = v.link_target_span {
+        v.link_target_span = Some(shift(span, d));
+    }
     for r in &mut v.references {
         *r = shift(*r, d);
     }

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -622,8 +622,8 @@ impl Analyser {
         // `all_classes` (in body/source order, so last-assignment-wins matches
         // the whole-file walk).  `instance_classes` carries no spans, so no
         // rebasing is needed.
-        for (cmd, args) in frag.instances {
-            self.record_instance_creation(&cmd, &args);
+        for (cmd, args, creation_ns) in frag.instances {
+            self.record_instance_creation(&cmd, &args, &creation_ns);
         }
     }
 
@@ -726,9 +726,10 @@ pub struct BodyFragment {
         Vec<super::types::CodeFix>,
         tcl_lexer::Span,
     )>,
-    /// Captured `TclOO` instance-creation candidates (`(command, args)`); the graft
-    /// replays them against the shell's full `all_classes`.
-    instances: Vec<(String, Vec<String>)>,
+    /// Captured `TclOO` instance-creation candidates (`(command, args, creation
+    /// namespace)`); the graft replays them against the shell's full
+    /// `all_classes`.
+    instances: Vec<(String, Vec<String>, String)>,
 }
 
 /// Analyse one `proc` **or method** body as an isolated unit at **offset 0** — a

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -431,6 +431,72 @@ pub fn namespace_variables(root: &Scope) -> Vec<(String, &VarDef)> {
     out
 }
 
+/// One local **alias** of a namespace/global cell: the cell it names, and the
+/// [`VarDef`] holding the alias.
+///
+/// See [`variable_alias_links`].
+#[derive(Debug, Clone, Copy)]
+pub struct VariableAliasLink<'a> {
+    /// The `::`-rooted cell the alias binds to (`VarDef::link_target`).
+    pub cell: &'a str,
+    /// The alias record itself — its [`VarDef::link_target_span`] is the word
+    /// a rename of `cell` must rewrite, and its own `definition_span` /
+    /// `references` are the local spelling.
+    pub var: &'a VarDef,
+}
+
+/// Every variable in `root` that **aliases** a namespace/global cell — a
+/// `variable v`, `global v`, `namespace upvar ns v local`, or `upvar #0 ::ns::v
+/// local` — paired with the cell it binds.
+///
+/// The alias counterpart of [`namespace_variables`], and the second half of
+/// the same rule: `namespace_variables` enumerates the cells a document
+/// *declares*, this enumerates the ones it *binds to*.  Unlike declarations,
+/// an alias can live in any scope and in any namespace — a global `proc p {}
+/// { namespace upvar ::ns v local; … }` binds `::ns::v` from `::`, declaring
+/// nothing in `::ns` and writing no qualified occurrence — so both consumers
+/// need this walk to answer completely:
+///
+/// * the workspace index, so a rename of `::ns::v` visits every document that
+///   binds the cell rather than only those declaring or spelling it
+///   (`WorkspaceIndex::documents_aliasing_variable`);
+/// * the rename itself, so the word naming the cell is the word rewritten.
+///
+/// Every scope kind is walked, precisely because a proc's locals are where
+/// aliases live.
+#[must_use]
+pub fn variable_alias_links(root: &Scope) -> Vec<VariableAliasLink<'_>> {
+    fn walk<'a>(node: &'a Scope, out: &mut Vec<VariableAliasLink<'a>>) {
+        for var in node.variables.values() {
+            if let Some(cell) = var.link_target.as_deref() {
+                out.push(VariableAliasLink { cell, var });
+            }
+        }
+        for child in &node.children {
+            walk(child, out);
+        }
+    }
+    let mut out = Vec::new();
+    walk(root, &mut out);
+    // `Scope::variables` is a `HashMap`, so the per-node order is the process
+    // hash seed's; sort by declaration span (then cell) for the same reason
+    // `namespace_variables` does — a stable, source-ordered index.
+    out.sort_by(|a, b| {
+        a.var
+            .definition_span
+            .start()
+            .cmp(&b.var.definition_span.start())
+            .then(
+                a.var
+                    .definition_span
+                    .end()
+                    .cmp(&b.var.definition_span.end()),
+            )
+            .then_with(|| a.cell.cmp(b.cell))
+    });
+    out
+}
+
 /// Bundles the field-disjoint borrows [`Analyser::finalise_invocation_resolutions`]'s
 /// call-site "is `qualified` known, for a call at `call_off`?" predicate
 /// needs, and the small body/enclosing-definition/liveness helpers it's
@@ -1677,6 +1743,7 @@ impl Analyser {
                 warn_if_unused,
                 array_indices: indices,
                 link_target: None,
+                link_target_span: None,
             };
             scope.variables.insert(base_owned.clone(), var.clone());
             let key = format!("{}::{base_owned}", scope.name);
@@ -1689,12 +1756,26 @@ impl Analyser {
     /// upvar` binding), so Find-References / Rename can unify every alias of the
     /// same cell.  A no-op if the variable wasn't defined (call after
     /// [`Self::define_var`]).
-    pub fn set_var_link_target(&mut self, name: &str, scope_path: &[usize], target: String) {
+    ///
+    /// `target_span` is the span of the **word that names the cell**, which is
+    /// not always the declaration word: `variable v` / `global ::ns::v` name
+    /// the cell with the very word that introduces the local alias, but
+    /// `namespace upvar ::ns v local` / `upvar #0 ::ns::v local` name it one
+    /// word earlier.  Recording it is what lets a rename of the cell rewrite
+    /// the right word — see [`VarDef::link_target_span`].
+    pub fn set_var_link_target(
+        &mut self,
+        name: &str,
+        scope_path: &[usize],
+        target: String,
+        target_span: Span,
+    ) {
         let base = crate::naming::normalise_var_name(name).to_string();
         if let Some(scope) = scope_at_mut(&mut self.result.global_scope, scope_path)
             && let Some(v) = scope.variables.get_mut(&base)
         {
             v.link_target = Some(target);
+            v.link_target_span = Some(target_span);
         }
     }
 
@@ -2495,6 +2576,7 @@ mod tests {
             warn_if_unused: false,
             array_indices: std::collections::BTreeSet::new(),
             link_target: None,
+            link_target_span: None,
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/snapshot.rs
+++ b/rust/tcl-compiler/src/analyser/snapshot.rs
@@ -202,6 +202,7 @@ mod tests {
             warn_if_unused: true,
             array_indices: std::collections::BTreeSet::new(),
             link_target: None,
+            link_target_span: None,
         }
     }
 

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -729,11 +729,11 @@ pub struct Analyser {
     /// Deferred `TclOO` instance-creation candidates (`set v [Cls new]` /
     /// `Cls create v`) captured by an isolated proc body, which has an *empty*
     /// `all_classes` and so can't resolve the (sibling) class.  Each is the raw
-    /// `(command, args)`; [`Self::graft_proc_body`] replays
+    /// `(command, args, creation namespace)`; [`Self::graft_proc_body`] replays
     /// `record_instance_creation` against the shell's full `all_classes` so the
     /// `instance_classes` map matches a whole-file walk.  `None` on the whole-file
     /// path (instances resolve inline).
-    pub(super) pending_instances: Option<Vec<(String, Vec<String>)>>,
+    pub(super) pending_instances: Option<Vec<(String, Vec<String>, String)>>,
     /// **Experimental probe flag.**  When `true`, the per-item path does *not*
     /// take the duplicate-definition fallback, to measure the residual
     /// divergence the duplicate fast-path must still close.  Defaults to `false`.

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -303,6 +303,24 @@ pub struct VarDef {
     /// (the analyser analogue of Tcl's `VAR_LINK`).  `None` for an ordinary
     /// local or a directly-defined variable.
     pub link_target: Option<String>,
+    /// Span of the source word that **names** [`Self::link_target`] — the
+    /// word a rename of that cell must rewrite.
+    ///
+    /// For `variable v` and `global ::ns::v` this is the declaration word
+    /// itself, so it equals [`Self::definition_span`]: the local alias name
+    /// *is* the cell's (tail) name, and renaming the cell renames the local
+    /// spelling with it.
+    ///
+    /// For `namespace upvar ::ns v local` and `upvar #0 ::ns::v local` it is
+    /// a **different** word from the declaration: the cell is named by
+    /// `otherVar` (`v` / `::ns::v`), while `local` is an independent local
+    /// spelling that the cell's name does not determine.  Renaming the cell
+    /// must rewrite `otherVar` and leave `local` alone — rewriting `local`
+    /// instead re-points the alias at a cell that no longer exists (tclsh
+    /// 9.0.4 / 8.6.16 alike: `can't read "total": no such variable`).
+    ///
+    /// `None` whenever [`Self::link_target`] is `None`.
+    pub link_target_span: Option<Span>,
 }
 
 /// How a proc parameter is used inside the proc body.

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1056,6 +1056,27 @@ pub struct AnalysisResult {
     /// holds one of these names — must not be flagged as an unknown command
     /// (W123) or a stray non-literal command word (W307).  Issue #777.
     pub created_instance_commands: std::collections::HashSet<String>,
+    /// **Namespace-qualified** object-command bindings — one record per
+    /// `CLASS create NAME` site whose `CLASS` resolves to a user class.
+    ///
+    /// `created_instance_commands` above keeps only the bare name as written,
+    /// which is namespace-blind: `::a::Factory create rex` and `::b::Widget
+    /// create rex` are two *different* commands (tclsh 9.0.4 / 8.6.16 both run
+    /// `rex make` inside `::a` against `::a::rex` and inside `::b` against
+    /// `::b::rex`, and both object commands coexist), but a bare-name set
+    /// cannot tell them apart — so find-references and rename cross-linked the
+    /// two, and a rename of one class's method rewrote the other's call site
+    /// (issue #981, object-command half).
+    ///
+    /// Each record carries the qualified command name the creation site's own
+    /// namespace produces and the qualified name of the creating class, so the
+    /// dispatch scanner can resolve a written head against the call site's
+    /// lexical namespace instead of comparing text.  A `Vec`, not a map: two
+    /// creations of the same bare name in different namespaces are both real,
+    /// and two creations of the same *qualified* name by different classes are
+    /// a genuine ambiguity the rename safety gate refuses on rather than
+    /// silently resolving last-write-wins.
+    pub instance_command_bindings: Vec<InstanceCommandBinding>,
     /// Names dropped from [`Self::instance_classes`] because a *registry*
     /// object-factory binding (Tk widget path, tcllib naming factory) saw
     /// the same name bound to two different classes somewhere in the file
@@ -1315,6 +1336,20 @@ pub struct QualifiedVarRef {
     pub qualified_name: String,
     /// Byte span of the name token as written.
     pub span: Span,
+}
+
+/// One `CLASS create NAME` object-command binding, namespace-qualified.
+///
+/// See [`AnalysisResult::instance_command_bindings`] for why the bare-name
+/// set it accompanies is not enough.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct InstanceCommandBinding {
+    /// The object command's `::`-rooted qualified name — the creation site's
+    /// own namespace applied to `NAME` as written (an already-qualified
+    /// `NAME` is used as written).
+    pub qualified_name: String,
+    /// The `::`-rooted qualified name of the class whose `create` bound it.
+    pub class_q: String,
 }
 
 /// Which `auto_path` mutation wrote an [`AutoPathEntry`].

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -4095,6 +4095,7 @@ mod tests {
             warn_if_unused: false,
             array_indices: std::collections::BTreeSet::new(),
             link_target: None,
+            link_target_span: None,
         };
         let text = var_hover_text(&var_def, Some("int"), Some("tainted (from I/O)"));
         assert!(text.contains("**Inferred intrep**: int"), "{text}");

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -72,6 +72,7 @@ pub mod package_resolver;
 pub mod refactor;
 pub mod references;
 pub mod rename;
+pub mod rename_safety;
 pub mod selection_range;
 pub mod semantic_tokens;
 pub mod signature_help;

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -75,11 +75,15 @@
 //!   rule (current namespace, then `namespace path`, then global — see
 //!   [`CommandReceivers::class_head_matches`]), so two classes sharing a
 //!   simple name in different namespaces are never cross-linked (issue
-//!   #981).  A `CLASS create NAME` **object command** is still matched by
-//!   text: the analyser records instance-command names unqualified
-//!   (`AnalysisResult::created_instance_commands`), so two same-named object
-//!   commands in different namespaces are already indistinguishable in the
-//!   data this scanner reads — qualifying them is an analyser-shape change.
+//!   #981).  A `CLASS create NAME` **object command** now resolves the same
+//!   way: the analyser records each creation site's namespace
+//!   (`AnalysisResult::instance_command_bindings`), so `::a::Factory create
+//!   rex` binds `::a::rex` and `::b::Widget create rex` binds `::b::rex`, and
+//!   a bare `rex make` reaches whichever its own namespace resolves to — the
+//!   object-command half of #981, closed by PR C3.  An object command bound
+//!   by a *registry* object factory (a Tk widget path, a tcllib naming
+//!   factory) carries no creating user class, so it keeps the bare-name
+//!   match; it has no class identity to mis-attribute in the first place.
 //! * An **explicit** `namespace import ::a::Factory` is followed: the imported
 //!   name is a real command in the importing namespace, so it joins the
 //!   resolver's `exists` universe and resolves through to the source command
@@ -1135,7 +1139,7 @@ pub(crate) fn collect_member_bodies(
 /// [`collect_member_bodies`], which mixes both (used only where the caller
 /// has no per-table dispatch-scope concern of its own, e.g. `rename`'s
 /// property scan).
-fn collect_member_bodies_scoped(
+pub(crate) fn collect_member_bodies_scoped(
     cd: &tcl_compiler::analyser::types::ClassDef,
     is_classmethod: bool,
 ) -> Vec<tcl_lexer::Span> {
@@ -1284,6 +1288,13 @@ pub(crate) fn method_references_for_class(
         method,
         is_classmethod,
     ));
+    // Definition-body words that *name* the member — `export m` / `unexport m`
+    // / `filter m` / `deletemethod m` (the registry's
+    // `MemberRefKind::Method` members).  These are references, and rewriting
+    // them is load-bearing: an `export` left naming the old name leaves the
+    // renamed method unexported and every call to it fails (tclsh 9.0.4 /
+    // 8.6.16 alike).
+    call_spans.extend(member_reference_spans(source, dialect, class_def, method));
     Some((decl_span, call_spans))
 }
 
@@ -2054,17 +2065,56 @@ fn dispatch_receivers<'a>(
     // (so `NAME` is a command, dispatched bare as `NAME method`, not `$NAME
     // method`).  A `set v [CLASS new]` receiver is a *variable* only and never
     // enters this set, so a bare `v method` is (correctly) not matched.
+    //
+    // A name the analyser recorded a *namespace-qualified* binding for is
+    // matched by resolving the written head against the call site's own
+    // namespace (issue #981).  The bare-name set below is kept only for names
+    // with no such binding — the registry object-factories (Tk widget paths,
+    // tcllib naming factories) and the external-package `create NAME` shape,
+    // neither of which carries a creating user class to attribute a dispatch
+    // to in the first place.
+    let bound_tails: FxHashSet<&str> = analysis
+        .instance_command_bindings
+        .iter()
+        .filter_map(|b| {
+            std::str::from_utf8(tcl_syntax::naming::written_command_tail(
+                b.qualified_name.as_bytes(),
+            ))
+            .ok()
+        })
+        .collect();
     let mut receivers = CommandReceivers {
         object_commands: var_set
             .iter()
             .copied()
-            .filter(|name| analysis.created_instance_commands.contains(*name))
+            .filter(|name| {
+                analysis.created_instance_commands.contains(*name) && !bound_tails.contains(*name)
+            })
             .map(str::to_owned)
             .collect(),
         class_targets: FxHashSet::default(),
         class_tails: FxHashSet::default(),
+        object_command_targets: FxHashSet::default(),
+        object_command_tails: FxHashSet::default(),
+        object_command_universe: analysis
+            .instance_command_bindings
+            .iter()
+            .map(|b| b.qualified_name.clone())
+            .collect(),
         import_aliases: explicit_import_aliases(analysis),
     };
+    // A `classmethod` never dispatches on an instance, so object commands are
+    // only receivers for a plain `method` — the same rule that leaves
+    // `var_set` empty above.
+    if !is_classmethod {
+        for binding in &analysis.instance_command_bindings {
+            if binding.class_q == class_q
+                || hierarchy.method_target(&binding.class_q, method) == Some(class_q)
+            {
+                receivers.add_object_command_target(&binding.qualified_name);
+            }
+        }
+    }
     // A `classmethod` dispatches on the *class's own* command (`Factory
     // make`) — never on an instance: TclOO's `classmethod` sugar puts the
     // method on the class object's own class, which no instance's MRO
@@ -2244,15 +2294,40 @@ fn find_obj_method_call_sites_with_extra_cmd_names(
 ///   `b-made` there, `invalid command name "Factory"` where no candidate
 ///   exists, and the global class where only that exists).
 ///
-/// * `object_commands` — the instance-command names bound by `CLASS create
-///   NAME`.  These stay an exact text match: the analyser records them
-///   unqualified (`AnalysisResult::created_instance_commands` is a set of
-///   bare names with no creation namespace, and `instance_classes` keeps one
-///   binding per bare name), so two same-named object commands in different
-///   namespaces are already indistinguishable in the data this scanner
-///   reads.  Qualifying them is an analyser-shape change, not a scanner one.
+/// * `object_command_targets` — the object commands bound by `CLASS create
+///   NAME`, by the **qualified** name the creation site's namespace produced
+///   (`AnalysisResult::instance_command_bindings`).  Matched by the same
+///   namespace resolution as `class_targets`, so `::a::Factory create rex`
+///   and `::b::Widget create rex` are two commands, not one name (issue
+///   #981's object-command half).
+///
+/// * `object_commands` — the residual bare-name set, for instance commands
+///   with **no** qualified binding: those bound by a registry object factory
+///   (a Tk widget path, a tcllib naming factory) or by an unresolved
+///   external-package `create NAME`.  Neither records a creating user class,
+///   so there is no class identity to mis-attribute; an exact text match is
+///   all the data supports and all it needs to.
 struct CommandReceivers {
     class_targets: FxHashSet<String>,
+    /// The `::`-rooted **qualified** names of the object commands (`CLASS
+    /// create NAME`) whose creating class dispatches the method — matched by
+    /// resolving a written head against the call site's own namespace, the
+    /// same rule `class_targets` uses.  Populated from
+    /// [`tcl_compiler::analyser::AnalysisResult::instance_command_bindings`],
+    /// which records the creation site's namespace (issue #981's
+    /// object-command half): `::a::Factory create rex` binds `::a::rex` and
+    /// `::b::Widget create rex` binds `::b::rex`, and a bare `rex make`
+    /// reaches whichever of the two its own namespace resolves to — never
+    /// both, as the bare-name set below could not help doing.
+    object_command_targets: FxHashSet<String>,
+    /// Simple (tail) names of every entry in `object_command_targets` — the
+    /// same cheap pre-filter `class_tails` is for `class_targets`.
+    object_command_tails: FxHashSet<String>,
+    /// Every qualified object-command name the document binds, whatever class
+    /// bound it — the `exists` universe for the resolution above, so a
+    /// sibling namespace's same-named object command properly *shadows*
+    /// rather than being invisible.
+    object_command_universe: FxHashSet<String>,
     /// Simple (tail) names of every entry in `class_targets` — the cheap
     /// pre-filter that keeps the namespace resolution off every command head
     /// in the document.
@@ -2313,7 +2388,61 @@ impl CommandReceivers {
     }
 
     fn has_any(&self) -> bool {
-        !self.class_targets.is_empty() || !self.object_commands.is_empty()
+        !self.class_targets.is_empty()
+            || !self.object_commands.is_empty()
+            || !self.object_command_targets.is_empty()
+    }
+
+    /// Register an object command bound by `CLASS create NAME`, by the
+    /// qualified name the creation site's namespace produced.
+    fn add_object_command_target(&mut self, qualified_name: &str) {
+        if let Ok(tail) = std::str::from_utf8(tcl_syntax::naming::written_command_tail(
+            qualified_name.as_bytes(),
+        )) {
+            self.object_command_tails.insert(tail.to_owned());
+        }
+        self.object_command_targets
+            .insert(qualified_name.to_owned());
+    }
+
+    /// Whether the bare head `raw`, written at byte offset `offset`, is one of
+    /// the object commands in `object_command_targets` — resolved the way Tcl
+    /// resolves it, from the namespace lexically in effect there.
+    ///
+    /// The `exists` universe is every object command the document binds plus
+    /// its procs and classes, so a same-named object command in a nearer
+    /// namespace shadows a farther one exactly as it would at runtime
+    /// (`Factory create rex` in `::a` and `Widget create rex` in `::b`:
+    /// tclsh 9.0.4 / 8.6.16 dispatch `rex make` inside `::a` to `::a::rex`
+    /// and inside `::b` to `::b::rex`).
+    fn object_command_head_matches(
+        &self,
+        analysis: &AnalysisResult,
+        raw: &str,
+        offset: u32,
+    ) -> bool {
+        if self.object_command_targets.is_empty() {
+            return false;
+        }
+        let Ok(tail) =
+            std::str::from_utf8(tcl_syntax::naming::written_command_tail(raw.as_bytes()))
+        else {
+            return false;
+        };
+        if !self.object_command_tails.contains(tail) {
+            return false;
+        }
+        let namespace = crate::definition::namespace_context_at(
+            &analysis.global_scope,
+            offset,
+            &analysis.namespace_overrides,
+        );
+        crate::definition::resolved_command_name(analysis, &namespace, raw, &|candidate| {
+            self.object_command_universe.contains(candidate)
+                || analysis.all_classes.contains_key(candidate)
+                || analysis.all_procs.contains_key(candidate)
+        })
+        .is_some_and(|winner| self.object_command_targets.contains(&winner))
     }
 
     /// Whether the bare head `raw`, written at byte offset `offset`, is a
@@ -2404,6 +2533,9 @@ impl ObjMethodScan<'_> {
     /// dispatch this scan is looking for.
     fn command_receiver_matches(&self, raw: &str, offset: u32) -> bool {
         self.receivers.object_commands.contains(raw)
+            || self
+                .receivers
+                .object_command_head_matches(self.analysis, raw, offset)
             || self
                 .receivers
                 .class_head_matches(self.analysis, raw, offset)
@@ -2516,7 +2648,7 @@ fn scan_obj_method_region(
 /// refuses to descend into it, so every re-scanned body needs the braces
 /// stripped first.  Out-of-bounds / empty input is returned unchanged — the
 /// caller is expected to bounds-check before segmenting.
-fn strip_outer_braces(source: &str, span: tcl_lexer::Span) -> (usize, usize) {
+pub(crate) fn strip_outer_braces(source: &str, span: tcl_lexer::Span) -> (usize, usize) {
     let mut start = span.start() as usize;
     let mut end = span.end() as usize;
     if start >= source.len() || end > source.len() || start > end {
@@ -2630,7 +2762,7 @@ pub(crate) fn nested_dispatch_regions(
 ///
 /// Registry-driven throughout: which arguments are bodies, and whether they
 /// are same-frame, comes from the command's spec, never from its name.
-fn frame_shifted_dispatch_regions(
+pub(crate) fn frame_shifted_dispatch_regions(
     source: &str,
     dialect: &str,
     cmd: &tcl_compiler::segmenter::SegmentedCommand,
@@ -2677,6 +2809,157 @@ fn frame_shifted_dispatch_regions(
         let (start, end) = (body.start() as usize, body.end() as usize);
         if start < end && end <= source.len() {
             regions.push((start, end));
+        }
+    }
+    regions
+}
+/// Every nested script region a **rename-safety** scan must also visit from
+/// one segmented command: the union of the same-frame set
+/// ([`nested_dispatch_regions`]) and the frame-shifted set
+/// ([`frame_shifted_dispatch_regions`]).
+///
+/// The reference scan keeps the two apart because a `$var` receiver's bare
+/// name stops naming the enclosing frame's variable across a frame shift.
+/// The safety gate has no such distinction to make: it is asking "is there a
+/// dispatch anywhere in this document that this rename cannot account for",
+/// and a hazard written inside a `namespace eval` / `uplevel` / `apply` body
+/// is every bit as unrewritable as one written beside it.
+pub(crate) fn dispatch_scan_regions(
+    source: &str,
+    dialect: &str,
+    cmd: &tcl_compiler::segmenter::SegmentedCommand,
+) -> Vec<(usize, usize)> {
+    let mut regions = nested_dispatch_regions(source, dialect, cmd);
+    regions.extend(frame_shifted_dispatch_regions(source, dialect, cmd));
+    regions
+}
+
+/// Every word inside `class_def`'s definition body that **references**
+/// `method` as a method name — the registry's
+/// [`tcl_registry::definer::MemberRefKind::Method`] members (`export m`, `unexport m`,
+/// `filter m`, `deletemethod m`, `renamemethod from to`).
+///
+/// These are genuine references to the member, and load-bearing ones: an
+/// `export` naming a method that no longer exists leaves the *renamed*
+/// method unexported, so `$obj NewName` fails at run time (`unknown method
+/// "Bar": must be destroy` — tclsh 9.0.4 and 8.6.16, identical).  A rename
+/// that rewrote only the declaration and the call sites therefore broke the
+/// program; rewriting these words is what keeps it running.
+///
+/// Which member keywords carry method references is **registry data** (the
+/// definer's `definition_body` grammar, read through
+/// [`crate::oo_body::member_ref_indices`]), so this walker names no member
+/// keyword and works for `TclOO`, snit, and itcl alike.
+///
+/// Regions scanned: the class's own recorded body, plus every definition-body
+/// argument in the document whose definer call names this class (an
+/// `oo::define Cls { export m }` block written apart from the class's own
+/// `create`).
+pub(crate) fn member_reference_spans(
+    source: &str,
+    dialect: &str,
+    class_def: &tcl_compiler::analyser::types::ClassDef,
+    method: &str,
+) -> Vec<tcl_lexer::Span> {
+    use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
+    let registry = tcl_registry::registry_for_dialect(dialect);
+    let Some(grammar) = registry
+        .get(&class_def.metaclass)
+        .and_then(|spec| spec.definition_body)
+    else {
+        return Vec::new();
+    };
+    let mut regions: Vec<(usize, usize)> = Vec::new();
+    if !class_def.body_span.is_empty() {
+        let (start, end) = strip_outer_braces(source, class_def.body_span);
+        if start < end {
+            regions.push((start, end));
+        }
+    }
+    regions.extend(definition_body_regions_naming(source, dialect, class_def));
+    let mut out: Vec<tcl_lexer::Span> = Vec::new();
+    let mut seen: FxHashSet<(u32, u32)> = FxHashSet::default();
+    for (start, end) in regions {
+        if start >= end || end > source.len() {
+            continue;
+        }
+        let commands = segment_commands_with_offset_and_config(
+            &source[start..end],
+            u32::try_from(start).unwrap_or(0),
+            tcl_lexer::LexerConfig::for_dialect(dialect),
+        );
+        for cmd in &commands {
+            let Some(keyword) = cmd.texts.first() else {
+                continue;
+            };
+            let args: Vec<&str> = cmd.texts.iter().skip(1).map(String::as_str).collect();
+            let Some((kind, indices)) = crate::oo_body::member_ref_indices(grammar, keyword, &args)
+            else {
+                continue;
+            };
+            if kind != tcl_registry::definer::MemberRefKind::Method {
+                continue;
+            }
+            for idx in indices {
+                if args.get(idx) != Some(&method) {
+                    continue;
+                }
+                let Some(tok) = cmd.argv.get(idx + 1) else {
+                    continue;
+                };
+                if seen.insert((tok.span.start(), tok.span.end())) {
+                    out.push(tok.span);
+                }
+            }
+        }
+    }
+    out
+}
+
+/// The definition-body argument regions of every top-level definer call in
+/// `source` that names `class_def` — `oo::define Cls { … }` and the class's
+/// own `oo::class create Cls { … }`.
+///
+/// Definer recognition is [`crate::oo_body::outer_definition_grammar`]
+/// (registry `definition_body` data); the *target* is matched on the class
+/// name text, which is a class name, not a command-name special case.
+fn definition_body_regions_naming(
+    source: &str,
+    dialect: &str,
+    class_def: &tcl_compiler::analyser::types::ClassDef,
+) -> Vec<(usize, usize)> {
+    use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
+    let registry = tcl_registry::registry_for_dialect(dialect);
+    let commands = segment_commands_with_offset_and_config(
+        source,
+        0,
+        tcl_lexer::LexerConfig::for_dialect(dialect),
+    );
+    let qualified = tcl_syntax::naming::normalise_qualified_name(&class_def.qualified_name);
+    let mut regions: Vec<(usize, usize)> = Vec::new();
+    for cmd in &commands {
+        let Some(keyword) = cmd.texts.first() else {
+            continue;
+        };
+        let args: Vec<&str> = cmd.texts.iter().skip(1).map(String::as_str).collect();
+        if crate::oo_body::outer_definition_grammar(keyword, &args, registry).is_none() {
+            continue;
+        }
+        let body_indices =
+            registry.arg_indices_for_role(keyword, &args, tcl_registry::ArgRole::Body);
+        for idx in body_indices {
+            let names_class = args.iter().take(idx).any(|w| {
+                *w == class_def.name || tcl_syntax::naming::normalise_qualified_name(w) == qualified
+            });
+            if !names_class {
+                continue;
+            }
+            if let Some(tok) = cmd.argv.get(idx + 1) {
+                let (start, end) = strip_outer_braces(source, tok.span);
+                if start < end {
+                    regions.push((start, end));
+                }
+            }
         }
     }
     regions
@@ -2828,7 +3111,7 @@ fn cmd_substitution_regions(
 /// Strip a `$name` / `${name}` decoration to the bare variable
 /// name.  Returns `None` when the text isn't a `$`-prefixed
 /// reference.
-fn strip_var_decoration(raw: &str) -> Option<&str> {
+pub(crate) fn strip_var_decoration(raw: &str) -> Option<&str> {
     let rest = raw.strip_prefix('$')?;
     let inner = rest
         .strip_prefix('{')

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -4004,6 +4004,7 @@ mod tests {
                 warn_if_unused: false,
                 array_indices: std::collections::BTreeSet::new(),
                 link_target: None,
+                link_target_span: None,
             },
         );
         let a = Result {

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -301,47 +301,58 @@ pub fn rename(
     analysis: &AnalysisResult,
     registry: Option<&CommandRegistry>,
 ) -> Vec<TextEdit> {
+    rename_with_diagnosis(
+        source, dialect, line, character, new_name, analysis, registry,
+    )
+    .unwrap_or_default()
+}
+
+/// [`rename`], but reporting *why* a rename was refused.
+///
+/// `Err(refusal)` means the cursor names a real, resolvable symbol whose
+/// rename cannot be completed soundly — the safety gate
+/// ([`crate::rename_safety`]) proved the edit set would change what the
+/// program does.  The server turns that into an LSP error response carrying
+/// the reason, so the editor tells the user instead of silently applying a
+/// partial edit set.  `Ok(vec![])` keeps its existing meaning: no renameable
+/// symbol here, or a shape / collision gate said no.
+///
+/// The distinction matters because the two answers must not be conflated: an
+/// empty edit set falls through to the server's cross-document and
+/// workspace-resolved rename branches, and a *refusal* must not.
+pub fn rename_with_diagnosis(
+    source: &str,
+    dialect: &str,
+    line: u32,
+    character: u32,
+    new_name: &str,
+    analysis: &AnalysisResult,
+    registry: Option<&CommandRegistry>,
+) -> Result<Vec<TextEdit>, crate::rename_safety::RenameRefusal> {
     // Shape gate first — applies to every rename target.
     if !is_safe_symbol_name(new_name) {
-        return Vec::new();
+        return Ok(Vec::new());
     }
     let line_index = LineIndex::new(source);
-
-    if let Some(var_name) = find_var_at_position(source, line, character) {
-        return rename_var(
-            source,
-            line,
-            character,
-            new_name,
-            analysis,
-            &line_index,
-            &var_name,
-        );
-    }
-
-    // Definition / same-cell write site: the cursor sits on a `set x` /
-    // `variable x` declaration, a proc/method parameter, or a `catch`
-    // result-var (no `$`), so the `$ref` scan above missed it. Resolve via
-    // `var_def_at_declaration_offset`'s byte-offset span search (see its
-    // own doc for why the ordinary scope-chain walk can't reach a
-    // parameter's own declaring token).
-    let def_byte = crate::definition::byte_offset_at(&line_index, source, line, character);
-    if let Some(var_def) =
-        crate::definition::var_def_at_declaration_offset(&analysis.global_scope, def_byte)
+    // Safety gate: when the cursor names a `TclOO` member, refuse outright if
+    // any dispatch of it in this document cannot be proved safe to rewrite.
+    // Checked before any edit is built so a hazard can never leak a partial
+    // edit set (issue #923 idx 79).
+    if let Some(refusal) =
+        method_rename_refusal(source, dialect, line, character, analysis, &line_index)
     {
-        return rename_var(
-            source,
-            line,
-            character,
-            new_name,
-            analysis,
-            &line_index,
-            &var_def.name,
-        );
+        return Err(refusal);
     }
+
+    if let Some(edits) =
+        rename_variable_at(source, line, character, new_name, analysis, &line_index)
+    {
+        return Ok(edits);
+    }
+    let def_byte = crate::definition::byte_offset_at(&line_index, source, line, character);
 
     let Some((word, _start, _end)) = find_word_span_at_position(source, line, character) else {
-        return Vec::new();
+        return Ok(Vec::new());
     };
 
     if let Some(edits) = rename_proc(
@@ -353,7 +364,7 @@ pub fn rename(
         registry,
         &line_index,
     ) {
-        return edits;
+        return Ok(edits);
     }
     if let Some(edits) = rename_class(
         source,
@@ -364,7 +375,7 @@ pub fn rename(
         registry,
         &line_index,
     ) {
-        return edits;
+        return Ok(edits);
     }
     if let Some(edits) = rename_itcl_class_proc(
         source,
@@ -374,7 +385,7 @@ pub fn rename(
         analysis,
         &line_index,
     ) {
-        return edits;
+        return Ok(edits);
     }
     // `$obj method` external call site — when the cursor sits
     // on the method-name token of an instance-method call and
@@ -399,7 +410,7 @@ pub fn rename(
             &line_index,
         )
     {
-        return edits;
+        return Ok(edits);
     }
     // Method rename — match `word` against any class's methods
     // / classmethods / properties at the cursor's byte offset.
@@ -413,9 +424,74 @@ pub fn rename(
         cursor_offset,
         &line_index,
     ) {
-        return edits;
+        return Ok(edits);
     }
-    Vec::new()
+    Ok(Vec::new())
+}
+
+/// The safety refusal for a `TclOO` member rename anchored at the cursor, if
+/// any — the single in-document entry point to [`crate::rename_safety`].
+///
+/// Resolves the cursor to a member and its whole override family exactly the
+/// way the rename itself does ([`method_rename_target`] + [`override_family`]),
+/// so the gate is asked about precisely the declarations the edit set would
+/// rewrite — never a wider or narrower set.
+fn method_rename_refusal(
+    source: &str,
+    dialect: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    line_index: &LineIndex,
+) -> Option<crate::rename_safety::RenameRefusal> {
+    let (seed_class, method, is_classmethod) =
+        method_rename_target(source, line, character, analysis)?;
+    let family = override_family(analysis, &seed_class, &method);
+    if family.is_empty() {
+        return None;
+    }
+    crate::rename_safety::method_rename_hazard(
+        source,
+        dialect,
+        analysis,
+        crate::rename_safety::MethodRenameTarget {
+            family: &family,
+            method: &method,
+            is_classmethod,
+        },
+        line_index,
+    )
+}
+
+/// The variable-rename edits for a cursor that names one, or `None` when it
+/// names no variable at all.
+///
+/// Two cursor shapes, both variables: a `$ref` occurrence, and a *declaration
+/// / same-cell write* token with no `$` (a `set x` / `variable x`, a
+/// proc/method parameter, a `catch` result-var).  The second needs
+/// `var_def_at_declaration_offset`'s byte-offset span search — a parameter's
+/// own declaring token sits textually *before* its scope's body span even
+/// starts, so the ordinary scope-chain walk never reaches it (see that
+/// function's own doc).
+fn rename_variable_at(
+    source: &str,
+    line: u32,
+    character: u32,
+    new_name: &str,
+    analysis: &AnalysisResult,
+    line_index: &LineIndex,
+) -> Option<Vec<TextEdit>> {
+    let name = if let Some(var_name) = find_var_at_position(source, line, character) {
+        var_name
+    } else {
+        let def_byte = crate::definition::byte_offset_at(line_index, source, line, character);
+        crate::definition::var_def_at_declaration_offset(&analysis.global_scope, def_byte)?
+            .name
+            .clone()
+    };
+    Some(rename_var(
+        source, line, character, new_name, analysis, line_index, &name,
+    ))
 }
 
 /// Rename `method` across the class identified by `class_q` **and every
@@ -1279,6 +1355,122 @@ pub fn workspace_symbol_rename_edits(
         index,
         "",
     ))
+}
+
+/// Every edit renaming the **namespace-variable cell** `cell` to `new_name`
+/// within `source` — one document's share of the workspace-wide rename the
+/// cross-document tier drives.
+///
+/// `cell` is a `::`-rooted qualified name
+/// ([`crate::definition::qualified_variable_cell_at`] is the single entry
+/// point that decides which cell a cursor names, shared with go-to-definition
+/// / hover / find-references so the four cannot disagree).  Three occurrence
+/// kinds are rewritten, and they are the complete static set for a namespace
+/// cell:
+///
+/// * the **namespace-scoped declaration(s)** this document holds — the
+///   `variable v` / `set v …` sitting directly in a `namespace eval` body,
+///   read off the scope tree via `namespace_variables` rather than re-derived;
+/// * every **alias** Tcl treats as the same cell — a `variable v` / `global v`
+///   / `namespace upvar ns v local` inside a proc or method body, plus all its
+///   *unqualified* reads, unioned by
+///   [`crate::definition::linked_var_reference_spans`] over `VarDef::link_target`
+///   (the analyser's analogue of Tcl's `VAR_LINK`).  Missing these is what
+///   makes a naive "declaration + qualified occurrences" rename break a
+///   program: `namespace eval ns { proc p {} { variable v; puts $v } }`
+///   keeps working only if that `variable v` and its `$v` are renamed too;
+/// * every **`::`-qualified occurrence** (`$::ns::v`, `set app::ns::v 1`) —
+///   `analysis.qualified_var_refs`, the same table the workspace index's
+///   cross-document reference set is built from.
+///
+/// Deliberately *not* rewritten: an unqualified `$v` that is not an alias of
+/// this cell.  A bare name means whatever the local scope chain supplies,
+/// which is a per-document question this cell's identity cannot answer.
+///
+/// The result is unsorted and deduplicated by range; the caller merges it
+/// with the other documents' shares.
+#[must_use]
+pub fn namespace_variable_rename_edits(
+    source: &str,
+    analysis: &AnalysisResult,
+    cell: &str,
+    new_name: &str,
+) -> Vec<TextEdit> {
+    if !is_safe_symbol_name(new_name) {
+        return Vec::new();
+    }
+    let target = cell.trim_start_matches("::");
+    // Collision gate, the in-document half of the workspace one the server
+    // applies: renaming onto a cell this document already declares would
+    // merge two distinct variables into one.  Same discipline (and same
+    // "answer nothing" shape) as the single-document variable rename's own
+    // scope-chain collision check.
+    let new_cell = match cell.rfind("::") {
+        Some(idx) => format!("{}::{new_name}", &cell[..idx]),
+        None => format!("::{new_name}"),
+    };
+    if tcl_compiler::analyser::lookup_var_by_qualified_name(&analysis.global_scope, &new_cell)
+        .is_some()
+    {
+        return Vec::new();
+    }
+    let line_index = LineIndex::new(source);
+    let mut spans: Vec<tcl_lexer::Span> = Vec::new();
+    for (qualified, var) in tcl_compiler::analyser::namespace_variables(&analysis.global_scope) {
+        if qualified.trim_start_matches("::") != target {
+            continue;
+        }
+        spans.push(var.definition_span);
+        spans.extend(crate::definition::linked_var_reference_spans(
+            &analysis.global_scope,
+            var,
+        ));
+    }
+    collect_cell_alias_spans(&analysis.global_scope, target, &mut spans);
+    for vref in &analysis.qualified_var_refs {
+        if vref.qualified_name.trim_start_matches("::") == target {
+            spans.push(vref.span);
+        }
+    }
+    let mut edits: Vec<TextEdit> = spans
+        .into_iter()
+        .filter(|s| !s.is_empty())
+        .map(|s| TextEdit {
+            range: span_to_range(source, &line_index, var_ref_edit_span(source, s)),
+            new_text: build_var_ref_replacement(source, s, new_name),
+        })
+        .collect();
+    dedup_edits(&mut edits);
+    edits
+}
+
+/// Every declaration + reference span of a variable *aliasing* `target` (a
+/// `::`-rooted cell) anywhere in the scope tree — a proc-local `variable v` /
+/// `global v` / `namespace upvar` and all its unqualified uses.
+///
+/// The namespace-scoped declaration walk above only sees namespace and global
+/// scopes, so an alias declared inside a proc or method body (the ordinary way
+/// a namespace variable is used) is invisible to it; without this the
+/// cross-document rename would rewrite the declaration and leave every
+/// `variable v; … $v` body naming a cell that no longer exists.
+fn collect_cell_alias_spans(
+    scope: &tcl_compiler::analyser::Scope,
+    target: &str,
+    out: &mut Vec<tcl_lexer::Span>,
+) {
+    for var in scope.variables.values() {
+        if var
+            .link_target
+            .as_deref()
+            .is_some_and(|t| t.trim_start_matches("::") == target)
+        {
+            out.push(var.definition_span);
+            out.extend(var.references.iter().copied());
+        }
+    }
+    for child in &scope.children {
+        collect_cell_alias_spans(child, target, out);
+    }
 }
 
 /// Extend a `${name}` reference span to cover its own closing
@@ -2868,5 +3060,210 @@ mod tests {
             lines.contains(&1) && lines.contains(&5),
             "expected decl (l1) + `my speak` in inheriting subclass (l5); got {edits:?}",
         );
+    }
+
+    /// TP — the `export` list is part of the rename.
+    ///
+    /// Oracle (tclsh 9.0.4 and 8.6.16, identical): with `method Foo` +
+    /// `export Foo`, `[$a Foo]` prints `foo`.  Rename `Foo` → `Bar` touching
+    /// only the declaration and the call site, leaving `export Foo` behind,
+    /// and both interpreters answer
+    /// `unknown method "Bar": must be destroy` — the renamed method is no
+    /// longer exported.  A `method` whose name begins with an upper-case
+    /// letter is unexported by default (probed on 9.0.4: `$a Foo` errors,
+    /// `$a bar` works), which is exactly why the corpus writes the list.
+    #[test]
+    fn tp_rename_method_rewrites_its_export_list() {
+        let src = "oo::class create A {\n    method Foo {} { return 1 }\n    export Foo\n}\nset a [A new]\nputs [$a Foo]\n";
+        let analysis = analyse(src);
+        let edits = rename(src, "tcl8.6", 1, 12, "Bar", &analysis, None);
+        let applied = apply_edits(src, &edits);
+        assert!(
+            applied.contains("export Bar"),
+            "the export list must be renamed with the method: {applied}"
+        );
+        assert!(
+            !applied.contains("Foo"),
+            "no stale name may survive: {applied}"
+        );
+    }
+
+    /// TP — an `export` written in a separate `oo::define` block is found
+    /// through the definer grammar, not the class's own body span.
+    #[test]
+    fn tp_rename_method_rewrites_an_export_in_a_separate_oo_define_block() {
+        let src = "oo::class create A {\n    method Foo {} { return 1 }\n}\noo::define A {\n    export Foo\n}\n";
+        let analysis = analyse(src);
+        let edits = rename(src, "tcl8.6", 1, 12, "Bar", &analysis, None);
+        let applied = apply_edits(src, &edits);
+        assert!(
+            applied.contains("export Bar"),
+            "an `oo::define` export list must rename too: {applied}"
+        );
+    }
+
+    /// TP + TN, issue #981's object-command half.
+    ///
+    /// Oracle (tclsh 9.0.4 / 8.6.16, identical): `::a::Factory create rex`
+    /// and `::b::Widget create rex` bind two different commands; `rex make`
+    /// inside `::a` prints `a-made` and inside `::b` prints `b-made`, and
+    /// `::a::rex make` / `::b::rex make` both work from the top level.
+    /// Renaming `::b::Widget::make` → `produce` and also rewriting `::a`'s
+    /// call site makes both interpreters fail with
+    /// `unknown method "produce": must be destroy or make` at `rex produce`
+    /// inside `::a` — which is exactly what the LSP emitted before this fix.
+    #[test]
+    fn tn_object_command_dispatch_is_scoped_to_its_creation_namespace() {
+        let src = "namespace eval ::a {\n\
+                   \x20   oo::class create Factory {\n\
+                   \x20       method make {} { return \"a-made\" }\n\
+                   \x20   }\n\
+                   \x20   Factory create rex\n\
+                   \x20   puts [rex make]\n\
+                   }\n\
+                   namespace eval ::b {\n\
+                   \x20   oo::class create Widget {\n\
+                   \x20       method make {} { return \"b-made\" }\n\
+                   \x20   }\n\
+                   \x20   Widget create rex\n\
+                   \x20   puts [rex make]\n\
+                   }\n";
+        let analysis = analyse(src);
+        // Cursor on `make` in `::b::Widget`'s declaration.
+        let edits = rename(src, "tcl8.6", 9, 15, "produce", &analysis, None);
+        let applied = apply_edits(src, &edits);
+        assert!(
+            applied.contains("method produce {} { return \"b-made\" }"),
+            "::b's declaration must rename: {applied}"
+        );
+        assert!(
+            applied.contains("method make {} { return \"a-made\" }"),
+            "::a's declaration must be untouched: {applied}"
+        );
+        // `::a`'s own call site must survive verbatim; `::b`'s must rename.
+        let a_call = applied
+            .split("namespace eval ::b")
+            .next()
+            .expect("split keeps the ::a half");
+        assert!(
+            a_call.contains("puts [rex make]"),
+            "::a's `rex make` must not be rewritten (issue #981): {applied}"
+        );
+        assert!(
+            applied
+                .split("namespace eval ::b")
+                .nth(1)
+                .is_some_and(|b| b.contains("puts [rex produce]")),
+            "::b's own `rex make` must rename (the finding's lost-site half): {applied}"
+        );
+    }
+
+    /// TP — the namespace-variable cell's declaration, its proc-local
+    /// `variable` alias, that alias's unqualified reads, and every qualified
+    /// occurrence rename as one unit.
+    ///
+    /// Oracle (tclsh 9.0.4 / 8.6.16, identical): the script prints `1` before
+    /// and after the complete rename; renaming only the declaration and the
+    /// qualified read leaves `p` reading a cell that no longer exists.
+    #[test]
+    fn tp_namespace_variable_rename_covers_declaration_alias_and_qualified_use() {
+        let src = "namespace eval ::ns {\n\
+                   \x20   variable v 1\n\
+                   \x20   proc p {} {\n\
+                   \x20       variable v\n\
+                   \x20       return $v\n\
+                   \x20   }\n\
+                   }\n\
+                   puts $::ns::v\n\
+                   puts [::ns::p]\n";
+        let analysis = analyse(src);
+        let edits = namespace_variable_rename_edits(src, &analysis, "::ns::v", "total");
+        let applied = apply_edits(src, &edits);
+        assert!(applied.contains("variable total 1"), "{applied}");
+        assert!(applied.contains("        variable total\n"), "{applied}");
+        assert!(applied.contains("return $total"), "{applied}");
+        assert!(applied.contains("puts $::ns::total"), "{applied}");
+        assert!(
+            !applied.contains("$v\n"),
+            "no stale read may survive: {applied}"
+        );
+    }
+
+    /// TN — a same-tailed cell in a *different* namespace is a different
+    /// variable and must be untouched (`$other::v` never searches enclosing
+    /// namespaces; tclsh 9.0.4 / 8.6.16 keep the two independent).
+    #[test]
+    fn tn_namespace_variable_rename_leaves_a_same_tailed_sibling_cell_alone() {
+        let src = "namespace eval ::a {\n    variable v 1\n}\n\
+                   namespace eval ::b {\n    variable v 2\n}\n\
+                   puts $::a::v\nputs $::b::v\n";
+        let analysis = analyse(src);
+        let edits = namespace_variable_rename_edits(src, &analysis, "::a::v", "total");
+        let applied = apply_edits(src, &edits);
+        assert!(applied.contains("puts $::a::total"), "{applied}");
+        assert!(
+            applied.contains("puts $::b::v"),
+            "::b's cell must survive: {applied}"
+        );
+        assert!(
+            applied.contains("namespace eval ::b {\n    variable v 2\n}"),
+            "::b's declaration must survive: {applied}"
+        );
+    }
+
+    /// FP guard — renaming a cell onto a name the same namespace already
+    /// declares would merge two distinct variables, so the whole rename
+    /// answers nothing (the same discipline the single-document variable
+    /// rename's scope-chain collision check applies).
+    #[test]
+    fn fp_namespace_variable_rename_refuses_a_collision_in_its_own_namespace() {
+        let src =
+            "namespace eval ::ns {\n    variable v 1\n    variable total 2\n}\nputs $::ns::v\n";
+        let analysis = analyse(src);
+        assert!(
+            namespace_variable_rename_edits(src, &analysis, "::ns::v", "total").is_empty(),
+            "renaming `v` onto the existing `total` must produce no edits"
+        );
+    }
+
+    /// TN — an unqualified local that merely shares the tail name is not the
+    /// cell, so it is not renamed.
+    #[test]
+    fn tn_namespace_variable_rename_leaves_an_unrelated_local_alone() {
+        let src = "namespace eval ::ns {\n    variable v 1\n}\n\
+                   proc other {} {\n    set v 9\n    return $v\n}\n\
+                   puts $::ns::v\n";
+        let analysis = analyse(src);
+        let edits = namespace_variable_rename_edits(src, &analysis, "::ns::v", "total");
+        let applied = apply_edits(src, &edits);
+        assert!(
+            applied.contains("set v 9"),
+            "the proc local must survive: {applied}"
+        );
+        assert!(applied.contains("return $v"), "{applied}");
+        assert!(applied.contains("puts $::ns::total"), "{applied}");
+    }
+
+    /// FP guard, end of the in-document path: the idx-79 shape refuses with a
+    /// reason rather than emitting the declaration-only edit set that broke
+    /// the program on both interpreters.
+    #[test]
+    fn fp_rename_refuses_the_untracked_receiver_dispatch() {
+        let src = "oo::class create Vector3d {\n\
+                   \x20   variable _x\n\
+                   \x20   constructor {args} {\n\
+                   \x20       set other [lindex $args 0]\n\
+                   \x20       set _x [$other X]\n\
+                   \x20   }\n\
+                   \x20   method X {} { return $_x }\n\
+                   }\n";
+        let analysis = analyse(src);
+        let err = rename_with_diagnosis(src, "tcl8.6", 6, 11, "GetX", &analysis, None)
+            .expect_err("idx 79's shape must refuse");
+        assert!(err.reason.contains("not tracked"), "{}", err.reason);
+        assert!(err.range.is_some(), "the refusal must point at the site");
+        // And the plain entry point must produce no edits at all — never a
+        // partial set.
+        assert!(rename(src, "tcl8.6", 6, 11, "GetX", &analysis, None).is_empty());
     }
 }

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -1372,13 +1372,13 @@ pub fn workspace_symbol_rename_edits(
 ///   `variable v` / `set v …` sitting directly in a `namespace eval` body,
 ///   read off the scope tree via `namespace_variables` rather than re-derived;
 /// * every **alias** Tcl treats as the same cell — a `variable v` / `global v`
-///   / `namespace upvar ns v local` inside a proc or method body, plus all its
-///   *unqualified* reads, unioned by
-///   [`crate::definition::linked_var_reference_spans`] over `VarDef::link_target`
-///   (the analyser's analogue of Tcl's `VAR_LINK`).  Missing these is what
-///   makes a naive "declaration + qualified occurrences" rename break a
-///   program: `namespace eval ns { proc p {} { variable v; puts $v } }`
-///   keeps working only if that `variable v` and its `$v` are renamed too;
+///   / `namespace upvar ns v local` inside a proc or method body, enumerated
+///   by [`tcl_compiler::analyser::variable_alias_links`] over
+///   `VarDef::link_target` (the analyser's analogue of Tcl's `VAR_LINK`).
+///   Missing these is what makes a naive "declaration + qualified
+///   occurrences" rename break a program: `namespace eval ns { proc p {} {
+///   variable v; puts $v } }` keeps working only if that `variable v` and its
+///   `$v` are renamed too;
 /// * every **`::`-qualified occurrence** (`$::ns::v`, `set app::ns::v 1`) —
 ///   `analysis.qualified_var_refs`, the same table the workspace index's
 ///   cross-document reference set is built from.
@@ -1386,6 +1386,12 @@ pub fn workspace_symbol_rename_edits(
 /// Deliberately *not* rewritten: an unqualified `$v` that is not an alias of
 /// this cell.  A bare name means whatever the local scope chain supplies,
 /// which is a per-document question this cell's identity cannot answer.
+///
+/// Also deliberately *not* rewritten: the **local spelling of a
+/// differently-named alias**.  `namespace upvar ::ns v local` names the cell
+/// in its `otherVar` word (`v`); `local` is an independent local name the
+/// cell's identity does not determine.  See
+/// [`cell_rename_spans`] for the rule and its oracle.
 ///
 /// The result is unsorted and deduplicated by range; the caller merges it
 /// with the other documents' shares.
@@ -1420,13 +1426,14 @@ pub fn namespace_variable_rename_edits(
         if qualified.trim_start_matches("::") != target {
             continue;
         }
+        // The declaration itself, plus its own unqualified reads in the
+        // namespace frame.  Aliases are *not* unioned in here — they are
+        // handled by `cell_rename_spans`, which knows which of an alias's
+        // words names the cell and which is merely a local spelling.
         spans.push(var.definition_span);
-        spans.extend(crate::definition::linked_var_reference_spans(
-            &analysis.global_scope,
-            var,
-        ));
+        spans.extend(var.references.iter().copied());
     }
-    collect_cell_alias_spans(&analysis.global_scope, target, &mut spans);
+    cell_rename_spans(&analysis.global_scope, target, &mut spans);
     for vref in &analysis.qualified_var_refs {
         if vref.qualified_name.trim_start_matches("::") == target {
             spans.push(vref.span);
@@ -1444,32 +1451,68 @@ pub fn namespace_variable_rename_edits(
     edits
 }
 
-/// Every declaration + reference span of a variable *aliasing* `target` (a
-/// `::`-rooted cell) anywhere in the scope tree — a proc-local `variable v` /
-/// `global v` / `namespace upvar` and all its unqualified uses.
+/// The spans a rename of the `::`-rooted cell `target` must rewrite in every
+/// variable *aliasing* it — a proc-local `variable v` / `global v` /
+/// `namespace upvar ns v local` / `upvar #0 ::ns::v local`, anywhere in the
+/// scope tree.
 ///
 /// The namespace-scoped declaration walk above only sees namespace and global
 /// scopes, so an alias declared inside a proc or method body (the ordinary way
 /// a namespace variable is used) is invisible to it; without this the
 /// cross-document rename would rewrite the declaration and leave every
 /// `variable v; … $v` body naming a cell that no longer exists.
-fn collect_cell_alias_spans(
+///
+/// # Which word an alias contributes
+///
+/// An alias binds a **local spelling** to a **cell**, and only one of the two
+/// words involved is determined by the cell's name.
+/// [`VarDef::link_target_span`](tcl_compiler::analyser::VarDef::link_target_span)
+/// says which word names the cell, and this walk splits on whether that is the
+/// declaration word itself:
+///
+/// * **Same word** — `variable v`, `global ::ns::v`.  The local spelling *is*
+///   the cell's tail name, so renaming the cell renames the declaration and
+///   every unqualified read with it.  Rewriting only some of them breaks the
+///   program: with `variable total` against a body still reading `$v`, tclsh
+///   9.0.4 and 8.6.16 both give `can't read "v": no such variable`.
+///
+/// * **Different words** — `namespace upvar ::ns v local`, `upvar #0 ::ns::v
+///   local`.  The cell is named by `otherVar`; `local` is an independent
+///   spelling the cell's name does not determine.  Only `otherVar` is
+///   rewritten, and `local` and all its reads are left exactly as written.
+///   Rewriting `local` instead — which is what the declaration span alone
+///   gives — produces `namespace upvar ::ns v total; … $total`, and both
+///   interpreters then fail `can't read "total": no such variable`, because
+///   the alias still points at the cell that was renamed away.
+///
+/// A same-*spelled* `namespace upvar ::ns v v` is the second case, not the
+/// first: its two `v`s are distinct words at distinct offsets, and the local
+/// one is still an independent spelling.  Both interpreters accept either
+/// answer (`namespace upvar ::ns total v; … $v` and `namespace upvar ::ns
+/// total total; … $total` both print `42` on 9.0.4 and 8.6.16), so the
+/// **minimal** edit is taken: rewrite the word that names the cell, and touch
+/// nothing whose meaning the rename does not change.
+fn cell_rename_spans(
     scope: &tcl_compiler::analyser::Scope,
     target: &str,
     out: &mut Vec<tcl_lexer::Span>,
 ) {
-    for var in scope.variables.values() {
-        if var
-            .link_target
-            .as_deref()
-            .is_some_and(|t| t.trim_start_matches("::") == target)
-        {
-            out.push(var.definition_span);
-            out.extend(var.references.iter().copied());
+    for link in tcl_compiler::analyser::variable_alias_links(scope) {
+        if link.cell.trim_start_matches("::") != target {
+            continue;
         }
-    }
-    for child in &scope.children {
-        collect_cell_alias_spans(child, target, out);
+        let var = link.var;
+        match var.link_target_span {
+            // The cell is named by a word other than the declaration: rewrite
+            // only that word, and leave the local spelling (and its reads)
+            // alone.
+            Some(span) if span != var.definition_span => out.push(span),
+            // Declaration word and cell-naming word are one and the same.
+            _ => {
+                out.push(var.definition_span);
+                out.extend(var.references.iter().copied());
+            }
+        }
     }
 }
 
@@ -3186,6 +3229,121 @@ mod tests {
         assert!(
             !applied.contains("$v\n"),
             "no stale read may survive: {applied}"
+        );
+    }
+
+    /// FP (Codex review of PR #1091, finding 3) — `namespace upvar ::ns v
+    /// local` names the cell in its *third* word; `local` is an independent
+    /// local spelling.  Rewriting the alias token and leaving the target word
+    /// behind re-points the alias at a cell that no longer exists.
+    ///
+    /// Oracle (tclsh 9.0.4 / 8.6.16, byte-identical):
+    ///   before                         -> `p -> 42`, `cell -> 42`, rc 0
+    ///   `namespace upvar ::ns v total; … $total` (alias rewritten, target
+    ///   word left)                     -> `can't read "total": no such
+    ///                                     variable` at `"expr {$total + 41}"`,
+    ///                                     rc 1
+    ///   `namespace upvar ::ns total local; … $local` (target word rewritten,
+    ///   local spelling kept)           -> `p -> 42`, `cell -> 42`, rc 0
+    #[test]
+    fn fp_namespace_variable_rename_keeps_a_differently_named_alias_spelling() {
+        let src = "namespace eval ::ns {\n    variable v 1\n}\n\
+                   proc p {} {\n\
+                   \x20   namespace upvar ::ns v local\n\
+                   \x20   set local [expr {$local + 41}]\n\
+                   \x20   return $local\n\
+                   }\n";
+        let analysis = analyse(src);
+        let edits = namespace_variable_rename_edits(src, &analysis, "::ns::v", "total");
+        let applied = apply_edits(src, &edits);
+        assert!(applied.contains("variable total 1"), "{applied}");
+        assert!(
+            applied.contains("namespace upvar ::ns total local"),
+            "the word naming the cell is the word rewritten: {applied}"
+        );
+        assert!(
+            applied.contains("set local [expr {$local + 41}]") && applied.contains("return $local"),
+            "the local spelling and its reads must survive verbatim: {applied}"
+        );
+        assert!(
+            !applied.contains("$total"),
+            "no read may be re-spelled to the cell's new name: {applied}"
+        );
+    }
+
+    /// TN (same finding) — a *same-spelled* `namespace upvar ::ns v v` is
+    /// still two independent words.  Both interpreters accept either answer
+    /// (`namespace upvar ::ns total v; … $v` and `namespace upvar ::ns total
+    /// total; … $total` both print `42` on 9.0.4 and 8.6.16), so the minimal
+    /// edit is taken: rewrite the word that names the cell, and leave the
+    /// local spelling — whose meaning the rename does not change — alone.
+    #[test]
+    fn tn_namespace_variable_rename_takes_the_minimal_edit_for_a_same_spelled_alias() {
+        let src = "namespace eval ::ns {\n    variable v 1\n}\n\
+                   proc p {} {\n\
+                   \x20   namespace upvar ::ns v v\n\
+                   \x20   return $v\n\
+                   }\n";
+        let analysis = analyse(src);
+        let edits = namespace_variable_rename_edits(src, &analysis, "::ns::v", "total");
+        let applied = apply_edits(src, &edits);
+        assert!(applied.contains("variable total 1"), "{applied}");
+        assert!(
+            applied.contains("namespace upvar ::ns total v"),
+            "only the cell-naming word changes: {applied}"
+        );
+        assert!(
+            applied.contains("return $v"),
+            "the local read is unaffected by the cell's name: {applied}"
+        );
+    }
+
+    /// TP (same finding) — `upvar #0 ::ns::v local` is the other
+    /// differently-named shape, and resolves the same way: the `otherVar`
+    /// word is qualified, so the rewrite must preserve its qualifier.
+    #[test]
+    fn tp_namespace_variable_rename_rewrites_a_global_upvar_target_word() {
+        let src = "namespace eval ::ns {\n    variable v 1\n}\n\
+                   proc p {} {\n\
+                   \x20   upvar #0 ::ns::v local\n\
+                   \x20   return $local\n\
+                   }\n";
+        let analysis = analyse(src);
+        let edits = namespace_variable_rename_edits(src, &analysis, "::ns::v", "total");
+        let applied = apply_edits(src, &edits);
+        assert!(applied.contains("variable total 1"), "{applied}");
+        assert!(
+            applied.contains("upvar #0 ::ns::total local"),
+            "the qualified target word keeps its qualifier: {applied}"
+        );
+        assert!(
+            applied.contains("return $local"),
+            "the local spelling survives: {applied}"
+        );
+    }
+
+    /// TP (same finding) — `global ::ns::v` is the *same*-word shape: its one
+    /// declaration word both names the cell and introduces the local alias
+    /// (whose name is the cell's tail), so the rename must rewrite the word
+    /// **and** every unqualified read it enables.
+    ///
+    /// Oracle (9.0.4 / 8.6.16): leaving the reads behind gives `can't read
+    /// "v": no such variable`.
+    #[test]
+    fn tp_namespace_variable_rename_rewrites_a_global_alias_and_its_reads() {
+        let src = "namespace eval ::ns {\n    variable v 1\n}\n\
+                   proc p {} {\n\
+                   \x20   global ::ns::v\n\
+                   \x20   return $v\n\
+                   }\n";
+        let analysis = analyse(src);
+        let edits = namespace_variable_rename_edits(src, &analysis, "::ns::v", "total");
+        let applied = apply_edits(src, &edits);
+        assert!(applied.contains("variable total 1"), "{applied}");
+        assert!(applied.contains("global ::ns::total"), "{applied}");
+        assert!(
+            applied.contains("return $total"),
+            "the local spelling is the cell's tail, so it travels: {applied}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/rename_safety.rs
+++ b/rust/tcl-lsp-core/src/rename_safety.rs
@@ -1,0 +1,787 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Rename **safety gate** — the one place that decides a rename must be
+//! *refused* rather than answered with an edit set.
+//!
+//! # The oracle question
+//!
+//! A rename is a textual edit, and the only question that matters is what
+//! the program does *after* it: a rename is safe exactly when the program's
+//! runtime binding structure is preserved.  When static analysis cannot
+//! prove that, the answer must be a refusal with a precise reason, never a
+//! partial edit set — a refused rename costs the user a keystroke, a wrong
+//! one silently breaks running code.
+//!
+//! tclsh 9.0.4 and 8.6.16 agree byte-for-byte on every shape gated here;
+//! the transcripts are pinned as tests in this module and in
+//! `rust/tcl-lsp-server/tests/e2e/rename_safety.rs`.
+//!
+//! # What is gated
+//!
+//! ## Untracked receivers (issue #923 differential-audit finding idx 79)
+//!
+//! ```tcl
+//! oo::class create Vector3d {
+//!     constructor {args} {
+//!         set other [lindex $args 0]
+//!         if {[info object isa typeof $other ::Vector3d]} { set _x [$other X] }
+//!     }
+//!     method X {} { return $_x }
+//!     export X
+//! }
+//! ```
+//!
+//! `$other` holds a live `Vector3d` at run time, but nothing in the source
+//! *assigns* a constructor result to it — it is `[lindex $args 0]`, guarded
+//! by a runtime `info object isa` test.  The analyser's
+//! `instance_classes` therefore has no binding for it, and the reference
+//! scan ([`crate::references::find_obj_method_call_sites`]) correctly does
+//! not match the site.  Renaming `X` used to emit an edit set touching only
+//! the declaration; applying it and running under both interpreters gives
+//! `unknown method "X": must be Get, GetX, Y or destroy`.
+//!
+//! The receiver's class cannot be *proved* to be this class — and it cannot
+//! be proved *not* to be, either.  So the rename is refused.
+//!
+//! ## Computed member names
+//!
+//! `$obj $m` on a receiver that *is* an instance of the renamed class, and
+//! `my $m` inside the class's own bodies, dispatch a member whose name is
+//! run-time data.  No edit can keep such a site consistent with a renamed
+//! declaration, and no analysis can rule out that it names the member being
+//! renamed.
+//!
+//! ## Export lists that cannot be located
+//!
+//! `export`/`unexport`/`filter` name a method (the registry's
+//! [`tcl_registry::MemberRefKind::Method`] members).  Leaving `export Foo`
+//! behind after renaming `Foo` to `Bar` really does break the program —
+//! tclsh 9.0.4 / 8.6.16, identically: `$a Bar` then answers `unknown method
+//! "Bar": must be destroy`, because the renamed method is no longer
+//! exported.  Rename rewrites those words ([`crate::references::
+//! member_reference_spans`]); when the analyser recorded such a member for
+//! the renamed name but the grammar-driven scan cannot find a rewritable
+//! word for it (an `oo::define` block the class record does not span), the
+//! rename is refused rather than emitted incomplete.
+//!
+//! ## Ambiguous object commands (issue #981, object-command half)
+//!
+//! `CLASS create NAME` binds `NAME` in the *creation site's* namespace, so
+//! `::a::Factory create rex` and `::b::Widget create rex` are two different
+//! commands.  Attribution is namespace-scoped (see
+//! [`crate::references::CommandReceivers`]); when two *different* classes
+//! bind the very same qualified object-command name, no static rule can say
+//! which one a later `rex make` reaches, and the rename is refused.
+//!
+//! ## Namespace variables whose occurrences are not enumerable
+//!
+//! The workspace namespace-variable tier renames `$::ns::v` across every
+//! document.  A document that computes a variable name
+//! ([`tcl_compiler::dynamic_names::names_a_dynamic_variable`]) in a
+//! registry-declared variable-name argument position
+//! ([`tcl_registry::ArgRole::VarWrite`] / [`tcl_registry::ArgRole::VarRead`])
+//! may be naming the very cell being renamed, with no word to rewrite — so
+//! a rename that would touch that namespace is refused.
+//!
+//! # No command names here
+//!
+//! Every command-level fact this module uses comes from the registry: the
+//! self-dispatch keyword ([`crate::definition::method_dispatch_keyword_in`]),
+//! the definition-body member grammar (`definition_body` /
+//! [`tcl_registry::MemberRefKind`]), the same-frame and frame-shifted body
+//! roles ([`crate::references::nested_dispatch_regions`]), and the
+//! variable-name argument roles.  There is no command-name string match in
+//! this file.
+
+use rustc_hash::FxHashSet;
+use tcl_compiler::analyser::AnalysisResult;
+use tcl_compiler::segmenter::SegmentedCommand;
+use tcl_lexer::{LineIndex, Span, TokenType};
+
+use crate::definition::LspRange;
+use crate::definition::span_to_range;
+use crate::references::{
+    MAX_DISPATCH_SCAN_DEPTH, collect_member_bodies_scoped, dispatch_scan_regions,
+    strip_outer_braces, strip_var_decoration,
+};
+
+/// A refused rename: why, and (when there is one) the offending site.
+///
+/// The server turns this into an LSP error response, so the editor shows the
+/// reason instead of applying a partial edit set.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RenameRefusal {
+    /// Precise, user-facing explanation — names the shape that could not be
+    /// proved safe, so the user can decide what to do about it.
+    pub reason: String,
+    /// The site the refusal is about, when it is a single place in the
+    /// document the request was issued against.
+    pub range: Option<LspRange>,
+}
+
+impl RenameRefusal {
+    fn new(reason: String, source: &str, line_index: &LineIndex, span: Option<Span>) -> Self {
+        Self {
+            reason,
+            range: span.map(|s| span_to_range(source, line_index, s)),
+        }
+    }
+}
+
+/// The member rename a [`method_rename_hazard`] check is about.
+#[derive(Debug, Clone, Copy)]
+pub struct MethodRenameTarget<'a> {
+    /// Every class in the rename's override family, fully qualified — the
+    /// set whose declarations the edit set rewrites.
+    pub family: &'a [String],
+    /// The member name being renamed.
+    pub method: &'a str,
+    /// Which dispatch table the member lives in — a `classmethod` is never
+    /// reached through an instance receiver.
+    pub is_classmethod: bool,
+}
+
+/// Whether renaming `target`'s member is unsafe **in this document**.
+///
+/// Called once per document the rename would touch (the request's own
+/// document plus every family / consumer document the cross-file path
+/// visits), so a hazard anywhere in the workspace refuses the whole rename.
+#[must_use]
+pub fn method_rename_hazard(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    target: MethodRenameTarget<'_>,
+    line_index: &LineIndex,
+) -> Option<RenameRefusal> {
+    unlocatable_member_reference(source, dialect, analysis, target, line_index)
+        .or_else(|| dispatch_hazard(source, dialect, analysis, target, line_index))
+        .or_else(|| ambiguous_object_command(source, analysis, target, line_index))
+}
+
+/// A `MemberRefKind::Method` word the analyser recorded for the renamed
+/// member (`export X`, `unexport X`, `filter X`) that the grammar-driven
+/// span scan cannot find a rewritable word for.
+///
+/// The two halves disagreeing means the edit set would leave a stale
+/// method-name word behind, and that word is load-bearing: an `export`
+/// naming a method that no longer exists leaves the *renamed* method
+/// unexported, so every `$obj NewName` call fails (`unknown method "Bar":
+/// must be destroy` on tclsh 9.0.4 and 8.6.16 alike).
+fn unlocatable_member_reference(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    target: MethodRenameTarget<'_>,
+    line_index: &LineIndex,
+) -> Option<RenameRefusal> {
+    for class_q in target.family {
+        let Some(class_def) = analysis.all_classes.get(class_q) else {
+            continue;
+        };
+        let recorded = class_def.exports.contains(target.method)
+            || class_def.unexports.contains(target.method)
+            || class_def.filters.iter().any(|f| f == target.method);
+        if !recorded {
+            continue;
+        }
+        if crate::references::member_reference_spans(source, dialect, class_def, target.method)
+            .is_empty()
+        {
+            return Some(RenameRefusal::new(
+                format!(
+                    "cannot rename `{method}`: class `{class_q}` declares an export / \
+                     unexport / filter naming it, but the declaring word is outside the \
+                     class body this document records, so the rename cannot rewrite it. \
+                     Leaving it behind would leave `{method}` unexported and break every \
+                     call to the renamed member.",
+                    method = target.method,
+                ),
+                source,
+                line_index,
+                None,
+            ));
+        }
+    }
+    None
+}
+
+/// Two different classes binding the very same **qualified** object-command
+/// name (`::a::Factory create rex` and `::a::Widget create rex`).
+///
+/// Namespace scoping (issue #981) tells `::a::rex` from `::b::rex`, but two
+/// creations of the same qualified name are genuinely indistinguishable: a
+/// later `rex make` reaches whichever creation ran last, which is a runtime
+/// fact.  Rewriting either class's `make` would rewrite call sites that may
+/// belong to the other, so the rename is refused.
+fn ambiguous_object_command(
+    source: &str,
+    analysis: &AnalysisResult,
+    target: MethodRenameTarget<'_>,
+    line_index: &LineIndex,
+) -> Option<RenameRefusal> {
+    let family: FxHashSet<&str> = target.family.iter().map(String::as_str).collect();
+    for binding in &analysis.instance_command_bindings {
+        if !family.contains(binding.class_q.as_str()) {
+            continue;
+        }
+        let clashes = analysis.instance_command_bindings.iter().any(|other| {
+            other.qualified_name == binding.qualified_name && other.class_q != binding.class_q
+        });
+        if clashes {
+            return Some(RenameRefusal::new(
+                format!(
+                    "cannot rename `{method}`: the object command `{cmd}` is created by \
+                     more than one class in this workspace, so which class a `{tail} \
+                     {method}` call dispatches to is a runtime fact this rename cannot \
+                     resolve.",
+                    method = target.method,
+                    cmd = binding.qualified_name,
+                    tail = tail_of(&binding.qualified_name),
+                ),
+                source,
+                line_index,
+                None,
+            ));
+        }
+    }
+    None
+}
+
+fn tail_of(qualified: &str) -> &str {
+    std::str::from_utf8(tcl_syntax::naming::written_command_tail(
+        qualified.as_bytes(),
+    ))
+    .unwrap_or(qualified)
+}
+
+/// A dispatch site this rename can neither rewrite nor rule out.
+///
+/// * **untracked receiver, literal member word** — `$v METHOD`, where `v`
+///   has no class binding at all (idx 79's `$args X` / `$other X`).  The
+///   receiver may be an instance of the renamed class; nothing in the
+///   source says it isn't.
+/// * **computed member word on a receiver of this family** — `$v $m` /
+///   `[$v [pick]]`, where `v` *is* bound to a family class.  The member the
+///   site names is run-time data.
+/// * **computed member word on `my`** — the same, through the registry's own
+///   self-dispatch keyword, inside a family class's own bodies.
+///
+/// A receiver bound to some *other* class is not a hazard: its dispatch
+/// provably reaches that class's table, not this one, so the ordinary
+/// reference scan's decision to skip it is sound.
+fn dispatch_hazard(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    target: MethodRenameTarget<'_>,
+    line_index: &LineIndex,
+) -> Option<RenameRefusal> {
+    let hierarchy = analysis.class_hierarchy();
+    let family: FxHashSet<&str> = target.family.iter().map(String::as_str).collect();
+    let in_family = |class: &str| -> bool {
+        family.contains(class)
+            || hierarchy
+                .method_target(class, target.method)
+                .is_some_and(|owner| family.contains(owner))
+    };
+
+    let mut hazard: Option<(Span, &'static str)> = None;
+    let mut visit = |cmd: &SegmentedCommand| {
+        if hazard.is_some() {
+            return;
+        }
+        let (Some(head), Some(member)) = (cmd.argv.first(), cmd.argv.get(1)) else {
+            return;
+        };
+        let Some(head_text) = slice(source, head.span) else {
+            return;
+        };
+        let computed_member = matches!(member.kind, TokenType::Var | TokenType::Cmd);
+        if head.kind == TokenType::Var {
+            let Some(receiver) = strip_var_decoration(head_text) else {
+                return;
+            };
+            match analysis.instance_classes.get(receiver) {
+                // Receiver bound to a class: only a computed member word is
+                // a hazard, and only when that class's dispatch really can
+                // reach the member being renamed.
+                Some(class) => {
+                    // An instance receiver never reaches a `classmethod` —
+                    // TclOO puts a classmethod on the class object's own
+                    // class, which no instance's MRO walks — so a computed
+                    // member name here cannot be the one being renamed.
+                    if !target.is_classmethod && computed_member && in_family(class) {
+                        hazard = Some((member.span, "computed-member"));
+                    }
+                }
+                // Receiver of unknown class: a literal word naming the
+                // renamed member is the idx-79 shape.
+                None => {
+                    if !target.is_classmethod
+                        && !computed_member
+                        && slice(source, member.span) == Some(target.method)
+                    {
+                        hazard = Some((member.span, "untracked-receiver"));
+                    }
+                }
+            }
+        }
+    };
+
+    walk_document(source, dialect, analysis, &mut visit);
+    if hazard.is_none() {
+        walk_self_dispatch(source, dialect, analysis, target, &mut |span| {
+            hazard = Some((span, "computed-member"));
+        });
+    }
+
+    let (span, kind) = hazard?;
+    let written = slice(source, span).unwrap_or("");
+    let reason = if kind == "untracked-receiver" {
+        format!(
+            "cannot rename `{method}`: `{site}` is dispatched here on a receiver whose \
+             class is not tracked, so the rename can neither prove this call reaches \
+             `{method}` nor prove it does not. Rewriting only the declaration would \
+             leave this call naming a member that no longer exists.",
+            method = target.method,
+            site = written,
+        )
+    } else {
+        format!(
+            "cannot rename `{method}`: a member name computed at run time is dispatched \
+             here on a receiver of this class, so no edit can keep this call consistent \
+             with the renamed declaration.",
+            method = target.method,
+        )
+    };
+    Some(RenameRefusal::new(reason, source, line_index, Some(span)))
+}
+
+/// Run `visit` over every command in every region of the document a dispatch
+/// can be written in — the top-level stream, every proc body, and every
+/// class member body, descending both same-frame and frame-shifted nested
+/// regions exactly as the reference scan does.
+fn walk_document(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    visit: &mut impl FnMut(&SegmentedCommand),
+) {
+    walk_region(source, dialect, 0, source.len(), 0, visit);
+    for proc_def in analysis.all_procs.values() {
+        walk_body(source, dialect, proc_def.body_span, visit);
+    }
+    for class_def in analysis.all_classes.values() {
+        for m in class_def
+            .methods
+            .values()
+            .chain(class_def.class_methods.values())
+            .chain(class_def.constructors.iter())
+            .chain(class_def.destructor.iter())
+        {
+            walk_body(source, dialect, m.body_span, visit);
+        }
+    }
+}
+
+/// `my $computed` inside a family class's own member bodies — the
+/// self-dispatch counterpart of the `$obj $computed` hazard, recognised
+/// through the registry's own dispatch-keyword table rather than a literal
+/// `my` comparison.
+fn walk_self_dispatch(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    target: MethodRenameTarget<'_>,
+    hit: &mut impl FnMut(Span),
+) {
+    let mut found: Option<Span> = None;
+    for class_q in target.family {
+        let Some(class_def) = analysis.all_classes.get(class_q) else {
+            continue;
+        };
+        for body in collect_member_bodies_scoped(class_def, target.is_classmethod) {
+            walk_body(source, dialect, body, &mut |cmd: &SegmentedCommand| {
+                if found.is_some() {
+                    return;
+                }
+                let (Some(head), Some(member)) = (cmd.argv.first(), cmd.argv.get(1)) else {
+                    return;
+                };
+                if !matches!(member.kind, TokenType::Var | TokenType::Cmd) {
+                    return;
+                }
+                let Some(head_text) = slice(source, head.span) else {
+                    return;
+                };
+                if crate::definition::method_dispatch_keyword_in(dialect, head_text)
+                    == Some(tcl_registry::registry::MethodDispatchKind::SelfDispatch)
+                {
+                    found = Some(member.span);
+                }
+            });
+        }
+    }
+    if let Some(span) = found {
+        hit(span);
+    }
+}
+
+fn walk_body(
+    source: &str,
+    dialect: &str,
+    body_span: Span,
+    visit: &mut impl FnMut(&SegmentedCommand),
+) {
+    if body_span.is_empty() {
+        return;
+    }
+    let (start, end) = strip_outer_braces(source, body_span);
+    if start >= end {
+        return;
+    }
+    walk_region(source, dialect, start, end, 0, visit);
+}
+
+fn walk_region(
+    source: &str,
+    dialect: &str,
+    start: usize,
+    end: usize,
+    depth: u32,
+    visit: &mut impl FnMut(&SegmentedCommand),
+) {
+    use tcl_compiler::segmenter::segment_commands_with_offset_and_config;
+    if start >= end || end > source.len() || MAX_DISPATCH_SCAN_DEPTH.exceeded(depth) {
+        return;
+    }
+    let commands = segment_commands_with_offset_and_config(
+        &source[start..end],
+        u32::try_from(start).unwrap_or(0),
+        tcl_lexer::LexerConfig::for_dialect(dialect),
+    );
+    for cmd in &commands {
+        visit(cmd);
+        for (inner_start, inner_end) in dispatch_scan_regions(source, dialect, cmd) {
+            walk_region(source, dialect, inner_start, inner_end, depth + 1, visit);
+        }
+    }
+}
+
+fn slice(source: &str, span: Span) -> Option<&str> {
+    let start = span.start() as usize;
+    let end = span.end() as usize;
+    (start <= end && end <= source.len()).then(|| &source[start..end])
+}
+
+/// Whether a **namespace-variable** rename must be refused because this
+/// document computes a variable name that could be the cell being renamed.
+///
+/// The cross-document namespace-variable rename enumerates occurrences by
+/// name: the declaration, every alias Tcl treats as the same cell
+/// (`variable` / `global` / `namespace upvar`), and every `::`-qualified
+/// occurrence.  A **computed** name in a variable-name argument position
+/// (`set ::ns::$n 1`, `variable $n`, `namespace upvar ::ns $n local`) names
+/// a cell no enumeration can predict, so a rename that touches that
+/// namespace cannot be completed from source edits.
+///
+/// Which argument of which command names a variable is the registry's
+/// answer ([`tcl_registry::ArgRole::VarWrite`] /
+/// [`tcl_registry::ArgRole::VarRead`]); whether a word is computed is
+/// [`tcl_compiler::dynamic_names::names_a_dynamic_variable`]'s.  No command
+/// name is matched here.
+///
+/// Scoped to the namespace being renamed: a dynamic name in a document that
+/// has nothing to do with `::ns` is irrelevant, and refusing on it would
+/// make the tier unusable.
+#[must_use]
+pub fn namespace_variable_rename_hazard(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    cell: &str,
+    line_index: &LineIndex,
+) -> Option<RenameRefusal> {
+    let registry = tcl_registry::registry_for_dialect(dialect);
+    let mut hazard: Option<Span> = None;
+    let mut visit = |cmd: &SegmentedCommand| {
+        if hazard.is_some() {
+            return;
+        }
+        let Some(cmd_name) = cmd.texts.first() else {
+            return;
+        };
+        let args: Vec<&str> = cmd.texts.iter().skip(1).map(String::as_str).collect();
+        for role in [
+            tcl_registry::ArgRole::VarWrite,
+            tcl_registry::ArgRole::VarRead,
+        ] {
+            for idx in registry.arg_indices_for_role(cmd_name, &args, role) {
+                let Some(word) = args.get(idx) else {
+                    continue;
+                };
+                if !tcl_compiler::dynamic_names::names_a_dynamic_variable(word) {
+                    continue;
+                }
+                if let Some(tok) = cmd.argv.get(idx + 1) {
+                    hazard = Some(tok.span);
+                    return;
+                }
+            }
+        }
+    };
+    walk_document(source, dialect, analysis, &mut visit);
+    let span = hazard?;
+    let written = slice(source, span).unwrap_or("");
+    Some(RenameRefusal::new(
+        format!(
+            "cannot rename `{cell}`: this document names a variable through a value \
+             computed at run time (`{written}`), which may be this very cell — there is \
+             no word to rewrite, so the rename cannot be completed from source edits.",
+        ),
+        source,
+        line_index,
+        Some(span),
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tcl_compiler::analyser::Analyser;
+
+    fn analyse(source: &str) -> AnalysisResult {
+        let mut a = Analyser::new();
+        a.analyse(source, "tcl8.6").clone()
+    }
+
+    fn hazard(source: &str, family: &[&str], method: &str, is_classmethod: bool) -> Option<String> {
+        let analysis = analyse(source);
+        let owned: Vec<String> = family.iter().map(|s| (*s).to_string()).collect();
+        method_rename_hazard(
+            source,
+            "tcl8.6",
+            &analysis,
+            MethodRenameTarget {
+                family: &owned,
+                method,
+                is_classmethod,
+            },
+            &LineIndex::new(source),
+        )
+        .map(|r| r.reason)
+    }
+
+    /// Issue #923 differential-audit finding idx 79, in its own shape.
+    ///
+    /// nico-robert/tomato's `Vector3d.tcl` copy-constructor: `$other` is
+    /// `[lindex $args 0]` guarded by a runtime `info object isa` test, so it
+    /// really is a `Vector3d` at run time (tclsh 9.0.4 / 8.6.16 both print
+    /// `v2 = 7 9`) but the analyser has no binding for it.  The rename used to
+    /// emit an edit set touching only the declaration; applying exactly that
+    /// and re-running gives, on both interpreters:
+    ///
+    /// ```text
+    /// unknown method "X": must be Get, GetX, Y or destroy
+    ///     while executing
+    /// "$other X"
+    /// ```
+    ///
+    /// FP guard: the gate must refuse.
+    #[test]
+    fn fp_refuses_a_method_dispatched_on_an_untracked_receiver() {
+        let src = "oo::class create Vector3d {\n\
+                   \x20   variable _x\n\
+                   \x20   constructor {args} {\n\
+                   \x20       set other [lindex $args 0]\n\
+                   \x20       if {[info object isa typeof $other ::Vector3d]} {\n\
+                   \x20           set _x [$other X]\n\
+                   \x20       }\n\
+                   \x20   }\n\
+                   \x20   method X {} { return $_x }\n\
+                   }\n";
+        let reason = hazard(src, &["::Vector3d"], "X", false)
+            .expect("an untracked `$other X` dispatch must refuse the rename");
+        assert!(
+            reason.contains("not tracked"),
+            "refusal must name the untracked receiver: {reason}"
+        );
+    }
+
+    /// FN guard: the ordinary, provable shape must still rename.  `$v` is
+    /// bound by `set v [Dog new]`, so its dispatch is found and rewritten by
+    /// the reference scan — nothing to refuse.
+    #[test]
+    fn fn_guard_allows_a_method_whose_receivers_are_all_tracked() {
+        let src = "oo::class create Dog {\n\
+                   \x20   method speak {} { return woof }\n\
+                   }\n\
+                   set v [Dog new]\n\
+                   puts [$v speak]\n";
+        assert_eq!(hazard(src, &["::Dog"], "speak", false), None);
+    }
+
+    /// FN guard: an untracked receiver dispatching some *other* member is not
+    /// a hazard for this rename — refusing on it would block almost every
+    /// real rename, and it cannot affect the member being renamed.
+    #[test]
+    fn fn_guard_allows_when_the_untracked_receiver_names_another_member() {
+        let src = "oo::class create Dog {\n\
+                   \x20   method speak {} { return woof }\n\
+                   \x20   method walk {} { return ok }\n\
+                   \x20   constructor {other} { $other walk }\n\
+                   }\n";
+        assert_eq!(hazard(src, &["::Dog"], "speak", false), None);
+    }
+
+    /// TN: a receiver tracked to an *unrelated* class provably dispatches
+    /// that class's table, so a same-named member elsewhere is untouched and
+    /// unblocked.  tclsh 9.0.4 / 8.6.16 confirm the two `speak`s are
+    /// independent methods on independent objects.
+    #[test]
+    fn tn_allows_when_the_receiver_is_tracked_to_an_unrelated_class() {
+        let src = "oo::class create Dog {\n\
+                   \x20   method speak {} { return woof }\n\
+                   }\n\
+                   oo::class create Cat {\n\
+                   \x20   method speak {} { return meow }\n\
+                   }\n\
+                   set c [Cat new]\n\
+                   puts [$c speak]\n";
+        assert_eq!(hazard(src, &["::Dog"], "speak", false), None);
+    }
+
+    /// FP guard: a member name computed at run time, dispatched on a receiver
+    /// of this very class.  No edit can keep `$v $m` consistent with a
+    /// renamed declaration, and nothing proves `$m` is not the renamed
+    /// member.
+    #[test]
+    fn fp_refuses_a_computed_member_name_on_a_tracked_receiver() {
+        let src = "oo::class create Dog {\n\
+                   \x20   method speak {} { return woof }\n\
+                   }\n\
+                   set v [Dog new]\n\
+                   set m speak\n\
+                   puts [$v $m]\n";
+        let reason = hazard(src, &["::Dog"], "speak", false)
+            .expect("a computed member name on an instance of the class must refuse");
+        assert!(
+            reason.contains("computed at run time"),
+            "refusal must name the computed dispatch: {reason}"
+        );
+    }
+
+    /// FP guard: the same, through the registry's own self-dispatch keyword
+    /// inside the class's own bodies (`my $m`) — recognised via
+    /// [`crate::definition::method_dispatch_keyword_in`], never a literal
+    /// `== "my"`.
+    #[test]
+    fn fp_refuses_a_computed_member_name_dispatched_through_my() {
+        let src = "oo::class create Dog {\n\
+                   \x20   method speak {} { return woof }\n\
+                   \x20   method run {m} { my $m }\n\
+                   }\n";
+        let reason = hazard(src, &["::Dog"], "speak", false)
+            .expect("a `my $m` dispatch inside the class must refuse");
+        assert!(reason.contains("computed at run time"), "{reason}");
+    }
+
+    /// FN guard: a plain `my speak` is exactly what the reference scan finds
+    /// and rewrites — never a refusal.
+    #[test]
+    fn fn_guard_allows_a_literal_my_dispatch() {
+        let src = "oo::class create Dog {\n\
+                   \x20   method speak {} { return woof }\n\
+                   \x20   method run {} { my speak }\n\
+                   }\n";
+        assert_eq!(hazard(src, &["::Dog"], "speak", false), None);
+    }
+
+    /// FP guard, issue #981's object-command half: two classes binding the
+    /// *same qualified* object command.  `::a::Factory create rex` twice over
+    /// (here with two different classes in one namespace) leaves which class
+    /// a later `rex make` reaches a runtime fact — the second `create`
+    /// replaces the first command.
+    #[test]
+    fn fp_refuses_when_two_classes_bind_the_same_qualified_object_command() {
+        let src = "namespace eval ::a {\n\
+                   \x20   oo::class create Factory { method make {} { return f } }\n\
+                   \x20   oo::class create Widget { method make {} { return w } }\n\
+                   \x20   Factory create rex\n\
+                   \x20   Widget create rex\n\
+                   \x20   puts [rex make]\n\
+                   }\n";
+        let reason = hazard(src, &["::a::Factory"], "make", false)
+            .expect("an object command bound by two classes must refuse");
+        assert!(
+            reason.contains("more than one class"),
+            "refusal must name the ambiguity: {reason}"
+        );
+    }
+
+    /// FN guard: the same bare name bound in *different* namespaces is not
+    /// ambiguous at all — `::a::rex` and `::b::rex` are two distinct commands
+    /// (tclsh 9.0.4 / 8.6.16: `rex make` inside `::a` prints `a-made`, inside
+    /// `::b` prints `b-made`, and both object commands coexist).
+    #[test]
+    fn fn_guard_allows_same_bare_object_command_in_sibling_namespaces() {
+        let src = "namespace eval ::a {\n\
+                   \x20   oo::class create Factory { method make {} { return a } }\n\
+                   \x20   Factory create rex\n\
+                   }\n\
+                   namespace eval ::b {\n\
+                   \x20   oo::class create Widget { method make {} { return b } }\n\
+                   \x20   Widget create rex\n\
+                   }\n";
+        assert_eq!(hazard(src, &["::a::Factory"], "make", false), None);
+    }
+
+    fn var_hazard(source: &str, cell: &str) -> Option<String> {
+        let analysis = analyse(source);
+        namespace_variable_rename_hazard(source, "tcl8.6", &analysis, cell, &LineIndex::new(source))
+            .map(|r| r.reason)
+    }
+
+    /// FP guard: a computed variable name in a registry-declared variable-name
+    /// argument position may be naming the very cell being renamed, and there
+    /// is no word to rewrite.
+    #[test]
+    fn fp_refuses_a_namespace_variable_rename_beside_a_computed_name() {
+        let src = "namespace eval ::ns {\n\
+                   \x20   variable v 1\n\
+                   \x20   proc p {n} { set $n 2 }\n\
+                   }\n";
+        let reason = var_hazard(src, "::ns::v")
+            .expect("a `set $n` in the same document must refuse the cell rename");
+        assert!(reason.contains("computed at run time"), "{reason}");
+    }
+
+    /// FN guard: the ordinary namespace-variable document has no dynamic
+    /// name and must rename freely.
+    #[test]
+    fn fn_guard_allows_a_namespace_variable_rename_with_static_names() {
+        let src = "namespace eval ::ns {\n\
+                   \x20   variable v 1\n\
+                   \x20   proc p {} { variable v; return $v }\n\
+                   }\n\
+                   puts $::ns::v\n";
+        assert_eq!(var_hazard(src, "::ns::v"), None);
+    }
+}

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -1406,6 +1406,52 @@ impl WorkspaceIndex {
             .collect()
     }
 
+    /// Every document holding an indexed symbol declared **directly in**
+    /// `namespace` — a proc, a class, or a namespace variable whose parent
+    /// namespace is exactly it.
+    ///
+    /// The candidate set a namespace-variable *rename* must visit.  An
+    /// unqualified alias of `::ns::v` (`variable v` inside a proc, and every
+    /// bare `$v` it enables) is invisible to both variable tables — it is a
+    /// proc-scope binding, deliberately not indexed — but it can only be
+    /// written in a document that has code in `::ns`, and such a document
+    /// always declares something there.  Visiting those documents and
+    /// recomputing their edits from their own analysis is what keeps a
+    /// cross-document namespace-variable rename from leaving `variable v; …
+    /// $v` bodies naming a cell that no longer exists.
+    #[must_use]
+    pub fn documents_in_namespace(&self, namespace: &str) -> Vec<String> {
+        let target = namespace.trim_start_matches("::");
+        let parent_matches = |qualified: &str| -> bool {
+            let bare = qualified.trim_start_matches("::");
+            match bare.rfind("::") {
+                Some(idx) => &bare[..idx] == target,
+                None => target.is_empty(),
+            }
+        };
+        let mut uris: Vec<String> = self
+            .procs
+            .iter()
+            .filter(|p| parent_matches(&p.qualified_name))
+            .map(|p| p.uri.clone())
+            .chain(
+                self.classes
+                    .iter()
+                    .filter(|c| parent_matches(&c.qualified_name))
+                    .map(|c| c.uri.clone()),
+            )
+            .chain(
+                self.variables
+                    .iter()
+                    .filter(|v| parent_matches(&v.qualified_name))
+                    .map(|v| v.uri.clone()),
+            )
+            .collect();
+        uris.sort();
+        uris.dedup();
+        uris
+    }
+
     /// Occurrence (read / write) sites naming the namespace variable
     /// `qualified_name`, excluding any in `exclude_uri`.  The reference-side
     /// twin of [`Self::variable_definitions_qualified`], matched the same

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -283,6 +283,50 @@ pub struct WorkspaceVariableRef {
     pub span: Span,
 }
 
+/// One local **alias** of a namespace-qualified cell recorded in the index —
+/// a `variable v` / `global ::ns::v` / `namespace upvar ::ns v local` /
+/// `upvar #0 ::ns::v local`, wherever it is written.
+///
+/// The third variable table, and the only one that is not about a document's
+/// *own* namespace.  An alias binds a cell from an arbitrary scope in an
+/// arbitrary namespace: a global `proc p {} { namespace upvar ::ns v local;
+/// return $local }` binds `::ns::v` while declaring nothing in `::ns` and
+/// writing no qualified occurrence, so it appears in neither
+/// [`WorkspaceVariable`] nor [`WorkspaceVariableRef`] nor
+/// [`WorkspaceIndex::documents_in_namespace`].  Renaming `::ns::v` without
+/// visiting that document moves the declaration and leaves the alias bound to
+/// a cell that no longer exists — `can't read "local": no such variable` on
+/// tclsh 9.0.4 and 8.6.16 alike.
+///
+/// Unlike the other two tables this one *is* keyed on a proc-scope binding.
+/// That is not a widening of the index's bound: the fact recorded is the
+/// **qualified cell** the alias names, which is exactly as spellable from
+/// another document as a declaration is.  The local spelling is not recorded
+/// and stays a per-document question.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceVariableAlias {
+    /// Document the alias is written in.
+    pub uri: String,
+    /// `::`-rooted cell the alias binds to, e.g. `::ns::v`.
+    pub qualified_name: String,
+}
+
+/// Whether a word carries a substitution marker, so its run-time text is not
+/// the text as written.
+fn is_computed_word(word: &str) -> bool {
+    word.contains(['$', '['])
+}
+
+/// Whether an alias's recorded cell is **computed** rather than a fixed name.
+///
+/// `namespace upvar $ns v local` records the cell as written (`::$ns::v`) —
+/// the analyser keeps the substitution marker rather than inventing a name —
+/// so a marker anywhere in the cell is exactly the signal that this alias
+/// binds no statically-known variable.
+fn alias_cell_is_computed(cell: &str) -> bool {
+    is_computed_word(cell)
+}
+
 /// One `source FILE` reference recorded in the index.
 ///
 /// Tracks where a document loads another file so a file rename can
@@ -439,6 +483,7 @@ pub struct WorkspaceIndex {
     classes: Vec<WorkspaceClass>,
     variables: Vec<WorkspaceVariable>,
     variable_refs: Vec<WorkspaceVariableRef>,
+    variable_aliases: Vec<WorkspaceVariableAlias>,
     invocations: Vec<WorkspaceInvocation>,
     sources: Vec<WorkspaceSource>,
     package_requires: Vec<WorkspacePackageRequire>,
@@ -590,27 +635,7 @@ impl WorkspaceIndex {
                 metaclass: class_def.metaclass.clone(),
             });
         }
-        // Namespace-scoped variable declarations only — the compiler owns the
-        // "which frames hold a namespace's variable table" rule
-        // (`namespace_variables`, the enumerating twin of the single-name
-        // `lookup_var_in_namespace` the in-document providers use), so the
-        // index cannot drift from it.
-        for (qualified, var) in tcl_compiler::analyser::namespace_variables(&analysis.global_scope)
-        {
-            self.variables.push(WorkspaceVariable {
-                uri: uri.to_owned(),
-                name: var.name.clone(),
-                qualified_name: qualified,
-                name_span: var.definition_span,
-            });
-        }
-        for vref in &analysis.qualified_var_refs {
-            self.variable_refs.push(WorkspaceVariableRef {
-                uri: uri.to_owned(),
-                qualified_name: tcl_syntax::naming::normalise_qualified_name(&vref.qualified_name),
-                span: vref.span,
-            });
-        }
+        self.index_variables(uri, analysis);
         for inv in &analysis.command_invocations {
             self.invocations.push(WorkspaceInvocation {
                 uri: uri.to_owned(),
@@ -644,6 +669,47 @@ impl WorkspaceIndex {
             });
         }
         self.index_command_links(uri, analysis);
+    }
+
+    /// Lift a document's three **variable** tables: the namespace-scoped
+    /// declarations it holds, the qualified cells it *aliases*, and the
+    /// qualified occurrences it writes.
+    ///
+    /// The compiler owns both enumeration rules — `namespace_variables` (the
+    /// enumerating twin of the single-name `lookup_var_in_namespace` the
+    /// in-document providers use) and `variable_alias_links` (the enumerating
+    /// twin of `VarDef::link_target`) — so the index cannot drift from what a
+    /// single-document lookup would answer.
+    fn index_variables(&mut self, uri: &str, analysis: &AnalysisResult) {
+        for (qualified, var) in tcl_compiler::analyser::namespace_variables(&analysis.global_scope)
+        {
+            self.variables.push(WorkspaceVariable {
+                uri: uri.to_owned(),
+                name: var.name.clone(),
+                qualified_name: qualified,
+                name_span: var.definition_span,
+            });
+        }
+        // Only the *cell* is recorded, so a document aliasing one cell twenty
+        // times contributes one row: the question this table answers is "must
+        // the rename visit this document", not "where in it".
+        let mut aliased: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
+        for link in tcl_compiler::analyser::variable_alias_links(&analysis.global_scope) {
+            aliased.insert(tcl_syntax::naming::normalise_qualified_name(link.cell));
+        }
+        for qualified_name in aliased {
+            self.variable_aliases.push(WorkspaceVariableAlias {
+                uri: uri.to_owned(),
+                qualified_name,
+            });
+        }
+        for vref in &analysis.qualified_var_refs {
+            self.variable_refs.push(WorkspaceVariableRef {
+                uri: uri.to_owned(),
+                qualified_name: tcl_syntax::naming::normalise_qualified_name(&vref.qualified_name),
+                span: vref.span,
+            });
+        }
     }
 
     /// Lift a document's `namespace import` / `interp alias` / `rename`
@@ -734,6 +800,7 @@ impl WorkspaceIndex {
         self.classes.retain(|c| c.uri != uri);
         self.variables.retain(|v| v.uri != uri);
         self.variable_refs.retain(|v| v.uri != uri);
+        self.variable_aliases.retain(|v| v.uri != uri);
         self.invocations.retain(|i| i.uri != uri);
         self.sources.retain(|s| s.uri != uri);
         self.package_requires.retain(|pr| pr.uri != uri);
@@ -1410,15 +1477,18 @@ impl WorkspaceIndex {
     /// `namespace` — a proc, a class, or a namespace variable whose parent
     /// namespace is exactly it.
     ///
-    /// The candidate set a namespace-variable *rename* must visit.  An
-    /// unqualified alias of `::ns::v` (`variable v` inside a proc, and every
-    /// bare `$v` it enables) is invisible to both variable tables — it is a
-    /// proc-scope binding, deliberately not indexed — but it can only be
-    /// written in a document that has code in `::ns`, and such a document
-    /// always declares something there.  Visiting those documents and
-    /// recomputing their edits from their own analysis is what keeps a
-    /// cross-document namespace-variable rename from leaving `variable v; …
-    /// $v` bodies naming a cell that no longer exists.
+    /// One of the three candidate sources a namespace-variable *rename* must
+    /// visit, and the one that catches a document whose only stake in the
+    /// cell is an unqualified alias written *inside* the namespace
+    /// (`namespace eval ns { proc p {} { variable v; puts $v } }`): that
+    /// binding is proc-scope and deliberately not in either variable table,
+    /// but the enclosing `proc` is indexed as `::ns::p`.
+    ///
+    /// It is **not** sufficient on its own.  An alias can be written from any
+    /// namespace — a global `proc p {} { namespace upvar ::ns v local; … }`
+    /// declares nothing in `::ns` at all — which is what
+    /// [`Self::documents_aliasing_variable`] answers.  Both are needed;
+    /// neither subsumes the other.
     #[must_use]
     pub fn documents_in_namespace(&self, namespace: &str) -> Vec<String> {
         let target = namespace.trim_start_matches("::");
@@ -1446,6 +1516,77 @@ impl WorkspaceIndex {
                     .filter(|v| parent_matches(&v.qualified_name))
                     .map(|v| v.uri.clone()),
             )
+            .collect();
+        uris.sort();
+        uris.dedup();
+        uris
+    }
+
+    /// Every document holding a local **alias** of the cell `qualified_name`
+    /// — a `variable v` / `global ::ns::v` / `namespace upvar ::ns v local` /
+    /// `upvar #0 ::ns::v local`, written from any scope in any namespace.
+    ///
+    /// The candidate source that makes a namespace-variable rename's coverage
+    /// provable rather than presumed.  A document can bind `::ns::v` without
+    /// declaring anything in `::ns` and without writing a single qualified
+    /// occurrence of it, so it appears in neither variable table and in no
+    /// namespace listing; renaming the cell while leaving that document
+    /// unvisited leaves the alias bound to a cell that no longer exists.
+    ///
+    /// Matched the same exact way as the other two — one cell, one name, no
+    /// scope-chain search (see [`Self::variable_definitions_qualified`]).
+    /// Aliases whose cell is *computed* name no fixed cell and so match
+    /// nothing here; they are [`Self::documents_with_ambiguous_alias_of`]'s
+    /// business instead.
+    #[must_use]
+    pub fn documents_aliasing_variable(&self, qualified_name: &str) -> Vec<String> {
+        let target = qualified_name.trim_start_matches("::");
+        let mut uris: Vec<String> = self
+            .variable_aliases
+            .iter()
+            .filter(|a| !alias_cell_is_computed(&a.qualified_name))
+            .filter(|a| a.qualified_name.trim_start_matches("::") == target)
+            .map(|a| a.uri.clone())
+            .collect();
+        uris.sort();
+        uris.dedup();
+        uris
+    }
+
+    /// Every document holding an alias whose cell is **computed** and could
+    /// therefore be `qualified_name` — `namespace upvar $ns version local`,
+    /// `namespace upvar ::ns $v local`.
+    ///
+    /// The completeness proof for [`Self::documents_aliasing_variable`].  A
+    /// computed cell names no fixed variable, so no candidate scan can find
+    /// the alias and no edit can keep it consistent; renaming the cell anyway
+    /// leaves it bound to a variable that no longer exists (tclsh 9.0.4 /
+    /// 8.6.16 alike: `namespace eval mypkg { variable version 1 }` +
+    /// `namespace upvar $ns version local` prints `1`, and renaming
+    /// `version` to `release` gives `can't read "local": no such variable`).
+    /// A rename whose cell this could be is refused.
+    ///
+    /// The match is on whichever half is still written literally, so this
+    /// stays narrow: a computed *namespace* with a literal tail can only be
+    /// this cell if the tails agree, and a computed *tail* under a literal
+    /// namespace only if the namespaces do.  Both computed matches anything
+    /// in scope.
+    #[must_use]
+    pub fn documents_with_ambiguous_alias_of(&self, qualified_name: &str) -> Vec<String> {
+        let bare = qualified_name.trim_start_matches("::");
+        let (cell_ns, cell_tail) = bare.rsplit_once("::").unwrap_or(("", bare));
+        let mut uris: Vec<String> = self
+            .variable_aliases
+            .iter()
+            .filter(|a| alias_cell_is_computed(&a.qualified_name))
+            .filter(|a| {
+                let written = a.qualified_name.trim_start_matches("::");
+                let (ns, tail) = written.rsplit_once("::").unwrap_or(("", written));
+                let ns_could_match = is_computed_word(ns) || ns == cell_ns;
+                let tail_could_match = is_computed_word(tail) || tail == cell_tail;
+                ns_could_match && tail_could_match
+            })
+            .map(|a| a.uri.clone())
             .collect();
         uris.sort();
         uris.dedup();
@@ -2729,6 +2870,64 @@ mod tests {
         assert!(
             index.workspace_command_exists_for_call("::set", false),
             "with no colliding builtin, the nested alias still counts",
+        );
+    }
+
+    /// TP (Codex review of PR #1091, finding 2) — a document whose only stake
+    /// in `::ns::v` is an alias written from *outside* `::ns` is found by the
+    /// alias table, and by nothing else.
+    ///
+    /// A global `proc p {} { namespace upvar ::ns v local; … }` declares
+    /// nothing in `::ns`, holds no namespace-scoped declaration of the cell,
+    /// and writes no qualified occurrence of it — so all three of the older
+    /// candidate sources miss it, while the alias it holds breaks the moment
+    /// the declaration moves without it (tclsh 9.0.4 / 8.6.16: `can't read
+    /// "local": no such variable`).
+    #[test]
+    fn indexes_a_cell_alias_written_from_another_namespace() {
+        let decl = analyse("namespace eval ns {\n    variable v 1\n}\n");
+        let aliaser =
+            analyse("proc p {} {\n    namespace upvar ::ns v local\n    return $local\n}\n");
+        let mut index = WorkspaceIndex::new();
+        index.add_document("file:///decl.tcl", &decl);
+        index.add_document("file:///aliaser.tcl", &aliaser);
+
+        assert_eq!(
+            index.documents_aliasing_variable("::ns::v"),
+            vec![
+                "file:///aliaser.tcl".to_string(),
+                "file:///decl.tcl".to_string()
+            ],
+            "both the `variable v` declaration and the out-of-namespace \
+             `namespace upvar` are aliases of the one cell",
+        );
+        assert!(
+            !index
+                .documents_in_namespace("::ns")
+                .contains(&"file:///aliaser.tcl".to_string()),
+            "the aliasing document declares nothing in ::ns — which is why \
+             the alias table is needed",
+        );
+        assert!(
+            index
+                .variable_refs_of("::ns::v", "")
+                .iter()
+                .all(|r| r.uri != "file:///aliaser.tcl"),
+            "and it writes no qualified occurrence either",
+        );
+    }
+
+    /// TN (same finding) — the alias table is keyed on the cell, so an alias
+    /// of a *different* cell never drags its document into another cell's
+    /// rename.
+    #[test]
+    fn cell_alias_index_does_not_match_a_different_cell() {
+        let other = analyse("proc p {} {\n    namespace upvar ::ns other local\n}\n");
+        let index = WorkspaceIndex::from_documents([("file:///other.tcl", &other)]);
+        assert!(index.documents_aliasing_variable("::ns::v").is_empty());
+        assert_eq!(
+            index.documents_aliasing_variable("::ns::other"),
+            vec!["file:///other.tcl".to_string()]
         );
     }
 

--- a/rust/tcl-lsp-core/tests/name_resolution.rs
+++ b/rust/tcl-lsp-core/tests/name_resolution.rs
@@ -1134,6 +1134,53 @@ mod namespace_scoped_class_dispatch {
         assert_eq!(refs_at(src, 2, 15), vec![2, 5], "decl + `rex make`");
     }
 
+    /// TN + TP, the object-command half of #981 (closed by PR C3).
+    ///
+    /// `CLASS create NAME` binds `NAME` in the **creation site's** namespace,
+    /// so `::a::Factory create rex` and `::b::Widget create rex` are two
+    /// coexisting commands.  Oracle, identical on tclsh 9.0.4 and 8.6.16:
+    ///
+    /// ```text
+    /// in ::a -> a-made
+    /// in ::b -> b-made
+    /// global a: a-made        ;# ::a::rex make
+    /// global b: b-made        ;# ::b::rex make
+    /// ```
+    ///
+    /// Before this fix `created_instance_commands` was a flat bare-name set:
+    /// `::b::Widget::make` counted (and renamed) `::a`'s `rex make`, while
+    /// `::a::Factory::make` lost its own call site entirely to
+    /// last-write-wins.
+    #[test]
+    fn tn_object_command_dispatch_is_scoped_to_its_creation_namespace() {
+        let src = concat!(
+            "namespace eval ::a {\n",
+            "    oo::class create Factory {\n",
+            "        method make {} { return 1 }\n",
+            "    }\n",
+            "    Factory create rex\n",
+            "    rex make\n",
+            "}\n",
+            "namespace eval ::b {\n",
+            "    oo::class create Widget {\n",
+            "        method make {} { return 2 }\n",
+            "    }\n",
+            "    Widget create rex\n",
+            "    rex make\n",
+            "}\n",
+        );
+        assert_eq!(
+            refs_at(src, 2, 15),
+            vec![2, 5],
+            "::a::Factory::make: decl + its OWN `rex make`, never ::b's"
+        );
+        assert_eq!(
+            refs_at(src, 9, 15),
+            vec![9, 12],
+            "::b::Widget::make: decl + its OWN `rex make`, never ::a's"
+        );
+    }
+
     /// FN→TP: an **explicit** `namespace import` creates a real command in the
     /// importing namespace, so a bare dispatch through the imported name is a
     /// reference to the source class's method.  Post-#1047 this one scanner

--- a/rust/tcl-lsp-core/tests/references_residual.rs
+++ b/rust/tcl-lsp-core/tests/references_residual.rs
@@ -284,6 +284,7 @@ fn document_highlights_dedup_keeps_write_over_read_on_collision() {
             warn_if_unused: false,
             array_indices: std::collections::BTreeSet::new(),
             link_target: None,
+            link_target_span: None,
         },
     );
     let analysis = R {

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -2809,6 +2809,9 @@ struct ConsumerScan {
     /// Qualified names of every class whose instances dispatch the method to
     /// the family — the override-family definers plus the pure inheritors.
     family: Vec<String>,
+    /// Documents **declaring** a family class — the definers' and pure
+    /// inheritors' own files.
+    family_uris: Vec<String>,
     /// Candidate consumer documents: those invoking a family constructor.
     consumer_uris: Vec<String>,
     /// Class names valid as a bare classmethod-dispatch head; empty for an
@@ -5583,6 +5586,13 @@ impl Backend {
         }
         family.sort();
         family.dedup();
+        let mut family_uris: Vec<String> = definers
+            .iter()
+            .chain(inheritors.iter())
+            .map(|wc| wc.uri.clone())
+            .collect();
+        family_uris.sort();
+        family_uris.dedup();
         let family_norm: std::collections::HashSet<&str> =
             family.iter().map(|s| s.trim_start_matches("::")).collect();
         // The index answers with a `HashSet`; sort so the per-document scan
@@ -5596,6 +5606,7 @@ impl Backend {
         drop(index);
         Some(ConsumerScan {
             family,
+            family_uris,
             consumer_uris,
             classmethod_cmd_names,
         })
@@ -5798,6 +5809,31 @@ impl Backend {
     /// bit as fatal as one in the request's own: the edit set spans all of
     /// them, so an unrewritable dispatch anywhere refuses the whole rename
     /// rather than half-applying it (issue #923 idx 79).
+    ///
+    /// # The gate's set is the edit collector's set
+    ///
+    /// Coverage comes from [`Self::consumer_scan_plan`] — the *same* index
+    /// read [`Self::cross_file_method_rename`] resolves its own document set
+    /// from — so the two can never diverge.  A gate narrower than the edit
+    /// collector is a hollow guarantee: a pure-consumer document that
+    /// dispatches the method on an untracked receiver is rewritten by the
+    /// consumer leg but, if never scanned, contributes no refusal, and the
+    /// declaration moves out from under a call that still names the old
+    /// member (issue #1092, Codex review of PR #1091).  The set is therefore
+    /// the definers' and pure inheritors' documents, every consumer document,
+    /// and the request's own.
+    ///
+    /// Each document is scanned against the **workspace-class oracle**
+    /// analysis, which is exactly what the consumer edit leg resolves its
+    /// call sites with — so a receiver the oracle types (and the edit
+    /// collector therefore rewrites) is not mistaken for an untracked one.
+    /// That analysis is memoised per document in
+    /// [`Self::analyse_with_workspace_classes`], so scanning a document here
+    /// and rewriting it there analyses it once between them, not twice.
+    ///
+    /// Falls back to the request's own document and the seed class when the
+    /// family is not indexed at all (a freshly-opened buffer): the gate still
+    /// applies to what the single-document rename would edit.
     async fn method_rename_refusal(
         &self,
         uri: &Uri,
@@ -5807,25 +5843,16 @@ impl Backend {
     ) -> Option<core_rename_safety::RenameRefusal> {
         let (seed_class, method, is_classmethod) =
             core_rename::method_rename_target(&doc.text, pos.line, pos.character, analysis)?;
-        let family: Vec<String> = {
-            let index = self.workspace_index.read().await;
-            let mut f: Vec<String> = index
-                .method_override_family(&seed_class, &method)
-                .into_iter()
-                .map(|c| c.qualified_name.clone())
-                .collect();
-            if !f.contains(&seed_class) {
-                f.push(seed_class.clone());
+        let plan = self
+            .consumer_scan_plan(&doc.dialect, &seed_class, &method, is_classmethod)
+            .await;
+        let (family, mut uris) = match plan {
+            Some(plan) => {
+                let mut uris = plan.family_uris;
+                uris.extend(plan.consumer_uris);
+                (plan.family, uris)
             }
-            f
-        };
-        let mut uris: Vec<String> = {
-            let index = self.workspace_index.read().await;
-            index
-                .method_override_family(&seed_class, &method)
-                .into_iter()
-                .map(|c| c.uri.clone())
-                .collect()
+            None => (vec![seed_class.clone()], Vec::new()),
         };
         uris.push(uri.as_str().to_owned());
         uris.sort();
@@ -5838,7 +5865,7 @@ impl Backend {
                 continue;
             };
             let target_analysis = self
-                .analysis_for(&parsed, target_doc.text.clone(), target_doc.dialect.clone())
+                .analyse_with_workspace_classes(&parsed, &target_doc.text, &target_doc.dialect)
                 .await;
             if let Some(refusal) = core_rename_safety::method_rename_hazard(
                 &target_doc.text,
@@ -5870,13 +5897,20 @@ impl Backend {
     /// Every candidate document is re-analysed and its share of the edit set
     /// computed by [`core_rename::namespace_variable_rename_edits`], so a
     /// proc-local `variable v` alias and its unqualified `$v` reads are
-    /// rewritten alongside the declaration.  Candidates are the documents
-    /// declaring the cell, those naming it qualified, and those with any code
-    /// in its namespace ([`WorkspaceIndex::documents_in_namespace`]).
+    /// rewritten alongside the declaration.  Candidates come from four index
+    /// sources, and all four are needed — no one of them subsumes another:
+    /// the documents **declaring** the cell, those **naming it qualified**,
+    /// those with any code **in its namespace**
+    /// ([`WorkspaceIndex::documents_in_namespace`], which catches an
+    /// unqualified `variable v` alias written inside `::ns`), and those
+    /// **aliasing** it from anywhere at all
+    /// ([`WorkspaceIndex::documents_aliasing_variable`], which catches a
+    /// `namespace upvar ::ns v local` written from `::`).
     ///
     /// `Err` is a **refusal**, not a miss: the new name would collide with an
-    /// existing cell, or a candidate document computes a variable name that
-    /// might be this very cell.
+    /// existing cell, some document aliases a cell computed at run time that
+    /// might be this one, or a candidate document computes a variable name
+    /// that might be this very cell.
     async fn cross_document_variable_rename(
         &self,
         uri: &Uri,
@@ -5902,15 +5936,35 @@ impl Backend {
             let index = self.workspace_index.read().await;
             // Collision gate: the target cell already exists, so the rename
             // would silently merge two distinct namespace variables.
+            // A document that only *aliases* the target cell is proof it
+            // exists just as much as a declaration is, and merging onto it is
+            // just as destructive — so both tables gate the collision.
             if !index
                 .variable_definitions_qualified(&new_cell, "")
                 .is_empty()
+                || !index.documents_aliasing_variable(&new_cell).is_empty()
             {
                 return Err(core_rename_safety::RenameRefusal {
                     reason: format!(
                         "cannot rename `{cell}`: `{new_cell}` is already declared in this \
                          workspace, and renaming would merge two distinct namespace variables \
                          into one cell."
+                    ),
+                    range: None,
+                });
+            }
+            // Coverage gate: an alias whose cell is computed
+            // (`namespace upvar $ns version local`) names no fixed variable,
+            // so no candidate scan can find it and no edit can keep it
+            // consistent.  Refuse rather than rename out from under it.
+            if let Some(u) = index.documents_with_ambiguous_alias_of(&cell).first() {
+                return Err(core_rename_safety::RenameRefusal {
+                    reason: format!(
+                        "cannot rename `{cell}`: `{u}` aliases a namespace variable whose \
+                         cell is computed at run time, so this rename can neither prove \
+                         that alias names `{cell}` nor prove it does not. Renaming the \
+                         declaration would leave it bound to a variable that no longer \
+                         exists."
                     ),
                     range: None,
                 });
@@ -5926,6 +5980,11 @@ impl Backend {
                         .map(|v| v.uri.clone()),
                 )
                 .chain(index.documents_in_namespace(namespace))
+                // Documents that merely *bind* the cell — a global `proc p {}
+                // { namespace upvar ::ns v local; … }` sits in none of the
+                // three sources above, yet its alias breaks the moment the
+                // declaration moves without it.
+                .chain(index.documents_aliasing_variable(&cell))
                 .collect();
             c.push(uri.as_str().to_owned());
             c.sort();

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -67,6 +67,7 @@ use tcl_lsp_core::minify as core_minify;
 use tcl_lsp_core::package_resolver::PackageResolver;
 use tcl_lsp_core::references as core_references;
 use tcl_lsp_core::rename as core_rename;
+use tcl_lsp_core::rename_safety as core_rename_safety;
 use tcl_lsp_core::selection_range as core_selection_range;
 use tcl_lsp_core::semantic_tokens as core_semantic_tokens;
 use tcl_lsp_core::signature_help::{
@@ -5721,6 +5722,257 @@ impl Backend {
             classmethod_cmd_names,
         }
     }
+    /// The cross-file **override-family** method rename, or `None` when the
+    /// cursor names no method (or the family produced no edit).
+    ///
+    /// A method (re)defined up or down the hierarchy is one polymorphic name,
+    /// and the override family can span files, so this handles the current
+    /// document *and* every sibling that defines a family class uniformly —
+    /// the single-document family is incomplete when the connecting ancestor
+    /// lives in another file.  Falling through to the single-document path on
+    /// an empty result keeps an unpopulated index from regressing anything.
+    async fn method_family_rename_tier(
+        &self,
+        uri: &Uri,
+        doc: &DocumentState,
+        analysis: &AnalysisResult,
+        pos: Position,
+        new_name: &str,
+    ) -> Option<std::collections::HashMap<Uri, Vec<TextEdit>>> {
+        if !core_rename::is_safe_symbol_name(new_name) {
+            return None;
+        }
+        let (seed_class, method, is_classmethod) =
+            core_rename::method_rename_target(&doc.text, pos.line, pos.character, analysis)?;
+        let changes = self
+            .cross_file_method_rename(uri, doc, &seed_class, &method, new_name, is_classmethod)
+            .await;
+        (!changes.is_empty()).then_some(changes)
+    }
+
+    /// The two rename tiers that answer *before* the ordinary in-document /
+    /// cross-document path, or `None` when neither applies.
+    ///
+    /// `Some(Err(..))` is a **refusal** carrying its own reason; `Some(Ok(..))`
+    /// is a complete namespace-variable edit set.  Split out of
+    /// [`Backend::rename`] so that handler stays inside the line budget.
+    async fn gated_rename_tiers(
+        &self,
+        uri: &Uri,
+        doc: &DocumentState,
+        analysis: &AnalysisResult,
+        pos: Position,
+        new_name: &str,
+    ) -> Option<jsonrpc::Result<Option<WorkspaceEdit>>> {
+        // Safety gate: when the cursor names a `TclOO` member whose dispatch
+        // this rename cannot account for anywhere in the workspace, refuse
+        // with a precise reason instead of emitting a partial edit set that
+        // breaks the program once applied.
+        if core_rename::is_safe_symbol_name(new_name)
+            && let Some(refusal) = self.method_rename_refusal(uri, doc, analysis, pos).await
+        {
+            return Some(Err(rename_refusal_error(&refusal)));
+        }
+        // Namespace-variable tier: the cursor names a `::`-rooted cell, so
+        // rename it across every document that declares, aliases, or names it.
+        match self
+            .cross_document_variable_rename(uri, doc, analysis, pos, new_name)
+            .await
+        {
+            Err(refusal) => Some(Err(rename_refusal_error(&refusal))),
+            Ok(changes) if !changes.is_empty() => Some(Ok(Some(WorkspaceEdit {
+                changes: Some(changes),
+                document_changes: None,
+                change_annotations: None,
+            }))),
+            Ok(_) => None,
+        }
+    }
+
+    /// The rename **safety refusal** for the `TclOO` member at `pos`, if any —
+    /// checked across every document the rename would touch before a single
+    /// edit is built.
+    ///
+    /// The gate itself is [`core_rename_safety::method_rename_hazard`]; this
+    /// is the workspace fan-out.  A hazard in a *sibling* document is every
+    /// bit as fatal as one in the request's own: the edit set spans all of
+    /// them, so an unrewritable dispatch anywhere refuses the whole rename
+    /// rather than half-applying it (issue #923 idx 79).
+    async fn method_rename_refusal(
+        &self,
+        uri: &Uri,
+        doc: &DocumentState,
+        analysis: &AnalysisResult,
+        pos: Position,
+    ) -> Option<core_rename_safety::RenameRefusal> {
+        let (seed_class, method, is_classmethod) =
+            core_rename::method_rename_target(&doc.text, pos.line, pos.character, analysis)?;
+        let family: Vec<String> = {
+            let index = self.workspace_index.read().await;
+            let mut f: Vec<String> = index
+                .method_override_family(&seed_class, &method)
+                .into_iter()
+                .map(|c| c.qualified_name.clone())
+                .collect();
+            if !f.contains(&seed_class) {
+                f.push(seed_class.clone());
+            }
+            f
+        };
+        let mut uris: Vec<String> = {
+            let index = self.workspace_index.read().await;
+            index
+                .method_override_family(&seed_class, &method)
+                .into_iter()
+                .map(|c| c.uri.clone())
+                .collect()
+        };
+        uris.push(uri.as_str().to_owned());
+        uris.sort();
+        uris.dedup();
+        for u in uris {
+            let Ok(parsed) = Uri::from_str(&u) else {
+                continue;
+            };
+            let Some(target_doc) = self.read_document(&parsed).await else {
+                continue;
+            };
+            let target_analysis = self
+                .analysis_for(&parsed, target_doc.text.clone(), target_doc.dialect.clone())
+                .await;
+            if let Some(refusal) = core_rename_safety::method_rename_hazard(
+                &target_doc.text,
+                &target_doc.dialect,
+                &target_analysis,
+                core_rename_safety::MethodRenameTarget {
+                    family: &family,
+                    method: &method,
+                    is_classmethod,
+                },
+                &target_doc.line_index,
+            ) {
+                return Some(refusal);
+            }
+        }
+        None
+    }
+
+    /// Rename the **namespace variable** cell at `pos` across the workspace
+    /// (PR C3, completing the cross-document variable tier PR #1086 added for
+    /// go-to-definition / hover / find-references).
+    ///
+    /// The cell is resolved by the one shared entry point
+    /// ([`Self::qualified_variable_cell`]), which already applies the
+    /// inert-text gate every other provider applies — a `$::ns::v`-shaped
+    /// substring inside a comment or a brace-quoted data word substitutes
+    /// nothing and is not an occurrence.
+    ///
+    /// Every candidate document is re-analysed and its share of the edit set
+    /// computed by [`core_rename::namespace_variable_rename_edits`], so a
+    /// proc-local `variable v` alias and its unqualified `$v` reads are
+    /// rewritten alongside the declaration.  Candidates are the documents
+    /// declaring the cell, those naming it qualified, and those with any code
+    /// in its namespace ([`WorkspaceIndex::documents_in_namespace`]).
+    ///
+    /// `Err` is a **refusal**, not a miss: the new name would collide with an
+    /// existing cell, or a candidate document computes a variable name that
+    /// might be this very cell.
+    async fn cross_document_variable_rename(
+        &self,
+        uri: &Uri,
+        doc: &DocumentState,
+        analysis: &AnalysisResult,
+        pos: Position,
+        new_name: &str,
+    ) -> Result<std::collections::HashMap<Uri, Vec<TextEdit>>, core_rename_safety::RenameRefusal>
+    {
+        let mut changes: std::collections::HashMap<Uri, Vec<TextEdit>> =
+            std::collections::HashMap::new();
+        let Some(cell) = Self::qualified_variable_cell(&doc.text, &analysis.dialect, analysis, pos)
+        else {
+            return Ok(changes);
+        };
+        if !core_rename::is_safe_symbol_name(new_name) {
+            return Ok(changes);
+        }
+        self.refresh_source_rehoming().await;
+        let namespace = cell.rsplit_once("::").map_or("::", |(ns, _)| ns);
+        let new_cell = format!("{namespace}::{new_name}");
+        let candidates: Vec<String> = {
+            let index = self.workspace_index.read().await;
+            // Collision gate: the target cell already exists, so the rename
+            // would silently merge two distinct namespace variables.
+            if !index
+                .variable_definitions_qualified(&new_cell, "")
+                .is_empty()
+            {
+                return Err(core_rename_safety::RenameRefusal {
+                    reason: format!(
+                        "cannot rename `{cell}`: `{new_cell}` is already declared in this \
+                         workspace, and renaming would merge two distinct namespace variables \
+                         into one cell."
+                    ),
+                    range: None,
+                });
+            }
+            let mut c: Vec<String> = index
+                .variable_definitions_qualified(&cell, "")
+                .into_iter()
+                .map(|v| v.uri.clone())
+                .chain(
+                    index
+                        .variable_refs_of(&cell, "")
+                        .into_iter()
+                        .map(|v| v.uri.clone()),
+                )
+                .chain(index.documents_in_namespace(namespace))
+                .collect();
+            c.push(uri.as_str().to_owned());
+            c.sort();
+            c.dedup();
+            c
+        };
+        for u in candidates {
+            let Ok(parsed) = Uri::from_str(&u) else {
+                continue;
+            };
+            let Some(target_doc) = self.read_document(&parsed).await else {
+                continue;
+            };
+            let target_analysis = self
+                .analysis_for(&parsed, target_doc.text.clone(), target_doc.dialect.clone())
+                .await;
+            if let Some(refusal) = core_rename_safety::namespace_variable_rename_hazard(
+                &target_doc.text,
+                &target_doc.dialect,
+                &target_analysis,
+                &cell,
+                &target_doc.line_index,
+            ) {
+                return Err(refusal);
+            }
+            let edits = core_rename::namespace_variable_rename_edits(
+                &target_doc.text,
+                &target_analysis,
+                &cell,
+                new_name,
+            );
+            if edits.is_empty() {
+                continue;
+            }
+            let bucket = changes.entry(parsed).or_default();
+            for e in edits {
+                let range = lift_lsp_range(e.range);
+                if !bucket.iter().any(|x| x.range == range) {
+                    bucket.push(TextEdit {
+                        range,
+                        new_text: e.new_text,
+                    });
+                }
+            }
+        }
+        Ok(changes)
+    }
 
     /// Cross-file rename of a `TclOO` method across its override family.
     ///
@@ -11268,35 +11520,25 @@ impl LanguageServer for Backend {
         let analysis = self
             .analysis_for(&uri, doc.text.clone(), doc.dialect.clone())
             .await;
-        // Method rename → cross-file override-family path.  A method
-        // (re)defined up or down the hierarchy is one polymorphic name, and
-        // the override family can span files, so this handles the current
-        // document *and* every sibling that defines a family class
-        // uniformly (the single-document family is incomplete when the
-        // connecting ancestor lives in another file).  Falls through to the
-        // single-document path when the family is empty (e.g. the index is
-        // not yet populated) so nothing regresses.
-        if core_rename::is_safe_symbol_name(&new_name)
-            && let Some((seed_class, method, is_classmethod)) =
-                core_rename::method_rename_target(&doc.text, pos.line, pos.character, &analysis)
+        // The gated tiers, before any ordinary edit is built: the `TclOO`
+        // member safety gate (issue #923 idx 79 / #981) and the workspace
+        // namespace-variable rename (PR #1086's reference set, rename half).
+        if let Some(gated) = self
+            .gated_rename_tiers(&uri, &doc, &analysis, pos, &new_name)
+            .await
         {
-            let changes = self
-                .cross_file_method_rename(
-                    &uri,
-                    &doc,
-                    &seed_class,
-                    &method,
-                    &new_name,
-                    is_classmethod,
-                )
-                .await;
-            if !changes.is_empty() {
-                return Ok(Some(WorkspaceEdit {
-                    changes: Some(changes),
-                    document_changes: None,
-                    change_annotations: None,
-                }));
-            }
+            return gated;
+        }
+        // Method rename → cross-file override-family path.
+        if let Some(changes) = self
+            .method_family_rename_tier(&uri, &doc, &analysis, pos, &new_name)
+            .await
+        {
+            return Ok(Some(WorkspaceEdit {
+                changes: Some(changes),
+                document_changes: None,
+                change_annotations: None,
+            }));
         }
         let text = doc.text.clone();
         let dialect = doc.dialect.clone();
@@ -11705,6 +11947,20 @@ fn lift_lsp_range(r: CoreLspRange) -> Range {
             line: r.end_line,
             character: r.end_character,
         },
+    }
+}
+/// Turn a rename safety refusal into the LSP error response the editor shows.
+///
+/// A refusal is deliberately **not** a `null` result: `null` means "nothing to
+/// rename here" and lets the editor quietly do nothing, which is exactly the
+/// wrong signal when the symbol *is* renameable but the rename would break the
+/// program.  `InvalidRequest` with the gate's own reason puts that reason in
+/// front of the user (issue #923 idx 79).
+fn rename_refusal_error(refusal: &core_rename_safety::RenameRefusal) -> jsonrpc::Error {
+    jsonrpc::Error {
+        code: jsonrpc::ErrorCode::InvalidRequest,
+        message: refusal.reason.clone().into(),
+        data: None,
     }
 }
 

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -81,6 +81,8 @@ mod recovery;
 mod references;
 #[path = "e2e/rename.rs"]
 mod rename;
+#[path = "e2e/rename_safety.rs"]
+mod rename_safety;
 #[path = "e2e/semantic_tokens.rs"]
 mod semantic_tokens;
 #[path = "e2e/semantic_tokens_reference_client.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/common/mod.rs
+++ b/rust/tcl-lsp-server/tests/e2e/common/mod.rs
@@ -661,6 +661,20 @@ impl Lsp {
 
     /// Like [`Lsp::request`] with an explicit timeout.
     pub fn request_timeout(&mut self, method: &str, params: Value, timeout: Duration) -> Value {
+        let resp = self.request_response(method, params, timeout);
+        if let Some(err) = resp.get("error") {
+            panic!("{method} -> error {err}");
+        }
+        resp.get("result").cloned().unwrap_or(Value::Null)
+    }
+
+    /// The whole JSON-RPC response object, `error` included.
+    ///
+    /// [`Lsp::request`] panics on an error response, which is right for every
+    /// request that must succeed — but the rename **safety gate** answers a
+    /// refusal *as* an error (a `null` result would read as "nothing to
+    /// rename here"), so its tests need the error itself.
+    pub fn request_response(&mut self, method: &str, params: Value, timeout: Duration) -> Value {
         let id = self.next_id;
         self.next_id += 1;
         let mut msg = json!({ "jsonrpc": "2.0", "id": id, "method": method });
@@ -672,10 +686,7 @@ impl Lsp {
             {
                 let mut responses = self.shared.responses.lock().unwrap();
                 if let Some(resp) = responses.remove(&id) {
-                    if let Some(err) = resp.get("error") {
-                        panic!("{method} -> error {err}");
-                    }
-                    return resp.get("result").cloned().unwrap_or(Value::Null);
+                    return resp;
                 }
             }
             assert!(
@@ -1299,6 +1310,16 @@ impl Lsp {
         let mut params = Self::doc_pos(uri, line, ch);
         params["newName"] = json!(new_name);
         self.request("textDocument/rename", params)
+    }
+    /// The rename request's JSON-RPC `error` object, or `null` when the
+    /// request succeeded — the wire view of a safety-gate refusal.
+    pub fn rename_error(&mut self, uri: &str, line: u32, ch: u32, new_name: &str) -> Value {
+        let mut params = Self::doc_pos(uri, line, ch);
+        params["newName"] = json!(new_name);
+        self.request_response("textDocument/rename", params, REQUEST_TIMEOUT)
+            .get("error")
+            .cloned()
+            .unwrap_or(Value::Null)
     }
     pub fn folding_range(&mut self, uri: &str) -> Value {
         self.request(

--- a/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
+++ b/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
@@ -382,3 +382,230 @@ fn fp_namespace_variable_rename_refuses_beside_a_computed_variable_name() {
         "the refusal must say why, got {err}"
     );
 }
+
+// -- Codex review of PR #1091: fan-out coverage -------------------------
+
+// FP guard (finding 1, issue #1092): the hazard lives in a **pure-consumer**
+// document — one that neither defines nor extends any family class.  The
+// consumer leg of the edit collector visits it; the gate must too, or the
+// gate's guarantee is hollow: the declaration moves while `$who speak` keeps
+// naming a member that no longer exists.
+//
+// Oracle, tclsh 9.0.4 and 8.6.16 identically:
+//   before                        -> `direct   -> woof`, `indirect -> woof`,
+//                                    rc 0
+//   after renaming `speak` -> `bark` in the definer and at the tracked call
+//   site, with the consumer's `[$who speak]` left alone
+//                                 -> `direct   -> woof` then `unknown method
+//                                    "speak": must be bark or destroy` at
+//                                    `"$who speak"`, rc 1
+#[test]
+fn fp_rename_refuses_a_hazard_that_lives_only_in_a_consumer_document() {
+    let mut lsp = Lsp::tcl();
+    let definer = unique_uri("tcl");
+    lsp.open_ready(
+        &definer,
+        "oo::class create Dog {\n\
+         \x20   method speak {} { return \"woof\" }\n\
+         \x20   export speak\n\
+         }\n",
+    );
+    // Pure consumer: constructs a `Dog` (so the index lists it as a consumer
+    // document) and *also* dispatches on a receiver nothing binds to a class.
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(
+        &consumer,
+        "proc bark {who} {\n\
+         \x20   return [$who speak]\n\
+         }\n\
+         set d [Dog new]\n\
+         puts [$d speak]\n\
+         puts [bark $d]\n",
+    );
+
+    // Cursor on the `speak` of `method speak`, in the definer.
+    let err = lsp.rename_error(&definer, 1, 11, "bark");
+    let message = err
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        message.contains("not tracked"),
+        "a hazard in a consumer document must refuse the whole rename, got {err}"
+    );
+}
+
+// FN guard (same finding): consumer documents whose dispatches are all
+// tracked and literal must still rename.  The fan-out widened to reach them;
+// it must not start refusing on their account.
+//
+// Oracle (9.0.4 / 8.6.16): renaming `speak` -> `bark` throughout keeps
+// `direct -> woof` / `via   -> woof`, rc 0.
+#[test]
+fn fn_guard_rename_still_applies_across_tracked_consumer_documents() {
+    let mut lsp = Lsp::tcl();
+    let definer = unique_uri("tcl");
+    lsp.open_ready(
+        &definer,
+        "oo::class create Dog {\n\
+         \x20   method speak {} { return \"woof\" }\n\
+         \x20   export speak\n\
+         }\n",
+    );
+    let consumer = unique_uri("tcl");
+    lsp.open_ready(
+        &consumer,
+        "set d [Dog new]\n\
+         puts [$d speak]\n",
+    );
+
+    let result = lsp.rename(&definer, 1, 11, "bark");
+    let edits = rename_edits(&result);
+    assert!(
+        edits.contains_key(&definer),
+        "the definer must be edited: {edits:?}"
+    );
+    assert!(
+        edits.contains_key(&consumer),
+        "the tracked consumer call site must be edited too: {edits:?}"
+    );
+    let texts = all_texts(&result);
+    assert!(
+        texts.iter().filter(|t| *t == "bark").count() >= 3,
+        "declaration, export, and the consumer call all rename: {texts:?}"
+    );
+}
+
+// TP (finding 2): a document whose only stake in the cell is an alias written
+// from **another namespace** is visited and rewritten.  A global `proc p {} {
+// namespace upvar ::ns v local; … }` declares nothing in `::ns` and writes no
+// qualified occurrence, so it is reached only through the index's alias
+// table.
+//
+// Oracle, tclsh 9.0.4 and 8.6.16 identically:
+//   before                        -> `p    -> 1`, `cell -> 1`, rc 0
+//   declaration renamed, alias left as `namespace upvar ::ns v local`
+//                                 -> `can't read "local": no such variable`
+//                                    at `"return $local"`, rc 1
+//   declaration renamed and the alias's target word rewritten to
+//   `namespace upvar ::ns total local`
+//                                 -> `p    -> 1`, `cell -> 1`, rc 0
+#[test]
+fn tp_namespace_variable_rename_reaches_an_alias_in_another_namespace() {
+    let mut lsp = Lsp::tcl();
+    let decl = unique_uri("tcl");
+    lsp.open_ready(&decl, "namespace eval mypkg {\n    variable version 1\n}\n");
+    let aliaser = unique_uri("tcl");
+    lsp.open_ready(
+        &aliaser,
+        "proc show {} {\n\
+         \x20   namespace upvar ::mypkg version local\n\
+         \x20   return $local\n\
+         }\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "puts $::mypkg::version\n");
+
+    let result = lsp.rename(&user, 0, 20, "release");
+    let edits = rename_edits(&result);
+    assert!(
+        edits.contains_key(&aliaser),
+        "the out-of-namespace aliasing document must be edited: {edits:?}"
+    );
+    let aliaser_texts: Vec<String> = edits
+        .get(&aliaser)
+        .into_iter()
+        .flatten()
+        .map(|e| {
+            e.get("newText")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned()
+        })
+        .collect();
+    assert_eq!(
+        aliaser_texts,
+        vec!["release".to_string()],
+        "exactly one edit there — the word naming the cell, not the local \
+         alias `local` nor its read: {aliaser_texts:?}"
+    );
+    let line: i64 = edits
+        .get(&aliaser)
+        .and_then(|e| e.first())
+        .and_then(|e| e.get("range"))
+        .and_then(|r| r.get("start"))
+        .and_then(|s| s.get("line"))
+        .and_then(Value::as_i64)
+        .unwrap_or(-1);
+    assert_eq!(line, 1, "the edit is on the `namespace upvar` line");
+}
+
+// FP guard (finding 2, completeness half): an alias whose *cell* is computed
+// (`namespace upvar $ns version local`) names no fixed variable, so no
+// candidate scan can find it and no edit can keep it consistent.  The rename
+// must refuse rather than move the declaration out from under it.
+//
+// Oracle, tclsh 9.0.4 and 8.6.16 identically:
+//   before                        -> `show -> 1`, `cell -> 1`, rc 0
+//   `variable version` renamed to `variable release`, the computed alias
+//   necessarily left as written
+//                                 -> `can't read "local": no such variable`
+//                                    at `"return $local"`, rc 1
+#[test]
+fn fp_namespace_variable_rename_refuses_beside_a_computed_alias_cell() {
+    let mut lsp = Lsp::tcl();
+    let decl = unique_uri("tcl");
+    lsp.open_ready(&decl, "namespace eval mypkg {\n    variable version 1\n}\n");
+    let aliaser = unique_uri("tcl");
+    lsp.open_ready(
+        &aliaser,
+        "proc show {ns} {\n\
+         \x20   namespace upvar $ns version local\n\
+         \x20   return $local\n\
+         }\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "puts $::mypkg::version\n");
+
+    let err = lsp.rename_error(&user, 0, 20, "release");
+    let message = err
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        message.contains("computed at run time"),
+        "the refusal must say why, got {err}"
+    );
+}
+
+// FN guard (same): a computed alias cell that provably is *not* this cell —
+// its literal tail names a different variable — must not block the rename.
+// Refusing on the mere presence of a `namespace upvar $ns … …` anywhere in
+// the workspace would make the tier unusable.
+#[test]
+fn fn_guard_namespace_variable_rename_ignores_a_computed_alias_of_another_cell() {
+    let mut lsp = Lsp::tcl();
+    let decl = unique_uri("tcl");
+    lsp.open_ready(&decl, "namespace eval mypkg {\n    variable version 1\n}\n");
+    let aliaser = unique_uri("tcl");
+    lsp.open_ready(
+        &aliaser,
+        "proc show {ns} {\n\
+         \x20   namespace upvar $ns counter local\n\
+         \x20   return $local\n\
+         }\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "puts $::mypkg::version\n");
+
+    let result = lsp.rename(&user, 0, 20, "release");
+    let edits = rename_edits(&result);
+    assert!(
+        edits.contains_key(&decl),
+        "a computed alias of `counter` says nothing about `version`: {edits:?}"
+    );
+    assert!(
+        !edits.contains_key(&aliaser),
+        "and it must not be edited: {edits:?}"
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
+++ b/rust/tcl-lsp-server/tests/e2e/rename_safety.rs
@@ -1,0 +1,384 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The rename **safety gate**, end-to-end on the wire (PR C3).
+//!
+//! Three mandates, one mechanism:
+//!
+//! * issue #923 differential-audit finding **idx 79** — a member dispatched on
+//!   a receiver whose class is not tracked;
+//! * issue **#981**'s object-command residual — `CLASS create NAME` binds
+//!   `NAME` in the *creation site's* namespace, so two same-named object
+//!   commands in sibling namespaces must never cross-link;
+//! * the workspace **namespace-variable** rename tier, the rename half of the
+//!   reference set PR #1086 added.
+//!
+//! A refusal travels as a JSON-RPC **error** with the gate's own reason, not
+//! as a `null` result: `null` means "nothing renameable here" and lets the
+//! editor quietly do nothing, which is precisely the wrong signal when the
+//! symbol *is* renameable but the rename would break the program.
+//!
+//! Every behavioural claim below is pinned against tclsh 9.0.4 and 8.6.16,
+//! which agree byte-for-byte; each test records the transcript it was written
+//! against.
+
+use crate::common::helpers::*;
+use crate::common::{Lsp, unique_uri};
+use serde_json::Value;
+
+/// The `newText` values of every edit in the whole workspace edit.
+fn all_texts(result: &Value) -> Vec<String> {
+    rename_edits(result)
+        .values()
+        .flatten()
+        .map(|e| {
+            e.get("newText")
+                .and_then(Value::as_str)
+                .unwrap_or("")
+                .to_owned()
+        })
+        .collect()
+}
+
+// -- idx 79: untracked receivers ----------------------------------------
+
+// FP guard (idx 79).  nico-robert/tomato's `Vector3d.tcl` copy-constructor
+// shape: `$other` is `[lindex $args 0]`, guarded by a runtime `info object
+// isa` test, so it really is a `Vector3d` — but nothing assigns a constructor
+// result to it, so the analyser has no binding.
+//
+// Oracle, tclsh 9.0.4 and 8.6.16 identically:
+//   before                      -> `v1 = 7 9`, `v2 = 7 9`
+//   after the declaration-only rename (`method X` -> `method GetX`,
+//   `export X` -> `export GetX`, `[$other X]` left alone)
+//                               -> `unknown method "X": must be Get, GetX, Y
+//                                   or destroy` at `"$other X"`, rc=1
+//
+// That declaration-only edit set is exactly what the server used to return.
+// It must now refuse instead.
+#[test]
+fn fp_rename_refuses_a_member_dispatched_on_an_untracked_receiver() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "oo::class create Vector3d {\n\
+         \x20   variable _x _y\n\
+         \x20   constructor {args} {\n\
+         \x20       if {[llength $args] == 1} {\n\
+         \x20           set other [lindex $args 0]\n\
+         \x20           set _x [$other X]\n\
+         \x20       } else {\n\
+         \x20           lassign $args _x _y\n\
+         \x20       }\n\
+         \x20   }\n\
+         \x20   method X {} { return $_x }\n\
+         \x20   method Get {} { return \"$_x $_y\" }\n\
+         \x20   export X Get\n\
+         }\n",
+    );
+    // Cursor on the `X` of `method X`.
+    let err = lsp.rename_error(&uri, 10, 11, "GetX");
+    let message = err
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        message.contains("not tracked"),
+        "the refusal must say why, got {err}"
+    );
+}
+
+// FN guard: the same class, the same file, renaming a member the untracked
+// receiver never names.  `Get` is dispatched only through tracked receivers,
+// so the gate must not block it — over-refusal would make the feature
+// unusable on any class with an internal `$var method` helper.
+//
+// Oracle (9.0.4 / 8.6.16): renaming `Get` -> `Fetch` everywhere it appears
+// keeps `v1 = 7 9` / `v2 = 7 9`.
+#[test]
+fn fn_guard_rename_still_applies_for_a_member_the_untracked_receiver_never_names() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "oo::class create Vector3d {\n\
+         \x20   variable _x _y\n\
+         \x20   constructor {other} {\n\
+         \x20       set _x [$other X]\n\
+         \x20   }\n\
+         \x20   method X {} { return $_x }\n\
+         \x20   method Get {} { return \"$_x $_y\" }\n\
+         \x20   export X Get\n\
+         }\n",
+    );
+    // Cursor on the `Get` of `method Get`.
+    let result = lsp.rename(&uri, 6, 11, "Fetch");
+    let texts = all_texts(&result);
+    assert!(
+        texts.iter().filter(|t| *t == "Fetch").count() >= 2,
+        "declaration + export list must both rename, got {texts:?}"
+    );
+}
+
+// TP: the `export` list is part of the edit set.
+//
+// Oracle (9.0.4 / 8.6.16): a `method` whose name starts with an upper-case
+// letter is *not* exported by default — `oo::class create A { method Foo {}
+// {return 1} }; [A new] Foo` errors `unknown method "Foo": must be destroy`.
+// With `export Foo` it prints `foo`.  Rename the method and leave the export
+// behind and both interpreters answer `unknown method "Bar": must be
+// destroy`, so the export word has to travel with the rename.
+#[test]
+fn tp_rename_rewrites_the_export_list_with_the_method() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "oo::class create A {\n\
+         \x20   method Foo {} { return foo }\n\
+         \x20   export Foo\n\
+         }\n\
+         set a [A new]\n\
+         puts [$a Foo]\n",
+    );
+    let result = lsp.rename(&uri, 1, 12, "Bar");
+    let texts = all_texts(&result);
+    assert!(
+        texts.iter().filter(|t| *t == "Bar").count() >= 3,
+        "declaration + export + call site must all rename, got {texts:?}"
+    );
+}
+
+// -- issue #981: object commands are namespace-scoped --------------------
+
+// TN + TP.  Oracle, tclsh 9.0.4 and 8.6.16 identically:
+//
+//   in ::a -> a-made
+//   in ::b -> b-made
+//   global a: a-made
+//   global b: b-made
+//
+// Renaming `::b::Widget::make` -> `produce` *and* rewriting `::a`'s own `rex
+// make` (what the server did before this fix) makes both interpreters fail
+// with `unknown method "produce": must be destroy or make` at `"rex produce"`
+// inside `::a`.  Renaming only `::b`'s half keeps the transcript identical.
+#[test]
+fn tn_object_command_rename_does_not_cross_namespaces() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval ::a {\n\
+         \x20   oo::class create Factory {\n\
+         \x20       method make {} { return \"a-made\" }\n\
+         \x20       export make\n\
+         \x20   }\n\
+         \x20   Factory create rex\n\
+         \x20   puts [rex make]\n\
+         }\n\
+         namespace eval ::b {\n\
+         \x20   oo::class create Widget {\n\
+         \x20       method make {} { return \"b-made\" }\n\
+         \x20       export make\n\
+         \x20   }\n\
+         \x20   Widget create rex\n\
+         \x20   puts [rex make]\n\
+         }\n",
+    );
+    // Cursor on `make` in `::b::Widget`'s declaration (line 10).
+    let result = lsp.rename(&uri, 10, 15, "produce");
+    let edits = rename_edits(&result);
+    let lines: Vec<i64> = edits
+        .get(&uri)
+        .into_iter()
+        .flatten()
+        .map(|e| {
+            e.get("range")
+                .and_then(|r| r.get("start"))
+                .and_then(|s| s.get("line"))
+                .and_then(Value::as_i64)
+                .unwrap_or(-1)
+        })
+        .collect();
+    assert!(
+        !lines.contains(&6),
+        "::a's own `rex make` (line 6) must never be rewritten (issue #981): {lines:?}"
+    );
+    assert!(
+        lines.contains(&14),
+        "::b's own `rex make` (line 14) must rename — the finding's lost-site \
+         half: {lines:?}"
+    );
+    assert!(
+        lines.contains(&10),
+        "::b's declaration must rename: {lines:?}"
+    );
+}
+
+// -- workspace namespace-variable tier ----------------------------------
+
+// TP: renaming `$::mypkg::version` from a *consumer* document rewrites the
+// declaring sibling's `variable version` too.
+//
+// Oracle (9.0.4 / 8.6.16, sourcing both files): `version : 1.0` before and
+// after the complete rename.
+#[test]
+fn tp_namespace_variable_rename_spans_documents() {
+    let mut lsp = Lsp::tcl();
+    let decl = unique_uri("tcl");
+    lsp.open_ready(
+        &decl,
+        "namespace eval mypkg {\n    variable version 1.0\n}\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "puts $::mypkg::version\n");
+
+    let result = lsp.rename(&user, 0, 20, "release");
+    let edits = rename_edits(&result);
+    assert!(
+        edits.contains_key(&decl),
+        "the declaring document must be edited too: {edits:?}"
+    );
+    assert!(
+        edits.contains_key(&user),
+        "the consumer document must be edited: {edits:?}"
+    );
+    let texts = all_texts(&result);
+    assert!(
+        texts.iter().any(|t| t == "release"),
+        "the declaration renames to a bare name: {texts:?}"
+    );
+    assert!(
+        texts.iter().any(|t| t == "$::mypkg::release"),
+        "the qualified read keeps its qualifier: {texts:?}"
+    );
+}
+
+// FN guard: a proc-local `variable v` alias in the declaring document — and
+// every unqualified `$v` it enables — renames with the cell.  Rewriting only
+// the declaration and the qualified read would leave `p` reading a cell that
+// no longer exists.
+//
+// Oracle (9.0.4 / 8.6.16): the script prints `1` / `1` before and after the
+// complete rename.
+#[test]
+fn fn_guard_namespace_variable_rename_rewrites_a_proc_local_alias() {
+    let mut lsp = Lsp::tcl();
+    let decl = unique_uri("tcl");
+    lsp.open_ready(
+        &decl,
+        "namespace eval mypkg {\n\
+         \x20   variable version 1\n\
+         \x20   proc show {} {\n\
+         \x20       variable version\n\
+         \x20       return $version\n\
+         \x20   }\n\
+         }\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "puts $::mypkg::version\n");
+
+    let result = lsp.rename(&user, 0, 20, "release");
+    let edits = rename_edits(&result);
+    let decl_lines: Vec<i64> = edits
+        .get(&decl)
+        .into_iter()
+        .flatten()
+        .map(|e| {
+            e.get("range")
+                .and_then(|r| r.get("start"))
+                .and_then(|s| s.get("line"))
+                .and_then(Value::as_i64)
+                .unwrap_or(-1)
+        })
+        .collect();
+    assert!(
+        decl_lines.contains(&1),
+        "the namespace declaration must rename: {decl_lines:?}"
+    );
+    assert!(
+        decl_lines.contains(&3),
+        "the proc-local `variable version` alias must rename: {decl_lines:?}"
+    );
+    assert!(
+        decl_lines.contains(&4),
+        "the alias's unqualified `$version` read must rename: {decl_lines:?}"
+    );
+}
+
+// TN: a same-tailed cell in a sibling namespace is a different variable.
+// `$other::v` never searches enclosing namespaces (9.0.4 / 8.6.16 both keep
+// `::a::v` and `::b::v` independent), so it must be untouched.
+#[test]
+fn tn_namespace_variable_rename_leaves_a_sibling_namespaces_cell_alone() {
+    let mut lsp = Lsp::tcl();
+    let a = unique_uri("tcl");
+    lsp.open_ready(&a, "namespace eval alpha {\n    variable v 1\n}\n");
+    let b = unique_uri("tcl");
+    lsp.open_ready(&b, "namespace eval beta {\n    variable v 2\n}\n");
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "puts $::alpha::v\nputs $::beta::v\n");
+
+    let result = lsp.rename(&user, 0, 15, "total");
+    let edits = rename_edits(&result);
+    assert!(
+        !edits.contains_key(&b),
+        "`::beta::v` must not be touched by a `::alpha::v` rename: {edits:?}"
+    );
+    assert!(
+        edits.contains_key(&a),
+        "`::alpha::v` must rename: {edits:?}"
+    );
+}
+
+// FP guard: a document in the cell's namespace that computes a variable name
+// (`set $n …` — a registry `ArgRole::VarWrite` word that
+// `names_a_dynamic_variable`) may be naming this very cell, with no word to
+// rewrite.  Refuse rather than emit an edit set that silently misses it.
+//
+// Oracle (9.0.4 / 8.6.16): `namespace eval ns { variable v 1; proc bump {n}
+// {variable $n; set $n 2} }; ns::bump v; puts $::ns::v` prints `2` — the
+// dynamic name really does reach the cell.
+#[test]
+fn fp_namespace_variable_rename_refuses_beside_a_computed_variable_name() {
+    let mut lsp = Lsp::tcl();
+    let decl = unique_uri("tcl");
+    lsp.open_ready(
+        &decl,
+        "namespace eval mypkg {\n\
+         \x20   variable version 1\n\
+         \x20   proc bump {n} {\n\
+         \x20       variable $n\n\
+         \x20       set $n 2\n\
+         \x20   }\n\
+         }\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "puts $::mypkg::version\n");
+
+    let err = lsp.rename_error(&user, 0, 20, "release");
+    let message = err
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        message.contains("computed at run time"),
+        "the refusal must say why, got {err}"
+    );
+}


### PR DESCRIPTION
## Summary

PR C3 — the rename subsystem's safety pass. Three mandates, all oracle-pinned on tclsh 9.0.4 + 8.6 with byte-identical transcripts in the tests. **This closes the last tier-1 audit finding: tier 1 is now 24/24.**

- **Audit idx 79 (tier 1) — rename refuses instead of silently breaking running code.** Renaming `method X` used to produce a declaration-only `WorkspaceEdit` when the method was also dispatched through an untracked receiver (`set other [lindex $args 0]; [$other X]` — the tomato `Vector3d` copy-constructor idiom); running the "renamed" program then dies with `unknown method "X"`. New `tcl-lsp-core::rename_safety` gate: `rename_with_diagnosis` returns a typed `RenameRefusal`, and the server answers `InvalidRequest` with the reason (deliberately not `Ok(None)`, which editors read as "nothing renameable here"). The decision procedure keys on the receiver's *binding state*: tracked-to-family and tracked-to-unrelated receivers rename; an untracked receiver naming the renamed member refuses; a computed member word (`$m`, `[…]`, including through `my`) refuses. A refused rename is acceptable; a wrong one is not.
- **Adjacent TP fix:** rename never rewrote `export`/`unexport`/`filter` words. New `references::member_reference_spans` collects them from the definer grammar (class body + separate `oo::define` blocks) and is shared by find-references and rename, so the two providers can't disagree. Oracle pins the stale-export failure (`unknown method "Bar": must be destroy`).
- **#981 residual — object-command dispatch is now namespace-scoped.** `CLASS create NAME` records `instance_command_bindings` with the creation namespace; call-site heads resolve through the same `command_resolution_candidates` scoping classmethods got in #1063. Renaming `::b::Widget::make` no longer rewrites `::a`'s same-named sibling (oracle: doing so dies with `unknown method "produce"`), and same-qualified-name ambiguity refuses. Bare-name matching survives only for registry object factories with no qualified binding. Closes #981 (classmethod half landed in #1063).
- **#1087 — cross-document namespace-variable rename.** Rename now routes through the same `qualified_variable_cell_at` the other providers use (inert-text gate included): declarations, `variable` aliases (including proc-local links and their unqualified reads), and every qualified occurrence workspace-wide, with refusals for workspace collisions and dynamic variable names beside the cell (`variable $n` provably reaches it — oracle-pinned). Closes #1087.

No `CommandSpec` field added — all command-level facts consumed are existing registry data (`MethodDispatchKind::SelfDispatch`, definer grammars/`MemberRefKind`, `ArgRole` VarWrite/VarRead, `BodyKind`), so the spec-studio gates are untouched.

**Residuals documented in STATUS.md §6b rather than half-fixed:** pure-consumer documents aren't yet hazard-scanned (needs the gate to take the edit collector's document set); namespace-variable candidate discovery infers from declarations, so an alias-only file needs a namespace-participation index fact; the dynamic-name refusal for assembled `upvar` targets is correct but blunt (per-site provenance would refuse less).

## Validation

- [x] `cargo test --workspace --all-features` — **311 suites, 15,292 passed, 0 failed** (re-run clean after an ENOSPC event; identical totals).
- [x] New tests: 11 gate unit tests + 8 rename unit tests + 1 integration + 8 e2e + 2 VS Code, explicitly split TP/FP/TN/FN per mandate; the e2e harness gained `Lsp::rename_error` (it previously panicked on any error response).
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` — clean, **zero new allows** (4 lints the new code introduced were fixed structurally).
- [x] `cargo fmt --all --check`, `make lint-ts` (ESLint + Prettier), `make xtask-check` — all clean/OK (command backing 384/384).

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — `AnalysisResult::instance_command_bindings` is a new analyser fact (creation-namespace binding for object commands); rename's contract gains the typed-refusal channel.
- [x] KCS notes updated: rename feature page (refusal semantics + the safe/refuse matrix), references feature page (shared member-reference collector), `workspace-indexing.md` (variable-rename tier + candidate-discovery bound). STATUS.md §6b: idx 79 resolved section with the verdict table; **counts recomputed from the tables: 69 fixed / 16 remaining of 85** (the previous running total was one low against its own tables — the reconciliation is stated explicitly in the ledger paragraph).
- [ ] New compiler KCS note linked. (n/a — existing notes updated)

Closes #981. Closes #1087.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_