### PR TITLE
The import edge becomes an indirection-tracked link: forget, -force shadowing, source lifecycle, chains (#1103)

### DIFF
--- a/docs/design/contracts/command-resolution.md
+++ b/docs/design/contracts/command-resolution.md
@@ -157,12 +157,24 @@ not change the rule, and must not grow bespoke resolution logic. Every
     reinstates the alias.
   - **`-force` decides the conflict.** Importing onto a name the target
     namespace already holds aborts (`can't import command "p": already
-    exists`) and installs nothing — the local command survives and `namespace
-    origin` still answers it; with `-force` the import silently replaces the
-    local command and `namespace origin` answers the source. Statically the
-    "installed nothing" / "replaced the local" halves are both modelled; the
-    error's *control-flow* consequence (nothing after it in that script runs)
-    is deliberately out of scope.
+    exists`) and installs nothing — the existing command survives and
+    `namespace origin` still answers it; with `-force` the import silently
+    replaces it and `namespace origin` answers the source. "Already holds"
+    covers a local `proc`/class **and a live alias from a different source**:
+    with `::dst` importing `::A::*`, a later unforced `namespace import ::B::*`
+    raises the same error and leaves `origin` at `::A::p`, while `-force`
+    makes it `::B::p` and a preceding `namespace forget` lets the unforced one
+    through (all pinned). Re-importing from the *same* source is a silent
+    no-op, not a conflict (pinned). Statically the "installed nothing" /
+    "replaced what was there" halves are both modelled; the error's
+    *control-flow* consequence (nothing after it in that script runs) is
+    deliberately out of scope.
+  - **Redefining the imported name ends the alias.** A `proc ::dst::p` written
+    after the import silently recreates `::dst::p` as an ordinary command:
+    no error, `::dst::p` runs the new body, `namespace origin ::dst::p`
+    becomes `::dst::p`, and `::src::p` is untouched (pinned). It is an
+    ordered event like every other — a call written *between* the import and
+    the redefinition still reaches the source.
   - **A source *delete* kills the alias, a source *rename* does not.**
     `rename ::src::p {}` makes `::dst::p` an `invalid command name`, while
     `rename ::src::p ::src::pp` leaves it working and merely moves the origin
@@ -184,10 +196,16 @@ not change the rule, and must not grow bespoke resolution logic. Every
   leading option word was consumed", never as a `-force` name match. Both tiers
   answer through one shared decision function
   (`tcl_lsp_core::namespace_import::alias_live_at`), under the same
-  `in_effect` / `in_effect_within` order rule as the export snapshot. Removals
-  abstain toward *keeping* the alias: one in another file has no static load
-  order and revokes nothing, and one written inside a proc/class body is
-  conditional and is not published at all.
+  `in_effect` / `in_effect_within` order rule as the export snapshot, and it
+  gates the **exact**-import link the same way it gates a glob lookup.
+  Byte offsets order events only *within* one document, so a cross-file event
+  — an install as much as a removal — is passed unordered rather than compared
+  against an unrelated file's numbering. Removals then abstain toward
+  *keeping* the alias: one in another file revokes nothing, and one written
+  inside a proc/class body is conditional and is not published at all. The one
+  exception is **destroying the source command**, which is not a slot event on
+  a timeline but the disappearance of the command object workspace-wide: it
+  revokes a link regardless of where it is written.
 - **`unknown` / `namespace unknown`** fire only after the full candidate
   walk (path included) misses. `namespace unknown` handlers are
   **per-namespace, NOT inherited** by children; the global namespace's

--- a/docs/design/contracts/command-resolution.md
+++ b/docs/design/contracts/command-resolution.md
@@ -142,6 +142,52 @@ not change the rule, and must not grow bespoke resolution logic. Every
   (`tcl_lsp_core::namespace_import::exported_at_import_site`), under one
   shared execution-order rule (`analyser::indirection::in_effect` /
   `in_effect_within`). Issue #1027.
+
+  The import edge is a **link with a lifecycle**, not a standing
+  name-visibility fact (issue #1103; every row below oracle-pinned on tclsh
+  9.0.4 + 8.6.14, byte-identical):
+
+  - **`namespace forget` removes the alias.** `namespace forget ::src::p`
+    empties `info commands ::dst::*` of it and a later bare call is `invalid
+    command name`. Both `Tcl_ForgetImport` pattern shapes hold: a *qualified*
+    pattern names the source namespace whose imports are dropped, a *simple*
+    one matches the forgetting namespace's own imported command names whatever
+    their origin. Forgetting a name that was never imported is a silent no-op;
+    only an unknown namespace in a qualified pattern errors. A later re-import
+    reinstates the alias.
+  - **`-force` decides the conflict.** Importing onto a name the target
+    namespace already holds aborts (`can't import command "p": already
+    exists`) and installs nothing — the local command survives and `namespace
+    origin` still answers it; with `-force` the import silently replaces the
+    local command and `namespace origin` answers the source. Statically the
+    "installed nothing" / "replaced the local" halves are both modelled; the
+    error's *control-flow* consequence (nothing after it in that script runs)
+    is deliberately out of scope.
+  - **A source *delete* kills the alias, a source *rename* does not.**
+    `rename ::src::p {}` makes `::dst::p` an `invalid command name`, while
+    `rename ::src::p ::src::pp` leaves it working and merely moves the origin
+    — the alias holds the command *object*, the same
+    rename-captures-object-identity rule `analyser::indirection` already
+    models. A redefinition of the source is seen straight through the link.
+  - **Chains follow.** `::A` importing `::B::*` where `::B` imported `::C::*`
+    makes `::A::p` run `::C`'s body, with `namespace origin ::A::p` → `::C::p`;
+    a forget anywhere along the chain kills the whole thing (deleting an
+    imported command deletes the commands imported from it). Both LSP tiers
+    follow the chain while every hop is provable, bounded by
+    `analyser::indirection::MAX_COMMAND_NAME_HOPS`, and abstain otherwise.
+
+  Statically the removals join the same ordered event log: `namespace forget`
+  as `SignatureNamespaceForget`, a destroying `rename OLD {}` /
+  `interp alias {} NAME {}` as `AnalysisResult::destroyed_commands` (a *re*name
+  is deliberately absent from it), and `-force` as
+  `SignatureNamespaceImport::forced` — read, like `-clear`, as "the declared
+  leading option word was consumed", never as a `-force` name match. Both tiers
+  answer through one shared decision function
+  (`tcl_lsp_core::namespace_import::alias_live_at`), under the same
+  `in_effect` / `in_effect_within` order rule as the export snapshot. Removals
+  abstain toward *keeping* the alias: one in another file has no static load
+  order and revokes nothing, and one written inside a proc/class body is
+  conditional and is not published at all.
 - **`unknown` / `namespace unknown`** fire only after the full candidate
   walk (path included) misses. `namespace unknown` handlers are
   **per-namespace, NOT inherited** by children; the global namespace's

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -53,6 +53,35 @@ created would freeze a cross-document answer that goes stale as soon as the
 exporting file is edited.  `interp alias` / `rename` links, and imports merely
 *conjectured* from a tcllib `<NS>::import <ALIAS>` wrapper, carry no gate.
 
+The edge also has a **lifecycle** after it is installed (issue #1103), so the
+tier indexes its removals beside the exports: `namespace_forgets` (one row per
+`namespace forget` pattern, carrying the qualified pattern's source namespace
+or `None` for the simple form) and `command_deletions` (a *destroying* `rename
+OLD {}` / `interp alias {} NAME {}` — a plain rename is not one, because the
+alias holds the command object and survives it).  `glob_imports` and the exact
+form's `import_gate` both carry `forced`, so a non-`-force` import onto a name
+the target namespace already **defines** installs nothing, while a `-force` one
+replaces it.  `WorkspaceIndex::resolve_wildcard_import` therefore takes a
+`CallSite` (the calling document plus the call's own offset): removals are a
+question about the *call*, not the import, and the same shared decision
+function the same-document resolver uses
+(`tcl_lsp_core::namespace_import::alias_live_at`) answers it for both tiers.
+
+Two abstentions are deliberate here.  A removal in a **different document**
+from the call has no static load order and revokes nothing — the same
+unordered-event rule the `-clear` tombstones follow.  And within one document
+the removal is ordered by a plain offset comparison rather than
+`in_effect_within`, because the index stores an enclosing-body span per
+*import* row, not per invocation, and building one per call site would be
+O(procs × invocations) at index time; the missing fact can only make a removal
+look not-yet-run, i.e. keep answering, never invent one.
+
+Resolution follows **import chains**: when the hop's source namespace does not
+itself define the name, the walk continues from there, bounded by
+`tcl_compiler::analyser::indirection::MAX_COMMAND_NAME_HOPS`, so `::A`
+importing `::B::*` where `::B` imported `::C::*` resolves to `::C::p` instead
+of abstaining.
+
 The variable tables are deliberately narrower than the proc/class ones.  A
 namespace variable has one cell in one namespace, so `$::ns::v` in any
 document names the same thing as `variable v` inside `namespace eval ns`,

--- a/docs/design/contracts/workspace-indexing.md
+++ b/docs/design/contracts/workspace-indexing.md
@@ -68,14 +68,35 @@ question about the *call*, not the import, and the same shared decision
 function the same-document resolver uses
 (`tcl_lsp_core::namespace_import::alias_live_at`) answers it for both tiers.
 
-Two abstentions are deliberate here.  A removal in a **different document**
-from the call has no static load order and revokes nothing — the same
-unordered-event rule the `-clear` tombstones follow.  And within one document
-the removal is ordered by a plain offset comparison rather than
-`in_effect_within`, because the index stores an enclosing-body span per
-*import* row, not per invocation, and building one per call site would be
-O(procs × invocations) at index time; the missing fact can only make a removal
-look not-yet-run, i.e. keep answering, never invent one.
+Ordering is per document on **both** sides of the comparison: an install
+whose document differs from the call's is passed unordered too, because a byte
+offset in the importing file and one in the calling file are unrelated numbers
+— comparing them let a `namespace forget` in the caller revoke a cross-file
+import purely because its local offset happened to be larger (issue #1116
+finding 1).  Unordered, the shared function keeps the alias.
+
+Three further points are deliberate.  A removal in a **different document**
+from the call revokes nothing, the same unordered-event rule the `-clear`
+tombstones follow.  Within one document the removal is ordered by a plain
+offset comparison rather than `in_effect_within`, because the index stores an
+enclosing-body span per *import* row, not per invocation, and building one per
+call site would be O(procs × invocations) at index time; the missing fact can
+only make a removal look not-yet-run, i.e. keep answering, never invent one.
+And **destroying** the source command is not treated as a slot event on a
+timeline at all — the command object is gone workspace-wide — so it revokes
+wherever it is written.
+
+The **exact**-import link tier runs the same decision function with no call
+site (`WildcardImportIndex::link_alias_live`, issue #1116 finding 2): the
+question a link answers is "does this alias exist for navigation", so every
+recorded removal counts as having run and the ordering that remains is the
+removal's position relative to the *import* — a forget or a redefinition of
+the imported name in the import's own document revokes the link when written
+after it, one before it is undone by the import, and one in another document
+revokes nothing.  A non-`-force` exact import also conflicts with an earlier
+exact import of the same name from a **different** source in the same document
+(`earlier_conflicting_link`), matching the glob tier's
+`conflicting_alias_at`.
 
 Resolution follows **import chains**: when the hop's source namespace does not
 itself define the name, the walk continues from there, bounded by

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -68,6 +68,29 @@ export further down the file still counts; an export written after the import
 the import and the export are in different files, nothing fixes which loads
 first, so navigation keeps answering rather than guessing a revocation.
 
+An import is not a permanent name, either. `namespace forget ::src::p` — or
+the unqualified `namespace forget p`, which drops whatever this namespace
+imported under that name — takes the alias away again, and a bare call written
+after it resolves to nothing; a call written *before* it still jumps to the
+source. Deleting the source command (`rename ::src::p {}`) has the same effect,
+because the alias holds the command *object*: a plain `rename ::src::p
+::src::pp` does **not** break it (the alias keeps working, only `namespace
+origin` moves), and redefining the source is seen straight through the link.
+Re-running the import after a forget brings the alias back.
+
+Importing onto a name the target namespace already has is an error unless the
+import carries `-force`, and the failed import installs nothing — so a bare
+call still reaches the *local* definition, and Go to Definition stays on it.
+With `-force` the import replaces the local command, and from that point on
+the same bare call jumps to the **source** instead.
+
+Imports chain. When `::A` imports `::B::*` and `::B` had imported `::C::*`
+(and re-exported), a bare call in `::A` runs `::C`'s body, and Go to Definition
+follows the whole chain to `::C`'s header — while a forget anywhere along it
+kills the call, exactly as `namespace origin` reports. The chase is bounded
+(eight hops, the same cap the rename / alias chase uses), so mutually
+importing namespaces cannot spin; past that bound navigation abstains.
+
 A proc declared twice in one file is two definitions of one command. A call
 between the two jumps to the **first** header, a call after both jumps to
 the second, and a cursor on either header stays on that header.
@@ -166,11 +189,15 @@ same name — Tcl keeps those in a separate table from variables.
 - `rust/tcl-lsp-core/src/caller_frame.rs` — unit tests for the binding scan
 - `rust/tcl-lsp-core/src/definition.rs` (`mod tests`)
 - `rust/tcl-lsp-core/src/namespace_import.rs` (`mod tests`) — the
-  per-import-site export snapshot, shared by the same-document and workspace
-  resolvers
+  per-import-site export snapshot and the import edge's own lifecycle
+  (`alias_live_at`), both shared by the same-document and workspace resolvers
 - `rust/tcl-lsp-server/tests/e2e/definition.rs`
   (`wildcard_import_survives_a_later_export_clear_cross_document`,
-  `wildcard_import_ignores_an_export_written_after_it_cross_document`)
+  `wildcard_import_ignores_an_export_written_after_it_cross_document`,
+  `a_forgotten_wildcard_import_stops_resolving_cross_document`,
+  `a_forced_import_shadows_the_local_command_cross_document`,
+  `a_wildcard_import_chain_follows_to_the_original_source_cross_document`,
+  `deleting_the_source_command_kills_the_import_cross_document`)
 - `rust/tcl-lsp-server/tests/e2e/issue923_crossdoc.rs` (cross-file namespace
   variables, cross-file class-reference arguments)
 - `rust/tcl-lsp-server/src/lib.rs` unit tests

--- a/docs/kcs/features/kcs-feature-definition.md
+++ b/docs/kcs/features/kcs-feature-definition.md
@@ -81,8 +81,13 @@ Re-running the import after a forget brings the alias back.
 Importing onto a name the target namespace already has is an error unless the
 import carries `-force`, and the failed import installs nothing — so a bare
 call still reaches the *local* definition, and Go to Definition stays on it.
-With `-force` the import replaces the local command, and from that point on
-the same bare call jumps to the **source** instead.
+"Already has" includes a name it imported earlier from somewhere else: a
+second unforced import of the same name from a different namespace fails too,
+and navigation keeps answering the first source. With `-force` the import
+replaces whatever was there, and from that point on the same bare call jumps
+to the **source** instead — until a `proc` of that name is written, which
+silently takes the name back and sends navigation to the new local
+definition.
 
 Imports chain. When `::A` imports `::B::*` and `::B` had imported `::C::*`
 (and re-exported), a bare call in `::A` runs `::C`'s body, and Go to Definition

--- a/rust/tcl-compiler/src/analyser/commands.rs
+++ b/rust/tcl-compiler/src/analyser/commands.rs
@@ -1185,6 +1185,10 @@ impl Analyser {
                 self.handle_namespace_export_command(args, arg_tokens, scope_path);
                 false
             }
+            Hook::NamespaceForget => {
+                self.handle_namespace_forget_command(args, arg_tokens, scope_path);
+                false
+            }
             Hook::NamespacePath => {
                 self.handle_namespace_path_command(args, scope_path);
                 false

--- a/rust/tcl-compiler/src/analyser/handlers.rs
+++ b/rust/tcl-compiler/src/analyser/handlers.rs
@@ -3976,6 +3976,11 @@ impl Analyser {
     /// subcommand word the detectors expect.
     pub fn handle_interp_alias(&mut self, args: &[String], scope_path: &[usize], offset: u32) {
         if let Some(deleted) = crate::alias::detect_interp_alias_delete(args) {
+            // Deleting an alias destroys the command object, so every
+            // `namespace import` edge pointing at it dies too (issue #1103).
+            self.result
+                .destroyed_commands
+                .insert(deleted.clone(), offset);
             self.deleted_commands.insert(deleted, offset);
             return;
         }
@@ -4272,6 +4277,12 @@ impl Analyser {
             return false;
         }
         if new.is_empty() {
+            // `rename OLD {}` destroys the command object — unlike `rename OLD
+            // NEW`, which hands it over and leaves every import edge alive
+            // (issue #1103).
+            self.result
+                .destroyed_commands
+                .insert(old.clone(), deletion_offset);
             self.deleted_commands.insert(old, deletion_offset);
             return false;
         }
@@ -5353,8 +5364,14 @@ impl Analyser {
         // Skip the subcommand word + the leading flag words the registry says
         // `namespace import` consumes (`-force`, at most one). Both facts are
         // read from the spec rather than matched by name or bounded by a
-        // literal here — see [`Self::namespace_leading_flag_words`].
-        let mut idx = 1 + self.namespace_leading_flag_words("import", &args[1..]);
+        // literal here — see [`Self::namespace_leading_flag_words`]. That the
+        // option word was consumed *is* `-force` (`IMPORT_OPTIONS` declares
+        // exactly one option and `max_leading_option_words` caps it at one),
+        // so the conflict semantics below need no name match either — the
+        // same reading `namespace export`'s `-clear` tombstone already gets.
+        let flag_words = self.namespace_leading_flag_words("import", &args[1..]);
+        let forced = flag_words > 0;
+        let mut idx = 1 + flag_words;
         // `namespace import` imports into the namespace current at the call —
         // the command-resolution namespace, so an import inside
         // `proc ::ns::p {}` lands in `::ns` (issue #923 idx 85).
@@ -5387,6 +5404,84 @@ impl Analyser {
                     pattern: pat,
                     range: arg_tokens[idx].span,
                     conjectured: false,
+                    forced,
+                },
+            );
+            idx += 1;
+        }
+    }
+
+    /// Record `namespace forget ?PATTERN ...?` events — the removal half of
+    /// the import edge's lifecycle log (issue #1103).
+    ///
+    /// A `namespace import` is not a permanent name: `namespace forget`
+    /// removes the alias and a later bare call raises `invalid command name`
+    /// (oracle in
+    /// [`crate::signature_scan::types::SignatureNamespaceForget`], tclsh
+    /// 8.6.14 / 9.0.4 byte-identical). Recorded as an ordered event beside
+    /// the `namespace export` tombstones so the resolvers in `tcl-lsp-core`
+    /// can ask "does this namespace still hold an alias for NAME *here*?"
+    /// rather than "was one ever installed"
+    /// (`tcl_lsp_core::namespace_import::alias_live_at`).
+    ///
+    /// The pattern shapes follow `Tcl_ForgetImport` exactly: a qualified
+    /// pattern names the *source* namespace whose commands lose their import
+    /// here, a simple one matches this namespace's own imported command
+    /// names whatever their origin. Both are oracle-confirmed; see the record
+    /// type.
+    ///
+    /// A dynamic pattern (`$`/`[` substitution) can't be statically resolved
+    /// to a glob text and is skipped rather than guessed at: revoking an
+    /// alias on a guess would silently drop real references, the same
+    /// abstain-toward-answering direction the unordered `-clear` takes.
+    /// `namespace forget` declares no options, so — unlike `import` /
+    /// `export` — there is no leading flag word to consume; the registry's
+    /// own [`Self::namespace_leading_flag_words`] is still what says so.
+    ///
+    /// Dispatched via
+    /// [`tcl_registry::hooks::AnalyserHookId::NamespaceForget`] (stamped on
+    /// `namespace`'s `forget` subcommand); `args[0]` is still the subcommand
+    /// word.
+    pub fn handle_namespace_forget_command(
+        &mut self,
+        args: &[String],
+        arg_tokens: &[Token],
+        scope_path: &[usize],
+    ) {
+        if args.is_empty() {
+            return;
+        }
+        let mut idx = 1 + self.namespace_leading_flag_words("forget", &args[1..]);
+        // As for `import` / `export`: the namespace losing the aliases is the
+        // one current at the call, not the lexically enclosing one.
+        let forgetting_ns = self.command_resolution_namespace(scope_path);
+        while idx < args.len() && idx < arg_tokens.len() {
+            let raw = &args[idx];
+            if raw.contains('$') || raw.contains('[') {
+                idx += 1;
+                continue;
+            }
+            let (source_ns, pattern) = match raw.rsplit_once("::") {
+                Some((prefix, tail)) => {
+                    let prefix = if prefix.is_empty() {
+                        "::".to_string()
+                    } else if prefix.starts_with("::") {
+                        prefix.to_string()
+                    } else if forgetting_ns == "::" {
+                        format!("::{prefix}")
+                    } else {
+                        format!("{forgetting_ns}::{prefix}")
+                    };
+                    (Some(prefix), tail.to_string())
+                }
+                None => (None, raw.clone()),
+            };
+            self.result.namespace_forgets.push(
+                crate::signature_scan::types::SignatureNamespaceForget {
+                    ns: forgetting_ns.clone(),
+                    source_ns,
+                    pattern,
+                    range: arg_tokens[idx].span,
                 },
             );
             idx += 1;
@@ -5614,6 +5709,13 @@ impl Analyser {
                 pattern: format!("{source_ns}::*"),
                 range: cmd_tok.span,
                 conjectured: true,
+                // The wrapper's own body is not read, so whether the
+                // `namespace import` it `uplevel`s carries `-force` is
+                // unknown. `false` is the conservative reading for the one
+                // thing the flag decides: a conjectured import never claims
+                // to have replaced a command the target namespace already
+                // holds.
+                forced: false,
             },
         );
     }

