### PR TITLE
TclOO introspection: [self class] folding, self-block outline members, defining-namespace proc homing (#1077, #1080, #1081)

### DIFF
--- a/docs/kcs/codes/kcs-diagnostic-w214-unused-proc-parameter.md
+++ b/docs/kcs/codes/kcs-diagnostic-w214-unused-proc-parameter.md
@@ -41,9 +41,41 @@ Use the parameter or remove it from the signature:
 proc greet {name greeting} { puts "$greeting, $name" }
 ```
 
+## Where the squiggle lands, and which proc it names
+
+The squiggle covers just the offending parameter's *name* inside the parameter
+list, so each unused parameter gets its own tight range rather than stacking on
+the whole `proc` definition.
+
+The fully-qualified name in the message is the proc's **defining** namespace,
+which for a proc created inside another proc's body is the namespace the
+*enclosing* proc is defined in — not the namespace the `proc` command was
+written in. Tcl resolves the name in the namespace current when the body
+executes, and a proc body executes in the namespace of the proc itself
+(verified identical on tclsh 9.0.4 and 8.6.16):
+
+```tcl
+namespace eval ::a {}
+proc a::outer {} { proc helper {unused} { return 1 } }
+a::outer
+info commands ::a::helper    ;# -> ::a::helper
+info commands ::helper       ;# -> {}   (nothing was created here)
+```
+
+so W214 reports `::a::helper`. The name word's own qualifier wins over any
+enclosing `namespace eval`, and an absolutely-written inner name (`proc ::abs
+…`) is unaffected. Before #1077 the lexical position was used instead, which
+both named the wrong proc and — because the per-parameter span lookup is keyed
+on that name — dropped the tight range back to the whole definition.
+
 ## How to suppress
 
 Add `# noqa: W214` at the end of the offending line.
+
+## File-path anchors
+
+- `rust/tcl-compiler/src/analyser/diagnostics/dataflow.rs` — `emit_unused_param_diagnostics`, `param_name_spans_for`
+- `rust/tcl-compiler/src/lowering/mod.rs` — `proc_body_namespace` (the defining-namespace rule, with its oracle transcript)
 
 ## Related
 

--- a/docs/kcs/codes/kcs-optimisation-o129-builtin-command-substitution-folding.md
+++ b/docs/kcs/codes/kcs-optimisation-o129-builtin-command-substitution-folding.md
@@ -37,6 +37,50 @@ puts [string length abcde]
 puts 5
 ```
 
+## Inside a TclOO method body: `[self class]`
+
+O129 also answers the one introspection keyword whose value the *enclosing
+method frame* fixes rather than its arguments — `self class`, the class that
+defines the running method implementation:
+
+```tcl
+oo::class create ::ticklecharts::C {
+    method render {} { puts [self class] }
+}
+```
+
+becomes `puts ::ticklecharts::C`. The value is the class whose definition body
+lexically encloses the method, and real Tcl keeps it that class through
+inheritance, mixins, and `next` — each link of a `next` chain reports its own
+definer, and a mixin-provided method reports the mixin, not the receiver
+(verified identical on tclsh 9.0.4 and 8.6.16). Constructor and destructor
+bodies fold the same way, as do methods added by `oo::define` (which fold to
+the class `oo::define` names) and classes created under `namespace eval`.
+
+This is registry-driven: `self`'s spec declares which of its words is a frame
+fact (`oo_context_facts`), so the optimiser never matches a command or
+subcommand by name.
+
+Four shapes deliberately do **not** fold, because the value is either not
+static or not a value at all:
+
+- **`self object` / `self namespace`** (and a bare `self`) name the *receiving
+  instance* — a fresh `::oo::ObjNN` per `new`. The chain words (`method`,
+  `call`, `caller`, `filter`, `next`, `target`) are reshaped at run time.
+- **A method on the class object** — `self method NAME …`, `classmethod`, or an
+  `oo::objdefine` instance method. There `self class` *raises*
+  ("method not defined by a class"), so there is no name to fold to.
+- **A renamed class command.** `self class` answers with the class's *current*
+  name, so a module containing `rename ::R ::R2` anywhere makes every
+  `[self class]` written under `::R` unfoldable.
+- **A dynamic class name** (`oo::class create $nm { … }`), which the compiler
+  never resolves to a class in the first place.
+
+The method-body fold carries no constants map, so it introduces no variable
+propagation inside a method: an instance variable is object state that outlives
+the frame and any `my …` call may rewrite it, which the per-function lattice
+does not model.
+
 ## Safety conditions
 
 - All arguments to the inner command must be compile-time constants (no
@@ -55,6 +99,12 @@ puts 5
 
 Toggle the optimiser profile in your editor settings. See the
 [optimiser feature](../features/kcs-feature-optimiser.md) for profile options.
+
+## File-path anchors
+
+- `rust/tcl-compiler/src/optimiser/propagation.rs` — `fold_builtin_cmd_subst_raw`, and `run_oo_method_folds` / `oo_frame_for` / `oo_context_fact_fold` for the method-frame half
+- `rust/tcl-registry/src/spec.rs` — `CommandSpec::oo_context_facts`, `OoContextFact` (with the oracle transcript)
+- `rust/tcl-registry/src/commands/tcl/oo_self.rs` — `self`'s declaration
 
 ## Related
 

--- a/docs/kcs/features/kcs-feature-document-symbols.md
+++ b/docs/kcs/features/kcs-feature-document-symbols.md
@@ -25,6 +25,8 @@ Commands that *define a named unit* also contribute an outline entry, each under
 
 A `TclOO` class body contributes its members as children of the class symbol: `method` (instance), `classmethod` and `self method` (class-side, shown with a `classmethod` detail), `constructor`, `destructor`, and `property`. Both spellings of the class-side and visibility wrappers list — the prefix form (`self method make {n} {…}`) and the *block* form (`self { method make {n} {…} }`), and likewise `private method …` / `private { method … }`. The block form is normalised into the prefix form by the definition-body walker from registry data (the definer grammar marks `self` and `private` as wrapper members that also take a bare script block), so both spellings travel one code path and pick up dispatch, hover, and go-to-definition together with the outline entry (#1081). A `self` *introspection* call inside a method body (`[self class]`, `[self object]`) is an ordinary command substitution and contributes nothing to the outline. A dynamic block word (`self $body`) is skipped rather than guessed at.
 
+Within a `self` / `private` block, a member that a later word in the same block **deletes or renames** (`deletemethod`, `renamemethod`) is dropped rather than listed — real Tcl removes it, so keeping the entry would navigate to a name the interpreter does not have. Which member words retract is registry data (the definer grammar's `retracts_named_members`), so the sibling reference members `export` / `unexport` / `filter`, which name a method without removing it, keep their outline entry. A member retracted in one `oo::define` body and redeclared in a later one is listed again — the retraction applies where the body is walked, not document-wide. *Known gap:* an **unwrapped** `deletemethod` / `renamemethod` (one with no `self` / `private` wrapper, directly in a class-creation or `oo::define` body) is not yet honoured, so its member is still listed.
+
 A BIG-IP `.conf` file (any canonical basename — `bigip.conf`, `bigip_base.conf`, …) gets a different outline shape: a `module → kind → object` tree built from the config stanza tree rather than the Tcl scope walk. Nameless global singletons (`auth password-policy`, `net self-allow`, …) fall back to their kind label so no outline entry is ever empty. Both the Python and the native Rust servers serve this outline.
 
 ## File-path anchors
@@ -36,7 +38,7 @@ A BIG-IP `.conf` file (any canonical basename — `bigip.conf`, `bigip_base.conf
 - `rust/tcl-registry/src/symbol_def.rs` — `SymbolDef` / `DefinedSymbolKind` (registry-driven symbol-definer commands)
 - `rust/tcl-compiler/src/analyser/handlers.rs` — `handle_defines_symbol` (records test cases, constant-propagated name)
 - `rust/tcl-compiler/src/analyser/oo.rs` — `expand_wrapper_block_members` (`self { … }` / `private { … }` block forms), `apply_oo_self`
-- `rust/tcl-registry/src/definer.rs` — `MemberSpec::wrapper_or_body` (which members take a bare script block)
+- `rust/tcl-registry/src/definer.rs` — `MemberSpec::wrapper_or_body` (which members take a bare script block), `MemberSpec::retracts_named_members` (which member words delete the members they name, with the oracle transcript)
 
 ## Failure modes
 

--- a/docs/kcs/features/kcs-feature-document-symbols.md
+++ b/docs/kcs/features/kcs-feature-document-symbols.md
@@ -23,6 +23,8 @@ Produces a hierarchical symbol tree with procs nested inside namespaces, variabl
 
 Commands that *define a named unit* also contribute an outline entry, each under its own kind: `tcltest::test NAME …` (a function-like test case, description shown as detail), `tcltest::testConstraint NAME value` (a constant-kind constraint — only the two-argument setter defines; the one-argument getter is a reference), and `tcltest::customMatch MODE command` (an operator-kind match mode). All forms are recognised whether the command is called qualified or via `namespace import ::tcltest::*`, and a definition inside `namespace eval` nests under it. This is registry-driven: a command declares `defines_symbol` in its [`CommandSpec`](../../design/compiler/command-registry.md) and every symbol consumer (document + workspace symbols, MCP) picks it up generically, so adding the next such command is a spec change, not a compiler edit. The *name* is resolved through the analyser's constant-propagation lattice, so a name written as a literal, a quoted string, or a constant `$var` all resolve; a genuinely dynamic name is skipped rather than shown as raw `$var` text (#790).
 
+A `TclOO` class body contributes its members as children of the class symbol: `method` (instance), `classmethod` and `self method` (class-side, shown with a `classmethod` detail), `constructor`, `destructor`, and `property`. Both spellings of the class-side and visibility wrappers list — the prefix form (`self method make {n} {…}`) and the *block* form (`self { method make {n} {…} }`), and likewise `private method …` / `private { method … }`. The block form is normalised into the prefix form by the definition-body walker from registry data (the definer grammar marks `self` and `private` as wrapper members that also take a bare script block), so both spellings travel one code path and pick up dispatch, hover, and go-to-definition together with the outline entry (#1081). A `self` *introspection* call inside a method body (`[self class]`, `[self object]`) is an ordinary command substitution and contributes nothing to the outline. A dynamic block word (`self $body`) is skipped rather than guessed at.
+
 A BIG-IP `.conf` file (any canonical basename — `bigip.conf`, `bigip_base.conf`, …) gets a different outline shape: a `module → kind → object` tree built from the config stanza tree rather than the Tcl scope walk. Nameless global singletons (`auth password-policy`, `net self-allow`, …) fall back to their kind label so no outline entry is ever empty. Both the Python and the native Rust servers serve this outline.
 
 ## File-path anchors
@@ -33,6 +35,8 @@ A BIG-IP `.conf` file (any canonical basename — `bigip.conf`, `bigip_base.conf
 - `rust/tcl-lsp-core/src/document_symbols.rs` — native outline builder (walks the analyser scope tree)
 - `rust/tcl-registry/src/symbol_def.rs` — `SymbolDef` / `DefinedSymbolKind` (registry-driven symbol-definer commands)
 - `rust/tcl-compiler/src/analyser/handlers.rs` — `handle_defines_symbol` (records test cases, constant-propagated name)
+- `rust/tcl-compiler/src/analyser/oo.rs` — `expand_wrapper_block_members` (`self { … }` / `private { … }` block forms), `apply_oo_self`
+- `rust/tcl-registry/src/definer.rs` — `MemberSpec::wrapper_or_body` (which members take a bare script block)
 
 ## Failure modes
 

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -1836,6 +1836,9 @@ fn apply_oo_private(
     let Some(member) = grammar.member(inner_subcmd) else {
         return;
     };
+    // `private deletemethod m` removes an instance-side member — `private`'s
+    // own side — including one this same block just recorded.
+    retract_wrapped_members(member, inner_args, &mut class_def.methods);
     match inner_subcmd {
         "method" => {
             if let Some(md) =
@@ -1857,6 +1860,41 @@ fn apply_oo_private(
             }
         }
         _ => {}
+    }
+}
+
+/// Drop every member named by a *retracting* wrapper-scoped member word
+/// (`self deletemethod m`, `private renamemethod old new`) from `table` — the
+/// method table of the side the wrapper targets.
+///
+/// This is an **abstention**, not a model of `deletemethod` / `renamemethod`:
+/// it stops a member the body goes on to delete from being retained, but it
+/// records nothing in its place (a `renamemethod old new` drops `old` without
+/// recording `new`). Keeping a member real Tcl removed would show a stale
+/// document symbol and let navigation and method validation resolve a name
+/// that does not exist — a false positive; dropping the renamed-to name is a
+/// false negative, which is the direction this campaign abstains toward.
+///
+/// Which member words retract is registry data
+/// ([`MemberSpec::retracts_named_members`]), never a keyword matched here —
+/// the sibling [`MemberRefKind::Method`] members (`export` / `unexport` /
+/// `filter`) name a method without removing it and must not retract.
+///
+/// Source order needs no tracking: real Tcl makes retracting a
+/// not-yet-declared member a hard error that aborts the whole definition (see
+/// the oracle on [`MemberSpec::retracts_named_members`]), so the only legal
+/// order is declare-then-retract, and a body that violates it never creates a
+/// class for us to describe.
+fn retract_wrapped_members(
+    member: &MemberSpec,
+    names: &[String],
+    table: &mut std::collections::HashMap<String, MethodDef>,
+) {
+    if !member.retracts_named_members {
+        return;
+    }
+    for name in names {
+        table.remove(name);
     }
 }
 
@@ -1892,6 +1930,11 @@ fn apply_oo_self(
     let Some(member) = grammar.member(inner_subcmd) else {
         return;
     };
+    // `self deletemethod m` / `self renamemethod old new` remove class-side
+    // members — including ones this same block just recorded (issue #1095
+    // review). Handled before the declaration arms below so the wrapper's own
+    // side is the only table touched.
+    retract_wrapped_members(member, inner_args, &mut class_def.class_methods);
     if !matches!(inner_subcmd, "method" | "classmethod") {
         return;
     }
@@ -3177,6 +3220,166 @@ mod tests {
         let c = r.all_classes.get("::Dyn").expect("::Dyn recorded");
         assert!(c.class_methods.is_empty(), "{:?}", c.class_methods);
         assert!(c.methods.is_empty(), "{:?}", c.methods);
+    }
+
+    #[test]
+    fn self_block_destructive_member_drops_the_member_it_deletes() {
+        // TP — issue #1095 review. Oracle (tclsh 9.0.4 / 8.6.16, identical):
+        //   oo::class create ::C1 {
+        //       self { method gone {} {…} ; method kept {} {…} ; deletemethod gone }
+        //   }
+        //   info object methods ::C1  ->  kept
+        //   ::C1 gone                 ->  unknown method "gone"
+        // Retaining `gone` would show a stale document symbol and let
+        // navigation resolve a name the interpreter does not have.
+        let src = "oo::class create ::C {\n                   self {\n                   method gone {} { return g }\n                   method kept {} { return k }\n                   deletemethod gone\n                   }\n                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::C").expect("::C recorded");
+        assert!(
+            !c.class_methods.contains_key("gone"),
+            "{:?}",
+            c.class_methods
+        );
+        assert!(c.class_methods.contains_key("kept"));
+    }
+
+    #[test]
+    fn self_block_renamemethod_drops_the_source_name() {
+        // TP. Oracle: `self { method old {} {…} ; renamemethod old new }` gives
+        // `info object methods ::C2` -> new, and `::C2 old` is an unknown
+        // method. We drop `old` and record nothing for `new` — the
+        // false-negative direction, which is the one to abstain toward.
+        let src = "oo::class create ::C {\n                   self {\n                   method old {} { return o }\n                   renamemethod old new\n                   }\n                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::C").expect("::C recorded");
+        assert!(
+            !c.class_methods.contains_key("old"),
+            "{:?}",
+            c.class_methods
+        );
+    }
+
+    #[test]
+    fn private_block_destructive_member_drops_the_instance_side_member() {
+        // TP, symmetric half. Oracle (9.0 — `private` is a 9.0 member):
+        //   oo::class create ::C5 {
+        //       private { method secret {} {…} ; method other {} {…} ;
+        //                 deletemethod secret }
+        //   }
+        //   info class methods ::C5 -all -private   ->  no `secret`
+        let src = "oo::class create ::C {\n                   private {\n                   method secret {} { return s }\n                   method other {} { return o }\n                   deletemethod secret\n                   }\n                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::C").expect("::C recorded");
+        assert!(!c.methods.contains_key("secret"), "{:?}", c.methods);
+        assert!(c.methods.contains_key("other"));
+    }
+
+    #[test]
+    fn wrapper_block_and_prefix_forms_retract_identically() {
+        // The block form is normalised into the prefix form, so both spellings
+        // must land on the same result. Oracle for the prefix side:
+        //   oo::define ::C7 { self method sgone {} {…} }
+        //   info object methods ::C7                  ->  sgone
+        //   oo::define ::C7 { self deletemethod sgone }
+        //   info object methods ::C7                  ->  (empty)
+        let src = "oo::class create ::C {}\n                   oo::define ::C { self method gone {} { return g } }\n                   oo::define ::C { self deletemethod gone }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::C").expect("::C recorded");
+        assert!(c.class_methods.is_empty(), "{:?}", c.class_methods);
+    }
+
+    #[test]
+    fn a_retraction_does_not_cross_to_the_other_side() {
+        // TN. `self deletemethod` touches only the class-object side. Oracle:
+        //   oo::class create ::D { method m {} {return inst}
+        //                          self { method m {} {return cls} } }
+        //   oo::define ::D { self deletemethod m }
+        //   info class methods ::D   ->  m        (instance side survives)
+        //   info object methods ::D  ->  (empty)
+        //   [::D new] m              ->  inst
+        let src = "oo::class create ::D {\n                   method m {} { return inst }\n                   self { method m {} { return cls } }\n                   }\n                   oo::define ::D { self deletemethod m }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::D").expect("::D recorded");
+        assert!(c.methods.contains_key("m"), "instance side must survive");
+        assert!(!c.class_methods.contains_key("m"), "class side must go");
+    }
+
+    #[test]
+    fn non_retracting_method_reference_members_keep_their_member() {
+        // TN, the discrimination the registry flag exists for: `export`,
+        // `unexport`, and `filter` are the sibling `MemberRefKind::Method`
+        // members — they *name* a method without removing it, so they must not
+        // retract. Oracle:
+        //   oo::class create ::A { self { method a {} {…} ; unexport a ; export a } }
+        //   info object methods ::A  ->  a   ;  ::A a  ->  1
+        //   oo::class create ::B { self { method f {} {…} ; filter f } }
+        //   info object methods ::B  ->  f
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "oo::class create ::A {\n self {\n method a {} { return 1 }\n unexport a\n export a\n }\n}",
+            "tcl9.0",
+        );
+        assert!(
+            r.all_classes["::A"].class_methods.contains_key("a"),
+            "export/unexport must not retract",
+        );
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "oo::class create ::B {\n self {\n method f {} { return 1 }\n filter f\n }\n}",
+            "tcl9.0",
+        );
+        assert!(
+            r.all_classes["::B"].class_methods.contains_key("f"),
+            "filter must not retract",
+        );
+    }
+
+    #[test]
+    fn a_retracted_member_can_be_redeclared_by_a_later_body() {
+        // Source-order guard. Oracle:
+        //   oo::class create ::C { method m {} {return 1} }
+        //   oo::define ::C { self method m {} {return 2} }
+        //   oo::define ::C { self deletemethod m }
+        //   oo::define ::C { self method m {} {return 3} }
+        //   ::C m        ->  3     (class side, redeclared after the delete)
+        //   [::C new] m  ->  1     (instance side, never touched)
+        // Retraction happens where the body is walked, so a later declaration
+        // wins — it is not a whole-document erasure of the name.
+        let src = "oo::class create ::C { method m {} { return 1 } }\n                   oo::define ::C { self method m {} { return 2 } }\n                   oo::define ::C { self deletemethod m }\n                   oo::define ::C { self method m {} { return 3 } }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::C").expect("::C recorded");
+        assert!(c.class_methods.contains_key("m"), "redeclaration must win");
+        assert!(c.methods.contains_key("m"), "instance side untouched");
+    }
+
+    #[test]
+    fn unwrapped_destructive_members_are_a_documented_residual() {
+        // Residual pin (reported for its own issue, deliberately NOT fixed
+        // here): an *unwrapped* `deletemethod` — in a class-creation body or an
+        // `oo::define` body, with no `self` / `private` wrapper — is still
+        // ignored, exactly as it was before the wrapper-block work. Real Tcl
+        // does delete it:
+        //   oo::class create ::C6 { method gone {} {…} ; method kept {} {…} }
+        //   oo::define ::C6 { deletemethod gone }
+        //   info class methods ::C6  ->  kept
+        // Fixing it is one more `apply_oo_subcommand` arm on this same
+        // `retracts_named_members` flag, but it changes the recorded shape of
+        // bodies this PR never touched, so it belongs to its own change.
+        let mut a = Analyser::new();
+        let r = a.analyse(
+            "oo::class create ::C { method gone {} { return g } }\n             oo::define ::C { deletemethod gone }",
+            "tcl9.0",
+        );
+        assert!(
+            r.all_classes["::C"].methods.contains_key("gone"),
+            "if this now fails the residual was fixed — update the note",
+        );
     }
 
     // snit (tcllib) type / widget support.  Verified against real

--- a/rust/tcl-compiler/src/analyser/oo.rs
+++ b/rust/tcl-compiler/src/analyser/oo.rs
@@ -437,17 +437,38 @@ impl Analyser {
             if let (Some(subcmd), Some(tok)) = (texts.first(), argv.first()) {
                 self.emit_w002_oo_member_disabled(grammar, subcmd, *tok, definer_disabled);
             }
-            apply_oo_subcommand(grammar, texts, argv, class_def);
-            // A member argument that *names* a command — the class a
-            // `superclass`/`mixin` extends, the command a `forward` delegates to
-            // — is a first-class command reference.  Record it so references /
-            // go-to-definition / rename / call-hierarchy reach it the same as a
-            // direct call.  Which arguments name commands is registry data (the
-            // member grammar's `all_args_ref` / `ArgRole::CommandName`), never a
-            // member keyword the walker knows by name.
-            self.record_member_command_references(grammar, texts, argv, scope_path);
-            if let Some(mb) = collect_method_body(grammar, texts, argv) {
-                method_bodies.push(mb);
+            // A wrapper member's bare *script-block* form (`self { method m …
+            // }`, `private { … }`) declares exactly the members its block
+            // spells out — so rewrite each inner command into the equivalent
+            // prefix form (`self method m …`) and feed the one member walker
+            // below.  Which members take a block is registry data
+            // (`MemberKind::Wrapper` + `wrapper_block_body`), never a keyword
+            // matched here; `None` means "not a block form", i.e. the command
+            // stands for itself.
+            let expanded = expand_wrapper_block_members(grammar, texts, argv, self.lexer_config());
+            let member_calls: Vec<(&[String], &[Token])> = expanded.as_ref().map_or_else(
+                || vec![(texts, argv)],
+                |inner| {
+                    inner
+                        .iter()
+                        .map(|(t, a)| (t.as_slice(), a.as_slice()))
+                        .collect()
+                },
+            );
+            for (texts, argv) in member_calls {
+                apply_oo_subcommand(grammar, texts, argv, class_def);
+                // A member argument that *names* a command — the class a
+                // `superclass`/`mixin` extends, the command a `forward`
+                // delegates to — is a first-class command reference.  Record it
+                // so references / go-to-definition / rename / call-hierarchy
+                // reach it the same as a direct call.  Which arguments name
+                // commands is registry data (the member grammar's
+                // `all_args_ref` / `ArgRole::CommandName`), never a member
+                // keyword the walker knows by name.
+                self.record_member_command_references(grammar, texts, argv, scope_path);
+                if let Some(mb) = collect_method_body(grammar, texts, argv) {
+                    method_bodies.push(mb);
+                }
             }
             match texts.first().map(String::as_str) {
                 Some("property") => {
@@ -1587,6 +1608,101 @@ fn walk_unknown_stmt(stmt: &Statement, first_param: &str, info: &mut UnknownProc
 /// word carries its own true source range and downstream consumers
 /// (document symbols, `my`-dispatch, hover) get real positions rather than
 /// the whole-list span.
+/// Expand a wrapper member's bare **script-block** form into the equivalent
+/// prefix forms, so one walker handles both spellings of the same declaration.
+///
+/// `TclOO`'s `self` and `private` are the two members the registry marks
+/// [`MemberKind::Wrapper`] *with* `wrapper_block_body`: each takes both
+/// `self method NAME ARGS BODY` (prefix) and `self { method NAME ARGS BODY; … }`
+/// (block, a definition script evaluated against the class object / with
+/// private visibility).  Only the prefix form was ever walked, so every member
+/// declared in a block was invisible to the whole analysis — no `ClassDef`
+/// entry, hence no document-symbol node, no dispatch arity, and no body walk
+/// (issue #1081).
+///
+/// Returns `Some(calls)` — each `(texts, argv)` being the block's inner command
+/// with the wrapper keyword (and its token) spliced back on at index 0 — for a
+/// block form, and `None` for everything else, including the prefix form, which
+/// the caller already handles as written.
+///
+/// Oracle, identical on tclsh 9.0.4 and 8.6.16 — the block form declares
+/// exactly the same class-side methods the prefix form does:
+///
+/// ```tcl
+/// oo::class create ::C {
+///     self { method make {n} {return "made-$n"} ; method other {} {return other} }
+///     method inst {} {return inst}
+/// }
+/// ::C make 7                  ;# -> made-7
+/// info class methods ::C      ;# -> inst          (instance side untouched)
+/// info object methods ::C     ;# -> other make    (class-object side)
+/// oo::class create ::F { superclass ::C }
+/// ::F make 1                  ;# -> error: unknown method "make"  (not inherited)
+/// ```
+///
+/// and `export`/`unexport` inside the block act on the class-object side:
+/// `oo::class create ::E { self { method hidden {} {…} ; unexport hidden } }`
+/// leaves `info object methods ::E` empty while `-all -private` still lists
+/// `hidden`.
+///
+/// Abstains — returning `None`, so the command is walked exactly as it is
+/// today — on a dynamic (non-`Str`) block word, which cannot be re-segmented
+/// statically, and on any shape carrying words after the block.
+fn expand_wrapper_block_members(
+    grammar: &DefinitionBodyGrammar,
+    texts: &[String],
+    argv: &[Token],
+    config: tcl_lexer::LexerConfig,
+) -> Option<Vec<(Vec<String>, Vec<Token>)>> {
+    use tcl_registry::definer::MemberKind;
+    let keyword = texts.first()?;
+    let keyword_tok = *argv.first()?;
+    let member = grammar.member(keyword)?;
+    if member.kind != MemberKind::Wrapper || !member.wrapper_block_body {
+        return None;
+    }
+    // The prefix form — the word after the wrapper is itself a member keyword —
+    // is already the spelling the walker consumes; leave it alone.
+    let inner_first = texts.get(1)?;
+    if grammar.member(inner_first).is_some() {
+        return None;
+    }
+    // `+ 1` because a member's registry arg-role indices are relative to its
+    // *arguments*, while `texts`/`argv` still carry the keyword at 0.
+    let body_idx = member.indices_for(ArgRole::Body).next()? + 1;
+    if texts.len() != body_idx + 1 {
+        return None;
+    }
+    let body_text = texts.get(body_idx)?;
+    let body_tok = *argv.get(body_idx)?;
+    if body_tok.kind != TokenType::Str {
+        return None;
+    }
+    let base_offset = body_tok.span.start() + u32::from(body_tok.content_offset);
+    let cmds =
+        crate::segmenter::segment_commands_with_offset_and_config(body_text, base_offset, config);
+    let mut out: Vec<(Vec<String>, Vec<Token>)> = Vec::new();
+    for cmd in &cmds {
+        if cmd.is_partial || cmd.argv.is_empty() {
+            continue;
+        }
+        let spliced = splice_static_member_expansions(cmd);
+        let (inner_texts, inner_argv) = spliced
+            .as_ref()
+            .map_or((cmd.texts.as_slice(), cmd.argv.as_slice()), |(t, a)| {
+                (t.as_slice(), a.as_slice())
+            });
+        let mut wrapped_texts = Vec::with_capacity(inner_texts.len() + 1);
+        wrapped_texts.push(keyword.clone());
+        wrapped_texts.extend(inner_texts.iter().cloned());
+        let mut wrapped_argv = Vec::with_capacity(inner_argv.len() + 1);
+        wrapped_argv.push(keyword_tok);
+        wrapped_argv.extend(inner_argv.iter().copied());
+        out.push((wrapped_texts, wrapped_argv));
+    }
+    Some(out)
+}
+
 fn splice_static_member_expansions(
     cmd: &crate::segmenter::SegmentedCommand,
 ) -> Option<(Vec<String>, Vec<Token>)> {
@@ -1753,9 +1869,10 @@ fn apply_oo_private(
 /// inherited the way an `ooutil`-style `classmethod` is (real tclsh: a
 /// subclass with no override does not gain a `self method` at all).
 ///
-/// Scoped to the prefix form only; `self { method NAME ARGS BODY; … }`'s
-/// block form is a documented, symmetric (`private { … }` shares the same
-/// gap) follow-up, not fixed here.
+/// Consumes the **prefix** form only.  `self { method NAME ARGS BODY; … }`'s
+/// block form (and `private`'s symmetric one) is normalised *into* this form
+/// by [`expand_wrapper_block_members`] before the member walker runs, so both
+/// spellings land here (issue #1081).
 fn apply_oo_self(
     grammar: &DefinitionBodyGrammar,
     sub_args: &[String],
@@ -2903,6 +3020,163 @@ mod tests {
         let body = r"switch -exact $cmd { foo { return 1 } }";
         let info = a.extract_unknown_proc_info(body, &[]);
         assert!(info.dispatch_targets.contains("foo"));
+    }
+
+    // ---- issue #1081: the `self { … }` / `private { … }` block forms ----
+
+    #[test]
+    fn self_block_form_records_every_member_as_a_class_method() {
+        // TP. Oracle (tclsh 9.0.4 / 8.6.16, identical):
+        //   oo::class create ::C {
+        //       self { method make {n} {…} ; method other {} {…} }
+        //       method inst {} {…}
+        //   }
+        //   ::C make 7               -> made-7
+        //   info object methods ::C  -> other make   (class-object side)
+        //   info class methods ::C   -> inst         (instance side)
+        //   oo::class create ::F {superclass ::C} ; ::F make 1
+        //                            -> error: unknown method "make"
+        // i.e. exactly what the `self method …` prefix form declares — which
+        // is why both spellings land on the same recording path.
+        let src = "oo::class create ::C {\n\
+                   self {\n\
+                   method make {n} { return $n }\n\
+                   method other {} { return other }\n\
+                   }\n\
+                   method inst {} { return inst }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::C").expect("::C recorded");
+        for name in ["make", "other"] {
+            let md = c
+                .class_methods
+                .get(name)
+                .unwrap_or_else(|| panic!("`{name}` must record as a class method"));
+            assert_eq!(md.kind, "classmethod");
+            assert!(
+                md.is_self_method,
+                "`self`-scoped members are not inherited by subclasses",
+            );
+            assert_eq!(md.visibility, "public");
+        }
+        // The instance side is untouched — `inst` stays an instance method and
+        // the block's members never leak into it.
+        assert!(c.methods.contains_key("inst"));
+        assert!(!c.methods.contains_key("make"));
+        assert!(!c.methods.contains_key("other"));
+    }
+
+    #[test]
+    fn self_block_form_records_through_oo_define_too() {
+        // TP. Same block, reached through `oo::define` rather than the class
+        // creation body (oracle: `oo::define ::D { self { method mk {} {…} } }`
+        // → `info object methods ::D` is `mk`).
+        let src = "oo::class create ::D {}\n\
+                   oo::define ::D {\n\
+                   self {\n\
+                   method mk {} { return dmk }\n\
+                   }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::D").expect("::D recorded");
+        assert!(c.class_methods.contains_key("mk"));
+    }
+
+    #[test]
+    fn self_block_member_records_but_block_scoped_unexport_abstains() {
+        // Documented residual, pinned so it cannot regress silently.
+        //
+        // Oracle: `oo::class create ::E { self { method hidden {} {…} ;
+        // unexport hidden } }` leaves `info object methods ::E` empty while
+        // `-all -private` still lists `hidden`, and `::E hidden` errors
+        // "unknown method" — so the block's `unexport` really does apply to
+        // the class-object side.
+        //
+        // We record the *member* (that is #1081's outline gap) but abstain on
+        // the visibility effect, exactly as the `self unexport hidden` prefix
+        // form already does: `set_member_visibility` flips by bare name across
+        // BOTH the instance and class tables, so honouring it here would also
+        // un-export an identically-named instance method that the block never
+        // touched. Fixing that needs a side-scoped visibility setter, which is
+        // its own change.
+        let src = "oo::class create ::E {\n\
+                   self {\n\
+                   method hidden {} { return h }\n\
+                   unexport hidden\n\
+                   }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::E").expect("::E recorded");
+        assert!(c.class_methods.contains_key("hidden"));
+        assert_eq!(c.class_methods["hidden"].visibility, "public");
+    }
+
+    #[test]
+    fn private_block_form_records_instance_methods() {
+        // TP, symmetric half — `private` is the other registry member marked
+        // wrapper-with-block-body.
+        let src = "oo::class create ::P {\n\
+                   private {\n\
+                   method secret {k} { return $k }\n\
+                   }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::P").expect("::P recorded");
+        assert_eq!(c.methods["secret"].visibility, "private");
+        assert!(!c.class_methods.contains_key("secret"));
+    }
+
+    #[test]
+    fn self_block_does_not_declare_instance_variables() {
+        // TN / abstention boundary. `self { variable x }` declares a variable
+        // on the *class object*, not an instance variable of the class — the
+        // prefix form (`self variable x`) is not recorded either, and the
+        // block form must not start recording it as one.
+        let src = "oo::class create ::V {\n\
+                   self {\n\
+                   variable classlevel\n\
+                   }\n\
+                   variable instancelevel\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::V").expect("::V recorded");
+        assert_eq!(c.variables, vec!["instancelevel".to_string()]);
+    }
+
+    #[test]
+    fn self_introspection_prefix_is_not_a_block_member() {
+        // TN. Inside a *method body*, `self class` is an introspection call,
+        // not a definer member. The body is walked as a script (never as a
+        // definition body), so nothing here may reach `class_methods`.
+        let src = "oo::class create ::W {\n\
+                   method whoami {} { return [self class] }\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::W").expect("::W recorded");
+        assert!(c.methods.contains_key("whoami"));
+        assert!(c.class_methods.is_empty(), "{:?}", c.class_methods);
+    }
+
+    #[test]
+    fn dynamic_self_block_abstains() {
+        // Abstention boundary: a non-literal block word cannot be re-segmented
+        // statically, so the expansion declines and the class records nothing
+        // rather than guessing.
+        let src = "set b {method make {n} { return $n }}\n\
+                   oo::class create ::Dyn {\n\
+                   self $b\n\
+                   }";
+        let mut a = Analyser::new();
+        let r = a.analyse(src, "tcl9.0");
+        let c = r.all_classes.get("::Dyn").expect("::Dyn recorded");
+        assert!(c.class_methods.is_empty(), "{:?}", c.class_methods);
+        assert!(c.methods.is_empty(), "{:?}", c.methods);
     }
 
     // snit (tcllib) type / widget support.  Verified against real

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -214,6 +214,58 @@ fn qualify_proc_name(namespace: &str, proc_name: &str) -> String {
     normalise_qualified_name(&format!("{namespace}::{proc_name}"))
 }
 
+/// The namespace a `proc`'s **body** resolves names against: the namespace the
+/// proc is *defined in* (the qualifier prefix of its own qualified name), not
+/// the lexical namespace the `proc` command was written in.
+///
+/// The two agree for every proc whose name word carries no qualifier — the
+/// overwhelmingly common case, including `proc outer {} { proc inner … }` at
+/// top level — and diverge exactly when the name word is itself qualified, so
+/// the definition site and the defining namespace are different namespaces.
+///
+/// Oracle, identical on tclsh 9.0.4 and 8.6.16 (`self class`-style
+/// introspection is not involved; this is plain `info commands` after
+/// running the outer proc):
+///
+/// ```tcl
+/// namespace eval ::a {}
+/// proc a::outer {} { proc helper {x} { return $x } ; return [namespace current] }
+/// a::outer                        ;# -> ::a           (the body's frame namespace)
+/// info commands ::helper          ;# -> {}            (NOT the lexical ::)
+/// info commands ::a::helper       ;# -> ::a::helper
+///
+/// namespace eval ::b::c {}
+/// proc b::c::o2 {} { proc h2 {y} { return $y } }
+/// b::c::o2 ; info commands ::b::c::h2   ;# -> ::b::c::h2, and ::h2 is empty
+///
+/// # The *lexical* enclosing `namespace eval` loses to the name's own qualifier:
+/// namespace eval ::e {}
+/// namespace eval ::d { proc ::e::o3 {} { proc h3 {z} { return $z } } }
+/// ::e::o3 ; info commands ::e::h3       ;# -> ::e::h3, ::d::h3 and ::h3 empty
+///
+/// # Nesting composes — each level re-homes to its own defining namespace:
+/// namespace eval ::g {}
+/// proc g::o7 {} { proc o7b {} { proc h7 {u} { return $u } } }
+/// g::o7 ; ::g::o7b ; info commands ::g::h7   ;# -> ::g::h7, ::h7 empty
+/// ```
+///
+/// An absolutely-written nested name (`proc ::abs {q} {…}`) is unaffected —
+/// [`qualify_proc_name`] already short-circuits on the leading `::`.
+///
+/// `qualified` is always rooted (it comes from [`qualify_proc_name`], which
+/// routes every result through `normalise_qualified_name`), so the holder is
+/// never the empty "relative" marker [`tcl_syntax::naming::key_holder_and_tail`]
+/// returns for a bare simple name; `lexical_fallback` covers that
+/// impossible-by-construction case rather than silently producing `""`.
+fn proc_body_namespace(qualified: &str, lexical_fallback: &str) -> String {
+    let (holder, _) = tcl_syntax::naming::key_holder_and_tail(qualified);
+    if holder.is_empty() {
+        lexical_fallback.to_string()
+    } else {
+        holder.to_string()
+    }
+}
+
 /// Parse a Tcl parameter / variable list into its names.
 ///
 /// The list is a braced word, so a `\<newline>` line continuation collapses to
@@ -1384,6 +1436,12 @@ impl<'r> Lowerer<'r> {
         // and emit the runtime `proc` Call.
         let params = parse_param_names(&args[1]);
         let qualified = qualify_proc_name(namespace, proc_name);
+        // The body's own command/variable resolution namespace is the one the
+        // proc is *defined in* — the qualifier prefix of its own qualified
+        // name — not the lexical namespace the `proc` call was written in.
+        // See [`proc_body_namespace`] for the oracle transcript.
+        let body_namespace = proc_body_namespace(&qualified, namespace);
+        let body_namespace: &str = &body_namespace;
         let body_text = &args[2];
         // Fresh const-map frame for the nested proc body.
         // ``lower_body`` would otherwise inherit the enclosing
@@ -1396,7 +1454,7 @@ impl<'r> Lowerer<'r> {
         self.proc_depth += 1;
         self.const_map_stack.push(HashMap::new());
         let body = if let Some(text) = materialised_body {
-            self.lower_script(&text, namespace)
+            self.lower_script(&text, body_namespace)
         } else if body_is_dynamic {
             // Dynamic body, no materialisation possible — but the
             // proc name resolved via the const-map (otherwise we'd
@@ -1418,11 +1476,11 @@ impl<'r> Lowerer<'r> {
             // context-carrying sibling no longer disables the cache for this one.
             // Guarded by the corpus differential gates (`file_analysis_corpus` /
             // `compiler_check_corpus` / `per_item_corpus`).
-            let mut s = cache(body_text, namespace);
+            let mut s = cache(body_text, body_namespace);
             crate::lattice_rebase::rebase_script(&mut s, i64::from(body_offset));
             s
         } else {
-            self.lower_body(body_text, body_offset, namespace)
+            self.lower_body(body_text, body_offset, body_namespace)
         };
         self.const_map_stack.pop();
         self.proc_depth -= 1;
@@ -3536,6 +3594,106 @@ mod tests {
         let m = lower_to_ir("set x 1\nproc foo {} {return 1}", &r);
         assert_eq!(m.top_level.statements.len(), 2);
         assert!(m.procedures.contains_key("::foo"));
+    }
+
+    // ---- issue #1077: a proc body homes nested definitions to the proc's
+    // *defining* namespace, not the lexical namespace of the `proc` call. ----
+
+    #[test]
+    fn proc_body_namespace_peels_the_names_own_qualifier() {
+        // Unit-level: the helper is the inverse of `qualify_proc_name`.
+        assert_eq!(proc_body_namespace("::a::outer", "::"), "::a");
+        assert_eq!(proc_body_namespace("::b::c::o2", "::"), "::b::c");
+        assert_eq!(proc_body_namespace("::plain", "::ignored"), "::");
+        // A bare (unrooted) key can't come out of `qualify_proc_name`, but the
+        // fallback must not manufacture an empty namespace if it ever did.
+        assert_eq!(proc_body_namespace("plain", "::lex"), "::lex");
+    }
+
+    #[test]
+    fn nested_proc_homes_to_the_outer_procs_defining_namespace() {
+        // TP. Oracle (tclsh 9.0.4 and 8.6.16, identical):
+        //   namespace eval ::a {}
+        //   proc a::outer {} { proc helper {x} {return $x} }
+        //   a::outer ; info commands ::a::helper   -> ::a::helper
+        //              info commands ::helper      -> {}
+        let m = lower_to_ir(
+            "namespace eval ::a {}\nproc a::outer {} { proc helper {x} { return $x } }\n",
+            &reg(),
+        );
+        assert!(
+            m.procedures.contains_key("::a::helper"),
+            "nested proc must home to ::a, got {:?}",
+            m.procedures.keys().collect::<Vec<_>>(),
+        );
+        assert!(
+            !m.procedures.contains_key("::helper"),
+            "nested proc must NOT home lexically to ::",
+        );
+    }
+
+    #[test]
+    fn nested_proc_homing_composes_through_three_levels() {
+        // TP. Oracle: `proc g::o7 {} { proc o7b {} { proc h7 {u} … } }` →
+        // running `g::o7` then `::g::o7b` leaves `::g::h7` (never `::h7`).
+        let m = lower_to_ir(
+            "namespace eval ::g {}\nproc g::o7 {} { proc o7b {} { proc h7 {u} { return $u } } }\n",
+            &reg(),
+        );
+        assert!(m.procedures.contains_key("::g::o7b"));
+        assert!(
+            m.procedures.contains_key("::g::h7"),
+            "third level must stay in ::g, got {:?}",
+            m.procedures.keys().collect::<Vec<_>>(),
+        );
+        assert!(!m.procedures.contains_key("::h7"));
+    }
+
+    #[test]
+    fn nested_proc_name_qualifier_beats_the_lexical_namespace_eval() {
+        // TP. Oracle: inside `namespace eval ::d`, `proc ::e::o3` still homes
+        // its body to `::e` — `::e::h3` exists, `::d::h3` and `::h3` do not.
+        let m = lower_to_ir(
+            "namespace eval ::e {}\nnamespace eval ::d {\n    proc ::e::o3 {} { proc h3 {z} { return $z } }\n}\n",
+            &reg(),
+        );
+        assert!(
+            m.procedures.contains_key("::e::h3"),
+            "got {:?}",
+            m.procedures.keys().collect::<Vec<_>>(),
+        );
+        assert!(!m.procedures.contains_key("::d::h3"));
+        assert!(!m.procedures.contains_key("::h3"));
+    }
+
+    #[test]
+    fn unqualified_outer_proc_leaves_nested_homing_unchanged() {
+        // TN. The common shape: lexical and defining namespace agree, so the
+        // fix must be a no-op. Both at top level…
+        let m = lower_to_ir("proc outer {} { proc inner {} { return 1 } }\n", &reg());
+        assert!(m.procedures.contains_key("::inner"));
+        // …and inside a `namespace eval`, where both are `::ns`.
+        let m = lower_to_ir(
+            "namespace eval ::ns {\n    proc outer {} { proc inner {} { return 1 } }\n}\n",
+            &reg(),
+        );
+        assert!(
+            m.procedures.contains_key("::ns::inner"),
+            "got {:?}",
+            m.procedures.keys().collect::<Vec<_>>(),
+        );
+    }
+
+    #[test]
+    fn absolutely_named_nested_proc_is_unaffected() {
+        // TN. Oracle: `proc a::outer4 {} { proc ::abs {q} … }` creates `::abs`
+        // — an absolute inner name ignores the enclosing frame entirely.
+        let m = lower_to_ir(
+            "namespace eval ::a {}\nproc a::outer4 {} { proc ::abs {q} { return $q } }\n",
+            &reg(),
+        );
+        assert!(m.procedures.contains_key("::abs"));
+        assert!(!m.procedures.contains_key("::a::abs"));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/propagation.rs
+++ b/rust/tcl-compiler/src/optimiser/propagation.rs
@@ -82,6 +82,7 @@ use super::{Optimisation, PassContext};
 /// …) are skipped because substituting them as a bare word
 /// would change the command's interpretation.
 pub fn run(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
+    run_oo_method_folds(ctx, cu);
     run_function(ctx, cu, &cu.top_level, &cu.ir_module.top_level, "::");
     for (qname, fu) in &cu.procedures {
         let Some(proc) = cu.ir_module.procedures.get(qname) else {
@@ -854,6 +855,282 @@ fn simple_var_ref_matches(text: &str, var_name: &str) -> bool {
     normalise_var_name(&format!("${name}")) == normalise_var_name(&format!("${var_name}"))
 }
 
+/// The statically-proven facts about the `TclOO` method frame a body runs in
+/// (issue #1080).
+///
+/// Built once per method body by [`oo_frame_for`], which is where every
+/// abstention lives; by the time an `OoFrame` exists, each field is a value
+/// real `tclsh` would produce for every reachable invocation of that body.
+#[derive(Debug, Clone)]
+struct OoFrame {
+    /// The fully-qualified class that defines this implementation — the value
+    /// of [`tcl_registry::OoContextFact::DefiningClass`].
+    defining_class: String,
+}
+
+/// `method`'s provable frame facts, or `None` to abstain.
+///
+/// Folding direction is abstain-toward-no-fold: a wrong fold is a correctness
+/// bug, a missed fold only a lost optimisation. Three gates, each pinned to
+/// the oracle transcript on [`tcl_registry::OoContextFact::DefiningClass`]:
+///
+/// * **Class-object implementations.** `self class` *raises* ("method not
+///   defined by a class") inside an `oo::objdefine` instance method and inside
+///   a method on the class object (`self method` / `classmethod`) — there is
+///   no value to fold to. `oo::objdefine` never reaches here at all (the
+///   lowering's OO extraction only recognises the `oo::class`-family and
+///   `oo::define` definers), so the live gate is [`MethodKind::ClassMethod`].
+/// * **A class the source doesn't name.** The lowering already declines a
+///   dynamic class word, leaving an empty name; nothing to answer with.
+/// * **A renamed class command.** `rename ::R ::R2` makes `self class` answer
+///   `::R2` from bodies written under `::R` — the same rename-captures-identity
+///   rule `indirection.rs` applies. [`trusts_proc_binding`] is the
+///   whole-module, flow-insensitive query for "this name was never moved onto
+///   or vacated", which is exactly the property needed: a rename buried in a
+///   proc body still fires before some later method call.
+///
+/// [`trusts_proc_binding`]: crate::command_binding::ModuleCommandMutations::trusts_proc_binding
+fn oo_frame_for(
+    method: &crate::ir::MethodDef,
+    mutations: &crate::command_binding::ModuleCommandMutations,
+) -> Option<OoFrame> {
+    use crate::ir::MethodKind;
+    if method.kind == MethodKind::ClassMethod {
+        return None;
+    }
+    if method.class_name.is_empty() {
+        return None;
+    }
+    if !mutations.trusts_proc_binding(&method.class_name) {
+        return None;
+    }
+    Some(OoFrame {
+        defining_class: method.class_name.clone(),
+    })
+}
+
+/// Fold the command substitutions in every `TclOO` method body that the
+/// enclosing method frame makes constant — `[self class]`, and anything built
+/// purely out of it (`[namespace tail [self class]]` folds in one step, since
+/// the builtin fold resolves nested substitutions first).
+///
+/// Deliberately narrower than [`run_function`]: it carries **no** constants
+/// map, so no `$var` is propagated inside a method body. An instance variable
+/// is object state that outlives the frame and can be rewritten by any `my …`
+/// call, and the per-function SCCP lattice does not model that — so the
+/// variable-propagation half of this pass stays off for methods (which is the
+/// status quo) while the frame-constant fold, which touches no variable at
+/// all, is switched on.
+fn run_oo_method_folds(ctx: &mut PassContext<'_>, cu: &CompilationUnit) {
+    if ctx.registry.is_none() {
+        return;
+    }
+    // Sorted so the emitted rewrite order is deterministic across runs
+    // (`ir_module.methods` is a `HashMap`).
+    let mut qnames: Vec<&String> = cu.ir_module.methods.keys().collect();
+    qnames.sort();
+    for qname in qnames {
+        let Some(method) = cu.ir_module.methods.get(qname) else {
+            continue;
+        };
+        let Some(frame) = oo_frame_for(method, &ctx.command_mutations) else {
+            continue;
+        };
+        walk_oo_script(ctx, &method.body, &frame, 0);
+    }
+}
+
+/// `depth` is the nesting level of `script` — see
+/// [`super::MAX_OPTIMISER_WALK_DEPTH`].
+fn walk_oo_script(ctx: &mut PassContext<'_>, script: &Script, frame: &OoFrame, depth: u32) {
+    if super::MAX_OPTIMISER_WALK_DEPTH.exceeded(depth) {
+        return;
+    }
+    for stmt in &script.statements {
+        walk_oo_statement(ctx, stmt, frame, depth);
+    }
+}
+
+/// Visit one statement's command words for the frame-constant fold, then
+/// recurse into any nested body it carries.
+fn walk_oo_statement(ctx: &mut PassContext<'_>, stmt: &Statement, frame: &OoFrame, depth: u32) {
+    match stmt {
+        Statement::Call {
+            tokens: Some(t), ..
+        }
+        | Statement::AssignValue {
+            tokens: Some(t), ..
+        } => visit_oo_frame_folds(ctx, t, frame),
+        // `return [self class]` is the single most common shape of all, and a
+        // `Return` carries no `CommandTokens` — only the whole statement span
+        // and the raw value text. Rewrite the statement the way the sibling
+        // `return`-terminator folds (O101 / O115) already do.
+        Statement::Return {
+            span,
+            value: Some(raw),
+            expr: None,
+            ..
+        } => try_oo_frame_return_fold(ctx, *span, raw, frame),
+        Statement::If {
+            clauses, else_body, ..
+        } => {
+            for c in clauses {
+                walk_oo_script(ctx, &c.body, frame, depth + 1);
+            }
+            if let Some(b) = else_body {
+                walk_oo_script(ctx, b, frame, depth + 1);
+            }
+        }
+        Statement::For {
+            init, next, body, ..
+        } => {
+            walk_oo_script(ctx, init, frame, depth + 1);
+            walk_oo_script(ctx, next, frame, depth + 1);
+            walk_oo_script(ctx, body, frame, depth + 1);
+        }
+        Statement::While { body, .. }
+        | Statement::Catch { body, .. }
+        | Statement::Foreach { body, .. }
+        | Statement::Block { body, .. } => walk_oo_script(ctx, body, frame, depth + 1),
+        Statement::Try {
+            body,
+            handlers,
+            finally_body,
+            ..
+        } => {
+            walk_oo_script(ctx, body, frame, depth + 1);
+            for h in handlers {
+                walk_oo_script(ctx, &h.body, frame, depth + 1);
+            }
+            if let Some(fb) = finally_body {
+                walk_oo_script(ctx, fb, frame, depth + 1);
+            }
+        }
+        Statement::Switch {
+            arms, default_body, ..
+        } => {
+            for a in arms {
+                if let Some(body) = &a.body {
+                    walk_oo_script(ctx, body, frame, depth + 1);
+                }
+            }
+            if let Some(b) = default_body {
+                walk_oo_script(ctx, b, frame, depth + 1);
+            }
+        }
+        _ => {}
+    }
+}
+
+/// Report an `O129` for each single-token `[cmd …]` word of this command that
+/// the method frame folds to a constant.
+fn visit_oo_frame_folds(ctx: &mut PassContext<'_>, tokens: &CommandTokens, frame: &OoFrame) {
+    let Some(registry) = ctx.registry else {
+        return;
+    };
+    let no_constants = std::collections::HashMap::new();
+    let mut rewrites: Vec<(tcl_lexer::Span, String)> = Vec::new();
+    for (i, argv_span) in tokens.argv.iter().enumerate() {
+        if !tokens.single_token_word.get(i).copied().unwrap_or(false) {
+            continue;
+        }
+        let Some(text) = tokens.argv_texts.get(i) else {
+            continue;
+        };
+        let Some(inner) = text.strip_prefix('[').and_then(|s| s.strip_suffix(']')) else {
+            continue;
+        };
+        if let Some(folded) = try_o129_fold(
+            registry,
+            &ctx.command_mutations,
+            &no_constants,
+            inner,
+            ctx.dialect,
+            Some(frame),
+        ) {
+            rewrites.push((*argv_span, folded));
+        }
+    }
+    for (span, folded) in rewrites {
+        ctx.report(Optimisation::new(
+            DiagCode::O129,
+            "Fold constant builtin command substitution",
+            full_word_span(ctx.source, span),
+            folded,
+        ));
+    }
+}
+
+/// `return [self class]` → `return ::TheClass`.
+///
+/// The whole statement is the rewrite target (a `Return` keeps no per-word
+/// tokens), so the replacement re-spells the `return` keyword — the same shape
+/// [`try_fold_return_terminator`]'s O101 / O115 rewrites emit.
+fn try_oo_frame_return_fold(
+    ctx: &mut PassContext<'_>,
+    span: tcl_lexer::Span,
+    raw: &str,
+    frame: &OoFrame,
+) {
+    let Some(registry) = ctx.registry else {
+        return;
+    };
+    let Some(inner) = raw
+        .trim()
+        .strip_prefix('[')
+        .and_then(|s| s.strip_suffix(']'))
+    else {
+        return;
+    };
+    let no_constants = std::collections::HashMap::new();
+    let Some(folded) = try_o129_fold(
+        registry,
+        &ctx.command_mutations,
+        &no_constants,
+        inner,
+        ctx.dialect,
+        Some(frame),
+    ) else {
+        return;
+    };
+    ctx.report(Optimisation::new(
+        DiagCode::O129,
+        "Fold constant builtin command substitution",
+        span,
+        format!("return {folded}"),
+    ));
+}
+
+/// Answer a command substitution from the enclosing method frame, when the
+/// registry declares that this command's invoked keyword *is* a frame fact.
+///
+/// Entirely registry-driven: the word is looked up in the spec's
+/// [`CommandSpec::oo_context_facts`](tcl_registry::CommandSpec::oo_context_facts)
+/// table, so no command or subcommand name appears here.  A call carrying
+/// anything other than exactly the one keyword word declines — a bare `[self]`
+/// (equivalent to `self object`, the receiving instance) has no entry, and
+/// neither does any word the table omits.
+fn oo_context_fact_fold(
+    spec: &tcl_registry::CommandSpec,
+    args: &[String],
+    frame: &OoFrame,
+) -> Option<String> {
+    if spec.oo_context_facts.is_empty() {
+        return None;
+    }
+    let [word] = args else {
+        return None;
+    };
+    let fact = spec
+        .oo_context_facts
+        .iter()
+        .find(|(w, _)| *w == word.as_str())
+        .map(|(_, f)| *f)?;
+    match fact {
+        tcl_registry::OoContextFact::DefiningClass => Some(frame.defining_class.clone()),
+    }
+}
+
 fn run_function(
     ctx: &mut PassContext<'_>,
     cu: &CompilationUnit,
@@ -1380,6 +1657,7 @@ fn parse_static_call_args(
         registry,
         &ctx.command_mutations,
         ctx.dialect,
+        None,
     )?;
     Some(
         words
@@ -1827,8 +2105,14 @@ fn visit_call_cmd_subst_folds(
         // needed). Checked before the O103 interproc bail so it fires
         // even when no interprocedural summary is available.
         if let Some(reg) = ctx.registry
-            && let Some(folded) =
-                try_o129_fold(reg, &ctx.command_mutations, constants, inner, ctx.dialect)
+            && let Some(folded) = try_o129_fold(
+                reg,
+                &ctx.command_mutations,
+                constants,
+                inner,
+                ctx.dialect,
+                None,
+            )
         {
             // `list` / `lindex` keep their historical diagnostic codes
             // (O116 / O118) for editor granularity; everything else reports
@@ -1970,8 +2254,9 @@ fn try_o129_fold(
     constants: &std::collections::HashMap<String, String>,
     inner: &str,
     dialect: Option<&str>,
+    oo: Option<&OoFrame>,
 ) -> Option<String> {
-    let folded = fold_builtin_cmd_subst_raw(registry, mutations, constants, inner, dialect)?;
+    let folded = fold_builtin_cmd_subst_raw(registry, mutations, constants, inner, dialect, oo)?;
     Some(render_propagation_word(&folded))
 }
 
@@ -1990,13 +2275,23 @@ fn fold_builtin_cmd_subst_raw(
     constants: &std::collections::HashMap<String, String>,
     inner: &str,
     dialect: Option<&str>,
+    oo: Option<&OoFrame>,
 ) -> Option<String> {
-    let words = literal_words(inner, constants, registry, mutations, dialect)?;
+    let words = literal_words(inner, constants, registry, mutations, dialect, oo)?;
     let (head, rest) = words.split_first()?;
     if !mutations.trusts(head) {
         return None;
     }
     let spec = registry.get(head)?;
+    // A keyword whose value the enclosing `TclOO` method frame fixes
+    // (`[self class]`) answers from the frame rather than from its arguments —
+    // it has no `const_fold`, because the value is not a function of the args.
+    // Only reachable when the caller proved a frame; `None` everywhere else.
+    if let Some(frame) = oo
+        && let Some(folded) = oo_context_fact_fold(spec, rest, frame)
+    {
+        return Some(folded);
+    }
     if spec.subcommands.is_empty() {
         let arg_refs: Vec<&str> = rest.iter().map(String::as_str).collect();
         spec.run_const_fold(&arg_refs, dialect)
@@ -2027,6 +2322,7 @@ fn literal_words(
     registry: &tcl_registry::CommandRegistry,
     mutations: &crate::command_binding::ModuleCommandMutations,
     dialect: Option<&str>,
+    oo: Option<&OoFrame>,
 ) -> Option<Vec<String>> {
     use tcl_lexer::{Lexer, SourceMap, TokenType};
 
@@ -2080,8 +2376,9 @@ fn literal_words(
                 // A `Cmd` token's text is already the bracket *interior*
                 // (`list a b c`, not `[list a b c]`), so fold it directly.
                 let nested = sm.token_text(*tok);
-                let folded =
-                    fold_builtin_cmd_subst_raw(registry, mutations, constants, nested, dialect)?;
+                let folded = fold_builtin_cmd_subst_raw(
+                    registry, mutations, constants, nested, dialect, oo,
+                )?;
                 words.push(folded);
                 prev_is_sep = false;
             }
@@ -2228,6 +2525,7 @@ fn visit_string_interpolation_cmd_subs(
                     constants,
                     cmd,
                     ctx.dialect,
+                    None,
                 ) {
                     // Reject a result that would re-introduce a
                     // substitution into the `"…"` context.

--- a/rust/tcl-compiler/tests/checks.rs
+++ b/rust/tcl-compiler/tests/checks.rs
@@ -2229,6 +2229,50 @@ mod unused_proc_parameters {
         assert_eq!(w214_names(src), ["token"].map(String::from).into());
     }
 
+    /// The proc FQNs W214 names, for `src`.
+    fn w214_procs(src: &str) -> std::collections::HashSet<String> {
+        of_code(src, D, "W214")
+            .into_iter()
+            .filter_map(|(m, _, _)| m.split('\'').nth(3).map(str::to_string))
+            .collect()
+    }
+
+    #[test]
+    fn nested_proc_is_named_by_its_defining_namespace() {
+        // Issue #1077. Oracle (tclsh 9.0.4 / 8.6.16, identical): a proc body
+        // runs in the namespace the proc is *defined* in, so `proc a::outer`'s
+        // body creates `::a::helper`, not the lexical `::helper`.
+        assert_eq!(
+            w214_procs(
+                "namespace eval ::a {}\nproc a::outer {} { proc helper {unusedp} { return 1 } }\n"
+            ),
+            ["::a::helper"].map(String::from).into(),
+        );
+        // The name word's own qualifier beats the enclosing `namespace eval`.
+        assert_eq!(
+            w214_procs(
+                "namespace eval ::e {}\nnamespace eval ::d {\n    proc ::e::o3 {} { proc h3 {unusedz} { return 1 } }\n}\n"
+            ),
+            ["::e::h3"].map(String::from).into(),
+        );
+    }
+
+    #[test]
+    fn unqualified_and_absolute_nested_names_keep_their_fqn() {
+        // TN pair for #1077 — the shapes where lexical and defining namespace
+        // already agreed must not move.
+        assert_eq!(
+            w214_procs("proc outer {} { proc inner {unusedq} { return 1 } }\n"),
+            ["::inner"].map(String::from).into(),
+        );
+        assert_eq!(
+            w214_procs(
+                "namespace eval ::a {}\nproc a::outer4 {} { proc ::abs {unusedq} { return 1 } }\n"
+            ),
+            ["::abs"].map(String::from).into(),
+        );
+    }
+
     #[test]
     fn unique_signature_still_fires() {
         assert_eq!(

--- a/rust/tcl-compiler/tests/optimiser_codegen_residual.rs
+++ b/rust/tcl-compiler/tests/optimiser_codegen_residual.rs
@@ -876,3 +876,194 @@ fn emit_cmd_subst_arg_composite_and_special_forms() {
     // A bare `$name` form loads the scalar directly.
     assert_eq!(arg_ops(true, &["v"], "$v", false), vec![Op::LOAD_SCALAR1]);
 }
+
+// ===========================================================================
+// Issue #1080 — `[self class]` folds to the enclosing method's defining class.
+//
+// The value is a registry fact (`CommandSpec::oo_context_facts` maps `self`'s
+// `class` word to `OoContextFact::DefiningClass`), answered by the optimiser
+// from the class whose definition body encloses the method. Folding direction
+// is abstain-toward-no-fold, so each abstention gets its own TN below.
+//
+// Oracle, byte-identical on tclsh 9.0.4 and 8.6.16 — see
+// `OoContextFact::DefiningClass`'s doc comment for the full transcript.
+// ===========================================================================
+
+/// Every O129 replacement in `src`.
+fn o129(src: &str) -> Vec<String> {
+    repls(src, "O129")
+}
+
+#[test]
+fn self_class_folds_to_the_lexically_enclosing_class() {
+    // TP. Oracle: `oo::class create ::A { method m {} { self class } }` then
+    // `[::A new] m` -> ::A.
+    assert_eq!(
+        o129("oo::class create ::A {\n    method m {} { puts [self class] }\n}\n"),
+        vec!["::A".to_string()],
+    );
+    // TP, the `return` shape — the whole statement is the rewrite target.
+    assert_eq!(
+        o129("oo::class create ::A {\n    method m {} { return [self class] }\n}\n"),
+        vec!["return ::A".to_string()],
+    );
+    // TP, the `set` value position.
+    assert_eq!(
+        o129("oo::class create ::A {\n    method m {} { set c [self class]\n    puts $c }\n}\n"),
+        vec!["::A".to_string()],
+    );
+}
+
+#[test]
+fn self_class_folds_through_every_class_defining_shape() {
+    // TP. `oo::define` targets the class it names — oracle:
+    // `oo::define ::B { method n {} { self class } }` -> ::B, even for a
+    // subclass whose inherited method still answers with ::A.
+    assert_eq!(
+        o129("oo::class create ::B {}\noo::define ::B { method n {} { puts [self class] } }\n"),
+        vec!["::B".to_string()],
+    );
+    // TP. A relative class name inside `namespace eval` resolves the same way
+    // tclsh does — oracle: `namespace eval ::N { oo::class create C {…} }` and
+    // `[::N::C new] m` -> ::N::C.
+    assert_eq!(
+        o129(
+            "namespace eval ::N {\n    oo::class create C { method m {} { puts [self class] } }\n}\n"
+        ),
+        vec!["::N::C".to_string()],
+    );
+    // TP. Constructor and destructor bodies are class-defined implementations
+    // — oracle: both report ::E.
+    assert_eq!(
+        o129(
+            "oo::class create ::E {\n    constructor {} { puts [self class] }\n    destructor { puts [self class] }\n}\n"
+        ),
+        vec!["::E".to_string(), "::E".to_string()],
+    );
+}
+
+#[test]
+fn self_class_folds_inside_nested_bodies() {
+    // TP. The method-body walk recurses through control-flow bodies.
+    let r = o129(
+        "oo::class create ::A {\n    method m {} {\n        if {1} { puts [self class] }\n        foreach x {1 2} { puts [self class] }\n        while {0} { puts [self class] }\n    }\n}\n",
+    );
+    assert_eq!(r, vec!["::A".to_string(); 3], "got {r:?}");
+}
+
+#[test]
+fn self_class_abstains_on_a_class_object_method() {
+    // TN. Oracle: a method on the class *object* is not defined by a class, so
+    // `self class` RAISES rather than returning a name —
+    //   oo::class create ::U { self method cm {} { self class } }
+    //   ::U cm   ->  method not defined by a class
+    // Folding it to `::U` would invent a value the interpreter never produces.
+    assert!(
+        o129("oo::class create ::U {\n    classmethod cm {} { puts [self class] }\n}\n").is_empty(),
+    );
+    assert!(
+        o129("oo::class create ::U {\n    self method cm {} { puts [self class] }\n}\n").is_empty(),
+    );
+}
+
+#[test]
+fn self_class_abstains_when_the_class_command_is_renamed() {
+    // TN. Oracle: `self class` answers with the class's *current* name —
+    //   oo::class create ::R { method r {} { self class } }
+    //   set r [::R new] ; rename ::R ::R2 ; $r r   ->  ::R2
+    // so a module that renames the class anywhere must not fold to ::R. Same
+    // rename-captures-identity rule `indirection.rs` applies.
+    assert!(
+        o129("oo::class create ::R {\n    method r {} { puts [self class] }\n}\nrename ::R ::R2\n")
+            .is_empty(),
+    );
+    // The rename buried inside a proc body counts too: the whole-module query
+    // is flow-insensitive because the call order is not statically known.
+    assert!(
+        o129(
+            "oo::class create ::R {\n    method r {} { puts [self class] }\n}\nproc ::later {} { rename ::R ::R2 }\n"
+        )
+        .is_empty(),
+    );
+}
+
+#[test]
+fn self_class_abstains_when_self_itself_is_rebound() {
+    // TN. The generic builtin-fold trust gate: a module that redefines `self`
+    // no longer has `self`'s builtin semantics to fold with.
+    assert!(
+        o129(
+            "proc self {args} { return spoofed }\noo::class create ::A {\n    method m {} { puts [self class] }\n}\n"
+        )
+        .is_empty(),
+    );
+}
+
+#[test]
+fn the_other_self_words_never_fold() {
+    // TN. `object` / `namespace` name the receiving *instance* — a fresh
+    // `::oo::ObjNN` per `new`, never a source constant. Oracle:
+    //   oo::class create ::A { method m {} { list [self] [self object] \
+    //                                             [self namespace] } }
+    //   [::A new] m   ->  ::oo::Obj22 ::oo::Obj22 ::oo::Obj22
+    // and the chain words (`method`, `call`, `next`, `target`, `filter`,
+    // `caller`) are reshaped at run time by mixins, filters, and `next`.
+    for word in [
+        "",
+        "object",
+        "namespace",
+        "method",
+        "call",
+        "caller",
+        "filter",
+        "next",
+        "target",
+    ] {
+        let src =
+            format!("oo::class create ::A {{\n    method m {{}} {{ puts [self {word}] }}\n}}\n");
+        assert!(
+            o129(&src).is_empty(),
+            "`self {word}` must not fold: {:?}",
+            o129(&src),
+        );
+    }
+}
+
+#[test]
+fn self_class_outside_a_method_body_never_folds() {
+    // TN. `self` resolves only inside a method frame — oracle: at top level and
+    // in a plain proc it is not even a command
+    // (`invalid command name "self"`), so there is no frame to answer from and
+    // the fold must never reach these bodies.
+    assert!(o129("puts [self class]\n").is_empty());
+    assert!(o129("proc ::p {} { puts [self class] }\n").is_empty());
+}
+
+#[test]
+fn a_dynamic_class_name_leaves_self_class_alone() {
+    // TN. The lowering already declines a class word it cannot resolve
+    // statically, so no frame exists and nothing is claimed.
+    assert!(
+        o129("set nm ::F\noo::class create $nm { method m {} { puts [self class] } }\n").is_empty(),
+    );
+}
+
+#[test]
+fn folding_self_class_does_not_disturb_the_rest_of_the_method_body() {
+    // Blast-radius guard. The method-body walk carries no constants map, so it
+    // introduces no variable propagation inside a method — an instance
+    // variable is object state that outlives the frame and any `my …` call may
+    // rewrite it, which the per-function SCCP lattice does not model. Only the
+    // frame-constant fold fires here.
+    let src = "oo::class create ::A {\n    variable ivar\n    method m {} {\n        set ivar 1\n        my other\n        puts $ivar\n        puts [self class]\n    }\n    method other {} { set ivar 2 }\n}\n";
+    assert_eq!(o129(src), vec!["::A".to_string()]);
+    // No `$ivar` was propagated to a literal `1` anywhere.
+    assert!(
+        !opts(src).iter().any(|o| o.replacement == "1"),
+        "instance-variable propagation must stay off: {:?}",
+        opts(src)
+            .iter()
+            .map(|o| (o.code.as_str(), o.replacement.clone()))
+            .collect::<Vec<_>>(),
+    );
+}

--- a/rust/tcl-lsp-core/src/document_symbols.rs
+++ b/rust/tcl-lsp-core/src/document_symbols.rs
@@ -1170,6 +1170,140 @@ mod tests {
     }
 
     #[test]
+    fn oo_self_block_form_emits_class_side_method_symbols() {
+        // Issue #1081 — TP. `self { method … }` is `self method …` spelled as
+        // a block; both declare a method on the class *object*. Oracle
+        // (tclsh 9.0.4 / 8.6.16, identical):
+        //   oo::class create ::C { self { method make {n} {…} } }
+        //   ::C make 7               -> made-7
+        //   info object methods ::C  -> make      (class-object side)
+        //   info class methods ::C   -> {}        (instance side untouched)
+        // Only the prefix spelling reached the outline before the fix.
+        for source in [
+            concat!(
+                "oo::class create Counter {\n",
+                "    self {\n",
+                "        method make {n} { return $n }\n",
+                "        method reset {} { return 0 }\n",
+                "    }\n",
+                "    method tick {} { return 1 }\n",
+                "}\n",
+            ),
+            concat!(
+                "oo::class create Counter {}\n",
+                "oo::define Counter {\n",
+                "    self {\n",
+                "        method make {n} { return $n }\n",
+                "        method reset {} { return 0 }\n",
+                "    }\n",
+                "    method tick {} { return 1 }\n",
+                "}\n",
+            ),
+        ] {
+            for dialect in ["tcl8.6", "tcl9.0"] {
+                let symbols = document_symbols(source, dialect);
+                let cls = &symbols[0];
+                let make = cls
+                    .children
+                    .iter()
+                    .find(|c| c.name == "make")
+                    .unwrap_or_else(|| panic!("expected `make` in outline for {dialect}"));
+                assert_eq!(make.kind, SymbolKind::Method);
+                assert_eq!(
+                    make.detail.as_deref(),
+                    Some("classmethod (n)"),
+                    "block-form `self method` must carry the same detail the \
+                     prefix form does",
+                );
+                assert!(
+                    cls.children.iter().any(|c| c.name == "reset"),
+                    "every member of the block must be emitted, not just the first",
+                );
+                // The plain instance method alongside it is untouched.
+                let tick = cls
+                    .children
+                    .iter()
+                    .find(|c| c.name == "tick")
+                    .expect("expected instance method `tick`");
+                assert_eq!(tick.detail.as_deref(), Some("()"));
+            }
+        }
+    }
+
+    #[test]
+    fn oo_self_block_method_selection_range_covers_the_inner_name() {
+        // The symbol must select the member's own name word inside the block,
+        // not the enclosing `self` keyword — otherwise the outline jump lands
+        // on the wrapper.
+        let source = concat!(
+            "oo::class create Counter {\n",
+            "    self {\n",
+            "        method make {n} { return $n }\n",
+            "    }\n",
+            "}\n",
+        );
+        let symbols = document_symbols(source, "tcl9.0");
+        let make = symbols[0]
+            .children
+            .iter()
+            .find(|c| c.name == "make")
+            .expect("expected `make`");
+        // Line 2 (0-based): `        method make {n} { return $n }`.
+        assert_eq!(make.selection_range.start_line, 2);
+        assert_eq!(make.selection_range.start_character, 15);
+        assert_eq!(make.selection_range.end_character, 19);
+    }
+
+    #[test]
+    fn self_introspection_call_in_a_method_body_emits_no_symbol() {
+        // Issue #1081 — TN. A `self` *introspection* call inside a method body
+        // is not a definer member at all; it must contribute nothing to the
+        // outline. (`self class` there is an ordinary command substitution —
+        // tclsh returns the defining class, it declares nothing.)
+        let source = concat!(
+            "oo::class create Counter {\n",
+            "    method whoami {} {\n",
+            "        set c [self class]\n",
+            "        return [self object]\n",
+            "    }\n",
+            "}\n",
+        );
+        let symbols = document_symbols(source, "tcl9.0");
+        let names: Vec<&str> = symbols[0]
+            .children
+            .iter()
+            .map(|c| c.name.as_str())
+            .collect();
+        assert_eq!(
+            names,
+            ["whoami"],
+            "only the method itself is a symbol; `self class`/`self object` are not",
+        );
+    }
+
+    #[test]
+    fn oo_private_block_form_emits_instance_method_symbols() {
+        // Issue #1081, symmetric half: `private` is the other registry member
+        // marked wrapper-with-block-body, so the same normalisation gives it
+        // the outline node its prefix form already had.
+        let source = concat!(
+            "oo::class create Counter {\n",
+            "    private {\n",
+            "        method secret {k} { return $k }\n",
+            "    }\n",
+            "}\n",
+        );
+        let symbols = document_symbols(source, "tcl9.0");
+        let secret = symbols[0]
+            .children
+            .iter()
+            .find(|c| c.name == "secret")
+            .expect("expected private method `secret` in the outline");
+        assert_eq!(secret.kind, SymbolKind::Method);
+        assert_eq!(secret.detail.as_deref(), Some("(k)"));
+    }
+
+    #[test]
     fn merge_ranges_takes_outer_bounds() {
         let a = LineRange {
             start_line: 1,

--- a/rust/tcl-lsp-core/src/document_symbols.rs
+++ b/rust/tcl-lsp-core/src/document_symbols.rs
@@ -1282,6 +1282,58 @@ mod tests {
     }
 
     #[test]
+    fn oo_self_block_deleted_member_is_not_in_the_outline() {
+        // Issue #1095 review. A member the same block goes on to delete must
+        // not appear in the outline — a stale entry navigates to a name the
+        // interpreter does not have. Oracle (tclsh 9.0.4 / 8.6.16, identical):
+        //   oo::class create ::C1 {
+        //       self { method gone {} {…} ; method kept {} {…} ; deletemethod gone }
+        //   }
+        //   info object methods ::C1  ->  kept
+        //   ::C1 gone                 ->  unknown method "gone"
+        let source = concat!(
+            "oo::class create Counter {\n",
+            "    self {\n",
+            "        method gone {} { return 1 }\n",
+            "        method kept {} { return 2 }\n",
+            "        deletemethod gone\n",
+            "    }\n",
+            "}\n",
+        );
+        for dialect in ["tcl8.6", "tcl9.0"] {
+            let symbols = document_symbols(source, dialect);
+            let names: Vec<&str> = symbols[0]
+                .children
+                .iter()
+                .map(|c| c.name.as_str())
+                .collect();
+            assert_eq!(names, ["kept"], "{dialect}: stale member in outline");
+        }
+    }
+
+    #[test]
+    fn oo_self_block_non_destructive_reference_keeps_the_member_listed() {
+        // TN for the same mechanism: `export` / `unexport` / `filter` name a
+        // method without removing it, so the member stays in the outline.
+        // Oracle: `self { method a {} {…} ; unexport a ; export a }` leaves
+        // `info object methods ::A` -> a, and `::A a` -> 1.
+        let source = concat!(
+            "oo::class create Counter {\n",
+            "    self {\n",
+            "        method a {} { return 1 }\n",
+            "        unexport a\n",
+            "        export a\n",
+            "    }\n",
+            "}\n",
+        );
+        let symbols = document_symbols(source, "tcl9.0");
+        assert!(
+            symbols[0].children.iter().any(|c| c.name == "a"),
+            "export/unexport must not drop the outline entry",
+        );
+    }
+
+    #[test]
     fn oo_private_block_form_emits_instance_method_symbols() {
         // Issue #1081, symmetric half: `private` is the other registry member
         // marked wrapper-with-block-body, so the same normalisation gives it

--- a/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
+++ b/rust/tcl-lsp-server/tests/e2e/diagnostics.rs
@@ -3410,6 +3410,47 @@ fn w214_two_unused_params_get_separate_tight_ranges() {
 }
 
 #[test]
+fn w214_nested_proc_names_its_defining_namespace_and_anchors_on_the_param() {
+    // Issue #1077. `proc a::outer` runs its body in `::a` (the namespace it is
+    // *defined* in), so the `proc helper` it executes creates `::a::helper` —
+    // NOT the lexical `::helper`. Oracle, identical on tclsh 9.0.4 / 8.6.16:
+    //
+    //   namespace eval ::a {}
+    //   proc a::outer {} { proc helper {x} {return $x} ; return [namespace current] }
+    //   a::outer                  ;# -> ::a
+    //   info commands ::helper    ;# -> {}
+    //   info commands ::a::helper ;# -> ::a::helper
+    //
+    // Before the fix, lowering homed `helper` lexically to `::helper`; the
+    // reported FQN was wrong AND — because the per-parameter name-span lookup
+    // is keyed on that FQN against the analyser's `all_procs` (which already
+    // homed it correctly) — the lookup missed and the squiggle fell back to
+    // the whole `proc` definition. Both halves are asserted here.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    let src =
+        "namespace eval ::a {}\nproc a::outer {} {\n    proc helper {unusedp} { return 1 }\n}\n";
+    let diags = lsp.open_ready(&uri, src);
+    let w214: Vec<&Value> = diags
+        .iter()
+        .filter(|d| code_str(d).as_deref() == Some("W214"))
+        .collect();
+    assert_eq!(w214.len(), 1, "expected exactly one W214: {diags:?}");
+    let message = w214[0]["message"].as_str().unwrap_or_default();
+    assert!(
+        message.contains("'::a::helper'"),
+        "W214 must name the defining-namespace FQN, got {message:?}",
+    );
+    // Line 2 (0-based), `    proc helper {unusedp} …` — `unusedp` starts at
+    // column 17 and ends at 24.
+    assert_eq!(
+        diag_range(w214[0]),
+        ((2, 17), (2, 24)),
+        "W214 must span only `unusedp`, not the whole nested definition",
+    );
+}
+
+#[test]
 fn ordering_compare_on_strings_has_no_s100() {
     // `$s < "banana"` compares two strings — Tcl stays on the string path and
     // never coerces `$s` to a number, so its intrep is untouched (verified on

--- a/rust/tcl-lsp-server/tests/e2e/document_symbols.rs
+++ b/rust/tcl-lsp-server/tests/e2e/document_symbols.rs
@@ -356,6 +356,39 @@ fn self_block_form_members_appear_in_the_outline() {
 }
 
 #[test]
+fn self_block_deleted_member_is_absent_from_the_outline() {
+    // Issue #1095 review — TN, end to end. A member the block deletes must not
+    // reach the outline. Oracle (tclsh 9.0.4 / 8.6.16, identical):
+    //   oo::class create ::C1 {
+    //       self { method gone {} {…} ; method kept {} {…} ; deletemethod gone }
+    //   }
+    //   info object methods ::C1  ->  kept
+    //   ::C1 gone                 ->  unknown method "gone"
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        concat!(
+            "oo::class create Counter {\n",
+            "    self {\n",
+            "        method gone {} { return 1 }\n",
+            "        method kept {} { return 2 }\n",
+            "        deletemethod gone\n",
+            "    }\n",
+            "}\n",
+        ),
+    );
+    let syms = top(&mut lsp, &uri);
+    let kids = children(&syms[0]);
+    let names: Vec<&str> = kids.iter().map(name).collect();
+    assert_eq!(
+        names,
+        ["kept"],
+        "stale deleted member in outline: {names:?}"
+    );
+}
+
+#[test]
 fn self_introspection_inside_a_method_body_adds_no_symbol() {
     // Issue #1081 — TN, end to end. `self class` / `self object` in a method
     // body are introspection calls, not definer members: the outline must show

--- a/rust/tcl-lsp-server/tests/e2e/document_symbols.rs
+++ b/rust/tcl-lsp-server/tests/e2e/document_symbols.rs
@@ -310,6 +310,75 @@ fn classmethod_detail() {
     );
 }
 
+#[test]
+fn self_block_form_members_appear_in_the_outline() {
+    // Issue #1081 — TP, end to end. `self { method … }` declares exactly what
+    // `self method …` does; only the prefix spelling used to reach the outline.
+    // Oracle (tclsh 9.0.4 / 8.6.16, identical):
+    //   oo::class create ::C { self { method make {n} {…} } ; method tick {} {…} }
+    //   ::C make 7               -> made-7
+    //   info object methods ::C  -> make     (class-object side)
+    //   info class methods ::C   -> tick     (instance side)
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        concat!(
+            "oo::class create Counter {\n",
+            "    self {\n",
+            "        method make {n} { return $n }\n",
+            "        method reset {} { return 0 }\n",
+            "    }\n",
+            "    method tick {} { return 1 }\n",
+            "}\n",
+        ),
+    );
+    let syms = top(&mut lsp, &uri);
+    let cls = &syms[0];
+    assert_eq!(kind(cls), CLASS);
+    let kids = children(cls);
+    let make: Vec<&Value> = kids.iter().filter(|c| name(c) == "make").collect();
+    assert_eq!(make.len(), 1, "expected `make` in the outline: {kids:?}");
+    assert_eq!(kind(make[0]), METHOD);
+    assert!(
+        detail(make[0]).contains("classmethod"),
+        "a `self`-scoped member carries the classmethod detail, got {:?}",
+        detail(make[0]),
+    );
+    assert!(
+        kids.iter().any(|c| name(c) == "reset"),
+        "every member of the block lists, not just the first: {kids:?}",
+    );
+    // The instance method alongside it keeps its own (non-classmethod) detail.
+    let tick: Vec<&Value> = kids.iter().filter(|c| name(c) == "tick").collect();
+    assert_eq!(tick.len(), 1);
+    assert!(!detail(tick[0]).contains("classmethod"));
+}
+
+#[test]
+fn self_introspection_inside_a_method_body_adds_no_symbol() {
+    // Issue #1081 — TN, end to end. `self class` / `self object` in a method
+    // body are introspection calls, not definer members: the outline must show
+    // the method and nothing else.
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        concat!(
+            "oo::class create Counter {\n",
+            "    method whoami {} {\n",
+            "        set c [self class]\n",
+            "        return [self object]\n",
+            "    }\n",
+            "}\n",
+        ),
+    );
+    let syms = top(&mut lsp, &uri);
+    let kids = children(&syms[0]);
+    let names: Vec<&str> = kids.iter().map(|c| name(c)).collect();
+    assert_eq!(names, ["whoami"], "unexpected outline members: {names:?}");
+}
+
 // -- tcltest test cases (issue #790) -------------------------------------
 
 #[test]

--- a/rust/tcl-lsp-server/tests/e2e/document_symbols.rs
+++ b/rust/tcl-lsp-server/tests/e2e/document_symbols.rs
@@ -375,7 +375,7 @@ fn self_introspection_inside_a_method_body_adds_no_symbol() {
     );
     let syms = top(&mut lsp, &uri);
     let kids = children(&syms[0]);
-    let names: Vec<&str> = kids.iter().map(|c| name(c)).collect();
+    let names: Vec<&str> = kids.iter().map(name).collect();
     assert_eq!(names, ["whoami"], "unexpected outline members: {names:?}");
 }
 

--- a/rust/tcl-registry/src/commands/tcl/oo_self.rs
+++ b/rust/tcl-registry/src/commands/tcl/oo_self.rs
@@ -130,6 +130,26 @@ pub fn spec() -> CommandSpec {
         return_type: Some(TclType::String),
         arg_values: &[(0, SELF_SUBCOMMAND_VALUES)],
         closed_value_args: &[0],
+        // `class` is the one word of the nine whose value the *source* fixes:
+        // the defining class is the class whose definition body lexically
+        // encloses the method, unchanged by inheritance, mixins, and `next`
+        // (each chain link reports its own definer).  See
+        // [`OoContextFact::DefiningClass`] for the 9.0.4/8.6.16 transcript and
+        // the two shapes a consumer must still abstain on.
+        //
+        // The other eight are deliberately absent.  `object` and `namespace`
+        // name the *receiving instance* — a fresh `::oo::ObjNN` per `new`, so
+        // never a source constant, which is why issue #1080's "`self object`
+        // folds too" framing does not survive the oracle:
+        //
+        //     oo::class create ::A { method m {} { list [self] [self object] \
+        //                                               [self namespace] } }
+        //     [::A new] m   ;# -> ::oo::Obj22 ::oo::Obj22 ::oo::Obj22
+        //
+        // and `method`/`call`/`caller`/`filter`/`next`/`target` describe the
+        // live call chain, which mixins, filters, and `next` reshape at run
+        // time.
+        oo_context_facts: &[("class", OoContextFact::DefiningClass)],
         hover: Some(HoverSnippet {
             summary: "query information about the current method invocation",
             synopsis: &["self ?subcommand?"],

--- a/rust/tcl-registry/src/definer.rs
+++ b/rust/tcl-registry/src/definer.rs
@@ -105,6 +105,34 @@ pub struct MemberSpec {
     /// not exist in the 8.6 `TclOO` definition grammar — so a document using it
     /// under an older core is flagged rather than silently accepted.
     pub dialects: Option<crate::dialects::DialectSet>,
+    /// Whether this member **removes** the members its arguments name, rather
+    /// than merely referring to them.
+    ///
+    /// Distinguishes `deletemethod m` / `renamemethod old new` from the other
+    /// [`MemberRefKind::Method`] members (`export` / `unexport` / `filter`),
+    /// which name a method without retracting it.  A consumer that records
+    /// members from a definition body must not keep a member some later word
+    /// in the same body deletes.  Oracle, identical on tclsh 9.0.4 and 8.6.16:
+    ///
+    /// ```tcl
+    /// oo::class create ::C1 {
+    ///     self { method gone {} {…} ; method kept {} {…} ; deletemethod gone }
+    /// }
+    /// info object methods ::C1   ;# -> kept          (`gone` really is gone)
+    /// ::C1 gone                  ;# -> unknown method "gone"
+    ///
+    /// oo::class create ::C2 { self { method old {} {…} ; renamemethod old new } }
+    /// info object methods ::C2   ;# -> new
+    /// ::C2 old                   ;# -> unknown method "old"
+    /// ```
+    ///
+    /// Source order is not a consumer concern: naming a member that does not
+    /// exist *yet* is a hard error, not a no-op, so the only legal order is
+    /// declare-then-retract —
+    /// `oo::class create ::C3 { self { deletemethod ghost ; method ghost {} {…} } }`
+    /// fails with `method ghost does not exist` and no class is created at all
+    /// (same on both interpreters), as does deleting a never-declared name.
+    pub retracts_named_members: bool,
 }
 
 impl MemberSpec {
@@ -119,6 +147,7 @@ impl MemberSpec {
             kind: MemberKind::Flat,
             wrapper_block_body: false,
             dialects: None,
+            retracts_named_members: false,
         }
     }
 
@@ -134,6 +163,7 @@ impl MemberSpec {
             kind: MemberKind::Flat,
             wrapper_block_body: false,
             dialects: None,
+            retracts_named_members: false,
         }
     }
 
@@ -148,6 +178,7 @@ impl MemberSpec {
             kind: MemberKind::Flat,
             wrapper_block_body: false,
             dialects: None,
+            retracts_named_members: false,
         }
     }
 
@@ -163,6 +194,7 @@ impl MemberSpec {
             kind: MemberKind::Flat,
             wrapper_block_body: false,
             dialects: None,
+            retracts_named_members: false,
         }
     }
 
@@ -179,6 +211,7 @@ impl MemberSpec {
             kind: MemberKind::Wrapper,
             wrapper_block_body: false,
             dialects: None,
+            retracts_named_members: false,
         }
     }
 
@@ -198,6 +231,7 @@ impl MemberSpec {
             kind: MemberKind::Wrapper,
             wrapper_block_body: true,
             dialects: None,
+            retracts_named_members: false,
         }
     }
 
@@ -207,6 +241,15 @@ impl MemberSpec {
     #[must_use]
     const fn with_dialects(mut self, dialects: crate::dialects::DialectSet) -> Self {
         self.dialects = Some(dialects);
+        self
+    }
+
+    /// Mark this member as one that **retracts** the members its arguments
+    /// name (a builder over the constructors above) — see
+    /// [`Self::retracts_named_members`].
+    #[must_use]
+    const fn retracting(mut self) -> Self {
+        self.retracts_named_members = true;
         self
     }
 
@@ -221,6 +264,7 @@ impl MemberSpec {
             kind: MemberKind::FlagKeyed,
             wrapper_block_body: false,
             dialects: None,
+            retracts_named_members: false,
         }
     }
 
@@ -359,7 +403,7 @@ const TCLOO_MEMBERS: &[MemberSpec] = &[
     MemberSpec::all_refs("filter", MemberRefKind::Method),
     MemberSpec::all_refs("export", MemberRefKind::Method),
     MemberSpec::all_refs("unexport", MemberRefKind::Method),
-    MemberSpec::all_refs("deletemethod", MemberRefKind::Method),
+    MemberSpec::all_refs("deletemethod", MemberRefKind::Method).retracting(),
     // `forward NAME cmd ?arg…?` declares NAME as a method; the word after it
     // (`cmd`) is the delegated command's name — a first-class command
     // reference the walker records so navigation reaches it, exactly like the
@@ -367,7 +411,9 @@ const TCLOO_MEMBERS: &[MemberSpec] = &[
     // ordinary values.
     MemberSpec::flat("forward", FORWARD_ROLES),
     // `renamemethod FROM TO` — both name methods.
-    MemberSpec::all_refs("renamemethod", MemberRefKind::Method),
+    // Both words name methods; the FROM word is retracted (and the TO word is
+    // a member this walker does not record), so the whole call retracts.
+    MemberSpec::all_refs("renamemethod", MemberRefKind::Method).retracting(),
     MemberSpec::keyword_only("definitionnamespace").with_dialects(TCL90_MEMBERS),
     // Structurally irregular — a nested-member wrapper (`self method …`) and a
     // flag-keyed body form (`property … -get/-set …`); their body indices come

--- a/rust/tcl-registry/src/lib.rs
+++ b/rust/tcl-registry/src/lib.rs
@@ -121,7 +121,7 @@ pub mod prelude {
     pub use crate::side_effects::{ConnectionSide, SideEffect, SideEffectTarget, StorageType};
     pub use crate::spec::{
         BytePayloadSpec, CaseListSpec, CommandSpec, ContextGate, DefaultFormFirstWord,
-        ObjectClassSpec, SubCommand, SubSubCommand,
+        ObjectClassSpec, OoContextFact, SubCommand, SubSubCommand,
     };
     pub use crate::symbol_def::{DefinedSymbolKind, SymbolDef};
     pub use crate::taint::{SetterConstraint, TaintColour};
@@ -149,7 +149,7 @@ pub use profile_queries::{ProfileQueries, VendorSurface};
 pub use registry::{CommandRegistry, MethodDispatchKind, ResolvedCall, ResolvedTerminator};
 pub use spec::{
     BytePayloadSpec, CaseListSpec, CommandSpec, ContextGate, DefaultFormFirstWord, ObjectClassSpec,
-    SubCommand, SubSubCommand,
+    OoContextFact, SubCommand, SubSubCommand,
 };
 pub use special_vars::{
     SPECIAL_VARS, SpecialVarKey, SpecialVarKind, SpecialVarSpec, VarAccess, VarOrigin,

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -146,6 +146,66 @@ impl Default for BytePayloadSpec {
     }
 }
 
+/// A compile-time-constant fact about the **enclosing `TclOO` method frame**
+/// that an introspection keyword answers with.
+///
+/// Declared per keyword word on [`CommandSpec::oo_context_facts`], so a
+/// consumer folding `[self class]` reads registry data rather than matching
+/// the command name or the subcommand word.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OoContextFact {
+    /// The class that **defines** the currently executing method
+    /// implementation — what `self class` returns.
+    ///
+    /// The source fixes it: it is the class whose definition body lexically
+    /// encloses the method, and it stays that class through inheritance,
+    /// mixins, and `next`.  Oracle, byte-identical on tclsh 9.0.4 and 8.6.16:
+    ///
+    /// ```tcl
+    /// oo::class create ::A { method m {} { self class } }
+    /// [::A new] m                       ;# -> ::A
+    /// oo::class create ::B { superclass ::A }
+    /// [::B new] m                       ;# -> ::A   (the definer, not the receiver)
+    /// oo::define ::B { method n {} { self class } }
+    /// [::B new] n                       ;# -> ::B
+    /// oo::class create ::M { method mx {} { self class } }
+    /// oo::define ::B { mixin ::M } ; [::B new] mx
+    ///                                   ;# -> ::M   (a mixin still reports its definer)
+    /// oo::class create ::S { method q {} { list S:[self class] } }
+    /// oo::class create ::T { superclass ::S
+    ///                        method q {} { list T:[self class] {*}[next] } }
+    /// [::T new] q                       ;# -> T:::T S:::S  (per chain link)
+    /// oo::class create ::E { constructor {} { self class } }   ;# ctor -> ::E
+    /// oo::class create ::G { method real {} {return real}
+    ///                        method filt args { list [self class] {*}[next {*}$args] }
+    ///                        filter filt }
+    /// [::G new] real                    ;# -> ::G real       (a filter is a method)
+    /// namespace eval ::N { oo::class create C { method m {} { self class } } }
+    /// [::N::C new] m                    ;# -> ::N::C
+    /// ```
+    ///
+    /// Two shapes make it **not** a source constant.  A consumer must abstain
+    /// on both — the first is not even a value:
+    ///
+    /// ```tcl
+    /// # (1) The implementation is not defined by a class: an `oo::objdefine`
+    /// #     instance method, or a method on the class object itself
+    /// #     (`self method` / `classmethod`).  `self class` raises.
+    /// oo::objdefine $obj { method p {} { self class } }
+    /// $obj p                ;# -> error: method not defined by a class
+    /// oo::class create ::U { self method cm {} { self class } }
+    /// ::U cm                ;# -> error: method not defined by a class
+    ///
+    /// # (2) The class command was renamed: `self class` answers with the
+    /// #     class's *current* name, not the one written at definition —
+    /// #     the same rename-captures-identity rule `indirection.rs` applies.
+    /// oo::class create ::R { method r {} { self class } }
+    /// set r [::R new] ; rename ::R ::R2
+    /// $r r                  ;# -> ::R2
+    /// ```
+    DefiningClass,
+}
+
 /// Metadata for a `TclOO` / megawidget class whose instances are dispatched as
 /// `$obj <method> …`.
 ///
@@ -784,6 +844,22 @@ pub struct CommandSpec {
     /// every ensemble whose subcommands are C `switch`-statement arms with
     /// no individually-callable backing command (`string`, `array`, …).
     pub implementation_namespace: Option<&'static str>,
+
+    /// Argument-0 keyword words whose value is a compile-time constant fixed
+    /// by the enclosing `TclOO` **method frame** rather than by the arguments
+    /// — `self`'s `class`, and nothing else in the registry today.
+    ///
+    /// This is what lets the optimiser answer `[self class]` from the class
+    /// whose definition body encloses the method without ever matching the
+    /// command or the word by name: it looks the invoked word up here and
+    /// asks the frame for the named [`OoContextFact`].  Empty (the default)
+    /// for every command whose result no method frame determines.
+    ///
+    /// Deliberately keyed on the *word*, not the command: `self`'s nine words
+    /// differ — only `class` names something the source fixes.  See
+    /// [`OoContextFact`] for the oracle transcript and the abstention shapes
+    /// the consumer must still apply on top of this declaration.
+    pub oo_context_facts: &'static [(&'static str, OoContextFact)],
 }
 
 /// Count the leading words of `args` that are declared options in
@@ -925,6 +1001,7 @@ impl CommandSpec {
         defines_command_at: None,
         context_gate: None,
         implementation_namespace: None,
+        oo_context_facts: &[],
     };
 
     /// Run this command's constant folder for `args` under the optimiser's

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -873,6 +873,10 @@ fn command_advanced(d: &mut Draft, spec: &CommandSpec, lost: &mut Unrecovered) {
         lost.expr("case_list", spec.case_list.is_some()),
     );
     d.insert(
+        "oo_context_facts".into(),
+        lost.expr("oo_context_facts", !spec.oo_context_facts.is_empty()),
+    );
+    d.insert(
         "object_class".into(),
         lost.expr("object_class", spec.object_class.is_some()),
     );

--- a/rust/tcl-spec-studio/src/schema.rs
+++ b/rust/tcl-spec-studio/src/schema.rs
@@ -833,6 +833,15 @@ pub const COMMAND_FIELDS: &[FieldSchema] = &[
         "The `{pattern body …}` clause list the command takes as its final braced word.",
     ),
     f(
+        "oo_context_facts",
+        "TclOO context facts",
+        ADVANCED,
+        FieldKind::RustExpr {
+            hint: "&[(\"class\", OoContextFact::DefiningClass)]",
+        },
+        "Keyword words whose value the enclosing TclOO method frame fixes, so the optimiser can fold them.",
+    ),
+    f(
         "object_class",
         "Object class",
         ADVANCED,


### PR DESCRIPTION
## Summary

PR D2 — three TclOO/diagnostics residuals, each oracle-pinned on tclsh 9.0.4 + 8.6 (byte-identical across all probes). Two of the three issues' premises needed correction against the oracle, and the corrections are in the tests.

- **#1080 — `[self class]` folds to the lexically-enclosing class.** A 20-probe oracle matrix established that `self class` answers the *definer*, not the receiver, in every non-erroring shape — including mixin-provided methods and each link of a `next` chain, which is exactly what makes the lexical answer sound. Registry-driven: new `CommandSpec::oo_context_facts` field with `OoContextFact::DefiningClass` declared on `self`'s `class` word; the optimiser consults the table generically (no command names in the consumer). **Partly refutes the issue:** `self object`/`self namespace` return the per-instance `::oo::ObjNN` and can never fold — all nine non-`class` words abstain by declaration. Abstentions: class-object methods (`self class` *raises* there), dynamic class words, renamed class commands (`trusts_proc_binding`), rebound `self`. Deliberately narrow: the general propagation pass is NOT enabled on method bodies — instance variables outlive the frame and any `my …` call can rewrite them, which the per-function SCCP lattice doesn't model; `run_oo_method_folds` is a dedicated walk carrying no constants map, with a blast-radius test pinning that.
- **#1081 — `self { method … }` block members reach the outline.** The prefix forms already worked; only the block form produced nothing — one level above the symbols walker the brief suspected. `expand_wrapper_block_members` normalises the block through the definer grammar's existing `MemberKind::Wrapper` modelling into the prefix path, so `ClassDef` recording, references, and the method-body walk all come along; `private { … }` fixed symmetrically for free. Oracle pins block ≡ prefix (`info object methods`, dispatch, no instance leakage, no inheritance).
- **#1077 — nested procs home to their defining namespace.** Not a span bug: `lower_proc` resolved a body-defined proc against the lexical namespace, but a proc body executes in the namespace it's *defined in* — `proc a::outer {} { proc helper … }` defines `::a::helper`, not `::helper` (oracle-pinned, including qualifier-beats-`namespace eval` and three-level composition). Lowering now consumes the defining-context fact `register_proc_definition` records (post-#1075) instead of re-deriving lexical position. Both W214 symptoms fall out of the one change: the FQN is right, and the span lookup now hits so the squiggle tightens from the `proc` keyword to the parameter word.

New spec-studio coverage for the `oo_context_facts` field (schema.rs + draft.rs); no new trait flags, so the TRAITS catalogue is untouched.

**Residuals filed as issues rather than half-fixed:** `namespace qualifiers`/`namespace tail` have no const_fold (the issue's "already fold" claim verified false — full edge-case oracle transcript captured for the follow-up); the `${ns}` hop of the ticklecharts chain needs the instance-variable escaping model in propagation; block-scoped `export`/`unexport` abstains pending a side-scoped visibility setter.

## Validation

- [x] `cargo test -p tcl-compiler` (5028 lib + 56 integration suites), `-p tcl-registry -p tcl-lsp-core -p tcl-spec-studio` (incl. `schema_covers_every_command_spec_field`, dialect render sweep), `-p tcl-lsp-server` (1128 e2e + smoke) — **all 0 failed**; targeted suites re-run clean after freeing low disk (no ENOSPC occurred).
- [x] New tests: TP/TN split per issue — 10 for #1080 (incl. all-nine-words-never-fold and the blast-radius pin), 13 for #1081 (incl. the block-scoped-visibility residual pin), 9 for #1077 (incl. exact-span e2e `((2,17),(2,24))` and `'::a::helper'`).
- [x] `cargo clippy --workspace --all-targets` — 0 warnings, **zero new allows**; `cargo fmt --all --check` clean; `make xtask-check` EXIT=0.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — `CommandSpec::oo_context_facts` is a new registry fact; `lower_proc` FQN homing changes W214's reported names/spans for nested procs; the O129 fold surface gains `[self class]`.
- [x] KCS notes updated: new O129 optimisation page, W214 code page (defining-namespace homing + span), document-symbols feature page. STATUS.md untouched — idx 44/45/96 were already ticked and these three issues carry no idx of their own.
- [x] New compiler KCS note linked: `docs/kcs/codes/kcs-optimisation-o129-self-class-fold.md`.

Closes #1077. Closes #1080. Closes #1081.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_