### PR TITLE
lsp-client harness: wait for the workspace scan before cross-file assertions (#1094)

### DIFF
--- a/.claude/skills/lsp-client/SKILL.md
+++ b/.claude/skills/lsp-client/SKILL.md
@@ -53,11 +53,13 @@ All line/col arguments are **0-based**, matching the LSP protocol.
 
 ### Cross-file assertions
 
-`definition`, `references`, `diagnostics`, `code-actions`, `context`, and
-`all` wait for the server's background workspace scan to finish before
+`definition`, `references`, `diagnostics`, `code-actions`, `context`,
+`all`, `completion`, and `code-lens` wait for the server's background
+workspace scan to finish before
 proceeding (bounded by `--scan-timeout`, default 15s) — otherwise
 cross-file results (workspace variables, package tiers, cross-file
-definition/references) are racy depending on scan timing (issue #1094).
+definition/references, sibling-file completions, workspace-wide lens
+counts) are racy depending on scan timing (issue #1094).
 Other subcommands are single-file and unaffected. If you add a new
 cross-file check, call `client.wait_for_workspace_scan()` yourself before
 opening the document(s) it depends on — see the method's docstring in

--- a/.claude/skills/lsp-client/SKILL.md
+++ b/.claude/skills/lsp-client/SKILL.md
@@ -51,6 +51,19 @@ The script auto-detects the `tcl-lsp/` server directory.  Override with
 
 All line/col arguments are **0-based**, matching the LSP protocol.
 
+### Cross-file assertions
+
+`definition`, `references`, `diagnostics`, `code-actions`, `context`, and
+`all` wait for the server's background workspace scan to finish before
+proceeding (bounded by `--scan-timeout`, default 15s) — otherwise
+cross-file results (workspace variables, package tiers, cross-file
+definition/references) are racy depending on scan timing (issue #1094).
+Other subcommands are single-file and unaffected. If you add a new
+cross-file check, call `client.wait_for_workspace_scan()` yourself before
+opening the document(s) it depends on — see the method's docstring in
+`lsp_client.py` for the exact signal it waits on and why waiting *before*
+`didOpen` matters for diagnostics specifically.
+
 ## Interpreting Output
 
 ### Semantic Tokens

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -23,13 +23,14 @@ Starts the server, sends LSP requests, and prints human-readable results.
 Uses only the Python standard library — no external dependencies.
 
 Cross-file assertions (definition/references/diagnostics/code-actions/
-context/all touching more than one file's worth of state — workspace
-variables, package tiers) wait out the server's background workspace scan
+context/all/completion/code-lens touching more than one file's worth of
+state — workspace variables, package tiers, sibling-file completions,
+workspace-wide lens counts) wait out the server's background workspace scan
 first via `LspClient.wait_for_workspace_scan()` (bounded by --scan-timeout,
 default 15s) rather than racing it — see issue #1094 and that method's
 docstring for the exact server-side signal it waits on. Single-file
-subcommands (semantic-tokens, hover, completion, format, ...) are
-unaffected and don't wait.
+subcommands (semantic-tokens, hover, format, ...) are unaffected and
+don't wait.
 
 Usage:
     python3 lsp_client.py semantic-tokens <file.tcl>
@@ -176,6 +177,10 @@ COMPLETION_KIND = {
 # would just race that republish instead. So for these, `main()` waits
 # *before* `open_document()`, ensuring the first (and only) diagnostics
 # publish already sees the fully-populated workspace state.
+# `completion` and `code-lens` also read `workspace_index` per-request
+# (completion enumerates sibling-file procedures; lenses count
+# workspace-wide references), so they wait too — before `didOpen` via
+# `main()`, which is also sufficient for their per-request reads.
 CROSS_FILE_COMMANDS = {
     "definition",
     "references",
@@ -183,6 +188,8 @@ CROSS_FILE_COMMANDS = {
     "code-actions",
     "context",
     "all",
+    "completion",
+    "code-lens",
 }
 
 SYMBOL_KIND = {

--- a/.claude/skills/lsp-client/lsp_client.py
+++ b/.claude/skills/lsp-client/lsp_client.py
@@ -22,6 +22,15 @@
 Starts the server, sends LSP requests, and prints human-readable results.
 Uses only the Python standard library — no external dependencies.
 
+Cross-file assertions (definition/references/diagnostics/code-actions/
+context/all touching more than one file's worth of state — workspace
+variables, package tiers) wait out the server's background workspace scan
+first via `LspClient.wait_for_workspace_scan()` (bounded by --scan-timeout,
+default 15s) rather than racing it — see issue #1094 and that method's
+docstring for the exact server-side signal it waits on. Single-file
+subcommands (semantic-tokens, hover, completion, format, ...) are
+unaffected and don't wait.
+
 Usage:
     python3 lsp_client.py semantic-tokens <file.tcl>
     python3 lsp_client.py diagnostics <file.tcl>
@@ -110,6 +119,23 @@ SEMANTIC_TOKEN_MODIFIERS = [
 
 LSP_SEVERITY = {1: "ERROR", 2: "WARNING", 3: "INFO", 4: "HINT"}
 
+# The one documented, intentional readiness signal for the background
+# workspace scan (`Backend::scan_workspace_folders` in
+# rust/tcl-lsp-server/src/lib.rs). It fires exactly once, after
+# `package_resolver` / `workspace_index` have been (re)built from disk —
+# unconditionally, even for a zero-root / single-file session — via a
+# `window/logMessage` notification (MessageType::LOG). The server's own doc
+# comment on that call site says explicitly: "a client (or a test) that
+# needs to know the autoload / cross-file workspace state is current rather
+# than racing this scan should wait on this line instead of an unrelated
+# per-document signal (issue #1003)". See issue #1094.
+#
+# NOT the same marker as `[timing] workspace_state.update`, which is a
+# *per-document* diagnostics-publish timing line (fires once per open
+# document, unrelated to workspace-scan completion) — waiting on that one
+# instead is the exact confusion issue #1094 warns against.
+WORKSPACE_SCAN_SIGNAL = "[timing] workspace_folders_scan"
+
 COMPLETION_KIND = {
     1: "Text",
     2: "Method",
@@ -136,6 +162,27 @@ COMPLETION_KIND = {
     23: "Event",
     24: "Operator",
     25: "TypeParameter",
+}
+
+# Subcommands whose results can depend on cross-file workspace state
+# (workspace variables, package tiers — issue #1094): `definition` and
+# `references` query `workspace_index` directly per-request, so waiting
+# right before the request (see `cmd_definition`/`cmd_references`) is
+# sufficient. `diagnostics`, `code-actions`, `context`, and `all` are
+# different: diagnostics are *pushed* once, right after `didOpen`, and only
+# get republished once the scan completes if the doc was already open when
+# `initialized` fired (see `initialized`'s "reschedule every open document"
+# comment in rust/tcl-lsp-server/src/lib.rs) — waiting *after* `didOpen`
+# would just race that republish instead. So for these, `main()` waits
+# *before* `open_document()`, ensuring the first (and only) diagnostics
+# publish already sees the fully-populated workspace state.
+CROSS_FILE_COMMANDS = {
+    "definition",
+    "references",
+    "diagnostics",
+    "code-actions",
+    "context",
+    "all",
 }
 
 SYMBOL_KIND = {
@@ -392,6 +439,57 @@ class LspClient:
                     continue
                 messages.append(params.get("message", ""))
         return messages
+
+    def wait_for_workspace_scan(self, timeout: float = 15.0) -> str:
+        """Block until the server's initial background workspace scan completes.
+
+        Cross-file navigation (`textDocument/definition`,
+        `textDocument/references`) and cross-file diagnostics (workspace
+        variable / package-tier resolution, W120/W123) read
+        `workspace_index` / `package_resolver`, which
+        `Backend::scan_workspace_folders` populates in the background —
+        kicked off from the `initialized` handler, running concurrently
+        with whatever `didOpen` the client sends next. Asserting before
+        that scan lands is issue #1094: results flip between "resolved"
+        and "unresolved" depending on scan timing.
+
+        Waits for the `[timing] workspace_folders_scan` `window/logMessage`
+        line (see `WORKSPACE_SCAN_SIGNAL` above) — the scan's one
+        documented readiness signal, always emitted exactly once per scan
+        regardless of workspace size (even a zero-root session gets it).
+        Call this *before* `open_document()` / navigation requests for any
+        assertion that depends on cross-file state; calling it again after
+        the signal has already arrived returns immediately (cheap to call
+        defensively from multiple places).
+
+        Raises TimeoutError with a pointer back to the server-side signal
+        and this issue if the line never arrives within *timeout* seconds.
+        """
+        deadline = time.monotonic() + timeout
+        while True:
+            for msg in self.get_log_messages():
+                if WORKSPACE_SCAN_SIGNAL in msg:
+                    return msg
+            # Defensive: also accept a plain stderr echo of the same line,
+            # in case the server (or a future build) mirrors log messages
+            # there in addition to `window/logMessage`.
+            for line in self.get_stderr_lines():
+                if WORKSPACE_SCAN_SIGNAL in line:
+                    return line
+            if time.monotonic() >= deadline:
+                break
+            time.sleep(0.05)
+        raise TimeoutError(
+            f"Timed out after {timeout}s waiting for the server's workspace "
+            f"scan to complete — no {WORKSPACE_SCAN_SIGNAL!r} window/logMessage "
+            "was seen. Cross-file navigation/diagnostics results read here "
+            "would be racy (issue #1094). If this is a legitimately large "
+            "workspace, pass a higher --scan-timeout; otherwise check that "
+            "the server actually reached `scan_workspace_folders` (see "
+            "rust/tcl-lsp-server/src/lib.rs) — e.g. it never got past "
+            "`initialized` because a server-to-client request went "
+            "unanswered."
+        )
 
     def clear_timing(self) -> None:
         """Clear collected stderr lines and notifications for fresh measurement."""
@@ -1020,7 +1118,14 @@ def cmd_completion(client: LspClient, uri: str, line: int, col: int) -> None:
 
 
 def cmd_definition(client: LspClient, uri: str, line: int, col: int) -> None:
-    """Request and display definitions."""
+    """Request and display definitions.
+
+    A "navigation request" per issue #1094: waits out the background
+    workspace scan first (idempotent/cheap if `main()` already did) so a
+    cross-file definition isn't raced. Belt-and-suspenders for callers that
+    invoke this directly rather than through `main()`.
+    """
+    client.wait_for_workspace_scan()
     result = client.send_request(
         "textDocument/definition",
         {
@@ -1034,7 +1139,14 @@ def cmd_definition(client: LspClient, uri: str, line: int, col: int) -> None:
 
 
 def cmd_references(client: LspClient, uri: str, line: int, col: int) -> None:
-    """Request and display references."""
+    """Request and display references.
+
+    A "navigation request" per issue #1094: waits out the background
+    workspace scan first (idempotent/cheap if `main()` already did) so
+    cross-file references aren't raced. Belt-and-suspenders for callers
+    that invoke this directly rather than through `main()`.
+    """
+    client.wait_for_workspace_scan()
     result = client.send_request(
         "textDocument/references",
         {
@@ -1549,6 +1661,17 @@ examples:
         "--server-bin",
         help="Path to the native tcl-lsp-server binary (for --server rust; else auto-detected).",
     )
+    parser.add_argument(
+        "--scan-timeout",
+        type=float,
+        default=15.0,
+        help=(
+            "Seconds to wait for the background workspace scan to complete "
+            "before cross-file subcommands (definition, references, "
+            "diagnostics, code-actions, context, all) proceed. See "
+            "issue #1094. Default: 15.0."
+        ),
+    )
 
     sub = parser.add_subparsers(dest="command", required=True)
 
@@ -1726,6 +1849,15 @@ examples:
                     "workspace/didChangeConfiguration",
                     {"settings": {"tclLsp": {"dialect": dialect}}},
                 )
+
+            # Cross-file-sensitive commands: wait out the background
+            # workspace scan *before* opening the document, so the doc's
+            # one diagnostics publish (and any definition/references
+            # request issued below) already sees the fully-populated
+            # workspace_index / package_resolver instead of racing the
+            # scan (issue #1094).
+            if args.command in CROSS_FILE_COMMANDS:
+                client.wait_for_workspace_scan(timeout=args.scan_timeout)
 
             uri, content = open_document(client, args.file)
 


### PR DESCRIPTION
## Summary

PR D6 — fixes #1094's workspace-scan race in the Python harness, taking the wait-for-signal option because a real, documented signal exists: `scan_workspace_folders()` logs `[timing] workspace_folders_scan …` exactly once at scan end, and its doc comment explicitly names it the readiness signal clients should wait on (issue #1003). It fires unconditionally, so no special-casing. Notably the issue's suggested marker (`workspace_state.update`) is a *different*, per-document publish-timing line — the distinction is now documented in code comments so the mix-up isn't repeated. Confirmed no `$/progress` is ever emitted (grepped all progress machinery; only request-parameter scaffolding exists).

- `LspClient.wait_for_workspace_scan(timeout)` polls captured `window/logMessage` notifications (stderr fallback), raising a `TimeoutError` that points at #1094 and the server-side signal.
- Cross-file paths call it automatically: `main()` before `open_document()` for `diagnostics`/`code-actions`/`context`/`all` (waiting *before* `didOpen` — diagnostics are pushed once after `didOpen` and only republished post-scan for documents already open at `initialized`, so waiting after would race the republish), and `cmd_definition`/`cmd_references` directly (idempotent) for callers bypassing `main()`.
- New `--scan-timeout` flag (default 15s). Single-file subcommands untouched.
- SKILL.md documents the pattern for anyone adding multi-file helpers.

## Validation

- [x] Python-only change; no server binary was available in the sandbox, so: `py_compile` + ruff check/format clean; a 7-test unittest suite against a real `LspClient` with faked notification/stderr buffers (immediate return on present signal, threaded delivery, wrong-marker ignored → timeout, stderr-mirrored acceptance); and an end-to-end run against a fake JSON-RPC subprocess server — `definition` waits out a simulated scan delay (timing-confirmed), times out cleanly with exit 1 at short `--scan-timeout`, `hover` unaffected.
- [x] Grepped for other harness users: only SKILL.md (updated) and a historical STATUS.md design note — which records a prior real instance of this bug class (a false "cross-file resolution is broken" report), corroborating the hazard.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [ ] Did this change alter a compiler fact contract? No — test-harness only, no Rust touched.
- [ ] KCS notes: n/a (SKILL.md carries the usage contract).
- [ ] New compiler KCS note linked: n/a.

Closes #1094.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7

---
_Generated by [Claude Code](https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7)_