--- a/rust/tcl-compiler/src/analyser/state.rs
+++ b/rust/tcl-compiler/src/analyser/state.rs
@@ -1779,12 +1779,36 @@ impl Analyser {
     /// disabled-code filter and the dedupe + canonical-order pass.  Shared by
     /// `analyse` / `analyse_chunked` / `analyse_commands` so the emitter set and
     /// ordering stay identical across every entry point.
+    /// Drop the conditional entries from
+    /// [`AnalysisResult::destroyed_commands`], keeping only destructions
+    /// written at **load level**.
+    ///
+    /// A `rename OLD {}` inside a proc/class body runs at *call* time, when
+    /// and if that definition is invoked — the same conditionality
+    /// [`AnalysisResult::offset_is_inside_any_definition_body`] already
+    /// governs for a nested `proc` shadow — and the consumer of this table
+    /// revokes an import alias on it (issue #1103), which would drop a
+    /// genuinely-live command. Removal events abstain toward keeping the
+    /// alias, so the conditional ones are simply not published.
+    ///
+    /// It also keeps the incremental per-item path byte-identical to the
+    /// whole-file one: an isolated body's destruction reaches the shell only
+    /// on one of the two paths, and this filter removes it from both.
+    fn publish_load_level_destructions(&mut self) {
+        let all = std::mem::take(&mut self.result.destroyed_commands);
+        self.result.destroyed_commands = all
+            .into_iter()
+            .filter(|&(_, off)| !self.result.offset_is_inside_any_definition_body(off))
+            .collect();
+    }
+
     pub(super) fn run_diagnostic_emitters(&mut self, source: &str) {
         // Settle every invocation's `resolved_qualified_name` with Tcl's
         // existence-checked two-step rule now that the walk has recorded
         // every definition in the file (a local candidate defined later in
         // the file still wins; an absent one falls back to global).
         self.finalise_invocation_resolutions();
+        self.publish_load_level_destructions();
         // Attach every namespace-qualified occurrence to the cell it names,
         // now that the whole file's `namespace eval` bodies have been walked
         // — a qualified read can precede its declaring `namespace eval`

--- a/rust/tcl-compiler/src/analyser/types.rs
+++ b/rust/tcl-compiler/src/analyser/types.rs
@@ -28,7 +28,7 @@ use tcl_lexer::Span;
 
 use crate::signature_scan::types::{
     ParamDef, SignatureCommandAlias, SignatureCommandInvocation, SignatureNamespaceExport,
-    SignatureNamespaceImport, SignaturePackageRequire, SignatureSource,
+    SignatureNamespaceForget, SignatureNamespaceImport, SignaturePackageRequire, SignatureSource,
 };
 
 pub use tcl_core_types::DiagCode;
@@ -1054,6 +1054,42 @@ pub struct AnalysisResult {
     pub ensemble_subcommand_targets: HashMap<String, HashMap<String, String>>,
     /// Namespace import records.
     pub namespace_imports: Vec<SignatureNamespaceImport>,
+    /// Namespace `forget` records — the removal half of the import edge's
+    /// ordered lifecycle log (issue #1103). See
+    /// [`SignatureNamespaceForget`] for the oracle: an import installs an
+    /// alias, `namespace forget` takes it away again, and a bare call after
+    /// the forget is `invalid command name`. Consumed together with
+    /// [`Self::namespace_imports`] by
+    /// `tcl_lsp_core::namespace_import::alias_live_at`, under the same
+    /// order gate ([`super::indirection::in_effect`]) the export snapshot
+    /// and the `rename` / `interp alias` timeline already use.
+    pub namespace_forgets: Vec<SignatureNamespaceForget>,
+    /// Byte offset of the statement that **destroyed** each qualified command
+    /// — `rename OLD {}` and `interp alias {} NAME {}`, the two forms that
+    /// delete the command *object* rather than move it.
+    ///
+    /// A destruction is a lifecycle event on every `namespace import` edge
+    /// pointing at the command: the alias holds the object, so destroying it
+    /// kills the alias too (oracle tclsh 8.6.14 / 9.0.4 — with `::dst::p`
+    /// imported from `::src::p`, `rename ::src::p {}` makes `::dst::p` an
+    /// `invalid command name` and empties `info commands ::dst::*`). Issue
+    /// #1103.
+    ///
+    /// A **rename** is deliberately absent, which is why this is not
+    /// [`super::state::Analyser::deleted_commands`] (whose "`OLD` is no
+    /// longer callable under that name" meaning covers both forms, because
+    /// that is what its W123 / arity consumers ask). `rename ::src::p
+    /// ::src::pp` keeps `::dst::p` working and merely moves the origin
+    /// (`namespace origin ::dst::p` → `::src::pp`) — the same
+    /// rename-captures-object-identity rule
+    /// [`super::indirection`] already models.
+    ///
+    /// Only straight-line (non-conditional) **load-level** destructions are
+    /// recorded: one written inside a proc/class body runs at call time, when
+    /// and if that definition is invoked, and a consumer that revoked an alias
+    /// on it would drop a genuinely-live command
+    /// ([`super::state::Analyser::publish_load_level_destructions`]).
+    pub destroyed_commands: HashMap<String, u32>,
     /// Namespace `export` records — see [`SignatureNamespaceExport`] for why
     /// they exist (gating wildcard-import bareword resolution, issue #923
     /// idx 18).

--- a/rust/tcl-compiler/src/signature_scan/handlers.rs
+++ b/rust/tcl-compiler/src/signature_scan/handlers.rs
@@ -34,8 +34,9 @@ use tcl_lexer::{Token, TokenType};
 use super::ctx::{FactoryCandidate, ProcBodyInfo, ScanCtx};
 use super::params::parse_param_list;
 use super::types::{
-    SignatureAutoPathEntry, SignatureClass, SignatureCommandAlias, SignatureNamespaceImport,
-    SignaturePackageRequire, SignatureProc, SignatureRename, SignatureScanResult, SignatureSource,
+    SignatureAutoPathEntry, SignatureClass, SignatureCommandAlias, SignatureNamespaceForget,
+    SignatureNamespaceImport, SignaturePackageRequire, SignatureProc, SignatureRename,
+    SignatureScanResult, SignatureSource,
 };
 
 /// Fully qualify `name` within `ns_prefix` following Tcl scoping.
@@ -70,6 +71,53 @@ fn canonical_subcommand<'w>(
         .and_then(|r| r.get(parent))
         .and_then(|spec| spec.resolve_subcommand(word))
         .map_or(word, |sub| sub.name)
+}
+
+/// How many of `args`' leading words `PARENT SUB` consumes as option flags,
+/// entirely from registry data: a word matching a declared flag option of
+/// that subcommand, capped by its declared
+/// [`tcl_registry::SubCommand::max_leading_option_words`].
+///
+/// The scanner-side twin of the analyser's
+/// `Analyser::namespace_leading_flag_words` — see that function for why the
+/// match is exact rather than the generic unique-prefix rule, and why the
+/// cap is registry data. Kept in step so the light background scan and the
+/// full analyser cannot disagree on where a `namespace import`'s patterns
+/// start.
+///
+/// `0` with no registry attached: a flagless read then treats the option word
+/// as an ordinary pattern, which the callers below discard anyway (`-force`
+/// carries no `::`).
+///
+/// The subcommand's own declared `options` are read directly rather than
+/// through a dialect profile: this scan has no resolved dialect, and the two
+/// subcommands involved (`namespace import` / `namespace forget`) declare no
+/// dialect-gated options, so profile filtering could only ever return the same
+/// set.
+fn leading_flag_words(
+    registry: Option<&tcl_registry::CommandRegistry>,
+    parent: &str,
+    sub: &str,
+    args: &[String],
+) -> usize {
+    let Some(sub_spec) = registry
+        .and_then(|r| r.get(parent))
+        .and_then(|spec| spec.subcommand(sub))
+    else {
+        return 0;
+    };
+    let cap = sub_spec
+        .max_leading_option_words
+        .map_or(usize::MAX, usize::from);
+    args.iter()
+        .take(cap)
+        .take_while(|w| {
+            sub_spec
+                .options
+                .iter()
+                .any(|o| o.matches(w.as_str()) && !o.takes_value())
+        })
+        .count()
 }
 
 /// Insert a class record under `result.classes`, computing the
@@ -246,7 +294,62 @@ pub(super) fn handle_namespace(
         return;
     }
     if sub == "import" && texts.len() >= 3 {
-        handle_namespace_import(texts, argv, ns_prefix, &mut ctx.result);
+        handle_namespace_import(texts, argv, ns_prefix, ctx.registry, &mut ctx.result);
+    }
+    if sub == "forget" && texts.len() >= 3 {
+        handle_namespace_forget(texts, argv, ns_prefix, ctx.registry, &mut ctx.result);
+    }
+}
+
+/// Handler for `namespace forget ?PATTERN…?` — the removal half of the
+/// import edge's lifecycle log (issue #1103).
+///
+/// The scanner-side twin of `Analyser::handle_namespace_forget_command`; see
+/// that function and
+/// [`crate::signature_scan::types::SignatureNamespaceForget`] for the
+/// semantics and the oracle. Dynamic patterns are skipped (revoking an alias
+/// on a guess would silently drop real references).
+pub(super) fn handle_namespace_forget(
+    texts: &[String],
+    argv: &[Token],
+    ns_prefix: &str,
+    registry: Option<&tcl_registry::CommandRegistry>,
+    result: &mut SignatureScanResult,
+) {
+    let forgetting_ns = if ns_prefix.is_empty() {
+        "::".to_string()
+    } else {
+        format!("::{ns_prefix}")
+    };
+    let mut i = 2 + leading_flag_words(registry, "namespace", "forget", &texts[2..]);
+    while i < texts.len() && i < argv.len() {
+        let raw = &texts[i];
+        if raw.contains('$') || raw.contains('[') {
+            i += 1;
+            continue;
+        }
+        let (source_ns, pattern) = match raw.rsplit_once("::") {
+            Some((prefix, tail)) => {
+                let prefix = if prefix.is_empty() {
+                    "::".to_string()
+                } else if prefix.starts_with("::") {
+                    prefix.to_string()
+                } else if forgetting_ns == "::" {
+                    format!("::{prefix}")
+                } else {
+                    format!("{forgetting_ns}::{prefix}")
+                };
+                (Some(prefix), tail.to_string())
+            }
+            None => (None, raw.clone()),
+        };
+        result.namespace_forgets.push(SignatureNamespaceForget {
+            ns: forgetting_ns.clone(),
+            source_ns,
+            pattern,
+            range: argv[i].span,
+        });
+        i += 1;
     }
 }
 
@@ -262,6 +365,7 @@ pub(super) fn handle_namespace_import(
     texts: &[String],
     argv: &[Token],
     ns_prefix: &str,
+    registry: Option<&tcl_registry::CommandRegistry>,
     result: &mut SignatureScanResult,
 ) {
     let importing_ns = if ns_prefix.is_empty() {
@@ -269,13 +373,16 @@ pub(super) fn handle_namespace_import(
     } else {
         format!("::{ns_prefix}")
     };
-    let mut i = 2;
+    // Which leading words are options, and how many are consumed, is registry
+    // data — not the `-force` string match this loop used to carry. That the
+    // option word *was* consumed is exactly "`-force` was given", since
+    // `IMPORT_OPTIONS` declares one option and `max_leading_option_words`
+    // caps it at one.
+    let flag_words = leading_flag_words(registry, "namespace", "import", &texts[2..]);
+    let forced = flag_words > 0;
+    let mut i = 2 + flag_words;
     while i < texts.len() {
         let pattern_raw = &texts[i];
-        if pattern_raw == "-force" {
-            i += 1;
-            continue;
-        }
         if !pattern_raw.contains("::") || pattern_raw.contains('$') || pattern_raw.contains('[') {
             i += 1;
             continue;
@@ -292,6 +399,7 @@ pub(super) fn handle_namespace_import(
             pattern,
             range: argv[i].span,
             conjectured: false,
+            forced,
         });
         i += 1;
     }
@@ -549,6 +657,9 @@ pub(super) fn maybe_handle_import_wrapper(
         pattern: format!("{source_ns}::*"),
         range: argv[0].span,
         conjectured: true,
+        // The wrapper body is not read, so `-force` is unknown; `false` is
+        // the conservative reading (see the analyser twin).
+        forced: false,
     });
 }
 
@@ -771,7 +882,7 @@ mod tests {
         ];
         let argv = vec![token(0, 9), token(10, 16), token(17, 25)];
         let mut result = SignatureScanResult::default();
-        handle_namespace_import(&texts, &argv, "", &mut result);
+        handle_namespace_import(&texts, &argv, "", None, &mut result);
         assert_eq!(result.namespace_imports.len(), 1);
         let imp = &result.namespace_imports[0];
         assert_eq!(imp.ns, "::");
@@ -789,9 +900,88 @@ mod tests {
         ];
         let argv = vec![token(0, 9), token(10, 16), token(17, 23), token(24, 32)];
         let mut result = SignatureScanResult::default();
-        handle_namespace_import(&texts, &argv, "", &mut result);
+        handle_namespace_import(&texts, &argv, "", None, &mut result);
         assert_eq!(result.namespace_imports.len(), 1);
         assert_eq!(result.namespace_imports[0].pattern, "::foo::*");
+    }
+
+    /// The consumed leading option word *is* `-force`, read from the
+    /// registry's own `IMPORT_OPTIONS` + `max_leading_option_words` rather
+    /// than matched by name (issue #1103).
+    #[test]
+    fn handle_namespace_import_records_the_force_flag() {
+        let registry = tcl_registry::registry_for_dialect("tcl9.0");
+        let texts = vec![
+            "namespace".to_string(),
+            "import".to_string(),
+            "-force".to_string(),
+            "::foo::*".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 23), token(24, 32)];
+        let mut result = SignatureScanResult::default();
+        handle_namespace_import(&texts, &argv, "", Some(registry), &mut result);
+        assert_eq!(result.namespace_imports.len(), 1);
+        assert!(result.namespace_imports[0].forced);
+
+        let texts = vec![
+            "namespace".to_string(),
+            "import".to_string(),
+            "::foo::*".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 25)];
+        let mut result = SignatureScanResult::default();
+        handle_namespace_import(&texts, &argv, "", Some(registry), &mut result);
+        assert_eq!(result.namespace_imports.len(), 1);
+        assert!(!result.namespace_imports[0].forced);
+    }
+
+    /// `namespace forget` in both pattern shapes `Tcl_ForgetImport` accepts.
+    #[test]
+    fn handle_namespace_forget_records_both_pattern_shapes() {
+        let registry = tcl_registry::registry_for_dialect("tcl9.0");
+        // Qualified: names the source namespace.
+        let texts = vec![
+            "namespace".to_string(),
+            "forget".to_string(),
+            "::src::p".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 25)];
+        let mut result = SignatureScanResult::default();
+        handle_namespace_forget(&texts, &argv, "dst", Some(registry), &mut result);
+        assert_eq!(result.namespace_forgets.len(), 1);
+        let fgt = &result.namespace_forgets[0];
+        assert_eq!(fgt.ns, "::dst");
+        assert_eq!(fgt.source_ns.as_deref(), Some("::src"));
+        assert_eq!(fgt.pattern, "p");
+
+        // Simple: matches this namespace's own imported names, any origin.
+        let texts = vec![
+            "namespace".to_string(),
+            "forget".to_string(),
+            "p*".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 19)];
+        let mut result = SignatureScanResult::default();
+        handle_namespace_forget(&texts, &argv, "dst", Some(registry), &mut result);
+        assert_eq!(result.namespace_forgets.len(), 1);
+        assert!(result.namespace_forgets[0].source_ns.is_none());
+        assert_eq!(result.namespace_forgets[0].pattern, "p*");
+    }
+
+    /// A dynamic forget pattern is skipped rather than guessed at: revoking
+    /// an alias on a guess would silently drop real references.
+    #[test]
+    fn handle_namespace_forget_skips_dynamic_patterns() {
+        let registry = tcl_registry::registry_for_dialect("tcl9.0");
+        let texts = vec![
+            "namespace".to_string(),
+            "forget".to_string(),
+            "${ns}::*".to_string(),
+        ];
+        let argv = vec![token(0, 9), token(10, 16), token(17, 25)];
+        let mut result = SignatureScanResult::default();
+        handle_namespace_forget(&texts, &argv, "", Some(registry), &mut result);
+        assert!(result.namespace_forgets.is_empty());
     }
 
     #[test]
@@ -803,7 +993,7 @@ mod tests {
         ];
         let argv = vec![token(0, 9), token(10, 16), token(17, 23)];
         let mut result = SignatureScanResult::default();
-        handle_namespace_import(&texts, &argv, "foo", &mut result);
+        handle_namespace_import(&texts, &argv, "foo", None, &mut result);
         assert_eq!(result.namespace_imports.len(), 1);
         let imp = &result.namespace_imports[0];
         assert_eq!(imp.ns, "::foo");
@@ -819,7 +1009,7 @@ mod tests {
         ];
         let argv = vec![token(0, 9), token(10, 16), token(17, 25)];
         let mut result = SignatureScanResult::default();
-        handle_namespace_import(&texts, &argv, "", &mut result);
+        handle_namespace_import(&texts, &argv, "", None, &mut result);
         assert!(result.namespace_imports.is_empty());
     }
 

--- a/rust/tcl-compiler/src/signature_scan/types.rs
+++ b/rust/tcl-compiler/src/signature_scan/types.rs
@@ -176,6 +176,88 @@ pub struct SignatureNamespaceImport {
     /// `<NS>::import <ALIAS>` call rather than a direct `namespace
     /// import` invocation.
     pub conjectured: bool,
+    /// `true` when the call consumed its leading option word — i.e. the
+    /// import is `namespace import -force …`.
+    ///
+    /// The distinction is not cosmetic: it decides what the import does to a
+    /// command of the same name that the importing namespace *already* holds
+    /// (oracle tclsh 8.6.14 / 9.0.4, issue #1103).
+    ///
+    /// - Without `-force`, the import **fails**: `namespace eval ::dst {proc
+    ///   p {} {return LOCAL}}` then `namespace eval ::dst {namespace import
+    ///   ::src::*}` raises `can't import command "p": already exists`, the
+    ///   rest of that script never runs, and `::dst::p` still runs `LOCAL`
+    ///   (`namespace origin ::dst::p` → `::dst::p`). The import installed
+    ///   nothing.
+    /// - With `-force`, the import silently **replaces** the local command:
+    ///   `::dst::p` then runs `SRC` and `namespace origin ::dst::p` →
+    ///   `::src::p`.
+    ///
+    /// Which leading words are options, and how many are consumed, is
+    /// registry data (`IMPORT_OPTIONS` + `SubCommand::max_leading_option_words`
+    /// = 1) — this flag is "the declared leading option word was consumed",
+    /// not a `-force` string match, exactly as `namespace export`'s
+    /// [`SignatureNamespaceExport::clears`] is.
+    pub forced: bool,
+}
+
+/// A `namespace forget` **event** recorded by the signature scanner.
+///
+/// `namespace import` does not create a permanent name: `namespace forget`
+/// removes the alias again, and a later bare call is `invalid command name`
+/// (oracle tclsh 8.6.14 / 9.0.4, byte-identical — issue #1103):
+///
+/// ```tcl
+/// namespace eval ::src { proc p {} {return P}; namespace export p }
+/// namespace eval ::dst { namespace import ::src::* }
+/// namespace eval ::dst { p }                  ;# → P
+/// namespace eval ::dst { namespace forget ::src::p }
+/// namespace eval ::dst { p }                  ;# → invalid command name "p"
+/// ```
+///
+/// So the import edge is not a static name-visibility fact but a link with a
+/// lifecycle, and these records are the *removal* half of its ordered event
+/// log — the exact counterpart of [`SignatureNamespaceExport`]'s `-clear`
+/// tombstones, consumed the same way (latest visible event wins, order-gated
+/// by `analyser::indirection::in_effect`) through
+/// `tcl_lsp_core::namespace_import::alias_live_at`.
+///
+/// # Two pattern shapes
+///
+/// `Tcl_ForgetImport` (`tclNamesp.c`) branches on whether the pattern is
+/// qualified, and both forms are oracle-confirmed:
+///
+/// - **Qualified** (`namespace forget ::src::p`, `::src::*`) — every command
+///   in `::src` matching the tail pattern has its *import* in the current
+///   namespace removed. [`Self::source_ns`] is `Some("::src")`.
+/// - **Simple** (`namespace forget p`, `*`) — every *imported* command of the
+///   current namespace whose own name matches the pattern is removed,
+///   whatever it was imported from. [`Self::source_ns`] is `None`.
+///   (Oracle: with `::dst::p` imported from `::src`, `namespace eval ::dst
+///   {namespace forget p}` leaves `info commands ::dst::*` empty and raises
+///   no error.)
+///
+/// Forgetting a name that was never imported is a silent no-op, not an error
+/// — only an unknown *namespace* in a qualified pattern errors (`unknown
+/// namespace in namespace forget pattern "::nope::x"`), which is a
+/// diagnostics question, not a resolution one.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SignatureNamespaceForget {
+    /// The namespace the forget runs in — the one losing the aliases, with
+    /// leading `::`.
+    pub ns: String,
+    /// The pattern's source namespace with leading `::` when the pattern was
+    /// qualified (`::src` for `::src::p`), `None` for a simple pattern.
+    ///
+    /// `None` matches *any* source: a simple pattern is matched against the
+    /// forgetting namespace's own imported command names.
+    pub source_ns: Option<String>,
+    /// The pattern's final `::`-segment, exactly as written (`p`, `*`,
+    /// `get*`) — matched against a command's bare name with Tcl glob
+    /// semantics.
+    pub pattern: String,
+    /// Source span of the pattern argument.
+    pub range: Span,
 }
 
 /// One `namespace export` **event** recorded by the signature scanner.
