### PR TITLE
namespace import: per-import-site export snapshots, not final export state (#1027)

### DIFF
--- a/docs/design/contracts/command-resolution.md
+++ b/docs/design/contracts/command-resolution.md
@@ -127,12 +127,21 @@ not change the rule, and must not grow bespoke resolution logic. Every
   name, never `::`-qualified (`namespace export ::foo` is an error —
   pinned), and are not references to commands: `namespace export p` before
   `proc p` still exports it (pinned). A non-glob `namespace import` of an
-  unexported name is a silent no-op, not an error (pinned); importing onto
-  an existing command errors unless `-force` (pinned). Statically the
-  analyser records these as an ordered event log
+  unexported name is a silent no-op, not an error (pinned) — so the **exact**
+  form is snapshot-gated exactly like the glob one; importing onto
+  an existing command errors unless `-force` (pinned). Both subcommands
+  consume at most **one** leading flag word: a second `-clear` is an ordinary
+  export pattern (and `-clear` is then a genuinely importable command name),
+  a second — or trailing — `-force` is an import pattern that aborts the
+  script, and neither flag abbreviates (`-c` / `-f` are patterns, not
+  options) — all pinned, and declared as
+  `SubCommand::max_leading_option_words`. Statically the
+  analyser records exports as an ordered event log
   (`SignatureNamespaceExport`, with `-clear` tombstones) and both LSP tiers
   answer through one shared decision function
-  (`tcl_lsp_core::namespace_import::exported_at_import_site`). Issue #1027.
+  (`tcl_lsp_core::namespace_import::exported_at_import_site`), under one
+  shared execution-order rule (`analyser::indirection::in_effect` /
+  `in_effect_within`). Issue #1027.
 - **`unknown` / `namespace unknown`** fire only after the full candidate
   walk (path included) misses. `namespace unknown` handlers are
   **per-namespace, NOT inherited** by children; the global namespace's

--- a/docs/design/contracts/command-resolution.md
+++ b/docs/design/contracts/command-resolution.md
@@ -115,6 +115,24 @@ not change the rule, and must not grow bespoke resolution logic. Every
   The WASM runtime retargets its by-name redirects on rename to match;
   the VM's clone-model import (a later redefinition of the origin is not
   seen) is a **known divergence**, documented here.
+  The export gate is a **snapshot taken at the import site**, not a
+  standing subscription: the import binds the names exported when it runs,
+  and neither a later `namespace export -clear` (which does **not** revoke
+  the alias — pinned) nor a later `namespace export` (which does **not**
+  add one retroactively — pinned) reaches back. A second, later import
+  takes its own snapshot and may bind names the first could not (pinned).
+  `namespace export` is **additive** across calls, and `-clear` empties the
+  list before the same call's own patterns are appended (both pinned).
+  Export patterns are glob *patterns* matched against a command's tail
+  name, never `::`-qualified (`namespace export ::foo` is an error —
+  pinned), and are not references to commands: `namespace export p` before
+  `proc p` still exports it (pinned). A non-glob `namespace import` of an
+  unexported name is a silent no-op, not an error (pinned); importing onto
+  an existing command errors unless `-force` (pinned). Statically the
+  analyser records these as an ordered event log
+  (`SignatureNamespaceExport`, with `-clear` tombstones) and both LSP tiers
+  answer through one shared decision function
+  (`tcl_lsp_core::namespace_import::exported_at_import_site`). Issue #1027.
 - **`unknown` / `namespace unknown`** fire only after the full candidate
   walk (path included) misses. `namespace unknown` handlers are
   **per-namespace, NOT inherited** by children; the global namespace's

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -33,6 +33,26 @@ same-document resolver in `definition.rs` decide through the one shared
 function `tcl_lsp_core::namespace_import::exported_at_import_site`, so they
 cannot disagree about what an import site sees.
 
+Ordering within a document is **not** a plain offset comparison. A
+`glob_imports` row also stores the innermost proc/class body containing the
+import (`enclosing_body`), so the tier applies
+`tcl_compiler::analyser::indirection::in_effect_within` — the same rule
+`in_effect` applies same-file: an import inside a body observes every
+*top-level* statement of its own file, wherever written, because the whole
+file loads before any body runs, while a statement of that same body stays
+ordered by offset.
+
+The gate is not limited to glob imports.  An **exact** `namespace import
+::src::p` installs nothing at all when `p` is not exported at that point, so
+the `command_links` row it produces carries an `import_gate` and is only
+*live* while the snapshot admits it.  Liveness is a function of the whole
+index — the export usually lives in another document — so it is a lazily-built
+whole-index derived view (rule 5 below), rebuilt per `generation()` and read
+through `WorkspaceIndex::live_command_links`.  Deciding it when the link is
+created would freeze a cross-document answer that goes stale as soon as the
+exporting file is edited.  `interp alias` / `rename` links, and imports merely
+*conjectured* from a tcllib `<NS>::import <ALIAS>` wrapper, carry no gate.
+
 The variable tables are deliberately narrower than the proc/class ones.  A
 namespace variable has one cell in one namespace, so `$::ns::v` in any
 document names the same thing as `variable v` inside `namespace eval ns`,

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -22,6 +22,17 @@ entry has an identity another document can spell:
 | `variable_refs` | occurrences written with a `::` qualifier | **qualified name only** |
 | `sources` / `package_requires` / `command_links` / `glob_imports` / `namespace_exports` | the cross-file graph edges | — |
 
+`glob_imports` and `namespace_exports` each carry their document **and their
+byte offset within it**, because a `namespace import` binds the names its
+source namespace exported *at the import site*, not in the workspace's final
+export state (issue #1027). Offsets order events only *within* one document:
+which of two files loads first is not a static fact, so an export in a
+different file from the import is treated as unordered — its pattern still
+counts, and a `-clear` it carries revokes nothing. Both this tier and the
+same-document resolver in `definition.rs` decide through the one shared
+function `tcl_lsp_core::namespace_import::exported_at_import_site`, so they
+cannot disagree about what an import site sees.
+
 The variable tables are deliberately narrower than the proc/class ones.  A
 namespace variable has one cell in one namespace, so `$::ns::v` in any
 document names the same thing as `variable v` inside `namespace eval ns`,

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -46,6 +46,20 @@ When a name carries both a `rename` and an `interp alias`, the one written
 **later** is what the call reaches — an alias silently replaces whatever the
 name held, and so does a rename.
 
+A `namespace import ::src::*` is order-gated the same way, on the *export*
+side. The import binds the names `::src` exported **at the moment the import
+runs**, and the export list keeps changing afterwards without reaching back: a
+`namespace export -clear` written after the import does **not** revoke the
+alias (the bare call still jumps to the source proc), and a `namespace export`
+written after the import does **not** create one (the bare call resolves to
+nothing through that import). A second, later `namespace import` takes its own
+snapshot, so it can pick up a name the first one could not. Export patterns
+are glob *patterns*, not command references — `namespace export get*` covers
+`getX` and not `setX`, and `namespace export p` written before `proc p` still
+exports it. Ordering only exists inside one document; when the import and the
+export are in different files, nothing fixes which loads first, so navigation
+keeps answering rather than guessing a revocation.
+
 A proc declared twice in one file is two definitions of one command. A call
 between the two jumps to the **first** header, a call after both jumps to
 the second, and a cursor on either header stays on that header.
@@ -143,6 +157,12 @@ same name — Tcl keeps those in a separate table from variables.
 - `rust/tcl-lsp-server/tests/e2e/navigation.rs` — the caller-frame cases
 - `rust/tcl-lsp-core/src/caller_frame.rs` — unit tests for the binding scan
 - `rust/tcl-lsp-core/src/definition.rs` (`mod tests`)
+- `rust/tcl-lsp-core/src/namespace_import.rs` (`mod tests`) — the
+  per-import-site export snapshot, shared by the same-document and workspace
+  resolvers
+- `rust/tcl-lsp-server/tests/e2e/definition.rs`
+  (`wildcard_import_survives_a_later_export_clear_cross_document`,
+  `wildcard_import_ignores_an_export_written_after_it_cross_document`)
 - `rust/tcl-lsp-server/tests/e2e/issue923_crossdoc.rs` (cross-file namespace
   variables, cross-file class-reference arguments)
 - `rust/tcl-lsp-server/src/lib.rs` unit tests

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -56,9 +56,17 @@ nothing through that import). A second, later `namespace import` takes its own
 snapshot, so it can pick up a name the first one could not. Export patterns
 are glob *patterns*, not command references — `namespace export get*` covers
 `getX` and not `setX`, and `namespace export p` written before `proc p` still
