### PR TITLE
Naming layer keys variables by their written spelling (#1078, #1079)

### DIFF
--- a/docs/design/compiler/ssa-construction.md
+++ b/docs/design/compiler/ssa-construction.md
@@ -392,6 +392,19 @@ now looks at a `return`'s value word (a terminator, which it never walked), so
 `proc f {} {set n 1; set n 2; return [set n]}` no longer reports two dead
 stores on code tclsh runs to `2`.
 
+All five variable providers resolve their `$ref` cursor through one gate,
+`definition::substituting_var_at_position`. The character scan under it
+reports `n` for a cursor on the `n` of `set {$n} 1` — that word is
+brace-quoted, so the `$n` is not a reference at all but part of a different
+variable's literal *name*. Each provider used to short-circuit on that scan,
+so a cursor one column right of the `{` stopped resolving the cell whose
+declaration it sits inside. The gate answers `None` there (it also folds in
+the two `inert_text` proofs, issue #923 idx 24, that every caller previously
+re-derived), which lets each provider fall through to its declaration-span
+search — the behaviour the `{` column already had. Document-highlight has no
+declaration-span search, so it abstains for a braced cursor exactly as it
+already does for a plain bareword declaration cursor.
+
 Rename **refuses** rather than guesses for these cells
 (`rename_safety::literal_name_variable_rename_refusal`, the #1091 typed-refusal
 precedent): the recorded spans cover a word's content, not its delimiters, and

--- a/docs/design/compiler/ssa-construction.md
+++ b/docs/design/compiler/ssa-construction.md
@@ -334,26 +334,70 @@ Two gaps remain, both needing a fact the analyser does not record yet:
   in the model changed; the workspace layer still has to merge the maps
   before `prepare_cfg_context` runs.
 
-### Known limitation — a brace-quoted `$`-bearing name is mis-keyed
+### A brace-quoted `$`-bearing name is its own variable (issue #1078)
 
-A variable whose literal name contains a `$` (`set {$n} 1`) is recognised as
-*not dynamic* by the barrier, but the SSA naming layer below still mis-keys
-it. `is_dynamic_write_target` reads the name text without consulting the IR's
-`name_braced` flag, so it calls `$n` a dynamic target: the assignment produces
-no def, and `uses_of` records a read of `n` instead — surfacing as
-`W210 Variable 'n' is read before it is set` on code that never touches `n`.
+Braces suppress every substitution, so a brace-quoted word in a variable-name
+position spells a **literal** name: `set {$n} 1` creates the variable *called*
+`$n`, which Tcl keeps entirely separate from `n`. tclsh 9.0.4 and 8.6.14 give
+byte-identical transcripts:
 
-This is pre-existing and independent of the barrier. Making the target
-braced-aware is *not* a local fix: `element_var_name_braced` normalises a
-braced `$n` down to `n`, so the def would be recorded against the wrong
-variable — measured, that trades the false positive for a *missed* one
-(`set {$n} 1; puts $n` stops warning, though tclsh errors `can't read "n"`)
-plus two fresh false `W220`s. A correct fix has to teach the shared naming
-helper that a braced literal keeps its `$`, which reaches defs, reads, rename,
-and highlighting together.
+```text
+set {$n} v ; set {$n}             -> v
+info exists {$n} / info exists n  -> 1 / 0     two distinct variables
+set n other ; set {$n}            -> v         `n` never affects it
+set {$m} 1 ; set m                -> can't read "m": no such variable
+set ${$n}                         -> can't read "v"   `${$n}` read `$n`
+set {a b} v2 ; set x ${a b}       -> v2        a space is a legal name char
+set i 5 ; set {arr($i)} 1
+  array names arr                 -> {$i}      the key is literal
+  info exists arr(5)              -> 0
+  set arr($i) 2 ; array names arr -> {$i} 5    two distinct elements
+unset {$n} ; info exists {$n} / n -> 0 / 1
+```
 
-The shape is rare and the current verdict is a false positive rather than a
-missed error, so it is recorded here rather than half-fixed.
+The rule lives in the shared naming helpers, once:
+`element_var_name_braced` / `normalise_var_name_braced` /
+`split_array_name_braced` return the word's content **verbatim** when the
+`braced_literal` flag is set — no `$` stripped, no `${…}` unwrapped, the array
+key literal whatever it spells (`normalise_var_name_braced` still takes the
+`(key)` suffix off, since `{arr($i)}` is element `$i` of the array `arr`).
+`is_dynamic_write_target` takes the same flag and answers *not dynamic* for a
+braced target. Which words are braced is one question with one answer:
+`CommandTokens::arg_is_braced_literal` (and its hook-side twin
+`LoweringCommand::arg_is_braced_literal`) — the `Str` representative token
+kind, since the IR stores de-braced content that cannot show the difference.
+
+Every consumer of the naming layer was moved onto it together, which is what
+made the fix land: defs (`defs_of_with_registry`, `collect_defs_from_script`,
+the `set`/`incr`/`unset`/`append`/`global`/`variable`/`upvar` lowering hooks,
+`lower_default`'s registry role harvest), reads (`var_token_name`,
+`scan_var_read_role_names`, `collect_ref_forms` +
+`scan_var_ref_forms_braced`, `scan_command_words`'s name-role skip), the
+analyser scope layer (`define_var` from the name word's token kind,
+`record_var_read_braced`), rename, and semantic highlighting.
+
+Measurements, against the two the reverted one-parameter attempt produced:
+
+| shape | before | after |
+| --- | --- | --- |
+| `set {$n} 1` | false `W210` on `n` | silent for `n`; `W211` names `$n` |
+| `set {$n} 1; puts $n` | *missed* TP (tclsh errors) | `W210` on `n` fires |
+| `set {$n} 1; set {$n} 2; return [set {$n}]` | two false `W220`s | silent — and byte-identical to the plain-named control |
+| `unset {$n}` after `set {$n} 1` | false `W213` on `n` | silent |
+
+Two adjacent recoveries were needed to reach the last two rows, and they fix
+the *plain* spelling as well: the `[set NAME]` textual read scan now also
+recognises the brace-quoted name word, and the substitution-hidden-read scan
+now looks at a `return`'s value word (a terminator, which it never walked), so
+`proc f {} {set n 1; set n 2; return [set n]}` no longer reports two dead
+stores on code tclsh runs to `2`.
+
+Rename **refuses** rather than guesses for these cells
+(`rename_safety::literal_name_variable_rename_refusal`, the #1091 typed-refusal
+precedent): the recorded spans cover a word's content, not its delimiters, and
+the delimiters a *new* name needs are a property of that new name — rewriting
+`{$n}`'s span with `q` would produce `set q} 1`. Renaming the plain `n` is
+unaffected and no longer touches the `{$n}` word.
 
 ## Related docs
 

--- a/docs/kcs/codes/kcs-diagnostic-e003-too-many-arguments.md
+++ b/docs/kcs/codes/kcs-diagnostic-e003-too-many-arguments.md
@@ -72,6 +72,24 @@ variadic tail (`{args}`) so it absorbs every appended argument.
 the [E002 page](kcs-diagnostic-e002-too-few-arguments.md#command-prefix-callback-context).
 Every other E003 case on this page fires unconditionally.
 
+## A computed parameter list is not checked
+
+A `proc`'s parameter list is an ordinary Tcl word, so it can be built at
+definition time:
+
+```tcl
+proc makeargs {} { return {a b} }
+proc p [makeargs] { return "p got $a $b" }
+puts [p 1 2]        ;# p got 1 2 — two parameters, decided at run time
+```
+
+Which names such a proc declares, and how many, is a run-time fact, so the
+arity checker **abstains** for it: no `E002`, `E003`, or `E005` on any call to
+`p`. The same applies to `proc q $params {…}`. (Before this abstention the
+unresolved word was read as a single literal parameter, and `p 1 2` drew a
+false `E003`.) A *literal* list — braced, bareword, or a quoted word with no
+substitution in it — is checked as usual.
+
 ## Fix
 
 ```tcl

--- a/docs/kcs/codes/kcs-diagnostic-w220-dead-store.md
+++ b/docs/kcs/codes/kcs-diagnostic-w220-dead-store.md
@@ -74,6 +74,24 @@ silent for the whole proc, and the optimiser stops removing stores there
 Removing a store the analyser cannot see the reader for would change what the
 program prints, so the analysis abstains instead.
 
+## A brace-quoted name is a *literal* name, not a computed one
+
+`{$n}` is not a computed name — braces suppress substitution, so `set {$n} 1`
+creates a variable literally called `$n`, unrelated to `n`:
+
+```tcl
+set {$n} v
+info exists {$n}      ;# 1
+info exists n         ;# 0  — a different variable entirely
+```
+
+Such a name is fully static, so it does **not** silence the check the way a
+computed `[set $v]` does: the assignment is analysed like any other, and
+`W220` / [`W211`](kcs-diagnostic-w211-variable-set-not-used.md) name the cell
+by its real spelling (`Assignment to '$n' is never read`). Reads of it —
+`[set {$n}]` and `${$n}` alike — count as reads of that cell and of no other,
+so an unrelated `set n …` nearby is judged entirely on its own merits.
+
 ## A procedure you call can read your variables
 
 A procedure can run a whole script in its **caller's** frame, so a store the

--- a/docs/kcs/features/kcs-feature-rename.md
+++ b/docs/kcs/features/kcs-feature-rename.md
@@ -136,7 +136,16 @@ code. The gate refuses when:
   already exists, a file in that namespace **computes a variable name**
   (`set $n 1`, `variable $n`) that might be this very cell, or a file
   **aliases a cell computed at run time** (`namespace upvar $ns v local`)
-  that could be this one.
+  that could be this one;
+- the variable's **name can only be written quoted** — `set {$n} 1` creates a
+  variable literally called `$n`, `set {a b} 1` one called `a b`. These are
+  ordinary variables (tclsh: `info exists {$n}` is 1 while `info exists n` is
+  0) and rename knows they are separate cells, so renaming an ordinary `n`
+  leaves every `{$n}` word alone. Renaming the quoted cell *itself* is
+  refused: each occurrence carries delimiters that are not part of the name,
+  and whether the new name needs delimiters at all depends on the new name —
+  rewriting the recorded span would yield `set q} 1`. Rename the cell by hand,
+  brackets and all.
 
 The gate is checked across **every file the rename would edit** — the class's
 own file, every file defining or extending a class in its override family,

--- a/docs/kcs/features/kcs-feature-semantic-tokens.md
+++ b/docs/kcs/features/kcs-feature-semantic-tokens.md
@@ -20,6 +20,16 @@ all-editors, analyser
 
 Semantic tokens add highlighting for constructs the TextMate grammar cannot handle: regular expression syntax inside `regexp`/`regsub`, `format`/`scan` specifiers, `binary format`/`scan` field descriptors, and `clock format`/`scan` directives.
 
+A word in a **variable-name argument position** is painted as a variable
+whether it is a bareword or brace-quoted: `set n 1` and `set {$n} 1` are both
+declarations, and `[set n]` / `[set {$n}]` both references. `{$n}` really does
+name a variable — tclsh reports `info exists {$n}` as 1 while `info exists n`
+is 0 — and quoting is the only way that variable can ever be written, so
+painting the word as a plain string hid the declaration and made the `$n`
+inside look like a substitution it is not. Which argument is a name comes from
+the registry's `VarWrite` / `VarRead` roles, so a brace-quoted word anywhere
+else (`puts {$n}`) stays a string.
+
 ## Performance and caching
 
 - **Delta encoding**: The server advertises `textDocument/semanticTokens/full/delta`. After the first full response, editors request deltas — only the changed portion of the token array is sent.  If the delta would be larger than a full response, the server falls back to full automatically.

--- a/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/fp/rbs.rs
@@ -1696,3 +1696,164 @@ emitted: {:?}",
         codes(src, D)
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1078 — a brace-quoted `$`-bearing name is a *literal* variable name
+//
+// Oracle, tclsh 9.0.4 and 8.6.14, byte-identical:
+//
+//   set {$n} v ; set {$n}            -> v
+//   info exists {$n} / info exists n -> 1 / 0     (two distinct variables)
+//   set n other ; set {$n}           -> v         (unaffected)
+//   set {$m} 1 ; set m               -> can't read "m": no such variable
+//   set ${$n}                        -> can't read "v"  (`${$n}` read `$n`)
+//   set {a b} v2 ; set x ${a b}      -> v2
+//   set i 5 ; set {arr($i)} 1
+//     array names arr                -> {$i}      (the literal key)
+//     info exists arr(5)             -> 0
+//   unset {$n} ; info exists {$n} / n -> 0 / 1
+//
+// These are the acceptance measurements recorded when PR #1076 reverted its
+// one-parameter attempt (`docs/design/compiler/ssa-construction.md`).
+// ---------------------------------------------------------------------------
+
+/// The **missed true positive** the reverted #1076 attempt produced: with the
+/// def landing on the wrong variable, `set {$n} 1; puts $n` stopped warning
+/// even though tclsh errors `can't read "n": no such variable`.
+#[test]
+fn issue_1078_braced_write_does_not_define_the_plain_name() {
+    let src = "proc f {} { set {$n} 1; puts $n }\n";
+    assert!(
+        fires(src, D, "W210"),
+        "#1078 TP: `set {{$n}} 1` defines `$n`, so the bare `$n` read is still \
+read-before-set (tclsh: `can't read \"n\"`); emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// The **pre-existing false positive** #1078 was filed for: a lone
+/// `set {$n} 1` reads nothing at all, yet the naming layer recorded a read of
+/// `n` and fired `W210 Variable 'n' is read before it is set` on code that
+/// never mentions `n`.
+#[test]
+fn issue_1078_braced_write_alone_is_not_a_read_of_the_plain_name() {
+    let src = "proc f {} { set {$n} 1 }\n";
+    assert!(
+        !fires(src, D, "W210"),
+        "#1078 FP: `set {{$n}} 1` substitutes nothing and reads nothing; \
+emitted: {:?}",
+        codes(src, D)
+    );
+    assert!(
+        fires(src, D, "W211"),
+        "#1078: the write is a genuine unused-variable hint; emitted: {:?}",
+        codes(src, D)
+    );
+    let unused: Vec<String> = crate::analyser::Analyser::new()
+        .analyse(src, D)
+        .diagnostics
+        .iter()
+        .filter(|d| d.code.to_string() == "W211")
+        .map(|d| d.message.clone())
+        .collect();
+    assert!(
+        unused.iter().any(|m| m.contains("'$n'")),
+        "#1078: the hint must name `$n`, not `n`; got {unused:?}"
+    );
+}
+
+/// The **two fresh false `W220`s** the reverted #1076 attempt produced.  The
+/// braced verdict must match the identically-shaped plain-named control
+/// exactly — both silent, because `[set …]` really does read the store.
+#[test]
+fn issue_1078_braced_double_store_matches_the_plain_control() {
+    let braced = "proc f {} { set {$n} 1; set {$n} 2; return [set {$n}] }\n";
+    let plain = "proc f {} { set n 1; set n 2; return [set n] }\n";
+    assert!(
+        !fires(braced, D, "W220"),
+        "#1078: `[set {{$n}}]` reads the store, so neither assignment is dead \
+(tclsh returns 2); emitted: {:?}",
+        codes(braced, D)
+    );
+    assert_eq!(
+        codes(braced, D),
+        codes(plain, D),
+        "#1078: the braced spelling must draw exactly the plain spelling's \
+verdicts"
+    );
+}
+
+/// `unset {$n}` destroys the literal `$n` — it neither reads nor destroys `n`,
+/// so no `W213 Variable 'n' may not exist`.
+#[test]
+fn issue_1078_braced_unset_does_not_touch_the_plain_name() {
+    let src = "proc f {} { set {$n} 1; unset {$n}; return ok }\n";
+    assert!(
+        !fires(src, D, "W213"),
+        "#1078: `unset {{$n}}` destroys the variable it just set; emitted: {:?}",
+        codes(src, D)
+    );
+    assert!(
+        !fires(src, D, "W210"),
+        "#1078: …and reads nothing; emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// TN control for the family: the *unbraced* substituted spellings must keep
+/// behaving as dynamic names — the #1076 barrier still has to fire.  Same
+/// shape as FP-DS-14's control, restated here so the #1078 changes cannot
+/// quietly erase the barrier they sit on top of.
+#[test]
+fn issue_1078_unbraced_substituted_target_still_behaves_dynamically() {
+    // `[set $p]` may observe *any* store, so the read barrier blinds the
+    // dead-store pass for the whole function.
+    let dynamic = "proc f {p} { set b [set $p]\n set a 1\n set a 2\n return \"$a$b\" }\n";
+    assert!(
+        !fires(dynamic, D, "W220"),
+        "#1076 barrier: a computed read target must still blind W220; \
+emitted: {:?}",
+        codes(dynamic, D)
+    );
+    // TP control: brace the name and the barrier clears, so the genuine dead
+    // store is reported again.
+    let braced = "proc f {p} { set b [set {$p}]\n set a 1\n set a 2\n return \"$a$b\" }\n";
+    assert!(
+        fires(braced, D, "W220"),
+        "#1078: a brace-quoted target computes nothing, so the unrelated dead \
+store is still reported; emitted: {:?}",
+        codes(braced, D)
+    );
+}
+
+/// The `${…}` **read** form reaches the same cell the brace-quoted write
+/// created: `set {$n} 1; return ${$n}` is a complete write/read pair with
+/// nothing to report, and it must not be read as touching `n`.
+#[test]
+fn issue_1078_brace_reference_form_reads_the_literal_name() {
+    let src = "proc f {} { set {$n} 1; return ${$n} }\n";
+    assert!(
+        codes(src, D).is_empty(),
+        "#1078: `${{$n}}` reads the `{{$n}}` cell — nothing to report; \
+emitted: {:?}",
+        codes(src, D)
+    );
+}
+
+/// A brace-quoted **array element** keeps its literal key, and a space-bearing
+/// braced name is an ordinary variable — both must key on their own spelling.
+#[test]
+fn issue_1078_braced_element_and_spaced_names_key_on_their_own_spelling() {
+    let elem = "proc f {} { set {arr($i)} 1; return [set {arr($i)}] }\n";
+    assert!(
+        codes(elem, D).is_empty(),
+        "#1078: `{{arr($i)}}` writes and reads one literal element; emitted: {:?}",
+        codes(elem, D)
+    );
+    let spaced = "proc f {} { set {a b} 1; return [set {a b}] }\n";
+    assert!(
+        codes(spaced, D).is_empty(),
+        "#1078: `{{a b}}` is a legal name written and read; emitted: {:?}",
+        codes(spaced, D)
+    );
+}

--- a/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/validity.rs
@@ -2061,7 +2061,7 @@ impl Analyser {
                 if !via_rename_hop && self.fact_superseded_by_deletion(c, proc_off, cand) {
                     continue;
                 }
-                let arity = crate::signature_scan::arity::arity_of(&def.params);
+                let arity = def.arity();
                 return Some(shift_arity(arity, prepended_total));
             }
             if let Some(old) = candidates.iter().find_map(|c| {

--- a/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
+++ b/rust/tcl-compiler/src/analyser/diagnostics/var_command.rs
@@ -626,7 +626,7 @@ impl Analyser {
                 .get(target)
                 .or_else(|| self.result.all_procs.get(&format!("::{target}")))
             {
-                arity = Some(crate::signature_scan::arity::arity_of(&def.params));
+                arity = Some(def.arity());
                 break;
             }
             if !bare.contains("::")

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -559,7 +559,15 @@ impl Analyser {
         if args.len() >= 2 {
             self.define_var(&args[0], *name_tok, scope_path, true, None);
         } else {
-            self.record_var_read(&args[0], name_tok.span, scope_path);
+            // `[set {$n}]` reads the variable literally called `$n` — the
+            // braces suppressed substitution, so the word's content is the
+            // name (issue #1078).
+            self.record_var_read_braced(
+                &args[0],
+                name_tok.span,
+                scope_path,
+                name_tok.kind == TokenType::Str,
+            );
         }
 
         // Track constant-string assignments for regex propagation.
@@ -1219,7 +1227,27 @@ impl Analyser {
         // **W314** — the name has no absolute written form (#934).
         self.emit_w314_no_absolute_name(raw_name, name_span);
 
-        let params = parse_param_list(&args[1]);
+        // A **computed** parameter-list word (`proc p [makeargs] {…}`,
+        // `proc q $params {…}`) builds the formals from a run-time value, so
+        // nothing about them is knowable: the proc's params are unmodelled
+        // (issue #1079).  Reading the unresolved word as a one-parameter
+        // literal registered a `VarDef` literally named `"[makeargs]"` and
+        // made the call-site arity checker demand exactly one argument, which
+        // tclsh 9.0.4 / 8.6.16 contradict (`proc makeargs {} {return {a b}}`;
+        // `proc p [makeargs] {…}`; `info args p` → `a b`; `p 1 2` runs).
+        //
+        // Literal ⟺ the word is a *single* `Str` (brace-quoted) or `Esc`
+        // (bareword / substitution-free quoted) token: any `$` / `[` splits
+        // the word into several tokens (or lexes it as `Var` / `Cmd`), which
+        // is exactly the "computed" case.  `proc r "m n" {…}` stays literal —
+        // tclsh really does declare `m` and `n` for it.
+        let params_computed = !(arg_single.get(1).copied().unwrap_or(true)
+            && matches!(arg_tokens[1].kind, TokenType::Str | TokenType::Esc));
+        let params = if params_computed {
+            Vec::new()
+        } else {
+            parse_param_list(&args[1])
+        };
         // Doc string: prefer the preceding-comment harvest from
         // the segmenter; fall back to ``extract_body_docstring``
         // (leading comment block at the top of the body).
@@ -1245,6 +1273,7 @@ impl Analyser {
             name: simple,
             qualified_name: qualified.clone(),
             params: params.clone(),
+            params_computed,
             name_span,
             body_span,
             doc,
@@ -1496,6 +1525,10 @@ impl Analyser {
             name: simple,
             qualified_name: qualified.clone(),
             params: real_params,
+            // `tcl::OptProc`'s Tcl-level signature is always the single
+            // catch-all `args`, derived above — a known list, not a computed
+            // one.
+            params_computed: false,
             name_span,
             body_span,
             doc,
@@ -9062,6 +9095,7 @@ mod tests {
                 name: "b".to_string(),
                 qualified_name: "::a::b".to_string(),
                 params: Vec::new(),
+                params_computed: false,
                 name_span: span(0, 0),
                 body_span: span(0, 0),
                 doc: String::new(),
@@ -9089,6 +9123,7 @@ mod tests {
                     name: "inner".to_string(),
                     qualified_name: qname.to_string(),
                     params: Vec::new(),
+                    params_computed: false,
                     name_span: span(0, 0),
                     body_span: span(0, 0),
                     doc: String::new(),

--- a/rust/tcl-compiler/src/analyser/scope.rs
+++ b/rust/tcl-compiler/src/analyser/scope.rs
@@ -38,7 +38,7 @@ use std::collections::{HashMap, HashSet};
 use tcl_core_types::DiagCode;
 use tcl_lexer::{Span, Token, TokenType};
 
-use crate::naming::{normalise_qualified_name, normalise_var_name, split_array_name};
+use crate::naming::normalise_qualified_name;
 
 use super::state::Analyser;
 use super::types::{ClassDef, ProcDef, Scope, ScopeKind, VarDef};
@@ -781,7 +781,10 @@ impl Analyser {
         // meaningful.
         let head_span = cmd.argv.first().map(|t| t.span);
         let source_len = u32::try_from(self.source.len()).unwrap_or(u32::MAX);
-        let mut reads: Vec<(String, tcl_lexer::Span)> = Vec::new();
+        // Each read carries whether it used the `${…}` brace form, whose
+        // content is a *literal* name: `${$n}` reads the variable called `$n`,
+        // not `n` (issue #1078).
+        let mut reads: Vec<(String, tcl_lexer::Span, bool)> = Vec::new();
         for tok in &cmd.all_tokens {
             if tok.kind != TokenType::Var {
                 continue;
@@ -795,10 +798,14 @@ impl Analyser {
             let Some(name) = var_name_from_span(&self.source, tok.span) else {
                 continue;
             };
-            reads.push((name.to_string(), tok.span));
+            let braced = self
+                .source
+                .get(tok.span.start() as usize..tok.span.end() as usize)
+                .is_some_and(|t| t.starts_with("${"));
+            reads.push((name.to_string(), tok.span, braced));
         }
-        for (name, span) in reads {
-            self.record_var_read(&name, span, scope_path);
+        for (name, span, braced) in reads {
+            self.record_var_read_braced(&name, span, scope_path, braced);
         }
 
         // `$var` reads also occur inside command substitutions
@@ -1517,13 +1524,33 @@ impl Analyser {
     /// is emitted by the SSA-based pass elsewhere — this helper only
     /// records the reference span.
     pub fn record_var_read(&mut self, name: &str, read_span: Span, scope_path: &[usize]) {
-        let base_name = normalise_var_name(name);
+        self.record_var_read_braced(name, read_span, scope_path, false);
+    }
+
+    /// [`Self::record_var_read`] for a read whose delimiters make its content
+    /// a **literal** name — a `${…}` reference or a brace-quoted word in a
+    /// variable-name role (`[set {$n}]`, `info exists {$n}`).
+    ///
+    /// Braces suppress every substitution, so the content is the name verbatim:
+    /// `${$n}` reads the variable *called* `$n`, which Tcl keeps distinct from
+    /// `n` (tclsh 9.0.4 / 8.6.14: `set {$n} v; set ${$n}` → `can't read "v"`,
+    /// i.e. it read `$n` and got `v`). Stripping the `$` here landed the
+    /// reference on the wrong variable and let Find-References / Rename merge
+    /// the two (issue #1078).
+    pub fn record_var_read_braced(
+        &mut self,
+        name: &str,
+        read_span: Span,
+        scope_path: &[usize],
+        braced_literal: bool,
+    ) {
+        let base_name = crate::naming::normalise_var_name_braced(name, braced_literal);
         if base_name.is_empty() {
             return;
         }
         self.record_qualified_var_ref(base_name, read_span, scope_path);
         // An `$arr(idx)` read records the element index on the array var.
-        let element = split_array_name(name)
+        let element = crate::naming::split_array_name_braced(name, braced_literal)
             .1
             .filter(|e| !e.is_empty())
             .map(ToString::to_string);
@@ -1668,6 +1695,16 @@ impl Analyser {
     /// ``"<scope_name>::<base_name>"``.  Re-defining an existing
     /// variable does not overwrite — it only escalates the
     /// `warn_if_unused` flag.
+    ///
+    /// `tok` is the token of the word that **spells the name**, and its kind
+    /// decides how that spelling reads: a brace-quoted word (`TokenType::Str`
+    /// — `set {$n} 1`, `foreach {$a} …`) substitutes nothing, so its content
+    /// is the literal name, `$` and all.  Tcl keeps `{$n}` and `n` apart
+    /// (tclsh 9.0.4 / 8.6.14: `set {$n} v; info exists {$n}` → 1 while
+    /// `info exists n` → 0); normalising the `$` away collapsed them into one
+    /// `VarDef`, so Find-References answered for both and a rename of `n`
+    /// rewrote the `{$n}` word (issue #1078). The array-element suffix still
+    /// comes off — `{arr($i)}` is element `$i` of the array `arr`.
     pub fn define_var(
         &mut self,
         name: &str,
@@ -1676,7 +1713,8 @@ impl Analyser {
         warn_if_unused: bool,
         definition_span: Option<Span>,
     ) {
-        let base_name = normalise_var_name(name);
+        let braced_literal = tok.kind == TokenType::Str;
+        let base_name = crate::naming::normalise_var_name_braced(name, braced_literal);
         if base_name.is_empty() {
             return;
         }
@@ -1684,7 +1722,7 @@ impl Analyser {
         let span = definition_span.unwrap_or(tok.span);
         self.record_qualified_var_ref(base_name, span, scope_path);
         // A `set arr(idx) …` definition records the element index on the array.
-        let element = split_array_name(name)
+        let element = crate::naming::split_array_name_braced(name, braced_literal)
             .1
             .filter(|e| !e.is_empty())
             .map(ToString::to_string);

--- a/rust/tcl-compiler/src/analyser/snapshot.rs
+++ b/rust/tcl-compiler/src/analyser/snapshot.rs
@@ -186,6 +186,7 @@ mod tests {
             name: name.to_string(),
             qualified_name: format!("::{name}"),
             params: Vec::new(),
+            params_computed: false,
             name_span: Span::new(0, 0),
             body_span: Span::new(0, 0),
             doc: String::new(),

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -403,7 +403,24 @@ pub struct ProcDef {
     /// Fully-qualified proc name with leading ``::``.
     pub qualified_name: String,
     /// Parameter list in declaration order.
+    ///
+    /// Empty *and* [`Self::params_computed`] set means "unknown", not
+    /// "none" — see that field.
     pub params: Vec<ParamDef>,
+    /// The parameter-list word was **computed**, so the proc's formals are
+    /// unmodelled (issue #1079).
+    ///
+    /// `proc p [makeargs] {…}` / `proc q $params {…}` build the formal list at
+    /// definition time from a value; which names it declares, and how many,
+    /// are run-time facts (tclsh 9.0.4 / 8.6.16: with
+    /// `proc makeargs {} {return {a b}}`, `proc p [makeargs] {…}` then
+    /// `info args p` → `a b`, and `p 1 2` runs).  The analyser used to read
+    /// the unresolved word as a one-parameter literal and register a
+    /// `VarDef` whose *name is the source text* (`"[makeargs]"`) — a wrong
+    /// fact that also made the call-site arity checker demand exactly one
+    /// argument.  Now nothing is claimed: no per-parameter `VarDef`, and the
+    /// arity resolvers abstain (`0..unlimited`).
+    pub params_computed: bool,
     /// Source span of the proc-name token.
     pub name_span: Span,
     /// Source span of the proc body (braces excluded).
@@ -430,6 +447,28 @@ pub struct ProcDef {
     /// trait alone.  Populated by
     /// [`super::param_traits::caller_frame_upvar_params`].
     pub caller_frame_params: std::collections::HashSet<String>,
+}
+
+impl ProcDef {
+    /// The proc's declared argument arity — or the **abstaining**
+    /// `0..unlimited` when its parameter list was computed
+    /// ([`Self::params_computed`], issue #1079).
+    ///
+    /// A computed list declares an unknown number of formals with unknown
+    /// names, so no call-site count can be wrong: `proc p [makeargs] {…}` with
+    /// `makeargs` returning `{a b}` really does take two arguments (tclsh
+    /// 9.0.4 / 8.6.16: `p 1 2` → `p got 1 2`), and reading the unresolved word
+    /// as one literal parameter made `p 1 2` draw a false
+    /// `E003 Too many arguments`.  Every arity consumer asks here rather than
+    /// calling [`crate::signature_scan::arity::arity_of`] on `params`
+    /// directly, so the abstention cannot be forgotten at one call site.
+    #[must_use]
+    pub fn arity(&self) -> tcl_registry::Arity {
+        if self.params_computed {
+            return tcl_registry::Arity::new(0, tcl_registry::Arity::UNLIMITED);
+        }
+        crate::signature_scan::arity::arity_of(&self.params)
+    }
 }
 
 /// A lightweight *named definition* introduced by a registry

--- a/rust/tcl-compiler/src/def_use.rs
+++ b/rust/tcl-compiler/src/def_use.rs
@@ -284,9 +284,14 @@ fn terminator_read_vars(terminator: Option<&Terminator>) -> Vec<String> {
             let mut set: std::collections::BTreeSet<String> = std::collections::BTreeSet::new();
             if let Some(v) = value {
                 set.extend(
-                    crate::var_refs::scan_var_ref_forms(v)
+                    crate::var_refs::scan_var_ref_forms_braced(v)
                         .into_iter()
-                        .map(|n| crate::naming::element_var_name(&n).to_string()),
+                        // A `${…}` read's content is a literal name — `${$n}`
+                        // reads the variable called `$n` — so its `$` must
+                        // survive canonicalisation (issue #1078).
+                        .map(|(n, braced)| {
+                            crate::naming::element_var_name_braced(&n, braced).to_string()
+                        }),
                 );
             }
             if let Some(e) = expr {

--- a/rust/tcl-compiler/src/dynamic_names.rs
+++ b/rust/tcl-compiler/src/dynamic_names.rs
@@ -277,15 +277,11 @@ fn scan_statement(stmt: &Statement, registry: &CommandRegistry, barrier: &mut Dy
         } => {
             // `args` is the segmenter's *reconstructed* text, which cannot
             // tell a brace-quoted `{$a}` (literal) from a substituted `$a`;
-            // the per-word token kinds can. Index 0 of `argv_kinds` /
-            // `single_token_word` is the command word, so the argument
-            // entries start at 1.
+            // the per-word token kinds can — asked via the shared
+            // `CommandTokens::arg_is_braced_literal`.
             let braced: Option<Vec<bool>> = tokens.as_ref().map(|t| {
-                t.argv_kinds
-                    .iter()
-                    .zip(t.single_token_word.iter())
-                    .skip(1)
-                    .map(|(kind, &single)| single && *kind == tcl_lexer::TokenType::Str)
+                (0..args.len())
+                    .map(|i| t.arg_is_braced_literal(i))
                     .collect()
             });
             // `command` likewise reports the head word's *content*, so a

--- a/rust/tcl-compiler/src/inlining/mod.rs
+++ b/rust/tcl-compiler/src/inlining/mod.rs
@@ -65,7 +65,7 @@ mod rename;
 
 use std::collections::{HashMap, HashSet};
 
-use tcl_lexer::{Span, TokenType};
+use tcl_lexer::Span;
 
 use crate::expr_ast::ExprNode;
 use crate::ir::{
@@ -1697,12 +1697,11 @@ fn build_param_bindings(
 /// Whether the call-site word at `args[idx]` was a braced literal (`{…}`)
 /// in source — so it must bind as an [`Statement::AssignConst`], preserving
 /// embedded `$`/`[` rather than re-substituting them at the inlined site.
-/// `argv[0]` is the command name, so `args[idx]` aligns with `argv[idx+1]`.
+///
+/// Thin wrapper over the shared [`CommandTokens::arg_is_braced_literal`] for
+/// the `Option<&CommandTokens>` the inliner carries.
 fn arg_is_braced_literal(tokens: Option<&CommandTokens>, idx: usize) -> bool {
-    let Some(t) = tokens else { return false };
-    t.argv_kinds
-        .get(idx + 1)
-        .is_some_and(|k| *k == TokenType::Str)
+    tokens.is_some_and(|t| t.arg_is_braced_literal(idx))
 }
 
 /// Try to fill missing positional args from declared defaults.

--- a/rust/tcl-compiler/src/ir.rs
+++ b/rust/tcl-compiler/src/ir.rs
@@ -62,6 +62,33 @@ pub struct CommandTokens {
     pub expand_word: Option<Vec<bool>>,
 }
 
+impl CommandTokens {
+    /// Whether **argument** `idx` (0-based, so `argv[idx + 1]`) is a
+    /// brace-quoted literal word — `{…}`, the one word form Tcl leaves
+    /// completely unsubstituted.
+    ///
+    /// The IR stores argument *content*, which cannot tell `{$a}` (the
+    /// literal three-character name `$a`) from `$a` (a substitution); the
+    /// per-word token kind can.  A `$var` lexes to `Var`, a `[cmd]` to `Cmd`,
+    /// a `"…"` (which *does* substitute) to `Esc`, and only a brace-quoted
+    /// word to `Str`.
+    ///
+    /// The single-token conjunct is belt-and-braces: a word that opens with
+    /// `{` must be entirely brace-quoted (`set x {a}{b}` is a tclsh parse
+    /// error, "extra characters after close-brace"), so a `Str`
+    /// representative token already implies a single-token word.
+    ///
+    /// The one definition of this question in the compiler — the dynamic-name
+    /// barrier, the place bridge, the inliner's literal-argument binding and
+    /// the def/use naming layer all ask it here rather than re-deriving it
+    /// (issue #1078).
+    #[must_use]
+    pub fn arg_is_braced_literal(&self, idx: usize) -> bool {
+        self.argv_kinds.get(idx + 1) == Some(&tcl_lexer::TokenType::Str)
+            && self.single_token_word.get(idx + 1).copied().unwrap_or(true)
+    }
+}
+
 // IR node types
 //
 // IR node kinds are modelled as a flat enum with struct variants.

--- a/rust/tcl-compiler/src/lowering/mod.rs
+++ b/rust/tcl-compiler/src/lowering/mod.rs
@@ -2253,20 +2253,31 @@ impl<'r> Lowerer<'r> {
         }
 
         if !var_indices.is_empty() || !var_read_indices.is_empty() {
+            // A brace-quoted name word (`set {$n} 1`, `unset {$n}`) is Tcl's
+            // literal spelling for a name that contains `$` / `[`: it
+            // substitutes nothing, so the word's content **is** the variable
+            // name (issue #1078). The de-braced `args` text cannot show that;
+            // the word's own token kind can.
+            let braced_at = |real: usize| {
+                matches!(seg.argv.get(real + 1).map(|t| t.kind), Some(TokenType::Str))
+                    && seg.single_token_word.get(real + 1).copied().unwrap_or(true)
+            };
             let var_defs: Vec<String> = var_indices
                 .iter()
                 .filter_map(|&i| {
                     let real = i.checked_sub(prepend_n)?;
-                    args.get(real)
-                        .map(|a| crate::naming::element_var_name(a).to_owned())
+                    args.get(real).map(|a| {
+                        crate::naming::element_var_name_braced(a, braced_at(real)).to_owned()
+                    })
                 })
                 .collect();
             let var_reads: Vec<String> = var_read_indices
                 .iter()
                 .filter_map(|&i| {
                     let real = i.checked_sub(prepend_n)?;
-                    args.get(real)
-                        .map(|a| crate::naming::element_var_name(a).to_owned())
+                    args.get(real).map(|a| {
+                        crate::naming::element_var_name_braced(a, braced_at(real)).to_owned()
+                    })
                 })
                 .collect();
             return Statement::Call {

--- a/rust/tcl-compiler/src/lowering_hooks.rs
+++ b/rust/tcl-compiler/src/lowering_hooks.rs
@@ -37,7 +37,6 @@ use tcl_registry::hooks::LoweringHookId;
 use crate::alias::{CommandAliasMap, expr_alias_names};
 use crate::expr_parser::parse_expr;
 use crate::ir::{CommandTokens, Statement};
-use crate::naming::normalise_var_name;
 
 /// Parsed command context passed to lowering hooks.
 pub struct LoweringCommand<'a> {
@@ -65,6 +64,23 @@ pub struct LoweringCommand<'a> {
     /// [`crate::expr_ast::ExprNode::Raw`] — which no downstream fold can
     /// evaluate.
     pub dialect: Option<&'a str>,
+}
+
+impl LoweringCommand<'_> {
+    /// Whether **argument** `idx` (0-based) is a brace-quoted literal word.
+    ///
+    /// Braces suppress every substitution, so such a word's content is a
+    /// *literal* variable name where the command's role says a name goes:
+    /// `unset {$n}` destroys the variable called `$n`, not `n` (issue #1078).
+    /// The de-braced `args` text cannot show that; the word's own token kind
+    /// can — `arg_kinds` is arg-indexed, `single_token_word` word-indexed
+    /// (index 0 is the command word).  Mirrors
+    /// [`crate::ir::CommandTokens::arg_is_braced_literal`] for the hook view.
+    #[must_use]
+    pub fn arg_is_braced_literal(&self, idx: usize) -> bool {
+        self.arg_kinds.get(idx) == Some(&ArgTokenKind::Str)
+            && self.single_token_word.get(idx + 1).copied().unwrap_or(true)
+    }
 }
 
 /// Simplified token kind for hook arg inspection.
@@ -371,7 +387,10 @@ fn lower_append_lappend(cmd: &LoweringCommand<'_>) -> Option<Statement> {
             Some(ArgTokenKind::Str | ArgTokenKind::Esc)
         );
     let defs = if name_is_literal {
-        vec![normalise_var_name(&cmd.args[0]).to_owned()]
+        vec![
+            crate::naming::normalise_var_name_braced(&cmd.args[0], cmd.arg_is_braced_literal(0))
+                .to_owned(),
+        ]
     } else {
         vec![]
     };
@@ -413,7 +432,10 @@ fn lower_unset(cmd: &LoweringCommand<'_>) -> Statement {
     }
     let var_names: Vec<String> = cmd.args[i..]
         .iter()
-        .map(|a| normalise_var_name(a).to_owned())
+        .enumerate()
+        .map(|(k, a)| {
+            crate::naming::normalise_var_name_braced(a, cmd.arg_is_braced_literal(i + k)).to_owned()
+        })
         .collect();
     Statement::Call {
         span: cmd.span,
@@ -438,7 +460,10 @@ fn lower_global(cmd: &LoweringCommand<'_>) -> Option<Statement> {
     let var_names: Vec<String> = cmd
         .args
         .iter()
-        .map(|a| normalise_var_name(a).to_owned())
+        .enumerate()
+        .map(|(i, a)| {
+            crate::naming::normalise_var_name_braced(a, cmd.arg_is_braced_literal(i)).to_owned()
+        })
         .collect();
     Some(Statement::Call {
         span: cmd.span,
@@ -460,8 +485,11 @@ fn lower_variable(cmd: &LoweringCommand<'_>) -> Statement {
     let var_names: Vec<String> = cmd
         .args
         .iter()
+        .enumerate()
         .step_by(2)
-        .map(|a| normalise_var_name(a).to_owned())
+        .map(|(i, a)| {
+            crate::naming::normalise_var_name_braced(a, cmd.arg_is_braced_literal(i)).to_owned()
+        })
         .collect();
     Statement::Call {
         span: cmd.span,
@@ -501,7 +529,13 @@ fn lower_upvar(cmd: &LoweringCommand<'_>) -> Option<Statement> {
     while i + 1 < rest.len() {
         let caller = &rest[i];
         if !caller.starts_with('$') && !caller.starts_with('[') {
-            my_vars.push(normalise_var_name(&rest[i + 1]).to_owned());
+            my_vars.push(
+                crate::naming::normalise_var_name_braced(
+                    &rest[i + 1],
+                    cmd.arg_is_braced_literal(start + i + 1),
+                )
+                .to_owned(),
+            );
         }
         i += 2;
     }

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -901,6 +901,14 @@ fn scan_set_read_refs(slice: &str, out: &mut HashSet<String>) {
         {
             name_cursor += 1;
         }
+        // The slice can end right here — a half-typed `[set ` is an ordinary
+        // intermediate state while editing, and this scan runs over partial
+        // functions (PR #1106 review, P2). There is no name word to read, so
+        // the conservative answer is "this bracket contributes nothing":
+        // stop rather than index off the end (nothing follows it either).
+        if name_cursor >= bytes.len() {
+            break;
+        }
         // A **brace-quoted** name word (`[set {$n}]`, `[set {a b}]`,
         // `[set {arr($i)}]`) is Tcl's literal spelling for a name the bareword
         // scan below cannot match: the braces suppress substitution, so the
@@ -1555,6 +1563,79 @@ mod tests {
             bad.is_empty(),
             "[set x] should count as a read for x; got {opts:?}",
         );
+    }
+
+    /// PR #1106 review, P2 — the `[set …]` name scan must survive a slice that
+    /// ends inside the command.
+    ///
+    /// A half-typed `[set ` is an ordinary intermediate state while editing,
+    /// and this scan runs over *partial* functions, so the whitespace skip can
+    /// walk `name_cursor` to `bytes.len()`. Indexing there panicked, taking
+    /// down whatever optimiser / diagnostic pass was asking — a crash where a
+    /// conservative answer was wanted.
+    #[test]
+    fn scan_set_read_refs_survives_truncated_input() {
+        for slice in [
+            // The reported shape: the slice ends after the separator.
+            "[set ",
+            "[set  ",
+            "[set\t",
+            // Off-by-one neighbours around the same cursor.
+            "[set",
+            "[set ]",
+            // Unclosed brace-quoted name words (the arm the guard precedes).
+            "[set {",
+            "[set {$n",
+            "[set {$n}",
+            "[set {{",
+            "[set {}",
+            // Unclosed bareword names.
+            "[set n",
+            "[set ::",
+        ] {
+            let mut out = HashSet::new();
+            scan_set_read_refs(slice, &mut out);
+            assert!(
+                out.is_empty(),
+                "a truncated `[set …]` names nothing; {slice:?} yielded {out:?}"
+            );
+        }
+    }
+
+    /// TP control for the guard: truncation must not cost the *complete*
+    /// reads earlier in the same slice, and the complete forms still parse.
+    #[test]
+    fn scan_set_read_refs_keeps_complete_reads_before_a_truncation() {
+        let mut out = HashSet::new();
+        scan_set_read_refs("puts [set x]; return [set ", &mut out);
+        assert!(
+            out.contains("x"),
+            "the complete read is still seen: {out:?}"
+        );
+
+        let mut braced = HashSet::new();
+        scan_set_read_refs("[set {$n}]", &mut braced);
+        assert!(braced.contains("$n"), "{braced:?}");
+        let mut spaced = HashSet::new();
+        scan_set_read_refs("[set  {$n} ]", &mut spaced);
+        assert!(spaced.contains("$n"), "{spaced:?}");
+    }
+
+    /// The same shape through the real entry point: an incomplete command in
+    /// a document must return conservative results, not crash the pass.
+    #[test]
+    fn textual_var_reference_scan_survives_an_incomplete_command_in_a_document() {
+        for src in [
+            "proc ::f {} { set x 1; return [set ",
+            "proc ::f {} { set x 1; return [set {",
+            "proc ::f {} { set x 1; return [set {$n",
+        ] {
+            let opts = run_pass(src);
+            // No assertion on the verdicts — a half-typed document may
+            // legitimately produce anything or nothing. The point is that it
+            // returns at all.
+            let _ = opts;
+        }
     }
 
     #[test]

--- a/rust/tcl-compiler/src/optimiser/elimination.rs
+++ b/rust/tcl-compiler/src/optimiser/elimination.rs
@@ -901,6 +901,50 @@ fn scan_set_read_refs(slice: &str, out: &mut HashSet<String>) {
         {
             name_cursor += 1;
         }
+        // A **brace-quoted** name word (`[set {$n}]`, `[set {a b}]`,
+        // `[set {arr($i)}]`) is Tcl's literal spelling for a name the bareword
+        // scan below cannot match: the braces suppress substitution, so the
+        // content *is* the name (issue #1078).  Without this arm the read went
+        // unseen and its `set {$n} 1` was reported unused (W211) / dead (W220)
+        // where the identical plain-named script was not.
+        if bytes[name_cursor] == b'{' {
+            let inner_start = name_cursor + 1;
+            let mut depth = 1usize;
+            let mut scan = inner_start;
+            while scan < bytes.len() && depth > 0 {
+                match bytes[scan] {
+                    b'{' => depth += 1,
+                    b'}' => depth -= 1,
+                    _ => {}
+                }
+                if depth > 0 {
+                    scan += 1;
+                }
+            }
+            if depth == 0 {
+                let mut tail = scan + 1;
+                while tail < bytes.len() && (bytes[tail] == b' ' || bytes[tail] == b'\t') {
+                    tail += 1;
+                }
+                if tail < bytes.len()
+                    && bytes[tail] == b']'
+                    && let Ok(name) = std::str::from_utf8(&bytes[inner_start..scan])
+                    && !name.is_empty()
+                {
+                    // Both the element-qualified spelling and its array base,
+                    // matching the two naming modes the consumers use.
+                    out.insert(name.to_owned());
+                    let base = crate::naming::normalise_var_name_braced(name, true);
+                    if !base.is_empty() {
+                        out.insert(base.to_owned());
+                    }
+                }
+                pos = scan + 1;
+                continue;
+            }
+            pos = open + 1;
+            continue;
+        }
         let name_start = name_cursor;
         while name_cursor < bytes.len() {
             let byte = bytes[name_cursor];
@@ -1009,6 +1053,7 @@ pub(crate) fn collect_rmw_hidden_reads(
         // bias.
         out.extend(dollar_reads_in_cmd_subs(word));
     };
+    let mut terminator_values: Vec<String> = Vec::new();
     for block in fu.cfg.blocks.values() {
         for stmt in &block.statements {
             match stmt {
@@ -1027,6 +1072,31 @@ pub(crate) fn collect_rmw_hidden_reads(
                 _ => {}
             }
         }
+        // A `return`'s value word is a terminator, not a statement, so the
+        // loop above never saw it — yet `return [set x]` / `return [incr i]`
+        // read exactly as the same word would in an argument position.
+        // Missing it reported the feeding `set x 2` as a dead store on code
+        // that reads it (tclsh 9.0.4 / 8.6.14: `proc f {} {set n 1; set n 2;
+        // return [set n]}; f` → 2).
+        //
+        // Deliberately the *precise* deep-minus-shallow scan only, without the
+        // `dollar_reads_in_cmd_subs` over-approximation the argument scan adds:
+        // that one credits every `$x` inside any `[…]`, which on a terminator
+        // (`return [subst {$a$b}]`) would silence a genuine dead store of `b`
+        // earlier in the proc (FP-DS-12's TN control).  A terminator read is
+        // recoverable exactly, so approximating it buys nothing.
+        if let Some(crate::cfg::Terminator::Return { value: Some(v), .. }) = &block.terminator
+            && v.contains('[')
+        {
+            terminator_values.push(v.clone());
+        }
+    }
+    // Collected above rather than scanned in place: `scan` holds `deep` /
+    // `shallow` / `out` mutably borrowed for the duration of the walk.
+    for v in &terminator_values {
+        let d = deep.scan_word(v, registry);
+        let sh = shallow.scan_word(v, registry);
+        out.extend(d.difference(&sh).cloned());
     }
     out
 }

--- a/rust/tcl-compiler/src/place_bridge.rs
+++ b/rust/tcl-compiler/src/place_bridge.rs
@@ -41,7 +41,6 @@ use crate::var_resolve::{ResolveContext, resolve_place};
 use crate::var_scoping::{
     global_declaration_indices, upvar_local_declaration_indices, variable_declaration_indices,
 };
-use tcl_lexer::TokenType;
 
 /// True when `name`'s `VarRead`-role argument names the *whole* array,
 /// not a scalar (so a write to any element is observed) — the registry's
@@ -193,16 +192,11 @@ fn collect_upvar_aliases(
 /// (`{…}`): Tcl performs no `$` / `[` substitution on it, so its de-braced IR
 /// text must NOT be scanned for reads — `puts {$a(k)}` does *not* read `a(k)`.
 ///
-/// Detected via the `Str` token kind: a `$var` lexes to `Var`, a `[cmd]` to
-/// `Cmd`, and a `"…"` (which *does* substitute) to `Esc` — only a brace-quoted
-/// word is `Str`.  `tokens.argv` is command-name-first, so args are 1-based.
-/// The IR keeps args de-braced, so we gate on the token kind rather than
-/// re-scanning the braced text.
+/// Thin wrapper over the shared
+/// [`CommandTokens::arg_is_braced_literal`] for the `Option<&CommandTokens>`
+/// this module carries.
 fn is_braced_literal(tokens: Option<&CommandTokens>, arg_index: usize) -> bool {
-    tokens
-        .and_then(|t| t.argv_kinds.get(arg_index + 1))
-        .copied()
-        == Some(TokenType::Str)
+    tokens.is_some_and(|t| t.arg_is_braced_literal(arg_index))
 }
 
 fn trace_target(args: &[String]) -> Option<&str> {

--- a/rust/tcl-compiler/src/ssa.rs
+++ b/rust/tcl-compiler/src/ssa.rs
@@ -373,8 +373,18 @@ fn barrier_is_loop_list_header(command: &str, registry: Option<&CommandRegistry>
 /// *base* (`a$b(k)`) is dynamic too.  A bare array element (`arr($i)`) keeps
 /// its static base `arr` (only the index is dynamic), so it is **not** a
 /// dynamic target here.
+///
+/// `braced_literal` is the statement's own `name_braced` flag: a brace-quoted
+/// word (`set {$n} 1`) substitutes nothing, so its `$` is part of a perfectly
+/// static name and the target is **not** dynamic (issue #1078).  Reading the
+/// name text alone called it dynamic, withheld the def, and recorded a read of
+/// `n` — a `W210 Variable 'n' is read before it is set` on code that never
+/// mentions `n`.
 #[must_use]
-pub fn is_dynamic_write_target(name: &str) -> bool {
+pub fn is_dynamic_write_target(name: &str, braced_literal: bool) -> bool {
+    if braced_literal {
+        return false;
+    }
     if name.starts_with('$') {
         return true;
     }
@@ -415,8 +425,10 @@ pub fn defs_of_with_registry(stmt: &Statement, registry: Option<&CommandRegistry
             // `set ${tok}(k) …`) denotes the variable named by the
             // substitution's value — a place that cannot be pinned down, so it
             // is **not** a static def of the name-bearing variable.  `uses_of`
-            // records the name read separately.
-            if is_dynamic_write_target(name) {
+            // records the name read separately.  A brace-quoted target
+            // (`set {$n} 1`) substitutes nothing — it is a static def of the
+            // variable literally named `$n` (issue #1078).
+            if is_dynamic_write_target(name, *name_braced) {
                 return Vec::new();
             }
             // A constant-keyed array element defs its own variable
@@ -425,7 +437,12 @@ pub fn defs_of_with_registry(stmt: &Statement, registry: Option<&CommandRegistry
             vec![crate::naming::element_var_name_braced(name, *name_braced).to_owned()]
         }
         Statement::Call { defs, .. } if !defs.is_empty() => defs.clone(),
-        Statement::Barrier { command, args, .. } => {
+        Statement::Barrier {
+            command,
+            args,
+            tokens,
+            ..
+        } => {
             // Loop-header barriers (`::tcl::dict::for`/`::map`, `::tcl::array::for`
             // — any ensemble subcommand the registry marks `loop_list_header`):
             // args[0] is the iteration-variable list, so extract the names.
@@ -456,8 +473,14 @@ pub fn defs_of_with_registry(stmt: &Statement, registry: Option<&CommandRegistry
                     return indices
                         .into_iter()
                         .filter_map(|idx| {
-                            args.get(idx)
-                                .map(|s| crate::naming::element_var_name(s).to_owned())
+                            // A brace-quoted name word is a literal name, `$`
+                            // and all (issue #1078).
+                            let braced = tokens
+                                .as_ref()
+                                .is_some_and(|t| t.arg_is_braced_literal(idx));
+                            args.get(idx).map(|s| {
+                                crate::naming::element_var_name_braced(s, braced).to_owned()
+                            })
                         })
                         .filter(|n| !n.is_empty())
                         .collect();
@@ -1403,42 +1426,63 @@ fn uses_in_assignment(
     vars_found: &mut BTreeSet<String>,
     reads_own_def: &mut BTreeSet<String>,
 ) {
+    // A brace-quoted target's `$` is part of a literal name, not a
+    // substitution: it is neither a dynamic target nor a read of the
+    // `$`-less lookalike (issue #1078).
     let note_reads_own = |name: &str,
+                          braced: bool,
                           scanner: &VarReferenceScanner,
                           vars_found: &BTreeSet<String>,
                           rod: &mut BTreeSet<String>| {
-        let norm = scanner.canonical_name(name);
+        let norm = scanner.canonical_name_braced(name, braced);
         if !norm.is_empty() && vars_found.contains(norm) {
             rod.insert(norm.to_owned());
         }
     };
     match stmt {
-        Statement::AssignConst { name, .. } => {
-            if is_dynamic_write_target(name) {
+        Statement::AssignConst {
+            name, name_braced, ..
+        } => {
+            if is_dynamic_write_target(name, *name_braced) {
                 vars_found.extend(scanner.scan_word(name, registry));
             }
         }
-        Statement::AssignExpr { name, expr, .. } => {
+        Statement::AssignExpr {
+            name,
+            name_braced,
+            expr,
+            ..
+        } => {
             vars_found.extend(expr_vars_for(scanner, expr));
-            if is_dynamic_write_target(name) {
+            if is_dynamic_write_target(name, *name_braced) {
                 vars_found.extend(scanner.scan_word(name, registry));
             } else {
-                note_reads_own(name, scanner, vars_found, reads_own_def);
+                note_reads_own(name, *name_braced, scanner, vars_found, reads_own_def);
             }
         }
-        Statement::AssignValue { name, value, .. } => {
+        Statement::AssignValue {
+            name,
+            name_braced,
+            value,
+            ..
+        } => {
             vars_found.extend(scanner.scan_word(value, registry));
-            if is_dynamic_write_target(name) {
+            if is_dynamic_write_target(name, *name_braced) {
                 vars_found.extend(scanner.scan_word(name, registry));
             } else {
-                note_reads_own(name, scanner, vars_found, reads_own_def);
+                note_reads_own(name, *name_braced, scanner, vars_found, reads_own_def);
             }
         }
-        Statement::Incr { name, amount, .. } => {
-            if is_dynamic_write_target(name) {
+        Statement::Incr {
+            name,
+            name_braced,
+            amount,
+            ..
+        } => {
+            if is_dynamic_write_target(name, *name_braced) {
                 vars_found.extend(scanner.scan_word(name, registry));
             } else {
-                let norm = scanner.canonical_name(name);
+                let norm = scanner.canonical_name_braced(name, *name_braced);
                 if !norm.is_empty() {
                     vars_found.insert(norm.to_owned());
                     reads_own_def.insert(norm.to_owned());
@@ -1483,8 +1527,29 @@ fn scan_command_words(
     // `tcltest::test`; the raw spelling alone is not a registry key).
     let lookup = canonical_command.unwrap_or(command);
     let body_indices = structural_body_indices(lookup, args, tokens, registry);
+    // A **brace-quoted word in a variable-name position** is a literal name,
+    // not a template: `unset {$n}` destroys the variable called `$n` and reads
+    // nothing (tclsh 9.0.4 / 8.6.14 — `set {$n} v; unset {$n}` leaves `n`
+    // untouched).  Scanning its de-braced content recorded a phantom read of
+    // `n`, which surfaced as `W213 Variable 'n' may not exist` (issue #1078).
+    // Only name roles are exempt: a braced `Expr` word (`expr {$a + $b}`)
+    // really does substitute, so its reads must still be seen.
+    let name_role_braced: std::collections::HashSet<usize> =
+        tokens.map_or_else(std::collections::HashSet::new, |t| {
+            let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+            let mut idx =
+                registry.arg_indices_for_role(lookup, &arg_strs, tcl_registry::ArgRole::VarWrite);
+            idx.extend(registry.arg_indices_for_role(
+                lookup,
+                &arg_strs,
+                tcl_registry::ArgRole::VarRead,
+            ));
+            idx.into_iter()
+                .filter(|&i| t.arg_is_braced_literal(i))
+                .collect()
+        });
     for (idx, arg) in args.iter().enumerate() {
-        if body_indices.contains(&idx) {
+        if body_indices.contains(&idx) || name_role_braced.contains(&idx) {
             continue;
         }
         vars_found.extend(scanner.scan_word(arg, registry));
@@ -2360,13 +2425,28 @@ mod tests {
 
     #[test]
     fn is_dynamic_write_target_classifies_names() {
-        assert!(is_dynamic_write_target("$p"));
-        assert!(is_dynamic_write_target("${p}"));
-        assert!(is_dynamic_write_target("a$b"));
-        assert!(is_dynamic_write_target("[gen]"));
-        assert!(!is_dynamic_write_target("p"));
-        assert!(!is_dynamic_write_target("arr(idx)"));
-        assert!(!is_dynamic_write_target("ns::var"));
+        assert!(is_dynamic_write_target("$p", false));
+        assert!(is_dynamic_write_target("${p}", false));
+        assert!(is_dynamic_write_target("a$b", false));
+        assert!(is_dynamic_write_target("[gen]", false));
+        assert!(!is_dynamic_write_target("p", false));
+        assert!(!is_dynamic_write_target("arr(idx)", false));
+        assert!(!is_dynamic_write_target("ns::var", false));
+    }
+
+    #[test]
+    fn brace_quoted_write_target_is_not_dynamic() {
+        // Issue #1078 — `set {$n} 1` names the literal variable `$n`; the
+        // braces suppressed every substitution, so nothing about the target
+        // is computed.  tclsh 9.0.4 / 8.6.14 (identical):
+        //   set {$n} v; info exists {$n} → 1 ; info exists n → 0
+        assert!(!is_dynamic_write_target("$n", true));
+        assert!(!is_dynamic_write_target("${n}", true));
+        assert!(!is_dynamic_write_target("[gen]", true));
+        assert!(!is_dynamic_write_target("$a(k)", true));
+        // TN control: the same spellings *unbraced* are still dynamic.
+        assert!(is_dynamic_write_target("$n", false));
+        assert!(is_dynamic_write_target("[gen]", false));
     }
 
     #[test]

--- a/rust/tcl-compiler/src/var_refs.rs
+++ b/rust/tcl-compiler/src/var_refs.rs
@@ -34,8 +34,6 @@ use std::collections::{BTreeSet, HashMap, VecDeque};
 use tcl_lexer::{Lexer, SourceMap, Token, TokenType};
 use tcl_registry::{ArgRole, CommandRegistry};
 
-use crate::naming::{element_var_name, normalise_var_name};
-
 /// Options controlling what a [`VarReferenceScanner`] looks for.
 #[allow(clippy::struct_excessive_bools)] // option flags, not a state machine
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -128,10 +126,20 @@ impl VarReferenceScanner {
     /// variable word: element-qualified or base, per the options.
     #[must_use]
     pub fn canonical_name<'a>(&self, raw: &'a str) -> &'a str {
+        self.canonical_name_braced(raw, false)
+    }
+
+    /// [`Self::canonical_name`] for a word whose delimiters make its content a
+    /// literal name — a brace-quoted write target (`set {$n} 1`) or the
+    /// `${…}` reference form. See
+    /// [`crate::naming::element_var_name_braced`] for the oracle: the content
+    /// is the name verbatim, `$` and all (issue #1078).
+    #[must_use]
+    pub fn canonical_name_braced<'a>(&self, raw: &'a str, braced_literal: bool) -> &'a str {
         if self.options.element_qualified {
-            element_var_name(raw)
+            crate::naming::element_var_name_braced(raw, braced_literal)
         } else {
-            normalise_var_name(raw)
+            crate::naming::normalise_var_name_braced(raw, braced_literal)
         }
     }
 
@@ -199,14 +207,18 @@ impl VarReferenceScanner {
 /// `options.element_qualified`, or `None` for a degenerate/empty name.
 fn var_token_name(source_map: &SourceMap, tok: &Token, options: VarScanOptions) -> Option<String> {
     let text = source_map.token_text(*tok);
+    // The `${…}` brace form substitutes nothing inside, so its content is the
+    // variable's literal name — `${$n}` reads the variable *called* `$n`, and
+    // `${arr($i)}` the element whose key is the two characters `$i` (tclsh
+    // 9.0.4 / 8.6.14: `set {$n} v; set ${$n}` → `can't read "v"`, i.e. it read
+    // `$n` and got `v`).  The sigil-stripped token text can't show that; the
+    // raw span keeps the `${` prefix.  Applies to both naming modes — dropping
+    // the `$` in the base-name mode keyed the read on `n` (issue #1078).
+    let braced = source_map.text(tok.span).starts_with("${");
     let name = if options.element_qualified {
-        // The `${…}` brace form substitutes nothing inside, so its key is
-        // literal even when it spells `$x` — the sigil-stripped token text
-        // can't show that, but the raw span keeps the `${` prefix.
-        let braced = source_map.text(tok.span).starts_with("${");
         crate::naming::element_var_name_braced(text, braced)
     } else {
-        normalise_var_name(text)
+        crate::naming::normalise_var_name_braced(text, braced)
     };
     (!name.is_empty()).then(|| name.to_owned())
 }
@@ -302,16 +314,19 @@ fn scan_var_read_role_names(
         return result;
     };
 
-    // Segment into commands by splitting on EOL/EOF.
-    let mut words: Vec<String> = Vec::new();
+    // Segment into commands by splitting on EOL/EOF.  Each word carries
+    // whether it is a *brace-quoted literal* — a single `Str` token, the one
+    // word form Tcl leaves entirely unsubstituted, so `unset {$n}` names the
+    // variable literally called `$n` rather than reading `n` (issue #1078).
+    let mut words: Vec<(String, bool)> = Vec::new();
     let mut prev_is_sep = true;
 
-    let flush = |words: &mut Vec<String>, result: &mut BTreeSet<String>| {
+    let flush = |words: &mut Vec<(String, bool)>, result: &mut BTreeSet<String>| {
         if words.is_empty() {
             return;
         }
-        let cmd_name = &words[0];
-        let args: Vec<&str> = words[1..].iter().map(String::as_str).collect();
+        let cmd_name = &words[0].0;
+        let args: Vec<&str> = words[1..].iter().map(|(w, _)| w.as_str()).collect();
         let mut read_idx: Vec<usize> =
             registry.arg_indices_for_role(cmd_name, &args, ArgRole::VarRead);
         // A read-modify-write command (`incr` / `append` / `lappend`) reads
@@ -325,10 +340,11 @@ fn scan_var_read_role_names(
         }
         for idx in read_idx {
             if idx < args.len() {
+                let braced = words[idx + 1].1;
                 let name = if element_qualified {
-                    element_var_name(args[idx])
+                    crate::naming::element_var_name_braced(args[idx], braced)
                 } else {
-                    normalise_var_name(args[idx])
+                    crate::naming::normalise_var_name_braced(args[idx], braced)
                 };
                 if !name.is_empty() {
                     result.insert(name.to_owned());
@@ -350,11 +366,14 @@ fn scan_var_read_role_names(
             _ => {
                 let text = source_map.token_text(*tok);
                 if prev_is_sep {
-                    words.push(text.to_owned());
+                    words.push((text.to_owned(), tok.kind == TokenType::Str));
                 } else if let Some(last) = words.last_mut() {
-                    last.push_str(text);
+                    last.0.push_str(text);
+                    // A second token in the word means it is not a single
+                    // brace-quoted literal.
+                    last.1 = false;
                 } else {
-                    words.push(text.to_owned());
+                    words.push((text.to_owned(), tok.kind == TokenType::Str));
                 }
                 prev_is_sep = false;
             }
@@ -401,7 +420,7 @@ fn deref_form(text: &str) -> &str {
     }
 }
 
-fn collect_ref_forms(text: &str, out: &mut Vec<String>) {
+fn collect_ref_forms(text: &str, out: &mut Vec<(String, bool)>) {
     if text.is_empty() {
         return;
     }
@@ -412,9 +431,18 @@ fn collect_ref_forms(text: &str, out: &mut Vec<String>) {
     for tok in &tokens {
         match tok.kind {
             TokenType::Var => {
-                let form = deref_form(source_map.token_text(*tok));
+                // `token_text` already drops the `$` / `${` decoration, so the
+                // remainder *is* the form.  Re-running `deref_form` over it
+                // would strip a second sigil that belongs to the name itself:
+                // `${$n}` reads the variable literally called `$n` (issue
+                // #1078), whose de-decorated text is `$n`, not `n`.  The
+                // `${…}` form's content is literal, which the flag carries so
+                // consumers do not re-normalise it either.
+                let braced = source_map.text(tok.span).starts_with("${");
+                let form = source_map.token_text(*tok);
+                let form = if braced { form } else { deref_form(form) };
                 if !form.is_empty() {
-                    out.push(form.to_owned());
+                    out.push((form.to_owned(), braced));
                 }
             }
             TokenType::Cmd => {
@@ -437,6 +465,22 @@ fn collect_ref_forms(text: &str, out: &mut Vec<String>) {
 /// distinguish a scalar from an array element from a dynamic ref.
 #[must_use]
 pub fn scan_var_ref_forms(text: &str) -> Vec<String> {
+    scan_var_ref_forms_braced(text)
+        .into_iter()
+        .map(|(f, _)| f)
+        .collect()
+}
+
+/// [`scan_var_ref_forms`], also reporting whether each reference used the
+/// `${…}` **brace form**, whose content is a literal name — `${$n}` reads the
+/// variable called `$n`, `${arr($i)}` the element whose key is the two
+/// characters `$i` (issue #1078).
+///
+/// A consumer that canonicalises the form must pass the flag on to
+/// [`crate::naming::element_var_name_braced`] rather than re-stripping a `$`
+/// that is part of the name.
+#[must_use]
+pub fn scan_var_ref_forms_braced(text: &str) -> Vec<(String, bool)> {
     let mut out = Vec::new();
     collect_ref_forms(text, &mut out);
     out

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -419,9 +419,11 @@ fn position_definition(
         ));
     }
     let param_position = parameter_list_position_at(analysis, source, cursor_off);
-    if param_position != ParamListPosition::Computed
-        && let Some(var_def) = var_def_at_declaration_offset(&analysis.global_scope, cursor_off)
-    {
+    // No `Computed` guard is needed here any more: since #1079 a computed
+    // parameter list registers no per-parameter `VarDef` at all, so there is
+    // no stub named `"[makeargs]"` for this lookup to land on. (#1073 added
+    // the guard while the stub still existed.)
+    if let Some(var_def) = var_def_at_declaration_offset(&analysis.global_scope, cursor_off) {
         return Some(vec![span_to_range(
             source,
             line_index,

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -395,7 +395,11 @@ fn position_definition(
         character,
         analysis,
     } = ctx;
-    if let Some(var_name) = find_var_at_position(source, line, character) {
+    // Resolved through the shared gate, not the raw character scan: a cursor
+    // inside a brace-quoted variable-name word (`set {$n} 1`) is not a `$n`
+    // reference, and must fall through to the declaration-span search below
+    // so it answers the *literal* cell (PR #1106 review, P2).
+    if let Some(var_name) = substituting_var_at_position(source, "", line, character, cursor_off) {
         if let Some(var_def) = lookup_var_read_at(
             &analysis.global_scope,
             source,
@@ -1517,19 +1521,9 @@ pub fn qualified_variable_cell_at(
 ) -> Option<String> {
     let line_index = LineIndex::new(source);
     let cursor_off = byte_offset_at(&line_index, source, line, character);
-    if let Some(name) = find_var_at_position(source, line, character) {
+    if let Some(name) = substituting_var_at_position(source, dialect, line, character, cursor_off) {
         let base = tcl_compiler::naming::normalise_var_name(&name);
         if !base.contains("::") {
-            return None;
-        }
-        if crate::inert_text::offset_in_comment(source, cursor_off)
-            || crate::inert_text::offset_in_data_brace(
-                source,
-                cursor_off,
-                tcl_registry::registry_for_dialect(dialect),
-                dialect,
-            )
-        {
             return None;
         }
         let here = innermost_namespace_at(&analysis.global_scope, cursor_off, &[]);
@@ -1615,14 +1609,60 @@ pub(crate) fn lookup_var_read_at<'a>(
     ns_global_fallback: bool,
 ) -> Option<&'a tcl_compiler::analyser::VarDef> {
     let var_def = lookup_var_in_scope_chain(global, cursor_off, name, ns_global_fallback)?;
-    let inert = crate::inert_text::offset_in_comment(source, cursor_off)
+    (!offset_is_inert(source, dialect, cursor_off)).then_some(var_def)
+}
+
+/// Whether `cursor_off` sits in text Tcl substitutes nothing in — a `#`
+/// comment or a braced *data* word.  The two [`crate::inert_text`] proofs
+/// under one name, so every caller asks the same question the same way.
+#[must_use]
+pub(crate) fn offset_is_inert(source: &str, dialect: &str, cursor_off: u32) -> bool {
+    crate::inert_text::offset_in_comment(source, cursor_off)
         || crate::inert_text::offset_in_data_brace(
             source,
             cursor_off,
             tcl_registry::registry_for_dialect(dialect),
             dialect,
-        );
-    (!inert).then_some(var_def)
+        )
+}
+
+/// **The one entry point** for "is the cursor on a live `$`-substitution, and
+/// which variable does it name?" — every variable provider (go-to-definition,
+/// hover, find-references, document-highlight, rename) resolves its `$ref`
+/// cursor through this, so the five cannot disagree.
+///
+/// [`crate::hover::find_var_at_position`] alone cannot answer it: it is a
+/// delimiter-based character scan, so it happily reports `n` for a cursor on
+/// the `n` of `set {$n} 1`. That word is **brace-quoted** — Tcl substitutes
+/// nothing inside it, so the `$n` there is not a reference to `n` at all; it
+/// is part of the literal *name* of a different variable (tclsh 9.0.4 /
+/// 8.6.14: `set {$n} v; info exists {$n}` → 1 while `info exists n` → 0).
+/// Answering `n` there made every provider report the unrelated plain cell's
+/// sites — or, once the scope gate rejected it, nothing at all — for a cursor
+/// sitting inside the literal cell's own declaration word (PR #1106 review,
+/// P2; the cursor half of issue #1108).
+///
+/// Returning `None` for such a cursor is what lets each provider fall through
+/// to its declaration-span search
+/// ([`var_def_at_declaration_offset`]), which resolves the literal cell
+/// correctly — exactly as it already did for a cursor on the word's opening
+/// `{`, where the character scan happened to find no `$`. The two columns of
+/// the same word now answer alike.
+///
+/// The same `None` covers the pre-existing inert cases (`puts {$v}`, a `$v`
+/// inside a `#` comment — issue #923 idx 24), which every caller already
+/// suppressed one layer further down; hoisting the proof here removes the
+/// short-circuit that hid the declaration-span search behind it.
+#[must_use]
+pub(crate) fn substituting_var_at_position(
+    source: &str,
+    dialect: &str,
+    line: u32,
+    character: u32,
+    cursor_off: u32,
+) -> Option<String> {
+    let name = find_var_at_position(source, line, character)?;
+    (!offset_is_inert(source, dialect, cursor_off)).then_some(name)
 }
 
 /// Whether `off` sits inside a **literal** parameter-list word of a proc or

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -391,15 +391,12 @@ fn variable_hover(
     }
 
     let decl_byte_offset = crate::definition::byte_offset_at(line_index, source, line, character);
-    // A *computed* parameter list (`proc p [makeargs] …`) is live code, not a
-    // declaration site: the analyser records a stub `VarDef` named after the
-    // whole word (`"[makeargs]"`), so trusting it here would render a bogus
-    // variable hover over what is really a call (Codex review of PR #1073).
-    if crate::definition::parameter_list_position_at(analysis, source, decl_byte_offset)
-        == crate::definition::ParamListPosition::Computed
-    {
-        return None;
-    }
+    // #1073 guarded this lookup against a *computed* parameter list
+    // (`proc p [makeargs] …`), where the analyser used to record a stub
+    // `VarDef` named after the whole word (`"[makeargs]"`) and hovering it
+    // rendered a bogus variable card over what is really a call.  Since #1079
+    // no such stub is registered, so the lookup simply finds nothing and the
+    // caller falls through to the command hover — the guard is gone.
     let var_def =
         crate::definition::var_def_at_declaration_offset(&analysis.global_scope, decl_byte_offset)?;
     let (type_info, taint_info) =

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -336,9 +336,18 @@ fn variable_hover(
     // `$var` resolution sits at a position where `find_word_span_at_position`
     // would also match the unqualified name, but a `$`-led ref should
     // surface the `VarDef` not the (typically absent) proc of the same name.
-    if let Some(var_name) = find_var_at_position(source, line, character) {
-        let var_byte_offset =
-            crate::definition::byte_offset_at(line_index, source, line, character);
+    let var_byte_offset = crate::definition::byte_offset_at(line_index, source, line, character);
+    // Resolved through the shared gate, not the raw character scan: a cursor
+    // inside a brace-quoted variable-name word (`set {$n} 1`) is not a `$n`
+    // reference, and must fall through to the declaration-span search below
+    // so it hovers the *literal* cell (PR #1106 review, P2).
+    if let Some(var_name) = crate::definition::substituting_var_at_position(
+        source,
+        profile.name,
+        line,
+        character,
+        var_byte_offset,
+    ) {
         // Use the byte-offset scope-chain lookup (the local line-based helper
         // mis-resolves namespace/proc-scoped vars), gated on the occurrence
         // actually being one Tcl substitutes — see `lookup_var_read_at`

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -151,7 +151,7 @@ use tcl_compiler::analyser::AnalysisResult;
 use tcl_lexer::LineIndex;
 
 use crate::definition::LspRange;
-use crate::hover::{find_var_at_position, find_word_span_at_position};
+use crate::hover::find_word_span_at_position;
 
 /// Byte spans of every call site the namespace-aware proc resolver
 /// attributes to `proc_def` (whose `all_procs` map key is `qname`),
@@ -708,10 +708,19 @@ fn variable_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
         include_declaration,
     } = *ctx;
     let byte_offset = crate::definition::byte_offset_at(line_index, source, line, character);
-    let var_def = if let Some(var_name) = find_var_at_position(source, line, character) {
-        // Gated on the occurrence being one Tcl actually substitutes — a
-        // `$name`-shaped substring in a comment or a data brace is not a
-        // reference (issue #923 idx 24; see `lookup_var_read_at`).
+    // Resolved through the shared gate, not the raw character scan: the
+    // occurrence must be one Tcl actually substitutes — a `$name`-shaped
+    // substring in a comment or a data brace is not a reference (issue #923
+    // idx 24), and neither is the `$n` inside a brace-quoted *name* word
+    // (`set {$n} 1`), which falls through to the declaration-span search in
+    // the final `else` so it answers the literal cell (PR #1106 review, P2).
+    let var_def = if let Some(var_name) = crate::definition::substituting_var_at_position(
+        source,
+        dialect,
+        line,
+        character,
+        byte_offset,
+    ) {
         match crate::definition::lookup_var_read_at(
             &analysis.global_scope,
             source,
@@ -3154,8 +3163,15 @@ pub fn document_highlights(
 ) -> Vec<(LspRange, HighlightKind)> {
     let line_index = LineIndex::new(source);
 
-    if let Some(var_name) = find_var_at_position(source, line, character) {
-        let byte_offset = crate::definition::byte_offset_at(&line_index, source, line, character);
+    let byte_offset = crate::definition::byte_offset_at(&line_index, source, line, character);
+    // Shared `$ref` gate — see `substituting_var_at_position`.
+    if let Some(var_name) = crate::definition::substituting_var_at_position(
+        source,
+        dialect,
+        line,
+        character,
+        byte_offset,
+    ) {
         let Some(var_def) = crate::definition::lookup_var_read_at(
             &analysis.global_scope,
             source,

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -343,6 +343,21 @@ pub fn rename_with_diagnosis(
     {
         return Err(refusal);
     }
+    // Safety gate: a variable whose *name* can only be written quoted
+    // (`set {$n} 1`) cannot be renamed by substituting into the recorded
+    // spans — see the gate's own doc (issue #1078).  Checked before
+    // `rename_variable_at`, whose `$`-reference cursor search would otherwise
+    // read the `$n` *inside* the braces as a reference to the unrelated
+    // variable `n` and rename that one instead.
+    if let Some(refusal) = crate::rename_safety::literal_name_variable_rename_refusal(
+        source,
+        line,
+        character,
+        analysis,
+        &line_index,
+    ) {
+        return Err(refusal);
+    }
 
     if let Some(edits) =
         rename_variable_at(source, line, character, new_name, analysis, &line_index)

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -86,7 +86,7 @@ use tcl_lexer::LineIndex;
 use tcl_registry::CommandRegistry;
 
 use crate::definition::LspRange;
-use crate::hover::{find_var_at_position, find_word_span_at_position};
+use crate::hover::find_word_span_at_position;
 use crate::references::{MemberSel, resolve_member_span};
 
 /// One text edit in a rename — span plus replacement text.
@@ -188,25 +188,26 @@ pub fn prepare_rename(
     analysis: &AnalysisResult,
 ) -> Option<PrepareRename> {
     let line_index = LineIndex::new(source);
-    // Variable?
-    if let Some(var_name) = find_var_at_position(source, line, character) {
-        let byte_offset = crate::definition::byte_offset_at(&line_index, source, line, character);
-        // A `$name`-shaped substring in a comment or a data brace is not a
-        // reference, so it is not renameable either (issue #923 idx 24; see
-        // `lookup_var_read_at`).
-        if let Some(var_def) = crate::definition::lookup_var_read_at(
+    // Variable?  Shared `$ref` gate: a `$name`-shaped substring in a comment
+    // or a data brace is not a reference, so it is not renameable either
+    // (issue #923 idx 24) — and neither is the `$n` inside a brace-quoted
+    // *name* word (PR #1106 review, P2).
+    let byte_offset = crate::definition::byte_offset_at(&line_index, source, line, character);
+    if let Some(var_name) =
+        crate::definition::substituting_var_at_position(source, "", line, character, byte_offset)
+        && let Some(var_def) = crate::definition::lookup_var_read_at(
             &analysis.global_scope,
             source,
             "",
             byte_offset,
             &var_name,
             analysis.ns_var_global_fallback(),
-        ) {
-            return Some(PrepareRename {
-                range: span_to_range(source, &line_index, var_def.definition_span),
-                placeholder: var_def.name.clone(),
-            });
-        }
+        )
+    {
+        return Some(PrepareRename {
+            range: span_to_range(source, &line_index, var_def.definition_span),
+            placeholder: var_def.name.clone(),
+        });
     }
     // Variable definition / same-cell write site (`set x` / `variable x` /
     // a proc-param / a `catch` result-var) — no `$`, so resolve directly
@@ -496,10 +497,17 @@ fn rename_variable_at(
     analysis: &AnalysisResult,
     line_index: &LineIndex,
 ) -> Option<Vec<TextEdit>> {
-    let name = if let Some(var_name) = find_var_at_position(source, line, character) {
+    let def_byte = crate::definition::byte_offset_at(line_index, source, line, character);
+    // Shared `$ref` gate — see `substituting_var_at_position`.  A cursor
+    // inside a brace-quoted name word falls through to the declaration-span
+    // search, so it names the literal cell; the refusal gate in
+    // `rename_with_diagnosis` has already stopped it before this point, but
+    // resolving it correctly here keeps the two from disagreeing.
+    let name = if let Some(var_name) =
+        crate::definition::substituting_var_at_position(source, "", line, character, def_byte)
+    {
         var_name
     } else {
-        let def_byte = crate::definition::byte_offset_at(line_index, source, line, character);
         crate::definition::var_def_at_declaration_offset(&analysis.global_scope, def_byte)?
             .name
             .clone()

--- a/rust/tcl-lsp-core/src/rename_safety.rs
+++ b/rust/tcl-lsp-core/src/rename_safety.rs
@@ -562,6 +562,53 @@ pub fn namespace_variable_rename_hazard(
     ))
 }
 
+/// Refuse a **variable** rename whose target's name can only be written
+/// quoted — `{$n}` / `${$n}`, `{a b}` / `${a b}`, `{[gen]}`.
+///
+/// Such a variable is perfectly legal and, since #1078, correctly modelled as
+/// its own cell (tclsh 9.0.4 / 8.6.14: `set {$n} v; info exists {$n}` → 1
+/// while `info exists n` → 0).  What it is *not* is renameable by span
+/// substitution, which is all the variable-rename edit builder does:
+///
+/// * the recorded spans cover a word's **content**, not its delimiters — the
+///   `{$n}` definition span starts at the `{` and stops before the `}`, so
+///   writing `q` over it yields `set q} 1`;
+/// * whether the *new* name needs delimiters at all is a property of the new
+///   name, so every occurrence would need its quoting recomputed — including
+///   read sites spelt `${$n}`, whose `${…}` may or may not survive.
+///
+/// Guessing produces a script that no longer parses, so the rename is refused
+/// with the reason, following the #1091 typed-refusal precedent.  A rename
+/// **to** such a name never gets this far: `is_safe_symbol_name` already
+/// rejects new names carrying `$` / whitespace / brackets.
+#[must_use]
+pub fn literal_name_variable_rename_refusal(
+    source: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+    line_index: &LineIndex,
+) -> Option<RenameRefusal> {
+    let off = crate::definition::byte_offset_at(line_index, source, line, character);
+    let def = crate::definition::var_def_at_declaration_offset(&analysis.global_scope, off)?;
+    if !tcl_syntax::naming::var_name_requires_quoting(&def.name) {
+        return None;
+    }
+    Some(RenameRefusal::new(
+        format!(
+            "cannot rename `{name}`: the variable's name can only be written quoted \
+             (`{{{name}}}` / `${{{name}}}`), so each occurrence carries delimiters that \
+             are not part of the recorded name, and the delimiters a new name needs \
+             depend on that new name. Rewriting the recorded spans would produce a \
+             script that no longer parses, so the rename is refused rather than guessed.",
+            name = def.name,
+        ),
+        source,
+        line_index,
+        Some(def.definition_span),
+    ))
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/rust/tcl-lsp-core/src/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/src/semantic_tokens.rs
@@ -2960,7 +2960,16 @@ fn insert_var_role_overrides(
             return;
         };
         if seg.single_token_word.get(i + 1) == Some(&true) {
-            if matches!(word.kind, TokenType::Esc) && !word.in_quote {
+            // `Str` — a brace-quoted word — is a variable *name* here just as
+            // much as a bareword is: braces suppress every substitution, so
+            // `set {$n} 1` declares the variable literally called `$n` and
+            // `[set {$n}]` reads it (tclsh 9.0.4 / 8.6.14: `info exists {$n}`
+            // → 1 while `info exists n` → 0).  Falling through painted the
+            // word as a plain `string`, hiding a declaration and inviting the
+            // reader to see the `$n` inside as a substitution (issue #1078).
+            // It is the quoting that makes such a name writable at all, so
+            // this is the *only* spelling those variables ever have.
+            if matches!(word.kind, TokenType::Esc | TokenType::Str) && !word.in_quote {
                 overrides.entry(word.span.start()).or_insert(ov);
             }
             return;

--- a/rust/tcl-lsp-core/tests/mathfunc_and_word_recognition.rs
+++ b/rust/tcl-lsp-core/tests/mathfunc_and_word_recognition.rs
@@ -879,6 +879,110 @@ proc s {a {b 1} args} { return \"s got $a $b $args\" }
 }
 
 // ---------------------------------------------------------------------------
+// Issue #1079 — a computed parameter list declares nothing the analyser can
+// model, so it registers no per-parameter `VarDef` and no arity
+// ---------------------------------------------------------------------------
+//
+// Oracle (tclsh 9.0.4 and 8.6.16, identical):
+//
+//   proc makeargs {} { return {a b} }
+//   proc p [makeargs] { return "p got $a $b" }
+//   puts [info args p]  -> a b
+//   puts [p 1 2]        -> p got 1 2
+//
+//   set params {x y}
+//   proc q $params { return "q got $x $y" }
+//   puts [q 1 2]        -> q got 1 2
+//
+// The analyser used to read the unresolved word as a *one-parameter literal*
+// and register a `VarDef` whose name is the source text (`"[makeargs]"` /
+// `"$params"`) spanning that word, plus a one-argument arity that made both
+// two-argument calls above draw a false `E003 Too many arguments`.
+
+/// TN: no `VarDef` is invented for a computed parameter-list word, in either
+/// of its two spellings.
+#[test]
+fn tn_computed_parameter_list_registers_no_variable() {
+    for (src, stub) in [
+        (
+            "proc makeargs {} { return {a b} }\nproc p [makeargs] { return \"$a$b\" }\n",
+            "[makeargs]",
+        ),
+        (
+            "set params {x y}\nproc q $params { return \"$x$y\" }\n",
+            "$params",
+        ),
+    ] {
+        let analysis = analyse(src);
+        let names: Vec<&String> = analysis.all_variables.keys().collect();
+        assert!(
+            !names.iter().any(|n| n.contains(stub)),
+            "no `VarDef` may be named after the computed word {stub:?}; got {names:?}"
+        );
+        // …and the proc itself carries no modelled parameters.
+        let proc = analysis
+            .all_procs
+            .values()
+            .find(|p| p.qualified_name == "::p" || p.qualified_name == "::q")
+            .expect("the proc is still registered");
+        assert!(
+            proc.params.is_empty() && proc.params_computed,
+            "the formals are unmodelled, not empty: {:?}",
+            proc.params
+        );
+    }
+}
+
+/// TN: with the formals unknown, the call-site arity checker abstains — the
+/// two-argument calls the oracle runs must draw no `E002`/`E003`/`E005`.
+#[test]
+fn tn_computed_parameter_list_abstains_from_arity_checking() {
+    for src in [
+        "proc makeargs {} { return {a b} }\nproc p [makeargs] { return \"$a$b\" }\nputs [p 1 2]\n",
+        "set params {x y}\nproc q $params { return \"$x$y\" }\nq 1 2\n",
+    ] {
+        let codes: Vec<String> = analyse(src)
+            .diagnostics
+            .iter()
+            .map(|d| d.code.to_string())
+            .collect();
+        assert!(
+            !codes
+                .iter()
+                .any(|c| c == "E002" || c == "E003" || c == "E005"),
+            "arity is unknowable for a computed parameter list; {src:?} emitted {codes:?}"
+        );
+    }
+}
+
+/// TP control: a *literal* parameter list — braced, bareword, or a quoted word
+/// with no substitution — still models its formals and still checks arity.
+/// tclsh 9.0.4 / 8.6.16: `proc s {a b} {…}; s 1 2 3` → `wrong # args`.
+#[test]
+fn tp_literal_parameter_lists_still_model_formals_and_arity() {
+    let src = "proc s {a b} { return \"$a$b\" }\ns 1 2 3\n";
+    let analysis = analyse(src);
+    let proc = &analysis.all_procs["::s"];
+    assert!(!proc.params_computed, "a braced list is literal");
+    assert_eq!(proc.params.len(), 2, "{:?}", proc.params);
+    let codes: Vec<String> = analysis
+        .diagnostics
+        .iter()
+        .map(|d| d.code.to_string())
+        .collect();
+    assert!(codes.iter().any(|c| c == "E003"), "{codes:?}");
+    // A quoted word with no substitution really does declare `m` and `n`
+    // (tclsh: `proc r "m n" {…}; info args r` → `m n`).
+    let quoted = analyse("proc r \"m n\" { return \"$m$n\" }\n");
+    let r = &quoted.all_procs["::r"];
+    assert!(
+        !r.params_computed,
+        "a substitution-free quoted list is literal"
+    );
+    assert_eq!(r.params.len(), 2, "{:?}", r.params);
+}
+
+// ---------------------------------------------------------------------------
 // Issue #1054 — hover type inference must be built for the document's dialect
 // ---------------------------------------------------------------------------
 

--- a/rust/tcl-lsp-core/tests/references_rename.rs
+++ b/rust/tcl-lsp-core/tests/references_rename.rs
@@ -2071,3 +2071,88 @@ fn rename_classmethod_is_scoped_in_the_other_direction_too() {
     let edits = rename(src, "tcl8.6", 8, 20, "produce", &analysis, None);
     assert_eq!(edit_lines(&edits), vec![8, 10], "{edits:?}");
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1078 — a brace-quoted `$`-bearing name is its own variable
+// ---------------------------------------------------------------------------
+//
+// tclsh 9.0.4 and 8.6.14, byte-identical:
+//
+//   set {$n} v ; set {$n}             -> v
+//   info exists {$n} / info exists n  -> 1 / 0     (two distinct variables)
+//   set n other ; set {$n}            -> v         (`n` never affects it)
+//   set ${$n}                         -> can't read "v"  (`${$n}` read `$n`)
+//
+// So `{$n}` and `n` are two cells, and an edit to one must never touch the
+// other.  Before the fix the analyser normalised `{$n}` down to `n`, merged
+// the two into one `VarDef`, and renaming the *plain* `n` emitted an edit
+// over the `{$n` span — turning `set {$n} 1` into `set q} 1`, which no longer
+// parses.
+
+/// The mixed script: line 1 writes the literal `$n`, line 2 the plain `n`,
+/// line 3 reads the plain one, line 4 reads the literal one.
+const BRACE_LITERAL_MIX: &str = "proc f {} {\n    \
+set {$n} 1\n    \
+set n 2\n    \
+puts $n\n    \
+puts [set {$n}]\n\
+}\n";
+
+#[test]
+fn references_of_the_plain_name_exclude_the_brace_literal_cell() {
+    let analysis = analyse(BRACE_LITERAL_MIX);
+    // Cursor on the `n` of `set n 2` (line 2).
+    let refs = references(BRACE_LITERAL_MIX, "tcl", 2, 8, &analysis, true);
+    assert_eq!(
+        ref_lines(&refs),
+        vec![2, 3],
+        "the plain `n`'s sites are its own write and its own `$n` read — the \
+`{{$n}}` word on line 1 is a different variable; got {refs:?}"
+    );
+}
+
+#[test]
+fn rename_of_the_plain_name_never_rewrites_a_brace_literal_word() {
+    let analysis = analyse(BRACE_LITERAL_MIX);
+    let edits = rename(BRACE_LITERAL_MIX, "tcl8.6", 2, 8, "q", &analysis, None);
+    assert_eq!(
+        edit_lines(&edits),
+        vec![2, 3],
+        "renaming `n` must leave both `{{$n}}` words alone; got {edits:?}"
+    );
+    // And the applied result is still the same program for the literal cell.
+    assert!(
+        edits
+            .iter()
+            .all(|e| e.range.start_line != 1 && e.range.start_line != 4),
+        "no edit may land on a `{{$n}}` word; got {edits:?}"
+    );
+}
+
+#[test]
+fn rename_of_a_brace_literal_name_is_refused_with_a_reason() {
+    use tcl_lsp_core::rename::rename_with_diagnosis;
+    let analysis = analyse(BRACE_LITERAL_MIX);
+    // Cursor inside the `{$n}` word on line 1.
+    let refusal = rename_with_diagnosis(BRACE_LITERAL_MIX, "tcl8.6", 1, 10, "q", &analysis, None)
+        .expect_err("a quoted-only name cannot be renamed by span substitution");
+    assert!(
+        refusal.reason.contains("$n") && refusal.reason.contains("quoted"),
+        "the refusal must name the cell and say why; got {:?}",
+        refusal.reason
+    );
+    // The refusal is typed, not an empty edit set: an empty set would fall
+    // through to the server's cross-document rename branches.
+    assert!(refusal.range.is_some(), "{refusal:?}");
+}
+
+#[test]
+fn rename_of_an_ordinary_name_is_still_allowed() {
+    // TN control for the refusal gate: it must key on the *target's* spelling,
+    // not merely on a brace-quoted word being present in the document.
+    use tcl_lsp_core::rename::rename_with_diagnosis;
+    let analysis = analyse(BRACE_LITERAL_MIX);
+    let edits = rename_with_diagnosis(BRACE_LITERAL_MIX, "tcl8.6", 2, 8, "q", &analysis, None)
+        .expect("an ordinary local is renameable");
+    assert_eq!(edit_lines(&edits), vec![2, 3], "{edits:?}");
+}

--- a/rust/tcl-lsp-core/tests/references_rename.rs
+++ b/rust/tcl-lsp-core/tests/references_rename.rs
@@ -2156,3 +2156,212 @@ fn rename_of_an_ordinary_name_is_still_allowed() {
         .expect("an ordinary local is renameable");
     assert_eq!(edit_lines(&edits), vec![2, 3], "{edits:?}");
 }
+
+// ---------------------------------------------------------------------------
+// PR #1106 review, P2 — every variable provider resolves a brace-literal
+// cursor to the literal cell (the cursor half of issue #1108)
+// ---------------------------------------------------------------------------
+//
+// The character scan behind `find_var_at_position` reports `n` for a cursor on
+// the `n` of `set {$n} 1`.  That word is brace-quoted, so Tcl substitutes
+// nothing in it: the `$n` there is not a reference to `n`, it is part of the
+// literal *name* of a different variable.  Every variable provider started
+// with that scan and short-circuited on it, so a cursor one column right of
+// the `{` stopped resolving the cell whose declaration it is sitting inside —
+// answering the unrelated plain cell where the scope gate allowed it, and
+// nothing at all where it did not.  Rename was the only one guarded.
+//
+// All five now resolve through `substituting_var_at_position`, so the `{`,
+// `$` and `n` columns of one word answer alike.
+
+/// Plain `n` declared *before* the literal cell — the ordering in which a
+/// scope-chain lookup for `n` would succeed and hand back the wrong cell.
+const BRACE_LITERAL_PLAIN_FIRST: &str = "proc f {} {\n    \
+set n 2\n    \
+puts $n\n    \
+set {$n} 1\n    \
+puts [set {$n}]\n\
+}\n";
+
+/// The literal cell alone — no `n` in scope for the mis-resolution to land on.
+const BRACE_LITERAL_ONLY: &str = "proc f {} {\n    \
+set {$n} 1\n    \
+puts [set {$n}]\n\
+}\n";
+
+fn hover_text(src: &str, line: u32, character: u32, analysis: &AnalysisResult) -> Option<String> {
+    tcl_lsp_core::hover::hover(
+        src,
+        line,
+        character,
+        analysis,
+        Some(tcl_registry::registry_for_dialect("tcl8.6")),
+    )
+    .map(|h| h.value)
+}
+
+#[test]
+fn every_variable_provider_resolves_a_brace_literal_cursor_to_the_literal_cell() {
+    // (source, line of `set {$n} 1`, the literal cell's declaration range)
+    for (label, src, decl_line) in [
+        ("plain `n` declared first", BRACE_LITERAL_PLAIN_FIRST, 3u32),
+        ("plain `n` declared after", BRACE_LITERAL_MIX, 1),
+        ("no plain `n` at all", BRACE_LITERAL_ONLY, 1),
+    ] {
+        let analysis = analyse(src);
+        // All three columns of the one word: the `{`, the `$`, the `n`.  The
+        // `{` column already worked (the character scan finds no `$` there);
+        // the other two are the regression.
+        for col in [8u32, 9, 10] {
+            let want = LspRange {
+                start_line: decl_line,
+                start_character: 8,
+                end_line: decl_line,
+                end_character: 11,
+            };
+
+            let defs = tcl_lsp_core::definition::definition(src, decl_line, col, &analysis);
+            assert_eq!(
+                defs,
+                vec![want],
+                "{label}: go-to-definition at column {col} must reach the `{{$n}}` \
+declaration"
+            );
+
+            let hover = hover_text(src, decl_line, col, &analysis)
+                .unwrap_or_else(|| panic!("{label}: hover at column {col} must resolve"));
+            assert!(
+                hover.contains("**Variable** `$n`"),
+                "{label}: hover at column {col} must name the literal cell; got {hover:?}"
+            );
+
+            let refs = references(src, "tcl8.6", decl_line, col, &analysis, true);
+            assert_eq!(
+                refs,
+                vec![want],
+                "{label}: find-references at column {col} must answer the literal cell"
+            );
+
+            // Document-highlight resolves `$ref` cursors only — it has no
+            // declaration-offset search, so it answers nothing for a *plain*
+            // bareword declaration cursor either (`set n 2` with the cursor on
+            // `n` → `[]`).  What matters here is that the braced cursor is no
+            // longer answered from the wrong cell: it now abstains exactly as
+            // the plain declaration cursor does.  Teaching that provider
+            // declaration cursors is an independent gap, not this finding.
+            let highlights = tcl_lsp_core::references::document_highlights(
+                src, "tcl8.6", decl_line, col, &analysis,
+            );
+            assert!(
+                highlights.is_empty(),
+                "{label}: document-highlight at column {col} must abstain like a \
+plain declaration cursor, not answer another cell; got {highlights:?}"
+            );
+        }
+    }
+}
+
+#[test]
+fn a_brace_literal_cursor_never_answers_the_plain_cells_sites() {
+    // FP guard for the pair above, stated the other way round: whatever the
+    // providers answer from inside `{$n}`, none of it may be a site of the
+    // unrelated plain `n` — line 1 (`set n 2`) or line 2 (`puts $n`) here.
+    let src = BRACE_LITERAL_PLAIN_FIRST;
+    let analysis = analyse(src);
+    let plain_lines = [1u32, 2];
+    for col in [8u32, 9, 10] {
+        for r in tcl_lsp_core::definition::definition(src, 3, col, &analysis) {
+            assert!(
+                !plain_lines.contains(&r.start_line),
+                "definition at column {col} leaked a plain-`n` site: {r:?}"
+            );
+        }
+        for r in references(src, "tcl8.6", 3, col, &analysis, true) {
+            assert!(
+                !plain_lines.contains(&r.start_line),
+                "references at column {col} leaked a plain-`n` site: {r:?}"
+            );
+        }
+        let hover = hover_text(src, 3, col, &analysis).unwrap_or_default();
+        assert!(
+            !hover.contains("**Variable** `n`\n"),
+            "hover at column {col} rendered the plain cell: {hover:?}"
+        );
+    }
+}
+
+#[test]
+fn a_plain_cursor_is_unaffected_by_the_shared_gate() {
+    // TN control: the ordinary `$ref` and bareword-declaration cursors keep
+    // resolving exactly as before, in a document that also holds a literal
+    // cell.  `set n 2` is line 1, its `$n` read line 2.
+    let src = BRACE_LITERAL_PLAIN_FIRST;
+    let analysis = analyse(src);
+    let decl = LspRange {
+        start_line: 1,
+        start_character: 8,
+        end_line: 1,
+        end_character: 9,
+    };
+    for (line, col) in [(1u32, 8u32), (2, 10)] {
+        assert_eq!(
+            tcl_lsp_core::definition::definition(src, line, col, &analysis),
+            vec![decl],
+            "the plain cell still resolves from ({line},{col})"
+        );
+        let hover = hover_text(src, line, col, &analysis).expect("plain hover");
+        assert!(hover.contains("**Variable** `n`"), "{hover:?}");
+        assert_eq!(
+            ref_lines(&references(src, "tcl8.6", line, col, &analysis, true)),
+            vec![1, 2],
+            "the plain cell's own sites, and only those"
+        );
+    }
+}
+
+#[test]
+fn rename_still_refuses_from_every_column_of_the_brace_literal_word() {
+    // The refusal gate resolves the same cell the other providers now do, so
+    // it fires from all three columns and names `$n` — not `n`.
+    use tcl_lsp_core::rename::rename_with_diagnosis;
+    let src = BRACE_LITERAL_PLAIN_FIRST;
+    let analysis = analyse(src);
+    for col in [8u32, 9, 10] {
+        let refusal = rename_with_diagnosis(src, "tcl8.6", 3, col, "q", &analysis, None)
+            .expect_err("a quoted-only name is refused from every column");
+        assert!(
+            refusal.reason.contains("`$n`"),
+            "column {col} must refuse for the literal cell: {:?}",
+            refusal.reason
+        );
+    }
+    // TN control: the plain cell in the same document still renames, and the
+    // edits stay off the `{$n}` words (lines 3 and 4).
+    let edits = rename(src, "tcl8.6", 1, 8, "q", &analysis, None);
+    assert_eq!(edit_lines(&edits), vec![1, 2], "{edits:?}");
+}
+
+#[test]
+fn genuinely_inert_dollar_shapes_still_resolve_to_nothing() {
+    // TN control for hoisting the inert-text proof into the shared gate
+    // (issue #923 idx 24): a `$v`-shaped substring Tcl never substitutes is
+    // still not a reference, in a data brace or a comment.
+    for (src, line, col) in [
+        ("set v 1\nputs {plain $v here}\n", 1u32, 14u32),
+        ("set v 1\nputs hi ;# note $v\n", 1, 18),
+    ] {
+        let analysis = analyse(src);
+        assert!(
+            tcl_lsp_core::definition::definition(src, line, col, &analysis).is_empty(),
+            "{src:?} at ({line},{col}) must stay suppressed"
+        );
+        assert!(
+            hover_text(src, line, col, &analysis).is_none(),
+            "{src:?} at ({line},{col}) must stay suppressed"
+        );
+        assert!(
+            references(src, "tcl8.6", line, col, &analysis, true).is_empty(),
+            "{src:?} at ({line},{col}) must stay suppressed"
+        );
+    }
+}

--- a/rust/tcl-lsp-core/tests/semantic_tokens.rs
+++ b/rust/tcl-lsp-core/tests/semantic_tokens.rs
@@ -1551,3 +1551,65 @@ fn bigip_conf_embedded_rule_body_is_tokenised_as_irules() {
         "an object reference in an embedded rule must read as an object: {seen:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Issue #1078 — a brace-quoted variable-name word is a variable, not a string
+// ---------------------------------------------------------------------------
+//
+// tclsh 9.0.4 / 8.6.14, byte-identical: `set {$n} v; info exists {$n}` → 1
+// while `info exists n` → 0, so `{$n}` names a real variable — and quoting is
+// the *only* way that variable can ever be written.  Painting the word as a
+// plain `string` hid the declaration and invited the reader to see the `$n`
+// inside as a substitution.
+
+#[test]
+fn brace_quoted_variable_name_word_paints_as_a_variable() {
+    let src = "proc f {} {\n    set {$n} 1\n    set n 2\n    puts [set {$n}]\n}\n";
+    let toks = decode(src, "tcl8.6");
+    let declaration_bit = legend_token_modifiers()
+        .iter()
+        .position(|m| *m == "declaration")
+        .map(|i| 1u32 << i)
+        .expect("legend carries `declaration`");
+
+    // The write target on line 1 — the whole `{$n}` word, tagged exactly like
+    // the plain `n` write on line 2.
+    let write = toks
+        .iter()
+        .find(|t| t.line == 1 && t.character == 8)
+        .expect("a token at the `{$n}` write word");
+    assert_eq!(write.ttype, "variable", "{write:?}");
+    assert_eq!(write.length, 4, "the whole `{{$n}}` word: {write:?}");
+    assert!(
+        write.mods & declaration_bit != 0,
+        "a write target is a declaration: {write:?}"
+    );
+    let plain_write = toks
+        .iter()
+        .find(|t| t.line == 2 && t.character == 8)
+        .expect("a token at the `n` write word");
+    assert_eq!(
+        (
+            plain_write.ttype.as_str(),
+            plain_write.mods & declaration_bit != 0
+        ),
+        (write.ttype.as_str(), true),
+        "the braced and plain write targets must be tagged alike"
+    );
+
+    // The one-arg read on line 3 — a variable *reference*, not a declaration.
+    let read = toks
+        .iter()
+        .find(|t| t.line == 3 && t.character == 14)
+        .expect("a token at the `{$n}` read word");
+    assert_eq!(read.ttype, "variable", "{read:?}");
+    assert_eq!(read.length, 4, "{read:?}");
+
+    // TN control: a brace-quoted word that is *not* in a variable-name role
+    // stays a string — the retag keys on the registry role, not on braces.
+    assert_eq!(
+        kind_of_word("puts {$n}\n", "tcl8.6", "{$n}").as_deref(),
+        Some("string"),
+        "`puts`'s argument is data, not a variable name"
+    );
+}

--- a/rust/tcl-syntax/src/naming.rs
+++ b/rust/tcl-syntax/src/naming.rs
@@ -426,11 +426,47 @@ pub fn element_var_name(name: &str) -> &str {
     element_var_name_braced(name, false)
 }
 
-/// [`element_var_name`] for a write-target word whose braced-ness is known
-/// from the lowering (`set {a($x)} v` — the braces suppressed substitution,
-/// so the key is literal even though it spells `$x`).
+/// [`element_var_name`] for a word whose **delimiters make its content a
+/// literal name** — a brace-quoted write target (`set {a($x)} v`) or the
+/// `${…}` reference form, both of which suppress every substitution inside.
+///
+/// With `braced_literal` set, the content **is** the variable name, verbatim:
+/// no `$` sigil to strip, no `${…}` form to unwrap, and the array key is
+/// literal whatever it spells.  Tcl keeps such a name distinct from the
+/// `$`-less one it looks like (tclsh 9.0.4 / 8.6.14, byte-identical):
+///
+/// ```text
+/// set {$n} v ; set {$n}   -> v
+/// info exists {$n} / n    -> 1 / 0     (two different variables)
+/// set n other ; set {$n}  -> v         (unaffected)
+/// set i 5 ; set {arr($i)} 1
+/// array names arr         -> {$i}      (the literal key, not `arr(5)`)
+/// info exists arr(5)      -> 0
+/// ```
+///
+/// Stripping the sigil here (issue #1078) keyed every consumer — defs, reads,
+/// W210/W211/W220, rename, semantic highlighting — on the wrong variable.
+///
+/// ```
+/// use tcl_syntax::naming::element_var_name_braced;
+/// // A brace-quoted word: the content is the name, verbatim.
+/// assert_eq!(element_var_name_braced("$n", true), "$n");
+/// assert_eq!(element_var_name_braced("${n}", true), "${n}");
+/// assert_eq!(element_var_name_braced("a b", true), "a b");
+/// assert_eq!(element_var_name_braced("arr($i)", true), "arr($i)");
+/// assert_eq!(element_var_name_braced("$arr(k)", true), "$arr(k)");
+/// // Unbraced: the ordinary substituting spellings.
+/// assert_eq!(element_var_name_braced("$n", false), "n");
+/// assert_eq!(element_var_name_braced("$arr($i)", false), "arr");
+/// ```
 #[must_use]
 pub fn element_var_name_braced(name: &str, braced_literal: bool) -> &str {
+    if braced_literal {
+        // The delimiters suppressed every substitution, so the content is the
+        // whole name — including a leading `$` and any `(key)`, which is
+        // literal by construction.
+        return name;
+    }
     // `${…}` brace form: the inner text is the whole (literal) name.
     if let Some(after) = name.strip_prefix("${")
         && let Some(rel) = after.find('}')
@@ -439,9 +475,90 @@ pub fn element_var_name_braced(name: &str, braced_literal: bool) -> &str {
     }
     let base = name.strip_prefix('$').unwrap_or(name);
     match split_array_name(name) {
-        (_, Some(key)) if braced_literal || array_key_is_literal(key) => base,
+        (_, Some(key)) if array_key_is_literal(key) => base,
         _ => normalise_var_name(name),
     }
+}
+
+/// [`normalise_var_name`] for a word whose delimiters make its content a
+/// literal name — see [`element_var_name_braced`] for the oracle.
+///
+/// The *base* name, so an array element still loses its `(key)` suffix
+/// (`{arr($i)}` is element `$i` of the array `arr`); what a braced word does
+/// **not** lose is its substitution sigil, because there was no substitution:
+/// `{$n}` names the variable `$n`, and `{$arr(k)}` element `k` of the array
+/// `$arr`.
+///
+/// ```
+/// use tcl_syntax::naming::normalise_var_name_braced;
+/// assert_eq!(normalise_var_name_braced("$n", true), "$n");
+/// assert_eq!(normalise_var_name_braced("${n}", true), "${n}");
+/// assert_eq!(normalise_var_name_braced("arr($i)", true), "arr");
+/// assert_eq!(normalise_var_name_braced("$arr(k)", true), "$arr");
+/// assert_eq!(normalise_var_name_braced("$n", false), "n");
+/// ```
+#[must_use]
+pub fn normalise_var_name_braced(name: &str, braced_literal: bool) -> &str {
+    if !braced_literal {
+        return normalise_var_name(name);
+    }
+    split_array_name_braced(name, true).0
+}
+
+/// [`split_array_name`] for a word whose delimiters make its content a
+/// literal name — see [`element_var_name_braced`] for the oracle.
+///
+/// ```
+/// use tcl_syntax::naming::split_array_name_braced;
+/// assert_eq!(split_array_name_braced("arr($i)", true), ("arr", Some("$i")));
+/// assert_eq!(split_array_name_braced("$n", true), ("$n", None));
+/// assert_eq!(split_array_name_braced("$arr(k)", true), ("$arr", Some("k")));
+/// assert_eq!(split_array_name_braced("$arr(k)", false), ("arr", Some("k")));
+/// ```
+#[must_use]
+pub fn split_array_name_braced(name: &str, braced_literal: bool) -> (&str, Option<&str>) {
+    if !braced_literal {
+        return split_array_name(name);
+    }
+    if name.ends_with(')')
+        && let Some(idx) = name.find('(')
+    {
+        return (&name[..idx], Some(&name[idx + 1..name.len() - 1]));
+    }
+    (name, None)
+}
+
+/// Whether a variable's **name** can only ever appear in source inside
+/// quoting — `{$n}` / `${$n}`, `{a b}` / `${a b}` — because writing it bare
+/// would substitute, split the word, or end the command.
+///
+/// Such a name is legal and distinct in Tcl (`set {$n} v` creates the
+/// variable `$n`, unrelated to `n`), but every occurrence of it carries
+/// delimiters that are *not* part of the recorded name span, and the
+/// delimiters a **new** name needs depend on that new name.  A rewrite is
+/// therefore not a matter of substituting new text into the recorded spans,
+/// which is what the rename edit builder does — so rename refuses instead of
+/// emitting an edit set that would produce `set q} 1` (issue #1078).
+///
+/// A namespace-qualified bareword (`::ns::v`) needs no quoting; neither does
+/// an array element whose base and key are barewords (`arr(k)`), since it is
+/// keyed by its base.
+///
+/// ```
+/// use tcl_syntax::naming::var_name_requires_quoting;
+/// assert!(var_name_requires_quoting("$n"));
+/// assert!(var_name_requires_quoting("a b"));
+/// assert!(var_name_requires_quoting("[gen]"));
+/// assert!(!var_name_requires_quoting("n"));
+/// assert!(!var_name_requires_quoting("::ns::v"));
+/// assert!(!var_name_requires_quoting("arr"));
+/// ```
+#[must_use]
+pub fn var_name_requires_quoting(name: &str) -> bool {
+    name.is_empty()
+        || name.contains([
+            '$', '[', ']', '{', '}', '"', '\\', ';', ' ', '\t', '\n', '\r',
+        ])
 }
 
 /// Return `true` when `${name}` would successfully look up `name` under the
@@ -1244,6 +1361,86 @@ mod tests {
         assert_eq!(split_array_name("a($i)"), ("a", Some("$i")));
         // a `)` with no `(` is not an element.
         assert_eq!(split_array_name("weird)"), ("weird)", None));
+    }
+
+    /// Issue #1078 — the full brace-literal spelling matrix, pinned against
+    /// tclsh 9.0.4 and 8.6.14 (byte-identical transcripts):
+    ///
+    /// ```text
+    /// set {$n} v ; set {$n}          -> v
+    /// info exists {$n} / n           -> 1 / 0      (distinct variables)
+    /// set n other ; set {$n}         -> v          (unaffected)
+    /// set ${$n}                      -> can't read "v"   (`${$n}` read `$n`)
+    /// set {a b} v2 ; set x ${a b}    -> v2         (space in a legal name)
+    /// set i 5 ; set {arr($i)} 1
+    ///   array names arr              -> {$i}       (literal key)
+    ///   info exists arr(5)           -> 0
+    ///   set arr($i) 2 ; array names arr -> {$i} 5  (two distinct elements)
+    /// unset {$n} ; info exists {$n} / n -> 0 / 1
+    /// ```
+    #[test]
+    fn brace_literal_names_keep_their_sigil() {
+        // Element-qualified (SSA / def-use) naming.
+        assert_eq!(element_var_name_braced("$n", true), "$n");
+        assert_eq!(element_var_name_braced("${n}", true), "${n}");
+        assert_eq!(element_var_name_braced("a b", true), "a b");
+        assert_eq!(element_var_name_braced("arr($i)", true), "arr($i)");
+        assert_eq!(element_var_name_braced("$arr(k)", true), "$arr(k)");
+        assert_eq!(element_var_name_braced("[gen]", true), "[gen]");
+        // Base-name (scope / analyser) naming: the element suffix still comes
+        // off, the sigil does not.
+        assert_eq!(normalise_var_name_braced("$n", true), "$n");
+        assert_eq!(normalise_var_name_braced("${n}", true), "${n}");
+        assert_eq!(normalise_var_name_braced("a b", true), "a b");
+        assert_eq!(normalise_var_name_braced("arr($i)", true), "arr");
+        assert_eq!(normalise_var_name_braced("$arr(k)", true), "$arr");
+        assert_eq!(
+            split_array_name_braced("$arr(k)", true),
+            ("$arr", Some("k"))
+        );
+        assert_eq!(split_array_name_braced("$n", true), ("$n", None));
+    }
+
+    /// TN control for [`brace_literal_names_keep_their_sigil`]: the *unbraced*
+    /// spellings are genuine substitutions and must keep normalising, or the
+    /// fix would blind every ordinary `$x` read.
+    #[test]
+    fn unbraced_names_still_normalise() {
+        assert_eq!(element_var_name_braced("$n", false), "n");
+        assert_eq!(element_var_name_braced("${n}", false), "n");
+        assert_eq!(element_var_name_braced("$arr($i)", false), "arr");
+        assert_eq!(element_var_name_braced("$arr(k)", false), "arr(k)");
+        assert_eq!(normalise_var_name_braced("$n", false), "n");
+        assert_eq!(normalise_var_name_braced("$arr(k)", false), "arr");
+        assert_eq!(
+            split_array_name_braced("$arr(k)", false),
+            ("arr", Some("k"))
+        );
+        // The `${…}` *reference* form already carried the rule: its content is
+        // the literal name whichever flag the caller passes.
+        assert_eq!(element_var_name("${$n}"), "$n");
+        assert_eq!(element_var_name("${arr($i)}"), "arr($i)");
+        assert_eq!(normalise_var_name("${$n}"), "$n");
+    }
+
+    /// The rename gate's predicate (issue #1078): a name that can only be
+    /// written quoted is not renameable by span substitution.
+    #[test]
+    fn quoting_requirement_matches_the_writable_spellings() {
+        for needs in [
+            "$n", "${n}", "a b", "[gen]", "a\tb", "x;y", "q\"r", "", "a\\b",
+        ] {
+            assert!(
+                var_name_requires_quoting(needs),
+                "{needs:?} can only be written quoted"
+            );
+        }
+        for plain in ["n", "::ns::v", "arr", "arr(k)", "_x1", "caf\u{e9}"] {
+            assert!(
+                !var_name_requires_quoting(plain),
+                "{plain:?} is writable bare"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

PR D1 — the naming layer's spelling-fidelity pass, landing across defs, reads, diagnostics, rename, and semantic highlighting together (the one-parameter fix measured and reverted in #1076 is the acceptance baseline). Full oracle spelling matrix pinned byte-identical on 9.0.4/8.6.14, including the proof row: `set {$n} v; set ${$n}` errors with `can't read "v"` — the `${…}` read form resolves the **braced** `$n` cell, not plain `n`.

- **#1078 — a brace-quoted `$`-bearing name is its own variable.** `element_var_name_braced` returned the content normalised to `n`, merging the `{$n}` cell with plain `n` in every consumer. Pre-fix measurements: false W210/W213 on `n`, the real `puts $n` error unmodelled, references answering the merged set, semantic tokens painting the cell as a string, and rename producing the unparseable `set q} 1`. The spelling rule now lives centrally in `tcl-syntax::naming` (verbatim under `braced_literal`, sigil-preserving element split), with one shared `arg_is_braced_literal` replacing three forked copies, threaded through SSA target classification, all lowering hooks, the reference scanners, and the analyser. **The #1076 acceptance measurements flip:** the missed TP (`set {$m} 1; puts $m` — tclsh errors) now fires W210 for the right reason; the two false W220s are gone with braced-vs-plain diagnostic parity asserted byte-for-byte; the #1076 barrier tests pass untouched. Renaming a name that only exists in quoted form refuses with a typed reason (#1091 precedent) instead of emitting a destructive edit. Two adjacent recoveries improve the plain spelling too: `[set {…}]` reads recognised, and `return`'s value word finally scanned for hidden reads (narrowly — the over-approximating alternative would have silenced an existing TN control).
- **#1079 — computed parameter lists register nothing.** `proc p [makeargs] {}` registered a stub VarDef literally named `"[makeargs]"` — and, unreported in the issue, the arity checker did **not** abstain: both two-argument calls tclsh runs drew a false E003. `ProcDef::params_computed` now makes the params unknown-not-none; `arity()` abstains centrally at `0..unlimited`; a substitution-free quoted list (`proc r "m n"`) correctly stays literal. The now-dead #1073 suppressions in `position_definition`/`variable_hover` are removed, with their regression tests passing unmodified.

**Residuals filed rather than half-fixed:** #1107 (the signature-scan tier's identical stub + the `Computed` classifier divergence), #1108 (variable reference completeness: `[set X]` reads unrecorded in scope refs, braced-word cursor answers empty), #1109 (`dollar_reads_in_cmd_subs` over-approximates braced names inside `[…]`, needs registry access to discriminate).

## Validation

- [x] `cargo test --workspace --all-features` — **311 binaries, 15,369 passed, 0 failed** (first attempt hit ENOSPC at 20G; discarded per campaign discipline, clean rebuild re-run — the figure is from the clean run).
- [x] Consumer-by-consumer TP/FP/TN/FN coverage: naming-helper matrices + doctests, W210/W211/W213/W220 acceptance tests (including plain-control byte-equality), the #1076 barrier interaction pins, rename refusal + destructive-edit FP guard, semantic-token parity + `puts {$n}` TN, and the #1079 arity abstention pair.
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings` clean, **zero new allows**; `cargo fmt --all --check` clean; `make xtask-check` all OK.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — braced-literal spellings are now distinct variable identities across the SSA/def-use/scope models; `ProcDef::params_computed` is a new fact; E003 abstains for computed parameter lists.
- [x] KCS notes updated: W220 (braced-literal vs computed distinction), E003 (computed-list abstention), rename (quoted-name refusal), semantic-tokens (variable-role painting); `ssa-construction.md`'s "Known limitation" replaced with the full rule + measurements.
- [ ] New compiler KCS note linked. (n/a — existing notes updated)

Closes #1078. Closes #1079.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7