@@ -381,6 +463,9 @@ pub struct SignatureScanResult {
     pub renames: BTreeMap<String, SignatureRename>,
     /// Every recorded `namespace import` (direct + conjectured).
     pub namespace_imports: Vec<SignatureNamespaceImport>,
+    /// Every recorded `namespace forget` event — the removal half of the
+    /// import edge's lifecycle log (issue #1103).
+    pub namespace_forgets: Vec<SignatureNamespaceForget>,
     /// Every `auto_path` mutation (one record per path element).
     pub auto_path_entries: Vec<SignatureAutoPathEntry>,
     /// Every command invocation visited (lightweight: name + range).

--- a/rust/tcl-lsp-core/src/call_hierarchy.rs
+++ b/rust/tcl-lsp-core/src/call_hierarchy.rs
@@ -635,7 +635,15 @@ fn unresolved_method_outgoing_calls(
         // method body's commands resolve there), with the deterministic
         // simple-name fallback — not a namespace-blind `any` scan.
         let class_ns = tcl_syntax::naming::key_holder_and_tail(&class_def.qualified_name).0;
-        if crate::definition::resolve_called_proc(analysis, source, class_ns, &head, None).is_some()
+        if crate::definition::resolve_called_proc(
+            analysis,
+            source,
+            class_ns,
+            &head,
+            span.start(),
+            None,
+        )
+        .is_some()
         {
             continue;
         }
@@ -1067,9 +1075,14 @@ fn method_outgoing_calls(
         // simple-name fallback, never a namespace-blind `p.name == head`
         // first-hit scan that could edge the hierarchy to an arbitrary
         // same-named proc in an unrelated namespace.
-        if let Some(proc_def) =
-            crate::definition::resolve_called_proc(analysis, source, class_ns, &head, None)
-        {
+        if let Some(proc_def) = crate::definition::resolve_called_proc(
+            analysis,
+            source,
+            class_ns,
+            &head,
+            span.start(),
+            None,
+        ) {
             let qname = &proc_def.qualified_name;
             let entry = by_target
                 .entry(CallItemKey::for_proc(qname, proc_def))

--- a/rust/tcl-lsp-core/src/caller_frame.rs
+++ b/rust/tcl-lsp-core/src/caller_frame.rs
@@ -335,6 +335,7 @@ fn bindings_from_call(
         ctx.source,
         &ctx.namespace,
         head_text,
+        head.span.start(),
         ctx.registry,
     ) else {
         return;

--- a/rust/tcl-lsp-core/src/code_actions.rs
+++ b/rust/tcl-lsp-core/src/code_actions.rs
@@ -1574,9 +1574,14 @@ fn inline_proc_action(
         head_off,
         &analysis.namespace_overrides,
     );
-    let Some(proc_def) =
-        crate::definition::resolve_called_proc(analysis, source, &ns, head, Some(registry))
-    else {
+    let Some(proc_def) = crate::definition::resolve_called_proc(
+        analysis,
+        source,
+        &ns,
+        head,
+        head_off,
+        Some(registry),
+    ) else {
         return Vec::new();
     };
     // Body text (strip the outer braces). `body_span` may exclude the proc's

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -112,6 +112,7 @@
 
 use rustc_hash::FxHashSet;
 use tcl_compiler::analyser::AnalysisResult;
+use tcl_compiler::analyser::indirection;
 use tcl_lexer::{LineIndex, Utf16Col};
 
 use crate::hover::{find_var_at_position, find_word_span_at_position};
@@ -211,6 +212,7 @@ pub fn definition(
                 source,
                 "::",
                 target,
+                cursor_offset,
                 Some(tcl_registry::registry_for_dialect(&analysis.dialect)),
             )
         {
@@ -287,6 +289,7 @@ pub fn definition(
         source,
         &namespace,
         &word,
+        cursor_offset,
         Some(tcl_registry::registry_for_dialect(&analysis.dialect)),
     ) {
         // A proc redefined later in the document is two definitions sharing
@@ -340,8 +343,14 @@ fn indirect_definition_target(
 ) -> Option<tcl_lexer::Span> {
     let hop = command_indirection(analysis, word, cursor_off)?;
     let registry = tcl_registry::registry_for_dialect(&analysis.dialect);
-    if let Some(proc_def) = resolve_called_proc(analysis, source, "::", &hop.target, Some(registry))
-    {
+    if let Some(proc_def) = resolve_called_proc(
+        analysis,
+        source,
+        "::",
+        &hop.target,
+        cursor_off,
+        Some(registry),
+    ) {
         let captured = analysis
             .proc_def_in_effect_at(&proc_def.qualified_name, hop.resolve_at)
             .unwrap_or(proc_def);
@@ -2260,21 +2269,18 @@ pub fn itcl_class_proc_target_at(
 
 /// Resolve a bareword `word` (`namespace` context, honouring `namespace
 /// path` exactly like [`proc_visible_from_namespace`]) through an
-/// in-document wildcard `namespace import NS::*` — a glob (or exact)
-/// pattern recorded in `analysis.namespace_imports`.
+/// in-document `namespace import NS::*` — a glob (or exact) pattern
+/// recorded in `analysis.namespace_imports`, as the call at `call_off` sees
+/// it.
 ///
 /// For each candidate qualified name Tcl's own lookup would try (the
 /// caller's namespace, then each `namespace path` entry, then global — the
 /// same order [`proc_visible_from_namespace`] walks), this checks whether
-/// that candidate's namespace has an in-scope import whose pattern's tail
-/// glob-matches `word`. A wildcard import only ever imports names its
-/// source namespace has actually `namespace export`ed (`Tcl_Export`,
-/// `tclNamesp.c`) — an unexported sibling command living in the same
-/// namespace is **not** reachable through the import (tclsh9.0/8.6-verified:
-/// `invalid command name` calling it bare) — so this also requires the source
-/// namespace to have exported a covering pattern **as of that import's own
-/// position** ([`crate::namespace_import::exported_at_import_site`], issue
-/// #1027), not in the document's final export state.
+/// that candidate's namespace **still holds a live imported alias** for
+/// `word` at `call_off` — see [`live_import_at`] for the lifecycle that
+/// question covers (issue #1103), and
+/// [`crate::namespace_import::exported_at_import_site`] for the export
+/// snapshot each import site is judged by (issue #1027).
 ///
 /// Only resolves a source namespace defined in **this** document
 /// (`analysis.all_procs`); a source namespace defined in another file is
@@ -2284,27 +2290,143 @@ fn proc_visible_via_wildcard_import<'a>(
     analysis: &'a AnalysisResult,
     namespace: &str,
     word: &str,
+    call_off: u32,
 ) -> Option<&'a tcl_compiler::analyser::ProcDef> {
+    let source_ns = wildcard_import_source_namespace(analysis, namespace, word, call_off)?;
+    analysis
+        .all_procs
+        .get(&tcl_syntax::naming::qualify(&source_ns, word))
+}
+
+/// Whether a live `namespace import -force` covering `word` has taken the
+/// name away from `namespace`'s own command table by the time the call at
+/// `call_off` runs — the only import that outranks a same-named command the
+/// importing namespace already holds.
+///
+/// Oracle (tclsh 8.6.14 / 9.0.4, byte-identical): with `proc ::dst::p`
+/// returning `LOCAL` and `::src::p` returning `SRC`, `namespace eval ::dst
+/// {namespace import -force ::src::*}` makes `::dst::p` return `SRC` and
+/// `namespace origin ::dst::p` answer `::src::p`. Without `-force` the same
+/// import raises `can't import command "p": already exists` and installs
+/// nothing at all — which [`live_import_at`] models by declining the import
+/// outright, so the two cases agree by construction.
+///
+/// Consulted *before* [`proc_visible_from_namespace`] in
+/// [`resolve_called_proc`], because that is the whole point of `-force`:
+/// from the import's own position onward, the local definition is gone. It
+/// answers a plain boolean rather than a `ProcDef` because the shadow holds
+/// whether or not this document can see the source — a `-force` import of a
+/// namespace defined in *another* file still deletes the local command, and
+/// answering with that local definition would be wrong; the cross-document
+/// resolver takes it from there.
+fn forced_import_shadows(
+    analysis: &AnalysisResult,
+    namespace: &str,
+    word: &str,
+    call_off: u32,
+) -> bool {
+    if word.contains("::") {
+        return false;
+    }
     let path = analysis
         .namespace_paths
         .get(namespace)
         .map_or(&[][..], Vec::as_slice);
-    let source_ns = wildcard_import_source_namespace(analysis, namespace, path, word)?;
-    analysis
-        .all_procs
-        .get(&tcl_syntax::naming::qualify(source_ns, word))
+    import_hop(
+        analysis,
+        namespace,
+        path,
+        word,
+        call_off,
+        ImportQuery::ForcedShadow,
+    )
+    .is_some()
 }
 
-/// Shared candidate walk behind [`proc_visible_via_wildcard_import`] and
-/// [`resolve_class_target_at`]'s wildcard-import fallback: find the first
-/// in-scope `namespace import` whose pattern covers `word`, whose source
-/// namespace has actually exported a matching pattern, and return that
-/// source namespace. `path` is the caller's own `namespace path` entries
-/// (empty for the class resolver, which — like
-/// [`tcl_syntax::naming::bareword_resolution_candidates`] — does not
-/// consult it). The caller joins the result with `word`
-/// ([`tcl_syntax::naming::qualify`]) and looks the qualified name up in
-/// whichever map (`all_procs` / `all_classes`) applies.
+/// [`forced_import_shadows`] over a call's already-computed candidate list —
+/// the shape the cross-document resolver has in hand.
+///
+/// `resolve_workspace_symbols` (`tcl-lsp-server`) is a separate resolver, not
+/// a caller of [`resolve_called_proc`], so it needs its own application of the
+/// same rule: a candidate naming this document's own `proc bar` must not
+/// settle the call while a live `namespace import -force ::Lib::*` has
+/// replaced it — the call reaches `::Lib::bar`, which only the workspace tier
+/// can find. Without this the two resolvers disagree, and the one that answers
+/// first wins with the definition the program no longer has.
+#[must_use]
+pub fn forced_import_shadows_call(
+    analysis: &AnalysisResult,
+    word: &str,
+    resolution_candidates: &[String],
+    call_off: u32,
+) -> bool {
+    if word.contains("::") {
+        return false;
+    }
+    live_import_over_candidates(
+        analysis,
+        resolution_candidates.iter().map(String::as_str),
+        word,
+        call_off,
+        ImportQuery::ForcedShadow,
+    )
+    .is_some()
+}
+
+/// Which question [`import_hop`] / [`live_import_at`] are being asked, and
+/// therefore what an *absent* `namespace export` record means.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ImportQuery {
+    /// "Which namespace does this call really reach?" Every import counts,
+    /// and the export gate is strict: a name the source did not export
+    /// installs nothing, so it must not resolve.
+    Resolve,
+    /// "Has a `namespace import -force` taken this name away from the
+    /// importing namespace's own command table?" ([`forced_import_shadows`])
+    /// Only forced imports count, and the export gate abstains for a source
+    /// namespace this document cannot see at all: `namespace import -force
+    /// ::Lib::*` deletes the local command whether or not `::Lib`'s export
+    /// declaration happens to live in *this* file, and answering with the
+    /// deleted definition would be worse than abstaining. The same
+    /// "absence of an export is evidence only where the definitions are
+    /// visible too" rule `WorkspaceIndex::live_command_links` applies
+    /// cross-document.
+    ForcedShadow,
+}
+
+/// Whether this document can say anything at all about `source_ns` — it holds
+/// a proc or class of that namespace, or an export declaration for it.
+///
+/// The in-document twin of `WorkspaceIndex::observable_namespaces`, and the
+/// discriminator [`ImportQuery::ForcedShadow`] needs between "this namespace
+/// did not export the name" (a fact) and "this namespace is in another file"
+/// (no information).
+fn namespace_is_observable(analysis: &AnalysisResult, source_ns: &str) -> bool {
+    let bare = source_ns.trim_start_matches("::");
+    let owns = |qualified: &String| {
+        qualified
+            .trim_start_matches("::")
+            .rsplit_once("::")
+            .is_some_and(|(ns, _)| ns == bare)
+    };
+    analysis.all_procs.keys().any(owns)
+        || analysis.all_classes.keys().any(owns)
+        || analysis
+            .namespace_exports
+            .iter()
+            .any(|e| e.ns.trim_start_matches("::") == bare)
+}
+
+/// Shared candidate walk behind [`proc_visible_via_wildcard_import`],
+/// [`proc_visible_via_forced_import`] and [`resolve_class_target_at`]'s
+/// import fallback: find the namespace whose command `word` really names
+/// when the call at `call_off` reaches it through one or more import edges,
+/// or `None`.
+///
+/// The caller joins the result with `word` ([`tcl_syntax::naming::qualify`])
+/// and looks the qualified name up in whichever map (`all_procs` /
+/// `all_classes`) applies — which is also the map this walk consults to
+/// decide whether a chain has terminated.
 ///
 /// Restricted to a genuine bareword `word` (no embedded `::`) — `namespace
 /// import` / `namespace export` patterns only ever name simple command
@@ -2313,43 +2435,264 @@ fn proc_visible_via_wildcard_import<'a>(
 /// abstains rather than risk mismatching a namespace-path segment against
 /// an unrelated import.
 ///
-/// The export check is taken **at each import's own position** rather than
-/// against the document's final export state: an import binds the names
-/// exported when it runs, and neither a later `-clear` nor a later `namespace
-/// export` reaches back (issue #1027 — see
-/// [`crate::namespace_import`] for the oracle). Every import site in scope is
-/// tried, so a second, later import that *does* see a name still resolves it.
-fn wildcard_import_source_namespace<'a, S: AsRef<str>>(
-    analysis: &'a AnalysisResult,
+/// # Import chains
+///
+/// An import edge may land on a name that is *itself* imported: with `::C`
+/// exporting `p`, `::B` importing `::C::*` and re-exporting, and `::A`
+/// importing `::B::*`, `::A::p` runs `::C`'s body and `namespace origin
+/// ::A::p` answers `::C::p` (oracle tclsh 8.6.14 / 9.0.4 — issue #1103).
+/// Statically the middle hop is in no `all_procs`, so a single-hop walk
+/// found nothing. This one follows the chain while every hop is provable,
+/// bounded by [`indirection::MAX_COMMAND_NAME_HOPS`] — the same cap the
+/// `rename` / `interp alias` walk applies to the same kind of chain, so a
+/// mutually-importing pair cannot spin — and abstains otherwise.
+///
+/// The whole chain is judged at the *call's* offset, not at each import's:
+/// a forget anywhere along it kills the call (oracle: forgetting `::C::p`
+/// inside `::B` makes `::A::p` an `invalid command name` too, because
+/// deleting an imported command deletes the commands imported *from* it).
+fn wildcard_import_source_namespace(
+    analysis: &AnalysisResult,
     namespace: &str,
-    path: &[S],
     word: &str,
-) -> Option<&'a str> {
+    call_off: u32,
+) -> Option<String> {
     if word.contains("::") {
         return None;
     }
-    for candidate in tcl_syntax::naming::command_resolution_candidates(namespace, path, word) {
-        let Some((prefix, _)) = candidate.rsplit_once("::") else {
+    let mut current = namespace.to_owned();
+    let mut first_hop = true;
+    for _ in 0..indirection::MAX_COMMAND_NAME_HOPS {
+        let path = if first_hop {
+            analysis
+                .namespace_paths
+                .get(current.as_str())
+                .map_or(&[][..], Vec::as_slice)
+        } else {
+            // A chain's inner hop starts from the previous hop's source
+            // namespace, where the alias is an ordinary command of that
+            // namespace — `namespace path` is a *caller*-side search rule and
+            // has no bearing on it.
+            &[][..]
+        };
+        let hop = import_hop(
+            analysis,
+            &current,
+            path,
+            word,
+            call_off,
+            ImportQuery::Resolve,
+        )?;
+        // The chain terminates where a real definition lives: everything the
+        // caller can look the name up in.
+        let qualified = tcl_syntax::naming::qualify(&hop, word);
+        if analysis.all_procs.contains_key(&qualified)
+            || analysis.all_classes.contains_key(&qualified)
+        {
+            return Some(hop);
+        }
+        current = hop;
+        first_hop = false;
+    }
+    None
+}
+
+/// One hop of [`wildcard_import_source_namespace`]: the source namespace of
+/// the live import that makes `word` callable from `namespace` (or one of its
+/// `path` entries) at `call_off`.
+fn import_hop<S: AsRef<str>>(
+    analysis: &AnalysisResult,
+    namespace: &str,
+    path: &[S],
+    word: &str,
+    call_off: u32,
+    query: ImportQuery,
+) -> Option<String> {
+    let candidates = tcl_syntax::naming::command_resolution_candidates(namespace, path, word);
+    live_import_over_candidates(
+        analysis,
+        candidates.iter().map(String::as_str),
+        word,
+        call_off,
+        query,
+    )
+}
+
+/// [`import_hop`] over an already-computed candidate list: the first candidate
+/// namespace holding a live import edge for `word` wins, in Tcl's own
+/// resolution order.
+fn live_import_over_candidates<'c>(
+    analysis: &AnalysisResult,
+    candidates: impl Iterator<Item = &'c str>,
+    word: &str,
+    call_off: u32,
+    query: ImportQuery,
+) -> Option<String> {
+    for candidate in candidates {
+        let Some((prefix, tail)) = candidate.rsplit_once("::") else {
             continue;
         };
+        if tail != word {
+            continue;
+        }
         let candidate_ns = if prefix.is_empty() { "::" } else { prefix };
-        for imp in analysis
-            .namespace_imports
-            .iter()
-            .filter(|i| i.ns == candidate_ns)
-        {
-            let Some((source_ns, export_tail)) = imp.pattern.rsplit_once("::") else {
-                continue;
-            };
-            if source_ns.is_empty() || !tcl_syntax::glob::string_match(export_tail, word) {
-                continue;
-            }
-            if exported_at_import(analysis, source_ns, word, imp.range.start()) {
-                return Some(source_ns);
-            }
+        if let Some(hop) = live_import_at(analysis, candidate_ns, word, call_off, query) {
+            return Some(hop);
         }
     }
     None
+}
+
+/// The source namespace of the import alias `importing_ns` holds for `word`
+/// **at `call_off`**, or `None` when it holds none — the same-document
+/// binding of the shared lifecycle decision
+/// [`crate::namespace_import::alias_live_at`] (issue #1103).
+///
+/// An import edge is a link with a lifecycle, not a standing name-visibility
+/// fact. Four events bear on it, all oracle-confirmed byte-identically on
+/// tclsh 9.0.4 and 8.6.14:
+///
+/// 1. **The import installs it** — gated by the source namespace's export
+///    snapshot at the import's own position
+///    ([`exported_at_import`], issue #1027).
+/// 2. **A conflict makes it install nothing.** Without `-force`, importing
+///    onto a name the target namespace already holds raises `can't import
+///    command "p": already exists`; the local command survives and
+///    `namespace origin` still answers the local. Such an import is declined
+///    here. (Modelling the *error* — that the rest of that script never runs
+///    — is deliberately out of scope; only the "installed nothing" half is
+///    modelled.) With `-force` the import wins instead, which is what
+///    [`ImportQuery::ForcedShadow`] selects for.
+/// 3. **`namespace forget` removes it** — `namespace forget ::src::p`, or the
+///    simple form `namespace forget p`, and a later bare call is `invalid
+///    command name`.
+/// 4. **Deleting the source command removes it** — the alias holds the
+///    command *object*, so `rename ::src::p {}` kills `::dst::p` too, while a
+///    plain `rename ::src::p ::src::pp` leaves it alive (only the origin
+///    moves) and a redefinition of `::src::p` is seen straight through the
+///    link. That asymmetry is `indirection`'s own
+///    rename-captures-object-identity rule, which is why only the *deletion*
+///    appears here.
+///
+/// Ordering is [`indirection::in_effect`] — the same "had this statement
+/// run?" primitive the export snapshot and the `rename` / `interp alias`
+/// timeline use, so none of them can disagree about what "already ran" means.
+/// It gates the *removals*; whether a call written before its own import
+/// should stop resolving is #1104 item 1's separate, still-open leniency (see
+/// [`crate::namespace_import::alias_live_at`]).
+fn live_import_at(
+    analysis: &AnalysisResult,
+    importing_ns: &str,
+    word: &str,
+    call_off: u32,
+    query: ImportQuery,
+) -> Option<String> {
+    use crate::namespace_import::{AliasEvent, AliasEventKind};
+    let visible = |at: u32| indirection::in_effect(analysis, at, call_off);
+    // The install events: every import of this namespace whose pattern covers
+    // `word`, whose source had exported it, and which a conflict did not
+    // reduce to a no-op.
+    let mut latest: Option<(u32, &str)> = None;
+    let mut installs: Vec<(u32, &str)> = Vec::new();
+    for imp in analysis
+        .namespace_imports
+        .iter()
+        .filter(|i| i.ns == importing_ns)
+    {
+        if query == ImportQuery::ForcedShadow && !imp.forced {
+            continue;
+        }
+        let Some((source_ns, export_tail)) = imp.pattern.rsplit_once("::") else {
+            continue;
+        };
+        if source_ns.is_empty() || !tcl_syntax::glob::string_match(export_tail, word) {
+            continue;
+        }
+        let at = imp.range.start();
+        if !exported_at_import(analysis, source_ns, word, at)
+            && (query == ImportQuery::Resolve || namespace_is_observable(analysis, source_ns))
+        {
+            continue;
+        }
+        if !imp.forced && local_command_in_effect_at(analysis, importing_ns, word, at) {
+            continue;
+        }
+        installs.push((at, source_ns));
+        // The latest install wins the source namespace — a second import of
+        // the same name from elsewhere replaces the first alias, exactly as a
+        // second `namespace import` re-snapshots the export list. Deliberately
+        // *not* filtered by `visible`: whether a call written before its own
+        // import should stop resolving is the separate, still-open leniency
+        // #1104 item 1 — see `crate::namespace_import::alias_live_at`.
+        if latest.is_none_or(|(best, _)| at > best) {
+            latest = Some((at, source_ns));
+        }
+    }
+    let (_, source_ns) = latest?;
+    let removals = analysis
+        .namespace_forgets
+        .iter()
+        .filter(|f| {
+            f.ns == importing_ns
+                && f.source_ns.as_deref().is_none_or(|src| {
+                    src.trim_start_matches("::") == source_ns.trim_start_matches("::")
+                })
+                && tcl_syntax::glob::string_match(&f.pattern, word)
+        })
+        .map(|f| AliasEvent {
+            kind: AliasEventKind::Remove,
+            at: Some(f.range.start()),
+        })
+        .chain(
+            analysis
+                .destroyed_commands
+                .get(&tcl_syntax::naming::qualify(source_ns, word))
+                .map(|&at| AliasEvent {
+                    kind: AliasEventKind::Remove,
+                    at: Some(at),
+                }),
+        );
+    // Only the winning source's own installs order against its removals: an
+    // import of the same name from a *different* namespace is a different
+    // edge, and letting it out-date this edge's forget would resurrect it.
+    let mut events = installs
+        .iter()
+        .filter(|(_, ns)| *ns == source_ns)
+        .map(|&(at, _)| AliasEvent {
+            kind: AliasEventKind::Install,
+            at: Some(at),
+        })
+        .chain(removals);
+    crate::namespace_import::alias_live_at(&mut events, &visible).then(|| source_ns.to_owned())
+}
+
+/// Whether `importing_ns` already holds its own command named `word` by the
+/// time the import at `import_at` runs — the conflict a non-`-force`
+/// `namespace import` aborts on (case 2 of [`live_import_at`]).
+///
+/// A definition written *after* the import is not a conflict: the import
+/// succeeds and the later `proc` simply replaces the alias, which the
+/// ordinary namespace lookup already answers. So every declaration is
+/// order-gated by [`indirection::in_effect`] — the same "had this statement
+/// run?" primitive the rest of this module uses — rather than tested for mere
+/// presence. (`AnalysisResult::proc_def_in_effect_at` answers a different
+/// question — *which* of several declarations a call captured — and
+/// deliberately falls back to the winner when none precedes the offset, so it
+/// cannot serve as an existence gate here.)
+fn local_command_in_effect_at(
+    analysis: &AnalysisResult,
+    importing_ns: &str,
+    word: &str,
+    import_at: u32,
+) -> bool {
+    let qualified = tcl_syntax::naming::qualify(importing_ns, word);
+    analysis
+        .proc_declarations(&qualified)
+        .any(|p| indirection::in_effect(analysis, p.name_span.start(), import_at))
+        || analysis
+            .all_classes
+            .get(&qualified)
+            .is_some_and(|c| indirection::in_effect(analysis, c.name_span.start(), import_at))
 }
 
 /// Whether `source_ns` had exported `word` by the time the `namespace import`
@@ -2382,8 +2725,23 @@ pub(crate) fn exported_at_import(
             at: Some(e.range.start()),
         });
     crate::namespace_import::exported_at_import_site(&mut events, word, &|at| {
-        tcl_compiler::analyser::indirection::in_effect(analysis, at, import_at)
+        indirection::in_effect(analysis, at, import_at)
     })
+}
+
+/// Whether the call at `call_off` in `namespace` reaches `def_qualified`
+/// through a live import edge — the entry point `references.rs` shares with
+/// go-to-definition so the two cannot disagree about an import's lifecycle.
+///
+/// Returns the terminal source namespace the chain lands on, which the caller
+/// compares against the definition it is gathering references for.
+pub(crate) fn import_chain_target(
+    analysis: &AnalysisResult,
+    namespace: &str,
+    word: &str,
+    call_off: u32,
+) -> Option<String> {
+    wildcard_import_source_namespace(analysis, namespace, word, call_off)
 }
 
 /// Resolve a call `word` written in `namespace` to the proc it denotes:
@@ -2416,10 +2774,21 @@ pub(crate) fn resolve_called_proc<'a>(
     source: &str,
     namespace: &str,
     word: &str,
+    call_off: u32,
     registry: Option<&tcl_registry::CommandRegistry>,
 ) -> Option<&'a tcl_compiler::analyser::ProcDef> {
     let has_builtin = registry.is_some_and(|r| r.get(word).is_some());
-    if let Some(proc_def) = proc_visible_from_namespace(analysis, namespace, word) {
+    // A `namespace import -force` *replaces* a same-named command the
+    // importing namespace already holds, so from its own position onward the
+    // local definition is no longer what a bare call reaches (oracle on
+    // [`forced_import_shadows`]). The ordinary namespace lookup is therefore
+    // skipped entirely while such a shadow is live — including when the
+    // import's source lives in another file, where answering with the local
+    // definition would be the wrong answer and the cross-document resolver is
+    // the one that can answer.
+    let forced_shadow = forced_import_shadows(analysis, namespace, word, call_off);
+    if !forced_shadow && let Some(proc_def) = proc_visible_from_namespace(analysis, namespace, word)
+    {
         let nested_shadow = has_builtin
             && analysis.offset_is_inside_any_definition_body(proc_def.name_span.start());
         if !nested_shadow {
@@ -2433,14 +2802,20 @@ pub(crate) fn resolve_called_proc<'a>(
     // priority tier (same nested-shadow gate) so an unconditional
     // top-level import still outranks a same-named builtin, matching how
     // an equivalent top-level `proc` redefinition already would.
-    if let Some(proc_def) = proc_visible_via_wildcard_import(analysis, namespace, word) {
+    if let Some(proc_def) = proc_visible_via_wildcard_import(analysis, namespace, word, call_off) {
         let nested_shadow = has_builtin
             && analysis.offset_is_inside_any_definition_body(proc_def.name_span.start());
         if !nested_shadow {
             return Some(proc_def);
         }
     }
-    if has_builtin {
+    if has_builtin || forced_shadow {
+        // With a `-force` shadow live, this document's own command of that
+        // name is gone; the lenient tail match must not resurrect it (nor
+        // reach for a same-named proc in some unrelated namespace). Whatever
+        // the import's source namespace holds is the answer, and the
+        // cross-document resolver is the one that can find it when the source
+        // lives in another file.
         return None;
     }
     fallback_proc_by_simple_name(analysis, source, word)
@@ -2515,7 +2890,7 @@ pub(crate) fn resolve_proc_target_at<'a>(
         cursor_off,
         &analysis.namespace_overrides,
     );
-    let proc_def = resolve_called_proc(analysis, source, &ns, word, registry)?;
+    let proc_def = resolve_called_proc(analysis, source, &ns, word, cursor_off, registry)?;
     analysis.all_procs.get_key_value(&proc_def.qualified_name)
 }
 
@@ -2565,10 +2940,10 @@ pub(crate) fn resolve_class_target_at<'a>(
     // callable bare — see [`proc_visible_via_wildcard_import`] for the full
     // rationale (issue #923 idx 18); classes never consult `namespace path`,
     // matching `bareword_resolution_candidates` above.
-    let source_ns = wildcard_import_source_namespace(analysis, &ns, &[] as &[&str], word)?;
+    let source_ns = wildcard_import_source_namespace(analysis, &ns, word, cursor_off)?;
     analysis
         .all_classes
-        .get_key_value(&tcl_syntax::naming::qualify(source_ns, word))
+        .get_key_value(&tcl_syntax::naming::qualify(&source_ns, word))
 }
 
 /// Deterministic replacement for the old first-`HashMap`-hit tail match: of
@@ -3017,7 +3392,7 @@ mod tests {
         // visible, not the gate this test is proving.
         let src = "namespace eval Foo {\n    proc bar {} { return 1 }\n    proc other {} { return 2 }\n    namespace export bar\n}\nnamespace import ::Foo::*\nother\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "::", "other");
+        let hit = proc_visible_via_wildcard_import(&analysis, "::", "other", u32::MAX);
         assert!(
             hit.is_none(),
             "an unexported sibling must stay unresolved through the wildcard import: {hit:?}"
@@ -3107,7 +3482,7 @@ mod tests {
         // and `info commands ::dst::*` still lists `::dst::p`.
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export -clear\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p");
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a `-clear` written after the import must not revoke it: {hit:?}"
@@ -3123,7 +3498,7 @@ mod tests {
         // p}; ::dst::p` → `invalid command name "::dst::p"`.
         let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export p\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p");
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
         assert!(
             hit.is_none(),
             "an export written after the import must not apply retroactively: {hit:?}"
@@ -3142,7 +3517,7 @@ mod tests {
         let src = "namespace eval src {\n    proc p {} { return P }\n    proc q {} { return Q }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    namespace export -clear p q\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         for name in ["p", "q"] {
-            let hit = proc_visible_via_wildcard_import(&analysis, "dst", name);
+            let hit = proc_visible_via_wildcard_import(&analysis, "dst", name, u32::MAX);
             assert!(
                 hit.is_some(),
                 "the second import must see `{name}`: {hit:?}"
@@ -3158,7 +3533,7 @@ mod tests {
         // returns the empty list, and the later import binds no command.
         let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n    namespace export -clear\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p");
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
         assert!(
             hit.is_none(),
             "a `-clear` before the import leaves nothing exported: {hit:?}"
@@ -3173,11 +3548,11 @@ mod tests {
         let src = "namespace eval src {\n    proc a {} { return A }\n    proc p {} { return P }\n    namespace export a\n    namespace export -clear p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p").is_some(),
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_some(),
             "the `-clear` call's own pattern survives it"
         );
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "a").is_none(),
+            proc_visible_via_wildcard_import(&analysis, "dst", "a", u32::MAX).is_none(),
             "the pattern cleared by the same call must not survive"
         );
     }
@@ -3192,7 +3567,7 @@ mod tests {
         let analysis = analyse(src);
         for name in ["a", "b"] {
             assert!(
-                proc_visible_via_wildcard_import(&analysis, "dst", name).is_some(),
+                proc_visible_via_wildcard_import(&analysis, "dst", name, u32::MAX).is_some(),
                 "`{name}` must stay exported — `namespace export` is additive"
             );
         }
@@ -3205,8 +3580,8 @@ mod tests {
         // `getX` (`::dst::setX` → `invalid command name`).
         let src = "namespace eval src {\n    proc getX {} { return GX }\n    proc setX {} { return SX }\n    namespace export get*\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
-        assert!(proc_visible_via_wildcard_import(&analysis, "dst", "getX").is_some());
-        assert!(proc_visible_via_wildcard_import(&analysis, "dst", "setX").is_none());
+        assert!(proc_visible_via_wildcard_import(&analysis, "dst", "getX", u32::MAX).is_some());
+        assert!(proc_visible_via_wildcard_import(&analysis, "dst", "setX", u32::MAX).is_none());
     }
 
     #[test]
@@ -3219,7 +3594,7 @@ mod tests {
         let src = "namespace eval src {\n    namespace export p\n    proc p {} { return P }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
         assert!(
-            proc_visible_via_wildcard_import(&analysis, "dst", "p").is_some(),
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_some(),
             "`namespace export` names a pattern, not an existing command"
         );
     }
@@ -3237,7 +3612,7 @@ mod tests {
         // plain offset compare did not, which is what the review caught.
         let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    proc setup {} { namespace import ::src::* }\n}\nnamespace eval src {\n    namespace export p\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p");
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a body-local import observes a top-level export written later in \
@@ -3254,7 +3629,7 @@ mod tests {
         // p}}` then `::dst::setup` leaves `::dst::p` an invalid command name.
         let src = "namespace eval src {\n    proc p {} { return P }\n}\nnamespace eval dst {\n    proc setup {} { namespace import ::src::* ; namespace eval ::src { namespace export p } }\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p");
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
         assert!(
             hit.is_none(),
             "an export written after the import in the same body has not run \
@@ -3272,7 +3647,7 @@ mod tests {
         // Consuming both words as flags dropped the export entirely.
         let src = "namespace eval src {\n    proc -clear {} { return DC }\n    namespace export -clear -clear\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "-clear");
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "-clear", u32::MAX);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::-clear"),
             "the second `-clear` is an export pattern, not a second flag: {hit:?}"
@@ -3296,6 +3671,332 @@ mod tests {
             locs[0].start_line, 1,
             "must resolve to Foo::bar's declaration"
         );
+    }
+
+    // ---- the import edge's own lifecycle (issue #1103) -------------------
+    //
+    // #1102 made the import edge a *snapshot* fact; these pin it as a **link
+    // with a lifetime**. Every case is oracle-pinned against tclsh 9.0.4 and
+    // 8.6.14, byte-identical on both, and drives
+    // `proc_visible_via_wildcard_import` / `proc_visible_via_forced_import`
+    // directly for the same reason the #1027 block above does: the lenient
+    // `fallback_proc_by_simple_name` in `resolve_called_proc` would answer
+    // either way and prove nothing about this gate.
+
+    /// Byte offset just past the last occurrence of `needle`.
+    fn after_last(src: &str, needle: &str) -> u32 {
+        u32::try_from(src.rfind(needle).expect("needle present") + needle.len())
+            .expect("tiny test source")
+    }
+
+    /// Byte offset of the first occurrence of `needle`.
+    fn at_first(src: &str, needle: &str) -> u32 {
+        u32::try_from(src.find(needle).expect("needle present")).expect("tiny test source")
+    }
+
+    // Behaviour 1 — `namespace forget`.
+
+    #[test]
+    fn a_forget_after_the_import_stops_resolving_the_alias() {
+        // TN (the bug): oracle
+        //   namespace eval ::src { proc p {} {return P}; namespace export p }
+        //   namespace eval ::dst { namespace import ::src::* }
+        //   namespace eval ::dst { p }                        → P
+        //   namespace eval ::dst { namespace forget ::src::p }
+        //   namespace eval ::dst { p }                        → invalid command name "p"
+        //   info commands ::dst::*                            → (empty)
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget ::src::p\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_none(),
+            "a forgotten alias must stop resolving after the forget: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_call_before_the_forget_still_resolves() {
+        // TP — the forget is order-gated, not file-wide: a call written
+        // between the import and the forget still reaches `::src::p`.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\np\nnamespace eval dst {\n    namespace forget ::src::p\n}\n";
+        let analysis = analyse(src);
+        let call = at_first(src, "\np\n") + 1;
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "a call before the forget is unaffected by it: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_glob_forget_removes_every_matching_alias() {
+        // TN — oracle: `namespace forget ::src::*` empties `info commands
+        // ::dst::*` entirely.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    proc q {} { return Q }\n    namespace export *\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget ::src::*\n}\n";
+        let analysis = analyse(src);
+        for name in ["p", "q"] {
+            assert!(
+                proc_visible_via_wildcard_import(&analysis, "dst", name, u32::MAX).is_none(),
+                "`{name}` must be forgotten by the glob pattern"
+            );
+        }
+    }
+
+    #[test]
+    fn a_simple_forget_pattern_removes_the_alias_too() {
+        // TN — `Tcl_ForgetImport`'s unqualified branch: the pattern is matched
+        // against this namespace's own imported command names, whatever their
+        // origin. Oracle: `namespace eval ::dst {namespace forget p}` leaves
+        // `info commands ::dst::*` empty and raises no error.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget p\n}\n";
+        let analysis = analyse(src);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
+            "an unqualified forget pattern removes the alias too"
+        );
+    }
+
+    #[test]
+    fn a_forget_of_an_unrelated_source_leaves_the_alias_alone() {
+        // FP guard — a qualified forget names the source whose imports it
+        // removes; one naming a *different* namespace must not touch this
+        // alias.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval other {\n    proc p {} { return O }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget ::other::p\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "a forget aimed at another source namespace revokes nothing: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_re_import_after_a_forget_resolves_again() {
+        // TP — the log is ordered, not a one-way tombstone: re-running the
+        // import after the forget installs the alias again (oracle: the bare
+        // call works once more).
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    namespace forget ::src::p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "a later re-import reinstates the alias: {hit:?}"
+        );
+    }
+
+    // Behaviour 2 — `-force` / import-conflict semantics.
+
+    #[test]
+    fn a_forced_import_shadows_the_local_command() {
+        // TP (the bug): oracle
+        //   namespace eval ::src { proc p {} {return SRC}; namespace export p }
+        //   namespace eval ::dst { proc p {} {return LOCAL} }
+        //   ::dst::p                                   → LOCAL
+        //   namespace eval ::dst { namespace import -force ::src::* }
+        //   ::dst::p                                   → SRC
+        //   namespace origin ::dst::p                  → ::src::p
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\nnamespace eval dst {\n    namespace import -force ::src::*\n}\nnamespace eval dst {\n    p\n}\n";
+        let analysis = analyse(src);
+        let call = after_last(src, "    p\n");
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", call, None);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "a `-force` import replaces the local command: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn an_unforced_import_onto_an_existing_command_installs_nothing() {
+        // TN (the other bug): the same program without `-force` raises `can't
+        // import command "p": already exists`, the local survives, and
+        // `namespace origin ::dst::p` answers `::dst::p`. The import must not
+        // make the call a reference to `::src::p`.
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_none(),
+            "a conflicting non-`-force` import installs nothing"
+        );
+        // …and the ordinary namespace lookup still answers the local.
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", u32::MAX, None);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::dst::p"),
+            "the local definition survives the failed import: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_local_defined_after_the_import_is_not_a_conflict() {
+        // FP guard — the conflict is judged at the *import's* position: a
+        // `proc` written after it simply replaces the alias, which the
+        // ordinary namespace lookup answers, and must not retroactively make
+        // the import a no-op for calls sitting between the two.
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "a later local definition is not a conflict at the import: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn an_unforced_import_without_a_conflict_still_installs() {
+        // FN guard — the conflict rule must not fire when the importing
+        // namespace holds nothing of that name (the overwhelmingly common
+        // case, oracle `H` row: `::dst::p` → `SRC`).
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\n";
+        let analysis = analyse(src);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX).is_some(),
+            "an unconflicted import still installs"
+        );
+    }
+
+    #[test]
+    fn a_forced_import_before_the_call_does_not_shadow_a_later_call_site() {
+        // FP guard on the `-force` shortcut: it outranks the local lookup
+        // only where a live import edge really covers the word. With the
+        // forced import forgotten again, the local definition wins back.
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\nnamespace eval dst {\n    namespace import -force ::src::*\n}\nnamespace eval dst {\n    namespace forget ::src::p\n}\nnamespace eval dst {\n    p\n}\n";
+        let analysis = analyse(src);
+        let call = after_last(src, "    p\n");
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", call, None);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::dst::p"),
+            "after the forget the local definition is what the call reaches: {hit:?}"
+        );
+    }
+
+    // Behaviour 3 — source rename / delete / redefine after the import.
+
+    #[test]
+    fn deleting_the_source_command_kills_the_alias() {
+        // TN (the bug): oracle
+        //   namespace eval ::src { proc p {} {return P}; namespace export p }
+        //   namespace eval ::dst { namespace import ::src::* }
+        //   ::dst::p              → P
+        //   rename ::src::p {}
+        //   ::dst::p              → invalid command name "::dst::p"
+        //   info commands ::dst::* → (empty)
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nrename ::src::p {}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_none(),
+            "the alias holds the command object, so deleting it kills the alias: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn renaming_the_source_command_leaves_the_alias_alive() {
+        // TP — the crucial asymmetry: oracle
+        //   rename ::src::p ::src::pp
+        //   ::dst::p                  → P          (still works)
+        //   namespace origin ::dst::p → ::src::pp  (only the origin moved)
+        //   info commands ::dst::*    → ::dst::p
+        // A model that treated any `rename` of the source as a removal would
+        // lose a genuinely-live command here.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nrename ::src::p ::src::pp\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "a rename moves the origin but keeps the alias: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_call_before_the_source_deletion_still_resolves() {
+        // FP guard — the deletion is order-gated like every other lifecycle
+        // event, so a call written before it is unaffected.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\np\nrename ::src::p {}\n";
+        let analysis = analyse(src);
+        let call = at_first(src, "\np\n") + 1;
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", call).is_some(),
+            "a call before the deletion still reaches the source"
+        );
+    }
+
+    #[test]
+    fn a_redefinition_of_the_source_is_seen_through_the_link() {
+        // TP — oracle: redefining `::src::p` after the import makes `::dst::p`
+        // run the *new* body (`SECOND`), with `namespace origin ::dst::p`
+        // still `::src::p`. The alias re-reads the source at call time, so the
+        // definition a call reaches is the one in effect at the *call*, not
+        // the one in effect at the import.
+        let src = "namespace eval src {\n    proc p {} { return FIRST }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval src {\n    proc p {} { return SECOND }\n}\ndst::p\n";
+        let analysis = analyse(src);
+        let call = after_last(src, "dst::p");
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", call).expect("alias");
+        let captured = analysis
+            .proc_def_in_effect_at(&hit.qualified_name, call)
+            .expect("definition in effect at the call");
+        assert_eq!(
+            captured.name_span.start(),
+            at_first(src, "p {} { return SECOND }"),
+            "the redefinition is seen through the link"
+        );
+    }
+
+    // Behaviour 4 — import chains.
+
+    #[test]
+    fn an_import_chain_follows_to_the_original_source() {
+        // TP (the bug): oracle
+        //   namespace eval ::C { proc p {} {return CP}; namespace export p }
+        //   namespace eval ::B { namespace import ::C::*; namespace export p }
+        //   namespace eval ::A { namespace import ::B::* }
+        //   ::A::p                    → CP
+        //   namespace origin ::A::p   → ::C::p
+        // Statically `::B::p` is in no `all_procs`, so a single-hop walk found
+        // nothing and navigation abstained.
+        let src = "namespace eval C {\n    proc p {} { return CP }\n    namespace export p\n}\nnamespace eval B {\n    namespace import ::C::*\n    namespace export p\n}\nnamespace eval A {\n    namespace import ::B::*\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "A", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::C::p"),
+            "the chain must follow ::A → ::B → ::C: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_forget_in_the_middle_of_a_chain_kills_the_whole_chain() {
+        // TN — oracle: `namespace eval ::B {namespace forget ::C::p}` makes
+        // `::A::p` an `invalid command name` too, because deleting an imported
+        // command deletes the commands imported *from* it. Both `info commands
+        // ::A::*` and `::B::*` come back empty.
+        let src = "namespace eval C {\n    proc p {} { return CP }\n    namespace export p\n}\nnamespace eval B {\n    namespace import ::C::*\n    namespace export p\n}\nnamespace eval A {\n    namespace import ::B::*\n}\nnamespace eval B {\n    namespace forget ::C::p\n}\n";
+        let analysis = analyse(src);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "A", "p", u32::MAX).is_none(),
+            "a forget in the middle hop kills the outer alias too"
+        );
+    }
+
+    #[test]
+    fn a_chain_hop_that_was_never_exported_does_not_resolve() {
+        // FN guard — each hop keeps its own export gate: with `::B` importing
+        // `::C::*` but never re-exporting `p`, `::A`'s import of `::B::*`
+        // binds nothing (oracle: `::A::p` → invalid command name).
+        let src = "namespace eval C {\n    proc p {} { return CP }\n    namespace export p\n}\nnamespace eval B {\n    namespace import ::C::*\n}\nnamespace eval A {\n    namespace import ::B::*\n}\n";
+        let analysis = analyse(src);
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "A", "p", u32::MAX).is_none(),
+            "the middle hop must have exported the name for the chain to run"
+        );
+    }
+
+    #[test]
+    fn a_mutually_importing_pair_terminates() {
+        // FP/hang guard — two namespaces importing each other's `*` form a
+        // cycle with no definition at either end; the walk is bounded by
+        // `indirection::MAX_COMMAND_NAME_HOPS` and must simply abstain.
+        let src = "namespace eval A {\n    namespace import ::B::*\n    namespace export *\n}\nnamespace eval B {\n    namespace import ::A::*\n    namespace export *\n}\n";
+        let analysis = analyse(src);
+        assert!(proc_visible_via_wildcard_import(&analysis, "A", "p", u32::MAX).is_none());
+        assert!(proc_visible_via_wildcard_import(&analysis, "B", "p", u32::MAX).is_none());
     }
 
     #[test]

--- a/rust/tcl-lsp-core/src/definition.rs
+++ b/rust/tcl-lsp-core/src/definition.rs
@@ -2561,26 +2561,76 @@ fn live_import_over_candidates<'c>(
     None
 }
 
+/// One ordered event on an importing namespace's `word` slot, as the
+/// same-document tier sees it.
+///
+/// The four things that can happen to `<importing_ns>::<word>` over the life
+/// of a script. Folding them in order answers both questions
+/// [`live_import_at`] asks: *what did this namespace already hold when import
+/// I ran?* (the non-`-force` conflict) and *what does it hold at the call?*
+#[derive(Debug, Clone, Copy)]
+enum SlotEvent<'a> {
+    /// A `namespace import` covering `word` whose export snapshot passed.
+    Import {
+        at: u32,
+        source_ns: &'a str,
+        forced: bool,
+    },
+    /// A `namespace forget` covering `word`; `source_ns` is `None` for the
+    /// simple pattern form, which matches whatever the alias was imported
+    /// from.
+    Forget { at: u32, source_ns: Option<&'a str> },
+    /// A `proc` / class declaration of `<importing_ns>::<word>` — the
+    /// namespace's *own* command of that name.
+    Declare { at: u32 },
+    /// A destroying `rename <source_ns>::<word> {}` — the command object the
+    /// alias holds is gone.
+    Destroy { at: u32, source_ns: &'a str },
+}
+
+impl SlotEvent<'_> {
+    fn at(self) -> u32 {
+        match self {
+            SlotEvent::Import { at, .. }
+            | SlotEvent::Forget { at, .. }
+            | SlotEvent::Declare { at }
+            | SlotEvent::Destroy { at, .. } => at,
+        }
+    }
+}
+
+/// Whether a forget event covers an alias taken from `source_ns`.
+fn forget_covers(forget_source: Option<&str>, source_ns: &str) -> bool {
+    forget_source
+        .is_none_or(|src| src.trim_start_matches("::") == source_ns.trim_start_matches("::"))
+}
+
 /// The source namespace of the import alias `importing_ns` holds for `word`
 /// **at `call_off`**, or `None` when it holds none — the same-document
 /// binding of the shared lifecycle decision
 /// [`crate::namespace_import::alias_live_at`] (issue #1103).
 ///
 /// An import edge is a link with a lifecycle, not a standing name-visibility
-/// fact. Four events bear on it, all oracle-confirmed byte-identically on
-/// tclsh 9.0.4 and 8.6.14:
+/// fact. Everything that writes the `<importing_ns>::<word>` slot is an event
+/// on one ordered log ([`SlotEvent`]); all of it is oracle-confirmed
+/// byte-identically on tclsh 9.0.4 and 8.6.14:
 ///
 /// 1. **The import installs it** — gated by the source namespace's export
 ///    snapshot at the import's own position
 ///    ([`exported_at_import`], issue #1027).
 /// 2. **A conflict makes it install nothing.** Without `-force`, importing
 ///    onto a name the target namespace already holds raises `can't import
-///    command "p": already exists`; the local command survives and
-///    `namespace origin` still answers the local. Such an import is declined
-///    here. (Modelling the *error* — that the rest of that script never runs
-///    — is deliberately out of scope; only the "installed nothing" half is
-///    modelled.) With `-force` the import wins instead, which is what
-///    [`ImportQuery::ForcedShadow`] selects for.
+///    command "p": already exists`; the existing command survives and
+///    `namespace origin` still answers it. "Already holds" covers a local
+///    `proc`/class **and a live alias from a different source**: with `::dst`
+///    already importing `::A::*`, a later unforced `namespace import ::B::*`
+///    fails with exactly that error and leaves `namespace origin ::dst::p` →
+///    `::A::p` (oracle). Re-importing from the *same* source is a silent
+///    no-op instead, so it is not a conflict. With `-force` the import wins
+///    and replaces whichever of the two was there (oracle: `origin` → `::B::p`),
+///    which is what [`ImportQuery::ForcedShadow`] selects for. (Modelling the
+///    *error* — that the rest of that script never runs — is deliberately out
+///    of scope; only the "installed nothing" half is modelled.)
 /// 3. **`namespace forget` removes it** — `namespace forget ::src::p`, or the
 ///    simple form `namespace forget p`, and a later bare call is `invalid
 ///    command name`.
@@ -2591,6 +2641,14 @@ fn live_import_over_candidates<'c>(
 ///    link. That asymmetry is `indirection`'s own
 ///    rename-captures-object-identity rule, which is why only the *deletion*
 ///    appears here.
+/// 5. **Redefining the imported name removes it.** A `proc ::dst::p` written
+///    after the import silently recreates `::dst::p` as an ordinary command:
+///    oracle (9.0.4 / 8.6.14, `namespace import -force ::src::*` then `proc
+///    ::dst::p`) — the redefinition raises no error, `::dst::p` runs the new
+///    body, `namespace origin ::dst::p` becomes `::dst::p`, and `::src::p`
+///    is untouched. A call written *between* the import and the redefinition
+///    still reaches `::src::p`, so this is an ordered event like every other,
+///    not a file-wide fact.
 ///
 /// Ordering is [`indirection::in_effect`] — the same "had this statement
 /// run?" primitive the export snapshot and the `rename` / `interp alias`
@@ -2606,12 +2664,111 @@ fn live_import_at(
     query: ImportQuery,
 ) -> Option<String> {
     use crate::namespace_import::{AliasEvent, AliasEventKind};
-    let visible = |at: u32| indirection::in_effect(analysis, at, call_off);
-    // The install events: every import of this namespace whose pattern covers
-    // `word`, whose source had exported it, and which a conflict did not
-    // reduce to a no-op.
-    let mut latest: Option<(u32, &str)> = None;
+    let events = slot_events(analysis, importing_ns, word, query);
+    // Which imports actually install something: an unforced import onto a
+    // slot the namespace already holds (a local declaration, or a live alias
+    // from a *different* source) raises `already exists` and binds nothing.
+    // Decided by folding the log in order, each import judged by what the
+    // slot held when *it* ran — the same question the call-site gate below
+    // asks at its own point.
+    let mut held: Option<&str> = None;
+    let mut declared = false;
     let mut installs: Vec<(u32, &str)> = Vec::new();
+    let mut latest: Option<(u32, &str)> = None;
+    for ev in &events {
+        match *ev {
+            SlotEvent::Declare { .. } => {
+                declared = true;
+                held = None;
+            }
+            SlotEvent::Forget { source_ns, .. } => {
+                if held.is_some_and(|src| forget_covers(source_ns, src)) {
+                    held = None;
+                }
+            }
+            SlotEvent::Destroy { source_ns, .. } => {
+                if held == Some(source_ns) {
+                    held = None;
+                }
+            }
+            SlotEvent::Import {
+                at,
+                source_ns,
+                forced,
+            } => {
+                let conflicts = declared || held.is_some_and(|current| current != source_ns);
+                if !forced && conflicts {
+                    continue;
+                }
+                held = Some(source_ns);
+                // A `-force` import replaces whatever was there, including a
+                // local declaration.
+                declared = false;
+                installs.push((at, source_ns));
+                // The latest install wins the source namespace. Deliberately
+                // *not* filtered against `call_off`: whether a call written
+                // before its own import should stop resolving is the
+                // separate, still-open leniency #1104 item 1 — see
+                // `crate::namespace_import::alias_live_at`.
+                if latest.is_none_or(|(best, _)| at > best) {
+                    latest = Some((at, source_ns));
+                }
+            }
+        }
+    }
+    let (_, source_ns) = latest?;
+    // Only the winning source's own installs order against its removals: an
+    // import of the same name from a *different* namespace is a different
+    // edge, and letting it out-date this edge's forget would resurrect it.
+    let mut log = events
+        .iter()
+        .filter_map(|ev| match *ev {
+            SlotEvent::Import {
+                at, source_ns: s, ..
+            } if s == source_ns => installs
+                .iter()
+                .any(|&(i, _)| i == at)
+                .then_some(AliasEvent {
+                    kind: AliasEventKind::Install,
+                    at: Some(at),
+                }),
+            SlotEvent::Forget { at, source_ns: s } if forget_covers(s, source_ns) => {
+                Some(AliasEvent {
+                    kind: AliasEventKind::Remove,
+                    at: Some(at),
+                })
+            }
+            SlotEvent::Destroy { at, source_ns: s } if s == source_ns => Some(AliasEvent {
+                kind: AliasEventKind::Remove,
+                at: Some(at),
+            }),
+            SlotEvent::Declare { at } => Some(AliasEvent {
+                kind: AliasEventKind::Remove,
+                at: Some(at),
+            }),
+            _ => None,
+        })
+        .collect::<Vec<_>>()
+        .into_iter();
+    crate::namespace_import::alias_live_at(&mut log, &|at| {
+        indirection::in_effect(analysis, at, call_off)
+    })
+    .then(|| source_ns.to_owned())
+}
+
+/// Every [`SlotEvent`] bearing on `<importing_ns>::<word>` in this document,
+/// in source order.
+///
+/// Ordering the four record kinds against each other once, here, is what lets
+/// [`live_import_at`] answer the conflict question and the call-site question
+/// with the same log instead of two ad-hoc scans.
+fn slot_events<'a>(
+    analysis: &'a AnalysisResult,
+    importing_ns: &str,
+    word: &str,
+    query: ImportQuery,
+) -> Vec<SlotEvent<'a>> {
+    let mut events: Vec<SlotEvent<'a>> = Vec::new();
     for imp in analysis
         .namespace_imports
         .iter()
@@ -2632,85 +2789,45 @@ fn live_import_at(
         {
             continue;
         }
-        if !imp.forced && local_command_in_effect_at(analysis, importing_ns, word, at) {
-            continue;
-        }
-        installs.push((at, source_ns));
-        // The latest install wins the source namespace — a second import of
-        // the same name from elsewhere replaces the first alias, exactly as a
-        // second `namespace import` re-snapshots the export list. Deliberately
-        // *not* filtered by `visible`: whether a call written before its own
-        // import should stop resolving is the separate, still-open leniency
-        // #1104 item 1 — see `crate::namespace_import::alias_live_at`.
-        if latest.is_none_or(|(best, _)| at > best) {
-            latest = Some((at, source_ns));
+        events.push(SlotEvent::Import {
+            at,
+            source_ns,
+            forced: imp.forced,
+        });
+        // The source command's own destruction, ordered against this edge.
+        if let Some(&at) = analysis
+            .destroyed_commands
+            .get(&tcl_syntax::naming::qualify(source_ns, word))
+        {
+            events.push(SlotEvent::Destroy { at, source_ns });
         }
     }
-    let (_, source_ns) = latest?;
-    let removals = analysis
+    for f in analysis
         .namespace_forgets
         .iter()
-        .filter(|f| {
-            f.ns == importing_ns
-                && f.source_ns.as_deref().is_none_or(|src| {
-                    src.trim_start_matches("::") == source_ns.trim_start_matches("::")
-                })
-                && tcl_syntax::glob::string_match(&f.pattern, word)
-        })
-        .map(|f| AliasEvent {
-            kind: AliasEventKind::Remove,
-            at: Some(f.range.start()),
-        })
+        .filter(|f| f.ns == importing_ns && tcl_syntax::glob::string_match(&f.pattern, word))
+    {
+        events.push(SlotEvent::Forget {
+            at: f.range.start(),
+            source_ns: f.source_ns.as_deref(),
+        });
+    }
+    let qualified = tcl_syntax::naming::qualify(importing_ns, word);
+    for at in analysis
+        .proc_declarations(&qualified)
+        .map(|p| p.name_span.start())
         .chain(
             analysis
-                .destroyed_commands
-                .get(&tcl_syntax::naming::qualify(source_ns, word))
-                .map(|&at| AliasEvent {
-                    kind: AliasEventKind::Remove,
-                    at: Some(at),
-                }),
-        );
-    // Only the winning source's own installs order against its removals: an
-    // import of the same name from a *different* namespace is a different
-    // edge, and letting it out-date this edge's forget would resurrect it.
-    let mut events = installs
-        .iter()
-        .filter(|(_, ns)| *ns == source_ns)
-        .map(|&(at, _)| AliasEvent {
-            kind: AliasEventKind::Install,
-            at: Some(at),
-        })
-        .chain(removals);
-    crate::namespace_import::alias_live_at(&mut events, &visible).then(|| source_ns.to_owned())
-}
-
-/// Whether `importing_ns` already holds its own command named `word` by the
-/// time the import at `import_at` runs — the conflict a non-`-force`
-/// `namespace import` aborts on (case 2 of [`live_import_at`]).
-///
-/// A definition written *after* the import is not a conflict: the import
-/// succeeds and the later `proc` simply replaces the alias, which the
-/// ordinary namespace lookup already answers. So every declaration is
-/// order-gated by [`indirection::in_effect`] — the same "had this statement
-/// run?" primitive the rest of this module uses — rather than tested for mere
-/// presence. (`AnalysisResult::proc_def_in_effect_at` answers a different
-/// question — *which* of several declarations a call captured — and
-/// deliberately falls back to the winner when none precedes the offset, so it
-/// cannot serve as an existence gate here.)
-fn local_command_in_effect_at(
-    analysis: &AnalysisResult,
-    importing_ns: &str,
-    word: &str,
-    import_at: u32,
-) -> bool {
-    let qualified = tcl_syntax::naming::qualify(importing_ns, word);
-    analysis
-        .proc_declarations(&qualified)
-        .any(|p| indirection::in_effect(analysis, p.name_span.start(), import_at))
-        || analysis
-            .all_classes
-            .get(&qualified)
-            .is_some_and(|c| indirection::in_effect(analysis, c.name_span.start(), import_at))
+                .all_classes
+                .get(&qualified)
+                .map(|c| c.name_span.start()),
+        )
+    {
+        events.push(SlotEvent::Declare { at });
+    }
+    events.sort_by_key(|ev| ev.at());
+    events.dedup_by_key(|ev| (ev.at(), std::mem::discriminant(ev)));
+    events
 }
 
 /// Whether `source_ns` had exported `word` by the time the `namespace import`
