### PR TITLE
Namespace names as navigable symbols (#1088, audit idx 75 secondary claim)

### DIFF
--- a/README.md
+++ b/README.md
@@ -603,7 +603,10 @@ wherever those live, since reopening a namespace extends the same one. A
 relative name resolves against the namespace it is written in, exactly as
 Tcl does. Words that only look like namespace names are left alone:
 `namespace tail` / `qualifiers` take arbitrary strings, `import` / `export`
-/ `forget` take glob patterns, and `origin` / `which` name commands.
+/ `forget` take glob patterns, and `origin` / `which` name commands. A
+namespace whose name also happens to be a command's never resolves to that
+command — the two are different kinds of symbol — and renaming a namespace
+is refused with a reason rather than quietly renaming the command instead.
 
 ### Signature help
 

--- a/README.md
+++ b/README.md
@@ -595,6 +595,16 @@ whatever the surrounding scope supplies, which is a within-file question, so
 it is never widened to a same-named variable somewhere else in the
 workspace.
 
+Namespace **names** navigate too. The `::tomato` of `namespace children
+::tomato`, `namespace exists`, `namespace delete`, `namespace upvar`, or a
+second `namespace eval ::tomato { … }` block jumps to — and hovers, and
+finds references for — every `namespace eval` block that declares it,
+wherever those live, since reopening a namespace extends the same one. A
+relative name resolves against the namespace it is written in, exactly as
+Tcl does. Words that only look like namespace names are left alone:
+`namespace tail` / `qualifiers` take arbitrary strings, `import` / `export`
+/ `forget` take glob patterns, and `origin` / `which` name commands.
+
 ### Signature help
 
 As you type arguments, the server shows the expected parameter list with the

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -20,6 +20,7 @@ entry has an identity another document can spell:
 | `invocations` | every call site, with its ordered resolution candidates | — |
 | `variables` | namespace- and global-scope variable declarations | **qualified name only** |
 | `variable_refs` | occurrences written with a `::` qualifier | **qualified name only** |
+| `namespace_refs` | every word naming a namespace, declaring or not | qualified name (rooted at record time) |
 | `sources` / `package_requires` / `command_links` / `glob_imports` / `namespace_exports` | the cross-file graph edges | — |
 
 `glob_imports` and `namespace_exports` each carry their document **and their
@@ -66,6 +67,42 @@ The `variable_refs` rows come from `qualified_var_refs`, which the analyser
 (`tcl_compiler::analyser::QualifiedVarRef`) records whether or not the named
 cell resolves in the recording document: the cross-file case is precisely
 the one where it does not.
+
+### The namespace tier
+
+`namespace_refs` (issue #1088) holds one row per word the registry marks
+`ArgRole::NamespaceName`: the `namespace eval` target that **declares** a
+namespace (`declares: true`, from `Traits::DECLARES_NAMESPACE`) and every
+other spelling of it — `namespace children`, `exists`, `delete`, `parent`,
+`upvar`, `inscope`.  One table rather than two, because a namespace's
+declaring site *is* one of its spellings: it is both what go-to-definition
+answers with and a word find-references reports.
+
+This tier needs **no** qualified-only bound, unlike the variable one.  A
+namespace word roots against the command-resolution namespace in force where
+it is written, and that is a lexical fact the recording document already
+knows, so `tcl_compiler::analyser::NamespaceRef` stores the rooted name and
+every indexed row names one namespace absolutely.  Two consequences the
+providers rely on: a relative `inner` inside `namespace eval ::outer` is
+indexed as `::outer::inner` and matches a sibling document's
+`::outer::inner` exactly; and the index never has to re-derive the rooting
+rule, so it cannot disagree with the same-document resolver
+(`tcl_lsp_core::namespace_symbol::namespace_cell_at`, the single entry point
+definition, hover, and references all answer through).
+
+Two shapes are deliberately absent.  A **computed** target (`namespace eval
+$ns { … }`) names no static namespace and is recorded nowhere.  A namespace
+that exists only as an implicit **parent** — `namespace eval ::p::q::r {}`
+really does create `::p` and `::p::q` on tclsh 9.0.4 and 8.6.16 alike — has
+no declaring row, because its name is written nowhere; definition abstains
+rather than pointing into the middle of another namespace's name word.
+
+`observable_namespaces` (the discriminator between "this namespace does not
+export the name" and "this namespace is not in the workspace at all", which
+gates `live_command_links`) reads the declaring rows as a fourth source,
+alongside proc/class owners and `namespace_exports`.  A `namespace eval ::ns
+{ namespace import ::other::* }` block declaring no proc, class, or export
+of its own *is* a namespace the workspace can see.
 
 ### The variable tier's rename half
 
@@ -172,6 +209,8 @@ cache.
 
 - `rust/tcl-lsp-core/src/workspace_index.rs` (`mod tests`)
 - `rust/tcl-lsp-server/tests/e2e/issue923_crossdoc.rs`
+- `rust/tcl-lsp-server/tests/e2e/issue1088_namespace_symbols.rs` (the
+  namespace tier, single-file and cross-file)
 - `rust/tcl-lsp-server/tests/e2e/rename_safety.rs` (the variable tier's
   rename half: TP cross-document, TP out-of-namespace alias, FN-guard
   proc-local alias, TN sibling namespace, FP-guard computed variable name,

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -104,6 +104,27 @@ alongside proc/class owners and `namespace_exports`.  A `namespace eval ::ns
 { namespace import ::other::* }` block declaring no proc, class, or export
 of its own *is* a namespace the workspace can see.
 
+Both halves of a namespace query are a **union**, not a fallback: the
+request's own analysis supplies the local sites and the index supplies every
+other document's, deduplicated by `(uri, span)`.  Returning as soon as the
+in-document provider answered — and excluding the request's own URI from the
+index lookup, which the first cut did — reported only the local half of a
+namespace reopened in two files, contradicting the contract that every
+declaring block is a target (issue #1088 review, finding 2).  Reading the
+local half from the analysis rather than the index is deliberate: a document
+that is unindexed, or has been edited since it was indexed, still answers.
+Hover counts the same merged set and states how many documents it counted, so
+it cannot say "1 block" while go-to-definition offers three.
+
+A namespace-name position is also **definitive** in the server, not just in
+the providers: the query is answered by one branch taken before every other
+tier.  An empty answer must not reach the proc/class tiers — an empty local
+reference set (asking without declarations from a namespace's only declaring
+block) used to route the query to `workspace_resolved_references`, and an
+empty rename edit set falls through to the workspace-resolved rename branch
+by design, which renamed a same-spelled *proc* instead (issue #1088 review,
+finding 1).
+
 ### The variable tier's rename half
 
 Go-to-definition, hover, and find-references answer a namespace variable

--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -849,7 +849,9 @@ issue:
 - **Rename is not wired to the namespace tier.** Definition, hover, and
   references answer; renaming a namespace would have to rewrite every
   qualified proc/variable name under it, which is a materially bigger edit
-  set than the variable tier's and is not attempted here.
+  set than the variable tier's and is not attempted here. It now **refuses
+  with a reason** rather than answering nothing — see the review section
+  below for why that distinction is load-bearing.
 - **A computed target (`namespace eval $ns { … }`) resolves nowhere**, by
   design — it names no static namespace. The per-call-site synthetic domain
   the analyser already builds for it (`@dynns@<offset>`) could in principle
@@ -861,6 +863,82 @@ issue:
   own, so no `ArgRole` reaches it; the analyser already models its
   *semantics* (`AnalysisResult::namespace_overrides`), just not its identity
   as a reference.
+
+**Codex review of PR #1112 (P2 × 3)** — all three were *tier-completeness*
+faults on the new feature, and all three are fixed in the same PR. Recorded
+here because the reasoning generalises to any new symbol kind.
+
+- **A span-definitive position must be definitive in every provider**
+  (finding 1). The design point was that a `NamespaceName`-role word is
+  span-precise, so no word-based resolver may claim it — but hover only
+  returned early when it had a *local* answer, and otherwise fell through to
+  the command resolvers. `namespace exists string`, with `::string` declared
+  in a sibling document, therefore rendered the built-in `string` command's
+  documentation; and because that is an answer, the server returned it and
+  never reached the cross-document namespace tier at all. `None` now means
+  "no local answer" — the signal that tier needs — and never "try something
+  else". The same fall-through class was audited across the other providers:
+  definition and references were already definitive in core, but the
+  *server's* references handler routes an empty local set to
+  `workspace_resolved_references` (the proc/class tier), which an empty
+  namespace answer reaches whenever `includeDeclaration` is false and the
+  cursor sits on the namespace's only declaring block. **Rename was the worst
+  of the family**: `Ok(vec![])` is documented to fall through to the
+  workspace-resolved rename branch, so `namespace children widget` beside a
+  `proc widget` offered to rename the *proc*, with the editor's highlight
+  pointing at the proc's declaration on a different line. Rename now refuses
+  with a reason (`rename_safety::RenameRefusal`), prepare-rename answers
+  `None`, and every namespace query is answered by one server-side branch
+  taken *before* any other tier runs.
+- **Every declaring block is a target, wherever it lives** (finding 2). The
+  first cut returned as soon as the in-document provider answered *and*
+  excluded the request's own URI from the index lookup, so a namespace
+  reopened both locally and in a sibling reported only the local half —
+  contradicting the feature's own contract. Definition and references now
+  union the local analysis with the index (deduplicated by `(uri, span)`),
+  and hover counts the same merged set, saying how many documents it looked
+  at. Rendering stays in one function
+  (`namespace_symbol::namespace_hover_markdown`) fed by a
+  `NamespaceFacts { declarations, references, documents }`, so the
+  in-document and workspace tiers cannot word the same fact differently —
+  they differ only in how wide a set they counted. References already
+  unioned; that was verified rather than assumed, with a test pinning it.
+- **The empty literal is a namespace name** (finding 3), and the oracle
+  refines the claim. tclsh 9.0.4 and 8.6.16 agree byte-for-byte that it is an
+  ordinary **relative** name, not a synonym for `::`. At global scope
+  `namespace exists {}` is `1`, `namespace children {}` equals `namespace
+  children ::`, `namespace inscope {} {namespace current}` is `::`, and
+  `namespace eval {} { … }` reopens the global namespace. Written *inside*
+  `namespace eval ::outer` the same word means `::outer`'s empty-named child:
+  `namespace exists {}` is `0`, `namespace children {}` fails `namespace ""
+  not found in "::outer"`, and `namespace eval {} { … }` fails `can't create
+  namespace "": only global namespace can have empty name`. Dropping the
+  `name.is_empty()` skip is therefore the whole fix — `naming::qualify`
+  already maps the word to `::` at global scope and to `::outer::` inside a
+  namespace, which is exactly Tcl's rule. Two consequences had to be fixed
+  with it: the root-collapsing comparison must fold **only** the root, or
+  `::outer::` (a namespace that cannot exist) would answer with `::outer`'s
+  declarations; and the data-brace inertness proof must **not** run on a
+  namespace word, because a namespace name may legitimately *be* a braced
+  word — `namespace eval {my ns} { variable v 7; proc p {} {return P} }`
+  creates a real namespace on both interpreters (`namespace children ::`
+  lists `{::my ns}`, `set {::my ns::v}` is `7`, `{::my ns::p}` runs). That
+  gate was redundant anyway: a `NamespaceRef` exists only because the
+  analyser walked the command as live code, which is a strictly stronger
+  liveness proof than the textual test.
+
+**Further residuals from that review**:
+
+- **A braced name's recorded span omits its closing brace** (`{my ns` for
+  `{my ns}`). This is a pre-existing, product-wide token-span convention —
+  `proc {my p}`'s own `name_span` is `{my p` — not a namespace-tier fact, so
+  it is left alone rather than fixed asymmetrically here. It is cosmetic: the
+  range an editor highlights is one character short, and resolution is
+  unaffected.
+- **Whitespace-only namespace names are recorded, deliberately.** `namespace
+  eval " " { … }` genuinely creates a namespace both interpreters list as
+  `{:: }` among `namespace children ::`, so there is no whitespace skip to
+  add.
 
 **By corpus** (confirmed only): ticklecharts 20, tk 17, argparse 10,
 SpiceGenTcl 10, tclopt 13 (6+7, split across two inconsistent corpus-label

--- a/docs/design/issue-923-differential-audit/STATUS.md
+++ b/docs/design/issue-923-differential-audit/STATUS.md
@@ -770,6 +770,98 @@ reasoning is the useful part:
   dynamic-name gate and refuses. Correct but blunt, and the same provenance
   work would fix it.
 
+**2026-07-31 update — PR C4b
+(`claude/commandregistry-compiler-fixes-tshu8d-nssym`) closes idx 75's
+*secondary* claim, split out as issue #1088: a namespace **name** written as
+an argument was never a navigable symbol.** The finding's own note is exact —
+"a general `namespace name is never a go-to-def/references target` gap, not
+specifically about unioning many files" — and it reproduced in a single file
+with one trivial `namespace eval mypkg { … }` reopening. idx 75's headline
+count does not move: it was already ticked FIXED by PR C2 for its primary,
+cross-file namespace-*variable* claim, and this is the same finding's other
+half.
+
+Namespaces were modelled only as *containers* — a `ScopeKind::Namespace`
+node and a `Namespace` entry in the document outline — never as symbols. The
+fix makes them one, registry-first. A new **`ArgRole::NamespaceName`** marks
+which argument positions name a namespace (`namespace children` / `exists` /
+`delete` — variadic, via an `arg_role_resolver` — / `parent` / `upvar` /
+`eval` / `inscope`), and a new **`Traits::DECLARES_NAMESPACE`** marks the one
+form that *creates* one. Both are precise rather than sweeping: `namespace
+tail` and `qualifiers` take an arbitrary string (`namespace tail a::b` → `b`
+whether or not `::a` exists, both interpreters), `import` / `export` /
+`forget` take glob patterns, `origin` / `which` name commands, and `code`
+takes a script — none of them is marked, and a registry test asserts each
+stays unmarked. The analyser records every marked word as a
+`NamespaceRef` — including inside a `[…]` substitution, which is where the
+finding's own idiom lives (`set targets [namespace children ::tomato]`) —
+already rooted against the occurrence's own namespace, and the trait (not the
+subcommand's spelling) decides whether the word declares.
+
+The oracle decides what "the namespace's definition" is, and both
+interpreters agree byte-for-byte (9.0.4 / 8.6.16): `namespace eval ::a {}`
+twice creates the namespace once and extends it the second time (`info vars
+::a::*` → `::a::x ::a::y`), so **every** block is a declaring site and
+go-to-definition answers with all of them in source order — the same shape
+idx 31 established for a proc declared twice. `namespace eval` is also the
+*only* declaring form: `proc ::nope::gone::p {} {}` fails with `can't create
+procedure "::nope::gone::p": unknown namespace` and `set ::brandnew::v 1`
+with `can't set "::brandnew::v": parent namespace doesn't exist`, which is
+why `DECLARES_NAMESPACE` sits on `eval` alone and not on `inscope` (identical
+argument layout, same analyser hook, but it requires the namespace to exist).
+A relative name roots against the current namespace — inside `namespace eval
+::outer`, `namespace exists inner` is `1` and the same words at global scope
+are `0` — and a proc body's current namespace is its defining one, which is
+exactly what `innermost_namespace_at` already reports.
+
+One entry point, as the campaign requires: `tcl-lsp-core`'s new
+[`namespace_symbol`](../../../rust/tcl-lsp-core/src/namespace_symbol.rs)
+module holds `namespace_cell_at` and the span queries, and definition, hover,
+and find-references all answer through it, so they cannot disagree. It is
+**span**-driven, not word-driven — the cursor must sit inside a word the
+registry marked — so a proc or class of the same spelling never claims the
+position (Tcl keeps namespaces, commands, and variables in disjoint symbol
+spaces), and the inert-text gate (idx 24's `offset_in_comment` /
+`offset_in_data_brace`) applies unchanged. The workspace tier follows #1086's
+established pattern: a `namespace_refs` table on `WorkspaceIndex`, matched by
+exact qualified name with no re-analysis. It needs no qualified-only bound —
+the analyser roots relative spellings before recording, so every indexed row
+names one namespace absolutely — and its declaring rows become a fourth
+source for `observable_namespaces`, closing the case of a `namespace eval
+::ns { namespace import ::other::* }` block the import gate previously could
+not see. Document outline is left alone: `document_symbols` already nests
+under `namespace eval`, so this only wires navigation.
+
+**Residuals (documented, not half-fixed)** — each to be filed as its own
+issue:
+
+- **An implicitly-created parent namespace has no declaring site.**
+  `namespace eval ::p::q::r {}` really does create `::p` and `::p::q` (both
+  interpreters), but neither name is written anywhere, so
+  `namespace children ::p::q` resolves to nothing rather than jumping into
+  the middle of the `::p::q::r` word. Answering it needs a synthetic
+  declaration identity the span model has no place for yet.
+- **`namespace path {::a ::b}` is not covered.** Its argument is a *list* of
+  namespace names inside one word, and `ArgRole` marks whole words. The role
+  cannot express it, so the subcommand stays unmarked rather than
+  half-marked; a list-of-names role (or the `case_list` treatment
+  `ArgRole::Body` needed) would close it.
+- **Rename is not wired to the namespace tier.** Definition, hover, and
+  references answer; renaming a namespace would have to rewrite every
+  qualified proc/variable name under it, which is a materially bigger edit
+  set than the variable tier's and is not attempted here.
+- **A computed target (`namespace eval $ns { … }`) resolves nowhere**, by
+  design — it names no static namespace. The per-call-site synthetic domain
+  the analyser already builds for it (`@dynns@<offset>`) could in principle
+  carry navigation for the constant-dominated case (idx 44's treatment for
+  command heads), which is not attempted here.
+- **An `apply` lambda's third list element names a namespace** (`apply
+  {{x} {…} ::ns} 1`) and is not navigable. It sits *inside* an
+  `ArgRole::LambdaLiteral` word rather than at an argument position of its
+  own, so no `ArgRole` reaches it; the analyser already models its
+  *semantics* (`AnalysisResult::namespace_overrides`), just not its identity
+  as a reference.
+
 **By corpus** (confirmed only): ticklecharts 20, tk 17, argparse 10,
 SpiceGenTcl 10, tclopt 13 (6+7, split across two inconsistent corpus-label
 strings in the raw data — same corpus), tomato 7, pix 8.
@@ -1019,7 +1111,7 @@ mixin/oo::configurable class-scoping findings, idx 34/36).
 | feature | count | idx (severity) |
 |---|---|---|
 | tclOO | 10 | ~~15~~ **ALREADY FIXED** (pinned, PR B2), 16, ~~34~~ **FIXED** (PR B2), ~~35~~ **FIXED** (PR B2), ~~36~~ **FIXED** (PR B2), ~~53~~ **FIXED**, ~~54~~ **FIXED**, ~~55~~ **FIXED**, ~~96~~ **FIXED**, ~~97~~ **FIXED** (all medium) |
-| namespaces | 8 | ~~3~~ **FIXED** (#1071), ~~19~~ **ALREADY FIXED** (pinned, PR C2), ~~43~~ **ALREADY FIXED**, ~~44~~ **FIXED**, ~~64~~ **FIXED**, ~~65~~ **FIXED** (PR C2), ~~75~~ **FIXED** (PR C2), 85 (all medium) |
+| namespaces | 8 | ~~3~~ **FIXED** (#1071), ~~19~~ **ALREADY FIXED** (pinned, PR C2), ~~43~~ **ALREADY FIXED**, ~~44~~ **FIXED**, ~~64~~ **FIXED**, ~~65~~ **FIXED** (PR C2), ~~75~~ **FIXED** (PR C2; its *secondary* claim — a namespace name as an argument is not a navigable symbol — was split to **#1088** and **FIXED** by PR C4b, no count change), 85 (all medium) |
 | tricky_indirection | 7 | 0 (medium, **FIXED** — see below), ~~1~~ **FIXED**, ~~2~~ **FIXED**, 14, ~~49~~ **FIXED**, 50, 51 (all medium) |
 | upvar | 7 | ~~7~~ **FIXED** (PR C1a), 22 (**PARTIAL** — model landed C1a, `$param` navigation C1b; the literal `upvar 1 name name` shape stays open), ~~57~~ **FIXED** (PR C1a), ~~58~~ **FIXED** (PR C1b), ~~59~~ **FIXED** (PR C1a, single-document; cross-file open), 98 (**PARTIAL** — same as 22), 99 (all medium) |
 | proc_args | 7 | ~~11~~ **FIXED** (#1071), ~~28~~ **FIXED** (PR B2), ~~37~~ **FIXED** (PR B2), 62, 67, ~~78~~ **FIXED** (PR C2), ~~104~~ **FIXED** (all medium) |

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -110,6 +110,16 @@ name commands. A namespace that exists only because it is a parent
 (`namespace eval ::p::q::r { … }` really does create `::p::q`) has no name
 of its own written anywhere, so nothing is reported for it.
 
+Two spellings surprise people, and both follow the same relative rule. The
+**empty** word names the global namespace at the top level — `namespace eval
+{} { … }` really does reopen `::`, and `namespace children {}` lists the same
+children as `namespace children ::` — so all three spellings are one symbol.
+Written inside another namespace the same word means that namespace's
+empty-named child, which Tcl refuses to create at all, so it resolves to
+nothing rather than to the namespace around it. And a **braced** name is an
+ordinary name: `namespace eval {my ns} { … }` creates a real namespace, and
+`namespace children {my ns}` jumps to it.
+
 A command a `package require`d package provides also jumps: the package's
 `pkgIndex.tcl` is resolved through the search path, including the one the
 file builds for itself with `lappend auto_path [file dirname [file dirname

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -93,6 +93,23 @@ other file can know, so it stays a within-file question. A `$name`-shaped
 run of characters inside a comment or a data brace substitutes nothing in
 real Tcl and is likewise never a jump target.
 
+A **namespace name** is a jump target too. The `::tomato` of `namespace
+children ::tomato`, `namespace exists ::tomato`, `namespace delete
+::tomato`, `namespace upvar ::tomato v local`, `namespace inscope`, or a
+second `namespace eval ::tomato { … }` block all land on the `namespace
+eval` blocks that declare that namespace — every one of them, in source
+order, because reopening a namespace extends the same namespace rather than
+making a new one. The declaring block may live in another file. A
+**relative** name resolves against the namespace it is written in, exactly
+as Tcl resolves it: inside `namespace eval ::outer`, `namespace exists
+inner` means `::outer::inner`, and the same words at the top level mean
+`::inner`. Words that only look like namespaces are not: `namespace tail`
+and `namespace qualifiers` take an arbitrary string, `namespace import` /
+`export` / `forget` take glob patterns, and `namespace origin` / `which`
+name commands. A namespace that exists only because it is a parent
+(`namespace eval ::p::q::r { … }` really does create `::p::q`) has no name
+of its own written anywhere, so nothing is reported for it.
+
 A command a `package require`d package provides also jumps: the package's
 `pkgIndex.tcl` is resolved through the search path, including the one the
 file builds for itself with `lappend auto_path [file dirname [file dirname
@@ -153,6 +170,8 @@ same name — Tcl keeps those in a separate table from variables.
 - A cross-file namespace variable stops resolving when the declaring file is
   no longer in the workspace index (it was closed *and* is outside every
   workspace folder).
+- A namespace whose target is computed (`namespace eval $ns { … }`) names no
+  fixed namespace, so neither the block nor any reference to it resolves.
 - A callee that binds a *literal* caller-side name (`upvar 1 options options`)
   names it nowhere at the call site, so there is no word to jump to.
 - A callee whose `upvar` level is not `1` (`upvar 0`, `upvar #0`, `upvar 2`)
@@ -173,6 +192,10 @@ same name — Tcl keeps those in a separate table from variables.
   `wildcard_import_ignores_an_export_written_after_it_cross_document`)
 - `rust/tcl-lsp-server/tests/e2e/issue923_crossdoc.rs` (cross-file namespace
   variables, cross-file class-reference arguments)
+- `rust/tcl-lsp-core/src/namespace_symbol.rs` (`mod tests`) — the shared
+  namespace resolver definition, hover, and references all answer through
+- `rust/tcl-lsp-server/tests/e2e/issue1088_namespace_symbols.rs` (namespace
+  names as jump targets, in one file and across files)
 - `rust/tcl-lsp-server/src/lib.rs` unit tests
   (`definition_resolves_through_a_document_auto_path_package`,
   `set_auto_path_puts_every_list_element_on_the_search_path`,

--- a/docs/kcs/features/kcs-feature-hover.md
+++ b/docs/kcs/features/kcs-feature-hover.md
@@ -97,11 +97,14 @@ Both of those are decided narrowly, so a real reference is never hidden:
   file has no such variable.
 - A **namespace name** is described as one. Hovering the `::tomato` of
   `namespace children ::tomato` — or of the `namespace eval ::tomato { … }`
-  block itself — names the namespace, says how many `namespace eval` blocks
-  declare it, and how many other places in the declaring file refer to it.
-  The declaring block may be in another file. Nothing is shown for a
-  namespace no file in view declares, so a guess is never presented as an
-  answer.
+  block itself — names the namespace and counts every `namespace eval` block
+  that declares it and every other place that refers to it, **across the
+  whole workspace**, saying how many documents it looked at. Nothing is shown
+  for a namespace no file in view declares, so a guess is never presented as
+  an answer. In particular, a namespace whose name also happens to be a
+  command's — `namespace exists string` — never shows that *command's*
+  documentation instead: the two are different kinds of symbol, and the
+  position says which one is meant.
 
 ### Caller-frame variables
 

--- a/docs/kcs/features/kcs-feature-hover.md
+++ b/docs/kcs/features/kcs-feature-hover.md
@@ -95,6 +95,13 @@ Both of those are decided narrowly, so a real reference is never hidden:
   (`::tomato::version`) and how many times the declaring file itself uses
   it. A bare `$v` is still a within-file question and shows nothing when the
   file has no such variable.
+- A **namespace name** is described as one. Hovering the `::tomato` of
+  `namespace children ::tomato` — or of the `namespace eval ::tomato { … }`
+  block itself — names the namespace, says how many `namespace eval` blocks
+  declare it, and how many other places in the declaring file refer to it.
+  The declaring block may be in another file. Nothing is shown for a
+  namespace no file in view declares, so a guess is never presented as an
+  answer.
 
 ### Caller-frame variables
 
@@ -165,6 +172,10 @@ in separate tables, so `$dataset` can never mean a method called `dataset`.
 - `rust/tcl-lsp-core/src/hover.rs` — renderer unit tests
 - `rust/tcl-lsp-core/tests/mathfunc_and_word_recognition.rs` — the `expr`
   math-function and not-a-reference cases
+- `rust/tcl-lsp-core/src/namespace_symbol.rs` (`mod tests`) — the namespace
+  resolver and its hover text
+- `rust/tcl-lsp-server/tests/e2e/issue1088_namespace_symbols.rs` — namespace
+  hover in one file and across files
 
 ## Screenshots
 

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -122,6 +122,21 @@ When nothing binds the name, Find All References returns nothing rather than
 falling back to a command or method of the same name — a `$`-led token can
 only ever be the variable.
 
+### Namespace names
+
+A namespace is a symbol in its own right. Asking for references from the
+`::tomato` of `namespace children ::tomato` — or from the name word of a
+`namespace eval ::tomato { … }` block — returns every other place that names
+that namespace: `namespace exists`, `namespace delete`, `namespace parent`,
+`namespace upvar`, `namespace inscope`, and every declaring `namespace eval`
+block, in this file and in every other file in the workspace. Turning
+declarations off drops the `namespace eval` blocks and keeps the rest.
+Relative names count: inside `namespace eval ::outer`, a bare `inner` names
+`::outer::inner` and is listed with the qualified spellings of the same
+namespace. Words that merely look like namespace names are not listed —
+`namespace tail` and `namespace qualifiers` take arbitrary strings, and
+`namespace import` / `export` / `forget` take glob patterns.
+
 ### Method-name references in a class body
 
 A method's references include the definition-body words that *name* it, not
@@ -144,6 +159,8 @@ that reason.
   call-site word and the reads it feeds, shared with Hover and Go to
   Definition)
 - `rust/tcl-lsp-core/src/definition.rs` (shared namespace-aware resolvers)
+- `rust/tcl-lsp-core/src/namespace_symbol.rs` (the one namespace resolver Go
+  to Definition, Hover, and Find References all answer through)
 - `rust/tcl-compiler/src/analyser/oo.rs` (`record_member_command_references` —
   `superclass` / `mixin` / `inherit` / `forward` as command references)
 
@@ -222,6 +239,8 @@ that reason.
   `dispatch_scan_depth_guard_stops_runaway_nesting`,
   `tn_expect_clause_flags_not_decomposed`)
 - `rust/tcl-lsp-server/tests/e2e/issue923_class_refs.rs` (cross-file)
+- `rust/tcl-lsp-server/tests/e2e/issue1088_namespace_symbols.rs` (namespace
+  names as references, in one file and across files)
 - `rust/tcl-lsp-server/tests/e2e/issue923_crossdoc.rs` (cross-file namespace
   variables, TP + TN)
 - `rust/tcl-lsp-server/tests/e2e/tcloo_navigation.rs` (rename / references /

--- a/docs/kcs/features/kcs-feature-references.md
+++ b/docs/kcs/features/kcs-feature-references.md
@@ -135,7 +135,10 @@ Relative names count: inside `namespace eval ::outer`, a bare `inner` names
 `::outer::inner` and is listed with the qualified spellings of the same
 namespace. Words that merely look like namespace names are not listed —
 `namespace tail` and `namespace qualifiers` take arbitrary strings, and
-`namespace import` / `export` / `forget` take glob patterns.
+`namespace import` / `export` / `forget` take glob patterns. Asking from a
+namespace name never falls back to a command or proc of the same spelling,
+even when the namespace is declared only in another file and the local set is
+empty: the two are different kinds of symbol.
 
 ### Method-name references in a class body
 

--- a/docs/kcs/features/kcs-feature-rename.md
+++ b/docs/kcs/features/kcs-feature-rename.md
@@ -137,6 +137,12 @@ code. The gate refuses when:
   (`set $n 1`, `variable $n`) that might be this very cell, or a file
   **aliases a cell computed at run time** (`namespace upvar $ns v local`)
   that could be this one.
+- the cursor is on a **namespace name** (`namespace children ::tomato`, or
+  the name word of a `namespace eval` block). Renaming a namespace is not
+  supported: it would have to rewrite every qualified name declared beneath
+  it and every `namespace eval` block that reopens it. Rename says so rather
+  than quietly renaming a command or procedure that happens to share the
+  spelling, which is what an empty answer would have led to.
 
 The gate is checked across **every file the rename would edit** — the class's
 own file, every file defining or extending a class in its override family,

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -758,6 +758,13 @@ impl Analyser {
             // any arity check (it is introspected, not called).
             self.record_command_name_invocations(cmd_name, args, arg_tokens, scope_path);
 
+            // Record `ArgRole::NamespaceName` arguments (`namespace children
+            // ::tomato`, `namespace exists ns`, `namespace eval NS { … }`) as
+            // namespace occurrences, so a namespace name is a navigable
+            // symbol for go-to-definition / hover / find-references rather
+            // than an inert word (issue #1088).
+            self.record_namespace_name_references(cmd_name, args, arg_tokens, scope_path);
+
             // Run the per-command syntactic checks on commands nested inside
             // ``[…]`` substitutions — the main walk never descends a
             // substitution (it treats `[cmd …]` as a value), so a command
@@ -2126,6 +2133,61 @@ impl Analyser {
         }
     }
 
+    /// Record each [`tcl_registry::arg_role::ArgRole::NamespaceName`]
+    /// argument as a [`NamespaceRef`](super::types::NamespaceRef): a word
+    /// naming a namespace, which navigation must reach (issue #1088).
+    ///
+    /// A **relative** name roots against the call site's own
+    /// command-resolution namespace, which is what Tcl does — pinned on
+    /// tclsh 9.0.4 and 8.6.16, byte-identically: inside `namespace eval
+    /// ::outer`, `namespace exists inner` answers `1` (it means
+    /// `::outer::inner`) while the same words at global scope answer `0`.
+    /// A proc body's current namespace is its *defining* namespace, which is
+    /// exactly what [`Self::command_resolution_namespace`] reports.
+    ///
+    /// A dynamic word (`namespace eval $ns { … }`) names no static namespace
+    /// and is skipped, as is an empty one. The declaring flag comes from the
+    /// registry's [`tcl_registry::Traits::DECLARES_NAMESPACE`], never from
+    /// the subcommand's spelling: `namespace eval` declares, `namespace
+    /// inscope` — same argument layout, same analyser hook — does not.
+    fn record_namespace_name_references(
+        &mut self,
+        cmd_name: &str,
+        args: &[String],
+        arg_tokens: &[Token],
+        scope_path: &[usize],
+    ) {
+        let Some(registry) = self.registry else {
+            return;
+        };
+        let arg_strs: Vec<&str> = args.iter().map(String::as_str).collect();
+        let indices = registry.arg_indices_for_role(
+            cmd_name,
+            &arg_strs,
+            tcl_registry::arg_role::ArgRole::NamespaceName,
+        );
+        if indices.is_empty() {
+            return;
+        }
+        let declares = registry
+            .call_traits(cmd_name, &arg_strs)
+            .contains(tcl_registry::Traits::DECLARES_NAMESPACE);
+        let here = self.command_resolution_namespace(scope_path);
+        for idx in indices {
+            let (Some(name), Some(tok)) = (args.get(idx), arg_tokens.get(idx)) else {
+                continue;
+            };
+            if name.is_empty() || crate::naming::is_dynamic_word(name) {
+                continue;
+            }
+            self.result.namespace_refs.push(super::types::NamespaceRef {
+                qualified_name: crate::naming::qualify(&here, name),
+                span: tok.span,
+                declares,
+            });
+        }
+    }
+
     /// `<ensemble> <subcommand> …` — when `resolved_cmd` names a known
     /// ensemble (a key in [`AnalysisResult::ensemble_subcommand_targets`])
     /// and the first actual argument is a static, non-`{*}`-expanded
@@ -2593,6 +2655,14 @@ impl Analyser {
         // the IRULE5005 emitter never sees it.  Matches the top-level
         // `process_command` ordering (proc-resolution after site recording).
         self.emit_proc_resolution_diagnostics(&cmd_name, args, cmd_tok, scope_path);
+        // A namespace-name argument nested in a `[…]` substitution names the
+        // same namespace a top-level one would — and this is the *dominant*
+        // real shape: `set targets [namespace children ::tomato]` is the very
+        // line issue #1088 was mined from.  The main walk treats `[…]` as an
+        // opaque value, so without this the occurrence would be invisible to
+        // go-to-definition / hover / find-references exactly where it matters
+        // most.
+        self.record_namespace_name_references(&cmd_name, args, arg_tokens, scope_path);
         // A `package require` nested in a `[…]` substitution still runs — the
         // guarded-optional-dependency idiom puts it exactly there
         // (`if {[catch {package require Tk} err]} { … fallback … }`), and the

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -2146,10 +2146,31 @@ impl Analyser {
     /// exactly what [`Self::command_resolution_namespace`] reports.
     ///
     /// A dynamic word (`namespace eval $ns { … }`) names no static namespace
-    /// and is skipped, as is an empty one. The declaring flag comes from the
-    /// registry's [`tcl_registry::Traits::DECLARES_NAMESPACE`], never from
-    /// the subcommand's spelling: `namespace eval` declares, `namespace
-    /// inscope` — same argument layout, same analyser hook — does not.
+    /// and is the **only** skip. The declaring flag comes from the registry's
+    /// [`tcl_registry::Traits::DECLARES_NAMESPACE`], never from the
+    /// subcommand's spelling: `namespace eval` declares, `namespace inscope`
+    /// — same argument layout, same analyser hook — does not.
+    ///
+    /// The **empty** literal is a real namespace name and is recorded like
+    /// any other relative one.  It needs no special case, because it *is* the
+    /// ordinary relative rule: `crate::naming::qualify` maps it to `::` at
+    /// global scope and to `::outer::` inside `namespace eval ::outer`, which
+    /// is exactly what tclsh 9.0.4 and 8.6.16 do (byte-identical). At global
+    /// scope `namespace exists {}` is `1`, `namespace children {}` equals
+    /// `namespace children ::`, `namespace inscope {} {namespace current}` is
+    /// `::`, and `namespace eval {} {…}` reopens the global namespace
+    /// (`namespace current` inside is `::`, and the variables it sets land in
+    /// `::`). Inside `namespace eval ::outer` the very same word means a
+    /// namespace that cannot exist: `namespace exists {}` is `0`, `namespace
+    /// children {}` fails `namespace "" not found in "::outer"`, and
+    /// `namespace eval {} {…}` fails `can't create namespace "": only global
+    /// namespace can have empty name`.  Recording it as `::outer::` — a name
+    /// nothing ever declares — makes navigation abstain there, which is the
+    /// right answer.
+    ///
+    /// A **whitespace-only** word is not empty and is not special either:
+    /// `namespace eval " " {…}` genuinely creates a namespace named `" "`,
+    /// which both interpreters list as `{:: }` among `namespace children ::`.
     fn record_namespace_name_references(
         &mut self,
         cmd_name: &str,
@@ -2177,7 +2198,7 @@ impl Analyser {
             let (Some(name), Some(tok)) = (args.get(idx), arg_tokens.get(idx)) else {
                 continue;
             };
-            if name.is_empty() || crate::naming::is_dynamic_word(name) {
+            if crate::naming::is_dynamic_word(name) {
                 continue;
             }
             self.result.namespace_refs.push(super::types::NamespaceRef {

--- a/rust/tcl-compiler/src/analyser/per_item.rs
+++ b/rust/tcl-compiler/src/analyser/per_item.rs
@@ -563,6 +563,7 @@ impl Analyser {
         self.result.class_body_spans.extend(r.class_body_spans);
         self.result.auto_path_entries.extend(r.auto_path_entries);
         self.result.qualified_var_refs.extend(r.qualified_var_refs);
+        self.result.namespace_refs.extend(r.namespace_refs);
         self.result.regex_patterns.extend(r.regex_patterns);
         self.result
             .namespace_overrides
@@ -1041,6 +1042,9 @@ fn rebase_fragment(frag: &mut BodyFragment, d: u32, line_delta: i32) {
         x.range = shift(x.range, d);
     }
     for x in &mut r.qualified_var_refs {
+        x.span = shift(x.span, d);
+    }
+    for x in &mut r.namespace_refs {
         x.span = shift(x.span, d);
     }
     for x in &mut r.regex_patterns {

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -1855,6 +1855,9 @@ impl Analyser {
             .qualified_var_refs
             .sort_by_key(|r| (r.span.start(), r.span.end()));
         self.result
+            .namespace_refs
+            .sort_by_key(|r| (r.span.start(), r.span.end()));
+        self.result
             .regex_patterns
             .sort_by_key(|r| (r.range.start(), r.range.end()));
         // `unresolved_command_sites` is a set of call sites consumed

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -1031,6 +1031,12 @@ pub struct AnalysisResult {
     /// [`QualifiedVarRef`].  The cross-document variable reference set is
     /// built from these; an unqualified occurrence is never recorded.
     pub qualified_var_refs: Vec<QualifiedVarRef>,
+    /// Words naming a **namespace**, in source order — see [`NamespaceRef`].
+    /// Both the declaring `namespace eval` name tokens (`declares: true`) and
+    /// every other spelling of the same namespace, so go-to-definition /
+    /// hover / find-references treat a namespace as a first-class symbol
+    /// (issue #1088).
+    pub namespace_refs: Vec<NamespaceRef>,
     /// Byte spans where command resolution is pinned to a namespace by
     /// runtime context rather than lexical nesting (issue #923 idx 116):
     /// `apply {{params} body ns}` runs `body` in `ns`, not the namespace
@@ -1354,6 +1360,40 @@ pub struct QualifiedVarRef {
     pub qualified_name: String,
     /// Byte span of the name token as written.
     pub span: Span,
+}
+
+/// One occurrence of a word that **names a namespace** — every argument the
+/// registry marks [`tcl_registry::ArgRole::NamespaceName`] (`namespace
+/// children ::tomato`, `namespace exists ns`, `namespace delete ::a ::b`,
+/// `namespace eval NS body`, `namespace inscope NS script`, `namespace upvar
+/// NS v local`).
+///
+/// The namespace analogue of [`QualifiedVarRef`], and it exists for the same
+/// reason: the declaring `namespace eval` block routinely lives elsewhere —
+/// another block in the same file, or a sibling document — so the occurrence
+/// leaves no trace in the scope tree, which only records a namespace as a
+/// *container* ([`Scope`] with [`ScopeKind::Namespace`]) and never as a
+/// referenceable symbol (issue #1088).
+///
+/// Unlike the variable table this one records **relative** names too, because
+/// there is nothing per-document about them: a namespace word roots against
+/// the command-resolution namespace in effect at the occurrence, and that
+/// namespace is a lexical fact this document already knows. Pinned on tclsh
+/// 9.0.4 and 8.6.16, byte-identically: inside `namespace eval ::outer`,
+/// `namespace exists inner` answers `1` for `::outer::inner` while the same
+/// words at global scope answer `0`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct NamespaceRef {
+    /// The `::`-rooted namespace the occurrence names, with a relative
+    /// spelling already rooted against the occurrence's own namespace.
+    pub qualified_name: String,
+    /// Byte span of the name token as written.
+    pub span: Span,
+    /// `true` when this occurrence is also a **declaring** site — the name
+    /// word of a [`tcl_registry::Traits::DECLARES_NAMESPACE`] command
+    /// (`namespace eval`).  Go-to-definition answers with these; the
+    /// reference set is everything else.
+    pub declares: bool,
 }
 
 /// One `CLASS create NAME` object-command binding, namespace-qualified.

--- a/rust/tcl-compiler/src/unit_scope.rs
+++ b/rust/tcl-compiler/src/unit_scope.rs
@@ -740,8 +740,8 @@ fn record_call_site_evidence(
         // be walked with the caller's namespace: `namespace eval ::a { helper }`
         // calls `::a::helper`, never the caller's own `helper`
         // (tclsh8.6-confirmed; see `lowering`'s `register_body_unit` call for
-        // the same reasoning). Such a command carries an absolute `ArgRole::Name`
-        // naming that namespace, and lowering has already registered its body as
+        // the same reasoning). Such a command carries an absolute namespace
+        // name argument, and lowering has already registered its body as
         // a body unit whose qname encodes it — which
         // `build_extra_call_site_scan_contexts` scans with the *correct*
         // namespace. Recursing here as well would scan it a second time under
@@ -749,12 +749,19 @@ fn record_call_site_evidence(
         // namespace. Cross-file that is a false edge into another file's
         // procedure; in-unit it was merely invisible, because a bare global
         // `::helper` is rarely in a single file's own `known` set (issue #977).
-        if ctx
-            .registry
-            .arg_indices_for_role(command, &arg_strs, tcl_registry::ArgRole::Name)
-            .into_iter()
-            .filter_map(|i| args.get(i))
-            .any(|name| name.starts_with("::"))
+        //
+        // Both name roles are consulted: `ArgRole::NamespaceName` is the
+        // precise one (`namespace eval` / `inscope`, issue #1088), while a
+        // generic `ArgRole::Name` still covers any other command whose
+        // symbolic name word is written absolutely.
+        if [
+            tcl_registry::ArgRole::NamespaceName,
+            tcl_registry::ArgRole::Name,
+        ]
+        .into_iter()
+        .flat_map(|role| ctx.registry.arg_indices_for_role(command, &arg_strs, role))
+        .filter_map(|i| args.get(i))
+        .any(|name| name.starts_with("::"))
         {
             continue;
         }

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -437,7 +437,7 @@ fn position_definition(
     // 8.6.16).  An empty answer means this document declares it nowhere —
     // the cross-document tier picks it up from there.
     if let Some(cell) =
-        crate::namespace_symbol::namespace_cell_at_offset(source, "", analysis, cursor_off)
+        crate::namespace_symbol::namespace_cell_at_offset(source, analysis, cursor_off)
     {
         return Some(
             crate::namespace_symbol::namespace_declaration_spans(analysis, &cell)

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -428,6 +428,24 @@ fn position_definition(
             var_def.definition_span,
         )]);
     }
+    // A word naming a namespace (`namespace children ::tomato`, and the
+    // `::tomato` of `namespace eval ::tomato { … }` itself) — issue #1088.
+    // Definitive: the position is inside a registry-declared
+    // `ArgRole::NamespaceName` word, so it is about a namespace and nothing
+    // else.  Every declaring `namespace eval` block answers, in source order,
+    // because reopening a namespace extends the same one (tclsh 9.0.4 /
+    // 8.6.16).  An empty answer means this document declares it nowhere —
+    // the cross-document tier picks it up from there.
+    if let Some(cell) =
+        crate::namespace_symbol::namespace_cell_at_offset(source, "", analysis, cursor_off)
+    {
+        return Some(
+            crate::namespace_symbol::namespace_declaration_spans(analysis, &cell)
+                .into_iter()
+                .map(|span| span_to_range(source, line_index, span))
+                .collect(),
+        );
+    }
     if let Some(inv) = crate::expr_context::mathfunc_call_at(analysis, cursor_off) {
         return Some(
             inv.resolved_qualified_name

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -209,6 +209,22 @@ pub fn qualified_variable_hover(
     )))
 }
 
+/// Hover for a **namespace** declared in another document, rendered from that
+/// document's own analysis — the namespace twin of
+/// [`qualified_variable_hover`] (issue #1088).
+///
+/// `qualified` is the `::`-rooted namespace name
+/// ([`crate::namespace_symbol::namespace_cell_at`]); the counts shown are the
+/// declaring document's, matching exactly what hovering a declaring
+/// `namespace eval` there renders.
+#[must_use]
+pub fn qualified_namespace_hover(
+    defining_analysis: &AnalysisResult,
+    qualified: &str,
+) -> Option<Hover> {
+    crate::namespace_symbol::namespace_hover_text(defining_analysis, qualified).map(Hover::markdown)
+}
+
 /// `<ensemble> <subcommand>` hover — a static `namespace ensemble create
 /// -map`/`-subcommands` mapping (issue #923 idx 106), the hover twin of
 /// `definition()`'s identical check. Extracted from
@@ -530,6 +546,19 @@ pub fn hover_with_profile(
     // (`proc p [makeargs] {…}`) holds live code and stays navigable.
     if crate::definition::offset_is_in_parameter_list(analysis, source, cursor_offset) {
         return None;
+    }
+
+    // A word naming a namespace (issue #1088) — span-precise, so it is asked
+    // before every word-based resolver: a namespace is its own symbol space
+    // in Tcl, and a proc or class of the same spelling is not what
+    // `namespace children ::tomato` refers to.  Abstains (falls through)
+    // when no `namespace eval` in *this* document declares it — the
+    // cross-document tier answers those.
+    if let Some(cell) =
+        crate::namespace_symbol::namespace_cell_at(source, profile.name, analysis, line, character)
+        && let Some(text) = crate::namespace_symbol::namespace_hover_text(analysis, &cell)
+    {
+        return Some(Hover::markdown(text));
     }
 
     if let Some(hover) = format_string_hover(source, line, character) {

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -209,20 +209,25 @@ pub fn qualified_variable_hover(
     )))
 }
 
-/// Hover for a **namespace** declared in another document, rendered from that
-/// document's own analysis — the namespace twin of
-/// [`qualified_variable_hover`] (issue #1088).
+/// Hover for a **namespace**, rendered from counts the caller gathered — one
+/// document for the in-document provider, the whole workspace index for the
+/// server's cross-document tier (issue #1088).
 ///
 /// `qualified` is the `::`-rooted namespace name
-/// ([`crate::namespace_symbol::namespace_cell_at`]); the counts shown are the
-/// declaring document's, matching exactly what hovering a declaring
-/// `namespace eval` there renders.
+/// ([`crate::namespace_symbol::namespace_cell_at`]).  The markdown itself
+/// comes from [`crate::namespace_symbol::namespace_hover_markdown`], the one
+/// renderer, so the two tiers cannot word the same fact differently; this
+/// wrapper exists because [`Hover`]'s constructors are crate-private.
+///
+/// `None` when nothing in the gathered set declares the namespace — a genuine
+/// "no hover", never a licence for the caller to fall through to command
+/// documentation.
 #[must_use]
-pub fn qualified_namespace_hover(
-    defining_analysis: &AnalysisResult,
+pub fn namespace_hover(
     qualified: &str,
+    facts: crate::namespace_symbol::NamespaceFacts,
 ) -> Option<Hover> {
-    crate::namespace_symbol::namespace_hover_text(defining_analysis, qualified).map(Hover::markdown)
+    crate::namespace_symbol::namespace_hover_markdown(qualified, facts).map(Hover::markdown)
 }
 
 /// `<ensemble> <subcommand>` hover — a static `namespace ensemble create
@@ -549,16 +554,20 @@ pub fn hover_with_profile(
     }
 
     // A word naming a namespace (issue #1088) — span-precise, so it is asked
-    // before every word-based resolver: a namespace is its own symbol space
-    // in Tcl, and a proc or class of the same spelling is not what
-    // `namespace children ::tomato` refers to.  Abstains (falls through)
-    // when no `namespace eval` in *this* document declares it — the
-    // cross-document tier answers those.
+    // before every word-based resolver AND it is **definitive**: once the
+    // cursor is provably inside a registry-declared `ArgRole::NamespaceName`
+    // argument, a proc, class, or built-in command of the same spelling is
+    // not what it refers to.  Tcl keeps namespaces in their own symbol
+    // space, so falling through on an empty local answer produced *command*
+    // documentation for `namespace exists string` whenever `::string` was
+    // declared in a sibling document — and, because that is a `Some`, the
+    // server returned it and never consulted the cross-document namespace
+    // tier at all (issue #1088 review, finding 1).  `None` here means "no
+    // local answer", which is exactly the signal that tier needs.
     if let Some(cell) =
-        crate::namespace_symbol::namespace_cell_at(source, profile.name, analysis, line, character)
-        && let Some(text) = crate::namespace_symbol::namespace_hover_text(analysis, &cell)
+        crate::namespace_symbol::namespace_cell_at(source, analysis, line, character)
     {
-        return Some(Hover::markdown(text));
+        return crate::namespace_symbol::namespace_hover_text(analysis, &cell).map(Hover::markdown);
     }
 
     if let Some(hover) = format_string_hover(source, line, character) {

--- a/rust/tcl-lsp-core/src/lib.rs
+++ b/rust/tcl-lsp-core/src/lib.rs
@@ -67,6 +67,7 @@ pub mod irules_object_refs;
 pub mod linked_editing_range;
 pub mod minify;
 pub mod namespace_import;
+pub mod namespace_symbol;
 pub mod oo_body;
 mod oo_dispatch;
 pub mod package_resolver;

--- a/rust/tcl-lsp-core/src/namespace_symbol.rs
+++ b/rust/tcl-lsp-core/src/namespace_symbol.rs
@@ -78,9 +78,14 @@
 //!   another namespace's reference set.
 //! * Inert text is excluded: a `namespace exists ::x` that is really comment
 //!   prose or a braced data word is not code, so it must not resolve
-//!   ([`crate::inert_text`], issue #923 idx 24).  The analyser walk already
-//!   declines to descend either, so this gate is a second, independent guard
-//!   rather than the only one.
+//!   (issue #923 idx 24).  Here that falls out of the model rather than
+//!   needing a textual gate — a `NamespaceRef` exists only because the
+//!   analyser walked the command as live code, and the walk descends neither
+//!   comments nor braced data words.  See [`namespace_cell_at_offset`] for
+//!   why [`crate::inert_text::offset_in_data_brace`] specifically must *not*
+//!   be applied: a namespace name may legitimately be a braced word
+//!   (`namespace eval {my ns} { … }` creates a real namespace on both
+//!   interpreters).
 
 use tcl_compiler::analyser::AnalysisResult;
 use tcl_lexer::Span;
@@ -105,21 +110,19 @@ use tcl_lexer::Span;
 #[must_use]
 pub fn namespace_cell_at(
     source: &str,
-    dialect: &str,
     analysis: &AnalysisResult,
     line: u32,
     character: u32,
 ) -> Option<String> {
     let line_index = tcl_lexer::LineIndex::new(source);
     let cursor_off = crate::definition::byte_offset_at(&line_index, source, line, character);
-    namespace_cell_at_offset(source, dialect, analysis, cursor_off)
+    namespace_cell_at_offset(source, analysis, cursor_off)
 }
 
 /// [`namespace_cell_at`] keyed on a byte offset the caller already has.
 #[must_use]
 pub fn namespace_cell_at_offset(
     source: &str,
-    dialect: &str,
     analysis: &AnalysisResult,
     cursor_off: u32,
 ) -> Option<String> {
@@ -127,14 +130,26 @@ pub fn namespace_cell_at_offset(
         .namespace_refs
         .iter()
         .find(|r| r.span.start() <= cursor_off && cursor_off < r.span.end())?;
-    if crate::inert_text::offset_in_comment(source, cursor_off)
-        || crate::inert_text::offset_in_data_brace(
-            source,
-            cursor_off,
-            tcl_registry::registry_for_dialect(dialect),
-            dialect,
-        )
-    {
+    // The recording itself is the liveness proof, and it is a *stronger* one
+    // than the textual data-brace test: a `NamespaceRef` exists only because
+    // the analyser walked that command as live code, and the walk never
+    // descends a comment or a braced data word (`set d {namespace children
+    // ::mypkg}` records nothing at all — see the TN test).
+    //
+    // Applying [`crate::inert_text::offset_in_data_brace`] here would be
+    // actively wrong, because a namespace-name argument may legitimately *be*
+    // a braced word.  Pinned on tclsh 9.0.4 and 8.6.16, byte-identical:
+    // `namespace eval {my ns} { variable v 7; proc p {} {return P} }` creates
+    // a real namespace — `namespace exists {my ns}` is `1`, `namespace
+    // children ::` lists `{::my ns}`, `set {::my ns::v}` is `7`, `{::my
+    // ns::p}` runs — and `namespace eval {} { … }` reopens the global one.
+    // The brace-role test sees a word whose `ArgRole` does not carry script
+    // and calls it data, which would silently un-resolve every such name.
+    //
+    // The comment test stays: it is conservative (it answers "inert" only
+    // when the position provably is), so it can only ever agree with the
+    // walk, and it costs a cheap scan (issue #923 idx 24).
+    if crate::inert_text::offset_in_comment(source, cursor_off) {
         return None;
     }
     Some(hit.qualified_name.clone())
@@ -143,12 +158,30 @@ pub fn namespace_cell_at_offset(
 /// Whether `a` and `b` name the same namespace.
 ///
 /// Both are `::`-rooted by the analyser, so this is an exact comparison —
-/// with the one normalisation the root needs: the global namespace's real
+/// with the one normalisation the **root** needs: the global namespace's real
 /// name is the empty string and `::` is its accepted synonym everywhere
-/// (`namespace current` at top level prints `::` on both interpreters).
+/// (`namespace current` at top level prints `::` on both interpreters, and
+/// `namespace eval :: {…}` / `namespace eval {} {…}` reopen the same
+/// namespace — `namespace current` inside each is `::`).
+///
+/// Only the root collapses.  A *trailing* separator elsewhere is a different
+/// namespace, not a spelling of its parent: `::outer::` is the empty-named
+/// child of `::outer`, which Tcl refuses to create at all (`can't create
+/// namespace "": only global namespace can have empty name`, and `namespace
+/// exists {}` inside `namespace eval ::outer` answers `0` — tclsh 9.0.4 and
+/// 8.6.16, byte-identical). Folding it into `::outer` would answer a query
+/// about a namespace that cannot exist with the enclosing namespace's
+/// declarations.
+fn normalise_namespace(name: &str) -> &str {
+    match name.trim_start_matches("::") {
+        // The root, however it was spelled (`::`, `` ``, `::::`).
+        root if root.is_empty() || root.chars().all(|c| c == ':') => "",
+        other => other,
+    }
+}
+
 fn same_namespace(a: &str, b: &str) -> bool {
-    a.trim_end_matches("::").trim_start_matches("::")
-        == b.trim_end_matches("::").trim_start_matches("::")
+    normalise_namespace(a) == normalise_namespace(b)
 }
 
 /// Every **declaring** site of `cell` in this document, in source order — the
@@ -195,32 +228,97 @@ pub fn namespace_all_spans(
         .collect()
 }
 
-/// Hover text for the namespace `cell`, rendered from the analysis of a
-/// document that **declares** it.
+/// What is known about a namespace, over whatever document set the caller
+/// gathered — one document for the in-document provider, the whole workspace
+/// index for the server's cross-document tier.
 ///
-/// `None` when that document declares it nowhere — hover then abstains rather
-/// than describing a namespace nothing in view creates, which is the same
-/// rule the variable tier follows
-/// ([`crate::hover::qualified_variable_hover`]).
-///
-/// The counts are the declaring document's own and say so: a workspace-wide
-/// tally is the code lens's job, not hover's.
+/// The counts and the document tally travel together so
+/// [`namespace_hover_markdown`] can say *which* set it is describing. A
+/// namespace reopened in three files is a single symbol with three declaring
+/// blocks (tclsh 9.0.4 / 8.6.16: `namespace eval ::a {}` twice leaves one
+/// namespace holding both blocks' contents), so a hover that counted only the
+/// blocks in the file under the cursor would contradict go-to-definition,
+/// which offers all of them.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct NamespaceFacts {
+    /// Declaring `namespace eval` blocks.
+    pub declarations: usize,
+    /// Occurrences that are not declarations.
+    pub references: usize,
+    /// How many documents contributed — `1` for a single-document tally.
+    pub documents: usize,
+}
+
+impl NamespaceFacts {
+    /// Fold another document's counts in.
+    #[must_use]
+    pub fn merged(self, other: Self) -> Self {
+        Self {
+            declarations: self.declarations + other.declarations,
+            references: self.references + other.references,
+            documents: self.documents + other.documents,
+        }
+    }
+}
+
+/// What one document knows about `cell`.
 #[must_use]
-pub fn namespace_hover_text(analysis: &AnalysisResult, cell: &str) -> Option<String> {
-    let declarations = namespace_declaration_spans(analysis, cell).len();
-    if declarations == 0 {
+pub fn namespace_facts(analysis: &AnalysisResult, cell: &str) -> NamespaceFacts {
+    let (declarations, references) = analysis
+        .namespace_refs
+        .iter()
+        .filter(|r| same_namespace(&r.qualified_name, cell))
+        .fold(
+            (0, 0),
+            |(d, r), row| {
+                if row.declares { (d + 1, r) } else { (d, r + 1) }
+            },
+        );
+    NamespaceFacts {
+        declarations,
+        references,
+        documents: usize::from(declarations + references > 0),
+    }
+}
+
+/// Render hover markdown for the namespace `cell` from `facts`.
+///
+/// `None` when nothing in the gathered set **declares** it — hover then
+/// abstains rather than describing a namespace nothing in view creates, the
+/// same rule the variable tier follows
+/// ([`crate::hover::qualified_variable_hover`]).  The abstention is what lets
+/// the server's cross-document tier answer; it must never become a
+/// fall-through to *command* hover, because the cursor is provably on a
+/// namespace-name argument (issue #1088 review, finding 1).
+///
+/// The one renderer, so the in-document provider and the workspace tier
+/// cannot word the same fact differently — they differ only in how wide a set
+/// they counted, which the text states.
+#[must_use]
+pub fn namespace_hover_markdown(cell: &str, facts: NamespaceFacts) -> Option<String> {
+    if facts.declarations == 0 {
         return None;
     }
-    let references = namespace_reference_spans(analysis, cell).len();
-    let blocks = if declarations == 1 {
+    let blocks = if facts.declarations == 1 {
         "1 `namespace eval` block".to_owned()
     } else {
-        format!("{declarations} `namespace eval` blocks")
+        format!("{} `namespace eval` blocks", facts.declarations)
+    };
+    let scope = if facts.documents > 1 {
+        format!(" across {} documents", facts.documents)
+    } else {
+        " in this document".to_owned()
     };
     Some(format!(
-        "**Namespace** `{cell}`\n\nDeclared by {blocks} in the declaring document; \
-         {references} other reference(s) there",
+        "**Namespace** `{cell}`\n\nDeclared by {blocks}{scope}; {} other reference(s)",
+        facts.references,
     ))
+}
+
+/// Hover text for the namespace `cell` from a single document's analysis.
+#[must_use]
+pub fn namespace_hover_text(analysis: &AnalysisResult, cell: &str) -> Option<String> {
+    namespace_hover_markdown(cell, namespace_facts(analysis, cell))
 }
 
 #[cfg(test)]
@@ -238,7 +336,7 @@ mod tests {
         let analysis = analyse(source);
         let off =
             u32::try_from(source.find(needle).expect("needle present")).expect("offset fits u32");
-        namespace_cell_at_offset(source, "", &analysis, off)
+        namespace_cell_at_offset(source, &analysis, off)
     }
 
     fn texts(source: &str, spans: &[Span]) -> Vec<String> {
@@ -299,7 +397,7 @@ mod tests {
         let inside =
             u32::try_from(src.find("children inner").expect("found") + 9).expect("offset fits u32");
         assert_eq!(
-            namespace_cell_at_offset(src, "", &analysis, inside).as_deref(),
+            namespace_cell_at_offset(src, &analysis, inside).as_deref(),
             Some("::outer::inner"),
         );
         // …and the global one means `::inner`, a different namespace that
@@ -307,7 +405,7 @@ mod tests {
         let outside = u32::try_from(src.rfind("children inner").expect("found") + 9)
             .expect("offset fits u32");
         assert_eq!(
-            namespace_cell_at_offset(src, "", &analysis, outside).as_deref(),
+            namespace_cell_at_offset(src, &analysis, outside).as_deref(),
             Some("::inner"),
         );
         assert!(namespace_declaration_spans(&analysis, "::inner").is_empty());
@@ -475,6 +573,126 @@ mod tests {
         assert_eq!(
             texts(src, &namespace_all_spans(&analysis, "::", true)).len(),
             2,
+        );
+    }
+
+    // TP (issue #1088 review, finding 3): the **empty literal** is an
+    // ordinary relative namespace name, so it means `::` at global scope and
+    // a namespace that cannot exist inside another one.
+    //
+    // Oracle — tclsh 9.0.4 and 8.6.16, byte-identical.  At global scope:
+    // `namespace exists {}` -> 1; `namespace children {}` == `namespace
+    // children ::`; `namespace inscope {} {namespace current}` -> `::`;
+    // `namespace eval {} {…}` reopens `::` (`namespace current` inside is
+    // `::`, and a `variable` it declares lands in `::`).  Inside `namespace
+    // eval ::outer`: `namespace exists {}` -> 0; `namespace children {}`
+    // fails `namespace "" not found in "::outer"`; `namespace eval {} {…}`
+    // fails `can't create namespace "": only global namespace can have empty
+    // name`.
+    #[test]
+    fn tp_empty_literal_is_the_global_namespace_at_global_scope() {
+        let src = "namespace eval :: {}\nnamespace eval {} {}\nnamespace children {}\n";
+        let analysis = analyse(src);
+        assert_eq!(cell_at(src, "{} {}").as_deref(), Some("::"));
+        assert_eq!(
+            texts(src, &namespace_declaration_spans(&analysis, "::")),
+            vec!["::", "{}"],
+            "both spellings declare the global namespace",
+        );
+        assert_eq!(
+            texts(src, &namespace_reference_spans(&analysis, "::")),
+            vec!["{}"],
+        );
+    }
+
+    #[test]
+    fn tn_empty_literal_inside_a_namespace_names_a_namespace_that_cannot_exist() {
+        let src = "namespace eval ::outer {\n    namespace exists {}\n}\n";
+        let analysis = analyse(src);
+        // It is *recorded* — the word is a real namespace name — but it names
+        // `::outer::`, the empty-named child, not `::outer`.
+        assert_eq!(cell_at(src, "{}").as_deref(), Some("::outer::"));
+        assert!(namespace_declaration_spans(&analysis, "::outer::").is_empty());
+        assert!(
+            namespace_reference_spans(&analysis, "::outer").is_empty(),
+            "`{{}}` must not be folded into the enclosing namespace: {:?}",
+            analysis.namespace_refs,
+        );
+    }
+
+    // TP: a **braced** namespace name is an ordinary name, so the data-brace
+    // inertness proof must not veto it (issue #1088 review, finding 3
+    // adjacent).
+    //
+    // Oracle — both interpreters: `namespace eval {my ns} { variable v 7;
+    // proc p {} {return P} }` gives `namespace exists {my ns}` -> 1,
+    // `namespace children ::` listing `{::my ns}`, `set {::my ns::v}` -> 7,
+    // and `{::my ns::p}` -> P.
+    #[test]
+    fn tp_a_braced_namespace_name_resolves() {
+        let src = "namespace eval {my ns} { variable v 7 }\nnamespace children {my ns}\n";
+        let analysis = analyse(src);
+        assert_eq!(cell_at(src, "{my ns}").as_deref(), Some("::my ns"));
+        // The recorded span is the word token's, which for a braced word
+        // covers the opening brace and the content but not the closing one —
+        // a pre-existing, product-wide convention shared with `proc {my p}`'s
+        // own `name_span`, not a namespace-tier fact. What matters here is
+        // that the name resolves at all: the data-brace inertness proof used
+        // to veto it.
+        assert_eq!(
+            texts(src, &namespace_declaration_spans(&analysis, "::my ns")),
+            vec!["{my ns"],
+        );
+        assert_eq!(
+            texts(src, &namespace_reference_spans(&analysis, "::my ns")),
+            vec!["{my ns"],
+        );
+    }
+
+    // Hover counts travel with the size of the set they describe, so the
+    // in-document provider and the server's workspace tier cannot word the
+    // same fact differently.
+    #[test]
+    fn tp_hover_says_which_set_it_counted() {
+        let one = NamespaceFacts {
+            declarations: 1,
+            references: 2,
+            documents: 1,
+        };
+        let text = namespace_hover_markdown("::mypkg", one).expect("hover");
+        assert!(
+            text.contains("1 `namespace eval` block in this document"),
+            "{text}"
+        );
+        let many = NamespaceFacts {
+            declarations: 3,
+            references: 4,
+            documents: 2,
+        };
+        let text = namespace_hover_markdown("::mypkg", many).expect("hover");
+        assert!(
+            text.contains("3 `namespace eval` blocks across 2 documents"),
+            "{text}",
+        );
+        assert_eq!(
+            namespace_hover_markdown("::mypkg", NamespaceFacts::default()),
+            None,
+            "nothing declares it — abstain, never fall through",
+        );
+    }
+
+    #[test]
+    fn tp_facts_merge_across_documents() {
+        let a = analyse("namespace eval mypkg {}\nnamespace children ::mypkg\n");
+        let b = analyse("namespace eval mypkg {}\n");
+        let merged = namespace_facts(&a, "::mypkg").merged(namespace_facts(&b, "::mypkg"));
+        assert_eq!(
+            merged,
+            NamespaceFacts {
+                declarations: 2,
+                references: 1,
+                documents: 2,
+            },
         );
     }
 

--- a/rust/tcl-lsp-core/src/namespace_symbol.rs
+++ b/rust/tcl-lsp-core/src/namespace_symbol.rs
@@ -1,0 +1,501 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Namespaces as **navigable symbols** — the one entry point every provider
+//! resolves a namespace name through (issue #1088).
+//!
+//! Before this, a namespace existed in the model only as a *container*: a
+//! [`ScopeKind::Namespace`](tcl_compiler::analyser::ScopeKind) node holding
+//! variables and procs, and a `Namespace` entry in the document outline.  A
+//! namespace *name* written as an argument — `namespace children ::tomato`,
+//! `namespace exists ::x`, `namespace delete ::a`, the `::app` of a second
+//! `namespace eval ::app { … }` block — resolved to nothing at all, in any
+//! provider, even single-file.
+//!
+//! ## What a namespace's definition is
+//!
+//! Pinned on tclsh 9.0.4 and 8.6.16, byte-identically:
+//!
+//! ```text
+//! namespace eval ::a { variable x 1 }
+//! namespace eval ::a { variable y 2 }
+//! namespace exists ::a            -> 1
+//! info vars ::a::*                -> ::a::x ::a::y
+//! ```
+//!
+//! Both blocks are the same namespace: the first creates it, the second
+//! extends it.  So a namespace has a **set** of declaring sites, not one, and
+//! go-to-definition answers with all of them in source order — the same shape
+//! find-references already takes for a proc declared twice (issue #923
+//! idx 31), and the reason [`namespace_declaration_spans`] returns a `Vec`.
+//!
+//! `namespace eval` is also the **only** declaring form.  A qualified `proc`
+//! does *not* create the namespace it names:
+//!
+//! ```text
+//! proc ::nope::gone::p {} {}  -> can't create procedure "::nope::gone::p": unknown namespace
+//! set ::brandnew::v 1         -> can't set "::brandnew::v": parent namespace doesn't exist
+//! ```
+//!
+//! which is why [`tcl_registry::Traits::DECLARES_NAMESPACE`] sits on
+//! `namespace eval` alone — not on `namespace inscope`, whose argument layout
+//! and analyser hook are identical but which requires the namespace to exist.
+//!
+//! ## Relative names
+//!
+//! A namespace word roots against the command-resolution namespace in force
+//! where it is written, exactly as Tcl resolves it (both interpreters: inside
+//! `namespace eval ::outer`, `namespace exists inner` is `1` for
+//! `::outer::inner`, and the same words at global scope are `0`).  The
+//! analyser does that rooting once, when it records the occurrence, so every
+//! consumer here compares fully-qualified names and none of them re-derives
+//! the rule.
+//!
+//! ## Bounds
+//!
+//! * A namespace created only **implicitly**, as a parent (`namespace eval
+//!   ::p::q::r {}` creates `::p` and `::p::q` too, both interpreters), has no
+//!   declaring site of its own.  Asking for `::p::q` answers nothing rather
+//!   than jumping into the middle of the `::p::q::r` word, which is not that
+//!   namespace's name.
+//! * A **computed** target (`namespace eval $ns { … }`) names no static
+//!   namespace and is never recorded, so it neither answers nor pollutes
+//!   another namespace's reference set.
+//! * Inert text is excluded: a `namespace exists ::x` that is really comment
+//!   prose or a braced data word is not code, so it must not resolve
+//!   ([`crate::inert_text`], issue #923 idx 24).  The analyser walk already
+//!   declines to descend either, so this gate is a second, independent guard
+//!   rather than the only one.
+
+use tcl_compiler::analyser::AnalysisResult;
+use tcl_lexer::Span;
+
+/// The `::`-rooted **namespace** the cursor names, when it names one.
+///
+/// The single entry point definition / hover / find-references (and their
+/// cross-document tiers) resolve a namespace through, so they cannot disagree
+/// about which position is about a namespace at all.  Deliberately
+/// span-driven rather than word-driven: the answer is `Some` only when the
+/// cursor sits inside a word the registry marked
+/// [`tcl_registry::ArgRole::NamespaceName`] and the analyser recorded, so a
+/// bare word that merely *looks* like a namespace never claims a position a
+/// proc / class / variable resolver owns.
+///
+/// Both cursor shapes answer, and they are the same shape:
+///
+/// 1. A **reference** — the `::tomato` of `namespace children ::tomato`.
+/// 2. A **declaration** — the `::tomato` of `namespace eval ::tomato { … }`,
+///    which is also a `NamespaceName` word.  That is what lets
+///    find-references run *from* the declaration.
+#[must_use]
+pub fn namespace_cell_at(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    line: u32,
+    character: u32,
+) -> Option<String> {
+    let line_index = tcl_lexer::LineIndex::new(source);
+    let cursor_off = crate::definition::byte_offset_at(&line_index, source, line, character);
+    namespace_cell_at_offset(source, dialect, analysis, cursor_off)
+}
+
+/// [`namespace_cell_at`] keyed on a byte offset the caller already has.
+#[must_use]
+pub fn namespace_cell_at_offset(
+    source: &str,
+    dialect: &str,
+    analysis: &AnalysisResult,
+    cursor_off: u32,
+) -> Option<String> {
+    let hit = analysis
+        .namespace_refs
+        .iter()
+        .find(|r| r.span.start() <= cursor_off && cursor_off < r.span.end())?;
+    if crate::inert_text::offset_in_comment(source, cursor_off)
+        || crate::inert_text::offset_in_data_brace(
+            source,
+            cursor_off,
+            tcl_registry::registry_for_dialect(dialect),
+            dialect,
+        )
+    {
+        return None;
+    }
+    Some(hit.qualified_name.clone())
+}
+
+/// Whether `a` and `b` name the same namespace.
+///
+/// Both are `::`-rooted by the analyser, so this is an exact comparison —
+/// with the one normalisation the root needs: the global namespace's real
+/// name is the empty string and `::` is its accepted synonym everywhere
+/// (`namespace current` at top level prints `::` on both interpreters).
+fn same_namespace(a: &str, b: &str) -> bool {
+    a.trim_end_matches("::").trim_start_matches("::")
+        == b.trim_end_matches("::").trim_start_matches("::")
+}
+
+/// Every **declaring** site of `cell` in this document, in source order — the
+/// name token of each `namespace eval` block that creates or extends it.
+///
+/// Empty when the document declares the namespace nowhere, including the
+/// implicit-parent case described in the module docs.
+#[must_use]
+pub fn namespace_declaration_spans(analysis: &AnalysisResult, cell: &str) -> Vec<Span> {
+    analysis
+        .namespace_refs
+        .iter()
+        .filter(|r| r.declares && same_namespace(&r.qualified_name, cell))
+        .map(|r| r.span)
+        .collect()
+}
+
+/// Every **non-declaring** occurrence of `cell` in this document, in source
+/// order — the reference set find-references reports when the declarations
+/// are not asked for.
+#[must_use]
+pub fn namespace_reference_spans(analysis: &AnalysisResult, cell: &str) -> Vec<Span> {
+    analysis
+        .namespace_refs
+        .iter()
+        .filter(|r| !r.declares && same_namespace(&r.qualified_name, cell))
+        .map(|r| r.span)
+        .collect()
+}
+
+/// Every occurrence of `cell` in this document — declarations included when
+/// `include_declaration`, in source order.
+#[must_use]
+pub fn namespace_all_spans(
+    analysis: &AnalysisResult,
+    cell: &str,
+    include_declaration: bool,
+) -> Vec<Span> {
+    analysis
+        .namespace_refs
+        .iter()
+        .filter(|r| (include_declaration || !r.declares) && same_namespace(&r.qualified_name, cell))
+        .map(|r| r.span)
+        .collect()
+}
+
+/// Hover text for the namespace `cell`, rendered from the analysis of a
+/// document that **declares** it.
+///
+/// `None` when that document declares it nowhere — hover then abstains rather
+/// than describing a namespace nothing in view creates, which is the same
+/// rule the variable tier follows
+/// ([`crate::hover::qualified_variable_hover`]).
+///
+/// The counts are the declaring document's own and say so: a workspace-wide
+/// tally is the code lens's job, not hover's.
+#[must_use]
+pub fn namespace_hover_text(analysis: &AnalysisResult, cell: &str) -> Option<String> {
+    let declarations = namespace_declaration_spans(analysis, cell).len();
+    if declarations == 0 {
+        return None;
+    }
+    let references = namespace_reference_spans(analysis, cell).len();
+    let blocks = if declarations == 1 {
+        "1 `namespace eval` block".to_owned()
+    } else {
+        format!("{declarations} `namespace eval` blocks")
+    };
+    Some(format!(
+        "**Namespace** `{cell}`\n\nDeclared by {blocks} in the declaring document; \
+         {references} other reference(s) there",
+    ))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tcl_compiler::analyser::Analyser;
+
+    fn analyse(source: &str) -> AnalysisResult {
+        let mut a = Analyser::new();
+        a.analyse(source, "tcl8.6").clone()
+    }
+
+    /// The cell the cursor at the first occurrence of `needle` names.
+    fn cell_at(source: &str, needle: &str) -> Option<String> {
+        let analysis = analyse(source);
+        let off =
+            u32::try_from(source.find(needle).expect("needle present")).expect("offset fits u32");
+        namespace_cell_at_offset(source, "", &analysis, off)
+    }
+
+    fn texts(source: &str, spans: &[Span]) -> Vec<String> {
+        spans
+            .iter()
+            .map(|s| source[s.start() as usize..s.end() as usize].to_owned())
+            .collect()
+    }
+
+    // TP: a namespace *name* argument resolves to the namespace, and its
+    // declaring `namespace eval` blocks are the definition set.  Both blocks
+    // answer — tclsh 9.0.4 / 8.6.16 agree byte-for-byte that reopening
+    // `::mypkg` extends the one namespace (`info vars ::mypkg::*` lists both
+    // blocks' variables).
+    #[test]
+    fn tp_namespace_name_argument_resolves_to_every_declaring_block() {
+        let src = "namespace eval mypkg { variable a 1 }\n\
+                   namespace eval mypkg { variable b 2 }\n\
+                   namespace children ::mypkg\n";
+        assert_eq!(cell_at(src, "::mypkg").as_deref(), Some("::mypkg"));
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(src, &namespace_declaration_spans(&analysis, "::mypkg")),
+            vec!["mypkg", "mypkg"],
+        );
+        assert_eq!(
+            texts(src, &namespace_reference_spans(&analysis, "::mypkg")),
+            vec!["::mypkg"],
+        );
+    }
+
+    // TP: the real mined shape — the name inside a `[…]` command
+    // substitution (`set targets [namespace children ::tomato]`), which the
+    // main walk treats as an opaque value.
+    #[test]
+    fn tp_namespace_name_inside_command_substitution_resolves() {
+        let src = "namespace eval tomato {}\nset targets [namespace children ::tomato]\n";
+        assert_eq!(cell_at(src, "::tomato").as_deref(), Some("::tomato"));
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(src, &namespace_declaration_spans(&analysis, "::tomato")),
+            vec!["tomato"],
+        );
+    }
+
+    // TP: a **relative** name roots against the enclosing namespace, exactly
+    // as Tcl does — tclsh 9.0.4 / 8.6.16: inside `namespace eval ::outer`,
+    // `namespace exists inner` is 1; the same words at global scope are 0.
+    #[test]
+    fn tp_relative_name_roots_against_the_enclosing_namespace() {
+        let src = "namespace eval ::outer {\n\
+                   \x20   namespace eval inner {}\n\
+                   \x20   namespace children inner\n\
+                   }\n\
+                   namespace children inner\n";
+        let analysis = analyse(src);
+        // The occurrence inside `::outer` means `::outer::inner`…
+        let inside =
+            u32::try_from(src.find("children inner").expect("found") + 9).expect("offset fits u32");
+        assert_eq!(
+            namespace_cell_at_offset(src, "", &analysis, inside).as_deref(),
+            Some("::outer::inner"),
+        );
+        // …and the global one means `::inner`, a different namespace that
+        // nothing here declares.
+        let outside = u32::try_from(src.rfind("children inner").expect("found") + 9)
+            .expect("offset fits u32");
+        assert_eq!(
+            namespace_cell_at_offset(src, "", &analysis, outside).as_deref(),
+            Some("::inner"),
+        );
+        assert!(namespace_declaration_spans(&analysis, "::inner").is_empty());
+        assert_eq!(
+            texts(
+                src,
+                &namespace_declaration_spans(&analysis, "::outer::inner")
+            ),
+            vec!["inner"],
+        );
+    }
+
+    // TP: every subcommand the registry marks carries the role — `exists`,
+    // `delete` (variadic), `parent`, `upvar`, `inscope`.
+    #[test]
+    fn tp_every_marked_subcommand_records_its_namespace_word() {
+        let src = "namespace exists ::a\n\
+                   namespace delete ::a ::b\n\
+                   namespace parent ::a\n\
+                   namespace upvar ::a v l\n\
+                   namespace inscope ::a {set x 1}\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(src, &namespace_reference_spans(&analysis, "::a")).len(),
+            5,
+            "exists / delete / parent / upvar / inscope all reference `::a`: {:?}",
+            analysis.namespace_refs,
+        );
+        assert_eq!(
+            texts(src, &namespace_reference_spans(&analysis, "::b")),
+            vec!["::b"],
+        );
+    }
+
+    // FP guard: `namespace qualifiers` / `tail` take an arbitrary **string**,
+    // not a namespace — `namespace tail a::b` answers `b` on both
+    // interpreters whether or not `::a` exists — and `import` / `export` /
+    // `forget` take glob patterns.  None of them may claim a namespace
+    // reference.
+    #[test]
+    fn fp_string_and_pattern_arguments_are_not_namespace_references() {
+        let src = "namespace eval a {}\n\
+                   namespace tail a::b\n\
+                   namespace qualifiers a::b\n\
+                   namespace import a::*\n\
+                   namespace export a\n\
+                   namespace forget a::*\n";
+        let analysis = analyse(src);
+        assert!(
+            namespace_reference_spans(&analysis, "::a").is_empty(),
+            "only the declaring block may be recorded: {:?}",
+            analysis.namespace_refs,
+        );
+    }
+
+    // FP guard: `namespace which -command ::a` / `namespace origin ::a` name
+    // a **command**, and `namespace code` takes a script.  Namespaces are a
+    // disjoint symbol space, so none of these is a namespace reference.
+    #[test]
+    fn fp_command_name_arguments_are_not_namespace_references() {
+        let src = "namespace eval a {}\n\
+                   namespace origin ::a\n\
+                   namespace which -command ::a\n\
+                   namespace code {puts hi}\n";
+        let analysis = analyse(src);
+        assert!(
+            namespace_reference_spans(&analysis, "::a").is_empty(),
+            "command-name words are not namespace references: {:?}",
+            analysis.namespace_refs,
+        );
+    }
+
+    // TN: a namespace-name-shaped run of text inside a **comment** is inert —
+    // Tcl runs nothing there, so it must resolve to nothing (issue #923
+    // idx 24's rule, applied to this new symbol kind).
+    #[test]
+    fn tn_comment_text_is_not_a_namespace_reference() {
+        let src = "namespace eval mypkg {}\n# namespace children ::mypkg here\n";
+        assert_eq!(cell_at(src, "::mypkg here"), None);
+        let analysis = analyse(src);
+        assert!(namespace_reference_spans(&analysis, "::mypkg").is_empty());
+    }
+
+    // TN: the same inside a **braced data word** — `set d {namespace children
+    // ::mypkg}` is a literal string on both interpreters, never a command.
+    #[test]
+    fn tn_braced_data_word_is_not_a_namespace_reference() {
+        let src = "namespace eval mypkg {}\nset d {namespace children ::mypkg}\n";
+        assert_eq!(cell_at(src, "::mypkg}"), None);
+        let analysis = analyse(src);
+        assert!(namespace_reference_spans(&analysis, "::mypkg").is_empty());
+    }
+
+    // TN: a **computed** target names no static namespace, so it is recorded
+    // nowhere and cannot be mistaken for a literal one.
+    #[test]
+    fn tn_computed_namespace_target_is_not_recorded() {
+        let src = "set ns ::mypkg\nnamespace eval $ns {}\nnamespace children $ns\n";
+        let analysis = analyse(src);
+        assert!(
+            analysis.namespace_refs.is_empty(),
+            "a `$ns` target names nothing statically: {:?}",
+            analysis.namespace_refs,
+        );
+    }
+
+    // TN: a namespace that exists only as an **implicit parent** has no
+    // declaring site of its own.  `namespace eval ::p::q::r {}` really does
+    // create `::p` and `::p::q` (both interpreters), but neither name is
+    // written anywhere, so definition abstains rather than jumping into the
+    // middle of another namespace's name word.
+    #[test]
+    fn tn_implicit_parent_namespace_has_no_declaration_site() {
+        let src = "namespace eval ::p::q::r {}\nnamespace children ::p::q\n";
+        let analysis = analyse(src);
+        assert_eq!(cell_at(src, "::p::q\n").as_deref(), Some("::p::q"));
+        assert!(namespace_declaration_spans(&analysis, "::p::q").is_empty());
+        assert_eq!(
+            texts(src, &namespace_declaration_spans(&analysis, "::p::q::r")),
+            vec!["::p::q::r"],
+        );
+    }
+
+    // FN guard: `namespace inscope` must **not** be treated as a declaration —
+    // it requires the namespace to exist already, and the discriminator is
+    // the registry's `DECLARES_NAMESPACE`, not the argument layout (which is
+    // identical to `eval`'s).
+    #[test]
+    fn fn_inscope_is_a_reference_not_a_declaration() {
+        let src = "namespace inscope ::a {set x 1}\n";
+        let analysis = analyse(src);
+        assert!(namespace_declaration_spans(&analysis, "::a").is_empty());
+        assert_eq!(
+            texts(src, &namespace_reference_spans(&analysis, "::a")),
+            vec!["::a"],
+        );
+    }
+
+    // FN guard: find-references run *from* the declaration must reach the
+    // references, and `include_declaration` decides whether the declaring
+    // blocks come back too.
+    #[test]
+    fn fn_references_from_the_declaration_reach_every_use() {
+        let src = "namespace eval mypkg {}\n\
+                   namespace children ::mypkg\n\
+                   namespace exists mypkg\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(src, &namespace_all_spans(&analysis, "::mypkg", true)),
+            vec!["mypkg", "::mypkg", "mypkg"],
+        );
+        assert_eq!(
+            texts(src, &namespace_all_spans(&analysis, "::mypkg", false)),
+            vec!["::mypkg", "mypkg"],
+        );
+    }
+
+    // The global namespace's real name is the empty string and `::` is its
+    // accepted synonym everywhere (`namespace current` prints `::` at top
+    // level on both interpreters), so the two spellings must be one symbol.
+    #[test]
+    fn tp_global_namespace_spellings_are_one_symbol() {
+        let src = "namespace eval :: {}\nnamespace children ::\n";
+        let analysis = analyse(src);
+        assert_eq!(
+            texts(src, &namespace_all_spans(&analysis, "::", true)).len(),
+            2,
+        );
+    }
+
+    // Hover abstains for a namespace this document declares nowhere, so the
+    // cross-document tier can answer instead of a wrong local guess.
+    #[test]
+    fn tn_hover_abstains_without_a_local_declaration() {
+        let src = "namespace children ::elsewhere\n";
+        let analysis = analyse(src);
+        assert_eq!(namespace_hover_text(&analysis, "::elsewhere"), None);
+    }
+
+    #[test]
+    fn tp_hover_counts_declaring_blocks_and_references() {
+        let src = "namespace eval mypkg {}\n\
+                   namespace eval mypkg {}\n\
+                   namespace children ::mypkg\n";
+        let analysis = analyse(src);
+        let text = namespace_hover_text(&analysis, "::mypkg").expect("hover");
+        assert!(text.contains("`::mypkg`"), "{text}");
+        assert!(text.contains("2 `namespace eval` blocks"), "{text}");
+        assert!(text.contains("1 other reference(s)"), "{text}");
+    }
+}

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -516,6 +516,16 @@ pub fn references(
         return Vec::new();
     }
 
+    // Namespace references — a word the registry marks
+    // `ArgRole::NamespaceName` (issue #1088).  Checked before every bareword
+    // resolver below because it is span-precise: the cursor is provably
+    // inside a namespace-name argument, so a class or proc that happens to
+    // share the spelling must not claim it.  Namespaces are their own symbol
+    // space in Tcl, disjoint from commands and variables.
+    if let Some(out) = namespace_references(&ctx) {
+        return out;
+    }
+
     let Some((word, _start, _end)) = find_word_span_at_position(source, line, character) else {
         return Vec::new();
     };
@@ -583,6 +593,39 @@ pub fn references(
     }
 
     Vec::new()
+}
+
+/// References for the **namespace** the cursor names — every other spelling
+/// of it in this document, plus its declaring `namespace eval` blocks when
+/// `include_declaration` (issue #1088).
+///
+/// `None` means the cursor is not on a namespace-name word at all, so the
+/// caller falls through.  `Some` is definitive, empty vector included: once
+/// the position is provably a namespace reference, an unrelated same-spelled
+/// proc or class is not the answer.
+///
+/// Resolution — including a relative name's rooting against the enclosing
+/// namespace — happens once, in
+/// [`crate::namespace_symbol::namespace_cell_at`], so this and
+/// go-to-definition and hover cannot disagree about which namespace is meant.
+fn namespace_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
+    let RefCtx {
+        source,
+        dialect,
+        line_index,
+        line,
+        character,
+        analysis,
+        include_declaration,
+    } = *ctx;
+    let cell =
+        crate::namespace_symbol::namespace_cell_at(source, dialect, analysis, line, character)?;
+    Some(
+        crate::namespace_symbol::namespace_all_spans(analysis, &cell, include_declaration)
+            .into_iter()
+            .map(|span| crate::definition::span_to_range(source, line_index, span))
+            .collect(),
+    )
 }
 
 /// Build references for a `constructor` / `destructor` keyword: when the

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -611,15 +611,14 @@ pub fn references(
 fn namespace_references(ctx: &RefCtx<'_>) -> Option<Vec<LspRange>> {
     let RefCtx {
         source,
-        dialect,
         line_index,
         line,
         character,
         analysis,
         include_declaration,
+        ..
     } = *ctx;
-    let cell =
-        crate::namespace_symbol::namespace_cell_at(source, dialect, analysis, line, character)?;
+    let cell = crate::namespace_symbol::namespace_cell_at(source, analysis, line, character)?;
     Some(
         crate::namespace_symbol::namespace_all_spans(analysis, &cell, include_declaration)
             .into_iter()

--- a/rust/tcl-lsp-core/src/rename.rs
+++ b/rust/tcl-lsp-core/src/rename.rs
@@ -188,6 +188,16 @@ pub fn prepare_rename(
     analysis: &AnalysisResult,
 ) -> Option<PrepareRename> {
     let line_index = LineIndex::new(source);
+    // A namespace name is not a renameable symbol (see
+    // [`namespace_rename_refusal`]), and the check must come first: the word
+    // resolvers below would otherwise anchor prepare on a same-spelled proc
+    // or class in a completely different place in the file (issue #1088
+    // review, finding 1).  `None` is the right answer here — the editor
+    // simply offers no rename UI — while a client that skips prepare and
+    // calls `rename` directly meets the refusal instead.
+    if crate::namespace_symbol::namespace_cell_at(source, analysis, line, character).is_some() {
+        return None;
+    }
     // Variable?
     if let Some(var_name) = find_var_at_position(source, line, character) {
         let byte_offset = crate::definition::byte_offset_at(&line_index, source, line, character);
@@ -343,6 +353,17 @@ pub fn rename_with_diagnosis(
     {
         return Err(refusal);
     }
+    // A namespace name is not a rename target here, and — crucially — it must
+    // **refuse** rather than return an empty edit set: `Ok(vec![])` falls
+    // through to the server's workspace-resolved rename branch, which
+    // resolved the word as a *command* and rewrote a same-spelled proc
+    // instead (issue #1088 review, finding 1).  The cursor is provably on a
+    // registry-declared `ArgRole::NamespaceName` argument, so it names a
+    // namespace and nothing else; renaming one would have to rewrite every
+    // qualified name beneath it, which this tier does not do.
+    if let Some(refusal) = namespace_rename_refusal(source, line, character, analysis) {
+        return Err(refusal);
+    }
 
     if let Some(edits) =
         rename_variable_at(source, line, character, new_name, analysis, &line_index)
@@ -427,6 +448,38 @@ pub fn rename_with_diagnosis(
         return Ok(edits);
     }
     Ok(Vec::new())
+}
+
+/// The refusal for a cursor sitting on a **namespace name** — a word the
+/// registry marks [`tcl_registry::ArgRole::NamespaceName`] (issue #1088).
+///
+/// Renaming a namespace is not implemented: the edit set would have to
+/// rewrite every qualified proc, class, and variable name beneath it, plus
+/// every `namespace eval` block that reopens it, across the workspace.  That
+/// is a materially larger question than the variable tier's, and until it is
+/// answered the honest response is a refusal *with a reason*.
+///
+/// It has to be a refusal rather than an empty edit set for the reason
+/// [`rename_with_diagnosis`]'s own doc gives: an empty set falls through to
+/// the server's cross-document and workspace-resolved branches, which resolve
+/// the cursor **word** as a command — so `namespace children widget` beside a
+/// `proc widget` offered to rename the proc, pointing the editor's highlight
+/// at the proc's declaration on another line.
+fn namespace_rename_refusal(
+    source: &str,
+    line: u32,
+    character: u32,
+    analysis: &AnalysisResult,
+) -> Option<crate::rename_safety::RenameRefusal> {
+    let cell = crate::namespace_symbol::namespace_cell_at(source, analysis, line, character)?;
+    Some(crate::rename_safety::RenameRefusal {
+        reason: format!(
+            "`{cell}` is a namespace name. Renaming a namespace is not supported: \
+             it would have to rewrite every qualified name declared beneath it \
+             and every `namespace eval` block that reopens it."
+        ),
+        range: None,
+    })
 }
 
 /// The safety refusal for a `TclOO` member rename anchored at the cursor, if

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -57,8 +57,21 @@
 //! differential-audit findings idx 65 / 75 / 78).  An **unqualified**
 //! `$v` names whichever cell the local scope chain supplies, which is a
 //! per-document question with no statically-sound cross-file answer, so
-//! proc locals and bare occurrences are still not indexed.  Namespaces
-//! themselves are not indexed.
+//! proc locals and bare occurrences are still not indexed.
+//!
+//! **Namespaces** are indexed as first-class symbols too
+//! ([`WorkspaceNamespaceRef`], issue #1088): every word the registry marks
+//! [`tcl_registry::ArgRole::NamespaceName`] — the declaring `namespace eval`
+//! name token and every other spelling (`namespace children ::tomato`,
+//! `namespace exists ns`, `namespace delete ::a`, `namespace upvar ns v l`).
+//! This tier needs no qualified-only bound the way variables do: the analyser
+//! roots a relative namespace word against its own lexical namespace before
+//! recording it, so every indexed row names one namespace absolutely.  A
+//! **computed** target (`namespace eval $ns { … }`) is recorded nowhere — it
+//! names no static namespace — and a namespace brought into being only as an
+//! implicit parent (`namespace eval ::p::q::r {}` creates `::p` and `::p::q`
+//! on both interpreters) has no declaring row of its own, because its name is
+//! not written anywhere.
 
 use std::collections::HashSet;
 use std::sync::Arc;
@@ -309,6 +322,32 @@ pub struct WorkspaceVariableAlias {
     pub uri: String,
     /// `::`-rooted cell the alias binds to, e.g. `::ns::v`.
     pub qualified_name: String,
+}
+
+/// One occurrence of a word naming a **namespace**, recorded workspace-wide —
+/// the cross-document half of issue #1088, lifted verbatim from
+/// [`tcl_compiler::analyser::NamespaceRef`].
+///
+/// One table, not two, because a namespace's declaring site *is* one of its
+/// spellings: the `::tomato` of `namespace eval ::tomato { … }` is both the
+/// definition go-to-definition answers with and a word find-references
+/// reports.  [`Self::declares`] is the discriminator, and it is registry data
+/// ([`tcl_registry::Traits::DECLARES_NAMESPACE`]), not a spelling check.
+///
+/// Unlike [`WorkspaceVariable`] this table needs no qualified-only bound: the
+/// analyser roots a relative namespace word against its own lexical namespace
+/// before recording it, so every row already names one namespace absolutely,
+/// spellable from any document.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceNamespaceRef {
+    /// Document the occurrence is in.
+    pub uri: String,
+    /// `::`-rooted namespace the occurrence names.
+    pub qualified_name: String,
+    /// Byte span of the name token as written.
+    pub span: Span,
+    /// `true` for a declaring `namespace eval` name word.
+    pub declares: bool,
 }
 
 /// Whether a word carries a substitution marker, so its run-time text is not
@@ -576,6 +615,7 @@ pub struct WorkspaceIndex {
     variables: Vec<WorkspaceVariable>,
     variable_refs: Vec<WorkspaceVariableRef>,
     variable_aliases: Vec<WorkspaceVariableAlias>,
+    namespace_refs: Vec<WorkspaceNamespaceRef>,
     invocations: Vec<WorkspaceInvocation>,
     sources: Vec<WorkspaceSource>,
     package_requires: Vec<WorkspacePackageRequire>,
@@ -739,12 +779,18 @@ impl WorkspaceIndex {
     }
 
     /// The `::`-stripped namespaces the workspace can say anything about: one
-    /// that owns an indexed proc or class, or that declares a `namespace
-    /// export` somewhere.
+    /// that owns an indexed proc or class, that declares a `namespace export`
+    /// somewhere, or that an indexed `namespace eval` block declares.
     ///
     /// The discriminator between "this namespace does not export the name"
     /// (a fact) and "this namespace is not in the workspace at all" (no
     /// information) — see [`Self::live_command_links`].
+    ///
+    /// The declaring-block source (issue #1088) closes a hole the first two
+    /// leave: a `namespace eval ::ns { namespace import ::other::* }` block
+    /// that declares no proc, class, or export of its own *is* a namespace
+    /// the workspace can see, and treating it as unknown made the import gate
+    /// abstain where it had the evidence to decide.
     fn observable_namespaces(&self) -> HashSet<&str> {
         fn owning_ns(qualified: &str) -> &str {
             qualified
@@ -760,6 +806,12 @@ impl WorkspaceIndex {
                 self.namespace_exports
                     .iter()
                     .map(|e| e.ns.trim_start_matches("::")),
+            )
+            .chain(
+                self.namespace_refs
+                    .iter()
+                    .filter(|n| n.declares)
+                    .map(|n| n.qualified_name.trim_start_matches("::")),
             )
             .collect()
     }
@@ -825,6 +877,7 @@ impl WorkspaceIndex {
             });
         }
         self.index_variables(uri, analysis);
+        self.index_namespace_refs(uri, analysis);
         for inv in &analysis.command_invocations {
             self.invocations.push(WorkspaceInvocation {
                 uri: uri.to_owned(),
@@ -899,6 +952,25 @@ impl WorkspaceIndex {
                 uri: uri.to_owned(),
                 qualified_name: tcl_syntax::naming::normalise_qualified_name(&vref.qualified_name),
                 span: vref.span,
+            });
+        }
+    }
+
+    /// Lift a document's namespace-name occurrences
+    /// ([`tcl_compiler::analyser::AnalysisResult::namespace_refs`]) into the
+    /// workspace table, so `namespace children ::tomato` in one file reaches
+    /// the `namespace eval ::tomato { … }` in another (issue #1088).
+    ///
+    /// A straight copy: the analyser has already rooted relative spellings
+    /// and dropped computed ones, so there is no second resolution rule here
+    /// that could disagree with the in-document providers.
+    fn index_namespace_refs(&mut self, uri: &str, analysis: &AnalysisResult) {
+        for nref in &analysis.namespace_refs {
+            self.namespace_refs.push(WorkspaceNamespaceRef {
+                uri: uri.to_owned(),
+                qualified_name: tcl_syntax::naming::normalise_qualified_name(&nref.qualified_name),
+                span: nref.span,
+                declares: nref.declares,
             });
         }
     }
@@ -1017,6 +1089,7 @@ impl WorkspaceIndex {
         self.variables.retain(|v| v.uri != uri);
         self.variable_refs.retain(|v| v.uri != uri);
         self.variable_aliases.retain(|v| v.uri != uri);
+        self.namespace_refs.retain(|n| n.uri != uri);
         self.invocations.retain(|i| i.uri != uri);
         self.sources.retain(|s| s.uri != uri);
         self.package_requires.retain(|pr| pr.uri != uri);
@@ -1807,6 +1880,55 @@ impl WorkspaceIndex {
         uris.sort();
         uris.dedup();
         uris
+    }
+
+    /// Every indexed namespace-name occurrence.
+    #[must_use]
+    pub fn namespace_refs(&self) -> &[WorkspaceNamespaceRef] {
+        &self.namespace_refs
+    }
+
+    /// **Declaring** sites of the namespace `qualified_name` — the name word
+    /// of each `namespace eval` block that creates or extends it — excluding
+    /// any in `exclude_uri` (pass `""` to exclude nothing).
+    ///
+    /// A set, not an `Option`, and for a stronger reason than the variable
+    /// tier's: reopening a namespace is the *normal* way to build one, and
+    /// tclsh 9.0.4 / 8.6.16 agree byte-for-byte that two `namespace eval ::a
+    /// {}` blocks are one namespace (`info vars ::a::*` shows both blocks'
+    /// variables).  Every block is a real definition site.
+    ///
+    /// Exact-name matching only: the analyser already rooted every relative
+    /// spelling, so there is no candidate list to walk.
+    #[must_use]
+    pub fn namespace_declarations_qualified<'a>(
+        &'a self,
+        qualified_name: &str,
+        exclude_uri: &str,
+    ) -> Vec<&'a WorkspaceNamespaceRef> {
+        let target = qualified_name.trim_start_matches("::");
+        self.namespace_refs
+            .iter()
+            .filter(|n| n.declares && n.uri != exclude_uri)
+            .filter(|n| n.qualified_name.trim_start_matches("::") == target)
+            .collect()
+    }
+
+    /// Non-declaring occurrences of the namespace `qualified_name`, excluding
+    /// any in `exclude_uri` — the reference-side twin of
+    /// [`Self::namespace_declarations_qualified`].
+    #[must_use]
+    pub fn namespace_refs_of<'a>(
+        &'a self,
+        qualified_name: &str,
+        exclude_uri: &str,
+    ) -> Vec<&'a WorkspaceNamespaceRef> {
+        let target = qualified_name.trim_start_matches("::");
+        self.namespace_refs
+            .iter()
+            .filter(|n| !n.declares && n.uri != exclude_uri)
+            .filter(|n| n.qualified_name.trim_start_matches("::") == target)
+            .collect()
     }
 
     /// Occurrence (read / write) sites naming the namespace variable
@@ -3306,6 +3428,87 @@ mod tests {
             "with no colliding builtin, the nested definition still counts \
              (e.g. `namespace which -command` probes, W120 existence checks)",
         );
+    }
+
+    #[test]
+    fn namespace_declarations_and_refs_are_indexed_across_documents() {
+        // TP (issue #1088) — the declaring `namespace eval` blocks live in
+        // one document and the `namespace children ::mypkg` consumer in
+        // another; both spellings name the one namespace.  Oracle (tclsh
+        // 9.0.4 / 8.6.16, byte-identical): reopening `::mypkg` extends the
+        // same namespace, and `namespace children ::mypkg` lists its
+        // children rather than erroring.
+        let decl = analyse("namespace eval mypkg {}\nnamespace eval mypkg {}\n");
+        let user = analyse("set t [namespace children ::mypkg]\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///decl.tcl", &decl),
+            ("file:///user.tcl", &user),
+        ]);
+        assert_eq!(
+            index
+                .namespace_declarations_qualified("::mypkg", "")
+                .iter()
+                .map(|n| n.uri.as_str())
+                .collect::<Vec<_>>(),
+            vec!["file:///decl.tcl", "file:///decl.tcl"],
+            "both declaring blocks are definition sites",
+        );
+        assert_eq!(
+            index
+                .namespace_refs_of("::mypkg", "")
+                .iter()
+                .map(|n| n.uri.as_str())
+                .collect::<Vec<_>>(),
+            vec!["file:///user.tcl"],
+        );
+        // The declaring document is excluded on request, which is how the
+        // cross-document definition tier avoids re-reporting local answers.
+        assert!(
+            index
+                .namespace_declarations_qualified("::mypkg", "file:///decl.tcl")
+                .is_empty(),
+        );
+    }
+
+    #[test]
+    fn namespace_rows_are_dropped_with_their_document() {
+        // A re-index (`remove_document` then `add_document`) must not leave
+        // stale namespace rows behind — the same discipline every other
+        // table follows.
+        let a = analyse("namespace eval gone {}\n");
+        let mut index = WorkspaceIndex::from_documents([("file:///a.tcl", &a)]);
+        assert_eq!(
+            index.namespace_declarations_qualified("::gone", "").len(),
+            1
+        );
+        index.remove_document("file:///a.tcl");
+        assert!(
+            index
+                .namespace_declarations_qualified("::gone", "")
+                .is_empty()
+        );
+        assert!(index.namespace_refs().is_empty());
+    }
+
+    #[test]
+    fn a_relative_namespace_word_is_indexed_rooted() {
+        // TP — the analyser roots a relative spelling against its own
+        // namespace before the index sees it, so a sibling document can
+        // match it by exact qualified name.  Oracle: inside `namespace eval
+        // ::outer`, `namespace children inner` means `::outer::inner`; the
+        // same words at global scope mean `::inner` (both interpreters).
+        let a = analyse(
+            "namespace eval ::outer {\n    namespace eval inner {}\n    namespace children inner\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a)]);
+        assert_eq!(
+            index
+                .namespace_declarations_qualified("::outer::inner", "")
+                .len(),
+            1,
+        );
+        assert_eq!(index.namespace_refs_of("::outer::inner", "").len(), 1);
+        assert!(index.namespace_refs_of("::inner", "").is_empty());
     }
 
     #[test]

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4283,6 +4283,18 @@ impl Backend {
         // collide with a sibling proc/class name produces a
         // false-positive go-to-definition jump.
         let on_command_head = position_is_command_head(&doc.text, pos, &analysis);
+        // A namespace-name argument is answered here, in full, and never
+        // reaches the tiers below.  Two reasons, both from the review of
+        // #1088: the position is *definitive* (a proc or class of the same
+        // spelling is not what it names), and the answer is the union of the
+        // local and workspace declaring blocks — reopening a namespace
+        // extends the same namespace, so a local block does not make a
+        // sibling document's block any less of a definition.
+        if let Some(cell) = Self::namespace_cell(&doc.text, &analysis, pos) {
+            return Ok(self
+                .namespace_declaration_locations(uri, &analysis, &cell)
+                .await);
+        }
         let text = doc.text.clone();
         let analysis_worker = Arc::clone(&analysis);
         let in_doc = tokio::task::spawn_blocking(move || {
@@ -4323,17 +4335,6 @@ impl Backend {
             if !method_defs.is_empty() {
                 return Ok(method_defs);
             }
-        }
-        // Cross-file namespace: `namespace children ::tomato` whose declaring
-        // `namespace eval ::tomato { … }` is in another document (issue
-        // #1088).  Not gated on `on_command_head` — a namespace-name argument
-        // never is one — and safe without that gate because the namespace is
-        // named exactly, not matched by simple name.
-        let cross_ns = self
-            .cross_document_namespace_definition(uri, &doc.text, pos, &analysis)
-            .await;
-        if !cross_ns.is_empty() {
-            return Ok(cross_ns);
         }
         // Cross-file namespace variable: `$::NS::var` whose declaring
         // `namespace eval NS { variable var }` is in another document (issue
@@ -4392,125 +4393,137 @@ impl Backend {
     /// cursor shapes that answer.  The one place the server decides "this
     /// position is about a namespace", shared by the cross-document
     /// definition, hover, and references tiers so they cannot disagree.
-    fn namespace_cell(
-        source: &str,
-        dialect: &str,
-        analysis: &AnalysisResult,
-        pos: Position,
-    ) -> Option<String> {
-        core_namespace_symbol::namespace_cell_at(source, dialect, analysis, pos.line, pos.character)
+    fn namespace_cell(source: &str, analysis: &AnalysisResult, pos: Position) -> Option<String> {
+        core_namespace_symbol::namespace_cell_at(source, analysis, pos.line, pos.character)
     }
 
-    /// Cross-document go-to-definition for a namespace: the declaring
-    /// `namespace eval` blocks the workspace index holds for the namespace at
-    /// `pos`, in *other* documents.
+    /// Every declaring `namespace eval` block of `cell`, local **and**
+    /// workspace, as LSP locations.
     ///
-    /// Only ever consulted after the in-document provider came back empty, so
-    /// a locally-declared namespace always answers locally.  The index lookup
-    /// is an exact qualified-name match — no scan of other documents, no
-    /// re-analysis (issue #1088).  Every declaring block answers, not just
-    /// the first: reopening a namespace extends the same one on tclsh 9.0.4
-    /// and 8.6.16 alike.
-    async fn cross_document_namespace_definition(
+    /// The union is the contract, not an optimisation: reopening a namespace
+    /// extends the same namespace (tclsh 9.0.4 / 8.6.16, byte-identical —
+    /// `namespace eval ::a {}` twice leaves one namespace holding both
+    /// blocks' variables), so every block is a definition site and a local
+    /// one does not make a sibling document's block any less of one.  The
+    /// first cut returned as soon as the in-document provider answered, *and*
+    /// excluded the current URI from the index lookup, so a namespace opened
+    /// both here and next door reported only the local half (issue #1088
+    /// review, finding 2).
+    ///
+    /// The local half is read from the request's own analysis rather than the
+    /// index, so an unindexed or just-edited document still answers; rows are
+    /// deduplicated by `(uri, span)`, which is what makes overlapping with
+    /// the index harmless.
+    async fn namespace_declaration_locations(
         &self,
         uri: &Uri,
-        source: &str,
-        pos: Position,
         analysis: &AnalysisResult,
+        cell: &str,
     ) -> Vec<Location> {
-        let Some(cell) = Self::namespace_cell(source, &analysis.dialect, analysis, pos) else {
-            return Vec::new();
-        };
         self.refresh_source_rehoming().await;
-        let targets: Vec<(String, tcl_lexer::Span)> = {
-            let index = self.workspace_index.read().await;
-            index
-                .namespace_declarations_qualified(&cell, uri.as_str())
+        let mut targets: Vec<(String, tcl_lexer::Span)> =
+            core_namespace_symbol::namespace_declaration_spans(analysis, cell)
                 .into_iter()
-                .map(|n| (n.uri.clone(), n.span))
-                .collect()
-        };
+                .map(|span| (uri.as_str().to_owned(), span))
+                .collect();
+        {
+            let index = self.workspace_index.read().await;
+            targets.extend(
+                index
+                    .namespace_declarations_qualified(cell, "")
+                    .into_iter()
+                    .map(|n| (n.uri.clone(), n.span)),
+            );
+        }
+        dedup_span_targets(&mut targets);
         self.resolve_target_locations(targets).await
     }
 
-    /// Hover for a namespace declared in a sibling document — the hover twin
-    /// of [`Self::cross_document_namespace_definition`], rendered from the
-    /// *declaring* document's own analysis (memoised by
-    /// [`Self::analysis_for`]).
-    async fn cross_document_namespace_hover(
+    /// Hover for the namespace `cell`, counted over the local document **and**
+    /// every indexed sibling.
+    ///
+    /// Counting only the document under the cursor contradicted
+    /// go-to-definition, which offers every declaring block wherever it lives
+    /// (issue #1088 review, finding 2).  The rendering itself stays in
+    /// [`core_namespace_symbol::namespace_hover_markdown`], so the
+    /// in-document provider and this tier cannot word the same fact
+    /// differently — they differ only in how wide a set they counted, which
+    /// the text states.
+    ///
+    /// `None` when nothing anywhere declares it: hover then shows nothing,
+    /// which is the correct answer for a namespace no file in view creates —
+    /// never a fall-through to command documentation.
+    async fn namespace_hover(
         &self,
         uri: &Uri,
-        source: &str,
-        pos: Position,
         analysis: &AnalysisResult,
+        cell: &str,
     ) -> Option<CoreHover> {
-        let cell = Self::namespace_cell(source, &analysis.dialect, analysis, pos)?;
         self.refresh_source_rehoming().await;
-        let target_uris: Vec<String> = {
+        let local = core_namespace_symbol::namespace_facts(analysis, cell);
+        let facts = {
             let index = self.workspace_index.read().await;
-            index
-                .namespace_declarations_qualified(&cell, uri.as_str())
+            let mut merged = local;
+            let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
+            for row in index
+                .namespace_declarations_qualified(cell, uri.as_str())
                 .into_iter()
-                .map(|n| n.uri.clone())
-                .collect()
-        };
-        for target_uri in target_uris {
-            let Ok(parsed) = Uri::from_str(&target_uri) else {
-                continue;
-            };
-            let Some(target_doc) = self.read_document(&parsed).await else {
-                continue;
-            };
-            let target_analysis = self
-                .analysis_for(&parsed, target_doc.text.clone(), target_doc.dialect.clone())
-                .await;
-            if let Some(hover) = core_hover::qualified_namespace_hover(&target_analysis, &cell) {
-                return Some(hover);
+                .chain(index.namespace_refs_of(cell, uri.as_str()))
+            {
+                if row.declares {
+                    merged.declarations += 1;
+                } else {
+                    merged.references += 1;
+                }
+                if seen.insert(row.uri.as_str()) {
+                    merged.documents += 1;
+                }
             }
-        }
-        None
+            merged
+        };
+        core_hover::namespace_hover(cell, facts)
     }
 
-    /// Workspace references for the namespace at `pos`: every occurrence of
-    /// it anywhere in the index, plus its declaring `namespace eval` blocks
-    /// when `include_declaration`.
+    /// Every occurrence of the namespace `cell`, local **and** workspace —
+    /// declarations included when `include_declaration`.
     ///
-    /// Like the variable tier this excludes **no** document, the caller's own
-    /// included, and for the same structural reason: a document that merely
-    /// mentions `::tomato` holds no declaration to anchor the single-document
-    /// pass on.  The caller dedupes ([`dedup_locations`]) and the index
-    /// records the same spans the single-document pass does, so an occurrence
-    /// already reported collapses rather than doubling.
-    async fn cross_document_namespace_references(
+    /// Excludes no document, the caller's own included: a document that
+    /// merely mentions `::tomato` holds no declaration to anchor a
+    /// single-document pass on, and the local half is read from the request's
+    /// own analysis so an unindexed document still contributes.  Rows are
+    /// deduplicated by `(uri, span)`, so an occurrence the index also holds
+    /// collapses rather than doubling.
+    async fn namespace_reference_locations(
         &self,
-        source: &str,
+        uri: &Uri,
         analysis: &AnalysisResult,
-        pos: Position,
+        cell: &str,
         include_declaration: bool,
     ) -> Vec<Location> {
-        let Some(cell) = Self::namespace_cell(source, &analysis.dialect, analysis, pos) else {
-            return Vec::new();
-        };
         self.refresh_source_rehoming().await;
-        let targets: Vec<(String, tcl_lexer::Span)> = {
-            let index = self.workspace_index.read().await;
-            let mut t: Vec<(String, tcl_lexer::Span)> = index
-                .namespace_refs_of(&cell, "")
+        let mut targets: Vec<(String, tcl_lexer::Span)> =
+            core_namespace_symbol::namespace_all_spans(analysis, cell, include_declaration)
                 .into_iter()
-                .map(|n| (n.uri.clone(), n.span))
+                .map(|span| (uri.as_str().to_owned(), span))
                 .collect();
+        {
+            let index = self.workspace_index.read().await;
+            targets.extend(
+                index
+                    .namespace_refs_of(cell, "")
+                    .into_iter()
+                    .map(|n| (n.uri.clone(), n.span)),
+            );
             if include_declaration {
-                t.extend(
+                targets.extend(
                     index
-                        .namespace_declarations_qualified(&cell, "")
+                        .namespace_declarations_qualified(cell, "")
                         .into_iter()
                         .map(|n| (n.uri.clone(), n.span)),
                 );
             }
-            t.sort_by_key(|(u, s)| (u.clone(), s.start(), s.end()));
-            t.dedup();
-            t
-        };
+        }
+        dedup_span_targets(&mut targets);
         self.resolve_target_locations(targets).await
     }
 
@@ -5328,6 +5341,17 @@ impl Backend {
         position: Position,
         include_declaration: bool,
     ) -> Vec<Location> {
+        // A namespace-name argument is answered here, in full.  It must not
+        // reach the tiers below: the position is definitive, and an *empty*
+        // local set — which is what asking for references without
+        // declarations from a namespace's only declaring block produces —
+        // would otherwise route the query to `workspace_resolved_references`,
+        // the proc/class tier (issue #1088 review, finding 1).
+        if let Some(cell) = Self::namespace_cell(&doc.text, analysis, position) {
+            return self
+                .namespace_reference_locations(uri, analysis, &cell, include_declaration)
+                .await;
+        }
         let text = doc.text.clone();
         let dialect = doc.dialect.clone();
         let analysis_for_worker = analysis.clone();
@@ -5375,20 +5399,6 @@ impl Backend {
         // consumer document holds no `VarDef` for a cell it merely reads.
         locations.extend(
             self.cross_document_variable_references(
-                &doc.text,
-                analysis,
-                position,
-                include_declaration,
-            )
-            .await,
-        );
-        // Cross-document namespace sites: every other spelling of the
-        // namespace the cursor names, plus its declaring `namespace eval`
-        // blocks when asked for (issue #1088).  The single-document provider
-        // above only sees this file, and a namespace is routinely referenced
-        // from files that declare none of it.
-        locations.extend(
-            self.cross_document_namespace_references(
                 &doc.text,
                 analysis,
                 position,
@@ -5948,6 +5958,27 @@ impl Backend {
         pos: Position,
         new_name: &str,
     ) -> Option<jsonrpc::Result<Option<WorkspaceEdit>>> {
+        // Namespace names refuse outright.  This has to be a *refusal* and
+        // not an empty edit set: an empty set falls through to the ordinary
+        // and workspace-resolved rename tiers, which resolve the cursor
+        // **word** as a command — so `namespace children widget` beside a
+        // `proc widget` renamed the proc instead (issue #1088 review,
+        // finding 1).  Renaming a namespace itself is not implemented: the
+        // edit set would have to rewrite every qualified name declared
+        // beneath it and every `namespace eval` block that reopens it.
+        if let Some(cell) = Self::namespace_cell(&doc.text, analysis, pos) {
+            return Some(Err(rename_refusal_error(
+                &core_rename_safety::RenameRefusal {
+                    reason: format!(
+                        "`{cell}` is a namespace name. Renaming a namespace is not \
+                         supported: it would have to rewrite every qualified name \
+                         declared beneath it and every `namespace eval` block that \
+                         reopens it."
+                    ),
+                    range: None,
+                },
+            )));
+        }
         // Safety gate: when the cursor names a `TclOO` member whose dispatch
         // this rename cannot account for anywhere in the workspace, refuse
         // with a precise reason instead of emitting a partial edit set that
@@ -12028,6 +12059,18 @@ impl LanguageServer for Backend {
         // that happens to share a sibling proc's name would pop up that proc's
         // signature.  Computed here, while `analysis` is still in scope.
         let on_command_head = position_is_command_head(&doc.text, pos, &analysis);
+        // A namespace-name argument is answered here, in full, and never
+        // reaches the tiers below — the position is definitive, and the
+        // counts describe the whole workspace rather than just this document
+        // (issue #1088 review, findings 1 and 2).  `None` means no file in
+        // view declares the namespace, which is a real "no hover", not a
+        // licence to fall through to command documentation.
+        if let Some(cell) = Self::namespace_cell(&doc.text, &analysis, pos) {
+            return Ok(self
+                .namespace_hover(&uri, &analysis, &cell)
+                .await
+                .map(lift_hover));
+        }
         let text = doc.text.clone();
         let analysis_worker = Arc::clone(&analysis);
         let result = tokio::task::spawn_blocking(move || {
@@ -12055,14 +12098,6 @@ impl LanguageServer for Backend {
         // reach the tiers below (issue #923 idx 65 / 75 / 78).
         if let Some(hover) = self
             .cross_document_variable_hover(&uri, &doc.text, pos, &analysis)
-            .await
-        {
-            return Ok(Some(lift_hover(hover)));
-        }
-        // Same for a namespace whose declaring `namespace eval` is in a
-        // sibling document (issue #1088).
-        if let Some(hover) = self
-            .cross_document_namespace_hover(&uri, &doc.text, pos, &analysis)
             .await
         {
             return Ok(Some(lift_hover(hover)));
@@ -12391,6 +12426,23 @@ fn action_command_to_lsp(
 /// Deduplicate `Location`s by `(uri, range)`, preserving first-
 /// seen order.  Used to merge current-document and cross-
 /// document reference hits without double-listing a location.
+/// Sort `(uri, span)` targets into a stable document-then-position order and
+/// drop exact duplicates.
+///
+/// The union tiers (namespace declarations / references) read the same site
+/// from two places — the request document's own analysis and the workspace
+/// index — so overlap is the normal case, not an error.  Deduplicating on the
+/// pair rather than on the rendered `Location` keeps it independent of the
+/// (async, source-reading) span-to-range conversion.
+fn dedup_span_targets(targets: &mut Vec<(String, tcl_lexer::Span)>) {
+    targets.sort_by(|(au, a), (bu, b)| {
+        au.cmp(bu)
+            .then_with(|| a.start().cmp(&b.start()))
+            .then_with(|| a.end().cmp(&b.end()))
+    });
+    targets.dedup();
+}
+
 fn dedup_locations(locations: &mut Vec<Location>) {
     let mut seen: std::collections::HashSet<(String, u32, u32, u32, u32)> =
         std::collections::HashSet::new();

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -64,6 +64,7 @@ use tcl_lsp_core::implementation as core_implementation;
 use tcl_lsp_core::inlay_hints as core_inlay_hints;
 use tcl_lsp_core::linked_editing_range as core_linked_editing_range;
 use tcl_lsp_core::minify as core_minify;
+use tcl_lsp_core::namespace_symbol as core_namespace_symbol;
 use tcl_lsp_core::package_resolver::PackageResolver;
 use tcl_lsp_core::references as core_references;
 use tcl_lsp_core::rename as core_rename;
@@ -4323,6 +4324,17 @@ impl Backend {
                 return Ok(method_defs);
             }
         }
+        // Cross-file namespace: `namespace children ::tomato` whose declaring
+        // `namespace eval ::tomato { … }` is in another document (issue
+        // #1088).  Not gated on `on_command_head` — a namespace-name argument
+        // never is one — and safe without that gate because the namespace is
+        // named exactly, not matched by simple name.
+        let cross_ns = self
+            .cross_document_namespace_definition(uri, &doc.text, pos, &analysis)
+            .await;
+        if !cross_ns.is_empty() {
+            return Ok(cross_ns);
+        }
         // Cross-file namespace variable: `$::NS::var` whose declaring
         // `namespace eval NS { variable var }` is in another document (issue
         // #923 idx 65 / 75 / 78).  Not gated on `on_command_head` — a `$var`
@@ -4373,6 +4385,133 @@ impl Backend {
             pos.line,
             pos.character,
         )
+    }
+
+    /// The `::`-rooted namespace the cursor names, or `None` when it names
+    /// none — see [`core_namespace_symbol::namespace_cell_at`] for the two
+    /// cursor shapes that answer.  The one place the server decides "this
+    /// position is about a namespace", shared by the cross-document
+    /// definition, hover, and references tiers so they cannot disagree.
+    fn namespace_cell(
+        source: &str,
+        dialect: &str,
+        analysis: &AnalysisResult,
+        pos: Position,
+    ) -> Option<String> {
+        core_namespace_symbol::namespace_cell_at(source, dialect, analysis, pos.line, pos.character)
+    }
+
+    /// Cross-document go-to-definition for a namespace: the declaring
+    /// `namespace eval` blocks the workspace index holds for the namespace at
+    /// `pos`, in *other* documents.
+    ///
+    /// Only ever consulted after the in-document provider came back empty, so
+    /// a locally-declared namespace always answers locally.  The index lookup
+    /// is an exact qualified-name match — no scan of other documents, no
+    /// re-analysis (issue #1088).  Every declaring block answers, not just
+    /// the first: reopening a namespace extends the same one on tclsh 9.0.4
+    /// and 8.6.16 alike.
+    async fn cross_document_namespace_definition(
+        &self,
+        uri: &Uri,
+        source: &str,
+        pos: Position,
+        analysis: &AnalysisResult,
+    ) -> Vec<Location> {
+        let Some(cell) = Self::namespace_cell(source, &analysis.dialect, analysis, pos) else {
+            return Vec::new();
+        };
+        self.refresh_source_rehoming().await;
+        let targets: Vec<(String, tcl_lexer::Span)> = {
+            let index = self.workspace_index.read().await;
+            index
+                .namespace_declarations_qualified(&cell, uri.as_str())
+                .into_iter()
+                .map(|n| (n.uri.clone(), n.span))
+                .collect()
+        };
+        self.resolve_target_locations(targets).await
+    }
+
+    /// Hover for a namespace declared in a sibling document — the hover twin
+    /// of [`Self::cross_document_namespace_definition`], rendered from the
+    /// *declaring* document's own analysis (memoised by
+    /// [`Self::analysis_for`]).
+    async fn cross_document_namespace_hover(
+        &self,
+        uri: &Uri,
+        source: &str,
+        pos: Position,
+        analysis: &AnalysisResult,
+    ) -> Option<CoreHover> {
+        let cell = Self::namespace_cell(source, &analysis.dialect, analysis, pos)?;
+        self.refresh_source_rehoming().await;
+        let target_uris: Vec<String> = {
+            let index = self.workspace_index.read().await;
+            index
+                .namespace_declarations_qualified(&cell, uri.as_str())
+                .into_iter()
+                .map(|n| n.uri.clone())
+                .collect()
+        };
+        for target_uri in target_uris {
+            let Ok(parsed) = Uri::from_str(&target_uri) else {
+                continue;
+            };
+            let Some(target_doc) = self.read_document(&parsed).await else {
+                continue;
+            };
+            let target_analysis = self
+                .analysis_for(&parsed, target_doc.text.clone(), target_doc.dialect.clone())
+                .await;
+            if let Some(hover) = core_hover::qualified_namespace_hover(&target_analysis, &cell) {
+                return Some(hover);
+            }
+        }
+        None
+    }
+
+    /// Workspace references for the namespace at `pos`: every occurrence of
+    /// it anywhere in the index, plus its declaring `namespace eval` blocks
+    /// when `include_declaration`.
+    ///
+    /// Like the variable tier this excludes **no** document, the caller's own
+    /// included, and for the same structural reason: a document that merely
+    /// mentions `::tomato` holds no declaration to anchor the single-document
+    /// pass on.  The caller dedupes ([`dedup_locations`]) and the index
+    /// records the same spans the single-document pass does, so an occurrence
+    /// already reported collapses rather than doubling.
+    async fn cross_document_namespace_references(
+        &self,
+        source: &str,
+        analysis: &AnalysisResult,
+        pos: Position,
+        include_declaration: bool,
+    ) -> Vec<Location> {
+        let Some(cell) = Self::namespace_cell(source, &analysis.dialect, analysis, pos) else {
+            return Vec::new();
+        };
+        self.refresh_source_rehoming().await;
+        let targets: Vec<(String, tcl_lexer::Span)> = {
+            let index = self.workspace_index.read().await;
+            let mut t: Vec<(String, tcl_lexer::Span)> = index
+                .namespace_refs_of(&cell, "")
+                .into_iter()
+                .map(|n| (n.uri.clone(), n.span))
+                .collect();
+            if include_declaration {
+                t.extend(
+                    index
+                        .namespace_declarations_qualified(&cell, "")
+                        .into_iter()
+                        .map(|n| (n.uri.clone(), n.span)),
+                );
+            }
+            t.sort_by_key(|(u, s)| (u.clone(), s.start(), s.end()));
+            t.dedup();
+            t
+        };
+        self.resolve_target_locations(targets).await
     }
 
     /// Cross-document go-to-definition for a namespace variable: the
@@ -5236,6 +5375,20 @@ impl Backend {
         // consumer document holds no `VarDef` for a cell it merely reads.
         locations.extend(
             self.cross_document_variable_references(
+                &doc.text,
+                analysis,
+                position,
+                include_declaration,
+            )
+            .await,
+        );
+        // Cross-document namespace sites: every other spelling of the
+        // namespace the cursor names, plus its declaring `namespace eval`
+        // blocks when asked for (issue #1088).  The single-document provider
+        // above only sees this file, and a namespace is routinely referenced
+        // from files that declare none of it.
+        locations.extend(
+            self.cross_document_namespace_references(
                 &doc.text,
                 analysis,
                 position,
@@ -11902,6 +12055,14 @@ impl LanguageServer for Backend {
         // reach the tiers below (issue #923 idx 65 / 75 / 78).
         if let Some(hover) = self
             .cross_document_variable_hover(&uri, &doc.text, pos, &analysis)
+            .await
+        {
+            return Ok(Some(lift_hover(hover)));
+        }
+        // Same for a namespace whose declaring `namespace eval` is in a
+        // sibling document (issue #1088).
+        if let Some(hover) = self
+            .cross_document_namespace_hover(&uri, &doc.text, pos, &analysis)
             .await
         {
             return Ok(Some(lift_hover(hover)));

--- a/rust/tcl-lsp-server/tests/e2e.rs
+++ b/rust/tcl-lsp-server/tests/e2e.rs
@@ -57,6 +57,8 @@ mod invariants;
 mod irules;
 #[path = "e2e/issue1001.rs"]
 mod issue1001;
+#[path = "e2e/issue1088_namespace_symbols.rs"]
+mod issue1088_namespace_symbols;
 #[path = "e2e/issue923_class_refs.rs"]
 mod issue923_class_refs;
 #[path = "e2e/issue923_crossdoc.rs"]

--- a/rust/tcl-lsp-server/tests/e2e/issue1088_namespace_symbols.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1088_namespace_symbols.rs
@@ -1,0 +1,338 @@
+// tcl-lsp — a language server and toolchain for Tcl
+// Copyright (C) 2026 James Deucker (bitwisecook) <https://github.com/bitwisecook>
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <https://www.gnu.org/licenses/>.
+//
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+//! Issue #1088 — namespace names as navigable symbols.
+//!
+//! Split out of issue #923 audit idx 75's secondary claim: a namespace *name*
+//! written as an argument (`namespace children ::tomato`, `namespace exists`,
+//! `namespace delete`, `namespace upvar`, and the `namespace eval` target
+//! itself) had no definition / hover / references answer at all, even in a
+//! single file — namespaces were modelled as containers, never as symbols.
+//!
+//! The oracle every positive case here is written against, pinned on tclsh
+//! 9.0.4 and 8.6.16 and byte-identical on both:
+//!
+//! ```text
+//! namespace eval ::a { variable x 1 }
+//! namespace eval ::a { variable y 2 }
+//! namespace exists ::a      -> 1          ;# one namespace, two declaring blocks
+//! info vars ::a::*          -> ::a::x ::a::y
+//!
+//! namespace eval ::p::q::r {}
+//! namespace exists ::p      -> 1          ;# parents created implicitly
+//!
+//! proc ::nope::gone::p {} {} -> can't create procedure "::nope::gone::p": unknown namespace
+//! set ::brandnew::v 1        -> can't set "::brandnew::v": parent namespace doesn't exist
+//!
+//! namespace eval ::outer { namespace eval inner {} ; namespace exists inner } -> 1
+//! namespace exists inner    -> 0          ;# …at global scope, a different name
+//!
+//! namespace delete ::d ; namespace exists ::d -> 0
+//! namespace exists ::never  -> 0
+//! namespace children ::never -> namespace "::never" not found        (rc 1)
+//! namespace delete ::never   -> unknown namespace "::never" in namespace delete command (rc 1)
+//! ```
+
+use crate::common::helpers::*;
+use crate::common::{Lsp, unique_uri};
+use serde_json::Value;
+
+/// The definition/reference target start lines that land in document `uri`.
+fn lines_in(result: &Value, uri: &str) -> Vec<i64> {
+    locations(result)
+        .iter()
+        .filter(|l| l.uri == uri)
+        .map(|l| {
+            l.range
+                .get("start")
+                .and_then(|s| s.get("line"))
+                .and_then(Value::as_i64)
+                .unwrap_or(-1)
+        })
+        .collect()
+}
+
+// TP — the finding's own shape: `namespace children ::mypkg` jumps to *every*
+// `namespace eval mypkg` block, because reopening extends the one namespace.
+#[test]
+fn tp_namespace_children_argument_reaches_every_declaring_block() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval mypkg {\n\
+         \x20   variable version 1.0\n\
+         }\n\
+         namespace eval mypkg {\n\
+         \x20   proc helper {} { return 1 }\n\
+         }\n\
+         set targets [namespace children ::mypkg]\n",
+    );
+
+    let def = lsp.definition(&uri, 6, 33);
+    assert_eq!(
+        lines_in(&def, &uri),
+        vec![0, 3],
+        "both `namespace eval mypkg` blocks are declaring sites: {:?}",
+        locations(&def),
+    );
+}
+
+// TP — hover names the namespace rather than showing nothing.
+#[test]
+fn tp_namespace_name_hover_names_the_namespace() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval tomato {}\nputs [namespace exists ::tomato]\n",
+    );
+
+    let text = hover_text(&lsp.hover(&uri, 1, 26));
+    assert!(
+        text.contains("::tomato") && text.contains("Namespace"),
+        "hover must describe the namespace, got: {text:?}",
+    );
+}
+
+// TP — find-references from a declaring block reaches every other spelling,
+// and the declarations themselves when asked for.
+#[test]
+fn tp_references_from_the_declaration_reach_every_spelling() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval mypkg {}\n\
+         namespace children ::mypkg\n\
+         namespace exists mypkg\n\
+         namespace delete ::mypkg\n",
+    );
+
+    let refs = lsp.references(&uri, 0, 16, true);
+    assert_eq!(
+        lines_in(&refs, &uri),
+        vec![0, 1, 2, 3],
+        "declaration + children + exists + delete: {:?}",
+        locations(&refs),
+    );
+}
+
+// TP — cross-file: the consumer document declares nothing, the declaring
+// `namespace eval` lives in a sibling.  This is the tier the qualified
+// variable work (#1086) established, applied to namespaces.
+#[test]
+fn tp_cross_file_namespace_definition() {
+    let mut lsp = Lsp::tcl();
+    let decl = unique_uri("tcl");
+    lsp.open_ready(
+        &decl,
+        "namespace eval mypkg {\n    variable version 1.0\n}\n",
+    );
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "set targets [namespace children ::mypkg]\n");
+
+    let def = lsp.definition(&user, 0, 33);
+    assert_eq!(
+        lines_in(&def, &decl),
+        vec![0],
+        "the sibling document's `namespace eval mypkg` must be the target: {:?}",
+        locations(&def),
+    );
+}
+
+// TP — cross-file hover and references, both directions.
+#[test]
+fn tp_cross_file_namespace_hover_and_references() {
+    let mut lsp = Lsp::tcl();
+    let decl = unique_uri("tcl");
+    lsp.open_ready(&decl, "namespace eval tomato {\n    variable v 1\n}\n");
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "puts [namespace children ::tomato]\n");
+
+    let text = hover_text(&lsp.hover(&user, 0, 28));
+    assert!(
+        text.contains("::tomato"),
+        "cross-file hover must name the namespace, got: {text:?}",
+    );
+
+    let refs = lsp.references(&decl, 0, 16, true);
+    assert!(
+        lines_in(&refs, &user).contains(&0),
+        "the sibling document's use must be a reference: {:?}",
+        locations(&refs),
+    );
+}
+
+// TP — a **relative** name resolves against the enclosing namespace, so the
+// two `inner`s below are different namespaces.  Oracle: inside `namespace
+// eval ::outer`, `namespace exists inner` is 1; at global scope it is 0.
+#[test]
+fn tp_relative_namespace_name_resolves_against_the_enclosing_namespace() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval ::outer {\n\
+         \x20   namespace eval inner {}\n\
+         \x20   namespace children inner\n\
+         }\n\
+         namespace children inner\n",
+    );
+
+    let inside = lsp.definition(&uri, 2, 24);
+    assert_eq!(
+        lines_in(&inside, &uri),
+        vec![1],
+        "a relative name inside `::outer` means `::outer::inner`: {:?}",
+        locations(&inside),
+    );
+    let outside = lsp.definition(&uri, 4, 21);
+    assert!(
+        lines_in(&outside, &uri).is_empty(),
+        "the same word at global scope means `::inner`, which nothing declares: {:?}",
+        locations(&outside),
+    );
+}
+
+// TN — a namespace-name-shaped run of text inside a **comment** substitutes
+// nothing in real Tcl, so it must resolve to nothing.
+#[test]
+fn tn_comment_text_is_not_a_namespace_reference() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval mypkg {}\n# namespace children ::mypkg here\n",
+    );
+
+    let def = lsp.definition(&uri, 1, 26);
+    assert!(
+        lines_in(&def, &uri).is_empty(),
+        "a comment is not a reference: {:?}",
+        locations(&def),
+    );
+    let refs = lsp.references(&uri, 0, 16, true);
+    assert_eq!(
+        lines_in(&refs, &uri),
+        vec![0],
+        "only the declaration itself: {:?}",
+        locations(&refs),
+    );
+}
+
+// TN — the same inside a **braced data word**: `set d {namespace children
+// ::mypkg}` is a literal string on both interpreters, never a command.
+#[test]
+fn tn_braced_data_word_is_not_a_namespace_reference() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval mypkg {}\nset d {namespace children ::mypkg}\n",
+    );
+
+    let def = lsp.definition(&uri, 1, 30);
+    assert!(
+        lines_in(&def, &uri).is_empty(),
+        "a braced data word is not code: {:?}",
+        locations(&def),
+    );
+}
+
+// TN — an **unknown** namespace answers nothing rather than guessing at a
+// same-tailed one.  Oracle: `namespace children ::never` fails with
+// `namespace "::never" not found`, rc 1, on both interpreters.
+#[test]
+fn tn_unknown_namespace_resolves_to_nothing() {
+    let mut lsp = Lsp::tcl();
+    let decl = unique_uri("tcl");
+    lsp.open_ready(&decl, "namespace eval ::real::mypkg {}\n");
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "namespace children ::mypkg\n");
+
+    let def = lsp.definition(&user, 0, 21);
+    assert!(
+        locations(&def).is_empty(),
+        "`::mypkg` is not `::real::mypkg`: {:?}",
+        locations(&def),
+    );
+}
+
+// FP guard — `namespace tail` / `qualifiers` take an arbitrary string, not a
+// namespace.  Oracle: `namespace tail a::b` answers `b` on both interpreters
+// whether or not `::a` exists.
+#[test]
+fn fp_namespace_tail_argument_is_not_a_namespace_reference() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval mypkg {}\nputs [namespace tail mypkg]\n",
+    );
+
+    let def = lsp.definition(&uri, 1, 23);
+    assert!(
+        lines_in(&def, &uri).is_empty(),
+        "a `namespace tail` argument is a string, not a namespace: {:?}",
+        locations(&def),
+    );
+}
+
+// FN guard — a same-named **proc** must not be the answer for a namespace
+// word, and vice versa: Tcl keeps the two symbol spaces disjoint.
+#[test]
+fn fn_a_same_named_proc_does_not_answer_a_namespace_query() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc mypkg {} { return 1 }\n\
+         namespace eval mypkg {}\n\
+         namespace children mypkg\n",
+    );
+
+    let def = lsp.definition(&uri, 2, 20);
+    assert_eq!(
+        lines_in(&def, &uri),
+        vec![1],
+        "the namespace, not the same-named proc: {:?}",
+        locations(&def),
+    );
+}
+
+// FN guard — `namespace inscope` references, it does not declare.  Oracle:
+// `namespace inscope ::never {}` on an unknown namespace fails, while
+// `namespace eval ::never {}` creates it.
+#[test]
+fn fn_inscope_target_is_a_reference_not_a_declaration() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval ::a {}\nnamespace inscope ::a {set x 1}\n",
+    );
+
+    let def = lsp.definition(&uri, 1, 20);
+    assert_eq!(
+        lines_in(&def, &uri),
+        vec![0],
+        "`inscope`'s target reaches the declaring `eval`, not itself: {:?}",
+        locations(&def),
+    );
+}

--- a/rust/tcl-lsp-server/tests/e2e/issue1088_namespace_symbols.rs
+++ b/rust/tcl-lsp-server/tests/e2e/issue1088_namespace_symbols.rs
@@ -336,3 +336,245 @@ fn fn_inscope_target_is_a_reference_not_a_declaration() {
         locations(&def),
     );
 }
+
+// ---------------------------------------------------------------------------
+// Review of PR #1112 — three P2 tier-completeness findings.
+// ---------------------------------------------------------------------------
+
+// TN (finding 1) — a namespace-name position is **definitive**: it must never
+// fall through to command resolution.  `namespace exists string` with
+// `::string` declared in a sibling document produced the built-in `string`
+// command's documentation, and because that is an answer the server returned
+// it and never consulted the cross-document namespace tier at all.
+#[test]
+fn tn_command_hover_never_claims_a_namespace_word() {
+    let mut lsp = Lsp::tcl();
+    let decl = unique_uri("tcl");
+    lsp.open_ready(&decl, "namespace eval ::string {}\n");
+    let user = unique_uri("tcl");
+    lsp.open_ready(&user, "puts [namespace exists string]\n");
+
+    let text = hover_text(&lsp.hover(&user, 0, 24));
+    assert!(
+        !text.contains("built-in command"),
+        "command hover claimed a namespace word: {text:?}",
+    );
+    assert!(
+        text.contains("::string") && text.contains("Namespace"),
+        "the sibling declaration must answer instead: {text:?}",
+    );
+}
+
+// TN (finding 1) — the same rule for find-references.  Asking *without*
+// declarations from a namespace's only declaring block leaves the local set
+// empty, which is exactly what used to route the query to the proc/class
+// workspace tier.
+#[test]
+fn tn_references_never_fall_through_to_the_proc_tier() {
+    let mut lsp = Lsp::tcl();
+    let lib = unique_uri("tcl");
+    lsp.open_ready(&lib, "proc widget {} { return 1 }\nwidget\n");
+    let here = unique_uri("tcl");
+    lsp.open_ready(&here, "namespace eval widget {}\n");
+
+    let refs = lsp.references(&here, 0, 16, false);
+    assert!(
+        lines_in(&refs, &lib).is_empty(),
+        "proc sites claimed a namespace word: {:?}",
+        locations(&refs),
+    );
+}
+
+// TN (finding 1) — and for rename.  Prepare must offer no UI, and a client
+// that skips prepare must meet a *refusal*, not an empty edit set: an empty
+// set falls through to the server's workspace-resolved rename branch, which
+// resolved the word as a command and rewrote the same-spelled proc — pointing
+// the editor's highlight at a declaration on a completely different line.
+#[test]
+fn tn_rename_refuses_a_namespace_word_rather_than_renaming_a_proc() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "proc widget {} { return 1 }\nnamespace eval widget {}\nnamespace children widget\n",
+    );
+
+    assert!(
+        lsp.prepare_rename(&uri, 2, 20).is_null(),
+        "prepare-rename must not offer to rename a namespace word",
+    );
+    let err = lsp.rename_error(&uri, 2, 20, "gadget");
+    let message = err
+        .get("message")
+        .and_then(Value::as_str)
+        .unwrap_or_default();
+    assert!(
+        message.contains("is a namespace name"),
+        "rename must refuse with a reason naming the namespace, got {err}",
+    );
+}
+
+// TP (finding 2) — a namespace reopened here **and** next door reports both
+// blocks.  Returning as soon as the in-document provider answered (and
+// excluding the current URI from the index lookup) reported only the local
+// half, contradicting the feature's own contract that every declaring block
+// is a target.
+//
+// Oracle — tclsh 9.0.4 and 8.6.16, byte-identical: sourcing both files,
+// `namespace eval mypkg` twice leaves one namespace holding both blocks'
+// contents (`info vars ::mypkg::*` -> `::mypkg::v`, `::mypkg::p` callable).
+#[test]
+fn tp_definition_unions_local_and_sibling_declaring_blocks() {
+    let mut lsp = Lsp::tcl();
+    let sib = unique_uri("tcl");
+    lsp.open_ready(&sib, "namespace eval mypkg {\n    variable v 1\n}\n");
+    let here = unique_uri("tcl");
+    lsp.open_ready(
+        &here,
+        "namespace eval mypkg {\n    proc p {} {}\n}\nset t [namespace children ::mypkg]\n",
+    );
+
+    let def = lsp.definition(&here, 3, 28);
+    assert_eq!(
+        lines_in(&def, &here),
+        vec![0],
+        "the local block is a target"
+    );
+    assert_eq!(
+        lines_in(&def, &sib),
+        vec![0],
+        "so is the sibling document's block: {:?}",
+        locations(&def),
+    );
+}
+
+// TP (finding 2) — find-references unions both documents' sites too.
+#[test]
+fn tp_references_union_local_and_sibling_sites() {
+    let mut lsp = Lsp::tcl();
+    let sib = unique_uri("tcl");
+    lsp.open_ready(&sib, "namespace eval mypkg {}\nnamespace exists ::mypkg\n");
+    let here = unique_uri("tcl");
+    lsp.open_ready(
+        &here,
+        "namespace eval mypkg {}\nnamespace children ::mypkg\n",
+    );
+
+    let refs = lsp.references(&here, 1, 22, true);
+    assert_eq!(lines_in(&refs, &here), vec![0, 1], "local sites");
+    assert_eq!(
+        lines_in(&refs, &sib),
+        vec![0, 1],
+        "sibling sites: {:?}",
+        locations(&refs),
+    );
+}
+
+// TP (finding 2) — hover counts the whole workspace, not just this file.  A
+// hover saying "1 block" while go-to-definition offers three contradicts
+// itself.
+#[test]
+fn tp_hover_counts_declaring_blocks_across_the_workspace() {
+    let mut lsp = Lsp::tcl();
+    let sib = unique_uri("tcl");
+    lsp.open_ready(&sib, "namespace eval mypkg {}\nnamespace eval mypkg {}\n");
+    let here = unique_uri("tcl");
+    lsp.open_ready(
+        &here,
+        "namespace eval mypkg {}\nnamespace children ::mypkg\n",
+    );
+
+    let text = hover_text(&lsp.hover(&here, 1, 22));
+    assert!(
+        text.contains("3 `namespace eval` blocks") && text.contains("across 2 documents"),
+        "hover must count every declaring block: {text:?}",
+    );
+}
+
+// TP (finding 3) — the **empty literal** names the global namespace at global
+// scope, so `namespace eval {} { … }` is a declaration of `::` and
+// `namespace children {}` is a reference to it.
+//
+// Oracle — tclsh 9.0.4 and 8.6.16, byte-identical:
+//   namespace exists {}                       -> 1
+//   namespace children {}                     == namespace children ::
+//   namespace inscope {} {namespace current}  -> ::
+//   namespace eval {} {namespace current}     -> ::
+//   namespace eval :: {variable a 1}; namespace eval {} {variable b 1}
+//                                             -> both ::a and ::b exist
+#[test]
+fn tp_empty_literal_is_the_global_namespace_at_global_scope() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval :: {}\nnamespace eval {} {}\nnamespace children {}\n",
+    );
+
+    let def = lsp.definition(&uri, 2, 20);
+    assert_eq!(
+        lines_in(&def, &uri),
+        vec![0, 1],
+        "both spellings declare the same global namespace: {:?}",
+        locations(&def),
+    );
+    let refs = lsp.references(&uri, 0, 15, true);
+    assert_eq!(
+        lines_in(&refs, &uri),
+        vec![0, 1, 2],
+        "every spelling is one symbol: {:?}",
+        locations(&refs),
+    );
+}
+
+// TN (finding 3) — inside another namespace the very same word names a
+// namespace that *cannot exist*, so it must resolve to nothing rather than to
+// the enclosing namespace's declarations.
+//
+// Oracle — tclsh 9.0.4 and 8.6.16, byte-identical, inside `namespace eval
+// ::outer`:
+//   namespace exists {}     -> 0
+//   namespace children {}   -> namespace "" not found in "::outer"        (rc 1)
+//   namespace eval {} {…}   -> can't create namespace "": only global
+//                              namespace can have empty name              (rc 1)
+#[test]
+fn tn_empty_literal_inside_a_namespace_names_nothing() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval ::outer {\n    namespace exists {}\n}\n",
+    );
+
+    let def = lsp.definition(&uri, 1, 21);
+    assert!(
+        locations(&def).is_empty(),
+        "`{{}}` inside `::outer` is not `::outer`: {:?}",
+        locations(&def),
+    );
+}
+
+// TP (finding 3, adjacent) — a **braced** namespace name is an ordinary name,
+// so the data-brace inertness test must not veto it.
+//
+// Oracle — tclsh 9.0.4 and 8.6.16, byte-identical: `namespace eval {my ns} {
+// variable v 7; proc p {} {return P} }` gives `namespace exists {my ns}` -> 1,
+// `namespace children ::` listing `{::my ns}`, `set {::my ns::v}` -> 7, and
+// `{::my ns::p}` -> P.
+#[test]
+fn tp_a_braced_namespace_name_is_navigable() {
+    let mut lsp = Lsp::tcl();
+    let uri = unique_uri("tcl");
+    lsp.open_ready(
+        &uri,
+        "namespace eval {my ns} { variable v 7 }\nnamespace children {my ns}\n",
+    );
+
+    let def = lsp.definition(&uri, 1, 22);
+    assert_eq!(
+        lines_in(&def, &uri),
+        vec![0],
+        "a braced namespace name is a real name: {:?}",
+        locations(&def),
+    );
+}

--- a/rust/tcl-registry/src/arg_role.rs
+++ b/rust/tcl-registry/src/arg_role.rs
@@ -131,6 +131,39 @@ pub enum ArgRole {
     /// {…} $x]`) is recognised the same way, with no command-name check in
     /// the consumer.
     LambdaLiteral,
+    /// A word that names a **namespace** — `namespace children ::tomato`,
+    /// `namespace exists ::x`, `namespace delete ::a ::b`, `namespace eval
+    /// NS body`, `namespace inscope NS script`, `namespace upvar NS v local`.
+    ///
+    /// A first-class namespace **reference**: the compiler records the word
+    /// as a namespace occurrence so go-to-definition / hover / find-references
+    /// reach the `namespace eval` block(s) that declare it (issue #1088).
+    /// Namespaces are their own symbol space in Tcl — disjoint from commands
+    /// and from variables — so this is neither
+    /// [`Self::CommandName`] nor [`Self::VarRead`]; a consumer that treated a
+    /// namespace word as either would resolve `namespace exists ::tomato` to
+    /// an unrelated same-named proc.
+    ///
+    /// The word may be written **relative**, and then it roots against the
+    /// call site's own current namespace, exactly as Tcl resolves it
+    /// (tclsh 9.0.4 and 8.6.16, byte-identical: inside `namespace eval
+    /// ::outer`, `namespace exists inner` finds `::outer::inner` and the
+    /// global `namespace exists inner` does not).
+    ///
+    /// Deliberately **not** stamped on positions that merely *look* like
+    /// namespace words: `namespace qualifiers` / `namespace tail` take an
+    /// arbitrary string (`namespace tail a::b` answers `b` whether or not
+    /// `::a` exists), `namespace import` / `export` / `forget` take glob
+    /// **patterns**, `namespace origin` / `which` take command names, and
+    /// `namespace code` takes a script.
+    ///
+    /// Whether the named namespace has to *exist* is the subcommand's
+    /// business, not the role's: `namespace exists` probes (`0` for an
+    /// unknown name), while `namespace children` / `delete` error
+    /// (`namespace "::never" not found`, rc 1, on both interpreters). The
+    /// role carries navigation identity only, the same split
+    /// [`Self::CommandName`] / [`Self::CommandNameProbe`] draw for commands.
+    NamespaceName,
 }
 
 impl ArgRole {
@@ -156,6 +189,7 @@ impl ArgRole {
         Self::CommandName,
         Self::CommandNameProbe,
         Self::LambdaLiteral,
+        Self::NamespaceName,
     ];
 
     /// Whether an argument in this role carries **executable Tcl** that a
@@ -203,6 +237,7 @@ impl ArgRole {
             | Self::ScanFormat
             | Self::Channel
             | Self::Index
+            | Self::NamespaceName
             | Self::Keyword => false,
         }
     }

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -197,6 +197,21 @@ static IMPORT_OPTIONS: &[OptionSpec] = &[OptionSpec {
     min_version: None,
 }];
 
+/// `namespace delete ?namespace namespace ...?` — every positional word names
+/// a namespace, so the role is variadic and cannot be a fixed index table.
+///
+/// `NamespaceDeleteCmd` (tclNamesp.c) walks `objv[1..]` and deletes each,
+/// erroring on the first unknown one (`unknown namespace "::never" in
+/// namespace delete command`, rc 1 — identical on tclsh 9.0.4 and 8.6.16), so
+/// there is no flag or terminator word to skip. `args` are the words after
+/// the `delete` subcommand.
+fn namespace_delete_arg_roles(args: &[&str]) -> Vec<(u8, ArgRole)> {
+    (0..args.len())
+        .filter_map(|i| u8::try_from(i).ok())
+        .map(|i| (i, ArgRole::NamespaceName))
+        .collect()
+}
+
 static SUBCOMMANDS: &[SubCommand] = &[
     SubCommand {
         name: "children",
@@ -205,6 +220,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "namespace children ?namespace? ?pattern?",
         pure: true,
         return_type: Some(TclType::List),
+        // The optional first word names the namespace whose children are
+        // listed (`namespace children ::tomato` — issue #1088); the optional
+        // second is a glob pattern filtering the *result*, not a namespace.
+        arg_roles: &[(0, ArgRole::NamespaceName), (1, ArgRole::Pattern)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -249,6 +268,9 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // suppression keys off.
         destructive: true,
         return_type: Some(TclType::String),
+        // Every positional word names a namespace — see
+        // `namespace_delete_arg_roles`.
+        arg_role_resolver: Some(namespace_delete_arg_roles),
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -288,7 +310,12 @@ static SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(2),
         detail: "Evaluate a script in a namespace context.",
         synopsis: "namespace eval namespace arg ?arg ...?",
-        arg_roles: &[(0, ArgRole::Name), (1, ArgRole::Body)],
+        // The target word is a namespace **name**, not a generic symbolic
+        // `Name`: it is the one form that *declares* a namespace (see
+        // `Traits::DECLARES_NAMESPACE` below), and every other spelling of
+        // the same namespace — `namespace children ::ns`, `namespace exists
+        // ns` — must navigate to it (issue #1088).
+        arg_roles: &[(0, ArgRole::NamespaceName), (1, ArgRole::Body)],
         lowering_hook: Some(crate::hooks::LoweringHookId::NamespaceEval),
         return_type: Some(TclType::String),
         // The body evaluates in the *namespace* frame, not the caller's, so
@@ -301,7 +328,20 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // key off this.  Words after the body concatenate into it exactly as
         // `eval`'s do (`namespace eval ::n set l2 hello` sets `::n::l2`,
         // tclsh8.6.14/9.0.4-confirmed), so the eval-family trait applies.
-        traits: Traits::EVALUATES_CODE.union(Traits::SCRIPT_CONCATENATES_ARGS),
+        // `DECLARES_NAMESPACE` is what makes this the namespace's *declaring*
+        // site rather than merely another reference to it.  Pinned on tclsh
+        // 9.0.4 and 8.6.16 (byte-identical): `namespace eval ::a {}` twice
+        // creates the namespace once and extends it the second time, a deep
+        // `namespace eval ::p::q::r {}` creates `::p` and `::p::q` too, and
+        // it is the **only** declaring form — `proc ::nope::gone::p {} {}`
+        // with no such namespace fails (`can't create procedure
+        // "::nope::gone::p": unknown namespace`, rc 1), as does `set
+        // ::brandnew::v 1` (`parent namespace doesn't exist`).  `inscope`,
+        // which shares this hook and arg layout, deliberately does **not**
+        // carry it: it requires the namespace to already exist.
+        traits: Traits::EVALUATES_CODE
+            .union(Traits::SCRIPT_CONCATENATES_ARGS)
+            .union(Traits::DECLARES_NAMESPACE),
         analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceEval),
         ..SubCommand::DEFAULT
     },
@@ -312,6 +352,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "namespace exists namespace",
         pure: true,
         return_type: Some(TclType::Boolean),
+        // An existence probe of a namespace: the name navigates like any
+        // other namespace reference, and no diagnostic asserts it exists
+        // (both interpreters answer `0` rather than erroring).
+        arg_roles: &[(0, ArgRole::NamespaceName)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -388,7 +432,10 @@ static SUBCOMMANDS: &[SubCommand] = &[
         arity: Arity::at_least(2),
         detail: "Executes a script in the context of the specified namespace.",
         synopsis: "namespace inscope namespace script ?arg ...?",
-        arg_roles: &[(0, ArgRole::Name), (1, ArgRole::Body)],
+        // Same shape as `eval`'s, and the same namespace **reference** —
+        // but `inscope` requires the namespace to exist already, so it
+        // carries no `DECLARES_NAMESPACE`.
+        arg_roles: &[(0, ArgRole::NamespaceName), (1, ArgRole::Body)],
         return_type: Some(TclType::String),
         // Like `eval`, the script runs in the namespace frame — the `[subcmd,
         // namespace, body]` shape is identical, so the same analyser hook
@@ -424,6 +471,8 @@ static SUBCOMMANDS: &[SubCommand] = &[
         synopsis: "namespace parent ?namespace?",
         pure: true,
         return_type: Some(TclType::String),
+        // The optional word names the namespace whose parent is reported.
+        arg_roles: &[(0, ArgRole::NamespaceName)],
         ..SubCommand::DEFAULT
     },
     SubCommand {
@@ -502,6 +551,11 @@ static SUBCOMMANDS: &[SubCommand] = &[
         detail: "Arrange local variables to refer to namespace variables, as zero or more otherVar/myVar pairs. Tcl 8.5 requires at least one pair; from Tcl 8.6 the namespace argument alone is legal (and a no-op).",
         synopsis: "namespace upvar namespace ?otherVar myVar ...?",
         return_type: Some(TclType::String),
+        // The leading word names the namespace the aliased cells live in —
+        // relative names root against the current namespace exactly as
+        // elsewhere (tclsh 9.0.4 / 8.6.16: inside `namespace eval ::rel`,
+        // `namespace upvar kid v alias` binds `::rel::kid::v`).
+        arg_roles: &[(0, ArgRole::NamespaceName)],
         creates_scope_alias: true,
         dialects: Some(DialectSet::TCL85_PLUS),
         analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceUpvar),

--- a/rust/tcl-registry/src/registry.rs
+++ b/rust/tcl-registry/src/registry.rs
@@ -1277,6 +1277,29 @@ impl CommandRegistry {
         self.get(name).and_then(|spec| spec.frame_effect)
     }
 
+    /// The behavioural traits in force for one **concrete call** — the
+    /// command's own set, unioned with those of the subcommand `args[0]`
+    /// resolves to (exact or unique-prefix), when it has subcommands.
+    ///
+    /// The trait counterpart of [`Self::arg_indices_for_role`], and it takes
+    /// the same `args` shape (subcommand first) for the same reason: a
+    /// consumer asking "does *this* call declare a namespace / evaluate code"
+    /// must not have to know whether the fact lives on the ensemble or on one
+    /// of its subcommands. `namespace eval` carries
+    /// [`Traits::DECLARES_NAMESPACE`] on the subcommand while `namespace`
+    /// itself does not, and `namespace inscope` — identical argument layout,
+    /// same analyser hook — does not carry it at all.
+    #[must_use]
+    pub fn call_traits(&self, name: &str, args: &[&str]) -> Traits {
+        let Some(spec) = self.get(name) else {
+            return Traits::empty();
+        };
+        let sub = (!spec.subcommands.is_empty())
+            .then(|| args.first().and_then(|word| spec.resolve_subcommand(word)))
+            .flatten();
+        sub.map_or(spec.traits, |sub| spec.traits.union(sub.traits))
+    }
+
     /// Resolve argument indices for a given role.
     ///
     /// For subcommand-based commands (e.g. `dict create`), pass the

--- a/rust/tcl-registry/src/traits.rs
+++ b/rust/tcl-registry/src/traits.rs
@@ -940,6 +940,26 @@ declare_traits! {
     /// paired with the call site's own frame kind. Offering a word the
     /// interpreter will refuse is the defect this trait exists to prevent.
     TclooRequiresMethodFrame => TCLOO_REQUIRES_METHOD_FRAME;
+
+    /// This command (or subcommand) **declares** the namespace its
+    /// [`crate::arg_role::ArgRole::NamespaceName`] word names — it brings
+    /// the namespace into existence if it does not already exist, and its
+    /// name word is therefore a *definition* site go-to-definition answers
+    /// with (issue #1088).
+    ///
+    /// `namespace eval` is the only carrier, and the oracle is why.  On
+    /// tclsh 9.0.4 and 8.6.16, byte-identically: two `namespace eval ::a
+    /// {}` blocks create the namespace once and then extend it (both are
+    /// declaring sites, and both `::a::x` and `::a::y` survive); a deep
+    /// `namespace eval ::p::q::r {}` implicitly creates `::p` and `::p::q`;
+    /// and no other form creates one — `proc ::nope::gone::p {} {}` fails
+    /// with `can't create procedure "::nope::gone::p": unknown namespace`
+    /// and `set ::brandnew::v 1` with `can't set "::brandnew::v": parent
+    /// namespace doesn't exist`.  `namespace inscope`, whose argument
+    /// layout is identical and which shares `eval`'s analyser hook, is the
+    /// reason this is a trait rather than a subcommand-name check in the
+    /// handler: it references an existing namespace and never declares one.
+    DeclaresNamespace => DECLARES_NAMESPACE;
 }
 
 /// Every trait that widens a file's caller set beyond the file itself — the

--- a/rust/tcl-registry/tests/registry_commands.rs
+++ b/rust/tcl-registry/tests/registry_commands.rs
@@ -2552,3 +2552,114 @@ mod textutil_submodule_vs_umbrella {
         assert_eq!(umbrella_spec.traits, submodule_spec.traits);
     }
 }
+
+/// `namespace`'s namespace-name argument positions — the registry data issue
+/// #1088's navigation is driven by.  Which words name a namespace is a
+/// registry fact, so no analyser or provider matches a subcommand spelling.
+///
+/// Oracle (tclsh 9.0.4 and 8.6.16, byte-identical): `namespace children
+/// ::never` fails `namespace "::never" not found`; `namespace exists ::never`
+/// answers `0`; `namespace delete ::a ::b` deletes both and errors on the
+/// first unknown one; `namespace upvar ::rel::kid v alias` binds through the
+/// namespace word; and inside `namespace eval ::outer`, `namespace exists
+/// inner` is `1` while the same words at global scope are `0`.
+///
+/// registry-metadata: `arg_roles` / `arg_role_resolver`.
+#[test]
+fn namespace_subcommands_declare_their_namespace_name_arguments() {
+    let (reg, _) = reg_and_set("tcl8.6");
+    for (args, expected) in [
+        (vec!["children", "::a"], vec![1usize]),
+        (vec!["children", "::a", "pat*"], vec![1]),
+        (vec!["exists", "::a"], vec![1]),
+        (vec!["parent", "::a"], vec![1]),
+        (vec!["eval", "::a", "{}"], vec![1]),
+        (vec!["inscope", "::a", "{}"], vec![1]),
+        (vec!["upvar", "::a", "v", "l"], vec![1]),
+        (vec!["delete", "::a", "::b"], vec![1, 2]),
+    ] {
+        assert_eq!(
+            reg.arg_indices_for_role("namespace", &args, ArgRole::NamespaceName),
+            expected,
+            "namespace {args:?} namespace-name positions",
+        );
+    }
+    // `children`'s second word filters the *result*; it is a glob pattern.
+    assert_eq!(
+        reg.arg_indices_for_role("namespace", &["children", "::a", "pat*"], ArgRole::Pattern),
+        vec![2],
+    );
+}
+
+/// The `namespace` subcommands whose arguments only *look* like namespaces
+/// must declare no namespace-name position at all.
+///
+/// Oracle (both interpreters): `namespace tail a::b` → `b` and `namespace
+/// qualifiers a::b` → `a` whether or not `::a` exists, so those words are
+/// arbitrary strings; `import`/`export`/`forget` take glob patterns;
+/// `origin`/`which` name commands; `code` takes a script.
+///
+/// registry-metadata: `arg_roles`.
+#[test]
+fn namespace_string_and_command_subcommands_declare_no_namespace_name() {
+    let (reg, _) = reg_and_set("tcl8.6");
+    for args in [
+        vec!["tail", "a::b"],
+        vec!["qualifiers", "a::b"],
+        vec!["import", "::a::*"],
+        vec!["export", "p"],
+        vec!["forget", "::a::*"],
+        vec!["origin", "::a::p"],
+        vec!["which", "-command", "::a::p"],
+        vec!["code", "{puts hi}"],
+        vec!["current"],
+        vec!["path", "{::a ::b}"],
+    ] {
+        assert!(
+            reg.arg_indices_for_role("namespace", &args, ArgRole::NamespaceName)
+                .is_empty(),
+            "namespace {args:?} must declare no namespace-name argument",
+        );
+    }
+}
+
+/// Only `namespace eval` **declares** a namespace, and the fact is a trait
+/// rather than a spelling check — `namespace inscope`'s argument layout and
+/// analyser hook are identical but it requires the namespace to exist.
+///
+/// Oracle (both interpreters): `namespace eval ::brandnew {}` creates it;
+/// `namespace inscope ::brandnew {}` on an undeclared namespace fails; and no
+/// other form creates one (`proc ::nope::gone::p {} {}` → `can't create
+/// procedure "::nope::gone::p": unknown namespace`).
+///
+/// registry-metadata: `Traits::DECLARES_NAMESPACE`.
+#[test]
+fn only_namespace_eval_declares_a_namespace() {
+    let (reg, _) = reg_and_set("tcl8.6");
+    assert!(
+        reg.call_traits("namespace", &["eval", "::a", "{}"])
+            .contains(Traits::DECLARES_NAMESPACE),
+    );
+    for sub in ["inscope", "children", "exists", "delete", "parent", "upvar"] {
+        assert!(
+            !reg.call_traits("namespace", &[sub, "::a"])
+                .contains(Traits::DECLARES_NAMESPACE),
+            "namespace {sub} must not be a declaring form",
+        );
+    }
+    // No other command in any dialect claims it either — a declaring form the
+    // navigation tier does not know about would silently lose definitions.
+    let declarers: Vec<&str> = reg
+        .command_names()
+        .filter(|name| {
+            reg.get(name).is_some_and(|spec| {
+                spec.traits.contains(Traits::DECLARES_NAMESPACE)
+                    || spec
+                        .subcommands
+                        .iter()
+                        .any(|sub| sub.traits.contains(Traits::DECLARES_NAMESPACE))
+            })
+        })
+        .collect();
+    assert_eq!(declarers, vec!["namespace"]);
+}

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -80,6 +80,10 @@ pub const ARG_ROLES: &[Variant] = &[
         "names a command that need not exist yet",
     ),
     v("LambdaLiteral", "an `apply`-style lambda literal"),
+    v(
+        "NamespaceName",
+        "names a namespace (`namespace children ::ns`)",
+    ),
 ];
 
 /// [`TclType`] — the intrep a value carries.
@@ -502,6 +506,10 @@ pub const TRAITS: &[Variant] = &[
         "TCLOO_REQUIRES_METHOD_FRAME",
         "calling it needs a real method invocation, not just an object frame",
     ),
+    v(
+        "DECLARES_NAMESPACE",
+        "declares the namespace its NamespaceName word names",
+    ),
 ];
 
 /// [`TaintColour`] bits.
@@ -705,7 +713,8 @@ mod tests {
             | ArgRole::CommandPrefix
             | ArgRole::CommandName
             | ArgRole::CommandNameProbe
-            | ArgRole::LambdaLiteral => true,
+            | ArgRole::LambdaLiteral
+            | ArgRole::NamespaceName => true,
         }
     }
 


### PR DESCRIPTION
## Summary

PR C4b — namespaces become first-class navigable symbols (issue #1088, split from audit idx 75's secondary claim). Oracle matrix byte-identical on 9.0.4/8.6.16, pinning the model: **`namespace eval` is the only declaring form** (`proc ::nope::gone::p` errors rather than creating namespaces, as does `set ::brandnew::v`), **every** `namespace eval` block on a name is a declaring site, parents created implicitly by `::p::q::r` have no written name, and relative names root at the current namespace (for `eval`, `inscope`, `upvar`, `delete` alike).

- **Registry data, not name matching:** new `ArgRole::NamespaceName` marks which argument positions reference a namespace (`children`, `exists`, `parent`, `upvar`, `eval`, `inscope`, `delete` via a variadic resolver), and new trait `DECLARES_NAMESPACE` distinguishes `eval`'s declaring word — with a registry test asserting no other command in any dialect carries it, and deliberate non-annotations pinned (`tail`/`qualifiers` operate on strings — oracle-proved independent of namespace existence — plus `import`/`export`/`origin`/`which`/`code`). New `CommandRegistry::call_traits` is the trait counterpart of `arg_indices_for_role`.
- **One shared resolver** (`namespace_symbol::namespace_cell_at` + span accessors), **span-driven**: it answers only when the cursor is inside a registry-marked word the analyser recorded, so a same-spelled proc or class can never claim the position. Inert-text gate applied. Definition answers *every* declaring block (per the oracle: all blocks declare); hover names the namespace with block/reference counts; references reach every spelling including the `[namespace children ::x]` command-substitution idiom from the finding.
- **Workspace tier** mirrors #1086's variable tier: a `WorkspaceNamespaceRef` table with declaring rows feeding the existing `observable_namespaces()` as a fourth source (not duplicated), and cross-document definition/hover/references on the server.

Before/after on the fixture: every probe (children/exists/delete/declaration cursor, relative name, cross-file) goes from 0 results to the full declaring-block set, with comment/braced-data TNs held at 0.

**Residuals filed rather than half-fixed:** #1113 (coverage refinements: implicit-parent identity, `namespace path` list-argument, computed targets via the constant-dominated domain, `apply` lambda's third element) and #1114 (namespace rename tier — a materially larger edit-set/safety design).

## Validation

- [x] `cargo test --workspace --all-features` — **311 suites, 15,421 passed, 0 failed** (first attempt ENOSPC'd; re-run clean after target rebuild with symbol stripping — reported figures are from the clean run).
- [x] 15 core unit tests + 3 workspace-index + 3 registry contract tests + 12 lsp_e2e, explicitly TP/FP/TN/FN split (FPs: string/pattern/command-name arguments never counted; FNs: `inscope` is a reference not a declaration, same-named proc doesn't answer).
- [x] `cargo clippy --workspace --all-targets --all-features` — 0 warnings, **zero new allows**; fmt clean; `make xtask-check` all OK (ARG_ROLES/TRAITS spec-studio witnesses updated for the new variants).

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — `AnalysisResult::namespace_refs` is a new analyser fact (rooted, span-recorded, `declares`-tagged); `ArgRole::NamespaceName` + `DECLARES_NAMESPACE` are new registry surface.
- [x] KCS notes updated: definition/hover/references feature pages; `workspace-indexing.md` gains "The namespace tier"; README. STATUS.md §6b: idx 75's secondary-claim split annotated as fixed by this PR (no count change — the primary claim was already ticked by PR C2).
- [ ] New compiler KCS note linked. (n/a — existing notes updated)

Closes #1088.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7