-exports it. Ordering only exists inside one document; when the import and the
-export are in different files, nothing fixes which loads first, so navigation
-keeps answering rather than guessing a revocation.
+exports it. The same gate applies to an *exact* `namespace import ::src::p`:
+real Tcl silently binds nothing when `p` is not exported, so neither does
+navigation.
+
+Ordering follows the same load-order rule renames and aliases do. An import
+written **inside a proc or method body** sees every top-level statement of its
+own file, wherever written — the file loads before any body runs — so an
+export further down the file still counts; an export written after the import
+*in that same body* does not. Ordering only exists inside one document; when
+the import and the export are in different files, nothing fixes which loads
+first, so navigation keeps answering rather than guessing a revocation.
 
 A proc declared twice in one file is two definitions of one command. A call
 between the two jumps to the **first** header, a call after both jumps to

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -5304,9 +5304,13 @@ impl Analyser {
         if args.is_empty() {
             return;
         }
-        // Skip the subcommand word + an optional ``-force`` flag.
+        // Skip the subcommand word + any leading flag the registry declares
+        // for `namespace import` (`-force`). Read from the spec rather than
+        // matched by name here: which words are options of this subcommand is
+        // command-level knowledge, and it lives in the registry
+        // (`IMPORT_OPTIONS` in `tcl-registry`'s `namespace_` module).
         let mut idx = 1;
-        if idx < args.len() && args[idx] == "-force" {
+        while idx < args.len() && self.namespace_subcommand_flag("import", &args[idx]) {
             idx += 1;
         }
         // `namespace import` imports into the namespace current at the call —
@@ -5359,13 +5363,22 @@ impl Analyser {
     /// (cross-document) can gate a would-be import target on whether its
     /// source namespace actually exports it (issue #923 idx 18).
     ///
-    /// `-clear` resets the namespace's previously recorded patterns (in this
-    /// same forward pass) before any new patterns on the same call are
-    /// added, mirroring `Tcl_Export`'s own `-clear` semantics. A dynamic
-    /// pattern (`$`/`[` substitution) can't be statically resolved to a
-    /// glob text, so it is silently skipped — the wildcard-import resolver
-    /// then correctly abstains for names it might have covered, rather than
-    /// guessing.
+    /// `-clear` is recorded as an ordered **tombstone** entry rather than
+    /// applied by dropping the namespace's earlier entries: an import
+    /// snapshots the export list as it stood when the import ran, so a
+    /// `-clear` written *after* an import must not revoke what that import
+    /// already bound (issue #1027, oracle in
+    /// [`crate::signature_scan::types::SignatureNamespaceExport`]).
+    /// Collapsing it eagerly — as this handler originally did — destroys
+    /// exactly the ordering the snapshot needs. Consumers reconstruct the
+    /// export set as of an offset with
+    /// `tcl_lsp_core::namespace_import::exported_at_import_site`.
+    ///
+    /// A dynamic pattern (`$`/`[` substitution) can't be statically resolved
+    /// to a glob text, so it is silently skipped — the wildcard-import
+    /// resolver then correctly abstains for names it might have covered,
+    /// rather than guessing. A dynamic word cannot hide a `-clear`, which is
+    /// a literal flag word or nothing.
     ///
     /// Dispatched via
     /// [`tcl_registry::hooks::AnalyserHookId::NamespaceExport`] (stamped on
@@ -5384,10 +5397,21 @@ impl Analyser {
         // As for `import`: the exporting namespace is the one current at the
         // call, not the lexically enclosing one (issue #923 idx 85).
         let exporting_ns = self.command_resolution_namespace(scope_path);
-        if idx < args.len() && args[idx] == "-clear" {
-            self.result
-                .namespace_exports
-                .retain(|e| e.ns != exporting_ns);
+        // Which leading words are flags is registry data (`EXPORT_OPTIONS`),
+        // not a name match here. `-clear` is the only one, and it lands as a
+        // tombstone event at its own token so the ordering survives.
+        while idx < args.len()
+            && idx < arg_tokens.len()
+            && self.namespace_subcommand_flag("export", &args[idx])
+        {
+            self.result.namespace_exports.push(
+                crate::signature_scan::types::SignatureNamespaceExport {
+                    ns: exporting_ns.clone(),
+                    pattern: String::new(),
+                    range: arg_tokens[idx].span,
+                    clears: true,
+                },
+            );
             idx += 1;
         }
         while idx < args.len() && idx < arg_tokens.len() {
@@ -5401,10 +5425,38 @@ impl Analyser {
                     ns: exporting_ns.clone(),
                     pattern,
                     range: arg_tokens[idx].span,
+                    clears: false,
                 },
             );
             idx += 1;
         }
+    }
+
+    /// Whether `word` is a leading **flag** option the registry declares for
+    /// `namespace SUB` in the active dialect profile.
+    ///
+    /// `namespace import`'s `-force` and `namespace export`'s `-clear` are
+    /// the two that matter here; both are pure flags (they consume no value
+    /// word), so a caller that skips them advances by exactly one. Reading
+    /// the option set from the spec — the same route
+    /// [`Self::handle_namespace_ensemble`] takes for `-command`/`-map` — is
+    /// what keeps this argument-role knowledge in the registry rather than as
+    /// a literal in the walker.
+    ///
+    /// `false` when no registry is attached (the analyser runs registry-less
+    /// in some unit tests): a flagless read then treats `-clear` as an
+    /// ordinary pattern, which is inert — no command is named `-clear`.
+    fn namespace_subcommand_flag(&self, sub: &str, word: &str) -> bool {
+        use tcl_registry::ProfileQueries;
+        self.registry
+            .and_then(|r| r.get("namespace"))
+            .and_then(|spec| spec.subcommand(sub).map(|s| (spec, s)))
+            .is_some_and(|(spec, s)| {
+                self.profile
+                    .available_sub_option_specs(spec, s)
+                    .iter()
+                    .any(|o| o.matches(word) && !o.takes_value())
+            })
     }
 
     /// Handle `namespace unknown HANDLER` — installing a per-namespace
@@ -6749,8 +6801,9 @@ mod tests {
     }
 
     #[test]
-    fn handle_namespace_export_clear_resets_previous_patterns_for_the_namespace() {
+    fn handle_namespace_export_clear_records_an_ordered_tombstone() {
         let mut a = Analyser::new();
+        a.registry = Some(tcl_registry::registry_for_dialect("tcl"));
         a.handle_namespace_export_command(
             &["export".to_string(), "bar".to_string()],
             &[esc_tok(span(0, 6)), esc_tok(span(7, 10))],
@@ -6769,17 +6822,33 @@ mod tests {
             ],
             &[],
         );
-        let patterns: Vec<&str> = a
+        // `-clear` is an ordered event, not an eager delete: the earlier
+        // `bar` entry stays on the log so a `namespace import` that ran
+        // *before* the `-clear` can still see it (issue #1027).
+        let events: Vec<(&str, bool, u32)> = a
             .result
             .namespace_exports
             .iter()
-            .map(|e| e.pattern.as_str())
+            .map(|e| (e.pattern.as_str(), e.clears, e.range.start()))
             .collect();
         assert_eq!(
-            patterns,
-            vec!["baz"],
-            "-clear must drop the earlier `bar` entry"
+            events,
+            vec![("bar", false, 7), ("", true, 18), ("baz", false, 25)]
         );
+    }
+
+    #[test]
+    fn handle_namespace_export_bare_clear_records_a_tombstone() {
+        let mut a = Analyser::new();
+        a.registry = Some(tcl_registry::registry_for_dialect("tcl"));
+        a.handle_namespace_export_command(
+            &["export".to_string(), "-clear".to_string()],
+            &[esc_tok(span(0, 6)), esc_tok(span(7, 13))],
+            &[],
+        );
+        assert_eq!(a.result.namespace_exports.len(), 1);
+        assert!(a.result.namespace_exports[0].clears);
+        assert!(a.result.namespace_exports[0].pattern.is_empty());
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -5304,15 +5304,11 @@ impl Analyser {
         if args.is_empty() {
             return;
         }
-        // Skip the subcommand word + any leading flag the registry declares
-        // for `namespace import` (`-force`). Read from the spec rather than
-        // matched by name here: which words are options of this subcommand is
-        // command-level knowledge, and it lives in the registry
-        // (`IMPORT_OPTIONS` in `tcl-registry`'s `namespace_` module).
-        let mut idx = 1;
-        while idx < args.len() && self.namespace_subcommand_flag("import", &args[idx]) {
-            idx += 1;
-        }
+        // Skip the subcommand word + the leading flag words the registry says
+        // `namespace import` consumes (`-force`, at most one). Both facts are
+        // read from the spec rather than matched by name or bounded by a
+        // literal here — see [`Self::namespace_leading_flag_words`].
+        let mut idx = 1 + self.namespace_leading_flag_words("import", &args[1..]);
         // `namespace import` imports into the namespace current at the call —
         // the command-resolution namespace, so an import inside
         // `proc ::ns::p {}` lands in `::ns` (issue #923 idx 85).
@@ -5397,13 +5393,19 @@ impl Analyser {
         // As for `import`: the exporting namespace is the one current at the
         // call, not the lexically enclosing one (issue #923 idx 85).
         let exporting_ns = self.command_resolution_namespace(scope_path);
-        // Which leading words are flags is registry data (`EXPORT_OPTIONS`),
-        // not a name match here. `-clear` is the only one, and it lands as a
-        // tombstone event at its own token so the ordering survives.
-        while idx < args.len()
-            && idx < arg_tokens.len()
-            && self.namespace_subcommand_flag("export", &args[idx])
-        {
+        // Which leading words are flags — and how many of them the command
+        // consumes — is registry data (`EXPORT_OPTIONS` plus
+        // `max_leading_option_words`), not a name match or a loop bound here.
+        // `-clear` is the only option and at most one is consumed, so a
+        // second `-clear` falls through to the pattern loop below and is
+        // recorded as the export pattern real Tcl treats it as. Each consumed
+        // flag lands as a tombstone event at its own token so the ordering
+        // survives.
+        let flag_words = self.namespace_leading_flag_words("export", &args[1..]);
+        for _ in 0..flag_words {
+            if idx >= args.len() || idx >= arg_tokens.len() {
+                break;
+            }
             self.result.namespace_exports.push(
                 crate::signature_scan::types::SignatureNamespaceExport {
                     ns: exporting_ns.clone(),
@@ -5432,31 +5434,56 @@ impl Analyser {
         }
     }
 
-    /// Whether `word` is a leading **flag** option the registry declares for
-    /// `namespace SUB` in the active dialect profile.
+    /// How many of `args`' leading words `namespace SUB` consumes as option
+    /// flags, entirely from registry data: a word that matches a declared
+    /// flag option of that subcommand, capped by the subcommand's declared
+    /// [`tcl_registry::SubCommand::max_leading_option_words`].
     ///
-    /// `namespace import`'s `-force` and `namespace export`'s `-clear` are
-    /// the two that matter here; both are pure flags (they consume no value
-    /// word), so a caller that skips them advances by exactly one. Reading
-    /// the option set from the spec — the same route
-    /// [`Self::handle_namespace_ensemble`] takes for `-command`/`-map` — is
-    /// what keeps this argument-role knowledge in the registry rather than as
-    /// a literal in the walker.
+    /// `args` is the word list *after* the subcommand word.
     ///
-    /// `false` when no registry is attached (the analyser runs registry-less
-    /// in some unit tests): a flagless read then treats `-clear` as an
-    /// ordinary pattern, which is inert — no command is named `-clear`.
-    fn namespace_subcommand_flag(&self, sub: &str, word: &str) -> bool {
+    /// Two registry facts, no literal in the walker:
+    ///
+    /// - **Which** words are flags — `namespace import`'s `-force` and
+    ///   `namespace export`'s `-clear` (`IMPORT_OPTIONS` / `EXPORT_OPTIONS`).
+    ///   Matching is exact (`OptionSpec::matches`, canonical name or declared
+    ///   alias), never the generic unique-prefix rule, because both
+    ///   subcommands hand-parse with `strcmp` in C: oracle (tclsh 8.6.14 /
+    ///   9.0.4) `namespace export -c p` exports `-c` and `p`, and `namespace
+    ///   import -f ::src::p` aborts with `no namespace specified in import
+    ///   pattern "-f"`.
+    /// - **How many** — one, declared as `max_leading_option_words`. A second
+    ///   `-clear` is an ordinary export pattern (and `-clear` is a perfectly
+    ///   valid, importable command name); a second `-force` is an import
+    ///   pattern that aborts the script.
+    ///
+    /// The scan also stops at the first non-flag word, which is what makes
+    /// `namespace export a -clear` export both (the flag is only ever the
+    /// first word — oracle-verified).
+    ///
+    /// `0` when no registry is attached (the analyser runs registry-less in
+    /// some unit tests): a flagless read then treats `-clear` as an ordinary
+    /// pattern, which is inert — nothing else records a command by that name.
+    fn namespace_leading_flag_words(&self, sub: &str, args: &[String]) -> usize {
         use tcl_registry::ProfileQueries;
-        self.registry
+        let Some((spec, sub_spec)) = self
+            .registry
             .and_then(|r| r.get("namespace"))
             .and_then(|spec| spec.subcommand(sub).map(|s| (spec, s)))
-            .is_some_and(|(spec, s)| {
-                self.profile
-                    .available_sub_option_specs(spec, s)
+        else {
+            return 0;
+        };
+        let options = self.profile.available_sub_option_specs(spec, sub_spec);
+        let cap = sub_spec
+            .max_leading_option_words
+            .map_or(usize::MAX, usize::from);
+        args.iter()
+            .take(cap)
+            .take_while(|w| {
+                options
                     .iter()
-                    .any(|o| o.matches(word) && !o.takes_value())
+                    .any(|o| o.matches(w.as_str()) && !o.takes_value())
             })
+            .count()
     }
 
     /// Handle `namespace unknown HANDLER` — installing a per-namespace
@@ -6835,6 +6862,99 @@ mod tests {
             events,
             vec![("bar", false, 7), ("", true, 18), ("baz", false, 25)]
         );
+    }
+
+    #[test]
+    fn handle_namespace_export_consumes_only_one_clear_flag() {
+        // PR #1102 review finding 3 — `NamespaceExportCmd` compares `objv[1]`
+        // against `-clear` once, so a *second* `-clear` is an ordinary export
+        // pattern. Oracle (tclsh 8.6.14 / 9.0.4): `namespace export -clear
+        // -clear p` leaves exactly `-clear p` exported, and a command really
+        // named `-clear` is then importable through `namespace import
+        // ::src::*`. Consuming every matching word instead recorded two
+        // tombstones and silently dropped the `-clear` export.
+        let mut a = Analyser::new();
+        a.registry = Some(tcl_registry::registry_for_dialect("tcl"));
+        a.handle_namespace_export_command(
+            &[
+                "export".to_string(),
+                "-clear".to_string(),
+                "-clear".to_string(),
+                "p".to_string(),
+            ],
+            &[
+                esc_tok(span(0, 6)),
+                esc_tok(span(7, 13)),
+                esc_tok(span(14, 20)),
+                esc_tok(span(21, 22)),
+            ],
+            &[],
+        );
+        let events: Vec<(&str, bool)> = a
+            .result
+            .namespace_exports
+            .iter()
+            .map(|e| (e.pattern.as_str(), e.clears))
+            .collect();
+        assert_eq!(events, vec![("", true), ("-clear", false), ("p", false)]);
+    }
+
+    #[test]
+    fn handle_namespace_export_flag_after_a_pattern_is_a_pattern() {
+        // The flag is only ever the *first* word: oracle `namespace export a
+        // -clear` → `namespace export` returns `a -clear`.
+        let mut a = Analyser::new();
+        a.registry = Some(tcl_registry::registry_for_dialect("tcl"));
+        a.handle_namespace_export_command(
+            &["export".to_string(), "a".to_string(), "-clear".to_string()],
+            &[
+                esc_tok(span(0, 6)),
+                esc_tok(span(7, 8)),
+                esc_tok(span(9, 15)),
+            ],
+            &[],
+        );
+        let events: Vec<(&str, bool)> = a
+            .result
+            .namespace_exports
+            .iter()
+            .map(|e| (e.pattern.as_str(), e.clears))
+            .collect();
+        assert_eq!(events, vec![("a", false), ("-clear", false)]);
+    }
+
+    #[test]
+    fn handle_namespace_import_consumes_only_one_force_flag() {
+        // Symmetric to the export case: `namespace import -force -force
+        // ::src::*` reads the second `-force` as an import *pattern* (and
+        // aborts with `no namespace specified in import pattern "-force"`,
+        // tclsh 8.6.14/9.0.4). Only the first is skipped as a flag, so the
+        // second is recorded as the pattern word it is — one whose empty
+        // source namespace both wildcard resolvers already decline.
+        let mut a = Analyser::new();
+        a.registry = Some(tcl_registry::registry_for_dialect("tcl"));
+        a.handle_namespace_import_command(
+            &[
+                "import".to_string(),
+                "-force".to_string(),
+                "-force".to_string(),
+                "::src::*".to_string(),
+            ],
+            &[
+                esc_tok(span(0, 6)),
+                esc_tok(span(7, 13)),
+                esc_tok(span(14, 20)),
+                esc_tok(span(21, 29)),
+            ],
+            &[],
+        );
+        let patterns: Vec<&str> = a
+            .result
+            .namespace_imports
+            .iter()
+            .map(|i| i.pattern.as_str())
+            .collect();
+        assert_eq!(patterns, vec!["::-force", "::src::*"]);
     }
 
     #[test]

--- a/rust/tcl-compiler/src/analyser/indirection.rs
+++ b/rust/tcl-compiler/src/analyser/indirection.rs
@@ -89,6 +89,8 @@
 
 use std::collections::HashMap;
 
+use tcl_lexer::Span;
+
 use super::types::AnalysisResult;
 
 /// Maximum command-name hops [`walk`] follows.
@@ -151,12 +153,34 @@ pub struct Indirection {
 /// not statically decidable.
 #[must_use]
 pub fn in_effect(result: &AnalysisResult, established: u32, call_off: u32) -> bool {
+    in_effect_within(
+        established,
+        call_off,
+        result.innermost_definition_body_span(call_off),
+    )
+}
+
+/// [`in_effect`]'s rule, stated over the two facts it actually needs, for a
+/// consumer that cannot hold the whole [`AnalysisResult`].
+///
+/// `enclosing_body` is the innermost recorded proc/class body span containing
+/// `call_off` (`None` when `call_off` is top-level) — exactly what
+/// [`AnalysisResult::innermost_definition_body_span`] returns, and the only
+/// thing [`in_effect`] reads out of the result.
+///
+/// Exists so the cross-document tier can apply the *identical* execution-order
+/// rule from facts it stores per row (`tcl_lsp_core`'s
+/// `WorkspaceGlobImport::enclosing_body`) instead of a weaker plain-offset
+/// comparison: an import written inside a proc body genuinely does observe a
+/// top-level `namespace export` written *later* in the same file, because the
+/// whole file loads before any body runs. A tier that compared offsets alone
+/// would reject that export and lose a real imported alias.
+#[must_use]
+pub fn in_effect_within(established: u32, call_off: u32, enclosing_body: Option<Span>) -> bool {
     if established < call_off {
         return true;
     }
-    result
-        .innermost_definition_body_span(call_off)
-        .is_some_and(|body| !(body.start() <= established && established < body.end()))
+    enclosing_body.is_some_and(|body| !(body.start() <= established && established < body.end()))
 }
 
 /// The binding a command name's slot holds, as of `as_of` — the later of its

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -1278,6 +1278,20 @@ mod tests {
     }
 
     #[test]
+    fn namespace_export_clear_tombstone_ordering_matches() {
+        // Issue #1027: `-clear` is recorded as an ordered tombstone rather
+        // than applied by deleting the namespace's earlier entries, so the
+        // export log now carries *more* rows and their relative order is
+        // load-bearing. Both walks must produce the identical log — a rebased
+        // offset or a dropped tombstone on either path would change what a
+        // per-import-site snapshot answers.
+        eq("namespace eval src {\n    proc p {} { return P }\n    \
+             namespace export p\n}\nnamespace eval dst {\n    \
+             namespace import ::src::*\n}\nnamespace eval src {\n    \
+             namespace export -clear q\n}\n");
+    }
+
+    #[test]
     fn namespace_export_inside_body_falls_back() {
         // A `namespace export` buried in a proc body leaks into the
         // whole-file walk's global export set (reached by a later

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -178,23 +178,64 @@ pub struct SignatureNamespaceImport {
     pub conjectured: bool,
 }
 
-/// A `namespace export` declaration recorded by the signature scanner.
+/// One `namespace export` **event** recorded by the signature scanner.
 ///
 /// Gates which commands a wildcard `namespace import NS::*` elsewhere may
 /// actually reach: real Tcl only imports names `NS` has exported
 /// (`Tcl_Export`, `tclNamesp.c`) — an unexported sibling command living in
 /// `NS` is not reachable through the import at all (tclsh9.0/8.6-verified:
 /// `invalid command name` calling it bare). Issue #923 idx 18.
+///
+/// # Why an event log, not a set
+///
+/// A namespace's export list is *mutable state on a timeline*, and
+/// `namespace import` snapshots it at the instant the import runs — later
+/// changes never reach back (issue #1027). Both directions are observable
+/// (oracle, tclsh 8.6.14 / 9.0.4):
+///
+/// - `namespace export -clear` **after** an import does not revoke the alias
+///   the import already installed: with `::src` exporting `p`, `namespace
+///   import ::src::*` in `::dst`, then `namespace export -clear` in `::src`,
+///   `::dst::p` still runs `::src::p`.
+/// - Exporting a name **after** an import does not add it retroactively:
+///   importing `::src::*` while nothing is exported, then `namespace export
+///   p`, leaves `::dst::p` an `invalid command name`. Only a *later* import
+///   picks the new name up.
+///
+/// So the records are kept as an ordered, append-only log — one entry per
+/// pattern word, plus a [`Self::clears`] tombstone for each `-clear` — and
+/// consumers reconstruct the export set *as of a given offset* rather than
+/// reading a flat final set. Collapsing `-clear` eagerly (dropping the
+/// namespace's earlier entries, as this type's first implementation did)
+/// destroys exactly the ordering the snapshot needs.
+///
+/// Note that an export pattern is a *name pattern*, not a reference to a
+/// command: `namespace export p` before `proc p` is written still exports
+/// `p` (oracle-verified), so nothing here is gated on the command existing.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SignatureNamespaceExport {
     /// Exporting namespace, with leading `::`.
     pub ns: String,
     /// Exported pattern text, exactly as written. Always relative to `ns`
     /// (Tcl's `namespace export` patterns are simple, unqualified glob
-    /// patterns matched against a command's tail name — never `::`-qualified).
+    /// patterns matched against a command's tail name — never `::`-qualified;
+    /// a `::`-qualified one is a hard error in real Tcl: `invalid export
+    /// pattern "::foo": pattern can't specify a namespace`).
+    ///
+    /// Empty when this record is a [`Self::clears`] tombstone, which carries
+    /// no pattern of its own.
     pub pattern: String,
-    /// Source span of the pattern argument.
+    /// Source span of the pattern argument — of the `-clear` word itself for
+    /// a [`Self::clears`] tombstone.
     pub range: Span,
+    /// `true` when this record is the `-clear` tombstone of a `namespace
+    /// export -clear ?pattern …?` call rather than an exported pattern.
+    ///
+    /// A tombstone revokes every pattern this namespace recorded *before* it;
+    /// the same call's own patterns are recorded after it and survive
+    /// (`namespace export a b; namespace export -clear p` leaves exactly `p`
+    /// exported — oracle-verified).
+    pub clears: bool,
 }
 
 /// An `auto_path` mutation recorded by the signature scanner.

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -2229,9 +2229,10 @@ pub fn itcl_class_proc_target_at(
 /// source namespace has actually `namespace export`ed (`Tcl_Export`,
 /// `tclNamesp.c`) — an unexported sibling command living in the same
 /// namespace is **not** reachable through the import (tclsh9.0/8.6-verified:
-/// `invalid command name` calling it bare) — so this also requires a recorded
-/// `analysis.namespace_exports` entry from that same source namespace whose
-/// pattern covers `word`.
+/// `invalid command name` calling it bare) — so this also requires the source
+/// namespace to have exported a covering pattern **as of that import's own
+/// position** ([`crate::namespace_import::exported_at_import_site`], issue
+/// #1027), not in the document's final export state.
 ///
 /// Only resolves a source namespace defined in **this** document
 /// (`analysis.all_procs`); a source namespace defined in another file is
@@ -2269,6 +2270,13 @@ fn proc_visible_via_wildcard_import<'a>(
 /// (`inner::p`) never goes through an imported alias in real Tcl, so this
 /// abstains rather than risk mismatching a namespace-path segment against
 /// an unrelated import.
+///
+/// The export check is taken **at each import's own position** rather than
+/// against the document's final export state: an import binds the names
+/// exported when it runs, and neither a later `-clear` nor a later `namespace
+/// export` reaches back (issue #1027 — see
+/// [`crate::namespace_import`] for the oracle). Every import site in scope is
+/// tried, so a second, later import that *does* see a name still resolves it.
 fn wildcard_import_source_namespace<'a, S: AsRef<str>>(
     analysis: &'a AnalysisResult,
     namespace: &str,
@@ -2294,16 +2302,46 @@ fn wildcard_import_source_namespace<'a, S: AsRef<str>>(
             if source_ns.is_empty() || !tcl_syntax::glob::string_match(export_tail, word) {
                 continue;
             }
-            let exported = analysis
-                .namespace_exports
-                .iter()
-                .any(|e| e.ns == source_ns && tcl_syntax::glob::string_match(&e.pattern, word));
-            if exported {
+            if exported_at_import(analysis, source_ns, word, imp.range.start()) {
                 return Some(source_ns);
             }
         }
     }
     None
+}
+
+/// Whether `source_ns` had exported `word` by the time the `namespace import`
+/// at `import_at` ran — the same-document binding of the shared decision
+/// function [`crate::namespace_import::exported_at_import_site`].
+///
+/// Every export event in this document is ordered against the import, so all
+/// of them carry an `at`; the "had it run?" primitive is
+/// [`tcl_compiler::analyser::indirection::in_effect`], reused rather than
+/// re-derived so an export written inside a proc body is judged by exactly the
+/// same load-order rule the `rename` / `interp alias` timeline applies (the
+/// whole file loads before any body runs, but a statement of the *same* body
+/// stays offset-ordered).
+///
+/// `pub(crate)` because `references.rs` asks the identical question about the
+/// identical records — one decision, not two.
+pub(crate) fn exported_at_import(
+    analysis: &AnalysisResult,
+    source_ns: &str,
+    word: &str,
+    import_at: u32,
+) -> bool {
+    let mut events = analysis
+        .namespace_exports
+        .iter()
+        .filter(|e| e.ns == source_ns)
+        .map(|e| crate::namespace_import::ExportEvent {
+            pattern: &e.pattern,
+            clears: e.clears,
+            at: Some(e.range.start()),
+        });
+    crate::namespace_import::exported_at_import_site(&mut events, word, &|at| {
+        tcl_compiler::analyser::indirection::in_effect(analysis, at, import_at)
+    })
 }
 
 /// Resolve a call `word` written in `namespace` to the proc it denotes:
@@ -3003,6 +3041,144 @@ mod tests {
             locs[0].start_line, 2,
             "must resolve to realns::helper (the exported, imported target), \
              not the decoy: {locs:?}"
+        );
+    }
+
+    // Per-import-site export snapshots (issue #1027). `namespace import`
+    // binds the names exported *when it runs*; the export list keeps
+    // changing afterwards and none of it reaches back. Every case below is
+    // oracle-pinned against tclsh 8.6.14 and 9.0.4.
+    //
+    // These drive `proc_visible_via_wildcard_import` rather than the full
+    // `definition()` provider for the same reason
+    // `wildcard_namespace_import_unexported_sibling_stays_unresolved` does:
+    // `resolve_called_proc`'s unrelated lenient `fallback_proc_by_simple_name`
+    // would answer either way and would prove nothing about this gate.
+
+    #[test]
+    fn import_site_snapshot_survives_a_later_export_clear() {
+        // TP, issue #1027 direction A — `namespace export -clear` after the
+        // import does NOT revoke the alias the import already installed.
+        // Oracle: `namespace eval ::src {proc p {} {return P}; namespace
+        // export p}; namespace eval ::dst {namespace import ::src::*};
+        // namespace eval ::src {namespace export -clear}; ::dst::p` → `P`,
+        // and `info commands ::dst::*` still lists `::dst::p`.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export -clear\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p");
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "a `-clear` written after the import must not revoke it: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn import_site_snapshot_ignores_a_later_export() {
+        // FP guard (CRITICAL), issue #1027 direction B — exporting a name
+        // *after* an import does not add it retroactively. Oracle:
+        // `namespace eval ::src {proc p {} {return P}}; namespace eval ::dst
+        // {namespace import ::src::*}; namespace eval ::src {namespace export
+        // p}; ::dst::p` → `invalid command name "::dst::p"`.
+        let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export p\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p");
+        assert!(
+            hit.is_none(),
+            "an export written after the import must not apply retroactively: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_second_import_after_a_later_export_does_pick_the_name_up() {
+        // TP — each import takes its own snapshot, so the *second* import,
+        // written after the export, binds `q` even though the first could
+        // not. Oracle: `namespace eval ::src {proc p …; proc q …; namespace
+        // export p}; namespace eval ::dst {namespace import ::src::*};
+        // namespace eval ::src {namespace export -clear p q}; namespace eval
+        // ::dst {namespace import ::src::*}` → both `::dst::p` and
+        // `::dst::q` run.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    proc q {} { return Q }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export -clear p q\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        for name in ["p", "q"] {
+            let hit = proc_visible_via_wildcard_import(&analysis, "dst", name);
+            assert!(
+                hit.is_some(),
+                "the second import must see `{name}`: {hit:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn export_clear_before_the_import_does_revoke() {
+        // TN — the ordering gate is real in both directions: a `-clear`
+        // written *before* the import leaves nothing for it to bind.
+        // Oracle: after `namespace export -clear`, `namespace export`
+        // returns the empty list, and the later import binds no command.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n    namespace export -clear\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p");
+        assert!(
+            hit.is_none(),
+            "a `-clear` before the import leaves nothing exported: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn export_clear_with_patterns_on_the_same_call_keeps_only_the_new_ones() {
+        // TP + TN — `namespace export a b; namespace export -clear p` leaves
+        // exactly `p` exported (oracle: `namespace export` → `p`), so an
+        // import after it binds `p` and not `a`.
+        let src = "namespace eval src {\n    proc a {} { return A }\n    proc p {} { return P }\n    namespace export a\n    namespace export -clear p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p").is_some(),
+            "the `-clear` call's own pattern survives it"
+        );
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "a").is_none(),
+            "the pattern cleared by the same call must not survive"
+        );
+    }
+
+    #[test]
+    fn separate_export_calls_are_additive() {
+        // TP — `namespace export a` then `namespace export b` exports both
+        // (oracle: `namespace export` → `a b`); `export` appends, it does
+        // not replace. A snapshot model that kept only the newest call's
+        // patterns would lose `a`.
+        let src = "namespace eval src {\n    proc a {} { return A }\n    proc b {} { return B }\n    namespace export a\n    namespace export b\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        for name in ["a", "b"] {
+            assert!(
+                proc_visible_via_wildcard_import(&analysis, "dst", name).is_some(),
+                "`{name}` must stay exported — `namespace export` is additive"
+            );
+        }
+    }
+
+    #[test]
+    fn export_glob_patterns_use_tcl_glob_semantics() {
+        // TP + TN — export patterns are glob *patterns*: oracle `namespace
+        // export get*` with `getX`/`setX` in the namespace imports only
+        // `getX` (`::dst::setX` → `invalid command name`).
+        let src = "namespace eval src {\n    proc getX {} { return GX }\n    proc setX {} { return SX }\n    namespace export get*\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        assert!(proc_visible_via_wildcard_import(&analysis, "dst", "getX").is_some());
+        assert!(proc_visible_via_wildcard_import(&analysis, "dst", "setX").is_none());
+    }
+
+    #[test]
+    fn an_export_written_before_the_proc_still_exports_it() {
+        // TP — an export pattern is a *name pattern*, not a reference to a
+        // command: oracle `namespace eval ::src {namespace export p; proc p
+        // {} {return P}}` then importing `::src::*` yields a working
+        // `::dst::p`. Nothing in the snapshot may require the proc to have
+        // been defined by the time the export ran.
+        let src = "namespace eval src {\n    namespace export p\n    proc p {} { return P }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p").is_some(),
+            "`namespace export` names a pattern, not an existing command"
         );
     }
 

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -3183,6 +3183,61 @@ mod tests {
     }
 
     #[test]
+    fn an_import_inside_a_body_sees_a_later_top_level_export() {
+        // TP — the same-document half of the ordering rule the workspace tier
+        // must match (PR #1102 review finding 1, pinned on both sides so they
+        // cannot drift): the import runs only when `setup` is called, by which
+        // time the whole file — including the `namespace export` written below
+        // it — has loaded. Oracle (tclsh 8.6.14 / 9.0.4): `::app::setup;
+        // ::app::run` → `HELP`.
+        //
+        // `indirection::in_effect` already said so here; the workspace tier's
+        // plain offset compare did not, which is what the review caught.
+        let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    proc setup {} { namespace import ::src::* }\n}\nnamespace eval src {\n    namespace export p\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p");
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "a body-local import observes a top-level export written later in \
+             the same file: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn an_export_in_the_importing_body_itself_stays_ordered() {
+        // FN guard for the leniency above: the "whole file loads first"
+        // exception does not extend to a statement of the *same* body, where
+        // the offsets are in genuine execution order. Oracle: `proc setup {}
+        // {namespace import ::src::*; namespace eval ::src {namespace export
+        // p}}` then `::dst::setup` leaves `::dst::p` an invalid command name.
+        let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    proc setup {} { namespace import ::src::* ; namespace eval ::src { namespace export p } }\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p");
+        assert!(
+            hit.is_none(),
+            "an export written after the import in the same body has not run \
+             yet: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_command_named_like_the_export_flag_is_exportable() {
+        // TP — the user-visible consequence of consuming only one `-clear`
+        // (PR #1102 review finding 3): `namespace export -clear -clear`
+        // exports a command genuinely *named* `-clear`, and a wildcard import
+        // then binds it. Oracle (tclsh 8.6.14 / 9.0.4): `namespace export`
+        // returns `-clear`, and `info commands ::dst::*` lists `::dst::-clear`.
+        // Consuming both words as flags dropped the export entirely.
+        let src = "namespace eval src {\n    proc -clear {} { return DC }\n    namespace export -clear -clear\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "-clear");
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::-clear"),
+            "the second `-clear` is an export pattern, not a second flag: {hit:?}"
+        );
+    }
+
+    #[test]
     fn exact_namespace_import_resolves_source_proc_in_document() {
         // FP guard / bonus TP — a plain (non-glob) `namespace import
         // ::Foo::bar` must keep working through the same in-document path

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -66,6 +66,7 @@ pub mod irules_context;
 pub mod irules_object_refs;
 pub mod linked_editing_range;
 pub mod minify;
+pub mod namespace_import;
 pub mod oo_body;
 mod oo_dispatch;
 pub mod package_resolver;

--- a/rust/tcl-lsp-core/src/namespace_import.rs
+++ b/rust/tcl-lsp-core/src/namespace_import.rs
@@ -63,14 +63,31 @@
 //! same-document resolver (`definition.rs` / `references.rs`) and the
 //! cross-document one (`workspace_index.rs`) both call it, so they cannot
 //! disagree about the semantics — the same "one entry point" discipline
-//! `qualified_variable_cell_at` uses. What *is* tier-specific is the primitive
+//! `qualified_variable_cell_at` uses. It gates **every** `namespace import`,
+//! glob or exact: an exact `namespace import ::src::p` of a name `::src` has
+//! not exported silently installs nothing in real Tcl (oracle: `info commands
+//! ::dst::*` stays empty and no error is raised), so the cross-document
+//! `WorkspaceCommandLink` an exact import produces is only live while this
+//! function admits it (`WorkspaceIndex::live_command_links`).
+//!
+//! What *is* tier-specific is the primitive
 //! "had this event already run when the import executed?", which the caller
 //! supplies as `visible`:
 //!
 //! - Same document: `analyser::indirection::in_effect`, so a declaration
 //!   inside a proc body is judged by the same load-order rule the rename /
 //!   alias timeline uses.
-//! - Cross-document, same file as the import: a plain offset comparison.
+//! - Cross-document, same file as the import:
+//!   `analyser::indirection::in_effect_within` — the *identical* rule, stated
+//!   over the two facts the index stores per row (the import's offset and the
+//!   innermost proc/class body containing it). A plain offset comparison is
+//!   **not** good enough and was a real tier divergence (PR #1102 review): an
+//!   import written inside a body genuinely observes a top-level export
+//!   written later in the same file, because the whole file loads before any
+//!   body runs — oracle (tclsh 8.6.14 / 9.0.4), `namespace eval ::app {proc
+//!   setup {} {namespace import ::mymod::*}; proc run {} {helper}}` followed
+//!   by `namespace eval ::mymod {namespace export helper}`, then
+//!   `::app::setup; ::app::run` → `HELP`.
 //! - **Different file from the import: not ordered at all.** Which file loads
 //!   first is not a static fact, so such an event is passed with
 //!   [`ExportEvent::at`] `None`, and this module abstains toward the safer

--- a/rust/tcl-lsp-core/src/namespace_import.rs
+++ b/rust/tcl-lsp-core/src/namespace_import.rs
@@ -1,0 +1,322 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! The per-import-site export snapshot: the one decision both wildcard-import
+//! tiers ask.
+//!
+//! `namespace import ::src::*` does not create a standing subscription to
+//! `::src`'s export list — it creates *aliases*, once, for the names exported
+//! at the moment the import runs. Everything after that is history:
+//!
+//! - **`namespace export -clear` after an import does not revoke the alias.**
+//!   Oracle (tclsh 8.6.14 / 9.0.4):
+//!   ```tcl
+//!   namespace eval ::src { proc p {} {return P}; namespace export p }
+//!   namespace eval ::dst { namespace import ::src::* }
+//!   namespace eval ::src { namespace export -clear }
+//!   ::dst::p     ;# → P   (and `info commands ::dst::*` still lists ::dst::p)
+//!   ```
+//! - **Exporting a name after an import does not add it retroactively.**
+//!   Oracle:
+//!   ```tcl
+//!   namespace eval ::src { proc p {} {return P} }
+//!   namespace eval ::dst { namespace import ::src::* }
+//!   namespace eval ::src { namespace export p }
+//!   ::dst::p     ;# → invalid command name "::dst::p"
+//!   ```
+//!   A *second* `namespace import ::src::*` written after the export does
+//!   pick `p` up — each import site takes its own snapshot.
+//!
+//! Joining every import against a namespace's *final* export set gets both
+//! directions wrong (issue #1027): it drops an alias the program still has,
+//! and invents one the program never had.
+//!
+//! # The model
+//!
+//! `namespace export` records are an ordered, append-only event log —
+//! [`tcl_compiler::signature_scan::types::SignatureNamespaceExport`], one
+//! entry per pattern word plus a `clears` tombstone per `-clear`. The
+//! question this module answers is *"was NAME exported by this namespace at
+//! the point import I ran?"*, which is the export half of the same
+//! "what does this name hold at this point?" timeline
+//! `tcl_compiler::analyser::indirection` answers for `rename` / `interp
+//! alias`, and under the same order-gating discipline.
+//!
+//! # One entry point, two tiers
+//!
+//! [`exported_at_import_site`] is the single decision function. The
+//! same-document resolver (`definition.rs` / `references.rs`) and the
+//! cross-document one (`workspace_index.rs`) both call it, so they cannot
+//! disagree about the semantics — the same "one entry point" discipline
+//! `qualified_variable_cell_at` uses. What *is* tier-specific is the primitive
+//! "had this event already run when the import executed?", which the caller
+//! supplies as `visible`:
+//!
+//! - Same document: `analyser::indirection::in_effect`, so a declaration
+//!   inside a proc body is judged by the same load-order rule the rename /
+//!   alias timeline uses.
+//! - Cross-document, same file as the import: a plain offset comparison.
+//! - **Different file from the import: not ordered at all.** Which file loads
+//!   first is not a static fact, so such an event is passed with
+//!   [`ExportEvent::at`] `None`, and this module abstains toward the safer
+//!   side *for navigation*: an unordered pattern still counts (keep answering
+//!   go-to-definition / find-references, the pre-#1027 behaviour), while an
+//!   unordered `-clear` does **not** revoke anything (revoking on a guess
+//!   would silently drop real references).
+
+use tcl_syntax::glob::string_match;
+
+/// One `namespace export` event as either tier sees it.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ExportEvent<'a> {
+    /// The exported glob pattern exactly as written, relative to the
+    /// exporting namespace. Empty (and ignored) when [`Self::clears`].
+    pub pattern: &'a str,
+    /// `true` for a `namespace export -clear` tombstone.
+    pub clears: bool,
+    /// Byte offset of the event *when it is ordered relative to the import
+    /// site* — i.e. when both are in the same document. `None` when the two
+    /// sit in different files, whose relative load order is not a static
+    /// fact.
+    pub at: Option<u32>,
+}
+
+/// Whether the source namespace exported `name` **at the point the import
+/// ran** — the per-import-site snapshot (issue #1027).
+///
+/// `events` are that namespace's export events, in any order. `visible`
+/// decides, for an ordered event at the given offset, whether it had already
+/// run when the import executed; see the module docs for why that primitive is
+/// the caller's and everything else is not.
+///
+/// The rule, applied to the events `visible` admits:
+///
+/// 1. Take the latest visible `-clear` tombstone, if any.
+/// 2. `name` is exported when some visible pattern event *after* that
+///    tombstone glob-matches it (Tcl's own `Tcl_StringMatch` semantics, via
+///    [`tcl_syntax::glob::string_match`] — export patterns are glob patterns:
+///    `namespace export get*` exports `getX` and not `setX`, and
+///    `namespace export {p[ab]}` exports `pa`/`pb` and not `pc`,
+///    oracle-verified).
+/// 3. Failing that, an *unordered* pattern event (a different file from the
+///    import) may still match — unordered `-clear`s revoke nothing.
+///
+/// An export pattern is a name pattern, not a reference to a command, so
+/// nothing here requires the command to exist: `namespace export p` written
+/// before `proc p` still exports `p` (oracle-verified). Whether the command
+/// exists is the caller's own lookup, which it does afterwards.
+///
+/// Single pass, no sort, no allocation — "some matching pattern sits after the
+/// latest `-clear`" is decided by comparing the *latest matching* pattern's
+/// offset with the latest tombstone's, which needs only two running maxima.
+/// This runs inside the cross-document find-references loop, once per
+/// candidate import per invocation, where the workspace tier already had to
+/// hoist an index out (see
+/// `WorkspaceIndex::resolve_wildcard_import_indexed`) to keep that path off
+/// the profiler.
+#[must_use]
+pub fn exported_at_import_site(
+    events: &mut dyn Iterator<Item = ExportEvent<'_>>,
+    name: &str,
+    visible: &dyn Fn(u32) -> bool,
+) -> bool {
+    // Latest visible tombstone, and the latest visible pattern event that
+    // matches `name`.
+    let mut cleared_through: Option<u32> = None;
+    let mut latest_match: Option<u32> = None;
+    let mut unordered_match = false;
+    for ev in events {
+        let Some(at) = ev.at else {
+            unordered_match |= !ev.clears && string_match(ev.pattern, name);
+            continue;
+        };
+        if !visible(at) {
+            continue;
+        }
+        if ev.clears {
+            cleared_through = cleared_through.max(Some(at));
+        } else if string_match(ev.pattern, name) {
+            latest_match = latest_match.max(Some(at));
+        }
+    }
+    let ordered_match =
+        latest_match.is_some_and(|m| cleared_through.is_none_or(|cleared| m > cleared));
+    ordered_match || unordered_match
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn ev(pattern: &str, at: u32) -> ExportEvent<'_> {
+        ExportEvent {
+            pattern,
+            clears: false,
+            at: Some(at),
+        }
+    }
+
+    fn clear(at: u32) -> ExportEvent<'static> {
+        ExportEvent {
+            pattern: "",
+            clears: true,
+            at: Some(at),
+        }
+    }
+
+    fn unordered(pattern: &str) -> ExportEvent<'_> {
+        ExportEvent {
+            pattern,
+            clears: false,
+            at: None,
+        }
+    }
+
+    /// `visible` for an import at `import_at`: plain textual order.
+    fn before(import_at: u32) -> impl Fn(u32) -> bool {
+        move |at| at <= import_at
+    }
+
+    #[test]
+    fn export_before_import_is_visible() {
+        let mut evs = [ev("p", 10)].into_iter();
+        assert!(exported_at_import_site(&mut evs, "p", &before(20)));
+    }
+
+    #[test]
+    fn direction_b_export_after_import_is_not_retroactive() {
+        // `namespace export p` at 30, import at 20 → not yet exported.
+        let mut evs = [ev("p", 30)].into_iter();
+        assert!(!exported_at_import_site(&mut evs, "p", &before(20)));
+    }
+
+    #[test]
+    fn direction_a_clear_after_import_does_not_revoke() {
+        // export p @10, import @20, `-clear` @30.
+        let mut evs = [ev("p", 10), clear(30)].into_iter();
+        assert!(exported_at_import_site(&mut evs, "p", &before(20)));
+    }
+
+    #[test]
+    fn clear_before_import_does_revoke() {
+        let mut evs = [ev("p", 10), clear(15)].into_iter();
+        assert!(!exported_at_import_site(&mut evs, "p", &before(20)));
+    }
+
+    #[test]
+    fn clear_then_add_on_the_same_call_keeps_the_new_pattern() {
+        // `namespace export a b; namespace export -clear p` → exactly `p`.
+        let mut evs = [ev("a", 5), ev("b", 7), clear(20), ev("p", 27)].into_iter();
+        assert!(exported_at_import_site(&mut evs.clone(), "p", &before(40)));
+        assert!(!exported_at_import_site(&mut evs, "a", &before(40)));
+    }
+
+    #[test]
+    fn exports_are_additive_across_calls() {
+        let mut evs = [ev("a", 5), ev("b", 20)].into_iter();
+        assert!(exported_at_import_site(&mut evs.clone(), "a", &before(40)));
+        assert!(exported_at_import_site(&mut evs, "b", &before(40)));
+    }
+
+    #[test]
+    fn a_second_import_sees_the_later_export() {
+        let events = [ev("p", 10), clear(30), ev("p", 37), ev("q", 39)];
+        // First import at 20: `p` yes, `q` no.
+        assert!(exported_at_import_site(
+            &mut events.into_iter(),
+            "p",
+            &before(20)
+        ));
+        assert!(!exported_at_import_site(
+            &mut events.into_iter(),
+            "q",
+            &before(20)
+        ));
+        // Second import at 50: both.
+        assert!(exported_at_import_site(
+            &mut events.into_iter(),
+            "p",
+            &before(50)
+        ));
+        assert!(exported_at_import_site(
+            &mut events.into_iter(),
+            "q",
+            &before(50)
+        ));
+    }
+
+    #[test]
+    fn glob_patterns_use_tcl_semantics() {
+        let events = [ev("get*", 10)];
+        assert!(exported_at_import_site(
+            &mut events.into_iter(),
+            "getX",
+            &before(20)
+        ));
+        assert!(!exported_at_import_site(
+            &mut events.into_iter(),
+            "setX",
+            &before(20)
+        ));
+        let cc = [ev("p[ab]", 10)];
+        assert!(exported_at_import_site(
+            &mut cc.into_iter(),
+            "pa",
+            &before(20)
+        ));
+        assert!(!exported_at_import_site(
+            &mut cc.into_iter(),
+            "pc",
+            &before(20)
+        ));
+    }
+
+    #[test]
+    fn unordered_pattern_counts_and_unordered_clear_does_not_revoke() {
+        // Export declared in another file: ordering unknown, so it still
+        // resolves…
+        let mut evs = [unordered("p")].into_iter();
+        assert!(exported_at_import_site(&mut evs, "p", &before(0)));
+        // …and a `-clear` from another file cannot silently drop it.
+        let mut evs = [
+            unordered("p"),
+            ExportEvent {
+                pattern: "",
+                clears: true,
+                at: None,
+            },
+        ]
+        .into_iter();
+        assert!(exported_at_import_site(&mut evs, "p", &before(0)));
+    }
+
+    #[test]
+    fn an_ordered_clear_does_not_revoke_an_unordered_export() {
+        // The `-clear` is ordered before the import, but the surviving
+        // pattern comes from a file whose load order is unknown — it may well
+        // have run after. Navigation keeps answering.
+        let mut evs = [clear(5), unordered("p")].into_iter();
+        assert!(exported_at_import_site(&mut evs, "p", &before(20)));
+    }
+
+    #[test]
+    fn no_events_means_not_exported() {
+        let mut evs = [].into_iter();
+        assert!(!exported_at_import_site(&mut evs, "p", &before(20)));
+    }
+}

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -311,6 +311,17 @@ fn invocation_references_via_indirection(
 /// (`WorkspaceIndex::linked_invocations_of`, used by cross-document
 /// references only, never by cross-document rename's
 /// `invocations_of`-based edit gathering).
+///
+/// The export gate is applied **per import site**, at that import's own
+/// position, through the same shared decision function the go-to-definition
+/// resolver uses (`definition::exported_at_import` →
+/// [`crate::namespace_import::exported_at_import_site`]): an import binds the
+/// names exported when it runs, so a later `namespace export -clear` does not
+/// revoke this call site's alias and a later `namespace export` does not
+/// create one (issue #1027). Testing "some import matches" and "the final
+/// export set covers the name" as two independent conditions — as this
+/// originally did — gets both directions wrong, and lets an import whose own
+/// snapshot excluded the name borrow an unrelated import's export.
 #[must_use]
 fn invocation_references_via_wildcard_import(
     analysis: &AnalysisResult,
@@ -330,7 +341,7 @@ fn invocation_references_via_wildcard_import(
         inv.range.start(),
         &analysis.namespace_overrides,
     );
-    let imported = analysis.namespace_imports.iter().any(|imp| {
+    analysis.namespace_imports.iter().any(|imp| {
         imp.ns.trim_start_matches("::") == call_ns
             && imp
                 .pattern
@@ -338,13 +349,14 @@ fn invocation_references_via_wildcard_import(
                 .is_some_and(|(source_ns, tail)| {
                     source_ns.trim_start_matches("::") == target_ns
                         && tcl_syntax::glob::string_match(tail, def_name)
+                        && crate::definition::exported_at_import(
+                            analysis,
+                            source_ns,
+                            def_name,
+                            imp.range.start(),
+                        )
                 })
-    });
-    imported
-        && analysis.namespace_exports.iter().any(|e| {
-            e.ns.trim_start_matches("::") == target_ns
-                && tcl_syntax::glob::string_match(&e.pattern, def_name)
-        })
+    })
 }
 
 #[must_use]
@@ -3113,6 +3125,47 @@ mod tests {
         assert!(
             lines.contains(&5),
             "wildcard-imported bareword call site missing: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_keep_a_wildcard_imported_call_after_a_later_export_clear() {
+        // TP, issue #1027 direction A — the import bound `p` while `::src`
+        // still exported it; the later `namespace export -clear` does not
+        // revoke that alias (oracle tclsh 8.6.14/9.0.4: `::dst::p` still
+        // runs, `info commands ::dst::*` still lists it). Before the
+        // per-import-site snapshot, the export gate read the *final* export
+        // set — which the `-clear` had emptied — and find-references
+        // silently dropped this real call site.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n    p\n}\nnamespace eval src {\n    namespace export -clear\n}\n";
+        let analysis = analyse(src);
+        // Cursor on the `p` declaration (line 1, col 9).
+        let refs = references(src, "tcl", 1, 9, &analysis, true);
+        let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+        assert!(lines.contains(&1), "decl missing: {refs:?}");
+        assert!(
+            lines.contains(&6),
+            "the imported call site must survive a later `-clear`: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_exclude_a_wildcard_imported_call_the_import_predates_the_export_of() {
+        // FP guard (CRITICAL), issue #1027 direction B — `::src` exports `p`
+        // only *after* `::dst` imported `::src::*`, so real Tcl never binds
+        // `::dst::p` at all (oracle: `invalid command name "::dst::p"`) and
+        // the bare `p` inside `::dst` is not a call to `::src::p`. Reading
+        // the final export set reported it as one.
+        let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    namespace import ::src::*\n    p\n}\nnamespace eval src {\n    namespace export p\n}\n";
+        let analysis = analyse(src);
+        // Cursor on the `p` declaration (line 1, col 9).
+        let refs = references(src, "tcl", 1, 9, &analysis, true);
+        let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+        assert!(lines.contains(&1), "decl missing: {refs:?}");
+        assert!(
+            !lines.contains(&5),
+            "an export written after the import must not make the bare call a \
+             reference: {refs:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -358,6 +358,40 @@ pub struct WorkspaceCommandLink {
     /// unconditional (top-level) alias/rename/import still counts as
     /// existing.
     pub nested: bool,
+    /// For a link introduced by an **exact** `namespace import ::src::p`: the
+    /// export snapshot the import must pass before it installs anything.
+    /// `None` for an `interp alias` / `rename` link, and for a *conjectured*
+    /// import — neither is gated by `namespace export`.
+    ///
+    /// An exact import is no less gated than a glob one: real Tcl installs
+    /// **no** alias, silently, when `p` is not exported at the moment the
+    /// import runs (oracle tclsh 8.6.14 / 9.0.4 — `namespace eval ::src {proc
+    /// p {} {}}; namespace eval ::dst {namespace import ::src::p}` leaves
+    /// `info commands ::dst::*` empty and raises no error; with `namespace
+    /// export p` first it binds). Recording the site here, rather than
+    /// resolving the gate when the link is created, is what keeps the answer
+    /// correct across edits: the export usually lives in a *different*
+    /// document, re-indexed independently of this one, so a decision frozen
+    /// at creation time would go stale the moment that file changes (issue
+    /// #1027). [`WorkspaceIndex::live_command_links`] applies it against the
+    /// current index, cached per [`WorkspaceIndex::generation`].
+    pub import_gate: Option<WorkspaceImportGate>,
+}
+
+/// The export-snapshot condition an exact `namespace import` link must satisfy
+/// to be installed at all — see [`WorkspaceCommandLink::import_gate`].
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceImportGate {
+    /// The pattern's source namespace, with leading `::` (`::src` for
+    /// `::src::p`).
+    pub source_ns: String,
+    /// The bare name the import binds (`p`).
+    pub name: String,
+    /// Byte offset of the import's pattern word within the link's own `uri`.
+    pub at: u32,
+    /// Span of the innermost proc/class body containing the import; `None` at
+    /// load level. See [`WorkspaceGlobImport::enclosing_body`].
+    pub enclosing_body: Option<Span>,
 }
 
 /// One wildcard `namespace import NS::*` recorded in the index.
@@ -396,6 +430,43 @@ pub struct WorkspaceGlobImport {
     /// loads first is not a static fact — so
     /// [`WildcardImportIndex::exports_name_at`] only compares within one URI.
     pub at: u32,
+    /// Span of the innermost proc/class **body** containing this import,
+    /// within [`Self::uri`]; `None` when the import is at load level.
+    ///
+    /// Ordering an event against this import is not a plain offset compare:
+    /// an import written *inside a body* observes every top-level statement
+    /// of its own file, wherever written, because the whole file loads before
+    /// any body runs. This is the one fact
+    /// [`tcl_compiler::analyser::indirection::in_effect`] reads out of an
+    /// `AnalysisResult`, stored per row so the cross-document tier can apply
+    /// that identical rule via
+    /// [`tcl_compiler::analyser::indirection::in_effect_within`] instead of a
+    /// weaker `at <= import_at` — which rejected such an export and lost a
+    /// real imported alias.
+    pub enclosing_body: Option<Span>,
+}
+
+impl WorkspaceGlobImport {
+    /// This import's site, for the export-snapshot gate.
+    fn site(&self) -> ImportSite<'_> {
+        ImportSite {
+            uri: &self.uri,
+            at: self.at,
+            enclosing_body: self.enclosing_body,
+        }
+    }
+}
+
+impl WorkspaceImportGate {
+    /// This gate's import site, for the export-snapshot query. `uri` is the
+    /// owning link's document — the gate itself does not duplicate it.
+    fn site<'a>(&self, uri: &'a str) -> ImportSite<'a> {
+        ImportSite {
+            uri,
+            at: self.at,
+            enclosing_body: self.enclosing_body,
+        }
+    }
 }
 
 /// One `namespace export` **event** recorded in the index.
@@ -468,6 +539,7 @@ pub struct WorkspaceIndex {
     namespace_exports: Vec<WorkspaceNamespaceExport>,
     generation: u64,
     command_names: CommandNameCache,
+    live_links: LiveLinkCache,
 }
 
 /// Lazily-built cache of [`WorkspaceIndex::command_names`], reset by every
@@ -481,6 +553,30 @@ pub struct WorkspaceIndex {
 struct CommandNameCache(std::sync::OnceLock<Arc<HashSet<String>>>);
 
 impl Clone for CommandNameCache {
+    fn clone(&self) -> Self {
+        Self(std::sync::OnceLock::new())
+    }
+}
+
+/// Lazily-built parallel mask over [`WorkspaceIndex::command_links`]: `true`
+/// where the link is actually installed.
+///
+/// An `interp alias` / `rename` link always is; an **exact** `namespace
+/// import` link is only installed when its
+/// [`WorkspaceCommandLink::import_gate`] passes against the whole current
+/// index (the export it depends on typically lives in another document).
+/// That makes liveness a function of the *entire* index, not of the link's
+/// own document — so, per the workspace-indexing contract's "a whole-index
+/// derived view lives on the index, built lazily and dropped by the same
+/// mutation hook that bumps `generation()`" rule, it is cached here rather
+/// than recomputed per consumer, and dropped by
+/// [`WorkspaceIndex::invalidate`]. Deciding it eagerly at link-creation time
+/// would instead freeze a cross-document answer that goes stale as soon as
+/// the exporting file is edited.
+#[derive(Debug, Default)]
+struct LiveLinkCache(std::sync::OnceLock<Arc<Vec<bool>>>);
+
+impl Clone for LiveLinkCache {
     fn clone(&self) -> Self {
         Self(std::sync::OnceLock::new())
     }
@@ -549,6 +645,78 @@ impl WorkspaceIndex {
     fn invalidate(&mut self) {
         self.generation = self.generation.wrapping_add(1);
         self.command_names = CommandNameCache::default();
+        self.live_links = LiveLinkCache::default();
+    }
+
+    /// The command name-links that are actually installed — every `interp
+    /// alias` / `rename` link, plus each exact `namespace import` link whose
+    /// [`WorkspaceCommandLink::import_gate`] its source namespace's export
+    /// timeline admits (issue #1027).
+    ///
+    /// Every consumer of `command_links` that answers "does this name exist /
+    /// what does it reach" goes through here, so an import Tcl never
+    /// installed cannot leak into definition, references, or the existence
+    /// oracle through one of them. The mask is built once per
+    /// [`Self::generation`] ([`LiveLinkCache`]); this call is then a `Vec` of
+    /// borrows, the same order of cost as the `HashMap`/`HashSet` each caller
+    /// already builds.
+    ///
+    /// The gate only fires for a source namespace the workspace can actually
+    /// *observe* ([`Self::observable_namespaces`]).  `namespace import
+    /// ::msgcat::mc` names a namespace that lives in an installed package, not
+    /// in any indexed document: the index holds no export declaration for it
+    /// and never will, so treating that silence as "not exported" would revoke
+    /// a real command and hand W123 a fresh false positive on every bare `mc`
+    /// call.  Absence of an export is evidence only where the definitions are
+    /// visible too — otherwise this abstains and keeps the link, the same
+    /// abstain-toward-silence rule the unknown-command pass follows.
+    fn live_command_links(&self) -> Vec<&WorkspaceCommandLink> {
+        let mask = Arc::clone(self.live_links.0.get_or_init(|| {
+            let wci = WildcardImportIndex::build(self);
+            let observable = self.observable_namespaces();
+            Arc::new(
+                self.command_links
+                    .iter()
+                    .map(|l| {
+                        l.import_gate.as_ref().is_none_or(|g| {
+                            !observable.contains(g.source_ns.trim_start_matches("::"))
+                                || wci.exports_name_at(&g.source_ns, &g.name, g.site(&l.uri))
+                        })
+                    })
+                    .collect(),
+            )
+        }));
+        self.command_links
+            .iter()
+            .zip(mask.iter())
+            .filter_map(|(link, &live)| live.then_some(link))
+            .collect()
+    }
+
+    /// The `::`-stripped namespaces the workspace can say anything about: one
+    /// that owns an indexed proc or class, or that declares a `namespace
+    /// export` somewhere.
+    ///
+    /// The discriminator between "this namespace does not export the name"
+    /// (a fact) and "this namespace is not in the workspace at all" (no
+    /// information) — see [`Self::live_command_links`].
+    fn observable_namespaces(&self) -> HashSet<&str> {
+        fn owning_ns(qualified: &str) -> &str {
+            qualified
+                .trim_start_matches("::")
+                .rsplit_once("::")
+                .map_or("", |(ns, _)| ns)
+        }
+        self.procs
+            .iter()
+            .map(|p| owning_ns(&p.qualified_name))
+            .chain(self.classes.iter().map(|c| owning_ns(&c.qualified_name)))
+            .chain(
+                self.namespace_exports
+                    .iter()
+                    .map(|e| e.ns.trim_start_matches("::")),
+            )
+            .collect()
     }
 
     /// Add (or refresh) one document's proc / class definitions.
@@ -692,6 +860,7 @@ impl WorkspaceIndex {
                         source_ns: source_ns.to_owned(),
                         tail_pattern: tail_pattern.to_owned(),
                         at: imp.range.start(),
+                        enclosing_body: analysis.innermost_definition_body_span(imp.range.start()),
                     });
                 }
                 continue;
@@ -699,12 +868,33 @@ impl WorkspaceIndex {
             let Some(tail) = imp.pattern.rsplit("::").find(|s| !s.is_empty()) else {
                 continue;
             };
+            // An exact import is export-gated exactly like a glob one — real
+            // Tcl silently installs nothing when the name is not exported at
+            // the import's own position (issue #1027; oracle on
+            // `WorkspaceCommandLink::import_gate`). Two shapes stay ungated:
+            // a pattern with no source namespace (`namespace import ::p` —
+            // the same empty-`source_ns` case the glob branch above skips),
+            // and a *conjectured* import, which is inferred from a tcllib
+            // `<NS>::import <ALIAS>` wrapper rather than read off a real
+            // `namespace import` word, so there is no export declaration for
+            // it to have passed and gating it would drop the idiom entirely.
+            let import_gate = (!imp.conjectured)
+                .then(|| imp.pattern.rsplit_once("::"))
+                .flatten()
+                .filter(|(source_ns, _)| !source_ns.is_empty())
+                .map(|(source_ns, _)| WorkspaceImportGate {
+                    source_ns: source_ns.to_owned(),
+                    name: tail.to_owned(),
+                    at: imp.range.start(),
+                    enclosing_body: analysis.innermost_definition_body_span(imp.range.start()),
+                });
             self.command_links.push(WorkspaceCommandLink {
                 uri: uri.to_owned(),
                 linked_qname: tcl_syntax::naming::qualify(&imp.ns, tail),
                 target_qname: normalise_qualified_name(&imp.pattern),
                 target_span: Some(imp.range),
                 nested: analysis.offset_is_inside_any_definition_body(imp.range.start()),
+                import_gate,
             });
         }
         // `interp alias {} a {} ::mod::helper` binds `a` to `::mod::helper`;
@@ -727,6 +917,7 @@ impl WorkspaceIndex {
                 target_qname: normalise_qualified_name(&alias.target),
                 target_span: None,
                 nested,
+                import_gate: None,
             });
         }
         // `rename OLD NEW` makes `NEW` run what `OLD` denoted.  The recorded
@@ -746,6 +937,7 @@ impl WorkspaceIndex {
                 target_qname: normalise_qualified_name(old),
                 target_span: None,
                 nested,
+                import_gate: None,
             });
         }
     }
@@ -1594,8 +1786,8 @@ impl WorkspaceIndex {
     /// The command name-link map (`::`-stripped `linked → immediate target`)
     /// used to chase an import / alias / rename to the command it names.
     fn command_link_map(&self) -> std::collections::HashMap<&str, &str> {
-        self.command_links
-            .iter()
+        self.live_command_links()
+            .into_iter()
             .map(|l| {
                 (
                     l.linked_qname.trim_start_matches("::"),
@@ -1649,8 +1841,8 @@ impl WorkspaceIndex {
         exclude_uri: &str,
     ) -> Vec<(String, Span)> {
         let target = qualified_name.trim_start_matches("::");
-        self.command_links
-            .iter()
+        self.live_command_links()
+            .into_iter()
             .filter(|l| l.uri != exclude_uri)
             .filter(|l| l.target_qname.trim_start_matches("::") == target)
             .filter_map(|l| l.target_span.map(|sp| (l.uri.clone(), sp)))
@@ -1747,8 +1939,8 @@ impl WorkspaceIndex {
                 .iter()
                 .any(|c| c.qualified_name.trim_start_matches("::") == target)
             || self
-                .command_links
-                .iter()
+                .live_command_links()
+                .into_iter()
                 .any(|l| !l.nested && l.linked_qname.trim_start_matches("::") == target)
     }
 
@@ -1770,8 +1962,8 @@ impl WorkspaceIndex {
             .collect();
         if include_links {
             names.extend(
-                self.command_links
-                    .iter()
+                self.live_command_links()
+                    .into_iter()
                     .map(|l| l.linked_qname.trim_start_matches("::")),
             );
         }
@@ -1851,7 +2043,7 @@ impl WorkspaceIndex {
                 if !tcl_syntax::glob::string_match(&imp.tail_pattern, word) {
                     continue;
                 }
-                if !wci.exports_name_at(&imp.source_ns, word, &imp.uri, imp.at) {
+                if !wci.exports_name_at(&imp.source_ns, word, imp.site()) {
                     continue;
                 }
                 let target = format!("{}::{word}", imp.source_ns);
@@ -1907,20 +2099,40 @@ impl<'a> WildcardImportIndex<'a> {
     /// document has no static order relative to this import (nothing fixes
     /// which file loads first), so it is passed unordered and the shared
     /// function abstains toward continuing to resolve.
-    fn exports_name_at(&self, ns: &str, name: &str, import_uri: &str, import_at: u32) -> bool {
+    fn exports_name_at(&self, ns: &str, name: &str, site: ImportSite<'_>) -> bool {
         self.exports_by_ns.get(ns).is_some_and(|exports| {
             let mut events = exports
                 .iter()
                 .map(|e| crate::namespace_import::ExportEvent {
                     pattern: e.pattern.as_str(),
                     clears: e.clears,
-                    at: (e.uri == import_uri).then_some(e.at),
+                    at: (e.uri == site.uri).then_some(e.at),
                 });
             crate::namespace_import::exported_at_import_site(&mut events, name, &|at| {
-                at <= import_at
+                tcl_compiler::analyser::indirection::in_effect_within(
+                    at,
+                    site.at,
+                    site.enclosing_body,
+                )
             })
         })
     }
+}
+
+/// Where a `namespace import` sits, as the export-snapshot gate needs to see
+/// it: the document, the offset, and the innermost proc/class body containing
+/// it (`None` at load level).
+///
+/// The body span is what makes the workspace tier's ordering rule the *same*
+/// rule the same-document tier applies rather than a weaker offset compare —
+/// see [`WorkspaceGlobImport::enclosing_body`] and
+/// [`tcl_compiler::analyser::indirection::in_effect_within`]. Carried as one
+/// value so no caller can pass two of the three and silently drop the third.
+#[derive(Debug, Clone, Copy)]
+struct ImportSite<'a> {
+    uri: &'a str,
+    at: u32,
+    enclosing_body: Option<Span>,
 }
 
 #[cfg(test)]
@@ -2607,6 +2819,181 @@ mod tests {
             &["::app::helper".to_string(), "::helper".to_string()],
         );
         assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
+    }
+
+    #[test]
+    fn wildcard_import_inside_a_body_sees_a_later_top_level_export() {
+        // TP, PR #1102 review finding 1 — a plain `at <= import_at` predicate
+        // is *weaker* than the same-document tier's
+        // `indirection::in_effect`, and rejected this real alias. The import
+        // sits in `::app::setup`'s body; the `namespace export` is written
+        // further down the *same file* but at load level, so loading `app.tcl`
+        // runs the export before `setup` can ever be called.
+        //
+        // Oracle (tclsh 8.6.14 / 9.0.4): with `::mymod::helper` defined
+        // elsewhere, `namespace eval ::app {proc setup {} {namespace import
+        // ::mymod::*}; proc run {} {helper}}` followed by `namespace eval
+        // ::mymod {namespace export helper}`, then `::app::setup; ::app::run`
+        // → `HELP`.
+        let mymod = analyse("namespace eval ::mymod { proc helper {} {} }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    proc setup {} { namespace import ::mymod::* }\n    proc run {} { helper }\n}\nnamespace eval ::mymod {\n    namespace export helper\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+        );
+        assert_eq!(
+            resolved.as_deref(),
+            Some("::mymod::helper"),
+            "an import inside a body observes every top-level statement of \
+             its own file, wherever written",
+        );
+    }
+
+    #[test]
+    fn wildcard_import_inside_a_body_still_refuses_an_export_in_that_same_body() {
+        // FN guard for the leniency above (PR #1102 review finding 1): the
+        // "whole file loads first" exception does **not** extend to a
+        // statement of the *same* body — there the offsets are in genuine
+        // execution order. Oracle: `proc setup {} {namespace import ::m::*;
+        // namespace eval ::m {namespace export helper}}` then `::a::setup`
+        // leaves `::a::helper` an `invalid command name`.
+        let mymod = analyse("namespace eval ::mymod { proc helper {} {} }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    proc setup {} { namespace import ::mymod::* ; namespace eval ::mymod { namespace export helper } }\n    proc run {} { helper }\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+        );
+        assert!(
+            resolved.is_none(),
+            "an export written after the import in the same body is a later \
+             statement of the running script: {resolved:?}",
+        );
+    }
+
+    // Exact (non-glob) `namespace import` is export-gated too — PR #1102
+    // review finding 2. Real Tcl silently installs nothing when the name is
+    // not exported at the import's own position (oracle: `namespace eval
+    // ::m {proc helper {} {}}; namespace eval ::a {namespace import
+    // ::m::helper}` leaves `info commands ::a::*` empty and raises no error).
+
+    #[test]
+    fn exact_import_of_an_unexported_name_installs_no_link() {
+        // FP guard (CRITICAL) — `::mymod` never exports `helper`, so the
+        // exact import binds nothing: no `::app::helper` exists, the bare
+        // call is not a reference to the source, and the pattern token is not
+        // a link span. Before the gate, `index_command_links` created the
+        // link unconditionally.
+        let mymod = analyse("namespace eval ::mymod { proc helper {} {} }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    namespace import ::mymod::helper\n    proc run {} { helper }\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert!(
+            !index.workspace_command_exists("::app::helper"),
+            "an unexported exact import installs no command",
+        );
+        assert!(
+            index
+                .linked_invocations_of("::mymod::helper", "file:///mymod.tcl")
+                .is_empty(),
+            "the bare call reaches nothing, so it is no reference",
+        );
+        assert!(
+            index
+                .link_target_spans("::mymod::helper", "file:///mymod.tcl")
+                .is_empty(),
+            "a link that was never installed has no target span",
+        );
+    }
+
+    #[test]
+    fn exact_import_ignores_an_export_written_after_it() {
+        // FP guard, direction B for the exact form — the export lands after
+        // the import in the same file, so real Tcl still binds nothing
+        // (oracle: `info commands ::a5::*` empty).
+        let mymod = analyse("namespace eval ::mymod { proc helper {} {} }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    namespace import ::mymod::helper\n    proc run {} { helper }\n}\nnamespace eval ::mymod {\n    namespace export helper\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert!(!index.workspace_command_exists("::app::helper"));
+    }
+
+    #[test]
+    fn exact_import_survives_a_later_export_clear() {
+        // TP, direction A for the exact form — the `-clear` runs after the
+        // import, so the alias it already installed stays.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    namespace import ::mymod::helper\n    proc run {} { helper }\n}\nnamespace eval ::mymod {\n    namespace export -clear\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert!(index.workspace_command_exists("::app::helper"));
+        let refs = index.linked_invocations_of("::mymod::helper", "file:///mymod.tcl");
+        assert_eq!(refs.len(), 1, "{refs:?}");
+    }
+
+    #[test]
+    fn exact_import_from_an_unseen_namespace_keeps_its_link() {
+        // Abstention guard (CRITICAL for W123 silence) — `::msgcat` lives in
+        // an installed package, not in any indexed document, so the index
+        // holds no export declaration for it and never will. Treating that
+        // silence as "not exported" would revoke `::app::mc` and hand the
+        // unknown-command pass a false positive on every bare `mc` call. The
+        // gate only fires where the workspace can see the namespace's own
+        // definitions or exports.
+        let app = analyse(
+            "namespace eval ::app {\n    namespace import ::msgcat::mc\n    proc run {} { mc hello }\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([("file:///app.tcl", &app)]);
+        assert!(
+            index.workspace_command_exists("::app::mc"),
+            "an import from a namespace the workspace cannot observe must not \
+             be gated away",
+        );
+    }
+
+    #[test]
+    fn alias_and_rename_links_are_never_export_gated() {
+        // TN — only a `namespace import` link carries an export snapshot.
+        // `interp alias` and `rename` introduce a name with no reference to
+        // any export list, and must keep working unchanged.
+        let lib = analyse("proc ::mymod::helper {} {}\n");
+        let app = analyse(
+            "interp alias {} ::app::a {} ::mymod::helper\nrename ::mymod::helper ::mymod::gone\n",
+        );
+        let index =
+            WorkspaceIndex::from_documents([("file:///lib.tcl", &lib), ("file:///app.tcl", &app)]);
+        assert!(
+            index.workspace_command_exists("::app::a"),
+            "an interp alias is not gated by any namespace export",
+        );
+        assert!(
+            index.workspace_command_exists("::mymod::gone"),
+            "a rename is not gated by any namespace export",
+        );
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -387,23 +387,44 @@ pub struct WorkspaceGlobImport {
     /// or a literal tail) — matched against a call's bare name with Tcl
     /// glob semantics ([`tcl_syntax::glob::string_match`]).
     pub tail_pattern: String,
+    /// Byte offset of the import's pattern word within [`Self::uri`].
+    ///
+    /// The import's position on its own document's timeline: an import binds
+    /// the names its source namespace exported *when the import ran*, so an
+    /// export declared in the same file is judged against this offset (issue
+    /// #1027). Meaningless against another file's offsets — which document
+    /// loads first is not a static fact — so
+    /// [`WildcardImportIndex::exports_name_at`] only compares within one URI.
+    pub at: u32,
 }
 
-/// One `namespace export` declaration recorded in the index.
+/// One `namespace export` **event** recorded in the index.
 ///
 /// Aggregated workspace-wide (unlike
 /// [`tcl_compiler::analyser::AnalysisResult::namespace_exports`], which is
 /// per-document) so a wildcard import in one file can be checked against an
 /// export declared in *another* file — the cross-document half of issue
 /// #923 idx 18.
+///
+/// An *event*, not a member of a set: `-clear` tombstones and ordering are
+/// carried through so the cross-document tier applies the same per-import-site
+/// snapshot the same-document one does (issue #1027 — see
+/// [`crate::namespace_import`]). Ordering only means something *within* a
+/// document, which is why [`Self::uri`] and [`Self::at`] are always read
+/// together.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct WorkspaceNamespaceExport {
     /// Document the `namespace export` is in.
     pub uri: String,
     /// Exporting namespace, with leading `::`.
     pub ns: String,
-    /// Exported pattern text, exactly as written (relative to `ns`).
+    /// Exported pattern text, exactly as written (relative to `ns`). Empty
+    /// for a [`Self::clears`] tombstone.
     pub pattern: String,
+    /// Byte offset of the event within [`Self::uri`].
+    pub at: u32,
+    /// `true` for a `namespace export -clear` tombstone.
+    pub clears: bool,
 }
 
 /// Collect `items` into source order by the span `key` reports, so a
@@ -641,6 +662,8 @@ impl WorkspaceIndex {
                 uri: uri.to_owned(),
                 ns: exp.ns.clone(),
                 pattern: exp.pattern.clone(),
+                at: exp.range.start(),
+                clears: exp.clears,
             });
         }
         self.index_command_links(uri, analysis);
@@ -668,6 +691,7 @@ impl WorkspaceIndex {
                         ns: imp.ns.clone(),
                         source_ns: source_ns.to_owned(),
                         tail_pattern: tail_pattern.to_owned(),
+                        at: imp.range.start(),
                     });
                 }
                 continue;
@@ -1827,7 +1851,7 @@ impl WorkspaceIndex {
                 if !tcl_syntax::glob::string_match(&imp.tail_pattern, word) {
                     continue;
                 }
-                if !wci.exports_name(&imp.source_ns, word) {
+                if !wci.exports_name_at(&imp.source_ns, word, &imp.uri, imp.at) {
                     continue;
                 }
                 let target = format!("{}::{word}", imp.source_ns);
@@ -1846,7 +1870,7 @@ impl WorkspaceIndex {
 /// [`WorkspaceIndex::resolve_wildcard_import_indexed`]'s doc for why.
 struct WildcardImportIndex<'a> {
     imports_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceGlobImport>>,
-    exports_by_ns: std::collections::HashMap<&'a str, Vec<&'a str>>,
+    exports_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceNamespaceExport>>,
 }
 
 impl<'a> WildcardImportIndex<'a> {
@@ -1856,13 +1880,10 @@ impl<'a> WildcardImportIndex<'a> {
         for imp in &index.glob_imports {
             imports_by_ns.entry(imp.ns.as_str()).or_default().push(imp);
         }
-        let mut exports_by_ns: std::collections::HashMap<&str, Vec<&str>> =
+        let mut exports_by_ns: std::collections::HashMap<&str, Vec<&WorkspaceNamespaceExport>> =
             std::collections::HashMap::new();
         for exp in &index.namespace_exports {
-            exports_by_ns
-                .entry(exp.ns.as_str())
-                .or_default()
-                .push(exp.pattern.as_str());
+            exports_by_ns.entry(exp.ns.as_str()).or_default().push(exp);
         }
         Self {
             imports_by_ns,
@@ -1870,16 +1891,34 @@ impl<'a> WildcardImportIndex<'a> {
         }
     }
 
-    /// Whether `ns` (`::`-rooted) has recorded a `namespace export` pattern
-    /// that covers the unqualified `name` — the cross-document half of the
-    /// wildcard-import gate (issue #923 idx 18): real Tcl only imports names
-    /// a source namespace has actually exported (`Tcl_Export`,
-    /// `tclNamesp.c`).
-    fn exports_name(&self, ns: &str, name: &str) -> bool {
-        self.exports_by_ns.get(ns).is_some_and(|patterns| {
-            patterns
+    /// Whether `ns` (`::`-rooted) had exported the unqualified `name` **as of
+    /// the import site** at `import_at` in `import_uri` — the cross-document
+    /// half of the wildcard-import gate (issue #923 idx 18: real Tcl only
+    /// imports names a source namespace has actually exported, `Tcl_Export`,
+    /// `tclNamesp.c`), taken per import site rather than against the
+    /// workspace's final export state (issue #1027).
+    ///
+    /// Delegates to [`crate::namespace_import::exported_at_import_site`] — the
+    /// same function the same-document resolver
+    /// (`definition::exported_at_import`) calls, so the two tiers cannot
+    /// disagree about what an import site sees. The only tier-specific part
+    /// is which events are *ordered* against the import: those in the
+    /// import's own document, compared by offset. An export in another
+    /// document has no static order relative to this import (nothing fixes
+    /// which file loads first), so it is passed unordered and the shared
+    /// function abstains toward continuing to resolve.
+    fn exports_name_at(&self, ns: &str, name: &str, import_uri: &str, import_at: u32) -> bool {
+        self.exports_by_ns.get(ns).is_some_and(|exports| {
+            let mut events = exports
                 .iter()
-                .any(|p| tcl_syntax::glob::string_match(p, name))
+                .map(|e| crate::namespace_import::ExportEvent {
+                    pattern: e.pattern.as_str(),
+                    clears: e.clears,
+                    at: (e.uri == import_uri).then_some(e.at),
+                });
+            crate::namespace_import::exported_at_import_site(&mut events, name, &|at| {
+                at <= import_at
+            })
         })
     }
 }
@@ -2481,6 +2520,87 @@ mod tests {
             ("file:///mymod.tcl", &mymod),
             ("file:///imports.tcl", &imports),
             ("file:///caller.tcl", &caller),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+        );
+        assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
+    }
+
+    // Per-import-site export snapshots, cross-document tier (issue #1027).
+    // The workspace resolver applies the same shared decision function the
+    // same-document one does (`namespace_import::exported_at_import_site`),
+    // so the two tiers cannot disagree — but only events in the *import's own
+    // document* are ordered against it; another file's load order is not a
+    // static fact.
+
+    #[test]
+    fn resolve_wildcard_import_survives_a_later_export_clear_in_the_import_file() {
+        // TP, direction A, cross-document — the import and the later
+        // `namespace export -clear` are both in `app.tcl`, so they *are*
+        // ordered: the `-clear` runs after the import and cannot revoke what
+        // it bound (oracle tclsh 8.6.14/9.0.4). `::mymod`'s own export is in
+        // the other file and unordered, which the shared function keeps.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    namespace import ::mymod::*\n    proc run {} { helper }\n}\nnamespace eval ::mymod {\n    namespace export -clear\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+        );
+        assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
+    }
+
+    #[test]
+    fn resolve_wildcard_import_ignores_a_same_file_export_written_after_the_import() {
+        // FP guard (CRITICAL), direction B, cross-document — the import and
+        // the export are both in `app.tcl` and the export comes *after*, so
+        // real Tcl never binds `::app::helper` (oracle: `invalid command
+        // name`). `mymod.tcl` exports nothing, so there is no unordered
+        // event to fall back on and the resolver must abstain.
+        let mymod = analyse("namespace eval ::mymod { proc helper {} {} }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    namespace import ::mymod::*\n    proc run {} { helper }\n}\nnamespace eval ::mymod {\n    namespace export helper\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+        );
+        assert!(
+            resolved.is_none(),
+            "an export written after the import in the same file must not \
+             apply retroactively: {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn resolve_wildcard_import_keeps_answering_when_the_export_is_in_another_file() {
+        // TN-for-abstention — which of two files loads first is not a static
+        // fact, so a `namespace export -clear` in a *third* document cannot
+        // be ordered against this import and must not silently revoke it.
+        // Navigation keeps answering; the residual is documented in
+        // `namespace_import`'s module docs.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    namespace import ::mymod::*\n    proc run {} { helper }\n}\n",
+        );
+        let teardown = analyse("namespace eval ::mymod { namespace export -clear }\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+            ("file:///teardown.tcl", &teardown),
         ]);
         let resolved = index.resolve_wildcard_import(
             "helper",

--- a/rust/tcl-lsp-server/tests/e2e/definition.rs
+++ b/rust/tcl-lsp-server/tests/e2e/definition.rs
@@ -328,6 +328,66 @@ fn wildcard_namespace_import_does_not_resolve_unexported_sibling_cross_document(
     );
 }
 
+// -- per-import-site export snapshots, cross-document (issue #1027) --
+//
+// `namespace import` binds the names exported *when it runs*. A later
+// `namespace export -clear` does not revoke the alias, and a later
+// `namespace export` does not create one. Both oracle-pinned against
+// tclsh 8.6.14 and 9.0.4; see `tcl_lsp_core::namespace_import` for the
+// transcripts. Ordering only exists within one document — which of two
+// files loads first is not a static fact — so both cases put the ordered
+// pair in the same file.
+
+#[test]
+fn wildcard_import_survives_a_later_export_clear_cross_document() {
+    // TP, direction A: `main.tcl` imports `::Lib::*` and then, further down
+    // the same file, clears `::Lib`'s exports. Real Tcl keeps the alias
+    // (`::dst::bar` still runs); before the per-import-site snapshot the
+    // resolver read `::Lib`'s final export state and stopped resolving the
+    // call entirely.
+    let mut lsp = Lsp::tcl();
+    let lib_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &lib_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n    namespace export bar\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &main_uri,
+        "namespace import ::Lib::*\nbar\nnamespace eval Lib {\n    namespace export -clear\n}\n",
+    );
+    let result = lsp.definition(&main_uri, 1, 0);
+    let locs = locations(&result);
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(locs[0].uri, lib_uri, "must still jump into lib.tcl");
+    assert_eq!(start_line(&locs[0]), 1, "proc bar is declared on line 1");
+}
+
+#[test]
+fn wildcard_import_ignores_an_export_written_after_it_cross_document() {
+    // FP guard (CRITICAL), direction B: `lib.tcl` exports nothing;
+    // `main.tcl` imports `::Lib::*` and only *afterwards* exports `bar`.
+    // Real Tcl never binds the alias (`invalid command name`), so the bare
+    // call must not resolve to `::Lib::bar`.
+    let mut lsp = Lsp::tcl();
+    let lib_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &lib_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &main_uri,
+        "namespace import ::Lib::*\nbar\nnamespace eval Lib {\n    namespace export bar\n}\n",
+    );
+    let result = lsp.definition(&main_uri, 1, 0);
+    assert!(
+        locations(&result).is_empty(),
+        "an export written after the import must not resolve the call \
+         retroactively: {result:?}"
+    );
+}
+
 /// idx 33 (differential-audit main audit wave, high severity): a class
 /// *instantiation* call (`GSA new`, the real corpus's
 /// `georgtree_tclopt`'s `arbitaryTest.tcl` idiom — `GSA new -funct

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -321,6 +321,13 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "namespace export ?-clear? ?pattern pattern ...?",
         return_type: Some(TclType::List),
         options: EXPORT_OPTIONS,
+        // `NamespaceExportCmd` compares `objv[1]` against `-clear` once and
+        // never again, so a second `-clear` is an ordinary export *pattern*
+        // (tclsh 8.6.14/9.0.4: `namespace export -clear -clear p` leaves
+        // `-clear p` exported, and `-clear` is then a genuinely importable
+        // command name). Likewise `namespace export a -clear` exports both —
+        // the flag is only ever the first word.
+        max_leading_option_words: Some(1),
         analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceExport),
         // Publishes this namespace's commands for another unit to
         // `namespace import`, so the exported names have callers this file
@@ -359,6 +366,12 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "namespace import ?-force? ?pattern pattern ...?",
         return_type: Some(TclType::List),
         options: IMPORT_OPTIONS,
+        // As for `export`: `NamespaceImportCmd` consumes at most one leading
+        // `-force`. A second one is read as an import pattern and aborts the
+        // script (tclsh 8.6.14/9.0.4: `namespace import -force -force
+        // ::src::*` → `no namespace specified in import pattern "-force"`),
+        // as does a trailing one (`namespace import ::src::p -force`).
+        max_leading_option_words: Some(1),
         analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceImport),
         // Deliberately NOT `LOADS_EXTERNAL_UNIT`: `namespace import
         // ::lib::*` is just as often an intra-file convenience over a

--- a/rust/tcl-registry/src/spec.rs
+++ b/rust/tcl-registry/src/spec.rs
@@ -1466,6 +1466,24 @@ pub struct SubCommand {
     /// command.  A word at the index that is an option flag (leading `-`) or
     /// a missing name (auto-generated at run time) names nothing statically.
     pub defines_command_at: Option<u8>,
+
+    /// How many leading option **words** this subcommand consumes before every
+    /// remaining word is positional, however it is spelled.  `None` — the
+    /// ordinary rule: keep consuming while each word matches a declared
+    /// option.
+    ///
+    /// `namespace export ?-clear?` and `namespace import ?-force?` parse
+    /// exactly one optional leading flag by hand in C (`NamespaceExportCmd` /
+    /// `NamespaceImportCmd` in `tclNamesp.c` compare `objv[1]` and nothing
+    /// else), so a *second* occurrence is an ordinary argument word.  Oracle
+    /// (tclsh 8.6.14 / 9.0.4): `namespace export -clear -clear p` leaves
+    /// exactly `-clear p` exported — and a command genuinely named `-clear`
+    /// is then importable, `namespace import ::src::*` binding `::dst::-clear`
+    /// — while `namespace import -force -force ::src::*` aborts with `no
+    /// namespace specified in import pattern "-force"`.  Declaring the limit
+    /// here keeps the count in registry data rather than as a loop bound in a
+    /// consumer.
+    pub max_leading_option_words: Option<u8>,
 }
 
 /// A second-level subcommand of a two-level ensemble (`info object <op>`,
@@ -1543,6 +1561,7 @@ impl SubCommand {
         cfg_rewrite_name: None,
         sub_subcommands: &[],
         defines_command_at: None,
+        max_leading_option_words: None,
     };
 
     /// The subcommand's primary invocation synopsis — its own
@@ -1562,9 +1581,18 @@ impl SubCommand {
     /// argument index (e.g. [`Self::defines_command_at`]) can be shifted
     /// past them. The subcommand counterpart of
     /// [`CommandSpec::leading_option_word_count`].
+    ///
+    /// Capped by [`Self::max_leading_option_words`] when the subcommand
+    /// declares one: a subcommand that hand-parses a single optional flag
+    /// treats every further option-shaped word as positional, so counting
+    /// them all would shift a positional index past real arguments.
     #[must_use]
     pub fn leading_option_word_count(&self, args: &[&str]) -> usize {
-        leading_option_word_count(self.options, args)
+        let counted = leading_option_word_count(self.options, args);
+        match self.max_leading_option_words {
+            Some(cap) => counted.min(usize::from(cap)),
+            None => counted,
+        }
     }
 
     /// Run this subcommand's constant folder for `args` under `dialect` —

--- a/rust/tcl-registry/tests/registry_commands.rs
+++ b/rust/tcl-registry/tests/registry_commands.rs
@@ -849,6 +849,44 @@ fn proc_body_is_structural() {
     assert_eq!(proc.arg_role_at(2), Some(ArgRole::Body));
 }
 
+/// `namespace export ?-clear?` and `namespace import ?-force?` hand-parse a
+/// single optional leading flag in C (`NamespaceExportCmd` /
+/// `NamespaceImportCmd`, `tclNamesp.c`), so exactly one leading option word is
+/// consumed and every further word is positional however it is spelled.
+///
+/// Oracle (tclsh 8.6.14 / 9.0.4): `namespace export -clear -clear p` leaves
+/// `-clear p` exported — and `namespace import ::src::*` then binds a genuine
+/// `::dst::-clear` command — while `namespace import -force -force ::src::*`
+/// aborts with `no namespace specified in import pattern "-force"`.
+/// `namespace export a -clear` exports both, so the flag is only ever the
+/// first word. Consumers read the limit from here rather than bounding a loop
+/// of their own (PR #1102 review finding 3).
+///
+/// registry-metadata: `max_leading_option_words`.
+#[test]
+fn namespace_export_and_import_consume_one_leading_option_word() {
+    let (reg, _) = reg_and_set("tcl8.6");
+    let spec = reg.get("namespace").expect("namespace registered");
+    for (sub, flag) in [("export", "-clear"), ("import", "-force")] {
+        let s = spec
+            .subcommand(sub)
+            .unwrap_or_else(|| panic!("namespace {sub} registered"));
+        assert_eq!(
+            s.max_leading_option_words,
+            Some(1),
+            "namespace {sub} consumes exactly one leading option word",
+        );
+        assert!(
+            s.options.iter().any(|o| o.name == flag && !o.takes_value()),
+            "namespace {sub} declares {flag} as a flag",
+        );
+        // The cap is what the shared leading-option walk applies: a second
+        // occurrence is an ordinary argument word, not a second flag.
+        assert_eq!(s.leading_option_word_count(&[flag, flag, "p"]), 1);
+        assert_eq!(s.leading_option_word_count(&["p", flag]), 0);
+    }
+}
+
 /// `test_exported_short_name_resolves_via_registry_property` — `tcltest::test`
 /// declares it is namespace-exported (so the bare `test` can resolve to it).
 ///

--- a/rust/tcl-spec-studio/src/draft.rs
+++ b/rust/tcl-spec-studio/src/draft.rs
@@ -566,6 +566,10 @@ fn subcommand_rest(d: &mut Draft, sub: &SubCommand, lost: &mut Unrecovered) {
         "defines_command_at".into(),
         opt_index(sub.defines_command_at),
     );
+    d.insert(
+        "max_leading_option_words".into(),
+        opt_index(sub.max_leading_option_words),
+    );
 }
 
 /// Seed a draft from a live [`CommandSpec`].

--- a/rust/tcl-spec-studio/src/schema.rs
+++ b/rust/tcl-spec-studio/src/schema.rs
@@ -1329,6 +1329,13 @@ pub const SUBCOMMAND_FIELDS: &[FieldSchema] = &[
         FieldKind::OptIndex,
         "Index after the subcommand word whose literal value becomes a command name.",
     ),
+    f(
+        "max_leading_option_words",
+        "Max leading option words",
+        OPTS,
+        FieldKind::OptIndex,
+        "Cap on leading option words consumed; further option-shaped words are positional.",
+    ),
 ];
 
 /// The variant catalogues the form's pickers read, keyed by catalogue id.


### PR DESCRIPTION
## Summary

PR C4 — fixes #1027's both wrong directions with an ordered export **event log** and one shared per-import-site decision function. A 30-row oracle matrix (tclsh 9.0.4 + 8.6.14, identical on every row) pins the semantics first, including the traps: exports are **additive name patterns** (glob, matchable before the proc exists), `-clear` is a same-call clear-then-add, a second import takes its **own** snapshot, imports are links (they survive source renames and see redefinitions), and importing an unexported name is a silent no-op, not an error.

- **Fact change:** `SignatureNamespaceExport` gains `clears: bool` and becomes an ordered, append-only event log — `-clear` pushes a tombstone at its own span instead of `retain`-deleting earlier records (which destroyed exactly the ordering a snapshot needs). No new `CommandSpec` field: `-clear`/`-force` were already registry option data, and the analyser's two literal flag matches are replaced by `namespace_subcommand_flag` reading `available_sub_option_specs` — the same route `handle_namespace_ensemble` takes.
- **Ordering model:** reuses `indirection::in_effect` — the export half of the same "what does this name hold at this point?" timeline rename/alias already answer, so the two cannot diverge on what "has run by here" means.
- **One decision function:** new `tcl-lsp-core::namespace_import::exported_at_import_site` (latest visible tombstone wins; a visible pattern after it must glob-match via the existing `tcl_syntax::glob`; unordered patterns count, unordered `-clear`s revoke nothing). Consumed by definition, references, and `WildcardImportIndex::exports_name_at`, so single-file and workspace tiers agree by construction. Single pass, two running maxima, no allocation — it sits inside the find-references loop.
- **A second FP fixed on the way:** references previously tested "some import matches" and "the final export set covers the name" as independent conditions, letting an import whose own snapshot excluded a name borrow an unrelated import's export — the gate now evaluates per import site.

**Before/after:** Direction A (a `-clear` after the import) restores the dropped call-site reference; Direction B (export after import) removes the spurious one — cross-document, `definition` itself flips, covered by two lsp_e2e tests that fail on the pre-fix tree.

**Residuals filed rather than half-fixed** (#1103 import-edge lifecycle: `namespace forget`, `-force` shadowing, source rename/delete following, import chains; #1104 gating precision: call-site ordering, the single-file simple-name fallback leniency, cross-file export ordering) — each row oracle-confirmed in this PR's matrix.

## Validation

- [x] `cargo test --workspace` — **310 suites, 15,286 passed, 0 failed** (isolated worktree, no ENOSPC).
- [x] New tests: 11-case unit matrix on the decision function, TP/FP/TN splits across definition/references/workspace-index, 2 cross-document lsp_e2e (both fail pre-fix), incremental-analysis ordering pin (whole-file ≡ per-item with tombstones).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean, **zero new allows**; `cargo fmt --all --check` clean; `make xtask-check` all 12 gates OK.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — `SignatureNamespaceExport` is now an ordered event log with tombstones; `WorkspaceGlobImport`/`WorkspaceNamespaceExport` carry offsets.
- [x] KCS notes updated: definition feature page (per-site snapshot rules), `command-resolution.md` and `workspace-indexing.md` contracts.
- [ ] New compiler KCS note linked. (n/a — existing notes updated)

Closes #1027.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7