@@ -3844,17 +3961,125 @@ mod tests {
     }
 
     #[test]
-    fn a_local_defined_after_the_import_is_not_a_conflict() {
-        // FP guard — the conflict is judged at the *import's* position: a
-        // `proc` written after it simply replaces the alias, which the
-        // ordinary namespace lookup answers, and must not retroactively make
-        // the import a no-op for calls sitting between the two.
-        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\n";
+    fn a_local_defined_after_the_import_is_not_a_conflict_but_does_end_the_alias() {
+        // The three-phase ordering (issue #1116 finding 3). The conflict is
+        // judged at the *import's* position, so a `proc` written after it does
+        // not retroactively make the import a no-op — a call between the two
+        // still reaches `::src::p`. But the `proc` *does* recreate
+        // `::dst::p` as an ordinary command, silently, so a call after it
+        // reaches the local one. Oracle (9.0.4 / 8.6.14, byte-identical):
+        //   namespace eval ::dst {namespace import ::src::*}
+        //   ::dst::p                    → SRC   ; origin → ::src::p
+        //   namespace eval ::dst {proc p {} {return LOCAL}}    (rc 0, silent)
+        //   ::dst::p                    → LOCAL ; origin → ::dst::p
+        //   ::src::p                    → SRC   (untouched)
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n}\np\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\n";
         let analysis = analyse(src);
-        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        // TP — between the import and the redefinition, the alias is live.
+        let between = at_first(src, "\np\n") + 1;
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", between);
         assert!(
             hit.is_some_and(|p| p.qualified_name == "::src::p"),
             "a later local definition is not a conflict at the import: {hit:?}"
+        );
+        // TN — after it, the alias is gone and the local command is what the
+        // ordinary namespace lookup answers.
+        let after = after_last(src, "return LOCAL }");
+        assert!(
+            proc_visible_via_wildcard_import(&analysis, "dst", "p", after).is_none(),
+            "redefining the imported name ends the alias"
+        );
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", after, None);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::dst::p"),
+            "after the redefinition the call reaches the local proc: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_redefinition_ends_a_forced_import_shadow() {
+        // TN, issue #1116 finding 3 — the same rule reached through
+        // `forced_import_shadows`, which is what made this a P2: with the
+        // shadow stuck on, `definition` / `hover` / `signature_help` skipped
+        // the valid local definition and answered the import source forever.
+        // Oracle: `proc ::dst::p` after `namespace import -force ::src::*`
+        // returns LOCAL2 with `namespace origin ::dst::p` → `::dst::p`.
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n}\nnamespace eval dst {\n    namespace import -force ::src::*\n}\nnamespace eval dst {\n    proc p {} { return LOCAL2 }\n}\n";
+        let analysis = analyse(src);
+        let between = at_first(src, "namespace import -force")
+            + u32::try_from("namespace import -force ::src::*".len()).expect("tiny");
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", between, None);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::src::p"),
+            "between the forced import and the redefinition the source wins: {hit:?}"
+        );
+        let after = after_last(src, "return LOCAL2 }");
+        let hit = resolve_called_proc(&analysis, src, "::dst", "p", after, None);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::dst::p"),
+            "the redefinition ends the forced shadow: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_live_alias_is_an_import_conflict_for_a_different_source() {
+        // TN, issue #1116 finding 4 (CRITICAL) — with `::dst` already
+        // importing `::A::*`, a later *unforced* `namespace import ::B::*`
+        // fails and changes nothing. Oracle (9.0.4 / 8.6.14):
+        //   namespace eval ::dst {namespace import ::A::*}   ; origin → ::A::p
+        //   namespace eval ::dst {namespace import ::B::*}
+        //     → can't import command "p": already exists
+        //   ::dst::p → AP ; origin → ::A::p
+        // Before this, both imports entered the install set and the *newest*
+        // won, resolving later calls to `::B::p`.
+        let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return BP }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\nnamespace eval dst {\n    namespace import ::B::*\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::A::p"),
+            "the failed second import leaves the first alias in place: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_forced_import_from_a_second_source_replaces_the_first_alias() {
+        // TP, the other half of finding 4 — with `-force` the second import
+        // wins (oracle: `::dst::p` → BP, `namespace origin` → `::B::p`).
+        let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return BP }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\nnamespace eval dst {\n    namespace import -force ::B::*\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::B::p"),
+            "a `-force` import replaces a live alias too: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_forget_lets_the_next_unforced_import_install() {
+        // FN guard for finding 4 — the conflict is the *live* alias, not the
+        // fact that one was ever installed. Oracle: forgetting `::A::p` first
+        // makes the unforced `::B::*` import succeed (`origin` → `::B::p`).
+        let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval B {\n    proc p {} { return BP }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\nnamespace eval dst {\n    namespace forget ::A::p\n}\nnamespace eval dst {\n    namespace import ::B::*\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::B::p"),
+            "after the forget the next unforced import installs: {hit:?}"
+        );
+    }
+
+    #[test]
+    fn a_re_import_from_the_same_source_is_not_a_conflict() {
+        // FN guard — re-importing the *same* thing is a silent no-op, not the
+        // `already exists` error (oracle: rc 0, `origin` still `::A::p`), so
+        // the second import must not be treated as conflicting with the alias
+        // it would reinstall.
+        let src = "namespace eval A {\n    proc p {} { return AP }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\nnamespace eval dst {\n    namespace import ::A::*\n}\n";
+        let analysis = analyse(src);
+        let hit = proc_visible_via_wildcard_import(&analysis, "dst", "p", u32::MAX);
+        assert!(
+            hit.is_some_and(|p| p.qualified_name == "::A::p"),
+            "a same-source re-import stays live: {hit:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/hover.rs
+++ b/rust/tcl-lsp-core/src/hover.rs
@@ -233,8 +233,14 @@ fn ensemble_subcommand_hover(
         &analysis.namespace_overrides,
     );
     let target = crate::definition::ensemble_subcommand_target(analysis, &namespace, &head, &sub)?;
-    let proc_def =
-        crate::definition::resolve_called_proc(analysis, source, "::", target, registry)?;
+    let proc_def = crate::definition::resolve_called_proc(
+        analysis,
+        source,
+        "::",
+        target,
+        cursor_offset,
+        registry,
+    )?;
     let text = format!(
         "**Ensemble subcommand** of `{head}`\n\n{}",
         proc_hover_text(proc_def)
@@ -302,8 +308,14 @@ fn proc_hover_at(
         cursor_offset,
         &analysis.namespace_overrides,
     );
-    let proc_def =
-        crate::definition::resolve_called_proc(analysis, source, &namespace, word, registry)?;
+    let proc_def = crate::definition::resolve_called_proc(
+        analysis,
+        source,
+        &namespace,
+        word,
+        cursor_offset,
+        registry,
+    )?;
     Some(Hover::markdown(proc_hover_text(proc_def)))
 }
 

--- a/rust/tcl-lsp-core/src/inlay_hints.rs
+++ b/rust/tcl-lsp-core/src/inlay_hints.rs
@@ -940,7 +940,7 @@ fn lookup_proc<'a>(
         cmd_off,
         &analysis.namespace_overrides,
     );
-    crate::definition::resolve_called_proc(analysis, source, &ns, name, registry)
+    crate::definition::resolve_called_proc(analysis, source, &ns, name, cmd_off, registry)
 }
 
 /// Walk a single segmented command, emit a hint per argument

--- a/rust/tcl-lsp-core/src/namespace_import.rs
+++ b/rust/tcl-lsp-core/src/namespace_import.rs
@@ -16,8 +16,9 @@
 //
 // SPDX-License-Identifier: AGPL-3.0-or-later
 
-//! The per-import-site export snapshot: the one decision both wildcard-import
-//! tiers ask.
+//! The import edge: the per-import-site export snapshot that decides whether
+//! it is installed, and the lifecycle log that decides whether it is still
+//! there — the two decisions both wildcard-import tiers ask.
 //!
 //! `namespace import ::src::*` does not create a standing subscription to
 //! `::src`'s export list — it creates *aliases*, once, for the names exported
@@ -95,6 +96,39 @@
 //!   go-to-definition / find-references, the pre-#1027 behaviour), while an
 //!   unordered `-clear` does **not** revoke anything (revoking on a guess
 //!   would silently drop real references).
+//!
+//! # The edge has a lifetime, not just a birth
+//!
+//! Installing the alias is only the first event on it (issue #1103). The same
+//! ordered-log discipline answers the second question — *does this namespace
+//! still hold the alias here?* — in [`alias_live_at`]:
+//!
+//! - **`namespace forget` removes it.** `namespace forget ::src::p` (or the
+//!   simple form `namespace forget p`) makes a later bare call `invalid
+//!   command name`.
+//! - **Deleting the source command removes it.** The alias holds the command
+//!   *object*, so `rename ::src::p {}` kills `::dst::p` as well — while a
+//!   plain `rename ::src::p ::src::pp` leaves it working (only `namespace
+//!   origin` moves) and a redefinition of the source is seen straight through
+//!   the link. That asymmetry is exactly
+//!   `tcl_compiler::analyser::indirection`'s
+//!   rename-captures-object-identity rule, which is why this module models
+//!   the deletion and not the rename.
+//! - **A conflict means it was never installed at all.** Without `-force`,
+//!   importing onto a name the target namespace already holds raises `can't
+//!   import command "p": already exists`; with `-force` it silently replaces
+//!   the local command, and a later bare call reaches the source
+//!   (`namespace origin` → `::src::p`). The install/no-install half is
+//!   modelled; the error's control-flow consequence (the rest of that script
+//!   never running) deliberately is not.
+//! - **Chains are edges of edges.** `::A` importing `::B::*` where `::B`
+//!   imported `::C::*` makes `::A::p` run `::C`'s body, and a forget anywhere
+//!   along the chain kills the whole thing. The tiers follow the chain while
+//!   every hop is provable, bounded by the same
+//!   `indirection::MAX_COMMAND_NAME_HOPS` cap the rename / alias walk uses.
+//!
+//! Every one of those rows is oracle-confirmed byte-identically on tclsh
+//! 9.0.4 and 8.6.14; the transcripts sit on the individual items.
 
 use tcl_syntax::glob::string_match;
 
@@ -174,6 +208,127 @@ pub fn exported_at_import_site(
     let ordered_match =
         latest_match.is_some_and(|m| cleared_through.is_none_or(|cleared| m > cleared));
     ordered_match || unordered_match
+}
+
+/// What one lifecycle event does to an import edge — see [`AliasEvent`].
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum AliasEventKind {
+    /// A `namespace import` **installed** the alias. The caller has already
+    /// applied the export snapshot ([`exported_at_import_site`]) and the
+    /// pattern match, so this event says only "an import ran here".
+    Install,
+    /// The alias was **removed**: a `namespace forget`, or the deletion of
+    /// the source command the alias holds (`rename ::src::p {}`).
+    Remove,
+}
+
+/// One event on an import edge's own lifecycle, as either tier sees it.
+///
+/// The installing/removing counterpart of [`ExportEvent`], on the same kind of
+/// ordered, append-only log and read by the same "latest visible event wins"
+/// rule.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct AliasEvent {
+    /// What the event does.
+    pub kind: AliasEventKind,
+    /// Byte offset of the event *when it is ordered relative to the query
+    /// point* — i.e. when both are in the same document. `None` when the two
+    /// sit in different files, whose relative load order is not a static
+    /// fact.
+    pub at: Option<u32>,
+}
+
+/// Whether the importing namespace still holds a live imported alias at the
+/// query point, given every lifecycle event that bears on it (issue #1103).
+///
+/// `namespace import` does not create a permanent name. `namespace forget`
+/// takes the alias away again, and so does deleting the source command the
+/// alias holds — both oracle-confirmed byte-identically on tclsh 9.0.4 and
+/// 8.6.14:
+///
+/// ```tcl
+/// namespace eval ::src { proc p {} {return P}; namespace export p }
+/// namespace eval ::dst { namespace import ::src::* }
+/// namespace eval ::dst { p }                        ;# → P
+/// namespace eval ::dst { namespace forget ::src::p }
+/// namespace eval ::dst { p }                        ;# → invalid command name "p"
+/// ```
+///
+/// ```tcl
+/// namespace eval ::src { proc p {} {return P}; namespace export p }
+/// namespace eval ::dst { namespace import ::src::* }
+/// rename ::src::p {}
+/// ::dst::p                                          ;# → invalid command name "::dst::p"
+/// ```
+///
+/// A *re*name is deliberately **not** a removal: the alias holds the command
+/// object, not the name, so `rename ::src::p ::src::pp` leaves `::dst::p`
+/// working (only `namespace origin ::dst::p` moves, to `::src::pp`), and a
+/// redefinition of the source is seen straight through the link. That is the
+/// same rename-captures-object-identity rule
+/// [`tcl_compiler::analyser::indirection`] already applies to `rename` /
+/// `interp alias`, which is why this module carries no rename event kind.
+///
+/// # The rule
+///
+/// Symmetric with [`exported_at_import_site`], and for the same reason: the
+/// latest in-effect [`AliasEventKind::Remove`] wins over every install before
+/// it, and an install *after* that removal reinstates the alias (a re-import
+/// after a forget genuinely does — oracle: re-running `namespace import
+/// ::src::*` after a `namespace forget` makes the bare call work again).
+/// Unordered events — from a different file, where no static load order
+/// exists — abstain toward *answering*: an unordered install counts, an
+/// unordered removal revokes nothing, exactly as an unordered `-clear` does
+/// not revoke an export.
+///
+/// # What `removal_in_effect` does and does not gate
+///
+/// `removal_in_effect` decides, for a **removal** at the given offset,
+/// whether it had already run at the query point. Both tiers pass the
+/// order-gating primitive they already use for the export snapshot
+/// ([`tcl_compiler::analyser::indirection::in_effect`] /
+/// [`tcl_compiler::analyser::indirection::in_effect_within`]), so "has run by
+/// here" cannot mean two things.
+///
+/// It deliberately does **not** filter installs. Whether a bare call written
+/// *before* its own `namespace import` should stop resolving is a separate,
+/// still-open leniency (issue #1104 item 1: the workspace tier has no
+/// call-site body span to apply the identical rule with, so gating only
+/// in-document would make the two tiers disagree — the divergence the shared
+/// decision function exists to prevent). Installs still carry their offsets,
+/// because a removal revokes only the installs *before* it; they are simply
+/// not dropped for being later than the call.
+///
+/// With no install at all the answer is `false`: nothing put the alias there.
+/// Callers that have already proven an import matches (pattern, export
+/// snapshot, conflict rule) pass it as an [`AliasEventKind::Install`].
+///
+/// Single pass, two running maxima, no allocation — the same shape and the
+/// same cost as [`exported_at_import_site`], which it runs beside.
+#[must_use]
+pub fn alias_live_at(
+    events: &mut dyn Iterator<Item = AliasEvent>,
+    removal_in_effect: &dyn Fn(u32) -> bool,
+) -> bool {
+    let mut installed: Option<u32> = None;
+    let mut removed: Option<u32> = None;
+    let mut unordered_install = false;
+    for ev in events {
+        let Some(at) = ev.at else {
+            unordered_install |= ev.kind == AliasEventKind::Install;
+            continue;
+        };
+        match ev.kind {
+            AliasEventKind::Install => installed = installed.max(Some(at)),
+            AliasEventKind::Remove => {
+                if removal_in_effect(at) {
+                    removed = removed.max(Some(at));
+                }
+            }
+        }
+    }
+    let ordered_live = installed.is_some_and(|i| removed.is_none_or(|r| i > r));
+    ordered_live || unordered_install
 }
 
 #[cfg(test)]
@@ -335,5 +490,106 @@ mod tests {
     fn no_events_means_not_exported() {
         let mut evs = [].into_iter();
         assert!(!exported_at_import_site(&mut evs, "p", &before(20)));
+    }
+
+    // ---- the import edge's own lifecycle (issue #1103) -------------------
+
+    fn install(at: u32) -> AliasEvent {
+        AliasEvent {
+            kind: AliasEventKind::Install,
+            at: Some(at),
+        }
+    }
+
+    fn remove(at: u32) -> AliasEvent {
+        AliasEvent {
+            kind: AliasEventKind::Remove,
+            at: Some(at),
+        }
+    }
+
+    fn unordered_event(kind: AliasEventKind) -> AliasEvent {
+        AliasEvent { kind, at: None }
+    }
+
+    /// `removal_in_effect` for a call at `call_at`: plain textual order.
+    fn ran_before(call_at: u32) -> impl Fn(u32) -> bool {
+        move |at| at < call_at
+    }
+
+    #[test]
+    fn an_import_with_no_removal_is_live() {
+        let mut evs = [install(10)].into_iter();
+        assert!(alias_live_at(&mut evs, &ran_before(20)));
+    }
+
+    #[test]
+    fn nothing_installed_means_no_alias() {
+        let mut evs = [remove(10)].into_iter();
+        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+    }
+
+    #[test]
+    fn a_forget_after_the_import_kills_the_alias() {
+        // import @10, `namespace forget` @15, call @20.
+        let mut evs = [install(10), remove(15)].into_iter();
+        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+    }
+
+    #[test]
+    fn a_forget_after_the_call_leaves_it_alive() {
+        // import @10, call @20, `namespace forget` @30 — the call runs first.
+        let mut evs = [install(10), remove(30)].into_iter();
+        assert!(alias_live_at(&mut evs, &ran_before(20)));
+    }
+
+    #[test]
+    fn a_re_import_after_a_forget_reinstates_the_alias() {
+        let mut evs = [install(10), remove(15), install(17)].into_iter();
+        assert!(alias_live_at(&mut evs, &ran_before(20)));
+    }
+
+    #[test]
+    fn the_latest_removal_wins_over_an_earlier_install() {
+        // Two forgets; the alias is dead from the first one that follows the
+        // last install.
+        let mut evs = [install(10), remove(12), remove(15)].into_iter();
+        assert!(!alias_live_at(&mut evs, &ran_before(20)));
+    }
+
+    #[test]
+    fn an_install_later_than_the_call_still_counts() {
+        // Whether a call written *before* its own import resolves is #1104
+        // item 1's still-open leniency: this function must not decide it, so
+        // an install at 30 with the call at 20 still installs.
+        let mut evs = [install(30)].into_iter();
+        assert!(alias_live_at(&mut evs, &ran_before(20)));
+        // …but a removal between them is still a removal.
+        let mut evs = [install(30), remove(10)].into_iter();
+        assert!(alias_live_at(&mut evs, &ran_before(20)));
+    }
+
+    #[test]
+    fn an_unordered_removal_revokes_nothing() {
+        // A `namespace forget` in another file: no static load order, so
+        // navigation keeps answering rather than dropping a real alias.
+        let mut evs = [install(10), unordered_event(AliasEventKind::Remove)].into_iter();
+        assert!(alias_live_at(&mut evs, &ran_before(20)));
+    }
+
+    #[test]
+    fn an_unordered_install_counts() {
+        let mut evs = [unordered_event(AliasEventKind::Install)].into_iter();
+        assert!(alias_live_at(&mut evs, &ran_before(20)));
+        // …and survives an ordered removal, for the same reason an ordered
+        // `-clear` cannot revoke an unordered export.
+        let mut evs = [unordered_event(AliasEventKind::Install), remove(5)].into_iter();
+        assert!(alias_live_at(&mut evs, &ran_before(20)));
+    }
+
+    #[test]
+    fn no_events_at_all_means_no_alias() {
+        let mut evs = [].into_iter();
+        assert!(!alias_live_at(&mut evs, &ran_before(20)));
     }
 }

--- a/rust/tcl-lsp-core/src/references.rs
+++ b/rust/tcl-lsp-core/src/references.rs
@@ -316,16 +316,17 @@ fn invocation_references_via_indirection(
 /// references only, never by cross-document rename's
 /// `invocations_of`-based edit gathering).
 ///
-/// The export gate is applied **per import site**, at that import's own
-/// position, through the same shared decision function the go-to-definition
-/// resolver uses (`definition::exported_at_import` →
-/// [`crate::namespace_import::exported_at_import_site`]): an import binds the
-/// names exported when it runs, so a later `namespace export -clear` does not
-/// revoke this call site's alias and a later `namespace export` does not
-/// create one (issue #1027). Testing "some import matches" and "the final
-/// export set covers the name" as two independent conditions — as this
-/// originally did — gets both directions wrong, and lets an import whose own
-/// snapshot excluded the name borrow an unrelated import's export.
+/// The whole import **lifecycle** is applied, not just "some import matches":
+/// the export snapshot at that import's own position (issue #1027), the
+/// non-`-force` conflict that makes an import install nothing, a `namespace
+/// forget` or a deletion of the source command that takes the alias away
+/// again, and an import *chain* that reaches the definition through an
+/// intermediate namespace (issue #1103). All of it comes from the one shared
+/// entry point go-to-definition resolves through
+/// (`definition::import_chain_target`), so references and definition cannot
+/// disagree about what a call site reaches. Testing "some import matches" and
+/// "the final export set covers the name" as two independent conditions — as
+/// this originally did — gets both directions wrong.
 #[must_use]
 fn invocation_references_via_wildcard_import(
     analysis: &AnalysisResult,
@@ -340,27 +341,13 @@ fn invocation_references_via_wildcard_import(
         .trim_start_matches("::")
         .rsplit_once("::")
         .map_or(String::new(), |(ns, _)| ns.to_owned());
-    let call_ns = crate::definition::innermost_namespace_at(
+    let call_ns = crate::definition::namespace_context_at(
         &analysis.global_scope,
         inv.range.start(),
         &analysis.namespace_overrides,
     );
-    analysis.namespace_imports.iter().any(|imp| {
-        imp.ns.trim_start_matches("::") == call_ns
-            && imp
-                .pattern
-                .rsplit_once("::")
-                .is_some_and(|(source_ns, tail)| {
-                    source_ns.trim_start_matches("::") == target_ns
-                        && tcl_syntax::glob::string_match(tail, def_name)
-                        && crate::definition::exported_at_import(
-                            analysis,
-                            source_ns,
-                            def_name,
-                            imp.range.start(),
-                        )
-                })
-    })
+    crate::definition::import_chain_target(analysis, &call_ns, def_name, inv.range.start())
+        .is_some_and(|source_ns| source_ns.trim_start_matches("::") == target_ns)
 }
 
 #[must_use]
@@ -3465,6 +3452,81 @@ mod tests {
             !lines.contains(&5),
             "an export written after the import must not make the bare call a \
              reference: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_drop_a_call_after_a_namespace_forget() {
+        // TN, issue #1103 behaviour 1 — the alias the import installed is
+        // gone by the time the second `p` runs (oracle: `invalid command
+        // name "p"`), so that call is not a reference to `::src::p`. The
+        // call *before* the forget still is.
+        let src = "namespace eval src {\n    proc p {} { return P }\n    namespace export p\n}\nnamespace eval dst {\n    namespace import ::src::*\n    p\n    namespace forget ::src::p\n    p\n}\n";
+        let analysis = analyse(src);
+        // Cursor on the `p` declaration (line 1, col 9).
+        let refs = references(src, "tcl", 1, 9, &analysis, true);
+        let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+        assert!(lines.contains(&1), "decl missing: {refs:?}");
+        assert!(
+            lines.contains(&6),
+            "the call before the forget is still a reference: {refs:?}"
+        );
+        assert!(
+            !lines.contains(&8),
+            "the call after the forget reaches no command: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_drop_a_conflicting_unforced_imports_call_site() {
+        // FP guard (CRITICAL), issue #1103 behaviour 2 — `::dst` already has
+        // its own `p`, so the non-`-force` import errors and installs
+        // nothing (oracle: `can't import command "p": already exists`, and
+        // `namespace origin ::dst::p` → `::dst::p`). The bare `p` inside
+        // `::dst` runs the *local* proc and is not a reference to `::src::p`.
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n    namespace import ::src::*\n    p\n}\n";
+        let analysis = analyse(src);
+        // Cursor on `::src::p`'s declaration (line 1, col 9).
+        let refs = references(src, "tcl", 1, 9, &analysis, true);
+        let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+        assert!(lines.contains(&1), "decl missing: {refs:?}");
+        assert!(
+            !lines.contains(&7),
+            "a failed import makes no call site of the source: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_include_a_forced_imports_call_site() {
+        // TP, the other half of the row above — with `-force` the import
+        // replaces the local `p`, so the bare call *is* a reference to
+        // `::src::p` (oracle: `namespace origin ::dst::p` → `::src::p`).
+        let src = "namespace eval src {\n    proc p {} { return SRC }\n    namespace export p\n}\nnamespace eval dst {\n    proc p {} { return LOCAL }\n    namespace import -force ::src::*\n    p\n}\n";
+        let analysis = analyse(src);
+        let refs = references(src, "tcl", 1, 9, &analysis, true);
+        let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+        assert!(
+            lines.contains(&7),
+            "a `-force` import makes the bare call a reference to the source: {refs:?}"
+        );
+    }
+
+    #[test]
+    fn references_include_a_call_through_an_import_chain() {
+        // TP, issue #1103 behaviour 4 — `::A` imports `::B::*`, `::B`
+        // imported `::C::*` and re-exported; the bare `p` in `::A` runs
+        // `::C::p` (oracle: `namespace origin ::A::p` → `::C::p`), so it is
+        // a reference to it. The middle hop is in no `all_procs`, so this
+        // previously found nothing.
+        let src = "namespace eval C {\n    proc p {} { return CP }\n    namespace export p\n}\nnamespace eval B {\n    namespace import ::C::*\n    namespace export p\n}\nnamespace eval A {\n    namespace import ::B::*\n    p\n}\n";
+        let analysis = analyse(src);
+        // Cursor on `::C::p`'s declaration (line 1, col 9).
+        let refs = references(src, "tcl", 1, 9, &analysis, true);
+        let lines: Vec<u32> = refs.iter().map(|r| r.start_line).collect();
+        assert!(lines.contains(&1), "decl missing: {refs:?}");
+        assert!(
+            lines.contains(&10),
+            "the chained bare call is a reference to ::C::p: {refs:?}"
         );
     }
 

--- a/rust/tcl-lsp-core/src/signature_help.rs
+++ b/rust/tcl-lsp-core/src/signature_help.rs
@@ -108,16 +108,18 @@ pub fn signature_help(
     // Tcl's own command resolution would (caller namespace, then global), so a
     // same-named proc in an unrelated namespace never hijacks the signature and
     // a same-named builtin keeps its synopsis unless a proc is actually visible.
-    let namespace = {
+    let cursor_off = {
         let line_index = tcl_lexer::LineIndex::new(source);
-        let cursor_off = crate::definition::byte_offset_at(&line_index, source, line, character);
-        crate::definition::namespace_context_at(
-            &analysis.global_scope,
-            cursor_off,
-            &analysis.namespace_overrides,
-        )
+        crate::definition::byte_offset_at(&line_index, source, line, character)
     };
-    if let Some(proc_def) = lookup_proc(analysis, source, &namespace, &command, registry) {
+    let namespace = crate::definition::namespace_context_at(
+        &analysis.global_scope,
+        cursor_off,
+        &analysis.namespace_overrides,
+    );
+    if let Some(proc_def) =
+        lookup_proc(analysis, source, &namespace, &command, cursor_off, registry)
+    {
         return Some(proc_signature_help(proc_def, active_param));
     }
     let registry = registry?;
@@ -317,18 +319,26 @@ fn lookup_proc<'a>(
     source: &str,
     namespace: &str,
     name: &str,
+    call_off: u32,
     registry: Option<&CommandRegistry>,
 ) -> Option<&'a ProcDef> {
-    if let Some(proc_def) =
-        crate::definition::resolve_called_proc(analysis, source, namespace, name, registry)
-    {
+    if let Some(proc_def) = crate::definition::resolve_called_proc(
+        analysis, source, namespace, name, call_off, registry,
+    ) {
         return Some(proc_def);
     }
     // Alias resolution.  When the cursor's command isn't a visible proc, check
     // whether it matches an `interp alias {} ALIAS {} TARGET` record and follow
     // the chain, resolving the target the same namespace-aware way.
     let resolved_target = resolve_alias_chain(analysis, name)?;
-    crate::definition::resolve_called_proc(analysis, source, namespace, &resolved_target, registry)
+    crate::definition::resolve_called_proc(
+        analysis,
+        source,
+        namespace,
+        &resolved_target,
+        call_off,
+        registry,
+    )
 }
 
 /// Follow the alias chain from `name` to its terminal

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -436,6 +436,9 @@ pub struct WorkspaceImportGate {
     /// Span of the innermost proc/class body containing the import; `None` at
     /// load level. See [`WorkspaceGlobImport::enclosing_body`].
     pub enclosing_body: Option<Span>,
+    /// `true` when the import carried its declared leading option word —
+    /// `namespace import -force`. See [`WorkspaceGlobImport::forced`].
+    pub forced: bool,
 }
 
 /// One wildcard `namespace import NS::*` recorded in the index.
@@ -488,6 +491,62 @@ pub struct WorkspaceGlobImport {
     /// weaker `at <= import_at` — which rejected such an export and lost a
     /// real imported alias.
     pub enclosing_body: Option<Span>,
+    /// `true` when the import carried its declared leading option word —
+    /// `namespace import -force`.
+    ///
+    /// Decides what happens when the importing namespace already holds a
+    /// command of the imported name (oracle tclsh 8.6.14 / 9.0.4, issue
+    /// #1103): without `-force` the import raises `can't import command "p":
+    /// already exists` and installs **nothing**, so a bare call still reaches
+    /// the local definition; with `-force` it silently replaces it and the
+    /// call reaches the source (`namespace origin` → `::src::p`). See
+    /// [`tcl_compiler::signature_scan::types::SignatureNamespaceImport::forced`]
+    /// for why this is registry data rather than a `-force` name match.
+    pub forced: bool,
+}
+
+/// One `namespace forget` **event** recorded in the index — the removal half
+/// of the import edge's lifecycle log (issue #1103).
+///
+/// Aggregated workspace-wide for the same reason
+/// [`WorkspaceNamespaceExport`] is: the forget and the import it undoes need
+/// not live in the same file. Ordering only means something *within* a
+/// document, which is why [`Self::uri`] and [`Self::at`] are always read
+/// together.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceNamespaceForget {
+    /// Document the `namespace forget` is in.
+    pub uri: String,
+    /// The namespace losing the aliases, with leading `::`.
+    pub ns: String,
+    /// Source namespace named by a *qualified* pattern (`::src` for
+    /// `namespace forget ::src::p`), `None` for a simple pattern — which
+    /// matches this namespace's own imported command names whatever their
+    /// origin. See
+    /// [`tcl_compiler::signature_scan::types::SignatureNamespaceForget`].
+    pub source_ns: Option<String>,
+    /// The pattern's final `::`-segment, exactly as written, matched against
+    /// a command's bare name with Tcl glob semantics.
+    pub pattern: String,
+    /// Byte offset of the event within [`Self::uri`].
+    pub at: u32,
+}
+
+/// One straight-line command **deletion** recorded in the index — `rename
+/// OLD {}` / `interp alias {} NAME {}`.
+///
+/// A deletion is a lifecycle event on every import edge pointing at the
+/// deleted command: the alias holds the command object, so deleting the
+/// source kills the alias too (issue #1103, oracle on
+/// [`tcl_compiler::analyser::AnalysisResult::deleted_commands`]).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct WorkspaceCommandDeletion {
+    /// Document the deletion is in.
+    pub uri: String,
+    /// The `::`-normalised qualified name that was deleted.
+    pub qualified_name: String,
+    /// Byte offset of the deleting statement within [`Self::uri`].
+    pub at: u32,
 }
 
 impl WorkspaceGlobImport {
@@ -582,6 +641,8 @@ pub struct WorkspaceIndex {
     command_links: Vec<WorkspaceCommandLink>,
     glob_imports: Vec<WorkspaceGlobImport>,
     namespace_exports: Vec<WorkspaceNamespaceExport>,
+    namespace_forgets: Vec<WorkspaceNamespaceForget>,
+    command_deletions: Vec<WorkspaceCommandDeletion>,
     generation: u64,
     command_names: CommandNameCache,
     live_links: LiveLinkCache,
@@ -724,8 +785,21 @@ impl WorkspaceIndex {
                     .iter()
                     .map(|l| {
                         l.import_gate.as_ref().is_none_or(|g| {
-                            !observable.contains(g.source_ns.trim_start_matches("::"))
-                                || wci.exports_name_at(&g.source_ns, &g.name, g.site(&l.uri))
+                            if !observable.contains(g.source_ns.trim_start_matches("::")) {
+                                return true;
+                            }
+                            if !wci.exports_name_at(&g.source_ns, &g.name, g.site(&l.uri)) {
+                                return false;
+                            }
+                            // A non-`-force` import onto a name the target
+                            // namespace already holds installs nothing at all
+                            // (oracle on `WorkspaceGlobImport::forced`), so
+                            // the link it would introduce is not live either.
+                            // Only a real *definition* counts as the
+                            // conflicting command: another link's name would
+                            // make two imports of the same name cancel each
+                            // other out.
+                            g.forced || !self.defines_command(&l.linked_qname)
                         })
                     })
                     .collect(),
@@ -745,6 +819,24 @@ impl WorkspaceIndex {
     /// The discriminator between "this namespace does not export the name"
     /// (a fact) and "this namespace is not in the workspace at all" (no
     /// information) — see [`Self::live_command_links`].
+    /// Whether the workspace holds a real proc or class definition at
+    /// `qualified_name` — the "already exists" side of a non-`-force`
+    /// `namespace import` conflict.
+    ///
+    /// Deliberately *not* [`Self::workspace_command_exists`], which also
+    /// admits linked names: a link is what this question is being asked
+    /// about, so counting one would make an import conflict with itself.
+    fn defines_command(&self, qualified_name: &str) -> bool {
+        let target = qualified_name.trim_start_matches("::");
+        self.procs
+            .iter()
+            .any(|p| p.qualified_name.trim_start_matches("::") == target)
+            || self
+                .classes
+                .iter()
+                .any(|c| c.qualified_name.trim_start_matches("::") == target)
+    }
+
     fn observable_namespaces(&self) -> HashSet<&str> {
         fn owning_ns(qualified: &str) -> &str {
             qualified
@@ -859,7 +951,40 @@ impl WorkspaceIndex {
                 clears: exp.clears,
             });
         }
+        self.index_import_lifecycle(uri, analysis);
         self.index_command_links(uri, analysis);
+    }
+
+    /// Lift a document's `namespace forget` events and command **destructions**
+    /// — the removal half of the import edge's lifecycle (issue #1103).
+    ///
+    /// A destroying `rename OLD {}` / `interp alias {} NAME {}` kills every
+    /// import alias pointing at `OLD`, because the alias holds the command
+    /// object; a plain `rename OLD NEW` does not, which is why
+    /// `AnalysisResult::destroyed_commands` (not `deleted_commands`) is the
+    /// source here.
+    fn index_import_lifecycle(&mut self, uri: &str, analysis: &AnalysisResult) {
+        for fgt in &analysis.namespace_forgets {
+            self.namespace_forgets.push(WorkspaceNamespaceForget {
+                uri: uri.to_owned(),
+                ns: fgt.ns.clone(),
+                source_ns: fgt.source_ns.clone(),
+                pattern: fgt.pattern.clone(),
+                at: fgt.range.start(),
+            });
+        }
+        // `HashMap`-valued, so sort into source order for the same reason
+        // `sorted_by_span` exists (issue #1028): a consumer answering with the
+        // first matching record must not answer differently run to run.
+        let mut destroyed: Vec<(&String, &u32)> = analysis.destroyed_commands.iter().collect();
+        destroyed.sort_unstable_by(|a, b| a.1.cmp(b.1).then_with(|| a.0.cmp(b.0)));
+        for (name, at) in destroyed {
+            self.command_deletions.push(WorkspaceCommandDeletion {
+                uri: uri.to_owned(),
+                qualified_name: tcl_syntax::naming::normalise_qualified_name(name),
+                at: *at,
+            });
+        }
     }
 
     /// Lift a document's three **variable** tables: the namespace-scoped
@@ -927,6 +1052,7 @@ impl WorkspaceIndex {
                         tail_pattern: tail_pattern.to_owned(),
                         at: imp.range.start(),
                         enclosing_body: analysis.innermost_definition_body_span(imp.range.start()),
+                        forced: imp.forced,
                     });
                 }
                 continue;
@@ -953,6 +1079,7 @@ impl WorkspaceIndex {
                     name: tail.to_owned(),
                     at: imp.range.start(),
                     enclosing_body: analysis.innermost_definition_body_span(imp.range.start()),
+                    forced: imp.forced,
                 });
             self.command_links.push(WorkspaceCommandLink {
                 uri: uri.to_owned(),
@@ -1023,6 +1150,8 @@ impl WorkspaceIndex {
         self.command_links.retain(|l| l.uri != uri);
         self.glob_imports.retain(|g| g.uri != uri);
         self.namespace_exports.retain(|e| e.uri != uri);
+        self.namespace_forgets.retain(|f| f.uri != uri);
+        self.command_deletions.retain(|d| d.uri != uri);
     }
 
     /// Every indexed `source FILE` reference.
@@ -1966,7 +2095,15 @@ impl WorkspaceIndex {
         // just because its ultimate source is renamed.
         links.is_some()
             && self
-                .resolve_wildcard_import_indexed(&inv.name, &inv.resolution_candidates, wci)
+                .resolve_wildcard_import_indexed(
+                    &inv.name,
+                    &inv.resolution_candidates,
+                    CallSite {
+                        uri: &inv.uri,
+                        at: inv.range.start(),
+                    },
+                    wci,
+                )
                 .is_some_and(|resolved| resolved.trim_start_matches("::") == target)
     }
 
@@ -2189,10 +2326,12 @@ impl WorkspaceIndex {
         &self,
         word: &str,
         resolution_candidates: &[String],
+        call: CallSite<'_>,
     ) -> Option<String> {
         self.resolve_wildcard_import_indexed(
             word,
             resolution_candidates,
+            call,
             &WildcardImportIndex::build(self),
         )
     }
@@ -2210,6 +2349,7 @@ impl WorkspaceIndex {
         &self,
         word: &str,
         resolution_candidates: &[String],
+        call: CallSite<'_>,
         wci: &WildcardImportIndex<'_>,
     ) -> Option<String> {
         if word.contains("::") {
@@ -2223,21 +2363,88 @@ impl WorkspaceIndex {
                 continue;
             }
             let candidate_ns = if prefix.is_empty() { "::" } else { prefix };
-            let Some(imports) = wci.imports_by_ns.get(candidate_ns) else {
-                continue;
-            };
-            for imp in imports {
-                if !tcl_syntax::glob::string_match(&imp.tail_pattern, word) {
-                    continue;
-                }
-                if !wci.exports_name_at(&imp.source_ns, word, imp.site()) {
-                    continue;
-                }
-                let target = format!("{}::{word}", imp.source_ns);
-                if self.workspace_command_exists(&target) {
-                    return Some(target);
-                }
+            if let Some(target) = self.follow_import_chain(candidate_ns, word, call, wci) {
+                return Some(target);
             }
+        }
+        None
+    }
+
+    /// Follow the import edges out of `ns` until they reach a command the
+    /// workspace actually defines, and return that qualified name.
+    ///
+    /// An import edge may land on a name that is *itself* imported: with
+    /// `::C` exporting `p`, `::B` importing `::C::*` and re-exporting, and
+    /// `::A` importing `::B::*`, `::A::p` runs `::C`'s body and `namespace
+    /// origin ::A::p` answers `::C::p` (oracle tclsh 8.6.14 / 9.0.4 — issue
+    /// #1103). The middle hop is in no workspace proc/class table, so a
+    /// single-hop walk found nothing and go-to-definition silently abstained.
+    ///
+    /// Bounded by [`tcl_compiler::analyser::indirection::MAX_COMMAND_NAME_HOPS`]
+    /// — the same cap the `rename` / `interp alias` walk applies to the same
+    /// kind of chain, so a mutually-importing pair cannot spin. The whole
+    /// chain is judged at the *call's* offset: a forget anywhere along it
+    /// kills the call (oracle: forgetting `::C::p` inside `::B` makes
+    /// `::A::p` an `invalid command name` too, because deleting an imported
+    /// command deletes the commands imported from it).
+    fn follow_import_chain(
+        &self,
+        ns: &str,
+        word: &str,
+        call: CallSite<'_>,
+        wci: &WildcardImportIndex<'_>,
+    ) -> Option<String> {
+        let mut current = ns.to_owned();
+        for _ in 0..tcl_compiler::analyser::indirection::MAX_COMMAND_NAME_HOPS {
+            let hop = self.import_hop(&current, word, call, wci)?;
+            let target = format!("{hop}::{word}");
+            if self.workspace_command_exists(&target) {
+                return Some(target);
+            }
+            current = hop;
+        }
+        None
+    }
+
+    /// One hop of [`Self::follow_import_chain`]: the source namespace of the
+    /// live import that makes `word` callable from `ns` at `call`, or `None`.
+    ///
+    /// Three gates, in the order real Tcl applies them:
+    ///
+    /// 1. the pattern must cover `word`;
+    /// 2. the source namespace must have exported it **at that import's own
+    ///    position** ([`WildcardImportIndex::exports_name_at`], issue #1027);
+    /// 3. without `-force`, the importing namespace must not already hold a
+    ///    command of that name — such an import raises `can't import command
+    ///    "p": already exists` and installs nothing, so a bare call still
+    ///    reaches the local definition (issue #1103). With `-force` it
+    ///    replaces the local one instead, which is why the check is skipped
+    ///    there.
+    ///
+    /// …and then the edge must still be *there*
+    /// ([`WildcardImportIndex::alias_live_at`]).
+    fn import_hop(
+        &self,
+        ns: &str,
+        word: &str,
+        call: CallSite<'_>,
+        wci: &WildcardImportIndex<'_>,
+    ) -> Option<String> {
+        let imports = wci.imports_by_ns.get(ns)?;
+        for imp in imports {
+            if !tcl_syntax::glob::string_match(&imp.tail_pattern, word) {
+                continue;
+            }
+            if !wci.exports_name_at(&imp.source_ns, word, imp.site()) {
+                continue;
+            }
+            if !imp.forced && self.defines_command(&format!("{ns}::{word}")) {
+                continue;
+            }
+            if !wci.alias_live_at(ns, &imp.source_ns, word, imp.site(), call) {
+                continue;
+            }
+            return Some(imp.source_ns.clone());
         }
         None
     }
@@ -2250,6 +2457,8 @@ impl WorkspaceIndex {
 struct WildcardImportIndex<'a> {
     imports_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceGlobImport>>,
     exports_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceNamespaceExport>>,
+    forgets_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceNamespaceForget>>,
+    deletions_by_name: std::collections::HashMap<&'a str, Vec<&'a WorkspaceCommandDeletion>>,
 }
 
 impl<'a> WildcardImportIndex<'a> {
@@ -2264,10 +2473,86 @@ impl<'a> WildcardImportIndex<'a> {
         for exp in &index.namespace_exports {
             exports_by_ns.entry(exp.ns.as_str()).or_default().push(exp);
         }
+        let mut forgets_by_ns: std::collections::HashMap<&str, Vec<&WorkspaceNamespaceForget>> =
+            std::collections::HashMap::new();
+        for fgt in &index.namespace_forgets {
+            forgets_by_ns.entry(fgt.ns.as_str()).or_default().push(fgt);
+        }
+        let mut deletions_by_name: std::collections::HashMap<&str, Vec<&WorkspaceCommandDeletion>> =
+            std::collections::HashMap::new();
+        for del in &index.command_deletions {
+            deletions_by_name
+                .entry(del.qualified_name.as_str())
+                .or_default()
+                .push(del);
+        }
         Self {
             imports_by_ns,
             exports_by_ns,
+            forgets_by_ns,
+            deletions_by_name,
         }
+    }
+
+    /// Whether the alias `importing_ns` took from `source_ns` for `name` is
+    /// still there when the call at `call` runs — the cross-document binding
+    /// of the shared lifecycle decision
+    /// [`crate::namespace_import::alias_live_at`] (issue #1103).
+    ///
+    /// `install_at` is the import's own site; the removals are this
+    /// namespace's `namespace forget` events plus any deletion of the source
+    /// command itself.
+    ///
+    /// Only removals in the **calling document** are ordered against the
+    /// call: which of two files loads first is not a static fact (#1104 item
+    /// 3), so a foreign forget is passed unordered and revokes nothing.
+    /// Within that document the comparison is a plain offset test rather than
+    /// [`tcl_compiler::analyser::indirection::in_effect_within`], because the
+    /// index does not store a *call site's* enclosing body span — only an
+    /// import's. That can only make a removal look not-yet-run, i.e. keep
+    /// answering, which is the abstention direction navigation wants; it can
+    /// never invent a removal and drop a live alias.
+    fn alias_live_at(
+        &self,
+        importing_ns: &str,
+        source_ns: &str,
+        name: &str,
+        install_at: ImportSite<'_>,
+        call: CallSite<'_>,
+    ) -> bool {
+        use crate::namespace_import::{AliasEvent, AliasEventKind};
+        let install = std::iter::once(AliasEvent {
+            kind: AliasEventKind::Install,
+            at: Some(install_at.at),
+        });
+        let forgets = self
+            .forgets_by_ns
+            .get(importing_ns)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .filter(|f| {
+                f.source_ns.as_deref().is_none_or(|src| {
+                    src.trim_start_matches("::") == source_ns.trim_start_matches("::")
+                }) && tcl_syntax::glob::string_match(&f.pattern, name)
+            })
+            .map(|f| AliasEvent {
+                kind: AliasEventKind::Remove,
+                at: (f.uri == call.uri).then_some(f.at),
+            });
+        let qualified = tcl_syntax::naming::qualify(source_ns, name);
+        let deletions = self
+            .deletions_by_name
+            .get(qualified.as_str())
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .map(|d| AliasEvent {
+                kind: AliasEventKind::Remove,
+                at: (d.uri == call.uri).then_some(d.at),
+            });
+        let mut events = install.chain(forgets).chain(deletions);
+        crate::namespace_import::alias_live_at(&mut events, &|at| at < call.at)
     }
 
     /// Whether `ns` (`::`-rooted) had exported the unqualified `name` **as of
@@ -2322,6 +2607,27 @@ struct ImportSite<'a> {
     enclosing_body: Option<Span>,
 }
 
+/// Where the **call** being resolved sits: the document and the offset of its
+/// command-head token.
+///
+/// The import edge's lifecycle is a question about the call, not about the
+/// import — a `namespace forget` written after the import kills calls after
+/// it and leaves calls before it alone (issue #1103) — so the resolver needs
+/// the call's own position, which
+/// [`WorkspaceIndex::resolve_wildcard_import`] previously never received.
+///
+/// Carries no enclosing-body span: the index stores one per *import* row, not
+/// per invocation, and building it per call would be O(procs × invocations)
+/// at index time. See [`WildcardImportIndex::alias_live_at`] for why its
+/// absence can only make this abstain toward answering.
+#[derive(Debug, Clone, Copy)]
+pub struct CallSite<'a> {
+    /// Document the call is in.
+    pub uri: &'a str,
+    /// Byte offset of the call's command-head token within `uri`.
+    pub at: u32,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -2330,6 +2636,19 @@ mod tests {
     fn analyse(source: &str) -> AnalysisResult {
         let mut a = Analyser::new();
         a.analyse(source, "tcl8.6").clone()
+    }
+
+    /// A call site at the end of `uri` — the offset only matters to the
+    /// import-lifecycle gate (a `namespace forget` / source deletion earlier
+    /// in the *same* document), so tests with no such event may use it
+    /// freely.
+    /// Byte offset of `needle` in a test source.
+    fn app_src_offset(src: &str, needle: &str) -> usize {
+        src.find(needle).expect("needle present")
+    }
+
+    fn call_from(uri: &str) -> CallSite<'_> {
+        CallSite { uri, at: u32::MAX }
     }
 
     #[test]
@@ -2844,6 +3163,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///caller.tcl"),
         );
         assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
     }
@@ -2868,6 +3188,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "other",
             &["::app::other".to_string(), "::other".to_string()],
+            call_from("file:///caller.tcl"),
         );
         assert!(resolved.is_none(), "{resolved:?}");
     }
@@ -2890,7 +3211,11 @@ mod tests {
             ("file:///mypkg.tcl", &mypkg),
             ("file:///consumer.tcl", &consumer),
         ]);
-        let resolved = index.resolve_wildcard_import("Widget", &["::Widget".to_string()]);
+        let resolved = index.resolve_wildcard_import(
+            "Widget",
+            &["::Widget".to_string()],
+            call_from("file:///caller.tcl"),
+        );
         assert_eq!(resolved.as_deref(), Some("::mypkg::Widget"));
     }
 
@@ -2923,6 +3248,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///caller.tcl"),
         );
         assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
     }
@@ -2953,6 +3279,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///caller.tcl"),
         );
         assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
     }
@@ -2975,6 +3302,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///caller.tcl"),
         );
         assert!(
             resolved.is_none(),
@@ -3004,6 +3332,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///caller.tcl"),
         );
         assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
     }
@@ -3033,6 +3362,7 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///caller.tcl"),
         );
         assert_eq!(
             resolved.as_deref(),
@@ -3061,11 +3391,284 @@ mod tests {
         let resolved = index.resolve_wildcard_import(
             "helper",
             &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///caller.tcl"),
         );
         assert!(
             resolved.is_none(),
             "an export written after the import in the same body is a later \
              statement of the running script: {resolved:?}",
+        );
+    }
+
+    // ---- the import edge's own lifecycle, cross-document (issue #1103) ---
+    //
+    // The workspace twin of `definition.rs`'s in-document block. Same oracle
+    // rows (tclsh 9.0.4 + 8.6.14, byte-identical), same shared decision
+    // function (`namespace_import::alias_live_at`), so the two tiers cannot
+    // drift.
+
+    #[test]
+    fn cross_file_forget_after_the_import_stops_resolving() {
+        // TN — the source lives in another file, so only this tier can
+        // answer; the forget and the call are in one document, so they are
+        // ordered.
+        let src = "namespace eval ::app {\n    namespace import ::mymod::*\n}\nnamespace eval ::app {\n    namespace forget ::mymod::helper\n}\nhelper\n";
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(src);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let call = u32::try_from(app_src_offset(src, "\nhelper\n") + 1).expect("tiny source");
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            CallSite {
+                uri: "file:///app.tcl",
+                at: call,
+            },
+        );
+        assert!(
+            resolved.is_none(),
+            "a call after the forget must not resolve through the alias: {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn cross_file_call_before_the_forget_still_resolves() {
+        // TP — the same document, a call written before the forget.
+        let src = "namespace eval ::app {\n    namespace import ::mymod::*\n}\nhelper\nnamespace eval ::app {\n    namespace forget ::mymod::helper\n}\n";
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(src);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let call = u32::try_from(app_src_offset(src, "\nhelper\n") + 1).expect("tiny source");
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            CallSite {
+                uri: "file:///app.tcl",
+                at: call,
+            },
+        );
+        assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
+    }
+
+    #[test]
+    fn a_forget_in_another_file_revokes_nothing() {
+        // TN-for-abstention — no static load order between two files, so a
+        // foreign forget is passed unordered and cannot silently drop a real
+        // alias. Same direction as an unordered `namespace export -clear`
+        // (#1104 item 3).
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse("namespace eval ::app {\n    namespace import ::mymod::*\n}\n");
+        let teardown = analyse("namespace eval ::app {\n    namespace forget ::mymod::helper\n}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+            ("file:///teardown.tcl", &teardown),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///caller.tcl"),
+        );
+        assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
+    }
+
+    #[test]
+    fn cross_file_source_deletion_kills_the_alias() {
+        // TN — `rename ::mymod::helper {}` destroys the command object, and
+        // the alias holds the object. Ordered because the deletion and the
+        // call share a document.
+        let src = "namespace eval ::app {\n    namespace import ::mymod::*\n}\nrename ::mymod::helper {}\nhelper\n";
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(src);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let call = u32::try_from(app_src_offset(src, "\nhelper\n") + 1).expect("tiny source");
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            CallSite {
+                uri: "file:///app.tcl",
+                at: call,
+            },
+        );
+        assert!(resolved.is_none(), "{resolved:?}");
+    }
+
+    #[test]
+    fn cross_file_source_rename_leaves_the_alias_alive() {
+        // TP — the asymmetry again: `rename ::mymod::helper ::mymod::h2`
+        // moves the origin and keeps `::app::helper` working.
+        let src = "namespace eval ::app {\n    namespace import ::mymod::*\n}\nrename ::mymod::helper ::mymod::h2\nhelper\n";
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(src);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let call = u32::try_from(app_src_offset(src, "\nhelper\n") + 1).expect("tiny source");
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            CallSite {
+                uri: "file:///app.tcl",
+                at: call,
+            },
+        );
+        assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
+    }
+
+    #[test]
+    fn an_unforced_import_onto_an_existing_workspace_command_installs_nothing() {
+        // TN — `::app` already defines `helper`, so the non-`-force` import
+        // errors and installs nothing; the call reaches the local definition,
+        // not `::mymod::helper` (oracle: `namespace origin ::app::helper` →
+        // `::app::helper`).
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    proc helper {} {}\n    namespace import ::mymod::*\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///app.tcl"),
+        );
+        assert!(resolved.is_none(), "{resolved:?}");
+    }
+
+    #[test]
+    fn a_forced_import_onto_an_existing_workspace_command_installs() {
+        // TP — the same program with `-force` replaces the local command, so
+        // the call reaches `::mymod::helper` (oracle: `namespace origin
+        // ::app::helper` → `::mymod::helper`).
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    proc helper {} {}\n    namespace import -force ::mymod::*\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            call_from("file:///app.tcl"),
+        );
+        assert_eq!(resolved.as_deref(), Some("::mymod::helper"));
+    }
+
+    #[test]
+    fn an_exact_import_onto_an_existing_workspace_command_installs_no_link() {
+        // TN — the same conflict rule on the exact-import link path
+        // (`live_command_links`), so definition / references / the existence
+        // oracle all agree the import bound nothing.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    proc helper {} {}\n    namespace import ::mymod::helper\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::app::helper"),
+            "::app::helper",
+            "a conflicting exact import installs no link"
+        );
+    }
+
+    #[test]
+    fn a_forced_exact_import_still_installs_its_link() {
+        // FN guard for the rule above.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    proc helper {} {}\n    namespace import -force ::mymod::helper\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::app::helper"),
+            "::mymod::helper"
+        );
+    }
+
+    #[test]
+    fn a_cross_file_import_chain_follows_to_the_original_source() {
+        // TP — `::A` imports `::B::*`, `::B` imported `::C::*`, each in its
+        // own file. Oracle: `::A::p` runs `::C`'s body and `namespace origin
+        // ::A::p` → `::C::p`. The middle hop is in no workspace proc table,
+        // so a single-hop walk abstained.
+        let c = analyse("namespace eval ::C { proc p {} { return CP }\n namespace export p }\n");
+        let b = analyse("namespace eval ::B { namespace import ::C::*\n namespace export p }\n");
+        let a = analyse("namespace eval ::A { namespace import ::B::* }\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///c.tcl", &c),
+            ("file:///b.tcl", &b),
+            ("file:///a.tcl", &a),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "p",
+            &["::A::p".to_string(), "::p".to_string()],
+            call_from("file:///caller.tcl"),
+        );
+        assert_eq!(resolved.as_deref(), Some("::C::p"), "{resolved:?}");
+    }
+
+    #[test]
+    fn a_cross_file_chain_hop_that_was_never_re_exported_abstains() {
+        // FN guard — the middle hop keeps its own export gate.
+        let c = analyse("namespace eval ::C { proc p {} { return CP }\n namespace export p }\n");
+        let b = analyse("namespace eval ::B { namespace import ::C::* }\n");
+        let a = analyse("namespace eval ::A { namespace import ::B::* }\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///c.tcl", &c),
+            ("file:///b.tcl", &b),
+            ("file:///a.tcl", &a),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "p",
+            &["::A::p".to_string(), "::p".to_string()],
+            call_from("file:///caller.tcl"),
+        );
+        assert!(resolved.is_none(), "{resolved:?}");
+    }
+
+    #[test]
+    fn a_mutually_importing_pair_terminates_cross_file() {
+        // FP/hang guard — bounded by `MAX_COMMAND_NAME_HOPS`.
+        let a = analyse("namespace eval ::A { namespace import ::B::*\n namespace export * }\n");
+        let b = analyse("namespace eval ::B { namespace import ::A::*\n namespace export * }\n");
+        let index = WorkspaceIndex::from_documents([("file:///a.tcl", &a), ("file:///b.tcl", &b)]);
+        assert!(
+            index
+                .resolve_wildcard_import(
+                    "p",
+                    &["::A::p".to_string()],
+                    call_from("file:///caller.tcl"),
+                )
+                .is_none()
         );
     }
 

--- a/rust/tcl-lsp-core/src/workspace_index.rs
+++ b/rust/tcl-lsp-core/src/workspace_index.rs
@@ -835,11 +835,27 @@ impl WorkspaceIndex {
                             // namespace already holds installs nothing at all
                             // (oracle on `WorkspaceGlobImport::forced`), so
                             // the link it would introduce is not live either.
-                            // Only a real *definition* counts as the
-                            // conflicting command: another link's name would
-                            // make two imports of the same name cancel each
-                            // other out.
-                            g.forced || !self.defines_command(&l.linked_qname)
+                            // "Already holds" is a real *definition* or an
+                            // earlier live alias from a **different** source
+                            // in the same document (issue #1116 finding 4);
+                            // a same-source re-import is a silent no-op, and
+                            // two links cancelling each other out is what the
+                            // different-source test rules out.
+                            if !g.forced
+                                && (self.defines_command(&l.linked_qname)
+                                    || self.earlier_conflicting_link(l))
+                            {
+                                return false;
+                            }
+                            // …and the alias it installed can be taken away
+                            // again: `namespace forget`, a redefinition of the
+                            // imported name, or destruction of the source
+                            // command (issue #1116 finding 2).
+                            let importing_ns = l
+                                .linked_qname
+                                .rsplit_once("::")
+                                .map_or("::", |(ns, _)| if ns.is_empty() { "::" } else { ns });
+                            wci.link_alias_live(importing_ns, g, &l.uri)
                         })
                     })
                     .collect(),
@@ -859,6 +875,32 @@ impl WorkspaceIndex {
     /// Deliberately *not* [`Self::workspace_command_exists`], which also
     /// admits linked names: a link is what this question is being asked
     /// about, so counting one would make an import conflict with itself.
+    /// Whether another **exact** import link in the same document installs
+    /// the same name from a *different* source before this one — the live
+    /// alias a non-`-force` import conflicts with (issue #1116 finding 4).
+    ///
+    /// Oracle (9.0.4 / 8.6.14): with `::dst` already importing `::A::p`, a
+    /// later `namespace import ::B::p` raises `can't import command "p":
+    /// already exists` and leaves `namespace origin ::dst::p` → `::A::p`.
+    ///
+    /// Restricted to one document because that is where an order exists: two
+    /// imports in different files have none, and conflicting on a guess would
+    /// drop a link Tcl really installed. A **same-source** re-import is a
+    /// silent no-op (oracle), so it is not a conflict — which is also what
+    /// stops a link from conflicting with itself.
+    fn earlier_conflicting_link(&self, link: &WorkspaceCommandLink) -> bool {
+        self.command_links.iter().any(|other| {
+            other.uri == link.uri
+                && other.linked_qname == link.linked_qname
+                && other.target_qname != link.target_qname
+                && other
+                    .import_gate
+                    .as_ref()
+                    .zip(link.import_gate.as_ref())
+                    .is_some_and(|(o, l)| o.at < l.at)
+        })
+    }
+
     fn defines_command(&self, qualified_name: &str) -> bool {
         let target = qualified_name.trim_start_matches("::");
         self.procs
@@ -2553,22 +2595,26 @@ impl WorkspaceIndex {
         wci: &WildcardImportIndex<'_>,
     ) -> Option<String> {
         let imports = wci.imports_by_ns.get(ns)?;
-        for imp in imports {
-            if !tcl_syntax::glob::string_match(&imp.tail_pattern, word) {
-                continue;
-            }
-            if !wci.exports_name_at(&imp.source_ns, word, imp.site()) {
-                continue;
-            }
-            if !imp.forced && self.defines_command(&format!("{ns}::{word}")) {
-                continue;
-            }
-            if !wci.alias_live_at(ns, &imp.source_ns, word, imp.site(), call) {
-                continue;
-            }
-            return Some(imp.source_ns.clone());
-        }
-        None
+        // The **latest** live install wins, not the first match: a second
+        // import of the same name — `-force`, or after a forget — replaces
+        // the first alias (oracle on `conflicting_alias_at`), exactly as the
+        // same-document tier's fold decides it. Offsets only order rows in
+        // the calling document, so same-document imports rank above
+        // unordered foreign ones, and among foreign ones the index's own
+        // stable source order breaks the tie.
+        imports
+            .iter()
+            .filter(|imp| tcl_syntax::glob::string_match(&imp.tail_pattern, word))
+            .filter(|imp| wci.exports_name_at(&imp.source_ns, word, imp.site()))
+            .filter(|imp| {
+                imp.forced
+                    || !(self.defines_command(&format!("{ns}::{word}"))
+                        || wci.conflicting_alias_at(ns, &imp.source_ns, word, imp.site()))
+            })
+            .filter(|imp| wci.alias_live_at(ns, &imp.source_ns, word, imp.site(), call))
+            .enumerate()
+            .max_by_key(|(seq, imp)| (imp.uri == call.uri, imp.at, *seq))
+            .map(|(_, imp)| imp.source_ns.clone())
     }
 }
 
@@ -2581,6 +2627,11 @@ struct WildcardImportIndex<'a> {
     exports_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceNamespaceExport>>,
     forgets_by_ns: std::collections::HashMap<&'a str, Vec<&'a WorkspaceNamespaceForget>>,
     deletions_by_name: std::collections::HashMap<&'a str, Vec<&'a WorkspaceCommandDeletion>>,
+    /// Every proc / class declaration site, by `::`-rooted qualified name —
+    /// a redefinition of an *imported* name ends the alias (issue #1116
+    /// finding 3), which is a question about where the declaration sits, not
+    /// merely whether one exists.
+    declarations_by_qname: std::collections::HashMap<&'a str, Vec<(&'a str, u32)>>,
 }
 
 impl<'a> WildcardImportIndex<'a> {
@@ -2608,12 +2659,107 @@ impl<'a> WildcardImportIndex<'a> {
                 .or_default()
                 .push(del);
         }
+        let mut declarations_by_qname: std::collections::HashMap<&str, Vec<(&str, u32)>> =
+            std::collections::HashMap::new();
+        for (qname, uri, at) in index
+            .procs
+            .iter()
+            .map(|p| {
+                (
+                    p.qualified_name.as_str(),
+                    p.uri.as_str(),
+                    p.name_span.start(),
+                )
+            })
+            .chain(index.classes.iter().map(|c| {
+                (
+                    c.qualified_name.as_str(),
+                    c.uri.as_str(),
+                    c.name_span.start(),
+                )
+            }))
+        {
+            declarations_by_qname
+                .entry(qname)
+                .or_default()
+                .push((uri, at));
+        }
         Self {
             imports_by_ns,
             exports_by_ns,
             forgets_by_ns,
             deletions_by_name,
+            declarations_by_qname,
         }
+    }
+
+    /// Every removal event bearing on the alias `importing_ns` took from
+    /// `source_ns` for `name`, as seen from `query` — the cross-document
+    /// half of [`crate::namespace_import::alias_live_at`]'s event log
+    /// (issue #1103).
+    ///
+    /// Three kinds, and the ordering rule differs per kind because the
+    /// underlying facts differ:
+    ///
+    /// - **`namespace forget`** and **a redefinition of the imported name**
+    ///   are events on *this namespace's* slot. They are ordered only inside
+    ///   one document: which of two files loads first is not a static fact
+    ///   (#1104 item 3), so an event in another document is passed unordered
+    ///   and revokes nothing.
+    /// - **Destroying the source command** (`rename ::src::p {}`) is not a
+    ///   slot event at all — the command *object* the alias holds is gone,
+    ///   workspace-wide, and no load order brings it back. When there is a
+    ///   call site to order against it is ordered like the rest; with none
+    ///   ([`Self::link_alias_live`]) it is passed as having already happened.
+    fn removal_events<'e>(
+        &'e self,
+        importing_ns: &'e str,
+        source_ns: &'e str,
+        name: &'e str,
+        ordered_in: &'e str,
+        destroy_at: impl Fn(&WorkspaceCommandDeletion) -> Option<u32> + 'e,
+    ) -> impl Iterator<Item = crate::namespace_import::AliasEvent> + 'e {
+        use crate::namespace_import::{AliasEvent, AliasEventKind};
+        let forgets = self
+            .forgets_by_ns
+            .get(importing_ns)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .filter(move |f| {
+                f.source_ns.as_deref().is_none_or(|src| {
+                    src.trim_start_matches("::") == source_ns.trim_start_matches("::")
+                }) && tcl_syntax::glob::string_match(&f.pattern, name)
+            })
+            .map(move |f| AliasEvent {
+                kind: AliasEventKind::Remove,
+                at: (f.uri == ordered_in).then_some(f.at),
+            });
+        // A `proc` / class declaration of the *imported* name recreates it as
+        // an ordinary command and ends the alias (oracle on
+        // `definition::live_import_at` case 5).
+        let redefinitions = self
+            .declarations_by_qname
+            .get(tcl_syntax::naming::qualify(importing_ns, name).as_str())
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .map(move |(uri, at)| AliasEvent {
+                kind: AliasEventKind::Remove,
+                at: (*uri == ordered_in).then_some(*at),
+            });
+        let qualified = tcl_syntax::naming::qualify(source_ns, name);
+        let deletions = self
+            .deletions_by_name
+            .get(qualified.as_str())
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .map(move |d| AliasEvent {
+                kind: AliasEventKind::Remove,
+                at: destroy_at(d),
+            });
+        forgets.chain(redefinitions).chain(deletions)
     }
 
     /// Whether the alias `importing_ns` took from `source_ns` for `name` is
@@ -2621,14 +2767,15 @@ impl<'a> WildcardImportIndex<'a> {
     /// of the shared lifecycle decision
     /// [`crate::namespace_import::alias_live_at`] (issue #1103).
     ///
-    /// `install_at` is the import's own site; the removals are this
-    /// namespace's `namespace forget` events plus any deletion of the source
-    /// command itself.
+    /// `install_at` is the import's own site. It is ordered against the call
+    /// **only when the two share a document** (issue #1116 finding 1): a byte
+    /// offset in the importing file and a byte offset in the calling file are
+    /// unrelated numbers, and comparing them let a `namespace forget` in the
+    /// caller revoke a cross-file import purely because its local offset
+    /// happened to be the larger one. Unordered, the shared function keeps the
+    /// alias — the same direction every other cross-file event takes here.
     ///
-    /// Only removals in the **calling document** are ordered against the
-    /// call: which of two files loads first is not a static fact (#1104 item
-    /// 3), so a foreign forget is passed unordered and revokes nothing.
-    /// Within that document the comparison is a plain offset test rather than
+    /// Within one document the comparison is a plain offset test rather than
     /// [`tcl_compiler::analyser::indirection::in_effect_within`], because the
     /// index does not store a *call site's* enclosing body span — only an
     /// import's. That can only make a removal look not-yet-run, i.e. keep
@@ -2645,36 +2792,96 @@ impl<'a> WildcardImportIndex<'a> {
         use crate::namespace_import::{AliasEvent, AliasEventKind};
         let install = std::iter::once(AliasEvent {
             kind: AliasEventKind::Install,
-            at: Some(install_at.at),
+            at: (install_at.uri == call.uri).then_some(install_at.at),
         });
-        let forgets = self
-            .forgets_by_ns
-            .get(importing_ns)
-            .map(Vec::as_slice)
-            .unwrap_or_default()
-            .iter()
-            .filter(|f| {
-                f.source_ns.as_deref().is_none_or(|src| {
-                    src.trim_start_matches("::") == source_ns.trim_start_matches("::")
-                }) && tcl_syntax::glob::string_match(&f.pattern, name)
-            })
-            .map(|f| AliasEvent {
-                kind: AliasEventKind::Remove,
-                at: (f.uri == call.uri).then_some(f.at),
-            });
-        let qualified = tcl_syntax::naming::qualify(source_ns, name);
-        let deletions = self
-            .deletions_by_name
-            .get(qualified.as_str())
-            .map(Vec::as_slice)
-            .unwrap_or_default()
-            .iter()
-            .map(|d| AliasEvent {
-                kind: AliasEventKind::Remove,
-                at: (d.uri == call.uri).then_some(d.at),
-            });
-        let mut events = install.chain(forgets).chain(deletions);
+        let mut events =
+            install.chain(
+                self.removal_events(importing_ns, source_ns, name, call.uri, |d| {
+                    (d.uri == call.uri).then_some(d.at)
+                }),
+            );
         crate::namespace_import::alias_live_at(&mut events, &|at| at < call.at)
+    }
+
+    /// Whether `ns` already holds a live alias for `name` from a namespace
+    /// other than `source_ns` when the import at `site` runs — the conflict a
+    /// non-`-force` `namespace import` aborts on (issue #1116 finding 4).
+    ///
+    /// Ordered within the import's own document only: two imports in
+    /// different files have no static load order, and conflicting on a guess
+    /// would drop an alias Tcl really installed. A **same-source** re-import
+    /// is a silent no-op (oracle), never a conflict.
+    fn conflicting_alias_at(
+        &self,
+        ns: &str,
+        source_ns: &str,
+        name: &str,
+        site: ImportSite<'_>,
+    ) -> bool {
+        self.imports_by_ns
+            .get(ns)
+            .map(Vec::as_slice)
+            .unwrap_or_default()
+            .iter()
+            .any(|other| {
+                other.uri == site.uri
+                    && other.at < site.at
+                    && other.source_ns != source_ns
+                    && tcl_syntax::glob::string_match(&other.tail_pattern, name)
+                    && self.exports_name_at(&other.source_ns, name, other.site())
+                    && self.alias_live_at(
+                        ns,
+                        &other.source_ns,
+                        name,
+                        other.site(),
+                        CallSite {
+                            uri: site.uri,
+                            at: site.at,
+                        },
+                    )
+            })
+    }
+
+    /// Whether an **exact** import link is still installed, with no call site
+    /// to order against — the gate [`WorkspaceIndex::live_command_links`]
+    /// applies (issue #1116 finding 2).
+    ///
+    /// `namespace import ::src::p` produces a fixed `WorkspaceCommandLink`
+    /// rather than a per-call glob lookup, so the export snapshot and the
+    /// `-force` conflict were the only things gating it: after `namespace
+    /// forget ::src::p` — or `rename ::src::p {}` — the link stayed live and
+    /// cross-document definition / references still resolved `::dst::p`.
+    ///
+    /// The question a link answers is "does this alias exist for navigation",
+    /// which has no query point of its own, so every recorded removal counts
+    /// as having run (`removal_in_effect` is unconditionally true) and the
+    /// ordering that remains is the removal's position relative to the
+    /// **import**:
+    ///
+    /// - A forget or redefinition in the import's own document orders against
+    ///   it: one written *after* the import revokes the link, one written
+    ///   before is undone by the import itself (a re-import after a forget
+    ///   reinstalls — oracle).
+    /// - One in another document has no static load order and revokes
+    ///   nothing, exactly as in [`Self::alias_live_at`].
+    /// - A destroyed source command revokes regardless: the command object is
+    ///   gone workspace-wide (oracle: `rename ::src::p {}` makes `::dst::p`
+    ///   an `invalid command name` and empties `info commands ::dst::*`), so
+    ///   it is passed at [`u32::MAX`] — later than any install.
+    fn link_alias_live(&self, importing_ns: &str, gate: &WorkspaceImportGate, uri: &str) -> bool {
+        use crate::namespace_import::{AliasEvent, AliasEventKind};
+        let install = std::iter::once(AliasEvent {
+            kind: AliasEventKind::Install,
+            at: Some(gate.at),
+        });
+        let mut events = install.chain(self.removal_events(
+            importing_ns,
+            &gate.source_ns,
+            &gate.name,
+            uri,
+            |_| Some(u32::MAX),
+        ));
+        crate::namespace_import::alias_live_at(&mut events, &|_| true)
     }
 
     /// Whether `ns` (`::`-rooted) had exported the unqualified `name` **as of
@@ -3733,6 +3940,247 @@ mod tests {
         assert_eq!(
             index.resolve_command_target("::app::helper"),
             "::mymod::helper"
+        );
+    }
+
+    #[test]
+    fn a_cross_file_forget_cannot_revoke_on_unrelated_offsets() {
+        // FP guard (CRITICAL), issue #1116 finding 1 — the import lives in a
+        // short `imports.tcl` (small byte offset); the forget lives in a long
+        // `caller.tcl` (large byte offset) and names a namespace the caller
+        // never imported into itself. Nothing orders the two files, so the
+        // forget must revoke nothing — but comparing the raw offsets made the
+        // caller's larger number "later" and dropped a live alias.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let imports = analyse("namespace eval ::app { namespace import ::mymod::* }\n");
+        // Padding so the forget's offset is numerically far past the import's.
+        let pad = "# ".to_string() + &"x".repeat(400) + "\n";
+        let caller_src = format!(
+            "{pad}namespace eval ::app {{\n    namespace forget ::mymod::helper\n}}\nhelper\n"
+        );
+        let caller = analyse(&caller_src);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///imports.tcl", &imports),
+            ("file:///caller.tcl", &caller),
+        ]);
+        let call =
+            u32::try_from(app_src_offset(&caller_src, "\nhelper\n") + 1).expect("tiny source");
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            CallSite {
+                uri: "file:///caller.tcl",
+                at: call,
+            },
+        );
+        assert_eq!(
+            resolved.as_deref(),
+            Some("::mymod::helper"),
+            "a forget in another document has no order against the import and \
+             must not revoke it: {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn a_same_file_forget_after_the_import_still_revokes() {
+        // TN, the other direction of finding 1 — when the import, the forget
+        // and the call really do share a document the offsets mean something
+        // and the ordering is unchanged.
+        let src = "namespace eval ::app {\n    namespace import ::mymod::*\n}\nnamespace eval ::app {\n    namespace forget ::mymod::helper\n}\nhelper\n";
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(src);
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        let call = u32::try_from(app_src_offset(src, "\nhelper\n") + 1).expect("tiny source");
+        let resolved = index.resolve_wildcard_import(
+            "helper",
+            &["::app::helper".to_string(), "::helper".to_string()],
+            CallSite {
+                uri: "file:///app.tcl",
+                at: call,
+            },
+        );
+        assert!(resolved.is_none(), "{resolved:?}");
+    }
+
+    #[test]
+    fn an_exact_import_link_dies_on_a_same_file_forget() {
+        // TN (CRITICAL), issue #1116 finding 2 — an exact `namespace import
+        // ::mymod::helper` produces a fixed link rather than a per-call glob
+        // lookup, and the lifecycle events never reached it: after the forget
+        // the link stayed live and cross-document definition / references
+        // still resolved `::app::helper` to `::mymod::helper`.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    namespace import ::mymod::helper\n    namespace forget ::mymod::helper\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::app::helper"),
+            "::app::helper",
+            "a forgotten exact import installs no live link"
+        );
+        assert!(!index.workspace_command_exists("::app::helper"));
+    }
+
+    #[test]
+    fn an_exact_import_link_survives_a_forget_written_before_it() {
+        // FN guard for the row above — the forget is ordered against the
+        // *import*, and one written before it is undone by the import itself
+        // (a re-import after a forget reinstalls — oracle).
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    namespace forget ::mymod::helper\n    namespace import ::mymod::helper\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::app::helper"),
+            "::mymod::helper"
+        );
+    }
+
+    #[test]
+    fn an_exact_import_link_ignores_a_forget_in_another_file() {
+        // FP guard — finding 1's rule applied to the link tier: a forget with
+        // no static order against the import revokes nothing.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse("namespace eval ::app {\n    namespace import ::mymod::helper\n}\n");
+        let teardown = analyse("namespace eval ::app {\n    namespace forget ::mymod::helper\n}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+            ("file:///teardown.tcl", &teardown),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::app::helper"),
+            "::mymod::helper"
+        );
+    }
+
+    #[test]
+    fn an_exact_import_link_dies_when_the_source_command_is_destroyed() {
+        // TN — destroying the source is not order-ambiguous the way a forget
+        // is: the command *object* the alias holds is gone workspace-wide
+        // (oracle: `rename ::mymod::helper {}` makes `::app::helper` an
+        // `invalid command name` and empties `info commands ::app::*`), so the
+        // link dies even though the deletion sits in another document.
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse("namespace eval ::app {\n    namespace import ::mymod::helper\n}\n");
+        let teardown = analyse("rename ::mymod::helper {}\n");
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+            ("file:///teardown.tcl", &teardown),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::app::helper"),
+            "::app::helper",
+            "destroying the source destroys the link"
+        );
+    }
+
+    #[test]
+    fn an_exact_import_link_dies_when_the_imported_name_is_redefined() {
+        // TN, issue #1116 finding 3 cross-document — a `proc ::app::helper`
+        // after the import recreates the name as an ordinary command
+        // (oracle: rc 0, `namespace origin` → `::app::helper`).
+        let mymod =
+            analyse("namespace eval ::mymod { proc helper {} {}\n namespace export helper }\n");
+        let app = analyse(
+            "namespace eval ::app {\n    namespace import ::mymod::helper\n}\nproc ::app::helper {} {}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///mymod.tcl", &mymod),
+            ("file:///app.tcl", &app),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::app::helper"),
+            "::app::helper"
+        );
+    }
+
+    #[test]
+    fn a_cross_file_live_alias_is_an_import_conflict_for_a_different_source() {
+        // TN, issue #1116 finding 4 cross-document — `::dst` imports `::A::*`
+        // and then, further down the same file, `::B::*` without `-force`.
+        // Oracle: the second import raises `can't import command "p": already
+        // exists` and `namespace origin ::dst::p` stays `::A::p`.
+        let a = analyse("namespace eval ::A { proc p {} { return AP }\n namespace export p }\n");
+        let b = analyse("namespace eval ::B { proc p {} { return BP }\n namespace export p }\n");
+        let dst = analyse(
+            "namespace eval ::dst {\n    namespace import ::A::*\n}\nnamespace eval ::dst {\n    namespace import ::B::*\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///dst.tcl", &dst),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "p",
+            &["::dst::p".to_string(), "::p".to_string()],
+            call_from("file:///dst.tcl"),
+        );
+        assert_eq!(
+            resolved.as_deref(),
+            Some("::A::p"),
+            "the failed second import leaves the first alias in place: {resolved:?}"
+        );
+    }
+
+    #[test]
+    fn a_cross_file_forced_import_replaces_a_live_alias() {
+        // TP, the other half — with `-force` the second import wins (oracle:
+        // `namespace origin ::dst::p` → `::B::p`).
+        let a = analyse("namespace eval ::A { proc p {} { return AP }\n namespace export p }\n");
+        let b = analyse("namespace eval ::B { proc p {} { return BP }\n namespace export p }\n");
+        let dst = analyse(
+            "namespace eval ::dst {\n    namespace import ::A::*\n}\nnamespace eval ::dst {\n    namespace import -force ::B::*\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///dst.tcl", &dst),
+        ]);
+        let resolved = index.resolve_wildcard_import(
+            "p",
+            &["::dst::p".to_string(), "::p".to_string()],
+            call_from("file:///dst.tcl"),
+        );
+        assert_eq!(resolved.as_deref(), Some("::B::p"));
+    }
+
+    #[test]
+    fn a_cross_file_exact_link_conflicts_with_an_earlier_different_source() {
+        // TN — finding 4 on the exact-link tier.
+        let a = analyse("namespace eval ::A { proc p {} {}\n namespace export p }\n");
+        let b = analyse("namespace eval ::B { proc p {} {}\n namespace export p }\n");
+        let dst = analyse(
+            "namespace eval ::dst {\n    namespace import ::A::p\n    namespace import ::B::p\n}\n",
+        );
+        let index = WorkspaceIndex::from_documents([
+            ("file:///a.tcl", &a),
+            ("file:///b.tcl", &b),
+            ("file:///dst.tcl", &dst),
+        ]);
+        assert_eq!(
+            index.resolve_command_target("::dst::p"),
+            "::A::p",
+            "the second exact import fails and the first alias stays"
         );
     }
 

--- a/rust/tcl-lsp-server/src/lib.rs
+++ b/rust/tcl-lsp-server/src/lib.rs
@@ -4960,7 +4960,22 @@ impl Backend {
         {
             let index = self.workspace_index.read().await;
             let registry = tcl_registry::registry_for_dialect(&analysis.dialect);
+            // A live `namespace import -force` has *replaced* the importing
+            // namespace's own command of this name, so no candidate naming it
+            // may settle the call — the call reaches the import's source,
+            // which the wildcard-import tier below resolves (issue #1103).
+            // Applied here because this is a separate resolver from
+            // `resolve_called_proc`, which already applies the same rule.
+            let forced_shadow = core_definition::forced_import_shadows_call(
+                analysis,
+                &inv.name,
+                &inv.resolution_candidates,
+                offset_u32,
+            );
             if let Some(cand) = inv.resolution_candidates.iter().find(|cand| {
+                if forced_shadow {
+                    return false;
+                }
                 let cand = cand.as_str();
                 // A candidate naming a real registry builtin only counts a
                 // same-file or cross-file proc definition when that
@@ -5011,9 +5026,14 @@ impl Backend {
             // `definition::resolve_called_proc` / `resolve_class_target_at`
             // already apply in-document, extended here to a source
             // namespace defined in another file.)
-            if let Some(target) =
-                index.resolve_wildcard_import(&inv.name, &inv.resolution_candidates)
-            {
+            if let Some(target) = index.resolve_wildcard_import(
+                &inv.name,
+                &inv.resolution_candidates,
+                core_workspace_index::CallSite {
+                    uri: uri.as_str(),
+                    at: inv.range.start(),
+                },
+            ) {
                 return vec![target];
             }
         }

--- a/rust/tcl-lsp-server/tests/e2e/definition.rs
+++ b/rust/tcl-lsp-server/tests/e2e/definition.rs
@@ -388,6 +388,166 @@ fn wildcard_import_ignores_an_export_written_after_it_cross_document() {
     );
 }
 
+// -- the import edge's lifecycle, cross-document (issue #1103) --
+//
+// #1027 made the edge a per-import-site *snapshot*; these pin it as a link
+// with a lifetime. Rows oracle-confirmed byte-identically on tclsh 9.0.4 and
+// 8.6.14 (transcripts in `tcl_lsp_core::namespace_import`). Ordering exists
+// only within one document, so every ordered pair sits in the same file.
+
+#[test]
+fn a_forgotten_wildcard_import_stops_resolving_cross_document() {
+    // TN (issue #1103 behaviour 1): `main.tcl` imports `::Lib::*`, forgets
+    // it, and only then calls `bar`. Oracle: `namespace forget ::Lib::bar`
+    // empties `info commands` of the alias and the later bare call raises
+    // `invalid command name "bar"`.
+    let mut lsp = Lsp::tcl();
+    let lib_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &lib_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n    namespace export bar\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &main_uri,
+        "namespace import ::Lib::*\nnamespace forget ::Lib::bar\nbar\n",
+    );
+    let result = lsp.definition(&main_uri, 2, 0);
+    assert!(
+        locations(&result).is_empty(),
+        "a call after `namespace forget` must not resolve through the alias: {result:?}"
+    );
+}
+
+#[test]
+fn a_call_before_the_forget_still_resolves_cross_document() {
+    // TP — the forget is order-gated, not file-wide: the same file, with the
+    // call written between the import and the forget, still jumps into
+    // `lib.tcl`.
+    let mut lsp = Lsp::tcl();
+    let lib_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &lib_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n    namespace export bar\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &main_uri,
+        "namespace import ::Lib::*\nbar\nnamespace forget ::Lib::bar\n",
+    );
+    let result = lsp.definition(&main_uri, 1, 0);
+    let locs = locations(&result);
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(locs[0].uri, lib_uri);
+    assert_eq!(start_line(&locs[0]), 1, "proc bar is declared on line 1");
+}
+
+#[test]
+fn a_forced_import_shadows_the_local_command_cross_document() {
+    // TP (issue #1103 behaviour 2): `main.tcl` defines its own `bar`, then
+    // `namespace import -force ::Lib::*`. Oracle: the local command is
+    // replaced, the later bare call runs `::Lib::bar`, and `namespace origin
+    // ::bar` answers `::Lib::bar` — so go-to-definition must land in
+    // `lib.tcl`, not on the local `proc bar`.
+    let mut lsp = Lsp::tcl();
+    let lib_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &lib_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n    namespace export bar\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &main_uri,
+        "proc bar {} { return 0 }\nnamespace import -force ::Lib::*\nbar\n",
+    );
+    let result = lsp.definition(&main_uri, 2, 0);
+    let locs = locations(&result);
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(
+        locs[0].uri, lib_uri,
+        "a `-force` import replaces the local command: {locs:?}"
+    );
+}
+
+#[test]
+fn an_unforced_conflicting_import_leaves_the_local_command_cross_document() {
+    // FP guard for the row above — without `-force` the same program raises
+    // `can't import command "bar": already exists` and installs nothing, so
+    // the call still reaches the *local* definition (line 0), never
+    // `lib.tcl`.
+    let mut lsp = Lsp::tcl();
+    let lib_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &lib_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n    namespace export bar\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &main_uri,
+        "proc bar {} { return 0 }\nnamespace import ::Lib::*\nbar\n",
+    );
+    let result = lsp.definition(&main_uri, 2, 0);
+    let locs = locations(&result);
+    assert_eq!(locs.len(), 1, "{locs:?}");
+    assert_eq!(
+        locs[0].uri, main_uri,
+        "a failed import leaves the local definition in place: {locs:?}"
+    );
+    assert_eq!(start_line(&locs[0]), 0);
+}
+
+#[test]
+fn a_wildcard_import_chain_follows_to_the_original_source_cross_document() {
+    // TP (issue #1103 behaviour 4): three files — `::C` defines and exports
+    // `p`, `::B` imports `::C::*` and re-exports, `main.tcl` imports
+    // `::B::*` and calls `p` bare. Oracle: the call runs `::C`'s body and
+    // `namespace origin` answers `::C::p`, so definition must jump to
+    // `c.tcl`. The middle hop is in no proc table, so this previously
+    // abstained entirely.
+    let mut lsp = Lsp::tcl();
+    let c_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &c_uri,
+        "namespace eval C {\n    proc p {} { return CP }\n    namespace export p\n}\n",
+    );
+    let b_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &b_uri,
+        "namespace eval B {\n    namespace import ::C::*\n    namespace export p\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(&main_uri, "namespace import ::B::*\np\n");
+    let result = lsp.definition(&main_uri, 1, 0);
+    let locs = locations(&result);
+    assert_eq!(locs.len(), 1, "the chain must resolve: {locs:?}");
+    assert_eq!(locs[0].uri, c_uri, "must follow ::B through to ::C");
+    assert_eq!(start_line(&locs[0]), 1, "proc p is declared on line 1");
+}
+
+#[test]
+fn deleting_the_source_command_kills_the_import_cross_document() {
+    // TN (issue #1103 behaviour 3): the alias holds the command *object*, so
+    // `rename ::Lib::bar {}` makes the later bare call an `invalid command
+    // name`. A plain rename would not — that row is pinned as a unit test in
+    // `tcl_lsp_core::definition`.
+    let mut lsp = Lsp::tcl();
+    let lib_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &lib_uri,
+        "namespace eval Lib {\n    proc bar {} { return 1 }\n    namespace export bar\n}\n",
+    );
+    let main_uri = unique_uri("tcl");
+    lsp.open_ready(
+        &main_uri,
+        "namespace import ::Lib::*\nrename ::Lib::bar {}\nbar\n",
+    );
+    let result = lsp.definition(&main_uri, 2, 0);
+    assert!(
+        locations(&result).is_empty(),
+        "destroying the source command destroys the alias: {result:?}"
+    );
+}
+
 /// idx 33 (differential-audit main audit wave, high severity): a class
 /// *instantiation* call (`GSA new`, the real corpus's
 /// `georgtree_tclopt`'s `arbitaryTest.tcl` idiom — `GSA new -funct

--- a/rust/tcl-registry/src/commands/tcl/namespace_.rs
+++ b/rust/tcl-registry/src/commands/tcl/namespace_.rs
@@ -348,6 +348,11 @@ static SUBCOMMANDS: &[SubCommand] = &[
         // suppression.
         destructive: true,
         return_type: Some(TclType::String),
+        // The removal half of the import edge's lifecycle: the analyser
+        // records each pattern as an ordered event so a bare call written
+        // after the forget stops resolving through the alias it removed
+        // (issue #1103; `namespace import`'s own hook is the install half).
+        analyser_hook: Some(crate::hooks::AnalyserHookId::NamespaceForget),
         ..SubCommand::DEFAULT
     },
     SubCommand {

--- a/rust/tcl-registry/src/hooks.rs
+++ b/rust/tcl-registry/src/hooks.rs
@@ -305,6 +305,13 @@ pub enum AnalyserHookId {
     /// (`Tcl_Export`, `tclNamesp.c`), so an unexported sibling command
     /// must stay unresolved through the import.
     NamespaceExport,
+    /// `namespace forget ?pattern ...?` — records the removal of an
+    /// imported alias. The counterpart of [`Self::NamespaceImport`]: an
+    /// import edge has a lifecycle, and `namespace forget` ends it, so a
+    /// bare call after the forget raises `invalid command name` (issue
+    /// #1103, oracle tclsh 8.6.14 / 9.0.4). Recorded as an ordered event
+    /// beside `namespace export`'s `-clear` tombstones.
+    NamespaceForget,
     /// `namespace path {ns ...}` — records the namespace's
     /// command-resolution search path.
     NamespacePath,

--- a/rust/tcl-registry/tests/analyser_hooks.rs
+++ b/rust/tcl-registry/tests/analyser_hooks.rs
@@ -96,6 +96,10 @@ fn analyser_hook_stamps_match_the_former_guard_list() {
         ("namespace", "ensemble", H::NamespaceEnsemble),
         ("namespace", "import", H::NamespaceImport),
         ("namespace", "export", H::NamespaceExport),
+        // The removal half of the import edge's lifecycle: `namespace forget`
+        // takes an imported alias away again, so a bare call after it stops
+        // resolving (issue #1103).
+        ("namespace", "forget", H::NamespaceForget),
         // `inscope` shares the namespace-eval handler: same `[subcmd, ns,
         // body]` shape, body analysed in the named namespace's scope.
         ("namespace", "inscope", H::NamespaceEval),

--- a/rust/tcl-spec-studio/src/catalogue.rs
+++ b/rust/tcl-spec-studio/src/catalogue.rs
@@ -320,6 +320,7 @@ pub const ANALYSER_HOOKS: &[Variant] = &[
     v("NamespaceEnsemble", "namespace ensemble"),
     v("NamespaceImport", "namespace import"),
     v("NamespaceExport", "namespace export"),
+    v("NamespaceForget", "namespace forget"),
     v("NamespacePath", "namespace path"),
     v("NamespaceUnknown", "namespace unknown"),
     v("NamespaceUpvar", "namespace upvar"),
@@ -950,6 +951,7 @@ mod tests {
             | AnalyserHookId::NamespaceEnsemble
             | AnalyserHookId::NamespaceImport
             | AnalyserHookId::NamespaceExport
+            | AnalyserHookId::NamespaceForget
             | AnalyserHookId::NamespacePath
             | AnalyserHookId::NamespaceUnknown
             | AnalyserHookId::NamespaceUpvar


### PR DESCRIPTION
## Summary

PR C6 — #1102 built the ordered export event log; this makes the import edge itself live through its lifecycle, with every behaviour oracle-pinned byte-identical on 9.0.4/8.6.14 (transcripts in the tests):

- **`namespace forget`** — a new registry-stamped analyser hook records forget events (both `Tcl_ForgetImport` pattern shapes) on the same ordered event log, and one shared decision function — `alias_live_at`, the removal twin of `exported_at_import_site` (latest in-effect removal wins, later install reinstates, unordered removal revokes nothing) — is consumed by both tiers. A forgotten alias stops resolving after the forget point; a call before it is untouched; a re-import reinstates.
- **`-force` / conflict semantics** — a non-`-force` import onto an existing command errors and installs nothing (both tiers, plus exact-import links); a `-force` import shadows the local so later bare calls reach the source (`namespace origin` → source). The forced flag is read via the registry option route (`IMPORT_OPTIONS` + the #1102 occurrence cap) — and the scanner's one surviving `"-force"` literal is replaced by the same registry rule on the way.
- **Source rename/delete/redefine** — the alias holds the command token: deletion (`rename X {}`, published load-level-only as `destroyed_commands`) kills it, a plain rename keeps it (indirection's rename-captures-object-identity rule — the first cut got this wrong and was caught by the FN guard), redefinition is seen through the link.
- **Import chains** — A←B←C follows to the original across both tiers, bounded by indirection's hop cap, each hop keeping its own export gate; a mid-chain forget kills the whole chain; a never-re-exported middle hop still abstains; mutual imports terminate (hang-guard test).

**Deliberately not taken:** #1104's call-site ordering is now nearly free (both tiers carry a call offset; `alias_live_at` gates removals only, documented asymmetry) but changes import-vs-call answers corpus-wide and deserves its own before/after — left for C7. The #1105 perf rider was skipped (diff not modest; measurement not affordable beside a sibling agent).

**Residuals filed:** #1116 (gating precision: in-document `-force` shadow needs a same-document export declaration; exact-import links not forget-gated cross-document; workspace-tier removals ordered by plain offset, not `in_effect_within`; import-error control flow unmodelled; dynamic forget patterns skipped).

## Validation

- [x] `cargo test --workspace` — 199 suites, 13,458 passed + the 18 suites past one flake re-run green separately (703 passed); the flake (`vscode_parity::test_optimiser_toggle_suppresses_o_codes`, a 15s republish deadline under full-workspace CPU load, no imports in its fixture) passed 4/4 in isolation and in the preceding full e2e run of the identical binary.
- [x] Before/after against the pre-fix tree: **4 of 6 cross-file e2e cases fail pre-fix** (forget, `-force` shadow, chain, source-delete); the other two are direction guards, correct both sides by design.
- [x] 10-case unit matrix on `alias_live_at`; 19 in-document + 11 workspace + 4 references + 3 scanner tests, TP/FP/TN/FN split; base-branch merge (#1112) resolved with touched suites re-run green (69 + 30 + 35).
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean, **zero new allows** (one `too_many_lines` fixed by extraction); fmt clean; `make xtask-check` 12/12.

## Compiler/KCS checklist (when touching compiler behaviour, diagnostics, or analysis contracts)

- [x] Did this change alter a compiler fact contract? Yes — `SignatureNamespaceForget`/`forced` flags are new ordered event-log facts; `AnalysisResult::destroyed_commands` is a new load-level fact; `resolve_called_proc` takes the call offset.
- [x] KCS notes updated: `command-resolution.md` (lifecycle section), `workspace-indexing.md`, definition feature page.
- [ ] New compiler KCS note linked. (n/a — existing notes updated)

Closes #1103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Mf12569PiJ3F78PAp2iVX7